### PR TITLE
Restrict ownership of CODEOWNERS to maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,5 @@
 #
 
 * @open-telemetry/ebpf-instrumentation-approvers
+
+CODEOWNERS @open-telemetry/ebpf-instrumentation-maintainers


### PR DESCRIPTION
Require approval of a maintainer to change the CODEOWNERS file.