### PR TITLE
Create docker-generator image

### DIFF
--- a/.github/workflows/generator-image.yml
+++ b/.github/workflows/generator-image.yml
@@ -1,0 +1,56 @@
+name: Publish Docker Generator Image
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: open-telemetry/ebpf-instrumentation-generator
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+
+      - name: Get current timestamp
+        id: timestamp
+        run: echo "::set-output name=ts::$(date +'%Y%m%d%H%M')"
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          file: ./generator.Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.timestamp.outputs.ts }}"
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CACHE_MAIN_GO_FILE ?= cmd/$(CACHE_CMD)/main.go
 GOOS ?= linux
 GOARCH ?= amd64
 
-# todo: upload to a grafana artifact
+# TODO: upload as a ghcr.io artifact
 PROTOC_IMAGE = docker.io/mariomac/protoc-go:latest
 
 # RELEASE_VERSION will contain the tag name, or the branch name if current commit is not a tag
@@ -27,7 +27,7 @@ IMG = $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # The generator is a container image that provides a reproducible environment for
 # building eBPF binaries
-GEN_IMG ?= ghcr.io/grafana/beyla-ebpf-generator:main
+GEN_IMG ?= ghcr.io/open-telemetry/ebpf-instrumentation-generator:main
 
 COMPOSE_ARGS ?= -f test/integration/docker-compose.yml
 
@@ -187,12 +187,12 @@ generate: export BPF_CFLAGS := $(CFLAGS)
 generate: export BPF2GO := $(BPF2GO)
 generate: bpf2go
 	@echo "### Generating files..."
-	@BEYLA_GENFILES_RUN_LOCALLY=1 go generate cmd/beyla-genfiles/beyla_genfiles.go
+	@OTEL_EBPF_GENFILES_RUN_LOCALLY=1 go generate cmd/ebpf-instrument-genfiles/genfiles.go
 
 .PHONY: docker-generate
 docker-generate:
 	@echo "### Generating files (docker)..."
-	@BEYLA_GENFILES_GEN_IMG=$(GEN_IMG) go generate cmd/beyla-genfiles/beyla_genfiles.go
+	@OTEL_EBPF_GENFILES_GEN_IMG=$(GEN_IMG) go generate cmd/ebpf-instrument-genfiles/genfiles.go
 
 .PHONY: verify
 verify: prereqs lint-dashboard lint test

--- a/cmd/ebpf-instrument-genfiles/genfiles.go
+++ b/cmd/ebpf-instrument-genfiles/genfiles.go
@@ -29,8 +29,7 @@ type config struct {
 	HostPrefix      string `env:"OTEL_EBPF_GENFILES_HOST_PREFIX"      envDefault:"/home/runner/work/"`
 	Package         string `env:"OTEL_EBPF_GENFILES_PKG"              envDefault:"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/beyla"`
 	OCIBin          string `env:"OTEL_EBPF_GENFILES_OCI_BIN"          envDefault:"docker"`
-	//TODO: replace by OTEL image once we publish them
-	GenImage string `env:"OTEL_EBPF_GENFILES_GEN_IMG"          envDefault:"ghcr.io/grafana/beyla-ebpf-generator:main"`
+	GenImage        string `env:"OTEL_EBPF_GENFILES_GEN_IMG"          envDefault:"ghcr.io/open-telemetry/ebpf-instrumentation-generator:main"`
 }
 
 var cfg config

--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -3,10 +3,10 @@ FROM base AS builder
 
 WORKDIR /build
 
-COPY cmd/beyla-genfiles/beyla_genfiles.go .
+COPY cmd/ebpf-instrument-genfiles/genfiles.go .
 COPY go.mod go.mod
 COPY go.sum go.sum
-RUN go build -o beyla_genfiles beyla_genfiles.go
+RUN go build -o genfiles genfiles.go
 
 FROM base AS dist
 
@@ -19,7 +19,7 @@ ARG EBPF_VER
 RUN apk add clang llvm19 wget
 RUN apk cache purge
 RUN go install github.com/cilium/ebpf/cmd/bpf2go@$EBPF_VER
-COPY --from=builder /build/beyla_genfiles /go/bin
+COPY --from=builder /build/genfiles /go/bin
 
 RUN cat <<EOF > /generate.sh
 #!/bin/sh
@@ -27,9 +27,9 @@ export GOCACHE=/tmp
 export BPF2GO=bpf2go
 export BPF_CLANG=clang
 export BPF_CFLAGS="-O2 -g -Wall -Werror"
-export BEYLA_GENFILES_RUN_LOCALLY=1
-export BEYLA_GENFILES_MODULE_ROOT="/src"
-beyla_genfiles
+export OTEL_EBPF_GENFILES_RUN_LOCALLY=1
+export OTEL_EBPF_GENFILES_MODULE_ROOT="/src"
+genfiles
 EOF
 
 RUN chmod +x /generate.sh


### PR DESCRIPTION
We are currently using an image under the Grafana Beyla GH organization. Creating our own image under `ghcr.io/open-telemetry` to avoid that any breaking change in another organization impacts in the OTEL GH repo.