### PR TITLE
Remove routes > ignored_patterns configuration option

### DIFF
--- a/pkg/export/debug/debug_test.go
+++ b/pkg/export/debug/debug_test.go
@@ -66,8 +66,6 @@ func traceFuncHelper(t *testing.T, tracePrinter TracePrinter) string {
 		Statement:      "statement",
 	}
 
-	fakeSpan.SetIgnoreMetrics()
-
 	// redirect the TracePrinter function stdout to a pipe so that we can
 	// capture and return its output
 	r, w, err := os.Pipe()
@@ -115,7 +113,7 @@ func TestTracePrinterResolve_PrinterCounter(t *testing.T) {
 func TestTracePrinterResolve_PrinterJSON(t *testing.T) {
 	// test as separate chunks to exclude timestamps (start, handlerStart, end)
 
-	prefix := `[{"type":"HTTP","ignoreSpan":"Metrics","peer":"peer","peerPort":"1234",` +
+	prefix := `[{"type":"HTTP","peer":"peer","peerPort":"1234",` +
 		`"host":"host","hostPort":"5678","traceID":"01020300000000000000000000000000",` +
 		`"spanID":"0102030000000000","parentSpanID":"0102040000000000","flags":"1",` +
 		`"peerName":"peername","hostName":"hostname","kind":"SPAN_KIND_SERVER","`
@@ -136,7 +134,6 @@ func TestTracePrinterResolve_PrinterJSONIndent(t *testing.T) {
 	prefix := `[
  {
   "type": "HTTP",
-  "ignoreSpan": "Metrics",
   "peer": "peer",
   "peerPort": "1234",
   "host": "host",

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -1040,10 +1040,6 @@ func (mr *MetricsReporter) reportMetrics(_ context.Context) {
 			if s.InternalSignal() {
 				continue
 			}
-			// If we are ignoring this span because of route patterns, don't do anything
-			if s.IgnoreMetrics() {
-				continue
-			}
 			reporter, err := mr.reporters.For(&s.Service)
 			if err != nil {
 				mlog().Error("unexpected error creating OTEL resource. Ignoring metric",

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -204,7 +204,7 @@ func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, e
 }
 
 func (tr *tracesOTELReceiver) spanDiscarded(span *request.Span) bool {
-	return span.IgnoreTraces() || span.Service.ExportsOTelTraces() || !tr.acceptSpan(span)
+	return span.Service.ExportsOTelTraces() || !tr.acceptSpan(span)
 }
 
 func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Traces, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler) {

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -733,7 +733,7 @@ func (r *metricsReporter) otelSpanObserved(span *request.Span) bool {
 }
 
 func (r *metricsReporter) otelSpanFiltered(span *request.Span) bool {
-	return span.InternalSignal() || span.IgnoreMetrics()
+	return span.InternalSignal()
 }
 
 //nolint:cyclop

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -314,45 +314,32 @@ func TestSpanMetricsDiscarded(t *testing.T) {
 	svcExportTraces := svc.Attrs{}
 	svcExportTraces.SetExportsOTelTraces()
 
-	ignoredSpan := request.Span{Service: svcExportTraces, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/v1/traces", RequestStart: 100, End: 200}
-	ignoredSpan.SetIgnoreMetrics()
-
 	tests := []struct {
 		name      string
 		span      request.Span
 		discarded bool
-		filtered  bool
 	}{
 		{
 			name:      "Foo span is not filtered",
 			span:      request.Span{Service: svcNoExport, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/foo", RequestStart: 100, End: 200},
 			discarded: false,
-			filtered:  false,
 		},
 		{
 			name:      "/v1/metrics span is filtered",
 			span:      request.Span{Service: svcExportMetrics, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/v1/metrics", RequestStart: 100, End: 200},
 			discarded: true,
-			filtered:  false,
-		},
-		{
-			name:      "/v1/traces span is filtered because we ignore this span",
-			span:      ignoredSpan,
-			discarded: false,
-			filtered:  true,
 		},
 		{
 			name:      "/v1/traces span is not filtered",
 			span:      request.Span{Service: svcExportTraces, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/v1/traces", RequestStart: 100, End: 200},
 			discarded: false,
-			filtered:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.discarded, !(mr.otelSpanObserved(&tt.span)), tt.name)
-			assert.Equal(t, tt.filtered, mr.otelSpanFiltered(&tt.span), tt.name)
+			assert.False(t, mr.otelSpanFiltered(&tt.span), tt.name)
 		})
 	}
 }

--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -92,30 +92,6 @@ func (t EventType) MarshalText() ([]byte, error) {
 	return []byte(t.String()), nil
 }
 
-type ignoreMode uint8
-
-const (
-	ignoreMetrics ignoreMode = 0x1
-	ignoreTraces  ignoreMode = 0x2
-)
-
-func (m ignoreMode) String() string {
-	result := ""
-
-	if (m & ignoreMetrics) == ignoreMetrics {
-		result += "Metrics"
-	}
-	if (m & ignoreTraces) == ignoreTraces {
-		result += "Traces"
-	}
-
-	return result
-}
-
-func (m ignoreMode) MarshalText() ([]byte, error) {
-	return []byte(m.String()), nil
-}
-
 const (
 	MessagingPublish = "publish"
 	MessagingProcess = "process"
@@ -145,7 +121,6 @@ type PidInfo struct {
 // SpanPromGetters and getDefinitions in pkg/export/attributes/attr_defs.go
 type Span struct {
 	Type           EventType      `json:"type"`
-	IgnoreSpan     ignoreMode     `json:"ignoreSpan"`
 	Method         string         `json:"-"`
 	Path           string         `json:"-"`
 	Route          string         `json:"-"`
@@ -339,30 +314,6 @@ func (s *Span) IsClientSpan() bool {
 	}
 
 	return false
-}
-
-func (s *Span) setIgnoreFlag(flag ignoreMode) {
-	s.IgnoreSpan |= flag
-}
-
-func (s *Span) isIgnored(flag ignoreMode) bool {
-	return (s.IgnoreSpan & flag) == flag
-}
-
-func (s *Span) SetIgnoreMetrics() {
-	s.setIgnoreFlag(ignoreMetrics)
-}
-
-func (s *Span) SetIgnoreTraces() {
-	s.setIgnoreFlag(ignoreTraces)
-}
-
-func (s *Span) IgnoreMetrics() bool {
-	return s.isIgnored(ignoreMetrics)
-}
-
-func (s *Span) IgnoreTraces() bool {
-	return s.isIgnored(ignoreTraces)
 }
 
 const (

--- a/pkg/internal/request/span_test.go
+++ b/pkg/internal/request/span_test.go
@@ -46,19 +46,6 @@ func TestEventTypeString(t *testing.T) {
 	}
 }
 
-func TestIgnoreModeString(t *testing.T) {
-	modeStringMap := map[ignoreMode]string{
-		ignoreMetrics:                "Metrics",
-		ignoreTraces:                 "Traces",
-		ignoreMode(0):                "",
-		ignoreTraces | ignoreMetrics: "MetricsTraces",
-	}
-
-	for mode, str := range modeStringMap {
-		assert.Equal(t, mode.String(), str)
-	}
-}
-
 func TestKindString(t *testing.T) {
 	m := map[*Span]string{
 		{Type: EventTypeHTTP}:                                  "SPAN_KIND_SERVER",
@@ -181,7 +168,6 @@ func TestSerializeJSONSpans(t *testing.T) {
 	test := func(t *testing.T, tData *testData) {
 		span := Span{
 			Type:           tData.eventType,
-			IgnoreSpan:     ignoreMetrics,
 			Method:         "method",
 			Path:           "path",
 			Route:          "route",
@@ -216,7 +202,6 @@ func TestSerializeJSONSpans(t *testing.T) {
 		assert.Equal(t, map[string]any{
 			"type":                tData.eventType.String(),
 			"kind":                span.ServiceGraphKind(),
-			"ignoreSpan":          "Metrics",
 			"peer":                "peer",
 			"peerPort":            "1234",
 			"host":                "host",

--- a/pkg/transform/routes.go
+++ b/pkg/transform/routes.go
@@ -47,9 +47,7 @@ type RoutesConfig struct {
 	// Unmatch specifies what to do when a route pattern is not matched
 	Unmatch UnmatchType `yaml:"unmatched"`
 	// Patterns of the paths that will match to a route
-	Patterns       []string   `yaml:"patterns"`
-	IgnorePatterns []string   `yaml:"ignored_patterns"`
-	IgnoredEvents  IgnoreMode `yaml:"ignore_mode"`
+	Patterns []string `yaml:"patterns"`
 	// Character that will be used to replace route segments
 	WildcardChar string `yaml:"wildcard_char,omitempty"`
 }
@@ -80,14 +78,7 @@ func (rn *routerNode) provideRoutes(_ context.Context) (swarm.RunFunc, error) {
 		return nil, err
 	}
 	matcher := route.NewMatcher(rc.Patterns)
-	discarder := route.NewMatcher(rc.IgnorePatterns)
 	routesEnabled := len(rc.Patterns) > 0
-	ignoreEnabled := len(rc.IgnorePatterns) > 0
-
-	ignoreMode := rc.IgnoredEvents
-	if ignoreMode == "" {
-		ignoreMode = IgnoreDefault
-	}
 
 	in := rn.input.Subscribe()
 	out := rn.output
@@ -98,16 +89,6 @@ func (rn *routerNode) provideRoutes(_ context.Context) (swarm.RunFunc, error) {
 		for spans := range in {
 			for i := range spans {
 				s := &spans[i]
-				if ignoreEnabled {
-					if discarder.Find(s.Path) != "" {
-						if ignoreMode == IgnoreAll {
-							s.SetIgnoreMetrics()
-							s.SetIgnoreTraces()
-						}
-						// we can't discard it here, ignoring is selective (metrics | traces)
-						setSpanIgnoreMode(ignoreMode, s)
-					}
-				}
 				if routesEnabled {
 					s.Route = matcher.Find(s.Path)
 				}
@@ -172,14 +153,5 @@ func setUnmatchToPath(_ *RoutesConfig, str *request.Span) {
 func classifyFromPath(rc *RoutesConfig, s *request.Span) {
 	if s.Route == "" && (s.Type == request.EventTypeHTTP || s.Type == request.EventTypeHTTPClient) {
 		s.Route = route.ClusterPath(s.Path, rc.WildcardChar[0])
-	}
-}
-
-func setSpanIgnoreMode(mode IgnoreMode, s *request.Span) {
-	switch mode {
-	case IgnoreMetrics:
-		s.SetIgnoreMetrics()
-	case IgnoreTraces:
-		s.SetIgnoreTraces()
 	}
 }

--- a/test/integration/configs/instrumenter-config-grpc-export.yml
+++ b/test/integration/configs/instrumenter-config-grpc-export.yml
@@ -1,10 +1,11 @@
 routes:
   patterns:
     - /basic/:rnd
-  ignored_patterns:
-    - /metrics
-  ignore_mode: traces
   unmatched: path
+filter:
+  application:
+    url_path:
+      not_match: /metrics
 otel_metrics_export:
   endpoint: http://otelcol:4317
   protocol: grpc

--- a/test/integration/configs/instrumenter-config-no-route.yml
+++ b/test/integration/configs/instrumenter-config-no-route.yml
@@ -1,7 +1,9 @@
 routes:
-  ignored_patterns:
-    - /metrics
   unmatched: heuristic
+filter:
+  application:
+    url_path:
+      not_match: /metrics
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:

--- a/test/integration/configs/instrumenter-config-other-grpc.yml
+++ b/test/integration/configs/instrumenter-config-other-grpc.yml
@@ -9,10 +9,11 @@ discovery:
 routes:
   patterns:
     - /factorial/:rnd
-  ignored_patterns:
-    - /metrics
-  ignore_mode: traces
   unmatched: path
+filter:
+  application:
+    url_path:
+      not_match: /metrics
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:

--- a/test/integration/configs/instrumenter-config.yml
+++ b/test/integration/configs/instrumenter-config.yml
@@ -1,10 +1,11 @@
 routes:
   patterns:
     - /basic/:rnd
-  ignored_patterns:
-    - /metrics
-  ignore_mode: traces
   unmatched: path
+filter:
+  application:
+    url_path:
+      not_match: /metrics
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:

--- a/test/integration/k8s/manifests/06-beyla-daemonset-disable-informers.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-disable-informers.yml
@@ -24,9 +24,11 @@ data:
     routes:
       patterns:
         - /pingpong
-      ignored_patterns:
-        - /metrics
       unmatched: path
+    filter:
+      application:
+        url_path:
+          not_match: /metrics
     otel_metrics_export:
       endpoint: http://otelcol:4318
     otel_traces_export:

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -24,9 +24,11 @@ data:
     routes:
       patterns:
         - /pingpong
-      ignored_patterns:
-        - /metrics
       unmatched: path
+      filter:
+        application:
+          url_path:
+            not_match: /metrics
     otel_metrics_export:
       endpoint: http://otelcol:4318
     otel_traces_export:

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -455,11 +455,6 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	assert.GreaterOrEqual(t, sum, float64(0))
 	addr = res.Metric["client_address"]
 	assert.NotNil(t, addr)
-
-	// Check that we never recorded metrics for /metrics, in the basic test only traces are ignored
-	results, err = pq.Query(`http_server_request_duration_seconds_count{http_route="/metrics"}`)
-	require.NoError(t, err)
-	enoughPromResults(t, results)
 }
 
 func testREDMetricsGRPC(t *testing.T) {


### PR DESCRIPTION
Keeps addressing #7 .

Removing YAML configuration section `routes > ignored_patterns`:
- Its usage is confusing because it does not use regular expressions nor globs, but route matchers (same as the `patterns` sibling section). It adds yet another way to specify a pattern in our configuration.
- Its functionality is already covered by `filter > application > url_path > not_match` YAML section.
