### PR TITLE
Support OTEL env var substitution in YAML config

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -347,6 +347,8 @@ func LoadConfig(file io.Reader) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reading YAML configuration: %w", err)
 		}
+		// replaces environment variables in YAML file
+		cfgBuf = config.ReplaceEnv(cfgBuf)
 		if err := yaml.Unmarshal(cfgBuf, &cfg); err != nil {
 			return nil, fmt.Errorf("parsing YAML configuration: %w", err)
 		}

--- a/pkg/config/env_replacer.go
+++ b/pkg/config/env_replacer.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"bytes"
+	"os"
+	"regexp"
+)
+
+var envVarRegex = regexp.MustCompile(`\$?\${(?:env:)?([a-zA-Z_][a-zA-Z0-9_]*)(?::-([^}]*))?}`)
+
+func ReplaceEnv(content []byte) []byte {
+	// Process normal environment variable substitutions
+	return envVarRegex.ReplaceAllFunc(content, func(match []byte) []byte {
+		// Replaces $$-escaped env vars by single-dollar mark
+		// but does not replace the contents
+		if bytes.HasPrefix(match, []byte("$$")) {
+			return bytes.ReplaceAll(match, []byte("$$"), []byte{'$'})
+		}
+		// Logic to extract and replace ENV-NAME with its value or DEFAULT-VALUE
+
+		matches := envVarRegex.FindStringSubmatch(string(match))
+		envName := matches[1]
+		defaultValue := ""
+		if len(matches) > 2 {
+			defaultValue = matches[2]
+		}
+
+		// Get environment variable value
+		envValue := os.Getenv(envName)
+		if envValue == "" && defaultValue != "" {
+			envValue = defaultValue
+		}
+
+		// Keep the prefix that was matched to avoid replacing $ in the prefix
+		prefix := match[:1]
+		if prefix[0] != '$' {
+			return append(prefix, []byte(envValue)...)
+		}
+		return []byte(envValue)
+	})
+}

--- a/pkg/config/env_replacer_test.go
+++ b/pkg/config/env_replacer_test.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplaceEnv(t *testing.T) {
+	// Set env vars for testing
+	t.Setenv("TEST_VAR", "test_value")
+	t.Setenv("ANOTHER_VAR", "another_value")
+	t.Setenv("EMPTY_VAR", "")
+
+	tests := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "Simple YAML with environment variable",
+			input:    []byte("key: ${TEST_VAR}\n"),
+			expected: []byte("key: test_value\n"),
+		},
+		{
+			name:     "YAML with default value when env var exists",
+			input:    []byte("key: ${TEST_VAR:-default}\n"),
+			expected: []byte("key: test_value\n"),
+		},
+		{
+			name:     "YAML with default value when env var doesn't exist",
+			input:    []byte("key: ${NON_EXISTENT_VAR:-default}\n"),
+			expected: []byte("key: default\n"),
+		},
+		{
+			name:     "YAML with when env var doesn't exist",
+			input:    []byte("key: ${NON_EXISTENT_VAR}\n"),
+			expected: []byte("key: \n"),
+		},
+		{
+			name:     "YAML with empty default value when env var doesn't exist",
+			input:    []byte("key: ${NON_EXISTENT_VAR:-}\n"),
+			expected: []byte("key: \n"),
+		},
+		{
+			name:     "YAML with escaped environment variable",
+			input:    []byte("key: $${TEST_VAR}\n"),
+			expected: []byte("key: ${TEST_VAR}\n"),
+		},
+		{
+			name:     "YAML with multiple environment variables",
+			input:    []byte("key1: ${TEST_VAR}\nkey2: ${ANOTHER_VAR}\n"),
+			expected: []byte("key1: test_value\nkey2: another_value\n"),
+		},
+		{
+			name:     "YAML with environment variable in the middle of a string",
+			input:    []byte("key: prefix-${TEST_VAR}-suffix\n"),
+			expected: []byte("key: prefix-test_value-suffix\n"),
+		},
+		{
+			name:     "YAML with empty environment variable and no default",
+			input:    []byte("key: ${EMPTY_VAR}\n"),
+			expected: []byte("key: \n"),
+		},
+		{
+			name:     "YAML with empty environment variable and default",
+			input:    []byte("key: ${EMPTY_VAR:-default}\n"),
+			expected: []byte("key: default\n"),
+		},
+		{
+			name: "Complex YAML with nested structures",
+			input: []byte(`
+service:
+  name: ${TEST_VAR}
+  port: 8080
+config:
+  timeout: ${NON_EXISTENT_VAR:-30}
+  retries: 3
+  credentials:
+    username: admin
+    password: $${PASSWORD}
+`),
+			expected: []byte(`
+service:
+  name: test_value
+  port: 8080
+config:
+  timeout: 30
+  retries: 3
+  credentials:
+    username: admin
+    password: ${PASSWORD}
+`),
+		},
+		{
+			name:     "YAML with 'env:' prefix in variable",
+			input:    []byte("key: ${env:TEST_VAR}\n"),
+			expected: []byte("key: test_value\n"),
+		},
+		{
+			name:     "YAML with 'env:' prefix in nonexisting variable",
+			input:    []byte("key: ${env:TEST_VAR_UNEXISTING}\n"),
+			expected: []byte("key: \n"),
+		},
+		{
+			name:     "YAML with no replacements",
+			input:    []byte("key: value\n"),
+			expected: []byte("key: value\n"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ReplaceEnv(tt.input)
+			assert.Equal(t, string(tt.expected), string(result))
+		})
+	}
+}

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -1,5 +1,4 @@
-// Package appobserv provides public access to Beyla application observability as a library. All the other subcomponents
-// of Beyla are hidden.
+// Package appolly provides public access to eBPF application observability as a library
 package appolly
 
 import (

--- a/pkg/kubecache/config.go
+++ b/pkg/kubecache/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/caarlos0/env/v9"
 	"gopkg.in/yaml.v3"
 
+	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/config"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/kubecache/instrument"
 )
 
@@ -51,6 +52,8 @@ func LoadConfig(file io.Reader) (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reading YAML configuration: %w", err)
 		}
+		// replaces environment variables in YAML file
+		cfgBuf = config.ReplaceEnv(cfgBuf)
 		if err := yaml.Unmarshal(cfgBuf, &cfg); err != nil {
 			return nil, fmt.Errorf("parsing YAML configuration: %w", err)
 		}

--- a/test/integration/k8s/manifests/06-beyla-external-informer.yml
+++ b/test/integration/k8s/manifests/06-beyla-external-informer.yml
@@ -18,7 +18,7 @@ data:
         cluster_name: my-kube
         meta_cache_address: k8s-cache:50055
         resource_labels:
-          deployment.environment: ["deployment.environment"]
+          deployment.environment: ["${DEPLOYMENT_ENVIRONMENT:-deployment.environment}"]
       select:
         "*":
           include: [ "*" ]

--- a/test/integration/k8s/manifests/06-beyla-netolly-dropexternal.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-dropexternal.yml
@@ -9,7 +9,7 @@ data:
         enable: true
         drop_external: true
         resource_labels:
-          deployment.environment: ["deployment.environment"]
+          deployment.environment: ["${DEPLOYMENT_ENVIRONMENT:-error-not-replaced}"]
       select:
         beyla.network.flow.bytes:
           include:
@@ -77,3 +77,6 @@ spec:
               value: "10ms"
             - name: OTEL_EBPF_KUBE_CLUSTER_NAME
               value: "beyla"
+            # expecting to be replaced during the configuration YAML load
+            - name: DEPLOYMENT_ENVIRONMENT
+              value: "deployment.environment"

--- a/test/integration/k8s/manifests/06-beyla-netolly-multizone.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-multizone.yml
@@ -22,7 +22,7 @@ data:
         enable: true
         cluster_name: my-kube
         resource_labels:
-          deployment.environment: ["deployment.environment"]
+          deployment.environment: ["${DEPLOYMENT_ENVIRONMENT:-error-not-replaced}"]
       select:
         beyla.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
@@ -85,3 +85,6 @@ spec:
               value: "10ms"
             - name: OTEL_METRIC_EXPORT_INTERVAL
               value: "5000"
+            # expecting to be replaced during the configuration YAML load
+            - name: DEPLOYMENT_ENVIRONMENT
+              value: "deployment.environment"

--- a/test/integration/k8s/manifests/06-beyla-netolly.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly.yml
@@ -21,7 +21,7 @@ data:
         enable: true
         cluster_name: my-kube
         resource_labels:
-          deployment.environment: ["deployment.environment"]
+          deployment.environment: ["${DEPLOYMENT_ENVIRONMENT:-deployment.environment}"]
       select:
         beyla.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!


### PR DESCRIPTION
Adds support for env var substitution according to the OTEL spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#environment-variable-substitution

Part of https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/7
