### PR TITLE
Fix race condition in K8s informers cache

### DIFF
--- a/pkg/kubecache/meta/informers.go
+++ b/pkg/kubecache/meta/informers.go
@@ -54,7 +54,10 @@ func (inf *Informers) Subscribe(observer Observer) {
 	storedEntities = append(storedEntities, pods...)
 	storedEntities = append(storedEntities, nodes...)
 	storedEntities = append(storedEntities, services...)
-	for _, entity := range inf.sortAndCut(storedEntities, fromEpoch) {
+	storedEntities = inf.sortAndCut(storedEntities, fromEpoch)
+	inf.log.Debug("sending welcome snapshot to new observer",
+		"observerID", observer.ID(), "count", len(storedEntities))
+	for _, entity := range storedEntities {
 		if err := observer.On(&informer.Event{
 			Type:     informer.EventType_CREATED,
 			Resource: entity.(*indexableEntity).EncodedMeta,

--- a/pkg/kubecache/service/service.go
+++ b/pkg/kubecache/service/service.go
@@ -98,7 +98,9 @@ func (ic *InformersCache) Subscribe(msg *informer.SubscribeMessage, server infor
 		fromEpoch:   msg.GetFromTimestampEpoch(),
 		messages:    sync.NewQueue[*informer.Event](),
 	}
-	ic.log.Info("client subscribed", "id", o.ID())
+	ic.log.Info("client subscribed", "id", o.ID(),
+		"fromEpoch", o.fromEpoch,
+		"fromLast", time.Since(time.Unix(o.fromEpoch, 0)))
 	ic.informers.Subscribe(o)
 	// Keep the connection open
 	o.handleMessagesQueue(server.Context())


### PR DESCRIPTION
Since the Kubernetes event handler does not run with a defined order, using it to define the last status update of the stored entities was a bad Idea because they could be modified after the data is stored (and accessed e.g. for ordering).

This patch makes sure that the kubernetes entities are immutable, since the StatusTimeEpoch field is inferred from metadata before it is stored in the Informer storage.

Port of https://github.com/grafana/beyla/pull/1973