### PR TITLE
Temporarily restore regular expression usage in service selector

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"regexp"
 	"time"
 
 	"github.com/caarlos0/env/v9"
-	"github.com/gobwas/glob"
 	"gopkg.in/yaml.v3"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/config"
@@ -121,10 +121,9 @@ var DefaultConfig = Config{
 	NetworkFlows: defaultNetworkConfig,
 	Discovery: services.DiscoveryConfig{
 		ExcludeOTelInstrumentedServices: true,
-		DefaultExcludeServices: services.DefinitionCriteria{
-			services.Attributes{
-				// excluding telemetry components from being instrumented
-				Path: services.NewGlob(glob.MustCompile("{*beyla,*alloy,*ebpf-instrument,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*}")),
+		DefaultExcludeServices: services.RegexDefinitionCriteria{
+			services.RegexSelector{
+				Path: services.NewPathRegexp(regexp.MustCompile("(?:^|/)(beyla$|alloy$|otelcol[^/]*$)")),
 			},
 		},
 	},
@@ -150,10 +149,10 @@ type Config struct {
 
 	// Exec allows selecting the instrumented executable whose complete path contains the Exec value.
 	// TODO: setup an EXECUTABLE_NAME property that only cares about the executable name, ignoring the path
-	Exec services.GlobAttr `yaml:"executable_path" env:"OTEL_EBPF_EXECUTABLE_PATH"`
+	Exec services.RegexpAttr `yaml:"executable_path" env:"OTEL_EBPF_EXECUTABLE_PATH"`
 
 	//nolint:undoc
-	ExecOtelGo services.GlobAttr `env:"OTEL_GO_AUTO_TARGET_EXE"`
+	ExecOtelGo services.RegexpAttr `env:"OTEL_GO_AUTO_TARGET_EXE"`
 	// Port allows selecting the instrumented executable that owns the Port value. If this value is set (and
 	// different to zero), the value of the Exec property won't take effect.
 	// It's important to emphasize that if your process opens multiple HTTP/GRPC ports, the auto-instrumenter

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gobwas/glob"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -72,11 +71,8 @@ network:
   enable: true
   cidrs:
     - 10.244.0.0/16
-discovery:
-  default_exclude_services:
-    - exe_path: "*foo*"
 `)
-	t.Setenv("OTEL_EBPF_EXECUTABLE_PATH", "*tras*")
+	t.Setenv("OTEL_EBPF_EXECUTABLE_PATH", "tras")
 	t.Setenv("OTEL_EBPF_NETWORK_AGENT_IP", "1.2.3.4")
 	t.Setenv("OTEL_EBPF_OPEN_PORT", "8080-8089")
 	t.Setenv("OTEL_SERVICE_NAME", "svc-name")
@@ -208,9 +204,9 @@ discovery:
 		},
 		Discovery: services.DiscoveryConfig{
 			ExcludeOTelInstrumentedServices: true,
-			DefaultExcludeServices: services.DefinitionCriteria{
-				services.Attributes{
-					Path: services.NewGlob(glob.MustCompile("*foo*")),
+			DefaultExcludeServices: services.RegexDefinitionCriteria{
+				services.RegexSelector{
+					Path: services.NewPathRegexp(regexp.MustCompile("(?:^|/)(beyla$|alloy$|otelcol[^/]*$)")),
 				},
 			},
 		},

--- a/pkg/internal/discover/matcher.go
+++ b/pkg/internal/discover/matcher.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
 	"slices"
 
-	"github.com/gobwas/glob"
 	"github.com/shirou/gopsutil/v3/process"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/beyla"
@@ -46,8 +46,8 @@ func CriteriaMatcherProvider(
 
 type matcher struct {
 	log             *slog.Logger
-	criteria        services.DefinitionCriteria
-	excludeCriteria services.DefinitionCriteria
+	criteria        []services.Selector
+	excludeCriteria services.RegexDefinitionCriteria
 	// processHistory keeps track of the processes that have been already matched and submitted for
 	// instrumentation.
 	// This avoids keep inspecting again and again client processes each time they open a new connection port
@@ -60,7 +60,7 @@ type matcher struct {
 
 // ProcessMatch matches a found process with the first selection criteria it fulfilled.
 type ProcessMatch struct {
-	Criteria *services.Attributes
+	Criteria services.Selector
 	Process  *services.ProcessInfo
 }
 
@@ -104,12 +104,12 @@ func (m *matcher) filterCreated(obj processAttrs) (Event[ProcessMatch], bool) {
 		return Event[ProcessMatch]{}, false
 	}
 	for i := range m.criteria {
-		if m.matchProcess(&obj, proc, &m.criteria[i]) && !m.isExcluded(&obj, proc) {
+		if m.matchProcess(&obj, proc, m.criteria[i]) && !m.isExcluded(&obj, proc) {
 			m.log.Debug("found process", "pid", proc.Pid, "comm", proc.ExePath, "metadata", obj.metadata, "podLabels", obj.podLabels)
 			m.processHistory[obj.pid] = proc
 			return Event[ProcessMatch]{
 				Type: EventCreated,
-				Obj:  ProcessMatch{Criteria: &m.criteria[i], Process: proc},
+				Obj:  ProcessMatch{Criteria: m.criteria[i], Process: proc},
 			}, true
 		}
 	}
@@ -120,7 +120,7 @@ func (m *matcher) filterCreated(obj processAttrs) (Event[ProcessMatch], bool) {
 		m.processHistory[obj.pid] = proc
 		return Event[ProcessMatch]{
 			Type: EventCreated,
-			Obj:  ProcessMatch{Criteria: &m.criteria[0], Process: proc},
+			Obj:  ProcessMatch{Criteria: m.criteria[0], Process: proc},
 		}, true
 	}
 
@@ -151,21 +151,21 @@ func (m *matcher) isExcluded(obj *processAttrs, proc *services.ProcessInfo) bool
 	return false
 }
 
-func (m *matcher) matchProcess(obj *processAttrs, p *services.ProcessInfo, a *services.Attributes) bool {
+func (m *matcher) matchProcess(obj *processAttrs, p *services.ProcessInfo, a services.Selector) bool {
 	log := m.log.With("pid", p.Pid, "exe", p.ExePath)
-	if !a.Path.IsSet() && a.OpenPorts.Len() == 0 && len(obj.metadata) == 0 {
+	if !a.GetPath().IsSet() && a.GetOpenPorts().Len() == 0 && len(obj.metadata) == 0 {
 		log.Debug("no Kube metadata, no local selection criteria. Ignoring")
 		return false
 	}
-	if a.Path.IsSet() && !m.matchByExecutable(p, a) {
-		log.Debug("executable path does not match", "path", a.Path)
+	if (a.GetPath().IsSet() || a.GetPathRegexp().IsSet()) && !m.matchByExecutable(p, a) {
+		log.Debug("executable path does not match", "path", a.GetPath())
 		return false
 	}
-	if a.OpenPorts.Len() > 0 && !m.matchByPort(p, a) {
-		log.Debug("open ports do not match", "openPorts", a.OpenPorts)
+	if a.GetOpenPorts().Len() > 0 && !m.matchByPort(p, a) {
+		log.Debug("open ports do not match", "openPorts", a.GetOpenPorts())
 		return false
 	}
-	if a.ContainersOnly {
+	if a.IsContainersOnly() {
 		ns, _ := namespaceFetcherFunc(p.Pid)
 		if ns == m.beylaNamespace && m.hasHostPidAccess {
 			log.Debug("not in a container", "namespace", ns)
@@ -179,20 +179,23 @@ func (m *matcher) matchProcess(obj *processAttrs, p *services.ProcessInfo, a *se
 	return m.matchByAttributes(obj, a)
 }
 
-func (m *matcher) matchByPort(p *services.ProcessInfo, a *services.Attributes) bool {
+func (m *matcher) matchByPort(p *services.ProcessInfo, a services.Selector) bool {
 	for _, c := range p.OpenPorts {
-		if a.OpenPorts.Matches(int(c)) {
+		if a.GetOpenPorts().Matches(int(c)) {
 			return true
 		}
 	}
 	return false
 }
 
-func (m *matcher) matchByExecutable(p *services.ProcessInfo, a *services.Attributes) bool {
-	return a.Path.MatchString(p.ExePath)
+func (m *matcher) matchByExecutable(p *services.ProcessInfo, a services.Selector) bool {
+	if a.GetPath().IsSet() {
+		return a.GetPath().MatchString(p.ExePath)
+	}
+	return a.GetPathRegexp().MatchString(p.ExePath)
 }
 
-func (m *matcher) matchByAttributes(actual *processAttrs, required *services.Attributes) bool {
+func (m *matcher) matchByAttributes(actual *processAttrs, required services.Selector) bool {
 	if required == nil {
 		return true
 	}
@@ -201,7 +204,7 @@ func (m *matcher) matchByAttributes(actual *processAttrs, required *services.Att
 	}
 	log := m.log.With("pid", actual.pid)
 	// match metadata
-	for attrName, criteriaRegexp := range required.Metadata {
+	for attrName, criteriaRegexp := range required.RangeMetadata() {
 		if attrValue, ok := actual.metadata[attrName]; !ok || !criteriaRegexp.MatchString(attrValue) {
 			log.Debug("metadata does not match", "attr", attrName, "value", attrValue)
 			return false
@@ -209,7 +212,7 @@ func (m *matcher) matchByAttributes(actual *processAttrs, required *services.Att
 	}
 
 	// match pod labels
-	for labelName, criteriaRegexp := range required.PodLabels {
+	for labelName, criteriaRegexp := range required.RangePodLabels() {
 		if actualPodLabelValue, ok := actual.podLabels[labelName]; !ok || !criteriaRegexp.MatchString(actualPodLabelValue) {
 			log.Debug("pod label does not match", "label", labelName, "value", actualPodLabelValue)
 			return false
@@ -217,7 +220,7 @@ func (m *matcher) matchByAttributes(actual *processAttrs, required *services.Att
 	}
 
 	// match pod annotations
-	for annotationName, criteriaRegexp := range required.PodAnnotations {
+	for annotationName, criteriaRegexp := range required.RangePodAnnotations() {
 		if actualPodAnnotationValue, ok := actual.podAnnotations[annotationName]; !ok || !criteriaRegexp.MatchString(actualPodAnnotationValue) {
 			log.Debug("pod annotation does not match", "annotation", annotationName, "value", actualPodAnnotationValue)
 			return false
@@ -226,13 +229,31 @@ func (m *matcher) matchByAttributes(actual *processAttrs, required *services.Att
 	return true
 }
 
-func FindingCriteria(cfg *beyla.Config) services.DefinitionCriteria {
+func normalizeRegexCriteria(finderCriteria services.RegexDefinitionCriteria) []services.Selector {
+	// normalize criteria that only define metadata (e.g. k8s)
+	// but do neither define executable name nor port: configure them to match
+	// any executable in the matched k8s entities
+	criteria := make([]services.Selector, 0, len(finderCriteria))
+	for i := range finderCriteria {
+		fc := &finderCriteria[i]
+		if !fc.Path.IsSet() && fc.OpenPorts.Len() == 0 && (len(fc.Metadata) > 0 || len(fc.PodLabels) > 0 || len(fc.PodAnnotations) > 0) {
+			// match any executable path
+			if err := fc.Path.UnmarshalText([]byte(".")); err != nil {
+				panic("bug! " + err.Error())
+			}
+		}
+		criteria = append(criteria, fc)
+	}
+	return criteria
+}
+
+func FindingCriteria(cfg *beyla.Config) []services.Selector {
 	if cfg.Discovery.SystemWide {
 		// will return all the executables in the system
-		return services.DefinitionCriteria{
-			services.Attributes{
+		return []services.Selector{
+			&services.RegexSelector{
 				Namespace: cfg.ServiceNamespace,
-				Path:      services.NewGlob(glob.MustCompile("**")),
+				Path:      services.NewPathRegexp(regexp.MustCompile(".")),
 			},
 		}
 	}
@@ -241,27 +262,15 @@ func FindingCriteria(cfg *beyla.Config) services.DefinitionCriteria {
 	// with the new, map-based multi-services selector.
 	if cfg.Exec.IsSet() || cfg.Port.Len() > 0 {
 		finderCriteria = slices.Clone(cfg.Discovery.Services)
-		finderCriteria = append(finderCriteria, services.Attributes{
+		finderCriteria = append(finderCriteria, services.RegexSelector{
 			Name:      cfg.ServiceName,
 			Namespace: cfg.ServiceNamespace,
 			Path:      cfg.Exec,
 			OpenPorts: cfg.Port,
 		})
 	}
-	// normalize criteria that only define metadata (e.g. k8s)
-	// but do neither define executable name nor port: configure them to match
-	// any executable in the matched k8s entities
-	for i := range finderCriteria {
-		fc := &finderCriteria[i]
-		if !fc.Path.IsSet() && fc.OpenPorts.Len() == 0 && (len(fc.Metadata) > 0 || len(fc.PodLabels) > 0 || len(fc.PodAnnotations) > 0) {
-			// match any executable path
-			if err := fc.Path.UnmarshalText([]byte("**")); err != nil {
-				panic("bug! " + err.Error())
-			}
-		}
-	}
 
-	return finderCriteria
+	return normalizeRegexCriteria(finderCriteria)
 }
 
 // replaceable function to allow unit tests with faked processes

--- a/pkg/internal/discover/typer.go
+++ b/pkg/internal/discover/typer.go
@@ -84,8 +84,8 @@ func (t *typer) FilterClassify(evs []Event[ProcessMatch]) []Event[ebpf.Instrumen
 		case EventCreated:
 			svcID := svc.Attrs{
 				UID: svc.UID{
-					Name:      ev.Obj.Criteria.Name,
-					Namespace: ev.Obj.Criteria.Namespace,
+					Name:      ev.Obj.Criteria.GetName(),
+					Namespace: ev.Obj.Criteria.GetNamespace(),
 				},
 				ProcPID: ev.Obj.Process.Pid,
 			}

--- a/pkg/internal/discover/watcher_kube_test.go
+++ b/pkg/internal/discover/watcher_kube_test.go
@@ -170,7 +170,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 		require.Len(t, matches, 1)
 		m := matches[0]
 		assert.Equal(t, EventCreated, m.Type)
-		assert.Equal(t, "port-only", m.Obj.Criteria.Name)
+		assert.Equal(t, "port-only", m.Obj.Criteria.GetName())
 		assert.EqualValues(t, 12, m.Obj.Process.Pid)
 	})
 
@@ -181,7 +181,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 		require.Len(t, matches, 1)
 		m := matches[0]
 		assert.Equal(t, EventCreated, m.Type)
-		assert.Equal(t, "metadata-only", m.Obj.Criteria.Name)
+		assert.Equal(t, "metadata-only", m.Obj.Criteria.GetName())
 		assert.EqualValues(t, 34, m.Obj.Process.Pid)
 	})
 
@@ -192,7 +192,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 		require.Len(t, matches, 1)
 		m := matches[0]
 		assert.Equal(t, EventCreated, m.Type)
-		assert.Equal(t, "pod-label-only", m.Obj.Criteria.Name)
+		assert.Equal(t, "pod-label-only", m.Obj.Criteria.GetName())
 		assert.EqualValues(t, 42, m.Obj.Process.Pid)
 	})
 
@@ -203,7 +203,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 		require.Len(t, matches, 1)
 		m := matches[0]
 		assert.Equal(t, EventCreated, m.Type)
-		assert.Equal(t, "pod-multi-label-only", m.Obj.Criteria.Name)
+		assert.Equal(t, "pod-multi-label-only", m.Obj.Criteria.GetName())
 		assert.EqualValues(t, 43, m.Obj.Process.Pid)
 	})
 
@@ -214,7 +214,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 		require.Len(t, matches, 1)
 		m := matches[0]
 		assert.Equal(t, EventCreated, m.Type)
-		assert.Equal(t, "pod-annotation-only", m.Obj.Criteria.Name)
+		assert.Equal(t, "pod-annotation-only", m.Obj.Criteria.GetName())
 		assert.EqualValues(t, 44, m.Obj.Process.Pid)
 	})
 
@@ -225,7 +225,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 		require.Len(t, matches, 1)
 		m := matches[0]
 		assert.Equal(t, EventCreated, m.Type)
-		assert.Equal(t, "pod-multi-annotation-only", m.Obj.Criteria.Name)
+		assert.Equal(t, "pod-multi-annotation-only", m.Obj.Criteria.GetName())
 		assert.EqualValues(t, 45, m.Obj.Process.Pid)
 	})
 
@@ -236,7 +236,7 @@ func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 		require.Len(t, matches, 1)
 		m := matches[0]
 		assert.Equal(t, EventCreated, m.Type)
-		assert.Equal(t, "both", m.Obj.Criteria.Name)
+		assert.Equal(t, "both", m.Obj.Criteria.GetName())
 		assert.EqualValues(t, 56, m.Obj.Process.Pid)
 	})
 

--- a/pkg/internal/discover/watcher_proc.go
+++ b/pkg/internal/discover/watcher_proc.go
@@ -103,7 +103,7 @@ type pollAccounter struct {
 	stateMux          sync.Mutex
 	bpfWatcherEnabled bool
 	fetchPorts        bool
-	findingCriteria   services.DefinitionCriteria
+	findingCriteria   []services.Selector
 	output            *msg.Queue[[]Event[processAttrs]]
 }
 
@@ -174,6 +174,15 @@ func (pa *pollAccounter) portFetchRequired() bool {
 	return ret
 }
 
+func portOfInterest(criteria []services.Selector, port int) bool {
+	for _, cr := range criteria {
+		if cr.GetOpenPorts().Matches(port) {
+			return true
+		}
+	}
+	return false
+}
+
 func (pa *pollAccounter) watchForProcessEvents(log *slog.Logger, events <-chan watcher.Event) {
 	for e := range events {
 		switch e.Type {
@@ -181,7 +190,7 @@ func (pa *pollAccounter) watchForProcessEvents(log *slog.Logger, events <-chan w
 			pa.bpfWatcherIsReady()
 		case watcher.NewPort:
 			port := int(e.Payload)
-			if pa.cfg.Port.Matches(port) || pa.findingCriteria.PortOfInterest(port) {
+			if pa.cfg.Port.Matches(port) || portOfInterest(pa.findingCriteria, port) {
 				pa.refetchPorts()
 			}
 		default:

--- a/pkg/internal/ebpf/common/common_darwin.go
+++ b/pkg/internal/ebpf/common/common_darwin.go
@@ -9,7 +9,7 @@ func hasCapSysAdmin() bool {
 }
 
 func HasHostPidAccess() bool {
-	return false
+	return true
 }
 
 func HasHostNetworkAccess() (bool, error) {

--- a/pkg/internal/ebpf/common/http2grpc_transform.go
+++ b/pkg/internal/ebpf/common/http2grpc_transform.go
@@ -348,7 +348,7 @@ func http2FromBuffers(event *BPFHTTP2Info) (request.Span, bool, error) {
 			method, path, contentType, ok := readMetaFrame(connID, framer, ff)
 
 			if path == "" {
-				path = "*"
+				path = "."
 			}
 
 			grpcInStatus := false

--- a/pkg/internal/ebpf/common/http2grpc_transform_test.go
+++ b/pkg/internal/ebpf/common/http2grpc_transform_test.go
@@ -251,7 +251,7 @@ func TestDynamicTableUpdates(t *testing.T) {
 	s, ignore, _ = http2FromBuffers(&info)
 	assert.False(t, ignore)
 	assert.Equal(t, "POST", s.Method)
-	assert.Equal(t, "*", s.Path) // this value is the same I just changed the first character from r to p
+	assert.Equal(t, ".", s.Path) // this value is the same I just changed the first character from r to p
 }
 
 func makeBPFHTTP2Info(buf, rbuf []byte, length int) BPFHTTP2Info {

--- a/pkg/internal/ebpf/tctracer/tctracer_notlinux.go
+++ b/pkg/internal/ebpf/tctracer/tctracer_notlinux.go
@@ -43,3 +43,4 @@ func (p *Tracer) Constants() map[string]any                              { retur
 func (p *Tracer) SetupTailCalls()                                        {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets)    {}
 func (p *Tracer) ProcessBinary(_ *exec.FileInfo)                         {}
+func CanRun() bool                                                       { return false }

--- a/pkg/services/attr_glob.go
+++ b/pkg/services/attr_glob.go
@@ -1,0 +1,161 @@
+package services
+
+import (
+	"fmt"
+	"iter"
+
+	"github.com/gobwas/glob"
+	"gopkg.in/yaml.v3"
+)
+
+// GlobDefinitionCriteria allows defining a group of services to be instrumented according to a set
+// of attributes. If a given executable/service matches multiple of the attributes, the
+// earliest defined service will take precedence.
+type GlobDefinitionCriteria []GlobAttributes
+
+func (dc GlobDefinitionCriteria) Validate() error {
+	// an empty definition criteria is valid
+	for i := range dc {
+		if dc[i].OpenPorts.Len() == 0 &&
+			!dc[i].Path.IsSet() &&
+			len(dc[i].Metadata) == 0 &&
+			len(dc[i].PodLabels) == 0 &&
+			len(dc[i].PodAnnotations) == 0 {
+			return fmt.Errorf("entry [%d] should define at least one selection criteria", i)
+		}
+		for k := range dc[i].Metadata {
+			if _, ok := allowedAttributeNames[k]; !ok {
+				return fmt.Errorf("unknown attribute in discovery.services[%d]: %s", i, k)
+			}
+		}
+	}
+	return nil
+}
+
+func (dc GlobDefinitionCriteria) PortOfInterest(port int) bool {
+	for i := range dc {
+		if dc[i].OpenPorts.Matches(port) {
+			return true
+		}
+	}
+	return false
+}
+
+type GlobAttributes struct {
+	// Name will define a name for the matching service. If unset, it will take the name of the executable process
+	Name string `yaml:"name"`
+	// Namespace will define a namespace for the matching service. If unset, it will be left empty.
+	Namespace string `yaml:"namespace"`
+
+	// OpenPorts allows defining a group of ports that this service could open. It accepts a comma-separated
+	// list of port numbers (e.g. 80) and port ranges (e.g. 8080-8089)
+	OpenPorts PortEnum `yaml:"open_ports"`
+
+	// Path allows defining the regular expression matching the full executable path.
+	Path GlobAttr `yaml:"exe_path"`
+
+	// Metadata stores other attributes, such as Kubernetes object metadata
+	Metadata map[string]*GlobAttr `yaml:",inline"`
+
+	// PodLabels allows matching against the labels of a pod
+	PodLabels map[string]*GlobAttr `yaml:"k8s_pod_labels"`
+
+	// PodAnnotations allows matching against the annotations of a pod
+	PodAnnotations map[string]*GlobAttr `yaml:"k8s_pod_annotations"`
+
+	// ContainersOnly restricts the discovery to processes which are running inside a container
+	ContainersOnly bool `yaml:"containers_only"`
+}
+
+// GlobAttr provides a YAML handler for glob.Glob so the type can be parsed from YAML or environment variables
+type GlobAttr struct {
+	glob glob.Glob
+}
+
+func NewGlob(g glob.Glob) GlobAttr {
+	return GlobAttr{glob: g}
+}
+
+func (p *GlobAttr) IsSet() bool {
+	return p.glob != nil
+}
+
+func (p *GlobAttr) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("GlobAttr: unexpected YAML node kind %d", value.Kind)
+	}
+	if len(value.Value) == 0 {
+		p.glob = nil
+		return nil
+	}
+
+	re, err := glob.Compile(value.Value)
+	if err != nil {
+		return fmt.Errorf("invalid regular expression in node %s: %w", value.Tag, err)
+	}
+	p.glob = re
+	return nil
+}
+
+func (p *GlobAttr) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		p.glob = nil
+		return nil
+	}
+	re, err := glob.Compile(string(text))
+	if err != nil {
+		return fmt.Errorf("invalid regular expression %q: %w", string(text), err)
+	}
+	p.glob = re
+	return nil
+}
+
+func (p *GlobAttr) MatchString(input string) bool {
+	// no glob means "empty glob", so anything will match it
+	if p.glob == nil {
+		return true
+	}
+	return p.glob.Match(input)
+}
+
+func (ga *GlobAttributes) GetName() string              { return ga.Name }
+func (ga *GlobAttributes) GetNamespace() string         { return ga.Namespace }
+func (ga *GlobAttributes) GetPath() StringMatcher       { return &ga.Path }
+func (ga *GlobAttributes) GetPathRegexp() StringMatcher { return nilMatcher{} }
+func (ga *GlobAttributes) GetOpenPorts() *PortEnum      { return &ga.OpenPorts }
+func (ga *GlobAttributes) IsContainersOnly() bool       { return ga.ContainersOnly }
+
+func (ga *GlobAttributes) RangeMetadata() iter.Seq2[string, StringMatcher] {
+	return func(yield func(string, StringMatcher) bool) {
+		for k, v := range ga.Metadata {
+			if !yield(k, v) {
+				break
+			}
+		}
+	}
+}
+
+func (ga *GlobAttributes) RangePodLabels() iter.Seq2[string, StringMatcher] {
+	return func(yield func(string, StringMatcher) bool) {
+		for k, v := range ga.PodLabels {
+			if !yield(k, v) {
+				break
+			}
+		}
+	}
+}
+
+func (ga *GlobAttributes) RangePodAnnotations() iter.Seq2[string, StringMatcher] {
+	return func(yield func(string, StringMatcher) bool) {
+		for k, v := range ga.PodAnnotations {
+			if !yield(k, v) {
+				break
+			}
+		}
+	}
+}
+
+type nilMatcher struct{}
+
+func (n nilMatcher) IsSet() bool               { return false }
+func (n nilMatcher) MatchString(_ string) bool { return false }

--- a/pkg/services/attr_regex.go
+++ b/pkg/services/attr_regex.go
@@ -1,0 +1,160 @@
+package services
+
+import (
+	"fmt"
+	"iter"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RegexDefinitionCriteria allows defining a group of services to be instrumented according to a set
+// of attributes. If a given executable/service matches multiple of the attributes, the
+// earliest defined service will take precedence.
+type RegexDefinitionCriteria []RegexSelector
+
+func (dc RegexDefinitionCriteria) Validate() error {
+	// an empty definition criteria is valid
+	for i := range dc {
+		if dc[i].OpenPorts.Len() == 0 &&
+			!dc[i].Path.IsSet() &&
+			!dc[i].PathRegexp.IsSet() &&
+			len(dc[i].Metadata) == 0 &&
+			len(dc[i].PodLabels) == 0 &&
+			len(dc[i].PodAnnotations) == 0 {
+			return fmt.Errorf("discovery.services[%d] should define at least one selection criteria", i)
+		}
+		for k := range dc[i].Metadata {
+			if _, ok := allowedAttributeNames[k]; !ok {
+				return fmt.Errorf("unknown attribute in discovery.services[%d]: %s", i, k)
+			}
+		}
+	}
+	return nil
+}
+
+func (dc RegexDefinitionCriteria) PortOfInterest(port int) bool {
+	for i := range dc {
+		if dc[i].OpenPorts.Matches(port) {
+			return true
+		}
+	}
+	return false
+}
+
+// RegexSelector that specify a given instrumented service.
+// Each instance has to define either the OpenPorts or Path property, or both. These are used to match
+// a given executable. If both OpenPorts and Path are defined, the inspected executable must fulfill both
+// properties.
+type RegexSelector struct {
+	// Name will define a name for the matching service. If unset, it will take the name of the executable process
+	Name string `yaml:"name"`
+	// Namespace will define a namespace for the matching service. If unset, it will be left empty.
+	Namespace string `yaml:"namespace"`
+	// OpenPorts allows defining a group of ports that this service could open. It accepts a comma-separated
+	// list of port numbers (e.g. 80) and port ranges (e.g. 8080-8089)
+	OpenPorts PortEnum `yaml:"open_ports"`
+	// Path allows defining the regular expression matching the full executable path.
+	Path RegexpAttr `yaml:"exe_path"`
+	// PathRegexp is deprecated but kept here for backwards compatibility with Beyla 1.0.x.
+	// Deprecated. Please use Path (exe_path YAML attribute)
+	PathRegexp RegexpAttr `yaml:"exe_path_regexp"`
+
+	// Metadata stores other attributes, such as Kubernetes object metadata
+	Metadata map[string]*RegexpAttr `yaml:",inline"`
+
+	// PodLabels allows matching against the labels of a pod
+	PodLabels map[string]*RegexpAttr `yaml:"k8s_pod_labels"`
+
+	// PodAnnotations allows matching against the annotations of a pod
+	PodAnnotations map[string]*RegexpAttr `yaml:"k8s_pod_annotations"`
+
+	// Restrict the discovery to processes which are running inside a container
+	ContainersOnly bool `yaml:"containers_only"`
+}
+
+// RegexpAttr stores a regular expression representing an executable file path.
+type RegexpAttr struct {
+	re *regexp.Regexp
+}
+
+func NewPathRegexp(re *regexp.Regexp) RegexpAttr {
+	return RegexpAttr{re: re}
+}
+
+func (p *RegexpAttr) IsSet() bool {
+	return p.re != nil
+}
+
+func (p *RegexpAttr) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("RegexpAttr: unexpected YAML node kind %d", value.Kind)
+	}
+	if len(value.Value) == 0 {
+		p.re = nil
+		return nil
+	}
+	re, err := regexp.Compile(value.Value)
+	if err != nil {
+		return fmt.Errorf("invalid regular expression in node %s: %w", value.Tag, err)
+	}
+	p.re = re
+	return nil
+}
+
+func (p *RegexpAttr) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		p.re = nil
+		return nil
+	}
+	re, err := regexp.Compile(string(text))
+	if err != nil {
+		return fmt.Errorf("invalid regular expression %q: %w", string(text), err)
+	}
+	p.re = re
+	return nil
+}
+
+func (p *RegexpAttr) MatchString(input string) bool {
+	// no regexp means "empty regexp", so anything will match it
+	if p.re == nil {
+		return true
+	}
+	return p.re.MatchString(input)
+}
+
+func (a *RegexSelector) GetName() string              { return a.Name }
+func (a *RegexSelector) GetNamespace() string         { return a.Namespace }
+func (a *RegexSelector) GetPath() StringMatcher       { return &a.Path }
+func (a *RegexSelector) GetPathRegexp() StringMatcher { return &a.PathRegexp }
+func (a *RegexSelector) GetOpenPorts() *PortEnum      { return &a.OpenPorts }
+func (a *RegexSelector) IsContainersOnly() bool       { return a.ContainersOnly }
+func (a *RegexSelector) RangeMetadata() iter.Seq2[string, StringMatcher] {
+	return func(yield func(string, StringMatcher) bool) {
+		for k, v := range a.Metadata {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}
+
+func (a *RegexSelector) RangePodLabels() iter.Seq2[string, StringMatcher] {
+	return func(yield func(string, StringMatcher) bool) {
+		for k, v := range a.PodLabels {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}
+
+func (a *RegexSelector) RangePodAnnotations() iter.Seq2[string, StringMatcher] {
+	return func(yield func(string, StringMatcher) bool) {
+		for k, v := range a.PodAnnotations {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}

--- a/pkg/services/criteria_test.go
+++ b/pkg/services/criteria_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 type yamlFile struct {
-	Services DefinitionCriteria `yaml:"services"`
+	Services RegexDefinitionCriteria `yaml:"services"`
 }
 
 func TestYAMLParse_PathRegexp(t *testing.T) {
 	inputFile := `
 services:
   - name: foo
-    exe_path: "abc"
+    exe_path: "^abc$"
 `
 	yf := yamlFile{}
 	require.NoError(t, yaml.Unmarshal([]byte(inputFile), &yf))
@@ -33,7 +33,7 @@ services:
 }
 
 func TestYAMLParse_PathRegexp_Errors(t *testing.T) {
-	t.Run("wrong glob expression", func(t *testing.T) {
+	t.Run("wrong regex expression", func(t *testing.T) {
 		require.Error(t, yaml.Unmarshal([]byte(`services:
   - exe_path: "{a\("`), &yamlFile{}))
 	})

--- a/test/integration/configs/instrumenter-config-multiexec.yml
+++ b/test/integration/configs/instrumenter-config-multiexec.yml
@@ -14,9 +14,9 @@ discovery:
     - namespace: initial-set
       name: some-server
       open_ports: 18080
-      exe_path: "*dupe*" # choose only the dupe* process that uses port 18080
+      exe_path: "dupe" # choose only the dupe* process that uses port 18080
     - namespace: initial-set
-      exe_path: "*{testserver,rename1}"
+      exe_path: "(testserver|rename1)"
     - namespace: multi-k
       name: rust-service-ssl
       open_ports: 8490

--- a/test/integration/configs/instrumenter-config-other-grpc.yml
+++ b/test/integration/configs/instrumenter-config-other-grpc.yml
@@ -1,10 +1,10 @@
 discovery:
   services:
-    - exe_path: "*backend"
+    - exe_path: "backend"
       namespace: integration-test
-    - exe_path: "*worker"
+    - exe_path: "worker"
       namespace: integration-test
-    - exe_path: "*grpcpinger"
+    - exe_path: "grpcpinger"
       namespace: integration-test
 routes:
   patterns:

--- a/test/integration/k8s/manifests/06-beyla-external-informer.yml
+++ b/test/integration/k8s/manifests/06-beyla-external-informer.yml
@@ -38,8 +38,8 @@ data:
     log_level: debug
     discovery:
       services:
-        - k8s_deployment_name: "{otherinstance,testserver}"
-        - k8s_pod_name: "*pinger*"
+        - k8s_deployment_name: "(otherinstance|testserver)"
+        - k8s_pod_name: "pinger"
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
@@ -66,7 +66,7 @@ spec:
         - name: OTEL_EBPF_TRACE_PRINTER
           value: "text"
         - name: OTEL_EBPF_EXECUTABLE_PATH
-          value: "*httppinger"
+          value: "httppinger"
         - name: OTEL_EBPF_METRICS_INTERVAL
           value: "10ms"
         - name: OTEL_EBPF_BPF_BATCH_TIMEOUT

--- a/test/integration/k8s/manifests/06-instrumented-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-client.template.yml
@@ -66,7 +66,7 @@ spec:
         - name: OTEL_EBPF_TRACE_PRINTER
           value: "text"
         - name: OTEL_EBPF_EXECUTABLE_PATH
-          value: "*httppinger"
+          value: "httppinger"
         - name: OTEL_EBPF_METRICS_INTERVAL
           value: "10ms"
         - name: OTEL_EBPF_BPF_BATCH_TIMEOUT

--- a/test/integration/k8s/manifests/06-instrumented-grpc-client-prom.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-grpc-client-prom.template.yml
@@ -67,7 +67,7 @@ spec:
         - name: OTEL_EBPF_TRACE_PRINTER
           value: "counter"
         - name: OTEL_EBPF_EXECUTABLE_PATH
-          value: "*grpcpinger"
+          value: "grpcpinger"
         - name: OTEL_EBPF_METRICS_INTERVAL
           value: "10ms"
         - name: OTEL_EBPF_BPF_BATCH_TIMEOUT

--- a/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
+++ b/test/integration/k8s/manifests/06-instrumented-grpc-client.template.yml
@@ -68,7 +68,7 @@ spec:
         - name: OTEL_EBPF_TRACE_PRINTER
           value: "json_indent"
         - name: OTEL_EBPF_EXECUTABLE_PATH
-          value: "*grpcpinger"
+          value: "grpcpinger"
         - name: OTEL_EBPF_METRICS_INTERVAL
           value: "10ms"
         - name: OTEL_EBPF_BPF_BATCH_TIMEOUT


### PR DESCRIPTION
In order to smooth the transition from Beyla to OBI, this PR temporarily reverts the changes we did to replace regular expressions by globs.

The plan will be:
* Temporarily keep the discovery > services section with regular expressions in order to keep compatibility between configurations.
* Deprecate the discovery > services section, and warn users about its future removal.
* Create a proper discovery > instrument section that will use globs, which will be the "stable" service selection mechanism.

To facilitate the switch, this PR abstract either Regex or Glob matchers between an interface, to let the matchers easily exchange between one implementation or another, depending on the used configuration section.