### PR TITLE
Add extra debug data to flaky test

### DIFF
--- a/test/integration/red_test_dotnet.go
+++ b/test/integration/red_test_dotnet.go
@@ -5,6 +5,8 @@ package integration
 import (
 	"testing"
 
+	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/test/tools"
+
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -36,7 +38,7 @@ func testREDMetricsForNetHTTPLibrary(t *testing.T, url string, comm string) {
 		require.NoError(t, err)
 		enoughPromResults(t, results)
 		val := totalPromCount(t, results)
-		assert.LessOrEqual(t, 3, val)
+		assert.LessOrEqual(t, 3, val, "received:", tools.ToJSON(val))
 		if len(results) > 0 {
 			res := results[0]
 			addr := res.Metric["client_address"]

--- a/test/tools/debug.go
+++ b/test/tools/debug.go
@@ -1,0 +1,16 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ToJSON is just a one-line convenience method to provide some debug data
+// in tests, without having to deal with error handling nor byte-to-string transformation
+func ToJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Sprintf("converting %+v to JSON: %s", v, err.Error()))
+	}
+	return string(b)
+}

--- a/test/tools/debug_test.go
+++ b/test/tools/debug_test.go
@@ -1,0 +1,27 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToJSON(t *testing.T) {
+	obj := struct {
+		A string
+		B int
+	}{A: "A", B: 2}
+
+	assert.JSONEq(t, `{"A":"A","B":2}`, ToJSON(obj))
+}
+
+func TestToJSON_Fail(t *testing.T) {
+	type A struct {
+		A *A
+	}
+	assert.Panics(t, func() {
+		a := A{}
+		a.A = &a
+		ToJSON(a)
+	})
+}


### PR DESCRIPTION
`TestSuite_DotNet` test is lately flaky, and the issue seems difficult to reproduce locally. This PR just prints whatever the failed tests receive

