### PR TITLE
Node swarm zombie detector

### DIFF
--- a/pkg/instrumenter/instrumenter.go
+++ b/pkg/instrumenter/instrumenter.go
@@ -74,16 +74,19 @@ func setupAppO11y(ctx context.Context, ctxInfo *global.ContextInfo, config *beyl
 		return fmt.Errorf("can't create new instrumenter: %w", err)
 	}
 
-	err = instr.FindAndInstrument(ctx)
-	if err != nil {
+	if err := instr.FindAndInstrument(ctx); err != nil {
 		slog.Debug("can't find target process", "error", err)
 		return fmt.Errorf("can't find target process: %w", err)
 	}
 
-	err = instr.ReadAndForward(ctx)
-	if err != nil {
-		slog.Debug("can't read and forward auto-instrumenter", "error", err)
-		return fmt.Errorf("can't read and forward auto-instrumente: %w", err)
+	if err := instr.ReadAndForward(ctx); err != nil {
+		slog.Debug("read and forward auto-instrumenter", "error", err)
+		return err
+	}
+
+	if err := instr.WaitUntilFinished(); err != nil {
+		slog.Error("waiting for App O11y pipeline to finish", "error", err)
+		return err
 	}
 
 	return nil

--- a/pkg/instrumenter/instrumenter.go
+++ b/pkg/instrumenter/instrumenter.go
@@ -61,7 +61,7 @@ func Run(
 	if err := g.Wait(); err != nil {
 		return err
 	}
-
+	slog.Debug("OBI main node finished")
 	return nil
 }
 
@@ -89,6 +89,7 @@ func setupAppO11y(ctx context.Context, ctxInfo *global.ContextInfo, config *beyl
 		return err
 	}
 
+	slog.Debug("Application O11y pipeline finished")
 	return nil
 }
 

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -41,6 +41,13 @@ type Instrumenter struct {
 	tracesInput       *msg.Queue[[]request.Span]
 	processEventInput *msg.Queue[exec.ProcessEvent]
 	peGraphBuilder    *swarm.Instancer
+
+	finishers []finisher
+}
+
+type finisher struct {
+	name string
+	done <-chan error
 }
 
 // New Instrumenter, given a Config
@@ -103,16 +110,29 @@ func (i *Instrumenter) FindAndInstrument(ctx context.Context) error {
 	// the Host or Kubernetes metadata
 	graph, err := i.peGraphBuilder.Instance(ctx)
 	if err == nil {
-		go i.processEventsPipeline(ctx, graph)
+		i.processEventsPipeline(ctx, graph)
 	} else {
 		return fmt.Errorf("couldn't start Process Event pipeline: %w", err)
 	}
+
+	// registers resources that must be done before exiting OBI
+	i.finishers = append(i.finishers,
+		finisher{name: "process finder", done: finder.Done()},
+		finisher{name: "process instrumenter", done: graph.Done()})
 
 	// In background, listen indefinitely for each new process and run its
 	// associated ebpf.ProcessTracer once it is found.
 	go i.instrumentedEventLoop(ctx, processEvents)
 
-	// TODO: wait until all the resources have been freed/unmounted
+	return nil
+}
+
+func (i *Instrumenter) WaitUntilFinished() error {
+	for _, f := range i.finishers {
+		if err := <-f.done; err != nil {
+			return fmt.Errorf("node %s couldn't finish: %w", f.name, err)
+		}
+	}
 	return nil
 }
 
@@ -161,8 +181,10 @@ func (i *Instrumenter) ReadAndForward(ctx context.Context) error {
 
 	log.Info("Starting main node")
 
-	i.bp.Run(ctx)
-
+	i.finishers = append(i.finishers, finisher{
+		name: "Instrumenter Pipeline",
+		done: i.bp.Start(ctx),
+	})
 	<-ctx.Done()
 
 	log.Info("exiting auto-instrumenter")
@@ -225,10 +247,5 @@ func refreshK8sInformerCache(ctx context.Context, ctxInfo *global.ContextInfo) e
 }
 
 func (i *Instrumenter) processEventsPipeline(ctx context.Context, graph *swarm.Runner) {
-	graph.Start(ctx)
-	// run until either the graph is finished or the context is cancelled
-	select {
-	case <-graph.Done():
-	case <-ctx.Done():
-	}
+	graph.Start(ctx, swarm.WithCancelTimeout(i.config.ShutdownTimeout)) // zurulao
 }

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -22,7 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/transform"
 )
 
-var errShutdownTimeout = errors.New("graceful shutdown has timed out")
+var errShutdownTimeout = errors.New("graceful shutdown has timed out while waiting for eBPF tracers to finish")
 
 func log() *slog.Logger {
 	return slog.With("component", "beyla.Instrumenter")

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -69,7 +69,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *beyla.Config)
 		&config.Attributes.InstanceID,
 		processEventsInput,
 		processEventsHostDecorated,
-	))
+	), swarm.WithID("HostProcessEventDecoratorProvider"))
 
 	processEventsKubeDecorated := newEventQueue()
 	swi.Add(transform.KubeProcessEventDecoratorProvider(
@@ -77,7 +77,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *beyla.Config)
 		&config.Attributes.Kubernetes,
 		processEventsHostDecorated,
 		processEventsKubeDecorated,
-	))
+	), swarm.WithID("KubeProcessEventDecoratorProvider"))
 
 	bp, err := pipe.Build(ctx, config, ctxInfo, tracesInput, processEventsKubeDecorated)
 	if err != nil {
@@ -130,7 +130,7 @@ func (i *Instrumenter) FindAndInstrument(ctx context.Context) error {
 func (i *Instrumenter) WaitUntilFinished() error {
 	for _, f := range i.finishers {
 		if err := <-f.done; err != nil {
-			return fmt.Errorf("node %s couldn't finish: %w", f.name, err)
+			return fmt.Errorf("node %q couldn't finish: %w", f.name, err)
 		}
 	}
 	return nil
@@ -189,8 +189,7 @@ func (i *Instrumenter) ReadAndForward(ctx context.Context) error {
 
 	log.Info("exiting auto-instrumenter")
 
-	err := i.stop()
-	if err != nil {
+	if err := i.stop(); err != nil {
 		return fmt.Errorf("failed to stop auto-instrumenter: %w", err)
 	}
 
@@ -204,7 +203,7 @@ func (i *Instrumenter) stop() error {
 	go func() {
 		log.Debug("stopped searching for new processes to instrument. Waiting for the eBPF tracers to be unloaded")
 		i.tracersWg.Wait()
-		stopped <- struct{}{}
+		close(stopped)
 		log.Debug("tracers unloaded, exiting FindAndInstrument")
 	}()
 

--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -182,7 +182,7 @@ func (ta *TraceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 		return false
 	}
 
-	tracer := ebpf.NewProcessTracer(tracerType, programs)
+	tracer := ebpf.NewProcessTracer(tracerType, programs, ta.Cfg.ShutdownTimeout)
 
 	if err := tracer.Init(); err != nil {
 		ta.log.Error("couldn't trace process. Stopping process tracer", "error", err)

--- a/pkg/internal/ebpf/common/ringbuf_test.go
+++ b/pkg/internal/ebpf/common/ringbuf_test.go
@@ -134,7 +134,7 @@ func TestForwardRingbuf_Close(t *testing.T) {
 	)(t.Context(), msg.NewQueue[[]request.Span](msg.ChannelBufferLen(100)))
 
 	assert.False(t, ringBuf.explicitClose.Load())
-	assert.False(t, closable.closed)
+	assert.False(t, closable.closed.Load())
 
 	// WHEN the ring buffer is closed
 	close(ringBuf.closeCh)
@@ -143,7 +143,7 @@ func TestForwardRingbuf_Close(t *testing.T) {
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		assert.True(t, ringBuf.explicitClose.Load())
 	})
-	assert.True(t, closable.closed)
+	assert.True(t, closable.closed.Load())
 
 	// AND metrics haven't been updated
 	assert.Equal(t, 0, metrics.flushes)
@@ -195,11 +195,11 @@ func (f *fakeRingBufReader) ReadInto(record *ringbuf.Record) error {
 }
 
 type closableObject struct {
-	closed bool
+	closed atomic.Bool
 }
 
 func (c *closableObject) Close() error {
-	c.closed = true
+	c.closed.Store(true)
 	return nil
 }
 

--- a/pkg/internal/ebpf/tracer.go
+++ b/pkg/internal/ebpf/tracer.go
@@ -125,7 +125,6 @@ type ProcessTracer struct {
 	log      *slog.Logger
 	Programs []Tracer
 
-	//nolint:unused
 	shutdownTimeout time.Duration
 
 	Type            ProcessTracerType

--- a/pkg/internal/ebpf/tracer.go
+++ b/pkg/internal/ebpf/tracer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"time"
 
 	"github.com/cilium/ebpf"
 
@@ -123,6 +124,9 @@ const (
 type ProcessTracer struct {
 	log      *slog.Logger
 	Programs []Tracer
+
+	//nolint:unused
+	shutdownTimeout time.Duration
 
 	Type            ProcessTracerType
 	Instrumentables map[uint64]*instrumenter

--- a/pkg/internal/ebpf/tracer_darwin.go
+++ b/pkg/internal/ebpf/tracer_darwin.go
@@ -2,6 +2,7 @@ package ebpf
 
 import (
 	"context"
+	"time"
 
 	"github.com/cilium/ebpf/link"
 
@@ -17,7 +18,7 @@ type instrumenter struct{}
 
 func (pt *ProcessTracer) Run(_ context.Context, _ *msg.Queue[[]request.Span]) {}
 
-func NewProcessTracer(_ ProcessTracerType, _ []Tracer) *ProcessTracer {
+func NewProcessTracer(_ ProcessTracerType, _ []Tracer, _ time.Duration) *ProcessTracer {
 	return nil
 }
 

--- a/pkg/internal/ebpf/tracer_darwin.go
+++ b/pkg/internal/ebpf/tracer_darwin.go
@@ -23,7 +23,8 @@ func NewProcessTracer(_ ProcessTracerType, _ []Tracer, _ time.Duration) *Process
 }
 
 func (pt *ProcessTracer) Init() error {
-	pt.log.Debug("avoiding linter complaints for not using log field")
+	pt.log.Debug("avoiding linter complaints for not using log and shutdownTimeout fields",
+		"v", pt.shutdownTimeout)
 	return nil
 }
 

--- a/pkg/internal/ebpf/tracer_linux.go
+++ b/pkg/internal/ebpf/tracer_linux.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
@@ -104,26 +106,49 @@ func NewProcessTracer(tracerType ProcessTracerType, programs []Tracer) *ProcessT
 	}
 }
 
+type tracerInstance struct {
+	implType string
+	done     atomic.Bool
+}
+
 func (pt *ProcessTracer) Run(ctx context.Context, out *msg.Queue[[]request.Span]) {
 	pt.log = ptlog().With("type", pt.Type)
 
 	pt.log.Debug("starting process tracer")
 	// Searches for traceable functions
 	trcrs := pt.Programs
-
 	wg := sync.WaitGroup{}
-
-	for _, t := range trcrs {
+	runningTracers := make([]tracerInstance, 0, len(trcrs))
+	for i := range trcrs {
+		idx := i
+		t := trcrs[idx]
 		wg.Add(1)
+		runningTracers = append(runningTracers, tracerInstance{
+			implType: reflect.TypeOf(t).String(),
+		})
 		go func() {
 			defer wg.Done()
 			t.Run(ctx, out)
+			runningTracers[idx].done.Store(true)
 		}()
 	}
 
 	<-ctx.Done()
 
-	wg.Wait()
+	tracersEnded := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(tracersEnded)
+	}()
+
+	for {
+		select {
+		case <-tracersEnded:
+			return
+		case <-time.After(time.Second):
+			pt.log.Warn("some process tracers did not finish", "tracers", runningTracers)
+		}
+	}
 }
 
 func (pt *ProcessTracer) loadSpec(p Tracer) (*ebpf.CollectionSpec, error) {

--- a/pkg/internal/ebpf/tracer_linux.go
+++ b/pkg/internal/ebpf/tracer_linux.go
@@ -98,11 +98,12 @@ func resolveMaps(spec *ebpf.CollectionSpec) (*ebpf.CollectionOptions, error) {
 	return &collOpts, nil
 }
 
-func NewProcessTracer(tracerType ProcessTracerType, programs []Tracer) *ProcessTracer {
+func NewProcessTracer(tracerType ProcessTracerType, programs []Tracer, shutdownTimeout time.Duration) *ProcessTracer {
 	return &ProcessTracer{
 		Programs:        programs,
 		Type:            tracerType,
 		Instrumentables: map[uint64]*instrumenter{},
+		shutdownTimeout: shutdownTimeout,
 	}
 }
 
@@ -141,12 +142,18 @@ func (pt *ProcessTracer) Run(ctx context.Context, out *msg.Queue[[]request.Span]
 		close(tracersEnded)
 	}()
 
+	hasWarned := false
 	for {
 		select {
-		case <-tracersEnded:
-			return
-		case <-time.After(time.Second):
+		// notifyng before OBI times out on finish
+		case <-time.After(3 * pt.shutdownTimeout / 4):
 			pt.log.Warn("some process tracers did not finish", "tracers", runningTracers)
+			hasWarned = true
+		case <-tracersEnded:
+			if hasWarned {
+				pt.log.Info("all process tracers finished")
+			}
+			return
 		}
 	}
 }


### PR DESCRIPTION
Sometimes, OBI gets stalled during shutdown, causing that it requires to detect that situation and self-terminate its process. But that could cause that some eBPF resources aren't properly clean).

This PR adds to the `swarm.Runner` a mechanism to auto-detect which nodes are frozen during shutdown and pointing to them, to facilitate debugging.

This PR also fixes some nodes that weren't properly finished because their input channels weren't closed nor addressed the context cancelation.