### PR TITLE
add k8s-cache build image github action

### DIFF
--- a/.github/workflows/publish_dockerhub_k8s_cache_main.yml
+++ b/.github/workflows/publish_dockerhub_k8s_cache_main.yml
@@ -14,7 +14,7 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     env:
-      IMAGE_NAME: ebpf-instrument-k8s-cache
+      IMAGE_NAME: opentelemetry-ebpf-k8s-cache
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
I've duplicated the main image workflow for now, please tell me if you think it should be part of the same workflow or this is ok
[issue](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/115)