### PR TITLE
Fix unknown gRPC status when indexing fails

### DIFF
--- a/pkg/components/ebpf/common/http2grpc_transform_test.go
+++ b/pkg/components/ebpf/common/http2grpc_transform_test.go
@@ -184,6 +184,41 @@ func TestHTTP2EventsParsing(t *testing.T) {
 	}
 }
 
+func TestHTTP2EventsErrorParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		rinput   []byte
+		inputLen int
+		status   int
+	}{
+		{
+			name:     "Error response with bad index",
+			input:    []byte{0, 0, 8, 1, 4, 0, 0, 0, 7, 195, 194, 131, 134, 193, 192, 191, 190, 0, 0, 4, 8, 0, 0, 0, 0, 7, 0, 0, 0, 5, 0, 0, 5, 0, 1, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 4, 8, 0, 0, 0, 0, 0, 0, 0, 0, 84},
+			rinput:   []byte{0, 0, 55, 1, 5, 0, 0, 0, 3, 136, 192, 64, 11, 103, 114, 112, 99, 45, 115, 116, 97, 116, 117, 115, 1, 51, 0, 12, 103, 114, 112, 99, 45, 109, 101, 115, 115, 97, 103, 101, 23, 76, 97, 116, 105, 116, 117, 100, 101, 32, 99, 97, 110, 110, 111, 116, 32, 98, 101, 32, 122, 101, 114, 111},
+			inputLen: 201,
+			status:   3,
+		},
+		{
+			name:     "Error response with bad index on grpc-status",
+			input:    []byte{0, 0, 8, 1, 4, 0, 0, 0, 7, 195, 194, 131, 134, 193, 192, 191, 190, 0, 0, 4, 8, 0, 0, 0, 0, 7, 0, 0, 0, 5, 0, 0, 5, 0, 1, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 4, 8, 0, 0, 0, 0, 0, 0, 0, 0, 84},
+			rinput:   []byte{0, 0, 41, 1, 5, 0, 0, 0, 7, 136, 193, 190, 0, 12, 103, 114, 112, 99, 45, 109, 101, 115, 115, 97, 103, 101, 23, 76, 97, 116, 105, 116, 117, 100, 101, 32, 99, 97, 110, 110, 111, 116, 32, 98, 101, 32, 122, 101, 114, 111, 0, 0, 4, 8, 0, 0, 0, 0, 0, 0, 0, 0, 5, 97},
+			inputLen: 201,
+			status:   2,
+		},
+	}
+
+	parseContext := NewEBPFParseContext()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := makeBPFHTTP2Info(tt.input, tt.rinput, tt.inputLen)
+			span, _, _ := http2FromBuffers(parseContext, &info)
+			assert.Equal(t, tt.status, span.Status)
+		})
+	}
+}
+
 func TestDynamicTableUpdates(t *testing.T) {
 	rinput := []byte{0, 0, 138, 1, 36, 0, 0, 0, 11, 0, 0, 0, 0, 15, 0, 0, 0, 0, 45, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
@@ -256,7 +291,7 @@ func TestDynamicTableUpdates(t *testing.T) {
 	s, ignore, _ = http2FromBuffers(parseContext, &info)
 	assert.False(t, ignore)
 	assert.Equal(t, "POST", s.Method)
-	assert.Equal(t, ".", s.Path) // this value is the same I just changed the first character from r to p
+	assert.Equal(t, "*", s.Path) // this value is the same I just changed the first character from r to p
 }
 
 func makeBPFHTTP2Info(buf, rbuf []byte, length int) BPFHTTP2Info {


### PR DESCRIPTION
If a gRPC request isn't captured by OBI from the very beginning, there might be indexed fields for which we haven't recorded in the OBI dynamic gRPC tables for the given connection. In these cases the information captured is partial. Namely, in this scenario we may fail to decode `grpc-status` and the current OBI code assumes this is successful, e.g. sets the gRPC status 0. 

However there's another gRPC field called `grpc-message` which will be set to non-empty string if a request fails. In this PR we try to do a bit better, when the request fails, but we don't know the reason we say error UNKNOWN (status code 2) instead of incorrectly marking it as unsuccessful. This error will eventually translate to proper OTel error request. So even thought we don't know the protocol exact error we'll at least be able to mark the gRPC request as failed.

Relates to Beyla issue https://github.com/grafana/beyla/issues/1777