### PR TITLE
Remove stale service attribute and replace with service.name

### DIFF
--- a/pkg/app/request/metric_attributes.go
+++ b/pkg/app/request/metric_attributes.go
@@ -56,10 +56,6 @@ func SourceMetric(val string) attribute.KeyValue {
 	return attribute.Key(attr.Source).String(val)
 }
 
-func ServiceMetric(val string) attribute.KeyValue {
-	return attribute.Key(attr.Service).String(val)
-}
-
 func StatusCodeMetric(val string) attribute.KeyValue {
 	return attribute.Key(attr.StatusCode).String(val)
 }

--- a/pkg/app/request/span_getters.go
+++ b/pkg/app/request/span_getters.go
@@ -60,8 +60,6 @@ func SpanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 			}
 			return ServerNamespaceMetric(s.Service.UID.Namespace)
 		}
-	case attr.Service:
-		getter = func(s *Span) attribute.KeyValue { return ServiceMetric(s.Service.UID.Name) }
 	case attr.ServiceInstanceID:
 		getter = func(s *Span) attribute.KeyValue { return semconv.ServiceInstanceID(s.Service.UID.Instance) }
 	case attr.ServiceName:

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -278,7 +278,7 @@ func getDefinitions(groups AttrGroups) map[Section]AttrReportGroup {
 				attr.Server:            false,
 				attr.ServerNamespace:   false,
 				attr.Source:            false,
-				attr.Service:           false,
+				attr.ServiceName:       false,
 				attr.ServiceInstanceID: false,
 				attr.ServiceNamespace:  false,
 				attr.SpanKind:          false,

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -36,7 +36,6 @@ const (
 	SpanName               = Name("span.name")
 	StatusCode             = Name("status.code")
 	Source                 = Name("source")
-	Service                = Name("service")
 	Client                 = Name("client")
 	ClientNamespace        = Name("client_service_namespace")
 	Server                 = Name("server")
@@ -67,6 +66,7 @@ const (
 	K8sNodeName        = Name("k8s.node.name")
 	K8sPodUID          = Name("k8s.pod.uid")
 	K8sPodStartTime    = Name("k8s.pod.start_time")
+	K8sKind            = Name("k8s.kind")
 )
 
 // Beyla-specific network attributes

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -882,7 +882,7 @@ func (mr *MetricsReporter) tracesResourceAttributes(service *svc.Attrs) attribut
 		return *attribute.EmptySet()
 	}
 	baseAttrs := []attribute.KeyValue{
-		request.ServiceMetric(service.UID.Name),
+		semconv.ServiceName(service.UID.Name),
 		semconv.ServiceInstanceID(service.UID.Instance),
 		semconv.ServiceNamespace(service.UID.Namespace),
 		semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage.String()),
@@ -916,7 +916,7 @@ func (mr *MetricsReporter) metricHostAttributes() attribute.Set {
 func (mr *MetricsReporter) spanMetricAttributes() []attributes.Field[*request.Span, attribute.KeyValue] {
 	return append(attributes.OpenTelemetryGetters(
 		request.SpanOTELGetters, []attr.Name{
-			attr.Service,
+			attr.ServiceName,
 			attr.ServiceInstanceID,
 			attr.ServiceNamespace,
 			attr.SpanKind,

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -672,7 +672,7 @@ func TestMetricResourceAttributes(t *testing.T) {
 			},
 			attributeSelect: attributes.Selection{},
 			expectedAttrs: []string{
-				"service",
+				"service.name",
 				"service.instance.id",
 				"service.namespace",
 				"telemetry.sdk.language",
@@ -710,7 +710,7 @@ func TestMetricResourceAttributes(t *testing.T) {
 				},
 			},
 			expectedAttrs: []string{
-				"service",
+				"service.name",
 				"service.instance.id",
 				"service.namespace",
 				"telemetry.sdk.language",
@@ -749,7 +749,7 @@ func TestMetricResourceAttributes(t *testing.T) {
 				},
 			},
 			expectedAttrs: []string{
-				"service",
+				"service.name",
 				"service.instance.id",
 				"service.namespace",
 				"telemetry.sdk.language",
@@ -788,7 +788,7 @@ func TestMetricResourceAttributes(t *testing.T) {
 				},
 			},
 			expectedAttrs: []string{
-				"service",
+				"service.name",
 				"service.instance.id",
 				"service.namespace",
 				"telemetry.sdk.language",

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -46,7 +46,7 @@ const (
 	ServiceGraphFailed = "traces_service_graph_request_failed_total"
 	ServiceGraphTotal  = "traces_service_graph_request_total"
 
-	serviceKey          = "service"
+	serviceNameKey      = "service_name"
 	serviceNamespaceKey = "service_namespace"
 
 	hostIDKey        = "host_id"
@@ -905,7 +905,7 @@ func appendK8sLabelValuesService(values []string, service *svc.Attrs) []string {
 }
 
 func labelNamesSpans() []string {
-	return []string{serviceKey, serviceNamespaceKey, spanNameKey, statusCodeKey, spanKindKey, serviceInstanceKey, serviceJobKey, sourceKey}
+	return []string{serviceNameKey, serviceNamespaceKey, spanNameKey, statusCodeKey, spanKindKey, serviceInstanceKey, serviceJobKey, sourceKey}
 }
 
 func (r *metricsReporter) labelValuesSpans(span *request.Span) []string {
@@ -925,7 +925,7 @@ func labelNamesTargetInfo(kubeEnabled bool, extraMetadataLabelNames []attr.Name)
 	names := []string{
 		hostIDKey,
 		hostNameKey,
-		serviceKey,
+		serviceNameKey,
 		serviceNamespaceKey,
 		serviceInstanceKey,
 		serviceJobKey,


### PR DESCRIPTION
Removes uses of stale "service" attribute and updates to match the latest OTel spec. I also added the missing k8s.kind attribute.