### PR TITLE
Add span Flags field

### DIFF
--- a/pkg/app/request/span.go
+++ b/pkg/app/request/span.go
@@ -121,6 +121,7 @@ type PidInfo struct {
 // SpanPromGetters and getDefinitions in pkg/export/attributes/attr_defs.go
 type Span struct {
 	Type           EventType      `json:"type"`
+	Flags          uint8          `json:"-"`
 	Method         string         `json:"-"`
 	Path           string         `json:"-"`
 	Route          string         `json:"-"`

--- a/pkg/app/request/span.go
+++ b/pkg/app/request/span.go
@@ -138,7 +138,7 @@ type Span struct {
 	TraceID        trace2.TraceID `json:"traceID"`
 	SpanID         trace2.SpanID  `json:"spanID"`
 	ParentSpanID   trace2.SpanID  `json:"parentSpanID"`
-	Flags          uint8          `json:"flags,string"`
+	TraceFlags     uint8          `json:"traceFlags,string"`
 	Pid            PidInfo        `json:"-"`
 	PeerName       string         `json:"peerName"`
 	HostName       string         `json:"hostName"`

--- a/pkg/app/request/span_test.go
+++ b/pkg/app/request/span_test.go
@@ -184,7 +184,7 @@ func TestSerializeJSONSpans(t *testing.T) {
 			TraceID:        trace2.TraceID{0x1, 0x2, 0x3},
 			SpanID:         trace2.SpanID{0x1, 0x2, 0x3},
 			ParentSpanID:   trace2.SpanID{0x1, 0x2, 0x3},
-			Flags:          1,
+			TraceFlags:     1,
 			PeerName:       "peername",
 			HostName:       "hostname",
 			OtherNamespace: "otherns",

--- a/pkg/app/request/span_test.go
+++ b/pkg/app/request/span_test.go
@@ -218,7 +218,7 @@ func TestSerializeJSONSpans(t *testing.T) {
 			"traceID":             "01020300000000000000000000000000",
 			"spanID":              "0102030000000000",
 			"parentSpanID":        "0102030000000000",
-			"flags":               "1",
+			"traceFlags":          "1",
 			"attributes":          tData.attribs,
 		}, s)
 	}

--- a/pkg/components/ebpf/common/fast_cgi_detect_transform.go
+++ b/pkg/components/ebpf/common/fast_cgi_detect_transform.go
@@ -212,7 +212,7 @@ func TCPToFastCGIToSpan(trace *TCPRequestInfo, op, uri string, status int) reque
 		TraceID:       trace.Tp.TraceId,
 		SpanID:        trace.Tp.SpanId,
 		ParentSpanID:  trace.Tp.ParentId,
-		Flags:         trace.Tp.Flags,
+		TraceFlags:    trace.Tp.Flags,
 		Pid: request.PidInfo{
 			HostPID:   trace.Pid.HostPid,
 			UserPID:   trace.Pid.UserPid,

--- a/pkg/components/ebpf/common/http2grpc_transform.go
+++ b/pkg/components/ebpf/common/http2grpc_transform.go
@@ -257,7 +257,7 @@ func http2InfoToSpan(info *BPFHTTP2Info, method, path, peer, host string, status
 		TraceID:       trace.TraceID(info.Tp.TraceId),
 		SpanID:        trace.SpanID(info.Tp.SpanId),
 		ParentSpanID:  trace.SpanID(info.Tp.ParentId),
-		Flags:         info.Tp.Flags,
+		TraceFlags:    info.Tp.Flags,
 		Pid: request.PidInfo{
 			HostPID:   info.Pid.HostPid,
 			UserPID:   info.Pid.UserPid,

--- a/pkg/components/ebpf/common/httpfltr_transform.go
+++ b/pkg/components/ebpf/common/httpfltr_transform.go
@@ -34,7 +34,7 @@ func httpInfoToSpan(info *HTTPInfo) request.Span {
 		TraceID:        info.Tp.TraceId,
 		SpanID:         info.Tp.SpanId,
 		ParentSpanID:   info.Tp.ParentId,
-		Flags:          info.Tp.Flags,
+		TraceFlags:     info.Tp.Flags,
 		Pid: request.PidInfo{
 			HostPID:   info.Pid.HostPid,
 			UserPID:   info.Pid.UserPid,

--- a/pkg/components/ebpf/common/kafka_detect_transform.go
+++ b/pkg/components/ebpf/common/kafka_detect_transform.go
@@ -376,7 +376,7 @@ func TCPToKafkaToSpan(trace *TCPRequestInfo, data *KafkaInfo) request.Span {
 		TraceID:       trace2.TraceID(trace.Tp.TraceId),
 		SpanID:        trace2.SpanID(trace.Tp.SpanId),
 		ParentSpanID:  trace2.SpanID(trace.Tp.ParentId),
-		Flags:         trace.Tp.Flags,
+		TraceFlags:    trace.Tp.Flags,
 		Pid: request.PidInfo{
 			HostPID:   trace.Pid.HostPid,
 			UserPID:   trace.Pid.UserPid,

--- a/pkg/components/ebpf/common/pids.go
+++ b/pkg/components/ebpf/common/pids.go
@@ -106,7 +106,7 @@ func (pf *PIDsFilter) CurrentPIDs(t PIDType) map[uint32]map[uint32]svc.Attrs {
 func (pf *PIDsFilter) normalizeTraceContext(span *request.Span) {
 	if !span.TraceID.IsValid() {
 		span.TraceID = otel.RandomTraceID()
-		span.Flags = 1
+		span.TraceFlags = 1
 	}
 	if !span.SpanID.IsValid() {
 		span.SpanID = otel.RandomSpanID()

--- a/pkg/components/ebpf/common/pids_test.go
+++ b/pkg/components/ebpf/common/pids_test.go
@@ -197,7 +197,7 @@ func resetTraceContext(spans []request.Span) []request.Span {
 	for i := range spans {
 		spans[i].TraceID = trace.TraceID{0}
 		spans[i].SpanID = trace.SpanID{0}
-		spans[i].Flags = 0
+		spans[i].TraceFlags = 0
 	}
 
 	return spans

--- a/pkg/components/ebpf/common/redis_detect_transform.go
+++ b/pkg/components/ebpf/common/redis_detect_transform.go
@@ -197,7 +197,7 @@ func TCPToRedisToSpan(trace *TCPRequestInfo, op, text string, status int) reques
 		TraceID:       trace2.TraceID(trace.Tp.TraceId),
 		SpanID:        trace2.SpanID(trace.Tp.SpanId),
 		ParentSpanID:  trace2.SpanID(trace.Tp.ParentId),
-		Flags:         trace.Tp.Flags,
+		TraceFlags:    trace.Tp.Flags,
 		Pid: request.PidInfo{
 			HostPID:   trace.Pid.HostPid,
 			UserPID:   trace.Pid.UserPid,
@@ -243,7 +243,7 @@ func ReadGoRedisRequestIntoSpan(record *ringbuf.Record) (request.Span, bool, err
 		TraceID:       trace2.TraceID(event.Tp.TraceId),
 		SpanID:        trace2.SpanID(event.Tp.SpanId),
 		ParentSpanID:  trace2.SpanID(event.Tp.ParentId),
-		Flags:         event.Tp.Flags,
+		TraceFlags:    event.Tp.Flags,
 		Pid: request.PidInfo{
 			HostPID:   event.Pid.HostPid,
 			UserPID:   event.Pid.UserPid,

--- a/pkg/components/ebpf/common/spanner.go
+++ b/pkg/components/ebpf/common/spanner.go
@@ -50,7 +50,7 @@ func HTTPRequestTraceToSpan(trace *HTTPRequestTrace) request.Span {
 		TraceID:        trace2.TraceID(trace.Tp.TraceId),
 		SpanID:         trace2.SpanID(trace.Tp.SpanId),
 		ParentSpanID:   trace2.SpanID(trace.Tp.ParentId),
-		Flags:          trace.Tp.Flags,
+		TraceFlags:     trace.Tp.Flags,
 		Pid: request.PidInfo{
 			HostPID:   trace.Pid.HostPid,
 			UserPID:   trace.Pid.UserPid,
@@ -98,7 +98,7 @@ func SQLRequestTraceToSpan(trace *SQLRequestTrace) request.Span {
 		TraceID:       trace2.TraceID(trace.Tp.TraceId),
 		SpanID:        trace2.SpanID(trace.Tp.SpanId),
 		ParentSpanID:  trace2.SpanID(trace.Tp.ParentId),
-		Flags:         trace.Tp.Flags,
+		TraceFlags:    trace.Tp.Flags,
 		Pid: request.PidInfo{
 			HostPID:   trace.Pid.HostPid,
 			UserPID:   trace.Pid.UserPid,

--- a/pkg/components/ebpf/common/sql_detect_transform.go
+++ b/pkg/components/ebpf/common/sql_detect_transform.go
@@ -119,7 +119,7 @@ func TCPToSQLToSpan(trace *TCPRequestInfo, op, table, sql string, kind request.S
 		TraceID:       trace2.TraceID(trace.Tp.TraceId),
 		SpanID:        trace2.SpanID(trace.Tp.SpanId),
 		ParentSpanID:  trace2.SpanID(trace.Tp.ParentId),
-		Flags:         trace.Tp.Flags,
+		TraceFlags:    trace.Tp.Flags,
 		Pid: request.PidInfo{
 			HostPID:   trace.Pid.HostPid,
 			UserPID:   trace.Pid.UserPid,

--- a/pkg/export/debug/debug.go
+++ b/pkg/export/debug/debug.go
@@ -140,7 +140,7 @@ func traceparent(span *request.Span) string {
 	if !span.TraceID.IsValid() {
 		return ""
 	}
-	return fmt.Sprintf("00-%s-%s[%s]-%02x", span.TraceID.String(), span.SpanID.String(), span.ParentSpanID.String(), span.Flags)
+	return fmt.Sprintf("00-%s-%s[%s]-%02x", span.TraceID.String(), span.SpanID.String(), span.ParentSpanID.String(), span.TraceFlags)
 }
 
 func counterPrinter(in *msg.Queue[[]request.Span]) swarm.RunFunc {

--- a/pkg/export/debug/debug_test.go
+++ b/pkg/export/debug/debug_test.go
@@ -59,7 +59,7 @@ func traceFuncHelper(t *testing.T, tracePrinter TracePrinter) string {
 		TraceID:        trace2.TraceID{0x1, 0x2, 0x3},
 		SpanID:         trace2.SpanID{0x1, 0x2, 0x3},
 		ParentSpanID:   trace2.SpanID{0x1, 0x2, 0x4},
-		Flags:          1,
+		TraceFlags:     1,
 		PeerName:       "peername",
 		HostName:       "hostname",
 		OtherNamespace: "otherns",
@@ -115,7 +115,7 @@ func TestTracePrinterResolve_PrinterJSON(t *testing.T) {
 
 	prefix := `[{"type":"HTTP","peer":"peer","peerPort":"1234",` +
 		`"host":"host","hostPort":"5678","traceID":"01020300000000000000000000000000",` +
-		`"spanID":"0102030000000000","parentSpanID":"0102040000000000","flags":"1",` +
+		`"spanID":"0102030000000000","parentSpanID":"0102040000000000","traceFlags":"1",` +
 		`"peerName":"peername","hostName":"hostname","kind":"SPAN_KIND_SERVER","`
 
 	suffix := `duration":"25µs","durationUSec":"25","handlerDuration":"20µs",` +
@@ -141,7 +141,7 @@ func TestTracePrinterResolve_PrinterJSONIndent(t *testing.T) {
   "traceID": "01020300000000000000000000000000",
   "spanID": "0102030000000000",
   "parentSpanID": "0102040000000000",
-  "flags": "1",
+  "traceFlags": "1",
   "peerName": "peername",
   "hostName": "hostname",
   "kind": "SPAN_KIND_SERVER",`

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -963,7 +963,7 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 	t := span.Timings()
 	duration := t.End.Sub(t.RequestStart).Seconds()
 
-	ctx := trace.ContextWithSpanContext(r.ctx, trace.SpanContext{}.WithTraceID(span.TraceID).WithSpanID(span.SpanID).WithTraceFlags(trace.TraceFlags(span.Flags)))
+	ctx := trace.ContextWithSpanContext(r.ctx, trace.SpanContext{}.WithTraceID(span.TraceID).WithSpanID(span.SpanID).WithTraceFlags(trace.TraceFlags(span.TraceFlags)))
 
 	if otelSpanAccepted(span, mr) {
 		switch span.Type {


### PR DESCRIPTION
Beyla, which now vendors OBI, has a legacy feature to mark spans as ignored by traces and metrics. We will remove it from the next major release but for now we need an additional space to set the ignore flags on the span. This PR renames the existing Flags field on the request.Span to TraceFlags (because it was related to the w3c trace context) and introduces a new Flags field which allows Span to be tagged.