### PR TITLE
Provide means for attribute groups to be extended

### DIFF
--- a/pkg/components/netolly/agent/pipeline.go
+++ b/pkg/components/netolly/agent/pipeline.go
@@ -84,7 +84,7 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 	})
 
 	filteredFlows := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(f.cfg.ChannelBufferLen))
-	swi.Add(filter.ByAttribute(f.cfg.Filters.Network, selectorCfg.ExtraGroupAttributesCfg, ebpf.RecordStringGetters, decoratedFlows, filteredFlows))
+	swi.Add(filter.ByAttribute(f.cfg.Filters.Network, attributes.GetDefinitions, selectorCfg.ExtraGroupAttributesCfg, ebpf.RecordStringGetters, decoratedFlows, filteredFlows))
 
 	// Terminal nodes export the flow record information out of the pipeline: OTEL, Prom and printer.
 	// Not all the nodes are mandatory here. Is the responsibility of each Provider function to decide

--- a/pkg/components/netolly/agent/pipeline.go
+++ b/pkg/components/netolly/agent/pipeline.go
@@ -84,7 +84,7 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 	})
 
 	filteredFlows := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(f.cfg.ChannelBufferLen))
-	swi.Add(filter.ByAttribute(f.cfg.Filters.Network, attributes.GetDefinitions, selectorCfg.ExtraGroupAttributesCfg, ebpf.RecordStringGetters, decoratedFlows, filteredFlows))
+	swi.Add(filter.ByAttribute(f.cfg.Filters.Network, nil, selectorCfg.ExtraGroupAttributesCfg, ebpf.RecordStringGetters, decoratedFlows, filteredFlows))
 
 	// Terminal nodes export the flow record information out of the pipeline: OTEL, Prom and printer.
 	// Not all the nodes are mandatory here. Is the responsibility of each Provider function to decide

--- a/pkg/components/pipe/instrumenter.go
+++ b/pkg/components/pipe/instrumenter.go
@@ -87,7 +87,7 @@ func newGraphBuilder(config *beyla.Config, ctxInfo *global.ContextInfo, tracesCh
 	if exportableSpans == nil {
 		exportableSpans = newQueue()
 	}
-	swi.Add(filter.ByAttribute(config.Filters.Application, selectorCfg.ExtraGroupAttributesCfg, spanPtrPromGetters,
+	swi.Add(filter.ByAttribute(config.Filters.Application, attributes.GetDefinitions, selectorCfg.ExtraGroupAttributesCfg, spanPtrPromGetters,
 		nameResolverToAttrFilter, exportableSpans))
 
 	swi.Add(otel.ReportMetrics(

--- a/pkg/components/pipe/instrumenter.go
+++ b/pkg/components/pipe/instrumenter.go
@@ -87,7 +87,7 @@ func newGraphBuilder(config *beyla.Config, ctxInfo *global.ContextInfo, tracesCh
 	if exportableSpans == nil {
 		exportableSpans = newQueue()
 	}
-	swi.Add(filter.ByAttribute(config.Filters.Application, attributes.GetDefinitions, selectorCfg.ExtraGroupAttributesCfg, spanPtrPromGetters,
+	swi.Add(filter.ByAttribute(config.Filters.Application, nil, selectorCfg.ExtraGroupAttributesCfg, spanPtrPromGetters,
 		nameResolverToAttrFilter, exportableSpans))
 
 	swi.Add(otel.ReportMetrics(

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -41,7 +41,7 @@ func (e *AttrGroups) Add(groups AttrGroups) {
 
 // Any new metric and attribute must be added here to be matched from the user-provided wildcard
 // selectors of the attributes.select section
-func getDefinitions(
+func GetDefinitions(
 	groups AttrGroups,
 	extraGroupAttributes GroupAttributes,
 ) map[Section]AttrReportGroup {
@@ -345,11 +345,13 @@ func copyDisabled(src AttrReportGroup) AttrReportGroup {
 
 // AllAttributeNames returns a set with all the names in the attributes database
 // as returned by the getDefinitions function
-func AllAttributeNames(extraGroupAttributesCfg map[string][]attr.Name) map[attr.Name]struct{} {
+func AllAttributeNames(
+	definitionsProvider func(groups AttrGroups, extraGroupAttributes GroupAttributes) map[Section]AttrReportGroup,
+	extraGroupAttributesCfg map[string][]attr.Name) map[attr.Name]struct{} {
 	extraGroupAttributes := NewGroupAttributes(extraGroupAttributesCfg)
 	names := map[attr.Name]struct{}{}
 	// -1 to enable all the metric group flags
-	for _, section := range getDefinitions(-1, extraGroupAttributes) {
+	for _, section := range definitionsProvider(-1, extraGroupAttributes) {
 		maps.Copy(names, section.All())
 	}
 	return names

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -41,7 +41,7 @@ func (e *AttrGroups) Add(groups AttrGroups) {
 
 // Any new metric and attribute must be added here to be matched from the user-provided wildcard
 // selectors of the attributes.select section
-func GetDefinitions(
+func getDefinitions(
 	groups AttrGroups,
 	extraGroupAttributes GroupAttributes,
 ) map[Section]AttrReportGroup {
@@ -346,13 +346,19 @@ func copyDisabled(src AttrReportGroup) AttrReportGroup {
 // AllAttributeNames returns a set with all the names in the attributes database
 // as returned by the getDefinitions function
 func AllAttributeNames(
-	definitionsProvider func(groups AttrGroups, extraGroupAttributes GroupAttributes) map[Section]AttrReportGroup,
-	extraGroupAttributesCfg map[string][]attr.Name) map[attr.Name]struct{} {
+	extraDefinitionsProvider func(groups AttrGroups, extraGroupAttributes GroupAttributes) map[Section]AttrReportGroup,
+	extraGroupAttributesCfg map[string][]attr.Name,
+) map[attr.Name]struct{} {
 	extraGroupAttributes := NewGroupAttributes(extraGroupAttributesCfg)
 	names := map[attr.Name]struct{}{}
 	// -1 to enable all the metric group flags
-	for _, section := range definitionsProvider(-1, extraGroupAttributes) {
+	for _, section := range getDefinitions(-1, extraGroupAttributes) {
 		maps.Copy(names, section.All())
+	}
+	if extraDefinitionsProvider != nil {
+		for _, section := range extraDefinitionsProvider(-1, extraGroupAttributes) {
+			maps.Copy(names, section.All())
+		}
 	}
 	return names
 }

--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -97,20 +97,29 @@ func NewAttrSelector(
 	groups AttrGroups,
 	cfg *SelectorConfig,
 ) (*AttrSelector, error) {
-	return NewCustomAttrSelector(groups, cfg, GetDefinitions)
+	return NewCustomAttrSelector(groups, cfg, getDefinitions)
 }
 
 func NewCustomAttrSelector(
 	groups AttrGroups,
 	cfg *SelectorConfig,
-	definitionsProvider func(groups AttrGroups, extraGroupAttributes GroupAttributes) map[Section]AttrReportGroup,
+	extraDefinitionsProvider func(groups AttrGroups, extraGroupAttributes GroupAttributes) map[Section]AttrReportGroup,
 ) (*AttrSelector, error) {
 	cfg.SelectionCfg.Normalize()
 	extraGroupAttributes := NewGroupAttributes(cfg.ExtraGroupAttributesCfg)
+
+	definitions := getDefinitions(groups, extraGroupAttributes)
+
+	if extraDefinitionsProvider != nil {
+		for section, group := range extraDefinitionsProvider(groups, extraGroupAttributes) {
+			definitions[section] = group
+		}
+	}
+
 	// TODO: validate
 	return &AttrSelector{
 		selector:   cfg.SelectionCfg,
-		definition: definitionsProvider(groups, extraGroupAttributes),
+		definition: definitions,
 	}, nil
 }
 

--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -97,7 +97,7 @@ func NewAttrSelector(
 	groups AttrGroups,
 	cfg *SelectorConfig,
 ) (*AttrSelector, error) {
-	return NewCustomAttrSelector(groups, cfg, getDefinitions)
+	return NewCustomAttrSelector(groups, cfg, GetDefinitions)
 }
 
 func NewCustomAttrSelector(

--- a/pkg/filter/attribute.go
+++ b/pkg/filter/attribute.go
@@ -26,7 +26,7 @@ type AttributeFamilyConfig map[string]MatchDefinition
 // that do not match the provided AttributeFamilyConfig.
 func ByAttribute[T any](
 	config AttributeFamilyConfig,
-	definitionsProvider func(groups attributes.AttrGroups, extraGroupAttributes attributes.GroupAttributes) map[attributes.Section]attributes.AttrReportGroup,
+	extraDefinitionsProvider func(groups attributes.AttrGroups, extraGroupAttributes attributes.GroupAttributes) map[attributes.Section]attributes.AttrReportGroup,
 	extraGroupAttributeCfg map[string][]attr.Name,
 	getters attributes.NamedGetters[T, string],
 	input, output *msg.Queue[[]T],
@@ -36,7 +36,7 @@ func ByAttribute[T any](
 			// No filter configuration provided. The node will be ignored
 			return swarm.Bypass(input, output)
 		}
-		f, err := newFilter(config, definitionsProvider, extraGroupAttributeCfg, getters, input, output)
+		f, err := newFilter(config, extraDefinitionsProvider, extraGroupAttributeCfg, getters, input, output)
 		if err != nil {
 			return nil, err
 		}
@@ -52,7 +52,7 @@ type filter[T any] struct {
 
 func newFilter[T any](
 	config AttributeFamilyConfig,
-	definitionsProvider func(groups attributes.AttrGroups, extraGroupAttributes attributes.GroupAttributes) map[attributes.Section]attributes.AttrReportGroup,
+	extraDefinitionsProvider func(groups attributes.AttrGroups, extraGroupAttributes attributes.GroupAttributes) map[attributes.Section]attributes.AttrReportGroup,
 	extraGroupAttributesCfg map[string][]attr.Name,
 	getters attributes.NamedGetters[T, string],
 	input, output *msg.Queue[[]T],
@@ -64,7 +64,7 @@ func newFilter[T any](
 	// Then, to validate the user-provided input, we map the prom-like attributes to
 	// our internal representation.
 	attrProm2Normal := map[string]attr.Name{}
-	for normalizedName := range attributes.AllAttributeNames(definitionsProvider, extraGroupAttributesCfg) {
+	for normalizedName := range attributes.AllAttributeNames(extraDefinitionsProvider, extraGroupAttributesCfg) {
 		attrProm2Normal[normalizedName.Prom()] = normalizedName
 	}
 	// Validate and build Matcher implementations for the user-provided attributes.

--- a/pkg/filter/attribute.go
+++ b/pkg/filter/attribute.go
@@ -26,6 +26,7 @@ type AttributeFamilyConfig map[string]MatchDefinition
 // that do not match the provided AttributeFamilyConfig.
 func ByAttribute[T any](
 	config AttributeFamilyConfig,
+	definitionsProvider func(groups attributes.AttrGroups, extraGroupAttributes attributes.GroupAttributes) map[attributes.Section]attributes.AttrReportGroup,
 	extraGroupAttributeCfg map[string][]attr.Name,
 	getters attributes.NamedGetters[T, string],
 	input, output *msg.Queue[[]T],
@@ -35,7 +36,7 @@ func ByAttribute[T any](
 			// No filter configuration provided. The node will be ignored
 			return swarm.Bypass(input, output)
 		}
-		f, err := newFilter(config, extraGroupAttributeCfg, getters, input, output)
+		f, err := newFilter(config, definitionsProvider, extraGroupAttributeCfg, getters, input, output)
 		if err != nil {
 			return nil, err
 		}
@@ -51,6 +52,7 @@ type filter[T any] struct {
 
 func newFilter[T any](
 	config AttributeFamilyConfig,
+	definitionsProvider func(groups attributes.AttrGroups, extraGroupAttributes attributes.GroupAttributes) map[attributes.Section]attributes.AttrReportGroup,
 	extraGroupAttributesCfg map[string][]attr.Name,
 	getters attributes.NamedGetters[T, string],
 	input, output *msg.Queue[[]T],
@@ -62,7 +64,7 @@ func newFilter[T any](
 	// Then, to validate the user-provided input, we map the prom-like attributes to
 	// our internal representation.
 	attrProm2Normal := map[string]attr.Name{}
-	for normalizedName := range attributes.AllAttributeNames(extraGroupAttributesCfg) {
+	for normalizedName := range attributes.AllAttributeNames(definitionsProvider, extraGroupAttributesCfg) {
 		attrProm2Normal[normalizedName.Prom()] = normalizedName
 	}
 	// Validate and build Matcher implementations for the user-provided attributes.

--- a/pkg/filter/attribute_test.go
+++ b/pkg/filter/attribute_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/app/request"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/netolly/ebpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/testutil"
-	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/export/attributes"
 	attr "github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/export/attributes/names"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/pipe/msg"
 )
@@ -26,7 +25,7 @@ func TestAttributeFilter(t *testing.T) {
 		"beyla.ip":          MatchDefinition{Match: "148.*"},
 		"k8s.src.namespace": MatchDefinition{NotMatch: "debug"},
 		"k8s.app.version":   MatchDefinition{Match: "*"},
-	}, attributes.GetDefinitions, map[string][]attr.Name{
+	}, nil, map[string][]attr.Name{
 		"k8s_app_meta": {"k8s.app.version"},
 	}, ebpf.RecordStringGetters, input, output)(t.Context())
 	require.NoError(t, err)
@@ -192,7 +191,7 @@ func TestAttributeFilter_VerificationError(t *testing.T) {
 		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
 			input := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
 			output := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
-			_, err := ByAttribute[*ebpf.Record](tc, attributes.GetDefinitions, map[string][]attr.Name{}, ebpf.RecordStringGetters, input, output)(t.Context())
+			_, err := ByAttribute[*ebpf.Record](tc, nil, map[string][]attr.Name{}, ebpf.RecordStringGetters, input, output)(t.Context())
 			assert.Error(t, err)
 		})
 	}
@@ -205,7 +204,7 @@ func TestAttributeFilter_SpanMetrics(t *testing.T) {
 	filterFunc, err := ByAttribute[*request.Span](AttributeFamilyConfig{
 		"client": MatchDefinition{NotMatch: "filtered"},
 		"server": MatchDefinition{NotMatch: "filtered"},
-	}, attributes.GetDefinitions, map[string][]attr.Name{}, request.SpanPromGetters, input, output)(t.Context())
+	}, nil, map[string][]attr.Name{}, request.SpanPromGetters, input, output)(t.Context())
 	require.NoError(t, err)
 
 	out := output.Subscribe()

--- a/pkg/filter/attribute_test.go
+++ b/pkg/filter/attribute_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/app/request"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/netolly/ebpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/testutil"
+	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/export/attributes"
 	attr "github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/export/attributes/names"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/pipe/msg"
 )
@@ -25,7 +26,7 @@ func TestAttributeFilter(t *testing.T) {
 		"beyla.ip":          MatchDefinition{Match: "148.*"},
 		"k8s.src.namespace": MatchDefinition{NotMatch: "debug"},
 		"k8s.app.version":   MatchDefinition{Match: "*"},
-	}, map[string][]attr.Name{
+	}, attributes.GetDefinitions, map[string][]attr.Name{
 		"k8s_app_meta": {"k8s.app.version"},
 	}, ebpf.RecordStringGetters, input, output)(t.Context())
 	require.NoError(t, err)
@@ -191,7 +192,7 @@ func TestAttributeFilter_VerificationError(t *testing.T) {
 		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
 			input := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
 			output := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
-			_, err := ByAttribute[*ebpf.Record](tc, map[string][]attr.Name{}, ebpf.RecordStringGetters, input, output)(t.Context())
+			_, err := ByAttribute[*ebpf.Record](tc, attributes.GetDefinitions, map[string][]attr.Name{}, ebpf.RecordStringGetters, input, output)(t.Context())
 			assert.Error(t, err)
 		})
 	}
@@ -204,7 +205,7 @@ func TestAttributeFilter_SpanMetrics(t *testing.T) {
 	filterFunc, err := ByAttribute[*request.Span](AttributeFamilyConfig{
 		"client": MatchDefinition{NotMatch: "filtered"},
 		"server": MatchDefinition{NotMatch: "filtered"},
-	}, map[string][]attr.Name{}, request.SpanPromGetters, input, output)(t.Context())
+	}, attributes.GetDefinitions, map[string][]attr.Name{}, request.SpanPromGetters, input, output)(t.Context())
 	require.NoError(t, err)
 
 	out := output.Subscribe()


### PR DESCRIPTION
This PR makes part of the attributes code extensible so that components embedding OBI can supply their own attribute group extensions.