### PR TITLE
Fix beyla_genfiles.go

### DIFF
--- a/cmd/beyla-genfiles/beyla_genfiles.go
+++ b/cmd/beyla-genfiles/beyla_genfiles.go
@@ -1,5 +1,3 @@
-//go:generate go run beyla_genfiles.go
-
 package main
 
 import (


### PR DESCRIPTION
When we try to run `make generate`inside a dockerfile, we get this error:

```
2.827 error waiting for child process: failed to start program: exec: "docker": executable file not found in $PATH
```

This seems to be caused by `beyla_genfiles.go` go:Generate header.

>that was just so if people did not want to call go run beyla_genfiles , but instead decided to do go generate ./...  - then it would in turn go run beyla_genfiles to make the generation process more "go-esque"
>I think it can be removed at this stage