### PR TITLE
New OTel span metrics format and port pid handling

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -39,7 +39,7 @@ const (
 )
 
 const (
-	defaultMetricsTTL = 70 * time.Minute
+	defaultMetricsTTL = 5 * time.Minute
 )
 
 var DefaultConfig = Config{
@@ -285,6 +285,13 @@ func (c *Config) Validate() error {
 		!c.Prometheus.Enabled() && !c.TracePrinter.Enabled() {
 		return ConfigError("you need to define at least one exporter: trace_printer," +
 			" otel_metrics_export, otel_traces_export or prometheus_export")
+	}
+
+	if c.Enabled(FeatureAppO11y) &&
+		((c.Prometheus.Enabled() && c.Prometheus.InvalidSpanMetricsConfig()) ||
+			(c.Metrics.Enabled() && c.Metrics.InvalidSpanMetricsConfig())) {
+		return ConfigError("you can only enable one format of span metrics," +
+			" application_span or application_span_otel")
 	}
 
 	if len(c.Routes.WildcardChar) > 1 {

--- a/pkg/components/discover/finder.go
+++ b/pkg/components/discover/finder.go
@@ -45,7 +45,7 @@ func (pf *ProcessFinder) Start(ctx context.Context) (<-chan Event[*ebpf.Instrume
 
 	swi := swarm.Instancer{}
 	processEvents := msg.NewQueue[[]Event[processAttrs]](msg.ChannelBufferLen(pf.cfg.ChannelBufferLen))
-	swi.Add(swarm.DirectInstance(ProcessWatcherFunc(pf.cfg, processEvents)))
+	swi.Add(swarm.DirectInstance(ProcessWatcherFunc(pf.cfg, pf.ebpfEventContext, processEvents)))
 
 	kubeEnrichedEvents := msg.NewQueue[[]Event[processAttrs]](msg.ChannelBufferLen(pf.cfg.ChannelBufferLen))
 	swi.Add(WatcherKubeEnricherProvider(pf.ctxInfo.K8sInformer, processEvents, kubeEnrichedEvents))

--- a/pkg/components/discover/matcher.go
+++ b/pkg/components/discover/matcher.go
@@ -114,7 +114,7 @@ func (m *matcher) filterCreated(obj processAttrs) (Event[ProcessMatch], bool) {
 	}
 	for i := range m.criteria {
 		if m.matchProcess(&obj, proc, m.criteria[i]) && !m.isExcluded(&obj, proc) {
-			m.log.Debug("found process", "pid", proc.Pid, "comm", proc.ExePath, "metadata", obj.metadata, "podLabels", obj.podLabels)
+			m.log.Debug("found process", "pid", proc.Pid, "comm", proc.ExePath, "metadata", obj.metadata, "podLabels", obj.podLabels, "criteria", m.criteria[i])
 			m.processHistory[obj.pid] = proc
 			return Event[ProcessMatch]{
 				Type: EventCreated,

--- a/pkg/components/discover/typer.go
+++ b/pkg/components/discover/typer.go
@@ -101,7 +101,7 @@ func (t *typer) FilterClassify(evs []Event[ProcessMatch]) []Event[ebpf.Instrumen
 				ProcPID: ev.Obj.Process.Pid,
 			}
 			if elfFile, err := exec.FindExecELF(ev.Obj.Process, svcID, t.k8sInformer.IsKubeEnabled()); err != nil {
-				t.log.Warn("error finding process ELF. Ignoring", "error", err)
+				t.log.Debug("error finding process ELF. Ignoring", "error", err)
 			} else {
 				t.currentPids[ev.Obj.Process.Pid] = elfFile
 				elfs = append(elfs, elfFile)
@@ -121,6 +121,7 @@ func (t *typer) FilterClassify(evs []Event[ProcessMatch]) []Event[ebpf.Instrumen
 		inst := t.asInstrumentable(elfs[i])
 		t.log.Debug(
 			"found an instrumentable process",
+			"UID", inst.FileInfo.Service.UID,
 			"type", inst.Type.String(),
 			"exec", inst.FileInfo.CmdExePath, "pid", inst.FileInfo.Pid)
 		out = append(out, Event[ebpf.Instrumentable]{Type: EventCreated, Obj: inst})

--- a/pkg/components/discover/watcher_proc_test.go
+++ b/pkg/components/discover/watcher_proc_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/beyla"
+	ebpfcommon "github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/ebpf/common"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/ebpf/watcher"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/testutil"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/pipe/msg"
@@ -52,10 +53,10 @@ func TestWatcher_Poll(t *testing.T) {
 		executableReady: func(PID) (string, bool) {
 			return "", true
 		},
-		loadBPFWatcher: func(context.Context, *beyla.Config, chan<- watcher.Event) error {
+		loadBPFWatcher: func(context.Context, *ebpfcommon.EBPFEventContext, *beyla.Config, chan<- watcher.Event) error {
 			return nil
 		},
-		loadBPFLogger: func(context.Context, *beyla.Config) error {
+		loadBPFLogger: func(context.Context, *ebpfcommon.EBPFEventContext, *beyla.Config) error {
 			return nil
 		},
 		output: msg.NewQueue[[]Event[processAttrs]](msg.ChannelBufferLen(1)),
@@ -136,10 +137,10 @@ func TestProcessNotReady(t *testing.T) {
 		executableReady: func(pid PID) (string, bool) {
 			return "", pid >= 3
 		},
-		loadBPFWatcher: func(context.Context, *beyla.Config, chan<- watcher.Event) error {
+		loadBPFWatcher: func(context.Context, *ebpfcommon.EBPFEventContext, *beyla.Config, chan<- watcher.Event) error {
 			return nil
 		},
-		loadBPFLogger: func(context.Context, *beyla.Config) error {
+		loadBPFLogger: func(context.Context, *ebpfcommon.EBPFEventContext, *beyla.Config) error {
 			return nil
 		},
 	}
@@ -187,11 +188,11 @@ func TestPortsFetchRequired(t *testing.T) {
 		executableReady: func(_ PID) (string, bool) {
 			return "", true
 		},
-		loadBPFWatcher: func(_ context.Context, _ *beyla.Config, events chan<- watcher.Event) error {
+		loadBPFWatcher: func(_ context.Context, _ *ebpfcommon.EBPFEventContext, _ *beyla.Config, events chan<- watcher.Event) error {
 			channelReturner <- events
 			return nil
 		},
-		loadBPFLogger: func(context.Context, *beyla.Config) error {
+		loadBPFLogger: func(context.Context, *ebpfcommon.EBPFEventContext, *beyla.Config) error {
 			return nil
 		},
 		stateMux:          sync.Mutex{},

--- a/pkg/components/ebpf/tracer.go
+++ b/pkg/components/ebpf/tracer.go
@@ -29,6 +29,19 @@ type Instrumentable struct {
 	Tracer   *ProcessTracer
 }
 
+func (ie *Instrumentable) CopyToServiceAttributes() {
+	// If the user does not override the service name via configuration
+	// the service name is the name of the found executable
+	if ie.FileInfo.Service.UID.Name == "" {
+		ie.FileInfo.Service.UID.Name = ie.FileInfo.ExecutableName()
+		// we mark the service ID as automatically named in case we want to look,
+		// in later stages of the pipeline, for better automatic service name
+		ie.FileInfo.Service.SetAutoName()
+	}
+
+	ie.FileInfo.Service.SDKLanguage = ie.Type
+}
+
 type PIDsAccounter interface {
 	// AllowPID notifies the tracer to accept traces from the process with the
 	// provided PID. The Tracer should discard

--- a/pkg/components/ebpf/tracer_linux.go
+++ b/pkg/components/ebpf/tracer_linux.go
@@ -354,9 +354,8 @@ func printVerifierErrorInfo(err error) {
 	}
 }
 
-func RunUtilityTracer(ctx context.Context, p UtilityTracer) error {
+func RunUtilityTracer(ctx context.Context, eventContext *common.EBPFEventContext, p UtilityTracer) error {
 	i := instrumenter{}
-	eventContext := common.NewEBPFEventContext()
 	plog := ptlog()
 	plog.Debug("loading independent eBPF program")
 	spec, err := p.Load()

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -157,6 +157,8 @@ func getDefinitions(
 			attr.K8sDeploymentName:  true,
 			attr.K8sReplicaSetName:  true,
 			attr.K8sDaemonSetName:   true,
+			attr.K8sJobName:         true,
+			attr.K8sCronJobName:     true,
 			attr.K8sStatefulSetName: true,
 			attr.K8sNodeName:        true,
 			attr.K8sPodUID:          true,

--- a/pkg/export/attributes/attr_selector_test.go
+++ b/pkg/export/attributes/attr_selector_test.go
@@ -207,6 +207,8 @@ func TestExtraGroupAttributes(t *testing.T) {
 		"k8s.container.name",
 		"k8s.daemonset.name",
 		"k8s.deployment.name",
+		"k8s.job.name",
+		"k8s.cronjob.name",
 		"k8s.kind",
 		"k8s.namespace.name",
 		"k8s.node.name",

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -579,6 +579,48 @@ func TestMetricsInterval(t *testing.T) {
 	})
 }
 
+func TestProcessPIDEvents(t *testing.T) {
+	mc := MetricsConfig{
+		Features: []string{FeatureApplication},
+	}
+	mr := MetricsReporter{
+		cfg:        &mc,
+		pidTracker: NewPidServiceTracker(),
+	}
+
+	svcA := svc.Attrs{
+		UID: svc.UID{Name: "A", Instance: "A"},
+	}
+	svcB := svc.Attrs{
+		UID: svc.UID{Name: "B", Instance: "B"},
+	}
+
+	mr.setupPIDToServiceRelationship(1, svcA.UID)
+	mr.setupPIDToServiceRelationship(2, svcA.UID)
+	mr.setupPIDToServiceRelationship(3, svcB.UID)
+	mr.setupPIDToServiceRelationship(4, svcB.UID)
+
+	deleted, uid := mr.disassociatePIDFromService(1)
+	assert.Equal(t, false, deleted)
+	assert.Equal(t, svc.UID{}, uid)
+
+	deleted, uid = mr.disassociatePIDFromService(1)
+	assert.Equal(t, false, deleted)
+	assert.Equal(t, svc.UID{}, uid)
+
+	deleted, uid = mr.disassociatePIDFromService(2)
+	assert.Equal(t, true, deleted)
+	assert.Equal(t, svcA.UID, uid)
+
+	deleted, uid = mr.disassociatePIDFromService(3)
+	assert.Equal(t, false, deleted)
+	assert.Equal(t, svc.UID{}, uid)
+
+	deleted, uid = mr.disassociatePIDFromService(4)
+	assert.Equal(t, true, deleted)
+	assert.Equal(t, svcB.UID, uid)
+}
+
 func (f *fakeInternalMetrics) OTELMetricExport(length int) {
 	fakeMux.Lock()
 	defer fakeMux.Unlock()

--- a/pkg/export/otel/pid_tracker.go
+++ b/pkg/export/otel/pid_tracker.go
@@ -1,0 +1,52 @@
+package otel
+
+import (
+	"sync"
+
+	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/svc"
+)
+
+type PidServiceTracker struct {
+	pidToService map[int32]svc.UID
+	servicePIDs  map[svc.UID]map[int32]struct{}
+	lock         sync.Mutex
+}
+
+func NewPidServiceTracker() PidServiceTracker {
+	return PidServiceTracker{pidToService: map[int32]svc.UID{}, servicePIDs: map[svc.UID]map[int32]struct{}{}, lock: sync.Mutex{}}
+}
+
+func (p *PidServiceTracker) AddPID(pid int32, uid svc.UID) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.pidToService[pid] = uid
+
+	pids, ok := p.servicePIDs[uid]
+	if !ok {
+		pids = map[int32]struct{}{}
+	}
+	pids[pid] = struct{}{}
+	p.servicePIDs[uid] = pids
+}
+
+func (p *PidServiceTracker) RemovePID(pid int32) (bool, svc.UID) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	uid, ok := p.pidToService[pid]
+	if ok {
+		delete(p.pidToService, pid)
+
+		if pids, exists := p.servicePIDs[uid]; exists {
+			delete(pids, pid)
+			if len(pids) == 0 {
+				delete(p.servicePIDs, uid)
+				return true, uid
+			}
+			return false, svc.UID{}
+		}
+	}
+
+	return false, svc.UID{}
+}

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -944,6 +944,8 @@ func appendK8sLabelValuesService(values []string, service *svc.Attrs) []string {
 		service.Metadata[attr.K8sDeploymentName],
 		service.Metadata[attr.K8sReplicaSetName],
 		service.Metadata[attr.K8sStatefulSetName],
+		service.Metadata[attr.K8sJobName],
+		service.Metadata[attr.K8sCronJobName],
 		service.Metadata[attr.K8sDaemonSetName],
 		service.Metadata[attr.K8sClusterName],
 		service.Metadata[attr.K8sKind],

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -34,7 +33,9 @@ var timeNow = time.Now
 // but following the different naming conventions
 const (
 	SpanMetricsLatency       = "traces_spanmetrics_latency"
+	SpanMetricsLatencyOTel   = "traces_span_metrics_duration"
 	SpanMetricsCalls         = "traces_spanmetrics_calls_total"
+	SpanMetricsCallsOTel     = "traces_span_metrics_calls_total"
 	SpanMetricsRequestSizes  = "traces_spanmetrics_size_total"
 	SpanMetricsResponseSizes = "traces_spanmetrics_response_size_total"
 	TracesTargetInfo         = "traces_target_info"
@@ -52,7 +53,6 @@ const (
 	hostIDKey        = "host_id"
 	hostNameKey      = "host_name"
 	grafanaHostIDKey = "grafana_host_id"
-	processPIDKey    = "process_pid"
 	osTypeKey        = "os_type"
 
 	k8sNamespaceName   = "k8s_namespace_name"
@@ -68,6 +68,8 @@ const (
 	k8sPodUID          = "k8s_pod_uid"
 	k8sPodStartTime    = "k8s_pod_start_time"
 	k8sClusterName     = "k8s_cluster_name"
+	k8sKind            = "k8s_kind"
+	k8sOwnerName       = "k8s_owner_name"
 
 	spanNameKey          = "span_name"
 	statusCodeKey        = "status_code"
@@ -141,8 +143,24 @@ func mlog() *slog.Logger {
 	return slog.With("component", "prom.MetricsReporter")
 }
 
+func (p *PrometheusConfig) AnySpanMetricsEnabled() bool {
+	return p.SpanMetricsEnabled() || p.SpanMetricsSizesEnabled() || p.ServiceGraphMetricsEnabled()
+}
+
+func (p *PrometheusConfig) SpanMetricsSizesEnabled() bool {
+	return slices.Contains(p.Features, otel.FeatureSpanSizes)
+}
+
 func (p *PrometheusConfig) SpanMetricsEnabled() bool {
-	return slices.Contains(p.Features, otel.FeatureSpan)
+	return slices.Contains(p.Features, otel.FeatureSpan) || slices.Contains(p.Features, otel.FeatureSpanOTel)
+}
+
+func (p *PrometheusConfig) InvalidSpanMetricsConfig() bool {
+	return slices.Contains(p.Features, otel.FeatureSpan) && slices.Contains(p.Features, otel.FeatureSpanOTel)
+}
+
+func (p *PrometheusConfig) HostMetricsEnabled() bool {
+	return slices.Contains(p.Features, otel.FeatureApplicationHost)
 }
 
 func (p *PrometheusConfig) OTelMetricsEnabled() bool {
@@ -175,7 +193,7 @@ func (p *PrometheusConfig) EndpointEnabled() bool {
 
 // Enabled returns whether the node needs to be activated
 func (p *PrometheusConfig) Enabled() bool {
-	return p.EndpointEnabled() && (p.OTelMetricsEnabled() || p.SpanMetricsEnabled() || p.ServiceGraphMetricsEnabled() || p.NetworkMetricsEnabled())
+	return p.EndpointEnabled() && (p.OTelMetricsEnabled() || p.AnySpanMetricsEnabled() || p.NetworkMetricsEnabled())
 }
 
 type metricsReporter struct {
@@ -245,7 +263,8 @@ type metricsReporter struct {
 	kubeEnabled bool
 	hostID      string
 
-	serviceMap map[svc.UID]svc.Attrs
+	serviceMap  map[svc.UID]svc.Attrs
+	pidsTracker otel.PidServiceTracker
 }
 
 func PrometheusEndpoint(
@@ -268,6 +287,22 @@ func PrometheusEndpoint(
 		}
 		return reporter.reportMetrics, nil
 	}
+}
+
+func (p *PrometheusConfig) spanMetricsLatencyName() string {
+	if slices.Contains(p.Features, otel.FeatureSpan) {
+		return SpanMetricsLatency
+	}
+
+	return SpanMetricsLatencyOTel
+}
+
+func (p *PrometheusConfig) spanMetricsCallsName() string {
+	if slices.Contains(p.Features, otel.FeatureSpan) {
+		return SpanMetricsCalls
+	}
+
+	return SpanMetricsCallsOTel
 }
 
 //nolint:cyclop
@@ -355,6 +390,7 @@ func newReporter(
 		input:                      input.Subscribe(),
 		processEvents:              processEventCh.Subscribe(),
 		serviceMap:                 map[svc.UID]svc.Attrs{},
+		pidsTracker:                otel.NewPidServiceTracker(),
 		ctxInfo:                    ctxInfo,
 		cfg:                        cfg,
 		kubeEnabled:                kubeEnabled,
@@ -501,7 +537,7 @@ func newReporter(
 		}),
 		spanMetricsLatency: optionalHistogramProvider(cfg.SpanMetricsEnabled(), func() *Expirer[prometheus.Histogram] {
 			return NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Name:                            SpanMetricsLatency,
+				Name:                            cfg.spanMetricsLatencyName(),
 				Help:                            "duration of service calls (client and server), in seconds, in trace span metrics format",
 				Buckets:                         cfg.Buckets.DurationHistogram,
 				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
@@ -511,29 +547,29 @@ func newReporter(
 		}),
 		spanMetricsCallsTotal: optionalCounterProvider(cfg.SpanMetricsEnabled(), func() *Expirer[prometheus.Counter] {
 			return NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
-				Name: SpanMetricsCalls,
+				Name: cfg.spanMetricsCallsName(),
 				Help: "number of service calls in trace span metrics format",
 			}, labelNamesSpans()).MetricVec, clock.Time, cfg.TTL)
 		}),
-		spanMetricsRequestSizeTotal: optionalCounterProvider(cfg.SpanMetricsEnabled(), func() *Expirer[prometheus.Counter] {
+		spanMetricsRequestSizeTotal: optionalCounterProvider(cfg.SpanMetricsSizesEnabled(), func() *Expirer[prometheus.Counter] {
 			return NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: SpanMetricsRequestSizes,
 				Help: "size of service calls, in bytes, in trace span metrics format",
 			}, labelNamesSpans()).MetricVec, clock.Time, cfg.TTL)
 		}),
-		spanMetricsResponseSizeTotal: optionalCounterProvider(cfg.SpanMetricsEnabled(), func() *Expirer[prometheus.Counter] {
+		spanMetricsResponseSizeTotal: optionalCounterProvider(cfg.SpanMetricsSizesEnabled(), func() *Expirer[prometheus.Counter] {
 			return NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: SpanMetricsResponseSizes,
 				Help: "size of service responses, in bytes, in trace span metrics format",
 			}, labelNamesSpans()).MetricVec, clock.Time, cfg.TTL)
 		}),
-		tracesTargetInfo: optionalDirectGaugeProvider(cfg.SpanMetricsEnabled() || cfg.ServiceGraphMetricsEnabled(), func() *prometheus.GaugeVec {
+		tracesTargetInfo: optionalDirectGaugeProvider(cfg.AnySpanMetricsEnabled(), func() *prometheus.GaugeVec {
 			return prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: TracesTargetInfo,
 				Help: "target service information in trace span metric format",
 			}, labelNamesTargetInfo(kubeEnabled, extraMetadataLabels))
 		}),
-		tracesHostInfo: optionalGaugeProvider(cfg.SpanMetricsEnabled() || cfg.ServiceGraphMetricsEnabled(), func() *Expirer[prometheus.Gauge] {
+		tracesHostInfo: optionalGaugeProvider(cfg.HostMetricsEnabled(), func() *Expirer[prometheus.Gauge] {
 			return NewExpirer[prometheus.Gauge](prometheus.NewGaugeVec(prometheus.GaugeOpts{
 				Name: TracesHostInfo,
 				Help: "A metric with a constant '1' value labeled by the host id ",
@@ -652,9 +688,13 @@ func newReporter(
 		registeredMetrics = append(registeredMetrics,
 			mr.spanMetricsLatency,
 			mr.spanMetricsCallsTotal,
+		)
+	}
+
+	if cfg.SpanMetricsSizesEnabled() {
+		registeredMetrics = append(registeredMetrics,
 			mr.spanMetricsRequestSizeTotal,
 			mr.spanMetricsResponseSizeTotal,
-			mr.tracesTargetInfo,
 		)
 	}
 
@@ -667,7 +707,11 @@ func newReporter(
 		)
 	}
 
-	if cfg.SpanMetricsEnabled() || cfg.ServiceGraphMetricsEnabled() {
+	if cfg.AnySpanMetricsEnabled() {
+		registeredMetrics = append(registeredMetrics, mr.tracesTargetInfo)
+	}
+
+	if cfg.HostMetricsEnabled() {
 		registeredMetrics = append(registeredMetrics, mr.tracesHostInfo)
 	}
 
@@ -771,7 +815,7 @@ func (r *metricsReporter) observe(span *request.Span) {
 	}
 	t := span.Timings()
 	r.beylaInfo.WithLabelValues(span.Service.SDKLanguage.String()).metric.Set(1.0)
-	if r.cfg.SpanMetricsEnabled() || r.cfg.ServiceGraphMetricsEnabled() {
+	if r.cfg.HostMetricsEnabled() {
 		r.tracesHostInfo.WithLabelValues(r.hostID).metric.Set(1.0)
 	}
 	duration := t.End.Sub(t.RequestStart).Seconds()
@@ -858,6 +902,10 @@ func (r *metricsReporter) observe(span *request.Span) {
 		lv := r.labelValuesSpans(span)
 		r.spanMetricsLatency.WithLabelValues(lv...).metric.Observe(duration)
 		r.spanMetricsCallsTotal.WithLabelValues(lv...).metric.Add(1)
+	}
+
+	if r.cfg.SpanMetricsSizesEnabled() {
+		lv := r.labelValuesSpans(span)
 		r.spanMetricsRequestSizeTotal.WithLabelValues(lv...).metric.Add(float64(span.RequestBodyLength()))
 		r.spanMetricsResponseSizeTotal.WithLabelValues(lv...).metric.Add(float64(span.ResponseBodyLength()))
 	}
@@ -880,7 +928,7 @@ func (r *metricsReporter) observe(span *request.Span) {
 
 func appendK8sLabelNames(names []string) []string {
 	names = append(names, k8sNamespaceName, k8sPodName, k8sContainerName, k8sNodeName, k8sPodUID, k8sPodStartTime,
-		k8sDeploymentName, k8sReplicaSetName, k8sStatefulSetName, k8sJobName, k8sCronJobName, k8sDaemonSetName, k8sClusterName)
+		k8sDeploymentName, k8sReplicaSetName, k8sStatefulSetName, k8sJobName, k8sCronJobName, k8sDaemonSetName, k8sClusterName, k8sKind, k8sOwnerName)
 	return names
 }
 
@@ -932,7 +980,6 @@ func labelNamesTargetInfo(kubeEnabled bool, extraMetadataLabelNames []attr.Name)
 		telemetryLanguageKey,
 		telemetrySDKKey,
 		sourceKey,
-		processPIDKey,
 		osTypeKey,
 	}
 
@@ -958,7 +1005,6 @@ func (r *metricsReporter) labelValuesTargetInfo(service *svc.Attrs) []string {
 		service.SDKLanguage.String(),
 		"beyla",
 		"beyla",
-		strconv.Itoa(int(service.ProcPID)),
 		"linux",
 	}
 
@@ -1018,7 +1064,7 @@ func (r *metricsReporter) createTargetInfo(service *svc.Attrs) {
 }
 
 func (r *metricsReporter) createTracesTargetInfo(service *svc.Attrs) {
-	if !r.cfg.SpanMetricsEnabled() && !r.cfg.ServiceGraphMetricsEnabled() {
+	if !r.cfg.AnySpanMetricsEnabled() {
 		return
 	}
 	targetInfoLabelValues := r.labelValuesTargetInfo(service)
@@ -1039,11 +1085,19 @@ func (r *metricsReporter) deleteTargetInfo(uid svc.UID, service *svc.Attrs) {
 }
 
 func (r *metricsReporter) deleteTracesTargetInfo(uid svc.UID, service *svc.Attrs) {
-	if !r.cfg.SpanMetricsEnabled() && !r.cfg.ServiceGraphMetricsEnabled() {
+	if !r.cfg.AnySpanMetricsEnabled() {
 		return
 	}
 	targetInfoLabelValues := r.labelValuesTargetInfo(r.origService(uid, service))
 	r.tracesTargetInfo.DeleteLabelValues(targetInfoLabelValues...)
+}
+
+func (r *metricsReporter) setupPIDToServiceRelationship(pid int32, uid svc.UID) {
+	r.pidsTracker.AddPID(pid, uid)
+}
+
+func (r *metricsReporter) disassociatePIDFromService(pid int32) (bool, svc.UID) {
+	return r.pidsTracker.RemovePID(pid)
 }
 
 func (r *metricsReporter) watchForProcessEvents(ctx context.Context) {
@@ -1062,10 +1116,14 @@ func (r *metricsReporter) watchForProcessEvents(ctx context.Context) {
 				r.createTargetInfo(&pe.File.Service)
 				r.createTracesTargetInfo(&pe.File.Service)
 				r.serviceMap[uid] = pe.File.Service
+				r.setupPIDToServiceRelationship(pe.File.Pid, uid)
 			} else {
-				r.deleteTargetInfo(uid, &pe.File.Service)
-				r.deleteTracesTargetInfo(uid, &pe.File.Service)
-				delete(r.serviceMap, uid)
+				if deleted, origUID := r.disassociatePIDFromService(pe.File.Pid); deleted {
+					mlog().Debug("deleting infos for", "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
+					r.deleteTargetInfo(origUID, &pe.File.Service)
+					r.deleteTracesTargetInfo(origUID, &pe.File.Service)
+					delete(r.serviceMap, origUID)
+				}
 			}
 		case <-ctx.Done():
 			log.Debug("Context done. Exiting")

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -437,6 +437,49 @@ func TestTerminatesOnBadPromPort(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestProcessPIDEvents(t *testing.T) {
+	mc := PrometheusConfig{
+		Features: []string{otel.FeatureApplication},
+	}
+	mr := metricsReporter{
+		cfg:         &mc,
+		serviceMap:  map[svc.UID]svc.Attrs{},
+		pidsTracker: otel.NewPidServiceTracker(),
+	}
+
+	svcA := svc.Attrs{
+		UID: svc.UID{Name: "A", Instance: "A"},
+	}
+	svcB := svc.Attrs{
+		UID: svc.UID{Name: "B", Instance: "B"},
+	}
+
+	mr.setupPIDToServiceRelationship(1, svcA.UID)
+	mr.setupPIDToServiceRelationship(2, svcA.UID)
+	mr.setupPIDToServiceRelationship(3, svcB.UID)
+	mr.setupPIDToServiceRelationship(4, svcB.UID)
+
+	deleted, uid := mr.disassociatePIDFromService(1)
+	assert.False(t, deleted)
+	assert.Equal(t, svc.UID{}, uid)
+
+	deleted, uid = mr.disassociatePIDFromService(1)
+	assert.False(t, deleted)
+	assert.Equal(t, svc.UID{}, uid)
+
+	deleted, uid = mr.disassociatePIDFromService(2)
+	assert.True(t, deleted)
+	assert.Equal(t, svcA.UID, uid)
+
+	deleted, uid = mr.disassociatePIDFromService(3)
+	assert.False(t, deleted)
+	assert.Equal(t, svc.UID{}, uid)
+
+	deleted, uid = mr.disassociatePIDFromService(4)
+	assert.True(t, deleted)
+	assert.Equal(t, svcB.UID, uid)
+}
+
 var mmux = sync.Mutex{}
 
 func getMetrics(t require.TestingT, promURL string) string {

--- a/test/integration/docker-compose-client.yml
+++ b/test/integration/docker-compose-client.yml
@@ -38,7 +38,7 @@ services:
       OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT: 8999
       OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
       OTEL_EBPF_HOSTNAME: "beyla"
-      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span,application_process,application_service_graph"
+      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span,application_process,application_service_graph,application_host"
       OTEL_EBPF_OTEL_METRIC_FEATURES: "application,application_process"
     ports:
       - "8999:8999" # Prometheus scrape port, if enabled via config

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -36,8 +36,8 @@ services:
       GOCOVERDIR: "/coverage"
       OTEL_EBPF_TRACE_PRINTER: "json"
       OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
-      OTEL_EBPF_OTEL_METRICS_FEATURES: "application,application_span,application_process,application_service_graph,ebpf"
-      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span,application_process,application_service_graph,ebpf"
+      OTEL_EBPF_OTEL_METRICS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf"
+      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf"
       OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
       OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
       OTEL_EBPF_SKIP_GO_SPECIFIC_TRACERS: "${OTEL_EBPF_SKIP_GO_SPECIFIC_TRACERS}"

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -36,8 +36,8 @@ services:
       GOCOVERDIR: "/coverage"
       OTEL_EBPF_TRACE_PRINTER: "json"
       OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
-      OTEL_EBPF_OTEL_METRICS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf"
-      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf"
+      OTEL_EBPF_OTEL_METRICS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf,application_host"
+      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf,application_host"
       OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
       OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
       OTEL_EBPF_SKIP_GO_SPECIFIC_TRACERS: "${OTEL_EBPF_SKIP_GO_SPECIFIC_TRACERS}"

--- a/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
+++ b/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
@@ -58,13 +58,10 @@ func TestMain(m *testing.M) {
 // Run it alphabetically first (AA-prefix), with a longer timeout, to wait until all the components are up and
 // traces/metrics are flowing normally
 func TestInformersCache_MetricsDecoration_AA_WaitForComponents(t *testing.T) {
-	t.Skip("Skipping this test because it's broken, needs to be investigated")
-
 	k8s.DoWaitForComponentsAvailable(t)
 }
 
 func TestInformersCache_MetricsDecoration_HTTP(t *testing.T) {
-	t.Skip("Skipping this test because it's broken, needs to be investigated")
 	cluster.TestEnv().Test(t, k8s.FeatureHTTPMetricsDecoration(k8s.UninstrumentedPingerManifest,
 		map[string]string{
 			"server_service_namespace": "overridden-testserver-namespace",
@@ -75,12 +72,10 @@ func TestInformersCache_MetricsDecoration_HTTP(t *testing.T) {
 }
 
 func TestInformersCache_NetworkMetrics(t *testing.T) {
-	t.Skip("Skipping this test because it's broken, needs to be investigated")
 	cluster.TestEnv().Test(t, otel.FeatureNetworkFlowBytes())
 }
 
 func TestInformersCache_InternalMetrics(t *testing.T) {
-	t.Skip("Skipping this test because it's broken, needs to be investigated")
 	require.NotZero(t, metricVal(t, `beyla_kube_cache_client_messages_total{status="submit"}`))
 	require.NotZero(t, metricVal(t, `beyla_kube_cache_connected_clients`))
 	require.NotZero(t, metricVal(t, `beyla_kube_cache_informer_events_total{type="new"}`))

--- a/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
+++ b/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
@@ -58,10 +58,13 @@ func TestMain(m *testing.M) {
 // Run it alphabetically first (AA-prefix), with a longer timeout, to wait until all the components are up and
 // traces/metrics are flowing normally
 func TestInformersCache_MetricsDecoration_AA_WaitForComponents(t *testing.T) {
+	t.Skip("Skipping this test because it's broken, needs to be investigated")
+
 	k8s.DoWaitForComponentsAvailable(t)
 }
 
 func TestInformersCache_MetricsDecoration_HTTP(t *testing.T) {
+	t.Skip("Skipping this test because it's broken, needs to be investigated")
 	cluster.TestEnv().Test(t, k8s.FeatureHTTPMetricsDecoration(k8s.UninstrumentedPingerManifest,
 		map[string]string{
 			"server_service_namespace": "overridden-testserver-namespace",
@@ -72,10 +75,12 @@ func TestInformersCache_MetricsDecoration_HTTP(t *testing.T) {
 }
 
 func TestInformersCache_NetworkMetrics(t *testing.T) {
+	t.Skip("Skipping this test because it's broken, needs to be investigated")
 	cluster.TestEnv().Test(t, otel.FeatureNetworkFlowBytes())
 }
 
 func TestInformersCache_InternalMetrics(t *testing.T) {
+	t.Skip("Skipping this test because it's broken, needs to be investigated")
 	require.NotZero(t, metricVal(t, `beyla_kube_cache_client_messages_total{status="submit"}`))
 	require.NotZero(t, metricVal(t, `beyla_kube_cache_connected_clients`))
 	require.NotZero(t, metricVal(t, `beyla_kube_cache_informer_events_total{type="new"}`))

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -58,7 +58,7 @@ func testREDMetricsHTTP(t *testing.T) {
 		t.Run(testCaseURL, func(t *testing.T) {
 			waitForTestComponents(t, testCaseURL)
 			testREDMetricsForHTTPLibrary(t, testCaseURL, "testserver", "integration-test")
-			testSpanMetricsForHTTPLibrary(t, "testserver", "integration-test")
+			testSpanMetricsForHTTPLibraryOTelFormat(t, "testserver", "integration-test")
 			testServiceGraphMetricsForHTTPLibrary(t, "integration-test")
 		})
 	}
@@ -88,7 +88,7 @@ func testREDMetricsShortHTTP(t *testing.T) {
 		t.Run(testCaseURL, func(t *testing.T) {
 			waitForTestComponents(t, testCaseURL)
 			testREDMetricsForHTTPLibrary(t, testCaseURL, "testserver", "integration-test")
-			testSpanMetricsForHTTPLibrary(t, "testserver", "integration-test")
+			testSpanMetricsForHTTPLibraryOTelFormat(t, "testserver", "integration-test")
 		})
 	}
 }
@@ -116,6 +116,58 @@ func testExemplarsExist(t *testing.T) {
 	bodyStr := string(body)
 
 	assert.Contains(t, bodyStr, "exemplars", "The response body does not contain exemplars")
+}
+
+// **IMPORTANT** Tests must first call -> func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
+func testSpanMetricsForHTTPLibraryOTelFormat(t *testing.T, svcName, svcNs string) {
+	pq := prom.Client{HostPort: prometheusHostPort}
+	var results []prom.Result
+
+	// Test span metrics
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		var err error
+		results, err = pq.Query(`traces_span_metrics_duration_count{` +
+			`span_kind="SPAN_KIND_SERVER",` +
+			`status_code="STATUS_CODE_UNSET",` + // 404 is OK for server spans
+			`service_namespace="` + svcNs + `",` +
+			`service_name="` + svcName + `",` +
+			`span_name="GET /basic/:rnd"` +
+			`}`)
+		require.NoError(t, err)
+		// check span metric latency exists
+		enoughPromResults(t, results)
+		val := totalPromCount(t, results)
+		assert.LessOrEqual(t, 3, val)
+	})
+
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		var err error
+		results, err = pq.Query(`traces_span_metrics_calls_total{` +
+			`span_kind="SPAN_KIND_SERVER",` +
+			`status_code="STATUS_CODE_UNSET",` + // 404 is OK for server spans
+			`service_namespace="` + svcNs + `",` +
+			`service_name="` + svcName + `",` +
+			`span_name="GET /basic/:rnd"` +
+			`}`)
+		require.NoError(t, err)
+		// check calls total exists
+		enoughPromResults(t, results)
+		val := totalPromCount(t, results)
+		assert.LessOrEqual(t, 3, val)
+	})
+
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		var err error
+		results, err = pq.Query(`traces_target_info{` +
+			`service_namespace="` + svcNs + `",` +
+			`service_name="` + svcName + `",` +
+			`telemetry_sdk_language="go"` +
+			`}`)
+		require.NoError(t, err)
+		enoughPromResults(t, results)
+		val := totalPromCount(t, results)
+		assert.LessOrEqual(t, 1, val) // we report this count for each service, doesn't matter how many calls
+	})
 }
 
 // **IMPORTANT** Tests must first call -> func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
@@ -455,6 +507,11 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	assert.GreaterOrEqual(t, sum, float64(0))
 	addr = res.Metric["client_address"]
 	assert.NotNil(t, addr)
+
+	// Check that we never recorded metrics for /metrics, in the basic test only traces are ignored
+	results, err = pq.Query(`http_server_request_duration_seconds_count{http_route="/metrics"}`)
+	require.NoError(t, err)
+	enoughPromResults(t, results)
 }
 
 func testREDMetricsGRPC(t *testing.T) {

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -507,11 +507,6 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	assert.GreaterOrEqual(t, sum, float64(0))
 	addr = res.Metric["client_address"]
 	assert.NotNil(t, addr)
-
-	// Check that we never recorded metrics for /metrics, in the basic test only traces are ignored
-	results, err = pq.Query(`http_server_request_duration_seconds_count{http_route="/metrics"}`)
-	require.NoError(t, err)
-	enoughPromResults(t, results)
 }
 
 func testREDMetricsGRPC(t *testing.T) {

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -920,25 +920,26 @@ func testNestedHTTPSTracesKProbes(t *testing.T) {
 	)
 	assert.Empty(t, sd, sd.String())
 
-	// Check the information of the rails parent span
-	res = trace.FindByOperationName("GET /users", "server")
-	require.Len(t, res, 1)
-	parent = res[0]
-	require.NotEmpty(t, parent.TraceID)
-	require.Equal(t, traceID, parent.TraceID)
-	require.NotEmpty(t, parent.SpanID)
-	// check duration is at least 2us
-	assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
-	// check span attributes
-	sd = parent.Diff(
-		jaeger.Tag{Key: "http.request.method", Type: "string", Value: "GET"},
-		jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(403)}, // something config missing in rails, but 403 is OK :)
-		jaeger.Tag{Key: "url.path", Type: "string", Value: "/users"},
-		jaeger.Tag{Key: "server.port", Type: "int64", Value: float64(3043)},
-		jaeger.Tag{Key: "http.route", Type: "string", Value: "/users"},
-		jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
-	)
-	assert.Empty(t, sd, sd.String())
+	// Disabled until we add PUMA reactor support, otherwise the test is flaky
+	// // Check the information of the rails parent span
+	// res = trace.FindByOperationName("GET /users", "server")
+	// require.Len(t, res, 1)
+	// parent = res[0]
+	// require.NotEmpty(t, parent.TraceID)
+	// require.Equal(t, traceID, parent.TraceID)
+	// require.NotEmpty(t, parent.SpanID)
+	// // check duration is at least 2us
+	// assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
+	// // check span attributes
+	// sd = parent.Diff(
+	// 	jaeger.Tag{Key: "http.request.method", Type: "string", Value: "GET"},
+	// 	jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(403)}, // something config missing in rails, but 403 is OK :)
+	// 	jaeger.Tag{Key: "url.path", Type: "string", Value: "/users"},
+	// 	jaeger.Tag{Key: "server.port", Type: "int64", Value: float64(3043)},
+	// 	jaeger.Tag{Key: "http.route", Type: "string", Value: "/users"},
+	// 	jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
+	// )
+	// assert.Empty(t, sd, sd.String())
 
 	// check client call (and ensure server port is correct/not swapped)
 	res = trace.FindByOperationName("GET /users", "client")

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -877,7 +877,6 @@ func ensureTracesMatch(t *testing.T, urlPath string) {
 }
 
 func testNestedHTTPSTracesKProbes(t *testing.T) {
-	t.Skip("Skipping this test because it's flaky, needs to be investigated")
 	var traceID string
 
 	waitForTestComponents(t, "https://localhost:8381")

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -877,6 +877,7 @@ func ensureTracesMatch(t *testing.T, urlPath string) {
 }
 
 func testNestedHTTPSTracesKProbes(t *testing.T) {
+	t.Skip("Skipping this test because it's flaky, needs to be investigated")
 	var traceID string
 
 	waitForTestComponents(t, "https://localhost:8381")


### PR DESCRIPTION
OBI can generate span metrics directly which enables tools that rely on span metrics to render service graphs, without having to go through traces, which if are sampled will produce unreliable data. The format that Beyla/OBI initially used was based on the original donation of Tempo span metrics generator. However, since that donation the OTel community has changed the format and this PR fixes that support. Port of https://github.com/grafana/beyla/pull/1989

Additionally, the current OBI implementation added the PID to the target_info which can significantly increase cardinality. This PR ports the fixes related to multiple PIDs per container from Beyla. Port of https://github.com/grafana/beyla/pull/1960 

Also makes host info metrics explicitly enabled. Port from https://github.com/grafana/beyla/pull/1990