### PR TITLE
Add route ignore logic back to routes

### DIFF
--- a/pkg/app/request/span_ignores.go
+++ b/pkg/app/request/span_ignores.go
@@ -1,0 +1,32 @@
+package request
+
+type ignoreMode uint8
+
+const (
+	ignoreMetrics ignoreMode = 0x1
+	ignoreTraces  ignoreMode = 0x2
+)
+
+func setIgnoreFlag(s *Span, flag ignoreMode) {
+	s.Flags |= uint8(flag)
+}
+
+func isIgnored(s *Span, flag ignoreMode) bool {
+	return (s.Flags & uint8(flag)) == uint8(flag)
+}
+
+func SetIgnoreMetrics(s *Span) {
+	setIgnoreFlag(s, ignoreMetrics)
+}
+
+func SetIgnoreTraces(s *Span) {
+	setIgnoreFlag(s, ignoreTraces)
+}
+
+func IgnoreMetrics(s *Span) bool {
+	return isIgnored(s, ignoreMetrics)
+}
+
+func IgnoreTraces(s *Span) bool {
+	return isIgnored(s, ignoreTraces)
+}

--- a/pkg/transform/routes.go
+++ b/pkg/transform/routes.go
@@ -47,7 +47,9 @@ type RoutesConfig struct {
 	// Unmatch specifies what to do when a route pattern is not matched
 	Unmatch UnmatchType `yaml:"unmatched"`
 	// Patterns of the paths that will match to a route
-	Patterns []string `yaml:"patterns"`
+	Patterns       []string   `yaml:"patterns"`
+	IgnorePatterns []string   `yaml:"ignored_patterns"`
+	IgnoredEvents  IgnoreMode `yaml:"ignore_mode"`
 	// Character that will be used to replace route segments
 	WildcardChar string `yaml:"wildcard_char,omitempty"`
 }
@@ -78,22 +80,45 @@ func (rn *routerNode) provideRoutes(_ context.Context) (swarm.RunFunc, error) {
 		return nil, err
 	}
 	matcher := route.NewMatcher(rc.Patterns)
+	discarder := route.NewMatcher(rc.IgnorePatterns)
 	routesEnabled := len(rc.Patterns) > 0
+	ignoreEnabled := len(rc.IgnorePatterns) > 0
+
+	ignoreMode := rc.IgnoredEvents
+	if ignoreMode == "" {
+		ignoreMode = IgnoreDefault
+	}
 
 	in := rn.input.Subscribe()
 	out := rn.output
-	return func(_ context.Context) {
+	return func(ctx context.Context) {
 		// output channel must be closed so later stages in the pipeline can finish in cascade
 		defer rn.output.Close()
-		for spans := range in {
-			for i := range spans {
-				s := &spans[i]
-				if routesEnabled {
-					s.Route = matcher.Find(s.Path)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case spans := <-in:
+				for i := range spans {
+					s := &spans[i]
+					if ignoreEnabled {
+						if discarder.Find(s.Path) != "" {
+							if ignoreMode == IgnoreAll {
+								request.SetIgnoreMetrics(s)
+								request.SetIgnoreTraces(s)
+							}
+							// we can't discard it here, ignoring is selective (metrics | traces)
+							setSpanIgnoreMode(ignoreMode, s)
+						}
+					}
+					if routesEnabled {
+						s.Route = matcher.Find(s.Path)
+					}
+					unmatchAction(rc, s)
 				}
-				unmatchAction(rc, s)
+				out.Send(spans)
 			}
-			out.Send(spans)
 		}
 	}, nil
 }
@@ -152,5 +177,13 @@ func setUnmatchToPath(_ *RoutesConfig, str *request.Span) {
 func classifyFromPath(rc *RoutesConfig, s *request.Span) {
 	if s.Route == "" && (s.Type == request.EventTypeHTTP || s.Type == request.EventTypeHTTPClient) {
 		s.Route = route.ClusterPath(s.Path, rc.WildcardChar[0])
+	}
+}
+func setSpanIgnoreMode(mode IgnoreMode, s *request.Span) {
+	switch mode {
+	case IgnoreMetrics:
+		request.SetIgnoreMetrics(s)
+	case IgnoreTraces:
+		request.SetIgnoreTraces(s)
 	}
 }

--- a/pkg/transform/routes_test.go
+++ b/pkg/transform/routes_test.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -118,6 +119,42 @@ func TestUnmatchedAuto(t *testing.T) {
 	}
 }
 
+func TestIgnoreRoutes(t *testing.T) {
+	input := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
+	output := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
+	router, err := RoutesProvider(&RoutesConfig{
+		Unmatch: UnmatchPath, Patterns: []string{"/user/:id", "/v1/metrics"},
+		IgnorePatterns: []string{"/v1/metrics/*", "/v1/traces/*", "/exact"}},
+		input, output)(context.Background())
+	require.NoError(t, err)
+	out := output.Subscribe()
+	defer input.Close()
+	go router(context.Background())
+	input.Send([]request.Span{{Path: "/user/1234"}})
+	input.Send([]request.Span{{Path: "/v1/metrics"}}) // this is in routes and ignore, ignore takes precedence
+	input.Send([]request.Span{{Path: "/v1/traces/1234/test"}})
+	input.Send([]request.Span{{Path: "/v1/metrics/1234/test"}}) // this is in routes and ignore, ignore takes precedence
+	input.Send([]request.Span{{Path: "/v1/traces"}})
+	input.Send([]request.Span{{Path: "/exact"}})
+	input.Send([]request.Span{{Path: "/some/path"}})
+	assert.Equal(t, []request.Span{{
+		Path:  "/user/1234",
+		Route: "/user/:id",
+	}}, filterIgnored(func() []request.Span { return testutil.ReadChannel(t, out, testTimeout) }))
+	assert.Equal(t, []request.Span{{
+		Path:  "/some/path",
+		Route: "/some/path",
+	}}, filterIgnored(func() []request.Span { return testutil.ReadChannel(t, out, testTimeout) }))
+}
+
+func TestIgnoreMode(t *testing.T) {
+	s := request.Span{Path: "/user/1234"}
+	setSpanIgnoreMode(IgnoreTraces, &s)
+	assert.True(t, request.IgnoreTraces(&s))
+	setSpanIgnoreMode(IgnoreMetrics, &s)
+	assert.True(t, request.IgnoreMetrics(&s))
+}
+
 func BenchmarkRoutesProvider_Wildcard(b *testing.B) {
 	benchProvider(b, UnmatchWildcard)
 }
@@ -149,5 +186,29 @@ func benchProvider(b *testing.B, unmatch UnmatchType) {
 	for i := 0; i < b.N; i++ {
 		inCh <- benchmarkInput
 		<-outCh
+	}
+}
+
+func filterIgnored(reader func() []request.Span) []request.Span {
+	for {
+		input := reader()
+		output := make([]request.Span, 0, len(input))
+		for i := range input {
+			s := &input[i]
+
+			if request.IgnoreMetrics(s) {
+				continue
+			}
+
+			if request.IgnoreTraces(s) {
+				continue
+			}
+
+			output = append(output, *s)
+		}
+
+		if len(output) > 0 {
+			return output
+		}
 	}
 }


### PR DESCRIPTION
This logic was somehow removed when donated Beyla.
This PR brings it back in order to proverly vendorise this in Beyla.