### PR TITLE
[Test fix] Give enough time for the nodejs injector

### DIFF
--- a/test/integration/nodejs_multiproc_test.go
+++ b/test/integration/nodejs_multiproc_test.go
@@ -18,12 +18,17 @@ import (
 )
 
 func testNestedTraces(t *testing.T) {
-	t.Skip("disabling as it's failing")
 	var traceID string
 
 	waitForTestComponents(t, "http://localhost:5000")
 	waitForTestComponents(t, "http://localhost:5002")
 	waitForTestComponents(t, "http://localhost:5003")
+
+	// give enough time for the NodeJS injector to finish
+	// TODO: once we implement the instrumentation status query API, replace
+	// this with  a proper check to see if the target process has finished
+	// being instrumented
+	time.Sleep(60 * time.Second)
 
 	// Add and check for specific trace ID
 	// Run couple of requests to make sure we flush out any transactions that might be


### PR DESCRIPTION
The test starts sending requests before the injector has had the chance to finish injecting - give it a little time.