### PR TITLE
Enable more clang-tidy diagnostics

### DIFF
--- a/bpf/.clang-tidy
+++ b/bpf/.clang-tidy
@@ -10,6 +10,8 @@ Checks:
   - '-bugprone-reserved-identifier'
   - '-bugprone-easily-swappable-parameters'
   - '-bugprone-narrowing-conversions' #TODO this needs to be checked/enabled
+  - 'clang-analyzer-*'
+  - '-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'
   - '-misc-unused-parameters'
   - '-misc-misplaced-const'
   - '-misc-include-cleaner'

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -844,10 +844,6 @@ int beyla_socket__http_filter(struct __sk_buff *skb) {
         //d_print_http_connection_info(&conn);
 
         if (packet_type == PACKET_TYPE_REQUEST) {
-            u32 full_len = skb->len - tcp.hdr_len;
-            if (full_len > FULL_BUF_SIZE) {
-                full_len = FULL_BUF_SIZE;
-            }
             u64 cookie = bpf_get_socket_cookie(skb);
             //bpf_printk("=== http_filter cookie = %llx, len=%d %s ===", cookie, len, buf);
             //dbg_print_http_connection_info(&conn);

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -711,7 +711,6 @@ int beyla_uprobe_http2ResponseWriterStateWriteHeader(struct pt_regs *ctx) {
             go_addr_key_t p_key = {};
             go_addr_key_from_id(&p_key, parent_go);
             invocation = bpf_map_lookup_elem(&ongoing_http_server_requests, &p_key);
-            goroutine_addr = parent_go;
         }
         if (!invocation) {
             bpf_dbg_printk("can't read http invocation metadata");


### PR DESCRIPTION
Enable a new class of clang-tidy diagnostics (clang-analyzer). One of the diagnostics (dead store) already pointed out a couple of places in which we were reading/writing variables that were not being used.

The `-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling` has been disabled as it implicates `__builtin_memcpy` and it's all over the place at this stage (and there's no ebpf alternative, in a regular scenario we'd replace that with `memcpy_s`).