### PR TITLE
Fix ignoreMetrics and ignoreTraces flags

### DIFF
--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -1215,6 +1215,10 @@ func (mr *MetricsReporter) reportMetrics(_ context.Context) {
 			if s.InternalSignal() {
 				continue
 			}
+			// If we are ignoring this span because of route patterns, don't do anything
+			if request.IgnoreMetrics(s) {
+				continue
+			}
 			reporter, err := mr.reporters.For(&s.Service)
 			if err != nil {
 				mlog().Error("unexpected error creating OTEL resource. Ignoring metric",

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -223,7 +223,7 @@ func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, e
 }
 
 func spanDiscarded(span *request.Span, is instrumentations.InstrumentationSelection) bool {
-	return span.Service.ExportsOTelTraces() || !acceptSpan(is, span)
+	return request.IgnoreTraces(span) || span.Service.ExportsOTelTraces() || !acceptSpan(is, span)
 }
 
 func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection) map[svc.UID][]TraceSpanAndAttributes {

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -805,7 +805,7 @@ func (r *metricsReporter) otelSpanObserved(span *request.Span) bool {
 }
 
 func (r *metricsReporter) otelSpanFiltered(span *request.Span) bool {
-	return span.InternalSignal()
+	return span.InternalSignal() || request.IgnoreMetrics(span)
 }
 
 //nolint:cyclop

--- a/test/integration/configs/instrumenter-config-grpc-export.yml
+++ b/test/integration/configs/instrumenter-config-grpc-export.yml
@@ -2,10 +2,9 @@ routes:
   patterns:
     - /basic/:rnd
   unmatched: path
-filter:
-  application:
-    url_path:
-      not_match: /metrics
+  ignored_patterns:
+    - /metrics
+  ignore_mode: traces
 otel_metrics_export:
   endpoint: http://otelcol:4317
   protocol: grpc

--- a/test/integration/configs/instrumenter-config-no-route.yml
+++ b/test/integration/configs/instrumenter-config-no-route.yml
@@ -1,9 +1,7 @@
 routes:
+  ignored_patterns:
+    - /metrics
   unmatched: heuristic
-filter:
-  application:
-    url_path:
-      not_match: /metrics
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:

--- a/test/integration/configs/instrumenter-config-other-grpc.yml
+++ b/test/integration/configs/instrumenter-config-other-grpc.yml
@@ -10,10 +10,9 @@ routes:
   patterns:
     - /factorial/:rnd
   unmatched: path
-filter:
-  application:
-    url_path:
-      not_match: /metrics
+  ignored_patterns:
+    - /metrics
+  ignore_mode: traces
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:

--- a/test/integration/configs/instrumenter-config.yml
+++ b/test/integration/configs/instrumenter-config.yml
@@ -2,10 +2,9 @@ routes:
   patterns:
     - /basic/:rnd
   unmatched: path
-filter:
-  application:
-    url_path:
-      not_match: /metrics
+  ignored_patterns:
+    - /metrics
+  ignore_mode: traces
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:

--- a/test/integration/k8s/manifests/06-beyla-daemonset-disable-informers.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset-disable-informers.yml
@@ -25,10 +25,9 @@ data:
       patterns:
         - /pingpong
       unmatched: path
-    filter:
-      application:
-        url_path:
-          not_match: /metrics
+    ignored_patterns:
+      - /metrics
+    ignore_mode: traces
     otel_metrics_export:
       endpoint: http://otelcol:4318
     otel_traces_export:

--- a/test/integration/k8s/manifests/06-beyla-daemonset.yml
+++ b/test/integration/k8s/manifests/06-beyla-daemonset.yml
@@ -27,10 +27,9 @@ data:
       patterns:
         - /pingpong
       unmatched: path
-      filter:
-        application:
-          url_path:
-            not_match: /metrics
+      ignored_patterns:
+        - /metrics
+      ignore_mode: traces
     otel_metrics_export:
       endpoint: http://otelcol:4318
     otel_traces_export:

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -507,6 +507,11 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	assert.GreaterOrEqual(t, sum, float64(0))
 	addr = res.Metric["client_address"]
 	assert.NotNil(t, addr)
+
+	// Check that we recorded metrics for /metrics, in the basic test only traces are ignored
+	results, err = pq.Query(`http_server_request_duration_seconds_count{http_route="/metrics"}`)
+	require.NoError(t, err)
+	enoughPromResults(t, results)
 }
 
 func testREDMetricsGRPC(t *testing.T) {


### PR DESCRIPTION
[This previous PR](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/183) didn't really restored te ignore_routes functionality, as the metrics/traces exporters didn't make use of the flag in order to discard metrics or traces.