### PR TITLE
Add process minimum age to filter out short lived processes if needed

### DIFF
--- a/pkg/components/discover/watcher_proc_test.go
+++ b/pkg/components/discover/watcher_proc_test.go
@@ -35,7 +35,7 @@ func TestWatcher_Poll(t *testing.T) {
 		interval: time.Microsecond,
 		cfg:      &beyla.Config{},
 		pidPorts: map[pidPort]ProcessAttrs{},
-		listProcesses: func(bool) (map[PID]ProcessAttrs, error) {
+		listProcesses: func(bool, time.Duration) (map[PID]ProcessAttrs, error) {
 			invocation++
 			switch invocation {
 			case 1:
@@ -131,7 +131,7 @@ func TestProcessNotReady(t *testing.T) {
 		interval: time.Microsecond,
 		cfg:      &beyla.Config{},
 		pidPorts: map[pidPort]ProcessAttrs{},
-		listProcesses: func(bool) (map[PID]ProcessAttrs, error) {
+		listProcesses: func(bool, time.Duration) (map[PID]ProcessAttrs, error) {
 			return map[PID]ProcessAttrs{p1.pid: p1, p5.pid: p5, p2.pid: p2, p3.pid: p3, p4.pid: p4}, nil
 		},
 		executableReady: func(pid PID) (string, bool) {
@@ -145,7 +145,7 @@ func TestProcessNotReady(t *testing.T) {
 		},
 	}
 
-	procs, err := acc.listProcesses(true)
+	procs, err := acc.listProcesses(true, 0)
 	require.NoError(t, err)
 	assert.Len(t, procs, 5)
 	events := acc.snapshot(procs)
@@ -182,7 +182,7 @@ func TestPortsFetchRequired(t *testing.T) {
 		cfg:      cfg,
 		interval: time.Hour, // don't let the inner loop mess with our test
 		pidPorts: map[pidPort]ProcessAttrs{},
-		listProcesses: func(bool) (map[PID]ProcessAttrs, error) {
+		listProcesses: func(bool, time.Duration) (map[PID]ProcessAttrs, error) {
 			return nil, nil
 		},
 		executableReady: func(_ PID) (string, bool) {

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -91,6 +91,10 @@ type DiscoveryConfig struct {
 
 	// Disables instrumentation of services which are already instrumented
 	ExcludeOTelInstrumentedServices bool `yaml:"exclude_otel_instrumented_services" env:"OTEL_EBPF_EXCLUDE_OTEL_INSTRUMENTED_SERVICES"`
+
+	// Min process age to be considered for discovery.
+	//nolint:undoc
+	MinProcessAge time.Duration `yaml:"min_process_age" env:"BEYLA_MIN_PROCESS_AGE"`
 }
 
 func (c *DiscoveryConfig) Validate() error {


### PR DESCRIPTION
Added minimum process age to be considered for discovery.

The new process detection logic will ignore a new process until its age reach a minimum value. As an example we may set a 3 seconds threshold as part of the monitoring configuration.
Any process will be considered as suitable for monitoring once is passing that configurable limit.
The noise of short lived processes can be filtered out.

Configuration example:
discovery:
exclude_services:
- k8s_namespace: (istio-system|kube-node-lease)
services:
- k8s_namespace: (acmefitness)
min_process_age: 5s

Moved the RP from https://github.com/grafana/beyla/pull/2066