### PR TITLE
Reorganise ebpf file structure - part II

### DIFF
--- a/bpf/generictracer/iovec_len.h
+++ b/bpf/generictracer/iovec_len.h
@@ -1,0 +1,3 @@
+#pragma once
+
+enum { k_iovec_max_len = 512 };

--- a/bpf/generictracer/k_send_receive.h
+++ b/bpf/generictracer/k_send_receive.h
@@ -5,26 +5,9 @@
 
 #include <generictracer/k_tracer_defs.h>
 
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __type(key, u64);
-    __type(value, recv_args_t);
-} active_recv_args SEC(".maps");
-
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __type(key, u64);           // pid_tid
-    __type(value, send_args_t); // size to be sent
-} active_send_args SEC(".maps");
-
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __type(key, u64);           // *sock
-    __type(value, send_args_t); // size to be sent
-} active_send_sock_args SEC(".maps");
+#include <generictracer/maps/active_recv_args.h>
+#include <generictracer/maps/active_send_args.h>
+#include <generictracer/maps/active_send_sock_args.h>
 
 static __always_inline void ensure_sent_event(u64 id, u64 *sock_p) {
     if (high_request_volume) {

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -9,10 +9,13 @@
 #include <common/ssl_helpers.h>
 #include <common/tcp_info.h>
 
-#include <generictracer/k_tracer_defs.h>
-#include <generictracer/ssl_defs.h>
 #include <generictracer/k_send_receive.h>
+#include <generictracer/k_tracer_defs.h>
 #include <generictracer/k_unix_sock.h>
+#include <generictracer/maps/active_accept_args.h>
+#include <generictracer/maps/active_connect_args.h>
+#include <generictracer/maps/tcp_connection_map.h>
+#include <generictracer/ssl_defs.h>
 
 #include <logger/bpf_dbg.h>
 
@@ -22,32 +25,6 @@
 #include <maps/sk_buffers.h>
 
 #include <pid/pid.h>
-
-// Temporary tracking of accept arguments
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __type(key, u64);
-    __type(value, sock_args_t);
-} active_accept_args SEC(".maps");
-
-// Temporary tracking of connect arguments
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __type(key, u64);
-    __type(value, sock_args_t);
-} active_connect_args SEC(".maps");
-
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __type(
-        key,
-        partial_connection_info_t); // key: the connection info without the destination address, but with the tcp sequence
-    __type(value, connection_info_t); // value: traceparent info
-    __uint(max_entries, 1024);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
-} tcp_connection_map SEC(".maps");
 
 // Used by accept to grab the sock details
 SEC("kretprobe/sock_alloc")

--- a/bpf/generictracer/maps/active_accept_args.h
+++ b/bpf/generictracer/maps/active_accept_args.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/sockaddr.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __type(key, u64);
+    __type(value, sock_args_t);
+} active_accept_args SEC(".maps");

--- a/bpf/generictracer/maps/active_connect_args.h
+++ b/bpf/generictracer/maps/active_connect_args.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/sockaddr.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __type(key, u64);
+    __type(value, sock_args_t);
+} active_connect_args SEC(".maps");

--- a/bpf/generictracer/maps/active_recv_args.h
+++ b/bpf/generictracer/maps/active_recv_args.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <generictracer/k_tracer_defs.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __type(key, u64);
+    __type(value, recv_args_t);
+} active_recv_args SEC(".maps");

--- a/bpf/generictracer/maps/active_send_args.h
+++ b/bpf/generictracer/maps/active_send_args.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <generictracer/k_tracer_defs.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __type(key, u64);           // pid_tid
+    __type(value, send_args_t); // size to be sent
+} active_send_args SEC(".maps");

--- a/bpf/generictracer/maps/active_send_sock_args.h
+++ b/bpf/generictracer/maps/active_send_sock_args.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <generictracer/k_tracer_defs.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __type(key, u64);           // *sock
+    __type(value, send_args_t); // size to be sent
+} active_send_sock_args SEC(".maps");

--- a/bpf/generictracer/maps/connection_meta_mem.h
+++ b/bpf/generictracer/maps/connection_meta_mem.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/http_types.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, int);
+    __type(value, http_connection_metadata_t);
+    __uint(max_entries, 1);
+} connection_meta_mem SEC(".maps");

--- a/bpf/generictracer/maps/grpc_frames_ctx_mem.h
+++ b/bpf/generictracer/maps/grpc_frames_ctx_mem.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <generictracer/types/grpc_frames_ctx.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, int);
+    __type(value, grpc_frames_ctx_t);
+    __uint(max_entries, 1);
+} grpc_frames_ctx_mem SEC(".maps");

--- a/bpf/generictracer/maps/http2_info_mem.h
+++ b/bpf/generictracer/maps/http2_info_mem.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/http_types.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, int);
+    __type(value, http2_grpc_request_t);
+    __uint(max_entries, 1);
+} http2_info_mem SEC(".maps");

--- a/bpf/generictracer/maps/http_info_mem.h
+++ b/bpf/generictracer/maps/http_info_mem.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/http_info.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, int);
+    __type(value, http_info_t);
+    __uint(max_entries, 1);
+} http_info_mem SEC(".maps");

--- a/bpf/generictracer/maps/iovec_mem.h
+++ b/bpf/generictracer/maps/iovec_mem.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <generictracer/iovec_len.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, int);
+    __type(value, unsigned char[(k_iovec_max_len * 2)]);
+    __uint(max_entries, 1);
+} iovec_mem SEC(".maps");

--- a/bpf/generictracer/maps/ongoing_http2_connections.h
+++ b/bpf/generictracer/maps/ongoing_http2_connections.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/connection_info.h>
+#include <common/map_sizing.h>
+
+#include <generictracer/types/http2_conn_info_data.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, pid_connection_info_t);
+    __type(value, http2_conn_info_data_t); // flags and id
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+} ongoing_http2_connections SEC(".maps");

--- a/bpf/generictracer/maps/ongoing_http2_grpc.h
+++ b/bpf/generictracer/maps/ongoing_http2_grpc.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/connection_info.h>
+#include <common/http_types.h>
+#include <common/map_sizing.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, http2_conn_stream_t);
+    __type(value, http2_grpc_request_t);
+    __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
+} ongoing_http2_grpc SEC(".maps");

--- a/bpf/generictracer/maps/ongoing_tcp_req.h
+++ b/bpf/generictracer/maps/ongoing_tcp_req.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/connection_info.h>
+#include <common/http_types.h>
+#include <common/map_sizing.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, pid_connection_info_t);
+    __type(value, tcp_req_t);
+    __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
+    __uint(pinning, BEYLA_PIN_INTERNAL);
+} ongoing_tcp_req SEC(".maps");

--- a/bpf/generictracer/maps/pid_tid_to_conn.h
+++ b/bpf/generictracer/maps/pid_tid_to_conn.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/connection_info.h>
+#include <common/map_sizing.h>
+
+// LRU map, we don't clean-it up at the moment, which holds onto the mapping
+// of the pid-tid and the current connection. It's setup by tcp_rcv_established
+// in case we miss SSL_do_handshake
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u64);                         // the pid-tid pair
+    __type(value, ssl_pid_connection_info_t); // the pointer to the file descriptor matching ssl
+    __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
+} pid_tid_to_conn SEC(".maps");

--- a/bpf/generictracer/maps/protocol_args_mem.h
+++ b/bpf/generictracer/maps/protocol_args_mem.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/http_types.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, int);
+    __type(value, call_protocol_args_t);
+    __uint(max_entries, 1);
+} protocol_args_mem SEC(".maps");

--- a/bpf/generictracer/maps/ssl_to_pid_tid.h
+++ b/bpf/generictracer/maps/ssl_to_pid_tid.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/map_sizing.h>
+
+// LRU map which holds onto the mapping of an ssl pointer to pid-tid,
+// we clean-it up when we lookup by ssl. It's setup by SSL_read for cases where frameworks
+// process SSL requests on separate thread pools, e.g. Ruby on Rails
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u64);   // the ssl pointer
+    __type(value, u64); // the pid tid of the thread in ssl read
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+} ssl_to_pid_tid SEC(".maps");

--- a/bpf/generictracer/maps/tcp_connection_map.h
+++ b/bpf/generictracer/maps/tcp_connection_map.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/connection_info.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(
+        key,
+        partial_connection_info_t); // key: the connection info without the destination address, but with the tcp sequence
+    __type(value, connection_info_t); // value: traceparent info
+    __uint(max_entries, 1024);
+} tcp_connection_map SEC(".maps");

--- a/bpf/generictracer/maps/tcp_req_mem.h
+++ b/bpf/generictracer/maps/tcp_req_mem.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/http_types.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, int);
+    __type(value, tcp_req_t);
+    __uint(max_entries, 1);
+} tcp_req_mem SEC(".maps");

--- a/bpf/generictracer/maps/upstream_init_args.h
+++ b/bpf/generictracer/maps/upstream_init_args.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/map_sizing.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u64);   // the pid_tid
+    __type(value, u64); // the req ptr
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+} upstream_init_args SEC(".maps");

--- a/bpf/generictracer/nginx.c
+++ b/bpf/generictracer/nginx.c
@@ -7,6 +7,8 @@
 #include <common/connection_info.h>
 #include <common/sockaddr.h>
 
+#include <generictracer/maps/upstream_init_args.h>
+
 #include <logger/bpf_dbg.h>
 
 #include <maps/nginx_upstream.h>
@@ -19,14 +21,6 @@ volatile const s32 ngx_http_upstream_s_conn = 0x10;
 volatile const s32 ngx_connection_s_fd = 0x18;
 volatile const s32 ngx_http_rev_s_conn = 0x8;
 volatile const s32 ngx_connection_s_sockaddr = 0x68;
-
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __type(key, u64);   // the pid_tid
-    __type(value, u64); // the req ptr
-    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
-} upstream_init_args SEC(".maps");
 
 SEC("uprobe/nginx:ngx_http_upstream_init")
 int beyla_ngx_http_upstream_init(struct pt_regs *ctx) {

--- a/bpf/generictracer/protocol_common.h
+++ b/bpf/generictracer/protocol_common.h
@@ -7,35 +7,18 @@
 #include <common/pin_internal.h>
 #include <common/ringbuf.h>
 
+#include <generictracer/iovec_len.h>
+
+#include <generictracer/maps/connection_meta_mem.h>
+#include <generictracer/maps/iovec_mem.h>
+#include <generictracer/maps/protocol_args_mem.h>
+
 #include <logger/bpf_dbg.h>
 
 #define PACKET_TYPE_REQUEST 1
 #define PACKET_TYPE_RESPONSE 2
 
-#define IO_VEC_MAX_LEN 512
-
 volatile const s32 capture_header_buffer = 0;
-
-struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __type(key, int);
-    __type(value, http_connection_metadata_t);
-    __uint(max_entries, 1);
-} connection_meta_mem SEC(".maps");
-
-struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __type(key, int);
-    __type(value, unsigned char[(IO_VEC_MAX_LEN * 2)]);
-    __uint(max_entries, 1);
-} iovec_mem SEC(".maps");
-
-struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __type(key, int);
-    __type(value, call_protocol_args_t);
-    __uint(max_entries, 1);
-} protocol_args_mem SEC(".maps");
 
 static __always_inline http_connection_metadata_t *empty_connection_meta() {
     int zero = 0;
@@ -132,7 +115,7 @@ static __always_inline int read_iovec_ctx(iovec_iter_ctx *ctx, unsigned char *bu
         return 0;
     }
 
-    bpf_clamp_umax(max_len, IO_VEC_MAX_LEN);
+    bpf_clamp_umax(max_len, k_iovec_max_len);
 
     bpf_dbg_printk("iter_type=%u", ctx->iter_type);
     bpf_dbg_printk("nr_segs=%lu, iov=%p, ubuf=%p", ctx->nr_segs, ctx->iov, ctx->ubuf);
@@ -144,7 +127,7 @@ static __always_inline int read_iovec_ctx(iovec_iter_ctx *ctx, unsigned char *bu
         // ITER_UBUF is never a bitmask, and can be 0, so we perform a proper
         // equality check rather than a bitwise and like we do for ITER_IOVEC
         if (ctx->ubuf != NULL && ctx->iter_type == iter_ubuf) {
-            bpf_clamp_umax(max_len, IO_VEC_MAX_LEN);
+            bpf_clamp_umax(max_len, k_iovec_max_len);
             return bpf_probe_read(buf, max_len, ctx->ubuf) == 0 ? max_len : 0;
         }
     }
@@ -176,11 +159,11 @@ static __always_inline int read_iovec_ctx(iovec_iter_ctx *ctx, unsigned char *bu
             continue;
         }
 
-        const u32 remaining = IO_VEC_MAX_LEN > tot_len ? (IO_VEC_MAX_LEN - tot_len) : 0;
+        const u32 remaining = k_iovec_max_len > tot_len ? (k_iovec_max_len - tot_len) : 0;
         u32 iov_size = vec.iov_len < max_len ? vec.iov_len : max_len;
         iov_size = iov_size < remaining ? iov_size : remaining;
-        bpf_clamp_umax(tot_len, IO_VEC_MAX_LEN);
-        bpf_clamp_umax(iov_size, IO_VEC_MAX_LEN);
+        bpf_clamp_umax(tot_len, k_iovec_max_len);
+        bpf_clamp_umax(iov_size, k_iovec_max_len);
 
         // bpf_dbg_printk("tot_len=%d, remaining=%d", tot_len, remaining);
 

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -9,21 +9,13 @@
 #include <common/runtime.h>
 #include <common/trace_common.h>
 
+#include <generictracer/maps/http_info_mem.h>
 #include <generictracer/protocol_common.h>
 
 #include <maps/active_ssl_connections.h>
 #include <maps/ongoing_http.h>
 
 volatile const u32 high_request_volume;
-
-// http_info_t became too big to be declared as a variable in the stack.
-// We use a percpu array to keep a reusable copy of it
-struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __type(key, int);
-    __type(value, http_info_t);
-    __uint(max_entries, 1);
-} http_info_mem SEC(".maps");
 
 // empty_http_info zeroes and return the unique percpu copy in the map
 // this function assumes that a given thread is not trying to use many

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -10,21 +10,8 @@
 
 #include <generictracer/protocol_common.h>
 
-// Keeps track of tcp buffers for unknown protocols
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __type(key, pid_connection_info_t);
-    __type(value, tcp_req_t);
-    __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
-} ongoing_tcp_req SEC(".maps");
-
-struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __type(key, int);
-    __type(value, tcp_req_t);
-    __uint(max_entries, 1);
-} tcp_req_mem SEC(".maps");
+#include <generictracer/maps/ongoing_tcp_req.h>
+#include <generictracer/maps/tcp_req_mem.h>
 
 static __always_inline tcp_req_t *empty_tcp_req() {
     int zero = 0;

--- a/bpf/generictracer/types/grpc_frames_ctx.h
+++ b/bpf/generictracer/types/grpc_frames_ctx.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+
+#include <common/connection_info.h>
+#include <common/http_types.h>
+
+#include <generictracer/types/http2_conn_info_data.h>
+
+typedef struct grpc_frames_ctx {
+    http2_grpc_request_t prev_info;
+    u8 has_prev_info;
+    u8 found_data_frame;
+    u8 iterations;
+    u8 terminate_search;
+
+    int pos; //FIXME should be size_t equivalent
+    int saved_buf_pos;
+    u32 saved_stream_id;
+    call_protocol_args_t args;
+    http2_conn_stream_t stream;
+
+    u8 _pad[4];
+} grpc_frames_ctx_t;

--- a/bpf/generictracer/types/http2_conn_info_data.h
+++ b/bpf/generictracer/types/http2_conn_info_data.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+
+typedef struct http2_conn_info_data {
+    u64 id;
+    u8 flags;
+    u8 _pad[7];
+} http2_conn_info_data_t;


### PR DESCRIPTION
This is a follow up of https://github.com/grafana/beyla/pull/1791 - see that PR's decription for context.

There's still plenty to do and other PRs will follow from time to time.

The present PR solely targets the maps in `generictracer`.