### PR TITLE
Ensure target info has the correct description

### DIFF
--- a/pkg/components/ebpf/common/ringbuf_test.go
+++ b/pkg/components/ebpf/common/ringbuf_test.go
@@ -143,6 +143,9 @@ func TestForwardRingbuf_Close(t *testing.T) {
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		assert.True(t, ringBuf.explicitClose.Load())
 	})
+	// Wait a bit for the defer to close resources
+	time.Sleep(time.Second)
+
 	assert.True(t, closable.closed.Load())
 
 	// AND metrics haven't been updated

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -506,7 +506,7 @@ func (mr *MetricsReporter) graphMetricOptions(mlog *slog.Logger) []metric.Option
 
 func (mr *MetricsReporter) setupTargetInfo(m *Metrics, meter instrument.Meter) error {
 	var err error
-	m.targetInfo, err = meter.Int64UpDownCounter(TargetInfo)
+	m.targetInfo, err = meter.Int64UpDownCounter(TargetInfo, instrument.WithDescription("Target metadata"))
 	if err != nil {
 		return fmt.Errorf("creating target info: %w", err)
 	}


### PR DESCRIPTION
We pre-create target info so that we can write the process as instrumented even before any traffic is seen by the BPF side. The target info was created but without a description label, which can cause this annoying message in debug OTel collector export logs:

```
collected metric target_info label:{name:"host_id"  value:"d8dc7712-a82d-4108-bb2c-9d1d39d4915e"}  label:{name:"host_name"  value:"beyla"}  label:{name:"instance"  value:"beyla:133937"}  label:{name:"job"  value:"integration-test/service-r"}  label:{name:"os_type"  value:"linux"}  label:{name:"service_instance_id"  value:"beyla:133937"}  label:{name:"service_name"  value:"service-r"}  label:{name:"service_namespace"  value:"integration-test"}  label:{name:"telemetry_sdk_language"  value:"nodejs"}  label:{name:"telemetry_sdk_name"  value:"beyla"}  label:{name:"telemetry_sdk_version"  value:"unset"}  gauge:{value:1} has help "" but should have "Target metadata"
```