### PR TITLE
Allow overriding some behaviors of the OTEL exporters

### DIFF
--- a/pkg/export/otel/common.go
+++ b/pkg/export/otel/common.go
@@ -69,13 +69,13 @@ var DefaultBuckets = Buckets{
 	ResponseSizeHistogram: []float64{0, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192},
 }
 
-func getAppResourceAttrs(hostID string, service *svc.Attrs) []attribute.KeyValue {
-	return append(getResourceAttrs(hostID, service),
+func GetAppResourceAttrs(hostID string, service *svc.Attrs) []attribute.KeyValue {
+	return append(GetResourceAttrs(hostID, service),
 		semconv.ServiceInstanceID(service.UID.Instance),
 	)
 }
 
-func getResourceAttrs(hostID string, service *svc.Attrs) []attribute.KeyValue {
+func GetResourceAttrs(hostID string, service *svc.Attrs) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		semconv.ServiceName(service.UID.Name),
 		// SpanMetrics requires an extra attribute besides service name
@@ -101,8 +101,8 @@ func getResourceAttrs(hostID string, service *svc.Attrs) []attribute.KeyValue {
 	return attrs
 }
 
-// getFilteredAttributesByPrefix applies attribute filtering based on selector patterns.
-func getFilteredAttributesByPrefix(baseAttrs []attribute.KeyValue, attrSelector attributes.Selection,
+// GetFilteredAttributesByPrefix applies attribute filtering based on selector patterns.
+func GetFilteredAttributesByPrefix(baseAttrs []attribute.KeyValue, attrSelector attributes.Selection,
 	extraAttrs []attribute.KeyValue, prefixPatterns []string,
 ) []attribute.KeyValue {
 	result := make([]attribute.KeyValue, len(baseAttrs))
@@ -228,10 +228,12 @@ func NewReporterPool[K uidGetter, T any](
 	cacheLen int,
 	ttl time.Duration,
 	clock expire.Clock,
-	callback simplelru.EvictCallback[svc.UID, *expirable[T]],
+	callback simplelru.EvictCallback[svc.UID, T],
 	itemConstructor func(id K) (T, error),
 ) ReporterPool[K, T] {
-	pool, err := simplelru.NewLRU[svc.UID, *expirable[T]](cacheLen, callback)
+	pool, err := simplelru.NewLRU[svc.UID, *expirable[T]](cacheLen, func(key svc.UID, value *expirable[T]) {
+		callback(key, value.value)
+	})
 	if err != nil {
 		// should never happen: bug!
 		panic(err)
@@ -507,5 +509,5 @@ func ResolveOTLPEndpoint(endpoint, common string) (string, bool) {
 // This is especially useful for RED metrics and span metrics where we want to control
 // which attributes are included in the metrics.
 func getFilteredMetricResourceAttrs(baseAttrs []attribute.KeyValue, attrSelector attributes.Selection, extraAttrs []attribute.KeyValue, metricTypes []string) []attribute.KeyValue {
-	return getFilteredAttributesByPrefix(baseAttrs, attrSelector, extraAttrs, metricTypes)
+	return GetFilteredAttributesByPrefix(baseAttrs, attrSelector, extraAttrs, metricTypes)
 }

--- a/pkg/export/otel/common_test.go
+++ b/pkg/export/otel/common_test.go
@@ -369,7 +369,7 @@ func TestGetFilteredResourceAttrs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := getFilteredAttributesByPrefix(tc.baseAttrs, tc.attrSelector, tc.extraAttrs, tc.prefixPatterns)
+			result := GetFilteredAttributesByPrefix(tc.baseAttrs, tc.attrSelector, tc.extraAttrs, tc.prefixPatterns)
 
 			attrMap := make(map[string]attribute.Value)
 			for _, attr := range result {

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -127,6 +127,13 @@ type MetricsConfig struct {
 	TTL time.Duration `yaml:"ttl" env:"OTEL_EBPF_OTEL_METRICS_TTL"`
 
 	AllowServiceGraphSelfReferences bool `yaml:"allow_service_graph_self_references" env:"OTEL_EBPF_OTEL_ALLOW_SERVICE_GRAPH_SELF_REFERENCES"`
+
+	// OTLPEndpointProvider allows overriding the OTLP Endpoint. It needs to return an endpoint and
+	// a boolean indicating if the endpoint is common for both traces and metrics
+	OTLPEndpointProvider func() (string, bool) `yaml:"-" env:"-"`
+
+	// InjectHeaders allows injecting custom headers to the HTTP OTLP exporter
+	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
 }
 
 func (m *MetricsConfig) GetProtocol() Protocol {
@@ -163,6 +170,9 @@ func (m *MetricsConfig) GuessProtocol() Protocol {
 }
 
 func (m *MetricsConfig) OTLPMetricsEndpoint() (string, bool) {
+	if m.OTLPEndpointProvider != nil {
+		return m.OTLPEndpointProvider()
+	}
 	return ResolveOTLPEndpoint(m.MetricsEndpoint, m.CommonEndpoint)
 }
 
@@ -172,7 +182,8 @@ func (m *MetricsConfig) OTLPMetricsEndpoint() (string, bool) {
 // Reason to disable linting: it requires to be a value despite it is considered a "heavy struct".
 // This method is invoked only once during startup time so it doesn't have a noticeable performance impact.
 func (m *MetricsConfig) EndpointEnabled() bool {
-	return m.CommonEndpoint != "" || m.MetricsEndpoint != ""
+	ep, _ := m.OTLPMetricsEndpoint()
+	return ep != ""
 }
 
 func (m *MetricsConfig) AnySpanMetricsEnabled() bool {
@@ -403,16 +414,16 @@ func newMetricsReporter(
 	}
 
 	mr.reporters = NewReporterPool[*svc.Attrs, *Metrics](cfg.ReportersCacheLen, cfg.TTL, timeNow,
-		func(id svc.UID, v *expirable[*Metrics]) {
+		func(id svc.UID, v *Metrics) {
 			llog := log.With("service", id)
 			llog.Debug("evicting metrics reporter from cache")
-			v.value.cleanupAllMetricsInstances()
+			v.cleanupAllMetricsInstances()
 
-			mr.deleteTracesTargetInfo(v.value)
-			mr.deleteTargetInfo(v.value)
+			mr.deleteTracesTargetInfo(v)
+			mr.deleteTargetInfo(v)
 
 			go func() {
-				if err := v.value.provider.ForceFlush(ctx); err != nil {
+				if err := v.provider.ForceFlush(ctx); err != nil {
 					llog.Warn("error flushing evicted metrics provider", "error", err)
 				}
 			}()
@@ -765,7 +776,7 @@ func (mr *MetricsReporter) newMetricsInstance(service *svc.Attrs) Metrics {
 	var resourceAttributes []attribute.KeyValue
 	if service != nil {
 		mlog = mlog.With("service", service)
-		resourceAttributes = append(getAppResourceAttrs(mr.hostID, service), ResourceAttrsFromEnv(service)...)
+		resourceAttributes = append(GetAppResourceAttrs(mr.hostID, service), ResourceAttrsFromEnv(service)...)
 	}
 	mlog.Debug("creating new Metrics reporter")
 	resources := resource.NewWithAttributes(semconv.SchemaURL, resourceAttributes...)
@@ -1264,6 +1275,9 @@ func getHTTPMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
 		opts.SkipTLSVerify = cfg.InsecureSkipVerify
 	}
 
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
 	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
 	maps.Copy(opts.Headers, HeadersFromEnv(envMetricsHeaders))
 
@@ -1291,6 +1305,9 @@ func getGRPCMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
 		opts.SkipTLSVerify = true
 	}
 
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
 	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
 	maps.Copy(opts.Headers, HeadersFromEnv(envMetricsHeaders))
 
@@ -1298,11 +1315,9 @@ func getGRPCMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
 }
 
 // the HTTP path will be defined from one of the following sources, from highest to lowest priority
+// - the result from any overridden OTLP Provider function
 // - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, if defined
 // - OTEL_EXPORTER_OTLP_ENDPOINT, if defined
-// - https://otlp-gateway-${GRAFANA_CLOUD_ZONE}.grafana.net/otlp, if GRAFANA_CLOUD_ZONE is defined
-// If, by some reason, Grafana changes its OTLP Gateway URL in a distant future, you can still point to the
-// correct URL with the OTLP_EXPORTER_... variables.
 func parseMetricsEndpoint(cfg *MetricsConfig) (*url.URL, bool, error) {
 	endpoint, isCommon := cfg.OTLPMetricsEndpoint()
 

--- a/pkg/export/otel/metrics_net.go
+++ b/pkg/export/otel/metrics_net.go
@@ -54,7 +54,7 @@ func getFilteredNetworkResourceAttrs(hostID string, attrSelector attributes.Sele
 		semconv.HostID(hostID),
 	}
 
-	return getFilteredAttributesByPrefix(baseAttrs, attrSelector, extraAttrs, []string{"network.", "beyla.network"})
+	return GetFilteredAttributesByPrefix(baseAttrs, attrSelector, extraAttrs, []string{"network.", "beyla.network"})
 }
 
 func createFilteredNetworkResource(hostID string, attrSelector attributes.Selection) *resource.Resource {

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -510,6 +510,14 @@ func TestMetricsConfig_Enabled(t *testing.T) {
 	assert.True(t, (&MetricsConfig{Features: []string{FeatureApplication, FeatureNetwork}, CommonEndpoint: "foo"}).Enabled())
 	assert.True(t, (&MetricsConfig{Features: []string{FeatureApplication}, MetricsEndpoint: "foo"}).Enabled())
 	assert.True(t, (&MetricsConfig{MetricsEndpoint: "foo", Features: []string{FeatureNetwork}}).Enabled())
+	assert.True(t, (&MetricsConfig{
+		Features:             []string{FeatureNetwork},
+		OTLPEndpointProvider: func() (string, bool) { return "something", false },
+	}).Enabled())
+	assert.True(t, (&MetricsConfig{
+		Features:             []string{FeatureNetwork},
+		OTLPEndpointProvider: func() (string, bool) { return "something", true },
+	}).Enabled())
 }
 
 func TestMetricsConfig_Disabled(t *testing.T) {
@@ -519,6 +527,10 @@ func TestMetricsConfig_Disabled(t *testing.T) {
 	// application feature is not enabled
 	assert.False(t, (&MetricsConfig{CommonEndpoint: "foo"}).Enabled())
 	assert.False(t, (&MetricsConfig{}).Enabled())
+	assert.False(t, (&MetricsConfig{
+		Features:             []string{FeatureApplication},
+		OTLPEndpointProvider: func() (string, bool) { return "", false },
+	}).Enabled())
 }
 
 func TestSpanMetricsDiscarded(t *testing.T) {


### PR DESCRIPTION
Allows changing the endpoints and overriding some header values for the OTEL metrics and traces exporters.