### PR TITLE
Span metrics export filtering with a separate flag

### DIFF
--- a/pkg/components/ebpf/common/pids_test.go
+++ b/pkg/components/ebpf/common/pids_test.go
@@ -119,6 +119,7 @@ func TestFilter_ExportsOTelDetection(t *testing.T) {
 	span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/random/server/span", RequestStart: 100, End: 200, Status: 200}
 
 	checkIfExportsOTel(&s, &span)
+	assert.False(t, s.ExportsOTelMetricsSpan())
 	assert.False(t, s.ExportsOTelMetrics())
 	assert.False(t, s.ExportsOTelTraces())
 
@@ -126,6 +127,7 @@ func TestFilter_ExportsOTelDetection(t *testing.T) {
 	span = request.Span{Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/metrics", RequestStart: 100, End: 200, Status: 200}
 
 	checkIfExportsOTel(&s, &span)
+	assert.False(t, s.ExportsOTelMetricsSpan())
 	assert.True(t, s.ExportsOTelMetrics())
 	assert.False(t, s.ExportsOTelTraces())
 
@@ -133,7 +135,36 @@ func TestFilter_ExportsOTelDetection(t *testing.T) {
 	span = request.Span{Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces", RequestStart: 100, End: 200, Status: 200}
 
 	checkIfExportsOTel(&s, &span)
+	assert.False(t, s.ExportsOTelMetricsSpan())
 	assert.False(t, s.ExportsOTelMetrics())
+	assert.True(t, s.ExportsOTelTraces())
+}
+
+func TestFilter_ExportsOTelSpanDetection(t *testing.T) {
+	s := svc.Attrs{}
+	span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/random/server/span", RequestStart: 100, End: 200, Status: 200}
+
+	checkIfExportsOTelSpanMetrics(&s, &span)
+	assert.False(t, s.ExportsOTelMetricsSpan())
+	assert.False(t, s.ExportsOTelMetrics())
+	assert.False(t, s.ExportsOTelTraces())
+
+	s = svc.Attrs{}
+	span = request.Span{Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/metrics", RequestStart: 100, End: 200, Status: 200}
+
+	checkIfExportsOTelSpanMetrics(&s, &span)
+	assert.False(t, s.ExportsOTelMetricsSpan())
+	assert.False(t, s.ExportsOTelMetrics())
+	assert.False(t, s.ExportsOTelTraces())
+
+	s = svc.Attrs{}
+	span = request.Span{Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces", RequestStart: 100, End: 200, Status: 200}
+
+	checkIfExportsOTelSpanMetrics(&s, &span)
+	assert.False(t, s.ExportsOTelMetrics())
+	assert.True(t, s.ExportsOTelMetricsSpan())
+	assert.False(t, s.ExportsOTelTraces())
+	checkIfExportsOTel(&s, &span)
 	assert.True(t, s.ExportsOTelTraces())
 }
 

--- a/pkg/components/ebpf/common/pids_test.go
+++ b/pkg/components/ebpf/common/pids_test.go
@@ -14,6 +14,15 @@ import (
 )
 
 var spanSet = []request.Span{
+	{Pid: request.PidInfo{UserPID: 33, HostPID: 123, Namespace: 33}},
+	{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
+	{Pid: request.PidInfo{UserPID: 66, HostPID: 456, Namespace: 33}},
+	{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
+	{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
+	{Pid: request.PidInfo{UserPID: 1000, HostPID: 1234, Namespace: 44}},
+}
+
+var spanSetWithPaths = []request.Span{
 	{Pid: request.PidInfo{UserPID: 33, HostPID: 123, Namespace: 33}, Path: "/something"},
 	{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/traces"},
 	{Pid: request.PidInfo{UserPID: 66, HostPID: 456, Namespace: 33}, Path: "/v1/metrics"},
@@ -34,7 +43,7 @@ func TestFilter_SameNS(t *testing.T) {
 	// with the same namespace, it filters by user PID, as it is the PID
 	// that is seen by Beyla's process discovery
 	assert.Equal(t, []request.Span{
-		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/traces"},
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
 		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
 		{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
 	}, resetTraceContext(pf.Filter(spanSet)))
@@ -84,16 +93,16 @@ func TestFilter_NewNSLater(t *testing.T) {
 	// with the same namespace, it filters by user PID, as it is the PID
 	// that is seen by Beyla's process discovery
 	assert.Equal(t, []request.Span{
-		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/metrics"},
-		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}, Path: "/v1/traces"},
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
 		{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
 	}, resetTraceContext(pf.Filter(spanSet)))
 
 	pf.AllowPID(1000, 44, &svc.Attrs{}, PIDTypeGo)
 
 	assert.Equal(t, []request.Span{
-		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/metrics"},
-		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}, Path: "/v1/traces"},
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
 		{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
 		{Pid: request.PidInfo{UserPID: 1000, HostPID: 1234, Namespace: 44}},
 	}, resetTraceContext(pf.Filter(spanSet)))
@@ -101,7 +110,7 @@ func TestFilter_NewNSLater(t *testing.T) {
 	pf.BlockPID(456, 33)
 
 	assert.Equal(t, []request.Span{
-		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/metrics"},
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
 		{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
 		{Pid: request.PidInfo{UserPID: 1000, HostPID: 1234, Namespace: 44}},
 	}, resetTraceContext(pf.Filter(spanSet)))
@@ -109,7 +118,7 @@ func TestFilter_NewNSLater(t *testing.T) {
 	pf.BlockPID(1000, 44)
 
 	assert.Equal(t, []request.Span{
-		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/metrics"},
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
 		{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
 	}, resetTraceContext(pf.Filter(spanSet)))
 }
@@ -181,12 +190,12 @@ func TestFilter_TriggersOTelFiltering(t *testing.T) {
 	pf.AllowPID(66, 33, &commonSvc, PIDTypeGo)
 	pf.AllowPID(789, 33, &commonSvc, PIDTypeGo)
 
-	testSpans := make([]request.Span, len(spanSet))
+	testSpans := make([]request.Span, len(spanSetWithPaths))
 
 	service := svc.Attrs{}
 
-	for i := range spanSet {
-		testSpans[i] = spanSet[i]
+	for i := range spanSetWithPaths {
+		testSpans[i] = spanSetWithPaths[i]
 		testSpans[i].Service = service
 		testSpans[i].Status = 200
 		testSpans[i].Type = request.EventTypeHTTPClient
@@ -226,12 +235,12 @@ func TestFilter_TriggersOTelSpanFiltering(t *testing.T) {
 	pf.AllowPID(66, 33, &commonSvc, PIDTypeGo)
 	pf.AllowPID(789, 33, &commonSvc, PIDTypeGo)
 
-	testSpans := make([]request.Span, len(spanSet))
+	testSpans := make([]request.Span, len(spanSetWithPaths))
 
 	service := svc.Attrs{}
 
-	for i := range spanSet {
-		testSpans[i] = spanSet[i]
+	for i := range spanSetWithPaths {
+		testSpans[i] = spanSetWithPaths[i]
 		testSpans[i].Service = service
 		testSpans[i].Status = 200
 		testSpans[i].Type = request.EventTypeHTTPClient

--- a/pkg/components/ebpf/common/pids_test.go
+++ b/pkg/components/ebpf/common/pids_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 var spanSet = []request.Span{
-	{Pid: request.PidInfo{UserPID: 33, HostPID: 123, Namespace: 33}},
-	{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
-	{Pid: request.PidInfo{UserPID: 66, HostPID: 456, Namespace: 33}},
+	{Pid: request.PidInfo{UserPID: 33, HostPID: 123, Namespace: 33}, Path: "/something"},
+	{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/traces"},
+	{Pid: request.PidInfo{UserPID: 66, HostPID: 456, Namespace: 33}, Path: "/v1/metrics"},
 	{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
 	{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
 	{Pid: request.PidInfo{UserPID: 1000, HostPID: 1234, Namespace: 44}},
@@ -34,7 +34,7 @@ func TestFilter_SameNS(t *testing.T) {
 	// with the same namespace, it filters by user PID, as it is the PID
 	// that is seen by Beyla's process discovery
 	assert.Equal(t, []request.Span{
-		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/traces"},
 		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
 		{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
 	}, resetTraceContext(pf.Filter(spanSet)))
@@ -84,16 +84,16 @@ func TestFilter_NewNSLater(t *testing.T) {
 	// with the same namespace, it filters by user PID, as it is the PID
 	// that is seen by Beyla's process discovery
 	assert.Equal(t, []request.Span{
-		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
-		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/metrics"},
+		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}, Path: "/v1/traces"},
 		{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
 	}, resetTraceContext(pf.Filter(spanSet)))
 
 	pf.AllowPID(1000, 44, &svc.Attrs{}, PIDTypeGo)
 
 	assert.Equal(t, []request.Span{
-		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
-		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/metrics"},
+		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}, Path: "/v1/traces"},
 		{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
 		{Pid: request.PidInfo{UserPID: 1000, HostPID: 1234, Namespace: 44}},
 	}, resetTraceContext(pf.Filter(spanSet)))
@@ -101,7 +101,7 @@ func TestFilter_NewNSLater(t *testing.T) {
 	pf.BlockPID(456, 33)
 
 	assert.Equal(t, []request.Span{
-		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/metrics"},
 		{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
 		{Pid: request.PidInfo{UserPID: 1000, HostPID: 1234, Namespace: 44}},
 	}, resetTraceContext(pf.Filter(spanSet)))
@@ -109,7 +109,7 @@ func TestFilter_NewNSLater(t *testing.T) {
 	pf.BlockPID(1000, 44)
 
 	assert.Equal(t, []request.Span{
-		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, Path: "/v1/metrics"},
 		{Pid: request.PidInfo{UserPID: 789, HostPID: 234, Namespace: 33}},
 	}, resetTraceContext(pf.Filter(spanSet)))
 }
@@ -166,6 +166,96 @@ func TestFilter_ExportsOTelSpanDetection(t *testing.T) {
 	assert.False(t, s.ExportsOTelTraces())
 	checkIfExportsOTel(&s, &span)
 	assert.True(t, s.ExportsOTelTraces())
+}
+
+func TestFilter_TriggersOTelFiltering(t *testing.T) {
+	readNamespacePIDs = func(pid int32) ([]uint32, error) {
+		return []uint32{uint32(pid)}, nil
+	}
+	pf := newPIDsFilter(&services.DiscoveryConfig{ExcludeOTelInstrumentedServices: true, ExcludeOTelInstrumentedServicesSpanMetrics: true}, slog.With("env", "testing"))
+
+	commonSvc := svc.Attrs{}
+	pf.AllowPID(33, 33, &commonSvc, PIDTypeGo)
+	pf.AllowPID(123, 33, &commonSvc, PIDTypeGo)
+	pf.AllowPID(456, 33, &commonSvc, PIDTypeGo)
+	pf.AllowPID(66, 33, &commonSvc, PIDTypeGo)
+	pf.AllowPID(789, 33, &commonSvc, PIDTypeGo)
+
+	testSpans := make([]request.Span, len(spanSet))
+
+	service := svc.Attrs{}
+
+	for i := range spanSet {
+		testSpans[i] = spanSet[i]
+		testSpans[i].Service = service
+		testSpans[i].Status = 200
+		testSpans[i].Type = request.EventTypeHTTPClient
+	}
+
+	filtered := filterService(pf.Filter(testSpans))
+	assert.Len(t, filtered, 5)
+
+	// the first one didn't see any of the /v1/metrics, /v1/traces URLs in traffic
+	assert.False(t, filtered[0].ExportsOTelMetrics())
+	assert.False(t, filtered[0].ExportsOTelMetricsSpan())
+	assert.False(t, filtered[0].ExportsOTelTraces())
+
+	// second one saw /v1/traces so we marked both traces and span metrics as exported
+	assert.False(t, filtered[1].ExportsOTelMetrics())
+	assert.True(t, filtered[1].ExportsOTelMetricsSpan())
+	assert.True(t, filtered[1].ExportsOTelTraces())
+
+	// after the third, which has url /v1/metrics, we detected everything exported
+	for i := 2; i < 5; i++ {
+		assert.True(t, filtered[i].ExportsOTelMetrics())
+		assert.True(t, filtered[i].ExportsOTelMetricsSpan())
+		assert.True(t, filtered[i].ExportsOTelTraces())
+	}
+}
+
+func TestFilter_TriggersOTelSpanFiltering(t *testing.T) {
+	readNamespacePIDs = func(pid int32) ([]uint32, error) {
+		return []uint32{uint32(pid)}, nil
+	}
+	pf := newPIDsFilter(&services.DiscoveryConfig{ExcludeOTelInstrumentedServices: true}, slog.With("env", "testing"))
+
+	commonSvc := svc.Attrs{}
+	pf.AllowPID(33, 33, &commonSvc, PIDTypeGo)
+	pf.AllowPID(123, 33, &commonSvc, PIDTypeGo)
+	pf.AllowPID(456, 33, &commonSvc, PIDTypeGo)
+	pf.AllowPID(66, 33, &commonSvc, PIDTypeGo)
+	pf.AllowPID(789, 33, &commonSvc, PIDTypeGo)
+
+	testSpans := make([]request.Span, len(spanSet))
+
+	service := svc.Attrs{}
+
+	for i := range spanSet {
+		testSpans[i] = spanSet[i]
+		testSpans[i].Service = service
+		testSpans[i].Status = 200
+		testSpans[i].Type = request.EventTypeHTTPClient
+	}
+
+	filtered := filterService(pf.Filter(testSpans))
+	assert.Len(t, filtered, 5)
+
+	// the first one didn't see any of the /v1/metrics, /v1/traces URLs in traffic
+	assert.False(t, filtered[0].ExportsOTelMetrics())
+	assert.False(t, filtered[0].ExportsOTelMetricsSpan())
+	assert.False(t, filtered[0].ExportsOTelTraces())
+
+	// second one saw /v1/traces so we marked traces as exported, but not span metrics because the default config is false
+	assert.False(t, filtered[1].ExportsOTelMetrics())
+	assert.False(t, filtered[1].ExportsOTelMetricsSpan())
+	assert.True(t, filtered[1].ExportsOTelTraces())
+
+	// after the third, which has url /v1/metrics, we detected everything exported, but not span metrics
+	for i := 2; i < 5; i++ {
+		assert.True(t, filtered[i].ExportsOTelMetrics())
+		assert.False(t, filtered[i].ExportsOTelMetricsSpan())
+		assert.True(t, filtered[i].ExportsOTelTraces())
+	}
 }
 
 func TestFilter_Cleanup(t *testing.T) {
@@ -232,4 +322,13 @@ func resetTraceContext(spans []request.Span) []request.Span {
 	}
 
 	return spans
+}
+
+func filterService(spans []request.Span) []svc.Attrs {
+	result := []svc.Attrs{}
+	for i := range spans {
+		result = append(result, spans[i].Service)
+	}
+
+	return result
 }

--- a/pkg/components/svc/svc.go
+++ b/pkg/components/svc/svc.go
@@ -49,9 +49,10 @@ func (it InstrumentableType) String() string {
 type idFlags uint8
 
 const (
-	autoName           idFlags = 0x1
-	exportsOTelMetrics idFlags = 0x2
-	exportsOTelTraces  idFlags = 0x4
+	autoName               idFlags = 0x1
+	exportsOTelMetrics     idFlags = 0x2
+	exportsOTelTraces      idFlags = 0x4
+	exportsOTelMetricsSpan idFlags = 0x8
 )
 
 // UID uniquely identifies a service instance across the whole system
@@ -123,6 +124,14 @@ func (i *Attrs) SetExportsOTelMetrics() {
 
 func (i *Attrs) ExportsOTelMetrics() bool {
 	return i.getFlag(exportsOTelMetrics)
+}
+
+func (i *Attrs) SetExportsOTelMetricsSpan() {
+	i.setFlag(exportsOTelMetricsSpan)
+}
+
+func (i *Attrs) ExportsOTelMetricsSpan() bool {
+	return i.getFlag(exportsOTelMetricsSpan)
 }
 
 func (i *Attrs) SetExportsOTelTraces() {

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -1030,8 +1030,12 @@ func (mr *MetricsReporter) serviceGraphAttributes() []attributes.Field[*request.
 		})
 }
 
-func otelSpanAccepted(span *request.Span, mr *MetricsReporter) bool {
+func otelMetricsAccepted(span *request.Span, mr *MetricsReporter) bool {
 	return mr.cfg.OTelMetricsEnabled() && !span.Service.ExportsOTelMetrics()
+}
+
+func otelSpanMetricsAccepted(span *request.Span, mr *MetricsReporter) bool {
+	return mr.cfg.OTelMetricsEnabled() && !span.Service.ExportsOTelMetricsSpan()
 }
 
 //nolint:cyclop
@@ -1041,7 +1045,7 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 
 	ctx := trace.ContextWithSpanContext(r.ctx, trace.SpanContext{}.WithTraceID(span.TraceID).WithSpanID(span.SpanID).WithTraceFlags(trace.TraceFlags(span.TraceFlags)))
 
-	if otelSpanAccepted(span, mr) {
+	if otelMetricsAccepted(span, mr) {
 		switch span.Type {
 		case request.EventTypeHTTP:
 			if mr.is.HTTPEnabled() {
@@ -1109,36 +1113,38 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 		}
 	}
 
-	if mr.cfg.SpanMetricsEnabled() {
-		sml, attrs := r.spanMetricsLatency.ForRecord(span)
-		sml.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+	if otelSpanMetricsAccepted(span, mr) {
+		if mr.cfg.SpanMetricsEnabled() {
+			sml, attrs := r.spanMetricsLatency.ForRecord(span)
+			sml.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 
-		smct, attrs := r.spanMetricsCallsTotal.ForRecord(span)
-		smct.Add(ctx, 1, instrument.WithAttributeSet(attrs))
-	}
+			smct, attrs := r.spanMetricsCallsTotal.ForRecord(span)
+			smct.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+		}
 
-	if mr.cfg.SpanMetricsSizesEnabled() {
-		smst, attrs := r.spanMetricsRequestSizeTotal.ForRecord(span)
-		smst.Add(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
+		if mr.cfg.SpanMetricsSizesEnabled() {
+			smst, attrs := r.spanMetricsRequestSizeTotal.ForRecord(span)
+			smst.Add(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
 
-		smst, attr := r.spanMetricsResponseSizeTotal.ForRecord(span)
-		smst.Add(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attr))
-	}
+			smst, attr := r.spanMetricsResponseSizeTotal.ForRecord(span)
+			smst.Add(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attr))
+		}
 
-	if mr.cfg.ServiceGraphMetricsEnabled() {
-		if !span.IsSelfReferenceSpan() || mr.cfg.AllowServiceGraphSelfReferences {
-			if span.IsClientSpan() {
-				sgc, attrs := r.serviceGraphClient.ForRecord(span)
-				sgc.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			} else {
-				sgs, attrs := r.serviceGraphServer.ForRecord(span)
-				sgs.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-			sgt, attrs := r.serviceGraphTotal.ForRecord(span)
-			sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
-			if request.SpanStatusCode(span) == request.StatusCodeError {
-				sgf, attrs := r.serviceGraphFailed.ForRecord(span)
-				sgf.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+		if mr.cfg.ServiceGraphMetricsEnabled() {
+			if !span.IsSelfReferenceSpan() || mr.cfg.AllowServiceGraphSelfReferences {
+				if span.IsClientSpan() {
+					sgc, attrs := r.serviceGraphClient.ForRecord(span)
+					sgc.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				} else {
+					sgs, attrs := r.serviceGraphServer.ForRecord(span)
+					sgs.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
+				sgt, attrs := r.serviceGraphTotal.ForRecord(span)
+				sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+				if request.SpanStatusCode(span) == request.StatusCodeError {
+					sgf, attrs := r.serviceGraphFailed.ForRecord(span)
+					sgf.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+				}
 			}
 		}
 	}

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -91,6 +91,9 @@ type DiscoveryConfig struct {
 
 	// Disables instrumentation of services which are already instrumented
 	ExcludeOTelInstrumentedServices bool `yaml:"exclude_otel_instrumented_services" env:"OTEL_EBPF_EXCLUDE_OTEL_INSTRUMENTED_SERVICES"`
+
+	// Disables generation of span metrics of services which are already instrumented
+	ExcludeOTelInstrumentedServicesSpanMetrics bool `yaml:"exclude_otel_instrumented_services_span_metrics" env:"OTEL_EBPF_EXCLUDE_OTEL_INSTRUMENTED_SERVICES_SPAN_METRICS"`
 }
 
 func (c *DiscoveryConfig) Validate() error {


### PR DESCRIPTION
OBI can detect that a service that has been defined to be instrumented is already instrumented with the OTel SDK, e.g. it's exporting actively it's own traces, metrics or both. We have this option on by default.

However, OBI can also directly produce span and service graph metrics. In this case we would duplicate metrics if a service is exporting traces and the end user has configured the OTel collector span/graph metrics processor. This PR adds an option to disable the generation of the span/service graph metrics, for OTel instrumented services, if the user environment has the span/service graph processor enabled in their Collector.