### PR TITLE
Fix reading the eBPF IPC buffers

### DIFF
--- a/bpf/common/scratch_mem.h
+++ b/bpf/common/scratch_mem.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#define SCRATCH_MEM_TYPED(NAME, TYPE)                                                              \
+    struct {                                                                                       \
+        __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);                                                   \
+        __type(key, u32);                                                                          \
+        __type(value, TYPE);                                                                       \
+        __uint(max_entries, 1);                                                                    \
+    } NAME##_storage SEC(".maps");                                                                 \
+                                                                                                   \
+    static __always_inline TYPE *NAME##_mem(void) {                                                \
+        return bpf_map_lookup_elem(&NAME##_storage, &(u32){0});                                    \
+    }
+
+#define SCRATCH_MEM(NAME) SCRATCH_MEM_TYPED(NAME, NAME)

--- a/bpf/generictracer/ebpf_ipc.h
+++ b/bpf/generictracer/ebpf_ipc.h
@@ -5,6 +5,8 @@
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/utils.h>
 
+#include <common/scratch_mem.h>
+
 #include <logger/bpf_dbg.h>
 
 #include <maps/nodejs_fd_map.h>
@@ -15,25 +17,27 @@ typedef enum ev_type : u8 {
     IPC_EV_NODEJS,
 } ev_type;
 
-struct ipc_header_t {
+typedef struct ipc_header_t {
     u32 marker;
     ev_type type;
     u8 size;
     u8 _pad[2];
-};
+} ipc_header;
 
-struct nodejs_ev_t {
-    struct ipc_header_t hdr;
+typedef struct nodejs_ev_t {
+    ipc_header hdr;
     u32 serverFD;
     u32 clientFD;
     u8 _pad[3];
     u8 crc;
-};
+} nodejs_ev;
 
-union ipc_buffer {
-    struct ipc_header_t hdr;
-    struct nodejs_ev_t njs;
-};
+typedef union ipc_buffer_t {
+    ipc_header hdr;
+    nodejs_ev njs;
+} ipc_buffer;
+
+SCRATCH_MEM(ipc_buffer)
 
 static __always_inline uint8_t crc8(const unsigned char *data, u8 size) {
     const u8 polynomial = 0x07;
@@ -56,8 +60,8 @@ static __always_inline uint8_t crc8(const unsigned char *data, u8 size) {
     return crc;
 }
 
-static __always_inline int handle_ev_nodejs(const union ipc_buffer *ev) {
-    const size_t ev_size = sizeof(struct nodejs_ev_t);
+static __always_inline int handle_ev_nodejs(const ipc_buffer *ev) {
+    const size_t ev_size = sizeof(nodejs_ev);
 
     bpf_dbg_printk("checking for node ipc event size=%u, expected = %llu", ev->hdr.size, ev_size);
 
@@ -93,27 +97,31 @@ static __always_inline int handle_ebpf_ipc(const void *buf, size_t buf_size) {
     // events don't usually share buffers with other traffic, so the following
     // sanity check ensures we bail early if the buffer is unlikely to contain
     // an event
-    if (buf_size < sizeof(struct ipc_header_t) || buf_size > sizeof(union ipc_buffer)) {
+    if (buf_size < sizeof(ipc_header) || buf_size > sizeof(ipc_buffer)) {
         return 0;
     }
 
-    union ipc_buffer ev;
+    ipc_buffer *ev = (ipc_buffer *)ipc_buffer_mem();
 
-    bpf_clamp_umax(buf_size, sizeof(union ipc_buffer));
-
-    if (bpf_probe_read(&ev, buf_size, buf) != 0) {
+    if (!ev) {
         return 0;
     }
 
-    const u32 marker = bpf_ntohl(ev.hdr.marker);
+    bpf_clamp_umax(buf_size, sizeof(ipc_buffer));
+
+    if (bpf_probe_read(ev, buf_size, buf) != 0) {
+        return 0;
+    }
+
+    const u32 marker = bpf_ntohl(ev->hdr.marker);
 
     if (marker != k_ebpf_ipc_magic) {
         return 0;
     }
 
-    switch (ev.hdr.type) {
+    switch (ev->hdr.type) {
     case IPC_EV_NODEJS:
-        return handle_ev_nodejs(&ev);
+        return handle_ev_nodejs(ev);
     }
 
     return 0;

--- a/bpf/generictracer/ebpf_ipc.h
+++ b/bpf/generictracer/ebpf_ipc.h
@@ -3,6 +3,7 @@
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_endian.h>
 #include <bpfcore/bpf_helpers.h>
+#include <bpfcore/utils.h>
 
 #include <logger/bpf_dbg.h>
 
@@ -29,6 +30,11 @@ struct nodejs_ev_t {
     u8 crc;
 };
 
+union ipc_buffer {
+    struct ipc_header_t hdr;
+    struct nodejs_ev_t njs;
+};
+
 static __always_inline uint8_t crc8(const unsigned char *data, u8 size) {
     const u8 polynomial = 0x07;
 
@@ -50,18 +56,16 @@ static __always_inline uint8_t crc8(const unsigned char *data, u8 size) {
     return crc;
 }
 
-static __always_inline int handle_ev_nodejs(const struct ipc_header_t *hdr, size_t buf_size) {
+static __always_inline int handle_ev_nodejs(const union ipc_buffer *ev) {
     const size_t ev_size = sizeof(struct nodejs_ev_t);
 
-    bpf_dbg_printk("checking for node ipc event size=%u, buf_size=%u", hdr->size, buf_size);
+    bpf_dbg_printk("checking for node ipc event size=%u, expected = %llu", ev->hdr.size, ev_size);
 
-    if (hdr->size != ev_size || buf_size < ev_size) {
+    if (ev->hdr.size != ev_size) {
         return 0;
     }
 
-    const struct nodejs_ev_t *ev = (const struct nodejs_ev_t *)hdr;
-
-    const u8 crc = crc8((const unsigned char *)ev, sizeof(*ev));
+    const u8 crc = crc8((const unsigned char *)ev, ev_size);
 
     bpf_dbg_printk("calculated CRC = %u", crc);
 
@@ -69,8 +73,8 @@ static __always_inline int handle_ev_nodejs(const struct ipc_header_t *hdr, size
         return 0;
     }
 
-    const s32 serverFD = bpf_ntohl(ev->serverFD);
-    const s32 clientFD = bpf_ntohl(ev->clientFD);
+    const s32 serverFD = bpf_ntohl(ev->njs.serverFD);
+    const s32 clientFD = bpf_ntohl(ev->njs.clientFD);
     const u64 pid_tgid = bpf_get_current_pid_tgid();
     const u64 key = (pid_tgid << 32) | clientFD;
 
@@ -86,20 +90,30 @@ static __always_inline int handle_ev_nodejs(const struct ipc_header_t *hdr, size
 // communicate the file descriptors of the incoming and outgoing calls - this
 // could be extended in the future (and potentially become a tail call target)
 static __always_inline int handle_ebpf_ipc(const void *buf, size_t buf_size) {
-    if (buf_size < sizeof(struct ipc_header_t)) {
+    // events don't usually share buffers with other traffic, so the following
+    // sanity check ensures we bail early if the buffer is unlikely to contain
+    // an event
+    if (buf_size < sizeof(struct ipc_header_t) || buf_size > sizeof(union ipc_buffer)) {
         return 0;
     }
 
-    const struct ipc_header_t *hdr = (const struct ipc_header_t *)buf;
-    const u32 marker = bpf_ntohl(hdr->marker);
+    union ipc_buffer ev;
+
+    bpf_clamp_umax(buf_size, sizeof(union ipc_buffer));
+
+    if (bpf_probe_read(&ev, buf_size, buf) != 0) {
+        return 0;
+    }
+
+    const u32 marker = bpf_ntohl(ev.hdr.marker);
 
     if (marker != k_ebpf_ipc_magic) {
         return 0;
     }
 
-    switch (hdr->type) {
+    switch (ev.hdr.type) {
     case IPC_EV_NODEJS:
-        return handle_ev_nodejs(hdr, buf_size);
+        return handle_ev_nodejs(&ev);
     }
 
     return 0;

--- a/bpf/generictracer/ebpf_ipc.h
+++ b/bpf/generictracer/ebpf_ipc.h
@@ -101,7 +101,7 @@ static __always_inline int handle_ebpf_ipc(const void *buf, size_t buf_size) {
         return 0;
     }
 
-    ipc_buffer *ev = (ipc_buffer *)ipc_buffer_mem();
+    ipc_buffer *ev = ipc_buffer_mem();
 
     if (!ev) {
         return 0;

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -323,10 +323,6 @@ int BPF_KPROBE(beyla_kprobe_tcp_sendmsg, struct sock *sk, struct msghdr *msg, si
                 if (buf) {
                     size = read_msghdr_buf(msg, buf, size);
 
-                    if (handle_ebpf_ipc(buf, size)) {
-                        return 0;
-                    }
-
                     // If a sock_msg program is installed, this kprobe will fail to
                     // read anything, because the data is in bvec physical pages. However,
                     // the sock_msg will setup a buffer for us if this is the case. We

--- a/bpf/generictracer/k_tracer_defs.h
+++ b/bpf/generictracer/k_tracer_defs.h
@@ -9,6 +9,7 @@
 #include <common/tc_common.h>
 #include <common/trace_common.h>
 
+#include <generictracer/ebpf_ipc.h>
 #include <generictracer/k_tracer_tailcall.h>
 #include <generictracer/protocol_common.h>
 #include <generictracer/protocol_http.h>
@@ -128,6 +129,10 @@ static __always_inline void handle_buf_with_connection(void *ctx,
                                                        u8 ssl,
                                                        u8 direction,
                                                        u16 orig_dport) {
+    if (handle_ebpf_ipc(u_buf, bytes_len)) {
+        return;
+    }
+
     call_protocol_args_t *args = make_protocol_args(u_buf, bytes_len, ssl, direction, orig_dport);
 
     if (!args) {


### PR DESCRIPTION
The original codepath of the ebpf IPC buffers/`handle_ebpf_ipc` could not deal with a corner case in which the originating buffer was coming from a kernel bvec - bvecs represent physical pages that cannot be mapped into the eBPF memory space, and therefore cannot be read.

Because the eBPF IPC payloads are very small (currently 20 bytes), sometimes the kernel is able to detect that they are being sent to a destination inside the same host, and instead of copying the payload, it just shares the memory pages with the receiving end, thus yielding a bvec.

When that happens, we cannot read the IPC payload, and the trace context propagation breaks.

This PR relies on the already implemented fallback mechanisms (such as buffer setup by the http filter program) to defeat this limitation.