### PR TITLE
Add YAML marshaller for services.GlobAttr, PortEnum and RegexpAttr

### DIFF
--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"regexp"
 	"time"
 
 	"github.com/caarlos0/env/v9"
-	"github.com/gobwas/glob"
 	"gopkg.in/yaml.v3"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/ebpf/tcmanager"
@@ -53,8 +51,8 @@ const (
 )
 
 var (
-	k8sDefaultNamespacesRegex = services.NewPathRegexp(regexp.MustCompile("^kube-system$|^kube-node-lease$|^local-path-storage$|^grafana-alloy$|^cert-manager$|^monitoring$" + k8sGKEDefaultNamespacesRegex + k8sAKSDefaultNamespacesRegex))
-	k8sDefaultNamespacesGlob  = services.NewGlob(glob.MustCompile("{kube-system,kube-node-lease,local-path-storage,grafana-alloy,cert-manager,monitoring" + k8sGKEDefaultNamespacesGlob + k8sAKSDefaultNamespacesGlob + "}"))
+	k8sDefaultNamespacesRegex = services.NewRegexp("^kube-system$|^kube-node-lease$|^local-path-storage$|^grafana-alloy$|^cert-manager$|^monitoring$" + k8sGKEDefaultNamespacesRegex + k8sAKSDefaultNamespacesRegex)
+	k8sDefaultNamespacesGlob  = services.NewGlob("{kube-system,kube-node-lease,local-path-storage,grafana-alloy,cert-manager,monitoring" + k8sGKEDefaultNamespacesGlob + k8sAKSDefaultNamespacesGlob + "}")
 )
 
 var DefaultConfig = Config{
@@ -140,7 +138,7 @@ var DefaultConfig = Config{
 		ExcludeOTelInstrumentedServices: true,
 		DefaultExcludeServices: services.RegexDefinitionCriteria{
 			services.RegexSelector{
-				Path: services.NewPathRegexp(regexp.MustCompile("(?:^|/)(beyla$|alloy$|otelcol[^/]*$)")),
+				Path: services.NewRegexp("(?:^|/)(beyla$|alloy$|otelcol[^/]*$)"),
 			},
 			services.RegexSelector{
 				Metadata: map[string]*services.RegexpAttr{"k8s_namespace": &k8sDefaultNamespacesRegex},
@@ -148,7 +146,7 @@ var DefaultConfig = Config{
 		},
 		DefaultExcludeInstrument: services.GlobDefinitionCriteria{
 			services.GlobAttributes{
-				Path: services.NewGlob(glob.MustCompile("{*beyla,*alloy,*ebpf-instrument,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*}")),
+				Path: services.NewGlob("{*beyla,*alloy,*ebpf-instrument,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*}"),
 			},
 			services.GlobAttributes{
 				Metadata: map[string]*services.GlobAttr{"k8s_namespace": &k8sDefaultNamespacesGlob},

--- a/pkg/beyla/config_test.go
+++ b/pkg/beyla/config_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gobwas/glob"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -213,7 +212,7 @@ network:
 			ExcludeOTelInstrumentedServices: true,
 			DefaultExcludeServices: services.RegexDefinitionCriteria{
 				services.RegexSelector{
-					Path: services.NewPathRegexp(regexp.MustCompile("(?:^|/)(beyla$|alloy$|otelcol[^/]*$)")),
+					Path: services.NewRegexp("(?:^|/)(beyla$|alloy$|otelcol[^/]*$)"),
 				},
 				services.RegexSelector{
 					Metadata: map[string]*services.RegexpAttr{"k8s_namespace": &k8sDefaultNamespacesRegex},
@@ -221,7 +220,7 @@ network:
 			},
 			DefaultExcludeInstrument: services.GlobDefinitionCriteria{
 				services.GlobAttributes{
-					Path: services.NewGlob(glob.MustCompile("{*beyla,*alloy,*ebpf-instrument,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*}")),
+					Path: services.NewGlob("{*beyla,*alloy,*ebpf-instrument,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*}"),
 				},
 				services.GlobAttributes{
 					Metadata: map[string]*services.GlobAttr{"k8s_namespace": &k8sDefaultNamespacesGlob},

--- a/pkg/components/discover/matcher_test.go
+++ b/pkg/components/discover/matcher_test.go
@@ -1,10 +1,8 @@
 package discover
 
 import (
-	"regexp"
 	"testing"
 
-	"github.com/gobwas/glob"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -362,18 +360,18 @@ func TestInstrumentation_CoexistingWithDeprecatedServices(t *testing.T) {
 		name string
 		cfg  beyla.Config
 	}
-	pass := services.NewGlob(glob.MustCompile("*/must-pass"))
-	notPass := services.NewGlob(glob.MustCompile("*/dont-pass"))
-	neitherPass := services.NewGlob(glob.MustCompile("*/neither-pass"))
-	bothPass := services.NewGlob(glob.MustCompile("*/{must,also}-pass"))
+	pass := services.NewGlob("*/must-pass")
+	notPass := services.NewGlob("*/dont-pass")
+	neitherPass := services.NewGlob("*/neither-pass")
+	bothPass := services.NewGlob("*/{must,also}-pass")
 
 	passPort := services.PortEnum{Ranges: []services.PortRange{{Start: 80}}}
 	allPorts := services.PortEnum{Ranges: []services.PortRange{{Start: 1, End: 65535}}}
 
-	passRE := services.NewPathRegexp(regexp.MustCompile("must-pass"))
-	notPassRE := services.NewPathRegexp(regexp.MustCompile("dont-pass"))
-	neitherPassRE := services.NewPathRegexp(regexp.MustCompile("neither-pass"))
-	bothPassRE := services.NewPathRegexp(regexp.MustCompile("(must|also)-pass"))
+	passRE := services.NewRegexp("must-pass")
+	notPassRE := services.NewRegexp("dont-pass")
+	neitherPassRE := services.NewRegexp("neither-pass")
+	bothPassRE := services.NewRegexp("(must|also)-pass")
 
 	for _, tc := range []testCase{
 		{name: "discovery > instrument", cfg: beyla.Config{Discovery: services.DiscoveryConfig{
@@ -411,7 +409,7 @@ func TestInstrumentation_CoexistingWithDeprecatedServices(t *testing.T) {
 			name: "discovery > instrument ignoring deprecated path option",
 			cfg: beyla.Config{Discovery: services.DiscoveryConfig{
 				Instrument: services.GlobDefinitionCriteria{{Path: pass}, {OpenPorts: passPort}},
-			}, Exec: services.NewPathRegexp(regexp.MustCompile("dont-pass"))},
+			}, Exec: services.NewRegexp("dont-pass")},
 		},
 		// cases below would be removed if the deprecated discovery > services options are removed,
 		{name: "deprecated discovery > services", cfg: beyla.Config{Discovery: services.DiscoveryConfig{

--- a/pkg/services/attr_glob.go
+++ b/pkg/services/attr_glob.go
@@ -74,11 +74,13 @@ type GlobAttributes struct {
 
 // GlobAttr provides a YAML handler for glob.Glob so the type can be parsed from YAML or environment variables
 type GlobAttr struct {
+	// str is kept for debugging/printing purposes
+	str  string
 	glob glob.Glob
 }
 
-func NewGlob(g glob.Glob) GlobAttr {
-	return GlobAttr{glob: g}
+func NewGlob(pattern string) GlobAttr {
+	return GlobAttr{str: pattern, glob: glob.MustCompile(pattern)}
 }
 
 func (p *GlobAttr) IsSet() bool {
@@ -98,8 +100,13 @@ func (p *GlobAttr) UnmarshalYAML(value *yaml.Node) error {
 	if err != nil {
 		return fmt.Errorf("invalid regular expression in node %s: %w", value.Tag, err)
 	}
+	p.str = value.Value
 	p.glob = re
 	return nil
+}
+
+func (p GlobAttr) MarshalYAML() (any, error) {
+	return p.str, nil
 }
 
 func (p *GlobAttr) UnmarshalText(text []byte) error {

--- a/pkg/services/attr_regex.go
+++ b/pkg/services/attr_regex.go
@@ -83,8 +83,8 @@ type RegexpAttr struct {
 	re *regexp.Regexp
 }
 
-func NewPathRegexp(re *regexp.Regexp) RegexpAttr {
-	return RegexpAttr{re: re}
+func NewRegexp(pattern string) RegexpAttr {
+	return RegexpAttr{re: regexp.MustCompile(pattern)}
 }
 
 func (p *RegexpAttr) IsSet() bool {
@@ -105,6 +105,10 @@ func (p *RegexpAttr) UnmarshalYAML(value *yaml.Node) error {
 	}
 	p.re = re
 	return nil
+}
+
+func (p RegexpAttr) MarshalYAML() (any, error) {
+	return p.re.String(), nil
 }
 
 func (p *RegexpAttr) UnmarshalText(text []byte) error {

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bytes"
 	"fmt"
 	"iter"
 	"regexp"
@@ -163,6 +164,21 @@ func (p *PortEnum) UnmarshalYAML(value *yaml.Node) error {
 		return fmt.Errorf("PortEnum: unexpected YAML node kind %d", value.Kind)
 	}
 	return p.UnmarshalText([]byte(value.Value))
+}
+
+func (p PortEnum) MarshalYAML() (any, error) {
+	sb := bytes.Buffer{}
+	for i, r := range p.Ranges {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(strconv.Itoa(r.Start))
+		if r.End > 0 {
+			sb.WriteByte('-')
+			sb.WriteString(strconv.Itoa(r.End))
+		}
+	}
+	return sb.String(), nil
 }
 
 func (p *PortEnum) UnmarshalText(text []byte) error {


### PR DESCRIPTION
This introduces a breaking change at API level: `services.NewGlob` and `services.NewPathRegexp` now receive directly a string (they were always invoked with `regexp/glob.MustCompile` as they are just internal utility functions).
Also `services.NewPathRegexp` has been renamed to `NewRegexp` for coherence.