### PR TITLE
Switch nodejs inspector line to debug

### DIFF
--- a/pkg/components/nodejs/injector.go
+++ b/pkg/components/nodejs/injector.go
@@ -210,7 +210,7 @@ func (ctx *connectionContext) readLoop() {
 		_, msg, err := ctx.wsConn.ReadMessage()
 		if err != nil {
 			if !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
-				ctx.log.Error("WebSocket read error", "error", err)
+				ctx.log.Debug("WebSocket read error", "error", err)
 			}
 
 			ctx.wsConn.Close()


### PR DESCRIPTION
The websocket can throw an error in number of cases, namely error 105 (no status) is common. Moving this line to debug to avoid confusion with users.