### PR TITLE
Fix Prometheus export span metric name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ test/integration/components/testserver_1.17/vendor/*
 *_bpfel.o
 pkg/internal/otelsdk/grafana-opentelemetry-java.jar
 opentelemetry-ebpf-instrumentation.sln
+obi.sln

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -482,8 +482,12 @@ func (mr *MetricsReporter) otelMetricOptions(mlog *slog.Logger) []metric.Option 
 	return opts
 }
 
+func (mr *MetricsReporter) usesOTelSpanNames() bool {
+	return slices.Contains(mr.cfg.Features, FeatureSpan)
+}
+
 func (mr *MetricsReporter) spanMetricsLatencyName() string {
-	if slices.Contains(mr.cfg.Features, FeatureSpan) {
+	if mr.usesOTelSpanNames() {
 		return SpanMetricsLatency
 	}
 
@@ -650,7 +654,7 @@ func (mr *MetricsReporter) setupOtelMeters(m *Metrics, meter instrument.Meter) e
 }
 
 func (mr *MetricsReporter) spanMetricsCallsName() string {
-	if slices.Contains(mr.cfg.Features, FeatureSpan) {
+	if mr.usesOTelSpanNames() {
 		return SpanMetricsCalls
 	}
 
@@ -703,7 +707,13 @@ func (mr *MetricsReporter) setupSpanMeters(m *Metrics, meter instrument.Meter) e
 
 	spanMetricAttrs := mr.spanMetricAttributes()
 
-	spanMetricsLatency, err := meter.Float64Histogram(mr.spanMetricsLatencyName())
+	instrumentOpts := []instrument.Float64HistogramOption{}
+
+	if mr.usesOTelSpanNames() {
+		instrumentOpts = append(instrumentOpts, instrument.WithUnit("s"))
+	}
+
+	spanMetricsLatency, err := meter.Float64Histogram(mr.spanMetricsLatencyName(), instrumentOpts...)
 	if err != nil {
 		return fmt.Errorf("creating span metric histogram for latency: %w", err)
 	}

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -482,12 +482,12 @@ func (mr *MetricsReporter) otelMetricOptions(mlog *slog.Logger) []metric.Option 
 	return opts
 }
 
-func (mr *MetricsReporter) usesOTelSpanNames() bool {
+func (mr *MetricsReporter) usesLegacySpanNames() bool {
 	return slices.Contains(mr.cfg.Features, FeatureSpan)
 }
 
 func (mr *MetricsReporter) spanMetricsLatencyName() string {
-	if mr.usesOTelSpanNames() {
+	if mr.usesLegacySpanNames() {
 		return SpanMetricsLatency
 	}
 
@@ -654,7 +654,7 @@ func (mr *MetricsReporter) setupOtelMeters(m *Metrics, meter instrument.Meter) e
 }
 
 func (mr *MetricsReporter) spanMetricsCallsName() string {
-	if mr.usesOTelSpanNames() {
+	if mr.usesLegacySpanNames() {
 		return SpanMetricsCalls
 	}
 
@@ -709,7 +709,7 @@ func (mr *MetricsReporter) setupSpanMeters(m *Metrics, meter instrument.Meter) e
 
 	instrumentOpts := []instrument.Float64HistogramOption{}
 
-	if mr.usesOTelSpanNames() {
+	if !mr.usesLegacySpanNames() {
 		instrumentOpts = append(instrumentOpts, instrument.WithUnit("s"))
 	}
 

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -33,7 +33,7 @@ var timeNow = time.Now
 // but following the different naming conventions
 const (
 	SpanMetricsLatency       = "traces_spanmetrics_latency"
-	SpanMetricsLatencyOTel   = "traces_span_metrics_duration"
+	SpanMetricsLatencyOTel   = "traces_span_metrics_duration_seconds"
 	SpanMetricsCalls         = "traces_spanmetrics_calls_total"
 	SpanMetricsCallsOTel     = "traces_span_metrics_calls_total"
 	SpanMetricsRequestSizes  = "traces_spanmetrics_size_total"

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -126,7 +126,7 @@ func testSpanMetricsForHTTPLibraryOTelFormat(t *testing.T, svcName, svcNs string
 	// Test span metrics
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		var err error
-		results, err = pq.Query(`traces_span_metrics_duration_count{` +
+		results, err = pq.Query(`traces_span_metrics_duration_seconds_count{` +
 			`span_kind="SPAN_KIND_SERVER",` +
 			`status_code="STATUS_CODE_UNSET",` + // 404 is OK for server spans
 			`service_namespace="` + svcNs + `",` +


### PR DESCRIPTION
We are missing "_seconds" for the Prometheus side for the new OTel Span metrics format.