### PR TITLE
cleanup: replace some `bpf_printk` with `bpf_dbg_printk`

### DIFF
--- a/bpf/generictracer/k_unix_sock.h
+++ b/bpf/generictracer/k_unix_sock.h
@@ -58,7 +58,7 @@ int BPF_KPROBE(beyla_kprobe_unix_stream_recvmsg,
         return 0;
     }
 
-    bpf_printk("=== unix_stream recvmsg %d ===", id);
+    bpf_dbg_printk("=== unix_stream recvmsg %d ===", id);
 
     struct sock *sk;
     BPF_CORE_READ_INTO(&sk, sock, sk);
@@ -225,7 +225,7 @@ int BPF_KPROBE(beyla_kprobe_unix_stream_sendmsg,
         return 0;
     }
 
-    bpf_printk("=== unix_stream sendmsg %d ===", id);
+    bpf_dbg_printk("=== unix_stream sendmsg %d ===", id);
 
     struct sock *sk;
     BPF_CORE_READ_INTO(&sk, sock, sk);

--- a/bpf/gotracer/go_grpc.c
+++ b/bpf/gotracer/go_grpc.c
@@ -194,9 +194,9 @@ SEC("uprobe/serverHandlerTransport_HandleStreams")
 int beyla_uprobe_server_handler_transport_handle_streams(struct pt_regs *ctx) {
     void *tr = GO_PARAM1(ctx);
     void *goroutine_addr = GOROUTINE_PTR(ctx);
-    bpf_printk("=== uprobe/serverHandlerTransport_HandleStreams tr %llx goroutine %lx === ",
-               tr,
-               goroutine_addr);
+    bpf_dbg_printk("=== uprobe/serverHandlerTransport_HandleStreams tr %llx goroutine %lx === ",
+                   tr,
+                   goroutine_addr);
 
     go_addr_key_t g_key = {};
     go_addr_key_from_id(&g_key, goroutine_addr);

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -109,8 +109,8 @@ static __always_inline void bpf_sock_ops_establish_cb(struct bpf_sock_ops *skops
         sk_ops_extract_key_ip4(skops, &conn);
     }
 
-    bpf_printk("SET s_ip[3]: %llx s_port: %d", conn.s_ip[3], conn.s_port);
-    bpf_printk("SET d_ip[3]: %llx d_port: %d", conn.d_ip[3], conn.d_port);
+    bpf_dbg_printk("SET s_ip[3]: %llx s_port: %d", conn.s_ip[3], conn.s_port);
+    bpf_dbg_printk("SET d_ip[3]: %llx d_port: %d", conn.d_ip[3], conn.d_port);
 
     bpf_sock_hash_update(skops, &sock_dir, &conn, BPF_ANY);
 }


### PR DESCRIPTION
While running the code, I noticed some `bpf_printk` that could be leftovers since they seem to be called frequently or at least at each bpf prog invocation. If this is not the case and they are intentional, feel free to close this one :) 
