### PR TITLE
docs: define the OBI abbreviation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This repository provides eBPF instrumentation based on the OpenTelemetry standard.
 It provides a lightweight and efficient way to collect telemetry data using eBPF for user-space applications.
 
+**O**penTelemetry e-**B**PF **I**nstrumentation is commonly referred to as OBIgo.
+
 :construction: This project is currently work in progress.
 
 ## How to start developing
@@ -26,5 +28,5 @@ the [test/integration](./test/integration) and [test/integration/k8s](./test/int
 
 ## License
 
-OpenTelemetry eBPF Instrumentation is licensed under the terms of the [Apache Software License version 2.0].
+OpenTelemetry eBPF Instrumentation is licensed under the terms of the Apache Software License version 2.0.
 See the [license file](./LICENSE) for more details.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository provides eBPF instrumentation based on the OpenTelemetry standard.
 It provides a lightweight and efficient way to collect telemetry data using eBPF for user-space applications.
 
-**O**penTelemetry e-**B**PF **I**nstrumentation is commonly referred to as OBIgo.
+**O**penTelemetry e-**B**PF **I**nstrumentation is commonly referred to as OBI.
 
 :construction: This project is currently work in progress.
 


### PR DESCRIPTION
I know that **OBI** term is commonly used by OTel Go Auto-Instrumentation SIG.
 I think we should document this term for transparency.

CC @open-telemetry/go-instrumentation-maintainers 