### PR TITLE
cleanup: rename socket filter prog in netolly

### DIFF
--- a/bpf/netolly/flows_sock.c
+++ b/bpf/netolly/flows_sock.c
@@ -181,8 +181,8 @@ static __always_inline bool same_ip(const u8 *ip1, const u8 *ip2) {
     return true;
 }
 
-SEC("socket/http_filter")
-int beyla_socket__http_filter(struct __sk_buff *skb) {
+SEC("socket/filter")
+int beyla_socket__filter(struct __sk_buff *skb) {
     // If sampling is defined, will only parse 1 out of "sampling" flows
     if (sampling != 0 && (bpf_get_prandom_u32() % sampling) != 0) {
         return TC_ACT_UNSPEC;

--- a/pkg/components/netolly/ebpf/sock_tracer.go
+++ b/pkg/components/netolly/ebpf/sock_tracer.go
@@ -88,7 +88,7 @@ func NewSockFlowFetcher(
 
 	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ALL)))
 	if err == nil {
-		ssoErr := syscall.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_ATTACH_BPF, objects.BeylaSocketHttpFilter.FD())
+		ssoErr := syscall.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_ATTACH_BPF, objects.BeylaSocketFilter.FD())
 		if ssoErr != nil {
 			return nil, fmt.Errorf("loading and assigning BPF objects: %w", ssoErr)
 		}
@@ -145,7 +145,7 @@ func (m *SockFlowFetcher) Close() error {
 
 func (m *SockFlowFetcher) closeObjects() []error {
 	var errs []error
-	if err := m.objects.BeylaSocketHttpFilter.Close(); err != nil {
+	if err := m.objects.BeylaSocketFilter.Close(); err != nil {
 		errs = append(errs, err)
 	}
 	if err := m.objects.AggregatedFlows.Close(); err != nil {


### PR DESCRIPTION
If you run together netolly and appolly, you will see 2 EBPF programs with the same name `beyla_socket__http_filter`.  This is not ideal if you want to debug/benchmark EBPF programs. Moreover, this is not an HTTP-specific code, so it could make sense to change its name.