### PR TITLE
GH generator image action: fix autoversion

### DIFF
--- a/.github/workflows/generator-image.yml
+++ b/.github/workflows/generator-image.yml
@@ -60,7 +60,7 @@ jobs:
             TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64)
           
             # Fetch tags from GHCR API
-            TAGS=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            TAGS=$(curl -s -H "Authorization: Bearer ${{ TOKEN }}" \
               "https://${{ env.REGISTRY }}/v2/${{ env.IMAGE }}/tags/list")
             echo "Image tags: ${TAGS}"
           


### PR DESCRIPTION
The Publish OBI generator image action was failing because this error:
```
Fetching latest version from ghcr.io/open-telemetry/obi-generator...
Image tags: {"errors":[{"code":"DENIED","message":"invalid token"}]}
jq: error (at <stdin>:1): Cannot iterate over null (null)
```

It is because we were passing a wrong token.