### PR TITLE
tpinjector: remove verbose debug message

### DIFF
--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -109,9 +109,6 @@ static __always_inline void bpf_sock_ops_establish_cb(struct bpf_sock_ops *skops
         sk_ops_extract_key_ip4(skops, &conn);
     }
 
-    bpf_dbg_printk("SET s_ip[3]: %llx s_port: %d", conn.s_ip[3], conn.s_port);
-    bpf_dbg_printk("SET d_ip[3]: %llx d_port: %d", conn.d_ip[3], conn.d_port);
-
     bpf_sock_hash_update(skops, &sock_dir, &conn, BPF_ANY);
 }
 


### PR DESCRIPTION
These messages happen too often and end up polluting the log to an unreadable state.