### PR TITLE
Fix traces_service_graph_request_total double count

### DIFF
--- a/pkg/components/svc/svc.go
+++ b/pkg/components/svc/svc.go
@@ -55,12 +55,21 @@ const (
 	exportsOTelMetricsSpan idFlags = 0x8
 )
 
+type ServiceNameNamespace struct {
+	Name      string
+	Namespace string
+}
+
 // UID uniquely identifies a service instance across the whole system
 // according to the OpenTelemetry specification: (name, namespace, instance)
 type UID struct {
 	Name      string
 	Namespace string
 	Instance  string
+}
+
+func (uid *UID) NameNamespace() ServiceNameNamespace {
+	return ServiceNameNamespace{Name: uid.Name, Namespace: uid.Namespace}
 }
 
 // Attrs stores the metadata attributes of a service/resource

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -1145,12 +1145,19 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 				if span.IsClientSpan() {
 					sgc, attrs := r.serviceGraphClient.ForRecord(span)
 					sgc.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+					if span.HostName != "" {
+						n := svc.ServiceNameNamespace{Name: span.HostName, Namespace: span.OtherNamespace}
+						if !mr.pidTracker.IsTrackingServerService(n) {
+							sgt, attrs := r.serviceGraphTotal.ForRecord(span)
+							sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+						}
+					}
 				} else {
 					sgs, attrs := r.serviceGraphServer.ForRecord(span)
 					sgs.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+					sgt, attrs := r.serviceGraphTotal.ForRecord(span)
+					sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 				}
-				sgt, attrs := r.serviceGraphTotal.ForRecord(span)
-				sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 				if request.SpanStatusCode(span) == request.StatusCodeError {
 					sgf, attrs := r.serviceGraphFailed.ForRecord(span)
 					sgf.Add(ctx, 1, instrument.WithAttributeSet(attrs))

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -1145,12 +1145,12 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 				if span.IsClientSpan() {
 					sgc, attrs := r.serviceGraphClient.ForRecord(span)
 					sgc.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-					if span.HostName != "" {
-						n := svc.ServiceNameNamespace{Name: span.HostName, Namespace: span.OtherNamespace}
-						if !mr.pidTracker.IsTrackingServerService(n) {
-							sgt, attrs := r.serviceGraphTotal.ForRecord(span)
-							sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
-						}
+					// If we managed to resolve the remote name only, we check to see
+					// we are not instrumenting the server service, then and only then,
+					// we generate client span count for service graph total
+					if ClientSpanToUninstrumentedService(&mr.pidTracker, span) {
+						sgt, attrs := r.serviceGraphTotal.ForRecord(span)
+						sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 					}
 				} else {
 					sgs, attrs := r.serviceGraphServer.ForRecord(span)
@@ -1165,6 +1165,18 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 			}
 		}
 	}
+}
+
+func ClientSpanToUninstrumentedService(tracker *PidServiceTracker, span *request.Span) bool {
+	if span.HostName != "" {
+		n := svc.ServiceNameNamespace{Name: span.HostName, Namespace: span.OtherNamespace}
+		return !tracker.IsTrackingServerService(n)
+	}
+	// If we haven't resolved a hostname, don't add this node to the service graph
+	// it will appear only in client requests. Essentially, in this case we have no
+	// idea if the service is instrumented or not, therefore we take the conservative
+	// approach to avoid double counting.
+	return false
 }
 
 func (mr *MetricsReporter) createTargetInfo(reporter *Metrics) {

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -945,3 +945,33 @@ func getKeys(m map[string]string) []string {
 	}
 	return keys
 }
+
+func TestClientSpanToUninstrumentedService(t *testing.T) {
+	tracker := NewPidServiceTracker()
+	uid := svc.UID{Name: "foo", Namespace: "bar"}
+	tracker.AddPID(1, uid)
+
+	spanInstrumented := &request.Span{
+		HostName:       "foo",
+		OtherNamespace: "bar",
+	}
+	if ClientSpanToUninstrumentedService(&tracker, spanInstrumented) {
+		t.Errorf("Expected false for instrumented service, got true")
+	}
+
+	spanUninstrumented := &request.Span{
+		HostName:       "baz",
+		OtherNamespace: "qux",
+	}
+	if !ClientSpanToUninstrumentedService(&tracker, spanUninstrumented) {
+		t.Errorf("Expected true for uninstrumented service, got false")
+	}
+
+	spanNoHost := &request.Span{
+		HostName:       "",
+		OtherNamespace: "bar",
+	}
+	if ClientSpanToUninstrumentedService(&tracker, spanNoHost) {
+		t.Errorf("Expected false for span with no HostName, got true")
+	}
+}

--- a/pkg/export/otel/pid_tracker_test.go
+++ b/pkg/export/otel/pid_tracker_test.go
@@ -1,0 +1,135 @@
+package otel
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/svc"
+)
+
+func makeUID(name, ns string) svc.UID {
+	return svc.UID{
+		Name:      name,
+		Namespace: ns,
+	}
+}
+
+func makeNameNamespace(name, ns string) svc.ServiceNameNamespace {
+	return svc.ServiceNameNamespace{
+		Name:      name,
+		Namespace: ns,
+	}
+}
+
+func TestPidServiceTracker_AddAndRemovePID(t *testing.T) {
+	tracker := NewPidServiceTracker()
+	uid := makeUID("foo", "bar")
+	pid := int32(1234)
+
+	tracker.AddPID(pid, uid)
+
+	if got, ok := tracker.pidToService[pid]; !ok || got != uid {
+		t.Errorf("AddPID: pidToService not set correctly, got %v, want %v", got, uid)
+	}
+	if _, ok := tracker.servicePIDs[uid][pid]; !ok {
+		t.Errorf("AddPID: servicePIDs not set correctly")
+	}
+	if got, ok := tracker.names[uid.NameNamespace()]; !ok || got != uid {
+		t.Errorf("AddPID: names not set correctly, got %v, want %v", got, uid)
+	}
+
+	removed, removedUID := tracker.RemovePID(pid)
+	if !removed {
+		t.Errorf("RemovePID: should return true when last pid removed")
+	}
+	if removedUID != uid {
+		t.Errorf("RemovePID: should return correct UID, got %v, want %v", removedUID, uid)
+	}
+	if _, ok := tracker.pidToService[pid]; ok {
+		t.Errorf("RemovePID: pidToService not deleted")
+	}
+	if _, ok := tracker.servicePIDs[uid]; ok {
+		t.Errorf("RemovePID: servicePIDs not deleted")
+	}
+	if _, ok := tracker.names[uid.NameNamespace()]; ok {
+		t.Errorf("RemovePID: names not deleted")
+	}
+}
+
+func TestPidServiceTracker_RemovePID_NotLast(t *testing.T) {
+	tracker := NewPidServiceTracker()
+	uid := makeUID("foo", "bar")
+	pid1 := int32(1)
+	pid2 := int32(2)
+	tracker.AddPID(pid1, uid)
+	tracker.AddPID(pid2, uid)
+
+	removed, removedUID := tracker.RemovePID(pid1)
+	if removed {
+		t.Errorf("RemovePID: should return false when not last pid removed")
+	}
+	if removedUID != (svc.UID{}) {
+		t.Errorf("RemovePID: should return zero UID when not last pid removed")
+	}
+	if _, ok := tracker.pidToService[pid1]; ok {
+		t.Errorf("RemovePID: pidToService not deleted for pid1")
+	}
+	if _, ok := tracker.servicePIDs[uid][pid1]; ok {
+		t.Errorf("RemovePID: servicePIDs not deleted for pid1")
+	}
+	if _, ok := tracker.names[uid.NameNamespace()]; !ok {
+		t.Errorf("RemovePID: names should still exist")
+	}
+}
+
+func TestPidServiceTracker_RemovePID_Last(t *testing.T) {
+	tracker := NewPidServiceTracker()
+	uid := makeUID("foo", "bar")
+	pid1 := int32(1)
+	pid2 := int32(2)
+	tracker.AddPID(pid1, uid)
+	tracker.AddPID(pid2, uid)
+
+	removed, removedUID := tracker.RemovePID(pid1)
+	if removed {
+		t.Errorf("RemovePID: should return false when not last pid removed")
+	}
+	if removedUID != (svc.UID{}) {
+		t.Errorf("RemovePID: should return zero UID when not last pid removed")
+	}
+	removed, removedUID = tracker.RemovePID(pid2)
+	if !removed {
+		t.Errorf("RemovePID: should return true when last pid removed")
+	}
+	if removedUID == (svc.UID{}) {
+		t.Errorf("RemovePID: should return non zero UID when last pid removed")
+	}
+	if _, ok := tracker.pidToService[pid1]; ok {
+		t.Errorf("RemovePID: pidToService not deleted for pid1")
+	}
+	if _, ok := tracker.pidToService[pid2]; ok {
+		t.Errorf("RemovePID: pidToService not deleted for pid2")
+	}
+	if _, ok := tracker.servicePIDs[uid]; ok {
+		t.Errorf("RemovePID: servicePIDs not deleted for both pids")
+	}
+	if _, ok := tracker.names[uid.NameNamespace()]; ok {
+		t.Errorf("RemovePID: names should not exist")
+	}
+}
+
+func TestPidServiceTracker_IsTrackingServerService(t *testing.T) {
+	tracker := NewPidServiceTracker()
+	uid := makeUID("foo", "bar")
+	tracker.AddPID(42, uid)
+	nameNs := uid.NameNamespace()
+	if !tracker.IsTrackingServerService(nameNs) {
+		t.Errorf("IsTrackingServerService: should return true for tracked service")
+	}
+	if !tracker.IsTrackingServerService(makeNameNamespace("foo", "bar")) {
+		t.Errorf("IsTrackingServerService: should return true for tracked service")
+	}
+	other := makeNameNamespace("other", "bar")
+	if tracker.IsTrackingServerService(other) {
+		t.Errorf("IsTrackingServerService: should return false for untracked service")
+	}
+}

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -922,12 +922,9 @@ func (r *metricsReporter) observe(span *request.Span) {
 					r.serviceGraphClient.WithLabelValues(lvg...).Metric.Observe(duration)
 					// If we managed to resolve the remote name only, we check to see
 					// we are not instrumenting the server service, then and only then,
-					// we generate span count for service graph total
-					if span.HostName != "" {
-						n := svc.ServiceNameNamespace{Name: span.HostName, Namespace: span.OtherNamespace}
-						if !r.pidsTracker.IsTrackingServerService(n) {
-							r.serviceGraphTotal.WithLabelValues(lvg...).Metric.Add(1)
-						}
+					// we generate client span count for service graph total
+					if otel.ClientSpanToUninstrumentedService(&r.pidsTracker, span) {
+						r.serviceGraphTotal.WithLabelValues(lvg...).Metric.Add(1)
 					}
 				} else {
 					r.serviceGraphServer.WithLabelValues(lvg...).Metric.Observe(duration)

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -920,10 +920,19 @@ func (r *metricsReporter) observe(span *request.Span) {
 				lvg := r.labelValuesServiceGraph(span)
 				if span.IsClientSpan() {
 					r.serviceGraphClient.WithLabelValues(lvg...).Metric.Observe(duration)
+					// If we managed to resolve the remote name only, we check to see
+					// we are not instrumenting the server service, then and only then,
+					// we generate span count for service graph total
+					if span.HostName != "" {
+						n := svc.ServiceNameNamespace{Name: span.HostName, Namespace: span.OtherNamespace}
+						if !r.pidsTracker.IsTrackingServerService(n) {
+							r.serviceGraphTotal.WithLabelValues(lvg...).Metric.Add(1)
+						}
+					}
 				} else {
 					r.serviceGraphServer.WithLabelValues(lvg...).Metric.Observe(duration)
+					r.serviceGraphTotal.WithLabelValues(lvg...).Metric.Add(1)
 				}
-				r.serviceGraphTotal.WithLabelValues(lvg...).Metric.Add(1)
 				if request.SpanStatusCode(span) == request.StatusCodeError {
 					r.serviceGraphFailed.WithLabelValues(lvg...).Metric.Add(1)
 				}


### PR DESCRIPTION
The span metrics generation had a subtle bug where the series `traces_service_graph_request_total` was double counted if OBI would see both the client and the server call. Namely, for two services A and B, talking to each other, via say an API `/hello`, we'd count once for this series on the client call A->B and another time on the server call A->B.

Here's an example of a service graph like this:
![image](https://github.com/user-attachments/assets/8b587c77-5105-491b-9b75-9450d0dc9d10)

To fix this, I extended the pid tracker we use for both the OTel and Prometheus export to keep a map of instrumented services, by their name/namespace, which is the key we use for service graphs. We now count server calls only, unless the target server service is not instrumented. To do this verification, we check if the span has resolved a hostname, meaning OBI found more than it's IP address and then we check if the determined name has already been seen.

Tests added for some missing files too.