### PR TITLE
Disable flaky JSON-RPC test

### DIFF
--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -766,6 +766,7 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 		)
 		assert.Empty(t, sd, sd.String())
 
+		/* FIXME flaky
 		// Check the information of the go jsonrpc parent span
 		res = trace.FindByOperationName("Arith.T /jsonrpc", "server")
 		require.Len(t, res, 1)
@@ -785,6 +786,7 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 			jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
 		)
 		assert.Empty(t, sd, sd.String())
+		*/
 
 		// Check the information of the python parent span
 		res = trace.FindByOperationName("GET /tracemetoo", "server")


### PR DESCRIPTION
The test is flaky, working only sometimes, and is preventing other PRs from progressing. It was first introduced by https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/161.
