### PR TITLE
fix: use tcp_sendmsg instead of tcp_sendmsg_locked

### DIFF
--- a/pkg/components/ebpf/generictracer/generictracer.go
+++ b/pkg/components/ebpf/generictracer/generictracer.go
@@ -286,7 +286,7 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {
 			Required: true,
 			Start:    p.bpfObjects.BeylaKprobeTcpClose,
 		},
-		"tcp_sendmsg_locked": {
+		"tcp_sendmsg": {
 			Required: true,
 			Start:    p.bpfObjects.BeylaKprobeTcpSendmsg,
 			End:      p.bpfObjects.BeylaKretprobeTcpSendmsg,


### PR DESCRIPTION
This PR changes which kernel symbol is used to monitor TCP message sending from `tcp_sendmsg_locked` to `tcp_sendmsg`.

After pairing with @grcevski, we found that the use of `tcp_sendmsg_locked` was incompatible with the orbstack kernel `6.14.10-orbstack-00291-g1b252bd3edea`, even though `tcp_sendmsg_locked` was found to be present in `/proc/kallsyms`.

It could be that the use of `sock_*` BPF programs are changing the kernel execution path, which might cause the `tcp_sendmsg_locked()` function to never be called.

The `tcp_sendmsg_locked` symbol is also known to not always be available on certain kernel configurations.