### PR TITLE
Fix panic due invalid UTF-8 labels

### DIFF
--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -1067,9 +1068,25 @@ func labelNames[T any](getters []attributes.Field[T, string]) []string {
 func labelValues[T any](s T, getters []attributes.Field[T, string]) []string {
 	values := make([]string, 0, len(getters))
 	for _, getter := range getters {
-		values = append(values, getter.Get(s))
+		rawValue := getter.Get(s)
+		validatedValue := validateUTF8ForPrometheus(rawValue, getter.ExposedName)
+		values = append(values, validatedValue)
 	}
 	return values
+}
+
+// validateUTF8ForPrometheus checks if a string contains valid UTF-8 characters.
+func validateUTF8ForPrometheus(s, labelName string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+
+	// Log error and return empty string for invalid UTF-8
+	mlog().Error("invalid UTF-8 string detected in Prometheus label",
+		"label_name", labelName,
+		"invalid_value", s,
+		"length", len(s))
+	return ""
 }
 
 func (r *metricsReporter) createTargetInfo(service *svc.Attrs) {

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -1069,24 +1069,19 @@ func labelValues[T any](s T, getters []attributes.Field[T, string]) []string {
 	values := make([]string, 0, len(getters))
 	for _, getter := range getters {
 		rawValue := getter.Get(s)
-		validatedValue := validateUTF8ForPrometheus(rawValue, getter.ExposedName)
-		values = append(values, validatedValue)
+		sanitizedValue := sanitizeUTF8ForPrometheus(rawValue)
+		values = append(values, sanitizedValue)
 	}
 	return values
 }
 
-// validateUTF8ForPrometheus checks if a string contains valid UTF-8 characters.
-func validateUTF8ForPrometheus(s, labelName string) string {
+// sanitizeUTF8ForPrometheus sanitizes a string to ensure it contains only valid UTF-8 characters.
+// Invalid UTF-8 sequences are removed entirely.
+func sanitizeUTF8ForPrometheus(s string) string {
 	if utf8.ValidString(s) {
 		return s
 	}
-
-	// Log error and return empty string for invalid UTF-8
-	mlog().Error("invalid UTF-8 string detected in Prometheus label",
-		"label_name", labelName,
-		"invalid_value", s,
-		"length", len(s))
-	return ""
+	return strings.ToValidUTF8(s, "")
 }
 
 func (r *metricsReporter) createTargetInfo(service *svc.Attrs) {

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -610,47 +610,43 @@ func makePromExporter(
 	return exporter
 }
 
-func TestValidateUTF8ForPrometheus(t *testing.T) {
+func TestSanitizeUTF8ForPrometheus(t *testing.T) {
 	tests := []struct {
 		name      string
 		input     string
 		labelName string
 		expected  string
-		shouldLog bool
 	}{
 		{
-			name:      "valid UTF-8 string",
-			input:     "valid-string",
-			labelName: "test_label",
-			expected:  "valid-string",
-			shouldLog: false,
+			name:     "valid UTF-8 string",
+			input:    "valid-string",
+			expected: "valid-string",
 		},
 		{
-			name:      "empty string",
-			input:     "",
-			labelName: "test_label",
-			expected:  "",
-			shouldLog: false,
+			name:     "empty string",
+			input:    "",
+			expected: "",
 		},
 		{
-			name:      "binary data with null bytes",
-			input:     "deb.debian.or 1498318199  0     0     100644  828       `\n\x1f\x8b\b",
-			labelName: "metadata_field",
-			expected:  "",
-			shouldLog: true,
+			name:     "binary data with null bytes",
+			input:    "deb.debian.or 1498318199  0     0     100644  828       `\n\x1f\x8b\b",
+			expected: "deb.debian.or 1498318199  0     0     100644  828       `\n\x1f\b",
 		},
 		{
-			name:      "string with invalid UTF-8 sequence",
-			input:     "test\xff\xfe",
-			labelName: "invalid_field",
-			expected:  "",
-			shouldLog: true,
+			name:     "string with invalid UTF-8 sequence",
+			input:    "test\xff\xfe",
+			expected: "test",
+		},
+		{
+			name:     "mixed valid and invalid UTF-8",
+			input:    "hello\xff\xfeworld",
+			expected: "helloworld",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := validateUTF8ForPrometheus(tt.input, tt.labelName)
+			result := sanitizeUTF8ForPrometheus(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -609,3 +609,49 @@ func makePromExporter(
 
 	return exporter
 }
+
+func TestValidateUTF8ForPrometheus(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		labelName string
+		expected  string
+		shouldLog bool
+	}{
+		{
+			name:      "valid UTF-8 string",
+			input:     "valid-string",
+			labelName: "test_label",
+			expected:  "valid-string",
+			shouldLog: false,
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			labelName: "test_label",
+			expected:  "",
+			shouldLog: false,
+		},
+		{
+			name:      "binary data with null bytes",
+			input:     "deb.debian.or 1498318199  0     0     100644  828       `\n\x1f\x8b\b",
+			labelName: "metadata_field",
+			expected:  "",
+			shouldLog: true,
+		},
+		{
+			name:      "string with invalid UTF-8 sequence",
+			input:     "test\xff\xfe",
+			labelName: "invalid_field",
+			expected:  "",
+			shouldLog: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateUTF8ForPrometheus(tt.input, tt.labelName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Add sanitization step in Prometheus metric generation to avoid make OBI panic when a label with invalid UTF8 is present. 
Fixes https://github.com/grafana/beyla/issues/1867