### PR TITLE
bpf: correctly initialize classification protocol

### DIFF
--- a/bpf/generictracer/k_tracer_defs.h
+++ b/bpf/generictracer/k_tracer_defs.h
@@ -36,6 +36,7 @@ make_protocol_args(void *u_buf, int bytes_len, u8 ssl, u8 direction, u16 orig_dp
     args->direction = direction;
     args->orig_dport = orig_dport;
     args->u_buf = (u64)u_buf;
+    args->protocol_type = k_protocol_type_unknown;
 
     return args;
 }

--- a/bpf/generictracer/protocol_mysql.h
+++ b/bpf/generictracer/protocol_mysql.h
@@ -267,7 +267,12 @@ static __always_inline u8 is_mysql(connection_info_t *conn_info,
         // +------------+-------------+----------------------+
         // |    3B      |     1B      |     1B     | 4B      |
         // +------------+-------------+----------------------+
-        *packet_type = PACKET_TYPE_REQUEST;
+        if (*protocol_type == k_protocol_type_mysql) {
+            // Already identified, mark this as a request.
+            // NOTE: Trying to classify the connection based on this command
+            // would be unreliable, as the check is too shallow.
+            *packet_type = PACKET_TYPE_REQUEST;
+        }
         break;
     default:
         if (*protocol_type == k_protocol_type_mysql) {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/285

/cc @grcevski looks like the issue was the protocol type initialization, I thought it would be always initialized to zero and cached for the connection lifetime but that seems not to be the case. I noticed `make_protocol_args()` initializes the protocol type value to 1 without the mysql classifier code doing anything (and doesn't keep it for the connection lifetime). 

```
time=2025-07-10T14:15:47.383+02:00 level=DEBUG msg="GREPME protocol_type 0" component=BPFLogger pid=192519 comm=Finalizer
time=2025-07-10T14:15:47.383+02:00 level=DEBUG msg="is_mysql: unhandled mysql command_id: 35" component=BPFLogger pid=192519 comm=Finalizer
...snip...
time=2025-07-10T14:15:47.391+02:00 level=DEBUG msg="GREPME protocol_type 1" component=BPFLogger pid=192519 comm=ApacheHttpsExam
```

I changed it to always initialize it to `unknown`; We should probably change it (now or in the future) to keep it cached for the connection lifetime, wdyt?
I also modified the classification code as the `execute` command check is too shallow and could misclassify packets too easily.
I tested it with the java snippet and it seems to fix the issue