### PR TITLE
log out configuration in debug mode

### DIFF
--- a/cmd/ebpf-instrument/main.go
+++ b/cmd/ebpf-instrument/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io"
 	"log/slog"
 	"net/http"
@@ -13,6 +12,8 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	otelsdk "go.opentelemetry.io/otel/sdk"
 

--- a/cmd/ebpf-instrument/main.go
+++ b/cmd/ebpf-instrument/main.go
@@ -79,13 +79,7 @@ func main() {
 	}
 
 	if *shouldLogConfig {
-		configYaml, err := yaml.Marshal(config)
-		if err != nil {
-			slog.Warn("can't marshal configuration to YAML", "error", err)
-		}
-		// log out the running configuration
-		slog.Info("Running OpenTelemetry eBPF Instrumentation with configuration")
-		fmt.Println(string(configYaml))
+		printConfig(config)
 	}
 
 	// Adding shutdown hook for graceful stop.
@@ -121,4 +115,15 @@ func loadConfig(configPath *string) *beyla.Config {
 		os.Exit(-1)
 	}
 	return config
+}
+
+func printConfig(config *beyla.Config) {
+	configYaml, err := yaml.Marshal(config)
+	if err != nil {
+		slog.Warn("can't marshal configuration to YAML", "error", err)
+	}
+	// obfuscate sensitive information like endpoint with regex
+	// log out the running configuration
+	slog.Info("Running OpenTelemetry eBPF Instrumentation with configuration")
+	fmt.Println(string(configYaml))
 }

--- a/cmd/ebpf-instrument/main.go
+++ b/cmd/ebpf-instrument/main.go
@@ -69,6 +69,9 @@ func main() {
 		}()
 	}
 
+	// log out the running configuration
+	slog.Debug("Running OpenTelemetry eBPF Instrumentation with configuration", "config", *config)
+
 	// Adding shutdown hook for graceful stop.
 	// We must register the hook before we launch the pipe build, otherwise we won't clean up if the
 	// child process isn't found.

--- a/cmd/ebpf-instrument/main.go
+++ b/cmd/ebpf-instrument/main.go
@@ -71,20 +71,11 @@ func main() {
 		}()
 	}
 
-	shouldLogConfig := flag.Bool("log-config", false, "should log out configuration on startup")
-	flag.Parse()
-
-	if cfg := os.Getenv("OTEL_EBPF_LOG_CONFIG"); cfg == "true" {
-		*shouldLogConfig = true
-	}
-
-	if *shouldLogConfig {
+	if config.LogConfig {
 		configYaml, err := yaml.Marshal(config)
 		if err != nil {
 			slog.Warn("can't marshal configuration to YAML", "error", err)
 		}
-		// obfuscate sensitive information like endpoint with regex
-		// log out the running configuration
 		slog.Info("Running OpenTelemetry eBPF Instrumentation with configuration")
 		fmt.Println(string(configYaml))
 	}

--- a/cmd/ebpf-instrument/main.go
+++ b/cmd/ebpf-instrument/main.go
@@ -79,7 +79,14 @@ func main() {
 	}
 
 	if *shouldLogConfig {
-		printConfig(config)
+		configYaml, err := yaml.Marshal(config)
+		if err != nil {
+			slog.Warn("can't marshal configuration to YAML", "error", err)
+		}
+		// obfuscate sensitive information like endpoint with regex
+		// log out the running configuration
+		slog.Info("Running OpenTelemetry eBPF Instrumentation with configuration")
+		fmt.Println(string(configYaml))
 	}
 
 	// Adding shutdown hook for graceful stop.
@@ -115,15 +122,4 @@ func loadConfig(configPath *string) *beyla.Config {
 		os.Exit(-1)
 	}
 	return config
-}
-
-func printConfig(config *beyla.Config) {
-	configYaml, err := yaml.Marshal(config)
-	if err != nil {
-		slog.Warn("can't marshal configuration to YAML", "error", err)
-	}
-	// obfuscate sensitive information like endpoint with regex
-	// log out the running configuration
-	slog.Info("Running OpenTelemetry eBPF Instrumentation with configuration")
-	fmt.Println(string(configYaml))
 }

--- a/pkg/beyla/config.go
+++ b/pkg/beyla/config.go
@@ -226,6 +226,9 @@ type Config struct {
 	//nolint:undoc
 	ProfilePort     int             `yaml:"profile_port" env:"OTEL_EBPF_PROFILE_PORT"`
 	InternalMetrics imetrics.Config `yaml:"internal_metrics"`
+
+	// LogConfig enables the logging of the configuration on startup.
+	LogConfig bool `yaml:"log_config" env:"OTEL_EBPF_LOG_CONFIG"`
 }
 
 // Attributes configures the decoration of some extra attributes that will be

--- a/pkg/components/ebpf/tcmanager/tcmanager.go
+++ b/pkg/components/ebpf/tcmanager/tcmanager.go
@@ -93,6 +93,19 @@ func (b *TCBackend) UnmarshalText(text []byte) error {
 	return fmt.Errorf("invalid TCBakend value: '%s'", text)
 }
 
+func (b TCBackend) MarshalText() ([]byte, error) {
+	switch b {
+	case TCBackendTC:
+		return []byte("tc"), nil
+	case TCBackendTCX:
+		return []byte("tcx"), nil
+	case TCBackendAuto:
+		return []byte("auto"), nil
+	}
+
+	return nil, fmt.Errorf("invalid TCBakend value: %d", b)
+}
+
 func (b TCBackend) Valid() bool {
 	switch b {
 	case TCBackendTC, TCBackendTCX, TCBackendAuto:

--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -135,3 +135,18 @@ func (m *ContextPropagationMode) UnmarshalText(text []byte) error {
 
 	return fmt.Errorf("invalid value for context_propagation: '%s'", text)
 }
+
+func (m ContextPropagationMode) MarshalText() ([]byte, error) {
+	switch m {
+	case ContextPropagationAll:
+		return []byte("all"), nil
+	case ContextPropagationHeadersOnly:
+		return []byte("headers"), nil
+	case ContextPropagationIPOptionsOnly:
+		return []byte("ip"), nil
+	case ContextPropagationDisabled:
+		return []byte("disabled"), nil
+	}
+
+	return nil, fmt.Errorf("invalid context propagation mode: %d", m)
+}

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -136,6 +136,13 @@ type MetricsConfig struct {
 	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
 }
 
+func (m MetricsConfig) MarshalYAML() (any, error) {
+	omit := map[string]struct{}{
+		"endpoint": {},
+	}
+	return omitFieldsForYAML(m, omit), nil
+}
+
 func (m *MetricsConfig) GetProtocol() Protocol {
 	if m.MetricsProtocol != "" {
 		return m.MetricsProtocol

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -113,6 +113,13 @@ type TracesConfig struct {
 	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
 }
 
+func (m TracesConfig) MarshalYAML() (any, error) {
+	omit := map[string]struct{}{
+		"endpoint": {},
+	}
+	return omitFieldsForYAML(m, omit), nil
+}
+
 type SpanAttr struct {
 	ValLength uint16
 	Vtype     uint8

--- a/pkg/services/attr_regex.go
+++ b/pkg/services/attr_regex.go
@@ -108,7 +108,10 @@ func (p *RegexpAttr) UnmarshalYAML(value *yaml.Node) error {
 }
 
 func (p RegexpAttr) MarshalYAML() (any, error) {
-	return p.re.String(), nil
+	if p.re != nil {
+		return p.re.String(), nil
+	}
+	return "", nil
 }
 
 func (p *RegexpAttr) UnmarshalText(text []byte) error {


### PR DESCRIPTION
this is very helpful when debugging, looking at the config.yaml + environment variable can be confusing and misleading.
so logging this out can help

example log:

``` 
time=2025-07-10T16:50:37.591+03:00 level=DEBUG msg="Running OpenTelemetry eBPF Instrumentation with configuration" config="{EBPF:{BpfDebug:true WakeupLen:1 BatchLength:100 BatchTimeout:1s TrackRequestHeaders:true HTTPRequestTimeout:0s ContextPropagationEnabled:true ContextPropagation:0 OverrideBPFLoopEnabled:false TCBackend:3 DisableBlackBoxCP:false HighRequestVolume:false HeuristicSQLDetect:false InstrumentGPU:false ProtocolDebug:false UseOTelSDKForJava:false RedisDBCache:{Enabled:false MaxSize:1000} BufferSizes:{MySQL:1024}} NetworkFlows:{Enable:false Source:socket_filter AgentIP: AgentIPIface:external AgentIPType:any Interfaces:[] ExcludeInterfaces:[lo] Protocols:[] ExcludeProtocols:[] CacheMaxFlows:5000 CacheActiveTimeout:5s Deduper:first_come DeduperFCTTL:0s Direction:both Sampling:0 ListenInterfaces:watch ListenPollPeriod:10s ReverseDNS:{Type:none CacheLen:256 CacheTTL:1h0m0s} Print:false CIDRs:[]} Filters:{Application:map[] Network:map[]} Attributes:{Kubernetes:{Enable:autodetect ClusterName: KubeconfigPath: InformersSyncTimeout:30s InformersResyncPeriod:30m0s DropExternal:false DisableInformers:[] MetaCacheAddress: MetaRestrictLocalNode:false MetaSourceLabels:{ServiceName: ServiceNamespace:} ResourceLabels:map[service.name:[app.kubernetes.io/name] service.namespace:[app.kubernetes.io/part-of] service.version:[app.kubernetes.io/version]] ServiceNameTemplate:} InstanceID:{HostnameDNSResolution:true OverrideHostname:} Select:map[] HostID:{Override: FetchTimeout:500ms} ExtraGroupAttributes:map[]} Routes:0x56f05a0 NameResolver:0x56e1e60 Metrics:{Interval:0s OTELIntervalMS:60000 CommonEndpoint: MetricsEndpoint: Protocol: MetricsProtocol: InsecureSkipVerify:false Buckets:{DurationHistogram:[0 0.005 0.01 0.025 0.05 0.075 0.1 0.25 0.5 0.75 1 2.5 5 7.5 10] RequestSizeHistogram:[0 32 64 128 256 512 1024 2048 4096 8192] ResponseSizeHistogram:[0 32 64 128 256 512 1024 2048 4096 8192]} HistogramAggregation:explicit_bucket_histogram ReportersCacheLen:256 SDKLogLevel: Features:[application] Instrumentations:[*] TTL:5m0s AllowServiceGraphSelfReferences:false OTLPEndpointProvider:<nil> InjectHeaders:<nil>} Traces:{CommonEndpoint: TracesEndpoint: Protocol: TracesProtocol: Instrumentations:[*] InsecureSkipVerify:false Sampler:{Name: Arg:} MaxExportBatchSize:4096 MaxQueueSize:4096 BatchTimeout:0s BackOffInitialInterval:0s BackOffMaxInterval:0s BackOffMaxElapsedTime:0s ReportersCacheLen:256 SDKLogLevel: OTLPEndpointProvider:<nil> InjectHeaders:<nil>} Prometheus:{Port:0 Path:/metrics DisableBuildInfo:false Features:[application] Instrumentations:[*] Buckets:{DurationHistogram:[0 0.005 0.01 0.025 0.05 0.075 0.1 0.25 0.5 0.75 1 2.5 5 7.5 10] RequestSizeHistogram:[0 32 64 128 256 512 1024 2048 4096 8192] ResponseSizeHistogram:[0 32 64 128 256 512 1024 2048 4096 8192]} TTL:5m0s SpanMetricsServiceCacheSize:10000 AllowServiceGraphSelfReferences:false Registry:<nil> ExtraResourceLabels:[]} TracePrinter:json_indent Exec:{re:<nil>} AutoTargetExe:{str: glob:<nil>} Port:{Ranges:[{Start:3306 End:0} {Start:5432 End:0} {Start:5123 End:0} {Start:80 End:0} {Start:6379 End:0} {Start:8080 End:0}]} ServiceName: ServiceNamespace: Discovery:{Services:[] ExcludeServices:[] DefaultExcludeServices:[{Name: Namespace: OpenPorts:{Ranges:[]} Path:{re:0x4000910c80} PathRegexp:{re:<nil>} Metadata:map[] PodLabels:map[] PodAnnotations:map[] ContainersOnly:false} {Name: Namespace: OpenPorts:{Ranges:[]} Path:{re:<nil>} PathRegexp:{re:<nil>} Metadata:map[k8s_namespace:0x570dd58] PodLabels:map[] PodAnnotations:map[] ContainersOnly:false}] Instrument:[] ExcludeInstrument:[] DefaultExcludeInstrument:[{Name: Namespace: OpenPorts:{Ranges:[]} Path:{str:{*beyla,*alloy,*ebpf-instrument,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*} glob:{Value:{} Left:<nil> Right:{Matchers:[{Str:beyla RunesLength:5 BytesLength:5 Segments:[5]} {Str:alloy RunesLength:5 BytesLength:5 Segments:[5]} {Str:ebpf-instrument RunesLength:15 BytesLength:15 Segments:[15]} {Str:otelcol RunesLength:7 BytesLength:7 Segments:[7]} {Str:otelcol-contrib RunesLength:15 BytesLength:15 Segments:[15]} {Value:{Matchers:[{Str:otelcol-contrib RunesLength:15 BytesLength:15 Segments:[15]} {List:[47] Not:true}] RunesLength:16 Segments:[16]} Left:<nil> Right:{} ValueLengthRunes:16 LeftLengthRunes:0 RightLengthRunes:-1 LengthRunes:-1}]} ValueLengthRunes:-1 LeftLengthRunes:0 RightLengthRunes:-1 LengthRunes:-1}} Metadata:map[] PodLabels:map[] PodAnnotations:map[] ContainersOnly:false} {Name: Namespace: OpenPorts:{Ranges:[]} Path:{str: glob:<nil>} Metadata:map[k8s_namespace:0x5715c20] PodLabels:map[] PodAnnotations:map[] ContainersOnly:false}] PollInterval:0s SkipGoSpecificTracers:false BPFPidFilterOff:false ExcludeOTelInstrumentedServices:true ExcludeOTelInstrumentedServicesSpanMetrics:false} LogLevel:debug ShutdownTimeout:10s EnforceSysCaps:false ChannelBufferLen:10 ProfilePort:0 InternalMetrics:{Prometheus:{Port:0 Path:/internal/metrics} Exporter:disabled}}"
```