### PR TITLE
Fix BPF load error

### DIFF
--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -394,8 +394,7 @@ int beyla_uprobe_readContinuedLineSliceReturns(struct pt_regs *ctx) {
     return 0;
 }
 
-SEC("uprobe/ServeHTTP_ret")
-int serve_http_returns(struct pt_regs *ctx) {
+static __always_inline int serve_http_returns(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/ServeHTTP returns === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);


### PR DESCRIPTION
In some setups, the go_tracer.c file failed to load due to a verification error.

I don't know why but this (initially unrelated) change fixed it locally.

The uprobe/ServeHTTP_ret probe in go_nethttp.c  is unnecessarily defined twice.
* As [serve_http_returns](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/bpf/gotracer/go_nethttp.c#L397-L398)
* As [beyla_uprobe_ServeHTTPReturns](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/bpf/gotracer/go_nethttp.c#L397-L398)

The same probe was defined and loaded twice in the generated bpf_arm_bpfel...go , but only p.bpfObjects.BeylaUprobeServeHTTPReturns was explicitly used in gotracer.go.