### PR TITLE
Test: speedup VM integration tests

### DIFF
--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -111,8 +111,6 @@ int BPF_KRETPROBE(beyla_kretprobe_sys_accept4, s32 fd) {
         return 0;
     }
 
-    //bpf_dbg_printk("=== accept 4 ret id=%d ===", id);
-
     bpf_dbg_printk("=== accept 4 ret id=%d, fd=%d ===", id, fd);
 
     // The file descriptor is the value returned from the accept4 syscall.

--- a/test/vm/Makefile
+++ b/test/vm/Makefile
@@ -43,7 +43,7 @@ $(ROOT_IMG): Dockerfile
 	qemu-img convert $(ROOT_IMAGE_RAW) -O qcow2 $(ROOT_IMG) && rm $(ROOT_IMAGE_RAW)
 
 launchvm: check_qemu $(ROOT_IMG) $(TEST_OUTPUT)
-	qemu-system-$(ARCH) -enable-kvm -cpu host -m 5120 -smp 8 -kernel $(KERNEL) -drive file=$(ROOT_IMG),format=qcow2 \
+	qemu-system-$(ARCH) -enable-kvm -cpu host -m 5120 -smp 2 -kernel $(KERNEL) -drive file=$(ROOT_IMG),format=qcow2 \
 		-append "earlyprintk=ttyS0 console=ttyS0 root=/dev/sda rw quiet" \
 		-virtfs local,path=$(REPO_ROOT),mount_tag=beyla,security_model=mapped,id=beyla \
 		-virtfs local,path=$(TEST_OUTPUT),mount_tag=testout,security_model=mapped,id=testout \


### PR DESCRIPTION
VM integration tests are abnormally slow even if they run in the same architecture as the host.

Checking wether changing the way to setup QEMU or the underlying runner VM might help.