### PR TITLE
feat(go jsonrpc): fix jsonrpc flaky test

### DIFF
--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -86,10 +86,15 @@ struct {
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
 } ongoing_http_server_requests SEC(".maps");
 
+typedef struct http_body {
+    unsigned char buf[HTTP_BODY_MAX_LEN];
+    u32 len;
+} http_body_t;
+
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __type(key, go_addr_key_t); // key: pointer to the request goroutine
-    __type(value, unsigned char[HTTP_BODY_MAX_LEN]);
+    __type(value, http_body_t);
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
 } http_body_store SEC(".maps");
 
@@ -1351,18 +1356,15 @@ int obi_uprobe_bodyReadReturn(struct pt_regs *ctx) {
         return 0;
     }
 
-    unsigned char *body_buf = temp_body_mem();
-    if (!body_buf) {
-        return 0;
-    }
+    http_body_t body = {.len = n};
 
     const u32 safe_len = n > HTTP_BODY_MAX_LEN ? HTTP_BODY_MAX_LEN : n;
-    if (!read_go_str_n("http body", (void *)invocation->body_addr, n, body_buf, safe_len)) {
+    if (!read_go_str_n("http body", (void *)invocation->body_addr, n, body.buf, safe_len)) {
         bpf_dbg_printk("failed to read body, n=%llu, body_addr=%llx", n, invocation->body_addr);
         return 0;
     }
     // bpf_dbg_printk("body is %s", body_buf);
-    bpf_map_update_elem(&http_body_store, &g_key, body_buf, BPF_ANY);
+    bpf_map_update_elem(&http_body_store, &g_key, &body, BPF_ANY);
     bpf_tail_call(ctx, &jsonrpc_jump_table, k_tail_jsonrpc);
     return 0;
 }
@@ -1382,14 +1384,14 @@ int obi_read_jsonrpc_method(struct pt_regs *ctx) {
         return 0;
     }
 
-    unsigned char *body_buf = bpf_map_lookup_elem(&http_body_store, &g_key);
-    if (!body_buf) {
+    http_body_t *body = bpf_map_lookup_elem(&http_body_store, &g_key);
+    if (!body) {
         return 0;
     }
-    if (is_jsonrpc2_body((const unsigned char *)body_buf, HTTP_BODY_MAX_LEN)) {
+    if (is_jsonrpc2_body((const unsigned char *)body->buf, HTTP_BODY_MAX_LEN)) {
         unsigned char method_buf[JSONRPC_METHOD_BUF_SIZE] = {};
         u32 method_len = extract_jsonrpc2_method(
-            (const unsigned char *)body_buf, HTTP_BODY_MAX_LEN, method_buf, sizeof(method_buf));
+            (const unsigned char *)body->buf, HTTP_BODY_MAX_LEN, method_buf, sizeof(method_buf));
         if (method_len > 0) {
             bpf_dbg_printk("JSON-RPC method: %s", method_buf);
             read_go_str_n("JSON-RPC method",

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -87,6 +87,13 @@ struct {
 } ongoing_http_server_requests SEC(".maps");
 
 struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, go_addr_key_t); // key: pointer to the request goroutine
+    __type(value, unsigned char[HTTP_BODY_MAX_LEN]);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+} http_body_store SEC(".maps");
+
+struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
     __type(key, u32);
     __type(value, unsigned char[HTTP_HEADER_MAX_LEN]);
@@ -1325,6 +1332,7 @@ int obi_uprobe_bodyReadReturn(struct pt_regs *ctx) {
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     go_addr_key_t g_key = {};
     go_addr_key_from_id(&g_key, goroutine_addr);
+    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
 
     u64 n = (u64)GO_PARAM1(ctx);
     bpf_dbg_printk("n is %llu", n);
@@ -1354,6 +1362,7 @@ int obi_uprobe_bodyReadReturn(struct pt_regs *ctx) {
         return 0;
     }
     // bpf_dbg_printk("body is %s", body_buf);
+    bpf_map_update_elem(&http_body_store, &g_key, body_buf, BPF_ANY);
     bpf_tail_call(ctx, &jsonrpc_jump_table, k_tail_jsonrpc);
     return 0;
 }
@@ -1373,9 +1382,7 @@ int obi_read_jsonrpc_method(struct pt_regs *ctx) {
         return 0;
     }
 
-    // tail call is guaranteed to run on the same CPU as its caller
-    // so we can shared the same buffer via a per-CPU map
-    unsigned char *body_buf = temp_body_mem();
+    unsigned char *body_buf = bpf_map_lookup_elem(&http_body_store, &g_key);
     if (!body_buf) {
         return 0;
     }
@@ -1392,6 +1399,7 @@ int obi_read_jsonrpc_method(struct pt_regs *ctx) {
                           sizeof(invocation->method));
         }
     }
+    bpf_map_delete_elem(&http_body_store, &g_key);
     return 0;
 }
 

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -166,8 +166,10 @@ int obi_uprobe_ServeHTTP(struct pt_regs *ctx) {
         // get content-type from readContinuedLineSlice
         if (header_inv && header_inv->content_type[0]) {
             bpf_dbg_printk("Found content type in ongoing request: %s", header_inv->content_type);
-            if (is_json_content_type((void *)header_inv->content_type,
+            if (header_inv->json_content_type ||
+                is_json_content_type((void *)header_inv->content_type,
                                      sizeof(header_inv->content_type))) {
+
                 invocation.json_content_type = 1;
             }
         }

--- a/bpf/gotracer/protocol_jsonrpc.h
+++ b/bpf/gotracer/protocol_jsonrpc.h
@@ -87,12 +87,11 @@ static __always_inline u32 extract_json_string(
         return 0;
     }
 
-    const u32 copy_len = value_len < (buf_len - 1) ? value_len : (buf_len - 1);
+    const u32 max_copy =
+        (str_start + value_len <= HTTP_BODY_MAX_LEN) ? value_len : (HTTP_BODY_MAX_LEN - str_start);
+    const u32 copy_len = max_copy < (buf_len - 1) ? max_copy : (buf_len - 1);
 
-    for (u32 i = 0; i < buf_len; i++) {
-        if (i >= copy_len) {
-            break;
-        }
+    for (u32 i = 0; i < copy_len; i++) {
         buf[i] = body[str_start + i];
     }
     buf[copy_len] = '\0';

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -766,7 +766,6 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 		)
 		assert.Empty(t, sd, sd.String())
 
-		/* FIXME flaky
 		// Check the information of the go jsonrpc parent span
 		res = trace.FindByOperationName("Arith.T /jsonrpc", "server")
 		require.Len(t, res, 1)
@@ -786,7 +785,6 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 			jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
 		)
 		assert.Empty(t, sd, sd.String())
-		*/
 
 		// Check the information of the python parent span
 		res = trace.FindByOperationName("GET /tracemetoo", "server")


### PR DESCRIPTION
This PR intends to fix #273, which is a JSON-RPC flaky test introduced in #161.