### PR TITLE
Rename beyla.* to obi.* in network metrics and attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 	github.com/yl2chen/cidranger v1.0.2
 	go.mongodb.org/mongo-driver/v2 v2.2.2
+	go.opentelemetry.io/auto/sdk v1.1.0
 	go.opentelemetry.io/collector/component v1.34.0
 	go.opentelemetry.io/collector/config/configgrpc v0.128.0
 	go.opentelemetry.io/collector/config/confighttp v0.128.0
@@ -145,7 +146,6 @@ require (
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/vishvananda/netns v0.0.5 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/collector v0.128.0 // indirect
 	go.opentelemetry.io/collector/client v1.34.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.128.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,6 @@ github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNw
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
 github.com/prometheus/common v0.65.0 h1:QDwzd+G1twt//Kwj/Ww6E9FQq1iVMmODnILtW1t2VzE=
 github.com/prometheus/common v0.65.0/go.mod h1:0gZns+BLRQ3V6NdaerOhMbwwRbNh9hkGINtQAsP5GS8=
-github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
-github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
@@ -434,8 +432,6 @@ golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKl
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
-golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
 golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/components/netolly/agent/ip.go
+++ b/pkg/components/netolly/agent/ip.go
@@ -38,7 +38,7 @@ var (
 
 // fetchAgentIP guesses the non-loopback IP address of the Agent host, according to the
 // user-provided configuration:
-//   - If BeylaIP is provided, this value is used whatever is the real IP of the Agent.
+//   - If OBIIP is provided, this value is used whatever is the real IP of the Agent.
 //   - AgentIPIface specifies which interface this function should look into in order to pickup an address.
 //   - AgentIPType specifies which type of IP address should the agent pickup ("any" to pickup whichever
 //     ipv4 or ipv6 address is found first)

--- a/pkg/components/netolly/agent/pipeline_test.go
+++ b/pkg/components/netolly/agent/pipeline_test.go
@@ -50,8 +50,8 @@ func TestFilter(t *testing.T) {
 				Network: map[string]filter.MatchDefinition{"transport": {Match: "TCP"}},
 			},
 			Attributes: obi.Attributes{Select: attributes.Selection{
-				attributes.BeylaNetworkFlow.Section: attributes.InclusionLists{
-					Include: []string{"beyla_ip", "iface.direction", "dst_port", "iface", "src_port", "transport"},
+				attributes.NetworkFlow.Section: attributes.InclusionLists{
+					Include: []string{"obi_ip", "iface.direction", "dst_port", "iface", "src_port", "transport"},
 				},
 			}},
 		},
@@ -92,11 +92,11 @@ func TestFilter(t *testing.T) {
 
 		// assuming metrics returned alphabetically ordered
 		assert.Equal(t, []prom2.ScrapedMetric{
-			{Name: "beyla_network_flow_bytes_total", Labels: map[string]string{
-				"beyla_ip": "1.2.3.4", "iface_direction": "ingress", "dst_port": "1011", "iface": "fakeiface", "src_port": "789", "transport": "TCP",
+			{Name: "obi_network_flow_bytes_total", Labels: map[string]string{
+				"obi_ip": "1.2.3.4", "iface_direction": "ingress", "dst_port": "1011", "iface": "fakeiface", "src_port": "789", "transport": "TCP",
 			}},
-			{Name: "beyla_network_flow_bytes_total", Labels: map[string]string{
-				"beyla_ip": "1.2.3.4", "iface_direction": "ingress", "dst_port": "1415", "iface": "fakeiface", "src_port": "1213", "transport": "TCP",
+			{Name: "obi_network_flow_bytes_total", Labels: map[string]string{
+				"obi_ip": "1.2.3.4", "iface_direction": "ingress", "dst_port": "1415", "iface": "fakeiface", "src_port": "1213", "transport": "TCP",
 			}},
 			// standard prometheus metrics. Leaving them here to simplify test verification
 			{Name: "promhttp_metric_handler_errors_total", Labels: map[string]string{"cause": "encoding"}},

--- a/pkg/components/netolly/ebpf/record.go
+++ b/pkg/components/netolly/ebpf/record.go
@@ -56,8 +56,8 @@ type RecordAttrs struct {
 	DstZone string
 
 	Interface string
-	// BeylaIP provides information about the source of the flow (the Agent that traced it)
-	BeylaIP  string
+	// OBIIP provides information about the source of the flow (the Agent that traced it)
+	OBIIP    string
 	Metadata map[attr.Name]string
 }
 

--- a/pkg/components/netolly/ebpf/record_getters.go
+++ b/pkg/components/netolly/ebpf/record_getters.go
@@ -20,8 +20,8 @@ const (
 func RecordGetters(name attr.Name) (attributes.Getter[*Record, attribute.KeyValue], bool) {
 	var getter attributes.Getter[*Record, attribute.KeyValue]
 	switch name {
-	case attr.BeylaIP:
-		getter = func(r *Record) attribute.KeyValue { return attribute.String(string(attr.BeylaIP), r.Attrs.BeylaIP) }
+	case attr.OBIIP:
+		getter = func(r *Record) attribute.KeyValue { return attribute.String(string(attr.OBIIP), r.Attrs.OBIIP) }
 	case attr.Transport:
 		getter = func(r *Record) attribute.KeyValue {
 			return attribute.String(string(attr.Transport), transport.Protocol(r.Id.TransportProtocol).String())

--- a/pkg/components/netolly/export/printer.go
+++ b/pkg/components/netolly/export/printer.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/export/otel"
+
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/netolly/ebpf"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/pipe/msg"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/pipe/swarm"
@@ -31,8 +33,10 @@ func printFlow(f *ebpf.Record) {
 	sb := strings.Builder{}
 	sb.WriteString("transport=")
 	sb.WriteString(strconv.Itoa(int(f.Id.TransportProtocol)))
-	sb.WriteString(" beyla.ip=")
-	sb.WriteString(f.Attrs.BeylaIP)
+	sb.WriteByte(' ')
+	sb.WriteString(otel.VendorPrefix)
+	sb.WriteString(".ip=")
+	sb.WriteString(f.Attrs.OBIIP)
 	sb.WriteString(" iface=")
 	sb.WriteString(f.Attrs.Interface)
 	sb.WriteString(" iface_direction=")

--- a/pkg/components/netolly/flow/decorator.go
+++ b/pkg/components/netolly/flow/decorator.go
@@ -42,7 +42,7 @@ func Decorate(agentIP net.IP, ifaceNamer InterfaceNamer, input *msg.Queue[[]*ebp
 		for flows := range in {
 			for _, flow := range flows {
 				flow.Attrs.Interface = ifaceNamer(int(flow.Id.IfIndex))
-				flow.Attrs.BeylaIP = ip
+				flow.Attrs.OBIIP = ip
 				if flow.Attrs.DstName == "" {
 					flow.Attrs.DstName = flow.Id.DstIP().IP().String()
 				}

--- a/pkg/components/netolly/flow/decorator_test.go
+++ b/pkg/components/netolly/flow/decorator_test.go
@@ -48,12 +48,12 @@ func TestDecoration(t *testing.T) {
 	require.Len(t, decorated, 2)
 
 	assert.Equal(t, "eth1", decorated[0].Attrs.Interface)
-	assert.Equal(t, "3.3.3.3", decorated[0].Attrs.BeylaIP)
+	assert.Equal(t, "3.3.3.3", decorated[0].Attrs.OBIIP)
 	assert.Equal(t, "source", decorated[0].Attrs.SrcName)
 	assert.Equal(t, "4.3.2.1", decorated[0].Attrs.DstName)
 
 	assert.Equal(t, "eth2", decorated[1].Attrs.Interface)
-	assert.Equal(t, "3.3.3.3", decorated[1].Attrs.BeylaIP)
+	assert.Equal(t, "3.3.3.3", decorated[1].Attrs.OBIIP)
 	assert.Equal(t, "1.2.3.4", decorated[1].Attrs.SrcName)
 	assert.Equal(t, "destination", decorated[1].Attrs.DstName)
 }

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -80,7 +80,7 @@ func getDefinitions(
 		nil,
 		map[attr.Name]Default{
 			attr.Direction:      true,
-			attr.BeylaIP:        false,
+			attr.OBIIP:          false,
 			attr.Transport:      false,
 			attr.SrcAddress:     false,
 			attr.DstAddres:      false,
@@ -231,10 +231,10 @@ func getDefinitions(
 	)
 
 	return map[Section]AttrReportGroup{
-		BeylaNetworkFlow.Section: {
+		NetworkFlow.Section: {
 			SubGroups: []*AttrReportGroup{&networkAttributes, &networkCIDR, &networkKubeAttributes},
 		},
-		BeylaNetworkInterZone.Section: {
+		NetworkInterZone.Section: {
 			SubGroups: []*AttrReportGroup{&networkInterZone, &networkInterZoneCIDR, &networkInterZoneKube},
 		},
 		HTTPServerDuration.Section: {

--- a/pkg/export/attributes/attr_selector_test.go
+++ b/pkg/export/attributes/attr_selector_test.go
@@ -11,38 +11,38 @@ import (
 
 func TestNormalize(t *testing.T) {
 	incl := Selection{
-		"beyla_network_flow_bytes": InclusionLists{Include: []string{"foo", "bar"}},
-		"some.other.metric_sum":    InclusionLists{Include: []string{"attr", "other"}},
-		"tralari.tralara.total":    InclusionLists{Include: []string{"a1", "a2", "a3"}},
+		"obi_network_flow_bytes": InclusionLists{Include: []string{"foo", "bar"}},
+		"some.other.metric_sum":  InclusionLists{Include: []string{"attr", "other"}},
+		"tralari.tralara.total":  InclusionLists{Include: []string{"a1", "a2", "a3"}},
 	}
 	incl.Normalize()
 	assert.Equal(t, Selection{
-		"beyla.network.flow": InclusionLists{Include: []string{"foo", "bar"}},
-		"some.other.metric":  InclusionLists{Include: []string{"attr", "other"}},
-		"tralari.tralara":    InclusionLists{Include: []string{"a1", "a2", "a3"}},
+		"obi.network.flow":  InclusionLists{Include: []string{"foo", "bar"}},
+		"some.other.metric": InclusionLists{Include: []string{"attr", "other"}},
+		"tralari.tralara":   InclusionLists{Include: []string{"a1", "a2", "a3"}},
 	}, incl)
 }
 
 func TestFor(t *testing.T) {
 	p, err := NewAttrSelector(GroupKubernetes, &SelectorConfig{
 		SelectionCfg: Selection{
-			"beyla_network_flow_bytes_total": InclusionLists{
-				Include: []string{"beyla_ip", "src.*", "k8s.*"},
+			"obi_network_flow_bytes_total": InclusionLists{
+				Include: []string{"obi_ip", "src.*", "k8s.*"},
 				Exclude: []string{"k8s_*_name", "k8s.*.type", "*zone"},
 			},
 		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []attr.Name{
-		"beyla.ip",
 		"k8s.dst.namespace",
 		"k8s.dst.node.ip",
 		"k8s.src.namespace",
 		"k8s.src.node.ip",
+		"obi.ip",
 		"src.address",
 		"src.name",
 		"src.port",
-	}, p.For(BeylaNetworkFlow))
+	}, p.For(NetworkFlow))
 }
 
 func TestFor_GlobEntries(t *testing.T) {
@@ -50,12 +50,12 @@ func TestFor_GlobEntries(t *testing.T) {
 	p, err := NewAttrSelector(GroupKubernetes, &SelectorConfig{
 		SelectionCfg: Selection{
 			"*": InclusionLists{
-				Include: []string{"beyla_ip"},
+				Include: []string{"obi_ip"},
 				// won't be excluded from the final snapshot because they are
 				// re-included in the next inclusion list
 				Exclude: []string{"k8s_*_type"},
 			},
-			"beyla_network_flow_bytes_total": InclusionLists{
+			"obi_network_flow_bytes_total": InclusionLists{
 				Include: []string{"src.*", "k8s.*"},
 				Exclude: []string{"k8s.*.name", "*zone"},
 			},
@@ -63,7 +63,6 @@ func TestFor_GlobEntries(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []attr.Name{
-		"beyla.ip",
 		"k8s.dst.namespace",
 		"k8s.dst.node.ip",
 		"k8s.dst.owner.type",
@@ -72,10 +71,11 @@ func TestFor_GlobEntries(t *testing.T) {
 		"k8s.src.node.ip",
 		"k8s.src.owner.type",
 		"k8s.src.type",
+		"obi.ip",
 		"src.address",
 		"src.name",
 		"src.port",
-	}, p.For(BeylaNetworkFlow))
+	}, p.For(NetworkFlow))
 }
 
 // if no include lists are defined, it takes the default arguments
@@ -85,7 +85,7 @@ func TestFor_GlobEntries_NoInclusion(t *testing.T) {
 			"*": InclusionLists{
 				Exclude: []string{"*dst*"},
 			},
-			"beyla_network_flow_bytes_total": InclusionLists{
+			"obi_network_flow_bytes_total": InclusionLists{
 				Exclude: []string{"k8s.*.namespace", "*zone"},
 			},
 		},
@@ -97,7 +97,7 @@ func TestFor_GlobEntries_NoInclusion(t *testing.T) {
 		"k8s.src.owner.name",
 		"k8s.src.owner.type",
 		"src.cidr",
-	}, p.For(BeylaNetworkFlow))
+	}, p.For(NetworkFlow))
 }
 
 func TestFor_GlobEntries_Order(t *testing.T) {
@@ -107,24 +107,24 @@ func TestFor_GlobEntries_Order(t *testing.T) {
 			"*": InclusionLists{
 				Include: []string{"*"},
 			},
-			"beyla_network_*": InclusionLists{
+			"obi_network_*": InclusionLists{
 				Exclude: []string{"dst.*", "transport", "*direction", "iface", "*zone"},
 			},
-			"beyla_network_flow_bytes_total": InclusionLists{
+			"obi_network_flow_bytes_total": InclusionLists{
 				Include: []string{"dst.name"},
 			},
 		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []attr.Name{
-		"beyla.ip",
 		"client.port",
 		"dst.name",
+		"obi.ip",
 		"server.port",
 		"src.address",
 		"src.name",
 		"src.port",
-	}, p.For(BeylaNetworkFlow))
+	}, p.For(NetworkFlow))
 }
 
 func TestFor_GlobEntries_Order_Default(t *testing.T) {
@@ -152,25 +152,25 @@ func TestFor_GlobEntries_Order_Default(t *testing.T) {
 func TestFor_KubeDisabled(t *testing.T) {
 	p, err := NewAttrSelector(0, &SelectorConfig{
 		SelectionCfg: Selection{
-			"beyla_network_flow_bytes_total": InclusionLists{
-				Include: []string{"target.instance", "beyla_ip", "src.*", "k8s.*"},
+			"obi_network_flow_bytes_total": InclusionLists{
+				Include: []string{"target.instance", "obi_ip", "src.*", "k8s.*"},
 				Exclude: []string{"src.port", "*zone"},
 			},
 		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, []attr.Name{
-		"beyla.ip",
+		"obi.ip",
 		"src.address",
 		"src.name",
-	}, p.For(BeylaNetworkFlow))
+	}, p.For(NetworkFlow))
 }
 
 func TestNilDoesNotCrash(t *testing.T) {
 	assert.NotPanics(t, func() {
 		p, err := NewAttrSelector(GroupKubernetes, &SelectorConfig{})
 		require.NoError(t, err)
-		assert.NotEmpty(t, p.For(BeylaNetworkFlow))
+		assert.NotEmpty(t, p.For(NetworkFlow))
 	})
 }
 
@@ -186,7 +186,7 @@ func TestDefault(t *testing.T) {
 		"k8s.src.namespace",
 		"k8s.src.owner.name",
 		"k8s.src.owner.type",
-	}, p.For(BeylaNetworkFlow))
+	}, p.For(NetworkFlow))
 }
 
 func TestExtraGroupAttributes(t *testing.T) {
@@ -230,7 +230,7 @@ func TestTraces(t *testing.T) {
 	p, err := NewAttrSelector(GroupTraces, &SelectorConfig{
 		SelectionCfg: Selection{
 			"traces": InclusionLists{
-				Include: []string{"db.query.text", "beyla_ip", "src.*", "k8s.*"},
+				Include: []string{"db.query.text", "obi_ip", "src.*", "k8s.*"},
 			},
 		},
 	})

--- a/pkg/export/attributes/metric.go
+++ b/pkg/export/attributes/metric.go
@@ -21,15 +21,15 @@ type Name struct {
 }
 
 var (
-	BeylaNetworkFlow = Name{
-		Section: "beyla.network.flow",
-		Prom:    "beyla_network_flow_bytes_total",
-		OTEL:    "beyla.network.flow.bytes",
+	NetworkFlow = Name{
+		Section: "obi.network.flow",
+		Prom:    "obi_network_flow_bytes_total",
+		OTEL:    "obi.network.flow.bytes",
 	}
-	BeylaNetworkInterZone = Name{
-		Section: "beyla.network.inter.zone",
-		Prom:    "beyla_network_inter_zone_bytes_total",
-		OTEL:    "beyla.network.inter.zone.bytes",
+	NetworkInterZone = Name{
+		Section: "obi.network.inter.zone",
+		Prom:    "obi_network_inter_zone_bytes_total",
+		OTEL:    "obi.network.inter.zone.bytes",
 	}
 	HTTPServerRequestSize = Name{
 		Section: "http.server.request.body.size",
@@ -110,7 +110,7 @@ var (
 
 // normalizeMetric will facilitate the user-input in the attributes.enable section.
 // The user can specify the Prometheus or OTEL notation, and can include or not
-// the units and aggregations for the metrics. Beyla will accept all the inputs
+// the units and aggregations for the metrics. OBI will accept all the inputs
 // as long as the metric name is recorgnisable.
 func normalizeMetric(name Section) Section {
 	nameStr := strings.ReplaceAll(string(name), "_", ".")

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -69,9 +69,13 @@ const (
 	K8sKind            = Name("k8s.kind")
 )
 
-// Beyla-specific network attributes
+// OBI-specific network attributes
+// obi.-prefixed attributes are a var instead of a constant to allow overriding the prefix
+// from components that vendor OBI as a library
+
+var OBIIP = Name("obi.ip")
+
 const (
-	BeylaIP    = Name("beyla.ip")
 	Transport  = Name("transport")
 	SrcAddress = Name("src.address")
 	DstAddres  = Name("dst.address")

--- a/pkg/export/otel/common.go
+++ b/pkg/export/otel/common.go
@@ -53,6 +53,11 @@ const (
 	envResourceAttrs   = "OTEL_RESOURCE_ATTRIBUTES"
 )
 
+// VendorPrefix allows identifying some metrics (network, internal counters...)
+// as custom metrics, since at the moment they don't follow any semantic convention for them.
+// This value can be overridden when OBI is vendored as a library (e.g. from the OTEL collector)
+var VendorPrefix = "obi"
+
 func omitFieldsForYAML(input any, omitFields map[string]struct{}) map[string]any {
 	result := make(map[string]any)
 

--- a/pkg/export/otel/expirer_test.go
+++ b/pkg/export/otel/expirer_test.go
@@ -47,7 +47,7 @@ func TestNetMetricsExpiration(t *testing.T) {
 				},
 			}, SelectorCfg: &attributes.SelectorConfig{
 				SelectionCfg: attributes.Selection{
-					attributes.BeylaNetworkFlow.Section: attributes.InclusionLists{
+					attributes.NetworkFlow.Section: attributes.InclusionLists{
 						Include: []string{"src.name", "dst.name"},
 					},
 				},

--- a/pkg/export/otel/metrics_net.go
+++ b/pkg/export/otel/metrics_net.go
@@ -43,7 +43,7 @@ func nmlog() *slog.Logger {
 // for network metrics.
 func getFilteredNetworkResourceAttrs(hostID string, attrSelector attributes.Selection) []attribute.KeyValue {
 	baseAttrs := []attribute.KeyValue{
-		semconv.ServiceName("beyla-network-flows"),
+		semconv.ServiceName(VendorPrefix + "-network-flows"),
 		semconv.ServiceInstanceID(uuid.New().String()),
 		semconv.TelemetrySDKLanguageKey.String(semconv.TelemetrySDKLanguageGo.Value.AsString()),
 		semconv.TelemetrySDKNameKey.String("opentelemetry-ebpf-instrumentation"),
@@ -54,7 +54,7 @@ func getFilteredNetworkResourceAttrs(hostID string, attrSelector attributes.Sele
 		semconv.HostID(hostID),
 	}
 
-	return GetFilteredAttributesByPrefix(baseAttrs, attrSelector, extraAttrs, []string{"network.", "beyla.network"})
+	return GetFilteredAttributesByPrefix(baseAttrs, attrSelector, extraAttrs, []string{"network.", VendorPrefix + ".network"})
 }
 
 func createFilteredNetworkResource(hostID string, attrSelector attributes.Selection) *resource.Resource {
@@ -125,7 +125,7 @@ func newMetricsExporter(
 	}
 	if cfg.GloballyEnabled || cfg.Metrics.NetworkFlowBytesEnabled() {
 		log := log.With("metricFamily", "FlowBytes")
-		bytesMetric, err := ebpfEvents.Int64Counter(attributes.BeylaNetworkFlow.OTEL,
+		bytesMetric, err := ebpfEvents.Int64Counter(attributes.NetworkFlow.OTEL,
 			metric2.WithDescription("total bytes_sent value of network flows observed by probe since its launch"),
 			metric2.WithUnit("{bytes}"), // TODO: By?
 		)
@@ -137,14 +137,14 @@ func newMetricsExporter(
 		log.Debug("restricting attributes not in this list", "attributes", cfg.SelectorCfg.SelectionCfg)
 		attrs := attributes.OpenTelemetryGetters(
 			ebpf.RecordGetters,
-			attrProv.For(attributes.BeylaNetworkFlow))
+			attrProv.For(attributes.NetworkFlow))
 
 		nme.flowBytes = NewExpirer[*ebpf.Record, metric2.Int64Counter, float64](ctx, bytesMetric, attrs, clock.Time, cfg.Metrics.TTL)
 	}
 
 	if cfg.Metrics.NetworkInterzoneMetricsEnabled() {
 		log := log.With("metricFamily", "InterZoneBytes")
-		bytesMetric, err := ebpfEvents.Int64Counter(attributes.BeylaNetworkInterZone.OTEL,
+		bytesMetric, err := ebpfEvents.Int64Counter(attributes.NetworkInterZone.OTEL,
 			metric2.WithDescription("total bytes_sent value between Cloud availability zones"),
 			metric2.WithUnit("{bytes}"), // TODO: By?
 		)
@@ -155,7 +155,7 @@ func newMetricsExporter(
 		log.Debug("restricting attributes not in this list", "attributes", cfg.SelectorCfg.SelectionCfg)
 		attrs := attributes.OpenTelemetryGetters(
 			ebpf.RecordGetters,
-			attrProv.For(attributes.BeylaNetworkInterZone))
+			attrProv.For(attributes.NetworkInterZone))
 
 		nme.interZoneBytes = NewExpirer[*ebpf.Record, metric2.Int64Counter, float64](ctx, bytesMetric, attrs, clock.Time, cfg.Metrics.TTL)
 	}

--- a/pkg/export/otel/metrics_net_test.go
+++ b/pkg/export/otel/metrics_net_test.go
@@ -42,7 +42,7 @@ func TestMetricAttributes(t *testing.T) {
 		&global.ContextInfo{MetricAttributeGroups: attributes.GroupKubernetes},
 		&NetMetricsConfig{SelectorCfg: &attributes.SelectorConfig{
 			SelectionCfg: map[attributes.Section]attributes.InclusionLists{
-				attributes.BeylaNetworkFlow.Section: {Include: []string{"*"}},
+				attributes.NetworkFlow.Section: {Include: []string{"*"}},
 			},
 		}, Metrics: &MetricsConfig{
 			MetricsEndpoint:   "http://foo",
@@ -100,7 +100,7 @@ func TestMetricAttributes_Filter(t *testing.T) {
 		&global.ContextInfo{MetricAttributeGroups: attributes.GroupKubernetes},
 		&NetMetricsConfig{SelectorCfg: &attributes.SelectorConfig{
 			SelectionCfg: map[attributes.Section]attributes.InclusionLists{
-				attributes.BeylaNetworkFlow.Section: {Include: []string{
+				attributes.NetworkFlow.Section: {Include: []string{
 					"src.address",
 					"k8s.src.name",
 					"k8s.dst.name",
@@ -159,7 +159,7 @@ func TestNetMetricsConfig_Disabled(t *testing.T) {
 func TestGetFilteredNetworkResourceAttrs(t *testing.T) {
 	hostID := "test-host-id"
 	attrSelector := attributes.Selection{
-		attributes.BeylaNetworkFlow.Section: attributes.InclusionLists{
+		attributes.NetworkFlow.Section: attributes.InclusionLists{
 			Include: []string{"*"},
 			Exclude: []string{"host.*"},
 		},

--- a/pkg/export/prom/prom_net.go
+++ b/pkg/export/prom/prom_net.go
@@ -98,10 +98,10 @@ func newNetReporter(
 		log.Debug("registering network flow bytes metric")
 		mr.flowAttrs = attributes.PrometheusGetters(
 			ebpf.RecordStringGetters,
-			provider.For(attributes.BeylaNetworkFlow))
+			provider.For(attributes.NetworkFlow))
 
 		mr.flowBytes = NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: attributes.BeylaNetworkFlow.Prom,
+			Name: attributes.NetworkFlow.Prom,
 			Help: "bytes submitted from a source network endpoint to a destination network endpoint",
 		}, labelNames(mr.flowAttrs)).MetricVec, clock.Time, cfg.Config.TTL)
 		register = append(register, mr.flowBytes)
@@ -111,10 +111,10 @@ func newNetReporter(
 		log.Debug("registering network inter-zone metric")
 		mr.interZoneAttrs = attributes.PrometheusGetters(
 			ebpf.RecordStringGetters,
-			provider.For(attributes.BeylaNetworkInterZone))
+			provider.For(attributes.NetworkInterZone))
 
 		mr.interZone = NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: attributes.BeylaNetworkInterZone.Prom,
+			Name: attributes.NetworkInterZone.Prom,
 			Help: "bytes submitted between different cloud availability zones",
 		}, labelNames(mr.interZoneAttrs)).MetricVec, clock.Time, cfg.Config.TTL)
 		register = append(register, mr.interZone)

--- a/pkg/export/prom/prom_net_test.go
+++ b/pkg/export/prom/prom_net_test.go
@@ -39,7 +39,7 @@ func TestMetricsExpiration(t *testing.T) {
 			Features:                    []string{otel.FeatureNetwork},
 		}, SelectorCfg: &attributes.SelectorConfig{
 			SelectionCfg: attributes.Selection{
-				attributes.BeylaNetworkFlow.Section: attributes.InclusionLists{
+				attributes.NetworkFlow.Section: attributes.InclusionLists{
 					Include: []string{"src_name", "dst_name"},
 				},
 			},
@@ -63,8 +63,8 @@ func TestMetricsExpiration(t *testing.T) {
 	// THEN the metrics are exported
 	test.Eventually(t, timeout, func(t require.TestingT) {
 		exported := getMetrics(t, promURL)
-		assert.Contains(t, exported, `beyla_network_flow_bytes_total{dst_name="bar",src_name="foo"} 123`)
-		assert.Contains(t, exported, `beyla_network_flow_bytes_total{dst_name="bae",src_name="baz"} 456`)
+		assert.Contains(t, exported, `obi_network_flow_bytes_total{dst_name="bar",src_name="foo"} 123`)
+		assert.Contains(t, exported, `obi_network_flow_bytes_total{dst_name="bae",src_name="baz"} 456`)
 	})
 
 	// AND WHEN it keeps receiving a subset of the initial metrics during the timeout
@@ -81,11 +81,11 @@ func TestMetricsExpiration(t *testing.T) {
 	var exported string
 	test.Eventually(t, timeout, func(t require.TestingT) {
 		m := getMetrics(t, promURL)
-		assert.Contains(t, exported, `beyla_network_flow_bytes_total{dst_name="bar",src_name="foo"} 246`)
+		assert.Contains(t, exported, `obi_network_flow_bytes_total{dst_name="bar",src_name="foo"} 246`)
 		exported = m
 	})
 	// BUT not the metrics that haven't been received during that time
-	assert.NotContains(t, exported, `beyla_network_flow_bytes_total{dst_name="bae",src_name="baz"}`)
+	assert.NotContains(t, exported, `obi_network_flow_bytes_total{dst_name="bae",src_name="baz"}`)
 	now.Advance(2 * time.Minute)
 
 	// AND WHEN the metrics labels that disappeared are received again
@@ -100,8 +100,8 @@ func TestMetricsExpiration(t *testing.T) {
 	// THEN they are reported again, starting from zero in the case of counters
 	test.Eventually(t, timeout, func(t require.TestingT) {
 		m := getMetrics(t, promURL)
-		assert.Contains(t, exported, `beyla_network_flow_bytes_total{dst_name="bae",src_name="baz"} 456`)
+		assert.Contains(t, exported, `obi_network_flow_bytes_total{dst_name="bae",src_name="baz"} 456`)
 		exported = m
 	})
-	assert.NotContains(t, exported, `beyla_network_flow_bytes_total{dst_name="bar",src_name="foo"}`)
+	assert.NotContains(t, exported, `obi_network_flow_bytes_total{dst_name="bar",src_name="foo"}`)
 }

--- a/pkg/filter/attribute_test.go
+++ b/pkg/filter/attribute_test.go
@@ -22,7 +22,7 @@ func TestAttributeFilter(t *testing.T) {
 	output := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
 
 	filterFunc, err := ByAttribute[*ebpf.Record](AttributeFamilyConfig{
-		"beyla.ip":          MatchDefinition{Match: "148.*"},
+		"obi.ip":            MatchDefinition{Match: "148.*"},
 		"k8s.src.namespace": MatchDefinition{NotMatch: "debug"},
 		"k8s.app.version":   MatchDefinition{Match: "*"},
 	}, nil, map[string][]attr.Name{
@@ -37,7 +37,7 @@ func TestAttributeFilter(t *testing.T) {
 	input.Send([]*ebpf.Record{
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "148.132.1.1",
+				OBIIP: "148.132.1.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "debug",
 					"k8s.app.version":   "v0.0.1",
@@ -46,7 +46,7 @@ func TestAttributeFilter(t *testing.T) {
 		},
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "128.132.1.1",
+				OBIIP: "128.132.1.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "foo",
 					"k8s.app.version":   "v0.0.1",
@@ -55,7 +55,7 @@ func TestAttributeFilter(t *testing.T) {
 		},
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "148.132.1.1",
+				OBIIP: "148.132.1.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "foo",
 					"k8s.app.version":   "v0.0.1",
@@ -64,7 +64,7 @@ func TestAttributeFilter(t *testing.T) {
 		},
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "148.133.2.1",
+				OBIIP: "148.133.2.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "tralar",
 					"k8s.app.version":   "v0.0.1",
@@ -73,7 +73,7 @@ func TestAttributeFilter(t *testing.T) {
 		},
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "141.132.1.1",
+				OBIIP: "141.132.1.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "tralari",
 					"k8s.app.version":   "v0.0.1",
@@ -86,7 +86,7 @@ func TestAttributeFilter(t *testing.T) {
 	input.Send([]*ebpf.Record{
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "128.132.1.1",
+				OBIIP: "128.132.1.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "foo",
 					"k8s.app.version":   "v0.0.1",
@@ -95,7 +95,7 @@ func TestAttributeFilter(t *testing.T) {
 		},
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "141.132.1.1",
+				OBIIP: "141.132.1.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "tralari",
 					"k8s.app.version":   "v0.0.1",
@@ -108,7 +108,7 @@ func TestAttributeFilter(t *testing.T) {
 	input.Send([]*ebpf.Record{
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "148.132.1.1",
+				OBIIP: "148.132.1.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "foo",
 					"k8s.app.version":   "v0.0.1",
@@ -117,7 +117,7 @@ func TestAttributeFilter(t *testing.T) {
 		},
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "148.133.2.1",
+				OBIIP: "148.133.2.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "tralar",
 					"k8s.app.version":   "v0.0.1",
@@ -130,7 +130,7 @@ func TestAttributeFilter(t *testing.T) {
 	assert.Equal(t, []*ebpf.Record{
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "148.132.1.1",
+				OBIIP: "148.132.1.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "foo",
 					"k8s.app.version":   "v0.0.1",
@@ -139,7 +139,7 @@ func TestAttributeFilter(t *testing.T) {
 		},
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "148.133.2.1",
+				OBIIP: "148.133.2.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "tralar",
 					"k8s.app.version":   "v0.0.1",
@@ -152,7 +152,7 @@ func TestAttributeFilter(t *testing.T) {
 	assert.Equal(t, []*ebpf.Record{
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "148.132.1.1",
+				OBIIP: "148.132.1.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "foo",
 					"k8s.app.version":   "v0.0.1",
@@ -161,7 +161,7 @@ func TestAttributeFilter(t *testing.T) {
 		},
 		{
 			Attrs: ebpf.RecordAttrs{
-				BeylaIP: "148.133.2.1",
+				OBIIP: "148.133.2.1",
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "tralar",
 					"k8s.app.version":   "v0.0.1",
@@ -183,9 +183,9 @@ func TestAttributeFilter_VerificationError(t *testing.T) {
 		// non-existing attribute
 		{"super-attribute": MatchDefinition{Match: "foo"}},
 		// valid attribute without match definition
-		{"beyla.ip": MatchDefinition{}},
+		{"obi.ip": MatchDefinition{}},
 		// valid attribute with double match definition
-		{"beyla.ip": MatchDefinition{Match: "foo", NotMatch: "foo"}},
+		{"obi.ip": MatchDefinition{Match: "foo", NotMatch: "foo"}},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {

--- a/pkg/instrumenter/instrumenter_test_linux.go
+++ b/pkg/instrumenter/instrumenter_test_linux.go
@@ -71,7 +71,7 @@ func TestRunDontPanic(t *testing.T) {
 }
 
 func TestNetworkEnabled(t *testing.T) {
-	t.Setenv("BEYLA_NETWORK_METRICS", "true")
+	t.Setenv("obi_network_METRICS", "true")
 	cfg, err := obi.LoadConfig(bytes.NewReader(nil))
 	require.NoError(t, err)
 	assert.True(t, cfg.Enabled(obi.FeatureNetO11y))

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -65,7 +65,7 @@ attributes:
     override: the-host-id
     fetch_timeout: 4s
   select:
-    beyla.network.flow:
+    obi.network.flow:
       include: ["foo", "bar"]
       exclude: ["baz", "bae"]
   extra_group_attributes:
@@ -197,7 +197,7 @@ network:
 				FetchTimeout: 4 * time.Second,
 			},
 			Select: attributes.Selection{
-				attributes.BeylaNetworkFlow.Section: attributes.InclusionLists{
+				attributes.NetworkFlow.Section: attributes.InclusionLists{
 					Include: []string{"foo", "bar"},
 					Exclude: []string{"baz", "bae"},
 				},
@@ -329,7 +329,7 @@ attributes:
   kubernetes:
     enable: true
   select:
-    beyla_network_flow_bytes:
+    obi_network_flow_bytes:
       include:
         - k8s.src.name
         - k8s.dst.name

--- a/test/integration/components/prom/prometheus_test.go
+++ b/test/integration/components/prom/prometheus_test.go
@@ -12,10 +12,10 @@ import (
 func TestScrape(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		_, err := writer.Write([]byte(`#
-# HELP beyla_network_flow_bytes_total bytes submitted from a source network endpoint to a destination network endpoint
-# TYPE beyla_network_flow_bytes_total counter
-beyla_network_flow_bytes_total{beyla_ip="1.2.3.4",dst_port="1011",iface="fakeiface",iface_direction="ingress",src_port="789",transport="TCP"} 123.3
-beyla_network_flow_bytes_total{beyla_ip="1.2.3.4",dst_port="1415",iface="fakeiface",iface_direction="ingress",src_port="1213",transport="TCP"} 1
+# HELP obi_network_flow_bytes_total bytes submitted from a source network endpoint to a destination network endpoint
+# TYPE obi_network_flow_bytes_total counter
+obi_network_flow_bytes_total{obi_ip="1.2.3.4",dst_port="1011",iface="fakeiface",iface_direction="ingress",src_port="789",transport="TCP"} 123.3
+obi_network_flow_bytes_total{obi_ip="1.2.3.4",dst_port="1415",iface="fakeiface",iface_direction="ingress",src_port="1213",transport="TCP"} 1
 # HELP promhttp_metric_handler_errors_total Total number of internal errors encountered by the promhttp metric handler.
 # TYPE promhttp_metric_handler_errors_total counter
 promhttp_metric_handler_errors_total{cause="encoding"} 2
@@ -30,11 +30,11 @@ promhttp_metric_handler_errors_total{cause="gathering"} 3
 	scrapedMetrics, err := Scrape(server.URL)
 	require.NoError(t, err)
 	assert.Equal(t, []ScrapedMetric{
-		{Name: "beyla_network_flow_bytes_total", Value: 123.3, Labels: map[string]string{
-			"beyla_ip": "1.2.3.4", "iface_direction": "ingress", "dst_port": "1011", "iface": "fakeiface", "src_port": "789", "transport": "TCP",
+		{Name: "obi_network_flow_bytes_total", Value: 123.3, Labels: map[string]string{
+			"obi_ip": "1.2.3.4", "iface_direction": "ingress", "dst_port": "1011", "iface": "fakeiface", "src_port": "789", "transport": "TCP",
 		}},
-		{Name: "beyla_network_flow_bytes_total", Value: 1, Labels: map[string]string{
-			"beyla_ip": "1.2.3.4", "iface_direction": "ingress", "dst_port": "1415", "iface": "fakeiface", "src_port": "1213", "transport": "TCP",
+		{Name: "obi_network_flow_bytes_total", Value: 1, Labels: map[string]string{
+			"obi_ip": "1.2.3.4", "iface_direction": "ingress", "dst_port": "1415", "iface": "fakeiface", "src_port": "1213", "transport": "TCP",
 		}},
 		{Name: "promhttp_metric_handler_errors_total", Value: 2, Labels: map[string]string{"cause": "encoding"}},
 		{Name: "promhttp_metric_handler_errors_total", Value: 3, Labels: map[string]string{"cause": "gathering"}},

--- a/test/integration/configs/instrumenter-config-netolly-direction.yml
+++ b/test/integration/configs/instrumenter-config-netolly-direction.yml
@@ -1,8 +1,8 @@
 attributes:
   select:
-    beyla_network_flow_bytes:
+    obi_network_flow_bytes:
       include:
-      - beyla.ip
+      - obi.ip
       - src.address
       - dst.address
       - src.port

--- a/test/integration/configs/instrumenter-config-netolly-disallowattrs.yml
+++ b/test/integration/configs/instrumenter-config-netolly-disallowattrs.yml
@@ -1,7 +1,7 @@
 attributes:
   select:
-    beyla_network_flow_bytes:
+    obi_network_flow_bytes:
       include:
-      - beyla.ip
+      - obi.ip
       - src.name
       - dst.port

--- a/test/integration/configs/instrumenter-config-netolly.yml
+++ b/test/integration/configs/instrumenter-config-netolly.yml
@@ -1,8 +1,8 @@
 attributes:
   select:
-    beyla_network_flow_bytes:
+    obi_network_flow_bytes:
       include:
-      - beyla.ip
+      - obi.ip
       - src.address
       - dst.address
       - src.name

--- a/test/integration/configs/prometheus-config-promscrape-k8s-test.yml
+++ b/test/integration/configs/prometheus-config-promscrape-k8s-test.yml
@@ -2,7 +2,7 @@ global:
   evaluation_interval: 5s
   scrape_interval: 5s
 scrape_configs:
-  - job_name: beyla-network-flows
+  - job_name: obi-network-flows
     honor_labels: true
     static_configs:
       - targets:
@@ -22,7 +22,7 @@ scrape_configs:
   # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
   # * `prometheus.io/port`: If the metrics are exposed on a different port to the
   #   service then set this appropriately.
-  - job_name: 'beyla-network-flows-scrape'
+  - job_name: 'obi-network-flows-scrape'
     honor_labels: true
     kubernetes_sd_configs:
       - role: pod

--- a/test/integration/k8s/manifests/06-beyla-external-informer.yml
+++ b/test/integration/k8s/manifests/06-beyla-external-informer.yml
@@ -22,7 +22,7 @@ data:
       select:
         "*":
           include: [ "*" ]
-        beyla.network.flow.bytes:
+        obi.network.flow.bytes:
           include: [ "*" ]
           exclude: [ "src_port" ]
     network:

--- a/test/integration/k8s/manifests/06-beyla-netolly-dropexternal.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-dropexternal.yml
@@ -11,7 +11,7 @@ data:
         resource_labels:
           deployment.environment: ["${DEPLOYMENT_ENVIRONMENT:-error-not-replaced}"]
       select:
-        beyla.network.flow.bytes:
+        obi.network.flow.bytes:
           include:
           - src.name
           - dst.name

--- a/test/integration/k8s/manifests/06-beyla-netolly-multizone.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-multizone.yml
@@ -24,7 +24,7 @@ data:
         resource_labels:
           deployment.environment: ["${DEPLOYMENT_ENVIRONMENT:-error-not-replaced}"]
       select:
-        beyla.network.flow.bytes:
+        obi.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
           include: ["*"]
           exclude: ["src_port"]

--- a/test/integration/k8s/manifests/06-beyla-netolly-promexport.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-promexport.yml
@@ -23,7 +23,7 @@ data:
         resource_labels:
           deployment.environment: ["deployment.environment"]
       select:
-        beyla.network.flow.bytes:
+        obi.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
           include: ["*"]
           exclude: ["src_port"]

--- a/test/integration/k8s/manifests/06-beyla-netolly-tc-promexport.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly-tc-promexport.yml
@@ -23,7 +23,7 @@ data:
         resource_labels:
           deployment.environment: ["deployment.environment"]
       select:
-        beyla.network.flow.bytes:
+        obi.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
           include: ["*"]
           exclude: ["src_port"]

--- a/test/integration/k8s/manifests/06-beyla-netolly.yml
+++ b/test/integration/k8s/manifests/06-beyla-netolly.yml
@@ -23,7 +23,7 @@ data:
         resource_labels:
           deployment.environment: ["${DEPLOYMENT_ENVIRONMENT:-deployment.environment}"]
       select:
-        beyla.network.flow.bytes:
+        obi.network.flow.bytes:
           # assured cardinality explosion. Don't try in production!
           include: ["*"]
           exclude: ["src_port"]

--- a/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
+++ b/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
@@ -50,7 +50,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 	pq := prom.Client{HostPort: prometheusHostPort}
 	// testing request flows (to testserver as Service)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger-net",dst_name="testserver"}`)
+		results, err := pq.Query(`obi_network_flow_bytes_total{src_name="internal-pinger-net",dst_name="testserver"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -60,7 +60,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
 		assert.Regexp(t,
-			"^beyla-network-flows",
+			"^obi-network-flows",
 			metric["job"])
 		assert.Equal(t, "my-kube", metric["k8s_cluster_name"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
@@ -83,7 +83,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 	})
 	// testing request flows (to testserver as Pod)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger-net",dst_name=~"testserver-.*"}`)
+		results, err := pq.Query(`obi_network_flow_bytes_total{src_name="internal-pinger-net",dst_name=~"testserver-.*"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -93,7 +93,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
 		assert.Regexp(t,
-			"^beyla-network-flows",
+			"^obi-network-flows",
 			metric["job"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
 		assert.Equal(t, "internal-pinger-net", metric["k8s_src_name"])
@@ -120,7 +120,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 
 	// testing response flows (from testserver Pod)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name=~"testserver-.*",dst_name="internal-pinger-net"}`)
+		results, err := pq.Query(`obi_network_flow_bytes_total{src_name=~"testserver-.*",dst_name="internal-pinger-net"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -130,7 +130,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
 		assert.Regexp(t,
-			"^beyla-network-flows",
+			"^obi-network-flows",
 			metric["job"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
 		assert.Regexp(t, "^testserver-", metric["k8s_src_name"])
@@ -157,7 +157,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 
 	// testing response flows (from testserver Service)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="testserver",dst_name="internal-pinger-net"}`)
+		results, err := pq.Query(`obi_network_flow_bytes_total{src_name="testserver",dst_name="internal-pinger-net"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 
@@ -167,7 +167,7 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
 		assert.Regexp(t,
-			"^beyla-network-flows",
+			"^obi-network-flows",
 			metric["job"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
 		assert.Equal(t, "testserver", metric["k8s_src_name"])
@@ -189,12 +189,12 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 	})
 
 	// check that there aren't captured flows if there is no communication
-	results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger-net",dst_name="otherinstance"}`)
+	results, err := pq.Query(`obi_network_flow_bytes_total{src_name="internal-pinger-net",dst_name="otherinstance"}`)
 	require.NoError(t, err)
 	require.Empty(t, results)
 
 	// check that only TCP traffic is captured, according to the Protocols configuration option
-	results, err = pq.Query(`beyla_network_flow_bytes_total`)
+	results, err = pq.Query(`obi_network_flow_bytes_total`)
 	require.NoError(t, err)
 	require.NotEmpty(t, results)
 	for _, result := range results {
@@ -210,7 +210,7 @@ func testNetFlowBytesForExternalTraffic(ctx context.Context, t *testing.T, _ *en
 	// test external traffic (this test --> prometheus)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		// checks that at least one source without src kubernetes label is there
-		results, err := pq.Query(`beyla_network_flow_bytes_total{k8s_dst_owner_name="prometheus",k8s_src_owner_name=""}`)
+		results, err := pq.Query(`obi_network_flow_bytes_total{k8s_dst_owner_name="prometheus",k8s_src_owner_name=""}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 	})
@@ -218,7 +218,7 @@ func testNetFlowBytesForExternalTraffic(ctx context.Context, t *testing.T, _ *en
 	// test external traffic (prometheus --> this test)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		// checks that at least one source without dst kubernetes label is there
-		results, err := pq.Query(`beyla_network_flow_bytes_total{k8s_src_owner_name="prometheus",k8s_dst_owner_name=""}`)
+		results, err := pq.Query(`obi_network_flow_bytes_total{k8s_src_owner_name="prometheus",k8s_dst_owner_name=""}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 	})

--- a/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
+++ b/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
@@ -80,17 +80,17 @@ func testNoFlowsForExternalTraffic(ctx context.Context, t *testing.T, _ *envconf
 	// testing first that internal traffic is reported (this leaves room to populate Prometheus with
 	// the inspected metrics)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{src_name="internal-pinger",dst_name="testserver"}`)
+		results, err := pq.Query(`obi_network_flow_bytes_total{src_name="internal-pinger",dst_name="testserver"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 	})
 
 	// test that there isn't external traffic neither as source nor as a destination
-	results, err := pq.Query(`beyla_network_flow_bytes_total{k8s_src_owner_name=""}`)
+	results, err := pq.Query(`obi_network_flow_bytes_total{k8s_src_owner_name=""}`)
 	require.NoError(t, err)
 	require.Empty(t, results)
 
-	results, err = pq.Query(`beyla_network_flow_bytes_total{k8s_dst_owner_name=""}`)
+	results, err = pq.Query(`obi_network_flow_bytes_total{k8s_dst_owner_name=""}`)
 	require.NoError(t, err)
 	require.Empty(t, results)
 	return ctx

--- a/test/integration/k8s/netolly_multizone/netolly_multizone_feature.go
+++ b/test/integration/k8s/netolly_multizone/netolly_multizone_feature.go
@@ -31,7 +31,7 @@ func testFlowsDecoratedWithZone(ctx context.Context, t *testing.T, _ *envconf.Co
 
 	// checking pod-to-pod node communication (request)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+		results, err := pq.Query(`obi_network_flow_bytes_total{` +
 			`k8s_src_name="httppinger",k8s_dst_name=~"testserver.*",` +
 			`k8s_src_type="Pod",k8s_dst_type="Pod"` +
 			`}`)
@@ -48,7 +48,7 @@ func testFlowsDecoratedWithZone(ctx context.Context, t *testing.T, _ *envconf.Co
 	})
 	// checking pod-to-pod node communication (response)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+		results, err := pq.Query(`obi_network_flow_bytes_total{` +
 			`k8s_dst_name="httppinger",k8s_src_name=~"testserver.*",` +
 			`k8s_src_type="Pod",k8s_dst_type="Pod"` +
 			`}`)
@@ -66,7 +66,7 @@ func testFlowsDecoratedWithZone(ctx context.Context, t *testing.T, _ *envconf.Co
 
 	// checking node-to-node communication (e.g between control plane and workers)
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+		results, err := pq.Query(`obi_network_flow_bytes_total{` +
 			`src_zone="server-zone",dst_zone="control-plane-zone",` +
 			`k8s_src_type="Node",k8s_dst_type="Node"` +
 			`}`)
@@ -78,7 +78,7 @@ func testFlowsDecoratedWithZone(ctx context.Context, t *testing.T, _ *envconf.Co
 		require.GreaterOrEqual(t, len(results), 2)
 	})
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+		results, err := pq.Query(`obi_network_flow_bytes_total{` +
 			`dst_zone="server-zone",src_zone="control-plane-zone",` +
 			`k8s_src_type="Node",k8s_dst_type="Node"` +
 			`}`)
@@ -90,7 +90,7 @@ func testFlowsDecoratedWithZone(ctx context.Context, t *testing.T, _ *envconf.Co
 		require.GreaterOrEqual(t, len(results), 2)
 	})
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+		results, err := pq.Query(`obi_network_flow_bytes_total{` +
 			`src_zone="client-zone",dst_zone="control-plane-zone",` +
 			`k8s_src_type="Node",k8s_dst_type="Node"` +
 			`}`)
@@ -102,7 +102,7 @@ func testFlowsDecoratedWithZone(ctx context.Context, t *testing.T, _ *envconf.Co
 		require.GreaterOrEqual(t, len(results), 2)
 	})
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{` +
+		results, err := pq.Query(`obi_network_flow_bytes_total{` +
 			`dst_zone="client-zone",src_zone="control-plane-zone",` +
 			`k8s_src_type="Node",k8s_dst_type="Node"` +
 			`}`)
@@ -121,13 +121,13 @@ func testInterZoneMetric(ctx context.Context, t *testing.T, _ *envconf.Config) c
 
 	// inter-zone bytes are reported
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_inter_zone_bytes_total{` +
+		results, err := pq.Query(`obi_network_inter_zone_bytes_total{` +
 			`src_zone="client-zone", dst_zone="server-zone"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 	})
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_inter_zone_bytes_total{` +
+		results, err := pq.Query(`obi_network_inter_zone_bytes_total{` +
 			`dst_zone="client-zone", src_zone="server-zone"}`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
@@ -137,11 +137,11 @@ func testInterZoneMetric(ctx context.Context, t *testing.T, _ *envconf.Config) c
 	})
 
 	// BUT same-zone bytes are not reported in this metric
-	results, err := pq.Query(`beyla_network_inter_zone_bytes_total{` +
+	results, err := pq.Query(`obi_network_inter_zone_bytes_total{` +
 		`src_zone="client-zone", dst_zone="client-zone"}`)
 	require.NoError(t, err)
 	require.Empty(t, results)
-	results, err = pq.Query(`beyla_network_inter_zone_bytes_total{` +
+	results, err = pq.Query(`obi_network_inter_zone_bytes_total{` +
 		`src_zone="server-zone", dst_zone="server-zone"}`)
 	require.NoError(t, err)
 	require.Empty(t, results)

--- a/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
+++ b/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
@@ -68,7 +68,7 @@ func TestNoSourceAndDestAvailable(t *testing.T) {
 		t.Run("check "+args, func(t *testing.T) {
 			test.Eventually(t, testTimeout, func(t require.TestingT) {
 				var err error
-				results, err := pq.Query(`beyla_network_flow_bytes_total{` + args + `}`)
+				results, err := pq.Query(`obi_network_flow_bytes_total{` + args + `}`)
 				require.NoError(t, err)
 				require.NotEmpty(t, results)
 			})
@@ -78,11 +78,11 @@ func TestNoSourceAndDestAvailable(t *testing.T) {
 	// Verify that HTTP pinger/testserver metrics can't have both source and destination labels,
 	// as the test client and server are in different nodes, and Beyla is only getting information
 	// from its local node
-	results, err := pq.Query(`beyla_network_flow_bytes_total{k8s_dst_name="httppinger",k8s_src_name=~"otherinstance.*",k8s_src_kind="Pod"}`)
+	results, err := pq.Query(`obi_network_flow_bytes_total{k8s_dst_name="httppinger",k8s_src_name=~"otherinstance.*",k8s_src_kind="Pod"}`)
 	require.NoError(t, err)
 	require.Empty(t, results)
 
-	results, err = pq.Query(`beyla_network_flow_bytes_total{k8s_src_name="httppinger",k8s_dst_name=~"otherinstance.*",k8s_dst_kind="Pod"}`)
+	results, err = pq.Query(`obi_network_flow_bytes_total{k8s_src_name="httppinger",k8s_dst_name=~"otherinstance.*",k8s_dst_kind="Pod"}`)
 	require.NoError(t, err)
 	require.Empty(t, results)
 }

--- a/test/integration/suites_network_test.go
+++ b/test/integration/suites_network_test.go
@@ -76,10 +76,10 @@ func TestNetwork_AllowedAttributes(t *testing.T) {
 	// When there flow deduplication, results must only include
 	// the attributes under the attributes.allow section
 	for _, f := range getNetFlows(t) {
-		require.Contains(t, f.Metric, "beyla_ip")
+		require.Contains(t, f.Metric, "obi_ip")
 		require.Contains(t, f.Metric, "src_name")
 		require.Contains(t, f.Metric, "dst_port")
-		assert.NotEmpty(t, f.Metric["beyla_ip"])
+		assert.NotEmpty(t, f.Metric["obi_ip"])
 		assert.NotEmpty(t, f.Metric["src_name"])
 		assert.NotEmpty(t, f.Metric["dst_port"])
 
@@ -104,7 +104,7 @@ func TestNetwork_ReverseDNS(t *testing.T) {
 		pq := prom.Client{HostPort: prometheusHostPort}
 		test.Eventually(t, 4*testTimeout, func(t require.TestingT) {
 			// now, verify that the network metric has been reported.
-			results, err := pq.Query(`beyla_network_flow_bytes_total` + query)
+			results, err := pq.Query(`obi_network_flow_bytes_total` + query)
 			require.NoError(t, err)
 			require.NotEmpty(t, results)
 		})
@@ -182,7 +182,7 @@ func getNetFlows(t *testing.T) []prom.Result {
 		require.Equal(t, http.StatusOK, r.StatusCode)
 
 		// now, verify that the network metric has been reported.
-		results, err = pq.Query(`beyla_network_flow_bytes_total`)
+		results, err = pq.Query(`obi_network_flow_bytes_total`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 	}, test.Interval(time.Second))
@@ -195,7 +195,7 @@ func getDirectionNetFlows(t *testing.T) []prom.Result {
 
 	// wait for first network flow metrics
 	test.Eventually(t, 4*testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total`)
+		results, err := pq.Query(`obi_network_flow_bytes_total`)
 		require.NoError(t, err)
 		require.NotEmpty(t, results)
 	}, test.Interval(time.Second))
@@ -209,7 +209,7 @@ func getDirectionNetFlows(t *testing.T) []prom.Result {
 
 	// verify that the correct network metric has been reported.
 	test.Eventually(t, 4*testTimeout, func(t require.TestingT) {
-		results, err = pq.Query(`beyla_network_flow_bytes_total{src_port="7000", dst_port="8080"} or beyla_network_flow_bytes_total{src_port="8080", dst_port="7000"}`)
+		results, err = pq.Query(`obi_network_flow_bytes_total{src_port="7000", dst_port="8080"} or obi_network_flow_bytes_total{src_port="8080", dst_port="7000"}`)
 		require.NoError(t, err)
 		require.Len(t, results, 2)
 		require.NotEmpty(t, results)
@@ -227,7 +227,7 @@ func callAndCheckMetrics(t *testing.T, req *http.Request, pq prom.Client, previo
 
 	// wait for fetching aggregated flows in beyla about this call
 	test.Eventually(t, 4*testTimeout, func(t require.TestingT) {
-		results, err := pq.Query(`beyla_network_flow_bytes_total{src_port="7000", dst_port="8080"} or beyla_network_flow_bytes_total{src_port="8080", dst_port="7000"}`)
+		results, err := pq.Query(`obi_network_flow_bytes_total{src_port="7000", dst_port="8080"} or obi_network_flow_bytes_total{src_port="8080", dst_port="7000"}`)
 		require.NoError(t, err)
 		require.Len(t, results, 2)
 		require.NotEmpty(t, results)


### PR DESCRIPTION
It also allows overriding the prefix to avoid introducing breaking changes, or to let other vendoring components (e.g. OTEL collector in the future) to provide their own custom prefix.

When we agree on a semantic convention for network metrics, we can remove any prefix.

Part of the set of tasks for issue https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/282