### PR TITLE
Swap the beyla_ prefixes to obi_ in the eBPF probe names

### DIFF
--- a/bpf/bpfcore/placeholder.go
+++ b/bpf/bpfcore/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package bpfcore

--- a/bpf/common/placeholder.go
+++ b/bpf/common/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package common

--- a/bpf/generictracer/k_unix_sock.h
+++ b/bpf/generictracer/k_unix_sock.h
@@ -46,7 +46,7 @@ pid_connection_info_for_inode(u64 id, pid_connection_info_t *p_conn, u32 inode, 
 }
 
 SEC("kprobe/unix_stream_recvmsg")
-int BPF_KPROBE(beyla_kprobe_unix_stream_recvmsg,
+int BPF_KPROBE(obi_kprobe_unix_stream_recvmsg,
                struct socket *sock,
                struct msghdr *msg,
                size_t size,
@@ -201,7 +201,7 @@ static __always_inline int return_unix_recvmsg(void *ctx, u64 id, int copied_len
 }
 
 SEC("kretprobe/unix_stream_recvmsg")
-int BPF_KRETPROBE(beyla_kretprobe_unix_stream_recvmsg, size_t copied) {
+int BPF_KRETPROBE(obi_kretprobe_unix_stream_recvmsg, size_t copied) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -214,7 +214,7 @@ int BPF_KRETPROBE(beyla_kretprobe_unix_stream_recvmsg, size_t copied) {
 }
 
 SEC("kprobe/unix_stream_sendmsg")
-int BPF_KPROBE(beyla_kprobe_unix_stream_sendmsg,
+int BPF_KPROBE(obi_kprobe_unix_stream_sendmsg,
                struct socket *sock,
                struct msghdr *msg,
                size_t size) {
@@ -265,7 +265,7 @@ int BPF_KPROBE(beyla_kprobe_unix_stream_sendmsg,
 }
 
 SEC("kretprobe/unix_stream_sendmsg")
-int BPF_KRETPROBE(beyla_kretprobe_unix_stream_sendmsg, int sent_len) {
+int BPF_KRETPROBE(obi_kretprobe_unix_stream_sendmsg, int sent_len) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {

--- a/bpf/generictracer/libssl.c
+++ b/bpf/generictracer/libssl.c
@@ -20,7 +20,7 @@
 // SSL_read_ex sets an argument pointer with the number of bytes read, while SSL_read returns
 // the number of bytes read.
 SEC("uprobe/libssl.so:SSL_read")
-int BPF_UPROBE(beyla_uprobe_ssl_read, void *ssl, const void *buf, int num) {
+int BPF_UPROBE(obi_uprobe_ssl_read, void *ssl, const void *buf, int num) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -50,7 +50,7 @@ int BPF_UPROBE(beyla_uprobe_ssl_read, void *ssl, const void *buf, int num) {
 }
 
 SEC("uretprobe/libssl.so:SSL_read")
-int BPF_URETPROBE(beyla_uretprobe_ssl_read, int ret) {
+int BPF_URETPROBE(obi_uretprobe_ssl_read, int ret) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -69,7 +69,7 @@ int BPF_URETPROBE(beyla_uretprobe_ssl_read, int ret) {
 }
 
 SEC("uprobe/libssl.so:SSL_read_ex")
-int BPF_UPROBE(beyla_uprobe_ssl_read_ex,
+int BPF_UPROBE(obi_uprobe_ssl_read_ex,
                void *ssl,
                const void *buf,
                int num,
@@ -103,7 +103,7 @@ int BPF_UPROBE(beyla_uprobe_ssl_read_ex,
 }
 
 SEC("uretprobe/libssl.so:SSL_read_ex")
-int BPF_URETPROBE(beyla_uretprobe_ssl_read_ex, int ret) {
+int BPF_URETPROBE(obi_uretprobe_ssl_read_ex, int ret) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -132,7 +132,7 @@ int BPF_URETPROBE(beyla_uretprobe_ssl_read_ex, int ret) {
 // SSL_write_ex sets an argument pointer with the number of bytes written, while SSL_write returns
 // the number of bytes written.
 SEC("uprobe/libssl.so:SSL_write")
-int BPF_UPROBE(beyla_uprobe_ssl_write, void *ssl, const void *buf, int num) {
+int BPF_UPROBE(obi_uprobe_ssl_write, void *ssl, const void *buf, int num) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -153,7 +153,7 @@ int BPF_UPROBE(beyla_uprobe_ssl_write, void *ssl, const void *buf, int num) {
 }
 
 SEC("uretprobe/libssl.so:SSL_write")
-int BPF_URETPROBE(beyla_uretprobe_ssl_write, int ret) {
+int BPF_URETPROBE(obi_uretprobe_ssl_write, int ret) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -176,7 +176,7 @@ int BPF_URETPROBE(beyla_uretprobe_ssl_write, int ret) {
 }
 
 SEC("uprobe/libssl.so:SSL_write_ex")
-int BPF_UPROBE(beyla_uprobe_ssl_write_ex, void *ssl, const void *buf, int num, size_t *written) {
+int BPF_UPROBE(obi_uprobe_ssl_write_ex, void *ssl, const void *buf, int num, size_t *written) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -197,7 +197,7 @@ int BPF_UPROBE(beyla_uprobe_ssl_write_ex, void *ssl, const void *buf, int num, s
 }
 
 SEC("uretprobe/libssl.so:SSL_write_ex")
-int BPF_URETPROBE(beyla_uretprobe_ssl_write_ex, int ret) {
+int BPF_URETPROBE(obi_uretprobe_ssl_write_ex, int ret) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -220,7 +220,7 @@ int BPF_URETPROBE(beyla_uretprobe_ssl_write_ex, int ret) {
 }
 
 SEC("uprobe/libssl.so:SSL_shutdown")
-int BPF_UPROBE(beyla_uprobe_ssl_shutdown, void *s) {
+int BPF_UPROBE(obi_uprobe_ssl_shutdown, void *s) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {

--- a/bpf/generictracer/nginx.c
+++ b/bpf/generictracer/nginx.c
@@ -23,7 +23,7 @@ volatile const s32 ngx_http_rev_s_conn = 0x8;
 volatile const s32 ngx_connection_s_sockaddr = 0x68;
 
 SEC("uprobe/nginx:ngx_http_upstream_init")
-int beyla_ngx_http_upstream_init(struct pt_regs *ctx) {
+int obi_ngx_http_upstream_init(struct pt_regs *ctx) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -53,7 +53,7 @@ static __always_inline void get_sock_info(u64 id, void *conn_ptr, connection_inf
 }
 
 SEC("uprobe/nginx:ngx_event_connect_peer_ret")
-int beyla_ngx_event_connect_peer_ret(struct pt_regs *ctx) {
+int obi_ngx_event_connect_peer_ret(struct pt_regs *ctx) {
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {

--- a/bpf/generictracer/nodejs.c
+++ b/bpf/generictracer/nodejs.c
@@ -7,7 +7,7 @@
 #include <maps/nodejs_fd_map.h>
 
 SEC("uprobe/node:uv_fs_access")
-int BPF_KPROBE(beyla_uv_fs_access, void *loop, void *req, const char *path) {
+int BPF_KPROBE(obi_uv_fs_access, void *loop, void *req, const char *path) {
     (void)loop;
     (void)req;
 

--- a/bpf/generictracer/placeholder.go
+++ b/bpf/generictracer/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package generictracer

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -386,7 +386,7 @@ static __always_inline void handle_http_response(unsigned char *small_buf,
 
 // k_tail_protocol_http
 SEC("kprobe/http")
-int beyla_protocol_http(void *ctx) {
+int obi_protocol_http(void *ctx) {
     call_protocol_args_t *args = protocol_args();
 
     if (!args) {

--- a/bpf/generictracer/protocol_http2.h
+++ b/bpf/generictracer/protocol_http2.h
@@ -201,7 +201,7 @@ static __always_inline void handle_data_frame(void *ctx, grpc_frames_ctx_t *g_ct
 
 // k_tail_protocol_http2_grpc_handle_start_frame
 SEC("kprobe/http2")
-int beyla_protocol_http2_grpc_handle_start_frame(void *ctx) {
+int obi_protocol_http2_grpc_handle_start_frame(void *ctx) {
     (void)ctx;
 
     grpc_frames_ctx_t *g_ctx = grpc_ctx();
@@ -222,7 +222,7 @@ int beyla_protocol_http2_grpc_handle_start_frame(void *ctx) {
 
 // k_tail_protocol_http2_grpc_handle_end_frame
 SEC("kprobe/http2")
-int beyla_protocol_http2_grpc_handle_end_frame(void *ctx) {
+int obi_protocol_http2_grpc_handle_end_frame(void *ctx) {
     (void)ctx;
 
     grpc_frames_ctx_t *g_ctx = grpc_ctx();
@@ -261,7 +261,7 @@ int beyla_protocol_http2_grpc_handle_end_frame(void *ctx) {
 // information to evaluate whether the parsed data is potentially a GRPC
 // frame, and if so, we ship it to userspace for further processing.
 SEC("kprobe/http2")
-int beyla_protocol_http2_grpc_frames(void *ctx) {
+int obi_protocol_http2_grpc_frames(void *ctx) {
     const u8 k_max_loop_iterations = 4; // the maximum number of the for loop iterations
     const u8 k_loop_count = 3;          // the number of times we will retry the loop
     const u8 k_iterations = k_max_loop_iterations * k_loop_count;
@@ -332,7 +332,7 @@ int beyla_protocol_http2_grpc_frames(void *ctx) {
 
 // k_tail_protocol_http2
 SEC("kprobe/http2")
-int beyla_protocol_http2(void *ctx) {
+int obi_protocol_http2(void *ctx) {
     call_protocol_args_t *args = protocol_args();
 
     if (!args) {

--- a/bpf/generictracer/protocol_mysql.h
+++ b/bpf/generictracer/protocol_mysql.h
@@ -188,7 +188,7 @@ static __always_inline u32 mysql_command_offset(struct mysql_hdr *hdr) {
 
 // k_tail_protocol_mysql
 SEC("kprobe/mysql")
-int beyla_protocol_mysql(void *ctx) {
+int obi_protocol_mysql(void *ctx) {
     call_protocol_args_t *args = protocol_args();
     if (!args) {
         return 0;

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -228,7 +228,7 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
 
 // k_tail_protocol_tcp
 SEC("kprobe/tcp")
-int beyla_protocol_tcp(void *ctx) {
+int obi_protocol_tcp(void *ctx) {
     call_protocol_args_t *args = protocol_args();
 
     if (!args) {

--- a/bpf/gotracer/go_grpc.c
+++ b/bpf/gotracer/go_grpc.c
@@ -85,7 +85,7 @@ struct {
     49 // 1 + 1 + 8 + 1 +~ 38 = type byte + hpack_len_as_byte("traceparent") + strlen(hpack("traceparent")) + len_as_byte(38) + hpack(generated tracepanent id)
 
 SEC("uprobe/server_handleStream")
-int beyla_uprobe_server_handleStream(struct pt_regs *ctx) {
+int obi_uprobe_server_handleStream(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/server_handleStream === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
@@ -154,7 +154,7 @@ int beyla_uprobe_server_handleStream(struct pt_regs *ctx) {
 
 // Handles finding the connection information for http2 servers in grpc
 SEC("uprobe/http2Server_operateHeaders")
-int beyla_uprobe_http2Server_operateHeaders(struct pt_regs *ctx) {
+int obi_uprobe_http2Server_operateHeaders(struct pt_regs *ctx) {
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     void *tr = GO_PARAM1(ctx);
     void *frame = GO_PARAM2(ctx);
@@ -191,7 +191,7 @@ int beyla_uprobe_http2Server_operateHeaders(struct pt_regs *ctx) {
 
 // Handles finding the connection information for grpc ServeHTTP
 SEC("uprobe/serverHandlerTransport_HandleStreams")
-int beyla_uprobe_server_handler_transport_handle_streams(struct pt_regs *ctx) {
+int obi_uprobe_server_handler_transport_handle_streams(struct pt_regs *ctx) {
     void *tr = GO_PARAM1(ctx);
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     bpf_dbg_printk("=== uprobe/serverHandlerTransport_HandleStreams tr %llx goroutine %lx === ",
@@ -222,7 +222,7 @@ int beyla_uprobe_server_handler_transport_handle_streams(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/server_handleStream")
-int beyla_uprobe_server_handleStream_return(struct pt_regs *ctx) {
+int obi_uprobe_server_handleStream_return(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/server_handleStream return === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -315,7 +315,7 @@ done:
 }
 
 SEC("uprobe/transport_writeStatus")
-int beyla_uprobe_transport_writeStatus(struct pt_regs *ctx) {
+int obi_uprobe_transport_writeStatus(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/transport_writeStatus === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -388,7 +388,7 @@ static __always_inline void clientConnStart(
 }
 
 SEC("uprobe/ClientConn_Invoke")
-int beyla_uprobe_ClientConn_Invoke(struct pt_regs *ctx) {
+int obi_uprobe_ClientConn_Invoke(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc grpc ClientConn.Invoke === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -406,7 +406,7 @@ int beyla_uprobe_ClientConn_Invoke(struct pt_regs *ctx) {
 
 // Same as ClientConn_Invoke, registers for the method are offset by one
 SEC("uprobe/ClientConn_NewStream")
-int beyla_uprobe_ClientConn_NewStream(struct pt_regs *ctx) {
+int obi_uprobe_ClientConn_NewStream(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc grpc ClientConn.NewStream === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -492,7 +492,7 @@ done:
 
 // Same as ClientConn_Invoke, registers for the method are offset by one
 SEC("uprobe/ClientConn_NewStream")
-int beyla_uprobe_ClientConn_NewStream_return(struct pt_regs *ctx) {
+int obi_uprobe_ClientConn_NewStream_return(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc grpc ClientConn.NewStream return === ");
 
     void *stream = GO_PARAM1(ctx);
@@ -505,7 +505,7 @@ int beyla_uprobe_ClientConn_NewStream_return(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/ClientConn_Close")
-int beyla_uprobe_ClientConn_Close(struct pt_regs *ctx) {
+int obi_uprobe_ClientConn_Close(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc grpc ClientConn.Close === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -519,7 +519,7 @@ int beyla_uprobe_ClientConn_Close(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/ClientConn_Invoke")
-int beyla_uprobe_ClientConn_Invoke_return(struct pt_regs *ctx) {
+int obi_uprobe_ClientConn_Invoke_return(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc grpc ClientConn.Invoke return === ");
 
     void *err = GO_PARAM1(ctx);
@@ -533,7 +533,7 @@ int beyla_uprobe_ClientConn_Invoke_return(struct pt_regs *ctx) {
 
 // google.golang.org/grpc.(*clientStream).RecvMsg
 SEC("uprobe/clientStream_RecvMsg")
-int beyla_uprobe_clientStream_RecvMsg_return(struct pt_regs *ctx) {
+int obi_uprobe_clientStream_RecvMsg_return(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc grpc clientStream.RecvMsg return === ");
     void *err = (void *)GO_PARAM1(ctx);
     return grpc_connect_done(ctx, err);
@@ -554,7 +554,7 @@ struct {
 // The gRPC client stream is written on another goroutine in transport loopyWriter (controlbuf.go).
 // We extract the stream ID when it's just created and make a mapping of it to our goroutine that's executing ClientConn.Invoke.
 SEC("uprobe/transport_http2Client_NewStream")
-int beyla_uprobe_transport_http2Client_NewStream(struct pt_regs *ctx) {
+int obi_uprobe_transport_http2Client_NewStream(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc transport.(*http2Client).NewStream === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -638,7 +638,7 @@ int beyla_uprobe_transport_http2Client_NewStream(struct pt_regs *ctx) {
 // can hit the uprobe at the same time on different CPUs and both will grab the same stream_id, i.e
 // the nextID. We read what's the right stream id on exit.
 SEC("uprobe/transport_http2Client_NewStream_ret")
-int beyla_uprobe_transport_http2Client_NewStream_Returns(struct pt_regs *ctx) {
+int obi_uprobe_transport_http2Client_NewStream_Returns(struct pt_regs *ctx) {
 #ifndef NO_HEADER_PROPAGATION
     bpf_dbg_printk("=== uprobe/proc returns transport.(*http2Client).NewStream === ");
 
@@ -709,7 +709,7 @@ struct {
 } grpc_framer_invocation_map SEC(".maps");
 
 SEC("uprobe/grpcFramerWriteHeaders")
-int beyla_uprobe_grpcFramerWriteHeaders(struct pt_regs *ctx) {
+int obi_uprobe_grpcFramerWriteHeaders(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc grpc Framer writeHeaders === ");
 
     void *framer = GO_PARAM1(ctx);
@@ -788,7 +788,7 @@ int beyla_uprobe_grpcFramerWriteHeaders(struct pt_regs *ctx) {
 }
 #else
 SEC("uprobe/grpcFramerWriteHeaders")
-int beyla_uprobe_grpcFramerWriteHeaders(struct pt_regs *ctx) {
+int obi_uprobe_grpcFramerWriteHeaders(struct pt_regs *ctx) {
     return 0;
 }
 #endif
@@ -798,7 +798,7 @@ int beyla_uprobe_grpcFramerWriteHeaders(struct pt_regs *ctx) {
     66 // 1 + 1 + 8 + 1 + 55 = type byte + hpack_len_as_byte("traceparent") + strlen(hpack("traceparent")) + len_as_byte(55) + generated traceparent id
 
 SEC("uprobe/grpcFramerWriteHeaders_returns")
-int beyla_uprobe_grpcFramerWriteHeaders_returns(struct pt_regs *ctx) {
+int obi_uprobe_grpcFramerWriteHeaders_returns(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc grpc Framer writeHeaders returns === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -917,7 +917,7 @@ int beyla_uprobe_grpcFramerWriteHeaders_returns(struct pt_regs *ctx) {
 }
 #else
 SEC("uprobe/grpcFramerWriteHeaders_returns")
-int beyla_uprobe_grpcFramerWriteHeaders_returns(struct pt_regs *ctx) {
+int obi_uprobe_grpcFramerWriteHeaders_returns(struct pt_regs *ctx) {
     return 0;
 }
 #endif

--- a/bpf/gotracer/go_kafka_go.c
+++ b/bpf/gotracer/go_kafka_go.c
@@ -69,7 +69,7 @@ struct {
 
 // Code for the produce messages path
 SEC("uprobe/writer_write_messages")
-int beyla_uprobe_writer_write_messages(struct pt_regs *ctx) {
+int obi_uprobe_writer_write_messages(struct pt_regs *ctx) {
     void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
     void *w_ptr = (void *)GO_PARAM1(ctx);
     bpf_dbg_printk(
@@ -86,7 +86,7 @@ int beyla_uprobe_writer_write_messages(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/writer_produce")
-int beyla_uprobe_writer_produce(struct pt_regs *ctx) {
+int obi_uprobe_writer_produce(struct pt_regs *ctx) {
     void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
     bpf_dbg_printk("=== uprobe/kafka-go writer_produce %llx === ", goroutine_addr);
     go_addr_key_t g_key = {};
@@ -134,7 +134,7 @@ int beyla_uprobe_writer_produce(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/client_roundTrip")
-int beyla_uprobe_client_roundTrip(struct pt_regs *ctx) {
+int obi_uprobe_client_roundTrip(struct pt_regs *ctx) {
     void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
     bpf_dbg_printk("=== uprobe/kafka-go client_roundTrip %llx === ", goroutine_addr);
     go_addr_key_t g_key = {};
@@ -159,7 +159,7 @@ int beyla_uprobe_client_roundTrip(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/protocol_RoundTrip")
-int beyla_uprobe_protocol_roundtrip(struct pt_regs *ctx) {
+int obi_uprobe_protocol_roundtrip(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/kafka-go protocol_RoundTrip === ");
     void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
     void *rw_ptr = (void *)GO_PARAM2(ctx);
@@ -192,7 +192,7 @@ int beyla_uprobe_protocol_roundtrip(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/protocol_RoundTrip_ret")
-int beyla_uprobe_protocol_roundtrip_ret(struct pt_regs *ctx) {
+int obi_uprobe_protocol_roundtrip_ret(struct pt_regs *ctx) {
     void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
     bpf_dbg_printk("=== uprobe/protocol_RoundTrip ret %llx === ", goroutine_addr);
     go_addr_key_t g_key = {};
@@ -246,7 +246,7 @@ int beyla_uprobe_protocol_roundtrip_ret(struct pt_regs *ctx) {
 
 // Code for the fetch messages path
 SEC("uprobe/reader_read")
-int beyla_uprobe_reader_read(struct pt_regs *ctx) {
+int obi_uprobe_reader_read(struct pt_regs *ctx) {
     void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
     void *r_ptr = (void *)GO_PARAM1(ctx);
     void *conn = (void *)GO_PARAM5(ctx);
@@ -292,7 +292,7 @@ int beyla_uprobe_reader_read(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/reader_send_message")
-int beyla_uprobe_reader_send_message(struct pt_regs *ctx) {
+int obi_uprobe_reader_send_message(struct pt_regs *ctx) {
     void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
     bpf_dbg_printk("=== uprobe/kafka-go reader_send_message %llx === ", goroutine_addr);
     go_addr_key_t g_key = {};
@@ -309,7 +309,7 @@ int beyla_uprobe_reader_send_message(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/reader_read")
-int beyla_uprobe_reader_read_ret(struct pt_regs *ctx) {
+int obi_uprobe_reader_read_ret(struct pt_regs *ctx) {
     void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
     bpf_dbg_printk("=== uprobe/kafka-go reader_read ret %llx === ", goroutine_addr);
     go_addr_key_t g_key = {};

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -116,7 +116,7 @@ static __always_inline unsigned char *temp_body_mem() {
 // func (mux *ServeMux) ServeHTTP(w ResponseWriter, r *Request)
 // or other functions sharing the same signature (e.g http.Handler.ServeHTTP)
 SEC("uprobe/ServeHTTP")
-int beyla_uprobe_ServeHTTP(struct pt_regs *ctx) {
+int obi_uprobe_ServeHTTP(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/ServeHTTP === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
 
@@ -210,7 +210,7 @@ done:
 }
 
 SEC("uprobe/readRequest")
-int beyla_uprobe_readRequestStart(struct pt_regs *ctx) {
+int obi_uprobe_readRequestStart(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc readRequest === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -256,7 +256,7 @@ int beyla_uprobe_readRequestStart(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/readRequest")
-int beyla_uprobe_readRequestReturns(struct pt_regs *ctx) {
+int obi_uprobe_readRequestReturns(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc readRequest returns === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -286,7 +286,7 @@ int beyla_uprobe_readRequestReturns(struct pt_regs *ctx) {
 
 // Handles finding the connection information for http2 servers in grpc
 SEC("uprobe/http2Server_processHeaders")
-int beyla_uprobe_http2Server_processHeaders(struct pt_regs *ctx) {
+int obi_uprobe_http2Server_processHeaders(struct pt_regs *ctx) {
     void *sc_ptr = GO_PARAM1(ctx);
     void *frame = GO_PARAM2(ctx);
     bpf_dbg_printk("=== uprobe/http2Server_processHeaders sc %lx === ", sc_ptr);
@@ -352,7 +352,7 @@ static __always_inline unsigned char *match_header(
 }
 
 SEC("uprobe/readContinuedLineSlice")
-int beyla_uprobe_readContinuedLineSliceReturns(struct pt_regs *ctx) {
+int obi_uprobe_readContinuedLineSliceReturns(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc readContinuedLineSlice returns === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -487,7 +487,7 @@ done:
 }
 
 SEC("uprobe/ServeHTTP_ret")
-int beyla_uprobe_ServeHTTPReturns(struct pt_regs *ctx) {
+int obi_uprobe_ServeHTTPReturns(struct pt_regs *ctx) {
     return serve_http_returns(ctx);
 }
 
@@ -595,13 +595,13 @@ static __always_inline void roundTripStartHelper(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/roundTrip")
-int beyla_uprobe_roundTrip(struct pt_regs *ctx) {
+int obi_uprobe_roundTrip(struct pt_regs *ctx) {
     roundTripStartHelper(ctx);
     return 0;
 }
 
 SEC("uprobe/roundTrip_return")
-int beyla_uprobe_roundTripReturn(struct pt_regs *ctx) {
+int obi_uprobe_roundTripReturn(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc http roundTrip return === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -698,7 +698,7 @@ done:
 #ifndef NO_HEADER_PROPAGATION
 // Context propagation through HTTP headers
 SEC("uprobe/header_writeSubset")
-int beyla_uprobe_writeSubset(struct pt_regs *ctx) {
+int obi_uprobe_writeSubset(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc header writeSubset === ");
 
     void *header_addr = GO_PARAM1(ctx);
@@ -796,14 +796,14 @@ done:
 }
 #else
 SEC("uprobe/header_writeSubset")
-int beyla_uprobe_writeSubset(struct pt_regs *ctx) {
+int obi_uprobe_writeSubset(struct pt_regs *ctx) {
     return 0;
 }
 #endif
 
 // HTTP 2.0 server support
 SEC("uprobe/http2ResponseWriterStateWriteHeader")
-int beyla_uprobe_http2ResponseWriterStateWriteHeader(struct pt_regs *ctx) {
+int obi_uprobe_http2ResponseWriterStateWriteHeader(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc (http response)/(http2 responseWriterState) writeHeader === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -843,7 +843,7 @@ int beyla_uprobe_http2ResponseWriterStateWriteHeader(struct pt_regs *ctx) {
 
 // HTTP 2.0 server support
 SEC("uprobe/http2serverConn_runHandler")
-int beyla_uprobe_http2serverConn_runHandler(struct pt_regs *ctx) {
+int obi_uprobe_http2serverConn_runHandler(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc http2serverConn_runHandler === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -964,7 +964,7 @@ static __always_inline void setup_http2_client_conn(void *goroutine_addr,
 }
 
 SEC("uprobe/http2RoundTrip")
-int beyla_uprobe_http2RoundTrip(struct pt_regs *ctx) {
+int obi_uprobe_http2RoundTrip(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc http2RoundTrip === ");
     // we use the usual start helper, just like for normal http calls, but we later save
     // more context, like the streamID
@@ -976,7 +976,7 @@ int beyla_uprobe_http2RoundTrip(struct pt_regs *ctx) {
 // This runs on separate go routine called from the round tripper, but we need it
 // to establish the correct connection information and stream_id
 SEC("uprobe/http2WriteHeaders")
-int beyla_uprobe_http2WriteHeaders(struct pt_regs *ctx) {
+int obi_uprobe_http2WriteHeaders(struct pt_regs *ctx) {
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     void *cc_ptr = GO_PARAM1(ctx);
     u64 stream_id = (u64)GO_PARAM2(ctx);
@@ -997,7 +997,7 @@ int beyla_uprobe_http2WriteHeaders(struct pt_regs *ctx) {
 // to establish the correct connection information and stream_id. The Go vendored
 // version has its own offsets.
 SEC("uprobe/http2WriteHeadersVendored")
-int beyla_uprobe_http2WriteHeaders_vendored(struct pt_regs *ctx) {
+int obi_uprobe_http2WriteHeaders_vendored(struct pt_regs *ctx) {
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     void *cc_ptr = GO_PARAM1(ctx);
     u64 stream_id = (u64)GO_PARAM2(ctx);
@@ -1033,7 +1033,7 @@ struct {
 } framer_invocation_map SEC(".maps");
 
 SEC("uprobe/http2FramerWriteHeaders")
-int beyla_uprobe_http2FramerWriteHeaders(struct pt_regs *ctx) {
+int obi_uprobe_http2FramerWriteHeaders(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc http2 Framer writeHeaders === ");
     void *framer = GO_PARAM1(ctx);
 
@@ -1110,7 +1110,7 @@ int beyla_uprobe_http2FramerWriteHeaders(struct pt_regs *ctx) {
 }
 #else
 SEC("uprobe/http2FramerWriteHeaders")
-int beyla_uprobe_http2FramerWriteHeaders(struct pt_regs *ctx) {
+int obi_uprobe_http2FramerWriteHeaders(struct pt_regs *ctx) {
     return 0;
 }
 #endif
@@ -1120,7 +1120,7 @@ int beyla_uprobe_http2FramerWriteHeaders(struct pt_regs *ctx) {
     66 // 1 + 1 + 8 + 1 + 55 = type byte + hpack_len_as_byte("traceparent") + strlen(hpack("traceparent")) + len_as_byte(55) + generated traceparent id
 
 SEC("uprobe/http2FramerWriteHeaders_returns")
-int beyla_uprobe_http2FramerWriteHeaders_returns(struct pt_regs *ctx) {
+int obi_uprobe_http2FramerWriteHeaders_returns(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc http2 Framer writeHeaders returns === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -1232,13 +1232,13 @@ done:
 }
 #else
 SEC("uprobe/http2FramerWriteHeaders_returns")
-int beyla_uprobe_http2FramerWriteHeaders_returns(struct pt_regs *ctx) {
+int obi_uprobe_http2FramerWriteHeaders_returns(struct pt_regs *ctx) {
     return 0;
 }
 #endif
 
 SEC("uprobe/connServe")
-int beyla_uprobe_connServe(struct pt_regs *ctx) {
+int obi_uprobe_connServe(struct pt_regs *ctx) {
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     bpf_dbg_printk("=== uprobe/proc http conn serve goroutine %lx === ", goroutine_addr);
 
@@ -1252,7 +1252,7 @@ int beyla_uprobe_connServe(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/netFdRead")
-int beyla_uprobe_netFdRead(struct pt_regs *ctx) {
+int obi_uprobe_netFdRead(struct pt_regs *ctx) {
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     bpf_dbg_printk("=== uprobe/proc netFD read goroutine %lx === ", goroutine_addr);
 
@@ -1300,7 +1300,7 @@ int beyla_uprobe_netFdRead(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/bodyRead")
-int beyla_uprobe_bodyRead(struct pt_regs *ctx) {
+int obi_uprobe_bodyRead(struct pt_regs *ctx) {
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     bpf_dbg_printk("=== uprobe/proc body read goroutine === ");
     go_addr_key_t g_key = {};
@@ -1320,7 +1320,7 @@ int beyla_uprobe_bodyRead(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/bodyReadRet")
-int beyla_uprobe_bodyReadReturn(struct pt_regs *ctx) {
+int obi_uprobe_bodyReadReturn(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc body read returns goroutine === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     go_addr_key_t g_key = {};
@@ -1360,7 +1360,7 @@ int beyla_uprobe_bodyReadReturn(struct pt_regs *ctx) {
 
 //k_tail_jsonrpc
 SEC("uprobe/readJsonrpcMethod")
-int beyla_read_jsonrpc_method(struct pt_regs *ctx) {
+int obi_read_jsonrpc_method(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc read jsonrpc method === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     go_addr_key_t g_key = {};
@@ -1396,7 +1396,7 @@ int beyla_read_jsonrpc_method(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/connServeRet")
-int beyla_uprobe_connServeRet(struct pt_regs *ctx) {
+int obi_uprobe_connServeRet(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc http conn serve ret === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
 
@@ -1409,7 +1409,7 @@ int beyla_uprobe_connServeRet(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/persistConnRoundTrip")
-int beyla_uprobe_persistConnRoundTrip(struct pt_regs *ctx) {
+int obi_uprobe_persistConnRoundTrip(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc http persistConn roundTrip === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     off_table_t *ot = get_offsets_table();

--- a/bpf/gotracer/go_redis.c
+++ b/bpf/gotracer/go_redis.c
@@ -50,7 +50,7 @@ static __always_inline void setup_request(void *goroutine_addr) {
 // github.com/redis/go-redis/v9.(*baseClient)._process
 // func (c *baseClient) _process(ctx context.Context, cmd Cmder, attempt int) (bool, error) {
 SEC("uprobe/redis_process")
-int beyla_uprobe_redis_process(struct pt_regs *ctx) {
+int obi_uprobe_redis_process(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/redis _process === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
@@ -61,7 +61,7 @@ int beyla_uprobe_redis_process(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/redis_process")
-int beyla_uprobe_redis_process_ret(struct pt_regs *ctx) {
+int obi_uprobe_redis_process_ret(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/redis _process returns === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
@@ -90,7 +90,7 @@ int beyla_uprobe_redis_process_ret(struct pt_regs *ctx) {
 //	ctx context.Context, timeout time.Duration, fn func(wr *proto.Writer) error,
 // ) error
 SEC("uprobe/redis_with_writer")
-int beyla_uprobe_redis_with_writer(struct pt_regs *ctx) {
+int obi_uprobe_redis_with_writer(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/redis WithWriter === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     void *cn_ptr = GO_PARAM1(ctx);
@@ -140,7 +140,7 @@ int beyla_uprobe_redis_with_writer(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/redis_with_writer")
-int beyla_uprobe_redis_with_writer_ret(struct pt_regs *ctx) {
+int obi_uprobe_redis_with_writer_ret(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/redis WithWriter returns === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     off_table_t *ot = get_offsets_table();

--- a/bpf/gotracer/go_runtime.c
+++ b/bpf/gotracer/go_runtime.c
@@ -30,7 +30,7 @@ struct {
 } newproc1 SEC(".maps");
 
 SEC("uprobe/runtime_newproc1")
-int beyla_uprobe_proc_newproc1(struct pt_regs *ctx) {
+int obi_uprobe_proc_newproc1(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc newproc1 === ");
     void *creator_goroutine = GOROUTINE_PTR(ctx);
     bpf_dbg_printk("creator_goroutine_addr %lx", creator_goroutine);
@@ -48,7 +48,7 @@ int beyla_uprobe_proc_newproc1(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/runtime_newproc1_return")
-int beyla_uprobe_proc_newproc1_ret(struct pt_regs *ctx) {
+int obi_uprobe_proc_newproc1_ret(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc newproc1 returns === ");
     void *creator_goroutine = GOROUTINE_PTR(ctx);
     u64 pid_tid = bpf_get_current_pid_tgid();
@@ -91,7 +91,7 @@ done:
 }
 
 SEC("uprobe/runtime_goexit1")
-int beyla_uprobe_proc_goexit1(struct pt_regs *ctx) {
+int obi_uprobe_proc_goexit1(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/proc goexit1 === ");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);

--- a/bpf/gotracer/go_sarama.c
+++ b/bpf/gotracer/go_sarama.c
@@ -36,7 +36,7 @@ struct {
 } ongoing_kafka_requests SEC(".maps");
 
 SEC("uprobe/sarama_sendInternal")
-int beyla_uprobe_sarama_sendInternal(struct pt_regs *ctx) {
+int obi_uprobe_sarama_sendInternal(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/sarama_sendInternal === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     void *b_ptr = GO_PARAM1(ctx);
@@ -66,7 +66,7 @@ int beyla_uprobe_sarama_sendInternal(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/sarama_broker_write")
-int beyla_uprobe_sarama_broker_write(struct pt_regs *ctx) {
+int obi_uprobe_sarama_broker_write(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/sarama_broker write === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
 
@@ -138,7 +138,7 @@ int beyla_uprobe_sarama_broker_write(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/sarama_response_promise_handle")
-int beyla_uprobe_sarama_response_promise_handle(struct pt_regs *ctx) {
+int obi_uprobe_sarama_response_promise_handle(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/sarama_response_promise_handle === ");
 
     void *p = GO_PARAM1(ctx);

--- a/bpf/gotracer/go_sdk.c
+++ b/bpf/gotracer/go_sdk.c
@@ -132,12 +132,12 @@ static __always_inline int tracer_start(struct pt_regs *ctx, u8 check_delegate) 
 }
 
 SEC("uprobe/tracer_Start")
-int beyla_uprobe_tracer_Start(struct pt_regs *ctx) {
+int obi_uprobe_tracer_Start(struct pt_regs *ctx) {
     return tracer_start(ctx, 0);
 }
 
 SEC("uprobe/tracer_Start_global")
-int beyla_uprobe_tracer_Start_global(struct pt_regs *ctx) {
+int obi_uprobe_tracer_Start_global(struct pt_regs *ctx) {
     return tracer_start(ctx, 1);
 }
 
@@ -202,7 +202,7 @@ static __always_inline void read_attrs_from_opts(otel_span_t *span, void *opts_p
 // func (t *tracer) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span)
 // https://github.com/open-telemetry/opentelemetry-go/blob/98b32a6c3a87fbee5d34c063b9096f416b250897/internal/global/trace.go#L149
 SEC("uprobe/tracer_Start_ret")
-int beyla_uprobe_tracer_Start_Returns(struct pt_regs *ctx) {
+int obi_uprobe_tracer_Start_Returns(struct pt_regs *ctx) {
     void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
     void *span_ptr = (void *)GO_PARAM4(ctx);
     bpf_dbg_printk("=== uretprobe/tracer.Start [%lx] span %lx === ", goroutine_addr, span_ptr);
@@ -254,7 +254,7 @@ int beyla_uprobe_tracer_Start_Returns(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/nonRecordingSpan_End")
-int beyla_uprobe_nonRecordingSpan_End(struct pt_regs *ctx) {
+int obi_uprobe_nonRecordingSpan_End(struct pt_regs *ctx) {
     void *span_ptr = (void *)GO_PARAM1(ctx);
     bpf_dbg_printk("=== uprobe/nonRecordingSpan.End [%lx] span %lx === ",
                    (void *)GOROUTINE_PTR(ctx),
@@ -287,7 +287,7 @@ int beyla_uprobe_nonRecordingSpan_End(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/span_SetStatus")
-int beyla_uprobe_SetStatus(struct pt_regs *ctx) {
+int obi_uprobe_SetStatus(struct pt_regs *ctx) {
     void *span_ptr = (void *)GO_PARAM1(ctx);
     bpf_dbg_printk(
         "=== uprobe/span.SetStatus [%lx] span %lx === ", (void *)GOROUTINE_PTR(ctx), span_ptr);
@@ -319,7 +319,7 @@ int beyla_uprobe_SetStatus(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/span_SetAttributes")
-int beyla_uprobe_SetAttributes(struct pt_regs *ctx) {
+int obi_uprobe_SetAttributes(struct pt_regs *ctx) {
     void *span_ptr = (void *)GO_PARAM1(ctx);
     bpf_dbg_printk(
         "=== uprobe/span.SetAttributes [%lx] span %lx === ", (void *)GOROUTINE_PTR(ctx), span_ptr);
@@ -340,7 +340,7 @@ int beyla_uprobe_SetAttributes(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/span_SetName")
-int beyla_uprobe_SetName(struct pt_regs *ctx) {
+int obi_uprobe_SetName(struct pt_regs *ctx) {
     void *span_ptr = (void *)GO_PARAM1(ctx);
     bpf_dbg_printk(
         "=== uprobe/span.SetName [%lx] span %lx === ", (void *)GOROUTINE_PTR(ctx), span_ptr);
@@ -371,7 +371,7 @@ int beyla_uprobe_SetName(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/span_RecordError")
-int beyla_uprobe_RecordError(struct pt_regs *ctx) {
+int obi_uprobe_RecordError(struct pt_regs *ctx) {
     void *span_ptr = (void *)GO_PARAM1(ctx);
     bpf_dbg_printk(
         "=== uprobe/span.RecordError [%lx] span %lx === ", (void *)GOROUTINE_PTR(ctx), span_ptr);

--- a/bpf/gotracer/go_sql.c
+++ b/bpf/gotracer/go_sql.c
@@ -44,7 +44,7 @@ static __always_inline void set_sql_info(void *goroutine_addr, void *sql_param, 
 }
 
 SEC("uprobe/queryDC")
-int beyla_uprobe_queryDC(struct pt_regs *ctx) {
+int obi_uprobe_queryDC(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/queryDC === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
@@ -57,7 +57,7 @@ int beyla_uprobe_queryDC(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/execDC")
-int beyla_uprobe_execDC(struct pt_regs *ctx) {
+int obi_uprobe_execDC(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/execDC === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
@@ -69,7 +69,7 @@ int beyla_uprobe_execDC(struct pt_regs *ctx) {
 }
 
 SEC("uprobe/queryDC")
-int beyla_uprobe_queryReturn(struct pt_regs *ctx) {
+int obi_uprobe_queryReturn(struct pt_regs *ctx) {
 
     bpf_dbg_printk("=== uprobe/query return === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);

--- a/bpf/gotracer/placeholder.go
+++ b/bpf/gotracer/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package gotracer

--- a/bpf/gpuevent/placeholder.go
+++ b/bpf/gpuevent/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package gpuevent

--- a/bpf/imports.go
+++ b/bpf/imports.go
@@ -1,4 +1,4 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package bpf
 

--- a/bpf/logger/placeholder.go
+++ b/bpf/logger/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package logger

--- a/bpf/maps/placeholder.go
+++ b/bpf/maps/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package maps

--- a/bpf/netolly/flows.c
+++ b/bpf/netolly/flows.c
@@ -266,12 +266,12 @@ cleanup:
 }
 
 SEC("tc_ingress")
-int beyla_ingress_flow_parse(struct __sk_buff *skb) {
+int obi_ingress_flow_parse(struct __sk_buff *skb) {
     return flow_monitor(skb);
 }
 
 SEC("tc_egress")
-int beyla_egress_flow_parse(struct __sk_buff *skb) {
+int obi_egress_flow_parse(struct __sk_buff *skb) {
     return flow_monitor(skb);
 }
 

--- a/bpf/netolly/flows_sock.c
+++ b/bpf/netolly/flows_sock.c
@@ -182,7 +182,7 @@ static __always_inline bool same_ip(const u8 *ip1, const u8 *ip2) {
 }
 
 SEC("socket/filter")
-int beyla_socket__filter(struct __sk_buff *skb) {
+int obi_socket__filter(struct __sk_buff *skb) {
     // If sampling is defined, will only parse 1 out of "sampling" flows
     if (sampling != 0 && (bpf_get_prandom_u32() % sampling) != 0) {
         return TC_ACT_UNSPEC;

--- a/bpf/netolly/placeholder.go
+++ b/bpf/netolly/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package netolly

--- a/bpf/pid/placeholder.go
+++ b/bpf/pid/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package pid

--- a/bpf/rdns/placeholder.go
+++ b/bpf/rdns/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package rdns

--- a/bpf/tctracer/placeholder.go
+++ b/bpf/tctracer/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package tctracer

--- a/bpf/tctracer/tctracer.c
+++ b/bpf/tctracer/tctracer.c
@@ -26,7 +26,7 @@ enum protocol { protocol_ip4, protocol_ip6, protocol_unknown };
 char __license[] SEC("license") = "Dual MIT/GPL";
 
 SEC("tc_ingress")
-int beyla_app_ingress(struct __sk_buff *skb) {
+int obi_app_ingress(struct __sk_buff *skb) {
     //bpf_printk("ingress");
 
     protocol_info_t tcp = {};
@@ -210,7 +210,7 @@ static __always_inline void track_sock(struct __sk_buff *skb, const connection_i
 }
 
 SEC("tc_egress")
-int beyla_app_egress(struct __sk_buff *skb) {
+int obi_app_egress(struct __sk_buff *skb) {
     //bpf_printk("egress");
     protocol_info_t tcp = {};
     connection_info_t conn = {};

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -115,7 +115,7 @@ static __always_inline void bpf_sock_ops_establish_cb(struct bpf_sock_ops *skops
 // Tracks all outgoing sockets (BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB)
 // We don't track incoming, those would be BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB
 SEC("sockops")
-int beyla_sockmap_tracker(struct bpf_sock_ops *skops) {
+int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
     switch (skops->op) {
     case BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB:
         bpf_sock_ops_establish_cb(skops);
@@ -295,7 +295,7 @@ make_tp_string_skb(unsigned char *buf, const tp_info_t *tp, const unsigned char 
     *buf++ = '\r';
     *buf++ = '\n';
 
-    bpf_dbg_printk("beyla_packet_extender: %s", tp_string);
+    bpf_dbg_printk("obi_packet_extender: %s", tp_string);
 }
 
 static __always_inline bool
@@ -423,7 +423,7 @@ static __always_inline bool handle_go_request(struct sk_msg_md *msg,
 // the 'Traceparent' string. It extends the HTTP header and writes the
 // Traceparent string.
 SEC("sk_msg")
-int beyla_packet_extender(struct sk_msg_md *msg) {
+int obi_packet_extender(struct sk_msg_md *msg) {
     const u64 id = bpf_get_current_pid_tgid();
     const connection_info_t conn = get_connection_info(msg);
     const egress_key_t e_key = make_key(&conn);
@@ -488,7 +488,7 @@ int beyla_packet_extender(struct sk_msg_md *msg) {
 
 //k_tail_write_msg_traceparent
 SEC("sk_msg")
-int beyla_packet_extender_write_msg_tp(struct sk_msg_md *msg) {
+int obi_packet_extender_write_msg_tp(struct sk_msg_md *msg) {
     bpf_dbg_printk("== %s ==", __FUNCTION__);
 
     tp_info_pid_t *tp_p = tp_buf();

--- a/bpf/watcher/placeholder.go
+++ b/bpf/watcher/placeholder.go
@@ -1,3 +1,3 @@
-//go:build beyla_bpf
+//go:build obi_bpf
 
 package watcher

--- a/bpf/watcher/watcher.c
+++ b/bpf/watcher/watcher.c
@@ -25,7 +25,7 @@ struct {
 } watch_events SEC(".maps");
 
 SEC("kprobe/sys_bind")
-int beyla_kprobe_sys_bind(struct pt_regs *ctx) {
+int obi_kprobe_sys_bind(struct pt_regs *ctx) {
     // unwrap the args because it's a sys call
     struct pt_regs *__ctx = (struct pt_regs *)PT_REGS_PARM1(ctx);
     void *addr;

--- a/pkg/components/ebpf/generictracer/generictracer.go
+++ b/pkg/components/ebpf/generictracer/generictracer.go
@@ -153,35 +153,35 @@ func (p *Tracer) SetupTailCalls() {
 	}{
 		{
 			index: 0,
-			prog:  p.bpfObjects.BeylaProtocolHttp,
+			prog:  p.bpfObjects.ObiProtocolHttp,
 		},
 		{
 			index: 1,
-			prog:  p.bpfObjects.BeylaProtocolHttp2,
+			prog:  p.bpfObjects.ObiProtocolHttp2,
 		},
 		{
 			index: 2,
-			prog:  p.bpfObjects.BeylaProtocolTcp,
+			prog:  p.bpfObjects.ObiProtocolTcp,
 		},
 		{
 			index: 3,
-			prog:  p.bpfObjects.BeylaProtocolHttp2GrpcFrames,
+			prog:  p.bpfObjects.ObiProtocolHttp2GrpcFrames,
 		},
 		{
 			index: 4,
-			prog:  p.bpfObjects.BeylaProtocolHttp2GrpcHandleStartFrame,
+			prog:  p.bpfObjects.ObiProtocolHttp2GrpcHandleStartFrame,
 		},
 		{
 			index: 5,
-			prog:  p.bpfObjects.BeylaProtocolHttp2GrpcHandleEndFrame,
+			prog:  p.bpfObjects.ObiProtocolHttp2GrpcHandleEndFrame,
 		},
 		{
 			index: 6,
-			prog:  p.bpfObjects.BeylaProtocolMysql,
+			prog:  p.bpfObjects.ObiProtocolMysql,
 		},
 		{
 			index: 7,
-			prog:  p.bpfObjects.BeylaHandleBufWithArgs,
+			prog:  p.bpfObjects.ObiHandleBufWithArgs,
 		},
 	} {
 		err := p.bpfObjects.JumpTable.Update(uint32(tc.index), uint32(tc.prog.FD()), ebpf.UpdateAny)
@@ -253,74 +253,74 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {
 		// issues with the internal kernel code changing.
 		"sys_accept": {
 			Required: true,
-			End:      p.bpfObjects.BeylaKretprobeSysAccept4,
+			End:      p.bpfObjects.ObiKretprobeSysAccept4,
 		},
 		"sys_accept4": {
 			Required: true,
-			End:      p.bpfObjects.BeylaKretprobeSysAccept4,
+			End:      p.bpfObjects.ObiKretprobeSysAccept4,
 		},
 		"sock_alloc": {
 			Required: true,
-			End:      p.bpfObjects.BeylaKretprobeSockAlloc,
+			End:      p.bpfObjects.ObiKretprobeSockAlloc,
 		},
 		"tcp_rcv_established": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeTcpRcvEstablished,
+			Start:    p.bpfObjects.ObiKprobeTcpRcvEstablished,
 		},
 		// Tracking of HTTP client calls, by tapping into connect
 		"sys_connect": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeSysConnect,
-			End:      p.bpfObjects.BeylaKretprobeSysConnect,
+			Start:    p.bpfObjects.ObiKprobeSysConnect,
+			End:      p.bpfObjects.ObiKretprobeSysConnect,
 		},
 		"sock_recvmsg": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeSockRecvmsg,
-			End:      p.bpfObjects.BeylaKretprobeSockRecvmsg,
+			Start:    p.bpfObjects.ObiKprobeSockRecvmsg,
+			End:      p.bpfObjects.ObiKretprobeSockRecvmsg,
 		},
 		"tcp_connect": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeTcpConnect,
+			Start:    p.bpfObjects.ObiKprobeTcpConnect,
 		},
 		"tcp_close": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeTcpClose,
+			Start:    p.bpfObjects.ObiKprobeTcpClose,
 		},
 		"tcp_sendmsg": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeTcpSendmsg,
-			End:      p.bpfObjects.BeylaKretprobeTcpSendmsg,
+			Start:    p.bpfObjects.ObiKprobeTcpSendmsg,
+			End:      p.bpfObjects.ObiKretprobeTcpSendmsg,
 		},
 		// Reading more than 160 bytes
 		"tcp_recvmsg": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeTcpRecvmsg,
-			End:      p.bpfObjects.BeylaKretprobeTcpRecvmsg,
+			Start:    p.bpfObjects.ObiKprobeTcpRecvmsg,
+			End:      p.bpfObjects.ObiKretprobeTcpRecvmsg,
 		},
 		"tcp_cleanup_rbuf": {
-			Start: p.bpfObjects.BeylaKprobeTcpCleanupRbuf, // this kprobe runs the same code as recvmsg return, we use it because kretprobes can be unreliable.
+			Start: p.bpfObjects.ObiKprobeTcpCleanupRbuf, // this kprobe runs the same code as recvmsg return, we use it because kretprobes can be unreliable.
 		},
 		"sys_clone": {
 			Required: true,
-			End:      p.bpfObjects.BeylaKretprobeSysClone,
+			End:      p.bpfObjects.ObiKretprobeSysClone,
 		},
 		"sys_clone3": {
 			Required: false,
-			End:      p.bpfObjects.BeylaKretprobeSysClone,
+			End:      p.bpfObjects.ObiKretprobeSysClone,
 		},
 		"sys_exit": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeSysExit,
+			Start:    p.bpfObjects.ObiKprobeSysExit,
 		},
 		"unix_stream_recvmsg": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeUnixStreamRecvmsg,
-			End:      p.bpfObjects.BeylaKretprobeUnixStreamRecvmsg,
+			Start:    p.bpfObjects.ObiKprobeUnixStreamRecvmsg,
+			End:      p.bpfObjects.ObiKretprobeUnixStreamRecvmsg,
 		},
 		"unix_stream_sendmsg": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeUnixStreamSendmsg,
-			End:      p.bpfObjects.BeylaKretprobeUnixStreamSendmsg,
+			Start:    p.bpfObjects.ObiKprobeUnixStreamSendmsg,
+			End:      p.bpfObjects.ObiKretprobeUnixStreamSendmsg,
 		},
 	}
 
@@ -330,11 +330,11 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {
 		// if sk_msg is attached.
 		kp["tcp_rate_check_app_limited"] = ebpfcommon.ProbeDesc{
 			Required: false,
-			Start:    p.bpfObjects.BeylaKprobeTcpRateCheckAppLimited,
+			Start:    p.bpfObjects.ObiKprobeTcpRateCheckAppLimited,
 		}
 		kp["tcp_sendmsg_fastopen"] = ebpfcommon.ProbeDesc{
 			Required: false,
-			Start:    p.bpfObjects.BeylaKprobeTcpRateCheckAppLimited,
+			Start:    p.bpfObjects.ObiKprobeTcpRateCheckAppLimited,
 		}
 	}
 
@@ -350,50 +350,50 @@ func (p *Tracer) UProbes() map[string]map[string][]*ebpfcommon.ProbeDesc {
 		"libssl.so": {
 			"SSL_read": {{
 				Required: false,
-				Start:    p.bpfObjects.BeylaUprobeSslRead,
-				End:      p.bpfObjects.BeylaUretprobeSslRead,
+				Start:    p.bpfObjects.ObiUprobeSslRead,
+				End:      p.bpfObjects.ObiUretprobeSslRead,
 			}},
 			"SSL_write": {{
 				Required: false,
-				Start:    p.bpfObjects.BeylaUprobeSslWrite,
-				End:      p.bpfObjects.BeylaUretprobeSslWrite,
+				Start:    p.bpfObjects.ObiUprobeSslWrite,
+				End:      p.bpfObjects.ObiUretprobeSslWrite,
 			}},
 			"SSL_read_ex": {{
 				Required: false,
-				Start:    p.bpfObjects.BeylaUprobeSslReadEx,
-				End:      p.bpfObjects.BeylaUretprobeSslReadEx,
+				Start:    p.bpfObjects.ObiUprobeSslReadEx,
+				End:      p.bpfObjects.ObiUretprobeSslReadEx,
 			}},
 			"SSL_write_ex": {{
 				Required: false,
-				Start:    p.bpfObjects.BeylaUprobeSslWriteEx,
-				End:      p.bpfObjects.BeylaUretprobeSslWriteEx,
+				Start:    p.bpfObjects.ObiUprobeSslWriteEx,
+				End:      p.bpfObjects.ObiUretprobeSslWriteEx,
 			}},
 			"SSL_shutdown": {{
 				Required: false,
-				Start:    p.bpfObjects.BeylaUprobeSslShutdown,
+				Start:    p.bpfObjects.ObiUprobeSslShutdown,
 			}},
 		},
 		"nginx": {
 			"ngx_http_upstream_init": {{ // on upstream dispatch
 				Required: false,
-				Start:    p.bpfObjects.BeylaNgxHttpUpstreamInit,
+				Start:    p.bpfObjects.ObiNgxHttpUpstreamInit,
 			}},
 			"ngx_event_connect_peer": {{
 				Required: false,
-				End:      p.bpfObjects.BeylaNgxEventConnectPeerRet,
+				End:      p.bpfObjects.ObiNgxEventConnectPeerRet,
 			}},
 		},
 		"node": {
 			"uv_fs_access": {{
 				Required: false,
-				Start:    p.bpfObjects.BeylaUvFsAccess,
+				Start:    p.bpfObjects.ObiUvFsAccess,
 			}},
 		},
 	}
 }
 
 func (p *Tracer) SocketFilters() []*ebpf.Program {
-	return []*ebpf.Program{p.bpfObjects.BeylaSocketHttpFilter}
+	return []*ebpf.Program{p.bpfObjects.ObiSocketHttpFilter}
 }
 
 func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg { return nil }

--- a/pkg/components/ebpf/gotracer/gotracer.go
+++ b/pkg/components/ebpf/gotracer/gotracer.go
@@ -94,7 +94,7 @@ func (p *Tracer) SetupTailCalls() {
 	}{
 		{
 			index: 0,
-			prog:  p.bpfObjects.BeylaReadJsonrpcMethod,
+			prog:  p.bpfObjects.ObiReadJsonrpcMethod,
 		},
 	} {
 		err := p.bpfObjects.JsonrpcJumpTable.Update(uint32(tc.index), uint32(tc.prog.FD()), ebpf.UpdateAny)
@@ -235,247 +235,247 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 	m := map[string][]*ebpfcommon.ProbeDesc{
 		// Go runtime
 		"runtime.newproc1": {{
-			Start: p.bpfObjects.BeylaUprobeProcNewproc1,
-			End:   p.bpfObjects.BeylaUprobeProcNewproc1Ret,
+			Start: p.bpfObjects.ObiUprobeProcNewproc1,
+			End:   p.bpfObjects.ObiUprobeProcNewproc1Ret,
 		}},
 		"runtime.goexit1": {{
-			Start: p.bpfObjects.BeylaUprobeProcGoexit1,
+			Start: p.bpfObjects.ObiUprobeProcGoexit1,
 		}},
 		// Go net/http
 		"net/http.serverHandler.ServeHTTP": {{
-			Start: p.bpfObjects.BeylaUprobeServeHTTP,
-			End:   p.bpfObjects.BeylaUprobeServeHTTPReturns,
+			Start: p.bpfObjects.ObiUprobeServeHTTP,
+			End:   p.bpfObjects.ObiUprobeServeHTTPReturns,
 		}},
 		"net/http.(*conn).readRequest": {{
-			Start: p.bpfObjects.BeylaUprobeReadRequestStart,
-			End:   p.bpfObjects.BeylaUprobeReadRequestReturns,
+			Start: p.bpfObjects.ObiUprobeReadRequestStart,
+			End:   p.bpfObjects.ObiUprobeReadRequestReturns,
 		}},
 		"net/http.(*body).Read": {{
-			Start: p.bpfObjects.BeylaUprobeBodyRead,
-			End:   p.bpfObjects.BeylaUprobeBodyReadReturn,
+			Start: p.bpfObjects.ObiUprobeBodyRead,
+			End:   p.bpfObjects.ObiUprobeBodyReadReturn,
 		}},
 		"net/textproto.(*Reader).readContinuedLineSlice": {{
-			End: p.bpfObjects.BeylaUprobeReadContinuedLineSliceReturns,
+			End: p.bpfObjects.ObiUprobeReadContinuedLineSliceReturns,
 		}},
 		"net/http.(*Transport).roundTrip": {{ // HTTP client, works with Client.Do as well as using the RoundTripper directly
-			Start: p.bpfObjects.BeylaUprobeRoundTrip,
-			End:   p.bpfObjects.BeylaUprobeRoundTripReturn,
+			Start: p.bpfObjects.ObiUprobeRoundTrip,
+			End:   p.bpfObjects.ObiUprobeRoundTripReturn,
 		}},
 		"golang.org/x/net/http2.(*ClientConn).roundTrip": {{ // http2 client after 0.22
-			Start: p.bpfObjects.BeylaUprobeHttp2RoundTrip,
-			End:   p.bpfObjects.BeylaUprobeRoundTripReturn, // return is the same as for http 1.1
+			Start: p.bpfObjects.ObiUprobeHttp2RoundTrip,
+			End:   p.bpfObjects.ObiUprobeRoundTripReturn, // return is the same as for http 1.1
 		}},
 		"golang.org/x/net/http2.(*ClientConn).RoundTrip": {{ // http2 client
-			Start: p.bpfObjects.BeylaUprobeHttp2RoundTrip,
-			End:   p.bpfObjects.BeylaUprobeRoundTripReturn, // return is the same as for http 1.1
+			Start: p.bpfObjects.ObiUprobeHttp2RoundTrip,
+			End:   p.bpfObjects.ObiUprobeRoundTripReturn, // return is the same as for http 1.1
 		}},
 		"net/http.(*http2ClientConn).RoundTrip": {{ // http2 client vendored in Go
-			Start: p.bpfObjects.BeylaUprobeHttp2RoundTrip,
-			End:   p.bpfObjects.BeylaUprobeRoundTripReturn, // return is the same as for http 1.1
+			Start: p.bpfObjects.ObiUprobeHttp2RoundTrip,
+			End:   p.bpfObjects.ObiUprobeRoundTripReturn, // return is the same as for http 1.1
 		}},
 		"golang.org/x/net/http2.(*ClientConn).writeHeaders": {{ // http2 client
-			Start: p.bpfObjects.BeylaUprobeHttp2WriteHeaders,
+			Start: p.bpfObjects.ObiUprobeHttp2WriteHeaders,
 		}},
 		"net/http.(*http2ClientConn).writeHeaders": {{ // http2 client vendored in Go, but used from http 1.1 transition
-			Start: p.bpfObjects.BeylaUprobeHttp2WriteHeadersVendored,
+			Start: p.bpfObjects.ObiUprobeHttp2WriteHeadersVendored,
 		}},
 		"golang.org/x/net/http2.(*responseWriterState).writeHeader": {{ // http2 server request done, capture the response code
-			Start: p.bpfObjects.BeylaUprobeHttp2ResponseWriterStateWriteHeader,
+			Start: p.bpfObjects.ObiUprobeHttp2ResponseWriterStateWriteHeader,
 		}},
 		"net/http.(*http2responseWriterState).writeHeader": {{ // same as above, vendored in go
-			Start: p.bpfObjects.BeylaUprobeHttp2ResponseWriterStateWriteHeader,
+			Start: p.bpfObjects.ObiUprobeHttp2ResponseWriterStateWriteHeader,
 		}},
 		"net/http.(*response).WriteHeader": {{
-			Start: p.bpfObjects.BeylaUprobeHttp2ResponseWriterStateWriteHeader, // http response code capture
+			Start: p.bpfObjects.ObiUprobeHttp2ResponseWriterStateWriteHeader, // http response code capture
 		}},
 		"golang.org/x/net/http2.(*serverConn).runHandler": {{
-			Start: p.bpfObjects.BeylaUprobeHttp2serverConnRunHandler, // http2 server connection tracking
+			Start: p.bpfObjects.ObiUprobeHttp2serverConnRunHandler, // http2 server connection tracking
 		}},
 		"net/http.(*http2serverConn).runHandler": {{
-			Start: p.bpfObjects.BeylaUprobeHttp2serverConnRunHandler, // http2 server connection tracking, vendored in go
+			Start: p.bpfObjects.ObiUprobeHttp2serverConnRunHandler, // http2 server connection tracking, vendored in go
 		}},
 		"golang.org/x/net/http2.(*serverConn).processHeaders": {{
-			Start: p.bpfObjects.BeylaUprobeHttp2ServerProcessHeaders, // http2 server request header parsing
+			Start: p.bpfObjects.ObiUprobeHttp2ServerProcessHeaders, // http2 server request header parsing
 		}},
 		"net/http.(*http2serverConn).processHeaders": {{
-			Start: p.bpfObjects.BeylaUprobeHttp2ServerProcessHeaders, // http2 server request header parsing, vendored in go
+			Start: p.bpfObjects.ObiUprobeHttp2ServerProcessHeaders, // http2 server request header parsing, vendored in go
 		}},
 		// tracking of tcp connections for black-box propagation
 		"net/http.(*conn).serve": {{ // http server
-			Start: p.bpfObjects.BeylaUprobeConnServe,
-			End:   p.bpfObjects.BeylaUprobeConnServeRet,
+			Start: p.bpfObjects.ObiUprobeConnServe,
+			End:   p.bpfObjects.ObiUprobeConnServeRet,
 		}},
 		"net.(*netFD).Read": {
 			{
-				Start: p.bpfObjects.BeylaUprobeNetFdRead,
+				Start: p.bpfObjects.ObiUprobeNetFdRead,
 			},
 		},
 		"net/http.(*persistConn).roundTrip": {{ // http client
-			Start: p.bpfObjects.BeylaUprobePersistConnRoundTrip,
+			Start: p.bpfObjects.ObiUprobePersistConnRoundTrip,
 		}},
 		// sql
 		"database/sql.(*DB).queryDC": {{
-			Start: p.bpfObjects.BeylaUprobeQueryDC,
-			End:   p.bpfObjects.BeylaUprobeQueryReturn,
+			Start: p.bpfObjects.ObiUprobeQueryDC,
+			End:   p.bpfObjects.ObiUprobeQueryReturn,
 		}},
 		"database/sql.(*DB).execDC": {{
-			Start: p.bpfObjects.BeylaUprobeExecDC,
-			End:   p.bpfObjects.BeylaUprobeQueryReturn,
+			Start: p.bpfObjects.ObiUprobeExecDC,
+			End:   p.bpfObjects.ObiUprobeQueryReturn,
 		}},
 		// Go gRPC
 		"google.golang.org/grpc.(*Server).handleStream": {{
-			Start: p.bpfObjects.BeylaUprobeServerHandleStream,
-			End:   p.bpfObjects.BeylaUprobeServerHandleStreamReturn,
+			Start: p.bpfObjects.ObiUprobeServerHandleStream,
+			End:   p.bpfObjects.ObiUprobeServerHandleStreamReturn,
 		}},
 		"google.golang.org/grpc/internal/transport.(*http2Server).WriteStatus": {{
-			Start: p.bpfObjects.BeylaUprobeTransportWriteStatus,
+			Start: p.bpfObjects.ObiUprobeTransportWriteStatus,
 		}},
 		// in grpc 1.69.0 they renamed the above WriteStatus to writeStatus lowercase
 		"google.golang.org/grpc/internal/transport.(*http2Server).writeStatus": {{
-			Start: p.bpfObjects.BeylaUprobeTransportWriteStatus,
+			Start: p.bpfObjects.ObiUprobeTransportWriteStatus,
 		}},
 		"google.golang.org/grpc.(*ClientConn).Invoke": {{
-			Start: p.bpfObjects.BeylaUprobeClientConnInvoke,
-			End:   p.bpfObjects.BeylaUprobeClientConnInvokeReturn,
+			Start: p.bpfObjects.ObiUprobeClientConnInvoke,
+			End:   p.bpfObjects.ObiUprobeClientConnInvokeReturn,
 		}},
 		"google.golang.org/grpc.(*ClientConn).NewStream": {{
-			Start: p.bpfObjects.BeylaUprobeClientConnNewStream,
-			End:   p.bpfObjects.BeylaUprobeClientConnNewStreamReturn,
+			Start: p.bpfObjects.ObiUprobeClientConnNewStream,
+			End:   p.bpfObjects.ObiUprobeClientConnNewStreamReturn,
 		}},
 		"google.golang.org/grpc.(*ClientConn).Close": {{
-			Start: p.bpfObjects.BeylaUprobeClientConnClose,
+			Start: p.bpfObjects.ObiUprobeClientConnClose,
 		}},
 		"google.golang.org/grpc.(*clientStream).RecvMsg": {{
-			End: p.bpfObjects.BeylaUprobeClientStreamRecvMsgReturn,
+			End: p.bpfObjects.ObiUprobeClientStreamRecvMsgReturn,
 		}},
 		"google.golang.org/grpc.(*clientStream).CloseSend": {{
-			End: p.bpfObjects.BeylaUprobeClientConnInvokeReturn,
+			End: p.bpfObjects.ObiUprobeClientConnInvokeReturn,
 		}},
 		"google.golang.org/grpc/internal/transport.(*http2Client).NewStream": {{
-			Start: p.bpfObjects.BeylaUprobeTransportHttp2ClientNewStream,
-			End:   p.bpfObjects.BeylaUprobeTransportHttp2ClientNewStreamReturns,
+			Start: p.bpfObjects.ObiUprobeTransportHttp2ClientNewStream,
+			End:   p.bpfObjects.ObiUprobeTransportHttp2ClientNewStreamReturns,
 		}},
 		"google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders": {{
-			Start: p.bpfObjects.BeylaUprobeHttp2ServerOperateHeaders,
+			Start: p.bpfObjects.ObiUprobeHttp2ServerOperateHeaders,
 		}},
 		"google.golang.org/grpc/internal/transport.(*serverHandlerTransport).HandleStreams": {{
-			Start: p.bpfObjects.BeylaUprobeServerHandlerTransportHandleStreams,
+			Start: p.bpfObjects.ObiUprobeServerHandlerTransportHandleStreams,
 		}},
 		// Redis
 		"github.com/redis/go-redis/v9/internal/pool.(*Conn).WithWriter": {{
-			Start: p.bpfObjects.BeylaUprobeRedisWithWriter,
-			End:   p.bpfObjects.BeylaUprobeRedisWithWriterRet,
+			Start: p.bpfObjects.ObiUprobeRedisWithWriter,
+			End:   p.bpfObjects.ObiUprobeRedisWithWriterRet,
 		}},
 		"github.com/redis/go-redis/v9.(*baseClient)._process": {{
-			Start: p.bpfObjects.BeylaUprobeRedisProcess,
-			End:   p.bpfObjects.BeylaUprobeRedisProcessRet,
+			Start: p.bpfObjects.ObiUprobeRedisProcess,
+			End:   p.bpfObjects.ObiUprobeRedisProcessRet,
 		}},
 		"github.com/redis/go-redis/v9.(*baseClient).pipelineProcessCmds": {{
-			Start: p.bpfObjects.BeylaUprobeRedisProcess,
-			End:   p.bpfObjects.BeylaUprobeRedisProcessRet,
+			Start: p.bpfObjects.ObiUprobeRedisProcess,
+			End:   p.bpfObjects.ObiUprobeRedisProcessRet,
 		}},
 		"github.com/redis/go-redis/v9.(*baseClient).txPipelineProcessCmds": {{
-			Start: p.bpfObjects.BeylaUprobeRedisProcess,
-			End:   p.bpfObjects.BeylaUprobeRedisProcessRet,
+			Start: p.bpfObjects.ObiUprobeRedisProcess,
+			End:   p.bpfObjects.ObiUprobeRedisProcessRet,
 		}},
 		// Kafka Go
 		"github.com/segmentio/kafka-go.(*Writer).WriteMessages": {{ // runs on the same gorountine as other requests, finds traceparent info
-			Start: p.bpfObjects.BeylaUprobeWriterWriteMessages,
+			Start: p.bpfObjects.ObiUprobeWriterWriteMessages,
 		}},
 		"github.com/segmentio/kafka-go.(*Writer).produce": {{ // stores the current topic
-			Start: p.bpfObjects.BeylaUprobeWriterProduce,
+			Start: p.bpfObjects.ObiUprobeWriterProduce,
 		}},
 		"github.com/segmentio/kafka-go.(*Client).roundTrip": {{ // has the goroutine connection with (*Writer).produce and msg* connection with protocol.RoundTrip
-			Start: p.bpfObjects.BeylaUprobeClientRoundTrip,
+			Start: p.bpfObjects.ObiUprobeClientRoundTrip,
 		}},
 		"github.com/segmentio/kafka-go/protocol.RoundTrip": {{ // used for collecting the connection information
-			Start: p.bpfObjects.BeylaUprobeProtocolRoundtrip,
-			End:   p.bpfObjects.BeylaUprobeProtocolRoundtripRet,
+			Start: p.bpfObjects.ObiUprobeProtocolRoundtrip,
+			End:   p.bpfObjects.ObiUprobeProtocolRoundtripRet,
 		}},
 		"github.com/segmentio/kafka-go.(*reader).read": {{ // used for capturing the info for the fetch operations
-			Start: p.bpfObjects.BeylaUprobeReaderRead,
-			End:   p.bpfObjects.BeylaUprobeReaderReadRet,
+			Start: p.bpfObjects.ObiUprobeReaderRead,
+			End:   p.bpfObjects.ObiUprobeReaderReadRet,
 		}},
 		"github.com/segmentio/kafka-go.(*reader).sendMessage": {{ // to accurately measure the start time
-			Start: p.bpfObjects.BeylaUprobeReaderSendMessage,
+			Start: p.bpfObjects.ObiUprobeReaderSendMessage,
 		}},
 		// Kafka sarama
 		"github.com/IBM/sarama.(*Broker).write": {{
-			Start: p.bpfObjects.BeylaUprobeSaramaBrokerWrite,
+			Start: p.bpfObjects.ObiUprobeSaramaBrokerWrite,
 		}},
 		"github.com/IBM/sarama.(*responsePromise).handle": {{
-			Start: p.bpfObjects.BeylaUprobeSaramaResponsePromiseHandle,
+			Start: p.bpfObjects.ObiUprobeSaramaResponsePromiseHandle,
 		}},
 		"github.com/IBM/sarama.(*Broker).sendInternal": {{
-			Start: p.bpfObjects.BeylaUprobeSaramaSendInternal,
+			Start: p.bpfObjects.ObiUprobeSaramaSendInternal,
 		}},
 		"github.com/Shopify/sarama.(*Broker).write": {{
-			Start: p.bpfObjects.BeylaUprobeSaramaBrokerWrite,
+			Start: p.bpfObjects.ObiUprobeSaramaBrokerWrite,
 		}},
 		"github.com/Shopify/sarama.(*responsePromise).handle": {{
-			Start: p.bpfObjects.BeylaUprobeSaramaResponsePromiseHandle,
+			Start: p.bpfObjects.ObiUprobeSaramaResponsePromiseHandle,
 		}},
 		"github.com/Shopify/sarama.(*Broker).sendInternal": {{
-			Start: p.bpfObjects.BeylaUprobeSaramaSendInternal,
+			Start: p.bpfObjects.ObiUprobeSaramaSendInternal,
 		}},
 		// Go OTel SDK
 		"go.opentelemetry.io/otel/internal/global.(*tracer).Start": {{
-			Start: p.bpfObjects.BeylaUprobeTracerStartGlobal,
-			End:   p.bpfObjects.BeylaUprobeTracerStartReturns,
+			Start: p.bpfObjects.ObiUprobeTracerStartGlobal,
+			End:   p.bpfObjects.ObiUprobeTracerStartReturns,
 		}},
 		"go.opentelemetry.io/auto/sdk.(*tracer).Start": {{
-			Start: p.bpfObjects.BeylaUprobeTracerStart,
-			End:   p.bpfObjects.BeylaUprobeTracerStartReturns,
+			Start: p.bpfObjects.ObiUprobeTracerStart,
+			End:   p.bpfObjects.ObiUprobeTracerStartReturns,
 		}},
 		"go.opentelemetry.io/otel/internal/global.(*nonRecordingSpan).End": {{
-			Start: p.bpfObjects.BeylaUprobeNonRecordingSpanEnd,
+			Start: p.bpfObjects.ObiUprobeNonRecordingSpanEnd,
 		}},
 		"go.opentelemetry.io/auto/sdk.(*span).End": {{
-			Start: p.bpfObjects.BeylaUprobeNonRecordingSpanEnd,
+			Start: p.bpfObjects.ObiUprobeNonRecordingSpanEnd,
 		}},
 		"go.opentelemetry.io/otel/internal/global.(*nonRecordingSpan).SetStatus": {{
-			Start: p.bpfObjects.BeylaUprobeSetStatus,
+			Start: p.bpfObjects.ObiUprobeSetStatus,
 		}},
 		"go.opentelemetry.io/auto/sdk.(*span).SetStatus": {{
-			Start: p.bpfObjects.BeylaUprobeSetStatus,
+			Start: p.bpfObjects.ObiUprobeSetStatus,
 		}},
 		"go.opentelemetry.io/otel/internal/global.(*nonRecordingSpan).SetAttributes": {{
-			Start: p.bpfObjects.BeylaUprobeSetAttributes,
+			Start: p.bpfObjects.ObiUprobeSetAttributes,
 		}},
 		"go.opentelemetry.io/auto/sdk.(*span).SetAttributes": {{
-			Start: p.bpfObjects.BeylaUprobeSetAttributes,
+			Start: p.bpfObjects.ObiUprobeSetAttributes,
 		}},
 		"go.opentelemetry.io/otel/internal/global.(*nonRecordingSpan).SetName": {{
-			Start: p.bpfObjects.BeylaUprobeSetName,
+			Start: p.bpfObjects.ObiUprobeSetName,
 		}},
 		"go.opentelemetry.io/auto/sdk.(*span).SetName": {{
-			Start: p.bpfObjects.BeylaUprobeSetName,
+			Start: p.bpfObjects.ObiUprobeSetName,
 		}},
 		"go.opentelemetry.io/otel/internal/global.(*nonRecordingSpan).RecordError": {{
-			Start: p.bpfObjects.BeylaUprobeRecordError,
+			Start: p.bpfObjects.ObiUprobeRecordError,
 		}},
 		"go.opentelemetry.io/auto/sdk.(*span).RecordError": {{
-			Start: p.bpfObjects.BeylaUprobeRecordError,
+			Start: p.bpfObjects.ObiUprobeRecordError,
 		}},
 	}
 
 	if p.supportsContextPropagation() {
 		m["net/http.Header.writeSubset"] = []*ebpfcommon.ProbeDesc{{
-			Start: p.bpfObjects.BeylaUprobeWriteSubset, // http 1.x context propagation
+			Start: p.bpfObjects.ObiUprobeWriteSubset, // http 1.x context propagation
 		}}
 		m["golang.org/x/net/http2.(*Framer).WriteHeaders"] = []*ebpfcommon.ProbeDesc{
 			{ // http2 context propagation
-				Start: p.bpfObjects.BeylaUprobeHttp2FramerWriteHeaders,
-				End:   p.bpfObjects.BeylaUprobeHttp2FramerWriteHeadersReturns,
+				Start: p.bpfObjects.ObiUprobeHttp2FramerWriteHeaders,
+				End:   p.bpfObjects.ObiUprobeHttp2FramerWriteHeadersReturns,
 			},
 			{ // for grpc
-				Start: p.bpfObjects.BeylaUprobeGrpcFramerWriteHeaders,
-				End:   p.bpfObjects.BeylaUprobeGrpcFramerWriteHeadersReturns,
+				Start: p.bpfObjects.ObiUprobeGrpcFramerWriteHeaders,
+				End:   p.bpfObjects.ObiUprobeGrpcFramerWriteHeadersReturns,
 			},
 		}
 		m["net/http.(*http2Framer).WriteHeaders"] = []*ebpfcommon.ProbeDesc{{ // http2 context propagation
-			Start: p.bpfObjects.BeylaUprobeHttp2FramerWriteHeaders,
-			End:   p.bpfObjects.BeylaUprobeHttp2FramerWriteHeadersReturns,
+			Start: p.bpfObjects.ObiUprobeHttp2FramerWriteHeaders,
+			End:   p.bpfObjects.ObiUprobeHttp2FramerWriteHeadersReturns,
 		}}
 	}
 

--- a/pkg/components/ebpf/tctracer/tctracer.go
+++ b/pkg/components/ebpf/tctracer/tctracer.go
@@ -132,8 +132,8 @@ func (p *Tracer) startTC(ctx context.Context) {
 	p.ifaceManager = tcmanager.NewInterfaceManager()
 	p.tcManager = tcmanager.NewTCManager(p.cfg.EBPF.TCBackend)
 	p.tcManager.SetInterfaceManager(p.ifaceManager)
-	p.tcManager.AddProgram("tc/tc_egress", p.bpfObjects.BeylaAppEgress, tcmanager.AttachmentEgress)
-	p.tcManager.AddProgram("tc/tc_ingress", p.bpfObjects.BeylaAppIngress, tcmanager.AttachmentIngress)
+	p.tcManager.AddProgram("tc/tc_egress", p.bpfObjects.ObiAppEgress, tcmanager.AttachmentEgress)
+	p.tcManager.AddProgram("tc/tc_ingress", p.bpfObjects.ObiAppIngress, tcmanager.AttachmentIngress)
 
 	p.ifaceManager.Start(ctx)
 }

--- a/pkg/components/ebpf/tpinjector/tpinjector.go
+++ b/pkg/components/ebpf/tpinjector/tpinjector.go
@@ -56,7 +56,7 @@ func (p *Tracer) SetupTailCalls() {
 	}{
 		{
 			index: 0,
-			prog:  p.bpfObjects.BeylaPacketExtenderWriteMsgTp,
+			prog:  p.bpfObjects.ObiPacketExtenderWriteMsgTp,
 		},
 	} {
 		err := p.bpfObjects.ExtenderJumpTable.Update(uint32(tc.index), uint32(tc.prog.FD()), ebpf.UpdateAny)
@@ -117,7 +117,7 @@ func (p *Tracer) SocketFilters() []*ebpf.Program {
 func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg {
 	return []ebpfcommon.SockMsg{
 		{
-			Program:  p.bpfObjects.BeylaPacketExtender,
+			Program:  p.bpfObjects.ObiPacketExtender,
 			MapFD:    p.bpfObjects.SockDir.FD(),
 			AttachAs: ebpf.AttachSkMsgVerdict,
 		},
@@ -127,7 +127,7 @@ func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg {
 func (p *Tracer) SockOps() []ebpfcommon.SockOps {
 	return []ebpfcommon.SockOps{
 		{
-			Program:  p.bpfObjects.BeylaSockmapTracker,
+			Program:  p.bpfObjects.ObiSockmapTracker,
 			AttachAs: ebpf.AttachCGroupSockOps,
 		},
 	}

--- a/pkg/components/ebpf/watcher/watcher.go
+++ b/pkg/components/ebpf/watcher/watcher.go
@@ -71,7 +71,7 @@ func (p *Watcher) KProbes() map[string]ebpfcommon.ProbeDesc {
 	kprobes := map[string]ebpfcommon.ProbeDesc{
 		"sys_bind": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeSysBind,
+			Start:    p.bpfObjects.ObiKprobeSysBind,
 		},
 	}
 

--- a/pkg/components/netolly/ebpf/sock_tracer.go
+++ b/pkg/components/netolly/ebpf/sock_tracer.go
@@ -88,7 +88,7 @@ func NewSockFlowFetcher(
 
 	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW, int(htons(unix.ETH_P_ALL)))
 	if err == nil {
-		ssoErr := syscall.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_ATTACH_BPF, objects.BeylaSocketFilter.FD())
+		ssoErr := syscall.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_ATTACH_BPF, objects.ObiSocketFilter.FD())
 		if ssoErr != nil {
 			return nil, fmt.Errorf("loading and assigning BPF objects: %w", ssoErr)
 		}
@@ -145,7 +145,7 @@ func (m *SockFlowFetcher) Close() error {
 
 func (m *SockFlowFetcher) closeObjects() []error {
 	var errs []error
-	if err := m.objects.BeylaSocketFilter.Close(); err != nil {
+	if err := m.objects.ObiSocketFilter.Close(); err != nil {
 		errs = append(errs, err)
 	}
 	if err := m.objects.AggregatedFlows.Close(); err != nil {

--- a/pkg/components/netolly/ebpf/tracer.go
+++ b/pkg/components/netolly/ebpf/tracer.go
@@ -111,11 +111,11 @@ func NewFlowFetcher(
 	tcManager.SetInterfaceManager(ifaceManager)
 
 	if egress {
-		tcManager.AddProgram("tc/egress_flow_parse", objects.BeylaEgressFlowParse, tcmanager.AttachmentEgress)
+		tcManager.AddProgram("tc/egress_flow_parse", objects.ObiEgressFlowParse, tcmanager.AttachmentEgress)
 	}
 
 	if ingress {
-		tcManager.AddProgram("tc/ingress_flow_parse", objects.BeylaIngressFlowParse, tcmanager.AttachmentIngress)
+		tcManager.AddProgram("tc/ingress_flow_parse", objects.ObiIngressFlowParse, tcmanager.AttachmentIngress)
 	}
 
 	fetcher := &FlowFetcher{
@@ -171,10 +171,10 @@ func (m *FlowFetcher) Close() error {
 
 func (m *FlowFetcher) closeObjects() []error {
 	var errs []error
-	if err := m.objects.BeylaEgressFlowParse.Close(); err != nil {
+	if err := m.objects.ObiEgressFlowParse.Close(); err != nil {
 		errs = append(errs, err)
 	}
-	if err := m.objects.BeylaIngressFlowParse.Close(); err != nil {
+	if err := m.objects.ObiIngressFlowParse.Close(); err != nil {
 		errs = append(errs, err)
 	}
 	if err := m.objects.AggregatedFlows.Close(); err != nil {


### PR DESCRIPTION
Use `obi_` instead of `beyla_` for probe names and in the placeholder files.

Resolves #281 