### PR TITLE
Look for the alternative lockdown error message 

### DIFF
--- a/pkg/components/ebpf/tracer_linux.go
+++ b/pkg/components/ebpf/tracer_linux.go
@@ -197,7 +197,8 @@ func (pt *ProcessTracer) loadTracer(eventContext *common.EBPFEventContext, p Tra
 
 	err := pt.loadAndAssign(eventContext, p)
 
-	if err != nil && strings.Contains(err.Error(), "unknown func bpf_probe_write_user") {
+	if err != nil && (strings.Contains(err.Error(), "unknown func bpf_probe_write_user") ||
+		strings.Contains(err.Error(), "cannot use helper bpf_probe_write_user")) {
 		plog.Warn("Failed to enable Go write memory distributed tracing context-propagation on a " +
 			"Linux Kernel without write memory support. " +
 			"To avoid seeing this message, please ensure you have correctly mounted /sys/kernel/security. " +


### PR DESCRIPTION
Apparently on new kernels, when we cannot use `bpf_probe_write_user` we get the following error message: `cannot use helper bpf_probe_write_user` instead of `unknown func bpf_probe_write_user`.

Closes #313 