### PR TITLE
bpf: implement large buffer action, improve mysql protocol inference

### DIFF
--- a/bpf/common/common.h
+++ b/bpf/common/common.h
@@ -47,6 +47,11 @@ enum {
     k_mysql_error_message_max_mask = k_mysql_error_message_max - 1
 };
 
+enum large_buf_action : u8 {
+    k_large_buf_action_init = 0,
+    k_large_buf_action_append = 1,
+};
+
 #define MAX_SPAN_NAME_LEN 64
 #define MAX_STATUS_DESCRIPTION_LEN 64
 
@@ -147,7 +152,8 @@ typedef struct tcp_req {
 typedef struct tcp_large_buffer {
     u8 type; // Must be first
     u8 direction;
-    u8 _pad[2];
+    enum large_buf_action action;
+    u8 _pad;
     u32 len;
     tp_info_t tp;
     u8 buf[];

--- a/bpf/common/sql.h
+++ b/bpf/common/sql.h
@@ -6,7 +6,7 @@
 #include <common/strings.h>
 
 enum {
-    k_max_query_offset = 4,
+    k_max_query_offset = 8,
 
     k_max_sql_op_len = 6, // Maximum length of SQL operation names (e.g., "SELECT")
 };

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -945,18 +945,18 @@ int obi_handle_buf_with_args(void *ctx) {
         if (has_preface(args->small_buf, args->bytes_len) && args->bytes_len > MIN_HTTP2_SIZE) {
             args->u_buf = args->u_buf + MIN_HTTP2_SIZE;
         }
-    }
-
-    http2_conn_info_data_t *h2g = bpf_map_lookup_elem(&ongoing_http2_connections, &args->pid_conn);
-    if (h2g && (http2_flag_ssl(h2g->flags) == args->ssl)) {
-        bpf_tail_call(ctx, &jump_table, k_tail_protocol_http2);
     } else if (is_mysql(&args->pid_conn.conn,
                         (const unsigned char *)args->u_buf,
                         args->bytes_len,
                         &args->packet_type,
                         &args->protocol_type)) {
         bpf_dbg_printk("Found mysql connection");
-        bpf_tail_call(ctx, &jump_table, k_tail_protocol_mysql);
+        bpf_tail_call(ctx, &jump_table, k_tail_protocol_tcp);
+    }
+
+    http2_conn_info_data_t *h2g = bpf_map_lookup_elem(&ongoing_http2_connections, &args->pid_conn);
+    if (h2g && (http2_flag_ssl(h2g->flags) == args->ssl)) {
+        bpf_tail_call(ctx, &jump_table, k_tail_protocol_http2);
     } else { // large request tracking and generic TCP
         http_info_t *info = bpf_map_lookup_elem(&ongoing_http, &args->pid_conn);
 

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -945,6 +945,11 @@ int obi_handle_buf_with_args(void *ctx) {
         if (has_preface(args->small_buf, args->bytes_len) && args->bytes_len > MIN_HTTP2_SIZE) {
             args->u_buf = args->u_buf + MIN_HTTP2_SIZE;
         }
+    }
+
+    http2_conn_info_data_t *h2g = bpf_map_lookup_elem(&ongoing_http2_connections, &args->pid_conn);
+    if (h2g && (http2_flag_ssl(h2g->flags) == args->ssl)) {
+        bpf_tail_call(ctx, &jump_table, k_tail_protocol_http2);
     } else if (is_mysql(&args->pid_conn.conn,
                         (const unsigned char *)args->u_buf,
                         args->bytes_len,
@@ -952,11 +957,6 @@ int obi_handle_buf_with_args(void *ctx) {
                         &args->protocol_type)) {
         bpf_dbg_printk("Found mysql connection");
         bpf_tail_call(ctx, &jump_table, k_tail_protocol_tcp);
-    }
-
-    http2_conn_info_data_t *h2g = bpf_map_lookup_elem(&ongoing_http2_connections, &args->pid_conn);
-    if (h2g && (http2_flag_ssl(h2g->flags) == args->ssl)) {
-        bpf_tail_call(ctx, &jump_table, k_tail_protocol_http2);
     } else { // large request tracking and generic TCP
         http_info_t *info = bpf_map_lookup_elem(&ongoing_http, &args->pid_conn);
 

--- a/bpf/generictracer/k_tracer_tailcall.h
+++ b/bpf/generictracer/k_tracer_tailcall.h
@@ -17,6 +17,5 @@ enum {
     k_tail_protocol_http2_grpc_frames = 3,
     k_tail_protocol_http2_grpc_handle_start_frame = 4,
     k_tail_protocol_http2_grpc_handle_end_frame = 5,
-    k_tail_protocol_mysql = 6,
-    k_tail_handle_buf_with_args = 7,
+    k_tail_handle_buf_with_args = 6,
 };

--- a/bpf/generictracer/protocol_mysql.h
+++ b/bpf/generictracer/protocol_mysql.h
@@ -209,17 +209,12 @@ static __always_inline u8 is_mysql(connection_info_t *conn_info,
         return 0;
     }
 
-    if (data_len < (k_mysql_hdr_size + 1)) {
-        bpf_dbg_printk("is_mysql: data_len is too short: %d", data_len);
-        return 0;
-    }
-
     struct mysql_hdr hdr = {};
     if (mysql_parse_fixup_header(conn_info, &hdr, data, data_len) != 0) {
         bpf_dbg_printk("is_mysql: failed to parse mysql header");
         return 0;
     }
-    u32 payload_len = mysql_payload_length(hdr.payload_length);
+    const u32 payload_len = mysql_payload_length(hdr.payload_length);
 
     if (payload_len > k_mysql_payload_length_max) {
         bpf_dbg_printk("is_mysql: payload length is too large: %d", payload_len);

--- a/bpf/generictracer/protocol_mysql.h
+++ b/bpf/generictracer/protocol_mysql.h
@@ -56,6 +56,9 @@ enum {
     // Large buffer
     k_large_buf_max_size = 1 << 14, // 16K
     k_large_buf_max_size_mask = k_large_buf_max_size - 1,
+
+    // Sanity checks
+    k_mysql_payload_length_max = 1 << 13, // 8K
 };
 
 struct {
@@ -67,6 +70,12 @@ struct {
 
 SCRATCH_MEM_SIZED(mysql_large_buffers, k_large_buf_max_size);
 
+// This function is used to store the MySQL header if it comes in split packets
+// from double send.
+// Given the fact that we need to store this for the duration of the full request
+// (split in potentially multiple packets), we will **not** process or preserve
+// any actual payloads that are exactly 4 bytes long — they are intentionally
+// dropped in favor of state storage.
 static __always_inline int mysql_store_state_data(const connection_info_t *conn_info,
                                                   const unsigned char *data,
                                                   size_t data_len) {
@@ -74,36 +83,37 @@ static __always_inline int mysql_store_state_data(const connection_info_t *conn_
         return 0;
     }
 
-    struct mysql_state_data *state_data = bpf_map_lookup_elem(&mysql_state, conn_info);
-    if (state_data == NULL) {
-        // State data not found, treat this data as a header.
-        struct mysql_state_data new_state_data = {};
-        bpf_probe_read(&new_state_data, k_mysql_hdr_without_command_size, (const void *)data);
-        bpf_map_update_elem(&mysql_state, conn_info, &new_state_data, BPF_ANY);
-        return -1;
-    }
+    struct mysql_state_data new_state_data = {};
+    bpf_probe_read(&new_state_data, k_mysql_hdr_without_command_size, (const void *)data);
+    bpf_map_update_elem(&mysql_state, conn_info, &new_state_data, BPF_ANY);
 
-    // This is a payload.
-    return 0;
+    return -1;
 }
 
 static __always_inline int mysql_parse_fixup_header(const connection_info_t *conn_info,
                                                     struct mysql_hdr *hdr,
                                                     const unsigned char *data,
                                                     size_t data_len) {
+    // Try to parse and validate the header first.
+    bpf_probe_read(hdr, k_mysql_hdr_size, (const void *)data);
+    if (mysql_payload_length(hdr->payload_length) ==
+        (data_len - k_mysql_hdr_without_command_size)) {
+        // Header is valid and we have the full data, we can proceed.
+        hdr->hdr_arrived = false;
+        return 0;
+    }
+
+    // Prepend the header from state data.
     struct mysql_state_data *state_data = bpf_map_lookup_elem(&mysql_state, conn_info);
     if (state_data != NULL) {
         __builtin_memcpy(hdr, state_data, k_mysql_hdr_without_command_size);
         bpf_probe_read(&hdr->command_id, k_mysql_hdr_command_id_size, (const void *)data);
         hdr->hdr_arrived = true;
-    } else {
-        if (data_len < k_mysql_hdr_size) {
-            bpf_dbg_printk("mysql_parse_fixup_header: data_len is too short: %d", data_len);
-            return -1;
-        }
-        bpf_probe_read(hdr, k_mysql_hdr_size, (const void *)data);
+        return 0;
     }
-    return 0;
+
+    bpf_dbg_printk("mysql_parse_fixup_header: failed to parse mysql header");
+    return -1;
 }
 
 // This is an alternative version of mysql_parse_fixup_header that fills the buffer
@@ -140,36 +150,36 @@ static __always_inline int mysql_read_fixup_buffer(const connection_info_t *conn
     return *buf_len;
 }
 
-static __always_inline void mysql_send_large_buffer(tcp_req_t *req,
-                                                    pid_connection_info_t *pid_conn,
-                                                    const void *u_buf,
-                                                    u32 bytes_len,
-                                                    u8 direction) {
+// Emit a large buffer event for MySQL protocol.
+// The return value is used to control the flow for this specific protocol.
+// -1: wait additional data; 0: continue, regardless of errors.
+static __always_inline int mysql_send_large_buffer(tcp_req_t *req,
+                                                   pid_connection_info_t *pid_conn,
+                                                   const void *u_buf,
+                                                   u32 bytes_len,
+                                                   u8 direction,
+                                                   enum large_buf_action action) {
     if (mysql_store_state_data(&pid_conn->conn, u_buf, bytes_len) < 0) {
         bpf_dbg_printk("mysql_send_large_buffer: 4 bytes packet, storing state data");
-        return;
-    }
-
-    if (bytes_len < (k_mysql_hdr_size + 1)) {
-        bpf_dbg_printk("mysql_send_large_buffer: bytes_len is too short: %d", bytes_len);
-        return;
+        return -1;
     }
 
     tcp_large_buffer_t *large_buf = (tcp_large_buffer_t *)mysql_large_buffers_mem();
     if (!large_buf) {
         bpf_dbg_printk("mysql_send_large_buffer: failed to reserve space for MySQL large buffer");
-        return;
+        return 0;
     }
 
     large_buf->type = EVENT_TCP_LARGE_BUFFER;
     large_buf->direction = direction;
+    large_buf->action = action;
     __builtin_memcpy((void *)&large_buf->tp, (void *)&req->tp, sizeof(tp_info_t));
 
     int written =
         mysql_read_fixup_buffer(&pid_conn->conn, large_buf->buf, &large_buf->len, u_buf, bytes_len);
     if (written < 0) {
         bpf_dbg_printk("mysql_send_large_buffer: failed to read buffer, not sending large buffer");
-        return;
+        return 0;
     }
 
     req->has_large_buffers = true;
@@ -177,6 +187,7 @@ static __always_inline void mysql_send_large_buffer(tcp_req_t *req,
                        large_buf,
                        (sizeof(tcp_large_buffer_t) + written) & k_large_buf_max_size_mask,
                        get_flags());
+    return 0;
 }
 
 static __always_inline u32 data_offset(struct mysql_hdr *hdr) {
@@ -186,32 +197,6 @@ static __always_inline u32 data_offset(struct mysql_hdr *hdr) {
 
 static __always_inline u32 mysql_command_offset(struct mysql_hdr *hdr) {
     return data_offset(hdr) - k_mysql_hdr_command_id_size;
-}
-
-// k_tail_protocol_mysql
-SEC("kprobe/mysql")
-int obi_protocol_mysql(void *ctx) {
-    call_protocol_args_t *args = protocol_args();
-    if (!args) {
-        return 0;
-    }
-
-    bpf_dbg_printk("=== tcp_mysql_event len=%d pid=%d ===",
-                   args->bytes_len,
-                   pid_from_pid_tgid(bpf_get_current_pid_tgid()));
-
-    if (mysql_store_state_data(
-            &args->pid_conn.conn, (const unsigned char *)args->u_buf, args->bytes_len) < 0) {
-        bpf_dbg_printk("mysql: 4 bytes packet, storing state data");
-        return 0;
-    }
-
-    // Tail call back into generic TCP handler.
-    // Once the header is fixed up, we can use the generic TCP handling code
-    // in order to reuse all the common logic.
-    bpf_tail_call(ctx, &jump_table, k_tail_protocol_tcp);
-
-    return 0;
 }
 
 static __always_inline u8 is_mysql(connection_info_t *conn_info,
@@ -234,9 +219,15 @@ static __always_inline u8 is_mysql(connection_info_t *conn_info,
         bpf_dbg_printk("is_mysql: failed to parse mysql header");
         return 0;
     }
+    u32 payload_len = mysql_payload_length(hdr.payload_length);
+
+    if (payload_len > k_mysql_payload_length_max) {
+        bpf_dbg_printk("is_mysql: payload length is too large: %d", payload_len);
+        return 0;
+    }
 
     bpf_dbg_printk("is_mysql: payload_length=%d sequence_id=%d command_id=%d",
-                   mysql_payload_length(hdr.payload_length),
+                   payload_len,
                    hdr.sequence_id,
                    hdr.command_id);
 

--- a/bpf/generictracer/protocol_mysql.h
+++ b/bpf/generictracer/protocol_mysql.h
@@ -260,8 +260,9 @@ static __always_inline u8 is_mysql(connection_info_t *conn_info,
             // NOTE: Trying to classify the connection based on this command
             // would be unreliable, as the check is too shallow.
             *packet_type = PACKET_TYPE_REQUEST;
+            break;
         }
-        break;
+        return 0;
     default:
         if (*protocol_type == k_protocol_type_mysql) {
             // Check sequence ID and make sure we are processing a response.

--- a/pkg/components/ebpf/common/common.go
+++ b/pkg/components/ebpf/common/common.go
@@ -115,7 +115,7 @@ type MisclassifiedEvent struct {
 type EBPFParseContext struct {
 	h2c               *lru.Cache[uint64, h2Connection]
 	redisDBCache      *simplelru.LRU[BpfConnectionInfoT, int]
-	largeBuffers      *expirable.LRU[largeBufferKey, largeBuffer]
+	largeBuffers      *expirable.LRU[largeBufferKey, *largeBuffer]
 	mongoRequestCache *PendingMongoDBRequests
 }
 
@@ -135,7 +135,7 @@ func ptlog() *slog.Logger { return slog.With("component", "ebpf.ProcessTracer") 
 func NewEBPFParseContext(cfg *config.EBPFTracer) *EBPFParseContext {
 	var redisDBCache *simplelru.LRU[BpfConnectionInfoT, int]
 	h2c, _ := lru.New[uint64, h2Connection](1024 * 10)
-	largeBuffers := expirable.NewLRU[largeBufferKey, largeBuffer](1024, nil, 5*time.Minute)
+	largeBuffers := expirable.NewLRU[largeBufferKey, *largeBuffer](1024, nil, 5*time.Minute)
 
 	if cfg != nil && cfg.RedisDBCache.Enabled {
 		var err error

--- a/pkg/components/ebpf/common/common.go
+++ b/pkg/components/ebpf/common/common.go
@@ -116,6 +116,7 @@ type EBPFParseContext struct {
 	h2c               *lru.Cache[uint64, h2Connection]
 	redisDBCache      *simplelru.LRU[BpfConnectionInfoT, int]
 	largeBuffers      *expirable.LRU[largeBufferKey, largeBuffer]
+	largeBuffersMU    sync.RWMutex
 	mongoRequestCache *PendingMongoDBRequests
 }
 

--- a/pkg/components/ebpf/common/common.go
+++ b/pkg/components/ebpf/common/common.go
@@ -116,7 +116,6 @@ type EBPFParseContext struct {
 	h2c               *lru.Cache[uint64, h2Connection]
 	redisDBCache      *simplelru.LRU[BpfConnectionInfoT, int]
 	largeBuffers      *expirable.LRU[largeBufferKey, largeBuffer]
-	largeBuffersMU    sync.RWMutex
 	mongoRequestCache *PendingMongoDBRequests
 }
 
@@ -187,7 +186,7 @@ func ReadBPFTraceAsSpan(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, reco
 	case EventTypeGoKafkaGo:
 		return ReadGoKafkaGoRequestIntoSpan(record)
 	case EventTypeTCPLargeBuffer:
-		return setTCPLargeBuffer(parseCtx, record)
+		return appendTCPLargeBuffer(parseCtx, record)
 	case EventOTelSDKGo:
 		return ReadGoOTelEventIntoSpan(record)
 	}

--- a/pkg/components/ebpf/common/tcp_detect_transform.go
+++ b/pkg/components/ebpf/common/tcp_detect_transform.go
@@ -38,10 +38,10 @@ func ReadTCPRequestIntoSpan(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, 
 	responseBuffer = event.Rbuf[:l]
 
 	if event.HasLargeBuffers == 1 {
-		if b, ok := getTCPLargeBuffer(parseCtx, event.Tp.TraceId, event.Tp.SpanId, 0); ok {
+		if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, event.Tp.SpanId, 0); ok {
 			requestBuffer = b
 		}
-		if b, ok := getTCPLargeBuffer(parseCtx, event.Tp.TraceId, event.Tp.SpanId, 1); ok {
+		if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, event.Tp.SpanId, 1); ok {
 			responseBuffer = b
 		}
 	}

--- a/pkg/components/ebpf/common/tcp_large_buffer.go
+++ b/pkg/components/ebpf/common/tcp_large_buffer.go
@@ -25,8 +25,6 @@ func appendTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (r
 	if err != nil {
 		return request.Span{}, true, err
 	}
-	newBuffer := make([]byte, event.Len)
-	copy(newBuffer, record.RawSample[hdrSize:])
 
 	key := largeBufferKey{
 		traceID:   event.Tp.TraceId,
@@ -34,19 +32,17 @@ func appendTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (r
 		direction: event.Direction,
 	}
 
-	switch event.Action {
-	case 1: // LargeBufActionAppend
-		// If this is an append action, we need to check if the buffer already exists
-		lb, ok := parseCtx.largeBuffers.Get(key)
-		if ok {
-			newBuffer = append(lb.buf, newBuffer...)
-		}
-	default: // LargeBufActionInit
+	lb, ok := parseCtx.largeBuffers.Get(key)
+	if ok && event.Action == 1 {
+		// LargeBufActionAppend
+		lb.buf = append(lb.buf, record.RawSample[hdrSize:hdrSize+event.Len]...)
+	} else {
+		newBuffer := make([]byte, event.Len)
+		copy(newBuffer, record.RawSample[hdrSize:])
+		parseCtx.largeBuffers.Add(key, &largeBuffer{
+			buf: newBuffer,
+		})
 	}
-
-	parseCtx.largeBuffers.Add(key, largeBuffer{
-		buf: newBuffer,
-	})
 
 	return request.Span{}, true, nil
 }

--- a/pkg/components/ebpf/common/tcp_large_buffer.go
+++ b/pkg/components/ebpf/common/tcp_large_buffer.go
@@ -19,6 +19,9 @@ type (
 )
 
 func setTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (request.Span, bool, error) {
+	parseCtx.largeBuffersMU.Lock()
+	defer parseCtx.largeBuffersMU.Unlock()
+
 	hdrSize := uint32(unsafe.Sizeof(TCPLargeBufferHeader{}))
 
 	event, err := ReinterpretCast[TCPLargeBufferHeader](record.RawSample[:hdrSize])
@@ -27,6 +30,7 @@ func setTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (requ
 	}
 	hdrSize -= uint32(unsafe.Sizeof(uintptr(0))) // Remove `buf` placeholder
 	newBuffer := record.RawSample[hdrSize:]
+	newLen := int(event.Len)
 
 	key := largeBufferKey{
 		traceID:   event.Tp.TraceId,
@@ -34,7 +38,19 @@ func setTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (requ
 		direction: event.Direction,
 	}
 
-	copiedBuffer := make([]byte, event.Len)
+	switch event.Action {
+	case 1: // LargeBufActionAppend
+		// If this is an append action, we need to check if the buffer already exists
+		if lb, ok := parseCtx.largeBuffers.Get(key); ok {
+			// If it exists, we can append to it
+			newBuffer = append(lb.buf, newBuffer...)
+			newLen += len(lb.buf)
+			parseCtx.largeBuffers.Remove(key)
+		}
+	default: // LargeBufActionInit
+	}
+
+	copiedBuffer := make([]byte, newLen)
 	copy(copiedBuffer, newBuffer)
 	parseCtx.largeBuffers.Add(key, largeBuffer{
 		buf: copiedBuffer,
@@ -44,6 +60,9 @@ func setTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (requ
 }
 
 func getTCPLargeBuffer(parseCtx *EBPFParseContext, traceID [16]uint8, spanID [8]uint8, direction uint8) ([]byte, bool) {
+	parseCtx.largeBuffersMU.RLock()
+	defer parseCtx.largeBuffersMU.RUnlock()
+
 	key := largeBufferKey{
 		spanID:    spanID,
 		traceID:   traceID,

--- a/pkg/components/ebpf/common/tcp_large_buffer.go
+++ b/pkg/components/ebpf/common/tcp_large_buffer.go
@@ -25,8 +25,8 @@ func appendTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (r
 	if err != nil {
 		return request.Span{}, true, err
 	}
-	newBuffer := record.RawSample[hdrSize:]
-	newLen := int(event.Len)
+	newBuffer := make([]byte, event.Len)
+	copy(newBuffer, record.RawSample[hdrSize:])
 
 	key := largeBufferKey{
 		traceID:   event.Tp.TraceId,
@@ -37,18 +37,15 @@ func appendTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (r
 	switch event.Action {
 	case 1: // LargeBufActionAppend
 		// If this is an append action, we need to check if the buffer already exists
-		if lb, ok := parseCtx.largeBuffers.Get(key); ok {
-			// If it exists, we can append to it
+		lb, ok := parseCtx.largeBuffers.Get(key)
+		if ok {
 			newBuffer = append(lb.buf, newBuffer...)
-			newLen += len(lb.buf)
 		}
 	default: // LargeBufActionInit
 	}
 
-	copiedBuffer := make([]byte, newLen)
-	copy(copiedBuffer, newBuffer)
 	parseCtx.largeBuffers.Add(key, largeBuffer{
-		buf: copiedBuffer,
+		buf: newBuffer,
 	})
 
 	return request.Span{}, true, nil

--- a/pkg/components/ebpf/common/tcp_large_buffer.go
+++ b/pkg/components/ebpf/common/tcp_large_buffer.go
@@ -18,17 +18,13 @@ type (
 	}
 )
 
-func setTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (request.Span, bool, error) {
-	parseCtx.largeBuffersMU.Lock()
-	defer parseCtx.largeBuffersMU.Unlock()
+func appendTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (request.Span, bool, error) {
+	hdrSize := uint32(unsafe.Sizeof(TCPLargeBufferHeader{})) - uint32(unsafe.Sizeof(uintptr(0))) // Remove `buf` placeholder
 
-	hdrSize := uint32(unsafe.Sizeof(TCPLargeBufferHeader{}))
-
-	event, err := ReinterpretCast[TCPLargeBufferHeader](record.RawSample[:hdrSize])
+	event, err := ReinterpretCast[TCPLargeBufferHeader](record.RawSample)
 	if err != nil {
 		return request.Span{}, true, err
 	}
-	hdrSize -= uint32(unsafe.Sizeof(uintptr(0))) // Remove `buf` placeholder
 	newBuffer := record.RawSample[hdrSize:]
 	newLen := int(event.Len)
 
@@ -45,7 +41,6 @@ func setTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (requ
 			// If it exists, we can append to it
 			newBuffer = append(lb.buf, newBuffer...)
 			newLen += len(lb.buf)
-			parseCtx.largeBuffers.Remove(key)
 		}
 	default: // LargeBufActionInit
 	}
@@ -59,10 +54,7 @@ func setTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (requ
 	return request.Span{}, true, nil
 }
 
-func getTCPLargeBuffer(parseCtx *EBPFParseContext, traceID [16]uint8, spanID [8]uint8, direction uint8) ([]byte, bool) {
-	parseCtx.largeBuffersMU.RLock()
-	defer parseCtx.largeBuffersMU.RUnlock()
-
+func extractTCPLargeBuffer(parseCtx *EBPFParseContext, traceID [16]uint8, spanID [8]uint8, direction uint8) ([]byte, bool) {
 	key := largeBufferKey{
 		spanID:    spanID,
 		traceID:   traceID,

--- a/pkg/components/ebpf/common/tcp_large_buffer_test.go
+++ b/pkg/components/ebpf/common/tcp_large_buffer_test.go
@@ -3,7 +3,9 @@ package ebpfcommon
 import (
 	"bytes"
 	"encoding/binary"
+	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 
@@ -14,7 +16,7 @@ import (
 func TestTCPLargeBuffers(t *testing.T) {
 	pctx := NewEBPFParseContext(nil)
 	verifyLargeBuffer := func(traceID [16]uint8, spanID [8]uint8, direction uint8, expectedBuf string) {
-		buf, ok := getTCPLargeBuffer(pctx, traceID, spanID, direction)
+		buf, ok := extractTCPLargeBuffer(pctx, traceID, spanID, direction)
 		require.True(t, ok, "Expected to find large buffer")
 		require.Equal(t, expectedBuf, string(buf), "Buffer content mismatch")
 	}
@@ -28,7 +30,7 @@ func TestTCPLargeBuffers(t *testing.T) {
 	firstEvent.Tp.SpanId = [8]uint8{'2'}
 	firstBuf := "obi rocks!"
 
-	span, drop, err := setTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
+	span, drop, err := appendTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
 	require.NoError(t, err)
 	require.True(t, drop)
 	require.Equal(t, request.Span{}, span)
@@ -38,31 +40,31 @@ func TestTCPLargeBuffers(t *testing.T) {
 
 	secondBuf := "obi rocks twice!"
 	firstEvent.Len = uint32(len(secondBuf))
-	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
+	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
 	require.NoError(t, err)
-	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, secondBuf))
+	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, secondBuf))
 	require.NoError(t, err)
 	// Verify buffer overwrite
 	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.Direction, secondBuf)
 
 	// Verify second read error
-	_, ok := getTCPLargeBuffer(pctx, firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.Direction)
+	_, ok := extractTCPLargeBuffer(pctx, firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.Direction)
 	require.False(t, ok, "Expected to not find large buffer after first read")
 
 	firstEvent.Len = uint32(len(firstBuf))
-	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
+	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
 	require.NoError(t, err)
 
 	// Verify no buffer read happens for different traceID/direction
-	_, ok = getTCPLargeBuffer(pctx, [16]uint8{99}, firstEvent.Tp.SpanId, firstEvent.Direction)
+	_, ok = extractTCPLargeBuffer(pctx, [16]uint8{99}, firstEvent.Tp.SpanId, firstEvent.Direction)
 	require.False(t, ok, "Expected to not find large buffer for this traceID")
-	_, ok = getTCPLargeBuffer(pctx, firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, 3)
+	_, ok = extractTCPLargeBuffer(pctx, firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, 3)
 	require.False(t, ok, "Expected to not find large buffer for this direction")
 	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.Direction, firstBuf)
 
 	// Test append to existing buffer
 	firstEvent.Len = 10
-	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
+	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
 	require.NoError(t, err)
 
 	appendEvent := TCPLargeBufferHeader{
@@ -75,7 +77,7 @@ func TestTCPLargeBuffers(t *testing.T) {
 	appendEvent.Tp.SpanId = firstEvent.Tp.SpanId
 	appendBuf := "append"
 
-	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, appendBuf))
+	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, appendBuf))
 	require.NoError(t, err)
 	// The buffer should now be firstBuf + appendBuf
 	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.Direction, firstBuf+appendBuf)
@@ -85,7 +87,7 @@ func TestTCPLargeBuffers(t *testing.T) {
 	newSpanID := [8]uint8{'4'}
 	appendEvent.Tp.TraceId = newTraceID
 	appendEvent.Tp.SpanId = newSpanID
-	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, appendBuf))
+	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, appendBuf))
 	require.NoError(t, err)
 	verifyLargeBuffer(newTraceID, newSpanID, firstEvent.Direction, appendBuf)
 
@@ -94,13 +96,13 @@ func TestTCPLargeBuffers(t *testing.T) {
 	appendEvent.Tp.SpanId = firstEvent.Tp.SpanId
 	// Re-init buffer
 	firstEvent.Len = uint32(len(firstBuf))
-	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
+	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
 	require.NoError(t, err)
 	// Append twice
 	appendEvent.Len = 3
-	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, "foo"))
+	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, "foo"))
 	require.NoError(t, err)
-	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, "bar"))
+	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, "bar"))
 	require.NoError(t, err)
 	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.Direction, firstBuf+"foobar")
 }
@@ -109,6 +111,10 @@ func toRingbufRecord(t *testing.T, event TCPLargeBufferHeader, buf string) *ring
 	var fixedPart bytes.Buffer
 	if err := binary.Write(&fixedPart, binary.LittleEndian, event); err != nil {
 		t.Fatalf("failed to write ringbuf record fixed part: %v", err)
+	}
+
+	if len(buf) < int(unsafe.Sizeof(TCPLargeBufferHeader{})) {
+		buf += strings.Repeat("\x00", int(unsafe.Sizeof(TCPLargeBufferHeader{}))-len(buf))
 	}
 
 	fixedPart.Write([]byte(buf))

--- a/pkg/components/ebpf/common/tcp_large_buffer_test.go
+++ b/pkg/components/ebpf/common/tcp_large_buffer_test.go
@@ -59,6 +59,50 @@ func TestTCPLargeBuffers(t *testing.T) {
 	_, ok = getTCPLargeBuffer(pctx, firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, 3)
 	require.False(t, ok, "Expected to not find large buffer for this direction")
 	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.Direction, firstBuf)
+
+	// Test append to existing buffer
+	firstEvent.Len = 10
+	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
+	require.NoError(t, err)
+
+	appendEvent := TCPLargeBufferHeader{
+		Type:      firstEvent.Type,
+		Direction: firstEvent.Direction,
+		Len:       6,
+		Action:    1, // LargeBufActionAppend
+	}
+	appendEvent.Tp.TraceId = firstEvent.Tp.TraceId
+	appendEvent.Tp.SpanId = firstEvent.Tp.SpanId
+	appendBuf := "append"
+
+	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, appendBuf))
+	require.NoError(t, err)
+	// The buffer should now be firstBuf + appendBuf
+	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.Direction, firstBuf+appendBuf)
+
+	// Test append to non-existing buffer (should just add a new one)
+	newTraceID := [16]uint8{'3'}
+	newSpanID := [8]uint8{'4'}
+	appendEvent.Tp.TraceId = newTraceID
+	appendEvent.Tp.SpanId = newSpanID
+	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, appendBuf))
+	require.NoError(t, err)
+	verifyLargeBuffer(newTraceID, newSpanID, firstEvent.Direction, appendBuf)
+
+	// Test multiple appends
+	appendEvent.Tp.TraceId = firstEvent.Tp.TraceId
+	appendEvent.Tp.SpanId = firstEvent.Tp.SpanId
+	// Re-init buffer
+	firstEvent.Len = uint32(len(firstBuf))
+	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
+	require.NoError(t, err)
+	// Append twice
+	appendEvent.Len = 3
+	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, "foo"))
+	require.NoError(t, err)
+	_, _, err = setTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, "bar"))
+	require.NoError(t, err)
+	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.Direction, firstBuf+"foobar")
 }
 
 func toRingbufRecord(t *testing.T, event TCPLargeBufferHeader, buf string) *ringbuf.Record {

--- a/pkg/components/ebpf/common/tcp_large_buffer_test.go
+++ b/pkg/components/ebpf/common/tcp_large_buffer_test.go
@@ -8,6 +8,7 @@ import (
 	"unsafe"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
 
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/app/request"
 	"github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/components/ebpf/ringbuf"
@@ -18,7 +19,7 @@ func TestTCPLargeBuffers(t *testing.T) {
 	verifyLargeBuffer := func(traceID [16]uint8, spanID [8]uint8, direction uint8, expectedBuf string) {
 		buf, ok := extractTCPLargeBuffer(pctx, traceID, spanID, direction)
 		require.True(t, ok, "Expected to find large buffer")
-		require.Equal(t, expectedBuf, string(buf), "Buffer content mismatch")
+		require.Equal(t, expectedBuf, unix.ByteSliceToString(buf), "Buffer content mismatch")
 	}
 
 	firstEvent := TCPLargeBufferHeader{

--- a/pkg/components/ebpf/generictracer/generictracer.go
+++ b/pkg/components/ebpf/generictracer/generictracer.go
@@ -147,45 +147,17 @@ func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
 }
 
 func (p *Tracer) SetupTailCalls() {
-	for _, tc := range []struct {
-		index int
-		prog  *ebpf.Program
-	}{
-		{
-			index: 0,
-			prog:  p.bpfObjects.ObiProtocolHttp,
-		},
-		{
-			index: 1,
-			prog:  p.bpfObjects.ObiProtocolHttp2,
-		},
-		{
-			index: 2,
-			prog:  p.bpfObjects.ObiProtocolTcp,
-		},
-		{
-			index: 3,
-			prog:  p.bpfObjects.ObiProtocolHttp2GrpcFrames,
-		},
-		{
-			index: 4,
-			prog:  p.bpfObjects.ObiProtocolHttp2GrpcHandleStartFrame,
-		},
-		{
-			index: 5,
-			prog:  p.bpfObjects.ObiProtocolHttp2GrpcHandleEndFrame,
-		},
-		{
-			index: 6,
-			prog:  p.bpfObjects.ObiProtocolMysql,
-		},
-		{
-			index: 7,
-			prog:  p.bpfObjects.ObiHandleBufWithArgs,
-		},
+	for i, prog := range []*ebpf.Program{
+		p.bpfObjects.ObiProtocolHttp,                      // 0
+		p.bpfObjects.ObiProtocolHttp2,                     // 1
+		p.bpfObjects.ObiProtocolTcp,                       // 2
+		p.bpfObjects.ObiProtocolHttp2GrpcFrames,           // 3
+		p.bpfObjects.ObiProtocolHttp2GrpcHandleStartFrame, // 4
+		p.bpfObjects.ObiProtocolHttp2GrpcHandleEndFrame,   // 5
+		p.bpfObjects.ObiHandleBufWithArgs,                 // 6
 	} {
-		err := p.bpfObjects.JumpTable.Update(uint32(tc.index), uint32(tc.prog.FD()), ebpf.UpdateAny)
-		if err != nil {
+		p.log.Debug("loading program into tail call jump table", "index", i, "program", prog.String())
+		if err := p.bpfObjects.JumpTable.Update(uint32(i), uint32(prog.FD()), ebpf.UpdateAny); err != nil {
 			p.log.Error("error loading info tail call jump table", "error", err)
 		}
 	}

--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -84,7 +84,7 @@ type EBPFTracer struct {
 	RedisDBCache RedisDBCacheConfig `yaml:"redis_db_cache"`
 
 	// Limit max data buffer size per protocol.
-	BufferSizes EBPFBufferSizes `yaml:"buffer_sizes" env:"OTEL_EBPF_BPF_BUFFER_SIZES"`
+	BufferSizes EBPFBufferSizes `yaml:"buffer_sizes"`
 }
 
 type EBPFBufferSizes struct {


### PR DESCRIPTION
- Add large buffer `action`: init/append
- Remove mysql tail call program: it was essentially useless
- Add more sanity checks and better header parsing based on payload lengths
- Add large buffers userspace rwlock, add tests for different actions