### PR TITLE
Do not fail cleanup when empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,8 +242,10 @@ cleanup-integration-test:
 	@echo "### Removing integration test clusters"
 	$(KIND) delete cluster -n test-kind-cluster || true
 	@echo "### Removing docker containers and images"
-	$(OCI_BIN) rm -f $(shell $(OCI_BIN) ps --format '{{.Names}}' | grep 'integration-') || true
-	$(OCI_BIN) rmi -f $(shell $(OCI_BIN) images --format '{{.Repository}}:{{.Tag}}' | grep 'hatest-') || true
+	$(eval CONTAINERS := $(shell $(OCI_BIN) ps --format '{{.Names}}' | grep 'integration-'))
+	$(if $(strip $(CONTAINERS)),$(OCI_BIN) rm -f $$CONTAINERS,@echo "No integration test containers to remove")
+	$(eval IMAGES := $(shell $(OCI_BIN) images --format '{{.Repository}}:{{.Tag}}' | grep 'hatest-'))
+	$(if $(strip $(CONTAINERS)),$(OCI_BIN) rmi -f $$IMAGES,@echo "No integration test images to remove")
 
 .PHONY: run-integration-test
 run-integration-test:


### PR DESCRIPTION
If there are no docker containers or images the `docker rm` and `docker rmi` commands become syntactically invalid. Only run the commands if there are containers or images to remove.

For example: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/16375613470/job/46278493579?pr=330