### PR TITLE
Close the elf file when attacher is done with it

### DIFF
--- a/pkg/components/discover/attacher.go
+++ b/pkg/components/discover/attacher.go
@@ -118,7 +118,7 @@ func (ta *TraceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 							}
 
 							if instr.Obj.FileInfo.ELF != nil {
-								instr.Obj.FileInfo.ELF.Close()
+								_ = instr.Obj.FileInfo.ELF.Close()
 							}
 						}
 					case EventDeleted:

--- a/pkg/components/discover/attacher.go
+++ b/pkg/components/discover/attacher.go
@@ -116,6 +116,10 @@ func (ta *TraceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 							if ok := ta.getTracer(&instr.Obj); ok {
 								ta.OutputTracerEvents.Send(Event[*ebpf.Instrumentable]{Type: EventCreated, Obj: &instr.Obj})
 							}
+
+							if instr.Obj.FileInfo.ELF != nil {
+								instr.Obj.FileInfo.ELF.Close()
+							}
 						}
 					case EventDeleted:
 						ta.notifyProcessDeletion(&instr.Obj)


### PR DESCRIPTION
We never closed the ELF file opened during binary file inspection, which can cause for a large number of files to remain opened when OBI is running. This can especially become a problem for short lived binaries that we keep on detecting, instrumenting etc.