### PR TITLE
Wait for client metrics in k8s tests

### DIFF
--- a/test/integration/k8s/common/k8s_metrics_testfuncs.go
+++ b/test/integration/k8s/common/k8s_metrics_testfuncs.go
@@ -96,6 +96,19 @@ func DoWaitForComponentsAvailable(t *testing.T) {
 	}, test.Interval(time.Second))
 }
 
+func DoWaitForHTTPClientAvailable(t *testing.T) {
+	pq := prom.Client{HostPort: prometheusHostPort}
+	var results []prom.Result
+	test.Eventually(t, 4*testTimeout, func(t require.TestingT) {
+		// now, verify that the metric has been reported.
+		// we don't really care that this metric could be from a previous
+		// test. Once one it is visible, it means that Otel and Prometheus are healthy
+		results, err = pq.Query(`http_client_request_duration_seconds_count{url_path="/iping"}`)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+	}, test.Interval(time.Second))
+}
+
 func FeatureHTTPMetricsDecoration(manifest string, overrideAttrs map[string]string) features.Feature {
 	pinger := kube.Template[Pinger]{
 		TemplateFile: manifest,

--- a/test/integration/k8s/otel/k8s_otel_metrics_test.go
+++ b/test/integration/k8s/otel/k8s_otel_metrics_test.go
@@ -18,6 +18,7 @@ func TestOTEL_MetricsDecoration_AA_WaitForComponents(t *testing.T) {
 }
 
 func TestOTEL_MetricsDecoration_HTTP(t *testing.T) {
+	k8s.DoWaitForHTTPClientAvailable(t)
 	cluster.TestEnv().Test(t, k8s.FeatureHTTPMetricsDecoration(k8s.PingerManifest, nil))
 }
 


### PR DESCRIPTION
I believe commonly fail the k8s tests because we only wait to see server metrics before we proceed with the test. It often fails like this:
```
=== RUN   TestInformersCache_MetricsDecoration_HTTP/Decoration_of_Pod-to-Service_communications/all_the_client_metrics_are_properly_decorated
=== RUN   TestInformersCache_MetricsDecoration_HTTP/Decoration_of_Pod-to-Service_communications/all_the_client_metrics_are_properly_decorated/http_client_request_duration_seconds_count
    eventually.go:81: 
        	Error Trace:	/home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/test/integration/k8s/common/k8s_metrics_testfuncs.go:277
        	            				/home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/vendor/github.com/mariomac/guara/pkg/test/eventually.go:57
        	            				/opt/hostedtoolcache/go/1.24.4/x64/src/runtime/asm_amd64.s:1700
```

When I checked the logs for the http pinger, I see the following:

```
2025-07-18T18:39:24.83622516Z stdout F time=2025-07-18T18:39:24.836Z level=INFO msg="failed to upload metrics: Post \"http://otelcol:4318/v1/metrics\": dial tcp 10.96.34.167:4318: connect: connection refused"
2025-07-18T18:39:24.845230477Z stdout F time=2025-07-18T18:39:24.845Z level=INFO msg="failed to upload metrics: Post \"http://otelcol:4318/v1/metrics\": dial tcp 10.96.34.167:4318: connect: connection refused"
2025-07-18T18:39:24.855952629Z stdout F time=2025-07-18T18:39:24.855Z level=INFO msg="failed to upload metrics: Post \"http://otelcol:4318/v1/metrics\": dial tcp 10.96.34.167:4318: connect: connection refused"
2025-07-18T18:39:24.865457561Z stdout F time=2025-07-18T18:39:24.865Z level=INFO msg="failed to upload metrics: Post \"http://otelcol:4318/v1/metrics\": dial tcp 10.96.34.167:4318: connect: connection refused"
2025-07-18T18:39:24.875825334Z stdout F time=2025-07-18T18:39:24.875Z level=INFO msg="failed to upload metrics: Post \"http://otelcol:4318/v1/metrics\": dial tcp 10.96.34.167:4318: connect: connection refused"
2025-07-18T18:39:24.885432637Z stdout F time=2025-07-18T18:39:24.885Z level=INFO msg="failed to upload metrics: Post \"http://otelcol:4318/v1/metrics\": dial tcp 10.96.34.167:4318: connect: connection refused"
```

I'm attempting to see if it helps if I explicitly wait for the http pinger component before proceeding with the k8s test.