### PR TITLE
Add per service selecto sampler config

### DIFF
--- a/pkg/components/discover/matcher_test.go
+++ b/pkg/components/discover/matcher_test.go
@@ -466,6 +466,9 @@ func TestCriteriaMatcher_Granular(t *testing.T) {
     exports: [metrics]
   - k8s_deployment_name: planet-service
     exports: [traces]
+    sampler:
+        name: traceidratio
+        arg: 0.5
   - k8s_deployment_name: satellite-service
     exports: []
   - k8s_deployment_name: star-service
@@ -550,6 +553,8 @@ func TestCriteriaMatcher_Granular(t *testing.T) {
 
 	assert.True(t, planetAttrs.ExportModes.CanExportTraces())
 	assert.False(t, planetAttrs.ExportModes.CanExportMetrics())
+	require.NotNil(t, planetAttrs.Sampler)
+	assert.Equal(t, "TraceIDRatioBased{0.5}", planetAttrs.Sampler.Description())
 
 	satelliteMatch := matches[1].Obj
 
@@ -559,6 +564,7 @@ func TestCriteriaMatcher_Granular(t *testing.T) {
 
 	assert.False(t, satelliteAttrs.ExportModes.CanExportTraces())
 	assert.False(t, satelliteAttrs.ExportModes.CanExportMetrics())
+	require.Nil(t, satelliteAttrs.Sampler)
 
 	starMatch := matches[2].Obj
 
@@ -568,6 +574,7 @@ func TestCriteriaMatcher_Granular(t *testing.T) {
 
 	assert.False(t, starAttrs.ExportModes.CanExportTraces())
 	assert.True(t, starAttrs.ExportModes.CanExportMetrics())
+	require.Nil(t, starAttrs.Sampler)
 
 	asteroidMatch := matches[3].Obj
 
@@ -577,4 +584,5 @@ func TestCriteriaMatcher_Granular(t *testing.T) {
 
 	assert.True(t, asteroidAttrs.ExportModes.CanExportTraces())
 	assert.True(t, asteroidAttrs.ExportModes.CanExportMetrics())
+	require.Nil(t, asteroidAttrs.Sampler)
 }

--- a/pkg/components/svc/svc.go
+++ b/pkg/components/svc/svc.go
@@ -6,6 +6,8 @@ package svc
 import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 
+	"go.opentelemetry.io/otel/sdk/trace"
+
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/services"
 )
@@ -100,6 +102,8 @@ type Attrs struct {
 	flags idFlags
 
 	ExportModes services.ExportModes
+
+	Sampler trace.Sampler
 }
 
 func (i *Attrs) GetUID() UID {

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -52,6 +52,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+	"go.opentelemetry.io/obi/pkg/services"
 )
 
 func tlog() *slog.Logger {
@@ -78,7 +79,7 @@ type TracesConfig struct {
 	// InsecureSkipVerify is not standard, so we don't follow the same naming convention
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"OTEL_EBPF_INSECURE_SKIP_VERIFY"`
 
-	Sampler Sampler `yaml:"sampler"`
+	SamplerConfig services.SamplerConfig `yaml:"sampler"`
 
 	// Configuration options below this line will remain undocumented at the moment,
 	// but can be useful for performance-tuning of some customers.
@@ -325,7 +326,7 @@ func (tr *tracesOTELReceiver) provideLoop(ctx context.Context) {
 		traceAttrs[attr.SkipSpanMetrics] = struct{}{}
 	}
 
-	sampler := tr.cfg.Sampler.Implementation()
+	sampler := tr.cfg.SamplerConfig.Implementation()
 
 	for spans := range tr.input {
 		tr.processSpans(ctx, exp, spans, traceAttrs, sampler)

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -254,7 +254,15 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 
 		finalAttrs := TraceAttributes(span, traceAttrs)
 
-		sr := sampler.ShouldSample(trace.SamplingParameters{
+		spanSampler := func() trace.Sampler {
+			if span.Service.Sampler != nil {
+				return span.Service.Sampler
+			}
+
+			return sampler
+		}
+
+		sr := spanSampler().ShouldSample(trace.SamplingParameters{
 			ParentContext: ctx,
 			Name:          span.TraceName(),
 			TraceID:       span.TraceID,

--- a/pkg/services/attr_glob.go
+++ b/pkg/services/attr_glob.go
@@ -78,6 +78,8 @@ type GlobAttributes struct {
 	// or an empty array (disabled). An unspecified value (nil) will use the
 	// default configuration value
 	ExportModes ExportModes `yaml:"exports"`
+
+	SamplerConfig *SamplerConfig `yaml:"sampler"`
 }
 
 // GlobAttr provides a YAML handler for glob.Glob so the type can be parsed from YAML or environment variables
@@ -176,6 +178,8 @@ func (ga *GlobAttributes) RangePodAnnotations() iter.Seq2[string, StringMatcher]
 }
 
 func (ga *GlobAttributes) GetExportModes() ExportModes { return ga.ExportModes }
+
+func (ga *GlobAttributes) GetSamplerConfig() *SamplerConfig { return ga.SamplerConfig }
 
 type nilMatcher struct{}
 

--- a/pkg/services/attr_regex.go
+++ b/pkg/services/attr_regex.go
@@ -84,6 +84,8 @@ type RegexSelector struct {
 	// or an empty array (disabled). An unspecified value (nil) will use the
 	// default configuration value
 	ExportModes ExportModes `yaml:"exports"`
+
+	SamplerConfig *SamplerConfig `yaml:"sampler"`
 }
 
 // RegexpAttr stores a regular expression representing an executable file path.
@@ -180,3 +182,5 @@ func (a *RegexSelector) RangePodAnnotations() iter.Seq2[string, StringMatcher] {
 }
 
 func (a *RegexSelector) GetExportModes() ExportModes { return a.ExportModes }
+
+func (a *RegexSelector) GetSamplerConfig() *SamplerConfig { return a.SamplerConfig }

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -193,6 +193,7 @@ type Selector interface {
 	RangePodLabels() iter.Seq2[string, StringMatcher]
 	RangePodAnnotations() iter.Seq2[string, StringMatcher]
 	GetExportModes() ExportModes
+	GetSamplerConfig() *SamplerConfig
 }
 
 // StringMatcher provides a generic interface to match string values against some matcher types: regex and glob

--- a/pkg/services/samplerconfig.go
+++ b/pkg/services/samplerconfig.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otel
+package services
 
 import (
 	"log/slog"
@@ -13,12 +13,12 @@ import (
 // Sampler standard configuration
 // https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_traces_sampler
 // We don't support, yet, the jaeger and xray samplers.
-type Sampler struct {
+type SamplerConfig struct {
 	Name string `yaml:"name" env:"OTEL_TRACES_SAMPLER"`
 	Arg  string `yaml:"arg" env:"OTEL_TRACES_SAMPLER_ARG"`
 }
 
-func (s *Sampler) Implementation() trace.Sampler {
+func (s *SamplerConfig) Implementation() trace.Sampler {
 	defaultSampler := func() trace.Sampler {
 		return trace.ParentBased(trace.AlwaysSample())
 	}

--- a/pkg/services/samplerconfig_test.go
+++ b/pkg/services/samplerconfig_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otel
+package services
 
 import (
 	"testing"
@@ -12,7 +12,7 @@ import (
 
 func TestSamplerImplementation(t *testing.T) {
 	type testCase struct {
-		in  Sampler
+		in  SamplerConfig
 		out trace.Sampler
 	}
 
@@ -20,32 +20,32 @@ func TestSamplerImplementation(t *testing.T) {
 		// default sampler
 		out: trace.ParentBased(trace.AlwaysSample()),
 	}, {
-		in:  Sampler{Name: "invalid_sampler", Arg: "0.33"},
+		in:  SamplerConfig{Name: "invalid_sampler", Arg: "0.33"},
 		out: trace.ParentBased(trace.AlwaysSample()),
 	}, {
-		in:  Sampler{Name: "always_on"},
+		in:  SamplerConfig{Name: "always_on"},
 		out: trace.AlwaysSample(),
 	}, {
-		in:  Sampler{Name: "always_off"},
+		in:  SamplerConfig{Name: "always_off"},
 		out: trace.NeverSample(),
 	}, {
-		in:  Sampler{Name: "traceidratio", Arg: "0.33"},
+		in:  SamplerConfig{Name: "traceidratio", Arg: "0.33"},
 		out: trace.TraceIDRatioBased(0.33),
 	}, {
 		// wrong argument: using default sampler
-		in:  Sampler{Name: "traceidratio", Arg: "fofofofoof"},
+		in:  SamplerConfig{Name: "traceidratio", Arg: "fofofofoof"},
 		out: trace.ParentBased(trace.AlwaysSample()),
 	}, {
-		in:  Sampler{Name: "parentbased_always_off", Arg: "0.33"},
+		in:  SamplerConfig{Name: "parentbased_always_off", Arg: "0.33"},
 		out: trace.ParentBased(trace.NeverSample()),
 	}, {
-		in:  Sampler{Name: "parentbased_always_on", Arg: "0.33"},
+		in:  SamplerConfig{Name: "parentbased_always_on", Arg: "0.33"},
 		out: trace.ParentBased(trace.AlwaysSample()),
 	}, {
-		in:  Sampler{Name: "parentbased_traceidratio", Arg: "0.3"},
+		in:  SamplerConfig{Name: "parentbased_traceidratio", Arg: "0.3"},
 		out: trace.ParentBased(trace.TraceIDRatioBased(0.3)),
 	}, {
-		in:  Sampler{Name: "parentbased_traceidratio", Arg: "wrong argument"},
+		in:  SamplerConfig{Name: "parentbased_traceidratio", Arg: "wrong argument"},
 		out: trace.ParentBased(trace.AlwaysSample()),
 	}} {
 		t.Run(tc.in.Name+"/"+tc.in.Arg, func(t *testing.T) {

--- a/test/integration/configs/obi-config-sampler.yml
+++ b/test/integration/configs/obi-config-sampler.yml
@@ -1,0 +1,30 @@
+routes:
+  patterns:
+    - /basic/:rnd
+  unmatched: path
+otel_metrics_export:
+  endpoint: http://otelcol:4018
+otel_traces_export:
+  endpoint: http://jaeger:4318
+discovery:
+  services:
+    - name: another-service
+      exe_path: asdflkjasdf
+    - namespace: multi-k
+      name: service-a
+      open_ports: 5000
+    - namespace: multi-k
+      name: service-c
+      open_ports: 5002
+      sampler:
+        name: traceidratio
+        arg: "0.5"
+attributes:
+  kubernetes:
+    enable: true
+    cluster_name: my-kube
+  select:
+    http_server_request_duration_seconds_count:
+      exclude: ["server_address"]
+    "*":
+      include: ["*"]

--- a/test/integration/docker-compose-sampler.yml
+++ b/test/integration/docker-compose-sampler.yml
@@ -1,0 +1,93 @@
+version: "3.8"
+
+services:
+  nodeserver:
+    build:
+      context: ../..
+      dockerfile: test/integration/components/nodemultiproc/Dockerfile
+    image: nodemultiproc
+    ports:
+      - "5000:5000"
+      - "5001:5001"
+      - "5002:5002"
+      - "5003:5003"
+    environment:
+      LOG_LEVEL: DEBUG
+    depends_on:
+      otelcol:
+        condition: service_started
+      jaeger:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../..
+      dockerfile: ./test/integration/components/ebpf-instrument/Dockerfile
+    command:
+      - --config=/configs/obi-config-sampler.yml
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../testoutput:/coverage
+      - ../../testoutput/run-multi:/var/run/beyla
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    pid: "host"
+    environment:
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_METRICS_FEATURES: "application,application_span"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_METRICS_INTERVAL: "10ms"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT: 8999
+      OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PATH: /metrics
+    ports:
+      - "8999:8999"
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.104.0
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-4017.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4017" # OTLP over gRPC receiver
+      - "4018:4018" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v2.55.1
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+      - --log.level=debug
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317:4317" # OTEL GRPC traces collector
+      - "4318:4318" # OTEL HTTP traces collector
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=debug

--- a/test/integration/sampler_test.go
+++ b/test/integration/sampler_test.go
@@ -1,0 +1,90 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/test/integration/components/docker"
+	"go.opentelemetry.io/obi/test/integration/components/jaeger"
+)
+
+func testSampler(t *testing.T) {
+	waitForTestComponents(t, "http://localhost:5000")
+	waitForTestComponents(t, "http://localhost:5002")
+	waitForTestComponents(t, "http://localhost:5003")
+
+	// give enough time for the NodeJS injector to finish
+	// TODO: once we implement the instrumentation status query API, replace
+	// this with  a proper check to see if the target process has finished
+	// being instrumented
+	time.Sleep(60 * time.Second)
+
+	// Add and check for specific trace ID
+	// Run couple of requests to make sure we flush out any transactions that might be
+	// stuck because of our tracking of full request times
+	for i := 0; i < 10; i++ {
+		doHTTPGet(t, "http://localhost:5000/a", 200)
+	}
+
+	test.Eventually(t, testTimeout, func(t require.TestingT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=service-a&operation=GET%20%2Fa")
+
+		require.NoError(t, err)
+
+		if resp == nil {
+			return
+		}
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var tq jaeger.TracesQuery
+
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&tq))
+
+		traces := tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/a"})
+
+		lenA := len(traces)
+
+		require.LessOrEqual(t, 10, lenA)
+
+		resp, err = http.Get(jaegerQueryURL + "?service=service-c&operation=GET%20%2Fc")
+
+		require.NoError(t, err)
+
+		if resp == nil {
+			return
+		}
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		traces = tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/c"})
+
+		lenC := len(traces)
+
+		require.LessOrEqual(t, lenC, 6)
+		require.LessOrEqual(t, lenC, lenA)
+	}, test.Interval(1500*time.Millisecond))
+}
+
+func TestSampler(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-sampler.yml", path.Join(pathOutput, "test-suite-sampler.log"))
+	// we are going to setup discovery directly in the configuration file
+	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+
+	t.Run("Sampler", testSampler)
+
+	require.NoError(t, compose.Close())
+}


### PR DESCRIPTION
Allow to specify an OTEL Sampler configuration on a per criteria selector basis (e.g. per service).

This PR is best reviewed on a per-commit basis.