### PR TITLE
Initialize host info metric on first span

### DIFF
--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -75,6 +75,7 @@ type MetricsReporter struct {
 	attributes *attributes.AttrSelector
 	exporter   sdkmetric.Exporter
 	reporters  otelcfg.ReporterPool[*svc.Attrs, *Metrics]
+	hostInfo   *Expirer[*request.Span, instrument.Int64Gauge, int64]
 	pidTracker PidServiceTracker
 	is         instrumentations.InstrumentationSelection
 
@@ -570,8 +571,15 @@ func (mr *MetricsReporter) setupHostInfoMeter(meter instrument.Meter) error {
 	if err != nil {
 		return fmt.Errorf("creating span metric traces host info: %w", err)
 	}
-	attrOpt := instrument.WithAttributeSet(mr.metricHostAttributes())
-	tracesHostInfo.Record(mr.ctx, 1, attrOpt)
+	attr := attributes.Field[*request.Span, attribute.KeyValue]{
+		ExposedName: string(GrafanaHostIDKey),
+		Get: func(_ *request.Span) attribute.KeyValue {
+			return semconv.HostID(mr.hostID)
+		},
+	}
+
+	mr.hostInfo = NewExpirer[*request.Span, instrument.Int64Gauge, int64](
+		mr.ctx, tracesHostInfo, []attributes.Field[*request.Span, attribute.KeyValue]{attr}, timeNow, mr.cfg.TTL)
 
 	return nil
 }
@@ -969,6 +977,10 @@ func (mr *MetricsReporter) onProcessEvent(pe *exec.ProcessEvent) {
 			mlog().Debug("deleting infos for", "pid", pe.File.Pid, "attrs", reporter.service)
 			mr.deleteTracesTargetInfo(reporter)
 			mr.deleteTargetInfo(reporter)
+			if mr.cfg.HostMetricsEnabled() && mr.pidTracker.Count() == 0 {
+				mlog().Debug("No more PIDs tracked, expiring host info metric")
+				mr.hostInfo.RemoveAllMetrics(mr.ctx)
+			}
 		}
 	}
 }
@@ -993,6 +1005,11 @@ func (mr *MetricsReporter) onSpan(spans []request.Span) {
 			continue
 		}
 		reporter.record(s, mr)
+
+		if mr.cfg.HostMetricsEnabled() {
+			hostInfo, attrs := mr.hostInfo.ForRecord(s)
+			hostInfo.Record(mr.ctx, 1, instrument.WithAttributeSet(attrs))
+		}
 	}
 }
 

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -163,15 +163,6 @@ func ReportMetrics(
 			return nil, fmt.Errorf("instantiating OTEL metrics reporter: %w", err)
 		}
 
-		if mr.cfg.HostMetricsEnabled() {
-			hostMetrics := mr.newMetricsInstance(nil)
-			hostMeter := hostMetrics.provider.Meter(reporterName)
-			err := mr.setupHostInfoMeter(hostMeter)
-			if err != nil {
-				return nil, fmt.Errorf("setting up host metrics: %w", err)
-			}
-		}
-
 		return mr.reportMetrics, nil
 	}
 }
@@ -278,6 +269,15 @@ func newMetricsReporter(
 	mr.exporter = instrumentMetricsExporter(ctxInfo.Metrics, exporter)
 
 	mr.pidTracker = NewPidServiceTracker()
+
+	if cfg.HostMetricsEnabled() {
+		hostMetrics := mr.newMetricsInstance(nil)
+		hostMeter := hostMetrics.provider.Meter(reporterName)
+		err := mr.setupHostInfoMeter(hostMeter)
+		if err != nil {
+			return nil, fmt.Errorf("setting up host metrics: %w", err)
+		}
+	}
 
 	return &mr, nil
 }

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -202,20 +202,20 @@ func newResourceInternal(hostID string) *resource.Resource {
 }
 
 func (p *InternalMetricsReporter) recordAvoidedService(serviceName, serviceNamespace, serviceInstanceID, telemetryType string) {
-	   attrs := []attribute.KeyValue{
-			   semconv.ServiceName(serviceName),
-			   semconv.ServiceNamespace(serviceNamespace),
-			   semconv.ServiceInstanceID(serviceInstanceID),
-			   attribute.String("telemetry.type", telemetryType),
-	   }
+	attrs := []attribute.KeyValue{
+		semconv.ServiceName(serviceName),
+		semconv.ServiceNamespace(serviceNamespace),
+		semconv.ServiceInstanceID(serviceInstanceID),
+		attribute.String("telemetry.type", telemetryType),
+	}
 
-	   p.avoidedServices.Record(p.ctx, 1, instrument.WithAttributes(attrs...))
+	p.avoidedServices.Record(p.ctx, 1, instrument.WithAttributes(attrs...))
 }
 
 func (p *InternalMetricsReporter) AvoidInstrumentationMetrics(serviceName, serviceNamespace, serviceInstanceID string) {
-	   p.recordAvoidedService(serviceName, serviceNamespace, serviceInstanceID, "metrics")
+	p.recordAvoidedService(serviceName, serviceNamespace, serviceInstanceID, "metrics")
 }
 
 func (p *InternalMetricsReporter) AvoidInstrumentationTraces(serviceName, serviceNamespace, serviceInstanceID string) {
-	   p.recordAvoidedService(serviceName, serviceNamespace, serviceInstanceID, "traces")
+	p.recordAvoidedService(serviceName, serviceNamespace, serviceInstanceID, "traces")
 }

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -27,7 +27,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
-	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 	"go.opentelemetry.io/obi/test/collector"
 )
 
@@ -236,8 +235,8 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			require.NoError(t, err)
 
 			metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
-			otelExporter := makeExporter(ctx, t, tt.instr, []string{otelcfg.FeatureApplication}, otlp, metrics)
-
+			processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+			otelExporter := makeMetricsReporter(ctx, t, tt.instr, []string{otelcfg.FeatureApplication}, otlp, metrics, processEvents).reportMetrics
 			require.NoError(t, err)
 
 			go otelExporter(ctx)
@@ -302,8 +301,8 @@ func TestAppMetrics_ResourceAttributes(t *testing.T) {
 	timeNow = now.Now
 
 	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
-	otelExporter := makeExporter(ctx, t, []string{instrumentations.InstrumentationHTTP}, []string{otelcfg.FeatureApplication}, otlp, metrics)
-
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	otelExporter := makeMetricsReporter(ctx, t, []string{instrumentations.InstrumentationHTTP}, []string{otelcfg.FeatureApplication}, otlp, metrics, processEvents).reportMetrics
 	go otelExporter(ctx)
 
 	metrics.Send([]request.Span{
@@ -488,12 +487,10 @@ func readNChan(t require.TestingT, inCh <-chan collector.MetricRecord, numRecord
 	return records
 }
 
-func makeExporter(
+func makeMetricsReporter(
 	ctx context.Context, t *testing.T, instrumentations []string, features []string, otlp *collector.TestCollector,
-	input *msg.Queue[[]request.Span],
-) swarm.RunFunc {
-	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
-
+	input *msg.Queue[[]request.Span], processEvents *msg.Queue[exec.ProcessEvent],
+) *MetricsReporter {
 	mcfg := &otelcfg.MetricsConfig{
 		Interval:          50 * time.Millisecond,
 		CommonEndpoint:    otlp.ServerEndpoint,
@@ -503,19 +500,22 @@ func makeExporter(
 		ReportersCacheLen: 100,
 		Instrumentations:  instrumentations,
 	}
-	otelExporter, err := ReportMetrics(
+	mr, err := newMetricsReporter(
+		ctx,
 		&global.ContextInfo{OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg}},
-		mcfg, &attributes.SelectorConfig{
+		mcfg,
+		&attributes.SelectorConfig{
 			SelectionCfg: attributes.Selection{
 				attributes.HTTPServerDuration.Section: attributes.InclusionLists{
 					Include: []string{"url.path"},
 				},
 			},
-		}, input, processEvents)(ctx)
+		},
+		input,
+		processEvents)
 
 	require.NoError(t, err)
-
-	return otelExporter
+	return mr
 }
 
 func TestAppMetrics_TracesHostInfo(t *testing.T) {
@@ -530,27 +530,42 @@ func TestAppMetrics_TracesHostInfo(t *testing.T) {
 	timeNow = now.Now
 
 	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
-	otelExporter := makeExporter(ctx, t, []string{instrumentations.InstrumentationHTTP}, []string{otelcfg.FeatureApplication, otelcfg.FeatureApplicationHost}, otlp, metrics)
-
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	mr := makeMetricsReporter(ctx, t, []string{instrumentations.InstrumentationHTTP}, []string{otelcfg.FeatureApplication, otelcfg.FeatureApplicationHost}, otlp, metrics, processEvents)
+	otelExporter := mr.reportMetrics
 	go otelExporter(ctx)
 
 	assert.Len(t, otlp.Records(), 0, "metric reported before the first span is sent")
+
+	processEvents.Send(exec.ProcessEvent{
+		Type: exec.ProcessEventCreated,
+		File: &exec.FileInfo{
+			Service: svc.Attrs{
+				UID: svc.UID{Instance: "foo"},
+			},
+		},
+	})
 
 	metrics.Send([]request.Span{
 		{Service: svc.Attrs{UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeHTTP, Path: "/foo", RequestStart: 100, End: 200},
 	})
 
-	res := readNChan(t, otlp.Records(), 2, timeout)
-	assert.Len(t, res, 2)
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(t, 1, len(mr.hostInfo.entries.All())) // The entry should be expired
+	}, 10*time.Second, 10*time.Millisecond, "traces_host_info metric has not been created yet")
 
-	found := false
-	for _, r := range res {
-		if r.Name == "traces_host_info" {
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "traces_host_info metric not found in the exported metrics")
+	// Check expiration logic
+	processEvents.Send(exec.ProcessEvent{
+		Type: exec.ProcessEventTerminated,
+		File: &exec.FileInfo{
+			Service: svc.Attrs{
+				UID: svc.UID{Instance: "foo"},
+			},
+		},
+	})
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(t, 0, len(mr.hostInfo.entries.All())) // The entry should be expired
+	}, 10*time.Second, 10*time.Millisecond, "traces_host_info metric has not expired yet")
 }
 
 func TestMetricResourceAttributes(t *testing.T) {

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -551,7 +551,7 @@ func TestAppMetrics_TracesHostInfo(t *testing.T) {
 	})
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(t, 1, len(mr.hostInfo.entries.All())) // The entry should be expired
+		assert.Equal(t, 1, len(mr.hostInfo.entries.All()))
 	}, 10*time.Second, 10*time.Millisecond, "traces_host_info metric has not been created yet")
 
 	// Check expiration logic

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -236,7 +236,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			require.NoError(t, err)
 
 			metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
-			otelExporter := makeExporter(ctx, t, tt.instr, otlp, metrics)
+			otelExporter := makeExporter(ctx, t, tt.instr, []string{otelcfg.FeatureApplication}, otlp, metrics)
 
 			require.NoError(t, err)
 
@@ -302,7 +302,7 @@ func TestAppMetrics_ResourceAttributes(t *testing.T) {
 	timeNow = now.Now
 
 	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
-	otelExporter := makeExporter(ctx, t, []string{instrumentations.InstrumentationHTTP}, otlp, metrics)
+	otelExporter := makeExporter(ctx, t, []string{instrumentations.InstrumentationHTTP}, []string{otelcfg.FeatureApplication}, otlp, metrics)
 
 	go otelExporter(ctx)
 
@@ -489,7 +489,7 @@ func readNChan(t require.TestingT, inCh <-chan collector.MetricRecord, numRecord
 }
 
 func makeExporter(
-	ctx context.Context, t *testing.T, instrumentations []string, otlp *collector.TestCollector,
+	ctx context.Context, t *testing.T, instrumentations []string, features []string, otlp *collector.TestCollector,
 	input *msg.Queue[[]request.Span],
 ) swarm.RunFunc {
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
@@ -498,7 +498,7 @@ func makeExporter(
 		Interval:          50 * time.Millisecond,
 		CommonEndpoint:    otlp.ServerEndpoint,
 		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
-		Features:          []string{otelcfg.FeatureApplication},
+		Features:          features,
 		TTL:               30 * time.Minute,
 		ReportersCacheLen: 100,
 		Instrumentations:  instrumentations,
@@ -516,6 +516,41 @@ func makeExporter(
 	require.NoError(t, err)
 
 	return otelExporter
+}
+
+func TestAppMetrics_TracesHostInfo(t *testing.T) {
+	defer otelcfg.RestoreEnvAfterExecution()()
+
+	ctx := t.Context()
+
+	otlp, err := collector.Start(ctx)
+	require.NoError(t, err)
+
+	now := syncedClock{now: time.Now()}
+	timeNow = now.Now
+
+	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
+	otelExporter := makeExporter(ctx, t, []string{instrumentations.InstrumentationHTTP}, []string{otelcfg.FeatureApplication, otelcfg.FeatureApplicationHost}, otlp, metrics)
+
+	go otelExporter(ctx)
+
+	assert.Len(t, otlp.Records(), 0, "metric reported before the first span is sent")
+
+	metrics.Send([]request.Span{
+		{Service: svc.Attrs{UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeHTTP, Path: "/foo", RequestStart: 100, End: 200},
+	})
+
+	res := readNChan(t, otlp.Records(), 2, timeout)
+	assert.Len(t, res, 2)
+
+	found := false
+	for _, r := range res {
+		if r.Name == "traces_host_info" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "traces_host_info metric not found in the exported metrics")
 }
 
 func TestMetricResourceAttributes(t *testing.T) {

--- a/pkg/export/otel/pid_tracker.go
+++ b/pkg/export/otel/pid_tracker.go
@@ -64,6 +64,13 @@ func (p *PidServiceTracker) RemovePID(pid int32) (bool, svc.UID) {
 	return false, svc.UID{}
 }
 
+func (p *PidServiceTracker) Count() int {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	return len(p.pidToService)
+}
+
 func (p *PidServiceTracker) ServiceLive(uid svc.UID) bool {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/pkg/export/otel/pid_tracker_test.go
+++ b/pkg/export/otel/pid_tracker_test.go
@@ -128,6 +128,26 @@ func TestPidServiceTracker_RemovePID_Last(t *testing.T) {
 	assert.False(t, tracker.ServiceLive(uid))
 }
 
+func TestPidServiceTracker_Count(t *testing.T) {
+	tracker := NewPidServiceTracker()
+	uid := makeUID("foo", "bar")
+	pid1 := int32(1)
+	pid2 := int32(2)
+
+	assert.Equal(t, 0, tracker.Count())
+
+	tracker.AddPID(pid1, uid)
+	tracker.AddPID(pid2, uid)
+
+	assert.Equal(t, 2, tracker.Count())
+
+	_, _ = tracker.RemovePID(pid1)
+	assert.Equal(t, 1, tracker.Count())
+
+	_, _ = tracker.RemovePID(pid2)
+	assert.Equal(t, 0, tracker.Count())
+}
+
 func TestPidServiceTracker_IsTrackingServerService(t *testing.T) {
 	tracker := NewPidServiceTracker()
 	uid := makeUID("foo", "bar")

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -1178,6 +1178,10 @@ func (r *metricsReporter) watchForProcessEvents(ctx context.Context) {
 					mlog().Debug("deleting infos for", "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
 					r.deleteTargetInfo(origUID, &pe.File.Service)
 					r.deleteTracesTargetInfo(origUID, &pe.File.Service)
+					if r.cfg.HostMetricsEnabled() && r.pidsTracker.Count() == 0 {
+						mlog().Debug("No more PIDs tracked, expiring host info metric")
+						r.tracesHostInfo.entries.DeleteAll()
+					}
 					delete(r.serviceMap, origUID)
 				}
 			}


### PR DESCRIPTION
  - The metric `traces_host_info` metric should only be emitted for application hosts (i.e. hosts that emit traces).
  - This was the case for the prometheus exporter, but not for OTEL.
  - Fixes an issue where once the host info metric was initialized, it was never expired (even though it is wrapped in an `Expirer`) due to the fact that expirers only remove outdated entries as part of the process of recording new ones. Since the host won't go away (as opposed to service instances), the metric will always be recorded on every processed span.
  - Fixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/283