### PR TITLE
Don't delete target info on expiry if the service is still instrumented

### DIFF
--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -425,8 +425,10 @@ func newMetricsReporter(
 			llog.Debug("evicting metrics reporter from cache")
 			v.cleanupAllMetricsInstances()
 
-			mr.deleteTracesTargetInfo(v)
-			mr.deleteTargetInfo(v)
+			if !mr.pidTracker.ServiceLive(id) {
+				mr.deleteTracesTargetInfo(v)
+				mr.deleteTargetInfo(v)
+			}
 
 			go func() {
 				if err := v.provider.ForceFlush(ctx); err != nil {

--- a/pkg/export/otel/pid_tracker.go
+++ b/pkg/export/otel/pid_tracker.go
@@ -64,6 +64,15 @@ func (p *PidServiceTracker) RemovePID(pid int32) (bool, svc.UID) {
 	return false, svc.UID{}
 }
 
+func (p *PidServiceTracker) ServiceLive(uid svc.UID) bool {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	_, exists := p.servicePIDs[uid]
+
+	return exists
+}
+
 func (p *PidServiceTracker) IsTrackingServerService(n svc.ServiceNameNamespace) bool {
 	_, ok := p.names[n]
 	return ok

--- a/pkg/export/otel/pid_tracker_test.go
+++ b/pkg/export/otel/pid_tracker_test.go
@@ -6,6 +6,8 @@ package otel
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/obi/pkg/components/svc"
 )
 
@@ -56,6 +58,8 @@ func TestPidServiceTracker_AddAndRemovePID(t *testing.T) {
 	if _, ok := tracker.names[uid.NameNamespace()]; ok {
 		t.Errorf("RemovePID: names not deleted")
 	}
+
+	assert.False(t, tracker.ServiceLive(uid))
 }
 
 func TestPidServiceTracker_RemovePID_NotLast(t *testing.T) {
@@ -82,6 +86,8 @@ func TestPidServiceTracker_RemovePID_NotLast(t *testing.T) {
 	if _, ok := tracker.names[uid.NameNamespace()]; !ok {
 		t.Errorf("RemovePID: names should still exist")
 	}
+
+	assert.True(t, tracker.ServiceLive(uid))
 }
 
 func TestPidServiceTracker_RemovePID_Last(t *testing.T) {
@@ -118,6 +124,8 @@ func TestPidServiceTracker_RemovePID_Last(t *testing.T) {
 	if _, ok := tracker.names[uid.NameNamespace()]; ok {
 		t.Errorf("RemovePID: names should not exist")
 	}
+
+	assert.False(t, tracker.ServiceLive(uid))
 }
 
 func TestPidServiceTracker_IsTrackingServerService(t *testing.T) {


### PR DESCRIPTION
We recently changed the design of the handling of target_info to be setup when we first instrument a service and removed when the service is shutdown. This allows customers to implement liveness like graphs on the metrics data. However, I had put code in the metrics expiration to delete the target info when the metrics reporter for a service is expunged from the reporter pool.

This code was necessary because of the following scenarion:
1. A service has been generating metrics all the time and the metrics export buffer is full.
2. A service is now terminated, and we delete the target info based on the process remove hook.
3. Since there might be metrics that haven't fully been exported, the target info can be brought back, since it will be restored by the delayed exported events.

However, the way the code is setup today has one potential problem. A dormant service that doesn't export any data in 5 minutes (the default TTL interval) will be kicked out of the metrics pool, causing the function to run and remove the target info metric. It's not a big deal, since the metric will be restored as soon as new data is generated in the future, but it defeats the purpose of keeping target_info related to the process lifecycle so that dashboards don't end up with gaps.

With this PR I'm relying on the pid tracker to check if we should really remove the target info. If the service has been removed, then we remove it once more after all buffered metrics have been serialised. If the reporter is expunged because of inactivity, and the service is really alive, we don't delete the target info, relying on the process termination hook to do it when the process terminates.