### PR TITLE
Overhaul NodeJS injector

### DIFF
--- a/bpf/generictracer/nodejs.c
+++ b/bpf/generictracer/nodejs.c
@@ -4,6 +4,8 @@
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/bpf_tracing.h>
 
+#include <logger/bpf_dbg.h>
+
 #include <maps/nodejs_fd_map.h>
 
 SEC("uprobe/node:uv_fs_access")
@@ -40,7 +42,7 @@ int BPF_KPROBE(obi_uv_fs_access, void *loop, void *req, const char *path) {
         fd2 += buf[k_fd2_offset + i] - '0';
     }
 
-    bpf_printk("nodejs_correlation: %s, fd1 = %u, fd2 = %u", buf, fd1, fd2);
+    bpf_dbg_printk("nodejs_correlation: %s, fd1 = %u, fd2 = %u", buf, fd1, fd2);
 
     const u64 pid_tgid = bpf_get_current_pid_tgid();
     const u64 key = (pid_tgid << 32) | fd2;

--- a/pkg/components/ebpf/generictracer/generictracer.go
+++ b/pkg/components/ebpf/generictracer/generictracer.go
@@ -364,6 +364,12 @@ func (p *Tracer) UProbes() map[string]map[string][]*ebpfcommon.ProbeDesc {
 				Start:    p.bpfObjects.ObiUvFsAccess,
 			}},
 		},
+		"libuv.so": {
+			"uv_fs_access": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUvFsAccess,
+			}},
+		},
 	}
 }
 

--- a/pkg/components/nodejs/nodejs.go
+++ b/pkg/components/nodejs/nodejs.go
@@ -6,10 +6,7 @@ package nodejs
 import (
 	_ "embed"
 	"errors"
-	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"syscall"
 
 	"go.opentelemetry.io/obi/pkg/components/ebpf"
@@ -22,39 +19,11 @@ type NodeInjector struct {
 	cfg *obi.Config
 }
 
-// make sure not to use a variable name (such as that returned by
-// os.CreateTemp() to ensure that node does not load the file twice
-const fdExtractorPath = "/beyla_fdextractor.js"
-
 func NewNodeInjector(cfg *obi.Config) *NodeInjector {
 	return &NodeInjector{
 		cfg: cfg,
 		log: slog.With("component", "nodejs.Injector"),
 	}
-}
-
-func writeFile(data []byte, path string) (cleanup func(), err error) {
-	file, err := os.Create(path)
-	if err != nil {
-		return nil, err
-	}
-
-	cleanup = func() {
-		file.Close()
-		os.Remove(file.Name())
-	}
-
-	if _, err := file.Write(data); err != nil {
-		cleanup()
-		return nil, err
-	}
-
-	if err := os.Chmod(file.Name(), 0o444); err != nil {
-		cleanup()
-		return nil, errors.New("failed to chmod file")
-	}
-
-	return cleanup, nil
 }
 
 func (i *NodeInjector) Enabled() bool {
@@ -74,34 +43,20 @@ func (i *NodeInjector) NewExecutable(ie *ebpf.Instrumentable) {
 
 	i.log.Info("loading NodeJS instrumentation", "pid", ie.FileInfo.Pid)
 
-	root := fmt.Sprintf("/proc/%d/root", ie.FileInfo.Pid)
-
-	cleanup, err := writeFile(_extractorBytes, filepath.Join(root, fdExtractorPath))
-
-	const errorMsg = "trace-context propagation will not work for NodeJS services!"
-
-	if err != nil {
-		i.log.Error("could not write agent file", "error", err)
-		i.log.Error(errorMsg)
-		return
-	}
-
-	defer cleanup()
-
-	if err := i.attachAgent(int(ie.FileInfo.Pid), fdExtractorPath); err != nil {
+	if err := i.attachAgent(int(ie.FileInfo.Pid)); err != nil {
 		i.log.Error("couldn't attach NodeJS injector", "pid", ie.FileInfo.Pid, "error", err)
-		i.log.Error(errorMsg)
+		i.log.Error("trace-context propagation will not work for NodeJS services!")
 	}
 }
 
-func (i *NodeInjector) attachAgent(pid int, agentFile string) error {
+func (i *NodeInjector) attachAgent(pid int) error {
 	err := syscall.Kill(pid, syscall.SIGUSR1)
 	if err != nil {
 		i.log.Error("error enabling node inspector", "err", err)
 		return errors.New("error enabling node inspector")
 	}
 
-	return i.inject(pid, agentFile)
+	return i.inject(pid)
 }
 
 //go:embed fdextractor.js


### PR DESCRIPTION
This PR brings a few fixes and enhancements to the NodeJS injector:

1. rework the code that deals with the injector protocol: all operations are now done synchronous, and most importantly, **there's no longer the need to write an intermediate file to the target container filesystem** - the script is directly injected via the socket
2. injecting the script now happens in "real time" (big quotes here), meaning that it's much faster
3. newer node versions dynamically link against `libuv.so` - so added a missing probe there
4. small ebpf debug fix
5. deleted heaps of code!

_This PR is best reviewed on a per-commit basis_