### PR TITLE
Remove resource attributes for network flows

### DIFF
--- a/pkg/export/otel/metrics_net.go
+++ b/pkg/export/otel/metrics_net.go
@@ -11,13 +11,11 @@ import (
 
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 
-	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
-	"go.opentelemetry.io/obi/pkg/buildinfo"
 	"go.opentelemetry.io/obi/pkg/components/netolly/ebpf"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
@@ -47,13 +45,7 @@ func nmlog() *slog.Logger {
 // getFilteredNetworkResourceAttrs returns resource attributes that can be filtered based on the attribute selector
 // for network metrics.
 func getFilteredNetworkResourceAttrs(hostID string, attrSelector attributes.Selection) []attribute.KeyValue {
-	baseAttrs := []attribute.KeyValue{
-		semconv.ServiceName(attr.VendorPrefix + "-network-flows"),
-		semconv.ServiceInstanceID(uuid.New().String()),
-		semconv.TelemetrySDKLanguageKey.String(semconv.TelemetrySDKLanguageGo.Value.AsString()),
-		semconv.TelemetrySDKNameKey.String("opentelemetry-ebpf-instrumentation"),
-		semconv.TelemetrySDKVersion(buildinfo.Version),
-	}
+	baseAttrs := []attribute.KeyValue{}
 
 	extraAttrs := []attribute.KeyValue{
 		semconv.HostID(hostID),

--- a/pkg/export/otel/metrics_net_test.go
+++ b/pkg/export/otel/metrics_net_test.go
@@ -170,23 +170,12 @@ func TestGetFilteredNetworkResourceAttrs(t *testing.T) {
 
 	attrs := getFilteredNetworkResourceAttrs(hostID, attrSelector)
 
-	expectedAttrs := []string{
-		"service.name",
-		"service.instance.id",
-		"telemetry.sdk.language",
-		"telemetry.sdk.name",
-		"telemetry.sdk.version",
-	}
-
 	attrMap := make(map[string]string)
 	for _, attr := range attrs {
 		attrMap[string(attr.Key)] = attr.Value.AsString()
 	}
 
-	for _, key := range expectedAttrs {
-		_, exists := attrMap[key]
-		assert.True(t, exists, "Expected attribute %s not found", key)
-	}
+	assert.Empty(t, attrMap)
 
 	_, hostIDExists := attrMap["host.id"]
 	assert.False(t, hostIDExists, "Host ID should be filtered out")

--- a/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
+++ b/test/integration/k8s/netolly/k8s_netolly_network_metrics.go
@@ -62,9 +62,6 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		metric := results[0].Metric
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
-		assert.Regexp(t,
-			"^obi-network-flows",
-			metric["job"])
 		assert.Equal(t, "my-kube", metric["k8s_cluster_name"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
 		assert.Equal(t, "internal-pinger-net", metric["k8s_src_name"])
@@ -95,9 +92,6 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		metric := results[0].Metric
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
-		assert.Regexp(t,
-			"^obi-network-flows",
-			metric["job"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
 		assert.Equal(t, "internal-pinger-net", metric["k8s_src_name"])
 		assert.Equal(t, "Pod", metric["k8s_src_owner_type"])
@@ -132,9 +126,6 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		metric := results[0].Metric
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
-		assert.Regexp(t,
-			"^obi-network-flows",
-			metric["job"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
 		assert.Regexp(t, "^testserver-", metric["k8s_src_name"])
 		assert.Equal(t, "Deployment", metric["k8s_src_owner_type"])
@@ -169,9 +160,6 @@ func testNetFlowBytesForExistingConnections(ctx context.Context, t *testing.T, _
 		metric := results[0].Metric
 		assertIsIP(t, metric["src_address"])
 		assertIsIP(t, metric["dst_address"])
-		assert.Regexp(t,
-			"^obi-network-flows",
-			metric["job"])
 		assert.Equal(t, "default", metric["k8s_src_namespace"])
 		assert.Equal(t, "testserver", metric["k8s_src_name"])
 		assert.Equal(t, "Service", metric["k8s_src_owner_type"])


### PR DESCRIPTION
Network flows in OTel export mode have fake fixed resource attributes, which causes two problems:

1. It creates an entry in target info called obi-network-flows which makes no sense to the end users.
2. It creates a unique UUID each time OBI is launched, so technically it creates extra dimension in the metric which doesn't give any extra information and cannot uniquely identify the OBI instance.

Prometheus export doesn't have this problem. The Prometheus metrics for network contain the extra attributes, however since there's no getter for them in record_getters.go, I think it has no actual effect.

Open question: In case we are not running on Kubernetes, e.g. we query and we say Kube is disabled, should we have a better default network metrics config, for example, one that enables source/dst IP and server port?