### PR TITLE
Implement zero-alloc otel var parsing

### DIFF
--- a/pkg/export/attributes/env_test.go
+++ b/pkg/export/attributes/env_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const OTEL_RESOURCE_ATTRIBUTES = "service.name=order-api, ,service.version=2.0.0,deployment.environment=staging=a"
+const resAttrs = "service.name=order-api, ,service.version=2.0.0,deployment.environment=staging=a"
 
 func TestParseOTELResourceVariable(t *testing.T) {
 	expected := map[string]string{
@@ -28,12 +28,12 @@ func TestParseOTELResourceVariable(t *testing.T) {
 		require.Equal(t, e, v)
 	}
 
-	ParseOTELResourceVariable(OTEL_RESOURCE_ATTRIBUTES, handler)
+	ParseOTELResourceVariable(resAttrs, handler)
 }
 
 func TestParseOTELResourceVariable_NoAllocs(t *testing.T) {
 	allocs := testing.AllocsPerRun(1000, func() {
-		ParseOTELResourceVariable(OTEL_RESOURCE_ATTRIBUTES, func(k, v string) {})
+		ParseOTELResourceVariable(resAttrs, func(_, _ string) {})
 	})
 
 	if allocs != 0 {
@@ -45,7 +45,7 @@ func BenchmarkParseOTELResourceVariable(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		ParseOTELResourceVariable(OTEL_RESOURCE_ATTRIBUTES, func(k, v string) {
+		ParseOTELResourceVariable(resAttrs, func(_, _ string) {
 			// no‑op handler
 		})
 	}

--- a/pkg/export/attributes/env_test.go
+++ b/pkg/export/attributes/env_test.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package attributes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const OTEL_RESOURCE_ATTRIBUTES = "service.name=order-api, ,service.version=2.0.0,deployment.environment=staging=a"
+
+func TestParseOTELResourceVariable(t *testing.T) {
+	expected := map[string]string{
+		"service.name":           "order-api",
+		"service.version":        "2.0.0",
+		"deployment.environment": "staging=a",
+	}
+
+	handler := func(k, v string) {
+		require.NotEmpty(t, k)
+		require.NotEmpty(t, v)
+
+		e, ok := expected[k]
+
+		require.True(t, ok)
+		require.Equal(t, e, v)
+	}
+
+	ParseOTELResourceVariable(OTEL_RESOURCE_ATTRIBUTES, handler)
+}
+
+func TestParseOTELResourceVariable_NoAllocs(t *testing.T) {
+	allocs := testing.AllocsPerRun(1000, func() {
+		ParseOTELResourceVariable(OTEL_RESOURCE_ATTRIBUTES, func(k, v string) {})
+	})
+
+	if allocs != 0 {
+		t.Errorf("ParseOTELResourceVariable allocated %v allocs per run; want 0", allocs)
+	}
+}
+
+func BenchmarkParseOTELResourceVariable(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		ParseOTELResourceVariable(OTEL_RESOURCE_ATTRIBUTES, func(k, v string) {
+			// no‑op handler
+		})
+	}
+}


### PR DESCRIPTION
We noticed that `ParseOTELResourceVariable` was figuring out in a few profiles, as a consequence of `genSplit()` calls:
<img width="2968" height="582" alt="image" src="https://github.com/user-attachments/assets/3a8e1463-bf5e-40b7-96ce-ecda8df9f735" />

I went on to benchmark `ParseOTELResourceVariable` and because it allocates intermediate arrays, there's quite a bit happening there:
```
      flat  flat%   sum%        cum   cum%
 1480.56MB 99.76% 99.76%  1480.56MB 99.76%  strings.genSplit
         0     0% 99.76%  1480.06MB 99.73%  go.opentelemetry.io/obi/pkg/export/attributes.BenchmarkParseOTELResourceVariable
         0     0% 99.76%  1480.06MB 99.73%  go.opentelemetry.io/obi/pkg/export/attributes.ParseOTELResourceVariable
         0     0% 99.76%   502.03MB 33.83%  strings.Split (inline)
         0     0% 99.76%   978.53MB 65.94%  strings.SplitN (inline)
         0     0% 99.76%  1480.06MB 99.73%  testing.(*B).launch
         0     0% 99.76%  1480.06MB 99.73%  testing.(*B).runN
```

Reported allocations for a single run of the test (there are 5 Otel vars, one alloc per var):

```
BenchmarkParseOTELResourceVariable-12    	 6813796	       174.4 ns/op	     192 B/op	       5 allocs/op
```

The current PR reimplements this function to have _zero-allocations_.

This is what it looks like with the changes applied:

```
    1539kB 42.90% 42.90%     1539kB 42.90%  runtime.allocm
  512.44kB 14.28% 57.18%   512.44kB 14.28%  maps.Copy[go.shape.map[go.opentelemetry.io/obi/pkg/export/attributes/names.Name]struct {},go.shape.map[go.opentelemetry.io/obi/pkg/export/attributes/names.Name]struct {},go.shape.string,go.shape.struct {}] (inline)
  512.10kB 14.27% 71.46%   512.10kB 14.27%  go.opentelemetry.io/obi/pkg/export/attributes.getDefinitions
  512.07kB 14.27% 85.73%   512.07kB 14.27%  testing.(*common).Helper
  512.01kB 14.27%   100%   512.01kB 14.27%  runtime.(*timers).addHeap
         0     0%   100%   512.07kB 14.27%  github.com/stretchr/testify/require.NoError
         0     0%   100%   512.44kB 14.28%  go.opentelemetry.io/obi/pkg/export/attributes.(*AttrReportGroup).All
         0     0%   100%   512.44kB 14.28%  go.opentelemetry.io/obi/pkg/export/attributes.(*AttrSelector).For
         0     0%   100%   512.44kB 14.28%  go.opentelemetry.io/obi/pkg/export/attributes.(*AttrSelector).addIncludedAttributes
         0     0%   100%   512.10kB 14.27%  go.opentelemetry.io/obi/pkg/export/attributes.NewAttrSelector
```

i.e. it does not even figure in the memory profile.

And 0 reported allocs:

```
BenchmarkParseOTELResourceVariable-12    	19241635	        60.18 ns/op	       0 B/op	       0 allocs/op
```

It's also _arguably_ tree times faster.

