### PR TITLE
Handle event channel closure gracefully

### DIFF
--- a/pkg/components/appolly/appolly.go
+++ b/pkg/components/appolly/appolly.go
@@ -151,7 +151,12 @@ func (i *Instrumenter) instrumentedEventLoop(ctx context.Context, processEvents 
 		select {
 		case <-ctx.Done():
 			return
-		case ev := <-processEvents:
+		case ev, ok := <-processEvents:
+			if !ok {
+				log.Error("processEvents channel closed. Application instrumentation has stopped working")
+				return
+			}
+
 			switch ev.Type {
 			case discover.EventCreated:
 				pt := ev.Obj

--- a/pkg/components/discover/watcher_kube.go
+++ b/pkg/components/discover/watcher_kube.go
@@ -160,7 +160,10 @@ func (wk *watcherKubeEnricher) enrichProcessEvent(processEvents []Event[ProcessA
 			eventsWithMeta = append(eventsWithMeta, procEvent)
 		}
 	}
-	wk.output.Send(eventsWithMeta)
+
+	if len(eventsWithMeta) > 0 {
+		wk.output.Send(eventsWithMeta)
+	}
 }
 
 func (wk *watcherKubeEnricher) onNewProcess(procInfo ProcessAttrs) (ProcessAttrs, bool) {


### PR DESCRIPTION
Check if the event channel has been closed before handling the events - this is particularly relevant for events whose payload are a pointer type: a closing channel would return the zero value, which gets treated as a null pointer - and has the potential to crash the program if de-referenced.

Relates to https://github.com/grafana/beyla/issues/2114