### PR TITLE
Add obi.version and obi.revision as resource attributes in network metrics

### DIFF
--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -4,6 +4,7 @@
 package buildinfo
 
 // Version and Revision variables are overridden at build time with Git repository information
+// They can be also overridden at runtime by any software component vendoring OBI as library
 var (
 	Version  = "unset"
 	Revision = "unset"

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -121,7 +121,7 @@ const (
 	K8sDstNodeName  = Name("k8s.dst.node.name")
 )
 
-// other beyla-specific attributes
+// other OBI-specific attributes
 const (
 	// Instance and Job are only explicitly used in the Prometheus
 	// exporter, as the OpenTelemetry SDK already sets them implicitly.
@@ -142,6 +142,9 @@ const (
 
 	ServiceInstanceID = Name(semconv.ServiceInstanceIDKey)
 	SkipSpanMetrics   = Name("span.metrics.skip")
+
+	VendorVersionSuffix  = Name(".version")
+	VendorRevisionSuffix = Name(".revision")
 )
 
 // traces related attributes

--- a/pkg/export/otel/metrics_net.go
+++ b/pkg/export/otel/metrics_net.go
@@ -9,16 +9,16 @@ import (
 	"log/slog"
 	"time"
 
-	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
-
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
+	"go.opentelemetry.io/obi/pkg/buildinfo"
 	"go.opentelemetry.io/obi/pkg/components/netolly/ebpf"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/expire"
 	"go.opentelemetry.io/obi/pkg/export/otel/metric"
 	metric2 "go.opentelemetry.io/obi/pkg/export/otel/metric/api/metric"
@@ -45,7 +45,10 @@ func nmlog() *slog.Logger {
 // getFilteredNetworkResourceAttrs returns resource attributes that can be filtered based on the attribute selector
 // for network metrics.
 func getFilteredNetworkResourceAttrs(hostID string, attrSelector attributes.Selection) []attribute.KeyValue {
-	baseAttrs := []attribute.KeyValue{}
+	baseAttrs := []attribute.KeyValue{
+		attribute.String(attr.VendorPrefix+string(attr.VendorVersionSuffix), buildinfo.Version),
+		attribute.String(attr.VendorPrefix+string(attr.VendorRevisionSuffix), buildinfo.Revision),
+	}
 
 	extraAttrs := []attribute.KeyValue{
 		semconv.HostID(hostID),

--- a/pkg/export/otel/metrics_net_test.go
+++ b/pkg/export/otel/metrics_net_test.go
@@ -170,12 +170,21 @@ func TestGetFilteredNetworkResourceAttrs(t *testing.T) {
 
 	attrs := getFilteredNetworkResourceAttrs(hostID, attrSelector)
 
+	expectedAttrs := []string{
+		"obi.version",
+		"obi.revision",
+	}
+
 	attrMap := make(map[string]string)
 	for _, attr := range attrs {
 		attrMap[string(attr.Key)] = attr.Value.AsString()
 	}
 
-	assert.Empty(t, attrMap)
+	for _, key := range expectedAttrs {
+		v, exists := attrMap[key]
+		assert.True(t, exists, "Expected attribute %s not found", key)
+		assert.NotEmpty(t, v, "Expected attribute %s to have a value", key)
+	}
 
 	_, hostIDExists := attrMap["host.id"]
 	assert.False(t, hostIDExists, "Host ID should be filtered out")


### PR DESCRIPTION
This only affects OTEL exports ATM.

Since Prometheus resource metrics (target_info) might require extra coordination effort between te different exporters (network and application), that attribute will go into another PR.