### PR TITLE
Executable isn't ready if there's no path

### DIFF
--- a/pkg/components/discover/watcher_proc.go
+++ b/pkg/components/discover/watcher_proc.go
@@ -293,7 +293,7 @@ func executableReady(pid PID) (string, bool) {
 		return exePath, errors.Is(err, os.ErrNotExist)
 	}
 
-	return exePath, exePath != "/"
+	return exePath, (exePath != "/" && exePath != "")
 }
 
 func (pa *pollAccounter) checkNewProcessConnectionNotification(


### PR DESCRIPTION
If we scan the /proc/ file system for new processes, we might get unlucky and scan the process as it's being created, which might cause us to skip discovery of a process. This PR changes the condition of marking a process ready, if there's no path we say the process isn't ready.