### PR TITLE
Add few more prebuilt test images

### DIFF
--- a/.github/workflows/ghcr_publish_testing_images.yml
+++ b/.github/workflows/ghcr_publish_testing_images.yml
@@ -137,3 +137,28 @@ jobs:
           tag-version: ${{ steps.image_tag.outputs.imgtag }}
           tag-id: java-native
           file: test/integration/components/javatestserver/Dockerfile
+
+      - name: node
+        uses: ./.github/actions/integration-test-image-build
+        with:
+          labels: ${{ steps.meta.outputs.labels }}
+          tag-version: ${{ steps.image_tag.outputs.imgtag }}
+          tag-id: node
+          file: test/integration/components/nodejsserver/Dockerfile
+
+      - name: go
+        uses: ./.github/actions/integration-test-image-build
+        with:
+          labels: ${{ steps.meta.outputs.labels }}
+          tag-version: ${{ steps.image_tag.outputs.imgtag }}
+          tag-id: go
+          file: test/integration/components/testserver/Dockerfile
+
+      - name: python
+        uses: ./.github/actions/integration-test-image-build
+        with:
+          labels: ${{ steps.meta.outputs.labels }}
+          tag-version: ${{ steps.image_tag.outputs.imgtag }}
+          tag-id: python
+          file: test/integration/components/pythonserver/Dockerfile
+


### PR DESCRIPTION
The new created images are referenced from the documentation examples, for quick test of services in some languages.

In addition, we can replace some integration tests with their prebuilt versions, and speed up them.