### PR TITLE
Refactor OTEL Metrics exporter

### DIFF
--- a/pkg/components/appolly/appolly_test.go
+++ b/pkg/components/appolly/appolly_test.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/components/ebpf"
 	"go.opentelemetry.io/obi/pkg/components/exec"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
-	"go.opentelemetry.io/obi/pkg/export/otel"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/obi"
 )
 
@@ -25,7 +25,7 @@ func TestProcessEventsLoopDoesntBlock(t *testing.T) {
 		},
 		&obi.Config{
 			ChannelBufferLen: 1,
-			Traces: otel.TracesConfig{
+			Traces: otelcfg.TracesConfig{
 				TracesEndpoint: "http://something",
 			},
 		},

--- a/pkg/components/ebpf/tracer_darwin.go
+++ b/pkg/components/ebpf/tracer_darwin.go
@@ -21,7 +21,9 @@ type instrumenter struct{}
 // dummy implementations to avoid compilation errors in Darwin.
 // The tracer component is only usable in Linux.
 
-func (pt *ProcessTracer) Run(_ context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg.Queue[[]request.Span]) {
+func (pt *ProcessTracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg.Queue[[]request.Span]) {
+	// avoids linter complaining for not using metrics
+	pt.metrics.Start(ctx)
 }
 
 func NewProcessTracer(_ ProcessTracerType, _ []Tracer, _ time.Duration, _ imetrics.Reporter) *ProcessTracer {

--- a/pkg/components/netolly/agent/pipeline_test.go
+++ b/pkg/components/netolly/agent/pipeline_test.go
@@ -19,7 +19,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/components/netolly/flow/transport"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
-	"go.opentelemetry.io/obi/pkg/export/otel"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/export/prom"
 	"go.opentelemetry.io/obi/pkg/filter"
 	"go.opentelemetry.io/obi/pkg/obi"
@@ -46,7 +46,7 @@ func TestFilter(t *testing.T) {
 			Prometheus: prom.PrometheusConfig{
 				Path:     "/metrics",
 				Port:     promPort,
-				Features: []string{otel.FeatureNetwork},
+				Features: []string{otelcfg.FeatureNetwork},
 				TTL:      time.Hour,
 			},
 			Filters: filter.AttributesConfig{

--- a/pkg/components/otelsdk/sdk_inject.go
+++ b/pkg/components/otelsdk/sdk_inject.go
@@ -19,12 +19,13 @@ import (
 	"strconv"
 	"strings"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"github.com/grafana/jvmtools/jvm"
 
 	"go.opentelemetry.io/obi/pkg/components/ebpf"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/components/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/components/svc"
-	"go.opentelemetry.io/obi/pkg/export/otel"
 	"go.opentelemetry.io/obi/pkg/obi"
 )
 
@@ -148,12 +149,12 @@ func otlpOptions(cfg *obi.Config) (map[string]string, error) {
 		options["otel.exporter.otlp.endpoint"] = tracesEndpoint
 		options["otel.exporter.otlp.protocol"] = string(cfg.Traces.GetProtocol())
 		options["otel.metric.export.interval"] = strconv.Itoa(int(cfg.Metrics.GetInterval().Milliseconds()))
-		maps.Copy(options, otel.HeadersFromEnv("OTEL_EXPORTER_OTLP_HEADERS"))
+		maps.Copy(options, otelcfg.HeadersFromEnv("OTEL_EXPORTER_OTLP_HEADERS"))
 	} else {
 		if cfg.Traces.Enabled() {
 			options["otel.exporter.otlp.traces.endpoint"] = tracesEndpoint
 			options["otel.exporter.otlp.traces.protocol"] = string(cfg.Traces.GetProtocol())
-			maps.Copy(options, otel.HeadersFromEnv("OTEL_EXPORTER_OTLP_TRACES_HEADERS"))
+			maps.Copy(options, otelcfg.HeadersFromEnv("OTEL_EXPORTER_OTLP_TRACES_HEADERS"))
 		} else {
 			options["otel.traces.exporter"] = "none"
 		}
@@ -162,7 +163,7 @@ func otlpOptions(cfg *obi.Config) (map[string]string, error) {
 			options["otel.exporter.otlp.metrics.endpoint"] = metricsEndpoint
 			options["otel.exporter.otlp.metrics.protocol"] = string(cfg.Metrics.GetProtocol())
 			options["otel.metric.export.interval"] = strconv.Itoa(int(cfg.Metrics.GetInterval().Milliseconds()))
-			maps.Copy(options, otel.HeadersFromEnv("OTEL_EXPORTER_OTLP_METRICS_HEADERS"))
+			maps.Copy(options, otelcfg.HeadersFromEnv("OTEL_EXPORTER_OTLP_METRICS_HEADERS"))
 		} else {
 			options["otel.metrics.exporter"] = "none"
 		}

--- a/pkg/components/otelsdk/sdk_inject.go
+++ b/pkg/components/otelsdk/sdk_inject.go
@@ -19,13 +19,12 @@ import (
 	"strconv"
 	"strings"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"github.com/grafana/jvmtools/jvm"
 
 	"go.opentelemetry.io/obi/pkg/components/ebpf"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/components/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/components/svc"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/obi"
 )
 

--- a/pkg/components/pipe/global/context.go
+++ b/pkg/components/pipe/global/context.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/components/imetrics"
 	kube2 "go.opentelemetry.io/obi/pkg/components/kube"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 
@@ -39,6 +40,9 @@ type ContextInfo struct {
 
 	// ExtraResourceAttributes allows extending (or overriding) the reported resource attributes in the traces exporters
 	ExtraResourceAttributes []attribute.KeyValue
+
+	// OTELMetricsExporter allows sharing the same OTEL exporter through diverse metrics export nodes (Application, Network...)
+	OTELMetricsExporter *otelcfg.MetricsExporterInstancer
 }
 
 // AppO11y stores context information that is only required for application observability.

--- a/pkg/components/pipe/instrumenter.go
+++ b/pkg/components/pipe/instrumenter.go
@@ -114,6 +114,14 @@ func newGraphBuilder(
 		processEventsCh,
 	), swarm.WithID("OTELMetricsExport"))
 
+	swi.Add(otel.ReportSvcGraphMetrics(
+		ctxInfo,
+		&config.Metrics,
+		selectorCfg,
+		exportableSpans,
+		processEventsCh,
+	), swarm.WithID("OTELSvcGraphMetricsExport"))
+
 	swi.Add(otel.TracesReceiver(
 		ctxInfo, config.Traces, config.Metrics.SpanMetricsEnabled(), selectorCfg, exportableSpans,
 	), swarm.WithID("OTELTracesReceiver"))

--- a/pkg/components/pipe/instrumenter_test.go
+++ b/pkg/components/pipe/instrumenter_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/mariomac/guara/pkg/test"
@@ -32,6 +30,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/filter"
 	"go.opentelemetry.io/obi/pkg/kubeflags"
 	"go.opentelemetry.io/obi/pkg/obi"
@@ -42,12 +41,13 @@ import (
 
 const testTimeout = 5 * time.Second
 
-func gctx(groups attributes.AttrGroups) *global.ContextInfo {
+func gctx(groups attributes.AttrGroups, mcfg *otelcfg.MetricsConfig) *global.ContextInfo {
 	return &global.ContextInfo{
 		Metrics:               imetrics.NoopReporter{},
 		MetricAttributeGroups: groups,
 		K8sInformer:           kube.NewMetadataProvider(kube.MetadataConfig{Enable: kubeflags.EnabledFalse}),
 		HostID:                "host-id",
+		OTELMetricsExporter:   &otelcfg.MetricsExporterInstancer{Cfg: mcfg},
 	}
 }
 
@@ -72,18 +72,19 @@ func TestBasicPipeline(t *testing.T) {
 
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
-	gb := newGraphBuilder(&obi.Config{
-		Metrics: otelcfg.MetricsConfig{
-			Features:        []string{otelcfg.FeatureApplication},
-			MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
-			ReportersCacheLen: 16,
-			TTL:               5 * time.Minute,
-			Instrumentations: []string{
-				instrumentations.InstrumentationALL,
-			},
+	cfg := otelcfg.MetricsConfig{
+		Features:        []string{otelcfg.FeatureApplication},
+		MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
+		ReportersCacheLen: 16,
+		TTL:               5 * time.Minute,
+		Instrumentations: []string{
+			instrumentations.InstrumentationALL,
 		},
+	}
+	gb := newGraphBuilder(&obi.Config{
+		Metrics:    cfg,
 		Attributes: obi.Attributes{Select: allMetrics, InstanceID: traces.InstanceIDConfig{OverrideHostname: "the-host"}},
-	}, gctx(0), tracesInput, processEvents)
+	}, gctx(0, &cfg), tracesInput, processEvents)
 
 	// Override eBPF tracer to send some fake data
 	tracesInput.Send(newRequest("foo-svc", "/foo/bar", 404))
@@ -148,7 +149,7 @@ func TestTracerPipeline(t *testing.T) {
 
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
-	gCtx := gctx(0)
+	gCtx := gctx(0, nil)
 	gCtx.ExtraResourceAttributes = []attribute.KeyValue{attribute.String("overridden", "attr")}
 
 	gb := newGraphBuilder(&obi.Config{
@@ -196,7 +197,7 @@ func TestTracerPipelineBadTimestamps(t *testing.T) {
 			ReportersCacheLen: 16,
 			Instrumentations:  []string{instrumentations.InstrumentationALL},
 		},
-	}, gctx(0), tracesInput, processEvents)
+	}, gctx(0, nil), tracesInput, processEvents)
 	// Override eBPF tracer to send some fake data
 	tracesInput.Send(newRequestWithTiming("svc1", request.EventTypeHTTP, "GET", "/attach", 200, 60000, 59999, 70000))
 	// closing prematurely the input node would finish the whole graph processing
@@ -222,20 +223,21 @@ func TestRouteConsolidation(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 
-	gb := newGraphBuilder(&obi.Config{
-		Metrics: otelcfg.MetricsConfig{
-			SDKLogLevel:     "debug",
-			Features:        []string{otelcfg.FeatureApplication},
-			MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
-			ReportersCacheLen: 16,
-			TTL:               5 * time.Minute,
-			Instrumentations: []string{
-				instrumentations.InstrumentationALL,
-			},
+	cfg := otelcfg.MetricsConfig{
+		SDKLogLevel:     "debug",
+		Features:        []string{otelcfg.FeatureApplication},
+		MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
+		ReportersCacheLen: 16,
+		TTL:               5 * time.Minute,
+		Instrumentations: []string{
+			instrumentations.InstrumentationALL,
 		},
+	}
+	gb := newGraphBuilder(&obi.Config{
+		Metrics:    cfg,
 		Routes:     &transform.RoutesConfig{Patterns: []string{"/user/{id}", "/products/{id}/push"}},
 		Attributes: obi.Attributes{Select: allMetricsBut("client.address", "url.path"), InstanceID: traces.InstanceIDConfig{OverrideHostname: "the-host"}},
-	}, gctx(attributes.GroupHTTPRoutes), tracesInput, processEvents)
+	}, gctx(attributes.GroupHTTPRoutes, &cfg), tracesInput, processEvents)
 	// Override eBPF tracer to send some fake data
 	tracesInput.Send(newRequest("svc-1", "/user/1234", 200))
 	tracesInput.Send(newRequest("svc-1", "/products/3210/push", 200))
@@ -356,18 +358,19 @@ func TestGRPCPipeline(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 
-	gb := newGraphBuilder(&obi.Config{
-		Metrics: otelcfg.MetricsConfig{
-			Features:        []string{otelcfg.FeatureApplication},
-			MetricsEndpoint: tc.ServerEndpoint, Interval: time.Millisecond,
-			ReportersCacheLen: 16,
-			TTL:               5 * time.Minute,
-			Instrumentations: []string{
-				instrumentations.InstrumentationALL,
-			},
+	cfg := otelcfg.MetricsConfig{
+		Features:        []string{otelcfg.FeatureApplication},
+		MetricsEndpoint: tc.ServerEndpoint, Interval: time.Millisecond,
+		ReportersCacheLen: 16,
+		TTL:               5 * time.Minute,
+		Instrumentations: []string{
+			instrumentations.InstrumentationALL,
 		},
+	}
+	gb := newGraphBuilder(&obi.Config{
+		Metrics:    cfg,
 		Attributes: obi.Attributes{Select: allMetrics, InstanceID: traces.InstanceIDConfig{OverrideHostname: "the-host"}},
-	}, gctx(0), tracesInput, processEvents)
+	}, gctx(0, &cfg), tracesInput, processEvents)
 	// Override eBPF tracer to send some fake data
 	tracesInput.Send(newGRPCRequest("grpc-svc", "/foo/bar", 3))
 	pipe, err := gb.buildGraph(ctx)
@@ -426,7 +429,7 @@ func TestTraceGRPCPipeline(t *testing.T) {
 			Instrumentations: []string{instrumentations.InstrumentationALL},
 		},
 		Attributes: obi.Attributes{InstanceID: traces.InstanceIDConfig{OverrideHostname: "the-host"}},
-	}, gctx(0), tracesInput, processEvents)
+	}, gctx(0, nil), tracesInput, processEvents)
 	// Override eBPF tracer to send some fake data
 	tracesInput.Send(newGRPCRequest("svc", "foo.bar", 3))
 	pipe, err := gb.buildGraph(ctx)
@@ -453,21 +456,22 @@ func TestBasicPipelineInfo(t *testing.T) {
 
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
-	gb := newGraphBuilder(&obi.Config{
-		Metrics: otelcfg.MetricsConfig{
-			Features:        []string{otelcfg.FeatureApplication},
-			MetricsEndpoint: tc.ServerEndpoint,
-			Interval:        10 * time.Millisecond, ReportersCacheLen: 16,
-			TTL: 5 * time.Minute,
-			Instrumentations: []string{
-				instrumentations.InstrumentationALL,
-			},
+	cfg := otelcfg.MetricsConfig{
+		Features:        []string{otelcfg.FeatureApplication},
+		MetricsEndpoint: tc.ServerEndpoint,
+		Interval:        10 * time.Millisecond, ReportersCacheLen: 16,
+		TTL: 5 * time.Minute,
+		Instrumentations: []string{
+			instrumentations.InstrumentationALL,
 		},
+	}
+	gb := newGraphBuilder(&obi.Config{
+		Metrics: cfg,
 		Attributes: obi.Attributes{
 			Select:     allMetrics,
 			InstanceID: traces.InstanceIDConfig{OverrideHostname: "the-host"},
 		},
-	}, gctx(0), tracesInput, processEvents)
+	}, gctx(0, &cfg), tracesInput, processEvents)
 	// send some fake data through the traces' input
 	tracesInput.Send(newHTTPInfo("PATCH", "/aaa/bbb", "1.1.1.1", 204))
 	pipe, err := gb.buildGraph(ctx)
@@ -522,7 +526,7 @@ func TestTracerPipelineInfo(t *testing.T) {
 	gb := newGraphBuilder(&obi.Config{
 		Traces:     otelcfg.TracesConfig{TracesEndpoint: tc.ServerEndpoint, ReportersCacheLen: 16, Instrumentations: []string{instrumentations.InstrumentationALL}},
 		Attributes: obi.Attributes{InstanceID: traces.InstanceIDConfig{OverrideHostname: "the-host"}},
-	}, gctx(0), tracesInput, processEvents)
+	}, gctx(0, nil), tracesInput, processEvents)
 	// Override eBPF tracer to send some fake data
 	tracesInput.Send(newHTTPInfo("PATCH", "/aaa/bbb", "1.1.1.1", 204))
 	pipe, err := gb.buildGraph(ctx)
@@ -546,20 +550,21 @@ func TestSpanAttributeFilterNode(t *testing.T) {
 	// Application pipeline that will let only pass spans whose url.path matches /user/*
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	cfg := otelcfg.MetricsConfig{
+		SDKLogLevel:     "debug",
+		Features:        []string{otelcfg.FeatureApplication},
+		MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
+		ReportersCacheLen: 16,
+		TTL:               5 * time.Minute,
+		Instrumentations:  []string{instrumentations.InstrumentationALL},
+	}
 	gb := newGraphBuilder(&obi.Config{
-		Metrics: otelcfg.MetricsConfig{
-			SDKLogLevel:     "debug",
-			Features:        []string{otelcfg.FeatureApplication},
-			MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
-			ReportersCacheLen: 16,
-			TTL:               5 * time.Minute,
-			Instrumentations:  []string{instrumentations.InstrumentationALL},
-		},
+		Metrics: cfg,
 		Filters: filter.AttributesConfig{
 			Application: map[string]filter.MatchDefinition{"url.path": {Match: "/user/*"}},
 		},
 		Attributes: obi.Attributes{Select: allMetrics, InstanceID: traces.InstanceIDConfig{OverrideHostname: "the-host"}},
-	}, gctx(0), tracesInput, processEvents)
+	}, gctx(0, &cfg), tracesInput, processEvents)
 
 	// Override eBPF tracer to send some fake data
 	tracesInput.Send(newRequest("svc-0", "/products/3210/push", 200))

--- a/pkg/components/pipe/instrumenter_test.go
+++ b/pkg/components/pipe/instrumenter_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/mariomac/guara/pkg/test"
@@ -30,7 +32,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
-	"go.opentelemetry.io/obi/pkg/export/otel"
 	"go.opentelemetry.io/obi/pkg/filter"
 	"go.opentelemetry.io/obi/pkg/kubeflags"
 	"go.opentelemetry.io/obi/pkg/obi"
@@ -72,8 +73,8 @@ func TestBasicPipeline(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	gb := newGraphBuilder(&obi.Config{
-		Metrics: otel.MetricsConfig{
-			Features:        []string{otel.FeatureApplication},
+		Metrics: otelcfg.MetricsConfig{
+			Features:        []string{otelcfg.FeatureApplication},
 			MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 			ReportersCacheLen: 16,
 			TTL:               5 * time.Minute,
@@ -151,7 +152,7 @@ func TestTracerPipeline(t *testing.T) {
 	gCtx.ExtraResourceAttributes = []attribute.KeyValue{attribute.String("overridden", "attr")}
 
 	gb := newGraphBuilder(&obi.Config{
-		Traces: otel.TracesConfig{
+		Traces: otelcfg.TracesConfig{
 			BatchTimeout:      10 * time.Millisecond,
 			MaxQueueSize:      10,
 			TracesEndpoint:    tc.ServerEndpoint,
@@ -189,7 +190,7 @@ func TestTracerPipelineBadTimestamps(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	gb := newGraphBuilder(&obi.Config{
-		Traces: otel.TracesConfig{
+		Traces: otelcfg.TracesConfig{
 			BatchTimeout:      10 * time.Millisecond,
 			TracesEndpoint:    tc.ServerEndpoint,
 			ReportersCacheLen: 16,
@@ -222,9 +223,9 @@ func TestRouteConsolidation(t *testing.T) {
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 
 	gb := newGraphBuilder(&obi.Config{
-		Metrics: otel.MetricsConfig{
+		Metrics: otelcfg.MetricsConfig{
 			SDKLogLevel:     "debug",
-			Features:        []string{otel.FeatureApplication},
+			Features:        []string{otelcfg.FeatureApplication},
 			MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 			ReportersCacheLen: 16,
 			TTL:               5 * time.Minute,
@@ -356,8 +357,8 @@ func TestGRPCPipeline(t *testing.T) {
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 
 	gb := newGraphBuilder(&obi.Config{
-		Metrics: otel.MetricsConfig{
-			Features:        []string{otel.FeatureApplication},
+		Metrics: otelcfg.MetricsConfig{
+			Features:        []string{otelcfg.FeatureApplication},
 			MetricsEndpoint: tc.ServerEndpoint, Interval: time.Millisecond,
 			ReportersCacheLen: 16,
 			TTL:               5 * time.Minute,
@@ -419,7 +420,7 @@ func TestTraceGRPCPipeline(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	gb := newGraphBuilder(&obi.Config{
-		Traces: otel.TracesConfig{
+		Traces: otelcfg.TracesConfig{
 			TracesEndpoint: tc.ServerEndpoint,
 			BatchTimeout:   time.Millisecond, ReportersCacheLen: 16,
 			Instrumentations: []string{instrumentations.InstrumentationALL},
@@ -453,8 +454,8 @@ func TestBasicPipelineInfo(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	gb := newGraphBuilder(&obi.Config{
-		Metrics: otel.MetricsConfig{
-			Features:        []string{otel.FeatureApplication},
+		Metrics: otelcfg.MetricsConfig{
+			Features:        []string{otelcfg.FeatureApplication},
 			MetricsEndpoint: tc.ServerEndpoint,
 			Interval:        10 * time.Millisecond, ReportersCacheLen: 16,
 			TTL: 5 * time.Minute,
@@ -519,7 +520,7 @@ func TestTracerPipelineInfo(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	gb := newGraphBuilder(&obi.Config{
-		Traces:     otel.TracesConfig{TracesEndpoint: tc.ServerEndpoint, ReportersCacheLen: 16, Instrumentations: []string{instrumentations.InstrumentationALL}},
+		Traces:     otelcfg.TracesConfig{TracesEndpoint: tc.ServerEndpoint, ReportersCacheLen: 16, Instrumentations: []string{instrumentations.InstrumentationALL}},
 		Attributes: obi.Attributes{InstanceID: traces.InstanceIDConfig{OverrideHostname: "the-host"}},
 	}, gctx(0), tracesInput, processEvents)
 	// Override eBPF tracer to send some fake data
@@ -546,9 +547,9 @@ func TestSpanAttributeFilterNode(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	gb := newGraphBuilder(&obi.Config{
-		Metrics: otel.MetricsConfig{
+		Metrics: otelcfg.MetricsConfig{
 			SDKLogLevel:     "debug",
-			Features:        []string{otel.FeatureApplication},
+			Features:        []string{otelcfg.FeatureApplication},
 			MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 			ReportersCacheLen: 16,
 			TTL:               5 * time.Minute,

--- a/pkg/export/otel/expirer_test.go
+++ b/pkg/export/otel/expirer_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,7 +29,7 @@ import (
 const timeout = 20 * time.Second
 
 func TestNetMetricsExpiration(t *testing.T) {
-	defer restoreEnvAfterExecution()()
+	defer otelcfg.RestoreEnvAfterExecution()()
 	ctx := t.Context()
 
 	otlp, err := collector.Start(ctx)
@@ -39,11 +41,11 @@ func TestNetMetricsExpiration(t *testing.T) {
 	metrics := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(20))
 	otelExporter, err := NetMetricsExporterProvider(
 		&global.ContextInfo{}, &NetMetricsConfig{
-			Metrics: &MetricsConfig{
+			Metrics: &otelcfg.MetricsConfig{
 				Interval:        50 * time.Millisecond,
 				CommonEndpoint:  otlp.ServerEndpoint,
-				MetricsProtocol: ProtocolHTTPProtobuf,
-				Features:        []string{FeatureNetwork},
+				MetricsProtocol: otelcfg.ProtocolHTTPProtobuf,
+				Features:        []string{otelcfg.FeatureNetwork},
 				TTL:             3 * time.Minute,
 				Instrumentations: []string{
 					instrumentations.InstrumentationALL,
@@ -145,7 +147,7 @@ func TestNetMetricsExpiration(t *testing.T) {
 // (2) by metric set of a given service Attrs
 // this test verifies case 1
 func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
-	defer restoreEnvAfterExecution()()
+	defer otelcfg.RestoreEnvAfterExecution()()
 	ctx := t.Context()
 
 	otlp, err := collector.Start(ctx)
@@ -162,11 +164,11 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 	otelExporter, err := ReportMetrics(
 		&global.ContextInfo{
 			MetricAttributeGroups: g,
-		}, &MetricsConfig{
+		}, &otelcfg.MetricsConfig{
 			Interval:          50 * time.Millisecond,
 			CommonEndpoint:    otlp.ServerEndpoint,
-			MetricsProtocol:   ProtocolHTTPProtobuf,
-			Features:          []string{FeatureApplication},
+			MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
+			Features:          []string{otelcfg.FeatureApplication},
 			TTL:               3 * time.Minute,
 			ReportersCacheLen: 100,
 			Instrumentations: []string{
@@ -285,7 +287,7 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 // (2) by metric set of a given service Attrs
 // this test verifies case 2
 func TestAppMetricsExpiration_BySvcID(t *testing.T) {
-	defer restoreEnvAfterExecution()()
+	defer otelcfg.RestoreEnvAfterExecution()()
 	ctx := t.Context()
 
 	otlp, err := collector.Start(ctx)
@@ -297,11 +299,11 @@ func TestAppMetricsExpiration_BySvcID(t *testing.T) {
 	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	otelExporter, err := ReportMetrics(
-		&global.ContextInfo{}, &MetricsConfig{
+		&global.ContextInfo{}, &otelcfg.MetricsConfig{
 			Interval:          50 * time.Millisecond,
 			CommonEndpoint:    otlp.ServerEndpoint,
-			MetricsProtocol:   ProtocolHTTPProtobuf,
-			Features:          []string{FeatureApplication},
+			MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
+			Features:          []string{otelcfg.FeatureApplication},
 			TTL:               3 * time.Minute,
 			ReportersCacheLen: 100,
 			Instrumentations: []string{

--- a/pkg/export/otel/expirer_test.go
+++ b/pkg/export/otel/expirer_test.go
@@ -39,18 +39,21 @@ func TestNetMetricsExpiration(t *testing.T) {
 	timeNow = now.Now
 
 	metrics := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(20))
+	cfg := &otelcfg.MetricsConfig{
+		Interval:        50 * time.Millisecond,
+		CommonEndpoint:  otlp.ServerEndpoint,
+		MetricsProtocol: otelcfg.ProtocolHTTPProtobuf,
+		Features:        []string{otelcfg.FeatureNetwork},
+		TTL:             3 * time.Minute,
+		Instrumentations: []string{
+			instrumentations.InstrumentationALL,
+		},
+	}
 	otelExporter, err := NetMetricsExporterProvider(
-		&global.ContextInfo{}, &NetMetricsConfig{
-			Metrics: &otelcfg.MetricsConfig{
-				Interval:        50 * time.Millisecond,
-				CommonEndpoint:  otlp.ServerEndpoint,
-				MetricsProtocol: otelcfg.ProtocolHTTPProtobuf,
-				Features:        []string{otelcfg.FeatureNetwork},
-				TTL:             3 * time.Minute,
-				Instrumentations: []string{
-					instrumentations.InstrumentationALL,
-				},
-			}, SelectorCfg: &attributes.SelectorConfig{
+		&global.ContextInfo{OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{
+			Cfg: cfg,
+		}}, &NetMetricsConfig{
+			Metrics: cfg, SelectorCfg: &attributes.SelectorConfig{
 				SelectionCfg: attributes.Selection{
 					attributes.NetworkFlow.Section: attributes.InclusionLists{
 						Include: []string{"src.name", "dst.name"},
@@ -161,20 +164,22 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 
 	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	cfg := &otelcfg.MetricsConfig{
+		Interval:          50 * time.Millisecond,
+		CommonEndpoint:    otlp.ServerEndpoint,
+		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
+		Features:          []string{otelcfg.FeatureApplication},
+		TTL:               3 * time.Minute,
+		ReportersCacheLen: 100,
+		Instrumentations: []string{
+			instrumentations.InstrumentationALL,
+		},
+	}
 	otelExporter, err := ReportMetrics(
 		&global.ContextInfo{
 			MetricAttributeGroups: g,
-		}, &otelcfg.MetricsConfig{
-			Interval:          50 * time.Millisecond,
-			CommonEndpoint:    otlp.ServerEndpoint,
-			MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
-			Features:          []string{otelcfg.FeatureApplication},
-			TTL:               3 * time.Minute,
-			ReportersCacheLen: 100,
-			Instrumentations: []string{
-				instrumentations.InstrumentationALL,
-			},
-		}, &attributes.SelectorConfig{
+			OTELMetricsExporter:   &otelcfg.MetricsExporterInstancer{Cfg: cfg},
+		}, cfg, &attributes.SelectorConfig{
 			SelectionCfg: attributes.Selection{
 				attributes.HTTPServerDuration.Section: attributes.InclusionLists{
 					Include: []string{"url.path", "k8s.app.version"},
@@ -298,18 +303,21 @@ func TestAppMetricsExpiration_BySvcID(t *testing.T) {
 
 	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	cfg := &otelcfg.MetricsConfig{
+		Interval:          50 * time.Millisecond,
+		CommonEndpoint:    otlp.ServerEndpoint,
+		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
+		Features:          []string{otelcfg.FeatureApplication},
+		TTL:               3 * time.Minute,
+		ReportersCacheLen: 100,
+		Instrumentations: []string{
+			instrumentations.InstrumentationALL,
+		},
+	}
 	otelExporter, err := ReportMetrics(
-		&global.ContextInfo{}, &otelcfg.MetricsConfig{
-			Interval:          50 * time.Millisecond,
-			CommonEndpoint:    otlp.ServerEndpoint,
-			MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
-			Features:          []string{otelcfg.FeatureApplication},
-			TTL:               3 * time.Minute,
-			ReportersCacheLen: 100,
-			Instrumentations: []string{
-				instrumentations.InstrumentationALL,
-			},
-		}, &attributes.SelectorConfig{
+		&global.ContextInfo{OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: cfg}},
+		cfg,
+		&attributes.SelectorConfig{
 			SelectionCfg: attributes.Selection{
 				attributes.HTTPServerDuration.Section: attributes.InclusionLists{
 					Include: []string{"url.path"},

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -7,12 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
-	"net/url"
-	"os"
 	"slices"
-	"strings"
-	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -33,6 +28,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel/metric"
 	instrument "go.opentelemetry.io/obi/pkg/export/otel/metric/api/metric"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 )
@@ -56,22 +52,8 @@ const (
 	TargetInfo               = "target_info"
 	TracesHostInfo           = "traces_host_info"
 
-	UsualPortGRPC = "4317"
-	UsualPortHTTP = "4318"
-
 	AggregationExplicit    = "explicit_bucket_histogram"
 	AggregationExponential = "base2_exponential_bucket_histogram"
-
-	FeatureNetwork          = "network"
-	FeatureNetworkInterZone = "network_inter_zone"
-	FeatureApplication      = "application"
-	FeatureSpan             = "application_span"
-	FeatureSpanOTel         = "application_span_otel"
-	FeatureSpanSizes        = "application_span_sizes"
-	FeatureGraph            = "application_service_graph"
-	FeatureProcess          = "application_process"
-	FeatureApplicationHost  = "application_host"
-	FeatureEBPF             = "ebpf"
 )
 
 // GrafanaHostIDKey is the same attribute Key as HostIDKey, but used for
@@ -86,161 +68,15 @@ var MetricTypes = []string{
 	"messaging.",
 }
 
-type MetricsConfig struct {
-	Interval time.Duration `yaml:"interval" env:"OTEL_EBPF_METRICS_INTERVAL"`
-	// OTELIntervalMS supports metric intervals as specified by the standard OTEL definition.
-	// OTEL_EBPF_METRICS_INTERVAL takes precedence over it.
-	OTELIntervalMS int `env:"OTEL_METRIC_EXPORT_INTERVAL"`
-
-	CommonEndpoint  string `yaml:"-" env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
-	MetricsEndpoint string `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
-
-	Protocol        Protocol `yaml:"protocol" env:"OTEL_EXPORTER_OTLP_PROTOCOL"`
-	MetricsProtocol Protocol `yaml:"-" env:"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"`
-
-	// InsecureSkipVerify is not standard, so we don't follow the same naming convention
-	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"OTEL_EBPF_INSECURE_SKIP_VERIFY"`
-
-	Buckets              Buckets `yaml:"buckets"`
-	HistogramAggregation string  `yaml:"histogram_aggregation" env:"OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION"`
-
-	ReportersCacheLen int `yaml:"reporters_cache_len" env:"OTEL_EBPF_METRICS_REPORT_CACHE_LEN"`
-
-	// SDKLogLevel works independently from the global LogLevel because it prints GBs of logs in Debug mode
-	// and the Info messages leak internal details that are not usually valuable for the final user.
-	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL"`
-
-	// Features of metrics that are can be exported. Accepted values are "application" and "network".
-	// envDefault is provided to avoid breaking changes
-	Features []string `yaml:"features" env:"OTEL_EBPF_METRICS_FEATURES,expand" envDefault:"${OTEL_EBPF_METRIC_FEATURES}"  envSeparator:","`
-
-	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
-	Instrumentations []string `yaml:"instrumentations" env:"OTEL_EBPF_METRICS_INSTRUMENTATIONS" envSeparator:","`
-
-	// TTL is the time since a metric was updated for the last time until it is
-	// removed from the metrics set.
-	TTL time.Duration `yaml:"ttl" env:"OTEL_EBPF_METRICS_TTL"`
-
-	AllowServiceGraphSelfReferences bool `yaml:"allow_service_graph_self_references" env:"OTEL_EBPF_ALLOW_SERVICE_GRAPH_SELF_REFERENCES"`
-
-	// OTLPEndpointProvider allows overriding the OTLP Endpoint. It needs to return an endpoint and
-	// a boolean indicating if the endpoint is common for both traces and metrics
-	OTLPEndpointProvider func() (string, bool) `yaml:"-" env:"-"`
-
-	// InjectHeaders allows injecting custom headers to the HTTP OTLP exporter
-	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
-}
-
-func (m MetricsConfig) MarshalYAML() (any, error) {
-	omit := map[string]struct{}{
-		"endpoint": {},
-	}
-	return omitFieldsForYAML(m, omit), nil
-}
-
-func (m *MetricsConfig) GetProtocol() Protocol {
-	if m.MetricsProtocol != "" {
-		return m.MetricsProtocol
-	}
-	if m.Protocol != "" {
-		return m.Protocol
-	}
-	return m.GuessProtocol()
-}
-
-func (m *MetricsConfig) GetInterval() time.Duration {
-	if m.Interval == 0 {
-		return time.Duration(m.OTELIntervalMS) * time.Millisecond
-	}
-	return m.Interval
-}
-
-func (m *MetricsConfig) GuessProtocol() Protocol {
-	// If no explicit protocol is set, we guess it it from the metrics endpoint port
-	// (assuming it uses a standard port or a development-like form like 14317, 24317, 14318...)
-	ep, _, err := parseMetricsEndpoint(m)
-	if err == nil {
-		if strings.HasSuffix(ep.Port(), UsualPortGRPC) {
-			return ProtocolGRPC
-		} else if strings.HasSuffix(ep.Port(), UsualPortHTTP) {
-			return ProtocolHTTPProtobuf
-		}
-	}
-	// Otherwise we return default protocol according to the latest specification:
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md?plain=1#L53
-	return ProtocolHTTPProtobuf
-}
-
-func (m *MetricsConfig) OTLPMetricsEndpoint() (string, bool) {
-	if m.OTLPEndpointProvider != nil {
-		return m.OTLPEndpointProvider()
-	}
-	return ResolveOTLPEndpoint(m.MetricsEndpoint, m.CommonEndpoint)
-}
-
-// EndpointEnabled specifies that the OTEL metrics node is enabled if and only if
-// either the OTEL endpoint and OTEL metrics endpoint is defined.
-// If not enabled, this node won't be instantiated
-// Reason to disable linting: it requires to be a value despite it is considered a "heavy struct".
-// This method is invoked only once during startup time so it doesn't have a noticeable performance impact.
-func (m *MetricsConfig) EndpointEnabled() bool {
-	ep, _ := m.OTLPMetricsEndpoint()
-	return ep != ""
-}
-
-func (m *MetricsConfig) AnySpanMetricsEnabled() bool {
-	return m.SpanMetricsEnabled() || m.SpanMetricsSizesEnabled()
-}
-
-func (m *MetricsConfig) SpanMetricsSizesEnabled() bool {
-	return slices.Contains(m.Features, FeatureSpanSizes)
-}
-
-func (m *MetricsConfig) SpanMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureSpan) || slices.Contains(m.Features, FeatureSpanOTel)
-}
-
-func (m *MetricsConfig) InvalidSpanMetricsConfig() bool {
-	return slices.Contains(m.Features, FeatureSpan) && slices.Contains(m.Features, FeatureSpanOTel)
-}
-
-func (m *MetricsConfig) HostMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureApplicationHost)
-}
-
-func (m *MetricsConfig) ServiceGraphMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureGraph)
-}
-
-func (m *MetricsConfig) OTelMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureApplication)
-}
-
-func (m *MetricsConfig) NetworkMetricsEnabled() bool {
-	return m.NetworkFlowBytesEnabled() || m.NetworkInterzoneMetricsEnabled()
-}
-
-func (m *MetricsConfig) NetworkFlowBytesEnabled() bool {
-	return slices.Contains(m.Features, FeatureNetwork)
-}
-
-func (m *MetricsConfig) NetworkInterzoneMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureNetworkInterZone)
-}
-
-func (m *MetricsConfig) Enabled() bool {
-	return m.EndpointEnabled() && (m.OTelMetricsEnabled() || m.AnySpanMetricsEnabled() || m.NetworkMetricsEnabled())
-}
-
 // MetricsReporter implements the graph node that receives request.Span
 // instances and forwards them as OTEL metrics.
 type MetricsReporter struct {
 	ctx        context.Context
-	cfg        *MetricsConfig
+	cfg        *otelcfg.MetricsConfig
 	hostID     string
 	attributes *attributes.AttrSelector
 	exporter   sdkmetric.Exporter
-	reporters  ReporterPool[*svc.Attrs, *Metrics]
+	reporters  otelcfg.ReporterPool[*svc.Attrs, *Metrics]
 	pidTracker PidServiceTracker
 	is         instrumentations.InstrumentationSelection
 
@@ -301,7 +137,7 @@ type Metrics struct {
 
 func ReportMetrics(
 	ctxInfo *global.ContextInfo,
-	cfg *MetricsConfig,
+	cfg *otelcfg.MetricsConfig,
 	selectorCfg *attributes.SelectorConfig,
 	input *msg.Queue[[]request.Span],
 	processEventCh *msg.Queue[exec.ProcessEvent],
@@ -310,7 +146,7 @@ func ReportMetrics(
 		if !cfg.Enabled() {
 			return swarm.EmptyRunFunc()
 		}
-		SetupInternalOTELSDKLogger(cfg.SDKLogLevel)
+		otelcfg.SetupInternalOTELSDKLogger(cfg.SDKLogLevel)
 
 		mr, err := newMetricsReporter(
 			ctx,
@@ -340,7 +176,7 @@ func ReportMetrics(
 func newMetricsReporter(
 	ctx context.Context,
 	ctxInfo *global.ContextInfo,
-	cfg *MetricsConfig,
+	cfg *otelcfg.MetricsConfig,
 	selectorCfg *attributes.SelectorConfig,
 	input *msg.Queue[[]request.Span],
 	processEventCh *msg.Queue[exec.ProcessEvent],
@@ -411,7 +247,7 @@ func newMetricsReporter(
 			request.SpanOTELGetters, mr.attributes.For(attributes.GPUKernelBlockSize))
 	}
 
-	mr.reporters = NewReporterPool[*svc.Attrs, *Metrics](cfg.ReportersCacheLen, cfg.TTL, timeNow,
+	mr.reporters = otelcfg.NewReporterPool[*svc.Attrs, *Metrics](cfg.ReportersCacheLen, cfg.TTL, timeNow,
 		func(id svc.UID, v *Metrics) {
 			llog := log.With("service", id)
 			llog.Debug("evicting metrics reporter from cache")
@@ -483,7 +319,7 @@ func (mr *MetricsReporter) otelMetricOptions(mlog *slog.Logger) []metric.Option 
 }
 
 func (mr *MetricsReporter) usesLegacySpanNames() bool {
-	return slices.Contains(mr.cfg.Features, FeatureSpan)
+	return slices.Contains(mr.cfg.Features, otelcfg.FeatureSpan)
 }
 
 func (mr *MetricsReporter) spanMetricsLatencyName() string {
@@ -733,7 +569,7 @@ func (mr *MetricsReporter) newMetricsInstance(service *svc.Attrs) Metrics {
 	var resourceAttributes []attribute.KeyValue
 	if service != nil {
 		mlog = mlog.With("service", service)
-		resourceAttributes = append(GetAppResourceAttrs(mr.hostID, service), ResourceAttrsFromEnv(service)...)
+		resourceAttributes = append(otelcfg.GetAppResourceAttrs(mr.hostID, service), otelcfg.ResourceAttrsFromEnv(service)...)
 	}
 	mlog.Debug("creating new Metrics reporter")
 	resources := resource.NewWithAttributes(semconv.SchemaURL, resourceAttributes...)
@@ -804,7 +640,7 @@ func (mr *MetricsReporter) newMetricSet(service *svc.Attrs) (*Metrics, error) {
 	return &m, nil
 }
 
-func isExponentialAggregation(mc *MetricsConfig, mlog *slog.Logger) bool {
+func isExponentialAggregation(mc *otelcfg.MetricsConfig, mlog *slog.Logger) bool {
 	switch mc.HistogramAggregation {
 	case AggregationExponential:
 		return true
@@ -819,29 +655,29 @@ func isExponentialAggregation(mc *MetricsConfig, mlog *slog.Logger) bool {
 }
 
 // TODO: unify in single exporter for most metrics
-func InstantiateMetricsExporter(ctx context.Context, cfg *MetricsConfig, log *slog.Logger) (sdkmetric.Exporter, error) {
+func InstantiateMetricsExporter(ctx context.Context, cfg *otelcfg.MetricsConfig, log *slog.Logger) (sdkmetric.Exporter, error) {
 	var err error
 	var exporter sdkmetric.Exporter
 	switch proto := cfg.GetProtocol(); proto {
-	case ProtocolHTTPJSON, ProtocolHTTPProtobuf, "": // zero value defaults to HTTP for backwards-compatibility
+	case otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf, "": // zero value defaults to HTTP for backwards-compatibility
 		log.Debug("instantiating HTTP MetricsReporter", "protocol", proto)
 		if exporter, err = httpMetricsExporter(ctx, cfg); err != nil {
 			return nil, fmt.Errorf("can't instantiate OTEL HTTP metrics exporter: %w", err)
 		}
-	case ProtocolGRPC:
+	case otelcfg.ProtocolGRPC:
 		log.Debug("instantiating GRPC MetricsReporter", "protocol", proto)
 		if exporter, err = grpcMetricsExporter(ctx, cfg); err != nil {
 			return nil, fmt.Errorf("can't instantiate OTEL GRPC metrics exporter: %w", err)
 		}
 	default:
 		return nil, fmt.Errorf("invalid protocol value: %q. Accepted values are: %s, %s, %s",
-			proto, ProtocolGRPC, ProtocolHTTPJSON, ProtocolHTTPProtobuf)
+			proto, otelcfg.ProtocolGRPC, otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf)
 	}
 	return exporter, nil
 }
 
-func httpMetricsExporter(ctx context.Context, cfg *MetricsConfig) (sdkmetric.Exporter, error) {
-	opts, err := getHTTPMetricEndpointOptions(cfg)
+func httpMetricsExporter(ctx context.Context, cfg *otelcfg.MetricsConfig) (sdkmetric.Exporter, error) {
+	opts, err := otelcfg.HTTPMetricEndpointOptions(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -852,8 +688,8 @@ func httpMetricsExporter(ctx context.Context, cfg *MetricsConfig) (sdkmetric.Exp
 	return mexp, nil
 }
 
-func grpcMetricsExporter(ctx context.Context, cfg *MetricsConfig) (sdkmetric.Exporter, error) {
-	opts, err := getGRPCMetricEndpointOptions(cfg)
+func grpcMetricsExporter(ctx context.Context, cfg *otelcfg.MetricsConfig) (sdkmetric.Exporter, error) {
+	opts, err := otelcfg.GRPCMetricEndpointOptions(cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -934,7 +770,7 @@ func (mr *MetricsReporter) tracesResourceAttributes(service *svc.Attrs) attribut
 		extraAttrs = append(extraAttrs, k.OTEL().String(v))
 	}
 
-	filteredAttrs := getFilteredMetricResourceAttrs(baseAttrs, mr.userAttribSelection, extraAttrs, MetricTypes)
+	filteredAttrs := otelcfg.GetFilteredAttributesByPrefix(baseAttrs, mr.userAttribSelection, extraAttrs, MetricTypes)
 	return attribute.NewSet(filteredAttrs...)
 }
 
@@ -1170,119 +1006,6 @@ func (mr *MetricsReporter) reportMetrics(_ context.Context) {
 		}
 	}
 	mr.close()
-}
-
-func getHTTPMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
-	opts := otlpOptions{Headers: map[string]string{}}
-	log := mlog().With("transport", "http")
-	murl, isCommon, err := parseMetricsEndpoint(cfg)
-	if err != nil {
-		return opts, err
-	}
-	log.Debug("Configuring exporter",
-		"protocol", cfg.Protocol, "metricsProtocol", cfg.MetricsProtocol, "endpoint", murl.Host)
-
-	setMetricsProtocol(cfg)
-	opts.Endpoint = murl.Host
-	if murl.Scheme == "http" || murl.Scheme == "unix" {
-		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
-		opts.Insecure = true
-	}
-	// If the value is set from the OTEL_EXPORTER_OTLP_ENDPOINT common property, we need to add /v1/metrics to the path
-	// otherwise, we leave the path that is explicitly set by the user
-	opts.URLPath = murl.Path
-	if isCommon {
-		if strings.HasSuffix(opts.URLPath, "/") {
-			opts.URLPath += "v1/metrics"
-		} else {
-			opts.URLPath += "/v1/metrics"
-		}
-	}
-	log.Debug("Specifying path", "path", opts.URLPath)
-
-	if cfg.InsecureSkipVerify {
-		log.Debug("Setting InsecureSkipVerify")
-		opts.SkipTLSVerify = cfg.InsecureSkipVerify
-	}
-
-	if cfg.InjectHeaders != nil {
-		cfg.InjectHeaders(opts.Headers)
-	}
-	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
-	maps.Copy(opts.Headers, HeadersFromEnv(envMetricsHeaders))
-
-	return opts, nil
-}
-
-func getGRPCMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
-	opts := otlpOptions{Headers: map[string]string{}}
-	log := mlog().With("transport", "grpc")
-	murl, _, err := parseMetricsEndpoint(cfg)
-	if err != nil {
-		return opts, err
-	}
-	log.Debug("Configuring exporter",
-		"protocol", cfg.Protocol, "metricsProtocol", cfg.MetricsProtocol, "endpoint", murl.Host)
-
-	setMetricsProtocol(cfg)
-	opts.Endpoint = murl.Host
-	if murl.Scheme == "http" || murl.Scheme == "unix" {
-		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
-		opts.Insecure = true
-	}
-	if cfg.InsecureSkipVerify {
-		log.Debug("Setting InsecureSkipVerify")
-		opts.SkipTLSVerify = true
-	}
-
-	if cfg.InjectHeaders != nil {
-		cfg.InjectHeaders(opts.Headers)
-	}
-	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
-	maps.Copy(opts.Headers, HeadersFromEnv(envMetricsHeaders))
-
-	return opts, nil
-}
-
-// the HTTP path will be defined from one of the following sources, from highest to lowest priority
-// - the result from any overridden OTLP Provider function
-// - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, if defined
-// - OTEL_EXPORTER_OTLP_ENDPOINT, if defined
-func parseMetricsEndpoint(cfg *MetricsConfig) (*url.URL, bool, error) {
-	endpoint, isCommon := cfg.OTLPMetricsEndpoint()
-
-	murl, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, isCommon, fmt.Errorf("parsing endpoint URL %s: %w", endpoint, err)
-	}
-	if murl.Scheme == "" || murl.Host == "" {
-		return nil, isCommon, fmt.Errorf("URL %q must have a scheme and a host", endpoint)
-	}
-	return murl, isCommon, nil
-}
-
-// HACK: at the time of writing this, the otelpmetrichttp API does not support explicitly
-// setting the protocol. They should be properly set via environment variables, but
-// if the user supplied the value via configuration file (and not via env vars), we override the environment.
-// To be as least intrusive as possible, we will change the variables if strictly needed
-// TODO: remove this once otelpmetrichttp.WithProtocol is supported
-func setMetricsProtocol(cfg *MetricsConfig) {
-	if _, ok := os.LookupEnv(envMetricsProtocol); ok {
-		return
-	}
-	if _, ok := os.LookupEnv(envProtocol); ok {
-		return
-	}
-	if cfg.MetricsProtocol != "" {
-		os.Setenv(envMetricsProtocol, string(cfg.MetricsProtocol))
-		return
-	}
-	if cfg.Protocol != "" {
-		os.Setenv(envProtocol, string(cfg.Protocol))
-		return
-	}
-	// unset. Guessing it
-	os.Setenv(envMetricsProtocol, string(cfg.GuessProtocol()))
 }
 
 func cleanupMetrics(ctx context.Context, m *Expirer[*request.Span, instrument.Float64Histogram, float64]) {

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -818,6 +818,7 @@ func isExponentialAggregation(mc *MetricsConfig, mlog *slog.Logger) bool {
 	return false
 }
 
+// TODO: unify in single exporter for most metrics
 func InstantiateMetricsExporter(ctx context.Context, cfg *MetricsConfig, log *slog.Logger) (sdkmetric.Exporter, error) {
 	var err error
 	var exporter sdkmetric.Exporter

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -97,6 +97,8 @@ type MetricsReporter struct {
 	userAttribSelection        attributes.Selection
 	input                      <-chan []request.Span
 	processEvents              <-chan exec.ProcessEvent
+
+	log *slog.Logger
 }
 
 // Metrics is a set of metrics associated to a given OTEL MeterProvider.
@@ -197,6 +199,7 @@ func newMetricsReporter(
 		input:               input.Subscribe(),
 		processEvents:       processEventCh.Subscribe(),
 		userAttribSelection: selectorCfg.SelectionCfg,
+		log:                 mlog(),
 	}
 
 	// initialize attribute getters
@@ -897,67 +900,84 @@ func (mr *MetricsReporter) disassociatePIDFromService(pid int32) (bool, svc.UID)
 	return mr.pidTracker.RemovePID(pid)
 }
 
-func (mr *MetricsReporter) watchForProcessEvents() {
-	for pe := range mr.processEvents {
-		mlog().Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
-
-		reporter, err := mr.reporters.For(&pe.File.Service)
-		// If we are receiving a delete event, the service may come without kubernetes information, which
-		// is why we record the original service info. Delete look up the data from the pid tracker.
-		if err != nil {
-			mlog().Error("unexpected error creating OTEL resource. Ignoring metric",
-				"error", err, "service", pe.File.Service.UID)
-			continue
-		}
-
-		if pe.Type == exec.ProcessEventCreated {
-			mr.createTargetInfo(reporter)
-			mr.createTracesTargetInfo(reporter)
-			mr.setupPIDToServiceRelationship(pe.File.Pid, pe.File.Service.UID)
-		} else {
-			if deleted, origUID := mr.disassociatePIDFromService(pe.File.Pid); deleted {
-				// We only need the UID to look up in the pool, no need to cache
-				// the whole of the attrs in the pidTracker
-				svc := svc.Attrs{UID: origUID}
-				reporter, err = mr.reporters.For(&svc)
-				if err != nil {
-					mlog().Error("unexpected error creating OTEL resource. Ignoring metric",
-						"error", err, "service", pe.File.Service.UID)
-					continue
-				}
-				mlog().Debug("deleting infos for", "pid", pe.File.Pid, "attrs", reporter.service)
-				mr.deleteTracesTargetInfo(reporter)
-				mr.deleteTargetInfo(reporter)
+func (mr *MetricsReporter) reportMetrics(ctx context.Context) {
+	defer mr.close()
+	for {
+		select {
+		case <-ctx.Done():
+			mr.log.Debug("context done, stopping metrics reporting")
+			return
+		case pe, ok := <-mr.processEvents:
+			if !ok {
+				mr.log.Debug("process events channel closed, stopping metrics reporting")
+				return
 			}
+			mr.onProcessEvent(&pe)
+		case spans, ok := <-mr.input:
+			if !ok {
+				mr.log.Debug("input channel closed, stopping metrics reporting")
+				return
+			}
+			mr.onSpan(spans)
 		}
 	}
 }
 
-func (mr *MetricsReporter) reportMetrics(_ context.Context) {
-	go mr.watchForProcessEvents()
-	for spans := range mr.input {
-		for i := range spans {
-			s := &spans[i]
-			if s.InternalSignal() {
-				continue
-			}
-			if !s.Service.ExportModes.CanExportMetrics() {
-				continue
-			}
-			// If we are ignoring this span because of route patterns, don't do anything
-			if request.IgnoreMetrics(s) {
-				continue
-			}
-			reporter, err := mr.reporters.For(&s.Service)
+func (mr *MetricsReporter) onProcessEvent(pe *exec.ProcessEvent) {
+	mr.log.Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
+
+	reporter, err := mr.reporters.For(&pe.File.Service)
+	// If we are receiving a delete event, the service may come without kubernetes information, which
+	// is why we record the original service info. Delete look up the data from the pid tracker.
+	if err != nil {
+		mr.log.Error("unexpected error creating OTEL resource. Ignoring metric",
+			"error", err, "service", pe.File.Service.UID)
+		return
+	}
+
+	if pe.Type == exec.ProcessEventCreated {
+		mr.createTargetInfo(reporter)
+		mr.createTracesTargetInfo(reporter)
+		mr.setupPIDToServiceRelationship(pe.File.Pid, pe.File.Service.UID)
+	} else {
+		if deleted, origUID := mr.disassociatePIDFromService(pe.File.Pid); deleted {
+			// We only need the UID to look up in the pool, no need to cache
+			// the whole of the attrs in the pidTracker
+			svc := svc.Attrs{UID: origUID}
+			reporter, err = mr.reporters.For(&svc)
 			if err != nil {
-				mlog().Error("unexpected error creating OTEL resource. Ignoring metric",
-					"error", err, "service", s.Service)
-				continue
+				mr.log.Error("unexpected error creating OTEL resource. Ignoring metric",
+					"error", err, "service", pe.File.Service.UID)
+				return
 			}
-			reporter.record(s, mr)
+			mlog().Debug("deleting infos for", "pid", pe.File.Pid, "attrs", reporter.service)
+			mr.deleteTracesTargetInfo(reporter)
+			mr.deleteTargetInfo(reporter)
 		}
 	}
-	mr.close()
+}
+
+func (mr *MetricsReporter) onSpan(spans []request.Span) {
+	for i := range spans {
+		s := &spans[i]
+		if s.InternalSignal() {
+			continue
+		}
+		if !s.Service.ExportModes.CanExportMetrics() {
+			continue
+		}
+		// If we are ignoring this span because of route patterns, don't do anything
+		if request.IgnoreMetrics(s) {
+			continue
+		}
+		reporter, err := mr.reporters.For(&s.Service)
+		if err != nil {
+			mlog().Error("unexpected error creating OTEL resource. Ignoring metric",
+				"error", err, "service", s.Service)
+			continue
+		}
+		reporter.record(s, mr)
+	}
 }
 
 func cleanupMetrics(ctx context.Context, m *Expirer[*request.Span, instrument.Float64Histogram, float64]) {

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -10,8 +10,6 @@ import (
 	"slices"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -265,7 +263,7 @@ func newMetricsReporter(
 			}()
 		}, mr.newMetricSet)
 	// Instantiate the OTLP HTTP or GRPC metrics exporter
-	exporter, err := InstantiateMetricsExporter(ctx, cfg, log)
+	exporter, err := ctxInfo.OTELMetricsExporter.Instantiate(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -652,52 +650,6 @@ func isExponentialAggregation(mc *otelcfg.MetricsConfig, mlog *slog.Logger) bool
 			"value", mc.HistogramAggregation)
 	}
 	return false
-}
-
-// TODO: unify in single exporter for most metrics
-func InstantiateMetricsExporter(ctx context.Context, cfg *otelcfg.MetricsConfig, log *slog.Logger) (sdkmetric.Exporter, error) {
-	var err error
-	var exporter sdkmetric.Exporter
-	switch proto := cfg.GetProtocol(); proto {
-	case otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf, "": // zero value defaults to HTTP for backwards-compatibility
-		log.Debug("instantiating HTTP MetricsReporter", "protocol", proto)
-		if exporter, err = httpMetricsExporter(ctx, cfg); err != nil {
-			return nil, fmt.Errorf("can't instantiate OTEL HTTP metrics exporter: %w", err)
-		}
-	case otelcfg.ProtocolGRPC:
-		log.Debug("instantiating GRPC MetricsReporter", "protocol", proto)
-		if exporter, err = grpcMetricsExporter(ctx, cfg); err != nil {
-			return nil, fmt.Errorf("can't instantiate OTEL GRPC metrics exporter: %w", err)
-		}
-	default:
-		return nil, fmt.Errorf("invalid protocol value: %q. Accepted values are: %s, %s, %s",
-			proto, otelcfg.ProtocolGRPC, otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf)
-	}
-	return exporter, nil
-}
-
-func httpMetricsExporter(ctx context.Context, cfg *otelcfg.MetricsConfig) (sdkmetric.Exporter, error) {
-	opts, err := otelcfg.HTTPMetricEndpointOptions(cfg)
-	if err != nil {
-		return nil, err
-	}
-	mexp, err := otlpmetrichttp.New(ctx, opts.AsMetricHTTP()...)
-	if err != nil {
-		return nil, fmt.Errorf("creating HTTP metric exporter: %w", err)
-	}
-	return mexp, nil
-}
-
-func grpcMetricsExporter(ctx context.Context, cfg *otelcfg.MetricsConfig) (sdkmetric.Exporter, error) {
-	opts, err := otelcfg.GRPCMetricEndpointOptions(cfg)
-	if err != nil {
-		return nil, err
-	}
-	mexp, err := otlpmetricgrpc.New(ctx, opts.AsMetricGRPC()...)
-	if err != nil {
-		return nil, fmt.Errorf("creating GRPC metric exporter: %w", err)
-	}
-	return mexp, nil
 }
 
 func (mr *MetricsReporter) close() {

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -45,7 +45,7 @@ func imlog() *slog.Logger {
 func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo, metrics *otelcfg.MetricsConfig) (*InternalMetricsReporter, error) {
 	log := imlog()
 	log.Debug("instantiating internal metrics exporter provider")
-	exporter, err := InstantiateMetricsExporter(ctx, metrics, log)
+	exporter, err := ctxInfo.OTELMetricsExporter.Instantiate(ctx)
 	if err != nil {
 		log.Error("can't instantiate metrics exporter", "error", err)
 		return nil, err

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -9,6 +9,11 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/google/uuid"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
+
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -36,7 +41,7 @@ func imlog() *slog.Logger {
 	return slog.With("component", "otel.InternalMetricsReporter")
 }
 
-func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo, metrics *MetricsConfig) (*InternalMetricsReporter, error) {
+func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo, metrics *otelcfg.MetricsConfig) (*InternalMetricsReporter, error) {
 	log := imlog()
 	log.Debug("instantiating internal metrics exporter provider")
 	exporter, err := InstantiateMetricsExporter(ctx, metrics, log)
@@ -157,4 +162,17 @@ func (p *InternalMetricsReporter) InstrumentProcess(processName string) {
 
 func (p *InternalMetricsReporter) UninstrumentProcess(processName string) {
 	p.instrumentedProcesses.Add(p.ctx, -1, instrument.WithAttributes(attribute.String("process_name", processName)))
+}
+
+func newResourceInternal(hostID string) *resource.Resource {
+	attrs := []attribute.KeyValue{
+		semconv.ServiceName("opentelemetry-ebpf-instrumentation"),
+		semconv.ServiceInstanceID(uuid.New().String()),
+		semconv.TelemetrySDKLanguageKey.String(semconv.TelemetrySDKLanguageGo.Value.AsString()),
+		// We set the SDK name as Beyla, so we can distinguish beyla generated metrics from other SDKs
+		semconv.TelemetrySDKNameKey.String("opentelemetry-ebpf-instrumentation"),
+		semconv.HostID(hostID),
+	}
+
+	return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
 }

--- a/pkg/export/otel/metrics_net.go
+++ b/pkg/export/otel/metrics_net.go
@@ -103,7 +103,7 @@ func newMetricsExporter(
 ) (*netMetricsExporter, error) {
 	log := nmlog()
 	log.Debug("instantiating network metrics exporter provider")
-	exporter, err := InstantiateMetricsExporter(context.Background(), cfg.Metrics, log)
+	exporter, err := ctxInfo.OTELMetricsExporter.Instantiate(ctx)
 	if err != nil {
 		log.Error("can't instantiate metrics exporter", "error", err)
 		return nil, err

--- a/pkg/export/otel/metrics_net.go
+++ b/pkg/export/otel/metrics_net.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"time"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -28,7 +30,7 @@ import (
 
 // NetMetricsConfig extends MetricsConfig for Network Metrics
 type NetMetricsConfig struct {
-	Metrics     *MetricsConfig
+	Metrics     *otelcfg.MetricsConfig
 	SelectorCfg *attributes.SelectorConfig
 	// Deprecated: to be removed in Beyla 3.0 with OTEL_EBPF_NETWORK_METRICS bool flag
 	GloballyEnabled bool
@@ -54,7 +56,7 @@ func getFilteredNetworkResourceAttrs(hostID string, attrSelector attributes.Sele
 		semconv.HostID(hostID),
 	}
 
-	return GetFilteredAttributesByPrefix(baseAttrs, attrSelector, extraAttrs, []string{"network.", attr.VendorPrefix + ".network"})
+	return otelcfg.GetFilteredAttributesByPrefix(baseAttrs, attrSelector, extraAttrs, []string{"network.", attr.VendorPrefix + ".network"})
 }
 
 func createFilteredNetworkResource(hostID string, attrSelector attributes.Selection) *resource.Resource {

--- a/pkg/export/otel/metrics_net_test.go
+++ b/pkg/export/otel/metrics_net_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
@@ -19,7 +21,7 @@ import (
 )
 
 func TestMetricAttributes(t *testing.T) {
-	defer restoreEnvAfterExecution()()
+	defer otelcfg.RestoreEnvAfterExecution()()
 	in := &ebpf.Record{
 		NetFlowRecordT: ebpf.NetFlowRecordT{
 			Id: ebpf.NetFlowId{
@@ -47,12 +49,12 @@ func TestMetricAttributes(t *testing.T) {
 			SelectionCfg: map[attributes.Section]attributes.InclusionLists{
 				attributes.NetworkFlow.Section: {Include: []string{"*"}},
 			},
-		}, Metrics: &MetricsConfig{
+		}, Metrics: &otelcfg.MetricsConfig{
 			MetricsEndpoint:   "http://foo",
 			Interval:          10 * time.Millisecond,
 			ReportersCacheLen: 100,
 			TTL:               5 * time.Minute,
-			Features:          []string{FeatureNetwork, FeatureNetworkInterZone},
+			Features:          []string{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
 		}}, msg.NewQueue[[]*ebpf.Record]())
 	require.NoError(t, err)
 
@@ -77,7 +79,7 @@ func TestMetricAttributes(t *testing.T) {
 }
 
 func TestMetricAttributes_Filter(t *testing.T) {
-	defer restoreEnvAfterExecution()()
+	defer otelcfg.RestoreEnvAfterExecution()()
 	in := &ebpf.Record{
 		NetFlowRecordT: ebpf.NetFlowRecordT{
 			Id: ebpf.NetFlowId{
@@ -109,11 +111,11 @@ func TestMetricAttributes_Filter(t *testing.T) {
 					"k8s.dst.name",
 				}},
 			},
-		}, Metrics: &MetricsConfig{
+		}, Metrics: &otelcfg.MetricsConfig{
 			MetricsEndpoint:   "http://foo",
 			Interval:          10 * time.Millisecond,
 			ReportersCacheLen: 100,
-			Features:          []string{FeatureNetwork, FeatureNetworkInterZone},
+			Features:          []string{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
 		}}, msg.NewQueue[[]*ebpf.Record]())
 	require.NoError(t, err)
 
@@ -139,24 +141,24 @@ func TestMetricAttributes_Filter(t *testing.T) {
 }
 
 func TestNetMetricsConfig_Enabled(t *testing.T) {
-	assert.True(t, NetMetricsConfig{Metrics: &MetricsConfig{
-		Features: []string{FeatureApplication, FeatureNetwork}, CommonEndpoint: "foo",
+	assert.True(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{
+		Features: []string{otelcfg.FeatureApplication, otelcfg.FeatureNetwork}, CommonEndpoint: "foo",
 	}}.Enabled())
-	assert.True(t, NetMetricsConfig{Metrics: &MetricsConfig{
-		Features: []string{FeatureNetwork, FeatureApplication}, MetricsEndpoint: "foo",
+	assert.True(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{
+		Features: []string{otelcfg.FeatureNetwork, otelcfg.FeatureApplication}, MetricsEndpoint: "foo",
 	}}.Enabled())
 }
 
 func TestNetMetricsConfig_Disabled(t *testing.T) {
-	fa := []string{FeatureApplication}
-	fn := []string{FeatureNetwork}
-	assert.False(t, NetMetricsConfig{Metrics: &MetricsConfig{Features: fn}}.Enabled())
-	assert.False(t, NetMetricsConfig{Metrics: &MetricsConfig{Features: fn}}.Enabled())
-	assert.False(t, NetMetricsConfig{Metrics: &MetricsConfig{Features: fn}}.Enabled())
+	fa := []string{otelcfg.FeatureApplication}
+	fn := []string{otelcfg.FeatureNetwork}
+	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{Features: fn}}.Enabled())
+	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{Features: fn}}.Enabled())
+	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{Features: fn}}.Enabled())
 	// network feature is not enabled
-	assert.False(t, NetMetricsConfig{Metrics: &MetricsConfig{CommonEndpoint: "foo"}}.Enabled())
-	assert.False(t, NetMetricsConfig{Metrics: &MetricsConfig{MetricsEndpoint: "foo", Features: fa}}.Enabled())
-	assert.False(t, NetMetricsConfig{Metrics: &MetricsConfig{}}.Enabled())
+	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{CommonEndpoint: "foo"}}.Enabled())
+	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{MetricsEndpoint: "foo", Features: fa}}.Enabled())
+	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{}}.Enabled())
 }
 
 func TestGetFilteredNetworkResourceAttrs(t *testing.T) {

--- a/pkg/export/otel/metrics_net_test.go
+++ b/pkg/export/otel/metrics_net_test.go
@@ -43,19 +43,21 @@ func TestMetricAttributes(t *testing.T) {
 	in.Id.SrcIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 12, 34, 56, 78}
 	in.Id.DstIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 33, 22, 11, 1}
 
-	me, err := newMetricsExporter(t.Context(),
-		&global.ContextInfo{MetricAttributeGroups: attributes.GroupKubernetes},
-		&NetMetricsConfig{SelectorCfg: &attributes.SelectorConfig{
-			SelectionCfg: map[attributes.Section]attributes.InclusionLists{
-				attributes.NetworkFlow.Section: {Include: []string{"*"}},
-			},
-		}, Metrics: &otelcfg.MetricsConfig{
-			MetricsEndpoint:   "http://foo",
-			Interval:          10 * time.Millisecond,
-			ReportersCacheLen: 100,
-			TTL:               5 * time.Minute,
-			Features:          []string{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
-		}}, msg.NewQueue[[]*ebpf.Record]())
+	mcfg := &otelcfg.MetricsConfig{
+		MetricsEndpoint:   "http://foo",
+		Interval:          10 * time.Millisecond,
+		ReportersCacheLen: 100,
+		TTL:               5 * time.Minute,
+		Features:          []string{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
+	}
+	me, err := newMetricsExporter(t.Context(), &global.ContextInfo{
+		MetricAttributeGroups: attributes.GroupKubernetes,
+		OTELMetricsExporter:   &otelcfg.MetricsExporterInstancer{Cfg: mcfg},
+	}, &NetMetricsConfig{SelectorCfg: &attributes.SelectorConfig{
+		SelectionCfg: map[attributes.Section]attributes.InclusionLists{
+			attributes.NetworkFlow.Section: {Include: []string{"*"}},
+		},
+	}, Metrics: mcfg}, msg.NewQueue[[]*ebpf.Record]())
 	require.NoError(t, err)
 
 	_, reportedAttributes := me.flowBytes.ForRecord(in)
@@ -101,8 +103,16 @@ func TestMetricAttributes_Filter(t *testing.T) {
 	in.Id.SrcIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 12, 34, 56, 78}
 	in.Id.DstIp.In6U.U6Addr8 = [16]uint8{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 33, 22, 11, 1}
 
-	me, err := newMetricsExporter(t.Context(),
-		&global.ContextInfo{MetricAttributeGroups: attributes.GroupKubernetes},
+	mcfg := &otelcfg.MetricsConfig{
+		MetricsEndpoint:   "http://foo",
+		Interval:          10 * time.Millisecond,
+		ReportersCacheLen: 100,
+		Features:          []string{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
+	}
+	me, err := newMetricsExporter(t.Context(), &global.ContextInfo{
+		MetricAttributeGroups: attributes.GroupKubernetes,
+		OTELMetricsExporter:   &otelcfg.MetricsExporterInstancer{Cfg: mcfg},
+	},
 		&NetMetricsConfig{SelectorCfg: &attributes.SelectorConfig{
 			SelectionCfg: map[attributes.Section]attributes.InclusionLists{
 				attributes.NetworkFlow.Section: {Include: []string{
@@ -111,12 +121,7 @@ func TestMetricAttributes_Filter(t *testing.T) {
 					"k8s.dst.name",
 				}},
 			},
-		}, Metrics: &otelcfg.MetricsConfig{
-			MetricsEndpoint:   "http://foo",
-			Interval:          10 * time.Millisecond,
-			ReportersCacheLen: 100,
-			Features:          []string{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
-		}}, msg.NewQueue[[]*ebpf.Record]())
+		}, Metrics: mcfg}, msg.NewQueue[[]*ebpf.Record]())
 	require.NoError(t, err)
 
 	_, reportedAttributes := me.flowBytes.ForRecord(in)

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -42,11 +44,11 @@ const (
 // instances and forwards them as OTEL metrics.
 type SvcGraphMetricsReporter struct {
 	ctx        context.Context
-	cfg        *MetricsConfig
+	cfg        *otelcfg.MetricsConfig
 	hostID     string
 	attributes *attributes.AttrSelector
 	exporter   sdkmetric.Exporter
-	reporters  ReporterPool[*svc.Attrs, *SvcGraphMetrics]
+	reporters  otelcfg.ReporterPool[*svc.Attrs, *SvcGraphMetrics]
 	pidTracker PidServiceTracker
 	is         instrumentations.InstrumentationSelection
 
@@ -71,7 +73,7 @@ type SvcGraphMetrics struct {
 
 func ReportSvcGraphMetrics(
 	ctxInfo *global.ContextInfo,
-	cfg *MetricsConfig,
+	cfg *otelcfg.MetricsConfig,
 	selectorCfg *attributes.SelectorConfig,
 	input *msg.Queue[[]request.Span],
 	processEventCh *msg.Queue[exec.ProcessEvent],
@@ -80,7 +82,7 @@ func ReportSvcGraphMetrics(
 		if !cfg.EndpointEnabled() || !cfg.ServiceGraphMetricsEnabled() {
 			return swarm.EmptyRunFunc()
 		}
-		SetupInternalOTELSDKLogger(cfg.SDKLogLevel)
+		otelcfg.SetupInternalOTELSDKLogger(cfg.SDKLogLevel)
 
 		mr, err := newSvcGraphMetricsReporter(
 			ctx,
@@ -101,7 +103,7 @@ func ReportSvcGraphMetrics(
 func newSvcGraphMetricsReporter(
 	ctx context.Context,
 	ctxInfo *global.ContextInfo,
-	cfg *MetricsConfig,
+	cfg *otelcfg.MetricsConfig,
 	selectorCfg *attributes.SelectorConfig,
 	input *msg.Queue[[]request.Span],
 	processEventCh *msg.Queue[exec.ProcessEvent],
@@ -125,7 +127,7 @@ func newSvcGraphMetricsReporter(
 		processEvents: processEventCh.Subscribe(),
 	}
 
-	mr.reporters = NewReporterPool[*svc.Attrs, *SvcGraphMetrics](cfg.ReportersCacheLen, cfg.TTL, timeNow,
+	mr.reporters = otelcfg.NewReporterPool[*svc.Attrs, *SvcGraphMetrics](cfg.ReportersCacheLen, cfg.TTL, timeNow,
 		func(id svc.UID, v *SvcGraphMetrics) {
 			llog := log.With("service", id)
 			llog.Debug("evicting metrics reporter from cache")
@@ -208,7 +210,7 @@ func (mr *SvcGraphMetricsReporter) newSvcGraphMetricsInstance(service *svc.Attrs
 	var resourceAttributes []attribute.KeyValue
 	if service != nil {
 		sglog = sglog.With("service", service)
-		resourceAttributes = append(GetAppResourceAttrs(mr.hostID, service), ResourceAttrsFromEnv(service)...)
+		resourceAttributes = append(otelcfg.GetAppResourceAttrs(mr.hostID, service), otelcfg.ResourceAttrsFromEnv(service)...)
 	}
 	sglog.Debug("creating new Metrics reporter")
 	resources := resource.NewWithAttributes(semconv.SchemaURL, resourceAttributes...)
@@ -280,7 +282,7 @@ func (mr *SvcGraphMetricsReporter) tracesResourceAttributes(service *svc.Attrs) 
 		extraAttrs = append(extraAttrs, k.OTEL().String(v))
 	}
 
-	filteredAttrs := getFilteredMetricResourceAttrs(baseAttrs, nil, extraAttrs, MetricTypes)
+	filteredAttrs := otelcfg.GetFilteredAttributesByPrefix(baseAttrs, nil, extraAttrs, MetricTypes)
 	return attribute.NewSet(filteredAttrs...)
 }
 

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -54,6 +54,8 @@ type SvcGraphMetricsReporter struct {
 
 	input         <-chan []request.Span
 	processEvents <-chan exec.ProcessEvent
+
+	log *slog.Logger
 }
 
 // Metrics is a set of metrics associated to a given OTEL MeterProvider.
@@ -125,6 +127,7 @@ func newSvcGraphMetricsReporter(
 		hostID:        ctxInfo.HostID,
 		input:         input.Subscribe(),
 		processEvents: processEventCh.Subscribe(),
+		log:           sglog(),
 	}
 
 	mr.reporters = otelcfg.NewReporterPool[*svc.Attrs, *SvcGraphMetrics](cfg.ReportersCacheLen, cfg.TTL, timeNow,
@@ -380,64 +383,80 @@ func (mr *SvcGraphMetricsReporter) disassociatePIDFromService(pid int32) (bool, 
 	return mr.pidTracker.RemovePID(pid)
 }
 
-func (mr *SvcGraphMetricsReporter) watchForProcessEvents() {
-	log := sglog()
-	for pe := range mr.processEvents {
-		log.Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
-
-		reporter, err := mr.reporters.For(&pe.File.Service)
-		// If we are receiving a delete event, the service may come without kubernetes information, which
-		// is why we record the original service info. Delete look up the data from the pid tracker.
-		if err != nil {
-			log.Error("unexpected error creating OTEL resource. Ignoring metric",
-				"error", err, "service", pe.File.Service.UID)
-			continue
-		}
-
-		if pe.Type == exec.ProcessEventCreated {
-			mr.setupPIDToServiceRelationship(pe.File.Pid, pe.File.Service.UID)
-		} else {
-			if deleted, origUID := mr.disassociatePIDFromService(pe.File.Pid); deleted {
-				// We only need the UID to look up in the pool, no need to cache
-				// the whole of the attrs in the pidTracker
-				svc := svc.Attrs{UID: origUID}
-				reporter, err = mr.reporters.For(&svc)
-				if err != nil {
-					log.Error("unexpected error creating OTEL resource. Ignoring metric",
-						"error", err, "service", pe.File.Service.UID)
-					continue
-				}
-				log.Debug("deleting infos for", "pid", pe.File.Pid, "attrs", reporter.service)
+func (mr *SvcGraphMetricsReporter) reportMetrics(ctx context.Context) {
+	defer mr.close()
+	for {
+		select {
+		case <-ctx.Done():
+			mr.log.Debug("context done, stopping metrics reporting")
+			return
+		case pe, ok := <-mr.processEvents:
+			if !ok {
+				mr.log.Debug("process events channel closed, stopping metrics reporting")
+				return
 			}
+			mr.onProcessEvent(&pe)
+		case spans, ok := <-mr.input:
+			if !ok {
+				mr.log.Debug("input channel closed, stopping metrics reporting")
+				return
+			}
+			mr.onSpan(spans)
 		}
 	}
 }
 
-func (mr *SvcGraphMetricsReporter) reportMetrics(_ context.Context) {
-	go mr.watchForProcessEvents()
-	for spans := range mr.input {
-		for i := range spans {
-			s := &spans[i]
-			if s.InternalSignal() {
-				continue
-			}
-			if !s.Service.ExportModes.CanExportMetrics() {
-				continue
-			}
-			// If we are ignoring this span because of route patterns, don't do anything
-			if request.IgnoreMetrics(s) {
-				continue
-			}
-			reporter, err := mr.reporters.For(&s.Service)
+func (mr *SvcGraphMetricsReporter) onProcessEvent(pe *exec.ProcessEvent) {
+	mr.log.Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
+
+	reporter, err := mr.reporters.For(&pe.File.Service)
+	// If we are receiving a delete event, the service may come without kubernetes information, which
+	// is why we record the original service info. Delete look up the data from the pid tracker.
+	if err != nil {
+		mr.log.Error("unexpected error creating OTEL resource. Ignoring metric",
+			"error", err, "service", pe.File.Service.UID)
+		return
+	}
+
+	if pe.Type == exec.ProcessEventCreated {
+		mr.setupPIDToServiceRelationship(pe.File.Pid, pe.File.Service.UID)
+	} else {
+		if deleted, origUID := mr.disassociatePIDFromService(pe.File.Pid); deleted {
+			// We only need the UID to look up in the pool, no need to cache
+			// the whole of the attrs in the pidTracker
+			svc := svc.Attrs{UID: origUID}
+			reporter, err = mr.reporters.For(&svc)
 			if err != nil {
-				sglog().Error("unexpected error creating OTEL resource. Ignoring metric",
-					"error", err, "service", s.Service)
-				continue
+				mr.log.Error("unexpected error creating OTEL resource. Ignoring metric",
+					"error", err, "service", pe.File.Service.UID)
+				return
 			}
-			reporter.record(s, mr)
+			mr.log.Debug("deleting infos for", "pid", pe.File.Pid, "attrs", reporter.service)
 		}
 	}
-	mr.close()
+}
+
+func (mr *SvcGraphMetricsReporter) onSpan(spans []request.Span) {
+	for i := range spans {
+		s := &spans[i]
+		if s.InternalSignal() {
+			continue
+		}
+		if !s.Service.ExportModes.CanExportMetrics() {
+			continue
+		}
+		// If we are ignoring this span because of route patterns, don't do anything
+		if request.IgnoreMetrics(s) {
+			continue
+		}
+		reporter, err := mr.reporters.For(&s.Service)
+		if err != nil {
+			sglog().Error("unexpected error creating OTEL resource. Ignoring metric",
+				"error", err, "service", s.Service)
+			continue
+		}
+		reporter.record(s, mr)
+	}
 }
 
 func (r *SvcGraphMetrics) cleanupAllMetricsInstances() {

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -76,7 +76,7 @@ func ReportSvcGraphMetrics(
 	cfg *otelcfg.MetricsConfig,
 	selectorCfg *attributes.SelectorConfig,
 	input *msg.Queue[[]request.Span],
-	processEventCh *msg.Queue[exec.ProcessEvent],
+	processEvents *msg.Queue[exec.ProcessEvent],
 ) swarm.InstanceFunc {
 	return func(ctx context.Context) (swarm.RunFunc, error) {
 		if !cfg.EndpointEnabled() || !cfg.ServiceGraphMetricsEnabled() {
@@ -90,7 +90,7 @@ func ReportSvcGraphMetrics(
 			cfg,
 			selectorCfg,
 			input,
-			processEventCh,
+			processEvents,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("instantiating OTEL metrics reporter: %w", err)
@@ -381,20 +381,20 @@ func (mr *SvcGraphMetricsReporter) disassociatePIDFromService(pid int32) (bool, 
 }
 
 func (mr *SvcGraphMetricsReporter) watchForProcessEvents() {
+	log := sglog()
 	for pe := range mr.processEvents {
-		sglog().Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
+		log.Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
 
 		reporter, err := mr.reporters.For(&pe.File.Service)
 		// If we are receiving a delete event, the service may come without kubernetes information, which
 		// is why we record the original service info. Delete look up the data from the pid tracker.
 		if err != nil {
-			sglog().Error("unexpected error creating OTEL resource. Ignoring metric",
+			log.Error("unexpected error creating OTEL resource. Ignoring metric",
 				"error", err, "service", pe.File.Service.UID)
 			continue
 		}
 
 		if pe.Type == exec.ProcessEventCreated {
-			// TODO: necesitamos est0o?
 			mr.setupPIDToServiceRelationship(pe.File.Pid, pe.File.Service.UID)
 		} else {
 			if deleted, origUID := mr.disassociatePIDFromService(pe.File.Pid); deleted {
@@ -403,11 +403,11 @@ func (mr *SvcGraphMetricsReporter) watchForProcessEvents() {
 				svc := svc.Attrs{UID: origUID}
 				reporter, err = mr.reporters.For(&svc)
 				if err != nil {
-					sglog().Error("unexpected error creating OTEL resource. Ignoring metric",
+					log.Error("unexpected error creating OTEL resource. Ignoring metric",
 						"error", err, "service", pe.File.Service.UID)
 					continue
 				}
-				sglog().Debug("deleting infos for", "pid", pe.File.Pid, "attrs", reporter.service)
+				log.Debug("deleting infos for", "pid", pe.File.Pid, "attrs", reporter.service)
 			}
 		}
 	}

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -141,7 +141,7 @@ func newSvcGraphMetricsReporter(
 		}, mr.newMetricSet)
 
 	// Instantiate the OTLP HTTP or GRPC metrics exporter
-	exporter, err := InstantiateMetricsExporter(ctx, cfg, log)
+	exporter, err := ctxInfo.OTELMetricsExporter.Instantiate(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -7,17 +7,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
-	"net/url"
-	"os"
-	"slices"
-	"strings"
-	"time"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
-	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
-	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
@@ -25,7 +16,6 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/exec"
-	"go.opentelemetry.io/obi/pkg/components/imetrics"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/components/svc"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
@@ -42,272 +32,44 @@ func sglog() *slog.Logger {
 }
 
 const (
-	// SpanMetricsLatency and rest of metrics below haven't been yet moved to the
-	// pkg/internal/export/metric package as we are disabling user-provided attribute
-	// selection for them. They are very specific metrics with an opinionated format
-	// for Span Metrics and Service Graph Metrics functionalities
-	SpanMetricsLatency       = "traces_spanmetrics_latency"
-	SpanMetricsLatencyOTel   = "traces_span_metrics_duration"
-	SpanMetricsCalls         = "traces_spanmetrics_calls_total"
-	SpanMetricsCallsOTel     = "traces_span_metrics_calls_total"
-	SpanMetricsRequestSizes  = "traces_spanmetrics_size_total"
-	SpanMetricsResponseSizes = "traces_spanmetrics_response_size_total"
-	TracesTargetInfo         = "traces_target_info"
-	TargetInfo               = "target_info"
-	TracesHostInfo           = "traces_host_info"
-	ServiceGraphClient       = "traces_service_graph_request_client"
-	ServiceGraphServer       = "traces_service_graph_request_server"
-	ServiceGraphFailed       = "traces_service_graph_request_failed_total"
-	ServiceGraphTotal        = "traces_service_graph_request_total"
-
-	UsualPortGRPC = "4317"
-	UsualPortHTTP = "4318"
-
-	AggregationExplicit    = "explicit_bucket_histogram"
-	AggregationExponential = "base2_exponential_bucket_histogram"
-
-	FeatureNetwork          = "network"
-	FeatureNetworkInterZone = "network_inter_zone"
-	FeatureApplication      = "application"
-	FeatureSpan             = "application_span"
-	FeatureSpanOTel         = "application_span_otel"
-	FeatureSpanSizes        = "application_span_sizes"
-	FeatureGraph            = "application_service_graph"
-	FeatureProcess          = "application_process"
-	FeatureApplicationHost  = "application_host"
-	FeatureEBPF             = "ebpf"
+	ServiceGraphClient = "traces_service_graph_request_client"
+	ServiceGraphServer = "traces_service_graph_request_server"
+	ServiceGraphFailed = "traces_service_graph_request_failed_total"
+	ServiceGraphTotal  = "traces_service_graph_request_total"
 )
-
-// GrafanaHostIDKey is the same attribute Key as HostIDKey, but used for
-// traces_target_info
-const GrafanaHostIDKey = attribute.Key("grafana.host.id")
-
-// MetricTypes contains all the supported metric type prefixes used for filtering attributes
-var MetricTypes = []string{
-	"http.server", "http.client",
-	"rpc.server", "rpc.client",
-	"db.client",
-	"messaging.",
-}
-
-type MetricsConfig struct {
-	Interval time.Duration `yaml:"interval" env:"OTEL_EBPF_METRICS_INTERVAL"`
-	// OTELIntervalMS supports metric intervals as specified by the standard OTEL definition.
-	// OTEL_EBPF_METRICS_INTERVAL takes precedence over it.
-	OTELIntervalMS int `env:"OTEL_METRIC_EXPORT_INTERVAL"`
-
-	CommonEndpoint  string `yaml:"-" env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
-	MetricsEndpoint string `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
-
-	Protocol        Protocol `yaml:"protocol" env:"OTEL_EXPORTER_OTLP_PROTOCOL"`
-	MetricsProtocol Protocol `yaml:"-" env:"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"`
-
-	// InsecureSkipVerify is not standard, so we don't follow the same naming convention
-	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"OTEL_EBPF_INSECURE_SKIP_VERIFY"`
-
-	Buckets              Buckets `yaml:"buckets"`
-	HistogramAggregation string  `yaml:"histogram_aggregation" env:"OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION"`
-
-	ReportersCacheLen int `yaml:"reporters_cache_len" env:"OTEL_EBPF_METRICS_REPORT_CACHE_LEN"`
-
-	// SDKLogLevel works independently from the global LogLevel because it prints GBs of logs in Debug mode
-	// and the Info messages leak internal details that are not usually valuable for the final user.
-	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL"`
-
-	// Features of metrics that are can be exported. Accepted values are "application" and "network".
-	// envDefault is provided to avoid breaking changes
-	Features []string `yaml:"features" env:"OTEL_EBPF_METRICS_FEATURES,expand" envDefault:"${OTEL_EBPF_METRIC_FEATURES}"  envSeparator:","`
-
-	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
-	Instrumentations []string `yaml:"instrumentations" env:"OTEL_EBPF_METRICS_INSTRUMENTATIONS" envSeparator:","`
-
-	// TTL is the time since a metric was updated for the last time until it is
-	// removed from the metrics set.
-	TTL time.Duration `yaml:"ttl" env:"OTEL_EBPF_METRICS_TTL"`
-
-	AllowServiceGraphSelfReferences bool `yaml:"allow_service_graph_self_references" env:"OTEL_EBPF_ALLOW_SERVICE_GRAPH_SELF_REFERENCES"`
-
-	// OTLPEndpointProvider allows overriding the OTLP Endpoint. It needs to return an endpoint and
-	// a boolean indicating if the endpoint is common for both traces and metrics
-	OTLPEndpointProvider func() (string, bool) `yaml:"-" env:"-"`
-
-	// InjectHeaders allows injecting custom headers to the HTTP OTLP exporter
-	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
-}
-
-func (m MetricsConfig) MarshalYAML() (any, error) {
-	omit := map[string]struct{}{
-		"endpoint": {},
-	}
-	return omitFieldsForYAML(m, omit), nil
-}
-
-func (m *MetricsConfig) GetProtocol() Protocol {
-	if m.MetricsProtocol != "" {
-		return m.MetricsProtocol
-	}
-	if m.Protocol != "" {
-		return m.Protocol
-	}
-	return m.GuessProtocol()
-}
-
-func (m *MetricsConfig) GetInterval() time.Duration {
-	if m.Interval == 0 {
-		return time.Duration(m.OTELIntervalMS) * time.Millisecond
-	}
-	return m.Interval
-}
-
-func (m *MetricsConfig) GuessProtocol() Protocol {
-	// If no explicit protocol is set, we guess it it from the metrics endpoint port
-	// (assuming it uses a standard port or a development-like form like 14317, 24317, 14318...)
-	ep, _, err := parseMetricsEndpoint(m)
-	if err == nil {
-		if strings.HasSuffix(ep.Port(), UsualPortGRPC) {
-			return ProtocolGRPC
-		} else if strings.HasSuffix(ep.Port(), UsualPortHTTP) {
-			return ProtocolHTTPProtobuf
-		}
-	}
-	// Otherwise we return default protocol according to the latest specification:
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md?plain=1#L53
-	return ProtocolHTTPProtobuf
-}
-
-func (m *MetricsConfig) OTLPMetricsEndpoint() (string, bool) {
-	if m.OTLPEndpointProvider != nil {
-		return m.OTLPEndpointProvider()
-	}
-	return ResolveOTLPEndpoint(m.MetricsEndpoint, m.CommonEndpoint)
-}
-
-// EndpointEnabled specifies that the OTEL metrics node is enabled if and only if
-// either the OTEL endpoint and OTEL metrics endpoint is defined.
-// If not enabled, this node won't be instantiated
-// Reason to disable linting: it requires to be a value despite it is considered a "heavy struct".
-// This method is invoked only once during startup time so it doesn't have a noticeable performance impact.
-func (m *MetricsConfig) EndpointEnabled() bool {
-	ep, _ := m.OTLPMetricsEndpoint()
-	return ep != ""
-}
-
-func (m *MetricsConfig) AnySpanMetricsEnabled() bool {
-	return m.SpanMetricsEnabled() || m.ServiceGraphMetricsEnabled() || m.SpanMetricsSizesEnabled()
-}
-
-func (m *MetricsConfig) SpanMetricsSizesEnabled() bool {
-	return slices.Contains(m.Features, FeatureSpanSizes)
-}
-
-func (m *MetricsConfig) SpanMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureSpan) || slices.Contains(m.Features, FeatureSpanOTel)
-}
-
-func (m *MetricsConfig) InvalidSpanMetricsConfig() bool {
-	return slices.Contains(m.Features, FeatureSpan) && slices.Contains(m.Features, FeatureSpanOTel)
-}
-
-func (m *MetricsConfig) HostMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureApplicationHost)
-}
-
-func (m *MetricsConfig) ServiceGraphMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureGraph)
-}
-
-func (m *MetricsConfig) OTelMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureApplication)
-}
-
-func (m *MetricsConfig) NetworkMetricsEnabled() bool {
-	return m.NetworkFlowBytesEnabled() || m.NetworkInterzoneMetricsEnabled()
-}
-
-func (m *MetricsConfig) NetworkFlowBytesEnabled() bool {
-	return slices.Contains(m.Features, FeatureNetwork)
-}
-
-func (m *MetricsConfig) NetworkInterzoneMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureNetworkInterZone)
-}
-
-func (m *MetricsConfig) Enabled() bool {
-	return m.EndpointEnabled() && (m.OTelMetricsEnabled() || m.AnySpanMetricsEnabled() || m.NetworkMetricsEnabled())
-}
 
 // MetricsReporter implements the graph node that receives request.Span
 // instances and forwards them as OTEL metrics.
-type MetricsReporter struct {
+type SvcGraphMetricsReporter struct {
 	ctx        context.Context
 	cfg        *MetricsConfig
 	hostID     string
 	attributes *attributes.AttrSelector
 	exporter   sdkmetric.Exporter
-	reporters  ReporterPool[*svc.Attrs, *Metrics]
+	reporters  ReporterPool[*svc.Attrs, *SvcGraphMetrics]
 	pidTracker PidServiceTracker
 	is         instrumentations.InstrumentationSelection
 
-	// user-selected fields for each of the reported metrics
-	attrHTTPDuration           []attributes.Field[*request.Span, attribute.KeyValue]
-	attrHTTPClientDuration     []attributes.Field[*request.Span, attribute.KeyValue]
-	attrGRPCServer             []attributes.Field[*request.Span, attribute.KeyValue]
-	attrGRPCClient             []attributes.Field[*request.Span, attribute.KeyValue]
-	attrDBClient               []attributes.Field[*request.Span, attribute.KeyValue]
-	attrMessagingPublish       []attributes.Field[*request.Span, attribute.KeyValue]
-	attrMessagingProcess       []attributes.Field[*request.Span, attribute.KeyValue]
-	attrHTTPRequestSize        []attributes.Field[*request.Span, attribute.KeyValue]
-	attrHTTPResponseSize       []attributes.Field[*request.Span, attribute.KeyValue]
-	attrHTTPClientRequestSize  []attributes.Field[*request.Span, attribute.KeyValue]
-	attrHTTPClientResponseSize []attributes.Field[*request.Span, attribute.KeyValue]
-	attrGPUKernelCalls         []attributes.Field[*request.Span, attribute.KeyValue]
-	attrGPUKernelGridSize      []attributes.Field[*request.Span, attribute.KeyValue]
-	attrGPUKernelBlockSize     []attributes.Field[*request.Span, attribute.KeyValue]
-	attrGPUMemoryAllocations   []attributes.Field[*request.Span, attribute.KeyValue]
-	userAttribSelection        attributes.Selection
-	input                      <-chan []request.Span
-	processEvents              <-chan exec.ProcessEvent
+	input         <-chan []request.Span
+	processEvents <-chan exec.ProcessEvent
 }
 
 // Metrics is a set of metrics associated to a given OTEL MeterProvider.
 // There is a Metrics instance for each service/process instrumented by OBI.
-type Metrics struct {
+type SvcGraphMetrics struct {
 	ctx                      context.Context
 	service                  *svc.Attrs
 	provider                 *metric.MeterProvider
 	resourceAttributes       []attribute.KeyValue
 	tracesResourceAttributes attribute.Set
 
-	// IMPORTANT! Don't forget to clean each Expirer in cleanupAllMetricsInstances method
-	httpDuration           *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	httpClientDuration     *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	grpcDuration           *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	grpcClientDuration     *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	dbClientDuration       *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	msgPublishDuration     *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	msgProcessDuration     *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	httpRequestSize        *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	httpResponseSize       *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	httpClientRequestSize  *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	httpClientResponseSize *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	// trace span metrics
-	spanMetricsLatency           *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	spanMetricsCallsTotal        *Expirer[*request.Span, instrument.Int64Counter, int64]
-	spanMetricsRequestSizeTotal  *Expirer[*request.Span, instrument.Float64Counter, float64]
-	spanMetricsResponseSizeTotal *Expirer[*request.Span, instrument.Float64Counter, float64]
-	serviceGraphClient           *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	serviceGraphServer           *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	serviceGraphFailed           *Expirer[*request.Span, instrument.Int64Counter, int64]
-	serviceGraphTotal            *Expirer[*request.Span, instrument.Int64Counter, int64]
-	targetInfo                   instrument.Int64UpDownCounter
-	tracesTargetInfo             instrument.Int64UpDownCounter
-	gpuKernelCallsTotal          *Expirer[*request.Span, instrument.Int64Counter, int64]
-	gpuMemoryAllocsTotal         *Expirer[*request.Span, instrument.Int64Counter, int64]
-	gpuKernelGridSize            *Expirer[*request.Span, instrument.Float64Histogram, float64]
-	gpuKernelBlockSize           *Expirer[*request.Span, instrument.Float64Histogram, float64]
+	serviceGraphClient *Expirer[*request.Span, instrument.Float64Histogram, float64]
+	serviceGraphServer *Expirer[*request.Span, instrument.Float64Histogram, float64]
+	serviceGraphFailed *Expirer[*request.Span, instrument.Int64Counter, int64]
+	serviceGraphTotal  *Expirer[*request.Span, instrument.Int64Counter, int64]
 }
 
-func ReportMetrics(
+func ReportSvcGraphMetrics(
 	ctxInfo *global.ContextInfo,
 	cfg *MetricsConfig,
 	selectorCfg *attributes.SelectorConfig,
@@ -315,12 +77,12 @@ func ReportMetrics(
 	processEventCh *msg.Queue[exec.ProcessEvent],
 ) swarm.InstanceFunc {
 	return func(ctx context.Context) (swarm.RunFunc, error) {
-		if !cfg.Enabled() {
+		if !cfg.EndpointEnabled() || !cfg.ServiceGraphMetricsEnabled() {
 			return swarm.EmptyRunFunc()
 		}
 		SetupInternalOTELSDKLogger(cfg.SDKLogLevel)
 
-		mr, err := newMetricsReporter(
+		mr, err := newSvcGraphMetricsReporter(
 			ctx,
 			ctxInfo,
 			cfg,
@@ -332,27 +94,18 @@ func ReportMetrics(
 			return nil, fmt.Errorf("instantiating OTEL metrics reporter: %w", err)
 		}
 
-		if mr.cfg.HostMetricsEnabled() {
-			hostMetrics := mr.newMetricsInstance(nil)
-			hostMeter := hostMetrics.provider.Meter(reporterName)
-			err := mr.setupHostInfoMeter(hostMeter)
-			if err != nil {
-				return nil, fmt.Errorf("setting up host metrics: %w", err)
-			}
-		}
-
 		return mr.reportMetrics, nil
 	}
 }
 
-func newMetricsReporter(
+func newSvcGraphMetricsReporter(
 	ctx context.Context,
 	ctxInfo *global.ContextInfo,
 	cfg *MetricsConfig,
 	selectorCfg *attributes.SelectorConfig,
 	input *msg.Queue[[]request.Span],
 	processEventCh *msg.Queue[exec.ProcessEvent],
-) (*MetricsReporter, error) {
+) (*SvcGraphMetricsReporter, error) {
 	log := sglog()
 
 	attribProvider, err := attributes.NewAttrSelector(ctxInfo.MetricAttributeGroups, selectorCfg)
@@ -362,73 +115,21 @@ func newMetricsReporter(
 
 	is := instrumentations.NewInstrumentationSelection(cfg.Instrumentations)
 
-	mr := MetricsReporter{
-		ctx:                 ctx,
-		cfg:                 cfg,
-		is:                  is,
-		attributes:          attribProvider,
-		hostID:              ctxInfo.HostID,
-		input:               input.Subscribe(),
-		processEvents:       processEventCh.Subscribe(),
-		userAttribSelection: selectorCfg.SelectionCfg,
+	mr := SvcGraphMetricsReporter{
+		ctx:           ctx,
+		cfg:           cfg,
+		is:            is,
+		attributes:    attribProvider,
+		hostID:        ctxInfo.HostID,
+		input:         input.Subscribe(),
+		processEvents: processEventCh.Subscribe(),
 	}
 
-	// initialize attribute getters
-	if is.HTTPEnabled() {
-		mr.attrHTTPDuration = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.HTTPServerDuration))
-		mr.attrHTTPClientDuration = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.HTTPClientDuration))
-		mr.attrHTTPRequestSize = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.HTTPServerRequestSize))
-		mr.attrHTTPResponseSize = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.HTTPServerResponseSize))
-		mr.attrHTTPClientRequestSize = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.HTTPClientRequestSize))
-		mr.attrHTTPClientResponseSize = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.HTTPClientResponseSize))
-	}
-
-	if is.GRPCEnabled() {
-		mr.attrGRPCServer = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.RPCServerDuration))
-		mr.attrGRPCClient = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.RPCClientDuration))
-	}
-
-	if is.DBEnabled() {
-		mr.attrDBClient = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.DBClientDuration))
-	}
-
-	if is.MQEnabled() {
-		mr.attrMessagingPublish = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.MessagingPublishDuration))
-		mr.attrMessagingProcess = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.MessagingProcessDuration))
-	}
-
-	if is.GPUEnabled() {
-		mr.attrGPUKernelCalls = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.GPUKernelLaunchCalls))
-		mr.attrGPUMemoryAllocations = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.GPUMemoryAllocations))
-		mr.attrGPUKernelGridSize = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.GPUKernelGridSize))
-		mr.attrGPUKernelBlockSize = attributes.OpenTelemetryGetters(
-			request.SpanOTELGetters, mr.attributes.For(attributes.GPUKernelBlockSize))
-	}
-
-	mr.reporters = NewReporterPool[*svc.Attrs, *Metrics](cfg.ReportersCacheLen, cfg.TTL, timeNow,
-		func(id svc.UID, v *Metrics) {
+	mr.reporters = NewReporterPool[*svc.Attrs, *SvcGraphMetrics](cfg.ReportersCacheLen, cfg.TTL, timeNow,
+		func(id svc.UID, v *SvcGraphMetrics) {
 			llog := log.With("service", id)
 			llog.Debug("evicting metrics reporter from cache")
 			v.cleanupAllMetricsInstances()
-
-			if !mr.pidTracker.ServiceLive(id) {
-				mr.deleteTracesTargetInfo(v)
-				mr.deleteTargetInfo(v)
-			}
 
 			go func() {
 				if err := v.provider.ForceFlush(ctx); err != nil {
@@ -436,6 +137,7 @@ func newMetricsReporter(
 				}
 			}()
 		}, mr.newMetricSet)
+
 	// Instantiate the OTLP HTTP or GRPC metrics exporter
 	exporter, err := InstantiateMetricsExporter(ctx, cfg, log)
 	if err != nil {
@@ -448,73 +150,7 @@ func newMetricsReporter(
 	return &mr, nil
 }
 
-func (mr *MetricsReporter) otelMetricOptions(sglog *slog.Logger) []metric.Option {
-	var opts []metric.Option
-	if !mr.cfg.OTelMetricsEnabled() {
-		return opts
-	}
-
-	useExponentialHistograms := isExponentialAggregation(mr.cfg, sglog)
-
-	if mr.is.HTTPEnabled() {
-		opts = append(opts,
-			metric.WithView(otelHistogramConfig(attributes.HTTPServerDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.HTTPClientDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.HTTPServerRequestSize.OTEL, mr.cfg.Buckets.RequestSizeHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.HTTPServerResponseSize.OTEL, mr.cfg.Buckets.ResponseSizeHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.HTTPClientRequestSize.OTEL, mr.cfg.Buckets.RequestSizeHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.HTTPClientResponseSize.OTEL, mr.cfg.Buckets.ResponseSizeHistogram, useExponentialHistograms)),
-		)
-	}
-
-	if mr.is.GRPCEnabled() {
-		opts = append(opts,
-			metric.WithView(otelHistogramConfig(attributes.RPCServerDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.RPCClientDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-		)
-	}
-
-	if mr.is.DBEnabled() {
-		opts = append(opts,
-			metric.WithView(otelHistogramConfig(attributes.DBClientDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-		)
-	}
-
-	if mr.is.MQEnabled() {
-		opts = append(opts,
-			metric.WithView(otelHistogramConfig(attributes.MessagingPublishDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.MessagingProcessDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-		)
-	}
-
-	return opts
-}
-
-func (mr *MetricsReporter) usesLegacySpanNames() bool {
-	return slices.Contains(mr.cfg.Features, FeatureSpan)
-}
-
-func (mr *MetricsReporter) spanMetricsLatencyName() string {
-	if mr.usesLegacySpanNames() {
-		return SpanMetricsLatency
-	}
-
-	return SpanMetricsLatencyOTel
-}
-
-func (mr *MetricsReporter) spanMetricOptions(sglog *slog.Logger) []metric.Option {
-	if !mr.cfg.SpanMetricsEnabled() {
-		return []metric.Option{}
-	}
-
-	useExponentialHistograms := isExponentialAggregation(mr.cfg, sglog)
-
-	return []metric.Option{
-		metric.WithView(otelHistogramConfig(mr.spanMetricsLatencyName(), mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-	}
-}
-
-func (mr *MetricsReporter) graphMetricOptions(sglog *slog.Logger) []metric.Option {
+func (mr *SvcGraphMetricsReporter) graphMetricOptions(sglog *slog.Logger) []metric.Option {
 	if !mr.cfg.ServiceGraphMetricsEnabled() {
 		return []metric.Option{}
 	}
@@ -527,229 +163,7 @@ func (mr *MetricsReporter) graphMetricOptions(sglog *slog.Logger) []metric.Optio
 	}
 }
 
-func (mr *MetricsReporter) setupTargetInfo(m *Metrics, meter instrument.Meter) error {
-	var err error
-	m.targetInfo, err = meter.Int64UpDownCounter(TargetInfo, instrument.WithDescription("Target metadata"))
-	if err != nil {
-		return fmt.Errorf("creating target info: %w", err)
-	}
-
-	return nil
-}
-
-// nolint: cyclop
-func (mr *MetricsReporter) setupOtelMeters(m *Metrics, meter instrument.Meter) error {
-	if !mr.cfg.OTelMetricsEnabled() {
-		return nil
-	}
-
-	if mr.is.HTTPEnabled() {
-		httpDuration, err := meter.Float64Histogram(attributes.HTTPServerDuration.OTEL, instrument.WithUnit("s"))
-		if err != nil {
-			return fmt.Errorf("creating http duration histogram metric: %w", err)
-		}
-		m.httpDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, httpDuration, mr.attrHTTPDuration, timeNow, mr.cfg.TTL)
-
-		httpClientDuration, err := meter.Float64Histogram(attributes.HTTPClientDuration.OTEL, instrument.WithUnit("s"))
-		if err != nil {
-			return fmt.Errorf("creating http duration histogram metric: %w", err)
-		}
-		m.httpClientDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, httpClientDuration, mr.attrHTTPClientDuration, timeNow, mr.cfg.TTL)
-
-		httpRequestSize, err := meter.Float64Histogram(attributes.HTTPServerRequestSize.OTEL, instrument.WithUnit("By"))
-		if err != nil {
-			return fmt.Errorf("creating http request size histogram metric: %w", err)
-		}
-		m.httpRequestSize = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, httpRequestSize, mr.attrHTTPRequestSize, timeNow, mr.cfg.TTL)
-
-		httpResponseSize, err := meter.Float64Histogram(attributes.HTTPServerResponseSize.OTEL, instrument.WithUnit("By"))
-		if err != nil {
-			return fmt.Errorf("creating http response size histogram metric: %w", err)
-		}
-		m.httpResponseSize = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, httpResponseSize, mr.attrHTTPResponseSize, timeNow, mr.cfg.TTL)
-
-		httpClientRequestSize, err := meter.Float64Histogram(attributes.HTTPClientRequestSize.OTEL, instrument.WithUnit("By"))
-		if err != nil {
-			return fmt.Errorf("creating http client request size histogram metric: %w", err)
-		}
-		m.httpClientRequestSize = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, httpClientRequestSize, mr.attrHTTPClientRequestSize, timeNow, mr.cfg.TTL)
-
-		httpClientResponseSize, err := meter.Float64Histogram(attributes.HTTPClientResponseSize.OTEL, instrument.WithUnit("By"))
-		if err != nil {
-			return fmt.Errorf("creating http client response size histogram metric: %w", err)
-		}
-		m.httpClientResponseSize = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, httpClientResponseSize, mr.attrHTTPClientResponseSize, timeNow, mr.cfg.TTL)
-	}
-
-	if mr.is.GRPCEnabled() {
-		grpcDuration, err := meter.Float64Histogram(attributes.RPCServerDuration.OTEL, instrument.WithUnit("s"))
-		if err != nil {
-			return fmt.Errorf("creating grpc duration histogram metric: %w", err)
-		}
-		m.grpcDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, grpcDuration, mr.attrGRPCServer, timeNow, mr.cfg.TTL)
-
-		grpcClientDuration, err := meter.Float64Histogram(attributes.RPCClientDuration.OTEL, instrument.WithUnit("s"))
-		if err != nil {
-			return fmt.Errorf("creating grpc duration histogram metric: %w", err)
-		}
-		m.grpcClientDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, grpcClientDuration, mr.attrGRPCClient, timeNow, mr.cfg.TTL)
-	}
-
-	if mr.is.DBEnabled() {
-		dbClientDuration, err := meter.Float64Histogram(attributes.DBClientDuration.OTEL, instrument.WithUnit("s"))
-		if err != nil {
-			return fmt.Errorf("creating db client duration histogram metric: %w", err)
-		}
-		m.dbClientDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, dbClientDuration, mr.attrDBClient, timeNow, mr.cfg.TTL)
-	}
-
-	if mr.is.MQEnabled() {
-		msgPublishDuration, err := meter.Float64Histogram(attributes.MessagingPublishDuration.OTEL, instrument.WithUnit("s"))
-		if err != nil {
-			return fmt.Errorf("creating messaging client publish duration histogram metric: %w", err)
-		}
-		m.msgPublishDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, msgPublishDuration, mr.attrMessagingPublish, timeNow, mr.cfg.TTL)
-
-		msgProcessDuration, err := meter.Float64Histogram(attributes.MessagingProcessDuration.OTEL, instrument.WithUnit("s"))
-		if err != nil {
-			return fmt.Errorf("creating messaging client process duration histogram metric: %w", err)
-		}
-		m.msgProcessDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, msgProcessDuration, mr.attrMessagingProcess, timeNow, mr.cfg.TTL)
-	}
-
-	if mr.is.GPUEnabled() {
-		gpuKernelCallsTotal, err := meter.Int64Counter(attributes.GPUKernelLaunchCalls.OTEL)
-		if err != nil {
-			return fmt.Errorf("creating gpu kernel calls total: %w", err)
-		}
-		m.gpuKernelCallsTotal = NewExpirer[*request.Span, instrument.Int64Counter, int64](
-			m.ctx, gpuKernelCallsTotal, mr.attrGPUKernelCalls, timeNow, mr.cfg.TTL)
-
-		gpuMemoryAllocationsTotal, err := meter.Int64Counter(attributes.GPUMemoryAllocations.OTEL, instrument.WithUnit("By"))
-		if err != nil {
-			return fmt.Errorf("creating gpu memory allocations total: %w", err)
-		}
-		m.gpuMemoryAllocsTotal = NewExpirer[*request.Span, instrument.Int64Counter, int64](
-			m.ctx, gpuMemoryAllocationsTotal, mr.attrGPUMemoryAllocations, timeNow, mr.cfg.TTL)
-
-		gpuKernelGridSize, err := meter.Float64Histogram(attributes.GPUKernelGridSize.OTEL, instrument.WithUnit("1"))
-		if err != nil {
-			return fmt.Errorf("creating gpu kernel grid size histogram: %w", err)
-		}
-		m.gpuKernelGridSize = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, gpuKernelGridSize, mr.attrGPUKernelGridSize, timeNow, mr.cfg.TTL)
-
-		gpuKernelBlockSize, err := meter.Float64Histogram(attributes.GPUKernelBlockSize.OTEL, instrument.WithUnit("1"))
-		if err != nil {
-			return fmt.Errorf("creating gpu kernel block size histogram: %w", err)
-		}
-		m.gpuKernelBlockSize = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-			m.ctx, gpuKernelBlockSize, mr.attrGPUKernelBlockSize, timeNow, mr.cfg.TTL)
-	}
-
-	return nil
-}
-
-func (mr *MetricsReporter) spanMetricsCallsName() string {
-	if mr.usesLegacySpanNames() {
-		return SpanMetricsCalls
-	}
-
-	return SpanMetricsCallsOTel
-}
-
-func (mr *MetricsReporter) setupSpanSizeMeters(m *Metrics, meter instrument.Meter) error {
-	if !mr.cfg.SpanMetricsSizesEnabled() {
-		return nil
-	}
-
-	var err error
-
-	spanMetricAttrs := mr.spanMetricAttributes()
-
-	spanMetricsRequestSizeTotal, err := meter.Float64Counter(SpanMetricsRequestSizes)
-	if err != nil {
-		return fmt.Errorf("creating span metric request size total: %w", err)
-	}
-	m.spanMetricsRequestSizeTotal = NewExpirer[*request.Span, instrument.Float64Counter, float64](
-		m.ctx, spanMetricsRequestSizeTotal, spanMetricAttrs, timeNow, mr.cfg.TTL)
-
-	spanMetricsResponseSizeTotal, err := meter.Float64Counter(SpanMetricsResponseSizes)
-	if err != nil {
-		return fmt.Errorf("creating span metric response size total: %w", err)
-	}
-	m.spanMetricsResponseSizeTotal = NewExpirer[*request.Span, instrument.Float64Counter, float64](
-		m.ctx, spanMetricsResponseSizeTotal, spanMetricAttrs, timeNow, mr.cfg.TTL)
-
-	return nil
-}
-
-func (mr *MetricsReporter) setupTracesTargetInfo(m *Metrics, meter instrument.Meter) error {
-	var err error
-
-	m.tracesTargetInfo, err = meter.Int64UpDownCounter(TracesTargetInfo)
-	if err != nil {
-		return fmt.Errorf("creating span metric traces target info: %w", err)
-	}
-
-	return nil
-}
-
-func (mr *MetricsReporter) setupSpanMeters(m *Metrics, meter instrument.Meter) error {
-	if !mr.cfg.SpanMetricsEnabled() {
-		return nil
-	}
-
-	var err error
-
-	spanMetricAttrs := mr.spanMetricAttributes()
-
-	instrumentOpts := []instrument.Float64HistogramOption{}
-
-	if !mr.usesLegacySpanNames() {
-		instrumentOpts = append(instrumentOpts, instrument.WithUnit("s"))
-	}
-
-	spanMetricsLatency, err := meter.Float64Histogram(mr.spanMetricsLatencyName(), instrumentOpts...)
-	if err != nil {
-		return fmt.Errorf("creating span metric histogram for latency: %w", err)
-	}
-	m.spanMetricsLatency = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-		m.ctx, spanMetricsLatency, spanMetricAttrs, timeNow, mr.cfg.TTL)
-
-	spanMetricsCallsTotal, err := meter.Int64Counter(mr.spanMetricsCallsName())
-	if err != nil {
-		return fmt.Errorf("creating span metric calls total: %w", err)
-	}
-	m.spanMetricsCallsTotal = NewExpirer[*request.Span, instrument.Int64Counter, int64](
-		m.ctx, spanMetricsCallsTotal, spanMetricAttrs, timeNow, mr.cfg.TTL)
-
-	return nil
-}
-
-func (mr *MetricsReporter) setupHostInfoMeter(meter instrument.Meter) error {
-	tracesHostInfo, err := meter.Int64Gauge(TracesHostInfo)
-	if err != nil {
-		return fmt.Errorf("creating span metric traces host info: %w", err)
-	}
-	attrOpt := instrument.WithAttributeSet(mr.metricHostAttributes())
-	tracesHostInfo.Record(mr.ctx, 1, attrOpt)
-
-	return nil
-}
-
-func (mr *MetricsReporter) setupGraphMeters(m *Metrics, meter instrument.Meter) error {
+func (mr *SvcGraphMetricsReporter) setupGraphMeters(m *SvcGraphMetrics, meter instrument.Meter) error {
 	if !mr.cfg.ServiceGraphMetricsEnabled() {
 		return nil
 	}
@@ -789,7 +203,7 @@ func (mr *MetricsReporter) setupGraphMeters(m *Metrics, meter instrument.Meter) 
 	return nil
 }
 
-func (mr *MetricsReporter) newMetricsInstance(service *svc.Attrs) Metrics {
+func (mr *SvcGraphMetricsReporter) newSvcGraphMetricsInstance(service *svc.Attrs) SvcGraphMetrics {
 	sglog := sglog()
 	var resourceAttributes []attribute.KeyValue
 	if service != nil {
@@ -805,11 +219,9 @@ func (mr *MetricsReporter) newMetricsInstance(service *svc.Attrs) Metrics {
 			metric.WithInterval(mr.cfg.Interval))),
 	}
 
-	opts = append(opts, mr.otelMetricOptions(sglog)...)
-	opts = append(opts, mr.spanMetricOptions(sglog)...)
 	opts = append(opts, mr.graphMetricOptions(sglog)...)
 
-	return Metrics{
+	return SvcGraphMetrics{
 		ctx:                      mr.ctx,
 		service:                  service,
 		resourceAttributes:       resourceAttributes,
@@ -820,8 +232,8 @@ func (mr *MetricsReporter) newMetricsInstance(service *svc.Attrs) Metrics {
 	}
 }
 
-func (mr *MetricsReporter) newMetricSet(service *svc.Attrs) (*Metrics, error) {
-	m := mr.newMetricsInstance(service)
+func (mr *SvcGraphMetricsReporter) newMetricSet(service *svc.Attrs) (*SvcGraphMetrics, error) {
+	m := mr.newSvcGraphMetricsInstance(service)
 
 	sglog().Debug("creating new metric set", "service", service)
 	// time units for HTTP and GRPC durations are in seconds, according to the OTEL specification:
@@ -829,39 +241,6 @@ func (mr *MetricsReporter) newMetricSet(service *svc.Attrs) (*Metrics, error) {
 	// TODO: set ExplicitBucketBoundaries here and in prometheus from the previous specification
 	meter := m.provider.Meter(reporterName)
 	var err error
-
-	// Target info is created for every type of OTel metrics
-	if err = mr.setupTargetInfo(&m, meter); err != nil {
-		return nil, err
-	}
-
-	if mr.cfg.OTelMetricsEnabled() {
-		err = mr.setupOtelMeters(&m, meter)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if mr.cfg.AnySpanMetricsEnabled() {
-		err = mr.setupTracesTargetInfo(&m, meter)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if mr.cfg.SpanMetricsEnabled() {
-		err = mr.setupSpanMeters(&m, meter)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if mr.cfg.SpanMetricsSizesEnabled() {
-		err = mr.setupSpanSizeMeters(&m, meter)
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	if mr.cfg.ServiceGraphMetricsEnabled() {
 		err = mr.setupGraphMeters(&m, meter)
@@ -873,114 +252,13 @@ func (mr *MetricsReporter) newMetricSet(service *svc.Attrs) (*Metrics, error) {
 	return &m, nil
 }
 
-func isExponentialAggregation(mc *MetricsConfig, sglog *slog.Logger) bool {
-	switch mc.HistogramAggregation {
-	case AggregationExponential:
-		return true
-	case AggregationExplicit:
-	// do nothing
-	default:
-		sglog.Warn("invalid value for histogram aggregation. Accepted values are: "+
-			AggregationExponential+", "+AggregationExplicit+" (default). Using default",
-			"value", mc.HistogramAggregation)
-	}
-	return false
-}
-
-func InstantiateMetricsExporter(ctx context.Context, cfg *MetricsConfig, log *slog.Logger) (sdkmetric.Exporter, error) {
-	var err error
-	var exporter sdkmetric.Exporter
-	switch proto := cfg.GetProtocol(); proto {
-	case ProtocolHTTPJSON, ProtocolHTTPProtobuf, "": // zero value defaults to HTTP for backwards-compatibility
-		log.Debug("instantiating HTTP MetricsReporter", "protocol", proto)
-		if exporter, err = httpMetricsExporter(ctx, cfg); err != nil {
-			return nil, fmt.Errorf("can't instantiate OTEL HTTP metrics exporter: %w", err)
-		}
-	case ProtocolGRPC:
-		log.Debug("instantiating GRPC MetricsReporter", "protocol", proto)
-		if exporter, err = grpcMetricsExporter(ctx, cfg); err != nil {
-			return nil, fmt.Errorf("can't instantiate OTEL GRPC metrics exporter: %w", err)
-		}
-	default:
-		return nil, fmt.Errorf("invalid protocol value: %q. Accepted values are: %s, %s, %s",
-			proto, ProtocolGRPC, ProtocolHTTPJSON, ProtocolHTTPProtobuf)
-	}
-	return exporter, nil
-}
-
-func httpMetricsExporter(ctx context.Context, cfg *MetricsConfig) (sdkmetric.Exporter, error) {
-	opts, err := getHTTPMetricEndpointOptions(cfg)
-	if err != nil {
-		return nil, err
-	}
-	mexp, err := otlpmetrichttp.New(ctx, opts.AsMetricHTTP()...)
-	if err != nil {
-		return nil, fmt.Errorf("creating HTTP metric exporter: %w", err)
-	}
-	return mexp, nil
-}
-
-func grpcMetricsExporter(ctx context.Context, cfg *MetricsConfig) (sdkmetric.Exporter, error) {
-	opts, err := getGRPCMetricEndpointOptions(cfg)
-	if err != nil {
-		return nil, err
-	}
-	mexp, err := otlpmetricgrpc.New(ctx, opts.AsMetricGRPC()...)
-	if err != nil {
-		return nil, fmt.Errorf("creating GRPC metric exporter: %w", err)
-	}
-	return mexp, nil
-}
-
-func (mr *MetricsReporter) close() {
+func (mr *SvcGraphMetricsReporter) close() {
 	if err := mr.exporter.Shutdown(mr.ctx); err != nil {
 		slog.With("component", "MetricsReporter").Error("closing metrics provider", "error", err)
 	}
 }
 
-// instrumentMetricsExporter checks whether the context is configured to report internal metrics and,
-// in this case, wraps the passed metrics exporter inside an instrumented exporter
-func instrumentMetricsExporter(internalMetrics imetrics.Reporter, in sdkmetric.Exporter) sdkmetric.Exporter {
-	// avoid wrapping the instrumented exporter if we don't have
-	// internal instrumentation (NoopReporter)
-	if _, ok := internalMetrics.(imetrics.NoopReporter); ok || internalMetrics == nil {
-		return in
-	}
-	return &instrumentedMetricsExporter{
-		Exporter: in,
-		internal: internalMetrics,
-	}
-}
-
-func otelHistogramConfig(metricName string, buckets []float64, useExponentialHistogram bool) metric.View {
-	if useExponentialHistogram {
-		return metric.NewView(
-			metric.Instrument{
-				Name:  metricName,
-				Scope: instrumentation.Scope{Name: reporterName},
-			},
-			metric.Stream{
-				Name: metricName,
-				Aggregation: sdkmetric.AggregationBase2ExponentialHistogram{
-					MaxScale: 20,
-					MaxSize:  160,
-				},
-			})
-	}
-	return metric.NewView(
-		metric.Instrument{
-			Name:  metricName,
-			Scope: instrumentation.Scope{Name: reporterName},
-		},
-		metric.Stream{
-			Name: metricName,
-			Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				Boundaries: buckets,
-			},
-		})
-}
-
-func (mr *MetricsReporter) tracesResourceAttributes(service *svc.Attrs) attribute.Set {
+func (mr *SvcGraphMetricsReporter) tracesResourceAttributes(service *svc.Attrs) attribute.Set {
 	if service == nil {
 		return *attribute.EmptySet()
 	}
@@ -1002,11 +280,11 @@ func (mr *MetricsReporter) tracesResourceAttributes(service *svc.Attrs) attribut
 		extraAttrs = append(extraAttrs, k.OTEL().String(v))
 	}
 
-	filteredAttrs := getFilteredMetricResourceAttrs(baseAttrs, mr.userAttribSelection, extraAttrs, MetricTypes)
+	filteredAttrs := getFilteredMetricResourceAttrs(baseAttrs, nil, extraAttrs, MetricTypes)
 	return attribute.NewSet(filteredAttrs...)
 }
 
-func (mr *MetricsReporter) metricHostAttributes() attribute.Set {
+func (mr *SvcGraphMetricsReporter) metricHostAttributes() attribute.Set {
 	attrs := []attribute.KeyValue{
 		GrafanaHostIDKey.String(mr.hostID),
 	}
@@ -1016,7 +294,7 @@ func (mr *MetricsReporter) metricHostAttributes() attribute.Set {
 
 // spanMetricAttributes follow a given specification, so their attribute getters are predefined and can't be
 // selected by the user
-func (mr *MetricsReporter) spanMetricAttributes() []attributes.Field[*request.Span, attribute.KeyValue] {
+func (mr *SvcGraphMetricsReporter) spanMetricAttributes() []attributes.Field[*request.Span, attribute.KeyValue] {
 	return append(attributes.OpenTelemetryGetters(
 		request.SpanOTELGetters, []attr.Name{
 			attr.ServiceName,
@@ -1037,7 +315,7 @@ func (mr *MetricsReporter) spanMetricAttributes() []attributes.Field[*request.Sp
 		})
 }
 
-func (mr *MetricsReporter) serviceGraphAttributes() []attributes.Field[*request.Span, attribute.KeyValue] {
+func (mr *SvcGraphMetricsReporter) serviceGraphAttributes() []attributes.Field[*request.Span, attribute.KeyValue] {
 	return attributes.OpenTelemetryGetters(
 		request.SpanOTELGetters, []attr.Name{
 			attr.Client,
@@ -1048,128 +326,33 @@ func (mr *MetricsReporter) serviceGraphAttributes() []attributes.Field[*request.
 		})
 }
 
-func otelMetricsAccepted(span *request.Span, mr *MetricsReporter) bool {
-	return mr.cfg.OTelMetricsEnabled() && !span.Service.ExportsOTelMetrics()
-}
-
-func otelSpanMetricsAccepted(span *request.Span, mr *MetricsReporter) bool {
-	return mr.cfg.OTelMetricsEnabled() && !span.Service.ExportsOTelMetricsSpan()
-}
-
-//nolint:cyclop
-func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
+func (r *SvcGraphMetrics) record(span *request.Span, mr *SvcGraphMetricsReporter) {
 	t := span.Timings()
 	duration := t.End.Sub(t.RequestStart).Seconds()
 
 	ctx := trace.ContextWithSpanContext(r.ctx, trace.SpanContext{}.WithTraceID(span.TraceID).WithSpanID(span.SpanID).WithTraceFlags(trace.TraceFlags(span.TraceFlags)))
 
-	if otelMetricsAccepted(span, mr) {
-		switch span.Type {
-		case request.EventTypeHTTP:
-			if mr.is.HTTPEnabled() {
-				// TODO: for more accuracy, there must be a way to set the metric time from the actual span end time
-				httpDuration, attrs := r.httpDuration.ForRecord(span)
-				httpDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-
-				httpRequestSize, attrs := r.httpRequestSize.ForRecord(span)
-				httpRequestSize.Record(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
-
-				httpResponseSize, attrs := r.httpResponseSize.ForRecord(span)
-				httpResponseSize.Record(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeGRPC:
-			if mr.is.GRPCEnabled() {
-				grpcDuration, attrs := r.grpcDuration.ForRecord(span)
-				grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeGRPCClient:
-			if mr.is.GRPCEnabled() {
-				grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
-				grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeHTTPClient:
-			if mr.is.HTTPEnabled() {
-				httpClientDuration, attrs := r.httpClientDuration.ForRecord(span)
-				httpClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				httpClientRequestSize, attrs := r.httpClientRequestSize.ForRecord(span)
-				httpClientRequestSize.Record(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
-				httpClientResponseSize, attrs := r.httpClientResponseSize.ForRecord(span)
-				httpClientResponseSize.Record(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeRedisServer, request.EventTypeRedisClient, request.EventTypeSQLClient, request.EventTypeMongoClient:
-			if mr.is.DBEnabled() {
-				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeKafkaClient, request.EventTypeKafkaServer:
-			if mr.is.MQEnabled() {
-				switch span.Method {
-				case request.MessagingPublish:
-					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
-					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				case request.MessagingProcess:
-					msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
-					msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				}
-			}
-		case request.EventTypeGPUKernelLaunch:
-			if mr.is.GPUEnabled() {
-				gcalls, attrs := r.gpuKernelCallsTotal.ForRecord(span)
-				gcalls.Add(ctx, 1, instrument.WithAttributeSet(attrs))
-
-				ggrid, attrs := r.gpuKernelGridSize.ForRecord(span)
-				ggrid.Record(ctx, float64(span.ContentLength), instrument.WithAttributeSet(attrs))
-
-				gblock, attrs := r.gpuKernelBlockSize.ForRecord(span)
-				gblock.Record(ctx, float64(span.SubType), instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeGPUMalloc:
-			if mr.is.GPUEnabled() {
-				gmem, attrs := r.gpuMemoryAllocsTotal.ForRecord(span)
-				gmem.Add(ctx, span.ContentLength, instrument.WithAttributeSet(attrs))
-			}
-		}
-	}
-
-	if otelSpanMetricsAccepted(span, mr) {
-		if mr.cfg.SpanMetricsEnabled() {
-			sml, attrs := r.spanMetricsLatency.ForRecord(span)
-			sml.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-
-			smct, attrs := r.spanMetricsCallsTotal.ForRecord(span)
-			smct.Add(ctx, 1, instrument.WithAttributeSet(attrs))
-		}
-
-		if mr.cfg.SpanMetricsSizesEnabled() {
-			smst, attrs := r.spanMetricsRequestSizeTotal.ForRecord(span)
-			smst.Add(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
-
-			smst, attr := r.spanMetricsResponseSizeTotal.ForRecord(span)
-			smst.Add(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attr))
-		}
-
-		if mr.cfg.ServiceGraphMetricsEnabled() {
-			if !span.IsSelfReferenceSpan() || mr.cfg.AllowServiceGraphSelfReferences {
-				if span.IsClientSpan() {
-					sgc, attrs := r.serviceGraphClient.ForRecord(span)
-					sgc.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-					// If we managed to resolve the remote name only, we check to see
-					// we are not instrumenting the server service, then and only then,
-					// we generate client span count for service graph total
-					if ClientSpanToUninstrumentedService(&mr.pidTracker, span) {
-						sgt, attrs := r.serviceGraphTotal.ForRecord(span)
-						sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
-					}
-				} else {
-					sgs, attrs := r.serviceGraphServer.ForRecord(span)
-					sgs.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+	if mr.cfg.ServiceGraphMetricsEnabled() {
+		if !span.IsSelfReferenceSpan() || mr.cfg.AllowServiceGraphSelfReferences {
+			if span.IsClientSpan() {
+				sgc, attrs := r.serviceGraphClient.ForRecord(span)
+				sgc.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				// If we managed to resolve the remote name only, we check to see
+				// we are not instrumenting the server service, then and only then,
+				// we generate client span count for service graph total
+				if ClientSpanToUninstrumentedService(&mr.pidTracker, span) {
 					sgt, attrs := r.serviceGraphTotal.ForRecord(span)
 					sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 				}
-				if request.SpanStatusCode(span) == request.StatusCodeError {
-					sgf, attrs := r.serviceGraphFailed.ForRecord(span)
-					sgf.Add(ctx, 1, instrument.WithAttributeSet(attrs))
-				}
+			} else {
+				sgs, attrs := r.serviceGraphServer.ForRecord(span)
+				sgs.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				sgt, attrs := r.serviceGraphTotal.ForRecord(span)
+				sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+			}
+			if request.SpanStatusCode(span) == request.StatusCodeError {
+				sgf, attrs := r.serviceGraphFailed.ForRecord(span)
+				sgf.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 			}
 		}
 	}
@@ -1187,45 +370,15 @@ func ClientSpanToUninstrumentedService(tracker *PidServiceTracker, span *request
 	return false
 }
 
-func (mr *MetricsReporter) createTargetInfo(reporter *Metrics) {
-	sglog().Debug("Creating target_info")
-	attrOpt := instrument.WithAttributeSet(attribute.NewSet(reporter.resourceAttributes...))
-	reporter.targetInfo.Add(mr.ctx, 1, attrOpt)
-}
-
-func (mr *MetricsReporter) deleteTargetInfo(reporter *Metrics) {
-	sglog().Debug("Deleting target_info for", "attrs", reporter.resourceAttributes)
-	attrOpt := instrument.WithAttributeSet(attribute.NewSet(reporter.resourceAttributes...))
-	reporter.targetInfo.Remove(mr.ctx, attrOpt)
-}
-
-func (mr *MetricsReporter) createTracesTargetInfo(reporter *Metrics) {
-	if !mr.cfg.AnySpanMetricsEnabled() {
-		return
-	}
-	sglog().Debug("Creating traces_target_info")
-	attrOpt := instrument.WithAttributeSet(reporter.tracesResourceAttributes)
-	reporter.tracesTargetInfo.Add(mr.ctx, 1, attrOpt)
-}
-
-func (mr *MetricsReporter) deleteTracesTargetInfo(reporter *Metrics) {
-	if !mr.cfg.AnySpanMetricsEnabled() {
-		return
-	}
-	sglog().Debug("Deleting traces_target_info for", "attrs", reporter.resourceAttributes)
-	attrOpt := instrument.WithAttributeSet(reporter.tracesResourceAttributes)
-	reporter.tracesTargetInfo.Remove(mr.ctx, attrOpt)
-}
-
-func (mr *MetricsReporter) setupPIDToServiceRelationship(pid int32, uid svc.UID) {
+func (mr *SvcGraphMetricsReporter) setupPIDToServiceRelationship(pid int32, uid svc.UID) {
 	mr.pidTracker.AddPID(pid, uid)
 }
 
-func (mr *MetricsReporter) disassociatePIDFromService(pid int32) (bool, svc.UID) {
+func (mr *SvcGraphMetricsReporter) disassociatePIDFromService(pid int32) (bool, svc.UID) {
 	return mr.pidTracker.RemovePID(pid)
 }
 
-func (mr *MetricsReporter) watchForProcessEvents() {
+func (mr *SvcGraphMetricsReporter) watchForProcessEvents() {
 	for pe := range mr.processEvents {
 		sglog().Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
 
@@ -1239,8 +392,7 @@ func (mr *MetricsReporter) watchForProcessEvents() {
 		}
 
 		if pe.Type == exec.ProcessEventCreated {
-			mr.createTargetInfo(reporter)
-			mr.createTracesTargetInfo(reporter)
+			// TODO: necesitamos est0o?
 			mr.setupPIDToServiceRelationship(pe.File.Pid, pe.File.Service.UID)
 		} else {
 			if deleted, origUID := mr.disassociatePIDFromService(pe.File.Pid); deleted {
@@ -1254,14 +406,12 @@ func (mr *MetricsReporter) watchForProcessEvents() {
 					continue
 				}
 				sglog().Debug("deleting infos for", "pid", pe.File.Pid, "attrs", reporter.service)
-				mr.deleteTracesTargetInfo(reporter)
-				mr.deleteTargetInfo(reporter)
 			}
 		}
 	}
 }
 
-func (mr *MetricsReporter) reportMetrics(_ context.Context) {
+func (mr *SvcGraphMetricsReporter) reportMetrics(_ context.Context) {
 	go mr.watchForProcessEvents()
 	for spans := range mr.input {
 		for i := range spans {
@@ -1288,155 +438,9 @@ func (mr *MetricsReporter) reportMetrics(_ context.Context) {
 	mr.close()
 }
 
-func getHTTPMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
-	opts := otlpOptions{Headers: map[string]string{}}
-	log := sglog().With("transport", "http")
-	murl, isCommon, err := parseMetricsEndpoint(cfg)
-	if err != nil {
-		return opts, err
-	}
-	log.Debug("Configuring exporter",
-		"protocol", cfg.Protocol, "metricsProtocol", cfg.MetricsProtocol, "endpoint", murl.Host)
-
-	setMetricsProtocol(cfg)
-	opts.Endpoint = murl.Host
-	if murl.Scheme == "http" || murl.Scheme == "unix" {
-		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
-		opts.Insecure = true
-	}
-	// If the value is set from the OTEL_EXPORTER_OTLP_ENDPOINT common property, we need to add /v1/metrics to the path
-	// otherwise, we leave the path that is explicitly set by the user
-	opts.URLPath = murl.Path
-	if isCommon {
-		if strings.HasSuffix(opts.URLPath, "/") {
-			opts.URLPath += "v1/metrics"
-		} else {
-			opts.URLPath += "/v1/metrics"
-		}
-	}
-	log.Debug("Specifying path", "path", opts.URLPath)
-
-	if cfg.InsecureSkipVerify {
-		log.Debug("Setting InsecureSkipVerify")
-		opts.SkipTLSVerify = cfg.InsecureSkipVerify
-	}
-
-	if cfg.InjectHeaders != nil {
-		cfg.InjectHeaders(opts.Headers)
-	}
-	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
-	maps.Copy(opts.Headers, HeadersFromEnv(envMetricsHeaders))
-
-	return opts, nil
-}
-
-func getGRPCMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
-	opts := otlpOptions{Headers: map[string]string{}}
-	log := sglog().With("transport", "grpc")
-	murl, _, err := parseMetricsEndpoint(cfg)
-	if err != nil {
-		return opts, err
-	}
-	log.Debug("Configuring exporter",
-		"protocol", cfg.Protocol, "metricsProtocol", cfg.MetricsProtocol, "endpoint", murl.Host)
-
-	setMetricsProtocol(cfg)
-	opts.Endpoint = murl.Host
-	if murl.Scheme == "http" || murl.Scheme == "unix" {
-		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
-		opts.Insecure = true
-	}
-	if cfg.InsecureSkipVerify {
-		log.Debug("Setting InsecureSkipVerify")
-		opts.SkipTLSVerify = true
-	}
-
-	if cfg.InjectHeaders != nil {
-		cfg.InjectHeaders(opts.Headers)
-	}
-	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
-	maps.Copy(opts.Headers, HeadersFromEnv(envMetricsHeaders))
-
-	return opts, nil
-}
-
-// the HTTP path will be defined from one of the following sources, from highest to lowest priority
-// - the result from any overridden OTLP Provider function
-// - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, if defined
-// - OTEL_EXPORTER_OTLP_ENDPOINT, if defined
-func parseMetricsEndpoint(cfg *MetricsConfig) (*url.URL, bool, error) {
-	endpoint, isCommon := cfg.OTLPMetricsEndpoint()
-
-	murl, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, isCommon, fmt.Errorf("parsing endpoint URL %s: %w", endpoint, err)
-	}
-	if murl.Scheme == "" || murl.Host == "" {
-		return nil, isCommon, fmt.Errorf("URL %q must have a scheme and a host", endpoint)
-	}
-	return murl, isCommon, nil
-}
-
-// HACK: at the time of writing this, the otelpmetrichttp API does not support explicitly
-// setting the protocol. They should be properly set via environment variables, but
-// if the user supplied the value via configuration file (and not via env vars), we override the environment.
-// To be as least intrusive as possible, we will change the variables if strictly needed
-// TODO: remove this once otelpmetrichttp.WithProtocol is supported
-func setMetricsProtocol(cfg *MetricsConfig) {
-	if _, ok := os.LookupEnv(envMetricsProtocol); ok {
-		return
-	}
-	if _, ok := os.LookupEnv(envProtocol); ok {
-		return
-	}
-	if cfg.MetricsProtocol != "" {
-		os.Setenv(envMetricsProtocol, string(cfg.MetricsProtocol))
-		return
-	}
-	if cfg.Protocol != "" {
-		os.Setenv(envProtocol, string(cfg.Protocol))
-		return
-	}
-	// unset. Guessing it
-	os.Setenv(envMetricsProtocol, string(cfg.GuessProtocol()))
-}
-
-func cleanupMetrics(ctx context.Context, m *Expirer[*request.Span, instrument.Float64Histogram, float64]) {
-	if m != nil {
-		m.RemoveAllMetrics(ctx)
-	}
-}
-
-func cleanupCounterMetrics(ctx context.Context, m *Expirer[*request.Span, instrument.Int64Counter, int64]) {
-	if m != nil {
-		m.RemoveAllMetrics(ctx)
-	}
-}
-
-func cleanupFloatCounterMetrics(ctx context.Context, m *Expirer[*request.Span, instrument.Float64Counter, float64]) {
-	if m != nil {
-		m.RemoveAllMetrics(ctx)
-	}
-}
-
-func (r *Metrics) cleanupAllMetricsInstances() {
-	cleanupMetrics(r.ctx, r.httpDuration)
-	cleanupMetrics(r.ctx, r.httpClientDuration)
-	cleanupMetrics(r.ctx, r.grpcDuration)
-	cleanupMetrics(r.ctx, r.grpcClientDuration)
-	cleanupMetrics(r.ctx, r.dbClientDuration)
-	cleanupMetrics(r.ctx, r.msgPublishDuration)
-	cleanupMetrics(r.ctx, r.msgProcessDuration)
-	cleanupMetrics(r.ctx, r.httpRequestSize)
-	cleanupMetrics(r.ctx, r.httpResponseSize)
-	cleanupMetrics(r.ctx, r.httpClientRequestSize)
-	cleanupMetrics(r.ctx, r.spanMetricsLatency)
-	cleanupCounterMetrics(r.ctx, r.spanMetricsCallsTotal)
-	cleanupFloatCounterMetrics(r.ctx, r.spanMetricsRequestSizeTotal)
-	cleanupFloatCounterMetrics(r.ctx, r.spanMetricsResponseSizeTotal)
+func (r *SvcGraphMetrics) cleanupAllMetricsInstances() {
 	cleanupMetrics(r.ctx, r.serviceGraphClient)
 	cleanupMetrics(r.ctx, r.serviceGraphServer)
 	cleanupCounterMetrics(r.ctx, r.serviceGraphFailed)
 	cleanupCounterMetrics(r.ctx, r.serviceGraphTotal)
-	cleanupCounterMetrics(r.ctx, r.gpuKernelCallsTotal)
 }

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -37,8 +37,8 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 )
 
-func mlog() *slog.Logger {
-	return slog.With("component", "otel.MetricsReporter")
+func sglog() *slog.Logger {
+	return slog.With("component", "otel.SvcGraphMetricsReporter")
 }
 
 const (
@@ -55,6 +55,10 @@ const (
 	TracesTargetInfo         = "traces_target_info"
 	TargetInfo               = "target_info"
 	TracesHostInfo           = "traces_host_info"
+	ServiceGraphClient       = "traces_service_graph_request_client"
+	ServiceGraphServer       = "traces_service_graph_request_server"
+	ServiceGraphFailed       = "traces_service_graph_request_failed_total"
+	ServiceGraphTotal        = "traces_service_graph_request_total"
 
 	UsualPortGRPC = "4317"
 	UsualPortHTTP = "4318"
@@ -189,7 +193,7 @@ func (m *MetricsConfig) EndpointEnabled() bool {
 }
 
 func (m *MetricsConfig) AnySpanMetricsEnabled() bool {
-	return m.SpanMetricsEnabled() || m.SpanMetricsSizesEnabled()
+	return m.SpanMetricsEnabled() || m.ServiceGraphMetricsEnabled() || m.SpanMetricsSizesEnabled()
 }
 
 func (m *MetricsConfig) SpanMetricsSizesEnabled() bool {
@@ -291,6 +295,10 @@ type Metrics struct {
 	spanMetricsCallsTotal        *Expirer[*request.Span, instrument.Int64Counter, int64]
 	spanMetricsRequestSizeTotal  *Expirer[*request.Span, instrument.Float64Counter, float64]
 	spanMetricsResponseSizeTotal *Expirer[*request.Span, instrument.Float64Counter, float64]
+	serviceGraphClient           *Expirer[*request.Span, instrument.Float64Histogram, float64]
+	serviceGraphServer           *Expirer[*request.Span, instrument.Float64Histogram, float64]
+	serviceGraphFailed           *Expirer[*request.Span, instrument.Int64Counter, int64]
+	serviceGraphTotal            *Expirer[*request.Span, instrument.Int64Counter, int64]
 	targetInfo                   instrument.Int64UpDownCounter
 	tracesTargetInfo             instrument.Int64UpDownCounter
 	gpuKernelCallsTotal          *Expirer[*request.Span, instrument.Int64Counter, int64]
@@ -345,7 +353,7 @@ func newMetricsReporter(
 	input *msg.Queue[[]request.Span],
 	processEventCh *msg.Queue[exec.ProcessEvent],
 ) (*MetricsReporter, error) {
-	log := mlog()
+	log := sglog()
 
 	attribProvider, err := attributes.NewAttrSelector(ctxInfo.MetricAttributeGroups, selectorCfg)
 	if err != nil {
@@ -440,13 +448,13 @@ func newMetricsReporter(
 	return &mr, nil
 }
 
-func (mr *MetricsReporter) otelMetricOptions(mlog *slog.Logger) []metric.Option {
+func (mr *MetricsReporter) otelMetricOptions(sglog *slog.Logger) []metric.Option {
 	var opts []metric.Option
 	if !mr.cfg.OTelMetricsEnabled() {
 		return opts
 	}
 
-	useExponentialHistograms := isExponentialAggregation(mr.cfg, mlog)
+	useExponentialHistograms := isExponentialAggregation(mr.cfg, sglog)
 
 	if mr.is.HTTPEnabled() {
 		opts = append(opts,
@@ -494,15 +502,28 @@ func (mr *MetricsReporter) spanMetricsLatencyName() string {
 	return SpanMetricsLatencyOTel
 }
 
-func (mr *MetricsReporter) spanMetricOptions(mlog *slog.Logger) []metric.Option {
+func (mr *MetricsReporter) spanMetricOptions(sglog *slog.Logger) []metric.Option {
 	if !mr.cfg.SpanMetricsEnabled() {
 		return []metric.Option{}
 	}
 
-	useExponentialHistograms := isExponentialAggregation(mr.cfg, mlog)
+	useExponentialHistograms := isExponentialAggregation(mr.cfg, sglog)
 
 	return []metric.Option{
 		metric.WithView(otelHistogramConfig(mr.spanMetricsLatencyName(), mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
+	}
+}
+
+func (mr *MetricsReporter) graphMetricOptions(sglog *slog.Logger) []metric.Option {
+	if !mr.cfg.ServiceGraphMetricsEnabled() {
+		return []metric.Option{}
+	}
+
+	useExponentialHistograms := isExponentialAggregation(mr.cfg, sglog)
+
+	return []metric.Option{
+		metric.WithView(otelHistogramConfig(ServiceGraphClient, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
+		metric.WithView(otelHistogramConfig(ServiceGraphServer, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
 	}
 }
 
@@ -728,14 +749,54 @@ func (mr *MetricsReporter) setupHostInfoMeter(meter instrument.Meter) error {
 	return nil
 }
 
+func (mr *MetricsReporter) setupGraphMeters(m *Metrics, meter instrument.Meter) error {
+	if !mr.cfg.ServiceGraphMetricsEnabled() {
+		return nil
+	}
+
+	var err error
+
+	serviceGraphAttrs := mr.serviceGraphAttributes()
+
+	serviceGraphClient, err := meter.Float64Histogram(ServiceGraphClient, instrument.WithUnit("s"))
+	if err != nil {
+		return fmt.Errorf("creating service graph client histogram: %w", err)
+	}
+	m.serviceGraphClient = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
+		m.ctx, serviceGraphClient, serviceGraphAttrs, timeNow, mr.cfg.TTL)
+
+	serviceGraphServer, err := meter.Float64Histogram(ServiceGraphServer, instrument.WithUnit("s"))
+	if err != nil {
+		return fmt.Errorf("creating service graph server histogram: %w", err)
+	}
+	m.serviceGraphServer = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
+		m.ctx, serviceGraphServer, serviceGraphAttrs, timeNow, mr.cfg.TTL)
+
+	serviceGraphFailed, err := meter.Int64Counter(ServiceGraphFailed)
+	if err != nil {
+		return fmt.Errorf("creating service graph failed total: %w", err)
+	}
+	m.serviceGraphFailed = NewExpirer[*request.Span, instrument.Int64Counter, int64](
+		m.ctx, serviceGraphFailed, serviceGraphAttrs, timeNow, mr.cfg.TTL)
+
+	serviceGraphTotal, err := meter.Int64Counter(ServiceGraphTotal)
+	if err != nil {
+		return fmt.Errorf("creating service graph total: %w", err)
+	}
+	m.serviceGraphTotal = NewExpirer[*request.Span, instrument.Int64Counter, int64](
+		m.ctx, serviceGraphTotal, serviceGraphAttrs, timeNow, mr.cfg.TTL)
+
+	return nil
+}
+
 func (mr *MetricsReporter) newMetricsInstance(service *svc.Attrs) Metrics {
-	mlog := mlog()
+	sglog := sglog()
 	var resourceAttributes []attribute.KeyValue
 	if service != nil {
-		mlog = mlog.With("service", service)
+		sglog = sglog.With("service", service)
 		resourceAttributes = append(GetAppResourceAttrs(mr.hostID, service), ResourceAttrsFromEnv(service)...)
 	}
-	mlog.Debug("creating new Metrics reporter")
+	sglog.Debug("creating new Metrics reporter")
 	resources := resource.NewWithAttributes(semconv.SchemaURL, resourceAttributes...)
 
 	opts := []metric.Option{
@@ -744,8 +805,9 @@ func (mr *MetricsReporter) newMetricsInstance(service *svc.Attrs) Metrics {
 			metric.WithInterval(mr.cfg.Interval))),
 	}
 
-	opts = append(opts, mr.otelMetricOptions(mlog)...)
-	opts = append(opts, mr.spanMetricOptions(mlog)...)
+	opts = append(opts, mr.otelMetricOptions(sglog)...)
+	opts = append(opts, mr.spanMetricOptions(sglog)...)
+	opts = append(opts, mr.graphMetricOptions(sglog)...)
 
 	return Metrics{
 		ctx:                      mr.ctx,
@@ -761,7 +823,7 @@ func (mr *MetricsReporter) newMetricsInstance(service *svc.Attrs) Metrics {
 func (mr *MetricsReporter) newMetricSet(service *svc.Attrs) (*Metrics, error) {
 	m := mr.newMetricsInstance(service)
 
-	mlog().Debug("creating new metric set", "service", service)
+	sglog().Debug("creating new metric set", "service", service)
 	// time units for HTTP and GRPC durations are in seconds, according to the OTEL specification:
 	// https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/metrics/semantic_conventions
 	// TODO: set ExplicitBucketBoundaries here and in prometheus from the previous specification
@@ -801,17 +863,24 @@ func (mr *MetricsReporter) newMetricSet(service *svc.Attrs) (*Metrics, error) {
 		}
 	}
 
+	if mr.cfg.ServiceGraphMetricsEnabled() {
+		err = mr.setupGraphMeters(&m, meter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &m, nil
 }
 
-func isExponentialAggregation(mc *MetricsConfig, mlog *slog.Logger) bool {
+func isExponentialAggregation(mc *MetricsConfig, sglog *slog.Logger) bool {
 	switch mc.HistogramAggregation {
 	case AggregationExponential:
 		return true
 	case AggregationExplicit:
 	// do nothing
 	default:
-		mlog.Warn("invalid value for histogram aggregation. Accepted values are: "+
+		sglog.Warn("invalid value for histogram aggregation. Accepted values are: "+
 			AggregationExponential+", "+AggregationExplicit+" (default). Using default",
 			"value", mc.HistogramAggregation)
 	}
@@ -968,6 +1037,17 @@ func (mr *MetricsReporter) spanMetricAttributes() []attributes.Field[*request.Sp
 		})
 }
 
+func (mr *MetricsReporter) serviceGraphAttributes() []attributes.Field[*request.Span, attribute.KeyValue] {
+	return attributes.OpenTelemetryGetters(
+		request.SpanOTELGetters, []attr.Name{
+			attr.Client,
+			attr.ClientNamespace,
+			attr.Server,
+			attr.ServerNamespace,
+			attr.Source,
+		})
+}
+
 func otelMetricsAccepted(span *request.Span, mr *MetricsReporter) bool {
 	return mr.cfg.OTelMetricsEnabled() && !span.Service.ExportsOTelMetrics()
 }
@@ -1067,17 +1147,54 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 			smst, attr := r.spanMetricsResponseSizeTotal.ForRecord(span)
 			smst.Add(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attr))
 		}
+
+		if mr.cfg.ServiceGraphMetricsEnabled() {
+			if !span.IsSelfReferenceSpan() || mr.cfg.AllowServiceGraphSelfReferences {
+				if span.IsClientSpan() {
+					sgc, attrs := r.serviceGraphClient.ForRecord(span)
+					sgc.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+					// If we managed to resolve the remote name only, we check to see
+					// we are not instrumenting the server service, then and only then,
+					// we generate client span count for service graph total
+					if ClientSpanToUninstrumentedService(&mr.pidTracker, span) {
+						sgt, attrs := r.serviceGraphTotal.ForRecord(span)
+						sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+					}
+				} else {
+					sgs, attrs := r.serviceGraphServer.ForRecord(span)
+					sgs.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+					sgt, attrs := r.serviceGraphTotal.ForRecord(span)
+					sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+				}
+				if request.SpanStatusCode(span) == request.StatusCodeError {
+					sgf, attrs := r.serviceGraphFailed.ForRecord(span)
+					sgf.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+				}
+			}
+		}
 	}
 }
 
+func ClientSpanToUninstrumentedService(tracker *PidServiceTracker, span *request.Span) bool {
+	if span.HostName != "" {
+		n := svc.ServiceNameNamespace{Name: span.HostName, Namespace: span.OtherNamespace}
+		return !tracker.IsTrackingServerService(n)
+	}
+	// If we haven't resolved a hostname, don't add this node to the service graph
+	// it will appear only in client requests. Essentially, in this case we have no
+	// idea if the service is instrumented or not, therefore we take the conservative
+	// approach to avoid double counting.
+	return false
+}
+
 func (mr *MetricsReporter) createTargetInfo(reporter *Metrics) {
-	mlog().Debug("Creating target_info")
+	sglog().Debug("Creating target_info")
 	attrOpt := instrument.WithAttributeSet(attribute.NewSet(reporter.resourceAttributes...))
 	reporter.targetInfo.Add(mr.ctx, 1, attrOpt)
 }
 
 func (mr *MetricsReporter) deleteTargetInfo(reporter *Metrics) {
-	mlog().Debug("Deleting target_info for", "attrs", reporter.resourceAttributes)
+	sglog().Debug("Deleting target_info for", "attrs", reporter.resourceAttributes)
 	attrOpt := instrument.WithAttributeSet(attribute.NewSet(reporter.resourceAttributes...))
 	reporter.targetInfo.Remove(mr.ctx, attrOpt)
 }
@@ -1086,7 +1203,7 @@ func (mr *MetricsReporter) createTracesTargetInfo(reporter *Metrics) {
 	if !mr.cfg.AnySpanMetricsEnabled() {
 		return
 	}
-	mlog().Debug("Creating traces_target_info")
+	sglog().Debug("Creating traces_target_info")
 	attrOpt := instrument.WithAttributeSet(reporter.tracesResourceAttributes)
 	reporter.tracesTargetInfo.Add(mr.ctx, 1, attrOpt)
 }
@@ -1095,7 +1212,7 @@ func (mr *MetricsReporter) deleteTracesTargetInfo(reporter *Metrics) {
 	if !mr.cfg.AnySpanMetricsEnabled() {
 		return
 	}
-	mlog().Debug("Deleting traces_target_info for", "attrs", reporter.resourceAttributes)
+	sglog().Debug("Deleting traces_target_info for", "attrs", reporter.resourceAttributes)
 	attrOpt := instrument.WithAttributeSet(reporter.tracesResourceAttributes)
 	reporter.tracesTargetInfo.Remove(mr.ctx, attrOpt)
 }
@@ -1110,13 +1227,13 @@ func (mr *MetricsReporter) disassociatePIDFromService(pid int32) (bool, svc.UID)
 
 func (mr *MetricsReporter) watchForProcessEvents() {
 	for pe := range mr.processEvents {
-		mlog().Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
+		sglog().Debug("Received new process event", "event type", pe.Type, "pid", pe.File.Pid, "attrs", pe.File.Service.UID)
 
 		reporter, err := mr.reporters.For(&pe.File.Service)
 		// If we are receiving a delete event, the service may come without kubernetes information, which
 		// is why we record the original service info. Delete look up the data from the pid tracker.
 		if err != nil {
-			mlog().Error("unexpected error creating OTEL resource. Ignoring metric",
+			sglog().Error("unexpected error creating OTEL resource. Ignoring metric",
 				"error", err, "service", pe.File.Service.UID)
 			continue
 		}
@@ -1132,11 +1249,11 @@ func (mr *MetricsReporter) watchForProcessEvents() {
 				svc := svc.Attrs{UID: origUID}
 				reporter, err = mr.reporters.For(&svc)
 				if err != nil {
-					mlog().Error("unexpected error creating OTEL resource. Ignoring metric",
+					sglog().Error("unexpected error creating OTEL resource. Ignoring metric",
 						"error", err, "service", pe.File.Service.UID)
 					continue
 				}
-				mlog().Debug("deleting infos for", "pid", pe.File.Pid, "attrs", reporter.service)
+				sglog().Debug("deleting infos for", "pid", pe.File.Pid, "attrs", reporter.service)
 				mr.deleteTracesTargetInfo(reporter)
 				mr.deleteTargetInfo(reporter)
 			}
@@ -1161,7 +1278,7 @@ func (mr *MetricsReporter) reportMetrics(_ context.Context) {
 			}
 			reporter, err := mr.reporters.For(&s.Service)
 			if err != nil {
-				mlog().Error("unexpected error creating OTEL resource. Ignoring metric",
+				sglog().Error("unexpected error creating OTEL resource. Ignoring metric",
 					"error", err, "service", s.Service)
 				continue
 			}
@@ -1173,7 +1290,7 @@ func (mr *MetricsReporter) reportMetrics(_ context.Context) {
 
 func getHTTPMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
 	opts := otlpOptions{Headers: map[string]string{}}
-	log := mlog().With("transport", "http")
+	log := sglog().With("transport", "http")
 	murl, isCommon, err := parseMetricsEndpoint(cfg)
 	if err != nil {
 		return opts, err
@@ -1215,7 +1332,7 @@ func getHTTPMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
 
 func getGRPCMetricEndpointOptions(cfg *MetricsConfig) (otlpOptions, error) {
 	opts := otlpOptions{Headers: map[string]string{}}
-	log := mlog().With("transport", "grpc")
+	log := sglog().With("transport", "grpc")
 	murl, _, err := parseMetricsEndpoint(cfg)
 	if err != nil {
 		return opts, err
@@ -1317,5 +1434,9 @@ func (r *Metrics) cleanupAllMetricsInstances() {
 	cleanupCounterMetrics(r.ctx, r.spanMetricsCallsTotal)
 	cleanupFloatCounterMetrics(r.ctx, r.spanMetricsRequestSizeTotal)
 	cleanupFloatCounterMetrics(r.ctx, r.spanMetricsResponseSizeTotal)
+	cleanupMetrics(r.ctx, r.serviceGraphClient)
+	cleanupMetrics(r.ctx, r.serviceGraphServer)
+	cleanupCounterMetrics(r.ctx, r.serviceGraphFailed)
+	cleanupCounterMetrics(r.ctx, r.serviceGraphTotal)
 	cleanupCounterMetrics(r.ctx, r.gpuKernelCallsTotal)
 }

--- a/pkg/export/otel/metrics_svc_graph_test.go
+++ b/pkg/export/otel/metrics_svc_graph_test.go
@@ -1,0 +1,101 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/app/request"
+	"go.opentelemetry.io/obi/pkg/components/exec"
+	"go.opentelemetry.io/obi/pkg/components/pipe/global"
+	"go.opentelemetry.io/obi/pkg/components/svc"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+	"go.opentelemetry.io/obi/test/collector"
+)
+
+func TestServiceGraphMetrics(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer otelcfg.RestoreEnvAfterExecution()()
+
+	ctx := t.Context()
+
+	otlp, err := collector.Start(ctx)
+	require.NoError(t, err)
+
+	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+
+	otelExporter := makeSvcGraphExporter(ctx, t, otlp, metrics, processEvents)
+
+	require.NoError(t, err)
+	go func() {
+		otelExporter(ctx)
+	}()
+
+	clientID := svc.Attrs{ProcPID: 33, UID: svc.UID{Name: "client", Instance: "the-client"}}
+	serverID := svc.Attrs{ProcPID: 66, UID: svc.UID{Name: "server", Instance: "the-server"}}
+
+	processEvents.Send(exec.ProcessEvent{
+		Type: exec.ProcessEventCreated,
+		File: &exec.FileInfo{Service: clientID, Pid: clientID.ProcPID},
+	})
+	processEvents.Send(exec.ProcessEvent{
+		Type: exec.ProcessEventCreated,
+		File: &exec.FileInfo{Service: serverID, Pid: serverID.ProcPID},
+	})
+
+	metrics.Send([]request.Span{
+		{Service: serverID, Type: request.EventTypeHTTP, Peer: "client-host", Host: "server-host", Path: "/foo", RequestStart: 100, End: 200},
+		{Service: clientID, Type: request.EventTypeHTTPClient, Peer: "server-host", Host: "client-host", Path: "/bar", RequestStart: 150, End: 175},
+	})
+
+	// Read the exported metrics, add +extraColl for HTTP size metrics
+	res := readNChan(t, otlp.Records(), 6, timeout)
+	assert.NotEmpty(t, res)
+	reported := map[string]struct{}{}
+	for _, m := range res {
+		reported[m.Name+":"+m.Attributes["client"]+":"+m.Attributes["server"]] = struct{}{}
+	}
+
+	require.Equal(t, map[string]struct{}{
+		"traces_service_graph_request_client:server-host:client-host":       {},
+		"traces_service_graph_request_server:client-host:server-host":       {},
+		"traces_service_graph_request_failed_total:server-host:client-host": {},
+		"traces_service_graph_request_failed_total:client-host:server-host": {},
+		"traces_service_graph_request_total:client-host:server-host":        {},
+	}, reported)
+}
+
+func makeSvcGraphExporter(
+	ctx context.Context, t *testing.T, otlp *collector.TestCollector,
+	input *msg.Queue[[]request.Span],
+	processEvents *msg.Queue[exec.ProcessEvent],
+) swarm.RunFunc {
+	mcfg := &otelcfg.MetricsConfig{
+		Interval:          50 * time.Millisecond,
+		CommonEndpoint:    otlp.ServerEndpoint,
+		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
+		Features:          []string{otelcfg.FeatureGraph},
+		TTL:               30 * time.Minute,
+		ReportersCacheLen: 100,
+		Instrumentations:  []string{instrumentations.InstrumentationALL},
+	}
+	otelExporter, err := ReportSvcGraphMetrics(
+		&global.ContextInfo{OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg}},
+		mcfg, &attributes.SelectorConfig{}, input, processEvents)(ctx)
+	require.NoError(t, err)
+
+	return otelExporter
+}

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
@@ -33,77 +34,8 @@ import (
 
 var fakeMux = sync.Mutex{}
 
-func TestHTTPMetricsEndpointOptions(t *testing.T) {
-	defer restoreEnvAfterExecution()()
-	mcfg := MetricsConfig{
-		CommonEndpoint:  "https://localhost:3131",
-		MetricsEndpoint: "https://localhost:3232/v1/metrics",
-		Instrumentations: []string{
-			instrumentations.InstrumentationHTTP,
-		},
-	}
-
-	t.Run("testing with two endpoints", func(t *testing.T) {
-		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", URLPath: "/v1/metrics", Headers: map[string]string{}}, &mcfg)
-	})
-
-	mcfg = MetricsConfig{
-		CommonEndpoint: "https://localhost:3131/otlp",
-		Instrumentations: []string{
-			instrumentations.InstrumentationHTTP,
-		},
-	}
-
-	t.Run("testing with only common endpoint", func(t *testing.T) {
-		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3131", URLPath: "/otlp/v1/metrics", Headers: map[string]string{}}, &mcfg)
-	})
-
-	mcfg = MetricsConfig{
-		CommonEndpoint:  "https://localhost:3131",
-		MetricsEndpoint: "http://localhost:3232",
-		Instrumentations: []string{
-			instrumentations.InstrumentationHTTP,
-		},
-	}
-	t.Run("testing with insecure endpoint", func(t *testing.T) {
-		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", Insecure: true, Headers: map[string]string{}}, &mcfg)
-	})
-
-	mcfg = MetricsConfig{
-		CommonEndpoint:     "https://localhost:3232",
-		InsecureSkipVerify: true,
-		Instrumentations: []string{
-			instrumentations.InstrumentationHTTP,
-		},
-	}
-
-	t.Run("testing with skip TLS verification", func(t *testing.T) {
-		testMetricsHTTPOptions(t, otlpOptions{Endpoint: "localhost:3232", URLPath: "/v1/metrics", SkipTLSVerify: true, Headers: map[string]string{}}, &mcfg)
-	})
-}
-
-func testMetricsHTTPOptions(t *testing.T, expected otlpOptions, mcfg *MetricsConfig) {
-	defer restoreEnvAfterExecution()()
-	opts, err := getHTTPMetricEndpointOptions(mcfg)
-	require.NoError(t, err)
-	assert.Equal(t, expected, opts)
-}
-
-func TestMissingSchemeInMetricsEndpoint(t *testing.T) {
-	defer restoreEnvAfterExecution()()
-	opts, err := getHTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "http://foo:3030", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
-	require.NoError(t, err)
-	require.NotEmpty(t, opts)
-
-	_, err = getHTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo:3030", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
-	require.Error(t, err)
-
-	_, err = getHTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
-	require.Error(t, err)
-}
-
 func TestMetrics_InternalInstrumentation(t *testing.T) {
-	defer restoreEnvAfterExecution()()
+	defer otelcfg.RestoreEnvAfterExecution()()
 	// fake OTEL collector server
 	coll := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusOK)
@@ -122,9 +54,9 @@ func TestMetrics_InternalInstrumentation(t *testing.T) {
 	internalMetrics := &fakeInternalMetrics{}
 	reporter, err := ReportMetrics(&global.ContextInfo{
 		Metrics: internalMetrics,
-	}, &MetricsConfig{
+	}, &otelcfg.MetricsConfig{
 		CommonEndpoint: coll.URL, Interval: 10 * time.Millisecond, ReportersCacheLen: 16,
-		Features: []string{FeatureApplication}, Instrumentations: []string{instrumentations.InstrumentationHTTP},
+		Features: []string{otelcfg.FeatureApplication}, Instrumentations: []string{instrumentations.InstrumentationHTTP},
 	}, &attributes.SelectorConfig{}, exportMetrics, processEvents,
 	)(t.Context())
 	require.NoError(t, err)
@@ -194,130 +126,6 @@ type fakeInternalMetrics struct {
 	errs atomic.Int32
 }
 
-func TestGRPCMetricsEndpointOptions(t *testing.T) {
-	defer restoreEnvAfterExecution()()
-	t.Run("do not accept URLs without a scheme", func(t *testing.T) {
-		_, err := getGRPCMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo:3939"})
-		require.Error(t, err)
-	})
-
-	mcfg := MetricsConfig{
-		CommonEndpoint:   "https://localhost:3131",
-		MetricsEndpoint:  "https://localhost:3232",
-		Instrumentations: []string{instrumentations.InstrumentationHTTP},
-	}
-
-	t.Run("testing with two endpoints", func(t *testing.T) {
-		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", Headers: map[string]string{}}, &mcfg)
-	})
-
-	mcfg = MetricsConfig{
-		CommonEndpoint:   "https://localhost:3131",
-		Instrumentations: []string{instrumentations.InstrumentationHTTP},
-	}
-
-	t.Run("testing with only common endpoint", func(t *testing.T) {
-		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3131", Headers: map[string]string{}}, &mcfg)
-	})
-
-	mcfg = MetricsConfig{
-		CommonEndpoint:   "https://localhost:3131",
-		MetricsEndpoint:  "http://localhost:3232",
-		Instrumentations: []string{instrumentations.InstrumentationHTTP},
-	}
-	t.Run("testing with insecure endpoint", func(t *testing.T) {
-		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", Insecure: true, Headers: map[string]string{}}, &mcfg)
-	})
-
-	mcfg = MetricsConfig{
-		CommonEndpoint:     "https://localhost:3232",
-		InsecureSkipVerify: true,
-		Instrumentations:   []string{instrumentations.InstrumentationHTTP},
-	}
-
-	t.Run("testing with skip TLS verification", func(t *testing.T) {
-		testMetricsGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", SkipTLSVerify: true, Headers: map[string]string{}}, &mcfg)
-	})
-}
-
-func testMetricsGRPCOptions(t *testing.T, expected otlpOptions, mcfg *MetricsConfig) {
-	defer restoreEnvAfterExecution()()
-	opts, err := getGRPCMetricEndpointOptions(mcfg)
-	require.NoError(t, err)
-	assert.Equal(t, expected, opts)
-}
-
-func TestMetricsSetupHTTP_Protocol(t *testing.T) {
-	testCases := []struct {
-		Endpoint               string
-		ProtoVal               Protocol
-		MetricProtoVal         Protocol
-		ExpectedProtoEnv       string
-		ExpectedMetricProtoEnv string
-	}{
-		{ProtoVal: "", MetricProtoVal: "", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "http/protobuf"},
-		{ProtoVal: "", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
-		{ProtoVal: "bar", MetricProtoVal: "", ExpectedProtoEnv: "bar", ExpectedMetricProtoEnv: ""},
-		{ProtoVal: "bar", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
-		{Endpoint: "http://foo:4317", ProtoVal: "", MetricProtoVal: "", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "grpc"},
-		{Endpoint: "http://foo:4317", ProtoVal: "", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
-		{Endpoint: "http://foo:4317", ProtoVal: "bar", MetricProtoVal: "", ExpectedProtoEnv: "bar", ExpectedMetricProtoEnv: ""},
-		{Endpoint: "http://foo:4317", ProtoVal: "bar", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
-		{Endpoint: "http://foo:14317", ProtoVal: "", MetricProtoVal: "", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "grpc"},
-		{Endpoint: "http://foo:14317", ProtoVal: "", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
-		{Endpoint: "http://foo:14317", ProtoVal: "bar", MetricProtoVal: "", ExpectedProtoEnv: "bar", ExpectedMetricProtoEnv: ""},
-		{Endpoint: "http://foo:14317", ProtoVal: "bar", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
-		{Endpoint: "http://foo:4318", ProtoVal: "", MetricProtoVal: "", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "http/protobuf"},
-		{Endpoint: "http://foo:4318", ProtoVal: "", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
-		{Endpoint: "http://foo:4318", ProtoVal: "bar", MetricProtoVal: "", ExpectedProtoEnv: "bar", ExpectedMetricProtoEnv: ""},
-		{Endpoint: "http://foo:4318", ProtoVal: "bar", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
-		{Endpoint: "http://foo:24318", ProtoVal: "", MetricProtoVal: "", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "http/protobuf"},
-		{Endpoint: "http://foo:24318", ProtoVal: "", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
-		{Endpoint: "http://foo:24318", ProtoVal: "bar", MetricProtoVal: "", ExpectedProtoEnv: "bar", ExpectedMetricProtoEnv: ""},
-		{Endpoint: "http://foo:24318", ProtoVal: "bar", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.Endpoint+"/"+string(tc.ProtoVal)+"/"+string(tc.MetricProtoVal), func(t *testing.T) {
-			defer restoreEnvAfterExecution()()
-			_, err := getHTTPMetricEndpointOptions(&MetricsConfig{
-				CommonEndpoint:   "http://host:3333",
-				MetricsEndpoint:  tc.Endpoint,
-				Protocol:         tc.ProtoVal,
-				MetricsProtocol:  tc.MetricProtoVal,
-				Instrumentations: []string{instrumentations.InstrumentationHTTP},
-			})
-			require.NoError(t, err)
-			assert.Equal(t, tc.ExpectedProtoEnv, os.Getenv(envProtocol))
-			assert.Equal(t, tc.ExpectedMetricProtoEnv, os.Getenv(envMetricsProtocol))
-		})
-	}
-}
-
-func TestMetricSetupHTTP_DoNotOverrideEnv(t *testing.T) {
-	t.Run("setting both variables", func(t *testing.T) {
-		defer restoreEnvAfterExecution()()
-		t.Setenv(envProtocol, "foo-proto")
-		t.Setenv(envMetricsProtocol, "bar-proto")
-		_, err := getHTTPMetricEndpointOptions(&MetricsConfig{
-			CommonEndpoint: "http://host:3333", Protocol: "foo", MetricsProtocol: "bar", Instrumentations: []string{instrumentations.InstrumentationHTTP},
-		})
-		require.NoError(t, err)
-		assert.Equal(t, "foo-proto", os.Getenv(envProtocol))
-		assert.Equal(t, "bar-proto", os.Getenv(envMetricsProtocol))
-	})
-	t.Run("setting only proto env var", func(t *testing.T) {
-		defer restoreEnvAfterExecution()()
-		t.Setenv(envProtocol, "foo-proto")
-		_, err := getHTTPMetricEndpointOptions(&MetricsConfig{
-			CommonEndpoint: "http://host:3333", Protocol: "foo", Instrumentations: []string{instrumentations.InstrumentationHTTP},
-		})
-		require.NoError(t, err)
-		_, ok := os.LookupEnv(envMetricsProtocol)
-		assert.False(t, ok)
-		assert.Equal(t, "foo-proto", os.Getenv(envProtocol))
-	})
-}
-
 type InstrTest struct {
 	name      string
 	instr     []string
@@ -326,7 +134,7 @@ type InstrTest struct {
 }
 
 func TestAppMetrics_ByInstrumentation(t *testing.T) {
-	defer restoreEnvAfterExecution()()
+	defer otelcfg.RestoreEnvAfterExecution()()
 
 	tests := []InstrTest{
 		{
@@ -477,15 +285,15 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				assert.Equal(t, tt.expected[i], m[i].Name)
 			}
 
-			restoreEnvAfterExecution()
+			otelcfg.RestoreEnvAfterExecution()
 		})
 	}
 }
 
 func TestAppMetrics_ResourceAttributes(t *testing.T) {
-	defer restoreEnvAfterExecution()()
+	defer otelcfg.RestoreEnvAfterExecution()()
 
-	t.Setenv(envResourceAttrs, "deployment.environment=production,source=upstream.beyla")
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=production,source=upstream.beyla")
 
 	ctx := t.Context()
 
@@ -511,36 +319,9 @@ func TestAppMetrics_ResourceAttributes(t *testing.T) {
 	assert.Equal(t, "upstream.beyla", attributes["source"])
 }
 
-func TestMetricsConfig_Enabled(t *testing.T) {
-	assert.True(t, (&MetricsConfig{Features: []string{FeatureApplication, FeatureNetwork}, CommonEndpoint: "foo"}).Enabled())
-	assert.True(t, (&MetricsConfig{Features: []string{FeatureApplication}, MetricsEndpoint: "foo"}).Enabled())
-	assert.True(t, (&MetricsConfig{MetricsEndpoint: "foo", Features: []string{FeatureNetwork}}).Enabled())
-	assert.True(t, (&MetricsConfig{
-		Features:             []string{FeatureNetwork},
-		OTLPEndpointProvider: func() (string, bool) { return "something", false },
-	}).Enabled())
-	assert.True(t, (&MetricsConfig{
-		Features:             []string{FeatureNetwork},
-		OTLPEndpointProvider: func() (string, bool) { return "something", true },
-	}).Enabled())
-}
-
-func TestMetricsConfig_Disabled(t *testing.T) {
-	assert.False(t, (&MetricsConfig{Features: []string{FeatureApplication}}).Enabled())
-	assert.False(t, (&MetricsConfig{Features: []string{FeatureNetwork, FeatureApplication}}).Enabled())
-	assert.False(t, (&MetricsConfig{Features: []string{FeatureNetwork}}).Enabled())
-	// application feature is not enabled
-	assert.False(t, (&MetricsConfig{CommonEndpoint: "foo"}).Enabled())
-	assert.False(t, (&MetricsConfig{}).Enabled())
-	assert.False(t, (&MetricsConfig{
-		Features:             []string{FeatureApplication},
-		OTLPEndpointProvider: func() (string, bool) { return "", false },
-	}).Enabled())
-}
-
 func TestMetricsDiscarded(t *testing.T) {
-	mc := MetricsConfig{
-		Features: []string{FeatureApplication},
+	mc := otelcfg.MetricsConfig{
+		Features: []string{otelcfg.FeatureApplication},
 	}
 	mr := MetricsReporter{
 		cfg: &mc,
@@ -584,8 +365,8 @@ func TestMetricsDiscarded(t *testing.T) {
 }
 
 func TestSpanMetricsDiscarded(t *testing.T) {
-	mc := MetricsConfig{
-		Features: []string{FeatureApplication},
+	mc := otelcfg.MetricsConfig{
+		Features: []string{otelcfg.FeatureApplication},
 	}
 	mr := MetricsReporter{
 		cfg: &mc,
@@ -628,22 +409,9 @@ func TestSpanMetricsDiscarded(t *testing.T) {
 	}
 }
 
-func TestMetricsInterval(t *testing.T) {
-	cfg := MetricsConfig{
-		OTELIntervalMS: 60_000,
-	}
-	t.Run("If only OTEL is defined, it uses that value", func(t *testing.T) {
-		assert.Equal(t, 60*time.Second, cfg.GetInterval())
-	})
-	cfg.Interval = 5 * time.Second
-	t.Run("Beyla interval takes precedence over OTEL", func(t *testing.T) {
-		assert.Equal(t, 5*time.Second, cfg.GetInterval())
-	})
-}
-
 func TestProcessPIDEvents(t *testing.T) {
-	mc := MetricsConfig{
-		Features: []string{FeatureApplication},
+	mc := otelcfg.MetricsConfig{
+		Features: []string{otelcfg.FeatureApplication},
 	}
 	mr := MetricsReporter{
 		cfg:        &mc,
@@ -729,11 +497,11 @@ func makeExporter(
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 
 	otelExporter, err := ReportMetrics(
-		&global.ContextInfo{}, &MetricsConfig{
+		&global.ContextInfo{}, &otelcfg.MetricsConfig{
 			Interval:          50 * time.Millisecond,
 			CommonEndpoint:    otlp.ServerEndpoint,
-			MetricsProtocol:   ProtocolHTTPProtobuf,
-			Features:          []string{FeatureApplication},
+			MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
+			Features:          []string{otelcfg.FeatureApplication},
 			TTL:               30 * time.Minute,
 			ReportersCacheLen: 100,
 			Instrumentations:  instrumentations,

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -229,10 +229,6 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 		},
 	}
 
-	// avoid some race condition derived from concurrent otelExporter instances sharing some
-	// global resources (e.g. timeNow)
-	otelExporterRunning := sync.Mutex{}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := t.Context()
@@ -241,20 +237,11 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			require.NoError(t, err)
 
 			metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
-
-			otelExporterRunning.Lock()
-			now := syncedClock{now: time.Now()}
-			timeNow = now.Now
-			go func() {
-				<-ctx.Done()
-				metrics.Close()
-			}()
 			otelExporter := makeExporter(ctx, t, tt.instr, otlp, metrics)
+
 			require.NoError(t, err)
-			go func() {
-				defer otelExporterRunning.Unlock()
-				otelExporter(ctx)
-			}()
+
+			go otelExporter(ctx)
 
 			/* Available event types (defined in span.go):
 			EventTypeHTTP

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -52,12 +52,14 @@ func TestMetrics_InternalInstrumentation(t *testing.T) {
 	exportMetrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	internalMetrics := &fakeInternalMetrics{}
-	reporter, err := ReportMetrics(&global.ContextInfo{
-		Metrics: internalMetrics,
-	}, &otelcfg.MetricsConfig{
+	mcfg := &otelcfg.MetricsConfig{
 		CommonEndpoint: coll.URL, Interval: 10 * time.Millisecond, ReportersCacheLen: 16,
 		Features: []string{otelcfg.FeatureApplication}, Instrumentations: []string{instrumentations.InstrumentationHTTP},
-	}, &attributes.SelectorConfig{}, exportMetrics, processEvents,
+	}
+	reporter, err := ReportMetrics(&global.ContextInfo{
+		Metrics:             internalMetrics,
+		OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg},
+	}, mcfg, &attributes.SelectorConfig{}, exportMetrics, processEvents,
 	)(t.Context())
 	require.NoError(t, err)
 	go reporter(t.Context())
@@ -227,6 +229,10 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 		},
 	}
 
+	// avoid some race condition derived from concurrent otelExporter instances sharing some
+	// global resources (e.g. timeNow)
+	otelExporterRunning := sync.Mutex{}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := t.Context()
@@ -234,15 +240,21 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			otlp, err := collector.Start(ctx)
 			require.NoError(t, err)
 
+			metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
+
+			otelExporterRunning.Lock()
 			now := syncedClock{now: time.Now()}
 			timeNow = now.Now
-
-			metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
+			go func() {
+				<-ctx.Done()
+				metrics.Close()
+			}()
 			otelExporter := makeExporter(ctx, t, tt.instr, otlp, metrics)
-
 			require.NoError(t, err)
-
-			go otelExporter(ctx)
+			go func() {
+				defer otelExporterRunning.Unlock()
+				otelExporter(ctx)
+			}()
 
 			/* Available event types (defined in span.go):
 			EventTypeHTTP
@@ -496,16 +508,18 @@ func makeExporter(
 ) swarm.RunFunc {
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 
+	mcfg := &otelcfg.MetricsConfig{
+		Interval:          50 * time.Millisecond,
+		CommonEndpoint:    otlp.ServerEndpoint,
+		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
+		Features:          []string{otelcfg.FeatureApplication},
+		TTL:               30 * time.Minute,
+		ReportersCacheLen: 100,
+		Instrumentations:  instrumentations,
+	}
 	otelExporter, err := ReportMetrics(
-		&global.ContextInfo{}, &otelcfg.MetricsConfig{
-			Interval:          50 * time.Millisecond,
-			CommonEndpoint:    otlp.ServerEndpoint,
-			MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
-			Features:          []string{otelcfg.FeatureApplication},
-			TTL:               30 * time.Minute,
-			ReportersCacheLen: 100,
-			Instrumentations:  instrumentations,
-		}, &attributes.SelectorConfig{
+		&global.ContextInfo{OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg}},
+		mcfg, &attributes.SelectorConfig{
 			SelectionCfg: attributes.Selection{
 				attributes.HTTPServerDuration.Section: attributes.InclusionLists{
 					Include: []string{"url.path"},

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otel
+package otelcfg
 
 import (
 	"context"
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/google/uuid"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -24,7 +23,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 	"google.golang.org/grpc/credentials"
 
@@ -54,6 +52,22 @@ const (
 	envTracesHeaders   = "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
 	envMetricsHeaders  = "OTEL_EXPORTER_OTLP_METRICS_HEADERS"
 	envResourceAttrs   = "OTEL_RESOURCE_ATTRIBUTES"
+)
+
+const (
+	UsualPortGRPC = "4317"
+	UsualPortHTTP = "4318"
+
+	FeatureNetwork          = "network"
+	FeatureNetworkInterZone = "network_inter_zone"
+	FeatureApplication      = "application"
+	FeatureSpan             = "application_span"
+	FeatureSpanOTel         = "application_span_otel"
+	FeatureSpanSizes        = "application_span_sizes"
+	FeatureGraph            = "application_service_graph"
+	FeatureProcess          = "application_process"
+	FeatureApplicationHost  = "application_host"
+	FeatureEBPF             = "ebpf"
 )
 
 func omitFieldsForYAML(input any, omitFields map[string]struct{}) map[string]any {
@@ -214,19 +228,6 @@ func shouldIncludeAttribute(normalizedAttrName string, patterns []attributes.Inc
 	return true
 }
 
-func newResourceInternal(hostID string) *resource.Resource {
-	attrs := []attribute.KeyValue{
-		semconv.ServiceName("opentelemetry-ebpf-instrumentation"),
-		semconv.ServiceInstanceID(uuid.New().String()),
-		semconv.TelemetrySDKLanguageKey.String(semconv.TelemetrySDKLanguageGo.Value.AsString()),
-		// We set the SDK name as Beyla, so we can distinguish beyla generated metrics from other SDKs
-		semconv.TelemetrySDKNameKey.String("opentelemetry-ebpf-instrumentation"),
-		semconv.HostID(hostID),
-	}
-
-	return resource.NewWithAttributes(semconv.SchemaURL, attrs...)
-}
-
 // ReporterPool keeps an LRU cache of different OTEL reporters given a service name.
 type ReporterPool[K uidGetter, T any] struct {
 	pool *simplelru.LRU[svc.UID, *expirable[T]]
@@ -342,7 +343,7 @@ func (rp *ReporterPool[K, T]) get(uid svc.UID, service K) (*expirable[T], error)
 }
 
 // Intermediate representation of option functions suitable for testing
-type otlpOptions struct {
+type OTLPOptions struct {
 	Scheme   string
 	Endpoint string
 	Insecure bool
@@ -354,7 +355,7 @@ type otlpOptions struct {
 	Headers       map[string]string
 }
 
-func (o *otlpOptions) AsMetricHTTP() []otlpmetrichttp.Option {
+func (o *OTLPOptions) AsMetricHTTP() []otlpmetrichttp.Option {
 	opts := []otlpmetrichttp.Option{
 		otlpmetrichttp.WithEndpoint(o.Endpoint),
 	}
@@ -373,7 +374,7 @@ func (o *otlpOptions) AsMetricHTTP() []otlpmetrichttp.Option {
 	return opts
 }
 
-func (o *otlpOptions) AsMetricGRPC() []otlpmetricgrpc.Option {
+func (o *OTLPOptions) AsMetricGRPC() []otlpmetricgrpc.Option {
 	opts := []otlpmetricgrpc.Option{
 		otlpmetricgrpc.WithEndpoint(o.Endpoint),
 	}
@@ -389,7 +390,7 @@ func (o *otlpOptions) AsMetricGRPC() []otlpmetricgrpc.Option {
 	return opts
 }
 
-func (o *otlpOptions) AsTraceHTTP() []otlptracehttp.Option {
+func (o *OTLPOptions) AsTraceHTTP() []otlptracehttp.Option {
 	opts := []otlptracehttp.Option{
 		otlptracehttp.WithEndpoint(o.Endpoint),
 	}
@@ -408,7 +409,7 @@ func (o *otlpOptions) AsTraceHTTP() []otlptracehttp.Option {
 	return opts
 }
 
-func (o *otlpOptions) AsTraceGRPC() []otlptracegrpc.Option {
+func (o *OTLPOptions) AsTraceGRPC() []otlptracegrpc.Option {
 	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(o.Endpoint),
 	}
@@ -536,12 +537,4 @@ func ResolveOTLPEndpoint(endpoint, common string) (string, bool) {
 	}
 
 	return "", false
-}
-
-// getFilteredMetricResourceAttrs returns filtered resource attributes for metrics.
-// It applies filtering to extra attributes while preserving base attributes.
-// This is especially useful for RED metrics and span metrics where we want to control
-// which attributes are included in the metrics.
-func getFilteredMetricResourceAttrs(baseAttrs []attribute.KeyValue, attrSelector attributes.Selection, extraAttrs []attribute.KeyValue, metricTypes []string) []attribute.KeyValue {
-	return GetFilteredAttributesByPrefix(baseAttrs, attrSelector, extraAttrs, metricTypes)
 }

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -231,8 +230,7 @@ func shouldIncludeAttribute(normalizedAttrName string, patterns []attributes.Inc
 
 // ReporterPool keeps an LRU cache of different OTEL reporters given a service name.
 type ReporterPool[K uidGetter, T any] struct {
-	mutex sync.Mutex
-	pool  *simplelru.LRU[svc.UID, *expirable[T]]
+	pool *simplelru.LRU[svc.UID, *expirable[T]]
 
 	itemConstructor func(getter K) (T, error)
 
@@ -288,14 +286,7 @@ var emptyUID = svc.UID{}
 
 // For retrieves the associated item for the given service name, or
 // creates a new one if it does not exist
-// TODO: to minimize the impact of the mutex below, the ReporterPool could be divided
-// in two parts: the actual LRU and the accessor that stores the lastService... fields.
-// All the goroutines can share the same LRU but keep its own accessor and only
-// sychronize the access to the cache when it's required
 func (rp *ReporterPool[K, T]) For(service K) (T, error) {
-	rp.mutex.Lock()
-	defer rp.mutex.Unlock()
-
 	rp.expireOldReporters()
 	// optimization: do not query the resources' cache if the
 	// previously processed span belongs to the same service name

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -13,6 +13,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -230,7 +231,8 @@ func shouldIncludeAttribute(normalizedAttrName string, patterns []attributes.Inc
 
 // ReporterPool keeps an LRU cache of different OTEL reporters given a service name.
 type ReporterPool[K uidGetter, T any] struct {
-	pool *simplelru.LRU[svc.UID, *expirable[T]]
+	mutex sync.Mutex
+	pool  *simplelru.LRU[svc.UID, *expirable[T]]
 
 	itemConstructor func(getter K) (T, error)
 
@@ -286,7 +288,14 @@ var emptyUID = svc.UID{}
 
 // For retrieves the associated item for the given service name, or
 // creates a new one if it does not exist
+// TODO: to minimize the impact of the mutex below, the ReporterPool could be divided
+// in two parts: the actual LRU and the accessor that stores the lastService... fields.
+// All the goroutines can share the same LRU but keep its own accessor and only
+// sychronize the access to the cache when it's required
 func (rp *ReporterPool[K, T]) For(service K) (T, error) {
+	rp.mutex.Lock()
+	defer rp.mutex.Unlock()
+
 	rp.expireOldReporters()
 	// optimization: do not query the resources' cache if the
 	// previously processed span belongs to the same service name

--- a/pkg/export/otel/otelcfg/common_test.go
+++ b/pkg/export/otel/otelcfg/common_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otel
+package otelcfg
 
 import (
 	"fmt"
@@ -17,17 +17,17 @@ import (
 
 func TestOtlpOptions_AsMetricHTTP(t *testing.T) {
 	type testCase struct {
-		in  otlpOptions
+		in  OTLPOptions
 		len int
 	}
 	testCases := []testCase{
-		{in: otlpOptions{Endpoint: "foo"}, len: 1},
-		{in: otlpOptions{Endpoint: "foo", Insecure: true}, len: 2},
-		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo"}, len: 2},
-		{in: otlpOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
-		{in: otlpOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
-		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo", SkipTLSVerify: true}, len: 3},
-		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo", Insecure: true, SkipTLSVerify: true}, len: 4},
+		{in: OTLPOptions{Endpoint: "foo"}, len: 1},
+		{in: OTLPOptions{Endpoint: "foo", Insecure: true}, len: 2},
+		{in: OTLPOptions{Endpoint: "foo", URLPath: "/foo"}, len: 2},
+		{in: OTLPOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
+		{in: OTLPOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
+		{in: OTLPOptions{Endpoint: "foo", URLPath: "/foo", SkipTLSVerify: true}, len: 3},
+		{in: OTLPOptions{Endpoint: "foo", URLPath: "/foo", Insecure: true, SkipTLSVerify: true}, len: 4},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprint(tc), func(t *testing.T) {
@@ -38,14 +38,14 @@ func TestOtlpOptions_AsMetricHTTP(t *testing.T) {
 
 func TestOtlpOptions_AsMetricGRPC(t *testing.T) {
 	type testCase struct {
-		in  otlpOptions
+		in  OTLPOptions
 		len int
 	}
 	testCases := []testCase{
-		{in: otlpOptions{Endpoint: "foo"}, len: 1},
-		{in: otlpOptions{Endpoint: "foo", Insecure: true}, len: 2},
-		{in: otlpOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
-		{in: otlpOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
+		{in: OTLPOptions{Endpoint: "foo"}, len: 1},
+		{in: OTLPOptions{Endpoint: "foo", Insecure: true}, len: 2},
+		{in: OTLPOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
+		{in: OTLPOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprint(tc), func(t *testing.T) {
@@ -56,17 +56,17 @@ func TestOtlpOptions_AsMetricGRPC(t *testing.T) {
 
 func TestOtlpOptions_AsTraceHTTP(t *testing.T) {
 	type testCase struct {
-		in  otlpOptions
+		in  OTLPOptions
 		len int
 	}
 	testCases := []testCase{
-		{in: otlpOptions{Endpoint: "foo"}, len: 1},
-		{in: otlpOptions{Endpoint: "foo", Insecure: true}, len: 2},
-		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo"}, len: 2},
-		{in: otlpOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
-		{in: otlpOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
-		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo", SkipTLSVerify: true}, len: 3},
-		{in: otlpOptions{Endpoint: "foo", URLPath: "/foo", Insecure: true, SkipTLSVerify: true}, len: 4},
+		{in: OTLPOptions{Endpoint: "foo"}, len: 1},
+		{in: OTLPOptions{Endpoint: "foo", Insecure: true}, len: 2},
+		{in: OTLPOptions{Endpoint: "foo", URLPath: "/foo"}, len: 2},
+		{in: OTLPOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
+		{in: OTLPOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
+		{in: OTLPOptions{Endpoint: "foo", URLPath: "/foo", SkipTLSVerify: true}, len: 3},
+		{in: OTLPOptions{Endpoint: "foo", URLPath: "/foo", Insecure: true, SkipTLSVerify: true}, len: 4},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprint(tc), func(t *testing.T) {
@@ -77,14 +77,14 @@ func TestOtlpOptions_AsTraceHTTP(t *testing.T) {
 
 func TestOtlpOptions_AsTraceGRPC(t *testing.T) {
 	type testCase struct {
-		in  otlpOptions
+		in  OTLPOptions
 		len int
 	}
 	testCases := []testCase{
-		{in: otlpOptions{Endpoint: "foo"}, len: 1},
-		{in: otlpOptions{Endpoint: "foo", Insecure: true}, len: 2},
-		{in: otlpOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
-		{in: otlpOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
+		{in: OTLPOptions{Endpoint: "foo"}, len: 1},
+		{in: OTLPOptions{Endpoint: "foo", Insecure: true}, len: 2},
+		{in: OTLPOptions{Endpoint: "foo", SkipTLSVerify: true}, len: 2},
+		{in: OTLPOptions{Endpoint: "foo", Insecure: true, SkipTLSVerify: true}, len: 3},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprint(tc), func(t *testing.T) {

--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -1,0 +1,278 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg
+
+import (
+	"fmt"
+	"log/slog"
+	"maps"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+	"time"
+)
+
+func mlog() *slog.Logger {
+	return slog.With("component", "otelcfg.MetricsConfig")
+}
+
+type MetricsConfig struct {
+	Interval time.Duration `yaml:"interval" env:"OTEL_EBPF_METRICS_INTERVAL"`
+	// OTELIntervalMS supports metric intervals as specified by the standard OTEL definition.
+	// OTEL_EBPF_METRICS_INTERVAL takes precedence over it.
+	OTELIntervalMS int `env:"OTEL_METRIC_EXPORT_INTERVAL"`
+
+	CommonEndpoint  string `yaml:"-" env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	MetricsEndpoint string `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"`
+
+	Protocol        Protocol `yaml:"protocol" env:"OTEL_EXPORTER_OTLP_PROTOCOL"`
+	MetricsProtocol Protocol `yaml:"-" env:"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"`
+
+	// InsecureSkipVerify is not standard, so we don't follow the same naming convention
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"OTEL_EBPF_INSECURE_SKIP_VERIFY"`
+
+	Buckets              Buckets `yaml:"buckets"`
+	HistogramAggregation string  `yaml:"histogram_aggregation" env:"OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION"`
+
+	ReportersCacheLen int `yaml:"reporters_cache_len" env:"OTEL_EBPF_METRICS_REPORT_CACHE_LEN"`
+
+	// SDKLogLevel works independently from the global LogLevel because it prints GBs of logs in Debug mode
+	// and the Info messages leak internal details that are not usually valuable for the final user.
+	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL"`
+
+	// Features of metrics that are can be exported. Accepted values are "application" and "network".
+	// envDefault is provided to avoid breaking changes
+	Features []string `yaml:"features" env:"OTEL_EBPF_METRICS_FEATURES,expand" envDefault:"${OTEL_EBPF_METRIC_FEATURES}"  envSeparator:","`
+
+	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
+	Instrumentations []string `yaml:"instrumentations" env:"OTEL_EBPF_METRICS_INSTRUMENTATIONS" envSeparator:","`
+
+	// TTL is the time since a metric was updated for the last time until it is
+	// removed from the metrics set.
+	TTL time.Duration `yaml:"ttl" env:"OTEL_EBPF_METRICS_TTL"`
+
+	AllowServiceGraphSelfReferences bool `yaml:"allow_service_graph_self_references" env:"OTEL_EBPF_ALLOW_SERVICE_GRAPH_SELF_REFERENCES"`
+
+	// OTLPEndpointProvider allows overriding the OTLP Endpoint. It needs to return an endpoint and
+	// a boolean indicating if the endpoint is common for both traces and metrics
+	OTLPEndpointProvider func() (string, bool) `yaml:"-" env:"-"`
+
+	// InjectHeaders allows injecting custom headers to the HTTP OTLP exporter
+	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
+}
+
+func (m MetricsConfig) MarshalYAML() (any, error) {
+	omit := map[string]struct{}{
+		"endpoint": {},
+	}
+	return omitFieldsForYAML(m, omit), nil
+}
+
+func (m *MetricsConfig) GetProtocol() Protocol {
+	if m.MetricsProtocol != "" {
+		return m.MetricsProtocol
+	}
+	if m.Protocol != "" {
+		return m.Protocol
+	}
+	return m.GuessProtocol()
+}
+
+func (m *MetricsConfig) GetInterval() time.Duration {
+	if m.Interval == 0 {
+		return time.Duration(m.OTELIntervalMS) * time.Millisecond
+	}
+	return m.Interval
+}
+
+func (m *MetricsConfig) GuessProtocol() Protocol {
+	// If no explicit protocol is set, we guess it it from the metrics endpoint port
+	// (assuming it uses a standard port or a development-like form like 14317, 24317, 14318...)
+	ep, _, err := parseMetricsEndpoint(m)
+	if err == nil {
+		if strings.HasSuffix(ep.Port(), UsualPortGRPC) {
+			return ProtocolGRPC
+		} else if strings.HasSuffix(ep.Port(), UsualPortHTTP) {
+			return ProtocolHTTPProtobuf
+		}
+	}
+	// Otherwise we return default protocol according to the latest specification:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md?plain=1#L53
+	return ProtocolHTTPProtobuf
+}
+
+func (m *MetricsConfig) OTLPMetricsEndpoint() (string, bool) {
+	if m.OTLPEndpointProvider != nil {
+		return m.OTLPEndpointProvider()
+	}
+	return ResolveOTLPEndpoint(m.MetricsEndpoint, m.CommonEndpoint)
+}
+
+// EndpointEnabled specifies that the OTEL metrics node is enabled if and only if
+// either the OTEL endpoint and OTEL metrics endpoint is defined.
+// If not enabled, this node won't be instantiated
+// Reason to disable linting: it requires to be a value despite it is considered a "heavy struct".
+// This method is invoked only once during startup time so it doesn't have a noticeable performance impact.
+func (m *MetricsConfig) EndpointEnabled() bool {
+	ep, _ := m.OTLPMetricsEndpoint()
+	return ep != ""
+}
+
+func (m *MetricsConfig) AnySpanMetricsEnabled() bool {
+	return m.SpanMetricsEnabled() || m.SpanMetricsSizesEnabled()
+}
+
+func (m *MetricsConfig) SpanMetricsSizesEnabled() bool {
+	return slices.Contains(m.Features, FeatureSpanSizes)
+}
+
+func (m *MetricsConfig) SpanMetricsEnabled() bool {
+	return slices.Contains(m.Features, FeatureSpan) || slices.Contains(m.Features, FeatureSpanOTel)
+}
+
+func (m *MetricsConfig) InvalidSpanMetricsConfig() bool {
+	return slices.Contains(m.Features, FeatureSpan) && slices.Contains(m.Features, FeatureSpanOTel)
+}
+
+func (m *MetricsConfig) HostMetricsEnabled() bool {
+	return slices.Contains(m.Features, FeatureApplicationHost)
+}
+
+func (m *MetricsConfig) ServiceGraphMetricsEnabled() bool {
+	return slices.Contains(m.Features, FeatureGraph)
+}
+
+func (m *MetricsConfig) OTelMetricsEnabled() bool {
+	return slices.Contains(m.Features, FeatureApplication)
+}
+
+func (m *MetricsConfig) NetworkMetricsEnabled() bool {
+	return m.NetworkFlowBytesEnabled() || m.NetworkInterzoneMetricsEnabled()
+}
+
+func (m *MetricsConfig) NetworkFlowBytesEnabled() bool {
+	return slices.Contains(m.Features, FeatureNetwork)
+}
+
+func (m *MetricsConfig) NetworkInterzoneMetricsEnabled() bool {
+	return slices.Contains(m.Features, FeatureNetworkInterZone)
+}
+
+func (m *MetricsConfig) Enabled() bool {
+	return m.EndpointEnabled() && (m.OTelMetricsEnabled() || m.AnySpanMetricsEnabled() || m.NetworkMetricsEnabled())
+}
+
+func HTTPMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	log := mlog().With("transport", "http")
+	murl, isCommon, err := parseMetricsEndpoint(cfg)
+	if err != nil {
+		return opts, err
+	}
+	log.Debug("Configuring exporter",
+		"protocol", cfg.Protocol, "metricsProtocol", cfg.MetricsProtocol, "endpoint", murl.Host)
+
+	setMetricsProtocol(cfg)
+	opts.Endpoint = murl.Host
+	if murl.Scheme == "http" || murl.Scheme == "unix" {
+		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
+		opts.Insecure = true
+	}
+	// If the value is set from the OTEL_EXPORTER_OTLP_ENDPOINT common property, we need to add /v1/metrics to the path
+	// otherwise, we leave the path that is explicitly set by the user
+	opts.URLPath = murl.Path
+	if isCommon {
+		if strings.HasSuffix(opts.URLPath, "/") {
+			opts.URLPath += "v1/metrics"
+		} else {
+			opts.URLPath += "/v1/metrics"
+		}
+	}
+	log.Debug("Specifying path", "path", opts.URLPath)
+
+	if cfg.InsecureSkipVerify {
+		log.Debug("Setting InsecureSkipVerify")
+		opts.SkipTLSVerify = cfg.InsecureSkipVerify
+	}
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envMetricsHeaders))
+
+	return opts, nil
+}
+
+func GRPCMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	log := mlog().With("transport", "grpc")
+	murl, _, err := parseMetricsEndpoint(cfg)
+	if err != nil {
+		return opts, err
+	}
+	log.Debug("Configuring exporter",
+		"protocol", cfg.Protocol, "metricsProtocol", cfg.MetricsProtocol, "endpoint", murl.Host)
+
+	setMetricsProtocol(cfg)
+	opts.Endpoint = murl.Host
+	if murl.Scheme == "http" || murl.Scheme == "unix" {
+		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
+		opts.Insecure = true
+	}
+	if cfg.InsecureSkipVerify {
+		log.Debug("Setting InsecureSkipVerify")
+		opts.SkipTLSVerify = true
+	}
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envMetricsHeaders))
+
+	return opts, nil
+}
+
+// the HTTP path will be defined from one of the following sources, from highest to lowest priority
+// - the result from any overridden OTLP Provider function
+// - OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, if defined
+// - OTEL_EXPORTER_OTLP_ENDPOINT, if defined
+func parseMetricsEndpoint(cfg *MetricsConfig) (*url.URL, bool, error) {
+	endpoint, isCommon := cfg.OTLPMetricsEndpoint()
+
+	murl, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, isCommon, fmt.Errorf("parsing endpoint URL %s: %w", endpoint, err)
+	}
+	if murl.Scheme == "" || murl.Host == "" {
+		return nil, isCommon, fmt.Errorf("URL %q must have a scheme and a host", endpoint)
+	}
+	return murl, isCommon, nil
+}
+
+// HACK: at the time of writing this, the otelpmetrichttp API does not support explicitly
+// setting the protocol. They should be properly set via environment variables, but
+// if the user supplied the value via configuration file (and not via env vars), we override the environment.
+// To be as least intrusive as possible, we will change the variables if strictly needed
+// TODO: remove this once otelpmetrichttp.WithProtocol is supported
+func setMetricsProtocol(cfg *MetricsConfig) {
+	if _, ok := os.LookupEnv(envMetricsProtocol); ok {
+		return
+	}
+	if _, ok := os.LookupEnv(envProtocol); ok {
+		return
+	}
+	if cfg.MetricsProtocol != "" {
+		os.Setenv(envMetricsProtocol, string(cfg.MetricsProtocol))
+		return
+	}
+	if cfg.Protocol != "" {
+		os.Setenv(envProtocol, string(cfg.Protocol))
+		return
+	}
+	// unset. Guessing it
+	os.Setenv(envMetricsProtocol, string(cfg.GuessProtocol()))
+}

--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -88,7 +88,7 @@ func (m *MetricsConfig) GetInterval() time.Duration {
 }
 
 func (m *MetricsConfig) GuessProtocol() Protocol {
-	// If no explicit protocol is set, we guess it it from the metrics endpoint port
+	// If no explicit protocol is set, we guess it from the metrics endpoint port
 	// (assuming it uses a standard port or a development-like form like 14317, 24317, 14318...)
 	ep, _, err := parseMetricsEndpoint(m)
 	if err == nil {

--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -164,7 +164,7 @@ func (m *MetricsConfig) Enabled() bool {
 	return m.EndpointEnabled() && (m.OTelMetricsEnabled() || m.AnySpanMetricsEnabled() || m.NetworkMetricsEnabled())
 }
 
-func HTTPMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
+func httpMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
 	opts := OTLPOptions{Headers: map[string]string{}}
 	log := mlog().With("transport", "http")
 	murl, isCommon, err := parseMetricsEndpoint(cfg)
@@ -206,7 +206,7 @@ func HTTPMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
 	return opts, nil
 }
 
-func GRPCMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
+func grpcMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
 	opts := OTLPOptions{Headers: map[string]string{}}
 	log := mlog().With("transport", "grpc")
 	murl, _, err := parseMetricsEndpoint(cfg)

--- a/pkg/export/otel/otelcfg/config_metrics_test.go
+++ b/pkg/export/otel/otelcfg/config_metrics_test.go
@@ -1,0 +1,248 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+)
+
+func TestHTTPMetricsEndpointOptions(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	mcfg := MetricsConfig{
+		CommonEndpoint:  "https://localhost:3131",
+		MetricsEndpoint: "https://localhost:3232/v1/metrics",
+		Instrumentations: []string{
+			instrumentations.InstrumentationHTTP,
+		},
+	}
+
+	t.Run("testing with two endpoints", func(t *testing.T) {
+		testMetricsHTTPOptions(t, OTLPOptions{Endpoint: "localhost:3232", URLPath: "/v1/metrics", Headers: map[string]string{}}, &mcfg)
+	})
+
+	mcfg = MetricsConfig{
+		CommonEndpoint: "https://localhost:3131/otlp",
+		Instrumentations: []string{
+			instrumentations.InstrumentationHTTP,
+		},
+	}
+
+	t.Run("testing with only common endpoint", func(t *testing.T) {
+		testMetricsHTTPOptions(t, OTLPOptions{Endpoint: "localhost:3131", URLPath: "/otlp/v1/metrics", Headers: map[string]string{}}, &mcfg)
+	})
+
+	mcfg = MetricsConfig{
+		CommonEndpoint:  "https://localhost:3131",
+		MetricsEndpoint: "http://localhost:3232",
+		Instrumentations: []string{
+			instrumentations.InstrumentationHTTP,
+		},
+	}
+	t.Run("testing with insecure endpoint", func(t *testing.T) {
+		testMetricsHTTPOptions(t, OTLPOptions{Endpoint: "localhost:3232", Insecure: true, Headers: map[string]string{}}, &mcfg)
+	})
+
+	mcfg = MetricsConfig{
+		CommonEndpoint:     "https://localhost:3232",
+		InsecureSkipVerify: true,
+		Instrumentations: []string{
+			instrumentations.InstrumentationHTTP,
+		},
+	}
+
+	t.Run("testing with skip TLS verification", func(t *testing.T) {
+		testMetricsHTTPOptions(t, OTLPOptions{Endpoint: "localhost:3232", URLPath: "/v1/metrics", SkipTLSVerify: true, Headers: map[string]string{}}, &mcfg)
+	})
+}
+
+func testMetricsHTTPOptions(t *testing.T, expected OTLPOptions, mcfg *MetricsConfig) {
+	defer RestoreEnvAfterExecution()()
+	opts, err := HTTPMetricEndpointOptions(mcfg)
+	require.NoError(t, err)
+	assert.Equal(t, expected, opts)
+}
+
+func TestMissingSchemeInMetricsEndpoint(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	opts, err := HTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "http://foo:3030", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
+	require.NoError(t, err)
+	require.NotEmpty(t, opts)
+
+	_, err = HTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo:3030", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
+	require.Error(t, err)
+
+	_, err = HTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
+	require.Error(t, err)
+}
+
+func TestGRPCMetricsEndpointOptions(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	t.Run("do not accept URLs without a scheme", func(t *testing.T) {
+		_, err := GRPCMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo:3939"})
+		require.Error(t, err)
+	})
+
+	mcfg := MetricsConfig{
+		CommonEndpoint:   "https://localhost:3131",
+		MetricsEndpoint:  "https://localhost:3232",
+		Instrumentations: []string{instrumentations.InstrumentationHTTP},
+	}
+
+	t.Run("testing with two endpoints", func(t *testing.T) {
+		testMetricsGRPCOptions(t, OTLPOptions{Endpoint: "localhost:3232", Headers: map[string]string{}}, &mcfg)
+	})
+
+	mcfg = MetricsConfig{
+		CommonEndpoint:   "https://localhost:3131",
+		Instrumentations: []string{instrumentations.InstrumentationHTTP},
+	}
+
+	t.Run("testing with only common endpoint", func(t *testing.T) {
+		testMetricsGRPCOptions(t, OTLPOptions{Endpoint: "localhost:3131", Headers: map[string]string{}}, &mcfg)
+	})
+
+	mcfg = MetricsConfig{
+		CommonEndpoint:   "https://localhost:3131",
+		MetricsEndpoint:  "http://localhost:3232",
+		Instrumentations: []string{instrumentations.InstrumentationHTTP},
+	}
+	t.Run("testing with insecure endpoint", func(t *testing.T) {
+		testMetricsGRPCOptions(t, OTLPOptions{Endpoint: "localhost:3232", Insecure: true, Headers: map[string]string{}}, &mcfg)
+	})
+
+	mcfg = MetricsConfig{
+		CommonEndpoint:     "https://localhost:3232",
+		InsecureSkipVerify: true,
+		Instrumentations:   []string{instrumentations.InstrumentationHTTP},
+	}
+
+	t.Run("testing with skip TLS verification", func(t *testing.T) {
+		testMetricsGRPCOptions(t, OTLPOptions{Endpoint: "localhost:3232", SkipTLSVerify: true, Headers: map[string]string{}}, &mcfg)
+	})
+}
+
+func testMetricsGRPCOptions(t *testing.T, expected OTLPOptions, mcfg *MetricsConfig) {
+	defer RestoreEnvAfterExecution()()
+	opts, err := GRPCMetricEndpointOptions(mcfg)
+	require.NoError(t, err)
+	assert.Equal(t, expected, opts)
+}
+
+func TestMetricsSetupHTTP_Protocol(t *testing.T) {
+	testCases := []struct {
+		Endpoint               string
+		ProtoVal               Protocol
+		MetricProtoVal         Protocol
+		ExpectedProtoEnv       string
+		ExpectedMetricProtoEnv string
+	}{
+		{ProtoVal: "", MetricProtoVal: "", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "http/protobuf"},
+		{ProtoVal: "", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
+		{ProtoVal: "bar", MetricProtoVal: "", ExpectedProtoEnv: "bar", ExpectedMetricProtoEnv: ""},
+		{ProtoVal: "bar", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
+		{Endpoint: "http://foo:4317", ProtoVal: "", MetricProtoVal: "", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "grpc"},
+		{Endpoint: "http://foo:4317", ProtoVal: "", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
+		{Endpoint: "http://foo:4317", ProtoVal: "bar", MetricProtoVal: "", ExpectedProtoEnv: "bar", ExpectedMetricProtoEnv: ""},
+		{Endpoint: "http://foo:4317", ProtoVal: "bar", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
+		{Endpoint: "http://foo:14317", ProtoVal: "", MetricProtoVal: "", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "grpc"},
+		{Endpoint: "http://foo:14317", ProtoVal: "", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
+		{Endpoint: "http://foo:14317", ProtoVal: "bar", MetricProtoVal: "", ExpectedProtoEnv: "bar", ExpectedMetricProtoEnv: ""},
+		{Endpoint: "http://foo:14317", ProtoVal: "bar", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
+		{Endpoint: "http://foo:4318", ProtoVal: "", MetricProtoVal: "", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "http/protobuf"},
+		{Endpoint: "http://foo:4318", ProtoVal: "", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
+		{Endpoint: "http://foo:4318", ProtoVal: "bar", MetricProtoVal: "", ExpectedProtoEnv: "bar", ExpectedMetricProtoEnv: ""},
+		{Endpoint: "http://foo:4318", ProtoVal: "bar", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
+		{Endpoint: "http://foo:24318", ProtoVal: "", MetricProtoVal: "", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "http/protobuf"},
+		{Endpoint: "http://foo:24318", ProtoVal: "", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
+		{Endpoint: "http://foo:24318", ProtoVal: "bar", MetricProtoVal: "", ExpectedProtoEnv: "bar", ExpectedMetricProtoEnv: ""},
+		{Endpoint: "http://foo:24318", ProtoVal: "bar", MetricProtoVal: "foo", ExpectedProtoEnv: "", ExpectedMetricProtoEnv: "foo"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Endpoint+"/"+string(tc.ProtoVal)+"/"+string(tc.MetricProtoVal), func(t *testing.T) {
+			defer RestoreEnvAfterExecution()()
+			_, err := HTTPMetricEndpointOptions(&MetricsConfig{
+				CommonEndpoint:   "http://host:3333",
+				MetricsEndpoint:  tc.Endpoint,
+				Protocol:         tc.ProtoVal,
+				MetricsProtocol:  tc.MetricProtoVal,
+				Instrumentations: []string{instrumentations.InstrumentationHTTP},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.ExpectedProtoEnv, os.Getenv(envProtocol))
+			assert.Equal(t, tc.ExpectedMetricProtoEnv, os.Getenv(envMetricsProtocol))
+		})
+	}
+}
+
+func TestMetricSetupHTTP_DoNotOverrideEnv(t *testing.T) {
+	t.Run("setting both variables", func(t *testing.T) {
+		defer RestoreEnvAfterExecution()()
+		t.Setenv(envProtocol, "foo-proto")
+		t.Setenv(envMetricsProtocol, "bar-proto")
+		_, err := HTTPMetricEndpointOptions(&MetricsConfig{
+			CommonEndpoint: "http://host:3333", Protocol: "foo", MetricsProtocol: "bar", Instrumentations: []string{instrumentations.InstrumentationHTTP},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "foo-proto", os.Getenv(envProtocol))
+		assert.Equal(t, "bar-proto", os.Getenv(envMetricsProtocol))
+	})
+	t.Run("setting only proto env var", func(t *testing.T) {
+		defer RestoreEnvAfterExecution()()
+		t.Setenv(envProtocol, "foo-proto")
+		_, err := HTTPMetricEndpointOptions(&MetricsConfig{
+			CommonEndpoint: "http://host:3333", Protocol: "foo", Instrumentations: []string{instrumentations.InstrumentationHTTP},
+		})
+		require.NoError(t, err)
+		_, ok := os.LookupEnv(envMetricsProtocol)
+		assert.False(t, ok)
+		assert.Equal(t, "foo-proto", os.Getenv(envProtocol))
+	})
+}
+
+func TestMetricsConfig_Enabled(t *testing.T) {
+	assert.True(t, (&MetricsConfig{Features: []string{FeatureApplication, FeatureNetwork}, CommonEndpoint: "foo"}).Enabled())
+	assert.True(t, (&MetricsConfig{Features: []string{FeatureApplication}, MetricsEndpoint: "foo"}).Enabled())
+	assert.True(t, (&MetricsConfig{MetricsEndpoint: "foo", Features: []string{FeatureNetwork}}).Enabled())
+	assert.True(t, (&MetricsConfig{
+		Features:             []string{FeatureNetwork},
+		OTLPEndpointProvider: func() (string, bool) { return "something", false },
+	}).Enabled())
+	assert.True(t, (&MetricsConfig{
+		Features:             []string{FeatureNetwork},
+		OTLPEndpointProvider: func() (string, bool) { return "something", true },
+	}).Enabled())
+}
+
+func TestMetricsConfig_Disabled(t *testing.T) {
+	assert.False(t, (&MetricsConfig{Features: []string{FeatureApplication}}).Enabled())
+	assert.False(t, (&MetricsConfig{Features: []string{FeatureNetwork, FeatureApplication}}).Enabled())
+	assert.False(t, (&MetricsConfig{Features: []string{FeatureNetwork}}).Enabled())
+	// application feature is not enabled
+	assert.False(t, (&MetricsConfig{CommonEndpoint: "foo"}).Enabled())
+	assert.False(t, (&MetricsConfig{}).Enabled())
+	assert.False(t, (&MetricsConfig{
+		Features:             []string{FeatureApplication},
+		OTLPEndpointProvider: func() (string, bool) { return "", false },
+	}).Enabled())
+}
+
+func TestMetricsInterval(t *testing.T) {
+	cfg := MetricsConfig{
+		OTELIntervalMS: 60_000,
+	}
+	t.Run("If only OTEL is defined, it uses that value", func(t *testing.T) {
+		assert.Equal(t, 60*time.Second, cfg.GetInterval())
+	})
+	cfg.Interval = 5 * time.Second
+	t.Run("Beyla interval takes precedence over OTEL", func(t *testing.T) {
+		assert.Equal(t, 5*time.Second, cfg.GetInterval())
+	})
+}

--- a/pkg/export/otel/otelcfg/config_metrics_test.go
+++ b/pkg/export/otel/otelcfg/config_metrics_test.go
@@ -65,28 +65,28 @@ func TestHTTPMetricsEndpointOptions(t *testing.T) {
 
 func testMetricsHTTPOptions(t *testing.T, expected OTLPOptions, mcfg *MetricsConfig) {
 	defer RestoreEnvAfterExecution()()
-	opts, err := HTTPMetricEndpointOptions(mcfg)
+	opts, err := httpMetricEndpointOptions(mcfg)
 	require.NoError(t, err)
 	assert.Equal(t, expected, opts)
 }
 
 func TestMissingSchemeInMetricsEndpoint(t *testing.T) {
 	defer RestoreEnvAfterExecution()()
-	opts, err := HTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "http://foo:3030", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
+	opts, err := httpMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "http://foo:3030", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
 	require.NoError(t, err)
 	require.NotEmpty(t, opts)
 
-	_, err = HTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo:3030", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
+	_, err = httpMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo:3030", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
 	require.Error(t, err)
 
-	_, err = HTTPMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
+	_, err = httpMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo", Instrumentations: []string{instrumentations.InstrumentationHTTP}})
 	require.Error(t, err)
 }
 
 func TestGRPCMetricsEndpointOptions(t *testing.T) {
 	defer RestoreEnvAfterExecution()()
 	t.Run("do not accept URLs without a scheme", func(t *testing.T) {
-		_, err := GRPCMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo:3939"})
+		_, err := grpcMetricEndpointOptions(&MetricsConfig{CommonEndpoint: "foo:3939"})
 		require.Error(t, err)
 	})
 
@@ -131,7 +131,7 @@ func TestGRPCMetricsEndpointOptions(t *testing.T) {
 
 func testMetricsGRPCOptions(t *testing.T, expected OTLPOptions, mcfg *MetricsConfig) {
 	defer RestoreEnvAfterExecution()()
-	opts, err := GRPCMetricEndpointOptions(mcfg)
+	opts, err := grpcMetricEndpointOptions(mcfg)
 	require.NoError(t, err)
 	assert.Equal(t, expected, opts)
 }
@@ -168,7 +168,7 @@ func TestMetricsSetupHTTP_Protocol(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Endpoint+"/"+string(tc.ProtoVal)+"/"+string(tc.MetricProtoVal), func(t *testing.T) {
 			defer RestoreEnvAfterExecution()()
-			_, err := HTTPMetricEndpointOptions(&MetricsConfig{
+			_, err := httpMetricEndpointOptions(&MetricsConfig{
 				CommonEndpoint:   "http://host:3333",
 				MetricsEndpoint:  tc.Endpoint,
 				Protocol:         tc.ProtoVal,
@@ -187,7 +187,7 @@ func TestMetricSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 		defer RestoreEnvAfterExecution()()
 		t.Setenv(envProtocol, "foo-proto")
 		t.Setenv(envMetricsProtocol, "bar-proto")
-		_, err := HTTPMetricEndpointOptions(&MetricsConfig{
+		_, err := httpMetricEndpointOptions(&MetricsConfig{
 			CommonEndpoint: "http://host:3333", Protocol: "foo", MetricsProtocol: "bar", Instrumentations: []string{instrumentations.InstrumentationHTTP},
 		})
 		require.NoError(t, err)
@@ -197,7 +197,7 @@ func TestMetricSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 	t.Run("setting only proto env var", func(t *testing.T) {
 		defer RestoreEnvAfterExecution()()
 		t.Setenv(envProtocol, "foo-proto")
-		_, err := HTTPMetricEndpointOptions(&MetricsConfig{
+		_, err := httpMetricEndpointOptions(&MetricsConfig{
 			CommonEndpoint: "http://host:3333", Protocol: "foo", Instrumentations: []string{instrumentations.InstrumentationHTTP},
 		})
 		require.NoError(t, err)

--- a/pkg/export/otel/otelcfg/config_traces.go
+++ b/pkg/export/otel/otelcfg/config_traces.go
@@ -1,0 +1,223 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg
+
+import (
+	"fmt"
+	"log/slog"
+	"maps"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/obi/pkg/services"
+)
+
+func tlog() *slog.Logger {
+	return slog.With("component", "otelcfg.TracesConfig")
+}
+
+type TracesConfig struct {
+	CommonEndpoint string `yaml:"-" env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	TracesEndpoint string `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"`
+
+	Protocol       Protocol `yaml:"protocol" env:"OTEL_EXPORTER_OTLP_PROTOCOL"`
+	TracesProtocol Protocol `yaml:"-" env:"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"`
+
+	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
+	Instrumentations []string `yaml:"instrumentations" env:"OTEL_EBPF_TRACES_INSTRUMENTATIONS" envSeparator:","`
+
+	// InsecureSkipVerify is not standard, so we don't follow the same naming convention
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"OTEL_EBPF_INSECURE_SKIP_VERIFY"`
+
+	SamplerConfig services.SamplerConfig `yaml:"sampler"`
+
+	// Configuration options below this line will remain undocumented at the moment,
+	// but can be useful for performance-tuning of some customers.
+	MaxQueueSize int           `yaml:"max_queue_size" env:"OTEL_EBPF_OTLP_TRACES_MAX_QUEUE_SIZE"`
+	BatchTimeout time.Duration `yaml:"batch_timeout" env:"OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT"`
+
+	// Configuration options for BackOffConfig of the traces exporter.
+	// See https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configretry/backoff.go
+	// BackOffInitialInterval the time to wait after the first failure before retrying.
+	BackOffInitialInterval time.Duration `yaml:"backoff_initial_interval" env:"OTEL_EBPF_BACKOFF_INITIAL_INTERVAL"`
+	// BackOffMaxInterval is the upper bound on backoff interval.
+	BackOffMaxInterval time.Duration `yaml:"backoff_max_interval" env:"OTEL_EBPF_BACKOFF_MAX_INTERVAL"`
+	// BackOffMaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batch.
+	BackOffMaxElapsedTime time.Duration `yaml:"backoff_max_elapsed_time" env:"OTEL_EBPF_BACKOFF_MAX_ELAPSED_TIME"`
+	ReportersCacheLen     int           `yaml:"reporters_cache_len" env:"OTEL_EBPF_TRACES_REPORT_CACHE_LEN"`
+
+	// SDKLogLevel works independently from the global LogLevel because it prints GBs of logs in Debug mode
+	// and the Info messages leak internal details that are not usually valuable for the final user.
+	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL"`
+
+	// OTLPEndpointProvider allows overriding the OTLP Endpoint. It needs to return an endpoint and
+	// a boolean indicating if the endpoint is common for both traces and metrics
+	OTLPEndpointProvider func() (string, bool) `yaml:"-" env:"-"`
+
+	// InjectHeaders allows injecting custom headers to the HTTP OTLP exporter
+	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
+}
+
+func (m TracesConfig) MarshalYAML() (any, error) {
+	omit := map[string]struct{}{
+		"endpoint": {},
+	}
+	return omitFieldsForYAML(m, omit), nil
+}
+
+// Enabled specifies that the OTEL traces node is enabled if and only if
+// either the OTEL endpoint and OTEL traces endpoint is defined.
+// If not enabled, this node won't be instantiated
+func (m *TracesConfig) Enabled() bool {
+	return m.CommonEndpoint != "" || m.TracesEndpoint != ""
+}
+
+func (m *TracesConfig) GetProtocol() Protocol {
+	if m.TracesProtocol != "" {
+		return m.TracesProtocol
+	}
+	if m.Protocol != "" {
+		return m.Protocol
+	}
+	return m.guessProtocol()
+}
+
+func (m *TracesConfig) OTLPTracesEndpoint() (string, bool) {
+	if m.OTLPEndpointProvider != nil {
+		return m.OTLPEndpointProvider()
+	}
+	return ResolveOTLPEndpoint(m.TracesEndpoint, m.CommonEndpoint)
+}
+
+func (m *TracesConfig) guessProtocol() Protocol {
+	// If no explicit protocol is set, we guess it it from the metrics enpdoint port
+	// (assuming it uses a standard port or a development-like form like 14317, 24317, 14318...)
+	ep, _, err := ParseTracesEndpoint(m)
+	if err == nil {
+		if strings.HasSuffix(ep.Port(), UsualPortGRPC) {
+			return ProtocolGRPC
+		} else if strings.HasSuffix(ep.Port(), UsualPortHTTP) {
+			return ProtocolHTTPProtobuf
+		}
+	}
+	// Otherwise we return default protocol according to the latest specification:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md?plain=1#L53
+	return ProtocolHTTPProtobuf
+}
+
+// ParseTracesEndpoint defines the HTTP path of the traces collector.
+// The HTTP path will be defined from one of the following sources, from highest to lowest priority
+// - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, if defined
+// - OTEL_EXPORTER_OTLP_ENDPOINT, if defined
+// - https://otlp-gateway-${GRAFANA_CLOUD_ZONE}.grafana.net/otlp, if GRAFANA_CLOUD_ZONE is defined
+// If, by some reason, Grafana changes its OTLP Gateway URL in a distant future, you can still point to the
+// correct URL with the OTLP_EXPORTER_... variables.
+func ParseTracesEndpoint(cfg *TracesConfig) (*url.URL, bool, error) {
+	endpoint, isCommon := cfg.OTLPTracesEndpoint()
+
+	murl, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, isCommon, fmt.Errorf("parsing endpoint URL %s: %w", endpoint, err)
+	}
+	if murl.Scheme == "" || murl.Host == "" {
+		return nil, isCommon, fmt.Errorf("URL %q must have a scheme and a host", endpoint)
+	}
+	return murl, isCommon, nil
+}
+
+func HTTPTracesEndpointOptions(cfg *TracesConfig) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	log := tlog().With("transport", "http")
+
+	murl, isCommon, err := ParseTracesEndpoint(cfg)
+	if err != nil {
+		return opts, err
+	}
+
+	log.Debug("Configuring exporter", "protocol",
+		cfg.Protocol, "tracesProtocol", cfg.TracesProtocol, "endpoint", murl.Host)
+	setTracesProtocol(cfg)
+	opts.Scheme = murl.Scheme
+	opts.Endpoint = murl.Host
+	if murl.Scheme == "http" || murl.Scheme == "unix" {
+		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
+		opts.Insecure = true
+	}
+	// If the value is set from the OTEL_EXPORTER_OTLP_ENDPOINT common property, we need to add /v1/traces to the path
+	// otherwise, we leave the path that is explicitly set by the user
+	opts.URLPath = strings.TrimSuffix(murl.Path, "/")
+	opts.BaseURLPath = strings.TrimSuffix(opts.URLPath, "/v1/traces")
+	if isCommon {
+		opts.URLPath += "/v1/traces"
+		log.Debug("Specifying path", "path", opts.URLPath)
+	}
+
+	if cfg.InsecureSkipVerify {
+		log.Debug("Setting InsecureSkipVerify")
+		opts.SkipTLSVerify = true
+	}
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envTracesHeaders))
+
+	return opts, nil
+}
+
+func GRPCTracesEndpointOptions(cfg *TracesConfig) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	log := tlog().With("transport", "grpc")
+	murl, _, err := ParseTracesEndpoint(cfg)
+	if err != nil {
+		return opts, err
+	}
+
+	log.Debug("Configuring exporter", "protocol",
+		cfg.Protocol, "tracesProtocol", cfg.TracesProtocol, "endpoint", murl.Host)
+	opts.Endpoint = murl.Host
+	if murl.Scheme == "http" || murl.Scheme == "unix" {
+		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
+		opts.Insecure = true
+	}
+
+	if cfg.InsecureSkipVerify {
+		log.Debug("Setting InsecureSkipVerify")
+		opts.SkipTLSVerify = true
+	}
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envTracesHeaders))
+	return opts, nil
+}
+
+// HACK: at the time of writing this, the otelptracehttp API does not support explicitly
+// setting the protocol. They should be properly set via environment variables, but
+// if the user supplied the value via configuration file (and not via env vars), we override the environment.
+// To be as least intrusive as possible, we will change the variables if strictly needed
+// TODO: remove this once otelptracehttp.WithProtocol is supported
+func setTracesProtocol(cfg *TracesConfig) {
+	if _, ok := os.LookupEnv(envTracesProtocol); ok {
+		return
+	}
+	if _, ok := os.LookupEnv(envProtocol); ok {
+		return
+	}
+	if cfg.TracesProtocol != "" {
+		os.Setenv(envTracesProtocol, string(cfg.TracesProtocol))
+		return
+	}
+	if cfg.Protocol != "" {
+		os.Setenv(envProtocol, string(cfg.Protocol))
+		return
+	}
+	// unset. Guessing it
+	os.Setenv(envTracesProtocol, string(cfg.guessProtocol()))
+}

--- a/pkg/export/otel/otelcfg/config_traces_test.go
+++ b/pkg/export/otel/otelcfg/config_traces_test.go
@@ -1,0 +1,320 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+)
+
+func TestHTTPTracesEndpoint(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	tcfg := TracesConfig{
+		CommonEndpoint:   "https://localhost:3131",
+		TracesEndpoint:   "https://localhost:3232/v1/traces",
+		Instrumentations: []string{instrumentations.InstrumentationALL},
+	}
+
+	t.Run("testing with two endpoints", func(t *testing.T) {
+		testHTTPTracesOptions(t, OTLPOptions{Scheme: "https", Endpoint: "localhost:3232", URLPath: "/v1/traces", Headers: map[string]string{}}, &tcfg)
+	})
+
+	tcfg = TracesConfig{
+		CommonEndpoint:   "https://localhost:3131/otlp",
+		Instrumentations: []string{instrumentations.InstrumentationALL},
+	}
+
+	t.Run("testing with only common endpoint", func(t *testing.T) {
+		testHTTPTracesOptions(t, OTLPOptions{Scheme: "https", Endpoint: "localhost:3131", BaseURLPath: "/otlp", URLPath: "/otlp/v1/traces", Headers: map[string]string{}}, &tcfg)
+	})
+
+	tcfg = TracesConfig{
+		CommonEndpoint:   "https://localhost:3131",
+		TracesEndpoint:   "http://localhost:3232",
+		Instrumentations: []string{instrumentations.InstrumentationALL},
+	}
+	t.Run("testing with insecure endpoint", func(t *testing.T) {
+		testHTTPTracesOptions(t, OTLPOptions{Scheme: "http", Endpoint: "localhost:3232", Insecure: true, Headers: map[string]string{}}, &tcfg)
+	})
+
+	tcfg = TracesConfig{
+		CommonEndpoint:     "https://localhost:3232",
+		InsecureSkipVerify: true,
+		Instrumentations:   []string{instrumentations.InstrumentationALL},
+	}
+
+	t.Run("testing with skip TLS verification", func(t *testing.T) {
+		testHTTPTracesOptions(t, OTLPOptions{Scheme: "https", Endpoint: "localhost:3232", URLPath: "/v1/traces", SkipTLSVerify: true, Headers: map[string]string{}}, &tcfg)
+	})
+}
+
+func testHTTPTracesOptions(t *testing.T, expected OTLPOptions, tcfg *TracesConfig) {
+	defer RestoreEnvAfterExecution()()
+	opts, err := HTTPTracesEndpointOptions(tcfg)
+	require.NoError(t, err)
+	assert.Equal(t, expected, opts)
+}
+
+func TestMissingSchemeInHTTPTracesEndpoint(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	opts, err := HTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "http://foo:3030", Instrumentations: []string{instrumentations.InstrumentationALL}})
+	require.NoError(t, err)
+	require.NotEmpty(t, opts)
+
+	_, err = HTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo:3030", Instrumentations: []string{instrumentations.InstrumentationALL}})
+	require.Error(t, err)
+
+	_, err = HTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo", Instrumentations: []string{instrumentations.InstrumentationALL}})
+	require.Error(t, err)
+}
+
+func TestHTTPTracesEndpointHeaders(t *testing.T) {
+	type testCase struct {
+		Description     string
+		Env             map[string]string
+		ExpectedHeaders map[string]string
+	}
+	for _, tc := range []testCase{
+		{
+			Description:     "No headers",
+			ExpectedHeaders: map[string]string{},
+		},
+		{
+			Description:     "defining common OTLP_HEADERS",
+			Env:             map[string]string{"OTEL_EXPORTER_OTLP_HEADERS": "Foo=Bar ==,Authorization=Base 2222=="},
+			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 2222=="},
+		},
+		{
+			Description:     "defining common OTLP_TRACES_HEADERS",
+			Env:             map[string]string{"OTEL_EXPORTER_OTLP_TRACES_HEADERS": "Foo=Bar ==,Authorization=Base 1234=="},
+			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 1234=="},
+		},
+		{
+			Description: "OTLP_TRACES_HEADERS takes precedence over OTLP_HEADERS",
+			Env: map[string]string{
+				"OTEL_EXPORTER_OTLP_HEADERS":        "Foo=Bar ==,Authorization=Base 3210==",
+				"OTEL_EXPORTER_OTLP_TRACES_HEADERS": "Authorization=Base 1111==",
+			},
+			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 1111=="},
+		},
+	} {
+		// mutex to avoid running testcases in parallel so we don't mess up with env vars
+		mt := sync.Mutex{}
+		t.Run(tc.Description, func(t *testing.T) {
+			mt.Lock()
+			restore := RestoreEnvAfterExecution()
+			defer func() {
+				restore()
+				mt.Unlock()
+			}()
+			for k, v := range tc.Env {
+				t.Setenv(k, v)
+			}
+
+			opts, err := HTTPTracesEndpointOptions(&TracesConfig{
+				TracesEndpoint:   "https://localhost:1234/v1/traces",
+				Instrumentations: []string{instrumentations.InstrumentationALL},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.ExpectedHeaders, opts.Headers)
+		})
+	}
+}
+
+func TestGRPCTracesEndpointOptions(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	t.Run("do not accept URLs without a scheme", func(t *testing.T) {
+		_, err := GRPCTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo:3939", Instrumentations: []string{instrumentations.InstrumentationALL}})
+		require.Error(t, err)
+	})
+	tcfg := TracesConfig{
+		CommonEndpoint:   "https://localhost:3131",
+		TracesEndpoint:   "https://localhost:3232",
+		Instrumentations: []string{instrumentations.InstrumentationALL},
+	}
+
+	t.Run("testing with two endpoints", func(t *testing.T) {
+		testTracesGRPCOptions(t, OTLPOptions{Endpoint: "localhost:3232", Headers: map[string]string{}}, &tcfg)
+	})
+
+	tcfg = TracesConfig{
+		CommonEndpoint:   "https://localhost:3131",
+		Instrumentations: []string{instrumentations.InstrumentationALL},
+	}
+
+	t.Run("testing with only common endpoint", func(t *testing.T) {
+		testTracesGRPCOptions(t, OTLPOptions{Endpoint: "localhost:3131", Headers: map[string]string{}}, &tcfg)
+	})
+
+	tcfg = TracesConfig{
+		CommonEndpoint:   "https://localhost:3131",
+		TracesEndpoint:   "http://localhost:3232",
+		Instrumentations: []string{instrumentations.InstrumentationALL},
+	}
+	t.Run("testing with insecure endpoint", func(t *testing.T) {
+		testTracesGRPCOptions(t, OTLPOptions{Endpoint: "localhost:3232", Insecure: true, Headers: map[string]string{}}, &tcfg)
+	})
+
+	tcfg = TracesConfig{
+		CommonEndpoint:     "https://localhost:3232",
+		InsecureSkipVerify: true,
+		Instrumentations:   []string{instrumentations.InstrumentationALL},
+	}
+
+	t.Run("testing with skip TLS verification", func(t *testing.T) {
+		testTracesGRPCOptions(t, OTLPOptions{Endpoint: "localhost:3232", SkipTLSVerify: true, Headers: map[string]string{}}, &tcfg)
+	})
+}
+
+func TestGRPCTracesEndpointHeaders(t *testing.T) {
+	type testCase struct {
+		Description     string
+		Env             map[string]string
+		ExpectedHeaders map[string]string
+	}
+	for _, tc := range []testCase{
+		{
+			Description:     "No headers",
+			ExpectedHeaders: map[string]string{},
+		},
+		{
+			Description:     "defining common OTLP_HEADERS",
+			Env:             map[string]string{"OTEL_EXPORTER_OTLP_HEADERS": "Foo=Bar ==,Authorization=Base 2222=="},
+			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 2222=="},
+		},
+		{
+			Description:     "defining common OTLP_TRACES_HEADERS",
+			Env:             map[string]string{"OTEL_EXPORTER_OTLP_TRACES_HEADERS": "Foo=Bar ==,Authorization=Base 1234=="},
+			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 1234=="},
+		},
+		{
+			Description: "OTLP_TRACES_HEADERS takes precedence over OTLP_HEADERS",
+			Env: map[string]string{
+				"OTEL_EXPORTER_OTLP_HEADERS":        "Foo=Bar ==,Authorization=Base 3210==",
+				"OTEL_EXPORTER_OTLP_TRACES_HEADERS": "Authorization=Base 1111==",
+			},
+			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 1111=="},
+		},
+	} {
+		// mutex to avoid running testcases in parallel so we don't mess up with env vars
+		mt := sync.Mutex{}
+		t.Run(tc.Description, func(t *testing.T) {
+			mt.Lock()
+			restore := RestoreEnvAfterExecution()
+			defer func() {
+				restore()
+				mt.Unlock()
+			}()
+			for k, v := range tc.Env {
+				t.Setenv(k, v)
+			}
+
+			opts, err := GRPCTracesEndpointOptions(&TracesConfig{
+				TracesEndpoint:   "https://localhost:1234/v1/traces",
+				Instrumentations: []string{instrumentations.InstrumentationALL},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.ExpectedHeaders, opts.Headers)
+		})
+	}
+}
+
+func testTracesGRPCOptions(t *testing.T, expected OTLPOptions, tcfg *TracesConfig) {
+	defer RestoreEnvAfterExecution()()
+	opts, err := GRPCTracesEndpointOptions(tcfg)
+	require.NoError(t, err)
+	assert.Equal(t, expected, opts)
+}
+
+func TestTracesSetupHTTP_Protocol(t *testing.T) {
+	testCases := []struct {
+		Endpoint              string
+		ProtoVal              Protocol
+		TraceProtoVal         Protocol
+		ExpectedProtoEnv      string
+		ExpectedTraceProtoEnv string
+	}{
+		{ProtoVal: "", TraceProtoVal: "", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "http/protobuf"},
+		{ProtoVal: "", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
+		{ProtoVal: "bar", TraceProtoVal: "", ExpectedProtoEnv: "bar", ExpectedTraceProtoEnv: ""},
+		{ProtoVal: "bar", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
+		{Endpoint: "http://foo:4317", ProtoVal: "", TraceProtoVal: "", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "grpc"},
+		{Endpoint: "http://foo:4317", ProtoVal: "", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
+		{Endpoint: "http://foo:4317", ProtoVal: "bar", TraceProtoVal: "", ExpectedProtoEnv: "bar", ExpectedTraceProtoEnv: ""},
+		{Endpoint: "http://foo:4317", ProtoVal: "bar", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
+		{Endpoint: "http://foo:14317", ProtoVal: "", TraceProtoVal: "", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "grpc"},
+		{Endpoint: "http://foo:14317", ProtoVal: "", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
+		{Endpoint: "http://foo:14317", ProtoVal: "bar", TraceProtoVal: "", ExpectedProtoEnv: "bar", ExpectedTraceProtoEnv: ""},
+		{Endpoint: "http://foo:14317", ProtoVal: "bar", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
+		{Endpoint: "http://foo:4318", ProtoVal: "", TraceProtoVal: "", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "http/protobuf"},
+		{Endpoint: "http://foo:4318", ProtoVal: "", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
+		{Endpoint: "http://foo:4318", ProtoVal: "bar", TraceProtoVal: "", ExpectedProtoEnv: "bar", ExpectedTraceProtoEnv: ""},
+		{Endpoint: "http://foo:4318", ProtoVal: "bar", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
+		{Endpoint: "http://foo:24318", ProtoVal: "", TraceProtoVal: "", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "http/protobuf"},
+		{Endpoint: "http://foo:24318", ProtoVal: "", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
+		{Endpoint: "http://foo:24318", ProtoVal: "bar", TraceProtoVal: "", ExpectedProtoEnv: "bar", ExpectedTraceProtoEnv: ""},
+		{Endpoint: "http://foo:24318", ProtoVal: "bar", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Endpoint+"/"+string(tc.ProtoVal)+"/"+string(tc.TraceProtoVal), func(t *testing.T) {
+			defer RestoreEnvAfterExecution()()
+			_, err := HTTPTracesEndpointOptions(&TracesConfig{
+				CommonEndpoint:   "http://host:3333",
+				TracesEndpoint:   tc.Endpoint,
+				Protocol:         tc.ProtoVal,
+				TracesProtocol:   tc.TraceProtoVal,
+				Instrumentations: []string{instrumentations.InstrumentationALL},
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.ExpectedProtoEnv, os.Getenv(envProtocol))
+			assert.Equal(t, tc.ExpectedTraceProtoEnv, os.Getenv(envTracesProtocol))
+		})
+	}
+}
+
+func TestTracesSetupHTTP_DoNotOverrideEnv(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	t.Run("setting both variables", func(t *testing.T) {
+		defer RestoreEnvAfterExecution()()
+		t.Setenv(envProtocol, "foo-proto")
+		t.Setenv(envTracesProtocol, "bar-proto")
+		_, err := HTTPTracesEndpointOptions(&TracesConfig{
+			CommonEndpoint:   "http://host:3333",
+			Protocol:         "foo",
+			TracesProtocol:   "bar",
+			Instrumentations: []string{instrumentations.InstrumentationALL},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "foo-proto", os.Getenv(envProtocol))
+		assert.Equal(t, "bar-proto", os.Getenv(envTracesProtocol))
+	})
+	t.Run("setting only proto env var", func(t *testing.T) {
+		defer RestoreEnvAfterExecution()()
+		t.Setenv(envProtocol, "foo-proto")
+		_, err := HTTPTracesEndpointOptions(&TracesConfig{
+			CommonEndpoint:   "http://host:3333",
+			Protocol:         "foo",
+			Instrumentations: []string{instrumentations.InstrumentationALL},
+		})
+		require.NoError(t, err)
+		_, ok := os.LookupEnv(envTracesProtocol)
+		assert.False(t, ok)
+		assert.Equal(t, "foo-proto", os.Getenv(envProtocol))
+	})
+}
+
+func TestTracesConfig_Enabled(t *testing.T) {
+	assert.True(t, (&TracesConfig{CommonEndpoint: "foo"}).Enabled())
+	assert.True(t, (&TracesConfig{TracesEndpoint: "foo"}).Enabled())
+}
+
+func TestTracesConfig_Disabled(t *testing.T) {
+	assert.False(t, (&TracesConfig{}).Enabled())
+}

--- a/pkg/export/otel/otelcfg/exporter.go
+++ b/pkg/export/otel/otelcfg/exporter.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package otelcfg
 
 import (

--- a/pkg/export/otel/otelcfg/exporter.go
+++ b/pkg/export/otel/otelcfg/exporter.go
@@ -36,7 +36,7 @@ func (i *MetricsExporterInstancer) Instantiate(ctx context.Context) (sdkmetric.E
 	}
 
 	var err error
-	switch proto := i.Cfg.Protocol; proto {
+	switch proto := i.Cfg.GetProtocol(); proto {
 	case ProtocolHTTPJSON, ProtocolHTTPProtobuf, "": // zero value defaults to HTTP for backwards-compatibility
 		meilog().Debug("instantiating HTTP MetricsReporter", "protocol", proto)
 		if i.instance, err = i.httpMetricsExporter(ctx); err != nil {

--- a/pkg/export/otel/otelcfg/exporter.go
+++ b/pkg/export/otel/otelcfg/exporter.go
@@ -1,0 +1,76 @@
+package otelcfg
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+func meilog() *slog.Logger {
+	return slog.With("component", "otelcommon.MetricsExporterInstancer")
+}
+
+// MetricsExporterInstancer provides a common instance for the OTEL metrics exporter,
+// so all the OTEL metric families (RED, Network, Service Graph, Internal...) would go through
+// the same connection/instance
+type MetricsExporterInstancer struct {
+	mutex    sync.Mutex
+	instance sdkmetric.Exporter
+	Cfg      *MetricsConfig
+}
+
+// Instantiate the OTLP HTTP or GRPC metrics exporter
+func (i *MetricsExporterInstancer) Instantiate(ctx context.Context) (sdkmetric.Exporter, error) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+	if i.instance != nil {
+		return i.instance, nil
+	}
+
+	var err error
+	switch proto := i.Cfg.Protocol; proto {
+	case ProtocolHTTPJSON, ProtocolHTTPProtobuf, "": // zero value defaults to HTTP for backwards-compatibility
+		meilog().Debug("instantiating HTTP MetricsReporter", "protocol", proto)
+		if i.instance, err = i.httpMetricsExporter(ctx); err != nil {
+			return nil, fmt.Errorf("can't instantiate OTEL HTTP metrics exporter: %w", err)
+		}
+	case ProtocolGRPC:
+		meilog().Debug("instantiating GRPC MetricsReporter", "protocol", proto)
+		if i.instance, err = i.grpcMetricsExporter(ctx); err != nil {
+			return nil, fmt.Errorf("can't instantiate OTEL GRPC metrics exporter: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("invalid protocol value: %q. Accepted values are: %s, %s, %s",
+			proto, ProtocolGRPC, ProtocolHTTPJSON, ProtocolHTTPProtobuf)
+	}
+	return i.instance, nil
+}
+
+func (i *MetricsExporterInstancer) httpMetricsExporter(ctx context.Context) (sdkmetric.Exporter, error) {
+	opts, err := httpMetricEndpointOptions(i.Cfg)
+	if err != nil {
+		return nil, err
+	}
+	mexp, err := otlpmetrichttp.New(ctx, opts.AsMetricHTTP()...)
+	if err != nil {
+		return nil, fmt.Errorf("creating HTTP metric exporter: %w", err)
+	}
+	return mexp, nil
+}
+
+func (i *MetricsExporterInstancer) grpcMetricsExporter(ctx context.Context) (sdkmetric.Exporter, error) {
+	opts, err := grpcMetricEndpointOptions(i.Cfg)
+	if err != nil {
+		return nil, err
+	}
+	mexp, err := otlpmetricgrpc.New(ctx, opts.AsMetricGRPC()...)
+	if err != nil {
+		return nil, fmt.Errorf("creating GRPC metric exporter: %w", err)
+	}
+	return mexp, nil
+}

--- a/pkg/export/otel/otelcfg/exporter_test.go
+++ b/pkg/export/otel/otelcfg/exporter_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg
+
+import (
+	"testing"
+	"time"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+const testTimeout = 5 * time.Second
+
+// Tests that the Instantiate method of Exporter always returns the same instance
+// even if invoked concurrently
+func TestSingleton(t *testing.T) {
+	concurrency := 50
+	instancer := MetricsExporterInstancer{
+		Cfg: &MetricsConfig{
+			MetricsEndpoint: "http://localhost:4137",
+		},
+	}
+	// run multiple exporters concurrently
+	exporters := make(chan sdkmetric.Exporter, concurrency)
+	errs := make(chan error, concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			if exp, err := instancer.Instantiate(t.Context()); err != nil {
+				errs <- err
+			} else {
+				exporters <- exp
+			}
+		}()
+	}
+	// all the Instantiate invocations should return the same instance
+	get := func() sdkmetric.Exporter {
+		select {
+		case <-time.After(testTimeout):
+			t.Fatal("timeout waiting for exporter")
+		case exp := <-exporters:
+			return exp
+		case err := <-errs:
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return nil
+	}
+	ref := get()
+	for i := 0; i < concurrency-1; i++ {
+		if exp := get(); exp != ref {
+			t.Fatalf("expected exporter to be the same as %p, got %p", ref, exp)
+		}
+	}
+}

--- a/pkg/export/otel/otelcfg/testutil.go
+++ b/pkg/export/otel/otelcfg/testutil.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg
+
+import "os"
+
+// RestoreEnvAfterExecution stores the values of some modified env vars to avoid
+// interferences between cases. Must be invoked as:
+// defer RestoreEnvAfterExecution()()
+func RestoreEnvAfterExecution() func() {
+	vals := []*struct {
+		name   string
+		val    string
+		exists bool
+	}{
+		{name: envTracesProtocol},
+		{name: envMetricsProtocol},
+		{name: envProtocol},
+		{name: envHeaders},
+		{name: envTracesHeaders},
+	}
+	for _, v := range vals {
+		v.val, v.exists = os.LookupEnv(v.name)
+	}
+	return func() {
+		for _, v := range vals {
+			if v.exists {
+				os.Setenv(v.name, v.val)
+			} else {
+				os.Unsetenv(v.name)
+			}
+		}
+	}
+}

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -9,13 +9,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"maps"
 	"math"
-	"net/url"
-	"os"
 	"strconv"
-	"strings"
 	"time"
+
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 
 	"go.opentelemetry.io/collector/config/configoptional"
 
@@ -51,67 +49,13 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
-	"go.opentelemetry.io/obi/pkg/services"
 )
-
-func tlog() *slog.Logger {
-	return slog.With("component", "otel.TracesReporter")
-}
 
 const reporterName = "go.opentelemetry.io/obi"
 
 type TraceSpanAndAttributes struct {
 	Span       *request.Span
 	Attributes []attribute.KeyValue
-}
-
-type TracesConfig struct {
-	CommonEndpoint string `yaml:"-" env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
-	TracesEndpoint string `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"`
-
-	Protocol       Protocol `yaml:"protocol" env:"OTEL_EXPORTER_OTLP_PROTOCOL"`
-	TracesProtocol Protocol `yaml:"-" env:"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"`
-
-	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
-	Instrumentations []string `yaml:"instrumentations" env:"OTEL_EBPF_TRACES_INSTRUMENTATIONS" envSeparator:","`
-
-	// InsecureSkipVerify is not standard, so we don't follow the same naming convention
-	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"OTEL_EBPF_INSECURE_SKIP_VERIFY"`
-
-	SamplerConfig services.SamplerConfig `yaml:"sampler"`
-
-	// Configuration options below this line will remain undocumented at the moment,
-	// but can be useful for performance-tuning of some customers.
-	MaxQueueSize int           `yaml:"max_queue_size" env:"OTEL_EBPF_OTLP_TRACES_MAX_QUEUE_SIZE"`
-	BatchTimeout time.Duration `yaml:"batch_timeout" env:"OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT"`
-
-	// Configuration options for BackOffConfig of the traces exporter.
-	// See https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configretry/backoff.go
-	// BackOffInitialInterval the time to wait after the first failure before retrying.
-	BackOffInitialInterval time.Duration `yaml:"backoff_initial_interval" env:"OTEL_EBPF_BACKOFF_INITIAL_INTERVAL"`
-	// BackOffMaxInterval is the upper bound on backoff interval.
-	BackOffMaxInterval time.Duration `yaml:"backoff_max_interval" env:"OTEL_EBPF_BACKOFF_MAX_INTERVAL"`
-	// BackOffMaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batch.
-	BackOffMaxElapsedTime time.Duration `yaml:"backoff_max_elapsed_time" env:"OTEL_EBPF_BACKOFF_MAX_ELAPSED_TIME"`
-	ReportersCacheLen     int           `yaml:"reporters_cache_len" env:"OTEL_EBPF_TRACES_REPORT_CACHE_LEN"`
-
-	// SDKLogLevel works independently from the global LogLevel because it prints GBs of logs in Debug mode
-	// and the Info messages leak internal details that are not usually valuable for the final user.
-	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL"`
-
-	// OTLPEndpointProvider allows overriding the OTLP Endpoint. It needs to return an endpoint and
-	// a boolean indicating if the endpoint is common for both traces and metrics
-	OTLPEndpointProvider func() (string, bool) `yaml:"-" env:"-"`
-
-	// InjectHeaders allows injecting custom headers to the HTTP OTLP exporter
-	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
-}
-
-func (m TracesConfig) MarshalYAML() (any, error) {
-	omit := map[string]struct{}{
-		"endpoint": {},
-	}
-	return omitFieldsForYAML(m, omit), nil
 }
 
 type SpanAttr struct {
@@ -122,48 +66,8 @@ type SpanAttr struct {
 	Value     [128]uint8
 }
 
-// Enabled specifies that the OTEL traces node is enabled if and only if
-// either the OTEL endpoint and OTEL traces endpoint is defined.
-// If not enabled, this node won't be instantiated
-func (m *TracesConfig) Enabled() bool {
-	return m.CommonEndpoint != "" || m.TracesEndpoint != ""
-}
-
-func (m *TracesConfig) GetProtocol() Protocol {
-	if m.TracesProtocol != "" {
-		return m.TracesProtocol
-	}
-	if m.Protocol != "" {
-		return m.Protocol
-	}
-	return m.guessProtocol()
-}
-
-func (m *TracesConfig) OTLPTracesEndpoint() (string, bool) {
-	if m.OTLPEndpointProvider != nil {
-		return m.OTLPEndpointProvider()
-	}
-	return ResolveOTLPEndpoint(m.TracesEndpoint, m.CommonEndpoint)
-}
-
-func (m *TracesConfig) guessProtocol() Protocol {
-	// If no explicit protocol is set, we guess it it from the metrics enpdoint port
-	// (assuming it uses a standard port or a development-like form like 14317, 24317, 14318...)
-	ep, _, err := parseTracesEndpoint(m)
-	if err == nil {
-		if strings.HasSuffix(ep.Port(), UsualPortGRPC) {
-			return ProtocolGRPC
-		} else if strings.HasSuffix(ep.Port(), UsualPortHTTP) {
-			return ProtocolHTTPProtobuf
-		}
-	}
-	// Otherwise we return default protocol according to the latest specification:
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md?plain=1#L53
-	return ProtocolHTTPProtobuf
-}
-
 func makeTracesReceiver(
-	cfg TracesConfig,
+	cfg otelcfg.TracesConfig,
 	spanMetricsEnabled bool,
 	ctxInfo *global.ContextInfo,
 	selectorCfg *attributes.SelectorConfig,
@@ -183,7 +87,7 @@ func makeTracesReceiver(
 // TracesReceiver creates a terminal node that consumes request.Spans and sends OpenTelemetry metrics to the configured consumers.
 func TracesReceiver(
 	ctxInfo *global.ContextInfo,
-	cfg TracesConfig,
+	cfg otelcfg.TracesConfig,
 	spanMetricsEnabled bool,
 	selectorCfg *attributes.SelectorConfig,
 	input *msg.Queue[[]request.Span],
@@ -198,7 +102,7 @@ func TracesReceiver(
 }
 
 type tracesOTELReceiver struct {
-	cfg                TracesConfig
+	cfg                otelcfg.TracesConfig
 	ctxInfo            *global.ContextInfo
 	selectorCfg        *attributes.SelectorConfig
 	is                 instrumentations.InstrumentationSelection
@@ -294,7 +198,7 @@ func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Tra
 				continue
 			}
 
-			envResourceAttrs := ResourceAttrsFromEnv(&sample.Span.Service)
+			envResourceAttrs := otelcfg.ResourceAttrsFromEnv(&sample.Span.Service)
 			traces := generateTracesWithAttributes(tr.attributeCache, &sample.Span.Service, envResourceAttrs, tr.ctxInfo.HostID, spanGroup, tr.ctxInfo.ExtraResourceAttributes)
 			err := exp.ConsumeTraces(ctx, traces)
 			if err != nil {
@@ -340,13 +244,13 @@ func (tr *tracesOTELReceiver) provideLoop(ctx context.Context) {
 }
 
 //nolint:cyclop
-func getTracesExporter(ctx context.Context, cfg TracesConfig) (exporter.Traces, error) {
+func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig) (exporter.Traces, error) {
 	switch proto := cfg.GetProtocol(); proto {
-	case ProtocolHTTPJSON, ProtocolHTTPProtobuf, "": // zero value defaults to HTTP for backwards-compatibility
+	case otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf, "": // zero value defaults to HTTP for backwards-compatibility
 		slog.Debug("instantiating HTTP TracesReporter", "protocol", proto)
 		var err error
 
-		opts, err := getHTTPTracesEndpointOptions(&cfg)
+		opts, err := otelcfg.HTTPTracesEndpointOptions(&cfg)
 		if err != nil {
 			slog.Error("can't get HTTP traces endpoint options", "error", err)
 			return nil, err
@@ -393,15 +297,15 @@ func getTracesExporter(ctx context.Context, cfg TracesConfig) (exporter.Traces, 
 			exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 			exporterhelper.WithQueue(config.QueueConfig),
 			exporterhelper.WithRetry(config.RetryConfig))
-	case ProtocolGRPC:
+	case otelcfg.ProtocolGRPC:
 		slog.Debug("instantiating GRPC TracesReporter", "protocol", proto)
 		var err error
-		opts, err := getGRPCTracesEndpointOptions(&cfg)
+		opts, err := otelcfg.GRPCTracesEndpointOptions(&cfg)
 		if err != nil {
 			slog.Error("can't get GRPC traces endpoint options", "error", err)
 			return nil, err
 		}
-		endpoint, _, err := parseTracesEndpoint(&cfg)
+		endpoint, _, err := otelcfg.ParseTracesEndpoint(&cfg)
 		if err != nil {
 			slog.Error("can't parse GRPC traces endpoint", "error", err)
 			return nil, err
@@ -437,7 +341,7 @@ func getTracesExporter(ctx context.Context, cfg TracesConfig) (exporter.Traces, 
 		return factory.CreateTraces(ctx, set, config)
 	default:
 		slog.Error(fmt.Sprintf("invalid protocol value: %q. Accepted values are: %s, %s, %s",
-			proto, ProtocolGRPC, ProtocolHTTPJSON, ProtocolHTTPProtobuf))
+			proto, otelcfg.ProtocolGRPC, otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf))
 		return nil, fmt.Errorf("invalid protocol value: %q", proto)
 	}
 }
@@ -458,7 +362,7 @@ func getTraceSettings(dataTypeMetrics component.Type) exporter.Settings {
 	}
 }
 
-func getRetrySettings(cfg TracesConfig) configretry.BackOffConfig {
+func getRetrySettings(cfg otelcfg.TracesConfig) configretry.BackOffConfig {
 	backOffCfg := configretry.NewDefaultBackOffConfig()
 	if cfg.BackOffInitialInterval > 0 {
 		backOffCfg.InitialInterval = cfg.BackOffInitialInterval
@@ -472,17 +376,19 @@ func getRetrySettings(cfg TracesConfig) configretry.BackOffConfig {
 	return backOffCfg
 }
 
+var emptyUID = svc.UID{}
+
 func traceAppResourceAttrs(cache *expirable2.LRU[svc.UID, []attribute.KeyValue], hostID string, service *svc.Attrs) []attribute.KeyValue {
 	// TODO: remove?
 	if service.UID == emptyUID {
-		return GetAppResourceAttrs(hostID, service)
+		return otelcfg.GetAppResourceAttrs(hostID, service)
 	}
 
 	attrs, ok := cache.Get(service.UID)
 	if ok {
 		return attrs
 	}
-	attrs = GetAppResourceAttrs(hostID, service)
+	attrs = otelcfg.GetAppResourceAttrs(hostID, service)
 	cache.Add(service.UID, attrs)
 
 	return attrs
@@ -828,119 +734,6 @@ func spanStartTime(t request.Timings) time.Time {
 		realStart = t.Start
 	}
 	return realStart
-}
-
-// the HTTP path will be defined from one of the following sources, from highest to lowest priority
-// - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, if defined
-// - OTEL_EXPORTER_OTLP_ENDPOINT, if defined
-// - https://otlp-gateway-${GRAFANA_CLOUD_ZONE}.grafana.net/otlp, if GRAFANA_CLOUD_ZONE is defined
-// If, by some reason, Grafana changes its OTLP Gateway URL in a distant future, you can still point to the
-// correct URL with the OTLP_EXPORTER_... variables.
-func parseTracesEndpoint(cfg *TracesConfig) (*url.URL, bool, error) {
-	endpoint, isCommon := cfg.OTLPTracesEndpoint()
-
-	murl, err := url.Parse(endpoint)
-	if err != nil {
-		return nil, isCommon, fmt.Errorf("parsing endpoint URL %s: %w", endpoint, err)
-	}
-	if murl.Scheme == "" || murl.Host == "" {
-		return nil, isCommon, fmt.Errorf("URL %q must have a scheme and a host", endpoint)
-	}
-	return murl, isCommon, nil
-}
-
-func getHTTPTracesEndpointOptions(cfg *TracesConfig) (otlpOptions, error) {
-	opts := otlpOptions{Headers: map[string]string{}}
-	log := tlog().With("transport", "http")
-
-	murl, isCommon, err := parseTracesEndpoint(cfg)
-	if err != nil {
-		return opts, err
-	}
-
-	log.Debug("Configuring exporter", "protocol",
-		cfg.Protocol, "tracesProtocol", cfg.TracesProtocol, "endpoint", murl.Host)
-	setTracesProtocol(cfg)
-	opts.Scheme = murl.Scheme
-	opts.Endpoint = murl.Host
-	if murl.Scheme == "http" || murl.Scheme == "unix" {
-		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
-		opts.Insecure = true
-	}
-	// If the value is set from the OTEL_EXPORTER_OTLP_ENDPOINT common property, we need to add /v1/traces to the path
-	// otherwise, we leave the path that is explicitly set by the user
-	opts.URLPath = strings.TrimSuffix(murl.Path, "/")
-	opts.BaseURLPath = strings.TrimSuffix(opts.URLPath, "/v1/traces")
-	if isCommon {
-		opts.URLPath += "/v1/traces"
-		log.Debug("Specifying path", "path", opts.URLPath)
-	}
-
-	if cfg.InsecureSkipVerify {
-		log.Debug("Setting InsecureSkipVerify")
-		opts.SkipTLSVerify = true
-	}
-
-	if cfg.InjectHeaders != nil {
-		cfg.InjectHeaders(opts.Headers)
-	}
-	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
-	maps.Copy(opts.Headers, HeadersFromEnv(envTracesHeaders))
-
-	return opts, nil
-}
-
-func getGRPCTracesEndpointOptions(cfg *TracesConfig) (otlpOptions, error) {
-	opts := otlpOptions{Headers: map[string]string{}}
-	log := tlog().With("transport", "grpc")
-	murl, _, err := parseTracesEndpoint(cfg)
-	if err != nil {
-		return opts, err
-	}
-
-	log.Debug("Configuring exporter", "protocol",
-		cfg.Protocol, "tracesProtocol", cfg.TracesProtocol, "endpoint", murl.Host)
-	opts.Endpoint = murl.Host
-	if murl.Scheme == "http" || murl.Scheme == "unix" {
-		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
-		opts.Insecure = true
-	}
-
-	if cfg.InsecureSkipVerify {
-		log.Debug("Setting InsecureSkipVerify")
-		opts.SkipTLSVerify = true
-	}
-
-	if cfg.InjectHeaders != nil {
-		cfg.InjectHeaders(opts.Headers)
-	}
-	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
-	maps.Copy(opts.Headers, HeadersFromEnv(envTracesHeaders))
-	return opts, nil
-}
-
-// HACK: at the time of writing this, the otelptracehttp API does not support explicitly
-// setting the protocol. They should be properly set via environment variables, but
-// if the user supplied the value via configuration file (and not via env vars), we override the environment.
-// To be as least intrusive as possible, we will change the variables if strictly needed
-// TODO: remove this once otelptracehttp.WithProtocol is supported
-func setTracesProtocol(cfg *TracesConfig) {
-	if _, ok := os.LookupEnv(envTracesProtocol); ok {
-		return
-	}
-	if _, ok := os.LookupEnv(envProtocol); ok {
-		return
-	}
-	if cfg.TracesProtocol != "" {
-		os.Setenv(envTracesProtocol, string(cfg.TracesProtocol))
-		return
-	}
-	if cfg.Protocol != "" {
-		os.Setenv(envProtocol, string(cfg.Protocol))
-		return
-	}
-	// unset. Guessing it
-	os.Setenv(envTracesProtocol, string(cfg.guessProtocol()))
 }
 
 func manualSpanAttributes(span *request.Span) []attribute.KeyValue {

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -111,7 +111,7 @@ type tracesOTELReceiver struct {
 	input              <-chan []request.Span
 }
 
-func GetUserSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr.Name]struct{}, error) {
+func userSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr.Name]struct{}, error) {
 	// Get user attributes
 	attribProvider, err := attributes.NewAttrSelector(attributes.GroupTraces, selectorCfg)
 	if err != nil {
@@ -127,7 +127,7 @@ func GetUserSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr
 }
 
 func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, error) {
-	traceAttrs, err := GetUserSelectedAttributes(tr.selectorCfg)
+	traceAttrs, err := userSelectedAttributes(tr.selectorCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func spanDiscarded(span *request.Span, is instrumentations.InstrumentationSelect
 	return request.IgnoreTraces(span) || span.Service.ExportsOTelTraces() || !acceptSpan(is, span)
 }
 
-func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection) map[svc.UID][]TraceSpanAndAttributes {
+func groupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection) map[svc.UID][]TraceSpanAndAttributes {
 	spanGroups := map[svc.UID][]TraceSpanAndAttributes{}
 
 	for i := range spans {
@@ -154,7 +154,7 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 			continue
 		}
 
-		finalAttrs := TraceAttributes(span, traceAttrs)
+		finalAttrs := traceAttributes(span, traceAttrs)
 
 		spanSampler := func() trace.Sampler {
 			if span.Service.Sampler != nil {
@@ -168,7 +168,7 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 			ParentContext: ctx,
 			Name:          span.TraceName(),
 			TraceID:       span.TraceID,
-			Kind:          SpanKind(span),
+			Kind:          spanKind(span),
 			Attributes:    finalAttrs,
 		})
 
@@ -188,7 +188,7 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 }
 
 func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Traces, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler) {
-	spanGroups := GroupSpans(ctx, spans, traceAttrs, sampler, tr.is)
+	spanGroups := groupSpans(ctx, spans, traceAttrs, sampler, tr.is)
 
 	for _, spanGroup := range spanGroups {
 		if len(spanGroup) > 0 {
@@ -199,7 +199,7 @@ func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Tra
 			}
 
 			envResourceAttrs := otelcfg.ResourceAttrsFromEnv(&sample.Span.Service)
-			traces := generateTracesWithAttributes(tr.attributeCache, &sample.Span.Service, envResourceAttrs, tr.ctxInfo.HostID, spanGroup, tr.ctxInfo.ExtraResourceAttributes)
+			traces := generateTracesWithAttributes(tr.attributeCache, &sample.Span.Service, envResourceAttrs, tr.ctxInfo.HostID, spanGroup, tr.ctxInfo.ExtraResourceAttributes...)
 			err := exp.ConsumeTraces(ctx, traces)
 			if err != nil {
 				slog.Error("error sending trace to consumer", "error", err)
@@ -400,7 +400,7 @@ func generateTracesWithAttributes(
 	envResourceAttrs []attribute.KeyValue,
 	hostID string,
 	spans []TraceSpanAndAttributes,
-	extraResAttrs []attribute.KeyValue,
+	extraResAttrs ...attribute.KeyValue,
 ) ptrace.Traces {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
@@ -437,7 +437,7 @@ func generateTracesWithAttributes(
 		// Create a parent span for the whole request session
 		s := ss.Spans().AppendEmpty()
 		s.SetName(span.TraceName())
-		s.SetKind(ptrace.SpanKind(SpanKind(span)))
+		s.SetKind(ptrace.SpanKind(spanKind(span)))
 		s.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
 
 		// Set trace and span IDs
@@ -461,18 +461,6 @@ func generateTracesWithAttributes(
 		s.SetEndTimestamp(pcommon.NewTimestampFromTime(t.End))
 	}
 	return traces
-}
-
-// GenerateTraces creates a ptrace.Traces from a request.Span
-func GenerateTraces(
-	cache *expirable2.LRU[svc.UID, []attribute.KeyValue],
-	svc *svc.Attrs,
-	envResourceAttrs []attribute.KeyValue,
-	hostID string,
-	spans []TraceSpanAndAttributes,
-	extraResAttrs ...attribute.KeyValue,
-) ptrace.Traces {
-	return generateTracesWithAttributes(cache, svc, envResourceAttrs, hostID, spans, extraResAttrs)
 }
 
 // createSubSpans creates the internal spans for a request.Span
@@ -575,7 +563,7 @@ var (
 )
 
 //nolint:cyclop
-func TraceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
+func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
 
 	switch span.Type {
@@ -711,7 +699,7 @@ func TraceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) [
 	return attrs
 }
 
-func SpanKind(span *request.Span) trace2.SpanKind {
+func spanKind(span *request.Span) trace2.SpanKind {
 	switch span.Type {
 	case request.EventTypeHTTP, request.EventTypeGRPC, request.EventTypeRedisServer, request.EventTypeKafkaServer:
 		return trace2.SpanKindServer

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -6,12 +6,12 @@ package otel
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
+
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 
 	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
 
@@ -72,302 +72,6 @@ func BenchmarkGenerateTraces(b *testing.B) {
 			b.Fatal("Generated traces is empty")
 		}
 	}
-}
-
-func TestHTTPTracesEndpoint(t *testing.T) {
-	defer restoreEnvAfterExecution()()
-	tcfg := TracesConfig{
-		CommonEndpoint:   "https://localhost:3131",
-		TracesEndpoint:   "https://localhost:3232/v1/traces",
-		Instrumentations: []string{instrumentations.InstrumentationALL},
-	}
-
-	t.Run("testing with two endpoints", func(t *testing.T) {
-		testHTTPTracesOptions(t, otlpOptions{Scheme: "https", Endpoint: "localhost:3232", URLPath: "/v1/traces", Headers: map[string]string{}}, &tcfg)
-	})
-
-	tcfg = TracesConfig{
-		CommonEndpoint:   "https://localhost:3131/otlp",
-		Instrumentations: []string{instrumentations.InstrumentationALL},
-	}
-
-	t.Run("testing with only common endpoint", func(t *testing.T) {
-		testHTTPTracesOptions(t, otlpOptions{Scheme: "https", Endpoint: "localhost:3131", BaseURLPath: "/otlp", URLPath: "/otlp/v1/traces", Headers: map[string]string{}}, &tcfg)
-	})
-
-	tcfg = TracesConfig{
-		CommonEndpoint:   "https://localhost:3131",
-		TracesEndpoint:   "http://localhost:3232",
-		Instrumentations: []string{instrumentations.InstrumentationALL},
-	}
-	t.Run("testing with insecure endpoint", func(t *testing.T) {
-		testHTTPTracesOptions(t, otlpOptions{Scheme: "http", Endpoint: "localhost:3232", Insecure: true, Headers: map[string]string{}}, &tcfg)
-	})
-
-	tcfg = TracesConfig{
-		CommonEndpoint:     "https://localhost:3232",
-		InsecureSkipVerify: true,
-		Instrumentations:   []string{instrumentations.InstrumentationALL},
-	}
-
-	t.Run("testing with skip TLS verification", func(t *testing.T) {
-		testHTTPTracesOptions(t, otlpOptions{Scheme: "https", Endpoint: "localhost:3232", URLPath: "/v1/traces", SkipTLSVerify: true, Headers: map[string]string{}}, &tcfg)
-	})
-}
-
-func testHTTPTracesOptions(t *testing.T, expected otlpOptions, tcfg *TracesConfig) {
-	defer restoreEnvAfterExecution()()
-	opts, err := getHTTPTracesEndpointOptions(tcfg)
-	require.NoError(t, err)
-	assert.Equal(t, expected, opts)
-}
-
-func TestMissingSchemeInHTTPTracesEndpoint(t *testing.T) {
-	defer restoreEnvAfterExecution()()
-	opts, err := getHTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "http://foo:3030", Instrumentations: []string{instrumentations.InstrumentationALL}})
-	require.NoError(t, err)
-	require.NotEmpty(t, opts)
-
-	_, err = getHTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo:3030", Instrumentations: []string{instrumentations.InstrumentationALL}})
-	require.Error(t, err)
-
-	_, err = getHTTPTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo", Instrumentations: []string{instrumentations.InstrumentationALL}})
-	require.Error(t, err)
-}
-
-func TestHTTPTracesEndpointHeaders(t *testing.T) {
-	type testCase struct {
-		Description     string
-		Env             map[string]string
-		ExpectedHeaders map[string]string
-	}
-	for _, tc := range []testCase{
-		{
-			Description:     "No headers",
-			ExpectedHeaders: map[string]string{},
-		},
-		{
-			Description:     "defining common OTLP_HEADERS",
-			Env:             map[string]string{"OTEL_EXPORTER_OTLP_HEADERS": "Foo=Bar ==,Authorization=Base 2222=="},
-			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 2222=="},
-		},
-		{
-			Description:     "defining common OTLP_TRACES_HEADERS",
-			Env:             map[string]string{"OTEL_EXPORTER_OTLP_TRACES_HEADERS": "Foo=Bar ==,Authorization=Base 1234=="},
-			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 1234=="},
-		},
-		{
-			Description: "OTLP_TRACES_HEADERS takes precedence over OTLP_HEADERS",
-			Env: map[string]string{
-				"OTEL_EXPORTER_OTLP_HEADERS":        "Foo=Bar ==,Authorization=Base 3210==",
-				"OTEL_EXPORTER_OTLP_TRACES_HEADERS": "Authorization=Base 1111==",
-			},
-			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 1111=="},
-		},
-	} {
-		// mutex to avoid running testcases in parallel so we don't mess up with env vars
-		mt := sync.Mutex{}
-		t.Run(tc.Description, func(t *testing.T) {
-			mt.Lock()
-			restore := restoreEnvAfterExecution()
-			defer func() {
-				restore()
-				mt.Unlock()
-			}()
-			for k, v := range tc.Env {
-				t.Setenv(k, v)
-			}
-
-			opts, err := getHTTPTracesEndpointOptions(&TracesConfig{
-				TracesEndpoint:   "https://localhost:1234/v1/traces",
-				Instrumentations: []string{instrumentations.InstrumentationALL},
-			})
-			require.NoError(t, err)
-			assert.Equal(t, tc.ExpectedHeaders, opts.Headers)
-		})
-	}
-}
-
-func TestGRPCTracesEndpointOptions(t *testing.T) {
-	defer restoreEnvAfterExecution()()
-	t.Run("do not accept URLs without a scheme", func(t *testing.T) {
-		_, err := getGRPCTracesEndpointOptions(&TracesConfig{CommonEndpoint: "foo:3939", Instrumentations: []string{instrumentations.InstrumentationALL}})
-		require.Error(t, err)
-	})
-	tcfg := TracesConfig{
-		CommonEndpoint:   "https://localhost:3131",
-		TracesEndpoint:   "https://localhost:3232",
-		Instrumentations: []string{instrumentations.InstrumentationALL},
-	}
-
-	t.Run("testing with two endpoints", func(t *testing.T) {
-		testTracesGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", Headers: map[string]string{}}, &tcfg)
-	})
-
-	tcfg = TracesConfig{
-		CommonEndpoint:   "https://localhost:3131",
-		Instrumentations: []string{instrumentations.InstrumentationALL},
-	}
-
-	t.Run("testing with only common endpoint", func(t *testing.T) {
-		testTracesGRPCOptions(t, otlpOptions{Endpoint: "localhost:3131", Headers: map[string]string{}}, &tcfg)
-	})
-
-	tcfg = TracesConfig{
-		CommonEndpoint:   "https://localhost:3131",
-		TracesEndpoint:   "http://localhost:3232",
-		Instrumentations: []string{instrumentations.InstrumentationALL},
-	}
-	t.Run("testing with insecure endpoint", func(t *testing.T) {
-		testTracesGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", Insecure: true, Headers: map[string]string{}}, &tcfg)
-	})
-
-	tcfg = TracesConfig{
-		CommonEndpoint:     "https://localhost:3232",
-		InsecureSkipVerify: true,
-		Instrumentations:   []string{instrumentations.InstrumentationALL},
-	}
-
-	t.Run("testing with skip TLS verification", func(t *testing.T) {
-		testTracesGRPCOptions(t, otlpOptions{Endpoint: "localhost:3232", SkipTLSVerify: true, Headers: map[string]string{}}, &tcfg)
-	})
-}
-
-func TestGRPCTracesEndpointHeaders(t *testing.T) {
-	type testCase struct {
-		Description     string
-		Env             map[string]string
-		ExpectedHeaders map[string]string
-	}
-	for _, tc := range []testCase{
-		{
-			Description:     "No headers",
-			ExpectedHeaders: map[string]string{},
-		},
-		{
-			Description:     "defining common OTLP_HEADERS",
-			Env:             map[string]string{"OTEL_EXPORTER_OTLP_HEADERS": "Foo=Bar ==,Authorization=Base 2222=="},
-			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 2222=="},
-		},
-		{
-			Description:     "defining common OTLP_TRACES_HEADERS",
-			Env:             map[string]string{"OTEL_EXPORTER_OTLP_TRACES_HEADERS": "Foo=Bar ==,Authorization=Base 1234=="},
-			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 1234=="},
-		},
-		{
-			Description: "OTLP_TRACES_HEADERS takes precedence over OTLP_HEADERS",
-			Env: map[string]string{
-				"OTEL_EXPORTER_OTLP_HEADERS":        "Foo=Bar ==,Authorization=Base 3210==",
-				"OTEL_EXPORTER_OTLP_TRACES_HEADERS": "Authorization=Base 1111==",
-			},
-			ExpectedHeaders: map[string]string{"Foo": "Bar ==", "Authorization": "Base 1111=="},
-		},
-	} {
-		// mutex to avoid running testcases in parallel so we don't mess up with env vars
-		mt := sync.Mutex{}
-		t.Run(tc.Description, func(t *testing.T) {
-			mt.Lock()
-			restore := restoreEnvAfterExecution()
-			defer func() {
-				restore()
-				mt.Unlock()
-			}()
-			for k, v := range tc.Env {
-				t.Setenv(k, v)
-			}
-
-			opts, err := getGRPCTracesEndpointOptions(&TracesConfig{
-				TracesEndpoint:   "https://localhost:1234/v1/traces",
-				Instrumentations: []string{instrumentations.InstrumentationALL},
-			})
-			require.NoError(t, err)
-			assert.Equal(t, tc.ExpectedHeaders, opts.Headers)
-		})
-	}
-}
-
-func testTracesGRPCOptions(t *testing.T, expected otlpOptions, tcfg *TracesConfig) {
-	defer restoreEnvAfterExecution()()
-	opts, err := getGRPCTracesEndpointOptions(tcfg)
-	require.NoError(t, err)
-	assert.Equal(t, expected, opts)
-}
-
-func TestTracesSetupHTTP_Protocol(t *testing.T) {
-	testCases := []struct {
-		Endpoint              string
-		ProtoVal              Protocol
-		TraceProtoVal         Protocol
-		ExpectedProtoEnv      string
-		ExpectedTraceProtoEnv string
-	}{
-		{ProtoVal: "", TraceProtoVal: "", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "http/protobuf"},
-		{ProtoVal: "", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
-		{ProtoVal: "bar", TraceProtoVal: "", ExpectedProtoEnv: "bar", ExpectedTraceProtoEnv: ""},
-		{ProtoVal: "bar", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
-		{Endpoint: "http://foo:4317", ProtoVal: "", TraceProtoVal: "", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "grpc"},
-		{Endpoint: "http://foo:4317", ProtoVal: "", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
-		{Endpoint: "http://foo:4317", ProtoVal: "bar", TraceProtoVal: "", ExpectedProtoEnv: "bar", ExpectedTraceProtoEnv: ""},
-		{Endpoint: "http://foo:4317", ProtoVal: "bar", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
-		{Endpoint: "http://foo:14317", ProtoVal: "", TraceProtoVal: "", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "grpc"},
-		{Endpoint: "http://foo:14317", ProtoVal: "", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
-		{Endpoint: "http://foo:14317", ProtoVal: "bar", TraceProtoVal: "", ExpectedProtoEnv: "bar", ExpectedTraceProtoEnv: ""},
-		{Endpoint: "http://foo:14317", ProtoVal: "bar", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
-		{Endpoint: "http://foo:4318", ProtoVal: "", TraceProtoVal: "", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "http/protobuf"},
-		{Endpoint: "http://foo:4318", ProtoVal: "", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
-		{Endpoint: "http://foo:4318", ProtoVal: "bar", TraceProtoVal: "", ExpectedProtoEnv: "bar", ExpectedTraceProtoEnv: ""},
-		{Endpoint: "http://foo:4318", ProtoVal: "bar", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
-		{Endpoint: "http://foo:24318", ProtoVal: "", TraceProtoVal: "", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "http/protobuf"},
-		{Endpoint: "http://foo:24318", ProtoVal: "", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
-		{Endpoint: "http://foo:24318", ProtoVal: "bar", TraceProtoVal: "", ExpectedProtoEnv: "bar", ExpectedTraceProtoEnv: ""},
-		{Endpoint: "http://foo:24318", ProtoVal: "bar", TraceProtoVal: "foo", ExpectedProtoEnv: "", ExpectedTraceProtoEnv: "foo"},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.Endpoint+"/"+string(tc.ProtoVal)+"/"+string(tc.TraceProtoVal), func(t *testing.T) {
-			defer restoreEnvAfterExecution()()
-			_, err := getHTTPTracesEndpointOptions(&TracesConfig{
-				CommonEndpoint:   "http://host:3333",
-				TracesEndpoint:   tc.Endpoint,
-				Protocol:         tc.ProtoVal,
-				TracesProtocol:   tc.TraceProtoVal,
-				Instrumentations: []string{instrumentations.InstrumentationALL},
-			})
-			require.NoError(t, err)
-			assert.Equal(t, tc.ExpectedProtoEnv, os.Getenv(envProtocol))
-			assert.Equal(t, tc.ExpectedTraceProtoEnv, os.Getenv(envTracesProtocol))
-		})
-	}
-}
-
-func TestTracesSetupHTTP_DoNotOverrideEnv(t *testing.T) {
-	defer restoreEnvAfterExecution()()
-	t.Run("setting both variables", func(t *testing.T) {
-		defer restoreEnvAfterExecution()()
-		t.Setenv(envProtocol, "foo-proto")
-		t.Setenv(envTracesProtocol, "bar-proto")
-		_, err := getHTTPTracesEndpointOptions(&TracesConfig{
-			CommonEndpoint:   "http://host:3333",
-			Protocol:         "foo",
-			TracesProtocol:   "bar",
-			Instrumentations: []string{instrumentations.InstrumentationALL},
-		})
-		require.NoError(t, err)
-		assert.Equal(t, "foo-proto", os.Getenv(envProtocol))
-		assert.Equal(t, "bar-proto", os.Getenv(envTracesProtocol))
-	})
-	t.Run("setting only proto env var", func(t *testing.T) {
-		defer restoreEnvAfterExecution()()
-		t.Setenv(envProtocol, "foo-proto")
-		_, err := getHTTPTracesEndpointOptions(&TracesConfig{
-			CommonEndpoint:   "http://host:3333",
-			Protocol:         "foo",
-			Instrumentations: []string{instrumentations.InstrumentationALL},
-		})
-		require.NoError(t, err)
-		_, ok := os.LookupEnv(envTracesProtocol)
-		assert.False(t, ok)
-		assert.Equal(t, "foo-proto", os.Getenv(envProtocol))
-	})
 }
 
 func groupFromSpanAndAttributes(span *request.Span, attrs []attribute.KeyValue) []TraceSpanAndAttributes {
@@ -735,12 +439,12 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		assert.Equal(t, "Internal MongoDB error", spans.At(0).Status().Message())
 	})
 	t.Run("test env var resource attributes", func(t *testing.T) {
-		defer restoreEnvAfterExecution()()
-		t.Setenv(envResourceAttrs, "deployment.environment=productions,source.upstream=beyla")
+		defer otelcfg.RestoreEnvAfterExecution()()
+		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=productions,source.upstream=beyla")
 		span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Route: "/test", Status: 200}
 
 		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{})
-		traces := GenerateTraces(cache, &span.Service, ResourceAttrsFromEnv(&span.Service), "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		traces := GenerateTraces(cache, &span.Service, otelcfg.ResourceAttrsFromEnv(&span.Service), "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		rs := traces.ResourceSpans().At(0)
@@ -753,7 +457,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{})
 		traces := GenerateTraces(cache, &span.Service,
-			ResourceAttrsFromEnv(&span.Service), "host-id",
+			otelcfg.ResourceAttrsFromEnv(&span.Service), "host-id",
 			groupFromSpanAndAttributes(&span, tAttrs),
 			attribute.String("deployment.environment", "productions"),
 			attribute.String("source.upstream", "OBI"),
@@ -1011,15 +715,6 @@ func TestCodeToStatusCode(t *testing.T) {
 	})
 }
 
-func TestTracesConfig_Enabled(t *testing.T) {
-	assert.True(t, (&TracesConfig{CommonEndpoint: "foo"}).Enabled())
-	assert.True(t, (&TracesConfig{TracesEndpoint: "foo"}).Enabled())
-}
-
-func TestTracesConfig_Disabled(t *testing.T) {
-	assert.False(t, (&TracesConfig{}).Enabled())
-}
-
 func TestSpanHostPeer(t *testing.T) {
 	sp := request.Span{
 		HostName: "localhost",
@@ -1202,35 +897,6 @@ func TestTracesSkipsInstrumented(t *testing.T) {
 			traces := generateTracesForSpans(t, tr, tt.spans)
 			assert.Equal(t, tt.filtered, len(traces) == 0, tt.name)
 		})
-	}
-}
-
-// stores the values of some modified env vars to avoid
-// interferences between cases. Must be invoked as:
-// defer restoreEnvAfterExecution()()
-func restoreEnvAfterExecution() func() {
-	vals := []*struct {
-		name   string
-		val    string
-		exists bool
-	}{
-		{name: envTracesProtocol},
-		{name: envMetricsProtocol},
-		{name: envProtocol},
-		{name: envHeaders},
-		{name: envTracesHeaders},
-	}
-	for _, v := range vals {
-		v.val, v.exists = os.LookupEnv(v.name)
-	}
-	return func() {
-		for _, v := range vals {
-			if v.exists {
-				os.Setenv(v.name, v.val)
-			} else {
-				os.Unsetenv(v.name)
-			}
-		}
 	}
 }
 
@@ -1562,7 +1228,7 @@ func ensureTraceAttrNotExists(t *testing.T, attrs pcommon.Map, key attribute.Key
 
 func makeTracesTestReceiver(instr []string) *tracesOTELReceiver {
 	return makeTracesReceiver(
-		TracesConfig{
+		otelcfg.TracesConfig{
 			CommonEndpoint:    "http://something",
 			BatchTimeout:      10 * time.Millisecond,
 			ReportersCacheLen: 16,
@@ -1577,7 +1243,7 @@ func makeTracesTestReceiver(instr []string) *tracesOTELReceiver {
 
 func makeTracesTestReceiverWithSpanMetrics(instr []string) *tracesOTELReceiver {
 	return makeTracesReceiver(
-		TracesConfig{
+		otelcfg.TracesConfig{
 			CommonEndpoint:    "http://something",
 			BatchTimeout:      10 * time.Millisecond,
 			ReportersCacheLen: 16,

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -66,7 +66,7 @@ func BenchmarkGenerateTraces(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		traces := GenerateTraces(cache, &span.Service, attrs, "host-id", group)
+		traces := generateTracesWithAttributes(cache, &span.Service, attrs, "host-id", group)
 
 		if traces.ResourceSpans().Len() == 0 {
 			b.Fatal("Generated traces is empty")
@@ -100,7 +100,7 @@ func TestGenerateTraces(t *testing.T) {
 			Service:      svc.Attrs{UID: svc.UID{Name: "1"}},
 		}
 
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -145,7 +145,7 @@ func TestGenerateTraces(t *testing.T) {
 			SpanID:       spanID,
 			TraceID:      traceID,
 		}
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -181,7 +181,7 @@ func TestGenerateTraces(t *testing.T) {
 			Route:        "/test",
 			Status:       200,
 		}
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -218,7 +218,7 @@ func TestGenerateTraces(t *testing.T) {
 			SpanID:       spanID,
 			TraceID:      traceID,
 		}
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -244,7 +244,7 @@ func TestGenerateTraces(t *testing.T) {
 			TraceID:      traceID,
 		}
 
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -264,7 +264,7 @@ func TestGenerateTraces(t *testing.T) {
 			Method:       "GET",
 			Route:        "/test",
 		}
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -279,8 +279,8 @@ func TestGenerateTraces(t *testing.T) {
 func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("test SQL trace generation, no statement", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password FROM credentials WHERE username=\"bill\"")
-		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{})
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -301,8 +301,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test SQL trace generation, unknown attribute", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password, name FROM credentials WHERE username=\"bill\"")
-		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -323,8 +323,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test SQL trace generation, unknown attribute", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password FROM credentials WHERE username=\"bill\"")
-		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{attr.DBQueryText: {}})
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{attr.DBQueryText: {}})
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -345,8 +345,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test SQL trace generation, error", func(t *testing.T) {
 		span := makeSQLRequestErroredSpan("SELECT * FROM obi.nonexisting")
-		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{attr.DBQueryText: {}})
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{attr.DBQueryText: {}})
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -373,8 +373,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test Kafka trace generation", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeKafkaClient, Method: "process", Path: "important-topic", Statement: "test"}
-		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{})
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -392,8 +392,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test Mongo trace generation", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeMongoClient, Method: "insert", Path: "mycollection", DBNamespace: "mydatabase", Status: 0}
-		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -415,8 +415,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	})
 	t.Run("test Mongo trace generation with error", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeMongoClient, Method: "insert", Path: "mycollection", DBNamespace: "mydatabase", Status: 1, DBError: request.DBError{ErrorCode: "1", Description: "Internal MongoDB error"}}
-		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
-		traces := GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
+		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -443,8 +443,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=productions,source.upstream=beyla")
 		span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Route: "/test", Status: 200}
 
-		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{})
-		traces := GenerateTraces(cache, &span.Service, otelcfg.ResourceAttrsFromEnv(&span.Service), "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
+		traces := generateTracesWithAttributes(cache, &span.Service, otelcfg.ResourceAttrsFromEnv(&span.Service), "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		rs := traces.ResourceSpans().At(0)
@@ -455,8 +455,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("override resource attributes", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Route: "/test", Status: 200}
 
-		tAttrs := TraceAttributes(&span, map[attr.Name]struct{}{})
-		traces := GenerateTraces(cache, &span.Service,
+		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
+		traces := generateTracesWithAttributes(cache, &span.Service,
 			otelcfg.ResourceAttrsFromEnv(&span.Service), "host-id",
 			groupFromSpanAndAttributes(&span, tAttrs),
 			attribute.String("deployment.environment", "productions"),
@@ -1130,7 +1130,7 @@ func TestHostPeerAttributes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			attrs := TraceAttributes(&tt.span, nil)
+			attrs := traceAttributes(&tt.span, nil)
 			if tt.server != "" {
 				var found attribute.KeyValue
 				for _, a := range attrs {
@@ -1258,16 +1258,16 @@ func makeTracesTestReceiverWithSpanMetrics(instr []string) *tracesOTELReceiver {
 
 func generateTracesForSpans(t *testing.T, tr *tracesOTELReceiver, spans []request.Span) []ptrace.Traces {
 	res := []ptrace.Traces{}
-	traceAttrs, err := GetUserSelectedAttributes(tr.selectorCfg)
+	traceAttrs, err := userSelectedAttributes(tr.selectorCfg)
 	require.NoError(t, err)
 	for i := range spans {
 		span := &spans[i]
 		if spanDiscarded(span, tr.is) {
 			continue
 		}
-		tAttrs := TraceAttributes(span, traceAttrs)
+		tAttrs := traceAttributes(span, traceAttrs)
 
-		res = append(res, GenerateTraces(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, tAttrs)))
+		res = append(res, generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, tAttrs)))
 	}
 
 	return res

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -13,6 +13,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"go.opentelemetry.io/obi/pkg/app/request"
@@ -122,7 +124,7 @@ type PrometheusConfig struct {
 	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
 	Instrumentations []string `yaml:"instrumentations" env:"OTEL_EBPF_PROMETHEUS_INSTRUMENTATIONS" envSeparator:","`
 
-	Buckets otel.Buckets `yaml:"buckets"`
+	Buckets otelcfg.Buckets `yaml:"buckets"`
 
 	// TTL is the time since a metric was updated for the last time until it is
 	// removed from the metrics set.
@@ -150,27 +152,27 @@ func (p *PrometheusConfig) AnySpanMetricsEnabled() bool {
 }
 
 func (p *PrometheusConfig) SpanMetricsSizesEnabled() bool {
-	return slices.Contains(p.Features, otel.FeatureSpanSizes)
+	return slices.Contains(p.Features, otelcfg.FeatureSpanSizes)
 }
 
 func (p *PrometheusConfig) SpanMetricsEnabled() bool {
-	return slices.Contains(p.Features, otel.FeatureSpan) || slices.Contains(p.Features, otel.FeatureSpanOTel)
+	return slices.Contains(p.Features, otelcfg.FeatureSpan) || slices.Contains(p.Features, otelcfg.FeatureSpanOTel)
 }
 
 func (p *PrometheusConfig) InvalidSpanMetricsConfig() bool {
-	return slices.Contains(p.Features, otel.FeatureSpan) && slices.Contains(p.Features, otel.FeatureSpanOTel)
+	return slices.Contains(p.Features, otelcfg.FeatureSpan) && slices.Contains(p.Features, otelcfg.FeatureSpanOTel)
 }
 
 func (p *PrometheusConfig) HostMetricsEnabled() bool {
-	return slices.Contains(p.Features, otel.FeatureApplicationHost)
+	return slices.Contains(p.Features, otelcfg.FeatureApplicationHost)
 }
 
 func (p *PrometheusConfig) OTelMetricsEnabled() bool {
-	return slices.Contains(p.Features, otel.FeatureApplication)
+	return slices.Contains(p.Features, otelcfg.FeatureApplication)
 }
 
 func (p *PrometheusConfig) ServiceGraphMetricsEnabled() bool {
-	return slices.Contains(p.Features, otel.FeatureGraph)
+	return slices.Contains(p.Features, otelcfg.FeatureGraph)
 }
 
 func (p *PrometheusConfig) NetworkMetricsEnabled() bool {
@@ -178,15 +180,15 @@ func (p *PrometheusConfig) NetworkMetricsEnabled() bool {
 }
 
 func (p *PrometheusConfig) NetworkFlowBytesEnabled() bool {
-	return slices.Contains(p.Features, otel.FeatureNetwork)
+	return slices.Contains(p.Features, otelcfg.FeatureNetwork)
 }
 
 func (p *PrometheusConfig) NetworkInterzoneMetricsEnabled() bool {
-	return slices.Contains(p.Features, otel.FeatureNetworkInterZone)
+	return slices.Contains(p.Features, otelcfg.FeatureNetworkInterZone)
 }
 
 func (p *PrometheusConfig) EBPFEnabled() bool {
-	return slices.Contains(p.Features, otel.FeatureEBPF)
+	return slices.Contains(p.Features, otelcfg.FeatureEBPF)
 }
 
 func (p *PrometheusConfig) EndpointEnabled() bool {
@@ -292,7 +294,7 @@ func PrometheusEndpoint(
 }
 
 func (p *PrometheusConfig) spanMetricsLatencyName() string {
-	if slices.Contains(p.Features, otel.FeatureSpan) {
+	if slices.Contains(p.Features, otelcfg.FeatureSpan) {
 		return SpanMetricsLatency
 	}
 
@@ -300,7 +302,7 @@ func (p *PrometheusConfig) spanMetricsLatencyName() string {
 }
 
 func (p *PrometheusConfig) spanMetricsCallsName() string {
-	if slices.Contains(p.Features, otel.FeatureSpan) {
+	if slices.Contains(p.Features, otelcfg.FeatureSpan) {
 		return SpanMetricsCalls
 	}
 

--- a/pkg/export/prom/prom_net_test.go
+++ b/pkg/export/prom/prom_net_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,7 +18,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/components/netolly/ebpf"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
-	"go.opentelemetry.io/obi/pkg/export/otel"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 
@@ -39,7 +40,7 @@ func TestMetricsExpiration(t *testing.T) {
 			Path:                        "/metrics",
 			TTL:                         3 * time.Minute,
 			SpanMetricsServiceCacheSize: 10,
-			Features:                    []string{otel.FeatureNetwork},
+			Features:                    []string{otelcfg.FeatureNetwork},
 		}, SelectorCfg: &attributes.SelectorConfig{
 			SelectionCfg: attributes.Selection{
 				attributes.NetworkFlow.Section: attributes.InclusionLists{

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -62,7 +64,7 @@ func TestAppMetricsExpiration(t *testing.T) {
 			Path:                        "/metrics",
 			TTL:                         3 * time.Minute,
 			SpanMetricsServiceCacheSize: 10,
-			Features:                    []string{otel.FeatureApplication},
+			Features:                    []string{otelcfg.FeatureApplication},
 			Instrumentations:            []string{instrumentations.InstrumentationALL},
 		},
 		&attributes.SelectorConfig{
@@ -363,7 +365,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 
 func TestMetricsDiscarded(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []string{otel.FeatureApplication},
+		Features: []string{otelcfg.FeatureApplication},
 	}
 	mr := metricsReporter{
 		cfg: &mc,
@@ -417,7 +419,7 @@ func TestMetricsDiscarded(t *testing.T) {
 
 func TestSpanMetricsDiscarded(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []string{otel.FeatureApplication},
+		Features: []string{otelcfg.FeatureApplication},
 	}
 	mr := metricsReporter{
 		cfg: &mc,
@@ -512,7 +514,7 @@ func TestTerminatesOnBadPromPort(t *testing.T) {
 
 func TestProcessPIDEvents(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []string{otel.FeatureApplication},
+		Features: []string{otelcfg.FeatureApplication},
 	}
 	mr := metricsReporter{
 		cfg:         &mc,
@@ -595,7 +597,7 @@ func makePromExporter(
 			Path:                        "/metrics",
 			TTL:                         300 * time.Minute,
 			SpanMetricsServiceCacheSize: 10,
-			Features:                    []string{otel.FeatureApplication},
+			Features:                    []string{otelcfg.FeatureApplication},
 			Instrumentations:            instrumentations,
 		},
 		&attributes.SelectorConfig{

--- a/pkg/instrumenter/instrumenter.go
+++ b/pkg/instrumenter/instrumenter.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"text/template"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"golang.org/x/sync/errgroup"
 
 	"go.opentelemetry.io/obi/pkg/components/appolly"
@@ -172,6 +174,7 @@ func buildCommonContextInfo(
 			RestrictLocalNode:   config.Attributes.Kubernetes.MetaRestrictLocalNode,
 			ServiceNameTemplate: templ,
 		}),
+		OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: &config.Metrics},
 	}
 	if config.Attributes.HostID.Override == "" {
 		ctxInfo.FetchHostID(ctx, config.Attributes.HostID.FetchTimeout)

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 	"time"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"github.com/caarlos0/env/v9"
 	"gopkg.in/yaml.v3"
 
@@ -86,23 +88,23 @@ var DefaultConfig = Config{
 		CacheLen: 1024,
 		CacheTTL: 5 * time.Minute,
 	},
-	Metrics: otel.MetricsConfig{
-		Protocol:        otel.ProtocolUnset,
-		MetricsProtocol: otel.ProtocolUnset,
+	Metrics: otelcfg.MetricsConfig{
+		Protocol:        otelcfg.ProtocolUnset,
+		MetricsProtocol: otelcfg.ProtocolUnset,
 		// Matches Alloy and Grafana recommended scrape interval
 		OTELIntervalMS:       60_000,
-		Buckets:              otel.DefaultBuckets,
+		Buckets:              otelcfg.DefaultBuckets,
 		ReportersCacheLen:    ReporterLRUSize,
 		HistogramAggregation: otel.AggregationExplicit,
-		Features:             []string{otel.FeatureApplication},
+		Features:             []string{otelcfg.FeatureApplication},
 		Instrumentations: []string{
 			instrumentations.InstrumentationALL,
 		},
 		TTL: defaultMetricsTTL,
 	},
-	Traces: otel.TracesConfig{
-		Protocol:          otel.ProtocolUnset,
-		TracesProtocol:    otel.ProtocolUnset,
+	Traces: otelcfg.TracesConfig{
+		Protocol:          otelcfg.ProtocolUnset,
+		TracesProtocol:    otelcfg.ProtocolUnset,
 		MaxQueueSize:      4096,
 		ReportersCacheLen: ReporterLRUSize,
 		Instrumentations: []string{
@@ -111,8 +113,8 @@ var DefaultConfig = Config{
 	},
 	Prometheus: prom.PrometheusConfig{
 		Path:     "/metrics",
-		Buckets:  otel.DefaultBuckets,
-		Features: []string{otel.FeatureApplication},
+		Buckets:  otelcfg.DefaultBuckets,
+		Features: []string{otelcfg.FeatureApplication},
 		Instrumentations: []string{
 			instrumentations.InstrumentationALL,
 		},
@@ -180,8 +182,8 @@ type Config struct {
 	// Routes is an optional node. If not set, data will be directly forwarded to exporters.
 	Routes       *transform.RoutesConfig       `yaml:"routes"`
 	NameResolver *transform.NameResolverConfig `yaml:"name_resolver"`
-	Metrics      otel.MetricsConfig            `yaml:"otel_metrics_export"`
-	Traces       otel.TracesConfig             `yaml:"otel_traces_export"`
+	Metrics      otelcfg.MetricsConfig         `yaml:"otel_metrics_export"`
+	Traces       otelcfg.TracesConfig          `yaml:"otel_traces_export"`
 	Prometheus   prom.PrometheusConfig         `yaml:"prometheus_export"`
 	TracePrinter debug.TracePrinter            `yaml:"trace_printer" env:"OTEL_EBPF_TRACE_PRINTER"`
 

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -27,7 +29,6 @@ import (
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/debug"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
-	"go.opentelemetry.io/obi/pkg/export/otel"
 	"go.opentelemetry.io/obi/pkg/export/prom"
 	"go.opentelemetry.io/obi/pkg/kubeflags"
 	"go.opentelemetry.io/obi/pkg/services"
@@ -139,16 +140,16 @@ discovery:
 			MongoRequestsCacheSize:           1024,
 		},
 		NetworkFlows: nc,
-		Metrics: otel.MetricsConfig{
+		Metrics: otelcfg.MetricsConfig{
 			OTELIntervalMS:    60_000,
 			CommonEndpoint:    "localhost:3131",
 			MetricsEndpoint:   "localhost:3030",
-			Protocol:          otel.ProtocolUnset,
+			Protocol:          otelcfg.ProtocolUnset,
 			ReportersCacheLen: ReporterLRUSize,
-			Buckets: otel.Buckets{
+			Buckets: otelcfg.Buckets{
 				DurationHistogram:     []float64{0, 1, 2},
-				RequestSizeHistogram:  otel.DefaultBuckets.RequestSizeHistogram,
-				ResponseSizeHistogram: otel.DefaultBuckets.ResponseSizeHistogram,
+				RequestSizeHistogram:  otelcfg.DefaultBuckets.RequestSizeHistogram,
+				ResponseSizeHistogram: otelcfg.DefaultBuckets.ResponseSizeHistogram,
 			},
 			Features: []string{"application"},
 			Instrumentations: []string{
@@ -157,8 +158,8 @@ discovery:
 			HistogramAggregation: "base2_exponential_bucket_histogram",
 			TTL:                  5 * time.Minute,
 		},
-		Traces: otel.TracesConfig{
-			Protocol:          otel.ProtocolUnset,
+		Traces: otelcfg.TracesConfig{
+			Protocol:          otelcfg.ProtocolUnset,
 			CommonEndpoint:    "localhost:3131",
 			TracesEndpoint:    "localhost:3232",
 			MaxQueueSize:      4096,
@@ -169,14 +170,14 @@ discovery:
 		},
 		Prometheus: prom.PrometheusConfig{
 			Path:     "/metrics",
-			Features: []string{otel.FeatureApplication},
+			Features: []string{otelcfg.FeatureApplication},
 			Instrumentations: []string{
 				instrumentations.InstrumentationALL,
 			},
 			TTL:                         time.Second,
 			SpanMetricsServiceCacheSize: 10000,
-			Buckets: otel.Buckets{
-				DurationHistogram:     otel.DefaultBuckets.DurationHistogram,
+			Buckets: otelcfg.Buckets{
+				DurationHistogram:     otelcfg.DefaultBuckets.DurationHistogram,
 				RequestSizeHistogram:  []float64{0, 10, 20, 22},
 				ResponseSizeHistogram: []float64{0, 10, 20, 22},
 			},


### PR DESCRIPTION
In preparation for a fix in service graph metrics, this PR reworks the OTEL exporter to avoid that multiple metrics export nodes have their own OTEL metrics exporter (more connections, more resources, more API calls...).

* The OTEL service graph metrics generation has been moved to another node. The cause is that in the future fix, service graph metrics will require their own resource attributes, incompatible with rest of RED metrics.
* The OTEL exporter creation has been unified into a factory patter that will return the same exporter for all the metrics exporters (network, RED, service graph, internal...). Similar to what we currently do for the Prometheus Exporter.

This PR mostly just moves some types and definitions to a common "otelcfg" package to avoid cyclic dependencies.