### PR TITLE
Don't filter out pod update events

### DIFF
--- a/pkg/kubecache/envtest/integration_test.go
+++ b/pkg/kubecache/envtest/integration_test.go
@@ -281,64 +281,6 @@ func TestAsynchronousStartup(t *testing.T) {
 	assert.LessOrEqual(t, int32(createdPods), cl3.syncSignalOnMessage.Load())
 }
 
-func TestIgnoreHeadlessServices(t *testing.T) {
-	svcClient := serviceClient{
-		Address:  fmt.Sprintf("127.0.0.1:%d", freePort),
-		Messages: make(chan *informer.Event, 10),
-	}
-	test.Eventually(t, timeout, func(t require.TestingT) {
-		svcClient.Start(ctx, t, 0)
-	})
-	// wait for the service to have sent the initial snapshot of entities
-	// (at the end, will send the "SYNC_FINISHED" event)
-	test.Eventually(t, timeout, func(t require.TestingT) {
-		event := ReadChannel(t, svcClient.Messages, timeout)
-		require.Equal(t, informer.EventType_SYNC_FINISHED, event.Type)
-	})
-
-	// WHEN services are created
-	require.NoError(t, k8sClient.Create(ctx, &corev1.Service{
-		ObjectMeta: v1.ObjectMeta{Name: "service1", Namespace: "default"},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{Name: "foo", Port: 8080}},
-			ClusterIP: "10.0.0.101", ClusterIPs: []string{"10.0.0.101"},
-		},
-	}))
-	require.NoError(t, k8sClient.Create(ctx, &corev1.Service{
-		ObjectMeta: v1.ObjectMeta{Name: "headless", Namespace: "default"},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{Name: "foo", Port: 8080}},
-			ClusterIP: "None",
-		},
-	}))
-	require.NoError(t, k8sClient.Create(ctx, &corev1.Service{
-		ObjectMeta: v1.ObjectMeta{Name: "service2", Namespace: "default"},
-		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{Name: "foo", Port: 8080}},
-			ClusterIP: "10.0.0.102", ClusterIPs: []string{"10.0.0.102"},
-		},
-	}))
-
-	// THEN the informer cache receives the services with an IP
-	// AND ignores headless services (without ClusterIP)
-	event := ReadChannel(t, svcClient.Messages, timeout)
-	require.NotNil(t, event.Resource)
-	assert.Equal(t, "service1", event.Resource.Name)
-	assert.NotEmpty(t, event.Resource.Ips)
-
-	event = ReadChannel(t, svcClient.Messages, timeout)
-	require.NotNil(t, event.Resource)
-	assert.Equal(t, "service2", event.Resource.Name)
-	assert.NotEmpty(t, event.Resource.Ips)
-
-	select {
-	case event := <-svcClient.Messages:
-		assert.Failf(t, "did not expect more informer updates. Got %s", event.String())
-	default:
-		// ok!
-	}
-}
-
 func TestResultsSortedByTimestamp(t *testing.T) {
 	// This test:
 	// 1- retrieves all the existing K8s objects from previous test runs

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"os"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -550,7 +552,6 @@ func (inf *Informers) ipInfoEventHandler(ctx context.Context) *cache.ResourceEve
 			metrics.InformerNew()
 			em := obj.(*indexableEntity).EncodedMeta
 			log.Debug("AddFunc", "kind", em.Kind, "name", em.Name, "ips", em.Ips)
-			// ignore headless services from being added
 			inf.Notify(&informer.Event{
 				Type:     informer.EventType_CREATED,
 				Resource: em,
@@ -561,6 +562,9 @@ func (inf *Informers) ipInfoEventHandler(ctx context.Context) *cache.ResourceEve
 			nie := newObj.(*indexableEntity)
 			newEM := nie.EncodedMeta
 			oldEM := oldObj.(*indexableEntity).EncodedMeta
+			if unchanged(oldEM, newEM) {
+				return
+			}
 			log.Debug("UpdateFunc", "kind", newEM.Kind, "name", newEM.Name,
 				"ips", newEM.Ips, "oldIps", oldEM.Ips)
 			inf.Notify(&informer.Event{
@@ -592,4 +596,43 @@ func (inf *Informers) ipInfoEventHandler(ctx context.Context) *cache.ResourceEve
 			})
 		},
 	}
+}
+
+func containerInfoEquals(c1, c2 *informer.ContainerInfo) bool {
+	if c1 == c2 {
+		return true
+	}
+
+	if c1 == nil || c2 == nil {
+		return false
+	}
+
+	return c1.Id == c2.Id &&
+		c1.Name == c2.Name &&
+		maps.Equal(c1.Env, c2.Env)
+}
+
+func podInfoEquals(p1, p2 *informer.PodInfo) bool {
+	if p1 == p2 {
+		return true
+	}
+
+	if p1 == nil || p2 == nil {
+		return false
+	}
+
+	return p1.Uid == p2.Uid &&
+		p1.NodeName == p2.NodeName &&
+		p1.StartTimeStr == p2.StartTimeStr &&
+		p1.HostIp == p2.HostIp &&
+		slices.EqualFunc(p1.Containers, p2.Containers, containerInfoEquals)
+}
+
+// unchanged compares the relevant fields from two versions of an object and returns whether they are
+// different. It only compares fields that could effectively mutate during the life of a Pod, Service or Node
+func unchanged(o, n *informer.ObjectMeta) bool {
+	return slices.Equal(o.Ips, n.Ips) &&
+		maps.Equal(o.Labels, n.Labels) &&
+		maps.Equal(o.Annotations, n.Annotations) &&
+		podInfoEquals(o.Pod, n.Pod)
 }

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -7,11 +7,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
 	"net"
 	"os"
 	"path"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -544,10 +542,6 @@ func objLastUpdateTime(
 	return lastStatus.Unix()
 }
 
-func headlessService(om *informer.ObjectMeta) bool {
-	return len(om.Ips) == 0 && om.Kind == "Service"
-}
-
 func (inf *Informers) ipInfoEventHandler(ctx context.Context) *cache.ResourceEventHandlerFuncs {
 	metrics := instrument.FromContext(ctx)
 	log := inf.log.With("func", "ipInfoEventHandler")
@@ -557,9 +551,6 @@ func (inf *Informers) ipInfoEventHandler(ctx context.Context) *cache.ResourceEve
 			em := obj.(*indexableEntity).EncodedMeta
 			log.Debug("AddFunc", "kind", em.Kind, "name", em.Name, "ips", em.Ips)
 			// ignore headless services from being added
-			if headlessService(em) {
-				return
-			}
 			inf.Notify(&informer.Event{
 				Type:     informer.EventType_CREATED,
 				Resource: em,
@@ -570,13 +561,6 @@ func (inf *Informers) ipInfoEventHandler(ctx context.Context) *cache.ResourceEve
 			nie := newObj.(*indexableEntity)
 			newEM := nie.EncodedMeta
 			oldEM := oldObj.(*indexableEntity).EncodedMeta
-			// ignore headless services from being added
-			if headlessService(newEM) && headlessService(oldEM) {
-				return
-			}
-			if unchanged(oldEM, newEM) {
-				return
-			}
 			log.Debug("UpdateFunc", "kind", newEM.Kind, "name", newEM.Name,
 				"ips", newEM.Ips, "oldIps", oldEM.Ips)
 			inf.Notify(&informer.Event{
@@ -608,12 +592,4 @@ func (inf *Informers) ipInfoEventHandler(ctx context.Context) *cache.ResourceEve
 			})
 		},
 	}
-}
-
-// unchanged compares the relevant fields from two versions of an object and returns whether they are
-// different. It only compares fields that could effectively mutate during the life of a Pod, Service or Node
-func unchanged(o, n *informer.ObjectMeta) bool {
-	return slices.Equal(o.Ips, n.Ips) &&
-		maps.Equal(o.Labels, n.Labels) &&
-		maps.Equal(o.Annotations, n.Annotations)
 }

--- a/pkg/kubecache/meta/informers_init_test.go
+++ b/pkg/kubecache/meta/informers_init_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"go.opentelemetry.io/obi/pkg/kubecache/informer"
 )
 
 func TestEnvironmentFiltering(t *testing.T) {
@@ -24,4 +26,433 @@ func TestEnvironmentFiltering(t *testing.T) {
 	resourceAttrs, ok := filtered["OTEL_RESOURCE_ATTRIBUTES"]
 	assert.True(t, ok)
 	assert.Equal(t, "resource_attributes", resourceAttrs)
+}
+
+func testUnchangedImpl(t *testing.T, o1, o2 *informer.ObjectMeta, expected bool) {
+	assert.Equal(t, expected, unchanged(o1, o2))
+}
+
+func TestUnchanged(t *testing.T) {
+	type testData struct {
+		name           string
+		o1             informer.ObjectMeta
+		o2             informer.ObjectMeta
+		expectedResult bool
+	}
+
+	data := []testData{
+		{
+			"empty",
+			informer.ObjectMeta{},
+			informer.ObjectMeta{},
+			true,
+		},
+		{
+			"name",
+			informer.ObjectMeta{
+				Name: "meta",
+			},
+			informer.ObjectMeta{},
+			true,
+		},
+		{
+			"namespace",
+			informer.ObjectMeta{
+				Namespace: "default",
+			},
+			informer.ObjectMeta{},
+			true,
+		},
+		{
+			"labels",
+			informer.ObjectMeta{
+				Labels: map[string]string{"foo": "bar"},
+			},
+			informer.ObjectMeta{},
+			false,
+		},
+		{
+			"annotations",
+			informer.ObjectMeta{
+				Annotations: map[string]string{"foo": "bar"},
+			},
+			informer.ObjectMeta{},
+			false,
+		},
+		{
+			"nilpod",
+			informer.ObjectMeta{
+				Pod: nil,
+			},
+			informer.ObjectMeta{
+				Pod: nil,
+			},
+			true,
+		},
+		{
+			"zeropod",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{},
+			},
+			informer.ObjectMeta{
+				Pod: nil,
+			},
+			false,
+		},
+		{
+			"emptypod",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{},
+			},
+			true,
+		},
+		{
+			"pod_uid",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Uid: "uid",
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{},
+			},
+			false,
+		},
+		{
+			"pod_uid_eq",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Uid: "uid",
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Uid: "uid",
+				},
+			},
+			true,
+		},
+		{
+			"pod_nodename",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					NodeName: "abacaxi",
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					NodeName: "jabuticaba",
+				},
+			},
+			false,
+		},
+		{
+			"pod_nodename_eq",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					NodeName: "abacaxi",
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					NodeName: "abacaxi",
+				},
+			},
+			true,
+		},
+		{
+			"pod_startttime",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					StartTimeStr: "12345",
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					StartTimeStr: "7890",
+				},
+			},
+			false,
+		},
+		{
+			"pod_startttime_eq",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					StartTimeStr: "12345",
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					StartTimeStr: "12345",
+				},
+			},
+			true,
+		},
+		{
+			"pod_hostip",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					HostIp: "10.0.0.1",
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					HostIp: "10.0.0.2",
+				},
+			},
+			false,
+		},
+		{
+			"pod_hostip_eq",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					HostIp: "10.0.0.1",
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					HostIp: "10.0.0.1",
+				},
+			},
+			true,
+		},
+		{
+			"containers",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{},
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Id: "foo",
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"containers_eq",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Id: "foo",
+						},
+					},
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Id: "foo",
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"containers_nil",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						nil,
+					},
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						nil,
+					},
+				},
+			},
+			true,
+		},
+		{
+			"containers_eq_not_nil",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						nil,
+					},
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Id: "foo",
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"containers_count",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Id: "foo",
+						},
+						{
+							Id: "foo",
+						},
+					},
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Id: "foo",
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"containers_count_eq",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Id: "foo",
+						},
+						{
+							Id: "foo",
+						},
+					},
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Id: "foo",
+						},
+						{
+							Id: "foo",
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"containers_name",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Name: "foo",
+						},
+					},
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Name: "bar",
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"containers_name_eq",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Name: "foo",
+						},
+					},
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Name: "foo",
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"containers_env",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Env: map[string]string{
+								"foo": "not bar",
+							},
+						},
+					},
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Env: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"containers_env_eq",
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Env: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			informer.ObjectMeta{
+				Pod: &informer.PodInfo{
+					Containers: []*informer.ContainerInfo{
+						{
+							Env: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			true,
+		},
+	}
+
+	for i := range data {
+		d := &data[i]
+
+		t.Run(d.name, func(t *testing.T) {
+			testUnchangedImpl(t, &d.o1, &d.o2, d.expectedResult)
+		})
+	}
 }


### PR DESCRIPTION
The criteria used to filtering out POD events is not sufficient, causing it to filter out important POD events such as when the POD container changes.
It also prevents users from instrumenting headless services, a decision that should potentially be asserted via configuration, rather than hardcoded.

This fixes an important and silent bug which prevents OBI from instrumenting services that have been killed/restarted but end up in a different container (but same pod).