### PR TITLE
Fix build info for internal metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PROTOC_IMAGE ?= docker.io/mariomac/protoc-go:latest
 # RELEASE_VERSION will contain the tag name, or the branch name if current commit is not a tag
 RELEASE_VERSION := $(shell git describe --all | cut -d/ -f2)
 RELEASE_REVISION := $(shell git rev-parse --short HEAD )
-BUILDINFO_PKG ?= github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pkg/buildinfo
+BUILDINFO_PKG ?= go.opentelemetry.io/obi/pkg/buildinfo
 TEST_OUTPUT ?= ./testoutput
 
 IMG_REGISTRY ?= docker.io


### PR DESCRIPTION
We renamed the package to `go.opentelemetry.io/obi` but we forgot to update `BUILDINFO_PKG` in the Makefile.
That makes that build version and revision in internal metrics is set to `unset`.

Fixes https://github.com/grafana/beyla/issues/2117