### PR TITLE
Don't use memcmp directly in nodejs code

### DIFF
--- a/bpf/common/strings.h
+++ b/bpf/common/strings.h
@@ -15,3 +15,13 @@ static __always_inline bool stricmp(const char *s1, const char *s2, u8 n) {
     }
     return true;
 }
+
+static __always_inline int obi_bpf_memcmp(const char *s1, const char *s2, s32 size) {
+    for (int i = 0; i < size; i++) {
+        if (s1[i] != s2[i]) {
+            return i + 1;
+        }
+    }
+
+    return 0;
+}

--- a/bpf/generictracer/http2_grpc.h
+++ b/bpf/generictracer/http2_grpc.h
@@ -5,6 +5,7 @@
 #include <bpfcore/bpf_endian.h>
 
 #include <common/http_types.h>
+#include <common/strings.h>
 
 #define HTTP2_GRPC_PREFACE "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 
@@ -65,22 +66,12 @@ static __always_inline u8 is_headers_frame(const frame_header_t *frame) {
     return frame->type == FrameHeaders && frame->stream_id;
 }
 
-static __always_inline int bpf_memcmp(const char *s1, const char *s2, s32 size) {
-    for (int i = 0; i < size; i++) {
-        if (s1[i] != s2[i]) {
-            return i + 1;
-        }
-    }
-
-    return 0;
-}
-
 static __always_inline u8 has_preface(unsigned char *p, u32 len) {
     if (len < MIN_HTTP2_SIZE) {
         return 0;
     }
 
-    return !bpf_memcmp((char *)p, HTTP2_GRPC_PREFACE, MIN_HTTP2_SIZE);
+    return !obi_bpf_memcmp((char *)p, HTTP2_GRPC_PREFACE, MIN_HTTP2_SIZE);
 }
 
 static __always_inline u8 is_http2_or_grpc(unsigned char *p, u32 len) {

--- a/bpf/generictracer/nodejs.c
+++ b/bpf/generictracer/nodejs.c
@@ -4,15 +4,14 @@
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/bpf_tracing.h>
 
+#include <common/strings.h>
+
 #include <logger/bpf_dbg.h>
 
 #include <maps/nodejs_fd_map.h>
 
 SEC("uprobe/node:uv_fs_access")
 int BPF_KPROBE(obi_uv_fs_access, void *loop, void *req, const char *path) {
-    (void)loop;
-    (void)req;
-
     // the obi nodejs agent (fdextractor.js) passes the file descriptor pair
     // to the ebpf layer by invoking uv_fs_access() with an invalid path:
     // /dev/null/obi/<fd1><fd2> where each fd is a left-zero-padded 4 digit
@@ -28,7 +27,7 @@ int BPF_KPROBE(obi_uv_fs_access, void *loop, void *req, const char *path) {
         return 0;
     }
 
-    if (__builtin_memcmp(prefix, buf, prefix_size) != 0) {
+    if (obi_bpf_memcmp(prefix, buf, prefix_size) != 0) {
         return 0;
     }
 


### PR DESCRIPTION
Unlike the memcpy built in, __builtin_memcmp will not be expanded into a stream of instructions for all versions of Clang. Sometimes it requires -O2 and some compilers always leave the memcmp call, which cannot be loaded by the verfiier.

This PR changes the nodejs code to use the helper we already had for grpc and extracts that helper in common.