### PR TITLE
Fix missing namespace discovery from env variables

### DIFF
--- a/pkg/components/exec/file.go
+++ b/pkg/components/exec/file.go
@@ -29,9 +29,10 @@ type FileInfo struct {
 }
 
 const (
-	envServiceName   = "OTEL_SERVICE_NAME"
-	envResourceAttrs = "OTEL_RESOURCE_ATTRIBUTES"
-	serviceNameKey   = "service.name"
+	envServiceName      = "OTEL_SERVICE_NAME"
+	envResourceAttrs    = "OTEL_RESOURCE_ATTRIBUTES"
+	serviceNameKey      = "service.name"
+	serviceNamespaceKey = "service.namespace"
 )
 
 func (fi *FileInfo) ExecutableName() string {
@@ -75,24 +76,32 @@ func FindExecELF(p *services.ProcessInfo, svcID svc.Attrs, k8sEnabled bool) (*Fi
 		return nil, err
 	}
 
-	file.Service.EnvVars = envVars
-	if svcName, ok := file.Service.EnvVars[envServiceName]; ok {
-		// If Kubernetes is enabled we use the K8S metadata as the source of truth
-		if !k8sEnabled {
-			file.Service.UID.Name = svcName
-		}
+	setServiceEnvVariables(&file.Service, envVars, k8sEnabled)
+
+	return &file, nil
+}
+
+func setServiceEnvVariables(service *svc.Attrs, envVars map[string]string, k8sEnabled bool) {
+	service.EnvVars = envVars
+	// If Kubernetes is enabled we use the K8S metadata as the source of truth
+	// including the k8s supplied environment variables
+	if k8sEnabled {
+		return
+	}
+	if svcName, ok := service.EnvVars[envServiceName]; ok {
+		service.UID.Name = svcName
 	} else {
-		if resourceAttrs, ok := file.Service.EnvVars[envResourceAttrs]; ok {
+		if resourceAttrs, ok := service.EnvVars[envResourceAttrs]; ok {
 			allVars := map[string]string{}
 			collect := func(k string, v string) {
 				allVars[k] = v
 			}
 			attributes.ParseOTELResourceVariable(resourceAttrs, collect)
 			if result, ok := allVars[serviceNameKey]; ok {
-				file.Service.UID.Name = result
+				service.UID.Name = result
+			} else if result, ok := allVars[serviceNamespaceKey]; ok {
+				service.UID.Namespace = result
 			}
 		}
 	}
-
-	return &file, nil
 }

--- a/pkg/components/exec/file_test.go
+++ b/pkg/components/exec/file_test.go
@@ -1,0 +1,70 @@
+package exec
+
+import (
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/obi/pkg/components/svc"
+)
+
+func TestSetServiceEnvVariables(t *testing.T) {
+	tests := []struct {
+		name       string
+		envVars    map[string]string
+		k8sEnabled bool
+		expectName string
+		expectNS   string
+	}{
+		{
+			name:       "OTEL_SERVICE_NAME present, k8s disabled",
+			envVars:    map[string]string{"OTEL_SERVICE_NAME": "my-service"},
+			k8sEnabled: false,
+			expectName: "my-service",
+		},
+		{
+			name:       "OTEL_SERVICE_NAME present, k8s enabled",
+			envVars:    map[string]string{"OTEL_SERVICE_NAME": "my-service"},
+			k8sEnabled: true,
+			expectName: "",
+		},
+		{
+			name:       "OTEL_RESOURCE_ATTRIBUTES with service.name",
+			envVars:    map[string]string{"OTEL_RESOURCE_ATTRIBUTES": "service.name=otel-svc"},
+			k8sEnabled: false,
+			expectName: "otel-svc",
+		},
+		{
+			name:       "OTEL_RESOURCE_ATTRIBUTES with service.name",
+			envVars:    map[string]string{"OTEL_RESOURCE_ATTRIBUTES": "service.name=otel-svc"},
+			k8sEnabled: true,
+			expectName: "",
+		},
+		{
+			name:       "OTEL_RESOURCE_ATTRIBUTES with service.namespace",
+			envVars:    map[string]string{"OTEL_RESOURCE_ATTRIBUTES": "service.namespace=otel-ns"},
+			k8sEnabled: false,
+			expectNS:   "otel-ns",
+		},
+		{
+			name:       "No relevant env vars",
+			envVars:    map[string]string{"FOO": "BAR"},
+			k8sEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &svc.Attrs{}
+			setServiceEnvVariables(s, tt.envVars, tt.k8sEnabled)
+			if got := s.UID.Name; got != tt.expectName {
+				t.Errorf("UID.Name = %q, want %q", got, tt.expectName)
+			}
+			if got := s.UID.Namespace; got != tt.expectNS {
+				t.Errorf("UID.Namespace = %q, want %q", got, tt.expectNS)
+			}
+			if !reflect.DeepEqual(s.EnvVars, tt.envVars) {
+				t.Errorf("EnvVars = %#v, want %#v", s.EnvVars, tt.envVars)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We were correctly setting the namespace from environment variables for Kubernetes, but not when the process isn't running in k8s we were just parsing the service name, not namespace.