### PR TITLE
Fix missing pid info and prometheus collections

### DIFF
--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -414,6 +414,8 @@ func newReporter(
 		attrHTTPClientResponseSize: attrHTTPClientResponseSize,
 		attrGPUKernelCalls:         attrGPUKernelLaunchCalls,
 		attrGPUMemoryAllocs:        attrGPUMemoryAllocations,
+		attrGPUKernelGridSize:      attrGPUKernelGridSize,
+		attrGPUKernelBlockSize:     attrGPUKernelBlockSize,
 		beylaInfo: NewExpirer[prometheus.Gauge](prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: attr.VendorPrefix + buildInfoSuffix,
 			Help: "A metric with a constant '1' value labeled by version, revision, branch, " +


### PR DESCRIPTION
There are two separate issues with our CUDA kernel launch monitoring:

1. We recently changed all kprobes related code to share the same PID filter, the common PID filter, but the GPU/CUDA monitoring isn't tested because we don't have NVIDIA runners. The change to use the correct PID filter exposed a bug in the CUDA event creation that we weren't populating the PID info, so the filter can correctly remove unnecessary events. This is the first fix.
2. There were 2 series attributes (grid size and block size) which were missing to be included in the prometheus constructor.