### PR TITLE
Enable misc-unused-parameters checks

### DIFF
--- a/bpf/.clang-tidy
+++ b/bpf/.clang-tidy
@@ -12,7 +12,6 @@ Checks:
   - '-bugprone-narrowing-conversions' #TODO this needs to be checked/enabled
   - 'clang-analyzer-*'
   - '-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling'
-  - '-misc-unused-parameters'
   - '-misc-misplaced-const'
   - '-misc-include-cleaner'
   - '-readability-else-after-return'

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -34,6 +34,9 @@
 // Used by accept to grab the sock details
 SEC("kprobe/security_socket_accept")
 int BPF_KPROBE(obi_kprobe_security_socket_accept, struct socket *sock, struct socket *newsock) {
+    (void)ctx;
+    (void)sock;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -65,6 +68,9 @@ int BPF_KPROBE(obi_kprobe_security_socket_accept, struct socket *sock, struct so
 // data in the map, since those cannot be optimised.
 SEC("kprobe/tcp_rcv_established")
 int BPF_KPROBE(obi_kprobe_tcp_rcv_established, struct sock *sk, struct sk_buff *skb) {
+    (void)ctx;
+    (void)skb;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -106,6 +112,8 @@ int BPF_KPROBE(obi_kprobe_tcp_rcv_established, struct sock *sk, struct sk_buff *
 // process may have already reached accept, before the instrumenter has launched.
 SEC("kretprobe/sys_accept4")
 int BPF_KRETPROBE(obi_kretprobe_sys_accept4, s32 fd) {
+    (void)ctx;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -185,6 +193,8 @@ int BPF_KPROBE(obi_kprobe_sys_connect) {
 // Used by connect so that we can grab the sock details
 SEC("kprobe/tcp_connect")
 int BPF_KPROBE(obi_kprobe_tcp_connect, struct sock *sk) {
+    (void)ctx;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -228,6 +238,8 @@ static __always_inline void setup_cp_support_conn_info(pid_connection_info_t *p_
 // HTTP client calls
 SEC("kretprobe/sys_connect")
 int BPF_KRETPROBE(obi_kretprobe_sys_connect, int res) {
+    (void)ctx;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -512,6 +524,9 @@ int BPF_KRETPROBE(obi_kretprobe_tcp_sendmsg, int sent_len) {
 
 SEC("kprobe/tcp_close")
 int BPF_KPROBE(obi_kprobe_tcp_close, struct sock *sk, long timeout) {
+    (void)ctx;
+    (void)timeout;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -566,7 +581,12 @@ int BPF_KPROBE(obi_kprobe_tcp_recvmsg,
                struct msghdr *msg,
                size_t len,
                int flags,
-               int *addr_len) {
+               int *addr_len) { //NOLINT(readability-non-const-parameter)
+    (void)ctx;
+    (void)len;
+    (void)flags;
+    (void)addr_len;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -587,6 +607,9 @@ int BPF_KPROBE(obi_kprobe_tcp_recvmsg,
 // so if tcp_recvmsg happens, it will overwrite the data in the args.
 SEC("kprobe/sock_recvmsg")
 int BPF_KPROBE(obi_kprobe_sock_recvmsg, struct socket *sock, struct msghdr *msg, int flags) {
+    (void)ctx;
+    (void)flags;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -611,6 +634,8 @@ int BPF_KPROBE(obi_kprobe_sock_recvmsg, struct socket *sock, struct msghdr *msg,
 // cleaned up by that probe and this kprobe won't do anything.
 SEC("kretprobe/sock_recvmsg")
 int BPF_KRETPROBE(obi_kretprobe_sock_recvmsg, int copied_len) {
+    (void)ctx;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -875,6 +900,8 @@ int obi_socket__http_filter(struct __sk_buff *skb) {
 */
 SEC("kretprobe/sys_clone")
 int BPF_KRETPROBE(obi_kretprobe_sys_clone, int tid) {
+    (void)ctx;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id) || tid < 0) {
@@ -898,6 +925,9 @@ int BPF_KRETPROBE(obi_kretprobe_sys_clone, int tid) {
 
 SEC("kprobe/sys_exit")
 int BPF_KPROBE(obi_kprobe_sys_exit, int status) {
+    (void)ctx;
+    (void)status;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {

--- a/bpf/generictracer/k_unix_sock.h
+++ b/bpf/generictracer/k_unix_sock.h
@@ -51,6 +51,10 @@ int BPF_KPROBE(obi_kprobe_unix_stream_recvmsg,
                struct msghdr *msg,
                size_t size,
                int flags) {
+    (void)ctx;
+    (void)size;
+    (void)flags;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -266,6 +270,8 @@ int BPF_KPROBE(obi_kprobe_unix_stream_sendmsg,
 
 SEC("kretprobe/unix_stream_sendmsg")
 int BPF_KRETPROBE(obi_kretprobe_unix_stream_sendmsg, int sent_len) {
+    (void)ctx;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {

--- a/bpf/generictracer/libssl.c
+++ b/bpf/generictracer/libssl.c
@@ -21,6 +21,9 @@
 // the number of bytes read.
 SEC("uprobe/libssl.so:SSL_read")
 int BPF_UPROBE(obi_uprobe_ssl_read, void *ssl, const void *buf, int num) {
+    (void)ctx;
+    (void)num;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -74,6 +77,9 @@ int BPF_UPROBE(obi_uprobe_ssl_read_ex,
                const void *buf,
                int num,
                size_t *readbytes) { //NOLINT(readability-non-const-parameter)
+    (void)ctx;
+    (void)num;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -133,6 +139,8 @@ int BPF_URETPROBE(obi_uretprobe_ssl_read_ex, int ret) {
 // the number of bytes written.
 SEC("uprobe/libssl.so:SSL_write")
 int BPF_UPROBE(obi_uprobe_ssl_write, void *ssl, const void *buf, int num) {
+    (void)ctx;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -154,6 +162,8 @@ int BPF_UPROBE(obi_uprobe_ssl_write, void *ssl, const void *buf, int num) {
 
 SEC("uretprobe/libssl.so:SSL_write")
 int BPF_URETPROBE(obi_uretprobe_ssl_write, int ret) {
+    (void)ret;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -176,7 +186,14 @@ int BPF_URETPROBE(obi_uretprobe_ssl_write, int ret) {
 }
 
 SEC("uprobe/libssl.so:SSL_write_ex")
-int BPF_UPROBE(obi_uprobe_ssl_write_ex, void *ssl, const void *buf, int num, size_t *written) {
+int BPF_UPROBE(obi_uprobe_ssl_write_ex,
+               void *ssl,
+               const void *buf,
+               int num,
+               size_t *written) { //NOLINT(readability-non-const-parameter)
+    (void)ctx;
+    (void)written;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -198,6 +215,8 @@ int BPF_UPROBE(obi_uprobe_ssl_write_ex, void *ssl, const void *buf, int num, siz
 
 SEC("uretprobe/libssl.so:SSL_write_ex")
 int BPF_URETPROBE(obi_uretprobe_ssl_write_ex, int ret) {
+    (void)ret;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {
@@ -221,6 +240,8 @@ int BPF_URETPROBE(obi_uretprobe_ssl_write_ex, int ret) {
 
 SEC("uprobe/libssl.so:SSL_shutdown")
 int BPF_UPROBE(obi_uprobe_ssl_shutdown, void *s) {
+    (void)ctx;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {

--- a/bpf/generictracer/nginx.c
+++ b/bpf/generictracer/nginx.c
@@ -54,6 +54,8 @@ static __always_inline void get_sock_info(u64 id, void *conn_ptr, connection_inf
 
 SEC("uprobe/nginx:ngx_event_connect_peer_ret")
 int obi_ngx_event_connect_peer_ret(struct pt_regs *ctx) {
+    (void)ctx;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {

--- a/bpf/generictracer/nodejs.c
+++ b/bpf/generictracer/nodejs.c
@@ -12,6 +12,10 @@
 
 SEC("uprobe/node:uv_fs_access")
 int BPF_KPROBE(obi_uv_fs_access, void *loop, void *req, const char *path) {
+    (void)ctx;
+    (void)loop;
+    (void)req;
+
     // the obi nodejs agent (fdextractor.js) passes the file descriptor pair
     // to the ebpf layer by invoking uv_fs_access() with an invalid path:
     // /dev/null/obi/<fd1><fd2> where each fd is a left-zero-padded 4 digit

--- a/bpf/generictracer/protocol_common.h
+++ b/bpf/generictracer/protocol_common.h
@@ -53,8 +53,8 @@ static __always_inline u8 request_type_by_direction(u8 direction, u8 packet_type
     return 0;
 }
 
-static __always_inline http_connection_metadata_t *
-connection_meta_by_direction(pid_connection_info_t *pid_conn, u8 direction, u8 packet_type) {
+static __always_inline http_connection_metadata_t *connection_meta_by_direction(u8 direction,
+                                                                                u8 packet_type) {
     http_connection_metadata_t *meta = empty_connection_meta();
     if (!meta) {
         return 0;

--- a/bpf/generictracer/protocol_http2.h
+++ b/bpf/generictracer/protocol_http2.h
@@ -65,7 +65,7 @@ static __always_inline void http2_grpc_start(
     //dbg_print_http_connection_info(&s_key->pid_conn.conn); // commented out since GitHub CI doesn't like this call
     if (h2g_info) {
         http_connection_metadata_t *meta =
-            connection_meta_by_direction(&s_key->pid_conn, direction, PACKET_TYPE_REQUEST);
+            connection_meta_by_direction(direction, PACKET_TYPE_REQUEST);
         if (!meta) {
             bpf_dbg_printk("Can't get meta memory or connection not found");
             return;

--- a/bpf/generictracer/protocol_postgres.h
+++ b/bpf/generictracer/protocol_postgres.h
@@ -50,12 +50,8 @@ SCRATCH_MEM_SIZED(postgres_large_buffers, k_pg_large_buf_max_size);
 // Emit a large buffer event for Postgres protocol.
 // The return value is used to control the flow for this specific protocol.
 // -1: wait additional data; 0: continue, regardless of errors.
-static __always_inline int postgres_send_large_buffer(tcp_req_t *req,
-                                                      pid_connection_info_t *pid_conn,
-                                                      const void *u_buf,
-                                                      u32 bytes_len,
-                                                      u8 direction,
-                                                      enum large_buf_action action) {
+static __always_inline int postgres_send_large_buffer(
+    tcp_req_t *req, const void *u_buf, u32 bytes_len, u8 direction, enum large_buf_action action) {
     if (!is_pow2(postgres_buffer_size)) {
         bpf_dbg_printk("postgres_send_large_buffer: bug: postgres_buffer_size is not a power of 2");
         return -1;

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -114,7 +114,7 @@ static __always_inline int tcp_send_large_buffer(tcp_req_t *req,
         break;
     case k_protocol_type_postgres:
         if (postgres_buffer_size > 0) {
-            ret = postgres_send_large_buffer(req, pid_conn, u_buf, bytes_len, direction, action);
+            ret = postgres_send_large_buffer(req, u_buf, bytes_len, direction, action);
         }
         break;
     case k_protocol_type_unknown:
@@ -257,6 +257,8 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
 // k_tail_protocol_tcp
 SEC("kprobe/tcp")
 int obi_protocol_tcp(void *ctx) {
+    (void)ctx;
+
     call_protocol_args_t *args = protocol_args();
 
     if (!args) {

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -851,7 +851,6 @@ static __always_inline void setup_http2_client_conn(void *goroutine_addr,
                                                     void *cc_ptr,
                                                     u32 stream_id,
                                                     go_offset_const off_cc_tconn_pos,
-                                                    go_offset_const off_cc_next_stream_id_pos,
                                                     go_offset_const off_cc_framer_pos) {
     go_addr_key_t g_key = {};
     go_addr_key_from_id(&g_key, goroutine_addr);
@@ -930,12 +929,7 @@ int obi_uprobe_http2WriteHeaders(struct pt_regs *ctx) {
 
     bpf_dbg_printk("=== uprobe/proc http2WriteHeaders === ");
 
-    setup_http2_client_conn(goroutine_addr,
-                            cc_ptr,
-                            (u32)stream_id,
-                            _cc_tconn_pos,
-                            _cc_next_stream_id_pos,
-                            _cc_framer_pos);
+    setup_http2_client_conn(goroutine_addr, cc_ptr, (u32)stream_id, _cc_tconn_pos, _cc_framer_pos);
 
     return 0;
 }
@@ -951,12 +945,8 @@ int obi_uprobe_http2WriteHeaders_vendored(struct pt_regs *ctx) {
 
     bpf_dbg_printk("=== uprobe/proc http2WriteHeaders === ");
 
-    setup_http2_client_conn(goroutine_addr,
-                            cc_ptr,
-                            (u32)stream_id,
-                            _cc_tconn_vendored_pos,
-                            _cc_next_stream_id_vendored_pos,
-                            _cc_framer_vendored_pos);
+    setup_http2_client_conn(
+        goroutine_addr, cc_ptr, (u32)stream_id, _cc_tconn_vendored_pos, _cc_framer_vendored_pos);
 
     return 0;
 }

--- a/bpf/gpuevent/gpuevent.c
+++ b/bpf/gpuevent/gpuevent.c
@@ -103,6 +103,9 @@ int BPF_KPROBE(handle_cuda_launch,
 
 SEC("uprobe/cudaMalloc")
 int BPF_KPROBE(handle_cuda_malloc, void **devPtr, size_t size) {
+    (void)ctx;
+    (void)devPtr;
+
     u64 id = bpf_get_current_pid_tgid();
 
     if (!valid_pid(id)) {

--- a/bpf/rdns/rdns_xdp.c
+++ b/bpf/rdns/rdns_xdp.c
@@ -158,8 +158,8 @@ static __always_inline void submit_dns_packet(struct xdp_md *ctx, const unsigned
 }
 
 // Parses a DNS response packet and validates its structure
-static __always_inline void
-parse_dns_response(struct xdp_md *ctx, const unsigned char *const data, __u32 size) {
+static __always_inline void parse_dns_response(struct xdp_md *ctx,
+                                               const unsigned char *const data) {
     // Extract DNS header fields
     const __u8 flags0 = *(data + 2);
     const __u8 flags1 = *(data + 3);
@@ -251,7 +251,7 @@ int dns_response_tracker(struct xdp_md *ctx) {
     }
 
     // Parse and process DNS response
-    parse_dns_response(ctx, (unsigned char *)(udp) + UDP_HDR_SIZE, udp_len - UDP_HDR_SIZE);
+    parse_dns_response(ctx, (unsigned char *)(udp) + UDP_HDR_SIZE);
 
     return XDP_PASS;
 }

--- a/bpf/tctracer/tc_ip.h
+++ b/bpf/tctracer/tc_ip.h
@@ -78,7 +78,6 @@ parse_ip_options_ipv6(struct __sk_buff *skb, connection_info_t *conn, protocol_i
 }
 
 static __always_inline u8 inject_tc_ip_options_ipv4(struct __sk_buff *skb,
-                                                    connection_info_t *conn,
                                                     protocol_info_t *tcp,
                                                     tp_info_pid_t *tp) {
     if (!bpf_skb_adjust_room(skb, MAX_TC_TP_LEN, BPF_ADJ_ROOM_NET, BPF_F_ADJ_ROOM_NO_CSUM_RESET)) {
@@ -136,7 +135,6 @@ static __always_inline u8 inject_tc_ip_options_ipv4(struct __sk_buff *skb,
 }
 
 static __always_inline u8 inject_tc_ip_options_ipv6(struct __sk_buff *skb,
-                                                    connection_info_t *conn,
                                                     protocol_info_t *tcp,
                                                     tp_info_pid_t *tp) {
     if (!bpf_skb_adjust_room(skb,


### PR DESCRIPTION
Ensure clang-tidy notifies us of unused parameters. This requires us to explicitly note unused parameters that cannot be removed (such as kprobe signatures), but it also caught a few instances in which such parameters should no longer be there. It also uncovered a few other warnings that were being shadowed.

On a follow up PR I intend to enable `-Werror -Wunused-parameter` - I am not doing this now because a bunch of those are passed to `bpf_dbg_printk`, which expands to nothing on  non-debug builds, causing a few parameters to only be unused in a few instances (e.g. they need to be tagged with `[[maybe_unused]]`).