### PR TITLE
cleanup metrics_svc_graph.go

### DIFF
--- a/pkg/components/pipe/instrumenter.go
+++ b/pkg/components/pipe/instrumenter.go
@@ -117,7 +117,6 @@ func newGraphBuilder(
 	swi.Add(otel.ReportSvcGraphMetrics(
 		ctxInfo,
 		&config.Metrics,
-		selectorCfg,
 		exportableSpans,
 		processEventsCh,
 	), swarm.WithID("OTELSvcGraphMetricsExport"))

--- a/pkg/export/otel/metrics_svc_graph_test.go
+++ b/pkg/export/otel/metrics_svc_graph_test.go
@@ -17,7 +17,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/components/exec"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/components/svc"
-	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
@@ -94,7 +93,7 @@ func makeSvcGraphExporter(
 	}
 	otelExporter, err := ReportSvcGraphMetrics(
 		&global.ContextInfo{OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg}},
-		mcfg, &attributes.SelectorConfig{}, input, processEvents)(ctx)
+		mcfg, input, processEvents)(ctx)
 	require.NoError(t, err)
 
 	return otelExporter


### PR DESCRIPTION
This PR removes some unnecessary code that was left in metrics_svc_graph.go during a past refactor.