### PR TITLE
Fix package imports' ordering

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,19 +7,21 @@ issues:
 
 formatters:
   enable:
+    - gci
     - gofumpt
-    - goimports
 
   settings:
     gofmt:
       # simplify code: gofmt with `-s` option, true by default
       simplify: true
 
-    goimports:
-      # put imports beginning with prefix after 3rd-party packages;
-      # it's a comma-separated list of prefixes
-      local-prefixes:
-        - go.opentelemetry.io/obi
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/open-telemetry)
+        - prefix(go.opentelemetry.io)
+        - localmodule
 
 linters:
   exclusions:

--- a/configs/offsets/otelsdk/inspect.go
+++ b/configs/offsets/otelsdk/inspect.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel"
-
 	"go.opentelemetry.io/otel/attribute"
 )
 

--- a/pkg/app/request/span.go
+++ b/pkg/app/request/span.go
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/gavv/monotime"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"

--- a/pkg/app/request/span_test.go
+++ b/pkg/app/request/span_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	trace2 "go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/obi/pkg/components/svc"

--- a/pkg/components/appolly/appolly.go
+++ b/pkg/components/appolly/appolly.go
@@ -12,11 +12,10 @@ import (
 	"sync"
 	"time"
 
-	ebpfcommon "go.opentelemetry.io/obi/pkg/components/ebpf/common"
-
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/discover"
 	"go.opentelemetry.io/obi/pkg/components/ebpf"
+	ebpfcommon "go.opentelemetry.io/obi/pkg/components/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/components/exec"
 	"go.opentelemetry.io/obi/pkg/components/pipe"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"

--- a/pkg/components/discover/attacher.go
+++ b/pkg/components/discover/attacher.go
@@ -8,12 +8,11 @@ import (
 	"log/slog"
 	"os"
 
-	ebpfcommon "go.opentelemetry.io/obi/pkg/components/ebpf/common"
-
 	"github.com/cilium/ebpf/link"
 
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/ebpf"
+	ebpfcommon "go.opentelemetry.io/obi/pkg/components/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/components/helpers/maps"
 	"go.opentelemetry.io/obi/pkg/components/imetrics"
 	"go.opentelemetry.io/obi/pkg/components/nodejs"

--- a/pkg/components/discover/finder.go
+++ b/pkg/components/discover/finder.go
@@ -7,10 +7,9 @@ import (
 	"context"
 	"fmt"
 
-	ebpfcommon "go.opentelemetry.io/obi/pkg/components/ebpf/common"
-
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/ebpf"
+	ebpfcommon "go.opentelemetry.io/obi/pkg/components/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/components/ebpf/generictracer"
 	"go.opentelemetry.io/obi/pkg/components/ebpf/gotracer"
 	"go.opentelemetry.io/obi/pkg/components/ebpf/gpuevent"

--- a/pkg/components/ebpf/common/common.go
+++ b/pkg/components/ebpf/common/common.go
@@ -16,13 +16,11 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/hashicorp/golang-lru/v2/simplelru"
-
-	lru "github.com/hashicorp/golang-lru/v2"
-	"github.com/hashicorp/golang-lru/v2/expirable"
-
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/ebpf/ringbuf"

--- a/pkg/components/ebpf/common/http2grpc_transform.go
+++ b/pkg/components/ebpf/common/http2grpc_transform.go
@@ -12,8 +12,9 @@ import (
 	"unsafe"
 
 	lru "github.com/hashicorp/golang-lru/v2"
-	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/net/http2"
+
+	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/ebpf/bhpack"

--- a/pkg/components/ebpf/common/mongo_detect_transform.go
+++ b/pkg/components/ebpf/common/mongo_detect_transform.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"go.mongodb.org/mongo-driver/v2/bson"
+
 	trace2 "go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/obi/pkg/app/request"

--- a/pkg/components/ebpf/common/mongo_detect_transform_test.go
+++ b/pkg/components/ebpf/common/mongo_detect_transform_test.go
@@ -8,10 +8,9 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 

--- a/pkg/components/ebpf/common/pids_test.go
+++ b/pkg/components/ebpf/common/pids_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/obi/pkg/app/request"

--- a/pkg/components/ebpf/common/redis_detect_transform_test.go
+++ b/pkg/components/ebpf/common/redis_detect_transform_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/components/ebpf/gotracer/gotracer.go
+++ b/pkg/components/ebpf/gotracer/gotracer.go
@@ -21,6 +21,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf"
+
 	"go.opentelemetry.io/otel/attribute"
 
 	"go.opentelemetry.io/obi/pkg/app/request"

--- a/pkg/components/helpers/sync/queue_test.go
+++ b/pkg/components/helpers/sync/queue_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/components/testutil"
-
 	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/obi/pkg/components/testutil"
 )
 
 const timeout = 5 * time.Second

--- a/pkg/components/imetrics/iprom.go
+++ b/pkg/components/imetrics/iprom.go
@@ -8,12 +8,11 @@ import (
 	"runtime"
 	"time"
 
-	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"go.opentelemetry.io/obi/pkg/buildinfo"
 	"go.opentelemetry.io/obi/pkg/components/connector"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 )
 
 // pipelineBufferLengths buckets for histogram metrics about the number of traces submitted from one stage to another

--- a/pkg/components/pipe/global/host_id.go
+++ b/pkg/components/pipe/global/host_id.go
@@ -12,12 +12,13 @@ import (
 	"os"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"go.opentelemetry.io/contrib/detectors/aws/ec2"
 	"go.opentelemetry.io/contrib/detectors/azure/azurevm"
 	"go.opentelemetry.io/contrib/detectors/gcp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type hostIDFetcher func(context.Context, time.Duration) (string, error)

--- a/pkg/components/pipe/instrumenter_test.go
+++ b/pkg/components/pipe/instrumenter_test.go
@@ -10,13 +10,13 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
 
 	"go.opentelemetry.io/obi/pkg/app/request"

--- a/pkg/components/svc/svc.go
+++ b/pkg/components/svc/svc.go
@@ -4,9 +4,8 @@
 package svc
 
 import (
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
-
 	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/services"

--- a/pkg/export/debug/debug_test.go
+++ b/pkg/export/debug/debug_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	trace2 "go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/obi/pkg/app/request"

--- a/pkg/export/otel/expirer_test.go
+++ b/pkg/export/otel/expirer_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,6 +20,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/test/collector"
 )

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -10,19 +10,17 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
-
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
-	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 
 	"go.opentelemetry.io/otel/attribute"
 	instrument "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 
 	"go.opentelemetry.io/obi/pkg/buildinfo"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 )
 
 // InternalMetricsReporter is an internal metrics Reporter that exports to OTEL

--- a/pkg/export/otel/metrics_net.go
+++ b/pkg/export/otel/metrics_net.go
@@ -9,8 +9,6 @@ import (
 	"log/slog"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -24,6 +22,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/expire"
 	"go.opentelemetry.io/obi/pkg/export/otel/metric"
 	metric2 "go.opentelemetry.io/obi/pkg/export/otel/metric/api/metric"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 )

--- a/pkg/export/otel/metrics_net_test.go
+++ b/pkg/export/otel/metrics_net_test.go
@@ -7,16 +7,16 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/otel/attribute"
 
 	"go.opentelemetry.io/obi/pkg/components/netolly/ebpf"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -25,6 +23,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel/metric"
 	instrument "go.opentelemetry.io/obi/pkg/export/otel/metric/api/metric"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 )

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,6 +25,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 	"go.opentelemetry.io/obi/test/collector"

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"google.golang.org/grpc/credentials"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -24,7 +26,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	semconv "go.opentelemetry.io/otel/semconv/v1.19.0"
-	"google.golang.org/grpc/credentials"
 
 	"go.opentelemetry.io/obi/pkg/buildinfo"
 	"go.opentelemetry.io/obi/pkg/components/svc"

--- a/pkg/export/otel/otelcfg/common_test.go
+++ b/pkg/export/otel/otelcfg/common_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/attribute"
 
 	"go.opentelemetry.io/obi/pkg/components/svc"

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -13,17 +13,15 @@ import (
 	"strconv"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
-	"go.opentelemetry.io/collector/config/configoptional"
-
 	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
-	"go.opentelemetry.io/otel/attribute"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer"
@@ -33,13 +31,12 @@ import (
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 	trace2 "go.opentelemetry.io/otel/trace"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
-	"go.uber.org/zap"
-	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
@@ -47,6 +44,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 )

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -11,12 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -33,6 +31,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -13,8 +13,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"go.opentelemetry.io/obi/pkg/app/request"
@@ -28,6 +26,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/expire"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 )

--- a/pkg/export/prom/prom_net_test.go
+++ b/pkg/export/prom/prom_net_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,6 +16,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/components/netolly/ebpf"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -16,8 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +30,7 @@ import (
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 )

--- a/pkg/instrumenter/instrumenter.go
+++ b/pkg/instrumenter/instrumenter.go
@@ -10,8 +10,6 @@ import (
 	"sync"
 	"text/template"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"golang.org/x/sync/errgroup"
 
 	"go.opentelemetry.io/obi/pkg/components/appolly"
@@ -23,6 +21,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/otel"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/obi"
 )
 

--- a/pkg/instrumenter/instrumenter_test.go
+++ b/pkg/instrumenter/instrumenter_test.go
@@ -6,13 +6,11 @@ package instrumenter
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/obi/pkg/transform"
-
-	"github.com/stretchr/testify/assert"
-
 	"go.opentelemetry.io/obi/pkg/obi"
+	"go.opentelemetry.io/obi/pkg/transform"
 )
 
 func TestServiceNameTemplate(t *testing.T) {

--- a/pkg/kubecache/envtest/integration_test.go
+++ b/pkg/kubecache/envtest/integration_test.go
@@ -12,8 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/components/testutil"
-
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	"go.opentelemetry.io/obi/pkg/components/testutil"
 	"go.opentelemetry.io/obi/pkg/kubecache"
 	"go.opentelemetry.io/obi/pkg/kubecache/informer"
 	"go.opentelemetry.io/obi/pkg/kubecache/meta"

--- a/pkg/kubecache/instrument/imetrics.go
+++ b/pkg/kubecache/instrument/imetrics.go
@@ -6,12 +6,11 @@ package instrument
 import (
 	"runtime"
 
-	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"go.opentelemetry.io/obi/pkg/buildinfo"
 	"go.opentelemetry.io/obi/pkg/components/connector"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 )
 
 // InternalMetrics accounts diverse events of the Beyla Cache service

--- a/pkg/kubecache/service/service.go
+++ b/pkg/kubecache/service/service.go
@@ -12,11 +12,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/components/helpers/sync"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 
+	"go.opentelemetry.io/obi/pkg/components/helpers/sync"
 	"go.opentelemetry.io/obi/pkg/kubecache"
 	"go.opentelemetry.io/obi/pkg/kubecache/informer"
 	"go.opentelemetry.io/obi/pkg/kubecache/instrument"

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -9,8 +9,6 @@ import (
 	"log/slog"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"github.com/caarlos0/env/v9"
 	"gopkg.in/yaml.v3"
 
@@ -24,6 +22,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/debug"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/export/prom"
 	"go.opentelemetry.io/obi/pkg/filter"
 	"go.opentelemetry.io/obi/pkg/kubeflags"

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -29,6 +27,7 @@ import (
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/debug"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/export/prom"
 	"go.opentelemetry.io/obi/pkg/kubeflags"
 	"go.opentelemetry.io/obi/pkg/services"

--- a/pkg/services/samplerconfig_test.go
+++ b/pkg/services/samplerconfig_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 

--- a/test/integration/components/go_otel/main.go
+++ b/test/integration/components/go_otel/main.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"time"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -33,7 +35,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
-	"go.uber.org/zap"
 )
 
 // Server is Http server that exposes multiple endpoints.

--- a/test/integration/components/go_otel_grpc/main.go
+++ b/test/integration/components/go_otel_grpc/main.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"time"
 
+	"go.uber.org/zap"
+
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -33,7 +35,6 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
-	"go.uber.org/zap"
 )
 
 // Server is Http server that exposes multiple endpoints.

--- a/test/integration/red_test_dotnet.go
+++ b/test/integration/red_test_dotnet.go
@@ -8,13 +8,12 @@ package integration
 import (
 	"testing"
 
-	"go.opentelemetry.io/obi/test/tools"
-
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/test/integration/components/prom"
+	"go.opentelemetry.io/obi/test/tools"
 )
 
 func testREDMetricsForNetHTTPLibrary(t *testing.T, url string, comm string) {

--- a/test/integration/red_test_python_mongo.go
+++ b/test/integration/red_test_python_mongo.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/attribute"
 
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/test/integration/components/prom"

--- a/test/integration/red_test_python_redis.go
+++ b/test/integration/red_test_python_redis.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/attribute"
 
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/test/integration/components/prom"

--- a/test/integration/test_utils.go
+++ b/test/integration/test_utils.go
@@ -18,15 +18,14 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-
-	"go.opentelemetry.io/obi/test/integration/components/jaeger"
-
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
 
+	"go.opentelemetry.io/otel/attribute"
+
+	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 )
 


### PR DESCRIPTION
The previous goimports-based package ordering was not behaving as expected, as many automatically-added imports (e.g. by the IDE) weren't properly ordered if they were inserted in their own group (separated by a line from the rest).

Replacing goimports by `gci` in the golanci-lint, we get a more consistent order of imports in 4 separate groups:
        - standard packages
        - generic 3rd party packages
        - OpenTelemetry packages
        - Local OBI packages