### PR TITLE
Optimize ExportModes

### DIFF
--- a/pkg/components/discover/typer.go
+++ b/pkg/components/discover/typer.go
@@ -97,7 +97,7 @@ func samplerFromConfig(s *services.SamplerConfig) trace.Sampler {
 func makeServiceAttrs(processMatch *ProcessMatch) svc.Attrs {
 	var name string
 	var namespace string
-	var exportModes services.ExportModes
+	var exportModes *services.ExportModes
 	var samplerConfig *services.SamplerConfig
 
 	for _, s := range processMatch.Criteria {

--- a/pkg/components/svc/svc.go
+++ b/pkg/components/svc/svc.go
@@ -101,7 +101,7 @@ type Attrs struct {
 
 	flags idFlags
 
-	ExportModes services.ExportModes
+	ExportModes *services.ExportModes
 
 	Sampler trace.Sampler
 }

--- a/pkg/services/attr_glob.go
+++ b/pkg/services/attr_glob.go
@@ -77,7 +77,7 @@ type GlobAttributes struct {
 	// Configures what to export. Allowed values are 'metrics', 'traces',
 	// or an empty array (disabled). An unspecified value (nil) will use the
 	// default configuration value
-	ExportModes ExportModes `yaml:"exports"`
+	ExportModes *ExportModes `yaml:"exports"`
 
 	SamplerConfig *SamplerConfig `yaml:"sampler"`
 }
@@ -177,7 +177,7 @@ func (ga *GlobAttributes) RangePodAnnotations() iter.Seq2[string, StringMatcher]
 	}
 }
 
-func (ga *GlobAttributes) GetExportModes() ExportModes { return ga.ExportModes }
+func (ga *GlobAttributes) GetExportModes() *ExportModes { return ga.ExportModes }
 
 func (ga *GlobAttributes) GetSamplerConfig() *SamplerConfig { return ga.SamplerConfig }
 

--- a/pkg/services/attr_regex.go
+++ b/pkg/services/attr_regex.go
@@ -83,7 +83,7 @@ type RegexSelector struct {
 	// Configures what to export. Allowed values are 'metrics', 'traces',
 	// or an empty array (disabled). An unspecified value (nil) will use the
 	// default configuration value
-	ExportModes ExportModes `yaml:"exports"`
+	ExportModes *ExportModes `yaml:"exports"`
 
 	SamplerConfig *SamplerConfig `yaml:"sampler"`
 }
@@ -181,6 +181,6 @@ func (a *RegexSelector) RangePodAnnotations() iter.Seq2[string, StringMatcher] {
 	}
 }
 
-func (a *RegexSelector) GetExportModes() ExportModes { return a.ExportModes }
+func (a *RegexSelector) GetExportModes() *ExportModes { return a.ExportModes }
 
 func (a *RegexSelector) GetSamplerConfig() *SamplerConfig { return a.SamplerConfig }

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"iter"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -119,70 +118,6 @@ func (c *DiscoveryConfig) Validate() error {
 	return nil
 }
 
-type ExportMode uint8
-
-const (
-	ExportMetrics = ExportMode(iota)
-	ExportTraces
-)
-
-var textForMode = [...]string{
-	ExportMetrics: "metrics",
-	ExportTraces:  "traces",
-}
-
-func (e ExportMode) MarshalText() ([]byte, error) {
-	if int(e) < 0 || int(e) >= len(textForMode) {
-		return nil, fmt.Errorf("invalid ExportMode: %d", e)
-	}
-
-	return []byte(textForMode[e]), nil
-}
-
-func (e *ExportMode) UnmarshalText(text []byte) error {
-	s := string(text)
-
-	for i, v := range textForMode {
-		if v == s {
-			*e = ExportMode(i)
-			return nil
-		}
-	}
-
-	return fmt.Errorf("invalid value for export_mode: %q", s)
-}
-
-func (e ExportMode) String() string {
-	b, err := e.MarshalText()
-	if err != nil {
-		return "#INVALID!#"
-	}
-
-	return string(b)
-}
-
-type ExportModes []ExportMode
-
-func (modes ExportModes) CanExport(mode ExportMode) bool {
-	if modes == nil {
-		return true
-	}
-
-	return slices.Contains(modes, mode)
-}
-
-// CanExportTraces reports whether traces can be exported.
-// It's provided as a convenience function.
-func (modes ExportModes) CanExportTraces() bool {
-	return modes.CanExport(ExportTraces)
-}
-
-// CanExportMetrics reports whether metrics can be exported.
-// It's provided as a convenience function.
-func (modes ExportModes) CanExportMetrics() bool {
-	return modes.CanExport(ExportMetrics)
-}
-
 // Selector defines a generic interface for selecting service processes based on different criteria.
 type Selector interface {
 	// Deprecated: Name should be set in the instrumentation target via kube metadata or standard env vars
@@ -196,7 +131,7 @@ type Selector interface {
 	RangeMetadata() iter.Seq2[string, StringMatcher]
 	RangePodLabels() iter.Seq2[string, StringMatcher]
 	RangePodAnnotations() iter.Seq2[string, StringMatcher]
-	GetExportModes() ExportModes
+	GetExportModes() *ExportModes
 	GetSamplerConfig() *SamplerConfig
 }
 

--- a/pkg/services/export.go
+++ b/pkg/services/export.go
@@ -1,0 +1,105 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package services
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"go.opentelemetry.io/obi/pkg/components/helpers/maps"
+)
+
+const (
+	exportMetrics = maps.Bits(1 << iota)
+	exportTraces
+)
+
+var modeForText = map[string]maps.Bits{
+	"metrics": exportMetrics,
+	"traces":  exportTraces,
+}
+
+type ExportModes struct {
+	items maps.Bits
+}
+
+func (modes *ExportModes) canExport(mode maps.Bits) bool {
+	if modes == nil {
+		return true
+	}
+	return modes.items.Has(mode)
+}
+
+// CanExportTraces reports whether traces can be exported.
+// It's provided as a convenience function.
+func (modes *ExportModes) CanExportTraces() bool {
+	return modes.canExport(exportTraces)
+}
+
+// CanExportMetrics reports whether metrics can be exported.
+// It's provided as a convenience function.
+func (modes *ExportModes) CanExportMetrics() bool {
+	return modes.canExport(exportMetrics)
+}
+
+func (modes *ExportModes) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.SequenceNode {
+		return fmt.Errorf("ExportModes: unexpected YAML node kind %d", value.Kind)
+	}
+	for i, inner := range value.Content {
+		if inner.Kind != yaml.ScalarNode {
+			return fmt.Errorf("ExportModes[%d]: : unexpected YAML node kind %d", i, inner.Kind)
+		}
+		if mode, ok := modeForText[inner.Value]; !ok {
+			return fmt.Errorf("ExportModes[%d]: unknown export mode %q", i, inner.Value)
+		} else {
+			modes.items |= mode
+		}
+	}
+	return modes.UnmarshalText([]byte(value.Value))
+}
+
+func (modes *ExportModes) UnmarshalText(text []byte) error {
+	var options []string
+	if err := yaml.Unmarshal(text, &options); err != nil {
+		return fmt.Errorf("invalid export_modes: %w", err)
+	}
+	if options == nil {
+		return nil
+	}
+	modes.items = maps.MappedBits(options, modeForText)
+	return nil
+}
+
+func (modes *ExportModes) MarshalYAML() (any, error) {
+	if modes == nil {
+		return nil, nil
+	}
+	node := yaml.Node{
+		Kind: yaml.SequenceNode,
+	}
+	for text, mode := range modeForText {
+		if modes.items.Has(mode) {
+			node.Content = append(node.Content, &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Value: text,
+			})
+		}
+	}
+	return node, nil
+}
+
+func (modes *ExportModes) MarshalText() ([]byte, error) {
+	var options []string
+	if modes != nil {
+		options = make([]string, 0, len(modeForText))
+		for text, mode := range modeForText {
+			if modes.items.Has(mode) {
+				options = append(options, text)
+			}
+		}
+	}
+	return yaml.Marshal(options)
+}

--- a/pkg/services/export_test.go
+++ b/pkg/services/export_test.go
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestYAMLMarshal_Exports(t *testing.T) {
+	type tc struct {
+		Exports *ExportModes
+	}
+	t.Run("nil value", func(t *testing.T) {
+		yamlOut, err := yaml.Marshal(&tc{
+			Exports: nil,
+		})
+		require.NoError(t, err)
+		assert.YAMLEq(t, `exports: null`, string(yamlOut))
+	})
+	t.Run("empty value", func(t *testing.T) {
+		yamlOut, err := yaml.Marshal(&tc{
+			Exports: &ExportModes{},
+		})
+		require.NoError(t, err)
+		assert.YAMLEq(t, `exports: []`, string(yamlOut))
+	})
+	t.Run("some value", func(t *testing.T) {
+		yamlOut, err := yaml.Marshal(&tc{
+			Exports: &ExportModes{items: exportMetrics},
+		})
+		require.NoError(t, err)
+		assert.YAMLEq(t, `exports: ["metrics"]`, string(yamlOut))
+	})
+	t.Run("all values", func(t *testing.T) {
+		yamlOut, err := yaml.Marshal(&tc{
+			Exports: &ExportModes{items: exportMetrics | exportTraces},
+		})
+		require.NoError(t, err)
+		assert.YAMLEq(t, `exports: ["metrics", "traces"]`, string(yamlOut))
+	})
+}
+
+func TestYAMLUnmarshal_Exports(t *testing.T) {
+	type tc struct {
+		Exports *ExportModes
+	}
+	t.Run("nil value", func(t *testing.T) {
+		var tc tc
+		err := yaml.Unmarshal([]byte(`exports: null`), &tc)
+		require.NoError(t, err)
+		assert.Nil(t, tc.Exports)
+	})
+	t.Run("empty value", func(t *testing.T) {
+		var tc tc
+		err := yaml.Unmarshal([]byte(`exports: []`), &tc)
+		require.NoError(t, err)
+		assert.NotNil(t, tc.Exports)
+		assert.False(t, tc.Exports.CanExportMetrics())
+		assert.False(t, tc.Exports.CanExportTraces())
+	})
+	t.Run("metrics value", func(t *testing.T) {
+		var tc tc
+		err := yaml.Unmarshal([]byte(`exports: ["metrics"]`), &tc)
+		require.NoError(t, err)
+		assert.True(t, tc.Exports.CanExportMetrics())
+		assert.False(t, tc.Exports.CanExportTraces())
+	})
+	t.Run("traces value", func(t *testing.T) {
+		var tc tc
+		err := yaml.Unmarshal([]byte(`exports: ["traces"]`), &tc)
+		require.NoError(t, err)
+		assert.False(t, tc.Exports.CanExportMetrics())
+		assert.True(t, tc.Exports.CanExportTraces())
+	})
+	t.Run("metrics and traces value", func(t *testing.T) {
+		var tc tc
+		err := yaml.Unmarshal([]byte(`exports: ["metrics", "traces"]`), &tc)
+		require.NoError(t, err)
+		assert.True(t, tc.Exports.CanExportMetrics())
+		assert.True(t, tc.Exports.CanExportTraces())
+	})
+}


### PR DESCRIPTION
`ExportModes.CanExportMetrics` is invoked for each Span. I slightly optimized it by changing its internal representation by a bits map.

Now, instead of having to iterate a short slice and perform 1-2 string comparisons for each span, it just checks a bit in an integer.

The YAML marshaling/unmarshaling remained the same, as well as the rest of the public API.