### PR TITLE
Few extra improvements in ExportModes

### DIFF
--- a/pkg/components/discover/typer.go
+++ b/pkg/components/discover/typer.go
@@ -97,7 +97,7 @@ func samplerFromConfig(s *services.SamplerConfig) trace.Sampler {
 func makeServiceAttrs(processMatch *ProcessMatch) svc.Attrs {
 	var name string
 	var namespace string
-	var exportModes *services.ExportModes
+	exportModes := services.ExportModeUnset
 	var samplerConfig *services.SamplerConfig
 
 	for _, s := range processMatch.Criteria {
@@ -109,7 +109,7 @@ func makeServiceAttrs(processMatch *ProcessMatch) svc.Attrs {
 			namespace = n
 		}
 
-		if m := s.GetExportModes(); m != nil {
+		if m := s.GetExportModes(); m != services.ExportModeUnset {
 			exportModes = m
 		}
 

--- a/pkg/components/svc/svc.go
+++ b/pkg/components/svc/svc.go
@@ -100,7 +100,7 @@ type Attrs struct {
 
 	flags idFlags
 
-	ExportModes *services.ExportModes
+	ExportModes services.ExportModes
 
 	Sampler trace.Sampler
 }

--- a/pkg/services/attr_glob.go
+++ b/pkg/services/attr_glob.go
@@ -77,7 +77,7 @@ type GlobAttributes struct {
 	// Configures what to export. Allowed values are 'metrics', 'traces',
 	// or an empty array (disabled). An unspecified value (nil) will use the
 	// default configuration value
-	ExportModes *ExportModes `yaml:"exports"`
+	ExportModes ExportModes `yaml:"exports"`
 
 	SamplerConfig *SamplerConfig `yaml:"sampler"`
 }
@@ -177,7 +177,7 @@ func (ga *GlobAttributes) RangePodAnnotations() iter.Seq2[string, StringMatcher]
 	}
 }
 
-func (ga *GlobAttributes) GetExportModes() *ExportModes { return ga.ExportModes }
+func (ga *GlobAttributes) GetExportModes() ExportModes { return ga.ExportModes }
 
 func (ga *GlobAttributes) GetSamplerConfig() *SamplerConfig { return ga.SamplerConfig }
 

--- a/pkg/services/attr_regex.go
+++ b/pkg/services/attr_regex.go
@@ -83,7 +83,7 @@ type RegexSelector struct {
 	// Configures what to export. Allowed values are 'metrics', 'traces',
 	// or an empty array (disabled). An unspecified value (nil) will use the
 	// default configuration value
-	ExportModes *ExportModes `yaml:"exports"`
+	ExportModes ExportModes `yaml:"exports"`
 
 	SamplerConfig *SamplerConfig `yaml:"sampler"`
 }
@@ -181,6 +181,6 @@ func (a *RegexSelector) RangePodAnnotations() iter.Seq2[string, StringMatcher] {
 	}
 }
 
-func (a *RegexSelector) GetExportModes() *ExportModes { return a.ExportModes }
+func (a *RegexSelector) GetExportModes() ExportModes { return a.ExportModes }
 
 func (a *RegexSelector) GetSamplerConfig() *SamplerConfig { return a.SamplerConfig }

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -131,7 +131,7 @@ type Selector interface {
 	RangeMetadata() iter.Seq2[string, StringMatcher]
 	RangePodLabels() iter.Seq2[string, StringMatcher]
 	RangePodAnnotations() iter.Seq2[string, StringMatcher]
-	GetExportModes() *ExportModes
+	GetExportModes() ExportModes
 	GetSamplerConfig() *SamplerConfig
 }
 

--- a/pkg/services/export_test.go
+++ b/pkg/services/export_test.go
@@ -13,32 +13,32 @@ import (
 
 func TestYAMLMarshal_Exports(t *testing.T) {
 	type tc struct {
-		Exports *ExportModes
+		Exports ExportModes
 	}
 	t.Run("nil value", func(t *testing.T) {
 		yamlOut, err := yaml.Marshal(&tc{
-			Exports: nil,
+			Exports: ExportModes{},
 		})
 		require.NoError(t, err)
 		assert.YAMLEq(t, `exports: null`, string(yamlOut))
 	})
 	t.Run("empty value", func(t *testing.T) {
 		yamlOut, err := yaml.Marshal(&tc{
-			Exports: &ExportModes{},
+			Exports: ExportModes{blockSignal: blockAll},
 		})
 		require.NoError(t, err)
 		assert.YAMLEq(t, `exports: []`, string(yamlOut))
 	})
 	t.Run("some value", func(t *testing.T) {
 		yamlOut, err := yaml.Marshal(&tc{
-			Exports: &ExportModes{items: exportMetrics},
+			Exports: ExportModes{blockSignal: ^blockMetrics},
 		})
 		require.NoError(t, err)
 		assert.YAMLEq(t, `exports: ["metrics"]`, string(yamlOut))
 	})
 	t.Run("all values", func(t *testing.T) {
 		yamlOut, err := yaml.Marshal(&tc{
-			Exports: &ExportModes{items: exportMetrics | exportTraces},
+			Exports: ExportModes{blockSignal: ^(blockMetrics | blockTraces)},
 		})
 		require.NoError(t, err)
 		assert.YAMLEq(t, `exports: ["metrics", "traces"]`, string(yamlOut))
@@ -47,13 +47,14 @@ func TestYAMLMarshal_Exports(t *testing.T) {
 
 func TestYAMLUnmarshal_Exports(t *testing.T) {
 	type tc struct {
-		Exports *ExportModes
+		Exports ExportModes
 	}
-	t.Run("nil value", func(t *testing.T) {
+	t.Run("undefined value", func(t *testing.T) {
 		var tc tc
 		err := yaml.Unmarshal([]byte(`exports: null`), &tc)
 		require.NoError(t, err)
-		assert.Nil(t, tc.Exports)
+		assert.True(t, tc.Exports.CanExportMetrics())
+		assert.True(t, tc.Exports.CanExportTraces())
 	})
 	t.Run("empty value", func(t *testing.T) {
 		var tc tc

--- a/pkg/services/export_test.go
+++ b/pkg/services/export_test.go
@@ -51,6 +51,13 @@ func TestYAMLUnmarshal_Exports(t *testing.T) {
 	}
 	t.Run("undefined value", func(t *testing.T) {
 		var tc tc
+		err := yaml.Unmarshal([]byte(``), &tc)
+		require.NoError(t, err)
+		assert.True(t, tc.Exports.CanExportMetrics())
+		assert.True(t, tc.Exports.CanExportTraces())
+	})
+	t.Run("nil value", func(t *testing.T) {
+		var tc tc
 		err := yaml.Unmarshal([]byte(`exports: null`), &tc)
 		require.NoError(t, err)
 		assert.True(t, tc.Exports.CanExportMetrics())


### PR DESCRIPTION
Slightly improves the [previous PR](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/402) that already optimized ExportModes w.r.t. using slices:

This PR removes all the pointer semantics and uses ExportModes as a value:
- We don't need null checks to stay safe against null pointers.
- We save some indirections, as we are using a value.

This PR inverts the internal representation of the export list, but its public API remains the same.

Also, some places where `ExportModes` fields were defined as pointers, now become values.

In addition, we add extra code comments for a better understanding of the API and the internal implementation.