### PR TITLE
Revert change that breaks collector embedding

### DIFF
--- a/pkg/components/ebpf/common/pids.go
+++ b/pkg/components/ebpf/common/pids.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/exec"
 	"go.opentelemetry.io/obi/pkg/components/svc"
-	"go.opentelemetry.io/obi/pkg/export/otel"
+	"go.opentelemetry.io/obi/pkg/export/otel/idgen"
 	"go.opentelemetry.io/obi/pkg/services"
 )
 
@@ -110,11 +110,11 @@ func (pf *PIDsFilter) CurrentPIDs(t PIDType) map[uint32]map[uint32]svc.Attrs {
 
 func (pf *PIDsFilter) normalizeTraceContext(span *request.Span) {
 	if !span.TraceID.IsValid() {
-		span.TraceID = otel.RandomTraceID()
+		span.TraceID = idgen.RandomTraceID()
 		span.TraceFlags = 1
 	}
 	if !span.SpanID.IsValid() {
-		span.SpanID = otel.RandomSpanID()
+		span.SpanID = idgen.RandomSpanID()
 	}
 }
 

--- a/pkg/export/otel/idgen/id_generator.go
+++ b/pkg/export/otel/idgen/id_generator.go
@@ -16,7 +16,7 @@
 // This implementation was inspired by the code in
 // https://github.com/open-telemetry/opentelemetry-go-instrumentation/blob/cdfad4a67b86c282ed29141ca0b3bca46509eee9/internal/pkg/opentelemetry/id_generator.go
 
-package otel
+package idgen
 
 import (
 	"encoding/binary"

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/config/configtls"
@@ -36,24 +37,12 @@ import (
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 )
 
 const reporterName = "go.opentelemetry.io/obi"
-
-type TraceSpanAndAttributes struct {
-	Span       *request.Span
-	Attributes []attribute.KeyValue
-}
-
-type SpanAttr struct {
-	ValLength uint16
-	Vtype     uint8
-	Reserved  uint8
-	Key       [32]uint8
-	Value     [128]uint8
-}
 
 func makeTracesReceiver(
 	cfg otelcfg.TracesConfig,
@@ -101,7 +90,7 @@ type tracesOTELReceiver struct {
 }
 
 func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, error) {
-	traceAttrs, err := UserSelectedAttributes(tr.selectorCfg)
+	traceAttrs, err := tracesgen.UserSelectedAttributes(tr.selectorCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, e
 }
 
 func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Traces, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler) {
-	spanGroups := GroupSpans(ctx, spans, traceAttrs, sampler, tr.is)
+	spanGroups := tracesgen.GroupSpans(ctx, spans, traceAttrs, sampler, tr.is)
 
 	for _, spanGroup := range spanGroups {
 		if len(spanGroup) > 0 {
@@ -124,7 +113,7 @@ func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Tra
 			}
 
 			envResourceAttrs := otelcfg.ResourceAttrsFromEnv(&sample.Span.Service)
-			traces := GenerateTracesWithAttributes(tr.attributeCache, &sample.Span.Service, envResourceAttrs, tr.ctxInfo.HostID, spanGroup, tr.ctxInfo.ExtraResourceAttributes...)
+			traces := tracesgen.GenerateTracesWithAttributes(tr.attributeCache, &sample.Span.Service, envResourceAttrs, tr.ctxInfo.HostID, spanGroup, reporterName, tr.ctxInfo.ExtraResourceAttributes...)
 			err := exp.ConsumeTraces(ctx, traces)
 			if err != nil {
 				slog.Error("error sending trace to consumer", "error", err)
@@ -299,4 +288,12 @@ func getRetrySettings(cfg otelcfg.TracesConfig) configretry.BackOffConfig {
 		backOffCfg.MaxElapsedTime = cfg.BackOffMaxElapsedTime
 	}
 	return backOffCfg
+}
+
+func convertHeaders(headers map[string]string) map[string]configopaque.String {
+	opaqueHeaders := make(map[string]configopaque.String)
+	for key, value := range headers {
+		opaqueHeaders[key] = configopaque.String(value)
+	}
+	return opaqueHeaders
 }

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -5,22 +5,16 @@ package otel
 
 import (
 	"context"
-	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"log/slog"
-	"math"
-	"strconv"
 	"time"
 
 	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
 	"go.uber.org/zap"
-	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
-	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/config/configtls"
@@ -30,12 +24,9 @@ import (
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
-	trace2 "go.opentelemetry.io/otel/trace"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 
 	"go.opentelemetry.io/obi/pkg/app/request"
@@ -109,23 +100,8 @@ type tracesOTELReceiver struct {
 	input              <-chan []request.Span
 }
 
-func userSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr.Name]struct{}, error) {
-	// Get user attributes
-	attribProvider, err := attributes.NewAttrSelector(attributes.GroupTraces, selectorCfg)
-	if err != nil {
-		return nil, err
-	}
-	traceAttrsArr := attribProvider.For(attributes.Traces)
-	traceAttrs := make(map[attr.Name]struct{})
-	for _, a := range traceAttrsArr {
-		traceAttrs[a] = struct{}{}
-	}
-
-	return traceAttrs, err
-}
-
 func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, error) {
-	traceAttrs, err := userSelectedAttributes(tr.selectorCfg)
+	traceAttrs, err := UserSelectedAttributes(tr.selectorCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -136,57 +112,8 @@ func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, e
 	return traceAttrs, nil
 }
 
-func spanDiscarded(span *request.Span, is instrumentations.InstrumentationSelection) bool {
-	return request.IgnoreTraces(span) || span.Service.ExportsOTelTraces() || !acceptSpan(is, span)
-}
-
-func groupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection) map[svc.UID][]TraceSpanAndAttributes {
-	spanGroups := map[svc.UID][]TraceSpanAndAttributes{}
-
-	for i := range spans {
-		span := &spans[i]
-		if span.InternalSignal() {
-			continue
-		}
-		if spanDiscarded(span, is) {
-			continue
-		}
-
-		finalAttrs := traceAttributes(span, traceAttrs)
-
-		spanSampler := func() trace.Sampler {
-			if span.Service.Sampler != nil {
-				return span.Service.Sampler
-			}
-
-			return sampler
-		}
-
-		sr := spanSampler().ShouldSample(trace.SamplingParameters{
-			ParentContext: ctx,
-			Name:          span.TraceName(),
-			TraceID:       span.TraceID,
-			Kind:          spanKind(span),
-			Attributes:    finalAttrs,
-		})
-
-		if sr.Decision == trace.Drop {
-			continue
-		}
-
-		group, ok := spanGroups[span.Service.UID]
-		if !ok {
-			group = []TraceSpanAndAttributes{}
-		}
-		group = append(group, TraceSpanAndAttributes{Span: span, Attributes: finalAttrs})
-		spanGroups[span.Service.UID] = group
-	}
-
-	return spanGroups
-}
-
 func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Traces, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler) {
-	spanGroups := groupSpans(ctx, spans, traceAttrs, sampler, tr.is)
+	spanGroups := GroupSpans(ctx, spans, traceAttrs, sampler, tr.is)
 
 	for _, spanGroup := range spanGroups {
 		if len(spanGroup) > 0 {
@@ -197,7 +124,7 @@ func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Tra
 			}
 
 			envResourceAttrs := otelcfg.ResourceAttrsFromEnv(&sample.Span.Service)
-			traces := generateTracesWithAttributes(tr.attributeCache, &sample.Span.Service, envResourceAttrs, tr.ctxInfo.HostID, spanGroup, tr.ctxInfo.ExtraResourceAttributes...)
+			traces := GenerateTracesWithAttributes(tr.attributeCache, &sample.Span.Service, envResourceAttrs, tr.ctxInfo.HostID, spanGroup, tr.ctxInfo.ExtraResourceAttributes...)
 			err := exp.ConsumeTraces(ctx, traces)
 			if err != nil {
 				slog.Error("error sending trace to consumer", "error", err)
@@ -372,386 +299,4 @@ func getRetrySettings(cfg otelcfg.TracesConfig) configretry.BackOffConfig {
 		backOffCfg.MaxElapsedTime = cfg.BackOffMaxElapsedTime
 	}
 	return backOffCfg
-}
-
-var emptyUID = svc.UID{}
-
-func traceAppResourceAttrs(cache *expirable2.LRU[svc.UID, []attribute.KeyValue], hostID string, service *svc.Attrs) []attribute.KeyValue {
-	// TODO: remove?
-	if service.UID == emptyUID {
-		return otelcfg.GetAppResourceAttrs(hostID, service)
-	}
-
-	attrs, ok := cache.Get(service.UID)
-	if ok {
-		return attrs
-	}
-	attrs = otelcfg.GetAppResourceAttrs(hostID, service)
-	cache.Add(service.UID, attrs)
-
-	return attrs
-}
-
-func generateTracesWithAttributes(
-	cache *expirable2.LRU[svc.UID, []attribute.KeyValue],
-	svc *svc.Attrs,
-	envResourceAttrs []attribute.KeyValue,
-	hostID string,
-	spans []TraceSpanAndAttributes,
-	extraResAttrs ...attribute.KeyValue,
-) ptrace.Traces {
-	traces := ptrace.NewTraces()
-	rs := traces.ResourceSpans().AppendEmpty()
-	resourceAttrs := traceAppResourceAttrs(cache, hostID, svc)
-	resourceAttrs = append(resourceAttrs, envResourceAttrs...)
-	resourceAttrsMap := attrsToMap(resourceAttrs)
-	resourceAttrsMap.PutStr(string(semconv.OTelLibraryNameKey), reporterName)
-	addAttrsToMap(extraResAttrs, resourceAttrsMap)
-	resourceAttrsMap.MoveTo(rs.Resource().Attributes())
-
-	for _, spanWithAttributes := range spans {
-		span := spanWithAttributes.Span
-		attrs := spanWithAttributes.Attributes
-
-		ss := rs.ScopeSpans().AppendEmpty()
-
-		t := span.Timings()
-		start := spanStartTime(t)
-		hasSubSpans := t.Start.After(start)
-
-		traceID := pcommon.TraceID(span.TraceID)
-		spanID := pcommon.SpanID(RandomSpanID())
-		// This should never happen
-		if traceID.IsEmpty() {
-			traceID = pcommon.TraceID(RandomTraceID())
-		}
-
-		if hasSubSpans {
-			createSubSpans(span, spanID, traceID, &ss, t)
-		} else if span.SpanID.IsValid() {
-			spanID = pcommon.SpanID(span.SpanID)
-		}
-
-		// Create a parent span for the whole request session
-		s := ss.Spans().AppendEmpty()
-		s.SetName(span.TraceName())
-		s.SetKind(ptrace.SpanKind(spanKind(span)))
-		s.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
-
-		// Set trace and span IDs
-		s.SetSpanID(spanID)
-		s.SetTraceID(traceID)
-		if span.ParentSpanID.IsValid() {
-			s.SetParentSpanID(pcommon.SpanID(span.ParentSpanID))
-		}
-
-		// Set span attributes
-		m := attrsToMap(attrs)
-		m.MoveTo(s.Attributes())
-
-		// Set status code
-		statusCode := codeToStatusCode(request.SpanStatusCode(span))
-		s.Status().SetCode(statusCode)
-		statusMessage := request.SpanStatusMessage(span)
-		if statusMessage != "" {
-			s.Status().SetMessage(statusMessage)
-		}
-		s.SetEndTimestamp(pcommon.NewTimestampFromTime(t.End))
-	}
-	return traces
-}
-
-// createSubSpans creates the internal spans for a request.Span
-func createSubSpans(span *request.Span, parentSpanID pcommon.SpanID, traceID pcommon.TraceID, ss *ptrace.ScopeSpans, t request.Timings) {
-	// Create a child span showing the queue time
-	spQ := ss.Spans().AppendEmpty()
-	spQ.SetName("in queue")
-	spQ.SetStartTimestamp(pcommon.NewTimestampFromTime(t.RequestStart))
-	spQ.SetKind(ptrace.SpanKindInternal)
-	spQ.SetEndTimestamp(pcommon.NewTimestampFromTime(t.Start))
-	spQ.SetTraceID(traceID)
-	spQ.SetSpanID(pcommon.SpanID(RandomSpanID()))
-	spQ.SetParentSpanID(parentSpanID)
-
-	// Create a child span showing the processing time
-	spP := ss.Spans().AppendEmpty()
-	spP.SetName("processing")
-	spP.SetStartTimestamp(pcommon.NewTimestampFromTime(t.Start))
-	spP.SetKind(ptrace.SpanKindInternal)
-	spP.SetEndTimestamp(pcommon.NewTimestampFromTime(t.End))
-	spP.SetTraceID(traceID)
-	if span.SpanID.IsValid() {
-		spP.SetSpanID(pcommon.SpanID(span.SpanID))
-	} else {
-		spP.SetSpanID(pcommon.SpanID(RandomSpanID()))
-	}
-	spP.SetParentSpanID(parentSpanID)
-}
-
-// attrsToMap converts a slice of attribute.KeyValue to a pcommon.Map
-func attrsToMap(attrs []attribute.KeyValue) pcommon.Map {
-	m := pcommon.NewMap()
-	addAttrsToMap(attrs, m)
-	return m
-}
-
-func addAttrsToMap(attrs []attribute.KeyValue, dst pcommon.Map) {
-	dst.EnsureCapacity(dst.Len() + len(attrs))
-	for _, attr := range attrs {
-		switch v := attr.Value.AsInterface().(type) {
-		case string:
-			dst.PutStr(string(attr.Key), v)
-		case int64:
-			dst.PutInt(string(attr.Key), v)
-		case float64:
-			dst.PutDouble(string(attr.Key), v)
-		case bool:
-			dst.PutBool(string(attr.Key), v)
-		}
-	}
-}
-
-// codeToStatusCode converts a codes.Code to a ptrace.StatusCode
-func codeToStatusCode(code string) ptrace.StatusCode {
-	switch code {
-	case request.StatusCodeUnset:
-		return ptrace.StatusCodeUnset
-	case request.StatusCodeError:
-		return ptrace.StatusCodeError
-	case request.StatusCodeOk:
-		return ptrace.StatusCodeOk
-	}
-	return ptrace.StatusCodeUnset
-}
-
-func convertHeaders(headers map[string]string) map[string]configopaque.String {
-	opaqueHeaders := make(map[string]configopaque.String)
-	for key, value := range headers {
-		opaqueHeaders[key] = configopaque.String(value)
-	}
-	return opaqueHeaders
-}
-
-func acceptSpan(is instrumentations.InstrumentationSelection, span *request.Span) bool {
-	switch span.Type {
-	case request.EventTypeHTTP, request.EventTypeHTTPClient:
-		return is.HTTPEnabled()
-	case request.EventTypeGRPC, request.EventTypeGRPCClient:
-		return is.GRPCEnabled()
-	case request.EventTypeSQLClient:
-		return is.SQLEnabled()
-	case request.EventTypeRedisClient, request.EventTypeRedisServer:
-		return is.RedisEnabled()
-	case request.EventTypeKafkaClient, request.EventTypeKafkaServer:
-		return is.KafkaEnabled()
-	case request.EventTypeMongoClient:
-		return is.MongoEnabled()
-	case request.EventTypeManualSpan:
-		return true
-	}
-
-	return false
-}
-
-// TODO use semconv.DBSystemRedis when we update to OTEL semantic conventions library 1.30
-var (
-	dbSystemRedis   = attribute.String(string(attr.DBSystemName), semconv.DBSystemRedis.Value.AsString())
-	dbSystemMongo   = attribute.String(string(attr.DBSystemName), semconv.DBSystemMongoDB.Value.AsString())
-	spanMetricsSkip = attribute.Bool(string(attr.SkipSpanMetrics), true)
-)
-
-//nolint:cyclop
-func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
-	var attrs []attribute.KeyValue
-
-	switch span.Type {
-	case request.EventTypeHTTP:
-		attrs = []attribute.KeyValue{
-			request.HTTPRequestMethod(span.Method),
-			request.HTTPResponseStatusCode(span.Status),
-			request.HTTPUrlPath(span.Path),
-			request.ClientAddr(request.PeerAsClient(span)),
-			request.ServerAddr(request.SpanHost(span)),
-			request.ServerPort(span.HostPort),
-			request.HTTPRequestBodySize(int(span.RequestBodyLength())),
-			request.HTTPResponseBodySize(span.ResponseBodyLength()),
-		}
-		if span.Route != "" {
-			attrs = append(attrs, semconv.HTTPRoute(span.Route))
-		}
-	case request.EventTypeGRPC:
-		attrs = []attribute.KeyValue{
-			semconv.RPCMethod(span.Path),
-			semconv.RPCSystemGRPC,
-			semconv.RPCGRPCStatusCodeKey.Int(span.Status),
-			request.ClientAddr(request.PeerAsClient(span)),
-			request.ServerAddr(request.SpanHost(span)),
-			request.ServerPort(span.HostPort),
-		}
-	case request.EventTypeHTTPClient:
-		host := request.HTTPClientHost(span)
-		scheme := request.HTTPScheme(span)
-		url := span.Path
-		if span.HasOriginalHost() {
-			url = request.URLFull(scheme, host, span.Path)
-		}
-
-		attrs = []attribute.KeyValue{
-			request.HTTPRequestMethod(span.Method),
-			request.HTTPResponseStatusCode(span.Status),
-			request.HTTPUrlFull(url),
-			semconv.HTTPScheme(scheme),
-			request.ServerAddr(host),
-			request.ServerPort(span.HostPort),
-			request.HTTPRequestBodySize(int(span.RequestBodyLength())),
-			request.HTTPResponseBodySize(span.ResponseBodyLength()),
-		}
-	case request.EventTypeGRPCClient:
-		attrs = []attribute.KeyValue{
-			semconv.RPCMethod(span.Path),
-			semconv.RPCSystemGRPC,
-			semconv.RPCGRPCStatusCodeKey.Int(span.Status),
-			request.ServerAddr(request.HostAsServer(span)),
-			request.ServerPort(span.HostPort),
-		}
-	case request.EventTypeSQLClient:
-		attrs = []attribute.KeyValue{
-			request.ServerAddr(request.HostAsServer(span)),
-			request.ServerPort(span.HostPort),
-			span.DBSystemName(), // We can distinguish in the future for MySQL, Postgres etc
-		}
-		if _, ok := optionalAttrs[attr.DBQueryText]; ok {
-			attrs = append(attrs, request.DBQueryText(span.Statement))
-		}
-		operation := span.Method
-		if operation != "" {
-			attrs = append(attrs, request.DBOperationName(operation))
-			table := span.Path
-			if table != "" {
-				attrs = append(attrs, request.DBCollectionName(table))
-			}
-		}
-		if span.Status == 1 {
-			attrs = append(attrs, request.DBResponseStatusCode(strconv.Itoa(int(span.SQLError.Code))))
-			attrs = append(attrs, request.ErrorType(span.SQLError.SQLState))
-		}
-	case request.EventTypeRedisServer, request.EventTypeRedisClient:
-		attrs = []attribute.KeyValue{
-			request.ServerAddr(request.HostAsServer(span)),
-			request.ServerPort(span.HostPort),
-			dbSystemRedis,
-		}
-		operation := span.Method
-		if operation != "" {
-			attrs = append(attrs, request.DBOperationName(operation))
-			if _, ok := optionalAttrs[attr.DBQueryText]; ok {
-				query := span.Path
-				if query != "" {
-					attrs = append(attrs, request.DBQueryText(query))
-				}
-			}
-		}
-		if span.Status == 1 {
-			attrs = append(attrs, request.DBResponseStatusCode(span.DBError.ErrorCode))
-		}
-		if span.DBNamespace != "" {
-			attrs = append(attrs, request.DBNamespace(span.DBNamespace))
-		}
-	case request.EventTypeKafkaServer, request.EventTypeKafkaClient:
-		operation := request.MessagingOperationType(span.Method)
-		attrs = []attribute.KeyValue{
-			request.ServerAddr(request.HostAsServer(span)),
-			request.ServerPort(span.HostPort),
-			semconv.MessagingSystemKafka,
-			semconv.MessagingDestinationName(span.Path),
-			semconv.MessagingClientID(span.Statement),
-			operation,
-		}
-	case request.EventTypeMongoClient:
-		attrs = []attribute.KeyValue{
-			request.ServerAddr(request.HostAsServer(span)),
-			request.ServerPort(span.HostPort),
-			dbSystemMongo,
-		}
-		operation := span.Method
-		if operation != "" {
-			attrs = append(attrs, request.DBOperationName(operation))
-		}
-		if span.Path != "" {
-			attrs = append(attrs, request.DBCollectionName(span.Path))
-		}
-		if span.Status == 1 {
-			attrs = append(attrs, request.DBResponseStatusCode(span.DBError.ErrorCode))
-		}
-		if span.DBNamespace != "" {
-			attrs = append(attrs, request.DBNamespace(span.DBNamespace))
-		}
-	case request.EventTypeManualSpan:
-		attrs = manualSpanAttributes(span)
-	}
-
-	if _, ok := optionalAttrs[attr.SkipSpanMetrics]; ok {
-		attrs = append(attrs, spanMetricsSkip)
-	}
-
-	return attrs
-}
-
-func spanKind(span *request.Span) trace2.SpanKind {
-	switch span.Type {
-	case request.EventTypeHTTP, request.EventTypeGRPC, request.EventTypeRedisServer, request.EventTypeKafkaServer:
-		return trace2.SpanKindServer
-	case request.EventTypeHTTPClient, request.EventTypeGRPCClient, request.EventTypeSQLClient, request.EventTypeRedisClient, request.EventTypeMongoClient:
-		return trace2.SpanKindClient
-	case request.EventTypeKafkaClient:
-		switch span.Method {
-		case request.MessagingPublish:
-			return trace2.SpanKindProducer
-		case request.MessagingProcess:
-			return trace2.SpanKindConsumer
-		}
-	}
-	return trace2.SpanKindInternal
-}
-
-func spanStartTime(t request.Timings) time.Time {
-	realStart := t.RequestStart
-	if t.Start.Before(realStart) {
-		realStart = t.Start
-	}
-	return realStart
-}
-
-func manualSpanAttributes(span *request.Span) []attribute.KeyValue {
-	attrs := []attribute.KeyValue{}
-
-	if span.Statement == "" {
-		return attrs
-	}
-
-	var unmarshaledAttrs []SpanAttr
-	err := json.Unmarshal([]byte(span.Statement), &unmarshaledAttrs)
-	if err != nil {
-		fmt.Println(err)
-		return attrs
-	}
-
-	for i := range unmarshaledAttrs {
-		akv := unmarshaledAttrs[i]
-		key := unix.ByteSliceToString(akv.Key[:])
-		switch akv.Vtype {
-		case uint8(attribute.BOOL):
-			attrs = append(attrs, attribute.Bool(key, akv.Value[0] != 0))
-		case uint8(attribute.INT64):
-			v := binary.LittleEndian.Uint64(akv.Value[:8])
-			attrs = append(attrs, attribute.Int(key, int(v)))
-		case uint8(attribute.FLOAT64):
-			v := math.Float64frombits(binary.LittleEndian.Uint64(akv.Value[:8]))
-			attrs = append(attrs, attribute.Float64(key, v))
-		case uint8(attribute.STRING):
-			attrs = append(attrs, attribute.String(key, unix.ByteSliceToString(akv.Value[:])))
-		}
-	}
-
-	return attrs
 }

--- a/pkg/export/otel/traces_gen.go
+++ b/pkg/export/otel/traces_gen.go
@@ -1,0 +1,480 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/obi/pkg/app/request"
+	"go.opentelemetry.io/obi/pkg/components/svc"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	trace2 "go.opentelemetry.io/otel/trace"
+)
+
+// Must remain public for collectors embedding OBI
+func UserSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr.Name]struct{}, error) {
+	// Get user attributes
+	attribProvider, err := attributes.NewAttrSelector(attributes.GroupTraces, selectorCfg)
+	if err != nil {
+		return nil, err
+	}
+	traceAttrsArr := attribProvider.For(attributes.Traces)
+	traceAttrs := make(map[attr.Name]struct{})
+	for _, a := range traceAttrsArr {
+		traceAttrs[a] = struct{}{}
+	}
+
+	return traceAttrs, err
+}
+
+// Must remain public for collectors embedding OBI
+func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection) map[svc.UID][]TraceSpanAndAttributes {
+	spanGroups := map[svc.UID][]TraceSpanAndAttributes{}
+
+	for i := range spans {
+		span := &spans[i]
+		if span.InternalSignal() {
+			continue
+		}
+		if spanDiscarded(span, is) {
+			continue
+		}
+
+		finalAttrs := traceAttributes(span, traceAttrs)
+
+		spanSampler := func() trace.Sampler {
+			if span.Service.Sampler != nil {
+				return span.Service.Sampler
+			}
+
+			return sampler
+		}
+
+		sr := spanSampler().ShouldSample(trace.SamplingParameters{
+			ParentContext: ctx,
+			Name:          span.TraceName(),
+			TraceID:       span.TraceID,
+			Kind:          spanKind(span),
+			Attributes:    finalAttrs,
+		})
+
+		if sr.Decision == trace.Drop {
+			continue
+		}
+
+		group, ok := spanGroups[span.Service.UID]
+		if !ok {
+			group = []TraceSpanAndAttributes{}
+		}
+		group = append(group, TraceSpanAndAttributes{Span: span, Attributes: finalAttrs})
+		spanGroups[span.Service.UID] = group
+	}
+
+	return spanGroups
+}
+
+// Must remain public for collectors embedding OBI
+func GenerateTracesWithAttributes(
+	cache *expirable2.LRU[svc.UID, []attribute.KeyValue],
+	svc *svc.Attrs,
+	envResourceAttrs []attribute.KeyValue,
+	hostID string,
+	spans []TraceSpanAndAttributes,
+	extraResAttrs ...attribute.KeyValue,
+) ptrace.Traces {
+	traces := ptrace.NewTraces()
+	rs := traces.ResourceSpans().AppendEmpty()
+	resourceAttrs := traceAppResourceAttrs(cache, hostID, svc)
+	resourceAttrs = append(resourceAttrs, envResourceAttrs...)
+	resourceAttrsMap := attrsToMap(resourceAttrs)
+	resourceAttrsMap.PutStr(string(semconv.OTelLibraryNameKey), reporterName)
+	addAttrsToMap(extraResAttrs, resourceAttrsMap)
+	resourceAttrsMap.MoveTo(rs.Resource().Attributes())
+
+	for _, spanWithAttributes := range spans {
+		span := spanWithAttributes.Span
+		attrs := spanWithAttributes.Attributes
+
+		ss := rs.ScopeSpans().AppendEmpty()
+
+		t := span.Timings()
+		start := spanStartTime(t)
+		hasSubSpans := t.Start.After(start)
+
+		traceID := pcommon.TraceID(span.TraceID)
+		spanID := pcommon.SpanID(RandomSpanID())
+		// This should never happen
+		if traceID.IsEmpty() {
+			traceID = pcommon.TraceID(RandomTraceID())
+		}
+
+		if hasSubSpans {
+			createSubSpans(span, spanID, traceID, &ss, t)
+		} else if span.SpanID.IsValid() {
+			spanID = pcommon.SpanID(span.SpanID)
+		}
+
+		// Create a parent span for the whole request session
+		s := ss.Spans().AppendEmpty()
+		s.SetName(span.TraceName())
+		s.SetKind(ptrace.SpanKind(spanKind(span)))
+		s.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+
+		// Set trace and span IDs
+		s.SetSpanID(spanID)
+		s.SetTraceID(traceID)
+		if span.ParentSpanID.IsValid() {
+			s.SetParentSpanID(pcommon.SpanID(span.ParentSpanID))
+		}
+
+		// Set span attributes
+		m := attrsToMap(attrs)
+		m.MoveTo(s.Attributes())
+
+		// Set status code
+		statusCode := codeToStatusCode(request.SpanStatusCode(span))
+		s.Status().SetCode(statusCode)
+		statusMessage := request.SpanStatusMessage(span)
+		if statusMessage != "" {
+			s.Status().SetMessage(statusMessage)
+		}
+		s.SetEndTimestamp(pcommon.NewTimestampFromTime(t.End))
+	}
+	return traces
+}
+
+func spanDiscarded(span *request.Span, is instrumentations.InstrumentationSelection) bool {
+	return request.IgnoreTraces(span) || span.Service.ExportsOTelTraces() || !acceptSpan(is, span)
+}
+
+// createSubSpans creates the internal spans for a request.Span
+func createSubSpans(span *request.Span, parentSpanID pcommon.SpanID, traceID pcommon.TraceID, ss *ptrace.ScopeSpans, t request.Timings) {
+	// Create a child span showing the queue time
+	spQ := ss.Spans().AppendEmpty()
+	spQ.SetName("in queue")
+	spQ.SetStartTimestamp(pcommon.NewTimestampFromTime(t.RequestStart))
+	spQ.SetKind(ptrace.SpanKindInternal)
+	spQ.SetEndTimestamp(pcommon.NewTimestampFromTime(t.Start))
+	spQ.SetTraceID(traceID)
+	spQ.SetSpanID(pcommon.SpanID(RandomSpanID()))
+	spQ.SetParentSpanID(parentSpanID)
+
+	// Create a child span showing the processing time
+	spP := ss.Spans().AppendEmpty()
+	spP.SetName("processing")
+	spP.SetStartTimestamp(pcommon.NewTimestampFromTime(t.Start))
+	spP.SetKind(ptrace.SpanKindInternal)
+	spP.SetEndTimestamp(pcommon.NewTimestampFromTime(t.End))
+	spP.SetTraceID(traceID)
+	if span.SpanID.IsValid() {
+		spP.SetSpanID(pcommon.SpanID(span.SpanID))
+	} else {
+		spP.SetSpanID(pcommon.SpanID(RandomSpanID()))
+	}
+	spP.SetParentSpanID(parentSpanID)
+}
+
+var emptyUID = svc.UID{}
+
+func traceAppResourceAttrs(cache *expirable2.LRU[svc.UID, []attribute.KeyValue], hostID string, service *svc.Attrs) []attribute.KeyValue {
+	// TODO: remove?
+	if service.UID == emptyUID {
+		return otelcfg.GetAppResourceAttrs(hostID, service)
+	}
+
+	attrs, ok := cache.Get(service.UID)
+	if ok {
+		return attrs
+	}
+	attrs = otelcfg.GetAppResourceAttrs(hostID, service)
+	cache.Add(service.UID, attrs)
+
+	return attrs
+}
+
+// attrsToMap converts a slice of attribute.KeyValue to a pcommon.Map
+func attrsToMap(attrs []attribute.KeyValue) pcommon.Map {
+	m := pcommon.NewMap()
+	addAttrsToMap(attrs, m)
+	return m
+}
+
+func addAttrsToMap(attrs []attribute.KeyValue, dst pcommon.Map) {
+	dst.EnsureCapacity(dst.Len() + len(attrs))
+	for _, attr := range attrs {
+		switch v := attr.Value.AsInterface().(type) {
+		case string:
+			dst.PutStr(string(attr.Key), v)
+		case int64:
+			dst.PutInt(string(attr.Key), v)
+		case float64:
+			dst.PutDouble(string(attr.Key), v)
+		case bool:
+			dst.PutBool(string(attr.Key), v)
+		}
+	}
+}
+
+// codeToStatusCode converts a codes.Code to a ptrace.StatusCode
+func codeToStatusCode(code string) ptrace.StatusCode {
+	switch code {
+	case request.StatusCodeUnset:
+		return ptrace.StatusCodeUnset
+	case request.StatusCodeError:
+		return ptrace.StatusCodeError
+	case request.StatusCodeOk:
+		return ptrace.StatusCodeOk
+	}
+	return ptrace.StatusCodeUnset
+}
+
+func convertHeaders(headers map[string]string) map[string]configopaque.String {
+	opaqueHeaders := make(map[string]configopaque.String)
+	for key, value := range headers {
+		opaqueHeaders[key] = configopaque.String(value)
+	}
+	return opaqueHeaders
+}
+
+func acceptSpan(is instrumentations.InstrumentationSelection, span *request.Span) bool {
+	switch span.Type {
+	case request.EventTypeHTTP, request.EventTypeHTTPClient:
+		return is.HTTPEnabled()
+	case request.EventTypeGRPC, request.EventTypeGRPCClient:
+		return is.GRPCEnabled()
+	case request.EventTypeSQLClient:
+		return is.SQLEnabled()
+	case request.EventTypeRedisClient, request.EventTypeRedisServer:
+		return is.RedisEnabled()
+	case request.EventTypeKafkaClient, request.EventTypeKafkaServer:
+		return is.KafkaEnabled()
+	case request.EventTypeMongoClient:
+		return is.MongoEnabled()
+	case request.EventTypeManualSpan:
+		return true
+	}
+
+	return false
+}
+
+// TODO use semconv.DBSystemRedis when we update to OTEL semantic conventions library 1.30
+var (
+	dbSystemRedis   = attribute.String(string(attr.DBSystemName), semconv.DBSystemRedis.Value.AsString())
+	dbSystemMongo   = attribute.String(string(attr.DBSystemName), semconv.DBSystemMongoDB.Value.AsString())
+	spanMetricsSkip = attribute.Bool(string(attr.SkipSpanMetrics), true)
+)
+
+//nolint:cyclop
+func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
+	var attrs []attribute.KeyValue
+
+	switch span.Type {
+	case request.EventTypeHTTP:
+		attrs = []attribute.KeyValue{
+			request.HTTPRequestMethod(span.Method),
+			request.HTTPResponseStatusCode(span.Status),
+			request.HTTPUrlPath(span.Path),
+			request.ClientAddr(request.PeerAsClient(span)),
+			request.ServerAddr(request.SpanHost(span)),
+			request.ServerPort(span.HostPort),
+			request.HTTPRequestBodySize(int(span.RequestBodyLength())),
+			request.HTTPResponseBodySize(span.ResponseBodyLength()),
+		}
+		if span.Route != "" {
+			attrs = append(attrs, semconv.HTTPRoute(span.Route))
+		}
+	case request.EventTypeGRPC:
+		attrs = []attribute.KeyValue{
+			semconv.RPCMethod(span.Path),
+			semconv.RPCSystemGRPC,
+			semconv.RPCGRPCStatusCodeKey.Int(span.Status),
+			request.ClientAddr(request.PeerAsClient(span)),
+			request.ServerAddr(request.SpanHost(span)),
+			request.ServerPort(span.HostPort),
+		}
+	case request.EventTypeHTTPClient:
+		host := request.HTTPClientHost(span)
+		scheme := request.HTTPScheme(span)
+		url := span.Path
+		if span.HasOriginalHost() {
+			url = request.URLFull(scheme, host, span.Path)
+		}
+
+		attrs = []attribute.KeyValue{
+			request.HTTPRequestMethod(span.Method),
+			request.HTTPResponseStatusCode(span.Status),
+			request.HTTPUrlFull(url),
+			semconv.HTTPScheme(scheme),
+			request.ServerAddr(host),
+			request.ServerPort(span.HostPort),
+			request.HTTPRequestBodySize(int(span.RequestBodyLength())),
+			request.HTTPResponseBodySize(span.ResponseBodyLength()),
+		}
+	case request.EventTypeGRPCClient:
+		attrs = []attribute.KeyValue{
+			semconv.RPCMethod(span.Path),
+			semconv.RPCSystemGRPC,
+			semconv.RPCGRPCStatusCodeKey.Int(span.Status),
+			request.ServerAddr(request.HostAsServer(span)),
+			request.ServerPort(span.HostPort),
+		}
+	case request.EventTypeSQLClient:
+		attrs = []attribute.KeyValue{
+			request.ServerAddr(request.HostAsServer(span)),
+			request.ServerPort(span.HostPort),
+			span.DBSystemName(), // We can distinguish in the future for MySQL, Postgres etc
+		}
+		if _, ok := optionalAttrs[attr.DBQueryText]; ok {
+			attrs = append(attrs, request.DBQueryText(span.Statement))
+		}
+		operation := span.Method
+		if operation != "" {
+			attrs = append(attrs, request.DBOperationName(operation))
+			table := span.Path
+			if table != "" {
+				attrs = append(attrs, request.DBCollectionName(table))
+			}
+		}
+		if span.Status == 1 {
+			attrs = append(attrs, request.DBResponseStatusCode(strconv.Itoa(int(span.SQLError.Code))))
+			attrs = append(attrs, request.ErrorType(span.SQLError.SQLState))
+		}
+	case request.EventTypeRedisServer, request.EventTypeRedisClient:
+		attrs = []attribute.KeyValue{
+			request.ServerAddr(request.HostAsServer(span)),
+			request.ServerPort(span.HostPort),
+			dbSystemRedis,
+		}
+		operation := span.Method
+		if operation != "" {
+			attrs = append(attrs, request.DBOperationName(operation))
+			if _, ok := optionalAttrs[attr.DBQueryText]; ok {
+				query := span.Path
+				if query != "" {
+					attrs = append(attrs, request.DBQueryText(query))
+				}
+			}
+		}
+		if span.Status == 1 {
+			attrs = append(attrs, request.DBResponseStatusCode(span.DBError.ErrorCode))
+		}
+		if span.DBNamespace != "" {
+			attrs = append(attrs, request.DBNamespace(span.DBNamespace))
+		}
+	case request.EventTypeKafkaServer, request.EventTypeKafkaClient:
+		operation := request.MessagingOperationType(span.Method)
+		attrs = []attribute.KeyValue{
+			request.ServerAddr(request.HostAsServer(span)),
+			request.ServerPort(span.HostPort),
+			semconv.MessagingSystemKafka,
+			semconv.MessagingDestinationName(span.Path),
+			semconv.MessagingClientID(span.Statement),
+			operation,
+		}
+	case request.EventTypeMongoClient:
+		attrs = []attribute.KeyValue{
+			request.ServerAddr(request.HostAsServer(span)),
+			request.ServerPort(span.HostPort),
+			dbSystemMongo,
+		}
+		operation := span.Method
+		if operation != "" {
+			attrs = append(attrs, request.DBOperationName(operation))
+		}
+		if span.Path != "" {
+			attrs = append(attrs, request.DBCollectionName(span.Path))
+		}
+		if span.Status == 1 {
+			attrs = append(attrs, request.DBResponseStatusCode(span.DBError.ErrorCode))
+		}
+		if span.DBNamespace != "" {
+			attrs = append(attrs, request.DBNamespace(span.DBNamespace))
+		}
+	case request.EventTypeManualSpan:
+		attrs = manualSpanAttributes(span)
+	}
+
+	if _, ok := optionalAttrs[attr.SkipSpanMetrics]; ok {
+		attrs = append(attrs, spanMetricsSkip)
+	}
+
+	return attrs
+}
+
+func spanKind(span *request.Span) trace2.SpanKind {
+	switch span.Type {
+	case request.EventTypeHTTP, request.EventTypeGRPC, request.EventTypeRedisServer, request.EventTypeKafkaServer:
+		return trace2.SpanKindServer
+	case request.EventTypeHTTPClient, request.EventTypeGRPCClient, request.EventTypeSQLClient, request.EventTypeRedisClient, request.EventTypeMongoClient:
+		return trace2.SpanKindClient
+	case request.EventTypeKafkaClient:
+		switch span.Method {
+		case request.MessagingPublish:
+			return trace2.SpanKindProducer
+		case request.MessagingProcess:
+			return trace2.SpanKindConsumer
+		}
+	}
+	return trace2.SpanKindInternal
+}
+
+func spanStartTime(t request.Timings) time.Time {
+	realStart := t.RequestStart
+	if t.Start.Before(realStart) {
+		realStart = t.Start
+	}
+	return realStart
+}
+
+func manualSpanAttributes(span *request.Span) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{}
+
+	if span.Statement == "" {
+		return attrs
+	}
+
+	var unmarshaledAttrs []SpanAttr
+	err := json.Unmarshal([]byte(span.Statement), &unmarshaledAttrs)
+	if err != nil {
+		fmt.Println(err)
+		return attrs
+	}
+
+	for i := range unmarshaledAttrs {
+		akv := unmarshaledAttrs[i]
+		key := unix.ByteSliceToString(akv.Key[:])
+		switch akv.Vtype {
+		case uint8(attribute.BOOL):
+			attrs = append(attrs, attribute.Bool(key, akv.Value[0] != 0))
+		case uint8(attribute.INT64):
+			v := binary.LittleEndian.Uint64(akv.Value[:8])
+			attrs = append(attrs, attribute.Int(key, int(v)))
+		case uint8(attribute.FLOAT64):
+			v := math.Float64frombits(binary.LittleEndian.Uint64(akv.Value[:8]))
+			attrs = append(attrs, attribute.Float64(key, v))
+		case uint8(attribute.STRING):
+			attrs = append(attrs, attribute.String(key, unix.ByteSliceToString(akv.Value[:])))
+		}
+	}
+
+	return attrs
+}

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -31,7 +31,9 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/idgen"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 
@@ -65,7 +67,7 @@ func BenchmarkGenerateTraces(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		traces := GenerateTracesWithAttributes(cache, &span.Service, attrs, "host-id", group)
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, attrs, "host-id", group, reporterName)
 
 		if traces.ResourceSpans().Len() == 0 {
 			b.Fatal("Generated traces is empty")
@@ -73,9 +75,9 @@ func BenchmarkGenerateTraces(b *testing.B) {
 	}
 }
 
-func groupFromSpanAndAttributes(span *request.Span, attrs []attribute.KeyValue) []TraceSpanAndAttributes {
-	groups := []TraceSpanAndAttributes{}
-	groups = append(groups, TraceSpanAndAttributes{Span: span, Attributes: attrs})
+func groupFromSpanAndAttributes(span *request.Span, attrs []attribute.KeyValue) []tracesgen.TraceSpanAndAttributes {
+	groups := []tracesgen.TraceSpanAndAttributes{}
+	groups = append(groups, tracesgen.TraceSpanAndAttributes{Span: span, Attributes: attrs})
 	return groups
 }
 
@@ -99,7 +101,7 @@ func TestGenerateTraces(t *testing.T) {
 			Service:      svc.Attrs{UID: svc.UID{Name: "1"}},
 		}
 
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -144,7 +146,7 @@ func TestGenerateTraces(t *testing.T) {
 			SpanID:       spanID,
 			TraceID:      traceID,
 		}
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -180,7 +182,7 @@ func TestGenerateTraces(t *testing.T) {
 			Route:        "/test",
 			Status:       200,
 		}
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -217,7 +219,7 @@ func TestGenerateTraces(t *testing.T) {
 			SpanID:       spanID,
 			TraceID:      traceID,
 		}
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -243,7 +245,7 @@ func TestGenerateTraces(t *testing.T) {
 			TraceID:      traceID,
 		}
 
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -263,7 +265,7 @@ func TestGenerateTraces(t *testing.T) {
 			Method:       "GET",
 			Route:        "/test",
 		}
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -278,8 +280,8 @@ func TestGenerateTraces(t *testing.T) {
 func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("test SQL trace generation, no statement", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password FROM credentials WHERE username=\"bill\"")
-		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -300,8 +302,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test SQL trace generation, unknown attribute", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password, name FROM credentials WHERE username=\"bill\"")
-		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{"db.operation.name": {}})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -322,8 +324,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test SQL trace generation, unknown attribute", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password FROM credentials WHERE username=\"bill\"")
-		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{attr.DBQueryText: {}})
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{attr.DBQueryText: {}})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -344,8 +346,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test SQL trace generation, error", func(t *testing.T) {
 		span := makeSQLRequestErroredSpan("SELECT * FROM obi.nonexisting")
-		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{attr.DBQueryText: {}})
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{attr.DBQueryText: {}})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -372,8 +374,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test Kafka trace generation", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeKafkaClient, Method: "process", Path: "important-topic", Statement: "test"}
-		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -391,8 +393,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 
 	t.Run("test Mongo trace generation", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeMongoClient, Method: "insert", Path: "mycollection", DBNamespace: "mydatabase", Status: 0}
-		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{"db.operation.name": {}})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -414,8 +416,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	})
 	t.Run("test Mongo trace generation with error", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeMongoClient, Method: "insert", Path: "mycollection", DBNamespace: "mydatabase", Status: 1, DBError: request.DBError{ErrorCode: "1", Description: "Internal MongoDB error"}}
-		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
-		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{"db.operation.name": {}})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -442,8 +444,8 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "deployment.environment=productions,source.upstream=beyla")
 		span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Route: "/test", Status: 200}
 
-		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
-		traces := GenerateTracesWithAttributes(cache, &span.Service, otelcfg.ResourceAttrsFromEnv(&span.Service), "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, otelcfg.ResourceAttrsFromEnv(&span.Service), "host-id", groupFromSpanAndAttributes(&span, tAttrs), reporterName)
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		rs := traces.ResourceSpans().At(0)
@@ -454,10 +456,11 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("override resource attributes", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Route: "/test", Status: 200}
 
-		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
-		traces := GenerateTracesWithAttributes(cache, &span.Service,
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service,
 			otelcfg.ResourceAttrsFromEnv(&span.Service), "host-id",
 			groupFromSpanAndAttributes(&span, tAttrs),
+			reporterName,
 			attribute.String("deployment.environment", "productions"),
 			attribute.String("source.upstream", "OBI"),
 			semconv.OTelLibraryName("my-reporter"),
@@ -484,7 +487,7 @@ func TestTraceSampling(t *testing.T) {
 			Method:       "GET",
 			Route:        "/test" + strconv.Itoa(i),
 			Status:       200,
-			TraceID:      RandomTraceID(),
+			TraceID:      idgen.RandomTraceID(),
 			Service:      svc.Attrs{UID: svc.UID{Name: strconv.Itoa(i)}},
 		}
 		spans = append(spans, span)
@@ -557,7 +560,7 @@ func TestTraceSkipSpanMetrics(t *testing.T) {
 			Route:        "/test" + strconv.Itoa(i),
 			Status:       200,
 			Service:      svc.Attrs{UID: svc.UID{Name: strconv.Itoa(i)}},
-			TraceID:      RandomTraceID(),
+			TraceID:      idgen.RandomTraceID(),
 		}
 		spans = append(spans, span)
 	}
@@ -644,7 +647,7 @@ func TestAttrsToMap(t *testing.T) {
 		expected.PutStr("key1", "value1")
 		expected.PutStr("key2", "value2")
 
-		result := attrsToMap(attrs)
+		result := tracesgen.AttrsToMap(attrs)
 		assert.Equal(t, expected, result)
 	})
 
@@ -657,7 +660,7 @@ func TestAttrsToMap(t *testing.T) {
 		expected.PutInt("key1", 10)
 		expected.PutInt("key2", 20)
 
-		result := attrsToMap(attrs)
+		result := tracesgen.AttrsToMap(attrs)
 		assert.Equal(t, expected, result)
 	})
 
@@ -670,7 +673,7 @@ func TestAttrsToMap(t *testing.T) {
 		expected.PutDouble("key1", 3.14)
 		expected.PutDouble("key2", 2.718)
 
-		result := attrsToMap(attrs)
+		result := tracesgen.AttrsToMap(attrs)
 		assert.Equal(t, expected, result)
 	})
 
@@ -683,7 +686,7 @@ func TestAttrsToMap(t *testing.T) {
 		expected.PutBool("key1", true)
 		expected.PutBool("key2", false)
 
-		result := attrsToMap(attrs)
+		result := tracesgen.AttrsToMap(attrs)
 		assert.Equal(t, expected, result)
 	})
 }
@@ -693,7 +696,7 @@ func TestCodeToStatusCode(t *testing.T) {
 		code := request.StatusCodeUnset
 		expected := ptrace.StatusCodeUnset
 
-		result := codeToStatusCode(code)
+		result := tracesgen.CodeToStatusCode(code)
 		assert.Equal(t, expected, result)
 	})
 
@@ -701,7 +704,7 @@ func TestCodeToStatusCode(t *testing.T) {
 		code := request.StatusCodeError
 		expected := ptrace.StatusCodeError
 
-		result := codeToStatusCode(code)
+		result := tracesgen.CodeToStatusCode(code)
 		assert.Equal(t, expected, result)
 	})
 
@@ -709,7 +712,7 @@ func TestCodeToStatusCode(t *testing.T) {
 		code := request.StatusCodeOk
 		expected := ptrace.StatusCodeOk
 
-		result := codeToStatusCode(code)
+		result := tracesgen.CodeToStatusCode(code)
 		assert.Equal(t, expected, result)
 	})
 }
@@ -851,8 +854,8 @@ func TestTracesAttrReuse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			attr1 := traceAppResourceAttrs(cache, "123", &tt.span.Service)
-			attr2 := traceAppResourceAttrs(cache, "123", &tt.span.Service)
+			attr1 := tracesgen.TraceAppResourceAttrs(cache, "123", &tt.span.Service)
+			attr2 := tracesgen.TraceAppResourceAttrs(cache, "123", &tt.span.Service)
 			assert.Equal(t, tt.same, &attr1[0] == &attr2[0], tt.name)
 		})
 	}
@@ -1129,7 +1132,7 @@ func TestHostPeerAttributes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			attrs := traceAttributes(&tt.span, nil)
+			attrs := tracesgen.TraceAttributesSelector(&tt.span, nil)
 			if tt.server != "" {
 				var found attribute.KeyValue
 				for _, a := range attrs {
@@ -1166,7 +1169,7 @@ func TestTraceGrouping(t *testing.T) {
 			Method:       "GET",
 			Route:        "/test" + strconv.Itoa(i),
 			Status:       200,
-			TraceID:      RandomTraceID(),
+			TraceID:      idgen.RandomTraceID(),
 			Service:      svc.Attrs{UID: svc.UID{Instance: "1"}}, // Same service for all spans
 		}
 		spans = append(spans, span)
@@ -1257,16 +1260,16 @@ func makeTracesTestReceiverWithSpanMetrics(instr []string) *tracesOTELReceiver {
 
 func generateTracesForSpans(t *testing.T, tr *tracesOTELReceiver, spans []request.Span) []ptrace.Traces {
 	res := []ptrace.Traces{}
-	traceAttrs, err := UserSelectedAttributes(tr.selectorCfg)
+	traceAttrs, err := tracesgen.UserSelectedAttributes(tr.selectorCfg)
 	require.NoError(t, err)
 	for i := range spans {
 		span := &spans[i]
-		if spanDiscarded(span, tr.is) {
+		if tracesgen.SpanDiscarded(span, tr.is) {
 			continue
 		}
-		tAttrs := traceAttributes(span, traceAttrs)
+		tAttrs := tracesgen.TraceAttributesSelector(span, traceAttrs)
 
-		res = append(res, GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, tAttrs)))
+		res = append(res, tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, tAttrs), reporterName))
 	}
 
 	return res

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -65,7 +65,7 @@ func BenchmarkGenerateTraces(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		traces := generateTracesWithAttributes(cache, &span.Service, attrs, "host-id", group)
+		traces := GenerateTracesWithAttributes(cache, &span.Service, attrs, "host-id", group)
 
 		if traces.ResourceSpans().Len() == 0 {
 			b.Fatal("Generated traces is empty")
@@ -99,7 +99,7 @@ func TestGenerateTraces(t *testing.T) {
 			Service:      svc.Attrs{UID: svc.UID{Name: "1"}},
 		}
 
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -144,7 +144,7 @@ func TestGenerateTraces(t *testing.T) {
 			SpanID:       spanID,
 			TraceID:      traceID,
 		}
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -180,7 +180,7 @@ func TestGenerateTraces(t *testing.T) {
 			Route:        "/test",
 			Status:       200,
 		}
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -217,7 +217,7 @@ func TestGenerateTraces(t *testing.T) {
 			SpanID:       spanID,
 			TraceID:      traceID,
 		}
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -243,7 +243,7 @@ func TestGenerateTraces(t *testing.T) {
 			TraceID:      traceID,
 		}
 
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -263,7 +263,7 @@ func TestGenerateTraces(t *testing.T) {
 			Method:       "GET",
 			Route:        "/test",
 		}
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, []attribute.KeyValue{}))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -279,7 +279,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("test SQL trace generation, no statement", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password FROM credentials WHERE username=\"bill\"")
 		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -301,7 +301,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("test SQL trace generation, unknown attribute", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password, name FROM credentials WHERE username=\"bill\"")
 		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -323,7 +323,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("test SQL trace generation, unknown attribute", func(t *testing.T) {
 		span := makeSQLRequestSpan("SELECT password FROM credentials WHERE username=\"bill\"")
 		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{attr.DBQueryText: {}})
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -345,7 +345,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("test SQL trace generation, error", func(t *testing.T) {
 		span := makeSQLRequestErroredSpan("SELECT * FROM obi.nonexisting")
 		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{attr.DBQueryText: {}})
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -373,7 +373,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("test Kafka trace generation", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeKafkaClient, Method: "process", Path: "important-topic", Statement: "test"}
 		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -392,7 +392,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("test Mongo trace generation", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeMongoClient, Method: "insert", Path: "mycollection", DBNamespace: "mydatabase", Status: 0}
 		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -415,7 +415,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 	t.Run("test Mongo trace generation with error", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeMongoClient, Method: "insert", Path: "mycollection", DBNamespace: "mydatabase", Status: 1, DBError: request.DBError{ErrorCode: "1", Description: "Internal MongoDB error"}}
 		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{"db.operation.name": {}})
-		traces := generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
@@ -443,7 +443,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Route: "/test", Status: 200}
 
 		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
-		traces := generateTracesWithAttributes(cache, &span.Service, otelcfg.ResourceAttrsFromEnv(&span.Service), "host-id", groupFromSpanAndAttributes(&span, tAttrs))
+		traces := GenerateTracesWithAttributes(cache, &span.Service, otelcfg.ResourceAttrsFromEnv(&span.Service), "host-id", groupFromSpanAndAttributes(&span, tAttrs))
 
 		assert.Equal(t, 1, traces.ResourceSpans().Len())
 		rs := traces.ResourceSpans().At(0)
@@ -455,7 +455,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		span := request.Span{Type: request.EventTypeHTTP, Method: "GET", Route: "/test", Status: 200}
 
 		tAttrs := traceAttributes(&span, map[attr.Name]struct{}{})
-		traces := generateTracesWithAttributes(cache, &span.Service,
+		traces := GenerateTracesWithAttributes(cache, &span.Service,
 			otelcfg.ResourceAttrsFromEnv(&span.Service), "host-id",
 			groupFromSpanAndAttributes(&span, tAttrs),
 			attribute.String("deployment.environment", "productions"),
@@ -1257,7 +1257,7 @@ func makeTracesTestReceiverWithSpanMetrics(instr []string) *tracesOTELReceiver {
 
 func generateTracesForSpans(t *testing.T, tr *tracesOTELReceiver, spans []request.Span) []ptrace.Traces {
 	res := []ptrace.Traces{}
-	traceAttrs, err := userSelectedAttributes(tr.selectorCfg)
+	traceAttrs, err := UserSelectedAttributes(tr.selectorCfg)
 	require.NoError(t, err)
 	for i := range spans {
 		span := &spans[i]
@@ -1266,7 +1266,7 @@ func generateTracesForSpans(t *testing.T, tr *tracesOTELReceiver, spans []reques
 		}
 		tAttrs := traceAttributes(span, traceAttrs)
 
-		res = append(res, generateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, tAttrs)))
+		res = append(res, GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, "host-id", groupFromSpanAndAttributes(span, tAttrs)))
 	}
 
 	return res

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -44,7 +44,7 @@ type SpanAttr struct {
 	Value     [128]uint8
 }
 
-// Must remain public for collectors embedding OBI
+// UserSelectedAttributes must remain public for collectors embedding OBI
 func UserSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr.Name]struct{}, error) {
 	// Get user attributes
 	attribProvider, err := attributes.NewAttrSelector(attributes.GroupTraces, selectorCfg)
@@ -60,7 +60,7 @@ func UserSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr.Na
 	return traceAttrs, err
 }
 
-// Must remain public for collectors embedding OBI
+// GroupSpans must remain public for collectors embedding OBI
 func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection) map[svc.UID][]TraceSpanAndAttributes {
 	spanGroups := map[svc.UID][]TraceSpanAndAttributes{}
 
@@ -106,7 +106,7 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 	return spanGroups
 }
 
-// Must remain public for collectors embedding OBI
+// GenerateTracesWithAttributes must remain public for collectors embedding OBI
 func GenerateTracesWithAttributes(
 	cache *expirable2.LRU[svc.UID, []attribute.KeyValue],
 	svc *svc.Attrs,

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otel
+package tracesgen
 
 import (
 	"context"
@@ -12,23 +12,37 @@ import (
 	"strconv"
 	"time"
 
+	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
 	"golang.org/x/sys/unix"
 
-	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
-	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	trace2 "go.opentelemetry.io/otel/trace"
+
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/svc"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/idgen"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
-	trace2 "go.opentelemetry.io/otel/trace"
 )
+
+type TraceSpanAndAttributes struct {
+	Span       *request.Span
+	Attributes []attribute.KeyValue
+}
+
+type SpanAttr struct {
+	ValLength uint16
+	Vtype     uint8
+	Reserved  uint8
+	Key       [32]uint8
+	Value     [128]uint8
+}
 
 // Must remain public for collectors embedding OBI
 func UserSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr.Name]struct{}, error) {
@@ -55,11 +69,11 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 		if span.InternalSignal() {
 			continue
 		}
-		if spanDiscarded(span, is) {
+		if SpanDiscarded(span, is) {
 			continue
 		}
 
-		finalAttrs := traceAttributes(span, traceAttrs)
+		finalAttrs := TraceAttributesSelector(span, traceAttrs)
 
 		spanSampler := func() trace.Sampler {
 			if span.Service.Sampler != nil {
@@ -99,13 +113,14 @@ func GenerateTracesWithAttributes(
 	envResourceAttrs []attribute.KeyValue,
 	hostID string,
 	spans []TraceSpanAndAttributes,
+	reporterName string,
 	extraResAttrs ...attribute.KeyValue,
 ) ptrace.Traces {
 	traces := ptrace.NewTraces()
 	rs := traces.ResourceSpans().AppendEmpty()
-	resourceAttrs := traceAppResourceAttrs(cache, hostID, svc)
+	resourceAttrs := TraceAppResourceAttrs(cache, hostID, svc)
 	resourceAttrs = append(resourceAttrs, envResourceAttrs...)
-	resourceAttrsMap := attrsToMap(resourceAttrs)
+	resourceAttrsMap := AttrsToMap(resourceAttrs)
 	resourceAttrsMap.PutStr(string(semconv.OTelLibraryNameKey), reporterName)
 	addAttrsToMap(extraResAttrs, resourceAttrsMap)
 	resourceAttrsMap.MoveTo(rs.Resource().Attributes())
@@ -121,10 +136,10 @@ func GenerateTracesWithAttributes(
 		hasSubSpans := t.Start.After(start)
 
 		traceID := pcommon.TraceID(span.TraceID)
-		spanID := pcommon.SpanID(RandomSpanID())
+		spanID := pcommon.SpanID(idgen.RandomSpanID())
 		// This should never happen
 		if traceID.IsEmpty() {
-			traceID = pcommon.TraceID(RandomTraceID())
+			traceID = pcommon.TraceID(idgen.RandomTraceID())
 		}
 
 		if hasSubSpans {
@@ -147,11 +162,11 @@ func GenerateTracesWithAttributes(
 		}
 
 		// Set span attributes
-		m := attrsToMap(attrs)
+		m := AttrsToMap(attrs)
 		m.MoveTo(s.Attributes())
 
 		// Set status code
-		statusCode := codeToStatusCode(request.SpanStatusCode(span))
+		statusCode := CodeToStatusCode(request.SpanStatusCode(span))
 		s.Status().SetCode(statusCode)
 		statusMessage := request.SpanStatusMessage(span)
 		if statusMessage != "" {
@@ -162,7 +177,7 @@ func GenerateTracesWithAttributes(
 	return traces
 }
 
-func spanDiscarded(span *request.Span, is instrumentations.InstrumentationSelection) bool {
+func SpanDiscarded(span *request.Span, is instrumentations.InstrumentationSelection) bool {
 	return request.IgnoreTraces(span) || span.Service.ExportsOTelTraces() || !acceptSpan(is, span)
 }
 
@@ -175,7 +190,7 @@ func createSubSpans(span *request.Span, parentSpanID pcommon.SpanID, traceID pco
 	spQ.SetKind(ptrace.SpanKindInternal)
 	spQ.SetEndTimestamp(pcommon.NewTimestampFromTime(t.Start))
 	spQ.SetTraceID(traceID)
-	spQ.SetSpanID(pcommon.SpanID(RandomSpanID()))
+	spQ.SetSpanID(pcommon.SpanID(idgen.RandomSpanID()))
 	spQ.SetParentSpanID(parentSpanID)
 
 	// Create a child span showing the processing time
@@ -188,14 +203,14 @@ func createSubSpans(span *request.Span, parentSpanID pcommon.SpanID, traceID pco
 	if span.SpanID.IsValid() {
 		spP.SetSpanID(pcommon.SpanID(span.SpanID))
 	} else {
-		spP.SetSpanID(pcommon.SpanID(RandomSpanID()))
+		spP.SetSpanID(pcommon.SpanID(idgen.RandomSpanID()))
 	}
 	spP.SetParentSpanID(parentSpanID)
 }
 
 var emptyUID = svc.UID{}
 
-func traceAppResourceAttrs(cache *expirable2.LRU[svc.UID, []attribute.KeyValue], hostID string, service *svc.Attrs) []attribute.KeyValue {
+func TraceAppResourceAttrs(cache *expirable2.LRU[svc.UID, []attribute.KeyValue], hostID string, service *svc.Attrs) []attribute.KeyValue {
 	// TODO: remove?
 	if service.UID == emptyUID {
 		return otelcfg.GetAppResourceAttrs(hostID, service)
@@ -211,8 +226,8 @@ func traceAppResourceAttrs(cache *expirable2.LRU[svc.UID, []attribute.KeyValue],
 	return attrs
 }
 
-// attrsToMap converts a slice of attribute.KeyValue to a pcommon.Map
-func attrsToMap(attrs []attribute.KeyValue) pcommon.Map {
+// AttrsToMap converts a slice of attribute.KeyValue to a pcommon.Map
+func AttrsToMap(attrs []attribute.KeyValue) pcommon.Map {
 	m := pcommon.NewMap()
 	addAttrsToMap(attrs, m)
 	return m
@@ -234,8 +249,8 @@ func addAttrsToMap(attrs []attribute.KeyValue, dst pcommon.Map) {
 	}
 }
 
-// codeToStatusCode converts a codes.Code to a ptrace.StatusCode
-func codeToStatusCode(code string) ptrace.StatusCode {
+// CodeToStatusCode converts a codes.Code to a ptrace.StatusCode
+func CodeToStatusCode(code string) ptrace.StatusCode {
 	switch code {
 	case request.StatusCodeUnset:
 		return ptrace.StatusCodeUnset
@@ -245,14 +260,6 @@ func codeToStatusCode(code string) ptrace.StatusCode {
 		return ptrace.StatusCodeOk
 	}
 	return ptrace.StatusCodeUnset
-}
-
-func convertHeaders(headers map[string]string) map[string]configopaque.String {
-	opaqueHeaders := make(map[string]configopaque.String)
-	for key, value := range headers {
-		opaqueHeaders[key] = configopaque.String(value)
-	}
-	return opaqueHeaders
 }
 
 func acceptSpan(is instrumentations.InstrumentationSelection, span *request.Span) bool {
@@ -284,7 +291,7 @@ var (
 )
 
 //nolint:cyclop
-func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
+func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
 
 	switch span.Type {


### PR DESCRIPTION
Recent configuration refactoring made certain functions in the traces exporter private which breaks embedding OBI into collectors. I've now split the code that's reusable for embedding into a separate package to avoid this happening again.