### PR TITLE
Fix env var substitution for OpenTelemetry Operator

### DIFF
--- a/pkg/config/env_replacer.go
+++ b/pkg/config/env_replacer.go
@@ -9,7 +9,7 @@ import (
 	"regexp"
 )
 
-var envVarRegex = regexp.MustCompile(`\$?\${(?:env:)?([a-zA-Z_][a-zA-Z0-9_]*)(?::-([^}]*))?}`)
+var envVarRegex = regexp.MustCompile(`\$?\$[\{\(](?:env:)?([a-zA-Z_][a-zA-Z0-9_]*)(?::-([^}\)]*))?[\}\)]`)
 
 func ReplaceEnv(content []byte) []byte {
 	// Process normal environment variable substitutions

--- a/pkg/config/env_replacer_test.go
+++ b/pkg/config/env_replacer_test.go
@@ -110,6 +110,21 @@ config:
 			input:    []byte("key: value\n"),
 			expected: []byte("key: value\n"),
 		},
+		{
+			name:     "YAML with Kubernetes $(VAR) syntax",
+			input:    []byte("key: $(TEST_VAR)\n"),
+			expected: []byte("key: test_value\n"),
+		},
+		{
+			name:     "YAML with Kubernetes $(VAR) syntax with default",
+			input:    []byte("key: $(NON_EXISTENT_VAR:-default)\n"),
+			expected: []byte("key: default\n"),
+		},
+		{
+			name:     "YAML with mixed ${VAR} and $(VAR) syntax",
+			input:    []byte("key1: ${TEST_VAR}\nkey2: $(ANOTHER_VAR)\n"),
+			expected: []byte("key1: test_value\nkey2: another_value\n"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -29,6 +29,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/buildinfo"
 	"go.opentelemetry.io/obi/pkg/components/svc"
+	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/expire"
 )
@@ -515,7 +516,8 @@ func parseOTELEnvVar(svc *svc.Attrs, varName string, handler attributes.VarHandl
 		return
 	}
 
-	attributes.ParseOTELResourceVariable(envVar, handler)
+	expandedValue := string(config.ReplaceEnv([]byte(envVar)))
+	attributes.ParseOTELResourceVariable(expandedValue, handler)
 }
 
 func ResourceAttrsFromEnv(svc *svc.Attrs) []attribute.KeyValue {

--- a/pkg/export/otel/otelcfg/common_test.go
+++ b/pkg/export/otel/otelcfg/common_test.go
@@ -474,7 +474,7 @@ func TestResourceAttrsFromEnv(t *testing.T) {
 				attrMap[string(attr.Key)] = attr.Value.AsString()
 			}
 
-			assert.Equal(t, len(tt.expectedAttrs), len(attrMap), "Number of attributes should match")
+			assert.Len(t, attrMap, len(tt.expectedAttrs), "Number of attributes should match")
 			for k, v := range tt.expectedAttrs {
 				assert.Equal(t, v, attrMap[k], "Attribute %s should have value %s", k, v)
 			}

--- a/pkg/export/otel/otelcfg/common_test.go
+++ b/pkg/export/otel/otelcfg/common_test.go
@@ -392,3 +392,92 @@ func TestGetFilteredResourceAttrs(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceAttrsFromEnv(t *testing.T) {
+	tests := []struct {
+		name          string
+		resourceAttrs string
+		envVars       map[string]string
+		expectedAttrs map[string]string
+	}{
+		{
+			name:          "Simple key-value pairs without variables",
+			resourceAttrs: "service.name=test-service,service.version=1.0.0",
+			envVars:       map[string]string{},
+			expectedAttrs: map[string]string{
+				"service.name":    "test-service",
+				"service.version": "1.0.0",
+			},
+		},
+		{
+			name:          "Environment variables with ${VAR} syntax",
+			resourceAttrs: "k8s.pod.name=${POD_NAME},k8s.node.name=${NODE_NAME}",
+			envVars: map[string]string{
+				"POD_NAME":  "test-pod-123",
+				"NODE_NAME": "test-node-456",
+			},
+			expectedAttrs: map[string]string{
+				"k8s.pod.name":  "test-pod-123",
+				"k8s.node.name": "test-node-456",
+			},
+		},
+		{
+			name:          "Environment variables with $(VAR) syntax",
+			resourceAttrs: "k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME)",
+			envVars: map[string]string{
+				"OTEL_RESOURCE_ATTRIBUTES_POD_NAME":  "test-pod-789",
+				"OTEL_RESOURCE_ATTRIBUTES_NODE_NAME": "test-node-012",
+			},
+			expectedAttrs: map[string]string{
+				"k8s.pod.name":  "test-pod-789",
+				"k8s.node.name": "test-node-012",
+			},
+		},
+		{
+			name:          "Mixed syntax with default values",
+			resourceAttrs: "k8s.pod.name=$(POD_NAME:-default-pod),k8s.node.name=${NODE_NAME:-default-node}",
+			envVars:       map[string]string{},
+			expectedAttrs: map[string]string{
+				"k8s.pod.name":  "default-pod",
+				"k8s.node.name": "default-node",
+			},
+		},
+		{
+			name:          "Complex real-world example",
+			resourceAttrs: "service.name=my-service,k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.namespace.name=${K8S_NAMESPACE:-default}",
+			envVars: map[string]string{
+				"OTEL_RESOURCE_ATTRIBUTES_POD_NAME":  "web-server-pod-abc123",
+				"OTEL_RESOURCE_ATTRIBUTES_NODE_NAME": "worker-node-xyz789",
+				"K8S_NAMESPACE":                      "production",
+			},
+			expectedAttrs: map[string]string{
+				"service.name":       "my-service",
+				"k8s.pod.name":       "web-server-pod-abc123",
+				"k8s.node.name":      "worker-node-xyz789",
+				"k8s.namespace.name": "production",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			t.Setenv("OTEL_RESOURCE_ATTRIBUTES", tt.resourceAttrs)
+
+			attrs := ResourceAttrsFromEnv(nil)
+
+			attrMap := make(map[string]string)
+			for _, attr := range attrs {
+				attrMap[string(attr.Key)] = attr.Value.AsString()
+			}
+
+			assert.Equal(t, len(tt.expectedAttrs), len(attrMap), "Number of attributes should match")
+			for k, v := range tt.expectedAttrs {
+				assert.Equal(t, v, attrMap[k], "Attribute %s should have value %s", k, v)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We support OTEL env variable replacement but we don't have support for variables
of the format $(var), which is how OpenTelemetry Operator works.

Fixes https://github.com/grafana/beyla/issues/1856