### PR TITLE
[Route Classifier] Remove additional valid chars config option

### DIFF
--- a/pkg/components/transform/route/clusterurl/cluster.go
+++ b/pkg/components/transform/route/clusterurl/cluster.go
@@ -15,9 +15,10 @@ import (
 )
 
 type ClusterURLClassifier struct {
-	classifier *structs.GibberishData
-	cache      *lru.Cache[string, bool]
-	cfg        *Config
+	classifier     *structs.GibberishData
+	cache          *lru.Cache[string, bool]
+	cfg            *Config
+	validCharTable [256]bool
 }
 
 func NewClusterURLClassifier(config *Config) (*ClusterURLClassifier, error) {
@@ -39,10 +40,23 @@ func NewClusterURLClassifier(config *Config) (*ClusterURLClassifier, error) {
 		return nil, fmt.Errorf("NewClusterURLClassifier: unable to create cache: %w", err)
 	}
 
+	// Initialize lookup table for valid characters
+	var validCharTable [256]bool
+	for c := byte('a'); c <= 'z'; c++ {
+		validCharTable[c] = true
+	}
+	for c := byte('A'); c <= 'Z'; c++ {
+		validCharTable[c] = true
+	}
+	for _, c := range []byte{'-', '_', '.', ' '} {
+		validCharTable[c] = true
+	}
+
 	return &ClusterURLClassifier{
-		classifier: classifier,
-		cache:      cache,
-		cfg:        config,
+		classifier:     classifier,
+		cache:          cache,
+		cfg:            config,
+		validCharTable: validCharTable,
 	}, nil
 }
 
@@ -99,7 +113,7 @@ func (csf *ClusterURLClassifier) ClusterURL(path string) string {
 		} else if !skip {
 			p[sFwd] = c
 			sFwd++
-			if !csf.isValid(c) {
+			if !csf.validCharTable[c] {
 				if skipGrace && (sFwd-sPos) == 2 {
 					skipGrace = false
 					continue
@@ -135,13 +149,6 @@ func (csf *ClusterURLClassifier) okWord(w string) bool {
 
 	csf.cache.Add(w, true)
 	return true
-}
-
-func (csf *ClusterURLClassifier) isValid(c byte) bool {
-	if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '-' || c == '_' || c == '.' || c == ' ' {
-		return true
-	}
-	return false
 }
 
 //go:embed model.json

--- a/pkg/components/transform/route/clusterurl/cluster.go
+++ b/pkg/components/transform/route/clusterurl/cluster.go
@@ -138,16 +138,9 @@ func (csf *ClusterURLClassifier) okWord(w string) bool {
 }
 
 func (csf *ClusterURLClassifier) isValid(c byte) bool {
-	if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+	if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '-' || c == '_' || c == '.' || c == ' ' {
 		return true
 	}
-
-	for _, ac := range csf.cfg.AdditionalValidChars {
-		if c == ac {
-			return true
-		}
-	}
-
 	return false
 }
 

--- a/pkg/components/transform/route/clusterurl/cluster.go
+++ b/pkg/components/transform/route/clusterurl/cluster.go
@@ -142,7 +142,7 @@ func (csf *ClusterURLClassifier) isValid(c byte) bool {
 		return true
 	}
 
-	for _, ac := range DefaultConfig().AdditionalValidChars {
+	for _, ac := range csf.cfg.AdditionalValidChars {
 		if c == ac {
 			return true
 		}

--- a/pkg/components/transform/route/clusterurl/cluster_test.go
+++ b/pkg/components/transform/route/clusterurl/cluster_test.go
@@ -52,3 +52,59 @@ func TestClusterURL(t *testing.T) {
 	assert.Equal(t, "GET /api/cart", csf.ClusterURL("GET /api/cart?sessionId=55f4e5ea-5d6d-482a-80c4-799e3c72dfb0&currencyCode=USD"))
 	assert.Equal(t, "/getquote", csf.ClusterURL("/getquote"))
 }
+
+func BenchmarkClusterURLWithCache(b *testing.B) {
+	cfg := DefaultConfig()
+	cfg.CacheSize = 1000
+	csf, err := NewClusterURLClassifier(cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Test cases representing different scenarios
+	testCases := []string{
+		"/users/fdklsd/j4elk/23993/job/2",
+		"/v1/products/22",
+		"/products/1/org/3",
+		"/attach?session_id=ddfsdsf&track_id=sjdklnfldsn",
+		"GET /user_space/",
+		"/api/hello.world",
+		"123/ljgdflgjf",
+		"",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, testCase := range testCases {
+			_ = csf.ClusterURL(testCase)
+		}
+	}
+}
+
+func BenchmarkClusterURLWithoutCache(b *testing.B) {
+	cfg := DefaultConfig()
+	cfg.CacheSize = 1
+	csf, err := NewClusterURLClassifier(cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Test cases representing different scenarios
+	testCases := []string{
+		"/users/fdklsd/j4elk/23993/job/2",
+		"/v1/products/22",
+		"/products/1/org/3",
+		"/attach?session_id=ddfsdsf&track_id=sjdklnfldsn",
+		"GET /user_space/",
+		"/api/hello.world",
+		"123/ljgdflgjf",
+		"",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, testCase := range testCases {
+			_ = csf.ClusterURL(testCase)
+		}
+	}
+}

--- a/pkg/components/transform/route/clusterurl/config.go
+++ b/pkg/components/transform/route/clusterurl/config.go
@@ -14,20 +14,17 @@ type Config struct {
 	ReplaceWith byte `json:"replace_with"`
 	// CacheSize is the size of the cache for the classifier.
 	CacheSize int `json:"cache_size"`
-	// Additional characters that are considered valid in a segment.
-	AdditionalValidChars []byte `json:"additional_chars,omitempty"`
 	// ModelPath is the path to the model file.
 	ModelPath string `json:"model_path"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MaxSegments:          10,
-		Separator:            '/',
-		ReplaceWith:          '*',
-		CacheSize:            8192,
-		AdditionalValidChars: []byte{'-', '_', '.', ' '},
-		ModelPath:            "",
+		MaxSegments: 10,
+		Separator:   '/',
+		ReplaceWith: '*',
+		CacheSize:   8192,
+		ModelPath:   "",
 	}
 }
 


### PR DESCRIPTION
Adds a lookup table for performance reasons.

Benchmark results over 60s:

```
> table lookup

BenchmarkClusterURLWithoutCache-20      21180284              3417 ns/op            2000 B/op         59 allocs/op

> loop 

BenchmarkClusterURLWithoutCache-20      20406266              3387 ns/op            2000 B/op         59 allocs/op

> OR chain

BenchmarkClusterURLWithoutCache-20      21681082              3326 ns/op            2000 B/op         59 allocs/op
```