### PR TITLE
Fix span metrics export option dependency

### DIFF
--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -784,7 +784,7 @@ func otelMetricsAccepted(span *request.Span, mr *MetricsReporter) bool {
 }
 
 func otelSpanMetricsAccepted(span *request.Span, mr *MetricsReporter) bool {
-	return mr.cfg.OTelMetricsEnabled() && !span.Service.ExportsOTelMetricsSpan()
+	return mr.cfg.AnySpanMetricsEnabled() && !span.Service.ExportsOTelMetricsSpan()
 }
 
 //nolint:cyclop

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -363,7 +363,7 @@ func TestMetricsDiscarded(t *testing.T) {
 
 func TestSpanMetricsDiscarded(t *testing.T) {
 	mc := otelcfg.MetricsConfig{
-		Features: []string{otelcfg.FeatureApplication},
+		Features: []string{otelcfg.FeatureSpan},
 	}
 	mr := MetricsReporter{
 		cfg: &mc,

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -827,7 +827,7 @@ func (r *metricsReporter) otelMetricsObserved(span *request.Span) bool {
 }
 
 func (r *metricsReporter) otelSpanMetricsObserved(span *request.Span) bool {
-	return r.cfg.OTelMetricsEnabled() && !span.Service.ExportsOTelMetricsSpan()
+	return r.cfg.AnySpanMetricsEnabled() && !span.Service.ExportsOTelMetricsSpan()
 }
 
 func (r *metricsReporter) otelSpanFiltered(span *request.Span) bool {

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -433,7 +433,7 @@ func TestMetricsDiscarded(t *testing.T) {
 
 func TestSpanMetricsDiscarded(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []string{otelcfg.FeatureApplication},
+		Features: []string{otelcfg.FeatureSpanOTel},
 	}
 	mr := metricsReporter{
 		cfg: &mc,


### PR DESCRIPTION
The span metrics export was accidentally (copy paste error) depending also on export of OTEL application metrics, which are unrelated. This requires that customers export both when they may need only one format. The tests also had the copy-paste error. 