### PR TITLE
Fix yaml serialization test

### DIFF
--- a/pkg/services/export_test.go
+++ b/pkg/services/export_test.go
@@ -45,7 +45,7 @@ func TestYAMLMarshal_Exports(t *testing.T) {
 		var exports struct {
 			Exports []string `yaml:"exports"`
 		}
-		yaml.Unmarshal(yamlOut, &exports)
+		require.NoError(t, yaml.Unmarshal(yamlOut, &exports))
 		assert.ElementsMatch(t, []string{"metrics", "traces"}, exports.Exports)
 	})
 }


### PR DESCRIPTION
The test TestYAMLMarshal_Exports frequently fails because the array serialisation can be unpredictable.

Fixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/420