### PR TITLE
Fix number of other span metrics bugs

### DIFF
--- a/pkg/components/pipe/instrumenter.go
+++ b/pkg/components/pipe/instrumenter.go
@@ -122,7 +122,7 @@ func newGraphBuilder(
 	), swarm.WithID("OTELSvcGraphMetricsExport"))
 
 	swi.Add(otel.TracesReceiver(
-		ctxInfo, config.Traces, config.Metrics.SpanMetricsEnabled(), selectorCfg, exportableSpans,
+		ctxInfo, config.Traces, config.SpanMetricsEnabledForTraces(), selectorCfg, exportableSpans,
 	), swarm.WithID("OTELTracesReceiver"))
 	swi.Add(prom.PrometheusEndpoint(ctxInfo, &config.Prometheus, selectorCfg, exportableSpans, processEventsCh),
 		swarm.WithID("PrometheusEndpoint"))

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -406,6 +406,51 @@ func TestSpanMetricsDiscarded(t *testing.T) {
 	}
 }
 
+func TestSpanMetricsDiscardedGraph(t *testing.T) {
+	mc := otelcfg.MetricsConfig{
+		Features: []string{otelcfg.FeatureGraph},
+	}
+	mr := MetricsReporter{
+		cfg: &mc,
+	}
+
+	svcNoExport := svc.Attrs{}
+
+	svcExportMetrics := svc.Attrs{}
+	svcExportMetrics.SetExportsOTelMetrics()
+
+	svcExportSpanMetrics := svc.Attrs{}
+	svcExportSpanMetrics.SetExportsOTelMetricsSpan()
+
+	tests := []struct {
+		name      string
+		span      request.Span
+		discarded bool
+	}{
+		{
+			name:      "Foo span is not filtered",
+			span:      request.Span{Service: svcNoExport, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/foo", RequestStart: 100, End: 200},
+			discarded: false,
+		},
+		{
+			name:      "/v1/metrics span is not filtered",
+			span:      request.Span{Service: svcExportMetrics, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/v1/metrics", RequestStart: 100, End: 200},
+			discarded: false,
+		},
+		{
+			name:      "/v1/traces span is filtered",
+			span:      request.Span{Service: svcExportSpanMetrics, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/v1/traces", RequestStart: 100, End: 200},
+			discarded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.discarded, !otelSpanMetricsAccepted(&tt.span, &mr), tt.name)
+		})
+	}
+}
+
 func TestProcessPIDEvents(t *testing.T) {
 	mc := otelcfg.MetricsConfig{
 		Features: []string{otelcfg.FeatureApplication},

--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -121,7 +121,7 @@ func (m *MetricsConfig) EndpointEnabled() bool {
 }
 
 func (m *MetricsConfig) AnySpanMetricsEnabled() bool {
-	return m.SpanMetricsEnabled() || m.SpanMetricsSizesEnabled()
+	return m.SpanMetricsEnabled() || m.SpanMetricsSizesEnabled() || m.ServiceGraphMetricsEnabled()
 }
 
 func (m *MetricsConfig) SpanMetricsSizesEnabled() bool {

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -146,10 +146,6 @@ func (tr *tracesOTELReceiver) provideLoop(ctx context.Context) {
 		return
 	}
 
-	if tr.spanMetricsEnabled {
-		traceAttrs[attr.SkipSpanMetrics] = struct{}{}
-	}
-
 	sampler := tr.cfg.SamplerConfig.Implementation()
 
 	for spans := range tr.input {

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -566,7 +566,11 @@ func TestTraceSkipSpanMetrics(t *testing.T) {
 	}
 
 	t.Run("test with span metrics on", func(t *testing.T) {
-		receiver := makeTracesTestReceiverWithSpanMetrics([]string{"http"})
+		mc := otelcfg.MetricsConfig{
+			Features: []string{otelcfg.FeatureSpan},
+		}
+
+		receiver := makeTracesTestReceiverWithSpanMetrics(mc.Enabled() && mc.AnySpanMetricsEnabled(), []string{"http"})
 
 		sampler := sdktrace.AlwaysSample()
 		attrs, err := receiver.getConstantAttributes()
@@ -1243,7 +1247,7 @@ func makeTracesTestReceiver(instr []string) *tracesOTELReceiver {
 	)
 }
 
-func makeTracesTestReceiverWithSpanMetrics(instr []string) *tracesOTELReceiver {
+func makeTracesTestReceiverWithSpanMetrics(enabled bool, instr []string) *tracesOTELReceiver {
 	return makeTracesReceiver(
 		otelcfg.TracesConfig{
 			CommonEndpoint:    "http://something",
@@ -1251,7 +1255,7 @@ func makeTracesTestReceiverWithSpanMetrics(instr []string) *tracesOTELReceiver {
 			ReportersCacheLen: 16,
 			Instrumentations:  instr,
 		},
-		true,
+		enabled,
 		&global.ContextInfo{},
 		&attributes.SelectorConfig{},
 		msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10)),

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -477,6 +477,52 @@ func TestSpanMetricsDiscarded(t *testing.T) {
 	}
 }
 
+func TestSpanMetricsDiscardedGraph(t *testing.T) {
+	mc := PrometheusConfig{
+		Features: []string{otelcfg.FeatureGraph},
+	}
+	mr := metricsReporter{
+		cfg: &mc,
+	}
+
+	svcNoExport := svc.Attrs{}
+
+	svcExportMetrics := svc.Attrs{}
+	svcExportMetrics.SetExportsOTelMetrics()
+
+	svcExportMetricsSpan := svc.Attrs{}
+	svcExportMetricsSpan.SetExportsOTelMetricsSpan()
+
+	tests := []struct {
+		name      string
+		span      request.Span
+		discarded bool
+	}{
+		{
+			name:      "Foo span is not filtered",
+			span:      request.Span{Service: svcNoExport, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/foo", RequestStart: 100, End: 200},
+			discarded: false,
+		},
+		{
+			name:      "/v1/metrics span is filtered",
+			span:      request.Span{Service: svcExportMetrics, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/v1/metrics", RequestStart: 100, End: 200},
+			discarded: false,
+		},
+		{
+			name:      "/v1/traces span is not filtered",
+			span:      request.Span{Service: svcExportMetricsSpan, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/v1/traces", RequestStart: 100, End: 200},
+			discarded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.discarded, !(mr.otelSpanMetricsObserved(&tt.span)), tt.name)
+			assert.False(t, mr.otelSpanFiltered(&tt.span), tt.name)
+		})
+	}
+}
+
 func TestTerminatesOnBadPromPort(t *testing.T) {
 	now := syncedClock{now: time.Now()}
 	timeNow = now.Now

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -375,6 +375,13 @@ func (c *Config) Enabled(feature Feature) bool {
 	return false
 }
 
+func (c *Config) SpanMetricsEnabledForTraces() bool {
+	otelSpanMetricsEnabled := c.Metrics.Enabled() && c.Metrics.AnySpanMetricsEnabled()
+	promSpanMetricsEnabled := c.Prometheus.Enabled() && c.Prometheus.AnySpanMetricsEnabled()
+
+	return otelSpanMetricsEnabled || promSpanMetricsEnabled
+}
+
 // ExternalLogger sets the logging capabilities of OBI.
 // Used for integrating Beyla with an external logging system (for example Alloy)
 // TODO: maybe this method has too many responsibilities, as it affects the global logger.

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -579,6 +579,78 @@ func TestWillUseTC(t *testing.T) {
 	assert.True(t, cfg.willUseTC())
 }
 
+func TestConfig_SpanMetricsEnabledForTraces(t *testing.T) {
+	tests := []struct {
+		name        string
+		metrics     otelcfg.MetricsConfig
+		prometheus  prom.PrometheusConfig
+		wantEnabled bool
+	}{
+		{
+			name:        "none enabled",
+			metrics:     otelcfg.MetricsConfig{},
+			prometheus:  prom.PrometheusConfig{},
+			wantEnabled: false,
+		},
+		{
+			name: "otel metrics enabled, but not spans",
+			metrics: otelcfg.MetricsConfig{
+				MetricsEndpoint: "http://localhost:4318/v1/metrics",
+				Features:        []string{otelcfg.FeatureApplication},
+			},
+			prometheus:  prom.PrometheusConfig{},
+			wantEnabled: false,
+		},
+		{
+			name: "otel metrics enabled with spans",
+			metrics: otelcfg.MetricsConfig{
+				MetricsEndpoint: "http://localhost:4318/v1/metrics",
+				Features:        []string{otelcfg.FeatureSpanOTel},
+			},
+			prometheus:  prom.PrometheusConfig{},
+			wantEnabled: true,
+		},
+		{
+			name:    "prometheus metrics enabled, but not spans",
+			metrics: otelcfg.MetricsConfig{},
+			prometheus: prom.PrometheusConfig{
+				Port:     9090,
+				Features: []string{otelcfg.FeatureApplication},
+			},
+			wantEnabled: false,
+		},
+		{
+			name:    "prometheus span metrics enabled",
+			metrics: otelcfg.MetricsConfig{},
+			prometheus: prom.PrometheusConfig{
+				Port:     9090,
+				Features: []string{otelcfg.FeatureGraph},
+			},
+			wantEnabled: true,
+		},
+		{
+			name: "both have features, but not enabled",
+			metrics: otelcfg.MetricsConfig{
+				Features: []string{otelcfg.FeatureApplication},
+			},
+			prometheus: prom.PrometheusConfig{
+				Features: []string{otelcfg.FeatureGraph},
+			},
+			wantEnabled: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Metrics:    tc.metrics,
+				Prometheus: tc.prometheus,
+			}
+			got := cfg.SpanMetricsEnabledForTraces()
+			assert.Equal(t, tc.wantEnabled, got)
+		})
+	}
+}
 func loadConfig(t *testing.T, env envMap) *Config {
 	for k, v := range env {
 		t.Setenv(k, v)


### PR DESCRIPTION
While looking at the span metrics generation code I found couple of other issues:

1. Prometheus export and OTel export were inconsistent on what they reported on AnySpanMetricsEnabled(). Graph wasn't in the list for OTel and it should've been, otherwise if someone enabled only graph metrics we wouldn't enable traces_target_info.
2. When OBI generates span metrics it also adds an attribute on any generated traces `span.metrics.skip=true` so the Collector can easily be configured to avoid double generating span metrics. However, the code currently checked only for OTel metrics exports, if Prometheus metrics exports the spans weren't marked with the same attribute.

Most of the code changes are tests to catch the edge cases discovered.