### PR TITLE
fix: Ensure err is checked asap

### DIFF
--- a/test/integration/discovery_test.go
+++ b/test/integration/discovery_test.go
@@ -98,9 +98,10 @@ func testSelectiveExports(t *testing.T) {
 
 func TestDiscoverySection(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-discovery.yml", path.Join(pathOutput, "test-suite-discovery.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Selective exports", testSelectiveExports)

--- a/test/integration/grpc_go_mux_test.go
+++ b/test/integration/grpc_go_mux_test.go
@@ -44,9 +44,10 @@ func testREDMetricsForGRPCMuxLibrary(t *testing.T, route, svcNs, serverPort stri
 
 func TestGRPCMux(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-grpc-http2-mux.yml", path.Join(pathOutput, "test-suite-grpc-http2-mux.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`, `TARGET_URL=testserver:8080`, `TARGET_PORTS=8080:8080`)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Go RED metrics: grpc-http2 mux service", func(t *testing.T) {
@@ -58,9 +59,10 @@ func TestGRPCMux(t *testing.T) {
 
 func TestGRPCMuxTLS(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-grpc-http2-mux.yml", path.Join(pathOutput, "test-suite-grpc-http2-mux-tls.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`, `TARGET_URL=testserver:8383`, `TARGET_PORTS=8383:8383`, `TEST_SUFFIX=_tls`)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Go RED metrics: grpc-http2 mux service TLS", func(t *testing.T) {

--- a/test/integration/http2go_test.go
+++ b/test/integration/http2go_test.go
@@ -112,6 +112,8 @@ func testNestedHTTP2Traces(t *testing.T, url string) {
 
 func TestHTTP2Go(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-http2.yml", path.Join(pathOutput, "test-suite-http2.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
 	lockdown := KernelLockdownMode()
@@ -120,7 +122,6 @@ func TestHTTP2Go(t *testing.T) {
 		compose.Env = append(compose.Env, `SECURITY_CONFIG_SUFFIX=_none`)
 	}
 
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Go RED metrics: http2 service", func(t *testing.T) {

--- a/test/integration/http_go_otel_test.go
+++ b/test/integration/http_go_otel_test.go
@@ -131,6 +131,8 @@ func testInstrumentationMissing(t *testing.T, route, svcNs string) {
 
 func TestHTTPGoOTelInstrumentedApp(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-go-otel.yml", path.Join(pathOutput, "test-suite-go-otel.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=8080`, `APP_OTEL_ENDPOINT=http://localhost:1111`)
 	lockdown := KernelLockdownMode()
@@ -139,7 +141,6 @@ func TestHTTPGoOTelInstrumentedApp(t *testing.T) {
 		compose.Env = append(compose.Env, `SECURITY_CONFIG_SUFFIX=_none`)
 	}
 
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Go RED metrics: http service instrumented with OTel", func(t *testing.T) {
@@ -171,6 +172,8 @@ func otelWaitForTestComponents(t *testing.T, url, subpath string) {
 
 func TestHTTPGoOTelAvoidsInstrumentedApp(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-go-otel.yml", path.Join(pathOutput, "test-suite-go-otel-avoids.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=8080`, `APP_OTEL_METRICS_ENDPOINT=http://otelcol:4318`, `APP_OTEL_TRACES_ENDPOINT=http://jaeger:4318`)
 	lockdown := KernelLockdownMode()
@@ -179,7 +182,6 @@ func TestHTTPGoOTelAvoidsInstrumentedApp(t *testing.T) {
 		compose.Env = append(compose.Env, `SECURITY_CONFIG_SUFFIX=_none`)
 	}
 
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Go RED metrics: http service instrumented with OTel, no istrumentation", func(t *testing.T) {
@@ -193,6 +195,8 @@ func TestHTTPGoOTelAvoidsInstrumentedApp(t *testing.T) {
 
 func TestHTTPGoOTelDisabledOptInstrumentedApp(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-go-otel.yml", path.Join(pathOutput, "test-suite-go-otel-disabled.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(
 		compose.Env,
@@ -209,7 +213,6 @@ func TestHTTPGoOTelDisabledOptInstrumentedApp(t *testing.T) {
 		compose.Env = append(compose.Env, `SECURITY_CONFIG_SUFFIX=_none`)
 	}
 
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Go RED metrics: http service instrumented with OTel, option disabled", func(t *testing.T) {
@@ -223,6 +226,8 @@ func TestHTTPGoOTelDisabledOptInstrumentedApp(t *testing.T) {
 
 func TestHTTPGoOTelInstrumentedAppGRPC(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-go-otel-grpc.yml", path.Join(pathOutput, "test-suite-go-otel-grpc.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=8080`, `APP_OTEL_ENDPOINT=http://localhost:1111`)
 	lockdown := KernelLockdownMode()
@@ -231,7 +236,6 @@ func TestHTTPGoOTelInstrumentedAppGRPC(t *testing.T) {
 		compose.Env = append(compose.Env, `SECURITY_CONFIG_SUFFIX=_none`)
 	}
 
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Go RED metrics: http service instrumented with OTel - GRPC", func(t *testing.T) {
@@ -266,6 +270,8 @@ func otelWaitForTestComponentsTraces(t *testing.T, url, subpath string) {
 
 func TestHTTPGoOTelAvoidsInstrumentedAppGRPC(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-go-otel-grpc.yml", path.Join(pathOutput, "test-suite-go-otel-avoids-grpc.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=8080`, `APP_OTEL_METRICS_ENDPOINT=http://otelcol:4317`, `APP_OTEL_TRACES_ENDPOINT=http://jaeger:4317`)
 	lockdown := KernelLockdownMode()
@@ -274,7 +280,6 @@ func TestHTTPGoOTelAvoidsInstrumentedAppGRPC(t *testing.T) {
 		compose.Env = append(compose.Env, `SECURITY_CONFIG_SUFFIX=_none`)
 	}
 
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Go RED metrics: http service instrumented with OTel, no istrumentation, GRPC", func(t *testing.T) {

--- a/test/integration/internal_metrics_test.go
+++ b/test/integration/internal_metrics_test.go
@@ -23,9 +23,10 @@ import (
 
 func TestInstrumentationErrors(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-error-test.yml", path.Join(pathOutput, "test-suite-instrumentation-errors.log"))
+	require.NoError(t, err)
+
 	// Run OBI without privileged mode to force instrumentation errors
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Instrumentation error metrics", func(t *testing.T) {
@@ -37,6 +38,8 @@ func TestInstrumentationErrors(t *testing.T) {
 
 func TestAvoidedServicesMetrics(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-go-otel.yml", path.Join(pathOutput, "test-suite-avoided-services.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env,
 		`OTEL_EBPF_EXECUTABLE_PATH=`,
@@ -52,7 +55,6 @@ func TestAvoidedServicesMetrics(t *testing.T) {
 		compose.Env = append(compose.Env, `SECURITY_CONFIG_SUFFIX=_none`)
 	}
 
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Avoided services metrics are recorded", func(t *testing.T) {

--- a/test/integration/multiprocess_test.go
+++ b/test/integration/multiprocess_test.go
@@ -23,9 +23,10 @@ import (
 
 func TestMultiProcess(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-multiexec.yml", path.Join(pathOutput, "test-suite-multiexec.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Go RED metrics: usual service", func(t *testing.T) {
@@ -117,9 +118,10 @@ func TestMultiProcess(t *testing.T) {
 
 func TestMultiProcessAppCP(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-multiexec-host.yml", path.Join(pathOutput, "test-suite-multiexec-app-cp.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_BPF_DISABLE_BLACK_BOX_CP=1`, `OTEL_EBPF_BPF_CONTEXT_PROPAGATION=all`, `OTEL_EBPF_BPF_TRACK_REQUEST_HEADERS=1`)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	if kprobeTracesEnabled() {
@@ -132,10 +134,11 @@ func TestMultiProcessAppCP(t *testing.T) {
 
 func TestMultiProcessAppCPNoIP(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-multiexec-host.yml", path.Join(pathOutput, "test-suite-multiexec-app-cp-no-ip.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_BPF_DISABLE_BLACK_BOX_CP=1`, `OTEL_EBPF_BPF_CONTEXT_PROPAGATION=headers`, `OTEL_EBPF_BPF_TRACK_REQUEST_HEADERS=1`)
 
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	if kprobeTracesEnabled() {

--- a/test/integration/nodejs_multiproc_test.go
+++ b/test/integration/nodejs_multiproc_test.go
@@ -95,9 +95,10 @@ func testNestedTraces(t *testing.T) {
 
 func TestNodeJSMultiProc(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-nodemultiproc.yml", path.Join(pathOutput, "test-suite-node-multiproc.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Nested traces", testNestedTraces)

--- a/test/integration/old_grpc_test.go
+++ b/test/integration/old_grpc_test.go
@@ -129,6 +129,8 @@ func testGRPCGoClientFailsToConnect(t *testing.T) {
 
 func TestSuiteOtherGRPCGo(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-other-grpc.yml", path.Join(pathOutput, "test-suite-other-grpc.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
 	lockdown := KernelLockdownMode()
@@ -137,7 +139,6 @@ func TestSuiteOtherGRPCGo(t *testing.T) {
 		compose.Env = append(compose.Env, `SECURITY_CONFIG_SUFFIX=_none`)
 	}
 
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Go RED metrics and traces: old grpc service", func(t *testing.T) {

--- a/test/integration/php_fm_test.go
+++ b/test/integration/php_fm_test.go
@@ -116,9 +116,10 @@ func testREDMetricsPHPFPM(t *testing.T) {
 
 func TestPHPFM(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-php-fpm.yml", path.Join(pathOutput, "test-suite-php-fpm.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("PHP-FM RED metrics", testREDMetricsPHPFPM)
@@ -186,9 +187,10 @@ func testTracesPHPFPM(t *testing.T) {
 
 func TestPHPFMUnixSock(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-php-fpm-sock.yml", path.Join(pathOutput, "test-suite-php-fpm-sock.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("PHP-FM RED metrics", testTracesPHPFPM)

--- a/test/integration/sampler_test.go
+++ b/test/integration/sampler_test.go
@@ -79,9 +79,10 @@ func testSampler(t *testing.T) {
 
 func TestSampler(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-sampler.yml", path.Join(pathOutput, "test-suite-sampler.log"))
+	require.NoError(t, err)
+
 	// we are going to setup discovery directly in the configuration file
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	t.Run("Sampler", testSampler)

--- a/test/integration/suites_network_test.go
+++ b/test/integration/suites_network_test.go
@@ -24,8 +24,9 @@ import (
 
 func TestNetwork_Deduplication(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly.yml", path.Join(pathOutput, "test-suite-netolly-dedupe.log"))
-	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=")
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=")
 	require.NoError(t, compose.Up())
 
 	// When there flow deduplication, results must not include "iface" field.
@@ -39,8 +40,9 @@ func TestNetwork_Deduplication(t *testing.T) {
 
 func TestNetwork_Deduplication_Use_Socket_Filter(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly.yml", path.Join(pathOutput, "test-suite-netolly-dedupe-no-tc.log"))
-	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=", "OTEL_EBPF_NETWORK_SOURCE=socket_filter")
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=", "OTEL_EBPF_NETWORK_SOURCE=socket_filter")
 	require.NoError(t, compose.Up())
 
 	// When there flow deduplication, results must not include "iface" field.
@@ -54,8 +56,9 @@ func TestNetwork_Deduplication_Use_Socket_Filter(t *testing.T) {
 
 func TestNetwork_NoDeduplication(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly.yml", path.Join(pathOutput, "test-suite-netolly-nodedupe.log"))
-	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=none", "OTEL_EBPF_EXECUTABLE_PATH=")
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=none", "OTEL_EBPF_EXECUTABLE_PATH=")
 	require.NoError(t, compose.Up())
 
 	// When there is no flow deduplication, results must include "iface".
@@ -72,8 +75,9 @@ func TestNetwork_NoDeduplication(t *testing.T) {
 
 func TestNetwork_AllowedAttributes(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly.yml", path.Join(pathOutput, "test-suite-netolly-allowed-attrs.log"))
-	compose.Env = append(compose.Env, "OTEL_EBPF_EXECUTABLE_PATH=", `OTEL_EBPF_CONFIG_SUFFIX=-disallowattrs`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, "OTEL_EBPF_EXECUTABLE_PATH=", `OTEL_EBPF_CONFIG_SUFFIX=-disallowattrs`)
 	require.NoError(t, compose.Up())
 
 	// When there flow deduplication, results must only include
@@ -121,8 +125,9 @@ func TestNetwork_ReverseDNS(t *testing.T) {
 
 func TestNetwork_Direction(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly-direction.yml", path.Join(pathOutput, "test-suite-netolly-direction.log"))
-	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_NETWORK_SOURCE=tc", "OTEL_EBPF_EXECUTABLE_PATH=", `OTEL_EBPF_CONFIG_SUFFIX=-direction`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_NETWORK_SOURCE=tc", "OTEL_EBPF_EXECUTABLE_PATH=", `OTEL_EBPF_CONFIG_SUFFIX=-direction`)
 	require.NoError(t, compose.Up())
 
 	results := getDirectionNetFlows(t)
@@ -148,8 +153,9 @@ func TestNetwork_Direction(t *testing.T) {
 
 func TestNetwork_IfaceDirection_Use_Socket_Filter(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly-direction.yml", path.Join(pathOutput, "test-suite-netolly-direction-no-tc.log"))
-	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=", "OTEL_EBPF_NETWORK_SOURCE=socket_filter", `OTEL_EBPF_CONFIG_SUFFIX=-direction`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=", "OTEL_EBPF_NETWORK_SOURCE=socket_filter", `OTEL_EBPF_CONFIG_SUFFIX=-direction`)
 	require.NoError(t, compose.Up())
 
 	results := getDirectionNetFlows(t)

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -53,10 +53,11 @@ func TestSuiteNestedTraces(t *testing.T) {
 	// Echo (server) -> echo (client) -> EchoBack (server)
 	lockdown := KernelLockdownMode()
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-nested.log"))
+	require.NoError(t, err)
+
 	if !lockdown {
 		compose.Env = append(compose.Env, `SECURITY_CONFIG_SUFFIX=_none`)
 	}
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 	if !lockdown {
 		t.Run("HTTP traces (all spans nested)", testHTTPTracesNestedClientWithContextPropagation)
@@ -70,12 +71,13 @@ func TestSuiteNestedTraces(t *testing.T) {
 
 func TestSuiteClientPromScrape(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-client.yml", path.Join(pathOutput, "test-suite-client-promscrape.log"))
+	require.NoError(t, err)
+
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=pingclient`)
 	compose.Env = append(compose.Env,
 		`INSTRUMENTER_CONFIG_SUFFIX=-promscrape`,
 		`PROM_CONFIG_SUFFIX=-promscrape`,
 	)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 	t.Run("Client RED metrics", testREDMetricsForClientHTTPLibraryNoTraces)
 	t.Run("Testing Beyla Build Info metric", testPrometheusBeylaBuildInfo)
@@ -87,8 +89,9 @@ func TestSuiteClientPromScrape(t *testing.T) {
 // Same as Test suite, but the generated test image does not contain debug information
 func TestSuite_NoDebugInfo(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-nodebug.log"))
-	compose.Env = append(compose.Env, `TESTSERVER_DOCKERFILE_SUFFIX=_nodebug`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `TESTSERVER_DOCKERFILE_SUFFIX=_nodebug`)
 	require.NoError(t, compose.Up())
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("HTTP traces", testHTTPTraces)
@@ -102,8 +105,9 @@ func TestSuite_NoDebugInfo(t *testing.T) {
 // Same as Test suite, but the generated test image does not contain debug information
 func TestSuite_StaticCompilation(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-static.log"))
-	compose.Env = append(compose.Env, `TESTSERVER_DOCKERFILE_SUFFIX=_static`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `TESTSERVER_DOCKERFILE_SUFFIX=_static`)
 	require.NoError(t, compose.Up())
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("HTTP traces", testHTTPTraces)
@@ -116,8 +120,9 @@ func TestSuite_StaticCompilation(t *testing.T) {
 
 func TestSuite_OldestGoVersion(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-1.17.yml", path.Join(pathOutput, "test-suite-oldest-go.log"))
-	compose.Env = []string{`OTEL_GO_AUTO_TARGET_EXE=*testserver`}
 	require.NoError(t, err)
+
+	compose.Env = []string{`OTEL_GO_AUTO_TARGET_EXE=*testserver`}
 	require.NoError(t, compose.Up())
 	t.Run("RED metrics", testREDMetricsOldHTTP)
 	t.Run("HTTP traces", testHTTPTraces)
@@ -141,8 +146,9 @@ func TestSuite_UnsupportedGoVersion(t *testing.T) {
 func TestSuite_SkipGoTracers(t *testing.T) {
 	t.Skip("seems flaky, we need to look into this")
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-skip-go-tracers.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_SKIP_GO_SPECIFIC_TRACERS=1`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_SKIP_GO_SPECIFIC_TRACERS=1`)
 	require.NoError(t, compose.Up())
 	t.Run("RED metrics", testREDMetricsShortHTTP)
 	require.NoError(t, compose.Close())
@@ -150,8 +156,9 @@ func TestSuite_SkipGoTracers(t *testing.T) {
 
 func TestSuite_GRPCExport(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-grpc-export.log"))
-	compose.Env = append(compose.Env, "INSTRUMENTER_CONFIG_SUFFIX=-grpc-export")
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, "INSTRUMENTER_CONFIG_SUFFIX=-grpc-export")
 	require.NoError(t, compose.Up())
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("trace HTTP service and export as GRPC traces", testHTTPTraces)
@@ -163,9 +170,10 @@ func TestSuite_GRPCExport(t *testing.T) {
 
 func TestSuite_GRPCExportKProbes(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-grpc-export-kprobes.log"))
+	require.NoError(t, err)
+
 	compose.Env = append(compose.Env, "INSTRUMENTER_CONFIG_SUFFIX=-grpc-export")
 	compose.Env = append(compose.Env, `OTEL_EBPF_SKIP_GO_SPECIFIC_TRACERS=1`)
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	waitForTestComponents(t, instrumentedServiceStdURL)
@@ -180,6 +188,8 @@ func TestSuite_GRPCExportKProbes(t *testing.T) {
 // that is scraped by the Prometheus server
 func TestSuite_PrometheusScrape(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-promscrape.log"))
+	require.NoError(t, err)
+
 	compose.Env = append(compose.Env,
 		`INSTRUMENTER_CONFIG_SUFFIX=-promscrape`,
 		`PROM_CONFIG_SUFFIX=-promscrape`,
@@ -187,7 +197,6 @@ func TestSuite_PrometheusScrape(t *testing.T) {
 		`OTEL_EBPF_OPEN_PORT=8082,8999`, // force Beyla self-instrumentation to ensure we don't do it
 	)
 
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("GRPC RED metrics", testREDMetricsGRPC)
@@ -201,8 +210,9 @@ func TestSuite_PrometheusScrape(t *testing.T) {
 
 func TestSuite_Java(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-java.yml", path.Join(pathOutput, "test-suite-java.log"))
-	compose.Env = append(compose.Env, `JAVA_TEST_MODE=-native`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `JAVA_TEST_MODE=-native`)
 	require.NoError(t, compose.Up())
 	t.Run("Java RED metrics", testREDMetricsJavaHTTP)
 	require.NoError(t, compose.Close())
@@ -211,8 +221,9 @@ func TestSuite_Java(t *testing.T) {
 // Same as TestSuite_Java but we run in the process namespace and it uses process namespace filtering
 func TestSuite_Java_PID(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-java-pid.yml", path.Join(pathOutput, "test-suite-java-pid.log"))
-	compose.Env = append(compose.Env, `JAVA_OPEN_PORT=8085`, `JAVA_EXECUTABLE_PATH=`, `JAVA_TEST_MODE=-jar`, `OTEL_SERVICE_NAME=greeting`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `JAVA_OPEN_PORT=8085`, `JAVA_EXECUTABLE_PATH=`, `JAVA_TEST_MODE=-jar`, `OTEL_SERVICE_NAME=greeting`)
 	require.NoError(t, compose.Up())
 	t.Run("Java RED metrics", testREDMetricsJavaHTTP)
 	require.NoError(t, compose.Close())
@@ -221,8 +232,9 @@ func TestSuite_Java_PID(t *testing.T) {
 // Same as Java Test suite, but searching the executable by port instead of executable name. We also run the jar version of Java instead of native image
 func TestSuite_Java_OpenPort(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-java.yml", path.Join(pathOutput, "test-suite-java-openport.log"))
-	compose.Env = append(compose.Env, `JAVA_OPEN_PORT=8085`, `JAVA_EXECUTABLE_PATH=`, `JAVA_TEST_MODE=-jar`, `OTEL_SERVICE_NAME=greeting`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `JAVA_OPEN_PORT=8085`, `JAVA_EXECUTABLE_PATH=`, `JAVA_TEST_MODE=-jar`, `OTEL_SERVICE_NAME=greeting`)
 	require.NoError(t, compose.Up())
 	t.Run("Java RED metrics", testREDMetricsJavaHTTP)
 
@@ -232,8 +244,9 @@ func TestSuite_Java_OpenPort(t *testing.T) {
 // Test that we can also instrument when running with host network mode
 func TestSuite_Java_Host_Network(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-java-host.yml", path.Join(pathOutput, "test-suite-java-host-network.log"))
-	compose.Env = append(compose.Env, `JAVA_TEST_MODE=-native`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `JAVA_TEST_MODE=-native`)
 	require.NoError(t, compose.Up())
 	t.Run("Java RED metrics", testREDMetricsJavaHTTP)
 	require.NoError(t, compose.Close())
@@ -241,8 +254,9 @@ func TestSuite_Java_Host_Network(t *testing.T) {
 
 func TestSuite_JavaOTelSDK(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-java-agent.yml", path.Join(pathOutput, "test-suite-java-agent.log"))
-	compose.Env = append(compose.Env, `JAVA_TEST_MODE=-jar`, `JAVA_OPEN_PORT=8085`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `JAVA_TEST_MODE=-jar`, `JAVA_OPEN_PORT=8085`)
 	require.NoError(t, compose.Up())
 	t.Run("Java RED metrics with OTel SDK injection", testREDMetricsJavaOTelSDKHTTP)
 	require.NoError(t, compose.Close())
@@ -250,8 +264,9 @@ func TestSuite_JavaOTelSDK(t *testing.T) {
 
 func TestSuite_Rust(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-rust.yml", path.Join(pathOutput, "test-suite-rust.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8090`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8091:8090`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8090`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8091:8090`)
 	require.NoError(t, compose.Up())
 	t.Run("Rust RED metrics", testREDMetricsRustHTTP)
 	require.NoError(t, compose.Close())
@@ -259,8 +274,9 @@ func TestSuite_Rust(t *testing.T) {
 
 func TestSuite_RustSSL(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-rust.yml", path.Join(pathOutput, "test-suite-rust-tls.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8490`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8491:8490`, `TESTSERVER_IMAGE_SUFFIX=-ssl`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8490`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8491:8490`, `TESTSERVER_IMAGE_SUFFIX=-ssl`)
 	require.NoError(t, compose.Up())
 	t.Run("Rust RED metrics", testREDMetricsRustHTTPS)
 	require.NoError(t, compose.Close())
@@ -271,8 +287,9 @@ func TestSuite_RustSSL(t *testing.T) {
 // client to attempt http connection.
 func TestSuite_RustHTTP2(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-rust.yml", path.Join(pathOutput, "test-suite-rust-http2.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8490`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8491:8490`, `TESTSERVER_IMAGE_SUFFIX=-ssl`)
 	require.NoError(t, err)
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8490`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8491:8490`, `TESTSERVER_IMAGE_SUFFIX=-ssl`)
+
 	require.NoError(t, compose.Up())
 	t.Run("Rust RED metrics", testREDMetricsRustHTTP2)
 	require.NoError(t, compose.Close())
@@ -280,8 +297,9 @@ func TestSuite_RustHTTP2(t *testing.T) {
 
 func TestSuite_NodeJS(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-nodejs.yml", path.Join(pathOutput, "test-suite-nodejs.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3030`, `OTEL_EBPF_EXECUTABLE_PATH=`, `NODE_APP=app`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3030`, `OTEL_EBPF_EXECUTABLE_PATH=`, `NODE_APP=app`)
 	require.NoError(t, compose.Up())
 	t.Run("NodeJS RED metrics", testREDMetricsNodeJSHTTP)
 	t.Run("HTTP traces (kprobes)", testHTTPTracesKProbes)
@@ -290,8 +308,9 @@ func TestSuite_NodeJS(t *testing.T) {
 
 func TestSuite_NodeJSTLS(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-nodejs.yml", path.Join(pathOutput, "test-suite-nodejs-tls.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3033`, `OTEL_EBPF_EXECUTABLE_PATH=`, `NODE_APP=app_tls`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3033`, `OTEL_EBPF_EXECUTABLE_PATH=`, `NODE_APP=app_tls`)
 	require.NoError(t, compose.Up())
 	t.Run("NodeJS SSL RED metrics", testREDMetricsNodeJSHTTPS)
 	require.NoError(t, compose.Close())
@@ -299,8 +318,9 @@ func TestSuite_NodeJSTLS(t *testing.T) {
 
 func TestSuite_Rails(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-ruby.yml", path.Join(pathOutput, "test-suite-ruby.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3040,443`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=3041:3040`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3040,443`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=3041:3040`)
 	require.NoError(t, compose.Up())
 	t.Run("Rails RED metrics", testREDMetricsRailsHTTP)
 	t.Run("Rails NGINX traces", testHTTPTracesNestedNginx)
@@ -309,8 +329,9 @@ func TestSuite_Rails(t *testing.T) {
 
 func TestSuite_RailsTLS(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-ruby.yml", path.Join(pathOutput, "test-suite-ruby-tls.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3043`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TESTSERVER_IMAGE_SUFFIX=-ssl`, `TEST_SERVICE_PORTS=3044:3043`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3043`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TESTSERVER_IMAGE_SUFFIX=-ssl`, `TEST_SERVICE_PORTS=3044:3043`)
 	require.NoError(t, compose.Up())
 	t.Run("Rails SSL RED metrics", testREDMetricsRailsHTTPS)
 	require.NoError(t, compose.Close())
@@ -318,8 +339,9 @@ func TestSuite_RailsTLS(t *testing.T) {
 
 func TestSuite_DotNet(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-dotnet.yml", path.Join(pathOutput, "test-suite-dotnet.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=5266`, `OTEL_EBPF_EXECUTABLE_PATH=`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=5266`, `OTEL_EBPF_EXECUTABLE_PATH=`)
 	require.NoError(t, compose.Up())
 	t.Run("DotNet RED metrics", testREDMetricsDotNetHTTP)
 	require.NoError(t, compose.Close())
@@ -329,9 +351,10 @@ func TestSuite_DotNet(t *testing.T) {
 // Issue: https://github.com/grafana/beyla/issues/208
 func TestSuite_DotNetTLS(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-dotnet.yml", path.Join(pathOutput, "test-suite-dotnet-tls.log"))
+	require.NoError(t, err)
+
 	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=7033`, `OTEL_EBPF_EXECUTABLE_PATH=`)
 	// Add these above if you want to get the trace_pipe output in the test logs: `INSTRUMENT_DOCKERFILE_SUFFIX=_dbg`, `INSTRUMENT_COMMAND_SUFFIX=_wrapper.sh`
-	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 	t.Run("DotNet SSL RED metrics", testREDMetricsDotNetHTTPS)
 	require.NoError(t, compose.Close())
@@ -339,8 +362,9 @@ func TestSuite_DotNetTLS(t *testing.T) {
 
 func TestSuite_Python(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python.yml", path.Join(pathOutput, "test-suite-python.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8380`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8380`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8380`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8380`)
 	require.NoError(t, compose.Up())
 	t.Run("Python RED metrics", testREDMetricsPythonHTTP)
 	t.Run("Python RED metrics with timeouts", testREDMetricsTimeoutPythonHTTP)
@@ -349,8 +373,9 @@ func TestSuite_Python(t *testing.T) {
 
 func TestSuite_PythonPostgres(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-postgresql.yml", path.Join(pathOutput, "test-suite-python-postgresql.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, compose.Up())
 	t.Run("Python Postgres tests", testPythonPostgres)
 	require.NoError(t, compose.Close())
@@ -358,8 +383,9 @@ func TestSuite_PythonPostgres(t *testing.T) {
 
 func TestSuite_PythonMySQL(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-mysql.yml", path.Join(pathOutput, "test-suite-python-mysql.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, compose.Up())
 	t.Run("Python MySQL tests", testPythonMySQL)
 	require.NoError(t, compose.Close())
@@ -367,8 +393,9 @@ func TestSuite_PythonMySQL(t *testing.T) {
 
 func TestSuite_PythonRedis(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-redis.yml", path.Join(pathOutput, "test-suite-python-redis.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, compose.Up())
 	t.Run("Python Redis metrics", testREDMetricsPythonRedisOnly)
 	require.NoError(t, compose.Close())
@@ -376,8 +403,9 @@ func TestSuite_PythonRedis(t *testing.T) {
 
 func TestSuite_PythonMongo(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-mongo.yml", path.Join(pathOutput, "test-suite-python-mongo.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, compose.Up())
 	t.Run("Python Mongo metrics", testREDMetricsPythonMongoOnly)
 	require.NoError(t, compose.Close())
@@ -385,8 +413,9 @@ func TestSuite_PythonMongo(t *testing.T) {
 
 func TestSuite_PythonSQLSSL(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-sql-ssl.yml", path.Join(pathOutput, "test-suite-python-sql-ssl.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, compose.Up())
 	t.Run("Python SQL metrics", testREDMetricsPythonSQLSSL)
 	require.NoError(t, compose.Close())
@@ -394,8 +423,9 @@ func TestSuite_PythonSQLSSL(t *testing.T) {
 
 func TestSuite_PythonTLS(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python.yml", path.Join(pathOutput, "test-suite-python-tls.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8380`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8380`, `TESTSERVER_DOCKERFILE_SUFFIX=_tls`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8380`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8380`, `TESTSERVER_DOCKERFILE_SUFFIX=_tls`)
 	require.NoError(t, compose.Up())
 	t.Run("Python SSL RED metrics", testREDMetricsPythonHTTPS)
 	require.NoError(t, compose.Close())
@@ -403,8 +433,9 @@ func TestSuite_PythonTLS(t *testing.T) {
 
 func TestSuite_PythonSelfReference(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-self.yml", path.Join(pathOutput, "test-suite-python-self.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=7771`, `OTEL_EBPF_EXECUTABLE_PATH=`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=7771`, `OTEL_EBPF_EXECUTABLE_PATH=`)
 	require.NoError(t, compose.Up())
 	t.Run("Python Traces with self-references", testHTTPTracesNestedSelfCalls)
 	require.NoError(t, compose.Close())
@@ -412,8 +443,9 @@ func TestSuite_PythonSelfReference(t *testing.T) {
 
 func TestSuite_NodeJSDist(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-nodejs-dist.yml", path.Join(pathOutput, "test-suite-nodejs-dist.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=`, `OTEL_EBPF_EXECUTABLE_PATH=`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=`, `OTEL_EBPF_EXECUTABLE_PATH=`)
 	require.NoError(t, compose.Up())
 	t.Run("NodeJS Distributed Traces with multiple chained calls", testHTTPTracesNestedNodeJSDistCalls)
 	require.NoError(t, compose.Close())
@@ -438,9 +470,9 @@ func TestSuite_DisableKeepAlives(t *testing.T) {
 
 func TestSuite_OverrideServiceName(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-override-svcname.log"))
-	compose.Env = append(compose.Env, "INSTRUMENTER_CONFIG_SUFFIX=-override-svcname")
-
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, "INSTRUMENTER_CONFIG_SUFFIX=-override-svcname")
 	require.NoError(t, compose.Up())
 
 	// Just few simple test cases to verify that the tracers properly override the service name
@@ -463,8 +495,9 @@ func TestSuiteNodeClient(t *testing.T) {
 	}
 
 	compose, err := docker.ComposeSuite("docker-compose-nodeclient.yml", path.Join(pathOutput, "test-suite-nodeclient.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=node`, `NODE_APP=client`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=node`, `NODE_APP=client`)
 	require.NoError(t, compose.Up())
 	t.Run("Node Client RED metrics", func(t *testing.T) {
 		testNodeClientWithMethodAndStatusCode(t, "GET", 301, 80, "0000000000000000")
@@ -479,8 +512,9 @@ func TestSuiteNodeClientTLS(t *testing.T) {
 	}
 
 	compose, err := docker.ComposeSuite("docker-compose-nodeclient.yml", path.Join(pathOutput, "test-suite-nodeclient-tls.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=node`, `NODE_APP=client_tls`)
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=node`, `NODE_APP=client_tls`)
 	require.NoError(t, compose.Up())
 	t.Run("Node Client RED metrics", func(t *testing.T) {
 		testNodeClientWithMethodAndStatusCode(t, "GET", 200, 443, "0000000000000001")
@@ -490,8 +524,9 @@ func TestSuiteNodeClientTLS(t *testing.T) {
 
 func TestSuiteNoRoutes(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-no-routes.log"))
-	compose.Env = append(compose.Env, "INSTRUMENTER_CONFIG_SUFFIX=-no-route")
 	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, "INSTRUMENTER_CONFIG_SUFFIX=-no-route")
 	require.NoError(t, compose.Up())
 	t.Run("RED metrics", testREDMetricsHTTPNoRoute)
 	require.NoError(t, compose.Close())


### PR DESCRIPTION
If `testoutput` directory does not exist before running the integration tests, a segfault can occur.

This PR resolves the issue by ensuring the `err` is checked as soon as possible.

**Before**

```shell
make run-integration-test
### Running integration tests
go clean -testcache
go test -p 1 -failfast -v -timeout 60m -a ./test/integration/... --tags=integration -run "^TestPHP"
=== RUN   TestPHPFM
--- FAIL: TestPHPFM (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x101633eb0]

goroutine 6 [running]:
testing.tRunner.func1.2({0x101b32fe0, 0x102c4c620})
        /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:1734 +0x1ac
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:1737 +0x334
panic({0x101b32fe0?, 0x102c4c620?})
        /opt/homebrew/Cellar/go/1.24.4/libexec/src/runtime/panic.go:792 +0x124
go.opentelemetry.io/obi/test/integration.TestPHPFM(0x14000003dc0)
        /Users/skl/src/opentelemetry-ebpf-instrumentation/test/integration/php_fm_test.go:120 +0x80
testing.tRunner(0x14000003dc0, 0x101da6540)
        /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:1792 +0xe4
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.24.4/libexec/src/testing/testing.go:1851 +0x374
FAIL    go.opentelemetry.io/obi/test/integration        0.456s
FAIL
make: *** [run-integration-test] Error 1
```

**After**

```shell
make run-integration-test
### Running integration tests
go clean -testcache
go test -p 1 -failfast -v -timeout 60m -a ./test/integration/... --tags=integration -run "^TestPHP"
=== RUN   TestPHPFM
    php_fm_test.go:119: 
                Error Trace:    /Users/skl/src/opentelemetry-ebpf-instrumentation/test/integration/php_fm_test.go:119
                Error:          Received unexpected error:
                                open /Users/skl/src/opentelemetry-ebpf-instrumentation/testoutput/test-suite-php-fpm.log: no such file or directory
                Test:           TestPHPFM
--- FAIL: TestPHPFM (0.00s)
FAIL
FAIL    go.opentelemetry.io/obi/test/integration        0.450s
FAIL
make: *** [run-integration-test] Error 1
```