### PR TITLE
postgres: decrease log level to debug

### DIFF
--- a/pkg/components/ebpf/common/sql_detect_postgres.go
+++ b/pkg/components/ebpf/common/sql_detect_postgres.go
@@ -261,7 +261,7 @@ Loop:
 			break
 		}
 		if it.err != nil {
-			slog.Warn("failed to parse Postgres request messages", "error", it.err)
+			slog.Debug("failed to parse Postgres request messages", "error", it.err)
 			return span, errFallback
 		}
 

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -361,7 +361,7 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 				attrs = append(attrs, request.DBCollectionName(table))
 			}
 		}
-		if span.Status == 1 {
+		if span.Status == 1 && span.SQLError != nil {
 			attrs = append(attrs, request.DBResponseStatusCode(strconv.Itoa(int(span.SQLError.Code))))
 			attrs = append(attrs, request.ErrorType(span.SQLError.SQLState))
 		}


### PR DESCRIPTION
This log can happen when the full buffer is truncated and the msg iterator stops earlier than expected:

```
	if len(it.buf) < int(payloadSize) {
		it.err = fmt.Errorf("remaining buffer too short for message data: expected %d bytes, got %d", payloadSize, len(it.buf))
		return
	}
```

so in practice it happens often with default settings.

Decrease the log level to debug as the handler will just fallback