### PR TITLE
Feature/log config json

### DIFF
--- a/cmd/ebpf-instrument/main.go
+++ b/cmd/ebpf-instrument/main.go
@@ -104,9 +104,9 @@ func logConfig(config *obi.Config) {
 		return
 	}
 	switch config.LogConfig {
-	case obi.LogConfigOptionYaml:
+	case obi.LogConfigOptionYAML:
 		configString = string(configYaml)
-	case obi.LogConfigOptionJson:
+	case obi.LogConfigOptionJSON:
 		var configMap map[string]any
 		err = yaml.Unmarshal(configYaml, &configMap)
 		if err != nil {

--- a/cmd/ebpf-instrument/main.go
+++ b/cmd/ebpf-instrument/main.go
@@ -113,12 +113,12 @@ func logConfig(config *obi.Config) {
 			slog.Warn("can't unmarshal yaml configuration to map", "error", err)
 			break
 		}
-		configJson, err := json.Marshal(configMap)
+		configJSON, err := json.Marshal(configMap)
 		if err != nil {
 			slog.Warn("can't marshal configuration to JSON", "error", err)
 			break
 		}
-		configString = string(configJson)
+		configString = string(configJSON)
 	}
 	if configString != "" {
 		slog.Info("Running OpenTelemetry eBPF Instrumentation with configuration")

--- a/cmd/ebpf-instrument/main.go
+++ b/cmd/ebpf-instrument/main.go
@@ -94,30 +94,28 @@ func main() {
 }
 
 func logConfig(config *obi.Config) {
+	if config.LogConfig == "" {
+		return
+	}
 	var configString string
+	configYaml, err := yaml.Marshal(config)
+	if err != nil {
+		slog.Warn("can't marshal configuration to YAML", "error", err)
+		return
+	}
 	switch config.LogConfig {
 	case obi.LogConfigOptionYaml:
-		configYaml, err := yaml.Marshal(config)
-		if err != nil {
-			slog.Warn("can't marshal configuration to YAML", "error", err)
-			break
-		}
 		configString = string(configYaml)
 	case obi.LogConfigOptionJson:
-		rawConfigYaml, err := yaml.Marshal(config)
+		var configMap map[string]any
+		err = yaml.Unmarshal(configYaml, &configMap)
+		if err != nil {
+			slog.Warn("can't unmarshal yaml configuration to map", "error", err)
+			break
+		}
+		configJson, err := json.Marshal(configMap)
 		if err != nil {
 			slog.Warn("can't marshal configuration to JSON", "error", err)
-			break
-		}
-		var m map[string]any
-		err = yaml.Unmarshal(rawConfigYaml, &m)
-		if err != nil {
-			slog.Warn("can't unmarshal configuration to JSON", "error", err)
-			break
-		}
-		configJson, err := json.Marshal(m)
-		if err != nil {
-			slog.Warn("can't unmarshal configuration to JSON", "error", err)
 			break
 		}
 		configString = string(configJson)

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -243,8 +243,8 @@ type Config struct {
 type LogConfigOption string
 
 const (
-	LogConfigOptionYaml = LogConfigOption("yaml")
-	LogConfigOptionJson = LogConfigOption("json")
+	LogConfigOptionYAML = LogConfigOption("yaml")
+	LogConfigOptionJSON = LogConfigOption("json")
 )
 
 // Attributes configures the decoration of some extra attributes that will be

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -235,10 +235,17 @@ type Config struct {
 	InternalMetrics  imetrics.Config `yaml:"internal_metrics"`
 
 	// LogConfig enables the logging of the configuration on startup.
-	LogConfig bool `yaml:"log_config" env:"OTEL_EBPF_LOG_CONFIG"`
+	LogConfig LogConfigOption `yaml:"log_config" env:"OTEL_EBPF_LOG_CONFIG"`
 
 	NodeJS NodeJSConfig `yaml:"nodejs"`
 }
+
+type LogConfigOption string
+
+const (
+	LogConfigOptionYaml = LogConfigOption("yaml")
+	LogConfigOptionJson = LogConfigOption("json")
+)
 
 // Attributes configures the decoration of some extra attributes that will be
 // added to each span


### PR DESCRIPTION
adding an option to log the config as json instead of yaml,
many log shippers collect logs 1 row at a time, and logging the yaml config is not visible in the final logging system, logging it as json solves this, even though we can't copy paste the config and have obi read it (theoretically we can read json configs if we want, based on file extension) its still valuable to see the config

this breaks the config of LOG_CONFIG which was a bool and now an enum, but it probably wasn't used by anyone besides us so it should be fine


looks like:
```json
{"attributes":{"extra_group_attributes":{},"host_id":{"fetch_timeout":"500ms","override":""},"instance_id":{"dns":true,"override_hostname":""},"kubernetes":{"cluster_name":"","disable_informers":[],"drop_external":false,"enable":"autodetect","informers_resync_period":"30m0s","informers_sync_timeout":"30s","kubeconfig_path":"","meta_cache_address":"","meta_restrict_local_node":false,"meta_source_labels":{"service_name":"","service_namespace":""},"resource_labels":{"service.name":["app.kubernetes.io/name"],"service.namespace":["app.kubernetes.io/part-of"],"service.version":["app.kubernetes.io/version"]},"service_name_template":""},"select":{}},"autotargetexe":"","channel_buffer_len":10,"discovery":{"bpf_pid_filter_off":false,"default_exclude_instrument":[{"containers_only":false,"exe_path":"{*beyla,*alloy,*ebpf-instrument,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*}","exports":null,"k8s_pod_annotations":{},"k8s_pod_labels":{},"name":"","namespace":"","open_ports":"","sampler":null},{"containers_only":false,"exe_path":"","exports":null,"k8s_namespace":"{kube-system,kube-node-lease,local-path-storage,grafana-alloy,cert-manager,monitoring,gke-connect,gke-gmp-system,gke-managed-cim,gke-managed-filestorecsi,gke-managed-metrics-server,gke-managed-system,gke-system,gke-managed-volumepopulator,gatekeeper-system}","k8s_pod_annotations":{},"k8s_pod_labels":{},"name":"","namespace":"","open_ports":"","sampler":null}],"default_exclude_services":[{"containers_only":false,"exe_path":"(?:^|/)(beyla$|alloy$|otelcol[^/]*$)","exe_path_regexp":"","exports":null,"k8s_pod_annotations":{},"k8s_pod_labels":{},"name":"","namespace":"","open_ports":"","sampler":null},{"containers_only":false,"exe_path":"","exe_path_regexp":"","exports":null,"k8s_namespace":"^kube-system$|^kube-node-lease$|^local-path-storage$|^grafana-alloy$|^cert-manager$|^monitoring$|^gke-connect$|^gke-gmp-system$|^gke-managed-cim$|^gke-managed-filestorecsi$|^gke-managed-metrics-server$|^gke-managed-system$|^gke-system$|^gke-managed-volumepopulator$|^gatekeeper-system","k8s_pod_annotations":{},"k8s_pod_labels":{},"name":"","namespace":"","open_ports":"","sampler":null}],"exclude_instrument":[],"exclude_otel_instrumented_services":true,"exclude_otel_instrumented_services_span_metrics":false,"exclude_services":[],"instrument":[],"min_process_age":"5s","poll_interval":"0s","services":[],"skip_go_specific_tracers":false},"ebpf":{"batch_length":100,"batch_timeout":"1s","bpf_debug":true,"buffer_sizes":{"mysql":1024,"postgres":0},"context_propagation":"all","disable_black_box_cp":false,"enable_context_propagation":false,"heuristic_sql_detect":false,"high_request_volume":false,"http_request_timeout":"0s","instrument_gpu":false,"mongo_requests_cache_size":1024,"mysql_prepared_statements_cache_size":1024,"override_bpfloop_enabled":false,"postgres_prepared_statements_cache_size":1024,"protocol_debug_print":false,"redis_db_cache":{"enabled":true,"max_size":1000},"track_request_headers":true,"traffic_control_backend":"auto","use_otel_sdk_for_java":false,"wakeup_len":1},"enforce_sys_caps":false,"executable_path":"","filter":{"application":{},"network":{}},"internal_metrics":{"exporter":"otel","prometheus":{"path":"/internal/metrics"}},"log_config":"json","log_level":"DEBUG","name_resolver":{"cache_expiry":"5m0s","cache_len":1024,"sources":["k8s"]},"network":{"agent_ip":"","agent_ip_iface":"external","agent_ip_type":"any","cache_active_timeout":"5s","cache_max_flows":5000,"cidrs":[],"deduper":"first_come","deduper_fc_ttl":"0s","direction":"both","enable":false,"exclude_interfaces":["lo"],"exclude_protocols":[],"interfaces":[],"listen_interfaces":"watch","listen_poll_period":"10s","print_flows":false,"protocols":[],"reverse_dns":{"cache_expiry":"1h0m0s","cache_len":256,"type":"none"},"sampling":0,"source":"socket_filter"},"nodejs":{"enabled":true},"open_port":"9092,8080,6379","otel_metrics_export":{"allow_service_graph_self_references":false,"buckets":{"duration_histogram":[0,0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1,2.5,5,7.5,10],"request_size_histogram":[0,32,64,128,256,512,1024,2048,4096,8192],"response_size_histogram":[0,32,64,128,256,512,1024,2048,4096,8192]},"endpoint":"***","features":["application"],"histogram_aggregation":"explicit_bucket_histogram","insecure_skip_verify":false,"instrumentations":["*"],"interval":"0s","otel_sdk_log_level":"","protocol":"","reporters_cache_len":256,"ttl":"5m0s"},"otel_traces_export":{"backoff_initial_interval":"0s","backoff_max_elapsed_time":"0s","backoff_max_interval":"0s","batch_timeout":"0s","endpoint":"***","insecure_skip_verify":false,"instrumentations":["*"],"max_queue_size":4096,"otel_sdk_log_level":"","protocol":"","reporters_cache_len":256,"sampler":{"arg":"","name":""}},"profile_port":0,"prometheus_export":{"allow_service_graph_self_references":false,"buckets":{"duration_histogram":[0,0.005,0.01,0.025,0.05,0.075,0.1,0.25,0.5,0.75,1,2.5,5,7.5,10],"request_size_histogram":[0,32,64,128,256,512,1024,2048,4096,8192],"response_size_histogram":[0,32,64,128,256,512,1024,2048,4096,8192]},"disable_build_info":false,"extra_resource_attributes":[],"features":["application"],"instrumentations":["*"],"path":"/metrics","port":0,"service_cache_size":10000,"ttl":"5m0s"},"routes":{"ignore_mode":"","ignored_patterns":[],"patterns":[],"unmatched":"heuristic","wildcard_char":"*"},"service_name":"","service_namespace":"","shutdown_timeout":"10s","trace_printer":"json_indent"}

```