### PR TITLE
fix: Prometheus metrics export is missing the SDK version in target_info

### DIFF
--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -84,6 +84,7 @@ const (
 	sourceKey            = "source"
 	telemetryLanguageKey = "telemetry_sdk_language"
 	telemetrySDKKey      = "telemetry_sdk_name"
+	telemetryVersionKey  = "telemetry_sdk_version"
 
 	clientKey          = "client"
 	clientNamespaceKey = "client_service_namespace"
@@ -1024,6 +1025,7 @@ func labelNamesTargetInfo(kubeEnabled bool, extraMetadataLabelNames []attr.Name)
 		serviceJobKey,
 		telemetryLanguageKey,
 		telemetrySDKKey,
+		telemetryVersionKey,
 		sourceKey,
 		osTypeKey,
 	}


### PR DESCRIPTION
Fixes - [issue](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/218)

Added telemetryVersionKey in labelNamesTargetInfo for `telemetry.sdk.version` to be in the target_info while metrics export