### PR TITLE
fix(ci): docker rm requires at least 1 argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,10 +254,20 @@ cleanup-integration-test: $(KIND)
 	@echo "### Removing integration test clusters"
 	$(KIND) delete cluster -n test-kind-cluster || true
 	@echo "### Removing docker containers and images"
-	$(eval CONTAINERS := $(shell $(OCI_BIN) ps --format '{{.Names}}' | grep 'integration-'))
-	$(if $(strip $(CONTAINERS)),$(OCI_BIN) rm -f $$CONTAINERS,@echo "No integration test containers to remove")
-	$(eval IMAGES := $(shell $(OCI_BIN) images --format '{{.Repository}}:{{.Tag}}' | grep 'hatest-'))
-	$(if $(strip $(CONTAINERS)),$(OCI_BIN) rmi -f $$IMAGES,@echo "No integration test images to remove")
+	@CONTAINERS=$$($(OCI_BIN) ps --format '{{.Names}}' | grep 'integration-' || true); \
+	if [ -n "$$CONTAINERS" ]; then \
+		echo "Removing containers: $$CONTAINERS"; \
+		$(OCI_BIN) rm -f $$CONTAINERS; \
+	else \
+		echo "No integration test containers to remove"; \
+	fi
+	@IMAGES=$$($(OCI_BIN) images --format '{{.Repository}}:{{.Tag}}' | grep 'hatest-' || true); \
+	if [ -n "$$IMAGES" ]; then \
+		echo "Removing images: $$IMAGES"; \
+		$(OCI_BIN) rmi -f $$IMAGES; \
+	else \
+		echo "No integration test images to remove"; \
+	fi
 
 .PHONY: run-integration-test
 run-integration-test:


### PR DESCRIPTION
I was getting an error with the `cleanup-integration-test` Makefile target locally, I noticed two things:

1. `$CONTAINERS` was checked twice, and `$IMAGES` was missing a check
2. The Makefile `eval` didn't work on my laptop, ported logic to shell scripting instead to hopefully be more compatible

Also added `|| true` to the end of the `grep` command to prevent a non-zero exit code when no results are found.

```shell
### Removing docker containers and images
docker rm -f $CONTAINERS
docker: 'docker rm' requires at least 1 argument

Usage:  docker rm [OPTIONS] CONTAINER [CONTAINER...]

See 'docker rm --help' for more information
make[1]: *** [cleanup-integration-test] Error 1
make: *** [prepare-integration-test] Error 2
```