### PR TITLE
Delve-enabled debug dockerfile

### DIFF
--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,0 +1,44 @@
+FROM golang:1.25-alpine AS builder
+
+ARG TARGETARCH
+
+ENV GOARCH=$TARGETARCH
+
+WORKDIR /src
+
+# avoids redownloading the whole Go dependencies on each local build
+RUN go env -w GOCACHE=/go-cache
+RUN go env -w GOMODCACHE=/gomod-cache
+
+RUN apk add make git bash
+
+# Copy the go manifests and source
+COPY .git/ .git/
+COPY bpf/ bpf/
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY Makefile Makefile
+COPY LICENSE LICENSE
+COPY NOTICE NOTICE
+COPY third_party_licenses.csv third_party_licenses.csv
+
+# OBI's Makefile doesn't let to override BPF2GO env var: temporary hack until we can
+ENV TOOLS_DIR=/go/bin
+RUN --mount=type=cache,target=/gomod-cache --mount=type=cache,target=/go-cache \
+    go install github.com/go-delve/delve/cmd/dlv@latest
+
+# Prior to using this debug.Dockerfile, you should manually run `make docker-generate`
+RUN --mount=type=cache,target=/gomod-cache --mount=type=cache,target=/go-cache \
+    make debug
+
+FROM alpine:latest
+
+WORKDIR /
+
+COPY --from=builder /go/bin/dlv /
+COPY --from=builder /src/bin/ebpf-instrument /
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+
+ENTRYPOINT [ "/dlv", "--listen=:2345", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/ebpf-instrument" ]


### PR DESCRIPTION
Provides a `debug.Dockerfile` that would allow remote debugging, for example in Kubernetes clusters. To use it:

Build the image normally, and push it to your repository or to your cluster:
```bash
docker build -f debug.Dockerfile -t my/obi:dev .
# e.g. for local debugging in kind:
kind load docker-image my/obi:dev
```

In your kubernetes deployment, use the built image and make the `2345` port available for the OBI:
```yaml
        - name: obi
          image: my/obi:dev
          ports:
            - containerPort: 2345
              hostPort: 2345
              name: delve
```

Port-forward your OBI container port 2345:
```bash
k port-forward obi-3dzq 2345
```

Connect delve to your `localhost:2345` connection and start debugging.

Some IDEs (e.g. Jetbrains) seamessly can connect to your debug pod:

<img width="640" height="244" alt="image" src="https://github.com/user-attachments/assets/8e0d22aa-e614-4587-9b0e-3ac988e68975" />
