### PR TITLE
Add information message when injecting the NodeJS agent

### DIFF
--- a/pkg/components/nodejs/fdextractor.js
+++ b/pkg/components/nodejs/fdextractor.js
@@ -20,6 +20,9 @@ const { AsyncLocalStorage } = require('async_hooks');
 
 const debug_enabled = false;
 
+console.log('OpenTelemetry eBPF Instrumentation has injected instrumentation via the NodeJS debugger');
+console.log('The debugger will be deactivated again and closed');
+
 // ALS store holds only incomingFd
 const als = new AsyncLocalStorage();
 


### PR DESCRIPTION
The NodeJS agent injection is done via the debugger, which, when activated, prints the following message:
```
Debugger listening on ws://127.0.0.1:9229/579497dd-efb5-4813-b8e7-f5f46d7553ca
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
```

Customers sometimes wonder what this is about and why their debug port is being opened, which can come across as a major red flag. This PR introduces an informative message to help contextualise this. The output now looks like this:

```
Debugger listening on ws://127.0.0.1:9229/67ef359d-92ec-419d-8af7-d5c3579d2b36
For help, see: https://nodejs.org/en/docs/inspector
Debugger attached.
OpenTelemetry eBPF Instrumentation has injected instrumentation via the NodeJS debugger
The debugger will be deactivated again and closed
```