### PR TITLE
Fix flaky multiprocess test

### DIFF
--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -672,7 +672,7 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 	// /dist2 -> /jtrace2 -> /traceme -> /gotracemetoo -> /jsonrpc   -> /tracemetoo -> /users
 
 	// Get the first 5 traces
-	var traces []jaeger.Trace
+	// we might need to repeat until the traces include all the inner spans
 	test.Eventually(t, testTimeout, func(t require.TestingT) {
 		resp, err := http.Get(jaegerQueryURL + "?service=rust-service&operation=GET%20%2Fdist")
 		require.NoError(t, err)
@@ -682,14 +682,12 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		var tq jaeger.TracesQuery
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&tq))
-		traces = tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/dist"})
+		traces := tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/dist"})
 		require.LessOrEqual(t, 5, len(traces))
-	}, test.Interval(500*time.Millisecond))
 
-	// Validate each service individually with retries
-	for _, trace := range traces {
-		// Check the information of the rust parent span
-		test.Eventually(t, testTimeout, func(t require.TestingT) {
+		// Validate each service individually with retries
+		for _, trace := range traces {
+			// Check the information of the rust parent span
 			res := trace.FindByOperationName("GET /dist", "server")
 			require.Len(t, res, 1)
 			parent := res[0]
@@ -708,20 +706,18 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 				jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
 			)
 			assert.Empty(t, sd, sd.String())
-		}, test.Interval(100*time.Millisecond))
 
-		// Check the information of the java parent span
-		test.Eventually(t, testTimeout, func(t require.TestingT) {
-			res := trace.FindByOperationName("GET /jtrace", "server")
+			// Check the information of the java parent span
+			res = trace.FindByOperationName("GET /jtrace", "server")
 			require.Len(t, res, 1)
-			parent := res[0]
+			parent = res[0]
 			require.NotEmpty(t, parent.TraceID)
 			require.Equal(t, traceID, parent.TraceID)
 			require.NotEmpty(t, parent.SpanID)
 			// check duration is at least 2us
 			assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
 			// check span attributes
-			sd := parent.Diff(
+			sd = parent.Diff(
 				jaeger.Tag{Key: "http.request.method", Type: "string", Value: "GET"},
 				jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(200)},
 				jaeger.Tag{Key: "url.path", Type: "string", Value: "/jtrace"},
@@ -730,20 +726,18 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 				jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
 			)
 			assert.Empty(t, sd, sd.String())
-		}, test.Interval(100*time.Millisecond))
 
-		// Check the information of the nodejs parent span
-		test.Eventually(t, testTimeout, func(t require.TestingT) {
-			res := trace.FindByOperationName("GET /traceme", "server")
+			// Check the information of the nodejs parent span
+			res = trace.FindByOperationName("GET /traceme", "server")
 			require.Len(t, res, 1)
-			parent := res[0]
+			parent = res[0]
 			require.NotEmpty(t, parent.TraceID)
 			require.Equal(t, traceID, parent.TraceID)
 			require.NotEmpty(t, parent.SpanID)
 			// check duration is at least 2us
 			assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
 			// check span attributes
-			sd := parent.Diff(
+			sd = parent.Diff(
 				jaeger.Tag{Key: "http.request.method", Type: "string", Value: "GET"},
 				jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(200)},
 				jaeger.Tag{Key: "url.path", Type: "string", Value: "/traceme"},
@@ -752,20 +746,18 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 				jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
 			)
 			assert.Empty(t, sd, sd.String())
-		}, test.Interval(100*time.Millisecond))
 
-		// Check the information of the go parent span
-		test.Eventually(t, testTimeout, func(t require.TestingT) {
-			res := trace.FindByOperationName("GET /gotracemetoo", "server")
+			// Check the information of the go parent span
+			res = trace.FindByOperationName("GET /gotracemetoo", "server")
 			require.Len(t, res, 1)
-			parent := res[0]
+			parent = res[0]
 			require.NotEmpty(t, parent.TraceID)
 			traceID = parent.TraceID // we reset the traceID here
 			require.NotEmpty(t, parent.SpanID)
 			// check duration is at least 2us
 			assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
 			// check span attributes
-			sd := parent.Diff(
+			sd = parent.Diff(
 				jaeger.Tag{Key: "http.request.method", Type: "string", Value: "GET"},
 				jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(200)},
 				jaeger.Tag{Key: "url.path", Type: "string", Value: "/gotracemetoo"},
@@ -774,44 +766,42 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 				jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
 			)
 			assert.Empty(t, sd, sd.String())
-		}, test.Interval(100*time.Millisecond))
 
-		/* FIXME flaky
-		// Check the information of the go jsonrpc parent span
-		test.Eventually(t, testTimeout, func(t require.TestingT) {
-			res := trace.FindByOperationName("Arith.T /jsonrpc", "server")
+			/* FIXME flaky
+			// Check the information of the go jsonrpc parent span
+			test.Eventually(t, testTimeout, func(t require.TestingT) {
+				res := trace.FindByOperationName("Arith.T /jsonrpc", "server")
+				require.Len(t, res, 1)
+				parent := res[0]
+				require.NotEmpty(t, parent.TraceID)
+				require.Equal(t, traceID, parent.TraceID)
+				require.NotEmpty(t, parent.SpanID)
+				// check duration is at least 2us
+				assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
+				// check span attributes
+				sd := parent.Diff(
+					jaeger.Tag{Key: "http.request.method", Type: "string", Value: "Arith.T"},
+					jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(200)},
+					jaeger.Tag{Key: "url.path", Type: "string", Value: "/jsonrpc"},
+					jaeger.Tag{Key: "server.port", Type: "int64", Value: float64(8088)},
+					jaeger.Tag{Key: "http.route", Type: "string", Value: "/jsonrpc"},
+					jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
+				)
+				assert.Empty(t, sd, sd.String())
+			}, test.Interval(100*time.Millisecond))
+			*/
+
+			// Check the information of the python parent span
+			res = trace.FindByOperationName("GET /tracemetoo", "server")
 			require.Len(t, res, 1)
-			parent := res[0]
+			parent = res[0]
 			require.NotEmpty(t, parent.TraceID)
 			require.Equal(t, traceID, parent.TraceID)
 			require.NotEmpty(t, parent.SpanID)
 			// check duration is at least 2us
 			assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
 			// check span attributes
-			sd := parent.Diff(
-				jaeger.Tag{Key: "http.request.method", Type: "string", Value: "Arith.T"},
-				jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(200)},
-				jaeger.Tag{Key: "url.path", Type: "string", Value: "/jsonrpc"},
-				jaeger.Tag{Key: "server.port", Type: "int64", Value: float64(8088)},
-				jaeger.Tag{Key: "http.route", Type: "string", Value: "/jsonrpc"},
-				jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
-			)
-			assert.Empty(t, sd, sd.String())
-		}, test.Interval(100*time.Millisecond))
-		*/
-
-		// Check the information of the python parent span
-		test.Eventually(t, testTimeout, func(t require.TestingT) {
-			res := trace.FindByOperationName("GET /tracemetoo", "server")
-			require.Len(t, res, 1)
-			parent := res[0]
-			require.NotEmpty(t, parent.TraceID)
-			require.Equal(t, traceID, parent.TraceID)
-			require.NotEmpty(t, parent.SpanID)
-			// check duration is at least 2us
-			assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
-			// check span attributes
-			sd := parent.Diff(
+			sd = parent.Diff(
 				jaeger.Tag{Key: "http.request.method", Type: "string", Value: "GET"},
 				jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(200)},
 				jaeger.Tag{Key: "url.path", Type: "string", Value: "/tracemetoo"},
@@ -820,20 +810,18 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 				jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
 			)
 			assert.Empty(t, sd, sd.String())
-		}, test.Interval(100*time.Millisecond))
 
-		// Check the information of the rails parent span
-		test.Eventually(t, testTimeout, func(t require.TestingT) {
-			res := trace.FindByOperationName("GET /users", "server")
+			// Check the information of the rails parent span
+			res = trace.FindByOperationName("GET /users", "server")
 			require.Len(t, res, 1)
-			parent := res[0]
+			parent = res[0]
 			require.NotEmpty(t, parent.TraceID)
 			require.Equal(t, traceID, parent.TraceID)
 			require.NotEmpty(t, parent.SpanID)
 			// check duration is at least 2us
 			assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)
 			// check span attributes
-			sd := parent.Diff(
+			sd = parent.Diff(
 				jaeger.Tag{Key: "http.request.method", Type: "string", Value: "GET"},
 				jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(403)}, // something config missing in rails, but 403 is OK :)
 				jaeger.Tag{Key: "url.path", Type: "string", Value: "/users"},
@@ -842,8 +830,8 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 				jaeger.Tag{Key: "span.kind", Type: "string", Value: "server"},
 			)
 			assert.Empty(t, sd, sd.String())
-		}, test.Interval(100*time.Millisecond))
-	}
+		}
+	})
 
 	// test now with a different version of Java thread pool
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
The flaky multiprocess test first gets all the traces containing all the `GET /dist` spans, but later checks for the internal spans, which might not be populated yet when the Jaeger client retrieves the first set of traces.

This PR puts the whole process in an `Eventually` clause, meaning that if e.g. the `GET /jtrace` span is not found, instead of failing the test, we retrieve again all the traces, expecting that the next time they might be correctly populated with all the inner spans.