### PR TITLE
feat(ci): auto-shard integration tests

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -25,28 +25,16 @@ jobs:
           go-version: "1.24"
           cache: false
 
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.12.3
-
-      - run: mkdir -p /home/runner/reports
-
-      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        # zizmor cache-poisoning fix: Only cache reports for non-pull requests or pull requests from the same repository
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        with:
-          path: /home/runner/reports
-          key: read-go-test-reports-${{ github.run_number }}
-          restore-keys: go-test-reports-
+      - name: Generate files
+        run: make docker-generate
 
       - name: build matrix
         id: build-matrix
+        env:
+          PARTITIONS: 6
         run: |
-          (
-            echo -n "matrix="
-            go list -tags integration ./test/integration/... | gotestsum tool ci-matrix --debug \
-              --partitions 5 \
-              --timing-files '/home/runner/reports/*.log'
-          ) >> $GITHUB_OUTPUT
+          echo -n "matrix=" >> $GITHUB_OUTPUT
+          make integration-test-matrix-json >> $GITHUB_OUTPUT
 
   test:
     permissions:
@@ -72,28 +60,35 @@ jobs:
           go-version: "1.24"
           cache: false
 
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.12.3
-
       - name: Generate files
         run: make prereqs docker-generate
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.12.3
+
       - name: Run integration tests
-        timeout-minutes: 60
+        timeout-minutes: 20
         env:
           # zizmor template-injection fixes: pass data as env vars
           MATRIX_ID: ${{ matrix.id }}
           MATRIX_JSON: ${{ toJson(matrix) }}
-          MATRIX_PACKAGES: ${{ matrix.packages }}
+          MATRIX_TEST_PATTERN: ${{ matrix.test_pattern }}
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           echo Partition
           echo "${MATRIX_JSON}"
 
+          if [ -z "${MATRIX_TEST_PATTERN}" ]; then
+            echo "Error: Test pattern is empty for shard $MATRIX_ID"
+            exit 1
+          fi
+
           mkdir -p /home/runner/reports
+
           ~/go/bin/gotestsum -ftestname \
               --jsonfile=/home/runner/reports/test-run-"${RUN_NUMBER}"-"${MATRIX_ID}".log \
-              -- -race -tags=integration ${MATRIX_PACKAGES}
+              -- -race -tags=integration -timeout 15m \
+              -run="^(${MATRIX_TEST_PATTERN})$" ./test/integration/...
 
       - name: Upload test reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/Makefile
+++ b/Makefile
@@ -279,6 +279,43 @@ run-integration-test-arm:
 	go clean -testcache
 	go test -p 1 -failfast -v -timeout 90m -a ./test/integration/... --tags=integration -run "^TestMultiProcess"
 
+.PHONY: integration-test-matrix-json
+integration-test-matrix-json:
+	@bash -c '\
+		set -e; \
+		TEST_NAMES=$$(cd test/integration && go test -tags integration -list . | grep "^Test" | sort); \
+		PARTITIONS=$${PARTITIONS:-5}; \
+		TOTAL_TESTS=$$(echo "$$TEST_NAMES" | wc -l | tr -d " "); \
+		if [ "$$TOTAL_TESTS" -lt 10 ]; then \
+			echo "ERROR: Expected at least 10 tests, but found only $$TOTAL_TESTS" >&2; \
+			echo "Found tests:" >&2; \
+			echo "$$TEST_NAMES" >&2; \
+			exit 1; \
+		fi; \
+		TESTS_PER_SHARD=$$(((TOTAL_TESTS + PARTITIONS - 1) / PARTITIONS)); \
+		echo "Total tests: $$TOTAL_TESTS, Tests per shard: $$TESTS_PER_SHARD" >&2; \
+		MATRIX_JSON="{\"include\":["; \
+		SHARD=0; \
+		FIRST_SHARD=true; \
+		while [ $$SHARD -lt $$PARTITIONS ]; do \
+			START=$$((SHARD * TESTS_PER_SHARD + 1)); \
+			END=$$(((SHARD + 1) * TESTS_PER_SHARD)); \
+			SHARD_TESTS=$$(echo "$$TEST_NAMES" | sed -n "$${START},$${END}p" | tr "\n" "|" | sed "s/|$$//"); \
+			if [ ! -z "$$SHARD_TESTS" ]; then \
+				if [ "$$FIRST_SHARD" = "false" ]; then \
+					MATRIX_JSON+=","; \
+				fi; \
+				FIRST_SHARD=false; \
+				TEST_COUNT=$$(echo "$$SHARD_TESTS" | tr "|" "\n" | wc -l | tr -d " "); \
+				MATRIX_JSON+="{\"id\":$$SHARD,\"description\":\"shard-$$SHARD ($$TEST_COUNT tests)\",\"test_pattern\":\"$$SHARD_TESTS\"}"; \
+				echo "Shard $$SHARD: $$TEST_COUNT tests" >&2; \
+			fi; \
+			SHARD=$$((SHARD + 1)); \
+		done; \
+		MATRIX_JSON+="]}"; \
+		echo "$$MATRIX_JSON"; \
+	'
+
 .PHONY: integration-test
 integration-test: prereqs prepare-integration-test
 	$(MAKE) run-integration-test || (ret=$$?; $(MAKE) cleanup-integration-test && exit $$ret)


### PR DESCRIPTION
Part of a series of PRs speeding up CI, this PR looks at the following workflow:

> Pull request integration tests / test (1.24) (pull_request) - baseline 46 minutes

This PR introduces [gotestsum](https://github.com/gotestyourself/gotestsum):

1. First, I tried the built-in auto-sharding. However, as this is based on entire packages, all the slow tests ended up in a single shard. There were also several Zizmor security issues flagged with caching and restoring the previous test run time artefacts (c29635c00e92d505877c75dfee46058de802f493).
2. Next, I created a new Makefile target to generate the partitions based on the sorted list of test names only, then pass that list to gotestsum (ce1a46b7d35cf91da5801a81e57e488c55a8aabc).

I removed coverage upload for now to reduce complexity and will come back to this in a follow-up PR.

Alternative to:

- #525

---

[Successful run example](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/17401586370?pr=535) - 6 shards - 16m 38s

<img width="1165" height="600" alt="Screenshot 2025-09-02 at 12 24 32" src="https://github.com/user-attachments/assets/0477a94d-1365-474b-a253-f4c0e8e6ee26" />
