### PR TITLE
Move drop_unresolved_ips configuration to the attributes section

### DIFF
--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -55,9 +55,6 @@ type MetricsConfig struct {
 
 	AllowServiceGraphSelfReferences bool `yaml:"allow_service_graph_self_references" env:"OTEL_EBPF_ALLOW_SERVICE_GRAPH_SELF_REFERENCES"`
 
-	// DropUnresolvedIPs drops metrics that contain unresolved IP addresses to reduce cardinality
-	DropUnresolvedIPs bool `yaml:"drop_unresolved_ips" env:"OTEL_EBPF_DROP_UNRESOLVED_IPS"`
-
 	// OTLPEndpointProvider allows overriding the OTLP Endpoint. It needs to return an endpoint and
 	// a boolean indicating if the endpoint is common for both traces and metrics
 	OTLPEndpointProvider func() (string, bool) `yaml:"-" env:"-"`

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -123,9 +123,6 @@ type PrometheusConfig struct {
 	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
 	Instrumentations []string `yaml:"instrumentations" env:"OTEL_EBPF_PROMETHEUS_INSTRUMENTATIONS" envSeparator:","`
 
-	// DropUnresolvedIPs drops metrics that contain unresolved IP addresses to reduce cardinality
-	DropUnresolvedIPs bool `yaml:"drop_unresolved_ips" env:"OTEL_EBPF_PROMETHEUS_DROP_UNRESOLVED_IPS"`
-
 	Buckets otelcfg.Buckets `yaml:"buckets"`
 
 	// TTL is the time since a metric was updated for the last time until it is

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -100,8 +100,7 @@ var DefaultConfig = Config{
 		Instrumentations: []string{
 			instrumentations.InstrumentationALL,
 		},
-		DropUnresolvedIPs: true,
-		TTL:               defaultMetricsTTL,
+		TTL: defaultMetricsTTL,
 	},
 	Traces: otelcfg.TracesConfig{
 		Protocol:          otelcfg.ProtocolUnset,
@@ -121,7 +120,6 @@ var DefaultConfig = Config{
 		},
 		TTL:                         defaultMetricsTTL,
 		SpanMetricsServiceCacheSize: 10000,
-		DropUnresolvedIPs:           true,
 	},
 	TracePrinter: debug.TracePrinterDisabled,
 	InternalMetrics: imetrics.Config{
@@ -144,6 +142,7 @@ var DefaultConfig = Config{
 		HostID: HostIDConfig{
 			FetchTimeout: 500 * time.Millisecond,
 		},
+		DropMetricsUnresolvedIPs: true,
 	},
 	Routes: &transform.RoutesConfig{
 		Unmatch:      transform.UnmatchDefault,
@@ -257,6 +256,8 @@ type Attributes struct {
 	Select               attributes.Selection          `yaml:"select"`
 	HostID               HostIDConfig                  `yaml:"host_id"`
 	ExtraGroupAttributes map[string][]attr.Name        `yaml:"extra_group_attributes"`
+	// DropMetricsUnresolvedIPs drops metrics that contain unresolved IP addresses to reduce cardinality
+	DropMetricsUnresolvedIPs bool `yaml:"drop_metric_unresolved_ips" env:"OTEL_EBPF_DROP_METRIC_UNRESOLVED_IPS"`
 }
 
 type HostIDConfig struct {

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -50,14 +50,13 @@ otel_metrics_export:
   buckets:
     duration_histogram: [0, 1, 2]
   histogram_aggregation: base2_exponential_bucket_histogram
-  drop_unresolved_ips: false
 prometheus_export:
   ttl: 1s
   buckets:
     request_size_histogram: [0, 10, 20, 22]
     response_size_histogram: [0, 10, 20, 22]
-  drop_unresolved_ips: false
 attributes:
+  drop_metric_unresolved_ips: false
   kubernetes:
     kubeconfig_path: /foo/bar
     enable: true
@@ -159,7 +158,6 @@ discovery:
 			},
 			HistogramAggregation: "base2_exponential_bucket_histogram",
 			TTL:                  5 * time.Minute,
-			DropUnresolvedIPs:    false,
 		},
 		Traces: otelcfg.TracesConfig{
 			Protocol:          otelcfg.ProtocolUnset,
@@ -184,7 +182,6 @@ discovery:
 				RequestSizeHistogram:  []float64{0, 10, 20, 22},
 				ResponseSizeHistogram: []float64{0, 10, 20, 22},
 			},
-			DropUnresolvedIPs: false,
 		},
 		InternalMetrics: imetrics.Config{
 			Exporter: imetrics.InternalMetricsExporterDisabled,

--- a/pkg/transform/ips_filter.go
+++ b/pkg/transform/ips_filter.go
@@ -9,14 +9,13 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/obi/pkg/app/request"
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 )
 
-func IPsFilter(mc *otelcfg.MetricsConfig, input, output *msg.Queue[[]request.Span]) swarm.InstanceFunc {
+func IPsFilter(dropUnresolvedIPs bool, input, output *msg.Queue[[]request.Span]) swarm.InstanceFunc {
 	return func(_ context.Context) (swarm.RunFunc, error) {
-		if !mc.DropUnresolvedIPs {
+		if !dropUnresolvedIPs {
 			return swarm.Bypass(input, output)
 		}
 		in := input.Subscribe()

--- a/pkg/transform/ips_filter_test.go
+++ b/pkg/transform/ips_filter_test.go
@@ -12,7 +12,6 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/app/request"
 	"go.opentelemetry.io/obi/pkg/components/svc"
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 
@@ -122,7 +121,7 @@ func TestIPsFilter(t *testing.T) {
 				},
 			},
 			dropUnresolvedIPs: true,
-			description:       "IPv6 addresses should be filtered out when DropUnresolvedIPs is true",
+			description:       "IPv6 addresses should be filtered out when DropMetricsUnresolvedIPs is true",
 		},
 	}
 
@@ -132,13 +131,8 @@ func TestIPsFilter(t *testing.T) {
 			input := msg.NewQueue[[]request.Span]()
 			output := msg.NewQueue[[]request.Span]()
 
-			// Create metrics config
-			cfg := &otelcfg.MetricsConfig{
-				DropUnresolvedIPs: tt.dropUnresolvedIPs,
-			}
-
 			// Create the IP filter instance
-			instanceFunc := IPsFilter(cfg, input, output)
+			instanceFunc := IPsFilter(tt.dropUnresolvedIPs, input, output)
 			runFunc, err := instanceFunc(context.Background())
 			require.NoError(t, err)
 

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -58,8 +58,7 @@ services:
       OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT: 8999
       OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
       OTEL_EBPF_HOSTNAME: "beyla"
-      OTEL_EBPF_DROP_UNRESOLVED_IPS: "false"
-      OTEL_EBPF_PROMETHEUS_DROP_UNRESOLVED_IPS: "false"
+      OTEL_EBPF_DROP_METRIC_UNRESOLVED_IPS: "false"
     ports:
       - "8999:8999" # Prometheus scrape port, if enabled via config
 


### PR DESCRIPTION
This property was defined in both OTEL and Prometheus metrics section but actually only the OTEL definition was used.

Since this is a global attribute, independent from the exporter, I have moved it to the attributes section and renamed it to `drop_metric_unresolved_ips`