### PR TITLE
chore(ci): restore coverage reports for integration tests

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -105,3 +105,11 @@ jobs:
           path: |
             testoutput/*.log
             testoutput/kind
+
+      - name: Report coverage
+        uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./testoutput/itest-covdata.txt
+          flags: integration-test


### PR DESCRIPTION
Apparently, codecov supports automatically merging reports:

- https://docs.codecov.com/docs/merging-reports

So this should be as easy as each integration test shard uploading it's own coverage report to the same tag.