### PR TITLE
ci: shard k8s integration tests

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   test-matrix:
+    name: "Build integration matrix"
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
@@ -31,20 +32,21 @@ jobs:
       - name: build matrix
         id: build-matrix
         env:
-          PARTITIONS: 6
+          PARTITIONS: 10
+          TEST_TAGS: integration
         run: |
           echo -n "matrix=" >> $GITHUB_OUTPUT
           make integration-test-matrix-json >> $GITHUB_OUTPUT
 
   test:
+    name: ${{ matrix.description }}
+    needs: test-matrix
     permissions:
       # Required for codecov
       checks: write
       pull-requests: write
       # Required for uploading artifacts
       actions: write
-    name: "test ${{ matrix.description }}"
-    needs: test-matrix
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -66,14 +68,18 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.12.3
 
+      - name: Check disk usage before tests
+        run: df -h
+
       - name: Run integration tests
-        timeout-minutes: 30
+        timeout-minutes: 35
         env:
           # zizmor template-injection fixes: pass data as env vars
           MATRIX_ID: ${{ matrix.id }}
           MATRIX_JSON: ${{ toJson(matrix) }}
           MATRIX_TEST_PATTERN: ${{ matrix.test_pattern }}
           RUN_NUMBER: ${{ github.run_number }}
+          TEST_TAGS: integration
         run: |
           echo Partition
           echo "${MATRIX_JSON}"
@@ -87,17 +93,29 @@ jobs:
 
           ~/go/bin/gotestsum -ftestname \
               --jsonfile=/home/runner/reports/test-run-"${RUN_NUMBER}"-"${MATRIX_ID}".log \
-              -- -race -tags=integration -timeout 25m \
+              -- -race -tags=${TEST_TAGS} -timeout 30m \
               -run="^(${MATRIX_TEST_PATTERN})$" ./test/integration/...
 
+      - name: Process coverage data
+        run: make itest-coverage-data
+
+      - name: Report coverage
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./testoutput/itest-covdata.txt
+          flags: integration-test
+
       - name: Upload test reports
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: go-test-reports-${{ github.run_number }}-${{ matrix.id }}
           path: /home/runner/reports/*.log
           retention-days: 5
 
-      - name: Upload integration test logs
+      - name: Upload test logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
@@ -106,10 +124,6 @@ jobs:
             testoutput/*.log
             testoutput/kind
 
-      - name: Report coverage
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: ./testoutput/itest-covdata.txt
-          flags: integration-test-${{ github.run_number }}-${{ matrix.id }}
+      - name: Check final disk usage
+        if: always()
+        run: df -h

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -2,54 +2,116 @@ name: Pull request K8s integration tests
 
 on:
   push:
-    branches: [ 'main', 'release-*' ]
+    branches: ["main", "release-*"]
   pull_request:
-    branches: [ 'main', 'release-*' ]
+    branches: ["main", "release-*"]
 
 permissions:
   contents: read
 
 jobs:
+  test-matrix:
+    name: "Build integration_k8s matrix"
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: build matrix
+        id: build-matrix
+        run: |
+          echo -n "matrix=" >> $GITHUB_OUTPUT
+          make k8s-integration-test-matrix-json >> $GITHUB_OUTPUT
+
   test:
+    name: ${{ matrix.description }}
+    needs: test-matrix
     permissions:
       # Required for codecov
       checks: write
       pull-requests: write
       # Required for uploading artifacts
       actions: write
-    name: test
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        go: [ '1.25' ]
+      fail-fast: true
+      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          cache: 'false'
-          go-version: ${{ matrix.go }}
-      - name: Clean up disk space
-        run: |
-          docker system prune -af
-          docker volume prune -f
+          go-version: "1.25"
+          cache: false
+
+      - name: Generate files
+        run: make prereqs docker-generate
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.12.3
+
+      - name: Check disk usage before tests
+        run: df -h
+
       - name: Run integration tests
-        run: make docker-generate integration-test-k8s
-        timeout-minutes: 60
-      - name: Upload integration test logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: always()
-        with:
-          name: K8s test Logs
-          path: |
-            testoutput/*.log
-            testoutput/kind
+        timeout-minutes: 35
+        env:
+          # zizmor template-injection fixes: pass data as env vars
+          MATRIX_ID: ${{ matrix.id }}
+          MATRIX_JSON: ${{ toJson(matrix) }}
+          MATRIX_TEST_PATTERN: ${{ matrix.test_pattern }}
+          RUN_NUMBER: ${{ github.run_number }}
+          TEST_TAGS: integration_k8s
+        run: |
+          echo Partition
+          echo "${MATRIX_JSON}"
+
+          if [ -z "${MATRIX_TEST_PATTERN}" ]; then
+            echo "Error: Test pattern is empty for shard $MATRIX_ID"
+            exit 1
+          fi
+
+          mkdir -p /home/runner/reports
+
+          ~/go/bin/gotestsum -ftestname \
+              --jsonfile=/home/runner/reports/test-run-"${RUN_NUMBER}"-"${MATRIX_ID}".log \
+              -- -race -tags=${TEST_TAGS} -timeout 30m \
+              ${MATRIX_TEST_PATTERN}
+
+      - name: Process coverage data
+        run: make itest-coverage-data
+
       - name: Report coverage
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./testoutput/itest-covdata.txt
-          flags: k8s-integration-test-${{ github.run_number }}-${{ matrix.id }}
+          flags: k8s-integration-test
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: go-test-reports-${{ matrix.description }}-${{ github.run_number }}
+          path: /home/runner/reports/*.log
+          retention-days: 5
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: always()
+        with:
+          name: go-test-logs-${{ matrix.description }}-${{ github.run_number }}
+          path: |
+            testoutput/*.log
+            testoutput/kind
+
+      - name: Check final disk usage
+        if: always()
+        run: df -h

--- a/Makefile
+++ b/Makefile
@@ -281,40 +281,11 @@ run-integration-test-arm:
 
 .PHONY: integration-test-matrix-json
 integration-test-matrix-json:
-	@bash -c '\
-		set -e; \
-		TEST_NAMES=$$(cd test/integration && go test -tags integration -list . | grep "^Test" | sort); \
-		PARTITIONS=$${PARTITIONS:-5}; \
-		TOTAL_TESTS=$$(echo "$$TEST_NAMES" | wc -l | tr -d " "); \
-		if [ "$$TOTAL_TESTS" -lt 10 ]; then \
-			echo "ERROR: Expected at least 10 tests, but found only $$TOTAL_TESTS" >&2; \
-			echo "Found tests:" >&2; \
-			echo "$$TEST_NAMES" >&2; \
-			exit 1; \
-		fi; \
-		TESTS_PER_SHARD=$$(((TOTAL_TESTS + PARTITIONS - 1) / PARTITIONS)); \
-		echo "Total tests: $$TOTAL_TESTS, Tests per shard: $$TESTS_PER_SHARD" >&2; \
-		MATRIX_JSON="{\"include\":["; \
-		SHARD=0; \
-		FIRST_SHARD=true; \
-		while [ $$SHARD -lt $$PARTITIONS ]; do \
-			START=$$((SHARD * TESTS_PER_SHARD + 1)); \
-			END=$$(((SHARD + 1) * TESTS_PER_SHARD)); \
-			SHARD_TESTS=$$(echo "$$TEST_NAMES" | sed -n "$${START},$${END}p" | tr "\n" "|" | sed "s/|$$//"); \
-			if [ ! -z "$$SHARD_TESTS" ]; then \
-				if [ "$$FIRST_SHARD" = "false" ]; then \
-					MATRIX_JSON+=","; \
-				fi; \
-				FIRST_SHARD=false; \
-				TEST_COUNT=$$(echo "$$SHARD_TESTS" | tr "|" "\n" | wc -l | tr -d " "); \
-				MATRIX_JSON+="{\"id\":$$SHARD,\"description\":\"shard-$$SHARD ($$TEST_COUNT tests)\",\"test_pattern\":\"$$SHARD_TESTS\"}"; \
-				echo "Shard $$SHARD: $$TEST_COUNT tests" >&2; \
-			fi; \
-			SHARD=$$((SHARD + 1)); \
-		done; \
-		MATRIX_JSON+="]}"; \
-		echo "$$MATRIX_JSON"; \
-	'
+	@./scripts/generate-integration-matrix.sh "$${TEST_TAGS:-integration}" test/integration "$${PARTITIONS:-5}"
+
+.PHONY: k8s-integration-test-matrix-json
+k8s-integration-test-matrix-json:
+	@./scripts/generate-k8s-matrix.sh
 
 .PHONY: integration-test
 integration-test: prereqs prepare-integration-test

--- a/scripts/generate-integration-matrix.sh
+++ b/scripts/generate-integration-matrix.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Generate standard test matrix with configurable partitions
+# Usage: ./scripts/generate-integration-matrix.sh [test_tags] [search_dir] [partitions]
+
+set -e
+
+TEST_TAGS="${1:-integration}"
+SEARCH_DIR="${2:-test/integration}"
+PARTITIONS="${3:-5}"
+
+# Get test names (embedded list-tests.sh logic)
+if [ -n "$TEST_TAGS" ]; then
+    # Find files with the specific build tag (exact match with word boundaries)
+    FILES=$(find "$SEARCH_DIR" -type f -name "*_test.go" -exec grep -l "//go:build.*\b$TEST_TAGS\b" {} \;)
+else
+    # Find all test files
+    FILES=$(find "$SEARCH_DIR" -type f -name "*_test.go")
+fi
+
+if [ -z "$FILES" ]; then
+    echo "No test files found" >&2
+    exit 1
+fi
+
+# Extract test function names from the files and randomize order
+TEST_NAMES=$(grep -h "^func Test" $FILES | sed 's/^func \([^(]*\).*/\1/' | sort -u | sort -R)
+
+if [ -z "$TEST_NAMES" ]; then
+    echo "ERROR: No tests found for tags '$TEST_TAGS' in '$SEARCH_DIR'" >&2
+    exit 1
+fi
+
+TOTAL_TESTS=$(echo "$TEST_NAMES" | wc -l | tr -d " ")
+
+if [ "$TOTAL_TESTS" -lt 10 ]; then
+    echo "ERROR: Expected at least 10 tests, but found only $TOTAL_TESTS" >&2
+    echo "Found tests:" >&2
+    echo "$TEST_NAMES" >&2
+    exit 1
+fi
+
+BASE_TESTS_PER_SHARD=$((TOTAL_TESTS / PARTITIONS))
+EXTRA_TESTS=$((TOTAL_TESTS % PARTITIONS))
+
+echo "Total tests: $TOTAL_TESTS, Base tests per shard: $BASE_TESTS_PER_SHARD, Extra tests: $EXTRA_TESTS" >&2
+
+# Generate matrix JSON
+MATRIX_JSON='{"include":['
+SHARD=0
+FIRST_SHARD=true
+CURRENT_START=1
+
+while [ $SHARD -lt $PARTITIONS ]; do
+    TESTS_IN_THIS_SHARD=$BASE_TESTS_PER_SHARD
+    if [ $SHARD -lt $EXTRA_TESTS ]; then
+        TESTS_IN_THIS_SHARD=$((TESTS_IN_THIS_SHARD + 1))
+    fi
+    
+    START=$CURRENT_START
+    END=$((CURRENT_START + TESTS_IN_THIS_SHARD - 1))
+    SHARD_TESTS=$(echo "$TEST_NAMES" | sed -n "${START},${END}p" | tr "\n" "|" | sed "s/|$//")
+    
+    if [ ! -z "$SHARD_TESTS" ]; then
+        if [ "$FIRST_SHARD" = "false" ]; then
+            MATRIX_JSON+=","
+        fi
+        FIRST_SHARD=false
+        
+        TEST_COUNT=$(echo "$SHARD_TESTS" | tr "|" "\n" | wc -l | tr -d " ")
+        MATRIX_JSON+="{\"id\":$SHARD,\"description\":\"shard-$SHARD ($TEST_COUNT tests)\",\"test_pattern\":\"$SHARD_TESTS\"}"
+        
+        echo "Shard $SHARD: $TEST_COUNT tests" >&2
+    fi
+    
+    CURRENT_START=$((END + 1))
+    SHARD=$((SHARD + 1))
+done
+
+MATRIX_JSON+=']}'
+echo "$MATRIX_JSON"

--- a/scripts/generate-k8s-matrix.sh
+++ b/scripts/generate-k8s-matrix.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Generate simple k8s test matrix - one shard per test package directory
+# Usage: ./scripts/generate-simple-k8s-matrix.sh
+
+set -e
+
+# Find all k8s test package directories (excluding common)
+TEST_DIRS=$(find test/integration/k8s -name "*main_test.go" | grep -v common | sort | xargs dirname | xargs basename -a)
+
+if [ -z "$TEST_DIRS" ]; then
+    echo "ERROR: No k8s test directories found" >&2
+    exit 1
+fi
+
+# Count directories
+DIR_COUNT=$(echo "$TEST_DIRS" | wc -l | tr -d ' ')
+echo "Total k8s test packages: $DIR_COUNT" >&2
+
+# Generate matrix JSON
+MATRIX_JSON='{"include":['
+FIRST=true
+SHARD_ID=0
+
+for dir in $TEST_DIRS; do
+    if [ "$FIRST" = "false" ]; then
+        MATRIX_JSON+=","
+    fi
+    FIRST=false
+    
+    # Each shard runs all tests in its package directory
+    MATRIX_JSON+="{\"id\":$SHARD_ID,\"description\":\"$dir\",\"test_pattern\":\"./test/integration/k8s/$dir/...\"}"
+    
+    echo "Shard $SHARD_ID: $dir" >&2
+    
+    SHARD_ID=$((SHARD_ID + 1))
+done
+
+MATRIX_JSON+=']}'
+echo "$MATRIX_JSON"

--- a/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
+++ b/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
@@ -41,7 +41,7 @@ func TestMain(m *testing.M) {
 		os.Exit(-1)
 	}
 
-	cluster = kube.NewKind("test-kind-cluster-otel-multi",
+	cluster = kube.NewKind("test-kind-cluster-restrict-local-node",
 		kube.KindConfig(testpath.Manifests+"/00-kind-multi-node.yml"),
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("httppinger:dev"),


### PR DESCRIPTION
This PR builds on:

- #535

To reduce the CI execution time for the k8s integration tests, a different approach was required from the existing integration test sharding:

1. Shard per Kind cluster (instead of evenly distributing tests using multiple Kind clusters across various shards)
   - Improved process isolation
   - Faster test execution
   - Avoids cluster name and host port conflicts
   - Lower disk space usage per shard
2. Use `gotestsum` to make CI action logs easier to read
3. Also fixed coverage reporting for both k8s and non-k8s integration tests

Overall k8s integration execution time went down **from 45m to 10m**:

<img width="784" height="727" alt="Screenshot 2025-09-30 at 13 03 18" src="https://github.com/user-attachments/assets/f6b4d075-7e5a-42e1-84f5-1c0fb58247a4" />


# Research notes

## Resuable workflows must be in the main branch

Apparently, GitHub looks in the main branch for reusable workflow files. This is no longer applicable to this PR. I removed the shared workflow I was developing for the k8s and non-k8s integration tests, as they diverged.

## `go test -list` executes code

- https://github.com/golang/go/issues/25339

The `go test -list` command didn't translate well when using the `integration_k8s` build tag. It turns out that due to the issue above, the `TestMain` functions are executed - which in the case of the Kubernetes tests, causes Docker containers to spin up. To avoid this, I created a new shell script which lists the tests using `find` and `grep`.

## Multiple kind clusters cause conflicts

There were several issues running multiple k8s integration tests on the same shard:

1. Each package creates its own Kind cluster (cluster name and port conflicts)
7. Each test builds its own images (ran out of disk space)

The solution is to create one shard per Kind cluster, and ensure each package is 1:1 running in a unique Kind cluster. This means we end up with 1 shard per package, each with its own Kind cluster (avoiding port conflicts and disk space issues).

## Randomised ordering of (non-k8s) integration tests improve performance

Added `sort -R` and increased to 10 shards to reduce non-k8s integration test run time:

<img width="784" height="727" alt="Screenshot 2025-09-30 at 13 43 23" src="https://github.com/user-attachments/assets/8c0bc2cc-b8a7-4cfd-ba10-395c2e28c2ca" />
