### PR TITLE
Fix Queue mechanism

### DIFF
--- a/pkg/components/appolly/appolly.go
+++ b/pkg/components/appolly/appolly.go
@@ -64,7 +64,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *obi.Config) (
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(config.ChannelBufferLen))
 
 	newEventQueue := func() *msg.Queue[exec.ProcessEvent] {
-		return msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(config.ChannelBufferLen), msg.NotBlockIfNoSubscribers())
+		return msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(config.ChannelBufferLen))
 	}
 
 	swi := &swarm.Instancer{}

--- a/pkg/components/netolly/flow/decorator_test.go
+++ b/pkg/components/netolly/flow/decorator_test.go
@@ -26,6 +26,7 @@ func TestDecoration(t *testing.T) {
 	// Given a flow Decorator node
 	in := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
 	out := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+	outCh := out.Subscribe()
 	go Decorate(net.IPv4(3, 3, 3, 3), func(n int) string {
 		return fmt.Sprintf("eth%d", n)
 	}, in, out)(t.Context())
@@ -47,7 +48,7 @@ func TestDecoration(t *testing.T) {
 
 	// THEN it decorates them, by adding IPs to source/destination
 	// names only when they were missing
-	decorated := testutil.ReadChannel(t, out.Subscribe(), timeout)
+	decorated := testutil.ReadChannel(t, outCh, timeout)
 	require.Len(t, decorated, 2)
 
 	assert.Equal(t, "eth1", decorated[0].Attrs.Interface)


### PR DESCRIPTION
As long as the pipeline in `instrumenter.go` is growing, we have found some cases where the data stopped flowing across the internal queues.

In complex scenarios where queues are forked to different nodes which could either bypass or subscribe to the original queue, some race condition caused that messages were never delivered.

Current version of the pipeline works correctly, but future changes and addition could manifest again this behavior, and they are somewhat difficult to diagnose.

This PR fixes the race conditions but also adds more flexibility to the queue mechanism:
* To simplify, all the queues without subscriptors become non-blocking. We just have to make sure that each `subscribe()` method is invoked during the swarm instancing.
* Now we allow both bypassing and subscribing to the same queue (previously they were excluding operations).
    1. When you subscribe to a bypassing queue, you get the subscription to the last queue in the bypassing chain.
    2. When you bypass a queue with subscriptors, the subscriptors are forwarded to the last queue in the bypassing chain.