### PR TITLE
kafka: set default topic uuid-to-name cache size

### DIFF
--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -82,6 +82,7 @@ var DefaultConfig = Config{
 		MySQLPreparedStatementsCacheSize:    1024,
 		PostgresPreparedStatementsCacheSize: 1024,
 		MongoRequestsCacheSize:              1024,
+		KafkaTopicUUIDCacheSize:             1024,
 	},
 	NameResolver: &transform.NameResolverConfig{
 		Sources:  []string{"k8s"},

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -139,6 +139,7 @@ discovery:
 			MySQLPreparedStatementsCacheSize:    1024,
 			PostgresPreparedStatementsCacheSize: 1024,
 			MongoRequestsCacheSize:              1024,
+			KafkaTopicUUIDCacheSize:             1024,
 		},
 		NetworkFlows: nc,
 		Metrics: otelcfg.MetricsConfig{


### PR DESCRIPTION
If the value is `0`, the handler will crash