### PR TITLE
Fix race condition in unit tests

### DIFF
--- a/pkg/components/discover/watcher_proc.go
+++ b/pkg/components/discover/watcher_proc.go
@@ -19,7 +19,6 @@ import (
 	"github.com/shirou/gopsutil/v3/net"
 	"github.com/shirou/gopsutil/v3/process"
 	"github.com/tklauser/go-sysconf"
-	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/obi/pkg/components/ebpf"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/components/ebpf/common"
@@ -419,16 +418,6 @@ func nsToDuration(ns uint64) time.Duration {
 	}
 
 	return time.Duration(ns)
-}
-
-func currentTime() uint64 {
-	var ts unix.Timespec
-
-	if err := unix.ClockGettime(unix.CLOCK_BOOTTIME, &ts); err != nil {
-		return 0
-	}
-
-	return uint64(ts.Sec)*1e9 + uint64(ts.Nsec)
 }
 
 func getProcStartTime(pid int32) uint64 {

--- a/pkg/components/discover/watcher_proc_linux.go
+++ b/pkg/components/discover/watcher_proc_linux.go
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package discover
+
+import "golang.org/x/sys/unix"
+
+func currentTime() uint64 {
+	var ts unix.Timespec
+
+	if err := unix.ClockGettime(unix.CLOCK_BOOTTIME, &ts); err != nil {
+		return 0
+	}
+
+	return uint64(ts.Sec)*1e9 + uint64(ts.Nsec)
+}

--- a/pkg/components/discover/watcher_proc_linux_test.go
+++ b/pkg/components/discover/watcher_proc_linux_test.go
@@ -1,0 +1,100 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package discover
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseProcStatField(t *testing.T) {
+	// this has excessive whitespace on purpose
+	const procPidStat = " 1197473 (foo bar) R   1494929 1197473 1494929 34817 1197473 4194304 91 " +
+		"0 0 0 0 0 0 0 20 0 1 0 164004305 8724480 1364    18446744073709551615 93963828355072 " +
+		"93963828373377 140721901331744 0 0 0 0 0 0 0 0 0    17 4 0 0 0 0 0 93963828386384 " +
+		"93963828387944 93964083773440 140721901340217 140721901340237 140721901340237 " +
+		"140721901342699 0"
+
+	inParens := false
+
+	f := func(c rune) bool {
+		if c == '(' {
+			inParens = true
+			return true
+		}
+
+		if inParens {
+			if c == ')' {
+				inParens = false
+				return true
+			}
+
+			return false
+		}
+
+		return c == ' '
+	}
+
+	expected := strings.FieldsFunc(procPidStat, f)
+
+	for i := 0; i < len(expected); i++ {
+		assert.Equal(t, expected[i], parseProcStatField(procPidStat, i+1))
+	}
+
+	// test a few fields explicitly to ensure whitespace is being handled
+	// properly
+	assert.Empty(t, parseProcStatField(procPidStat, 0))
+	assert.Empty(t, parseProcStatField(procPidStat, 200))
+	assert.Equal(t, "1197473", parseProcStatField(procPidStat, 1))
+	assert.Equal(t, "foo bar", parseProcStatField(procPidStat, 2))
+	assert.Equal(t, "R", parseProcStatField(procPidStat, 3))
+	assert.Equal(t, "1494929", parseProcStatField(procPidStat, 4))
+
+	// empty input
+	assert.Empty(t, parseProcStatField("", 0))
+	assert.Empty(t, parseProcStatField("", 1))
+	assert.Empty(t, parseProcStatField("", 200))
+	assert.Empty(t, parseProcStatField("", -1))
+}
+
+func TestGetProcStatField(t *testing.T) {
+	assert.Empty(t, getProcStatField(0, 0))
+	assert.Empty(t, getProcStatField(-1, 0))
+
+	pid := os.Getpid()
+
+	exePath, err := os.Executable()
+
+	require.NoError(t, err)
+
+	exe := filepath.Base(exePath)
+
+	assert.Equal(t, exe, getProcStatField(int32(pid), 2))
+}
+
+func TestNSToDuration(t *testing.T) {
+	assert.Equal(t, time.Duration(math.MaxInt64), nsToDuration(math.MaxUint64))
+	assert.Equal(t, time.Duration(0), nsToDuration(0))
+}
+
+func TestProcessAge(t *testing.T) {
+	assert.Zero(t, processAge(0))
+
+	age := processAge(int32(os.Getpid()))
+
+	require.NotZero(t, age)
+
+	expected, err := time.ParseDuration("2m")
+
+	require.NoError(t, err)
+
+	assert.Less(t, age, expected)
+}

--- a/pkg/components/discover/watcher_proc_other.go
+++ b/pkg/components/discover/watcher_proc_other.go
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package discover
+
+// placeholder files to allow local compilation/unit testing in non-linux environments
+
+func currentTime() uint64 {
+	return 0
+}

--- a/pkg/components/discover/watcher_proc_test.go
+++ b/pkg/components/discover/watcher_proc_test.go
@@ -6,11 +6,7 @@ package discover
 import (
 	"bytes"
 	"context"
-	"math"
-	"os"
-	"path/filepath"
 	"slices"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -330,88 +326,4 @@ func TestMinProcessAge(t *testing.T) {
 
 	assert.True(t, ok)
 	assert.False(t, acc.processTooNew(process))
-}
-
-func TestParseProcStatField(t *testing.T) {
-	// this has excessive whitespace on purpose
-	const procPidStat = " 1197473 (foo bar) R   1494929 1197473 1494929 34817 1197473 4194304 91 " +
-		"0 0 0 0 0 0 0 20 0 1 0 164004305 8724480 1364    18446744073709551615 93963828355072 " +
-		"93963828373377 140721901331744 0 0 0 0 0 0 0 0 0    17 4 0 0 0 0 0 93963828386384 " +
-		"93963828387944 93964083773440 140721901340217 140721901340237 140721901340237 " +
-		"140721901342699 0"
-
-	inParens := false
-
-	f := func(c rune) bool {
-		if c == '(' {
-			inParens = true
-			return true
-		}
-
-		if inParens {
-			if c == ')' {
-				inParens = false
-				return true
-			}
-
-			return false
-		}
-
-		return c == ' '
-	}
-
-	expected := strings.FieldsFunc(procPidStat, f)
-
-	for i := 0; i < len(expected); i++ {
-		assert.Equal(t, expected[i], parseProcStatField(procPidStat, i+1))
-	}
-
-	// test a few fields explicitly to ensure whitespace is being handled
-	// properly
-	assert.Empty(t, parseProcStatField(procPidStat, 0))
-	assert.Empty(t, parseProcStatField(procPidStat, 200))
-	assert.Equal(t, "1197473", parseProcStatField(procPidStat, 1))
-	assert.Equal(t, "foo bar", parseProcStatField(procPidStat, 2))
-	assert.Equal(t, "R", parseProcStatField(procPidStat, 3))
-	assert.Equal(t, "1494929", parseProcStatField(procPidStat, 4))
-
-	// empty input
-	assert.Empty(t, parseProcStatField("", 0))
-	assert.Empty(t, parseProcStatField("", 1))
-	assert.Empty(t, parseProcStatField("", 200))
-	assert.Empty(t, parseProcStatField("", -1))
-}
-
-func TestGetProcStatField(t *testing.T) {
-	assert.Empty(t, getProcStatField(0, 0))
-	assert.Empty(t, getProcStatField(-1, 0))
-
-	pid := os.Getpid()
-
-	exePath, err := os.Executable()
-
-	require.NoError(t, err)
-
-	exe := filepath.Base(exePath)
-
-	assert.Equal(t, exe, getProcStatField(int32(pid), 2))
-}
-
-func TestNSToDuration(t *testing.T) {
-	assert.Equal(t, time.Duration(math.MaxInt64), nsToDuration(math.MaxUint64))
-	assert.Equal(t, time.Duration(0), nsToDuration(0))
-}
-
-func TestProcessAge(t *testing.T) {
-	assert.Zero(t, processAge(0))
-
-	age := processAge(int32(os.Getpid()))
-
-	require.NotZero(t, age)
-
-	expected, err := time.ParseDuration("2m")
-
-	require.NoError(t, err)
-
-	assert.Less(t, age, expected)
 }

--- a/pkg/components/netolly/agent/pipeline.go
+++ b/pkg/components/netolly/agent/pipeline.go
@@ -95,7 +95,6 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 	// Terminal nodes export the flow record information out of the pipeline: OTEL, Prom and printer.
 	// Not all the nodes are mandatory here. Is the responsibility of each Provider function to decide
 	// whether each node is going to be instantiated or just ignored.
-	f.cfg.Attributes.Select.Normalize()
 	swi.Add(otel.NetMetricsExporterProvider(f.ctxInfo, &otel.NetMetricsConfig{
 		Metrics:         &f.cfg.Metrics,
 		SelectorCfg:     selectorCfg,

--- a/pkg/export/attributes/attr_select_test.go
+++ b/pkg/export/attributes/attr_select_test.go
@@ -4,9 +4,7 @@
 package attributes
 
 import (
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -32,100 +30,4 @@ func TestSelectorMatch(t *testing.T) {
 		[]InclusionLists{pp},
 		selection.Matching(Name{Section: "pim.pam"}))
 	assert.Empty(t, selection.Matching(Name{Section: "pam.pum"}))
-}
-
-// TestConcurrentMapAccess demonstrates the race condition between Normalize() and Matching():
-// https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/508
-//
-// The race condition occurs when:
-// 1. Normalize() modifies the Selection map
-// 2. Matching() iterates over the Selection map
-// 3. These operations happen concurrently from different goroutines
-//
-// To demonstrate the issue, run with the -race flag:
-//
-//	go test ./pkg/export/attributes/... -race
-func TestConcurrentMapAccess(t *testing.T) {
-	// Create a selection with multiple entries to increase chances of race condition
-	selection := Selection{
-		"http.server.request.duration":   {Include: []string{"*"}},
-		"http.server.request.body.size":  {Include: []string{"*"}},
-		"http.server.response.body.size": {Include: []string{"*"}},
-		"http.client.request.duration":   {Include: []string{"*"}},
-		"http.client.request.body.size":  {Include: []string{"*"}},
-		"http.client.response.body.size": {Include: []string{"*"}},
-		"rpc.server.duration":            {Include: []string{"*"}},
-		"rpc.client.duration":            {Include: []string{"*"}},
-		"db.client.operation.duration":   {Include: []string{"*"}},
-		"messaging.publish.duration":     {Include: []string{"*"}},
-		"messaging.receive.duration":     {Include: []string{"*"}},
-		"network.flow.duration":          {Include: []string{"*"}},
-		"network.flow.bytes":             {Include: []string{"*"}},
-		"custom.metric.one":              {Include: []string{"service.*"}},
-		"custom.metric.two":              {Include: []string{"k8s.*"}},
-		"custom.metric.three":            {Include: []string{"host.*"}},
-		"custom.metric.four":             {Include: []string{"process.*"}},
-		"custom.metric.five":             {Include: []string{"container.*"}},
-	}
-
-	var wg sync.WaitGroup
-	done := make(chan struct{})
-
-	// Start multiple goroutines that call Normalize() concurrently
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for {
-				select {
-				case <-done:
-					return
-				default:
-					// Continuously call Normalize() which modifies the map
-					selection.Normalize()
-					time.Sleep(1 * time.Millisecond) // Small delay to allow other goroutines to run
-				}
-			}
-		}()
-	}
-
-	// Start multiple goroutines that call Matching() concurrently
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			metricNames := []Name{
-				{Section: "http.server.request.duration"},
-				{Section: "http.client.request.duration"},
-				{Section: "rpc.server.duration"},
-				{Section: "db.client.operation.duration"},
-				{Section: "messaging.publish.duration"},
-				{Section: "network.flow.duration"},
-				{Section: "custom.metric.one"},
-				{Section: "custom.metric.two"},
-			}
-
-			for {
-				select {
-				case <-done:
-					return
-				default:
-					// Continuously call Matching() which iterates over the map
-					for _, metricName := range metricNames {
-						_ = selection.Matching(metricName)
-					}
-					time.Sleep(1 * time.Millisecond) // Small delay to allow other goroutines to run
-				}
-			}
-		}()
-	}
-
-	// Let the race condition develop for a short time
-	time.Sleep(100 * time.Millisecond)
-
-	// Signal all goroutines to stop
-	close(done)
-	wg.Wait()
-
-	t.Log("test completed - this is here as at least one usage of t required for linting")
 }

--- a/pkg/instrumenter/instrumenter.go
+++ b/pkg/instrumenter/instrumenter.go
@@ -31,6 +31,8 @@ func Run(
 	ctx context.Context, cfg *obi.Config,
 	opts ...Option,
 ) error {
+	normalizeConfig(cfg)
+
 	ctxInfo, err := buildCommonContextInfo(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("can't build common context info: %w", err)
@@ -68,6 +70,11 @@ func Run(
 	}
 	slog.Debug("OBI main node finished")
 	return nil
+}
+
+// normalizeConfig normalizes user input to a common set of assumptions that are global to OBI
+func normalizeConfig(cfg *obi.Config) {
+	cfg.Attributes.Select.Normalize()
 }
 
 func setupAppO11y(ctx context.Context, ctxInfo *global.ContextInfo, config *obi.Config) error {


### PR DESCRIPTION
The pipeline unit tests failed with race conditions beause the atributes' selector `Normalize` method was invoked concurrently with the `otelcfg.GetFilteredAttributesByPrefix()` function.

`Normalize()` must be only invoked once, when we are sure the configuration is properly loaded. So I have moved it to a special section at the very beginning of the `instrumenter.Run` function and removed all the redundant invocations around the codebase.

There was already a similar issue with `Normalize` and `Matching`, that was initially resolved by adding a global mutex. Now there is no need for this synchronization mechanism as we are sure that `Normalize` won't be invoked concurrently with any other component.

This PR also reorganizes some functions introduced in https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/555 to let OBI unit tests compile in Non-linux hosts.