### PR TITLE
Fix some nodes not properly stopping

### DIFF
--- a/pkg/export/debug/debug.go
+++ b/pkg/export/debug/debug.go
@@ -69,51 +69,63 @@ func PrinterNode(p TracePrinter, input *msg.Queue[[]request.Span]) swarm.Instanc
 
 func textPrinter(in *msg.Queue[[]request.Span]) swarm.RunFunc {
 	input := in.Subscribe()
-	return func(_ context.Context) {
-		for spans := range input {
-			for i := range spans {
-				t := spans[i].Timings()
-
-				pn := ""
-				hn := ""
-
-				if spans[i].IsClientSpan() {
-					if spans[i].Service.UID.Namespace != "" {
-						pn = "." + spans[i].Service.UID.Namespace
-					}
-					if spans[i].OtherNamespace != "" {
-						hn = "." + spans[i].OtherNamespace
-					}
-				} else {
-					if spans[i].OtherNamespace != "" {
-						pn = "." + spans[i].OtherNamespace
-					}
-					if spans[i].Service.UID.Namespace != "" {
-						hn = "." + spans[i].Service.UID.Namespace
-					}
+	return func(ctx context.Context) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case spans, ok := <-input:
+				if !ok {
+					return
 				}
-
-				fmt.Printf("%s (%s[%s]) %s %v %s %s [%s:%d]->[%s:%d] contentLen:%dB responseLen:%dB svc=[%s %s] traceparent=[%s]\n",
-					t.Start.Format("2006-01-02 15:04:05.12345"),
-					t.End.Sub(t.RequestStart),
-					t.End.Sub(t.Start),
-					spans[i].Type,
-					spans[i].Status,
-					spans[i].Method,
-					spans[i].Path,
-					spans[i].Peer+" as "+request.SpanPeer(&spans[i])+pn,
-					spans[i].PeerPort,
-					spans[i].Host+" as "+request.SpanHost(&spans[i])+hn,
-					spans[i].HostPort,
-					spans[i].ContentLength,
-					spans[i].ResponseLength,
-					&spans[i].Service,
-					spans[i].Service.SDKLanguage.String(),
-					traceparent(&spans[i]),
-				)
+				for i := range spans {
+					printSpan(&spans[i])
+				}
 			}
 		}
 	}
+}
+
+func printSpan(span *request.Span) {
+	t := span.Timings()
+
+	pn := ""
+	hn := ""
+
+	if span.IsClientSpan() {
+		if span.Service.UID.Namespace != "" {
+			pn = "." + span.Service.UID.Namespace
+		}
+		if span.OtherNamespace != "" {
+			hn = "." + span.OtherNamespace
+		}
+	} else {
+		if span.OtherNamespace != "" {
+			pn = "." + span.OtherNamespace
+		}
+		if span.Service.UID.Namespace != "" {
+			hn = "." + span.Service.UID.Namespace
+		}
+	}
+
+	fmt.Printf("%s (%s[%s]) %s %v %s %s [%s:%d]->[%s:%d] contentLen:%dB responseLen:%dB svc=[%s %s] traceparent=[%s]\n",
+		t.Start.Format("2006-01-02 15:04:05.12345"),
+		t.End.Sub(t.RequestStart),
+		t.End.Sub(t.Start),
+		span.Type,
+		span.Status,
+		span.Method,
+		span.Path,
+		span.Peer+" as "+request.SpanPeer(span)+pn,
+		span.PeerPort,
+		span.Host+" as "+request.SpanHost(span)+hn,
+		span.HostPort,
+		span.ContentLength,
+		span.ResponseLength,
+		&span.Service,
+		span.Service.SDKLanguage.String(),
+		traceparent(span),
+	)
 }
 
 func serializeSpansJSON(spans []request.Span, indent bool) ([]byte, error) {

--- a/pkg/transform/ips_filter.go
+++ b/pkg/transform/ips_filter.go
@@ -5,6 +5,7 @@ package transform
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"strings"
 
@@ -13,19 +14,33 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 )
 
+func ipslog() *slog.Logger {
+	return slog.With("component", "transform.IPsFilter")
+}
+
 func IPsFilter(dropUnresolvedIPs bool, input, output *msg.Queue[[]request.Span]) swarm.InstanceFunc {
 	return func(_ context.Context) (swarm.RunFunc, error) {
 		if !dropUnresolvedIPs {
 			return swarm.Bypass(input, output)
 		}
 		in := input.Subscribe()
-		return func(_ context.Context) {
+		return func(ctx context.Context) {
 			defer output.Close()
-			for spans := range in {
-				for i := range spans {
-					filterIPsFromSpan(&spans[i])
+			for {
+				select {
+				case <-ctx.Done():
+					ipslog().Debug("context done. Stopping")
+					return
+				case spans, ok := <-in:
+					if !ok {
+						ipslog().Debug("input channel closed, stopping")
+						return
+					}
+					for i := range spans {
+						filterIPsFromSpan(&spans[i])
+					}
+					output.Send(spans)
 				}
-				output.Send(spans)
 			}
 		}, nil
 	}

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -136,18 +136,27 @@ type procEventMetadataDecorator struct {
 	output      *msg.Queue[exec.ProcessEvent]
 }
 
-func (md *metadataDecorator) nodeLoop(_ context.Context) {
+func (md *metadataDecorator) nodeLoop(ctx context.Context) {
 	// output channel must be closed so later stages in the pipeline can finish in cascade
 	defer md.output.Close()
 	klog().Debug("starting kubernetes span decoration loop")
-	for spans := range md.input {
-		// in-place decoration and forwarding
-		for i := range spans {
-			md.do(&spans[i])
+	for {
+		select {
+		case <-ctx.Done():
+			klog().Debug("context done, stopping kubernetes span decoration loop")
+			return
+		case spans, ok := <-md.input:
+			if !ok {
+				klog().Debug("input channel closed, stopping kubernetes span decoration loop")
+				return
+			}
+			// in-place decoration and forwarding
+			for i := range spans {
+				md.do(&spans[i])
+			}
+			md.output.Send(spans)
 		}
-		md.output.Send(spans)
 	}
-	klog().Debug("stopping kubernetes span decoration loop")
 }
 
 func (md *procEventMetadataDecorator) k8sLoop(ctx context.Context) {


### PR DESCRIPTION
There was a flaky unit test that successfully evaluated the behavioral assertions, but often got stuck at the last `<-done` verification (just verifying that the pipeline stopped on context cancellation).

There were still some nodes that did not properly handled the context cancellation and could make Beyla container destruction take longer than really required.