### PR TITLE
Avoid flaky test to block forever

### DIFF
--- a/pkg/components/pipe/instrumenter_test.go
+++ b/pkg/components/pipe/instrumenter_test.go
@@ -234,7 +234,7 @@ func TestMergedMetricsTracePipeline(t *testing.T) {
 	// Test that metrics flow through the pipeline to the end
 
 	cancel()
-	require.NoError(t, <-done)
+	testutil.ReadChannel(t, done, testTimeout)
 }
 
 func TestTracerPipelineBadTimestamps(t *testing.T) {


### PR DESCRIPTION
There is a flaky test that block for minutes when the `<-done` channel is not closed. It makes the error log unreadable because the OTEL library floods the output with "connection closed" messages.

Prior to the fix of that flaky test, let's first fix the actual test code for cleaner error messages.