### PR TITLE
distinguish flags for codecov reports

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -112,4 +112,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./testoutput/itest-covdata.txt
-          flags: integration-test
+          flags: integration-test-${{ github.run_number }}-${{ matrix.id }}

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -52,4 +52,4 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./testoutput/itest-covdata.txt
-          flags: k8s-integration-test
+          flags: k8s-integration-test-${{ github.run_number }}-${{ matrix.id }}


### PR DESCRIPTION
Codecov metrics decreased since the parallelization. I suspect that the cause is all the tests within the same matrix being submitted under the same flag.

This provides different coverage flags for Codecov, expecting that instead of overwriting coverage data, it merges.