### PR TITLE
Fix tests and metalinter in non-linux

### DIFF
--- a/pkg/components/transform/route/harvest/java.go
+++ b/pkg/components/transform/route/harvest/java.go
@@ -5,15 +5,12 @@ package harvest
 
 import (
 	"bufio"
-	"io"
 	"log/slog"
 	"net/url"
 	"regexp"
 	"sort"
 	"strings"
 	"unicode"
-
-	"github.com/grafana/jvmtools/jvm"
 )
 
 type JavaRoutes struct {
@@ -118,8 +115,6 @@ func (h *JavaRoutes) addRouteIfValid(line string, routes []string) []string {
 
 	return routes
 }
-
-var jvmAttachFunc func(pid int, argv []string, logger *slog.Logger) (io.ReadCloser, error) = jvm.Jattach
 
 func (h *JavaRoutes) ExtractRoutes(pid int32) (*RouteHarvesterResult, error) {
 	routes := []string{}

--- a/pkg/components/transform/route/harvest/java_linux.go
+++ b/pkg/components/transform/route/harvest/java_linux.go
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package harvest
+
+import "github.com/grafana/jvmtools/jvm"
+
+var jvmAttachFunc = jvm.Jattach

--- a/pkg/components/transform/route/harvest/java_notlinux.go
+++ b/pkg/components/transform/route/harvest/java_notlinux.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package harvest
+
+import (
+	"io"
+	"log/slog"
+)
+
+var jvmAttachFunc = func(_ int, _ []string, _ *slog.Logger) (io.ReadCloser, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Fixes this Darwin/Windows error caused by a dependency to a linux-only package:

```
Can't run linter goanalysis_metalinter: findcall: failed to load package : could not load export data: no export data for "github.com/grafana/jvmtool" 
```