### PR TITLE
Enforce CAP_SYS_ADMIN when AppO11y is enabled

### DIFF
--- a/pkg/obi/os.go
+++ b/pkg/obi/os.go
@@ -90,6 +90,7 @@ func checkCapabilitiesForSetOptions(config *Config, caps *helpers.OSCapabilities
 		testAndSet(caps, capError, unix.CAP_SYS_PTRACE)
 		testAndSet(caps, capError, unix.CAP_PERFMON)
 		testAndSet(caps, capError, unix.CAP_NET_RAW)
+		testAndSet(caps, capError, unix.CAP_SYS_ADMIN)
 
 		if config.EBPF.ContextPropagation != ebpfcfg.ContextPropagationDisabled {
 			testAndSet(caps, capError, unix.CAP_NET_ADMIN)
@@ -126,11 +127,6 @@ func CheckOSCapabilities(config *Config) error {
 		}
 
 		return capError
-	}
-
-	// if sys admin is set, we have all capabilities
-	if caps.Has(unix.CAP_SYS_ADMIN) {
-		return nil
 	}
 
 	// core capabilities


### PR DESCRIPTION
As of July 2025, the Linux kernel reintroduced the requirement for having `CAP_SYS_ADMIN` when loading **uprobes**, due to a security vulnerability - and as such, backported it to most active kernel versions, such as:
- 5.10.240
- 5.15.189
- 6.1.146
- 6.6.99
- 6.12.39
- 6.15.7
- 6.16-rc5

In practice, this means we need to start requiring `CAP_SYS_ADMIN` over the board when AppO11y is active. It is not practical (or even possible) to infer whether the underlying kernel has been patched.

For further reference see:
 - https://feedly.com/cve/CVE-2025-38466
 - https://nvd.nist.gov/vuln/detail/cve-2025-38466
 - https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=183bdb89af1b5193b1d1d9316986053b15ca6fa4

> [!IMPORTANT]
> It's a common misconception that CAP_SYS_ADMIN implies other capabilities (such as CAP_DAC_READ_SEARCH or even CAP_SYS_PTRACE). Some kernel codepaths may elect to check one or the other, but that is often not the case. This is the reason why I've kept the other capabilities intact in the code - they are still required, in addition to CAP_SYS_ADMIN.

As such, the following snippted was wrong and has been removed:
```
// if sys admin is set, we have all capabilities
if caps.Has(unix.CAP_SYS_ADMIN) {
	return nil
}
```