### PR TITLE
Allow ExportModes to be pragmatically constructed

### DIFF
--- a/pkg/services/export.go
+++ b/pkg/services/export.go
@@ -51,6 +51,10 @@ type ExportModes struct {
 	blockSignal maps.Bits
 }
 
+func NewExportModes() ExportModes {
+	return ExportModes{blockSignal: blockAll}
+}
+
 // CanExportTraces reports whether traces can be exported.
 // It's provided as a convenience function.
 func (modes ExportModes) CanExportTraces() bool {
@@ -61,6 +65,19 @@ func (modes ExportModes) CanExportTraces() bool {
 // It's provided as a convenience function.
 func (modes ExportModes) CanExportMetrics() bool {
 	return !modes.blockSignal.Has(blockMetrics)
+}
+
+// Allow ExportModes to be pragmatically constructed:
+//
+//  modes := NewExportModes()
+//  modes.AllowMetrics() // export metrics only
+
+func (modes *ExportModes) AllowTraces() {
+	modes.blockSignal ^= blockTraces
+}
+
+func (modes *ExportModes) AllowMetrics() {
+	modes.blockSignal ^= blockMetrics
 }
 
 func (modes *ExportModes) UnmarshalYAML(value *yaml.Node) error {

--- a/pkg/services/export_test.go
+++ b/pkg/services/export_test.go
@@ -98,3 +98,18 @@ func TestYAMLUnmarshal_Exports(t *testing.T) {
 		assert.True(t, tc.Exports.CanExportTraces())
 	})
 }
+
+func TestPragmaticExports(t *testing.T) {
+	modes := NewExportModes()
+
+	assert.False(t, modes.CanExportTraces())
+	assert.False(t, modes.CanExportMetrics())
+
+	modes.AllowTraces()
+
+	assert.True(t, modes.CanExportTraces())
+
+	modes.AllowMetrics()
+
+	assert.True(t, modes.CanExportMetrics())
+}


### PR DESCRIPTION
At the moment the only way to construct a non-unset object is via YAML unmarshalling. This lets us construct it pragmatically - used in downstream projects.