### PR TITLE
Fix crash in cluster_url

### DIFF
--- a/pkg/components/transform/route/clusterurl/cluster.go
+++ b/pkg/components/transform/route/clusterurl/cluster.go
@@ -123,6 +123,11 @@ func (csf *ClusterURLClassifier) ClusterURL(path string) string {
 		}
 	}
 
+	// this can happen if we have path with ?, & or # and all invalid chars, but no /
+	if len(p) == 0 {
+		return ""
+	}
+
 	if skip {
 		p[sPos] = csf.cfg.ReplaceWith
 		sPos++

--- a/pkg/components/transform/route/clusterurl/cluster_test.go
+++ b/pkg/components/transform/route/clusterurl/cluster_test.go
@@ -51,6 +51,12 @@ func TestClusterURL(t *testing.T) {
 	assert.Equal(t, "HTTP GET", csf.ClusterURL("HTTP GET"))
 	assert.Equal(t, "GET /api/cart", csf.ClusterURL("GET /api/cart?sessionId=55f4e5ea-5d6d-482a-80c4-799e3c72dfb0&currencyCode=USD"))
 	assert.Equal(t, "/getquote", csf.ClusterURL("/getquote"))
+	assert.Equal(t, "", csf.ClusterURL("?"))
+	assert.Equal(t, "", csf.ClusterURL("attach12?"))
+	assert.Equal(t, "", csf.ClusterURL("1?"))
+	assert.Equal(t, "", csf.ClusterURL("*&"))
+	assert.Equal(t, "", csf.ClusterURL("12#"))
+	assert.Equal(t, "/a", csf.ClusterURL("/a#"))
 }
 
 func BenchmarkClusterURLWithCache(b *testing.B) {


### PR DESCRIPTION
Recent change made by this PR https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/411 to handle ?, # and & introduced an edge case in handling routes that don't have `/` prefix.

Fixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/592