### PR TITLE
bpf: fallback to bounded loop if bpf_loop is not available

### DIFF
--- a/bpf/bpfcore/bpf_builtins.h
+++ b/bpf/bpfcore/bpf_builtins.h
@@ -9,6 +9,7 @@
 #ifndef __BPF_BUILTINS__
 #define __BPF_BUILTINS__
 
+#include "bpf_helpers.h"
 #include "compiler.h"
 
 /* Memory iterators used below. */
@@ -905,7 +906,8 @@ __bpf_no_builtin_memset(void *d __maybe_unused, __u8 c __maybe_unused, __u64 len
 }
 
 /* Redirect any direct use in our code to throw an error. */
-#define __builtin_memset __bpf_no_builtin_memset
+// TODO: re-enable once all __builtin_memset() are replaced with the optimized version
+// #define __builtin_memset __bpf_no_builtin_memset
 
 static __always_inline __maybe_unused __nobuiltin("memset") void bpf_memset(void *d,
                                                                             int c,
@@ -1795,7 +1797,8 @@ static __always_inline __maybe_unused void *__bpf_no_builtin_memcpy(void *d __ma
 }
 
 /* Redirect any direct use in our code to throw an error. */
-#define __builtin_memcpy __bpf_no_builtin_memcpy
+// TODO: re-enable once all __builtin_memcpy() are replaced with the optimized version
+// #define __builtin_memcpy __bpf_no_builtin_memcpy
 
 static __always_inline __maybe_unused __nobuiltin("memcpy") void bpf_memcpy(void *d,
                                                                             const void *s,
@@ -2692,7 +2695,8 @@ static __always_inline __maybe_unused __u64 __bpf_no_builtin_memcmp(const void *
 }
 
 /* Redirect any direct use in our code to throw an error. */
-#define __builtin_memcmp __bpf_no_builtin_memcmp
+// TODO: re-enable once all __builtin_memcmp() are replaced with the optimized version
+// #define __builtin_memcmp __bpf_no_builtin_memcmp
 
 /* Modified for our needs in that we only return either zero (x and y
  * are equal) or non-zero (x and y are non-equal).

--- a/bpf/common/http_types.h
+++ b/bpf/common/http_types.h
@@ -57,6 +57,7 @@ typedef struct call_protocol_args {
     u16 orig_dport;
     u16 _pad2;
     u64 u_buf;
+    u64 self_ref_parent_id;
 } call_protocol_args_t;
 
 // Here we keep information on the packets passing through the socket filter

--- a/bpf/common/trace_common.h
+++ b/bpf/common/trace_common.h
@@ -71,9 +71,9 @@ static int tp_match(u32 index, void *data) {
     return 0;
 }
 
-static __always_inline unsigned char *bpf_strstr_tp_loop(unsigned char *buf, int buf_len) {
+static __always_inline u16 bpf_strstr_tp_loop(unsigned char *buf, u16 buf_len) {
     if (!k_bpf_traceparent_enabled) {
-        return NULL;
+        return 0;
     }
 
     struct callback_ctx data = {.buf = buf, .pos = 0};
@@ -83,31 +83,29 @@ static __always_inline unsigned char *bpf_strstr_tp_loop(unsigned char *buf, int
     bpf_loop(nr_loops, tp_match, &data, 0);
 
     if (data.pos) {
-        return (data.pos > (TRACE_BUF_SIZE - TRACE_PARENT_HEADER_LEN)) ? NULL : &(buf[data.pos]);
+        return (data.pos > (TRACE_BUF_SIZE - TRACE_PARENT_HEADER_LEN)) ? 0 : data.pos;
     }
 
-    return NULL;
+    return 0;
 }
 
-static __always_inline unsigned char *bpf_strstr_tp_loop__legacy(unsigned char *buf, int buf_len) {
+static __always_inline u16 bpf_strstr_tp_loop__legacy(unsigned char *buf, u16 buf_len) {
     (void)buf_len;
 
     if (!k_bpf_traceparent_enabled) {
-        return NULL;
+        return 0;
     }
 
-    const u16 k_besteffort_max_loops = 450; // Limited best-effort search to stay within insns limit
-    for (u16 i = 0; i + TRACE_PARENT_HEADER_LEN < k_besteffort_max_loops; i++) {
-        if (i != 0 && buf[i - 1] != '\n') {
-            continue;
-        }
+    // Limited best-effort search to stay within insns limit
+    const u16 k_besteffort_max_loops = 350;
 
+    for (u16 i = 0; i < k_besteffort_max_loops; i++) {
         if (is_traceparent(&buf[i])) {
-            return &buf[i];
+            return i;
         }
     }
 
-    return NULL;
+    return 0;
 }
 
 static __always_inline const tp_info_pid_t *

--- a/bpf/common/trace_common.h
+++ b/bpf/common/trace_common.h
@@ -71,9 +71,9 @@ static int tp_match(u32 index, void *data) {
     return 0;
 }
 
-static __always_inline u16 bpf_strstr_tp_loop(unsigned char *buf, u16 buf_len) {
+static __always_inline unsigned char *bpf_strstr_tp_loop(unsigned char *buf, const u16 buf_len) {
     if (!k_bpf_traceparent_enabled) {
-        return 0;
+        return NULL;
     }
 
     struct callback_ctx data = {.buf = buf, .pos = 0};
@@ -83,17 +83,18 @@ static __always_inline u16 bpf_strstr_tp_loop(unsigned char *buf, u16 buf_len) {
     bpf_loop(nr_loops, tp_match, &data, 0);
 
     if (data.pos) {
-        return (data.pos > (TRACE_BUF_SIZE - TRACE_PARENT_HEADER_LEN)) ? 0 : data.pos;
+        return (data.pos > (TRACE_BUF_SIZE - TRACE_PARENT_HEADER_LEN)) ? NULL : &buf[data.pos];
     }
 
-    return 0;
+    return NULL;
 }
 
-static __always_inline u16 bpf_strstr_tp_loop__legacy(unsigned char *buf, u16 buf_len) {
+static __always_inline unsigned char *bpf_strstr_tp_loop__legacy(unsigned char *buf,
+                                                                 const u16 buf_len) {
     (void)buf_len;
 
     if (!k_bpf_traceparent_enabled) {
-        return 0;
+        return NULL;
     }
 
     // Limited best-effort search to stay within insns limit
@@ -101,11 +102,11 @@ static __always_inline u16 bpf_strstr_tp_loop__legacy(unsigned char *buf, u16 bu
 
     for (u16 i = 0; i < k_besteffort_max_loops; i++) {
         if (is_traceparent(&buf[i])) {
-            return i;
+            return &buf[i];
         }
     }
 
-    return 0;
+    return NULL;
 }
 
 static __always_inline const tp_info_pid_t *

--- a/bpf/generictracer/k_tracer_tailcall.h
+++ b/bpf/generictracer/k_tracer_tailcall.h
@@ -10,15 +10,17 @@ struct bpf_map_def SEC("maps") jump_table = {
     .type = BPF_MAP_TYPE_PROG_ARRAY,
     .key_size = sizeof(__u32),
     .value_size = sizeof(__u32),
-    .max_entries = 8,
+    .max_entries = 16,
 };
 
 enum {
     k_tail_protocol_http = 0,
-    k_tail_protocol_http2 = 1,
-    k_tail_protocol_tcp = 2,
-    k_tail_protocol_http2_grpc_frames = 3,
-    k_tail_protocol_http2_grpc_handle_start_frame = 4,
-    k_tail_protocol_http2_grpc_handle_end_frame = 5,
-    k_tail_handle_buf_with_args = 6,
+    k_tail_continue_protocol_http = 1,
+    k_tail_continue2_protocol_http = 2,
+    k_tail_protocol_http2 = 3,
+    k_tail_protocol_tcp = 4,
+    k_tail_protocol_http2_grpc_frames = 5,
+    k_tail_protocol_http2_grpc_handle_start_frame = 6,
+    k_tail_protocol_http2_grpc_handle_end_frame = 7,
+    k_tail_handle_buf_with_args = 8,
 };

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -13,6 +13,8 @@
 #include <common/trace_common.h>
 
 #include <generictracer/maps/http_info_mem.h>
+
+#include <generictracer/k_tracer_tailcall.h>
 #include <generictracer/protocol_common.h>
 
 #include <maps/accepted_connections.h>
@@ -41,16 +43,14 @@ static __always_inline u32 trace_type_from_meta(http_connection_metadata_t *meta
     return TRACE_TYPE_SERVER;
 }
 
-static __always_inline void
-http_get_or_create_trace_info(http_connection_metadata_t *meta,
-                              u32 pid,
-                              connection_info_t *conn,
-                              void *u_buf,
-                              int bytes_len,
-                              s32 capture_header_buffer,
-                              u8 ssl,
-                              u16 orig_dport,
-                              unsigned char *(*tp_loop_fn)(unsigned char *, int)) {
+static __always_inline void http_get_or_create_trace_info(http_connection_metadata_t *meta,
+                                                          u32 pid,
+                                                          connection_info_t *conn,
+                                                          void *u_buf,
+                                                          int bytes_len,
+                                                          u8 ssl,
+                                                          u16 orig_dport,
+                                                          u16 (*tp_loop_fn)(unsigned char *, u16)) {
     //TODO use make_key
     egress_key_t e_key = {
         .d_port = conn->d_port,
@@ -146,13 +146,15 @@ http_get_or_create_trace_info(http_connection_metadata_t *meta,
 
         unsigned char *buf = tp_char_buf();
         if (buf) {
-            int buf_len = bytes_len;
-            bpf_clamp_umax(buf_len, TRACE_BUF_SIZE - 1);
-
+            u16 buf_len = bytes_len & (TRACE_BUF_SIZE - 1);
+            __builtin_memset(buf, 0, TRACE_BUF_SIZE);
             bpf_probe_read(buf, buf_len, u_buf);
 
-            unsigned char *res = tp_loop_fn(buf, buf_len);
-            if (res) {
+            u16 idx = tp_loop_fn(buf, buf_len);
+
+            if (idx > 0 && idx < (TRACE_BUF_SIZE - TRACE_PARENT_HEADER_LEN)) {
+                unsigned char *res = &buf[idx];
+
                 bpf_dbg_printk("Found traceparent in headers [%s] overriding what was before", res);
                 unsigned char *t_id = extract_trace_id(res);
                 unsigned char *s_id = extract_span_id(res);
@@ -168,8 +170,7 @@ http_get_or_create_trace_info(http_connection_metadata_t *meta,
                 bpf_dbg_printk("new tp: %s", tp_buf);
 #endif
             } else {
-                bpf_dbg_printk("No additional traceparent in headers, using what was made before",
-                               res);
+                bpf_dbg_printk("No additional traceparent in headers, using what was made before");
             }
         } else {
             return;
@@ -403,7 +404,98 @@ static __always_inline void handle_http_response(unsigned char *small_buf,
     cleanup_http_request_data(pid_conn, info);
 }
 
-static __always_inline int __obi_protocol_http(unsigned char *(*tp_loop_fn)(unsigned char *, int)) {
+static __always_inline int __obi_continue2_protocol_http(struct pt_regs *ctx,
+                                                         call_protocol_args_t *args,
+                                                         http_info_t *info,
+                                                         http_connection_metadata_t *meta) {
+    (void)ctx;
+
+    if (meta) {
+        u32 type = trace_type_from_meta(meta);
+        tp_info_pid_t *tp_p = trace_info_for_connection(&args->pid_conn.conn, type);
+        if (tp_p) {
+            info->tp = tp_p->tp;
+            if (args->self_ref_parent_id) {
+                bpf_dbg_printk("overwriting parent id from the self referencing client request");
+                __builtin_memcpy(&info->tp.parent_id, &args->self_ref_parent_id, sizeof(u64));
+            }
+        } else {
+            bpf_dbg_printk("Can't find trace info, this is a bug!");
+        }
+    } else {
+        bpf_dbg_printk("No META!");
+    }
+
+    // we copy some small part of the buffer to the info trace event, so that we can process an event even with
+    // incomplete trace info in user space.
+    bpf_probe_read(info->buf, FULL_BUF_SIZE, (void *)args->u_buf);
+    process_http_request(info, args->bytes_len, meta, args->direction, args->orig_dport);
+
+    return 0;
+}
+
+// k_tail_continue2_protocol_http
+SEC("kprobe/http")
+int obi_continue2_protocol_http(struct pt_regs *ctx) {
+    call_protocol_args_t *args = protocol_args();
+    if (!args) {
+        return 0;
+    }
+
+    http_info_t *info = bpf_map_lookup_elem(&ongoing_http, &args->pid_conn);
+    if (!info) {
+        return 0;
+    }
+
+    http_connection_metadata_t *meta =
+        connection_meta_by_direction(args->direction, PACKET_TYPE_REQUEST);
+
+    return __obi_continue2_protocol_http(ctx, args, info, meta);
+}
+
+static __always_inline int __obi_continue_protocol_http(struct pt_regs *ctx,
+                                                        call_protocol_args_t *args,
+                                                        http_info_t *info,
+                                                        u16 (*tp_loop_fn)(unsigned char *, u16)) {
+    http_connection_metadata_t *meta =
+        connection_meta_by_direction(args->direction, PACKET_TYPE_REQUEST);
+
+    http_get_or_create_trace_info(meta,
+                                  args->pid_conn.pid,
+                                  &args->pid_conn.conn,
+                                  (void *)args->u_buf,
+                                  args->bytes_len,
+                                  args->ssl,
+                                  args->orig_dport,
+                                  tp_loop_fn);
+
+    if (tp_loop_fn == bpf_strstr_tp_loop) {
+        return __obi_continue2_protocol_http(ctx, args, info, meta);
+    } else {
+        bpf_tail_call(ctx, &jump_table, k_tail_continue2_protocol_http);
+    }
+
+    return 0;
+}
+
+// k_tail_continue_protocol_http
+SEC("kprobe/http")
+int obi_continue_protocol_http(struct pt_regs *ctx) {
+    call_protocol_args_t *args = protocol_args();
+    if (!args) {
+        return 0;
+    }
+
+    http_info_t *info = bpf_map_lookup_elem(&ongoing_http, &args->pid_conn);
+    if (!info) {
+        return 0;
+    }
+
+    return __obi_continue_protocol_http(ctx, args, info, bpf_strstr_tp_loop__legacy);
+}
+
+static __always_inline int __obi_protocol_http(struct pt_regs *ctx,
+                                               u16 (*tp_loop_fn)(unsigned char *, u16)) {
     call_protocol_args_t *args = protocol_args();
     if (!args) {
         return 0;
@@ -430,6 +522,7 @@ static __always_inline int __obi_protocol_http(unsigned char *(*tp_loop_fn)(unsi
     if (self_ref_tp) {
         __builtin_memcpy(&self_ref_parent_id, &self_ref_tp->parent_id, sizeof(u64));
     }
+    args->self_ref_parent_id = self_ref_parent_id;
 
     http_info_t *info =
         get_or_set_http_info(in, &args->pid_conn, args->packet_type, args->direction);
@@ -446,40 +539,12 @@ static __always_inline int __obi_protocol_http(unsigned char *(*tp_loop_fn)(unsi
 
     if (args->packet_type == PACKET_TYPE_REQUEST && (info->status == 0) &&
         (info->start_monotime_ns == 0)) {
-        http_connection_metadata_t *meta =
-            connection_meta_by_direction(args->direction, PACKET_TYPE_REQUEST);
-
-        http_get_or_create_trace_info(meta,
-                                      args->pid_conn.pid,
-                                      &args->pid_conn.conn,
-                                      (void *)args->u_buf,
-                                      args->bytes_len,
-                                      capture_header_buffer,
-                                      args->ssl,
-                                      args->orig_dport,
-                                      tp_loop_fn);
-
-        if (meta) {
-            u32 type = trace_type_from_meta(meta);
-            tp_info_pid_t *tp_p = trace_info_for_connection(&args->pid_conn.conn, type);
-            if (tp_p) {
-                info->tp = tp_p->tp;
-                if (self_ref_parent_id) {
-                    bpf_dbg_printk(
-                        "overwriting parent id from the self referencing client request");
-                    __builtin_memcpy(&info->tp.parent_id, &self_ref_parent_id, sizeof(u64));
-                }
-            } else {
-                bpf_dbg_printk("Can't find trace info, this is a bug!");
-            }
+        if (tp_loop_fn == bpf_strstr_tp_loop) {
+            return __obi_continue_protocol_http(ctx, args, info, bpf_strstr_tp_loop);
         } else {
-            bpf_dbg_printk("No META!");
+            bpf_tail_call(ctx, &jump_table, k_tail_continue_protocol_http);
+            return 0;
         }
-
-        // we copy some small part of the buffer to the info trace event, so that we can process an event even with
-        // incomplete trace info in user space.
-        bpf_probe_read(info->buf, FULL_BUF_SIZE, (void *)args->u_buf);
-        process_http_request(info, args->bytes_len, meta, args->direction, args->orig_dport);
     } else if ((args->packet_type == PACKET_TYPE_RESPONSE) && (info->status == 0)) {
         handle_http_response(
             args->small_buf, &args->pid_conn, info, args->bytes_len, args->direction, args->ssl);
@@ -493,14 +558,12 @@ static __always_inline int __obi_protocol_http(unsigned char *(*tp_loop_fn)(unsi
 
 // k_tail_protocol_http
 SEC("kprobe/http")
-static int obi_protocol_http(void *ctx) {
-    (void)ctx;
-    return __obi_protocol_http(bpf_strstr_tp_loop);
+int obi_protocol_http(struct pt_regs *ctx) {
+    return __obi_protocol_http(ctx, bpf_strstr_tp_loop);
 }
 
 // k_tail_protocol_http
 SEC("kprobe/http")
-static int obi_protocol_http_legacy(void *ctx) {
-    (void)ctx;
-    return __obi_protocol_http(bpf_strstr_tp_loop__legacy);
+int obi_protocol_http_legacy(struct pt_regs *ctx) {
+    return __obi_protocol_http(ctx, bpf_strstr_tp_loop__legacy);
 }

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -41,14 +41,16 @@ static __always_inline u32 trace_type_from_meta(http_connection_metadata_t *meta
     return TRACE_TYPE_SERVER;
 }
 
-static __always_inline void http_get_or_create_trace_info(http_connection_metadata_t *meta,
-                                                          u32 pid,
-                                                          connection_info_t *conn,
-                                                          void *u_buf,
-                                                          int bytes_len,
-                                                          s32 capture_header_buffer,
-                                                          u8 ssl,
-                                                          u16 orig_dport) {
+static __always_inline void
+http_get_or_create_trace_info(http_connection_metadata_t *meta,
+                              u32 pid,
+                              connection_info_t *conn,
+                              void *u_buf,
+                              int bytes_len,
+                              s32 capture_header_buffer,
+                              u8 ssl,
+                              u16 orig_dport,
+                              unsigned char *(*tp_loop_fn)(unsigned char *, int)) {
     //TODO use make_key
     egress_key_t e_key = {
         .d_port = conn->d_port,
@@ -148,8 +150,8 @@ static __always_inline void http_get_or_create_trace_info(http_connection_metada
             bpf_clamp_umax(buf_len, TRACE_BUF_SIZE - 1);
 
             bpf_probe_read(buf, buf_len, u_buf);
-            unsigned char *res = bpf_strstr_tp_loop(buf, buf_len);
 
+            unsigned char *res = tp_loop_fn(buf, buf_len);
             if (res) {
                 bpf_dbg_printk("Found traceparent in headers [%s] overriding what was before", res);
                 unsigned char *t_id = extract_trace_id(res);
@@ -401,13 +403,8 @@ static __always_inline void handle_http_response(unsigned char *small_buf,
     cleanup_http_request_data(pid_conn, info);
 }
 
-// k_tail_protocol_http
-SEC("kprobe/http")
-int obi_protocol_http(void *ctx) {
-    (void)ctx;
-
+static __always_inline int __obi_protocol_http(unsigned char *(*tp_loop_fn)(unsigned char *, int)) {
     call_protocol_args_t *args = protocol_args();
-
     if (!args) {
         return 0;
     }
@@ -459,7 +456,8 @@ int obi_protocol_http(void *ctx) {
                                       args->bytes_len,
                                       capture_header_buffer,
                                       args->ssl,
-                                      args->orig_dport);
+                                      args->orig_dport,
+                                      tp_loop_fn);
 
         if (meta) {
             u32 type = trace_type_from_meta(meta);
@@ -491,4 +489,18 @@ int obi_protocol_http(void *ctx) {
     }
 
     return 0;
+}
+
+// k_tail_protocol_http
+SEC("kprobe/http")
+static int obi_protocol_http(void *ctx) {
+    (void)ctx;
+    return __obi_protocol_http(bpf_strstr_tp_loop);
+}
+
+// k_tail_protocol_http
+SEC("kprobe/http")
+static int obi_protocol_http_legacy(void *ctx) {
+    (void)ctx;
+    return __obi_protocol_http(bpf_strstr_tp_loop__legacy);
 }

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_builtins.h>
 #include <bpfcore/bpf_helpers.h>
 
 #include <common/http_types.h>
@@ -43,14 +44,15 @@ static __always_inline u32 trace_type_from_meta(http_connection_metadata_t *meta
     return TRACE_TYPE_SERVER;
 }
 
-static __always_inline void http_get_or_create_trace_info(http_connection_metadata_t *meta,
-                                                          u32 pid,
-                                                          connection_info_t *conn,
-                                                          void *u_buf,
-                                                          int bytes_len,
-                                                          u8 ssl,
-                                                          u16 orig_dport,
-                                                          u16 (*tp_loop_fn)(unsigned char *, u16)) {
+static __always_inline void
+http_get_or_create_trace_info(http_connection_metadata_t *meta,
+                              u32 pid,
+                              connection_info_t *conn,
+                              void *u_buf,
+                              int bytes_len,
+                              u8 ssl,
+                              u16 orig_dport,
+                              unsigned char *(*tp_loop_fn)(unsigned char *, const u16)) {
     //TODO use make_key
     egress_key_t e_key = {
         .d_port = conn->d_port,
@@ -146,15 +148,16 @@ static __always_inline void http_get_or_create_trace_info(http_connection_metada
 
         unsigned char *buf = tp_char_buf();
         if (buf) {
-            u16 buf_len = bytes_len & (TRACE_BUF_SIZE - 1);
-            __builtin_memset(buf, 0, TRACE_BUF_SIZE);
+            const u16 buf_len = bytes_len & (TRACE_BUF_SIZE - 1);
+            _Static_assert(TRACE_BUF_SIZE == 1024,
+                           "Please fix the __bpf_memzero statements below this line");
+            __bpf_memzero(buf, 512);
+            __bpf_memzero(buf + 512, 512);
+
             bpf_probe_read(buf, buf_len, u_buf);
 
-            u16 idx = tp_loop_fn(buf, buf_len);
-
-            if (idx > 0 && idx < (TRACE_BUF_SIZE - TRACE_PARENT_HEADER_LEN)) {
-                unsigned char *res = &buf[idx];
-
+            unsigned char *res = tp_loop_fn(buf, buf_len);
+            if (res) {
                 bpf_dbg_printk("Found traceparent in headers [%s] overriding what was before", res);
                 unsigned char *t_id = extract_trace_id(res);
                 unsigned char *s_id = extract_span_id(res);
@@ -453,10 +456,11 @@ int obi_continue2_protocol_http(struct pt_regs *ctx) {
     return __obi_continue2_protocol_http(ctx, args, info, meta);
 }
 
-static __always_inline int __obi_continue_protocol_http(struct pt_regs *ctx,
-                                                        call_protocol_args_t *args,
-                                                        http_info_t *info,
-                                                        u16 (*tp_loop_fn)(unsigned char *, u16)) {
+static __always_inline int
+__obi_continue_protocol_http(struct pt_regs *ctx,
+                             call_protocol_args_t *args,
+                             http_info_t *info,
+                             unsigned char *(*tp_loop_fn)(unsigned char *, const u16)) {
     http_connection_metadata_t *meta =
         connection_meta_by_direction(args->direction, PACKET_TYPE_REQUEST);
 
@@ -494,8 +498,8 @@ int obi_continue_protocol_http(struct pt_regs *ctx) {
     return __obi_continue_protocol_http(ctx, args, info, bpf_strstr_tp_loop__legacy);
 }
 
-static __always_inline int __obi_protocol_http(struct pt_regs *ctx,
-                                               u16 (*tp_loop_fn)(unsigned char *, u16)) {
+static __always_inline int
+__obi_protocol_http(struct pt_regs *ctx, unsigned char *(*tp_loop_fn)(unsigned char *, const u16)) {
     call_protocol_args_t *args = protocol_args();
     if (!args) {
         return 0;

--- a/bpf/maps/sock_dir.h
+++ b/bpf/maps/sock_dir.h
@@ -17,5 +17,5 @@ struct {
     __uint(type, BPF_MAP_TYPE_SOCKHASH);
     __uint(max_entries, 65535);
     __uint(key_size, sizeof(connection_info_t));
-    __uint(value_size, sizeof(uint32_t));
+    __uint(value_size, sizeof(u32));
 } sock_dir SEC(".maps");

--- a/pkg/components/ebpf/common/common.go
+++ b/pkg/components/ebpf/common/common.go
@@ -306,7 +306,6 @@ func SupportsContextPropagationWithProbe(log *slog.Logger) bool {
 }
 
 func SupportsEBPFLoops(log *slog.Logger, overrideKernelVersion bool) bool {
-	// TODO(matt): probe for BPF_FUNC_loop instead of relying on kernel version?
 	if overrideKernelVersion {
 		log.Debug("Skipping kernel version check for bpf_loop functionality: user supplied confirmation of support")
 		return true
@@ -315,8 +314,8 @@ func SupportsEBPFLoops(log *slog.Logger, overrideKernelVersion bool) bool {
 	return kernelMajor > 5 || (kernelMajor == 5 && kernelMinor >= 17)
 }
 
-func FixupSpec(spec *ebpf.CollectionSpec, overrideKernelVersion bool) {
-	if !SupportsEBPFLoops(ptlog(), overrideKernelVersion) {
+func FixupSpec(spec *ebpf.CollectionSpec, bpfLoopEnabled bool) {
+	if !bpfLoopEnabled {
 		// Hack: instead of redefining bpf2go generated struct for mutually exclusive conditional programs,
 		// use one predefined field name to store either of them.
 		spec.Programs["obi_protocol_http"] = spec.Programs["obi_protocol_http_legacy"]

--- a/pkg/components/ebpf/common/common.go
+++ b/pkg/components/ebpf/common/common.go
@@ -314,8 +314,8 @@ func SupportsEBPFLoops(log *slog.Logger, overrideKernelVersion bool) bool {
 	return kernelMajor > 5 || (kernelMajor == 5 && kernelMinor >= 17)
 }
 
-func FixupSpec(spec *ebpf.CollectionSpec, bpfLoopEnabled bool) {
-	if !bpfLoopEnabled {
+func FixupSpec(spec *ebpf.CollectionSpec, overrideKernelVersion bool) {
+	if !SupportsEBPFLoops(ptlog(), overrideKernelVersion) {
 		// Hack: instead of redefining bpf2go generated struct for mutually exclusive conditional programs,
 		// use one predefined field name to store either of them.
 		spec.Programs["obi_protocol_http"] = spec.Programs["obi_protocol_http_legacy"]

--- a/pkg/components/ebpf/common/common.go
+++ b/pkg/components/ebpf/common/common.go
@@ -17,6 +17,7 @@ import (
 	"unsafe"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/link"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/hashicorp/golang-lru/v2/expirable"
@@ -305,12 +306,33 @@ func SupportsContextPropagationWithProbe(log *slog.Logger) bool {
 }
 
 func SupportsEBPFLoops(log *slog.Logger, overrideKernelVersion bool) bool {
+	// TODO(matt): probe for BPF_FUNC_loop instead of relying on kernel version?
 	if overrideKernelVersion {
 		log.Debug("Skipping kernel version check for bpf_loop functionality: user supplied confirmation of support")
 		return true
 	}
 	kernelMajor, kernelMinor := KernelVersion()
 	return kernelMajor > 5 || (kernelMajor == 5 && kernelMinor >= 17)
+}
+
+func FixupSpec(spec *ebpf.CollectionSpec, overrideKernelVersion bool) {
+	if !SupportsEBPFLoops(ptlog(), overrideKernelVersion) {
+		// Hack: instead of redefining bpf2go generated struct for mutually exclusive conditional programs,
+		// use one predefined field name to store either of them.
+		spec.Programs["obi_protocol_http"] = spec.Programs["obi_protocol_http_legacy"]
+		spec.Programs["obi_protocol_http"].Name = "obi_protocol_http"
+	}
+	// Hack: insert a dummy unused program in order to be able to use bpf2go generated struct to load
+	// the collection.
+	spec.Programs["obi_protocol_http_legacy"] = &ebpf.ProgramSpec{
+		Name: "obi_dummy",
+		Type: ebpf.Kprobe,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		License: "MIT",
+	}
 }
 
 // Injectable for tests

--- a/pkg/components/ebpf/generictracer/generictracer.go
+++ b/pkg/components/ebpf/generictracer/generictracer.go
@@ -141,18 +141,22 @@ func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
 
 	if p.cfg.EBPF.TrackRequestHeaders ||
 		p.cfg.EBPF.ContextPropagation != config.ContextPropagationDisabled {
-		if ebpfcommon.SupportsEBPFLoops(p.log, p.cfg.EBPF.OverrideBPFLoopEnabled) {
-			p.log.Info("Found compatible Linux kernel, enabling trace information parsing")
-			loader = LoadBpfTP
-			if p.cfg.EBPF.BpfDebug {
-				loader = LoadBpfTPDebug
-			}
-		} else {
-			p.log.Info("Found incompatible Linux kernel, disabling trace information parsing")
+		loader = LoadBpfTP
+		if p.cfg.EBPF.BpfDebug {
+			loader = LoadBpfTPDebug
 		}
+
+		p.log.Info("Enabling trace information parsing", "bpf_loop_enabled", ebpfcommon.SupportsEBPFLoops(p.log, p.cfg.EBPF.OverrideBPFLoopEnabled))
 	}
 
-	return loader()
+	spec, err := loader()
+	if err != nil {
+		return nil, fmt.Errorf("can't load bpf collection from reader: %w", err)
+	}
+
+	ebpfcommon.FixupSpec(spec, p.cfg.EBPF.OverrideBPFLoopEnabled)
+
+	return spec, err
 }
 
 func (p *Tracer) SetupTailCalls() {

--- a/pkg/components/ebpf/generictracer/generictracer.go
+++ b/pkg/components/ebpf/generictracer/generictracer.go
@@ -51,6 +51,7 @@ type Tracer struct {
 	instrumentedLibs ebpfcommon.InstrumentedLibsT
 	libsMux          sync.Mutex
 	iters            []*ebpfcommon.Iter
+	bpfLoopEnabled   bool
 }
 
 func tlog() *slog.Logger {
@@ -134,6 +135,10 @@ func (p *Tracer) BlockPID(pid, ns uint32) {
 }
 
 func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
+	// Default to true: if context propagation is disabled,
+	// load the non-legacy version of the http tailcalls.
+	bpfLoopEnabled := true
+
 	loader := LoadBpf
 	if p.cfg.EBPF.BpfDebug {
 		loader = LoadBpfDebug
@@ -146,7 +151,9 @@ func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
 			loader = LoadBpfTPDebug
 		}
 
-		p.log.Info("Enabling trace information parsing", "bpf_loop_enabled", ebpfcommon.SupportsEBPFLoops(p.log, p.cfg.EBPF.OverrideBPFLoopEnabled))
+		bpfLoopEnabled = ebpfcommon.SupportsEBPFLoops(p.log, p.cfg.EBPF.OverrideBPFLoopEnabled)
+
+		p.log.Info("Enabling trace information parsing", "bpf_loop_enabled", bpfLoopEnabled)
 	}
 
 	spec, err := loader()
@@ -154,7 +161,8 @@ func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
 		return nil, fmt.Errorf("can't load bpf collection from reader: %w", err)
 	}
 
-	ebpfcommon.FixupSpec(spec, p.cfg.EBPF.OverrideBPFLoopEnabled)
+	ebpfcommon.FixupSpec(spec, bpfLoopEnabled)
+	p.bpfLoopEnabled = bpfLoopEnabled
 
 	return spec, err
 }
@@ -162,12 +170,14 @@ func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
 func (p *Tracer) SetupTailCalls() {
 	for i, prog := range []*ebpf.Program{
 		p.bpfObjects.ObiProtocolHttp,                      // 0
-		p.bpfObjects.ObiProtocolHttp2,                     // 1
-		p.bpfObjects.ObiProtocolTcp,                       // 2
-		p.bpfObjects.ObiProtocolHttp2GrpcFrames,           // 3
-		p.bpfObjects.ObiProtocolHttp2GrpcHandleStartFrame, // 4
-		p.bpfObjects.ObiProtocolHttp2GrpcHandleEndFrame,   // 5
-		p.bpfObjects.ObiHandleBufWithArgs,                 // 6
+		p.bpfObjects.ObiContinueProtocolHttp,              // 1
+		p.bpfObjects.ObiContinue2ProtocolHttp,             // 2
+		p.bpfObjects.ObiProtocolHttp2,                     // 3
+		p.bpfObjects.ObiProtocolTcp,                       // 4
+		p.bpfObjects.ObiProtocolHttp2GrpcFrames,           // 5
+		p.bpfObjects.ObiProtocolHttp2GrpcHandleStartFrame, // 6
+		p.bpfObjects.ObiProtocolHttp2GrpcHandleEndFrame,   // 7
+		p.bpfObjects.ObiHandleBufWithArgs,                 // 8
 	} {
 		p.log.Debug("loading program into tail call jump table", "index", i, "program", prog.String())
 		if err := p.bpfObjects.JumpTable.Update(uint32(i), uint32(prog.FD()), ebpf.UpdateAny); err != nil {

--- a/pkg/components/ebpf/generictracer/generictracer.go
+++ b/pkg/components/ebpf/generictracer/generictracer.go
@@ -51,7 +51,6 @@ type Tracer struct {
 	instrumentedLibs ebpfcommon.InstrumentedLibsT
 	libsMux          sync.Mutex
 	iters            []*ebpfcommon.Iter
-	bpfLoopEnabled   bool
 }
 
 func tlog() *slog.Logger {
@@ -135,10 +134,6 @@ func (p *Tracer) BlockPID(pid, ns uint32) {
 }
 
 func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
-	// Default to true: if context propagation is disabled,
-	// load the non-legacy version of the http tailcalls.
-	bpfLoopEnabled := true
-
 	loader := LoadBpf
 	if p.cfg.EBPF.BpfDebug {
 		loader = LoadBpfDebug
@@ -151,9 +146,7 @@ func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
 			loader = LoadBpfTPDebug
 		}
 
-		bpfLoopEnabled = ebpfcommon.SupportsEBPFLoops(p.log, p.cfg.EBPF.OverrideBPFLoopEnabled)
-
-		p.log.Info("Enabling trace information parsing", "bpf_loop_enabled", bpfLoopEnabled)
+		p.log.Info("Enabling trace information parsing", "bpf_loop_enabled", ebpfcommon.SupportsEBPFLoops(p.log, p.cfg.EBPF.OverrideBPFLoopEnabled))
 	}
 
 	spec, err := loader()
@@ -161,8 +154,7 @@ func (p *Tracer) Load() (*ebpf.CollectionSpec, error) {
 		return nil, fmt.Errorf("can't load bpf collection from reader: %w", err)
 	}
 
-	ebpfcommon.FixupSpec(spec, bpfLoopEnabled)
-	p.bpfLoopEnabled = bpfLoopEnabled
+	ebpfcommon.FixupSpec(spec, p.cfg.EBPF.OverrideBPFLoopEnabled)
 
 	return spec, err
 }

--- a/pkg/components/ebpf/instrumenter.go
+++ b/pkg/components/ebpf/instrumenter.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
-	"github.com/containers/common/pkg/cgroupv2"
+	v2 "github.com/containers/common/pkg/cgroupv2"
 	"github.com/prometheus/procfs"
 	"golang.org/x/sys/unix"
 
@@ -488,7 +488,7 @@ func processMaps(pid int32) ([]*procfs.ProcMap, error) {
 func getCgroupPath() (string, error) {
 	cgroupPath := "/sys/fs/cgroup"
 
-	enabled, err := cgroupv2.Enabled()
+	enabled, err := v2.Enabled()
 	if !enabled {
 		if _, pathErr := os.Stat(filepath.Join(cgroupPath, "unified")); pathErr == nil {
 			slog.Debug("discovered hybrid cgroup hierarchy, will attempt to attach sockops")

--- a/pkg/components/ebpf/instrumenter.go
+++ b/pkg/components/ebpf/instrumenter.go
@@ -371,7 +371,8 @@ func (i *instrumenter) sockops(p Tracer) error {
 			if i.metrics != nil {
 				i.metrics.InstrumentationError(i.processName, imetrics.InstrumentationErrorCgroupNotFound)
 			}
-			return fmt.Errorf("error getting cgroup path for sockops: %w", err)
+			slog.Warn("could not get cgroup path (missing cgroup v2?), using best-effort TC tracking", "error", err)
+			return nil
 		}
 
 		slog.Info("Attaching sock ops", "path", cgroupPath)
@@ -385,7 +386,8 @@ func (i *instrumenter) sockops(p Tracer) error {
 			if i.metrics != nil {
 				i.metrics.InstrumentationError(i.processName, imetrics.InstrumentationErrorAttachingCgroup)
 			}
-			return fmt.Errorf("attaching sockops program: %w", err)
+			slog.Warn("could not attach sockops program, using best-effort TC tracking", "error", err)
+			return nil
 		}
 
 		p.AddCloser(&sockops)
@@ -494,6 +496,7 @@ func getCgroupPath() (string, error) {
 		}
 		return "", errors.New("failed to find unified cgroup hierarchy: sockops cannot be used with cgroups v1")
 	}
+
 	return cgroupPath, err
 }
 

--- a/pkg/components/ebpf/tcmanager/tcmanager.go
+++ b/pkg/components/ebpf/tcmanager/tcmanager.go
@@ -93,7 +93,7 @@ func (b *TCBackend) UnmarshalText(text []byte) error {
 		return nil
 	}
 
-	return fmt.Errorf("invalid TCBackend value: '%s'", text)
+	return fmt.Errorf("invalid TCBakend value: '%s'", text)
 }
 
 func (b TCBackend) MarshalText() ([]byte, error) {
@@ -106,7 +106,7 @@ func (b TCBackend) MarshalText() ([]byte, error) {
 		return []byte("auto"), nil
 	}
 
-	return nil, fmt.Errorf("invalid TCBackend value: %d", b)
+	return nil, fmt.Errorf("invalid TCBakend value: %d", b)
 }
 
 func (b TCBackend) Valid() bool {

--- a/pkg/components/kube/informer_provider.go
+++ b/pkg/components/kube/informer_provider.go
@@ -323,7 +323,7 @@ func loadKubeConfig(kubeConfigPath string) (*rest.Config, error) {
 	// fallback: use in-cluster config
 	config, err = rest.InClusterConfig()
 	if err != nil {
-		return nil, fmt.Errorf("can't access kubernetes. Tried using config from: "+
+		return nil, fmt.Errorf("can't access kubenetes. Tried using config from: "+
 			"config parameter, %s env, homedir and InClusterConfig. Got: %w",
 			kubeConfigEnvVariable, err)
 	}

--- a/pkg/kubecache/meta/informers_init.go
+++ b/pkg/kubecache/meta/informers_init.go
@@ -251,7 +251,7 @@ func loadKubeconfig(kubeConfigPath string) (*rest.Config, error) {
 	// fallback: use in-cluster config
 	config, err = rest.InClusterConfig()
 	if err != nil {
-		return nil, fmt.Errorf("can't access kubernetes. Tried using config from: "+
+		return nil, fmt.Errorf("can't access kubenetes. Tried using config from: "+
 			"config parameter, %s env, homedir and InClusterConfig. Got: %w",
 			kubeConfigEnvVariable, err)
 	}

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -83,6 +83,7 @@ var DefaultConfig = Config{
 		PostgresPreparedStatementsCacheSize: 1024,
 		MongoRequestsCacheSize:              1024,
 		KafkaTopicUUIDCacheSize:             1024,
+		OverrideBPFLoopEnabled:              false,
 	},
 	NameResolver: &transform.NameResolverConfig{
 		Sources:  []string{"k8s"},

--- a/test/integration/multiprocess_test.go
+++ b/test/integration/multiprocess_test.go
@@ -99,15 +99,13 @@ func TestMultiProcess(t *testing.T) {
 		assert.Empty(t, results)
 	})
 
-	if kprobeTracesEnabled() {
-		t.Run("Nested traces with kprobes: rust -> java -> node -> go -> go jsonrpc -> python -> rails", func(t *testing.T) {
-			testNestedHTTPTracesKProbes(t)
-		})
+	t.Run("Nested traces with kprobes: rust -> java -> node -> go -> go jsonrpc -> python -> rails", func(t *testing.T) {
+		testNestedHTTPTracesKProbes(t)
+	})
 
-		t.Run("Nested traces with kprobes: SSL node python rails", func(t *testing.T) {
-			testNestedHTTPSTracesKProbes(t)
-		})
-	}
+	t.Run("Nested traces with kprobes: SSL node python rails", func(t *testing.T) {
+		testNestedHTTPSTracesKProbes(t)
+	})
 
 	t.Run("Instrumented processes metric", func(t *testing.T) {
 		checkInstrumentedProcessesMetric(t)
@@ -124,11 +122,9 @@ func TestMultiProcessAppCP(t *testing.T) {
 	compose.Env = append(compose.Env, `OTEL_EBPF_BPF_DISABLE_BLACK_BOX_CP=1`, `OTEL_EBPF_BPF_CONTEXT_PROPAGATION=all`, `OTEL_EBPF_BPF_TRACK_REQUEST_HEADERS=1`)
 	require.NoError(t, compose.Up())
 
-	if kprobeTracesEnabled() {
-		t.Run("Nested traces with kprobes: rust -> java -> node -> go -> go jsonrpc -> python -> rails", func(t *testing.T) {
-			testNestedHTTPTracesKProbes(t)
-		})
-	}
+	t.Run("Nested traces with kprobes: rust -> java -> node -> go -> go jsonrpc -> python -> rails", func(t *testing.T) {
+		testNestedHTTPTracesKProbes(t)
+	})
 	require.NoError(t, compose.Close())
 }
 
@@ -141,11 +137,10 @@ func TestMultiProcessAppCPNoIP(t *testing.T) {
 
 	require.NoError(t, compose.Up())
 
-	if kprobeTracesEnabled() {
-		t.Run("Nested traces with kprobes: rust -> java -> node -> go -> go jsonrpc -> python -> rails", func(t *testing.T) {
-			testNestedHTTPTracesKProbes(t)
-		})
-	}
+	t.Run("Nested traces with kprobes: rust -> java -> node -> go -> go jsonrpc -> python -> rails", func(t *testing.T) {
+		testNestedHTTPTracesKProbes(t)
+	})
+
 	require.NoError(t, compose.Close())
 }
 

--- a/test/integration/red_test_nodeclient.go
+++ b/test/integration/red_test_nodeclient.go
@@ -100,9 +100,7 @@ func testNodeClientWithMethodAndStatusCode(t *testing.T, method string, statusCo
 	 We check that the traceID has that 16 character 0 suffix and then we
 	 use the first 16 characters for looking up by Parent span.
 	*/
-	if kprobeTracesEnabled() {
-		assert.NotEmpty(t, span.TraceID)
-		assert.Truef(t, strings.HasSuffix(span.TraceID, traceIDLookup),
-			"string %q should have suffix %q", span.TraceID, traceIDLookup)
-	}
+	assert.NotEmpty(t, span.TraceID)
+	assert.Truef(t, strings.HasSuffix(span.TraceID, traceIDLookup),
+		"string %q should have suffix %q", span.TraceID, traceIDLookup)
 }

--- a/test/integration/red_test_rust.go
+++ b/test/integration/red_test_rust.go
@@ -87,12 +87,12 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url, comm, namespace string,
 	require.Len(t, res, 1)
 	parent := res[0]
 	require.NotEmpty(t, parent.TraceID)
-	if kprobeTracesEnabled() {
-		require.Equal(t, traceID, parent.TraceID)
-		// Validate that "parent" is a CHILD_OF the traceparent's "parent-id"
-		childOfPID := trace.ChildrenOf(parentID)
-		require.Len(t, childOfPID, 1)
-	}
+	require.Equal(t, traceID, parent.TraceID)
+
+	// Validate that "parent" is a CHILD_OF the traceparent's "parent-id"
+	childOfPID := trace.ChildrenOf(parentID)
+	require.Len(t, childOfPID, 1)
+
 	require.NotEmpty(t, parent.SpanID)
 	// check duration is at least 2us
 	assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -14,15 +14,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/test/integration/components/docker"
 )
-
-func kprobeTracesEnabled() bool {
-	major, minor := obi.KernelVersion()
-
-	return major > 5 || (major == 5 && minor >= 17)
-}
 
 func TestSuite(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite.log"))
@@ -507,11 +500,6 @@ func TestSuite_OverrideServiceName(t *testing.T) {
 }
 
 func TestSuiteNodeClient(t *testing.T) {
-	if !kprobeTracesEnabled() {
-		t.Skip("distributed traces not supported")
-		return
-	}
-
 	compose, err := docker.ComposeSuite("docker-compose-nodeclient.yml", path.Join(pathOutput, "test-suite-nodeclient.log"))
 	require.NoError(t, err)
 
@@ -524,11 +512,6 @@ func TestSuiteNodeClient(t *testing.T) {
 }
 
 func TestSuiteNodeClientTLS(t *testing.T) {
-	if !kprobeTracesEnabled() {
-		t.Skip("distributed traces not supported")
-		return
-	}
-
 	compose, err := docker.ComposeSuite("docker-compose-nodeclient.yml", path.Join(pathOutput, "test-suite-nodeclient-tls.log"))
 	require.NoError(t, err)
 

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -333,12 +333,12 @@ func testHTTPTracesKProbes(t *testing.T) {
 	require.Len(t, res, 1)
 	parent := res[0]
 	require.NotEmpty(t, parent.TraceID)
-	if kprobeTracesEnabled() {
-		require.Equal(t, traceID, parent.TraceID)
-		// Validate that "parent" is a CHILD_OF the traceparent's "parent-id"
-		childOfPID := trace.ChildrenOf(parentID)
-		require.Len(t, childOfPID, 1)
-	}
+	require.Equal(t, traceID, parent.TraceID)
+
+	// Validate that "parent" is a CHILD_OF the traceparent's "parent-id"
+	childOfPID := trace.ChildrenOf(parentID)
+	require.Len(t, childOfPID, 1)
+
 	require.NotEmpty(t, parent.SpanID)
 	// check duration is at least 2us
 	assert.Less(t, (2 * time.Microsecond).Microseconds(), parent.Duration)


### PR DESCRIPTION
- Based on runtime kernel, load either a bpf_loop-enabled tail call or a bounded loop tail call*
- Continue with ebpf collection loading if sockops load fails


*I couldn't make this decision in a single program via BTF at runtime because of a possible loader bug. Loading an unused subprog with static linkage:
```
int prog(...) {
    ...

    if (bpf_core_enum_value_exists(enum bpf_func_id, BPF_FUNC_loop)) {
        res = myfunc();
    } else {
        res = myfunc__legacy();
    }

    ...
}

static int culprit(u32 index, void *data) {
    ...
}

static __always_inline int myfunc() {
    struct callback_ctx data = {.buf = buf, .pos = 0};
    bpf_loop(nr_loops, culprit, &data, 0);
    return 0;
}

static __always_inline int myfunc__legacy() {
    ...
    return 0;
}
```
would make func_info from .BTF.ext inconsistent:
```
field ObiProtocolHttp: program obi_protocol_http: load program: invalid argument: number of funcs in func_info doesn't match number of subprogs (1 line(s) omitted)
```
and I believe it has to do with the way instructions are marshaled in the loader; also these type of functions *must* be subprogs with static linkage: https://elixir.bootlin.com/linux/v6.16.3/source/kernel/bpf/verifier.c#L16708, and I found no other way around that