### PR TITLE
cleanup: rename `BEYLA_PIN_INTERNAL` to `OBI_PIN_INTERNAL` 

### DIFF
--- a/bpf/common/pin_internal.h
+++ b/bpf/common/pin_internal.h
@@ -3,4 +3,4 @@
 
 #pragma once
 
-enum { BEYLA_PIN_INTERNAL = 100 };
+enum { OBI_PIN_INTERNAL = 100 };

--- a/bpf/common/ringbuf.h
+++ b/bpf/common/ringbuf.h
@@ -35,7 +35,7 @@
 struct {
     __uint(type, BPF_MAP_TYPE_RINGBUF);
     __uint(max_entries, 1 << 16);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } events SEC(".maps");
 
 // To be Injected from the user space during the eBPF program load & initialization

--- a/bpf/generictracer/maps/node_fds.h
+++ b/bpf/generictracer/maps/node_fds.h
@@ -13,5 +13,5 @@ struct {
     __type(key, u64);
     __type(value, s32);
     __uint(max_entries, 1000);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } node_fds SEC(".maps");

--- a/bpf/generictracer/maps/ongoing_tcp_req.h
+++ b/bpf/generictracer/maps/ongoing_tcp_req.h
@@ -15,5 +15,5 @@ struct {
     __type(key, pid_connection_info_t);
     __type(value, tcp_req_t);
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } ongoing_tcp_req SEC(".maps");

--- a/bpf/gotracer/go_common.h
+++ b/bpf/gotracer/go_common.h
@@ -51,7 +51,7 @@ struct {
     __type(key, go_addr_key_t);        // key: pointer to the goroutine
     __type(value, goroutine_metadata); // value: timestamp of the goroutine creation
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } ongoing_goroutines SEC(".maps");
 
 struct {
@@ -59,7 +59,7 @@ struct {
     __type(key, go_addr_key_t); // key: pointer to the request goroutine
     __type(value, connection_info_t);
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } ongoing_server_connections SEC(".maps");
 
 struct {
@@ -74,7 +74,7 @@ struct {
     __type(key, go_addr_key_t); // key: pointer to the goroutine
     __type(value, tp_info_t);   // value: traceparent info
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } go_trace_map SEC(".maps");
 
 struct {

--- a/bpf/gotracer/go_sdk.c
+++ b/bpf/gotracer/go_sdk.c
@@ -46,7 +46,7 @@ struct {
     __type(key, go_addr_key_t); // goroutine
     __type(value, span_info_t);
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } span_names SEC(".maps");
 
 struct {
@@ -54,7 +54,7 @@ struct {
     __type(key, go_addr_key_t); // span pointer
     __type(value, otel_span_t);
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } active_spans SEC(".maps");
 
 struct {

--- a/bpf/logger/bpf_dbg.h
+++ b/bpf/logger/bpf_dbg.h
@@ -32,7 +32,7 @@ typedef struct log_info {
 struct {
     __uint(type, BPF_MAP_TYPE_RINGBUF);
     __uint(max_entries, 1 << 12);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } debug_events SEC(".maps");
 
 enum bpf_func_id___x { BPF_FUNC_snprintf___x = 42 /* avoid zero */ };

--- a/bpf/maps/active_ssl_connections.h
+++ b/bpf/maps/active_ssl_connections.h
@@ -15,5 +15,5 @@ struct {
     __type(key, pid_connection_info_t); // connection that's SSL
     __type(value, u64);                 // ssl
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } active_ssl_connections SEC(".maps");

--- a/bpf/maps/active_ssl_read_args.h
+++ b/bpf/maps/active_ssl_read_args.h
@@ -18,5 +18,5 @@ struct {
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
     __type(key, u64);
     __type(value, ssl_args_t);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } active_ssl_read_args SEC(".maps");

--- a/bpf/maps/active_ssl_write_args.h
+++ b/bpf/maps/active_ssl_write_args.h
@@ -15,5 +15,5 @@ struct {
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
     __type(key, u64);
     __type(value, ssl_args_t);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } active_ssl_write_args SEC(".maps");

--- a/bpf/maps/active_unix_socks.h
+++ b/bpf/maps/active_unix_socks.h
@@ -14,5 +14,5 @@ struct {
     __type(key, u64);   // the pid_tid
     __type(value, u32); // the last seen ino
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } active_unix_socks SEC(".maps");

--- a/bpf/maps/clone_map.h
+++ b/bpf/maps/clone_map.h
@@ -14,5 +14,5 @@ struct {
     __type(key, pid_key_t);   // key: the child pid
     __type(value, pid_key_t); // value: the parent pid
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } clone_map SEC(".maps");

--- a/bpf/maps/cp_support_connect_info.h
+++ b/bpf/maps/cp_support_connect_info.h
@@ -15,5 +15,5 @@ struct {
     __type(key, pid_connection_info_t); // key: conn_info
     __type(value, cp_support_data_t);   // value: tracekey to lookup in server_traces
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } cp_support_connect_info SEC(".maps");

--- a/bpf/maps/fd_map.h
+++ b/bpf/maps/fd_map.h
@@ -15,7 +15,7 @@ struct {
     __type(key, connection_info_part_t); // key: the connection info
     __type(value, fd_info_t);            // value: file descriptor with pid/tid information
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } fd_map SEC(".maps");
 
 static __always_inline void get_ephemeral_info(connection_info_part_t *part,

--- a/bpf/maps/fd_to_connection.h
+++ b/bpf/maps/fd_to_connection.h
@@ -16,5 +16,5 @@ struct {
     __type(key, fd_key); // key: fd
     __type(value, connection_info_t);
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } fd_to_connection SEC(".maps");

--- a/bpf/maps/go_ongoing_http.h
+++ b/bpf/maps/go_ongoing_http.h
@@ -15,5 +15,5 @@ struct {
     __type(key, egress_key_t);
     __type(value, go_addr_key_t);
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } go_ongoing_http SEC(".maps");

--- a/bpf/maps/go_ongoing_http_client_requests.h
+++ b/bpf/maps/go_ongoing_http_client_requests.h
@@ -15,5 +15,5 @@ struct {
     __type(key, go_addr_key_t); // key: pointer to the request goroutine
     __type(value, http_func_invocation_t);
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } go_ongoing_http_client_requests SEC(".maps");

--- a/bpf/maps/incoming_trace_map.h
+++ b/bpf/maps/incoming_trace_map.h
@@ -16,5 +16,5 @@ struct {
     __type(key, connection_info_t); // key: the connection info
     __type(value, tp_info_pid_t);   // value: traceparent info
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } incoming_trace_map SEC(".maps");

--- a/bpf/maps/msg_buffers.h
+++ b/bpf/maps/msg_buffers.h
@@ -15,5 +15,5 @@ struct {
     __type(key, egress_key_t);
     __type(value, msg_buffer_t);
     __uint(max_entries, 1000);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } msg_buffers SEC(".maps");

--- a/bpf/maps/nginx_upstream.h
+++ b/bpf/maps/nginx_upstream.h
@@ -16,5 +16,5 @@ struct {
     __type(key, fd_info_t);                // the fd information with pid, tid
     __type(value, connection_info_part_t); // the ephemeral connection info
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } nginx_upstream SEC(".maps");

--- a/bpf/maps/nodejs_fd_map.h
+++ b/bpf/maps/nodejs_fd_map.h
@@ -13,5 +13,5 @@ struct {
     __type(key, u64);          // tid | fd
     __type(value, s32);        // fd
     __uint(max_entries, 1000); // 1000 nodejs services, small number, nodejs is single threaded
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } nodejs_fd_map SEC(".maps");

--- a/bpf/maps/ongoing_http.h
+++ b/bpf/maps/ongoing_http.h
@@ -17,5 +17,5 @@ struct {
     __type(key, pid_connection_info_t);
     __type(value, http_info_t);
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } ongoing_http SEC(".maps");

--- a/bpf/maps/outgoing_trace_map.h
+++ b/bpf/maps/outgoing_trace_map.h
@@ -16,5 +16,5 @@ struct {
     __type(key, egress_key_t);    // key: the connection info
     __type(value, tp_info_pid_t); // value: traceparent info
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } outgoing_trace_map SEC(".maps");

--- a/bpf/maps/server_traces.h
+++ b/bpf/maps/server_traces.h
@@ -16,7 +16,7 @@ struct {
     __type(key, trace_key_t);     // key: pid_tid
     __type(value, tp_info_pid_t); // value: traceparent info
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } server_traces SEC(".maps");
 
 struct {
@@ -24,5 +24,5 @@ struct {
     __type(key, connection_info_part_t); // key: the ephemeral port + address
     __type(value, tp_info_pid_t);        // value: traceparent info
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } server_traces_aux SEC(".maps");

--- a/bpf/maps/sk_buffers.h
+++ b/bpf/maps/sk_buffers.h
@@ -26,7 +26,7 @@ struct {
     __type(key, connection_info_t);
     __type(value, sk_msg_buffer_t);
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } sk_buffers SEC(".maps");
 
 struct {

--- a/bpf/maps/ssl_to_conn.h
+++ b/bpf/maps/ssl_to_conn.h
@@ -18,5 +18,5 @@ struct {
     __type(key, u64);                         // the SSL struct pointer
     __type(value, ssl_pid_connection_info_t); // the pointer to the file descriptor matching ssl
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } ssl_to_conn SEC(".maps");

--- a/bpf/maps/trace_map.h
+++ b/bpf/maps/trace_map.h
@@ -16,5 +16,5 @@ struct {
     __type(key, trace_map_key_t); // key: the connection info
     __type(value, tp_info_pid_t); // value: traceparent info
     __uint(max_entries, MAX_CONCURRENT_SHARED_REQUESTS);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } trace_map SEC(".maps");

--- a/bpf/pid/maps/pid_cache.h
+++ b/bpf/pid/maps/pid_cache.h
@@ -15,5 +15,5 @@ struct {
     __uint(max_entries, k_max_concurrent_pids);
     __type(key, u32);
     __type(value, u32);
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } pid_cache SEC(".maps");

--- a/bpf/pid/maps/valid_pids.h
+++ b/bpf/pid/maps/valid_pids.h
@@ -15,5 +15,5 @@ struct {
     __uint(max_entries, k_max_concurrent_pids);
     __type(key, u32);
     __type(value, u64); // using 8 bytes, because array elements are 8 bytes aligned anyway
-    __uint(pinning, BEYLA_PIN_INTERNAL);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } valid_pids SEC(".maps");

--- a/pkg/components/appolly/appolly.go
+++ b/pkg/components/appolly/appolly.go
@@ -118,11 +118,10 @@ func (i *Instrumenter) FindAndInstrument(ctx context.Context) error {
 	// In the background process any process found events and annotate them with
 	// the Host or Kubernetes metadata
 	graph, err := i.peGraphBuilder.Instance(ctx)
-	if err == nil {
-		i.processEventsPipeline(ctx, graph)
-	} else {
+	if err != nil {
 		return fmt.Errorf("couldn't start Process Event pipeline: %w", err)
 	}
+	i.processEventsPipeline(ctx, graph)
 
 	// registers resources that must be done before exiting OBI
 	i.finishers = append(i.finishers,

--- a/pkg/components/discover/attacher.go
+++ b/pkg/components/discover/attacher.go
@@ -31,10 +31,10 @@ import (
 // for each received Instrumentable process and forwards an ebpf.ProcessTracer instance ready to run and start
 // instrumenting the executable
 type TraceAttacher struct {
-	log      *slog.Logger
-	Cfg      *obi.Config
-	Metrics  imetrics.Reporter
-	beylaPID int
+	log     *slog.Logger
+	Cfg     *obi.Config
+	Metrics imetrics.Reporter
+	obiPID  int
 
 	// processInstances keeps track of the instances of each process. This will help making sure
 	// that we don't remove the BPF resources of an executable until all their instances are removed
@@ -82,7 +82,7 @@ func (ta *TraceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 	ta.sdkInjector = otelsdk.NewSDKInjector(ta.Cfg)
 	ta.nodeInjector = nodejs.NewNodeInjector(ta.Cfg)
 	ta.processInstances = maps.MultiCounter[uint64]{}
-	ta.beylaPID = os.Getpid()
+	ta.obiPID = os.Getpid()
 	ta.EbpfEventContext.CommonPIDsFilter = ebpfcommon.CommonPIDsFilter(&ta.Cfg.Discovery, ta.Metrics)
 	ta.routeHarvester = harvest.NewRouteHarvester()
 


### PR DESCRIPTION
This PR includes the rename from `BEYLA_PIN_INTERNAL` to `OBI_PIN_INTERNAL`  and a minor cleanup to avoid nested code