### PR TITLE
Make RenovateBot to ignore github.com/Shopify/sarama

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,9 @@
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "ignorePaths": [
+    // github.com/Shopify/sarama has been moved to github.com/IBM/sarama
+    // but we keep supporting the go-offsets for the outdated library, which must not
+    // be updated.
     "configs/offsets/shopify/**"
   ],
   "packageRules": [


### PR DESCRIPTION
The reference `github.com/Shopify/sarama` has been moved to `github.com/IBM/sarama`.

We are keeping both references to support users still using the previous package URL.

However Renovate Bot now tries to update `github.com/Shopify/sarama` https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/610 and complaints.

This PR makes Renovate to ignore the old, outdated Shopify/sarama path.