### PR TITLE
Add option to disable certain route harvesters

### DIFF
--- a/pkg/components/discover/attacher.go
+++ b/pkg/components/discover/attacher.go
@@ -84,7 +84,7 @@ func (ta *TraceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 	ta.processInstances = maps.MultiCounter[uint64]{}
 	ta.beylaPID = os.Getpid()
 	ta.EbpfEventContext.CommonPIDsFilter = ebpfcommon.CommonPIDsFilter(&ta.Cfg.Discovery, ta.Metrics)
-	ta.routeHarvester = harvest.NewRouteHarvester()
+	ta.routeHarvester = harvest.NewRouteHarvester(ta.Cfg.Discovery.DisabledRouteHarvesters)
 
 	if err := ta.init(); err != nil {
 		ta.log.Error("cant start process tracer. Stopping it", "error", err)

--- a/pkg/services/criteria.go
+++ b/pkg/services/criteria.go
@@ -102,6 +102,8 @@ type DiscoveryConfig struct {
 
 	// Disables generation of span metrics of services which are already instrumented
 	ExcludeOTelInstrumentedServicesSpanMetrics bool `yaml:"exclude_otel_instrumented_services_span_metrics" env:"OTEL_EBPF_EXCLUDE_OTEL_INSTRUMENTED_SERVICES_SPAN_METRICS"`
+
+	DisabledRouteHarvesters []string `yaml:"disabled_route_harvesters"`
 }
 
 func (c *DiscoveryConfig) Validate() error {

--- a/test/oats/http/configs/instrumenter-config-traces-routes-disabled.yml
+++ b/test/oats/http/configs/instrumenter-config-traces-routes-disabled.yml
@@ -1,0 +1,8 @@
+routes:
+  patterns:
+    - /create-trace
+    - /smoke
+  unmatched: path
+discovery:
+  disabled_route_harvesters:
+    - java

--- a/test/oats/http/docker-compose-java-routes-disabled.yml
+++ b/test/oats/http/docker-compose-java-routes-disabled.yml
@@ -1,0 +1,36 @@
+services:
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./test/integration/components/javatestserver/Dockerfile_jar
+    image: javakafka
+    ports:
+      - "8080:8085"
+  # eBPF auto instrumenter
+  autoinstrumenter:
+    build:
+      context: ../../..
+      dockerfile: ./test/integration/components/ebpf-instrument/Dockerfile
+    command:
+      - --config=/configs/instrumenter-config-traces-routes-disabled.yml
+    volumes:
+      - {{ .ConfigDir }}:/configs
+      - ./testoutput/run:/var/run/beyla
+      - ../../../testoutput:/coverage
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      #OTEL_EBPF_EXECUTABLE_PATH: "java"
+      OTEL_EBPF_OPEN_PORT: "8085"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "10ms"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318"
+    depends_on:
+      testserver:
+        condition: service_started

--- a/test/oats/http/yaml/oats_java_routes_disabled.yaml
+++ b/test/oats/http/yaml/oats_java_routes_disabled.yaml
@@ -1,0 +1,15 @@
+docker-compose:
+  generator: generic
+  files:
+    - ../docker-compose-java-routes-disabled.yml
+input:
+  - path: "/greeting123/obitest"
+interval: 500ms
+expected:
+  traces:
+    - traceql: '{ .http.route = "/greeting123/obitest" }'
+      spans:
+        - name: "GET /greeting123/obitest"
+          attributes:
+            server.port: "8085"
+            url.path: "/greeting123/obitest"


### PR DESCRIPTION
We recently added a feature to harvest routes from processes, Java being the only one implemented for now. However, we might encounter an issue perhaps in the field with this new feature, so I'm providing a way for customers to disable specific harvesters.