### PR TITLE
Increase grpc max recv size

### DIFF
--- a/test/integration/configs/otelcol-config-4017.yml
+++ b/test/integration/configs/otelcol-config-4017.yml
@@ -3,6 +3,7 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4017
+        max_recv_msg_size_mib: 100
       http:
         endpoint: 0.0.0.0:4018
         cors:

--- a/test/integration/configs/otelcol-config.yml
+++ b/test/integration/configs/otelcol-config.yml
@@ -3,6 +3,7 @@ receivers:
     protocols:
       grpc:
         endpoint: 0.0.0.0:4317
+        max_recv_msg_size_mib: 100
       http:
         endpoint: 0.0.0.0:4318
         cors:


### PR DESCRIPTION
The neto11y tests are generating more metrics, which are causing the collector ingest to overflow and reject them.