### PR TITLE
use durations for bpf_metric_scrape_interval

### DIFF
--- a/pkg/components/imetrics/imetrics.go
+++ b/pkg/components/imetrics/imetrics.go
@@ -6,6 +6,7 @@ package imetrics
 
 import (
 	"context"
+	"time"
 )
 
 type InternalMetricsExporter string
@@ -58,9 +59,9 @@ func (t InternalMetricsExporter) Valid() bool {
 
 // Config options for the different metrics exporters
 type Config struct {
-	Prometheus                     PrometheusConfig        `yaml:"prometheus,omitempty"`
-	Exporter                       InternalMetricsExporter `yaml:"exporter,omitempty" env:"OTEL_EBPF_INTERNAL_METRICS_EXPORTER"`
-	BpfMetricScrapeIntervalSeconds int                     `yaml:"bpf_metric_scrape_interval_seconds" env:"OTEL_EBPF_BPF_METRIC_SCRAPE_INTERVAL_SECONDS"`
+	Prometheus              PrometheusConfig        `yaml:"prometheus,omitempty"`
+	Exporter                InternalMetricsExporter `yaml:"exporter,omitempty" env:"OTEL_EBPF_INTERNAL_METRICS_EXPORTER"`
+	BpfMetricScrapeInterval time.Duration           `yaml:"bpf_metric_scrape_interval" env:"OTEL_EBPF_BPF_METRIC_SCRAPE_INTERVAL"`
 }
 
 // Reporter of internal metrics
@@ -97,26 +98,26 @@ type Reporter interface {
 	BpfMapEntries(mapID, mapName, mapType string, entriesTotal int)
 	// BpfMapMaxEntries is invoked every time a BPF map max size is recorded
 	BpfMapMaxEntries(mapID, mapName, mapType string, maxEntries int)
-	// GetBpfInternalMetricsScrapeInterval returns the configured scrape interval for BPF internal metrics
-	GetBpfInternalMetricsScrapeInterval() int
+	// BpfInternalMetricsScrapeInterval returns the configured scrape interval for BPF internal metrics
+	BpfInternalMetricsScrapeInterval() time.Duration
 }
 
 // NoopReporter is a metrics Reporter that just does nothing
 type NoopReporter struct{}
 
-func (n NoopReporter) Start(_ context.Context)                    {}
-func (n NoopReporter) TracerFlush(_ int)                          {}
-func (n NoopReporter) OTELMetricExport(_ int)                     {}
-func (n NoopReporter) OTELMetricExportError(_ error)              {}
-func (n NoopReporter) OTELTraceExport(_ int)                      {}
-func (n NoopReporter) OTELTraceExportError(_ error)               {}
-func (n NoopReporter) PrometheusRequest(_, _ string)              {}
-func (n NoopReporter) InstrumentProcess(_ string)                 {}
-func (n NoopReporter) UninstrumentProcess(_ string)               {}
-func (n NoopReporter) InstrumentationError(_, _ string)           {}
-func (n NoopReporter) AvoidInstrumentationMetrics(_, _, _ string) {}
-func (n NoopReporter) AvoidInstrumentationTraces(_, _, _ string)  {}
-func (n NoopReporter) BpfProbeLatency(_, _, _ string, _ float64)  {}
-func (n NoopReporter) BpfMapEntries(_, _, _ string, _ int)        {}
-func (n NoopReporter) BpfMapMaxEntries(_, _, _ string, _ int)     {}
-func (n NoopReporter) GetBpfInternalMetricsScrapeInterval() int   { return 0 }
+func (n NoopReporter) Start(_ context.Context)                         {}
+func (n NoopReporter) TracerFlush(_ int)                               {}
+func (n NoopReporter) OTELMetricExport(_ int)                          {}
+func (n NoopReporter) OTELMetricExportError(_ error)                   {}
+func (n NoopReporter) OTELTraceExport(_ int)                           {}
+func (n NoopReporter) OTELTraceExportError(_ error)                    {}
+func (n NoopReporter) PrometheusRequest(_, _ string)                   {}
+func (n NoopReporter) InstrumentProcess(_ string)                      {}
+func (n NoopReporter) UninstrumentProcess(_ string)                    {}
+func (n NoopReporter) InstrumentationError(_, _ string)                {}
+func (n NoopReporter) AvoidInstrumentationMetrics(_, _, _ string)      {}
+func (n NoopReporter) AvoidInstrumentationTraces(_, _, _ string)       {}
+func (n NoopReporter) BpfProbeLatency(_, _, _ string, _ float64)       {}
+func (n NoopReporter) BpfMapEntries(_, _, _ string, _ int)             {}
+func (n NoopReporter) BpfMapMaxEntries(_, _, _ string, _ int)          {}
+func (n NoopReporter) BpfInternalMetricsScrapeInterval() time.Duration { return 0 }

--- a/pkg/components/imetrics/iprom.go
+++ b/pkg/components/imetrics/iprom.go
@@ -41,7 +41,7 @@ type PrometheusReporter struct {
 	bpfProbeLatencies                *prometheus.HistogramVec
 	bpfMapEntries                    *prometheus.GaugeVec
 	bpfMapMaxEntries                 *prometheus.GaugeVec
-	bpfInternalMetricsScrapeInterval int
+	bpfInternalMetricsScrapeInterval time.Duration
 }
 
 func NewPrometheusReporter(cfg *Config, manager *connector.PrometheusManager, registry *prometheus.Registry) *PrometheusReporter {
@@ -112,7 +112,7 @@ func NewPrometheusReporter(cfg *Config, manager *connector.PrometheusManager, re
 			Name: attr.VendorPrefix + "_bpf_map_max_entries_total",
 			Help: "Maximum number of entries in the BPF maps",
 		}, []string{"map_id", "map_name", "map_type"}),
-		bpfInternalMetricsScrapeInterval: cfg.BpfMetricScrapeIntervalSeconds,
+		bpfInternalMetricsScrapeInterval: cfg.BpfMetricScrapeInterval,
 	}
 	if registry != nil {
 		registry.MustRegister(pr.tracerFlushes,
@@ -215,6 +215,6 @@ func (p *PrometheusReporter) BpfMapMaxEntries(mapID, mapName, mapType string, ma
 	p.bpfMapMaxEntries.WithLabelValues(mapID, mapName, mapType).Set(float64(maxEntries))
 }
 
-func (p PrometheusReporter) GetBpfInternalMetricsScrapeInterval() int {
+func (p *PrometheusReporter) BpfInternalMetricsScrapeInterval() time.Duration {
 	return p.bpfInternalMetricsScrapeInterval
 }

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -39,7 +39,7 @@ type InternalMetricsReporter struct {
 	bpfProbeLatencies                instrument.Float64Histogram
 	bpfMapEntries                    instrument.Int64Gauge
 	bpfMapMaxEntries                 instrument.Int64Gauge
-	bpfInternalMetricsScrapeInterval int
+	bpfInternalMetricsScrapeInterval time.Duration
 }
 
 func imlog() *slog.Logger {
@@ -172,7 +172,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		bpfProbeLatencies:                bpfProbeLatencies,
 		bpfMapEntries:                    bpfMapEntries,
 		bpfMapMaxEntries:                 bpfMapMaxEntries,
-		bpfInternalMetricsScrapeInterval: internalMetrics.BpfMetricScrapeIntervalSeconds,
+		bpfInternalMetricsScrapeInterval: internalMetrics.BpfMetricScrapeInterval,
 	}, nil
 }
 
@@ -284,6 +284,6 @@ func (p *InternalMetricsReporter) BpfMapMaxEntries(mapID, mapName, mapType strin
 	p.bpfMapMaxEntries.Record(p.ctx, int64(maxEntries), instrument.WithAttributes(attrs...))
 }
 
-func (p InternalMetricsReporter) GetBpfInternalMetricsScrapeInterval() int {
+func (p InternalMetricsReporter) BpfInternalMetricsScrapeInterval() time.Duration {
 	return p.bpfInternalMetricsScrapeInterval
 }

--- a/pkg/export/prom/prom_bpf.go
+++ b/pkg/export/prom/prom_bpf.go
@@ -126,7 +126,7 @@ func (bc *BPFCollector) reportMetrics(ctx context.Context) {
 }
 
 func (bc *BPFCollector) collectInternalMetrics(ctx context.Context) {
-	ticker := time.NewTicker(time.Duration(bc.internalMetrics.GetBpfInternalMetricsScrapeInterval()) * time.Second)
+	ticker := time.NewTicker(bc.internalMetrics.BpfInternalMetricsScrapeInterval())
 	defer ticker.Stop()
 	for {
 		select {

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -129,7 +129,7 @@ var DefaultConfig = Config{
 			Port: 0, // disabled by default
 			Path: "/internal/metrics",
 		},
-		BpfMetricScrapeIntervalSeconds: 15,
+		BpfMetricScrapeInterval: 15 * time.Second,
 	},
 	Attributes: Attributes{
 		InstanceID: traces.InstanceIDConfig{

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -190,7 +190,7 @@ discovery:
 				Port: 3210,
 				Path: "/internal/metrics",
 			},
-			BpfMetricScrapeIntervalSeconds: 15,
+			BpfMetricScrapeInterval: 15 * time.Second,
 		},
 		Attributes: Attributes{
 			InstanceID: traces.InstanceIDConfig{


### PR DESCRIPTION
For consistency with the rest of configuration options that use `time.Duration` instead of integers, the `bpf_metric_scrape_interval_seconds` has been renamed to `bpf_metric_scrape_interval` and accepting any duration string.