### PR TITLE
fix: panic in clusterurl

### DIFF
--- a/pkg/components/transform/route/clusterurl/cluster.go
+++ b/pkg/components/transform/route/clusterurl/cluster.go
@@ -81,15 +81,19 @@ func (csf *ClusterURLClassifier) ClusterURL(path string) string {
 	nSegments := 0
 	for _, c := range p {
 		char := c
+
+		// Strip query string and fragment identifiers
 		if c == '?' || c == '&' || c == '#' {
-			// Strip query string and fragment identifiers
-			if skip {
-				// leave one extra byte for the ReplaceWith character
-				p = p[:sPos+1]
-			} else {
-				p = p[:sPos]
+			if skip && sPos < len(p) {
+				// no other chars, just use ReplaceWith
+				p[sPos] = csf.cfg.ReplaceWith
+				sPos++
+			} else if !skip && sFwd > sPos {
+				// preserve chars
+				sPos = sFwd
 			}
 
+			p = p[:sPos]
 			break
 		}
 
@@ -135,12 +139,16 @@ func (csf *ClusterURLClassifier) ClusterURL(path string) string {
 	}
 
 	if skip {
-		p[sPos] = csf.cfg.ReplaceWith
-		sPos++
-	} else if sFwd > sPos {
-		if !csf.okWord(string(p[sPos:sFwd])) {
+		if sPos < len(p) {
 			p[sPos] = csf.cfg.ReplaceWith
 			sPos++
+		}
+	} else if sFwd > sPos {
+		if !csf.okWord(string(p[sPos:sFwd])) {
+			if sPos < len(p) {
+				p[sPos] = csf.cfg.ReplaceWith
+				sPos++
+			}
 		} else {
 			sPos = sFwd
 		}

--- a/pkg/components/transform/route/clusterurl/cluster.go
+++ b/pkg/components/transform/route/clusterurl/cluster.go
@@ -83,7 +83,13 @@ func (csf *ClusterURLClassifier) ClusterURL(path string) string {
 		char := c
 		if c == '?' || c == '&' || c == '#' {
 			// Strip query string and fragment identifiers
-			p = p[:sPos]
+			if skip {
+				// leave one extra byte for the ReplaceWith character
+				p = p[:sPos+1]
+			} else {
+				p = p[:sPos]
+			}
+
 			break
 		}
 

--- a/pkg/components/transform/route/clusterurl/cluster_test.go
+++ b/pkg/components/transform/route/clusterurl/cluster_test.go
@@ -52,11 +52,13 @@ func TestClusterURL(t *testing.T) {
 	assert.Equal(t, "GET /api/cart", csf.ClusterURL("GET /api/cart?sessionId=55f4e5ea-5d6d-482a-80c4-799e3c72dfb0&currencyCode=USD"))
 	assert.Equal(t, "/getquote", csf.ClusterURL("/getquote"))
 	assert.Equal(t, "", csf.ClusterURL("?"))
-	assert.Equal(t, "", csf.ClusterURL("attach12?"))
-	assert.Equal(t, "", csf.ClusterURL("1?"))
-	assert.Equal(t, "", csf.ClusterURL("*&"))
-	assert.Equal(t, "", csf.ClusterURL("12#"))
+	assert.Equal(t, "*", csf.ClusterURL("attach12?"))
+	assert.Equal(t, "*", csf.ClusterURL("1?"))
+	assert.Equal(t, "*", csf.ClusterURL("*&"))
+	assert.Equal(t, "*", csf.ClusterURL("12#"))
 	assert.Equal(t, "/a", csf.ClusterURL("/a#"))
+	assert.Equal(t, "/*", csf.ClusterURL("/1#"))
+	assert.Equal(t, "a", csf.ClusterURL("a#"))
 }
 
 func BenchmarkClusterURLWithCache(b *testing.B) {

--- a/pkg/components/transform/route/clusterurl/cluster_test.go
+++ b/pkg/components/transform/route/clusterurl/cluster_test.go
@@ -59,6 +59,7 @@ func TestClusterURL(t *testing.T) {
 	assert.Equal(t, "/a", csf.ClusterURL("/a#"))
 	assert.Equal(t, "/*", csf.ClusterURL("/1#"))
 	assert.Equal(t, "a", csf.ClusterURL("a#"))
+	assert.Equal(t, "/a/b/c/d/e/f/g/h/i", csf.ClusterURL("/a/b/c/d/e/f/g/h/i/j"))
 }
 
 func BenchmarkClusterURLWithCache(b *testing.B) {


### PR DESCRIPTION
Investigating the following error:

```
panic: runtime error: index out of range [9] with length 9
```

After fixing the panic, I found some of the existing test cases to be inconsistent, and added some missing test cases for `ClusterURL`. Discussed with @grcevski and agreed to update the existing test cases to focus on consistency.

TL;DR The `p` slice was shrunk to strip characters, then access was attempted on an index that no longer existed.