### PR TITLE
Fix semantics of OTEL_EBPF_RENAME_UNRESOLVED_HOSTS

### DIFF
--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -144,7 +144,6 @@ var DefaultConfig = Config{
 		HostID: HostIDConfig{
 			FetchTimeout: 500 * time.Millisecond,
 		},
-		RenameUnresolvedHosts:          "unresolved",
 		MetricSpanNameAggregationLimit: 100,
 	},
 	Routes: &transform.RoutesConfig{


### PR DESCRIPTION
`OTEL_EBPF_RENAME_UNRESOLVED_HOSTS` semantics state that:

>RenameUnresolvedHosts will replace HostName and PeerName attributes when they are empty or contain unresolved IP addresses to reduce cardinality.
**Set this value to the empty string to disable this feature.**

However, it is not possible to do `export OTEL_EBPF_RENAME_UNRESOLVED_HOSTS=""` to set the value to an empty string and disable it, because https://github.com/caarlos0/env treats empty values as unset (it never overrides the struct): https://github.com/caarlos0/env/blob/6061c47a86bc2ffec1ee6dcb6a3a6b0a1096d14c/env.go#L292

The solution presented in this PR is to simply change the default value to empty, allowing any other value to be able to override it. If that is not acceptable, we may need another configuration option (a boolean) to enable/disable this feature explicitly.