### PR TITLE
Add job, instance, telemetry_sdk_version for prometheus export

### DIFF
--- a/pkg/app/request/metric_attributes.go
+++ b/pkg/app/request/metric_attributes.go
@@ -219,3 +219,11 @@ func CudaMemcpyName(val int) string {
 func CudaMemcpy(val int) attribute.KeyValue {
 	return attribute.Key(attr.CudaMemcpyKind).String(CudaMemcpyName(val))
 }
+
+func Job(val string) attribute.KeyValue {
+	return attribute.Key(attr.MessagingOpType).String(val)
+}
+
+func Instance(val string) attribute.KeyValue {
+	return attribute.Key(attr.MessagingOpType).String(val)
+}

--- a/pkg/app/request/span_getters.go
+++ b/pkg/app/request/span_getters.go
@@ -114,6 +114,10 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 		getter = func(span *Span) attribute.KeyValue { return CudaKernel(span.Method) }
 	case attr.CudaMemcpyKind:
 		getter = func(span *Span) attribute.KeyValue { return CudaMemcpy(span.SubType) }
+	case attr.Job:
+		getter = func(span *Span) attribute.KeyValue { return Job(span.Service.Job()) }
+	case attr.Instance:
+		getter = func(span *Span) attribute.KeyValue { return Job(span.Service.UID.Instance) }
 	}
 	// default: unlike the Prometheus getters, we don't check here for service name nor k8s metadata
 	// because they are already attributes of the Resource instead of the attributes.

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -85,6 +85,7 @@ const (
 	sourceKey            = "source"
 	telemetryLanguageKey = "telemetry_sdk_language"
 	telemetrySDKKey      = "telemetry_sdk_name"
+	telemetrySDKVersion  = "telemetry_sdk_version"
 
 	clientKey          = "client"
 	clientNamespaceKey = "client_service_namespace"
@@ -1030,6 +1031,7 @@ func labelNamesTargetInfo(kubeEnabled bool, extraMetadataLabelNames []attr.Name)
 		serviceJobKey,
 		telemetryLanguageKey,
 		telemetrySDKKey,
+		telemetrySDKVersion,
 		sourceKey,
 		osTypeKey,
 	}
@@ -1055,6 +1057,7 @@ func (r *metricsReporter) labelValuesTargetInfo(service *svc.Attrs) []string {
 		service.Job(),
 		service.SDKLanguage.String(),
 		attr.VendorPrefix,
+		buildinfo.Version,
 		attr.VendorPrefix,
 		"linux",
 	}


### PR DESCRIPTION
Job and instance are important fields in Prometheus metrics exports and they were missing from the standard OTel metrics, but they were present in the span metrics.

I also took this opportunity to complete https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/492