### PR TITLE
fix: race condition in TestAppMetricsExpiration

### DIFF
--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -148,14 +148,14 @@ func TestAppMetricsExpiration(t *testing.T) {
 	now.Advance(2 * time.Minute)
 
 	// THEN THE metrics that have been received during the timeout period are still visible
-	var exported string
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		exported = getMetrics(t, promURL)
+		exported := getMetrics(t, promURL)
 		assert.Contains(t, exported, `http_server_request_duration_seconds_sum{k8s_app_version="v0.0.1",url_path="/foo"} 246`)
+
+		// BUT not the metrics that haven't been received during that time
+		assert.NotContains(t, exported, `http_server_request_duration_seconds_sum{k8s_app_version="",url_path="/baz"}`)
+		assert.Regexp(t, containsTargetInfo, exported)
 	})
-	// BUT not the metrics that haven't been received during that time
-	assert.NotContains(t, exported, `http_server_request_duration_seconds_sum{k8s_app_version="",url_path="/baz"}`)
-	assert.Regexp(t, containsTargetInfo, exported)
 	now.Advance(2 * time.Minute)
 
 	// AND WHEN the metrics labels that disappeared are received again
@@ -166,11 +166,11 @@ func TestAppMetricsExpiration(t *testing.T) {
 
 	// THEN they are reported again, starting from zero in the case of counters
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		exported = getMetrics(t, promURL)
+		exported := getMetrics(t, promURL)
 		assert.Contains(t, exported, `http_server_request_duration_seconds_sum{k8s_app_version="",url_path="/baz"} 456`)
+		assert.NotContains(t, exported, `http_server_request_duration_seconds_sum{k8s_app_version="",url_path="/foo"}`)
+		assert.Regexp(t, containsTargetInfo, exported)
 	})
-	assert.NotContains(t, exported, `http_server_request_duration_seconds_sum{k8s_app_version="",url_path="/foo"}`)
-	assert.Regexp(t, containsTargetInfo, exported)
 
 	// AND WHEN the observed process is terminated
 	processEvents.Send(exec.ProcessEvent{
@@ -180,7 +180,7 @@ func TestAppMetricsExpiration(t *testing.T) {
 
 	// THEN traces_host_info and traces_target_info are removed
 	test.Eventually(t, timeout, func(t require.TestingT) {
-		exported = getMetrics(t, promURL)
+		exported := getMetrics(t, promURL)
 		assert.NotRegexp(t, containsTargetInfo, exported)
 		assert.NotRegexp(t, containsTracesHostInfo, exported)
 	})

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -111,6 +111,7 @@ func TestAppMetricsExpiration(t *testing.T) {
 		},
 		{Type: request.EventTypeHTTP, Path: "/baz", End: 456 * time.Second.Nanoseconds()},
 	})
+	awaitSpanProcessing()
 
 	containsTargetInfo := regexp.MustCompile(`\ntarget_info\{.*host_id="my-host"`)
 	containsTargetInfoSDKVersion := regexp.MustCompile(`\ntarget_info\{.*telemetry_sdk_version=.*`)
@@ -145,6 +146,7 @@ func TestAppMetricsExpiration(t *testing.T) {
 			},
 		},
 	})
+	awaitSpanProcessing()
 	now.Advance(2 * time.Minute)
 
 	// THEN THE metrics that have been received during the timeout period are still visible
@@ -162,6 +164,7 @@ func TestAppMetricsExpiration(t *testing.T) {
 	promInput.Send([]request.Span{
 		{Type: request.EventTypeHTTP, Path: "/baz", End: 456 * time.Second.Nanoseconds()},
 	})
+	awaitSpanProcessing()
 	now.Advance(2 * time.Minute)
 
 	// THEN they are reported again, starting from zero in the case of counters
@@ -372,6 +375,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				{Service: svc.Attrs{UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeKafkaServer, Method: "process", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMongoClient, Method: "find", RequestStart: 150, End: 175},
 			})
+			awaitSpanProcessing()
 
 			var exported string
 			test.Eventually(t, timeout, func(t require.TestingT) {
@@ -631,6 +635,13 @@ func getMetrics(t require.TestingT, promURL string) string {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	return string(body)
+}
+
+// awaitSpanProcessing allows for slower CI environments to catch up. The
+// intention is to prevent race conditions between sending spans, processing
+// them, and advancing the mocked clock.
+func awaitSpanProcessing() {
+	time.Sleep(10 * time.Millisecond)
 }
 
 type syncedClock struct {

--- a/pkg/transform/name_resolver_test.go
+++ b/pkg/transform/name_resolver_test.go
@@ -271,7 +271,7 @@ func TestResolveNodesFromK8s(t *testing.T) {
 
 func TestResolveClientFromHost(t *testing.T) {
 	inf := &fakeInformer{}
-	db := kube2.NewStore(inf, kube2.ResourceLabels{}, nil)
+	db := kube2.NewStore(inf, kube2.ResourceLabels{}, nil, imetrics.NoopReporter{})
 	pod1 := &informer.ObjectMeta{Name: "pod1", Kind: "Service", Ips: []string{"10.0.0.1", "10.1.0.1"}}
 	pod2 := &informer.ObjectMeta{Name: "pod2", Namespace: "something", Kind: "Service", Ips: []string{"10.0.0.2", "10.1.0.2"}}
 	pod3 := &informer.ObjectMeta{Name: "pod3", Kind: "Service", Ips: []string{"10.0.0.3", "10.1.0.3"}}


### PR DESCRIPTION
1) Fix race condition in TestAppMetricsExpiration ([link](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/18015439957/job/51259046190?pr=542#step:4:1208)):

```

==================
WARNING: DATA RACE
Write at 0x00c0001186c0 by goroutine 4555:
  go.opentelemetry.io/obi/pkg/export/prom.TestAppMetricsExpiration.func2()
      /home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/pkg/export/prom/prom_test.go:152 +0x79
  github.com/mariomac/guara/pkg/test.Eventually.func1.1()
      /home/runner/go/pkg/mod/github.com/mariomac/guara@v0.0.0-20250408105519-1e4dbdfb7136/pkg/test/eventually.go:57 +0x90

Previous read at 0x00c0001186c0 by goroutine 79:
  go.opentelemetry.io/obi/pkg/export/prom.TestAppMetricsExpiration()
      /home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/pkg/export/prom/prom_test.go:157 +0x17f7
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:1997 +0x44

Goroutine 4555 (running) created at:
  github.com/mariomac/guara/pkg/test.Eventually.func1()
      /home/runner/go/pkg/mod/github.com/mariomac/guara@v0.0.0-20250408105519-1e4dbdfb7136/pkg/test/eventually.go:55 +0x1f9

Goroutine 79 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:1997 +0x9d2
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:2477 +0x85
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:1934 +0x21c
  testing.runTests()
      /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:2475 +0x96c
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.25.1/x64/src/testing/testing.go:2337 +0xed4
  main.main()
      _testmain.go:75 +0x164
==================
==================
WARNING: DATA RACE
Write at 0x00c0001186c0 by goroutine 4565:
  go.opentelemetry.io/obi/pkg/export/prom.TestAppMetricsExpiration.func3()
      /home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/pkg/export/prom/prom_test.go:168 +0x79
  github.com/mariomac/guara/pkg/test.Eventually.func1.1()
      /home/runner/go/pkg/mod/github.com/mariomac/guara@v0.0.0-20250408105519-1e4dbdfb7136/pkg/test/eventually.go:57 +0x90

Previous read at 0x00c0001186c0 by goroutine 4555:
  go.opentelemetry.io/obi/pkg/export/prom.TestAppMetricsExpiration.func2()
      /home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/pkg/export/prom/prom_test.go:153 +0xe4
  github.com/mariomac/guara/pkg/test.Eventually.func1.1()
      /home/runner/go/pkg/mod/github.com/mariomac/guara@v0.0.0-20250408105519-1e4dbdfb7136/pkg/test/eventually.go:57 +0x90

Goroutine 4565 (running) created at:
  github.com/mariomac/guara/pkg/test.Eventually.func1()
      /home/runner/go/pkg/mod/github.com/mariomac/guara@v0.0.0-20250408105519-1e4dbdfb7136/pkg/test/eventually.go:55 +0x1f9

Goroutine 4555 (running) created at:
  github.com/mariomac/guara/pkg/test.Eventually.func1()
      /home/runner/go/pkg/mod/github.com/mariomac/guara@v0.0.0-20250408105519-1e4dbdfb7136/pkg/test/eventually.go:55 +0x1f9
==================
--- FAIL: TestAppMetricsExpiration (5.04s)
    eventually.go:86: 
        	Error Trace:	/home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/pkg/export/prom/prom_test.go:153
        	            				/home/runner/go/pkg/mod/github.com/mariomac/guara@v0.0.0-20250408105519-1e4dbdfb7136/pkg/test/eventually.go:57
        	            				/opt/hostedtoolcache/go/1.25.1/x64/src/runtime/asm_amd64.s:1693
        	Error:      	"# HELP http_server_request_body_size_bytes size, in bytes, of the HTTP request body as received at the server side\n# TYPE http_server_request_body_size_bytes histogram\nhttp_server_request_body_size_bytes_bucket{http_request_method=\"\",http_response_status_code=\"0\",instance=\"\",job=\"\",k8s_app_version=\"v0.0.1\",k8s_cluster_name=\"\",k8s_container_name=\"\",k8s_cronjob_name=\"\",k8s_daemonset_name=\"\",k8s_deployment_name=\"\",k8s_job_name=\"\",k8s_kind=\"\",k8s_namespace_name=\"\",k8s_node_name=\"\",k8s_owner_name=\"\",k8s_pod_name=\"\",k8s_pod_start_time=\"\",k8s_pod_uid=\"\",k8s_replicaset_name=\"\",k8s_statefulset_name=\"\",server_address=\"\",server_port=\"0\",service_name=\"\",service_namespace=\"\",le=\"+Inf\"} 1\nhttp_server_request_body_size_bytes_sum{http_request_method=\"\",http_response_status_code=\"0\",instance=\"\",job=\"\",k8s_app_version=\"v0.0.1\",k8s_cluster_name=\"\",k8s_container_name=\"\",k8s_cronjob_name=\"\",k8s_daemonset_name=\"\",k8s_deployment_name=\"\",k8s_job_name=\"\",k8s_kind=\"\",k8s_namespace_name=\"\",k8s_node_name=\"\",k8s_owner_name=\"\",k8s_pod_name=\"\",k8s_pod_start_time=\"\",k8s_pod_uid=\"\",k8s_replicaset_name=\"\",k8s_statefulset_name=\"\",server_address=\"\",server_port=\"0\",service_name=\"\",service_namespace=\"\"} 0\nhttp_server_request_body_size_bytes_count{http_request_method=\"\",http_response_status_code=\"0\",instance=\"\",job=\"\",k8s_app_version=\"v0.0.1\",k8s_cluster_name=\"\",k8s_container_name=\"\",k8s_cronjob_name=\"\",k8s_daemonset_name=\"\",k8s_deployment_name=\"\",k8s_job_name=\"\",k8s_kind=\"\",k8s_namespace_name=\"\",k8s_node_name=\"\",k8s_owner_name=\"\",k8s_pod_name=\"\",k8s_pod_start_time=\"\",k8s_pod_uid=\"\",k8s_replicaset_name=\"\",k8s_statefulset_name=\"\",server_address=\"\",server_port=\"0\",service_name=\"\",service_namespace=\"\"} 1\n# HELP http_server_request_duration_seconds duration of HTTP service calls from the server side, in seconds\n# TYPE http_server_request_duration_seconds histogram\nhttp_server_request_duration_seconds_bucket{k8s_app_version=\"v0.0.1\",url_path=\"/foo\",le=\"+Inf\"} 1\nhttp_server_request_duration_seconds_sum{k8s_app_version=\"v0.0.1\",url_path=\"/foo\"} 123\nhttp_server_request_duration_seconds_count{k8s_app_version=\"v0.0.1\",url_path=\"/foo\"} 1\n# HELP http_server_response_body_size_bytes size, in bytes, of the HTTP response body as received at the server side\n# TYPE http_server_response_body_size_bytes histogram\nhttp_server_response_body_size_bytes_bucket{http_request_method=\"\",http_response_status_code=\"0\",instance=\"\",job=\"\",k8s_app_version=\"v0.0.1\",k8s_cluster_name=\"\",k8s_container_name=\"\",k8s_cronjob_name=\"\",k8s_daemonset_name=\"\",k8s_deployment_name=\"\",k8s_job_name=\"\",k8s_kind=\"\",k8s_namespace_name=\"\",k8s_node_name=\"\",k8s_owner_name=\"\",k8s_pod_name=\"\",k8s_pod_start_time=\"\",k8s_pod_uid=\"\",k8s_replicaset_name=\"\",k8s_statefulset_name=\"\",server_address=\"\",server_port=\"0\",service_name=\"\",service_namespace=\"\",le=\"+Inf\"} 1\nhttp_server_response_body_size_bytes_sum{http_request_method=\"\",http_response_status_code=\"0\",instance=\"\",job=\"\",k8s_app_version=\"v0.0.1\",k8s_cluster_name=\"\",k8s_container_name=\"\",k8s_cronjob_name=\"\",k8s_daemonset_name=\"\",k8s_deployment_name=\"\",k8s_job_name=\"\",k8s_kind=\"\",k8s_namespace_name=\"\",k8s_node_name=\"\",k8s_owner_name=\"\",k8s_pod_name=\"\",k8s_pod_start_time=\"\",k8s_pod_uid=\"\",k8s_replicaset_name=\"\",k8s_statefulset_name=\"\",server_address=\"\",server_port=\"0\",service_name=\"\",service_namespace=\"\"} 0\nhttp_server_response_body_size_bytes_count{http_request_method=\"\",http_response_status_code=\"0\",instance=\"\",job=\"\",k8s_app_version=\"v0.0.1\",k8s_cluster_name=\"\",k8s_container_name=\"\",k8s_cronjob_name=\"\",k8s_daemonset_name=\"\",k8s_deployment_name=\"\",k8s_job_name=\"\",k8s_kind=\"\",k8s_namespace_name=\"\",k8s_node_name=\"\",k8s_owner_name=\"\",k8s_pod_name=\"\",k8s_pod_start_time=\"\",k8s_pod_uid=\"\",k8s_replicaset_name=\"\",k8s_statefulset_name=\"\",server_address=\"\",server_port=\"0\",service_name=\"\",service_namespace=\"\"} 1\n# HELP obi_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which Beyla was built, the goos and goarch for the build, and thelanguage of the reported services\n# TYPE obi_build_info gauge\nobi_build_info{goarch=\"amd64\",goos=\"linux\",goversion=\"go1.25.1\",revision=\"unset\",target_lang=\"unknown\",version=\"unset\"} 1\n# HELP promhttp_metric_handler_errors_total Total number of internal errors encountered by the promhttp metric handler.\n# TYPE promhttp_metric_handler_errors_total counter\npromhttp_metric_handler_errors_total{cause=\"encoding\"} 0\npromhttp_metric_handler_errors_total{cause=\"gathering\"} 0\n# HELP target_info attributes associated to a given monitored entity\n# TYPE target_info gauge\ntarget_info{host_id=\"my-host\",host_name=\"\",instance=\"test-app-1\",job=\"default/test-app\",os_type=\"linux\",service_name=\"test-app\",service_namespace=\"default\",source=\"obi\",telemetry_sdk_language=\"unknown\",telemetry_sdk_name=\"obi\",telemetry_sdk_version=\"unset\"} 1\n# HELP traces_host_info A metric with a constant '1' value labeled by the host id \n# TYPE traces_host_info gauge\ntraces_host_info{grafana_host_id=\"my-host\"} 1\n" does not contain "http_server_request_duration_seconds_sum{k8s_app_version=\"v0.0.1\",url_path=\"/foo\"} 246"
        
    testing.go:1617: race detected during execution of test
```

2) Fixed another race condition in the same test between span processing and mock time advancement.

3) Added more nodejs waiting logic to `test/integration/nodejs_multiproc_test.go` as it is flaky too.

4) Fixed a lint error inherited from main.