### PR TITLE
Fix harvesting messing up the obi uid,gid

### DIFF
--- a/pkg/internal/transform/route/harvest/harvester.go
+++ b/pkg/internal/transform/route/harvest/harvester.go
@@ -78,6 +78,12 @@ func (h *RouteHarvester) HarvestRoutes(fileInfo *exec.FileInfo) (*RouteHarvester
 
 	resultChan := make(chan result, 1)
 
+	// We need to fix this in the downstream library and then we can remove this code
+	if fileInfo.Service.SDKLanguage == svc.InstrumentableJava {
+		myUID, myGID := jvmAttachInitFunc()
+		defer jvmAttachCleanupFunc(myUID, myGID)
+	}
+
 	// Run the harvesting in a goroutine
 	go func() {
 		defer func() {

--- a/pkg/internal/transform/route/harvest/java_linux.go
+++ b/pkg/internal/transform/route/harvest/java_linux.go
@@ -3,6 +3,30 @@
 
 package harvest
 
-import "github.com/grafana/jvmtools/jvm"
+import (
+	"syscall"
+
+	"github.com/grafana/jvmtools/jvm"
+)
 
 var jvmAttachFunc = jvm.Jattach
+var jvmAttachInitFunc = initAttach
+var jvmAttachCleanupFunc = cleanupAttach
+
+func initAttach() (int, int) {
+	myUID := syscall.Geteuid()
+	myGID := syscall.Getegid()
+
+	return myUID, myGID
+}
+
+func cleanupAttach(myUID, myGID int) error {
+	if err := syscall.Setegid(int(myUID)); err != nil {
+		return err
+	}
+	if err := syscall.Seteuid(int(myGID)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/internal/transform/route/harvest/java_notlinux.go
+++ b/pkg/internal/transform/route/harvest/java_notlinux.go
@@ -13,3 +13,11 @@ import (
 var jvmAttachFunc = func(_ int, _ []string, _ *slog.Logger) (io.ReadCloser, error) {
 	return nil, nil
 }
+
+var jvmAttachInitFunc = func() (int, int) {
+	return 0, 0
+}
+
+var jvmAttachCleanupFunc = func(int, int) error {
+	return nil
+}


### PR DESCRIPTION
This is a bug in the downstream library we use to talk to JVMs. If we timeout or fail to talk to a JVM, but we had already entered the process namespace, we will not restore the OBI original UID/GID which causes all sorts of permission issues.