### PR TITLE
Update bpf metric scrape interval

### DIFF
--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -132,7 +132,7 @@ var DefaultConfig = Config{
 			Port: 0, // disabled by default
 			Path: "/internal/metrics",
 		},
-		BpfMetricScrapeInterval: 15 * time.Second,
+		BpfMetricScrapeInterval: 30 * time.Minute,
 	},
 	Attributes: Attributes{
 		InstanceID: traces.InstanceIDConfig{


### PR DESCRIPTION
Gathering ebpf metrics is expensive:

1. it involves multiple system calls when iterating maps
2. it needs to create ebpf.Program objects

On a large cluster with hundreds of ebpf programs, that can take a toll. This PR aims to establish saner defaults.

Below are the CPU and memory flame graphs for reference:

<img width="1689" height="637" alt="image" src="https://github.com/user-attachments/assets/5ce4f356-b6e9-4ab9-8c6a-cea14a33c1db" />

<img width="1689" height="637" alt="image" src="https://github.com/user-attachments/assets/90ab63ed-4396-4ca8-a3fa-02ea32ac7b7e" />
