### PR TITLE
Disabling network sampling again

### DIFF
--- a/pkg/obi/network_cfg.go
+++ b/pkg/obi/network_cfg.go
@@ -152,7 +152,6 @@ var defaultNetworkConfig = NetworkConfig{
 	RingBufferFlushPeriod: 10 * time.Second,
 	MaxFlowDuration:       60 * time.Second,
 	Direction:             "both",
-	Sampling:              10_000,
 	ListenInterfaces:      "watch",
 	ListenPollPeriod:      10 * time.Second,
 	ReverseDNS: flow.ReverseDNS{


### PR DESCRIPTION
I merged by mistake this PR https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/722 without realizing this added a breaking change. Sorry, my fault.

I think we need to discuss further the functionality implications for existing users before making the merge effective.