### PR TITLE
Introduce Queue.TrySend

### DIFF
--- a/pkg/pipe/msg/queue.go
+++ b/pkg/pipe/msg/queue.go
@@ -96,10 +96,19 @@ func NewQueue[T any](opts ...QueueOpts) *Queue[T] {
 // If there are subscribers, the message will be stored on their respective internal channels
 // until it is read by the subscribers.
 // If a subscriber is blocked, its internal channel might be full and
-// the Send operation would block for all the subscribers until all the internal channels
-// of the Queue room for a new message.
+// the Send operation will panic.
 func (q *Queue[T]) Send(o T) {
 	q.chainedSend(o, []string{q.cfg.name})
+}
+
+// Send a message to all subscribers of this queue.
+// If there are no subscribers at the moment of sending the message, the message will be lost.
+// If there are subscribers, the message will be stored on their respective internal channels
+// until it is read by the subscribers. In these cases, TrySend returns true.
+// If a subscriber is blocked, its internal channel might be full and
+// the TrySend operation will drop the message and return false.
+func (q *Queue[T]) TrySend(o T) bool {
+	return q.tryChainedSend(o, []string{q.cfg.name})
 }
 
 func (q *Queue[T]) chainedSend(o T, bypassPath []string) {
@@ -124,6 +133,29 @@ func (q *Queue[T]) chainedSend(o T, bypassPath []string) {
 				strings.Join(bypassPath, "->"), d.name))
 		}
 	}
+}
+
+func (q *Queue[T]) tryChainedSend(o T, bypassPath []string) bool {
+	q.assertNotClosed()
+	if q.bypassTo != nil {
+		return q.bypassTo.tryChainedSend(o, append(bypassPath, q.bypassTo.cfg.name))
+	}
+
+	// this can happen in dead paths (which are valid for disabled pipeline branches),
+	// exiting early to save timeout management
+	if len(q.dsts) == 0 {
+		return true
+	}
+	for _, d := range q.dsts {
+		select {
+		case d.ch <- o:
+			// good!
+		default:
+			return false
+		}
+	}
+
+	return true
 }
 
 type subscribeOpts struct {

--- a/pkg/pipe/msg/queue.go
+++ b/pkg/pipe/msg/queue.go
@@ -101,7 +101,7 @@ func (q *Queue[T]) Send(o T) {
 	q.chainedSend(o, []string{q.cfg.name})
 }
 
-// Send a message to all subscribers of this queue.
+// TrySend sends a message to all subscribers of this queue.
 // If there are no subscribers at the moment of sending the message, the message will be lost.
 // If there are subscribers, the message will be stored on their respective internal channels
 // until it is read by the subscribers. In these cases, TrySend returns true.

--- a/pkg/pipe/msg/queue_test.go
+++ b/pkg/pipe/msg/queue_test.go
@@ -31,11 +31,37 @@ func TestNoSubscribers(t *testing.T) {
 	testutil.ChannelEmpty(t, sent, 5*time.Millisecond)
 }
 
+func TestNoSubscribers_Try(t *testing.T) {
+	// test that sender is not blocked if there aren't subscribers
+	q := NewQueue[int](ChannelBufferLen(0))
+	sent := make(chan int)
+	go func() {
+		assert.True(t, q.TrySend(1))
+		close(sent)
+	}()
+	testutil.ReadChannel(t, sent, timeout)
+	testutil.ChannelEmpty(t, sent, 5*time.Millisecond)
+}
+
 func TestMultipleSubscribers(t *testing.T) {
 	q := NewQueue[int]()
 	ch1 := q.Subscribe()
 	ch2 := q.Subscribe()
 	go q.Send(123)
+
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch1, timeout))
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch2, timeout))
+	testutil.ChannelEmpty(t, ch1, 5*time.Millisecond)
+	testutil.ChannelEmpty(t, ch2, 5*time.Millisecond)
+}
+
+func TestMultipleSubscribers_Try(t *testing.T) {
+	q := NewQueue[int]()
+	ch1 := q.Subscribe()
+	ch2 := q.Subscribe()
+	go func() {
+		assert.True(t, q.TrySend(123))
+	}()
 
 	assert.Equal(t, 123, testutil.ReadChannel(t, ch1, timeout))
 	assert.Equal(t, 123, testutil.ReadChannel(t, ch2, timeout))
@@ -53,12 +79,40 @@ func TestBypass(t *testing.T) {
 	testutil.ChannelEmpty(t, ch2, 5*time.Millisecond)
 }
 
+func TestBypass_Try(t *testing.T) {
+	q1 := NewQueue[int]()
+	q2 := NewQueue[int]()
+	ch2 := q2.Subscribe()
+	q1.Bypass(q2)
+
+	go func() {
+		assert.True(t, q1.TrySend(123))
+	}()
+
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch2, timeout))
+	testutil.ChannelEmpty(t, ch2, 5*time.Millisecond)
+}
+
 func TestBypass_SubscribeAfterBypass(t *testing.T) {
 	q1 := NewQueue[int]()
 	q2 := NewQueue[int]()
 	q1.Bypass(q2)
 	ch2 := q2.Subscribe()
 	go q1.Send(123)
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch2, timeout))
+	testutil.ChannelEmpty(t, ch2, 5*time.Millisecond)
+}
+
+func TestBypass_SubscribeAfterBypass_Try(t *testing.T) {
+	q1 := NewQueue[int]()
+	q2 := NewQueue[int]()
+	q1.Bypass(q2)
+	ch2 := q2.Subscribe()
+
+	go func() {
+		assert.True(t, q1.TrySend(123))
+	}()
+
 	assert.Equal(t, 123, testutil.ReadChannel(t, ch2, timeout))
 	testutil.ChannelEmpty(t, ch2, 5*time.Millisecond)
 }
@@ -76,6 +130,22 @@ func TestChainedBypass(t *testing.T) {
 	testutil.ChannelEmpty(t, ch3, 5*time.Millisecond)
 }
 
+func TestChainedBypass_Try(t *testing.T) {
+	q1 := NewQueue[int]()
+	q2 := NewQueue[int]()
+	q3 := NewQueue[int]()
+	q1.Bypass(q2)
+	q2.Bypass(q3)
+	ch3 := q3.Subscribe()
+
+	go func() {
+		assert.True(t, q1.TrySend(123))
+	}()
+
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch3, timeout))
+	testutil.ChannelEmpty(t, ch3, 5*time.Millisecond)
+}
+
 func TestOneToManyBypass(t *testing.T) {
 	src := NewQueue[int]()
 	dst := NewQueue[int]()
@@ -84,6 +154,26 @@ func TestOneToManyBypass(t *testing.T) {
 	ch2 := dst.Subscribe()
 	ch3 := dst.Subscribe()
 	go src.Send(123)
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch1, timeout))
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch2, timeout))
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch3, timeout))
+	testutil.ChannelEmpty(t, ch1, 5*time.Millisecond)
+	testutil.ChannelEmpty(t, ch2, 5*time.Millisecond)
+	testutil.ChannelEmpty(t, ch3, 5*time.Millisecond)
+}
+
+func TestOneToManyBypass_Try(t *testing.T) {
+	src := NewQueue[int]()
+	dst := NewQueue[int]()
+	src.Bypass(dst)
+	ch1 := dst.Subscribe()
+	ch2 := dst.Subscribe()
+	ch3 := dst.Subscribe()
+
+	go func() {
+		assert.True(t, src.TrySend(123))
+	}()
+
 	assert.Equal(t, 123, testutil.ReadChannel(t, ch1, timeout))
 	assert.Equal(t, 123, testutil.ReadChannel(t, ch2, timeout))
 	assert.Equal(t, 123, testutil.ReadChannel(t, ch3, timeout))
@@ -406,4 +496,24 @@ func TestBlockingPanics(t *testing.T) {
 			time.Sleep(2 * sendTimeout)
 		}, "a deadlock should have been detected")
 	})
+}
+
+func TestTrySend(t *testing.T) {
+	q1 := NewQueue[int](ChannelBufferLen(1), Name("q1"))
+	q2 := NewQueue[int](ChannelBufferLen(1), Name("q2"))
+	q2a1 := NewQueue[int](ChannelBufferLen(1), Name("q2a1"))
+	q2a2 := NewQueue[int](ChannelBufferLen(1), Name("q2a2"))
+
+	// q1 -> q2 -> q2a1 -> q2a2 // a dead path must not block if nobody subscribes to it
+	//         \-> ch           // path with actual subscribers
+	q1.Bypass(q2)
+	_ = q2.Subscribe(SubscriberName("test"))
+	q2.Bypass(q2a1)
+	q2a1.Bypass(q2a2)
+
+	// queue size is 1 -> this must succeed
+	assert.True(t, q1.TrySend(1))
+
+	// at this point, the queue is full, TrySend should return false
+	assert.False(t, q1.TrySend(2))
 }


### PR DESCRIPTION
When pushing objects into a queue, `Queue.Send()` will panic if the queue is full. This is done to expose programming logic errors (such as cyclic dependencies).

There are scenarios though in which panicking may not be desirable: for instance, when too many events are pushing into the queue, causing it to fill and then block. In this case, the `TrySend()` function returns `false` and gives the caller the ability to handle this scenario without crashing the application.

This PR uses this function to prevent the network observability tracer from crashing / panicking when there are too many flows (due to a bad sampling configuration) that the pipeline can handle: in this case, the flows are simply dropped without any repercussion.

A log message is printed once (to avoid flooding the logs) to warn the user.