### PR TITLE
Fix disabling BPF internal metrics

### DIFF
--- a/pkg/export/prom/prom_bpf.go
+++ b/pkg/export/prom/prom_bpf.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/components/connector"
 	"go.opentelemetry.io/obi/pkg/components/imetrics"
 	"go.opentelemetry.io/obi/pkg/components/pipe/global"
+	"go.opentelemetry.io/obi/pkg/export/otel"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 )
 
@@ -70,11 +71,9 @@ func BPFMetrics(
 	}
 }
 
-func internalMetricsEnabled(internalMetrics imetrics.Reporter) bool {
-	if _, ok := internalMetrics.(imetrics.NoopReporter); ok || internalMetrics == nil {
-		return false
-	}
-	return true
+func internalMetricsOTELEnabled(internalMetrics imetrics.Reporter) bool {
+	_, ok := internalMetrics.(*otel.InternalMetricsReporter)
+	return ok
 }
 
 func promMetricsEnabled(cfg *PrometheusConfig) bool {
@@ -82,7 +81,7 @@ func promMetricsEnabled(cfg *PrometheusConfig) bool {
 }
 
 func bpfCollectorEnabled(cfg *PrometheusConfig, internalMetrics imetrics.Reporter) bool {
-	return promMetricsEnabled(cfg) || internalMetricsEnabled(internalMetrics)
+	return promMetricsEnabled(cfg) || internalMetricsOTELEnabled(internalMetrics)
 }
 
 func newBPFCollector(ctxInfo *global.ContextInfo, cfg *PrometheusConfig) *BPFCollector {


### PR DESCRIPTION
In order to enable BPF internal metrics with Prometheus, one needs to specify the "ebpf" feature explicitly in the config, i.e.

```
func promMetricsEnabled(cfg *PrometheusConfig) bool {
	return cfg.EndpointEnabled() && cfg.EBPFEnabled()
}
```

However, that can be bypassed by the following condition
```
_, ok := internalMetrics.(imetrics.NoopReporter); ok || internalMetrics == nil
```

as the internal metrics reporter is neither 'Noop' nor 'nil.

This also causes issues because even when `OTEL_EBPF_INTERNAL_METRICS_EXPORTER=disabled`, an internal reporter is created if a prometheus endpoint is set.

This PR conditions enabling these ebpf metrics either by enabling prometheus or otel metrics.