### PR TITLE
Allow overriding Network Export channel

### DIFF
--- a/pkg/components/netolly/agent/pipeline.go
+++ b/pkg/components/netolly/agent/pipeline.go
@@ -92,7 +92,10 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 		return flow.Decorate(f.agentIP, ifaceNamer, cidrDecoratedFlows, decoratedFlows), nil
 	}, swarm.WithID("FlowDecorator"))
 
-	filteredFlows := newQueue("filteredFlows")
+	filteredFlows := f.ctxInfo.OverrideNetExportQueue
+	if filteredFlows == nil {
+		filteredFlows = newQueue("filteredFlows")
+	}
 	swi.Add(filter.ByAttribute(f.cfg.Filters.Network, nil, selectorCfg.ExtraGroupAttributesCfg, ebpf.RecordStringGetters, decoratedFlows, filteredFlows),
 		swarm.WithID("AttributeFilter"))
 

--- a/pkg/components/netolly/ebpf/sock_tracer_nolinux.go
+++ b/pkg/components/netolly/ebpf/sock_tracer_nolinux.go
@@ -6,8 +6,6 @@
 package ebpf
 
 import (
-	"time"
-
 	"go.opentelemetry.io/obi/pkg/components/ebpf/ringbuf"
 )
 
@@ -27,12 +25,7 @@ func (s *SockFlowFetcher) ReadRingBuf() (ringbuf.Record, error) {
 
 func NewSockFlowFetcher(
 	_, _ int,
-	_ uint32,
-	_, _ time.Duration,
-	_, _ []string,
 ) (*SockFlowFetcher, error) {
 	// avoids linter complaining
-	_ = parseProtocolList
-	_ = assignProtocolList
 	return nil, nil
 }

--- a/pkg/components/netolly/ebpf/tracer_nonlinux.go
+++ b/pkg/components/netolly/ebpf/tracer_nonlinux.go
@@ -6,8 +6,6 @@
 package ebpf
 
 import (
-	"time"
-
 	"go.opentelemetry.io/obi/pkg/components/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/components/ebpf/tcmanager"
 )
@@ -19,9 +17,6 @@ func NewFlowFetcher(
 	_, _ bool,
 	_ *tcmanager.InterfaceManager,
 	_ tcmanager.TCBackend,
-	_ uint32,
-	_, _ time.Duration,
-	_, _ []string,
 ) (*FlowFetcher, error) {
 	return nil, nil
 }

--- a/pkg/components/pipe/global/context.go
+++ b/pkg/components/pipe/global/context.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/components/connector"
 	"go.opentelemetry.io/obi/pkg/components/imetrics"
 	kube2 "go.opentelemetry.io/obi/pkg/components/kube"
+	"go.opentelemetry.io/obi/pkg/components/netolly/ebpf"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
@@ -35,8 +36,17 @@ type ContextInfo struct {
 	// K8sInformer enables direct access to the Kubernetes API
 	K8sInformer *kube2.MetadataProvider
 
-	// OverrideAppExportQueue
+	// OverrideAppExportQueue allows overriding the output queue of the application exporter
+	// to connect your own application exporters outside the OBI code base. If left unset, OBI will
+	// create its own private queue.
+	// This is useful when OBI runs in vendored mode
 	OverrideAppExportQueue *msg.Queue[[]request.Span]
+
+	// OverrideNetExportQueue allows overriding the output queue of the network exporter
+	// to connect your own network exporters outside the OBI code base. If left unset, OBI will
+	// create its own private queue.
+	// This is useful when OBI runs in vendored mode
+	OverrideNetExportQueue *msg.Queue[[]*ebpf.Record]
 
 	// ExtraResourceAttributes allows extending (or overriding) the reported resource attributes in the traces exporters
 	ExtraResourceAttributes []attribute.KeyValue


### PR DESCRIPTION
Analogously to the `OverrideAppExportChannel` option in the context info, we are providing an analogous queue to allow providing more network data exporters.