### PR TITLE
ci: fix unit test coverage reporting

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,9 +2,9 @@ name: Pull request checks
 
 on:
   push:
-    branches: [ 'main', 'release-*' ]
+    branches: ["main", "release-*"]
   pull_request:
-    branches: [ 'main', 'release-*' ]
+    branches: ["main", "release-*"]
 
 permissions:
   contents: read
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.25' ]
+        go: ["1.25"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ matrix.go }}
-          cache: 'false'
+          cache: "false"
       - name: Run verification and unit tests
         run: make docker-generate verify cov-exclude-generated
       - name: Report coverage
@@ -36,7 +36,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./testoutput/cover.txt
+          files: ./testoutput/cover.txt
           flags: unittests
   verify-notices:
     runs-on: ubuntu-24.04
@@ -49,5 +49,5 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: stable
-          cache: 'false'
+          cache: "false"
       - run: make notices-update check-clean-work-tree


### PR DESCRIPTION
The unit test coverage report upload was silently failing ([link](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/18217579407/job/51870134749?pr=735)):

```
Unexpected input(s) 'file', valid inputs are ['base_sha', 'binary', 'codecov_yml_path', 'commit_parent', 'directory', 'disable_file_fixes', 'disable_search', 'disable_safe_directory', 'disable_telem', 'dry_run', 'env_vars', 'exclude', 'fail_ci_if_error', 'files', 'flags', 'force', 'git_service', 'gcov_args', 'gcov_executable', 'gcov_ignore', 'gcov_include', 'handle_no_reports_found', 'job_code', 'name', 'network_filter', 'network_prefix', 'os', 'override_branch', 'override_build', 'override_build_url', 'override_commit', 'override_pr', 'plugins', 'recurse_submodules', 'report_code', 'report_type', 'root_dir', 'run_command', 'skip_validation', 'slug', 'swift_project', 'token', 'url', 'use_legacy_upload_endpoint', 'use_oidc', 'use_pypi', 'verbose', 'version', 'working-directory']
```

Looks like this is the only place coverage is broken, the rest were already fixed in:

- #538