### PR TITLE
fix postgres error verbosity

### DIFF
--- a/pkg/components/ebpf/common/sql_detect_postgres.go
+++ b/pkg/components/ebpf/common/sql_detect_postgres.go
@@ -241,11 +241,11 @@ func handlePostgres(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBu
 	)
 
 	if len(requestBuffer) < sqlprune2.PostgresHdrSize+1 {
-		slog.Warn("Postgres request too short")
+		slog.Debug("Postgres request too short")
 		return span, errFallback
 	}
 	if len(responseBuffer) < sqlprune2.PostgresHdrSize+1 {
-		slog.Warn("Postgres response too short")
+		slog.Debug("Postgres response too short")
 		return span, errFallback
 	}
 


### PR DESCRIPTION
reduce postgres verbosity
```
2025-10-01 17:31:43.727	
time=2025-10-01T21:31:43.727Z level=WARN msg="Postgres response too short"
```
similar to https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/605 for mysql
