### PR TITLE
bpf: don't use span id to correlate large buffers

### DIFF
--- a/bpf/common/common.h
+++ b/bpf/common/common.h
@@ -146,8 +146,10 @@ typedef struct tcp_large_buffer {
     u8 type; // Must be first
     u8 packet_type;
     enum large_buf_action action;
-    u8 _pad;
+    u8 direction;
     u32 len;
+    connection_info_t conn_info;
+    u32 _pad2;
     tp_info_t tp;
     u8 buf[];
 } tcp_large_buffer_t;

--- a/bpf/common/http_info.h
+++ b/bpf/common/http_info.h
@@ -31,5 +31,6 @@ typedef struct http_info {
     u16 status;
     unsigned char buf[FULL_BUF_SIZE];
     u8 has_large_buffers;
-    u8 _pad[5];
+    u8 direction;
+    u8 _pad[4];
 } http_info_t;

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -1038,7 +1038,7 @@ int obi_handle_buf_with_args(void *ctx) {
 
                         tp_info_pid_t *existing = bpf_map_lookup_elem(&server_traces, &t_key);
                         if (existing) {
-                            __builtin_memcpy(&existing->tp, &info->tp, sizeof(tp_info_t));
+                            existing->tp = info->tp;
                             set_trace_info_for_connection(
                                 &args->pid_conn.conn, TRACE_TYPE_SERVER, existing);
                         } else {

--- a/bpf/generictracer/protocol_mysql.h
+++ b/bpf/generictracer/protocol_mysql.h
@@ -154,6 +154,7 @@ static __always_inline int mysql_send_large_buffer(tcp_req_t *req,
                                                    const void *u_buf,
                                                    u32 bytes_len,
                                                    u8 packet_type,
+                                                   u8 direction,
                                                    enum large_buf_action action) {
     if (mysql_store_state_data(&pid_conn->conn, u_buf, bytes_len) < 0) {
         bpf_dbg_printk("mysql_send_large_buffer: 4 bytes packet, storing state data");
@@ -169,7 +170,9 @@ static __always_inline int mysql_send_large_buffer(tcp_req_t *req,
     large_buf->type = EVENT_TCP_LARGE_BUFFER;
     large_buf->packet_type = packet_type;
     large_buf->action = action;
-    __builtin_memcpy((void *)&large_buf->tp, (void *)&req->tp, sizeof(tp_info_t));
+    large_buf->direction = direction;
+    large_buf->conn_info = pid_conn->conn;
+    large_buf->tp = req->tp;
 
     int written =
         mysql_read_fixup_buffer(&pid_conn->conn, large_buf->buf, &large_buf->len, u_buf, bytes_len);

--- a/bpf/generictracer/protocol_postgres.h
+++ b/bpf/generictracer/protocol_postgres.h
@@ -51,6 +51,7 @@ static __always_inline int postgres_send_large_buffer(tcp_req_t *req,
                                                       const void *u_buf,
                                                       u32 bytes_len,
                                                       u8 packet_type,
+                                                      u8 direction,
                                                       enum large_buf_action action) {
     tcp_large_buffer_t *large_buf = (tcp_large_buffer_t *)postgres_large_buffers_mem();
     if (!large_buf) {
@@ -62,7 +63,9 @@ static __always_inline int postgres_send_large_buffer(tcp_req_t *req,
     large_buf->type = EVENT_TCP_LARGE_BUFFER;
     large_buf->packet_type = packet_type;
     large_buf->action = action;
-    __builtin_memcpy((void *)&large_buf->tp, (void *)&req->tp, sizeof(tp_info_t));
+    large_buf->direction = direction;
+    large_buf->conn_info = req->conn_info;
+    large_buf->tp = req->tp;
 
     large_buf->len = bytes_len;
     if (large_buf->len >= postgres_buffer_size) {

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -114,13 +114,14 @@ static __always_inline int tcp_send_large_buffer(tcp_req_t *req,
     case k_protocol_type_mysql:
         if (mysql_buffer_size > 0) {
             u8 packet_type = infer_packet_type(direction, pid_conn->conn.d_port);
-            ret = mysql_send_large_buffer(req, pid_conn, u_buf, bytes_len, packet_type, action);
+            ret = mysql_send_large_buffer(
+                req, pid_conn, u_buf, bytes_len, packet_type, direction, action);
         }
         break;
     case k_protocol_type_postgres:
         if (postgres_buffer_size > 0) {
             u8 packet_type = infer_packet_type(direction, pid_conn->conn.d_port);
-            ret = postgres_send_large_buffer(req, u_buf, bytes_len, packet_type, action);
+            ret = postgres_send_large_buffer(req, u_buf, bytes_len, packet_type, direction, action);
         }
         break;
     case k_protocol_type_unknown:

--- a/pkg/components/ebpf/common/httpfltr_transform.go
+++ b/pkg/components/ebpf/common/httpfltr_transform.go
@@ -90,7 +90,7 @@ func HTTPInfoEventToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo) (reques
 	)
 
 	if event.HasLargeBuffers == 1 {
-		b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, event.Tp.SpanId, packetTypeRequest)
+		b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeRequest, directionSend, event.ConnInfo)
 		if ok {
 			requestBuffer = b
 		} else {

--- a/pkg/components/ebpf/common/tcp_detect_transform.go
+++ b/pkg/components/ebpf/common/tcp_detect_transform.go
@@ -21,6 +21,9 @@ var (
 const (
 	packetTypeRequest  = 1
 	packetTypeResponse = 2
+
+	directionRecv = 0
+	directionSend = 1
 )
 
 // ReadTCPRequestIntoSpan returns a request.Span from the provided ring buffer record
@@ -161,10 +164,10 @@ func getBuffers(parseCtx *EBPFParseContext, event *TCPRequestInfo) (req []byte, 
 	resp = event.Rbuf[:l]
 
 	if event.HasLargeBuffers == 1 {
-		if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, event.Tp.SpanId, packetTypeRequest); ok {
+		if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeRequest, directionSend, event.ConnInfo); ok {
 			req = b
 		}
-		if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, event.Tp.SpanId, packetTypeResponse); ok {
+		if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeResponse, directionRecv, event.ConnInfo); ok {
 			resp = b
 		}
 	}

--- a/pkg/components/ebpf/common/tcp_detect_transform_test.go
+++ b/pkg/components/ebpf/common/tcp_detect_transform_test.go
@@ -20,14 +20,9 @@ import (
 	"go.opentelemetry.io/obi/pkg/config"
 )
 
-const (
-	tcpSend = 1
-	tcpRecv = 0
-)
-
 func TestTCPReqSQLParsing(t *testing.T) {
 	sql := randomStringWithSub("SELECT * FROM accounts ")
-	r := makeTCPReq(sql, tcpSend, 343534, 8080, 2000)
+	r := makeTCPReq(sql, directionSend, 343534, 8080, 2000)
 	op, table, sql := detectSQL(sql)
 	assert.Equal(t, "SELECT", op)
 	assert.Equal(t, "accounts", table)
@@ -45,7 +40,7 @@ func TestTCPReqSQLParsing(t *testing.T) {
 
 func TestTCPReqParsing(t *testing.T) {
 	sql := "Not a sql or any known protocol"
-	r := makeTCPReq(sql, tcpSend, 343534, 8080, 2000)
+	r := makeTCPReq(sql, directionSend, 343534, 8080, 2000)
 	op, table, _ := detectSQL(sql)
 	assert.Empty(t, op)
 	assert.Empty(t, table)
@@ -157,7 +152,7 @@ func TestRedisDetection(t *testing.T) {
 func TestTCPReqKafkaParsing(t *testing.T) {
 	// kafka message
 	b := []byte{0, 0, 0, 94, 0, 1, 0, 11, 0, 0, 0, 224, 0, 6, 115, 97, 114, 97, 109, 97, 255, 255, 255, 255, 0, 0, 1, 244, 0, 0, 0, 1, 6, 64, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 0, 0, 0, 1, 0, 9, 105, 109, 112, 111, 114, 116, 97, 110, 116, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0}
-	r := makeTCPReq(string(b), tcpSend, 343534, 8080, 2000)
+	r := makeTCPReq(string(b), directionSend, 343534, 8080, 2000)
 	k, _, err := ProcessKafkaRequest(b, nil)
 	require.NoError(t, err)
 	s := TCPToKafkaToSpan(&r, k)

--- a/pkg/components/ebpf/common/tcp_large_buffer.go
+++ b/pkg/components/ebpf/common/tcp_large_buffer.go
@@ -13,9 +13,9 @@ import (
 
 type (
 	largeBufferKey struct {
-		traceID    [16]uint8
-		spanID     [8]uint8
-		packetType uint8
+		traceID               [16]uint8
+		packetType, direction uint8
+		connInfo              BpfConnectionInfoT
 	}
 	largeBuffer struct {
 		buf []byte
@@ -37,8 +37,9 @@ func appendTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (r
 
 	key := largeBufferKey{
 		traceID:    event.Tp.TraceId,
-		spanID:     event.Tp.SpanId,
 		packetType: event.PacketType,
+		direction:  event.Direction,
+		connInfo:   event.ConnInfo,
 	}
 
 	switch event.Action {
@@ -61,11 +62,12 @@ func appendTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (r
 	return request.Span{}, true, nil
 }
 
-func extractTCPLargeBuffer(parseCtx *EBPFParseContext, traceID [16]uint8, spanID [8]uint8, packetType uint8) ([]byte, bool) {
+func extractTCPLargeBuffer(parseCtx *EBPFParseContext, traceID [16]uint8, packetType, direction uint8, connInfo BpfConnectionInfoT) ([]byte, bool) {
 	key := largeBufferKey{
-		spanID:     spanID,
 		traceID:    traceID,
 		packetType: packetType,
+		direction:  direction,
+		connInfo:   connInfo,
 	}
 
 	if lb, ok := parseCtx.largeBuffers.Get(key); ok {

--- a/pkg/components/ebpf/common/tcp_large_buffer_test.go
+++ b/pkg/components/ebpf/common/tcp_large_buffer_test.go
@@ -19,8 +19,8 @@ import (
 
 func TestTCPLargeBuffers(t *testing.T) {
 	pctx := NewEBPFParseContext(nil)
-	verifyLargeBuffer := func(traceID [16]uint8, spanID [8]uint8, packetType uint8, expectedBuf string) {
-		buf, ok := extractTCPLargeBuffer(pctx, traceID, spanID, packetType)
+	verifyLargeBuffer := func(traceID [16]uint8, packetType, direction uint8, connInfo BpfConnectionInfoT, expectedBuf string) {
+		buf, ok := extractTCPLargeBuffer(pctx, traceID, packetType, direction, connInfo)
 		require.True(t, ok, "Expected to find large buffer")
 		require.Equal(t, expectedBuf, unix.ByteSliceToString(buf), "Buffer content mismatch")
 	}
@@ -28,10 +28,13 @@ func TestTCPLargeBuffers(t *testing.T) {
 	firstEvent := TCPLargeBufferHeader{
 		Type:       12,
 		PacketType: 1,
+		Direction:  0,
 		Len:        10,
 	}
 	firstEvent.Tp.TraceId = [16]uint8{'1'}
-	firstEvent.Tp.SpanId = [8]uint8{'2'}
+	firstEvent.ConnInfo = BpfConnectionInfoT{
+		D_port: 2000,
+	}
 	firstBuf := "obi rocks!"
 
 	span, drop, err := appendTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, firstBuf))
@@ -40,7 +43,7 @@ func TestTCPLargeBuffers(t *testing.T) {
 	require.Equal(t, request.Span{}, span)
 
 	// Verify normal write
-	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.PacketType, firstBuf)
+	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.PacketType, firstEvent.Direction, firstEvent.ConnInfo, firstBuf)
 
 	secondBuf := "obi rocks twice!"
 	firstEvent.Len = uint32(len(secondBuf))
@@ -49,10 +52,10 @@ func TestTCPLargeBuffers(t *testing.T) {
 	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, firstEvent, secondBuf))
 	require.NoError(t, err)
 	// Verify buffer overwrite
-	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.PacketType, secondBuf)
+	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.PacketType, firstEvent.Direction, firstEvent.ConnInfo, secondBuf)
 
 	// Verify second read error
-	_, ok := extractTCPLargeBuffer(pctx, firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.PacketType)
+	_, ok := extractTCPLargeBuffer(pctx, firstEvent.Tp.TraceId, firstEvent.PacketType, firstEvent.Direction, firstEvent.ConnInfo)
 	require.False(t, ok, "Expected to not find large buffer after first read")
 
 	firstEvent.Len = uint32(len(firstBuf))
@@ -60,11 +63,11 @@ func TestTCPLargeBuffers(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify no buffer read happens for different traceID/packet_type
-	_, ok = extractTCPLargeBuffer(pctx, [16]uint8{99}, firstEvent.Tp.SpanId, firstEvent.PacketType)
+	_, ok = extractTCPLargeBuffer(pctx, [16]uint8{99}, firstEvent.PacketType, firstEvent.Direction, firstEvent.ConnInfo)
 	require.False(t, ok, "Expected to not find large buffer for this traceID")
-	_, ok = extractTCPLargeBuffer(pctx, firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, 3)
+	_, ok = extractTCPLargeBuffer(pctx, firstEvent.Tp.TraceId, 3, firstEvent.Direction, firstEvent.ConnInfo)
 	require.False(t, ok, "Expected to not find large buffer for this packet_type")
-	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.PacketType, firstBuf)
+	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.PacketType, firstEvent.Direction, firstEvent.ConnInfo, firstBuf)
 
 	// Test append to existing buffer
 	firstEvent.Len = 10
@@ -78,13 +81,15 @@ func TestTCPLargeBuffers(t *testing.T) {
 		Action:     largeBufferActionAppend,
 	}
 	appendEvent.Tp.TraceId = firstEvent.Tp.TraceId
-	appendEvent.Tp.SpanId = firstEvent.Tp.SpanId
+	appendEvent.ConnInfo = BpfConnectionInfoT{
+		D_port: 2000,
+	}
 	appendBuf := "append"
 
 	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, appendBuf))
 	require.NoError(t, err)
 	// The buffer should now be firstBuf + appendBuf
-	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.PacketType, firstBuf+appendBuf)
+	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.PacketType, firstEvent.Direction, firstEvent.ConnInfo, firstBuf+appendBuf)
 
 	// Test multiple appends
 	// Re-init buffer
@@ -97,7 +102,7 @@ func TestTCPLargeBuffers(t *testing.T) {
 	require.NoError(t, err)
 	_, _, err = appendTCPLargeBuffer(pctx, toRingbufRecord(t, appendEvent, "bar"))
 	require.NoError(t, err)
-	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.Tp.SpanId, firstEvent.PacketType, firstBuf+"foobar")
+	verifyLargeBuffer(firstEvent.Tp.TraceId, firstEvent.PacketType, firstEvent.Direction, firstEvent.ConnInfo, firstBuf+"foobar")
 }
 
 func toRingbufRecord(t *testing.T, event TCPLargeBufferHeader, buf string) *ringbuf.Record {

--- a/test/integration/docker-compose-python-self.yml
+++ b/test/integration/docker-compose-python-self.yml
@@ -51,6 +51,7 @@ services:
       OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
       OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
       OTEL_EBPF_METRICS_FEATURES: "application,application_process,application_span,application_service_graph"
+      OTEL_EBPF_BPF_BUFFER_SIZE_HTTP: 1024
     depends_on:
       testserver:
         condition: service_started


### PR DESCRIPTION
When the sk_msg program is loaded, http packets are split on the `tcp_sendmsg` path and during large buffers correlation the span ID doesn't match. It might be because it's a bug or because at that time there's not enough info to have the correct trace info.
This PR, as a workaround, correlates buffers with connection info and direction instead. I added the env var in the `pythonself` integration tests so http large buffers are tested too