### PR TITLE
fix: event.Resource nil pointer dereference

### DIFF
--- a/pkg/components/discover/watcher_kube.go
+++ b/pkg/components/discover/watcher_kube.go
@@ -79,7 +79,7 @@ func (wk *watcherKubeEnricher) ID() string { return "unique-watcher-kube-enriche
 // handling in the enrich main loop
 func (wk *watcherKubeEnricher) On(event *informer.Event) error {
 	// ignoring updates on non-pod resources
-	if event.GetResource().GetPod() == nil {
+	if event.Resource == nil || event.GetResource().GetPod() == nil {
 		return nil
 	}
 	switch event.Type {

--- a/pkg/components/kube/cache_svc_client.go
+++ b/pkg/components/kube/cache_svc_client.go
@@ -44,7 +44,7 @@ func (sc *cacheSvcClient) ID() string {
 func (sc *cacheSvcClient) On(event *informer.Event) error {
 	// we can safely assume that server-side events are ordered
 	// by timestamp
-	if event.GetType() != informer.EventType_SYNC_FINISHED {
+	if event.GetType() != informer.EventType_SYNC_FINISHED && event.Resource != nil {
 		sc.lastEventTSEpoch = event.Resource.StatusTimeEpoch
 	}
 	return nil

--- a/pkg/kubecache/service/service.go
+++ b/pkg/kubecache/service/service.go
@@ -141,7 +141,7 @@ func (o *connection) FromEpoch() int64 {
 func (o *connection) On(event *informer.Event) error {
 	// the client asked for events happening after their last successfully received event
 	// so ignore older events to save memory and network
-	if event.Type != informer.EventType_SYNC_FINISHED && event.Resource.StatusTimeEpoch < o.fromEpoch {
+	if event.Type != informer.EventType_SYNC_FINISHED && event.Resource != nil && event.Resource.StatusTimeEpoch < o.fromEpoch {
 		return nil
 	}
 	o.metrics.MessageSubmit()

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -256,7 +256,7 @@ func (md *procEventMetadataDecorator) ID() string { return "unique-proc-event-me
 
 func (md *procEventMetadataDecorator) On(event *informer.Event) error {
 	// ignoring updates on non-pod resources
-	if event.GetResource().GetPod() == nil {
+	if event.Resource == nil || event.GetResource().GetPod() == nil {
 		return nil
 	}
 	switch event.Type {


### PR DESCRIPTION
Seems `event.Resource` can be `nil`, I tried to find all occurrences.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x88 pc=0x1cedfb7]

goroutine 65 [running]:
go.opentelemetry.io/obi/pkg/components/kube.(*Store).On(0xc0001aa900, 0xc00613a040)
        /src/vendor/go.opentelemetry.io/obi/pkg/components/kube/store.go:212 +0x37
go.opentelemetry.io/obi/pkg/kubecache/meta.(*BaseNotifier).notifyAll(0xc0000f8a00, 0xc00613a040)
        /src/vendor/go.opentelemetry.io/obi/pkg/kubecache/meta/observer.go:63 +0x174
go.opentelemetry.io/obi/pkg/kubecache/meta.(*BaseNotifier).Notify(0xc0000f8a00, 0x305f708?)
        /src/vendor/go.opentelemetry.io/obi/pkg/kubecache/meta/observer.go:49 +0x28
go.opentelemetry.io/obi/pkg/components/kube.(*cacheSvcClient).connect(0xc0000f8a00, {0x305f708, 0xc0003294f0})
        /src/vendor/go.opentelemetry.io/obi/pkg/components/kube/cache_svc_client.go:123 +0x24d
go.opentelemetry.io/obi/pkg/components/kube.(*cacheSvcClient).Start.func1()
        /src/vendor/go.opentelemetry.io/obi/pkg/components/kube/cache_svc_client.go:82 +0x18e
created by go.opentelemetry.io/obi/pkg/components/kube.(*cacheSvcClient).Start in goroutine 57
        /src/vendor/go.opentelemetry.io/obi/pkg/components/kube/cache_svc_client.go:64 +0x15c
```