### PR TITLE
bpf: msg_buffer: use real buffer size instead of the hardcoded one

### DIFF
--- a/bpf/common/http_types.h
+++ b/bpf/common/http_types.h
@@ -30,9 +30,6 @@
 // 100K and above we try to track the response actual time with kretprobes
 #define KPROBES_LARGE_RESPONSE_LEN 100000
 
-// Max of HTTP, HTTP2/GRPC and TCP buffers. Used in sk_msg
-#define MAX_PROTOCOL_BUF_SIZE 256
-
 #define CONN_INFO_FLAG_TRACE 0x1
 
 #define FLAGS_SIZE_BYTES 1

--- a/bpf/common/msg_buffer.h
+++ b/bpf/common/msg_buffer.h
@@ -13,4 +13,5 @@
 typedef struct msg_buffer {
     unsigned char buf[k_kprobes_http2_buf_size];
     u16 pos;
+    u16 real_size;
 } msg_buffer_t;

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -404,8 +404,8 @@ int BPF_KPROBE(obi_kprobe_tcp_sendmsg, struct sock *sk, struct msghdr *msg, size
                             // handle_buf_with_connection logic and then mark it as seen by making
                             // m_buf->pos be the size of the buffer.
                             if (!m_buf->pos) {
-                                size = sizeof(m_buf->buf);
-                                m_buf->pos = size;
+                                size = m_buf->real_size;
+                                m_buf->pos = sizeof(m_buf->buf);
                                 bpf_dbg_printk("msg_buffer: size %d, buf[%s]", size, buf);
                             } else {
                                 size = 0;
@@ -491,8 +491,8 @@ int BPF_KPROBE(obi_kprobe_tcp_rate_check_app_limited, struct sock *sk) {
                 // handle_buf_with_connection logic and then mark it as seen by making
                 // m_buf->pos be the size of the buffer.
                 if (!m_buf->pos) {
-                    u16 size = sizeof(m_buf->buf);
-                    m_buf->pos = size;
+                    u16 size = m_buf->real_size;
+                    m_buf->pos = sizeof(m_buf->buf);
                     s_args.size = size;
                     bpf_dbg_printk("msg_buffer: size %d, buf[%s]", size, buf);
                     u64 sock_p = (u64)sk;

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -188,9 +188,10 @@ static __always_inline u8 protocol_detector(struct sk_msg_md *msg,
 
     msg_buffer_t msg_buf = {
         .pos = 0,
+        .real_size = msg->size > k_kprobes_http2_buf_size ? k_kprobes_http2_buf_size : msg->size,
     };
 
-    bpf_probe_read_kernel(msg_buf.buf, MAX_PROTOCOL_BUF_SIZE, msg->data);
+    bpf_probe_read_kernel(msg_buf.buf, k_kprobes_http2_buf_size, msg->data);
 
     // We setup any call that looks like HTTP request to be extended.
     // This must match exactly to what the decision will be for


### PR DESCRIPTION
This PR forwards the original buffer size for the saved buffers to `handle_buf_with_connection` instead of `256` in any case