### PR TITLE
Update EBPFTracer configuration validation

### DIFF
--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -4,7 +4,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -36,11 +38,13 @@ type EBPFTracer struct {
 	// before sending a wakeup request.
 	// High values of WakeupLen could add a noticeable metric delay in services with low
 	// requests/second.
+	// Must be at least 0
 	// TODO: see if there is a way to force eBPF to wakeup userspace on timeout
 	WakeupLen int `yaml:"wakeup_len" env:"OTEL_EBPF_BPF_WAKEUP_LEN"`
 
 	// BatchLength allows specifying how many traces will be batched at the initial
 	// stage before being forwarded to the next stage
+	// Must be at least 1
 	BatchLength int `yaml:"batch_length" env:"OTEL_EBPF_BPF_BATCH_LENGTH"`
 
 	// BatchTimeout specifies the timeout to forward the data batch if it didn't
@@ -51,6 +55,7 @@ type EBPFTracer struct {
 	// headers to process any 'Traceparent' fields.
 	TrackRequestHeaders bool `yaml:"track_request_headers" env:"OTEL_EBPF_BPF_TRACK_REQUEST_HEADERS"`
 
+	// Must be at least 0
 	HTTPRequestTimeout time.Duration `yaml:"http_request_timeout" env:"OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT"`
 
 	// Deprecated: equivalent to ContextPropagationAll
@@ -114,16 +119,61 @@ type EBPFBufferSizes struct {
 }
 
 func (c *EBPFTracer) Validate() error {
-	// TODO(matt): validate all the existing attributes
+	// WakeupLen is used to calculate the wakeup_data_bytes for the ringbuf
+	if c.WakeupLen < 0 {
+		return errors.New("ebpf.wakeup_len in the YAML configuration file or OTEL_EBPF_BPF_WAKEUP_LEN must be at least 1")
+	}
+	if c.BatchLength < 1 {
+		return errors.New("ebpf.batch_length in the YAML configuration file or OTEL_EBPF_BPF_BATCH_LENGTH must be at least 1")
+	}
 
-	if c.BufferSizes.HTTP > bufferSizeMax {
-		return fmt.Errorf("buffer size too large (HTTP): %d, max is %d", c.BufferSizes.HTTP, bufferSizeMax)
+	if c.BatchTimeout <= 0 {
+		return errors.New("ebpf.batch_timeout in the YAML configuration file or OTEL_EBPF_BPF_BATCH_TIMEOUT must be greater than 0")
 	}
-	if c.BufferSizes.MySQL > bufferSizeMax {
-		return fmt.Errorf("buffer size too large (MySQL): %d, max is %d", c.BufferSizes.MySQL, bufferSizeMax)
+
+	if c.HTTPRequestTimeout < 0 {
+		return errors.New("ebpf.http_request_timeout in the YAML configuration file or OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT must be greater than or equal to 0")
 	}
-	if c.BufferSizes.Postgres > bufferSizeMax {
-		return fmt.Errorf("buffer size too large (Postgres): %d, max is %d", c.BufferSizes.Postgres, bufferSizeMax)
+
+	if !c.TCBackend.Valid() {
+		return errors.New("invalid ebpf.traffic_control_backend in the YAML configuration file or OTEL_EBPF_BPF_TC_BACKEND value, must be 'tc' or 'tcx' or 'auto'")
+	}
+
+	// remove after deleting ContextPropagationEnabled
+	if c.ContextPropagationEnabled && c.ContextPropagation != ContextPropagationDisabled {
+		return errors.New("ebpf.enable_context_propagation and ebpf.context_propagation in the YAML configuration file or OTEL_EBPF_BPF_ENABLE_CONTEXT_PROPAGATION and OTEL_EBPF_BPF_CONTEXT_PROPAGATION are mutually exclusive")
+	}
+
+	// TODO deprecated (REMOVE)
+	// remove after deleting ContextPropagationEnabled
+	if c.ContextPropagationEnabled {
+		slog.Warn("DEPRECATION NOTICE: 'ebpf.enable_context_propagation' configuration option has been " +
+			"deprecated and will be removed in the future - use 'ebpf.context_propagation' instead")
+		c.ContextPropagation = ContextPropagationAll
+	}
+
+	if err := c.RedisDBCache.Validate(); err != nil {
+		return err
+	}
+
+	if err := c.BufferSizes.Validate(); err != nil {
+		return err
+	}
+
+	if c.MySQLPreparedStatementsCacheSize <= 0 {
+		return errors.New("ebpf.mysql_prepared_statements_cache_size in the YAML configuration file or OTEL_EBPF_BPF_MYSQL_PREPARED_STATEMENTS_CACHE_SIZE must be greater than 0")
+	}
+
+	if c.PostgresPreparedStatementsCacheSize <= 0 {
+		return errors.New("ebpf.postgres_prepared_statements_cache_size in the YAML configuration file or OTEL_EBPF_BPF_POSTGRES_PREPARED_STATEMENTS_CACHE_SIZE must be greater than 0")
+	}
+
+	if c.KafkaTopicUUIDCacheSize <= 0 {
+		return errors.New("ebpf.kafka_topic_uuid_cache_size in the YAML configuration file or OTEL_KAFKA_TOPIC_UUID_CACHE_SIZE must be greater than 0")
+	}
+
+	if c.MongoRequestsCacheSize <= 0 {
+		return errors.New("ebpf.mongo_requests_cache_size in the YAML configuration file or OTEL_EBPF_BPF_MONGO_REQUESTS_CACHE_SIZE must be greater than 0")
 	}
 
 	return nil
@@ -161,4 +211,24 @@ func (m ContextPropagationMode) MarshalText() ([]byte, error) {
 	}
 
 	return nil, fmt.Errorf("invalid context propagation mode: %d", m)
+}
+
+func (r RedisDBCacheConfig) Validate() error {
+	if r.MaxSize <= 0 {
+		return errors.New("ebpf.redis_db_cache.max_size in the YAML configuration file or OTEL_EBPF_BPF_REDIS_DB_CACHE_MAX_SIZE must be greater than 0")
+	}
+	return nil
+}
+
+func (b EBPFBufferSizes) Validate() error {
+	if b.HTTP > bufferSizeMax {
+		return fmt.Errorf("ebpf.buffer_sizes.http in YAML configuration file or OTEL_EBPF_BPF_BUFFER_SIZE_HTTP too large: %d, max is %d", b.HTTP, bufferSizeMax)
+	}
+	if b.MySQL > bufferSizeMax {
+		return fmt.Errorf("ebpf.buffer_sizes.mysql in YAML configuration file or OTEL_EBPF_BPF_BUFFER_SIZE_MYSQL too large: %d, max is %d", b.MySQL, bufferSizeMax)
+	}
+	if b.Postgres > bufferSizeMax {
+		return fmt.Errorf("ebpf.buffer_sizes.postgres in YAML configuration file or OTEL_EBPF_BPF_BUFFER_SIZE_POSTGRES too large: %d, max is %d", b.Postgres, bufferSizeMax)
+	}
+	return nil
 }

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -311,25 +311,6 @@ func (c *Config) Validate() error {
 			"Enable Prometheus export features using the 'OTEL_EBPF_PROMETHEUS_FEATURES=network,application' environment variable " +
 			"or 'prometheus_export: { features: [network,application] }' in the YAML configuration file.")
 	}
-	if c.EBPF.BatchLength == 0 {
-		return ConfigError("OTEL_EBPF_BPF_BATCH_LENGTH must be at least 1")
-	}
-	if !c.EBPF.TCBackend.Valid() {
-		return ConfigError("Invalid OTEL_EBPF_BPF_TC_BACKEND value")
-	}
-
-	// remove after deleting ContextPropagationEnabled
-	if c.EBPF.ContextPropagationEnabled && c.EBPF.ContextPropagation != config.ContextPropagationDisabled {
-		return ConfigError("context_propagation_enabled and context_propagation are mutually exclusive")
-	}
-
-	// TODO deprecated (REMOVE)
-	// remove after deleting ContextPropagationEnabled
-	if c.EBPF.ContextPropagationEnabled {
-		slog.Warn("DEPRECATION NOTICE: 'context_propagation_enabled' configuration option has been " +
-			"deprecated and will be removed in the future - use 'context_propagation' instead")
-		c.EBPF.ContextPropagation = config.ContextPropagationAll
-	}
 
 	if c.willUseTC() {
 		if err := tcmanager.EnsureCiliumCompatibility(c.EBPF.TCBackend); err != nil {


### PR DESCRIPTION
This PR updates the validation for EBPFTracer. It moves some parts of the code from Config's `Validate()` into the EBPFTracer's `Validate()` method to be aligned with the separation of concerns principle.

Below is a list of the validated fields with the logic used (for some of them I'm not sure):

- [x] WakeupLen: must be at least 0
- [x] BatchLength: must be at least 1
- [x] BatchTimeout must be at least 1 nanosecond (really small value)
- [x] HTTPRequestTimeout: must be at least 0
- [x] ContextPropagation: used old validation
- [x] TCBackend: used old validation, tc or tcx
- [x] RedisDBCacheConfig.MaxSize: must be at least 1
- [x] EBPFBufferSizes { HTTP, MySQL and Postgres}: used old validation, less than bufferSizeMax (8192)

I tried to use a standard way to return the error message, i.e., to use the full path of a yaml variable (ebpf.buffer_sizes.http) plus the unique name of the env variable OTEL_EBPF_BPF_BUFFER_SIZE_HTTP. 

If you have any advice I'm open.