### PR TITLE
Integrate go-playground/validator for improved configuration validation

### DIFF
--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -14,8 +14,8 @@ import (
 type ContextPropagationMode uint8
 
 type RedisDBCacheConfig struct {
-	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_BPF_REDIS_DB_CACHE_ENABLED"`
-	MaxSize int  `yaml:"max_size" env:"OTEL_EBPF_BPF_REDIS_DB_CACHE_MAX_SIZE"`
+	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_BPF_REDIS_DB_CACHE_ENABLED" validate:"boolean"`
+	MaxSize int  `yaml:"max_size" env:"OTEL_EBPF_BPF_REDIS_DB_CACHE_MAX_SIZE" validate:"gt=0"`
 }
 
 const (
@@ -25,12 +25,10 @@ const (
 	ContextPropagationDisabled
 )
 
-const bufferSizeMax = 8192
-
 // EBPFTracer configuration for eBPF programs
 type EBPFTracer struct {
 	// Enables logging of eBPF program events
-	BpfDebug bool `yaml:"bpf_debug" env:"OTEL_EBPF_BPF_DEBUG"`
+	BpfDebug bool `yaml:"bpf_debug" env:"OTEL_EBPF_BPF_DEBUG" validate:"boolean"`
 
 	// WakeupLen specifies how many messages need to be accumulated in the eBPF ringbuffer
 	// before sending a wakeup request.
@@ -38,56 +36,56 @@ type EBPFTracer struct {
 	// requests/second.
 	// Must be at least 0
 	// TODO: see if there is a way to force eBPF to wakeup userspace on timeout
-	WakeupLen int `yaml:"wakeup_len" env:"OTEL_EBPF_BPF_WAKEUP_LEN"`
+	WakeupLen int `yaml:"wakeup_len" env:"OTEL_EBPF_BPF_WAKEUP_LEN" validate:"gte=0"`
 
 	// BatchLength allows specifying how many traces will be batched at the initial
 	// stage before being forwarded to the next stage
 	// Must be at least 1
-	BatchLength int `yaml:"batch_length" env:"OTEL_EBPF_BPF_BATCH_LENGTH"`
+	BatchLength int `yaml:"batch_length" env:"OTEL_EBPF_BPF_BATCH_LENGTH" validate:"gt=0"`
 
 	// BatchTimeout specifies the timeout to forward the data batch if it didn't
 	// reach the BatchLength size
-	BatchTimeout time.Duration `yaml:"batch_timeout" env:"OTEL_EBPF_BPF_BATCH_TIMEOUT"`
+	BatchTimeout time.Duration `yaml:"batch_timeout" env:"OTEL_EBPF_BPF_BATCH_TIMEOUT" validate:"gte=0"`
 
 	// If enabled, the kprobes based HTTP request tracking will start tracking the request
 	// headers to process any 'Traceparent' fields.
-	TrackRequestHeaders bool `yaml:"track_request_headers" env:"OTEL_EBPF_BPF_TRACK_REQUEST_HEADERS"`
+	TrackRequestHeaders bool `yaml:"track_request_headers" env:"OTEL_EBPF_BPF_TRACK_REQUEST_HEADERS" validate:"boolean"`
 
 	// Must be at least 0
-	HTTPRequestTimeout time.Duration `yaml:"http_request_timeout" env:"OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT"`
+	HTTPRequestTimeout time.Duration `yaml:"http_request_timeout" env:"OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT" validate:"gte=0"`
 
 	// Deprecated: equivalent to ContextPropagationAll
-	ContextPropagationEnabled bool `yaml:"enable_context_propagation" env:"OTEL_EBPF_BPF_ENABLE_CONTEXT_PROPAGATION"`
+	ContextPropagationEnabled bool `yaml:"enable_context_propagation" env:"OTEL_EBPF_BPF_ENABLE_CONTEXT_PROPAGATION" validate:"boolean"`
 
 	// Enables distributed context propagation.
-	ContextPropagation ContextPropagationMode `yaml:"context_propagation" env:"OTEL_EBPF_BPF_CONTEXT_PROPAGATION"`
+	ContextPropagation ContextPropagationMode `yaml:"context_propagation" env:"OTEL_EBPF_BPF_CONTEXT_PROPAGATION" validate:"oneof=0 1 2 3"`
 
 	// Skips checking the kernel version for bpf_loop functionality. Some modified kernels have this
 	// backported prior to version 5.17.
-	OverrideBPFLoopEnabled bool `yaml:"override_bpfloop_enabled" env:"OTEL_EBPF_OVERRIDE_BPF_LOOP_ENABLED"`
+	OverrideBPFLoopEnabled bool `yaml:"override_bpfloop_enabled" env:"OTEL_EBPF_OVERRIDE_BPF_LOOP_ENABLED" validate:"boolean"`
 
 	// Select the TC attachment backend: accepted values are 'tc' (netlink),
 	// and 'tcx'
-	TCBackend TCBackend `yaml:"traffic_control_backend" env:"OTEL_EBPF_BPF_TC_BACKEND"`
+	TCBackend TCBackend `yaml:"traffic_control_backend" env:"OTEL_EBPF_BPF_TC_BACKEND" validate:"oneof=1 2 3"`
 
-	// Disables Beyla black-box context propagation. Used for testing purposes only.
-	DisableBlackBoxCP bool `yaml:"disable_black_box_cp" env:"OTEL_EBPF_BPF_DISABLE_BLACK_BOX_CP"`
+	// Disables OBI black-box context propagation. Used for testing purposes only.
+	DisableBlackBoxCP bool `yaml:"disable_black_box_cp" env:"OTEL_EBPF_BPF_DISABLE_BLACK_BOX_CP" validate:"boolean"`
 
 	// Optimizes for getting requests information immediately when request response is seen
-	HighRequestVolume bool `yaml:"high_request_volume" env:"OTEL_EBPF_BPF_HIGH_REQUEST_VOLUME"`
+	HighRequestVolume bool `yaml:"high_request_volume" env:"OTEL_EBPF_BPF_HIGH_REQUEST_VOLUME" validate:"boolean"`
 
 	// Enables the heuristic based detection of SQL requests. This can be used to detect
-	// talking to databases other than the ones we recognize in Beyla, like Postgres and MySQL
-	HeuristicSQLDetect bool `yaml:"heuristic_sql_detect" env:"OTEL_EBPF_HEURISTIC_SQL_DETECT"`
+	// talking to databases other than the ones we recognize in OBI, like Postgres and MySQL
+	HeuristicSQLDetect bool `yaml:"heuristic_sql_detect" env:"OTEL_EBPF_HEURISTIC_SQL_DETECT" validate:"boolean"`
 
 	// Enables GPU instrumentation for CUDA kernel launches and allocations
-	InstrumentGPU bool `yaml:"instrument_gpu" env:"OTEL_EBPF_INSTRUMENT_GPU"`
+	InstrumentGPU bool `yaml:"instrument_gpu" env:"OTEL_EBPF_INSTRUMENT_GPU" validate:"boolean"`
 
 	// Enables debug printing of the protocol data
-	ProtocolDebug bool `yaml:"protocol_debug_print" env:"OTEL_EBPF_PROTOCOL_DEBUG_PRINT"`
+	ProtocolDebug bool `yaml:"protocol_debug_print" env:"OTEL_EBPF_PROTOCOL_DEBUG_PRINT" validate:"boolean"`
 
 	// Enables Java instrumentation with the OpenTelemetry JDK Agent
-	UseOTelSDKForJava bool `yaml:"use_otel_sdk_for_java" env:"OTEL_EBPF_USE_OTEL_SDK_FOR_JAVA"`
+	UseOTelSDKForJava bool `yaml:"use_otel_sdk_for_java" env:"OTEL_EBPF_USE_OTEL_SDK_FOR_JAVA" validate:"boolean"`
 
 	RedisDBCache RedisDBCacheConfig `yaml:"redis_db_cache"`
 
@@ -95,16 +93,16 @@ type EBPFTracer struct {
 	BufferSizes EBPFBufferSizes `yaml:"buffer_sizes"`
 
 	// MySQL prepared statements cache size.
-	MySQLPreparedStatementsCacheSize int `yaml:"mysql_prepared_statements_cache_size" env:"OTEL_EBPF_BPF_MYSQL_PREPARED_STATEMENTS_CACHE_SIZE"`
+	MySQLPreparedStatementsCacheSize int `yaml:"mysql_prepared_statements_cache_size" env:"OTEL_EBPF_BPF_MYSQL_PREPARED_STATEMENTS_CACHE_SIZE" validate:"gt=0"`
 
 	// Postgres prepared statements cache size.
-	PostgresPreparedStatementsCacheSize int `yaml:"postgres_prepared_statements_cache_size" env:"OTEL_EBPF_BPF_POSTGRES_PREPARED_STATEMENTS_CACHE_SIZE"`
+	PostgresPreparedStatementsCacheSize int `yaml:"postgres_prepared_statements_cache_size" env:"OTEL_EBPF_BPF_POSTGRES_PREPARED_STATEMENTS_CACHE_SIZE" validate:"gt=0"`
 
 	// Kafka Topic UUID to Name cache size.
-	KafkaTopicUUIDCacheSize int `yaml:"kafka_topic_uuid_cache_size" env:"OTEL_KAFKA_TOPIC_UUID_CACHE_SIZE"`
+	KafkaTopicUUIDCacheSize int `yaml:"kafka_topic_uuid_cache_size" env:"OTEL_KAFKA_TOPIC_UUID_CACHE_SIZE" validate:"gt=0"`
 
 	// MongoDB requests cache size.
-	MongoRequestsCacheSize int `yaml:"mongo_requests_cache_size" env:"OTEL_EBPF_BPF_MONGO_REQUESTS_CACHE_SIZE"`
+	MongoRequestsCacheSize int `yaml:"mongo_requests_cache_size" env:"OTEL_EBPF_BPF_MONGO_REQUESTS_CACHE_SIZE" validate:"gt=0"`
 
 	// Configure data extraction/parsing based on protocol
 	PayloadExtraction PayloadExtraction `yaml:"payload_extraction"`
@@ -114,37 +112,21 @@ type EBPFTracer struct {
 // Max: 8192 bytes.
 // Default: 0 (disabled).
 type EBPFBufferSizes struct {
-	HTTP     uint32 `yaml:"http" env:"OTEL_EBPF_BPF_BUFFER_SIZE_HTTP"`
-	MySQL    uint32 `yaml:"mysql" env:"OTEL_EBPF_BPF_BUFFER_SIZE_MYSQL"`
-	Postgres uint32 `yaml:"postgres" env:"OTEL_EBPF_BPF_BUFFER_SIZE_POSTGRES"`
+	HTTP     uint32 `yaml:"http" env:"OTEL_EBPF_BPF_BUFFER_SIZE_HTTP" validate:"lte=8192"`
+	MySQL    uint32 `yaml:"mysql" env:"OTEL_EBPF_BPF_BUFFER_SIZE_MYSQL" validate:"lte=8192"`
+	Postgres uint32 `yaml:"postgres" env:"OTEL_EBPF_BPF_BUFFER_SIZE_POSTGRES" validate:"lte=8192"`
 }
 
 func (c *EBPFTracer) Validate() error {
-	// WakeupLen is used to calculate the wakeup_data_bytes for the ringbuf
-	if c.WakeupLen < 0 {
-		return errors.New("ebpf.wakeup_len in the YAML configuration file or OTEL_EBPF_BPF_WAKEUP_LEN must be at least 1")
-	}
-	if c.BatchLength < 1 {
-		return errors.New("ebpf.batch_length in the YAML configuration file or OTEL_EBPF_BPF_BATCH_LENGTH must be at least 1")
-	}
-
-	if c.BatchTimeout <= 0 {
-		return errors.New("ebpf.batch_timeout in the YAML configuration file or OTEL_EBPF_BPF_BATCH_TIMEOUT must be greater than 0")
-	}
-
-	if c.HTTPRequestTimeout < 0 {
-		return errors.New("ebpf.http_request_timeout in the YAML configuration file or OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT must be greater than or equal to 0")
-	}
-
-	if !c.TCBackend.Valid() {
-		return errors.New("invalid ebpf.traffic_control_backend in the YAML configuration file or OTEL_EBPF_BPF_TC_BACKEND value, must be 'tc' or 'tcx' or 'auto'")
-	}
-
-	// remove after deleting ContextPropagationEnabled
+	// TODO remove after deleting ContextPropagationEnabled
 	if c.ContextPropagationEnabled && c.ContextPropagation != ContextPropagationDisabled {
 		return errors.New("ebpf.enable_context_propagation and ebpf.context_propagation in the YAML configuration file or OTEL_EBPF_BPF_ENABLE_CONTEXT_PROPAGATION and OTEL_EBPF_BPF_CONTEXT_PROPAGATION are mutually exclusive")
 	}
 
+	return nil
+}
+
+func (c *EBPFTracer) IsContextPropagationEnabled() {
 	// TODO deprecated (REMOVE)
 	// remove after deleting ContextPropagationEnabled
 	if c.ContextPropagationEnabled {
@@ -152,32 +134,6 @@ func (c *EBPFTracer) Validate() error {
 			"deprecated and will be removed in the future - use 'ebpf.context_propagation' instead")
 		c.ContextPropagation = ContextPropagationAll
 	}
-
-	if err := c.RedisDBCache.Validate(); err != nil {
-		return err
-	}
-
-	if err := c.BufferSizes.Validate(); err != nil {
-		return err
-	}
-
-	if c.MySQLPreparedStatementsCacheSize <= 0 {
-		return errors.New("ebpf.mysql_prepared_statements_cache_size in the YAML configuration file or OTEL_EBPF_BPF_MYSQL_PREPARED_STATEMENTS_CACHE_SIZE must be greater than 0")
-	}
-
-	if c.PostgresPreparedStatementsCacheSize <= 0 {
-		return errors.New("ebpf.postgres_prepared_statements_cache_size in the YAML configuration file or OTEL_EBPF_BPF_POSTGRES_PREPARED_STATEMENTS_CACHE_SIZE must be greater than 0")
-	}
-
-	if c.KafkaTopicUUIDCacheSize <= 0 {
-		return errors.New("ebpf.kafka_topic_uuid_cache_size in the YAML configuration file or OTEL_KAFKA_TOPIC_UUID_CACHE_SIZE must be greater than 0")
-	}
-
-	if c.MongoRequestsCacheSize <= 0 {
-		return errors.New("ebpf.mongo_requests_cache_size in the YAML configuration file or OTEL_EBPF_BPF_MONGO_REQUESTS_CACHE_SIZE must be greater than 0")
-	}
-
-	return nil
 }
 
 func (m *ContextPropagationMode) UnmarshalText(text []byte) error {
@@ -212,24 +168,4 @@ func (m ContextPropagationMode) MarshalText() ([]byte, error) {
 	}
 
 	return nil, fmt.Errorf("invalid context propagation mode: %d", m)
-}
-
-func (r RedisDBCacheConfig) Validate() error {
-	if r.MaxSize <= 0 {
-		return errors.New("ebpf.redis_db_cache.max_size in the YAML configuration file or OTEL_EBPF_BPF_REDIS_DB_CACHE_MAX_SIZE must be greater than 0")
-	}
-	return nil
-}
-
-func (b EBPFBufferSizes) Validate() error {
-	if b.HTTP > bufferSizeMax {
-		return fmt.Errorf("ebpf.buffer_sizes.http in YAML configuration file or OTEL_EBPF_BPF_BUFFER_SIZE_HTTP too large: %d, max is %d", b.HTTP, bufferSizeMax)
-	}
-	if b.MySQL > bufferSizeMax {
-		return fmt.Errorf("ebpf.buffer_sizes.mysql in YAML configuration file or OTEL_EBPF_BPF_BUFFER_SIZE_MYSQL too large: %d, max is %d", b.MySQL, bufferSizeMax)
-	}
-	if b.Postgres > bufferSizeMax {
-		return fmt.Errorf("ebpf.buffer_sizes.postgres in YAML configuration file or OTEL_EBPF_BPF_BUFFER_SIZE_POSTGRES too large: %d, max is %d", b.Postgres, bufferSizeMax)
-	}
-	return nil
 }

--- a/pkg/config/payload_extraction.go
+++ b/pkg/config/payload_extraction.go
@@ -14,5 +14,5 @@ type HTTPConfig struct {
 
 type GraphQLConfig struct {
 	// Enable GraphQL payload extraction and parsing
-	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_HTTP_GRAPHQL_ENABLED"`
+	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_HTTP_GRAPHQL_ENABLED"  validate:"boolean"`
 }

--- a/pkg/internal/netolly/flow/reverse_dns.go
+++ b/pkg/internal/netolly/flow/reverse_dns.go
@@ -36,18 +36,18 @@ var netLookupAddr = net.LookupAddr
 // from the documentation. This means that it does not impact in the overall Beyla performance.
 type ReverseDNS struct {
 	// Type of ReverseDNS. Values are "none" (default), "local" and "ebpf"
-	Type string `yaml:"type" env:"OTEL_EBPF_NETWORK_REVERSE_DNS_TYPE"`
+	Type string `yaml:"type" env:"OTEL_EBPF_NETWORK_REVERSE_DNS_TYPE" validate:"oneof=none local ebpf"`
 
 	// CacheLen only applies to the "local" and "ebpf" ReverseDNS type. It
 	// specifies the max size of the LRU cache that is checked before
 	// performing the name lookup. Default: 256
-	CacheLen int `yaml:"cache_len" env:"OTEL_EBPF_NETWORK_REVERSE_DNS_CACHE_LEN"`
+	CacheLen int `yaml:"cache_len" env:"OTEL_EBPF_NETWORK_REVERSE_DNS_CACHE_LEN" validate:"gte=0"`
 
 	// CacheTTL only applies to the "local" and "ebpf" ReverseDNS type. It
 	// specifies the time-to-live of a cached IP->hostname entry. After the
 	// cached entry becomes older than this time, the IP->hostname entry will be looked
 	// up again.
-	CacheTTL time.Duration `yaml:"cache_expiry" env:"OTEL_EBPF_NETWORK_REVERSE_DNS_CACHE_TTL"`
+	CacheTTL time.Duration `yaml:"cache_expiry" env:"OTEL_EBPF_NETWORK_REVERSE_DNS_CACHE_TTL" validate:"gte=0"`
 }
 
 func (r ReverseDNS) Enabled() bool {

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v9"
+	"github.com/go-playground/validator/v10"
 	"gopkg.in/yaml.v3"
 
 	"go.opentelemetry.io/obi/pkg/components/imetrics"
@@ -29,9 +30,16 @@ import (
 	"go.opentelemetry.io/obi/pkg/transform"
 )
 
+// CustomValidations is a map of tag:function for custom validations
+type CustomValidations map[string]validator.Func
+
+const (
+	validationTagAgentIPIface = "agentIPIface"
+)
+
 const ReporterLRUSize = 256
 
-// Features that can be enabled in Beyla (can be at the same time): App O11y and/or Net O11y
+// Features that can be enabled in OBI (can be at the same time): App O11y and/or Net O11y
 type Feature uint
 
 const (
@@ -240,7 +248,7 @@ type Config struct {
 	ShutdownTimeout time.Duration `yaml:"shutdown_timeout" env:"OTEL_EBPF_SHUTDOWN_TIMEOUT"`
 
 	// Check for required system capabilities and bail if they are not
-	// present. If set to 'false', Beyla will still print a list of missing
+	// present. If set to 'false', OBI will still print a list of missing
 	// capabilities, but the execution will continue
 	EnforceSysCaps bool `yaml:"enforce_sys_caps" env:"OTEL_EBPF_ENFORCE_SYS_CAPS"`
 
@@ -287,7 +295,7 @@ type Attributes struct {
 }
 
 type HostIDConfig struct {
-	// Override allows overriding the reported host.id in Beyla
+	// Override allows overriding the reported host.id in OBI
 	Override string `yaml:"override" env:"OTEL_EBPF_HOST_ID"`
 	// FetchTimeout specifies the timeout for trying to fetch the HostID from diverse Cloud Providers
 	FetchTimeout time.Duration `yaml:"fetch_timeout" env:"OTEL_EBPF_HOST_ID_FETCH_TIMEOUT"`
@@ -307,6 +315,21 @@ func (e ConfigError) Error() string {
 //
 //nolint:cyclop
 func (c *Config) Validate() error {
+	validate := validator.New(validator.WithRequiredStructEnabled())
+
+	// for future custom validations
+	customValidations := CustomValidations{
+		validationTagAgentIPIface: ValidateAgentIPIface,
+	}
+
+	if err := registerCustomValidations(validate, customValidations); err != nil {
+		return ConfigError("error registering custom validations: " + err.Error())
+	}
+
+	if err := validate.Struct(c); err != nil {
+		return ConfigError(err.Error())
+	}
+
 	if err := c.Discovery.Validate(); err != nil {
 		return ConfigError(err.Error())
 	}
@@ -366,9 +389,8 @@ func (c *Config) Validate() error {
 		return ConfigError("you can't enable OTEL internal metrics without enabling OTEL metrics")
 	}
 
-	if err := c.EBPF.Validate(); err != nil {
-		return ConfigError(err.Error())
-	}
+	// TODO deprecated (REMOVE)
+	c.EBPF.IsContextPropagationEnabled()
 
 	return nil
 }
@@ -389,7 +411,7 @@ func (c *Config) willUseTC() bool {
 		(c.Enabled(FeatureNetO11y) && c.NetworkFlows.Source == EbpfSourceTC)
 }
 
-// Enabled checks if a given Beyla feature is enabled according to the global configuration
+// Enabled checks if a given OBI feature is enabled according to the global configuration
 func (c *Config) Enabled(feature Feature) bool {
 	switch feature {
 	case FeatureNetO11y:
@@ -409,7 +431,7 @@ func (c *Config) SpanMetricsEnabledForTraces() bool {
 }
 
 // ExternalLogger sets the logging capabilities of OBI.
-// Used for integrating Beyla with an external logging system (for example Alloy)
+// Used for integrating OBI with an external logging system (for example Alloy)
 // TODO: maybe this method has too many responsibilities, as it affects the global logger.
 func (c *Config) ExternalLogger(handler slog.Handler, debugMode bool) {
 	slog.SetDefault(slog.New(handler))
@@ -445,4 +467,13 @@ func LoadConfig(file io.Reader) (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+func registerCustomValidations(validate *validator.Validate, customValidations CustomValidations) error {
+	for k, v := range customValidations {
+		if err := validate.RegisterValidation(k, v); err != nil {
+			return fmt.Errorf("cannot add validation with the given tag %q: %w", k, err)
+		}
+	}
+	return nil
 }

--- a/pkg/obi/network_cfg.go
+++ b/pkg/obi/network_cfg.go
@@ -22,7 +22,10 @@
 package obi
 
 import (
+	"strings"
 	"time"
+
+	"github.com/go-playground/validator/v10"
 
 	"go.opentelemetry.io/obi/pkg/internal/netolly/flow"
 	"go.opentelemetry.io/obi/pkg/netolly/cidr"
@@ -30,82 +33,86 @@ import (
 )
 
 const (
-	EbpfSourceTC   = "tc"
-	EbpfSourceSock = "socket_filter"
+	EbpfSourceTC                 = "tc"
+	EbpfSourceSock               = "socket_filter"
+	NetworkListenInterfacesWatch = "watch"
+	NetworkListenInterfacesPoll  = "poll"
+	NetworkAgentIPIfaceExternal  = "external"
+	NetworkAgentIPIfaceLocal     = "local"
 )
 
 type NetworkConfig struct {
 	// Enable network metrics.
 	// Default value is false (disabled)
 	// Deprecated: add "network" to OTEL_EBPF_METRIC_FEATURES or OTEL_EBPF_PROMETHEUS_FEATURES
-	// TODO Beyla 3.0: remove
-	Enable bool `yaml:"enable" env:"OTEL_EBPF_NETWORK_METRICS"`
+	// TODO OBI 3.0: remove
+	Enable bool `yaml:"enable" env:"OTEL_EBPF_NETWORK_METRICS" validate:"boolean"`
 
 	// Specify the source type for network events, e.g tc or socket_filter. The tc implementation
 	// cannot be used when there are other tc eBPF probes, e.g. Cilium CNI.
-	Source string `yaml:"source" env:"OTEL_EBPF_NETWORK_SOURCE"`
+	Source string `yaml:"source" env:"OTEL_EBPF_NETWORK_SOURCE"  validate:"oneof=tc socket_filter"`
 
 	// AgentIP allows overriding the reported Agent IP address on each flow.
-	AgentIP string `yaml:"agent_ip" env:"OTEL_EBPF_NETWORK_AGENT_IP"`
+	AgentIP string `yaml:"agent_ip" env:"OTEL_EBPF_NETWORK_AGENT_IP" validate:"omitempty,ip"`
 
 	// AgentIPIface specifies which interface should the agent pick the IP address from in order to
 	// report it in the AgentIP field on each flow. Accepted values are: external (default), local,
 	// or name:<interface name> (e.g. name:eth0).
 	// If the AgentIP configuration property is set, this property has no effect.
-	AgentIPIface string `yaml:"agent_ip_iface" env:"OTEL_EBPF_NETWORK_AGENT_IP_IFACE"`
+	AgentIPIface string `yaml:"agent_ip_iface" env:"OTEL_EBPF_NETWORK_AGENT_IP_IFACE" validate:"agentIPIface"`
 	// AgentIPType specifies which type of IP address (IPv4 or IPv6 or any) should the agent report
 	// in the AgentID field of each flow. Accepted values are: any (default), ipv4, ipv6.
 	// If the AgentIP configuration property is set, this property has no effect.
-	AgentIPType string `yaml:"agent_ip_type" env:"OTEL_EBPF_NETWORK_AGENT_IP_TYPE"`
+	AgentIPType string `yaml:"agent_ip_type" env:"OTEL_EBPF_NETWORK_AGENT_IP_TYPE" validate:"omitempty,oneof=any ipv4 ipv6"`
 	// Interfaces contains the interface names from where flows will be collected. If empty, the agent
 	// will fetch all the interfaces in the system, excepting the ones listed in ExcludeInterfaces.
 	// If an entry is enclosed by slashes (e.g. `/br-/`), it will match as regular expression,
 	// otherwise it will be matched as a case-sensitive string.
-	Interfaces []string `yaml:"interfaces" env:"OTEL_EBPF_NETWORK_INTERFACES" envSeparator:","`
+	Interfaces []string `yaml:"interfaces" env:"OTEL_EBPF_NETWORK_INTERFACES" envSeparator:"," validate:"-"`
 	// ExcludeInterfaces contains the interface names that will be excluded from flow tracing. Default:
 	// "lo" (loopback).
 	// If an entry is enclosed by slashes (e.g. `/br-/`), it will match as regular expression,
 	// otherwise it will be matched as a case-sensitive string.
-	ExcludeInterfaces []string `yaml:"exclude_interfaces" env:"OTEL_EBPF_NETWORK_EXCLUDE_INTERFACES" envSeparator:","`
-	// Protocols causes Beyla to drop flows whose transport protocol is not in this list.
-	Protocols []string `yaml:"protocols" env:"OTEL_EBPF_NETWORK_PROTOCOLS" envSeparator:","`
-	// ExcludeProtocols causes Beyla to drop flows whose transport protocol is in this list.
+	ExcludeInterfaces []string `yaml:"exclude_interfaces" env:"OTEL_EBPF_NETWORK_EXCLUDE_INTERFACES" envSeparator:"," validate:"-"`
+	// Protocols causes OBI to drop flows whose transport protocol is not in this list.
+	Protocols []string `yaml:"protocols" env:"OTEL_EBPF_NETWORK_PROTOCOLS" envSeparator:"," validate:"-"`
+	// ExcludeProtocols causes OBI to drop flows whose transport protocol is in this list.
 	// If the Protocols list is already defined, ExcludeProtocols has no effect.
-	ExcludeProtocols []string `yaml:"exclude_protocols" env:"OTEL_EBPF_NETWORK_EXCLUDE_PROTOCOLS" envSeparator:","`
+	ExcludeProtocols []string `yaml:"exclude_protocols" env:"OTEL_EBPF_NETWORK_EXCLUDE_PROTOCOLS" envSeparator:"," validate:"-"`
 	// CacheMaxFlows specifies how many flows can be accumulated in the accounting cache before
 	// being flushed for its later export. Default value is 5000.
-	// Decrease it if you see the "received message larger than max" error in Beyla logs.
-	CacheMaxFlows int `yaml:"cache_max_flows" env:"OTEL_EBPF_NETWORK_CACHE_MAX_FLOWS"`
+	// Decrease it if you see the "received message larger than max" error in OBI logs.
+	CacheMaxFlows int `yaml:"cache_max_flows" env:"OTEL_EBPF_NETWORK_CACHE_MAX_FLOWS" validate:"gte=0"`
 	// CacheActiveTimeout specifies the maximum duration that flows are kept in the accounting
 	// cache before being flushed for its later export.
-	CacheActiveTimeout time.Duration `yaml:"cache_active_timeout" env:"OTEL_EBPF_NETWORK_CACHE_ACTIVE_TIMEOUT"`
+	CacheActiveTimeout time.Duration `yaml:"cache_active_timeout" env:"OTEL_EBPF_NETWORK_CACHE_ACTIVE_TIMEOUT" validate:"gte=0"`
 	// Deduper specifies the deduper type. Accepted values are "none" (disabled) and "first_come".
 	// When enabled, it will detect duplicate flows (flows that have been detected e.g. through
 	// both the physical and a virtual interface).
 	// "first_come" will forward only flows from the first interface the flows are received from.
 	// Default value: first_come
-	Deduper string `yaml:"deduper" env:"OTEL_EBPF_NETWORK_DEDUPER"`
+	Deduper string `yaml:"deduper" env:"OTEL_EBPF_NETWORK_DEDUPER" validate:"oneof=none first_come"`
 	// DeduperFCTTL specifies the expiry duration of the flows "first_come" deduplicator. After
 	// a flow hasn't been received for that expiry time, the deduplicator forgets it. That means
 	// that a flow from a connection that has been inactive during that period could be forwarded
 	// again from a different interface.
 	// If the value is not set, it will default to 2 * CacheActiveTimeout
-	DeduperFCTTL time.Duration `yaml:"deduper_fc_ttl" env:"OTEL_EBPF_NETWORK_DEDUPER_FC_TTL"`
+	DeduperFCTTL time.Duration `yaml:"deduper_fc_ttl" env:"OTEL_EBPF_NETWORK_DEDUPER_FC_TTL" validate:"omitempty,gt=0"`
 	// Direction allows selecting which flows to trace according to its direction. Accepted values
 	// are "ingress", "egress" or "both" (default).
-	Direction string `yaml:"direction" env:"OTEL_EBPF_NETWORK_DIRECTION"`
+	Direction string `yaml:"direction" env:"OTEL_EBPF_NETWORK_DIRECTION" validate:"oneof=ingress egress both"`
 	// Sampling holds the rate at which packets should be sampled and sent to the target collector.
 	// E.g. if set to 100, one out of 100 packets, on average, will be sent to the target collector.
-	Sampling int `yaml:"sampling" env:"OTEL_EBPF_NETWORK_SAMPLING"`
+	Sampling int `yaml:"sampling" env:"OTEL_EBPF_NETWORK_SAMPLING" validate:"omitempty,gt=0"`
 	// ListenInterfaces specifies the mechanism used by the agent to listen for added or removed
 	// network interfaces. Accepted values are "watch" (default) or "poll".
 	// If the value is "watch", interfaces are traced immediately after they are created. This is
 	// the recommended setting for most configurations. "poll" value is a fallback mechanism that
 	// periodically queries the current network interfaces (frequency specified by ListenPollPeriod).
-	ListenInterfaces string `yaml:"listen_interfaces" env:"OTEL_EBPF_NETWORK_LISTEN_INTERFACES"`
+	ListenInterfaces string `yaml:"listen_interfaces" env:"OTEL_EBPF_NETWORK_LISTEN_INTERFACES" validate:"oneof=watch poll"`
 	// ListenPollPeriod specifies the periodicity to query the network interfaces when the
 	// ListenInterfaces value is set to "poll".
-	ListenPollPeriod time.Duration `yaml:"listen_poll_period" env:"OTEL_EBPF_NETWORK_LISTEN_POLL_PERIOD"`
+	ListenPollPeriod time.Duration `yaml:"listen_poll_period" env:"OTEL_EBPF_NETWORK_LISTEN_POLL_PERIOD" validate:"gte=0"`
 
 	// ReverseDNS allows flows that haven't been previously decorated with any source/destination name
 	// to override the name with the network hostname of the source and destination IPs.
@@ -113,7 +120,7 @@ type NetworkConfig struct {
 	// for external traffic.
 	ReverseDNS flow.ReverseDNS `yaml:"reverse_dns"`
 	// Print the network flows in the Standard Output, if true
-	Print bool `yaml:"print_flows" env:"OTEL_EBPF_NETWORK_PRINT_FLOWS"`
+	Print bool `yaml:"print_flows" env:"OTEL_EBPF_NETWORK_PRINT_FLOWS" validate:"boolean"`
 
 	// CIDRs list, to be set as the "src.cidr" and "dst.cidr"
 	// attribute as a function of the source and destination IP addresses.
@@ -121,7 +128,7 @@ type NetworkConfig struct {
 	// If an IP matches multiple CIDR definitions, the flow will be decorated with the
 	// narrowest CIDR. By this reason, you can safely add a 0.0.0.0/0 entry to group there
 	// all the traffic that does not match any of the other CIDRs.
-	CIDRs cidr.Definitions `yaml:"cidrs" env:"OTEL_EBPF_NETWORK_CIDRS" envSeparator:","`
+	CIDRs cidr.Definitions `yaml:"cidrs" env:"OTEL_EBPF_NETWORK_CIDRS" envSeparator:"," validate:"omitempty,dive,cidr"`
 }
 
 var DefaultNetworkConfig = NetworkConfig{
@@ -140,4 +147,12 @@ var DefaultNetworkConfig = NetworkConfig{
 		CacheLen: 256,
 		CacheTTL: time.Hour,
 	},
+}
+
+// ValidateAgentIPIface checks if the string starts with "name:"
+// and then checks if there is something after "name:"
+func ValidateAgentIPIface(fl validator.FieldLevel) bool {
+	return fl.Field().String() == NetworkAgentIPIfaceLocal ||
+		fl.Field().String() == NetworkAgentIPIfaceExternal ||
+		strings.HasPrefix(fl.Field().String(), "name:") && len(strings.TrimPrefix(fl.Field().String(), "name:")) > 0
 }


### PR DESCRIPTION
Hi everyone.

This PR is the first one in introducing a more standardized configuration validation using the go-playground/validator pkg which is a consistent and declarative way to validate structs using tags so it's easier to read, extend and test it.

Instead of creating a single large PR, I broke it down into smaller parts to gather feedback from the community and evaluate if it makes sense to continue. 

In this first part, I've implemented the validation for the `EBPFTracer` and `NetworkConfig` structs.

I have some doubts about some reference values ​​used in some validations.
Finally, I had to change a bit the default configuration taking into account the new validation constraints.

Thanks, 
Pino
