### PR TITLE
ci: avoid filling /tmp

### DIFF
--- a/.github/workflows/update-offsets.yml
+++ b/.github/workflows/update-offsets.yml
@@ -1,5 +1,9 @@
 name: Update offsets
 on:
+  push:
+    branches: ["main", "release-*"]
+  pull_request:
+    branches: ["main", "release-*"]
   schedule:
     - cron: '1 1 * * *'
   workflow_dispatch:


### PR DESCRIPTION
The offset update workflow is [failing](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/18639427423/job/53135476428), looks like `/tmp` is full:

```
2025/10/20 01:47:44 go build returned standard error:
# internal/reflectlite
compile: writing output: write $WORK/b004/_pkg_.a: no space left on device
internal/godebug: mkdir /tmp/go-build1084724249/b065/: no space left on device
# runtime/cgo
_cgo_export.c:13:1: fatal error: error closing ../cct5kKfB.s: No space left on device
   13 | extern char* _cgo_topofstack(void);
      | ^~~~~~
compilation terminated.
2025/10/20 01:47:44 ERROR: loading Go standard library offsets: exit status 1
make: *** [Makefile:160: update-offsets] Error 1
Error: Process completed with exit code 2.
```