### PR TITLE
Fix grpc export options

### DIFF
--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -256,6 +256,7 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		}
 		if cfg.BatchTimeout > 0 {
 			batchCfg.FlushTimeout = cfg.BatchTimeout
+			batchCfg.MinSize = int64(cfg.MaxQueueSize)
 		}
 		queueConfig.Batch = configoptional.Some(batchCfg)
 		config.QueueConfig = queueConfig


### PR DESCRIPTION
This is a follow-up to https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/692. I missed this the time I made the fix to the HTTP export side.