### PR TITLE
Add the skip flag to the resource attributes too

### DIFF
--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -119,6 +119,9 @@ func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Tra
 			}
 
 			envResourceAttrs := otelcfg.ResourceAttrsFromEnv(&sample.Span.Service)
+			if tr.spanMetricsEnabled {
+				envResourceAttrs = append(envResourceAttrs, attribute.Bool(string(attr.SkipSpanMetrics.OTEL()), true))
+			}
 			traces := tracesgen.GenerateTracesWithAttributes(tr.attributeCache, &sample.Span.Service, envResourceAttrs, tr.ctxInfo.HostID, spanGroup, reporterName, tr.ctxInfo.ExtraResourceAttributes...)
 			err := exp.ConsumeTraces(ctx, traces)
 			if err != nil {


### PR DESCRIPTION
When we export span metrics directly from OBI, but the user has also enabled OBI traces export, we add a span attribute `span.metrics.skip` to allow for collector configurations to avoid double generating span metrics from the OBI traces. Some customers seem to prefer to check the attribute on the span resource attributes, so this change also adds the flag on the resource attributes for the service.