### PR TITLE
Add nil check for the kubernetes event

### DIFF
--- a/pkg/components/kube/store.go
+++ b/pkg/components/kube/store.go
@@ -206,6 +206,10 @@ func (s *Store) cacheResourceMetadata(meta *informer.ObjectMeta) *CachedObjMeta 
 // On is invoked by the informer when a new Kube object is created, updated or deleted.
 // It will forward the notification to all the Store subscribers
 func (s *Store) On(event *informer.Event) error {
+	if event == nil {
+		return nil
+	}
+
 	defer s.Notify(event)
 
 	if event.Type == informer.EventType_SYNC_FINISHED {


### PR DESCRIPTION
In certain scenarios (kubernetes API under heavy load), it seems that it's possible for us to receive a nil event for the store On() function. This PR adds a check to ensure we don't crash OBI but ignore the bad event.