### PR TITLE
Fix missing bound check for postgres bind parse

### DIFF
--- a/pkg/ebpf/common/sql_detect_postgres.go
+++ b/pkg/ebpf/common/sql_detect_postgres.go
@@ -115,6 +115,10 @@ func parsePostgresBindCommand(buf []byte) (string, string, []string, error) {
 		ptr += 2
 	}
 
+	if ptr+2 >= size {
+		return string(statement), string(portal), args, errors.New("too short, while parsing format codes")
+	}
+
 	params := int16(binary.BigEndian.Uint16(buf[ptr : ptr+2]))
 	ptr += 2
 	for i := 0; i < int(params); i++ {


### PR DESCRIPTION
One edge case where we didn't check if we can go beyond the bounds. Seen only once in the field.