### PR TITLE
Adds a bounds check before reading the params count

### DIFF
--- a/pkg/ebpf/common/sql_detect_postgres.go
+++ b/pkg/ebpf/common/sql_detect_postgres.go
@@ -115,6 +115,10 @@ func parsePostgresBindCommand(buf []byte) (string, string, []string, error) {
 		ptr += 2
 	}
 
+	if ptr+2 >= size {
+		return string(statement), string(portal), args, errors.New("too short, while parsing params count")
+	}
+
 	params := int16(binary.BigEndian.Uint16(buf[ptr : ptr+2]))
 	ptr += 2
 	for i := 0; i < int(params); i++ {


### PR DESCRIPTION
Hi All

The fix is about Grafana Beyla bug https://github.com/grafana/beyla/issues/2271

The problem: 
After parsing the format codes and advancing ptr through the formats loop, the code immediately tries to read 2 bytes for the params count without checking if those 2 bytes are actually available in the buffer.
If ptr is at position 127 in a 128-byte buffer, the expression buf[ptr : ptr+2] tries to create a slice buf[127:129], but the buffer only has capacity 128. This causes the panic: slice bounds out of range [:129] with capacity 128.

The Fix
Lines 118-120 now ensure that before attempting to slice buf[ptr : ptr+2], there are actually at least 2 bytes remaining in the buffer. If not, it returns an error gracefully instead of panicking.

The fault as reported on Grafana Beyla version 2.0.6:
panic: runtime error: slice bounds out of range [:129] with capacity 128

goroutine 192 [running]:
github.com/grafana/beyla/v2/pkg/internal/ebpf/common.parsePostgresBindCommand({0xc00314bc38, 0x80, 0x80})
	/opt/app-root/pkg/internal/ebpf/common/sql_detect_postgres.go:100 +0x88d
github.com/grafana/beyla/v2/pkg/internal/ebpf/common.postgresPreparedStatements({0xc00314bc38?, 0x80?, 0x80?})
	/opt/app-root/pkg/internal/ebpf/common/sql_detect_postgres.go:139 +0x7c
github.com/grafana/beyla/v2/pkg/internal/ebpf/common.detectSQLPayload(0x0, {0xc00314bc38, 0x80, 0x80})
	/opt/app-root/pkg/internal/ebpf/common/sql_detect_transform.go:70 +0xc9
github.com/grafana/beyla/v2/pkg/internal/ebpf/common.ReadTCPRequestIntoSpan(_, _, {_, _})
	/opt/app-root/pkg/internal/ebpf/common/tcp_detect_transform.go:43 +0x28e
github.com/grafana/beyla/v2/pkg/internal/ebpf/common.ReadBPFTraceAsSpan(_, _, {_, _})
	/opt/app-root/pkg/internal/ebpf/common/common.go:113 +0x338
github.com/grafana/beyla/v2/pkg/internal/ebpf/common.(*ringBufForwarder).processAndForward(0xc000eb79e0, {{0xc00314b680, 0x208, 0x208}, 0x88e0}, 0xc0000be310)
	/opt/app-root/pkg/internal/ebpf/common/ringbuf.go:174 +0x16e
github.com/grafana/beyla/v2/pkg/internal/ebpf/common.(*ringBufForwarder).readAndForwardInner(0xc000eb79e0, {0x28fe940, 0xc0000becb0}, 0xc0000be310)
	/opt/app-root/pkg/internal/ebpf/common/ringbuf.go:160 +0x159
github.com/grafana/beyla/v2/pkg/internal/ebpf/common.(*ringBufForwarder).sharedReadAndForward(0xc000eb79e0, {0x2919958, 0xc003c98dc0}, {0xc0018c4008, 0x97, 0xff}, 0xc0000be310)
	/opt/app-root/pkg/internal/ebpf/common/ringbuf.go:108 +0x254
github.com/grafana/beyla/v2/pkg/internal/ebpf/generictracer.(*Tracer).Run(0xc00053a908, {0x2919958, 0xc003c98dc0}, 0xc0000be310)
	/opt/app-root/pkg/internal/ebpf/generictracer/generictracer.go:452 +0x24c
github.com/grafana/beyla/v2/pkg/internal/ebpf.(*ProcessTracer).Run.func1()
	/opt/app-root/pkg/internal/ebpf/tracer_linux.go:118 +0x34
created by github.com/grafana/beyla/v2/pkg/internal/ebpf.(*ProcessTracer).Run in goroutine 191
	/opt/app-root/pkg/internal/ebpf/tracer_linux.go:117 +0x172
	
Best Regards
Corneliu	