### PR TITLE
Use first one wins for Go header parsing

### DIFF
--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -288,9 +288,11 @@ static __always_inline void handle_traceparent_header(server_http_func_invocatio
                                                       go_addr_key_t *g_key,
                                                       unsigned char *traceparent_start) {
     if (inv) {
-        update_traceparent(inv, traceparent_start);
+        if (!valid_trace(inv->tp.trace_id)) {
+            update_traceparent(inv, traceparent_start);
+        }
     } else {
-        server_http_func_invocation_t minimal_inv = {};
+        server_http_func_invocation_t minimal_inv = {.tp = {0}};
         update_traceparent(&minimal_inv, traceparent_start);
         bpf_map_update_elem(&ongoing_http_server_requests, g_key, &minimal_inv, BPF_ANY);
     }


### PR DESCRIPTION
This is a known common problem that some frameworks propagate automatically all incoming headers and make them outgoing. The kprobes trace propagation relies on first one wins, since the sock msg program always injects the header at the beginning. The go probes however were using a last one wins approach when parsing headers and we'd end up with wrong nesting.

Here's an example of something a Java app did, which messes up what the Go downstream service does:

starting state
```
Accept: application/json
traceparent: 00-dd898e6d9c22b1cff48f8f437e761046-46eeb2f1f63cf880-01
end-user: nikola
user-agent: Mozilla/5.0 (X11; Linux x86_64; rv:144.0) Gecko/20100101 Firefox/144.0
```
this is outgoing request and notice how this isn't a Traceparent set by OBI, since we always capitalise the T. 

After the extender adds the correct traceparent, it looks like this:
```
Traceparent: 00-dd898e6d9c22b1cff48f8f437e761046-91d841ea9ff3eb0e-01
Accept: application/json
traceparent: 00-dd898e6d9c22b1cff48f8f437e761046-46eeb2f1f63cf880-01
end-user: nikola
user-agent: Mozilla/5.0 (X11; Linux x86_64; rv:144.0) Gecko/20100101 Firefox/144.0
cookie: grafana_session=25f01ab9a9acae8ad18d6ae5eaeb2096; grafana_session_expiry=1759535106; session=eyJ1c2VyIjoibmlrb2xhIn0.aPju6g.LFfQejLtk4_kc6Qnd0w3inbXmUE
Cache-Control: no-cache
```

Go did last one wins, without checking if it had already parsed a traceparent, so we ended up getting a wrong trace ID.