### PR TITLE
Add support for building OBI with Podman

### DIFF
--- a/cmd/obi-genfiles/obi_genfiles.go
+++ b/cmd/obi-genfiles/obi_genfiles.go
@@ -36,8 +36,9 @@ type config struct {
 	ContainerPrefix string `env:"OTEL_EBPF_GENFILES_CONTAINER_PREFIX" envDefault:"/__w/"`
 	HostPrefix      string `env:"OTEL_EBPF_GENFILES_HOST_PREFIX"      envDefault:"/home/runner/work/"`
 	Package         string `env:"OTEL_EBPF_GENFILES_PKG"              envDefault:"go.opentelemetry.io/obi/pkg/obi"`
-	OCIBin          string `env:"OTEL_EBPF_GENFILES_OCI_BIN"          envDefault:"docker"`
+	GenFilesOCIBin  string `env:"OTEL_EBPF_GENFILES_OCI_BIN"`
 	GenImage        string `env:"OTEL_EBPF_GENFILES_GEN_IMG"`
+	OCIBin          string `env:"OCI_BIN"                             envDefault:"docker"`
 }
 
 var cfg config
@@ -450,7 +451,7 @@ func runInContainer(wd string) {
 
 	args := make([]string, 0, 10)
 	args = append(args, "run", "--rm")
-	if strings.HasSuffix(cfg.OCIBin, "podman") {
+	if strings.HasSuffix(cfg.GenFilesOCIBin, "podman") {
 		args = append(args, "--userns=keep-id")
 	} else {
 		currentUser, err := user.Current()
@@ -463,7 +464,7 @@ func runInContainer(wd string) {
 	args = append(args, "-e", "OTEL_EBPF_GENFILES_MODIFIED_ONLY="+strconv.FormatBool(cfg.GenModifiedOnly))
 	args = append(args, cfg.GenImage)
 
-	err := executeCommand(cfg.OCIBin, args...)
+	err := executeCommand(cfg.GenFilesOCIBin, args...)
 	if err != nil {
 		bail(fmt.Errorf("error waiting for child process: %w", err))
 	}
@@ -562,6 +563,9 @@ func runLocally(wd string) {
 func main() {
 	if err := env.Parse(&cfg); err != nil {
 		bail(fmt.Errorf("error loading config: %w", err))
+	}
+	if len(cfg.GenFilesOCIBin) == 0 {
+		cfg.GenFilesOCIBin = cfg.OCIBin
 	}
 
 	wd, err := moduleRoot()


### PR DESCRIPTION
By default the OBI build uses `docker`. The build scripts allow users to switch to `podman` via environment variables:

```
OCI_BIN=podman OTEL_EBPF_GENFILES_OCI_BIN=podman make
```

It turns out that this doesn't work on an out-of-the-box Fedora system for two reasons:

* With SELinux enabled the build image cannot access the source files. This can be fixed by appending the `:z` option to the volume mount.
* The Docker `--user uid:gid` parameter doesn't work. Using `--userns=keep-id` instead fixes this.

This PR applies these changes to make the build work with `podman`.

In addition, this PR makes `OTEL_EBPF_GENFILES_OCI_BIN` default to `OCI_BIN` so that it is now sufficient to set a single environment variable:

```
OCI_BIN=podman make
```