### PR TITLE
Prevent packet extender from running more than once

### DIFF
--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -447,7 +447,7 @@ static __always_inline u8 already_tracked(const connection_info_t *conn, u64 pid
     p_conn.pid = host_pid;
 
     http_info_t *http_info = bpf_map_lookup_elem(&ongoing_http, &p_conn);
-    if (http_info) {
+    if (http_info && !(http_info->delayed || http_info->submitted)) {
         return 1;
     }
 

--- a/test/integration/traces_test.go
+++ b/test/integration/traces_test.go
@@ -888,7 +888,7 @@ func ensureTracesMatch(t *testing.T, urlPath string) {
 		// Check the information of the nodejs parent span with retry
 		test.Eventually(t, testTimeout, func(t require.TestingT) {
 			res := trace.FindByOperationName("GET /traceme", "server")
-			require.Len(t, res, 1)
+			require.Len(t, res, 1, traceID)
 			parent := res[0]
 			require.NotEmpty(t, parent.TraceID)
 			require.Equal(t, traceID, parent.TraceID)


### PR DESCRIPTION
The packet extender (for injection of Traceparent) works at a begging of a packet, looking for information setup by the Go uprobes or by detecting the start of HTTP 1.1 request.

However, there could be HTTP 1.1 payloads, or TCP payloads that have HTTP like requests inside their body. In very unlikely scenarios the inside (the body) of these packets may end up being split at a point which would look like HTTP start. In these scenarios OBI will inject a traceparent again!

This PR fixes two things:
- For Go programs we had a bug with pointer of a pointer and we weren't cleaning the information after use.
- For non-Go I added a check for already tracked connection and we avoid to double inject.