### PR TITLE
java: fix jvm attach cleanup function

### DIFF
--- a/pkg/internal/transform/route/harvest/harvester.go
+++ b/pkg/internal/transform/route/harvest/harvester.go
@@ -85,8 +85,9 @@ func (h *RouteHarvester) HarvestRoutes(fileInfo *exec.FileInfo) (*RouteHarvester
 		defer runtime.UnlockOSThread()
 		myUID, myGID, myPID := jvmAttachInitFunc()
 		defer func() {
-			err := jvmAttachCleanupFunc(myUID, myGID, myPID)
-			h.log.Error("route harvesting cleanup failed", "error", err)
+			if err := jvmAttachCleanupFunc(myUID, myGID, myPID); err != nil {
+				h.log.Error("route harvesting cleanup failed", "error", err)
+			}
 		}()
 	}
 

--- a/pkg/internal/transform/route/harvest/java_linux.go
+++ b/pkg/internal/transform/route/harvest/java_linux.go
@@ -26,10 +26,10 @@ func initAttach() (int, int, int) {
 }
 
 func cleanupAttach(myUID, myGID, myPID int) error {
-	if err := syscall.Setegid(myUID); err != nil {
+	if err := syscall.Seteuid(myUID); err != nil {
 		return err
 	}
-	if err := syscall.Seteuid(myGID); err != nil {
+	if err := syscall.Setegid(myGID); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- fix error message being printed regardless of errors
- fix cleanup function; swap setegid/seteuid

/cc @grcevski 