### PR TITLE
bpf: fix .rodata constants loading for gpuevent and tctracer

### DIFF
--- a/pkg/internal/ebpf/gpuevent/gpuevent.go
+++ b/pkg/internal/ebpf/gpuevent/gpuevent.go
@@ -122,8 +122,6 @@ func (p *Tracer) Constants() map[string]any {
 		m["filter_pids"] = int32(1)
 	}
 
-	m["max_transaction_time"] = uint64(p.cfg.EBPF.MaxTransactionTime.Nanoseconds())
-
 	return m
 }
 

--- a/pkg/internal/ebpf/tctracer/tctracer.go
+++ b/pkg/internal/ebpf/tctracer/tctracer.go
@@ -74,9 +74,7 @@ func (p *Tracer) SetupTailCalls() {
 }
 
 func (p *Tracer) Constants() map[string]any {
-	return map[string]any{
-		"max_transaction_time": uint64(p.cfg.EBPF.MaxTransactionTime.Nanoseconds()),
-	}
+	return map[string]any{}
 }
 
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets) {}


### PR DESCRIPTION
the `max_transaction_time` constant is only used by `generictracer` and `tpinjector`; `tctracer` and `gpuevent` fail to load because the constant is not defined in their source:

```
time=2025-10-28T12:20:15.761+01:00 level=DEBUG msg="loading eBPF program" component=ebpf.ProcessTracer program=*gpuevent.Tracer type=1
time=2025-10-28T12:20:15.763+01:00 level=WARN msg="couldn't load tracer" component=ebpf.ProcessTracer error="loading and assigning BPF objects: rewriting BPF constants definition: rewrite constants: some constants are missing from .rodata: max_transaction_time" required=false
time=2025-10-28T12:20:15.763+01:00 level=DEBUG msg="loading eBPF program" component=ebpf.ProcessTracer program=*tctracer.Tracer type=1
time=2025-10-28T12:20:15.764+01:00 level=WARN msg="couldn't load tracer" component=ebpf.ProcessTracer error="loading and assigning BPF objects: rewriting BPF constants definition: rewrite constants: some constants are missing from .rodata: max_transaction_time" required=false
```