### PR TITLE
test: introduce integration test package

### DIFF
--- a/pkg/test/integration/config.go
+++ b/pkg/test/integration/config.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+// TestConfig holds project-specific configuration for integration tests
+type TestConfig struct {
+	// Environment variable prefixes
+	EnvPrefix string
+
+	// Docker compose configuration
+	ComposeServiceName string
+	ComposeImageName   string
+	DockerfilePath     string
+	ConfigPath         string
+
+	// Metric naming
+	MetricPrefix string
+	IPAttribute  string
+
+	// Telemetry SDK attributes
+	SDKName    string
+	VersionPkg string
+}
+
+// DefaultOBIConfig returns the default OBI test configuration
+func DefaultOBIConfig() *TestConfig {
+	return &TestConfig{
+		EnvPrefix:          "OTEL_EBPF_",
+		ComposeServiceName: "obi",
+		ComposeImageName:   "hatest-obi",
+		DockerfilePath:     "ebpf-instrument/Dockerfile",
+		ConfigPath:         "obi-config.yml",
+		MetricPrefix:       "obi",
+		IPAttribute:        "obi.ip",
+		SDKName:            "opentelemetry-ebpf-instrumentation",
+		VersionPkg:         "obibuildinfo.Version",
+	}
+}

--- a/pkg/test/integration/constants.go
+++ b/pkg/test/integration/constants.go
@@ -1,0 +1,11 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import "time"
+
+const (
+	instrumentedServiceStdURL = "http://localhost:8080"
+	testTimeout               = 60 * time.Second
+)

--- a/pkg/test/integration/doc.go
+++ b/pkg/test/integration/doc.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package integration provides reusable integration test utilities
+// for downstream projects, whilst allowing each project to maintain their own
+// project-specific configuration.
+//
+// Example usage:
+//
+//	config := &integration.TestConfig{
+//	    EnvPrefix:          "MY_PROJECT_",
+//	    ComposeServiceName: "my-service",
+//	    MetricPrefix:       "myproject",
+//	    // ... other project-specific settings
+//	}
+//	integration.InternalPrometheusExport(t, config)
+//
+// For OBI, use the provided DefaultOBIConfig() function.
+package integration

--- a/pkg/test/integration/internals.go
+++ b/pkg/test/integration/internals.go
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build integration
-
 package integration
 
 import (
@@ -18,16 +16,21 @@ import (
 )
 
 const (
-	flushesMetricName            = "obi_ebpf_tracer_flushes"
-	promRequestsMetricName       = "obi_prometheus_http_requests_total"
+	flushesMetricName            = "_ebpf_tracer_flushes"
+	promRequestsMetricName       = "_prometheus_http_requests_total"
 	internalPrometheusMetricsURL = "http://localhost:8999/internal/metrics"
 )
 
-func testInternalPrometheusExport(t *testing.T) {
+// InternalPrometheusExport tests that internal metrics are properly exposed and updated
+func InternalPrometheusExport(t *testing.T, config *TestConfig) {
+	// Use config-specific metric names
+	flushesMetricName := config.MetricPrefix + flushesMetricName
+	promRequestsMetricName := config.MetricPrefix + promRequestsMetricName
+
 	// tests that internal metrics are properly exposed and updated
 	initialFlushedRecords := metricValue(t, flushesMetricName, nil)
 	for i := 0; i < 7; i++ {
-		doHTTPGet(t, instrumentedServiceStdURL+"/testing/some/flushes", http.StatusOK)
+		DoHTTPGet(t, instrumentedServiceStdURL+"/testing/some/flushes", http.StatusOK)
 	}
 	eventuallyIterations := 0
 	test.Eventually(t, testTimeout, func(t require.TestingT) {

--- a/pkg/test/integration/utils.go
+++ b/pkg/test/integration/utils.go
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"bytes"
+	"crypto/tls"
+	"net/http"
+
+	"github.com/stretchr/testify/require"
+)
+
+// HTTP client for testing
+var testHTTPClient = &http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	},
+}
+
+func DoHTTPGet(t require.TestingT, path string, status int) {
+	// Random fake body to cause the request to have some size (38 bytes)
+	jsonBody := []byte(`{"productId": 123456, "quantity": 100}`)
+
+	req, err := http.NewRequest(http.MethodGet, path, bytes.NewReader(jsonBody))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	r, err := testHTTPClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, status, r.StatusCode)
+}

--- a/test/integration/constants.go
+++ b/test/integration/constants.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package integration
+
+import "time"
+
+const (
+	instrumentedServiceStdURL         = "http://localhost:8080"
+	instrumentedServiceGinURL         = "http://localhost:8081"
+	instrumentedServiceGorillaURL     = "http://localhost:8082"
+	instrumentedServiceGorillaMidURL  = "http://localhost:8083"
+	instrumentedServiceGorillaMid2URL = "http://localhost:8087"
+	instrumentedServiceStdTLSURL      = "https://localhost:8383"
+	instrumentedServiceJSONRPCURL     = "http://localhost:8088"
+	prometheusHostPort                = "localhost:9090"
+	jaegerQueryURL                    = "http://localhost:16686/api/traces"
+
+	testTimeout = 60 * time.Second
+)

--- a/test/integration/discovery_test.go
+++ b/test/integration/discovery_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/docker"
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
@@ -48,7 +49,7 @@ func testSelectiveExports(t *testing.T) {
 	// this with  a proper check to see if the target process has finished
 	// being instrumented
 	test.Eventually(t, 3*time.Minute, func(t require.TestingT) {
-		doHTTPGet(t, "http://localhost:5001/b", 200)
+		ti.DoHTTPGet(t, "http://localhost:5001/b", 200)
 		bTraces := getTraces("service-b", "/b")
 		require.NotNil(t, bTraces)
 	})
@@ -56,8 +57,8 @@ func testSelectiveExports(t *testing.T) {
 	// Run couple of requests to make sure we flush out any transactions that might be
 	// stuck because of our tracking of full request times
 	for i := 0; i < 10; i++ {
-		doHTTPGet(t, "http://localhost:5000/a", 200)
-		doHTTPGet(t, "http://localhost:5001/b", 200)
+		ti.DoHTTPGet(t, "http://localhost:5000/a", 200)
+		ti.DoHTTPGet(t, "http://localhost:5001/b", 200)
 	}
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {

--- a/test/integration/http_go_otel_test.go
+++ b/test/integration/http_go_otel_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/docker"
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
@@ -24,7 +25,7 @@ import (
 
 func testForHTTPGoOTelLibrary(t *testing.T, route, svcNs string) {
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, "http://localhost:8080"+route, 200)
+		ti.DoHTTPGet(t, "http://localhost:8080"+route, 200)
 	}
 
 	// Eventually, Prometheus would make this query visible
@@ -80,7 +81,7 @@ func testForHTTPGoOTelLibrary(t *testing.T, route, svcNs string) {
 
 func testInstrumentationMissing(t *testing.T, route, svcNs string) {
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, "http://localhost:8080"+route, 200)
+		ti.DoHTTPGet(t, "http://localhost:8080"+route, 200)
 	}
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {

--- a/test/integration/internal_metrics_test.go
+++ b/test/integration/internal_metrics_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/docker"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 )
@@ -67,7 +68,7 @@ func TestAvoidedServicesMetrics(t *testing.T) {
 
 		// Make additional requests to ensure OTLP endpoints are hit
 		for i := 0; i < 3; i++ {
-			doHTTPGet(t, "http://localhost:8080/rolldice", 200)
+			ti.DoHTTPGet(t, "http://localhost:8080/rolldice", 200)
 			time.Sleep(1 * time.Second)
 		}
 

--- a/test/integration/nodejs_multiproc_test.go
+++ b/test/integration/nodejs_multiproc_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/docker"
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 )
@@ -33,7 +34,7 @@ func testNestedTraces(t *testing.T) {
 	// being instrumented
 	t.Log("checking instrumentation status")
 	test.Eventually(t, 2*time.Minute, func(t require.TestingT) {
-		doHTTPGet(t, "http://localhost:5000/a", 200)
+		ti.DoHTTPGet(t, "http://localhost:5000/a", 200)
 
 		resp, err := http.Get(jaegerQueryURL + "?service=service-a&limit=1")
 		if err != nil || resp == nil || resp.StatusCode != http.StatusOK {
@@ -52,7 +53,7 @@ func testNestedTraces(t *testing.T) {
 	// Run couple of requests to make sure we flush out any transactions that might be
 	// stuck because of our tracking of full request times
 	for i := 0; i < 10; i++ {
-		doHTTPGet(t, "http://localhost:5000/a", 200)
+		ti.DoHTTPGet(t, "http://localhost:5000/a", 200)
 	}
 
 	// Get the first 5 traces

--- a/test/integration/php_fm_test.go
+++ b/test/integration/php_fm_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/docker"
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
@@ -43,7 +44,7 @@ func testREDMetricsForPHPHTTPLibrary(t *testing.T, url string, nginx, php string
 	// - process multiple calls in a row with, one more than we might need
 	// - returning a 200 code
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, fmt.Sprintf("%s%s", url, path), 200)
+		ti.DoHTTPGet(t, fmt.Sprintf("%s%s", url, path), 200)
 	}
 
 	// Eventually, Prometheus would make this query visible
@@ -129,7 +130,7 @@ func TestPHPFM(t *testing.T) {
 
 func testHTTPTracesPHP(t *testing.T) {
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, "http://localhost:8080/", 200)
+		ti.DoHTTPGet(t, "http://localhost:8080/", 200)
 	}
 
 	var trace jaeger.Trace

--- a/test/integration/red_test.go
+++ b/test/integration/red_test.go
@@ -22,34 +22,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 	grpcclient "go.opentelemetry.io/obi/test/integration/components/testserver/grpc/client"
 )
 
-const (
-	instrumentedServiceStdURL         = "http://localhost:8080"
-	instrumentedServiceGinURL         = "http://localhost:8081"
-	instrumentedServiceGorillaURL     = "http://localhost:8082"
-	instrumentedServiceGorillaMidURL  = "http://localhost:8083"
-	instrumentedServiceGorillaMid2URL = "http://localhost:8087"
-	instrumentedServiceStdTLSURL      = "https://localhost:8383"
-	instrumentedServiceJSONRPCURL     = "http://localhost:8088"
-	prometheusHostPort                = "localhost:9090"
-	jaegerQueryURL                    = "http://localhost:16686/api/traces"
-
-	testTimeout = 60 * time.Second
-)
-
 func rndStr() string {
 	return strconv.Itoa(rand.IntN(10000))
-}
-
-func waitForTestComponents(t *testing.T, url string) {
-	waitForTestComponentsSub(t, url, "/smoke")
-}
-
-func waitForTestComponentsHTTP2(t *testing.T, url string) {
-	waitForTestComponentsHTTP2Sub(t, url, "/smoke", 1)
 }
 
 func testREDMetricsHTTP(t *testing.T) {
@@ -380,11 +359,11 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	// - take at least 30ms to respond
 	// - returning a 404 code
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, url+"/metrics", 200)
-		doHTTPGet(t, url+path+"?delay=30ms&status=404", 404)
+		ti.DoHTTPGet(t, url+"/metrics", 200)
+		ti.DoHTTPGet(t, url+path+"?delay=30ms&status=404", 404)
 		if url == instrumentedServiceGorillaURL {
-			doHTTPGet(t, url+"/echo", 203)
-			doHTTPGet(t, url+"/echoCall", 204)
+			ti.DoHTTPGet(t, url+"/echo", 203)
+			ti.DoHTTPGet(t, url+"/echoCall", 204)
 		}
 	}
 
@@ -669,10 +648,10 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	// - take at least 30ms to respond
 	// - returning a 404 code
 	for i := 0; i < 3; i++ {
-		doHTTPGet(t, url+"/metrics", 200)
-		doHTTPGet(t, url+path+"?delay=30ms&status=404", 404)
-		doHTTPGet(t, url+"/echo", 203)
-		doHTTPGet(t, url+"/echoCall", 204)
+		ti.DoHTTPGet(t, url+"/metrics", 200)
+		ti.DoHTTPGet(t, url+path+"?delay=30ms&status=404", 404)
+		ti.DoHTTPGet(t, url+"/echo", 203)
+		ti.DoHTTPGet(t, url+"/echoCall", 204)
 	}
 
 	// Eventually, Prometheus would make this query visible
@@ -931,7 +910,7 @@ func testREDMetricsForGoBasicOnly(t *testing.T, url string, comm string) {
 	// - take at least 30ms to respond
 	// - returning a 204 code
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, url+path+"?delay=30", 200)
+		ti.DoHTTPGet(t, url+path+"?delay=30", 200)
 	}
 
 	commMatch := `service_name="` + comm + `",`

--- a/test/integration/red_test_dotnet.go
+++ b/test/integration/red_test_dotnet.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 	"go.opentelemetry.io/obi/test/tools"
 )
@@ -23,7 +24,7 @@ func testREDMetricsForNetHTTPLibrary(t *testing.T, url string, comm string) {
 	// - take a large JSON file
 	// - returning a 200 code
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, url+urlPath, 200)
+		ti.DoHTTPGet(t, url+urlPath, 200)
 	}
 
 	// Eventually, Prometheus would make this query visible
@@ -83,7 +84,7 @@ func testREDMetricsForNetHTTPSLibrary(t *testing.T, url string, comm string) {
 	// - take at least 30ms to respond
 	// - returning a 204 code
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, url+path, 200)
+		ti.DoHTTPGet(t, url+path, 200)
 	}
 
 	// Eventually, Prometheus would make this query visible

--- a/test/integration/red_test_elixir.go
+++ b/test/integration/red_test_elixir.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 )
 
@@ -32,7 +33,7 @@ func testREDMetricsForElixirHTTPLibrary(t *testing.T, url string, comm string) {
 	// - process multiple calls in a row with, one more than we might need
 	// - returning a 200 code
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, fmt.Sprintf("%s%s/%d", url, path, i), 200)
+		ti.DoHTTPGet(t, fmt.Sprintf("%s%s/%d", url, path, i), 200)
 	}
 
 	// Eventually, Prometheus would make this query visible

--- a/test/integration/red_test_java.go
+++ b/test/integration/red_test_java.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 )
 
@@ -29,7 +30,7 @@ func testREDMetricsForJavaHTTPLibrary(t *testing.T, urls []string, comm string) 
 	// - returning a 204 code
 	for i := 0; i < 4; i++ {
 		for _, url := range urls {
-			doHTTPGet(t, url+path+"?delay=30&response=204", 204)
+			ti.DoHTTPGet(t, url+path+"?delay=30&response=204", 204)
 		}
 	}
 
@@ -80,7 +81,7 @@ func testREDMetricsForJavaOTelSDK(t *testing.T, urls []string) {
 	// - returning a 204 code
 	for i := 0; i < 4; i++ {
 		for _, url := range urls {
-			doHTTPGet(t, url+path+"?delay=30&response=204", 204)
+			ti.DoHTTPGet(t, url+path+"?delay=30&response=204", 204)
 		}
 	}
 

--- a/test/integration/red_test_kafka.go
+++ b/test/integration/red_test_kafka.go
@@ -17,6 +17,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 )
@@ -35,7 +36,7 @@ func runKafkaTestCase(t *testing.T, testCase TestCase) {
 		err     error
 	)
 
-	doHTTPGet(t, url+"/"+urlPath, 200)
+	ti.DoHTTPGet(t, url+"/"+urlPath, 200)
 
 	// Ensure we don't see any http requests
 	results, err = pq.Query(`http_server_request_duration_seconds_count{}`)

--- a/test/integration/red_test_python.go
+++ b/test/integration/red_test_python.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 )
 
@@ -23,7 +24,7 @@ func testREDMetricsForPythonHTTPLibrary(t *testing.T, url, comm, namespace strin
 	// - take a large JSON file
 	// - returning a 200 code
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, url+urlPath, 200)
+		ti.DoHTTPGet(t, url+urlPath, 200)
 	}
 
 	// Eventually, Prometheus would make this query visible

--- a/test/integration/red_test_python_mongo.go
+++ b/test/integration/red_test_python_mongo.go
@@ -18,6 +18,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 )
@@ -31,7 +32,7 @@ func testREDMetricsForPythonMongoLibrary(t *testing.T, testCase TestCase) {
 	// - take a large JSON file
 	// - returning a 200 code
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, uri+"/"+urlPath, 200)
+		ti.DoHTTPGet(t, uri+"/"+urlPath, 200)
 	}
 
 	// Eventually, Prometheus would make mongo operations visible

--- a/test/integration/red_test_python_redis.go
+++ b/test/integration/red_test_python_redis.go
@@ -17,6 +17,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 )
@@ -30,7 +31,7 @@ func testREDMetricsForPythonRedisLibrary(t *testing.T, testCase TestCase) {
 	// - take a large JSON file
 	// - returning a 200 code
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, url+"/"+urlPath, 200)
+		ti.DoHTTPGet(t, url+"/"+urlPath, 200)
 	}
 
 	// Eventually, Prometheus would make redis operations visible

--- a/test/integration/red_test_python_sql.go
+++ b/test/integration/red_test_python_sql.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 )
@@ -170,7 +171,7 @@ func testPythonSQLQuery(t *testing.T, comm, url, table, db string) {
 	t.Helper()
 
 	urlPath := "/query"
-	doHTTPGet(t, url+urlPath, 200)
+	ti.DoHTTPGet(t, url+urlPath, 200)
 
 	assertSQLOperation(t, comm, "SELECT", table, db)
 }
@@ -179,7 +180,7 @@ func testPythonSQLPreparedStatements(t *testing.T, comm, url, table, db string) 
 	t.Helper()
 
 	urlPath := "/prepquery"
-	doHTTPGet(t, url+urlPath, 200)
+	ti.DoHTTPGet(t, url+urlPath, 200)
 
 	assertSQLOperation(t, comm, "SELECT", table, db)
 }
@@ -188,7 +189,7 @@ func testPythonSQLError(t *testing.T, comm, url, db string) {
 	t.Helper()
 
 	urlPath := "/error"
-	doHTTPGet(t, url+urlPath, 200)
+	ti.DoHTTPGet(t, url+urlPath, 200)
 
 	assertSQLOperationErrored(t, comm, "SELECT", "obi.nonexisting", db)
 }
@@ -228,7 +229,7 @@ func testREDMetricsForPythonSQLSSL(t *testing.T, url, comm, namespace string) {
 	// - take a large JSON file
 	// - returning a 200 code
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, url+urlPath, 200)
+		ti.DoHTTPGet(t, url+urlPath, 200)
 	}
 
 	// Eventually, Prometheus would make this query visible

--- a/test/integration/red_test_ruby.go
+++ b/test/integration/red_test_ruby.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/test/integration/components/prom"
 )
@@ -81,7 +82,7 @@ func testREDMetricsForRubyHTTPLibrary(t *testing.T, url string, comm string) {
 	// - process multiple calls in a row with, one more than we might need
 	// - returning a 200 code
 	for i := 0; i < 4; i++ {
-		doHTTPGet(t, url+path+"/1", 200)
+		ti.DoHTTPGet(t, url+path+"/1", 200)
 	}
 
 	// Eventually, Prometheus would make this query visible
@@ -128,11 +129,9 @@ func testREDMetricsRailsHTTPS(t *testing.T) {
 }
 
 // Assumes we've run the metrics tests
-//
-//nolint:testifylint
 func testHTTPTracesNestedNginx(t *testing.T) {
 	for i := 1; i <= 4; i++ {
-		go doHTTPGet(t, "https://localhost:8443/users/"+strconv.Itoa(i), 200)
+		go ti.DoHTTPGet(t, "https://localhost:8443/users/"+strconv.Itoa(i), 200)
 	}
 
 	for i := 1; i <= 4; i++ {

--- a/test/integration/sampler_test.go
+++ b/test/integration/sampler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/docker"
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 )
@@ -34,7 +35,7 @@ func testSampler(t *testing.T) {
 	// Run couple of requests to make sure we flush out any transactions that might be
 	// stuck because of our tracking of full request times
 	for i := 0; i < 10; i++ {
-		doHTTPGet(t, "http://localhost:5000/a", 200)
+		ti.DoHTTPGet(t, "http://localhost:5000/a", 200)
 	}
 
 	test.Eventually(t, testTimeout, func(t require.TestingT) {

--- a/test/integration/suites_test.go
+++ b/test/integration/suites_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/docker"
 )
 
@@ -22,6 +23,9 @@ func TestSuite(t *testing.T) {
 	require.NoError(t, err)
 	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=(pingclient|testserver)`)
 	require.NoError(t, compose.Up())
+
+	config := ti.DefaultOBIConfig()
+
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("RED JSON RPC metrics", testREDMetricsJSONRPCHTTP)
 	t.Run("HTTP traces", testHTTPTraces)
@@ -30,7 +34,7 @@ func TestSuite(t *testing.T) {
 	t.Run("GRPC traces", testGRPCTraces)
 	t.Run("GRPC RED metrics", testREDMetricsGRPC)
 	t.Run("GRPC TLS RED metrics", testREDMetricsGRPCTLS)
-	t.Run("Internal Prometheus metrics", testInternalPrometheusExport)
+	t.Run("Internal Prometheus metrics", func(t *testing.T) { ti.InternalPrometheusExport(t, config) })
 	t.Run("Exemplars exist", testExemplarsExist)
 	t.Run("Testing Host Info metric", testHostInfo)
 	t.Run("Client RED metrics", testREDMetricsForClientHTTPLibrary)
@@ -86,11 +90,14 @@ func TestSuite_NoDebugInfo(t *testing.T) {
 
 	compose.Env = append(compose.Env, `TESTSERVER_DOCKERFILE_SUFFIX=_nodebug`)
 	require.NoError(t, compose.Up())
+
+	config := ti.DefaultOBIConfig()
+
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("HTTP traces", testHTTPTraces)
 	t.Run("GRPC traces", testGRPCTraces)
 	t.Run("GRPC RED metrics", testREDMetricsGRPC)
-	t.Run("Internal Prometheus metrics", testInternalPrometheusExport)
+	t.Run("Internal Prometheus metrics", func(t *testing.T) { ti.InternalPrometheusExport(t, config) })
 
 	require.NoError(t, compose.Close())
 }
@@ -102,11 +109,14 @@ func TestSuite_StaticCompilation(t *testing.T) {
 
 	compose.Env = append(compose.Env, `TESTSERVER_DOCKERFILE_SUFFIX=_static`)
 	require.NoError(t, compose.Up())
+
+	config := ti.DefaultOBIConfig()
+
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("HTTP traces", testHTTPTraces)
 	t.Run("GRPC traces", testGRPCTraces)
 	t.Run("GRPC RED metrics", testREDMetricsGRPC)
-	t.Run("Internal Prometheus metrics", testInternalPrometheusExport)
+	t.Run("Internal Prometheus metrics", func(t *testing.T) { ti.InternalPrometheusExport(t, config) })
 
 	require.NoError(t, compose.Close())
 }
@@ -117,12 +127,15 @@ func TestSuite_OldestGoVersion(t *testing.T) {
 
 	compose.Env = []string{`OTEL_GO_AUTO_TARGET_EXE=*testserver`}
 	require.NoError(t, compose.Up())
+
+	config := ti.DefaultOBIConfig()
+
 	t.Run("RED metrics", testREDMetricsOldHTTP)
 	t.Run("HTTP traces", testHTTPTraces)
 	t.Run("GRPC traces", testGRPCTraces)
 	t.Run("GRPC RED metrics", testREDMetricsGRPC)
 	t.Run("HTTP traces (manual spans)", testHTTPTracesNestedManualSpans)
-	t.Run("Internal Prometheus metrics", testInternalPrometheusExport)
+	t.Run("Internal Prometheus metrics", func(t *testing.T) { ti.InternalPrometheusExport(t, config) })
 
 	require.NoError(t, compose.Close())
 }
@@ -191,9 +204,12 @@ func TestSuite_PrometheusScrape(t *testing.T) {
 	)
 
 	require.NoError(t, compose.Up())
+
+	config := ti.DefaultOBIConfig()
+
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("GRPC RED metrics", testREDMetricsGRPC)
-	t.Run("Internal Prometheus metrics", testInternalPrometheusExport)
+	t.Run("Internal Prometheus metrics", func(t *testing.T) { ti.InternalPrometheusExport(t, config) })
 	t.Run("Testing OBI Build Info metric", testPrometheusOBIBuildInfo)
 	t.Run("Testing for no OBI self metrics", testPrometheusNoOBIEvents)
 	t.Run("Testing BPF metrics", testPrometheusBPFMetrics)
@@ -499,12 +515,14 @@ func TestSuite_DisableKeepAlives(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
+	config := ti.DefaultOBIConfig()
+
 	// Run tests with keepalives disabled:
 	setHTTPClientDisableKeepAlives(true)
 	t.Run("RED metrics", testREDMetricsHTTP)
 
 	t.Run("HTTP DisableKeepAlives traces", testHTTPTraces)
-	t.Run("Internal Prometheus DisableKeepAlives metrics", testInternalPrometheusExport)
+	t.Run("Internal Prometheus DisableKeepAlives metrics", func(t *testing.T) { ti.InternalPrometheusExport(t, config) })
 	// Reset to defaults for any tests run afterward
 	setHTTPClientDisableKeepAlives(false)
 

--- a/test/integration/test_python_elasticsearchclient.go
+++ b/test/integration/test_python_elasticsearchclient.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
 	"go.opentelemetry.io/obi/test/integration/components/jaeger"
 )
 
@@ -33,13 +34,13 @@ func testPythonElasticsearch(t *testing.T) {
 
 func populate(t *testing.T, url string) {
 	urlPath := "/doc"
-	doHTTPGet(t, url+urlPath, 200)
+	ti.DoHTTPGet(t, url+urlPath, 200)
 }
 
 func testElasticsearchSearch(t *testing.T, comm, url, index string) {
 	queryText := "{\"query\":{\"match\":{\"name\":\"OBI\"}}}"
 	urlPath := "/search"
-	doHTTPGet(t, url+urlPath, 200)
+	ti.DoHTTPGet(t, url+urlPath, 200)
 
 	assertElasticsearchOperation(t, comm, "search", queryText, index)
 }

--- a/test/integration/test_utils.go
+++ b/test/integration/test_utils.go
@@ -83,19 +83,6 @@ func doHTTPPost(t *testing.T, path string, status int, jsonBody []byte) {
 	require.Equal(t, status, r.StatusCode)
 }
 
-func doHTTPGet(t require.TestingT, path string, status int) {
-	// Random fake body to cause the request to have some size (38 bytes)
-	jsonBody := []byte(`{"productId": 123456, "quantity": 100}`)
-
-	req, err := http.NewRequest(http.MethodGet, path, bytes.NewReader(jsonBody))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-
-	r, err := testHTTPClient.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, status, r.StatusCode)
-}
-
 //nolint:errcheck
 func doHTTPGetWithTimeout(t *testing.T, path string, timeout time.Duration) {
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
@@ -171,6 +158,14 @@ func createParentID() string {
 
 func createTraceparent(traceID string, parentID string) string {
 	return "00-" + traceID + "-" + parentID + "-01"
+}
+
+func waitForTestComponents(t *testing.T, url string) {
+	waitForTestComponentsSub(t, url, "/smoke")
+}
+
+func waitForTestComponentsHTTP2(t *testing.T, url string) {
+	waitForTestComponentsHTTP2Sub(t, url, "/smoke", 1)
 }
 
 func waitForTestComponentsSub(t *testing.T, url, subpath string) {


### PR DESCRIPTION
This PR introduces the new `pkg/test/integration` package to allow downstream projects to reuse the OBI integration tests.

Initially, this is a lift-and-shift export of:

- `testInternalPrometheusExport` --> `InternalPrometheusExport`
- `doHTTPGet` --> `DoHTTPGet`

And the introduction of `TestConfig`, which holds project-specific naming and prefixes.

Finally, I moved a couple of symbols around, which seemed out of place.