### PR TITLE
test: reduce k8s daemonset multi node disk usage

### DIFF
--- a/test/integration/k8s/daemonset_multi_node/k8s_daemonset_multi_node_main_test.go
+++ b/test/integration/k8s/daemonset_multi_node/k8s_daemonset_multi_node_main_test.go
@@ -31,9 +31,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "pythontestserver:dev", Dockerfile: k8s.DockerfilePythonTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.103.0"},
-		docker.ImageBuild{Tag: "jaegertracing/all-in-one:1.57"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -44,9 +41,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("pythontestserver:dev"),
 		kube.LocalImage("obi:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.103.0"),
-		kube.LocalImage("jaegertracing/all-in-one:1.57"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/03-otelcol-multi-node.yml"),

--- a/test/integration/k8s/manifests/05-uninstrumented-few-services.yml
+++ b/test/integration/k8s/manifests/05-uninstrumented-few-services.yml
@@ -151,7 +151,7 @@ spec:
       containers:
         - name: utestserver
           image: 'ghcr.io/open-telemetry/obi-testimg:rails-0.1.0'
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:          
           - containerPort: 3040
             hostPort: 3040


### PR DESCRIPTION
Reduce disk space usage of the k8s daemonset multi-node shard:

- Avoid pre-loading external images (let k8s download on-demand)
