### PR TITLE
Remove bitfields from DNS code

### DIFF
--- a/bpf/common/dns.h
+++ b/bpf/common/dns.h
@@ -25,10 +25,31 @@
 enum dns_qr_type : u8 { k_dns_qr_query = 0, k_dns_qr_resp = 1 };
 
 // https://datatracker.ietf.org/doc/html/rfc1035#section-4.1.1
+//
+// 4.1.1. Header section format
+//
+// The header contains the following fields:
+//
+//                                     1  1  1  1  1  1
+//       0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5
+//     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+//     |                      ID                       |
+//     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+//     |QR|   Opcode  |AA|TC|RD|RA|   Z    |   RCODE   | <--- flags (1)
+//     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+//     |                    QDCOUNT                    |
+//     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+//     |                    ANCOUNT                    |
+//     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+//     |                    NSCOUNT                    |
+//     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+//     |                    ARCOUNT                    |
+//     +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+
 struct dnshdr {
     u16 id;
 
-    u16 flags; // in network byte order
+    u16 flags; // flags (1) in network byte order
 
     u16 qdcount; // number of question entries
     u16 ancount; // number of answer entries


### PR DESCRIPTION
Bitfields carry a lot of undefined or implementation defined behaviour. The original code assumed ordering and packing semantics that are not guaranteed.

Reference from the C17 standard:

> "The order of allocation of bit-fields within a unit (high-order to low-order or low-order to high-order) is implementation-defined."
(§6.7.2.1 paragraph 11)

and

> "If enough space remains, a bit-field that immediately follows another bit-field in a structure shall be packed into adjacent bits of the same unit. If insufficient space remains, whether a bit-field that does not fit entirely within the unit is put into the next unit or overlaps adjacent units is implementation-defined."
(§6.7.2.1 paragraph 12)

which may lead to obscure and hard to spot/debug bugs.

Follow up to https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/793