### PR TITLE
Add large buffer debug logs under protocol_debug_print

### DIFF
--- a/internal/test/integration/docker-compose-elasticsearch.yml
+++ b/internal/test/integration/docker-compose-elasticsearch.yml
@@ -55,6 +55,7 @@ services:
       OTEL_EBPF_METRICS_FEATURES: "application"
       OTEL_EBPF_BPF_BUFFER_SIZE_HTTP: 1024
       OTEL_EBPF_HTTP_ELASTICSEARCH_ENABLED: true
+      OTEL_EBPF_PROTOCOL_DEBUG_PRINT: true
     depends_on:
       testserver:
         condition: service_started

--- a/internal/test/integration/docker-compose-python-aws.yml
+++ b/internal/test/integration/docker-compose-python-aws.yml
@@ -52,6 +52,7 @@ services:
       OTEL_EBPF_METRICS_FEATURES: "application"
       OTEL_EBPF_BPF_BUFFER_SIZE_HTTP: 2048
       OTEL_EBPF_HTTP_AWS_ENABLED: true
+      OTEL_EBPF_PROTOCOL_DEBUG_PRINT: true
     depends_on:
       testserver:
         condition: service_started


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/831

This PR adds the ability to print large buffers getting to userspace with their direction/action (0=init, 1=append)

Append:
```
>>> LargeBufferAppend: (packet=1 direction=1 action=0)
POST / HTTP/1.1
Host: localhost:4566
Accept-Encoding: identity
X-Amz-Target: AmazonSQS.DeleteMessage
Content-Type: application/x-amz-json-1.0
x-amzn-query-mode: true
User-Agent: Boto3/1.40.55 md/Botocore#1.40.55 ua/2.1 os/linux#6.8.0-79-generic md/arch#aarch64 lang/python#3.12.3 md/pyimpl#CPython m/b,N,D,e,Z cfg/retry-mode#legacy Botocore/1.40.55
X-Amz-Date: 20251030T140527Z
Authorization: AWS4-HMAC-SHA256 Credential=test/20251030/us-east-1/sqs/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target;x-amzn-query-mode, Signature=268865b73a1b1c563f6c382a32ec0b8a5028afc24151d2ba83ce7ac7acd9b88b
amz-sdk-invocation-id: 65e80309-7d8c-48ab-add7-614bd7826682
amz-sdk-request: attempt=1
Content-Length: 297

>>> LargeBufferAppend: (packet=1 direction=1 action=1)
{"QueueUrl": "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/demo-queue", "ReceiptHandle": "YjM5NGQxOGQtMzQ4Ny00OWQ4LTlhODMtOWIzOWM0ZmI0YTkwIGFybjphd3M6c3FzOnVzLWVhc3QtMTowMDAwMDAwMDAwMDA6ZGVtby1xdWV1ZSAwNjk2Y2FjZS03NDM2LTQwZjItYmUzOC0zYzMwZTBlMDkwNTQgMTc2MTgzMzEyNy4xMzExNTcy"}

>>> LargeBufferAppend: (packet=2 direction=0 action=0)
HTTP/1.1 200 OK
Server: TwistedWeb/24.3.0
Date: Thu, 30 Oct 2025 14:05:27 GMT
Content-Type: application/x-amz-json-1.0
Content-Length: 2
x-amzn-RequestId: 794d2c11-880c-4e06-92ac-09cd46596a4f
x-localstack: true

{}
```

Extract:
```
<<< LargeBufferExtract: (packet=1 direction=1)
POST / HTTP/1.1
Host: localhost:4566
Accept-Encoding: identity
X-Amz-Target: AmazonSQS.DeleteMessage
Content-Type: application/x-amz-json-1.0
x-amzn-query-mode: true
User-Agent: Boto3/1.40.55 md/Botocore#1.40.55 ua/2.1 os/linux#6.8.0-79-generic md/arch#aarch64 lang/python#3.12.3 md/pyimpl#CPython m/b,N,D,e,Z cfg/retry-mode#legacy Botocore/1.40.55
X-Amz-Date: 20251030T140527Z
Authorization: AWS4-HMAC-SHA256 Credential=test/20251030/us-east-1/sqs/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-target;x-amzn-query-mode, Signature=268865b73a1b1c563f6c382a32ec0b8a5028afc24151d2ba83ce7ac7acd9b88b
amz-sdk-invocation-id: 65e80309-7d8c-48ab-add7-614bd7826682
amz-sdk-request: attempt=1
Content-Length: 297

{"QueueUrl": "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/demo-queue", "ReceiptHandle": "YjM5NGQxOGQtMzQ4Ny00OWQ4LTlhODMtOWIzOWM0ZmI0YTkwIGFybjphd3M6c3FzOnVzLWVhc3QtMTowMDAwMDAwMDAwMDA6ZGVtby1xdWV1ZSAwNjk2Y2FjZS03NDM2LTQwZjItYmUzOC0zYzMwZTBlMDkwNTQgMTc2MTgzMzEyNy4xMzExNTcy"}
<<< LargeBufferExtract: (packet=2 direction=0)
HTTP/1.1 200 OK
Server: TwistedWeb/24.3.0
Date: Thu, 30 Oct 2025 14:05:27 GMT
Content-Type: application/x-amz-json-1.0
Content-Length: 2
x-amzn-RequestId: 794d2c11-880c-4e06-92ac-09cd46596a4f
x-localstack: true

{}
```