### PR TITLE
test: verify bpf test suite

### DIFF
--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -6,7 +6,7 @@ on:
     paths: ["bpf/**"]
   pull_request:
     branches: ["main", "release-*"]
-    # paths: ["bpf/**"]
+    paths: ["bpf/**"]
 
 permissions:
   contents: read


### PR DESCRIPTION
Test to validate bpf test suite since test package was moved to internal.

Fixed Makefile target path and validated in d506d1eaf.