### PR TITLE
ci: update workflow paths

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,9 +17,6 @@ jobs:
       pull-requests: write
     name: test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ["1.25"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -27,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: "go.mod"
           cache: "false"
       - name: Run verification and unit tests
         run: make docker-generate verify cov-exclude-generated check-go-mod
@@ -48,6 +45,6 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: stable
+          go-version-file: "go.mod"
           cache: "false"
       - run: make notices-update check-clean-work-tree

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.25"
+          go-version-file: "go.mod"
           cache: false
 
       - name: Generate files

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -35,9 +35,6 @@ jobs:
       actions: write
     name: test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ["1.25"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -46,7 +43,7 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           cache: "false"
-          go-version: ${{ matrix.go }}
+          go-version-file: "go.mod"
       - name: Clean up disk space
         run: |
           docker system prune -af

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.25"
+          go-version-file: "go.mod"
           cache: false
 
       - name: Generate files

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.25"
+          go-version-file: "go.mod"
           cache: false
 
       - name: Run oats tests

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.25"
+          go-version-file: "go.mod"
           cache: false
 
       - name: Generate files


### PR DESCRIPTION
This PR makes some updates to the CI workflows:

1. Standardise Go version based on `go.mod` (reduce toil when updating and stay in sync)
2. Add `paths` to trigger long-running workflows only if necessary (e.g. README changes don't need integration tests)
3. Add more paths to trigger the VM workflow (catch dependent changes)

For example, as this PR touches the workflow files, those workflows are triggered.