### PR TITLE
Add release tag to docker image

### DIFF
--- a/.github/workflows/publish_dockerhub_main.yml
+++ b/.github/workflows/publish_dockerhub_main.yml
@@ -2,6 +2,8 @@
 name: Push to DockerHub (main)
 on:
   push:
+    tags:
+      - "v*.*.*"
     branches:
       - main
 


### PR DESCRIPTION
Resolve #851 

When a new `v*.*.*` tag is pushed to the repository during a release, make sure to include that tag in the published images.