### PR TITLE
Tag otel/opentelemetry-ebpf-k8s-cache on release

### DIFF
--- a/.github/workflows/publish_dockerhub_k8s_cache_main.yml
+++ b/.github/workflows/publish_dockerhub_k8s_cache_main.yml
@@ -2,6 +2,8 @@
 name: Push k8s cache to DockerHub (main)
 on:
   push:
+    tags:
+      - "v*.*.*"
     branches:
       - main
 


### PR DESCRIPTION
Similar to #852, ensure that during a release the cache image receives the correct tag.