### PR TITLE
ci: github release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,34 @@
+# Configuration for GitHub's automatically generated release notes.
+#
+# Applies to both manual releases, and those triggered by a release workflow.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    authors:
+      # e.g. Automatic update of offsets.json
+      - otelbot[bot]
+
+  categories:
+    # General is a "catch all", so be sure to exclude any labels that are
+    # captured under another category.
+    - title: General
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - bug
+          - dependencies
+          - documentation
+
+    - title: Fixed
+      labels:
+        - bug
+
+    - title: Documentation
+      labels:
+        - documentation
+
+    - title: Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
This PR introduces a configuration file that splits the auto-generated GitHub release notes into several sections with headers. **This is not release automation**, it covers formatting of the release notes only, but it does apply to both manual and automated releases so can be used right away.

I took a quick look at our main commits, and found only the following (3) labels in use:

- bug
- dependencies
- documentation

So, working with what we have right now, I came up with this format:

- General
- Fixed
- Documentation
- Dependencies

I thought it might also be sensible to exclude `otelbot[bot]` commits, as they seem to only be "Automatic update of offsets.json", which are not useful.

This is an example and a starting point, happy for this to evolve as we go. Probably one thing we could do is be more vigilant in at least using the `bug` label on PRs, where appropriate to begin with?

Relates to:

- #865