### PR TITLE
ci: automatically create github release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  push:
+    tags:
+      # N.B. These workflows also trigger on this tag pattern:
+      # - publish_dockerhub_main.yml
+      # - publish_dockerhub_k8s_cache_main.yml
+      - "v*.*.*"
+
+# https://docs.zizmor.sh/audits/#excessive-permissions
+permissions: {}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # https://github.com/softprops/action-gh-release#permissions
+    steps:
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repository: open-telemetry/opentelemetry-ebpf-instrumentation
+          generate_release_notes: true


### PR DESCRIPTION
This PR creates a new GitHub actions workflow that triggers when a git tag following the pattern `v*.*.*` is pushed to this repo:

- Automatically publishes a GitHub release
- Uses GitHub's auto-generated release notes
- The release is named the same as the git tag (follows current convention in this repo)

NOTE: `publish_dockerhub_main.yml` and `publish_dockerhub_k8s_cache_main.yml` also currently trigger on this same tag pattern push, I thought best to solve the ordering/workflow-calling in a separate PR.

In future, it would be possible to modify this workflow to handle e.g. artifact signing, uploading, and attaching to releases.