### PR TITLE
Fix default-const-init warning

### DIFF
--- a/bpf/bpfcore/bpf_core_read.h
+++ b/bpf/bpfcore/bpf_core_read.h
@@ -430,7 +430,7 @@ enum bpf_enum_value_kind {
  */
 #define BPF_CORE_READ(src, a, ...)                                                                 \
     ({                                                                                             \
-        ___type((src), a, ##__VA_ARGS__) __r;                                                      \
+        ___type((src), a, ##__VA_ARGS__) __r = {};                                                 \
         BPF_CORE_READ_INTO(&__r, (src), a, ##__VA_ARGS__);                                         \
         __r;                                                                                       \
     })


### PR DESCRIPTION
Newer clang versions now enable `-Wdefault-const-init-unsafe` - which is good, it forces us to initialise variables.

libbpf hasn't yet caught up, but since we keep our own version of the headers (with our own formatting), it's simply best to fix the offending macro rather than disabling the warning altogether.

Tested with clang 21.

Here's a sample of the error:

```
In file included from /home/rafael/dev/opentelemetry-ebpf-instrumentation/bpf/tpinjector/tpinjector.c:19:
In file included from ../../../../bpf/generictracer/protocol_http.h:21:
In file included from ../../../../bpf/generictracer/protocol_common.h:9:
../../../../bpf/common/sock_port_ns.h:20:17: error: default initialization of an object of type 'typeof ((skc)->skc_num)' (aka 'const unsigned short') leaves the object uninitialized [-Werror,-Wdefault-const-init-var-unsafe]
   20 |         .port = BPF_CORE_READ(skc, skc_num),
      |                 ^
../../../../bpf/bpfcore/bpf_core_read.h:433:42: note: expanded from macro 'BPF_CORE_READ'
  433 |         ___type((src), a, ##__VA_ARGS__) __r;                                                      \
      |                                          ^
1 error generated.
```