### PR TITLE
Rename Java TLS probe from Beyla to OBI

### DIFF
--- a/bpf/generictracer/java_tls.c
+++ b/bpf/generictracer/java_tls.c
@@ -37,8 +37,7 @@ static __always_inline u8 cmd_to_op(u8 cmd) {
 }
 
 SEC("kprobe/do_vfs_ioctl")
-int BPF_KPROBE(
-    beyla_kprobe_do_vfs_ioctl, void *filp, unsigned int fd, unsigned int cmd, void *arg) {
+int BPF_KPROBE(obi_kprobe_do_vfs_ioctl, void *filp, unsigned int fd, unsigned int cmd, void *arg) {
     (void)ctx;
     (void)filp;
 

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -326,7 +326,7 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {
 		},
 		"do_vfs_ioctl": {
 			Required: true,
-			Start:    p.bpfObjects.BeylaKprobeDoVfsIoctl,
+			Start:    p.bpfObjects.ObiKprobeDoVfsIoctl,
 		},
 	}
 


### PR DESCRIPTION
I accidentally pushed an old name for this new probe (from my ancient branch) before the OBI probes were renamed. This PR just changes the kprobe prefix to match the rest of the code.