### PR TITLE
Add ability to configure extra span metrics resource attributes

### DIFF
--- a/internal/test/integration/docker-compose-1.17.yml
+++ b/internal/test/integration/docker-compose-1.17.yml
@@ -15,6 +15,7 @@ services:
       - "5051:5051"
     environment:
       LOG_LEVEL: DEBUG
+      OTEL_RESOURCE_ATTRIBUTES: "service.version=1.0.0"
 
   obi:
     build:
@@ -44,6 +45,8 @@ services:
       OTEL_EBPF_BPF_DEBUG: "TRUE"
       OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT: 8999
       OTEL_EBPF_HOSTNAME: "beyla"
+      OTEL_EBPF_PROMETHEUS_EXTRA_SPAN_RESOURCE_ATTRIBUTES: "service.version"
+      OTEL_EBPF_EXTRA_SPAN_RESOURCE_ATTRIBUTES: "service.version"
     ports:
       - "8999:8999" # Prometheus scrape port, if enabled via config
 

--- a/internal/test/integration/docker-compose.yml
+++ b/internal/test/integration/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - "50051:50051"
     environment:
       LOG_LEVEL: DEBUG
+      OTEL_RESOURCE_ATTRIBUTES: "service.version=1.0.0"
 
   pingclient:
     build:
@@ -60,6 +61,8 @@ services:
       OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
       OTEL_EBPF_HOSTNAME: "beyla"
       OTEL_EBPF_RENAME_UNRESOLVED_HOSTS: ""
+      OTEL_EBPF_PROMETHEUS_EXTRA_SPAN_RESOURCE_ATTRIBUTES: "service.version"
+      OTEL_EBPF_EXTRA_SPAN_RESOURCE_ATTRIBUTES: "service.version"
     ports:
       - "8999:8999" # Prometheus scrape port, if enabled via config
 

--- a/internal/test/integration/red_test.go
+++ b/internal/test/integration/red_test.go
@@ -129,6 +129,7 @@ func testSpanMetricsForHTTPLibraryOTelFormat(t *testing.T, svcName, svcNs string
 			`service_namespace="` + svcNs + `",` +
 			`service_name="` + svcName + `",` +
 			`span_name="GET /basic/:rnd",` +
+			`service_version="1.0.0",` +
 			`telemetry_sdk_language="go"` +
 			`}`)
 		require.NoError(t, err)
@@ -182,6 +183,7 @@ func testSpanMetricsForHTTPLibrary(t *testing.T, svcName, svcNs string) {
 			`service_namespace="` + svcNs + `",` +
 			`service_name="` + svcName + `",` +
 			`span_name="GET /basic/:rnd",` +
+			`service_version="1.0.0",` +
 			`telemetry_sdk_language="go"` +
 			`}`)
 		require.NoError(t, err)

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -82,6 +82,7 @@ type MetricsReporter struct {
 	is               instrumentations.InstrumentationSelection
 	targetMetrics    map[svc.UID]*TargetMetrics
 	attrGetters      attributes.NamedGetters[*request.Span, attribute.KeyValue]
+	spanExtraAttrs   []attr.Name
 
 	// user-selected fields for each of the reported metrics
 	attrHTTPDuration           []attributes.Field[*request.Span, attribute.KeyValue]
@@ -212,6 +213,11 @@ func newMetricsReporter(
 		userAttribSelection: selectorCfg.SelectionCfg,
 		log:                 mlog(),
 		attrGetters:         request.SpanOTELGetters(unresolved),
+	}
+
+	mr.spanExtraAttrs = []attr.Name{}
+	for _, label := range cfg.ExtraSpanResourceLabels {
+		mr.spanExtraAttrs = append(mr.spanExtraAttrs, attr.Name(label))
 	}
 
 	mr.createEventMetrics = mr.createTargetMetricData
@@ -895,6 +901,14 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 	}
 
 	if otelSpanMetricsAccepted(span, mr) {
+		extraAttrs := []attribute.KeyValue{}
+
+		for _, l := range mr.spanExtraAttrs {
+			if v, ok := span.Service.Metadata[l]; ok {
+				extraAttrs = append(extraAttrs, l.OTEL().String(v))
+			}
+		}
+
 		if mr.cfg.SpanMetricsEnabled() {
 			sml, attrs := r.spanMetricsLatency.ForRecord(span)
 			sml.Record(ctx, duration, instrument.WithAttributeSet(attrs))

--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -62,6 +62,11 @@ type MetricsConfig struct {
 
 	// InjectHeaders allows injecting custom headers to the HTTP OTLP exporter
 	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
+
+	// ExtraSpanResourceLabels adds extra metadata labels to OTEL span metrics from sources whose availability can't be known
+	// beforehand. For example, to add the OTEL deployment.environment resource attribute as a OTEL resource attribute,
+	// you should add `deployment.environment`.
+	ExtraSpanResourceLabels []string `yaml:"extra_span_resource_attributes" env:"OTEL_EBPF_EXTRA_SPAN_RESOURCE_ATTRIBUTES" envSeparator:","`
 }
 
 func (m MetricsConfig) MarshalYAML() (any, error) {

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -136,6 +136,11 @@ type PrometheusConfig struct {
 	// beforehand. For example, to add the OTEL deployment.environment resource attribute as a Prometheus resource attribute,
 	// you should add `deployment.environment`.
 	ExtraResourceLabels []string `yaml:"extra_resource_attributes" env:"OTEL_EBPF_PROMETHEUS_EXTRA_RESOURCE_ATTRIBUTES" envSeparator:","`
+
+	// ExtraSpanResourceLabels adds extra metadata labels to Prometheus span metrics from sources whose availability can't be known
+	// beforehand. For example, to add the OTEL deployment.environment resource attribute as a Prometheus resource attribute,
+	// you should add `deployment.environment`.
+	ExtraSpanResourceLabels []string `yaml:"extra_span_resource_attributes" env:"OTEL_EBPF_PROMETHEUS_EXTRA_SPAN_RESOURCE_ATTRIBUTES" envSeparator:","`
 }
 
 func mlog() *slog.Logger {
@@ -196,10 +201,12 @@ func (p *PrometheusConfig) Enabled() bool {
 }
 
 type metricsReporter struct {
-	cfg                 *PrometheusConfig
-	extraMetadataLabels []attr.Name
-	input               <-chan []request.Span
-	processEvents       <-chan exec.ProcessEvent
+	cfg                     *PrometheusConfig
+	extraMetadataLabels     []attr.Name
+	extraSpanMetadataLabels []attr.Name
+
+	input         <-chan []request.Span
+	processEvents <-chan exec.ProcessEvent
 
 	beylaInfo              *Expirer[prometheus.Gauge]
 	httpDuration           *Expirer[prometheus.Histogram]
@@ -414,6 +421,7 @@ func newReporter(
 	// If service name is not explicitly set, we take the service name as set by the
 	// executable inspector
 	extraMetadataLabels := parseExtraMetadata(cfg.ExtraResourceLabels)
+	extraSpanMetadataLabels := parseExtraMetadata(cfg.ExtraSpanResourceLabels)
 	mr := &metricsReporter{
 		input:                      input.Subscribe(msg.SubscriberName("prom.InputSpans")),
 		processEvents:              processEventCh.Subscribe(msg.SubscriberName("prom.ProcessEvents")),
@@ -423,6 +431,7 @@ func newReporter(
 		cfg:                        cfg,
 		kubeEnabled:                kubeEnabled,
 		extraMetadataLabels:        extraMetadataLabels,
+		extraSpanMetadataLabels:    extraSpanMetadataLabels,
 		hostID:                     ctxInfo.HostID,
 		clock:                      clock,
 		is:                         is,
@@ -576,25 +585,25 @@ func newReporter(
 				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
 				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
-			}, labelNamesSpans()).MetricVec, clock.Time, cfg.TTL)
+			}, labelNamesSpans(extraSpanMetadataLabels)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		spanMetricsCallsTotal: optionalCounterProvider(cfg.SpanMetricsEnabled(), func() *Expirer[prometheus.Counter] {
 			return NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: cfg.spanMetricsCallsName(),
 				Help: "number of service calls in trace span metrics format",
-			}, labelNamesSpans()).MetricVec, clock.Time, cfg.TTL)
+			}, labelNamesSpans(extraSpanMetadataLabels)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		spanMetricsRequestSizeTotal: optionalCounterProvider(cfg.SpanMetricsSizesEnabled(), func() *Expirer[prometheus.Counter] {
 			return NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: SpanMetricsRequestSizes,
 				Help: "size of service calls, in bytes, in trace span metrics format",
-			}, labelNamesSpans()).MetricVec, clock.Time, cfg.TTL)
+			}, labelNamesSpans(extraSpanMetadataLabels)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		spanMetricsResponseSizeTotal: optionalCounterProvider(cfg.SpanMetricsSizesEnabled(), func() *Expirer[prometheus.Counter] {
 			return NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 				Name: SpanMetricsResponseSizes,
 				Help: "size of service responses, in bytes, in trace span metrics format",
-			}, labelNamesSpans()).MetricVec, clock.Time, cfg.TTL)
+			}, labelNamesSpans(extraSpanMetadataLabels)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		tracesTargetInfo: optionalDirectGaugeProvider(cfg.AnySpanMetricsEnabled(), func() *prometheus.GaugeVec {
 			return prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -1036,12 +1045,28 @@ func appendK8sLabelValuesService(values []string, service *svc.Attrs) []string {
 	return values
 }
 
-func labelNamesSpans() []string {
-	return []string{serviceNameKey, serviceNamespaceKey, spanNameKey, statusCodeKey, spanKindKey, serviceInstanceKey, serviceJobKey, sourceKey, telemetryLanguageKey}
+func labelNamesSpans(extraMetadataLabelNames []attr.Name) []string {
+	names := []string{
+		serviceNameKey,
+		serviceNamespaceKey,
+		spanNameKey,
+		statusCodeKey,
+		spanKindKey,
+		serviceInstanceKey,
+		serviceJobKey,
+		sourceKey,
+		telemetryLanguageKey,
+	}
+
+	for _, mdn := range extraMetadataLabelNames {
+		names = append(names, mdn.Prom())
+	}
+
+	return names
 }
 
 func (r *metricsReporter) labelValuesSpans(span *request.Span) []string {
-	return []string{
+	values := []string{
 		span.Service.UID.Name,
 		span.Service.UID.Namespace,
 		span.TraceName(),
@@ -1052,6 +1077,12 @@ func (r *metricsReporter) labelValuesSpans(span *request.Span) []string {
 		attr.VendorPrefix,
 		span.Service.SDKLanguage.String(),
 	}
+
+	for _, k := range r.extraSpanMetadataLabels {
+		values = append(values, span.Service.Metadata[k])
+	}
+
+	return values
 }
 
 func labelNamesTargetInfo(kubeEnabled bool, extraMetadataLabelNames []attr.Name) []string {


### PR DESCRIPTION
This PR allows for users to configure extra resource attributes from trace spans to be added to the span metrics, allowing for more flexible metrics usage. For example, a custom resource attribute `service.version` can now be added to the span metrics.