### PR TITLE
Update OTEL_EBPF_PROMETHEUS_FEATURES comment

### DIFF
--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -114,7 +114,8 @@ type PrometheusConfig struct {
 
 	DisableBuildInfo bool `yaml:"disable_build_info" env:"OTEL_EBPF_PROMETHEUS_DISABLE_BUILD_INFO"`
 
-	// Features of metrics that can be exported. Accepted values are "application" and "network".
+	// Features of metrics that can be exported. Accepted values: application, network, application_process,
+	// application_span, application_service_graph, ...
 	Features []string `yaml:"features" env:"OTEL_EBPF_PROMETHEUS_FEATURES" envSeparator:","`
 	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
 	Instrumentations []string `yaml:"instrumentations" env:"OTEL_EBPF_PROMETHEUS_INSTRUMENTATIONS" envSeparator:","`


### PR DESCRIPTION
This PR updates the `OTEL_EBPF_PROMETHEUS_FEATURES` comment because we can add other values ​​besides "application" and "network" (same as `OTEL_EBPF_METRICS_FEATURES`).

Also, I noticed how the `export/prom` package uses variables like `Feature*` and `Buckets` declared in `export/otel/otelfcfg`. Technically, it would be more correct to create a `common.go `file at the `export` pkg level and include all the common elements between `prom` and `otel`, or something similar. What do you think? 