### PR TITLE
Bump to Golang 1.25.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the autoinstrumenter binary
-ARG TAG=0.2.2@sha256:e2adc24c661f612708f8627441f46fe24eb1c9dc37d4e4acf9bfab90f6ece510
+ARG TAG=0.2.3
 FROM ghcr.io/open-telemetry/obi-generator:${TAG} AS builder
 
 # TODO: embed software version in executable

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # The generator is a container image that provides a reproducible environment for
 # building eBPF binaries
-GEN_IMG ?= ghcr.io/open-telemetry/obi-generator:0.2.2
+GEN_IMG ?= ghcr.io/open-telemetry/obi-generator:0.2.3
 
 OCI_BIN ?= docker
 

--- a/configs/offsets/gin/go.mod
+++ b/configs/offsets/gin/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/gin
 
-go 1.25.4
+go 1.25.3
 
 require github.com/gin-gonic/gin v1.11.0
 

--- a/configs/offsets/kafkago/go.mod
+++ b/configs/offsets/kafkago/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/kafkago
 
-go 1.25.4
+go 1.25.3
 
 require github.com/segmentio/kafka-go v0.4.49
 

--- a/configs/offsets/mongo/go.mod
+++ b/configs/offsets/mongo/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/mongo
 
-go 1.25.4
+go 1.25.3
 
 require go.mongodb.org/mongo-driver v1.17.4
 

--- a/configs/offsets/mongov2/go.mod
+++ b/configs/offsets/mongov2/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/mongov2
 
-go 1.25.4
+go 1.25.3
 
 require go.mongodb.org/mongo-driver/v2 v2.3.1
 

--- a/configs/offsets/mux/go.mod
+++ b/configs/offsets/mux/go.mod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/obi/configs/offsets/mux
 
-go 1.25.4
+go 1.25.3
 
 require github.com/gorilla/mux v1.8.1

--- a/configs/offsets/otelsdk/go.mod
+++ b/configs/offsets/otelsdk/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/otelsdk
 
-go 1.25.4
+go 1.25.3
 
 require go.opentelemetry.io/otel v1.37.0
 

--- a/configs/offsets/redis/go.mod
+++ b/configs/offsets/redis/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/redis
 
-go 1.25.4
+go 1.25.3
 
 require github.com/redis/go-redis/v9 v9.14.1
 

--- a/configs/offsets/sarama/go.mod
+++ b/configs/offsets/sarama/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/sarama
 
-go 1.25.4
+go 1.25.3
 
 require github.com/IBM/sarama v1.46.2
 

--- a/configs/offsets/shopify/go.mod
+++ b/configs/offsets/shopify/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/shopify
 
-go 1.25.4
+go 1.25.3
 
 require github.com/Shopify/sarama v1.37.1
 

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.4-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS builder
+FROM golang:1.25.3-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS builder
 
 ARG TARGETARCH
 

--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.4-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS base
+FROM golang:1.25.3-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS base
 FROM base AS builder
 
 WORKDIR /build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi
 
-go 1.25.4
+go 1.25.3
 
 require (
 	github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396

--- a/internal/test/integration/components/ebpf-instrument-k8s-cache/Dockerfile
+++ b/internal/test/integration/components/ebpf-instrument-k8s-cache/Dockerfile
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/ebpf-instrument/Dockerfile
+++ b/internal/test/integration/components/ebpf-instrument/Dockerfile
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/ebpf-instrument/Dockerfile_dbg
+++ b/internal/test/integration/components/ebpf-instrument/Dockerfile_dbg
@@ -1,7 +1,7 @@
 # Development version of the beyla Dockerfile that compiles for coverage
 # and allows retrieving coverage files.
 # The production-ready minimal image is in the project root's dockerfile.
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/go_grpc_server_mux/Dockerfile
+++ b/internal/test/integration/components/go_grpc_server_mux/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/go_grpc_server_mux/Dockerfile_tls
+++ b/internal/test/integration/components/go_grpc_server_mux/Dockerfile_tls
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/go_grpc_server_mux/go.mod
+++ b/internal/test/integration/components/go_grpc_server_mux/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/go_grpc_server_mux
 
-go 1.25.4
+go 1.25.3
 
 require (
 	golang.org/x/net v0.38.0

--- a/internal/test/integration/components/go_otel/Dockerfile
+++ b/internal/test/integration/components/go_otel/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/go_otel/go.mod
+++ b/internal/test/integration/components/go_otel/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/go_otel
 
-go 1.25.4
+go 1.25.3
 
 require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0

--- a/internal/test/integration/components/go_otel_grpc/Dockerfile
+++ b/internal/test/integration/components/go_otel_grpc/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/go_otel_grpc/go.mod
+++ b/internal/test/integration/components/go_otel_grpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/go_otel_grpc
 
-go 1.25.4
+go 1.25.3
 
 require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.45.0

--- a/internal/test/integration/components/gohttp2/client/Dockerfile
+++ b/internal/test/integration/components/gohttp2/client/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testclient binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/gohttp2/client/go.mod
+++ b/internal/test/integration/components/gohttp2/client/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/go_http2/client
 
-go 1.25.4
+go 1.25.3
 
 require golang.org/x/net v0.38.0
 

--- a/internal/test/integration/components/gohttp2/server/Dockerfile
+++ b/internal/test/integration/components/gohttp2/server/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/gohttp2/server/go.mod
+++ b/internal/test/integration/components/gohttp2/server/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/go_http2/server
 
-go 1.25.4
+go 1.25.3
 
 require golang.org/x/net v0.38.0
 

--- a/internal/test/integration/components/gokafka-seg/Dockerfile
+++ b/internal/test/integration/components/gokafka-seg/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/gokafka-seg/go.mod
+++ b/internal/test/integration/components/gokafka-seg/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gokafka-seg
 
-go 1.25.4
+go 1.25.3
 
 require github.com/segmentio/kafka-go v0.4.49
 

--- a/internal/test/integration/components/gokafka/Dockerfile
+++ b/internal/test/integration/components/gokafka/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/gokafka/go.mod
+++ b/internal/test/integration/components/gokafka/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gokafka
 
-go 1.25.4
+go 1.25.3
 
 require github.com/IBM/sarama v1.43.2
 

--- a/internal/test/integration/components/gomongo/Dockerfile
+++ b/internal/test/integration/components/gomongo/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/gomongo/go.mod
+++ b/internal/test/integration/components/gomongo/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gomongo
 
-go 1.25.4
+go 1.25.3
 
 require go.mongodb.org/mongo-driver v1.17.4
 

--- a/internal/test/integration/components/gomongov2/Dockerfile
+++ b/internal/test/integration/components/gomongov2/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/gomongov2/go.mod
+++ b/internal/test/integration/components/gomongov2/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gomongov2
 
-go 1.25.4
+go 1.25.3
 
 require go.mongodb.org/mongo-driver/v2 v2.3.1
 

--- a/internal/test/integration/components/goredis/Dockerfile
+++ b/internal/test/integration/components/goredis/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/goredis/go.mod
+++ b/internal/test/integration/components/goredis/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/goredis
 
-go 1.25.4
+go 1.25.3
 
 require github.com/redis/go-redis/v9 v9.5.5
 

--- a/internal/test/integration/components/gosql/Dockerfile
+++ b/internal/test/integration/components/gosql/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/gosql/go.mod
+++ b/internal/test/integration/components/gosql/go.mod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gosql
 
-go 1.25.4
+go 1.25.3
 
 require github.com/lib/pq v1.10.9

--- a/internal/test/integration/components/grpcpinger/Dockerfile
+++ b/internal/test/integration/components/grpcpinger/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/httppinger/Dockerfile
+++ b/internal/test/integration/components/httppinger/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/old_grpc/backend/Dockerfile
+++ b/internal/test/integration/components/old_grpc/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 WORKDIR /src/go.opentelemetry.io/obi/internal/test/integration/components/old_grpc/
 

--- a/internal/test/integration/components/old_grpc/backend/go.mod
+++ b/internal/test/integration/components/old_grpc/backend/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/old_grpc/backend
 
-go 1.25.4
+go 1.25.3
 
 require (
 	github.com/caarlos0/env/v7 v7.1.0

--- a/internal/test/integration/components/old_grpc/backend/internal/distributed-service-example/Dockerfile
+++ b/internal/test/integration/components/old_grpc/backend/internal/distributed-service-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 WORKDIR /src
 

--- a/internal/test/integration/components/old_grpc/worker/Dockerfile
+++ b/internal/test/integration/components/old_grpc/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 WORKDIR /src
 

--- a/internal/test/integration/components/old_grpc/worker/go.mod
+++ b/internal/test/integration/components/old_grpc/worker/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/old_grpc/worker
 
-go 1.25.4
+go 1.25.3
 
 require (
 	github.com/caarlos0/env/v7 v7.1.0

--- a/internal/test/integration/components/pingclient/Dockerfile
+++ b/internal/test/integration/components/pingclient/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/sqlclient/Dockerfile
+++ b/internal/test/integration/components/sqlclient/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/sqlclient/go.mod
+++ b/internal/test/integration/components/sqlclient/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/sqlclient
 
-go 1.25.4
+go 1.25.3
 
 require modernc.org/sqlite v1.25.0
 

--- a/internal/test/integration/components/testserver/Dockerfile
+++ b/internal/test/integration/components/testserver/Dockerfile
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/testserver/Dockerfile_duplicate
+++ b/internal/test/integration/components/testserver/Dockerfile_duplicate
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/testserver/Dockerfile_nodebug
+++ b/internal/test/integration/components/testserver/Dockerfile_nodebug
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/testserver/Dockerfile_rename1
+++ b/internal/test/integration/components/testserver/Dockerfile_rename1
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/testserver/Dockerfile_static
+++ b/internal/test/integration/components/testserver/Dockerfile_static
@@ -1,6 +1,6 @@
 # Build the testserver binary
 # Docker command must be invoked from the projec root directory
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/oats/http/go.mod
+++ b/internal/test/oats/http/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/http
 
-go 1.25.4
+go 1.25.3
 
 require (
 	github.com/grafana/oats v0.0.3

--- a/internal/test/oats/kafka/go.mod
+++ b/internal/test/oats/kafka/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/kafka
 
-go 1.25.4
+go 1.25.3
 
 require (
 	github.com/grafana/oats v0.0.3

--- a/internal/test/oats/mongo/go.mod
+++ b/internal/test/oats/mongo/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/mongo
 
-go 1.25.4
+go 1.25.3
 
 require (
 	github.com/grafana/oats v0.0.3

--- a/internal/test/oats/redis/go.mod
+++ b/internal/test/oats/redis/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/redis
 
-go 1.25.4
+go 1.25.3
 
 require (
 	github.com/grafana/oats v0.0.3

--- a/internal/test/oats/sql/go.mod
+++ b/internal/test/oats/sql/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/sql
 
-go 1.25.4
+go 1.25.3
 
 require (
 	github.com/grafana/oats v0.0.3

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/tools
 
-go 1.25.4
+go 1.25.3
 
 require (
 	github.com/cilium/ebpf v0.20.0

--- a/k8scache.Dockerfile
+++ b/k8scache.Dockerfile
@@ -1,5 +1,5 @@
 # Build the binary for the k8s-cache service
-FROM golang:1.25.4@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
+FROM golang:1.25.3@sha256:1a13867f40c6ba8c3e7c07ab5fa921cb58cf8402bcbe452f4d41cd614655e700 AS builder
 
 ARG TARGETARCH
 ENV GOARCH=$TARGETARCH


### PR DESCRIPTION
Security scans detected vulnerabilites of serverity high for Go version 1.25.
Bumping to 1.25.3 fixes the CVEs