### PR TITLE
Metric features: replace string by otelcfg.MetricFeature type

### DIFF
--- a/pkg/appolly/instrumenter_test.go
+++ b/pkg/appolly/instrumenter_test.go
@@ -73,7 +73,7 @@ func TestBasicPipeline(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	cfg := otelcfg.MetricsConfig{
-		Features:        []string{otelcfg.FeatureApplication},
+		Features:        []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 		ReportersCacheLen: 16,
 		TTL:               5 * time.Minute,
@@ -192,7 +192,7 @@ func TestMergedMetricsTracePipeline(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	mCfg := otelcfg.MetricsConfig{
-		Features:        []string{otelcfg.FeatureApplication},
+		Features:        []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 		ReportersCacheLen: 16,
 		TTL:               5 * time.Minute,
@@ -281,7 +281,7 @@ func TestRouteConsolidation(t *testing.T) {
 
 	cfg := otelcfg.MetricsConfig{
 		SDKLogLevel:     "debug",
-		Features:        []string{otelcfg.FeatureApplication},
+		Features:        []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 		ReportersCacheLen: 16,
 		TTL:               5 * time.Minute,
@@ -415,7 +415,7 @@ func TestGRPCPipeline(t *testing.T) {
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 
 	cfg := otelcfg.MetricsConfig{
-		Features:        []string{otelcfg.FeatureApplication},
+		Features:        []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint, Interval: time.Millisecond,
 		ReportersCacheLen: 16,
 		TTL:               5 * time.Minute,
@@ -513,7 +513,7 @@ func TestBasicPipelineInfo(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	cfg := otelcfg.MetricsConfig{
-		Features:        []string{otelcfg.FeatureApplication},
+		Features:        []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint,
 		Interval:        10 * time.Millisecond, ReportersCacheLen: 16,
 		TTL: 5 * time.Minute,
@@ -608,7 +608,7 @@ func TestSpanAttributeFilterNode(t *testing.T) {
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	cfg := otelcfg.MetricsConfig{
 		SDKLogLevel:     "debug",
-		Features:        []string{otelcfg.FeatureApplication},
+		Features:        []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 		ReportersCacheLen: 16,
 		TTL:               5 * time.Minute,

--- a/pkg/export/otel/expirer_test.go
+++ b/pkg/export/otel/expirer_test.go
@@ -42,7 +42,7 @@ func TestNetMetricsExpiration(t *testing.T) {
 		Interval:        50 * time.Millisecond,
 		CommonEndpoint:  otlp.ServerEndpoint,
 		MetricsProtocol: otelcfg.ProtocolHTTPProtobuf,
-		Features:        []string{otelcfg.FeatureNetwork},
+		Features:        []otelcfg.MetricFeature{otelcfg.FeatureNetwork},
 		TTL:             3 * time.Minute,
 		Instrumentations: []string{
 			instrumentations.InstrumentationALL,
@@ -167,7 +167,7 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 		Interval:          50 * time.Millisecond,
 		CommonEndpoint:    otlp.ServerEndpoint,
 		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
-		Features:          []string{otelcfg.FeatureApplication},
+		Features:          []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 		TTL:               3 * time.Minute,
 		ReportersCacheLen: 100,
 		Instrumentations: []string{
@@ -306,7 +306,7 @@ func TestAppMetricsExpiration_BySvcID(t *testing.T) {
 		Interval:          50 * time.Millisecond,
 		CommonEndpoint:    otlp.ServerEndpoint,
 		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
-		Features:          []string{otelcfg.FeatureApplication},
+		Features:          []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 		TTL:               3 * time.Minute,
 		ReportersCacheLen: 100,
 		Instrumentations: []string{

--- a/pkg/export/otel/metrics_net_test.go
+++ b/pkg/export/otel/metrics_net_test.go
@@ -48,7 +48,7 @@ func TestMetricAttributes(t *testing.T) {
 		Interval:          10 * time.Millisecond,
 		ReportersCacheLen: 100,
 		TTL:               5 * time.Minute,
-		Features:          []string{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
+		Features:          []otelcfg.MetricFeature{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
 	}
 	me, err := newMetricsExporter(t.Context(), &global.ContextInfo{
 		MetricAttributeGroups: attributes.GroupKubernetes,
@@ -107,7 +107,7 @@ func TestMetricAttributes_Filter(t *testing.T) {
 		MetricsEndpoint:   "http://foo",
 		Interval:          10 * time.Millisecond,
 		ReportersCacheLen: 100,
-		Features:          []string{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
+		Features:          []otelcfg.MetricFeature{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
 	}
 	me, err := newMetricsExporter(t.Context(), &global.ContextInfo{
 		MetricAttributeGroups: attributes.GroupKubernetes,
@@ -147,16 +147,16 @@ func TestMetricAttributes_Filter(t *testing.T) {
 
 func TestNetMetricsConfig_Enabled(t *testing.T) {
 	assert.True(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{
-		Features: []string{otelcfg.FeatureApplication, otelcfg.FeatureNetwork}, CommonEndpoint: "foo",
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureApplication, otelcfg.FeatureNetwork}, CommonEndpoint: "foo",
 	}}.Enabled())
 	assert.True(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{
-		Features: []string{otelcfg.FeatureNetwork, otelcfg.FeatureApplication}, MetricsEndpoint: "foo",
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureNetwork, otelcfg.FeatureApplication}, MetricsEndpoint: "foo",
 	}}.Enabled())
 }
 
 func TestNetMetricsConfig_Disabled(t *testing.T) {
-	fa := []string{otelcfg.FeatureApplication}
-	fn := []string{otelcfg.FeatureNetwork}
+	fa := []otelcfg.MetricFeature{otelcfg.FeatureApplication}
+	fn := []otelcfg.MetricFeature{otelcfg.FeatureNetwork}
 	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{Features: fn}}.Enabled())
 	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{Features: fn}}.Enabled())
 	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{Features: fn}}.Enabled())

--- a/pkg/export/otel/metrics_svc_graph_test.go
+++ b/pkg/export/otel/metrics_svc_graph_test.go
@@ -86,7 +86,7 @@ func makeSvcGraphExporter(
 		Interval:          50 * time.Millisecond,
 		CommonEndpoint:    otlp.ServerEndpoint,
 		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
-		Features:          []string{otelcfg.FeatureGraph},
+		Features:          []otelcfg.MetricFeature{otelcfg.FeatureGraph},
 		TTL:               30 * time.Minute,
 		ReportersCacheLen: 100,
 		Instrumentations:  []string{instrumentations.InstrumentationALL},

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -56,7 +56,7 @@ func TestMetrics_InternalInstrumentation(t *testing.T) {
 	internalMetrics := &fakeInternalMetrics{}
 	mcfg := &otelcfg.MetricsConfig{
 		CommonEndpoint: coll.URL, Interval: 10 * time.Millisecond, ReportersCacheLen: 16,
-		Features: []string{otelcfg.FeatureApplication}, Instrumentations: []string{instrumentations.InstrumentationHTTP},
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureApplication}, Instrumentations: []string{instrumentations.InstrumentationHTTP},
 	}
 	reporter, err := ReportMetrics(&global.ContextInfo{
 		Metrics:             internalMetrics,
@@ -240,7 +240,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 
 			metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
 			processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
-			otelExporter := makeMetricsReporter(ctx, t, tt.instr, []string{otelcfg.FeatureApplication}, otlp, metrics, processEvents).reportMetrics
+			otelExporter := makeMetricsReporter(ctx, t, tt.instr, []otelcfg.MetricFeature{otelcfg.FeatureApplication}, otlp, metrics, processEvents).reportMetrics
 			require.NoError(t, err)
 
 			go otelExporter(ctx)
@@ -306,7 +306,7 @@ func TestAppMetrics_ResourceAttributes(t *testing.T) {
 
 	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
-	otelExporter := makeMetricsReporter(ctx, t, []string{instrumentations.InstrumentationHTTP}, []string{otelcfg.FeatureApplication}, otlp, metrics, processEvents).reportMetrics
+	otelExporter := makeMetricsReporter(ctx, t, []string{instrumentations.InstrumentationHTTP}, []otelcfg.MetricFeature{otelcfg.FeatureApplication}, otlp, metrics, processEvents).reportMetrics
 	go otelExporter(ctx)
 
 	metrics.Send([]request.Span{
@@ -322,7 +322,7 @@ func TestAppMetrics_ResourceAttributes(t *testing.T) {
 
 func TestMetricsDiscarded(t *testing.T) {
 	mc := otelcfg.MetricsConfig{
-		Features: []string{otelcfg.FeatureApplication},
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 	}
 	mr := MetricsReporter{
 		cfg: &mc,
@@ -367,7 +367,7 @@ func TestMetricsDiscarded(t *testing.T) {
 
 func TestSpanMetricsDiscarded(t *testing.T) {
 	mc := otelcfg.MetricsConfig{
-		Features: []string{otelcfg.FeatureSpan},
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureSpan},
 	}
 	mr := MetricsReporter{
 		cfg: &mc,
@@ -412,7 +412,7 @@ func TestSpanMetricsDiscarded(t *testing.T) {
 
 func TestSpanMetricsDiscardedGraph(t *testing.T) {
 	mc := otelcfg.MetricsConfig{
-		Features: []string{otelcfg.FeatureGraph},
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureGraph},
 	}
 	mr := MetricsReporter{
 		cfg: &mc,
@@ -457,7 +457,7 @@ func TestSpanMetricsDiscardedGraph(t *testing.T) {
 
 func TestProcessPIDEvents(t *testing.T) {
 	mc := otelcfg.MetricsConfig{
-		Features: []string{otelcfg.FeatureApplication},
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 	}
 	mr := MetricsReporter{
 		cfg:        &mc,
@@ -537,7 +537,7 @@ func readNChan(t require.TestingT, inCh <-chan collector.MetricRecord, numRecord
 }
 
 func makeMetricsReporter(
-	ctx context.Context, t *testing.T, instrumentations []string, features []string, otlp *collector.TestCollector,
+	ctx context.Context, t *testing.T, instrumentations []string, features []otelcfg.MetricFeature, otlp *collector.TestCollector,
 	input *msg.Queue[[]request.Span], processEvents *msg.Queue[exec.ProcessEvent],
 ) *MetricsReporter {
 	mcfg := &otelcfg.MetricsConfig{
@@ -579,7 +579,7 @@ func TestAppMetrics_TracesHostInfo(t *testing.T) {
 
 	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
-	mr := makeMetricsReporter(ctx, t, []string{instrumentations.InstrumentationHTTP}, []string{otelcfg.FeatureApplication, otelcfg.FeatureApplicationHost}, otlp, metrics, processEvents)
+	mr := makeMetricsReporter(ctx, t, []string{instrumentations.InstrumentationHTTP}, []otelcfg.MetricFeature{otelcfg.FeatureApplication, otelcfg.FeatureApplicationHost}, otlp, metrics, processEvents)
 	otelExporter := mr.reportMetrics
 	go otelExporter(ctx)
 

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -58,20 +58,22 @@ const (
 	envResourceAttrs   = "OTEL_RESOURCE_ATTRIBUTES"
 )
 
+type MetricFeature string
+
 const (
 	UsualPortGRPC = "4317"
 	UsualPortHTTP = "4318"
 
-	FeatureNetwork          = "network"
-	FeatureNetworkInterZone = "network_inter_zone"
-	FeatureApplication      = "application"
-	FeatureSpan             = "application_span"
-	FeatureSpanOTel         = "application_span_otel"
-	FeatureSpanSizes        = "application_span_sizes"
-	FeatureGraph            = "application_service_graph"
-	FeatureProcess          = "application_process"
-	FeatureApplicationHost  = "application_host"
-	FeatureEBPF             = "ebpf"
+	FeatureNetwork          MetricFeature = "network"
+	FeatureNetworkInterZone MetricFeature = "network_inter_zone"
+	FeatureApplication      MetricFeature = "application"
+	FeatureSpan             MetricFeature = "application_span"
+	FeatureSpanOTel         MetricFeature = "application_span_otel"
+	FeatureSpanSizes        MetricFeature = "application_span_sizes"
+	FeatureGraph            MetricFeature = "application_service_graph"
+	FeatureProcess          MetricFeature = "application_process"
+	FeatureApplicationHost  MetricFeature = "application_host"
+	FeatureEBPF             MetricFeature = "ebpf"
 )
 
 func omitFieldsForYAML(input any, omitFields map[string]struct{}) map[string]any {

--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -45,7 +45,7 @@ type MetricsConfig struct {
 	// Features of metrics that can be exported. Accepted values: application, network, application_process,
 	// application_span, application_service_graph, ...
 	// envDefault is provided to avoid breaking changes
-	Features []string `yaml:"features" env:"OTEL_EBPF_METRICS_FEATURES,expand" envDefault:"${OTEL_EBPF_METRIC_FEATURES}"  envSeparator:","`
+	Features []MetricFeature `yaml:"features" env:"OTEL_EBPF_METRICS_FEATURES,expand" envDefault:"${OTEL_EBPF_METRIC_FEATURES}"  envSeparator:","`
 
 	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
 	Instrumentations []string `yaml:"instrumentations" env:"OTEL_EBPF_METRICS_INSTRUMENTATIONS" envSeparator:","`

--- a/pkg/export/otel/otelcfg/config_metrics_test.go
+++ b/pkg/export/otel/otelcfg/config_metrics_test.go
@@ -208,28 +208,28 @@ func TestMetricSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 }
 
 func TestMetricsConfig_Enabled(t *testing.T) {
-	assert.True(t, (&MetricsConfig{Features: []string{FeatureApplication, FeatureNetwork}, CommonEndpoint: "foo"}).Enabled())
-	assert.True(t, (&MetricsConfig{Features: []string{FeatureApplication}, MetricsEndpoint: "foo"}).Enabled())
-	assert.True(t, (&MetricsConfig{MetricsEndpoint: "foo", Features: []string{FeatureNetwork}}).Enabled())
+	assert.True(t, (&MetricsConfig{Features: []MetricFeature{FeatureApplication, FeatureNetwork}, CommonEndpoint: "foo"}).Enabled())
+	assert.True(t, (&MetricsConfig{Features: []MetricFeature{FeatureApplication}, MetricsEndpoint: "foo"}).Enabled())
+	assert.True(t, (&MetricsConfig{MetricsEndpoint: "foo", Features: []MetricFeature{FeatureNetwork}}).Enabled())
 	assert.True(t, (&MetricsConfig{
-		Features:             []string{FeatureNetwork},
+		Features:             []MetricFeature{FeatureNetwork},
 		OTLPEndpointProvider: func() (string, bool) { return "something", false },
 	}).Enabled())
 	assert.True(t, (&MetricsConfig{
-		Features:             []string{FeatureNetwork},
+		Features:             []MetricFeature{FeatureNetwork},
 		OTLPEndpointProvider: func() (string, bool) { return "something", true },
 	}).Enabled())
 }
 
 func TestMetricsConfig_Disabled(t *testing.T) {
-	assert.False(t, (&MetricsConfig{Features: []string{FeatureApplication}}).Enabled())
-	assert.False(t, (&MetricsConfig{Features: []string{FeatureNetwork, FeatureApplication}}).Enabled())
-	assert.False(t, (&MetricsConfig{Features: []string{FeatureNetwork}}).Enabled())
+	assert.False(t, (&MetricsConfig{Features: []MetricFeature{FeatureApplication}}).Enabled())
+	assert.False(t, (&MetricsConfig{Features: []MetricFeature{FeatureNetwork, FeatureApplication}}).Enabled())
+	assert.False(t, (&MetricsConfig{Features: []MetricFeature{FeatureNetwork}}).Enabled())
 	// application feature is not enabled
 	assert.False(t, (&MetricsConfig{CommonEndpoint: "foo"}).Enabled())
 	assert.False(t, (&MetricsConfig{}).Enabled())
 	assert.False(t, (&MetricsConfig{
-		Features:             []string{FeatureApplication},
+		Features:             []MetricFeature{FeatureApplication},
 		OTLPEndpointProvider: func() (string, bool) { return "", false },
 	}).Enabled())
 }

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -565,7 +565,7 @@ func TestTraceSkipSpanMetrics(t *testing.T) {
 
 	t.Run("test with span metrics on", func(t *testing.T) {
 		mc := otelcfg.MetricsConfig{
-			Features: []string{otelcfg.FeatureSpan},
+			Features: []otelcfg.MetricFeature{otelcfg.FeatureSpan},
 		}
 
 		receiver := makeTracesTestReceiverWithSpanMetrics(mc.AnySpanMetricsEnabled(), []string{"http"})

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -116,7 +116,7 @@ type PrometheusConfig struct {
 
 	// Features of metrics that can be exported. Accepted values: application, network, application_process,
 	// application_span, application_service_graph, ...
-	Features []string `yaml:"features" env:"OTEL_EBPF_PROMETHEUS_FEATURES" envSeparator:","`
+	Features []otelcfg.MetricFeature `yaml:"features" env:"OTEL_EBPF_PROMETHEUS_FEATURES" envSeparator:","`
 	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
 	Instrumentations []string `yaml:"instrumentations" env:"OTEL_EBPF_PROMETHEUS_INSTRUMENTATIONS" envSeparator:","`
 

--- a/pkg/export/prom/prom_net_test.go
+++ b/pkg/export/prom/prom_net_test.go
@@ -40,7 +40,7 @@ func TestMetricsExpiration(t *testing.T) {
 			Path:                        "/metrics",
 			TTL:                         3 * time.Minute,
 			SpanMetricsServiceCacheSize: 10,
-			Features:                    []string{otelcfg.FeatureNetwork},
+			Features:                    []otelcfg.MetricFeature{otelcfg.FeatureNetwork},
 		}, SelectorCfg: &attributes.SelectorConfig{
 			SelectionCfg: attributes.Selection{
 				attributes.NetworkFlow.Section: attributes.InclusionLists{

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -65,7 +65,7 @@ func TestAppMetricsExpiration(t *testing.T) {
 			Path:                        "/metrics",
 			TTL:                         3 * time.Minute,
 			SpanMetricsServiceCacheSize: 10,
-			Features:                    []string{otelcfg.FeatureApplication, otelcfg.FeatureApplicationHost},
+			Features:                    []otelcfg.MetricFeature{otelcfg.FeatureApplication, otelcfg.FeatureApplicationHost},
 			Instrumentations:            []string{instrumentations.InstrumentationALL},
 		},
 		&attributes.SelectorConfig{
@@ -390,7 +390,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 
 func TestMetricsDiscarded(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []string{otelcfg.FeatureApplication},
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 	}
 	mr := metricsReporter{
 		cfg: &mc,
@@ -444,7 +444,7 @@ func TestMetricsDiscarded(t *testing.T) {
 
 func TestSpanMetricsDiscarded(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []string{otelcfg.FeatureSpanOTel},
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureSpanOTel},
 	}
 	mr := metricsReporter{
 		cfg: &mc,
@@ -490,7 +490,7 @@ func TestSpanMetricsDiscarded(t *testing.T) {
 
 func TestSpanMetricsDiscardedGraph(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []string{otelcfg.FeatureGraph},
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureGraph},
 	}
 	mr := metricsReporter{
 		cfg: &mc,
@@ -580,7 +580,7 @@ func TestTerminatesOnBadPromPort(t *testing.T) {
 
 func TestProcessPIDEvents(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []string{otelcfg.FeatureApplication},
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 	}
 	mr := metricsReporter{
 		cfg:         &mc,
@@ -670,7 +670,7 @@ func makePromExporter(
 			Path:                        "/metrics",
 			TTL:                         300 * time.Minute,
 			SpanMetricsServiceCacheSize: 10,
-			Features:                    []string{otelcfg.FeatureApplication},
+			Features:                    []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 			Instrumentations:            instrumentations,
 		},
 		&attributes.SelectorConfig{

--- a/pkg/netolly/agent/pipeline_test.go
+++ b/pkg/netolly/agent/pipeline_test.go
@@ -46,7 +46,7 @@ func TestFilter(t *testing.T) {
 			Prometheus: prom.PrometheusConfig{
 				Path:     "/metrics",
 				Port:     promPort,
-				Features: []string{otelcfg.FeatureNetwork},
+				Features: []otelcfg.MetricFeature{otelcfg.FeatureNetwork},
 				TTL:      time.Hour,
 			},
 			Filters: filter.AttributesConfig{

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -120,7 +120,7 @@ var DefaultConfig = Config{
 		Buckets:              otelcfg.DefaultBuckets,
 		ReportersCacheLen:    ReporterLRUSize,
 		HistogramAggregation: otel.AggregationExplicit,
-		Features:             []string{otelcfg.FeatureApplication},
+		Features:             []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 		Instrumentations: []string{
 			instrumentations.InstrumentationALL,
 		},
@@ -145,7 +145,7 @@ var DefaultConfig = Config{
 	Prometheus: prom.PrometheusConfig{
 		Path:     "/metrics",
 		Buckets:  otelcfg.DefaultBuckets,
-		Features: []string{otelcfg.FeatureApplication},
+		Features: []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 		Instrumentations: []string{
 			instrumentations.InstrumentationALL,
 		},

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -154,7 +154,7 @@ discovery:
 				RequestSizeHistogram:  otelcfg.DefaultBuckets.RequestSizeHistogram,
 				ResponseSizeHistogram: otelcfg.DefaultBuckets.ResponseSizeHistogram,
 			},
-			Features: []string{"application"},
+			Features: []otelcfg.MetricFeature{"application"},
 			Instrumentations: []string{
 				instrumentations.InstrumentationALL,
 			},
@@ -180,7 +180,7 @@ discovery:
 		},
 		Prometheus: prom.PrometheusConfig{
 			Path:     "/metrics",
-			Features: []string{otelcfg.FeatureApplication},
+			Features: []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 			Instrumentations: []string{
 				instrumentations.InstrumentationALL,
 			},
@@ -617,7 +617,7 @@ func TestConfig_SpanMetricsEnabledForTraces(t *testing.T) {
 			name: "otel metrics enabled, but not spans",
 			metrics: otelcfg.MetricsConfig{
 				MetricsEndpoint: "http://localhost:4318/v1/metrics",
-				Features:        []string{otelcfg.FeatureApplication},
+				Features:        []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 			},
 			prometheus:  prom.PrometheusConfig{},
 			wantEnabled: false,
@@ -626,7 +626,7 @@ func TestConfig_SpanMetricsEnabledForTraces(t *testing.T) {
 			name: "otel metrics enabled with spans",
 			metrics: otelcfg.MetricsConfig{
 				MetricsEndpoint: "http://localhost:4318/v1/metrics",
-				Features:        []string{otelcfg.FeatureSpanOTel},
+				Features:        []otelcfg.MetricFeature{otelcfg.FeatureSpanOTel},
 			},
 			prometheus:  prom.PrometheusConfig{},
 			wantEnabled: true,
@@ -636,7 +636,7 @@ func TestConfig_SpanMetricsEnabledForTraces(t *testing.T) {
 			metrics: otelcfg.MetricsConfig{},
 			prometheus: prom.PrometheusConfig{
 				Port:     9090,
-				Features: []string{otelcfg.FeatureApplication},
+				Features: []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 			},
 			wantEnabled: false,
 		},
@@ -645,17 +645,17 @@ func TestConfig_SpanMetricsEnabledForTraces(t *testing.T) {
 			metrics: otelcfg.MetricsConfig{},
 			prometheus: prom.PrometheusConfig{
 				Port:     9090,
-				Features: []string{otelcfg.FeatureGraph},
+				Features: []otelcfg.MetricFeature{otelcfg.FeatureGraph},
 			},
 			wantEnabled: true,
 		},
 		{
 			name: "both have features, but not enabled",
 			metrics: otelcfg.MetricsConfig{
-				Features: []string{otelcfg.FeatureApplication},
+				Features: []otelcfg.MetricFeature{otelcfg.FeatureApplication},
 			},
 			prometheus: prom.PrometheusConfig{
-				Features: []string{otelcfg.FeatureGraph},
+				Features: []otelcfg.MetricFeature{otelcfg.FeatureGraph},
 			},
 			wantEnabled: false,
 		},

--- a/pkg/transform/span_name_limiter_test.go
+++ b/pkg/transform/span_name_limiter_test.go
@@ -31,8 +31,8 @@ func TestSpanNameLimiter(t *testing.T) {
 	outCh := output.Subscribe()
 	runSpanNameLimiter, err := SpanNameLimiter(SpanNameLimiterConfig{
 		Limit: maxCardinalityBeforeAggregation,
-		OTEL:  &otelcfg.MetricsConfig{Features: []string{otelcfg.FeatureSpan}, TTL: time.Minute},
-		Prom:  &prom.PrometheusConfig{Features: []string{otelcfg.FeatureSpan}, TTL: time.Minute},
+		OTEL:  &otelcfg.MetricsConfig{Features: []otelcfg.MetricFeature{otelcfg.FeatureSpan}, TTL: time.Minute},
+		Prom:  &prom.PrometheusConfig{Features: []otelcfg.MetricFeature{otelcfg.FeatureSpan}, TTL: time.Minute},
 	}, input, output)(t.Context())
 	require.NoError(t, err)
 
@@ -116,8 +116,8 @@ func TestSpanNameLimiter_ExpireOld(t *testing.T) {
 		outCh := output.Subscribe()
 		runSpanNameLimiter, err := SpanNameLimiter(SpanNameLimiterConfig{
 			Limit: maxCardinalityBeforeAggregation,
-			OTEL:  &otelcfg.MetricsConfig{Features: []string{otelcfg.FeatureSpan}, TTL: time.Minute},
-			Prom:  &prom.PrometheusConfig{Features: []string{otelcfg.FeatureSpan}, TTL: time.Minute},
+			OTEL:  &otelcfg.MetricsConfig{Features: []otelcfg.MetricFeature{otelcfg.FeatureSpan}, TTL: time.Minute},
+			Prom:  &prom.PrometheusConfig{Features: []otelcfg.MetricFeature{otelcfg.FeatureSpan}, TTL: time.Minute},
 		}, input, output)(t.Context())
 		require.NoError(t, err)
 
@@ -180,8 +180,8 @@ func TestSpanNameLimiter_CopiesOutput(t *testing.T) {
 	outCh := output.Subscribe()
 	runSpanNameLimiter, err := SpanNameLimiter(SpanNameLimiterConfig{
 		Limit: 3,
-		OTEL:  &otelcfg.MetricsConfig{Features: []string{otelcfg.FeatureSpan}, TTL: time.Minute},
-		Prom:  &prom.PrometheusConfig{Features: []string{otelcfg.FeatureSpan}, TTL: time.Minute},
+		OTEL:  &otelcfg.MetricsConfig{Features: []otelcfg.MetricFeature{otelcfg.FeatureSpan}, TTL: time.Minute},
+		Prom:  &prom.PrometheusConfig{Features: []otelcfg.MetricFeature{otelcfg.FeatureSpan}, TTL: time.Minute},
 	}, input, output)(t.Context())
 	require.NoError(t, err)
 


### PR DESCRIPTION
Adds an extra bit of type safety.