### PR TITLE
Move Buckets and Feature definitions to pkg/export

### DIFF
--- a/pkg/appolly/instrumenter_test.go
+++ b/pkg/appolly/instrumenter_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
@@ -73,7 +74,7 @@ func TestBasicPipeline(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	cfg := otelcfg.MetricsConfig{
-		Features:        []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features:        []export.Feature{export.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 		ReportersCacheLen: 16,
 		TTL:               5 * time.Minute,
@@ -192,7 +193,7 @@ func TestMergedMetricsTracePipeline(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	mCfg := otelcfg.MetricsConfig{
-		Features:        []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features:        []export.Feature{export.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 		ReportersCacheLen: 16,
 		TTL:               5 * time.Minute,
@@ -281,7 +282,7 @@ func TestRouteConsolidation(t *testing.T) {
 
 	cfg := otelcfg.MetricsConfig{
 		SDKLogLevel:     "debug",
-		Features:        []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features:        []export.Feature{export.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 		ReportersCacheLen: 16,
 		TTL:               5 * time.Minute,
@@ -415,7 +416,7 @@ func TestGRPCPipeline(t *testing.T) {
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 
 	cfg := otelcfg.MetricsConfig{
-		Features:        []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features:        []export.Feature{export.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint, Interval: time.Millisecond,
 		ReportersCacheLen: 16,
 		TTL:               5 * time.Minute,
@@ -513,7 +514,7 @@ func TestBasicPipelineInfo(t *testing.T) {
 	tracesInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	cfg := otelcfg.MetricsConfig{
-		Features:        []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features:        []export.Feature{export.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint,
 		Interval:        10 * time.Millisecond, ReportersCacheLen: 16,
 		TTL: 5 * time.Minute,
@@ -608,7 +609,7 @@ func TestSpanAttributeFilterNode(t *testing.T) {
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
 	cfg := otelcfg.MetricsConfig{
 		SDKLogLevel:     "debug",
-		Features:        []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features:        []export.Feature{export.FeatureApplication},
 		MetricsEndpoint: tc.ServerEndpoint, Interval: 10 * time.Millisecond,
 		ReportersCacheLen: 16,
 		TTL:               5 * time.Minute,

--- a/pkg/export/bucket.go
+++ b/pkg/export/bucket.go
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package export
+
+// Buckets defines the histograms bucket boundaries, and allows users to
+// redefine them
+type Buckets struct {
+	DurationHistogram     []float64 `yaml:"duration_histogram"`
+	RequestSizeHistogram  []float64 `yaml:"request_size_histogram"`
+	ResponseSizeHistogram []float64 `yaml:"response_size_histogram"`
+}
+
+var DefaultBuckets = Buckets{
+	// Default values as specified in the OTEL specification
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md
+	DurationHistogram: []float64{0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10},
+
+	RequestSizeHistogram:  []float64{0, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192},
+	ResponseSizeHistogram: []float64{0, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192},
+}

--- a/pkg/export/feature.go
+++ b/pkg/export/feature.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package export
+
+type Feature string
+
+const (
+	FeatureNetwork          Feature = "network"
+	FeatureNetworkInterZone Feature = "network_inter_zone"
+	FeatureApplication      Feature = "application"
+	FeatureSpan             Feature = "application_span"
+	FeatureSpanOTel         Feature = "application_span_otel"
+	FeatureSpanSizes        Feature = "application_span_sizes"
+	FeatureGraph            Feature = "application_service_graph"
+	FeatureProcess          Feature = "application_process"
+	FeatureApplicationHost  Feature = "application_host"
+	FeatureEBPF             Feature = "ebpf"
+)

--- a/pkg/export/otel/expirer_test.go
+++ b/pkg/export/otel/expirer_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
@@ -42,7 +43,7 @@ func TestNetMetricsExpiration(t *testing.T) {
 		Interval:        50 * time.Millisecond,
 		CommonEndpoint:  otlp.ServerEndpoint,
 		MetricsProtocol: otelcfg.ProtocolHTTPProtobuf,
-		Features:        []otelcfg.Feature{otelcfg.FeatureNetwork},
+		Features:        []export.Feature{export.FeatureNetwork},
 		TTL:             3 * time.Minute,
 		Instrumentations: []instrumentations.Instrumentation{
 			instrumentations.InstrumentationALL,
@@ -167,7 +168,7 @@ func TestAppMetricsExpiration_ByMetricAttrs(t *testing.T) {
 		Interval:          50 * time.Millisecond,
 		CommonEndpoint:    otlp.ServerEndpoint,
 		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
-		Features:          []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features:          []export.Feature{export.FeatureApplication},
 		TTL:               3 * time.Minute,
 		ReportersCacheLen: 100,
 		Instrumentations: []instrumentations.Instrumentation{
@@ -306,7 +307,7 @@ func TestAppMetricsExpiration_BySvcID(t *testing.T) {
 		Interval:          50 * time.Millisecond,
 		CommonEndpoint:    otlp.ServerEndpoint,
 		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
-		Features:          []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features:          []export.Feature{export.FeatureApplication},
 		TTL:               3 * time.Minute,
 		ReportersCacheLen: 100,
 		Instrumentations: []instrumentations.Instrumentation{

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
@@ -365,7 +366,7 @@ func (mr *MetricsReporter) otelMetricOptions(mlog *slog.Logger) []metric.Option 
 }
 
 func (mr *MetricsReporter) usesLegacySpanNames() bool {
-	return slices.Contains(mr.cfg.Features, otelcfg.FeatureSpan)
+	return slices.Contains(mr.cfg.Features, export.FeatureSpan)
 }
 
 func (mr *MetricsReporter) spanMetricsLatencyName() string {

--- a/pkg/export/otel/metrics_net_test.go
+++ b/pkg/export/otel/metrics_net_test.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
@@ -48,7 +49,7 @@ func TestMetricAttributes(t *testing.T) {
 		Interval:          10 * time.Millisecond,
 		ReportersCacheLen: 100,
 		TTL:               5 * time.Minute,
-		Features:          []otelcfg.Feature{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
+		Features:          []export.Feature{export.FeatureNetwork, export.FeatureNetworkInterZone},
 	}
 	me, err := newMetricsExporter(t.Context(), &global.ContextInfo{
 		MetricAttributeGroups: attributes.GroupKubernetes,
@@ -107,7 +108,7 @@ func TestMetricAttributes_Filter(t *testing.T) {
 		MetricsEndpoint:   "http://foo",
 		Interval:          10 * time.Millisecond,
 		ReportersCacheLen: 100,
-		Features:          []otelcfg.Feature{otelcfg.FeatureNetwork, otelcfg.FeatureNetworkInterZone},
+		Features:          []export.Feature{export.FeatureNetwork, export.FeatureNetworkInterZone},
 	}
 	me, err := newMetricsExporter(t.Context(), &global.ContextInfo{
 		MetricAttributeGroups: attributes.GroupKubernetes,
@@ -147,16 +148,16 @@ func TestMetricAttributes_Filter(t *testing.T) {
 
 func TestNetMetricsConfig_Enabled(t *testing.T) {
 	assert.True(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{
-		Features: []otelcfg.Feature{otelcfg.FeatureApplication, otelcfg.FeatureNetwork}, CommonEndpoint: "foo",
+		Features: []export.Feature{export.FeatureApplication, export.FeatureNetwork}, CommonEndpoint: "foo",
 	}}.Enabled())
 	assert.True(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{
-		Features: []otelcfg.Feature{otelcfg.FeatureNetwork, otelcfg.FeatureApplication}, MetricsEndpoint: "foo",
+		Features: []export.Feature{export.FeatureNetwork, export.FeatureApplication}, MetricsEndpoint: "foo",
 	}}.Enabled())
 }
 
 func TestNetMetricsConfig_Disabled(t *testing.T) {
-	fa := []otelcfg.Feature{otelcfg.FeatureApplication}
-	fn := []otelcfg.Feature{otelcfg.FeatureNetwork}
+	fa := []export.Feature{export.FeatureApplication}
+	fn := []export.Feature{export.FeatureNetwork}
 	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{Features: fn}}.Enabled())
 	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{Features: fn}}.Enabled())
 	assert.False(t, NetMetricsConfig{Metrics: &otelcfg.MetricsConfig{Features: fn}}.Enabled())

--- a/pkg/export/otel/metrics_svc_graph_test.go
+++ b/pkg/export/otel/metrics_svc_graph_test.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
@@ -86,7 +87,7 @@ func makeSvcGraphExporter(
 		Interval:          50 * time.Millisecond,
 		CommonEndpoint:    otlp.ServerEndpoint,
 		MetricsProtocol:   otelcfg.ProtocolHTTPProtobuf,
-		Features:          []otelcfg.Feature{otelcfg.FeatureGraph},
+		Features:          []export.Feature{export.FeatureGraph},
 		TTL:               30 * time.Minute,
 		ReportersCacheLen: 100,
 		Instrumentations:  []instrumentations.Instrumentation{instrumentations.InstrumentationALL},

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
@@ -56,7 +57,7 @@ func TestMetrics_InternalInstrumentation(t *testing.T) {
 	internalMetrics := &fakeInternalMetrics{}
 	mcfg := &otelcfg.MetricsConfig{
 		CommonEndpoint: coll.URL, Interval: 10 * time.Millisecond, ReportersCacheLen: 16,
-		Features: []otelcfg.Feature{otelcfg.FeatureApplication}, Instrumentations: []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+		Features: []export.Feature{export.FeatureApplication}, Instrumentations: []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
 	}
 	reporter, err := ReportMetrics(&global.ContextInfo{
 		Metrics:             internalMetrics,
@@ -240,7 +241,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 
 			metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
 			processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
-			otelExporter := makeMetricsReporter(ctx, t, tt.instr, []otelcfg.Feature{otelcfg.FeatureApplication}, otlp, metrics, processEvents).reportMetrics
+			otelExporter := makeMetricsReporter(ctx, t, tt.instr, []export.Feature{export.FeatureApplication}, otlp, metrics, processEvents).reportMetrics
 			require.NoError(t, err)
 
 			go otelExporter(ctx)
@@ -306,7 +307,7 @@ func TestAppMetrics_ResourceAttributes(t *testing.T) {
 
 	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
-	otelExporter := makeMetricsReporter(ctx, t, []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP}, []otelcfg.Feature{otelcfg.FeatureApplication}, otlp, metrics, processEvents).reportMetrics
+	otelExporter := makeMetricsReporter(ctx, t, []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP}, []export.Feature{export.FeatureApplication}, otlp, metrics, processEvents).reportMetrics
 	go otelExporter(ctx)
 
 	metrics.Send([]request.Span{
@@ -322,7 +323,7 @@ func TestAppMetrics_ResourceAttributes(t *testing.T) {
 
 func TestMetricsDiscarded(t *testing.T) {
 	mc := otelcfg.MetricsConfig{
-		Features: []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features: []export.Feature{export.FeatureApplication},
 	}
 	mr := MetricsReporter{
 		cfg: &mc,
@@ -367,7 +368,7 @@ func TestMetricsDiscarded(t *testing.T) {
 
 func TestSpanMetricsDiscarded(t *testing.T) {
 	mc := otelcfg.MetricsConfig{
-		Features: []otelcfg.Feature{otelcfg.FeatureSpan},
+		Features: []export.Feature{export.FeatureSpan},
 	}
 	mr := MetricsReporter{
 		cfg: &mc,
@@ -412,7 +413,7 @@ func TestSpanMetricsDiscarded(t *testing.T) {
 
 func TestSpanMetricsDiscardedGraph(t *testing.T) {
 	mc := otelcfg.MetricsConfig{
-		Features: []otelcfg.Feature{otelcfg.FeatureGraph},
+		Features: []export.Feature{export.FeatureGraph},
 	}
 	mr := MetricsReporter{
 		cfg: &mc,
@@ -457,7 +458,7 @@ func TestSpanMetricsDiscardedGraph(t *testing.T) {
 
 func TestProcessPIDEvents(t *testing.T) {
 	mc := otelcfg.MetricsConfig{
-		Features: []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features: []export.Feature{export.FeatureApplication},
 	}
 	mr := MetricsReporter{
 		cfg:        &mc,
@@ -537,7 +538,7 @@ func readNChan(t require.TestingT, inCh <-chan collector.MetricRecord, numRecord
 }
 
 func makeMetricsReporter(
-	ctx context.Context, t *testing.T, instrumentations []instrumentations.Instrumentation, features []otelcfg.Feature, otlp *collector.TestCollector,
+	ctx context.Context, t *testing.T, instrumentations []instrumentations.Instrumentation, features []export.Feature, otlp *collector.TestCollector,
 	input *msg.Queue[[]request.Span], processEvents *msg.Queue[exec.ProcessEvent],
 ) *MetricsReporter {
 	mcfg := &otelcfg.MetricsConfig{
@@ -579,7 +580,7 @@ func TestAppMetrics_TracesHostInfo(t *testing.T) {
 
 	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
 	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
-	mr := makeMetricsReporter(ctx, t, []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP}, []otelcfg.Feature{otelcfg.FeatureApplication, otelcfg.FeatureApplicationHost}, otlp, metrics, processEvents)
+	mr := makeMetricsReporter(ctx, t, []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP}, []export.Feature{export.FeatureApplication, export.FeatureApplicationHost}, otlp, metrics, processEvents)
 	otelExporter := mr.reportMetrics
 	go otelExporter(ctx)
 

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -58,21 +58,6 @@ const (
 	envResourceAttrs   = "OTEL_RESOURCE_ATTRIBUTES"
 )
 
-type Feature string
-
-const (
-	FeatureNetwork          Feature = "network"
-	FeatureNetworkInterZone Feature = "network_inter_zone"
-	FeatureApplication      Feature = "application"
-	FeatureSpan             Feature = "application_span"
-	FeatureSpanOTel         Feature = "application_span_otel"
-	FeatureSpanSizes        Feature = "application_span_sizes"
-	FeatureGraph            Feature = "application_service_graph"
-	FeatureProcess          Feature = "application_process"
-	FeatureApplicationHost  Feature = "application_host"
-	FeatureEBPF             Feature = "ebpf"
-)
-
 const (
 	UsualPortGRPC = "4317"
 	UsualPortHTTP = "4318"
@@ -106,23 +91,6 @@ func omitFieldsForYAML(input any, omitFields map[string]struct{}) map[string]any
 	}
 
 	return result
-}
-
-// Buckets defines the histograms bucket boundaries, and allows users to
-// redefine them
-type Buckets struct {
-	DurationHistogram     []float64 `yaml:"duration_histogram"`
-	RequestSizeHistogram  []float64 `yaml:"request_size_histogram"`
-	ResponseSizeHistogram []float64 `yaml:"response_size_histogram"`
-}
-
-var DefaultBuckets = Buckets{
-	// Default values as specified in the OTEL specification
-	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md
-	DurationHistogram: []float64{0, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10},
-
-	RequestSizeHistogram:  []float64{0, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192},
-	ResponseSizeHistogram: []float64{0, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192},
 }
 
 func GetAppResourceAttrs(hostID string, service *svc.Attrs) []attribute.KeyValue {

--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 )
 
@@ -35,8 +36,8 @@ type MetricsConfig struct {
 	// InsecureSkipVerify is not standard, so we don't follow the same naming convention
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"OTEL_EBPF_INSECURE_SKIP_VERIFY"`
 
-	Buckets              Buckets `yaml:"buckets"`
-	HistogramAggregation string  `yaml:"histogram_aggregation" env:"OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION"`
+	Buckets              export.Buckets `yaml:"buckets"`
+	HistogramAggregation string         `yaml:"histogram_aggregation" env:"OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION"`
 
 	ReportersCacheLen int `yaml:"reporters_cache_len" env:"OTEL_EBPF_METRICS_REPORT_CACHE_LEN"`
 
@@ -47,7 +48,7 @@ type MetricsConfig struct {
 	// Features of metrics that can be exported. Accepted values: application, network, application_process,
 	// application_span, application_service_graph, ...
 	// envDefault is provided to avoid breaking changes
-	Features []Feature `yaml:"features" env:"OTEL_EBPF_METRICS_FEATURES,expand" envDefault:"${OTEL_EBPF_METRIC_FEATURES}" envSeparator:","`
+	Features []export.Feature `yaml:"features" env:"OTEL_EBPF_METRICS_FEATURES,expand" envDefault:"${OTEL_EBPF_METRIC_FEATURES}" envSeparator:","`
 
 	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
 	Instrumentations []instrumentations.Instrumentation `yaml:"instrumentations" env:"OTEL_EBPF_METRICS_INSTRUMENTATIONS" envSeparator:","`
@@ -133,27 +134,27 @@ func (m *MetricsConfig) AnySpanMetricsEnabled() bool {
 }
 
 func (m *MetricsConfig) SpanMetricsSizesEnabled() bool {
-	return slices.Contains(m.Features, FeatureSpanSizes)
+	return slices.Contains(m.Features, export.FeatureSpanSizes)
 }
 
 func (m *MetricsConfig) SpanMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureSpan) || slices.Contains(m.Features, FeatureSpanOTel)
+	return slices.Contains(m.Features, export.FeatureSpan) || slices.Contains(m.Features, export.FeatureSpanOTel)
 }
 
 func (m *MetricsConfig) InvalidSpanMetricsConfig() bool {
-	return slices.Contains(m.Features, FeatureSpan) && slices.Contains(m.Features, FeatureSpanOTel)
+	return slices.Contains(m.Features, export.FeatureSpan) && slices.Contains(m.Features, export.FeatureSpanOTel)
 }
 
 func (m *MetricsConfig) HostMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureApplicationHost)
+	return slices.Contains(m.Features, export.FeatureApplicationHost)
 }
 
 func (m *MetricsConfig) ServiceGraphMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureGraph)
+	return slices.Contains(m.Features, export.FeatureGraph)
 }
 
 func (m *MetricsConfig) OTelMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureApplication)
+	return slices.Contains(m.Features, export.FeatureApplication)
 }
 
 func (m *MetricsConfig) NetworkMetricsEnabled() bool {
@@ -161,11 +162,11 @@ func (m *MetricsConfig) NetworkMetricsEnabled() bool {
 }
 
 func (m *MetricsConfig) NetworkFlowBytesEnabled() bool {
-	return slices.Contains(m.Features, FeatureNetwork)
+	return slices.Contains(m.Features, export.FeatureNetwork)
 }
 
 func (m *MetricsConfig) NetworkInterzoneMetricsEnabled() bool {
-	return slices.Contains(m.Features, FeatureNetworkInterZone)
+	return slices.Contains(m.Features, export.FeatureNetworkInterZone)
 }
 
 func (m *MetricsConfig) Enabled() bool {

--- a/pkg/export/otel/otelcfg/config_metrics_test.go
+++ b/pkg/export/otel/otelcfg/config_metrics_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 )
 
@@ -208,28 +209,28 @@ func TestMetricSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 }
 
 func TestMetricsConfig_Enabled(t *testing.T) {
-	assert.True(t, (&MetricsConfig{Features: []Feature{FeatureApplication, FeatureNetwork}, CommonEndpoint: "foo"}).Enabled())
-	assert.True(t, (&MetricsConfig{Features: []Feature{FeatureApplication}, MetricsEndpoint: "foo"}).Enabled())
-	assert.True(t, (&MetricsConfig{MetricsEndpoint: "foo", Features: []Feature{FeatureNetwork}}).Enabled())
+	assert.True(t, (&MetricsConfig{Features: []export.Feature{export.FeatureApplication, export.FeatureNetwork}, CommonEndpoint: "foo"}).Enabled())
+	assert.True(t, (&MetricsConfig{Features: []export.Feature{export.FeatureApplication}, MetricsEndpoint: "foo"}).Enabled())
+	assert.True(t, (&MetricsConfig{MetricsEndpoint: "foo", Features: []export.Feature{export.FeatureNetwork}}).Enabled())
 	assert.True(t, (&MetricsConfig{
-		Features:             []Feature{FeatureNetwork},
+		Features:             []export.Feature{export.FeatureNetwork},
 		OTLPEndpointProvider: func() (string, bool) { return "something", false },
 	}).Enabled())
 	assert.True(t, (&MetricsConfig{
-		Features:             []Feature{FeatureNetwork},
+		Features:             []export.Feature{export.FeatureNetwork},
 		OTLPEndpointProvider: func() (string, bool) { return "something", true },
 	}).Enabled())
 }
 
 func TestMetricsConfig_Disabled(t *testing.T) {
-	assert.False(t, (&MetricsConfig{Features: []Feature{FeatureApplication}}).Enabled())
-	assert.False(t, (&MetricsConfig{Features: []Feature{FeatureNetwork, FeatureApplication}}).Enabled())
-	assert.False(t, (&MetricsConfig{Features: []Feature{FeatureNetwork}}).Enabled())
+	assert.False(t, (&MetricsConfig{Features: []export.Feature{export.FeatureApplication}}).Enabled())
+	assert.False(t, (&MetricsConfig{Features: []export.Feature{export.FeatureNetwork, export.FeatureApplication}}).Enabled())
+	assert.False(t, (&MetricsConfig{Features: []export.Feature{export.FeatureNetwork}}).Enabled())
 	// application feature is not enabled
 	assert.False(t, (&MetricsConfig{CommonEndpoint: "foo"}).Enabled())
 	assert.False(t, (&MetricsConfig{}).Enabled())
 	assert.False(t, (&MetricsConfig{
-		Features:             []Feature{FeatureApplication},
+		Features:             []export.Feature{export.FeatureApplication},
 		OTLPEndpointProvider: func() (string, bool) { return "", false },
 	}).Enabled())
 }

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -26,6 +26,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
@@ -565,7 +566,7 @@ func TestTraceSkipSpanMetrics(t *testing.T) {
 
 	t.Run("test with span metrics on", func(t *testing.T) {
 		mc := otelcfg.MetricsConfig{
-			Features: []otelcfg.Feature{otelcfg.FeatureSpan},
+			Features: []export.Feature{export.FeatureSpan},
 		}
 
 		receiver := makeTracesTestReceiverWithSpanMetrics(mc.AnySpanMetricsEnabled(), []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP})

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -19,13 +19,13 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/buildinfo"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/connector"
 	"go.opentelemetry.io/obi/pkg/export/expire"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel"
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
@@ -116,11 +116,11 @@ type PrometheusConfig struct {
 
 	// Features of metrics that can be exported. Accepted values: application, network, application_process,
 	// application_span, application_service_graph, ...
-	Features []otelcfg.Feature `yaml:"features" env:"OTEL_EBPF_PROMETHEUS_FEATURES" envSeparator:","`
+	Features []export.Feature `yaml:"features" env:"OTEL_EBPF_PROMETHEUS_FEATURES" envSeparator:","`
 	// Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql...
 	Instrumentations []instrumentations.Instrumentation `yaml:"instrumentations" env:"OTEL_EBPF_PROMETHEUS_INSTRUMENTATIONS" envSeparator:","`
 
-	Buckets otelcfg.Buckets `yaml:"buckets"`
+	Buckets export.Buckets `yaml:"buckets"`
 
 	// TTL is the time since a metric was updated for the last time until it is
 	// removed from the metrics set.
@@ -153,27 +153,27 @@ func (p *PrometheusConfig) AnySpanMetricsEnabled() bool {
 }
 
 func (p *PrometheusConfig) SpanMetricsSizesEnabled() bool {
-	return slices.Contains(p.Features, otelcfg.FeatureSpanSizes)
+	return slices.Contains(p.Features, export.FeatureSpanSizes)
 }
 
 func (p *PrometheusConfig) SpanMetricsEnabled() bool {
-	return slices.Contains(p.Features, otelcfg.FeatureSpan) || slices.Contains(p.Features, otelcfg.FeatureSpanOTel)
+	return slices.Contains(p.Features, export.FeatureSpan) || slices.Contains(p.Features, export.FeatureSpanOTel)
 }
 
 func (p *PrometheusConfig) InvalidSpanMetricsConfig() bool {
-	return slices.Contains(p.Features, otelcfg.FeatureSpan) && slices.Contains(p.Features, otelcfg.FeatureSpanOTel)
+	return slices.Contains(p.Features, export.FeatureSpan) && slices.Contains(p.Features, export.FeatureSpanOTel)
 }
 
 func (p *PrometheusConfig) HostMetricsEnabled() bool {
-	return slices.Contains(p.Features, otelcfg.FeatureApplicationHost)
+	return slices.Contains(p.Features, export.FeatureApplicationHost)
 }
 
 func (p *PrometheusConfig) OTelMetricsEnabled() bool {
-	return slices.Contains(p.Features, otelcfg.FeatureApplication)
+	return slices.Contains(p.Features, export.FeatureApplication)
 }
 
 func (p *PrometheusConfig) ServiceGraphMetricsEnabled() bool {
-	return slices.Contains(p.Features, otelcfg.FeatureGraph)
+	return slices.Contains(p.Features, export.FeatureGraph)
 }
 
 func (p *PrometheusConfig) NetworkMetricsEnabled() bool {
@@ -181,15 +181,15 @@ func (p *PrometheusConfig) NetworkMetricsEnabled() bool {
 }
 
 func (p *PrometheusConfig) NetworkFlowBytesEnabled() bool {
-	return slices.Contains(p.Features, otelcfg.FeatureNetwork)
+	return slices.Contains(p.Features, export.FeatureNetwork)
 }
 
 func (p *PrometheusConfig) NetworkInterzoneMetricsEnabled() bool {
-	return slices.Contains(p.Features, otelcfg.FeatureNetworkInterZone)
+	return slices.Contains(p.Features, export.FeatureNetworkInterZone)
 }
 
 func (p *PrometheusConfig) EBPFEnabled() bool {
-	return slices.Contains(p.Features, otelcfg.FeatureEBPF)
+	return slices.Contains(p.Features, export.FeatureEBPF)
 }
 
 func (p *PrometheusConfig) EndpointEnabled() bool {
@@ -309,7 +309,7 @@ func PrometheusEndpoint(
 }
 
 func (p *PrometheusConfig) spanMetricsLatencyName() string {
-	if slices.Contains(p.Features, otelcfg.FeatureSpan) {
+	if slices.Contains(p.Features, export.FeatureSpan) {
 		return SpanMetricsLatency
 	}
 
@@ -317,7 +317,7 @@ func (p *PrometheusConfig) spanMetricsLatencyName() string {
 }
 
 func (p *PrometheusConfig) spanMetricsCallsName() string {
-	if slices.Contains(p.Features, otelcfg.FeatureSpan) {
+	if slices.Contains(p.Features, export.FeatureSpan) {
 		return SpanMetricsCalls
 	}
 

--- a/pkg/export/prom/prom_net_test.go
+++ b/pkg/export/prom/prom_net_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/connector"
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/internal/netolly/ebpf"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
@@ -40,7 +40,7 @@ func TestMetricsExpiration(t *testing.T) {
 			Path:                        "/metrics",
 			TTL:                         3 * time.Minute,
 			SpanMetricsServiceCacheSize: 10,
-			Features:                    []otelcfg.Feature{otelcfg.FeatureNetwork},
+			Features:                    []export.Feature{export.FeatureNetwork},
 		}, SelectorCfg: &attributes.SelectorConfig{
 			SelectionCfg: attributes.Selection{
 				attributes.NetworkFlow.Section: attributes.InclusionLists{

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -25,12 +25,12 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/connector"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/export/otel"
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
@@ -65,7 +65,7 @@ func TestAppMetricsExpiration(t *testing.T) {
 			Path:                        "/metrics",
 			TTL:                         3 * time.Minute,
 			SpanMetricsServiceCacheSize: 10,
-			Features:                    []otelcfg.Feature{otelcfg.FeatureApplication, otelcfg.FeatureApplicationHost},
+			Features:                    []export.Feature{export.FeatureApplication, export.FeatureApplicationHost},
 			Instrumentations:            []instrumentations.Instrumentation{instrumentations.InstrumentationALL},
 		},
 		&attributes.SelectorConfig{
@@ -390,7 +390,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 
 func TestMetricsDiscarded(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features: []export.Feature{export.FeatureApplication},
 	}
 	mr := metricsReporter{
 		cfg: &mc,
@@ -444,7 +444,7 @@ func TestMetricsDiscarded(t *testing.T) {
 
 func TestSpanMetricsDiscarded(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []otelcfg.Feature{otelcfg.FeatureSpanOTel},
+		Features: []export.Feature{export.FeatureSpanOTel},
 	}
 	mr := metricsReporter{
 		cfg: &mc,
@@ -490,7 +490,7 @@ func TestSpanMetricsDiscarded(t *testing.T) {
 
 func TestSpanMetricsDiscardedGraph(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []otelcfg.Feature{otelcfg.FeatureGraph},
+		Features: []export.Feature{export.FeatureGraph},
 	}
 	mr := metricsReporter{
 		cfg: &mc,
@@ -580,7 +580,7 @@ func TestTerminatesOnBadPromPort(t *testing.T) {
 
 func TestProcessPIDEvents(t *testing.T) {
 	mc := PrometheusConfig{
-		Features: []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features: []export.Feature{export.FeatureApplication},
 	}
 	mr := metricsReporter{
 		cfg:         &mc,
@@ -670,7 +670,7 @@ func makePromExporter(
 			Path:                        "/metrics",
 			TTL:                         300 * time.Minute,
 			SpanMetricsServiceCacheSize: 10,
-			Features:                    []otelcfg.Feature{otelcfg.FeatureApplication},
+			Features:                    []export.Feature{export.FeatureApplication},
 			Instrumentations:            instrumentations,
 		},
 		&attributes.SelectorConfig{

--- a/pkg/instrumenter/instrumenter_test_linux.go
+++ b/pkg/instrumenter/instrumenter_test_linux.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/obi"
 )
 
@@ -26,7 +26,7 @@ func TestRunDontPanic(t *testing.T) {
 		description: "otel endpoint but feature excluded",
 		configProvider: func() obi.Config {
 			cfg := obi.DefaultConfig
-			cfg.Metrics.Features = []otelcfg.Feature{otelcfg.FeatureApplication}
+			cfg.Metrics.Features = []export.Feature{export.FeatureApplication}
 			cfg.NetworkFlows.Enable = true
 			cfg.Metrics.CommonEndpoint = "http://localhost"
 			return cfg
@@ -35,7 +35,7 @@ func TestRunDontPanic(t *testing.T) {
 		description: "prom endpoint but feature excluded",
 		configProvider: func() obi.Config {
 			cfg := obi.DefaultConfig
-			cfg.Prometheus.Features = []otelcfg.Feature{otelcfg.FeatureApplication}
+			cfg.Prometheus.Features = []export.Feature{export.FeatureApplication}
 			cfg.NetworkFlows.Enable = true
 			cfg.Prometheus.Port = 9090
 			return cfg
@@ -44,7 +44,7 @@ func TestRunDontPanic(t *testing.T) {
 		description: "otel endpoint, otel feature excluded, but prom enabled",
 		configProvider: func() obi.Config {
 			cfg := obi.DefaultConfig
-			cfg.Metrics.Features = []otelcfg.Feature{otelcfg.FeatureApplication}
+			cfg.Metrics.Features = []export.Feature{export.FeatureApplication}
 			cfg.NetworkFlows.Enable = true
 			cfg.Metrics.CommonEndpoint = "http://localhost"
 			cfg.Prometheus.Port = 9090
@@ -56,9 +56,9 @@ func TestRunDontPanic(t *testing.T) {
 			cfg := obi.DefaultConfig
 			cfg.NetworkFlows.Enable = true
 			cfg.Prometheus.Port = 9090
-			cfg.Prometheus.Features = []otelcfg.Feature{otelcfg.FeatureApplication}
+			cfg.Prometheus.Features = []export.Feature{export.FeatureApplication}
 			cfg.Metrics.CommonEndpoint = "http://localhost"
-			cfg.Metrics.Features = []otelcfg.Feature{otelcfg.FeatureApplication}
+			cfg.Metrics.Features = []export.Feature{export.FeatureApplication}
 			return cfg
 		},
 	}}

--- a/pkg/netolly/agent/pipeline_test.go
+++ b/pkg/netolly/agent/pipeline_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	prom2 "go.opentelemetry.io/obi/internal/test/integration/components/prom"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/connector"
-	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/export/prom"
 	"go.opentelemetry.io/obi/pkg/filter"
 	"go.opentelemetry.io/obi/pkg/internal/netolly/ebpf"
@@ -46,7 +46,7 @@ func TestFilter(t *testing.T) {
 			Prometheus: prom.PrometheusConfig{
 				Path:     "/metrics",
 				Port:     promPort,
-				Features: []otelcfg.Feature{otelcfg.FeatureNetwork},
+				Features: []export.Feature{export.FeatureNetwork},
 				TTL:      time.Hour,
 			},
 			Filters: filter.AttributesConfig{

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/ebpf/tcmanager"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/debug"
@@ -126,10 +127,10 @@ var DefaultConfig = Config{
 		MetricsProtocol: otelcfg.ProtocolUnset,
 		// Matches Alloy and Grafana recommended scrape interval
 		OTELIntervalMS:       60_000,
-		Buckets:              otelcfg.DefaultBuckets,
+		Buckets:              export.DefaultBuckets,
 		ReportersCacheLen:    ReporterLRUSize,
 		HistogramAggregation: otel.AggregationExplicit,
-		Features:             []otelcfg.Feature{otelcfg.FeatureApplication},
+		Features:             []export.Feature{export.FeatureApplication},
 		Instrumentations: []instrumentations.Instrumentation{
 			instrumentations.InstrumentationALL,
 		},
@@ -153,8 +154,8 @@ var DefaultConfig = Config{
 	},
 	Prometheus: prom.PrometheusConfig{
 		Path:     "/metrics",
-		Buckets:  otelcfg.DefaultBuckets,
-		Features: []otelcfg.Feature{otelcfg.FeatureApplication},
+		Buckets:  export.DefaultBuckets,
+		Features: []export.Feature{export.FeatureApplication},
 		Instrumentations: []instrumentations.Instrumentation{
 			instrumentations.InstrumentationALL,
 		},

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/debug"
@@ -149,12 +150,12 @@ discovery:
 			MetricsEndpoint:   "localhost:3030",
 			Protocol:          otelcfg.ProtocolUnset,
 			ReportersCacheLen: ReporterLRUSize,
-			Buckets: otelcfg.Buckets{
+			Buckets: export.Buckets{
 				DurationHistogram:     []float64{0, 1, 2},
-				RequestSizeHistogram:  otelcfg.DefaultBuckets.RequestSizeHistogram,
-				ResponseSizeHistogram: otelcfg.DefaultBuckets.ResponseSizeHistogram,
+				RequestSizeHistogram:  export.DefaultBuckets.RequestSizeHistogram,
+				ResponseSizeHistogram: export.DefaultBuckets.ResponseSizeHistogram,
 			},
-			Features: []otelcfg.Feature{otelcfg.FeatureApplication},
+			Features: []export.Feature{export.FeatureApplication},
 			Instrumentations: []instrumentations.Instrumentation{
 				instrumentations.InstrumentationALL,
 			},
@@ -180,14 +181,14 @@ discovery:
 		},
 		Prometheus: prom.PrometheusConfig{
 			Path:     "/metrics",
-			Features: []otelcfg.Feature{otelcfg.FeatureApplication},
+			Features: []export.Feature{export.FeatureApplication},
 			Instrumentations: []instrumentations.Instrumentation{
 				instrumentations.InstrumentationALL,
 			},
 			TTL:                         time.Second,
 			SpanMetricsServiceCacheSize: 10000,
-			Buckets: otelcfg.Buckets{
-				DurationHistogram:     otelcfg.DefaultBuckets.DurationHistogram,
+			Buckets: export.Buckets{
+				DurationHistogram:     export.DefaultBuckets.DurationHistogram,
 				RequestSizeHistogram:  []float64{0, 10, 20, 22},
 				ResponseSizeHistogram: []float64{0, 10, 20, 22},
 			},
@@ -617,7 +618,7 @@ func TestConfig_SpanMetricsEnabledForTraces(t *testing.T) {
 			name: "otel metrics enabled, but not spans",
 			metrics: otelcfg.MetricsConfig{
 				MetricsEndpoint: "http://localhost:4318/v1/metrics",
-				Features:        []otelcfg.Feature{otelcfg.FeatureApplication},
+				Features:        []export.Feature{export.FeatureApplication},
 			},
 			prometheus:  prom.PrometheusConfig{},
 			wantEnabled: false,
@@ -626,7 +627,7 @@ func TestConfig_SpanMetricsEnabledForTraces(t *testing.T) {
 			name: "otel metrics enabled with spans",
 			metrics: otelcfg.MetricsConfig{
 				MetricsEndpoint: "http://localhost:4318/v1/metrics",
-				Features:        []otelcfg.Feature{otelcfg.FeatureSpanOTel},
+				Features:        []export.Feature{export.FeatureSpanOTel},
 			},
 			prometheus:  prom.PrometheusConfig{},
 			wantEnabled: true,
@@ -636,7 +637,7 @@ func TestConfig_SpanMetricsEnabledForTraces(t *testing.T) {
 			metrics: otelcfg.MetricsConfig{},
 			prometheus: prom.PrometheusConfig{
 				Port:     9090,
-				Features: []otelcfg.Feature{otelcfg.FeatureApplication},
+				Features: []export.Feature{export.FeatureApplication},
 			},
 			wantEnabled: false,
 		},
@@ -644,7 +645,7 @@ func TestConfig_SpanMetricsEnabledForTraces(t *testing.T) {
 			name:    "prometheus span metrics enabled",
 			metrics: otelcfg.MetricsConfig{},
 			prometheus: prom.PrometheusConfig{
-				Features: []otelcfg.Feature{otelcfg.FeatureGraph},
+				Features: []export.Feature{export.FeatureGraph},
 				Port:     9090,
 			},
 			wantEnabled: true,
@@ -652,10 +653,10 @@ func TestConfig_SpanMetricsEnabledForTraces(t *testing.T) {
 		{
 			name: "both have features, but not enabled",
 			metrics: otelcfg.MetricsConfig{
-				Features: []otelcfg.Feature{otelcfg.FeatureApplication},
+				Features: []export.Feature{export.FeatureApplication},
 			},
 			prometheus: prom.PrometheusConfig{
-				Features: []otelcfg.Feature{otelcfg.FeatureGraph},
+				Features: []export.Feature{export.FeatureGraph},
 			},
 			wantEnabled: false,
 		},

--- a/pkg/transform/span_name_limiter.go
+++ b/pkg/transform/span_name_limiter.go
@@ -11,6 +11,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/export/prom"
 	"go.opentelemetry.io/obi/pkg/internal/helpers/cache"
@@ -69,8 +70,8 @@ func SpanNameLimiter(cfg SpanNameLimiterConfig, input, output *msg.Queue[[]reque
 
 func enabled(cfg *SpanNameLimiterConfig) bool {
 	return cfg.Limit > 0 &&
-		(slices.Contains(cfg.OTEL.Features, otelcfg.FeatureSpan) ||
-			slices.Contains(cfg.Prom.Features, otelcfg.FeatureSpan))
+		(slices.Contains(cfg.OTEL.Features, export.FeatureSpan) ||
+			slices.Contains(cfg.Prom.Features, export.FeatureSpan))
 }
 
 func (l *spanNameLimiter) doLimit(ctx context.Context) {

--- a/pkg/transform/span_name_limiter_test.go
+++ b/pkg/transform/span_name_limiter_test.go
@@ -16,6 +16,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/export/prom"
 	"go.opentelemetry.io/obi/pkg/internal/testutil"
@@ -31,8 +32,8 @@ func TestSpanNameLimiter(t *testing.T) {
 	outCh := output.Subscribe()
 	runSpanNameLimiter, err := SpanNameLimiter(SpanNameLimiterConfig{
 		Limit: maxCardinalityBeforeAggregation,
-		OTEL:  &otelcfg.MetricsConfig{Features: []otelcfg.Feature{otelcfg.FeatureSpan}, TTL: time.Minute},
-		Prom:  &prom.PrometheusConfig{Features: []otelcfg.Feature{otelcfg.FeatureSpan}, TTL: time.Minute},
+		OTEL:  &otelcfg.MetricsConfig{Features: []export.Feature{export.FeatureSpan}, TTL: time.Minute},
+		Prom:  &prom.PrometheusConfig{Features: []export.Feature{export.FeatureSpan}, TTL: time.Minute},
 	}, input, output)(t.Context())
 	require.NoError(t, err)
 
@@ -116,8 +117,8 @@ func TestSpanNameLimiter_ExpireOld(t *testing.T) {
 		outCh := output.Subscribe()
 		runSpanNameLimiter, err := SpanNameLimiter(SpanNameLimiterConfig{
 			Limit: maxCardinalityBeforeAggregation,
-			OTEL:  &otelcfg.MetricsConfig{Features: []otelcfg.Feature{otelcfg.FeatureSpan}, TTL: time.Minute},
-			Prom:  &prom.PrometheusConfig{Features: []otelcfg.Feature{otelcfg.FeatureSpan}, TTL: time.Minute},
+			OTEL:  &otelcfg.MetricsConfig{Features: []export.Feature{export.FeatureSpan}, TTL: time.Minute},
+			Prom:  &prom.PrometheusConfig{Features: []export.Feature{export.FeatureSpan}, TTL: time.Minute},
 		}, input, output)(t.Context())
 		require.NoError(t, err)
 
@@ -180,8 +181,8 @@ func TestSpanNameLimiter_CopiesOutput(t *testing.T) {
 	outCh := output.Subscribe()
 	runSpanNameLimiter, err := SpanNameLimiter(SpanNameLimiterConfig{
 		Limit: 3,
-		OTEL:  &otelcfg.MetricsConfig{Features: []otelcfg.Feature{otelcfg.FeatureSpan}, TTL: time.Minute},
-		Prom:  &prom.PrometheusConfig{Features: []otelcfg.Feature{otelcfg.FeatureSpan}, TTL: time.Minute},
+		OTEL:  &otelcfg.MetricsConfig{Features: []export.Feature{export.FeatureSpan}, TTL: time.Minute},
+		Prom:  &prom.PrometheusConfig{Features: []export.Feature{export.FeatureSpan}, TTL: time.Minute},
 	}, input, output)(t.Context())
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR moves `Buckets` and `Feature` definitions from `otelcfg` pkg to `pkg/export` to allow shared usage by different packages, such as `prom` and `otel`.