### PR TITLE
Fix missing initialisation for pattern when we don't set it

### DIFF
--- a/bpf/gotracer/go_grpc.c
+++ b/bpf/gotracer/go_grpc.c
@@ -271,6 +271,7 @@ int obi_uprobe_server_handleStream_return(struct pt_regs *ctx) {
     trace->method[0] = '\0';
     trace->host[0] = '\0';
     trace->scheme[0] = '\0';
+    trace->pattern[0] = '\0';
     trace->go_start_monotime_ns = invocation->start_monotime_ns;
     bpf_map_delete_elem(&ongoing_goroutines, &g_key);
 
@@ -454,6 +455,7 @@ static __always_inline int grpc_connect_done(struct pt_regs *ctx, void *err) {
     trace->method[0] = '\0';
     trace->host[0] = '\0';
     trace->scheme[0] = '\0';
+    trace->pattern[0] = '\0';
 
     // Read arguments from the original set of registers
 

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -691,6 +691,7 @@ int obi_uprobe_roundTripReturn(struct pt_regs *ctx) {
     trace->start_monotime_ns = invocation->start_monotime_ns;
     trace->go_start_monotime_ns = invocation->start_monotime_ns;
     trace->end_monotime_ns = bpf_ktime_get_ns();
+    trace->pattern[0] = '\0';
 
     // Copy the values read on request start
     __builtin_memcpy(trace->method, data->method, sizeof(trace->method));


### PR DESCRIPTION
Fixes missing initalisation for the new route parsing for Go.