### PR TITLE
feat(mqtt): initial docker compose setup

### DIFF
--- a/internal/test/integration/components/gomqtt/Dockerfile
+++ b/internal/test/integration/components/gomqtt/Dockerfile
@@ -1,0 +1,25 @@
+# Build the testserver binary
+# Docker command must be invoked from the project root directory
+FROM golang:1.25.3@sha256:6d4e5e74f47db00f7f24da5f53c1b4198ae46862a47395e30477365458347bf2 AS builder
+
+ARG TARGETARCH
+
+ENV GOARCH=$TARGETARCH
+
+WORKDIR /src
+
+# Copy the go manifests and source
+COPY internal/test/integration/components/gomqtt/ .
+
+# Build
+RUN go mod download && go build -o testserver main.go
+
+# Create final image from minimal + built binary
+FROM debian:bookworm-slim@sha256:78d2f66e0fec9e5a39fb2c72ea5e052b548df75602b5215ed01a17171529f706
+
+WORKDIR /
+COPY --from=builder /src/testserver .
+USER 0:0
+
+CMD [ "/testserver" ]
+

--- a/internal/test/integration/components/gomqtt/go.mod
+++ b/internal/test/integration/components/gomqtt/go.mod
@@ -1,0 +1,11 @@
+module go.opentelemetry.io/obi/internal/test/integration/components/gomqtt
+
+go 1.25.3
+
+require github.com/eclipse/paho.mqtt.golang v1.5.0
+
+require (
+	github.com/gorilla/websocket v1.5.3 // indirect
+	golang.org/x/net v0.27.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
+)

--- a/internal/test/integration/components/gomqtt/go.sum
+++ b/internal/test/integration/components/gomqtt/go.sum
@@ -1,0 +1,8 @@
+github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjOsyvMGvD6o=
+github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+golang.org/x/net v0.27.0 h1:5K3Njcw06/l2y9vpGCSdcxWOYHOUk3dVNGDXN+FvAys=
+golang.org/x/net v0.27.0/go.mod h1:dDi0PyhWNoiUOrAS8uXv/vnScO4wnHQO4mj9fn/RytE=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/internal/test/integration/components/gomqtt/main.go
+++ b/internal/test/integration/components/gomqtt/main.go
@@ -1,0 +1,134 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+var (
+	client mqtt.Client
+	topic  string
+	qos    byte
+	mu     sync.Mutex
+	count  int
+)
+
+func main() {
+	broker := os.Getenv("MQTT_BROKER")
+	if broker == "" {
+		broker = "vernemq:1883"
+	}
+
+	topic = os.Getenv("MQTT_TOPIC")
+	if topic == "" {
+		topic = "test/topic"
+	}
+
+	qosStr := os.Getenv("MQTT_QOS")
+	qos = byte(1) // Default to QOS 1 for guaranteed delivery
+	if qosStr != "" {
+		if q, err := strconv.Atoi(qosStr); err == nil && q >= 0 && q <= 2 {
+			qos = byte(q)
+		}
+	}
+
+	// Wait for broker to be ready
+	log.Printf("Waiting for MQTT broker at %s...", broker)
+	for {
+		opts := mqtt.NewClientOptions().AddBroker("tcp://" + broker)
+		opts.SetClientID("gomqtt_publisher")
+		opts.SetConnectTimeout(5 * time.Second)
+		opts.SetAutoReconnect(false)
+
+		testClient := mqtt.NewClient(opts)
+		if token := testClient.Connect(); token.Wait() && token.Error() == nil {
+			log.Printf("Connected to MQTT broker at %s", broker)
+			testClient.Disconnect(250)
+			break
+		}
+		log.Printf("Failed to connect, retrying in 2 seconds...")
+		time.Sleep(2 * time.Second)
+	}
+
+	// Set up client options
+	opts := mqtt.NewClientOptions().AddBroker("tcp://" + broker)
+	opts.SetClientID("gomqtt_publisher_" + strconv.FormatInt(time.Now().Unix(), 10))
+	opts.SetCleanSession(true)
+	opts.SetConnectTimeout(10 * time.Second)
+	opts.SetKeepAlive(60 * time.Second)
+	opts.SetPingTimeout(10 * time.Second)
+	opts.SetAutoReconnect(true)
+
+	// Set up message handler for publish confirmation
+	opts.SetOnConnectHandler(func(c mqtt.Client) {
+		log.Println("Connected to MQTT broker")
+	})
+	opts.SetConnectionLostHandler(func(c mqtt.Client, err error) {
+		log.Printf("Connection lost: %v", err)
+	})
+
+	client = mqtt.NewClient(opts)
+
+	// Connect to the broker
+	log.Printf("Connecting to MQTT broker at %s...", broker)
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		log.Fatalf("Error connecting to broker: %v", token.Error())
+	}
+	defer func() {
+		log.Println("Disconnecting from MQTT broker...")
+		client.Disconnect(250)
+	}()
+
+	http.HandleFunc("/mqtt", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		count++
+		messageNum := count
+		mu.Unlock()
+
+		// Ensure client is connected
+		if !client.IsConnected() {
+			log.Println("Client not connected, attempting to reconnect...")
+			if token := client.Connect(); token.Wait() && token.Error() != nil {
+				http.Error(w, "MQTT connection error: "+token.Error().Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+
+		// Publish message with guaranteed delivery (QOS 1)
+		payload := fmt.Sprintf("Hello from gomqtt! Message #%d, Timestamp: %s", messageNum, time.Now().Format(time.RFC3339))
+		log.Printf("Publishing message #%d to topic '%s' with QOS %d: %s", messageNum, topic, qos, payload)
+
+		token := client.Publish(topic, qos, false, payload)
+		token.Wait()
+
+		if token.Error() != nil {
+			http.Error(w, "Publish error: "+token.Error().Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// Respond with the results
+		result := map[string]interface{}{
+			"message_number": messageNum,
+			"topic":          topic,
+			"qos":            qos,
+			"payload":        payload,
+			"published":      true,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(result)
+	})
+
+	fmt.Println("Server running on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/internal/test/integration/components/pythonmqtt/Dockerfile
+++ b/internal/test/integration/components/pythonmqtt/Dockerfile
@@ -1,0 +1,8 @@
+# Dockerfile that will build a container that runs python with FastAPI and paho-mqtt on port 8080
+FROM python:3.12@sha256:de96c54f25e2d69597a72bd3309d723110e59586845c5675c8cb83afb808af18
+EXPOSE 8080
+RUN pip install fastapi uvicorn paho-mqtt
+COPY internal/test/integration/components/pythonmqtt /main
+WORKDIR /main
+CMD ["python", "pythonmqtt.py"]
+

--- a/internal/test/integration/components/pythonmqtt/pythonmqtt.py
+++ b/internal/test/integration/components/pythonmqtt/pythonmqtt.py
@@ -1,0 +1,225 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import time
+import logging
+from datetime import datetime
+from threading import Lock
+from fastapi import FastAPI, HTTPException
+import uvicorn
+import paho.mqtt.client as mqtt
+from paho.mqtt.enums import CallbackAPIVersion
+
+app = FastAPI()
+
+# Global variables
+client = None
+topic = "test/topic"
+qos = 1
+mu = Lock()
+count = 0
+
+# Configure logging
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
+
+
+def wait_for_broker(broker_host, broker_port):
+    """Wait for MQTT broker to be ready"""
+    logger.info(f"Waiting for MQTT broker at {broker_host}:{broker_port}...")
+    while True:
+        try:
+            test_client = mqtt.Client(CallbackAPIVersion.VERSION2, client_id="pythonmqtt_publisher_test")
+            test_client.connect(broker_host, broker_port, 5)
+            test_client.disconnect()
+            logger.info(f"Connected to MQTT broker at {broker_host}:{broker_port}")
+            break
+        except Exception as e:
+            logger.info(f"Failed to connect, retrying in 2 seconds... Error: {e}")
+            time.sleep(2)
+
+
+def on_connect(client, userdata, flags, reason_code, properties):
+    """Callback for when the client receives a CONNACK response from the server"""
+    if reason_code.is_failure:
+        logger.error(f"Failed to connect, reason code: {reason_code}")
+    else:
+        logger.info("Connected to MQTT broker")
+
+
+def on_disconnect(client, userdata, disconnect_flags, reason_code, properties):
+    """Callback for when the client disconnects from the server"""
+    if reason_code.is_failure:
+        logger.warning(f"Unexpected disconnection: {reason_code}")
+
+
+def setup_mqtt_client(broker_host, broker_port):
+    """Set up and connect MQTT client"""
+    global client
+
+    client_id = f"pythonmqtt_publisher_{int(time.time())}"
+    client = mqtt.Client(CallbackAPIVersion.VERSION2, client_id=client_id, clean_session=True)
+
+    client.on_connect = on_connect
+    client.on_disconnect = on_disconnect
+
+    client.connect(broker_host, broker_port, 60)
+    client.loop_start()
+
+    # Wait a bit for connection to establish
+    time.sleep(1)
+
+    return client
+
+
+@app.get("/mqtt")
+async def mqtt_publish():
+    """Handle HTTP request to publish MQTT message"""
+    global count, client
+
+    mu.acquire()
+    count += 1
+    message_num = count
+    mu.release()
+
+    # Ensure client is connected
+    if client is None or not client.is_connected():
+        logger.warning("Client not connected, attempting to reconnect...")
+        broker = os.getenv("MQTT_BROKER", "vernemq:1883")
+        broker_host, broker_port = broker.split(":") if ":" in broker else (broker, 1883)
+        broker_port = int(broker_port)
+        try:
+            client = setup_mqtt_client(broker_host, broker_port)
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"MQTT connection error: {str(e)}")
+
+    # Publish message
+    payload = f"Hello from pythonmqtt! Message #{message_num}, Timestamp: {datetime.now().isoformat()}"
+    logger.info(f"Publishing message #{message_num} to topic '{topic}' with QOS {qos}: {payload}")
+
+    try:
+        result = client.publish(topic, payload, qos)
+        result.wait_for_publish(timeout=5)
+
+        if result.rc != mqtt.MQTT_ERR_SUCCESS:
+            raise HTTPException(status_code=500, detail=f"Publish error: {result.rc}")
+
+        # Respond with the results
+        response = {
+            "message_number": message_num,
+            "topic": topic,
+            "qos": qos,
+            "payload": payload,
+            "published": True,
+        }
+        return response
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Publish error: {str(e)}")
+
+
+@app.get("/mqtt/connect")
+async def mqtt_connect():
+    """Connect to MQTT broker (or reconnect if already connected)"""
+    global client
+
+    broker = os.getenv("MQTT_BROKER", "vernemq:1883")
+    broker_host, broker_port = broker.split(":") if ":" in broker else (broker, 1883)
+    broker_port = int(broker_port)
+
+    # Disconnect existing client if connected
+    if client is not None:
+        if client.is_connected():
+            logger.info("Disconnecting existing client...")
+            client.disconnect()
+            client.loop_stop()
+        client = None
+
+    try:
+        # Create new client and connect
+        client_id = f"pythonmqtt_publisher_{int(time.time())}"
+        client = mqtt.Client(CallbackAPIVersion.VERSION2, client_id=client_id, clean_session=True)
+
+        client.on_connect = on_connect
+        client.on_disconnect = on_disconnect
+
+        logger.info(f"Connecting to MQTT broker at {broker_host}:{broker_port}...")
+        client.connect(broker_host, broker_port, 60)
+        client.loop_start()
+
+        # Wait a bit for connection to establish
+        time.sleep(1)
+
+        if client.is_connected():
+            response = {
+                "connected": True,
+                "client_id": client_id,
+                "broker": f"{broker_host}:{broker_port}",
+            }
+            return response
+        else:
+            raise HTTPException(status_code=500, detail="Failed to connect to MQTT broker")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Connection error: {str(e)}")
+
+
+@app.get("/mqtt/disconnect")
+async def mqtt_disconnect():
+    """Disconnect from MQTT broker"""
+    global client
+
+    if client is None:
+        return {
+            "disconnected": False,
+            "message": "No client to disconnect",
+        }
+
+    try:
+        if client.is_connected():
+            logger.info("Disconnecting from MQTT broker...")
+            client.disconnect()
+            client.loop_stop()
+            response = {
+                "disconnected": True,
+                "message": "Successfully disconnected",
+            }
+        else:
+            client.loop_stop()
+            response = {
+                "disconnected": True,
+                "message": "Client was not connected",
+            }
+
+        client = None
+        return response
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Disconnect error: {str(e)}")
+
+
+if __name__ == "__main__":
+    # Get configuration from environment
+    broker = os.getenv("MQTT_BROKER", "vernemq:1883")
+    broker_host, broker_port = broker.split(":") if ":" in broker else (broker, 1883)
+    broker_port = int(broker_port)
+
+    topic = os.getenv("MQTT_TOPIC", "test/topic")
+
+    qos_str = os.getenv("MQTT_QOS", "1")
+    try:
+        qos = int(qos_str)
+        if qos < 0 or qos > 2:
+            qos = 1
+    except ValueError:
+        qos = 1
+
+    # Wait for broker to be ready
+    wait_for_broker(broker_host, broker_port)
+
+    # Set up MQTT client
+    setup_mqtt_client(broker_host, broker_port)
+
+    print(f"Server running: port={8080} process_id={os.getpid()}")
+    uvicorn.run(app, host="0.0.0.0", port=8080)
+

--- a/internal/test/integration/docker-compose-go-mqtt.yml
+++ b/internal/test/integration/docker-compose-go-mqtt.yml
@@ -1,0 +1,115 @@
+services:
+  vernemq:
+    restart: always
+    container_name: vernemq-mqtt-broker
+    image: vernemq/vernemq:latest
+    ports:
+      - "1883:1883" # MQTT port
+    environment:
+      - DOCKER_VERNEMQ_ACCEPT_EULA=yes
+      - DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on
+      - DOCKER_VERNEMQ_LOG__CONSOLE__LEVEL=warning
+      - DOCKER_VERNEMQ_PLUGINS__vmq_acl=on
+      - DOCKER_VERNEMQ_VMQ_ACL__ACL_FILE=/etc/vernemq/vmq.acl
+    volumes:
+      - ./vernemq-acl:/etc/vernemq
+
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/gomqtt/Dockerfile
+    image: hatest-testserver-go-mqtt
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    environment:
+      - MQTT_BROKER=vernemq:1883
+      - MQTT_TOPIC=test/topic
+      - MQTT_QOS=1
+    depends_on:
+      otelcol:
+        condition: service_started
+      vernemq:
+        condition: service_started
+      jaeger:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/ebpf-instrument/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-mqtt:/var/run/beyla
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "10ms"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "beyla"
+      OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_TRACES_INSTRUMENTATIONS: "*"
+      OTEL_EBPF_METRICS_INSTRUMENTATIONS: "*"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+      OTEL_EBPF_PROTOCOL_DEBUG_PRINT: "true"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.118.0@sha256:3f6274fe609da4f9964fbc2ef36b83d08d47964fbb11629251393590d3924072
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318:4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v2.55.1@sha256:2659f4c2ebb718e7695cb9b25ffa7d6be64db013daba13e05c875451cf51b0d3
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+      - --log.level=warn
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.60@sha256:4fd2d70fa347d6a47e79fcb06b1c177e6079f92cba88b083153d56263082135e
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=warn

--- a/internal/test/integration/docker-compose-python-mqtt.yml
+++ b/internal/test/integration/docker-compose-python-mqtt.yml
@@ -1,0 +1,115 @@
+services:
+  vernemq:
+    restart: always
+    container_name: vernemq-mqtt-broker
+    image: vernemq/vernemq:latest
+    ports:
+      - "1883:1883" # MQTT port
+    environment:
+      - DOCKER_VERNEMQ_ACCEPT_EULA=yes
+      - DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on
+      - DOCKER_VERNEMQ_LOG__CONSOLE__LEVEL=warning
+      - DOCKER_VERNEMQ_PLUGINS__vmq_acl=on
+      - DOCKER_VERNEMQ_VMQ_ACL__ACL_FILE=/etc/vernemq/vmq.acl
+    volumes:
+      - ./vernemq-acl:/etc/vernemq
+
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/pythonmqtt/Dockerfile
+    image: hatest-testserver-python-mqtt
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    environment:
+      - MQTT_BROKER=vernemq:1883
+      - MQTT_TOPIC=test/topic
+      - MQTT_QOS=1
+    depends_on:
+      otelcol:
+        condition: service_started
+      vernemq:
+        condition: service_started
+      jaeger:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/ebpf-instrument/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-mqtt:/var/run/beyla
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "10ms"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "beyla"
+      OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_TRACES_INSTRUMENTATIONS: "*"
+      OTEL_EBPF_METRICS_INSTRUMENTATIONS: "*"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+      OTEL_EBPF_PROTOCOL_DEBUG_PRINT: "true"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.118.0@sha256:3f6274fe609da4f9964fbc2ef36b83d08d47964fbb11629251393590d3924072
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318:4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v2.55.1@sha256:2659f4c2ebb718e7695cb9b25ffa7d6be64db013daba13e05c875451cf51b0d3
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+      - --log.level=warn
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.60@sha256:4fd2d70fa347d6a47e79fcb06b1c177e6079f92cba88b083153d56263082135e
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=warn

--- a/internal/test/integration/docker-compose.yml
+++ b/internal/test/integration/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   testserver:
     build:

--- a/internal/test/integration/vernemq-acl/vmq.acl
+++ b/internal/test/integration/vernemq-acl/vmq.acl
@@ -1,0 +1,3 @@
+# ACL file for VerneMQ - Allow all operations for anonymous users
+allow publish
+allow subscribe


### PR DESCRIPTION
The first of several MQTT PRs (which I'm splitting to aid review).

This PR creates a new docker compose project that uses [VerneMQ](https://vernemq.com) as an MQTT broker, and provides both Python and Go test scripts to connect and publish a message to the broker.

No parsing or integration with existing test suites is occurring yet, this is an isolated docker compose project which has to be run manually using these testing steps:

```shell
TEST_SERVICE_PORTS="8080:8080" \
OTEL_EBPF_OPEN_PORT=8080 \
docker compose -f internal/test/integration/docker-compose-python-mqtt.yml \
up --build -d

# publish an mqtt message
curl http://localhost:8080/mqtt

docker logs integration-obi-1
```

This initial PR aims to trigger the raw TCP buffer to be printed to the log only for now, as an unhandled protocol.

## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](../devdocs/features.md)