### PR TITLE
fix: ReadTCPRequestIntoSpan missing unmatched debug print

### DIFF
--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -139,7 +139,7 @@ func ReadTCPRequestIntoSpan(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, 
 			return request.Span{}, true, nil // ignore for now, next event will be parsed
 		} else {
 			k, ignore, err := ProcessPossibleKafkaEvent(event, requestBuffer, responseBuffer, parseCtx.kafkaTopicUUIDToName)
-			if ignore {
+			if ignore && err == nil {
 				return request.Span{}, true, nil // parsed kafka event, but we don't want to create a span for it
 			}
 			if err == nil {


### PR DESCRIPTION
When testing mqtt, I noticed I was missing the extra `![>]` print.

Example with the fix:

```
time=2025-11-27T17:46:56.794Z level=DEBUG msg="=== return recvmsg id=867724 args=ffffd2ce08c00720 copied_len 1 ===" component=BPFLogger pid=867724 comm=python
time=2025-11-27T17:46:56.794Z level=DEBUG msg="=== kretprobe_tcp_recvmsg id=867724 copied_len 1 ===" component=BPFLogger pid=867724 comm=python
[>] [50 86 0 10 116 101 115 116 47 116 111 112 105 99 0 1 72 101 108 108 111 32 102 114 111 109 32 112 121 116 104 111 110 109 113 116 116 33 32 77 101 115 115 97 103 101 32 35 49 44 32 84 105 109 101 115 116 97 109 112 58 32 50 48 50 53 45 49 49 45 50 55 84 49 55 58 52 54 58 53 54 46 55 57 51 51 49 50]
[<] [0 1]
![>] [50 86 0 10 116 101 115 116 47 116 111 112 105 99 0 1 72 101 108 108 111 32 102 114 111 109 32 112 121 116 104 111 110 109 113 116 116 33 32 77 101 115 115 97 103 101 32 35 49 44 32 84 105 109 101 115 116 97 109 112 58 32 50 48 50 53 45 49 49 45 50 55 84 49 55 58 52 54 58 53 54 46 55 57 51 51 49 50]
![<] [0 1]
```