### PR TITLE
Only parse scheme and host for http types

### DIFF
--- a/pkg/appolly/app/request/metric_attributes.go
+++ b/pkg/appolly/app/request/metric_attributes.go
@@ -196,10 +196,12 @@ func SpanPeer(span *Span) string {
 }
 
 func HostFromSchemeHost(span *Span) string {
-	if strings.Index(span.Statement, SchemeHostSeparator) > 0 {
-		schemeHost := strings.Split(span.Statement, SchemeHostSeparator)
-		if schemeHost[1] != "" {
-			return schemeHost[1]
+	if span.Type == EventTypeHTTPClient || span.Type == EventTypeHTTP {
+		if strings.Index(span.Statement, SchemeHostSeparator) > 0 {
+			schemeHost := strings.Split(span.Statement, SchemeHostSeparator)
+			if schemeHost[1] != "" {
+				return schemeHost[1]
+			}
 		}
 	}
 

--- a/pkg/appolly/app/request/metric_attributes_test.go
+++ b/pkg/appolly/app/request/metric_attributes_test.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package request
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostFromSchemeHost(t *testing.T) {
+	t.Run("HTTP type with scheme and host", func(t *testing.T) {
+		span := &Span{
+			Type:      EventTypeHTTP,
+			Statement: "http;example.com",
+		}
+		assert.Equal(t, "example.com", HostFromSchemeHost(span))
+	})
+
+	t.Run("HTTPClient type with scheme and host", func(t *testing.T) {
+		span := &Span{
+			Type:      EventTypeHTTPClient,
+			Statement: "https;api.example.com",
+		}
+		assert.Equal(t, "api.example.com", HostFromSchemeHost(span))
+	})
+
+	t.Run("Statement with empty host after separator", func(t *testing.T) {
+		span := &Span{
+			Type:      EventTypeHTTP,
+			Statement: "http;",
+		}
+		assert.Empty(t, HostFromSchemeHost(span))
+	})
+
+	t.Run("Statement without scheme-host separator", func(t *testing.T) {
+		span := &Span{
+			Type:      EventTypeHTTP,
+			Statement: "http",
+		}
+		assert.Empty(t, HostFromSchemeHost(span))
+	})
+
+	t.Run("Non-HTTP event type", func(t *testing.T) {
+		span := &Span{
+			Type:      EventTypeSQLClient,
+			Statement: "grpc;example.com",
+		}
+		assert.Empty(t, HostFromSchemeHost(span))
+	})
+
+	t.Run("Empty statement", func(t *testing.T) {
+		span := &Span{
+			Type:      EventTypeHTTP,
+			Statement: "",
+		}
+		assert.Empty(t, HostFromSchemeHost(span))
+	})
+}


### PR DESCRIPTION
We were accidentally parsing host names from SQL statements (since we overload the meaning of statement for HTTP).