### PR TITLE
Initialise in few places for unexpected requests

### DIFF
--- a/bpf/gotracer/go_grpc.c
+++ b/bpf/gotracer/go_grpc.c
@@ -271,6 +271,7 @@ int obi_uprobe_server_handleStream_return(struct pt_regs *ctx) {
     trace->method[0] = '\0';
     trace->host[0] = '\0';
     trace->scheme[0] = '\0';
+    trace->path[0] = '\0';
     trace->pattern[0] = '\0';
     trace->go_start_monotime_ns = invocation->start_monotime_ns;
     bpf_map_delete_elem(&ongoing_goroutines, &g_key);
@@ -456,6 +457,7 @@ static __always_inline int grpc_connect_done(struct pt_regs *ctx, void *err) {
     trace->host[0] = '\0';
     trace->scheme[0] = '\0';
     trace->pattern[0] = '\0';
+    trace->path[0] = '\0';
 
     // Read arguments from the original set of registers
 

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -396,7 +396,7 @@ static __always_inline void handle_traceparent_header(server_http_func_invocatio
             update_traceparent(inv, traceparent_start);
         }
     } else {
-        server_http_func_invocation_t minimal_inv = {.tp = {0}};
+        server_http_func_invocation_t minimal_inv = {0};
         update_traceparent(&minimal_inv, traceparent_start);
         bpf_map_update_elem(&ongoing_http_server_requests, g_key, &minimal_inv, BPF_ANY);
     }
@@ -935,7 +935,7 @@ int obi_uprobe_http2serverConn_runHandler(struct pt_regs *ctx) {
         bpf_dbg_printk("looked up tp %llx", tp);
 
         if (tp) {
-            server_http_func_invocation_t inv = {};
+            server_http_func_invocation_t inv = {0};
             __builtin_memcpy(&inv.tp, tp, sizeof(tp_info_t));
             bpf_dbg_printk("Found traceparent in HTTP2 headers");
             bpf_map_update_elem(&ongoing_http_server_requests, &g_key, &inv, BPF_ANY);


### PR DESCRIPTION
I found that it's possible to get uninitialised buffer in certain rare cases. If we failed to read the data (for grpc and http) we sometimes would leave the pre-created invocation buffer, which sometimes only had the trace parent initalised.