### PR TITLE
Constrain go-mod-check to relevant files only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ check-clean-work-tree:
 .PHONY: check-go-mod
 check-go-mod:
 	go mod tidy
-	git diff -s --exit-code
+	git diff --quiet -- go.mod go.sum
 
 .PHONY: verify-mods
 verify-mods: $(MULTIMOD)


### PR DESCRIPTION
Ensure that Makefile target only fails if there's a problem with `go.mod` and `go.sum`. The current implementation will fail if anything in the tree is different (such as unstaged files), making it harder to pinpoint what and where the true failure lies.