### PR TITLE
better error log on socket filter fail error

### DIFF
--- a/pkg/ebpf/instrumenter.go
+++ b/pkg/ebpf/instrumenter.go
@@ -342,7 +342,7 @@ func (i *instrumenter) handleSockFilterErr(originalErr error, filter *ebpf.Progr
 	if err != nil {
 		return fmt.Errorf("getting jited size: %w", originalErr)
 	}
-	return fmt.Errorf("%s, socket filter has a jited size of %d, consider increasing the value net.core.optmem_max kernel parameter to be larger then the program jitted size, this will not affect existing sockets but only future ones created", originalErr.Error(), jitedSize)
+	return fmt.Errorf("%s, socket filter has a jited size of %d, consider increasing the value net.core.optmem_max kernel parameter to be larger then the program jited size, this will not affect existing sockets but only future ones created", originalErr.Error(), jitedSize)
 }
 
 func attachSocketFilter(filter *ebpf.Program) (int, error) {


### PR DESCRIPTION
This is more likely to happen on older kernel versions or specific distributions like bottlerocket, especially with BPF_DEBUG enabled
give a clear error message with actionable step to solve the issue

log:
```
time=2025-11-29T07:58:59.683+02:00 level=ERROR msg="couldn't trace process. Stopping process tracer" component=discover.traceAttacher error="error attaching socket filter: ran out of memory, socket filter has a jitted size of 6792, consider increasing the value net.core.optmem_max kernel parameter to be larger then the program jitted size, this will not affect existing sockets but only future ones created"

```