### PR TITLE
K8s integration tests: remove ImageBuild and LocalImage pointing to external repos

### DIFF
--- a/internal/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
+++ b/internal/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
@@ -32,9 +32,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "grpcpinger:dev", Dockerfile: k8s.DockerfilePinger},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.104.0"},
-		docker.ImageBuild{Tag: "jaegertracing/all-in-one:1.57"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -45,9 +42,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("grpcpinger:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.104.0"),
-		kube.LocalImage("jaegertracing/all-in-one:1.57"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),

--- a/internal/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
+++ b/internal/test/integration/k8s/daemonset_python/k8s_daemonset_main_test.go
@@ -30,9 +30,6 @@ func TestMain(m *testing.M) {
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
 		docker.ImageBuild{Tag: "pythontestserver:dev", Dockerfile: k8s.DockerfilePythonTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.104.0"},
-		docker.ImageBuild{Tag: "jaegertracing/all-in-one:1.57"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -42,9 +39,6 @@ func TestMain(m *testing.M) {
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("pythontestserver:dev"),
 		kube.LocalImage("obi:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.104.0"),
-		kube.LocalImage("jaegertracing/all-in-one:1.57"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),

--- a/internal/test/integration/k8s/disable_informers/k8s_disable_informers_test.go
+++ b/internal/test/integration/k8s/disable_informers/k8s_disable_informers_test.go
@@ -24,9 +24,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.104.0"},
-		docker.ImageBuild{Tag: "jaegertracing/all-in-one:1.57"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -37,9 +34,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("httppinger:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.104.0"),
-		kube.LocalImage("jaegertracing/all-in-one:1.57"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),

--- a/internal/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
+++ b/internal/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
@@ -35,7 +35,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 		docker.ImageBuild{Tag: "obi-k8s-cache:dev", Dockerfile: k8s.DockerfileK8sCache},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -47,7 +46,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("obi-k8s-cache:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),

--- a/internal/test/integration/k8s/netolly/k8s_netolly_main_test.go
+++ b/internal/test/integration/k8s/netolly/k8s_netolly_main_test.go
@@ -24,8 +24,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.104.0"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -36,8 +34,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("httppinger:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.104.0"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),

--- a/internal/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
+++ b/internal/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
@@ -37,8 +37,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.104.0"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -49,7 +47,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("httppinger:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),

--- a/internal/test/integration/k8s/netolly_multizone/k8s_netolly_multizone_main_test.go
+++ b/internal/test/integration/k8s/netolly_multizone/k8s_netolly_multizone_main_test.go
@@ -24,8 +24,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.104.0"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -36,8 +34,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("httppinger:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.104.0"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape-multi-node.yml"),

--- a/internal/test/integration/k8s/netolly_multizone_prom/k8s_netolly_multizone_prom_main_test.go
+++ b/internal/test/integration/k8s/netolly_multizone_prom/k8s_netolly_multizone_prom_main_test.go
@@ -25,7 +25,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -36,7 +35,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("httppinger:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape-multizone.yml"),

--- a/internal/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
+++ b/internal/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
@@ -25,7 +25,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -36,7 +35,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("httppinger:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),

--- a/internal/test/integration/k8s/netolly_tc_promexport/k8s_netolly_prom_main_test.go
+++ b/internal/test/integration/k8s/netolly_tc_promexport/k8s_netolly_prom_main_test.go
@@ -25,8 +25,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.104.0"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -37,8 +35,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("httppinger:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.104.0"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),

--- a/internal/test/integration/k8s/otel/k8s_main_test.go
+++ b/internal/test/integration/k8s/otel/k8s_main_test.go
@@ -34,9 +34,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "grpcpinger:dev", Dockerfile: k8s.DockerfilePinger},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.104.0"},
-		docker.ImageBuild{Tag: "jaegertracing/all-in-one:1.57"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -48,9 +45,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("grpcpinger:dev"),
 		kube.LocalImage("httppinger:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.104.0"),
-		kube.LocalImage("jaegertracing/all-in-one:1.57"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),

--- a/internal/test/integration/k8s/owners/k8s_owners_main_test.go
+++ b/internal/test/integration/k8s/owners/k8s_owners_main_test.go
@@ -32,9 +32,6 @@ func TestMain(m *testing.M) {
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
 		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.104.0"},
-		docker.ImageBuild{Tag: "jaegertracing/all-in-one:1.57"},
 		docker.ImageBuild{Tag: "grpcpinger:dev", Dockerfile: k8s.DockerfilePinger},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
@@ -46,9 +43,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("grpcpinger:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.104.0"),
-		kube.LocalImage("jaegertracing/all-in-one:1.57"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/03-otelcol.yml"),

--- a/internal/test/integration/k8s/prom/k8s_prom_main_test.go
+++ b/internal/test/integration/k8s/prom/k8s_prom_main_test.go
@@ -27,7 +27,6 @@ func TestMain(m *testing.M) {
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "grpcpinger:dev", Dockerfile: k8s.DockerfilePinger},
 		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -39,7 +38,6 @@ func TestMain(m *testing.M) {
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("grpcpinger:dev"),
 		kube.LocalImage("httppinger:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),

--- a/internal/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
+++ b/internal/test/integration/k8s/restrict_local_node/restrict_local_node_main_test.go
@@ -32,8 +32,6 @@ var cluster *kube.Kind
 func TestMain(m *testing.M) {
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "quay.io/prometheus/prometheus:v2.55.1"},
-		docker.ImageBuild{Tag: "otel/opentelemetry-collector-contrib:0.104.0"},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -42,8 +40,6 @@ func TestMain(m *testing.M) {
 	cluster = kube.NewKind("test-kind-cluster-restrict-local-node",
 		kube.KindConfig(testpath.Manifests+"/00-kind-multi-node.yml"),
 		kube.LocalImage("obi:dev"),
-		kube.LocalImage("quay.io/prometheus/prometheus:v2.55.1"),
-		kube.LocalImage("otel/opentelemetry-collector-contrib:0.104.0"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape-multi-node.yml"),


### PR DESCRIPTION
`kube.ImageBuild` and `kube.LocalImage` are used to build and push an image that is going to be tested.

We also used it for external images, like:
```
		kube.LocalImage("otel/opentelemetry-collector-contrib:0.104.0"),
```
The main idea was to avoid that every K8s test has to download the images again and again, by pushing a local docker image before the Kube test manifests are deployed.

This PR removes them, because:
* These image references aren't updated by Renovate bot
* Now that we are splitting integration tests, any potential benefit would be minimal