### PR TITLE
Don't enable the sdk log level unless we log as debug

### DIFF
--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
@@ -327,8 +328,15 @@ func createZapLoggerDev(sdkLogLevel string) *zap.Logger {
 func getTraceSettings(dataTypeMetrics component.Type, sdkLogLevel string) exporter.Settings {
 	traceProvider := tracenoop.NewTracerProvider()
 	meterProvider := metric.NewMeterProvider()
+
+	zapLogger := zap.NewNop()
+
+	if strings.ToLower(sdkLogLevel) == "debug" {
+		zapLogger = createZapLoggerDev(sdkLogLevel)
+	}
+
 	telemetrySettings := component.TelemetrySettings{
-		Logger:         createZapLoggerDev(sdkLogLevel),
+		Logger:         zapLogger,
 		MeterProvider:  meterProvider,
 		TracerProvider: traceProvider,
 		Resource:       pcommon.NewResource(),


### PR DESCRIPTION
We used to silence all traces SDK export log messages, but that prevented us from debugging when there was an issue. however, the traces export retry in the SDK is set as an error message, even though retry will succeed, so OBI produces unnecessary log lines which are confusing to the end users.

With this PR I'm restoring the noop zap logger and we only enable the proper logger if the OBI log level is set to debug.