### PR TITLE
bpf: revert 4ac221eb88b7d7c97b8a35117df221e3fa7c8739 , update bpf_core_read.h header

### DIFF
--- a/bpf/bpfcore/bpf_core_read.h
+++ b/bpf/bpfcore/bpf_core_read.h
@@ -114,6 +114,9 @@ enum bpf_enum_value_kind {
         case 8:                                                                                    \
             val = *(const unsigned long long *)p;                                                  \
             break;                                                                                 \
+        default:                                                                                   \
+            val = 0;                                                                               \
+            break;                                                                                 \
         }                                                                                          \
         val <<= __CORE_RELO(s, field, LSHIFT_U64);                                                 \
         if (__CORE_RELO(s, field, SIGNED))                                                         \
@@ -123,8 +126,79 @@ enum bpf_enum_value_kind {
         val;                                                                                       \
     })
 
+/*
+ * Write to a bitfield, identified by s->field.
+ * This is the inverse of BPF_CORE_WRITE_BITFIELD().
+ */
+#define BPF_CORE_WRITE_BITFIELD(s, field, new_val)                                                 \
+    ({                                                                                             \
+        void *p = (void *)s + __CORE_RELO(s, field, BYTE_OFFSET);                                  \
+        unsigned int byte_size = __CORE_RELO(s, field, BYTE_SIZE);                                 \
+        unsigned int lshift = __CORE_RELO(s, field, LSHIFT_U64);                                   \
+        unsigned int rshift = __CORE_RELO(s, field, RSHIFT_U64);                                   \
+        unsigned long long mask, val, nval = new_val;                                              \
+        unsigned int rpad = rshift - lshift;                                                       \
+                                                                                                   \
+        asm volatile("" : "+r"(p));                                                                \
+                                                                                                   \
+        switch (byte_size) {                                                                       \
+        case 1:                                                                                    \
+            val = *(unsigned char *)p;                                                             \
+            break;                                                                                 \
+        case 2:                                                                                    \
+            val = *(unsigned short *)p;                                                            \
+            break;                                                                                 \
+        case 4:                                                                                    \
+            val = *(unsigned int *)p;                                                              \
+            break;                                                                                 \
+        case 8:                                                                                    \
+            val = *(unsigned long long *)p;                                                        \
+            break;                                                                                 \
+        }                                                                                          \
+                                                                                                   \
+        mask = (~0ULL << rshift) >> lshift;                                                        \
+        val = (val & ~mask) | ((nval << rpad) & mask);                                             \
+                                                                                                   \
+        switch (byte_size) {                                                                       \
+        case 1:                                                                                    \
+            *(unsigned char *)p = val;                                                             \
+            break;                                                                                 \
+        case 2:                                                                                    \
+            *(unsigned short *)p = val;                                                            \
+            break;                                                                                 \
+        case 4:                                                                                    \
+            *(unsigned int *)p = val;                                                              \
+            break;                                                                                 \
+        case 8:                                                                                    \
+            *(unsigned long long *)p = val;                                                        \
+            break;                                                                                 \
+        }                                                                                          \
+    })
+
+/* Differentiator between compilers builtin implementations. This is a
+ * requirement due to the compiler parsing differences where GCC optimizes
+ * early in parsing those constructs of type pointers to the builtin specific
+ * type, resulting in not being possible to collect the required type
+ * information in the builtin expansion.
+ */
+#ifdef __clang__
+#define ___bpf_typeof(type) ((typeof(type) *)0)
+#else
+#define ___bpf_typeof1(type, NR)                                                                   \
+    ({                                                                                             \
+        extern typeof(type) *___concat(bpf_type_tmp_, NR);                                         \
+        ___concat(bpf_type_tmp_, NR);                                                              \
+    })
+#define ___bpf_typeof(type) ___bpf_typeof1(type, __COUNTER__)
+#endif
+
+#ifdef __clang__
 #define ___bpf_field_ref1(field) (field)
-#define ___bpf_field_ref2(type, field) (((typeof(type) *)0)->field)
+#define ___bpf_field_ref2(type, field) (___bpf_typeof(type)->field)
+#else
+#define ___bpf_field_ref1(field) (&(field))
+#define ___bpf_field_ref2(type, field) (&(___bpf_typeof(type)->field))
+#endif
 #define ___bpf_field_ref(args...) ___bpf_apply(___bpf_field_ref, ___bpf_narg(args))(args)
 
 /*
@@ -172,7 +246,7 @@ enum bpf_enum_value_kind {
  * information. Return 32-bit unsigned integer with type ID from program's own
  * BTF. Always succeeds.
  */
-#define bpf_core_type_id_local(type) __builtin_btf_type_id(*(typeof(type) *)0, BPF_TYPE_ID_LOCAL)
+#define bpf_core_type_id_local(type) __builtin_btf_type_id(*___bpf_typeof(type), BPF_TYPE_ID_LOCAL)
 
 /*
  * Convenience macro to get BTF type ID of a target kernel's type that matches
@@ -181,7 +255,8 @@ enum bpf_enum_value_kind {
  *    - valid 32-bit unsigned type ID in kernel BTF;
  *    - 0, if no matching type was found in a target kernel BTF.
  */
-#define bpf_core_type_id_kernel(type) __builtin_btf_type_id(*(typeof(type) *)0, BPF_TYPE_ID_TARGET)
+#define bpf_core_type_id_kernel(type)                                                              \
+    __builtin_btf_type_id(*___bpf_typeof(type), BPF_TYPE_ID_TARGET)
 
 /*
  * Convenience macro to check that provided named type
@@ -190,7 +265,8 @@ enum bpf_enum_value_kind {
  *    1, if such type is present in target kernel's BTF;
  *    0, if no matching type is found.
  */
-#define bpf_core_type_exists(type) __builtin_preserve_type_info(*(typeof(type) *)0, BPF_TYPE_EXISTS)
+#define bpf_core_type_exists(type)                                                                 \
+    __builtin_preserve_type_info(*___bpf_typeof(type), BPF_TYPE_EXISTS)
 
 /*
  * Convenience macro to check that provided named type
@@ -200,7 +276,7 @@ enum bpf_enum_value_kind {
  *    0, if the type does not match any in the target kernel
  */
 #define bpf_core_type_matches(type)                                                                \
-    __builtin_preserve_type_info(*(typeof(type) *)0, BPF_TYPE_MATCHES)
+    __builtin_preserve_type_info(*___bpf_typeof(type), BPF_TYPE_MATCHES)
 
 /*
  * Convenience macro to get the byte size of a provided named type
@@ -209,7 +285,7 @@ enum bpf_enum_value_kind {
  *    >= 0 size (in bytes), if type is present in target kernel's BTF;
  *    0, if no matching type is found.
  */
-#define bpf_core_type_size(type) __builtin_preserve_type_info(*(typeof(type) *)0, BPF_TYPE_SIZE)
+#define bpf_core_type_size(type) __builtin_preserve_type_info(*___bpf_typeof(type), BPF_TYPE_SIZE)
 
 /*
  * Convenience macro to check that provided enumerator value is defined in
@@ -219,8 +295,13 @@ enum bpf_enum_value_kind {
  *    kernel's BTF;
  *    0, if no matching enum and/or enum value within that enum is found.
  */
+#ifdef __clang__
 #define bpf_core_enum_value_exists(enum_type, enum_value)                                          \
     __builtin_preserve_enum_value(*(typeof(enum_type) *)enum_value, BPF_ENUMVAL_EXISTS)
+#else
+#define bpf_core_enum_value_exists(enum_type, enum_value)                                          \
+    __builtin_preserve_enum_value(___bpf_typeof(enum_type), enum_value, BPF_ENUMVAL_EXISTS)
+#endif
 
 /*
  * Convenience macro to get the integer value of an enumerator value in
@@ -230,8 +311,13 @@ enum bpf_enum_value_kind {
  *    present in target kernel's BTF;
  *    0, if no matching enum and/or enum value within that enum is found.
  */
+#ifdef __clang__
 #define bpf_core_enum_value(enum_type, enum_value)                                                 \
     __builtin_preserve_enum_value(*(typeof(enum_type) *)enum_value, BPF_ENUMVAL_VALUE)
+#else
+#define bpf_core_enum_value(enum_type, enum_value)                                                 \
+    __builtin_preserve_enum_value(___bpf_typeof(enum_type), enum_value, BPF_ENUMVAL_VALUE)
+#endif
 
 /*
  * bpf_core_read() abstracts away bpf_probe_read_kernel() call and captures
@@ -243,7 +329,7 @@ enum bpf_enum_value_kind {
  * a relocation, which records BTF type ID describing root struct/union and an
  * accessor string which describes exact embedded field that was used to take
  * an address. See detailed description of this relocation format and
- * semantics in comments to struct bpf_field_reloc in libbpf_internal.h.
+ * semantics in comments to struct bpf_core_relo in include/uapi/linux/bpf.h.
  *
  * This relocation allows libbpf to adjust BPF instruction to use correct
  * actual field offset, based on target kernel BTF type that matches original
@@ -266,6 +352,17 @@ enum bpf_enum_value_kind {
 /* NOTE: see comments for BPF_CORE_READ_USER() about the proper types use. */
 #define bpf_core_read_user_str(dst, sz, src)                                                       \
     bpf_probe_read_user_str(dst, sz, (const void *)__builtin_preserve_access_index(src))
+
+extern void *bpf_rdonly_cast(const void *obj, __u32 btf_id) __ksym __weak;
+
+/*
+ * Cast provided pointer *ptr* into a pointer to a specified *type* in such
+ * a way that BPF verifier will become aware of associated kernel-side BTF
+ * type. This allows to access members of kernel types directly without the
+ * need to use BPF_CORE_READ() macros.
+ */
+#define bpf_core_cast(ptr, type)                                                                   \
+    ((typeof(type) *)bpf_rdonly_cast((ptr), bpf_core_type_id_kernel(type)))
 
 #define ___concat(a, b) a##b
 #define ___apply(fn, n) ___concat(fn, n)
@@ -318,7 +415,13 @@ enum bpf_enum_value_kind {
 #define ___arrow10(a, b, c, d, e, f, g, h, i, j) a->b->c->d->e->f->g->h->i->j
 #define ___arrow(...) ___apply(___arrow, ___narg(__VA_ARGS__))(__VA_ARGS__)
 
+#if defined(__clang__) && (__clang_major__ >= 19)
+#define ___type(...) __typeof_unqual__(___arrow(__VA_ARGS__))
+#elif defined(__GNUC__) && (__GNUC__ >= 14)
+#define ___type(...) __typeof_unqual__(___arrow(__VA_ARGS__))
+#else
 #define ___type(...) typeof(___arrow(__VA_ARGS__))
+#endif
 
 #define ___read(read_fn, dst, src_type, src, accessor)                                             \
     read_fn((void *)(dst), sizeof(*(dst)), &((src_type)(src))->accessor)
@@ -365,7 +468,7 @@ enum bpf_enum_value_kind {
 
 /* Non-CO-RE variant of BPF_CORE_READ_INTO() */
 #define BPF_PROBE_READ_INTO(dst, src, a, ...)                                                      \
-    ({___core_read(bpf_probe_read, bpf_probe_read, dst, (src), a, ##__VA_ARGS__)})
+    ({___core_read(bpf_probe_read_kernel, bpf_probe_read_kernel, dst, (src), a, ##__VA_ARGS__)})
 
 /* Non-CO-RE variant of BPF_CORE_READ_USER_INTO().
  *
@@ -393,7 +496,7 @@ enum bpf_enum_value_kind {
 
 /* Non-CO-RE variant of BPF_CORE_READ_STR_INTO() */
 #define BPF_PROBE_READ_STR_INTO(dst, src, a, ...)                                                  \
-    ({___core_read(bpf_probe_read_str, bpf_probe_read, dst, (src), a, ##__VA_ARGS__)})
+    ({___core_read(bpf_probe_read_kernel_str, bpf_probe_read_kernel, dst, (src), a, ##__VA_ARGS__)})
 
 /*
  * Non-CO-RE variant of BPF_CORE_READ_USER_STR_INTO().
@@ -472,22 +575,5 @@ enum bpf_enum_value_kind {
         BPF_PROBE_READ_USER_INTO(&__r, (src), a, ##__VA_ARGS__);                                   \
         __r;                                                                                       \
     })
-
-#ifdef COMPILE_RUNTIME
-
-#undef BPF_CORE_READ
-#define BPF_CORE_READ BPF_PROBE_READ
-#undef BPF_CORE_READ_USER
-#define BPF_CORE_READ_USER BPF_PROBE_READ_USER
-#undef BPF_CORE_READ_INTO
-#define BPF_CORE_READ_INTO BPF_PROBE_READ_INTO
-#undef BPF_CORE_READ_USER_INTO
-#define BPF_CORE_READ_USER_INTO BPF_PROBE_READ_USER_INTO
-#undef BPF_CORE_READ_STR_INTO
-#define BPF_CORE_READ_STR_INTO BPF_PROBE_READ_STR_INTO
-#undef BPF_CORE_READ_USER_STR_INTO
-#define BPF_CORE_READ_USER_STR_INTO BPF_PROBE_READ_USER_STR_INTO
-
-#endif
 
 #endif


### PR DESCRIPTION
Commit https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/4ac221eb88b7d7c97b8a35117df221e3fa7c8739 silently broke the TCP iterator:

```
msg="Iterator output" component=generic.Tracer line="Add listening port=0 netns=-268435456" iterator=Tracing(obi_iter_tcp)#80
msg="Iterator output" component=generic.Tracer line="Add listening port=0 netns=-268435456" iterator=Tracing(obi_iter_tcp)#80
msg="Iterator output" component=generic.Tracer line="Add listening port=0 netns=-268435456" iterator=Tracing(obi_iter_tcp)#80
msg="Iterator output" component=generic.Tracer line="Add listening port=0 netns=-268435456" iterator=Tracing(obi_iter_tcp)#80
msg="Iterator output" component=generic.Tracer line="Add listening port=0 netns=-268435456" iterator=Tracing(obi_iter_tcp)#80
...
```

- Revert commit 4ac221eb88b7d7c97b8a35117df221e3fa7c8739
- Update bpf_core_read.h to include latest patches which fix the original issue: https://github.com/libbpf/libbpf/commit/d88ca951338a765bcb28672dc7b1221fde8e4ae4

TCP iterator is now able to read data correctly:
```
msg="Iterator output" component=generic.Tracer line="Add listening port=12865 netns=-268435456" iterator=Tracing(obi_iter_tcp)#78
msg="Iterator output" component=generic.Tracer line="Add listening port=6379 netns=-268435456" iterator=Tracing(obi_iter_tcp)#78
msg="Iterator output" component=generic.Tracer line="Add listening port=5000 netns=-268435456" iterator=Tracing(obi_iter_tcp)#78
msg="Iterator output" component=generic.Tracer line="Add listening port=5001 netns=-268435456" iterator=Tracing(obi_iter_tcp)#78
msg="Iterator output" component=generic.Tracer line="Add listening port=5002 netns=-268435456" iterator=Tracing(obi_iter_tcp)#78
```