### PR TITLE
feat(mqtt): header and CONNECT parsing

### DIFF
--- a/pkg/internal/ebpf/mqttparser/header.go
+++ b/pkg/internal/ebpf/mqttparser/header.go
@@ -1,0 +1,120 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mqttparser
+
+import (
+	"errors"
+)
+
+const (
+	MinPacketLen = 2 // fixed header (1 byte) + remaining length (1 byte)
+)
+
+type (
+	// PacketType is the type of MQTT Control Packet.
+	PacketType uint8
+
+	// Offset is the position in the packet or segment.
+	Offset = int
+)
+
+// MQTTControlPacket represents a parsed MQTT Control Packet's fixed header.
+// Data, including variable header and payload, are to be parsed separately.
+type MQTTControlPacket struct {
+	FixedHeader FixedHeader
+}
+
+// Length returns the total length of the packet.
+func (p MQTTControlPacket) Length() int {
+	return p.FixedHeader.Length + p.FixedHeader.RemainingLength
+}
+
+// MQTT Control Packet Types, 0 is reserved.
+const (
+	PacketTypeCONNECT     PacketType = 1
+	PacketTypeCONNACK     PacketType = 2
+	PacketTypePUBLISH     PacketType = 3
+	PacketTypePUBACK      PacketType = 4
+	PacketTypePUBREC      PacketType = 5 // Publish received (assured delivery part 1)
+	PacketTypePUBREL      PacketType = 6 // Publish release (assured delivery part 2)
+	PacketTypePUBCOMP     PacketType = 7 // Publish complete (assured delivery part 3)
+	PacketTypeSUBSCRIBE   PacketType = 8
+	PacketTypeSUBACK      PacketType = 9
+	PacketTypeUNSUBSCRIBE PacketType = 10
+	PacketTypeUNSUBACK    PacketType = 11
+	PacketTypePINGREQ     PacketType = 12
+	PacketTypePINGRESP    PacketType = 13
+	PacketTypeDISCONNECT  PacketType = 14
+	PacketTypeAUTH        PacketType = 15 // MQTT 5.0 only
+)
+
+// FixedHeader, present in all MQTT Control Packets.
+type FixedHeader struct {
+	PacketType PacketType
+
+	// Flags specific to each MQTT Control Packet type, particularly for PUBLISH packets.
+	Flags uint8
+
+	// RemainingLength of the packet (Variable Header + Payload).
+	RemainingLength int
+
+	// Length of fixed header:
+	// 1 byte for type/flags + 1-4 bytes to represent RemainingLength.
+	Length int
+}
+
+// ParseMQTTPackets parses multiple MQTT packets from a single byte slice, as
+// there may be cases where multiple MQTT packets are present in one TCP segment.
+func ParseMQTTPackets(segment []byte) ([]MQTTControlPacket, error) {
+	var packets []MQTTControlPacket
+	offset := 0
+
+	for offset < len(segment) {
+		if len(segment[offset:]) < MinPacketLen {
+			break
+		}
+
+		packet, err := NewMQTTControlPacket(segment[offset:])
+		if err != nil {
+			return packets, err
+		}
+
+		if offset+packet.Length() > len(segment) {
+			return packets, errors.New("incomplete packet")
+		}
+
+		packets = append(packets, packet)
+		offset += packet.Length()
+	}
+
+	return packets, nil
+}
+
+// NewMQTTControlPacket parses the MQTT fixed header from a packet.
+func NewMQTTControlPacket(pkt []byte) (MQTTControlPacket, error) {
+	if len(pkt) < MinPacketLen {
+		return MQTTControlPacket{}, errors.New("packet too short for MQTT fixed header")
+	}
+
+	// Parse first byte: packet type (bits 7-4) and flags (bits 3-0)
+	firstByte := pkt[0]
+	packetType := PacketType((firstByte >> 4) & 0x0F)
+	flags := firstByte & 0x0F
+
+	// Parse remaining length (variable-length encoding)
+	r := NewPacketReader(pkt, 1)
+	rl, err := r.ReadVariableByteInteger()
+	if err != nil {
+		return MQTTControlPacket{}, err
+	}
+
+	return MQTTControlPacket{
+		FixedHeader: FixedHeader{
+			PacketType:      packetType,
+			Flags:           flags,
+			RemainingLength: rl,
+			Length:          r.Offset(), // 1 byte for type/flags + variable length bytes
+		},
+	}, nil
+}

--- a/pkg/internal/ebpf/mqttparser/header_test.go
+++ b/pkg/internal/ebpf/mqttparser/header_test.go
@@ -1,0 +1,324 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mqttparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMQTTPackets(t *testing.T) {
+	tests := []struct {
+		name          string
+		packet        []byte
+		expectErr     bool
+		expectedCount int
+	}{
+		{
+			name: "single CONNECT packet",
+			packet: []byte{
+				0x10,       // CONNECT, flags=0
+				0x0A,       // remaining length = 10
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x04, 0x02, 0x00, 0x3C, // level, flags, keep alive
+			},
+			expectErr:     false,
+			expectedCount: 1,
+		},
+		{
+			name: "multiple packets - CONNECT and PUBLISH",
+			packet: []byte{
+				// First packet: CONNECT
+				0x10,       // CONNECT, flags=0
+				0x0A,       // remaining length = 10
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x04, 0x02, 0x00, 0x3C, // level, flags, keep alive
+				// Second packet: PUBLISH
+				0x30,       // PUBLISH, flags=0
+				0x05,       // remaining length = 5
+				0x00, 0x03, // topic length = 3
+				0x61, 0x2F, 0x62, // "a/b"
+			},
+			expectErr:     false,
+			expectedCount: 2,
+		},
+		{
+			name: "multiple packets - PINGREQ and PINGRESP",
+			packet: []byte{
+				// First packet: PINGREQ
+				0xC0, // PINGREQ, flags=0
+				0x00, // remaining length = 0
+				// Second packet: PINGRESP
+				0xD0, // PINGRESP, flags=0
+				0x00, // remaining length = 0
+			},
+			expectErr:     false,
+			expectedCount: 2,
+		},
+		{
+			name: "incomplete packet at end",
+			packet: []byte{
+				// Complete CONNECT packet
+				0x10,       // CONNECT, flags=0
+				0x0A,       // remaining length = 10
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x04, 0x02, 0x00, 0x3C, // level, flags, keep alive
+				// Incomplete PUBLISH packet
+				0x30, // PUBLISH, flags=0
+				0x05, // remaining length = 5, but only 2 bytes follow
+				0x00, 0x03,
+			},
+			expectErr:     true, // Error because incomplete packet
+			expectedCount: 1,    // Should parse first packet
+		},
+		{
+			name:          "empty packet",
+			packet:        []byte{},
+			expectErr:     false,
+			expectedCount: 0,
+		},
+		{
+			name: "invalid header - insufficient data",
+			packet: []byte{
+				0x10, // CONNECT
+				// Missing remaining length
+			},
+			expectErr:     false, // Not enough data, just stop parsing (no error)
+			expectedCount: 0,
+		},
+		{
+			name: "packet with variable length encoding",
+			packet: []byte{
+				// CONNECT with multi-byte remaining length
+				0x10,       // CONNECT
+				0x80, 0x01, // remaining length = 128 (2 bytes)
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x04, 0x02, 0x00, 0x3C, // level, flags, keep alive
+				// ... more bytes to make up 128 total payload
+			},
+			expectErr:     true, // Will fail because we don't have 128 bytes
+			expectedCount: 0,
+		},
+		{
+			name: "invalid packet",
+			packet: []byte{
+				0x10,                   // CONNECT
+				0x80, 0x80, 0x80, 0x80, // Invalid varint - continuation bit set on 4th byte but no 5th byte
+			},
+			expectErr:     true,
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			packets, err := ParseMQTTPackets(tt.packet)
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Len(t, packets, tt.expectedCount)
+		})
+	}
+}
+
+func TestParseMQTTPacketsMultiplePackets(t *testing.T) {
+	// Test with multiple complete packets
+	packet := []byte{
+		// Packet 1: CONNECT
+		0x10,       // CONNECT, flags=0
+		0x0A,       // remaining length = 10
+		0x00, 0x04, // protocol name length = 4
+		0x4D, 0x51, 0x54, 0x54, // "MQTT"
+		0x04, 0x02, 0x00, 0x3C, // level, flags, keep alive
+		// Packet 2: PUBLISH QoS 0
+		0x30,       // PUBLISH, flags=0
+		0x0A,       // remaining length = 10 (2 topic len + 3 topic + 5 payload)
+		0x00, 0x03, // topic length = 3
+		0x61, 0x2F, 0x62, // "a/b"
+		0x68, 0x65, 0x6C, 0x6C, 0x6F, // "hello"
+		// Packet 3: PINGREQ
+		0xC0, // PINGREQ, flags=0
+		0x00, // remaining length = 0
+	}
+
+	packets, err := ParseMQTTPackets(packet)
+	require.NoError(t, err)
+	assert.Len(t, packets, 3)
+
+	// Verify first packet (CONNECT)
+	assert.Equal(t, PacketTypeCONNECT, packets[0].FixedHeader.PacketType)
+	assert.Equal(t, 2, packets[0].FixedHeader.Length)
+	assert.Equal(t, 12, packets[0].Length())
+
+	// Verify second packet (PUBLISH)
+	assert.Equal(t, PacketTypePUBLISH, packets[1].FixedHeader.PacketType)
+	assert.Equal(t, 2, packets[1].FixedHeader.Length)
+	assert.Equal(t, 12, packets[1].Length()) // 2 header + 10 payload
+
+	// Verify third packet (PINGREQ)
+	assert.Equal(t, PacketTypePINGREQ, packets[2].FixedHeader.PacketType)
+	assert.Equal(t, 2, packets[2].FixedHeader.Length)
+	assert.Equal(t, 2, packets[2].Length())
+}
+
+func TestNewMQTTControlPacket(t *testing.T) {
+	tests := []struct {
+		name                    string
+		packet                  []byte
+		expectErr               bool
+		expectedType            PacketType
+		expectedFlags           uint8
+		expectedRemainingLength int
+		expectedHeaderLength    int
+	}{
+		{
+			name: "CONNECT packet with small remaining length",
+			packet: []byte{
+				0x10, // CONNECT (type=1), flags=0
+				0x0A, // remaining length = 10
+			},
+			expectErr:               false,
+			expectedType:            PacketTypeCONNECT,
+			expectedFlags:           0,
+			expectedRemainingLength: 10,
+			expectedHeaderLength:    2,
+		},
+		{
+			name: "PUBLISH packet QoS 0",
+			packet: []byte{
+				0x30, // PUBLISH (type=3), flags=0 (QoS 0, no retain)
+				0x05, // remaining length = 5
+			},
+			expectErr:               false,
+			expectedType:            PacketTypePUBLISH,
+			expectedFlags:           0,
+			expectedRemainingLength: 5,
+			expectedHeaderLength:    2,
+		},
+		{
+			name: "PUBLISH packet QoS 1 with retain",
+			packet: []byte{
+				0x33, // PUBLISH (type=3), flags=3 (QoS 1, retain=1)
+				0x0F, // remaining length = 15
+			},
+			expectErr:               false,
+			expectedType:            PacketTypePUBLISH,
+			expectedFlags:           3,
+			expectedRemainingLength: 15,
+			expectedHeaderLength:    2,
+		},
+		{
+			name: "SUBSCRIBE packet",
+			packet: []byte{
+				0x82, // SUBSCRIBE (type=8), flags=2 (reserved)
+				0x20, // remaining length = 32
+			},
+			expectErr:               false,
+			expectedType:            PacketTypeSUBSCRIBE,
+			expectedFlags:           2,
+			expectedRemainingLength: 32,
+			expectedHeaderLength:    2,
+		},
+		{
+			name: "remaining length with continuation byte",
+			packet: []byte{
+				0x10, // CONNECT
+				0x80, // continuation bit set, value = 0
+				0x01, // continuation bit clear, value = 1, total = 128
+			},
+			expectErr:               false,
+			expectedType:            PacketTypeCONNECT,
+			expectedFlags:           0,
+			expectedRemainingLength: 128,
+			expectedHeaderLength:    3,
+		},
+		{
+			name: "remaining length with multiple continuation bytes",
+			packet: []byte{
+				0x10, // CONNECT
+				0x80, // continuation bit set, value = 0
+				0x80, // continuation bit set, value = 0 * 128 = 0
+				0x01, // continuation bit clear, value = 1, total = 0 + 0*128 + 1*128^2 = 16384
+			},
+			expectErr:               false,
+			expectedType:            PacketTypeCONNECT,
+			expectedFlags:           0,
+			expectedRemainingLength: 16384,
+			expectedHeaderLength:    4,
+		},
+		{
+			name: "packet too short",
+			packet: []byte{
+				0x10, // Only one byte
+			},
+			expectErr: true,
+		},
+		{
+			name:      "empty packet",
+			packet:    []byte{},
+			expectErr: true,
+		},
+		{
+			name: "remaining length incomplete",
+			packet: []byte{
+				0x10, // CONNECT
+				0x80, // continuation bit set, but no more bytes
+			},
+			expectErr: true,
+		},
+		{
+			name: "actual CONNECT packet",
+			packet: []byte{
+				0x10,       // CONNECT, flags=0
+				0x2B,       // remaining length = 43
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT" (77='M', 81='Q', 84='T', 84='T')
+				0x04,       // protocol level = 4 (MQTT 3.1.1)
+				0x02,       // connect flags (clean session=1)
+				0x00, 0x3C, // keep alive = 60
+				0x00, 0x1F, // client ID length = 31
+
+				// Client ID: "pythonmqtt_publisher_1765206934"
+				0x70, 0x79, 0x74, 0x68, 0x6F, 0x6E, // "python"
+				0x6D, 0x71, 0x74, 0x74, // "mqtt"
+				0x5F,                                                 // "_"
+				0x70, 0x75, 0x62, 0x6C, 0x69, 0x73, 0x68, 0x65, 0x72, // "publisher"
+				0x5F,                                                       // "_"
+				0x31, 0x37, 0x36, 0x35, 0x32, 0x30, 0x36, 0x39, 0x33, 0x34, // "1765206934"
+			},
+			expectErr:               false,
+			expectedType:            PacketTypeCONNECT,
+			expectedFlags:           0,
+			expectedRemainingLength: 43,
+			expectedHeaderLength:    2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, err := NewMQTTControlPacket(tt.packet)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedType, parsed.FixedHeader.PacketType)
+				assert.Equal(t, tt.expectedFlags, parsed.FixedHeader.Flags)
+				assert.Equal(t, tt.expectedRemainingLength, parsed.FixedHeader.RemainingLength)
+				assert.Equal(t, tt.expectedHeaderLength, parsed.FixedHeader.Length)
+				assert.Equal(t, tt.expectedHeaderLength+tt.expectedRemainingLength, parsed.Length())
+			}
+		})
+	}
+}

--- a/pkg/internal/ebpf/mqttparser/packet_connect.go
+++ b/pkg/internal/ebpf/mqttparser/packet_connect.go
@@ -1,0 +1,225 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mqttparser
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ConnectPacket represents a parsed MQTT CONNECT packet.
+//
+// After a Network Connection is established by a Client to a Server, the first
+// packet sent from the Client to the Server MUST be a CONNECT packet.
+//
+// A Client can only send the CONNECT packet once over a Network Connection.
+//
+// The Payload contains one or more encoded fields. They specify a unique Client
+// identifier for the Client, a Will Topic, Will Payload, User Name and
+// Password. All but the Client identifier can be omitted and their presence is
+// determined based on flags in the Variable Header.
+type ConnectPacket struct {
+	Protocol Protocol
+
+	// CleanStart is a flag that indicates if the client should create a new session.
+	CleanStart bool
+
+	// KeepAlive is the maximum time in seconds between messages.
+	KeepAlive uint16
+
+	// ClientID is a required field in the CONNECT packet payload.
+	ClientID string
+}
+
+// ParseConnectPacket parses an MQTT CONNECT packet.
+// offset should point to the start of the variable header (after fixed header).
+func ParseConnectPacket(pkt []byte, offset Offset) (*ConnectPacket, Offset, error) {
+	var connect ConnectPacket
+
+	if offset >= len(pkt) {
+		return &connect, offset, errors.New("insufficient data for CONNECT packet")
+	}
+
+	r := NewConnectPacketReader(pkt, offset)
+
+	protocol, err := r.ReadProtocol()
+	if err != nil {
+		connect.Protocol = protocol // May contain partial data (e.g., Name only)
+		return &connect, r.Offset(), err
+	}
+	connect.Protocol = protocol
+
+	cleanStart, err := r.ReadConnectFlags()
+	if err != nil {
+		return &connect, r.Offset(), err
+	}
+	connect.CleanStart = cleanStart
+
+	keepAlive, err := r.ReadKeepAlive()
+	if err != nil {
+		return &connect, r.Offset(), err
+	}
+	connect.KeepAlive = keepAlive
+
+	if connect.Protocol.Level == ProtocolLevelMQTT50 {
+		if err := r.SkipProperties(); err != nil {
+			return &connect, r.Offset(), err
+		}
+	}
+
+	clientID, err := r.ReadClientID()
+	if err != nil {
+		return &connect, r.Offset(), err
+	}
+	connect.ClientID = clientID
+
+	return &connect, r.Offset(), nil
+}
+
+// ConnectPacketReader provides domain-specific read methods for CONNECT packets.
+// It embeds PacketReader to inherit primitive read operations.
+type ConnectPacketReader struct {
+	PacketReader
+}
+
+// NewConnectPacketReader creates a new ConnectPacketReader starting at the given offset.
+func NewConnectPacketReader(pkt []byte, offset int) *ConnectPacketReader {
+	return &ConnectPacketReader{PacketReader: NewPacketReader(pkt, offset)}
+}
+
+// ReadProtocol reads the protocol name and level from the packet.
+func (r *ConnectPacketReader) ReadProtocol() (Protocol, error) {
+	nameRaw, err := r.ReadString()
+	if err != nil {
+		return Protocol{}, err
+	}
+
+	name, err := NewProtocolName(nameRaw)
+	if err != nil {
+		return Protocol{}, err
+	}
+
+	levelRaw, err := r.ReadUint8()
+	if err != nil {
+		return Protocol{Name: name}, err
+	}
+
+	return Protocol{Name: name, Level: ProtocolLevel(levelRaw)}, nil
+}
+
+// ReadConnectFlags reads the connect flags byte and returns the CleanStart flag.
+func (r *ConnectPacketReader) ReadConnectFlags() (cleanStart bool, err error) {
+	flags, err := r.ReadUint8()
+	if err != nil {
+		return false, err
+	}
+	// Bit 1 is Clean Start flag
+	return (flags & 0x02) != 0, nil
+}
+
+// ReadKeepAlive reads the keep alive value (in seconds).
+func (r *ConnectPacketReader) ReadKeepAlive() (uint16, error) {
+	return r.ReadUint16()
+}
+
+// SkipProperties reads the property length and skips over the properties bytes.
+// This is used for MQTT 5.0 packets.
+func (r *ConnectPacketReader) SkipProperties() error {
+	propLen, err := r.ReadVariableByteInteger()
+	if err != nil {
+		return err
+	}
+	return r.Skip(propLen)
+}
+
+// ReadClientID reads the client identifier from the payload.
+func (r *ConnectPacketReader) ReadClientID() (string, error) {
+	return r.ReadString()
+}
+
+type Protocol struct {
+	Name  ProtocolName
+	Level ProtocolLevel
+}
+
+func NewProtocol(name string, level uint8) (*Protocol, error) {
+	n, err := NewProtocolName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	l, err := NewProtocolLevel(level)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Protocol{
+		Name:  n,
+		Level: l,
+	}, nil
+}
+
+func (p Protocol) IsValid() bool {
+	switch p.Level {
+	case ProtocolLevelMQTT31:
+		return p.Name == ProtocolNameMQIsdp
+	case ProtocolLevelMQTT311, ProtocolLevelMQTT50:
+		return p.Name == ProtocolNameMQTT
+	default:
+		return false
+	}
+}
+
+type ProtocolName string
+
+const (
+	ProtocolNameMQTT   ProtocolName = "MQTT"
+	ProtocolNameMQIsdp ProtocolName = "MQIsdp"
+)
+
+func NewProtocolName(name string) (ProtocolName, error) {
+	switch name {
+	case string(ProtocolNameMQTT), string(ProtocolNameMQIsdp):
+		return ProtocolName(name), nil
+	default:
+		return "", fmt.Errorf("%q is not a recognized mqtt protocol name", name)
+	}
+}
+
+func (pn ProtocolName) String() string {
+	return string(pn)
+}
+
+type ProtocolLevel uint8
+
+const (
+	ProtocolLevelMQTT31  ProtocolLevel = 3
+	ProtocolLevelMQTT311 ProtocolLevel = 4
+	ProtocolLevelMQTT50  ProtocolLevel = 5
+)
+
+func NewProtocolLevel(level uint8) (ProtocolLevel, error) {
+	switch level {
+	case 3:
+		return ProtocolLevelMQTT31, nil
+	case 4:
+		return ProtocolLevelMQTT311, nil
+	case 5:
+		return ProtocolLevelMQTT50, nil
+	}
+	return 0, fmt.Errorf("%d is not a recognized mqtt protocol level", level)
+}
+
+func (pl ProtocolLevel) String() string {
+	switch pl {
+	case ProtocolLevelMQTT31:
+		return "3.1"
+	case ProtocolLevelMQTT311:
+		return "3.1.1"
+	case ProtocolLevelMQTT50:
+		return "5.0"
+	default:
+		return fmt.Sprintf("%d", pl)
+	}
+}

--- a/pkg/internal/ebpf/mqttparser/packet_connect_test.go
+++ b/pkg/internal/ebpf/mqttparser/packet_connect_test.go
@@ -1,0 +1,783 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mqttparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseConnectPacketWithRealPacket(t *testing.T) {
+	// Real MQTT CONNECT packet from test
+	packet := []byte{
+		0x10,       // CONNECT, flags=0
+		0x2B,       // remaining length = 43
+		0x00, 0x04, // protocol name length = 4
+		0x4D, 0x51, 0x54, 0x54, // "MQTT"
+		0x04,       // protocol level = 4 (MQTT 3.1.1)
+		0x02,       // connect flags (clean session=1)
+		0x00, 0x3C, // keep alive = 60
+		0x00, 0x1F, // client ID length = 31
+		// Client ID: "pythonmqtt_publisher_1765206934"
+		0x70, 0x79, 0x74, 0x68, 0x6F, 0x6E, // "python"
+		0x6D, 0x71, 0x74, 0x74, // "mqtt"
+		0x5F,                                                 // "_"
+		0x70, 0x75, 0x62, 0x6C, 0x69, 0x73, 0x68, 0x65, 0x72, // "publisher"
+		0x5F,                                                       // "_"
+		0x31, 0x37, 0x36, 0x35, 0x32, 0x30, 0x36, 0x39, 0x33, 0x34, // "1765206934"
+	}
+
+	// Parse fixed header first
+	parsed, err := NewMQTTControlPacket(packet)
+	require.NoError(t, err)
+	assert.Equal(t, PacketTypeCONNECT, parsed.FixedHeader.PacketType)
+	assert.Equal(t, uint8(0), parsed.FixedHeader.Flags)
+	assert.Equal(t, 43, parsed.FixedHeader.RemainingLength)
+	assert.Equal(t, 2, parsed.FixedHeader.Length)
+
+	// Parse CONNECT packet starting from variable header
+	connect, offset, err := ParseConnectPacket(packet, parsed.FixedHeader.Length)
+	require.NoError(t, err)
+	require.NotNil(t, connect)
+
+	assert.Equal(t, ProtocolNameMQTT, connect.Protocol.Name)
+	assert.Equal(t, "MQTT", connect.Protocol.Name.String())
+	assert.Equal(t, ProtocolLevelMQTT311, connect.Protocol.Level)
+	assert.True(t, connect.CleanStart)
+	assert.Equal(t, uint16(60), connect.KeepAlive)
+	assert.Equal(t, "pythonmqtt_publisher_1765206934", connect.ClientID)
+
+	// Verify offset is correct (header + variable header + payload)
+	expectedOffset := parsed.Length()
+	assert.Equal(t, expectedOffset, offset)
+}
+
+func TestParseConnectPacket(t *testing.T) {
+	tests := []struct {
+		name           string
+		packet         []byte
+		offset         Offset
+		expectErr      bool
+		expected       *ConnectPacket
+		expectedOffset Offset
+	}{
+		{
+			name: "MQTT 3.1.1 with clean session",
+			packet: []byte{
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x04,       // protocol level = 4 (MQTT 3.1.1)
+				0x02,       // connect flags (clean session=1)
+				0x00, 0x3C, // keep alive = 60
+				0x00, 0x04, // client ID length = 4
+				0x74, 0x65, 0x73, 0x74, // "test"
+			},
+			offset: 0,
+			expected: &ConnectPacket{
+				Protocol: Protocol{
+					Name:  ProtocolNameMQTT,
+					Level: ProtocolLevelMQTT311,
+				},
+				CleanStart: true,
+				KeepAlive:  60,
+				ClientID:   "test",
+			},
+			expectedOffset: 16,
+		},
+		{
+			name: "MQTT 3.1.1 without clean session",
+			packet: []byte{
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x04,       // protocol level = 4
+				0x00,       // connect flags (clean session=0)
+				0x00, 0x3C, // keep alive = 60
+				0x00, 0x04, // client ID length = 4
+				0x74, 0x65, 0x73, 0x73, // "tess"
+			},
+			offset: 0,
+			expected: &ConnectPacket{
+				Protocol: Protocol{
+					Name:  ProtocolNameMQTT,
+					Level: ProtocolLevelMQTT311,
+				},
+				CleanStart: false,
+				KeepAlive:  60,
+				ClientID:   "tess",
+			},
+			expectedOffset: 16,
+		},
+		{
+			name: "MQTT 3.1 (MQIsdp)",
+			packet: []byte{
+				0x00, 0x06, // protocol name length = 6
+				0x4D, 0x51, 0x49, 0x73, 0x64, 0x70, // "MQIsdp"
+				0x03,       // protocol level = 3 (MQTT 3.1)
+				0x02,       // connect flags (clean session=1)
+				0x00, 0x3C, // keep alive = 60
+				0x00, 0x05, // client ID length = 5
+				0x68, 0x65, 0x6C, 0x6C, 0x6F, // "hello"
+			},
+			offset: 0,
+			expected: &ConnectPacket{
+				Protocol: Protocol{
+					Name:  ProtocolNameMQIsdp,
+					Level: ProtocolLevelMQTT31,
+				},
+				CleanStart: true,
+				KeepAlive:  60,
+				ClientID:   "hello",
+			},
+			expectedOffset: 19,
+		},
+		{
+			name: "MQTT 5.0 with properties",
+			packet: []byte{
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x05,       // protocol level = 5 (MQTT 5.0)
+				0x02,       // connect flags (clean session=1)
+				0x00, 0x3C, // keep alive = 60
+				0x03,             // Property Length = 3
+				0x11, 0x22, 0x33, // Properties bytes (3 bytes)
+				0x00, 0x04, // client ID length = 4
+				0x74, 0x65, 0x73, 0x74, // "test"
+			},
+			offset: 0,
+			expected: &ConnectPacket{
+				Protocol: Protocol{
+					Name:  ProtocolNameMQTT,
+					Level: ProtocolLevelMQTT50,
+				},
+				CleanStart: true,
+				KeepAlive:  60,
+				ClientID:   "test",
+			},
+			expectedOffset: 20,
+		},
+		{
+			name: "MQTT 5.0 with empty properties",
+			packet: []byte{
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x05,       // protocol level = 5 (MQTT 5.0)
+				0x02,       // connect flags (clean session=1)
+				0x00, 0x3C, // keep alive = 60
+				0x00,       // Property Length = 0 (no properties)
+				0x00, 0x04, // client ID length = 4
+				0x74, 0x65, 0x73, 0x74, // "test"
+			},
+			offset: 0,
+			expected: &ConnectPacket{
+				Protocol: Protocol{
+					Name:  ProtocolNameMQTT,
+					Level: ProtocolLevelMQTT50,
+				},
+				CleanStart: true,
+				KeepAlive:  60,
+				ClientID:   "test",
+			},
+			expectedOffset: 17,
+		},
+		{
+			name:      "error: offset beyond packet",
+			packet:    []byte{0x00},
+			offset:    5,
+			expectErr: true,
+		},
+		{
+			name:      "error: ReadProtocol fails",
+			packet:    []byte{0x00}, // insufficient for protocol name length
+			offset:    0,
+			expectErr: true,
+		},
+		{
+			name: "error: ReadConnectFlags fails",
+			packet: []byte{
+				0x00, 0x04, 0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x04, // protocol level
+				// missing connect flags
+			},
+			offset:    0,
+			expectErr: true,
+		},
+		{
+			name: "error: ReadKeepAlive fails",
+			packet: []byte{
+				0x00, 0x04, 0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x04, // protocol level
+				0x02, // connect flags
+				// missing keep alive
+			},
+			offset:    0,
+			expectErr: true,
+		},
+		{
+			name: "error: SkipProperties fails (MQTT 5.0)",
+			packet: []byte{
+				0x00, 0x04, 0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x05,       // protocol level = 5 (MQTT 5.0)
+				0x02,       // connect flags
+				0x00, 0x3C, // keep alive
+				0x03, 0x11, // property length = 3, but only 1 byte
+			},
+			offset:    0,
+			expectErr: true,
+		},
+		{
+			name: "error: ReadClientID fails",
+			packet: []byte{
+				0x00, 0x04, 0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x04,       // protocol level
+				0x02,       // connect flags
+				0x00, 0x3C, // keep alive
+				0x00, 0x04, // client ID length = 4
+				0x74, 0x65, // only 2 bytes
+			},
+			offset:    0,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			connect, offset, err := ParseConnectPacket(tt.packet, tt.offset)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, connect)
+			assert.Equal(t, tt.expected.Protocol.Name, connect.Protocol.Name)
+			assert.Equal(t, tt.expected.Protocol.Level, connect.Protocol.Level)
+			assert.Equal(t, tt.expected.CleanStart, connect.CleanStart)
+			assert.Equal(t, tt.expected.KeepAlive, connect.KeepAlive)
+			assert.Equal(t, tt.expected.ClientID, connect.ClientID)
+			assert.Equal(t, tt.expectedOffset, offset)
+		})
+	}
+}
+
+func TestNewProtocol(t *testing.T) {
+	tests := []struct {
+		name      string
+		protoName string
+		level     uint8
+		expectErr bool
+		expected  *Protocol
+	}{
+		{
+			name:      "valid MQTT 3.1.1",
+			protoName: "MQTT",
+			level:     4,
+			expectErr: false,
+			expected: &Protocol{
+				Name:  ProtocolNameMQTT,
+				Level: ProtocolLevelMQTT311,
+			},
+		},
+		{
+			name:      "valid MQTT 3.1",
+			protoName: "MQIsdp",
+			level:     3,
+			expectErr: false,
+			expected: &Protocol{
+				Name:  ProtocolNameMQIsdp,
+				Level: ProtocolLevelMQTT31,
+			},
+		},
+		{
+			name:      "valid MQTT 5.0",
+			protoName: "MQTT",
+			level:     5,
+			expectErr: false,
+			expected: &Protocol{
+				Name:  ProtocolNameMQTT,
+				Level: ProtocolLevelMQTT50,
+			},
+		},
+		{
+			name:      "invalid protocol name",
+			protoName: "HTTP",
+			level:     4,
+			expectErr: true,
+		},
+		{
+			name:      "invalid protocol level",
+			protoName: "MQTT",
+			level:     6,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proto, err := NewProtocol(tt.protoName, tt.level)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Nil(t, proto)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, proto)
+				assert.Equal(t, tt.expected.Name, proto.Name)
+				assert.Equal(t, tt.expected.Level, proto.Level)
+			}
+		})
+	}
+}
+
+func TestProtocolIsValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol Protocol
+		expected bool
+	}{
+		{
+			name: "valid MQTT 3.1",
+			protocol: Protocol{
+				Name:  ProtocolNameMQIsdp,
+				Level: ProtocolLevelMQTT31,
+			},
+			expected: true,
+		},
+		{
+			name: "valid MQTT 3.1.1",
+			protocol: Protocol{
+				Name:  ProtocolNameMQTT,
+				Level: ProtocolLevelMQTT311,
+			},
+			expected: true,
+		},
+		{
+			name: "valid MQTT 5.0",
+			protocol: Protocol{
+				Name:  ProtocolNameMQTT,
+				Level: ProtocolLevelMQTT50,
+			},
+			expected: true,
+		},
+		{
+			name: "invalid - MQTT 3.1 with wrong name",
+			protocol: Protocol{
+				Name:  ProtocolNameMQTT,
+				Level: ProtocolLevelMQTT31,
+			},
+			expected: false,
+		},
+		{
+			name: "invalid - MQTT 3.1.1 with wrong name",
+			protocol: Protocol{
+				Name:  ProtocolNameMQIsdp,
+				Level: ProtocolLevelMQTT311,
+			},
+			expected: false,
+		},
+		{
+			name: "invalid - unknown level",
+			protocol: Protocol{
+				Name:  ProtocolNameMQTT,
+				Level: ProtocolLevel(99),
+			},
+			expected: false,
+		},
+		{
+			name: "invalid - zero value",
+			protocol: Protocol{
+				Name:  "",
+				Level: 0,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.protocol.IsValid()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewProtocolLevel(t *testing.T) {
+	tests := []struct {
+		name           string
+		level          uint8
+		expectErr      bool
+		expected       ProtocolLevel
+		expectedString string
+	}{
+		{
+			name:           "valid MQTT 3.1",
+			level:          3,
+			expectErr:      false,
+			expected:       ProtocolLevelMQTT31,
+			expectedString: "3.1",
+		},
+		{
+			name:           "valid MQTT 3.1.1",
+			level:          4,
+			expectErr:      false,
+			expected:       ProtocolLevelMQTT311,
+			expectedString: "3.1.1",
+		},
+		{
+			name:           "valid MQTT 5.0",
+			level:          5,
+			expectErr:      false,
+			expected:       ProtocolLevelMQTT50,
+			expectedString: "5.0",
+		},
+		{
+			name:           "unknown level",
+			level:          42,
+			expectErr:      true,
+			expectedString: "42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			level, err := NewProtocolLevel(tt.level)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				assert.Equal(t, ProtocolLevel(0), level)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, level)
+			}
+			assert.Equal(t, tt.expectedString, ProtocolLevel(tt.level).String())
+		})
+	}
+}
+
+func TestConnectPacketReaderReadProtocol(t *testing.T) {
+	tests := []struct {
+		name           string
+		pkt            []byte
+		expectErr      bool
+		expectedName   ProtocolName
+		expectedLevel  ProtocolLevel
+		expectedOffset int
+	}{
+		{
+			name: "valid MQTT 3.1.1",
+			pkt: []byte{
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x04, // protocol level = 4 (MQTT 3.1.1)
+			},
+			expectErr:      false,
+			expectedName:   ProtocolNameMQTT,
+			expectedLevel:  ProtocolLevelMQTT311,
+			expectedOffset: 7,
+		},
+		{
+			name: "valid MQTT 5.0",
+			pkt: []byte{
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				0x05, // protocol level = 5 (MQTT 5.0)
+			},
+			expectErr:      false,
+			expectedName:   ProtocolNameMQTT,
+			expectedLevel:  ProtocolLevelMQTT50,
+			expectedOffset: 7,
+		},
+		{
+			name: "valid MQIsdp (MQTT 3.1)",
+			pkt: []byte{
+				0x00, 0x06, // protocol name length = 6
+				0x4D, 0x51, 0x49, 0x73, 0x64, 0x70, // "MQIsdp"
+				0x03, // protocol level = 3 (MQTT 3.1)
+			},
+			expectErr:      false,
+			expectedName:   ProtocolNameMQIsdp,
+			expectedLevel:  ProtocolLevelMQTT31,
+			expectedOffset: 9,
+		},
+		{
+			name: "insufficient data for protocol name length",
+			pkt: []byte{
+				0x00, // only one byte
+			},
+			expectErr: true,
+		},
+		{
+			name: "insufficient data for protocol name",
+			pkt: []byte{
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, // only 2 bytes, need 4
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid protocol name",
+			pkt: []byte{
+				0x00, 0x04, // protocol name length = 4
+				0x48, 0x54, 0x54, 0x50, // "HTTP" (invalid)
+				0x04, // protocol level
+			},
+			expectErr: true,
+		},
+		{
+			name: "insufficient data for protocol level",
+			pkt: []byte{
+				0x00, 0x04, // protocol name length = 4
+				0x4D, 0x51, 0x54, 0x54, // "MQTT"
+				// missing protocol level
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewConnectPacketReader(tt.pkt, 0)
+			protocol, err := r.ReadProtocol()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedName, protocol.Name)
+				assert.Equal(t, tt.expectedLevel, protocol.Level)
+				assert.Equal(t, tt.expectedOffset, r.Offset())
+			}
+		})
+	}
+}
+
+func TestConnectPacketReaderReadConnectFlags(t *testing.T) {
+	tests := []struct {
+		name               string
+		pkt                []byte
+		expectErr          bool
+		expectedCleanStart bool
+	}{
+		{
+			name:               "clean start set",
+			pkt:                []byte{0x02}, // bit 1 set
+			expectErr:          false,
+			expectedCleanStart: true,
+		},
+		{
+			name:               "clean start not set",
+			pkt:                []byte{0x00},
+			expectErr:          false,
+			expectedCleanStart: false,
+		},
+		{
+			name:               "clean start with other flags",
+			pkt:                []byte{0xFE}, // all bits except bit 0 set
+			expectErr:          false,
+			expectedCleanStart: true,
+		},
+		{
+			name:      "insufficient data",
+			pkt:       []byte{},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewConnectPacketReader(tt.pkt, 0)
+			cleanStart, err := r.ReadConnectFlags()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedCleanStart, cleanStart)
+			}
+		})
+	}
+}
+
+func TestConnectPacketReaderReadKeepAlive(t *testing.T) {
+	tests := []struct {
+		name              string
+		pkt               []byte
+		expectErr         bool
+		expectedKeepAlive uint16
+	}{
+		{
+			name:              "keep alive 60 seconds",
+			pkt:               []byte{0x00, 0x3C}, // 60
+			expectErr:         false,
+			expectedKeepAlive: 60,
+		},
+		{
+			name:              "keep alive 0 (disabled)",
+			pkt:               []byte{0x00, 0x00},
+			expectErr:         false,
+			expectedKeepAlive: 0,
+		},
+		{
+			name:              "keep alive max value",
+			pkt:               []byte{0xFF, 0xFF}, // 65535
+			expectErr:         false,
+			expectedKeepAlive: 65535,
+		},
+		{
+			name:      "insufficient data - one byte",
+			pkt:       []byte{0x00},
+			expectErr: true,
+		},
+		{
+			name:      "insufficient data - empty",
+			pkt:       []byte{},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewConnectPacketReader(tt.pkt, 0)
+			keepAlive, err := r.ReadKeepAlive()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedKeepAlive, keepAlive)
+			}
+		})
+	}
+}
+
+func TestConnectPacketReaderSkipProperties(t *testing.T) {
+	tests := []struct {
+		name           string
+		pkt            []byte
+		expectErr      bool
+		expectedOffset int
+	}{
+		{
+			name: "valid properties skip",
+			pkt: []byte{
+				0x03,             // property length = 3
+				0x11, 0x22, 0x33, // properties bytes
+			},
+			expectErr:      false,
+			expectedOffset: 4,
+		},
+		{
+			name: "empty properties",
+			pkt: []byte{
+				0x00, // property length = 0
+			},
+			expectErr:      false,
+			expectedOffset: 1,
+		},
+		{
+			name:      "insufficient data for property length",
+			pkt:       []byte{},
+			expectErr: true,
+		},
+		{
+			name: "insufficient data for properties",
+			pkt: []byte{
+				0x03,       // property length = 3
+				0x11, 0x22, // only 2 bytes, need 3
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewConnectPacketReader(tt.pkt, 0)
+			err := r.SkipProperties()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedOffset, r.Offset())
+			}
+		})
+	}
+}
+
+func TestConnectPacketReaderReadClientID(t *testing.T) {
+	tests := []struct {
+		name             string
+		pkt              []byte
+		expectErr        bool
+		expectedClientID string
+		expectedOffset   int
+	}{
+		{
+			name: "simple client ID",
+			pkt: []byte{
+				0x00, 0x04, // client ID length = 4
+				0x74, 0x65, 0x73, 0x74, // "test"
+			},
+			expectErr:        false,
+			expectedClientID: "test",
+			expectedOffset:   6,
+		},
+		{
+			name: "empty client ID",
+			pkt: []byte{
+				0x00, 0x00, // client ID length = 0
+			},
+			expectErr:        false,
+			expectedClientID: "",
+			expectedOffset:   2,
+		},
+		{
+			name: "long client ID",
+			pkt: []byte{
+				0x00, 0x1F, // client ID length = 31
+				// "pythonmqtt_publisher_1765206934"
+				0x70, 0x79, 0x74, 0x68, 0x6F, 0x6E, // "python"
+				0x6D, 0x71, 0x74, 0x74, // "mqtt"
+				0x5F,                                                 // "_"
+				0x70, 0x75, 0x62, 0x6C, 0x69, 0x73, 0x68, 0x65, 0x72, // "publisher"
+				0x5F,                                                       // "_"
+				0x31, 0x37, 0x36, 0x35, 0x32, 0x30, 0x36, 0x39, 0x33, 0x34, // "1765206934"
+			},
+			expectErr:        false,
+			expectedClientID: "pythonmqtt_publisher_1765206934",
+			expectedOffset:   33,
+		},
+		{
+			name: "insufficient data for length",
+			pkt: []byte{
+				0x00, // only one byte
+			},
+			expectErr: true,
+		},
+		{
+			name: "insufficient data for client ID",
+			pkt: []byte{
+				0x00, 0x04, // client ID length = 4
+				0x74, 0x65, // only 2 bytes, need 4
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewConnectPacketReader(tt.pkt, 0)
+			clientID, err := r.ReadClientID()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedClientID, clientID)
+				assert.Equal(t, tt.expectedOffset, r.Offset())
+			}
+		})
+	}
+}

--- a/pkg/internal/ebpf/mqttparser/reader.go
+++ b/pkg/internal/ebpf/mqttparser/reader.go
@@ -1,0 +1,110 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mqttparser
+
+import (
+	"errors"
+	"fmt"
+)
+
+// PacketReader provides primitive binary reading operations for MQTT packets.
+// It tracks the current offset automatically and is embedded by packet-specific
+// readers (e.g., ConnectPacketReader) to provide domain-specific read methods.
+type PacketReader struct {
+	pkt    []byte
+	offset int
+}
+
+// NewPacketReader creates a new PacketReader starting at the given offset.
+func NewPacketReader(pkt []byte, offset int) PacketReader {
+	return PacketReader{pkt: pkt, offset: offset}
+}
+
+// Offset returns the current position in the packet.
+func (r *PacketReader) Offset() int {
+	return r.offset
+}
+
+// Remaining returns the number of bytes remaining in the packet.
+func (r *PacketReader) Remaining() int {
+	return len(r.pkt) - r.offset
+}
+
+// Skip advances the offset by n bytes.
+func (r *PacketReader) Skip(n int) error {
+	if r.offset+n > len(r.pkt) {
+		return fmt.Errorf("not enough data to skip by %d bytes, remaining: %d", n, r.Remaining())
+	}
+	r.offset += n
+	return nil
+}
+
+// ReadUint8 reads a single byte.
+func (r *PacketReader) ReadUint8() (uint8, error) {
+	if r.offset >= len(r.pkt) {
+		return 0, errors.New("not enough data for uint8")
+	}
+	value := r.pkt[r.offset]
+	r.offset++
+	return value, nil
+}
+
+// ReadUint16 reads a big-endian 16-bit unsigned integer.
+func (r *PacketReader) ReadUint16() (uint16, error) {
+	if r.offset+2 > len(r.pkt) {
+		return 0, errors.New("not enough data for uint16")
+	}
+	value := uint16(r.pkt[r.offset])<<8 | uint16(r.pkt[r.offset+1])
+	r.offset += 2
+	return value, nil
+}
+
+// ReadVariableByteInteger reads an MQTT variable byte integer.
+// MQTT variable-length encoding (MQTT 5.0 spec, section 1.5.5):
+//   - Each byte encodes 7 bits of data (bits 0-6)
+//   - Bit 7 (0x80) is the continuation bit: 1 = more bytes follow, 0 = last byte
+//   - Value = byte0 + byte1*128 + byte2*128^2 + byte3*128^3
+//   - Maximum 4 bytes (max value: 268,435,455 = 2^28 - 1)
+func (r *PacketReader) ReadVariableByteInteger() (int, error) {
+	if r.offset >= len(r.pkt) {
+		return 0, errors.New("not enough data for variable byte integer")
+	}
+
+	multiplier := 1 // Multiplier for current byte position (1, 128, 128^2, 128^3)
+	var value int   // Accumulated decoded value
+	var pos int     // Current byte position (0-3)
+
+	for pos < 4 && r.offset+pos < len(r.pkt) {
+		encodedByte := r.pkt[r.offset+pos]
+		// Extract 7-bit value (bits 0-6) and add to total with position-based multiplier
+		value += int(encodedByte&0x7F) * multiplier
+		multiplier *= 128 // Next byte is worth 128x more
+
+		// Check continuation bit (bit 7): 0 means this is the last byte
+		if (encodedByte & 0x80) == 0 {
+			r.offset += pos + 1
+			return value, nil
+		}
+		pos++
+	}
+
+	return 0, errors.New("variable byte integer encoding exceeds 4 bytes or incomplete")
+}
+
+// ReadString reads an MQTT string (2-byte length prefix + UTF-8 string).
+func (r *PacketReader) ReadString() (string, error) {
+	strLen, err := r.ReadUint16()
+	if err != nil {
+		return "", errors.New("not enough data for string length")
+	}
+
+	if r.offset+int(strLen) > len(r.pkt) {
+		return "", errors.New("not enough data for string content")
+	}
+
+	str := string(r.pkt[r.offset : r.offset+int(strLen)])
+	r.offset += int(strLen)
+
+	return str, nil
+}

--- a/pkg/internal/ebpf/mqttparser/reader_test.go
+++ b/pkg/internal/ebpf/mqttparser/reader_test.go
@@ -1,0 +1,305 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mqttparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadUint8(t *testing.T) {
+	tests := []struct {
+		name        string
+		pkt         []byte
+		offset      Offset
+		expectErr   bool
+		expectedVal uint8
+		expectedOff Offset
+	}{
+		{
+			name:        "valid uint8",
+			pkt:         []byte{0x42},
+			offset:      0,
+			expectErr:   false,
+			expectedVal: 0x42,
+			expectedOff: 1,
+		},
+		{
+			name:      "insufficient data",
+			pkt:       []byte{},
+			offset:    0,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewPacketReader(tt.pkt, tt.offset)
+			val, err := r.ReadUint8()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedVal, val)
+				assert.Equal(t, tt.expectedOff, r.Offset())
+				assert.Equal(t, len(tt.pkt)-tt.expectedOff, r.Remaining())
+			}
+		})
+	}
+}
+
+func TestReadUint16(t *testing.T) {
+	tests := []struct {
+		name        string
+		pkt         []byte
+		offset      Offset
+		expectErr   bool
+		expectedVal uint16
+		expectedOff Offset
+	}{
+		{
+			name:        "valid uint16",
+			pkt:         []byte{0x12, 0x34},
+			offset:      0,
+			expectErr:   false,
+			expectedVal: 0x1234,
+			expectedOff: 2,
+		},
+		{
+			name:        "zero value",
+			pkt:         []byte{0x00, 0x00},
+			offset:      0,
+			expectErr:   false,
+			expectedVal: 0,
+			expectedOff: 2,
+		},
+		{
+			name:        "maximum value",
+			pkt:         []byte{0xFF, 0xFF},
+			offset:      0,
+			expectErr:   false,
+			expectedVal: 0xFFFF,
+			expectedOff: 2,
+		},
+		{
+			name:      "insufficient data",
+			pkt:       []byte{0x12},
+			offset:    0,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewPacketReader(tt.pkt, tt.offset)
+			val, err := r.ReadUint16()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedVal, val)
+				assert.Equal(t, tt.expectedOff, r.Offset())
+				assert.Equal(t, len(tt.pkt)-tt.expectedOff, r.Remaining())
+			}
+		})
+	}
+}
+
+func TestReadVariableByteInteger(t *testing.T) {
+	tests := []struct {
+		name        string
+		pkt         []byte
+		offset      Offset
+		expectErr   bool
+		expectedVal int
+		expectedOff Offset
+	}{
+		{
+			name:        "single byte encoding",
+			pkt:         []byte{0x00},
+			offset:      0,
+			expectErr:   false,
+			expectedVal: 0,
+			expectedOff: 1,
+		},
+		{
+			name:        "single byte encoding - value 5",
+			pkt:         []byte{0x05},
+			offset:      0,
+			expectErr:   false,
+			expectedVal: 5,
+			expectedOff: 1,
+		},
+		{
+			name:        "single byte encoding - max value",
+			pkt:         []byte{0x7F},
+			offset:      0,
+			expectErr:   false,
+			expectedVal: 127,
+			expectedOff: 1,
+		},
+		{
+			name:        "two byte encoding",
+			pkt:         []byte{0x80, 0x01},
+			offset:      0,
+			expectErr:   false,
+			expectedVal: 128,
+			expectedOff: 2,
+		},
+		{
+			name:        "two byte encoding - larger value",
+			pkt:         []byte{0xFF, 0x7},
+			offset:      0,
+			expectErr:   false,
+			expectedVal: 1023, // 127 + 7*128
+			expectedOff: 2,
+		},
+		{
+			name:        "three byte encoding",
+			pkt:         []byte{0x80, 0x80, 0x01},
+			offset:      0,
+			expectErr:   false,
+			expectedVal: 16384, // 0 + 0*128 + 1*128*128
+			expectedOff: 3,
+		},
+		{
+			name:        "with offset",
+			pkt:         []byte{0x42, 0x80, 0x01, 0x99},
+			offset:      1,
+			expectErr:   false,
+			expectedVal: 128,
+			expectedOff: 3,
+		},
+		{
+			name:      "insufficient data",
+			pkt:       []byte{},
+			offset:    0,
+			expectErr: true,
+		},
+		{
+			name:      "incomplete continuation",
+			pkt:       []byte{0x80},
+			offset:    0,
+			expectErr: true,
+		},
+		{
+			name:      "incomplete continuation with offset",
+			pkt:       []byte{0x42, 0x80},
+			offset:    1,
+			expectErr: true,
+		},
+		{
+			name:      "too many continuation bytes",
+			pkt:       []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+			offset:    0,
+			expectErr: true,
+		},
+		{
+			name:        "four byte encoding",
+			pkt:         []byte{0x80, 0x80, 0x80, 0x01},
+			offset:      0,
+			expectErr:   false,
+			expectedVal: 2097152,
+			expectedOff: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewPacketReader(tt.pkt, tt.offset)
+			val, err := r.ReadVariableByteInteger()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedVal, val)
+				assert.Equal(t, tt.expectedOff, r.Offset())
+				assert.Equal(t, len(tt.pkt)-tt.expectedOff, r.Remaining())
+			}
+		})
+	}
+}
+
+func TestReadString(t *testing.T) {
+	tests := []struct {
+		name        string
+		pkt         []byte
+		offset      Offset
+		expectErr   bool
+		expectedStr string
+		expectedOff Offset
+	}{
+		{
+			name: "valid string",
+			pkt: []byte{
+				0x00, 0x04, // length = 4
+				't', 'e', 's', 't', // "test"
+			},
+			offset:      0,
+			expectErr:   false,
+			expectedStr: "test",
+			expectedOff: 6,
+		},
+		{
+			name: "empty string",
+			pkt: []byte{
+				0x00, 0x00, // length = 0
+			},
+			offset:      0,
+			expectErr:   false,
+			expectedStr: "",
+			expectedOff: 2,
+		},
+		{
+			name: "string with offset",
+			pkt: []byte{
+				0x00, 0x00, // dummy
+				0x00, 0x05, // length = 5
+				'h', 'e', 'l', 'l', 'o', // "hello"
+			},
+			offset:      2,
+			expectErr:   false,
+			expectedStr: "hello",
+			expectedOff: 9,
+		},
+		{
+			name: "insufficient data for length",
+			pkt: []byte{
+				0x00, // only one byte
+			},
+			offset:    0,
+			expectErr: true,
+		},
+		{
+			name: "insufficient data for string content",
+			pkt: []byte{
+				0x00, 0x05, // length = 5
+				'h', 'e', // only 2 bytes
+			},
+			offset:    0,
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewPacketReader(tt.pkt, tt.offset)
+			str, err := r.ReadString()
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedStr, str)
+				assert.Equal(t, tt.expectedOff, r.Offset())
+				assert.Equal(t, len(tt.pkt)-tt.expectedOff, r.Remaining())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR, independent of #937, creates the `mqttparser` package with the initial goal of:

- Assuming all MQTT parsing will occur in user space
- Handling multiple MQTT packets within a single TCP segment, as may happen in high traffic scenarios
- Parsing the "Fixed Header" which is always at the start of every MQTT packet, to determine the packet type and length
- Parsing "CONNECT" packets, to provide an example implementation of the `PacketReader` approach introduced in this PR

This package is not yet in use. Actual integration will follow in subsequent PRs, along with more packet type parsers.

The intention of this PR is to open for comment the general approach to parsing of the MQTT binary protocol.

https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901006

## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](../devdocs/features.md)