### PR TITLE
Rework ioctl to tap into the syscall

### DIFF
--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -323,9 +323,9 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {
 			Required: true,
 			Start:    p.bpfObjects.ObiKprobeInetCskListenStop,
 		},
-		"do_vfs_ioctl": {
+		"sys_ioctl": {
 			Required: true,
-			Start:    p.bpfObjects.ObiKprobeDoVfsIoctl,
+			Start:    p.bpfObjects.ObiKprobeSysIoctl,
 		},
 	}
 


### PR DESCRIPTION
Apparently do_vfs_ioctl doesn't exist on all kernels, so I'm modifying the code to probe into sys_ioctl. The syscall is a bit uglier in code, since we have to unwrap the registers from the syscall calling convention, but it will be there on all kernels.

Closes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/982