### PR TITLE
ci: run arm workflow on arm runner

### DIFF
--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -34,7 +34,7 @@ jobs:
       # Required for uploading artifacts
       actions: write
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:


### PR DESCRIPTION
Looks like the arm workflow was actually running on x86, this PR uses an `ubuntu-24.04-arm` runner instead.