### PR TITLE
Fix path for OATS test logs

### DIFF
--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -76,7 +76,7 @@ jobs:
         if: always()
         with:
           name: Oats test logs - ${{ matrix.basename }}
-          path: test/oats/${{ matrix.basename }}/build/*
+          path: internal/test/oats/${{ matrix.basename }}/build/*
 
       - name: Process coverage data
         run: make itest-coverage-data


### PR DESCRIPTION
Currently OATS logs are not uploaded.

<img width="1717" height="350" alt="image" src="https://github.com/user-attachments/assets/0a9ca90b-ed93-4918-85de-f555ee647eef" />

I suspect this start happening after refactors in #825
