### PR TITLE
Fix panic when parsing MongoDB client data

### DIFF
--- a/pkg/internal/transform/route/harvest/java_notlinux.go
+++ b/pkg/internal/transform/route/harvest/java_notlinux.go
@@ -13,5 +13,12 @@ type (
 	}
 )
 
-func NewJavaRoutesHarvester() *JavaRoutes                                  { return nil }
+func NewJavaRoutesHarvester() *JavaRoutes {
+	return &JavaRoutes{Attacher: fakeAttacher{}}
+}
 func (h *JavaRoutes) ExtractRoutes(_ int32) (*RouteHarvesterResult, error) { return nil, nil }
+
+type fakeAttacher struct{}
+
+func (f fakeAttacher) Init()    {}
+func (f fakeAttacher) Cleanup() {}


### PR DESCRIPTION
OBI sometimes crashes with the following panic:
```
1765971730951	2025-12-17T11:42:10.951Z	panic: runtime error: slice bounds out of range [:237] with capacity 236
1765971730951	2025-12-17T11:42:10.951Z		/src/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/mongo_detect_transform.go:286 +0x3a5
```

This PR adds some extra guards to avoid reading beyond the buffer limits.