### PR TITLE
rb: flush stale data on interval

### DIFF
--- a/pkg/ebpf/common/ringbuf_test.go
+++ b/pkg/ebpf/common/ringbuf_test.go
@@ -202,6 +202,10 @@ func (f *fakeRingBufReader) ReadInto(record *ringbuf.Record) error {
 	}
 }
 
+func (f *fakeRingBufReader) AvailableBytes() int { return 0 }
+
+func (f *fakeRingBufReader) Flush() error { return nil }
+
 type closableObject struct {
 	closed atomic.Bool
 }

--- a/pkg/internal/ebpf/ringbuf/ringbuf_linux.go
+++ b/pkg/internal/ebpf/ringbuf/ringbuf_linux.go
@@ -16,6 +16,7 @@ type (
 )
 
 var (
-	ErrClosed = ringbuf.ErrClosed
-	NewReader = ringbuf.NewReader
+	ErrClosed  = ringbuf.ErrClosed
+	ErrFlushed = ringbuf.ErrFlushed
+	NewReader  = ringbuf.NewReader
 )

--- a/pkg/internal/ebpf/ringbuf/ringbuf_notlinux.go
+++ b/pkg/internal/ebpf/ringbuf/ringbuf_notlinux.go
@@ -6,6 +6,7 @@
 package ringbuf
 
 import (
+	"errors"
 	"os"
 	"time"
 )
@@ -15,6 +16,7 @@ type Record struct {
 }
 
 var ErrClosed = os.ErrClosed
+var ErrFlushed = errors.New("flushed")
 
 type Reader struct{}
 
@@ -22,6 +24,8 @@ func (*Reader) SetDeadline(time.Time)  {}
 func (*Reader) ReadInto(*Record) error { return nil }
 func (*Reader) Close() error           { return nil }
 func (*Reader) Read() (Record, error)  { return Record{}, nil }
+func (*Reader) AvailableBytes() int    { return 0 }
+func (*Reader) Flush() error           { return nil }
 
 func NewReader(_ any) (*Reader, error) {
 	return nil, nil


### PR DESCRIPTION
This PR adds a goroutine that flushes the ringbuffers when:

- stale data is detected (available bytes > 0)
- last read was longer than the predefined interval (3s)

This was practically never needed till now because in normal systems there is always data flowing which triggers user space notifications, but there's now an use case for it (logs ringbuffer with "silent" targeted processes -- the 4kb watermark is never hit if the targeted app just prints once and never logs again)


## Checklist

- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](../devdocs/features.md)