### PR TITLE
Add more null check code for null buffers inside buffer arrays

### DIFF
--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SSLEngineInst.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SSLEngineInst.java
@@ -156,6 +156,10 @@ public class SSLEngineInst {
 
       int[] positions = new int[dsts.length];
       for (int i = 0; i < dsts.length; i++) {
+        if (dsts[i] == null) {
+          positions[i] = -1;
+          continue;
+        }
         positions[i] = dsts[i].position();
       }
 
@@ -205,13 +209,21 @@ public class SSLEngineInst {
         }
 
         for (int i = 0; i < dsts.length; i++) {
+          if (dsts[i] == null) {
+            continue;
+          }
           oldDstPositions[i] = dsts[i].position();
-          dsts[i].position(savedDstPositions[i]);
+          if (savedDstPositions[i] != -1) {
+            dsts[i].position(savedDstPositions[i]);
+          }
         }
 
         ByteBuffer dstBuffer = ByteBufferExtractor.flattenFreshByteBufferArray(dsts);
 
         for (int i = 0; i < dsts.length; i++) {
+          if (dsts[i] == null) {
+            continue;
+          }
           dsts[i].position(oldDstPositions[i]);
         }
 
@@ -263,7 +275,7 @@ public class SSLEngineInst {
         @Advice.Argument(0) final ByteBuffer src,
         @Advice.Argument(1) final ByteBuffer dst,
         @Advice.Return SSLEngineResult result) {
-      if (engine == null || src == null || dst == null) {
+      if (src == null || dst == null) {
         return;
       }
       if (engine.getSession().getId().length == 0) {
@@ -314,7 +326,7 @@ public class SSLEngineInst {
     public static void wrap(
         @Advice.This final javax.net.ssl.SSLEngine engine,
         @Advice.Argument(0) final ByteBuffer[] srcs) {
-      if (engine == null || srcs == null) {
+      if (srcs == null) {
         return;
       }
       if (srcs.length == 0 || engine.getSession().getId().length == 0) {
@@ -334,7 +346,7 @@ public class SSLEngineInst {
         @Advice.Argument(0) final ByteBuffer[] srcs,
         @Advice.Argument(1) final ByteBuffer dst,
         @Advice.Return SSLEngineResult result) {
-      if (engine == null || srcs == null || dst == null) {
+      if (srcs == null || dst == null) {
         return;
       }
       if (srcs.length == 0 || engine.getSession().getId().length == 0) {

--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SocketChannelInst.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SocketChannelInst.java
@@ -73,6 +73,9 @@ public class SocketChannelInst {
   public static final class WriteAdvice {
     @Advice.OnMethodEnter
     public static void write(@Advice.Argument(0) final ByteBuffer src) {
+      if (src == null) {
+        return;
+      }
       SSLStorage.bufPos.set(src.position());
     }
 
@@ -135,6 +138,10 @@ public class SocketChannelInst {
       }
       int[] positions = new int[srcs.length];
       for (int i = 0; i < srcs.length; i++) {
+        if (srcs[i] == null) {
+          positions[i] = -1;
+          continue;
+        }
         positions[i] = srcs[i].position();
       }
 
@@ -160,13 +167,21 @@ public class SocketChannelInst {
       }
 
       for (int i = 0; i < srcs.length; i++) {
+        if (srcs[i] == null) {
+          continue;
+        }
         oldSrcPositions[i] = srcs[i].position();
-        srcs[i].position(savedSrcPositions[i]);
+        if (oldSrcPositions[i] != -1) {
+          srcs[i].position(savedSrcPositions[i]);
+        }
       }
 
       ByteBuffer srcBuffer = ByteBufferExtractor.flattenFreshByteBufferArray(srcs);
 
       for (int i = 0; i < srcs.length; i++) {
+        if (srcs[i] == null) {
+          continue;
+        }
         srcs[i].position(oldSrcPositions[i]);
       }
 

--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractor.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractor.java
@@ -21,6 +21,10 @@ public class ByteBufferExtractor {
     }
     int consumed = 0;
     for (int i = 0; i < dsts.length && consumed <= dstBuffer.limit(); i++) {
+      // Skip null buffers
+      if (dsts[i] == null) {
+        continue;
+      }
       // we want to read 0 -> oldPos, save the existing state
       int oldPos = dsts[i].position();
       int oldLimit = dsts[i].limit();
@@ -54,6 +58,10 @@ public class ByteBufferExtractor {
     }
     int consumed = 0;
     for (int i = 0; i < srcs.length && consumed <= dstBuffer.limit(); i++) {
+      // Skip null buffers
+      if (srcs[i] == null) {
+        continue;
+      }
       // save the prior values
       int oldPos = srcs[i].position();
       int oldLimit = srcs[i].limit();

--- a/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractorTest.java
+++ b/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractorTest.java
@@ -168,6 +168,55 @@ class ByteBufferExtractorTest {
   }
 
   @Test
+  void testFlattenUsedByteBufferArray_WithNullBufferInArray() {
+    ByteBuffer buf1 = ByteBuffer.allocate(3);
+    buf1.put(new byte[] {1, 2, 3});
+    ByteBuffer buf2 = null;
+    ByteBuffer buf3 = ByteBuffer.allocate(2);
+    buf3.put(new byte[] {4, 5});
+    ByteBuffer[] buffers = new ByteBuffer[] {buf1, buf2, buf3};
+
+    ByteBuffer result = ByteBufferExtractor.flattenUsedByteBufferArray(buffers, 5);
+    assertEquals(3, buf1.position());
+    assertEquals(2, buf3.position());
+
+    result.flip();
+    byte[] out = new byte[5];
+    result.get(out);
+    assertArrayEquals(new byte[] {1, 2, 3, 4, 5}, out);
+  }
+
+  @Test
+  void testFlattenUsedByteBufferArray_WithMultipleNullBuffers() {
+    ByteBuffer buf1 = null;
+    ByteBuffer buf2 = ByteBuffer.allocate(3);
+    buf2.put(new byte[] {10, 20, 30});
+    ByteBuffer buf3 = null;
+    ByteBuffer buf4 = ByteBuffer.allocate(2);
+    buf4.put(new byte[] {40, 50});
+    ByteBuffer buf5 = null;
+    ByteBuffer[] buffers = new ByteBuffer[] {buf1, buf2, buf3, buf4, buf5};
+
+    ByteBuffer result = ByteBufferExtractor.flattenUsedByteBufferArray(buffers, 5);
+    assertEquals(3, buf2.position());
+    assertEquals(2, buf4.position());
+
+    result.flip();
+    byte[] out = new byte[5];
+    result.get(out);
+    assertArrayEquals(new byte[] {10, 20, 30, 40, 50}, out);
+  }
+
+  @Test
+  void testFlattenUsedByteBufferArray_AllNullBuffers() {
+    ByteBuffer[] buffers = new ByteBuffer[] {null, null, null};
+
+    ByteBuffer result = ByteBufferExtractor.flattenUsedByteBufferArray(buffers, 10);
+    assertEquals(0, result.position());
+    assertEquals(10, result.capacity());
+  }
+
+  @Test
   void testFlattenFreshByteBufferArray_NullInput() {
     ByteBuffer result = ByteBufferExtractor.flattenFreshByteBufferArray(null);
     assertEquals(0, result.position());
@@ -353,6 +402,59 @@ class ByteBufferExtractorTest {
     assertEquals(800, buf1.limit());
     assertEquals(0, buf2.position());
     assertEquals(800, buf2.limit());
+  }
+
+  @Test
+  void testFlattenFreshByteBufferArray_WithNullBufferInArray() {
+    ByteBuffer buf1 = ByteBuffer.allocate(3);
+    buf1.put(new byte[] {1, 2, 3});
+    buf1.flip();
+    ByteBuffer buf3 = ByteBuffer.allocate(3);
+    buf3.put(new byte[] {4, 5, 6});
+    buf3.position(1);
+    ByteBuffer[] srcs = new ByteBuffer[] {buf1, null, buf3};
+
+    ByteBuffer result = ByteBufferExtractor.flattenFreshByteBufferArray(srcs);
+    assertEquals(0, buf1.position());
+    assertEquals(3, buf1.limit());
+    assertEquals(1, buf3.position());
+    assertEquals(3, buf3.limit());
+
+    result.flip();
+    byte[] out = new byte[5];
+    result.get(out);
+    assertArrayEquals(new byte[] {1, 2, 3, 5, 6}, out);
+  }
+
+  @Test
+  void testFlattenFreshByteBufferArray_WithMultipleNullBuffers() {
+    ByteBuffer buf2 = ByteBuffer.allocate(3);
+    buf2.put(new byte[] {10, 20, 30});
+    buf2.flip();
+    ByteBuffer buf4 = ByteBuffer.allocate(2);
+    buf4.put(new byte[] {40, 50});
+    buf4.position(1);
+    ByteBuffer[] srcs = new ByteBuffer[] {null, buf2, null, buf4, null};
+
+    ByteBuffer result = ByteBufferExtractor.flattenFreshByteBufferArray(srcs);
+    assertEquals(0, buf2.position());
+    assertEquals(3, buf2.limit());
+    assertEquals(1, buf4.position());
+    assertEquals(2, buf4.limit());
+
+    result.flip();
+    byte[] out = new byte[4];
+    result.get(out);
+    assertArrayEquals(new byte[] {10, 20, 30, 50}, out);
+  }
+
+  @Test
+  void testFlattenFreshByteBufferArray_AllNullBuffers() {
+    ByteBuffer[] srcs = new ByteBuffer[] {null, null, null};
+
+    ByteBuffer result = ByteBufferExtractor.flattenFreshByteBufferArray(srcs);
+    assertEquals(0, result.position());
+    assertEquals(ByteBufferExtractor.MAX_SIZE, result.capacity());
   }
 
   @Test


### PR DESCRIPTION
This PR fixes few more bugs related to the Java agent, where we were missing null checks for the bytebuffer array elements inside the write/read array advice code. I also removed some not needed checks on the "this" pointer that was pointed by a review of an earlier PR by @jaydeluca.