### PR TITLE
Integration tests: remove docker builder cache after each image build

### DIFF
--- a/internal/test/integration/components/docker/build.go
+++ b/internal/test/integration/components/docker/build.go
@@ -61,5 +61,15 @@ func buildDockerfile(logger io.WriteCloser, rootPath string, ilog *slog.Logger, 
 		ilog.Error("building dockerfile. Check build logs for details", "error", err)
 		return err
 	}
+	// OpenTelemetry images are very limited in disk. Remove dangling images after building each image
+	ilog.Info("removing docker builder cache")
+	cmd = exec.Command("docker", "builder", "prune", "-af")
+	if logger != nil {
+		cmd.Stdout = logger
+		cmd.Stderr = logger
+	}
+	if err := cmd.Run(); err != nil {
+		ilog.Warn("Can't remove docker builder cache. Tests will continue anyway", "error", err)
+	}
 	return nil
 }


### PR DESCRIPTION
Integration tests are becoming extremely flaky due to "No space left on device" errors.