### PR TITLE
ci: clean up unused GitHub runner directories

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,13 +21,16 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
+
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: "go.mod"
           cache: "false"
+
       - name: Run verification and unit tests
         run: make docker-generate verify cov-exclude-generated check-go-mod notices-update check-ebpf-ver-synced check-clean-work-tree
+
       - name: Report coverage
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         env:

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main", "release-*"]
     paths:
       - ".github/workflows/pull_request_integration_tests.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
       - "bpf/**"
       - "cmd/**"
       - "configs/**"
@@ -15,6 +18,9 @@ on:
     branches: ["main", "release-*"]
     paths:
       - ".github/workflows/pull_request_integration_tests.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
       - "bpf/**"
       - "cmd/**"
       - "configs/**"
@@ -59,6 +65,48 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
     steps:
+      - name: Check initial disk usage
+        run: df -h
+
+      - name: Free up disk space
+        run: |
+          # Remove Java (JDKs)
+          sudo rm -rf /usr/lib/jvm
+
+          # Remove .NET SDKs
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Swift toolchain
+          sudo rm -rf /usr/share/swift
+
+          # Remove Haskell (GHC)
+          sudo rm -rf /usr/local/.ghcup
+
+          # Remove Julia
+          sudo rm -rf /usr/local/julia*
+
+          # Remove Android SDKs
+          sudo rm -rf /usr/local/lib/android
+
+          # Remove Chromium (optional if not using for browser tests)
+          sudo rm -rf /usr/local/share/chromium
+
+          # Remove Microsoft/Edge and Google Chrome builds
+          sudo rm -rf /opt/microsoft /opt/google
+
+          # Remove Azure CLI
+          sudo rm -rf /opt/az
+
+          # Remove PowerShell
+          sudo rm -rf /usr/local/share/powershell
+
+          # Remove CodeQL (but keep hostedtoolcache for Go)
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+          docker system prune -af || true
+          docker builder prune -af || true
+          df -h
+
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main", "release-*"]
     paths:
       - ".github/workflows/pull_request_integration_tests_arm.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
       - "bpf/**"
       - "cmd/**"
       - "configs/**"
@@ -15,6 +18,9 @@ on:
     branches: ["main", "release-*"]
     paths:
       - ".github/workflows/pull_request_integration_tests_arm.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
       - "bpf/**"
       - "cmd/**"
       - "configs/**"
@@ -36,21 +42,62 @@ jobs:
     name: test
     runs-on: ubuntu-24.04-arm
     steps:
+      - name: Check initial disk usage
+        run: df -h
+
+      - name: Free up disk space
+        run: |
+          # Remove Java (JDKs)
+          sudo rm -rf /usr/lib/jvm
+
+          # Remove .NET SDKs
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Swift toolchain
+          sudo rm -rf /usr/share/swift
+
+          # Remove Haskell (GHC)
+          sudo rm -rf /usr/local/.ghcup
+
+          # Remove Julia
+          sudo rm -rf /usr/local/julia*
+
+          # Remove Android SDKs
+          sudo rm -rf /usr/local/lib/android
+
+          # Remove Chromium (optional if not using for browser tests)
+          sudo rm -rf /usr/local/share/chromium
+
+          # Remove Microsoft/Edge and Google Chrome builds
+          sudo rm -rf /opt/microsoft /opt/google
+
+          # Remove Azure CLI
+          sudo rm -rf /opt/az
+
+          # Remove PowerShell
+          sudo rm -rf /usr/local/share/powershell
+
+          # Remove CodeQL (but keep hostedtoolcache for Go)
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+          docker system prune -af || true
+          docker builder prune -af || true
+          df -h
+
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
+
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           cache: "false"
           go-version-file: "go.mod"
-      - name: Clean up disk space
-        run: |
-          docker system prune -af
-          docker volume prune -f
+
       - name: Run integration tests
         run: make docker-generate integration-test-arm
         timeout-minutes: 60
+
       - name: Upload integration test logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
@@ -59,6 +106,7 @@ jobs:
           path: |
             testoutput/*.log
             testoutput/kind
+
       - name: Report coverage
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         env:

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main", "release-*"]
     paths:
       - ".github/workflows/pull_request_k8s_integration_tests.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
       - "bpf/**"
       - "cmd/**"
       - "configs/**"
@@ -15,6 +18,9 @@ on:
     branches: ["main", "release-*"]
     paths:
       - ".github/workflows/pull_request_k8s_integration_tests.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
       - "bpf/**"
       - "cmd/**"
       - "configs/**"
@@ -56,6 +62,48 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
     steps:
+      - name: Check initial disk usage
+        run: df -h
+
+      - name: Free up disk space
+        run: |
+          # Remove Java (JDKs)
+          sudo rm -rf /usr/lib/jvm
+
+          # Remove .NET SDKs
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Swift toolchain
+          sudo rm -rf /usr/share/swift
+
+          # Remove Haskell (GHC)
+          sudo rm -rf /usr/local/.ghcup
+
+          # Remove Julia
+          sudo rm -rf /usr/local/julia*
+
+          # Remove Android SDKs
+          sudo rm -rf /usr/local/lib/android
+
+          # Remove Chromium (optional if not using for browser tests)
+          sudo rm -rf /usr/local/share/chromium
+
+          # Remove Microsoft/Edge and Google Chrome builds
+          sudo rm -rf /opt/microsoft /opt/google
+
+          # Remove Azure CLI
+          sudo rm -rf /opt/az
+
+          # Remove PowerShell
+          sudo rm -rf /usr/local/share/powershell
+
+          # Remove CodeQL (but keep hostedtoolcache for Go)
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+          docker system prune -af || true
+          docker builder prune -af || true
+          df -h
+
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main", "release-*"]
     paths:
       - ".github/workflows/pull_request_oats_test.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
       - "bpf/**"
       - "cmd/**"
       - "configs/**"
@@ -15,6 +18,9 @@ on:
     branches: ["main", "release-*"]
     paths:
       - ".github/workflows/pull_request_oats_test.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
       - "bpf/**"
       - "cmd/**"
       - "configs/**"
@@ -56,6 +62,48 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
     steps:
+      - name: Check initial disk usage
+        run: df -h
+
+      - name: Free up disk space
+        run: |
+          # Remove Java (JDKs)
+          sudo rm -rf /usr/lib/jvm
+
+          # Remove .NET SDKs
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Swift toolchain
+          sudo rm -rf /usr/share/swift
+
+          # Remove Haskell (GHC)
+          sudo rm -rf /usr/local/.ghcup
+
+          # Remove Julia
+          sudo rm -rf /usr/local/julia*
+
+          # Remove Android SDKs
+          sudo rm -rf /usr/local/lib/android
+
+          # Remove Chromium (optional if not using for browser tests)
+          sudo rm -rf /usr/local/share/chromium
+
+          # Remove Microsoft/Edge and Google Chrome builds
+          sudo rm -rf /opt/microsoft /opt/google
+
+          # Remove Azure CLI
+          sudo rm -rf /opt/az
+
+          # Remove PowerShell
+          sudo rm -rf /usr/local/share/powershell
+
+          # Remove CodeQL (but keep hostedtoolcache for Go)
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+          docker system prune -af || true
+          docker builder prune -af || true
+          df -h
+
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -68,6 +68,48 @@ jobs:
             arch: "x86_64"
         test: ${{ fromJson(needs.vm-test-matrix.outputs.matrix).include }}
     steps:
+      - name: Check initial disk usage
+        run: df -h
+
+      - name: Free up disk space
+        run: |
+          # Remove Java (JDKs)
+          sudo rm -rf /usr/lib/jvm
+
+          # Remove .NET SDKs
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Swift toolchain
+          sudo rm -rf /usr/share/swift
+
+          # Remove Haskell (GHC)
+          sudo rm -rf /usr/local/.ghcup
+
+          # Remove Julia
+          sudo rm -rf /usr/local/julia*
+
+          # Remove Android SDKs
+          sudo rm -rf /usr/local/lib/android
+
+          # Remove Chromium (optional if not using for browser tests)
+          sudo rm -rf /usr/local/share/chromium
+
+          # Remove Microsoft/Edge and Google Chrome builds
+          sudo rm -rf /opt/microsoft /opt/google
+
+          # Remove Azure CLI
+          sudo rm -rf /opt/az
+
+          # Remove PowerShell
+          sudo rm -rf /usr/local/share/powershell
+
+          # Remove CodeQL (but keep hostedtoolcache for Go)
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+          docker system prune -af || true
+          docker builder prune -af || true
+          df -h
+
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false


### PR DESCRIPTION
CI still struggles for disk space, it so happens there's a bunch of bloat pre-installed on the GitHub Runners - most of which can be removed. This gives the workflows a lot more room to start with (in addition to the cache clean ups once running).

I opted to explicitly paste in the commands into individual steps, rather than importing a random public GitHub action, for visibility and in case we need to customise in future.

Example below, this increases initial available disk from 15G --> 52G:

<img width="1373" height="292" alt="Screenshot 2026-01-12 at 17 39 01" src="https://github.com/user-attachments/assets/29309253-9025-4601-be8c-9dd00d478f50" />
