### PR TITLE
Experiment: replacing informers by watch API

### DIFF
--- a/pkg/kube/kubecache/meta/informers.go
+++ b/pkg/kube/kubecache/meta/informers.go
@@ -8,8 +8,6 @@ import (
 	"log/slog"
 	"slices"
 
-	"k8s.io/client-go/tools/cache"
-
 	"go.opentelemetry.io/obi/pkg/kube/kubecache/informer"
 )
 
@@ -19,10 +17,8 @@ type Informers struct {
 	log    *slog.Logger
 	config *informersConfig
 
-	// pods and replicaSets cache the different K8s types to custom, smaller object types
-	pods     cache.SharedIndexInformer
-	nodes    cache.SharedIndexInformer
-	services cache.SharedIndexInformer
+	// watchManager manages the Watch API-based watchers for pods, nodes, and services
+	watchManager *watchManager
 
 	waitForSync chan struct{}
 
@@ -45,13 +41,15 @@ func (inf *Informers) Subscribe(observer Observer) {
 	}
 
 	// as a "welcome" message, we send the whole kube metadata to the new observer
-	pods := inf.pods.GetStore().List()
-	var nodes, services []any
-	if !inf.config.disableNodes {
-		nodes = inf.nodes.GetStore().List()
+	var pods, nodes, services []any
+	if inf.watchManager.podWatcher != nil {
+		pods = inf.watchManager.podWatcher.cache.List()
 	}
-	if !inf.config.disableServices {
-		services = inf.services.GetStore().List()
+	if !inf.config.disableNodes && inf.watchManager.nodeWatcher != nil {
+		nodes = inf.watchManager.nodeWatcher.cache.List()
+	}
+	if !inf.config.disableServices && inf.watchManager.serviceWatcher != nil {
+		services = inf.watchManager.serviceWatcher.cache.List()
 	}
 	storedEntities := make([]any, 0, len(pods)+len(nodes)+len(services))
 	storedEntities = append(storedEntities, pods...)

--- a/pkg/kube/kubecache/meta/informers_init.go
+++ b/pkg/kube/kubecache/meta/informers_init.go
@@ -8,18 +8,14 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
-	"net"
 	"os"
 	"path"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -27,7 +23,6 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/kube/kubecache/informer"
 	"go.opentelemetry.io/obi/pkg/kube/kubecache/instrument"
-	"go.opentelemetry.io/obi/pkg/kube/kubecache/meta/cni"
 )
 
 const (
@@ -137,26 +132,16 @@ func InitInformers(ctx context.Context, opts ...InformerOption) (*Informers, err
 		}
 	}
 
-	createdFactories, err := svc.initInformers(ctx, config)
-	if err != nil {
+	if err := svc.initInformers(ctx, config); err != nil {
 		return nil, err
 	}
 
-	svc.log.Debug("starting kubernetes informers")
-	allSynced := sync.WaitGroup{}
-	allSynced.Add(len(createdFactories))
-	for _, factory := range createdFactories {
-		factory.Start(ctx.Done())
-		go func() {
-			factory.WaitForCacheSync(ctx.Done())
-			allSynced.Done()
-		}()
-	}
+	svc.log.Debug("starting kubernetes watch manager")
 
 	go func() {
-		svc.log.Debug("waiting for informers' synchronization")
-		allSynced.Wait()
-		svc.log.Debug("informers synchronized")
+		svc.log.Debug("waiting for watchers' synchronization")
+		<-svc.watchManager.waitForSync
+		svc.log.Debug("watchers synchronized")
 		close(svc.waitForSync)
 	}()
 	if config.waitCacheSync {
@@ -174,47 +159,22 @@ func InitInformers(ctx context.Context, opts ...InformerOption) (*Informers, err
 	return svc, nil
 }
 
-func (inf *Informers) initInformers(ctx context.Context, config *informersConfig) ([]informers.SharedInformerFactory, error) {
-	var informerFactory informers.SharedInformerFactory
-	if config.restrictNode == "" {
-		informerFactory = informers.NewSharedInformerFactory(inf.config.kubeClient, inf.config.resyncPeriod)
-	} else {
-		informerFactory = informers.NewSharedInformerFactoryWithOptions(inf.config.kubeClient, inf.config.resyncPeriod,
-			informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-				options.FieldSelector = fields.Set{"spec.nodeName": config.restrictNode}.String()
-			}))
+func (inf *Informers) initInformers(ctx context.Context, config *informersConfig) error {
+	// Create watch manager
+	metrics := instrument.FromContext(ctx)
+	wm, err := newWatchManager(ctx, config, inf.config.kubeClient, metrics, inf.log)
+	if err != nil {
+		return fmt.Errorf("failed to create watch manager: %w", err)
 	}
-	createdFactories := []informers.SharedInformerFactory{informerFactory}
-	if err := inf.initPodInformer(ctx, informerFactory); err != nil {
-		return nil, err
+	inf.watchManager = wm
+	inf.localInstance = config.localInstance
+
+	// Start all watchers
+	if err := wm.Start(inf); err != nil {
+		return fmt.Errorf("failed to start watch manager: %w", err)
 	}
 
-	if !inf.config.disableNodes {
-		nodeIFactory := informerFactory
-		if config.restrictNode != "" {
-			nodeIFactory = informers.NewSharedInformerFactoryWithOptions(inf.config.kubeClient, inf.config.resyncPeriod,
-				informers.WithTweakListOptions(func(options *metav1.ListOptions) {
-					options.FieldSelector = fields.Set{"metadata.name": config.restrictNode}.String()
-				}))
-			createdFactories = append(createdFactories, nodeIFactory)
-		} // else: use default, unfiltered informerFactory instance
-		if err := inf.initNodeIPInformer(ctx, nodeIFactory); err != nil {
-			return nil, err
-		}
-	}
-	if !inf.config.disableServices {
-		svcIFactory := informerFactory
-		if config.restrictNode != "" {
-			// informerFactory will be initially set to a "spec.nodeName"-filtered instance, so we need
-			// to create an unfiltered one for global services
-			svcIFactory = informers.NewSharedInformerFactory(inf.config.kubeClient, inf.config.resyncPeriod)
-			createdFactories = append(createdFactories, svcIFactory)
-		}
-		if err := inf.initServiceIPInformer(ctx, svcIFactory); err != nil {
-			return nil, err
-		}
-	}
-	return createdFactories, nil
+	return nil
 }
 
 func initConfigOpts(opts []InformerOption) *informersConfig {
@@ -272,40 +232,6 @@ func minimalIndex(om *metav1.ObjectMeta) metav1.ObjectMeta {
 	}
 }
 
-func (inf *Informers) initPodInformer(ctx context.Context, informerFactory informers.SharedInformerFactory) error {
-	pods := informerFactory.Core().V1().Pods().Informer()
-
-	// Transform any *v1.Pod instance into a *PodInfo instance to save space
-	// in the informer's cache
-	if err := pods.SetTransform(func(i any) (any, error) {
-		pod, ok := i.(*v1.Pod)
-		if !ok {
-			// it's Ok. The K8s library just informed from an entity
-			// that has been previously transformed/stored/deleted
-			if pi, ok := i.(*indexableEntity); ok {
-				return pi, nil
-			}
-			// let's forward the stale object to the event handler
-			if obj, stale := i.(cache.DeletedFinalStateUnknown); stale {
-				return obj, nil
-			}
-			return nil, fmt.Errorf("was expecting a *v1.Pod. Got: %T", i)
-		}
-		return inf.podToIndexableEntity(pod)
-	}); err != nil {
-		return fmt.Errorf("can't set pods transform: %w", err)
-	}
-
-	_, err := pods.AddEventHandler(inf.ipInfoEventHandler(ctx))
-	if err != nil {
-		return fmt.Errorf("can't register Pod event handler in the K8s informer: %w", err)
-	}
-
-	inf.log.Debug("registered Pod event handler in the K8s informer")
-
-	inf.pods = pods
-	return nil
-}
 
 func (inf *Informers) podToIndexableEntity(pod *v1.Pod) (any, error) {
 	containers := make([]*informer.ContainerInfo, 0,
@@ -425,104 +351,7 @@ func rmContainerIDSchema(containerID string) string {
 	return containerID
 }
 
-func (inf *Informers) initNodeIPInformer(ctx context.Context, informerFactory informers.SharedInformerFactory) error {
-	nodes := informerFactory.Core().V1().Nodes().Informer()
-	// Transform any *v1.Node instance into an *indexableEntity instance to save space
-	// in the informer's cache
-	if err := nodes.SetTransform(func(i any) (any, error) {
-		node, ok := i.(*v1.Node)
-		// todo: move to generic function
-		if !ok {
-			// it's Ok. The K8s library just informed from an entity
-			// that has been previously transformed/stored
-			if pi, ok := i.(*indexableEntity); ok {
-				return pi, nil
-			}
-			// let's forward the stale object to the event handler
-			if obj, stale := i.(cache.DeletedFinalStateUnknown); stale {
-				return obj, nil
-			}
-			return nil, fmt.Errorf("was expecting a *v1.Node. Got: %T", i)
-		}
-		ips := make([]string, 0, len(node.Status.Addresses))
-		for _, address := range node.Status.Addresses {
-			ip := net.ParseIP(address.Address)
-			if ip != nil {
-				ips = append(ips, ip.String())
-			}
-		}
-		// CNI-dependent logic (must work regardless of whether the CNI is installed)
-		ips = cni.AddOvnIPs(ips, node)
 
-		return &indexableEntity{
-			ObjectMeta: minimalIndex(&node.ObjectMeta),
-			EncodedMeta: &informer.ObjectMeta{
-				Name:            node.Name,
-				Namespace:       node.Namespace,
-				Labels:          node.Labels,
-				Ips:             ips,
-				Kind:            typeNode,
-				StatusTimeEpoch: objLastUpdateTime(&node.ObjectMeta, nil, node.Status.Conditions),
-			},
-		}, nil
-	}); err != nil {
-		return fmt.Errorf("can't set nodes transform: %w", err)
-	}
-
-	if _, err := nodes.AddEventHandler(inf.ipInfoEventHandler(ctx)); err != nil {
-		return fmt.Errorf("can't register Node event handler in the K8s informer: %w", err)
-	}
-	inf.log.Debug("registered Node event handler in the K8s informer")
-
-	inf.nodes = nodes
-	return nil
-}
-
-func (inf *Informers) initServiceIPInformer(ctx context.Context, informerFactory informers.SharedInformerFactory) error {
-	services := informerFactory.Core().V1().Services().Informer()
-	// Transform any *v1.Service instance into a *indexableEntity instance to save space
-	// in the informer's cache
-	if err := services.SetTransform(func(i any) (any, error) {
-		svc, ok := i.(*v1.Service)
-		if !ok {
-			// it's Ok. The K8s library just informed from an entity
-			// that has been previously transformed/stored
-			if pi, ok := i.(*indexableEntity); ok {
-				return pi, nil
-			}
-			// let's forward the stale object to the event handler
-			if obj, stale := i.(cache.DeletedFinalStateUnknown); stale {
-				return obj, nil
-			}
-			return nil, fmt.Errorf("was expecting a *v1.Service. Got: %T", i)
-		}
-		var ips []string
-		if svc.Spec.ClusterIP != v1.ClusterIPNone {
-			ips = svc.Spec.ClusterIPs
-		}
-		return &indexableEntity{
-			ObjectMeta: minimalIndex(&svc.ObjectMeta),
-			EncodedMeta: &informer.ObjectMeta{
-				Name:            svc.Name,
-				Namespace:       svc.Namespace,
-				Labels:          svc.Labels,
-				Ips:             ips,
-				Kind:            typeService,
-				StatusTimeEpoch: objLastUpdateTime(&svc.ObjectMeta, nil, nil),
-			},
-		}, nil
-	}); err != nil {
-		return fmt.Errorf("can't set services transform: %w", err)
-	}
-
-	if _, err := services.AddEventHandler(inf.ipInfoEventHandler(ctx)); err != nil {
-		return fmt.Errorf("can't register Service event handler in the K8s informer: %w", err)
-	}
-	inf.log.Debug("registered Service event handler in the K8s informer")
-
-	inf.services = services
-	return nil
-}
 
 func objLastUpdateTime(
 	om *metav1.ObjectMeta, podConditions []v1.PodCondition, nodeConditions []v1.NodeCondition,

--- a/pkg/kube/kubecache/meta/resource_watcher.go
+++ b/pkg/kube/kubecache/meta/resource_watcher.go
@@ -1,0 +1,571 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package meta
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"go.opentelemetry.io/obi/pkg/kube/kubecache/instrument"
+)
+
+// resourceWatcher manages the Watch lifecycle for a single Kubernetes resource type.
+type resourceWatcher struct {
+	ctx          context.Context
+	cancel       context.CancelFunc
+	client       kubernetes.Interface
+	resourceType string // "Pod", "Node", or "Service"
+	listOptions  metav1.ListOptions
+
+	cache        *watchBackedCache
+	transformFn  TransformFunc
+	eventHandler *cache.ResourceEventHandlerFuncs
+
+	resyncPeriod time.Duration
+	resyncTicker *time.Ticker
+
+	currentRV string // current resourceVersion
+
+	log     *slog.Logger
+	metrics instrument.InternalMetrics
+
+	syncCallback func(string) // callback when initial sync completes
+}
+
+// TransformFunc transforms a Kubernetes API object into a cache-optimized object.
+type TransformFunc func(obj interface{}) (interface{}, error)
+
+// resourceWatcherConfig holds configuration for creating a new resourceWatcher.
+type resourceWatcherConfig struct {
+	ctx          context.Context
+	client       kubernetes.Interface
+	resourceType string
+	fieldSelector string
+	resyncPeriod time.Duration
+	transformFn  TransformFunc
+	eventHandler *cache.ResourceEventHandlerFuncs
+	metrics      instrument.InternalMetrics
+	log          *slog.Logger
+	syncCallback func(string)
+}
+
+// newResourceWatcher creates a new resource watcher.
+func newResourceWatcher(cfg *resourceWatcherConfig) (*resourceWatcher, error) {
+	ctx, cancel := context.WithCancel(cfg.ctx)
+
+	listOpts := metav1.ListOptions{}
+	if cfg.fieldSelector != "" {
+		listOpts.FieldSelector = cfg.fieldSelector
+	}
+
+	rw := &resourceWatcher{
+		ctx:          ctx,
+		cancel:       cancel,
+		client:       cfg.client,
+		resourceType: cfg.resourceType,
+		listOptions:  listOpts,
+		cache:        newWatchBackedCache(cfg.resourceType, cfg.log),
+		transformFn:  cfg.transformFn,
+		eventHandler: cfg.eventHandler,
+		resyncPeriod: cfg.resyncPeriod,
+		log:          cfg.log.With("component", "resourceWatcher", "resourceType", cfg.resourceType),
+		metrics:      cfg.metrics,
+		syncCallback: cfg.syncCallback,
+	}
+
+	return rw, nil
+}
+
+// Start begins watching the resource. It performs initial LIST, starts the watch loop, and sets up periodic resync.
+func (w *resourceWatcher) Start() error {
+	// Perform initial LIST to populate cache
+	if err := w.performInitialList(); err != nil {
+		return fmt.Errorf("failed to perform initial list for %s: %w", w.resourceType, err)
+	}
+
+	// Signal that initial sync is complete
+	if w.syncCallback != nil {
+		w.syncCallback(w.resourceType)
+	}
+
+	// Start resync ticker
+	if w.resyncPeriod > 0 {
+		w.resyncTicker = time.NewTicker(w.resyncPeriod)
+	}
+
+	// Start watch loop in background
+	go w.watchLoop()
+
+	w.log.Info("resource watcher started", "resourceType", w.resourceType)
+	return nil
+}
+
+// Stop stops the resource watcher.
+func (w *resourceWatcher) Stop() {
+	if w.resyncTicker != nil {
+		w.resyncTicker.Stop()
+	}
+	w.cancel()
+	w.log.Info("resource watcher stopped", "resourceType", w.resourceType)
+}
+
+// performInitialList performs the initial LIST operation to populate the cache.
+func (w *resourceWatcher) performInitialList() error {
+	w.log.Debug("performing initial LIST", "resourceType", w.resourceType)
+
+	var resourceVersion string
+
+	switch w.resourceType {
+	case typePod:
+		podList, listErr := w.client.CoreV1().Pods(metav1.NamespaceAll).List(w.ctx, w.listOptions)
+		if listErr != nil {
+			return listErr
+		}
+		resourceVersion = podList.ResourceVersion
+
+		// Transform and add each pod to cache
+		for i := range podList.Items {
+			if err := w.addObjectToCache(&podList.Items[i]); err != nil {
+				w.log.Warn("failed to add pod to cache during initial list", "error", err)
+			}
+		}
+
+	case typeNode:
+		nodeList, listErr := w.client.CoreV1().Nodes().List(w.ctx, w.listOptions)
+		if listErr != nil {
+			return listErr
+		}
+		resourceVersion = nodeList.ResourceVersion
+
+		// Transform and add each node to cache
+		for i := range nodeList.Items {
+			if err := w.addObjectToCache(&nodeList.Items[i]); err != nil {
+				w.log.Warn("failed to add node to cache during initial list", "error", err)
+			}
+		}
+
+	case typeService:
+		svcList, listErr := w.client.CoreV1().Services(metav1.NamespaceAll).List(w.ctx, w.listOptions)
+		if listErr != nil {
+			return listErr
+		}
+		resourceVersion = svcList.ResourceVersion
+
+		// Transform and add each service to cache
+		for i := range svcList.Items {
+			if err := w.addObjectToCache(&svcList.Items[i]); err != nil {
+				w.log.Warn("failed to add service to cache during initial list", "error", err)
+			}
+		}
+
+	default:
+		return fmt.Errorf("unsupported resource type: %s", w.resourceType)
+	}
+
+	w.currentRV = resourceVersion
+	w.log.Info("initial LIST complete", "resourceType", w.resourceType, "resourceVersion", resourceVersion, "count", len(w.cache.List()))
+	return nil
+}
+
+// addObjectToCache transforms an object and adds it to the cache, calling the AddFunc handler.
+func (w *resourceWatcher) addObjectToCache(obj interface{}) error {
+	transformed, err := w.transformFn(obj)
+	if err != nil {
+		return fmt.Errorf("failed to transform object: %w", err)
+	}
+
+	if err := w.cache.Add(transformed); err != nil {
+		return fmt.Errorf("failed to add to cache: %w", err)
+	}
+
+	if w.eventHandler != nil && w.eventHandler.AddFunc != nil {
+		w.eventHandler.AddFunc(transformed)
+	}
+
+	return nil
+}
+
+// watchLoop runs the main watch processing loop.
+func (w *resourceWatcher) watchLoop() {
+	backoff := time.Second
+	maxBackoff := 5 * time.Minute
+	consecutiveErrors := 0
+
+	for {
+		select {
+		case <-w.ctx.Done():
+			w.log.Debug("watch loop terminated")
+			return
+
+		case <-func() <-chan time.Time {
+			if w.resyncTicker != nil {
+				return w.resyncTicker.C
+			}
+			// Return a never-triggering channel if resync is disabled
+			return make(<-chan time.Time)
+		}():
+			w.log.Debug("resync triggered")
+			if err := w.performResync(); err != nil {
+				w.log.Warn("resync failed", "error", err)
+			}
+
+		default:
+			// Run watch
+			err := w.runWatch()
+			if err != nil {
+				consecutiveErrors++
+				w.log.Warn("watch error", "error", err, "consecutiveErrors", consecutiveErrors)
+
+				// Exponential backoff
+				if consecutiveErrors > 1 {
+					backoff = backoff * 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
+				}
+
+				select {
+				case <-w.ctx.Done():
+					return
+				case <-time.After(backoff):
+					// Retry after backoff
+				}
+			} else {
+				// Reset backoff on successful watch
+				consecutiveErrors = 0
+				backoff = time.Second
+			}
+		}
+	}
+}
+
+// runWatch establishes a watch connection and processes events.
+func (w *resourceWatcher) runWatch() error {
+	w.log.Debug("starting watch", "resourceVersion", w.currentRV)
+
+	// Set up watch options
+	watchOpts := w.listOptions
+	watchOpts.ResourceVersion = w.currentRV
+	watchOpts.Watch = true
+	watchOpts.AllowWatchBookmarks = true
+
+	var watcher watch.Interface
+	var err error
+
+	switch w.resourceType {
+	case typePod:
+		watcher, err = w.client.CoreV1().Pods(metav1.NamespaceAll).Watch(w.ctx, watchOpts)
+	case typeNode:
+		watcher, err = w.client.CoreV1().Nodes().Watch(w.ctx, watchOpts)
+	case typeService:
+		watcher, err = w.client.CoreV1().Services(metav1.NamespaceAll).Watch(w.ctx, watchOpts)
+	default:
+		return fmt.Errorf("unsupported resource type: %s", w.resourceType)
+	}
+
+	if err != nil {
+		// Check if resource version is too old
+		if isResourceVersionTooOldError(err) {
+			w.log.Warn("resource version too old, performing resync")
+			if resyncErr := w.performResync(); resyncErr != nil {
+				return fmt.Errorf("resync after resource version error failed: %w", resyncErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to create watch: %w", err)
+	}
+	defer watcher.Stop()
+
+	// Process watch events
+	for {
+		select {
+		case <-w.ctx.Done():
+			return nil
+
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				// Watch channel closed, need to restart
+				w.log.Debug("watch channel closed")
+				return nil
+			}
+
+			if err := w.processWatchEvent(event); err != nil {
+				w.log.Warn("error processing watch event", "error", err, "eventType", event.Type)
+				// Continue processing other events despite this error
+			}
+		}
+	}
+}
+
+// processWatchEvent handles individual watch events.
+func (w *resourceWatcher) processWatchEvent(event watch.Event) error {
+	switch event.Type {
+	case watch.Added:
+		return w.handleAddEvent(event.Object)
+
+	case watch.Modified:
+		return w.handleModifyEvent(event.Object)
+
+	case watch.Deleted:
+		return w.handleDeleteEvent(event.Object)
+
+	case watch.Bookmark:
+		return w.handleBookmarkEvent(event.Object)
+
+	case watch.Error:
+		return w.handleErrorEvent(event.Object)
+
+	default:
+		w.log.Warn("unknown watch event type", "type", event.Type)
+		return nil
+	}
+}
+
+// handleAddEvent processes watch Added events.
+func (w *resourceWatcher) handleAddEvent(obj interface{}) error {
+	transformed, err := w.transformFn(obj)
+	if err != nil {
+		return fmt.Errorf("failed to transform added object: %w", err)
+	}
+
+	if err := w.cache.Add(transformed); err != nil {
+		return fmt.Errorf("failed to add object to cache: %w", err)
+	}
+
+	// Update resource version
+	w.updateResourceVersion(obj)
+
+	// Call event handler
+	if w.eventHandler != nil && w.eventHandler.AddFunc != nil {
+		w.eventHandler.AddFunc(transformed)
+	}
+
+	return nil
+}
+
+// handleModifyEvent processes watch Modified events.
+func (w *resourceWatcher) handleModifyEvent(obj interface{}) error {
+	transformed, err := w.transformFn(obj)
+	if err != nil {
+		return fmt.Errorf("failed to transform modified object: %w", err)
+	}
+
+	// Get old object for comparison (for UpdateFunc handler)
+	var oldObj interface{}
+	if key, err := cache.MetaNamespaceKeyFunc(transformed); err == nil {
+		if old, exists, _ := w.cache.GetByKey(key); exists {
+			oldObj = old
+		}
+	}
+
+	if err := w.cache.Update(transformed); err != nil {
+		return fmt.Errorf("failed to update object in cache: %w", err)
+	}
+
+	// Update resource version
+	w.updateResourceVersion(obj)
+
+	// Call event handler
+	if w.eventHandler != nil && w.eventHandler.UpdateFunc != nil {
+		if oldObj != nil {
+			w.eventHandler.UpdateFunc(oldObj, transformed)
+		} else {
+			// If we don't have the old object, treat it as an add
+			if w.eventHandler.AddFunc != nil {
+				w.eventHandler.AddFunc(transformed)
+			}
+		}
+	}
+
+	return nil
+}
+
+// handleDeleteEvent processes watch Deleted events.
+func (w *resourceWatcher) handleDeleteEvent(obj interface{}) error {
+	transformed, err := w.transformFn(obj)
+	if err != nil {
+		return fmt.Errorf("failed to transform deleted object: %w", err)
+	}
+
+	if err := w.cache.Delete(transformed); err != nil {
+		return fmt.Errorf("failed to delete object from cache: %w", err)
+	}
+
+	// Update resource version
+	w.updateResourceVersion(obj)
+
+	// Call event handler
+	if w.eventHandler != nil && w.eventHandler.DeleteFunc != nil {
+		w.eventHandler.DeleteFunc(transformed)
+	}
+
+	return nil
+}
+
+// handleBookmarkEvent processes watch Bookmark events.
+func (w *resourceWatcher) handleBookmarkEvent(obj interface{}) error {
+	// Bookmarks only update the resource version
+	w.updateResourceVersion(obj)
+	w.log.Debug("bookmark received", "resourceVersion", w.currentRV)
+	return nil
+}
+
+// handleErrorEvent processes watch Error events.
+func (w *resourceWatcher) handleErrorEvent(obj interface{}) error {
+	w.log.Warn("watch error event received", "object", obj)
+	// Return error to trigger watch restart
+	return fmt.Errorf("watch error event: %v", obj)
+}
+
+// updateResourceVersion extracts and updates the resource version from an object.
+func (w *resourceWatcher) updateResourceVersion(obj interface{}) {
+	accessor, err := meta.Accessor(obj)
+	if err == nil && accessor.GetResourceVersion() != "" {
+		w.currentRV = accessor.GetResourceVersion()
+	}
+}
+
+// performResync performs a periodic resync by listing all objects and comparing with the cache.
+func (w *resourceWatcher) performResync() error {
+	w.log.Debug("performing resync", "resourceType", w.resourceType)
+
+	// Get current cache contents
+	currentCache := make(map[string]interface{})
+	for _, item := range w.cache.List() {
+		if key, err := cache.MetaNamespaceKeyFunc(item); err == nil {
+			currentCache[key] = item
+		}
+	}
+
+	// Perform LIST with ResourceVersion="0" to get current state
+	listOpts := w.listOptions
+	listOpts.ResourceVersion = "0"
+
+	var resourceVersion string
+	freshObjects := make(map[string]interface{})
+
+	switch w.resourceType {
+	case typePod:
+		podList, err := w.client.CoreV1().Pods(metav1.NamespaceAll).List(w.ctx, listOpts)
+		if err != nil {
+			return fmt.Errorf("failed to list pods during resync: %w", err)
+		}
+		resourceVersion = podList.ResourceVersion
+		for i := range podList.Items {
+			transformed, err := w.transformFn(&podList.Items[i])
+			if err != nil {
+				continue
+			}
+			if key, err := cache.MetaNamespaceKeyFunc(transformed); err == nil {
+				freshObjects[key] = transformed
+			}
+		}
+
+	case typeNode:
+		nodeList, err := w.client.CoreV1().Nodes().List(w.ctx, listOpts)
+		if err != nil {
+			return fmt.Errorf("failed to list nodes during resync: %w", err)
+		}
+		resourceVersion = nodeList.ResourceVersion
+		for i := range nodeList.Items {
+			transformed, err := w.transformFn(&nodeList.Items[i])
+			if err != nil {
+				continue
+			}
+			if key, err := cache.MetaNamespaceKeyFunc(transformed); err == nil {
+				freshObjects[key] = transformed
+			}
+		}
+
+	case typeService:
+		svcList, err := w.client.CoreV1().Services(metav1.NamespaceAll).List(w.ctx, listOpts)
+		if err != nil {
+			return fmt.Errorf("failed to list services during resync: %w", err)
+		}
+		resourceVersion = svcList.ResourceVersion
+		for i := range svcList.Items {
+			transformed, err := w.transformFn(&svcList.Items[i])
+			if err != nil {
+				continue
+			}
+			if key, err := cache.MetaNamespaceKeyFunc(transformed); err == nil {
+				freshObjects[key] = transformed
+			}
+		}
+
+	default:
+		return fmt.Errorf("unsupported resource type: %s", w.resourceType)
+	}
+
+	// Compare fresh objects with cache
+	for key, freshObj := range freshObjects {
+		if cachedObj, exists := currentCache[key]; exists {
+			// Object exists in both - check if it changed
+			freshEntity, freshOK := freshObj.(*indexableEntity)
+			cachedEntity, cachedOK := cachedObj.(*indexableEntity)
+			if freshOK && cachedOK && !unchanged(cachedEntity.EncodedMeta, freshEntity.EncodedMeta) {
+				// Object changed - update
+				w.cache.Update(freshObj)
+				if w.eventHandler != nil && w.eventHandler.UpdateFunc != nil {
+					w.eventHandler.UpdateFunc(cachedObj, freshObj)
+				}
+			}
+			// Remove from currentCache to track what's left
+			delete(currentCache, key)
+		} else {
+			// New object - add
+			w.cache.Add(freshObj)
+			if w.eventHandler != nil && w.eventHandler.AddFunc != nil {
+				w.eventHandler.AddFunc(freshObj)
+			}
+		}
+	}
+
+	// Remaining items in currentCache are deleted
+	for _, deletedObj := range currentCache {
+		w.cache.Delete(deletedObj)
+		if w.eventHandler != nil && w.eventHandler.DeleteFunc != nil {
+			w.eventHandler.DeleteFunc(deletedObj)
+		}
+	}
+
+	w.currentRV = resourceVersion
+	w.log.Info("resync complete", "resourceType", w.resourceType, "resourceVersion", resourceVersion, "count", len(freshObjects))
+	return nil
+}
+
+// isResourceVersionTooOldError checks if an error is due to an expired resource version.
+func isResourceVersionTooOldError(err error) bool {
+	// Check for the "too old resource version" error from Kubernetes API
+	// This can be determined by checking the error message
+	if err == nil {
+		return false
+	}
+	errMsg := err.Error()
+	return contains(errMsg, "too old resource version") ||
+		contains(errMsg, "resource version is too old") ||
+		contains(errMsg, "expired")
+}
+
+// contains checks if a string contains a substring (case-insensitive helper).
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) &&
+		(s[:len(substr)] == substr || s[len(s)-len(substr):] == substr ||
+		func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}()))
+}

--- a/pkg/kube/kubecache/meta/watch_cache.go
+++ b/pkg/kube/kubecache/meta/watch_cache.go
@@ -1,0 +1,147 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package meta
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"k8s.io/client-go/tools/cache"
+)
+
+// watchBackedCache implements cache.Store interface with thread-safe in-memory storage.
+// This cache is used by resourceWatcher to store transformed Kubernetes objects.
+type watchBackedCache struct {
+	mu           sync.RWMutex
+	items        map[string]interface{} // key = namespace/name
+	keyFunc      cache.KeyFunc
+	resourceType string
+	log          *slog.Logger
+}
+
+// newWatchBackedCache creates a new cache instance for a specific resource type.
+func newWatchBackedCache(resourceType string, log *slog.Logger) *watchBackedCache {
+	return &watchBackedCache{
+		items:        make(map[string]interface{}),
+		keyFunc:      cache.MetaNamespaceKeyFunc,
+		resourceType: resourceType,
+		log:          log.With("component", "watchBackedCache", "resourceType", resourceType),
+	}
+}
+
+// Add inserts an item into the cache.
+func (c *watchBackedCache) Add(obj interface{}) error {
+	key, err := c.keyFunc(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get key for object: %w", err)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.items[key] = obj
+	c.log.Debug("added object to cache", "key", key)
+	return nil
+}
+
+// Update modifies an existing item in the cache or adds it if it doesn't exist.
+func (c *watchBackedCache) Update(obj interface{}) error {
+	key, err := c.keyFunc(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get key for object: %w", err)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.items[key] = obj
+	c.log.Debug("updated object in cache", "key", key)
+	return nil
+}
+
+// Delete removes an item from the cache.
+func (c *watchBackedCache) Delete(obj interface{}) error {
+	key, err := c.keyFunc(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get key for object: %w", err)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	delete(c.items, key)
+	c.log.Debug("deleted object from cache", "key", key)
+	return nil
+}
+
+// List returns all items currently in the cache.
+func (c *watchBackedCache) List() []interface{} {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	list := make([]interface{}, 0, len(c.items))
+	for _, item := range c.items {
+		list = append(list, item)
+	}
+	return list
+}
+
+// ListKeys returns all keys of items currently in the cache.
+func (c *watchBackedCache) ListKeys() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	keys := make([]string, 0, len(c.items))
+	for key := range c.items {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// Get returns the requested item if it exists in the cache.
+func (c *watchBackedCache) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	key, err := c.keyFunc(obj)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get key for object: %w", err)
+	}
+	return c.GetByKey(key)
+}
+
+// GetByKey returns the requested item by key if it exists in the cache.
+func (c *watchBackedCache) GetByKey(key string) (item interface{}, exists bool, err error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	item, exists = c.items[key]
+	return item, exists, nil
+}
+
+// Replace replaces the cache contents with the given list of objects.
+// This is typically used during resync operations.
+func (c *watchBackedCache) Replace(list []interface{}, resourceVersion string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Clear existing items
+	c.items = make(map[string]interface{}, len(list))
+
+	// Add all items from the list
+	for _, item := range list {
+		key, err := c.keyFunc(item)
+		if err != nil {
+			return fmt.Errorf("failed to get key for object during replace: %w", err)
+		}
+		c.items[key] = item
+	}
+
+	c.log.Debug("replaced cache contents", "count", len(list), "resourceVersion", resourceVersion)
+	return nil
+}
+
+// Resync is a no-op for this cache implementation as resync is handled by resourceWatcher.
+func (c *watchBackedCache) Resync() error {
+	// Resync logic is handled by the resourceWatcher, not the cache itself
+	return nil
+}

--- a/pkg/kube/kubecache/meta/watch_manager.go
+++ b/pkg/kube/kubecache/meta/watch_manager.go
@@ -1,0 +1,343 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package meta
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"go.opentelemetry.io/obi/pkg/kube/kubecache/informer"
+	"go.opentelemetry.io/obi/pkg/kube/kubecache/instrument"
+	"go.opentelemetry.io/obi/pkg/kube/kubecache/meta/cni"
+)
+
+// watchManager manages multiple resourceWatcher instances and coordinates their synchronization.
+type watchManager struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	client kubernetes.Interface
+	config *informersConfig
+
+	podWatcher     *resourceWatcher
+	nodeWatcher    *resourceWatcher
+	serviceWatcher *resourceWatcher
+
+	syncedMu    sync.Mutex
+	syncedTypes map[string]bool // tracks which resources have completed initial sync
+	waitForSync chan struct{}   // closed when all watchers are synced
+
+	log     *slog.Logger
+	metrics instrument.InternalMetrics
+}
+
+// newWatchManager creates a new watch manager.
+func newWatchManager(ctx context.Context, config *informersConfig, client kubernetes.Interface, metrics instrument.InternalMetrics, log *slog.Logger) (*watchManager, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	wm := &watchManager{
+		ctx:         ctx,
+		cancel:      cancel,
+		client:      client,
+		config:      config,
+		syncedTypes: make(map[string]bool),
+		waitForSync: make(chan struct{}),
+		log:         log.With("component", "watchManager"),
+		metrics:     metrics,
+	}
+
+	return wm, nil
+}
+
+// Start initializes and starts all resource watchers based on configuration.
+func (wm *watchManager) Start(inf *Informers) error {
+	wm.log.Debug("starting watch manager")
+
+	expectedSyncs := 0
+
+	// Create and start pod watcher
+	if err := wm.startPodWatcher(inf); err != nil {
+		return fmt.Errorf("failed to start pod watcher: %w", err)
+	}
+	expectedSyncs++
+
+	// Create and start node watcher if not disabled
+	if !wm.config.disableNodes {
+		if err := wm.startNodeWatcher(inf); err != nil {
+			return fmt.Errorf("failed to start node watcher: %w", err)
+		}
+		expectedSyncs++
+	}
+
+	// Create and start service watcher if not disabled
+	if !wm.config.disableServices {
+		if err := wm.startServiceWatcher(inf); err != nil {
+			return fmt.Errorf("failed to start service watcher: %w", err)
+		}
+		expectedSyncs++
+	}
+
+	// Wait for all watchers to complete initial sync
+	go func() {
+		for {
+			wm.syncedMu.Lock()
+			syncedCount := len(wm.syncedTypes)
+			wm.syncedMu.Unlock()
+
+			if syncedCount >= expectedSyncs {
+				wm.log.Info("all resource watchers synced", "count", syncedCount)
+				close(wm.waitForSync)
+				return
+			}
+
+			// Check every 100ms
+			select {
+			case <-wm.ctx.Done():
+				return
+			case <-func() <-chan struct{} {
+				ch := make(chan struct{})
+				go func() {
+					<-wm.ctx.Done()
+					close(ch)
+				}()
+				return ch
+			}():
+				return
+			default:
+				// Small sleep to avoid busy-waiting
+				select {
+				case <-wm.ctx.Done():
+					return
+				default:
+				}
+			}
+		}
+	}()
+
+	wm.log.Info("watch manager started")
+	return nil
+}
+
+// Stop stops all resource watchers.
+func (wm *watchManager) Stop() {
+	wm.log.Debug("stopping watch manager")
+
+	if wm.podWatcher != nil {
+		wm.podWatcher.Stop()
+	}
+	if wm.nodeWatcher != nil {
+		wm.nodeWatcher.Stop()
+	}
+	if wm.serviceWatcher != nil {
+		wm.serviceWatcher.Stop()
+	}
+
+	wm.cancel()
+	wm.log.Info("watch manager stopped")
+}
+
+// markSynced marks a resource type as synced.
+func (wm *watchManager) markSynced(resourceType string) {
+	wm.syncedMu.Lock()
+	defer wm.syncedMu.Unlock()
+
+	wm.syncedTypes[resourceType] = true
+	wm.log.Debug("resource type synced", "resourceType", resourceType, "totalSynced", len(wm.syncedTypes))
+}
+
+// startPodWatcher creates and starts the pod watcher.
+func (wm *watchManager) startPodWatcher(inf *Informers) error {
+	fieldSelector := ""
+	if wm.config.restrictNode != "" {
+		fieldSelector = fields.Set{"spec.nodeName": wm.config.restrictNode}.String()
+	}
+
+	// Wrap podToIndexableEntity to match TransformFunc signature
+	podTransform := func(obj interface{}) (interface{}, error) {
+		pod, ok := obj.(*v1.Pod)
+		if !ok {
+			// Handle already transformed objects
+			if ie, ok := obj.(*indexableEntity); ok {
+				return ie, nil
+			}
+			// Handle stale objects
+			if stale, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				return stale, nil
+			}
+			return nil, fmt.Errorf("expected *v1.Pod, got %T", obj)
+		}
+		return inf.podToIndexableEntity(pod)
+	}
+
+	cfg := &resourceWatcherConfig{
+		ctx:           wm.ctx,
+		client:        wm.client,
+		resourceType:  typePod,
+		fieldSelector: fieldSelector,
+		resyncPeriod:  wm.config.resyncPeriod,
+		transformFn:   podTransform,
+		eventHandler:  inf.ipInfoEventHandler(wm.ctx),
+		metrics:       wm.metrics,
+		log:           wm.log,
+		syncCallback:  wm.markSynced,
+	}
+
+	watcher, err := newResourceWatcher(cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := watcher.Start(); err != nil {
+		return err
+	}
+
+	wm.podWatcher = watcher
+	wm.log.Debug("pod watcher started")
+	return nil
+}
+
+// startNodeWatcher creates and starts the node watcher.
+func (wm *watchManager) startNodeWatcher(inf *Informers) error {
+	fieldSelector := ""
+	if wm.config.restrictNode != "" {
+		fieldSelector = fields.Set{"metadata.name": wm.config.restrictNode}.String()
+	}
+
+	// Transform function for nodes
+	nodeTransform := func(obj interface{}) (interface{}, error) {
+		node, ok := obj.(*v1.Node)
+		if !ok {
+			// Handle already transformed objects
+			if ie, ok := obj.(*indexableEntity); ok {
+				return ie, nil
+			}
+			// Handle stale objects
+			if stale, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				return stale, nil
+			}
+			return nil, fmt.Errorf("expected *v1.Node, got %T", obj)
+		}
+
+		// Extract IPs from node addresses
+		ips := make([]string, 0, len(node.Status.Addresses))
+		for _, address := range node.Status.Addresses {
+			ip := net.ParseIP(address.Address)
+			if ip != nil {
+				ips = append(ips, ip.String())
+			}
+		}
+
+		// Add CNI-specific IPs
+		ips = cni.AddOvnIPs(ips, node)
+
+		return &indexableEntity{
+			ObjectMeta: minimalIndex(&node.ObjectMeta),
+			EncodedMeta: &informer.ObjectMeta{
+				Name:            node.Name,
+				Namespace:       node.Namespace,
+				Labels:          node.Labels,
+				Ips:             ips,
+				Kind:            typeNode,
+				StatusTimeEpoch: objLastUpdateTime(&node.ObjectMeta, nil, node.Status.Conditions),
+			},
+		}, nil
+	}
+
+	cfg := &resourceWatcherConfig{
+		ctx:           wm.ctx,
+		client:        wm.client,
+		resourceType:  typeNode,
+		fieldSelector: fieldSelector,
+		resyncPeriod:  wm.config.resyncPeriod,
+		transformFn:   nodeTransform,
+		eventHandler:  inf.ipInfoEventHandler(wm.ctx),
+		metrics:       wm.metrics,
+		log:           wm.log,
+		syncCallback:  wm.markSynced,
+	}
+
+	watcher, err := newResourceWatcher(cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := watcher.Start(); err != nil {
+		return err
+	}
+
+	wm.nodeWatcher = watcher
+	wm.log.Debug("node watcher started")
+	return nil
+}
+
+// startServiceWatcher creates and starts the service watcher.
+func (wm *watchManager) startServiceWatcher(inf *Informers) error {
+	// Services are never filtered by node
+
+	// Transform function for services
+	serviceTransform := func(obj interface{}) (interface{}, error) {
+		svc, ok := obj.(*v1.Service)
+		if !ok {
+			// Handle already transformed objects
+			if ie, ok := obj.(*indexableEntity); ok {
+				return ie, nil
+			}
+			// Handle stale objects
+			if stale, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				return stale, nil
+			}
+			return nil, fmt.Errorf("expected *v1.Service, got %T", obj)
+		}
+
+		var ips []string
+		if svc.Spec.ClusterIP != v1.ClusterIPNone {
+			ips = svc.Spec.ClusterIPs
+		}
+
+		return &indexableEntity{
+			ObjectMeta: minimalIndex(&svc.ObjectMeta),
+			EncodedMeta: &informer.ObjectMeta{
+				Name:            svc.Name,
+				Namespace:       svc.Namespace,
+				Labels:          svc.Labels,
+				Ips:             ips,
+				Kind:            typeService,
+				StatusTimeEpoch: objLastUpdateTime(&svc.ObjectMeta, nil, nil),
+			},
+		}, nil
+	}
+
+	cfg := &resourceWatcherConfig{
+		ctx:           wm.ctx,
+		client:        wm.client,
+		resourceType:  typeService,
+		fieldSelector: "", // No field selector for services
+		resyncPeriod:  wm.config.resyncPeriod,
+		transformFn:   serviceTransform,
+		eventHandler:  inf.ipInfoEventHandler(wm.ctx),
+		metrics:       wm.metrics,
+		log:           wm.log,
+		syncCallback:  wm.markSynced,
+	}
+
+	watcher, err := newResourceWatcher(cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := watcher.Start(); err != nil {
+		return err
+	}
+
+	wm.serviceWatcher = watcher
+	wm.log.Debug("service watcher started")
+	return nil
+}


### PR DESCRIPTION
This is just a vibe-coded PoC. Informers have a big impact in the memory of each K8s cache instance. This PoC replaces them by the Watch API.

This is just a test to see if it passes all the tests, and a starting point for human review and later optimization/improvements.