### PR TITLE
Per-app metric features: make it consistent with the rest of the instrument entries

### DIFF
--- a/internal/test/integration/components/gomysql-otelsql/gomysql_otelsql.go
+++ b/internal/test/integration/components/gomysql-otelsql/gomysql_otelsql.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/XSAM/otelsql"
 	_ "github.com/go-sql-driver/mysql"
+
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 )
 

--- a/pkg/appolly/discover/typer.go
+++ b/pkg/appolly/discover/typer.go
@@ -18,7 +18,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/ebpf"
-	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/goexec"
 	"go.opentelemetry.io/obi/pkg/internal/procs"
@@ -95,7 +94,7 @@ func (t *typer) makeServiceAttrs(processMatch *ProcessMatch) svc.Attrs {
 	exportModes := services.ExportModeUnset
 	var samplerConfig *services.SamplerConfig
 	var routesConfig *services.CustomRoutesConfig
-	svcFeatures := export.Features(0)
+	svcFeatures := t.cfg.Metrics.Features
 
 	for _, s := range processMatch.Criteria {
 		if n := s.GetName(); n != "" {
@@ -118,14 +117,9 @@ func (t *typer) makeServiceAttrs(processMatch *ProcessMatch) svc.Attrs {
 			routesConfig = m
 		}
 
-		if critFeat := s.MetricsConfig().Features; svcFeatures.Undefined() && !critFeat.Undefined() {
+		if critFeat := s.MetricsConfig().Features; !critFeat.Undefined() {
 			svcFeatures = critFeat
 		}
-	}
-
-	// If no matching criteria defines their own features, we set it to the base configuration.
-	if svcFeatures.Undefined() {
-		svcFeatures = t.cfg.Metrics.Features
 	}
 
 	routesCfg := t.cfg.Routes


### PR DESCRIPTION
When a process match multiple criteria, the properties of the later criteria have preference to the properties from the earlier criteria.

Per-application metric feature definition was behaving the opposite way (the earlier criteria has top preference). This would be really confusing for our users so this PR reverts the behavior to make it consistent with the rest of `instrument` entries.