### PR TITLE
Refactor query return handler for Go SQL probes

### DIFF
--- a/internal/test/integration/components/gomysql/gomysql.go
+++ b/internal/test/integration/components/gomysql/gomysql.go
@@ -53,6 +53,31 @@ func main() {
 		fmt.Fprintf(w, "Student: %s, ID: %d", name, id)
 	})
 
+	http.HandleFunc("/mysqlerror", func(w http.ResponseWriter, r *http.Request) {
+		if !mysqlInit {
+			db, err = sql.Open("mysql", "root:mysql@tcp(mysqlserver:3306)/sqltest")
+			if err != nil {
+				log.Printf("Failed to connect: %v\n", err)
+				w.WriteHeader(200)
+				w.Write([]byte("DB connection failed (expected)"))
+				return
+			}
+			mysqlInit = true
+		}
+
+		// Execute broken SQL - this should return an error
+		rows, err := db.Query("SELECT * FROM nonexistent_table WHERE id=1")
+		if err != nil {
+			log.Printf("Expected error from broken SQL: %v\n", err)
+			w.WriteHeader(200) // Return 200 for OATS framework, actual SQL error is in trace
+			w.Write([]byte("SQL error (expected)"))
+			return
+		}
+		defer rows.Close()
+
+		w.Write([]byte("unexpected success"))
+	})
+
 	log.Println("Starting Go MySQL test server on :8080")
 	http.ListenAndServe(":8080", nil)
 }

--- a/internal/test/oats/sql/yaml/oats_sql_go_mysql.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_mysql.yaml
@@ -4,15 +4,23 @@ docker-compose:
     - ../docker-compose-beyla-gomysqlclient.yml
 input:
   - path: /mysqltest
+  - path: /mysqlerror
 interval: 500ms
 expected:
   traces:
-    - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "other_sql" }'
+    - traceql: '{ name = "SELECT students" }'
       spans:
         - name: 'SELECT students'
           attributes:
             db.operation.name: SELECT
             db.collection.name: students
+            db.system.name: other_sql
+    - traceql: '{ .db.operation.name = "SELECT" && status = error }'
+      spans:
+        - name: 'SELECT nonexistent_table'
+          attributes:
+            db.operation.name: SELECT
+            db.collection.name: nonexistent_table
             db.system.name: other_sql
   metrics:
     - promql: 'db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}'


### PR DESCRIPTION
This PR refactors the duplicated probe function for Go SQL added in #1089 
Now Mysql and PGX use same return method for query operations, having as parameter
the `err` return to set `status` of the SQL operation.

I also added an extra OATS test for mysql for the failure mode.