### PR TITLE
build: upgrade spotless for JDK 25 compat

### DIFF
--- a/pkg/internal/java/agent/build.gradle.kts
+++ b/pkg/internal/java/agent/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     java
     id("com.gradleup.shadow") version "8.3.9"
     id("me.champeau.jmh") version "0.7.3"
-    id("com.diffplug.spotless") version "6.25.0"
+    id("com.diffplug.spotless") version "8.0.0"
 }
 
 group = "io.opentelemetry.obi"

--- a/pkg/internal/java/loader/build.gradle.kts
+++ b/pkg/internal/java/loader/build.gradle.kts
@@ -3,7 +3,7 @@ import com.diffplug.gradle.spotless.SpotlessExtension
 plugins {
     java
     id("com.gradleup.shadow") version "8.3.9"
-    id("com.diffplug.spotless") version "6.25.0"
+    id("com.diffplug.spotless") version "8.0.0"
 }
 
 // We need this dependency to load the resource JNA shared libraries


### PR DESCRIPTION
The spotless plugin includes `google-java-format`, the version of which is currently incompatible with JDK 25. Bumping spotless to a newer version also includes a newer version of `google-java-format` which is compatible with JDK 25.

Steps to repro:

```shell
java -version
openjdk version "25.0.1" 2025-10-21
OpenJDK Runtime Environment Homebrew (build 25.0.1)
OpenJDK 64-Bit Server VM Homebrew (build 25.0.1, mixed mode, sharing)

cd pkg/internal/java
./gradlew build
```

Before:

```shell
./gradlew build
Starting a Gradle Daemon (subsequent builds will be faster)

> Task :agent:spotlessJava FAILED
Step 'google-java-format' found problem in 'src/jmh/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractorBenchmark.java':
'java.util.Queue com.sun.tools.javac.util.Log$DeferredDiagnosticHandler.getDiagnostics()'
java.lang.NoSuchMethodError: 'java.util.Queue com.sun.tools.javac.util.Log$DeferredDiagnosticHandler.getDiagnostics()'
        at com.google.googlejavaformat.java.JavaInput.buildToks(JavaInput.java:367)
        at com.google.googlejavaformat.java.JavaInput.buildToks(JavaInput.java:335)
        at com.google.googlejavaformat.java.JavaInput.<init>(JavaInput.java:277)

... snip stack trace higher than the empire state

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':agent:spotlessJava'.
> 'java.util.Queue com.sun.tools.javac.util.Log$DeferredDiagnosticHandler.getDiagnostics()'

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to generate a Build Scan (powered by Develocity).
> Get more help at https://help.gradle.org.

BUILD FAILED in 3s
7 actionable tasks: 1 executed, 6 up-to-date
```

After:

```shell
./gradlew build

> Task :agent:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by com.sun.jna.Native in an unnamed module (file:/Users/skl/.gradle/caches/modules-2/files-2.1/net.java.dev.jna/jna/5.18.1/b27ba04287cc4abe769642fe8318d39fc89bf937/jna-5.18.1.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.github.benmanes.caffeine.cache.UnsafeAccess (file:/Users/skl/.gradle/caches/modules-2/files-2.1/com.github.ben-manes.caffeine/caffeine/2.9.3/b162491f768824d21487551873f9b3b374a7fe19/caffeine-2.9.3.jar)
WARNING: Please consider reporting this to the maintainers of class com.github.benmanes.caffeine.cache.UnsafeAccess
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release

> Task :loader:compileJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

[Incubating] Problems report is available at: file:///Users/skl/src/opentelemetry-ebpf-instrumentation/pkg/internal/java/build/reports/problems/problems-report.html

BUILD SUCCESSFUL in 4s
17 actionable tasks: 13 executed, 4 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.2.1/userguide/configuration_cache_enabling.html
```