### PR TITLE
fix: llvm-strip not found

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -52,6 +52,7 @@ COPY --from=builder /build/obi_genfiles /go/bin
 
 RUN cat <<EOF > /generate.sh
 #!/bin/sh
+export PATH="/usr/lib/llvm20/bin:\$PATH"
 export BPF2GO=bpf2go
 export BPF_CLANG=clang
 export BPF_CFLAGS="-O2 -g -Wall -Werror"


### PR DESCRIPTION
Generator image 0.2.4 had an issue where the `llvm-strip` binary could not be found in the PATH. Image 0.2.5 has been created from this branch:

- https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/21065683669

Validated in #1113.