### PR TITLE
Fix features link with absolute path

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
 ## Checklist
 
-- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](../devdocs/features.md)
+- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)
+
+<!-- markdownlint-disable-file MD041 -->


### PR DESCRIPTION
This PR fixes the features doc link by using an absolute path. It also updates the *Checklist* heading to satisfy the linter.