### PR TITLE
Add support for Exec operations for pgx

### DIFF
--- a/bpf/gotracer/go_sql.c
+++ b/bpf/gotracer/go_sql.c
@@ -314,6 +314,20 @@ int obi_uprobe_pgx_Query(struct pt_regs *ctx) {
     return 0;
 }
 
+SEC("uprobe/pgx_Exec")
+int obi_uprobe_pgx_Exec(struct pt_regs *ctx) {
+    bpf_dbg_printk("=== uprobe/pgx_Exec === ");
+    void *goroutine_addr = GOROUTINE_PTR(ctx);
+    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+
+    void *pgx_conn = GO_PARAM1(ctx);
+    void *sql_param = GO_PARAM4(ctx);
+    void *query_len = GO_PARAM5(ctx);
+
+    set_sql_info(goroutine_addr, pgx_conn, sql_param, query_len);
+    return 0;
+}
+
 SEC("uprobe/execDC")
 int obi_uprobe_execDC(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/execDC === ");

--- a/internal/test/oats/sql/yaml/oats_sql_go_pgx.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_pgx.yaml
@@ -3,18 +3,27 @@ docker-compose:
   files:
     - ../docker-compose-beyla-gopgxclient.yml
 input:
-  - path: /pgxtest
+  - path: /pgxquery
+  - path: /pgxupdate
   - path: /pgxerror
 
 interval: 500ms
 expected:
   traces:
-    # Successful query
+    # Successful SELECT
     - traceql: '{ name = "SELECT accounting.contacts" }'
       spans:
         - name: 'SELECT accounting.contacts'
           attributes:
             db.operation.name: SELECT
+            db.collection.name: accounting.contacts
+            db.system.name: other_sql
+    # Successful UPDATE
+    - traceql: '{ name = "UPDATE accounting.contacts" }'
+      spans:
+        - name: 'UPDATE accounting.contacts'
+          attributes:
+            db.operation.name: UPDATE
             db.collection.name: accounting.contacts
             db.system.name: other_sql
     # Error query
@@ -26,6 +35,7 @@ expected:
             db.collection.name: nonexistent_table
             db.system.name: other_sql
   metrics:
+    # SELECT metrics
     - promql: 'db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}'
       value: "> 0"
     - promql: 'db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}'
@@ -33,4 +43,9 @@ expected:
     - promql: 'db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}'
       value: "> 0"
     - promql: 'db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}'
+      value: "> 0"
+    # UPDATE metrics
+    - promql: 'db_client_operation_duration_seconds_sum{db_operation_name="UPDATE", db_system_name="other_sql", server_address="sqlserver"}'
+      value: "> 0"
+    - promql: 'db_client_operation_duration_seconds_count{db_operation_name="UPDATE", db_system_name="other_sql", server_address="sqlserver"}'
       value: "> 0"

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -347,6 +347,10 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 			Start: p.bpfObjects.ObiUprobePgxQuery,
 			End:   p.bpfObjects.ObiUprobePgxQueryReturn,
 		}},
+		"github.com/jackc/pgx/v5.(*Conn).Exec": {{
+			Start: p.bpfObjects.ObiUprobePgxExec,
+			End:   p.bpfObjects.ObiUprobePgxQueryReturn,
+		}},
 		// Go gRPC
 		"google.golang.org/grpc.(*Server).handleStream": {{
 			Start: p.bpfObjects.ObiUprobeServerHandleStream,


### PR DESCRIPTION
This PR adds support to instrument `Exec` operations (updates, inserts, etc) for Postgres pgx.