### PR TITLE
build: bump obi-generator to use go 1.25.6

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-alpine@sha256:ac09a5f469f307e5da71e766b0bd59c9c49ea460a528cc3e6686513d64a6f1fb AS base
+FROM golang:1.25.6-alpine@sha256:d9b2e14101f27ec8d09674cd01186798d227bb0daec90e032aeb1cd22ac0f029 AS base
 FROM base AS builder
 
 WORKDIR /build


### PR DESCRIPTION
- Publish new obi-generator image ([action link](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/21141619162))