### PR TITLE
Fix noisy warnings when skipped go specific tracer

### DIFF
--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -174,10 +174,12 @@ func (ta *traceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 		// gets all the possible supported tracers for a go program, and filters out
 		// those whose symbols are not present in the ELF functions list
 		if ta.Cfg.Discovery.SkipGoSpecificTracers || ie.InstrumentationError != nil || ie.Offsets == nil {
-			if ie.InstrumentationError != nil {
-				ta.log.Warn("Unsupported Go program detected, using generic instrumentation", "error", ie.InstrumentationError)
-			} else if ie.Offsets == nil {
-				ta.log.Warn("Go program with null offsets detected, using generic instrumentation")
+			if !ta.Cfg.Discovery.SkipGoSpecificTracers {
+				if ie.InstrumentationError != nil {
+					ta.log.Warn("Unsupported Go program detected, using generic instrumentation", "error", ie.InstrumentationError)
+				} else if ie.Offsets == nil {
+					ta.log.Warn("Go program with null offsets detected, using generic instrumentation")
+				}
 			}
 			if ta.reusableTracer != nil {
 				// We need to do more than monitor PIDs. It's possible that this new

--- a/pkg/appolly/discover/typer.go
+++ b/pkg/appolly/discover/typer.go
@@ -241,7 +241,7 @@ func (t *typer) asInstrumentable(execElf *exec.FileInfo) ebpf.Instrumentable {
 
 	detectedType := procs.FindProcLanguage(execElf.Pid)
 
-	if detectedType == svc.InstrumentableGolang && err == nil {
+	if !t.cfg.Discovery.SkipGoSpecificTracers && detectedType == svc.InstrumentableGolang && err == nil {
 		log.Warn("ELF binary appears to be a Go program, but no offsets were found",
 			"comm", execElf.CmdExePath, "pid", execElf.Pid)
 


### PR DESCRIPTION
When we explicitly set "skip specific go tracers", we still see a lot of warnings that could make users thinking that there is something wrong, when OBI is really following the expected path:

```
time=2026-01-22T09:28:26.789Z level=WARN msg="ELF binary appears to be a Go program, but no offsets were found" component=discover.ExecTyper pid=956269 comm=/netfilter-exporter comm=/netfilter-exporter pid=956269
time=2026-01-22T09:28:32.202Z level=WARN msg="Unsupported Go program detected, using generic instrumentation" component=discover.traceAttacher error="could not find any Go offsets in Go binary /usr/local/bin/crossplane"
```
(👆 repeated for every instrumented process)