### PR TITLE
Slightly improve HTTP2grpc memory generation

### DIFF
--- a/pkg/ebpf/common/http2grpc_transform.go
+++ b/pkg/ebpf/common/http2grpc_transform.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"io"
 	"regexp"
 	"strconv"
 	"strings"
@@ -47,8 +48,10 @@ type h2Connection struct {
 }
 
 func byteFramer(data []uint8) *http2.Framer {
-	buf := bytes.NewBuffer(data)
-	fr := http2.NewFramer(buf, buf) // the write is same as read, but we never write
+	fr := http2.NewFramer(
+		// we never write. We can save some resources
+		io.Discard,
+		bytes.NewReader(data))
 
 	return fr
 }


### PR DESCRIPTION
Replaced `bytes.NewBuffer` by a zero-copy alternative, as`byteFramer` function reported to generate a lot of memory in some super-high-load scenarios:
<img width="919" height="416" alt="image" src="https://github.com/user-attachments/assets/4f211d9b-ece0-4ae0-8912-f4f1825005e2" />

After the changes, there is a slight improvement in terms of pod memory:

<img width="914" height="421" alt="image" src="https://github.com/user-attachments/assets/e72eabde-fd9f-439f-86df-875e78f8cf8c" />

The Garbage collector also shows some slight improvement in terms of cpu (-3%) under low-load scenarios
