### PR TITLE
Improving internal queue block mechanism

### DIFF
--- a/pkg/appolly/instrumenter.go
+++ b/pkg/appolly/instrumenter.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 	"go.opentelemetry.io/obi/pkg/export/prom"
 	"go.opentelemetry.io/obi/pkg/filter"
+	msg2 "go.opentelemetry.io/obi/pkg/internal/helpers/msg"
 	"go.opentelemetry.io/obi/pkg/internal/traces"
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
@@ -65,39 +66,33 @@ func newGraphBuilder(
 		ExtraGroupAttributesCfg: config.Attributes.ExtraGroupAttributes,
 	}
 
-	newQueue := func(name string) *msg.Queue[[]request.Span] {
-		return msg.NewQueue[[]request.Span](msg.ChannelBufferLen(config.ChannelBufferLen), msg.Name(name))
-	}
-
 	// Second, we register instancers for each pipe node, as well as communication queues between them
 	// TODO: consider moving the queues to a public structure so when OBI is used as library, other components can
 	// listen to the messages and expanding the Pipeline
-	tracesReaderToRouter := newQueue("tracesReaderToRouter")
+	tracesReaderToRouter := msg2.QueueFromConfig[[]request.Span](config, "tracesReaderToRouter")
 	swi.Add(traces.ReadFromChannel(&traces.ReadDecorator{
 		InstanceID:      config.Attributes.InstanceID,
 		TracesInput:     tracesCh,
 		DecoratedTraces: tracesReaderToRouter,
 	}), swarm.WithID("ReadFromChannel"))
 
-	routerToKubeDecorator := msg.NewQueue[[]request.Span](
-		msg.ChannelBufferLen(config.ChannelBufferLen),
-		msg.Name("routerToKubeDecorator"),
+	routerToKubeDecorator := msg2.QueueFromConfig[[]request.Span](config, "routerToKubeDecorator",
 		// make sure that we are able to wait for the informer sync timeout before failing the pipeline
 		// if a message gets bocked while the Kube decorator starts
-		msg.SendTimeout(config.Attributes.Kubernetes.InformersSyncTimeout+20*time.Second))
+		msg.SendTimeout(max(config.Attributes.Kubernetes.InformersSyncTimeout, config.ChannelSendTimeout)))
 	swi.Add(transform.RoutesProvider(
 		config.Routes,
 		tracesReaderToRouter,
 		routerToKubeDecorator,
 	), swarm.WithID("Routes"))
 
-	kubeDecoratorToNameResolver := newQueue("kubeDecoratorToNameResolver")
+	kubeDecoratorToNameResolver := msg2.QueueFromConfig[[]request.Span](config, "kubeDecoratorToNameResolver")
 	swi.Add(transform.KubeDecoratorProvider(
 		ctxInfo, &config.Attributes.Kubernetes,
 		routerToKubeDecorator, kubeDecoratorToNameResolver,
 	), swarm.WithID("KubeDecorator"))
 
-	nameResolverToAttrFilter := newQueue("nameResolverToAttrFilter")
+	nameResolverToAttrFilter := msg2.QueueFromConfig[[]request.Span](config, "nameResolverToAttrFilter")
 	swi.Add(transform.NameResolutionProvider(ctxInfo, config.NameResolver,
 		kubeDecoratorToNameResolver, nameResolverToAttrFilter),
 		swarm.WithID("NameResolution"))
@@ -106,7 +101,7 @@ func newGraphBuilder(
 	// own exporters, otherwise we create a new queue
 	exportableSpans := ctxInfo.OverrideAppExportQueue
 	if exportableSpans == nil {
-		exportableSpans = newQueue("exportableSpans")
+		exportableSpans = msg2.QueueFromConfig[[]request.Span](config, "exportableSpans")
 	}
 	swi.Add(filter.ByAttribute(config.Filters.Application,
 		nil,
@@ -149,12 +144,10 @@ func setupMetricsSubPipeline(
 	selectorCfg *attributes.SelectorConfig,
 	processEventsCh *msg.Queue[exec.ProcessEvent],
 ) {
-	newQueue := func(name string) *msg.Queue[[]request.Span] {
-		return msg.NewQueue[[]request.Span](msg.ChannelBufferLen(config.ChannelBufferLen), msg.Name(name))
-	}
 	jointMetricsConfig := joinMetricsConfig(config)
 
-	spanNameAggregatedMetrics := newQueue("spanNameAggregatedMetrics")
+	spanNameAggregatedMetrics := msg2.QueueFromConfig[[]request.Span](config, "spanNameAggregatedMetrics")
+
 	swi.Add(transform.SpanNameLimiter(transform.SpanNameLimiterConfig{
 		Limit:      config.Attributes.MetricSpanNameAggregationLimit,
 		OTEL:       &config.OTELMetrics,

--- a/pkg/internal/helpers/msg/queue_from_cfg.go
+++ b/pkg/internal/helpers/msg/queue_from_cfg.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package msg // import "go.opentelemetry.io/obi/pkg/internal/helpers/msg"
+
+import (
+	"go.opentelemetry.io/obi/pkg/obi"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+)
+
+// QueueFromConfig creates a standard msg.Queue[T] from the given OBI config
+func QueueFromConfig[T any](config *obi.Config, name string, overrideQueueOpts ...msg.QueueOpts) *msg.Queue[T] {
+	queueOpts := []msg.QueueOpts{
+		msg.ChannelBufferLen(config.ChannelBufferLen),
+		msg.SendTimeout(config.ChannelSendTimeout),
+		msg.Name(name),
+	}
+	if config.ChannelSendTimeoutPanic {
+		queueOpts = append(queueOpts, msg.PanicOnSendTimeout())
+	}
+	queueOpts = append(queueOpts, overrideQueueOpts...)
+
+	return msg.NewQueue[T](queueOpts...)
+}

--- a/pkg/internal/helpers/msg/queue_from_cfg_test.go
+++ b/pkg/internal/helpers/msg/queue_from_cfg_test.go
@@ -1,0 +1,114 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package msg
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/internal/testutil"
+	"go.opentelemetry.io/obi/pkg/obi"
+	msg2 "go.opentelemetry.io/obi/pkg/pipe/msg"
+)
+
+const timeout = 5 * time.Second
+
+func TestBasicOptions(t *testing.T) {
+	logOutput := threadSafeBuffer{}
+
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+
+	queue := QueueFromConfig[int](&obi.Config{
+		ChannelBufferLen:   1,
+		ChannelSendTimeout: 5 * time.Millisecond,
+	}, "basicQueue")
+	out := queue.Subscribe(msg2.SubscriberName("test-out"))
+
+	ctx, c := context.WithTimeout(t.Context(), timeout)
+	defer c()
+	go func() {
+		// will be immediately sent due to buffer = 1
+		queue.SendCtx(ctx, 123)
+		// won't be immediately sent due to timeout on buffer
+		go queue.SendCtx(ctx, 456)
+	}()
+
+	// wait for the blocked log to be written
+	var amsg atomic.Value
+	test.Eventually(t, timeout, func(t require.TestingT) {
+		str, err := logOutput.ReadString('\n')
+		require.NoError(t, err)
+		amsg.Store(str)
+	})
+	require.NotNil(t, amsg.Load())
+	msg := amsg.Load().(string)
+	assert.Contains(t, msg, "blocked")
+	assert.Contains(t, msg, "timeout=5ms")
+	assert.Contains(t, msg, "queueName=basicQueue")
+	assert.Contains(t, msg, "queueLen=1")
+	assert.Contains(t, msg, "queueCap=1")
+	assert.Contains(t, msg, "subscriber=test-out")
+
+	// the messages are eventually delivered
+	assert.Equal(t, 123, testutil.ReadChannel(t, out, timeout))
+	assert.Equal(t, 456, testutil.ReadChannel(t, out, timeout))
+}
+
+func TestBasicOptions_PanicOnBlock(t *testing.T) {
+	logOutput := threadSafeBuffer{}
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+
+	queue := QueueFromConfig[int](&obi.Config{
+		ChannelBufferLen:        1,
+		ChannelSendTimeout:      5 * time.Millisecond,
+		ChannelSendTimeoutPanic: true,
+	}, "basicQueue")
+	out := queue.Subscribe(msg2.SubscriberName("test-out"))
+
+	ctx, c := context.WithTimeout(t.Context(), timeout)
+	defer c()
+	// will be immediately sent due to buffer = 1
+	sent := make(chan struct{})
+	go func() {
+		queue.SendCtx(ctx, 123)
+		close(sent)
+	}()
+	testutil.ReadChannel(t, sent, timeout)
+	// won't be immediately sent due to timeout on buffer
+	assert.Panics(t, func() {
+		queue.SendCtx(ctx, 456)
+	}, "expected panic due to timeout")
+
+	// the first message was delivered
+	assert.Equal(t, 123, testutil.ReadChannel(t, out, timeout))
+	// but the second message was never delivered
+	testutil.ChannelEmpty(t, out, 10*time.Millisecond)
+}
+
+// avoids some race conditions between the queue and the eventually clauses
+type threadSafeBuffer struct {
+	mt     sync.Mutex
+	buffer bytes.Buffer
+}
+
+func (t *threadSafeBuffer) Write(p []byte) (n int, err error) {
+	t.mt.Lock()
+	defer t.mt.Unlock()
+	return t.buffer.Write(p)
+}
+
+func (t *threadSafeBuffer) ReadString(delim byte) (string, error) {
+	t.mt.Lock()
+	defer t.mt.Unlock()
+	return t.buffer.ReadString(delim)
+}

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -85,10 +85,12 @@ var (
 )
 
 var DefaultConfig = Config{
-	ChannelBufferLen: 10,
-	LogLevel:         LogLevelInfo,
-	ShutdownTimeout:  10 * time.Second,
-	EnforceSysCaps:   false,
+	ChannelBufferLen:        50,
+	ChannelSendTimeout:      time.Minute,
+	ChannelSendTimeoutPanic: false,
+	LogLevel:                LogLevelInfo,
+	ShutdownTimeout:         10 * time.Second,
+	EnforceSysCaps:          false,
 	EBPF: config.EBPFTracer{
 		BatchLength:        100,
 		BatchTimeout:       time.Second,
@@ -305,9 +307,12 @@ type Config struct {
 	// From this comment, the properties below will remain undocumented, as they
 	// are useful for development purposes. They might be helpful for customer support.
 
-	ChannelBufferLen int             `yaml:"channel_buffer_len" env:"OTEL_EBPF_CHANNEL_BUFFER_LEN"`
-	ProfilePort      int             `yaml:"profile_port" env:"OTEL_EBPF_PROFILE_PORT"`
-	InternalMetrics  imetrics.Config `yaml:"internal_metrics"`
+	ChannelBufferLen        int           `yaml:"channel_buffer_len" env:"OTEL_EBPF_CHANNEL_BUFFER_LEN"`
+	ChannelSendTimeout      time.Duration `yaml:"channel_send_timeout" env:"OTEL_EBPF_CHANNEL_SEND_TIMEOUT"`
+	ChannelSendTimeoutPanic bool          `yaml:"channel_send_timeout_panic" env:"OTEL_EBPF_CHANNEL_SEND_TIMEOUT_PANIC"`
+
+	ProfilePort     int             `yaml:"profile_port" env:"OTEL_EBPF_PROFILE_PORT"`
+	InternalMetrics imetrics.Config `yaml:"internal_metrics"`
 
 	// LogConfig enables the logging of the configuration on startup.
 	LogConfig LogConfigOption `yaml:"log_config" env:"OTEL_EBPF_LOG_CONFIG"`

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -41,6 +41,8 @@ func TestConfig_Overrides(t *testing.T) {
 trace_printer: json
 shutdown_timeout: 30s
 channel_buffer_len: 33
+channel_send_timeout: 10s
+channel_send_timeout_panic: true
 ebpf:
   functions:
     - FooBar
@@ -115,14 +117,18 @@ discovery:
 	metaSources["service.namespace"] = []string{"huha.com/yeah"}
 
 	assert.Equal(t, &Config{
-		Exec:             cfg.Exec,
-		Port:             cfg.Port,
-		ServiceName:      "svc-name",
-		ChannelBufferLen: 33,
-		LogLevel:         LogLevelInfo,
-		ShutdownTimeout:  30 * time.Second,
-		EnforceSysCaps:   false,
-		TracePrinter:     "json",
+		Exec:        cfg.Exec,
+		Port:        cfg.Port,
+		ServiceName: "svc-name",
+
+		ChannelBufferLen:        33,
+		ChannelSendTimeout:      10 * time.Second,
+		ChannelSendTimeoutPanic: true,
+
+		LogLevel:        LogLevelInfo,
+		ShutdownTimeout: 30 * time.Second,
+		EnforceSysCaps:  false,
+		TracePrinter:    "json",
 		EBPF: config.EBPFTracer{
 			BatchLength:        100,
 			BatchTimeout:       time.Second,

--- a/pkg/pipe/msg/queue.go
+++ b/pkg/pipe/msg/queue.go
@@ -16,7 +16,7 @@ import (
 
 // if a Send operation takes more than this time, we panic informing about a deadlock
 // in the user-provide pipeline
-const defaultSendTimeout = 20 * time.Second
+const defaultSendTimeout = time.Minute
 
 const unnamed = "(unnamed)"
 
@@ -25,6 +25,7 @@ type queueConfig struct {
 	closingAttempts  int
 	name             string
 	sendTimeout      time.Duration
+	panicOnTimeout   bool
 }
 
 var defaultQueueConfig = queueConfig{
@@ -32,6 +33,7 @@ var defaultQueueConfig = queueConfig{
 	closingAttempts:  1,
 	name:             unnamed,
 	sendTimeout:      defaultSendTimeout,
+	panicOnTimeout:   false,
 }
 
 // QueueOpts allow configuring some operation of a queue
@@ -59,6 +61,13 @@ func Name(name string) QueueOpts {
 func SendTimeout(to time.Duration) QueueOpts {
 	return func(c *queueConfig) {
 		c.sendTimeout = to
+	}
+}
+
+// PanicOnSendTimeout configures the queue to panic when a send operation times out.
+func PanicOnSendTimeout() QueueOpts {
+	return func(c *queueConfig) {
+		c.panicOnTimeout = true
 	}
 }
 
@@ -95,6 +104,7 @@ type Queue[T any] struct {
 	closed   atomic.Bool
 
 	sendTimeout *time.Timer
+	logger      *slog.Logger
 }
 
 // NewQueue creates a new Queue instance with the given options.
@@ -103,7 +113,12 @@ func NewQueue[T any](opts ...QueueOpts) *Queue[T] {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	return &Queue[T]{cfg: &cfg, remainingClosers: cfg.closingAttempts, sendTimeout: time.NewTimer(cfg.sendTimeout)}
+	return &Queue[T]{
+		cfg:              &cfg,
+		remainingClosers: cfg.closingAttempts,
+		sendTimeout:      time.NewTimer(cfg.sendTimeout),
+		logger:           slog.With("queueName", cfg.name),
+	}
 }
 
 // SendCtx sends a message to all subscribers of this queue, and interrupts the operation if the
@@ -139,9 +154,13 @@ func (q *Queue[T]) chainedSend(ctx context.Context, o T, bypassPath []string) {
 		return
 	}
 
-	// instead of directly panicking in sendTimeout, we first warn at 0.75*sendTimeout,
-	// to get logged about other blocked senders before panicking
-	q.sendTimeout.Reset(3 * q.cfg.sendTimeout / 4)
+	if q.cfg.panicOnTimeout {
+		// instead of directly panicking in sendTimeout, we first warn at 90% sendTimeout,
+		// to get logged about other blocked senders before panicking
+		q.sendTimeout.Reset(9 * q.cfg.sendTimeout / 10)
+	} else {
+		q.sendTimeout.Reset(q.cfg.sendTimeout)
+	}
 	var blocked []dst[T]
 	for _, d := range q.dsts {
 		select {
@@ -150,31 +169,44 @@ func (q *Queue[T]) chainedSend(ctx context.Context, o T, bypassPath []string) {
 		case d.ch <- o:
 			// good!
 		case <-q.sendTimeout.C:
-			slog.With(
-				"timeout", q.cfg.sendTimeout,
-				"queueLen", len(d.ch), "queueCap", cap(d.ch),
-				"sendPath", strings.Join(bypassPath, "->"),
-				"dstName", d.name).
-				Warn("subscriber channel is taking too long to respond")
-			// reset timeout to a small amount to detect any other possible blocked subscriber
-			q.sendTimeout.Reset(time.Second)
+			q.logger.Warn("an internal queue seems to be blocked. You might need to change "+
+				"some of the following configuration options: OTEL_EBPF_OTLP_TRACES_MAX_QUEUE_SIZE, "+
+				"OTEL_EBPF_CHANNEL_BUFFER_LEN, OTEL_EBPF_CHANNEL_SEND_TIMEOUT, "+
+				"OTEL_EBPF_BPF_BATCH_LENGTH, OTEL_EBPF_BPF_BATCH_TIMEOUT",
+				slog.Duration("timeout", q.cfg.sendTimeout),
+				slog.Int("queueLen", len(d.ch)),
+				slog.Int("queueCap", cap(d.ch)),
+				slog.String("sendPath", strings.Join(bypassPath, "->")),
+				slog.String("subscriber", d.name),
+			)
 			blocked = append(blocked, d)
 		}
 	}
-	if len(blocked) == 0 {
-		return
-	}
-	// if we confirm that the blocker candidates are actually blocked, we panic
-	q.sendTimeout.Reset(q.cfg.sendTimeout / 4)
-	for _, d := range blocked {
-		select {
-		case <-ctx.Done():
-			return
-		case d.ch <- o:
-			// good!
-		case <-q.sendTimeout.C:
-			panic(fmt.Sprintf("sending through queue path %s. Subscriber channel %s is blocked",
-				strings.Join(bypassPath, "->"), d.name))
+
+	if !q.cfg.panicOnTimeout {
+		// if we don't configure the queue to panic on timeout, we wait
+		// for the messages to be delivered
+		for _, d := range blocked {
+			select {
+			case <-ctx.Done():
+				return
+			case d.ch <- o:
+				// good!
+			}
+		}
+	} else {
+		// if we confirm that the blocker candidates are actually blocked, we panic
+		q.sendTimeout.Reset(q.cfg.sendTimeout / 10)
+		for _, d := range blocked {
+			select {
+			case <-ctx.Done():
+				return
+			case d.ch <- o:
+				// good!
+			case <-q.sendTimeout.C:
+				panic(fmt.Sprintf("sending through queue path %s. Subscriber channel %s is blocked",
+					strings.Join(bypassPath, "->"), d.name))
+			}
 		}
 	}
 }

--- a/pkg/pipe/msg/queue_test.go
+++ b/pkg/pipe/msg/queue_test.go
@@ -388,10 +388,10 @@ func TestBlockingPanics(t *testing.T) {
 			// tests the deadlock verifier. It should panic if a message is sent
 			// and nobody reads it
 
-			q1 := NewQueue[int](ChannelBufferLen(1), Name("q1"))
-			q2 := NewQueue[int](ChannelBufferLen(1), Name("q2"))
-			q2a1 := NewQueue[int](ChannelBufferLen(1), Name("q2a1"))
-			q2a2 := NewQueue[int](ChannelBufferLen(1), Name("q2a2"))
+			q1 := NewQueue[int](ChannelBufferLen(1), Name("q1"), PanicOnSendTimeout())
+			q2 := NewQueue[int](ChannelBufferLen(1), Name("q2"), PanicOnSendTimeout())
+			q2a1 := NewQueue[int](ChannelBufferLen(1), Name("q2a1"), PanicOnSendTimeout())
+			q2a2 := NewQueue[int](ChannelBufferLen(1), Name("q2a2"), PanicOnSendTimeout())
 
 			// q1 -> q2 -> q2a1 -> q2a2 // a dead path must not block if nobody subscribes to it
 			//         \-> ch           // path with actual subscribers


### PR DESCRIPTION
Under certain high-load scenarios, some users are complaining about the warning messages that appear under high-load scenarios after we migrated to a synchronous OTEL traces exporter that does not drop traces (so we don't loose traces but then backpressure leads to OBI internal pipeline being completely full). OBI might eventually panic as it detects it might be an internal bug.

This PR minimizes this issue by:
* Providing saner defaults: 
   - Internal queue length increased from 10 to 50
   - Internal channel submission timeout increased from 20s to 1 minute (to avoid network congestions to generate too many warnings)
   - By default, don't panic if the internal pipeline is full (to avoid network congestions to generate too many warnings)
* Providing newer configuration options: `OTEL_EBPF_CHANNEL_SEND_TIMEOUT` and `OTEL_EBPF_CHANNEL_SEND_TIMEOUT_PANIC`
* Channel warning message is more descriptive.
