### PR TITLE
enhance test-matrix job output to include test names

### DIFF
--- a/scripts/generate-integration-matrix.sh
+++ b/scripts/generate-integration-matrix.sh
@@ -57,7 +57,7 @@ while [ $SHARD -lt $PARTITIONS ]; do
         TEST_COUNT=$(echo "$SHARD_TESTS" | tr "|" "\n" | wc -l | tr -d " ")
         MATRIX_JSON+="{\"id\":$SHARD,\"description\":\"shard-$SHARD ($TEST_COUNT tests)\",\"test_pattern\":\"$SHARD_TESTS\"}"
         
-        echo "Shard $SHARD: $TEST_COUNT tests" >&2
+        echo "Shard $SHARD: $TEST_COUNT tests: $SHARD_TESTS" >&2
     fi
     
     CURRENT_START=$((END + 1))


### PR DESCRIPTION
Finding in which "shard" the test is executed is not user-friendly as of now (requires looking at all shard executions).
Compare [old (main)](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/21365028091/job/61494291883#step:3:9) with [new (this PR)](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/21375099832/job/61529196737?pr=1187#step:3:8).