### PR TITLE
Add golangci-lint rule for latest semconv

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,14 +111,23 @@ linters:
           files:
             - '!**/internal/test/integration/components/testserver_1.17/**'
           deny:
-            - pkg: "go.opentelemetry.io/otel/semconv/v1\\.[0-3][0-7]\\.[0-9]"
+            # Deny v1.0.0–v1.29.x (single- or double-digit minors below 30)
+            - pkg: "go.opentelemetry.io/otel/semconv/v1\\.[0-2]?[0-9]\\.[0-9]"
               desc: "Use 'go.opentelemetry.io/otel/semconv/v1.38.0' only (except in testserver_1.17)"
+            # Deny v1.30.0–v1.37.x
             - pkg: "go.opentelemetry.io/otel/semconv/v1\\.3[0-7]\\.[0-9]"
               desc: "Use 'go.opentelemetry.io/otel/semconv/v1.38.0' only (except in testserver_1.17)"
-            # Update to allow v1.39.x when we to upgrade to that version.
+            # Update to allow v1.39.x when we upgrade to that version.
             - pkg: "go.opentelemetry.io/otel/semconv/v1\\.39\\.[0-9]"
               desc: "Use 'go.opentelemetry.io/otel/semconv/v1.38.0' only (except in testserver_1.17)"
-            - pkg: "go.opentelemetry.io/otel/semconv/v[2-9]\\.[0-9]\\.[0-9]"
+            # Deny v1.40.0–v1.99.x
+            - pkg: "go.opentelemetry.io/otel/semconv/v1\\.[4-9][0-9]\\.[0-9]"
+              desc: "Use 'go.opentelemetry.io/otel/semconv/v1.38.0' only (except in testserver_1.17)"
+            # Deny v1.100.0 and higher minor versions
+            - pkg: "go.opentelemetry.io/otel/semconv/v1\\.[1-9][0-9]{2,}\\.[0-9]"
+              desc: "Use 'go.opentelemetry.io/otel/semconv/v1.38.0' only (except in testserver_1.17)"
+            # Deny all semconv v2+ versions, regardless of minor/patch length
+            - pkg: "go.opentelemetry.io/otel/semconv/v[2-9]\\.[0-9]+\\.[0-9]+"
               desc: "Use 'go.opentelemetry.io/otel/semconv/v1.38.0' only (except in testserver_1.17)"
 
     gosec:


### PR DESCRIPTION
Ensure the latest version of `go.opentelemetry.io/otel/semconv/*` is used.

Follow up to #1175 