### PR TITLE
Remove explicit mentions to bpf_printk

### DIFF
--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -267,7 +267,7 @@ static __always_inline void finish_http(http_info_t *info, pid_connection_info_t
             trace->flags = EVENT_K_HTTP_REQUEST;
             bpf_ringbuf_submit(trace, get_flags());
         } else {
-            bpf_printk("failed to reserve space in the ringbuf");
+            bpf_dbg_printk("failed to reserve space in the ringbuf");
         }
 
         // bpf_dbg_printk("Terminating trace for pid=%d", pid_from_pid_tgid(pid_tid));

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -293,7 +293,7 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
 
                 bpf_ringbuf_submit(trace, get_flags());
             } else {
-                bpf_printk("failed to reserve space on the ringbuf");
+                bpf_dbg_printk("failed to reserve space on the ringbuf");
             }
             cleanup_trace_info(existing, pid_conn);
         }

--- a/bpf/gotracer/types/otel_types.h
+++ b/bpf/gotracer/types/otel_types.h
@@ -39,7 +39,7 @@ static __always_inline bool set_attr_value(otel_attribute_t *attr,
     // String values
     if (vtype == attr_type_string) {
         if (go_attr_value->string.len >= OTEL_ATTRIBUTE_VALUE_MAX_LEN) {
-            bpf_printk("Aattribute string value is too long\n");
+            bpf_dbg_printk("Aattribute string value is too long");
             return false;
         }
         long res =


### PR DESCRIPTION
Raw `bpf_printk` is also costly, as it also relies on an internal  ring buffer for passing the event back to the kernel - as such, it should not be enabled in non-debug settings.

## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->