### PR TITLE
Update the return value for the processCudaEvent function

### DIFF
--- a/pkg/internal/ebpf/gpuevent/gpuevent.go
+++ b/pkg/internal/ebpf/gpuevent/gpuevent.go
@@ -256,7 +256,7 @@ func (p *Tracer) processCudaEvent(_ *ebpfcommon.EBPFParseContext, _ *config.EBPF
 		p.log.Error("unknown cuda event")
 	}
 
-	return request.Span{}, false, nil
+	return request.Span{}, true, nil
 }
 
 func (p *Tracer) readGPUMallocIntoSpan(record *ringbuf.Record) (request.Span, bool, error) {


### PR DESCRIPTION
This PR updates the value returned by the `processCudaEvent` function.
The returned bool value is then checked in the `processAndForward` function:

```
if ignore {
	return
}
```
for events that should be ignored (like "unknown cuda event").