### PR TITLE
Handle TCX program attachment gracefully

### DIFF
--- a/pkg/internal/ebpf/tcmanager/tcxmanager.go
+++ b/pkg/internal/ebpf/tcmanager/tcxmanager.go
@@ -196,11 +196,12 @@ func (tcx *tcxManager) attachProgramToIfaceLocked(prog *attachedProg, iface int)
 		Anchor:    link.Head(),
 	})
 
-	if err == nil {
+	switch {
+	case err == nil:
 		tcx.links = append(tcx.links, &ifaceLink{Link: link, progName: prog.name, iface: iface})
-	} else if errors.Is(err, unix.EEXIST) {
+	case errors.Is(err, unix.EEXIST):
 		tcx.log.Warn("Program already attached", "program", prog.name, "iface", iface)
-	} else {
+	default:
 		tcx.emitError("Error attaching tcx", "error", err)
 	}
 }


### PR DESCRIPTION
It is theoretically possible that we get the same interface reported more than once - in which case, we should not try to reattach the program (nor error out). Instead, we simply print a warning and continue to have fun as usual...

## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->