### PR TITLE
Support BPF_PROG_TYPE_TRACING

### DIFF
--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -125,6 +125,12 @@ type Iter struct {
 	Link    link.Link
 }
 
+type Tracing struct {
+	Program  *ebpf.Program
+	AttachAs ebpf.AttachType
+	Link     link.Link
+}
+
 type MisclassifiedEvent struct {
 	EventType int
 	TCPInfo   *TCPRequestInfo

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -108,6 +108,9 @@ type Tracer interface {
 	// Iters returns a list of programs that need to be loaded as a
 	// BPF_PROG_TYPE_TRACING with BPF_TRACE_ITER attach type
 	Iters() []*ebpfcommon.Iter
+	// Tracing() returns a list of programs that need to be loaded as a
+	// BPF_PROG_TYPE_TRACING
+	Tracing() []*ebpfcommon.Tracing
 	// Probes can potentially instrument a shared library among multiple executables
 	// These two functions alow programs to remember this and avoid duplicated instrumentations
 	// The argument is the OS file id

--- a/pkg/ebpf/tracer_linux.go
+++ b/pkg/ebpf/tracer_linux.go
@@ -297,6 +297,11 @@ func (pt *ProcessTracer) loadTracer(eventContext *common.EBPFEventContext, p Tra
 		return err
 	}
 
+	if err := i.tracing(p); err != nil {
+		printVerifierErrorInfo(err)
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/export/imetrics/imetrics.go
+++ b/pkg/export/imetrics/imetrics.go
@@ -47,6 +47,7 @@ const (
 	InstrumentationErrorAttachingKprobe                = "attaching_kprobe"
 	InstrumentationErrorAttachingUprobe                = "attaching_uprobe"
 	InstrumentationErrorAttachingIter                  = "attaching_iter"
+	InstrumentationErrorAttachingTracing               = "attaching_tracing"
 	InstrumentationErrorInvalidTracepoint              = "invalid_tracepoint"
 )
 

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -441,6 +441,8 @@ func (p *Tracer) Iters() []*ebpfcommon.Iter {
 	return p.iters
 }
 
+func (p *Tracer) Tracing() []*ebpfcommon.Tracing { return nil }
+
 func (p *Tracer) RecordInstrumentedLib(id uint64, closers []io.Closer) {
 	p.libsMux.Lock()
 	defer p.libsMux.Unlock()

--- a/pkg/internal/ebpf/generictracer/generictracer_notlinux.go
+++ b/pkg/internal/ebpf/generictracer/generictracer_notlinux.go
@@ -39,6 +39,7 @@ func (p *Tracer) SocketFilters() []*ebpf.Program                                
 func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg                                 { return nil }
 func (p *Tracer) SockOps() []ebpfcommon.SockOps                                  { return nil }
 func (p *Tracer) Iters() []*ebpfcommon.Iter                                      { return nil }
+func (p *Tracer) Tracing() []*ebpfcommon.Tracing                                 { return nil }
 func (p *Tracer) RecordInstrumentedLib(_ uint64, _ []io.Closer)                  {}
 func (p *Tracer) AddInstrumentedLibRef(_ uint64)                                 {}
 func (p *Tracer) UnlinkInstrumentedLib(_ uint64)                                 {}

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -647,6 +647,8 @@ func (p *Tracer) SockOps() []ebpfcommon.SockOps { return nil }
 
 func (p *Tracer) Iters() []*ebpfcommon.Iter { return nil }
 
+func (p *Tracer) Tracing() []*ebpfcommon.Tracing { return nil }
+
 func (p *Tracer) RecordInstrumentedLib(_ uint64, _ []io.Closer) {}
 
 func (p *Tracer) AddInstrumentedLibRef(_ uint64) {}

--- a/pkg/internal/ebpf/gpuevent/gpuevent.go
+++ b/pkg/internal/ebpf/gpuevent/gpuevent.go
@@ -161,6 +161,8 @@ func (p *Tracer) SockOps() []ebpfcommon.SockOps { return nil }
 
 func (p *Tracer) Iters() []*ebpfcommon.Iter { return nil }
 
+func (p *Tracer) Tracing() []*ebpfcommon.Tracing { return nil }
+
 func (p *Tracer) RecordInstrumentedLib(id uint64, closers []io.Closer) {
 	p.libsMux.Lock()
 	defer p.libsMux.Unlock()

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -182,6 +182,8 @@ func (p *Tracer) Iters() []*ebpfcommon.Iter {
 	return nil
 }
 
+func (p *Tracer) Tracing() []*ebpfcommon.Tracing { return nil }
+
 func (p *Tracer) RecordInstrumentedLib(uint64, []io.Closer) {}
 
 func (p *Tracer) AddInstrumentedLibRef(uint64) {}

--- a/pkg/internal/ebpf/logenricher/logenricher_notlinux.go
+++ b/pkg/internal/ebpf/logenricher/logenricher_notlinux.go
@@ -36,6 +36,7 @@ func (p *Tracer) SocketFilters() []*ebpf.Program                         { retur
 func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg                         { return nil }
 func (p *Tracer) SockOps() []ebpfcommon.SockOps                          { return nil }
 func (p *Tracer) Iters() []*ebpfcommon.Iter                              { return nil }
+func (p *Tracer) Tracing() []*ebpfcommon.Tracing                         { return nil }
 func (p *Tracer) RecordInstrumentedLib(_ uint64, _ []io.Closer)          {}
 func (p *Tracer) AddInstrumentedLibRef(_ uint64)                         {}
 func (p *Tracer) UnlinkInstrumentedLib(_ uint64)                         {}

--- a/pkg/internal/ebpf/tctracer/tctracer.go
+++ b/pkg/internal/ebpf/tctracer/tctracer.go
@@ -118,6 +118,8 @@ func (p *Tracer) Iters() []*ebpfcommon.Iter {
 	return nil
 }
 
+func (p *Tracer) Tracing() []*ebpfcommon.Tracing { return nil }
+
 func (p *Tracer) RecordInstrumentedLib(uint64, []io.Closer) {}
 
 func (p *Tracer) AddInstrumentedLibRef(uint64) {}

--- a/pkg/internal/ebpf/tctracer/tctracer_notlinux.go
+++ b/pkg/internal/ebpf/tctracer/tctracer_notlinux.go
@@ -38,6 +38,7 @@ func (p *Tracer) SocketFilters() []*ebpf.Program                         { retur
 func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg                         { return nil }
 func (p *Tracer) SockOps() []ebpfcommon.SockOps                          { return nil }
 func (p *Tracer) Iters() []*ebpfcommon.Iter                              { return nil }
+func (p *Tracer) Tracing() []*ebpfcommon.Tracing                         { return nil }
 func (p *Tracer) RecordInstrumentedLib(_ uint64, _ []io.Closer)          {}
 func (p *Tracer) AddInstrumentedLibRef(_ uint64)                         {}
 func (p *Tracer) UnlinkInstrumentedLib(_ uint64)                         {}

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -134,6 +134,10 @@ func (p *Tracer) Iters() []*ebpfcommon.Iter {
 	return nil
 }
 
+func (p *Tracer) Tracing() []*ebpfcommon.Tracing {
+	return nil
+}
+
 func (p *Tracer) RecordInstrumentedLib(uint64, []io.Closer) {}
 
 func (p *Tracer) AddInstrumentedLibRef(uint64) {}

--- a/pkg/internal/ebpf/tpinjector/tpinjector_notlinux.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector_notlinux.go
@@ -38,6 +38,7 @@ func (p *Tracer) SocketFilters() []*ebpf.Program                         { retur
 func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg                         { return nil }
 func (p *Tracer) SockOps() []ebpfcommon.SockOps                          { return nil }
 func (p *Tracer) Iters() []*ebpfcommon.Iter                              { return nil }
+func (p *Tracer) Tracing() []*ebpfcommon.Tracing                         { return nil }
 func (p *Tracer) RecordInstrumentedLib(_ uint64, _ []io.Closer)          {}
 func (p *Tracer) AddInstrumentedLibRef(_ uint64)                         {}
 func (p *Tracer) UnlinkInstrumentedLib(_ uint64)                         {}


### PR DESCRIPTION
This PR just adds the scaffolding to enable OBI to load [BPF_PROG_TYPE_TRACING](https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_TRACING/).

This is required for the upcoming socket-level handling of the traceparent injection (WIP) - but I've split this into its own PR as it's an atomic change. Fentry and Fexit programs load fine.

Relates to #1099 

## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->