### PR TITLE
Update bpf debug printouts in gotracer

### DIFF
--- a/bpf/gotracer/go_common.h
+++ b/bpf/gotracer/go_common.h
@@ -169,7 +169,7 @@ static __always_inline u64 find_parent_goroutine(go_addr_key_t *current) {
                 break;
             }
         } else {
-            bpf_dbg_printk("Found parent %lx", r_addr);
+            bpf_dbg_printk("Found parent, r_addr=%lx", r_addr);
             return r_addr;
         }
 
@@ -278,7 +278,7 @@ server_trace_parent(void *goroutine_addr, tp_info_t *tp, tp_info_t *found_tp) {
 
     unsigned char tp_buf[TP_MAX_VAL_LENGTH];
     make_tp_string(tp_buf, tp);
-    bpf_dbg_printk("tp: %s", tp_buf);
+    bpf_dbg_printk("tp_buf=[%s]", tp_buf);
 }
 
 static __always_inline tp_info_t *tp_info_from_parent_go(go_addr_key_t *g_key, u64 *parent_found) {
@@ -293,7 +293,7 @@ static __always_inline tp_info_t *tp_info_from_parent_go(go_addr_key_t *g_key, u
     }
 
     if (tp) {
-        bpf_dbg_printk("Found parent request trace_parent %llx", tp);
+        bpf_dbg_printk("Found parent request, tp=%llx", tp);
         if (parent_found) {
             *parent_found = parent_id;
         }
@@ -379,8 +379,8 @@ static __always_inline u8 get_conn_info_from_fd(void *fd_ptr, connection_info_t 
             sizeof(raddr_ptr),
             (void *)(fd_ptr + go_offset_of(ot, (go_offset){.v = _fd_raddr_pos}) + 8)); // find raddr
 
-        bpf_dbg_printk("laddr_ptr %llx, laddr %llx, raddr %llx",
-                       fd_ptr + fd_laddr_pos + 8,
+        bpf_dbg_printk("laddr_field_ptr=%llx, laddr_ptr=%llx, raddr_ptr=%llx",
+                       fd_ptr + fd_laddr_pos + 8, //laddr_field_ptr
                        laddr_ptr,
                        raddr_ptr);
         if (laddr_ptr && raddr_ptr) {
@@ -416,7 +416,7 @@ static __always_inline u8 get_conn_info(void *conn_ptr, connection_info_t *info)
             sizeof(fd_ptr),
             (void *)(conn_ptr + go_offset_of(ot, (go_offset){.v = _conn_fd_pos}))); // find fd
 
-        bpf_dbg_printk("Found fd ptr %llx", fd_ptr);
+        bpf_dbg_printk("Found fd, fd_ptr=%llx", fd_ptr);
 
         return get_conn_info_from_fd(fd_ptr, info);
     }
@@ -429,7 +429,7 @@ static __always_inline void *unwrap_tls_conn_info(void *conn_ptr, void *tls_stat
         void *c_ptr = 0;
         bpf_probe_read(&c_ptr, sizeof(c_ptr), conn_ptr); // unwrap conn
 
-        bpf_dbg_printk("unwrapped conn ptr %llx", c_ptr);
+        bpf_dbg_printk("unwrapped conn, c_ptr=%llx", c_ptr);
 
         if (c_ptr) {
             return c_ptr + 8;
@@ -451,18 +451,18 @@ static __always_inline void process_meta_frame_headers(void *frame, tp_info_t *t
     bpf_probe_read(&fields, sizeof(fields), (void *)(frame + fields_off));
     u64 fields_len = 0;
     bpf_probe_read(&fields_len, sizeof(fields_len), (void *)(frame + fields_off + 8));
-    bpf_dbg_printk("fields ptr %llx, len %d", fields, fields_len);
+    bpf_dbg_printk("fields=%llx, fields_len=%d", fields, fields_len);
     if (fields && fields_len > 0) {
         for (u8 i = 0; i < 16; i++) {
             if (i >= fields_len) {
                 break;
             }
             void *field_ptr = fields + (i * sizeof(grpc_header_field_t));
-            //bpf_dbg_printk("field_ptr %llx", field_ptr);
+            //bpf_dbg_printk("field_ptr=%llx", field_ptr);
             grpc_header_field_t field = {};
             bpf_probe_read(&field, sizeof(grpc_header_field_t), field_ptr);
-            //bpf_dbg_printk("grpc header %s:%s", field.key_ptr, field.val_ptr);
-            //bpf_dbg_printk("grpc sizes %d:%d", field.key_len, field.val_len);
+            //bpf_dbg_printk("grpc header=%s:%s", field.key_ptr, field.val_ptr);
+            //bpf_dbg_printk("grpc sizes=%d:%d", field.key_len, field.val_len);
             if (field.key_len == W3C_KEY_LENGTH && field.val_len == W3C_VAL_LENGTH) {
                 unsigned char temp[W3C_VAL_LENGTH];
 
@@ -487,7 +487,7 @@ static __always_inline u64 golang_stream_id(struct pt_regs *ctx, off_table_t *ot
 
     const void *sp = (const void *)PT_REGS_SP(ctx);
 
-    bpf_dbg_printk("golang_stream_id: sp = %llx", sp);
+    bpf_dbg_printk("sp=%llx", sp);
 
     u64 stream_id = 0;
 

--- a/bpf/gotracer/go_mongo.c
+++ b/bpf/gotracer/go_mongo.c
@@ -41,9 +41,8 @@ MONGO_OP_DEF(distinct, "distinct")
 
 static __always_inline int
 obi_uprobe_mongo_coll_op(struct pt_regs *ctx, const char *op, const u32 op_len) {
-    bpf_dbg_printk("=== uprobe/mongo op_execute === ");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
-    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+    bpf_dbg_printk("goroutine_addr=%lx", goroutine_addr);
 
     void *coll_ptr = (void *)GO_PARAM1(ctx);
     off_table_t *ot = get_offsets_table();
@@ -68,7 +67,7 @@ obi_uprobe_mongo_coll_op(struct pt_regs *ctx, const char *op, const u32 op_len) 
 
     client_trace_parent(goroutine_addr, &req.tp);
 
-    bpf_d_printk("op %s", req.op);
+    bpf_d_printk("op=%s, [%s]", req.op, __FUNCTION__);
 
     bpf_map_update_elem(&ongoing_mongo_requests, &g_key, &req, BPF_ANY);
 
@@ -129,9 +128,9 @@ int obi_uprobe_mongo_op_distinct(struct pt_regs *ctx) {
 // func (op Operation) Execute(ctx context.Context) error
 SEC("uprobe/op_execute")
 int obi_uprobe_mongo_op_execute(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/mongo op_execute === ");
+    bpf_dbg_printk("=== uprobe/op_execute ===");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
-    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+    bpf_dbg_printk("goroutine_addr=%lx", goroutine_addr);
 
     void *op_ptr = (void *)PT_REGS_SP(ctx) + 8;
     off_table_t *ot = get_offsets_table();
@@ -154,7 +153,7 @@ int obi_uprobe_mongo_op_execute(struct pt_regs *ctx) {
         return 0;
     }
 
-    bpf_dbg_printk("op_ptr %llx", op_ptr);
+    bpf_dbg_printk("op_ptr=%llx", op_ptr);
 
     u64 new_mongo_version = go_offset_of(ot, (go_offset){.v = _mongo_op_name_new});
 
@@ -186,9 +185,9 @@ int obi_uprobe_mongo_op_execute(struct pt_regs *ctx) {
 
 SEC("uprobe/op_execute")
 int obi_uprobe_mongo_op_execute_ret(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/mongo op_execute return === ");
+    bpf_dbg_printk("=== uprobe/op_execute ===");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
-    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+    bpf_dbg_printk("goroutine_addr=%lx", goroutine_addr);
 
     void *err_ptr = (void *)GO_PARAM1(ctx);
 

--- a/bpf/gotracer/go_runtime.c
+++ b/bpf/gotracer/go_runtime.c
@@ -34,13 +34,13 @@ struct {
 
 SEC("uprobe/runtime_newproc1")
 int obi_uprobe_proc_newproc1(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/proc newproc1 === ");
-    void *creator_goroutine = GOROUTINE_PTR(ctx);
-    bpf_dbg_printk("creator_goroutine_addr %lx", creator_goroutine);
+    bpf_dbg_printk("=== uprobe/runtime_newproc1 ===");
+    void *creator_goroutine_addr = GOROUTINE_PTR(ctx);
+    bpf_dbg_printk("creator_goroutine_addr=%lx", creator_goroutine_addr);
 
     new_func_invocation_t invocation = {.parent = (u64)GO_PARAM2(ctx)};
     go_addr_key_t g_key = {};
-    go_addr_key_from_id(&g_key, creator_goroutine);
+    go_addr_key_from_id(&g_key, creator_goroutine_addr);
 
     // Save the registers on invocation to be able to fetch the arguments at return of newproc1
     if (bpf_map_update_elem(&newproc1, &g_key, &invocation, BPF_ANY)) {
@@ -52,13 +52,13 @@ int obi_uprobe_proc_newproc1(struct pt_regs *ctx) {
 
 SEC("uprobe/runtime_newproc1_return")
 int obi_uprobe_proc_newproc1_ret(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/proc newproc1 returns === ");
-    void *creator_goroutine = GOROUTINE_PTR(ctx);
+    bpf_dbg_printk("=== uprobe/runtime_newproc1_return ===");
+    void *creator_goroutine_addr = GOROUTINE_PTR(ctx);
     u64 pid_tid = bpf_get_current_pid_tgid();
     u32 pid = pid_from_pid_tgid(pid_tid);
-    go_addr_key_t c_key = {.addr = (u64)creator_goroutine, .pid = pid};
+    go_addr_key_t c_key = {.addr = (u64)creator_goroutine_addr, .pid = pid};
 
-    bpf_dbg_printk("creator_goroutine_addr %lx", creator_goroutine);
+    bpf_dbg_printk("creator_goroutine_addr=%lx", creator_goroutine_addr);
 
     // Lookup the newproc1 invocation metadata
     new_func_invocation_t *invocation = bpf_map_lookup_elem(&newproc1, &c_key);
@@ -69,11 +69,11 @@ int obi_uprobe_proc_newproc1_ret(struct pt_regs *ctx) {
 
     // The parent goroutine is the second argument of newproc1
     void *parent_goroutine = (void *)invocation->parent;
-    bpf_dbg_printk("parent goroutine_addr %lx", parent_goroutine);
+    bpf_dbg_printk("parent_goroutine=%lx", parent_goroutine);
 
     // The result of newproc1 is the new goroutine
     void *goroutine_addr = (void *)GO_PARAM1(ctx);
-    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+    bpf_dbg_printk("goroutine_addr=%lx", goroutine_addr);
 
     go_addr_key_t g_key = {.addr = (u64)goroutine_addr, .pid = pid};
     go_addr_key_t p_key = {.addr = (u64)parent_goroutine, .pid = pid};

--- a/bpf/gotracer/go_sql.c
+++ b/bpf/gotracer/go_sql.c
@@ -85,7 +85,7 @@ static __always_inline void *get_mysql_conn_ptr(u64 driver_conn_ptr) {
             return NULL;
         }
 
-        bpf_dbg_printk("unwrap: inner type %llx", inner_type_ptr);
+        bpf_dbg_printk("unwrap: inner_type_ptr=%llx", inner_type_ptr);
         if ((u64)inner_type_ptr != mysql_type_addr) {
             bpf_dbg_printk("inner type still doesn't match mysql.mysqlConn");
             return NULL;
@@ -271,7 +271,7 @@ static __always_inline int process_sql_return(void *goroutine_addr, void *err_pt
             trace->sql[query_len] = '\0';
         }
 
-        bpf_dbg_printk("Found sql statement %s", trace->sql);
+        bpf_dbg_printk("Found sql statement: %s", trace->sql);
 
         __builtin_memcpy(&trace->conn, &invocation->conn, sizeof(connection_info_t));
 
@@ -287,9 +287,9 @@ static __always_inline int process_sql_return(void *goroutine_addr, void *err_pt
 
 SEC("uprobe/queryDC")
 int obi_uprobe_queryDC(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/queryDC === ");
+    bpf_dbg_printk("=== uprobe/queryDC ===");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
-    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+    bpf_dbg_printk("goroutine_addr=%lx", goroutine_addr);
 
     void *driver_conn = GO_PARAM6(ctx);
     void *sql_param = GO_PARAM8(ctx);
@@ -301,9 +301,9 @@ int obi_uprobe_queryDC(struct pt_regs *ctx) {
 
 SEC("uprobe/pgx_Query")
 int obi_uprobe_pgx_Query(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/pgx_Query === ");
+    bpf_dbg_printk("=== uprobe/pgx_Query ===");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
-    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+    bpf_dbg_printk("goroutine_add=%lx", goroutine_addr);
 
     void *pgx_conn = GO_PARAM1(ctx);
     void *sql_param = GO_PARAM4(ctx);
@@ -315,9 +315,9 @@ int obi_uprobe_pgx_Query(struct pt_regs *ctx) {
 
 SEC("uprobe/pgx_Exec")
 int obi_uprobe_pgx_Exec(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/pgx_Exec === ");
+    bpf_dbg_printk("=== uprobe/pgx_Exec ===");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
-    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+    bpf_dbg_printk("goroutine_addr=%lx", goroutine_addr);
 
     void *pgx_conn = GO_PARAM1(ctx);
     void *sql_param = GO_PARAM4(ctx);
@@ -329,9 +329,9 @@ int obi_uprobe_pgx_Exec(struct pt_regs *ctx) {
 
 SEC("uprobe/execDC")
 int obi_uprobe_execDC(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/execDC === ");
+    bpf_dbg_printk("=== uprobe/execDC ===");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
-    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+    bpf_dbg_printk("goroutine_addr=%lx", goroutine_addr);
 
     void *driver_conn = GO_PARAM4(ctx);
     void *sql_param = GO_PARAM6(ctx);
@@ -343,9 +343,9 @@ int obi_uprobe_execDC(struct pt_regs *ctx) {
 
 SEC("uprobe/queryDC")
 int obi_uprobe_queryReturn(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/query return === ");
+    bpf_dbg_printk("=== uprobe/queryDC ===");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
-    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+    bpf_dbg_printk("goroutine_addr=%lx", goroutine_addr);
 
     // queryDC returns (*Rows, error)
     void *err_ptr = GO_PARAM2(ctx);
@@ -354,9 +354,9 @@ int obi_uprobe_queryReturn(struct pt_regs *ctx) {
 
 SEC("uprobe/pgx_Query_return")
 int obi_uprobe_pgx_Query_return(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/pgx_Query_return === ");
+    bpf_dbg_printk("=== uprobe/pgx_Query_return ===");
     void *goroutine_addr = GOROUTINE_PTR(ctx);
-    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+    bpf_dbg_printk("goroutine_addr=%lx", goroutine_addr);
 
     // pgx.Conn.Query returns (Rows, error)
     void *err_ptr = GO_PARAM3(ctx);
@@ -365,7 +365,7 @@ int obi_uprobe_pgx_Query_return(struct pt_regs *ctx) {
 
 SEC("uprobe/pq_network_return")
 int obi_uprobe_pq_network_return(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/pq.network return ===");
+    bpf_dbg_printk("=== uprobe/pq_network_return ===");
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     go_addr_key_t g_key = {};
@@ -375,11 +375,11 @@ int obi_uprobe_pq_network_return(struct pt_regs *ctx) {
     void *address_ptr = (void *)GO_PARAM3(ctx);
     u64 address_len = (u64)GO_PARAM4(ctx);
 
-    bpf_dbg_printk("address_ptr=%llx address_len=%d", address_ptr, address_len);
+    bpf_dbg_printk("address_ptr=%llx, address_len=%d", address_ptr, address_len);
 
     char address[SQL_HOSTNAME_MAX_LEN] = {0};
     if (read_go_str_n("pq address", address_ptr, address_len, address, sizeof(address))) {
-        bpf_dbg_printk("pq.network address: %s", address);
+        bpf_dbg_printk("address=%s", address);
         bpf_map_update_elem(&pq_hostnames, &g_key, address, BPF_ANY);
     }
 

--- a/bpf/gotracer/types/otel_types.h
+++ b/bpf/gotracer/types/otel_types.h
@@ -39,7 +39,7 @@ static __always_inline bool set_attr_value(otel_attribute_t *attr,
     // String values
     if (vtype == attr_type_string) {
         if (go_attr_value->string.len >= OTEL_ATTRIBUTE_VALUE_MAX_LEN) {
-            bpf_dbg_printk("Aattribute string value is too long");
+            bpf_dbg_printk("Attribute string value is too long");
             return false;
         }
         long res =


### PR DESCRIPTION
This PR finalizes the work started in previous PRs to standardize ebpf debug prints.

Reference doc [BPF print format](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/bpf-print-format.md)