### PR TITLE
Add db error to span status for sql++ spans

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -593,6 +593,10 @@ func SpanStatusMessage(span *Span) string {
 		}
 	case EventTypeManualSpan:
 		return span.Path
+	case EventTypeHTTPClient:
+		if span.SubType == HTTPSubtypeSQLPP && span.Status != 0 && span.DBError.Description != "" {
+			return span.DBError.Description
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
In addition add some tests for tracegen of sqlpp spans

## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->