### PR TITLE
feat: add podname to env for filtering when running OBI as a sidecar

### DIFF
--- a/pkg/appolly/discover/matcher.go
+++ b/pkg/appolly/discover/matcher.go
@@ -359,13 +359,14 @@ func FindingCriteria(cfg *obi.Config) []services.Selector {
 
 	if len(cfg.Discovery.Instrument) > 0 {
 		finderCriteria := cfg.Discovery.Instrument
-		if cfg.AutoTargetExe.IsSet() || cfg.Port.Len() > 0 {
+		if cfg.AutoTargetExe.IsSet() || cfg.Port.Len() > 0 || cfg.PodName.IsSet() {
 			finderCriteria = slices.Clone(cfg.Discovery.Instrument)
 			finderCriteria = append(finderCriteria, services.GlobAttributes{
 				Name:      cfg.ServiceName,
 				Namespace: cfg.ServiceNamespace,
 				Path:      cfg.AutoTargetExe,
 				OpenPorts: cfg.Port,
+				Metadata:  map[string]*services.GlobAttr{services.AttrPodName: &cfg.PodName},
 			})
 		}
 		return NormalizeGlobCriteria(finderCriteria)
@@ -381,8 +382,24 @@ func FindingCriteria(cfg *obi.Config) []services.Selector {
 				Namespace: cfg.ServiceNamespace,
 				Path:      cfg.AutoTargetExe,
 				OpenPorts: cfg.Port,
+				Metadata:  map[string]*services.GlobAttr{services.AttrPodName: &cfg.PodName},
 			},
 		}
+	}
+
+	// edge case: when neither discovery > services nor discovery > instrument sections are set,
+	// and the user is not using the new OTEL_EBPF_AUTO_TARGET_EXE/OTEL_GO_AUTO_TARGET_EXE property
+	// but is using the OTEL_EBPF_K8S_POD_NAME property, we will prioritize it and match any executable in the matched pod, to avoid missing instrumentation opportunities
+	if cfg.PodName.IsSet() {
+		criteria := services.GlobDefinitionCriteria{
+			{
+				Name:      cfg.ServiceName,
+				Namespace: cfg.ServiceNamespace,
+				OpenPorts: cfg.Port,
+				Metadata:  map[string]*services.GlobAttr{services.AttrPodName: &cfg.PodName},
+			},
+		}
+		return NormalizeGlobCriteria(criteria)
 	}
 
 	return []services.Selector{

--- a/pkg/appolly/discover/matcher_test.go
+++ b/pkg/appolly/discover/matcher_test.go
@@ -590,3 +590,99 @@ func TestCriteriaMatcher_Granular(t *testing.T) {
 	assert.True(t, asteroidAttrs.ExportModes.CanExportMetrics())
 	require.Nil(t, asteroidAttrs.Sampler)
 }
+
+func TestFindingCriteria_PodName(t *testing.T) {
+	testCases := []struct {
+		name               string
+		cfg                *obi.Config
+		expectedPodName    string
+		expectedSelCount   int
+		checkSelectorIdx   int
+		shouldMatchAnyPath bool
+	}{
+		{
+			name: "with AutoTargetExe",
+			cfg: &obi.Config{
+				PodName:       services.NewGlob("test-pod"),
+				AutoTargetExe: services.NewGlob("/bin/myapp"),
+				TracePrinter:  "text",
+			},
+			expectedPodName:    "test-pod",
+			expectedSelCount:   1,
+			checkSelectorIdx:   0,
+			shouldMatchAnyPath: false,
+		},
+		{
+			name: "with discovery.instrument section",
+			cfg: &obi.Config{
+				PodName:      services.NewGlob("test-pod"),
+				TracePrinter: "text",
+				Discovery: services.DiscoveryConfig{
+					Instrument: services.GlobDefinitionCriteria{
+						{
+							Path:      services.NewGlob("/bin/myapp"),
+							OpenPorts: services.PortEnum{Ranges: []services.PortRange{{Start: 8080}}},
+						},
+					},
+				},
+			},
+			expectedPodName:    "test-pod",
+			expectedSelCount:   2, // Discovery instrument + appended pod-name criteria
+			checkSelectorIdx:   1, // checking the appended pod-name criteria
+			shouldMatchAnyPath: true,
+		},
+		{
+			name: "with discovery.instrument section and AutoTargetExe",
+			cfg: &obi.Config{
+				PodName:       services.NewGlob("test-pod"),
+				AutoTargetExe: services.NewGlob("/bin/newapp"),
+				TracePrinter:  "text",
+				Discovery: services.DiscoveryConfig{
+					Instrument: services.GlobDefinitionCriteria{
+						{
+							Path:      services.NewGlob("/bin/myapp"),
+							OpenPorts: services.PortEnum{Ranges: []services.PortRange{{Start: 8080}}},
+						},
+					},
+				},
+			},
+			expectedPodName:    "test-pod",
+			expectedSelCount:   2,     // Discovery instrument + appended pod-name criteria
+			checkSelectorIdx:   1,     // checking the appended pod-name criteria
+			shouldMatchAnyPath: false, // AutoTargetExe should take precedence and set the path to /bin/newapp, not match any path
+		},
+		{
+			name: "only PodName set",
+			cfg: &obi.Config{
+				PodName:      services.NewGlob("test-pod"),
+				TracePrinter: "text",
+			},
+			expectedPodName:    "test-pod",
+			expectedSelCount:   1,
+			checkSelectorIdx:   0,
+			shouldMatchAnyPath: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			selectors := FindingCriteria(tc.cfg)
+			require.NotEmpty(t, selectors)
+			require.Len(t, selectors, tc.expectedSelCount)
+
+			targetSelector := selectors[tc.checkSelectorIdx]
+			metadata := make(map[string]services.StringMatcher)
+			for key, value := range targetSelector.RangeMetadata() {
+				metadata[key] = value
+			}
+			require.Contains(t, metadata, services.AttrPodName)
+			assert.True(t, metadata[services.AttrPodName].MatchString(tc.expectedPodName))
+			assert.False(t, metadata[services.AttrPodName].MatchString("other-pod"))
+
+			if tc.shouldMatchAnyPath {
+				assert.True(t, targetSelector.GetPath().IsSet(), "path should be set to match any executable")
+				assert.True(t, targetSelector.GetPath().MatchString("/any/path"), "should match any path when set")
+			}
+		})
+	}
+}

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -270,6 +270,10 @@ type Config struct {
 	// It also accepts OTEL_GO_AUTO_TARGET_EXE for compatibility with opentelemetry-go-instrumentation
 	AutoTargetExe services.GlobAttr `env:"OTEL_EBPF_AUTO_TARGET_EXE,expand" envDefault:"${OTEL_GO_AUTO_TARGET_EXE}"`
 
+	// PodName allows selecting the instrumented executable by the Kubernetes pod name.
+	// Can be set via OTEL_EBPF_K8S_POD_NAME to simplify sidecar deployments.
+	PodName services.GlobAttr `env:"OTEL_EBPF_K8S_POD_NAME,expand"`
+
 	// Port allows selecting the instrumented executable that owns the Port value. If this value is set (and
 	// different to zero), the value of the Exec property won't take effect.
 	// It's important to emphasize that if your process opens multiple HTTP/GRPC ports, the auto-instrumenter

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -761,3 +761,11 @@ func TestNormalizeConfig_Network(t *testing.T) {
 	assert.Equal(t, export.FeatureApplicationRED|export.FeatureNetwork,
 		obi.Metrics.Features)
 }
+
+func TestConfig_PodName(t *testing.T) {
+	t.Setenv("OTEL_EBPF_K8S_POD_NAME", "test-pod")
+	t.Setenv("OTEL_EBPF_TRACE_PRINTER", "text")
+	cfg, err := LoadConfig(bytes.NewReader(nil))
+	require.NoError(t, err)
+	assert.True(t, cfg.PodName.MatchString("test-pod"))
+}


### PR DESCRIPTION
## Checklist
fixes #1240

<!-- markdownlint-disable-file MD041 -->