### PR TITLE
Ignore `dist`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ internal/test/cmd/grpc/client/client
 
 .tools/
 bin/
+dist/
 internal/test/integration/components/server
 internal/test/integration/components/testserver/testserver
 


### PR DESCRIPTION
The `make release` target outputs all release artifacts and checks in the `dist` directory. Ignore this directory in git.