### PR TITLE
Update jump_table map to modern BTF style map

### DIFF
--- a/bpf/generictracer/k_tracer_tailcall.h
+++ b/bpf/generictracer/k_tracer_tailcall.h
@@ -6,12 +6,12 @@
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_helpers.h>
 
-struct bpf_map_def SEC("maps") jump_table = {
-    .type = BPF_MAP_TYPE_PROG_ARRAY,
-    .key_size = sizeof(__u32),
-    .value_size = sizeof(__u32),
-    .max_entries = 16,
-};
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __type(key, u32);
+    __type(value, u32);
+    __uint(max_entries, 16);
+} jump_table SEC(".maps");
 
 enum {
     k_tail_protocol_http = 0,


### PR DESCRIPTION
This PR just updates the `jump_table` map by moving from the legacy `struct bpf_map_def` to the BTF style one. 