### PR TITLE
ci: fix ParseAddr("localhost"): unable to parse IP

### DIFF
--- a/internal/test/integration/dockerutil_test.go
+++ b/internal/test/integration/dockerutil_test.go
@@ -1,6 +1,5 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
-// TODO: trigger ci
 
 package integration
 
@@ -50,7 +49,7 @@ func setupContainerPrometheus(t *testing.T, network *dockertest.Network, configF
 		},
 		ExposedPorts: []string{"9090/tcp"},
 		PortBindings: map[docker.Port][]docker.PortBinding{
-			"9090/tcp": {{HostIP: "localhost", HostPort: "9090"}},
+			"9090/tcp": {{HostIP: "127.0.0.1", HostPort: "9090"}},
 		},
 	})
 	require.NoError(t, err, "could not start Prometheus container")
@@ -75,7 +74,7 @@ func setupContainerJaeger(t *testing.T, network *dockertest.Network) {
 		},
 		ExposedPorts: []string{"16686/tcp", "4317/tcp", "4318/tcp"},
 		PortBindings: map[docker.Port][]docker.PortBinding{
-			"16686/tcp": {{HostIP: "localhost", HostPort: "16686"}},
+			"16686/tcp": {{HostIP: "127.0.0.1", HostPort: "16686"}},
 		},
 	})
 	require.NoError(t, err, "could not start Jaeger container")
@@ -185,7 +184,7 @@ func (o obi) instrument(t *testing.T, network *dockertest.Network, resource *doc
 		Privileged:   true,
 		ExposedPorts: []string{"8999/tcp"},
 		PortBindings: map[docker.Port][]docker.PortBinding{
-			"8999/tcp": {{HostIP: "localhost", HostPort: "8999"}},
+			"8999/tcp": {{HostIP: "127.0.0.1", HostPort: "8999"}},
 		},
 	}, func(hc *docker.HostConfig) {
 		hc.PidMode = "container:" + resource.Container.ID

--- a/internal/test/integration/http_go_otel_test.go
+++ b/internal/test/integration/http_go_otel_test.go
@@ -55,7 +55,7 @@ func setupGoOTelTestServer(t *testing.T, network *dockertest.Network, env []stri
 		Env:          env,
 		ExposedPorts: []string{"8080/tcp"},
 		PortBindings: map[docker.Port][]docker.PortBinding{
-			"8080/tcp": {{HostIP: "localhost", HostPort: "8080"}},
+			"8080/tcp": {{HostIP: "127.0.0.1", HostPort: "8080"}},
 		},
 	})
 	require.NoError(t, err, "could not start test server container")


### PR DESCRIPTION
Trying to reproduce a test failure with the following error:

```
API error (400): invalid JSON: ParseAddr("localhost"): unable to parse IP
```

Reproduced in b1cea4d, root cause:

- https://github.com/actions/runner-images/issues/13474

Fixed by using the IP address `127.0.0.1` instead of the hostname `localhost` in order to pass stricter verification which now requires an IP address.