### PR TITLE
Use `const 64` for `bpf_ringbuf_query` result

### DIFF
--- a/bpf/common/ringbuf.h
+++ b/bpf/common/ringbuf.h
@@ -47,12 +47,11 @@ volatile const u32 wakeup_data_bytes;
 // If wakeup_data_bytes > 0, it will wait until wakeup_data_bytes are accumulated
 // into the buffer before waking the userspace.
 static __always_inline long get_flags() {
-    long sz;
 
     if (!wakeup_data_bytes) {
         return 0;
     }
 
-    sz = bpf_ringbuf_query(&events, BPF_RB_AVAIL_DATA);
+    const u64 sz = bpf_ringbuf_query(&events, BPF_RB_AVAIL_DATA);
     return sz >= wakeup_data_bytes ? BPF_RB_FORCE_WAKEUP : BPF_RB_NO_WAKEUP;
 }

--- a/bpf/logenricher/maps/log_events.h
+++ b/bpf/logenricher/maps/log_events.h
@@ -15,6 +15,6 @@ struct {
 } log_events SEC(".maps");
 
 static __always_inline long log_events_flags() {
-    long sz = bpf_ringbuf_query(&log_events, BPF_RB_AVAIL_DATA);
+    const u64 sz = bpf_ringbuf_query(&log_events, BPF_RB_AVAIL_DATA);
     return sz >= 4096 ? BPF_RB_FORCE_WAKEUP : BPF_RB_NO_WAKEUP;
 }


### PR DESCRIPTION
As @rafaelroquetto pointed out during a review, we should use `const u64` as the type for the result given by `bpf_ringbuf_query` instead of `long` because `long` is a signed integer type and is not guaranteed to be 64 bits.