### PR TITLE
Omit -u option when building on podman.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,7 +251,7 @@ generate/all: $(BPF2GO)
 docker-generate:
 	@echo "### Generating files in Docker..."
 	@$(OCI_BIN) run --rm \
-		-u $(DOCKER_USER) \
+		$(if $(findstring podman,$(OCI_BIN)),  ,-u "$(DOCKER_USER)") \
 		-v "$(CURDIR):/src:z" \
 		-w /src \
 		$(GEN_IMG) \


### PR DESCRIPTION
Passing the -u option to podman makes `make docker-generate` fail if `OCI_BIN` is set to `podman`.
Thanks for @mmat11 providing me a link to the Cilium build script
Closes: #1311
