### PR TITLE
build: obi-generator needs git package

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -10,7 +10,7 @@ ENV PROTOC_AARCH_64_SHA256="56af3fc2e43a0230802e6fadb621d890ba506c5c17a1ae1070f6
 
 ARG TARGETARCH
 
-RUN apk add clang llvm20 wget unzip curl make bash
+RUN apk add clang llvm20 wget unzip curl make bash git
 RUN apk cache purge
 
 # Install protoc


### PR DESCRIPTION
obi-generator image is [failing to execute](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/22095423265/job/63851122128?pr=1315) with the error:

```
Status: Downloaded newer image for ghcr.io/open-telemetry/obi-generator:0.2.7
/bin/sh: git: not found
make: git: No such file or directory
make: *** No rule to make target 'bpf2go', needed by 'generate'.  Stop.
make: *** [Makefile:253: docker-generate] Error 2
Error: Process completed with exit code 2.
```

This PR adds the missing `git` package.