### PR TITLE
build: obi-generator needs git package and bpf2go path

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -38,7 +38,7 @@ RUN --mount=type=cache,target=/go/pkg \
 RUN cat <<EOF > /generate.sh
 #!/bin/sh
 export PATH="/usr/lib/llvm20/bin:\$PATH"
-export BPF2GO=bpf2go
+export BPF2GO=/go/bin/bpf2go
 export BPF_CLANG=clang
 export BPF_CFLAGS="-O2 -g -Wall -Werror"
 export GOCACHE=/tmp/go-build


### PR DESCRIPTION
Supersedes #1316, had to raise a new PR as I don't have access to push new commits to source branches. Required by #1315.

Fixes these errors with obi-generator:

```
Status: Downloaded newer image for ghcr.io/open-telemetry/obi-generator:0.2.7
/bin/sh: git: not found
make: git: No such file or directory
make: *** No rule to make target 'bpf2go', needed by 'generate'.  Stop.
make: *** [Makefile:253: docker-generate] Error 2
Error: Process completed with exit code 2.
```

and

```
Status: Downloaded newer image for ghcr.io/open-telemetry/obi-generator:0.2.8
fatal: No names found, cannot describe anything.
make: *** No rule to make target 'bpf2go', needed by 'generate'.  Stop.
make: *** [Makefile:253: docker-generate] Error 2
Error: Process completed with exit code 2.
```

Relates to #1290.