### PR TITLE
feat: Allow selecting instrumentation by PIDs

### DIFF
--- a/examples/vendoring/vendoring.go
+++ b/examples/vendoring/vendoring.go
@@ -32,7 +32,7 @@ func main() {
 	// for example, we override the instrumentation ports from the PORT env, otherwise we provide some defaults
 	if err := config.Port.UnmarshalText([]byte(os.Getenv("PORT"))); err != nil {
 		log.Println("Error parsing PORT environment variable. Defaulting to 80,8080,443,8443: " + err.Error())
-		config.Port.Ranges = []services.PortRange{{Start: 80}, {Start: 8080}, {Start: 443}, {Start: 8443}}
+		config.Port.Ranges = []services.IntRange{{Start: 80}, {Start: 8080}, {Start: 443}, {Start: 8443}}
 	}
 
 	// the instrumenter creates internally some communication Queues, but we can override some of them

--- a/pkg/appolly/discover/matcher.go
+++ b/pkg/appolly/discover/matcher.go
@@ -212,13 +212,7 @@ func (m *Matcher) isExcluded(obj *ProcessAttrs, proc *services.ProcessInfo) bool
 func (m *Matcher) matchProcess(obj *ProcessAttrs, p *services.ProcessInfo, a services.Selector) bool {
 	log := m.Log.With("pid", p.Pid, "exe", p.ExePath)
 	if pids, ok := a.GetPIDs(); ok && len(pids) > 0 {
-		if !pidInList(p.Pid, pids) {
-			return false
-		}
-		// PID matches; if this is PID-only criteria, skip path/port checks
-		if !a.GetPath().IsSet() && !a.GetPathRegexp().IsSet() && a.GetOpenPorts().Len() == 0 {
-			return m.matchByAttributes(obj, a)
-		}
+		return pidInList(p.Pid, pids)
 	}
 	if !a.GetPath().IsSet() && !a.GetLanguages().IsSet() && a.GetOpenPorts().Len() == 0 && len(obj.metadata) == 0 {
 		pids, hasPIDs := a.GetPIDs()
@@ -370,9 +364,10 @@ func FindingCriteria(cfg *obi.Config) []services.Selector {
 	logDeprecationAndConflicts(cfg)
 
 	if cfg.TargetPIDs.Len() > 0 {
-		pids := make([]uint32, 0, cfg.TargetPIDs.Len())
-		for _, pid := range cfg.TargetPIDs {
-			pids = append(pids, pid)
+		vals := cfg.TargetPIDs.AllValues()
+		pids := make([]uint32, 0, len(vals))
+		for _, v := range vals {
+			pids = append(pids, uint32(v))
 		}
 		return []services.Selector{
 			&services.GlobAttributes{

--- a/pkg/appolly/discover/matcher_test.go
+++ b/pkg/appolly/discover/matcher_test.go
@@ -382,8 +382,8 @@ func TestInstrumentation_CoexistingWithDeprecatedServices(t *testing.T) {
 	neitherPass := services.NewGlob("*/neither-pass")
 	bothPass := services.NewGlob("*/{must,also}-pass")
 
-	passPort := services.PortEnum{Ranges: []services.PortRange{{Start: 80}}}
-	allPorts := services.PortEnum{Ranges: []services.PortRange{{Start: 1, End: 65535}}}
+	passPort := services.IntEnum{Ranges: []services.IntRange{{Start: 80}}}
+	allPorts := services.IntEnum{Ranges: []services.IntRange{{Start: 1, End: 65535}}}
 
 	passRE := services.NewRegexp("must-pass")
 	notPassRE := services.NewRegexp("dont-pass")
@@ -511,7 +511,7 @@ func TestCriteriaMatcher_TargetPIDs(t *testing.T) {
 	t.Run("single PID", func(t *testing.T) {
 		// When TargetPIDs has one PID, only that PID is matched.
 		pipeConfig := obi.Config{
-			TargetPIDs:       obi.TargetPIDs{42},
+			TargetPIDs:       services.IntEnum{Ranges: []services.IntRange{{Start: 42}}},
 			ServiceName:      "targeted-svc",
 			ServiceNamespace: "target-ns",
 		}
@@ -542,7 +542,7 @@ func TestCriteriaMatcher_TargetPIDs(t *testing.T) {
 
 	t.Run("multiple PIDs", func(t *testing.T) {
 		pipeConfig := obi.Config{
-			TargetPIDs:       obi.TargetPIDs{10, 20, 30},
+			TargetPIDs:       services.IntEnum{Ranges: []services.IntRange{{Start: 10}, {Start: 20}, {Start: 30}}},
 			ServiceName:      "multi-svc",
 			ServiceNamespace: "ns",
 		}

--- a/pkg/appolly/discover/typer_test.go
+++ b/pkg/appolly/discover/typer_test.go
@@ -27,7 +27,7 @@ type dummyCriterion struct {
 }
 
 func (d dummyCriterion) GetName() string                                                { return d.name }
-func (d dummyCriterion) GetOpenPorts() *services.PortEnum                               { return nil }
+func (d dummyCriterion) GetOpenPorts() *services.IntEnum                                { return nil }
 func (d dummyCriterion) GetPath() services.StringMatcher                                { return nil }
 func (d dummyCriterion) GetLanguages() services.StringMatcher                           { return nil }
 func (d dummyCriterion) RangeMetadata() iter.Seq2[string, services.StringMatcher]       { return nil }

--- a/pkg/appolly/services/attr_glob.go
+++ b/pkg/appolly/services/attr_glob.go
@@ -66,7 +66,7 @@ type GlobAttributes struct {
 
 	// OpenPorts allows defining a group of ports that this service could open. It accepts a comma-separated
 	// list of port numbers (e.g. 80) and port ranges (e.g. 8080-8089)
-	OpenPorts PortEnum `yaml:"open_ports"`
+	OpenPorts IntEnum `yaml:"open_ports"`
 
 	// Language allows defining services to instrument based on the
 	// programming language they are written in. Use lowercase names, e.g. java,go
@@ -166,7 +166,7 @@ func (ga *GlobAttributes) GetNamespace() string                   { return ga.Na
 func (ga *GlobAttributes) GetPath() StringMatcher                 { return &ga.Path }
 func (ga *GlobAttributes) GetLanguages() StringMatcher            { return &ga.Languages }
 func (ga *GlobAttributes) GetPathRegexp() StringMatcher           { return nilMatcher{} }
-func (ga *GlobAttributes) GetOpenPorts() *PortEnum                { return &ga.OpenPorts }
+func (ga *GlobAttributes) GetOpenPorts() *IntEnum                 { return &ga.OpenPorts }
 func (ga *GlobAttributes) GetPIDs() ([]app.PID, bool)             { return ga.pids() }
 func (ga *GlobAttributes) IsContainersOnly() bool                 { return ga.ContainersOnly }
 func (ga *GlobAttributes) MetricsConfig() perapp.SvcMetricsConfig { return ga.Metrics }

--- a/pkg/appolly/services/attr_regex.go
+++ b/pkg/appolly/services/attr_regex.go
@@ -70,7 +70,7 @@ type RegexSelector struct {
 	Namespace string `yaml:"namespace"`
 	// OpenPorts allows defining a group of ports that this service could open. It accepts a comma-separated
 	// list of port numbers (e.g. 80) and port ranges (e.g. 8080-8089)
-	OpenPorts PortEnum `yaml:"open_ports"`
+	OpenPorts IntEnum `yaml:"open_ports"`
 	// PIDs allows selecting processes by PID. When non-empty, the process PID must be in this list (in addition to any path/port criteria).
 	PIDs []uint32 `yaml:"target_pids"`
 	// Path allows defining the regular expression matching the full executable path.
@@ -169,7 +169,7 @@ func (a *RegexSelector) GetNamespace() string                   { return a.Names
 func (a *RegexSelector) GetPath() StringMatcher                 { return &a.Path }
 func (a *RegexSelector) GetLanguages() StringMatcher            { return &a.Languages }
 func (a *RegexSelector) GetPathRegexp() StringMatcher           { return &a.PathRegexp }
-func (a *RegexSelector) GetOpenPorts() *PortEnum                { return &a.OpenPorts }
+func (a *RegexSelector) GetOpenPorts() *IntEnum                 { return &a.OpenPorts }
 func (a *RegexSelector) GetPIDs() ([]app.PID, bool)             { return a.pids() }
 func (a *RegexSelector) IsContainersOnly() bool                 { return a.ContainersOnly }
 func (a *RegexSelector) MetricsConfig() perapp.SvcMetricsConfig { return a.Metrics }

--- a/pkg/appolly/services/criteria.go
+++ b/pkg/appolly/services/criteria.go
@@ -157,7 +157,7 @@ type Selector interface {
 	GetNamespace() string
 	GetPath() StringMatcher
 	GetPathRegexp() StringMatcher
-	GetOpenPorts() *PortEnum
+	GetOpenPorts() *IntEnum
 	GetLanguages() StringMatcher
 	// GetPIDs returns the list of target PIDs and true when this selector has PID criteria (analogous to OpenPorts).
 	GetPIDs() ([]app.PID, bool)
@@ -177,39 +177,46 @@ type StringMatcher interface {
 	MatchString(input string) bool
 }
 
-// PortEnum defines an enumeration of ports. It allows defining a set of single ports as well a set of
-// port ranges. When unmarshalled from text, it accepts a comma-separated
-// list of port numbers (e.g. 80) and port ranges (e.g. 8080-8089). For example, this would be a valid
-// port range: 80,443,8000-8999
-type PortEnum struct {
-	Ranges []PortRange
+// IntEnum defines an enumeration of integers (e.g. ports or PIDs). It allows a set of single
+// values or ranges. When unmarshalled from text, it accepts a comma-separated list (e.g. 80,443,8000-8999).
+// When unmarshalled from YAML, it accepts either a scalar (same as text) or a sequence (e.g. [1234, 5678]).
+type IntEnum struct {
+	Ranges []IntRange
 }
 
-type PortRange struct {
+// IntRange represents a single value (End == 0) or an inclusive range (Start to End).
+type IntRange struct {
 	Start int
-	// if End == 0, it means this entry is not a port range but a single port
+	// if End == 0, this entry is a single value; otherwise it's an inclusive range
 	End int
 }
 
-func (p *PortEnum) Len() int {
+func (p *IntEnum) Len() int {
 	return len(p.Ranges)
 }
 
-// Valid port Enums (printer pages-like notation)
-// 8080
-// 8000-8999
-// 80,443
-// 80,443,8000-8999
-var validPortEnum = regexp.MustCompile(`^\s*\d+\s*(-\s*\d+\s*)?(,\s*\d+\s*(-\s*\d+\s*)?)*$`)
+// Valid int enum (printer pages-like notation): 8080 | 8000-8999 | 80,443 | 80,443,8000-8999
+var validIntEnum = regexp.MustCompile(`^\s*\d+\s*(-\s*\d+\s*)?(,\s*\d+\s*(-\s*\d+\s*)?)*$`)
 
-func (p *PortEnum) UnmarshalYAML(value *yaml.Node) error {
+func (p *IntEnum) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.SequenceNode {
+		p.Ranges = make([]IntRange, 0, len(value.Content))
+		for _, n := range value.Content {
+			var v int
+			if err := n.Decode(&v); err != nil {
+				return fmt.Errorf("IntEnum: invalid integer in list: %w", err)
+			}
+			p.Ranges = append(p.Ranges, IntRange{Start: v})
+		}
+		return nil
+	}
 	if value.Kind != yaml.ScalarNode {
-		return fmt.Errorf("PortEnum: unexpected YAML node kind %d", value.Kind)
+		return fmt.Errorf("IntEnum: unexpected YAML node kind %d", value.Kind)
 	}
 	return p.UnmarshalText([]byte(value.Value))
 }
 
-func (p PortEnum) MarshalYAML() (any, error) {
+func (p IntEnum) MarshalYAML() (any, error) {
 	sb := bytes.Buffer{}
 	for i, r := range p.Ranges {
 		if i > 0 {
@@ -224,30 +231,52 @@ func (p PortEnum) MarshalYAML() (any, error) {
 	return sb.String(), nil
 }
 
-func (p *PortEnum) UnmarshalText(text []byte) error {
-	val := string(text)
-	if !validPortEnum.MatchString(val) {
-		return fmt.Errorf("invalid port range %q. Must be a comma-separated list of numeric ports or port ranges (e.g. 8000-8999)", val)
+func (p *IntEnum) UnmarshalText(text []byte) error {
+	val := strings.TrimSpace(string(text))
+	if val == "" {
+		p.Ranges = nil
+		return nil
+	}
+	if !validIntEnum.MatchString(val) {
+		return fmt.Errorf("invalid int enum %q. Must be a comma-separated list of integers or ranges (e.g. 8000-8999)", val)
 	}
 	for entry := range strings.SplitSeq(val, ",") {
-		e := PortRange{}
-		ports := strings.Split(entry, "-")
-		// don't need to check integer parsing, as we already did it via regular expression
-		e.Start, _ = strconv.Atoi(strings.TrimSpace(ports[0]))
-		if len(ports) > 1 {
-			e.End, _ = strconv.Atoi(strings.TrimSpace(ports[1]))
+		e := IntRange{}
+		parts := strings.Split(entry, "-")
+		e.Start, _ = strconv.Atoi(strings.TrimSpace(parts[0]))
+		if len(parts) > 1 {
+			e.End, _ = strconv.Atoi(strings.TrimSpace(parts[1]))
 		}
 		p.Ranges = append(p.Ranges, e)
 	}
 	return nil
 }
 
-func (p *PortEnum) Matches(port int) bool {
+// Matches returns true if n is contained in any range (or equals any single value).
+func (p *IntEnum) Matches(n int) bool {
 	for _, pr := range p.Ranges {
-		if pr.End == 0 && pr.Start == port ||
-			pr.End != 0 && pr.Start <= port && port <= pr.End {
+		if pr.End == 0 && pr.Start == n ||
+			pr.End != 0 && pr.Start <= n && n <= pr.End {
 			return true
 		}
 	}
 	return false
+}
+
+// AllValues returns all integers represented by this enum (expanding ranges to discrete values).
+func (p *IntEnum) AllValues() []int {
+	if len(p.Ranges) == 0 {
+		return nil
+	}
+	var out []int
+	for _, r := range p.Ranges {
+		if r.End == 0 {
+			out = append(out, r.Start)
+		} else {
+			for i := r.Start; i <= r.End; i++ {
+				out = append(out, i)
+			}
+		}
+	}
+	return out
 }

--- a/pkg/appolly/services/criteria_test.go
+++ b/pkg/appolly/services/criteria_test.go
@@ -55,8 +55,8 @@ func TestYAMLParse_PathRegexp_Errors(t *testing.T) {
 	})
 }
 
-func TestYAMLParse_PortEnum(t *testing.T) {
-	portEnumYAML := func(enum string) PortEnum {
+func TestYAMLParse_IntEnum(t *testing.T) {
+	intEnumYAML := func(enum string) IntEnum {
 		yf := yamlFile{}
 		err := yaml.Unmarshal(fmt.Appendf(nil, "services:\n  - open_ports: %s\n", enum), &yf)
 		require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestYAMLParse_PortEnum(t *testing.T) {
 		return yf.Services[0].OpenPorts
 	}
 	t.Run("single port number", func(t *testing.T) {
-		pe := portEnumYAML("80")
+		pe := intEnumYAML("80")
 		require.True(t, pe.Matches(80))
 		require.False(t, pe.Matches(8))
 		require.False(t, pe.Matches(79))
@@ -73,14 +73,14 @@ func TestYAMLParse_PortEnum(t *testing.T) {
 		require.False(t, pe.Matches(8080))
 	})
 	t.Run("comma-separated port numbers", func(t *testing.T) {
-		pe := portEnumYAML("80,8080")
+		pe := intEnumYAML("80,8080")
 		require.True(t, pe.Matches(80))
 		require.True(t, pe.Matches(8080))
 		require.False(t, pe.Matches(79))
 		require.False(t, pe.Matches(8081))
 	})
 	t.Run("ranges", func(t *testing.T) {
-		pe := portEnumYAML("8000-8999")
+		pe := intEnumYAML("8000-8999")
 		require.True(t, pe.Matches(8000))
 		require.True(t, pe.Matches(8999))
 		require.True(t, pe.Matches(8080))
@@ -88,7 +88,7 @@ func TestYAMLParse_PortEnum(t *testing.T) {
 		require.False(t, pe.Matches(9000))
 	})
 	t.Run("merging ranges and single ports, and lots of spaces", func(t *testing.T) {
-		pe := portEnumYAML("   80\t,   100 -200,443, 8000- 8999   ")
+		pe := intEnumYAML("   80\t,   100 -200,443, 8000- 8999   ")
 		require.True(t, pe.Matches(80))
 		require.True(t, pe.Matches(100))
 		require.True(t, pe.Matches(200))
@@ -104,7 +104,7 @@ func TestYAMLParse_PortEnum(t *testing.T) {
 	})
 }
 
-func TestYAMLParse_PortEnum_Errors(t *testing.T) {
+func TestYAMLParse_IntEnum_Errors(t *testing.T) {
 	assertError := func(desc, enum string) {
 		t.Run(desc, func(t *testing.T) {
 			err := yaml.Unmarshal(fmt.Appendf(nil, "services:\n  - open_ports: %s\n", enum), &yamlFile{})
@@ -148,30 +148,30 @@ services:
 
 func TestYAMLMarshal_CustomTypes(t *testing.T) {
 	type tc struct {
-		PortEnum    PortEnum
-		Regex       RegexpAttr
-		Glob        GlobAttr
-		PortEnumPtr *PortEnum
-		RegexPtr    *RegexpAttr
-		GlobPtr     *GlobAttr
+		IntEnum    IntEnum
+		Regex      RegexpAttr
+		Glob       GlobAttr
+		IntEnumPtr *IntEnum
+		RegexPtr   *RegexpAttr
+		GlobPtr    *GlobAttr
 	}
 	cases := &tc{
-		PortEnum: PortEnum{
-			Ranges: []PortRange{{Start: 80}, {Start: 8080, End: 8099}, {Start: 443}},
+		IntEnum: IntEnum{
+			Ranges: []IntRange{{Start: 80}, {Start: 8080, End: 8099}, {Start: 443}},
 		},
 		Regex: NewRegexp("^foo.*$"),
 		Glob:  NewGlob("bar*"),
 	}
 	cases.RegexPtr = &cases.Regex
 	cases.GlobPtr = &cases.Glob
-	cases.PortEnumPtr = &cases.PortEnum
+	cases.IntEnumPtr = &cases.IntEnum
 
 	yamlOut, err := yaml.Marshal(cases)
 	require.NoError(t, err)
-	assert.YAMLEq(t, `portenum: 80,8080-8099,443
+	assert.YAMLEq(t, `intenum: 80,8080-8099,443
 regex: ^foo.*$
 glob: bar*
-portenumptr: 80,8080-8099,443
+intenumptr: 80,8080-8099,443
 regexptr: ^foo.*$
 globptr: bar*
 `, string(yamlOut))

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"log/slog"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -48,63 +47,6 @@ const (
 	LogLevelWarn  LogLevel = "WARN"
 	LogLevelError LogLevel = "ERROR"
 )
-
-// TargetPIDs is a list of process IDs to instrument. Supports YAML arrays (e.g. [1234, 5678]),
-// a single YAML number, or env/comma-separated (e.g. OTEL_EBPF_TARGET_PID=1234,5678).
-type TargetPIDs []uint32
-
-// UnmarshalYAML accepts a YAML sequence of PIDs or a single scalar PID.
-func (p *TargetPIDs) UnmarshalYAML(value *yaml.Node) error {
-	if value.Kind == yaml.SequenceNode {
-		*p = make(TargetPIDs, 0, len(value.Content))
-		for _, n := range value.Content {
-			var pid uint32
-			if err := n.Decode(&pid); err != nil {
-				return fmt.Errorf("target_pids: invalid PID in list: %w", err)
-			}
-			*p = append(*p, pid)
-		}
-		return nil
-	}
-	if value.Kind == yaml.ScalarNode {
-		if strings.TrimSpace(value.Value) == "" {
-			*p = nil
-			return nil
-		}
-		pid, err := strconv.ParseUint(value.Value, 10, 32)
-		if err != nil {
-			return fmt.Errorf("target_pids: invalid PID %q: %w", value.Value, err)
-		}
-		*p = TargetPIDs{uint32(pid)}
-		return nil
-	}
-	return fmt.Errorf("target_pids: expected sequence or scalar, got kind %d", value.Kind)
-}
-
-// UnmarshalText parses comma-separated PIDs (e.g. from env OTEL_EBPF_TARGET_PID=1234,5678).
-func (p *TargetPIDs) UnmarshalText(text []byte) error {
-	s := strings.TrimSpace(string(text))
-	if s == "" {
-		*p = nil
-		return nil
-	}
-	*p = make(TargetPIDs, 0)
-	for _, part := range strings.Split(s, ",") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		pid, err := strconv.ParseUint(part, 10, 32)
-		if err != nil {
-			return fmt.Errorf("target_pids: invalid PID %q: %w", part, err)
-		}
-		*p = append(*p, uint32(pid))
-	}
-	return nil
-}
-
-// Len returns the number of target PIDs (0 means none set).
-func (p TargetPIDs) Len() int { return len(p) }
 
 // CustomValidations is a map of tag:function for custom validations
 type CustomValidations map[string]validator.Func
@@ -347,7 +289,7 @@ type Config struct {
 	// different to zero), the value of the Exec property won't take effect.
 	// It's important to emphasize that if your process opens multiple HTTP/GRPC ports, the auto-instrumenter
 	// will instrument all the service calls in all the ports, not only the port specified here.
-	Port services.PortEnum `yaml:"open_port" env:"OTEL_EBPF_OPEN_PORT"`
+	Port services.IntEnum `yaml:"open_port" env:"OTEL_EBPF_OPEN_PORT"`
 
 	// AutoTargetLanguage selects the executable to instrument matching a Glob of chosen languages.
 	// To set this value via YAML, use discovery > instrument.
@@ -356,7 +298,7 @@ type Config struct {
 	// TargetPIDs selects processes by PID for instrumentation. When non-empty, only these PIDs are
 	// instrumented. Accepts YAML list (target_pids: [1234, 5678]), single number, or env
 	// OTEL_EBPF_TARGET_PID=1234,5678. Alternative to Exec or AutoTargetExe when PIDs are known.
-	TargetPIDs TargetPIDs `yaml:"target_pids" env:"OTEL_EBPF_TARGET_PID"`
+	TargetPIDs services.IntEnum `yaml:"target_pids" env:"OTEL_EBPF_TARGET_PID"`
 
 	// ServiceName is taken from either OTEL_EBPF_SERVICE_NAME env var or OTEL_SERVICE_NAME (for OTEL spec compatibility)
 	// Using env and envDefault is a trick to get the value either from one of either variables.

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -494,25 +494,25 @@ func TestConfig_TargetPIDs(t *testing.T) {
 		t.Setenv("OTEL_EBPF_TARGET_PID", "1234")
 		cfg, err := LoadConfig(bytes.NewReader(nil))
 		require.NoError(t, err)
-		assert.Equal(t, TargetPIDs{1234}, cfg.TargetPIDs)
+		assert.Equal(t, services.IntEnum{Ranges: []services.IntRange{{Start: 1234}}}, cfg.TargetPIDs)
 		assert.True(t, cfg.Enabled(FeatureAppO11y))
 	})
 	t.Run("multiple PIDs from env", func(t *testing.T) {
 		t.Setenv("OTEL_EBPF_TARGET_PID", "1234,5678,90")
 		cfg, err := LoadConfig(bytes.NewReader(nil))
 		require.NoError(t, err)
-		assert.Equal(t, TargetPIDs{1234, 5678, 90}, cfg.TargetPIDs)
+		assert.Equal(t, services.IntEnum{Ranges: []services.IntRange{{Start: 1234}, {Start: 5678}, {Start: 90}}}, cfg.TargetPIDs)
 		assert.True(t, cfg.Enabled(FeatureAppO11y))
 	})
 	t.Run("YAML array", func(t *testing.T) {
 		cfg, err := LoadConfig(bytes.NewReader([]byte("target_pids: [11, 22, 33]")))
 		require.NoError(t, err)
-		assert.Equal(t, TargetPIDs{11, 22, 33}, cfg.TargetPIDs)
+		assert.Equal(t, services.IntEnum{Ranges: []services.IntRange{{Start: 11}, {Start: 22}, {Start: 33}}}, cfg.TargetPIDs)
 	})
 	t.Run("YAML single number", func(t *testing.T) {
 		cfg, err := LoadConfig(bytes.NewReader([]byte("target_pids: 999")))
 		require.NoError(t, err)
-		assert.Equal(t, TargetPIDs{999}, cfg.TargetPIDs)
+		assert.Equal(t, services.IntEnum{Ranges: []services.IntRange{{Start: 999}}}, cfg.TargetPIDs)
 	})
 }
 


### PR DESCRIPTION
This makes it possible to instrument by passing a PID, or list of PIDs, directly through the OBI config.

As a next step, it would be nice to be able to dynamically add/remove PIDs during runtime

## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->