### PR TITLE
Add numeric operators for filters.

### DIFF
--- a/pkg/filter/attribute.go
+++ b/pkg/filter/attribute.go
@@ -103,18 +103,43 @@ func buildMatcher[T any](getters attributes.NamedGetters[T, string], attribute a
 	if err := def.Validate(); err != nil {
 		return m, err
 	}
-	if def.Match != "" {
+	switch {
+	case def.Match != "":
 		var err error
 		if m.Glob, err = glob.Compile(def.Match); err != nil {
 			return m, fmt.Errorf("invalid glob in match property: %w", err)
 		}
-	} else {
+	case def.NotMatch != "":
 		var err error
 		if m.Glob, err = glob.Compile(def.NotMatch); err != nil {
 			return m, fmt.Errorf("invalid glob in not_match property: %w", err)
 		}
 		m.Negate = true
+	default:
+		// use match-all as dummy for numeric-only comparisons
+		m.Glob = glob.MustCompile("*")
+
+		// Set up numeric comparisons
+		if def.Equals != nil {
+			m.Equals = def.Equals
+		}
+		if def.NotEquals != nil {
+			m.NotEquals = def.NotEquals
+		}
+		if def.GreaterEquals != nil {
+			m.GreaterEquals = def.GreaterEquals
+		}
+		if def.GreaterThan != nil {
+			m.GreaterThan = def.GreaterThan
+		}
+		if def.LessEquals != nil {
+			m.LessEquals = def.LessEquals
+		}
+		if def.LessThan != nil {
+			m.LessThan = def.LessThan
+		}
 	}
+
 	getter, ok := getters(attribute)
 	if !ok {
 		var t T

--- a/pkg/filter/attribute_test.go
+++ b/pkg/filter/attribute_test.go
@@ -20,6 +20,11 @@ import (
 
 const timeout = 5 * time.Second
 
+// Helper to return a pointer to an int value for the numeric comparisons
+func intPtr(i int) *int {
+	return &i
+}
+
 func TestAttributeFilter(t *testing.T) {
 	input := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
 	output := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
@@ -168,6 +173,390 @@ func TestAttributeFilter(t *testing.T) {
 				Metadata: map[attr.Name]string{
 					"k8s.src.namespace": "tralar",
 					"k8s.app.version":   "v0.0.1",
+				},
+			},
+		},
+	}, filtered)
+
+	select {
+	case batch := <-out:
+		assert.Failf(t, "not expecting more output batches", "%#v", batch)
+	default:
+		// ok!!
+	}
+}
+
+func TestAttributeFilter_NumericComparisons(t *testing.T) {
+	input := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+	output := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+
+	// Test multiple numeric comparisons: status code must be in [200, 400) range
+	filterFunc, err := ByAttribute[*ebpf.Record](AttributeFamilyConfig{
+		"http.response.status_code": MatchDefinition{GreaterEquals: intPtr(200), LessThan: intPtr(400)},
+	}, nil, map[string][]attr.Name{}, ebpf.RecordStringGetters, input, output)(t.Context())
+	require.NoError(t, err)
+
+	out := output.Subscribe()
+	go filterFunc(t.Context())
+
+	// Send batch with mixed status codes
+	input.Send([]*ebpf.Record{
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "404", // >= 400, should be filtered out
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "199", // < 200, should be filtered out
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "304",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "500", // >= 400, should be filtered out
+				},
+			},
+		},
+	})
+
+	// Only records with status_code in [200, 400) should pass
+	filtered := testutil.ReadChannel(t, out, timeout)
+	assert.Equal(t, []*ebpf.Record{
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "304",
+				},
+			},
+		},
+	}, filtered)
+
+	select {
+	case batch := <-out:
+		assert.Failf(t, "not expecting more output batches", "%#v", batch)
+	default:
+		// ok!!
+	}
+}
+
+func TestAttributeFilter_NumericEquality(t *testing.T) {
+	input := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+	output := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+
+	filterFunc, err := ByAttribute[*ebpf.Record](AttributeFamilyConfig{
+		"http.response.status_code": MatchDefinition{Equals: intPtr(200)},
+	}, nil, map[string][]attr.Name{}, ebpf.RecordStringGetters, input, output)(t.Context())
+	require.NoError(t, err)
+
+	out := output.Subscribe()
+	go filterFunc(t.Context())
+
+	input.Send([]*ebpf.Record{
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "201",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200",
+				},
+			},
+		},
+	})
+
+	// Only records with status_code == 200 should pass
+	filtered := testutil.ReadChannel(t, out, timeout)
+	assert.Equal(t, []*ebpf.Record{
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200",
+				},
+			},
+		},
+	}, filtered)
+
+	select {
+	case batch := <-out:
+		assert.Failf(t, "not expecting more output batches", "%#v", batch)
+	default:
+		// ok!!
+	}
+}
+
+func TestAttributeFilter_NumericNotEquals(t *testing.T) {
+	input := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+	output := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+
+	filterFunc, err := ByAttribute[*ebpf.Record](AttributeFamilyConfig{
+		"http.response.status_code": MatchDefinition{NotEquals: intPtr(500)},
+	}, nil, map[string][]attr.Name{}, ebpf.RecordStringGetters, input, output)(t.Context())
+	require.NoError(t, err)
+
+	out := output.Subscribe()
+	go filterFunc(t.Context())
+
+	input.Send([]*ebpf.Record{
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "500",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "404",
+				},
+			},
+		},
+	})
+
+	// Records with status_code != 500 should pass
+	filtered := testutil.ReadChannel(t, out, timeout)
+	assert.Equal(t, []*ebpf.Record{
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "404",
+				},
+			},
+		},
+	}, filtered)
+
+	select {
+	case batch := <-out:
+		assert.Failf(t, "not expecting more output batches", "%#v", batch)
+	default:
+		// ok!!
+	}
+}
+
+func TestAttributeFilter_NumericAndGlob(t *testing.T) {
+	input := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+	output := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+
+	filterFunc, err := ByAttribute[*ebpf.Record](AttributeFamilyConfig{
+		"http.response.status_code": MatchDefinition{GreaterEquals: intPtr(200), LessThan: intPtr(300)},
+		"http.request.method":       MatchDefinition{Match: "GET"},
+	}, nil, map[string][]attr.Name{}, ebpf.RecordStringGetters, input, output)(t.Context())
+	require.NoError(t, err)
+
+	out := output.Subscribe()
+	go filterFunc(t.Context())
+
+	input.Send([]*ebpf.Record{
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200",
+					attr.HTTPRequestMethod:      "GET",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200",
+					attr.HTTPRequestMethod:      "POST", // Wrong method
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "404", // Wrong status
+					attr.HTTPRequestMethod:      "GET",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "201",
+					attr.HTTPRequestMethod:      "GET",
+				},
+			},
+		},
+	})
+
+	// Only records with status_code in [200, 300) AND method == "GET" should pass
+	filtered := testutil.ReadChannel(t, out, timeout)
+	assert.Equal(t, []*ebpf.Record{
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200",
+					attr.HTTPRequestMethod:      "GET",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "201",
+					attr.HTTPRequestMethod:      "GET",
+				},
+			},
+		},
+	}, filtered)
+
+	select {
+	case batch := <-out:
+		assert.Failf(t, "not expecting more output batches", "%#v", batch)
+	default:
+		// ok!!
+	}
+}
+
+func TestAttributeFilter_NumericGlobMixed(t *testing.T) {
+	input := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+	output := msg.NewQueue[[]*ebpf.Record](msg.ChannelBufferLen(10))
+
+	// Filter for error responses (>= 400) with write methods (POST, PUT, PATCH)
+	filterFunc, err := ByAttribute[*ebpf.Record](AttributeFamilyConfig{
+		"http.response.status_code": MatchDefinition{GreaterEquals: intPtr(400)},
+		"http.request.method":       MatchDefinition{Match: "P*"},
+	}, nil, map[string][]attr.Name{}, ebpf.RecordStringGetters, input, output)(t.Context())
+	require.NoError(t, err)
+
+	out := output.Subscribe()
+	go filterFunc(t.Context())
+
+	input.Send([]*ebpf.Record{
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "404",
+					attr.HTTPRequestMethod:      "POST",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "500",
+					attr.HTTPRequestMethod:      "GET", // Doesn't match P*
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "200", // < 400
+					attr.HTTPRequestMethod:      "POST",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "403",
+					attr.HTTPRequestMethod:      "PUT",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "422",
+					attr.HTTPRequestMethod:      "PATCH",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "401",
+					attr.HTTPRequestMethod:      "DELETE", // Doesn't match P*
+				},
+			},
+		},
+	})
+
+	// Only records with status_code >= 400 AND method matching "P*" should pass
+	filtered := testutil.ReadChannel(t, out, timeout)
+	assert.Equal(t, []*ebpf.Record{
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "404",
+					attr.HTTPRequestMethod:      "POST",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "403",
+					attr.HTTPRequestMethod:      "PUT",
+				},
+			},
+		},
+		{
+			Attrs: ebpf.RecordAttrs{
+				Metadata: map[attr.Name]string{
+					attr.HTTPResponseStatusCode: "422",
+					attr.HTTPRequestMethod:      "PATCH",
 				},
 			},
 		},

--- a/pkg/filter/matcher.go
+++ b/pkg/filter/matcher.go
@@ -5,6 +5,7 @@ package filter // import "go.opentelemetry.io/obi/pkg/filter"
 
 import (
 	"errors"
+	"strconv"
 
 	"github.com/gobwas/glob"
 
@@ -19,10 +20,54 @@ type Matcher[T any] struct {
 	Negate bool
 	// Getter for the field to be compared with the Glob
 	Getter attributes.Getter[T, string]
+
+	// Numeric matchers
+	GreaterEquals *int
+	GreaterThan   *int
+	Equals        *int
+	NotEquals     *int
+	LessEquals    *int
+	LessThan      *int
 }
 
 func (m *Matcher[T]) Matches(record T) bool {
-	matches := m.Glob.Match(m.Getter(record))
+	valueStr := m.Getter(record)
+
+	if m.Equals != nil || m.NotEquals != nil || m.LessEquals != nil ||
+		m.LessThan != nil || m.GreaterThan != nil || m.GreaterEquals != nil {
+		value, err := strconv.Atoi(valueStr)
+		if err != nil {
+			return false
+		}
+
+		if m.Equals != nil && value != *m.Equals {
+			return false
+		}
+
+		if m.NotEquals != nil && value == *m.NotEquals {
+			return false
+		}
+
+		if m.GreaterEquals != nil && value < *m.GreaterEquals {
+			return false
+		}
+
+		if m.GreaterThan != nil && value <= *m.GreaterThan {
+			return false
+		}
+
+		if m.LessEquals != nil && value > *m.LessEquals {
+			return false
+		}
+
+		if m.LessThan != nil && value >= *m.LessThan {
+			return false
+		}
+
+		return true
+	}
+
+	matches := m.Glob.Match(valueStr)
 	return m.Negate != matches
 }
 
@@ -33,11 +78,21 @@ type MatchDefinition struct {
 	Match string `yaml:"match"`
 	// NotMatch stores the glob that a given attribute MUST NOT match to let the record pass
 	NotMatch string `yaml:"not_match"`
+	// Numerical comparison for e.g. http.code or timings
+	GreaterThan   *int `yaml:"greater_than"`
+	GreaterEquals *int `yaml:"greater_equals"`
+	Equals        *int `yaml:"equals"`
+	NotEquals     *int `yaml:"not_equals"`
+	LessEquals    *int `yaml:"less_equals"`
+	LessThan      *int `yaml:"less_than"`
 }
 
 func (md *MatchDefinition) Validate() error {
-	if md.Match == "" && md.NotMatch == "" {
-		return errors.New("attribute must include a match or a not_match clause")
+	hasGlob := md.Match != "" || md.NotMatch != ""
+	hasNumeric := md.GreaterThan != nil || md.LessThan != nil || md.Equals != nil || md.NotEquals != nil || md.GreaterEquals != nil || md.LessEquals != nil
+
+	if !hasGlob && !hasNumeric {
+		return errors.New("attribute must include a match/not_match clause or numeric comparison")
 	}
 	if md.Match != "" && md.NotMatch != "" {
 		return errors.New("attribute can't include bot match or not_match clauses")

--- a/pkg/filter/matcher_test.go
+++ b/pkg/filter/matcher_test.go
@@ -4,6 +4,7 @@
 package filter
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -38,4 +39,106 @@ func TestMatchDefinition_Validate(t *testing.T) {
 	require.NoError(t, (&MatchDefinition{NotMatch: "foo"}).Validate())
 	require.Error(t, (&MatchDefinition{Match: "foo", NotMatch: "foo"}).Validate())
 	require.Error(t, (&MatchDefinition{}).Validate())
+}
+
+func TestMatches_GreaterEquals(t *testing.T) {
+	comp := 12
+	matcher := Matcher[int]{
+		GreaterEquals: &comp,
+		Getter:        strconv.Itoa,
+		Glob:          glob.MustCompile("*"),
+	}
+	assert.False(t, matcher.Matches(11))
+	assert.True(t, matcher.Matches(12))
+	assert.True(t, matcher.Matches(13))
+}
+
+func TestMatches_Equals(t *testing.T) {
+	comp := 42
+	matcher := Matcher[int]{
+		Equals: &comp,
+		Getter: strconv.Itoa,
+		Glob:   glob.MustCompile("*"),
+	}
+	assert.True(t, matcher.Matches(42))
+	assert.False(t, matcher.Matches(43))
+}
+
+func TestMatches_Equals_NonNumericString(t *testing.T) {
+	comp := 42
+	matcher := Matcher[string]{
+		Equals: &comp,
+		Getter: func(s string) string { return s }, // Returns the string as-is
+		Glob:   glob.MustCompile("*"),
+	}
+	// Non-numeric strings should fail to parse and return false
+	assert.False(t, matcher.Matches("hello"))
+	assert.False(t, matcher.Matches("abc123"))
+	assert.False(t, matcher.Matches("not a number"))
+	// But valid numeric strings should work
+	assert.True(t, matcher.Matches("42"))
+	assert.False(t, matcher.Matches("43"))
+}
+
+func TestMatches_NotEquals(t *testing.T) {
+	comp := 0
+	matcher := Matcher[int]{
+		NotEquals: &comp,
+		Getter:    strconv.Itoa,
+		Glob:      glob.MustCompile("*"),
+	}
+	assert.True(t, matcher.Matches(1))
+	assert.False(t, matcher.Matches(0))
+}
+
+func TestMatches_LessEquals(t *testing.T) {
+	comp := 100
+	matcher := Matcher[int]{
+		LessEquals: &comp,
+		Getter:     strconv.Itoa,
+		Glob:       glob.MustCompile("*"),
+	}
+	assert.True(t, matcher.Matches(100))
+	assert.True(t, matcher.Matches(50))
+	assert.False(t, matcher.Matches(101))
+}
+
+func TestMatches_GreaterThan(t *testing.T) {
+	comp := 5
+	matcher := Matcher[int]{
+		GreaterThan: &comp,
+		Getter:      strconv.Itoa,
+		Glob:        glob.MustCompile("*"),
+	}
+	assert.True(t, matcher.Matches(6))
+	assert.False(t, matcher.Matches(5))
+	assert.False(t, matcher.Matches(4))
+}
+
+func TestMatches_LessThan(t *testing.T) {
+	comp := 20
+	matcher := Matcher[int]{
+		LessThan: &comp,
+		Getter:   strconv.Itoa,
+		Glob:     glob.MustCompile("*"),
+	}
+	assert.True(t, matcher.Matches(19))
+	assert.False(t, matcher.Matches(20))
+	assert.False(t, matcher.Matches(21))
+}
+
+func TestMatches_MultipleComparisons(t *testing.T) {
+	ge := 10
+	le := 100
+	matcher := Matcher[int]{
+		GreaterEquals: &ge,
+		LessEquals:    &le,
+		Getter:        strconv.Itoa,
+		Glob:          glob.MustCompile("*"),
+	}
+	assert.True(t, matcher.Matches(10))
+	assert.True(t, matcher.Matches(50))
+	assert.True(t, matcher.Matches(100))
+	assert.False(t, matcher.Matches(9))
+	assert.False(t, matcher.Matches(101))
 }


### PR DESCRIPTION
Addresses #1291

This introduces new numeric filter options  
* equals
* not_equals
* greater_than
* greater_equals
* less_than
* less_equals

To be used e.g. like the following:

```yaml
filter:
  application:
    server.port:
      equals: 8787
```