### PR TITLE
fix(generator-image): add id-token permission for image signing

### DIFF
--- a/.github/workflows/generator-image.yml
+++ b/.github/workflows/generator-image.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
       attestations: write
 
     steps:


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1201 

Fixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/22094554390/job/63848068091#step:11:40

`id-token: write` is needed for signing the images with GitHub OIDC Token

References:
- https://github.com/sigstore/cosign-installer
- https://docs.sigstore.dev/quickstart/quickstart-ci/#signing-and-verifying-a-container-image