### PR TITLE
fix(release): remove k8s-cache from release artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -532,17 +532,16 @@ license-header-check:
 	   fi
 
 .PHONY: artifact
-artifact: docker-generate compile compile-cache java-docker-build
+artifact: docker-generate compile java-docker-build
 	@echo "### Packing generated artifact for $(GOOS)/$(GOARCH)"
 	@STAGING_DIR=$$(mktemp -d 2>/dev/null || mktemp -d -t obi.XXXXXX); \
 	trap "rm -rf $$STAGING_DIR" EXIT; \
 	cp ./bin/$(CMD) $$STAGING_DIR/; \
-	cp ./bin/$(CACHE_CMD) $$STAGING_DIR/; \
 	cp ./bin/$(JAVA_AGENT) $$STAGING_DIR/; \
 	cp LICENSE $$STAGING_DIR/; \
 	cp NOTICE $$STAGING_DIR/; \
 	cp -r NOTICES $$STAGING_DIR/; \
-	tar -C $$STAGING_DIR -czf bin/obi-$(RELEASE_VERSION)-$(GOOS)-$(GOARCH).tar.gz $(CMD) $(CACHE_CMD) $(JAVA_AGENT) LICENSE NOTICE NOTICES
+	tar -C $$STAGING_DIR -czf bin/obi-$(RELEASE_VERSION)-$(GOOS)-$(GOARCH).tar.gz $(CMD) $(JAVA_AGENT) LICENSE NOTICE NOTICES
 
 .PHONY: release
 release: artifact
@@ -553,13 +552,11 @@ release: artifact
 	@mkdir -p $(RELEASE_DIR)/verify-$(GOARCH)
 	@tar -xzf $(RELEASE_DIR)/obi-$(RELEASE_VERSION)-$(GOOS)-$(GOARCH).tar.gz -C $(RELEASE_DIR)/verify-$(GOARCH)
 	@if [ ! -f $(RELEASE_DIR)/verify-$(GOARCH)/$(CMD) ]; then echo "ERROR: $(CMD) binary missing in $(GOARCH) archive"; exit 1; fi
-	@if [ ! -f $(RELEASE_DIR)/verify-$(GOARCH)/$(CACHE_CMD) ]; then echo "ERROR: $(CACHE_CMD) binary missing in $(GOARCH) archive"; exit 1; fi
 	@if [ ! -f $(RELEASE_DIR)/verify-$(GOARCH)/$(JAVA_AGENT) ]; then echo "ERROR: $(JAVA_AGENT) missing in $(GOARCH) archive"; exit 1; fi
 	@if [ ! -f $(RELEASE_DIR)/verify-$(GOARCH)/LICENSE ]; then echo "ERROR: LICENSE missing in $(GOARCH) archive"; exit 1; fi
 	@if [ ! -f $(RELEASE_DIR)/verify-$(GOARCH)/NOTICE ]; then echo "ERROR: NOTICE missing in $(GOARCH) archive"; exit 1; fi
 	@if [ ! -d $(RELEASE_DIR)/verify-$(GOARCH)/NOTICES ]; then echo "ERROR: NOTICES directory missing in $(GOARCH) archive"; exit 1; fi
 	@if [ ! -x $(RELEASE_DIR)/verify-$(GOARCH)/$(CMD) ]; then echo "ERROR: $(CMD) binary not executable in $(GOARCH) archive"; exit 1; fi
-	@if [ ! -x $(RELEASE_DIR)/verify-$(GOARCH)/$(CACHE_CMD) ]; then echo "ERROR: $(CACHE_CMD) binary not executable in $(GOARCH) archive"; exit 1; fi
 	@echo "✓ Archive $(GOARCH) verified successfully"
 	@rm -rf $(RELEASE_DIR)/verify-$(GOARCH)
 	@echo "### Generating checksums"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -106,7 +106,7 @@ When you push a tag matching the pattern `vX.Y.Z` (e.g., `v1.2.3`) or `vX.Y.Z-su
 
 3. **Build Release Artifacts**: Once all checks pass, the workflow builds multi-architecture release artifacts:
    - Runs `make release` to generate versioned tarballs for amd64 and arm64
-   - Archives contain: `obi`, `k8s-cache`, `obi-java-agent.jar`, LICENSE, NOTICE, and NOTICES/ directory
+   - Archives contain: `obi`, `obi-java-agent.jar`, LICENSE, NOTICE, and NOTICES/ directory
    - Generates SHA256 checksums for all archives
    - Verifies archive contents and binary executability
 
@@ -138,7 +138,6 @@ Once the workflow completes successfully, a draft release is automatically creat
 Each release archive (`obi-<version>-linux-<arch>.tar.gz`) contains:
 
 - `obi`: Main OBI binary
-- `k8s-cache`: Kubernetes cache service binary
 - `obi-java-agent.jar`: Java instrumentation agent
 - `LICENSE`: Apache 2.0 license file
 - `NOTICE`: Legal notices


### PR DESCRIPTION
`k8s-cache` binary does not need to be included in the released archive.

Side note: it was added in https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1242.