### PR TITLE
Add `lint-fix` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,17 @@ clang-tidy:
 	cd bpf && find . -type f \( -name '*.c' -o -name '*.h' \) ! -path "./bpfcore/*" ! -path "./NOTICES/*" | xargs clang-tidy
 
 .PHONY: lint
-lint: $(GOLANGCI_LINT) vanity-import-check
+lint: LINT_EXTRA_ARGS =
+lint: lint-run
+
+.PHONY: lint-fix
+lint-fix: LINT_EXTRA_ARGS = --fix
+lint-fix: lint-run
+
+.PHONY: lint-run
+lint-run: $(GOLANGCI_LINT) vanity-import-check
 	@echo "### Linting code"
-	$(GOLANGCI_LINT) run ./... --timeout=6m
+	$(GOLANGCI_LINT) run ./... --timeout=6m $(LINT_EXTRA_ARGS)
 
 MARKDOWNIMAGE := $(shell awk '$$4=="markdown" {print $$2}' $(DEPENDENCIES_DOCKERFILE))
 WORKDIR := "/go/src/go.opentelemetry.io/obi"


### PR DESCRIPTION
DRY: refactor `lint` to use the added `lint-run` as well as the added `lint-fix`