### PR TITLE
ci: use 30 minute job timeouts

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,7 @@ jobs:
       pull-requests: write
     name: test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -34,6 +34,7 @@ jobs:
   test-matrix:
     name: "Build integration matrix"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -60,6 +61,7 @@ jobs:
       # Required for uploading artifacts
       actions: write
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
@@ -135,7 +137,6 @@ jobs:
         run: df -h
 
       - name: Run integration tests
-        timeout-minutes: 35
         env:
           # zizmor template-injection fixes: pass data as env vars
           MATRIX_ID: ${{ matrix.id }}

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -34,6 +34,7 @@ jobs:
   test-matrix:
     name: "Build ARM integration matrix"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -66,6 +67,7 @@ jobs:
       # Required for uploading artifacts
       actions: write
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
@@ -133,7 +135,6 @@ jobs:
         run: df -h
 
       - name: Run integration tests
-        timeout-minutes: 35
         env:
           MATRIX_ID: ${{ matrix.id }}
           MATRIX_JSON: ${{ toJson(matrix) }}

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -34,6 +34,7 @@ jobs:
   test-matrix:
     name: "Build integration k8s matrix"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -58,6 +59,7 @@ jobs:
       # Required for uploading artifacts
       actions: write
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
@@ -125,7 +127,6 @@ jobs:
         run: df -h
 
       - name: Run integration tests
-        timeout-minutes: 35
         env:
           # zizmor template-injection fixes: pass data as env vars
           MATRIX_ID: ${{ matrix.id }}

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -34,6 +34,7 @@ jobs:
   test-matrix:
     name: "Build oats matrix"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -58,6 +59,7 @@ jobs:
       # Required for uploading artifacts
       actions: write
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -29,6 +29,7 @@ jobs:
   vm-test-matrix:
     name: "Build VM integration matrix"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -62,6 +63,7 @@ jobs:
       # Required for uploading artifacts
       actions: write
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -179,7 +181,6 @@ jobs:
           fi
 
       - name: Run VM integration tests (${{ matrix.test.description }})
-        timeout-minutes: 60
         env:
           # zizmor template-injection fixes: pass data as env vars
           MATRIX_ID: ${{ matrix.test.id }}


### PR DESCRIPTION
These jobs are all expected to complete within 30 minutes. Also clean up individual step timeouts that are greater than 30 minutes.

In particular this should be useful for the VM workflow, where runners can stall and currently timeout after 1 hour in that case.