### PR TITLE
Add SendTimeout field in kubecache config

### DIFF
--- a/pkg/kube/kubecache/config.go
+++ b/pkg/kube/kubecache/config.go
@@ -30,13 +30,15 @@ type Config struct {
 	// LogLevel can be one of: debug, info, warn, error
 	LogLevel LogLevel `yaml:"log_level" env:"OTEL_EBPF_K8S_CACHE_LOG_LEVEL"`
 	// Port where the service is going to listen to
-	Port int `yaml:"port" env:"OTEL_EBPF_K8S_CACHE_PORT"`
+	Port int `yaml:"port" env:"OTEL_EBPF_K8S_CACHE_PORT" validate:"gte=0"`
 	// MaxConnection is the maximum number of concurrent clients that the service can handle at the same time
-	MaxConnections int `yaml:"max_connections" env:"OTEL_EBPF_K8S_CACHE_MAX_CONNECTIONS"`
+	MaxConnections int `yaml:"max_connections" env:"OTEL_EBPF_K8S_CACHE_MAX_CONNECTIONS" validate:"gte=0"`
 	// ProfilePort is the port where the pprof server is going to listen to. 0 (default) means disabled
-	ProfilePort int `yaml:"profile_port" env:"OTEL_EBPF_K8S_CACHE_PROFILE_PORT"`
+	ProfilePort int `yaml:"profile_port" env:"OTEL_EBPF_K8S_CACHE_PROFILE_PORT" validate:"gte=0"`
 	// InformerResyncPeriod is the time interval between complete resyncs of the informers
-	InformerResyncPeriod time.Duration `yaml:"informer_resync_period" env:"OTEL_EBPF_K8S_CACHE_INFORMER_RESYNC_PERIOD"`
+	InformerResyncPeriod time.Duration `yaml:"informer_resync_period" env:"OTEL_EBPF_K8S_CACHE_INFORMER_RESYNC_PERIOD" validate:"gte=0"`
+	// SendTimeout is the maximum duration to wait to receive an event before dropping the connection.
+	SendTimeout time.Duration `yaml:"informer_send_timeout" env:"OTEL_EBPF_K8S_CACHE_INFORMER_SEND_TIMEOUT" validate:"gte=0"`
 
 	InternalMetrics instrument.InternalMetricsConfig `yaml:"internal_metrics"`
 }
@@ -46,6 +48,7 @@ var DefaultConfig = Config{
 	Port:                 50055,
 	MaxConnections:       150,
 	InformerResyncPeriod: 30 * time.Minute,
+	SendTimeout:          10 * time.Second,
 	ProfilePort:          0,
 }
 

--- a/pkg/kube/kubecache/envtest/integration_test.go
+++ b/pkg/kube/kubecache/envtest/integration_test.go
@@ -99,7 +99,8 @@ func TestMain(m *testing.M) {
 	// Create and start informers client cache
 	iConfig := kubecache.DefaultConfig
 	iConfig.Port = freePort
-	svc := service.InformersCache{Config: &iConfig, SendTimeout: 150 * time.Millisecond}
+	iConfig.SendTimeout = 150 * time.Millisecond
+	svc := service.InformersCache{Config: &iConfig}
 	go func() {
 		if err := svc.Run(ctx,
 			meta.WithResyncPeriod(iConfig.InformerResyncPeriod),
@@ -268,7 +269,8 @@ func TestAsynchronousStartup(t *testing.T) {
 
 	iConfig := kubecache.DefaultConfig
 	iConfig.Port = newFreePort
-	svc := service.InformersCache{Config: &iConfig, SendTimeout: time.Second}
+	iConfig.SendTimeout = time.Second
+	svc := service.InformersCache{Config: &iConfig}
 	go func() {
 		if err := svc.Run(ctx,
 			meta.WithResyncPeriod(iConfig.InformerResyncPeriod),

--- a/pkg/kube/kubecache/service/service.go
+++ b/pkg/kube/kubecache/service/service.go
@@ -22,8 +22,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/kube/kubecache/meta"
 )
 
-const defaultSendTimeout = 10 * time.Second
-
 // InformersCache configures and starts the gRPC service
 type InformersCache struct {
 	informer.UnimplementedEventStreamServiceServer
@@ -34,16 +32,10 @@ type InformersCache struct {
 	informers *meta.Informers
 	log       *slog.Logger
 
-	// TODO: allow configuring by user
-	SendTimeout time.Duration
-
 	metrics instrument.InternalMetrics
 }
 
 func (ic *InformersCache) Run(ctx context.Context, opts ...meta.InformerOption) error {
-	if ic.SendTimeout == 0 {
-		ic.SendTimeout = defaultSendTimeout
-	}
 	if ic.started.Swap(true) {
 		return errors.New("server already started")
 	}
@@ -95,7 +87,7 @@ func (ic *InformersCache) Subscribe(msg *informer.SubscribeMessage, server infor
 		log:         ic.log.With("clientID", p.Addr.String()),
 		id:          p.Addr.String(),
 		server:      server,
-		sendTimeout: ic.SendTimeout,
+		sendTimeout: ic.Config.SendTimeout,
 		metrics:     ic.metrics,
 		fromEpoch:   msg.GetFromTimestampEpoch(),
 		messages:    sync.NewQueue[*informer.Event](),


### PR DESCRIPTION
This PR allows to set the `SendTimeout` value of the `k8s-cache` component during configuration. 
It also adds some config validations.