### PR TITLE
ci: shard unit tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,12 +20,59 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    permissions:
-      # Required for codecov
-      checks: write
-      pull-requests: write
-    name: test
+  generate-and-checks:
+    name: Generate and checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 # zizmor: ignore[cache-poisoning] go.sum verifies module integrity
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Go build cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3 # zizmor: ignore[cache-poisoning] go build cache is content-addressable and self-verifying
+        with:
+          path: ~/.cache/go-build
+          key: go-build-pr-race-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.go', 'go.sum') }}
+          restore-keys: |
+            go-build-pr-race-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Generate and build tools
+        run: make prereqs docker-generate unit-test-tools
+
+      - name: Run checks
+        run: make go-mod-tidy license-header-check notices-update check-go-mod check-ebpf-ver-synced check-config-schema check-clean-work-tree
+
+      - name: Build unit test matrix
+        id: build-matrix
+        env:
+          PARTITIONS: 3
+        run: |
+          echo -n "matrix=" >> $GITHUB_OUTPUT
+          make unit-test-matrix-json >> $GITHUB_OUTPUT
+
+      - name: Upload generated BPF files
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          # prevent cache poisoning by using the SHA of the commit
+          name: bpf-generated-${{ github.sha }}
+          path: |
+            **/*_bpfel.go
+            **/*_bpfel.o
+          retention-days: 1
+
+  lint:
+    name: Lint
+    needs: generate-and-checks
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -48,13 +95,69 @@ jobs:
           restore-keys: |
             go-build-pr-race-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Run verification and unit tests
-        run: make docker-generate verify cov-exclude-generated check-go-mod notices-update check-ebpf-ver-synced check-config-schema check-clean-work-tree
+      - name: Download generated BPF files
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: bpf-generated-${{ github.sha }}
+
+      - name: Lint
+        run: make lint
+
+  unit-test:
+    name: "Unit test ${{ matrix.description }}"
+    needs: generate-and-checks
+    permissions:
+      checks: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-and-checks.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 # zizmor: ignore[cache-poisoning] go.sum verifies module integrity
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Go build cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3 # zizmor: ignore[cache-poisoning] go build cache is content-addressable and self-verifying
+        with:
+          path: ~/.cache/go-build
+          key: go-build-pr-race-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.go', 'go.sum') }}
+          restore-keys: |
+            go-build-pr-race-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Download generated BPF files
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: bpf-generated-${{ github.sha }}
+
+      - name: Build test tools
+        run: make prereqs unit-test-tools
+
+      - name: Run unit tests
+        env:
+          MATRIX_ID: ${{ matrix.id }}
+          MATRIX_PACKAGES: ${{ matrix.packages }}
+        run: make run-unit-test-shard SHARD_ID="${MATRIX_ID}" UNIT_TEST_PACKAGES="${MATRIX_PACKAGES}"
+
+      - name: Exclude generated files from coverage
+        run: grep -vE "(_bpfel.go)|(/opentelemetry-ebpf-instrumentation/internal/test/)|(/opentelemetry-ebpf-instrumentation/configs/)|(.pb.go)|(/pkg/export/otel/metric/)" testoutput/cover-shard-"${MATRIX_ID}".all.txt > testoutput/cover-shard-"${MATRIX_ID}".txt
+        env:
+          MATRIX_ID: ${{ matrix.id }}
+
       - name: Report coverage
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: ./testoutput/cover.txt
+          files: ./testoutput/cover-shard-${{ matrix.id }}.txt
           flags: unittests
-          name: go-unittests-coverage-${{ github.run_number }}
+          name: go-unittests-coverage-shard-${{ matrix.id }}-${{ github.run_number }}

--- a/Makefile
+++ b/Makefile
@@ -445,6 +445,23 @@ run-integration-test-arm:
 	go clean -testcache
 	go test -p 1 -failfast -v -timeout 90m -a ./internal/test/integration -run "^TestMultiProcess"
 
+.PHONY: unit-test-tools
+unit-test-tools: $(GOTESTSUM) $(ENVTEST)
+
+.PHONY: unit-test-matrix-json
+unit-test-matrix-json: $(GOTESTSUM)
+	@go list ./... | $(GOTESTSUM) tool ci-matrix --partitions $${PARTITIONS:-3} --timing-files=$(TEST_OUTPUT)/unit-test-shard-*.log
+
+.PHONY: run-unit-test-shard
+run-unit-test-shard: $(GOTESTSUM) $(ENVTEST)
+	@echo "### Running unit test shard $(SHARD_ID)"
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
+	$(GOTESTSUM) \
+		--jsonfile=$(TEST_OUTPUT)/unit-test-shard-$(SHARD_ID).log \
+		-- -short -race -a -coverpkg=./... \
+		-coverprofile $(TEST_OUTPUT)/cover-shard-$(SHARD_ID).all.txt \
+		$(UNIT_TEST_PACKAGES)
+
 .PHONY: integration-test-matrix-json
 integration-test-matrix-json:
 	@./scripts/generate-integration-matrix.sh internal/test/integration "$${PARTITIONS:-5}"


### PR DESCRIPTION
Unit test workflow was taking ~10 minutes, let's see if sharding can help:

- Split the one-huge-job "PR checks" job into several jobs and steps
- Run lint in parallel with the tests
- Re-use the docker-generate caching from the lint-darwin workflow
- Re-use the go caching from various workflows
- Use a simple sharding strategy based on `go list`

Should be able to see the run time on this PR:

- https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/22314090260?pr=1350

FYI: There's a [GitHub Actions incident](https://www.githubstatus.com) currently, so it's making it difficult to measure timings as runners are taking a while to pick up jobs.