### PR TITLE
Allow to limit process selection by command line argument

### DIFF
--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -551,6 +551,10 @@
     },
     "GlobAttributes": {
       "properties": {
+        "cmd_args": {
+          "$ref": "#/$defs/GlobAttr",
+          "description": "CmdArgs allows to limit by matching command line arguments"
+        },
         "container_name": {
           "$ref": "#/$defs/GlobAttr"
         },
@@ -1439,6 +1443,10 @@
     },
     "RegexSelector": {
       "properties": {
+        "cmd_args": {
+          "$ref": "#/$defs/RegexpAttr",
+          "description": "CmdArgs allows matching by command line arguments"
+        },
         "container_name": {
           "$ref": "#/$defs/RegexpAttr"
         },

--- a/pkg/appolly/discover/matcher.go
+++ b/pkg/appolly/discover/matcher.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/shirou/gopsutil/v3/process"
 
@@ -214,7 +215,7 @@ func (m *Matcher) matchProcess(obj *ProcessAttrs, p *services.ProcessInfo, a ser
 	if pids, ok := a.GetPIDs(); ok && len(pids) > 0 {
 		return pidInList(p.Pid, pids)
 	}
-	if !a.GetPath().IsSet() && !a.GetLanguages().IsSet() && a.GetOpenPorts().Len() == 0 && len(obj.metadata) == 0 {
+	if !a.GetPath().IsSet() && !a.GetLanguages().IsSet() && !a.GetCmdArgs().IsSet() && a.GetOpenPorts().Len() == 0 && len(obj.metadata) == 0 {
 		pids, hasPIDs := a.GetPIDs()
 		if !hasPIDs || len(pids) == 0 {
 			log.Debug("no Kube metadata, no local selection criteria. Ignoring")
@@ -223,6 +224,10 @@ func (m *Matcher) matchProcess(obj *ProcessAttrs, p *services.ProcessInfo, a ser
 	}
 	if (a.GetPath().IsSet() || a.GetPathRegexp().IsSet()) && !m.matchByExecutable(p, a) {
 		log.Debug("executable path does not match", "path", a.GetPath(), "pathregexp", a.GetPathRegexp())
+		return false
+	}
+	if a.GetCmdArgs().IsSet() && !m.matchByCommandArgs(p, a) {
+		log.Debug("command line arguments do not match", "path", a.GetPath(), "commandline", a.GetCmdArgs())
 		return false
 	}
 	if a.GetOpenPorts().Len() > 0 && !m.matchByPort(p, a) {
@@ -274,6 +279,13 @@ func (m *Matcher) matchByExecutable(p *services.ProcessInfo, a services.Selector
 
 func (m *Matcher) matchByLanguage(actual *ProcessAttrs, a services.Selector) bool {
 	return a.GetLanguages().MatchString(actual.detectedType.String())
+}
+
+func (m *Matcher) matchByCommandArgs(p *services.ProcessInfo, a services.Selector) bool {
+	if a.GetCmdArgs().IsSet() {
+		return a.GetCmdArgs().MatchString(p.CmdArgs)
+	}
+	return false
 }
 
 func (m *Matcher) matchByAttributes(actual *ProcessAttrs, required services.Selector) bool {
@@ -511,10 +523,16 @@ var processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
 			return nil, fmt.Errorf("can't read /proc/<pid>/fd information: %w", err)
 		}
 	}
+	cmdLine, err := proc.Cmdline()
+	// the command line includes the process name, let's get rid of it.
+	if err == nil {
+		_, cmdLine, _ = strings.Cut(cmdLine, " ")
+	}
 	return &services.ProcessInfo{
 		Pid:       app.PID(proc.Pid),
 		PPid:      app.PID(ppid),
 		ExePath:   exePath,
+		CmdArgs:   cmdLine,
 		OpenPorts: pp.openPorts,
 	}, nil
 }

--- a/pkg/appolly/discover/matcher_test.go
+++ b/pkg/appolly/discover/matcher_test.go
@@ -41,6 +41,11 @@ func TestCriteriaMatcher(t *testing.T) {
   - name: both
     open_ports: 443
     exe_path_regexp: "server"
+  - name: exec-arg
+    exe_path: /bin/python
+    cmd_args: "my-server.py"
+  - name: arg-only
+    cmd_args: "my-server2.py"
 `), &pipeConfig))
 
 	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
@@ -56,8 +61,9 @@ func TestCriteriaMatcher(t *testing.T) {
 		exePath := map[app.PID]string{
 			1: "/bin/weird33", 2: "/bin/weird33", 3: "server",
 			4: "/bin/something", 5: "server", 6: "/bin/clientweird99",
+			7: "/bin/python", 8: "/bin/python", 9: "/bin/frobnitz",
 		}[pp.pid]
-		return &services.ProcessInfo{Pid: pp.pid, ExePath: exePath, OpenPorts: pp.openPorts}, nil
+		return &services.ProcessInfo{Pid: pp.pid, ExePath: exePath, OpenPorts: pp.openPorts, CmdArgs: pp.cmdArgs}, nil
 	}
 	discoveredProcesses.Send([]Event[ProcessAttrs]{
 		{Type: EventCreated, Obj: ProcessAttrs{pid: 1, openPorts: []uint32{1, 2, 3}}}, // pass
@@ -66,15 +72,20 @@ func TestCriteriaMatcher(t *testing.T) {
 		{Type: EventCreated, Obj: ProcessAttrs{pid: 4, openPorts: []uint32{8083}}},    // pass
 		{Type: EventCreated, Obj: ProcessAttrs{pid: 5, openPorts: []uint32{443}}},     // pass
 		{Type: EventCreated, Obj: ProcessAttrs{pid: 6}},                               // pass
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 7, cmdArgs: "my-server.py"}},      // pass
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 8, cmdArgs: "other-server.py"}},   // filter
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 9, cmdArgs: "my-server2.py"}},     // pass
 	})
 
 	matches := testutil.ReadChannel(t, filteredProcesses, testTimeout)
-	require.Len(t, matches, 4)
+	require.Len(t, matches, 6)
 
 	testMatch(t, matches[0], "exec-only", "", services.ProcessInfo{Pid: 1, ExePath: "/bin/weird33", OpenPorts: []uint32{1, 2, 3}})
 	testMatch(t, matches[1], "port-only", "foo", services.ProcessInfo{Pid: 4, ExePath: "/bin/something", OpenPorts: []uint32{8083}})
 	testMatch(t, matches[2], "both", "", services.ProcessInfo{Pid: 5, ExePath: "server", OpenPorts: []uint32{443}})
 	testMatch(t, matches[3], "exec-only", "", services.ProcessInfo{Pid: 6, ExePath: "/bin/clientweird99"})
+	testMatch(t, matches[4], "exec-arg", "", services.ProcessInfo{Pid: 7, ExePath: "/bin/python", CmdArgs: "my-server.py"})
+	testMatch(t, matches[5], "arg-only", "", services.ProcessInfo{Pid: 9, ExePath: "/bin/frobnitz", CmdArgs: "my-server2.py"})
 }
 
 func TestCriteriaMatcherLanguage(t *testing.T) {

--- a/pkg/appolly/discover/typer_test.go
+++ b/pkg/appolly/discover/typer_test.go
@@ -35,6 +35,7 @@ func (d dummyCriterion) RangePodAnnotations() iter.Seq2[string, services.StringM
 func (d dummyCriterion) RangePodLabels() iter.Seq2[string, services.StringMatcher]      { return nil }
 func (d dummyCriterion) IsContainersOnly() bool                                         { return false }
 func (d dummyCriterion) GetPathRegexp() services.StringMatcher                          { return nil }
+func (d dummyCriterion) GetCmdArgs() services.StringMatcher                             { return nil }
 func (d dummyCriterion) GetPIDs() ([]app.PID, bool)                                     { return nil, false }
 func (d dummyCriterion) GetNamespace() string                                           { return d.namespace }
 func (d dummyCriterion) GetExportModes() services.ExportModes                           { return d.export }

--- a/pkg/appolly/discover/watcher_proc.go
+++ b/pkg/appolly/discover/watcher_proc.go
@@ -59,6 +59,7 @@ type ProcessAttrs struct {
 	podAnnotations map[string]string
 	processAge     time.Duration
 	detectedType   svc.InstrumentableType
+	cmdArgs        string
 }
 
 func wplog() *slog.Logger {

--- a/pkg/appolly/services/attr_glob.go
+++ b/pkg/appolly/services/attr_glob.go
@@ -28,6 +28,7 @@ func (dc GlobDefinitionCriteria) Validate() error {
 			!dc[i].Path.IsSet() &&
 			!dc[i].Languages.IsSet() &&
 			len(dc[i].PIDs) == 0 &&
+			!dc[i].CmdArgs.IsSet() &&
 			len(dc[i].Metadata) == 0 &&
 			len(dc[i].PodLabels) == 0 &&
 			len(dc[i].PodAnnotations) == 0 {
@@ -95,6 +96,9 @@ type GlobAttributes struct {
 
 	// Path allows defining the regular expression matching the full executable path.
 	Path GlobAttr `yaml:"exe_path"`
+
+	// CmdArgs allows to limit by matching command line arguments
+	CmdArgs GlobAttr `yaml:"cmd_args"`
 
 	// Metadata stores other attributes, such as Kubernetes object metadata
 	Metadata MetadataGlobMap `yaml:",inline" mapstructure:",remain"`
@@ -192,6 +196,7 @@ func (ga *GlobAttributes) GetName() string                        { return ga.Na
 func (ga *GlobAttributes) GetNamespace() string                   { return ga.Namespace }
 func (ga *GlobAttributes) GetPath() StringMatcher                 { return &ga.Path }
 func (ga *GlobAttributes) GetLanguages() StringMatcher            { return &ga.Languages }
+func (ga *GlobAttributes) GetCmdArgs() StringMatcher              { return &ga.CmdArgs }
 func (ga *GlobAttributes) GetPathRegexp() StringMatcher           { return nilMatcher{} }
 func (ga *GlobAttributes) GetOpenPorts() *IntEnum                 { return &ga.OpenPorts }
 func (ga *GlobAttributes) GetPIDs() ([]app.PID, bool)             { return ga.pids() }

--- a/pkg/appolly/services/attr_regex.go
+++ b/pkg/appolly/services/attr_regex.go
@@ -96,6 +96,8 @@ type RegexSelector struct {
 	// Language allows defining services to instrument based on the
 	// programming language they are written in.
 	Languages RegexpAttr `yaml:"languages"`
+	// CmdArgs allows matching by command line arguments
+	CmdArgs RegexpAttr `yaml:"cmd_args"`
 	// PathRegexp is deprecated but kept here for backwards compatibility with Beyla 1.0.x.
 
 	// Deprecated: Please use Path (exe_path YAML attribute)
@@ -199,6 +201,7 @@ func (a *RegexSelector) GetLanguages() StringMatcher            { return &a.Lang
 func (a *RegexSelector) GetPathRegexp() StringMatcher           { return &a.PathRegexp }
 func (a *RegexSelector) GetOpenPorts() *IntEnum                 { return &a.OpenPorts }
 func (a *RegexSelector) GetPIDs() ([]app.PID, bool)             { return a.pids() }
+func (a *RegexSelector) GetCmdArgs() StringMatcher              { return &a.CmdArgs }
 func (a *RegexSelector) IsContainersOnly() bool                 { return a.ContainersOnly }
 func (a *RegexSelector) MetricsConfig() perapp.SvcMetricsConfig { return a.Metrics }
 func (a *RegexSelector) RangeMetadata() iter.Seq2[string, StringMatcher] {

--- a/pkg/appolly/services/criteria.go
+++ b/pkg/appolly/services/criteria.go
@@ -57,6 +57,7 @@ type ProcessInfo struct {
 	Pid       app.PID
 	PPid      app.PID
 	ExePath   string
+	CmdArgs   string
 	OpenPorts []uint32
 }
 
@@ -170,6 +171,7 @@ type Selector interface {
 	GetLanguages() StringMatcher
 	// GetPIDs returns the list of target PIDs and true when this selector has PID criteria (analogous to OpenPorts).
 	GetPIDs() ([]app.PID, bool)
+	GetCmdArgs() StringMatcher
 	IsContainersOnly() bool
 	RangeMetadata() iter.Seq2[string, StringMatcher]
 	RangePodLabels() iter.Seq2[string, StringMatcher]


### PR DESCRIPTION
This allows to limit process selection by command line argument. E.g.:
```
discovery:
  instrument:
    - exe_path: "*python*"
      cmd_args: "server*.py"
```

Especially in standalone case there may be a lot of Python processes running (on my RHEL one there are currently 3 system services), that should not be observed. 