### PR TITLE
fix(ci): give time for cosign sigs to propagate

### DIFF
--- a/.github/workflows/generator-image.yml
+++ b/.github/workflows/generator-image.yml
@@ -114,6 +114,10 @@ jobs:
           images="${{ env.REGISTRY }}/${{ env.IMAGE }}:${IMGTAG}@${DIGEST}"
           images+=" ${{ env.REGISTRY }}/${{ env.IMAGE }}:latest@${DIGEST}"
           cosign sign --yes ${images}
-          cosign verify ${images} \
-            --certificate-identity-regexp='.*' \
-            --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+          for i in 1 2 3 4 5; do
+            cosign verify ${images} \
+              --certificate-identity-regexp='.*' \
+              --certificate-oidc-issuer='https://token.actions.githubusercontent.com' && break
+            echo "Verify attempt $i failed, retrying in 10s..."
+            sleep 10
+          done

--- a/.github/workflows/publish_dockerhub_k8s_cache_main.yml
+++ b/.github/workflows/publish_dockerhub_k8s_cache_main.yml
@@ -174,6 +174,10 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           cosign sign --yes ${images}
-          cosign verify ${images} \
-            --certificate-identity-regexp='.*' \
-            --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+          for i in 1 2 3 4 5; do
+            cosign verify ${images} \
+              --certificate-identity-regexp='.*' \
+              --certificate-oidc-issuer='https://token.actions.githubusercontent.com' && break
+            echo "Verify attempt $i failed, retrying in 10s..."
+            sleep 10
+          done

--- a/.github/workflows/publish_dockerhub_main.yml
+++ b/.github/workflows/publish_dockerhub_main.yml
@@ -174,7 +174,11 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           cosign sign --yes ${images}
-          cosign verify ${images} \
-            --certificate-identity-regexp='.*' \
-            --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+          for i in 1 2 3 4 5; do
+            cosign verify ${images} \
+              --certificate-identity-regexp='.*' \
+              --certificate-oidc-issuer='https://token.actions.githubusercontent.com' && break
+            echo "Verify attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
 


### PR DESCRIPTION
The docker image signatures are failing to verify in CI. This might be due to the verification happening before the signatures are actually available for verification, so add a delay and retry loop to deal with the eventual consistency.

```
Signing artifact...
Signing artifact...
Error: no signatures found
error during command execution: no signatures found
Error: Process completed with exit code 10.
```

- https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/22330772312/job/64612709552