### PR TITLE
ci: remove cosign verify

### DIFF
--- a/.github/workflows/generator-image.yml
+++ b/.github/workflows/generator-image.yml
@@ -114,18 +114,3 @@ jobs:
           images="${{ env.REGISTRY }}/${{ env.IMAGE }}:${IMGTAG}@${DIGEST}"
           images+=" ${{ env.REGISTRY }}/${{ env.IMAGE }}:latest@${DIGEST}"
           cosign sign --yes ${images}
-          verified=false
-          for i in 1 2 3 4 5; do
-            if cosign verify ${images} \
-              --certificate-identity-regexp='.*' \
-              --certificate-oidc-issuer='https://token.actions.githubusercontent.com'; then
-              verified=true
-              break
-            fi
-            echo "Verify attempt $i failed, retrying in 60s..."
-            sleep 60
-          done
-          if [ "$verified" != "true" ]; then
-            echo "Failed to verify cosign signatures after 5 attempts"
-            exit 1
-          fi

--- a/.github/workflows/publish_dockerhub_k8s_cache_main.yml
+++ b/.github/workflows/publish_dockerhub_k8s_cache_main.yml
@@ -174,18 +174,3 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           cosign sign --yes ${images}
-          verified=false
-          for i in 1 2 3 4 5; do
-            if cosign verify ${images} \
-              --certificate-identity-regexp='.*' \
-              --certificate-oidc-issuer='https://token.actions.githubusercontent.com'; then
-              verified=true
-              break
-            fi
-            echo "Verify attempt $i failed, retrying in 60s..."
-            sleep 60
-          done
-          if [ "$verified" != "true" ]; then
-            echo "Failed to verify cosign signatures after 5 attempts"
-            exit 1
-          fi

--- a/.github/workflows/publish_dockerhub_main.yml
+++ b/.github/workflows/publish_dockerhub_main.yml
@@ -174,19 +174,4 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           cosign sign --yes ${images}
-          verified=false
-          for i in 1 2 3 4 5; do
-            if cosign verify ${images} \
-              --certificate-identity-regexp='.*' \
-              --certificate-oidc-issuer='https://token.actions.githubusercontent.com'; then
-              verified=true
-              break
-            fi
-            echo "Verify attempt $i failed, retrying in 60s..."
-            sleep 60
-          done
-          if [ "$verified" != "true" ]; then
-            echo "Failed to verify cosign signatures after 5 attempts"
-            exit 1
-          fi
 


### PR DESCRIPTION
@pellared the cosign verify step is still failing in main, even after I added an auto-retry in #1356. It looks green but that's because the actual status was lost by the for loop.

Removing `cosign verify` (see comments below).