### PR TITLE
ci: tentative fix for the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,6 @@ on:
         required: true
         type: string
 
-# https://docs.zizmor.sh/audits/#excessive-permissions
-permissions: {}
-
 jobs:
   # Validate tag format before proceeding with release.
   validate-tag:


### PR DESCRIPTION
AI explanation:

```
The Problem
The top-level permissions: {} sets all permissions to none for the entire workflow. In GitHub Actions, job-level permissions can only restrict, not expand, beyond the workflow-level ceiling. So even though individual jobs declare permissions like contents: read or checks: write, those declarations are blocked by the {} ceiling above them.

This is the line causing the issue:
# https://docs.zizmor.sh/audits/#excessive-permissions
permissions: {}

The Fix
Remove the top-level permissions: {}. Since every job in this workflow already has its own explicit permissions: block, the per-job declarations alone are sufficient to enforce least-privilege — which is exactly what the zizmor audit recommends. The top-level block is redundant here and actively harmful.
REMOVE this block entirely:
# permissions: {}

Each job already defines only what it needs, for example:
validate-tag:
  permissions:
    contents: read   # ✅ this is now respected

release:
  permissions:
    contents: write  # ✅ this is now respected

Why This Is Still Secure
The zizmor excessive-permissions audit is satisfied as long as each job declares its own minimal permissions — the top-level block isn't required for that. Its only unique effect here is preventing the per-job grants from working, which is the opposite of the intent. Removing it while keeping all job-level permissions: blocks intact gives you the same security posture without the breakage.
```

Fixes: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/22405505860