### PR TITLE
Fix rubytestserver/testapi image build

### DIFF
--- a/.github/workflows/ghcr_publish_testing_images.yml
+++ b/.github/workflows/ghcr_publish_testing_images.yml
@@ -90,6 +90,22 @@ jobs:
             echo "imgtag=$OVERRIDE_IMG_TAG" >> $GITHUB_OUTPUT
           fi
 
+      - name: go
+        uses: ./.github/actions/integration-test-image-build
+        with:
+          labels: ${{ steps.meta.outputs.labels }}
+          tag-version: ${{ steps.image_tag.outputs.imgtag }}
+          tag-id: go
+          file: internal/test/integration/components/testserver/Dockerfile
+
+      - name: go-http-client
+        uses: ./.github/actions/integration-test-image-build
+        with:
+          labels: ${{ steps.meta.outputs.labels }}
+          tag-version: ${{ steps.image_tag.outputs.imgtag }}
+          tag-id: go-http-client
+          file: internal/test/integration/components/httppinger/Dockerfile
+
       - name: rust
         uses: ./.github/actions/integration-test-image-build
         with:
@@ -146,14 +162,6 @@ jobs:
           tag-id: node
           file: internal/test/integration/components/nodejsserver/Dockerfile
 
-      - name: go
-        uses: ./.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: go
-          file: internal/test/integration/components/testserver/Dockerfile
-
       - name: python
         uses: ./.github/actions/integration-test-image-build
         with:
@@ -161,11 +169,3 @@ jobs:
           tag-version: ${{ steps.image_tag.outputs.imgtag }}
           tag-id: python
           file: internal/test/integration/components/pythonserver/Dockerfile
-
-      - name: go-http-client
-        uses: ./.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: go-http-client
-          file: internal/test/integration/components/httppinger/Dockerfile

--- a/internal/test/integration/components/rubytestserver/testapi/.gitignore
+++ b/internal/test/integration/components/rubytestserver/testapi/.gitignore
@@ -1,0 +1,5 @@
+cache
+extensions
+gems
+plugins
+specifications

--- a/internal/test/integration/components/rubytestserver/testapi/Dockerfile
+++ b/internal/test/integration/components/rubytestserver/testapi/Dockerfile
@@ -3,23 +3,29 @@ FROM ruby:3.4.8@sha256:a02a5f7b2412b75ac6ad4f14b253a33d59626b110b3e3d151cf6b1ddf
 # Set the working directory to /build
 WORKDIR /build
 
+ENV BUNDLE_PATH=/usr/local/bundle
+
 # Copy the source code into the image for building
 COPY internal/test/integration/components/rubytestserver/testapi .
 
-# Install Rails 
-RUN gem install rails
-RUN gem install bundler
+RUN gem update --system
+RUN gem install bundler -v 4.0.7
 RUN bundle install
-RUN bundle exec rake app:update:bin
-RUN bin/rails db:migrate
-
-EXPOSE 3040
+RUN bundle binstubs railties
+RUN bundle exec rake db:migrate
 
 FROM ruby:3.4.8-slim@sha256:dcc535e858eeeac1f70eaf8c39ef7ee257b183a9e495cc5a9ef3e340eadf2d3d
 
-WORKDIR /
+RUN gem update --system
+
+WORKDIR /build
+
+ENV BUNDLE_PATH=/usr/local/bundle
+
 COPY --from=builder /build .
 COPY --from=builder /usr/local/bundle /usr/local/bundle
 
+EXPOSE 3040
+
 # Run the node app
-CMD [ "rails", "server", "-p", "3040", "-b", "0.0.0.0" ]
+CMD [ "bundle", "exec", "rails", "server", "-p", "3040", "-b", "0.0.0.0" ]

--- a/internal/test/integration/components/rubytestserver/testapi/Dockerfile_tls
+++ b/internal/test/integration/components/rubytestserver/testapi/Dockerfile_tls
@@ -3,23 +3,29 @@ FROM ruby:3.4.8@sha256:a02a5f7b2412b75ac6ad4f14b253a33d59626b110b3e3d151cf6b1ddf
 # Set the working directory to /build
 WORKDIR /build
 
+ENV BUNDLE_PATH=/usr/local/bundle
+
 # Copy the source code into the image for building
 COPY internal/test/integration/components/rubytestserver/testapi .
 
-# Install Rails
-RUN gem install rails
-RUN gem install bundler
+RUN gem update --system
+RUN gem install bundler -v 4.0.7
 RUN bundle install
-RUN bundle exec rake app:update:bin
-RUN bin/rails db:migrate
-
-EXPOSE 3043
+RUN bundle binstubs railties
+RUN bundle exec rake db:migrate
 
 FROM ruby:3.4.8-slim@sha256:dcc535e858eeeac1f70eaf8c39ef7ee257b183a9e495cc5a9ef3e340eadf2d3d
 
-WORKDIR /
+RUN gem update --system
+
+WORKDIR /build
+
+ENV BUNDLE_PATH=/usr/local/bundle
+
 COPY --from=builder /build .
 COPY --from=builder /usr/local/bundle /usr/local/bundle
 
+EXPOSE 3043
+
 # Run the node app
-CMD [ "rails", "server", "-b", "ssl://0.0.0.0:3043?key=config/key.pem&cert=config/cert.pem" ]
+CMD [ "bundle", "exec", "rails", "server", "-b", "ssl://0.0.0.0:3043?key=config/key.pem&cert=config/cert.pem" ]

--- a/internal/test/integration/components/rubytestserver/testapi/Gemfile
+++ b/internal/test/integration/components/rubytestserver/testapi/Gemfile
@@ -10,7 +10,7 @@ gem "rails", "~> 7.2.0"
 gem "sqlite3", "~> 1.4"
 
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "~> 5.0"
+gem "puma", "~> 6.0"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "jbuilder"

--- a/internal/test/integration/components/rubytestserver/testapi/Gemfile.lock
+++ b/internal/test/integration/components/rubytestserver/testapi/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     psych (5.2.6)
       date
       stringio
-    puma (5.6.9)
+    puma (6.6.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.4)
@@ -208,13 +208,13 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
-  puma (~> 5.0)
+  puma (~> 6.0)
   rails (~> 7.2.0)
   sqlite3 (~> 1.4)
   tzinfo-data
 
 RUBY VERSION
-   ruby 3.4.8p72
+  ruby 3.4.8p72
 
 BUNDLED WITH
-   2.7.2
+  4.0.7

--- a/internal/test/integration/components/rubytestserver/testapi/db/schema.rb
+++ b/internal/test/integration/components/rubytestserver/testapi/db/schema.rb
@@ -10,12 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_26_101807) do
+ActiveRecord::Schema[7.2].define(version: 2023_06_26_101807) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
 end


### PR DESCRIPTION
Auto-updated ruby versions led to breaking changes that had to be manually fixed to fix the publication of testing images.