### PR TITLE
Fix Java TLS bugs

### DIFF
--- a/bpf/generictracer/http2_grpc.h
+++ b/bpf/generictracer/http2_grpc.h
@@ -55,16 +55,6 @@ static __always_inline u8 read_http2_grpc_frame_header(frame_header_t *frame,
     return 1;
 }
 
-static __always_inline u8 is_settings_frame(unsigned char *p, u32 len) {
-    frame_header_t frame = {0};
-
-    if (!read_http2_grpc_frame_header(&frame, p, len)) {
-        return 0;
-    }
-
-    return frame.type == FrameSettings && !frame.stream_id;
-}
-
 static __always_inline u8 is_headers_frame(const frame_header_t *frame) {
     return frame->type == FrameHeaders && frame->stream_id;
 }
@@ -78,7 +68,7 @@ static __always_inline u8 has_preface(unsigned char *p, u32 len) {
 }
 
 static __always_inline u8 is_http2_or_grpc(unsigned char *p, u32 len) {
-    return has_preface(p, len) || is_settings_frame(p, len);
+    return has_preface(p, len);
 }
 
 static __always_inline u8 http_grpc_stream_ended(const frame_header_t *frame) {

--- a/bpf/generictracer/java_tls.c
+++ b/bpf/generictracer/java_tls.c
@@ -140,6 +140,8 @@ int BPF_KPROBE(obi_kprobe_sys_ioctl) {
 
     if (len > 0) {
         void *buf = arg + 1 + sizeof(connection_info_t) + sizeof(u32);
+        const u64 zero = 0;
+        bpf_map_update_elem(&active_ssl_connections, &p_conn, &zero, BPF_ANY);
         handle_buf_with_connection(ctx, &p_conn, buf, len, WITH_SSL, op, orig_dport);
     }
 

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -344,6 +344,9 @@ cleanup:
 static __always_inline void
 tcp_send_ssl_check(u64 id, void *ssl, pid_connection_info_t *p_conn, u16 orig_dport) {
     bpf_dbg_printk("id=%d, ssl=%llx", id, ssl);
+    if (!ssl) {
+        return;
+    }
     ssl_pid_connection_info_t *s_conn = bpf_map_lookup_elem(&ssl_to_conn, &ssl);
     if (s_conn) {
         finish_possible_delayed_tls_http_request(&s_conn->p_conn, ssl);


### PR DESCRIPTION
This PR fixes two separate issues related to Java TLS with MySQL. The problem is intermittent and depends on the payload, but it can be exposed with this DEMO application https://github.com/fstab/2026-grafana-and-friends-meetup.

Essentially, we had two issues:
1. The Java TLS code didn't mark the connection as active ssl connection. This can cause problems with the accumulation of buffers in the mysql BPF detector. We would see proper traffic, but later the encrypted traffic would follow and we'd tack it on. We'd also be parsing TLS buffers that make no sense.
2. Some parts of the MySQL protocol were identified as HTTP2 settings frame. When I wrote the HTTP2 code in the generic tracer initially we had no backup userspace path for HTTP2 detection, so I added code to detect the settings frame as well as the HTTP2 preamble. The problem is that random other protocol bytes can look like a settings frame, in this case MySQL and randomly some SQL statements will not show. Since we have the userspace backup path now, this is not needed anymore and it will also eliminate the false positives.