### PR TITLE
fix: set telemetry.sdk.name to underlying sdk and add telemetry.distro.name

### DIFF
--- a/internal/test/integration/red_test_rust.go
+++ b/internal/test/integration/red_test_rust.go
@@ -112,7 +112,7 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url, comm, namespace string,
 	sd = jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.scope.name", Type: "string", Value: "go.opentelemetry.io/obi"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "rust"},
-		{Key: "telemetry.sdk.name", Type: "string", Value: "opentelemetry-go"},
+		{Key: "telemetry.sdk.name", Type: "string", Value: "opentelemetry"},
 		{Key: "telemetry.distro.name", Type: "string", Value: "opentelemetry-ebpf-instrumentation"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 		serviceInstance,

--- a/internal/test/integration/traces_test.go
+++ b/internal/test/integration/traces_test.go
@@ -149,7 +149,7 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 	jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.scope.name", Type: "string", Value: "go.opentelemetry.io/obi"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "go"},
-		{Key: "telemetry.sdk.name", Type: "string", Value: "opentelemetry-go"},
+		{Key: "telemetry.sdk.name", Type: "string", Value: "opentelemetry"},
 		{Key: "telemetry.distro.name", Type: "string", Value: "opentelemetry-ebpf-instrumentation"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 		serviceInstance,
@@ -362,7 +362,7 @@ func testHTTPTracesKProbes(t *testing.T) {
 	jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.scope.name", Type: "string", Value: "go.opentelemetry.io/obi"},
 		{Key: "telemetry.sdk.language", Type: "string", Value: "nodejs"},
-		{Key: "telemetry.sdk.name", Type: "string", Value: "opentelemetry-go"},
+		{Key: "telemetry.sdk.name", Type: "string", Value: "opentelemetry"},
 		{Key: "telemetry.distro.name", Type: "string", Value: "opentelemetry-ebpf-instrumentation"},
 		{Key: "service.namespace", Type: "string", Value: "integration-test"},
 		serviceInstance,

--- a/pkg/appolly/instrumenter_test.go
+++ b/pkg/appolly/instrumenter_test.go
@@ -108,6 +108,8 @@ func TestBasicPipeline(t *testing.T) {
 		delete(event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 		assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
 		delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+		assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
+		delete(event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
 		if event.Name == "http.server.request.duration" {
 			break
 		}
@@ -136,7 +138,7 @@ func TestBasicPipeline(t *testing.T) {
 			string(semconv.ServiceNameKey):          "foo-svc",
 			string(semconv.ServiceNamespaceKey):     "ns",
 			string(semconv.TelemetrySDKLanguageKey): "go",
-			string(semconv.TelemetrySDKNameKey):     "opentelemetry-go",
+			string(semconv.TelemetrySDKNameKey):     "opentelemetry",
 			string(semconv.TelemetryDistroNameKey):  "opentelemetry-ebpf-instrumentation",
 			string(semconv.OSTypeKey):               "linux",
 		},
@@ -329,6 +331,8 @@ func TestRouteConsolidation(t *testing.T) {
 		delete(event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 		assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
 		delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+		assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
+		delete(event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
 	}
 	assert.Equal(t, collector.MetricRecord{
 		Name: "http.server.request.duration",
@@ -348,7 +352,7 @@ func TestRouteConsolidation(t *testing.T) {
 			string(semconv.ServiceNameKey):          "svc-1",
 			string(semconv.ServiceNamespaceKey):     "ns",
 			string(semconv.TelemetrySDKLanguageKey): "go",
-			string(semconv.TelemetrySDKNameKey):     "opentelemetry-go",
+			string(semconv.TelemetrySDKNameKey):     "opentelemetry",
 			string(semconv.TelemetryDistroNameKey):  "opentelemetry-ebpf-instrumentation",
 			string(semconv.OSTypeKey):               "linux",
 		},
@@ -375,7 +379,7 @@ func TestRouteConsolidation(t *testing.T) {
 			string(semconv.ServiceNameKey):          "svc-1",
 			string(semconv.ServiceNamespaceKey):     "ns",
 			string(semconv.TelemetrySDKLanguageKey): "go",
-			string(semconv.TelemetrySDKNameKey):     "opentelemetry-go",
+			string(semconv.TelemetrySDKNameKey):     "opentelemetry",
 			string(semconv.TelemetryDistroNameKey):  "opentelemetry-ebpf-instrumentation",
 			string(semconv.OSTypeKey):               "linux",
 		},
@@ -402,7 +406,7 @@ func TestRouteConsolidation(t *testing.T) {
 			string(semconv.ServiceNameKey):          "svc-1",
 			string(semconv.ServiceNamespaceKey):     "ns",
 			string(semconv.TelemetrySDKLanguageKey): "go",
-			string(semconv.TelemetrySDKNameKey):     "opentelemetry-go",
+			string(semconv.TelemetrySDKNameKey):     "opentelemetry",
 			string(semconv.TelemetryDistroNameKey):  "opentelemetry-ebpf-instrumentation",
 			string(semconv.OSTypeKey):               "linux",
 		},
@@ -449,6 +453,8 @@ func TestGRPCPipeline(t *testing.T) {
 	delete(event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
 	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
 
 	assert.Equal(t, collector.MetricRecord{
 		Name: "rpc.server.duration",
@@ -468,7 +474,7 @@ func TestGRPCPipeline(t *testing.T) {
 			string(semconv.HostNameKey):             "the-host",
 			string(semconv.ServiceNameKey):          "grpc-svc",
 			string(semconv.TelemetrySDKLanguageKey): "go",
-			string(semconv.TelemetrySDKNameKey):     "opentelemetry-go",
+			string(semconv.TelemetrySDKNameKey):     "opentelemetry",
 			string(semconv.TelemetryDistroNameKey):  "opentelemetry-ebpf-instrumentation",
 			string(semconv.OSTypeKey):               "linux",
 		},
@@ -551,6 +557,8 @@ func TestBasicPipelineInfo(t *testing.T) {
 	delete(event.ResourceAttributes, string(semconv.ServiceInstanceIDKey))
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
 	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
 
 	assert.Equal(t, collector.MetricRecord{
 		Name: "http.server.request.duration",
@@ -570,7 +578,7 @@ func TestBasicPipelineInfo(t *testing.T) {
 			string(semconv.HostNameKey):             "the-host",
 			string(semconv.ServiceNameKey):          "comm",
 			string(semconv.TelemetrySDKLanguageKey): "go",
-			string(semconv.TelemetrySDKNameKey):     "opentelemetry-go",
+			string(semconv.TelemetrySDKNameKey):     "opentelemetry",
 			string(semconv.TelemetryDistroNameKey):  "opentelemetry-ebpf-instrumentation",
 			string(semconv.OSTypeKey):               "linux",
 		},
@@ -741,6 +749,8 @@ func getHostname() string {
 func matchTraceEvent(t require.TestingT, name string, event collector.TraceRecord) {
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
 	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
 
 	assert.NotEmpty(t, event.Attributes["span_id"])
 	assert.Equal(t, collector.TraceRecord{
@@ -763,7 +773,7 @@ func matchTraceEvent(t require.TestingT, name string, event collector.TraceRecor
 			string(semconv.ServiceNameKey):          "bar-svc",
 			string(semconv.ServiceNamespaceKey):     "ns",
 			string(semconv.TelemetrySDKLanguageKey): "go",
-			string(semconv.TelemetrySDKNameKey):     "opentelemetry-go",
+			string(semconv.TelemetrySDKNameKey):     "opentelemetry",
 			string(semconv.TelemetryDistroNameKey):  "opentelemetry-ebpf-instrumentation",
 			string(semconv.OSTypeKey):               "linux",
 			string(semconv.OTelScopeNameKey):        "go.opentelemetry.io/obi",
@@ -776,6 +786,8 @@ func matchTraceEvent(t require.TestingT, name string, event collector.TraceRecor
 func matchInnerTraceEvent(t require.TestingT, name string, event collector.TraceRecord) {
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
 	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
 
 	assert.NotEmpty(t, event.Attributes["span_id"])
 	assert.Equal(t, collector.TraceRecord{
@@ -790,7 +802,7 @@ func matchInnerTraceEvent(t require.TestingT, name string, event collector.Trace
 			string(semconv.ServiceNameKey):          "bar-svc",
 			string(semconv.ServiceNamespaceKey):     "ns",
 			string(semconv.TelemetrySDKLanguageKey): "go",
-			string(semconv.TelemetrySDKNameKey):     "opentelemetry-go",
+			string(semconv.TelemetrySDKNameKey):     "opentelemetry",
 			string(semconv.TelemetryDistroNameKey):  "opentelemetry-ebpf-instrumentation",
 			string(semconv.OSTypeKey):               "linux",
 			string(semconv.OTelScopeNameKey):        "go.opentelemetry.io/obi",
@@ -803,6 +815,8 @@ func matchInnerTraceEvent(t require.TestingT, name string, event collector.Trace
 func matchGRPCTraceEvent(t *testing.T, name string, event collector.TraceRecord) {
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
 	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
 
 	assert.Equal(t, collector.TraceRecord{
 		Name: name,
@@ -821,7 +835,7 @@ func matchGRPCTraceEvent(t *testing.T, name string, event collector.TraceRecord)
 			string(semconv.HostNameKey):             "the-host",
 			string(semconv.ServiceNameKey):          "svc",
 			string(semconv.TelemetrySDKLanguageKey): "go",
-			string(semconv.TelemetrySDKNameKey):     "opentelemetry-go",
+			string(semconv.TelemetrySDKNameKey):     "opentelemetry",
 			string(semconv.TelemetryDistroNameKey):  "opentelemetry-ebpf-instrumentation",
 			string(semconv.OSTypeKey):               "linux",
 			string(semconv.OTelScopeNameKey):        "go.opentelemetry.io/obi",
@@ -833,6 +847,8 @@ func matchGRPCTraceEvent(t *testing.T, name string, event collector.TraceRecord)
 func matchInnerGRPCTraceEvent(t *testing.T, name string, event collector.TraceRecord) {
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
 	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
 
 	assert.Equal(t, collector.TraceRecord{
 		Name: name,
@@ -845,7 +861,7 @@ func matchInnerGRPCTraceEvent(t *testing.T, name string, event collector.TraceRe
 			string(semconv.HostNameKey):             "the-host",
 			string(semconv.ServiceNameKey):          "svc",
 			string(semconv.TelemetrySDKLanguageKey): "go",
-			string(semconv.TelemetrySDKNameKey):     "opentelemetry-go",
+			string(semconv.TelemetrySDKNameKey):     "opentelemetry",
 			string(semconv.TelemetryDistroNameKey):  "opentelemetry-ebpf-instrumentation",
 			string(semconv.OSTypeKey):               "linux",
 			string(semconv.OTelScopeNameKey):        "go.opentelemetry.io/obi",
@@ -885,6 +901,8 @@ func newHTTPInfo(method, path, peer string, status int) []request.Span {
 func matchInfoEvent(t *testing.T, name string, event collector.TraceRecord) {
 	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
 	delete(event.ResourceAttributes, string(semconv.TelemetrySDKVersionKey))
+	assert.NotEmpty(t, event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
+	delete(event.ResourceAttributes, string(semconv.TelemetryDistroVersionKey))
 
 	assert.Equal(t, collector.TraceRecord{
 		Name: name,
@@ -905,7 +923,7 @@ func matchInfoEvent(t *testing.T, name string, event collector.TraceRecord) {
 			string(semconv.HostNameKey):             "the-host",
 			string(semconv.ServiceNameKey):          "comm",
 			string(semconv.TelemetrySDKLanguageKey): "go",
-			string(semconv.TelemetrySDKNameKey):     "opentelemetry-go",
+			string(semconv.TelemetrySDKNameKey):     "opentelemetry",
 			string(semconv.TelemetryDistroNameKey):  "opentelemetry-ebpf-instrumentation",
 			string(semconv.OSTypeKey):               "linux",
 			string(semconv.OTelScopeNameKey):        "go.opentelemetry.io/obi",

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -6,10 +6,13 @@
 package attr // import "go.opentelemetry.io/obi/pkg/export/attributes/names"
 
 import (
+	"runtime/debug"
 	"strings"
 
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
+
+	"go.opentelemetry.io/obi/pkg/buildinfo"
 )
 
 // Name of an attribute. This is the common internal representation of a metric attribute name,
@@ -96,10 +99,23 @@ const (
 // as custom metrics, since at the moment they don't follow any semantic convention for them.
 // This value can be overridden when OBI is vendored as a library (e.g. from the OTEL collector)
 var (
-	VendorPrefix        = "obi"
-	VendorSDKName       = "opentelemetry-go"
-	TelemetryDistroName = "opentelemetry-ebpf-instrumentation"
+	VendorPrefix           = "obi"
+	VendorSDKName          = "opentelemetry"
+	VendorSDKVersion       = "unknown"
+	TelemetryDistroName    = "opentelemetry-ebpf-instrumentation"
+	TelemetryDistroVersion = buildinfo.Version
 )
+
+func init() {
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, dep := range info.Deps {
+			if dep.Path == "go.opentelemetry.io/otel/sdk" {
+				VendorSDKVersion = dep.Version
+				return
+			}
+		}
+	}
+}
 
 var OBIIP = Name("obi.ip")
 

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -779,7 +779,9 @@ func (mr *MetricsReporter) tracesResourceAttributes(service *svc.Attrs) attribut
 		semconv.ServiceNamespace(service.UID.Namespace),
 		semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage.String()),
 		semconv.TelemetrySDKNameKey.String(attr.VendorSDKName),
+		semconv.TelemetrySDKVersion(attr.VendorSDKVersion),
 		semconv.TelemetryDistroName(attr.TelemetryDistroName),
+		semconv.TelemetryDistroVersion(attr.TelemetryDistroVersion),
 		request.SourceMetric(attr.VendorPrefix),
 		semconv.OSTypeKey.String("linux"),
 	}

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -246,7 +246,9 @@ func newResourceInternal(nodeMeta *meta.NodeMeta) *resource.Resource {
 		semconv.ServiceInstanceID(uuid.New().String()),
 		semconv.TelemetrySDKLanguageKey.String(semconv.TelemetrySDKLanguageGo.Value.AsString()),
 		semconv.TelemetrySDKNameKey.String(attr.VendorSDKName),
+		semconv.TelemetrySDKVersion(attr.VendorSDKVersion),
 		semconv.TelemetryDistroName(attr.TelemetryDistroName),
+		semconv.TelemetryDistroVersion(attr.TelemetryDistroVersion),
 		semconv.HostID(nodeMeta.HostID),
 	}
 

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -255,7 +255,9 @@ func (mr *SvcGraphMetricsReporter) tracesResourceAttributes(service *svc.Attrs) 
 		semconv.ServiceNamespace(service.UID.Namespace),
 		semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage.String()),
 		semconv.TelemetrySDKNameKey.String(attr.VendorSDKName),
+		semconv.TelemetrySDKVersion(attr.VendorSDKVersion),
 		semconv.TelemetryDistroName(attr.TelemetryDistroName),
+		semconv.TelemetryDistroVersion(attr.TelemetryDistroVersion),
 		request.SourceMetric(attr.VendorPrefix),
 		semconv.OSTypeKey.String("linux"),
 	}

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -29,7 +29,6 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
-	"go.opentelemetry.io/obi/pkg/buildinfo"
 	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
@@ -108,10 +107,10 @@ func GetResourceAttrs(nodeMeta *meta.NodeMeta, service *svc.Attrs) []attribute.K
 		// so the service is visible in the ServicesList
 		// This attribute also allows that App O11y plugin shows this app as a Go application.
 		semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage.String()),
-		// We set the SDK name as OBI, so we can distinguish OBI generated metrics from other SDKs
 		semconv.TelemetrySDKNameKey.String(attr.VendorSDKName),
-		semconv.TelemetrySDKVersion(buildinfo.Version),
+		semconv.TelemetrySDKVersion(attr.VendorSDKVersion),
 		semconv.TelemetryDistroName(attr.TelemetryDistroName),
+		semconv.TelemetryDistroVersion(attr.TelemetryDistroVersion),
 		semconv.HostName(service.HostName),
 		semconv.HostID(nodeMeta.HostID),
 		semconv.OSTypeLinux,

--- a/pkg/export/otel/otelcfg/common_test.go
+++ b/pkg/export/otel/otelcfg/common_test.go
@@ -235,7 +235,7 @@ func TestGetFilteredResourceAttrs(t *testing.T) {
 			name: "No filtering configuration",
 			baseAttrs: []attribute.KeyValue{
 				attribute.String("service.name", "test-service"),
-				attribute.String("telemetry.sdk.name", "opentelemetry-go"),
+				attribute.String("telemetry.sdk.name", "opentelemetry"),
 				attribute.String("telemetry.distro.name", "opentelemetry-ebpf-instrumentation"),
 			},
 			attrSelector: attributes.Selection{},
@@ -256,7 +256,7 @@ func TestGetFilteredResourceAttrs(t *testing.T) {
 			name: "With filtering configuration excluding process.command_args",
 			baseAttrs: []attribute.KeyValue{
 				attribute.String("service.name", "test-service"),
-				attribute.String("telemetry.sdk.name", "opentelemetry-go"),
+				attribute.String("telemetry.sdk.name", "opentelemetry"),
 				attribute.String("telemetry.distro.name", "opentelemetry-ebpf-instrumentation"),
 			},
 			attrSelector: attributes.Selection{
@@ -283,7 +283,7 @@ func TestGetFilteredResourceAttrs(t *testing.T) {
 			name: "With filtering configuration using glob patterns",
 			baseAttrs: []attribute.KeyValue{
 				attribute.String("service.name", "test-service"),
-				attribute.String("telemetry.sdk.name", "opentelemetry-go"),
+				attribute.String("telemetry.sdk.name", "opentelemetry"),
 				attribute.String("telemetry.distro.name", "opentelemetry-ebpf-instrumentation"),
 			},
 			attrSelector: attributes.Selection{
@@ -312,7 +312,7 @@ func TestGetFilteredResourceAttrs(t *testing.T) {
 			name: "With different exclusion patterns",
 			baseAttrs: []attribute.KeyValue{
 				attribute.String("service.name", "test-service"),
-				attribute.String("telemetry.sdk.name", "opentelemetry-go"),
+				attribute.String("telemetry.sdk.name", "opentelemetry"),
 				attribute.String("telemetry.distro.name", "opentelemetry-ebpf-instrumentation"),
 			},
 			attrSelector: attributes.Selection{
@@ -341,7 +341,7 @@ func TestGetFilteredResourceAttrs(t *testing.T) {
 			name: "Testing selector order - specific patterns override general ones",
 			baseAttrs: []attribute.KeyValue{
 				attribute.String("service.name", "test-service"),
-				attribute.String("telemetry.sdk.name", "opentelemetry-go"),
+				attribute.String("telemetry.sdk.name", "opentelemetry"),
 				attribute.String("telemetry.distro.name", "opentelemetry-ebpf-instrumentation"),
 			},
 			attrSelector: attributes.Selection{

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -83,15 +83,17 @@ const (
 	k8sKind            = "k8s_kind"
 	k8sOwnerName       = "k8s_owner_name"
 
-	spanNameKey          = "span_name"
-	statusCodeKey        = "status_code"
-	spanKindKey          = "span_kind"
-	serviceInstanceKey   = "instance"
-	serviceJobKey        = "job"
-	sourceKey            = "source"
-	telemetryLanguageKey = "telemetry_sdk_language"
-	telemetrySDKKey      = "telemetry_sdk_name"
-	telemetrySDKVersion  = "telemetry_sdk_version"
+	spanNameKey            = "span_name"
+	statusCodeKey          = "status_code"
+	spanKindKey            = "span_kind"
+	serviceInstanceKey     = "instance"
+	serviceJobKey          = "job"
+	sourceKey              = "source"
+	telemetryLanguageKey   = "telemetry_sdk_language"
+	telemetrySDKKey        = "telemetry_sdk_name"
+	telemetrySDKVersion    = "telemetry_sdk_version"
+	telemetryDistroNameKey = "telemetry_distro_name"
+	telemetryDistroVersion = "telemetry_distro_version"
 
 	// default values for the histogram configuration
 	// recommended values for native histogram migration
@@ -1114,6 +1116,8 @@ func labelNamesTargetInfo(kubeEnabled, dockerEnabled bool, nodeMeta *meta.NodeMe
 		telemetryLanguageKey,
 		telemetrySDKKey,
 		telemetrySDKVersion,
+		telemetryDistroNameKey,
+		telemetryDistroVersion,
 		sourceKey,
 		osTypeKey,
 	}
@@ -1146,8 +1150,9 @@ func (r *metricsReporter) labelValuesTargetInfo(service *svc.Attrs) []string {
 		service.Job(),
 		service.SDKLanguage.String(),
 		attr.VendorSDKName,
+		attr.VendorSDKVersion,
 		attr.TelemetryDistroName,
-		buildinfo.Version,
+		attr.TelemetryDistroVersion,
 		attr.VendorPrefix,
 		"linux",
 	}

--- a/pkg/test/integration/config.go
+++ b/pkg/test/integration/config.go
@@ -33,7 +33,7 @@ func DefaultOBIConfig() *TestConfig {
 		ConfigPath:         "obi-config.yml",
 		MetricPrefix:       "obi",
 		IPAttribute:        "obi.ip",
-		SDKName:            "opentelemetry-go",
+		SDKName:            "opentelemetry",
 		VersionPkg:         "obibuildinfo.Version",
 	}
 }


### PR DESCRIPTION
- change VendorSDKName to "opentelemetry-go" to correctly identify the underlying SDK
- introduce TelemetryDistroName ("opentelemetry-ebpf-instrumentation") for the distro attribute
- emit telemetry.distro.name in otel metrics, internal metrics, svc graph, and prom reporters
- update all tests to expect the new attribute split

Fixes #1375 