### PR TITLE
Fix request buffer lookup when instrumenting servers

### DIFF
--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -509,10 +509,12 @@ int BPF_KPROBE(obi_kprobe_tcp_rate_check_app_limited, struct sock *sk) {
     if (parse_sock_info(sk, &s_args.p_conn.conn)) {
         const u16 orig_dport = s_args.p_conn.conn.d_port;
         dbg_print_http_connection_info(&s_args.p_conn.conn);
-        const egress_key_t e_key = {
+        egress_key_t e_key = {
             .d_port = s_args.p_conn.conn.d_port,
             .s_port = s_args.p_conn.conn.s_port,
         };
+
+        sort_egress_key(&e_key);
 
         sort_connection_info(&s_args.p_conn.conn);
         s_args.p_conn.pid = pid_from_pid_tgid(id);


### PR DESCRIPTION
When instrumenting servers, it is possible that their egress codepath now run through `tpinjector` as a result of the new iterator introduced by https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1366 

There was a bug in k_tracer in which we forgot to sort the egress_key, thus never finding the buffer setup by sk_msg, which in turn made us never see the end of the request/response.

## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->