### PR TITLE
Fix docker-generate in git worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,9 +259,13 @@ generate/all: $(BPF2GO)
 .PHONY: docker-generate
 docker-generate:
 	@echo "### Generating files in Docker..."
-	@$(OCI_BIN) run --rm \
+	@_git_dir=$$(git rev-parse --absolute-git-dir) && \
+	_git_common_dir=$$(git rev-parse --path-format=absolute --git-common-dir) && \
+	$(OCI_BIN) run --rm \
 		$(if $(findstring podman,$(OCI_BIN)),  ,-u "$(DOCKER_USER)") \
 		-v "$(CURDIR):/src:z" \
+		-v "$$_git_common_dir:/src/.gitrepo:ro,z" \
+		-e GIT_DIR="/src/.gitrepo$${_git_dir#$$_git_common_dir}" \
 		-w /src \
 		$(GEN_IMG) \
 		make generate


### PR DESCRIPTION
## Summary

Fixes `make docker-generate` failing with `fatal: not a git repository` when run from a git worktree. The root cause is that `.git` is a file (not a directory) in worktrees, pointing to the real git directory outside the container mount.

The fix mounts the resolved git common directory into the container and sets `GIT_DIR` to point to the worktree-specific git directory within it. This allows git commands to work correctly regardless of whether the code is run from a normal clone, a submodule, or a worktree.

## Verification

- `make docker-generate` now runs without `fatal:` errors in worktrees
- Git commands (`git describe`, `git rev-parse`) execute correctly inside the container
- Generated eBPF files are produced correctly

## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)