### PR TITLE
ci: avoid docker hub rate limits

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -113,6 +113,12 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION }}
+
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 # zizmor: ignore[cache-poisoning] go.sum verifies module integrity
         with:

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -119,6 +119,12 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION }}
+
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 # zizmor: ignore[cache-poisoning] go.sum verifies module integrity
         with:

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -111,6 +111,12 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION }}
+
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 # zizmor: ignore[cache-poisoning] go.sum verifies module integrity
         with:

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -111,6 +111,12 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION }}
+
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 # zizmor: ignore[cache-poisoning] go.sum verifies module integrity
         with:

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -121,6 +121,12 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ vars.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION }}
+
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0 # zizmor: ignore[cache-poisoning] go.sum verifies module integrity
         with:

--- a/internal/test/integration/dockerutil_test.go
+++ b/internal/test/integration/dockerutil_test.go
@@ -134,6 +134,16 @@ func setupContainerCollector(t *testing.T, network *dockertest.Network, configFi
 	t.Log("OpenTelemetry Collector container started")
 }
 
+// dockerAuthConfigs loads Docker registry credentials from ~/.docker/config.json
+// if available. In CI, docker/login-action populates this file. Returns an empty
+// AuthConfigurations (no-op) when the config file is absent or unreadable.
+func dockerAuthConfigs() docker.AuthConfigurations {
+	if cfgs, err := docker.NewAuthConfigurationsFromDockerCfg(); err == nil {
+		return *cfgs
+	}
+	return docker.AuthConfigurations{}
+}
+
 // buildOBIImage builds the OBI image. When SKIP_DOCKER_BUILD is set, the image
 // has been pre-built for the VM workflow prior to QEMU startup.
 func buildOBIImage() error {
@@ -151,6 +161,7 @@ func buildOBIImage() error {
 		Dockerfile:   "internal/test/integration/components/obi/Dockerfile",
 		OutputStream: os.Stdout,
 		ErrorStream:  os.Stderr,
+		AuthConfigs:  dockerAuthConfigs(),
 	})
 }
 

--- a/internal/test/integration/http_go_otel_test.go
+++ b/internal/test/integration/http_go_otel_test.go
@@ -39,6 +39,7 @@ func setupGoOTelTestServer(t *testing.T, network *dockertest.Network, env []stri
 			Dockerfile:   "internal/test/integration/components/go_otel/Dockerfile",
 			OutputStream: t.Output(),
 			ErrorStream:  t.Output(),
+			AuthConfigs:  dockerAuthConfigs(),
 		})
 		if buildGoOTelTestServerErr != nil {
 			return


### PR DESCRIPTION
Lots of CI workflows are running docker pulls without authentication, meaning that we're more likely to hit rate limits. We already have an authentication token available, just need to use it in more places.

For ory/dockertest, this requires [NewAuthConfigurationsFromDockerCfg](https://pkg.go.dev/github.com/ory/dockertest/docker#NewAuthConfigurationsFromDockerCfg) in order to pass the credentials to the client.