### PR TITLE
ci: skip Docker Hub login when credentials unavailable

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -114,6 +114,7 @@ jobs:
           persist-credentials: false
 
       - name: Log in to Docker Hub
+        if: secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION != ''
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ vars.DOCKER_USERNAME }}

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -120,6 +120,7 @@ jobs:
           persist-credentials: false
 
       - name: Log in to Docker Hub
+        if: secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION != ''
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ vars.DOCKER_USERNAME }}

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -112,6 +112,7 @@ jobs:
           persist-credentials: false
 
       - name: Log in to Docker Hub
+        if: secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION != ''
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ vars.DOCKER_USERNAME }}

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -112,6 +112,7 @@ jobs:
           persist-credentials: false
 
       - name: Log in to Docker Hub
+        if: secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION != ''
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ vars.DOCKER_USERNAME }}

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -122,6 +122,7 @@ jobs:
           persist-credentials: false
 
       - name: Log in to Docker Hub
+        if: secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION != ''
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ vars.DOCKER_USERNAME }}


### PR DESCRIPTION
## Summary
Skip Docker Hub login in test workflows when credentials are not available. This prevents workflows from failing on fork PRs and Dependabot/Renovate PRs while preserving rate limit avoidance when credentials are present.

## Changes
- Added conditional to 5 test workflows: `if: secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION != ''`
- Affects: pull_request_integration_tests, pull_request_integration_tests_arm, pull_request_k8s_integration_tests, pull_request_oats_test, workflow_integration_tests_vm
- Docker Hub login is only needed for pull rate limits in tests, so gracefully skipping when unavailable is safe

## Checklist

- [x] Changes tested to prevent workflow failures on forks
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)