### PR TITLE
Initialize empty `PROM_CONFIG_SUFFIX` in test suite

### DIFF
--- a/internal/test/integration/old_grpc_test.go
+++ b/internal/test/integration/old_grpc_test.go
@@ -129,7 +129,7 @@ func TestSuiteOtherGRPCGo(t *testing.T) {
 	require.NoError(t, err)
 
 	// we are going to setup discovery directly in the configuration file
-	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
+	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`, `PROM_CONFIG_SUFFIX=`)
 	lockdown := KernelLockdownMode()
 
 	if !lockdown {

--- a/internal/test/integration/suites_network_test.go
+++ b/internal/test/integration/suites_network_test.go
@@ -24,7 +24,7 @@ func TestNetwork_Deduplication(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly.yml", path.Join(pathOutput, "test-suite-netolly-dedupe.log"))
 	require.NoError(t, err)
 
-	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=")
+	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=", `PROM_CONFIG_SUFFIX=`)
 	require.NoError(t, compose.Up())
 
 	// When there flow deduplication, results must not include "iface" field.
@@ -40,7 +40,7 @@ func TestNetwork_Deduplication_Use_Socket_Filter(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly.yml", path.Join(pathOutput, "test-suite-netolly-dedupe-no-tc.log"))
 	require.NoError(t, err)
 
-	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=", "OTEL_EBPF_NETWORK_SOURCE=socket_filter")
+	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=", "OTEL_EBPF_NETWORK_SOURCE=socket_filter", `PROM_CONFIG_SUFFIX=`)
 	require.NoError(t, compose.Up())
 
 	// When there flow deduplication, results must not include "iface" field.
@@ -56,7 +56,7 @@ func TestNetwork_NoDeduplication(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly.yml", path.Join(pathOutput, "test-suite-netolly-nodedupe.log"))
 	require.NoError(t, err)
 
-	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=none", "OTEL_EBPF_EXECUTABLE_PATH=")
+	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=none", "OTEL_EBPF_EXECUTABLE_PATH=", `PROM_CONFIG_SUFFIX=`)
 	require.NoError(t, compose.Up())
 
 	// When there is no flow deduplication, results must include "iface".
@@ -75,7 +75,7 @@ func TestNetwork_AllowedAttributes(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly.yml", path.Join(pathOutput, "test-suite-netolly-allowed-attrs.log"))
 	require.NoError(t, err)
 
-	compose.Env = append(compose.Env, "OTEL_EBPF_EXECUTABLE_PATH=", `OTEL_EBPF_CONFIG_SUFFIX=-disallowattrs`)
+	compose.Env = append(compose.Env, "OTEL_EBPF_EXECUTABLE_PATH=", `OTEL_EBPF_CONFIG_SUFFIX=-disallowattrs`, `PROM_CONFIG_SUFFIX=`)
 	require.NoError(t, compose.Up())
 
 	// When there flow deduplication, results must only include
@@ -107,6 +107,7 @@ func TestNetwork_AllowedAttributes(t *testing.T) {
 func TestNetwork_ReverseDNS(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly-rdns.yml", path.Join(pathOutput, "test-suite-netolly-reverse-dns.log"))
 	require.NoError(t, err)
+	compose.Env = append(compose.Env, `PROM_CONFIG_SUFFIX=`)
 	require.NoError(t, compose.Up())
 
 	checkCurlFlows := func(query string) {
@@ -129,7 +130,7 @@ func TestNetwork_Direction(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly-direction.yml", path.Join(pathOutput, "test-suite-netolly-direction.log"))
 	require.NoError(t, err)
 
-	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_NETWORK_SOURCE=tc", "OTEL_EBPF_EXECUTABLE_PATH=", `OTEL_EBPF_CONFIG_SUFFIX=-direction`)
+	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_NETWORK_SOURCE=tc", "OTEL_EBPF_EXECUTABLE_PATH=", `OTEL_EBPF_CONFIG_SUFFIX=-direction`, `PROM_CONFIG_SUFFIX=`)
 	require.NoError(t, compose.Up())
 
 	results := getDirectionNetFlows(t)
@@ -157,7 +158,7 @@ func TestNetwork_IfaceDirection_Use_Socket_Filter(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-netolly-direction.yml", path.Join(pathOutput, "test-suite-netolly-direction-no-tc.log"))
 	require.NoError(t, err)
 
-	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=", "OTEL_EBPF_NETWORK_SOURCE=socket_filter", `OTEL_EBPF_CONFIG_SUFFIX=-direction`)
+	compose.Env = append(compose.Env, "OTEL_EBPF_NETWORK_DEDUPER=first_come", "OTEL_EBPF_EXECUTABLE_PATH=", "OTEL_EBPF_NETWORK_SOURCE=socket_filter", `OTEL_EBPF_CONFIG_SUFFIX=-direction`, `PROM_CONFIG_SUFFIX=`)
 	require.NoError(t, compose.Up())
 
 	results := getDirectionNetFlows(t)

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -123,8 +123,7 @@ func TestSuite_StaticCompilation(t *testing.T) {
 func TestSuite_OldestGoVersion(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-1.17.yml", path.Join(pathOutput, "test-suite-oldest-go.log"))
 	require.NoError(t, err)
-
-	compose.Env = []string{`OTEL_GO_AUTO_TARGET_EXE=*testserver`}
+	compose.Env = append(compose.Env, `OTEL_GO_AUTO_TARGET_EXE=*testserver`, `PROM_CONFIG_SUFFIX=`)
 	require.NoError(t, compose.Up())
 
 	config := ti.DefaultOBIConfig()
@@ -143,6 +142,7 @@ func TestSuite_UnsupportedGoVersion(t *testing.T) {
 	t.Skip("seems flaky, we need to look into this")
 	compose, err := docker.ComposeSuite("docker-compose-1.16.yml", path.Join(pathOutput, "test-suite-unsupported-go.log"))
 	require.NoError(t, err)
+	compose.Env = append(compose.Env, `PROM_CONFIG_SUFFIX=`)
 	require.NoError(t, compose.Up())
 	t.Run("RED metrics", testREDMetricsUnsupportedHTTP)
 	require.NoError(t, compose.Close())
@@ -643,7 +643,7 @@ func TestSuiteNodeClient(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-nodeclient.yml", path.Join(pathOutput, "test-suite-nodeclient.log"))
 	require.NoError(t, err)
 
-	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=node`, `NODE_APP=client`)
+	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=node`, `NODE_APP=client`, `PROM_CONFIG_SUFFIX=`)
 	require.NoError(t, compose.Up())
 	t.Run("Node Client RED metrics", func(t *testing.T) {
 		testNodeClientWithMethodAndStatusCode(t, "GET", 301, 80, "0000000000000000")
@@ -655,7 +655,7 @@ func TestSuiteNodeClientTLS(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-nodeclient.yml", path.Join(pathOutput, "test-suite-nodeclient-tls.log"))
 	require.NoError(t, err)
 
-	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=node`, `NODE_APP=client_tls`)
+	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=node`, `NODE_APP=client_tls`, `PROM_CONFIG_SUFFIX=`)
 	require.NoError(t, compose.Up())
 	t.Run("Node Client RED metrics", func(t *testing.T) {
 		testNodeClientWithMethodAndStatusCode(t, "GET", 200, 443, "0000000000000001")


### PR DESCRIPTION
This PR explicitly initializes `PROM_CONFIG_SUFFIX` variable within the test suite.
