### PR TITLE
ci: manual concurrency groups

### DIFF
--- a/.github/workflows/check_gh_actions_security.yml
+++ b/.github/workflows/check_gh_actions_security.yml
@@ -8,7 +8,7 @@ on:
     branches: ["**"]
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: gh-actions-security-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: clang-format-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/clang-tidy-check.yml
+++ b/.github/workflows/clang-tidy-check.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: clang-tidy-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/java-agent.yml
+++ b/.github/workflows/java-agent.yml
@@ -17,7 +17,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: java-agent-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/lint_darwin.yml
+++ b/.github/workflows/lint_darwin.yml
@@ -18,7 +18,7 @@ on:
       - "scripts/**"
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: lint-darwin-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/markdown-fail-fast.yml
+++ b/.github/workflows/markdown-fail-fast.yml
@@ -9,7 +9,7 @@ on:
       - "**.md"
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: markdown-check-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: pull-request-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pull_request_docker_build_test.yml
+++ b/.github/workflows/pull_request_docker_build_test.yml
@@ -10,7 +10,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: docker-build-test-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -28,7 +28,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: integration-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -28,7 +28,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: integration-tests-arm-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -28,7 +28,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: k8s-integration-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -28,7 +28,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: oats-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -23,7 +23,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow_ref }}-${{ github.head_ref || github.run_id }}
+  group: vm-integration-tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Looks like `workflow_ref` didn't resolve the [situation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/22780468199):

```
Canceling since a higher priority waiting request for open-telemetry/opentelemetry-ebpf-instrumentation/.github/workflows/release.yml@refs/heads/main-22780468199 exists
```

Try manually hard coded concurrency group names instead.