### PR TITLE
Exclude dns from span and service graph metrics

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -630,7 +630,7 @@ func (s *Span) IsValid() bool {
 
 func (s *Span) IsClientSpan() bool {
 	switch s.Type {
-	case EventTypeGRPCClient, EventTypeHTTPClient, EventTypeRedisClient, EventTypeKafkaClient, EventTypeMQTTClient, EventTypeSQLClient, EventTypeMongoClient, EventTypeFailedConnect, EventTypeCouchbaseClient:
+	case EventTypeGRPCClient, EventTypeDNS, EventTypeHTTPClient, EventTypeRedisClient, EventTypeKafkaClient, EventTypeMQTTClient, EventTypeSQLClient, EventTypeMongoClient, EventTypeFailedConnect, EventTypeCouchbaseClient:
 		return true
 	}
 
@@ -953,6 +953,10 @@ func (s *Span) isMetricsExportURL() bool {
 	default:
 		return false
 	}
+}
+
+func (s *Span) IsDNSSpan() bool {
+	return s.Type == EventTypeDNS
 }
 
 func (s *Span) isTracesExportURL() bool {

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -830,7 +830,7 @@ func otelMetricsAccepted(span *request.Span) bool {
 
 func otelSpanMetricsAccepted(span *request.Span) bool {
 	return span.Service.Features.AnySpanMetrics() &&
-		!span.Service.ExportsOTelMetricsSpan()
+		!span.Service.ExportsOTelMetricsSpan() && !span.IsDNSSpan()
 }
 
 //nolint:cyclop

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -290,6 +290,10 @@ func serviceGraphGetters(unresolved request.UnresolvedNames, k8sEnabled bool) []
 }
 
 func (r *SvcGraphMetrics) record(span *request.Span, mr *SvcGraphMetricsReporter) {
+	if span.IsDNSSpan() {
+		return
+	}
+
 	t := span.Timings()
 	duration := t.End.Sub(t.RequestStart).Seconds()
 

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -853,7 +853,7 @@ func (r *metricsReporter) otelMetricsObserved(span *request.Span) bool {
 }
 
 func (r *metricsReporter) otelSpanMetricsObserved(span *request.Span) bool {
-	return span.Service.Features.AnySpanMetrics() && !span.Service.ExportsOTelMetricsSpan()
+	return span.Service.Features.AnySpanMetrics() && !span.Service.ExportsOTelMetricsSpan() && !span.IsDNSSpan()
 }
 
 func (r *metricsReporter) otelSpanFiltered(span *request.Span) bool {


### PR DESCRIPTION
DNS metrics are excluded from traces because they create noise and the same holds true for span and service graph metrics. These cause confusion to the end users now about additional requests they don't understand. We have separate DNS metrics series.