### PR TITLE
If the IP can't be resolved, use it and don't replace by process name.

### DIFF
--- a/pkg/transform/name_resolver.go
+++ b/pkg/transform/name_resolver.go
@@ -195,7 +195,6 @@ func (nr *NameResolver) resolveNames(span *request.Span) {
 		pn, span.OtherNamespace, span.OtherK8SNamespace = nr.resolve(&span.Service, span.Peer, span.PeerName)
 		hn, ns, _ = nr.resolve(&span.Service, span.Host, span.HostName)
 		if hn == "" || hn == span.Host {
-			hn = span.Service.UID.Name
 			if ns == "" {
 				ns = span.Service.UID.Namespace
 			}


### PR DESCRIPTION
## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

If IP resolution fails, don't fall back to using the process name, but rather use it literally.
Fixes #1499 