### PR TITLE
fix large buffers for mysql, add integration test

### DIFF
--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -222,6 +222,7 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
         tcp_req_t *req = empty_tcp_req();
         if (req) {
             req->is_server = is_server;
+            int original_bytes_len = bytes_len;
             bpf_clamp_umax(bytes_len, K_TCP_MAX_LEN);
             req->flags = EVENT_TCP_REQUEST;
             req->conn_info = pid_conn->conn;
@@ -232,7 +233,7 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
             req->end_monotime_ns = 0;
             req->resp_len = 0;
             req->len = bytes_len;
-            req->req_len = req->len;
+            req->req_len = original_bytes_len;
             req->extra_id = extra_runtime_id();
             req->protocol_type = protocol_type;
             task_pid(&req->pid);
@@ -247,8 +248,13 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
 
             tcp_get_or_set_trace_info(req, pid_conn, ssl, orig_dport);
 
-            tcp_send_large_buffer(
-                req, pid_conn, u_buf, bytes_len, direction, protocol_type, k_large_buf_action_init);
+            tcp_send_large_buffer(req,
+                                  pid_conn,
+                                  u_buf,
+                                  original_bytes_len,
+                                  direction,
+                                  protocol_type,
+                                  k_large_buf_action_init);
 
             bpf_map_update_elem(&ongoing_tcp_req, pid_conn, req, BPF_ANY);
         }

--- a/internal/test/integration/components/pythonsql/main_mysql.py
+++ b/internal/test/integration/components/pythonsql/main_mysql.py
@@ -72,6 +72,29 @@ async def root():
 
     return row
 
+@app.get("/bigquery")
+async def bigquery():
+    global conn
+    if conn is None:
+        conn = mysql.connector.connect(
+            database="sakila",
+            user="sakila",
+            password="p_ssW0rd",
+            host="sqlserver",
+            port="3306"
+        )
+
+    # Build a SELECT query that is exactly 5000 bytes.
+    ids = ", ".join(str(i) for i in range(1, 1000))
+    query = f"SELECT * FROM actor WHERE actor_id IN ({ids})"
+    query = query.ljust(5000)
+
+    cur = conn.cursor()
+    cur.execute(query)
+    rows = cur.fetchall()
+
+    return rows
+
 @app.get("/error")
 async def root():
     global conn

--- a/internal/test/integration/docker-compose-python-mysql.yml
+++ b/internal/test/integration/docker-compose-python-mysql.yml
@@ -58,7 +58,7 @@ services:
       OTEL_EBPF_TRACES_INSTRUMENTATIONS: "sql"
       OTEL_EBPF_METRICS_INSTRUMENTATIONS: "sql"
       OTEL_EBPF_METRICS_FEATURES: "application"
-      OTEL_EBPF_BPF_BUFFER_SIZE_MYSQL: 1024
+      OTEL_EBPF_BPF_BUFFER_SIZE_MYSQL: 8192
     depends_on:
       testserver:
         condition: service_started

--- a/internal/test/integration/red_test_python_sql.go
+++ b/internal/test/integration/red_test_python_sql.go
@@ -205,6 +205,61 @@ func testPythonPostgres(t *testing.T) {
 	testPythonSQLError(t, comm, testCaseURL, db)
 }
 
+func testPythonSQLBigQuery(t *testing.T, comm, url, table, db string) {
+	t.Helper()
+
+	urlPath := "/bigquery"
+	ti.DoHTTPGet(t, url+urlPath, 200)
+
+	dbOperation := "SELECT " + table
+
+	params := neturl.Values{}
+	params.Add("service", comm)
+	params.Add("operation", dbOperation)
+	fullURL := fmt.Sprintf("%s?%s", jaegerQueryURL, params.Encode())
+
+	queryPrefix := "SELECT * FROM actor WHERE actor_id IN (1, 2, 3,"
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(fullURL)
+		require.NoError(ct, err)
+		assert.NotNil(ct, resp)
+		assert.Equal(ct, http.StatusOK, resp.StatusCode)
+
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+		traces := tq.FindBySpan(jaeger.Tag{Key: "db.operation.name", Type: "string", Value: "SELECT"})
+		assert.GreaterOrEqual(ct, len(traces), 1)
+
+		var found bool
+		for _, trace := range traces {
+			span := trace.Spans[0]
+			tag, ok := jaeger.FindIn(span.Tags, "db.query.text")
+			if !ok {
+				continue
+			}
+			queryText, _ := tag.Value.(string)
+			if !strings.HasPrefix(queryText, queryPrefix) {
+				continue
+			}
+			found = true
+
+			assert.Equal(ct, dbOperation, span.OperationName)
+			assert.Len(ct, queryText, 5000, "expected query of 5000 chars, got %d chars", len(queryText))
+
+			tag, ok = jaeger.FindIn(span.Tags, "db.system.name")
+			assert.True(ct, ok)
+			assert.Equal(ct, db, tag.Value)
+
+			tag, ok = jaeger.FindIn(span.Tags, "db.collection.name")
+			assert.True(ct, ok)
+			assert.Equal(ct, table, tag.Value)
+			break
+		}
+		assert.True(ct, found, "no trace found with large query text starting with %q", queryPrefix)
+	}, testTimeout, 100*time.Millisecond)
+}
+
 func testPythonMySQL(t *testing.T) {
 	testCaseURL := "http://localhost:8381"
 	comm := "python3.14"
@@ -216,6 +271,7 @@ func testPythonMySQL(t *testing.T) {
 	assertHTTPRequests(t, comm, "/query")
 	testPythonSQLQuery(t, comm, testCaseURL, table, db)
 	testPythonSQLPreparedStatements(t, comm, testCaseURL, table, db)
+	testPythonSQLBigQuery(t, comm, testCaseURL, table, db)
 	testPythonSQLError(t, comm, testCaseURL, db)
 }
 

--- a/pkg/ebpf/common/tcp_large_buffer.go
+++ b/pkg/ebpf/common/tcp_large_buffer.go
@@ -46,19 +46,22 @@ func appendTCPLargeBuffer(parseCtx *EBPFParseContext, record *ringbuf.Record) (r
 
 	chunk := record.RawSample[hdrSize : hdrSize+event.Len]
 
+	initFunc := func(b []byte) {
+		lb := largebuf.NewLargeBuffer()
+		lb.AppendChunk(b)
+		parseCtx.largeBuffers.Add(key, lb)
+	}
+
 	switch event.Action {
 	case largeBufferActionInit:
-		lb := largebuf.NewLargeBuffer()
-		lb.AppendChunk(chunk)
-		parseCtx.largeBuffers.Add(key, lb)
-
+		initFunc(chunk)
 	case largeBufferActionAppend:
 		lb, ok := parseCtx.largeBuffers.Get(key)
 		if !ok {
-			return request.Span{}, true, nil
+			initFunc(chunk)
+		} else {
+			lb.AppendChunk(chunk)
 		}
-		lb.AppendChunk(chunk)
-
 	default:
 		return request.Span{}, true, fmt.Errorf("invalid large buffer action: %d", event.Action)
 	}


### PR DESCRIPTION
- fallback to init the buffer if action==append and current buffer not found
- in the request path, save the original length before clamping
- add integration test which tests a 5k bytes long query