### PR TITLE
configurable port guessing also in flows.c

### DIFF
--- a/bpf/netolly/flows.c
+++ b/bpf/netolly/flows.c
@@ -219,7 +219,7 @@ static inline int flow_monitor(struct __sk_buff *skb) {
                 bpf_map_update_elem(&flow_directions, &id, &new_flow.iface_direction, BPF_NOEXIST);
             }
             // fallback for lost or already started connections and UDP
-            else {
+            else if (port_guessing == PORT_GUESSING_ORDINAL) {
                 new_flow.iface_direction = INGRESS;
                 if (id.src_port > id.dst_port) {
                     new_flow.iface_direction = EGRESS;


### PR DESCRIPTION
In a previous PR (https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1519/changes), I forgot to selectively disable port guessing in the BPF code for `flows.c`.

The `port_guessing` constant was already set in the Go code that loads this BPF program.