### PR TITLE
Fix nil pointer dereference in ELF section parsing

### DIFF
--- a/pkg/internal/fastelf/fastelf.go
+++ b/pkg/internal/fastelf/fastelf.go
@@ -317,6 +317,10 @@ func (ctx *ElfContext) Close() error {
 
 func (ctx *ElfContext) HasSymbol(symbol string) bool {
 	for _, sec := range ctx.Sections {
+		if sec == nil {
+			continue
+		}
+
 		if sec.Type != SHT_SYMTAB && sec.Type != SHT_DYNSYM {
 			continue
 		}
@@ -326,6 +330,10 @@ func (ctx *ElfContext) HasSymbol(symbol string) bool {
 		}
 
 		strtab := ctx.Sections[sec.Link]
+
+		if strtab == nil {
+			continue
+		}
 
 		if int(strtab.Offset) >= len(ctx.Data) {
 			continue
@@ -374,7 +382,7 @@ func (ctx *ElfContext) shstrtabData() []byte {
 
 	shstrtab := ctx.Sections[ctx.Hdr.Shstrndx]
 
-	if int(shstrtab.Offset) >= len(ctx.Data) {
+	if shstrtab == nil || int(shstrtab.Offset) >= len(ctx.Data) {
 		return nil
 	}
 
@@ -389,6 +397,10 @@ func (ctx *ElfContext) section(sectionName string) *Elf64_Shdr {
 	}
 
 	for _, sec := range ctx.Sections {
+		if sec == nil {
+			continue
+		}
+
 		if GetCStringUnsafe(shstrtabData, sec.Name) == sectionName {
 			return sec
 		}


### PR DESCRIPTION
ReadStruct can return nil if the data slice is too short, but callers didn't check before dereferencing the result. Adds nil guards in shstrtabData, HasSymbol, and section.

## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->