### PR TITLE
do not prune docker builder cache in integration tests

### DIFF
--- a/internal/test/integration/components/docker/build.go
+++ b/internal/test/integration/components/docker/build.go
@@ -61,15 +61,5 @@ func buildDockerfile(logger io.WriteCloser, rootPath string, ilog *slog.Logger, 
 		ilog.Error("building dockerfile. Check build logs for details", "error", err)
 		return err
 	}
-	// OpenTelemetry images are very limited in disk. Remove dangling images after building each image
-	ilog.Info("removing docker builder cache")
-	cmd = exec.Command("docker", "builder", "prune", "-af")
-	if logger != nil {
-		cmd.Stdout = logger
-		cmd.Stderr = logger
-	}
-	if err := cmd.Run(); err != nil {
-		ilog.Warn("Can't remove docker builder cache. Tests will continue anyway", "error", err)
-	}
 	return nil
 }


### PR DESCRIPTION
We pruned the docker builder cache after each test, to prevent running out of disk space when we ran all the integration tests into a single GH action instance.

Now that we run smaller test suites in parallel, this step is not needed and will speedup integration tests, both in GitHub and locally