### PR TITLE
bump golang base image to 1.25.8 (CVE-2026-25679)

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced AS base
+FROM golang:1.25.8-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa AS base
 FROM base AS dist
 
 WORKDIR /src


### PR DESCRIPTION
Bumps `generator.Dockerfile` to `golang:1.25.8-alpine` to address
CVE-2026-25679 (net/url host validation bypass, CVSS 7.5 HIGH) in the
Go standard library, fixed in Go 1.25.8.

This is PR 1/2, once the obi-generator image is published from this
change, a follow-up PR will update go.mod, the remaining Dockerfiles,
and all integration test images.

## Checklist

- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->