### PR TITLE
bpf: fix logenricher and generictracer on older kernels

### DIFF
--- a/NOTICES/bpf/bpfcore/utils.h
+++ b/NOTICES/bpf/bpfcore/utils.h
@@ -59,6 +59,12 @@
                  : "+r"(VAR)                                                                       \
                  : [max] "i"(UMAX))
 
+#define bpf_clamp_umin(VAR, UMIN)                                                                  \
+    asm volatile("if %0 >= %[min] goto +1\n"                                                       \
+                 "%0 = %[min]\n"                                                                   \
+                 : "+r"(VAR)                                                                       \
+                 : [min] "i"(UMIN))
+
 static __always_inline bool is_pow2(u32 n) {
     return n != 0UL && (n & (n - 1)) == 0UL;
 }

--- a/bpf/bpfcore/utils.h
+++ b/bpf/bpfcore/utils.h
@@ -59,6 +59,12 @@
                  : "+r"(VAR)                                                                       \
                  : [max] "i"(UMAX))
 
+#define bpf_clamp_umin(VAR, UMIN)                                                                  \
+    asm volatile("if %0 >= %[min] goto +1\n"                                                       \
+                 "%0 = %[min]\n"                                                                   \
+                 : "+r"(VAR)                                                                       \
+                 : [min] "i"(UMIN))
+
 static __always_inline bool is_pow2(u32 n) {
     return n != 0UL && (n & (n - 1)) == 0UL;
 }

--- a/bpf/generictracer/protocol_common.h
+++ b/bpf/generictracer/protocol_common.h
@@ -27,6 +27,8 @@ static __always_inline u32 large_buf_emit_chunks(tcp_large_buffer_t *large_buf,
                                                  u32 available_bytes) {
     const unsigned char *p = (const unsigned char *)u_buf;
 
+    bpf_clamp_umax(available_bytes, k_large_buf_max_http_captured_bytes);
+
     const u32 niter = (available_bytes / k_large_buf_payload_max_size) +
                       ((available_bytes % k_large_buf_payload_max_size) > 0);
 
@@ -35,9 +37,10 @@ static __always_inline u32 large_buf_emit_chunks(tcp_large_buffer_t *large_buf,
     for (u32 b = 0; b < niter; b++) {
         const u32 offset = b * k_large_buf_payload_max_size;
 
-        const u32 read_size = available_bytes > k_large_buf_payload_max_size
-                                  ? k_large_buf_payload_max_size
-                                  : available_bytes;
+        u32 read_size = available_bytes > k_large_buf_payload_max_size
+                            ? k_large_buf_payload_max_size
+                            : available_bytes;
+        bpf_clamp_umax(read_size, k_large_buf_payload_max_size);
 
         if (bpf_probe_read(large_buf->buf, read_size, p + offset) != 0) {
             break;
@@ -45,8 +48,10 @@ static __always_inline u32 large_buf_emit_chunks(tcp_large_buffer_t *large_buf,
 
         large_buf->len = read_size;
 
-        const u32 payload_size = read_size > sizeof(void *) ? read_size : sizeof(void *);
-        const u32 total_size = sizeof(tcp_large_buffer_t) + payload_size;
+        u32 payload_size = read_size > sizeof(void *) ? read_size : sizeof(void *);
+        bpf_clamp_umax(payload_size, k_large_buf_payload_max_size);
+        u32 total_size = sizeof(tcp_large_buffer_t) + payload_size;
+        bpf_clamp_umax(total_size, k_large_buf_max_size);
 
         if (bpf_ringbuf_output(&events, large_buf, total_size, get_flags()) != 0) {
             break;

--- a/bpf/logenricher/logenricher.c
+++ b/bpf/logenricher/logenricher.c
@@ -4,6 +4,7 @@
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_core_read.h>
 #include <bpfcore/bpf_helpers.h>
+#include <bpfcore/compiler.h>
 
 #include <common/iov_iter.h>
 #include <common/scratch_mem.h>
@@ -120,10 +121,11 @@ __write(struct kiocb *iocb, struct iov_iter *from, const int fd, const struct ta
             return 0;
         }
 
-        const u32 to_write = e->len & k_log_event_max_log_mask;
+        u32 to_write = e->len & k_log_event_max_log_mask;
         if (to_write == 0) {
             return 0;
         }
+        bpf_clamp_umin(to_write, 1);
         bpf_probe_write_user(iov.iov_base, zero, to_write);
     }
 


### PR DESCRIPTION
Fixes: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1541
Issue: the compiler wasn't generating the correct instructions to let the verifier be able to correctly track `umin` before calling `bpf_probe_write_user`

Also fixes:
```
time=2026-03-19T15:31:44.643+01:00 level=WARN msg="couldn't load tracer" component=ebpf.ProcessTracer error="loading and assigning BPF objects: loading spec 0: field ObiContinue2ProtocolHttp: program obi_continue2_protocol_http: load program: bad address (hit verifier bug, increase LogSizeStart to fit the log and check dmesg)" required=true
time=2026-03-19T15:31:44.643+01:00 level=ERROR msg="couldn't trace process. Stopping process tracer" component=discover.traceAttacher error="loading and assigning BPF objects: loading spec 0: field ObiContinue2ProtocolHttp: program obi_continue2_protocol_http: load program: bad address (hit verifier bug, increase LogSizeStart to fit the log and check dmesg)"
```
Issue: `umax` getting lost in `large_buf_emit_chunks`