### PR TITLE
renovate: disable patch/digest bumps for test dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,6 +73,12 @@
       "schedule": ["before 6am on Thursday"]
     },
     {
+      "description": "Disable patch updates for test dependencies (only bump major/minor)",
+      "matchFileNames": ["internal/test/**"],
+      "matchUpdateTypes": ["patch", "digest"],
+      "enabled": false
+    },
+    {
       "description": "Disable Go 1.17 testserver updates",
       "matchFileNames": ["internal/test/integration/components/testserver_1.17"],
       "matchDatasources": ["docker"],


### PR DESCRIPTION
## Summary

disable patch/digest bumps for test dependencies

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->