### PR TITLE
Remove //nolint:undoc annotations

### DIFF
--- a/pkg/appolly/services/criteria.go
+++ b/pkg/appolly/services/criteria.go
@@ -121,7 +121,6 @@ type DiscoveryConfig struct {
 	DefaultOtlpGRPCPort int `yaml:"default_otlp_grpc_port" env:"OTEL_EBPF_DEFAULT_OTLP_GRPC_PORT"`
 
 	// Min process age to be considered for discovery.
-	//nolint:undoc
 	MinProcessAge time.Duration `yaml:"min_process_age" env:"OTEL_EBPF_MIN_PROCESS_AGE"`
 
 	// Disables generation of span metrics of services which are already instrumented
@@ -135,7 +134,6 @@ type DiscoveryConfig struct {
 
 	// Executable paths for which we don't run language detection and cannot be
 	// selected using the path or language selection criteria
-	//nolint:undoc
 	ExcludedLinuxSystemPaths []string `yaml:"excluded_linux_system_paths"`
 }
 

--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -129,7 +129,6 @@ type EBPFTracer struct {
 	// ForceBPFMapReader forces the PerCPU HashMap operation of the Network Flows reader.
 	// The system will always try "batch", which is more efficient, but legacy systems like RHEL8-based will fallback to
 	// "legacy" (the slowest, more resource-consuming iterate&delete approach).
-	//nolint:undoc
 	ForceBPFMapReader EBPFMapReader `yaml:"force_bpf_map_reader" env:"OTEL_EBPF_FORCE_BPF_MAP_READER" validate:"oneof=0 1 2" jsonschema:"type=string,enum=auto,enum=batch,enum=legacy"`
 }
 


### PR DESCRIPTION
## Summary

This annotations were used in Beyla to tell documentation linter that field doesn't need to
be documented. This is not used in this repo, so we can delete it.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->