### PR TITLE
httpSafeParseResponse: return error to prevent nil pointer

### DIFF
--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -260,7 +260,7 @@ func httpSafeParseResponse(responseBuffer *largebuf.LargeBuffer, req *http.Reque
 		rd.Reset(&r)
 		return http.ReadResponse(rd, req)
 	}
-	return resp, nil
+	return resp, err
 }
 
 func httpRequestToSpan(event *BPFHTTPInfo, requestBuffer *largebuf.LargeBuffer) request.Span {


### PR DESCRIPTION
## Summary

we don't propagate the err up in case of non EOF errors

this can cause the `defer resp.Body.Close()` to panic on a nil pointer

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->