### PR TITLE
Split`bpf_dbg_printk` to have less than 3 arguments

### DIFF
--- a/bpf/logger/bpf_dbg.h
+++ b/bpf/logger/bpf_dbg.h
@@ -36,6 +36,7 @@ struct {
 
 enum bpf_func_id___x {
     BPF_FUNC_snprintf___x = 42, /* avoid zero */
+    BPF_FUNC_trace_vprintk___x = 177,
 };
 
 #define bpf_dbg_printk(fmt, args...)                                                               \

--- a/bpf/rdns/rdns_xdp.c
+++ b/bpf/rdns/rdns_xdp.c
@@ -197,12 +197,29 @@ static __always_inline void parse_dns_response(struct xdp_md *ctx,
 
         bpf_dbg_printk("Found possible DNS response: %x!\n", id);
         bpf_dbg_printk("flags[0]=%x\n", flags0);
-        bpf_dbg_printk("id=%x, qr=%u, opcode=%u\n", id, qr, opcode);
-        bpf_dbg_printk("aa=%u, tc=%u, rd=%u\n", aa, tc, rd);
-        bpf_dbg_printk("ra=%u\n", ra);
-        bpf_dbg_printk("flags[1]=%x\n", flags1);
-        bpf_dbg_printk("z=%u, rcode=%u\n", z, rcode);
-        bpf_dbg_printk("qdcount=%u, ancount=%u\n", qdcount, ancount);
+        if (bpf_core_enum_value_exists(enum bpf_func_id___x, BPF_FUNC_trace_vprintk___x)) {
+            bpf_dbg_printk("id=%x, qr=%u, opcode=%u, aa=%u, tc=%u, rd=%u, ra=%u\n",
+                           id,
+                           qr,
+                           opcode,
+                           aa,
+                           tc,
+                           rd,
+                           ra);
+            bpf_dbg_printk("flags[1]=%x, z=%u, rcode=%u, qdcount=%u, ancount=%u\n",
+                           flags1,
+                           z,
+                           rcode,
+                           qdcount,
+                           ancount);
+        } else {
+            bpf_dbg_printk("id=%x, qr=%u, opcode=%u\n", id, qr, opcode);
+            bpf_dbg_printk("aa=%u, tc=%u, rd=%u\n", aa, tc, rd);
+            bpf_dbg_printk("ra=%u\n", ra);
+            bpf_dbg_printk("flags[1]=%x\n", flags1);
+            bpf_dbg_printk("z=%u, rcode=%u\n", z, rcode);
+            bpf_dbg_printk("qdcount=%u, ancount=%u\n", qdcount, ancount);
+        }
     }
 
     // Parse question sections


### PR DESCRIPTION
## Summary

This PR solves the following error on kernel `5.15`, when `g_bpf_debug=true`:
```
2026-03-24T12:42:54.5889915Z         load program: invalid argument:
2026-03-24T12:42:54.5911977Z         	; asm("%[res] = *(u32 *)(%[base] + %[offset])"
2026-03-24T12:42:54.5930805Z         	0: (61) r4 = *(u32 *)(r1 +0)
2026-03-24T12:42:54.5952407Z         	; asm("%[res] = *(u32 *)(%[base] + %[offset])"
2026-03-24T12:42:54.5970596Z         	1: (61) r2 = *(u32 *)(r1 +4)
2026-03-24T12:42:54.5998464Z         	; return (data + sizeof(struct iphdr) > ctx_xdp_data_end(ctx)) ? NULL : data;
2026-03-24T12:42:54.6009150Z         	2: (bf) r3 = r4
2026-03-24T12:42:54.6020387Z         	3: (07) r3 += 34
2026-03-24T12:42:54.6031873Z         	; if (!iph) {
2026-03-24T12:42:54.6048345Z         	4: (2d) if r3 > r2 goto pc+1550
2026-03-24T12:42:54.6084919Z         	 R1=ctx(id=0,off=0,imm=0) R2_w=pkt_end(id=0,off=0,imm=0) R3_w=pkt(id=0,off=34,r=34,imm=0) R4_w=pkt(id=0,off=0,r=34,imm=0) R10=fp0
2026-03-24T12:42:54.6095731Z         	5: (bf) r9 = r4
2026-03-24T12:42:54.6106714Z         	6: (07) r9 += 14
2026-03-24T12:42:54.6122821Z         	; if (iph->protocol != IPPROTO_UDP) {
...
// very long output
...
2026-03-24T12:42:56.0378749Z         	535: (7b) *(u64 *)(r10 -152) = r3
2026-03-24T12:42:56.0398563Z         	; bpf_dbg_printk("id=%x, qr=%u, opcode=%u, aa=%u, tc=%u, rd=%u, ra=%u\n",
2026-03-24T12:42:56.0408867Z         	536: (7b) *(u64 *)(r10 -16) = r3
2026-03-24T12:42:56.0419175Z         	537: (7b) *(u64 *)(r10 -104) = r1
2026-03-24T12:42:56.0429934Z         	538: (7b) *(u64 *)(r10 -24) = r1
2026-03-24T12:42:56.0440506Z         	539: (7b) *(u64 *)(r10 -32) = r9
2026-03-24T12:42:56.0450990Z         	540: (7b) *(u64 *)(r10 -40) = r7
2026-03-24T12:42:56.0457513Z         	541: (b7) r1 = 0
2026-03-24T12:42:56.0467830Z         	542: (7b) *(u64 *)(r10 -48) = r1
2026-03-24T12:42:56.0476743Z         	last_idx 542 first_idx 520
2026-03-24T12:42:56.0488711Z         	regs=2 stack=0 before 541: (b7) r1 = 0
2026-03-24T12:42:56.0499389Z         	543: (7b) *(u64 *)(r10 -144) = r2
2026-03-24T12:42:56.0510052Z         	544: (7b) *(u64 *)(r10 -56) = r2
2026-03-24T12:42:56.0520522Z         	545: (79) r1 = *(u64 *)(r10 -120)
2026-03-24T12:42:56.0531029Z         	546: (7b) *(u64 *)(r10 -64) = r1
2026-03-24T12:42:56.0538305Z         	547: (bf) r3 = r10
2026-03-24T12:42:56.0545719Z         	548: (07) r3 += -64
2026-03-24T12:42:56.0556648Z         	549: (18) r1 = 0xffffb3d0400f20c3
2026-03-24T12:42:56.0563464Z         	551: (b7) r2 = 53
2026-03-24T12:42:56.0570734Z         	552: (b7) r4 = 56
2026-03-24T12:42:56.0579870Z         	553: (85) call unknown#177
2026-03-24T12:42:56.0588661Z         	invalid func unknown#177
```

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->