### PR TITLE
Fix coverage data report in unit tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -146,19 +146,14 @@ jobs:
         env:
           MATRIX_ID: ${{ matrix.id }}
           MATRIX_PACKAGES: ${{ matrix.packages }}
-        run: make run-unit-test-shard SHARD_ID="${MATRIX_ID}" UNIT_TEST_PACKAGES="${MATRIX_PACKAGES}"
-
-      - name: Exclude generated files from coverage
-        run: grep -vE "(_bpfel.go)|(/opentelemetry-ebpf-instrumentation/internal/test/)|(/opentelemetry-ebpf-instrumentation/configs/)|(.pb.go)|(/pkg/export/otel/metric/)" testoutput/cover-shard-"${MATRIX_ID}".all.txt > testoutput/cover-shard-"${MATRIX_ID}".txt
-        env:
-          MATRIX_ID: ${{ matrix.id }}
+        run: make run-unit-test-shard cov-exclude-generated SHARD_ID="${MATRIX_ID}" UNIT_TEST_PACKAGES="${MATRIX_PACKAGES}"
 
       - name: Report coverage
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          files: ./testoutput/cover-shard-${{ matrix.id }}.txt
+          files: ./testoutput/cover.txt
           flags: unittests
           name: go-unittests-coverage-shard-${{ matrix.id }}-${{ github.run_number }}
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ CILIUM_EBPF_VER ?= v0.20.0
 CILIUM_EBPF_PKG := github.com/cilium/ebpf
 
 # regular expressions for excluded file patterns
-EXCLUDE_COVERAGE_FILES="(_bpfel.go)|(/opentelemetry-ebpf-instrumentation/internal/test/)|(/opentelemetry-ebpf-instrumentation/configs/)|(.pb.go)|(/pkg/export/otel/metric/)"
+EXCLUDE_COVERAGE_FILES="(_bpfel.go)|(/obi/internal/test/)|(/obi/configs/)|(.pb.go)|(/pkg/export/otel/metric/)"
 
 .DEFAULT_GOAL := all
 
@@ -505,7 +505,7 @@ run-unit-test-shard: $(GOTESTSUM) $(ENVTEST)
 	$(GOTESTSUM) \
 		--jsonfile=$(TEST_OUTPUT)/unit-test-shard-$(SHARD_ID).log \
 		-- -short -race -a -coverpkg=./... \
-		-coverprofile $(TEST_OUTPUT)/cover-shard-$(SHARD_ID).all.txt \
+		-coverprofile $(TEST_OUTPUT)/cover.all.txt \
 		$(UNIT_TEST_PACKAGES)
 
 .PHONY: integration-test-matrix-json
@@ -551,7 +551,7 @@ itest-coverage-data:
 	go tool covdata merge -i=$(TEST_OUTPUT) -o $(TEST_OUTPUT)/merge
 	go tool covdata textfmt -i=$(TEST_OUTPUT)/merge -o $(TEST_OUTPUT)/itest-covdata.raw.txt
 	# replace the unexpected /src/cmd/obi/main.go file by the module path
-	sed 's/^\/src\/cmd\//github.com\/open-telemetry\/opentelemetry-ebpf-instrumentation\/cmd\//' $(TEST_OUTPUT)/itest-covdata.raw.txt > $(TEST_OUTPUT)/itest-covdata.all.txt
+	sed 's/^\/src\/cmd\//go.opentelemetry.io\/obi\/cmd\//' $(TEST_OUTPUT)/itest-covdata.raw.txt > $(TEST_OUTPUT)/itest-covdata.all.txt
 	# exclude generated files from coverage data
 	grep -vE $(EXCLUDE_COVERAGE_FILES) $(TEST_OUTPUT)/itest-covdata.all.txt > $(TEST_OUTPUT)/itest-covdata.txt || true
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,13 @@ CILIUM_EBPF_VER ?= v0.20.0
 CILIUM_EBPF_PKG := github.com/cilium/ebpf
 
 # regular expressions for excluded file patterns
-EXCLUDE_COVERAGE_FILES="(_bpfel.go)|(/obi/internal/test/)|(/obi/configs/)|(.pb.go)|(/pkg/export/otel/metric/)"
+EXCLUDE_COVERAGE_FILES := "(_bpfel.go)|(.pb.go)|$\
+(/cmd/generate-port-lookup/)|$\
+(/cmd/obi-schema/)|$\
+(/obi/configs/)|$\
+(/obi/examples/)|$\
+(/obi/internal/test/)|$\
+(/pkg/export/otel/metric/)"
 
 .DEFAULT_GOAL := all
 


### PR DESCRIPTION
## Summary

Reported coverage numbers were way lower than real coverage, mainly because each shard of the test matrices shared the same code coverage flag.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->