### PR TITLE
Fix Native Java image creation

### DIFF
--- a/internal/test/integration/components/java_tls/sync_async_tls/pom.xml
+++ b/internal/test/integration/components/java_tls/sync_async_tls/pom.xml
@@ -76,6 +76,7 @@
 			<plugin>
 				<groupId>org.graalvm.buildtools</groupId>
 				<artifactId>native-maven-plugin</artifactId>
+				<version>0.10.6</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/internal/test/integration/components/javakafka-lb/pom400.xml
+++ b/internal/test/integration/components/javakafka-lb/pom400.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -33,6 +32,7 @@
 			<plugin>
 				<groupId>org.graalvm.buildtools</groupId>
 				<artifactId>native-maven-plugin</artifactId>
+				<version>0.10.6</version>
 			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/internal/test/integration/components/javakafka/pom.xml
+++ b/internal/test/integration/components/javakafka/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -33,6 +32,7 @@
 			<plugin>
 				<groupId>org.graalvm.buildtools</groupId>
 				<artifactId>native-maven-plugin</artifactId>
+				<version>0.10.6</version>
 			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/internal/test/integration/components/javakafka/pom400.xml
+++ b/internal/test/integration/components/javakafka/pom400.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -33,6 +32,7 @@
 			<plugin>
 				<groupId>org.graalvm.buildtools</groupId>
 				<artifactId>native-maven-plugin</artifactId>
+				<version>0.10.6</version>
 			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/internal/test/integration/components/javatestserver/pom.xml
+++ b/internal/test/integration/components/javatestserver/pom.xml
@@ -77,6 +77,7 @@
 			<plugin>
 				<groupId>org.graalvm.buildtools</groupId>
 				<artifactId>native-maven-plugin</artifactId>
+				<version>0.10.6</version>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
## Summary

Some Java tests suddenly started to fail because the last version of the native java maven plugin is incompatible with Graal 22, so I pinned it to an older version.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->