### PR TITLE
Update bpf verifier test with constants

### DIFF
--- a/pkg/internal/ebpf/verifier/bpf_verifier_test.go
+++ b/pkg/internal/ebpf/verifier/bpf_verifier_test.go
@@ -166,16 +166,11 @@ func TestBPFVerifierWithConstants(t *testing.T) {
 	})
 
 	// gotracer
-	// g_bpf_loop_enabled=true requires bpf_loop (kernel >= 5.17).
-	bpfLoopValues := []any{false}
-	if ebpfcommon.SupportsEBPFLoops(slog.Default(), false) {
-		bpfLoopValues = []any{true, false}
-	}
 	forEachCombination(t, "gotracer/Bpf", gotracerbpf.LoadBpf, []constOption{
 		{"g_bpf_debug", []any{true, false}},
 		{"g_bpf_traceparent_enabled", []any{true, false}},
 		{"g_bpf_header_propagation", []any{true, false}},
-		{"g_bpf_loop_enabled", bpfLoopValues},
+		{"g_bpf_loop_enabled", []any{ebpfcommon.SupportsEBPFLoops(slog.Default(), false)}},
 		{"disable_black_box_cp", []any{uint32(0), uint32(1)}},
 	})
 


### PR DESCRIPTION
## Summary

This PR replaces `TestBPFVerifier` with `TestBPFVerifierWithConstants`, which tests the bpf verifier across all combinations of constant values (debug flags, feature toggles, sampling rates, etc.). 

This is useful to check the verifier accepts all bpf programs under every combination of runtime constants, since different constant values cause the verifier to evaluate different code paths. 

For example, it found a bug on kernel 5.15 solved here #1654.


## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->