### PR TITLE
docs: add trace-profile correlation spec

### DIFF
--- a/devdocs/README.md
+++ b/devdocs/README.md
@@ -14,3 +14,4 @@ This directory contains documentation that is not useful for our users but might
 - [Dependency Integrity Policy](dependency-integrity-policy.md): required dependency pinning and verification rules for Dockerfiles.
 - [Statistical Metrics](statsolly.md): it explains how to add a new statitiscal metric to OBI.
 - [Python asyncio and uvloop Context Propagation](python-asyncio-context-propagation.md): architecture and implementation of Python async context propagation for `asyncio` workloads, including applications running on `uvloop`.
+- [Trace-Profile Correlation](trace-profile-correlation.md): standard communication channel for correlating profiles to OBI traces.

--- a/devdocs/trace-profile-correlation.md
+++ b/devdocs/trace-profile-correlation.md
@@ -1,0 +1,54 @@
+# Correlating Profiles to OBI Traces
+
+This document introduces a standard communication channel and a specification for correlating profiles to OBI traces.
+
+## Table Of Contents
+
+- [Motivation](#motivation)
+- [Design Notes](#design-notes)
+  - [Communication Channel](#communication-channel)
+  - [Data Model](#data-model)
+    - [eBPF Map Specification](#ebpf-map-specification)
+
+## Motivation
+
+Currently, OBI traces and profiles operate independently, making it difficult to attribute profiling data to specific traces or spans. By establishing a standard kernel-resident communication channel, this document enables:
+
+- Correlating profiles with their corresponding traces or spans
+- End-to-end observability workflows without requiring application-level instrumentation
+
+## Design Notes
+
+### Communication Channel
+
+The communication channel between OBI and the profiler is implemented via an eBPF map pinned at `$PINPATH/otel/traces_ctx_v1`.
+
+`$PINPATH` will default to bpffs (`/sys/fs/bpf`) but there must be options to specify an alternative location. If set, the user-configured location in OBI must match the one set in the profiler.
+
+On startup, both OBI and the profiler will create the map and pin it if it doesn't exist.
+
+### Data Model
+
+The shared eBPF map uses a minimal structure to store correlation data. OBI will be responsible for removing entries in order to avoid keeping stale contexts.
+
+#### eBPF Map Specification
+
+```c
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u64);
+    __type(value, struct trace_context);
+    __uint(max_entries, 1 << 14);
+    __uint(pinning, LIBBPF_PIN_BY_NAME);
+} traces_ctx_v1 SEC(".maps");
+```
+
+- **Key:** `(u64) pid_tgid`
+- **Value:**
+
+```c
+struct trace_context {
+    u8 trace_id[16];
+    u8 span_id[8];
+};
+```


### PR DESCRIPTION
## Summary

In the spec SIG it was agreed to not have an OTEP (https://github.com/open-telemetry/opentelemetry-specification/pull/4855) for now, so moving the spec here since it's OBI specific.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->