### PR TITLE
ci:  fail docker builds faster with compiler errors

### DIFF
--- a/cmd/obi/main.go
+++ b/cmd/obi/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	lvl = slog.LevelVar{}
+	lvl := slog.LevelVar{}
 	lvl.Set(slog.LevelInfo)
 
 	configPath := flag.String("config", "", "path to the configuration file")


### PR DESCRIPTION
## Summary

When a code change introduces a Go compiler error, the OATs CI workflow has jobs that will run until timeout (45 minutes). These jobs are waiting for a condition that will never be satisfied, because the Docker image was never built successfully.

To efficiently verify the compilation early, this PR introduces a Docker image build attempt BEFORE the OATs test suites executes, this does two things:

1. Early build attempt in dedicated CI step clearly communicates the compiler error and prevents long-running jobs from executing
2. Warms the docker build cache for the current build step, so wall clock execution time is hardly affected

First commit (acf0ce394) introduces an intentional compilation error to reproduce the issue:

<img width="821" height="312" alt="Screenshot 2026-03-31 at 14 33 17" src="https://github.com/user-attachments/assets/1f379fb6-56ef-485d-b43d-a4a19aa66c0d" />

Second commit (b94d159e3) adds the early build steps to the OATs workflow:

<img width="815" height="310" alt="Screenshot 2026-03-31 at 15 25 32" src="https://github.com/user-attachments/assets/7d7d6eb0-28c9-4049-9aab-58ef8ef55408" />

Third commit (064c03b8f) reverts the first.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->