### PR TITLE
Update obi-generator to Go 1.26.1

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS base
+FROM golang:1.26.1-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS base
 FROM base AS dist
 
 WORKDIR /src

--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa AS base
+FROM golang:1.26.1-alpine AS base
 FROM base AS dist
 
 WORKDIR /src


### PR DESCRIPTION
## Summary

This is a required previous step for this other PR: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1691

After this is merged, we will publish `obi-generator:0.3.0` and update the image coordinates in PR #1691

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->