### PR TITLE
Fix OATS tests output path

### DIFF
--- a/internal/test/oats/harness/compose.go
+++ b/internal/test/oats/harness/compose.go
@@ -1,0 +1,147 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package harness // import "go.opentelemetry.io/obi/internal/test/oats/harness"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/grafana/oats/model"
+	"github.com/grafana/oats/testhelpers/remote"
+	oatsyaml "github.com/grafana/oats/yaml"
+	"github.com/onsi/ginkgo/v2"
+)
+
+type compose struct {
+	path   string
+	logger io.WriteCloser
+	env    []string
+}
+
+func startEndpoint(c *model.TestCase, settings model.Settings, logFile string) (*remote.Endpoint, error) {
+	composePath := oatsyaml.CreateDockerComposeFile(oatsyaml.NewRunner(c, settings))
+	compose, err := newCompose(composePath, logFile)
+	if err != nil {
+		return nil, err
+	}
+
+	ports := remote.PortsConfig{
+		PrometheusHTTPPort: c.PortConfig.PrometheusHTTPPort,
+		TempoHTTPPort:      c.PortConfig.TempoHTTPPort,
+		LokiHttpPort:       c.PortConfig.LokiHTTPPort,
+		PyroscopeHttpPort:  c.PortConfig.PyroscopeHttpPort,
+	}
+
+	return remote.NewEndpoint(
+		settings.Host,
+		ports,
+		func(context.Context) error {
+			return compose.up()
+		},
+		func(context.Context) error {
+			return compose.close()
+		},
+		func(consume func(io.ReadCloser, *sync.WaitGroup)) error {
+			return compose.logsToConsumer(consume)
+		},
+	), nil
+}
+
+func newCompose(composeFile, logFile string) (*compose, error) {
+	logs, err := os.OpenFile(logFile, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o666)
+	if err != nil {
+		return nil, err
+	}
+
+	abs, err := filepath.Abs(logFile)
+	if err == nil {
+		ginkgo.GinkgoWriter.Printf("Logging to %s\n", abs)
+	}
+
+	return &compose{
+		path:   composeFile,
+		logger: logs,
+		env:    os.Environ(),
+	}, nil
+}
+
+func (c *compose) up() error {
+	return c.command("up", "--build", "--detach", "--force-recreate")
+}
+
+func (c *compose) logsToConsumer(consume func(io.ReadCloser, *sync.WaitGroup)) error {
+	cmd := exec.Command("docker", "compose", "--ansi", "never", "-f", c.path, "logs")
+	cmd.Env = c.env
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create compose logs pipe: %w", err)
+	}
+	cmd.Stderr = cmd.Stdout
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go consume(stdout, &wg)
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start docker compose logs: %w", err)
+	}
+
+	waitErr := cmd.Wait()
+	wg.Wait()
+	if waitErr != nil {
+		return fmt.Errorf("failed to run docker compose logs: %w", waitErr)
+	}
+
+	return nil
+}
+
+func (c *compose) close() error {
+	var errs []string
+
+	if err := c.command("logs"); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := c.command("stop"); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := c.command("rm", "-f"); err != nil {
+		errs = append(errs, err.Error())
+	}
+	if err := c.logger.Close(); err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errors.New(strings.Join(errs, " / "))
+}
+
+func (c *compose) command(args ...string) error {
+	cmdArgs := []string{"compose", "--ansi", "never", "-f", c.path}
+	cmdArgs = append(cmdArgs, args...)
+	cmd := exec.Command("docker", cmdArgs...)
+	cmd.Env = c.env
+	cmd.Stdout = c.logger
+	cmd.Stderr = c.logger
+
+	if _, err := fmt.Fprintf(c.logger, "Running: docker %s\n", strings.Join(cmdArgs, " ")); err != nil {
+		return fmt.Errorf("failed to write compose command header: %w", err)
+	}
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run docker compose %s: %w", strings.Join(args, " "), err)
+	}
+
+	return nil
+}

--- a/internal/test/oats/harness/harness.go
+++ b/internal/test/oats/harness/harness.go
@@ -4,14 +4,21 @@
 package harness // import "go.opentelemetry.io/obi/internal/test/oats/harness"
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/grafana/oats/model"
-	"github.com/grafana/oats/yaml"
+	"github.com/grafana/oats/testhelpers/remote"
+	oatsyaml "github.com/grafana/oats/yaml"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 )
 
 const suiteName = "Yaml Suite"
@@ -30,13 +37,13 @@ func RegisterSuite() bool {
 			})
 		}
 
-		yaml.VerboseLogging = true
+		oatsyaml.VerboseLogging = true
 		settings := testCaseSettings()
 
 		for i := range cases {
 			c := cases[i]
 			ginkgo.It(c.Name, func() {
-				yaml.RunTestCase(&c, settings)
+				runTestCase(&c, settings)
 			})
 		}
 	})
@@ -48,9 +55,40 @@ func readTestCases() ([]model.TestCase, string) {
 		return nil, ""
 	}
 
-	cases, err := yaml.ReadTestCases([]string{base}, true)
+	cases, err := oatsyaml.ReadTestCases([]string{base}, true)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	return cases, base
+}
+
+func runTestCase(c *model.TestCase, settings model.Settings) {
+	format.MaxLength = 100000
+	if settings.ManualDebug {
+		oatsyaml.RunTestCase(c, settings)
+		return
+	}
+
+	c.OutputDir = oatsyaml.PrepareBuildDir(c.Name)
+	c.ValidateAndSetVariables(gomega.Default)
+
+	logFile := filepath.Join(c.OutputDir, fmt.Sprintf("output-%s.log", c.Name))
+	endpoint, err := startEndpoint(c, settings, logFile)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "expected no error creating an observability endpoint")
+	err = endpoint.Start(context.Background())
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "expected no error starting an observability endpoint")
+
+	defer func() {
+		stopErr := endpoint.Stop(context.Background())
+		gomega.Expect(stopErr).ToNot(gomega.HaveOccurred(), "expected no error stopping the local observability endpoint")
+	}()
+
+	runner := oatsyaml.NewRunner(c, settings)
+	setRunnerEndpoint(runner, endpoint)
+	runner.ExecuteChecks()
+}
+
+func setRunnerEndpoint(runner *oatsyaml.Runner, endpoint *remote.Endpoint) {
+	field := reflect.ValueOf(runner).Elem().FieldByName("endpoint")
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(reflect.ValueOf(endpoint))
 }
 
 func testCaseSettings() model.Settings {


### PR DESCRIPTION
## Summary

In a recent PR (https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1587) we upgraded OATS version. However this broke the output paths for logs and it was polluting the console output with OBI logs.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->