### PR TITLE
Remove check-ebpf-ver-synced make target

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -50,7 +50,7 @@ jobs:
         run: make prereqs docker-generate unit-test-tools
 
       - name: Run checks
-        run: make go-mod-tidy license-header-check notices-update check-go-mod check-ebpf-ver-synced check-config-schema check-clean-work-tree
+        run: make go-mod-tidy license-header-check notices-update check-go-mod check-config-schema check-clean-work-tree
 
       - name: Build unit test matrix
         id: build-matrix

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,6 @@ CFLAGS := -std=gnu17 -O2 -g -Wunaligned-access -Wpacked -Wpadded -Wall -Werror $
 
 CLANG_TIDY ?= clang-tidy
 
-CILIUM_EBPF_VER ?= v0.20.0
-CILIUM_EBPF_PKG := github.com/cilium/ebpf
-
 # regular expressions for excluded file patterns
 EXCLUDE_COVERAGE_FILES="(_bpfel.go)|(/opentelemetry-ebpf-instrumentation/internal/test/)|(/opentelemetry-ebpf-instrumentation/configs/)|(.pb.go)|(/pkg/export/otel/metric/)"
 
@@ -776,16 +773,6 @@ COMMIT ?= "HEAD"
 add-tags: verify-mods
 	@[ "${MODSET}" ] || ( echo ">> env var MODSET is not set"; exit 1 )
 	$(MULTIMOD) tag -m ${MODSET} -c ${COMMIT}
-
-.PHONY: check-ebpf-ver-synced
-check-ebpf-ver-synced:
-	@if grep -Fq "$(CILIUM_EBPF_PKG) $(CILIUM_EBPF_VER)" go.mod && \
-	   grep -Fq "$(CILIUM_EBPF_PKG) $(CILIUM_EBPF_VER)" bpf/bpfcore/placeholder.go; then \
-		echo "ebpf lib version in sync"; \
-	else \
-		echo "ebpf lib version out of sync between go.mod and bpf/bpfcore/placeholder.go!"; \
-		exit 1; \
-	fi
 
 .PHONY: vanity-import-check
 vanity-import-check: $(PORTO)

--- a/bpf/bpfcore/placeholder.go
+++ b/bpf/bpfcore/placeholder.go
@@ -4,6 +4,3 @@
 //go:build obi_bpf
 
 package bpfcore // import "go.opentelemetry.io/obi/bpf/bpfcore"
-
-// Store loader version here in order to run the full test suite on upgrades.
-// github.com/cilium/ebpf v0.20.0


### PR DESCRIPTION
This target was used to ensure the github.com/cilium/ebpf package version was the same in the generator as that used locally. This was made unneeded in #1290.

Blocking #1624