### PR TITLE
Fix DynamicMatcher panic

### DIFF
--- a/pkg/appolly/discover/matcher_dynamic.go
+++ b/pkg/appolly/discover/matcher_dynamic.go
@@ -34,17 +34,15 @@ func dynamicMatcherProvider(
 		return swarm.DirectInstance(emptyFunc)
 	}
 
-	return swarm.DirectInstance(func(ctx context.Context) {
-		dynamicMatcher := &DynamicMatcher{
-			Log:                slog.With("component", "discover.DynamicMatcher"),
-			DynamicPIDSelector: dynamicPIDs.AsSelector(),
-			Input:              input.Subscribe(msg.SubscriberName("discover.DynamicMatcher")),
-			Output:             output,
-			ProcessHistory:     map[app.PID]ProcessMatch{},
-			RemovedPIDsNotify:  dynamicPIDs.RemovedNotify(),
-		}
-		dynamicMatcher.Run(ctx)
-	})
+	dynamicMatcher := &DynamicMatcher{
+		Log:                slog.With("component", "discover.DynamicMatcher"),
+		DynamicPIDSelector: dynamicPIDs.AsSelector(),
+		Input:              input.Subscribe(msg.SubscriberName("discover.DynamicMatcher")),
+		Output:             output,
+		ProcessHistory:     map[app.PID]ProcessMatch{},
+		RemovedPIDsNotify:  dynamicPIDs.RemovedNotify(),
+	}
+	return swarm.DirectInstance(dynamicMatcher.Run)
 }
 
 func (m *DynamicMatcher) Run(ctx context.Context) {


### PR DESCRIPTION
## Summary

`input.Subscribe` was invoked during the pipeline run stage, once all nodes are instantiated, some of them are already running and some message queues were automatically discarded/bypassed. This caused (only observed in unit tests so far) a race condition in the DynamicMatcher trying to subscribe to a Queue that was already closed.

`input.Subscribe` method should be created during the pipeline creation/instantiation stage.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->