### PR TITLE
fix: netolly flaky test when guess_ports is disable

### DIFF
--- a/internal/test/integration/k8s/manifests/06-obi-netolly.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-netolly.yml
@@ -8,6 +8,7 @@ data:
     otel_metrics_export:
       endpoint: http://otelcol.default:4317
     network:
+      guess_ports: ordinal
       protocols:
         - TCP
       cidrs:


### PR DESCRIPTION
## Summary

The netolly shard of the k8s integration test suite is flaky. The fix is to set `guess_ports: ordinal` in the manifest (as already done in other manifests). Default `guess_ports` is `disable`, which can leave server/client ports unset when the initiator is unknown and makes `TestNetworkFlowBytes` fail on `server_port` assertions.

[Example](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/23838971064/job/69489556126?pr=1700):

```
=== FAIL: internal/test/integration/k8s/netolly TestNetworkFlowBytes/network_flow_bytes/catches_network_metrics_between_connected_pods (re-run 2) (300.00s)
    k8s_netolly_network_metrics.go:52: 
        	Error Trace:	/home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/internal/test/integration/k8s/netolly/k8s_netolly_network_metrics.go:79
        	            				/opt/hostedtoolcache/go/1.25.8/x64/src/runtime/asm_amd64.s:1693
        	Error:      	Not equal: 
        	            	expected: "8080"
        	            	actual  : "0"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-8080
        	            	+0
    k8s_netolly_network_metrics.go:52: 
        	Error Trace:	/home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/internal/test/integration/k8s/netolly/k8s_netolly_network_metrics.go:52
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.6.0/pkg/env/env.go:475
        	            				/home/runner/go/pkg/mod/sigs.k8s.io/e2e-framework@v0.6.0/pkg/env/env.go:518
        	Error:      	Condition never satisfied
        	Test:       	TestNetworkFlowBytes/network_flow_bytes/catches_network_metrics_between_connected_pods
```

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->