### PR TITLE
Fix register spilling on decode hex

### DIFF
--- a/bpf/common/trace_util.h
+++ b/bpf/common/trace_util.h
@@ -45,8 +45,8 @@ static __always_inline void urand_bytes(unsigned char *buf, u32 size) {
 
 static __always_inline void decode_hex(unsigned char *dst, const unsigned char *src, u32 src_len) {
     for (u32 i = 1, j = 0; i < src_len; i += 2) {
-        unsigned char p = src[i - 1];
-        unsigned char q = src[i];
+        unsigned char p = *src++;
+        unsigned char q = *src++;
 
         unsigned char a = reverse_hex[p & 0xff];
         unsigned char b = reverse_hex[q & 0xff];


### PR DESCRIPTION
## Summary

Writing `p = src[i];` causes clang to spill the current pointer value `src` to another register, e.g.

```
r3 = r2
r3 += i

*r4 = *r3
```

which is wasteful and prevents proper range-validation when `p aka rX` is a pointer to packet, so the following code may not work:

```
const unsigned char *ptr = skb->data;

if (ptr + FOO > skb->data_end) // range validate ptr
  return;

decode_hex(dst, ptr, FOO); // breaks
```

as the verifier will have validated `r3` (in the example above)` but not `r4`. The trick with incrementing the pointer causes the generated asm to look like:

```
r2 += 1 // increments ptr directly -> range validated
*r4 = r2
```

This is relevant in particular for tpinjector.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->