### PR TITLE
Add dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,21 @@
+# https://docs.github.com/en/code-security/concepts/supply-chain-security/about-the-dependabot-yml-file
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"              
+    directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14


### PR DESCRIPTION
## Summary

This PR resolves #16 

I saw that Dependabot does not work recursively by default, so `directory: "/"` should be enough to remove `internal/test/*` and `configs/offsets`. Finally it adds:
```
commit-message:
      prefix: "chore"
```
which AFAIU is a best practice.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->