### PR TITLE
feat: add named CIDR labels

### DIFF
--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -183,10 +183,32 @@
     },
     "Definitions": {
       "items": {
-        "type": "string"
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "A CIDR range (e.g. \"10.0.0.0/8\"). The CIDR string is used as the attribute value."
+          },
+          {
+            "properties": {
+              "cidr": {
+                "type": "string",
+                "description": "A CIDR range (e.g. \"10.0.0.0/8\")."
+              },
+              "name": {
+                "type": "string",
+                "description": "A human-readable name for this CIDR. Used as the attribute value instead of the CIDR string."
+              }
+            },
+            "type": "object",
+            "required": [
+              "cidr"
+            ],
+            "description": "A named CIDR entry."
+          }
+        ]
       },
       "type": "array",
-      "description": "Definitions contains a list of CIDRs to be set as the \"src.cidr\" and \"dst.cidr\" attribute as a function of the source and destination IP addresses."
+      "description": "A list of CIDRs to be set as the \"src.cidr\" and \"dst.cidr\" attribute as a function of the source and destination IP addresses. Each entry can be a plain CIDR string or an object with \"cidr\" and \"name\" fields."
     },
     "DiscoveryConfig": {
       "properties": {

--- a/pkg/internal/pipe/cidr/cidr.go
+++ b/pkg/internal/pipe/cidr/cidr.go
@@ -8,8 +8,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 
+	"github.com/invopop/jsonschema"
 	"github.com/yl2chen/cidranger"
+	"gopkg.in/yaml.v3"
 
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/internal/pipe"
@@ -22,12 +25,121 @@ func glog() *slog.Logger {
 	return slog.With("component", "cidr.Decorator")
 }
 
+// Definition represents a single CIDR entry with an optional human-readable name.
+// When Name is empty, the CIDR string itself is used as the attribute value.
+type Definition struct {
+	CIDR string `yaml:"cidr" json:"cidr"`
+	Name string `yaml:"name" json:"name"`
+}
+
+// Label returns the name if set, otherwise the CIDR string.
+func (d Definition) Label() string {
+	if d.Name != "" {
+		return d.Name
+	}
+	return d.CIDR
+}
+
 // Definitions contains a list of CIDRs to be set as the "src.cidr" and "dst.cidr"
 // attribute as a function of the source and destination IP addresses.
-type Definitions []string
+// It supports two YAML formats:
+//   - A list of CIDR strings: ["10.0.0.0/8", "192.168.0.0/16"]
+//   - A list of named CIDRs: [{cidr: "10.0.0.0/8", name: "internal"}, ...]
+type Definitions []Definition
 
 func (c Definitions) Enabled() bool {
 	return len(c) > 0
+}
+
+// UnmarshalYAML supports both a list of plain CIDR strings and a list of
+// objects with "cidr" and "name" keys.
+func (c *Definitions) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.SequenceNode {
+		return fmt.Errorf("cidrs: expected a YAML sequence, got kind %v", value.Kind)
+	}
+	defs := make(Definitions, 0, len(value.Content))
+	for i, item := range value.Content {
+		switch item.Kind {
+		case yaml.ScalarNode:
+			defs = append(defs, Definition{CIDR: item.Value})
+		case yaml.MappingNode:
+			var d Definition
+			if err := item.Decode(&d); err != nil {
+				return fmt.Errorf("cidrs[%d]: %w", i, err)
+			}
+			if d.CIDR == "" {
+				return fmt.Errorf("cidrs[%d]: missing required 'cidr' field", i)
+			}
+			defs = append(defs, d)
+		default:
+			return fmt.Errorf("cidrs[%d]: unexpected YAML node kind %v", i, item.Kind)
+		}
+	}
+	*c = defs
+	return nil
+}
+
+// UnmarshalText parses comma-separated CIDR strings from environment variables.
+func (c *Definitions) UnmarshalText(text []byte) error {
+	s := strings.TrimSpace(string(text))
+	if s == "" {
+		*c = nil
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	defs := make(Definitions, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			defs = append(defs, Definition{CIDR: p})
+		}
+	}
+	*c = defs
+	return nil
+}
+
+// Validate checks that all CIDR strings are valid.
+func (c Definitions) Validate() error {
+	for i, d := range c {
+		if _, _, err := net.ParseCIDR(d.CIDR); err != nil {
+			return fmt.Errorf("cidrs[%d]: parsing CIDR %q: %w", i, d.CIDR, err)
+		}
+	}
+	return nil
+}
+
+// JSONSchema returns a schema that accepts both a list of CIDR strings and a
+// list of objects with "cidr" and "name" keys.
+func (Definitions) JSONSchema() *jsonschema.Schema {
+	namedCIDRProps := jsonschema.NewProperties()
+	namedCIDRProps.Set("cidr", &jsonschema.Schema{
+		Type:        "string",
+		Description: "A CIDR range (e.g. \"10.0.0.0/8\").",
+	})
+	namedCIDRProps.Set("name", &jsonschema.Schema{
+		Type:        "string",
+		Description: "A human-readable name for this CIDR. Used as the attribute value instead of the CIDR string.",
+	})
+	return &jsonschema.Schema{
+		Type: "array",
+		Items: &jsonschema.Schema{
+			OneOf: []*jsonschema.Schema{
+				{
+					Type:        "string",
+					Description: "A CIDR range (e.g. \"10.0.0.0/8\"). The CIDR string is used as the attribute value.",
+				},
+				{
+					Type:        "object",
+					Properties:  namedCIDRProps,
+					Required:    []string{"cidr"},
+					Description: "A named CIDR entry.",
+				},
+			},
+		},
+		Description: "A list of CIDRs to be set as the \"src.cidr\" and \"dst.cidr\" " +
+			"attribute as a function of the source and destination IP addresses. " +
+			"Each entry can be a plain CIDR string or an object with \"cidr\" and \"name\" fields.",
+	}
 }
 
 type ipGrouper struct {
@@ -60,7 +172,7 @@ func DecoratorProvider[T any](g Definitions, attrs func(T) *pipe.CommonAttrs,
 
 type customRangerEntry struct {
 	ipNet net.IPNet
-	cidr  string
+	label string
 }
 
 func (b *customRangerEntry) Network() net.IPNet {
@@ -69,13 +181,13 @@ func (b *customRangerEntry) Network() net.IPNet {
 
 func newIPGrouper(cfg Definitions) (ipGrouper, error) {
 	g := ipGrouper{ranger: cidranger.NewPCTrieRanger()}
-	for _, cidr := range cfg {
-		_, ipNet, err := net.ParseCIDR(cidr)
+	for _, def := range cfg {
+		_, ipNet, err := net.ParseCIDR(def.CIDR)
 		if err != nil {
-			return g, fmt.Errorf("parsing CIDR %s: %w", cidr, err)
+			return g, fmt.Errorf("parsing CIDR %s: %w", def.CIDR, err)
 		}
-		if err := g.ranger.Insert(&customRangerEntry{ipNet: *ipNet, cidr: cidr}); err != nil {
-			return g, fmt.Errorf("inserting CIDR %s: %w", cidr, err)
+		if err := g.ranger.Insert(&customRangerEntry{ipNet: *ipNet, label: def.Label()}); err != nil {
+			return g, fmt.Errorf("inserting CIDR %s: %w", def.CIDR, err)
 		}
 	}
 	return g, nil
@@ -87,7 +199,7 @@ func (g *ipGrouper) CIDR(ip net.IP) string {
 		return ""
 	}
 	// will always return the narrower matching CIDR
-	return entries[len(entries)-1].(*customRangerEntry).cidr
+	return entries[len(entries)-1].(*customRangerEntry).label
 }
 
 func (g *ipGrouper) decorate(a *pipe.CommonAttrs) {

--- a/pkg/internal/pipe/cidr/cidr_test.go
+++ b/pkg/internal/pipe/cidr/cidr_test.go
@@ -223,6 +223,85 @@ func TestDefinition_Label(t *testing.T) {
 	assert.Equal(t, "10.0.0.0/8", Definition{CIDR: "10.0.0.0/8"}.Label())
 }
 
+func TestEnvironmentVariableHandling(t *testing.T) {
+	// Test that the environment variable handling of OTEL_EBPF_NETWORK_CIDRS still works
+	// by verifying that comma-separated CIDR strings are correctly parsed.
+	// This test ensures backward compatibility with the old behavior.
+	// Note: UnmarshalText accepts any string and doesn't validate - validation is done
+	// separately via the Validate() method which is called during config validation.
+
+	tests := []struct {
+		name     string
+		envValue string
+		expected Definitions
+	}{
+		{
+			name:     "Single CIDR",
+			envValue: "10.0.0.0/8",
+			expected: Definitions{{CIDR: "10.0.0.0/8"}},
+		},
+		{
+			name:     "Multiple CIDRs comma-separated",
+			envValue: "10.0.0.0/8,192.168.0.0/16,2001::/16",
+			expected: Definitions{
+				{CIDR: "10.0.0.0/8"},
+				{CIDR: "192.168.0.0/16"},
+				{CIDR: "2001::/16"},
+			},
+		},
+		{
+			name:     "CIDRs with spaces around commas",
+			envValue: "10.0.0.0/8 , 192.168.0.0/16 , 2001::/16",
+			expected: Definitions{
+				{CIDR: "10.0.0.0/8"},
+				{CIDR: "192.168.0.0/16"},
+				{CIDR: "2001::/16"},
+			},
+		},
+		{
+			name:     "Empty environment variable",
+			envValue: "",
+			expected: nil,
+		},
+		{
+			name:     "Whitespace only",
+			envValue: "   ",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d Definitions
+			err := d.UnmarshalText([]byte(tt.envValue))
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, d)
+
+			// Verify that valid definitions validate correctly
+			if len(d) > 0 {
+				require.NoError(t, d.Validate())
+			}
+		})
+	}
+
+	// Test that invalid CIDRs are caught during validation (not during unmarshaling)
+	t.Run("Invalid CIDR format caught during validation", func(t *testing.T) {
+		var d Definitions
+		require.NoError(t, d.UnmarshalText([]byte("not-a-cidr")))
+		err := d.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not-a-cidr")
+	})
+
+	t.Run("Mix of valid and invalid CIDRs caught during validation", func(t *testing.T) {
+		var d Definitions
+		require.NoError(t, d.UnmarshalText([]byte("10.0.0.0/8,invalid-cidr")))
+		err := d.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid-cidr")
+	})
+}
+
 func flow(srcIP, dstIP string) *testRecord {
 	r := &testRecord{}
 	copy(r.SrcAddr[:], net.ParseIP(srcIP).To16())

--- a/pkg/internal/pipe/cidr/cidr_test.go
+++ b/pkg/internal/pipe/cidr/cidr_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"go.opentelemetry.io/obi/pkg/internal/pipe"
 	"go.opentelemetry.io/obi/pkg/internal/testutil"
@@ -22,18 +23,26 @@ type testRecord struct {
 	pipe.CommonAttrs
 }
 
+func defs(cidrs ...string) Definitions {
+	d := make(Definitions, len(cidrs))
+	for i, c := range cidrs {
+		d[i] = Definition{CIDR: c}
+	}
+	return d
+}
+
 func TestCIDRDecorator(t *testing.T) {
 	input := msg.NewQueue[[]*testRecord](msg.ChannelBufferLen(10))
 	defer input.Close()
 	outputQu := msg.NewQueue[[]*testRecord](msg.ChannelBufferLen(10))
 	outCh := outputQu.Subscribe()
-	grouper, err := DecoratorProvider([]string{
+	grouper, err := DecoratorProvider(defs(
 		"10.0.0.0/8",
 		"10.1.2.0/24",
 		"140.130.22.0/24",
 		"2001:db8:3c4d:15::/64",
 		"2001::/16",
-	}, func(r *testRecord) *pipe.CommonAttrs { return &r.CommonAttrs },
+	), func(r *testRecord) *pipe.CommonAttrs { return &r.CommonAttrs },
 		input, outputQu)(t.Context())
 	require.NoError(t, err)
 	go grouper(t.Context())
@@ -60,14 +69,14 @@ func TestCIDRDecorator_GroupAllUnknownTraffic(t *testing.T) {
 	defer input.Close()
 	outputQu := msg.NewQueue[[]*testRecord](msg.ChannelBufferLen(10))
 	outCh := outputQu.Subscribe()
-	grouper, err := DecoratorProvider([]string{
+	grouper, err := DecoratorProvider(defs(
 		"10.0.0.0/8",
 		"10.1.2.0/24",
 		"0.0.0.0/0", // this entry will capture all the unknown traffic
 		"140.130.22.0/24",
 		"2001:db8:3c4d:15::/64",
 		"2001::/16",
-	}, func(r *testRecord) *pipe.CommonAttrs { return &r.CommonAttrs },
+	), func(r *testRecord) *pipe.CommonAttrs { return &r.CommonAttrs },
 		input, outputQu)(t.Context())
 	require.NoError(t, err)
 	go grouper(t.Context())
@@ -87,6 +96,131 @@ func TestCIDRDecorator_GroupAllUnknownTraffic(t *testing.T) {
 	assert.Equal(t, "0.0.0.0/0", decorated[2].Metadata["dst.cidr"])
 	assert.Equal(t, "0.0.0.0/0", decorated[3].Metadata["src.cidr"])
 	assert.Equal(t, "10.1.2.0/24", decorated[3].Metadata["dst.cidr"])
+}
+
+func TestCIDRDecorator_NamedCIDRs(t *testing.T) {
+	input := msg.NewQueue[[]*testRecord](msg.ChannelBufferLen(10))
+	defer input.Close()
+	outputQu := msg.NewQueue[[]*testRecord](msg.ChannelBufferLen(10))
+	outCh := outputQu.Subscribe()
+	grouper, err := DecoratorProvider(Definitions{
+		{CIDR: "10.0.0.0/8", Name: "cluster-internal"},
+		{CIDR: "10.1.2.0/24", Name: "pod-network"},
+		{CIDR: "140.130.22.0/24", Name: "office"},
+		{CIDR: "2001:db8:3c4d:15::/64", Name: "ipv6-pods"},
+		{CIDR: "2001::/16"},
+	}, func(r *testRecord) *pipe.CommonAttrs { return &r.CommonAttrs },
+		input, outputQu)(t.Context())
+	require.NoError(t, err)
+	go grouper(t.Context())
+	input.Send([]*testRecord{
+		flow("10.3.4.5", "10.1.2.3"),
+		flow("2001:db8:3c4d:15:3210::", "2001:3333:3333::"),
+		flow("140.130.22.11", "140.130.23.11"),
+		flow("180.130.22.11", "10.1.2.4"),
+	})
+	decorated := testutil.ReadChannel(t, outCh, testTimeout)
+	require.Len(t, decorated, 4)
+	assert.Equal(t, "cluster-internal", decorated[0].Metadata["src.cidr"])
+	assert.Equal(t, "pod-network", decorated[0].Metadata["dst.cidr"])
+	assert.Equal(t, "ipv6-pods", decorated[1].Metadata["src.cidr"])
+	assert.Equal(t, "2001::/16", decorated[1].Metadata["dst.cidr"])
+	assert.Equal(t, "office", decorated[2].Metadata["src.cidr"])
+	assert.Empty(t, decorated[2].Metadata["dst.cidr"])
+	assert.Empty(t, decorated[3].Metadata["src.cidr"])
+	assert.Equal(t, "pod-network", decorated[3].Metadata["dst.cidr"])
+}
+
+func TestUnmarshalYAML_PlainStrings(t *testing.T) {
+	yamlData := `
+- 10.0.0.0/8
+- 192.168.0.0/16
+- 2001::/16
+`
+	var d Definitions
+	require.NoError(t, yaml.Unmarshal([]byte(yamlData), &d))
+	require.Len(t, d, 3)
+	assert.Equal(t, Definition{CIDR: "10.0.0.0/8"}, d[0])
+	assert.Equal(t, Definition{CIDR: "192.168.0.0/16"}, d[1])
+	assert.Equal(t, Definition{CIDR: "2001::/16"}, d[2])
+}
+
+func TestUnmarshalYAML_NamedCIDRs(t *testing.T) {
+	yamlData := `
+- cidr: 10.0.0.0/8
+  name: cluster-internal
+- cidr: 192.168.0.0/16
+  name: private
+- cidr: 172.16.0.0/12
+`
+	var d Definitions
+	require.NoError(t, yaml.Unmarshal([]byte(yamlData), &d))
+	require.Len(t, d, 3)
+	assert.Equal(t, Definition{CIDR: "10.0.0.0/8", Name: "cluster-internal"}, d[0])
+	assert.Equal(t, Definition{CIDR: "192.168.0.0/16", Name: "private"}, d[1])
+	assert.Equal(t, Definition{CIDR: "172.16.0.0/12"}, d[2])
+}
+
+func TestUnmarshalYAML_MixedFormats(t *testing.T) {
+	yamlData := `
+- 10.0.0.0/8
+- cidr: 192.168.0.0/16
+  name: private
+- 172.16.0.0/12
+`
+	var d Definitions
+	require.NoError(t, yaml.Unmarshal([]byte(yamlData), &d))
+	require.Len(t, d, 3)
+	assert.Equal(t, Definition{CIDR: "10.0.0.0/8"}, d[0])
+	assert.Equal(t, Definition{CIDR: "192.168.0.0/16", Name: "private"}, d[1])
+	assert.Equal(t, Definition{CIDR: "172.16.0.0/12"}, d[2])
+}
+
+func TestUnmarshalYAML_MissingCIDRField(t *testing.T) {
+	yamlData := `
+- name: missing-cidr
+`
+	var d Definitions
+	err := yaml.Unmarshal([]byte(yamlData), &d)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required 'cidr' field")
+}
+
+func TestUnmarshalText(t *testing.T) {
+	var d Definitions
+	require.NoError(t, d.UnmarshalText([]byte("10.0.0.0/8,192.168.0.0/16,2001::/16")))
+	require.Len(t, d, 3)
+	assert.Equal(t, "10.0.0.0/8", d[0].CIDR)
+	assert.Empty(t, d[0].Name)
+	assert.Equal(t, "192.168.0.0/16", d[1].CIDR)
+	assert.Equal(t, "2001::/16", d[2].CIDR)
+}
+
+func TestUnmarshalText_Empty(t *testing.T) {
+	var d Definitions
+	require.NoError(t, d.UnmarshalText([]byte("")))
+	assert.Nil(t, d)
+}
+
+func TestValidate(t *testing.T) {
+	valid := Definitions{
+		{CIDR: "10.0.0.0/8"},
+		{CIDR: "192.168.0.0/16", Name: "private"},
+	}
+	require.NoError(t, valid.Validate())
+
+	invalid := Definitions{
+		{CIDR: "10.0.0.0/8"},
+		{CIDR: "not-a-cidr", Name: "bad"},
+	}
+	err := invalid.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not-a-cidr")
+}
+
+func TestDefinition_Label(t *testing.T) {
+	assert.Equal(t, "my-network", Definition{CIDR: "10.0.0.0/8", Name: "my-network"}.Label())
+	assert.Equal(t, "10.0.0.0/8", Definition{CIDR: "10.0.0.0/8"}.Label())
 }
 
 func flow(srcIP, dstIP string) *testRecord {

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -619,6 +619,14 @@ func (c *Config) Validate() error {
 		return ConfigError(err.Error())
 	}
 
+	if err := c.NetworkFlows.CIDRs.Validate(); err != nil {
+		return ConfigError("network " + err.Error())
+	}
+
+	if err := c.Stats.CIDRs.Validate(); err != nil {
+		return ConfigError("stats " + err.Error())
+	}
+
 	if !c.Enabled(FeatureNetO11y) && !c.Enabled(FeatureAppO11y) && !c.Enabled(FeatureStatsO11y) {
 		return ConfigError("at least one of 'network', 'application' or 'stats' features must be enabled. " +
 			"Enable an OpenTelemetry or Prometheus metrics export, then enable any of the network*, application* or stats*" +

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -119,7 +119,7 @@ discovery:
 	nc := DefaultNetworkConfig
 	nc.Enable = true
 	nc.AgentIP = "1.2.3.4"
-	nc.CIDRs = cidr.Definitions{"10.244.0.0/16"}
+	nc.CIDRs = cidr.Definitions{{CIDR: "10.244.0.0/16"}}
 
 	sc := DefaultStatsConfig
 

--- a/pkg/obi/network_cfg.go
+++ b/pkg/obi/network_cfg.go
@@ -157,7 +157,7 @@ type NetworkConfig struct {
 	// If an IP matches multiple CIDR definitions, the flow will be decorated with the
 	// narrowest CIDR. By this reason, you can safely add a 0.0.0.0/0 entry to group there
 	// all the traffic that does not match any of the other CIDRs.
-	CIDRs cidr.Definitions `yaml:"cidrs" env:"OTEL_EBPF_NETWORK_CIDRS" envSeparator:"," validate:"omitempty,dive,cidr"`
+	CIDRs cidr.Definitions `yaml:"cidrs" env:"OTEL_EBPF_NETWORK_CIDRS"`
 }
 
 var DefaultNetworkConfig = NetworkConfig{

--- a/pkg/obi/stats_cfg.go
+++ b/pkg/obi/stats_cfg.go
@@ -35,7 +35,7 @@ type StatsConfig struct {
 	// If an IP matches multiple CIDR definitions, the stat will be decorated with the
 	// narrowest CIDR. By this reason, you can safely add a 0.0.0.0/0 entry to group there
 	// all the traffic that does not match any of the other CIDRs.
-	CIDRs cidr.Definitions `yaml:"cidrs" env:"OTEL_EBPF_STATS_CIDRS" envSeparator:"," validate:"omitempty,dive,cidr"`
+	CIDRs cidr.Definitions `yaml:"cidrs" env:"OTEL_EBPF_STATS_CIDRS"`
 	// Enables the calculation of tcp srtt of a given instrumented service
 
 	// ReverseDNS allows stats that haven't been previously decorated with any source/destination name


### PR DESCRIPTION
## Summary

This pull request implements named CIDR labels like documented here: https://opentelemetry.io/docs/zero-code/obi/network/#cidr-based-metrics

Unnamed CIDRs (like currently implemented and documented [here](https://opentelemetry.io/docs/zero-code/obi/network/config/)) are still working, so it is not a breaking change. Mixed representation (some named, some not) are also supported. The environment variable behavior is not changed.

This change was created with the help of an LLM. I manually reviewed all changes and tested the code in a production cluster to confirm that the old configmap still works and that the named CIDRs as well as mixed definitions work.

Related issue: https://github.com/open-telemetry/opentelemetry.io/issues/8438

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] ~If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)~