### PR TITLE
chore: disable Renovate Go major version bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,7 +26,7 @@
     {
       "groupName": "Go",
       "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["patch", "digest", "minor", "major"],
+      "matchUpdateTypes": ["patch", "digest", "minor"],
       "schedule": ["before 6am on Monday"],
       "postUpgradeTasks": {
         "commands": [
@@ -35,6 +35,20 @@
         ],
         "executionMode": "branch"
       }
+    },
+    {
+      "description": "Block Go language major upgrades in go.mod files (these require coordinated manual changes)",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang", "toolchain"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Block golang Docker image major upgrades (these require coordinated manual changes)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["golang"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     },
     {
       "groupName": "Docker",


### PR DESCRIPTION
Remove major updates from the main Go Renovate group so grouped Go dependency PRs only cover patch, digest, and minor updates.

Add explicit rules to block major upgrades for the Go language version in go.mod files and for golang Docker base images. Those upgrades require coordinated manual changes across the repository, including version references, generator images, and compatibility updates, so they are not suitable for automatic Renovate PRs.

This keeps routine dependency maintenance automated while preventing recurring Go major-version PRs that will not be applied as-is.