### PR TITLE
Manage Python test dependencies with pip-compile

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -95,7 +95,7 @@
     {
       "groupName": "Python",
       "matchManagers": ["pip-compile"],
-      "matchUpdateTypes": ["patch", "digest", "minor", "major"],
+      "matchUpdateTypes": ["minor", "major"],
       "schedule": ["before 6am on Thursday"]
     },
     {


### PR DESCRIPTION
Renovate was not configured to manage the integration-component Python dependencies through their generated pip-compile lockfiles, which left it free to treat the lockfiles as direct inputs instead of updating the underlying source manifests.

Update the Renovate configuration to:
  - enable the `pip-compile` manager for `internal/test/integration/components/**/requirements*.txt`
  - disable `pip_requirements` to avoid double-managing the same dependency sets
  - add a dedicated Python dependency group on the existing Thursday schedule

This aligns Renovate with the repository's Python dependency workflow so updates flow through the pip-compile source manifests and regenerate the corresponding lockfiles.

Also, see https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1726 for automation on how to fix things if renovate missing a lock file update.