### PR TITLE
Tide-up tcp_detect_transform

### DIFF
--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -8,9 +8,12 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
@@ -29,8 +32,6 @@ const (
 )
 
 // ReadTCPRequestIntoSpan returns a request.Span from the provided ring buffer record
-//
-//nolint:cyclop
 func ReadTCPRequestIntoSpan(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, record *ringbuf.Record, filter ServiceFilter) (request.Span, bool, error) {
 	event, err := ReinterpretCast[TCPRequestInfo](record.RawSample)
 	if err != nil {
@@ -54,163 +55,16 @@ func ReadTCPRequestIntoSpan(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, 
 		fmt.Printf("[<] %v\n", responseBuffer.UnsafeView())
 	}
 
-	// We might know already the protocol for this event
-	switch event.ProtocolType {
-	case ProtocolTypeKafka:
-		k, ignore, err := ProcessPossibleKafkaEvent(event, requestBuffer, responseBuffer, parseCtx.kafkaTopicUUIDToName)
-		if ignore && err == nil {
-			return request.Span{}, true, nil // parsed kafka event, but we don't want to create a span for it
-		}
-		if err == nil {
-			return TCPToKafkaToSpan(event, k), false, nil
-		}
-		return request.Span{}, true, fmt.Errorf("failed to handle Kafka event: %w", err)
-	case ProtocolTypeMQTT:
-		m, ignore, err := ProcessPossibleMQTTEvent(event, requestBuffer, responseBuffer)
-		if ignore && err == nil {
-			return request.Span{}, true, nil // parsed MQTT event, but we don't want to create a span for it
-		}
-		if err == nil {
-			return TCPToMQTTToSpan(event, m), false, nil
-		}
-		return request.Span{}, true, fmt.Errorf("failed to handle MQTT event: %w", err)
-	case ProtocolTypeMySQL:
-		span, err := handleMySQL(parseCtx, event, requestBuffer, responseBuffer)
-		if errors.Is(err, errFallback) {
-			slog.Debug("MySQL: falling back to generic handler")
-			break
-		}
-		if errors.Is(err, errIgnore) {
-			return request.Span{}, true, nil
-		}
-		if err != nil {
-			return request.Span{}, true, fmt.Errorf("failed to handle MySQL event: %w", err)
-		}
-
-		return span, false, nil
-	case ProtocolTypePostgres:
-		span, err := handlePostgres(parseCtx, event, requestBuffer, responseBuffer)
-		if errors.Is(err, errFallback) {
-			slog.Debug("Postgres: falling back to generic handler")
-			break
-		}
-		if errors.Is(err, errIgnore) {
-			return request.Span{}, true, nil
-		}
-		if err != nil {
-			return request.Span{}, true, fmt.Errorf("failed to handle Postgres event: %w", err)
-		}
-
-		return span, false, nil
-	case ProtocolTypeUnknown:
-	default:
+	if span, ignore, matched, err := dispatchKernelAssignedProtocol(parseCtx, event, requestBuffer, responseBuffer); matched {
+		return span, ignore, err
 	}
 
-	// Check if we have a SQL statement
-	op, table, sql, kind := detectSQLPayload(cfg.HeuristicSQLDetect, requestBuffer)
-	if validSQL(op, table, kind) {
-		return TCPToSQLToSpan(event, op, table, sql, kind, "", nil), false, nil
-	} else {
-		op, table, sql, kind = detectSQLPayload(cfg.HeuristicSQLDetect, responseBuffer)
-		if validSQL(op, table, kind) {
-			reverseTCPEvent(event)
-			return TCPToSQLToSpan(event, op, table, sql, kind, "", nil), false, nil
-		}
+	if span, ignore, matched, err := detectGenericProtocol(parseCtx, cfg, event, requestBuffer, responseBuffer); matched {
+		return span, ignore, err
 	}
 
-	if maybeFastCGI(requestBuffer) {
-		op, uri, status := detectFastCGI(requestBuffer, responseBuffer)
-		if status >= 0 {
-			return TCPToFastCGIToSpan(event, op, uri, status), false, nil
-		}
-	}
-	mongoInfo := mongoInfoFromEvent(event, requestBuffer, responseBuffer, parseCtx.mongoRequestCache)
-	if mongoInfo != nil {
-		mongoSpan := TCPToMongoToSpan(event, mongoInfo)
-		return mongoSpan, false, nil
-	}
-
-	// Check for Couchbase memcached binary protocol
-	cbInfo, ignore, err := ProcessPossibleCouchbaseEvent(event, requestBuffer, responseBuffer, parseCtx.couchbaseBucketCache)
-	if err == nil {
-		if ignore {
-			return request.Span{}, true, nil
-		}
-		if cbInfo != nil {
-			return TCPToCouchbaseToSpan(event, cbInfo), false, nil
-		}
-	}
-
-	// Request-only events are emitted on socket close.
-	// They might contain requests like memcached with noreply that we haven't seen the response for.
-	if responseBuffer.Len() == 0 {
-		requestReader := requestBuffer.NewReader()
-		if ops, ok := parseMemcachedExplicitNoreply(&requestReader); ok {
-			emitMemcachedNoreplySpans(parseCtx, event, ops)
-			return request.Span{}, true, nil
-		}
-	}
-
-	switch {
-	case isRedis(requestBuffer) && isRedis(responseBuffer):
-		op, text, ok := parseRedisRequest(requestBuffer.UnsafeView())
-
-		if ok {
-			var status int
-			var redisErr request.DBError
-			if op == "" {
-				op, text, ok = parseRedisRequest(responseBuffer.UnsafeView())
-				if !ok || op == "" {
-					return request.Span{}, true, nil // ignore if we couldn't parse it
-				}
-				// We've caught the event reversed in the middle of communication, let's
-				// reverse the event
-				reverseTCPEvent(event)
-				redisErr, status = redisStatus(requestBuffer)
-			} else {
-				redisErr, status = redisStatus(responseBuffer)
-			}
-
-			db, found := getRedisDB(event.ConnInfo, op, text, parseCtx.redisDBCache)
-			if !found {
-				db = -1 // if we don't have the db in cache, we assume it's not set
-			}
-			return TCPToRedisToSpan(event, op, text, status, db, redisErr), false, nil
-		}
-	case isMemcached(requestBuffer, responseBuffer):
-		span, err := ProcessPossibleMemcachedEvent(parseCtx, event, requestBuffer, responseBuffer)
-		if errors.Is(err, errIgnore) {
-			return request.Span{}, true, nil
-		}
-		if err != nil {
-			return request.Span{}, true, fmt.Errorf("failed to handle Memcached event: %w", err)
-		}
-		return span, false, nil
-	// must come before MQTT: the MQTT heuristic can match the HTTP/2 connection preface,
-	// silently dropping packets that should be re-routed as HTTP/2
-	case isHTTP2(requestBuffer, int(event.Len)) || isHTTP2(responseBuffer, int(event.RespLen)):
-		evCopy := *event
-		MisclassifiedEvents <- MisclassifiedEvent{EventType: EventTypeKHTTP2, TCPInfo: &evCopy}
-		return request.Span{}, true, nil // ignore for now, next event will be parsed
-	case isMQTT(requestBuffer) || isMQTT(responseBuffer):
-		m, ignore, err := ProcessPossibleMQTTEvent(event, requestBuffer, responseBuffer)
-		if ignore && err == nil {
-			return request.Span{}, true, nil // parsed MQTT event, but we don't want to create a span for it
-		}
-		if err == nil {
-			return TCPToMQTTToSpan(event, m), false, nil
-		}
-		// MQTT heuristic matched but full parsing failed - ignore the packet
-		slog.Debug("MQTT heuristic detection failed, ignoring", "error", err)
-	default:
-		// Kafka can arrive here for packets the kernel couldn't classify (e.g. OBI attached mid-connection).
-		k, ignore, err := ProcessPossibleKafkaEvent(event, requestBuffer, responseBuffer, parseCtx.kafkaTopicUUIDToName)
-		if ignore && err == nil {
-			return request.Span{}, true, nil // parsed kafka event, but we don't want to create a span for it
-		}
-		if err == nil {
-			return TCPToKafkaToSpan(event, k), false, nil
-		}
+	if span, ignore, matched, err := detectHeuristicProtocol(parseCtx, event, requestBuffer, responseBuffer); matched {
+		return span, ignore, err
 	}
 
 	if cfg.ProtocolDebug {
@@ -219,6 +73,299 @@ func ReadTCPRequestIntoSpan(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, 
 	}
 
 	return request.Span{}, true, nil // ignore if we couldn't parse it
+}
+
+// dispatchKernelAssignedProtocol handles events where the kernel has already classified the protocol.
+// returns matched=false for ProtocolTypeUnknown or when MySQL/Postgres fall back to generic detection.
+func dispatchKernelAssignedProtocol(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
+	switch event.ProtocolType {
+	case ProtocolTypeKafka:
+		return dispatchKafka(event, requestBuffer, responseBuffer, parseCtx.kafkaTopicUUIDToName)
+	case ProtocolTypeMQTT:
+		return dispatchMQTT(event, requestBuffer, responseBuffer)
+	case ProtocolTypeMySQL:
+		return dispatchMySQL(parseCtx, event, requestBuffer, responseBuffer)
+	case ProtocolTypePostgres:
+		return dispatchPostgres(parseCtx, event, requestBuffer, responseBuffer)
+	}
+
+	return request.Span{}, false, false, nil
+}
+
+func dispatchKafka(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (request.Span, bool, bool, error) {
+	k, ignore, err := ProcessPossibleKafkaEvent(event, requestBuffer, responseBuffer, kafkaTopicUUIDToName)
+
+	if ignore && err == nil {
+		return request.Span{}, true, true, nil // parsed kafka event, but we don't want to create a span for it
+	}
+
+	if err == nil {
+		return TCPToKafkaToSpan(event, k), false, true, nil
+	}
+
+	return request.Span{}, true, true, fmt.Errorf("failed to handle Kafka event: %w", err)
+}
+
+func dispatchMQTT(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
+	m, ignore, err := ProcessPossibleMQTTEvent(event, requestBuffer, responseBuffer)
+
+	if ignore && err == nil {
+		return request.Span{}, true, true, nil // parsed MQTT event, but we don't want to create a span for it
+	}
+
+	if err == nil {
+		return TCPToMQTTToSpan(event, m), false, true, nil
+	}
+
+	return request.Span{}, true, true, fmt.Errorf("failed to handle MQTT event: %w", err)
+}
+
+func handleError(span request.Span, err error, name string) (request.Span, bool, bool, error) {
+	if errors.Is(err, errFallback) {
+		slog.Debug(name + ": falling back to generic handler")
+		return request.Span{}, false, false, nil
+	}
+
+	if errors.Is(err, errIgnore) {
+		return request.Span{}, true, true, nil
+	}
+
+	if err != nil {
+		return request.Span{}, true, true, fmt.Errorf("failed to handle %s event: %w", name, err)
+	}
+
+	return span, false, true, nil
+}
+
+func dispatchMySQL(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
+	span, err := handleMySQL(parseCtx, event, requestBuffer, responseBuffer)
+	return handleError(span, err, "MySQL")
+}
+
+func dispatchPostgres(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
+	span, err := handlePostgres(parseCtx, event, requestBuffer, responseBuffer)
+	return handleError(span, err, "Postgres")
+}
+
+// detectGenericProtocol runs deterministic protocol detection for unclassified events:
+// SQL, FastCGI, MongoDB, Couchbase, and Memcached noreply.
+func detectGenericProtocol(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
+	if span, ignore, matched, err := matchSQL(cfg, event, requestBuffer, responseBuffer); matched {
+		return span, ignore, matched, err
+	}
+
+	if span, ignore, matched, err := matchFastCGI(event, requestBuffer, responseBuffer); matched {
+		return span, ignore, matched, err
+	}
+
+	if span, ignore, matched, err := matchMongo(parseCtx, event, requestBuffer, responseBuffer); matched {
+		return span, ignore, matched, err
+	}
+
+	if span, ignore, matched, err := matchCouchbase(parseCtx, event, requestBuffer, responseBuffer); matched {
+		return span, ignore, matched, err
+	}
+
+	if span, ignore, matched, err := matchMemcachedNoreply(parseCtx, event, requestBuffer, responseBuffer); matched {
+		return span, ignore, matched, err
+	}
+
+	return request.Span{}, false, false, nil
+}
+
+func matchSQL(cfg *config.EBPFTracer, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	op, table, sql, kind := detectSQLPayload(cfg.HeuristicSQLDetect, requestBuffer)
+
+	if validSQL(op, table, kind) {
+		return TCPToSQLToSpan(event, op, table, sql, kind, "", nil), false, true, nil
+	}
+
+	op, table, sql, kind = detectSQLPayload(cfg.HeuristicSQLDetect, responseBuffer)
+
+	if validSQL(op, table, kind) {
+		reverseTCPEvent(event)
+		return TCPToSQLToSpan(event, op, table, sql, kind, "", nil), false, true, nil
+	}
+
+	return request.Span{}, false, false, nil
+}
+
+func matchFastCGI(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	if maybeFastCGI(requestBuffer) {
+		op, uri, status := detectFastCGI(requestBuffer, responseBuffer)
+		if status >= 0 {
+			return TCPToFastCGIToSpan(event, op, uri, status), false, true, nil
+		}
+	}
+	return request.Span{}, false, false, nil
+}
+
+func matchMongo(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	if mongoInfo := mongoInfoFromEvent(event, requestBuffer, responseBuffer, parseCtx.mongoRequestCache); mongoInfo != nil {
+		return TCPToMongoToSpan(event, mongoInfo), false, true, nil
+	}
+	return request.Span{}, false, false, nil
+}
+
+func matchCouchbase(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	// Check for Couchbase memcached binary protocol
+	cbInfo, ignore, err := ProcessPossibleCouchbaseEvent(event, requestBuffer, responseBuffer, parseCtx.couchbaseBucketCache)
+
+	if err == nil {
+		if ignore {
+			return request.Span{}, true, true, nil
+		}
+
+		if cbInfo != nil {
+			return TCPToCouchbaseToSpan(event, cbInfo), false, true, nil
+		}
+	}
+
+	return request.Span{}, false, false, nil
+}
+
+func matchMemcachedNoreply(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	// Request-only events are emitted on socket close.
+	// They might contain requests like memcached with noreply that we haven't seen the response for.
+	if responseBuffer.Len() == 0 {
+		requestReader := requestBuffer.NewReader()
+		if ops, ok := parseMemcachedExplicitNoreply(&requestReader); ok {
+			emitMemcachedNoreplySpans(parseCtx, event, ops)
+			return request.Span{}, true, true, nil
+		}
+	}
+	return request.Span{}, false, false, nil
+}
+
+// detectHeuristicProtocol runs heuristic-based protocol detection as a last resort:
+// Redis, Memcached, HTTP/2, MQTT, and Kafka (for packets the kernel couldn't classify).
+func detectHeuristicProtocol(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
+	if span, ignore, matched, err := matchRedis(parseCtx, event, requestBuffer, responseBuffer); matched {
+		return span, ignore, matched, err
+	}
+
+	if span, ignore, matched, err := matchMemcached(parseCtx, event, requestBuffer, responseBuffer); matched {
+		return span, ignore, matched, err
+	}
+
+	// must come before MQTT: the MQTT heuristic can match the HTTP/2 connection preface,
+	// silently dropping packets that should be re-routed as HTTP/2
+	if span, ignore, matched, err := matchHTTP2(event, requestBuffer, responseBuffer); matched {
+		return span, ignore, matched, err
+	}
+
+	if span, ignore, matched, err := matchMQTT(event, requestBuffer, responseBuffer); matched {
+		return span, ignore, matched, err
+	}
+
+	// Kafka can arrive here for packets the kernel couldn't classify (e.g. OBI attached mid-connection).
+	if span, ignore, matched, err := matchKafkaFallback(event, requestBuffer, responseBuffer, parseCtx.kafkaTopicUUIDToName); matched {
+		return span, ignore, matched, err
+	}
+
+	return request.Span{}, false, false, nil
+}
+
+func matchRedis(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	if !isRedis(requestBuffer) || !isRedis(responseBuffer) {
+		return request.Span{}, false, false, nil
+	}
+
+	op, text, ok := parseRedisRequest(requestBuffer.UnsafeView())
+
+	if !ok {
+		return request.Span{}, false, false, nil
+	}
+
+	var status int
+	var redisErr request.DBError
+
+	if op == "" {
+		op, text, ok = parseRedisRequest(responseBuffer.UnsafeView())
+		if !ok || op == "" {
+			return request.Span{}, true, true, nil // ignore if we couldn't parse it
+		}
+		// We've caught the event reversed in the middle of communication, let's
+		// reverse the event
+		reverseTCPEvent(event)
+		redisErr, status = redisStatus(requestBuffer)
+	} else {
+		redisErr, status = redisStatus(responseBuffer)
+	}
+
+	db, found := getRedisDB(event.ConnInfo, op, text, parseCtx.redisDBCache)
+
+	if !found {
+		db = -1 // if we don't have the db in cache, we assume it's not set
+	}
+
+	return TCPToRedisToSpan(event, op, text, status, db, redisErr), false, true, nil
+}
+
+func matchMemcached(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
+	if !isMemcached(requestBuffer, responseBuffer) {
+		return request.Span{}, false, false, nil
+	}
+
+	span, err := ProcessPossibleMemcachedEvent(parseCtx, event, requestBuffer, responseBuffer)
+
+	if errors.Is(err, errIgnore) {
+		return request.Span{}, true, true, nil
+	}
+
+	if err != nil {
+		return request.Span{}, true, true, fmt.Errorf("failed to handle Memcached event: %w", err)
+	}
+
+	return span, false, true, nil
+}
+
+func matchHTTP2(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	if !isHTTP2(requestBuffer, int(event.Len)) && !isHTTP2(responseBuffer, int(event.RespLen)) {
+		return request.Span{}, false, false, nil
+	}
+
+	evCopy := *event
+	MisclassifiedEvents <- MisclassifiedEvent{EventType: EventTypeKHTTP2, TCPInfo: &evCopy}
+
+	return request.Span{}, true, true, nil // ignore for now, next event will be parsed
+}
+
+func matchMQTT(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	if !isMQTT(requestBuffer) && !isMQTT(responseBuffer) {
+		return request.Span{}, false, false, nil
+	}
+
+	m, ignore, err := ProcessPossibleMQTTEvent(event, requestBuffer, responseBuffer)
+
+	if ignore && err == nil {
+		return request.Span{}, true, true, nil // parsed MQTT event, but we don't want to create a span for it
+	}
+
+	if err == nil {
+		return TCPToMQTTToSpan(event, m), false, true, nil
+	}
+
+	// MQTT heuristic matched but full parsing failed - ignore the packet
+	slog.Debug("MQTT heuristic detection failed, ignoring", "error", err)
+
+	return request.Span{}, false, false, nil
+}
+
+// matchKafkaFallback handles Kafka for unclassified packets (e.g. when the kernel missed the
+// connection start). Unlike dispatchKafka, errors here mean "not Kafka" — no error is surfaced.
+func matchKafkaFallback(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (request.Span, bool, bool, error) { //nolint:unparam
+	k, ignore, err := ProcessPossibleKafkaEvent(event, requestBuffer, responseBuffer, kafkaTopicUUIDToName)
+
+	if ignore && err == nil {
+		return request.Span{}, true, true, nil // parsed kafka event, but we don't want to create a span for it
+	}
+
+	if err == nil {
+		return TCPToKafkaToSpan(event, k), false, true, nil
+	}
+
+	return request.Span{}, false, false, nil
 }
 
 func getBuffers(parseCtx *EBPFParseContext, event *TCPRequestInfo) (req *largebuf.LargeBuffer, resp *largebuf.LargeBuffer) {

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -122,7 +122,7 @@ func dispatchMQTT(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf
 
 func handleError(span request.Span, err error, name string) (request.Span, bool, bool, error) {
 	if errors.Is(err, errFallback) {
-		slog.Debug(name + ": falling back to generic handler")
+		slog.Debug("falling back to generic handler", "protocol", name)
 		return request.Span{}, false, false, nil
 	}
 


### PR DESCRIPTION
## Summary

`tcp_detect_transform.go` was getting unmanageable with those huge functions with big switch blocks and inline code. My friend Claudio and I took some time to tide this up properly in smaller and well separated per-protocol handling functions/dispatchers.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->