### PR TITLE
Fix element size too large

### DIFF
--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -315,6 +315,13 @@ func getQueueConfig(cfg otelcfg.TracesConfig) configoptional.Optional[exporterhe
 	if cfg.MaxQueueSize > 0 {
 		batchSet = true
 		batchCfg.MaxSize = int64(cfg.MaxQueueSize)
+		// Queue capacity must be at least 2x max batch size to prevent "element size too large"
+		// errors and permanent data loss. We use a 4x multiplier to provide headroom for
+		// transient latency spikes, ensuring brief collector slowdowns don't immediately
+		// back-pressure the eBPF reader.
+		if minQueue := int64(cfg.MaxQueueSize) * 4; queueConfig.QueueSize < minQueue {
+			queueConfig.QueueSize = minQueue
+		}
 	}
 	if cfg.BatchTimeout > 0 {
 		batchSet = true


### PR DESCRIPTION
## Summary

This PR fixes the "element size too large" error. 

When `MaxQueueSize` (batch max size) is set higher than the queue size, the memory queue rejects every batch and silently dropped spans. 

Now the otel traces exporter queue capacity is always large enough to hold configured batches. 
The queue size is now bumped to at least `4 × MaxQueueSize` when needed, leaving headroom for transient export latency spikes without back-pressuring the eBPF reader.


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->