### PR TITLE
Fix wrong log line emitted by the kube node metadata fetcher

### DIFF
--- a/pkg/appolly/meta/meta_node_kube.go
+++ b/pkg/appolly/meta/meta_node_kube.go
@@ -36,8 +36,11 @@ func kubeNodeFetcher(k8sInformer *kube.MetadataProvider) fetcher {
 		nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
 			FieldSelector: "metadata.name=" + nodeName,
 		})
-		if err != nil || len(nodes.Items) == 0 {
+		if err != nil {
 			return NodeMeta{}, fmt.Errorf("can't get node %s: %w", nodeName, err)
+		}
+		if len(nodes.Items) == 0 {
+			return NodeMeta{}, fmt.Errorf("can't get node %s: not found", nodeName)
 		}
 		return NodeMeta{
 			HostID: nodes.Items[0].Status.NodeInfo.MachineID,


### PR DESCRIPTION
## Summary

This PR fixes `%!w(<nil>)` in the kube node metadata fetcher, caused by wrapping a nil error with `%w` when the node list came back empty. Example: `can't fetch metadata. Will retry ... error="can't get node ip-...: %!w(<nil>)"`.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->