### PR TITLE
never resize pinned maps based on scale factor

### DIFF
--- a/pkg/ebpf/tracer_linux.go
+++ b/pkg/ebpf/tracer_linux.go
@@ -177,8 +177,8 @@ func (pt *ProcessTracer) setupOtelBPFFSPath(bundles []*common.SpecBundle) string
 	return ""
 }
 
-func setupBPFMapSizes(spec *ebpf.CollectionSpec, cfg *obi.Config, otelBPFFSPath string) {
-	ebpfconvenience.SetupMapSizes(spec, cfg.EBPF.MapsConfig.GlobalScaleFactor, otelBPFFSPath)
+func setupBPFMapSizes(spec *ebpf.CollectionSpec, cfg *obi.Config) {
+	ebpfconvenience.SetupMapSizes(spec, cfg.EBPF.MapsConfig.GlobalScaleFactor)
 }
 
 func (pt *ProcessTracer) loadAndAssign(eventContext *common.EBPFEventContext, p Tracer, cfg *obi.Config) error {
@@ -191,7 +191,7 @@ func (pt *ProcessTracer) loadAndAssign(eventContext *common.EBPFEventContext, p 
 
 	for i, bundle := range bundles {
 		// set max entries map using user defined values
-		setupBPFMapSizes(bundle.Spec, cfg, otelBPFFSPath)
+		setupBPFMapSizes(bundle.Spec, cfg)
 
 		if err := loadSpec(eventContext, bundle, otelBPFFSPath, i); err != nil {
 			closeLoadedSpecs(bundles[:i])
@@ -391,7 +391,7 @@ func RunUtilityTracer(ctx context.Context, eventContext *common.EBPFEventContext
 	for idx, bundle := range bundles {
 		// Utility tracers don't pin maps (empty pin path), so no pinned
 		// map conflicts are possible — the empty path is intentional.
-		setupBPFMapSizes(bundle.Spec, cfg, "")
+		setupBPFMapSizes(bundle.Spec, cfg)
 		if err := loadSpec(eventContext, bundle, "", idx); err != nil {
 			closeLoadedSpecs(bundles[:idx])
 			printVerifierErrorInfo(err)

--- a/pkg/internal/ebpf/convenience/convenience.go
+++ b/pkg/internal/ebpf/convenience/convenience.go
@@ -6,7 +6,6 @@ package ebpfconvenience // import "go.opentelemetry.io/obi/pkg/internal/ebpf/con
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -126,13 +125,13 @@ func isResizableMapType(t ebpf.MapType) bool {
 // SetupMapSizes scales all resizable maps in the spec by globalScaleFactor.
 // If globalScaleFactor > 0, sizes are doubled that many times (left shift).
 // If globalScaleFactor < 0, sizes are halved that many times (right shift).
-// Maps already pinned on bpffs (at bpffsPinPath) are skipped.
-func SetupMapSizes(spec *ebpf.CollectionSpec, globalScaleFactor int, bpffsPinPath string) {
+// Maps with PinByName are skipped regardless of scale factor.
+func SetupMapSizes(spec *ebpf.CollectionSpec, globalScaleFactor int) {
 	if globalScaleFactor == 0 {
 		return
 	}
 
-	for name, mSpec := range spec.Maps {
+	for _, mSpec := range spec.Maps {
 		if !isResizableMapType(mSpec.Type) {
 			continue
 		}
@@ -141,11 +140,8 @@ func SetupMapSizes(spec *ebpf.CollectionSpec, globalScaleFactor int, bpffsPinPat
 			continue
 		}
 
-		if bpffsPinPath != "" && mSpec.Pinning == ebpf.PinByName {
-			mapPath := filepath.Join(bpffsPinPath, name)
-			if _, err := os.Stat(mapPath); err == nil {
-				continue
-			}
+		if mSpec.Pinning == ebpf.PinByName {
+			continue
 		}
 
 		oldEntries := mSpec.MaxEntries

--- a/pkg/internal/ebpf/convenience/convenience_test.go
+++ b/pkg/internal/ebpf/convenience/convenience_test.go
@@ -5,8 +5,6 @@ package ebpfconvenience
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -47,7 +45,7 @@ func TestSetupMapSizes_ScaleUp(t *testing.T) {
 		"my_hash": {Type: ebpf.Hash, MaxEntries: 1024},
 	})
 
-	SetupMapSizes(spec, 2, "")
+	SetupMapSizes(spec, 2)
 
 	got := spec.Maps["my_hash"].MaxEntries
 	want := uint32(1024 << 2)
@@ -61,7 +59,7 @@ func TestSetupMapSizes_ScaleDown(t *testing.T) {
 		"my_hash": {Type: ebpf.Hash, MaxEntries: 1024},
 	})
 
-	SetupMapSizes(spec, -2, "")
+	SetupMapSizes(spec, -2)
 
 	got := spec.Maps["my_hash"].MaxEntries
 	want := uint32(1024 >> 2)
@@ -75,7 +73,7 @@ func TestSetupMapSizes_ZeroFactorNoOp(t *testing.T) {
 		"my_hash": {Type: ebpf.Hash, MaxEntries: 512},
 	})
 
-	SetupMapSizes(spec, 0, "")
+	SetupMapSizes(spec, 0)
 
 	got := spec.Maps["my_hash"].MaxEntries
 	if got != 512 {
@@ -88,7 +86,7 @@ func TestSetupMapSizes_ClampToMax(t *testing.T) {
 		"big": {Type: ebpf.Hash, MaxEntries: MaxMapEntries},
 	})
 
-	SetupMapSizes(spec, 1, "")
+	SetupMapSizes(spec, 1)
 
 	got := spec.Maps["big"].MaxEntries
 	if got != MaxMapEntries {
@@ -102,7 +100,7 @@ func TestSetupMapSizes_ClampToMin(t *testing.T) {
 	})
 
 	// Shift right by 2 → 128 >> 2 = 32, which is below MinMapEntries (64)
-	SetupMapSizes(spec, -2, "")
+	SetupMapSizes(spec, -2)
 
 	got := spec.Maps["small"].MaxEntries
 	if got != MinMapEntries {
@@ -117,7 +115,7 @@ func TestSetupMapSizes_SkipsNonResizableTypes(t *testing.T) {
 		"normal":     {Type: ebpf.Hash, MaxEntries: 256},
 	})
 
-	SetupMapSizes(spec, 2, "")
+	SetupMapSizes(spec, 2)
 
 	if spec.Maps["prog_array"].MaxEntries != 256 {
 		t.Errorf("ProgramArray should not be resized: got %d", spec.Maps["prog_array"].MaxEntries)
@@ -135,7 +133,7 @@ func TestSetupMapSizes_SkipsBelowMinResizableMapSize(t *testing.T) {
 		"tiny": {Type: ebpf.Hash, MaxEntries: 32},
 	})
 
-	SetupMapSizes(spec, 3, "")
+	SetupMapSizes(spec, 3)
 
 	if spec.Maps["tiny"].MaxEntries != 32 {
 		t.Errorf("maps below MinResizableMapSize should not be resized: got %d", spec.Maps["tiny"].MaxEntries)
@@ -143,27 +141,15 @@ func TestSetupMapSizes_SkipsBelowMinResizableMapSize(t *testing.T) {
 }
 
 func TestSetupMapSizes_SkipsPinnedMaps(t *testing.T) {
-	pinDir := t.TempDir()
-	// Create files to simulate pinned maps on bpffs
-	for _, name := range []string{"pinned_map", "not_pinned_map"} {
-		if err := os.WriteFile(filepath.Join(pinDir, name), []byte{}, 0o600); err != nil {
-			t.Fatal(err)
-		}
-	}
-
 	spec := makeSpec(map[string]*ebpf.MapSpec{
-		"pinned_map":     {Type: ebpf.Hash, MaxEntries: 1024, Pinning: ebpf.PinByName},
-		"not_pinned_map": {Type: ebpf.Hash, MaxEntries: 1024, Pinning: ebpf.PinNone},
-		"unpinned_map":   {Type: ebpf.Hash, MaxEntries: 1024},
+		"pinned_map":   {Type: ebpf.Hash, MaxEntries: 1024, Pinning: ebpf.PinByName},
+		"unpinned_map": {Type: ebpf.Hash, MaxEntries: 1024},
 	})
 
-	SetupMapSizes(spec, 2, pinDir)
+	SetupMapSizes(spec, 2)
 
 	if spec.Maps["pinned_map"].MaxEntries != 1024 {
-		t.Errorf("PinByName map with file on disk should be skipped: got %d, want 1024", spec.Maps["pinned_map"].MaxEntries)
-	}
-	if spec.Maps["not_pinned_map"].MaxEntries == 1024 {
-		t.Error("PinNone map should be resized even if a file with same name exists on disk")
+		t.Errorf("PinByName map should always be skipped: got %d, want 1024", spec.Maps["pinned_map"].MaxEntries)
 	}
 	if spec.Maps["unpinned_map"].MaxEntries == 1024 {
 		t.Error("unpinned map should have been resized")
@@ -176,7 +162,7 @@ func TestSetupMapSizes_OverflowClampsToMax(t *testing.T) {
 		"huge": {Type: ebpf.Hash, MaxEntries: 1 << 30},
 	})
 
-	SetupMapSizes(spec, 4, "")
+	SetupMapSizes(spec, 4)
 
 	got := spec.Maps["huge"].MaxEntries
 	if got != MaxMapEntries {

--- a/pkg/internal/netolly/ebpf/sock_tracer.go
+++ b/pkg/internal/netolly/ebpf/sock_tracer.go
@@ -79,7 +79,7 @@ func NewSockFlowFetcher(
 	spec.Maps[flowDirectionsMap].MaxEntries = uint32(cacheMaxSize)
 	spec.Maps[connInitiatorsMap].MaxEntries = uint32(cacheMaxSize)
 
-	convenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor, "")
+	convenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor)
 
 	traceMsgs := 0
 	if tlog.Enabled(context.TODO(), slog.LevelDebug) {

--- a/pkg/internal/netolly/ebpf/tracer.go
+++ b/pkg/internal/netolly/ebpf/tracer.go
@@ -101,7 +101,7 @@ func NewFlowFetcher(
 	spec.Maps[connInitiatorsMap].MaxEntries = uint32(cacheMaxSize)
 
 	// Apply global map scaling factor
-	convenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor, "")
+	convenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor)
 
 	traceMsgs := 0
 	if tlog.Enabled(context.TODO(), slog.LevelDebug) {

--- a/pkg/internal/rdns/ebpf/xdp/dnstrtacer.go
+++ b/pkg/internal/rdns/ebpf/xdp/dnstrtacer.go
@@ -59,7 +59,7 @@ func newTracer(ebpfCfg *config.EBPFTracer) (*tracer, error) {
 		return nil, fmt.Errorf("loading BPF data: %w", err)
 	}
 
-	convenience.SetupMapSizes(spec, ebpfCfg.MapsConfig.GlobalScaleFactor, "")
+	convenience.SetupMapSizes(spec, ebpfCfg.MapsConfig.GlobalScaleFactor)
 
 	sharedMaps := map[string]*ebpf.Map{}
 	var mu sync.Mutex

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -48,7 +48,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
 		return nil, fmt.Errorf("loading BPF data: %w", err)
 	}
 
-	ebpfconvenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor, "")
+	ebpfconvenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor)
 
 	sharedMaps := map[string]*ebpf.Map{}
 	var mu sync.Mutex


### PR DESCRIPTION
## Summary

Pinned maps should never be resized

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->