### PR TITLE
ci: auto re-run failed checks

### DIFF
--- a/.github/workflows/supervisor_rerun-flaky.yml
+++ b/.github/workflows/supervisor_rerun-flaky.yml
@@ -10,10 +10,6 @@ on: # zizmor: ignore[dangerous-triggers] checks out only scripts/rerun-flaky.sh 
       - "PR OATS test"
       - "Test Docker build"
       - "Pull request integration tests on VM"
-      - "Clang Format Check"
-      - "Clang Tidy Check"
-      - "Lint (Darwin)"
-      - "Markdown"
       - "Java Agent CI"
     types: [completed]
 

--- a/.github/workflows/supervisor_rerun-flaky.yml
+++ b/.github/workflows/supervisor_rerun-flaky.yml
@@ -1,0 +1,166 @@
+name: "CI Supervisor: Rerun flaky failures"
+
+on: # zizmor: ignore[dangerous-triggers] no code checkout; only github.token used for API calls
+  workflow_run:
+    workflows:
+      - "Pull request checks"
+      - "Pull request integration tests"
+      - "Pull request integration tests ARM"
+      - "Pull request K8s integration tests"
+      - "PR OATS test"
+      - "Test Docker build"
+      - "Pull request integration tests on VM"
+      - "Clang Format Check"
+      - "Clang Tidy Check"
+      - "Lint (Darwin)"
+      - "Markdown"
+      - "Java Agent CI"
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: "supervisor-${{ github.event.workflow_run.id }}"
+  cancel-in-progress: false
+
+jobs:
+  evaluate-and-rerun:
+    name: Evaluate failed checks
+    if: >
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: write
+    timeout-minutes: 5
+    steps:
+      - name: Evaluate and rerun flaky failures
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # --- Resolve the associated PR ---
+          RUN_DATA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
+            --jq '{pr: .pull_requests[0].number, sha: .head_sha}')
+          PR_NUMBER=$(echo "$RUN_DATA" | jq -r '.pr // empty')
+          HEAD_SHA=$(echo "$RUN_DATA" | jq -r '.sha // empty')
+
+          # Fallback for fork PRs: pull_requests array is often empty
+          if [ -z "$PR_NUMBER" ] && [ -n "$HEAD_SHA" ]; then
+            echo "pull_requests empty — falling back to SHA-based PR lookup"
+            PR_NUMBER=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
+              --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number" \
+              | head -1 || true)
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR associated with run ${RUN_ID}. Exiting."
+            exit 0
+          fi
+          if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+            echo "Invalid PR number: ${PR_NUMBER}. Exiting."
+            exit 1
+          fi
+          echo "PR #${PR_NUMBER} -- workflow: ${WORKFLOW_NAME}"
+
+          # --- Get run details ---
+          RUN_JSON=$(gh run view "$RUN_ID" --repo "$REPO" --json attempt,jobs,name)
+          ATTEMPT=$(echo "$RUN_JSON" | jq -r '.attempt')
+          echo "Current attempt: ${ATTEMPT}"
+
+          # --- Check attempt limit first ---
+          VERDICT="rerun"
+          REASON=""
+          if [ "$ATTEMPT" -ge 2 ]; then
+            VERDICT="skip"
+            REASON="Maximum re-run attempts reached (attempt ${ATTEMPT} of 2)"
+          fi
+
+          # --- Build job summary table ---
+          JOBS_TABLE=""
+
+          while IFS=$'\t' read -r job_name job_conclusion job_started job_completed; do
+            duration="unknown"
+            if [ -n "$job_started" ] && [ -n "$job_completed" ] \
+               && [ "$job_started" != "null" ] && [ "$job_completed" != "null" ]; then
+              start_epoch=$(date -d "$job_started" +%s 2>/dev/null || echo "0")
+              end_epoch=$(date -d "$job_completed" +%s 2>/dev/null || echo "0")
+              if [ "$start_epoch" -gt 0 ] && [ "$end_epoch" -gt 0 ]; then
+                duration_min=$(( (end_epoch - start_epoch) / 60 ))
+                duration="${duration_min}m"
+              fi
+            fi
+
+            job_verdict="flaky"
+
+            # Unrecoverable: lint/format/tidy failures won't be fixed by re-running
+            if [ "$WORKFLOW_NAME" = "Pull request checks" ] \
+               && echo "$job_name" | grep -qi "lint"; then
+              job_verdict="unrecoverable (lint failure)"
+              if [ "$VERDICT" != "skip" ]; then
+                VERDICT="skip"
+                REASON="Lint job failed in '${WORKFLOW_NAME}' -- compile-level problem, re-run will not help"
+              fi
+            fi
+            if [ "$WORKFLOW_NAME" = "Clang Format Check" ]; then
+              job_verdict="unrecoverable (format failure)"
+              if [ "$VERDICT" != "skip" ]; then
+                VERDICT="skip"
+                REASON="Clang format check failed -- formatting problem, re-run will not help"
+              fi
+            fi
+            if [ "$WORKFLOW_NAME" = "Clang Tidy Check" ]; then
+              job_verdict="unrecoverable (static analysis failure)"
+              if [ "$VERDICT" != "skip" ]; then
+                VERDICT="skip"
+                REASON="Clang tidy check failed -- static analysis problem, re-run will not help"
+              fi
+            fi
+            if [ "$WORKFLOW_NAME" = "Markdown" ]; then
+              job_verdict="unrecoverable (markdown lint failure)"
+              if [ "$VERDICT" != "skip" ]; then
+                VERDICT="skip"
+                REASON="Markdown lint failed -- formatting problem, re-run will not help"
+              fi
+            fi
+            if [ "$WORKFLOW_NAME" = "Lint (Darwin)" ]; then
+              job_verdict="unrecoverable (lint failure)"
+              if [ "$VERDICT" != "skip" ]; then
+                VERDICT="skip"
+                REASON="macOS lint failed -- lint problem, re-run will not help"
+              fi
+            fi
+
+            JOBS_TABLE="${JOBS_TABLE}| ${job_name} | ${job_conclusion} | ${duration} | ${job_verdict} |
+          "
+          done < <(echo "$RUN_JSON" | jq -r '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | [.name, .conclusion, .startedAt, .completedAt] | @tsv')
+
+          if [ -z "$JOBS_TABLE" ]; then
+            echo "No failed or timed-out jobs found. Exiting."
+            exit 0
+          fi
+
+          # --- Take action ---
+          if [ "$VERDICT" = "rerun" ]; then
+            ACTION_LINE="Re-running failed jobs (attempt $((ATTEMPT + 1)) of 2)"
+            echo "Re-running failed jobs for run ${RUN_ID}..."
+            gh run rerun "$RUN_ID" --repo "$REPO" --failed
+          else
+            ACTION_LINE="NOT re-running. Reason: ${REASON}"
+            echo "Skipping re-run: ${REASON}"
+          fi
+
+          # --- Post PR comment ---
+          printf -v COMMENT_BODY '%s\n\n%s\n%s\n%s\n%s' \
+            "### CI Supervisor: ${WORKFLOW_NAME} (attempt ${ATTEMPT})" \
+            "| Job | Conclusion | Duration | Verdict |" \
+            "|-----|-----------|----------|---------|" \
+            "${JOBS_TABLE}" \
+            "**Action**: ${ACTION_LINE}"
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT_BODY"
+          echo "Posted audit comment on PR #${PR_NUMBER}"

--- a/.github/workflows/supervisor_rerun-flaky.yml
+++ b/.github/workflows/supervisor_rerun-flaky.yml
@@ -1,6 +1,6 @@
 name: "CI Supervisor: Rerun flaky failures"
 
-on: # zizmor: ignore[dangerous-triggers] no code checkout; only github.token used for API calls
+on: # zizmor: ignore[dangerous-triggers] checks out only scripts/rerun-flaky.sh from default branch (explicit ref); GITHUB_TOKEN used for all ops
   workflow_run:
     workflows:
       - "Pull request checks"
@@ -27,140 +27,24 @@ jobs:
   evaluate-and-rerun:
     name: Evaluate failed checks
     if: >
-      github.event.workflow_run.conclusion == 'failure'
+      github.event.workflow_run.conclusion == 'failure' ||
+      github.event.workflow_run.conclusion == 'timed_out'
     runs-on: ubuntu-latest
     permissions:
       actions: write
       pull-requests: write
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: scripts/rerun-flaky.sh
+          sparse-checkout-cone-mode: false
       - name: Evaluate and rerun flaky failures
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
           REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          # --- Resolve the associated PR ---
-          RUN_DATA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
-            --jq '{pr: .pull_requests[0].number, sha: .head_sha}')
-          PR_NUMBER=$(echo "$RUN_DATA" | jq -r '.pr // empty')
-          HEAD_SHA=$(echo "$RUN_DATA" | jq -r '.sha // empty')
-
-          # Fallback for fork PRs: pull_requests array is often empty
-          if [ -z "$PR_NUMBER" ] && [ -n "$HEAD_SHA" ]; then
-            echo "pull_requests empty — falling back to SHA-based PR lookup"
-            PR_NUMBER=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
-              --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number" \
-              | head -1 || true)
-          fi
-
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No PR associated with run ${RUN_ID}. Exiting."
-            exit 0
-          fi
-          if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
-            echo "Invalid PR number: ${PR_NUMBER}. Exiting."
-            exit 1
-          fi
-          echo "PR #${PR_NUMBER} -- workflow: ${WORKFLOW_NAME}"
-
-          # --- Get run details ---
-          RUN_JSON=$(gh run view "$RUN_ID" --repo "$REPO" --json attempt,jobs,name)
-          ATTEMPT=$(echo "$RUN_JSON" | jq -r '.attempt')
-          echo "Current attempt: ${ATTEMPT}"
-
-          # --- Check attempt limit first ---
-          VERDICT="rerun"
-          REASON=""
-          if [ "$ATTEMPT" -ge 2 ]; then
-            VERDICT="skip"
-            REASON="Maximum re-run attempts reached (attempt ${ATTEMPT} of 2)"
-          fi
-
-          # --- Build job summary table ---
-          JOBS_TABLE=""
-
-          while IFS=$'\t' read -r job_name job_conclusion job_started job_completed; do
-            duration="unknown"
-            if [ -n "$job_started" ] && [ -n "$job_completed" ] \
-               && [ "$job_started" != "null" ] && [ "$job_completed" != "null" ]; then
-              start_epoch=$(date -d "$job_started" +%s 2>/dev/null || echo "0")
-              end_epoch=$(date -d "$job_completed" +%s 2>/dev/null || echo "0")
-              if [ "$start_epoch" -gt 0 ] && [ "$end_epoch" -gt 0 ]; then
-                duration_min=$(( (end_epoch - start_epoch) / 60 ))
-                duration="${duration_min}m"
-              fi
-            fi
-
-            job_verdict="flaky"
-
-            # Unrecoverable: lint/format/tidy failures won't be fixed by re-running
-            if [ "$WORKFLOW_NAME" = "Pull request checks" ] \
-               && echo "$job_name" | grep -qi "lint"; then
-              job_verdict="unrecoverable (lint failure)"
-              if [ "$VERDICT" != "skip" ]; then
-                VERDICT="skip"
-                REASON="Lint job failed in '${WORKFLOW_NAME}' -- compile-level problem, re-run will not help"
-              fi
-            fi
-            if [ "$WORKFLOW_NAME" = "Clang Format Check" ]; then
-              job_verdict="unrecoverable (format failure)"
-              if [ "$VERDICT" != "skip" ]; then
-                VERDICT="skip"
-                REASON="Clang format check failed -- formatting problem, re-run will not help"
-              fi
-            fi
-            if [ "$WORKFLOW_NAME" = "Clang Tidy Check" ]; then
-              job_verdict="unrecoverable (static analysis failure)"
-              if [ "$VERDICT" != "skip" ]; then
-                VERDICT="skip"
-                REASON="Clang tidy check failed -- static analysis problem, re-run will not help"
-              fi
-            fi
-            if [ "$WORKFLOW_NAME" = "Markdown" ]; then
-              job_verdict="unrecoverable (markdown lint failure)"
-              if [ "$VERDICT" != "skip" ]; then
-                VERDICT="skip"
-                REASON="Markdown lint failed -- formatting problem, re-run will not help"
-              fi
-            fi
-            if [ "$WORKFLOW_NAME" = "Lint (Darwin)" ]; then
-              job_verdict="unrecoverable (lint failure)"
-              if [ "$VERDICT" != "skip" ]; then
-                VERDICT="skip"
-                REASON="macOS lint failed -- lint problem, re-run will not help"
-              fi
-            fi
-
-            JOBS_TABLE="${JOBS_TABLE}| ${job_name} | ${job_conclusion} | ${duration} | ${job_verdict} |
-          "
-          done < <(echo "$RUN_JSON" | jq -r '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | [.name, .conclusion, .startedAt, .completedAt] | @tsv')
-
-          if [ -z "$JOBS_TABLE" ]; then
-            echo "No failed or timed-out jobs found. Exiting."
-            exit 0
-          fi
-
-          # --- Take action ---
-          if [ "$VERDICT" = "rerun" ]; then
-            ACTION_LINE="Re-running failed jobs (attempt $((ATTEMPT + 1)) of 2)"
-            echo "Re-running failed jobs for run ${RUN_ID}..."
-            gh run rerun "$RUN_ID" --repo "$REPO" --failed
-          else
-            ACTION_LINE="NOT re-running. Reason: ${REASON}"
-            echo "Skipping re-run: ${REASON}"
-          fi
-
-          # --- Post PR comment ---
-          printf -v COMMENT_BODY '%s\n\n%s\n%s\n%s\n%s' \
-            "### CI Supervisor: ${WORKFLOW_NAME} (attempt ${ATTEMPT})" \
-            "| Job | Conclusion | Duration | Verdict |" \
-            "|-----|-----------|----------|---------|" \
-            "${JOBS_TABLE}" \
-            "**Action**: ${ACTION_LINE}"
-
-          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT_BODY"
-          echo "Posted audit comment on PR #${PR_NUMBER}"
+        run: bash scripts/rerun-flaky.sh

--- a/.github/workflows/supervisor_rerun-flaky.yml
+++ b/.github/workflows/supervisor_rerun-flaky.yml
@@ -27,6 +27,7 @@ jobs:
       github.event.workflow_run.conclusion == 'timed_out'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       actions: write
       pull-requests: write
     timeout-minutes: 5

--- a/cmd/obi/main.go
+++ b/cmd/obi/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	lvl = slog.LevelVar{}
+	lvl := slog.LevelVar{}
 	lvl.Set(slog.LevelInfo)
 
 	configPath := flag.String("config", "", "path to the configuration file")

--- a/cmd/obi/main.go
+++ b/cmd/obi/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	lvl := slog.LevelVar{}
+	lvl = slog.LevelVar{}
 	lvl.Set(slog.LevelInfo)
 
 	configPath := flag.String("config", "", "path to the configuration file")

--- a/scripts/rerun-flaky.sh
+++ b/scripts/rerun-flaky.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # CI Supervisor: evaluate failed workflow runs and rerun flaky failures.
 # Called by .github/workflows/supervisor_rerun-flaky.yml
 #

--- a/scripts/rerun-flaky.sh
+++ b/scripts/rerun-flaky.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# CI Supervisor: evaluate failed workflow runs and rerun flaky failures.
+# Called by .github/workflows/supervisor_rerun-flaky.yml
+#
+# Required environment variables:
+#   GH_TOKEN       - GitHub token with actions:write and pull-requests:write
+#   RUN_ID         - The workflow run ID that failed
+#   WORKFLOW_NAME  - The name of the failed workflow
+#   REPO           - The owner/repo string (e.g. open-telemetry/opentelemetry-ebpf-instrumentation)
+
+set -euo pipefail
+
+MAX_ATTEMPTS=2
+
+# --- Resolve the associated PR ---
+RUN_DATA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
+  --jq '{pr: .pull_requests[0].number, sha: .head_sha}')
+PR_NUMBER=$(echo "$RUN_DATA" | jq -r '.pr // empty')
+HEAD_SHA=$(echo "$RUN_DATA" | jq -r '.sha // empty')
+
+# Fallback for fork PRs: pull_requests array is often empty
+if [ -z "$PR_NUMBER" ] && [ -n "$HEAD_SHA" ]; then
+  echo "pull_requests empty — falling back to commits/${HEAD_SHA}/pulls lookup"
+  PR_NUMBER=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+    --jq '[.[] | select(.state == "open")] | .[0].number // empty' || true)
+fi
+
+if [ -z "$PR_NUMBER" ]; then
+  echo "No PR associated with run ${RUN_ID}. Exiting."
+  exit 0
+fi
+if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+  echo "Invalid PR number: ${PR_NUMBER}. Exiting."
+  exit 1
+fi
+echo "PR #${PR_NUMBER} -- workflow: ${WORKFLOW_NAME}"
+
+# --- Get run details ---
+RUN_JSON=$(gh run view "$RUN_ID" --repo "$REPO" --json attempt,jobs,name)
+ATTEMPT=$(echo "$RUN_JSON" | jq -r '.attempt')
+echo "Current attempt: ${ATTEMPT}"
+
+# --- Check attempt limit first ---
+VERDICT="rerun"
+REASON=""
+if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+  VERDICT="skip"
+  REASON="Maximum re-run attempts reached (attempt ${ATTEMPT} of ${MAX_ATTEMPTS})"
+fi
+
+# --- Build job summary table ---
+JOBS_TABLE=""
+
+while IFS=$'\t' read -r job_name job_conclusion job_started job_completed; do
+  duration="unknown"
+  if [ -n "$job_started" ] && [ -n "$job_completed" ] \
+     && [ "$job_started" != "null" ] && [ "$job_completed" != "null" ]; then
+    start_epoch=$(date -d "$job_started" +%s 2>/dev/null || echo "0")
+    end_epoch=$(date -d "$job_completed" +%s 2>/dev/null || echo "0")
+    if [ "$start_epoch" -gt 0 ] && [ "$end_epoch" -gt 0 ]; then
+      duration_min=$(( (end_epoch - start_epoch) / 60 ))
+      duration="${duration_min}m"
+    fi
+  fi
+
+  job_verdict="flaky"
+
+  # Unrecoverable: lint/format/tidy failures won't be fixed by re-running
+  if [ "$WORKFLOW_NAME" = "Pull request checks" ] \
+     && echo "$job_name" | grep -qi "lint"; then
+    job_verdict="unrecoverable (lint failure)"
+    if [ "$VERDICT" != "skip" ]; then
+      VERDICT="skip"
+      REASON="Lint job failed in '${WORKFLOW_NAME}' -- static analysis/style failure, re-run will not help"
+    fi
+  fi
+  if [ "$WORKFLOW_NAME" = "Clang Format Check" ]; then
+    job_verdict="unrecoverable (format failure)"
+    if [ "$VERDICT" != "skip" ]; then
+      VERDICT="skip"
+      REASON="Clang format check failed -- formatting problem, re-run will not help"
+    fi
+  fi
+  if [ "$WORKFLOW_NAME" = "Clang Tidy Check" ]; then
+    job_verdict="unrecoverable (static analysis failure)"
+    if [ "$VERDICT" != "skip" ]; then
+      VERDICT="skip"
+      REASON="Clang tidy check failed -- static analysis problem, re-run will not help"
+    fi
+  fi
+  if [ "$WORKFLOW_NAME" = "Markdown" ]; then
+    job_verdict="unrecoverable (markdown lint failure)"
+    if [ "$VERDICT" != "skip" ]; then
+      VERDICT="skip"
+      REASON="Markdown lint failed -- formatting problem, re-run will not help"
+    fi
+  fi
+  if [ "$WORKFLOW_NAME" = "Lint (Darwin)" ]; then
+    job_verdict="unrecoverable (lint failure)"
+    if [ "$VERDICT" != "skip" ]; then
+      VERDICT="skip"
+      REASON="macOS lint failed -- lint problem, re-run will not help"
+    fi
+  fi
+
+  JOBS_TABLE="${JOBS_TABLE}| ${job_name} | ${job_conclusion} | ${duration} | ${job_verdict} |\n"
+done < <(echo "$RUN_JSON" | jq -r '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | [.name, .conclusion, .startedAt, .completedAt] | @tsv')
+
+if [ -z "$JOBS_TABLE" ]; then
+  echo "No failed or timed-out jobs found. Exiting."
+  exit 0
+fi
+
+# --- Take action ---
+if [ "$VERDICT" = "rerun" ]; then
+  ACTION_LINE="Re-running failed jobs (attempt $((ATTEMPT + 1)) of ${MAX_ATTEMPTS})"
+  echo "Re-running failed jobs for run ${RUN_ID}..."
+  gh run rerun "$RUN_ID" --repo "$REPO" --failed
+else
+  ACTION_LINE="NOT re-running. Reason: ${REASON}"
+  echo "Skipping re-run: ${REASON}"
+fi
+
+# --- Post PR comment ---
+COMMENT_BODY="### CI Supervisor: ${WORKFLOW_NAME} (attempt ${ATTEMPT})
+
+| Job | Conclusion | Duration | Verdict |
+|-----|-----------|----------|---------|
+$(printf '%b' "$JOBS_TABLE")
+**Action**: ${ACTION_LINE}"
+
+gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT_BODY"
+echo "Posted audit comment on PR #${PR_NUMBER}"

--- a/scripts/rerun-flaky.sh
+++ b/scripts/rerun-flaky.sh
@@ -77,35 +77,6 @@ while IFS=$'\t' read -r job_name job_conclusion job_started job_completed; do
       REASON="Lint job failed in '${WORKFLOW_NAME}' -- static analysis/style failure, re-run will not help"
     fi
   fi
-  if [ "$WORKFLOW_NAME" = "Clang Format Check" ]; then
-    job_verdict="unrecoverable (format failure)"
-    if [ "$VERDICT" != "skip" ]; then
-      VERDICT="skip"
-      REASON="Clang format check failed -- formatting problem, re-run will not help"
-    fi
-  fi
-  if [ "$WORKFLOW_NAME" = "Clang Tidy Check" ]; then
-    job_verdict="unrecoverable (static analysis failure)"
-    if [ "$VERDICT" != "skip" ]; then
-      VERDICT="skip"
-      REASON="Clang tidy check failed -- static analysis problem, re-run will not help"
-    fi
-  fi
-  if [ "$WORKFLOW_NAME" = "Markdown" ]; then
-    job_verdict="unrecoverable (markdown lint failure)"
-    if [ "$VERDICT" != "skip" ]; then
-      VERDICT="skip"
-      REASON="Markdown lint failed -- formatting problem, re-run will not help"
-    fi
-  fi
-  if [ "$WORKFLOW_NAME" = "Lint (Darwin)" ]; then
-    job_verdict="unrecoverable (lint failure)"
-    if [ "$VERDICT" != "skip" ]; then
-      VERDICT="skip"
-      REASON="macOS lint failed -- lint problem, re-run will not help"
-    fi
-  fi
-
   JOBS_TABLE="${JOBS_TABLE}| ${job_name} | ${job_conclusion} | ${duration} | ${job_verdict} |\n"
 done < <(echo "$RUN_JSON" | jq -r '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | [.name, .conclusion, .startedAt, .completedAt] | @tsv')
 


### PR DESCRIPTION
## Summary

Add CI supervisor workflow to automatically rerun certain check failures and timeouts.

- Hopefully works for fork PRs
- Minimal permissions - workflow runs from upstream `main` with read-only perms
- Does not re-run static check failures such as linting
- Capped re-run limit to prevent infinite re-runs
- Posts an audit comment on the PR with a job summary table and the action taken

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->