### PR TITLE
Add an Apache-2 Web Server example

### DIFF
--- a/examples/apache/README.md
+++ b/examples/apache/README.md
@@ -1,20 +1,31 @@
 # Apache Example
 
-This example shows Apache HTTP Server support in OBI with a small three-tier topology that covers direct request handling, reverse proxying, chained proxy hops, and route normalization.
-
-It covers:
+This example highlights the Apache HTTP Server behaviors that OBI can observe:
 
 - direct Apache route handling with `2xx`, `3xx`, `4xx`, and `5xx` responses
-- Apache acting as a reverse proxy
-- a chained proxy hop across multiple Apache processes
-- low-cardinality route grouping in OBI
-- traces and HTTP RED metrics exported to Grafana LGTM over OTLP
+- Apache acting as a reverse proxy, including a chained proxy hop between multiple Apache processes
 
-The demo uses three Apache instances:
+The scenario is framed as a small demo storefront:
 
-- `edge-apache`: the public storefront edge
-- `recommendations-v1`: the legacy recommendations backend
-- `recommendations-v2`: the newer recommendations backend, which still forwards some rollout traffic to `v1`
+- `edge-apache` is the public web edge for a shop landing page and a few user-facing routes
+- `recommendations-v1` is the legacy recommendations API
+- `recommendations-v2` is the next recommendations tier, which still forwards some traffic to `v1` during rollout
+
+That keeps the Apache example aligned with the nginx example so you can compare how OBI behaves across both web servers.
+
+You can run the example in three ways:
+
+- Docker Compose for the fastest local setup
+- Kubernetes with `kind`, manifests, and the Helm-installed OBI chart
+- a dedicated Linux host or VM where Apache and OBI run directly on the host
+
+## Topology
+
+The example uses three Apache instances:
+
+- `edge-apache`: serves storefront pages and proxies recommendation API calls
+- `recommendations-v1`: the legacy recommendations service
+- `recommendations-v2`: the newer recommendations service, which still chains some calls through `recommendations-v1`
 
 That gives us these flows:
 
@@ -22,11 +33,13 @@ That gives us these flows:
 - single proxy hop: client -> `edge-apache` -> `recommendations-v1`
 - chained proxy hop: client -> `edge-apache` -> `recommendations-v2` -> `recommendations-v1`
 
+The Apache route logic lives in shared vhost files under [`examples/apache/shared`](./shared). Docker Compose, Kubernetes, and the dedicated-host flow each use thin wrapper configs that only define local ports, upstream names, and mount paths.
+
 ## Routes To Exercise
 
 Use the bundled [`generate-traffic.sh`](./generate-traffic.sh) script, or call the routes manually. By default the script runs continuously until you stop it with `Ctrl+C`, prints periodic progress updates, and exercises the full route set concurrently at mixed rates. Use `--one-shot` if you only want a single pass.
 
-Docker Compose also starts this traffic generator automatically in a dedicated container, so the demo begins producing telemetry as soon as the environment is up.
+Docker Compose and Kubernetes also start this traffic generator automatically in a dedicated container or pod, so the demo begins producing telemetry as soon as the environment is up. In the dedicated-host mode, you run the traffic script yourself.
 
 - `/users/42/home` -> direct `200`
 - `/campaigns/spring-2026/redirect` -> direct `302`
@@ -38,7 +51,7 @@ Docker Compose also starts this traffic generator automatically in a dedicated c
 - `/api/users/42/recommendations/rollout/personalized-homepage` -> chained proxy `200`
 - `/api/users/9001/recommendations/rollout/cart-recovery` -> chained proxy `503`
 
-The OBI config uses the same route patterns as the nginx demo:
+The OBI route config uses the same route patterns as the nginx demo:
 
 ```yaml
 routes:
@@ -53,17 +66,27 @@ routes:
   unmatched: path
 ```
 
-That keeps user IDs and experience names out of low-cardinality route labels and span names.
+That means OBI can group the Apache traffic into the same low-cardinality route families you see in the nginx example.
+
+## Telemetry Pipeline
+
+All deployment modes follow the same default pattern:
+
+1. OBI exports traces and metrics over OTLP.
+2. A Grafana LGTM stack receives OTLP in a single backend.
+3. Grafana is prewired to its traces and metrics backends, so you can explore both signals from one UI.
+
+The example is still backend-neutral. If you want to compare Apache behavior with another OTLP backend later, keep the same three-tier topology and swap the OTLP destination.
 
 ## Docker Compose
 
-This example uses a single Docker Compose setup for Linux.
+This mode is the fastest way to try the full stack locally on Linux.
 
 ```bash
 docker compose up -d
 ```
 
-If you want to trigger an extra manual pass from your terminal, run:
+That command builds and starts a dedicated `traffic-generator` container automatically. If you want to trigger an extra manual pass from your terminal, you can still run:
 
 ```bash
 ./generate-traffic.sh --one-shot --base-url http://127.0.0.1:8080
@@ -79,21 +102,121 @@ To view telemetry in the UI:
 
 1. Open `http://localhost:3000` in your browser and sign in with `admin` / `admin`.
 2. Open Grafana Explore.
-3. Pick the traces data source to inspect end-to-end request traces.
+3. Pick the traces data source to inspect end-to-end Apache request traces.
 4. Pick the metrics data source to inspect HTTP metrics grouped by route and status code.
 
 Notes:
 
-- The `obi` service runs privileged with host PID access so it can attach to the Apache worker processes.
-- You can override the OBI image with `OBI_IMAGE=...`.
+- The `obi` service runs privileged with host PID access so it can attach to the Apache worker processes started by Docker Compose.
+- The compose file pins the topology and OTLP wiring, but you can override the OBI image with `OBI_IMAGE=...`.
+
+## Kubernetes
+
+The Kubernetes variant uses the official OpenTelemetry eBPF Instrumentation Helm chart:
+
+- chart: <https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-ebpf-instrumentation>
+
+The example still deploys the same three-tier Apache topology and LGTM backend with manifests, but OBI itself is installed through Helm so the example matches the supported Kubernetes installation path more closely.
+
+```bash
+docker build -t obi-apache-traffic:local -f examples/apache/traffic-runner/Dockerfile examples/apache
+kind load docker-image obi-apache-traffic:local
+
+kubectl apply -f examples/apache/k8s/00-namespace.yaml
+kubectl apply -k examples/apache/k8s
+
+helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+helm repo update
+helm upgrade --install obi open-telemetry/opentelemetry-ebpf-instrumentation \
+  --namespace obi-apache-example \
+  -f examples/apache/k8s/03-obi-values.yaml
+```
+
+Port-forward the UIs. Use two separate terminal windows for this:
+
+```bash
+# Terminal 1
+kubectl -n obi-apache-example port-forward svc/edge-apache 8080:8080
+```
+
+```bash
+# Terminal 2
+kubectl -n obi-apache-example port-forward svc/lgtm 3000:3000
+```
+
+Then open the UI:
+
+1. Open `http://localhost:3000` in your browser.
+2. Sign in with `admin` / `admin`.
+3. Open Grafana Explore.
+4. Use the traces data source to inspect the proxied Apache request chain.
+5. Use the metrics data source to inspect route-grouped HTTP metrics.
+
+Run an extra one-shot pass from your shell if you want:
+
+```bash
+./examples/apache/generate-traffic.sh --one-shot --base-url http://127.0.0.1:8080
+```
+
+The manifests also start a dedicated `traffic-generator` pod automatically, so the manual command above is optional.
+
+## Dedicated Linux Host Or VM
+
+This mode is meant for an EC2 instance or a local Linux machine where Apache and OBI run directly on the host.
+
+1. Install Apache HTTP Server, `obi`, and a recent Docker engine.
+2. Make sure `obi` runs with sufficient privileges to attach to Apache processes. The example commands below use `sudo`.
+3. Start the three host Apache instances:
+
+```bash
+./examples/apache/start-standalone.sh
+```
+
+1. Start the observability backend:
+
+```bash
+docker run -d --name lgtm --restart unless-stopped \
+  -p 3000:3000 -p 4317:4317 -p 4318:4318 \
+  grafana/otel-lgtm:0.23.0
+```
+
+1. Run OBI on the host:
+
+```bash
+sudo OTLP_ENDPOINT=http://127.0.0.1:4318 \
+  obi --config="$PWD/examples/apache/standalone/obi-config.yaml"
+```
+
+1. Generate traffic:
+
+```bash
+./examples/apache/generate-traffic.sh --base-url http://127.0.0.1:8080
+```
+
+1. When you are done, stop the host Apache instances:
+
+```bash
+./examples/apache/stop-standalone.sh
+docker rm -f lgtm
+```
+
+The host config discovers the three Apache processes by open port and keeps the OTLP target configurable through `OTLP_ENDPOINT`.
+
+To view telemetry in the UI:
+
+1. Open `http://localhost:3000` in your browser.
+2. Sign in with `admin` / `admin`.
+3. Open Grafana Explore.
+4. Use the traces data source to inspect the multi-hop recommendation requests.
+5. Use the metrics data source to inspect grouped route metrics and status-code breakdowns.
 
 ## What To Look For
 
 In Grafana Explore:
 
-- server spans for Apache-handled requests
-- trace continuity for proxied recommendation requests when Apache forwards traffic downstream
-- shared route grouping across direct, single-hop, and chained-hop traffic
+- one server span per Apache hop
+- child client spans for proxied recommendation requests
+- shared trace IDs across `edge-apache`, `recommendations-v1`, and `recommendations-v2` during proxied flows
 
 In Grafana metrics views:
 

--- a/examples/apache/README.md
+++ b/examples/apache/README.md
@@ -33,7 +33,7 @@ That gives us these flows:
 - single proxy hop: client -> `edge-apache` -> `recommendations-v1`
 - chained proxy hop: client -> `edge-apache` -> `recommendations-v2` -> `recommendations-v1`
 
-The Apache route logic lives in shared vhost files under [`examples/apache/shared`](./shared). Docker Compose, Kubernetes, and the dedicated-host flow each use thin wrapper configs that only define local ports, upstream names, and mount paths.
+The Apache route logic lives in shared vhost files under [`examples/apache/shared`](./shared). Docker Compose and the dedicated-host flow use those files directly. The Kubernetes manifests use mirrored copies under [`examples/apache/k8s/shared`](./k8s/shared) so the config stays within the kustomize tree while preserving the same route behavior.
 
 ## Routes To Exercise
 
@@ -164,7 +164,7 @@ The manifests also start a dedicated `traffic-generator` pod automatically, so t
 
 This mode is meant for an EC2 instance or a local Linux machine where Apache and OBI run directly on the host.
 
-1. Install Apache HTTP Server, `obi`, and a recent Docker engine.
+1. Install Apache HTTP Server with `httpd` available on `PATH`, `obi`, and a recent Docker engine.
 2. Make sure `obi` runs with sufficient privileges to attach to Apache processes. The example commands below use `sudo`.
 3. Start the three host Apache instances:
 

--- a/examples/apache/README.md
+++ b/examples/apache/README.md
@@ -1,0 +1,101 @@
+# Apache Example
+
+This example shows Apache HTTP Server support in OBI with a small three-tier topology that covers direct request handling, reverse proxying, chained proxy hops, and route normalization.
+
+It covers:
+
+- direct Apache route handling with `2xx`, `3xx`, `4xx`, and `5xx` responses
+- Apache acting as a reverse proxy
+- a chained proxy hop across multiple Apache processes
+- low-cardinality route grouping in OBI
+- traces and HTTP RED metrics exported to Grafana LGTM over OTLP
+
+The demo uses three Apache instances:
+
+- `edge-apache`: the public storefront edge
+- `recommendations-v1`: the legacy recommendations backend
+- `recommendations-v2`: the newer recommendations backend, which still forwards some rollout traffic to `v1`
+
+That gives us these flows:
+
+- direct handling: client -> `edge-apache`
+- single proxy hop: client -> `edge-apache` -> `recommendations-v1`
+- chained proxy hop: client -> `edge-apache` -> `recommendations-v2` -> `recommendations-v1`
+
+## Routes To Exercise
+
+Use the bundled [`generate-traffic.sh`](./generate-traffic.sh) script, or call the routes manually. By default the script runs continuously until you stop it with `Ctrl+C`, prints periodic progress updates, and exercises the full route set concurrently at mixed rates. Use `--one-shot` if you only want a single pass.
+
+Docker Compose also starts this traffic generator automatically in a dedicated container, so the demo begins producing telemetry as soon as the environment is up.
+
+- `/users/42/home` -> direct `200`
+- `/campaigns/spring-2026/redirect` -> direct `302`
+- `/support/articles/984404` -> direct `404`
+- `/checkout/sessions/abc123xyz` -> direct `500`
+- `/api/users/42/recommendations/v1/homepage-hero` -> proxied `200`
+- `/api/users/314159/recommendations/v1/category-bundles` -> proxied `404`
+- `/api/users/271828/recommendations/v2/style-refresh` -> proxied `302`
+- `/api/users/42/recommendations/rollout/personalized-homepage` -> chained proxy `200`
+- `/api/users/9001/recommendations/rollout/cart-recovery` -> chained proxy `503`
+
+The OBI config uses the same route patterns as the nginx demo:
+
+```yaml
+routes:
+  patterns:
+    - /users/:user_id/home
+    - /campaigns/:campaign_id/redirect
+    - /support/articles/:article_id
+    - /checkout/sessions/:session_id
+    - /api/users/:user_id/recommendations/v1/:experience
+    - /api/users/:user_id/recommendations/v2/:experience
+    - /api/users/:user_id/recommendations/rollout/:experience
+  unmatched: path
+```
+
+That keeps user IDs and experience names out of low-cardinality route labels and span names.
+
+## Docker Compose
+
+This example uses a single Docker Compose setup for Linux.
+
+```bash
+docker compose up -d
+```
+
+If you want to trigger an extra manual pass from your terminal, run:
+
+```bash
+./generate-traffic.sh --one-shot --base-url http://127.0.0.1:8080
+```
+
+Useful endpoints:
+
+- app: `http://localhost:8080`
+- Grafana: `http://localhost:3000` (`admin` / `admin`)
+- OTLP HTTP ingest: `http://localhost:4318`
+
+To view telemetry in the UI:
+
+1. Open `http://localhost:3000` in your browser and sign in with `admin` / `admin`.
+2. Open Grafana Explore.
+3. Pick the traces data source to inspect end-to-end request traces.
+4. Pick the metrics data source to inspect HTTP metrics grouped by route and status code.
+
+Notes:
+
+- The `obi` service runs privileged with host PID access so it can attach to the Apache worker processes.
+- You can override the OBI image with `OBI_IMAGE=...`.
+
+## What To Look For
+
+In Grafana Explore:
+
+- server spans for Apache-handled requests
+- trace continuity for proxied recommendation requests when Apache forwards traffic downstream
+- shared route grouping across direct, single-hop, and chained-hop traffic
+
+In Grafana metrics views:
+
+- HTTP duration and request metrics split by `http.response.status_code`
+- route aggregation for `/api/users/:user_id/recommendations/v1/:experience` and `/api/users/:user_id/recommendations/rollout/:experience`

--- a/examples/apache/docker-compose.yml
+++ b/examples/apache/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   edge-apache:
     image: httpd:2.4.65-alpine
-    container_name: edge-apache-hostnet
+    container_name: edge-apache
     network_mode: host
     volumes:
       - ./docker/edge/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro
@@ -13,7 +13,7 @@ services:
 
   recommendations-v1:
     image: httpd:2.4.65-alpine
-    container_name: recommendations-v1-apache-hostnet
+    container_name: recommendations-v1-apache
     network_mode: host
     volumes:
       - ./docker/recommendations-v1/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro
@@ -22,7 +22,7 @@ services:
 
   recommendations-v2:
     image: httpd:2.4.65-alpine
-    container_name: recommendations-v2-apache-hostnet
+    container_name: recommendations-v2-apache
     network_mode: host
     volumes:
       - ./docker/recommendations-v2/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro
@@ -35,7 +35,7 @@ services:
     build:
       context: .
       dockerfile: traffic-runner/Dockerfile
-    container_name: apache-traffic-generator-hostnet
+    container_name: apache-traffic-generator
     network_mode: host
     command:
       - --base-url
@@ -47,7 +47,7 @@ services:
 
   obi:
     image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.7.1@sha256:2a4df79f8af2d33090963b928bff4b38b691cb692fd75f02842d68b1359a4757}
-    container_name: obi-apache-example-hostnet
+    container_name: obi-apache-example
     command:
       - --config=/config/obi-config.yaml
     network_mode: host
@@ -64,5 +64,5 @@ services:
 
   lgtm:
     image: grafana/otel-lgtm:0.23.0@sha256:dde2dcd51e955e27e1ab454e6ba8e6f8c958e7d22dca1d4ab0be87fa64198051
-    container_name: lgtm-apache-example-hostnet
+    container_name: lgtm-apache-example
     network_mode: host

--- a/examples/apache/docker-compose.yml
+++ b/examples/apache/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   edge-apache:
-    image: httpd:2.4.65-alpine
+    image: httpd:2.4.65-alpine@sha256:07b2fabb7029a0b8aeb2e0fd02651c28fe22c21c5b5a59d6ff5b022791fcd89e
     container_name: edge-apache
     network_mode: host
     volumes:
@@ -12,7 +12,7 @@ services:
       - recommendations-v2
 
   recommendations-v1:
-    image: httpd:2.4.65-alpine
+    image: httpd:2.4.65-alpine@sha256:07b2fabb7029a0b8aeb2e0fd02651c28fe22c21c5b5a59d6ff5b022791fcd89e
     container_name: recommendations-v1-apache
     network_mode: host
     volumes:
@@ -21,7 +21,7 @@ services:
       - ./htdocs:/usr/local/apache2/htdocs:ro
 
   recommendations-v2:
-    image: httpd:2.4.65-alpine
+    image: httpd:2.4.65-alpine@sha256:07b2fabb7029a0b8aeb2e0fd02651c28fe22c21c5b5a59d6ff5b022791fcd89e
     container_name: recommendations-v2-apache
     network_mode: host
     volumes:

--- a/examples/apache/docker-compose.yml
+++ b/examples/apache/docker-compose.yml
@@ -1,0 +1,68 @@
+services:
+  edge-apache:
+    image: httpd:2.4.65-alpine
+    container_name: edge-apache-hostnet
+    network_mode: host
+    volumes:
+      - ./docker/edge/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro
+      - ./shared:/usr/local/apache2/conf/shared:ro
+      - ./htdocs:/usr/local/apache2/htdocs:ro
+    depends_on:
+      - recommendations-v1
+      - recommendations-v2
+
+  recommendations-v1:
+    image: httpd:2.4.65-alpine
+    container_name: recommendations-v1-apache-hostnet
+    network_mode: host
+    volumes:
+      - ./docker/recommendations-v1/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro
+      - ./shared:/usr/local/apache2/conf/shared:ro
+      - ./htdocs:/usr/local/apache2/htdocs:ro
+
+  recommendations-v2:
+    image: httpd:2.4.65-alpine
+    container_name: recommendations-v2-apache-hostnet
+    network_mode: host
+    volumes:
+      - ./docker/recommendations-v2/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro
+      - ./shared:/usr/local/apache2/conf/shared:ro
+      - ./htdocs:/usr/local/apache2/htdocs:ro
+    depends_on:
+      - recommendations-v1
+
+  traffic-generator:
+    build:
+      context: .
+      dockerfile: traffic-runner/Dockerfile
+    container_name: apache-traffic-generator-hostnet
+    network_mode: host
+    command:
+      - --base-url
+      - http://127.0.0.1:8080
+      - --progress-seconds
+      - "15"
+    depends_on:
+      - edge-apache
+
+  obi:
+    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.7.1@sha256:2a4df79f8af2d33090963b928bff4b38b691cb692fd75f02842d68b1359a4757}
+    container_name: obi-apache-example-hostnet
+    command:
+      - --config=/config/obi-config.yaml
+    network_mode: host
+    pid: host
+    privileged: true
+    volumes:
+      - ./docker/obi-config.yaml:/config/obi-config.yaml:ro
+    depends_on:
+      - edge-apache
+      - recommendations-v1
+      - recommendations-v2
+      - traffic-generator
+      - lgtm
+
+  lgtm:
+    image: grafana/otel-lgtm:0.23.0@sha256:dde2dcd51e955e27e1ab454e6ba8e6f8c958e7d22dca1d4ab0be87fa64198051
+    container_name: lgtm-apache-example-hostnet
+    network_mode: host

--- a/examples/apache/docker/edge/httpd.conf
+++ b/examples/apache/docker/edge/httpd.conf
@@ -32,7 +32,7 @@ Define RECOMMENDATIONS_V2_ORIGIN 127.0.0.1:8082
     Require all granted
 </Directory>
 
-CustomLog /proc/self/fd/1 common
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
+CustomLog /proc/self/fd/1 common
 
 Include conf/shared/edge-vhost.conf

--- a/examples/apache/docker/edge/httpd.conf
+++ b/examples/apache/docker/edge/httpd.conf
@@ -23,6 +23,9 @@ Group daemon
 
 TypesConfig conf/mime.types
 DocumentRoot "/usr/local/apache2/htdocs"
+Define APACHE_HTDOCS_ROOT /usr/local/apache2/htdocs
+Define RECOMMENDATIONS_V1_ORIGIN 127.0.0.1:8081
+Define RECOMMENDATIONS_V2_ORIGIN 127.0.0.1:8082
 
 <Directory "/usr/local/apache2/htdocs">
     AllowOverride None

--- a/examples/apache/docker/edge/httpd.conf
+++ b/examples/apache/docker/edge/httpd.conf
@@ -1,0 +1,35 @@
+ServerRoot "/usr/local/apache2"
+Listen 8080
+ServerName edge-apache
+PidFile "/tmp/httpd.pid"
+ErrorLog /proc/self/fd/2
+LogLevel warn
+
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule unixd_module modules/mod_unixd.so
+
+User daemon
+Group daemon
+
+TypesConfig conf/mime.types
+DocumentRoot "/usr/local/apache2/htdocs"
+
+<Directory "/usr/local/apache2/htdocs">
+    AllowOverride None
+    Require all granted
+</Directory>
+
+CustomLog /proc/self/fd/1 common
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+Include conf/shared/edge-vhost.conf

--- a/examples/apache/docker/obi-config.yaml
+++ b/examples/apache/docker/obi-config.yaml
@@ -1,0 +1,25 @@
+routes:
+  patterns:
+    - /users/:user_id/home
+    - /campaigns/:campaign_id/redirect
+    - /support/articles/:article_id
+    - /checkout/sessions/:session_id
+    - /api/users/:user_id/recommendations/v1/:experience
+    - /api/users/:user_id/recommendations/v2/:experience
+    - /api/users/:user_id/recommendations/rollout/:experience
+  unmatched: path
+otel_metrics_export:
+  endpoint: http://127.0.0.1:4318
+otel_traces_export:
+  endpoint: http://127.0.0.1:4318
+discovery:
+  instrument:
+    - namespace: apache-example
+      name: edge-apache
+      open_ports: 8080
+    - namespace: apache-example
+      name: recommendations-v1
+      open_ports: 8081
+    - namespace: apache-example
+      name: recommendations-v2
+      open_ports: 8082

--- a/examples/apache/docker/recommendations-v1/httpd.conf
+++ b/examples/apache/docker/recommendations-v1/httpd.conf
@@ -1,0 +1,33 @@
+ServerRoot "/usr/local/apache2"
+Listen 8081
+ServerName recommendations-v1
+PidFile "/tmp/httpd.pid"
+ErrorLog /proc/self/fd/2
+LogLevel warn
+
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule unixd_module modules/mod_unixd.so
+
+User daemon
+Group daemon
+
+TypesConfig conf/mime.types
+DocumentRoot "/usr/local/apache2/htdocs"
+
+<Directory "/usr/local/apache2/htdocs">
+    AllowOverride None
+    Require all granted
+</Directory>
+
+CustomLog /proc/self/fd/1 common
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+Include conf/shared/recommendations-v1-vhost.conf

--- a/examples/apache/docker/recommendations-v1/httpd.conf
+++ b/examples/apache/docker/recommendations-v1/httpd.conf
@@ -28,7 +28,7 @@ Define APACHE_HTDOCS_ROOT /usr/local/apache2/htdocs
     Require all granted
 </Directory>
 
-CustomLog /proc/self/fd/1 common
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
+CustomLog /proc/self/fd/1 common
 
 Include conf/shared/recommendations-v1-vhost.conf

--- a/examples/apache/docker/recommendations-v2/httpd.conf
+++ b/examples/apache/docker/recommendations-v2/httpd.conf
@@ -31,7 +31,7 @@ Define RECOMMENDATIONS_V1_ORIGIN 127.0.0.1:8081
     Require all granted
 </Directory>
 
-CustomLog /proc/self/fd/1 common
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
+CustomLog /proc/self/fd/1 common
 
 Include conf/shared/recommendations-v2-vhost.conf

--- a/examples/apache/docker/recommendations-v2/httpd.conf
+++ b/examples/apache/docker/recommendations-v2/httpd.conf
@@ -1,0 +1,35 @@
+ServerRoot "/usr/local/apache2"
+Listen 8082
+ServerName recommendations-v2
+PidFile "/tmp/httpd.pid"
+ErrorLog /proc/self/fd/2
+LogLevel warn
+
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule unixd_module modules/mod_unixd.so
+
+User daemon
+Group daemon
+
+TypesConfig conf/mime.types
+DocumentRoot "/usr/local/apache2/htdocs"
+
+<Directory "/usr/local/apache2/htdocs">
+    AllowOverride None
+    Require all granted
+</Directory>
+
+CustomLog /proc/self/fd/1 common
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+Include conf/shared/recommendations-v2-vhost.conf

--- a/examples/apache/docker/recommendations-v2/httpd.conf
+++ b/examples/apache/docker/recommendations-v2/httpd.conf
@@ -23,6 +23,8 @@ Group daemon
 
 TypesConfig conf/mime.types
 DocumentRoot "/usr/local/apache2/htdocs"
+Define APACHE_HTDOCS_ROOT /usr/local/apache2/htdocs
+Define RECOMMENDATIONS_V1_ORIGIN 127.0.0.1:8081
 
 <Directory "/usr/local/apache2/htdocs">
     AllowOverride None

--- a/examples/apache/generate-traffic.sh
+++ b/examples/apache/generate-traffic.sh
@@ -315,7 +315,8 @@ run_continuous() {
 
 main() {
   parse_args "$@"
-  trap cleanup EXIT INT TERM
+  trap 'cleanup' EXIT
+  trap 'log_info "received interrupt, shutting down"; exit 0' INT TERM
 
   if (( ONE_SHOT == 1 )); then
     run_one_shot

--- a/examples/apache/generate-traffic.sh
+++ b/examples/apache/generate-traffic.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -Eeuo pipefail
+
+PROGNAME="$(basename "$0")"
+readonly PROGNAME
+readonly DEFAULT_BASE_URL="http://127.0.0.1:8080"
+readonly DEFAULT_PROGRESS_INTERVAL=15
+readonly DEFAULT_CURL_TIMEOUT=10
+readonly DEFAULT_INITIAL_DELAY_MS=250
+
+declare -a WORKER_PIDS=()
+
+usage() {
+  cat <<EOF
+Usage: $PROGNAME [options]
+
+Exercise the Apache demo routes for the OBI example.
+
+Options:
+  -u, --base-url URL          Base URL for the edge Apache service.
+                              Default: $DEFAULT_BASE_URL
+  -o, --one-shot              Send a single pass across the full route set and exit.
+  -p, --progress-seconds N    Print a progress summary every N seconds.
+                              Default: $DEFAULT_PROGRESS_INTERVAL
+  -t, --curl-timeout N        Per-request curl timeout in seconds.
+                              Default: $DEFAULT_CURL_TIMEOUT
+      --initial-delay-ms N    Maximum startup jitter per worker in milliseconds.
+                              Default: $DEFAULT_INITIAL_DELAY_MS
+  -h, --help                  Show this help text.
+
+Examples:
+  $PROGNAME
+  $PROGNAME --base-url http://127.0.0.1:18080
+  $PROGNAME --one-shot --base-url http://127.0.0.1:18080
+
+In continuous mode the script runs until you stop it with Ctrl+C.
+EOF
+}
+
+die() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+is_unsigned_integer() {
+  local value="$1"
+  [[ "$value" =~ ^[0-9]+$ ]]
+}
+
+ms_to_seconds() {
+  local milliseconds="$1"
+
+  printf '%s.%03d' \
+    "$((milliseconds / 1000))" \
+    "$((milliseconds % 1000))"
+}
+
+log_info() {
+  printf '[%(%Y-%m-%dT%H:%M:%S%z)T] %s\n' -1 "$*"
+}
+
+route_specs() {
+  cat <<'EOF'
+/users/42/home|200|4000
+/campaigns/spring-2026/redirect|302|9000
+/support/articles/984404|404|12000
+/checkout/sessions/abc123xyz|500|15000
+/api/users/42/recommendations/v1/homepage-hero|200|2500
+/api/users/314159/recommendations/v1/category-bundles|404|10000
+/api/users/271828/recommendations/v2/style-refresh|302|7000
+/api/users/42/recommendations/rollout/personalized-homepage|200|3000
+/api/users/9001/recommendations/rollout/cart-recovery|503|11000
+EOF
+}
+
+fetch_http_code() {
+  local output_var_name="$1"
+  local path="$2"
+  local curl_http_code
+
+  if curl_http_code="$(
+    curl \
+      --silent \
+      --show-error \
+      --output /dev/null \
+      --write-out '%{http_code}' \
+      --max-time "$CURL_TIMEOUT" \
+      "${BASE_URL}${path}"
+  )"; then
+    printf -v "$output_var_name" '%s' "$curl_http_code"
+    return 0
+  fi
+
+  printf -v "$output_var_name" '%s' "${curl_http_code:-000}"
+  return 1
+}
+
+request_route() {
+  local path="$1"
+  local expected_code="$2"
+  local http_code=""
+
+  fetch_http_code http_code "$path" || true
+
+  if [[ "$http_code" == "$expected_code" ]]; then
+    return 0
+  fi
+
+  printf 'expected %s but got %s for %s\n' \
+    "$expected_code" \
+    "$http_code" \
+    "$path" >&2
+  return 1
+}
+
+emit_event() {
+  local fifo_path="$1"
+  local event_type="$2"
+  local path="$3"
+  local observed_code="$4"
+  local expected_code="$5"
+
+  printf '%s\t%s\t%s\t%s\n' \
+    "$event_type" \
+    "$path" \
+    "$observed_code" \
+    "$expected_code" >"$fifo_path"
+}
+
+worker_loop() {
+  local fifo_path="$1"
+  local path="$2"
+  local expected_code="$3"
+  local interval_ms="$4"
+  local startup_delay_ms=0
+  local http_code=""
+
+  trap 'exit 0' INT TERM
+
+  if (( INITIAL_DELAY_MS > 0 )); then
+    startup_delay_ms=$((RANDOM % (INITIAL_DELAY_MS + 1)))
+    sleep "$(ms_to_seconds "$startup_delay_ms")"
+  fi
+
+  while true; do
+    fetch_http_code http_code "$path" || true
+
+    if [[ "$http_code" == "$expected_code" ]]; then
+      emit_event "$fifo_path" "ok" "$path" "$http_code" "$expected_code"
+    else
+      emit_event "$fifo_path" "fail" "$path" "$http_code" "$expected_code"
+    fi
+
+    sleep "$(ms_to_seconds "$interval_ms")"
+  done
+}
+
+parse_args() {
+  local base_url="$DEFAULT_BASE_URL"
+  local progress_interval="$DEFAULT_PROGRESS_INTERVAL"
+  local curl_timeout="$DEFAULT_CURL_TIMEOUT"
+  local initial_delay_ms="$DEFAULT_INITIAL_DELAY_MS"
+  local one_shot=0
+
+  while (($# > 0)); do
+    case "$1" in
+      -u|--base-url)
+        (($# >= 2)) || die "missing value for $1"
+        base_url="$2"
+        shift 2
+        ;;
+      -o|--one-shot)
+        one_shot=1
+        shift
+        ;;
+      -p|--progress-seconds)
+        (($# >= 2)) || die "missing value for $1"
+        is_unsigned_integer "$2" || die "progress interval must be a non-negative integer"
+        progress_interval="$2"
+        shift 2
+        ;;
+      -t|--curl-timeout)
+        (($# >= 2)) || die "missing value for $1"
+        is_unsigned_integer "$2" || die "curl timeout must be a non-negative integer"
+        curl_timeout="$2"
+        shift 2
+        ;;
+      --initial-delay-ms)
+        (($# >= 2)) || die "missing value for $1"
+        is_unsigned_integer "$2" || die "initial delay must be a non-negative integer"
+        initial_delay_ms="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --)
+        shift
+        (($# == 0)) || die "unexpected positional arguments: $*"
+        ;;
+      -*)
+        die "unknown option: $1"
+        ;;
+      *)
+        die "unexpected positional argument: $1"
+        ;;
+    esac
+  done
+
+  declare -gr BASE_URL="$base_url"
+  declare -gr PROGRESS_INTERVAL="$progress_interval"
+  declare -gr CURL_TIMEOUT="$curl_timeout"
+  declare -gr INITIAL_DELAY_MS="$initial_delay_ms"
+  declare -gr ONE_SHOT="$one_shot"
+}
+
+cleanup() {
+  local pid
+
+  for pid in "${WORKER_PIDS[@]:-}"; do
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+
+  if [[ -n "${EVENT_FIFO:-}" && -p "${EVENT_FIFO:-}" ]]; then
+    rm -f "$EVENT_FIFO"
+  fi
+
+  if [[ -n "${STATE_DIR:-}" && -d "${STATE_DIR:-}" ]]; then
+    rm -rf "$STATE_DIR"
+  fi
+}
+
+run_one_shot() {
+  local path
+  local expected_code
+  local interval_ms
+  local total=0
+
+  log_info "sending one pass across the full route set"
+
+  while IFS='|' read -r path expected_code interval_ms; do
+    [[ -n "$path" ]] || continue
+    total=$((total + 1))
+
+    if request_route "$path" "$expected_code"; then
+      printf '%-60s -> %s\n' "$path" "$expected_code"
+    else
+      return 1
+    fi
+  done < <(route_specs)
+
+  log_info "completed one-shot run for $total routes"
+}
+
+spawn_workers() {
+  local path
+  local expected_code
+  local interval_ms
+
+  while IFS='|' read -r path expected_code interval_ms; do
+    [[ -n "$path" ]] || continue
+
+    worker_loop "$EVENT_FIFO" "$path" "$expected_code" "$interval_ms" &
+    WORKER_PIDS+=("$!")
+  done < <(route_specs)
+}
+
+run_continuous() {
+  local last_report_epoch
+  local now
+  local total_ok=0
+  local total_fail=0
+  local event_type
+  local path
+  local observed_code
+  local expected_code
+
+  STATE_DIR="$(mktemp -d)"
+  readonly STATE_DIR
+  EVENT_FIFO="$STATE_DIR/events.fifo"
+  readonly EVENT_FIFO
+  mkfifo "$EVENT_FIFO"
+
+  log_info "starting Apache demo traffic against $BASE_URL"
+  spawn_workers
+
+  last_report_epoch="$(date +%s)"
+
+  exec 3<>"$EVENT_FIFO"
+
+  while true; do
+    if IFS=$'\t' read -r -t 1 event_type path observed_code expected_code <&3; then
+      if [[ "$event_type" == "ok" ]]; then
+        total_ok=$((total_ok + 1))
+      else
+        total_fail=$((total_fail + 1))
+        log_info "unexpected response for $path: expected $expected_code, got $observed_code"
+      fi
+    fi
+
+    now="$(date +%s)"
+    if (( PROGRESS_INTERVAL > 0 && now - last_report_epoch >= PROGRESS_INTERVAL )); then
+      log_info "progress: ok=$total_ok fail=$total_fail"
+      last_report_epoch="$now"
+    fi
+  done
+}
+
+main() {
+  parse_args "$@"
+  trap cleanup EXIT INT TERM
+
+  if (( ONE_SHOT == 1 )); then
+    run_one_shot
+    return
+  fi
+
+  run_continuous
+}
+
+main "$@"

--- a/examples/apache/htdocs/edge/users/42/home.txt
+++ b/examples/apache/htdocs/edge/users/42/home.txt
@@ -1,0 +1,1 @@
+user home page

--- a/examples/apache/htdocs/recommendations-v1/api/users/42/recommendations/rollout/personalized-homepage.txt
+++ b/examples/apache/htdocs/recommendations-v1/api/users/42/recommendations/rollout/personalized-homepage.txt
@@ -1,0 +1,1 @@
+recommendations v1 rollout ok

--- a/examples/apache/htdocs/recommendations-v1/api/users/42/recommendations/v1/homepage-hero.txt
+++ b/examples/apache/htdocs/recommendations-v1/api/users/42/recommendations/v1/homepage-hero.txt
@@ -1,0 +1,1 @@
+recommendations v1 ok

--- a/examples/apache/k8s/00-namespace.yaml
+++ b/examples/apache/k8s/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: obi-apache-example

--- a/examples/apache/k8s/01-observability.yaml
+++ b/examples/apache/k8s/01-observability.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: lgtm
+  namespace: obi-apache-example
+spec:
+  selector:
+    app: lgtm
+  ports:
+    - name: grafana
+      port: 3000
+      targetPort: 3000
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lgtm
+  namespace: obi-apache-example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lgtm
+  template:
+    metadata:
+      labels:
+        app: lgtm
+    spec:
+      containers:
+        - name: lgtm
+          image: grafana/otel-lgtm:0.23.0@sha256:dde2dcd51e955e27e1ab454e6ba8e6f8c958e7d22dca1d4ab0be87fa64198051
+          ports:
+            - containerPort: 3000
+            - containerPort: 4317
+            - containerPort: 4318

--- a/examples/apache/k8s/02-apache.yaml
+++ b/examples/apache/k8s/02-apache.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: httpd
-          image: httpd:2.4.65-alpine
+          image: httpd:2.4.65-alpine@sha256:07b2fabb7029a0b8aeb2e0fd02651c28fe22c21c5b5a59d6ff5b022791fcd89e
           ports:
             - containerPort: 8080
           readinessProbe:
@@ -93,7 +93,7 @@ spec:
     spec:
       containers:
         - name: httpd
-          image: httpd:2.4.65-alpine
+          image: httpd:2.4.65-alpine@sha256:07b2fabb7029a0b8aeb2e0fd02651c28fe22c21c5b5a59d6ff5b022791fcd89e
           ports:
             - containerPort: 8081
           readinessProbe:
@@ -158,7 +158,7 @@ spec:
     spec:
       containers:
         - name: httpd
-          image: httpd:2.4.65-alpine
+          image: httpd:2.4.65-alpine@sha256:07b2fabb7029a0b8aeb2e0fd02651c28fe22c21c5b5a59d6ff5b022791fcd89e
           ports:
             - containerPort: 8082
           readinessProbe:
@@ -213,7 +213,7 @@ spec:
     spec:
       initContainers:
         - name: wait-for-apache
-          image: curlimages/curl:8.13.0
+          image: curlimages/curl:8.13.0@sha256:d43bdb28bae0be0998f3be83199bfb2b81e0a30b034b6d7586ce7e05de34c3fd
           command:
             - sh
             - -ec

--- a/examples/apache/k8s/02-apache.yaml
+++ b/examples/apache/k8s/02-apache.yaml
@@ -1,0 +1,252 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: edge-apache
+  namespace: obi-apache-example
+spec:
+  selector:
+    app: edge-apache
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: edge-apache
+  namespace: obi-apache-example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: edge-apache
+  template:
+    metadata:
+      labels:
+        app: edge-apache
+    spec:
+      containers:
+        - name: httpd
+          image: httpd:2.4.65-alpine
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /users/42/home
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/apache2/conf/httpd.conf
+              subPath: httpd.conf
+            - name: shared
+              mountPath: /usr/local/apache2/conf/shared
+            - name: htdocs
+              mountPath: /usr/local/apache2/htdocs
+      volumes:
+        - name: config
+          configMap:
+            name: edge-apache-config
+        - name: shared
+          configMap:
+            name: apache-shared-config
+        - name: htdocs
+          configMap:
+            name: apache-htdocs
+            items:
+              - key: edge-users-42-home.txt
+                path: edge/users/42/home.txt
+              - key: recommendations-v1-rollout-personalized-homepage.txt
+                path: recommendations-v1/api/users/42/recommendations/rollout/personalized-homepage.txt
+              - key: recommendations-v1-v1-homepage-hero.txt
+                path: recommendations-v1/api/users/42/recommendations/v1/homepage-hero.txt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendations-v1
+  namespace: obi-apache-example
+spec:
+  selector:
+    app: recommendations-v1
+  ports:
+    - name: http
+      port: 8081
+      targetPort: 8081
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recommendations-v1
+  namespace: obi-apache-example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: recommendations-v1
+  template:
+    metadata:
+      labels:
+        app: recommendations-v1
+    spec:
+      containers:
+        - name: httpd
+          image: httpd:2.4.65-alpine
+          ports:
+            - containerPort: 8081
+          readinessProbe:
+            httpGet:
+              path: /api/users/42/recommendations/v1/homepage-hero
+              port: 8081
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/apache2/conf/httpd.conf
+              subPath: httpd.conf
+            - name: shared
+              mountPath: /usr/local/apache2/conf/shared
+            - name: htdocs
+              mountPath: /usr/local/apache2/htdocs
+      volumes:
+        - name: config
+          configMap:
+            name: recommendations-v1-config
+        - name: shared
+          configMap:
+            name: apache-shared-config
+        - name: htdocs
+          configMap:
+            name: apache-htdocs
+            items:
+              - key: edge-users-42-home.txt
+                path: edge/users/42/home.txt
+              - key: recommendations-v1-rollout-personalized-homepage.txt
+                path: recommendations-v1/api/users/42/recommendations/rollout/personalized-homepage.txt
+              - key: recommendations-v1-v1-homepage-hero.txt
+                path: recommendations-v1/api/users/42/recommendations/v1/homepage-hero.txt
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendations-v2
+  namespace: obi-apache-example
+spec:
+  selector:
+    app: recommendations-v2
+  ports:
+    - name: http
+      port: 8082
+      targetPort: 8082
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recommendations-v2
+  namespace: obi-apache-example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: recommendations-v2
+  template:
+    metadata:
+      labels:
+        app: recommendations-v2
+    spec:
+      containers:
+        - name: httpd
+          image: httpd:2.4.65-alpine
+          ports:
+            - containerPort: 8082
+          readinessProbe:
+            httpGet:
+              path: /api/users/271828/recommendations/v2/style-refresh
+              port: 8082
+              httpHeaders:
+                - name: Host
+                  value: recommendations-v2
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/apache2/conf/httpd.conf
+              subPath: httpd.conf
+            - name: shared
+              mountPath: /usr/local/apache2/conf/shared
+            - name: htdocs
+              mountPath: /usr/local/apache2/htdocs
+      volumes:
+        - name: config
+          configMap:
+            name: recommendations-v2-config
+        - name: shared
+          configMap:
+            name: apache-shared-config
+        - name: htdocs
+          configMap:
+            name: apache-htdocs
+            items:
+              - key: edge-users-42-home.txt
+                path: edge/users/42/home.txt
+              - key: recommendations-v1-rollout-personalized-homepage.txt
+                path: recommendations-v1/api/users/42/recommendations/rollout/personalized-homepage.txt
+              - key: recommendations-v1-v1-homepage-hero.txt
+                path: recommendations-v1/api/users/42/recommendations/v1/homepage-hero.txt
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: traffic-generator
+  namespace: obi-apache-example
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: traffic-generator
+  template:
+    metadata:
+      labels:
+        app: traffic-generator
+    spec:
+      initContainers:
+        - name: wait-for-apache
+          image: curlimages/curl:8.13.0
+          command:
+            - sh
+            - -ec
+            - |
+              wait_for() {
+                local expected_code="$1"
+                local url="$2"
+                local attempt=0
+                local observed_code=""
+
+                until [ "$observed_code" = "$expected_code" ]; do
+                  observed_code="$(curl -sS -o /dev/null -w '%{http_code}' "$url" || true)"
+                  attempt=$((attempt + 1))
+                  if [ "$observed_code" = "$expected_code" ]; then
+                    break
+                  fi
+                  if [ "$attempt" -ge 60 ]; then
+                    echo "timed out waiting for $url: expected $expected_code, got ${observed_code:-000}" >&2
+                    exit 1
+                  fi
+                  sleep 2
+                done
+              }
+
+              wait_for 200 http://edge-apache:8080/users/42/home
+              wait_for 200 http://recommendations-v1:8081/api/users/42/recommendations/v1/homepage-hero
+              wait_for 302 http://recommendations-v2:8082/api/users/271828/recommendations/v2/style-refresh
+      containers:
+        - name: traffic-generator
+          image: obi-apache-traffic:local
+          imagePullPolicy: IfNotPresent
+          args:
+            - --base-url
+            - http://edge-apache:8080
+            - --progress-seconds
+            - "15"

--- a/examples/apache/k8s/03-obi-values.yaml
+++ b/examples/apache/k8s/03-obi-values.yaml
@@ -1,0 +1,44 @@
+namespaceOverride: obi-apache-example
+
+image:
+  registry: docker.io
+  repository: otel/ebpf-instrument
+  tag: v0.7.1
+  digest: sha256:2a4df79f8af2d33090963b928bff4b38b691cb692fd75f02842d68b1359a4757
+
+preset: application
+privileged: true
+
+config:
+  create: true
+  data:
+    attributes:
+      kubernetes:
+        enable: true
+    routes:
+      patterns:
+        - /users/:user_id/home
+        - /campaigns/:campaign_id/redirect
+        - /support/articles/:article_id
+        - /checkout/sessions/:session_id
+        - /api/users/:user_id/recommendations/v1/:experience
+        - /api/users/:user_id/recommendations/v2/:experience
+        - /api/users/:user_id/recommendations/rollout/:experience
+      unmatched: path
+    otel_metrics_export:
+      endpoint: http://lgtm:4318
+    otel_traces_export:
+      endpoint: http://lgtm:4318
+    discovery:
+      instrument:
+        - namespace: obi-apache-example
+          k8s_deployment_name: edge-apache
+        - namespace: obi-apache-example
+          k8s_deployment_name: recommendations-v1
+        - namespace: obi-apache-example
+          k8s_deployment_name: recommendations-v2
+
+env:
+  OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 5s
+  OTEL_EBPF_METRICS_INTERVAL: 30s
+  OTEL_EBPF_NAME_RESOLVER_SOURCES: k8s,dns

--- a/examples/apache/k8s/config/edge-httpd.conf
+++ b/examples/apache/k8s/config/edge-httpd.conf
@@ -1,6 +1,6 @@
 ServerRoot "/usr/local/apache2"
-Listen 8081
-ServerName recommendations-v1
+Listen 8080
+ServerName edge-apache
 PidFile "/tmp/httpd.pid"
 ErrorLog /proc/self/fd/2
 LogLevel warn
@@ -14,6 +14,8 @@ LoadModule dir_module modules/mod_dir.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule mime_module modules/mod_mime.so
 LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule unixd_module modules/mod_unixd.so
 
 User daemon
@@ -22,13 +24,15 @@ Group daemon
 TypesConfig conf/mime.types
 DocumentRoot "/usr/local/apache2/htdocs"
 Define APACHE_HTDOCS_ROOT /usr/local/apache2/htdocs
+Define RECOMMENDATIONS_V1_ORIGIN recommendations-v1:8081
+Define RECOMMENDATIONS_V2_ORIGIN recommendations-v2:8082
 
 <Directory "/usr/local/apache2/htdocs">
     AllowOverride None
     Require all granted
 </Directory>
 
-CustomLog /proc/self/fd/1 common
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
+CustomLog /proc/self/fd/1 common
 
-Include conf/shared/recommendations-v1-vhost.conf
+Include conf/shared/edge-vhost.conf

--- a/examples/apache/k8s/config/recommendations-v1-httpd.conf
+++ b/examples/apache/k8s/config/recommendations-v1-httpd.conf
@@ -28,7 +28,7 @@ Define APACHE_HTDOCS_ROOT /usr/local/apache2/htdocs
     Require all granted
 </Directory>
 
-CustomLog /proc/self/fd/1 common
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
+CustomLog /proc/self/fd/1 common
 
 Include conf/shared/recommendations-v1-vhost.conf

--- a/examples/apache/k8s/config/recommendations-v2-httpd.conf
+++ b/examples/apache/k8s/config/recommendations-v2-httpd.conf
@@ -1,6 +1,6 @@
 ServerRoot "/usr/local/apache2"
-Listen 8081
-ServerName recommendations-v1
+Listen 8082
+ServerName recommendations-v2
 PidFile "/tmp/httpd.pid"
 ErrorLog /proc/self/fd/2
 LogLevel warn
@@ -14,6 +14,8 @@ LoadModule dir_module modules/mod_dir.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule mime_module modules/mod_mime.so
 LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule unixd_module modules/mod_unixd.so
 
 User daemon
@@ -22,13 +24,14 @@ Group daemon
 TypesConfig conf/mime.types
 DocumentRoot "/usr/local/apache2/htdocs"
 Define APACHE_HTDOCS_ROOT /usr/local/apache2/htdocs
+Define RECOMMENDATIONS_V1_ORIGIN recommendations-v1:8081
 
 <Directory "/usr/local/apache2/htdocs">
     AllowOverride None
     Require all granted
 </Directory>
 
-CustomLog /proc/self/fd/1 common
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
+CustomLog /proc/self/fd/1 common
 
-Include conf/shared/recommendations-v1-vhost.conf
+Include conf/shared/recommendations-v2-vhost.conf

--- a/examples/apache/k8s/htdocs/edge-users-42-home.txt
+++ b/examples/apache/k8s/htdocs/edge-users-42-home.txt
@@ -1,0 +1,1 @@
+user home page

--- a/examples/apache/k8s/htdocs/recommendations-v1-rollout-personalized-homepage.txt
+++ b/examples/apache/k8s/htdocs/recommendations-v1-rollout-personalized-homepage.txt
@@ -1,0 +1,1 @@
+recommendations v1 rollout ok

--- a/examples/apache/k8s/htdocs/recommendations-v1-v1-homepage-hero.txt
+++ b/examples/apache/k8s/htdocs/recommendations-v1-v1-homepage-hero.txt
@@ -1,0 +1,1 @@
+recommendations v1 ok

--- a/examples/apache/k8s/kustomization.yaml
+++ b/examples/apache/k8s/kustomization.yaml
@@ -1,0 +1,36 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - 00-namespace.yaml
+  - 01-observability.yaml
+  - 02-apache.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: apache-shared-config
+    namespace: obi-apache-example
+    files:
+      - edge-vhost.conf=shared/edge-vhost.conf
+      - recommendations-v1-vhost.conf=shared/recommendations-v1-vhost.conf
+      - recommendations-v2-vhost.conf=shared/recommendations-v2-vhost.conf
+  - name: edge-apache-config
+    namespace: obi-apache-example
+    files:
+      - httpd.conf=config/edge-httpd.conf
+  - name: recommendations-v1-config
+    namespace: obi-apache-example
+    files:
+      - httpd.conf=config/recommendations-v1-httpd.conf
+  - name: recommendations-v2-config
+    namespace: obi-apache-example
+    files:
+      - httpd.conf=config/recommendations-v2-httpd.conf
+  - name: apache-htdocs
+    namespace: obi-apache-example
+    files:
+      - edge-users-42-home.txt=htdocs/edge-users-42-home.txt
+      - recommendations-v1-rollout-personalized-homepage.txt=htdocs/recommendations-v1-rollout-personalized-homepage.txt
+      - recommendations-v1-v1-homepage-hero.txt=htdocs/recommendations-v1-v1-homepage-hero.txt

--- a/examples/apache/k8s/shared/edge-vhost.conf
+++ b/examples/apache/k8s/shared/edge-vhost.conf
@@ -1,7 +1,7 @@
 <VirtualHost *:8080>
-    DocumentRoot "${APACHE_HTDOCS_ROOT}"
+    DocumentRoot "/usr/local/apache2/htdocs"
 
-    Alias "/users/42/home" "${APACHE_HTDOCS_ROOT}/edge/users/42/home.txt"
+    Alias "/users/42/home" "/usr/local/apache2/htdocs/edge/users/42/home.txt"
     Redirect 302 "/campaigns/spring-2026/redirect" "/users/42/home"
 
     RewriteEngine On

--- a/examples/apache/k8s/shared/recommendations-v1-vhost.conf
+++ b/examples/apache/k8s/shared/recommendations-v1-vhost.conf
@@ -1,0 +1,10 @@
+<VirtualHost *:8081>
+    DocumentRoot "/usr/local/apache2/htdocs"
+
+    Alias "/api/users/42/recommendations/v1/homepage-hero" "/usr/local/apache2/htdocs/recommendations-v1/api/users/42/recommendations/v1/homepage-hero.txt"
+    Alias "/api/users/42/recommendations/rollout/personalized-homepage" "/usr/local/apache2/htdocs/recommendations-v1/api/users/42/recommendations/rollout/personalized-homepage.txt"
+
+    RewriteEngine On
+    RewriteRule "^/api/users/314159/recommendations/v1/category-bundles$" "-" [R=404,L]
+    RewriteRule "^/api/users/9001/recommendations/rollout/cart-recovery$" "-" [R=503,L]
+</VirtualHost>

--- a/examples/apache/k8s/shared/recommendations-v2-vhost.conf
+++ b/examples/apache/k8s/shared/recommendations-v2-vhost.conf
@@ -1,5 +1,5 @@
 <VirtualHost *:8082>
-    DocumentRoot "${APACHE_HTDOCS_ROOT}"
+    DocumentRoot "/usr/local/apache2/htdocs"
 
     Redirect 302 "/api/users/271828/recommendations/v2/style-refresh" "/users/42/home"
 

--- a/examples/apache/shared/edge-vhost.conf
+++ b/examples/apache/shared/edge-vhost.conf
@@ -1,0 +1,25 @@
+<VirtualHost *:8080>
+    DocumentRoot "/usr/local/apache2/htdocs"
+
+    Alias "/users/42/home" "/usr/local/apache2/htdocs/edge/users/42/home.txt"
+    Redirect 302 "/campaigns/spring-2026/redirect" "/users/42/home"
+
+    RewriteEngine On
+    RewriteRule "^/support/articles/984404$" "-" [R=404,L]
+    RewriteRule "^/checkout/sessions/abc123xyz$" "-" [R=500,L]
+
+    ProxyPass "/api/users/42/recommendations/v1/homepage-hero" "http://127.0.0.1:8081/api/users/42/recommendations/v1/homepage-hero"
+    ProxyPassReverse "/api/users/42/recommendations/v1/homepage-hero" "http://127.0.0.1:8081/api/users/42/recommendations/v1/homepage-hero"
+
+    ProxyPass "/api/users/314159/recommendations/v1/category-bundles" "http://127.0.0.1:8081/api/users/314159/recommendations/v1/category-bundles"
+    ProxyPassReverse "/api/users/314159/recommendations/v1/category-bundles" "http://127.0.0.1:8081/api/users/314159/recommendations/v1/category-bundles"
+
+    ProxyPass "/api/users/271828/recommendations/v2/style-refresh" "http://127.0.0.1:8082/api/users/271828/recommendations/v2/style-refresh"
+    ProxyPassReverse "/api/users/271828/recommendations/v2/style-refresh" "http://127.0.0.1:8082/api/users/271828/recommendations/v2/style-refresh"
+
+    ProxyPass "/api/users/42/recommendations/rollout/personalized-homepage" "http://127.0.0.1:8082/api/users/42/recommendations/rollout/personalized-homepage"
+    ProxyPassReverse "/api/users/42/recommendations/rollout/personalized-homepage" "http://127.0.0.1:8082/api/users/42/recommendations/rollout/personalized-homepage"
+
+    ProxyPass "/api/users/9001/recommendations/rollout/cart-recovery" "http://127.0.0.1:8082/api/users/9001/recommendations/rollout/cart-recovery"
+    ProxyPassReverse "/api/users/9001/recommendations/rollout/cart-recovery" "http://127.0.0.1:8082/api/users/9001/recommendations/rollout/cart-recovery"
+</VirtualHost>

--- a/examples/apache/shared/recommendations-v1-vhost.conf
+++ b/examples/apache/shared/recommendations-v1-vhost.conf
@@ -1,0 +1,10 @@
+<VirtualHost *:8081>
+    DocumentRoot "/usr/local/apache2/htdocs"
+
+    Alias "/api/users/42/recommendations/v1/homepage-hero" "/usr/local/apache2/htdocs/recommendations-v1/api/users/42/recommendations/v1/homepage-hero.txt"
+    Alias "/api/users/42/recommendations/rollout/personalized-homepage" "/usr/local/apache2/htdocs/recommendations-v1/api/users/42/recommendations/rollout/personalized-homepage.txt"
+
+    RewriteEngine On
+    RewriteRule "^/api/users/314159/recommendations/v1/category-bundles$" "-" [R=404,L]
+    RewriteRule "^/api/users/9001/recommendations/rollout/cart-recovery$" "-" [R=503,L]
+</VirtualHost>

--- a/examples/apache/shared/recommendations-v1-vhost.conf
+++ b/examples/apache/shared/recommendations-v1-vhost.conf
@@ -1,8 +1,8 @@
 <VirtualHost *:8081>
-    DocumentRoot "/usr/local/apache2/htdocs"
+    DocumentRoot "${APACHE_HTDOCS_ROOT}"
 
-    Alias "/api/users/42/recommendations/v1/homepage-hero" "/usr/local/apache2/htdocs/recommendations-v1/api/users/42/recommendations/v1/homepage-hero.txt"
-    Alias "/api/users/42/recommendations/rollout/personalized-homepage" "/usr/local/apache2/htdocs/recommendations-v1/api/users/42/recommendations/rollout/personalized-homepage.txt"
+    Alias "/api/users/42/recommendations/v1/homepage-hero" "${APACHE_HTDOCS_ROOT}/recommendations-v1/api/users/42/recommendations/v1/homepage-hero.txt"
+    Alias "/api/users/42/recommendations/rollout/personalized-homepage" "${APACHE_HTDOCS_ROOT}/recommendations-v1/api/users/42/recommendations/rollout/personalized-homepage.txt"
 
     RewriteEngine On
     RewriteRule "^/api/users/314159/recommendations/v1/category-bundles$" "-" [R=404,L]

--- a/examples/apache/shared/recommendations-v2-vhost.conf
+++ b/examples/apache/shared/recommendations-v2-vhost.conf
@@ -1,0 +1,11 @@
+<VirtualHost *:8082>
+    DocumentRoot "/usr/local/apache2/htdocs"
+
+    Redirect 302 "/api/users/271828/recommendations/v2/style-refresh" "/users/42/home"
+
+    ProxyPass "/api/users/42/recommendations/rollout/personalized-homepage" "http://127.0.0.1:8081/api/users/42/recommendations/rollout/personalized-homepage"
+    ProxyPassReverse "/api/users/42/recommendations/rollout/personalized-homepage" "http://127.0.0.1:8081/api/users/42/recommendations/rollout/personalized-homepage"
+
+    ProxyPass "/api/users/9001/recommendations/rollout/cart-recovery" "http://127.0.0.1:8081/api/users/9001/recommendations/rollout/cart-recovery"
+    ProxyPassReverse "/api/users/9001/recommendations/rollout/cart-recovery" "http://127.0.0.1:8081/api/users/9001/recommendations/rollout/cart-recovery"
+</VirtualHost>

--- a/examples/apache/standalone/edge/httpd.conf
+++ b/examples/apache/standalone/edge/httpd.conf
@@ -1,8 +1,8 @@
-ServerRoot "/usr/local/apache2"
-Listen 8081
-ServerName recommendations-v1
-PidFile "/tmp/httpd.pid"
-ErrorLog /proc/self/fd/2
+ServerRoot "/etc/httpd"
+Listen 8080
+ServerName edge-apache
+PidFile "/tmp/obi-apache-edge.pid"
+ErrorLog "${EXAMPLE_ROOT}/standalone/edge/logs/error.log"
 LogLevel warn
 
 LoadModule mpm_event_module modules/mod_mpm_event.so
@@ -14,21 +14,25 @@ LoadModule dir_module modules/mod_dir.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule mime_module modules/mod_mime.so
 LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule unixd_module modules/mod_unixd.so
 
-User daemon
-Group daemon
+User http
+Group http
 
 TypesConfig conf/mime.types
-DocumentRoot "/usr/local/apache2/htdocs"
-Define APACHE_HTDOCS_ROOT /usr/local/apache2/htdocs
+DocumentRoot "${EXAMPLE_ROOT}/htdocs"
+Define APACHE_HTDOCS_ROOT ${EXAMPLE_ROOT}/htdocs
+Define RECOMMENDATIONS_V1_ORIGIN 127.0.0.1:8081
+Define RECOMMENDATIONS_V2_ORIGIN 127.0.0.1:8082
 
-<Directory "/usr/local/apache2/htdocs">
+<Directory "${EXAMPLE_ROOT}/htdocs">
     AllowOverride None
     Require all granted
 </Directory>
 
-CustomLog /proc/self/fd/1 common
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
+CustomLog "${EXAMPLE_ROOT}/standalone/edge/logs/access.log" common
 
-Include conf/shared/recommendations-v1-vhost.conf
+Include "${EXAMPLE_ROOT}/shared/edge-vhost.conf"

--- a/examples/apache/standalone/obi-config.yaml
+++ b/examples/apache/standalone/obi-config.yaml
@@ -1,0 +1,25 @@
+routes:
+  patterns:
+    - /users/:user_id/home
+    - /campaigns/:campaign_id/redirect
+    - /support/articles/:article_id
+    - /checkout/sessions/:session_id
+    - /api/users/:user_id/recommendations/v1/:experience
+    - /api/users/:user_id/recommendations/v2/:experience
+    - /api/users/:user_id/recommendations/rollout/:experience
+  unmatched: path
+otel_metrics_export:
+  endpoint: ${OTLP_ENDPOINT:-http://127.0.0.1:4318}
+otel_traces_export:
+  endpoint: ${OTLP_ENDPOINT:-http://127.0.0.1:4318}
+discovery:
+  instrument:
+    - namespace: apache-example
+      name: edge-apache
+      open_ports: 8080
+    - namespace: apache-example
+      name: recommendations-v1
+      open_ports: 8081
+    - namespace: apache-example
+      name: recommendations-v2
+      open_ports: 8082

--- a/examples/apache/standalone/recommendations-v1/httpd.conf
+++ b/examples/apache/standalone/recommendations-v1/httpd.conf
@@ -1,8 +1,8 @@
-ServerRoot "/usr/local/apache2"
+ServerRoot "/etc/httpd"
 Listen 8081
 ServerName recommendations-v1
-PidFile "/tmp/httpd.pid"
-ErrorLog /proc/self/fd/2
+PidFile "/tmp/obi-apache-recommendations-v1.pid"
+ErrorLog "${EXAMPLE_ROOT}/standalone/recommendations-v1/logs/error.log"
 LogLevel warn
 
 LoadModule mpm_event_module modules/mod_mpm_event.so
@@ -16,19 +16,19 @@ LoadModule mime_module modules/mod_mime.so
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule unixd_module modules/mod_unixd.so
 
-User daemon
-Group daemon
+User http
+Group http
 
 TypesConfig conf/mime.types
-DocumentRoot "/usr/local/apache2/htdocs"
-Define APACHE_HTDOCS_ROOT /usr/local/apache2/htdocs
+DocumentRoot "${EXAMPLE_ROOT}/htdocs"
+Define APACHE_HTDOCS_ROOT ${EXAMPLE_ROOT}/htdocs
 
-<Directory "/usr/local/apache2/htdocs">
+<Directory "${EXAMPLE_ROOT}/htdocs">
     AllowOverride None
     Require all granted
 </Directory>
 
-CustomLog /proc/self/fd/1 common
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
+CustomLog "${EXAMPLE_ROOT}/standalone/recommendations-v1/logs/access.log" common
 
-Include conf/shared/recommendations-v1-vhost.conf
+Include "${EXAMPLE_ROOT}/shared/recommendations-v1-vhost.conf"

--- a/examples/apache/standalone/recommendations-v2/httpd.conf
+++ b/examples/apache/standalone/recommendations-v2/httpd.conf
@@ -1,8 +1,8 @@
-ServerRoot "/usr/local/apache2"
-Listen 8081
-ServerName recommendations-v1
-PidFile "/tmp/httpd.pid"
-ErrorLog /proc/self/fd/2
+ServerRoot "/etc/httpd"
+Listen 8082
+ServerName recommendations-v2
+PidFile "/tmp/obi-apache-recommendations-v2.pid"
+ErrorLog "${EXAMPLE_ROOT}/standalone/recommendations-v2/logs/error.log"
 LogLevel warn
 
 LoadModule mpm_event_module modules/mod_mpm_event.so
@@ -14,21 +14,24 @@ LoadModule dir_module modules/mod_dir.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule mime_module modules/mod_mime.so
 LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule unixd_module modules/mod_unixd.so
 
-User daemon
-Group daemon
+User http
+Group http
 
 TypesConfig conf/mime.types
-DocumentRoot "/usr/local/apache2/htdocs"
-Define APACHE_HTDOCS_ROOT /usr/local/apache2/htdocs
+DocumentRoot "${EXAMPLE_ROOT}/htdocs"
+Define APACHE_HTDOCS_ROOT ${EXAMPLE_ROOT}/htdocs
+Define RECOMMENDATIONS_V1_ORIGIN 127.0.0.1:8081
 
-<Directory "/usr/local/apache2/htdocs">
+<Directory "${EXAMPLE_ROOT}/htdocs">
     AllowOverride None
     Require all granted
 </Directory>
 
-CustomLog /proc/self/fd/1 common
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
+CustomLog "${EXAMPLE_ROOT}/standalone/recommendations-v2/logs/access.log" common
 
-Include conf/shared/recommendations-v1-vhost.conf
+Include "${EXAMPLE_ROOT}/shared/recommendations-v2-vhost.conf"

--- a/examples/apache/start-standalone.sh
+++ b/examples/apache/start-standalone.sh
@@ -12,12 +12,7 @@ find_apache_bin() {
     return 0
   fi
 
-  if command -v apache2 >/dev/null 2>&1; then
-    printf '%s\n' "$(command -v apache2)"
-    return 0
-  fi
-
-  printf 'could not find an Apache binary; expected `httpd` or `apache2`\n' >&2
+  printf 'could not find `httpd`; install Apache HTTP Server and ensure `httpd` is on PATH\n' >&2
   return 1
 }
 

--- a/examples/apache/start-standalone.sh
+++ b/examples/apache/start-standalone.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -Eeuo pipefail
+
+readonly EXAMPLE_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+find_apache_bin() {
+  if command -v httpd >/dev/null 2>&1; then
+    printf '%s\n' "$(command -v httpd)"
+    return 0
+  fi
+
+  if command -v apache2 >/dev/null 2>&1; then
+    printf '%s\n' "$(command -v apache2)"
+    return 0
+  fi
+
+  printf 'could not find an Apache binary; expected `httpd` or `apache2`\n' >&2
+  return 1
+}
+
+start_instance() {
+  local apache_bin="$1"
+  local name="$2"
+  local config_path="$EXAMPLE_DIR/standalone/$name/httpd.conf"
+  local log_dir="$EXAMPLE_DIR/standalone/$name/logs"
+
+  mkdir -p "$log_dir"
+  "$apache_bin" -C "Define EXAMPLE_ROOT $EXAMPLE_DIR" -k start -f "$config_path"
+}
+
+main() {
+  local apache_bin
+
+  apache_bin="$(find_apache_bin)"
+
+  start_instance "$apache_bin" edge
+  start_instance "$apache_bin" recommendations-v1
+  start_instance "$apache_bin" recommendations-v2
+}
+
+main "$@"

--- a/examples/apache/stop-standalone.sh
+++ b/examples/apache/stop-standalone.sh
@@ -12,12 +12,7 @@ find_apache_bin() {
     return 0
   fi
 
-  if command -v apache2 >/dev/null 2>&1; then
-    printf '%s\n' "$(command -v apache2)"
-    return 0
-  fi
-
-  printf 'could not find an Apache binary; expected `httpd` or `apache2`\n' >&2
+  printf 'could not find `httpd`; install Apache HTTP Server and ensure `httpd` is on PATH\n' >&2
   return 1
 }
 

--- a/examples/apache/stop-standalone.sh
+++ b/examples/apache/stop-standalone.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -Eeuo pipefail
+
+readonly EXAMPLE_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+find_apache_bin() {
+  if command -v httpd >/dev/null 2>&1; then
+    printf '%s\n' "$(command -v httpd)"
+    return 0
+  fi
+
+  if command -v apache2 >/dev/null 2>&1; then
+    printf '%s\n' "$(command -v apache2)"
+    return 0
+  fi
+
+  printf 'could not find an Apache binary; expected `httpd` or `apache2`\n' >&2
+  return 1
+}
+
+stop_instance() {
+  local apache_bin="$1"
+  local name="$2"
+  local config_path="$EXAMPLE_DIR/standalone/$name/httpd.conf"
+
+  "$apache_bin" -C "Define EXAMPLE_ROOT $EXAMPLE_DIR" -k stop -f "$config_path" || true
+}
+
+main() {
+  local apache_bin
+
+  apache_bin="$(find_apache_bin)"
+
+  stop_instance "$apache_bin" edge
+  stop_instance "$apache_bin" recommendations-v1
+  stop_instance "$apache_bin" recommendations-v2
+}
+
+main "$@"

--- a/examples/apache/traffic-runner/Dockerfile
+++ b/examples/apache/traffic-runner/Dockerfile
@@ -1,0 +1,9 @@
+FROM bash:5.2.37-alpine3.22@sha256:a4b03e1bbd85d85af7f5db16d2c4337aa852b8b40f3df8346624a4b9e06c1f7c
+
+RUN apk add --no-cache curl
+
+WORKDIR /app
+
+COPY generate-traffic.sh /app/generate-traffic.sh
+
+ENTRYPOINT ["bash", "/app/generate-traffic.sh"]


### PR DESCRIPTION
Adds a full Apache example alongside the existing nginx example, with the same core behaviors and route patterns so Apache support can be evaluated on comparable terms.

The Apache example now supports:
- Docker Compose
- Kubernetes with `kind` plus the Helm-installed OBI chart
- a dedicated Linux host or VM where Apache and OBI run directly on the host

## What Changed

- Added `examples/apache` with a three-tier Apache topology:
  - `edge-apache`
  - `recommendations-v1`
  - `recommendations-v2`
- Mirrored the nginx demo route set:
  - direct `2xx`, `3xx`, `4xx`, `5xx`
  - single proxy hop
  - chained proxy hop
- Reused the same low-cardinality OBI route patterns as the nginx example.
- Added Kubernetes manifests and Helm values for the Apache demo.
- Added standalone-host configs and helper scripts for starting and stopping the Apache processes.
- Refactored the shared Apache vhost files so Docker, Kubernetes, and standalone-host all use the same route behavior while only varying upstream and document-root definitions.
- Simplified the docs so the Apache example reads as a single user-facing example rather than a collection of troubleshooting notes.

## Verification

Docker Compose:
- validated `docker compose -f examples/apache/docker-compose.yml config`

Kubernetes:
- deployed the example into a local `kind` cluster
- applied `examples/apache/k8s`
- installed OBI with the Helm chart and `examples/apache/k8s/03-obi-values.yaml`
- ran a one-shot sweep from the traffic pod and confirmed all 9 routes returned expected statuses
- queried Tempo in the LGTM pod and confirmed traces for:
  - `edge-apache`
  - `recommendations-v1`
  - `recommendations-v2`
- confirmed chained rollout traces include the full Apache hop sequence

Standalone host:
- started the three local Apache instances with `examples/apache/start-standalone.sh`
- ran a one-shot sweep against `http://127.0.0.1:8080` and confirmed all 9 routes returned expected statuses
- built a local `obi` binary from this checkout
- ran OBI against the host Apache processes
- confirmed OTLP connections to LGTM
- queried Tempo and confirmed standalone traces for:
  - `edge-apache`
  - `recommendations-v1`
  - `recommendations-v2`

## User-Facing Outcome

A user evaluating Apache support in OBI now has an example that:
- matches the nginx demo closely enough for side-by-side comparison
- shows direct Apache handling, reverse proxying, and chained proxy hops
- can be exercised locally with Compose, in Kubernetes, or on a standalone host
