### PR TITLE
Follow up fixes from review for go generic

### DIFF
--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -281,3 +281,33 @@ int obi_uprobe_netFdWrite(struct pt_regs *ctx) {
 
     return 0;
 }
+
+SEC("uprobe/netFdClose")
+int obi_uprobe_netFdClose(struct pt_regs *ctx) {
+    void *goroutine_addr = GOROUTINE_PTR(ctx);
+    bpf_dbg_printk("=== uprobe/proc netFD close goroutine %lx === ", goroutine_addr);
+
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+
+    void *fd_ptr = GO_PARAM1(ctx);
+
+    if (!fd_ptr) {
+        return 0;
+    }
+
+    connection_info_t conn = {0};
+
+    if (!get_conn_info_from_fd(fd_ptr, &conn, false)) {
+        return 0;
+    }
+
+    sort_connection_info(&conn);
+
+    dbg_print_http_connection_info(&conn);
+
+    remove_go_handled_connection(&conn);
+    remove_go_handled_goroutine(&g_key);
+
+    return 0;
+}

--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -165,7 +165,11 @@ int obi_uprobe_netFdRead(struct pt_regs *ctx) {
     net_args_t net_args = {
         .byte_ptr = (u64)byte_addr,
     };
-    get_conn_info_from_fd(fd_ptr, &net_args.p_conn.conn, false);
+
+    if (!get_conn_info_from_fd(fd_ptr, &net_args.p_conn.conn, false)) {
+        return 0;
+    }
+
     net_args.p_conn.pid = pid_from_pid_tgid(id);
 
     dbg_print_http_connection_info(&net_args.p_conn.conn);

--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -290,6 +290,8 @@ int obi_uprobe_netFdClose(struct pt_regs *ctx) {
     go_addr_key_t g_key = {};
     go_addr_key_from_id(&g_key, goroutine_addr);
 
+    remove_go_handled_goroutine(&g_key);
+
     void *fd_ptr = GO_PARAM1(ctx);
 
     if (!fd_ptr) {
@@ -307,7 +309,6 @@ int obi_uprobe_netFdClose(struct pt_regs *ctx) {
     dbg_print_http_connection_info(&conn);
 
     remove_go_handled_connection(&conn);
-    remove_go_handled_goroutine(&g_key);
 
     return 0;
 }

--- a/bpf/gotracer/maps/handled_by_go.h
+++ b/bpf/gotracer/maps/handled_by_go.h
@@ -47,5 +47,5 @@ static __always_inline void remove_go_handled_goroutine(const go_addr_key_t *goa
 }
 
 static __always_inline void remove_go_handled_connection(connection_info_t *sorted_conn) {
-    bpf_map_delete_elem(&handled_by_go_conn, &sorted_conn);
+    bpf_map_delete_elem(&handled_by_go_conn, sorted_conn);
 }

--- a/bpf/gotracer/maps/handled_by_go.h
+++ b/bpf/gotracer/maps/handled_by_go.h
@@ -45,3 +45,7 @@ static __always_inline void store_go_handled_goroutine(const go_addr_key_t *goad
 static __always_inline void remove_go_handled_goroutine(const go_addr_key_t *goaddr) {
     bpf_map_delete_elem(&handled_by_go, goaddr);
 }
+
+static __always_inline void remove_go_handled_connection(connection_info_t *sorted_conn) {
+    bpf_map_delete_elem(&handled_by_go_conn, &sorted_conn);
+}

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -401,6 +401,9 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 		"net.(*netFD).Write": {{
 			Start: p.bpfObjects.ObiUprobeNetFdWrite,
 		}},
+		"net.(*netFD).Close": {{
+			Start: p.bpfObjects.ObiUprobeNetFdClose,
+		}},
 		"net/http.(*persistConn).roundTrip": {{ // http client
 			Start: p.bpfObjects.ObiUprobePersistConnRoundTrip,
 		}},


### PR DESCRIPTION
## Summary

Follow up on https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1766 after merge.

@MrAlias I've addressed here both the missing if reading connection failed and I added a probe on netFD.Close. The Close should be rare, so it's safe to add the overhead. We will also likely need it for the TLS side when I add that.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->