### PR TITLE
[internal/tools] use native Go tool approach

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -152,9 +152,6 @@ jobs:
       - name: Generate files
         run: make prereqs docker-generate
 
-      - name: Install gotestsum
-        run: make tools
-
       - name: Check disk usage before tests
         run: df -h
 
@@ -176,7 +173,7 @@ jobs:
 
           mkdir -p /home/runner/reports
 
-          ./.tools/gotestsum \
+          go tool -modfile=./internal/tools/go.mod gotestsum \
               --rerun-fails=2 --rerun-fails-max-failures=2 --rerun-fails-abort-on-data-race \
               --packages="./internal/test/integration" -ftestname \
               --jsonfile=/home/runner/reports/test-run-"${RUN_NUMBER}"-"${MATRIX_ID}".log \

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -158,9 +158,6 @@ jobs:
       - name: Generate files
         run: make prereqs docker-generate
 
-      - name: Install gotestsum
-        run: make tools
-
       - name: Check disk usage before tests
         run: df -h
 
@@ -181,7 +178,7 @@ jobs:
 
           mkdir -p /home/runner/reports
 
-          ./.tools/gotestsum \
+          go tool -modfile=./internal/tools/go.mod gotestsum \
               --rerun-fails=2 --rerun-fails-max-failures=2 --rerun-fails-abort-on-data-race \
               --packages="./internal/test/integration" -ftestname \
               --jsonfile=/home/runner/reports/test-run-"${RUN_NUMBER}"-"${MATRIX_ID}".log \

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -150,9 +150,6 @@ jobs:
       - name: Generate files
         run: make prereqs docker-generate
 
-      - name: Install gotestsum
-        run: make tools
-
       - name: Check disk usage before tests
         run: df -h
 
@@ -174,7 +171,7 @@ jobs:
 
           mkdir -p /home/runner/reports
 
-          ./.tools/gotestsum \
+          go tool -modfile=./internal/tools/go.mod gotestsum \
               --rerun-fails=2 --rerun-fails-max-failures=2 --rerun-fails-abort-on-data-race \
               --packages="${MATRIX_TEST_PATTERN}" -ftestname \
               --jsonfile=/home/runner/reports/test-run-"${RUN_NUMBER}"-"${MATRIX_ID}".log \

--- a/Makefile
+++ b/Makefile
@@ -106,14 +106,11 @@ $(TOOLS)/setup-envtest: PACKAGE=sigs.k8s.io/controller-runtime/tools/setup-envte
 KIND ?= $(TOOLS)/kind
 $(TOOLS)/kind: PACKAGE=sigs.k8s.io/kind
 
-GOLICENSES = $(TOOLS)/go-licenses
-$(TOOLS)/go-licenses: PACKAGE=github.com/google/go-licenses/v2
-
 MULTIMOD = $(TOOLS)/multimod
 $(TOOLS)/multimod: PACKAGE=go.opentelemetry.io/build-tools/multimod
 
 .PHONY: tools
-tools: $(BPF2GO) $(GO_OFFSETS_TRACKER) $(ENVTEST) $(KIND) $(GOLICENSES)
+tools: $(BPF2GO) $(GO_OFFSETS_TRACKER) $(ENVTEST) $(KIND)
 
 ### Development Tools (end) #################################################
 
@@ -717,8 +714,8 @@ java-notices-update:
 	@cp pkg/internal/java/agent/build/reports/dependency-license/THIRD_PARTY_LICENSES.csv $(NOTICES_DIR)/java/agent/
 
 .PHONY: go-notices-update
-go-notices-update: $(GOLICENSES)
-	@GOOS=$(GOOS) GOARCH=amd64 $(GOLICENSES) save ./... --save_path=$(NOTICES_DIR) --force
+go-notices-update:
+	@GOOS=$(GOOS) GOARCH=amd64 go tool $(TOOLS_MODFILE) go-licenses save ./... --save_path=$(NOTICES_DIR) --force
 
 PYTHON_REQUIREMENTS_INS ?= $(shell find ./internal/test/integration/components -type f -name 'requirements.in' | sort)
 PYTHON_REQUIREMENTS_DIRS := $(sort $(dir $(PYTHON_REQUIREMENTS_INS)))

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,6 @@ $(TOOLS)/setup-envtest: PACKAGE=sigs.k8s.io/controller-runtime/tools/setup-envte
 KIND ?= $(TOOLS)/kind
 $(TOOLS)/kind: PACKAGE=sigs.k8s.io/kind
 
-MULTIMOD = $(TOOLS)/multimod
-$(TOOLS)/multimod: PACKAGE=go.opentelemetry.io/build-tools/multimod
-
 .PHONY: tools
 tools: $(BPF2GO) $(ENVTEST) $(KIND)
 
@@ -798,19 +795,19 @@ check-go-mod: go-mod-tidy
 	fi
 
 .PHONY: verify-mods
-verify-mods: $(MULTIMOD)
-	$(MULTIMOD) verify
+verify-mods:
+	go tool $(TOOLS_MODFILE) multimod verify
 
 .PHONY: prerelease
 prerelease: verify-mods
 	@[ "${MODSET}" ] || ( echo ">> env var MODSET is not set"; exit 1 )
-	$(MULTIMOD) prerelease -m ${MODSET}
+	go tool $(TOOLS_MODFILE) multimod prerelease -m ${MODSET}
 
 COMMIT ?= "HEAD"
 .PHONY: add-tags
 add-tags: verify-mods
 	@[ "${MODSET}" ] || ( echo ">> env var MODSET is not set"; exit 1 )
-	$(MULTIMOD) tag -m ${MODSET} -c ${COMMIT}
+	go tool $(TOOLS_MODFILE) multimod tag -m ${MODSET} -c ${COMMIT}
 
 .PHONY: check-ebpf-ver-synced
 check-ebpf-ver-synced:

--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,6 @@ $(TOOLS)/%: $(TOOLS_MOD_DIR)/go.mod | $(TOOLS)
 BPF2GO ?= $(TOOLS)/bpf2go
 $(TOOLS)/bpf2go: PACKAGE=github.com/cilium/ebpf/cmd/bpf2go
 
-GO_OFFSETS_TRACKER ?= $(TOOLS)/go-offsets-tracker
-$(TOOLS)/go-offsets-tracker: PACKAGE=github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker
-
 # Required for k8s-cache unit tests
 ENVTEST_K8S_VERSION ?= 1.30.0
 ENVTEST ?= $(TOOLS)/setup-envtest
@@ -110,7 +107,7 @@ MULTIMOD = $(TOOLS)/multimod
 $(TOOLS)/multimod: PACKAGE=go.opentelemetry.io/build-tools/multimod
 
 .PHONY: tools
-tools: $(BPF2GO) $(GO_OFFSETS_TRACKER) $(ENVTEST) $(KIND)
+tools: $(BPF2GO) $(ENVTEST) $(KIND)
 
 ### Development Tools (end) #################################################
 
@@ -177,9 +174,9 @@ lint-markdown-fix:
 	@docker run --rm -v "$(CURDIR):/workdir" $(MARKDOWNIMAGE) --fix "{*.md,!(NOTICES)/**/*.md}"
 
 .PHONY: update-offsets
-update-offsets: $(GO_OFFSETS_TRACKER)
+update-offsets:
 	@echo "### Updating pkg/internal/goexec/offsets.json"
-	$(GO_OFFSETS_TRACKER) -i configs/offsets/tracker_input.json pkg/internal/goexec/offsets.json
+	go tool $(TOOLS_MODFILE) go-offsets-tracker -i configs/offsets/tracker_input.json pkg/internal/goexec/offsets.json
 
 ### eBPF Code Generation ###########################################################
 #

--- a/Makefile
+++ b/Makefile
@@ -112,14 +112,11 @@ $(TOOLS)/kind: PACKAGE=sigs.k8s.io/kind
 GOLICENSES = $(TOOLS)/go-licenses
 $(TOOLS)/go-licenses: PACKAGE=github.com/google/go-licenses/v2
 
-GOTESTSUM = $(TOOLS)/gotestsum
-$(TOOLS)/gotestsum: PACKAGE=gotest.tools/gotestsum
-
 MULTIMOD = $(TOOLS)/multimod
 $(TOOLS)/multimod: PACKAGE=go.opentelemetry.io/build-tools/multimod
 
 .PHONY: tools
-tools: $(BPF2GO) $(GO_OFFSETS_TRACKER) $(GINKGO) $(ENVTEST) $(KIND) $(GOLICENSES) $(GOTESTSUM)
+tools: $(BPF2GO) $(GO_OFFSETS_TRACKER) $(GINKGO) $(ENVTEST) $(KIND) $(GOLICENSES)
 
 ### Development Tools (end) #################################################
 
@@ -470,8 +467,7 @@ run-integration-test-vm:
 			-test.run="^($(TEST_PATTERN))\$$"; \
 	else \
 		echo "Pre-compiled tests not found, compiling in VM"; \
-		$(MAKE) $(GOTESTSUM); \
-		$(GOTESTSUM) \
+		go tool $(TOOLS_MODFILE) gotestsum \
 			--rerun-fails=2 --rerun-fails-max-failures=2 \
 			-ftestname --jsonfile=testoutput/vm-test-run-$(RUN_NUMBER).log -- \
 			-p $$TEST_PARALLEL \
@@ -487,17 +483,17 @@ run-integration-test-arm:
 	go test -p 1 -failfast -v -timeout 90m -a ./internal/test/integration -run "^TestMultiProcess"
 
 .PHONY: unit-test-tools
-unit-test-tools: $(GOTESTSUM) $(ENVTEST)
+unit-test-tools: $(ENVTEST)
 
 .PHONY: unit-test-matrix-json
-unit-test-matrix-json: $(GOTESTSUM)
-	@go list ./... | $(GOTESTSUM) tool ci-matrix --partitions $${PARTITIONS:-3} --timing-files=$(TEST_OUTPUT)/unit-test-shard-*.log
+unit-test-matrix-json:
+	@go list ./... | go tool $(TOOLS_MODFILE) gotestsum tool ci-matrix --partitions $${PARTITIONS:-3} --timing-files=$(TEST_OUTPUT)/unit-test-shard-*.log
 
 .PHONY: run-unit-test-shard
-run-unit-test-shard: $(GOTESTSUM) $(ENVTEST)
+run-unit-test-shard: $(ENVTEST)
 	@echo "### Running unit test shard $(SHARD_ID)"
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
-	$(GOTESTSUM) \
+	go tool $(TOOLS_MODFILE) gotestsum \
 		--jsonfile=$(TEST_OUTPUT)/unit-test-shard-$(SHARD_ID).log \
 		-- -short -race -a -coverpkg=./... \
 		-coverprofile $(TEST_OUTPUT)/cover-shard-$(SHARD_ID).all.txt \

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ __check_defined = \
 
 # Tools module where tool versions are defined.
 TOOLS_MOD_DIR := ./internal/tools
+TOOLS_MODFILE := -modfile=./internal/tools/go.mod
 
 # Tools directory for built tool binaries.
 TOOLS = $(CURDIR)/.tools
@@ -93,9 +94,6 @@ $(TOOLS)/%: $(TOOLS_MOD_DIR)/go.mod | $(TOOLS)
 
 BPF2GO ?= $(TOOLS)/bpf2go
 $(TOOLS)/bpf2go: PACKAGE=github.com/cilium/ebpf/cmd/bpf2go
-
-GOLANGCI_LINT = $(TOOLS)/golangci-lint
-$(TOOLS)/golangci-lint: PACKAGE=github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 
 GO_OFFSETS_TRACKER ?= $(TOOLS)/go-offsets-tracker
 $(TOOLS)/go-offsets-tracker: PACKAGE=github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker
@@ -120,11 +118,8 @@ $(TOOLS)/gotestsum: PACKAGE=gotest.tools/gotestsum
 MULTIMOD = $(TOOLS)/multimod
 $(TOOLS)/multimod: PACKAGE=go.opentelemetry.io/build-tools/multimod
 
-PORTO = $(TOOLS)/porto
-$(TOOLS)/porto: PACKAGE=github.com/jcchavezs/porto/cmd/porto
-
 .PHONY: tools
-tools: $(BPF2GO) $(GOLANGCI_LINT) $(GO_OFFSETS_TRACKER) $(GINKGO) $(ENVTEST) $(KIND) $(GOLICENSES) $(GOTESTSUM) $(PORTO)
+tools: $(BPF2GO) $(GO_OFFSETS_TRACKER) $(GINKGO) $(ENVTEST) $(KIND) $(GOLICENSES) $(GOTESTSUM)
 
 ### Development Tools (end) #################################################
 
@@ -148,9 +143,9 @@ prereqs: install-hooks
 	mkdir -p $(TEST_OUTPUT)/run
 
 .PHONY: fmt
-fmt: $(GOLANGCI_LINT)
+fmt:
 	@echo "### Formatting code and fixing imports"
-	$(GOLANGCI_LINT) fmt
+	go tool $(TOOLS_MODFILE) golangci-lint fmt
 
 .PHONY: clang-tidy
 clang-tidy:
@@ -165,9 +160,9 @@ lint-fix: LINT_EXTRA_ARGS = --fix
 lint-fix: lint-run
 
 .PHONY: lint-run
-lint-run: $(GOLANGCI_LINT) vanity-import-check lint-dependency-policy
+lint-run: vanity-import-check lint-dependency-policy
 	@echo "### Linting code"
-	$(GOLANGCI_LINT) run ./... --timeout=6m $(LINT_EXTRA_ARGS)
+	go tool $(TOOLS_MODFILE) golangci-lint run ./... --timeout=6m $(LINT_EXTRA_ARGS)
 
 .PHONY: lint-dependency-policy
 lint-dependency-policy:
@@ -841,12 +836,12 @@ check-ebpf-ver-synced:
 	fi
 
 .PHONY: vanity-import-check
-vanity-import-check: $(PORTO)
-	$(PORTO) --include-internal --skip-dirs "^NOTICES$$" -l . || ( echo "(run: make vanity-import-fix)"; exit 1 )
+vanity-import-check:
+	go tool $(TOOLS_MODFILE) porto --include-internal --skip-dirs "^NOTICES$$" -l . || ( echo "(run: make vanity-import-fix)"; exit 1 )
 
 .PHONY: vanity-import-fix
 vanity-import-fix: $(PORTO)
-	$(PORTO) --include-internal --skip-dirs "^NOTICES$$" -w .
+	go tool $(TOOLS_MODFILE) porto --include-internal --skip-dirs "^NOTICES$$" -w .
 
 .PHONY: regenerate-port-lookup
 regenerate-port-lookup:

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ __check_defined = \
 
 # Tools module where tool versions are defined.
 TOOLS_MOD_DIR := ./internal/tools
-TOOLS_MODFILE := -modfile=./internal/tools/go.mod
+TOOLS_MODFILE := -modfile=$(CURDIR)/internal/tools/go.mod
 
 # Tools directory for built tool binaries.
 TOOLS = $(CURDIR)/.tools
@@ -98,9 +98,6 @@ $(TOOLS)/bpf2go: PACKAGE=github.com/cilium/ebpf/cmd/bpf2go
 GO_OFFSETS_TRACKER ?= $(TOOLS)/go-offsets-tracker
 $(TOOLS)/go-offsets-tracker: PACKAGE=github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker
 
-GINKGO ?= $(TOOLS)/ginkgo
-$(TOOLS)/ginkgo: PACKAGE=github.com/onsi/ginkgo/v2/ginkgo
-
 # Required for k8s-cache unit tests
 ENVTEST_K8S_VERSION ?= 1.30.0
 ENVTEST ?= $(TOOLS)/setup-envtest
@@ -116,7 +113,7 @@ MULTIMOD = $(TOOLS)/multimod
 $(TOOLS)/multimod: PACKAGE=go.opentelemetry.io/build-tools/multimod
 
 .PHONY: tools
-tools: $(BPF2GO) $(GO_OFFSETS_TRACKER) $(GINKGO) $(ENVTEST) $(KIND) $(GOLICENSES)
+tools: $(BPF2GO) $(GO_OFFSETS_TRACKER) $(ENVTEST) $(KIND) $(GOLICENSES)
 
 ### Development Tools (end) #################################################
 
@@ -547,43 +544,43 @@ itest-coverage-data:
 	grep -vE $(EXCLUDE_COVERAGE_FILES) $(TEST_OUTPUT)/itest-covdata.all.txt > $(TEST_OUTPUT)/itest-covdata.txt || true
 
 .PHONY: oats-prereq
-oats-prereq: $(GINKGO) docker-generate
+oats-prereq: docker-generate
 	mkdir -p $(TEST_OUTPUT)/run
 
 .PHONY: oats-test-sql
 oats-test-sql: oats-prereq
 	mkdir -p internal/test/oats/sql/$(TEST_OUTPUT)/run
-	cd internal/test/oats/sql && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
+	cd internal/test/oats/sql && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml go tool $(TOOLS_MODFILE) ginkgo -v -r
 
 .PHONY: oats-test-redis
 oats-test-redis: oats-prereq
 	mkdir -p internal/test/oats/redis/$(TEST_OUTPUT)/run
-	cd internal/test/oats/redis && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
+	cd internal/test/oats/redis && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml go tool $(TOOLS_MODFILE) ginkgo -v -r
 
 .PHONY: oats-test-kafka
 oats-test-kafka: oats-prereq
 	mkdir -p internal/test/oats/kafka/$(TEST_OUTPUT)/run
-	cd internal/test/oats/kafka && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
+	cd internal/test/oats/kafka && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml go tool $(TOOLS_MODFILE) ginkgo -v -r
 
 .PHONY: oats-test-http
 oats-test-http: oats-prereq
 	mkdir -p internal/test/oats/http/$(TEST_OUTPUT)/run
-	cd internal/test/oats/http && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
+	cd internal/test/oats/http && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml go tool $(TOOLS_MODFILE) ginkgo -v -r
 
 .PHONY: oats-test-mongo
 oats-test-mongo: oats-prereq
 	mkdir -p internal/test/oats/mongo/$(TEST_OUTPUT)/run
-	cd internal/test/oats/mongo && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
+	cd internal/test/oats/mongo && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml go tool $(TOOLS_MODFILE) ginkgo -v -r
 
 .PHONY: oats-test-memcached
 oats-test-memcached: oats-prereq
 	mkdir -p internal/test/oats/memcached/$(TEST_OUTPUT)/run
-	cd internal/test/oats/memcached && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
+	cd internal/test/oats/memcached && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml go tool $(TOOLS_MODFILE) ginkgo -v -r
 
 .PHONY: oats-test-ai
 oats-test-ai: oats-prereq
 	mkdir -p internal/test/oats/ai/$(TEST_OUTPUT)/run
-	cd internal/test/oats/ai && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml $(GINKGO) -v -r
+	cd internal/test/oats/ai && TESTCASE_TIMEOUT=5m TESTCASE_BASE_PATH=./yaml go tool $(TOOLS_MODFILE) ginkgo -v -r
 
 .PHONY: oats-test
 oats-test: oats-test-sql oats-test-mongo oats-test-redis oats-test-kafka oats-test-http oats-test-memcached oats-test-ai
@@ -591,7 +588,7 @@ oats-test: oats-test-sql oats-test-mongo oats-test-redis oats-test-kafka oats-te
 
 .PHONY: oats-test-debug
 oats-test-debug: oats-prereq
-	cd internal/test/oats/kafka && TESTCASE_BASE_PATH=./yaml TESTCASE_MANUAL_DEBUG=true TESTCASE_TIMEOUT=1h $(GINKGO) -v -r
+	cd internal/test/oats/kafka && TESTCASE_BASE_PATH=./yaml TESTCASE_MANUAL_DEBUG=true TESTCASE_TIMEOUT=1h go tool $(TOOLS_MODFILE) ginkgo -v -r
 
 .PHONY: license-header-check
 license-header-check:

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -4,10 +4,8 @@ go 1.25.8
 
 require (
 	github.com/cilium/ebpf v0.21.0
-	github.com/golangci/golangci-lint/v2 v2.11.4
 	github.com/google/go-licenses/v2 v2.0.1
 	github.com/grafana/go-offsets-tracker v0.1.7
-	github.com/jcchavezs/porto v0.7.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	go.opentelemetry.io/build-tools/multimod v0.29.0
 	gotest.tools/gotestsum v1.13.0
@@ -111,6 +109,7 @@ require (
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect
 	github.com/golangci/go-printf-func-name v0.1.1 // indirect
 	github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d // indirect
+	github.com/golangci/golangci-lint/v2 v2.11.4 // indirect
 	github.com/golangci/golines v0.15.0 // indirect
 	github.com/golangci/misspell v0.8.0 // indirect
 	github.com/golangci/plugin-module-register v0.1.2 // indirect
@@ -134,6 +133,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/jcchavezs/porto v0.7.0 // indirect
 	github.com/jgautheron/goconst v1.8.2 // indirect
 	github.com/jingyugao/rowserrcheck v1.1.1 // indirect
 	github.com/jjti/go-spancheck v0.6.5 // indirect
@@ -257,4 +257,9 @@ require (
 	mvdan.cc/gofumpt v0.9.2 // indirect
 	mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
+)
+
+tool (
+	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+	github.com/jcchavezs/porto/cmd/porto
 )

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/grafana/go-offsets-tracker v0.1.7
 	github.com/onsi/ginkgo/v2 v2.28.1
 	go.opentelemetry.io/build-tools/multimod v0.29.0
-	gotest.tools/gotestsum v1.13.0
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260331052815-773c064a8064
 	sigs.k8s.io/kind v0.31.0
 )
@@ -252,6 +251,7 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gotest.tools/gotestsum v1.13.0 // indirect
 	honnef.co/go/tools v0.7.0 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	mvdan.cc/gofumpt v0.9.2 // indirect
@@ -262,4 +262,5 @@ require (
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	github.com/jcchavezs/porto/cmd/porto
+	gotest.tools/gotestsum
 )

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -4,7 +4,6 @@ go 1.25.8
 
 require (
 	github.com/cilium/ebpf v0.21.0
-	github.com/google/go-licenses/v2 v2.0.1
 	github.com/grafana/go-offsets-tracker v0.1.7
 	go.opentelemetry.io/build-tools/multimod v0.29.0
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260331052815-773c064a8064
@@ -115,6 +114,7 @@ require (
 	github.com/golangci/swaggoswag v0.0.0-20250504205917-77f2aca3143e // indirect
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-licenses/v2 v2.0.1 // indirect
 	github.com/google/licenseclassifier/v2 v2.0.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
@@ -261,6 +261,7 @@ require (
 
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+	github.com/google/go-licenses/v2
 	github.com/jcchavezs/porto/cmd/porto
 	github.com/onsi/ginkgo/v2/ginkgo
 	gotest.tools/gotestsum

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/cilium/ebpf v0.21.0
 	github.com/google/go-licenses/v2 v2.0.1
 	github.com/grafana/go-offsets-tracker v0.1.7
-	github.com/onsi/ginkgo/v2 v2.28.1
 	go.opentelemetry.io/build-tools/multimod v0.29.0
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260331052815-773c064a8064
 	sigs.k8s.io/kind v0.31.0
@@ -171,6 +170,7 @@ require (
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.23.0 // indirect
+	github.com/onsi/ginkgo/v2 v2.28.1 // indirect
 	github.com/otiai10/copy v1.14.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
@@ -262,5 +262,6 @@ require (
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	github.com/jcchavezs/porto/cmd/porto
+	github.com/onsi/ginkgo/v2/ginkgo
 	gotest.tools/gotestsum
 )

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -4,7 +4,6 @@ go 1.25.8
 
 require (
 	github.com/cilium/ebpf v0.21.0
-	go.opentelemetry.io/build-tools/multimod v0.29.0
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260331052815-773c064a8064
 	sigs.k8s.io/kind v0.31.0
 )
@@ -235,6 +234,7 @@ require (
 	go.augendre.info/fatcontext v0.9.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/build-tools v0.29.0 // indirect
+	go.opentelemetry.io/build-tools/multimod v0.29.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
@@ -265,5 +265,6 @@ tool (
 	github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker
 	github.com/jcchavezs/porto/cmd/porto
 	github.com/onsi/ginkgo/v2/ginkgo
+	go.opentelemetry.io/build-tools/multimod
 	gotest.tools/gotestsum
 )

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -4,7 +4,6 @@ go 1.25.8
 
 require (
 	github.com/cilium/ebpf v0.21.0
-	github.com/grafana/go-offsets-tracker v0.1.7
 	go.opentelemetry.io/build-tools/multimod v0.29.0
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260331052815-773c064a8064
 	sigs.k8s.io/kind v0.31.0
@@ -123,6 +122,7 @@ require (
 	github.com/gostaticanalysis/comment v1.5.0 // indirect
 	github.com/gostaticanalysis/forcetypeassert v0.2.0 // indirect
 	github.com/gostaticanalysis/nilerr v0.1.2 // indirect
+	github.com/grafana/go-offsets-tracker v0.1.7 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
@@ -262,6 +262,7 @@ require (
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	github.com/google/go-licenses/v2
+	github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker
 	github.com/jcchavezs/porto/cmd/porto
 	github.com/onsi/ginkgo/v2/ginkgo
 	gotest.tools/gotestsum

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -10,7 +10,6 @@ import (
 	_ "github.com/google/go-licenses/v2"
 	_ "github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker"
 	_ "github.com/onsi/ginkgo/v2/ginkgo"
-	_ "gotest.tools/gotestsum"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
 	_ "sigs.k8s.io/kind"
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -7,7 +7,6 @@ package tools // import "go.opentelemetry.io/obi/internal/tools"
 
 import (
 	_ "github.com/cilium/ebpf/cmd/bpf2go"
-	_ "github.com/google/go-licenses/v2"
 	_ "github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
 	_ "sigs.k8s.io/kind"

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -7,10 +7,8 @@ package tools // import "go.opentelemetry.io/obi/internal/tools"
 
 import (
 	_ "github.com/cilium/ebpf/cmd/bpf2go"
-	_ "github.com/golangci/golangci-lint/v2/cmd/golangci-lint"
 	_ "github.com/google/go-licenses/v2"
 	_ "github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker"
-	_ "github.com/jcchavezs/porto/cmd/porto"
 	_ "github.com/onsi/ginkgo/v2/ginkgo"
 	_ "gotest.tools/gotestsum"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -9,6 +9,4 @@ import (
 	_ "github.com/cilium/ebpf/cmd/bpf2go"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
 	_ "sigs.k8s.io/kind"
-
-	_ "go.opentelemetry.io/build-tools/multimod"
 )

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -9,7 +9,6 @@ import (
 	_ "github.com/cilium/ebpf/cmd/bpf2go"
 	_ "github.com/google/go-licenses/v2"
 	_ "github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker"
-	_ "github.com/onsi/ginkgo/v2/ginkgo"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
 	_ "sigs.k8s.io/kind"
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -7,7 +7,6 @@ package tools // import "go.opentelemetry.io/obi/internal/tools"
 
 import (
 	_ "github.com/cilium/ebpf/cmd/bpf2go"
-	_ "github.com/grafana/go-offsets-tracker/cmd/go-offsets-tracker"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
 	_ "sigs.k8s.io/kind"
 


### PR DESCRIPTION
## Summary

Migrate tooling from `internal/tools/tools.go` to a more Go generic approach so that they can be used with `go tool ...`

If this change is accepted, I will look into migrating the rest of the tools.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] ~~If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)~~

<!-- markdownlint-disable-file MD041 -->