### PR TITLE
ci: rerun failed to find fork PR

### DIFF
--- a/scripts/rerun-flaky.sh
+++ b/scripts/rerun-flaky.sh
@@ -17,15 +17,20 @@ MAX_ATTEMPTS=2
 
 # --- Resolve the associated PR ---
 RUN_DATA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
-  --jq '{pr: .pull_requests[0].number, sha: .head_sha}')
+  --jq '{pr: .pull_requests[0].number, head_branch: .head_branch, head_owner: .head_repository.owner.login}')
 PR_NUMBER=$(echo "$RUN_DATA" | jq -r '.pr // empty')
-HEAD_SHA=$(echo "$RUN_DATA" | jq -r '.sha // empty')
 
-# Fallback for fork PRs: pull_requests array is often empty
-if [ -z "$PR_NUMBER" ] && [ -n "$HEAD_SHA" ]; then
-  echo "pull_requests empty — falling back to commits/${HEAD_SHA}/pulls lookup"
-  PR_NUMBER=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
-    --jq '[.[] | select(.state == "open")] | .[0].number // empty' || true)
+# Fallback for fork PRs: pull_requests array is often empty.
+# The commits/{sha}/pulls endpoint doesn't work for fork commits (the SHA
+# doesn't exist in the base repo). Instead, query by head={owner}:{branch}.
+if [ -z "$PR_NUMBER" ]; then
+  HEAD_BRANCH=$(echo "$RUN_DATA" | jq -r '.head_branch // empty')
+  HEAD_OWNER=$(echo "$RUN_DATA" | jq -r '.head_owner // empty')
+  if [ -n "$HEAD_OWNER" ] && [ -n "$HEAD_BRANCH" ]; then
+    echo "pull_requests empty — falling back to pulls?head=${HEAD_OWNER}:${HEAD_BRANCH} lookup"
+    PR_NUMBER=$(gh api "repos/${REPO}/pulls?state=open&head=${HEAD_OWNER}:${HEAD_BRANCH}&per_page=1" \
+      --jq '.[0].number // empty' || true)
+  fi
 fi
 
 if [ -z "$PR_NUMBER" ]; then


### PR DESCRIPTION
## Summary

[This rerun attempt](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/24244594374/job/70787457563) failed to find the matching fork PR (#1792) because the git SHA didn't exist in the source repo:

```
pull_requests empty — falling back to commits/efb13beff21467c842bf5abbd3c2671f06ec6102/pulls lookup
No PR associated with run 24244366715. Exiting.
```

This PR fixes the above by using a head filter for `owner:branch` instead, validated locally:

```shell
gh api "repos/open-telemetry/opentelemetry-ebpf-instrumentation/pulls?state=open&head=florianl:go-mod-tool&per_page=1" --jq '.[0].number // empty' 2>&1
1792
```

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->