### PR TITLE
ci: do not auto-rerun checks on renovate PRs

### DIFF
--- a/.github/workflows/supervisor_rerun-flaky.yml
+++ b/.github/workflows/supervisor_rerun-flaky.yml
@@ -23,8 +23,9 @@ jobs:
   evaluate-and-rerun:
     name: Evaluate failed checks
     if: >
-      github.event.workflow_run.conclusion == 'failure' ||
-      github.event.workflow_run.conclusion == 'timed_out'
+      (github.event.workflow_run.conclusion == 'failure' ||
+      github.event.workflow_run.conclusion == 'timed_out') &&
+      github.event.workflow_run.actor.login != 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Renovate constantly rebases against `main`, causing persistent auto re-runs such as in https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1777. This PR skips the auto re-run for `renovate[bot]` triggers.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)

<!-- markdownlint-disable-file MD041 -->