### PR TITLE
Add bpf_dbg_enter and bpf_dbg_return debug macros

### DIFF
--- a/bpf/logger/bpf_dbg.h
+++ b/bpf/logger/bpf_dbg.h
@@ -66,6 +66,9 @@ enum bpf_func_id___x {
         bpf_ringbuf_submit(__trace__, 0);                                                          \
     } while (0)
 
+#define bpf_dbg_enter() bpf_dbg_printk("%s entered", __FUNCTION__)
+#define bpf_dbg_return() bpf_dbg_printk("%s returning", __FUNCTION__)
+
 #define bpf_d_printk(fmt, args...)                                                                 \
     do {                                                                                           \
         if (!g_bpf_debug) {                                                                        \


### PR DESCRIPTION
## Summary

Add two convenience macros that log function entry and exit points through the existing bpf_dbg_printk infrastructure. Passing __FUNCTION__ as a format argument always produces exactly one bpf_printk arg, which is within bpf_trace_printk's 3-arg limit on all kernels.

This is in preparation for an upcoming `socktracer` PR.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](../SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
