### PR TITLE
Add const qualifiers to common BPF helper functions

### DIFF
--- a/bpf/common/ssl_connection.h
+++ b/bpf/common/ssl_connection.h
@@ -10,6 +10,6 @@
 
 #include <maps/active_ssl_connections.h>
 
-static __always_inline u64 *is_ssl_connection(pid_connection_info_t *conn) {
+static __always_inline u64 *is_ssl_connection(const pid_connection_info_t *conn) {
     return (u64 *)bpf_map_lookup_elem(&active_ssl_connections, conn);
 }

--- a/bpf/common/tracing.h
+++ b/bpf/common/tracing.h
@@ -59,7 +59,7 @@ static __always_inline tp_info_pid_t *trace_info_for_connection(const connection
 }
 
 static __always_inline void
-set_trace_info_for_connection(connection_info_t *conn, u32 type, tp_info_pid_t *info) {
+set_trace_info_for_connection(const connection_info_t *conn, u32 type, const tp_info_pid_t *info) {
     trace_map_key_t key = {};
 
     // bpf_dbg_printk("setting trace info, type=%d", info->req_type);
@@ -90,7 +90,8 @@ static __always_inline u64 current_immediate_epoch(u64 ts) {
     return temp * NANOSECONDS_PER_IMM_EPOCH;
 }
 
-static __always_inline u8 correlated_requests(tp_info_t *tp, tp_info_pid_t *existing_tp) {
+static __always_inline u8 correlated_requests(const tp_info_t *tp,
+                                              const tp_info_pid_t *existing_tp) {
     if (!existing_tp) {
         return 0;
     }


### PR DESCRIPTION
## Summary

Add const to parameters in is_ssl_connection, set_trace_info_for_connection and correlated_requests to enforce read-only intent at the call sites.


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](../SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
