### PR TITLE
fix(kafka): flip direction flag only, do not swap connection addresses

### DIFF
--- a/pkg/ebpf/common/kafka_detect_transform.go
+++ b/pkg/ebpf/common/kafka_detect_transform.go
@@ -54,7 +54,16 @@ func ProcessPossibleKafkaEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer,
 		// must be reversed and that's how we captured it.
 		k, ok, err = ProcessKafkaEvent(rpkt, pkt, kafkaTopicUUIDToName)
 		if err == nil {
-			reverseTCPEvent(event)
+			// Only flip the direction flag — do NOT swap S/D addresses.
+			// conn_info is normalized so that D is the server endpoint (server port
+			// in D_port) and S is the client. Swapping addresses would break HostPort.
+			// The direction flip is enough to produce the correct EventTypeKafkaClient
+			// in TCPToKafkaToSpan.
+			if event.Direction == directionRecv {
+				event.Direction = directionSend
+			} else {
+				event.Direction = directionRecv
+			}
 		}
 	}
 	return k, ok, err

--- a/pkg/ebpf/common/kafka_detect_transform.go
+++ b/pkg/ebpf/common/kafka_detect_transform.go
@@ -54,9 +54,10 @@ func ProcessPossibleKafkaEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer,
 		// must be reversed and that's how we captured it.
 		k, ok, err = ProcessKafkaEvent(rpkt, pkt, kafkaTopicUUIDToName)
 		if err == nil {
-			// Only flip the direction flag — do NOT swap S/D addresses.
-			// conn_info is normalized so that D is the server endpoint (server port
-			// in D_port) and S is the client. Swapping addresses would break HostPort.
+			// Only flip the direction flag - do NOT swap S/D addresses.
+			// conn_info is sorted so that S=client (ephemeral port) and
+			// D=server (well-known port). Swapping addresses would break
+			// HostPort.
 			// The direction flip is enough to produce the correct EventTypeKafkaClient
 			// in TCPToKafkaToSpan.
 			if event.Direction == directionRecv {

--- a/pkg/ebpf/common/kafka_detect_transform_test.go
+++ b/pkg/ebpf/common/kafka_detect_transform_test.go
@@ -262,3 +262,39 @@ func TestProcessKafkaRequestProduceV13WithTopicCache(t *testing.T) {
 		},
 	}, info)
 }
+
+// fetchRequest is a valid Kafka Fetch v11 request captured from a real client.
+var fetchRequest = []byte{
+	0, 0, 0, 94, 0, 1, 0, 11, 0, 0, 0, 224, 0, 6, 115, 97, 114, 97, 109, 97,
+	255, 255, 255, 255, 0, 0, 1, 244, 0, 0, 0, 1, 6, 64, 0, 0, 0, 0, 0, 0, 0,
+	255, 255, 255, 255, 0, 0, 0, 1, 0, 9, 105, 109, 112, 111, 114, 116, 97, 110,
+	116, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0,
+}
+
+// TestProcessPossibleKafkaEvent_ReversedCapture verifies that when the Kafka
+// request bytes arrive in the response buffer (reversed capture), only the
+// direction flag is flipped and the connection addresses (S/D) are unchanged.
+func TestProcessPossibleKafkaEvent_ReversedCapture(t *testing.T) {
+	cache, _ := simplelru.NewLRU[kafkaparser.UUID, string](1000, nil)
+
+	event := &TCPRequestInfo{
+		Direction: directionSend,
+	}
+	// S=client, D=server — must survive the direction flip unchanged.
+	event.ConnInfo.S_port = 54321
+	event.ConnInfo.D_port = 9092
+
+	// Pass the request bytes in rpkt (response buffer) to simulate reversed capture.
+	pkt := largebuf.NewLargeBufferFrom(nil)
+	rpkt := largebuf.NewLargeBufferFrom(fetchRequest)
+
+	info, _, err := ProcessPossibleKafkaEvent(event, pkt, rpkt, cache)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+
+	// Direction must flip, addresses must not change.
+	assert.Equal(t, uint8(directionRecv), event.Direction, "direction should flip to recv")
+	assert.Equal(t, uint16(54321), event.ConnInfo.S_port, "S_port must not change")
+	assert.Equal(t, uint16(9092), event.ConnInfo.D_port, "D_port must not change")
+}


### PR DESCRIPTION

## Summary

ReverseTCPEvent was swapping source and destination addresses in addition to flipping the direction bit. conn_info is always from the monitored process perspective (S=local, D=remote), so swapping broke HostPort. Flipping the direction flag alone is sufficient to produce the correct EventTypeKafkaClient in TCPToKafkaToSpan.


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](../SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
