### PR TITLE
feat(ebpf): add SetEventContext and Capabilities to Tracer interface

### DIFF
--- a/pkg/appolly/discover/attacher_test.go
+++ b/pkg/appolly/discover/attacher_test.go
@@ -58,6 +58,8 @@ func (r *recordingTracer) UnlinkInstrumentedLib(uint64)                         
 func (r *recordingTracer) RegisterOffsets(*execpkg.FileInfo, *goexec.Offsets)     {}
 func (r *recordingTracer) ProcessBinary(*execpkg.FileInfo)                        {}
 func (r *recordingTracer) Required() bool                                         { return false }
+func (r *recordingTracer) SetEventContext(*ebpfcommon.EBPFEventContext)           {}
+func (r *recordingTracer) Capabilities() ebpfcommon.TracerCapability              { return 0 }
 func (r *recordingTracer) Run(context.Context, *ebpfcommon.EBPFEventContext, *msg.Queue[[]request.Span]) {
 }
 

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -92,6 +92,8 @@ const (
 
 var IntegrityModeOverride = false
 
+type TracerCapability uint64
+
 // ProbeDesc holds the information of the instrumentation points of a given
 // function/symbol
 type ProbeDesc struct {
@@ -213,6 +215,7 @@ type EBPFEventContext struct {
 	RingBufLock      sync.Mutex
 	MapsLock         sync.Mutex
 	LoadLock         sync.Mutex
+	Capabilities     TracerCapability
 }
 
 var MisclassifiedEvents = make(chan MisclassifiedEvent)

--- a/pkg/ebpf/instrumenter_test.go
+++ b/pkg/ebpf/instrumenter_test.go
@@ -241,5 +241,7 @@ func (s *stubTracer) UnlinkInstrumentedLib(uint64)                           {}
 func (s *stubTracer) RegisterOffsets(*exec.FileInfo, *goexec.Offsets)        {}
 func (s *stubTracer) ProcessBinary(*exec.FileInfo)                           {}
 func (s *stubTracer) Required() bool                                         { return false }
+func (s *stubTracer) SetEventContext(*ebpfcommon.EBPFEventContext)           {}
+func (s *stubTracer) Capabilities() ebpfcommon.TracerCapability              { return 0 }
 func (s *stubTracer) Run(context.Context, *ebpfcommon.EBPFEventContext, *msg.Queue[[]request.Span]) {
 }

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -122,7 +122,9 @@ type Tracer interface {
 	UnlinkInstrumentedLib(uint64)
 	RegisterOffsets(*exec.FileInfo, *goexec.Offsets)
 	ProcessBinary(*exec.FileInfo)
+	SetEventContext(*ebpfcommon.EBPFEventContext)
 	Required() bool
+	Capabilities() ebpfcommon.TracerCapability
 	// Run will do the action of listening for eBPF traces and forward them
 	// periodically to the output channel.
 	Run(context.Context, *ebpfcommon.EBPFEventContext, *msg.Queue[[]request.Span])

--- a/pkg/ebpf/tracer_linux.go
+++ b/pkg/ebpf/tracer_linux.go
@@ -182,6 +182,8 @@ func setupBPFMapSizes(spec *ebpf.CollectionSpec, cfg *obi.Config) {
 }
 
 func (pt *ProcessTracer) loadAndAssign(eventContext *common.EBPFEventContext, p Tracer, cfg *obi.Config) error {
+	p.SetEventContext(eventContext)
+
 	bundles, err := p.LoadSpecs()
 	if err != nil {
 		return fmt.Errorf("loading eBPF program specs: %w", err)
@@ -289,6 +291,7 @@ func (pt *ProcessTracer) loadTracers(eventContext *common.EBPFEventContext, cfg 
 			}
 		} else {
 			loadedPrograms = append(loadedPrograms, p)
+			eventContext.Capabilities |= p.Capabilities()
 		}
 	}
 

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -46,6 +46,7 @@ type Tracer struct {
 	instrumentedLibs ebpfcommon.InstrumentedLibsT
 	libsMux          sync.Mutex
 	iters            []*ebpfcommon.Iter
+	eventCtx         *ebpfcommon.EBPFEventContext
 }
 
 func tlog() *slog.Logger {
@@ -649,6 +650,10 @@ func bpfConnInfoT(src ebpfcommon.BpfConnectionInfoT) (dst BpfConnectionInfoT) {
 	dst.S_port = src.S_port
 	return
 }
+
+func (p *Tracer) SetEventContext(ctx *ebpfcommon.EBPFEventContext) { p.eventCtx = ctx }
+
+func (p *Tracer) Capabilities() ebpfcommon.TracerCapability { return 0 }
 
 func (p *Tracer) Required() bool {
 	return true

--- a/pkg/internal/ebpf/generictracer/generictracer_notlinux.go
+++ b/pkg/internal/ebpf/generictracer/generictracer_notlinux.go
@@ -49,4 +49,6 @@ func (p *Tracer) Run(_ context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg.Q
 func (p *Tracer) SetupTailCalls()                                     {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets) {}
 func (p *Tracer) ProcessBinary(_ *exec.FileInfo)                      {}
+func (p *Tracer) SetEventContext(_ *ebpfcommon.EBPFEventContext)      {}
+func (p *Tracer) Capabilities() ebpfcommon.TracerCapability           { return 0 }
 func (p *Tracer) Required() bool                                      { return false }

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -754,6 +754,10 @@ func (p *Tracer) Run(ctx context.Context, ebpfEventContext *ebpfcommon.EBPFEvent
 	)(ctx, append(p.closers, &p.bpfObjects), eventsChan)
 }
 
+func (p *Tracer) SetEventContext(_ *ebpfcommon.EBPFEventContext) {}
+
+func (p *Tracer) Capabilities() ebpfcommon.TracerCapability { return 0 }
+
 func (p *Tracer) Required() bool {
 	return true
 }

--- a/pkg/internal/ebpf/gpuevent/gpuevent.go
+++ b/pkg/internal/ebpf/gpuevent/gpuevent.go
@@ -319,6 +319,10 @@ func (p *Tracer) readGPUGraphLaunchIntoSpan(record *ringbuf.Record) (request.Spa
 	}, false, nil
 }
 
+func (p *Tracer) SetEventContext(_ *ebpfcommon.EBPFEventContext) {}
+
+func (p *Tracer) Capabilities() ebpfcommon.TracerCapability { return 0 }
+
 func (p *Tracer) Required() bool {
 	return false
 }

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -297,6 +297,10 @@ func (p *Tracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg
 	p.log.Debug("terminating")
 }
 
+func (p *Tracer) SetEventContext(_ *ebpfcommon.EBPFEventContext) {}
+
+func (p *Tracer) Capabilities() ebpfcommon.TracerCapability { return 0 }
+
 func (p *Tracer) Required() bool {
 	return false
 }

--- a/pkg/internal/ebpf/logenricher/logenricher_notlinux.go
+++ b/pkg/internal/ebpf/logenricher/logenricher_notlinux.go
@@ -46,4 +46,6 @@ func (p *Tracer) Run(_ context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg.Q
 func (p *Tracer) SetupTailCalls()                                     {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets) {}
 func (p *Tracer) ProcessBinary(_ *exec.FileInfo)                      {}
+func (p *Tracer) SetEventContext(_ *ebpfcommon.EBPFEventContext)      {}
+func (p *Tracer) Capabilities() ebpfcommon.TracerCapability           { return 0 }
 func (p *Tracer) Required() bool                                      { return false }

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -200,6 +200,10 @@ func (p *Tracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg
 	p.log.Debug("tpinjector terminated")
 }
 
+func (p *Tracer) SetEventContext(_ *ebpfcommon.EBPFEventContext) {}
+
+func (p *Tracer) Capabilities() ebpfcommon.TracerCapability { return 0 }
+
 func (p *Tracer) Required() bool {
 	return false
 }

--- a/pkg/internal/ebpf/tpinjector/tpinjector_notlinux.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector_notlinux.go
@@ -48,4 +48,6 @@ func (p *Tracer) Run(_ context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg.Q
 func (p *Tracer) SetupTailCalls()                                     {}
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets) {}
 func (p *Tracer) ProcessBinary(_ *exec.FileInfo)                      {}
+func (p *Tracer) SetEventContext(_ *ebpfcommon.EBPFEventContext)      {}
+func (p *Tracer) Capabilities() ebpfcommon.TracerCapability           { return 0 }
 func (p *Tracer) Required() bool                                      { return false }


### PR DESCRIPTION
## Summary

Add two new methods to the Tracer interface: SetEventContext allows tracers to receive the shared EBPFEventContext before loading, and Capabilities returns a bitmask of capabilities the tracer provides. The Capabilities bitmask is accumulated into EBPFEventContext so that later-loaded tracers can adjust their behaviour accordingly (future socktracer will set a SockTracer capability that will help other tracers know what to do when that capability is set, such as skipping loading a few kprobes). It's a way to communicate capabilities between tracers without causing cross dependency amongs them.

All existing tracers get no-op implementations returning zero.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](../SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
