### PR TITLE
fix(http2): fix HPACK decoder reuse, frame classification, and header…

### DIFF
--- a/pkg/ebpf/common/http2grpc_transform.go
+++ b/pkg/ebpf/common/http2grpc_transform.go
@@ -93,8 +93,6 @@ func protocolIsGRPC(activeGRPCConnections *lru.Cache[uint64, h2Connection], conn
 	}
 }
 
-var commonHDec = bhpack.NewDecoder(0, nil)
-
 func isHTTPOp(op string) bool {
 	return op == "GET" || op == "POST" || op == "PATCH" || op == "DELETE" || op == "OPTIONS" || op == "HEAD"
 }
@@ -126,6 +124,8 @@ func handleHeaderField(hf *bhpack.HeaderField) bool {
 		}
 	case "grpc-status":
 		return true
+	case ":status":
+		return true
 	}
 
 	return false
@@ -133,18 +133,17 @@ func handleHeaderField(hf *bhpack.HeaderField) bool {
 
 func knownFrameKeys(fr *http2.Framer, hf *http2.HeadersFrame) bool {
 	knownCount := 0
-	commonHDec.SetEmitFunc(func(hf bhpack.HeaderField) {
+	dec := bhpack.NewDecoder(0, nil)
+	dec.SetEmitFunc(func(hf bhpack.HeaderField) {
 		if handleHeaderField(&hf) {
 			knownCount++
 		}
 	})
-	// Lose reference to MetaHeadersFrame:
-	defer commonHDec.SetEmitFunc(func(_ bhpack.HeaderField) {})
-	defer commonHDec.Close()
+	defer dec.Close()
 
 	frag := hf.HeaderBlockFragment()
 	for {
-		if _, err := commonHDec.Write(frag); err != nil {
+		if _, err := dec.Write(frag); err != nil {
 			break
 		}
 		if hf.HeadersEnded() {


### PR DESCRIPTION
## Summary

- knownFrameKeys used a package-level HPACK decoder shared across all calls, causing dynamic table corruption when concurrent connections or sequential frames updated the table state. Switch to a per-call decoder.
    
- handleHeaderField did not handle :status, causing response HEADERS frames to be unrecognised during protocol classification.


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](../SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
