### PR TITLE
fix(gemini): fix GenAI support for Vertex AI

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -381,9 +381,10 @@ type AnthropicError struct {
 // Google AI Studio (Gemini) types
 
 type VendorGemini struct {
-	Input  GeminiRequest
-	Output GeminiResponse
-	Model  string
+	Input     GeminiRequest
+	Output    GeminiResponse
+	Model     string
+	Operation string
 }
 
 type GeminiRequest struct {
@@ -444,6 +445,15 @@ func (g *VendorGemini) GetFinishReasons() []string {
 		}
 	}
 	return reasons
+}
+
+// OperationName returns the Gemini API operation name.
+// It falls back to "generate_content" when no operation was extracted from the URL.
+func (g *VendorGemini) OperationName() string {
+	if g.Operation != "" {
+		return g.Operation
+	}
+	return "generate_content"
 }
 
 func (g *VendorGemini) GetOutput() string {
@@ -1070,11 +1080,12 @@ func (s *Span) TraceName() string {
 		}
 
 		if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeGemini && s.GenAI != nil && s.GenAI.Gemini != nil {
+			op := s.GenAI.Gemini.OperationName()
 			model := s.GenAI.Gemini.Model
 			if model != "" {
-				return "generate_content " + model
+				return op + " " + model
 			}
-			return "generate_content"
+			return op
 		}
 
 		name := s.Method
@@ -1340,7 +1351,7 @@ func (s *Span) GenAIOperationName() string {
 		return s.GenAI.Anthropic.Output.Type
 	}
 	if s.GenAI.Gemini != nil {
-		return "generate_content"
+		return s.GenAI.Gemini.OperationName()
 	}
 	return ""
 }

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -380,6 +380,10 @@ type AnthropicError struct {
 
 // Google AI Studio (Gemini) types
 
+// DefaultGeminiOperation is the fallback operation name when no operation
+// can be extracted from the URL path.
+const DefaultGeminiOperation = "generate_content"
+
 type VendorGemini struct {
 	Input     GeminiRequest
 	Output    GeminiResponse
@@ -448,12 +452,12 @@ func (g *VendorGemini) GetFinishReasons() []string {
 }
 
 // OperationName returns the Gemini API operation name.
-// It falls back to "generate_content" when no operation was extracted from the URL.
+// It falls back to DefaultGeminiOperation when no operation was extracted from the URL.
 func (g *VendorGemini) OperationName() string {
 	if g.Operation != "" {
 		return g.Operation
 	}
-	return "generate_content"
+	return DefaultGeminiOperation
 }
 
 func (g *VendorGemini) GetOutput() string {

--- a/pkg/ebpf/common/http/gemini.go
+++ b/pkg/ebpf/common/http/gemini.go
@@ -22,8 +22,8 @@ const geminiModelPrefix = "/models/"
 // geminiHostPattern pairs a known hostname suffix with the URL path segment
 // that must be present for the request to be considered a Gemini API call.
 type geminiHostPattern struct {
-	hostSuffix    string
-	requiredPath  string
+	hostSuffix   string
+	requiredPath string
 }
 
 // geminiHostPatterns lists known Gemini API hosts and their required path

--- a/pkg/ebpf/common/http/gemini.go
+++ b/pkg/ebpf/common/http/gemini.go
@@ -156,7 +156,7 @@ func extractGeminiOperation(req *http.Request) string {
 	}
 	after := path[idx+len(geminiModelPrefix):]
 	colonIdx := strings.Index(after, ":")
-	if colonIdx < 0 {
+	if colonIdx < 0 || colonIdx+1 >= len(after) {
 		return request.DefaultGeminiOperation
 	}
 	return camelToSnake(after[colonIdx+1:])

--- a/pkg/ebpf/common/http/gemini.go
+++ b/pkg/ebpf/common/http/gemini.go
@@ -19,10 +19,20 @@ import (
 // in both the Gemini Developer API and Vertex AI URL layouts.
 const geminiModelPrefix = "/models/"
 
-// geminiHosts lists known hostnames used by the Gemini API and Vertex AI.
-var geminiHosts = []string{
-	"generativelanguage.googleapis.com",
-	"aiplatform.googleapis.com",
+// geminiHostPattern pairs a known hostname suffix with the URL path segment
+// that must be present for the request to be considered a Gemini API call.
+type geminiHostPattern struct {
+	hostSuffix    string
+	requiredPath  string
+}
+
+// geminiHostPatterns lists known Gemini API hosts and their required path
+// segments. The Gemini Developer API uses a simple /models/ prefix, while
+// Vertex AI requires the fuller /publishers/google/models/ path to avoid
+// matching unrelated Vertex AI prediction endpoints.
+var geminiHostPatterns = []geminiHostPattern{
+	{"generativelanguage.googleapis.com", "/models/"},
+	{"aiplatform.googleapis.com", "/publishers/google/models/"},
 }
 
 func isGemini(req *http.Request, respHeader http.Header) bool {
@@ -35,7 +45,7 @@ func isGemini(req *http.Request, respHeader http.Header) bool {
 
 // isGeminiURL checks whether the request targets a known Gemini endpoint
 // by matching the hostname against known Gemini/Vertex AI hosts and
-// verifying the URL path contains a Gemini-specific model segment.
+// verifying the URL path contains the host-specific model segment.
 // This covers the googleapis/go-genai library which calls both the
 // Gemini Developer API and Vertex AI backends.
 func isGeminiURL(req *http.Request) bool {
@@ -43,25 +53,16 @@ func isGeminiURL(req *http.Request) bool {
 		return false
 	}
 
-	if !hasGeminiModelPath(req.URL.Path) {
-		return false
-	}
-
 	host := extractHostname(req)
+	path := req.URL.Path
 
-	for _, h := range geminiHosts {
-		if strings.HasSuffix(host, h) {
-			return true
+	for _, hp := range geminiHostPatterns {
+		if strings.HasSuffix(host, hp.hostSuffix) {
+			return strings.Contains(path, hp.requiredPath)
 		}
 	}
 
 	return false
-}
-
-// hasGeminiModelPath reports whether the URL path contains the
-// /models/{model}:{operation} segment used by Gemini API endpoints.
-func hasGeminiModelPath(path string) bool {
-	return strings.Contains(path, geminiModelPrefix)
 }
 
 // extractHostname returns the hostname from the request, stripping any

--- a/pkg/ebpf/common/http/gemini.go
+++ b/pkg/ebpf/common/http/gemini.go
@@ -8,11 +8,16 @@ import (
 	"encoding/json"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
+
+// geminiModelPrefix is the URL path segment that precedes the model name
+// in both the Gemini Developer API and Vertex AI URL layouts.
+const geminiModelPrefix = "/models/"
 
 // geminiHosts lists known hostnames used by the Gemini API and Vertex AI.
 var geminiHosts = []string{
@@ -29,26 +34,47 @@ func isGemini(req *http.Request, respHeader http.Header) bool {
 }
 
 // isGeminiURL checks whether the request targets a known Gemini endpoint
-// by inspecting the host and URL path. This covers the googleapis/go-genai
-// library which calls both the Gemini Developer API and Vertex AI backends.
+// by matching the hostname against known Gemini/Vertex AI hosts and
+// verifying the URL path contains a Gemini-specific model segment.
+// This covers the googleapis/go-genai library which calls both the
+// Gemini Developer API and Vertex AI backends.
 func isGeminiURL(req *http.Request) bool {
 	if req == nil || req.URL == nil {
 		return false
 	}
 
-	host := req.URL.Host
-	if host == "" {
-		host = req.Host
+	if !hasGeminiModelPath(req.URL.Path) {
+		return false
 	}
 
+	host := extractHostname(req)
+
 	for _, h := range geminiHosts {
-		if host == h || strings.HasSuffix(host, "."+h) ||
-			strings.HasSuffix(host, "-"+h) {
+		if strings.HasSuffix(host, h) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// hasGeminiModelPath reports whether the URL path contains the
+// /models/{model}:{operation} segment used by Gemini API endpoints.
+func hasGeminiModelPath(path string) bool {
+	return strings.Contains(path, geminiModelPrefix)
+}
+
+// extractHostname returns the hostname from the request, stripping any
+// port number that may be present in req.URL.Host or req.Host.
+func extractHostname(req *http.Request) string {
+	if h := req.URL.Hostname(); h != "" {
+		return h
+	}
+	host := req.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
 }
 
 func GeminiSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {
@@ -104,12 +130,11 @@ func extractGeminiModel(req *http.Request) string {
 		return ""
 	}
 	path := req.URL.Path
-	const prefix = "/models/"
-	idx := strings.Index(path, prefix)
+	idx := strings.Index(path, geminiModelPrefix)
 	if idx < 0 {
 		return ""
 	}
-	model := path[idx+len(prefix):]
+	model := path[idx+len(geminiModelPrefix):]
 	if colonIdx := strings.Index(model, ":"); colonIdx >= 0 {
 		model = model[:colonIdx]
 	}
@@ -121,18 +146,17 @@ func extractGeminiModel(req *http.Request) string {
 // /models/gemini-2.0-flash:generateContent → generate_content.
 func extractGeminiOperation(req *http.Request) string {
 	if req == nil || req.URL == nil {
-		return "generate_content"
+		return request.DefaultGeminiOperation
 	}
 	path := req.URL.Path
-	const prefix = "/models/"
-	idx := strings.Index(path, prefix)
+	idx := strings.Index(path, geminiModelPrefix)
 	if idx < 0 {
-		return "generate_content"
+		return request.DefaultGeminiOperation
 	}
-	after := path[idx+len(prefix):]
+	after := path[idx+len(geminiModelPrefix):]
 	colonIdx := strings.Index(after, ":")
 	if colonIdx < 0 {
-		return "generate_content"
+		return request.DefaultGeminiOperation
 	}
 	return camelToSnake(after[colonIdx+1:])
 }

--- a/pkg/ebpf/common/http/gemini.go
+++ b/pkg/ebpf/common/http/gemini.go
@@ -14,12 +14,45 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
 
-func isGemini(respHeader http.Header) bool {
-	return respHeader.Get("X-Gemini-Service-Tier") != ""
+// geminiHosts lists known hostnames used by the Gemini API and Vertex AI.
+var geminiHosts = []string{
+	"generativelanguage.googleapis.com",
+	"aiplatform.googleapis.com",
+}
+
+func isGemini(req *http.Request, respHeader http.Header) bool {
+	if respHeader.Get("X-Gemini-Service-Tier") != "" {
+		return true
+	}
+
+	return isGeminiURL(req)
+}
+
+// isGeminiURL checks whether the request targets a known Gemini endpoint
+// by inspecting the host and URL path. This covers the googleapis/go-genai
+// library which calls both the Gemini Developer API and Vertex AI backends.
+func isGeminiURL(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+
+	host := req.URL.Host
+	if host == "" {
+		host = req.Host
+	}
+
+	for _, h := range geminiHosts {
+		if host == h || strings.HasSuffix(host, "."+h) ||
+			strings.HasSuffix(host, "-"+h) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func GeminiSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {
-	if !isGemini(resp.Header) {
+	if !isGemini(req, resp.Header) {
 		return *baseSpan, false
 	}
 
@@ -47,13 +80,15 @@ func GeminiSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 	}
 
 	model := extractGeminiModel(req)
+	operation := extractGeminiOperation(req)
 
 	baseSpan.SubType = request.HTTPSubtypeGemini
 	baseSpan.GenAI = &request.GenAI{
 		Gemini: &request.VendorGemini{
-			Input:  parsedRequest,
-			Output: parsedResponse,
-			Model:  model,
+			Input:     parsedRequest,
+			Output:    parsedResponse,
+			Model:     model,
+			Operation: operation,
 		},
 	}
 
@@ -61,7 +96,9 @@ func GeminiSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 }
 
 // extractGeminiModel extracts the model name from the URL path.
-// Gemini URLs follow the pattern: /v1beta/models/{model}:generateContent
+// Supported patterns:
+//   - Gemini API:  /v1beta/models/{model}:generateContent
+//   - Vertex AI:   /v1/projects/{p}/locations/{l}/publishers/google/models/{model}:generateContent
 func extractGeminiModel(req *http.Request) string {
 	if req == nil || req.URL == nil {
 		return ""
@@ -77,4 +114,41 @@ func extractGeminiModel(req *http.Request) string {
 		model = model[:colonIdx]
 	}
 	return model
+}
+
+// extractGeminiOperation extracts the operation name from the URL path.
+// The operation appears after the colon in the model segment, e.g.
+// /models/gemini-2.0-flash:generateContent → generate_content.
+func extractGeminiOperation(req *http.Request) string {
+	if req == nil || req.URL == nil {
+		return "generate_content"
+	}
+	path := req.URL.Path
+	const prefix = "/models/"
+	idx := strings.Index(path, prefix)
+	if idx < 0 {
+		return "generate_content"
+	}
+	after := path[idx+len(prefix):]
+	colonIdx := strings.Index(after, ":")
+	if colonIdx < 0 {
+		return "generate_content"
+	}
+	return camelToSnake(after[colonIdx+1:])
+}
+
+// camelToSnake converts a camelCase string to snake_case.
+func camelToSnake(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r + ('a' - 'A'))
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }

--- a/pkg/ebpf/common/http/gemini_test.go
+++ b/pkg/ebpf/common/http/gemini_test.go
@@ -155,6 +155,54 @@ func TestGeminiSpan_VertexAIEndpoint(t *testing.T) {
 	assert.Equal(t, "gemini-2.0-flash", span.GenAI.Gemini.Model)
 }
 
+func TestGeminiSpan_GoGenAI_GeminiAPI_NoHeader(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent", geminiRequestBody)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, geminiResponseBody)
+
+	base := &request.Span{}
+	span, ok := GeminiSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Gemini)
+	assert.Equal(t, request.HTTPSubtypeGemini, span.SubType)
+	assert.Equal(t, "gemini-2.5-flash", span.GenAI.Gemini.Model)
+	assert.Equal(t, "generate_content", span.GenAI.Gemini.Operation)
+}
+
+func TestGeminiSpan_GoGenAI_VertexAI_NoHeader(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/my-proj/locations/us-central1/publishers/google/models/gemini-2.0-flash:generateContent", geminiRequestBody)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, geminiResponseBody)
+
+	base := &request.Span{}
+	span, ok := GeminiSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Gemini)
+	assert.Equal(t, request.HTTPSubtypeGemini, span.SubType)
+	assert.Equal(t, "gemini-2.0-flash", span.GenAI.Gemini.Model)
+	assert.Equal(t, "generate_content", span.GenAI.Gemini.Operation)
+}
+
+func TestGeminiSpan_GoGenAI_EmbedContent(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent", `{"content":{"parts":[{"text":"hello"}]}}`)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, `{"embedding":{"values":[0.1,0.2]}}`)
+
+	base := &request.Span{}
+	span, ok := GeminiSpan(base, req, resp)
+
+	require.True(t, ok)
+	assert.Equal(t, "text-embedding-004", span.GenAI.Gemini.Model)
+	assert.Equal(t, "embed_content", span.GenAI.Gemini.Operation)
+}
+
 func TestExtractGeminiModel(t *testing.T) {
 	tests := []struct {
 		name string
@@ -172,6 +220,16 @@ func TestExtractGeminiModel(t *testing.T) {
 			want: "gemini-2.0-flash",
 		},
 		{
+			name: "vertex AI v1beta1 path",
+			url:  "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/p/locations/l/publishers/google/models/gemini-2.5-pro:streamGenerateContent",
+			want: "gemini-2.5-pro",
+		},
+		{
+			name: "embedContent operation",
+			url:  "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent",
+			want: "text-embedding-004",
+		},
+		{
 			name: "no model in path",
 			url:  "https://example.com/api/chat",
 			want: "",
@@ -182,6 +240,93 @@ func TestExtractGeminiModel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := makeRequest(t, http.MethodPost, tt.url, "{}")
 			assert.Equal(t, tt.want, extractGeminiModel(req))
+		})
+	}
+}
+
+func TestExtractGeminiOperation(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "generateContent",
+			url:  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+			want: "generate_content",
+		},
+		{
+			name: "streamGenerateContent",
+			url:  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:streamGenerateContent",
+			want: "stream_generate_content",
+		},
+		{
+			name: "embedContent",
+			url:  "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent",
+			want: "embed_content",
+		},
+		{
+			name: "countTokens",
+			url:  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:countTokens",
+			want: "count_tokens",
+		},
+		{
+			name: "vertex AI generateContent",
+			url:  "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models/gemini-2.0-flash:generateContent",
+			want: "generate_content",
+		},
+		{
+			name: "no model segment",
+			url:  "https://example.com/api/chat",
+			want: "generate_content",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := makeRequest(t, http.MethodPost, tt.url, "{}")
+			assert.Equal(t, tt.want, extractGeminiOperation(req))
+		})
+	}
+}
+
+func TestIsGeminiURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{
+			name: "Gemini Developer API",
+			url:  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+			want: true,
+		},
+		{
+			name: "Vertex AI us-central1",
+			url:  "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models/gemini-2.0-flash:generateContent",
+			want: true,
+		},
+		{
+			name: "Vertex AI europe-west4",
+			url:  "https://europe-west4-aiplatform.googleapis.com/v1beta1/projects/p/locations/l/publishers/google/models/gemini-2.5-pro:generateContent",
+			want: true,
+		},
+		{
+			name: "unrelated host",
+			url:  "https://api.openai.com/v1/chat/completions",
+			want: false,
+		},
+		{
+			name: "unrelated googleapis",
+			url:  "https://storage.googleapis.com/bucket/object",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := makeRequest(t, http.MethodPost, tt.url, "{}")
+			assert.Equal(t, tt.want, isGeminiURL(req))
 		})
 	}
 }

--- a/pkg/ebpf/common/http/gemini_test.go
+++ b/pkg/ebpf/common/http/gemini_test.go
@@ -321,6 +321,16 @@ func TestIsGeminiURL(t *testing.T) {
 			url:  "https://storage.googleapis.com/bucket/object",
 			want: false,
 		},
+		{
+			name: "Vertex AI non-Gemini prediction endpoint",
+			url:  "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/endpoints/12345:predict",
+			want: false,
+		},
+		{
+			name: "Vertex AI custom model with /models/ but no /publishers/google/",
+			url:  "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/models/my-custom-model:predict",
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ebpf/common/http/gemini_test.go
+++ b/pkg/ebpf/common/http/gemini_test.go
@@ -280,6 +280,11 @@ func TestExtractGeminiOperation(t *testing.T) {
 			url:  "https://example.com/api/chat",
 			want: "generate_content",
 		},
+		{
+			name: "trailing colon with no operation",
+			url:  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:",
+			want: "generate_content",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -1199,6 +1199,27 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		ensureTraceAttrNotExists(t, spanAttrs, semconv.GenAISystemInstructionsKey)
 	})
 
+	t.Run("Gemini span - dynamic operation name", func(t *testing.T) {
+		span := makeGeminiSpan(&request.VendorGemini{
+			Model:     "text-embedding-004",
+			Operation: "embed_content",
+			Output: request.GeminiResponse{
+				ModelVersion: "text-embedding-004",
+				UsageMetadata: request.GeminiUsage{
+					PromptTokenCount:     5,
+					CandidatesTokenCount: 0,
+				},
+			},
+		})
+
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
+
+		spanAttrs := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes()
+		ensureTraceStrAttr(t, spanAttrs, semconv.GenAIOperationNameKey, "embed_content")
+		ensureTraceStrAttr(t, spanAttrs, semconv.GenAIRequestModelKey, "text-embedding-004")
+	})
+
 	t.Run("Gemini span - optional attributes and error", func(t *testing.T) {
 		span := makeGeminiSpan(&request.VendorGemini{
 			Model: "gemini-2.0-flash",

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -535,7 +535,7 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 		if span.SubType == request.HTTPSubtypeGemini && span.GenAI != nil && span.GenAI.Gemini != nil {
 			ai := span.GenAI.Gemini
 			attrs = append(attrs, semconv.GenAIProviderNameGCPGemini)
-			attrs = append(attrs, semconv.GenAIOperationNameGenerateContent)
+			attrs = append(attrs, semconv.GenAIOperationNameKey.String(ai.OperationName()))
 			if ai.Output.ResponseID != "" {
 				attrs = append(attrs, semconv.GenAIResponseID(ai.Output.ResponseID))
 			}


### PR DESCRIPTION
## Summary

Enhance Gemini detection to support the googleapis/go-genai Go SDK,
which calls both the Gemini Developer API and Vertex AI backends.

Previously, Gemini requests were identified solely by the
X-Gemini-Service-Tier response header. The go-genai library, especially
when using the Vertex AI backend, may not return this header.

Changes:
- Add URL-based fallback detection for known Gemini hosts
  (generativelanguage.googleapis.com, *-aiplatform.googleapis.com)
- Extract operation name from URL path (e.g. generateContent →
  generate_content, embedContent → embed_content) instead of
  hardcoding "generate_content"
- Add Operation field to VendorGemini and OperationName() accessor
- Update tracesgen to use dynamic operation name


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](../SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
