### PR TITLE
Add TCP failed connections metric

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -129,6 +129,7 @@ OBI currently documents the following statistical instrumentation support:
 | Metric | Scope | Notes |
 |:-------|:------|:------|
 | TCP RTT | Node-wide statistical metric collection | Calculated from the kernel TCP `srtt_us` field |
+| TCP Failed Connections | Node-wide statistical metric collection | Counts the TCP failed connections between 2 endpoints |
 
 ## Context Propagation Frameworks
 

--- a/bpf/statsolly/k_tcp.c
+++ b/bpf/statsolly/k_tcp.c
@@ -68,5 +68,3 @@ int BPF_KPROBE(obi_kprobe_tcp_close_srtt, struct sock *sk) {
 
     return 0;
 }
-
-char __license[] SEC("license") = "Dual MIT/GPL";

--- a/bpf/statsolly/stats.c
+++ b/bpf/statsolly/stats.c
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build obi_bpf_ignore
+#include "k_tcp.c"
+#include "tp_tcp.c"
+
+char __license[] SEC("license") = "Dual MIT/GPL";

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -15,27 +15,43 @@
 #include <statsolly/types.h>
 #include <statsolly/maps/stats_events.h>
 
+#ifndef ECONNREFUSED
+#define ECONNREFUSED 111
+#endif
+#ifndef ECONNRESET
+#define ECONNRESET 104
+#endif
+#ifndef ETIMEDOUT
+#define ETIMEDOUT 110
+#endif
+#ifndef EHOSTUNREACH
+#define EHOSTUNREACH 113
+#endif
+#ifndef ENETUNREACH
+#define ENETUNREACH 101
+#endif
+
 enum tcp_fail_reason {
-    reason_unknown = 0,            // sk_err was 0, cause not determined
-    reason_connection_refused = 1, // ECONNREFUSED (111)
-    reason_connection_reset = 2,   // ECONNRESET (104)
-    reason_timed_out = 3,          // ETIMEDOUT (110)
-    reason_host_unreachable = 4,   // EHOSTUNREACH (113)
-    reason_net_unreachable = 5,    // ENETUNREACH (101)
-    reason_other = 255,            // anything else
+    reason_unknown = 0,
+    reason_connection_refused = 1,
+    reason_connection_reset = 2,
+    reason_timed_out = 3,
+    reason_host_unreachable = 4,
+    reason_net_unreachable = 5,
+    reason_other = 255,
 };
 
-static __always_inline u8 sk_err_to_reason(int err) {
+static __always_inline u8 sk_err_to_reason(const int err) {
     switch (err) {
-    case 111:
+    case ECONNREFUSED:
         return reason_connection_refused;
-    case 104:
+    case ECONNRESET:
         return reason_connection_reset;
-    case 110:
+    case ETIMEDOUT:
         return reason_timed_out;
-    case 113:
+    case EHOSTUNREACH:
         return reason_host_unreachable;
-    case 101:
+    case ENETUNREACH:
         return reason_net_unreachable;
     case 0:
         return reason_unknown;
@@ -76,8 +92,8 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
         return 0;
     }
 
-    int err = BPF_CORE_READ(sk, sk_err);
-    u8 reason = sk_err_to_reason(err);
+    const int err = BPF_CORE_READ(sk, sk_err);
+    const u8 reason = sk_err_to_reason(err);
 
     bpf_d_printk("tcp failed: oldstate=%d, reason=%d, s_port=%d, d_port=%d",
                  args->oldstate,

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build obi_bpf_ignore
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+#include <bpfcore/bpf_tracing.h>
+#include <bpfcore/bpf_core_read.h>
+
+#include <common/connection_info.h>
+#include <common/sockaddr.h>
+
+#include <logger/bpf_dbg.h>
+
+#include <statsolly/types.h>
+#include <statsolly/maps/stats_events.h>
+
+enum tcp_fail_reason {
+    reason_unknown = 0,            // sk_err was 0, cause not determined
+    reason_connection_refused = 1, // ECONNREFUSED (111)
+    reason_connection_reset = 2,   // ECONNRESET (104)
+    reason_timed_out = 3,          // ETIMEDOUT (110)
+    reason_host_unreachable = 4,   // EHOSTUNREACH (113)
+    reason_net_unreachable = 5,    // ENETUNREACH (101)
+    reason_other = 255,            // anything else
+};
+
+static __always_inline u8 sk_err_to_reason(int err) {
+    switch (err) {
+    case 111:
+        return reason_connection_refused;
+    case 104:
+        return reason_connection_reset;
+    case 110:
+        return reason_timed_out;
+    case 113:
+        return reason_host_unreachable;
+    case 101:
+        return reason_net_unreachable;
+    case 0:
+        return reason_unknown;
+    default:
+        return reason_other;
+    }
+}
+
+typedef struct tcp_failed_connection {
+    u8 flags; // Must be first, we use it to tell what kind of event we have on the ring buffer
+    u8 reason;
+    u8 _pad[2];
+    connection_info_t conn;
+} tcp_failed_connection_t;
+
+// Force tcp_failed_connection_t
+const tcp_failed_connection_t *unused_tcp_failed_connection __attribute__((unused));
+
+SEC("tracepoint/sock/inet_sock_set_state")
+int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_state *args) {
+    if (args->protocol != IPPROTO_TCP)
+        return 0;
+
+    if (args->newstate != TCP_CLOSE)
+        return 0;
+
+    // These are normal completions, not failures
+    if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT)
+        return 0;
+
+    struct sock *sk = (struct sock *)args->skaddr;
+
+    connection_info_t conn;
+    if (!parse_sock_info(sk, &conn)) {
+        return 0;
+    }
+
+    int err = BPF_CORE_READ(sk, sk_err);
+    u8 reason = sk_err_to_reason(err);
+
+    // TODO remove it
+    bpf_printk("tcp failed: oldstate=%d, reason=%d, s_port=%d, d_port=%d",
+               args->oldstate,
+               reason,
+               conn.s_port,
+               conn.d_port);
+
+    tcp_failed_connection_t *se = bpf_ringbuf_reserve(&stats_events, sizeof(*se), 0);
+    if (!se) {
+        return 0;
+    }
+
+    se->flags = k_event_stat_failed_connection;
+    se->reason = reason;
+    se->conn = conn;
+
+    bpf_ringbuf_submit(se, 0);
+
+    return 0;
+}

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -102,7 +102,7 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
         return 0;
     }
 
-    se->flags = k_event_stat_failed_connection;
+    se->flags = k_event_stat_tcp_failed_connection;
     se->reason = reason;
     se->conn = conn;
 

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -106,7 +106,7 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
     se->reason = reason;
     se->conn = conn;
 
-    bpf_ringbuf_submit(se, 0);
+    bpf_ringbuf_submit(se, stats_events_flags());
 
     return 0;
 }

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -95,11 +95,7 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
     const int err = BPF_CORE_READ(sk, sk_err);
     const u8 reason = sk_err_to_reason(err);
 
-    bpf_d_printk("tcp failed: oldstate=%d, reason=%d, s_port=%d, d_port=%d",
-                 args->oldstate,
-                 reason,
-                 conn.s_port,
-                 conn.d_port);
+    bpf_d_printk("tcp failed: s_port=%d, d_port=%d, reason=%d", conn.s_port, conn.d_port, reason);
 
     tcp_failed_connection_t *se = bpf_ringbuf_reserve(&stats_events, sizeof(*se), 0);
     if (!se) {

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -56,15 +56,18 @@ const tcp_failed_connection_t *unused_tcp_failed_connection __attribute__((unuse
 
 SEC("tracepoint/sock/inet_sock_set_state")
 int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_state *args) {
-    if (args->protocol != IPPROTO_TCP)
+    if (args->protocol != IPPROTO_TCP) {
         return 0;
+    }
 
-    if (args->newstate != TCP_CLOSE)
+    if (args->newstate != TCP_CLOSE) {
         return 0;
+    }
 
     // These are normal completions, not failures
-    if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT)
+    if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT) {
         return 0;
+    }
 
     struct sock *sk = (struct sock *)args->skaddr;
 

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -76,12 +76,11 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
     int err = BPF_CORE_READ(sk, sk_err);
     u8 reason = sk_err_to_reason(err);
 
-    // TODO remove it
-    bpf_printk("tcp failed: oldstate=%d, reason=%d, s_port=%d, d_port=%d",
-               args->oldstate,
-               reason,
-               conn.s_port,
-               conn.d_port);
+    bpf_d_printk("tcp failed: oldstate=%d, reason=%d, s_port=%d, d_port=%d",
+                 args->oldstate,
+                 reason,
+                 conn.s_port,
+                 conn.d_port);
 
     tcp_failed_connection_t *se = bpf_ringbuf_reserve(&stats_events, sizeof(*se), 0);
     if (!se) {

--- a/bpf/statsolly/types.h
+++ b/bpf/statsolly/types.h
@@ -5,6 +5,6 @@
 
 #pragma once
 enum {
-    k_event_stat_tcp_rtt = 1,           // StatTypeTCPRtt
-    k_event_stat_failed_connection = 2, // StatTypeTCPFailedConnection
+    k_event_stat_tcp_rtt = 1,               // StatTypeTCPRtt
+    k_event_stat_tcp_failed_connection = 2, // StatTypeTCPFailedConnection
 };

--- a/bpf/statsolly/types.h
+++ b/bpf/statsolly/types.h
@@ -5,5 +5,6 @@
 
 #pragma once
 enum {
-    k_event_stat_tcp_rtt = 1, // StatTypeTCPRtt
+    k_event_stat_tcp_rtt = 1,           // StatTypeTCPRtt
+    k_event_stat_failed_connection = 2, // StatTypeTCPFailedConnection
 };

--- a/devdocs/statsolly.md
+++ b/devdocs/statsolly.md
@@ -8,6 +8,7 @@ OBI offers the ability to obtain statistical metrics, such as TCP RTT of all app
 - [Add a new stat metric](#add-a-new-stat-metric)
 - [Notes on attributes](#notes-on-attributes)
 - [Final notes](#final-notes)
+- [Current metrics](#current-metrics)
 
 ## Example
 
@@ -44,3 +45,13 @@ Finally, it's possible to add ad hoc attributes specific to a given metric.
 We decided to create a component separate from **Appolly** and **Netolly**, focusing only on **statistical metrics**. Statistical metrics are calculated for all applications running on the node, regardless of the PID that triggered the event. This is because statistical metrics are important if correlated to all applications, and also because some hook points can cause unreliable PID calculations and lead to false positives.
 
 The user can then filter the metrics in userspace using appropriate filters or even the collector.
+
+
+# Current metrics
+
+Below is a table of the currently supported stat metrics:
+
+| Metric name | Hook Point | Description
+|:------------- |:--------------|:--------------|
+| obi_stat_tcp_rtt_seconds | kprobe/tcp_close | measures the smoothed TCP RTT as calculated by the kernel in seconds |
+| obi_stat_tcp_failed_connections | tracepoint/sock/inet_sock_set_state | counts the TCP failed connections between 2 endpoints | 

--- a/devdocs/statsolly.md
+++ b/devdocs/statsolly.md
@@ -46,7 +46,6 @@ We decided to create a component separate from **Appolly** and **Netolly**, focu
 
 The user can then filter the metrics in userspace using appropriate filters or even the collector.
 
-
 # Current metrics
 
 Below is a table of the currently supported stat metrics:
@@ -54,4 +53,4 @@ Below is a table of the currently supported stat metrics:
 | Metric name | Hook Point | Description
 |:------------- |:--------------|:--------------|
 | obi_stat_tcp_rtt_seconds | kprobe/tcp_close | measures the smoothed TCP RTT as calculated by the kernel in seconds |
-| obi_stat_tcp_failed_connections | tracepoint/sock/inet_sock_set_state | counts the TCP failed connections between 2 endpoints | 
+| obi_stat_tcp_failed_connections | tracepoint/sock/inet_sock_set_state | counts the TCP failed connections between 2 endpoints |

--- a/devdocs/statsolly.md
+++ b/devdocs/statsolly.md
@@ -40,17 +40,17 @@ To add a new metric, follow these guidelines:
 Statistical metrics have a list of attributes for both k8s and non-k8s defined in [pkg/export/attributes/attrs_defs.go](../pkg/export/attributes/attr_defs.go). Some of these attributes default to true, and false can be set to true during configuration.
 Finally, it's possible to add ad hoc attributes specific to a given metric.
 
-# Final notes
+## Final notes
 
 We decided to create a component separate from **Appolly** and **Netolly**, focusing only on **statistical metrics**. Statistical metrics are calculated for all applications running on the node, regardless of the PID that triggered the event. This is because statistical metrics are important if correlated to all applications, and also because some hook points can cause unreliable PID calculations and lead to false positives.
 
 The user can then filter the metrics in userspace using appropriate filters or even the collector.
 
-# Current metrics
+## Current metrics
 
 Below is a table of the currently supported stat metrics:
 
-| Metric name | Hook Point | Description
-|:------------- |:--------------|:--------------|
+| Metric name | Hook Point | Description |
+|:-------------|:--------------|:--------------|
 | obi_stat_tcp_rtt_seconds | kprobe/tcp_close | measures the smoothed TCP RTT as calculated by the kernel in seconds |
 | obi_stat_tcp_failed_connections | tracepoint/sock/inet_sock_set_state | counts the TCP failed connections between 2 endpoints |

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -590,7 +590,8 @@
           "ebpf",
           "network",
           "network_inter_zone",
-          "stats"
+          "stats_tcp_failed_connections",
+          "stats_tcp_rtt"
         ]
       },
       "type": "array",

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -590,6 +590,7 @@
           "ebpf",
           "network",
           "network_inter_zone",
+          "stats",
           "stats_tcp_failed_connections",
           "stats_tcp_rtt"
         ]

--- a/internal/test/integration/components/go-stat-metrics-client/main.go
+++ b/internal/test/integration/components/go-stat-metrics-client/main.go
@@ -20,6 +20,22 @@ func main() {
 		fmt.Printf("Env var TARGET_ADDRESS not set, defaulting to %s\n", address)
 	}
 
+	// Generate failed TCP connections by dialing a port where nothing listens
+	failAddress := os.Getenv("FAIL_TARGET_ADDRESS")
+	if failAddress != "" {
+		go func() {
+			for {
+				conn, err := net.DialTimeout("tcp", failAddress, 2*time.Second)
+				if err != nil {
+					fmt.Printf("Expected failed connection to %s: %v\n", failAddress, err)
+				} else {
+					conn.Close()
+				}
+				time.Sleep(1 * time.Second)
+			}
+		}()
+	}
+
 	for {
 		fmt.Printf("[%d] Connecting to %s...\n", counter, address)
 

--- a/internal/test/integration/docker-compose-go-stat-metrics.yml
+++ b/internal/test/integration/docker-compose-go-stat-metrics.yml
@@ -46,7 +46,7 @@ services:
       OTEL_EBPF_HOSTNAME: "obi"
       OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
       OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
-      OTEL_EBPF_METRICS_FEATURES: "stats_tcp_rtt,stats_tcp_failed_connections"
+      OTEL_EBPF_METRICS_FEATURES: "stats"
       OTEL_EBPF_PROTOCOL_DEBUG_PRINT: "true"
       OTEL_EBPF_PROMETHEUS_PORT: "8999"
     depends_on:

--- a/internal/test/integration/docker-compose-go-stat-metrics.yml
+++ b/internal/test/integration/docker-compose-go-stat-metrics.yml
@@ -17,6 +17,7 @@ services:
     image: hatest-testclient-go-stat-metrics
     environment:
       - TARGET_ADDRESS=testserver:8080
+      - FAIL_TARGET_ADDRESS=testserver:19999
 
   obi:
     build:
@@ -27,6 +28,7 @@ services:
       - ./system/sys/kernel/security:/sys/kernel/security
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-go-stat-metrics:/var/run/obi
+      - /sys/kernel/tracing:/sys/kernel/tracing:rw
     image: hatest-obi
     privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
     pid: "host"
@@ -44,7 +46,7 @@ services:
       OTEL_EBPF_HOSTNAME: "obi"
       OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
       OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
-      OTEL_EBPF_METRICS_FEATURES: "stats"
+      OTEL_EBPF_METRICS_FEATURES: "stats_tcp_rtt,stats_tcp_failed_connections"
       OTEL_EBPF_PROTOCOL_DEBUG_PRINT: "true"
       OTEL_EBPF_PROMETHEUS_PORT: "8999"
     depends_on:

--- a/internal/test/integration/red_test_stat_metrics.go
+++ b/internal/test/integration/red_test_stat_metrics.go
@@ -41,3 +41,13 @@ func testStatMetricsTCPRttGo(t *testing.T) {
 		})
 	}
 }
+
+func testStatMetricsTCPFailedConnectionGo(t *testing.T) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		results, err := pq.Query(`obi_stat_tcp_failed_connections{dst_port="19999"}`)
+		require.NoError(ct, err)
+		enoughPromResults(ct, results)
+		assert.Positive(ct, totalPromCount(ct, results))
+	}, testTimeout, 100*time.Millisecond)
+}

--- a/internal/test/integration/suites_stat_test.go
+++ b/internal/test/integration/suites_stat_test.go
@@ -18,5 +18,6 @@ func TestStat_GoStatMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 	t.Run("Go Stat Metrics TCP RTT tests", testStatMetricsTCPRttGo)
+	t.Run("Go Stat Metrics TCP Failed Connection tests", testStatMetricsTCPFailedConnectionGo)
 	require.NoError(t, compose.Close())
 }

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -462,7 +462,7 @@ func getDefinitions(
 		StatTCPFailedConnections.Section: {
 			SubGroups: []*AttrReportGroup{&statsAttributes, &statsKubeAttributes},
 			Attributes: map[attr.Name]Default{
-				attr.TCPFailedConnectionReason: true,
+				attr.TCPFailedConnectionReason: false,
 			},
 		},
 

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -459,6 +459,12 @@ func getDefinitions(
 				attr.ServerAddr:         true,
 			},
 		},
+		StatTCPFailedConnections.Section: {
+			SubGroups: []*AttrReportGroup{&statsAttributes, &statsKubeAttributes},
+			Attributes: map[attr.Name]Default{
+				attr.TCPFailedConnectionReason: true,
+			},
+		},
 
 		// span and service graph metrics don't yet implement attribute selection,
 		// but their values can still be filtered, so we list them here just to

--- a/pkg/export/attributes/metric.go
+++ b/pkg/export/attributes/metric.go
@@ -144,6 +144,11 @@ var (
 		Prom:    "gen_ai_client_operation_duration_seconds",
 		OTEL:    "gen_ai.client.operation.duration",
 	}
+	StatTCPFailedConnections = Name{
+		Section: "obi.stat.tcp.failed.connections",
+		Prom:    "obi_stat_tcp_failed_connections",
+		OTEL:    "obi.stat.tcp.failed.connections",
+	}
 )
 
 // normalizeMetric will facilitate the user-input in the attributes.enable section.

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -272,3 +272,8 @@ const (
 	GenAIRequestModel    = Name(semconv.GenAIRequestModelKey)
 	GenAIResponseModel   = Name(semconv.GenAIResponseModelKey)
 )
+
+// Stat metrics
+const (
+	TCPFailedConnectionReason = Name("reason")
+)

--- a/pkg/export/feature.go
+++ b/pkg/export/feature.go
@@ -39,6 +39,7 @@ const (
 // FeatureMapper stays public so any extension package can add and remove feature
 // definitions before loading them.
 var FeatureMapper = map[string]Features{
+	"stats":                        FeatureStatsTCPRtt | FeatureStatsTCPFailedConnections,
 	"stats_tcp_rtt":                FeatureStatsTCPRtt,
 	"stats_tcp_failed_connections": FeatureStatsTCPFailedConnections,
 	"network":                      FeatureNetwork,

--- a/pkg/export/feature.go
+++ b/pkg/export/feature.go
@@ -23,8 +23,8 @@ const (
 	// zero value.
 	FeatureEmpty Features = 1 << iota
 	FeatureNetwork
-	FeatureStatsTcpRtt
-	FeatureStatsTcpFailedConnections
+	FeatureStatsTCPRtt
+	FeatureStatsTCPFailedConnections
 	FeatureNetworkInterZone
 	FeatureApplicationRED
 	FeatureSpanLegacy
@@ -39,8 +39,8 @@ const (
 // FeatureMapper stays public so any extension package can add and remove feature
 // definitions before loading them.
 var FeatureMapper = map[string]Features{
-	"stats_tcp_rtt":                FeatureStatsTcpRtt,
-	"stats_tcp_failed_connections": FeatureStatsTcpFailedConnections,
+	"stats_tcp_rtt":                FeatureStatsTCPRtt,
+	"stats_tcp_failed_connections": FeatureStatsTCPFailedConnections,
 	"network":                      FeatureNetwork,
 	"network_inter_zone":           FeatureNetworkInterZone,
 	"application":                  FeatureApplicationRED,
@@ -177,15 +177,15 @@ func (f Features) NetworkBytes() bool {
 }
 
 func (f Features) StatMetrics() bool {
-	return f.any(FeatureStatsTcpRtt | FeatureStatsTcpFailedConnections)
+	return f.any(FeatureStatsTCPRtt | FeatureStatsTCPFailedConnections)
 }
 
 func (f Features) StatsTCPRtt() bool {
-	return f.any(FeatureStatsTcpRtt)
+	return f.any(FeatureStatsTCPRtt)
 }
 
 func (f Features) StatsTCPFailedConnections() bool {
-	return f.any(FeatureStatsTcpFailedConnections)
+	return f.any(FeatureStatsTCPFailedConnections)
 }
 
 func (f Features) NetworkInterZone() bool {

--- a/pkg/export/feature.go
+++ b/pkg/export/feature.go
@@ -36,10 +36,13 @@ const (
 	FeatureAll = Features(^uint(0)) // all bits to 1
 )
 
+// FeatureStats enables all stat metrics.
+const FeatureStats = FeatureStatsTCPRtt | FeatureStatsTCPFailedConnections
+
 // FeatureMapper stays public so any extension package can add and remove feature
 // definitions before loading them.
 var FeatureMapper = map[string]Features{
-	"stats":                        FeatureStatsTCPRtt | FeatureStatsTCPFailedConnections,
+	"stats":                        FeatureStats,
 	"stats_tcp_rtt":                FeatureStatsTCPRtt,
 	"stats_tcp_failed_connections": FeatureStatsTCPFailedConnections,
 	"network":                      FeatureNetwork,
@@ -178,7 +181,7 @@ func (f Features) NetworkBytes() bool {
 }
 
 func (f Features) StatMetrics() bool {
-	return f.any(FeatureStatsTCPRtt | FeatureStatsTCPFailedConnections)
+	return f.any(FeatureStats)
 }
 
 func (f Features) StatsTCPRtt() bool {

--- a/pkg/export/feature.go
+++ b/pkg/export/feature.go
@@ -23,7 +23,8 @@ const (
 	// zero value.
 	FeatureEmpty Features = 1 << iota
 	FeatureNetwork
-	FeatureStats
+	FeatureStatsTcpRtt
+	FeatureStatsTcpFailedConnections
 	FeatureNetworkInterZone
 	FeatureApplicationRED
 	FeatureSpanLegacy
@@ -38,18 +39,19 @@ const (
 // FeatureMapper stays public so any extension package can add and remove feature
 // definitions before loading them.
 var FeatureMapper = map[string]Features{
-	"stats":                     FeatureStats,
-	"network":                   FeatureNetwork,
-	"network_inter_zone":        FeatureNetworkInterZone,
-	"application":               FeatureApplicationRED,
-	"application_span":          FeatureSpanLegacy,
-	"application_span_otel":     FeatureSpanOTel,
-	"application_span_sizes":    FeatureSpanSizes,
-	"application_service_graph": FeatureGraph,
-	"application_host":          FeatureApplicationHost,
-	"ebpf":                      FeatureEBPF,
-	"all":                       FeatureAll,
-	"*":                         FeatureAll,
+	"stats_tcp_rtt":                FeatureStatsTcpRtt,
+	"stats_tcp_failed_connections": FeatureStatsTcpFailedConnections,
+	"network":                      FeatureNetwork,
+	"network_inter_zone":           FeatureNetworkInterZone,
+	"application":                  FeatureApplicationRED,
+	"application_span":             FeatureSpanLegacy,
+	"application_span_otel":        FeatureSpanOTel,
+	"application_span_sizes":       FeatureSpanSizes,
+	"application_service_graph":    FeatureGraph,
+	"application_host":             FeatureApplicationHost,
+	"ebpf":                         FeatureEBPF,
+	"all":                          FeatureAll,
+	"*":                            FeatureAll,
 }
 
 func (Features) JSONSchema() *jsonschema.Schema {
@@ -174,9 +176,16 @@ func (f Features) NetworkBytes() bool {
 	return f.any(FeatureNetwork)
 }
 
-// TODO add granularity on metric X
 func (f Features) StatMetrics() bool {
-	return f.any(FeatureStats)
+	return f.any(FeatureStatsTcpRtt | FeatureStatsTcpFailedConnections)
+}
+
+func (f Features) StatsTCPRtt() bool {
+	return f.any(FeatureStatsTcpRtt)
+}
+
+func (f Features) StatsTCPFailedConnections() bool {
+	return f.any(FeatureStatsTcpFailedConnections)
 }
 
 func (f Features) NetworkInterZone() bool {

--- a/pkg/export/feature.go
+++ b/pkg/export/feature.go
@@ -174,6 +174,7 @@ func (f Features) NetworkBytes() bool {
 	return f.any(FeatureNetwork)
 }
 
+// TODO add granularity on metric X
 func (f Features) StatMetrics() bool {
 	return f.any(FeatureStats)
 }

--- a/pkg/export/otel/metrics_stats.go
+++ b/pkg/export/otel/metrics_stats.go
@@ -37,11 +37,11 @@ type StatMetricsConfig struct {
 
 func (mc *StatMetricsConfig) Enabled() bool {
 	return mc.Metrics != nil && mc.Metrics.EndpointEnabled() &&
-		mc.CommonCfg.Features.StatMetrics()
+		(mc.CommonCfg.Features.StatMetrics())
 }
 
 func smlog() *slog.Logger {
-	return slog.With("component", "otel.StatsworkMetricsExporter")
+	return slog.With("component", "otel.StatMetricsExporter")
 }
 
 // getFilteredStatsResourceAttrs returns resource attributes that can be filtered based on the attribute selector
@@ -132,7 +132,8 @@ func newStatMetricsExporter(
 		clock:     clock,
 		expireTTL: cfg.Metrics.TTL,
 	}
-	if cfg.CommonCfg.Features.StatMetrics() {
+
+	if cfg.CommonCfg.Features.StatsTCPRtt() {
 		log := log.With("metricFamily", "StatsTCPRtt")
 
 		tcpRtt, err := ebpfEvents.Float64Histogram(attributes.StatTCPRtt.OTEL, metric2.WithUnit("s"))
@@ -141,22 +142,24 @@ func newStatMetricsExporter(
 			return nil, err
 		}
 
+		log.Debug("restricting attributes not in this list", "attributes", cfg.SelectorCfg.SelectionCfg)
+		attrs := attributes.OpenTelemetryGetters(
+			ebpf.StatGetters,
+			attrProv.For(attributes.StatTCPRtt))
+
+		nme.tcpRtt = NewExpirer[*ebpf.Stat, metric2.Float64Histogram, float64](ctx, tcpRtt, attrs, clock.Time, cfg.Metrics.TTL)
+	}
+
+	if cfg.CommonCfg.Features.StatsTCPFailedConnections() {
+		log := log.With("metricFamily", "StatsTCPFailedConnections")
+
 		tcpFailedConnections, err := ebpfEvents.Int64Counter(attributes.StatTCPFailedConnections.OTEL)
 		if err != nil {
 			log.Error("creating stats tcp failed connection counter", "error", err)
 			return nil, err
 		}
 
-		log.Debug("restricting attributes not in this list", "attributes", cfg.SelectorCfg.SelectionCfg)
-		// TODO check and add granular on metric X like in netolly
 		attrs := attributes.OpenTelemetryGetters(
-			ebpf.StatGetters,
-			attrProv.For(attributes.StatTCPRtt))
-
-		nme.tcpRtt = NewExpirer[*ebpf.Stat, metric2.Float64Histogram, float64](ctx, tcpRtt, attrs, clock.Time, cfg.Metrics.TTL)
-
-		// TODO pino check
-		attrs = attributes.OpenTelemetryGetters(
 			ebpf.StatGetters,
 			attrProv.For(attributes.StatTCPFailedConnections))
 
@@ -177,7 +180,7 @@ func (me *statMetricsExporter) Do(ctx context.Context) {
 			}
 			if me.tcpFailedConnections != nil && v.TCPFailedConnection != nil {
 				tcpFailedConnections, attrs := me.tcpFailedConnections.ForRecord(v)
-				tcpFailedConnections.Add(ctx, 1, metric2.WithAttributeSet(attrs)) // TODO pino, is 1?
+				tcpFailedConnections.Add(ctx, 1, metric2.WithAttributeSet(attrs))
 			}
 		}
 	}

--- a/pkg/export/otel/metrics_stats.go
+++ b/pkg/export/otel/metrics_stats.go
@@ -72,11 +72,12 @@ func newStatMeterProvider(res *resource.Resource, exporter *sdkmetric.Exporter, 
 }
 
 type statMetricsExporter struct {
-	tcpRtt         *Expirer[*ebpf.Stat, metric2.Float64Histogram, float64]
-	interZoneBytes *Expirer[*ebpf.Stat, metric2.Int64Counter, float64]
-	clock          *expire.CachedClock
-	expireTTL      time.Duration
-	in             <-chan []*ebpf.Stat
+	tcpRtt               *Expirer[*ebpf.Stat, metric2.Float64Histogram, float64]
+	tcpFailedConnections *Expirer[*ebpf.Stat, metric2.Int64Counter, int64]
+	interZoneBytes       *Expirer[*ebpf.Stat, metric2.Int64Counter, float64]
+	clock                *expire.CachedClock
+	expireTTL            time.Duration
+	in                   <-chan []*ebpf.Stat
 }
 
 func StatMetricsExporterProvider(
@@ -140,12 +141,26 @@ func newStatMetricsExporter(
 			return nil, err
 		}
 
+		tcpFailedConnections, err := ebpfEvents.Int64Counter(attributes.StatTCPFailedConnections.OTEL)
+		if err != nil {
+			log.Error("creating stats tcp failed connection counter", "error", err)
+			return nil, err
+		}
+
 		log.Debug("restricting attributes not in this list", "attributes", cfg.SelectorCfg.SelectionCfg)
+		// TODO check and add granular on metric X like in netolly
 		attrs := attributes.OpenTelemetryGetters(
 			ebpf.StatGetters,
 			attrProv.For(attributes.StatTCPRtt))
 
 		nme.tcpRtt = NewExpirer[*ebpf.Stat, metric2.Float64Histogram, float64](ctx, tcpRtt, attrs, clock.Time, cfg.Metrics.TTL)
+
+		// TODO pino check
+		attrs = attributes.OpenTelemetryGetters(
+			ebpf.StatGetters,
+			attrProv.For(attributes.StatTCPFailedConnections))
+
+		nme.tcpFailedConnections = NewExpirer[*ebpf.Stat, metric2.Int64Counter, int64](ctx, tcpFailedConnections, attrs, clock.Time, cfg.Metrics.TTL)
 	}
 
 	nme.in = input.Subscribe(msg.SubscriberName("otel.StatMetricsExporter"))
@@ -156,9 +171,13 @@ func (me *statMetricsExporter) Do(ctx context.Context) {
 	for i := range me.in {
 		me.clock.Update()
 		for _, v := range i {
-			if me.tcpRtt != nil {
+			if me.tcpRtt != nil && v.TCPRtt != nil {
 				tcpRtt, attrs := me.tcpRtt.ForRecord(v)
 				tcpRtt.Record(ctx, float64(v.TCPRtt.SrttUs)/1_000_000.0, metric2.WithAttributeSet(attrs))
+			}
+			if me.tcpFailedConnections != nil && v.TCPFailedConnection != nil {
+				tcpFailedConnections, attrs := me.tcpFailedConnections.ForRecord(v)
+				tcpFailedConnections.Add(ctx, 1, metric2.WithAttributeSet(attrs)) // TODO pino, is 1?
 			}
 		}
 	}

--- a/pkg/export/otel/metrics_stats.go
+++ b/pkg/export/otel/metrics_stats.go
@@ -74,7 +74,6 @@ func newStatMeterProvider(res *resource.Resource, exporter *sdkmetric.Exporter, 
 type statMetricsExporter struct {
 	tcpRtt               *Expirer[*ebpf.Stat, metric2.Float64Histogram, float64]
 	tcpFailedConnections *Expirer[*ebpf.Stat, metric2.Int64Counter, int64]
-	interZoneBytes       *Expirer[*ebpf.Stat, metric2.Int64Counter, float64]
 	clock                *expire.CachedClock
 	expireTTL            time.Duration
 	in                   <-chan []*ebpf.Stat

--- a/pkg/export/prom/prom_stats.go
+++ b/pkg/export/prom/prom_stats.go
@@ -39,9 +39,12 @@ type statMetricsReporter struct {
 
 	tcpRtt *Expirer[prometheus.Histogram]
 
+	tcpFailedConnections *Expirer[prometheus.Counter]
+
 	promConnect *connector.PrometheusManager
 
-	statsAttrs []attributes.Field[*ebpf.Stat, string]
+	statsAttrs                []attributes.Field[*ebpf.Stat, string] // TODO change with tcpRttAttrs
+	tcpFailedConnectionsAttrs []attributes.Field[*ebpf.Stat, string]
 
 	clock *expire.CachedClock
 
@@ -96,11 +99,13 @@ func newStatsReporter(
 	var register []prometheus.Collector
 	log := slog.With("component", "prom.StatsEndpoint")
 	if cfg.CommonCfg.Features.StatMetrics() {
+		// TODO add granular check on metric X
 		log.Debug("registering stat metrics")
 		mr.statsAttrs = attributes.PrometheusGetters(
 			ebpf.StatStringGetters,
 			provider.For(attributes.StatTCPRtt))
 
+		// TCP RTT
 		mr.tcpRtt = NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name: attributes.StatTCPRtt.Prom,
 			Help: "measures the smoothed TCP RTT as calculated by the kernel in seconds",
@@ -110,7 +115,18 @@ func newStatsReporter(
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
 		}, labelNames(mr.statsAttrs)).MetricVec, clock.Time, cfg.Config.TTL)
-		register = append(register, mr.tcpRtt)
+
+		mr.tcpFailedConnectionsAttrs = attributes.PrometheusGetters(
+			ebpf.StatStringGetters,
+			provider.For(attributes.StatTCPFailedConnections))
+
+		// TCP failed connection
+		mr.tcpFailedConnections = NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: attributes.StatTCPFailedConnections.Prom,
+			Help: "counts the TCP failed connections between 2 endpoints",
+		}, labelNames(mr.tcpFailedConnectionsAttrs)).MetricVec, clock.Time, cfg.Config.TTL)
+
+		register = append(register, mr.tcpFailedConnections)
 
 	}
 
@@ -136,6 +152,7 @@ func (r *statMetricsReporter) collectMetrics(_ context.Context) {
 		r.clock.Update()
 		for _, stat := range stats {
 			r.observeTCPRtt(stat)
+			r.observeTCPFailedConnections(stat)
 		}
 	}
 }
@@ -146,4 +163,12 @@ func (r *statMetricsReporter) observeTCPRtt(stat *ebpf.Stat) {
 	}
 	r.tcpRtt.WithLabelValues(labelValues(stat, r.statsAttrs)...).
 		Metric.Observe(float64(stat.TCPRtt.SrttUs) / 1_000_000.0)
+}
+
+func (r *statMetricsReporter) observeTCPFailedConnections(stat *ebpf.Stat) {
+	if r.tcpFailedConnections == nil || stat.TCPFailedConnection == nil {
+		return
+	}
+	r.tcpFailedConnections.WithLabelValues(labelValues(stat, r.tcpFailedConnectionsAttrs)...).
+		Metric.Add(1)
 }

--- a/pkg/export/prom/prom_stats.go
+++ b/pkg/export/prom/prom_stats.go
@@ -43,7 +43,7 @@ type statMetricsReporter struct {
 
 	promConnect *connector.PrometheusManager
 
-	statsAttrs                []attributes.Field[*ebpf.Stat, string] // TODO change with tcpRttAttrs
+	tcpRttAttrs               []attributes.Field[*ebpf.Stat, string]
 	tcpFailedConnectionsAttrs []attributes.Field[*ebpf.Stat, string]
 
 	clock *expire.CachedClock
@@ -98,14 +98,13 @@ func newStatsReporter(
 
 	var register []prometheus.Collector
 	log := slog.With("component", "prom.StatsEndpoint")
-	if cfg.CommonCfg.Features.StatMetrics() {
-		// TODO add granular check on metric X
-		log.Debug("registering stat metrics")
-		mr.statsAttrs = attributes.PrometheusGetters(
+	if cfg.CommonCfg.Features.StatsTCPRtt() {
+		log.Debug("registering stat tcp rtt metric")
+
+		mr.tcpRttAttrs = attributes.PrometheusGetters(
 			ebpf.StatStringGetters,
 			provider.For(attributes.StatTCPRtt))
 
-		// TCP RTT
 		mr.tcpRtt = NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name: attributes.StatTCPRtt.Prom,
 			Help: "measures the smoothed TCP RTT as calculated by the kernel in seconds",
@@ -114,20 +113,23 @@ func newStatsReporter(
 			NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
 			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
 			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
-		}, labelNames(mr.statsAttrs)).MetricVec, clock.Time, cfg.Config.TTL)
+		}, labelNames(mr.tcpRttAttrs)).MetricVec, clock.Time, cfg.Config.TTL)
+		register = append(register, mr.tcpRtt)
+	}
+
+	if cfg.CommonCfg.Features.StatsTCPFailedConnections() {
+		log.Debug("registering stat tcp failed connections metric")
 
 		mr.tcpFailedConnectionsAttrs = attributes.PrometheusGetters(
 			ebpf.StatStringGetters,
 			provider.For(attributes.StatTCPFailedConnections))
 
-		// TCP failed connection
 		mr.tcpFailedConnections = NewExpirer[prometheus.Counter](prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: attributes.StatTCPFailedConnections.Prom,
 			Help: "counts the TCP failed connections between 2 endpoints",
 		}, labelNames(mr.tcpFailedConnectionsAttrs)).MetricVec, clock.Time, cfg.Config.TTL)
 
 		register = append(register, mr.tcpFailedConnections)
-
 	}
 
 	if cfg.Config.Registry != nil {
@@ -161,7 +163,7 @@ func (r *statMetricsReporter) observeTCPRtt(stat *ebpf.Stat) {
 	if r.tcpRtt == nil || stat.TCPRtt == nil {
 		return
 	}
-	r.tcpRtt.WithLabelValues(labelValues(stat, r.statsAttrs)...).
+	r.tcpRtt.WithLabelValues(labelValues(stat, r.tcpRttAttrs)...).
 		Metric.Observe(float64(stat.TCPRtt.SrttUs) / 1_000_000.0)
 }
 

--- a/pkg/internal/statsolly/ebpf/stat.go
+++ b/pkg/internal/statsolly/ebpf/stat.go
@@ -11,6 +11,31 @@ type StatType uint8
 
 const (
 	StatTypeTCPRtt StatType = iota + 1
+	StatTypeTCPFailedConnection
+)
+
+type TCPFailReasonType string
+
+const (
+	Unknown           TCPFailReasonType = "unkown"
+	ConnectionRefused TCPFailReasonType = "refused"
+	ConnectionReset   TCPFailReasonType = "reset"
+	TimedOut          TCPFailReasonType = "timed-out"
+	HostUnreachable   TCPFailReasonType = "host-unreachable"
+	NetUnreachable    TCPFailReasonType = "net-unreachable"
+	Other             TCPFailReasonType = "other"
+)
+
+type TCPFailReasonTypeCode uint8
+
+const (
+	CodeUnknown           TCPFailReasonTypeCode = 0
+	CodeConnectionRefused TCPFailReasonTypeCode = 1
+	CodeConnectionReset   TCPFailReasonTypeCode = 2
+	CodeTimedOut          TCPFailReasonTypeCode = 3
+	CodeHostUnreachable   TCPFailReasonTypeCode = 4
+	CodeNetUnreachable    TCPFailReasonTypeCode = 5
+	CodeOther             TCPFailReasonTypeCode = 255
 )
 
 // Stat contains accumulated metrics from a stat, with extra metadata
@@ -19,8 +44,9 @@ const (
 // in pkg/internal/statsolly/ebpf/stat_getters.go and getDefinitions in
 // pkg/export/attributes/attr_defs.go
 type Stat struct {
-	Type   StatType `json:"type"`
-	TCPRtt *TCPRtt  `json:"-"`
+	Type                StatType             `json:"type"`
+	TCPRtt              *TCPRtt              `json:"-"`
+	TCPFailedConnection *TCPFailedConnection `json:"-"`
 
 	// Attrs of the flow record: source/destination, OBI IP, etc...
 	CommonAttrs pipe.CommonAttrs
@@ -28,4 +54,8 @@ type Stat struct {
 
 type TCPRtt struct {
 	SrttUs uint32 `json:"srtt_us"`
+}
+
+type TCPFailedConnection struct {
+	Reason uint8 `json:"reason"`
 }

--- a/pkg/internal/statsolly/ebpf/stat.go
+++ b/pkg/internal/statsolly/ebpf/stat.go
@@ -26,6 +26,7 @@ const (
 	Other             TCPFailReasonType = "other"
 )
 
+// TCPFailReasonTypeCode mirrors enum tcp_fail_reason in bpf/statsolly/tp_tcp.c.
 type TCPFailReasonTypeCode uint8
 
 const (

--- a/pkg/internal/statsolly/ebpf/stat.go
+++ b/pkg/internal/statsolly/ebpf/stat.go
@@ -17,7 +17,7 @@ const (
 type TCPFailReasonType string
 
 const (
-	Unknown           TCPFailReasonType = "unkown"
+	Unknown           TCPFailReasonType = "unknown"
 	ConnectionRefused TCPFailReasonType = "refused"
 	ConnectionReset   TCPFailReasonType = "reset"
 	TimedOut          TCPFailReasonType = "timed-out"

--- a/pkg/internal/statsolly/ebpf/stat_getters.go
+++ b/pkg/internal/statsolly/ebpf/stat_getters.go
@@ -45,6 +45,9 @@ func StatGetters(name attr.Name) (attributes.Getter[*Stat, attribute.KeyValue], 
 		getter = func(s *Stat) attribute.KeyValue { return attribute.String(string(attr.DstZone), s.CommonAttrs.DstZone) }
 	case attr.TCPFailedConnectionReason:
 		getter = func(s *Stat) attribute.KeyValue {
+			if s.TCPFailedConnection == nil {
+				return attribute.String(string(attr.TCPFailedConnectionReason), string(Unknown))
+			}
 			return attribute.String(string(attr.TCPFailedConnectionReason), tcpFailReasonStr(s.TCPFailedConnection.Reason))
 		}
 	default:

--- a/pkg/internal/statsolly/ebpf/stat_getters.go
+++ b/pkg/internal/statsolly/ebpf/stat_getters.go
@@ -43,6 +43,10 @@ func StatGetters(name attr.Name) (attributes.Getter[*Stat, attribute.KeyValue], 
 		getter = func(s *Stat) attribute.KeyValue { return attribute.String(string(attr.SrcZone), s.CommonAttrs.SrcZone) }
 	case attr.DstZone:
 		getter = func(s *Stat) attribute.KeyValue { return attribute.String(string(attr.DstZone), s.CommonAttrs.DstZone) }
+	case attr.TCPFailedConnectionReason:
+		getter = func(s *Stat) attribute.KeyValue {
+			return attribute.String(string(attr.TCPFailedConnectionReason), tcpFailReasonStr(s.TCPFailedConnection.Reason))
+		}
 	default:
 		getter = func(s *Stat) attribute.KeyValue { return attribute.String(string(name), s.CommonAttrs.Metadata[name]) }
 	}
@@ -54,4 +58,23 @@ func StatStringGetters(name attr.Name) (attributes.Getter[*Stat, string], bool) 
 		return func(s *Stat) string { return g(s).Value.Emit() }, true
 	}
 	return nil, false
+}
+
+func tcpFailReasonStr(reason uint8) string {
+	switch TCPFailReasonTypeCode(reason) {
+	case CodeConnectionRefused:
+		return string(ConnectionRefused)
+	case CodeConnectionReset:
+		return string(ConnectionReset)
+	case CodeTimedOut:
+		return string(TimedOut)
+	case CodeHostUnreachable:
+		return string(HostUnreachable)
+	case CodeNetUnreachable:
+		return string(NetUnreachable)
+	case CodeOther:
+		return string(Other)
+	default:
+		return string(Unknown)
+	}
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -22,8 +22,19 @@ import (
 	ebpfconvenience "go.opentelemetry.io/obi/pkg/internal/ebpf/convenience"
 )
 
-type StatsTCPRtt StatsTcpRttT
-type StatsTCPFailedConnection StatsTcpFailedConnectionT
+type (
+	StatsTCPRtt              StatsTcpRttT
+	StatsTCPFailedConnection StatsTcpFailedConnectionT
+)
+
+// Hook point names, grouped by attach type.
+const (
+	// Kprobes: kernel function names.
+	KprobeTCPClose = "tcp_close"
+
+	// Tracepoints: group/name.
+	TracepointInetSockSetState = "sock/inet_sock_set_state"
+)
 
 // $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -type tcp_rtt_t -type tcp_failed_connection_t -target amd64,arm64 Stats ../../../../bpf/statsolly/stats.c -- -I../../../../bpf
@@ -62,7 +73,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
 	}
 
 	kps := map[string]ebpfcommon.ProbeDesc{
-		"tcp_close": {
+		KprobeTCPClose: {
 			Required: true,
 			Start:    objects.ObiKprobeTcpCloseSrtt,
 		},
@@ -73,7 +84,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
 	}
 
 	tps := map[string]ebpfcommon.ProbeDesc{
-		"sock/inet_sock_set_state": { // TODO add names at the beginning of the file, like a list of consts
+		TracepointInetSockSetState: {
 			Required: true,
 			Start:    objects.ObiTracepointInetSockSetState,
 		},

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 
 	"go.opentelemetry.io/obi/pkg/config"
+	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	ebpfconvenience "go.opentelemetry.io/obi/pkg/internal/ebpf/convenience"
 )
 
@@ -58,17 +59,21 @@ func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
 		return nil, fmt.Errorf("loading stats eBPF spec: %w", err)
 	}
 
-	ktc, err := link.Kprobe("tcp_close", objects.ObiKprobeTcpCloseSrtt, nil)
+	probes := map[string]ebpfcommon.ProbeDesc{
+		"tcp_close": {
+			Required: true,
+			Start:    objects.ObiKprobeTcpCloseSrtt,
+		},
+	}
+	closables, err := kprobes(tlog, probes)
 	if err != nil {
-		tlog.Error("opening %s: %s", "tcp_close", err)
-		return nil, fmt.Errorf("opening kprobe: %w", err)
+		return nil, err
 	}
 
-	var closables []io.Closer
 	return &StatsFetcher{
 		log:         tlog,
 		statsEvents: objects.StatsEvents,
-		closables:   append(closables, ktc),
+		closables:   closables,
 	}, nil
 }
 
@@ -89,4 +94,33 @@ func (m *StatsFetcher) Close() error {
 // The caller (ForwardRingbuf) is responsible for creating and closing the reader.
 func (m *StatsFetcher) StatsEventsMap() *ebpf.Map {
 	return m.statsEvents
+}
+
+func kprobes(log *slog.Logger, probes map[string]ebpfcommon.ProbeDesc) ([]io.Closer, error) {
+	var closables []io.Closer
+	for funcName, desc := range probes {
+		if desc.Start != nil {
+			kp, err := link.Kprobe(funcName, desc.Start, nil)
+			if err != nil {
+				if desc.Required {
+					return closables, fmt.Errorf("kprobe %s: %w", funcName, err)
+				}
+				log.Warn("kprobe failed", "function", funcName, "error", err)
+				continue
+			}
+			closables = append(closables, kp)
+		}
+		if desc.End != nil {
+			krp, err := link.Kretprobe(funcName, desc.End, nil)
+			if err != nil {
+				if desc.Required {
+					return closables, fmt.Errorf("kretprobe %s: %w", funcName, err)
+				}
+				log.Warn("kretprobe failed", "function", funcName, "error", err)
+				continue
+			}
+			closables = append(closables, krp)
+		}
+	}
+	return closables, nil
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 
 	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/export"
 	ebpfconvenience "go.opentelemetry.io/obi/pkg/internal/ebpf/convenience"
 )
 
@@ -25,6 +26,12 @@ type (
 	StatsTCPRtt              StatsTcpRttT
 	StatsTCPFailedConnection StatsTcpFailedConnectionT
 )
+
+type probe struct {
+	name    string
+	program *ebpf.Program
+	enabled bool
+}
 
 // Hook point names, grouped by attach type.
 const (
@@ -48,7 +55,7 @@ func tlog() *slog.Logger {
 	return slog.With("component", "ebpf.StatFetcher")
 }
 
-func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
+func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsFetcher, error) {
 	tlog := tlog()
 	if err := rlimit.RemoveMemlock(); err != nil {
 		tlog.Warn("can't remove mem lock. The agent could not be able to start eBPF programs",
@@ -73,31 +80,49 @@ func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
 
 	var closables []io.Closer
 
-	for funcName, program := range map[string]*ebpf.Program{
-		KprobeTCPClose: objects.ObiKprobeTcpCloseSrtt,
+	// kprobes
+	for _, k := range []probe{
+		{
+			name:    KprobeTCPClose,
+			program: objects.ObiKprobeTcpCloseSrtt,
+			enabled: features.StatsTCPRtt(),
+		},
 	} {
-		kp, kerr := link.Kprobe(funcName, program, nil)
-		if kerr != nil {
-			closeAll(closables)
-			return nil, fmt.Errorf("kprobe attachment failed %s: %w", funcName, kerr)
+		if !k.enabled {
+			continue
 		}
-		closables = append(closables, kp)
+
+		l, err := link.Kprobe(k.name, k.program, nil)
+		if err != nil {
+			closeAll(closables)
+			return nil, fmt.Errorf("failed kprobe attachment %s: %w", k.name, err)
+		}
+		closables = append(closables, l)
 	}
 
-	for funcName, program := range map[string]*ebpf.Program{
-		TracepointInetSockSetState: objects.ObiTracepointInetSockSetState,
+	// tracepoints
+	for _, t := range []probe{
+		{
+			name:    TracepointInetSockSetState,
+			program: objects.ObiTracepointInetSockSetState,
+			enabled: features.StatsTCPFailedConnections(),
+		},
 	} {
-		parts := strings.SplitN(funcName, "/", 2)
+		if !t.enabled {
+			continue
+		}
+
+		parts := strings.SplitN(t.name, "/", 2)
 		if len(parts) != 2 {
 			closeAll(closables)
-			return nil, fmt.Errorf("invalid tracepoint %q: must be group/name", funcName)
+			return nil, fmt.Errorf("invalid tracepoint %q: must be group/name", t.name)
 		}
-		tp, terr := link.Tracepoint(parts[0], parts[1], program, nil)
-		if terr != nil {
+		l, err := link.Tracepoint(parts[0], parts[1], t.program, nil)
+		if err != nil {
 			closeAll(closables)
-			return nil, fmt.Errorf("tracepoint attachment failed %s: %w", funcName, terr)
+			return nil, fmt.Errorf("failed tracepoint attachment %s: %w", t.name, err)
 		}
-		closables = append(closables, tp)
+		closables = append(closables, l)
 	}
 
 	return &StatsFetcher{

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/ebpf/rlimit"
 
 	"go.opentelemetry.io/obi/pkg/config"
-	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	ebpfconvenience "go.opentelemetry.io/obi/pkg/internal/ebpf/convenience"
 )
 
@@ -72,35 +71,39 @@ func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
 		return nil, fmt.Errorf("loading stats eBPF spec: %w", err)
 	}
 
-	kps := map[string]ebpfcommon.ProbeDesc{
-		KprobeTCPClose: {
-			Required: true,
-			Start:    objects.ObiKprobeTcpCloseSrtt,
-		},
-	}
-	kpClosables, err := kprobes(tlog, kps)
-	if err != nil {
-		closeAll(kpClosables)
-		return nil, err
+	var closables []io.Closer
+
+	for funcName, program := range map[string]*ebpf.Program{
+		KprobeTCPClose: objects.ObiKprobeTcpCloseSrtt,
+	} {
+		kp, kerr := link.Kprobe(funcName, program, nil)
+		if kerr != nil {
+			closeAll(closables)
+			return nil, fmt.Errorf("kprobe attachment failed %s: %w", funcName, kerr)
+		}
+		closables = append(closables, kp)
 	}
 
-	tps := map[string]ebpfcommon.ProbeDesc{
-		TracepointInetSockSetState: {
-			Required: true,
-			Start:    objects.ObiTracepointInetSockSetState,
-		},
-	}
-	tpClosables, err := tracepoints(tlog, tps)
-	if err != nil {
-		closeAll(kpClosables)
-		closeAll(tpClosables)
-		return nil, err
+	for funcName, program := range map[string]*ebpf.Program{
+		TracepointInetSockSetState: objects.ObiTracepointInetSockSetState,
+	} {
+		parts := strings.SplitN(funcName, "/", 2)
+		if len(parts) != 2 {
+			closeAll(closables)
+			return nil, fmt.Errorf("invalid tracepoint %q: must be group/name", funcName)
+		}
+		tp, terr := link.Tracepoint(parts[0], parts[1], program, nil)
+		if terr != nil {
+			closeAll(closables)
+			return nil, fmt.Errorf("tracepoint attachment failed %s: %w", funcName, terr)
+		}
+		closables = append(closables, tp)
 	}
 
 	return &StatsFetcher{
 		log:         tlog,
 		statsEvents: objects.StatsEvents,
-		closables:   append(kpClosables, tpClosables...),
+		closables:   closables,
 	}, nil
 }
 
@@ -129,56 +132,4 @@ func (m *StatsFetcher) Close() error {
 // The caller (ForwardRingbuf) is responsible for creating and closing the reader.
 func (m *StatsFetcher) StatsEventsMap() *ebpf.Map {
 	return m.statsEvents
-}
-
-func kprobes(log *slog.Logger, probes map[string]ebpfcommon.ProbeDesc) ([]io.Closer, error) {
-	var closables []io.Closer
-	for funcName, desc := range probes {
-		if desc.Start != nil {
-			kp, err := link.Kprobe(funcName, desc.Start, nil)
-			if err != nil {
-				if desc.Required {
-					return closables, fmt.Errorf("kprobe %s: %w", funcName, err)
-				}
-				log.Warn("kprobe failed", "function", funcName, "error", err)
-				continue
-			}
-			closables = append(closables, kp)
-		}
-		if desc.End != nil {
-			krp, err := link.Kretprobe(funcName, desc.End, nil)
-			if err != nil {
-				if desc.Required {
-					return closables, fmt.Errorf("kretprobe %s: %w", funcName, err)
-				}
-				log.Warn("kretprobe failed", "function", funcName, "error", err)
-				continue
-			}
-			closables = append(closables, krp)
-		}
-	}
-	return closables, nil
-}
-
-func tracepoints(log *slog.Logger, probes map[string]ebpfcommon.ProbeDesc) ([]io.Closer, error) {
-	var closables []io.Closer
-	for funcName, desc := range probes {
-		if desc.Start == nil {
-			continue
-		}
-		parts := strings.SplitN(funcName, "/", 2)
-		if len(parts) != 2 {
-			return closables, fmt.Errorf("invalid tracepoint %q: must be group/name", funcName)
-		}
-		tp, err := link.Tracepoint(parts[0], parts[1], desc.Start, nil)
-		if err != nil {
-			if desc.Required {
-				return closables, fmt.Errorf("tracepoint %s: %w", funcName, err)
-			}
-			log.Warn("tracepoint failed", "tracepoint", funcName, "error", err)
-			continue
-		}
-		closables = append(closables, tp)
-	}
-	return closables, nil
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -80,6 +80,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
 	}
 	kpClosables, err := kprobes(tlog, kps)
 	if err != nil {
+		closeAll(kpClosables)
 		return nil, err
 	}
 
@@ -91,6 +92,8 @@ func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
 	}
 	tpClosables, err := tracepoints(tlog, tps)
 	if err != nil {
+		closeAll(kpClosables)
+		closeAll(tpClosables)
 		return nil, err
 	}
 
@@ -99,6 +102,14 @@ func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
 		statsEvents: objects.StatsEvents,
 		closables:   append(kpClosables, tpClosables...),
 	}, nil
+}
+
+func closeAll(closables []io.Closer) {
+	for _, c := range closables {
+		if c != nil {
+			c.Close()
+		}
+	}
 }
 
 // Close any resources that are taken

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 
 	"github.com/cilium/ebpf"
@@ -22,9 +23,10 @@ import (
 )
 
 type StatsTCPRtt StatsTcpRttT
+type StatsTCPFailedConnection StatsTcpFailedConnectionT
 
 // $BPF_CLANG and $BPF_CFLAGS are set by the Makefile.
-//go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -type tcp_rtt_t -target amd64,arm64 Stats ../../../../bpf/statsolly/k_tcp.c -- -I../../../../bpf
+//go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -type tcp_rtt_t -type tcp_failed_connection_t -target amd64,arm64 Stats ../../../../bpf/statsolly/stats.c -- -I../../../../bpf
 
 type StatsFetcher struct {
 	log         *slog.Logger
@@ -59,13 +61,24 @@ func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
 		return nil, fmt.Errorf("loading stats eBPF spec: %w", err)
 	}
 
-	probes := map[string]ebpfcommon.ProbeDesc{
+	kps := map[string]ebpfcommon.ProbeDesc{
 		"tcp_close": {
 			Required: true,
 			Start:    objects.ObiKprobeTcpCloseSrtt,
 		},
 	}
-	closables, err := kprobes(tlog, probes)
+	kpClosables, err := kprobes(tlog, kps)
+	if err != nil {
+		return nil, err
+	}
+
+	tps := map[string]ebpfcommon.ProbeDesc{
+		"sock/inet_sock_set_state": { // TODO add names at the beginning of the file, like a list of consts
+			Required: true,
+			Start:    objects.ObiTracepointInetSockSetState,
+		},
+	}
+	tpClosables, err := tracepoints(tlog, tps)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +86,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer) (*StatsFetcher, error) {
 	return &StatsFetcher{
 		log:         tlog,
 		statsEvents: objects.StatsEvents,
-		closables:   closables,
+		closables:   append(kpClosables, tpClosables...),
 	}, nil
 }
 
@@ -121,6 +134,29 @@ func kprobes(log *slog.Logger, probes map[string]ebpfcommon.ProbeDesc) ([]io.Clo
 			}
 			closables = append(closables, krp)
 		}
+	}
+	return closables, nil
+}
+
+func tracepoints(log *slog.Logger, probes map[string]ebpfcommon.ProbeDesc) ([]io.Closer, error) {
+	var closables []io.Closer
+	for funcName, desc := range probes {
+		if desc.Start == nil {
+			continue
+		}
+		parts := strings.SplitN(funcName, "/", 2)
+		if len(parts) != 2 {
+			return closables, fmt.Errorf("invalid tracepoint %q: must be group/name", funcName)
+		}
+		tp, err := link.Tracepoint(parts[0], parts[1], desc.Start, nil)
+		if err != nil {
+			if desc.Required {
+				return closables, fmt.Errorf("tracepoint %s: %w", funcName, err)
+			}
+			log.Warn("tracepoint failed", "tracepoint", funcName, "error", err)
+			continue
+		}
+		closables = append(closables, tp)
 	}
 	return closables, nil
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
@@ -29,6 +29,20 @@ type StatsTCPRtt struct {
 	}
 }
 
+type StatsTcpFailedConnectionT struct {
+	_      structs.HostLayout
+	Flags  uint8
+	Reason uint8
+	Pad    [2]uint8
+	Conn   struct {
+		_      structs.HostLayout
+		S_addr [16]uint8 //nolint:revive,staticcheck
+		D_addr [16]uint8 //nolint:revive,staticcheck
+		S_port uint16    //nolint:revive,staticcheck
+		D_port uint16    //nolint:revive,staticcheck
+	}
+}
+
 func NewStatsFetcher(_ *config.EBPFTracer) (*StatsFetcher, error) {
 	return nil, nil
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
@@ -11,6 +11,7 @@ import (
 	ciliumebpf "github.com/cilium/ebpf"
 
 	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/export"
 )
 
 type StatsFetcher struct{}
@@ -43,7 +44,7 @@ type StatsTCPFailedConnection struct {
 	}
 }
 
-func NewStatsFetcher(_ *config.EBPFTracer) (*StatsFetcher, error) {
+func NewStatsFetcher(_ *config.EBPFTracer, _ *export.Features) (*StatsFetcher, error) {
 	return nil, nil
 }
 

--- a/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
@@ -29,7 +29,7 @@ type StatsTCPRtt struct {
 	}
 }
 
-type StatsTcpFailedConnectionT struct {
+type StatsTCPFailedConnection struct {
 	_      structs.HostLayout
 	Flags  uint8
 	Reason uint8

--- a/pkg/internal/statsolly/stats/tracer_ringbuf.go
+++ b/pkg/internal/statsolly/stats/tracer_ringbuf.go
@@ -117,7 +117,7 @@ func readTCPFailedConnectionsIntoStat(record *ringbuf.Record) (ebpf.Stat, error)
 
 	sourcePort := event.Conn.S_port
 	return ebpf.Stat{
-		Type: ebpf.StatTypeTCPRtt,
+		Type: ebpf.StatTypeTCPFailedConnection,
 		TCPFailedConnection: &ebpf.TCPFailedConnection{
 			Reason: event.Reason,
 		},

--- a/pkg/internal/statsolly/stats/tracer_ringbuf.go
+++ b/pkg/internal/statsolly/stats/tracer_ringbuf.go
@@ -108,7 +108,7 @@ func readTCPFailedConnectionsIntoStat(record *ringbuf.Record) (ebpf.Stat, error)
 	}
 
 	var srcAddr, dstAddr pipe.IPAddr
-	var destinationPort uint16 = 0
+	var destinationPort uint16
 	if event.Conn.S_port != 0 || event.Conn.D_port != 0 {
 		srcAddr = pipe.IPAddr(event.Conn.S_addr)
 		dstAddr = pipe.IPAddr(event.Conn.D_addr)

--- a/pkg/internal/statsolly/stats/tracer_ringbuf.go
+++ b/pkg/internal/statsolly/stats/tracer_ringbuf.go
@@ -65,6 +65,8 @@ func handleStatEvent(record *ringbuf.Record) (ebpf.Stat, error) {
 	switch eventType {
 	case ebpf.StatTypeTCPRtt:
 		return readTCPRttIntoStat(record)
+	case ebpf.StatTypeTCPFailedConnection:
+		return readTCPFailedConnectionsIntoStat(record)
 	default:
 		return ebpf.Stat{}, fmt.Errorf("unknown stats event [type %d]", uint8(eventType))
 	}
@@ -89,6 +91,35 @@ func readTCPRttIntoStat(record *ringbuf.Record) (ebpf.Stat, error) {
 		Type: ebpf.StatTypeTCPRtt,
 		TCPRtt: &ebpf.TCPRtt{
 			SrttUs: event.SrttUs,
+		},
+		CommonAttrs: pipe.CommonAttrs{
+			SrcAddr: srcAddr,
+			DstAddr: dstAddr,
+			SrcPort: sourcePort,
+			DstPort: destinationPort,
+		},
+	}, nil
+}
+
+func readTCPFailedConnectionsIntoStat(record *ringbuf.Record) (ebpf.Stat, error) {
+	event, err := ebpfcommon.ReinterpretCast[ebpf.StatsTCPFailedConnection](record.RawSample)
+	if err != nil {
+		return ebpf.Stat{}, err
+	}
+
+	var srcAddr, dstAddr pipe.IPAddr
+	var destinationPort uint16 = 0
+	if event.Conn.S_port != 0 || event.Conn.D_port != 0 {
+		srcAddr = pipe.IPAddr(event.Conn.S_addr)
+		dstAddr = pipe.IPAddr(event.Conn.D_addr)
+		destinationPort = event.Conn.D_port
+	}
+
+	sourcePort := event.Conn.S_port
+	return ebpf.Stat{
+		Type: ebpf.StatTypeTCPRtt,
+		TCPFailedConnection: &ebpf.TCPFailedConnection{
+			Reason: event.Reason,
 		},
 		CommonAttrs: pipe.CommonAttrs{
 			SrcAddr: srcAddr,

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -631,10 +631,10 @@ func (c *Config) Validate() error {
 	}
 
 	if !c.Enabled(FeatureNetO11y) && !c.Enabled(FeatureAppO11y) && !c.Enabled(FeatureStatsO11y) {
-		return ConfigError("at least one of 'network', 'application' or 'stats' features must be enabled. " +
-			"Enable an OpenTelemetry or Prometheus metrics export, then enable any of the network*, application* or stats*" +
-			"features using the 'OTEL_EBPF_METRICS_FEATURES=network,application,stats' environment variable " +
-			"or 'meter_provider: { features: [network,application,stats] }' in the YAML configuration file. ")
+		return ConfigError("at least one feature must be enabled (network*, application* or stats* prefixed). " +
+			"Enable an OpenTelemetry or Prometheus metrics export and select features " +
+			"using the 'OTEL_EBPF_METRICS_FEATURES' environment variable (e.g. 'all' to enable everything) " +
+			"or 'meter_provider: { features: [...] }' in the YAML configuration file.")
 	}
 
 	if c.willUseTC() {

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -631,10 +631,10 @@ func (c *Config) Validate() error {
 	}
 
 	if !c.Enabled(FeatureNetO11y) && !c.Enabled(FeatureAppO11y) && !c.Enabled(FeatureStatsO11y) {
-		return ConfigError("at least one feature must be enabled (network*, application* or stats* prefixed). " +
-			"Enable an OpenTelemetry or Prometheus metrics export and select features " +
-			"using the 'OTEL_EBPF_METRICS_FEATURES' environment variable (e.g. 'all' to enable everything) " +
-			"or 'meter_provider: { features: [...] }' in the YAML configuration file.")
+		return ConfigError("at least one of 'network', 'application' or 'stats' features must be enabled. " +
+			"Enable an OpenTelemetry or Prometheus metrics export, then enable any of the network*, application* or stats*" +
+			"features using the 'OTEL_EBPF_METRICS_FEATURES=network,application,stats' environment variable " +
+			"or 'meter_provider: { features: [network,application,stats] }' in the YAML configuration file. ")
 	}
 
 	if c.willUseTC() {

--- a/pkg/statsolly/agent/agent.go
+++ b/pkg/statsolly/agent/agent.go
@@ -15,6 +15,7 @@ import (
 	ciliumebpf "github.com/cilium/ebpf"
 
 	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/internal/statsolly/ebpf"
 	stats "go.opentelemetry.io/obi/pkg/internal/statsolly/stats"
 	"go.opentelemetry.io/obi/pkg/netip"
@@ -98,7 +99,7 @@ func StatsAgent(ctxInfo *global.ContextInfo, cfg *obi.Config) (*Stats, error) {
 	}
 	alog.Debug("agent IP: " + agentIP.String())
 
-	statsFetcher, err = newFetcher(&cfg.EBPF)
+	statsFetcher, err = newFetcher(&cfg.EBPF, &cfg.Metrics.Features)
 	if err != nil {
 		return nil, err
 	}
@@ -106,8 +107,8 @@ func StatsAgent(ctxInfo *global.ContextInfo, cfg *obi.Config) (*Stats, error) {
 	return statsAgent(ctxInfo, cfg, statsFetcher, agentIP)
 }
 
-func newFetcher(cfg *config.EBPFTracer) (ebpFetcher, error) {
-	return ebpf.NewStatsFetcher(cfg)
+func newFetcher(cfg *config.EBPFTracer, features *export.Features) (ebpFetcher, error) {
+	return ebpf.NewStatsFetcher(cfg, features)
 }
 
 // statsAgent is a private constructor with injectable dependencies, usable for tests

--- a/pkg/statsolly/agent/pipeline_test.go
+++ b/pkg/statsolly/agent/pipeline_test.go
@@ -46,7 +46,7 @@ func TestFilter(t *testing.T) {
 				Port: promPort,
 				TTL:  time.Hour,
 			},
-			Metrics: perapp.MetricsConfig{Features: export.FeatureStatsTcpRtt},
+			Metrics: perapp.MetricsConfig{Features: export.FeatureStatsTCPRtt},
 			Attributes: obi.Attributes{Select: attributes.Selection{
 				attributes.StatTCPRtt.Section: attributes.InclusionLists{
 					Include: []string{"obi_ip", "dst_port", "src_port"},

--- a/pkg/statsolly/agent/pipeline_test.go
+++ b/pkg/statsolly/agent/pipeline_test.go
@@ -46,7 +46,7 @@ func TestFilter(t *testing.T) {
 				Port: promPort,
 				TTL:  time.Hour,
 			},
-			Metrics: perapp.MetricsConfig{Features: export.FeatureStatsTCPRtt},
+			Metrics: perapp.MetricsConfig{Features: export.FeatureStatsTCPRtt | export.FeatureStatsTCPFailedConnections},
 			Attributes: obi.Attributes{Select: attributes.Selection{
 				attributes.StatTCPRtt.Section: attributes.InclusionLists{
 					Include: []string{"obi_ip", "dst_port", "src_port"},

--- a/pkg/statsolly/agent/pipeline_test.go
+++ b/pkg/statsolly/agent/pipeline_test.go
@@ -51,6 +51,9 @@ func TestFilter(t *testing.T) {
 				attributes.StatTCPRtt.Section: attributes.InclusionLists{
 					Include: []string{"obi_ip", "dst_port", "src_port"},
 				},
+				attributes.StatTCPFailedConnections.Section: attributes.InclusionLists{
+					Include: []string{"obi_ip", "dst_port", "src_port", "reason"},
+				},
 			}},
 		},
 	}
@@ -80,6 +83,11 @@ func TestFilter(t *testing.T) {
 		fakeRecord(3333, 8080),
 	}
 
+	ringBuf <- []*ebpf.Stat{
+		fakeFailedConnRecord(555, 666, uint8(ebpf.CodeConnectionRefused)),
+		fakeFailedConnRecord(777, 888, uint8(ebpf.CodeTimedOut)),
+	}
+
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		allMetrics, err := promtest.Scrape(fmt.Sprintf("http://localhost:%d/metrics", promPort))
 		require.NoError(ct, err)
@@ -87,7 +95,10 @@ func TestFilter(t *testing.T) {
 		// Filter for only the metrics you want to verify
 		var filtered []promtest.ScrapedMetric
 		for _, m := range allMetrics {
-			if m.Name == "obi_stat_tcp_rtt_seconds_count" || m.Name == "promhttp_metric_handler_errors_total" {
+			switch m.Name {
+			case "obi_stat_tcp_rtt_seconds_count",
+				"obi_stat_tcp_failed_connections",
+				"promhttp_metric_handler_errors_total":
 				// Reset values to 0 if you don't care about the specific count,
 				// or keep them if you want to verify the Value: 1 seen in your logs.
 				filtered = append(filtered, m)
@@ -100,6 +111,8 @@ func TestFilter(t *testing.T) {
 			{Name: "obi_stat_tcp_rtt_seconds_count", Value: 1, Labels: map[string]string{"obi_ip": "1.2.3.4", "dst_port": "444", "src_port": "333"}},
 			{Name: "obi_stat_tcp_rtt_seconds_count", Value: 1, Labels: map[string]string{"obi_ip": "1.2.3.4", "dst_port": "456", "src_port": "123"}},
 			{Name: "obi_stat_tcp_rtt_seconds_count", Value: 1, Labels: map[string]string{"obi_ip": "1.2.3.4", "dst_port": "8080", "src_port": "3333"}},
+			{Name: "obi_stat_tcp_failed_connections", Value: 1, Labels: map[string]string{"obi_ip": "1.2.3.4", "dst_port": "666", "src_port": "555", "reason": "refused"}},
+			{Name: "obi_stat_tcp_failed_connections", Value: 1, Labels: map[string]string{"obi_ip": "1.2.3.4", "dst_port": "888", "src_port": "777", "reason": "timed-out"}},
 			{Name: "promhttp_metric_handler_errors_total", Value: 0, Labels: map[string]string{"cause": "encoding"}},
 			{Name: "promhttp_metric_handler_errors_total", Value: 0, Labels: map[string]string{"cause": "gathering"}},
 		}, filtered)
@@ -110,6 +123,18 @@ func fakeRecord(srcPort, dstPort uint16) *ebpf.Stat {
 	return &ebpf.Stat{
 		TCPRtt: &ebpf.TCPRtt{
 			SrttUs: 100,
+		},
+		CommonAttrs: pipe.CommonAttrs{
+			SrcPort: srcPort,
+			DstPort: dstPort,
+		},
+	}
+}
+
+func fakeFailedConnRecord(srcPort, dstPort uint16, reason uint8) *ebpf.Stat {
+	return &ebpf.Stat{
+		TCPFailedConnection: &ebpf.TCPFailedConnection{
+			Reason: reason,
 		},
 		CommonAttrs: pipe.CommonAttrs{
 			SrcPort: srcPort,

--- a/pkg/statsolly/agent/pipeline_test.go
+++ b/pkg/statsolly/agent/pipeline_test.go
@@ -46,7 +46,7 @@ func TestFilter(t *testing.T) {
 				Port: promPort,
 				TTL:  time.Hour,
 			},
-			Metrics: perapp.MetricsConfig{Features: export.FeatureStats},
+			Metrics: perapp.MetricsConfig{Features: export.FeatureStatsTcpRtt},
 			Attributes: obi.Attributes{Select: attributes.Selection{
 				attributes.StatTCPRtt.Section: attributes.InclusionLists{
 					Include: []string{"obi_ip", "dst_port", "src_port"},


### PR DESCRIPTION
## Summary

This PR adds TCP failed connections metric to Statsolly. 

Here's an example metric:
```
obi_stat_tcp_failed_connections{dst_address="192.168.x.x",dst_name="frontend-proxy-59cbb58fcd-fhxnj",dst_port="37868",dst_zone="***",k8s_cluster_name="",k8s_dst_name="frontend-proxy-59cbb58fcd-fhxnj",k8s_dst_namespace="default",k8s_dst_node_ip="192.168.x.x.",k8s_dst_node_name="node1",k8s_dst_owner_name="frontend-proxy",k8s_dst_owner_type="Deployment",k8s_dst_type="Pod",k8s_src_name="frontend-64765f9445-sjqrq",k8s_src_namespace="default",k8s_src_node_ip="192.168.x.x.",k8s_src_node_name="i-054820b1045823806",k8s_src_owner_name="frontend",k8s_src_owner_type="Deployment",k8s_src_type="Pod",obi_ip="192.168.x.x.",reason="unknown",service_name="frontend",service_namespace="opentelemetry-demo",service_peer_name="frontend-proxy",service_peer_namespace="opentelemetry-demo",src_address="192.168.x.x",src_name="frontend-64765f9445-sjqrq",src_port="0",src_zone="**"} 1
```
Note: The "reason" label is disabled by default.

To calculate this metric, `tracepoint/sock/inet_sock_set_state` was used. Therefore, I modified the Statsolly agent (stats_tracer) to handle tracepoints and also added support for multiple kprobes for the future.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](../SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
