### PR TITLE
logenricher: add .NET test, document .NET limitations

### DIFF
--- a/devdocs/trace-log-correlation.md
+++ b/devdocs/trace-log-correlation.md
@@ -12,6 +12,8 @@ OBI can enrich JSON log lines with `trace_id` and `span_id` fields, linking logs
   - [Node.js — `async_hooks` before callback + `uv_fs_access` uprobe](#nodejs--async_hooks-before-callback--uv_fs_access-uprobe)
   - [Java — `k_ioctl_java_threads` in the ioctl kprobe](#java--k_ioctl_java_threads-in-the-ioctl-kprobe)
   - [Ruby (Puma) — `rb_ary_shift` uprobe](#ruby-puma--rb_ary_shift-uprobe)
+- [Per-runtime stdout buffering](#per-runtime-stdout-buffering)
+  - [.NET specifics](#net-specifics)
 - [Requirements](#requirements)
 
 ## Overview
@@ -97,8 +99,45 @@ OBI hooks `rb_ary_shift` (Ruby's `Array#shift`), which fires when a Puma worker 
 
 In the direct path, `server_traces_aux` won't have an entry yet (HTTP hasn't been parsed), so step 2 is a harmless no-op.
 
+## Per-runtime stdout buffering
+
+The logenricher reads `traces_ctx_v1[pid_tgid]` at the moment the `write()` syscall fires. If the runtime buffers stdout and flushes asynchronously — on a different thread or after the request handler returns — the trace context for that TID will already be gone, and the log line will not be enriched.
+
+Each runtime behaves differently:
+
+| Runtime | Default stdout behaviour | Works out of the box? |
+|---------|--------------------------|----------------------|
+| Go | `fmt.Println` calls `write()` synchronously on the goroutine | Yes — Go refreshes `traces_ctx_v1` on every goroutine context switch via `runtime.casgstatus` |
+| Node.js | `process.stdout.write()` is synchronous | Yes |
+| Java | `System.out.println()` flushes immediately (PrintStream `autoFlush=true` by default) | Yes |
+| Ruby | `puts` / `STDOUT.syswrite` — both issue `write()`/`writev()` synchronously on the request thread | Yes |
+| Python | stdout is block-buffered when not a TTY (Docker) | **No** — set `PYTHONUNBUFFERED=1` |
+| .NET | `Console.Out` (StreamWriter) is block-buffered when stdout is a pipe | **No** — see below |
+
+### .NET specifics
+
+.NET's `Console.Out` wraps a `StreamWriter` with `AutoFlush = false` by default. When stdout is a pipe (as in Docker), writes are buffered until the buffer fills (4 KB) or the writer is flushed explicitly. The `write()` syscall may fire on a GC finalizer thread or when a later request fills the buffer — in both cases the TID no longer carries trace context.
+
+**Fix**: configure auto-flush at application startup:
+
+```csharp
+var stdout = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
+Console.SetOut(stdout);
+```
+
+**Microsoft.Extensions.Logging `AddConsole()` does not work**, even with `AutoFlush` set. The built-in console logger uses an internal background `Channel`: log entries are queued and drained by a dedicated writer thread whose TID has no trace context. This applies to ASP.NET Core's default logging pipeline.
+
+**Logging frameworks that do work**:
+
+- `Console.WriteLine` with `AutoFlush = true` (synchronous, same thread)
+- Serilog `WriteTo.Console()` — writes synchronously on the calling thread by default
+- NLog `targets/ColoredConsole` with `queueLimit=0` (synchronous mode)
+
+There is no environment variable equivalent to Python's `PYTHONUNBUFFERED=1` for .NET.
+
 ## Requirements
 
 - `CAP_SYS_ADMIN` capability and permission to use `bpf_probe_write_user` (kernel security lockdown mode should be `[none]`)
 - The target application writes logs in **JSON format**
+- Log writes must occur synchronously on the request-handling thread (see [Per-runtime stdout buffering](#per-runtime-stdout-buffering) above)
 - BPFFS mounted at `/sys/fs/bpf` (or another mountpath configurable via `config.ebpf.bpf_fs_path` / `OTEL_EBPF_BPF_FS_PATH`)

--- a/internal/test/integration/components/dotnetserver/Program.cs
+++ b/internal/test/integration/components/dotnetserver/Program.cs
@@ -1,3 +1,13 @@
+using System.Text;
+
+// Flush stdout after every write so the logenricher BPF program sees each JSON
+// line before the HTTP response is returned to the caller. Without AutoFlush,
+// .NET's StreamWriter buffers output and the write syscall may fire after the
+// response, causing the enricher to miss the trace context for that request.
+Console.OutputEncoding = Encoding.UTF8;
+var autoFlushStdout = new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true };
+Console.SetOut(autoFlushStdout);
+
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddHttpClient();
 var app = builder.Build();
@@ -10,5 +20,12 @@ app.MapGet("/greeting", async (HttpClient httpClient) =>
             return Results.Ok(content);
         });
 app.MapGet("/smoke", () => "");
+
+app.MapGet("/json_logger", () =>
+{
+    const string message = "this is a json log from dotnet";
+    Console.WriteLine("{\"message\":\"" + message + "\",\"level\":\"INFO\"}");
+    return Results.Ok(message);
+});
 
 app.Run();

--- a/internal/test/integration/docker-compose-log-enricher.yml
+++ b/internal/test/integration/docker-compose-log-enricher.yml
@@ -54,6 +54,16 @@ services:
       PORT: "3040"
       RAILS_MAX_THREADS: "2"
 
+  testserverdotnet:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/dotnetserver/Dockerfile
+    image: hatest-testserver-logenricher-dotnet
+    networks:
+      - shared
+    ports:
+      - "8386:5266"
+
   obi:
     build:
       context: ../../..
@@ -98,6 +108,8 @@ services:
       testserverjava:
         condition: service_started
       testserverruby:
+        condition: service_started
+      testserverdotnet:
         condition: service_started
 
 networks:

--- a/internal/test/integration/log_enricher_test.go
+++ b/internal/test/integration/log_enricher_test.go
@@ -73,6 +73,13 @@ var (
 		containerImage: "hatest-testserver-logenricher-ruby",
 		message:        "this is a json log from ruby via write",
 	}
+	logEnricherDotNetConstants = testServerConstants{
+		url:            "http://localhost:8386",
+		smokeEndpoint:  "/smoke",
+		logEndpoint:    "/json_logger",
+		containerImage: "hatest-testserver-logenricher-dotnet",
+		message:        "this is a json log from dotnet",
+	}
 )
 
 // logEnricherTestTraceparents are fixed W3C traceparents used by log enricher tests.
@@ -319,6 +326,68 @@ func testLogEnricherRuby(t *testing.T, constants testServerConstants) {
 				continue
 			}
 			if fields["message"] != constants.message {
+				continue
+			}
+			if tid, ok := fields["trace_id"]; ok {
+				lastSpanID[tid] = fields["span_id"]
+			}
+		}
+
+		// Every injected trace_id must appear with a non-empty span_id.
+		for _, tp := range logEnricherTestTraceparents {
+			spanID, found := lastSpanID[tp.traceID]
+			assert.True(ct, found, "no enriched log line found for trace_id %s", tp.traceID)
+			if found {
+				assert.NotEmpty(ct, spanID, "span_id missing for trace_id %s", tp.traceID)
+			}
+		}
+	}, testTimeout, 500*time.Millisecond)
+}
+
+// testLogEnricherDotNet sends concurrent requests with distinct traceparent
+// headers and verifies each enriched log line contains the correct trace_id.
+// ASP.NET Core (Kestrel) dispatches requests on a thread pool, so concurrent
+// requests may run on different threads simultaneously — this exercises whether
+// the logenricher correctly correlates the TID at write time with the trace
+// context established when the HTTP request was received.
+func testLogEnricherDotNet(t *testing.T) {
+	waitForTestComponentsNoMetrics(t, logEnricherDotNetConstants.url+logEnricherDotNetConstants.smokeEndpoint)
+
+	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err)
+	defer cl.Close()
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		var wg sync.WaitGroup
+		for _, tp := range logEnricherTestTraceparents {
+			wg.Add(1)
+			go func(tp struct{ traceID, parentID string }) {
+				defer wg.Done()
+				req, err := http.NewRequest(http.MethodGet,
+					logEnricherDotNetConstants.url+logEnricherDotNetConstants.logEndpoint, nil)
+				if err != nil {
+					return
+				}
+				req.Header.Set("traceparent", fmt.Sprintf("00-%s-%s-01", tp.traceID, tp.parentID))
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					return
+				}
+				resp.Body.Close()
+			}(tp)
+		}
+		wg.Wait()
+
+		containerID := testContainerID(ct, cl, logEnricherDotNetConstants.containerImage)
+		require.NotEmpty(ct, containerID, "could not find test container ID")
+		logs := containerLogs(ct, cl, containerID)
+		require.NotEmpty(ct, logs)
+
+		// Collect the last occurrence of each injected trace_id.
+		lastSpanID := make(map[string]string, len(logEnricherTestTraceparents))
+		for _, line := range logs {
+			var fields map[string]string
+			if json.Unmarshal([]byte(line), &fields) != nil {
 				continue
 			}
 			if tid, ok := fields["trace_id"]; ok {

--- a/internal/test/integration/log_enricher_test.go
+++ b/internal/test/integration/log_enricher_test.go
@@ -93,17 +93,23 @@ var logEnricherTestTraceparents = [5]struct{ traceID, parentID string }{
 	{"deadbeefcafebabe0123456789abcdef", "cafebabe01234567"},
 }
 
-func containerLogs(t require.TestingT, cl *client.Client, containerID string) []string {
+func containerLogs(t assert.TestingT, cl *client.Client, containerID string) []string {
 	reader, err := cl.ContainerLogs(context.TODO(), containerID, client.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 	})
-	require.NoError(t, err)
+	if err != nil {
+		assert.NoError(t, err)
+		return nil
+	}
 	defer reader.Close()
 
 	var stdout, stderr strings.Builder
 	_, err = stdcopy.StdCopy(&stdout, &stderr, reader)
-	require.NoError(t, err)
+	if err != nil {
+		assert.NoError(t, err)
+		return nil
+	}
 
 	combined := stdout.String() + stderr.String()
 
@@ -112,14 +118,19 @@ func containerLogs(t require.TestingT, cl *client.Client, containerID string) []
 	for scanner.Scan() {
 		lines = append(lines, scanner.Text())
 	}
-	require.NoError(t, scanner.Err())
+	if err := scanner.Err(); err != nil {
+		assert.NoError(t, err)
+	}
 
 	return lines
 }
 
-func testContainerID(t require.TestingT, cl *client.Client, image string) string {
+func testContainerID(t assert.TestingT, cl *client.Client, image string) string {
 	result, err := cl.ContainerList(context.TODO(), client.ContainerListOptions{All: true})
-	require.NoError(t, err)
+	if err != nil {
+		assert.NoError(t, err)
+		return ""
+	}
 
 	for _, c := range result.Items {
 		if c.Image == image {
@@ -147,6 +158,7 @@ func testLogEnricherNodeJS(t *testing.T) {
 		// are in-flight simultaneously. Goroutines are staggered by 5 ms so that
 		// requests arrive at the server in array order (server delay is 35 ms,
 		// much larger than the stagger), giving a deterministic log order.
+		errCh := make(chan error, len(logEnricherTestTraceparents))
 		var wg sync.WaitGroup
 		for i, tp := range logEnricherTestTraceparents {
 			wg.Add(1)
@@ -155,11 +167,13 @@ func testLogEnricherNodeJS(t *testing.T) {
 				req, err := http.NewRequest(http.MethodGet,
 					logEnricherNodeJSConstants.url+logEnricherNodeJSConstants.logEndpoint, nil)
 				if err != nil {
+					errCh <- err
 					return
 				}
 				req.Header.Set("traceparent", fmt.Sprintf("00-%s-%s-01", tp.traceID, tp.parentID))
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
+					errCh <- err
 					return
 				}
 				resp.Body.Close()
@@ -171,11 +185,19 @@ func testLogEnricherNodeJS(t *testing.T) {
 			}
 		}
 		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			assert.NoError(ct, err, "HTTP request failed")
+		}
 
 		containerID := testContainerID(ct, cl, logEnricherNodeJSConstants.containerImage)
-		require.NotEmpty(ct, containerID, "could not find test container ID")
+		if !assert.NotEmpty(ct, containerID, "could not find test container ID") {
+			return
+		}
 		logs := containerLogs(ct, cl, containerID)
-		require.NotEmpty(ct, logs)
+		if !assert.NotEmpty(ct, logs) {
+			return
+		}
 
 		// Find the last log-position of each injected trace_id (most recent retry).
 		lastPos := make(map[string]int, len(logEnricherTestTraceparents))
@@ -227,6 +249,7 @@ func testLogEnricherJava(t *testing.T) {
 	defer cl.Close()
 
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		errCh := make(chan error, len(logEnricherTestTraceparents))
 		var wg sync.WaitGroup
 		for _, tp := range logEnricherTestTraceparents {
 			wg.Add(1)
@@ -235,22 +258,32 @@ func testLogEnricherJava(t *testing.T) {
 				req, err := http.NewRequest(http.MethodGet,
 					logEnricherJavaConstants.url+logEnricherJavaConstants.logEndpoint, nil)
 				if err != nil {
+					errCh <- err
 					return
 				}
 				req.Header.Set("traceparent", fmt.Sprintf("00-%s-%s-01", tp.traceID, tp.parentID))
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
+					errCh <- err
 					return
 				}
 				resp.Body.Close()
 			}(tp)
 		}
 		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			assert.NoError(ct, err, "HTTP request failed")
+		}
 
 		containerID := testContainerID(ct, cl, logEnricherJavaConstants.containerImage)
-		require.NotEmpty(ct, containerID, "could not find test container ID")
+		if !assert.NotEmpty(ct, containerID, "could not find test container ID") {
+			return
+		}
 		logs := containerLogs(ct, cl, containerID)
-		require.NotEmpty(ct, logs)
+		if !assert.NotEmpty(ct, logs) {
+			return
+		}
 
 		// Collect the last occurrence of each injected trace_id.
 		lastSpanID := make(map[string]string, len(logEnricherTestTraceparents))
@@ -292,6 +325,7 @@ func testLogEnricherRuby(t *testing.T, constants testServerConstants) {
 		// Fire one request per traceparent concurrently against 2 Puma threads.
 		// The server sleeps 50ms per request, so at least 3 requests will be
 		// queued in the reactor, exercising the reactor→worker handoff path.
+		errCh := make(chan error, len(logEnricherTestTraceparents))
 		var wg sync.WaitGroup
 		for _, tp := range logEnricherTestTraceparents {
 			wg.Add(1)
@@ -300,22 +334,32 @@ func testLogEnricherRuby(t *testing.T, constants testServerConstants) {
 				req, err := http.NewRequest(http.MethodGet,
 					constants.url+constants.logEndpoint, nil)
 				if err != nil {
+					errCh <- err
 					return
 				}
 				req.Header.Set("traceparent", fmt.Sprintf("00-%s-%s-01", tp.traceID, tp.parentID))
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
+					errCh <- err
 					return
 				}
 				resp.Body.Close()
 			}(tp)
 		}
 		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			assert.NoError(ct, err, "HTTP request failed")
+		}
 
 		containerID := testContainerID(ct, cl, constants.containerImage)
-		require.NotEmpty(ct, containerID, "could not find test container ID")
+		if !assert.NotEmpty(ct, containerID, "could not find test container ID") {
+			return
+		}
 		logs := containerLogs(ct, cl, containerID)
-		require.NotEmpty(ct, logs)
+		if !assert.NotEmpty(ct, logs) {
+			return
+		}
 
 		// Collect the last occurrence of each injected trace_id
 		// from log lines matching this test's expected message.
@@ -358,6 +402,7 @@ func testLogEnricherDotNet(t *testing.T) {
 	defer cl.Close()
 
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		errCh := make(chan error, len(logEnricherTestTraceparents))
 		var wg sync.WaitGroup
 		for _, tp := range logEnricherTestTraceparents {
 			wg.Add(1)
@@ -366,22 +411,32 @@ func testLogEnricherDotNet(t *testing.T) {
 				req, err := http.NewRequest(http.MethodGet,
 					logEnricherDotNetConstants.url+logEnricherDotNetConstants.logEndpoint, nil)
 				if err != nil {
+					errCh <- err
 					return
 				}
 				req.Header.Set("traceparent", fmt.Sprintf("00-%s-%s-01", tp.traceID, tp.parentID))
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
+					errCh <- err
 					return
 				}
 				resp.Body.Close()
 			}(tp)
 		}
 		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			assert.NoError(ct, err, "HTTP request failed")
+		}
 
 		containerID := testContainerID(ct, cl, logEnricherDotNetConstants.containerImage)
-		require.NotEmpty(ct, containerID, "could not find test container ID")
+		if !assert.NotEmpty(ct, containerID, "could not find test container ID") {
+			return
+		}
 		logs := containerLogs(ct, cl, containerID)
-		require.NotEmpty(ct, logs)
+		if !assert.NotEmpty(ct, logs) {
+			return
+		}
 
 		// Collect the last occurrence of each injected trace_id.
 		lastSpanID := make(map[string]string, len(logEnricherTestTraceparents))
@@ -417,9 +472,13 @@ func testLogEnricher(t *testing.T, constants testServerConstants) {
 		ti.DoHTTPGet(ct, constants.url+constants.logEndpoint, 200)
 
 		containerID := testContainerID(ct, cl, constants.containerImage)
-		require.NotEmpty(ct, containerID, "could not find test container ID")
+		if !assert.NotEmpty(ct, containerID, "could not find test container ID") {
+			return
+		}
 		logs := containerLogs(ct, cl, containerID)
-		require.NotEmpty(ct, logs)
+		if !assert.NotEmpty(ct, logs) {
+			return
+		}
 
 		logIdx := -1
 		// Loop from the end -- it might be possible that OBI wasn't ready to inject
@@ -431,10 +490,12 @@ func testLogEnricher(t *testing.T, constants testServerConstants) {
 			}
 		}
 
-		require.GreaterOrEqual(ct, logIdx, 0, "no enriched log line found yet")
+		if !assert.GreaterOrEqual(ct, logIdx, 0, "no enriched log line found yet") {
+			return
+		}
 
 		var logFields map[string]string
-		require.NoError(ct, json.Unmarshal([]byte(logs[logIdx]), &logFields))
+		assert.NoError(ct, json.Unmarshal([]byte(logs[logIdx]), &logFields))
 
 		assert.Equal(ct, constants.message, logFields["message"])
 		assert.Equal(ct, "INFO", logFields["level"])

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -818,6 +818,19 @@ func TestSuite_LogEnricherRuby(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_LogEnricherDotNet(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-log-enricher.yml", path.Join(pathOutput, "test-suite-log-enricher-dotnet.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=5266`, `OTEL_EBPF_EXECUTABLE_PATH=`)
+	require.NoError(t, compose.Up())
+
+	t.Run("Log Enricher .NET", func(t *testing.T) {
+		testLogEnricherDotNet(t)
+	})
+	require.NoError(t, compose.Close())
+}
+
 // Helpers
 
 var lockdownPath = "/sys/kernel/security/lockdown"


### PR DESCRIPTION
## Summary

logenricher: add .NET test, document .NET limitations

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
