### PR TITLE
chore: block native-maven-plugin major version upgrades in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -146,6 +146,13 @@
       "matchPackageNames": ["org.springframework.boot:spring-boot-starter-parent"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Block native-maven-plugin major upgrades (v1.0.0 requires GraalVM JDK 21+ which needs coordinated Dockerfile base image updates)",
+      "matchManagers": ["maven"],
+      "matchPackageNames": ["org.graalvm.buildtools:native-maven-plugin"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "labels": [


### PR DESCRIPTION
Follow up to #1778

- Blocks Renovate from auto-opening PRs to upgrade `org.graalvm.buildtools:native-maven-plugin` across major versions
- The upgrade in #1778 requires GraalVM JDK 21+ for its new `reachability-metadata.json` schema, but `javakafka/Dockerfile` and `javatestserver/Dockerfile` are pinned to GraalVM CE 22 (Java 17), causing the OATS kafka test to fail with: `The configured GraalVM reachability metadata repository provides a reachability-metadata schema, but your GraalVM installation does not. Update to the latest GraalVM 21.x or 25.x.`
- The upgrade may be worth doing but requires a coordinated effort: updating the GraalVM base image in `javakafka/Dockerfile`, `javakafka/Dockerfile_400`, `javakafka-lb/Dockerfile_400`, and `javatestserver/Dockerfile`, along with the `JAVA_HOME` env var and `pom400.xml` files