### PR TITLE
Increase saftety check for max w ptr offset

### DIFF
--- a/bpf/gotracer/go_grpc.c
+++ b/bpf/gotracer/go_grpc.c
@@ -677,7 +677,7 @@ int obi_uprobe_transport_http2Client_NewStream_Returns(struct pt_regs *ctx) {
     return 0;
 }
 
-#define MAX_W_PTR_OFFSET 1024
+#define MAX_W_PTR_OFFSET 65535
 
 SEC("uprobe/grpcFramerWriteHeaders")
 int obi_uprobe_grpcFramerWriteHeaders(struct pt_regs *ctx) {


### PR DESCRIPTION
## Summary

Increases the size of the safety check to a larger value to accommodate higher gRPC concurrency.

Partially fixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/564, I'll follow-up with the another PR for the goroutine proposal.

Relates to https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/564

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [X] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
