### PR TITLE
harden couchbase detection to remove wrong classification

### DIFF
--- a/pkg/ebpf/common/couchbase_detect_transform.go
+++ b/pkg/ebpf/common/couchbase_detect_transform.go
@@ -149,6 +149,11 @@ func processCouchbaseEvent(connInfo BpfConnectionInfoT, requestBuf []byte, respo
 			continue
 		}
 
+		if reqPacket.Header().KeyLen() == 0 {
+			slog.Debug("Ignoring Couchbase KV operation with empty key", "opcode", reqPacket.Header().Opcode().String())
+			continue
+		}
+
 		info := &CouchbaseInfo{
 			Operation: reqPacket.Header().Opcode().String(),
 			Key:       reqPacket.KeyString(),

--- a/pkg/ebpf/common/couchbase_detect_transform.go
+++ b/pkg/ebpf/common/couchbase_detect_transform.go
@@ -150,7 +150,7 @@ func processCouchbaseEvent(connInfo BpfConnectionInfoT, requestBuf []byte, respo
 		}
 
 		if reqPacket.Header().KeyLen() == 0 {
-			slog.Debug("Ignoring Couchbase KV operation with empty key", "opcode", reqPacket.Header().Opcode().String())
+			slog.Debug("Ignoring Couchbase KV operation with empty key")
 			continue
 		}
 

--- a/pkg/ebpf/common/tcp_detect_transform_test.go
+++ b/pkg/ebpf/common/tcp_detect_transform_test.go
@@ -566,6 +566,77 @@ func TestReadTCPRequestIntoSpan_MemcachedRequestOnlyWithoutNoreplyIgnored(t *tes
 	testutil.ChannelEmpty(t, out, 100*time.Millisecond)
 }
 
+// TestReadTCPRequestIntoSpan_DNSNotMisclassifiedAsCouchbase guards against a
+// regression where DNS query/response TCP captures were being misclassified as
+// Couchbase memcached binary protocol. The Couchbase magic bytes (0x80, 0x81,
+// 0x82, 0x83, 0x08, 0x18) can collide with the high byte of a random DNS
+// transaction ID, and the subsequent DNS header bytes occasionally satisfied
+// Couchbase's loose header validation.
+func TestReadTCPRequestIntoSpan_DNSNotMisclassifiedAsCouchbase(t *testing.T) {
+	// All packet pairs below were captured from real DNS-over-TCP traffic that
+	// was incorrectly matched as Couchbase prior to tightening validation.
+	tests := []struct {
+		name    string
+		request []byte
+		// response may be empty when the capture was request-only.
+		response []byte
+	}{
+		{
+			// Query A "redis.svc.cluster.local" — classic magic 0x80, KeyLen=256 (DNS flags 0x0100).
+			name:     "classic-magic DNS A query",
+			request:  []byte{128, 15, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 5, 114, 101, 100, 105, 115, 3, 115, 118, 99, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 0, 1, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
+			response: []byte{128, 15, 133, 3, 0, 1, 0, 0, 0, 1, 0, 1, 5, 114, 101, 100, 105, 115, 3, 115, 118, 99, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 0, 1, 0, 1, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 0, 6, 0, 1, 0, 0, 0, 3, 0, 68, 2, 110, 115, 3, 100, 110, 115, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 10, 104, 111, 115, 116, 109, 97, 115, 116, 101, 114, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 105, 223, 110, 169, 0, 0, 28, 32, 0, 0, 7, 8, 0, 1},
+		},
+		{
+			// Query AAAA "redis.default.svc.cluster.local" — alt magic 0x08, header shape passed previous KeyLen+BodyLen check with KeyLen=0.
+			name:    "alt-magic DNS AAAA query",
+			request: []byte{8, 26, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 5, 114, 101, 100, 105, 115, 7, 100, 101, 102, 97, 117, 108, 116, 3, 115, 118, 99, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			// Query AAAA "redis.us-east-2.compute.internal" — classic magic 0x80.
+			name:    "classic-magic DNS internal query",
+			request: []byte{128, 4, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 5, 114, 101, 100, 105, 115, 9, 117, 115, 45, 101, 97, 115, 116, 45, 50, 7, 99, 111, 109, 112, 117, 116, 101, 8, 105, 110, 116, 101, 114, 110, 97, 108, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			// Minimal DNS query "redis" only — alt magic 0x08.
+			name:     "alt-magic tiny DNS query",
+			request:  []byte{8, 29, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 5, 114, 101, 100, 105, 115, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
+			response: []byte{8, 29, 133, 133, 0, 1, 0, 0, 0, 0, 0, 1, 5, 114, 101, 100, 105, 115, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tri := TCPRequestInfo{
+				StartMonotimeNs: 1000000000,
+				EndMonotimeNs:   1000500000,
+				Len:             uint32(len(tt.request)),
+				RespLen:         uint32(len(tt.response)),
+				Direction:       directionSend,
+			}
+			copy(tri.Buf[:], tt.request)
+			copy(tri.Rbuf[:], tt.response)
+			tri.ConnInfo.S_addr = [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 10, 0, 0, 2}
+			tri.ConnInfo.D_addr = [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 10, 0, 0, 10}
+			tri.ConnInfo.S_port = 54321
+			tri.ConnInfo.D_port = 53
+
+			cfg := config.EBPFTracer{HeuristicSQLDetect: false}
+			ctx := NewEBPFParseContext(&cfg, nil, nil)
+
+			binaryRecord := bytes.Buffer{}
+			require.NoError(t, binary.Write(&binaryRecord, binary.LittleEndian, tri))
+
+			fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+
+			span, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &ringbuf.Record{RawSample: binaryRecord.Bytes()}, &fltr)
+			require.NoError(t, err)
+			assert.True(t, ignore, "DNS packet must not produce a span")
+			assert.NotEqual(t, request.EventTypeCouchbaseClient, span.Type, "DNS packet must not be classified as Couchbase")
+		})
+	}
+}
+
 func makeTCPReq(buf string, peerPort uint32) TCPRequestInfo {
 	i := TCPRequestInfo{
 		StartMonotimeNs: 2000 * 1000000,

--- a/pkg/ebpf/common/tcp_detect_transform_test.go
+++ b/pkg/ebpf/common/tcp_detect_transform_test.go
@@ -567,15 +567,16 @@ func TestReadTCPRequestIntoSpan_MemcachedRequestOnlyWithoutNoreplyIgnored(t *tes
 }
 
 // TestReadTCPRequestIntoSpan_DNSNotMisclassifiedAsCouchbase guards against a
-// regression where DNS query/response TCP captures were being misclassified as
-// Couchbase memcached binary protocol. The Couchbase magic bytes (0x80, 0x81,
-// 0x82, 0x83, 0x08, 0x18) can collide with the high byte of a random DNS
-// transaction ID, and the subsequent DNS header bytes occasionally satisfied
-// Couchbase's loose header validation.
+// regression where TCP payloads containing raw DNS query/response messages were
+// being misclassified as Couchbase memcached binary protocol. The Couchbase
+// magic bytes (0x80, 0x81, 0x82, 0x83, 0x08, 0x18) can collide with the first
+// byte of a raw DNS message (the transaction ID high byte), and the subsequent
+// DNS header bytes occasionally satisfied Couchbase's loose header validation.
 func TestReadTCPRequestIntoSpan_DNSNotMisclassifiedAsCouchbase(t *testing.T) {
-	// Each case is a DNS-over-TCP query (and optional response) whose header
-	// bytes collide with Couchbase magic and would have been misclassified
-	// prior to tightening validation. Hostnames use RFC 2606 reserved names.
+	// Each case is a raw DNS message payload carried over TCP-port traffic,
+	// without the 2-byte DNS-over-TCP length prefix. These leading bytes can
+	// collide with Couchbase magic and would have been misclassified prior to
+	// tightening validation. Hostnames use RFC 2606 reserved names.
 	tests := []struct {
 		name     string
 		request  []byte

--- a/pkg/ebpf/common/tcp_detect_transform_test.go
+++ b/pkg/ebpf/common/tcp_detect_transform_test.go
@@ -573,35 +573,35 @@ func TestReadTCPRequestIntoSpan_MemcachedRequestOnlyWithoutNoreplyIgnored(t *tes
 // transaction ID, and the subsequent DNS header bytes occasionally satisfied
 // Couchbase's loose header validation.
 func TestReadTCPRequestIntoSpan_DNSNotMisclassifiedAsCouchbase(t *testing.T) {
-	// All packet pairs below were captured from real DNS-over-TCP traffic that
-	// was incorrectly matched as Couchbase prior to tightening validation.
+	// Each case is a DNS-over-TCP query (and optional response) whose header
+	// bytes collide with Couchbase magic and would have been misclassified
+	// prior to tightening validation. Hostnames use RFC 2606 reserved names.
 	tests := []struct {
-		name    string
-		request []byte
-		// response may be empty when the capture was request-only.
+		name     string
+		request  []byte
 		response []byte
 	}{
 		{
-			// Query A "redis.svc.cluster.local" — classic magic 0x80, KeyLen=256 (DNS flags 0x0100).
+			// Query A "example.com" — classic magic 0x80, KeyLen=256 (DNS flags 0x0100).
 			name:     "classic-magic DNS A query",
-			request:  []byte{128, 15, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 5, 114, 101, 100, 105, 115, 3, 115, 118, 99, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 0, 1, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
-			response: []byte{128, 15, 133, 3, 0, 1, 0, 0, 0, 1, 0, 1, 5, 114, 101, 100, 105, 115, 3, 115, 118, 99, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 0, 1, 0, 1, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 0, 6, 0, 1, 0, 0, 0, 3, 0, 68, 2, 110, 115, 3, 100, 110, 115, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 10, 104, 111, 115, 116, 109, 97, 115, 116, 101, 114, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 105, 223, 110, 169, 0, 0, 28, 32, 0, 0, 7, 8, 0, 1},
+			request:  []byte{128, 15, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 7, 101, 120, 97, 109, 112, 108, 101, 3, 99, 111, 109, 0, 0, 1, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
+			response: []byte{128, 15, 133, 3, 0, 1, 0, 0, 0, 1, 0, 0, 7, 101, 120, 97, 109, 112, 108, 101, 3, 99, 111, 109, 0, 0, 1, 0, 1, 7, 101, 120, 97, 109, 112, 108, 101, 3, 99, 111, 109, 0, 0, 6, 0, 1, 0, 0, 0, 3, 0, 55, 2, 110, 115, 7, 101, 120, 97, 109, 112, 108, 101, 3, 99, 111, 109, 0, 5, 97, 100, 109, 105, 110, 7, 101, 120, 97, 109, 112, 108, 101, 3, 99, 111, 109, 0, 0, 0, 0, 1, 0, 0, 28, 32, 0, 0, 7, 8, 0, 0, 14, 16, 0, 0, 1, 44},
 		},
 		{
-			// Query AAAA "redis.default.svc.cluster.local" — alt magic 0x08, header shape passed previous KeyLen+BodyLen check with KeyLen=0.
+			// Query AAAA "host.example.com" — alt magic 0x08, header shape passed previous KeyLen+BodyLen check with KeyLen=0.
 			name:    "alt-magic DNS AAAA query",
-			request: []byte{8, 26, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 5, 114, 101, 100, 105, 115, 7, 100, 101, 102, 97, 117, 108, 116, 3, 115, 118, 99, 7, 99, 108, 117, 115, 116, 101, 114, 5, 108, 111, 99, 97, 108, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
+			request: []byte{8, 26, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 4, 104, 111, 115, 116, 7, 101, 120, 97, 109, 112, 108, 101, 3, 99, 111, 109, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
 		},
 		{
-			// Query AAAA "redis.us-east-2.compute.internal" — classic magic 0x80.
-			name:    "classic-magic DNS internal query",
-			request: []byte{128, 4, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 5, 114, 101, 100, 105, 115, 9, 117, 115, 45, 101, 97, 115, 116, 45, 50, 7, 99, 111, 109, 112, 117, 116, 101, 8, 105, 110, 116, 101, 114, 110, 97, 108, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
+			// Query AAAA "test.example.net" — classic magic 0x80.
+			name:    "classic-magic DNS AAAA query",
+			request: []byte{128, 4, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 4, 116, 101, 115, 116, 7, 101, 120, 97, 109, 112, 108, 101, 3, 110, 101, 116, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
 		},
 		{
-			// Minimal DNS query "redis" only — alt magic 0x08.
+			// Minimal DNS query for single label "host" — alt magic 0x08.
 			name:     "alt-magic tiny DNS query",
-			request:  []byte{8, 29, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 5, 114, 101, 100, 105, 115, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
-			response: []byte{8, 29, 133, 133, 0, 1, 0, 0, 0, 0, 0, 1, 5, 114, 101, 100, 105, 115, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
+			request:  []byte{8, 29, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 4, 104, 111, 115, 116, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
+			response: []byte{8, 29, 133, 133, 0, 1, 0, 0, 0, 0, 0, 1, 4, 104, 111, 115, 116, 0, 0, 28, 0, 1, 0, 0, 41, 4, 208, 0, 0, 0, 0, 0, 0},
 		},
 	}
 

--- a/pkg/internal/ebpf/couchbasekv/header.go
+++ b/pkg/internal/ebpf/couchbasekv/header.go
@@ -45,6 +45,8 @@ func (h Header) KeyLen() uint16 {
 
 func (h Header) ExtrasLen() uint8 { return h[4] }
 
+func (h Header) DataType() DataType { return DataType(h[5]) }
+
 // Status returns bytes 6-7 as status code of the response; returns 0 for requests.
 func (h Header) Status() Status {
 	if h.IsResponse() {
@@ -225,19 +227,12 @@ func (p Packet) valueEnd() int {
 
 // validateHeader checks for basic validity of the parsed header.
 func validateHeader(h Header) error {
-	// Key length must not exceed the protocol's 250-byte maximum. This also
-	// helps reject random TCP data whose bytes 2-3 happen to decode as a huge
-	// uint16 (e.g. DNS traffic whose flags field falls in this position).
 	if int(h.KeyLen()) > MaxKeyLen {
 		return fmt.Errorf("invalid key length: %d > max(%d)", h.KeyLen(), MaxKeyLen)
 	}
 
-	// Byte 5 (data type) is a bitfield with only bits 0-2 defined
-	// (JSON/Snappy/Xattr). Any other bit set means this isn't a Couchbase
-	// packet — commonly triggered by DNS/other TCP traffic whose byte at this
-	// offset is arbitrary.
-	if h[5]&^byte(DataTypeJSON|DataTypeSnappy|DataTypeXattr) != 0 {
-		return fmt.Errorf("invalid data type: 0x%02x has reserved bits set", h[5])
+	if !h.DataType().IsValid() {
+		return fmt.Errorf("invalid data type: 0x%02x has reserved bits set", byte(h.DataType()))
 	}
 
 	minBodyLen := int(h.FramingExtrasLen()) + int(h.ExtrasLen()) + int(h.KeyLen())

--- a/pkg/internal/ebpf/couchbasekv/header.go
+++ b/pkg/internal/ebpf/couchbasekv/header.go
@@ -225,6 +225,21 @@ func (p Packet) valueEnd() int {
 
 // validateHeader checks for basic validity of the parsed header.
 func validateHeader(h Header) error {
+	// Key length must not exceed the protocol's 250-byte maximum. This also
+	// helps reject random TCP data whose bytes 2-3 happen to decode as a huge
+	// uint16 (e.g. DNS traffic whose flags field falls in this position).
+	if int(h.KeyLen()) > MaxKeyLen {
+		return fmt.Errorf("invalid key length: %d > max(%d)", h.KeyLen(), MaxKeyLen)
+	}
+
+	// Byte 5 (data type) is a bitfield with only bits 0-2 defined
+	// (JSON/Snappy/Xattr). Any other bit set means this isn't a Couchbase
+	// packet — commonly triggered by DNS/other TCP traffic whose byte at this
+	// offset is arbitrary.
+	if h[5]&^byte(DataTypeJSON|DataTypeSnappy|DataTypeXattr) != 0 {
+		return fmt.Errorf("invalid data type: 0x%02x has reserved bits set", h[5])
+	}
+
 	minBodyLen := int(h.FramingExtrasLen()) + int(h.ExtrasLen()) + int(h.KeyLen())
 	if int(h.BodyLen()) < minBodyLen {
 		return fmt.Errorf("invalid body length: %d < framingExtras(%d) + extras(%d) + key(%d)",

--- a/pkg/internal/ebpf/couchbasekv/types.go
+++ b/pkg/internal/ebpf/couchbasekv/types.go
@@ -969,3 +969,8 @@ func (d DataType) HasSnappy() bool {
 func (d DataType) HasXattr() bool {
 	return d&DataTypeXattr != 0
 }
+
+// IsValid returns true if no reserved bits are set.
+func (d DataType) IsValid() bool {
+	return d&^(DataTypeJSON|DataTypeSnappy|DataTypeXattr) == 0
+}

--- a/pkg/internal/ebpf/couchbasekv/types.go
+++ b/pkg/internal/ebpf/couchbasekv/types.go
@@ -6,6 +6,9 @@ package couchbasekv // import "go.opentelemetry.io/obi/pkg/internal/ebpf/couchba
 // Header sizes
 const (
 	HeaderLen = 24 // All packets have a 24-byte header
+	// MaxKeyLen is the maximum document key length allowed by the Couchbase
+	// memcached binary protocol (250 bytes per Couchbase server limits).
+	MaxKeyLen = 250
 )
 
 // Magic bytes identify packet direction and encoding format


### PR DESCRIPTION
## Summary

Add more checks for couchbase protocol to avoid missclassification
- Couchbase max key size = 250 ([source](https://docs.couchbase.com/server/current/learn/clusters-and-availability/size-limitations.html))
- make sure DataType byte is valid
- make sure key is not empty

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
