### PR TITLE
Fix local ebpf generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,13 @@ __check_defined = \
 # Tools module where tool versions are defined.
 TOOLS_MODFILE := -modfile=$(CURDIR)/internal/tools/go.mod
 
-BPF2GO ?= go tool $(TOOLS_MODFILE) bpf2go
+BPF2GO_WRAPPER := $(CURDIR)/.tools/bpf2go
+$(BPF2GO_WRAPPER):
+	@mkdir -p $(dir $@)
+	@printf '#!/bin/sh\nexec go tool $(TOOLS_MODFILE) bpf2go "$$@"\n' > $@
+	@chmod +x $@
+
+BPF2GO ?= $(BPF2GO_WRAPPER)
 
 # Required for k8s-cache unit tests
 ENVTEST_K8S_VERSION ?= 1.30.0
@@ -218,7 +224,7 @@ BPF_GEN_ALL := $(if $(BPF_GEN_GO),$(BPF_GEN_GO) $(BPF_GEN_OBJ))
 generate: export BPF_CLANG := $(CLANG)
 generate: export BPF_CFLAGS := $(CFLAGS)
 generate: export BPF2GO := $(BPF2GO)
-generate: $(if $(BPF_GEN_ALL),$(BPF_GEN_ALL),generate/all)
+generate: $(BPF2GO) $(if $(BPF_GEN_ALL),$(BPF_GEN_ALL),generate/all)
 
 # Pattern rule: regenerate specific eBPF files when dependencies change
 $(BPF_GEN_ALL):


### PR DESCRIPTION
## Summary

The PR https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1818 broke local go docker generate on Linux, I'm not sure if I'm doing something wrong, but in my shell the expansion of the bpf2go doesn't happen.

I think `go generate` does not perform word splitting after the variable expansion. It expands $BPF2GO and treats the entire value "go tool -modfile=... bpf2go" as a single executable name. The OS then tries to exec a file literally named go tool -modfile=... bpf2go, which doesn't exist.

If I run `make generate` on Linux zsh locally I get:

```
Generating pkg/ebpf/common/...
pkg/ebpf/common/common.go:38: running "/home/nino/work/obi/.tools/bpf2go": fork/exec /home/nino/work/obi/.tools/bpf2go: no such file or directory
```

The way I fixed it is by adding a small script that did part of what we used to before.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
