### PR TITLE
fix(http): cap decompressed response bodies

### DIFF
--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -341,7 +341,7 @@
         }
       },
       "type": "object",
-      "description": "Per-protocol maximum bytes to capture per request per direction, sent to userspace via large buffer events. The lte=65536 ceiling must match the k_large_buf_max_*_captured_bytes constants in bpf/common/large_buffers.h.  Default: 0 (disabled)."
+      "description": "Per-protocol maximum bytes to capture per request per direction, sent to userspace via large buffer events. MaxCapturedPayloadBytes must match the k_large_buf_max_*_captured_bytes constants in bpf/common/large_buffers.h. The validate tags below must stay aligned with MaxCapturedPayloadBytes.  Default: 0 (disabled)."
     },
     "EBPFTracer": {
       "properties": {

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -341,7 +341,7 @@
         }
       },
       "type": "object",
-      "description": "Per-protocol maximum bytes to capture per request per direction, sent to userspace via large buffer events. MaxCapturedPayloadBytes must match the k_large_buf_max_*_captured_bytes constants in bpf/common/large_buffers.h. The validate tags below must stay aligned with MaxCapturedPayloadBytes.  Default: 0 (disabled)."
+      "description": "Per-protocol maximum bytes to capture per request per direction, sent to userspace via large buffer events. Values must stay aligned with MaxCapturedPayloadBytes and the k_large_buf_max_*_captured_bytes constants in bpf/common/large_buffers.h.  Default: 0 (disabled)."
     },
     "EBPFTracer": {
       "properties": {

--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -171,8 +171,8 @@ func (e *EBPFTracer) CudaInstrumentationEnabled() bool {
 const MaxCapturedPayloadBytes = 1 << 16
 
 // Per-protocol maximum bytes to capture per request per direction, sent to userspace via large buffer events.
-// MaxCapturedPayloadBytes must match the k_large_buf_max_*_captured_bytes constants in bpf/common/large_buffers.h.
-// The validate tags below must stay aligned with MaxCapturedPayloadBytes.
+// Values must stay aligned with MaxCapturedPayloadBytes and the
+// k_large_buf_max_*_captured_bytes constants in bpf/common/large_buffers.h.
 //
 // Default: 0 (disabled).
 type EBPFBufferSizes struct {

--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -163,8 +163,16 @@ func (e *EBPFTracer) CudaInstrumentationEnabled() bool {
 	return false
 }
 
+// MaxCapturedPayloadBytes is the maximum number of bytes that can be captured
+// per protocol request direction via large buffer events.
+//
+// It must stay aligned with the k_large_buf_max_*_captured_bytes constants in
+// bpf/common/large_buffers.h and with the validate tags in EBPFBufferSizes.
+const MaxCapturedPayloadBytes = 1 << 16
+
 // Per-protocol maximum bytes to capture per request per direction, sent to userspace via large buffer events.
-// The lte=65536 ceiling must match the k_large_buf_max_*_captured_bytes constants in bpf/common/large_buffers.h.
+// MaxCapturedPayloadBytes must match the k_large_buf_max_*_captured_bytes constants in bpf/common/large_buffers.h.
+// The validate tags below must stay aligned with MaxCapturedPayloadBytes.
 //
 // Default: 0 (disabled).
 type EBPFBufferSizes struct {

--- a/pkg/config/ebpf_tracer_test.go
+++ b/pkg/config/ebpf_tracer_test.go
@@ -261,8 +261,6 @@ func TestEBPFTracer_CudaInstrumentationEnabled(t *testing.T) {
 }
 
 func TestEBPFBufferSizesValidateTagsMatchMaxCapturedPayloadBytes(t *testing.T) {
-	t.Helper()
-
 	expected := fmt.Sprintf("lte=%d", MaxCapturedPayloadBytes)
 	typ := reflect.TypeOf(EBPFBufferSizes{})
 

--- a/pkg/config/ebpf_tracer_test.go
+++ b/pkg/config/ebpf_tracer_test.go
@@ -4,6 +4,8 @@
 package config
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -255,5 +257,29 @@ func TestEBPFTracer_CudaInstrumentationEnabled(t *testing.T) {
 					got, tt.wantEnabled, tt.description)
 			}
 		})
+	}
+}
+
+func TestEBPFBufferSizesValidateTagsMatchMaxCapturedPayloadBytes(t *testing.T) {
+	t.Helper()
+
+	expected := fmt.Sprintf("lte=%d", MaxCapturedPayloadBytes)
+	typ := reflect.TypeOf(EBPFBufferSizes{})
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if got := field.Tag.Get("validate"); got != expected {
+			t.Fatalf(
+				"EBPFBufferSizes.%s validate tag drifted: got %q, want %q.\n"+
+					"To resolve this, update all of the following together:\n"+
+					"1. %s validate tag in pkg/config/ebpf_tracer.go\n"+
+					"2. MaxCapturedPayloadBytes in pkg/config/ebpf_tracer.go\n"+
+					"3. matching k_large_buf_max_*_captured_bytes constant in bpf/common/large_buffers.h",
+				field.Name,
+				got,
+				expected,
+				field.Name,
+			)
+		}
 	}
 }

--- a/pkg/ebpf/common/http/responses.go
+++ b/pkg/ebpf/common/http/responses.go
@@ -7,12 +7,23 @@ import (
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/zstd"
+)
+
+// Keep the decompressed response cap aligned with the maximum captured HTTP body
+// size so body enrichment cannot expand a compressed payload beyond the configured
+// userspace budget.
+const maxDecompressedResponseBodyBytes = 64 * 1024
+
+var errResponseBodyTooLarge = fmt.Errorf(
+	"response body exceeds decompression limit of %d bytes",
+	maxDecompressedResponseBodyBytes,
 )
 
 // getResponseBody tries to read the body as plain text and then
@@ -41,28 +52,52 @@ func getResponseBody(resp *http.Response) ([]byte, error) {
 // decompressBody decompresses b according to the Content-Encoding value.
 // Mirrors what http.Transport does for gzip, extended to cover zstd, deflate and brotli.
 func decompressBody(encoding string, b []byte) ([]byte, error) {
+	var (
+		reader  io.Reader
+		closeFn func()
+		err     error
+	)
+
 	switch encoding {
 	case "gzip":
-		gr, err := gzip.NewReader(bytes.NewReader(b))
-		if err != nil {
-			return nil, err
-		}
-		defer gr.Close()
-		return io.ReadAll(gr)
+		var gr *gzip.Reader
+		gr, err = gzip.NewReader(bytes.NewReader(b))
+		reader = gr
+		closeFn = func() { _ = gr.Close() }
 	case "zstd":
-		zr, err := zstd.NewReader(bytes.NewReader(b))
-		if err != nil {
-			return nil, err
-		}
-		defer zr.Close()
-		return io.ReadAll(zr)
+		var zr *zstd.Decoder
+		zr, err = zstd.NewReader(bytes.NewReader(b))
+		reader = zr
+		closeFn = zr.Close
 	case "deflate":
 		fr := flate.NewReader(bytes.NewReader(b))
-		defer fr.Close()
-		return io.ReadAll(fr)
+		reader = fr
+		closeFn = func() { _ = fr.Close() }
 	case "br":
-		return io.ReadAll(brotli.NewReader(bytes.NewReader(b)))
+		reader = brotli.NewReader(bytes.NewReader(b))
 	default:
 		return b, nil
 	}
+
+	if err != nil {
+		return nil, err
+	}
+	if closeFn != nil {
+		defer closeFn()
+	}
+
+	return readBodyWithLimit(reader, maxDecompressedResponseBodyBytes)
+}
+
+func readBodyWithLimit(reader io.Reader, limit int64) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(reader, limit+1))
+	if err != nil {
+		return nil, err
+	}
+
+	if int64(len(body)) > limit {
+		return nil, errResponseBodyTooLarge
+	}
+
+	return body, nil
 }

--- a/pkg/ebpf/common/http/responses.go
+++ b/pkg/ebpf/common/http/responses.go
@@ -51,7 +51,10 @@ func getResponseBody(resp *http.Response) ([]byte, error) {
 }
 
 // decompressBody decompresses b according to the Content-Encoding value.
-// Mirrors what http.Transport does for gzip, extended to cover zstd, deflate and brotli.
+// Mirrors what http.Transport does for gzip, extended to cover zstd, deflate
+// and brotli. Unsupported encodings are returned unchanged. Decompressed
+// output is capped at maxDecompressedResponseBodyBytes, and it returns
+// errResponseBodyTooLarge if that limit is exceeded.
 func decompressBody(encoding string, b []byte) ([]byte, error) {
 	var (
 		reader  io.Reader

--- a/pkg/ebpf/common/http/responses.go
+++ b/pkg/ebpf/common/http/responses.go
@@ -13,12 +13,13 @@ import (
 
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/zstd"
+	"go.opentelemetry.io/obi/pkg/config"
 )
 
-// Keep the decompressed response cap aligned with the maximum captured HTTP body
-// size so body enrichment cannot expand a compressed payload beyond the configured
+// Keep the decompressed response cap aligned with the maximum captured payload size
+// so body enrichment cannot expand a compressed payload beyond the configured
 // userspace budget.
-const maxDecompressedResponseBodyBytes = 64 * 1024
+const maxDecompressedResponseBodyBytes = config.MaxCapturedPayloadBytes
 
 var errResponseBodyTooLarge = fmt.Errorf(
 	"response body exceeds decompression limit of %d bytes",

--- a/pkg/ebpf/common/http/responses.go
+++ b/pkg/ebpf/common/http/responses.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"

--- a/pkg/ebpf/common/http/responses.go
+++ b/pkg/ebpf/common/http/responses.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/zstd"
+
 	"go.opentelemetry.io/obi/pkg/config"
 )
 

--- a/pkg/ebpf/common/http/responses_test.go
+++ b/pkg/ebpf/common/http/responses_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -129,6 +130,14 @@ func TestDecompressBody(t *testing.T) {
 			t.Fatal("expected error for corrupted brotli data, got nil")
 		}
 	})
+
+	t.Run("gzip decompression over limit returns error", func(t *testing.T) {
+		payload := bytes.Repeat([]byte("a"), maxDecompressedResponseBodyBytes+1)
+		_, err := decompressBody("gzip", gzipEncode(t, payload))
+		if !errors.Is(err, errResponseBodyTooLarge) {
+			t.Fatalf("expected errResponseBodyTooLarge, got %v", err)
+		}
+	})
 }
 
 func TestGetResponseBody(t *testing.T) {
@@ -222,6 +231,25 @@ func TestGetResponseBody(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "decompress error") {
 			t.Errorf("error message should mention decompress error, got: %v", err)
+		}
+	})
+
+	t.Run("compressed body over limit returns error and body is restored", func(t *testing.T) {
+		payload := bytes.Repeat([]byte("a"), maxDecompressedResponseBodyBytes+1)
+		compressed := gzipEncode(t, payload)
+		resp := makeResponse(t, compressed, "gzip")
+
+		_, err := getResponseBody(resp)
+		if !errors.Is(err, errResponseBodyTooLarge) {
+			t.Fatalf("expected errResponseBodyTooLarge, got %v", err)
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			t.Fatalf("re-reading body after limit error: %v", readErr)
+		}
+		if !bytes.Equal(body, compressed) {
+			t.Fatal("response body was not restored after decompression limit error")
 		}
 	})
 }


### PR DESCRIPTION
Caps decompressed HTTP response bodies at 64 KiB in the shared response parsing path.

This prevents compressed response payloads from expanding without bound when HTTP body enrichment or other HTTP response parsers read compressed bodies in userspace.

This has no impact on released versions, as the feature has yet to be released.

## Changes

- add a hard 64 KiB limit for decompressed HTTP response bodies
- return a clear error when decompressed content exceeds the limit
- keep the original response body readable after decompression errors
- add regression tests covering oversized compressed bodies

## Rationale

HTTP response capture is already bounded on the compressed side, but decompression previously used unbounded `io.ReadAll` calls for `gzip`, `zstd`, `deflate`, and `br`.

That allowed a decompression bomb to expand well beyond the configured HTTP body capture budget once body enrichment was enabled.

Keeping the decompressed limit aligned with the maximum captured HTTP body size closes that gap without changing the existing feature surface.