### PR TITLE
Add issue templates, stale workflow, and component auto-labeler

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,94 @@
+name: Bug Report
+description: Report a bug in OBI or k8s-cache
+labels: ["bug", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill out the fields below to help us investigate.
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I have searched existing issues for duplicates.
+          required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the project does this affect?
+      options:
+        - OBI (eBPF instrumentation)
+        - k8s-cache
+        - Both / unsure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: OBI / k8s-cache version (binary `--version` output or container image tag).
+      placeholder: e.g. v1.2.3
+    validations:
+      required: true
+  - type: input
+    id: kernel
+    attributes:
+      label: Kernel version
+      description: Output of `uname -r`.
+      placeholder: e.g. 6.5.0-15-generic
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS / Distribution
+      placeholder: e.g. Ubuntu 24.04, Amazon Linux 2023, RHEL 9
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      options:
+        - Kubernetes
+        - Docker / container
+        - Bare metal / VM
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: OBI configuration
+      description: Paste your OBI / k8s-cache config YAML. Redact secrets.
+      render: yaml
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste relevant log output. Debug-level logs are especially helpful.
+      render: shell
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,17 +1,7 @@
 name: Bug Report
-description: Report a bug in OBI or k8s-cache
+description: Report a bug
 labels: ["bug", "needs triage"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to file a bug report. Please fill out the fields below to help us investigate.
-  - type: checkboxes
-    attributes:
-      label: Prerequisites
-      options:
-        - label: I have searched existing issues for duplicates.
-          required: true
   - type: dropdown
     id: component
     attributes:
@@ -21,40 +11,6 @@ body:
         - OBI (eBPF instrumentation)
         - k8s-cache
         - Both / unsure
-    validations:
-      required: true
-  - type: input
-    id: version
-    attributes:
-      label: Version
-      description: OBI / k8s-cache version (binary `--version` output or container image tag).
-      placeholder: e.g. v1.2.3
-    validations:
-      required: true
-  - type: input
-    id: kernel
-    attributes:
-      label: Kernel version
-      description: Output of `uname -r`.
-      placeholder: e.g. 6.5.0-15-generic
-    validations:
-      required: true
-  - type: input
-    id: os
-    attributes:
-      label: OS / Distribution
-      placeholder: e.g. Ubuntu 24.04, Amazon Linux 2023, RHEL 9
-    validations:
-      required: true
-  - type: dropdown
-    id: deployment
-    attributes:
-      label: Deployment
-      options:
-        - Kubernetes
-        - Docker / container
-        - Bare metal / VM
-        - Other
     validations:
       required: true
   - type: textarea
@@ -80,15 +36,41 @@ body:
     id: config
     attributes:
       label: OBI configuration
-      description: Paste your OBI / k8s-cache config YAML. Redact secrets.
+      description: Paste your OBI / k8s-cache config YAML.
       render: yaml
   - type: textarea
     id: logs
     attributes:
       label: Relevant logs
-      description: Paste relevant log output. Debug-level logs are especially helpful.
+      description: Paste relevant log output.
       render: shell
   - type: textarea
     id: context
     attributes:
       label: Additional context
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: OBI / k8s-cache version (binary `--version` output or container image tag).
+      placeholder: e.g. v1.2.3
+  - type: input
+    id: kernel
+    attributes:
+      label: Kernel version
+      description: Output of `uname -r`.
+      placeholder: e.g. 6.5.0-15-generic
+  - type: input
+    id: os
+    attributes:
+      label: OS / Distribution
+      placeholder: e.g. Ubuntu 24.04, Amazon Linux 2023, RHEL 9
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      options:
+        - Kubernetes
+        - Docker / container
+        - Bare metal / VM
+        - Other

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Questions & Discussions
     url: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/discussions
     about: Ask questions, share ideas, and discuss OBI with the community.
-  - name: CNCF Slack — #otel-ebpf-instrumentation
+  - name: Slack Channel
     url: https://cloud-native.slack.com/archives/C08P9L4FPKJ
     about: Real-time chat with maintainers and users.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/discussions
+    about: Ask questions, share ideas, and discuss OBI with the community.
+  - name: CNCF Slack — #otel-ebpf-instrumentation
+    url: https://cloud-native.slack.com/archives/C08P9L4FPKJ
+    about: Real-time chat with maintainers and users.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,48 @@
+name: Feature Request
+description: Suggest an enhancement for OBI or k8s-cache
+labels: ["enhancement", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature. Please fill out the fields below.
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I have searched existing issues for duplicates.
+          required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the project does this affect?
+      options:
+        - OBI (eBPF instrumentation)
+        - k8s-cache
+        - Both / unsure
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve? What's the current pain point?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered and why they're insufficient.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,17 +1,7 @@
 name: Feature Request
-description: Suggest an enhancement for OBI or k8s-cache
+description: Suggest an enhancement
 labels: ["enhancement", "needs triage"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for suggesting a feature. Please fill out the fields below.
-  - type: checkboxes
-    attributes:
-      label: Prerequisites
-      options:
-        - label: I have searched existing issues for duplicates.
-          required: true
   - type: dropdown
     id: component
     attributes:
@@ -21,7 +11,7 @@ body:
         - OBI (eBPF instrumentation)
         - k8s-cache
         - Both / unsure
-    validations:
+    validations:s
       required: true
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -10,7 +10,7 @@ body:
       options:
         - OBI (eBPF instrumentation)
         - k8s-cache
-        - Both / unsure
+        - Other
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -23,15 +23,15 @@ body:
   - type: textarea
     id: solution
     attributes:
-      label: Proposed solution
-      description: How would you like this to work?
+      label: Describe the solution you'd like
+      description: A clear and concise description of the desired behavior.
     validations:
       required: true
   - type: textarea
     id: alternatives
     attributes:
-      label: Alternatives considered
-      description: Other approaches you considered and why they're insufficient.
+      label: Describe alternatives you've considered
+      description: Any alternative approaches or workarounds you've considered.
   - type: textarea
     id: context
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -11,7 +11,7 @@ body:
         - OBI (eBPF instrumentation)
         - k8s-cache
         - Both / unsure
-    validations:s
+    validations:
       required: true
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -25,8 +25,6 @@ body:
     attributes:
       label: Describe the solution you'd like
       description: A clear and concise description of the desired behavior.
-    validations:
-      required: true
   - type: textarea
     id: alternatives
     attributes:

--- a/.github/ISSUE_TEMPLATE/new_instrumentation.yaml
+++ b/.github/ISSUE_TEMPLATE/new_instrumentation.yaml
@@ -1,6 +1,6 @@
 name: New Instrumentation Request
 description: Request support for instrumenting a new library, protocol, or runtime
-labels: ["enhancement", "new instrumentation", "needs triage"]
+labels: ["enhancement", "new instrumentation", "needs triage", "component:obi"]
 body:
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/new_instrumentation.yaml
+++ b/.github/ISSUE_TEMPLATE/new_instrumentation.yaml
@@ -1,0 +1,69 @@
+name: New Instrumentation Request
+description: Request support for instrumenting a new library, protocol, or runtime
+labels: ["enhancement", "new instrumentation", "needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Before you file
+
+        Please check the following to confirm this instrumentation is not already supported or planned:
+
+        - [`devdocs/features.md`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)
+        - [`SUPPORT_MATRIX.md`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md)
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I have checked `devdocs/features.md` and this instrumentation is not already listed.
+          required: true
+        - label: I have searched existing issues for duplicates.
+          required: true
+  - type: input
+    id: library
+    attributes:
+      label: Library / protocol / runtime
+      description: What would you like OBI to instrument?
+      placeholder: e.g. NATS client, QUIC, Deno runtime
+    validations:
+      required: true
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language / runtime
+      options:
+        - Go
+        - Node.js
+        - Python
+        - Java / JVM
+        - Ruby
+        - Rust
+        - C/C++
+        - Multiple / cross-language
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: references
+    attributes:
+      label: Reference documentation
+      description: Link to the library homepage, protocol spec, or relevant docs.
+  - type: checkboxes
+    id: signals
+    attributes:
+      label: Desired telemetry signals
+      options:
+        - label: Traces
+        - label: Metrics
+        - label: Logs
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Why do you need this instrumentation? What would you use it for?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/new_instrumentation.yaml
+++ b/.github/ISSUE_TEMPLATE/new_instrumentation.yaml
@@ -2,45 +2,18 @@ name: New Instrumentation Request
 description: Request support for instrumenting a new library, protocol, or runtime
 labels: ["enhancement", "new instrumentation", "needs triage"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        ### Before you file
-
-        Please check the following to confirm this instrumentation is not already supported or planned:
-
-        - [`devdocs/features.md`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)
-        - [`SUPPORT_MATRIX.md`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md)
   - type: checkboxes
     attributes:
       label: Prerequisites
       options:
-        - label: I have checked `devdocs/features.md` and this instrumentation is not already listed.
-          required: true
-        - label: I have searched existing issues for duplicates.
+        - label: I have checked [`devdocs/features.md`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and this instrumentation is not already listed.
           required: true
   - type: input
     id: library
     attributes:
       label: Library / protocol / runtime
       description: What would you like OBI to instrument?
-      placeholder: e.g. NATS client, QUIC, Deno runtime
-    validations:
-      required: true
-  - type: dropdown
-    id: language
-    attributes:
-      label: Language / runtime
-      options:
-        - Go
-        - Node.js
-        - Python
-        - Java / JVM
-        - Ruby
-        - Rust
-        - C/C++
-        - Multiple / cross-language
-        - Other
+      placeholder: e.g. AMQP, ClickHouse, Rust Tokio
     validations:
       required: true
   - type: input
@@ -48,6 +21,14 @@ body:
     attributes:
       label: Reference documentation
       description: Link to the library homepage, protocol spec, or relevant docs.
+  - type: input
+    id: semconv
+    attributes:
+      label: OTel semantic conventions
+      description: |
+        Link to the relevant section of the [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions),
+        if one exists for this library / protocol. Leave blank if there is no defined semconv yet.
+      placeholder: e.g. https://opentelemetry.io/docs/specs/semconv/database/mongodb/
   - type: checkboxes
     id: signals
     attributes:
@@ -55,7 +36,6 @@ body:
       options:
         - label: Traces
         - label: Metrics
-        - label: Logs
   - type: textarea
     id: use-case
     attributes:

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,9 @@
+# Regex patterns matching the rendered form output of .github/ISSUE_TEMPLATE/*.yaml
+# The Component dropdown renders as "### Component" followed by the selected value.
+# Selecting "Both / unsure" applies both component labels.
+"component:obi":
+  - '### Component[^\S\n]*\n+[^\S\n]*OBI \(eBPF instrumentation\)'
+  - '### Component[^\S\n]*\n+[^\S\n]*Both / unsure'
+"component:k8s-cache":
+  - '### Component[^\S\n]*\n+[^\S\n]*k8s-cache'
+  - '### Component[^\S\n]*\n+[^\S\n]*Both / unsure'

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,9 +1,10 @@
 # Regex patterns matching the rendered form output of .github/ISSUE_TEMPLATE/*.yaml
 # The Component dropdown renders as "### Component" followed by the selected value.
-# Selecting "Both / unsure" applies both component labels.
+# Selecting "Both / unsure" matches both label patterns so both are applied.
+#
+# NOTE: github/issue-labeler treats multiple entries under a label as AND, not OR.
+# We use a single regex per label with alternation (`a|b`) to express OR logic.
 "component:obi":
-  - '### Component[^\S\n]*\n+[^\S\n]*OBI \(eBPF instrumentation\)'
-  - '### Component[^\S\n]*\n+[^\S\n]*Both / unsure'
+  - '### Component[^\S\n]*\n+[^\S\n]*(OBI \(eBPF instrumentation\)|Both / unsure)'
 "component:k8s-cache":
-  - '### Component[^\S\n]*\n+[^\S\n]*k8s-cache'
-  - '### Component[^\S\n]*\n+[^\S\n]*Both / unsure'
+  - '### Component[^\S\n]*\n+[^\S\n]*(k8s-cache|Both / unsure)'

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -12,8 +12,10 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: github/issue-labeler@v3.4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
         with:
           configuration-path: .github/issue-labeler.yml
           enable-versioned-regex: 0

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,21 @@
+name: Auto-label issues
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3.4
+        with:
+          configuration-path: .github/issue-labeler.yml
+          enable-versioned-regex: 0
+          include-title: 0
+          include-body: 1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -12,6 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: github/issue-labeler@v3.4
         with:
           configuration-path: .github/issue-labeler.yml

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-issue-stale: 60
           days-before-pr-stale: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,13 +23,13 @@ jobs:
           exempt-issue-labels: 'never stale,pinned,help wanted,good first issue'
           exempt-pr-labels: 'never stale,blocked'
           stale-issue-message: |
-            This issue has been inactive for 60 days and is now marked as stale.
+            This issue has been inactive for 120 days and is now marked as stale.
 
             cc @open-telemetry/ebpf-instrumentation-maintainers — please review and close if no longer relevant.
 
             A comment from anyone or the `never stale` label will remove the stale marker.
           stale-pr-message: |
-            This PR has been inactive for 30 days and is now marked as stale.
+            This PR has been inactive for 60 days and is now marked as stale.
 
             cc @open-telemetry/ebpf-instrumentation-maintainers — please review and close if no longer being worked on.
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 60
+          days-before-issue-stale: 0
           days-before-pr-stale: 30
           days-before-close: -1
           stale-issue-label: 'stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 0
+          days-before-issue-stale: 60
           days-before-pr-stale: 30
           days-before-close: -1
           stale-issue-label: 'stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
-          days-before-issue-stale: 60
-          days-before-pr-stale: 30
+          days-before-issue-stale: 120
+          days-before-pr-stale: 60
           days-before-close: -1
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,37 @@
+name: Mark stale issues and PRs
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-pr-stale: 30
+          days-before-close: -1
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'never stale,pinned,help wanted,good first issue'
+          exempt-pr-labels: 'never stale,blocked'
+          stale-issue-message: |
+            This issue has been inactive for 60 days and is now marked as stale.
+
+            cc @open-telemetry/ebpf-instrumentation-maintainers — please review and close if no longer relevant.
+
+            A comment from anyone or the `never stale` label will remove the stale marker.
+          stale-pr-message: |
+            This PR has been inactive for 30 days and is now marked as stale.
+
+            cc @open-telemetry/ebpf-instrumentation-maintainers — please review and close if no longer being worked on.
+
+            A comment or new commits will remove the stale marker.
+          operations-per-run: 200


### PR DESCRIPTION
## Summary

Adds structured issue management to OBI, taking insperation from how other open-telemetry projects (collector-contrib, operator, JS, Python) manage their issue lifecycle.

### Issue templates (YAML forms)

- **Bug Report** — collects component (OBI vs k8s-cache), description, repro steps,
  config, logs, and environment details (version, kernel, OS, deployment type).
  Auto-labels: `bug`, `needs triage`.       
- **Feature Request** — collects component, problem statement, desired solution,
  and alternatives considered. Auto-labels: `enhancement`, `needs triage`.
- **New Instrumentation Request** — collects target library/protocol, reference docs,                                                                                                                          
  OTel semantic conventions link, desired signals (traces/metrics), and use case.
  Includes a required checkbox confirming the requester checked                                                                                                                                                
  [`devdocs/features.md`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md)            
  to avoid duplicates. Auto-labels: `enhancement`, `new instrumentation`, `needs triage`,                                                                                                                      
  `component:obi`.                                                                                                                       
                                                                                                                                                                                                               
### Contact links (`config.yml`)                                                                                                                                                                               
                                                                                                                                                                                                               
- Redirects general questions to **GitHub Discussions** and **CNCF Slack (#otel-ebpf-instrumentation)**.                                                                                                       
- Blank issues are disabled to encourage use of templates (Allowed for maintainers).                                                                                                                                                     
                                                                                                                                         
### Stale workflow (`stale.yml`)                                                                                                                                                                               
                                                                                                                                         
- Runs daily via `actions/stale@v9`.                                                                                                                                                                           
- Issues inactive for **60 days** are marked `stale`; PRs after **30 days**.                                                             
- **No auto-closing** — stale items are only labeled, not closed.                                                                                                                                              
  The bot pings `@open-telemetry/ebpf-instrumentation-maintainers` to review and close manually.                                         
- Any comment or the `never stale` label removes the stale marker on the next stale run.
- Exempt labels: `never stale`, `pinned`, `help wanted`, `good first issue` (issues);                                                                                                                          
  `never stale`, `blocked` (PRs).                                                                                                                                                                              
                                                                                                                                                                                                               
### Component auto-labeler (`issue-labeler.yml`)                                                                                                                                                               
                                                                                                                                                                                                               
- On issue open/edit, `github/issue-labeler@v3.4` reads the Component dropdown value                                                                                                                           
  and applies `component:obi` and/or `component:k8s-cache`.                                                                              
- "Both / unsure" applies both labels via regex alternation.
                                        
## Labels to create before merging          
                                                                                                                                                                                                               
The following labels must exist on the repo for the workflows and templates to function:
                                                                                                                                                                                                               
| Label | Purpose |                                                                                                                      
|---|---|                                                                                                                                                                                                      
| `needs triage` | Applied to all new issues via template frontmatter |                                                                  
| `new instrumentation` | Marks instrumentation requests |                                                                                                                                                     
| `component:obi` | Applied by auto-labeler for OBI component |                                                                          
| `component:k8s-cache` | Applied by auto-labeler for k8s-cache component |
| `stale` | Applied by stale bot to inactive issues/PRs |                                                                                                                                                      
| `never stale` | Exempt label — protects issues from stale bot |                                                                                                                                              
| `pinned` | Exempt label — protects pinned issues from stale bot |                                                                                                                                            
                                                                                                                                                                                                               
Already exist: `bug`, `enhancement`, `help wanted`, `good first issue`, `blocked`.                                                       
                                                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                               
## Testing                                                                                                                                                                                                     
                                                                                                                                                                                                               
Tested on a personal fork ([NimrodAvni78/opentelemetry-ebpf-instrumentation](https://github.com/NimrodAvni78/opentelemetry-ebpf-instrumentation)):                                                             
- All three templates render correctly on the "New Issue" chooser                                                                        
- Static labels (`bug`, `enhancement`, `needs triage`, `new instrumentation`) applied on issue creation                                                                                                        
- Component auto-labeler applies `component:obi` / `component:k8s-cache` based on dropdown selection                                                                                                           
- Stale workflow runs cleanly via `workflow_dispatch`
- Contact links (Discussions, Slack) render on the chooser page

You are Welcome to try and test yourself on [my OBI fork](https://github.com/NimrodAvni78/opentelemetry-ebpf-instrumentation/issues), create issues and see existing ones

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
