### PR TITLE
Add bpf2go as a make dependency of `generate/all`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ $(BPF_GEN_ALL):
 generate/all: export BPF_CLANG := $(CLANG)
 generate/all: export BPF_CFLAGS := $(CFLAGS)
 generate/all: export BPF2GO := $(BPF2GO)
-generate/all:
+generate/all: $(BPF2GO)
 	@echo "### Generating all eBPF files..."
 	@go generate ./...
 


### PR DESCRIPTION
Running `make generate/all` on a clean repository currently fails due to this dependency not existing nor being built prior.
