### PR TITLE
Release v0.8.0

### DIFF
--- a/internal/test/integration/components/gogeneric/go.mod
+++ b/internal/test/integration/components/gogeneric/go.mod
@@ -1,4 +1,4 @@
-module fiber-example
+module go.opentelemetry.io/obi/internal/test/integration/components/gogeneric/fiber-example
 
 go 1.24.0
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   obi:
-    version: v0.7.1
+    version: v0.8.0
     modules:
       - go.opentelemetry.io/obi
 excluded-modules:

--- a/versions.yaml
+++ b/versions.yaml
@@ -32,6 +32,7 @@ excluded-modules:
   - go.opentelemetry.io/obi/internal/test/integration/components/go_otel
   - go.opentelemetry.io/obi/internal/test/integration/components/go_otel_grpc
   - go.opentelemetry.io/obi/internal/test/integration/components/go_simple_grpc
+  - go.opentelemetry.io/obi/internal/test/integration/components/gogeneric/fiber-example
   - go.opentelemetry.io/obi/internal/test/integration/components/gokafka
   - go.opentelemetry.io/obi/internal/test/integration/components/gokafka-seg
   - go.opentelemetry.io/obi/internal/test/integration/components/gomongo


### PR DESCRIPTION
`v0.8.0` is a minor release focused on broader protocol and AI instrumentation coverage, new extraction capabilities, and support/documentation improvements.

### New instrumentation and protocol coverage

- Added generic Go protocol support, including context propagation for generic requests. PR [#1766](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1766), PR [#1811](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1811), PR [#1789](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1789)
- Added support for JSON-RPC protocol detection in all languages. PR [#1784](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1784)
- Added HTTP full body extraction and capped decompressed response bodies to bound extraction size. PR [#1750](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1750), PR [#1849](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1849)
- Added payload extraction for Gemini (Google AI Studio) and AWS Bedrock, and fixed Vertex AI Gemini support. PR [#1710](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1710), PR [#1820](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1820), PR [#1842](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1842)
- Added named CIDR labels. PR [#1717](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1717)
- Added Kafka produce request v13 support. PR [#1798](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1798)

### User-visible fixes and improvements

- Hardened Java agent injection against unsafe `TMPDIR` path traversal and symlink overwrite behavior when copying the agent into a target process filesystem. Commit [`bd228b5`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/bd228b53a29b7c25229ec04879fa553f59a7abe7)
- Fixed OBI shutdown blocking behavior. PR [#1782](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1782)
- Fixed `k8s-cache` gRPC server shutdown on context cancellation. PR [#1838](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1838)
- Prevented pinned maps from being resized based on scale factor. PR [#1783](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1783)
- Hardened Couchbase detection to avoid incorrect protocol classification. PR [#1845](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1845)
- Added `SetEventContext` and `Capabilities` to the tracer interface for richer tracer coordination. PR [#1816](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1816)
- Added .NET log enricher test coverage and documented current .NET limitations. PR [#1833](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1833)

### Docs and examples

- Added an Apache-2 Web Server example. PR [#1788](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1788)
- Added the project support matrix. PR [#1760](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1760)
- Added integration coverage for NGINX support floors and validated Ruby 3.0.2 and Puma 5 support. PR [#1768](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1768), PR [#1767](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1767)

### Contributor and CI updates

- Expanded privileged unit test coverage and fixed coverage data reporting. PR [#1808](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1808), PR [#1661](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1661)
- Switched internal tools to the native Go tool approach. PR [#1792](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1792), PR [#1818](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1818)
- Improved CI rerun behavior and integration test reliability. PR [#1785](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1785), PR [#1796](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1796), PR [#1797](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1797), PR [#1858](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1858)

**Full Changelog**: [v0.7.1...v0.8.0](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/compare/v0.7.1...v0.8.0)