### PR TITLE
Gracefully handle unavailable /proc/pid/exe

### DIFF
--- a/internal/test/integration/configs/obi-config-exeperm.yml
+++ b/internal/test/integration/configs/obi-config-exeperm.yml
@@ -1,0 +1,9 @@
+routes:
+  unmatched: path
+otel_traces_export:
+  endpoint: http://jaeger:4318
+discovery:
+  instrument:
+    - name: nodeserver
+      namespace: integration-test
+      open_ports: 3030

--- a/internal/test/integration/docker-compose-exeperm.yml
+++ b/internal/test/integration/docker-compose-exeperm.yml
@@ -1,0 +1,50 @@
+services:
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/nodejsserver/Dockerfile
+    image: hatest-testserver-node
+    ports:
+      - "3030:3030"
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    command:
+      - --config=/configs/obi-config-exeperm.yml
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security_none:/sys/kernel/security
+      - /sys/fs/cgroup:/sys/fs/cgroup
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-exeperm:/var/run/obi
+    image: hatest-obi
+    privileged: true
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_METRICS_INTERVAL: "10ms"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_SIMULATE_EXE_PERM_DENIED: "true"
+    depends_on:
+      testserver:
+        condition: service_started
+      jaeger:
+        condition: service_started
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.60@sha256:4fd2d70fa347d6a47e79fcb06b1c177e6079f92cba88b083153d56263082135e
+    ports:
+      - "16686:16686"
+      - "4317"
+      - "4318"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=debug

--- a/internal/test/integration/exepath_permission_test.go
+++ b/internal/test/integration/exepath_permission_test.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
+	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+)
+
+// TestExePathPermission validates that a process is still instrumented and produces
+// kprobe-based spans when discovered by open_ports alone — the fallback that kicks in
+// when /proc/<pid>/exe is unreadable (EACCES) on hardened kernels with restrictive
+// ptrace_scope or SELinux policy.
+func TestExePathPermission(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-exeperm.yml", path.Join(pathOutput, "test-suite-exeperm.log"))
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+	defer compose.Close()
+
+	waitForTestComponentsNoMetrics(t, "http://localhost:3030/smoke")
+
+	var trace jaeger.Trace
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := testHTTPClient.Get("http://localhost:3030/greeting")
+		if assert.NoError(ct, err) {
+			resp.Body.Close()
+		}
+
+		resp, err = http.Get(jaegerQueryURL + "?service=nodeserver&operation=GET%20%2Fgreeting")
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		defer resp.Body.Close()
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+		traces := tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/greeting"})
+		require.NotEmpty(ct, traces)
+		trace = traces[0]
+	}, testTimeout, time.Second)
+
+	spans := trace.FindByOperationName("GET /greeting", "server")
+	require.NotEmpty(t, spans)
+
+	tag, ok := jaeger.FindIn(spans[0].Tags, "http.response.status_code")
+	require.True(t, ok)
+	assert.InDelta(t, float64(200), tag.Value, 0)
+}

--- a/pkg/appolly/discover/matcher.go
+++ b/pkg/appolly/discover/matcher.go
@@ -517,6 +517,10 @@ func logDeprecationAndConflicts(cfg *obi.Config) {
 	}
 }
 
+// simulateExePermDenied simulates EACCES on /proc/<pid>/exe for integration testing.
+// Set OTEL_EBPF_SIMULATE_EXE_PERM_DENIED=true to enable.
+var simulateExePermDenied = os.Getenv("OTEL_EBPF_SIMULATE_EXE_PERM_DENIED") == "true"
+
 // replaceable function to allow unit tests with faked processes
 var processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
 	proc, err := process.NewProcess(int32(pp.pid))
@@ -524,14 +528,22 @@ var processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
 		return nil, fmt.Errorf("can't read process: %w", err)
 	}
 	ppid, _ := proc.Ppid()
-	exePath, err := proc.Exe()
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			// this might happen if you query from the port a service that does not have executable path.
-			// Since this value is just for attributing, we set a default placeholder
-			exePath = "unknown"
-		} else {
-			return nil, fmt.Errorf("can't read /proc/<pid>/fd information: %w", err)
+	exePath := "unknown"
+	if !simulateExePermDenied {
+		exePath, err = proc.Exe()
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// this might happen if you query from the port a service that does not have executable path.
+				// Since this value is just for attributing, we set a default placeholder
+				exePath = "unknown"
+			} else if errors.Is(err, os.ErrPermission) {
+				exePath = "unknown"
+				slog.Warn("can't read executable path for process. Some functionality may be degraded,"+
+					" including SSL/TLS detection and language-specific instrumentation. This is usually caused"+
+					" by a restrictive ptrace_scope or LSM policy on the host", "pid", pp.pid, "error", err)
+			} else {
+				return nil, fmt.Errorf("can't read /proc/<pid>/fd information: %w", err)
+			}
 		}
 	}
 	cmdLine, err := proc.Cmdline()

--- a/pkg/appolly/discover/matcher.go
+++ b/pkg/appolly/discover/matcher.go
@@ -542,7 +542,7 @@ var processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
 					" including SSL/TLS detection and language-specific instrumentation. This is usually caused"+
 					" by a restrictive ptrace_scope or LSM policy on the host", "pid", pp.pid, "error", err)
 			} else {
-				return nil, fmt.Errorf("can't read /proc/<pid>/fd information: %w", err)
+				return nil, fmt.Errorf("can't read /proc/<pid>/exe information: %w", err)
 			}
 		}
 	}

--- a/pkg/appolly/discover/matcher_test.go
+++ b/pkg/appolly/discover/matcher_test.go
@@ -882,3 +882,32 @@ func TestCriteriaMatcher_Granular(t *testing.T) {
 	assert.True(t, asteroidAttrs.ExportModes.CanExportMetrics())
 	require.Nil(t, asteroidAttrs.Sampler)
 }
+
+func TestCriteriaMatcher_ErrPermission(t *testing.T) {
+	// Processes whose /proc/<pid>/exe is unreadable (ptrace_scope/LSM) must still be
+	// matched by open_ports — they must not be silently dropped.
+	var pipeConfig obi.Config
+	require.NoError(t, yaml.Unmarshal([]byte("open_port: 8080\n"), &pipeConfig))
+
+	processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
+		return &services.ProcessInfo{Pid: pp.pid, ExePath: "unknown", OpenPorts: pp.openPorts}, nil
+	}
+
+	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+	filteredProcesses := filteredProcessesQu.Subscribe()
+
+	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
+	require.NoError(t, err)
+	go matcherFunc(t.Context())
+	defer filteredProcessesQu.Close()
+
+	discoveredProcesses.SendCtx(t.Context(), []Event[ProcessAttrs]{
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 1, openPorts: []uint32{8080}}},
+	})
+
+	matches := testutil.ReadChannel(t, filteredProcesses, testTimeout)
+	require.Len(t, matches, 1)
+	assert.Equal(t, app.PID(1), matches[0].Obj.Process.Pid)
+	assert.Equal(t, "unknown", matches[0].Obj.Process.ExePath)
+}

--- a/pkg/obi/os.go
+++ b/pkg/obi/os.go
@@ -42,7 +42,7 @@ func parseOSReleaseIsRHEL(data []byte) bool {
 		}
 		val = strings.Trim(val, "\"'")
 		if strings.Contains(val, "rhel") || strings.Contains(val, "centos") ||
-			strings.Contains(val, "rocky") || strings.Contains(val, "alma") {
+			strings.Contains(val, "rocky") || strings.Contains(val, "alma") || val == "ol" {
 			return true
 		}
 	}

--- a/pkg/obi/os_test.go
+++ b/pkg/obi/os_test.go
@@ -110,6 +110,7 @@ func TestParseOSReleaseIsRHEL(t *testing.T) {
 		{name: "RHEL unquoted", content: "ID=rhel\n", want: true},
 		{name: "RHEL single-quoted", content: "ID='rhel'\n", want: true},
 		{name: "Rocky via ID_LIKE single-quoted", content: "ID='rocky'\nID_LIKE='rhel centos fedora'\n", want: true},
+		{name: "Oracle Linux", content: "ID=\"ol\"\nID_LIKE=\"fedora\"\n", want: true},
 		{name: "Ubuntu", content: "ID=ubuntu\nID_LIKE=debian\n", want: false},
 		{name: "Debian", content: "ID=debian\n", want: false},
 		{name: "empty file", content: "", want: false},


### PR DESCRIPTION
## Summary

On hardened systems with restrictive ptrace_scope or SELinux, reading `/proc/<pid>/exe` returns `EACCES`.

We now treat `os.ErrPermission` like `os.ErrNotExist` and continue with `exePath="unknown"`, so that the functionality provided by kprobes still work.

Also fixes Oracle Linux (ID="ol") not being recognized as RHEL-based, causing a spurious "kernel version not supported" error on 4.18 UEK kernels.

Closes https://github.com/grafana/beyla/issues/2712.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
