### PR TITLE
Fix signed length handling in `netFdReadRet` uprobe

### DIFF
--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -193,9 +193,11 @@ int obi_uprobe_netFdReadRet(struct pt_regs *ctx) {
 
     void *buf = (void *)net_ptr->byte_ptr;
 
-    u64 len = (u64)GO_PARAM1(ctx);
-    bpf_dbg_printk("buf=%llx, len=%d === ", buf, len);
+    s64 len = (s64)GO_PARAM1(ctx);
+    bpf_dbg_printk("buf=%llx, len=%lld === ", buf, len);
     if (buf && len > 0) {
+        const int bytes_len = (len > __INT_MAX__) ? __INT_MAX__ : (int)len;
+
         dbg_print_http_connection_info(&net_ptr->p_conn.conn);
 
         u16 orig_dport = net_ptr->p_conn.conn.d_port;
@@ -210,7 +212,7 @@ int obi_uprobe_netFdReadRet(struct pt_regs *ctx) {
                                        (protocol_selector_t){.http = 1, .http2 = 0, .tcp = 1},
                                        &net_ptr->p_conn,
                                        buf,
-                                       len,
+                                       bytes_len,
                                        NO_SSL,
                                        TCP_RECV,
                                        orig_dport);

--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -238,8 +238,9 @@ int obi_uprobe_netFdWrite(struct pt_regs *ctx) {
 
     void *fd_ptr = GO_PARAM1(ctx);
     u8 *buf = GO_PARAM2(ctx);
-    u64 len = (u64)GO_PARAM3(ctx);
+    s64 len = (s64)GO_PARAM3(ctx);
     if (buf && len > 0) {
+        const int bytes_len = (int)min((s64)__INT_MAX__, len);
         pid_connection_info_t p_conn = {0};
 
         if (!get_conn_info_from_fd(fd_ptr, &p_conn.conn, false)) {
@@ -264,7 +265,7 @@ int obi_uprobe_netFdWrite(struct pt_regs *ctx) {
                                        (protocol_selector_t){.http = 1, .http2 = 0, .tcp = 1},
                                        &p_conn,
                                        buf,
-                                       len,
+                                       bytes_len,
                                        NO_SSL,
                                        TCP_SEND,
                                        orig_dport);

--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -19,6 +19,7 @@
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/utils.h>
 
+#include <common/algorithm.h>
 #include <common/common.h>
 #include <common/connection_info.h>
 #include <common/go_addr_key.h>
@@ -196,7 +197,7 @@ int obi_uprobe_netFdReadRet(struct pt_regs *ctx) {
     s64 len = (s64)GO_PARAM1(ctx);
     bpf_dbg_printk("buf=%llx, len=%lld === ", (unsigned long long)buf, (long long)len);
     if (buf && len > 0) {
-        const int bytes_len = (len > __INT_MAX__) ? __INT_MAX__ : (int)len;
+        const int bytes_len = (int)min((s64)__INT_MAX__, len);
 
         dbg_print_http_connection_info(&net_ptr->p_conn.conn);
 

--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -15,8 +15,6 @@
 
 //go:build obi_bpf_ignore
 
-#include <limits.h>
-
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/utils.h>
@@ -196,10 +194,9 @@ int obi_uprobe_netFdReadRet(struct pt_regs *ctx) {
     void *buf = (void *)net_ptr->byte_ptr;
 
     s64 len = (s64)GO_PARAM1(ctx);
-    bpf_dbg_printk(
-        "buf=%llx, len=%lld === ", (unsigned long long)buf, (long long)len);
+    bpf_dbg_printk("buf=%llx, len=%lld === ", (unsigned long long)buf, (long long)len);
     if (buf && len > 0) {
-        const int bytes_len = (len > INT_MAX) ? INT_MAX : (int)len;
+        const int bytes_len = (len > __INT_MAX__) ? __INT_MAX__ : (int)len;
 
         dbg_print_http_connection_info(&net_ptr->p_conn.conn);
 

--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -15,6 +15,8 @@
 
 //go:build obi_bpf_ignore
 
+#include <limits.h>
+
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/utils.h>
@@ -194,9 +196,10 @@ int obi_uprobe_netFdReadRet(struct pt_regs *ctx) {
     void *buf = (void *)net_ptr->byte_ptr;
 
     s64 len = (s64)GO_PARAM1(ctx);
-    bpf_dbg_printk("buf=%llx, len=%lld === ", buf, len);
+    bpf_dbg_printk(
+        "buf=%llx, len=%lld === ", (unsigned long long)buf, (long long)len);
     if (buf && len > 0) {
-        const int bytes_len = (len > __INT_MAX__) ? __INT_MAX__ : (int)len;
+        const int bytes_len = (len > INT_MAX) ? INT_MAX : (int)len;
 
         dbg_print_http_connection_info(&net_ptr->p_conn.conn);
 


### PR DESCRIPTION
Prevent negative `netFD.Read` return values from being cast to an unsigned type and sign-wrapped into huge lengths that could be forwarded into protocol parsing and cause out-of-bounds `bpf_probe_read` memory disclosure.

This treats the return value in `obi_uprobe_netFdReadRet` as signed by changing `len` from `u64` to `s64` and update the debug print format to use `%lld`, while preserving the existing `len > 0` guard before calling `handle_light_weight_thread_buf`.

The overflow is not something that is expected to happen, given the Go code this instruments, but this ensures safety and prevents bad writes from creeping in.
