### PR TITLE
feat(embedding):add embedding support

### DIFF
--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -536,6 +536,16 @@
       },
       "type": "object"
     },
+    "EmbeddingProviderConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing",
+          "x-env-var": "OTEL_EBPF_HTTP_EMBEDDING_ENABLED"
+        }
+      },
+      "type": "object"
+    },
     "EnrichmentConfig": {
       "properties": {
         "enabled": {
@@ -627,6 +637,10 @@
         "bedrock": {
           "$ref": "#/$defs/BedrockConfig",
           "description": "AWS Bedrock payload extraction and parsing"
+        },
+        "embedding": {
+          "$ref": "#/$defs/EmbeddingProviderConfig",
+          "description": "Generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing"
         },
         "gemini": {
           "$ref": "#/$defs/GeminiConfig",

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -629,10 +629,10 @@ const EmbeddingOperationName = "embeddings"
 // VendorEmbedding represents a generic embedding API provider such as
 // Voyage AI, Cohere, or Jina AI.
 type VendorEmbedding struct {
-	Provider   string
-	Model      string
-	Input      EmbeddingRequest
-	Output     EmbeddingResponse
+	Provider string
+	Model    string
+	Input    EmbeddingRequest
+	Output   EmbeddingResponse
 }
 
 // OperationName returns the canonical embedding operation name.
@@ -646,7 +646,7 @@ type EmbeddingRequest struct {
 	Input      json.RawMessage `json:"input"`
 	Dimensions int             `json:"dimensions,omitempty"`
 	// Cohere uses "texts" instead of "input"
-	Texts      json.RawMessage `json:"texts,omitempty"`
+	Texts json.RawMessage `json:"texts,omitempty"`
 }
 
 // InputCount returns the number of input texts in the request.

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -97,13 +97,15 @@ const (
 	HTTPSubtypeGemini        = 8  // http + Google AI Studio (Gemini)
 	HTTPSubtypeJSONRPC       = 9  // http + JSON-RPC
 	HTTPSubtypeAWSBedrock    = 10 // http + AWS Bedrock
+	HTTPSubtypeEmbedding     = 11 // http + generic embedding provider (Voyage, Cohere, Jina)
 )
 
 func IsGenAISubtype(subtype int) bool {
 	return subtype == HTTPSubtypeOpenAI ||
 		subtype == HTTPSubtypeAnthropic ||
 		subtype == HTTPSubtypeGemini ||
-		subtype == HTTPSubtypeAWSBedrock
+		subtype == HTTPSubtypeAWSBedrock ||
+		subtype == HTTPSubtypeEmbedding
 }
 
 //nolint:cyclop
@@ -253,6 +255,7 @@ type GenAI struct {
 	Anthropic *VendorAnthropic
 	Gemini    *VendorGemini
 	Bedrock   *VendorBedrock
+	Embedding *VendorEmbedding
 }
 
 type OpenAIUsage struct {
@@ -325,6 +328,7 @@ type OpenAIInput struct {
 	Messages     json.RawMessage `json:"messages"`
 	Items        json.RawMessage `json:"items"`
 	Temperature  float64         `json:"temperature"`
+	Dimensions   int             `json:"dimensions,omitempty"`
 }
 
 func (air *OpenAIInput) GetInput() string {
@@ -615,6 +619,91 @@ type JSONRPC struct {
 	RequestID    string `json:"requestId"`
 	ErrorCode    int    `json:"errorCode,omitempty"`
 	ErrorMessage string `json:"errorMessage,omitempty"`
+}
+
+// Generic embedding provider types (Voyage AI, Cohere, Jina AI)
+
+// EmbeddingOperationName is the canonical operation name for embedding spans.
+const EmbeddingOperationName = "embeddings"
+
+// VendorEmbedding represents a generic embedding API provider such as
+// Voyage AI, Cohere, or Jina AI.
+type VendorEmbedding struct {
+	Provider   string
+	Model      string
+	Input      EmbeddingRequest
+	Output     EmbeddingResponse
+}
+
+// OperationName returns the canonical embedding operation name.
+func (e *VendorEmbedding) OperationName() string {
+	return EmbeddingOperationName
+}
+
+// EmbeddingRequest captures the common fields from embedding API requests.
+type EmbeddingRequest struct {
+	Model      string          `json:"model"`
+	Input      json.RawMessage `json:"input"`
+	Dimensions int             `json:"dimensions,omitempty"`
+	// Cohere uses "texts" instead of "input"
+	Texts      json.RawMessage `json:"texts,omitempty"`
+}
+
+// InputCount returns the number of input texts in the request.
+// It handles both single-string and array-of-strings formats.
+func (r *EmbeddingRequest) InputCount() int {
+	raw := r.Input
+	if len(raw) == 0 {
+		raw = r.Texts
+	}
+	if len(raw) == 0 {
+		return 0
+	}
+	// Array of strings: count elements
+	var arr []json.RawMessage
+	if json.Unmarshal(raw, &arr) == nil {
+		return len(arr)
+	}
+	// Single string
+	return 1
+}
+
+// EmbeddingResponse captures the common fields from embedding API responses.
+type EmbeddingResponse struct {
+	Model string         `json:"model"`
+	Usage EmbeddingUsage `json:"usage"`
+	// Cohere uses meta.billed_units for token counts
+	Meta *CohereResponseMeta `json:"meta,omitempty"`
+}
+
+// EmbeddingUsage captures token usage in embedding responses.
+type EmbeddingUsage struct {
+	PromptTokens int `json:"prompt_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}
+
+// CohereResponseMeta captures Cohere-specific response metadata.
+type CohereResponseMeta struct {
+	BilledUnits *CohereBilledUnits `json:"billed_units,omitempty"`
+}
+
+// CohereBilledUnits captures Cohere token billing information.
+type CohereBilledUnits struct {
+	InputTokens int `json:"input_tokens"`
+}
+
+// GetInputTokens returns the input token count, handling provider-specific formats.
+func (e *VendorEmbedding) GetInputTokens() int {
+	if e.Output.Usage.PromptTokens > 0 {
+		return e.Output.Usage.PromptTokens
+	}
+	if e.Output.Usage.TotalTokens > 0 {
+		return e.Output.Usage.TotalTokens
+	}
+	if e.Output.Meta != nil && e.Output.Meta.BilledUnits != nil {
+		return e.Output.Meta.BilledUnits.InputTokens
+	}
+	return 0
 }
 
 // Span contains the information being submitted by the following nodes in the graph.
@@ -1254,6 +1343,18 @@ func (s *Span) TraceName() string {
 			return "invoke_model"
 		}
 
+		if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeEmbedding && s.GenAI != nil && s.GenAI.Embedding != nil {
+			op := s.GenAI.Embedding.OperationName()
+			model := s.GenAI.Embedding.Model
+			if s.GenAI.Embedding.Input.Model != "" {
+				model = s.GenAI.Embedding.Input.Model
+			}
+			if model != "" {
+				return op + " " + model
+			}
+			return op
+		}
+
 		if s.SubType == HTTPSubtypeJSONRPC && s.JSONRPC != nil {
 			if s.JSONRPC.Method != "" {
 				return s.JSONRPC.Method
@@ -1537,6 +1638,9 @@ func (s *Span) GenAIOperationName() string {
 	if s.GenAI.Bedrock != nil {
 		return "invoke_model"
 	}
+	if s.GenAI.Embedding != nil {
+		return s.GenAI.Embedding.OperationName()
+	}
 	return ""
 }
 
@@ -1556,6 +1660,9 @@ func (s *Span) GenAIProviderName() string {
 	if s.GenAI.Bedrock != nil {
 		return semconv.GenAIProviderNameAWSBedrock.Value.AsString()
 	}
+	if s.GenAI.Embedding != nil {
+		return s.GenAI.Embedding.Provider
+	}
 	return ""
 }
 
@@ -1574,6 +1681,12 @@ func (s *Span) GenAIRequestModel() string {
 	}
 	if s.GenAI.Bedrock != nil {
 		return s.GenAI.Bedrock.Model
+	}
+	if s.GenAI.Embedding != nil {
+		if s.GenAI.Embedding.Input.Model != "" {
+			return s.GenAI.Embedding.Input.Model
+		}
+		return s.GenAI.Embedding.Model
 	}
 	return ""
 }
@@ -1596,6 +1709,12 @@ func (s *Span) GenAIResponseModel() string {
 	}
 	if s.GenAI.Bedrock != nil {
 		return s.GenAI.Bedrock.Model
+	}
+	if s.GenAI.Embedding != nil {
+		if s.GenAI.Embedding.Output.Model != "" {
+			return s.GenAI.Embedding.Output.Model
+		}
+		return s.GenAI.Embedding.Model
 	}
 	return ""
 }

--- a/pkg/config/payload_extraction.go
+++ b/pkg/config/payload_extraction.go
@@ -77,11 +77,14 @@ type GenAIConfig struct {
 	Gemini GeminiConfig `yaml:"gemini"`
 	// AWS Bedrock payload extraction and parsing
 	Bedrock BedrockConfig `yaml:"bedrock"`
+	// Generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing
+	Embedding EmbeddingProviderConfig `yaml:"embedding"`
 }
 
 func (g *GenAIConfig) Enabled() bool {
 	return g.Anthropic.Enabled || g.OpenAI.Enabled ||
-		g.Gemini.Enabled || g.Bedrock.Enabled
+		g.Gemini.Enabled || g.Bedrock.Enabled ||
+		g.Embedding.Enabled
 }
 
 type OpenAIConfig struct {
@@ -102,6 +105,11 @@ type GeminiConfig struct {
 type BedrockConfig struct {
 	// Enable AWS Bedrock payload extraction and parsing
 	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_HTTP_BEDROCK_ENABLED" validate:"boolean"`
+}
+
+type EmbeddingProviderConfig struct {
+	// Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing
+	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_HTTP_EMBEDDING_ENABLED" validate:"boolean"`
 }
 
 type JSONRPCConfig struct {

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -1,0 +1,104 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+)
+
+// embeddingHostPattern pairs a known hostname suffix with a required URL path
+// prefix and the provider name to assign when matched.
+type embeddingHostPattern struct {
+	hostSuffix string
+	pathPrefix string
+	provider   string
+}
+
+// embeddingHostPatterns lists known embedding API hosts and their required
+// URL path prefixes. Matching is performed by hostname suffix and path prefix.
+var embeddingHostPatterns = []embeddingHostPattern{
+	{"api.voyageai.com", "/v1/embeddings", "voyage"},
+	{"api.cohere.com", "/v2/embed", "cohere"},
+	{"api.jina.ai", "/v1/embeddings", "jina"},
+}
+
+// isEmbeddingProvider checks whether the request targets a known embedding-only
+// provider by matching the hostname and URL path against embeddingHostPatterns.
+// Returns the provider name if matched, or empty string otherwise.
+func isEmbeddingProvider(req *http.Request) string {
+	if req == nil || req.URL == nil {
+		return ""
+	}
+
+	host := extractHostname(req)
+	path := req.URL.Path
+
+	for _, hp := range embeddingHostPatterns {
+		if strings.HasSuffix(host, hp.hostSuffix) &&
+			strings.HasPrefix(path, hp.pathPrefix) {
+			return hp.provider
+		}
+	}
+
+	return ""
+}
+
+// EmbeddingSpan detects embedding API calls to Voyage AI, Cohere, and Jina AI
+// based on hostname and URL path matching, and extracts embedding-specific
+// fields into the span.
+func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {
+	provider := isEmbeddingProvider(req)
+	if provider == "" {
+		return *baseSpan, false
+	}
+
+	reqB, err := io.ReadAll(req.Body)
+	if err != nil {
+		return *baseSpan, false
+	}
+	req.Body = io.NopCloser(bytes.NewBuffer(reqB))
+
+	respB, err := getResponseBody(resp)
+	if err != nil && len(respB) == 0 {
+		return *baseSpan, false
+	}
+
+	slog.Debug("Embedding", "provider", provider, "request", string(reqB), "response", string(respB))
+
+	var parsedRequest request.EmbeddingRequest
+	if err := json.Unmarshal(reqB, &parsedRequest); err != nil {
+		slog.Debug("failed to parse embedding request", "provider", provider, "error", err)
+	}
+
+	var parsedResponse request.EmbeddingResponse
+	if len(respB) > 0 {
+		if err := json.Unmarshal(respB, &parsedResponse); err != nil {
+			slog.Debug("failed to parse embedding response", "provider", provider, "error", err)
+		}
+	}
+
+	model := parsedRequest.Model
+	if model == "" {
+		model = parsedResponse.Model
+	}
+
+	baseSpan.SubType = request.HTTPSubtypeEmbedding
+	baseSpan.GenAI = &request.GenAI{
+		Embedding: &request.VendorEmbedding{
+			Provider: provider,
+			Model:    model,
+			Input:    parsedRequest,
+			Output:   parsedResponse,
+		},
+	}
+
+	return *baseSpan, true
+}

--- a/pkg/ebpf/common/http/embedding_test.go
+++ b/pkg/ebpf/common/http/embedding_test.go
@@ -1,0 +1,208 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+)
+
+const voyageRequestBody = `{"model":"voyage-3","input":["Hello world","Goodbye world"]}`
+
+const voyageResponseBody = `{
+  "object": "list",
+  "data": [
+    {"object": "embedding", "embedding": [0.1, 0.2], "index": 0},
+    {"object": "embedding", "embedding": [0.3, 0.4], "index": 1}
+  ],
+  "model": "voyage-3",
+  "usage": {"total_tokens": 8}
+}`
+
+const cohereRequestBody = `{"model":"embed-english-v3.0","texts":["Hello world"],"input_type":"search_document"}`
+
+const cohereResponseBody = `{
+  "id": "emb-123",
+  "embeddings": {"float": [[0.1, 0.2]]},
+  "meta": {"api_version": {"version": "2"}, "billed_units": {"input_tokens": 4}}
+}`
+
+const jinaRequestBody = `{"model":"jina-embeddings-v3","input":["Hello world"],"dimensions":512}`
+
+const jinaResponseBody = `{
+  "model": "jina-embeddings-v3",
+  "object": "list",
+  "data": [
+    {"object": "embedding", "embedding": [0.1, 0.2], "index": 0}
+  ],
+  "usage": {"prompt_tokens": 6, "total_tokens": 6}
+}`
+
+func TestEmbeddingSpan_VoyageAI(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "https://api.voyageai.com/v1/embeddings", voyageRequestBody)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, voyageResponseBody)
+
+	base := &request.Span{}
+	span, ok := EmbeddingSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Embedding)
+	assert.Equal(t, request.HTTPSubtypeEmbedding, span.SubType)
+
+	ai := span.GenAI.Embedding
+	assert.Equal(t, "voyage", ai.Provider)
+	assert.Equal(t, "voyage-3", ai.Model)
+	assert.Equal(t, "embeddings", ai.OperationName())
+	assert.Equal(t, 8, ai.GetInputTokens())
+	assert.Equal(t, 2, ai.Input.InputCount())
+}
+
+func TestEmbeddingSpan_Cohere(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "https://api.cohere.com/v2/embed", cohereRequestBody)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, cohereResponseBody)
+
+	base := &request.Span{}
+	span, ok := EmbeddingSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Embedding)
+	assert.Equal(t, request.HTTPSubtypeEmbedding, span.SubType)
+
+	ai := span.GenAI.Embedding
+	assert.Equal(t, "cohere", ai.Provider)
+	assert.Equal(t, "embed-english-v3.0", ai.Model)
+	assert.Equal(t, "embeddings", ai.OperationName())
+	assert.Equal(t, 4, ai.GetInputTokens())
+	assert.Equal(t, 1, ai.Input.InputCount())
+}
+
+func TestEmbeddingSpan_JinaAI(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "https://api.jina.ai/v1/embeddings", jinaRequestBody)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, jinaResponseBody)
+
+	base := &request.Span{}
+	span, ok := EmbeddingSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Embedding)
+	assert.Equal(t, request.HTTPSubtypeEmbedding, span.SubType)
+
+	ai := span.GenAI.Embedding
+	assert.Equal(t, "jina", ai.Provider)
+	assert.Equal(t, "jina-embeddings-v3", ai.Model)
+	assert.Equal(t, "embeddings", ai.OperationName())
+	assert.Equal(t, 6, ai.GetInputTokens())
+	assert.Equal(t, 512, ai.Input.Dimensions)
+	assert.Equal(t, 1, ai.Input.InputCount())
+}
+
+func TestEmbeddingSpan_NotEmbeddingProvider(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "http://example.com/api", `{"query":"hello"}`)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, `{"result":"ok"}`)
+
+	base := &request.Span{}
+	_, ok := EmbeddingSpan(base, req, resp)
+
+	assert.False(t, ok, "should not be detected as embedding provider for unknown host")
+}
+
+func TestIsEmbeddingProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "Voyage AI",
+			url:      "https://api.voyageai.com/v1/embeddings",
+			expected: "voyage",
+		},
+		{
+			name:     "Cohere",
+			url:      "https://api.cohere.com/v2/embed",
+			expected: "cohere",
+		},
+		{
+			name:     "Jina AI",
+			url:      "https://api.jina.ai/v1/embeddings",
+			expected: "jina",
+		},
+		{
+			name:     "unknown host",
+			url:      "https://api.example.com/v1/embeddings",
+			expected: "",
+		},
+		{
+			name:     "wrong path for cohere",
+			url:      "https://api.cohere.com/v1/embeddings",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := makeRequest(t, http.MethodPost, tt.url, "{}")
+			assert.Equal(t, tt.expected, isEmbeddingProvider(req))
+		})
+	}
+}
+
+func TestEmbeddingSpan_TraceName(t *testing.T) {
+	span := &request.Span{
+		Type:    request.EventTypeHTTPClient,
+		SubType: request.HTTPSubtypeEmbedding,
+		GenAI: &request.GenAI{
+			Embedding: &request.VendorEmbedding{
+				Provider: "voyage",
+				Model:    "voyage-3",
+			},
+		},
+	}
+	assert.Equal(t, "embeddings voyage-3", span.TraceName())
+
+	spanNoModel := &request.Span{
+		Type:    request.EventTypeHTTPClient,
+		SubType: request.HTTPSubtypeEmbedding,
+		GenAI: &request.GenAI{
+			Embedding: &request.VendorEmbedding{
+				Provider: "cohere",
+			},
+		},
+	}
+	assert.Equal(t, "embeddings", spanNoModel.TraceName())
+}
+
+func TestEmbeddingInputCount(t *testing.T) {
+	// array of strings
+	r := &request.EmbeddingRequest{Input: []byte(`["hello", "world"]`)}
+	assert.Equal(t, 2, r.InputCount())
+
+	// single string
+	r2 := &request.EmbeddingRequest{Input: []byte(`"hello"`)}
+	assert.Equal(t, 1, r2.InputCount())
+
+	// empty
+	r3 := &request.EmbeddingRequest{}
+	assert.Equal(t, 0, r3.InputCount())
+
+	// Cohere texts field
+	r4 := &request.EmbeddingRequest{Texts: []byte(`["hello"]`)}
+	assert.Equal(t, 1, r4.InputCount())
+}

--- a/pkg/ebpf/common/http/openai.go
+++ b/pkg/ebpf/common/http/openai.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
@@ -51,6 +52,11 @@ func OpenAISpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 	}
 
 	parsedResponse.Request = parsedRequest
+
+	// Override operation name for embedding requests.
+	if req.URL != nil && strings.Contains(req.URL.Path, "/v1/embeddings") {
+		parsedResponse.OperationName = request.EmbeddingOperationName
+	}
 
 	baseSpan.SubType = request.HTTPSubtypeOpenAI
 	baseSpan.GenAI = &request.GenAI{

--- a/pkg/ebpf/common/http/openai_test.go
+++ b/pkg/ebpf/common/http/openai_test.go
@@ -286,3 +286,43 @@ func TestOpenAIInput_GetInput(t *testing.T) {
 	inp4 := &request.OpenAIInput{Items: []byte(`[{"item":1}]`)}
 	assert.JSONEq(t, `[{"item":1}]`, inp4.GetInput())
 }
+
+const embeddingsRequestBody = `{"input":"The food was delicious","model":"text-embedding-3-small","dimensions":256}`
+
+const embeddingsResponseBody = `{
+  "object": "list",
+  "data": [
+    {
+      "object": "embedding",
+      "embedding": [0.0023064255, -0.009327292],
+      "index": 0
+    }
+  ],
+  "model": "text-embedding-3-small",
+  "usage": {
+    "prompt_tokens": 5,
+    "total_tokens": 5
+  }
+}`
+
+func TestOpenAISpan_Embeddings(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "http://api.openai.com/v1/embeddings", embeddingsRequestBody)
+	resp := makeGzipResponse(t, http.StatusOK, openAIHeaders(), embeddingsResponseBody)
+
+	base := &request.Span{}
+	span, ok := OpenAISpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI.OpenAI)
+	assert.Equal(t, request.HTTPSubtypeOpenAI, span.SubType)
+
+	ai := span.GenAI.OpenAI
+	assert.Equal(t, "embeddings", ai.OperationName)
+	assert.Equal(t, "text-embedding-3-small", ai.ResponseModel)
+	assert.Equal(t, 5, ai.Usage.GetInputTokens())
+
+	// request fields
+	assert.Equal(t, "text-embedding-3-small", ai.Request.Model)
+	assert.Equal(t, 256, ai.Request.Dimensions)
+	assert.Equal(t, "The food was delicious", ai.Request.Input)
+}

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -197,6 +197,13 @@ func httpRequestResponseToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo, r
 		}
 	}
 
+	if isClientEvent(event.Type) && parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Embedding.Enabled {
+		span, ok := ebpfhttp.EmbeddingSpan(&httpSpan, req, resp)
+		if ok {
+			return span
+		}
+	}
+
 	if parseCtx != nil && parseCtx.payloadExtraction.HTTP.JSONRPC.Enabled {
 		span, ok := ebpfhttp.JSONRPCSpan(&httpSpan, req, resp)
 		if ok {

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -515,6 +515,10 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Error.Type))
 				attrs = append(attrs, semconv.ErrorMessage(ai.Error.Message))
 			}
+			// embedding-specific extension attributes
+			if ai.OperationName == request.EmbeddingOperationName && ai.Request.Dimensions > 0 {
+				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.dimensions", ai.Request.Dimensions))
+			}
 		}
 
 		if span.SubType == request.HTTPSubtypeAnthropic && span.GenAI != nil && span.GenAI.Anthropic != nil {
@@ -664,6 +668,29 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			if ai.Output.ErrorType != "" {
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Output.ErrorType))
 				attrs = append(attrs, semconv.ErrorMessage(ai.Output.ErrorMessage))
+			}
+		}
+
+		if span.SubType == request.HTTPSubtypeEmbedding && span.GenAI != nil && span.GenAI.Embedding != nil {
+			ai := span.GenAI.Embedding
+			attrs = append(attrs, semconv.GenAIProviderNameKey.String(ai.Provider))
+			attrs = append(attrs, semconv.GenAIOperationNameKey.String(ai.OperationName()))
+			model := ai.Input.Model
+			if model == "" {
+				model = ai.Model
+			}
+			attrs = append(attrs, semconv.GenAIRequestModel(model))
+			if ai.Output.Model != "" {
+				attrs = append(attrs, semconv.GenAIResponseModel(ai.Output.Model))
+			} else {
+				attrs = append(attrs, semconv.GenAIResponseModel(model))
+			}
+			attrs = append(attrs, semconv.GenAIUsageInputTokens(ai.GetInputTokens()))
+			if ai.Input.Dimensions > 0 {
+				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.dimensions", ai.Input.Dimensions))
+			}
+			if count := ai.Input.InputCount(); count > 0 {
+				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.input_count", count))
 			}
 		}
 


### PR DESCRIPTION
## Summary

Add embedding operation detection for GenAI providers
Add support for detecting vector embedding API calls across multiple providers, enabling observability for embedding operations in RAG systems and similar architectures.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
