### PR TITLE
Add debug events to `netolly` and `statsolly` userspace

### DIFF
--- a/pkg/internal/ebpf/logger/logger.go
+++ b/pkg/internal/ebpf/logger/logger.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 
+	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
@@ -85,12 +86,49 @@ func (p *BPFLogger) Run(ctx context.Context) {
 	)(ctx, nil)
 }
 
-func (p *BPFLogger) processLogEvent(record *ringbuf.Record) (request.Span, bool, error) {
+func logDebugEvent(log *slog.Logger, record *ringbuf.Record) {
 	event, err := ebpfcommon.ReinterpretCast[BPFLogInfo](record.RawSample)
-
 	if err == nil {
-		p.log.Debug(unix.ByteSliceToString(event.Log[:]), "pid", event.Pid, "comm", unix.ByteSliceToString(event.Comm[:]))
+		log.Debug(unix.ByteSliceToString(event.Log[:]),
+			"pid", event.Pid,
+			"comm", unix.ByteSliceToString(event.Comm[:]))
+	}
+}
+
+func (p *BPFLogger) processLogEvent(record *ringbuf.Record) (request.Span, bool, error) {
+	logDebugEvent(p.log, record)
+	return request.Span{}, true, nil
+}
+
+// RunDebugEventsReader can be used by any subsystem that loads BPF programs including
+// bpf_dbg.h but doesn't go through the main appolly pipeline (e.g. statsolly, netolly).
+func RunDebugEventsReader(ctx context.Context, debugEventsMap *ebpf.Map, log *slog.Logger) {
+	if debugEventsMap == nil {
+		return
 	}
 
-	return request.Span{}, true, nil
+	reader, err := ringbuf.NewReader(debugEventsMap)
+	if err != nil {
+		log.Error("failed to create debug events reader", "error", err)
+		return
+	}
+
+	go func() {
+		<-ctx.Done()
+		reader.Close()
+	}()
+
+	go func() {
+		for {
+			record, err := reader.Read()
+			if err != nil {
+				if errors.Is(err, ringbuf.ErrClosed) {
+					return
+				}
+				log.Error("reading debug event", "error", err)
+				continue
+			}
+			logDebugEvent(log, &record)
+		}
+	}()
 }

--- a/pkg/internal/ebpf/logger/logger.go
+++ b/pkg/internal/ebpf/logger/logger.go
@@ -100,9 +100,10 @@ func (p *BPFLogger) processLogEvent(record *ringbuf.Record) (request.Span, bool,
 	return request.Span{}, true, nil
 }
 
-// RunDebugEventsReader can be used by any subsystem that loads BPF programs including
+// ReadDebugEventsMap can be used by any subsystem that loads BPF programs including
 // bpf_dbg.h but doesn't go through the main appolly pipeline (e.g. statsolly, netolly).
-func RunDebugEventsReader(ctx context.Context, debugEventsMap *ebpf.Map, log *slog.Logger) {
+// This is a blocking function. Callers should invoke it with `go ReadDebugEventsMap(..)`.
+func ReadDebugEventsMap(ctx context.Context, debugEventsMap *ebpf.Map, log *slog.Logger) {
 	if debugEventsMap == nil {
 		return
 	}
@@ -112,23 +113,18 @@ func RunDebugEventsReader(ctx context.Context, debugEventsMap *ebpf.Map, log *sl
 		log.Error("failed to create debug events reader", "error", err)
 		return
 	}
+	stop := context.AfterFunc(ctx, func() { reader.Close() })
+	defer stop()
 
-	go func() {
-		<-ctx.Done()
-		reader.Close()
-	}()
-
-	go func() {
-		for {
-			record, err := reader.Read()
-			if err != nil {
-				if errors.Is(err, ringbuf.ErrClosed) {
-					return
-				}
-				log.Error("reading debug event", "error", err)
-				continue
+	for {
+		record, err := reader.Read()
+		if err != nil {
+			if errors.Is(err, ringbuf.ErrClosed) {
+				return
 			}
-			logDebugEvent(log, &record)
+			log.Error("reading debug event", "error", err)
+			continue
 		}
-	}()
+		logDebugEvent(log, &record)
+	}
 }

--- a/pkg/internal/ebpf/logger/logger.go
+++ b/pkg/internal/ebpf/logger/logger.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"time"
 
 	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
@@ -88,11 +89,13 @@ func (p *BPFLogger) Run(ctx context.Context) {
 
 func logDebugEvent(log *slog.Logger, record *ringbuf.Record) {
 	event, err := ebpfcommon.ReinterpretCast[BPFLogInfo](record.RawSample)
-	if err == nil {
-		log.Debug(unix.ByteSliceToString(event.Log[:]),
-			"pid", event.Pid,
-			"comm", unix.ByteSliceToString(event.Comm[:]))
+	if err != nil {
+		log.Debug("failed to decode debug event", "error", err)
+		return
 	}
+	log.Debug(unix.ByteSliceToString(event.Log[:]),
+		"pid", event.Pid,
+		"comm", unix.ByteSliceToString(event.Comm[:]))
 }
 
 func (p *BPFLogger) processLogEvent(record *ringbuf.Record) (request.Span, bool, error) {
@@ -116,13 +119,21 @@ func ReadDebugEventsMap(ctx context.Context, debugEventsMap *ebpf.Map, log *slog
 	stop := context.AfterFunc(ctx, func() { reader.Close() })
 	defer stop()
 
+	record := ringbuf.Record{}
+
 	for {
-		record, err := reader.Read()
+		err := reader.ReadInto(&record)
 		if err != nil {
 			if errors.Is(err, ringbuf.ErrClosed) {
 				return
 			}
 			log.Error("reading debug event", "error", err)
+			// Back off so a persistent error (e.g. invalid FD) doesn't spin the CPU.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(time.Second):
+			}
 			continue
 		}
 		logDebugEvent(log, &record)

--- a/pkg/internal/netolly/ebpf/sock_tracer.go
+++ b/pkg/internal/netolly/ebpf/sock_tracer.go
@@ -146,6 +146,10 @@ func (m *SockFlowFetcher) LookupPacketStats() (NetPacketCount, error) {
 	return lookupPacketStats(m.objects.FlowPacketStats)
 }
 
+func (m *SockFlowFetcher) DebugEventsMap() *ebpf.Map {
+	return m.objects.DebugEvents
+}
+
 // Close any resources that are taken up by the socket filter, the filter itself and some maps.
 func (m *SockFlowFetcher) Close() error {
 	m.log.Debug("unregistering eBPF objects")

--- a/pkg/internal/netolly/ebpf/sock_tracer_nolinux.go
+++ b/pkg/internal/netolly/ebpf/sock_tracer_nolinux.go
@@ -6,6 +6,8 @@
 package ebpf // import "go.opentelemetry.io/obi/pkg/internal/netolly/ebpf"
 
 import (
+	cebpf "github.com/cilium/ebpf"
+
 	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/netolly/flowdef"
@@ -29,7 +31,7 @@ func (s *SockFlowFetcher) LookupPacketStats() (NetPacketCount, error) {
 	panic("this is never going to be executed")
 }
 
-func (s *SockFlowFetcher) DebugEventsMap() *ebpf.Map {
+func (s *SockFlowFetcher) DebugEventsMap() *cebpf.Map {
 	return nil
 }
 

--- a/pkg/internal/netolly/ebpf/sock_tracer_nolinux.go
+++ b/pkg/internal/netolly/ebpf/sock_tracer_nolinux.go
@@ -29,6 +29,10 @@ func (s *SockFlowFetcher) LookupPacketStats() (NetPacketCount, error) {
 	panic("this is never going to be executed")
 }
 
+func (s *SockFlowFetcher) DebugEventsMap() *ebpf.Map {
+	return nil
+}
+
 func NewSockFlowFetcher(
 	_, _ int, _ flowdef.PortGuessPolicy, _ *config.EBPFTracer,
 ) (*SockFlowFetcher, error) {

--- a/pkg/internal/netolly/ebpf/tracer.go
+++ b/pkg/internal/netolly/ebpf/tracer.go
@@ -202,6 +202,10 @@ func (m *FlowFetcher) LookupPacketStats() (NetPacketCount, error) {
 	return lookupPacketStats(m.objects.FlowPacketStats)
 }
 
+func (m *FlowFetcher) DebugEventsMap() *ebpf.Map {
+	return m.objects.DebugEvents
+}
+
 func (m *FlowFetcher) ReadRingBuf() (ringbuf.Record, error) {
 	return m.ringbufReader.Read()
 }

--- a/pkg/internal/netolly/ebpf/tracer_nonlinux.go
+++ b/pkg/internal/netolly/ebpf/tracer_nonlinux.go
@@ -42,3 +42,7 @@ func (m *FlowFetcher) LookupAndDeleteMap() map[NetFlowId]*NetFlowMetrics {
 func (m *FlowFetcher) LookupPacketStats() (NetPacketCount, error) {
 	panic("this is never going to be executed")
 }
+
+func (m *FlowFetcher) DebugEventsMap() *ebpf.Map {
+	return nil
+}

--- a/pkg/internal/netolly/ebpf/tracer_nonlinux.go
+++ b/pkg/internal/netolly/ebpf/tracer_nonlinux.go
@@ -6,6 +6,8 @@
 package ebpf // import "go.opentelemetry.io/obi/pkg/internal/netolly/ebpf"
 
 import (
+	cebpf "github.com/cilium/ebpf"
+
 	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/tcmanager"
@@ -43,6 +45,6 @@ func (m *FlowFetcher) LookupPacketStats() (NetPacketCount, error) {
 	panic("this is never going to be executed")
 }
 
-func (m *FlowFetcher) DebugEventsMap() *ebpf.Map {
+func (m *FlowFetcher) DebugEventsMap() *cebpf.Map {
 	return nil
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -46,9 +46,9 @@ const (
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -type tcp_rtt_t -type tcp_failed_connection_t -target amd64,arm64 Stats ../../../../bpf/statsolly/stats.c -- -I../../../../bpf
 
 type StatsFetcher struct {
-	log         *slog.Logger
-	statsEvents *ebpf.Map
-	closables   []io.Closer
+	log       *slog.Logger
+	objects   *StatsObjects
+	closables []io.Closer
 }
 
 func tlog() *slog.Logger {
@@ -126,9 +126,9 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 	}
 
 	return &StatsFetcher{
-		log:         tlog,
-		statsEvents: objects.StatsEvents,
-		closables:   closables,
+		log:       tlog,
+		objects:   &objects,
+		closables: closables,
 	}, nil
 }
 
@@ -156,5 +156,9 @@ func (m *StatsFetcher) Close() error {
 // StatsEventsMap returns the ring buffer map for stats events.
 // The caller (ForwardRingbuf) is responsible for creating and closing the reader.
 func (m *StatsFetcher) StatsEventsMap() *ebpf.Map {
-	return m.statsEvents
+	return m.objects.StatsEvents
+}
+
+func (m *StatsFetcher) DebugEventsMap() *ebpf.Map {
+	return m.objects.DebugEvents
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
@@ -56,3 +56,7 @@ func (m *StatsFetcher) Close() error {
 func (m *StatsFetcher) StatsEventsMap() *ciliumebpf.Map {
 	return nil
 }
+
+func (m *StatsFetcher) DebugEventsMap() *ciliumebpf.Map {
+	return nil
+}

--- a/pkg/netolly/agent/agent.go
+++ b/pkg/netolly/agent/agent.go
@@ -244,7 +244,7 @@ func (f *Flows) Run(ctx context.Context) error {
 	alog.Info("starting Flows agent")
 
 	if f.cfg.EBPF.BpfDebug {
-		logger.RunDebugEventsReader(ctx, f.ebpf.DebugEventsMap(),
+		go logger.ReadDebugEventsMap(ctx, f.ebpf.DebugEventsMap(),
 			slog.With("component", "netolly.BPFDebug"))
 	}
 

--- a/pkg/netolly/agent/agent.go
+++ b/pkg/netolly/agent/agent.go
@@ -115,7 +115,6 @@ type ebpfFlowFetcher interface {
 	ReadRingBuf() (ringbuf.Record, error)
 
 	LookupPacketStats() (ebpf.NetPacketCount, error)
-	FlowPacketStatsMap() *cebpf.Map
 	DebugEventsMap() *cebpf.Map
 }
 
@@ -243,8 +242,11 @@ func (f *Flows) Run(ctx context.Context) error {
 	f.status = StatusStarting
 	alog.Info("starting Flows agent")
 
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	if f.cfg.EBPF.BpfDebug {
-		go logger.ReadDebugEventsMap(ctx, f.ebpf.DebugEventsMap(),
+		go logger.ReadDebugEventsMap(runCtx, f.ebpf.DebugEventsMap(),
 			slog.With("component", "netolly.BPFDebug"))
 	}
 

--- a/pkg/netolly/agent/agent.go
+++ b/pkg/netolly/agent/agent.go
@@ -30,6 +30,9 @@ import (
 	"net"
 	"time"
 
+	cebpf "github.com/cilium/ebpf"
+
+	"go.opentelemetry.io/obi/pkg/internal/ebpf/logger"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/tcmanager"
 	"go.opentelemetry.io/obi/pkg/internal/netolly/ebpf"
@@ -112,6 +115,8 @@ type ebpfFlowFetcher interface {
 	ReadRingBuf() (ringbuf.Record, error)
 
 	LookupPacketStats() (ebpf.NetPacketCount, error)
+	FlowPacketStatsMap() *cebpf.Map
+	DebugEventsMap() *cebpf.Map
 }
 
 // FlowsAgent instantiates a new agent, given a configuration.
@@ -237,6 +242,11 @@ func (f *Flows) Run(ctx context.Context) error {
 
 	f.status = StatusStarting
 	alog.Info("starting Flows agent")
+
+	if f.cfg.EBPF.BpfDebug {
+		logger.RunDebugEventsReader(ctx, f.ebpf.DebugEventsMap(),
+			slog.With("component", "netolly.BPFDebug"))
+	}
 
 	graph, err := f.buildPipeline(ctx)
 	if err != nil {

--- a/pkg/statsolly/agent/agent.go
+++ b/pkg/statsolly/agent/agent.go
@@ -139,7 +139,7 @@ func (s *Stats) Run(ctx context.Context) error {
 	alog.Info("starting Stats agent")
 
 	if s.cfg.EBPF.BpfDebug {
-		logger.RunDebugEventsReader(ctx, s.fetcher.DebugEventsMap(),
+		go logger.ReadDebugEventsMap(ctx, s.fetcher.DebugEventsMap(),
 			slog.With("component", "statsolly.BPFDebug"))
 	}
 

--- a/pkg/statsolly/agent/agent.go
+++ b/pkg/statsolly/agent/agent.go
@@ -16,6 +16,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/internal/ebpf/logger"
 	"go.opentelemetry.io/obi/pkg/internal/statsolly/ebpf"
 	stats "go.opentelemetry.io/obi/pkg/internal/statsolly/stats"
 	"go.opentelemetry.io/obi/pkg/netip"
@@ -80,6 +81,7 @@ type Stats struct {
 type ebpFetcher interface {
 	io.Closer
 	StatsEventsMap() *ciliumebpf.Map
+	DebugEventsMap() *ciliumebpf.Map
 }
 
 func StatsAgent(ctxInfo *global.ContextInfo, cfg *obi.Config) (*Stats, error) {
@@ -135,6 +137,11 @@ func (s *Stats) Run(ctx context.Context) error {
 
 	s.status = StatusStarting
 	alog.Info("starting Stats agent")
+
+	if s.cfg.EBPF.BpfDebug {
+		logger.RunDebugEventsReader(ctx, s.fetcher.DebugEventsMap(),
+			slog.With("component", "statsolly.BPFDebug"))
+	}
 
 	graph, err := s.buildPipeline(ctx)
 	if err != nil {

--- a/pkg/statsolly/agent/agent.go
+++ b/pkg/statsolly/agent/agent.go
@@ -138,8 +138,11 @@ func (s *Stats) Run(ctx context.Context) error {
 	s.status = StatusStarting
 	alog.Info("starting Stats agent")
 
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	if s.cfg.EBPF.BpfDebug {
-		go logger.ReadDebugEventsMap(ctx, s.fetcher.DebugEventsMap(),
+		go logger.ReadDebugEventsMap(runCtx, s.fetcher.DebugEventsMap(),
 			slog.With("component", "statsolly.BPFDebug"))
 	}
 


### PR DESCRIPTION
## Summary

This PR enables `netolly` and `statsolly` userspace to read from the shared `debug_events` map via a common reader.

I noticed that `bpf_dbg_printk` calls in netolly were lost in userspace. `statsolly` only uses `bpf_d_printk`, but it was also missing a userspace reader.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
