### PR TITLE
feat(embedding): add embedding support

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -78,7 +78,7 @@ through language-specific library instrumentation documented later in this file.
 | AWS S3 | All | `CreateBucket`, `DeleteBucket`, `PutObject`, `DeleteObject`, `ListBuckets`, `ListObjects`, `GetObject` | Yes | No | None documented |
 | AWS SQS | All | All | Yes | No | None documented |
 | SQL++ | All | All | Yes | No | None documented |
-| GenAI | All | All | Yes | No | Supported vendors are OpenAI, Anthropic, Google AI Studio (Gemini), AWS Bedrock, and Qwen (DashScope) |
+| GenAI | All | All | Yes | No | Supported vendors are OpenAI, Anthropic, Google AI Studio (Gemini), AWS Bedrock, Qwen (DashScope), and generic embedding providers (Voyage AI, Cohere, Jina AI) |
 
 ## Runtime, Server, And Library Instrumentation
 

--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -253,6 +253,12 @@ HTTPParsingPolicy defines the default action for http enrichment rules.
 |---|---|---|---|---|---|---|
 | `ebpf.payload_extraction.http.genai.bedrock.enabled` | `boolean` | `OTEL_EBPF_HTTP_BEDROCK_ENABLED` | `false` |  |  | Enable AWS Bedrock payload extraction and parsing |
 
+#### `ebpf.payload_extraction.http.genai.embedding`
+
+| YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
+|---|---|---|---|---|---|---|
+| `ebpf.payload_extraction.http.genai.embedding.enabled` | `boolean` | `OTEL_EBPF_HTTP_EMBEDDING_ENABLED` | `false` |  |  | Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing |
+
 #### `ebpf.payload_extraction.http.genai.gemini`
 
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |

--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -257,7 +257,7 @@ HTTPParsingPolicy defines the default action for http enrichment rules.
 
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
 |---|---|---|---|---|---|---|
-| `ebpf.payload_extraction.http.genai.embedding.enabled` | `boolean` | `OTEL_EBPF_HTTP_EMBEDDING_ENABLED` | `false` |  |  | Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing |
+| `ebpf.payload_extraction.http.genai.embedding.enabled` | `boolean` | `OTEL_EBPF_HTTP_GENAI_EMBEDDING_ENABLED` | `false` |  |  | Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing |
 
 #### `ebpf.payload_extraction.http.genai.gemini`
 

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -756,6 +756,16 @@
       },
       "type": "object"
     },
+    "EmbeddingProviderConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing",
+          "x-env-var": "OTEL_EBPF_HTTP_EMBEDDING_ENABLED"
+        }
+      },
+      "type": "object"
+    },
     "EnrichmentConfig": {
       "properties": {
         "enabled": {
@@ -849,6 +859,10 @@
         "bedrock": {
           "$ref": "#/$defs/BedrockConfig",
           "description": "AWS Bedrock payload extraction and parsing"
+        },
+        "embedding": {
+          "$ref": "#/$defs/EmbeddingProviderConfig",
+          "description": "Generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing"
         },
         "gemini": {
           "$ref": "#/$defs/GeminiConfig",

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -762,7 +762,7 @@
           "type": "boolean",
           "description": "Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing",
           "default": false,
-          "x-env-var": "OTEL_EBPF_HTTP_EMBEDDING_ENABLED"
+          "x-env-var": "OTEL_EBPF_HTTP_GENAI_EMBEDDING_ENABLED"
         }
       },
       "type": "object"

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -761,6 +761,7 @@
         "enabled": {
           "type": "boolean",
           "description": "Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing",
+          "default": false,
           "x-env-var": "OTEL_EBPF_HTTP_EMBEDDING_ENABLED"
         }
       },

--- a/devdocs/features.md
+++ b/devdocs/features.md
@@ -25,7 +25,7 @@ through language-specific library instrumentation documented later in this file.
 | AWS S3        |    All    |         All | CreateBucket, DeleteBucket, PutObject, DeleteObject, ListBuckets, ListObjects, GetObject |  Yes   |                 No |                                                                                                                             N/A
 | AWS SQS       |    All    |         All | All                                                                                      |  Yes   |                 No |                                                                                                                             N/A
 | SQL++         |    All    |         All | All                                                                                      |  Yes   |                 No |                                                                                                                             N/A
-| GenAI         |    All    |         All | All                                                                                      |  Yes   |                 No |                                                                          Supported vendors: OpenAI, Anthropic, Google AI Studio (Gemini), AWS Bedrock, Qwen (DashScope)
+| GenAI         |    All    |         All | All                                                                                      |  Yes   |                 No |                                                                          Supported vendors: OpenAI, Anthropic, Google AI Studio (Gemini), AWS Bedrock, Qwen (DashScope), and generic embedding providers (Voyage AI, Cohere, Jina AI)
 
 ## Go Instrumentation
 

--- a/docs/config-schema.json
+++ b/docs/config-schema.json
@@ -536,6 +536,16 @@
       },
       "type": "object"
     },
+    "EmbeddingProviderConfig": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing",
+          "x-env-var": "OTEL_EBPF_HTTP_EMBEDDING_ENABLED"
+        }
+      },
+      "type": "object"
+    },
     "EnrichmentConfig": {
       "properties": {
         "enabled": {
@@ -627,6 +637,10 @@
         "bedrock": {
           "$ref": "#/$defs/BedrockConfig",
           "description": "AWS Bedrock payload extraction and parsing"
+        },
+        "embedding": {
+          "$ref": "#/$defs/EmbeddingProviderConfig",
+          "description": "Generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing"
         },
         "gemini": {
           "$ref": "#/$defs/GeminiConfig",

--- a/internal/test/integration/components/ai/openai/main.py
+++ b/internal/test/integration/components/ai/openai/main.py
@@ -32,6 +32,17 @@ async def error_messages():
     resp = requests.post(f"{OPENAI_BASE_URL}/v1/responses?error", json=payload)
     return resp.json()
 
+@app.get("/embeddings")
+async def embeddings():
+    payload = {
+        "input": "The food was delicious",
+        "model": "text-embedding-3-small",
+        "dimensions": 256,
+    }
+    resp = requests.post(f"{OPENAI_BASE_URL}/v1/embeddings", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+
 @app.get("/chat")
 async def createobject():
     payload = {

--- a/internal/test/integration/components/ai/openai/mock-server/main.go
+++ b/internal/test/integration/components/ai/openai/mock-server/main.go
@@ -145,6 +145,22 @@ const conversationBody = `
 }
 `
 
+const embeddingsBody = `{
+  "object": "list",
+  "data": [
+    {
+      "object": "embedding",
+      "embedding": [0.0023064255, -0.009327292],
+      "index": 0
+    }
+  ],
+  "model": "text-embedding-3-small",
+  "usage": {
+    "prompt_tokens": 5,
+    "total_tokens": 5
+  }
+}`
+
 type responsesRequest struct {
 	Input        string `json:"input"`
 	Instructions string `json:"instructions"`
@@ -297,6 +313,65 @@ type conversationRequest struct {
 	Metadata json.RawMessage `json:"metadata"`
 }
 
+type embeddingsRequest struct {
+	Model      string          `json:"model"`
+	Input      json.RawMessage `json:"input"`
+	Dimensions int             `json:"dimensions"`
+}
+
+func handleEmbeddings(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to read request body: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	var req embeddingsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid JSON: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	var validationErrors []string
+	if len(req.Input) == 0 {
+		validationErrors = append(validationErrors, "input cannot be empty")
+	}
+	if req.Model == "" {
+		validationErrors = append(validationErrors, "model cannot be empty")
+	}
+	if len(validationErrors) > 0 {
+		http.Error(w, "request validation failed:\n"+strings.Join(validationErrors, "\n"), http.StatusBadRequest)
+		return
+	}
+
+	if r.URL.Query().Has("error") {
+		h := w.Header()
+		h.Set("Content-Type", "application/json")
+		h.Set("Openai-Version", "2020-10-01")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(errorBody))
+		return
+	}
+
+	h := w.Header()
+	setResponseHeaders(h)
+	w.WriteHeader(http.StatusOK)
+
+	gz := gzip.NewWriter(w)
+	if _, err := gz.Write([]byte(embeddingsBody)); err != nil {
+		log.Printf("error writing gzip body: %v", err)
+		return
+	}
+	if err := gz.Close(); err != nil {
+		log.Printf("error closing gzip writer: %v", err)
+	}
+}
+
 func handleConversations(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -359,6 +434,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/responses", handleResponses)
 	mux.HandleFunc("/v1/chat/completions", handleCompletions)
+	mux.HandleFunc("/v1/embeddings", handleEmbeddings)
 	mux.HandleFunc("/v1/conversations", handleConversations)
 
 	addr := ":" + port

--- a/internal/test/oats/ai/yaml/oats_open_ai_test.yaml
+++ b/internal/test/oats/ai/yaml/oats_open_ai_test.yaml
@@ -7,6 +7,7 @@ input:
 - path: /error
 - path: /chat
 - path: /conversations
+- path: /embeddings
 interval: 500ms
 expected:
   traces:
@@ -38,10 +39,22 @@ expected:
     attributes:
       gen_ai.operation.name: conversation
       gen_ai.conversation.id: conv_699c949418b08194ba11beed9ba85d9607f4edeb470fde91
+  # OpenAI embeddings API (client span via OpenAISpan + /v1/embeddings)
+  - traceql: '{ .gen_ai.provider.name = "openai" && .gen_ai.operation.name = "embeddings" && .gen_ai.request.model = "text-embedding-3-small"}'
+    equals: embeddings text-embedding-3-small
+    attributes:
+      gen_ai.operation.name: embeddings
+      gen_ai.input.messages: The food was delicious
+      gen_ai.response.model: text-embedding-3-small
+      gen_ai.usage.input_tokens: 5
   metrics:
   - promql: gen_ai_client_token_usage_count{gen_ai_operation_name="response",gen_ai_provider_name="openai",gen_ai_token_type="input",gen_ai_request_model="gpt-5-mini",gen_ai_response_model="gpt-5-mini-2025-08-07"}
     value: '> 0'
   - promql: gen_ai_client_token_usage_count{gen_ai_operation_name="response",gen_ai_provider_name="openai",gen_ai_token_type="output",gen_ai_request_model="gpt-5-mini",gen_ai_response_model="gpt-5-mini-2025-08-07"}
     value: '> 0'
   - promql: gen_ai_client_operation_duration_seconds_count{gen_ai_operation_name="response",gen_ai_provider_name="openai",gen_ai_request_model="gpt-5-mini",gen_ai_response_model="gpt-5-mini-2025-08-07"}
+    value: '> 0'
+  - promql: gen_ai_client_token_usage_count{gen_ai_operation_name="embeddings",gen_ai_provider_name="openai",gen_ai_token_type="input",gen_ai_request_model="text-embedding-3-small",gen_ai_response_model="text-embedding-3-small"}
+    value: '> 0'
+  - promql: gen_ai_client_operation_duration_seconds_count{gen_ai_operation_name="embeddings",gen_ai_provider_name="openai",gen_ai_request_model="text-embedding-3-small",gen_ai_response_model="text-embedding-3-small"}
     value: '> 0'

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -1687,6 +1687,10 @@ func (s *Span) GenAIInputTokens() int {
 		return s.GenAI.Bedrock.Output.InputTokens
 	}
 
+	if s.GenAI.Embedding != nil {
+		return s.GenAI.Embedding.GetInputTokens()
+	}
+
 	return 0
 }
 
@@ -1714,6 +1718,8 @@ func (s *Span) GenAIOutputTokens() int {
 	if s.GenAI.Bedrock != nil {
 		return s.GenAI.Bedrock.Output.OutputTokens
 	}
+
+	// Embedding APIs do not produce output tokens.
 
 	return 0
 }

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -748,6 +748,15 @@ func (e *VendorEmbedding) GetInputTokens() int {
 	return 0
 }
 
+// GetOutputTokens returns the output token count for embedding requests,
+// derived as total_tokens - prompt_tokens.
+func (e *VendorEmbedding) GetOutputTokens() int {
+	if e.Output.Usage.TotalTokens > 0 && e.Output.Usage.PromptTokens > 0 {
+		return e.Output.Usage.TotalTokens - e.Output.Usage.PromptTokens
+	}
+	return 0
+}
+
 // Span contains the information being submitted by the following nodes in the graph.
 // It enables comfortable handling of data from Go.
 // REMINDER: any attribute here must be also added to the functions SpanOTELGetters
@@ -1719,7 +1728,9 @@ func (s *Span) GenAIOutputTokens() int {
 		return s.GenAI.Bedrock.Output.OutputTokens
 	}
 
-	// Embedding APIs do not produce output tokens.
+	if s.GenAI.Embedding != nil {
+		return s.GenAI.Embedding.GetOutputTokens()
+	}
 
 	return 0
 }

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -299,7 +299,17 @@ func (u *OpenAIUsage) GetOutputTokens() int {
 		return u.OutputTokens
 	}
 
-	return u.CompletionTokens
+	if u.CompletionTokens > 0 {
+		return u.CompletionTokens
+	}
+
+	// Embedding responses only report prompt_tokens and total_tokens.
+	// Derive output tokens from the difference.
+	if u.TotalTokens > 0 && u.PromptTokens > 0 {
+		return u.TotalTokens - u.PromptTokens
+	}
+
+	return 0
 }
 
 type OpenAIError struct {

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -629,10 +629,10 @@ const EmbeddingOperationName = "embeddings"
 // VendorEmbedding represents a generic embedding API provider such as
 // Voyage AI, Cohere, or Jina AI.
 type VendorEmbedding struct {
-	Provider   string
-	Model      string
-	Input      EmbeddingRequest
-	Output     EmbeddingResponse
+	Provider string
+	Model    string
+	Input    EmbeddingRequest
+	Output   EmbeddingResponse
 }
 
 // OperationName returns the canonical embedding operation name.
@@ -646,7 +646,7 @@ type EmbeddingRequest struct {
 	Input      json.RawMessage `json:"input"`
 	Dimensions int             `json:"dimensions,omitempty"`
 	// Cohere uses "texts" instead of "input"
-	Texts      json.RawMessage `json:"texts,omitempty"`
+	Texts json.RawMessage `json:"texts,omitempty"`
 }
 
 // InputCount returns the number of input texts in the request.

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -671,10 +671,10 @@ const EmbeddingOperationName = "embeddings"
 // VendorEmbedding represents a generic embedding API provider such as
 // Voyage AI, Cohere, or Jina AI.
 type VendorEmbedding struct {
-	Provider   string
-	Model      string
-	Input      EmbeddingRequest
-	Output     EmbeddingResponse
+	Provider string
+	Model    string
+	Input    EmbeddingRequest
+	Output   EmbeddingResponse
 }
 
 // OperationName returns the canonical embedding operation name.
@@ -688,7 +688,7 @@ type EmbeddingRequest struct {
 	Input      json.RawMessage `json:"input"`
 	Dimensions int             `json:"dimensions,omitempty"`
 	// Cohere uses "texts" instead of "input"
-	Texts      json.RawMessage `json:"texts,omitempty"`
+	Texts json.RawMessage `json:"texts,omitempty"`
 }
 
 // InputCount returns the number of input texts in the request.

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -97,13 +97,15 @@ const (
 	HTTPSubtypeGemini        = 8  // http + Google AI Studio (Gemini)
 	HTTPSubtypeJSONRPC       = 9  // http + JSON-RPC
 	HTTPSubtypeAWSBedrock    = 10 // http + AWS Bedrock
+	HTTPSubtypeEmbedding     = 11 // http + generic embedding provider (Voyage, Cohere, Jina)
 )
 
 func IsGenAISubtype(subtype int) bool {
 	return subtype == HTTPSubtypeOpenAI ||
 		subtype == HTTPSubtypeAnthropic ||
 		subtype == HTTPSubtypeGemini ||
-		subtype == HTTPSubtypeAWSBedrock
+		subtype == HTTPSubtypeAWSBedrock ||
+		subtype == HTTPSubtypeEmbedding
 }
 
 //nolint:cyclop
@@ -253,6 +255,7 @@ type GenAI struct {
 	Anthropic *VendorAnthropic
 	Gemini    *VendorGemini
 	Bedrock   *VendorBedrock
+	Embedding *VendorEmbedding
 }
 
 type OpenAIUsage struct {
@@ -325,6 +328,7 @@ type OpenAIInput struct {
 	Messages     json.RawMessage `json:"messages"`
 	Items        json.RawMessage `json:"items"`
 	Temperature  float64         `json:"temperature"`
+	Dimensions   int             `json:"dimensions,omitempty"`
 }
 
 func (air *OpenAIInput) GetInput() string {
@@ -615,6 +619,91 @@ type JSONRPC struct {
 	RequestID    string `json:"requestId"`
 	ErrorCode    int    `json:"errorCode,omitempty"`
 	ErrorMessage string `json:"errorMessage,omitempty"`
+}
+
+// Generic embedding provider types (Voyage AI, Cohere, Jina AI)
+
+// EmbeddingOperationName is the canonical operation name for embedding spans.
+const EmbeddingOperationName = "embeddings"
+
+// VendorEmbedding represents a generic embedding API provider such as
+// Voyage AI, Cohere, or Jina AI.
+type VendorEmbedding struct {
+	Provider   string
+	Model      string
+	Input      EmbeddingRequest
+	Output     EmbeddingResponse
+}
+
+// OperationName returns the canonical embedding operation name.
+func (e *VendorEmbedding) OperationName() string {
+	return EmbeddingOperationName
+}
+
+// EmbeddingRequest captures the common fields from embedding API requests.
+type EmbeddingRequest struct {
+	Model      string          `json:"model"`
+	Input      json.RawMessage `json:"input"`
+	Dimensions int             `json:"dimensions,omitempty"`
+	// Cohere uses "texts" instead of "input"
+	Texts      json.RawMessage `json:"texts,omitempty"`
+}
+
+// InputCount returns the number of input texts in the request.
+// It handles both single-string and array-of-strings formats.
+func (r *EmbeddingRequest) InputCount() int {
+	raw := r.Input
+	if len(raw) == 0 {
+		raw = r.Texts
+	}
+	if len(raw) == 0 {
+		return 0
+	}
+	// Array of strings: count elements
+	var arr []json.RawMessage
+	if json.Unmarshal(raw, &arr) == nil {
+		return len(arr)
+	}
+	// Single string
+	return 1
+}
+
+// EmbeddingResponse captures the common fields from embedding API responses.
+type EmbeddingResponse struct {
+	Model string         `json:"model"`
+	Usage EmbeddingUsage `json:"usage"`
+	// Cohere uses meta.billed_units for token counts
+	Meta *CohereResponseMeta `json:"meta,omitempty"`
+}
+
+// EmbeddingUsage captures token usage in embedding responses.
+type EmbeddingUsage struct {
+	PromptTokens int `json:"prompt_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}
+
+// CohereResponseMeta captures Cohere-specific response metadata.
+type CohereResponseMeta struct {
+	BilledUnits *CohereBilledUnits `json:"billed_units,omitempty"`
+}
+
+// CohereBilledUnits captures Cohere token billing information.
+type CohereBilledUnits struct {
+	InputTokens int `json:"input_tokens"`
+}
+
+// GetInputTokens returns the input token count, handling provider-specific formats.
+func (e *VendorEmbedding) GetInputTokens() int {
+	if e.Output.Usage.PromptTokens > 0 {
+		return e.Output.Usage.PromptTokens
+	}
+	if e.Output.Usage.TotalTokens > 0 {
+		return e.Output.Usage.TotalTokens
+	}
+	if e.Output.Meta != nil && e.Output.Meta.BilledUnits != nil {
+		return e.Output.Meta.BilledUnits.InputTokens
+	}
+	return 0
 }
 
 // Span contains the information being submitted by the following nodes in the graph.
@@ -1254,6 +1343,18 @@ func (s *Span) TraceName() string {
 			return "invoke_model"
 		}
 
+		if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeEmbedding && s.GenAI != nil && s.GenAI.Embedding != nil {
+			op := s.GenAI.Embedding.OperationName()
+			model := s.GenAI.Embedding.Model
+			if s.GenAI.Embedding.Input.Model != "" {
+				model = s.GenAI.Embedding.Input.Model
+			}
+			if model != "" {
+				return op + " " + model
+			}
+			return op
+		}
+
 		if s.SubType == HTTPSubtypeJSONRPC && s.JSONRPC != nil {
 			if s.JSONRPC.Method != "" {
 				return s.JSONRPC.Method
@@ -1537,6 +1638,9 @@ func (s *Span) GenAIOperationName() string {
 	if s.GenAI.Bedrock != nil {
 		return "invoke_model"
 	}
+	if s.GenAI.Embedding != nil {
+		return s.GenAI.Embedding.OperationName()
+	}
 	return ""
 }
 
@@ -1556,6 +1660,9 @@ func (s *Span) GenAIProviderName() string {
 	if s.GenAI.Bedrock != nil {
 		return semconv.GenAIProviderNameAWSBedrock.Value.AsString()
 	}
+	if s.GenAI.Embedding != nil {
+		return s.GenAI.Embedding.Provider
+	}
 	return ""
 }
 
@@ -1574,6 +1681,12 @@ func (s *Span) GenAIRequestModel() string {
 	}
 	if s.GenAI.Bedrock != nil {
 		return s.GenAI.Bedrock.Model
+	}
+	if s.GenAI.Embedding != nil {
+		if s.GenAI.Embedding.Input.Model != "" {
+			return s.GenAI.Embedding.Input.Model
+		}
+		return s.GenAI.Embedding.Model
 	}
 	return ""
 }
@@ -1596,6 +1709,12 @@ func (s *Span) GenAIResponseModel() string {
 	}
 	if s.GenAI.Bedrock != nil {
 		return s.GenAI.Bedrock.Model
+	}
+	if s.GenAI.Embedding != nil {
+		if s.GenAI.Embedding.Output.Model != "" {
+			return s.GenAI.Embedding.Output.Model
+		}
+		return s.GenAI.Embedding.Model
 	}
 	return ""
 }

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -102,6 +102,7 @@ const (
 	HTTPSubtypeAWSBedrock    = 10 // http + AWS Bedrock
 	HTTPSubtypeQwen          = 11 // http + Qwen (DashScope)
 	HTTPSubtypeMCP           = 12 // http + Model Context Protocol
+	HTTPSubtypeEmbedding     = 13 // http + generic embedding provider (Voyage, Cohere, Jina)
 )
 
 func IsGenAISubtype(subtype int) bool {
@@ -110,7 +111,8 @@ func IsGenAISubtype(subtype int) bool {
 		subtype == HTTPSubtypeGemini ||
 		subtype == HTTPSubtypeQwen ||
 		subtype == HTTPSubtypeAWSBedrock ||
-		subtype == HTTPSubtypeMCP
+		subtype == HTTPSubtypeMCP ||
+		subtype == HTTPSubtypeEmbedding
 }
 
 //nolint:cyclop
@@ -270,9 +272,10 @@ type GenAI struct {
 	// both via GetInputTokens()/GetOutputTokens() and the Output field.
 	// A separate field (rather than sharing OpenAI) keeps provider
 	// routing explicit and allows future divergence without refactoring.
-	Qwen    *VendorOpenAI
-	Bedrock *VendorBedrock
-	MCP     *MCPCall
+	Qwen      *VendorOpenAI
+	Bedrock   *VendorBedrock
+	MCP       *MCPCall
+	Embedding *VendorEmbedding
 }
 
 type OpenAIUsage struct {
@@ -345,6 +348,7 @@ type OpenAIInput struct {
 	Messages     json.RawMessage `json:"messages"`
 	Items        json.RawMessage `json:"items"`
 	Temperature  float64         `json:"temperature"`
+	Dimensions   int             `json:"dimensions,omitempty"`
 }
 
 func (air *OpenAIInput) GetInput() string {
@@ -657,6 +661,91 @@ type JSONRPC struct {
 	RequestID    string `json:"requestId"`
 	ErrorCode    int    `json:"errorCode,omitempty"`
 	ErrorMessage string `json:"errorMessage,omitempty"`
+}
+
+// Generic embedding provider types (Voyage AI, Cohere, Jina AI)
+
+// EmbeddingOperationName is the canonical operation name for embedding spans.
+const EmbeddingOperationName = "embeddings"
+
+// VendorEmbedding represents a generic embedding API provider such as
+// Voyage AI, Cohere, or Jina AI.
+type VendorEmbedding struct {
+	Provider   string
+	Model      string
+	Input      EmbeddingRequest
+	Output     EmbeddingResponse
+}
+
+// OperationName returns the canonical embedding operation name.
+func (e *VendorEmbedding) OperationName() string {
+	return EmbeddingOperationName
+}
+
+// EmbeddingRequest captures the common fields from embedding API requests.
+type EmbeddingRequest struct {
+	Model      string          `json:"model"`
+	Input      json.RawMessage `json:"input"`
+	Dimensions int             `json:"dimensions,omitempty"`
+	// Cohere uses "texts" instead of "input"
+	Texts      json.RawMessage `json:"texts,omitempty"`
+}
+
+// InputCount returns the number of input texts in the request.
+// It handles both single-string and array-of-strings formats.
+func (r *EmbeddingRequest) InputCount() int {
+	raw := r.Input
+	if len(raw) == 0 {
+		raw = r.Texts
+	}
+	if len(raw) == 0 {
+		return 0
+	}
+	// Array of strings: count elements
+	var arr []json.RawMessage
+	if json.Unmarshal(raw, &arr) == nil {
+		return len(arr)
+	}
+	// Single string
+	return 1
+}
+
+// EmbeddingResponse captures the common fields from embedding API responses.
+type EmbeddingResponse struct {
+	Model string         `json:"model"`
+	Usage EmbeddingUsage `json:"usage"`
+	// Cohere uses meta.billed_units for token counts
+	Meta *CohereResponseMeta `json:"meta,omitempty"`
+}
+
+// EmbeddingUsage captures token usage in embedding responses.
+type EmbeddingUsage struct {
+	PromptTokens int `json:"prompt_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}
+
+// CohereResponseMeta captures Cohere-specific response metadata.
+type CohereResponseMeta struct {
+	BilledUnits *CohereBilledUnits `json:"billed_units,omitempty"`
+}
+
+// CohereBilledUnits captures Cohere token billing information.
+type CohereBilledUnits struct {
+	InputTokens int `json:"input_tokens"`
+}
+
+// GetInputTokens returns the input token count, handling provider-specific formats.
+func (e *VendorEmbedding) GetInputTokens() int {
+	if e.Output.Usage.PromptTokens > 0 {
+		return e.Output.Usage.PromptTokens
+	}
+	if e.Output.Usage.TotalTokens > 0 {
+		return e.Output.Usage.TotalTokens
+	}
+	if e.Output.Meta != nil && e.Output.Meta.BilledUnits != nil {
+		return e.Output.Meta.BilledUnits.InputTokens
+	}
+	return 0
 }
 
 // Span contains the information being submitted by the following nodes in the graph.
@@ -1340,6 +1429,18 @@ func (s *Span) TraceName() string {
 			return op
 		}
 
+		if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeEmbedding && s.GenAI != nil && s.GenAI.Embedding != nil {
+			op := s.GenAI.Embedding.OperationName()
+			model := s.GenAI.Embedding.Model
+			if s.GenAI.Embedding.Input.Model != "" {
+				model = s.GenAI.Embedding.Input.Model
+			}
+			if model != "" {
+				return op + " " + model
+			}
+			return op
+		}
+
 		if s.SubType == HTTPSubtypeJSONRPC && s.JSONRPC != nil {
 			if s.JSONRPC.Method != "" {
 				return s.JSONRPC.Method
@@ -1636,6 +1737,9 @@ func (s *Span) GenAIOperationName() string {
 	if s.GenAI.Bedrock != nil {
 		return "invoke_model"
 	}
+	if s.GenAI.Embedding != nil {
+		return s.GenAI.Embedding.OperationName()
+	}
 	return ""
 }
 
@@ -1658,6 +1762,9 @@ func (s *Span) GenAIProviderName() string {
 	if s.GenAI.Bedrock != nil {
 		return semconv.GenAIProviderNameAWSBedrock.Value.AsString()
 	}
+	if s.GenAI.Embedding != nil {
+		return s.GenAI.Embedding.Provider
+	}
 	return ""
 }
 
@@ -1679,6 +1786,12 @@ func (s *Span) GenAIRequestModel() string {
 	}
 	if s.GenAI.Bedrock != nil {
 		return s.GenAI.Bedrock.Model
+	}
+	if s.GenAI.Embedding != nil {
+		if s.GenAI.Embedding.Input.Model != "" {
+			return s.GenAI.Embedding.Input.Model
+		}
+		return s.GenAI.Embedding.Model
 	}
 	return ""
 }
@@ -1707,6 +1820,12 @@ func (s *Span) GenAIResponseModel() string {
 	}
 	if s.GenAI.Bedrock != nil {
 		return s.GenAI.Bedrock.Model
+	}
+	if s.GenAI.Embedding != nil {
+		if s.GenAI.Embedding.Output.Model != "" {
+			return s.GenAI.Embedding.Output.Model
+		}
+		return s.GenAI.Embedding.Model
 	}
 	return ""
 }

--- a/pkg/config/payload_extraction.go
+++ b/pkg/config/payload_extraction.go
@@ -124,7 +124,7 @@ type MCPConfig struct {
 
 type EmbeddingProviderConfig struct {
 	// Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing
-	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_HTTP_EMBEDDING_ENABLED" validate:"boolean"`
+	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_HTTP_GENAI_EMBEDDING_ENABLED" validate:"boolean"`
 }
 
 type JSONRPCConfig struct {

--- a/pkg/config/payload_extraction.go
+++ b/pkg/config/payload_extraction.go
@@ -77,11 +77,14 @@ type GenAIConfig struct {
 	Gemini GeminiConfig `yaml:"gemini"`
 	// AWS Bedrock payload extraction and parsing
 	Bedrock BedrockConfig `yaml:"bedrock"`
+	// Generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing
+	Embedding EmbeddingProviderConfig `yaml:"embedding"`
 }
 
 func (g *GenAIConfig) Enabled() bool {
 	return g.Anthropic.Enabled || g.OpenAI.Enabled ||
-		g.Gemini.Enabled || g.Bedrock.Enabled
+		g.Gemini.Enabled || g.Bedrock.Enabled ||
+		g.Embedding.Enabled
 }
 
 type OpenAIConfig struct {
@@ -102,6 +105,11 @@ type GeminiConfig struct {
 type BedrockConfig struct {
 	// Enable AWS Bedrock payload extraction and parsing
 	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_HTTP_BEDROCK_ENABLED" validate:"boolean"`
+}
+
+type EmbeddingProviderConfig struct {
+	// Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing
+	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_HTTP_EMBEDDING_ENABLED" validate:"boolean"`
 }
 
 type JSONRPCConfig struct {

--- a/pkg/config/payload_extraction.go
+++ b/pkg/config/payload_extraction.go
@@ -81,12 +81,15 @@ type GenAIConfig struct {
 	Bedrock BedrockConfig `yaml:"bedrock"`
 	// Model Context Protocol (MCP) payload extraction and parsing
 	MCP MCPConfig `yaml:"mcp"`
+	// Generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing
+	Embedding EmbeddingProviderConfig `yaml:"embedding"`
 }
 
 func (g *GenAIConfig) Enabled() bool {
 	return g.Anthropic.Enabled || g.OpenAI.Enabled ||
 		g.Gemini.Enabled || g.Qwen.Enabled || g.Bedrock.Enabled ||
-		g.MCP.Enabled
+		g.MCP.Enabled ||
+		g.Embedding.Enabled
 }
 
 type OpenAIConfig struct {
@@ -117,6 +120,11 @@ type BedrockConfig struct {
 type MCPConfig struct {
 	// Enable Model Context Protocol (MCP) payload extraction and parsing
 	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_HTTP_MCP_ENABLED" validate:"boolean"`
+}
+
+type EmbeddingProviderConfig struct {
+	// Enable generic embedding provider (Voyage AI, Cohere, Jina AI) payload extraction and parsing
+	Enabled bool `yaml:"enabled" env:"OTEL_EBPF_HTTP_EMBEDDING_ENABLED" validate:"boolean"`
 }
 
 type JSONRPCConfig struct {

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -40,7 +40,7 @@ func isEmbeddingProvider(req *http.Request) string {
 	}
 
 	host := extractHostname(req)
-	path := req.URL.Path
+	path := strings.TrimSuffix(req.URL.Path, "/")
 
 	for _, hp := range embeddingHostPatterns {
 		if (host == hp.hostSuffix || strings.HasSuffix(host, "."+hp.hostSuffix)) &&

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -24,12 +24,11 @@ type embeddingHostPattern struct {
 
 // embeddingHostPatterns lists known embedding API hosts and their required
 // URL path suffixes. Matching is performed by hostname suffix and path suffix,
-// which naturally handles path prefixes like DashScope's /compatible-mode/.
+// which naturally handles arbitrary path prefixes before the API suffix.
 var embeddingHostPatterns = []embeddingHostPattern{
 	{"api.voyageai.com", "/v1/embeddings", "voyage"},
 	{"api.cohere.com", "/v2/embed", "cohere"},
 	{"api.jina.ai", "/v1/embeddings", "jina"},
-	{"dashscope.aliyuncs.com", "/v1/embeddings", "dashscope"},
 }
 
 // isEmbeddingProvider checks whether the request targets a known embedding-only
@@ -53,9 +52,9 @@ func isEmbeddingProvider(req *http.Request) string {
 	return ""
 }
 
-// EmbeddingSpan detects embedding API calls to Voyage AI, Cohere, Jina AI,
-// and DashScope based on hostname and URL path matching, and extracts
-// embedding-specific fields into the span.
+// EmbeddingSpan detects embedding API calls to Voyage AI, Cohere, and Jina AI
+// based on hostname and URL path matching, and extracts embedding-specific
+// fields into the span.
 func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {
 	provider := isEmbeddingProvider(req)
 	if provider == "" {

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -43,7 +43,7 @@ func isEmbeddingProvider(req *http.Request) string {
 	path := req.URL.Path
 
 	for _, hp := range embeddingHostPatterns {
-		if strings.HasSuffix(host, hp.hostSuffix) &&
+		if (host == hp.hostSuffix || strings.HasSuffix(host, "."+hp.hostSuffix)) &&
 			strings.HasSuffix(path, hp.pathSuffix) {
 			return hp.provider
 		}
@@ -96,16 +96,11 @@ func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 		}
 	}
 
-	model := parsedRequest.Model
-	if model == "" {
-		model = parsedResponse.Model
-	}
-
 	baseSpan.SubType = request.HTTPSubtypeEmbedding
 	baseSpan.GenAI = &request.GenAI{
 		Embedding: &request.VendorEmbedding{
 			Provider: provider,
-			Model:    model,
+			Model:    parsedRequest.Model,
 			Input:    parsedRequest,
 			Output:   parsedResponse,
 		},

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -15,19 +15,21 @@ import (
 )
 
 // embeddingHostPattern pairs a known hostname suffix with a required URL path
-// prefix and the provider name to assign when matched.
+// suffix and the provider name to assign when matched.
 type embeddingHostPattern struct {
 	hostSuffix string
-	pathPrefix string
+	pathSuffix string
 	provider   string
 }
 
 // embeddingHostPatterns lists known embedding API hosts and their required
-// URL path prefixes. Matching is performed by hostname suffix and path prefix.
+// URL path suffixes. Matching is performed by hostname suffix and path suffix,
+// which naturally handles path prefixes like DashScope's /compatible-mode/.
 var embeddingHostPatterns = []embeddingHostPattern{
 	{"api.voyageai.com", "/v1/embeddings", "voyage"},
 	{"api.cohere.com", "/v2/embed", "cohere"},
 	{"api.jina.ai", "/v1/embeddings", "jina"},
+	{"dashscope.aliyuncs.com", "/v1/embeddings", "dashscope"},
 }
 
 // isEmbeddingProvider checks whether the request targets a known embedding-only
@@ -43,7 +45,7 @@ func isEmbeddingProvider(req *http.Request) string {
 
 	for _, hp := range embeddingHostPatterns {
 		if strings.HasSuffix(host, hp.hostSuffix) &&
-			strings.HasPrefix(path, hp.pathPrefix) {
+			strings.HasSuffix(path, hp.pathSuffix) {
 			return hp.provider
 		}
 	}
@@ -51,9 +53,9 @@ func isEmbeddingProvider(req *http.Request) string {
 	return ""
 }
 
-// EmbeddingSpan detects embedding API calls to Voyage AI, Cohere, and Jina AI
-// based on hostname and URL path matching, and extracts embedding-specific
-// fields into the span.
+// EmbeddingSpan detects embedding API calls to Voyage AI, Cohere, Jina AI,
+// and DashScope based on hostname and URL path matching, and extracts
+// embedding-specific fields into the span.
 func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {
 	provider := isEmbeddingProvider(req)
 	if provider == "" {

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -57,16 +57,8 @@ func isEmbeddingProvider(req *http.Request) string {
 // and DashScope based on hostname and URL path matching, and extracts
 // embedding-specific fields into the span.
 func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {
-	host := extractHostname(req)
-	path := ""
-	if req != nil && req.URL != nil {
-		path = req.URL.Path
-	}
-	slog.Debug("EmbeddingSpan called", "host", host, "path", path)
-
 	provider := isEmbeddingProvider(req)
 	if provider == "" {
-		slog.Debug("EmbeddingSpan: no provider matched", "host", host, "path", path)
 		return *baseSpan, false
 	}
 
@@ -77,10 +69,11 @@ func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 	}
 	req.Body = io.NopCloser(bytes.NewBuffer(reqB))
 
+	// Response body parsing is best-effort: gzip-compressed or truncated
+	// responses should not prevent provider detection.
 	respB, err := getResponseBody(resp)
-	if err != nil && len(respB) == 0 {
-		slog.Debug("EmbeddingSpan: failed to read response body", "provider", provider, "error", err)
-		return *baseSpan, false
+	if err != nil {
+		slog.Debug("EmbeddingSpan: failed to read response body, continuing without it", "provider", provider, "error", err)
 	}
 
 	slog.Debug("Embedding", "provider", provider, "request", string(reqB), "response", string(respB))

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -61,12 +61,19 @@ func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 		return *baseSpan, false
 	}
 
-	reqB, err := io.ReadAll(req.Body)
-	if err != nil {
-		slog.Debug("EmbeddingSpan: failed to read request body", "provider", provider, "error", err)
-		return *baseSpan, false
+	// Request body parsing is best-effort: since the provider is already
+	// confirmed by hostname+path, a body read failure should not prevent
+	// classification — otherwise the request falls through to downstream
+	// detectors and may be misclassified.
+	var reqB []byte
+	if req.Body != nil {
+		var err error
+		reqB, err = io.ReadAll(req.Body)
+		if err != nil {
+			slog.Debug("EmbeddingSpan: failed to read request body, continuing without it", "provider", provider, "error", err)
+		}
+		req.Body = io.NopCloser(bytes.NewBuffer(reqB))
 	}
-	req.Body = io.NopCloser(bytes.NewBuffer(reqB))
 
 	// Response body parsing is best-effort: gzip-compressed or truncated
 	// responses should not prevent provider detection.

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -31,10 +31,10 @@ var embeddingHostPatterns = []embeddingHostPattern{
 	{"api.jina.ai", "/v1/embeddings", "jina"},
 }
 
-// isEmbeddingProvider checks whether the request targets a known embedding-only
+// parseEmbeddingProvider checks whether the request targets a known embedding-only
 // provider by matching the hostname and URL path against embeddingHostPatterns.
 // Returns the provider name if matched, or empty string otherwise.
-func isEmbeddingProvider(req *http.Request) string {
+func parseEmbeddingProvider(req *http.Request) string {
 	if req == nil || req.URL == nil {
 		return ""
 	}
@@ -56,7 +56,7 @@ func isEmbeddingProvider(req *http.Request) string {
 // based on hostname and URL path matching, and extracts embedding-specific
 // fields into the span.
 func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {
-	provider := isEmbeddingProvider(req)
+	provider := parseEmbeddingProvider(req)
 	if provider == "" {
 		return *baseSpan, false
 	}
@@ -75,8 +75,8 @@ func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 		req.Body = io.NopCloser(bytes.NewBuffer(reqB))
 	}
 
-	// Response body parsing is best-effort: gzip-compressed or truncated
-	// responses should not prevent provider detection.
+	// Response body parsing is best-effort: truncated responses may fail
+	// to parse but should not prevent provider detection.
 	respB, err := getResponseBody(resp)
 	if err != nil {
 		slog.Debug("EmbeddingSpan: failed to read response body, continuing without it", "provider", provider, "error", err)

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -57,19 +57,29 @@ func isEmbeddingProvider(req *http.Request) string {
 // and DashScope based on hostname and URL path matching, and extracts
 // embedding-specific fields into the span.
 func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {
+	host := extractHostname(req)
+	path := ""
+	if req != nil && req.URL != nil {
+		path = req.URL.Path
+	}
+	slog.Debug("EmbeddingSpan called", "host", host, "path", path)
+
 	provider := isEmbeddingProvider(req)
 	if provider == "" {
+		slog.Debug("EmbeddingSpan: no provider matched", "host", host, "path", path)
 		return *baseSpan, false
 	}
 
 	reqB, err := io.ReadAll(req.Body)
 	if err != nil {
+		slog.Debug("EmbeddingSpan: failed to read request body", "provider", provider, "error", err)
 		return *baseSpan, false
 	}
 	req.Body = io.NopCloser(bytes.NewBuffer(reqB))
 
 	respB, err := getResponseBody(resp)
 	if err != nil && len(respB) == 0 {
+		slog.Debug("EmbeddingSpan: failed to read response body", "provider", provider, "error", err)
 		return *baseSpan, false
 	}
 

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -1,0 +1,104 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+)
+
+// embeddingHostPattern pairs a known hostname suffix with a required URL path
+// prefix and the provider name to assign when matched.
+type embeddingHostPattern struct {
+	hostSuffix string
+	pathPrefix string
+	provider   string
+}
+
+// embeddingHostPatterns lists known embedding API hosts and their required
+// URL path prefixes. Matching is performed by hostname suffix and path prefix.
+var embeddingHostPatterns = []embeddingHostPattern{
+	{"api.voyageai.com", "/v1/embeddings", "voyage"},
+	{"api.cohere.com", "/v2/embed", "cohere"},
+	{"api.jina.ai", "/v1/embeddings", "jina"},
+}
+
+// isEmbeddingProvider checks whether the request targets a known embedding-only
+// provider by matching the hostname and URL path against embeddingHostPatterns.
+// Returns the provider name if matched, or empty string otherwise.
+func isEmbeddingProvider(req *http.Request) string {
+	if req == nil || req.URL == nil {
+		return ""
+	}
+
+	host := extractHostname(req)
+	path := req.URL.Path
+
+	for _, hp := range embeddingHostPatterns {
+		if strings.HasSuffix(host, hp.hostSuffix) &&
+			strings.HasPrefix(path, hp.pathPrefix) {
+			return hp.provider
+		}
+	}
+
+	return ""
+}
+
+// EmbeddingSpan detects embedding API calls to Voyage AI, Cohere, and Jina AI
+// based on hostname and URL path matching, and extracts embedding-specific
+// fields into the span.
+func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {
+	provider := isEmbeddingProvider(req)
+	if provider == "" {
+		return *baseSpan, false
+	}
+
+	reqB, err := io.ReadAll(req.Body)
+	if err != nil {
+		return *baseSpan, false
+	}
+	req.Body = io.NopCloser(bytes.NewBuffer(reqB))
+
+	respB, err := getResponseBody(resp)
+	if err != nil && len(respB) == 0 {
+		return *baseSpan, false
+	}
+
+	slog.Debug("Embedding", "provider", provider, "request", string(reqB), "response", string(respB))
+
+	var parsedRequest request.EmbeddingRequest
+	if err := json.Unmarshal(reqB, &parsedRequest); err != nil {
+		slog.Debug("failed to parse embedding request", "provider", provider, "error", err)
+	}
+
+	var parsedResponse request.EmbeddingResponse
+	if len(respB) > 0 {
+		if err := json.Unmarshal(respB, &parsedResponse); err != nil {
+			slog.Debug("failed to parse embedding response", "provider", provider, "error", err)
+		}
+	}
+
+	model := parsedRequest.Model
+	if model == "" {
+		model = parsedResponse.Model
+	}
+
+	baseSpan.SubType = request.HTTPSubtypeEmbedding
+	baseSpan.GenAI = &request.GenAI{
+		Embedding: &request.VendorEmbedding{
+			Provider: provider,
+			Model:    model,
+			Input:    parsedRequest,
+			Output:   parsedResponse,
+		},
+	}
+
+	return *baseSpan, true
+}

--- a/pkg/ebpf/common/http/embedding_test.go
+++ b/pkg/ebpf/common/http/embedding_test.go
@@ -123,6 +123,24 @@ func TestEmbeddingSpan_NotEmbeddingProvider(t *testing.T) {
 	assert.False(t, ok, "should not be detected as embedding provider for unknown host")
 }
 
+func TestEmbeddingSpan_DashScope(t *testing.T) {
+	// DashScope uses /compatible-mode/v1/embeddings with OpenAI-compatible JSON.
+	req := makeRequest(t, http.MethodPost, "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings", jinaRequestBody)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, jinaResponseBody)
+
+	base := &request.Span{}
+	span, ok := EmbeddingSpan(base, req, resp)
+
+	require.True(t, ok, "should detect DashScope embedding via hostname + path suffix")
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Embedding)
+	assert.Equal(t, request.HTTPSubtypeEmbedding, span.SubType)
+	assert.Equal(t, "dashscope", span.GenAI.Embedding.Provider)
+	assert.Equal(t, "jina-embeddings-v3", span.GenAI.Embedding.Model)
+}
+
 func TestIsEmbeddingProvider(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -143,6 +161,11 @@ func TestIsEmbeddingProvider(t *testing.T) {
 			name:     "Jina AI",
 			url:      "https://api.jina.ai/v1/embeddings",
 			expected: "jina",
+		},
+		{
+			name:     "DashScope",
+			url:      "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings",
+			expected: "dashscope",
 		},
 		{
 			name:     "unknown host",

--- a/pkg/ebpf/common/http/embedding_test.go
+++ b/pkg/ebpf/common/http/embedding_test.go
@@ -174,7 +174,7 @@ func TestIsEmbeddingProvider(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := makeRequest(t, http.MethodPost, tt.url, "{}")
-			assert.Equal(t, tt.expected, isEmbeddingProvider(req))
+			assert.Equal(t, tt.expected, parseEmbeddingProvider(req))
 		})
 	}
 }

--- a/pkg/ebpf/common/http/embedding_test.go
+++ b/pkg/ebpf/common/http/embedding_test.go
@@ -1,0 +1,208 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+)
+
+const voyageRequestBody = `{"model":"voyage-3","input":["Hello world","Goodbye world"]}`
+
+const voyageResponseBody = `{
+  "object": "list",
+  "data": [
+    {"object": "embedding", "embedding": [0.1, 0.2], "index": 0},
+    {"object": "embedding", "embedding": [0.3, 0.4], "index": 1}
+  ],
+  "model": "voyage-3",
+  "usage": {"total_tokens": 8}
+}`
+
+const cohereRequestBody = `{"model":"embed-english-v3.0","texts":["Hello world"],"input_type":"search_document"}`
+
+const cohereResponseBody = `{
+  "id": "emb-123",
+  "embeddings": {"float": [[0.1, 0.2]]},
+  "meta": {"api_version": {"version": "2"}, "billed_units": {"input_tokens": 4}}
+}`
+
+const jinaRequestBody = `{"model":"jina-embeddings-v3","input":["Hello world"],"dimensions":512}`
+
+const jinaResponseBody = `{
+  "model": "jina-embeddings-v3",
+  "object": "list",
+  "data": [
+    {"object": "embedding", "embedding": [0.1, 0.2], "index": 0}
+  ],
+  "usage": {"prompt_tokens": 6, "total_tokens": 6}
+}`
+
+func TestEmbeddingSpan_VoyageAI(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "https://api.voyageai.com/v1/embeddings", voyageRequestBody)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, voyageResponseBody)
+
+	base := &request.Span{}
+	span, ok := EmbeddingSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Embedding)
+	assert.Equal(t, request.HTTPSubtypeEmbedding, span.SubType)
+
+	ai := span.GenAI.Embedding
+	assert.Equal(t, "voyage", ai.Provider)
+	assert.Equal(t, "voyage-3", ai.Model)
+	assert.Equal(t, "embeddings", ai.OperationName())
+	assert.Equal(t, 8, ai.GetInputTokens())
+	assert.Equal(t, 2, ai.Input.InputCount())
+}
+
+func TestEmbeddingSpan_Cohere(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "https://api.cohere.com/v2/embed", cohereRequestBody)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, cohereResponseBody)
+
+	base := &request.Span{}
+	span, ok := EmbeddingSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Embedding)
+	assert.Equal(t, request.HTTPSubtypeEmbedding, span.SubType)
+
+	ai := span.GenAI.Embedding
+	assert.Equal(t, "cohere", ai.Provider)
+	assert.Equal(t, "embed-english-v3.0", ai.Model)
+	assert.Equal(t, "embeddings", ai.OperationName())
+	assert.Equal(t, 4, ai.GetInputTokens())
+	assert.Equal(t, 1, ai.Input.InputCount())
+}
+
+func TestEmbeddingSpan_JinaAI(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "https://api.jina.ai/v1/embeddings", jinaRequestBody)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, jinaResponseBody)
+
+	base := &request.Span{}
+	span, ok := EmbeddingSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Embedding)
+	assert.Equal(t, request.HTTPSubtypeEmbedding, span.SubType)
+
+	ai := span.GenAI.Embedding
+	assert.Equal(t, "jina", ai.Provider)
+	assert.Equal(t, "jina-embeddings-v3", ai.Model)
+	assert.Equal(t, "embeddings", ai.OperationName())
+	assert.Equal(t, 6, ai.GetInputTokens())
+	assert.Equal(t, 512, ai.Input.Dimensions)
+	assert.Equal(t, 1, ai.Input.InputCount())
+}
+
+func TestEmbeddingSpan_NotEmbeddingProvider(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "http://example.com/api", `{"query":"hello"}`)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type": []string{"application/json"},
+	}, `{"result":"ok"}`)
+
+	base := &request.Span{}
+	_, ok := EmbeddingSpan(base, req, resp)
+
+	assert.False(t, ok, "should not be detected as embedding provider for unknown host")
+}
+
+func TestIsEmbeddingProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "Voyage AI",
+			url:      "https://api.voyageai.com/v1/embeddings",
+			expected: "voyage",
+		},
+		{
+			name:     "Cohere",
+			url:      "https://api.cohere.com/v2/embed",
+			expected: "cohere",
+		},
+		{
+			name:     "Jina AI",
+			url:      "https://api.jina.ai/v1/embeddings",
+			expected: "jina",
+		},
+		{
+			name:     "unknown host",
+			url:      "https://api.example.com/v1/embeddings",
+			expected: "",
+		},
+		{
+			name:     "wrong path for cohere",
+			url:      "https://api.cohere.com/v1/embeddings",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := makeRequest(t, http.MethodPost, tt.url, "{}")
+			assert.Equal(t, tt.expected, isEmbeddingProvider(req))
+		})
+	}
+}
+
+func TestEmbeddingSpan_TraceName(t *testing.T) {
+	span := &request.Span{
+		Type:    request.EventTypeHTTPClient,
+		SubType: request.HTTPSubtypeEmbedding,
+		GenAI: &request.GenAI{
+			Embedding: &request.VendorEmbedding{
+				Provider: "voyage",
+				Model:    "voyage-3",
+			},
+		},
+	}
+	assert.Equal(t, "embeddings voyage-3", span.TraceName())
+
+	spanNoModel := &request.Span{
+		Type:    request.EventTypeHTTPClient,
+		SubType: request.HTTPSubtypeEmbedding,
+		GenAI: &request.GenAI{
+			Embedding: &request.VendorEmbedding{
+				Provider: "cohere",
+			},
+		},
+	}
+	assert.Equal(t, "embeddings", spanNoModel.TraceName())
+}
+
+func TestEmbeddingInputCount(t *testing.T) {
+	// array of strings
+	r := &request.EmbeddingRequest{Input: []byte(`["hello", "world"]`)}
+	assert.Equal(t, 2, r.InputCount())
+
+	// single string
+	r2 := &request.EmbeddingRequest{Input: []byte(`"hello"`)}
+	assert.Equal(t, 1, r2.InputCount())
+
+	// empty
+	r3 := &request.EmbeddingRequest{}
+	assert.Equal(t, 0, r3.InputCount())
+
+	// Cohere texts field
+	r4 := &request.EmbeddingRequest{Texts: []byte(`["hello"]`)}
+	assert.Equal(t, 1, r4.InputCount())
+}

--- a/pkg/ebpf/common/http/embedding_test.go
+++ b/pkg/ebpf/common/http/embedding_test.go
@@ -154,6 +154,21 @@ func TestIsEmbeddingProvider(t *testing.T) {
 			url:      "https://api.cohere.com/v1/embeddings",
 			expected: "",
 		},
+		{
+			name:     "Voyage AI trailing slash",
+			url:      "https://api.voyageai.com/v1/embeddings/",
+			expected: "voyage",
+		},
+		{
+			name:     "Cohere trailing slash",
+			url:      "https://api.cohere.com/v2/embed/",
+			expected: "cohere",
+		},
+		{
+			name:     "Jina AI trailing slash",
+			url:      "https://api.jina.ai/v1/embeddings/",
+			expected: "jina",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ebpf/common/http/embedding_test.go
+++ b/pkg/ebpf/common/http/embedding_test.go
@@ -123,24 +123,6 @@ func TestEmbeddingSpan_NotEmbeddingProvider(t *testing.T) {
 	assert.False(t, ok, "should not be detected as embedding provider for unknown host")
 }
 
-func TestEmbeddingSpan_DashScope(t *testing.T) {
-	// DashScope uses /compatible-mode/v1/embeddings with OpenAI-compatible JSON.
-	req := makeRequest(t, http.MethodPost, "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings", jinaRequestBody)
-	resp := makePlainResponse(http.StatusOK, http.Header{
-		"Content-Type": []string{"application/json"},
-	}, jinaResponseBody)
-
-	base := &request.Span{}
-	span, ok := EmbeddingSpan(base, req, resp)
-
-	require.True(t, ok, "should detect DashScope embedding via hostname + path suffix")
-	require.NotNil(t, span.GenAI)
-	require.NotNil(t, span.GenAI.Embedding)
-	assert.Equal(t, request.HTTPSubtypeEmbedding, span.SubType)
-	assert.Equal(t, "dashscope", span.GenAI.Embedding.Provider)
-	assert.Equal(t, "jina-embeddings-v3", span.GenAI.Embedding.Model)
-}
-
 func TestIsEmbeddingProvider(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -161,11 +143,6 @@ func TestIsEmbeddingProvider(t *testing.T) {
 			name:     "Jina AI",
 			url:      "https://api.jina.ai/v1/embeddings",
 			expected: "jina",
-		},
-		{
-			name:     "DashScope",
-			url:      "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings",
-			expected: "dashscope",
 		},
 		{
 			name:     "unknown host",

--- a/pkg/ebpf/common/http/openai.go
+++ b/pkg/ebpf/common/http/openai.go
@@ -54,8 +54,11 @@ func OpenAISpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 	parsedResponse.Request = parsedRequest
 
 	// Override operation name for embedding requests.
-	if req.URL != nil && strings.Contains(req.URL.Path, "/v1/embeddings") {
-		parsedResponse.OperationName = request.EmbeddingOperationName
+	if req.URL != nil {
+		path := strings.TrimSuffix(req.URL.Path, "/")
+		if path == "/v1/embeddings" {
+			parsedResponse.OperationName = request.EmbeddingOperationName
+		}
 	}
 
 	baseSpan.SubType = request.HTTPSubtypeOpenAI

--- a/pkg/ebpf/common/http/openai.go
+++ b/pkg/ebpf/common/http/openai.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
@@ -51,6 +52,11 @@ func OpenAISpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 	}
 
 	parsedResponse.Request = parsedRequest
+
+	// Override operation name for embedding requests.
+	if req.URL != nil && strings.Contains(req.URL.Path, "/v1/embeddings") {
+		parsedResponse.OperationName = request.EmbeddingOperationName
+	}
 
 	baseSpan.SubType = request.HTTPSubtypeOpenAI
 	baseSpan.GenAI = &request.GenAI{

--- a/pkg/ebpf/common/http/openai_test.go
+++ b/pkg/ebpf/common/http/openai_test.go
@@ -286,3 +286,43 @@ func TestOpenAIInput_GetInput(t *testing.T) {
 	inp4 := &request.OpenAIInput{Items: []byte(`[{"item":1}]`)}
 	assert.JSONEq(t, `[{"item":1}]`, inp4.GetInput())
 }
+
+const embeddingsRequestBody = `{"input":"The food was delicious","model":"text-embedding-3-small","dimensions":256}`
+
+const embeddingsResponseBody = `{
+  "object": "list",
+  "data": [
+    {
+      "object": "embedding",
+      "embedding": [0.0023064255, -0.009327292],
+      "index": 0
+    }
+  ],
+  "model": "text-embedding-3-small",
+  "usage": {
+    "prompt_tokens": 5,
+    "total_tokens": 5
+  }
+}`
+
+func TestOpenAISpan_Embeddings(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "http://api.openai.com/v1/embeddings", embeddingsRequestBody)
+	resp := makeGzipResponse(t, http.StatusOK, openAIHeaders(), embeddingsResponseBody)
+
+	base := &request.Span{}
+	span, ok := OpenAISpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI.OpenAI)
+	assert.Equal(t, request.HTTPSubtypeOpenAI, span.SubType)
+
+	ai := span.GenAI.OpenAI
+	assert.Equal(t, "embeddings", ai.OperationName)
+	assert.Equal(t, "text-embedding-3-small", ai.ResponseModel)
+	assert.Equal(t, 5, ai.Usage.GetInputTokens())
+
+	// request fields
+	assert.Equal(t, "text-embedding-3-small", ai.Request.Model)
+	assert.Equal(t, 256, ai.Request.Dimensions)
+	assert.Equal(t, "The food was delicious", ai.Request.Input)
+}

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -197,7 +197,7 @@ func httpRequestResponseToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo, r
 		}
 	}
 
-	if isClientEvent(event.Type) && parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Embedding.Enabled {
+	if parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Embedding.Enabled {
 		span, ok := ebpfhttp.EmbeddingSpan(&httpSpan, req, resp)
 		if ok {
 			return span

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -241,8 +241,6 @@ func HTTPInfoEventToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo) (reques
 
 	slog.Debug("Event", "traceID", event.Tp.TraceId, "conn", event.ConnInfo, "buf", event.Buf[:])
 
-	slog.Debug("HTTPInfoEventToSpan", "hasLargeBuffers", event.HasLargeBuffers, "traceID", event.Tp.TraceId)
-
 	if event.HasLargeBuffers == 1 {
 		b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeRequest, directionByPacketType(packetTypeRequest, isClient), event.ConnInfo)
 		if ok {
@@ -264,12 +262,13 @@ func HTTPInfoEventToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo) (reques
 	}
 
 	if parseCtx != nil && !parseCtx.payloadExtraction.Enabled() {
-		slog.Debug("HTTPInfoEventToSpan: payload extraction disabled, skipping detection chain", "traceID", event.Tp.TraceId)
+		// There's no need to parse HTTP headers/body,
+		// create the span directly.
 		return httpRequestToSpan(event, requestBuffer), false, nil
 	}
 
 	if !hasResponse {
-		slog.Debug("HTTPInfoEventToSpan: no response buffer, skipping detection chain", "traceID", event.Tp.TraceId, "hasLargeBuffers", event.HasLargeBuffers)
+		// Large buffers disabled
 		return httpRequestToSpan(event, requestBuffer), false, nil
 	}
 

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -169,6 +169,17 @@ func httpRequestResponseToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo, r
 		}
 	}
 
+	// Embedding detection uses hostname+path matching and must run before
+	// header-based detectors (OpenAI, Anthropic, etc.) so that known
+	// embedding-only providers are not misclassified when they return
+	// OpenAI-compatible response headers.
+	if isClientEvent(event.Type) && parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Embedding.Enabled {
+		span, ok := ebpfhttp.EmbeddingSpan(&httpSpan, req, resp)
+		if ok {
+			return span
+		}
+	}
+
 	if isClientEvent(event.Type) && parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.OpenAI.Enabled {
 		span, ok := ebpfhttp.OpenAISpan(&httpSpan, req, resp)
 		if ok {
@@ -199,13 +210,6 @@ func httpRequestResponseToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo, r
 
 	if isClientEvent(event.Type) && parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Bedrock.Enabled {
 		span, ok := ebpfhttp.BedrockSpan(&httpSpan, req, resp)
-		if ok {
-			return span
-		}
-	}
-
-	if isClientEvent(event.Type) && parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Embedding.Enabled {
-		span, ok := ebpfhttp.EmbeddingSpan(&httpSpan, req, resp)
 		if ok {
 			return span
 		}

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -204,7 +204,7 @@ func httpRequestResponseToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo, r
 		}
 	}
 
-	if isClientEvent(event.Type) && parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Embedding.Enabled {
+	if parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Embedding.Enabled {
 		span, ok := ebpfhttp.EmbeddingSpan(&httpSpan, req, resp)
 		if ok {
 			return span

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -257,6 +257,8 @@ func HTTPInfoEventToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo) (reques
 
 	slog.Debug("Event", "traceID", event.Tp.TraceId, "conn", event.ConnInfo, "buf", event.Buf[:])
 
+	slog.Debug("HTTPInfoEventToSpan", "hasLargeBuffers", event.HasLargeBuffers, "traceID", event.Tp.TraceId)
+
 	if event.HasLargeBuffers == 1 {
 		b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeRequest, directionByPacketType(packetTypeRequest, isClient), event.ConnInfo)
 		if ok {
@@ -278,13 +280,12 @@ func HTTPInfoEventToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo) (reques
 	}
 
 	if parseCtx != nil && !parseCtx.payloadExtraction.Enabled() {
-		// There's no need to parse HTTP headers/body,
-		// create the span directly.
+		slog.Debug("HTTPInfoEventToSpan: payload extraction disabled, skipping detection chain", "traceID", event.Tp.TraceId)
 		return httpRequestToSpan(event, requestBuffer), false, nil
 	}
 
 	if !hasResponse {
-		// Large buffers disabled
+		slog.Debug("HTTPInfoEventToSpan: no response buffer, skipping detection chain", "traceID", event.Tp.TraceId, "hasLargeBuffers", event.HasLargeBuffers)
 		return httpRequestToSpan(event, requestBuffer), false, nil
 	}
 

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -204,6 +204,13 @@ func httpRequestResponseToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo, r
 		}
 	}
 
+	if isClientEvent(event.Type) && parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Embedding.Enabled {
+		span, ok := ebpfhttp.EmbeddingSpan(&httpSpan, req, resp)
+		if ok {
+			return span
+		}
+	}
+
 	// Parse JSON-RPC once and reuse for both MCP and plain JSON-RPC
 	// detection, since MCP is a protocol layer on top of JSON-RPC.
 	if parseCtx != nil && (parseCtx.payloadExtraction.HTTP.GenAI.MCP.Enabled || parseCtx.payloadExtraction.HTTP.JSONRPC.Enabled) {

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -197,6 +197,13 @@ func httpRequestResponseToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo, r
 		}
 	}
 
+	if isClientEvent(event.Type) && parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Embedding.Enabled {
+		span, ok := ebpfhttp.EmbeddingSpan(&httpSpan, req, resp)
+		if ok {
+			return span
+		}
+	}
+
 	if parseCtx != nil && parseCtx.payloadExtraction.HTTP.JSONRPC.Enabled {
 		span, ok := ebpfhttp.JSONRPCSpan(&httpSpan, req, resp)
 		if ok {

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -257,8 +257,6 @@ func HTTPInfoEventToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo) (reques
 
 	slog.Debug("Event", "traceID", event.Tp.TraceId, "conn", event.ConnInfo, "buf", event.Buf[:])
 
-	slog.Debug("HTTPInfoEventToSpan", "hasLargeBuffers", event.HasLargeBuffers, "traceID", event.Tp.TraceId)
-
 	if event.HasLargeBuffers == 1 {
 		b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeRequest, directionByPacketType(packetTypeRequest, isClient), event.ConnInfo)
 		if ok {
@@ -280,12 +278,13 @@ func HTTPInfoEventToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo) (reques
 	}
 
 	if parseCtx != nil && !parseCtx.payloadExtraction.Enabled() {
-		slog.Debug("HTTPInfoEventToSpan: payload extraction disabled, skipping detection chain", "traceID", event.Tp.TraceId)
+		// There's no need to parse HTTP headers/body,
+		// create the span directly.
 		return httpRequestToSpan(event, requestBuffer), false, nil
 	}
 
 	if !hasResponse {
-		slog.Debug("HTTPInfoEventToSpan: no response buffer, skipping detection chain", "traceID", event.Tp.TraceId, "hasLargeBuffers", event.HasLargeBuffers)
+		// Large buffers disabled
 		return httpRequestToSpan(event, requestBuffer), false, nil
 	}
 

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -204,7 +204,7 @@ func httpRequestResponseToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo, r
 		}
 	}
 
-	if parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Embedding.Enabled {
+	if isClientEvent(event.Type) && parseCtx != nil && parseCtx.payloadExtraction.HTTP.GenAI.Embedding.Enabled {
 		span, ok := ebpfhttp.EmbeddingSpan(&httpSpan, req, resp)
 		if ok {
 			return span

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -241,6 +241,8 @@ func HTTPInfoEventToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo) (reques
 
 	slog.Debug("Event", "traceID", event.Tp.TraceId, "conn", event.ConnInfo, "buf", event.Buf[:])
 
+	slog.Debug("HTTPInfoEventToSpan", "hasLargeBuffers", event.HasLargeBuffers, "traceID", event.Tp.TraceId)
+
 	if event.HasLargeBuffers == 1 {
 		b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeRequest, directionByPacketType(packetTypeRequest, isClient), event.ConnInfo)
 		if ok {
@@ -262,13 +264,12 @@ func HTTPInfoEventToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo) (reques
 	}
 
 	if parseCtx != nil && !parseCtx.payloadExtraction.Enabled() {
-		// There's no need to parse HTTP headers/body,
-		// create the span directly.
+		slog.Debug("HTTPInfoEventToSpan: payload extraction disabled, skipping detection chain", "traceID", event.Tp.TraceId)
 		return httpRequestToSpan(event, requestBuffer), false, nil
 	}
 
 	if !hasResponse {
-		// Large buffers disabled
+		slog.Debug("HTTPInfoEventToSpan: no response buffer, skipping detection chain", "traceID", event.Tp.TraceId, "hasLargeBuffers", event.HasLargeBuffers)
 		return httpRequestToSpan(event, requestBuffer), false, nil
 	}
 

--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -411,7 +411,7 @@ func makeBPFInfoWithBuf(buf []uint8) BPFHTTPInfo {
 }
 
 func TestHTTPRequestResponseToSpan_EmbeddingTakesPriorityOverOpenAI(t *testing.T) {
-	// When a DashScope embedding request returns OpenAI-compatible response headers,
+	// When a known embedding provider request returns OpenAI-compatible response headers,
 	// EmbeddingSpan should take priority over OpenAISpan because it matches the
 	// hostname and path of a known embedding provider.
 	parseCtx := &EBPFParseContext{
@@ -430,8 +430,8 @@ func TestHTTPRequestResponseToSpan_EmbeddingTakesPriorityOverOpenAI(t *testing.T
 
 	req := &http.Request{
 		Method: http.MethodPost,
-		URL:    &url.URL{Scheme: "https", Host: "dashscope.aliyuncs.com", Path: "/compatible-mode/v1/embeddings"},
-		Host:   "dashscope.aliyuncs.com",
+		URL:    &url.URL{Scheme: "https", Host: "api.jina.ai", Path: "/v1/embeddings"},
+		Host:   "api.jina.ai",
 		Body:   io.NopCloser(strings.NewReader(reqBody)),
 	}
 	resp := &http.Response{
@@ -450,11 +450,11 @@ func TestHTTPRequestResponseToSpan_EmbeddingTakesPriorityOverOpenAI(t *testing.T
 	span := httpRequestResponseToSpan(parseCtx, event, req, resp)
 
 	assert.Equal(t, request.HTTPSubtypeEmbedding, span.SubType,
-		"DashScope embedding request should be detected as Embedding span, not OpenAI span")
+		"known embedding provider request should be detected as Embedding span, not OpenAI span")
 	require.NotNil(t, span.GenAI)
 	require.NotNil(t, span.GenAI.Embedding, "span.GenAI.Embedding should be set")
 	assert.Nil(t, span.GenAI.OpenAI, "span.GenAI.OpenAI should not be set")
-	assert.Equal(t, "dashscope", span.GenAI.Embedding.Provider)
+	assert.Equal(t, "jina", span.GenAI.Embedding.Provider)
 }
 
 func TestHTTPRequestResponseToSpan_OpenAIEmbeddingDetectedByOpenAISpan(t *testing.T) {

--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -418,8 +418,7 @@ func TestHTTPRequestResponseToSpan_EmbeddingTakesPriorityOverOpenAI(t *testing.T
 		payloadExtraction: config.PayloadExtraction{
 			HTTP: config.HTTPConfig{
 				GenAI: config.GenAIConfig{
-					OpenAI:   config.OpenAIConfig{Enabled: true},
-					Embedding: config.EmbeddingProviderConfig{Enabled: true},
+					Embedding: config.EmbeddingProviderConfig{Enabled: true}, OpenAI: config.OpenAIConfig{Enabled: true},
 				},
 			},
 		},
@@ -437,9 +436,9 @@ func TestHTTPRequestResponseToSpan_EmbeddingTakesPriorityOverOpenAI(t *testing.T
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header: http.Header{
-			"Content-Type":       []string{"application/json"},
-			"Openai-Version":     []string{"2020-10-01"},
+			"Content-Type":        []string{"application/json"},
 			"Openai-Organization": []string{"org-123"},
+			"Openai-Version":      []string{"2020-10-01"},
 		},
 		Body: io.NopCloser(strings.NewReader(respBody)),
 	}
@@ -465,8 +464,7 @@ func TestHTTPRequestResponseToSpan_OpenAIEmbeddingDetectedByOpenAISpan(t *testin
 		payloadExtraction: config.PayloadExtraction{
 			HTTP: config.HTTPConfig{
 				GenAI: config.GenAIConfig{
-					OpenAI:   config.OpenAIConfig{Enabled: true},
-					Embedding: config.EmbeddingProviderConfig{Enabled: true},
+					Embedding: config.EmbeddingProviderConfig{Enabled: true}, OpenAI: config.OpenAIConfig{Enabled: true},
 				},
 			},
 		},
@@ -484,9 +482,9 @@ func TestHTTPRequestResponseToSpan_OpenAIEmbeddingDetectedByOpenAISpan(t *testin
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header: http.Header{
-			"Content-Type":       []string{"application/json"},
-			"Openai-Version":     []string{"2020-10-01"},
+			"Content-Type":        []string{"application/json"},
 			"Openai-Organization": []string{"org-123"},
+			"Openai-Version":      []string{"2020-10-01"},
 		},
 		Body: io.NopCloser(strings.NewReader(respBody)),
 	}

--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
 )
 
@@ -407,4 +408,97 @@ func makeBPFInfoWithBuf(buf []uint8) BPFHTTPInfo {
 	copy(bpfInfo.Buf[:], buf)
 
 	return bpfInfo
+}
+
+func TestHTTPRequestResponseToSpan_EmbeddingTakesPriorityOverOpenAI(t *testing.T) {
+	// When a DashScope embedding request returns OpenAI-compatible response headers,
+	// EmbeddingSpan should take priority over OpenAISpan because it matches the
+	// hostname and path of a known embedding provider.
+	parseCtx := &EBPFParseContext{
+		payloadExtraction: config.PayloadExtraction{
+			HTTP: config.HTTPConfig{
+				GenAI: config.GenAIConfig{
+					OpenAI:   config.OpenAIConfig{Enabled: true},
+					Embedding: config.EmbeddingProviderConfig{Enabled: true},
+				},
+			},
+		},
+	}
+
+	reqBody := `{"model":"text-embedding-v3","input":"hello"}`
+	respBody := `{"object":"list","data":[{"object":"embedding","embedding":[0.1],"index":0}],"model":"text-embedding-v3","usage":{"prompt_tokens":5,"total_tokens":5}}`
+
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Scheme: "https", Host: "dashscope.aliyuncs.com", Path: "/compatible-mode/v1/embeddings"},
+		Host:   "dashscope.aliyuncs.com",
+		Body:   io.NopCloser(strings.NewReader(reqBody)),
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type":       []string{"application/json"},
+			"Openai-Version":     []string{"2020-10-01"},
+			"Openai-Organization": []string{"org-123"},
+		},
+		Body: io.NopCloser(strings.NewReader(respBody)),
+	}
+	event := &BPFHTTPInfo{
+		Type: uint8(request.EventTypeHTTPClient),
+	}
+
+	span := httpRequestResponseToSpan(parseCtx, event, req, resp)
+
+	assert.Equal(t, request.HTTPSubtypeEmbedding, span.SubType,
+		"DashScope embedding request should be detected as Embedding span, not OpenAI span")
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Embedding, "span.GenAI.Embedding should be set")
+	assert.Nil(t, span.GenAI.OpenAI, "span.GenAI.OpenAI should not be set")
+	assert.Equal(t, "dashscope", span.GenAI.Embedding.Provider)
+}
+
+func TestHTTPRequestResponseToSpan_OpenAIEmbeddingDetectedByOpenAISpan(t *testing.T) {
+	// When a request to api.openai.com/v1/embeddings returns OpenAI response headers,
+	// it should still be detected by OpenAISpan (not EmbeddingSpan) because
+	// api.openai.com is not a known embedding-only provider.
+	parseCtx := &EBPFParseContext{
+		payloadExtraction: config.PayloadExtraction{
+			HTTP: config.HTTPConfig{
+				GenAI: config.GenAIConfig{
+					OpenAI:   config.OpenAIConfig{Enabled: true},
+					Embedding: config.EmbeddingProviderConfig{Enabled: true},
+				},
+			},
+		},
+	}
+
+	reqBody := `{"model":"text-embedding-3-small","input":"hello"}`
+	respBody := `{"object":"list","data":[{"object":"embedding","embedding":[0.1],"index":0}],"model":"text-embedding-3-small","usage":{"prompt_tokens":5,"total_tokens":5}}`
+
+	req := &http.Request{
+		Method: http.MethodPost,
+		URL:    &url.URL{Scheme: "https", Host: "api.openai.com", Path: "/v1/embeddings"},
+		Host:   "api.openai.com",
+		Body:   io.NopCloser(strings.NewReader(reqBody)),
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type":       []string{"application/json"},
+			"Openai-Version":     []string{"2020-10-01"},
+			"Openai-Organization": []string{"org-123"},
+		},
+		Body: io.NopCloser(strings.NewReader(respBody)),
+	}
+	event := &BPFHTTPInfo{
+		Type: uint8(request.EventTypeHTTPClient),
+	}
+
+	span := httpRequestResponseToSpan(parseCtx, event, req, resp)
+
+	assert.Equal(t, request.HTTPSubtypeOpenAI, span.SubType,
+		"OpenAI embedding request should be detected by OpenAISpan")
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.OpenAI, "span.GenAI.OpenAI should be set")
+	assert.Equal(t, request.EmbeddingOperationName, span.GenAI.OpenAI.OperationName)
 }

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -775,6 +775,7 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 				attrs = append(attrs, semconv.GenAIResponseModel(model))
 			}
 			attrs = append(attrs, semconv.GenAIUsageInputTokens(ai.GetInputTokens()))
+			attrs = append(attrs, semconv.GenAIUsageOutputTokens(ai.GetOutputTokens()))
 			if ai.Input.Dimensions > 0 {
 				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.dimensions", ai.Input.Dimensions))
 			}

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -515,6 +515,10 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Error.Type))
 				attrs = append(attrs, semconv.ErrorMessage(ai.Error.Message))
 			}
+			// embedding-specific extension attributes
+			if ai.OperationName == request.EmbeddingOperationName && ai.Request.Dimensions > 0 {
+				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.dimensions", ai.Request.Dimensions))
+			}
 		}
 
 		if span.SubType == request.HTTPSubtypeAnthropic && span.GenAI != nil && span.GenAI.Anthropic != nil {
@@ -664,6 +668,29 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			if ai.Output.ErrorType != "" {
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Output.ErrorType))
 				attrs = append(attrs, semconv.ErrorMessage(ai.Output.ErrorMessage))
+			}
+		}
+
+		if span.SubType == request.HTTPSubtypeEmbedding && span.GenAI != nil && span.GenAI.Embedding != nil {
+			ai := span.GenAI.Embedding
+			attrs = append(attrs, semconv.GenAIProviderNameKey.String(ai.Provider))
+			attrs = append(attrs, semconv.GenAIOperationNameKey.String(ai.OperationName()))
+			model := ai.Input.Model
+			if model == "" {
+				model = ai.Model
+			}
+			attrs = append(attrs, semconv.GenAIRequestModel(model))
+			if ai.Output.Model != "" {
+				attrs = append(attrs, semconv.GenAIResponseModel(ai.Output.Model))
+			} else {
+				attrs = append(attrs, semconv.GenAIResponseModel(model))
+			}
+			attrs = append(attrs, semconv.GenAIUsageInputTokens(ai.GetInputTokens()))
+			if ai.Input.Dimensions > 0 {
+				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.dimensions", ai.Input.Dimensions))
+			}
+			if count := ai.Input.InputCount(); count > 0 {
+				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.input_count", count))
 			}
 		}
 

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -556,6 +556,10 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Error.Type))
 				attrs = append(attrs, semconv.ErrorMessage(ai.Error.Message))
 			}
+			// embedding-specific extension attributes
+			if ai.OperationName == request.EmbeddingOperationName && ai.Request.Dimensions > 0 {
+				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.dimensions", ai.Request.Dimensions))
+			}
 		}
 
 		if span.SubType == request.HTTPSubtypeAnthropic && span.GenAI != nil && span.GenAI.Anthropic != nil {
@@ -755,6 +759,29 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 		}
 
 		attrs = append(attrs, mcpAttributes(span)...)
+
+		if span.SubType == request.HTTPSubtypeEmbedding && span.GenAI != nil && span.GenAI.Embedding != nil {
+			ai := span.GenAI.Embedding
+			attrs = append(attrs, semconv.GenAIProviderNameKey.String(ai.Provider))
+			attrs = append(attrs, semconv.GenAIOperationNameKey.String(ai.OperationName()))
+			model := ai.Input.Model
+			if model == "" {
+				model = ai.Model
+			}
+			attrs = append(attrs, semconv.GenAIRequestModel(model))
+			if ai.Output.Model != "" {
+				attrs = append(attrs, semconv.GenAIResponseModel(ai.Output.Model))
+			} else {
+				attrs = append(attrs, semconv.GenAIResponseModel(model))
+			}
+			attrs = append(attrs, semconv.GenAIUsageInputTokens(ai.GetInputTokens()))
+			if ai.Input.Dimensions > 0 {
+				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.dimensions", ai.Input.Dimensions))
+			}
+			if count := ai.Input.InputCount(); count > 0 {
+				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.input_count", count))
+			}
+		}
 
 		attrs = append(attrs, jsonRPCAttributes(span)...)
 		attrs = append(attrs, httpEnrichmentAttributes(span)...)


### PR DESCRIPTION
## Summary

## Embedding Detection Architecture

Embedding monitoring is handled in two layers:

### Embedding requests already handled by existing provider detectors

- **OpenAI embeddings**: Detected by `OpenAISpan` via response headers; when the URL path contains `/v1/embeddings`, the operation name is automatically overridden to `"embeddings"`.
- **Qwen/DashScope embeddings**: Detected by `QwenSpan` via the `X-DashScope-Request-Id` response header; `extractQwenOperation()` maps the `/embeddings` URL path to the operation name `"embedding"`.

### Embedding requests handled by the standalone `embedding.go`

Covers only **Voyage AI**, **Cohere**, and **Jina AI** — three embedding-only providers.

| Reason | Detail |
|:-------|:-------|
| No existing vendor to belong to | These providers have no chat/completion API and do not fit into any existing vendor detector |
| No identifiable response headers | Unlike OpenAI (`Openai-Version`) or Anthropic (`Anthropic-Organization-Id`), these providers do not return vendor-specific headers; detection relies on hostname + URL path matching |
| Different API formats | e.g., Cohere uses `texts` instead of `input`, and token counts live under `meta.billed_units` rather than `usage`, requiring a dedicated `VendorEmbedding` data structure |

### Detection priority
## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
