### PR TITLE
Fix Java Agent injection

### DIFF
--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -87,12 +87,7 @@ func (ta *traceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 	ta.log = slog.With("component", "discover.traceAttacher")
 	ta.existingTracers = map[uint64]*ebpf.ProcessTracer{}
 	ta.nodeInjector = nodejs.NewNodeInjector(ta.Cfg)
-	javaInjector, err := javaagent.NewJavaInjector(ta.Cfg)
-	if err != nil {
-		ta.log.Warn("unable to inject OBI java agent, Java TLS telemetry generation will not work", "error", err)
-	} else {
-		ta.javaInjector = javaInjector
-	}
+	ta.javaInjector = javaagent.NewJavaInjector(ta.Cfg)
 	ta.processInstances = maps.MultiCounter[uint64]{}
 	ta.EbpfEventContext.CommonPIDsFilter = ebpfcommon.NewPIDsFilter(&ta.Cfg.Discovery, slog.With("component", "ebpfCommon.CommonPIDsFilter"), ta.Metrics)
 	ta.routeHarvester = harvest.NewRouteHarvester(&ta.Cfg.Discovery.RouteHarvestConfig, ta.Cfg.Discovery.DisabledRouteHarvesters, ta.Cfg.Discovery.RouteHarvesterTimeout)

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -49,16 +49,16 @@ type JavaInjector struct {
 	cfg *obi.Config
 }
 
-func NewJavaInjector(cfg *obi.Config) (*JavaInjector, error) {
+func NewJavaInjector(cfg *obi.Config) *JavaInjector {
 	if !cfg.Java.Enabled {
-		return nil, nil
+		return nil
 	}
 	ensureEmbeddedAgent()
 
 	return &JavaInjector{
 		cfg: cfg,
 		log: slog.With("component", "javaagent.Injector"),
-	}, nil
+	}
 }
 
 func tempDirPath(root, dir string) (string, bool) {

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/sha256"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -35,14 +34,7 @@ const (
 )
 
 //go:embed embedded/obi-java-agent.jar
-var embeddedJavaAgentRaw []byte
-
-// Aliases used for testing.
-var (
-	embeddedJavaAgentBytes = embeddedJavaAgentRaw
-	userCacheDir           = os.UserCacheDir
-	renameFile             = os.Rename
-)
+var embeddedJavaAgentBytes []byte
 
 type JavaInjectError struct {
 	Message string
@@ -53,25 +45,19 @@ func (e *JavaInjectError) Error() string {
 }
 
 type JavaInjector struct {
-	log       *slog.Logger
-	cfg       *obi.Config
-	agentPath string
+	log *slog.Logger
+	cfg *obi.Config
 }
 
 func NewJavaInjector(cfg *obi.Config) (*JavaInjector, error) {
 	if !cfg.Java.Enabled {
 		return nil, nil
 	}
-
-	agentPath, err := ensureEmbeddedAgentInCache()
-	if err != nil {
-		return nil, fmt.Errorf("unable to extract embedded OBI java agent jar: %w", err)
-	}
+	ensureEmbeddedAgent()
 
 	return &JavaInjector{
-		cfg:       cfg,
-		log:       slog.With("component", "javaagent.Injector"),
-		agentPath: agentPath,
+		cfg: cfg,
+		log: slog.With("component", "javaagent.Injector"),
 	}, nil
 }
 
@@ -211,92 +197,10 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 	return nil
 }
 
-func ensureEmbeddedAgentInCache() (string, error) {
+func ensureEmbeddedAgent() {
 	if len(embeddedJavaAgentBytes) == 0 || strings.TrimSpace(string(embeddedJavaAgentBytes)) == javaAgentEmbedPlaceholder {
-		return "", errors.New("embedded OBI java agent artifact is missing; run `make java-docker-build`")
+		panic("embedded OBI java agent artifact is missing; run `make java-docker-build`")
 	}
-
-	cacheRoot, err := userCacheDir()
-	if err != nil {
-		return "", fmt.Errorf("unable to resolve user cache directory: %w", err)
-	}
-
-	cacheDir := filepath.Join(cacheRoot, "obi", "java")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		return "", fmt.Errorf("unable to create java agent cache directory: %w", err)
-	}
-
-	checksum := sha256.Sum256(embeddedJavaAgentBytes)
-	// The final cache filename is content-addressed so identical embedded bytes
-	// always resolve to the same reusable artifact path.
-	targetPath := filepath.Join(cacheDir, fmt.Sprintf("obi-java-agent-%x.jar", checksum))
-
-	// Fast path: if the checksum-addressed artifact already exists and matches
-	// expected size, reuse it without rewriting.
-	if info, err := os.Stat(targetPath); err == nil {
-		if !info.IsDir() && info.Size() == int64(len(embeddedJavaAgentBytes)) {
-			return targetPath, nil
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return "", fmt.Errorf("unable to stat cached java agent: %w", err)
-	}
-
-	// Stage writes in a temporary file first so readers never observe a partially
-	// written jar if this process fails mid-write.
-	tmpFile, err := os.CreateTemp(cacheDir, "obi-java-agent-*.jar")
-	if err != nil {
-		return "", fmt.Errorf("unable to create temporary java agent file: %w", err)
-	}
-
-	tmpPath := tmpFile.Name()
-	cleanup := true
-	defer func() {
-		if cleanup {
-			_ = os.Remove(tmpPath)
-		}
-	}()
-
-	written, err := tmpFile.Write(embeddedJavaAgentBytes)
-	func() {
-		defer func() {
-			e := tmpFile.Close()
-			if e != nil {
-				err = errors.Join(err, e)
-			}
-		}()
-		if err != nil {
-			return
-		}
-		if written != len(embeddedJavaAgentBytes) {
-			err = errors.New("short write")
-			return
-		}
-		if err = tmpFile.Chmod(0o644); err != nil {
-			err = fmt.Errorf("unable to set permissions on temporary java agent file: %w", err)
-			return
-		}
-	}()
-	if err != nil {
-		return "", fmt.Errorf("unable to write embedded java agent: %w", err)
-	}
-
-	// Publish by atomic rename (same directory/filesystem), which also behaves
-	// safely under concurrent writers of identical content.
-	if err := renameFile(tmpPath, targetPath); err != nil {
-		// A concurrent OBI process may have already published the same
-		// checksum-addressed file between our initial stat and rename.
-		// If the target is now present and valid, treat this as success.
-		if info, statErr := os.Stat(targetPath); statErr == nil {
-			if !info.IsDir() && info.Size() == int64(len(embeddedJavaAgentBytes)) {
-				return targetPath, nil
-			}
-		}
-
-		return "", fmt.Errorf("unable to move java agent into cache: %w", err)
-	}
-
-	cleanup = false // Renamed, tmpPath no longer exists.
-	return targetPath, nil
 }
 
 // to be changed in tests
@@ -318,12 +222,7 @@ func (i *JavaInjector) copyAgent(ie *ebpf.Instrumentable) (string, error) {
 
 	agentPathHost := filepath.Join(fullTempDir, ObiJavaAgentFileName)
 
-	source, err := os.Open(i.agentPath)
-	if err != nil {
-		return "", fmt.Errorf("unable to access OBI java agent: %w", err)
-	}
-
-	defer source.Close()
+	source := bytes.NewReader(embeddedJavaAgentBytes)
 	target, err := os.CreateTemp(fullTempDir, ObiJavaAgentFileName+".tmp-*")
 	if err != nil {
 		return "", fmt.Errorf("unable to create target OBI java agent: %w", err)

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -199,7 +199,9 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 
 func ensureEmbeddedAgent() {
 	if len(embeddedJavaAgentBytes) == 0 || strings.TrimSpace(string(embeddedJavaAgentBytes)) == javaAgentEmbedPlaceholder {
-		panic("embedded OBI java agent artifact is missing; run `make java-docker-build`")
+		// Make sure to run `make java-docker-build` to build the Java Agent
+		// so that it can be embedded during build.
+		return errors.New("embedded OBI java agent artifact is missing") 
 	}
 }
 

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -201,7 +201,7 @@ func ensureEmbeddedAgent() {
 	if len(embeddedJavaAgentBytes) == 0 || strings.TrimSpace(string(embeddedJavaAgentBytes)) == javaAgentEmbedPlaceholder {
 		// Make sure to run `make java-docker-build` to build the Java Agent
 		// so that it can be embedded during build.
-		return errors.New("embedded OBI java agent artifact is missing") 
+		panic("embedded OBI java agent artifact is missing")
 	}
 }
 

--- a/pkg/internal/java/java_inject_notlinux.go
+++ b/pkg/internal/java/java_inject_notlinux.go
@@ -9,5 +9,5 @@ package javaagent // import "go.opentelemetry.io/obi/pkg/internal/java"
 
 type JavaInjector struct{}
 
-func NewJavaInjector(_ any) (*JavaInjector, error) { return nil, nil }
-func (*JavaInjector) NewExecutable(_ any) error    { return nil }
+func NewJavaInjector(_ any) *JavaInjector       { return nil }
+func (*JavaInjector) NewExecutable(_ any) error { return nil }

--- a/pkg/internal/java/java_inject_test.go
+++ b/pkg/internal/java/java_inject_test.go
@@ -6,9 +6,6 @@
 package javaagent
 
 import (
-	"crypto/sha256"
-	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -26,9 +23,14 @@ import (
 )
 
 func TestJavaInjector_CopyAgent(t *testing.T) {
+	oldJavaAgentBytes := embeddedJavaAgentBytes
+	embeddedJavaAgentBytes = []byte("test agent content")
+	t.Cleanup(func() {
+		embeddedJavaAgentBytes = oldJavaAgentBytes
+	})
+
 	tests := []struct {
 		name          string
-		setupAgent    func(t *testing.T) string
 		setupTempDir  func(t *testing.T, pid app.PID) string
 		envVars       map[string]string
 		pid           app.PID
@@ -38,11 +40,6 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 	}{
 		{
 			name: "successful copy to /tmp",
-			setupAgent: func(t *testing.T) string {
-				tmpFile := filepath.Join(t.TempDir(), ObiJavaAgentFileName)
-				require.NoError(t, os.WriteFile(tmpFile, []byte("test agent content"), 0o644))
-				return tmpFile
-			},
 			setupTempDir: func(t *testing.T, _ app.PID) string {
 				tmpDir := t.TempDir()
 				procRoot := filepath.Join(tmpDir, "proc", "root")
@@ -56,11 +53,6 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 		},
 		{
 			name: "successful copy to TMPDIR from env",
-			setupAgent: func(t *testing.T) string {
-				tmpFile := filepath.Join(t.TempDir(), ObiJavaAgentFileName)
-				require.NoError(t, os.WriteFile(tmpFile, []byte("test agent content"), 0o644))
-				return tmpFile
-			},
 			setupTempDir: func(t *testing.T, _ app.PID) string {
 				tmpDir := t.TempDir()
 				procRoot := filepath.Join(tmpDir, "proc", "root")
@@ -77,11 +69,6 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 		},
 		{
 			name: "TMPDIR absolute path outside process root is ignored",
-			setupAgent: func(t *testing.T) string {
-				tmpFile := filepath.Join(t.TempDir(), ObiJavaAgentFileName)
-				require.NoError(t, os.WriteFile(tmpFile, []byte("test agent content"), 0o644))
-				return tmpFile
-			},
 			setupTempDir: func(t *testing.T, _ app.PID) string {
 				tmpDir := t.TempDir()
 				procRoot := filepath.Join(tmpDir, "proc", "root")
@@ -97,11 +84,6 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 		},
 		{
 			name: "TMPDIR relative path escape is ignored",
-			setupAgent: func(t *testing.T) string {
-				tmpFile := filepath.Join(t.TempDir(), ObiJavaAgentFileName)
-				require.NoError(t, os.WriteFile(tmpFile, []byte("test agent content"), 0o644))
-				return tmpFile
-			},
 			setupTempDir: func(t *testing.T, _ app.PID) string {
 				tmpDir := t.TempDir()
 				procRoot := filepath.Join(tmpDir, "proc", "root")
@@ -117,11 +99,6 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 		},
 		{
 			name: "fallback to /var/tmp when /tmp not available",
-			setupAgent: func(t *testing.T) string {
-				tmpFile := filepath.Join(t.TempDir(), ObiJavaAgentFileName)
-				require.NoError(t, os.WriteFile(tmpFile, []byte("test agent content"), 0o644))
-				return tmpFile
-			},
 			setupTempDir: func(t *testing.T, _ app.PID) string {
 				tmpDir := t.TempDir()
 				procRoot := filepath.Join(tmpDir, "proc", "root")
@@ -135,11 +112,6 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 		},
 		{
 			name: "error when no temp directory available",
-			setupAgent: func(t *testing.T) string {
-				tmpFile := filepath.Join(t.TempDir(), ObiJavaAgentFileName)
-				require.NoError(t, os.WriteFile(tmpFile, []byte("test agent content"), 0o644))
-				return tmpFile
-			},
 			setupTempDir: func(t *testing.T, _ app.PID) string {
 				tmpDir := t.TempDir()
 				procRoot := filepath.Join(tmpDir, "proc", "root")
@@ -153,29 +125,7 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 			verifyFile:    false,
 		},
 		{
-			name: "error when agent file not accessible",
-			setupAgent: func(t *testing.T) string {
-				return filepath.Join(t.TempDir(), "nonexistent", ObiJavaAgentFileName)
-			},
-			setupTempDir: func(t *testing.T, _ app.PID) string {
-				tmpDir := t.TempDir()
-				procRoot := filepath.Join(tmpDir, "proc", "root")
-				require.NoError(t, os.MkdirAll(filepath.Join(procRoot, "tmp"), 0o755))
-				return tmpDir
-			},
-			envVars:       map[string]string{},
-			pid:           1000,
-			expectError:   true,
-			errorContains: "unable to access OBI java agent",
-			verifyFile:    false,
-		},
-		{
 			name: "error when target directory not writable",
-			setupAgent: func(t *testing.T) string {
-				tmpFile := filepath.Join(t.TempDir(), ObiJavaAgentFileName)
-				require.NoError(t, os.WriteFile(tmpFile, []byte("test agent content"), 0o644))
-				return tmpFile
-			},
 			setupTempDir: func(t *testing.T, _ app.PID) string {
 				tmpDir := t.TempDir()
 				procRoot := filepath.Join(tmpDir, "proc", "root")
@@ -192,12 +142,6 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 		},
 		{
 			name: "agent content correctly copied",
-			setupAgent: func(t *testing.T) string {
-				tmpFile := filepath.Join(t.TempDir(), ObiJavaAgentFileName)
-				content := []byte("unique test agent content 12345")
-				require.NoError(t, os.WriteFile(tmpFile, content, 0o644))
-				return tmpFile
-			},
 			setupTempDir: func(t *testing.T, _ app.PID) string {
 				tmpDir := t.TempDir()
 				procRoot := filepath.Join(tmpDir, "proc", "root")
@@ -211,11 +155,6 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 		},
 		{
 			name: "copy does not follow existing symlink target",
-			setupAgent: func(t *testing.T) string {
-				tmpFile := filepath.Join(t.TempDir(), ObiJavaAgentFileName)
-				require.NoError(t, os.WriteFile(tmpFile, []byte("test agent content"), 0o644))
-				return tmpFile
-			},
 			setupTempDir: func(t *testing.T, _ app.PID) string {
 				tmpDir := t.TempDir()
 				procRoot := filepath.Join(tmpDir, "proc", "root")
@@ -236,7 +175,6 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			agentPath := tt.setupAgent(t)
 			tmpDir := tt.setupTempDir(t, tt.pid)
 
 			// Override the root directory function
@@ -247,9 +185,8 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 			}
 
 			injector := &JavaInjector{
-				cfg:       &obi.DefaultConfig,
-				log:       slog.With("component", "javaagent.Injector"),
-				agentPath: agentPath,
+				cfg: &obi.DefaultConfig,
+				log: slog.With("component", "javaagent.Injector"),
 			}
 
 			ie := &ebpf.Instrumentable{
@@ -284,8 +221,7 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 					assert.Equal(t, os.FileMode(0o644), info.Mode().Perm())
 
 					// Verify content matches
-					originalContent, err := os.ReadFile(agentPath)
-					require.NoError(t, err)
+					originalContent := embeddedJavaAgentBytes
 					copiedContent, err := os.ReadFile(expectedHostPath)
 					require.NoError(t, err)
 					assert.Equal(t, originalContent, copiedContent)
@@ -570,123 +506,22 @@ func TestJavaInjector_AttachOpts(t *testing.T) {
 	}
 }
 
-func TestEnsureEmbeddedAgentInCache_WritesAndReuses(t *testing.T) {
-	originalUserCacheDir := userCacheDir
+func TestEnsureEmbeddedAgentInCache_ForgotToEmbed(t *testing.T) {
 	originalEmbeddedBytes := embeddedJavaAgentBytes
 	t.Cleanup(func() {
-		userCacheDir = originalUserCacheDir
 		embeddedJavaAgentBytes = originalEmbeddedBytes
 	})
 
-	cacheRoot := t.TempDir()
-	embeddedJavaAgentBytes = []byte("embedded-java-agent-content")
-	userCacheDir = func() (string, error) {
-		return cacheRoot, nil
-	}
-
-	firstPath, err := ensureEmbeddedAgentInCache()
-	require.NoError(t, err)
-	content, err := os.ReadFile(firstPath)
-	require.NoError(t, err)
-	assert.Equal(t, embeddedJavaAgentBytes, content)
-
-	secondPath, err := ensureEmbeddedAgentInCache()
-	require.NoError(t, err)
-	assert.Equal(t, firstPath, secondPath)
+	embeddedJavaAgentBytes = nil
+	assert.Panics(t, ensureEmbeddedAgent)
 }
 
 func TestEnsureEmbeddedAgentInCache_PlaceholderBytesError(t *testing.T) {
-	originalUserCacheDir := userCacheDir
 	originalEmbeddedBytes := embeddedJavaAgentBytes
 	t.Cleanup(func() {
-		userCacheDir = originalUserCacheDir
 		embeddedJavaAgentBytes = originalEmbeddedBytes
 	})
 
 	embeddedJavaAgentBytes = []byte(javaAgentEmbedPlaceholder + "\n")
-
-	_, err := ensureEmbeddedAgentInCache()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "embedded OBI java agent artifact is missing")
-}
-
-func TestEnsureEmbeddedAgentInCache_RenameRaceTreatsAsSuccess(t *testing.T) {
-	originalUserCacheDir := userCacheDir
-	originalEmbeddedBytes := embeddedJavaAgentBytes
-	originalRenameFile := renameFile
-	t.Cleanup(func() {
-		userCacheDir = originalUserCacheDir
-		embeddedJavaAgentBytes = originalEmbeddedBytes
-		renameFile = originalRenameFile
-	})
-
-	cacheRoot := t.TempDir()
-	embeddedJavaAgentBytes = []byte("embedded-java-agent-content")
-	userCacheDir = func() (string, error) {
-		return cacheRoot, nil
-	}
-
-	checksum := sha256.Sum256(embeddedJavaAgentBytes)
-	expectedPath := filepath.Join(cacheRoot, "obi", "java", fmt.Sprintf("obi-java-agent-%x.jar", checksum))
-
-	renameFile = func(_, target string) error {
-		require.NoError(t, os.MkdirAll(filepath.Dir(target), 0o755))
-		require.NoError(t, os.WriteFile(target, embeddedJavaAgentBytes, 0o644))
-		return errors.New("simulated concurrent rename conflict")
-	}
-
-	path, err := ensureEmbeddedAgentInCache()
-	require.NoError(t, err)
-	assert.Equal(t, expectedPath, path)
-
-	content, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Equal(t, embeddedJavaAgentBytes, content)
-}
-
-func TestEnsureEmbeddedAgentInCache_RewritesIncorrectSizedCacheFile(t *testing.T) {
-	originalUserCacheDir := userCacheDir
-	originalEmbeddedBytes := embeddedJavaAgentBytes
-	t.Cleanup(func() {
-		userCacheDir = originalUserCacheDir
-		embeddedJavaAgentBytes = originalEmbeddedBytes
-	})
-
-	cacheRoot := t.TempDir()
-	embeddedJavaAgentBytes = []byte("embedded-java-agent-content")
-	userCacheDir = func() (string, error) {
-		return cacheRoot, nil
-	}
-
-	checksum := sha256.Sum256(embeddedJavaAgentBytes)
-	expectedPath := filepath.Join(cacheRoot, "obi", "java", fmt.Sprintf("obi-java-agent-%x.jar", checksum))
-	require.NoError(t, os.MkdirAll(filepath.Dir(expectedPath), 0o755))
-	require.NoError(t, os.WriteFile(expectedPath, []byte("bad"), 0o644))
-
-	path, err := ensureEmbeddedAgentInCache()
-	require.NoError(t, err)
-	assert.Equal(t, expectedPath, path)
-
-	content, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Equal(t, embeddedJavaAgentBytes, content)
-}
-
-func TestEnsureEmbeddedAgentInCache_UserCacheDirError(t *testing.T) {
-	originalUserCacheDir := userCacheDir
-	originalEmbeddedBytes := embeddedJavaAgentBytes
-	t.Cleanup(func() {
-		userCacheDir = originalUserCacheDir
-		embeddedJavaAgentBytes = originalEmbeddedBytes
-	})
-
-	embeddedJavaAgentBytes = []byte("embedded-java-agent-content")
-	userCacheDir = func() (string, error) {
-		return "", errors.New("cache dir lookup failed")
-	}
-
-	_, err := ensureEmbeddedAgentInCache()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unable to resolve user cache directory")
-	assert.Contains(t, err.Error(), "cache dir lookup failed")
+	assert.Panics(t, ensureEmbeddedAgent)
 }


### PR DESCRIPTION
## Summary

Some container users got their Java instrumentation broken because OBI was trying to write a copy of the agent JAR in `/.cache` (no permissions).

While working on a fix, I realized it was unnecessary caching the agent in disk because it's already in the executable memory, so it is injected directly from memory to the target filesystem. It simplifies a bit the code.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
