### PR TITLE
Update error handling in netolly packet stats path

### DIFF
--- a/pkg/internal/netolly/ebpf/sock_tracer_nolinux.go
+++ b/pkg/internal/netolly/ebpf/sock_tracer_nolinux.go
@@ -26,7 +26,7 @@ func (s *SockFlowFetcher) ReadRingBuf() (ringbuf.Record, error) {
 }
 
 func (s *SockFlowFetcher) LookupPacketStats() (NetPacketCount, error) {
-	panic("this is never going to be executed")
+	return NetPacketCount{}, ErrTracerTerminated
 }
 
 func NewSockFlowFetcher(

--- a/pkg/internal/netolly/ebpf/tracer_common_linux.go
+++ b/pkg/internal/netolly/ebpf/tracer_common_linux.go
@@ -6,14 +6,18 @@
 package ebpf // import "go.opentelemetry.io/obi/pkg/internal/netolly/ebpf"
 
 import (
+	"errors"
+
 	"github.com/cilium/ebpf"
 )
 
+var errFlowPacketStatsMapNotInitialized = errors.New("flow packet stats map not initialized")
+
 // lookupPacketStats is a common function called by LookupPacketStats().
-// Returns ErrTracerTerminated after Close().
+// Returns errFlowPacketStatsMapNotInitialized after Close().
 func lookupPacketStats(m *ebpf.Map) (NetPacketCount, error) {
 	if m == nil {
-		return NetPacketCount{}, ErrTracerTerminated
+		return NetPacketCount{}, errFlowPacketStatsMapNotInitialized
 	}
 	var perCPUCounts []NetPacketCount
 	if err := m.Lookup(uint32(0), &perCPUCounts); err != nil {

--- a/pkg/internal/netolly/ebpf/tracer_nonlinux.go
+++ b/pkg/internal/netolly/ebpf/tracer_nonlinux.go
@@ -40,5 +40,5 @@ func (m *FlowFetcher) LookupAndDeleteMap() map[NetFlowId]*NetFlowMetrics {
 }
 
 func (m *FlowFetcher) LookupPacketStats() (NetPacketCount, error) {
-	panic("this is never going to be executed")
+	return NetPacketCount{}, ErrTracerTerminated
 }


### PR DESCRIPTION
## Summary

This PR is just a follow-up to #1873 with small cleanups to error handling in the netolly packet stats path. 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
