### PR TITLE
fix(otel): clean up missing metric instances on teardown

### DIFF
--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -728,28 +728,28 @@ func (mr *MetricsReporter) newMetricSet(service *svc.Attrs) (*Metrics, error) {
 	meter := m.provider.Meter(reporterName)
 	var err error
 
-	if mr.jointMetricsCfg.Features.AppRED() {
-		err = mr.setupOtelMeters(&m, meter)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if mr.jointMetricsCfg.Features.SpanMetrics() {
-		err = mr.setupSpanMeters(&m, meter)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if mr.jointMetricsCfg.Features.SpanSizes() {
-		err = mr.setupSpanSizeMeters(&m, meter)
-		if err != nil {
-			return nil, err
-		}
+	err = mr.setupMetricExpirers(&m, meter)
+	if err != nil {
+		return nil, err
 	}
 
 	return &m, nil
+}
+
+func (mr *MetricsReporter) setupMetricExpirers(m *Metrics, meter instrument.Meter) error {
+	if err := mr.setupOtelMeters(m, meter); err != nil {
+		return err
+	}
+
+	if err := mr.setupSpanMeters(m, meter); err != nil {
+		return err
+	}
+
+	if err := mr.setupSpanSizeMeters(m, meter); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func isExponentialAggregation(mc *otelcfg.MetricsConfig, mlog *slog.Logger) bool {
@@ -1281,6 +1281,7 @@ func (r *Metrics) cleanupAllMetricsInstances() {
 	cleanupFloatCounterMetrics(r.ctx, r.spanMetricsRequestSizeTotal)
 	cleanupFloatCounterMetrics(r.ctx, r.spanMetricsResponseSizeTotal)
 	cleanupCounterMetrics(r.ctx, r.gpuKernelCallsTotal)
+	cleanupCounterMetrics(r.ctx, r.gpuGraphCallsTotal)
 	cleanupCounterMetrics(r.ctx, r.gpuMemoryAllocsTotal)
 	cleanupMetrics(r.ctx, r.gpuKernelGridSize)
 	cleanupMetrics(r.ctx, r.gpuKernelBlockSize)

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -1288,4 +1288,5 @@ func (r *Metrics) cleanupAllMetricsInstances() {
 	cleanupMetrics(r.ctx, r.dnsLookupDuration)
 	cleanupMetrics(r.ctx, r.genAIClientDuration)
 	cleanupMetrics(r.ctx, r.genAIInputTokenUsage)
+	cleanupMetrics(r.ctx, r.genAIOutputTokenUsage)
 }

--- a/pkg/export/otel/metrics_cleanup_test.go
+++ b/pkg/export/otel/metrics_cleanup_test.go
@@ -5,95 +5,213 @@ package otel
 
 import (
 	"context"
-	"sync"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/embedded"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	instrument "go.opentelemetry.io/obi/pkg/export/otel/metric/api/metric"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 )
 
-func TestCleanupAllMetricsInstances_RemovesGenAIOutputTokenUsage(t *testing.T) {
+func TestCleanupAllMetricsInstances_RemovesAllMetrics(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
-	inputMetric := newTestFloat64Histogram()
-	outputMetric := newTestFloat64Histogram()
+	metrics := &Metrics{ctx: ctx}
+	meter := &testMeter{}
+	reporter := newCleanupTestMetricsReporter(ctx)
 
-	metrics := &Metrics{
-		ctx:                   ctx,
-		genAIInputTokenUsage:  newTestExpirer(ctx, inputMetric, "input"),
-		genAIOutputTokenUsage: newTestExpirer(ctx, outputMetric, "output"),
-	}
+	err := reporter.setupMetricExpirers(metrics, meter)
+	require.NoError(t, err)
+
+	seeded := seedMetricsExpirers(t, metrics)
+	require.NotEmpty(t, seeded)
 
 	metrics.cleanupAllMetricsInstances()
 
-	assert.Equal(t, []attribute.Set{testAttributeSet("input")}, inputMetric.removed())
-	assert.Equal(t, []attribute.Set{testAttributeSet("output")}, outputMetric.removed())
-	assert.Empty(t, metrics.genAIInputTokenUsage.entries.All())
-	assert.Empty(t, metrics.genAIOutputTokenUsage.entries.All())
+	for _, fieldName := range seeded {
+		t.Run(fieldName, func(t *testing.T) {
+			assertMetricExpirerCleared(t, metrics, fieldName)
+		})
+	}
+}
+
+type testMeter struct {
+	embedded.Meter
+}
+
+func (m *testMeter) Int64Counter(string, ...instrument.Int64CounterOption) (instrument.Int64Counter, error) {
+	return &testInt64Counter{}, nil
+}
+
+func (m *testMeter) Int64UpDownCounter(string, ...instrument.Int64UpDownCounterOption) (instrument.Int64UpDownCounter, error) {
+	return nil, nil
+}
+
+func (m *testMeter) Int64Histogram(string, ...instrument.Int64HistogramOption) (instrument.Int64Histogram, error) {
+	return nil, nil
+}
+
+func (m *testMeter) Int64Gauge(string, ...instrument.Int64GaugeOption) (instrument.Int64Gauge, error) {
+	return nil, nil
+}
+
+func (m *testMeter) Int64ObservableCounter(string, ...instrument.Int64ObservableCounterOption) (instrument.Int64ObservableCounter, error) {
+	return nil, nil
+}
+
+func (m *testMeter) Int64ObservableUpDownCounter(string, ...instrument.Int64ObservableUpDownCounterOption) (instrument.Int64ObservableUpDownCounter, error) {
+	return nil, nil
+}
+
+func (m *testMeter) Int64ObservableGauge(string, ...instrument.Int64ObservableGaugeOption) (instrument.Int64ObservableGauge, error) {
+	return nil, nil
+}
+
+func (m *testMeter) Float64Counter(string, ...instrument.Float64CounterOption) (instrument.Float64Counter, error) {
+	return &testFloat64Counter{}, nil
+}
+
+func (m *testMeter) Float64UpDownCounter(string, ...instrument.Float64UpDownCounterOption) (instrument.Float64UpDownCounter, error) {
+	return nil, nil
+}
+
+func (m *testMeter) Float64Histogram(string, ...instrument.Float64HistogramOption) (instrument.Float64Histogram, error) {
+	return &testFloat64Histogram{}, nil
+}
+
+func (m *testMeter) Float64Gauge(string, ...instrument.Float64GaugeOption) (instrument.Float64Gauge, error) {
+	return nil, nil
+}
+
+func (m *testMeter) Float64ObservableCounter(string, ...instrument.Float64ObservableCounterOption) (instrument.Float64ObservableCounter, error) {
+	return nil, nil
+}
+
+func (m *testMeter) Float64ObservableUpDownCounter(string, ...instrument.Float64ObservableUpDownCounterOption) (instrument.Float64ObservableUpDownCounter, error) {
+	return nil, nil
+}
+
+func (m *testMeter) Float64ObservableGauge(string, ...instrument.Float64ObservableGaugeOption) (instrument.Float64ObservableGauge, error) {
+	return nil, nil
+}
+
+func (m *testMeter) RegisterCallback(instrument.Callback, ...instrument.Observable) (instrument.Registration, error) {
+	return nil, nil
 }
 
 type testFloat64Histogram struct {
 	embedded.Float64Histogram
-
-	mu           sync.Mutex
-	removedAttrs []attribute.Set
-}
-
-func newTestFloat64Histogram() *testFloat64Histogram {
-	return &testFloat64Histogram{}
 }
 
 func (h *testFloat64Histogram) Record(context.Context, float64, ...instrument.RecordOption) {}
 
-func (h *testFloat64Histogram) Remove(_ context.Context, options ...instrument.RemoveOption) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+func (h *testFloat64Histogram) Remove(context.Context, ...instrument.RemoveOption) {}
 
-	h.removedAttrs = append(h.removedAttrs, instrument.NewRemoveConfig(options).Attributes())
+type testFloat64Counter struct {
+	embedded.Float64Counter
 }
 
-func (h *testFloat64Histogram) removed() []attribute.Set {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+func (c *testFloat64Counter) Add(context.Context, float64, ...instrument.AddOption) {}
 
-	removed := make([]attribute.Set, len(h.removedAttrs))
-	copy(removed, h.removedAttrs)
-	return removed
+func (c *testFloat64Counter) Remove(context.Context, ...instrument.RemoveOption) {}
+
+type testInt64Counter struct {
+	embedded.Int64Counter
 }
 
-func newTestExpirer(
-	ctx context.Context,
-	metric instrument.Float64Histogram,
-	value string,
-) *Expirer[*request.Span, instrument.Float64Histogram, float64] {
-	expirer := NewExpirer[*request.Span, instrument.Float64Histogram, float64](
-		ctx,
-		metric,
-		[]attributes.Field[*request.Span, attribute.KeyValue]{
-			{
-				ExposedName: "token.type",
-				Get: func(*request.Span) attribute.KeyValue {
-					return attribute.String("token.type", value)
-				},
-			},
+func (c *testInt64Counter) Add(context.Context, int64, ...instrument.AddOption) {}
+
+func (c *testInt64Counter) Remove(context.Context, ...instrument.RemoveOption) {}
+
+func newCleanupTestMetricsReporter(ctx context.Context) *MetricsReporter {
+	return &MetricsReporter{
+		ctx: ctx,
+		cfg: &otelcfg.MetricsConfig{
+			TTL: time.Minute,
 		},
-		time.Now,
-		time.Minute,
-	)
-
-	expirer.ForRecord(&request.Span{})
-
-	return expirer
+		jointMetricsCfg: &perapp.MetricsConfig{
+			Features: export.FeatureApplicationRED | export.FeatureSpanOTel | export.FeatureSpanSizes,
+		},
+		is: instrumentations.NewInstrumentationSelection([]instrumentations.Instrumentation{
+			instrumentations.InstrumentationHTTP,
+			instrumentations.InstrumentationGRPC,
+			instrumentations.InstrumentationSQL,
+			instrumentations.InstrumentationKafka,
+			instrumentations.InstrumentationGPU,
+			instrumentations.InstrumentationDNS,
+			instrumentations.InstrumentationGenAI,
+		}),
+		attrGetters: func(name attr.Name) (attributes.Getter[*request.Span, attribute.KeyValue], bool) {
+			return func(*request.Span) attribute.KeyValue {
+				return attribute.String(string(name.OTEL()), string(name.OTEL()))
+			}, true
+		},
+	}
 }
 
-func testAttributeSet(value string) attribute.Set {
-	return attribute.NewSet(attribute.String("token.type", value))
+func seedMetricsExpirers(t *testing.T, metrics *Metrics) []string {
+	t.Helper()
+
+	value := reflect.ValueOf(metrics).Elem()
+	typ := value.Type()
+	seeded := make([]string, 0, typ.NumField())
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := value.Field(i)
+		fieldType := typ.Field(i)
+		if !isSeedableMetricExpirer(field) {
+			continue
+		}
+
+		seedMetricExpirer(t, field, fieldType.Name)
+		seeded = append(seeded, fieldType.Name)
+	}
+
+	return seeded
+}
+
+func isSeedableMetricExpirer(field reflect.Value) bool {
+	return field.Kind() == reflect.Pointer &&
+		!field.IsNil() &&
+		strings.Contains(field.Type().String(), ".Expirer[")
+}
+
+func seedMetricExpirer(t *testing.T, field reflect.Value, fieldName string) {
+	t.Helper()
+
+	field = accessibleFieldValue(field)
+	results := field.MethodByName("ForRecord").Call([]reflect.Value{reflect.ValueOf(&request.Span{})})
+	require.Len(t, results, 2, "seeding expirer %s", fieldName)
+
+	attrs := results[1].Interface().(attribute.Set)
+	assert.NotNil(t, attrs)
+}
+
+func assertMetricExpirerCleared(t *testing.T, metrics *Metrics, fieldName string) {
+	t.Helper()
+
+	field := accessibleFieldValue(reflect.ValueOf(metrics).Elem().FieldByName(fieldName))
+	entries := accessibleFieldValue(field.Elem().FieldByName("entries"))
+	all := entries.MethodByName("All").Call(nil)
+	require.Len(t, all, 1, "reading entries for %s", fieldName)
+	assert.Len(t, all[0].Interface(), 0, "expected %s expirer to be empty after cleanup", fieldName)
+}
+
+func accessibleFieldValue(field reflect.Value) reflect.Value {
+	return reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
 }

--- a/pkg/export/otel/metrics_cleanup_test.go
+++ b/pkg/export/otel/metrics_cleanup_test.go
@@ -148,13 +148,7 @@ func newCleanupTestMetricsReporter(ctx context.Context) *MetricsReporter {
 			Features: export.FeatureApplicationRED | export.FeatureSpanOTel | export.FeatureSpanSizes,
 		},
 		is: instrumentations.NewInstrumentationSelection([]instrumentations.Instrumentation{
-			instrumentations.InstrumentationHTTP,
-			instrumentations.InstrumentationGRPC,
-			instrumentations.InstrumentationSQL,
-			instrumentations.InstrumentationKafka,
-			instrumentations.InstrumentationGPU,
-			instrumentations.InstrumentationDNS,
-			instrumentations.InstrumentationGenAI,
+			instrumentations.InstrumentationALL,
 		}),
 		attrGetters: func(name attr.Name) (attributes.Getter[*request.Span, attribute.KeyValue], bool) {
 			return func(*request.Span) attribute.KeyValue {

--- a/pkg/export/otel/metrics_cleanup_test.go
+++ b/pkg/export/otel/metrics_cleanup_test.go
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/embedded"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	instrument "go.opentelemetry.io/obi/pkg/export/otel/metric/api/metric"
+)
+
+func TestCleanupAllMetricsInstances_RemovesGenAIOutputTokenUsage(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	inputMetric := newTestFloat64Histogram()
+	outputMetric := newTestFloat64Histogram()
+
+	metrics := &Metrics{
+		ctx:                   ctx,
+		genAIInputTokenUsage:  newTestExpirer(ctx, inputMetric, "input"),
+		genAIOutputTokenUsage: newTestExpirer(ctx, outputMetric, "output"),
+	}
+
+	metrics.cleanupAllMetricsInstances()
+
+	assert.Equal(t, []attribute.Set{testAttributeSet("input")}, inputMetric.removed())
+	assert.Equal(t, []attribute.Set{testAttributeSet("output")}, outputMetric.removed())
+	assert.Empty(t, metrics.genAIInputTokenUsage.entries.All())
+	assert.Empty(t, metrics.genAIOutputTokenUsage.entries.All())
+}
+
+type testFloat64Histogram struct {
+	embedded.Float64Histogram
+
+	mu           sync.Mutex
+	removedAttrs []attribute.Set
+}
+
+func newTestFloat64Histogram() *testFloat64Histogram {
+	return &testFloat64Histogram{}
+}
+
+func (h *testFloat64Histogram) Record(context.Context, float64, ...instrument.RecordOption) {}
+
+func (h *testFloat64Histogram) Remove(_ context.Context, options ...instrument.RemoveOption) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.removedAttrs = append(h.removedAttrs, instrument.NewRemoveConfig(options).Attributes())
+}
+
+func (h *testFloat64Histogram) removed() []attribute.Set {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	removed := make([]attribute.Set, len(h.removedAttrs))
+	copy(removed, h.removedAttrs)
+	return removed
+}
+
+func newTestExpirer(
+	ctx context.Context,
+	metric instrument.Float64Histogram,
+	value string,
+) *Expirer[*request.Span, instrument.Float64Histogram, float64] {
+	expirer := NewExpirer[*request.Span, instrument.Float64Histogram, float64](
+		ctx,
+		metric,
+		[]attributes.Field[*request.Span, attribute.KeyValue]{
+			{
+				ExposedName: "token.type",
+				Get: func(*request.Span) attribute.KeyValue {
+					return attribute.String("token.type", value)
+				},
+			},
+		},
+		time.Now,
+		time.Minute,
+	)
+
+	expirer.ForRecord(&request.Span{})
+
+	return expirer
+}
+
+func testAttributeSet(value string) attribute.Set {
+	return attribute.NewSet(attribute.String("token.type", value))
+}


### PR DESCRIPTION
## Summary
This PR fixes missing OTEL metric cleanup on `Metrics` teardown and strengthens the regression coverage around that cleanup path.

## Problem
`(*Metrics).cleanupAllMetricsInstances()` did not clean up all metric expirer instances created for a `Metrics` set.

The original issue in this PR was that `genAIOutputTokenUsage` was skipped. While broadening the regression coverage, the test also exposed that `gpuGraphCallsTotal` was missing from teardown cleanup as well.

That left stale metric attribute sets behind after teardown for those instruments.

## Changes
- add the missing cleanup call for `genAIOutputTokenUsage`
- add the missing cleanup call for `gpuGraphCallsTotal`
- factor the metric-expirer setup used by `newMetricSet()` into a shared helper
- replace the narrow regression test with one that builds metrics through the shared setup path, seeds every created expirer, and verifies teardown clears them all

## Testing
- `go test ./pkg/export/otel -run TestCleanupAllMetricsInstances_RemovesAllMetrics -count=1`
