### PR TITLE
fix(ebpf): preserve multiple pid tracer types

### DIFF
--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -19,7 +19,7 @@ import (
 type PIDType uint8
 
 const (
-	PIDTypeKProbes PIDType = iota + 1
+	PIDTypeKProbes PIDType = 1 << iota
 	PIDTypeGo
 )
 
@@ -30,7 +30,7 @@ var readNamespacePIDs = procs.FindNamespacedPids
 
 type PIDInfo struct {
 	service        *svc.Attrs
-	pidType        PIDType
+	pidTypes       PIDType
 	otherKnownPids []app.PID
 }
 
@@ -85,7 +85,7 @@ func (pf *PIDsFilter) ValidPID(userPID app.PID, ns uint32, pidType PIDType) bool
 
 	if ns, nsExists := pf.current[ns]; nsExists {
 		if info, pidExists := ns[userPID]; pidExists {
-			return info.pidType == pidType
+			return info.pidTypes&pidType != 0
 		}
 	}
 
@@ -100,7 +100,7 @@ func (pf *PIDsFilter) CurrentPIDs(t PIDType) map[uint32]map[app.PID]svc.Attrs {
 	for k, v := range pf.current {
 		cVal := map[app.PID]svc.Attrs{}
 		for kv, vv := range v {
-			if vv.pidType == t {
+			if vv.pidTypes&t != 0 {
 				cVal[kv] = *vv.service
 			}
 		}
@@ -175,7 +175,11 @@ func (pf *PIDsFilter) addPID(pid app.PID, nsid uint32, s *svc.Attrs, t PIDType) 
 	}
 
 	for _, p := range allPids {
-		ns[p] = PIDInfo{service: s, pidType: t, otherKnownPids: allPids}
+		pidInfo := ns[p]
+		pidInfo.service = s
+		pidInfo.pidTypes |= t
+		pidInfo.otherKnownPids = allPids
+		ns[p] = pidInfo
 	}
 }
 

--- a/pkg/ebpf/common/pids_test.go
+++ b/pkg/ebpf/common/pids_test.go
@@ -335,6 +335,34 @@ func TestFilter_Cleanup(t *testing.T) {
 	assert.False(t, pf.ValidPID(234, 33, PIDTypeGo))
 }
 
+func TestFilter_PreservesMultiplePIDTypes(t *testing.T) {
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid, pid + 1000}, nil
+	}
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+
+	pf.AllowPID(123, 33, &svc.Attrs{}, PIDTypeGo)
+	pf.AllowPID(123, 33, &svc.Attrs{}, PIDTypeKProbes)
+
+	assert.True(t, pf.ValidPID(123, 33, PIDTypeGo))
+	assert.True(t, pf.ValidPID(123, 33, PIDTypeKProbes))
+	assert.True(t, pf.ValidPID(1123, 33, PIDTypeGo))
+	assert.True(t, pf.ValidPID(1123, 33, PIDTypeKProbes))
+
+	_, goOK := pf.CurrentPIDs(PIDTypeGo)[33][123]
+	assert.True(t, goOK)
+
+	_, kprobeOK := pf.CurrentPIDs(PIDTypeKProbes)[33][123]
+	assert.True(t, kprobeOK)
+
+	pf.BlockPID(123, 33)
+
+	assert.False(t, pf.ValidPID(123, 33, PIDTypeGo))
+	assert.False(t, pf.ValidPID(123, 33, PIDTypeKProbes))
+	assert.False(t, pf.ValidPID(1123, 33, PIDTypeGo))
+	assert.False(t, pf.ValidPID(1123, 33, PIDTypeKProbes))
+}
+
 func resetTraceContext(spans []request.Span) []request.Span {
 	for i := range spans {
 		spans[i].TraceID = trace.TraceID{0}

--- a/pkg/ebpf/common/pids_test.go
+++ b/pkg/ebpf/common/pids_test.go
@@ -349,11 +349,19 @@ func TestFilter_PreservesMultiplePIDTypes(t *testing.T) {
 	assert.True(t, pf.ValidPID(1123, 33, PIDTypeGo))
 	assert.True(t, pf.ValidPID(1123, 33, PIDTypeKProbes))
 
-	_, goOK := pf.CurrentPIDs(PIDTypeGo)[33][123]
-	assert.True(t, goOK)
+	goPIDs := pf.CurrentPIDs(PIDTypeGo)
+	goNamespacePIDs, goNamespaceOK := goPIDs[33]
+	if assert.True(t, goNamespaceOK) {
+		_, goOK := goNamespacePIDs[123]
+		assert.True(t, goOK)
+	}
 
-	_, kprobeOK := pf.CurrentPIDs(PIDTypeKProbes)[33][123]
-	assert.True(t, kprobeOK)
+	kprobePIDs := pf.CurrentPIDs(PIDTypeKProbes)
+	kprobeNamespacePIDs, kprobeNamespaceOK := kprobePIDs[33]
+	if assert.True(t, kprobeNamespaceOK) {
+		_, kprobeOK := kprobeNamespacePIDs[123]
+		assert.True(t, kprobeOK)
+	}
 
 	pf.BlockPID(123, 33)
 


### PR DESCRIPTION
## Summary
This PR fixes a PID classification bug in the shared PID filter used by the eBPF tracers.

## Problem
When the same process was registered by both the Go tracer and the GPU event tracer, the later registration overwrote the earlier `PIDType` in `pkg/ebpf/common/pids.go`.

That allowed `PIDTypeKProbes` membership to replace `PIDTypeGo` for shared PIDs. As a result, enabling GPU tracing could cause Go processes to show up in the generic tracer's kprobe PID set, which risks unintended generic instrumentation, duplicate spans, and extra overhead.

## Changes
- treat `PIDType` as a bitmask instead of a single mutually exclusive value
- union PID memberships in `addPID` instead of overwriting them
- update `ValidPID` and `CurrentPIDs` to test membership with bit operations
- add a focused regression test that verifies the same PID can retain both `PIDTypeGo` and `PIDTypeKProbes`

## Testing
- `go test ./pkg/ebpf/common -run 'TestFilter_(PreservesMultiplePIDTypes|Cleanup|SameNS|DifferentNS|Block|NewNSLater)$' -count=1`
