### PR TITLE
fix(kube) kube reconnect initial interval handling

### DIFF
--- a/pkg/kube/cache_svc_client.go
+++ b/pkg/kube/cache_svc_client.go
@@ -20,6 +20,8 @@ func cslog() *slog.Logger {
 	return slog.With("component", "kube.CacheSvcClient")
 }
 
+const defaultReconnectInitialInterval = 5 * time.Second
+
 type cacheSvcClient struct {
 	meta.BaseNotifier
 	address string
@@ -52,6 +54,7 @@ func (sc *cacheSvcClient) Start(ctx context.Context) {
 	sc.waitForSubscription = make(chan struct{})
 	sc.waitForSynchronization = make(chan struct{})
 	sc.ctx = ctx
+	sc.reconnectInitialInterval = normalizeReconnectInitialInterval(sc.reconnectInitialInterval)
 
 	// subscribe itself to each message from the cache, to keep track of the
 	// message timestamps for a more efficient reconnection
@@ -81,6 +84,14 @@ func (sc *cacheSvcClient) Start(ctx context.Context) {
 			}
 		}
 	}()
+}
+
+func normalizeReconnectInitialInterval(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return defaultReconnectInitialInterval
+	}
+
+	return interval
 }
 
 func (sc *cacheSvcClient) connect(ctx context.Context) error {

--- a/pkg/kube/cache_svc_client_test.go
+++ b/pkg/kube/cache_svc_client_test.go
@@ -111,6 +111,18 @@ func TestStartNormalizesReconnectInitialInterval(t *testing.T) {
 	assert.Equal(t, defaultReconnectInitialInterval, svc.reconnectInitialInterval)
 }
 
+func TestStartPreservesPositiveReconnectInitialInterval(t *testing.T) {
+	svc := cacheSvcClient{
+		BaseNotifier:             meta.NewBaseNotifier(klog()),
+		syncTimeout:              timeout,
+		reconnectInitialInterval: 10 * time.Millisecond,
+	}
+
+	svc.Start(t.Context())
+
+	assert.Equal(t, 10*time.Millisecond, svc.reconnectInitialInterval)
+}
+
 // cacheSvcClient requires a subscriber to start processing the events, so we provide a dummy here
 type dummySubscriber struct{}
 

--- a/pkg/kube/cache_svc_client_test.go
+++ b/pkg/kube/cache_svc_client_test.go
@@ -69,6 +69,48 @@ func TestClientForwardsLastTimestamp(t *testing.T) {
 	assert.Equal(t, itemTime, secondSubscribe.FromTimestampEpoch)
 }
 
+func TestNormalizeReconnectInitialInterval(t *testing.T) {
+	testCases := []struct {
+		name     string
+		interval time.Duration
+		expected time.Duration
+	}{
+		{
+			name:     "zero falls back to default",
+			interval: 0,
+			expected: defaultReconnectInitialInterval,
+		},
+		{
+			name:     "negative falls back to default",
+			interval: -time.Second,
+			expected: defaultReconnectInitialInterval,
+		},
+		{
+			name:     "positive is preserved",
+			interval: 10 * time.Millisecond,
+			expected: 10 * time.Millisecond,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, normalizeReconnectInitialInterval(tc.interval))
+		})
+	}
+}
+
+func TestStartNormalizesReconnectInitialInterval(t *testing.T) {
+	svc := cacheSvcClient{
+		BaseNotifier:             meta.NewBaseNotifier(klog()),
+		syncTimeout:              timeout,
+		reconnectInitialInterval: 0,
+	}
+
+	svc.Start(t.Context())
+
+	assert.Equal(t, defaultReconnectInitialInterval, svc.reconnectInitialInterval)
+}
+
 // cacheSvcClient requires a subscriber to start processing the events, so we provide a dummy here
 type dummySubscriber struct{}
 

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -443,10 +444,14 @@ network:
 
 func TestConfigValidate_KubeReconnectInitialIntervalZero(t *testing.T) {
 	userConfig := bytes.NewBufferString(`
+otel_metrics_export:
+  endpoint: http://otelcol:4318
 trace_printer: text
 attributes:
   kubernetes:
     reconnect_initial_interval: 0s
+network:
+  enable: true
 `)
 
 	cfg, err := LoadConfig(userConfig)
@@ -454,7 +459,35 @@ attributes:
 
 	err = cfg.Validate()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ReconnectInitialInterval")
+
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	validationErr := validate.Struct(cfg.Attributes.Kubernetes)
+	require.Error(t, validationErr)
+
+	fieldErrs, ok := validationErr.(validator.ValidationErrors)
+	require.True(t, ok)
+	require.Len(t, fieldErrs, 1)
+	assert.Equal(t, "ReconnectInitialInterval", fieldErrs[0].Field())
+	assert.Equal(t, "gt", fieldErrs[0].Tag())
+}
+
+func TestConfigValidate_KubeReconnectInitialIntervalOmitted(t *testing.T) {
+	userConfig := bytes.NewBufferString(`
+otel_metrics_export:
+  endpoint: http://otelcol:4318
+trace_printer: text
+attributes:
+  kubernetes:
+    enable: true
+network:
+  enable: true
+`)
+
+	cfg, err := LoadConfig(userConfig)
+	require.NoError(t, err)
+
+	assert.Equal(t, 5*time.Second, cfg.Attributes.Kubernetes.ReconnectInitialInterval)
+	require.NoError(t, cfg.Validate())
 }
 
 func TestConfigValidate_TracePrinter(t *testing.T) {

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -464,8 +464,8 @@ network:
 	validationErr := validate.Struct(cfg.Attributes.Kubernetes)
 	require.Error(t, validationErr)
 
-	fieldErrs, ok := validationErr.(validator.ValidationErrors)
-	require.True(t, ok)
+	var fieldErrs validator.ValidationErrors
+	require.ErrorAs(t, validationErr, &fieldErrs)
 	require.Len(t, fieldErrs, 1)
 	assert.Equal(t, "ReconnectInitialInterval", fieldErrs[0].Field())
 	assert.Equal(t, "gt", fieldErrs[0].Tag())

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -441,6 +441,22 @@ network:
 	require.NoError(t, cfg.Validate())
 }
 
+func TestConfigValidate_KubeReconnectInitialIntervalZero(t *testing.T) {
+	userConfig := bytes.NewBufferString(`
+trace_printer: text
+attributes:
+  kubernetes:
+    reconnect_initial_interval: 0s
+`)
+
+	cfg, err := LoadConfig(userConfig)
+	require.NoError(t, err)
+
+	err = cfg.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ReconnectInitialInterval")
+}
+
 func TestConfigValidate_TracePrinter(t *testing.T) {
 	type test struct {
 		env      envMap

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -48,7 +48,7 @@ type KubernetesDecorator struct {
 	InformersSyncTimeout time.Duration `yaml:"informers_sync_timeout" env:"OTEL_EBPF_KUBE_INFORMERS_SYNC_TIMEOUT" validate:"gt=0"`
 
 	// ReconnectInitialInterval specifies the time to wait before reconnecting to the Kubernetes API after a connection loss.
-	ReconnectInitialInterval time.Duration `yaml:"reconnect_initial_interval" env:"OTEL_EBPF_KUBE_RECONNECT_INITIAL_INTERVAL" validate:"gte=0"`
+	ReconnectInitialInterval time.Duration `yaml:"reconnect_initial_interval" env:"OTEL_EBPF_KUBE_RECONNECT_INITIAL_INTERVAL" validate:"gt=0"`
 
 	// InformersResyncPeriod defaults to 30m. Higher values will reduce the load on the Kube API.
 	InformersResyncPeriod time.Duration `yaml:"informers_resync_period" env:"OTEL_EBPF_KUBE_INFORMERS_RESYNC_PERIOD" validate:"gte=0"`


### PR DESCRIPTION
## Summary
- reject `attributes.kubernetes.reconnect_initial_interval: 0s` during config validation
- normalize any non-positive runtime reconnect interval to the default `5s` before the Kubernetes cache service client starts
- add regression coverage for both config validation and reconnect interval normalization

## Why
A zero reconnect interval could cause the Kubernetes cache service client to retry immediately after connection loss instead of backing off. In practice, that turns cache service outages or invalid configuration into a hot reconnect loop with avoidable CPU usage, log noise, and reconnect traffic.

This change applies the fix in two places:
- config validation now rejects `0s` so new invalid configurations fail early
- the runtime client still normalizes any non-positive interval to the default `5s` as a defensive fallback

## Impact
This keeps reconnect behavior bounded when the cache service is unavailable and preserves the existing default behavior for valid configurations.

## Validation
- `go test ./pkg/obi -run TestConfigValidate_KubeReconnectInitialIntervalZero -count=1`
