### PR TITLE
fix(netolly): honor configured port guesser for protocol inference

### DIFF
--- a/pkg/internal/netolly/ebpf/record_getters.go
+++ b/pkg/internal/netolly/ebpf/record_getters.go
@@ -48,9 +48,10 @@ func (r recordGetters) get(name attr.Name) (attributes.Getter[*Record, attribute
 			return attribute.String(string(attr.NetworkType), transport.NetworkType(r.NetAttrs.EthProtocol).String())
 		}
 	case attr.NetworkProtocol:
+		guesser := r.cfg.serverPortGuesser()
 		getter = func(r *Record) attribute.KeyValue {
 			return attribute.String(string(attr.NetworkProtocol),
-				transport.ApplicationPortToString(serverPort(r, serverPortOrdinalGuess)))
+				transport.ApplicationPortToString(serverPort(r, guesser)))
 		}
 	case attr.SrcAddress:
 		getter = func(r *Record) attribute.KeyValue {

--- a/pkg/internal/netolly/ebpf/record_port_guess_test.go
+++ b/pkg/internal/netolly/ebpf/record_port_guess_test.go
@@ -18,7 +18,7 @@ func TestRecordGettersWithPortGuessMode_OrdinalUnknownInitiator(t *testing.T) {
 	record := &Record{
 		CommonAttrs: pipe.CommonAttrs{
 			SrcPort: 45678,
-			DstPort: 8080,
+			DstPort: 443,
 		},
 	}
 
@@ -28,16 +28,19 @@ func TestRecordGettersWithPortGuessMode_OrdinalUnknownInitiator(t *testing.T) {
 	require.True(t, ok)
 	serverGetter, ok := RecordStringGetters(cfg)(attr.ServerPort)
 	require.True(t, ok)
+	netProtocolGetter, ok := RecordStringGetters(cfg)(attr.NetworkProtocol)
+	require.True(t, ok)
 
 	assert.Equal(t, "45678", clientGetter(record))
-	assert.Equal(t, "8080", serverGetter(record))
+	assert.Equal(t, "443", serverGetter(record))
+	assert.Equal(t, "https", netProtocolGetter(record))
 }
 
 func TestRecordGettersWithPortGuessMode_DisableUnknownInitiator(t *testing.T) {
 	record := &Record{
 		CommonAttrs: pipe.CommonAttrs{
 			SrcPort: 45678,
-			DstPort: 8080,
+			DstPort: 443,
 		},
 	}
 


### PR DESCRIPTION
## Summary
- make `network.protocol` use the configured server port guesser instead of always using ordinal guessing
- add regression coverage for the disabled guess mode and the inferred protocol value

## Why
The netolly attribute getter for `network.protocol` ignored the configured port guess strategy and always used ordinal guessing to choose the server port. That made `guess_ports: false` ineffective for protocol inference even though the rest of the port-based getters respected the setting.

## Impact
This keeps protocol inference consistent with the configured port guessing behavior and avoids deriving application protocol names from a guessing mode the operator explicitly disabled.

## Validation
- `go test ./pkg/internal/netolly/ebpf`
