### PR TITLE
fix(appolly): allow cmd_args-only regex selectors

### DIFF
--- a/pkg/appolly/services/attr_regex.go
+++ b/pkg/appolly/services/attr_regex.go
@@ -29,6 +29,7 @@ func (dc RegexDefinitionCriteria) Validate() error {
 			!dc[i].PathRegexp.IsSet() &&
 			!dc[i].Languages.IsSet() &&
 			len(dc[i].PIDs) == 0 &&
+			!dc[i].CmdArgs.IsSet() &&
 			len(dc[i].Metadata) == 0 &&
 			len(dc[i].PodLabels) == 0 &&
 			len(dc[i].PodAnnotations) == 0 {

--- a/pkg/appolly/services/criteria_test.go
+++ b/pkg/appolly/services/criteria_test.go
@@ -202,6 +202,11 @@ func TestRegexDefinitionCriteria_Validate(t *testing.T) {
 		require.NoError(t, yaml.Unmarshal([]byte(`- languages: "go|java"`), &dc))
 		require.NoError(t, dc.Validate())
 	})
+	t.Run("valid with cmd_args", func(t *testing.T) {
+		dc := RegexDefinitionCriteria{}
+		require.NoError(t, yaml.Unmarshal([]byte(`- cmd_args: "--foo"`), &dc))
+		require.NoError(t, dc.Validate())
+	})
 	t.Run("valid with metadata", func(t *testing.T) {
 		dc := RegexDefinitionCriteria{}
 		require.NoError(t, yaml.Unmarshal([]byte(`- k8s_namespace: "default"`), &dc))
@@ -305,6 +310,20 @@ func TestGlobDefinitionCriteria_Validate(t *testing.T) {
 		dc := GlobDefinitionCriteria{}
 		require.NoError(t, yaml.Unmarshal([]byte("- open_ports: 80\n- languages: go\n- exe_path: \"/bin/*\""), &dc))
 		require.NoError(t, dc.Validate())
+	})
+}
+
+func TestDiscoveryConfig_Validate_CmdArgsOnlyRegexCriteria(t *testing.T) {
+	t.Run("services accepts cmd_args-only regex selector", func(t *testing.T) {
+		cfg := DiscoveryConfig{}
+		require.NoError(t, yaml.Unmarshal([]byte("services:\n  - cmd_args: \"--foo\""), &cfg))
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("exclude_services accepts cmd_args-only regex selector", func(t *testing.T) {
+		cfg := DiscoveryConfig{}
+		require.NoError(t, yaml.Unmarshal([]byte("exclude_services:\n  - cmd_args: \"--foo\""), &cfg))
+		require.NoError(t, cfg.Validate())
 	})
 }
 


### PR DESCRIPTION
## Summary
- treat `cmd_args` as a valid standalone regex selector criterion during validation (an [intended original feature](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1354#discussion_r2860479640))
- add regression coverage for cmd-args-only selectors in both direct criteria validation and discovery config validation

## Why
Regex selector validation rejected definitions that only matched on `cmd_args`, even though `cmd_args` is a supported selector field. That made valid selector configurations fail validation unless they also included an unrelated criterion.

## Impact
This makes regex selector validation consistent with the supported configuration shape and allows operators to use command-argument-only selectors in `services` and `exclude_services`.

## Validation
- `go test ./pkg/appolly/services`
