### PR TITLE
fix(appolly): preserve other selector criteria with pid matches

### DIFF
--- a/pkg/appolly/discover/matcher.go
+++ b/pkg/appolly/discover/matcher.go
@@ -221,12 +221,12 @@ func (m *Matcher) isExcluded(obj *ProcessAttrs, proc *services.ProcessInfo) bool
 
 func (m *Matcher) matchProcess(obj *ProcessAttrs, p *services.ProcessInfo, a services.Selector) bool {
 	log := m.Log.With("pid", p.Pid, "exe", p.ExePath)
-	if pids, ok := a.GetPIDs(); ok && len(pids) > 0 {
-		return pidInList(p.Pid, pids)
+	pids, hasPIDs := a.GetPIDs()
+	if hasPIDs && len(pids) > 0 && !pidInList(p.Pid, pids) {
+		return false
 	}
 
 	if !a.GetPath().IsSet() && !a.GetLanguages().IsSet() && !a.GetCmdArgs().IsSet() && a.GetOpenPorts().Len() == 0 && len(obj.metadata) == 0 {
-		pids, hasPIDs := a.GetPIDs()
 		if !hasPIDs || len(pids) == 0 {
 			log.Debug("no Kube metadata, no local selection criteria. Ignoring")
 			return false

--- a/pkg/appolly/discover/matcher_test.go
+++ b/pkg/appolly/discover/matcher_test.go
@@ -4,6 +4,7 @@
 package discover
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
@@ -661,6 +662,18 @@ func TestCriteriaMatcher_TargetPIDs(t *testing.T) {
 		}
 		assert.ElementsMatch(t, []app.PID{10, 20, 30}, pids)
 	})
+}
+
+func TestMatchProcess_TargetPIDsDoNotBypassOtherCriteria(t *testing.T) {
+	m := &Matcher{Log: slog.Default()}
+	selector := &services.GlobAttributes{
+		PIDs: []uint32{42},
+		Path: services.NewGlob("/bin/expected"),
+	}
+	obj := &ProcessAttrs{pid: 42}
+
+	assert.False(t, m.matchProcess(obj, &services.ProcessInfo{Pid: 42, ExePath: "/bin/other"}, selector))
+	assert.True(t, m.matchProcess(obj, &services.ProcessInfo{Pid: 42, ExePath: "/bin/expected"}, selector))
 }
 
 func TestCriteriaMatcher_DynamicTargetPIDs(t *testing.T) {


### PR DESCRIPTION
## Summary
- keep PID selectors as a narrowing criterion instead of letting them bypass the rest of the selector
- add regression coverage to ensure PID matches still require the other configured criteria to match

## Why
Process matching returned early when a selector included `target_pids`, which let a PID hit short-circuit the rest of the selector criteria. That made mixed selectors behave too broadly whenever a matching PID was present.

This behavior also conflicted with the documented selector semantics. The generated OBI config reference describes `target_pids` as additive: the PID must match ["in addition to any path/port criteria"](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/config/CONFIG.md#:~:text=in%20addition%20to%20any%20path/port%20criteria). The published OBI service discovery docs also state that when multiple selectors are configured in the same `instrument` entry, [the process must match all selector properties](https://opentelemetry.io/docs/zero-code/obi/configure/service-discovery/#target-pids:~:text=ignores%20this%20option.-,If%20you%20specify%20other%20selectors%20in%20the%20same%20instrument%20entry%2C%20the%20processes%20must%20match%20all%20the%20selector%20properties.,-Container%20name).

## Impact
This keeps selector evaluation consistent with the documented configuration model: a configured PID list can narrow matching, but it no longer overrides other path, language, command-argument, container, or metadata criteria.

## Validation
- `go test ./pkg/appolly/discover`
