### PR TITLE
fix(generator): reject malformed services responses

### DIFF
--- a/cmd/generate-port-lookup/main.go
+++ b/cmd/generate-port-lookup/main.go
@@ -21,7 +21,9 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -80,57 +82,96 @@ func requiresRegeneration() bool {
 	return !strings.Contains(string(content), ServicesURL)
 }
 
-func main() {
-	flag.Parse()
-	if !requiresRegeneration() {
-		slog.Info("protocol file is up to date, skipping generation")
-		return
-	}
-	resp, err := http.Get(ServicesURL)
-	if err != nil {
-		slog.Error("failed to get services file", "err", err)
-		return
-	}
-	defer resp.Body.Close()
-	slog.Info("reading services file")
-	s := bufio.NewScanner(resp.Body)
+func parseServices(r io.Reader) (map[int]string, error) {
+	s := bufio.NewScanner(r)
 	mapping := make(map[int]string)
-	for s.Scan() {
+	for lineNum := 1; s.Scan(); lineNum++ {
 		line := s.Text()
 		if strings.HasPrefix(line, "#") {
 			continue
 		}
+
 		fields := strings.Fields(line)
 		if len(fields) < 2 {
 			continue
 		}
-		portdef := strings.Split(fields[1], "/")
-		if n, err := strconv.Atoi(portdef[0]); err == nil {
-			if portdef[1] == "udp" || portdef[1] == "tcp" {
-				mapping[n] = fields[0]
-			}
+
+		port, protocol, ok := strings.Cut(fields[1], "/")
+		if !ok || port == "" || protocol == "" {
+			return nil, fmt.Errorf("malformed services entry on line %d: %q", lineNum, line)
 		}
+
+		n, err := strconv.Atoi(port)
+		if err != nil {
+			continue
+		}
+
+		if protocol == "udp" || protocol == "tcp" {
+			mapping[n] = fields[0]
+		}
+	}
+
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	if len(mapping) == 0 {
+		return nil, errors.New("services response did not contain any tcp or udp entries")
+	}
+
+	return mapping, nil
+}
+
+func fetchServices(client *http.Client, url string) (map[int]string, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected services response status: %s", resp.Status)
+	}
+
+	return parseServices(resp.Body)
+}
+
+func run(client *http.Client, servicesURL string) error {
+	flag.Parse()
+	if !requiresRegeneration() {
+		slog.Info("protocol file is up to date, skipping generation")
+		return nil
+	}
+	slog.Info("reading services file")
+	mapping, err := fetchServices(client, servicesURL)
+	if err != nil {
+		return fmt.Errorf("failed to read services file: %w", err)
 	}
 	slog.Info("finished reading service file", "detected_services", len(mapping))
 
 	tmpl, err := template.New("protocol.go").Parse(fileTemplate)
 	if err != nil {
-		slog.Error("failed to parse template", "err", err)
-		return
+		return fmt.Errorf("failed to parse template: %w", err)
 	}
 
 	f, err := os.Create(*protocolsFile)
 	if err != nil {
-		slog.Error("failed to open file for writing", "err", err)
-		return
+		return fmt.Errorf("failed to open file for writing: %w", err)
 	}
 	defer f.Close()
 	if err := tmpl.Execute(f, map[string]any{
-		"ServicesURL": ServicesURL,
+		"ServicesURL": servicesURL,
 		"Services":    mapping,
 	}); err != nil {
-		slog.Error("failed to execute template", "err", err)
-		return
+		return fmt.Errorf("failed to execute template: %w", err)
 	}
 	slog.Info("finished generating service lookup code")
+
+	return nil
+}
+
+func main() {
+	if err := run(http.DefaultClient, ServicesURL); err != nil {
+		slog.Error(err.Error())
+		os.Exit(1)
+	}
 }

--- a/cmd/generate-port-lookup/main.go
+++ b/cmd/generate-port-lookup/main.go
@@ -67,7 +67,7 @@ const ServicesURL = "https://raw.githubusercontent.com/openbsd/src/28304016fe935
 
 var protocolsFile = flag.String("dst", "protocol.go", "destination file path for generated code")
 
-func requiresRegeneration() bool {
+func requiresRegeneration(servicesURL string) bool {
 	existing, err := os.Open(*protocolsFile)
 	if err != nil {
 		slog.Warn("unable to open existing file, forcing rebuild", "err", err)
@@ -79,7 +79,7 @@ func requiresRegeneration() bool {
 		slog.Warn("unable to read contents of existing file, forcing rebuild", "err", err)
 		return true
 	}
-	return !strings.Contains(string(content), ServicesURL)
+	return !strings.Contains(string(content), servicesURL)
 }
 
 func parseServices(r io.Reader) (map[int]string, error) {
@@ -136,8 +136,7 @@ func fetchServices(client *http.Client, url string) (map[int]string, error) {
 }
 
 func run(client *http.Client, servicesURL string) error {
-	flag.Parse()
-	if !requiresRegeneration() {
+	if !requiresRegeneration(servicesURL) {
 		slog.Info("protocol file is up to date, skipping generation")
 		return nil
 	}
@@ -170,6 +169,8 @@ func run(client *http.Client, servicesURL string) error {
 }
 
 func main() {
+	flag.Parse()
+
 	if err := run(http.DefaultClient, ServicesURL); err != nil {
 		slog.Error(err.Error())
 		os.Exit(1)

--- a/cmd/generate-port-lookup/main_test.go
+++ b/cmd/generate-port-lookup/main_test.go
@@ -1,0 +1,166 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseServices(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    map[int]string
+		wantErr string
+	}{
+		{
+			name: "valid services",
+			input: strings.Join([]string{
+				"# comment",
+				"http 80/tcp www www-http # WorldWideWeb HTTP",
+				"domain 53/udp",
+				"sctp-only 5000/sctp",
+				"",
+			}, "\n"),
+			want: map[int]string{
+				53: "domain",
+				80: "http",
+			},
+		},
+		{
+			name:    "missing protocol separator",
+			input:   "foo 123\n",
+			wantErr: "malformed services entry",
+		},
+		{
+			name:    "empty protocol",
+			input:   "foo 123/\n",
+			wantErr: "malformed services entry",
+		},
+		{
+			name:    "empty response",
+			input:   "",
+			wantErr: "did not contain any tcp or udp entries",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseServices(strings.NewReader(tc.input))
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %d services, got %d", len(tc.want), len(got))
+			}
+			for port, service := range tc.want {
+				if got[port] != service {
+					t.Fatalf("expected port %d to map to %q, got %q", port, service, got[port])
+				}
+			}
+		})
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func TestFetchServicesRejectsNonOKStatus(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "502 Bad Gateway",
+				StatusCode: http.StatusBadGateway,
+				Body:       io.NopCloser(strings.NewReader("bad gateway")),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	_, err := fetchServices(client, "https://example.invalid/services")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unexpected services response status") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestFetchServicesRejectsMalformedOKBody(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("bad 123\n")),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	got, err := fetchServices(client, "https://example.invalid/services")
+	if err == nil {
+		t.Fatalf("expected error, got mapping %v", got)
+	}
+	if !strings.Contains(err.Error(), "malformed services entry") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunReturnsErrorOnFetchFailure(t *testing.T) {
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("bad 123\n")),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	oldProtocolsFile := *protocolsFile
+	*protocolsFile = filepath.Join(t.TempDir(), "protocol.go")
+	t.Cleanup(func() {
+		*protocolsFile = oldProtocolsFile
+	})
+
+	err := run(client, "https://example.invalid/services")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to read services file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(*protocolsFile); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no output file to be created, stat err = %v", statErr)
+	}
+}

--- a/cmd/generate-port-lookup/main_test.go
+++ b/cmd/generate-port-lookup/main_test.go
@@ -53,7 +53,6 @@ func TestParseServices(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -162,5 +161,28 @@ func TestRunReturnsErrorOnFetchFailure(t *testing.T) {
 	}
 	if _, statErr := os.Stat(*protocolsFile); !os.IsNotExist(statErr) {
 		t.Fatalf("expected no output file to be created, stat err = %v", statErr)
+	}
+}
+
+func TestRequiresRegenerationUsesConfiguredURL(t *testing.T) {
+	t.Parallel()
+
+	oldProtocolsFile := *protocolsFile
+	*protocolsFile = filepath.Join(t.TempDir(), "protocol.go")
+	t.Cleanup(func() {
+		*protocolsFile = oldProtocolsFile
+	})
+
+	content := strings.Replace(fileTemplate, "{{ .ServicesURL }}", "https://example.invalid/services", 1)
+	content = strings.Replace(content, "{{- range $port, $svc := .Services }}\n\t{{ $port }}: \"{{ $svc }}\",\n{{- end }}", "", 1)
+	if err := os.WriteFile(*protocolsFile, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write protocol file: %v", err)
+	}
+
+	if requiresRegeneration("https://example.invalid/services") {
+		t.Fatal("expected matching services URL to skip regeneration")
+	}
+	if !requiresRegeneration("https://example.invalid/other-services") {
+		t.Fatal("expected different services URL to require regeneration")
 	}
 }


### PR DESCRIPTION
## Summary
- split service-response parsing into explicit parsing and fetching helpers
- reject malformed service entries and non-200 HTTP responses with errors instead of panicking
- add regression coverage for malformed input, empty input, bad HTTP status, and run failure handling

## Why
The generator previously split the service definition field and indexed the protocol component without checking that the split succeeded. That allowed malformed response lines to trigger a panic during generation. The fetch path also accepted non-OK HTTP responses without validation, which made malformed upstream content more likely to reach the parser.

## Impact
This keeps the generator resilient to malformed or unexpected service responses. Invalid input now fails cleanly with an error, while valid input still generates the expected protocol lookup mapping.

## Validation
- `go test ./cmd/generate-port-lookup`
- `go run ./cmd/generate-port-lookup -dst .tmp-go-cache/out/protocol.go`
