### PR TITLE
fix(qwen):fix qwen test failed randomly

### DIFF
--- a/internal/test/integration/components/ai/qwen/mock-server/main.go
+++ b/internal/test/integration/components/ai/qwen/mock-server/main.go
@@ -88,14 +88,16 @@ func handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	const chatResponseID = "chatcmpl-a1ad370d-b4b0-90bb-9a87-a131fd0687d6"
-	setQwenHeaders(w.Header(), chatResponseID)
 	if r.URL.Query().Has("error") {
+		const errorResponseID = "chatcmpl-err-429-insufficient-quota"
+		setQwenHeaders(w.Header(), errorResponseID)
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = w.Write([]byte(errorResponseBody))
 		return
 	}
 
+	const chatResponseID = "chatcmpl-a1ad370d-b4b0-90bb-9a87-a131fd0687d6"
+	setQwenHeaders(w.Header(), chatResponseID)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte(chatResponseBody))
 }

--- a/internal/test/oats/ai/yaml/oats_qwen_test.yaml
+++ b/internal/test/oats/ai/yaml/oats_qwen_test.yaml
@@ -26,7 +26,7 @@ expected:
       gen_ai.usage.input_tokens: 12
       gen_ai.usage.output_tokens: 10
   # Error case
-  - traceql: '{ .error.type = "insufficient_quota" && .gen_ai.provider.name = "qwen" && .gen_ai.request.model = "qwen-plus"}'
+  - traceql: '{ .error.type = "insufficient_quota" && .gen_ai.provider.name = "qwen" && .gen_ai.request.model = "qwen-plus" && .gen_ai.response.id = "chatcmpl-err-429-insufficient-quota"}'
     equals: chat.completion qwen-plus
     attributes:
       gen_ai.operation.name: chat.completion


### PR DESCRIPTION
## Summary

matched **both** the success span (`output_tokens: 66`) and the error span (`output_tokens: 0`). When the error span was returned first, the attribute assertion failed.

### Fix

1. **Mock server**: Assign a distinct request ID (`chatcmpl-err-429-insufficient-quota`) to the error response, and move the error branch **before** setting the success headers.
2. **Test YAML**: Add `gen_ai.response.id` to the error case TraceQL for precise matching.

### Changed Files

- `internal/test/integration/components/ai/qwen/mock-server/main.go`
- `internal/test/oats/ai/yaml/oats_qwen_test.yaml`

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
