### PR TITLE
Avoid false-positive tcp failed connection events

### DIFF
--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -80,8 +80,10 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
         return 0;
     }
 
-    // These are normal completions, not failures
-    if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT) {
+    // {TCP_LAST_ACK|TCP_TIME_WAIT}->TCP_CLOSE are normal close transitions
+    // TCP_LISTEN->TCP_CLOSE is what happens when a listener socket is shut down
+    if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT ||
+        args->oldstate == TCP_LISTEN) {
         return 0;
     }
 
@@ -93,6 +95,9 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
     }
 
     const int err = BPF_CORE_READ(sk, sk_err);
+    if (err == 0 && args->oldstate != TCP_SYN_SENT) {
+        return 0;
+    }
     const u8 reason = sk_err_to_reason(err);
 
     bpf_d_printk("tcp failed: s_port=%d, d_port=%d, reason=%d", conn.s_port, conn.d_port, reason);

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -89,16 +89,19 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
 
     struct sock *sk = (struct sock *)args->skaddr;
 
-    connection_info_t conn;
-    if (!parse_sock_info(sk, &conn)) {
-        return 0;
-    }
-
     const int err = BPF_CORE_READ(sk, sk_err);
+    // Trust sk_err: err==0 means the kernel saw no problem (e.g. local close()
+    // with unread data sends RST without setting sk_err).
+    // Exception: aborted connect (TCP_SYN_SENT -> TCP_CLOSE) never established, still a failure.
     if (err == 0 && args->oldstate != TCP_SYN_SENT) {
         return 0;
     }
     const u8 reason = sk_err_to_reason(err);
+
+    connection_info_t conn;
+    if (!parse_sock_info(sk, &conn)) {
+        return 0;
+    }
 
     bpf_d_printk("tcp failed: s_port=%d, d_port=%d, reason=%d", conn.s_port, conn.d_port, reason);
 


### PR DESCRIPTION
## Summary

I was running some tests and found that there are some false-positives related to TCP connection failure events. This PR updates the TCP failed connections metric probe with:
- listener socket shutdowns (`TCP_LISTEN` -> `TCP_CLOSE`). Closing a listening socket is a normal lifecycle event, not a connection failure.
- non-graceful closes with `sk_err == 0`: e.g. the kernel sending RST on behalf of an app that calls close() with unread data in the receive buffer. These are local application choices, not network failures; sk_err is 0 precisely because the kernel does not consider them errors.


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
