### PR TITLE
fix(collector): avoid shutdown hang after start failure

### DIFF
--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -127,9 +127,8 @@ func (c *Controller) Start(ctx context.Context, _ component.Host) error {
 // Shutdown stops the receiver. Only the last shutdown call actually stops OBI.
 func (c *Controller) Shutdown(_ context.Context) error {
 	c.shared.mu.Lock()
-	defer c.shared.mu.Unlock()
-
 	if c.shared.refCnt == 0 {
+		c.shared.mu.Unlock()
 		c.cleanupSharedController()
 		return nil
 	}
@@ -137,27 +136,36 @@ func (c *Controller) Shutdown(_ context.Context) error {
 	c.shared.refCnt--
 
 	if c.shared.refCnt > 0 {
+		c.shared.mu.Unlock()
 		// Other receivers still using the shared controller
 		return nil
 	}
 
 	// Last receiver shutting down, stop OBI
-	if c.shared.cancel != nil {
-		c.shared.cancel()
+	cancel := c.shared.cancel
+	runDone := c.shared.runDone
+	c.shared.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
 	}
 
-	if c.shared.runDone == nil {
+	if runDone == nil {
 		c.cleanupSharedController()
 		return nil
 	}
 
 	// Wait for OBI to finish
-	<-c.shared.runDone
+	<-runDone
 
 	// Clean up the shared controller for this component ID
 	c.cleanupSharedController()
 
-	return c.shared.runErr
+	c.shared.mu.Lock()
+	runErr := c.shared.runErr
+	c.shared.mu.Unlock()
+
+	return runErr
 }
 
 func (c *Controller) cleanupSharedController() {

--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -53,8 +53,7 @@ func NewController(id component.ID, cfg *obi.Config) (*Controller, error) {
 	shared, exists := sharedControllers[id]
 	if !exists {
 		shared = &sharedController{
-			config:  cfg,
-			runDone: make(chan struct{}),
+			config: cfg,
 		}
 		sharedControllers[id] = shared
 	} else {
@@ -104,18 +103,22 @@ func (c *Controller) Start(ctx context.Context, _ component.Host) error {
 	}
 
 	// First caller - start OBI
-	ctx, c.shared.cancel = context.WithCancel(ctx)
-	ctxInfo, err := instrumenter.BuildCommonContextInfo(ctx, c.shared.config)
+	runCtx, cancel := context.WithCancel(ctx)
+	ctxInfo, err := instrumenter.BuildCommonContextInfo(runCtx, c.shared.config)
 	if err != nil {
+		cancel()
 		c.shared.refCnt-- // rollback on failure
 		slog.Error("building common context info for OBI", "error", err, "id", c.id)
 		return err
 	}
 
+	c.shared.cancel = cancel
+	c.shared.runDone = make(chan struct{})
+
 	// Run OBI in a goroutine
 	go func() {
 		defer close(c.shared.runDone)
-		c.shared.runErr = instrumenter.RunWithContextInfo(ctx, c.shared.config, ctxInfo)
+		c.shared.runErr = instrumenter.RunWithContextInfo(runCtx, c.shared.config, ctxInfo)
 	}()
 
 	return nil
@@ -125,6 +128,11 @@ func (c *Controller) Start(ctx context.Context, _ component.Host) error {
 func (c *Controller) Shutdown(_ context.Context) error {
 	c.shared.mu.Lock()
 	defer c.shared.mu.Unlock()
+
+	if c.shared.refCnt == 0 {
+		c.cleanupSharedController()
+		return nil
+	}
 
 	c.shared.refCnt--
 
@@ -138,13 +146,22 @@ func (c *Controller) Shutdown(_ context.Context) error {
 		c.shared.cancel()
 	}
 
+	if c.shared.runDone == nil {
+		c.cleanupSharedController()
+		return nil
+	}
+
 	// Wait for OBI to finish
 	<-c.shared.runDone
 
 	// Clean up the shared controller for this component ID
+	c.cleanupSharedController()
+
+	return c.shared.runErr
+}
+
+func (c *Controller) cleanupSharedController() {
 	sharedControllersMu.Lock()
 	delete(sharedControllers, c.id)
 	sharedControllersMu.Unlock()
-
-	return c.shared.runErr
 }

--- a/collector/internal/controller_test.go
+++ b/collector/internal/controller_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"go.opentelemetry.io/obi/pkg/obi"
 )
@@ -22,7 +23,7 @@ func TestShutdownAfterStartFailureCleansSharedController(t *testing.T) {
 
 	c := newTestController(t, id, cfg)
 
-	if err := c.Start(context.Background(), nil); err == nil {
+	if err := c.Start(context.Background(), componenttest.NewNopHost()); err == nil {
 		t.Fatal("expected Start to fail")
 	}
 
@@ -31,12 +32,15 @@ func TestShutdownAfterStartFailureCleansSharedController(t *testing.T) {
 		shutdownDone <- c.Shutdown(context.Background())
 	}()
 
+	timer := newShutdownTimer(t)
+	defer stopTestTimer(timer)
+
 	select {
 	case err := <-shutdownDone:
 		if err != nil {
 			t.Fatalf("expected Shutdown to return nil after failed start, got %v", err)
 		}
-	case <-time.After(time.Second):
+	case <-timer.C:
 		t.Fatal("Shutdown blocked after Start failure")
 	}
 
@@ -98,4 +102,29 @@ func newTestController(t *testing.T, id component.ID, cfg *obi.Config) *Controll
 	})
 
 	return c
+}
+
+func newShutdownTimer(t *testing.T) *time.Timer {
+	t.Helper()
+
+	timeout := 5 * time.Second
+	if deadline, ok := t.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining > time.Second && remaining-time.Second < timeout {
+			timeout = remaining - time.Second
+		}
+	}
+
+	return time.NewTimer(timeout)
+}
+
+func stopTestTimer(timer *time.Timer) {
+	if timer.Stop() {
+		return
+	}
+
+	select {
+	case <-timer.C:
+	default:
+	}
 }

--- a/collector/internal/controller_test.go
+++ b/collector/internal/controller_test.go
@@ -1,0 +1,101 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && (amd64 || arm64)
+
+package internal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+func TestShutdownAfterStartFailureCleansSharedController(t *testing.T) {
+	id := component.MustNewIDWithName("obi", "start-failure")
+	cfg := &obi.Config{}
+	cfg.Attributes.Kubernetes.ServiceNameTemplate = "{{"
+
+	c := newTestController(t, id, cfg)
+
+	if err := c.Start(context.Background(), nil); err == nil {
+		t.Fatal("expected Start to fail")
+	}
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownDone <- c.Shutdown(context.Background())
+	}()
+
+	select {
+	case err := <-shutdownDone:
+		if err != nil {
+			t.Fatalf("expected Shutdown to return nil after failed start, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown blocked after Start failure")
+	}
+
+	if err := c.Shutdown(context.Background()); err != nil {
+		t.Fatalf("second Shutdown returned error after failed start: %v", err)
+	}
+
+	retriedCfg := &obi.Config{}
+	retried := newTestController(t, id, retriedCfg)
+
+	if retried.shared == c.shared {
+		t.Fatal("expected failed-start shutdown to remove the shared controller for retries")
+	}
+	if retried.shared.config != retriedCfg {
+		t.Fatal("expected retry to use the replacement config")
+	}
+
+	if err := retried.Shutdown(context.Background()); err != nil {
+		t.Fatalf("retry Shutdown returned error without Start: %v", err)
+	}
+}
+
+func TestShutdownWithoutStartCleansSharedController(t *testing.T) {
+	id := component.MustNewIDWithName("obi", "shutdown-without-start")
+
+	c := newTestController(t, id, &obi.Config{})
+
+	if err := c.Shutdown(context.Background()); err != nil {
+		t.Fatalf("first Shutdown returned error: %v", err)
+	}
+
+	retriedCfg := &obi.Config{}
+	retried := newTestController(t, id, retriedCfg)
+
+	if retried.shared == c.shared {
+		t.Fatal("expected never-started shutdown to remove the shared controller")
+	}
+	if retried.shared.config != retriedCfg {
+		t.Fatal("expected replacement controller to use the new config")
+	}
+
+	if err := retried.Shutdown(context.Background()); err != nil {
+		t.Fatalf("second controller Shutdown returned error: %v", err)
+	}
+}
+
+func newTestController(t *testing.T, id component.ID, cfg *obi.Config) *Controller {
+	t.Helper()
+
+	c, err := NewController(id, cfg)
+	if err != nil {
+		t.Fatalf("NewController returned error: %v", err)
+	}
+
+	t.Cleanup(func() {
+		sharedControllersMu.Lock()
+		delete(sharedControllers, id)
+		sharedControllersMu.Unlock()
+	})
+
+	return c
+}

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	go.mongodb.org/mongo-driver/v2 v2.5.0
 	go.opentelemetry.io/auto/sdk v1.2.1
 	go.opentelemetry.io/collector/component v1.55.0
+	go.opentelemetry.io/collector/component/componenttest v0.149.0
 	go.opentelemetry.io/collector/config/configgrpc v0.149.0
 	go.opentelemetry.io/collector/config/confighttp v0.149.0
 	go.opentelemetry.io/collector/config/configopaque v1.55.0
@@ -214,7 +215,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/collector v0.149.0 // indirect
 	go.opentelemetry.io/collector/client v1.55.0 // indirect
-	go.opentelemetry.io/collector/component/componenttest v0.149.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v1.55.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.55.0 // indirect
 	go.opentelemetry.io/collector/config/configmiddleware v1.55.0 // indirect


### PR DESCRIPTION
## Summary
- only create run-state channels and cancellation after controller startup succeeds
- make shutdown clean up shared controller state when start never completed
- add regression coverage for shutdown after start failure and shutdown without a prior start

## Why
The shared collector controller created `runDone` before the OBI run goroutine actually started. If startup failed early, the shared controller could be left behind with a zero reference count and a `runDone` channel that no goroutine would ever close. A later `Shutdown` call could then block forever waiting on a run that never started.

## Impact
This keeps controller lifecycle state consistent across failed starts and repeated shutdowns. Receivers now clean up failed-start shared controllers promptly, avoid hanging during shutdown, and can retry with a fresh shared controller state.

## Validation
- `go test ./collector/internal`
