### PR TITLE
fix(ebpf): synchronize ring buffer flush timestamps

### DIFF
--- a/pkg/ebpf/common/ringbuf.go
+++ b/pkg/ebpf/common/ringbuf.go
@@ -68,8 +68,8 @@ type ringBufForwarder[T any] struct {
 
 	// metrics is optional (nil = no-op)
 	metrics imetrics.Reporter
-	// lastReadAt is updated by the read loop and observed by the periodic flusher.
-	lastReadAt atomic.Pointer[time.Time]
+	// lastReadAtUnixNano is updated by the read loop and observed by the periodic flusher.
+	lastReadAtUnixNano atomic.Int64
 }
 
 // AlreadyForwarded is used in the case when a second tracer tries to set up the
@@ -174,7 +174,7 @@ func (rbf *ringBufForwarder[T]) flushOnAvailableBytes(ctx context.Context, event
 		select {
 		case <-ticker.C:
 			available := eventsReader.AvailableBytes()
-			if available > 0 && rbf.timeSinceLastRead(time.Now()) > flushInterval {
+			if available > 0 && rbf.hasPendingReadIdleSince(time.Now(), flushInterval) {
 				err := eventsReader.Flush()
 				rbf.logger.Debug("flushing ringbuf", "available_bytes", available, "flush_err", err)
 			}
@@ -209,7 +209,6 @@ func (rbf *ringBufForwarder[T]) readAndForwardInner(ctx context.Context, eventsR
 	var record ringbuf.Record
 	for {
 		err := eventsReader.ReadInto(&record)
-		rbf.storeLastReadAt(time.Now())
 		if err != nil {
 			if errors.Is(err, ringbuf.ErrFlushed) {
 				rbf.logger.Debug("ring buffer already flushed")
@@ -222,23 +221,22 @@ func (rbf *ringBufForwarder[T]) readAndForwardInner(ctx context.Context, eventsR
 			rbf.logger.Error("error reading from perf reader", "error", err)
 			continue
 		}
+		rbf.storeLastReadAt(time.Now())
 		rbf.processAndForward(ctx, record, out)
 	}
 }
 
 func (rbf *ringBufForwarder[T]) storeLastReadAt(t time.Time) {
-	rbf.lastReadAt.Store(&t)
+	rbf.lastReadAtUnixNano.Store(t.UnixNano())
 }
 
-func (rbf *ringBufForwarder[T]) timeSinceLastRead(now time.Time) time.Duration {
-	lastReadAt := rbf.lastReadAt.Load()
-	if lastReadAt == nil {
-		// No successful read has happened yet, so allow the flusher to drain
-		// pending bytes.
-		return flushInterval + time.Nanosecond
+func (rbf *ringBufForwarder[T]) hasPendingReadIdleSince(now time.Time, interval time.Duration) bool {
+	lastReadAtUnixNano := rbf.lastReadAtUnixNano.Load()
+	if lastReadAtUnixNano == 0 {
+		return true
 	}
 
-	return now.Sub(*lastReadAt)
+	return now.Sub(time.Unix(0, lastReadAtUnixNano)) > interval
 }
 
 func (rbf *ringBufForwarder[T]) processAndForward(ctx context.Context, record ringbuf.Record, out *msg.Queue[[]T]) {

--- a/pkg/ebpf/common/ringbuf.go
+++ b/pkg/ebpf/common/ringbuf.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cilium/ebpf"
@@ -66,8 +67,9 @@ type ringBufForwarder[T any] struct {
 	filter BatchFilterFunc[T]
 
 	// metrics is optional (nil = no-op)
-	metrics    imetrics.Reporter
-	lastReadAt time.Time
+	metrics imetrics.Reporter
+	// lastReadAt is updated by the read loop and observed by the periodic flusher.
+	lastReadAt atomic.Pointer[time.Time]
 }
 
 // AlreadyForwarded is used in the case when a second tracer tries to set up the
@@ -172,7 +174,7 @@ func (rbf *ringBufForwarder[T]) flushOnAvailableBytes(ctx context.Context, event
 		select {
 		case <-ticker.C:
 			available := eventsReader.AvailableBytes()
-			if available > 0 && time.Since(rbf.lastReadAt) > flushInterval {
+			if available > 0 && rbf.timeSinceLastRead(time.Now()) > flushInterval {
 				err := eventsReader.Flush()
 				rbf.logger.Debug("flushing ringbuf", "available_bytes", available, "flush_err", err)
 			}
@@ -207,7 +209,7 @@ func (rbf *ringBufForwarder[T]) readAndForwardInner(ctx context.Context, eventsR
 	var record ringbuf.Record
 	for {
 		err := eventsReader.ReadInto(&record)
-		rbf.lastReadAt = time.Now()
+		rbf.storeLastReadAt(time.Now())
 		if err != nil {
 			if errors.Is(err, ringbuf.ErrFlushed) {
 				rbf.logger.Debug("ring buffer already flushed")
@@ -222,6 +224,21 @@ func (rbf *ringBufForwarder[T]) readAndForwardInner(ctx context.Context, eventsR
 		}
 		rbf.processAndForward(ctx, record, out)
 	}
+}
+
+func (rbf *ringBufForwarder[T]) storeLastReadAt(t time.Time) {
+	rbf.lastReadAt.Store(&t)
+}
+
+func (rbf *ringBufForwarder[T]) timeSinceLastRead(now time.Time) time.Duration {
+	lastReadAt := rbf.lastReadAt.Load()
+	if lastReadAt == nil {
+		// No successful read has happened yet, so allow the flusher to drain
+		// pending bytes.
+		return flushInterval + time.Nanosecond
+	}
+
+	return now.Sub(*lastReadAt)
 }
 
 func (rbf *ringBufForwarder[T]) processAndForward(ctx context.Context, record ringbuf.Record, out *msg.Queue[[]T]) {

--- a/pkg/ebpf/common/ringbuf_test.go
+++ b/pkg/ebpf/common/ringbuf_test.go
@@ -5,7 +5,9 @@ package ebpfcommon
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
+	"io"
 	"log/slog"
 	"sync/atomic"
 	"testing"
@@ -176,6 +178,42 @@ func TestForwardRingbuf_Close(t *testing.T) {
 	assert.Equal(t, 0, metrics.flushedLen)
 }
 
+func TestRingbufLastReadAtRace(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	rbf := &ringBufForwarder[HTTPRequestTrace]{
+		cfg:    &config.EBPFTracer{BatchLength: 1},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		parse: func(*ringbuf.Record) (HTTPRequestTrace, bool, error) {
+			return HTTPRequestTrace{}, true, nil
+		},
+	}
+
+	eventsReader := newFlushTrackingReader()
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		rbf.readAndForwardInner(ctx, eventsReader, msg.NewQueue[[]HTTPRequestTrace](msg.ChannelBufferLen(1)))
+	}()
+
+	deadline := time.Now().Add(flushInterval + 500*time.Millisecond)
+	for time.Now().Before(deadline) {
+		eventsReader.AllowRead()
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	assert.Zero(t, eventsReader.FlushCount())
+
+	require.Eventually(t, func() bool {
+		return eventsReader.FlushCount() > 0
+	}, 2*flushInterval+time.Second, 100*time.Millisecond)
+
+	cancel()
+	eventsReader.Close()
+	<-readDone
+}
+
 // replaces the original ring buffer factory by a fake ring buffer creator and returns it
 func replaceTestRingBuf() *fakeRingBufReader {
 	rb := fakeRingBufReader{events: make(chan HTTPRequestTrace, 100), closeCh: make(chan struct{})}
@@ -223,6 +261,62 @@ func (f *fakeRingBufReader) ReadInto(record *ringbuf.Record) error {
 func (f *fakeRingBufReader) AvailableBytes() int { return 0 }
 
 func (f *fakeRingBufReader) Flush() error { return nil }
+
+type flushTrackingReader struct {
+	readTokens chan struct{}
+	closed     chan struct{}
+	// flushCount lets the test observe when the background flusher decides
+	// reads went idle.
+	flushCount atomic.Int32
+}
+
+func newFlushTrackingReader() *flushTrackingReader {
+	return &flushTrackingReader{
+		readTokens: make(chan struct{}, 1),
+		closed:     make(chan struct{}),
+	}
+}
+
+func (f *flushTrackingReader) AllowRead() {
+	select {
+	case f.readTokens <- struct{}{}:
+	default:
+	}
+}
+
+func (f *flushTrackingReader) FlushCount() int {
+	return int(f.flushCount.Load())
+}
+
+func (f *flushTrackingReader) Close() error {
+	select {
+	case <-f.closed:
+	default:
+		close(f.closed)
+	}
+	return nil
+}
+
+func (f *flushTrackingReader) Read() (ringbuf.Record, error) { return ringbuf.Record{}, nil }
+
+func (f *flushTrackingReader) ReadInto(record *ringbuf.Record) error {
+	select {
+	case <-f.readTokens:
+		// Returning an empty sample is enough to exercise the read path and
+		// update lastReadAt.
+		record.RawSample = nil
+		return nil
+	case <-f.closed:
+		return ringbuf.ErrClosed
+	}
+}
+
+func (f *flushTrackingReader) AvailableBytes() int { return 1 }
+
+func (f *flushTrackingReader) Flush() error {
+	f.flushCount.Add(1)
+	return nil
+}
 
 type closableObject struct {
 	closed atomic.Bool

--- a/pkg/ebpf/common/ringbuf_test.go
+++ b/pkg/ebpf/common/ringbuf_test.go
@@ -199,11 +199,13 @@ func TestRingbufLastReadAtRace(t *testing.T) {
 
 	deadline := time.Now().Add(flushInterval + 500*time.Millisecond)
 	for time.Now().Before(deadline) {
+		readCount := eventsReader.ReadCount()
 		eventsReader.AllowRead()
-		time.Sleep(100 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			return eventsReader.ReadCount() > readCount
+		}, time.Second, 10*time.Millisecond)
+		assert.Zero(t, eventsReader.FlushCount())
 	}
-
-	assert.Zero(t, eventsReader.FlushCount())
 
 	require.Eventually(t, func() bool {
 		return eventsReader.FlushCount() > 0
@@ -265,6 +267,7 @@ func (f *fakeRingBufReader) Flush() error { return nil }
 type flushTrackingReader struct {
 	readTokens chan struct{}
 	closed     chan struct{}
+	readCount  atomic.Int32
 	// flushCount lets the test observe when the background flusher decides
 	// reads went idle.
 	flushCount atomic.Int32
@@ -288,6 +291,10 @@ func (f *flushTrackingReader) FlushCount() int {
 	return int(f.flushCount.Load())
 }
 
+func (f *flushTrackingReader) ReadCount() int {
+	return int(f.readCount.Load())
+}
+
 func (f *flushTrackingReader) Close() error {
 	select {
 	case <-f.closed:
@@ -297,7 +304,13 @@ func (f *flushTrackingReader) Close() error {
 	return nil
 }
 
-func (f *flushTrackingReader) Read() (ringbuf.Record, error) { return ringbuf.Record{}, nil }
+func (f *flushTrackingReader) Read() (ringbuf.Record, error) {
+	record := ringbuf.Record{}
+
+	err := f.ReadInto(&record)
+
+	return record, err
+}
 
 func (f *flushTrackingReader) ReadInto(record *ringbuf.Record) error {
 	select {
@@ -305,6 +318,7 @@ func (f *flushTrackingReader) ReadInto(record *ringbuf.Record) error {
 		// Returning an empty sample is enough to exercise the read path and
 		// update lastReadAt.
 		record.RawSample = nil
+		f.readCount.Add(1)
 		return nil
 	case <-f.closed:
 		return ringbuf.ErrClosed


### PR DESCRIPTION
## Summary
- replace the unsynchronized `lastReadAt` timestamp with an atomic pointer-backed value
- make the flush loop compute idle time through helper methods that handle the no-read-yet case safely
- add regression coverage for the interaction between the read loop and the periodic flusher

## Why
The ring buffer forwarder updated `lastReadAt` in the read loop while the periodic flusher read it concurrently without synchronization. That created a data race in the flush-idle timestamp tracking path.

## Impact
This makes the flush timing state safe to read and update concurrently without changing the intended behavior. The flusher still drains pending bytes after reads go idle, including before the first successful read.

## Validation
- `go test ./pkg/ebpf/common`
