### PR TITLE
fix(otel): apply extra labels to span metrics

### DIFF
--- a/internal/test/collector/collector.go
+++ b/internal/test/collector/collector.go
@@ -170,12 +170,21 @@ func (tc *TestCollector) metricEvent(writer http.ResponseWriter, body []byte) {
 	json, _ := req.MarshalJSON()
 	log.Debug("received metric", "json", string(json))
 
-	for _, rm := range req.Metrics().ResourceMetrics().All() {
+	VisitMetricRecords(req.Metrics(), func(mr MetricRecord) {
+		tc.Records() <- mr
+	})
+}
+
+// VisitMetricRecords iterates over OTLP metric payloads and emits the flattened
+// MetricRecord values used by tests.
+func VisitMetricRecords(metrics pmetric.Metrics, visit func(MetricRecord)) {
+	for _, rm := range metrics.ResourceMetrics().All() {
 		resourceAttrs := map[string]string{}
 		rm.Resource().Attributes().Range(func(k string, v pcommon.Value) bool {
 			resourceAttrs[k] = v.AsString()
 			return true
 		})
+
 		for _, sm := range rm.ScopeMetrics().All() {
 			for _, m := range sm.Metrics().All() {
 				switch m.Type() {
@@ -194,14 +203,15 @@ func (tc *TestCollector) metricEvent(writer http.ResponseWriter, body []byte) {
 							mr.Attributes[k] = v.AsString()
 							return true
 						})
-						tc.Records() <- mr
+						visit(mr)
 					}
 				case pmetric.MetricTypeHistogram:
 					for _, hdp := range m.Histogram().DataPoints().All() {
-						// for simplicity, reporting only sum histogram data
+						// For simplicity, report only histogram points with a computed sum.
 						if !hdp.HasSum() {
-							return
+							continue
 						}
+
 						mr := MetricRecord{
 							Name:               m.Name(),
 							Unit:               m.Unit(),
@@ -215,7 +225,7 @@ func (tc *TestCollector) metricEvent(writer http.ResponseWriter, body []byte) {
 							mr.Attributes[k] = v.AsString()
 							return true
 						})
-						tc.Records() <- mr
+						visit(mr)
 					}
 				case pmetric.MetricTypeGauge:
 					for _, ndp := range m.Gauge().DataPoints().All() {
@@ -232,7 +242,7 @@ func (tc *TestCollector) metricEvent(writer http.ResponseWriter, body []byte) {
 							mr.Attributes[k] = v.AsString()
 							return true
 						})
-						tc.Records() <- mr
+						visit(mr)
 					}
 				default:
 					log.Warn("unsupported metric type", "type", m.Type().String())

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -1012,18 +1012,18 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 		}
 
 		if span.Service.Features.SpanMetrics() {
-			sml, attrs := r.spanMetricsLatency.ForRecord(span)
+			sml, attrs := r.spanMetricsLatency.ForRecord(span, extraAttrs...)
 			sml.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 
-			smct, attrs := r.spanMetricsCallsTotal.ForRecord(span)
+			smct, attrs := r.spanMetricsCallsTotal.ForRecord(span, extraAttrs...)
 			smct.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 		}
 
 		if span.Service.Features.SpanSizes() {
-			smst, attrs := r.spanMetricsRequestSizeTotal.ForRecord(span)
+			smst, attrs := r.spanMetricsRequestSizeTotal.ForRecord(span, extraAttrs...)
 			smst.Add(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
 
-			smst, attr := r.spanMetricsResponseSizeTotal.ForRecord(span)
+			smst, attr := r.spanMetricsResponseSizeTotal.ForRecord(span, extraAttrs...)
 			smst.Add(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attr))
 		}
 	}

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/attribute"
 
 	"go.opentelemetry.io/obi/internal/test/collector"
@@ -359,6 +362,149 @@ func TestAppMetrics_ResourceAttributes(t *testing.T) {
 	assert.Equal(t, "upstream.obi", attributes["source"])
 }
 
+func TestSpanMetrics_ExtraResourceAttributes(t *testing.T) {
+	defer otelcfg.RestoreEnvAfterExecution()()
+
+	ctx := t.Context()
+	metricRecords := make(chan collector.MetricRecord, 100)
+
+	now := syncedClock{now: time.Now()}
+	timeNow = now.Now
+
+	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	mcfg := &otelcfg.MetricsConfig{
+		Interval:                50 * time.Millisecond,
+		MetricsProtocol:         otelcfg.ProtocolHTTPProtobuf,
+		TTL:                     30 * time.Minute,
+		ReportersCacheLen:       100,
+		Instrumentations:        []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+		ExtraSpanResourceLabels: []string{"deployment.environment"},
+		MetricsConsumer:         testMetricsConsumer(metricRecords),
+	}
+
+	reporter, err := newMetricsReporter(
+		ctx,
+		&global.ContextInfo{OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg}},
+		mcfg,
+		&perapp.MetricsConfig{Features: export.FeatureSpanOTel},
+		&attributes.SelectorConfig{},
+		request.UnresolvedNames{},
+		metrics,
+		processEvents,
+	)
+	require.NoError(t, err)
+
+	go reporter.reportMetrics(ctx)
+
+	span := request.Span{
+		Service: svc.Attrs{
+			Features: export.FeatureSpanOTel,
+			UID:      svc.UID{Instance: "foo"},
+			Metadata: map[attr.Name]string{
+				attr.Name("deployment.environment"): "production",
+			},
+		},
+		Type:         request.EventTypeHTTPClient,
+		Method:       "GET",
+		Route:        "/v1/traces",
+		RequestStart: 100,
+		End:          200,
+	}
+
+	metrics.Send([]request.Span{span})
+
+	res := readNChan(t, metricRecords, 2, timeout)
+	assert.Len(t, res, 2)
+
+	expected := map[string]struct{}{
+		reporter.spanMetricsLatencyName(): {},
+		reporter.spanMetricsCallsName():   {},
+	}
+
+	for _, record := range res {
+		_, ok := expected[record.Name]
+		require.Truef(t, ok, "unexpected metric %q", record.Name)
+		assert.Equal(t, "production", record.Attributes["deployment.environment"])
+		delete(expected, record.Name)
+	}
+
+	assert.Empty(t, expected)
+}
+
+func TestSpanSizeMetrics_ExtraResourceAttributes(t *testing.T) {
+	defer otelcfg.RestoreEnvAfterExecution()()
+
+	ctx := t.Context()
+	metricRecords := make(chan collector.MetricRecord, 100)
+
+	now := syncedClock{now: time.Now()}
+	timeNow = now.Now
+
+	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	mcfg := &otelcfg.MetricsConfig{
+		Interval:                50 * time.Millisecond,
+		MetricsProtocol:         otelcfg.ProtocolHTTPProtobuf,
+		TTL:                     30 * time.Minute,
+		ReportersCacheLen:       100,
+		Instrumentations:        []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+		ExtraSpanResourceLabels: []string{"deployment.environment"},
+		MetricsConsumer:         testMetricsConsumer(metricRecords),
+	}
+
+	reporter, err := newMetricsReporter(
+		ctx,
+		&global.ContextInfo{OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg}},
+		mcfg,
+		&perapp.MetricsConfig{Features: export.FeatureSpanSizes},
+		&attributes.SelectorConfig{},
+		request.UnresolvedNames{},
+		metrics,
+		processEvents,
+	)
+	require.NoError(t, err)
+
+	go reporter.reportMetrics(ctx)
+
+	span := request.Span{
+		Service: svc.Attrs{
+			Features: export.FeatureSpanSizes,
+			UID:      svc.UID{Instance: "foo"},
+			Metadata: map[attr.Name]string{
+				attr.Name("deployment.environment"): "production",
+			},
+		},
+		Type:           request.EventTypeHTTPClient,
+		Method:         "GET",
+		Route:          "/v1/traces",
+		RequestStart:   100,
+		End:            200,
+		ContentLength:  123,
+		ResponseLength: 456,
+		Status:         200,
+	}
+
+	metrics.Send([]request.Span{span})
+
+	res := readNChan(t, metricRecords, 2, timeout)
+	assert.Len(t, res, 2)
+
+	expected := map[string]struct{}{
+		SpanMetricsRequestSizes:  {},
+		SpanMetricsResponseSizes: {},
+	}
+
+	for _, record := range res {
+		_, ok := expected[record.Name]
+		require.Truef(t, ok, "unexpected metric %q", record.Name)
+		assert.Equal(t, "production", record.Attributes["deployment.environment"])
+		delete(expected, record.Name)
+	}
+
+	assert.Empty(t, expected)
+}
+
 func TestMetricsDiscarded(t *testing.T) {
 	svcNoExport := svc.Attrs{Features: export.FeatureAll}
 
@@ -552,6 +698,87 @@ func readNChan(t require.TestingT, inCh <-chan collector.MetricRecord, numRecord
 		}
 	}
 	return records
+}
+
+func testMetricsConsumer(out chan<- collector.MetricRecord) consumer.Metrics {
+	c, err := consumer.NewMetrics(func(_ context.Context, md pmetric.Metrics) error {
+		for _, rm := range md.ResourceMetrics().All() {
+			resourceAttrs := map[string]string{}
+			rm.Resource().Attributes().Range(func(k string, v pcommon.Value) bool {
+				resourceAttrs[k] = v.AsString()
+				return true
+			})
+
+			for _, sm := range rm.ScopeMetrics().All() {
+				for _, m := range sm.Metrics().All() {
+					switch m.Type() {
+					case pmetric.MetricTypeSum:
+						for _, ndp := range m.Sum().DataPoints().All() {
+							record := collector.MetricRecord{
+								Name:               m.Name(),
+								Unit:               m.Unit(),
+								Type:               m.Type(),
+								FloatVal:           ndp.DoubleValue(),
+								IntVal:             ndp.IntValue(),
+								Attributes:         map[string]string{},
+								ResourceAttributes: resourceAttrs,
+							}
+							ndp.Attributes().Range(func(k string, v pcommon.Value) bool {
+								record.Attributes[k] = v.AsString()
+								return true
+							})
+							out <- record
+						}
+					case pmetric.MetricTypeHistogram:
+						for _, hdp := range m.Histogram().DataPoints().All() {
+							if !hdp.HasSum() {
+								continue
+							}
+
+							record := collector.MetricRecord{
+								Name:               m.Name(),
+								Unit:               m.Unit(),
+								Type:               m.Type(),
+								FloatVal:           hdp.Sum(),
+								Count:              int(hdp.Count()),
+								Attributes:         map[string]string{},
+								ResourceAttributes: resourceAttrs,
+							}
+							hdp.Attributes().Range(func(k string, v pcommon.Value) bool {
+								record.Attributes[k] = v.AsString()
+								return true
+							})
+							out <- record
+						}
+					case pmetric.MetricTypeGauge:
+						for _, gdp := range m.Gauge().DataPoints().All() {
+							record := collector.MetricRecord{
+								Name:               m.Name(),
+								Unit:               m.Unit(),
+								Type:               m.Type(),
+								FloatVal:           gdp.DoubleValue(),
+								IntVal:             gdp.IntValue(),
+								Attributes:         map[string]string{},
+								ResourceAttributes: resourceAttrs,
+							}
+							gdp.Attributes().Range(func(k string, v pcommon.Value) bool {
+								record.Attributes[k] = v.AsString()
+								return true
+							})
+							out <- record
+						}
+					}
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	return c
 }
 
 func makeMetricsReporter(

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -414,7 +413,10 @@ func TestSpanMetrics_ExtraResourceAttributes(t *testing.T) {
 
 	metrics.Send([]request.Span{span})
 
-	res := readNChan(t, metricRecords, 2, timeout)
+	res := readMetricsByName(t, metricRecords, timeout,
+		reporter.spanMetricsLatencyName(),
+		reporter.spanMetricsCallsName(),
+	)
 	assert.Len(t, res, 2)
 
 	expected := map[string]struct{}{
@@ -487,7 +489,10 @@ func TestSpanSizeMetrics_ExtraResourceAttributes(t *testing.T) {
 
 	metrics.Send([]request.Span{span})
 
-	res := readNChan(t, metricRecords, 2, timeout)
+	res := readMetricsByName(t, metricRecords, timeout,
+		SpanMetricsRequestSizes,
+		SpanMetricsResponseSizes,
+	)
 	assert.Len(t, res, 2)
 
 	expected := map[string]struct{}{
@@ -702,76 +707,9 @@ func readNChan(t require.TestingT, inCh <-chan collector.MetricRecord, numRecord
 
 func testMetricsConsumer(out chan<- collector.MetricRecord) consumer.Metrics {
 	c, err := consumer.NewMetrics(func(_ context.Context, md pmetric.Metrics) error {
-		for _, rm := range md.ResourceMetrics().All() {
-			resourceAttrs := map[string]string{}
-			rm.Resource().Attributes().Range(func(k string, v pcommon.Value) bool {
-				resourceAttrs[k] = v.AsString()
-				return true
-			})
-
-			for _, sm := range rm.ScopeMetrics().All() {
-				for _, m := range sm.Metrics().All() {
-					switch m.Type() {
-					case pmetric.MetricTypeSum:
-						for _, ndp := range m.Sum().DataPoints().All() {
-							record := collector.MetricRecord{
-								Name:               m.Name(),
-								Unit:               m.Unit(),
-								Type:               m.Type(),
-								FloatVal:           ndp.DoubleValue(),
-								IntVal:             ndp.IntValue(),
-								Attributes:         map[string]string{},
-								ResourceAttributes: resourceAttrs,
-							}
-							ndp.Attributes().Range(func(k string, v pcommon.Value) bool {
-								record.Attributes[k] = v.AsString()
-								return true
-							})
-							out <- record
-						}
-					case pmetric.MetricTypeHistogram:
-						for _, hdp := range m.Histogram().DataPoints().All() {
-							if !hdp.HasSum() {
-								continue
-							}
-
-							record := collector.MetricRecord{
-								Name:               m.Name(),
-								Unit:               m.Unit(),
-								Type:               m.Type(),
-								FloatVal:           hdp.Sum(),
-								Count:              int(hdp.Count()),
-								Attributes:         map[string]string{},
-								ResourceAttributes: resourceAttrs,
-							}
-							hdp.Attributes().Range(func(k string, v pcommon.Value) bool {
-								record.Attributes[k] = v.AsString()
-								return true
-							})
-							out <- record
-						}
-					case pmetric.MetricTypeGauge:
-						for _, gdp := range m.Gauge().DataPoints().All() {
-							record := collector.MetricRecord{
-								Name:               m.Name(),
-								Unit:               m.Unit(),
-								Type:               m.Type(),
-								FloatVal:           gdp.DoubleValue(),
-								IntVal:             gdp.IntValue(),
-								Attributes:         map[string]string{},
-								ResourceAttributes: resourceAttrs,
-							}
-							gdp.Attributes().Range(func(k string, v pcommon.Value) bool {
-								record.Attributes[k] = v.AsString()
-								return true
-							})
-							out <- record
-						}
-					}
-				}
-			}
-		}
-
+		collector.VisitMetricRecords(md, func(record collector.MetricRecord) {
+			out <- record
+		})
 		return nil
 	})
 	if err != nil {
@@ -779,6 +717,33 @@ func testMetricsConsumer(out chan<- collector.MetricRecord) consumer.Metrics {
 	}
 
 	return c
+}
+
+func readMetricsByName(t require.TestingT, inCh <-chan collector.MetricRecord, timeout time.Duration, names ...string) []collector.MetricRecord {
+	expected := map[string]struct{}{}
+	for _, name := range names {
+		expected[name] = struct{}{}
+	}
+
+	records := make([]collector.MetricRecord, 0, len(expected))
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	for len(expected) > 0 {
+		select {
+		case item := <-inCh:
+			if _, ok := expected[item.Name]; !ok {
+				continue
+			}
+			records = append(records, item)
+			delete(expected, item.Name)
+		case <-deadline.C:
+			require.Failf(t, "timeout while waiting for metric records", "missing metrics: %v", names)
+			return records
+		}
+	}
+
+	return records
 }
 
 func makeMetricsReporter(


### PR DESCRIPTION
## Summary
- pass configured extra span resource labels through the span metrics and span size metrics recorders
- add regression coverage that verifies extra resource attributes are exported on span metric series

## Why
The OTEL metrics exporter parsed `extra_span_resource_attributes`, but the span metrics paths did not pass those extra attributes into the metric recorders. As a result, the configured labels were silently ignored for span latency, call count, request size, and response size metrics.

## Impact
Configured extra span resource attributes now appear on the exported span metric series as intended, keeping the span metrics behavior consistent with the configuration.

## Validation
- `go test ./pkg/export/otel`
