### PR TITLE
fix: run go-notices-update for both amd64 and arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -713,6 +713,7 @@ java-notices-update:
 .PHONY: go-notices-update
 go-notices-update:
 	@GOOS=$(GOOS) GOARCH=amd64 go tool $(TOOLS_MODFILE) go-licenses save ./... --save_path=$(NOTICES_DIR) --force
+	@GOOS=$(GOOS) GOARCH=arm64 go tool $(TOOLS_MODFILE) go-licenses save ./... --save_path=$(NOTICES_DIR) --force
 
 PYTHON_REQUIREMENTS_INS ?= $(shell find ./internal/test/integration/components -type f -name 'requirements.in' | sort)
 PYTHON_REQUIREMENTS_DIRS := $(sort $(dir $(PYTHON_REQUIREMENTS_INS)))


### PR DESCRIPTION
## Summary

`go-notices-update` only ran `go-licenses` for amd64. This meant arm64-specific dependency notices were missing, and running the target on an arm64 machine produced diffs against CI.

Added a second `go-licenses save` invocation with `GOARCH=arm64` so both architectures contribute their notices to the same output directory.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

Fixes #1224