### PR TITLE
fix(services): remove duplicate colon in ExportModes error message

### DIFF
--- a/pkg/appolly/services/export.go
+++ b/pkg/appolly/services/export.go
@@ -119,7 +119,7 @@ func (modes *ExportModes) UnmarshalYAML(value *yaml.Node) error {
 	}
 	for i, inner := range value.Content {
 		if inner.Kind != yaml.ScalarNode {
-			return fmt.Errorf("ExportModes[%d]: : unexpected YAML node kind %d", i, inner.Kind)
+			return fmt.Errorf("ExportModes[%d]: unexpected YAML node kind %d", i, inner.Kind)
 		}
 		if mode, ok := modeForText[inner.Value]; !ok {
 			return fmt.Errorf("ExportModes[%d]: unknown export mode %q", i, inner.Value)


### PR DESCRIPTION
## Summary

Removes a stray extra colon in the error returned when a YAML entry inside `ExportModes` is not a scalar node. The message previously read `ExportModes[%d]: : unexpected YAML node kind %d`; now it matches the format of the sibling error two lines below (`ExportModes[%d]: unknown export mode %q`).

Pure typo fix — no behavior change.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] N/A — typo in an error message, not a core feature change.