### PR TITLE
bpf: set shared context for async python

### DIFF
--- a/bpf/common/python_task.h
+++ b/bpf/common/python_task.h
@@ -5,8 +5,11 @@
 
 #include <bpfcore/vmlinux.h>
 
+#include <common/tp_info.h>
+
 #include <maps/python_context_task.h>
 #include <maps/python_task_state.h>
+#include <maps/server_traces.h>
 
 static __always_inline u64 resolve_python_context_task(const python_context_task_t *context_task) {
     if (!context_task || !context_task->task) {
@@ -24,4 +27,28 @@ static __always_inline u64 resolve_python_context_task(const python_context_task
     }
 
     return context_task->task;
+}
+
+// Walks the python_task_state parent chain looking for the server trace that
+// owns task_id. Returns the raw server_traces_aux entry (caller filters on valid)
+static __always_inline tp_info_pid_t *find_python_owning_server_trace(u64 task_id) {
+    enum { k_max_depth = 4 };
+    for (u8 i = 0; i < k_max_depth; ++i) {
+        const python_task_state_t *task_state =
+            (const python_task_state_t *)bpf_map_lookup_elem(&python_task_state, &task_id);
+        if (!task_state) {
+            return NULL;
+        }
+        if (task_state->conn.port) {
+            tp_info_pid_t *tp = bpf_map_lookup_elem(&server_traces_aux, &task_state->conn);
+            if (tp) {
+                return tp;
+            }
+        }
+        if (!task_state->parent) {
+            return NULL;
+        }
+        task_id = task_state->parent;
+    }
+    return NULL;
 }

--- a/bpf/common/trace_parent.h
+++ b/bpf/common/trace_parent.h
@@ -175,10 +175,7 @@ static __always_inline u64 resolve_python_current_task(const trace_key_t *t_key,
 
 static __always_inline tp_info_pid_t *find_python_parent_trace(const trace_key_t *t_key,
                                                                u64 pid_tgid) {
-    enum { k_max_depth = 4 };
-
-    u64 task_id = resolve_python_current_task(t_key, pid_tgid);
-
+    const u64 task_id = resolve_python_current_task(t_key, pid_tgid);
     if (!task_id) {
         bpf_dbg_printk("find_python_parent_trace: no current task pid=%d tid=%d",
                        t_key->p_key.pid,
@@ -186,38 +183,16 @@ static __always_inline tp_info_pid_t *find_python_parent_trace(const trace_key_t
         return NULL;
     }
 
-    for (u8 i = 0; i < k_max_depth; ++i) {
-        const python_task_state_t *task_state =
-            (const python_task_state_t *)bpf_map_lookup_elem(&python_task_state, &task_id);
-        if (!task_state) {
-            bpf_dbg_printk("find_python_parent_trace: no task state for tid=%d task=%llx",
-                           t_key->p_key.tid,
-                           task_id);
-            break;
-        }
-
-        if (task_state->conn.port) {
-            tp_info_pid_t *server_tp = bpf_map_lookup_elem(&server_traces_aux, &task_state->conn);
-            if (server_tp) {
-                bpf_dbg_printk("find_python_parent_trace: FOUND tid=%d task=%llx port=%d",
-                               t_key->p_key.tid,
-                               task_id,
-                               task_state->conn.port);
-                return server_tp;
-            }
-        }
-
-        if (!task_state->parent) {
-            bpf_dbg_printk("find_python_parent_trace: no parent for tid=%d task=%llx",
-                           t_key->p_key.tid,
-                           task_id);
-            break;
-        }
-
-        task_id = task_state->parent;
+    tp_info_pid_t *server_tp = find_python_owning_server_trace(task_id);
+    if (server_tp) {
+        bpf_dbg_printk(
+            "find_python_parent_trace: FOUND tid=%d task=%llx", t_key->p_key.tid, task_id);
+    } else {
+        bpf_dbg_printk("find_python_parent_trace: no owning trace for tid=%d task=%llx",
+                       t_key->p_key.tid,
+                       task_id);
     }
-
-    return NULL;
+    return server_tp;
 }
 
 static __always_inline tp_info_pid_t *find_parent_java_trace(trace_key_t *t_key) {

--- a/bpf/generictracer/python.c
+++ b/bpf/generictracer/python.c
@@ -155,6 +155,41 @@ int obi_uprobe_context_run(struct pt_regs *ctx) {
     const u64 task_id = resolve_python_context_task(context_task);
     if (task_id) {
         refresh_obi_ctx_for_task(id, task_id);
+    } else if (thread_state->current_task == k_python_state_none) {
+        // Worker thread (no current_task) reusing entry from a previous job:
+        // drop stale obi_ctx so profiler samples taken before refresh are not
+        // attributed to the previous job's trace
+        obi_ctx__del(id);
+    }
+
+    return 0;
+}
+
+SEC("uretprobe/libpython3.:context_run")
+int obi_uretprobe_context_run(struct pt_regs *ctx) {
+    (void)ctx;
+    const u64 id = bpf_get_current_pid_tgid();
+    if (!valid_pid(id)) {
+        return 0;
+    }
+
+    python_thread_state_t *thread_state =
+        (python_thread_state_t *)bpf_map_lookup_elem(&python_thread_state, &id);
+    if (!thread_state) {
+        return 0;
+    }
+
+    thread_state->current_context = k_python_state_none;
+    // Only worker threads have no current_task here; on the event-loop thread
+    // task_step_ret owns obi_ctx cleanup so we leave it alone
+    if (thread_state->current_task == k_python_state_none) {
+        obi_ctx__del(id);
+    }
+
+    if (thread_state->current_context == k_python_state_none &&
+        thread_state->current_task == k_python_state_none &&
+        thread_state->inflight_task == k_python_state_none) {
+        bpf_map_delete_elem(&python_thread_state, &id);
     }
 
     return 0;

--- a/bpf/generictracer/python.c
+++ b/bpf/generictracer/python.c
@@ -12,15 +12,47 @@
 #include <maps/python_context_task.h>
 #include <maps/python_task_state.h>
 #include <maps/python_thread_state.h>
+#include <maps/server_traces.h>
 
 #include <common/connection_info.h>
+#include <common/python_task.h>
 
 #include <generictracer/maps/pid_tid_to_conn.h>
 
 #include <pid/pid.h>
 
+#include <shared/obi_ctx.h>
+
 // Python task/context pointers use 0 to mean "no active state" in thread-local tracking.
 enum { k_python_state_none = 0 };
+
+// Walks parent chain to find owning server trace; mirrors find_python_parent_trace
+static __always_inline void refresh_obi_ctx_for_task(u64 pid_tgid, u64 task_id) {
+    if (!task_id) {
+        obi_ctx__del(pid_tgid);
+        return;
+    }
+    enum { k_max_depth = 4 };
+    for (u8 i = 0; i < k_max_depth; ++i) {
+        const python_task_state_t *task_state =
+            (const python_task_state_t *)bpf_map_lookup_elem(&python_task_state, &task_id);
+        if (!task_state) {
+            break;
+        }
+        if (task_state->conn.port) {
+            tp_info_pid_t *tp = bpf_map_lookup_elem(&server_traces_aux, &task_state->conn);
+            if (tp && tp->valid) {
+                obi_ctx__set(pid_tgid, &tp->tp);
+                return;
+            }
+        }
+        if (!task_state->parent) {
+            break;
+        }
+        task_id = task_state->parent;
+    }
+    obi_ctx__del(pid_tgid);
+}
 
 static __always_inline void map_context_to_task(u64 context, u64 task) {
     python_context_task_t mapping = {
@@ -60,6 +92,7 @@ static __always_inline int update_current_task(u64 id, u64 task) {
     }
 
     thread_state->current_task = task;
+    refresh_obi_ctx_for_task(id, task);
     return 0;
 }
 
@@ -103,6 +136,7 @@ int obi_uprobe_task_step_ret(struct pt_regs *ctx) {
     }
 
     thread_state->current_task = k_python_state_none;
+    obi_ctx__del(id);
     if (thread_state->current_context == k_python_state_none &&
         thread_state->inflight_task == k_python_state_none) {
         bpf_map_delete_elem(&python_thread_state, &id);
@@ -130,6 +164,14 @@ int obi_uprobe_context_run(struct pt_regs *ctx) {
     }
 
     thread_state->current_context = context;
+
+    // asyncio.to_thread worker has no current_task; look up which task copied this context
+    const python_context_task_t *context_task =
+        (const python_context_task_t *)bpf_map_lookup_elem(&python_context_task, &context);
+    const u64 task_id = resolve_python_context_task(context_task);
+    if (task_id) {
+        refresh_obi_ctx_for_task(id, task_id);
+    }
 
     return 0;
 }

--- a/bpf/generictracer/python.c
+++ b/bpf/generictracer/python.c
@@ -12,7 +12,6 @@
 #include <maps/python_context_task.h>
 #include <maps/python_task_state.h>
 #include <maps/python_thread_state.h>
-#include <maps/server_traces.h>
 
 #include <common/connection_info.h>
 #include <common/python_task.h>
@@ -26,30 +25,15 @@
 // Python task/context pointers use 0 to mean "no active state" in thread-local tracking.
 enum { k_python_state_none = 0 };
 
-// Walks parent chain to find owning server trace; mirrors find_python_parent_trace
 static __always_inline void refresh_obi_ctx_for_task(u64 pid_tgid, u64 task_id) {
     if (!task_id) {
         obi_ctx__del(pid_tgid);
         return;
     }
-    enum { k_max_depth = 4 };
-    for (u8 i = 0; i < k_max_depth; ++i) {
-        const python_task_state_t *task_state =
-            (const python_task_state_t *)bpf_map_lookup_elem(&python_task_state, &task_id);
-        if (!task_state) {
-            break;
-        }
-        if (task_state->conn.port) {
-            tp_info_pid_t *tp = bpf_map_lookup_elem(&server_traces_aux, &task_state->conn);
-            if (tp && tp->valid) {
-                obi_ctx__set(pid_tgid, &tp->tp);
-                return;
-            }
-        }
-        if (!task_state->parent) {
-            break;
-        }
-        task_id = task_state->parent;
+    tp_info_pid_t *tp = find_python_owning_server_trace(task_id);
+    if (tp && tp->valid) {
+        obi_ctx__set(pid_tgid, &tp->tp);
+        return;
     }
     obi_ctx__del(pid_tgid);
 }

--- a/devdocs/trace-log-correlation.md
+++ b/devdocs/trace-log-correlation.md
@@ -12,6 +12,7 @@ OBI can enrich JSON log lines with `trace_id` and `span_id` fields, linking logs
   - [Node.js — `async_hooks` before callback + `uv_fs_access` uprobe](#nodejs--async_hooks-before-callback--uv_fs_access-uprobe)
   - [Java — `k_ioctl_java_threads` in the ioctl kprobe](#java--k_ioctl_java_threads-in-the-ioctl-kprobe)
   - [Ruby (Puma) — `rb_ary_shift` uprobe](#ruby-puma--rb_ary_shift-uprobe)
+  - [Python (asyncio) — `task_step` / `context_run` uprobes](#python-asyncio--task_step--context_run-uprobes)
 - [Per-runtime stdout buffering](#per-runtime-stdout-buffering)
   - [.NET specifics](#net-specifics)
 - [Requirements](#requirements)
@@ -47,6 +48,7 @@ The map is **written** by the generic tracer (in `server_or_client_trace()`) whe
 - **Node.js**: The single-threaded event loop can read data for multiple in-flight requests (via libuv) before invoking any JS callback, overwriting `traces_ctx_v1` each time.
 - **Java**: HTTP servers (Tomcat, Netty) use thread pools. The acceptor thread receives the data, but a worker thread from the pool processes the request and writes logs.
 - **Ruby (Puma)**: When all workers are busy, the reactor thread reads HTTP data (setting context for itself), then hands off to a worker that has no context.
+- **Python (asyncio)**: A single OS thread runs many tasks via the event loop. `pid_tgid` identifies the thread, not the request, so any `await` boundary that switches tasks would otherwise leave `traces_ctx_v1[pid_tgid]` pointing at whichever task ran most recently.
 
 Without correction, `traces_ctx_v1[pid_tgid]` may carry the wrong trace context when a log is written. Each runtime has a dedicated mechanism to refresh the map at the right moment.
 
@@ -98,6 +100,20 @@ OBI hooks `rb_ary_shift` (Ruby's `Array#shift`), which fires when a Puma worker 
 3. If found, calls `obi_ctx__set(worker_pid_tgid, &tp)`.
 
 In the direct path, `server_traces_aux` won't have an entry yet (HTTP hasn't been parsed), so step 2 is a harmless no-op.
+
+### Python (asyncio) — `task_step` / `context_run` uprobes
+
+OBI hooks the CPython internals that mark every async transition:
+
+- `_asyncio.Task.__init__` → records the new task and its parent so each task carries the request connection it was created under.
+- `PyContext_CopyCurrent` (and `context_new_from_vars` under tail-call optimization) → binds the copied `PyContext*` to the task that owns it, including child tasks created via `asyncio.create_task` and worker contexts copied for `asyncio.to_thread`.
+- `_asyncio.Task.task_step` (3.12+) / `task_step_legacy` (< 3.12) → fires when the event loop resumes a task. The handler walks the task's parent chain (up to 4 levels) to find the owning server connection in `server_traces_aux` and calls `obi_ctx__set(pid_tgid, &tp)`.
+- `task_step_ret` → fires when a task yields back to the loop. The handler calls `obi_ctx__del(pid_tgid)` so logs emitted from idle event-loop code aren't attributed to the previous task.
+- `libpython3.context_run` → covers the `asyncio.to_thread` worker thread, where the user function runs inside a copied context but no `task_step` ever fires. The handler resolves the originating task via `python_context_task[context]` and refreshes `traces_ctx_v1` for the worker `pid_tgid`.
+
+Together these probes keep `traces_ctx_v1[pid_tgid]` aligned with whichever async task is currently executing, so logs written between any two `await` points get the correct trace/span IDs.
+
+This works for plain `asyncio` and uvloop (the probe targets are CPython's `_asyncio` module and `libpython3.so` — both loops drive the same task machinery). Greenlet/gevent are out of scope: their context switches happen entirely inside the greenlet C extension and don't touch any of the probed symbols.
 
 ## Per-runtime stdout buffering
 

--- a/internal/test/integration/components/pythonasync-uvloop/async_context_test.py
+++ b/internal/test/integration/components/pythonasync-uvloop/async_context_test.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI
 import httpx
 import asyncio
+import json
 import requests
 import os
+import sys
 
 app = FastAPI()
 http_client = None
@@ -38,6 +40,24 @@ async def test_sequential(req_id: int):
 
 @app.get("/health")
 async def health_check():
+    return {"status": "ok"}
+
+
+@app.get("/smoke")
+async def smoke():
+    return {"status": "ok"}
+
+
+@app.get("/json_logger")
+async def json_logger():
+    # Yield so concurrent requests interleave on the event loop
+    await asyncio.sleep(0.05)
+    line = json.dumps({
+        "message": "this is a json log from python async",
+        "level": "INFO",
+    })
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
     return {"status": "ok"}
 
 

--- a/internal/test/integration/components/pythonasync-uvloop/async_context_test.py
+++ b/internal/test/integration/components/pythonasync-uvloop/async_context_test.py
@@ -48,16 +48,54 @@ async def smoke():
     return {"status": "ok"}
 
 
+def _emit_json_log(message: str):
+    sys.stdout.write(json.dumps({"message": message, "level": "INFO"}) + "\n")
+    sys.stdout.flush()
+
+
 @app.get("/json_logger")
 async def json_logger():
     # Yield so concurrent requests interleave on the event loop
     await asyncio.sleep(0.05)
-    line = json.dumps({
-        "message": "this is a json log from python async",
-        "level": "INFO",
-    })
-    sys.stdout.write(line + "\n")
-    sys.stdout.flush()
+    _emit_json_log("this is a json log from python async")
+    return {"status": "ok"}
+
+
+@app.get("/json_logger_to_thread")
+async def json_logger_to_thread():
+    # Log from a worker thread offloaded via asyncio.to_thread; the worker has
+    # no current_task, so the context_run uprobe path drives the refresh
+    def worker():
+        _emit_json_log("this is a json log from python async to_thread")
+
+    await asyncio.to_thread(worker)
+    return {"status": "ok"}
+
+
+@app.get("/json_logger_nested")
+async def json_logger_nested():
+    # Log from a nested create_task chain; exercises the parent-chain walk
+    async def leaf():
+        await asyncio.sleep(0.01)
+        _emit_json_log("this is a json log from python async nested")
+
+    async def middle():
+        await asyncio.gather(asyncio.create_task(leaf()), asyncio.create_task(leaf()))
+
+    await asyncio.create_task(middle())
+    return {"status": "ok"}
+
+
+@app.get("/json_logger_gather")
+async def json_logger_gather():
+    # Log from sibling tasks running under asyncio.gather; each task yields
+    # so the event loop interleaves them and the task_step refresh has to
+    # update traces_ctx_v1 between sibling boundaries
+    async def sibling():
+        await asyncio.sleep(0.02)
+        _emit_json_log("this is a json log from python async gather")
+
+    await asyncio.gather(sibling(), sibling(), sibling())
     return {"status": "ok"}
 
 

--- a/internal/test/integration/docker-compose-log-enricher.yml
+++ b/internal/test/integration/docker-compose-log-enricher.yml
@@ -64,6 +64,20 @@ services:
     ports:
       - "8386:5266"
 
+  testserverpythonasync:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/pythonasync-uvloop/Dockerfile-3.14
+    image: hatest-testserver-logenricher-pythonasync
+    networks:
+      - shared
+    ports:
+      - "8387:8391"
+    environment:
+      PYTHONUNBUFFERED: "1"
+      UVICORN_LOOP: "uvloop"
+      BACKEND_URL: "http://testserverhttp:8380"
+
   obi:
     build:
       context: ../../..
@@ -110,6 +124,8 @@ services:
       testserverruby:
         condition: service_started
       testserverdotnet:
+        condition: service_started
+      testserverpythonasync:
         condition: service_started
 
 networks:

--- a/internal/test/integration/log_enricher_test.go
+++ b/internal/test/integration/log_enricher_test.go
@@ -395,9 +395,39 @@ func testLogEnricherRuby(t *testing.T, constants testServerConstants) {
 	}, testTimeout, 500*time.Millisecond)
 }
 
+// pythonAsyncLogEnricherVariants enumerates the asyncio scenarios exercised
+// by the testserver. Each variant emits a distinct message so concurrent
+// requests across variants don't cross-contaminate the assertions
+var pythonAsyncLogEnricherVariants = []struct {
+	name        string
+	logEndpoint string
+	message     string
+}{
+	{
+		name:        "interleaved (sleep)",
+		logEndpoint: "/json_logger",
+		message:     "this is a json log from python async",
+	},
+	{
+		name:        "asyncio.to_thread worker",
+		logEndpoint: "/json_logger_to_thread",
+		message:     "this is a json log from python async to_thread",
+	},
+	{
+		name:        "nested create_task",
+		logEndpoint: "/json_logger_nested",
+		message:     "this is a json log from python async nested",
+	},
+	{
+		name:        "asyncio.gather siblings",
+		logEndpoint: "/json_logger_gather",
+		message:     "this is a json log from python async gather",
+	},
+}
+
 // testLogEnricherPythonAsync exercises the asyncio task-switch refresh of
 // traces_ctx_v1 by interleaving concurrent requests on a single uvicorn/uvloop
-// event-loop thread
+// event-loop thread, across the variants above.
 func testLogEnricherPythonAsync(t *testing.T) {
 	waitForTestComponentsNoMetrics(t, logEnricherPythonAsyncConstants.url+logEnricherPythonAsyncConstants.smokeEndpoint)
 
@@ -405,6 +435,14 @@ func testLogEnricherPythonAsync(t *testing.T) {
 	require.NoError(t, err)
 	defer cl.Close()
 
+	for _, v := range pythonAsyncLogEnricherVariants {
+		t.Run(v.name, func(t *testing.T) {
+			testLogEnricherPythonAsyncEndpoint(t, cl, v.logEndpoint, v.message)
+		})
+	}
+}
+
+func testLogEnricherPythonAsyncEndpoint(t *testing.T, cl *client.Client, logEndpoint, message string) {
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		errCh := make(chan error, len(logEnricherTestTraceparents))
 		var wg sync.WaitGroup
@@ -413,7 +451,7 @@ func testLogEnricherPythonAsync(t *testing.T) {
 			go func(tp struct{ traceID, parentID string }) {
 				defer wg.Done()
 				req, err := http.NewRequest(http.MethodGet,
-					logEnricherPythonAsyncConstants.url+logEnricherPythonAsyncConstants.logEndpoint, nil)
+					logEnricherPythonAsyncConstants.url+logEndpoint, nil)
 				if err != nil {
 					errCh <- err
 					return
@@ -448,7 +486,7 @@ func testLogEnricherPythonAsync(t *testing.T) {
 			if json.Unmarshal([]byte(line), &fields) != nil {
 				continue
 			}
-			if fields["message"] != logEnricherPythonAsyncConstants.message {
+			if fields["message"] != message {
 				continue
 			}
 			if tid, ok := fields["trace_id"]; ok {

--- a/internal/test/integration/log_enricher_test.go
+++ b/internal/test/integration/log_enricher_test.go
@@ -80,6 +80,13 @@ var (
 		containerImage: "hatest-testserver-logenricher-dotnet",
 		message:        "this is a json log from dotnet",
 	}
+	logEnricherPythonAsyncConstants = testServerConstants{
+		url:            "http://localhost:8387",
+		smokeEndpoint:  "/smoke",
+		logEndpoint:    "/json_logger",
+		containerImage: "hatest-testserver-logenricher-pythonasync",
+		message:        "this is a json log from python async",
+	}
 )
 
 // logEnricherTestTraceparents are fixed W3C traceparents used by log enricher tests.
@@ -378,6 +385,77 @@ func testLogEnricherRuby(t *testing.T, constants testServerConstants) {
 		}
 
 		// Every injected trace_id must appear with a non-empty span_id.
+		for _, tp := range logEnricherTestTraceparents {
+			spanID, found := lastSpanID[tp.traceID]
+			assert.True(ct, found, "no enriched log line found for trace_id %s", tp.traceID)
+			if found {
+				assert.NotEmpty(ct, spanID, "span_id missing for trace_id %s", tp.traceID)
+			}
+		}
+	}, testTimeout, 500*time.Millisecond)
+}
+
+// testLogEnricherPythonAsync exercises the asyncio task-switch refresh of
+// traces_ctx_v1 by interleaving concurrent requests on a single uvicorn/uvloop
+// event-loop thread
+func testLogEnricherPythonAsync(t *testing.T) {
+	waitForTestComponentsNoMetrics(t, logEnricherPythonAsyncConstants.url+logEnricherPythonAsyncConstants.smokeEndpoint)
+
+	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err)
+	defer cl.Close()
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		errCh := make(chan error, len(logEnricherTestTraceparents))
+		var wg sync.WaitGroup
+		for _, tp := range logEnricherTestTraceparents {
+			wg.Add(1)
+			go func(tp struct{ traceID, parentID string }) {
+				defer wg.Done()
+				req, err := http.NewRequest(http.MethodGet,
+					logEnricherPythonAsyncConstants.url+logEnricherPythonAsyncConstants.logEndpoint, nil)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				req.Header.Set("traceparent", fmt.Sprintf("00-%s-%s-01", tp.traceID, tp.parentID))
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				resp.Body.Close()
+			}(tp)
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			assert.NoError(ct, err, "HTTP request failed")
+		}
+
+		containerID := testContainerID(ct, cl, logEnricherPythonAsyncConstants.containerImage)
+		if !assert.NotEmpty(ct, containerID, "could not find test container ID") {
+			return
+		}
+		logs := containerLogs(ct, cl, containerID)
+		if !assert.NotEmpty(ct, logs) {
+			return
+		}
+
+		lastSpanID := make(map[string]string, len(logEnricherTestTraceparents))
+		for _, line := range logs {
+			var fields map[string]string
+			if json.Unmarshal([]byte(line), &fields) != nil {
+				continue
+			}
+			if fields["message"] != logEnricherPythonAsyncConstants.message {
+				continue
+			}
+			if tid, ok := fields["trace_id"]; ok {
+				lastSpanID[tid] = fields["span_id"]
+			}
+		}
+
 		for _, tp := range logEnricherTestTraceparents {
 			spanID, found := lastSpanID[tp.traceID]
 			assert.True(ct, found, "no enriched log line found for trace_id %s", tp.traceID)

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -877,6 +877,19 @@ func TestSuite_LogEnricherDotNet(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_LogEnricherPythonAsync(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-log-enricher.yml", path.Join(pathOutput, "test-suite-log-enricher-pythonasync.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8391`, `OTEL_EBPF_EXECUTABLE_PATH=`)
+	require.NoError(t, compose.Up())
+
+	t.Run("Log Enricher Python async", func(t *testing.T) {
+		testLogEnricherPythonAsync(t)
+	})
+	require.NoError(t, compose.Close())
+}
+
 // Helpers
 
 var lockdownPath = "/sys/kernel/security/lockdown"

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -421,10 +421,12 @@ func (p *Tracer) UProbes() map[string]map[string][]*ebpfcommon.ProbeDesc {
 			"context_run": {{
 				Required: false,
 				Start:    p.bpfObjects.ObiUprobeContextRun,
+				End:      p.bpfObjects.ObiUretprobeContextRun,
 			}},
 			"context_run.lto_priv.0": {{ // In Python 3.14, context_run has different symbols due to Link Time Optimization
 				Required: false,
 				Start:    p.bpfObjects.ObiUprobeContextRun,
+				End:      p.bpfObjects.ObiUretprobeContextRun,
 			}},
 			"PyContext_CopyCurrent": {{
 				Required: false,


### PR DESCRIPTION
## Summary

- Refresh obi_ctx_v1 in python async state transitions
- Add logenricher test for async python

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
