### PR TITLE
Fix Prometheus unit tests

### DIFF
--- a/pkg/export/prom/prom_net_test.go
+++ b/pkg/export/prom/prom_net_test.go
@@ -25,7 +25,6 @@ import (
 var mpConfig = &perapp.MetricsConfig{Features: export.FeatureNetwork | export.FeatureNetworkInterZone}
 
 func TestMetricsExpiration(t *testing.T) {
-	t.Skip("fails regularly with port already in use or data race condition")
 	now := syncedClock{now: time.Now()}
 	timeNow = now.Now
 

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -46,7 +46,6 @@ import (
 const timeout = 5 * time.Second
 
 func TestAppMetricsExpiration(t *testing.T) {
-	t.Skip("fails regularly with port already in use")
 	now := syncedClock{now: time.Now()}
 	timeNow = now.Now
 
@@ -92,11 +91,19 @@ func TestAppMetricsExpiration(t *testing.T) {
 
 	go exporter(ctx)
 
+	svcAttrs := svc.Attrs{
+		Features: export.FeatureApplicationRED | export.FeatureApplicationHost,
+		UID:      svc.UID{Name: "test-app", Namespace: "default", Instance: "test-app-1"},
+	}
+	svcAttrs001 := svc.Attrs{
+		Features: svcAttrs.Features,
+		UID:      svcAttrs.UID,
+		Metadata: map[attr.Name]string{"k8s.app.version": "v0.0.1"},
+	}
+
 	app := exec.FileInfo{
-		Service: svc.Attrs{
-			UID: svc.UID{Name: "test-app", Namespace: "default", Instance: "test-app-1"},
-		},
-		Pid: 1,
+		Service: svcAttrs,
+		Pid:     1,
 	}
 
 	// Send a process event so we make target_info and traces_host_info
@@ -105,17 +112,12 @@ func TestAppMetricsExpiration(t *testing.T) {
 	// WHEN it receives metrics
 	promInput.Send([]request.Span{
 		{
-			Type: request.EventTypeHTTP,
-			Path: "/foo",
-			End:  123 * time.Second.Nanoseconds(),
-			Service: svc.Attrs{
-				UID: svc.UID{Name: "test-app", Namespace: "default", Instance: "test-app-1"},
-				Metadata: map[attr.Name]string{
-					"k8s.app.version": "v0.0.1",
-				},
-			},
+			Type:    request.EventTypeHTTP,
+			Path:    "/foo",
+			End:     123 * time.Second.Nanoseconds(),
+			Service: svcAttrs001,
 		},
-		{Type: request.EventTypeHTTP, Path: "/baz", End: 456 * time.Second.Nanoseconds()},
+		{Service: svcAttrs, Type: request.EventTypeHTTP, Path: "/baz", End: 456 * time.Second.Nanoseconds()},
 	})
 
 	containsTargetInfo := regexp.MustCompile(`\ntarget_info\{.*host_id="my-host"`)
@@ -134,21 +136,17 @@ func TestAppMetricsExpiration(t *testing.T) {
 		assert.Regexp(ct, containsTracesHostInfo, exported)
 		assert.Regexp(ct, containsJob, exported)
 		assert.Regexp(ct, containsInstance, exported)
-	}, timeout, 100*time.Millisecond)
+	}, 300*timeout, 100*time.Millisecond)
 
 	// AND WHEN it keeps receiving a subset of the initial metrics during the timeout
 	now.Advance(2 * time.Minute)
 	// WHEN it receives metrics
 	promInput.Send([]request.Span{
 		{
-			Type: request.EventTypeHTTP,
-			Path: "/foo",
-			End:  123 * time.Second.Nanoseconds(),
-			Service: svc.Attrs{
-				Metadata: map[attr.Name]string{
-					"k8s.app.version": "v0.0.1",
-				},
-			},
+			Type:    request.EventTypeHTTP,
+			Path:    "/foo",
+			End:     123 * time.Second.Nanoseconds(),
+			Service: svcAttrs001,
 		},
 	})
 	now.Advance(2 * time.Minute)
@@ -166,7 +164,7 @@ func TestAppMetricsExpiration(t *testing.T) {
 
 	// AND WHEN the metrics labels that disappeared are received again
 	promInput.Send([]request.Span{
-		{Type: request.EventTypeHTTP, Path: "/baz", End: 456 * time.Second.Nanoseconds()},
+		{Service: svcAttrs, Type: request.EventTypeHTTP, Path: "/baz", End: 456 * time.Second.Nanoseconds()},
 	})
 	now.Advance(2 * time.Minute)
 

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -136,7 +136,7 @@ func TestAppMetricsExpiration(t *testing.T) {
 		assert.Regexp(ct, containsTracesHostInfo, exported)
 		assert.Regexp(ct, containsJob, exported)
 		assert.Regexp(ct, containsInstance, exported)
-	}, 300*timeout, 100*time.Millisecond)
+	}, timeout, 100*time.Millisecond)
 
 	// AND WHEN it keeps receiving a subset of the initial metrics during the timeout
 	now.Advance(2 * time.Minute)

--- a/pkg/internal/testutil/net.go
+++ b/pkg/internal/testutil/net.go
@@ -6,7 +6,10 @@ package testutil // import "go.opentelemetry.io/obi/pkg/internal/testutil"
 import (
 	"net"
 	"testing"
+	"time"
 )
+
+const tcpPortTimeout = 5 * time.Second
 
 // FreeTCPPort returns a free TCP port that can be used for testing.
 func FreeTCPPort(t *testing.T) int {
@@ -15,12 +18,25 @@ func FreeTCPPort(t *testing.T) int {
 	if err != nil {
 		t.Fatalf("failed to find a free TCP port: %v", err)
 	}
-	defer listener.Close()
 
 	addr, ok := listener.Addr().(*net.TCPAddr)
 	if !ok {
 		t.Fatal("failed to get TCP address")
 	}
 
-	return addr.Port
+	if err := listener.Close(); err != nil {
+		t.Fatalf("failed to close listener: %v", err)
+	}
+
+	// wait until the listener port is effectively closed
+	deadline := time.Now().Add(tcpPortTimeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr.String(), 10*time.Millisecond)
+		if err != nil {
+			return addr.Port
+		}
+		conn.Close()
+	}
+	t.Fatalf("port %d was not released within %s", addr.Port, tcpPortTimeout)
+	return 0
 }


### PR DESCRIPTION
## Summary

* Fixes `FreeTCPPort` to make sure we wait until the port becomes free again.
* Removes `t.Skip` from some prometheus tests that were flaky because of the issue in `FreeTCPPort`
* Fixes `TestAppMetricsExpiration`, which was broken

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
