### PR TITLE
Fix buggy register spill

### DIFF
--- a/bpf/common/http_types.h
+++ b/bpf/common/http_types.h
@@ -50,7 +50,8 @@ typedef struct call_protocol_args {
     unsigned char small_buf[MIN_HTTP2_SIZE];
     protocol_selector_t protocols;
     u8 skip_tp_parsing;
-    u8 pad[2];
+    u8 use_bpf_loop;
+    u8 pad[1];
     int bytes_len;
     u16 orig_dport;
     u16 _pad2;

--- a/bpf/generictracer/k_tracer_tailcall.h
+++ b/bpf/generictracer/k_tracer_tailcall.h
@@ -24,4 +24,5 @@ enum {
     k_tail_protocol_http2_grpc_handle_end_frame = 7,
     k_tail_handle_buf_with_args = 8,
     k_tail_continue_protocol_http_tp = 9,
+    k_tail_continue_netfd_read = 10,
 };

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -650,7 +650,23 @@ skip_tp:
     }
 }
 
-// k_tail_continue_protocol_http
+// k_tail_continue_protocol_http (legacy)
+SEC("kprobe/http")
+int obi_continue_protocol_http_legacy(struct pt_regs *ctx) {
+    call_protocol_args_t *args = protocol_args();
+    if (!args) {
+        return 0;
+    }
+
+    http_info_t *info = bpf_map_lookup_elem(&ongoing_http, &args->pid_conn);
+    if (!info) {
+        return 0;
+    }
+
+    return __obi_continue_protocol_http(ctx, args, info, bpf_strstr_tp_loop__legacy);
+}
+
+// k_tail_continue_protocol_http (new kernels)
 SEC("kprobe/http")
 int obi_continue_protocol_http(struct pt_regs *ctx) {
     call_protocol_args_t *args = protocol_args();
@@ -661,6 +677,10 @@ int obi_continue_protocol_http(struct pt_regs *ctx) {
     http_info_t *info = bpf_map_lookup_elem(&ongoing_http, &args->pid_conn);
     if (!info) {
         return 0;
+    }
+
+    if (args->use_bpf_loop) {
+        return __obi_continue_protocol_http(ctx, args, info, bpf_strstr_tp_loop);
     }
 
     return __obi_continue_protocol_http(ctx, args, info, bpf_strstr_tp_loop__legacy);
@@ -712,12 +732,11 @@ __obi_protocol_http(struct pt_regs *ctx, unsigned char *(*tp_loop_fn)(unsigned c
     info->direction = args->direction;
     if (args->packet_type == PACKET_TYPE_REQUEST && (info->status == 0) &&
         (info->start_monotime_ns == 0)) {
-        if (tp_loop_fn == bpf_strstr_tp_loop) {
-            return __obi_continue_protocol_http(ctx, args, info, bpf_strstr_tp_loop);
-        } else {
-            bpf_tail_call(ctx, &jump_table, k_tail_continue_protocol_http);
-            return 0;
-        }
+
+        args->use_bpf_loop = tp_loop_fn == bpf_strstr_tp_loop;
+        bpf_tail_call(ctx, &jump_table, k_tail_continue_protocol_http);
+
+        return 0;
     } else if ((args->packet_type == PACKET_TYPE_RESPONSE) && (info->status == 0)) {
         http_send_large_buffer(info,
                                (void *)args->u_buf,

--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -149,6 +149,19 @@ int obi_uprobe_netFdRead(struct pt_regs *ctx) {
         // on the same goroutine.
     }
 
+    bpf_tail_call(ctx, &jump_table, k_tail_continue_netfd_read);
+    return 0;
+}
+
+// k_tail_continue_netfd_read
+SEC("uprobe/netFdRead_cont")
+int obi_continue_netfd_read(struct pt_regs *ctx) {
+    void *goroutine_addr = GOROUTINE_PTR(ctx);
+    bpf_dbg_printk("=== uprobe/netFdRead_cont goroutine_addr=%lx ===", goroutine_addr);
+
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+
     const u64 id = bpf_get_current_pid_tgid();
 
     void *fd_ptr = GO_PARAM1(ctx);

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -517,10 +517,10 @@ func FixupSpec(spec *ebpf.CollectionSpec, overrideKernelVersion bool) {
 		// use one predefined field name to store either of them.
 		spec.Programs["obi_protocol_http"] = spec.Programs["obi_protocol_http_legacy"]
 		spec.Programs["obi_protocol_http"].Name = "obi_protocol_http"
+		spec.Programs["obi_continue_protocol_http"] = spec.Programs["obi_continue_protocol_http_legacy"]
+		spec.Programs["obi_continue_protocol_http"].Name = "obi_continue_protocol_http"
 	}
-	// Hack: insert a dummy unused program in order to be able to use bpf2go generated struct to load
-	// the collection.
-	spec.Programs["obi_protocol_http_legacy"] = &ebpf.ProgramSpec{
+	dummy := &ebpf.ProgramSpec{
 		Name: "obi_dummy",
 		Type: ebpf.Kprobe,
 		Instructions: asm.Instructions{
@@ -529,6 +529,10 @@ func FixupSpec(spec *ebpf.CollectionSpec, overrideKernelVersion bool) {
 		},
 		License: "MIT",
 	}
+	// Hack: insert dummy unused programs in order to be able to use bpf2go generated struct to load
+	// the collection.
+	spec.Programs["obi_protocol_http_legacy"] = dummy
+	spec.Programs["obi_continue_protocol_http_legacy"] = dummy
 }
 
 // Injectable for tests

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -166,6 +166,8 @@ func (p *Tracer) SetupTailCalls() {
 		p.bpfObjects.ObiProtocolHttp2GrpcHandleStartFrame, // 6
 		p.bpfObjects.ObiProtocolHttp2GrpcHandleEndFrame,   // 7
 		p.bpfObjects.ObiHandleBufWithArgs,                 // 8
+		p.bpfObjects.ObiContinueProtocolHttpTp,            // 9
+		p.bpfObjects.ObiContinueNetfdRead,                 // 10
 	} {
 		p.log.Debug("loading program into tail call jump table", "index", i, "program", prog.String())
 		if err := p.bpfObjects.JumpTable.Update(uint32(i), uint32(prog.FD()), ebpf.UpdateAny); err != nil {


### PR DESCRIPTION
## Summary

This fixes kernel crashes in obi_protocol_http and Go tracers caused by invalid stack-slot reuse in the generated BPF bytecode. Under high register pressure, clang (18–22) spills pointers to the BPF stack and later overwrites those slots with unrelated scalar values, eventually reloading them as pointers and causing invalid memory accesses (e.g., 0x45, 0x14, 0x81).

The issue was latent on kernels ≤6.18 and became visible starting in 6.19 due to verifier/liveness changes. The fix splits the large program into smaller tail-called subprograms, reducing register pressure and avoiding the problematic stack reuse without changing functionality.

## Validation

Tested on kernels **6.19** and **7.0** (ArchLinux)

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
