### PR TITLE
perf(ci): bound compose.Close() to prevent shard timeouts

### DIFF
--- a/internal/test/integration/components/docker/compose.go
+++ b/internal/test/integration/components/docker/compose.go
@@ -5,6 +5,7 @@
 package docker // import "go.opentelemetry.io/obi/internal/test/integration/components/docker"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -13,9 +14,19 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/obi/internal/test/tools"
 )
+
+// stopTimeout bounds how long `docker compose stop` waits between SIGTERM and
+// SIGKILL for each container. Keeps shutdown predictable when a container is
+// hung.
+const stopTimeout = "5"
+
+// waitTimeout bounds how long Close() will wait for the obi container to
+// exit. A stuck container would otherwise burn the shard's job timeout.
+const waitTimeout = 30 * time.Second
 
 type Compose struct {
 	Path   string
@@ -63,7 +74,7 @@ func (c *Compose) Logs() error {
 }
 
 func (c *Compose) Stop() error {
-	return c.command("stop")
+	return c.command("stop", "--timeout", stopTimeout)
 }
 
 func (c *Compose) Remove() error {
@@ -71,9 +82,13 @@ func (c *Compose) Remove() error {
 }
 
 func (c *Compose) command(args ...string) error {
+	return c.commandContext(context.Background(), args...)
+}
+
+func (c *Compose) commandContext(ctx context.Context, args ...string) error {
 	cmdArgs := []string{"compose", "--ansi", "never", "-f", c.Path}
 	cmdArgs = append(cmdArgs, args...)
-	cmd := exec.Command("docker", cmdArgs...)
+	cmd := exec.CommandContext(ctx, "docker", cmdArgs...)
 	cmd.Env = c.Env
 	if c.Logger != nil {
 		cmd.Stdout = c.Logger
@@ -100,16 +115,27 @@ func (c *Compose) ExecOutput(service string, args ...string) (string, error) {
 
 func (c *Compose) Close() error {
 	var errs []error
-	if err := c.Logs(); err != nil {
-		errs = append(errs, fmt.Errorf("flushing logs: %w", err))
-	}
+
+	// Logs is read-only; run it in parallel with Stop so neither blocks the other.
+	logsErr := make(chan error, 1)
+	go func() {
+		logsErr <- c.Logs()
+	}()
+
 	if err := c.Stop(); err != nil {
 		// we just warn, as the container will be force-removed later
 		slog.Warn("stopping docker compose. Will force remove", "error", err)
 	}
-	if err := c.command("wait", "obi"); err != nil {
+
+	if err := <-logsErr; err != nil {
+		errs = append(errs, fmt.Errorf("flushing logs: %w", err))
+	}
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), waitTimeout)
+	if err := c.commandContext(waitCtx, "wait", "obi"); err != nil {
 		slog.Warn("waiting for obi to stop. Will force remove", "error", err)
 	}
+	cancel()
 
 	if err := c.Remove(); err != nil {
 		errs = append(errs, fmt.Errorf("removing container: %w", err))


### PR DESCRIPTION
## Summary

`compose.Close()` can hang a CI shard until the 45m job timeout when a container fails to exit cleanly.

Concrete example: [run 25045610747, shard-5](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/25045610747/job/73359795599) — 29 min of nothing after the last suite passed, while peer shards finished in 18–27 min.

This PR bounds the worst case: `wait obi` runs under a 30s context timeout, `Stop()` passes `--timeout 5` so SIGTERM grace is capped, and `Logs()` runs in parallel with `Stop()` since reads don't block stop. Happy-path behavior is unchanged; worst-case shutdown is now ~35s instead of unbounded.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->