### PR TITLE
[do not review/do not merge] java: drop stale residue past unwrapped plaintext, bump MAX_SIZE to 16k

### DIFF
--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/ebpf/ProxyInputStream.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/ebpf/ProxyInputStream.java
@@ -28,9 +28,9 @@ public class ProxyInputStream extends InputStream {
   public int read(byte[] b) throws IOException {
     int len = delegate.read(b);
     if (len > 0) {
-      NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + b.length);
-      int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, b.length);
-      IOCTLPacket.writePacketBuffer(p, wOff, b);
+      NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + len);
+      int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, len);
+      IOCTLPacket.writePacketBuffer(p, wOff, b, 0, len);
       Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
     }
     return len;

--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/ebpf/ProxyOutputStream.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/ebpf/ProxyOutputStream.java
@@ -24,24 +24,24 @@ public class ProxyOutputStream extends OutputStream {
     delegate.write(b);
   }
 
-  private void writeWrapper(byte[] b) {
-    if (b.length > 0) {
-      NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + b.length);
-      int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.SEND, socket, b.length);
-      IOCTLPacket.writePacketBuffer(p, wOff, b);
+  private void writeWrapper(byte[] b, int off, int len) {
+    if (len > 0) {
+      NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + len);
+      int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.SEND, socket, len);
+      IOCTLPacket.writePacketBuffer(p, wOff, b, off, len);
       Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
     }
   }
 
   @Override
   public void write(byte[] b) throws IOException {
-    writeWrapper(b);
+    writeWrapper(b, 0, b.length);
     delegate.write(b);
   }
 
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
-    writeWrapper(b);
+    writeWrapper(b, off, len);
     delegate.write(b, off, len);
   }
 

--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SSLEngineInst.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SSLEngineInst.java
@@ -250,6 +250,11 @@ public class SSLEngineInst {
           }
           if (savedDstPositions[i] != -1) {
             dups[i] = dsts[i].duplicate();
+            // [savedPos, dsts[i].position()) covers exactly what unwrap just wrote.
+            // Bytes past dsts[i].position() may be stale residue from a pooled
+            // ByteBuf and can look like TLS records, so clamp the duplicate's
+            // limit before flattening to avoid leaking that residue downstream.
+            b(dups[i]).limit(b(dsts[i]).position());
             b(dups[i]).position(savedDstPositions[i]);
           }
         }
@@ -315,6 +320,10 @@ public class SSLEngineInst {
           return;
         }
 
+        // wrap may consume fewer bytes than we captured on enter; truncate so
+        // the captured payload matches what actually got encrypted and sent
+        int sentLen = Math.min(bLen.len, result.bytesConsumed());
+
         if (SSLStorage.debugOn) {
           System.err.println("[SSLEngineInst] wrap :" + java.util.Arrays.toString(bLen.buf));
         }
@@ -328,16 +337,16 @@ public class SSLEngineInst {
                   + Thread.currentThread().getName());
         }
         if (c != null) {
-          NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + bLen.len);
-          int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.SEND, c, bLen.len);
-          IOCTLPacket.writePacketBuffer(p, wOff, bLen.buf, 0, bLen.len);
+          NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + sentLen);
+          int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.SEND, c, sentLen);
+          IOCTLPacket.writePacketBuffer(p, wOff, bLen.buf, 0, sentLen);
           Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
         } else {
           String encrypted = ByteBufferExtractor.keyFromUsedBuffer(dst);
           if (SSLStorage.debugOn) {
             System.err.println("[SSLEngineInst] buf mapping on: " + encrypted);
           }
-          SSLStorage.setBufferMapping(encrypted, bLen);
+          SSLStorage.setBufferMapping(encrypted, new BytesWithLen(bLen.buf, sentLen));
         }
       }
 
@@ -385,6 +394,10 @@ public class SSLEngineInst {
           return;
         }
 
+        // wrap may consume fewer bytes than we captured on enter; truncate so
+        // the captured payload matches what actually got encrypted and sent
+        int sentLen = Math.min(bLen.len, result.bytesConsumed());
+
         if (SSLStorage.debugOn) {
           System.err.println(
               "[SSLEngineInst] wrap array :["
@@ -402,16 +415,16 @@ public class SSLEngineInst {
                   + Thread.currentThread().getName());
         }
         if (c != null) {
-          NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + bLen.len);
-          int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.SEND, c, bLen.len);
-          IOCTLPacket.writePacketBuffer(p, wOff, bLen.buf, 0, bLen.len);
+          NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + sentLen);
+          int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.SEND, c, sentLen);
+          IOCTLPacket.writePacketBuffer(p, wOff, bLen.buf, 0, sentLen);
           Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
         } else {
           String encrypted = ByteBufferExtractor.keyFromUsedBuffer(dst);
           if (SSLStorage.debugOn) {
             System.err.println("[SSLEngineInst] buf array mapping on: " + encrypted);
           }
-          SSLStorage.setBufferMapping(encrypted, bLen);
+          SSLStorage.setBufferMapping(encrypted, new BytesWithLen(bLen.buf, sentLen));
         }
       }
 

--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SSLSocketStreamInst.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SSLSocketStreamInst.java
@@ -104,9 +104,9 @@ public class SSLSocketStreamInst {
         }
         if (socket != null) {
           try {
-            NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + b.length);
-            int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, b.length);
-            IOCTLPacket.writePacketBuffer(p, wOff, b);
+            NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + len);
+            int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, len);
+            IOCTLPacket.writePacketBuffer(p, wOff, b, 0, len);
             Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
           } catch (Throwable t) {
             if (SSLStorage.debugOn) {

--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractor.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractor.java
@@ -9,7 +9,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 public class ByteBufferExtractor {
-  public static final int MAX_SIZE = 1024;
+  public static final int MAX_SIZE = 16 * 1024;
   public static final int MAX_KEY_SIZE = 64;
 
   // Made for JDK8 support

--- a/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractorTest.java
+++ b/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractorTest.java
@@ -709,8 +709,7 @@ class ByteBufferExtractorTest {
     ((java.nio.Buffer) dup).limit(((java.nio.Buffer) dst).position());
     ((java.nio.Buffer) dup).position(savedPos);
 
-    ByteBuffer result =
-        ByteBufferExtractor.flattenFreshByteBufferArray(new ByteBuffer[] {dup});
+    ByteBuffer result = ByteBufferExtractor.flattenFreshByteBufferArray(new ByteBuffer[] {dup});
 
     assertEquals(postUnwrapPos, result.position());
     result.flip();

--- a/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractorTest.java
+++ b/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractorTest.java
@@ -151,13 +151,14 @@ class ByteBufferExtractorTest {
 
   @Test
   void testFlattenUsedByteBufferArray_LenGreaterThanMaxSize() {
-    ByteBuffer buf = ByteBuffer.allocate(2000);
-    for (int i = 0; i < 2000; i++) {
+    int n = ByteBufferExtractor.MAX_SIZE + 1000;
+    ByteBuffer buf = ByteBuffer.allocate(n);
+    for (int i = 0; i < n; i++) {
       buf.put((byte) (i % 128));
     }
     ByteBuffer[] buffers = new ByteBuffer[] {buf};
-    ByteBuffer result = ByteBufferExtractor.flattenUsedByteBufferArray(buffers, 2000);
-    assertEquals(2000, buf.position());
+    ByteBuffer result = ByteBufferExtractor.flattenUsedByteBufferArray(buffers, n);
+    assertEquals(n, buf.position());
 
     assertEquals(ByteBufferExtractor.MAX_SIZE, result.capacity());
 
@@ -360,8 +361,9 @@ class ByteBufferExtractorTest {
 
   @Test
   void testFlattenFreshByteBufferArray_LimitGreaterThanMaxSize() {
-    ByteBuffer buf1 = ByteBuffer.allocate(2000);
-    for (int i = 0; i < 2000; i++) {
+    int n = ByteBufferExtractor.MAX_SIZE + 1000;
+    ByteBuffer buf1 = ByteBuffer.allocate(n);
+    for (int i = 0; i < n; i++) {
       buf1.put((byte) (i % 128));
     }
     buf1.flip();
@@ -374,14 +376,16 @@ class ByteBufferExtractorTest {
       assertEquals((byte) (i % 128), result.get());
     }
     assertEquals(0, buf1.position());
-    assertEquals(2000, buf1.limit());
+    assertEquals(n, buf1.limit());
   }
 
   @Test
   void testFlattenFreshByteBufferArray_MultipleBuffers_ExceedMaxSize() {
-    ByteBuffer buf1 = ByteBuffer.allocate(800);
-    ByteBuffer buf2 = ByteBuffer.allocate(800);
-    for (int i = 0; i < 800; i++) {
+    int n = 10240;
+    int residual = ByteBufferExtractor.MAX_SIZE - (n - 1);
+    ByteBuffer buf1 = ByteBuffer.allocate(n);
+    ByteBuffer buf2 = ByteBuffer.allocate(n);
+    for (int i = 0; i < n; i++) {
       buf1.put((byte) (i + 1));
       buf2.put((byte) (i + 101));
     }
@@ -392,16 +396,16 @@ class ByteBufferExtractorTest {
     ByteBuffer result = ByteBufferExtractor.flattenFreshByteBufferArray(srcs);
     assertEquals(ByteBufferExtractor.MAX_SIZE, result.capacity());
     result.flip();
-    for (int i = 1; i < 800; i++) {
+    for (int i = 1; i < n; i++) {
       assertEquals((byte) (i + 1), result.get());
     }
-    for (int i = 0; i < 224; i++) {
+    for (int i = 0; i < residual; i++) {
       assertEquals((byte) (i + 101), result.get());
     }
     assertEquals(1, buf1.position());
-    assertEquals(800, buf1.limit());
+    assertEquals(n, buf1.limit());
     assertEquals(0, buf2.position());
-    assertEquals(800, buf2.limit());
+    assertEquals(n, buf2.limit());
   }
 
   @Test
@@ -519,19 +523,20 @@ class ByteBufferExtractorTest {
 
   @Test
   void testFromFreshBuffer_LenGreaterThanMaxSize() {
-    ByteBuffer src = ByteBuffer.allocate(2000);
-    for (int i = 0; i < 2000; i++) {
+    int n = ByteBufferExtractor.MAX_SIZE + 1000;
+    ByteBuffer src = ByteBuffer.allocate(n);
+    for (int i = 0; i < n; i++) {
       src.put((byte) (i % 128));
     }
     src.flip();
-    ByteBuffer result = ByteBufferExtractor.fromFreshBuffer(src, 2000);
+    ByteBuffer result = ByteBufferExtractor.fromFreshBuffer(src, n);
     assertEquals(ByteBufferExtractor.MAX_SIZE, result.capacity());
     result.flip();
     for (int i = 0; i < ByteBufferExtractor.MAX_SIZE; i++) {
       assertEquals((byte) (i % 128), result.get());
     }
     assertEquals(0, src.position());
-    assertEquals(2000, src.limit());
+    assertEquals(n, src.limit());
   }
 
   @Test
@@ -665,5 +670,52 @@ class ByteBufferExtractorTest {
     assertEquals(sb.toString(), ByteBufferExtractor.keyFromFreshBuffer(buf));
     assertEquals(5, buf.position());
     assertEquals(size, buf.limit());
+  }
+
+  // Regression for issue #1935: pooled ByteBuf reused across requests can leave
+  // stale TLS-record-shaped bytes past the freshly-decrypted plaintext. The
+  // unwrap-array advice must clamp dup.limit to dst.position_post_unwrap so
+  // flatten returns only the bytes that this unwrap call wrote
+  @Test
+  void testFlattenFreshByteBufferArray_DropsStaleResidueAfterUnwrap() {
+    int capacity = 1024;
+    int savedPos = 0;
+    int postUnwrapPos = 32; // unwrap wrote 32 plaintext bytes
+
+    ByteBuffer dst = ByteBuffer.allocate(capacity);
+    // Fresh plaintext written by SSLEngine.unwrap
+    byte[] plaintext = "HTTP/1.1 200 OK\r\nServer: ok\r\n\r\n!".getBytes();
+    assertEquals(postUnwrapPos, plaintext.length);
+    for (int i = 0; i < postUnwrapPos; i++) {
+      dst.put(i, plaintext[i]);
+    }
+    // Stale residue from a previous use of the pooled buffer: starts with a
+    // TLS 1.2 application-data record header followed by ciphertext-shaped bytes
+    dst.put(postUnwrapPos, (byte) 0x17);
+    dst.put(postUnwrapPos + 1, (byte) 0x03);
+    dst.put(postUnwrapPos + 2, (byte) 0x03);
+    dst.put(postUnwrapPos + 3, (byte) 0x05);
+    dst.put(postUnwrapPos + 4, (byte) 0x6a);
+    for (int i = postUnwrapPos + 5; i < capacity; i++) {
+      dst.put(i, (byte) (i & 0xff));
+    }
+    // Simulate the state SSLEngine.unwrap leaves: position advanced past the
+    // newly-written plaintext, limit unchanged at capacity
+    ((java.nio.Buffer) dst).position(postUnwrapPos);
+
+    // Build the duplicate the same way UnwrapAdviceArray.OnMethodExit does post-fix:
+    // limit clamped to dst.position(), then position rewound to savedPos
+    ByteBuffer dup = dst.duplicate();
+    ((java.nio.Buffer) dup).limit(((java.nio.Buffer) dst).position());
+    ((java.nio.Buffer) dup).position(savedPos);
+
+    ByteBuffer result =
+        ByteBufferExtractor.flattenFreshByteBufferArray(new ByteBuffer[] {dup});
+
+    assertEquals(postUnwrapPos, result.position());
+    result.flip();
+    byte[] out = new byte[result.limit()];
+    result.get(out);
+    assertArrayEquals(plaintext, out);
   }
 }


### PR DESCRIPTION
## Summary

Context: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1944/changes#r3152923400

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
