### PR TITLE
Delay cleaning the SSL requests until we finish HTTP

### DIFF
--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -238,6 +238,7 @@ static __always_inline void cleanup_http_request_data(pid_connection_info_t *pid
 static __always_inline void terminate_http_request_if_needed(pid_connection_info_t *pid_conn) {
     http_info_t *info = bpf_map_lookup_elem(&ongoing_http, pid_conn);
     cleanup_http_request_data(pid_conn, info);
+    bpf_map_delete_elem(&active_ssl_connections, pid_conn);
 }
 
 static __always_inline void process_http_request(http_info_t *info,

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -131,6 +131,8 @@ static __always_inline void finish_http(http_info_t *info, pid_connection_info_t
         if (info->delayed) {
             bpf_map_delete_elem(&ongoing_http, pid_conn);
         }
+
+        bpf_map_delete_elem(&active_ssl_connections, pid_conn);
     }
 }
 
@@ -231,7 +233,6 @@ static __always_inline void cleanup_http_request_data(pid_connection_info_t *pid
             delete_client_trace_info(pid_conn);
         }
     }
-    bpf_map_delete_elem(&active_ssl_connections, pid_conn);
 }
 
 static __always_inline void terminate_http_request_if_needed(pid_connection_info_t *pid_conn) {


### PR DESCRIPTION
## Summary

We were deleting the SSL marking on a connection too early for HTTP requests, meaning we'd delete as soon as we saw the first response packet. If the SSL response was large including large buffers, we would send TLS data to userspace mixed with non-TLS, making payload extraction fail.

Relates to https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1944

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [X] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
