### PR TITLE
ci: harden oats test matrix generation

### DIFF
--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -157,7 +157,7 @@ jobs:
         env:
           MATRIX_BASENAME: ${{ matrix.basename }}
           TESTCASE_TIMEOUT: 5m
-        run: make oats-test-$MATRIX_BASENAME
+        run: make "oats-test-$MATRIX_BASENAME"
 
       - name: Upload oats test logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/scripts/generate-dir-matrix.sh
+++ b/scripts/generate-dir-matrix.sh
@@ -18,7 +18,7 @@ while IFS= read -r -d '' test_file; do
         continue
     fi
 
-    dir=$(basename "$(dirname "$test_file")")
+    dir=$(basename -- "$(dirname -- "$test_file")")
     if [[ ! "$dir" =~ ^[A-Za-z0-9_-]+$ ]]; then
         echo "ERROR: Invalid test directory basename '$dir' in $SEARCH_DIR; only [A-Za-z0-9_-] are allowed" >&2
         exit 1

--- a/scripts/generate-dir-matrix.sh
+++ b/scripts/generate-dir-matrix.sh
@@ -5,38 +5,55 @@
 # Generate test matrix - one shard per test directory
 # Usage: ./scripts/generate-dir-matrix.sh [search_dir] [exclude_pattern]
 
-set -e
+set -euo pipefail
 
-# Find all test directories
 SEARCH_DIR="${1:-internal/test/integration/k8s}"
 EXCLUDE_PATTERN="${2:-common}"
-TEST_DIRS=$(find "$SEARCH_DIR" -name "*_test.go" | grep -v "$EXCLUDE_PATTERN" | sort | xargs dirname | xargs basename -a | sort -u)
 
-if [ -z "$TEST_DIRS" ]; then
+declare -A seen_dirs=()
+declare -a test_dirs=()
+
+while IFS= read -r -d '' test_file; do
+    if [[ -n "$EXCLUDE_PATTERN" && "$test_file" =~ $EXCLUDE_PATTERN ]]; then
+        continue
+    fi
+
+    dir=$(basename "$(dirname "$test_file")")
+    if [[ ! "$dir" =~ ^[A-Za-z0-9_-]+$ ]]; then
+        echo "ERROR: Invalid test directory basename '$dir' in $SEARCH_DIR; only [A-Za-z0-9_-] are allowed" >&2
+        exit 1
+    fi
+
+    if [[ -z "${seen_dirs[$dir]+x}" ]]; then
+        seen_dirs["$dir"]=1
+        test_dirs+=("$dir")
+    fi
+done < <(find "$SEARCH_DIR" -name "*_test.go" -print0 | sort -z)
+
+if [ "${#test_dirs[@]}" -eq 0 ]; then
     echo "ERROR: No test directories found in $SEARCH_DIR" >&2
     exit 1
 fi
 
-# Count directories
-DIR_COUNT=$(echo "$TEST_DIRS" | wc -l | tr -d ' ')
+mapfile -t sorted_dirs < <(printf '%s\n' "${test_dirs[@]}" | sort)
+
+DIR_COUNT="${#sorted_dirs[@]}"
 echo "Total test packages: $DIR_COUNT" >&2
 
-# Generate matrix JSON
 MATRIX_JSON='{"include":['
 FIRST=true
 SHARD_ID=0
 
-for dir in $TEST_DIRS; do
+for dir in "${sorted_dirs[@]}"; do
     if [ "$FIRST" = "false" ]; then
         MATRIX_JSON+=","
     fi
     FIRST=false
-    
-    # Each shard runs all tests in its package directory
+
     MATRIX_JSON+="{\"id\":$SHARD_ID,\"basename\":\"$dir\",\"test_pattern\":\"./$SEARCH_DIR/$dir/...\"}"
-    
+
     echo "Shard $SHARD_ID: $dir" >&2
-    
+
     SHARD_ID=$((SHARD_ID + 1))
 done
 

--- a/scripts/generate-dir-matrix_test.go
+++ b/scripts/generate-dir-matrix_test.go
@@ -5,6 +5,7 @@ package scripts
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,7 +76,8 @@ func runGenerateDirMatrix(t *testing.T, searchDir, excludePattern string) (strin
 	}
 
 	var stderr string
-	if exitErr, ok := err.(*exec.ExitError); ok {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
 		stderr = string(exitErr.Stderr)
 	}
 

--- a/scripts/generate-dir-matrix_test.go
+++ b/scripts/generate-dir-matrix_test.go
@@ -1,0 +1,93 @@
+package scripts
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type dirMatrix struct {
+	Include []struct {
+		ID       int    `json:"id"`
+		Basename string `json:"basename"`
+	} `json:"include"`
+}
+
+func TestGenerateDirMatrixIncludesSortedBasenames(t *testing.T) {
+	searchDir := t.TempDir()
+	mustWriteTestFile(t, searchDir, "zeta")
+	mustWriteTestFile(t, searchDir, "alpha")
+	mustWriteTestFile(t, searchDir, "safe-name_1")
+
+	stdout, stderr, err := runGenerateDirMatrix(t, searchDir, "")
+	if err != nil {
+		t.Fatalf("generate-dir-matrix.sh failed: %v\nstderr:\n%s", err, stderr)
+	}
+
+	var matrix dirMatrix
+	if err := json.Unmarshal([]byte(stdout), &matrix); err != nil {
+		t.Fatalf("failed to parse matrix json %q: %v", stdout, err)
+	}
+
+	if len(matrix.Include) != 3 {
+		t.Fatalf("expected 3 matrix entries, got %d", len(matrix.Include))
+	}
+
+	if matrix.Include[0].Basename != "alpha" || matrix.Include[1].Basename != "safe-name_1" || matrix.Include[2].Basename != "zeta" {
+		t.Fatalf("unexpected basenames: %+v", matrix.Include)
+	}
+}
+
+func TestGenerateDirMatrixRejectsUnsafeBasename(t *testing.T) {
+	for _, basename := range []string{"evil name", "evil;touch_pwn"} {
+		t.Run(basename, func(t *testing.T) {
+			searchDir := t.TempDir()
+			mustWriteTestFile(t, searchDir, basename)
+
+			_, stderr, err := runGenerateDirMatrix(t, searchDir, "")
+			if err == nil {
+				t.Fatal("expected generate-dir-matrix.sh to reject an unsafe basename")
+			}
+
+			if !strings.Contains(stderr, "Invalid test directory basename") {
+				t.Fatalf("expected validation error, got stderr:\n%s", stderr)
+			}
+		})
+	}
+}
+
+func runGenerateDirMatrix(t *testing.T, searchDir, excludePattern string) (string, string, error) {
+	t.Helper()
+
+	cmd := exec.Command("bash", "./generate-dir-matrix.sh", searchDir, excludePattern)
+	cmd.Dir = "."
+
+	stdout, err := cmd.Output()
+	if err == nil {
+		return string(stdout), "", nil
+	}
+
+	var stderr string
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		stderr = string(exitErr.Stderr)
+	}
+
+	return string(stdout), stderr, err
+}
+
+func mustWriteTestFile(t *testing.T, rootDir, packageDir string) {
+	t.Helper()
+
+	dir := filepath.Join(rootDir, packageDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create %s: %v", dir, err)
+	}
+
+	filePath := filepath.Join(dir, "sample_test.go")
+	if err := os.WriteFile(filePath, []byte("package sample\n"), 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", filePath, err)
+	}
+}

--- a/scripts/generate-dir-matrix_test.go
+++ b/scripts/generate-dir-matrix_test.go
@@ -21,6 +21,7 @@ type dirMatrix struct {
 
 func TestGenerateDirMatrixIncludesSortedBasenames(t *testing.T) {
 	searchDir := t.TempDir()
+	mustWriteTestFile(t, searchDir, "-dash")
 	mustWriteTestFile(t, searchDir, "zeta")
 	mustWriteTestFile(t, searchDir, "alpha")
 	mustWriteTestFile(t, searchDir, "safe-name_1")
@@ -35,11 +36,11 @@ func TestGenerateDirMatrixIncludesSortedBasenames(t *testing.T) {
 		t.Fatalf("failed to parse matrix json %q: %v", stdout, err)
 	}
 
-	if len(matrix.Include) != 3 {
-		t.Fatalf("expected 3 matrix entries, got %d", len(matrix.Include))
+	if len(matrix.Include) != 4 {
+		t.Fatalf("expected 4 matrix entries, got %d", len(matrix.Include))
 	}
 
-	if matrix.Include[0].Basename != "alpha" || matrix.Include[1].Basename != "safe-name_1" || matrix.Include[2].Basename != "zeta" {
+	if matrix.Include[0].Basename != "-dash" || matrix.Include[1].Basename != "alpha" || matrix.Include[2].Basename != "safe-name_1" || matrix.Include[3].Basename != "zeta" {
 		t.Fatalf("unexpected basenames: %+v", matrix.Include)
 	}
 }

--- a/scripts/generate-dir-matrix_test.go
+++ b/scripts/generate-dir-matrix_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package scripts
 
 import (


### PR DESCRIPTION
## Summary
- harden OATS test matrix generation against unsafe directory basenames
- quote the matrix-derived make target in the CI workflow
- add Go tests for sorted output and invalid basename rejection

## Why
The matrix generator previously relied on shell pipelines and unquoted command-facing values derived from test directory basenames. This was brittle and could behave incorrectly for unexpected basename content.

## Impact
This preserves existing behavior for valid test directories while making matrix generation deterministic and rejecting invalid basenames before they reach CI command execution.

## Validation
- `shellcheck scripts/generate-dir-matrix.sh`
- `go test -v ./scripts`