### PR TITLE
Define the OBI telemetry schema registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ If you are evaluating OBI for production use:
 For the project's versioning and stability policy, see [VERSIONING.md](./VERSIONING.md).
 For the environments and artifact platforms OBI currently documents as supported, see [SUPPORT_MATRIX.md](./SUPPORT_MATRIX.md).
 
+## Telemetry Schema
+
+OBI's emission contract is defined as a [Weaver](https://github.com/open-telemetry/weaver)-compatible schema registry under [schemas/obi/](./schemas/obi/).
+
+It extends the upstream [OpenTelemetry semantic conventions](https://github.com/open-telemetry/semantic-conventions) registry with the metrics, spans, and attributes OBI emits that are not covered upstream.
+
 ## How to start developing
 
 Requirements:

--- a/internal/test/integration/docker-compose-python-redis.yml
+++ b/internal/test/integration/docker-compose-python-redis.yml
@@ -88,10 +88,13 @@ services:
     command:
       - registry
       - live-check
-      # Semconv version is set via SEMCONV_VERSION env var from the test code
-      # (derived from go.opentelemetry.io/otel/semconv).
+      # OBI's own schema registry. The manifest at the root pins the upstream
+      # semconv dependency (currently v1.38.0). Bump in lockstep with the Go
+      # `go.opentelemetry.io/otel/semconv/...` import — guarded by
+      # TestSemconvVersionMatchesManifest.
       - --registry
-      - https://github.com/open-telemetry/semantic-conventions.git@v${SEMCONV_VERSION}[model]
+      - /obi-registry
+      - --include-unreferenced
       - --inactivity-timeout
       - "300"
       - --admin-port
@@ -101,6 +104,8 @@ services:
       - --diagnostic-format
       - json
       - --no-stream
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
     ports:
       - "4320:4320" # admin port (for /stop from test host)
     healthcheck:

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -557,8 +557,7 @@ func TestSuite_PythonRedis(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-redis.yml", path.Join(pathOutput, "test-suite-python-redis.log"))
 	require.NoError(t, err)
 
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`,
-		`SEMCONV_VERSION=`+SemconvVersion())
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, compose.Up())
 	t.Run("Python Redis metrics", testREDMetricsPythonRedisOnly)
 	runWeaverValidation(t)

--- a/internal/test/integration/weaver.go
+++ b/internal/test/integration/weaver.go
@@ -30,11 +30,28 @@ const (
 
 // weaverIgnoredSignals is an escape hatch for advice we explicitly suppress
 // without declaring the underlying signal in the OBI registry. Most non-semconv
-// emissions (Prometheus `target_info`, Grafana spanmetrics, Grafana service
-// graph, OBI-internal markers) are now declared in `schemas/obi/` and validated
+// emissions (Prometheus `target_info`, OTel-contrib spanmetrics / service-graph
+// shape, OBI-internal markers) are declared in `schemas/obi/` and validated
 // against by weaver, so this map is normally empty. Add entries here only as a
 // short-lived bridge while a registry update is in flight.
 var weaverIgnoredSignals = map[string]struct{}{}
+
+// weaverIgnoredAdviceMessages suppresses specific advice messages that match
+// known structural tensions weaver reports against the registry as a whole
+// rather than against any one signal. Today this only covers the `server` /
+// `client` namespace collision: the OTel collector-contrib `servicegraphconnector`
+// emits bare `server` / `client` labels (matched in `service_graph.yaml`), but
+// upstream semconv reserves `server.*` / `client.*` as namespace prefixes
+// (`server.address`, `server.port`, …). Weaver's lint flags the registry-level
+// collision on every signal that touches an upstream `server.*` / `client.*`
+// attribute, even ones that don't use the bare label. The contract OBI emits
+// is fixed by the connector convention; the ignore documents the tension.
+var weaverIgnoredAdviceMessages = map[string]struct{}{
+	"Namespace 'server' collides with existing attribute 'server.address'": {},
+	"Namespace 'server' collides with existing attribute 'server.port'":    {},
+	"Namespace 'client' collides with existing attribute 'client.address'": {},
+	"Namespace 'client' collides with existing attribute 'client.port'":    {},
+}
 
 func SemconvVersion() string {
 	// semconv.SchemaURL is "https://opentelemetry.io/schemas/1.38.0"
@@ -170,10 +187,15 @@ func validateWeaverReport(t *testing.T, report *weaverReport) {
 	t.Logf("  advisory details:")
 	for _, level := range []string{"violation", "improvement", "information"} {
 		for msg, count := range stats.AdviceMessageCounts {
+			_, msgIgnored := weaverIgnoredAdviceMessages[msg]
 			info := adviceByMsg[msg]
 			if info == nil {
-				t.Logf("    [%s] [%dx] %s (signals: unknown)", level, count, msg)
-				if level == "violation" {
+				suffix := ""
+				if msgIgnored {
+					suffix = " [ignored]"
+				}
+				t.Logf("    [%s] [%dx] %s (signals: unknown)%s", level, count, msg, suffix)
+				if level == "violation" && !msgIgnored {
 					actionableViolations += count
 				}
 				continue
@@ -182,7 +204,7 @@ func validateWeaverReport(t *testing.T, report *weaverReport) {
 				continue
 			}
 			signals := sortedSignals(info.Signals)
-			ignored := allSignalsIgnored(info.Signals)
+			ignored := msgIgnored || allSignalsIgnored(info.Signals)
 			suffix := ""
 			if ignored {
 				suffix = " [ignored]"

--- a/internal/test/integration/weaver.go
+++ b/internal/test/integration/weaver.go
@@ -190,12 +190,16 @@ func validateWeaverReport(t *testing.T, report *weaverReport) {
 			_, msgIgnored := weaverIgnoredAdviceMessages[msg]
 			info := adviceByMsg[msg]
 			if info == nil {
+				if level != "violation" {
+					continue
+				}
+
 				suffix := ""
 				if msgIgnored {
 					suffix = " [ignored]"
 				}
 				t.Logf("    [%s] [%dx] %s (signals: unknown)%s", level, count, msg, suffix)
-				if level == "violation" && !msgIgnored {
+				if !msgIgnored {
 					actionableViolations += count
 				}
 				continue

--- a/internal/test/integration/weaver.go
+++ b/internal/test/integration/weaver.go
@@ -28,15 +28,13 @@ const (
 	weaverTimeout   = 2 * time.Minute
 )
 
-// weaverIgnoredSignals lists signals whose violations are expected and should
-// not cause the test to fail. target_info is a Prometheus/OpenMetrics convention
-// (with Prometheus-style instance/job attributes) that is not part of the OTel
-// semantic conventions registry.
-// TODO: replace with custom override / filter once
-// https://github.com/open-telemetry/weaver/pull/1256 is merged.
-var weaverIgnoredSignals = map[string]struct{}{
-	"metric:target_info": {},
-}
+// weaverIgnoredSignals is an escape hatch for advice we explicitly suppress
+// without declaring the underlying signal in the OBI registry. Most non-semconv
+// emissions (Prometheus `target_info`, Grafana spanmetrics, Grafana service
+// graph, OBI-internal markers) are now declared in `schemas/obi/` and validated
+// against by weaver, so this map is normally empty. Add entries here only as a
+// short-lived bridge while a registry update is in flight.
+var weaverIgnoredSignals = map[string]struct{}{}
 
 func SemconvVersion() string {
 	// semconv.SchemaURL is "https://opentelemetry.io/schemas/1.38.0"

--- a/internal/test/integration/weaver_test.go
+++ b/internal/test/integration/weaver_test.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// TestSemconvVersionMatchesManifest guards against drift between the Go-side
+// semconv import and the upstream-semconv dependency pinned in the OBI
+// schema registry's manifest. The two MUST move together — bumping the Go
+// import without updating `schemas/obi/manifest.yaml` (or vice versa) would
+// cause weaver to validate emissions against the wrong version of the
+// upstream registry.
+func TestSemconvVersionMatchesManifest(t *testing.T) {
+	manifestPath := filepath.Join("..", "..", "..", "schemas", "obi", "manifest.yaml")
+	raw, err := os.ReadFile(manifestPath)
+	require.NoError(t, err, "failed to read %s", manifestPath)
+
+	var manifest struct {
+		Dependencies []struct {
+			SchemaURL    string `yaml:"schema_url"`
+			RegistryPath string `yaml:"registry_path"`
+		} `yaml:"dependencies"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &manifest), "failed to parse manifest YAML")
+	require.NotEmpty(t, manifest.Dependencies, "manifest has no dependencies entry")
+
+	dep := manifest.Dependencies[0]
+
+	// The schema_url ends with `/<version>`; extract that segment.
+	manifestSemconvVersion := dep.SchemaURL[strings.LastIndex(dep.SchemaURL, "/")+1:]
+
+	require.Equal(t, SemconvVersion(), manifestSemconvVersion,
+		"go.opentelemetry.io/otel/semconv version (%s) does not match "+
+			"schemas/obi/manifest.yaml dependencies[0].schema_url version (%s); "+
+			"bump them together",
+		SemconvVersion(), manifestSemconvVersion)
+
+	// The registry_path also embeds the version; sanity-check it matches.
+	expectedRefspec := "@v" + manifestSemconvVersion
+	require.Contains(t, dep.RegistryPath, expectedRefspec,
+		"manifest dependencies[0].registry_path (%s) does not pin %s",
+		dep.RegistryPath, expectedRefspec)
+}

--- a/internal/test/integration/weaver_test.go
+++ b/internal/test/integration/weaver_test.go
@@ -13,6 +13,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// upstreamSemconvSchemaURLPrefix uniquely identifies the upstream OpenTelemetry
+// semantic conventions registry among `schemas/obi/manifest.yaml` dependencies.
+const upstreamSemconvSchemaURLPrefix = "https://opentelemetry.io/schemas/"
+
 // TestSemconvVersionMatchesManifest guards against drift between the Go-side
 // semconv import and the upstream-semconv dependency pinned in the OBI
 // schema registry's manifest. The two MUST move together — bumping the Go
@@ -33,20 +37,33 @@ func TestSemconvVersionMatchesManifest(t *testing.T) {
 	require.NoError(t, yaml.Unmarshal(raw, &manifest), "failed to parse manifest YAML")
 	require.NotEmpty(t, manifest.Dependencies, "manifest has no dependencies entry")
 
-	dep := manifest.Dependencies[0]
+	// Locate the upstream semconv dependency by schema_url prefix rather than
+	// assuming a position in the list — keeps the test robust if other
+	// registries get added as dependencies later.
+	depIdx := -1
+	for i, d := range manifest.Dependencies {
+		if strings.HasPrefix(d.SchemaURL, upstreamSemconvSchemaURLPrefix) {
+			depIdx = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, depIdx,
+		"manifest dependencies do not contain an upstream semconv entry "+
+			"(no schema_url with prefix %q)", upstreamSemconvSchemaURLPrefix)
+	dep := manifest.Dependencies[depIdx]
 
 	// The schema_url ends with `/<version>`; extract that segment.
 	manifestSemconvVersion := dep.SchemaURL[strings.LastIndex(dep.SchemaURL, "/")+1:]
 
 	require.Equal(t, SemconvVersion(), manifestSemconvVersion,
 		"go.opentelemetry.io/otel/semconv version (%s) does not match "+
-			"schemas/obi/manifest.yaml dependencies[0].schema_url version (%s); "+
-			"bump them together",
+			"the upstream semconv schema_url version pinned in "+
+			"schemas/obi/manifest.yaml (%s); bump them together",
 		SemconvVersion(), manifestSemconvVersion)
 
 	// The registry_path also embeds the version; sanity-check it matches.
 	expectedRefspec := "@v" + manifestSemconvVersion
 	require.Contains(t, dep.RegistryPath, expectedRefspec,
-		"manifest dependencies[0].registry_path (%s) does not pin %s",
+		"manifest semconv dependency registry_path (%s) does not pin %s",
 		dep.RegistryPath, expectedRefspec)
 }

--- a/schemas/obi/groups/internal_spans.yaml
+++ b/schemas/obi/groups/internal_spans.yaml
@@ -1,10 +1,9 @@
 groups:
   # OBI synthesises a pair of internal child spans under every accepted
   # server-side request span to surface the queue-time vs processing-time
-  # split of the request. Both are emitted by `createSubSpans` in
-  # `pkg/export/otel/tracesgen/tracesgen.go`. They carry no custom attributes
-  # — only the standard span fields (name, kind, parent, timing) — so they
-  # are documented here purely to anchor OBI's emission contract.
+  # split of the request. They carry no custom attributes — only the
+  # standard span fields (name, kind, parent, timing) — so they are
+  # documented here purely to anchor OBI's emission contract.
 
   - id: span.obi.in_queue
     type: span
@@ -23,7 +22,5 @@ groups:
     brief: >
       Internal child span representing the time between when request
       processing started and when the response was sent. Span name is the
-      literal string `processing`. Parent is the originating server span;
-      the span ID is reused from the upstream span when valid, otherwise
-      generated.
+      literal string `processing`. Parent is the originating server span.
     attributes: []

--- a/schemas/obi/groups/internal_spans.yaml
+++ b/schemas/obi/groups/internal_spans.yaml
@@ -1,0 +1,29 @@
+groups:
+  # OBI synthesises a pair of internal child spans under every accepted
+  # server-side request span to surface the queue-time vs processing-time
+  # split of the request. Both are emitted by `createSubSpans` in
+  # `pkg/export/otel/tracesgen/tracesgen.go`. They carry no custom attributes
+  # — only the standard span fields (name, kind, parent, timing) — so they
+  # are documented here purely to anchor OBI's emission contract.
+
+  - id: span.obi.in_queue
+    type: span
+    span_kind: internal
+    stability: development
+    brief: >
+      Internal child span representing the time between when a request was
+      received by the server and when its processing started. Span name is
+      the literal string `in queue`. Parent is the originating server span.
+    attributes: []
+
+  - id: span.obi.processing
+    type: span
+    span_kind: internal
+    stability: development
+    brief: >
+      Internal child span representing the time between when request
+      processing started and when the response was sent. Span name is the
+      literal string `processing`. Parent is the originating server span;
+      the span ID is reused from the upstream span when valid, otherwise
+      generated.
+    attributes: []

--- a/schemas/obi/groups/obi_internal.yaml
+++ b/schemas/obi/groups/obi_internal.yaml
@@ -1,0 +1,119 @@
+groups:
+  - id: registry.obi
+    type: attribute_group
+    display_name: OBI Internal Telemetry
+    brief: >
+      OBI's own meta-telemetry: the `target_info` / `host_info` family of
+      Prometheus-style and OBI-invented per-target meta-metrics that
+      identify the instrumenter and the resource it is running against,
+      together with the labels they carry and any deviations from upstream
+      semconv that are tracked for removal. Distinct from OBI's emissions
+      that describe the *instrumented application's* behaviour
+      (HTTP / DB / messaging / spanmetrics / service-graph), which live in
+      sibling files or in upstream semconv.
+    attributes:
+      - id: source
+        type: string
+        stability: development
+        brief: >
+          Identifier of the vendor / SDK that produced the metric. OBI sets
+          this to its `VendorPrefix` (currently `obi`). Used by the
+          spanmetrics and service-graph emissions to disambiguate from
+          collector-contrib connector output. See
+          `pkg/export/attributes/names/attrs.go` (`Source`) and
+          `request.SourceMetric`.
+        examples: [ "obi" ]
+      - id: cloud.host.id
+        type: string
+        stability: development
+        brief: >
+          Cloud-provider host identifier, attached to OBI's
+          `traces_host_info` meta-metric so dashboards can join trace
+          metrics back to per-host identity. Distinct from upstream
+          `host.id` (which is the OS-reported host identifier). Defined in
+          `pkg/export/otel/metrics.go` as `CloudHostIDKey`.
+      - id: instance
+        type: string
+        stability: development
+        brief: >
+          Scrape target instance label, originating from the Prometheus /
+          OpenMetrics convention. Carried on `target_info` and on every
+          series exported via OBI's Prometheus exporter.
+        examples: ["host.local:9090"]
+      - id: job
+        type: string
+        stability: development
+        brief: >
+          Scrape target job label, originating from the Prometheus /
+          OpenMetrics convention. Carried on `target_info` and on every
+          series exported via OBI's Prometheus exporter.
+        examples: ["my-service"]
+
+  # Source: pkg/export/otel/metrics.go (constant `TargetInfo`).
+  - id: metric.target_info
+    type: metric
+    metric_name: target_info
+    instrument: gauge
+    unit: "1"
+    stability: development
+    brief: >
+      `target_info` meta-metric in the Prometheus / OpenMetrics style.
+      Emitted with value 1 to carry the resource attributes of the
+      originating service.
+    attributes:
+      - ref: instance
+      - ref: job
+
+  # Source: pkg/export/otel/metrics.go (constants `TracesTargetInfo`,
+  # `setupTracesTargetInfo` / `createTracesTargetInfo`). Same `target_info`
+  # pattern as the metrics-pipeline series above, applied to the traces
+  # pipeline so dashboards joining trace metrics back to service identity
+  # have the equivalent meta-metric. Only emitted when any span-metrics
+  # feature (`application_span` or `application_service_graph`) is enabled
+  # — see the `Features.AnySpanMetrics()` gate in `createTracesTargetInfo`.
+  - id: metric.traces_target_info
+    type: metric
+    metric_name: traces_target_info
+    instrument: updowncounter
+    unit: "1"
+    stability: development
+    brief: >
+      OBI counterpart of `target_info` for the traces pipeline. Carries the
+      resource attribute set of every traced service so dashboards can
+      join trace metrics back to service identity.
+    attributes:
+      - ref: source
+
+  # Source: pkg/export/otel/metrics.go (constant `TracesHostInfo`,
+  # `setupHostInfoMeter`). OBI-invented per-host meta-metric — there is no
+  # upstream / collector-contrib analogue — so it lives next to the
+  # `cloud.host.id` attribute it carries.
+  - id: metric.traces_host_info
+    type: metric
+    metric_name: traces_host_info
+    instrument: gauge
+    unit: "1"
+    stability: development
+    brief: >
+      OBI per-host meta-metric carrying the cloud host identifier so
+      dashboards can join trace metrics back to host / instance identity.
+    attributes:
+      - ref: cloud.host.id
+        requirement_level: opt_in
+
+  # OBI deviation from upstream semconv: we currently emit `rpc.server.duration`
+  # in seconds while semconv == 1.38 specifies milliseconds. This declaration
+  # produces a duplicate-id / duplicate-metric-name warning during
+  # `weaver registry check` (because the upstream registry also defines this
+  # metric). The warning is non-fatal; it documents the deviation explicitly.
+  # TODO: drop this group once we update semconv to > 1.4.0
+  - id: metric.rpc.server.duration
+    type: metric
+    metric_name: rpc.server.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    brief: >
+      OBI deviation: rpc.server.duration is emitted in seconds rather than
+      the milliseconds specified by upstream semconv. Tracked for removal.
+    attributes: [ ]

--- a/schemas/obi/groups/obi_internal.yaml
+++ b/schemas/obi/groups/obi_internal.yaml
@@ -17,11 +17,9 @@ groups:
         stability: development
         brief: >
           Identifier of the vendor / SDK that produced the metric. OBI sets
-          this to its `VendorPrefix` (currently `obi`). Used by the
-          spanmetrics and service-graph emissions to disambiguate from
-          collector-contrib connector output. See
-          `pkg/export/attributes/names/attrs.go` (`Source`) and
-          `request.SourceMetric`.
+          this to `obi`. Used by the spanmetrics and service-graph
+          emissions to disambiguate from collector-contrib connector
+          output.
         examples: [ "obi" ]
       - id: instance
         type: string
@@ -40,11 +38,9 @@ groups:
           series exported via OBI's Prometheus exporter.
         examples: ["my-service"]
 
-  # Source: pkg/export/otel/metrics.go (constant `TargetInfo`,
-  # `setupTargetInfo`). Emitted as `meter.Int64UpDownCounter(TargetInfo)`
-  # with no unit set; the registry mirrors that exact shape rather than
-  # the OTel-canonical `gauge` / `unit: "1"` Prometheus mapping so weaver
-  # validates against what OBI actually emits.
+  # The instrument and (empty) unit declared here mirror what OBI currently
+  # emits over OTLP rather than the OTel-canonical `gauge` / `unit: "1"`
+  # Prometheus mapping, so weaver validates against the actual contract.
   - id: metric.target_info
     type: metric
     metric_name: target_info
@@ -59,15 +55,10 @@ groups:
       - ref: instance
       - ref: job
 
-  # Source: pkg/export/otel/metrics.go (constants `TracesTargetInfo`,
-  # `setupTracesTargetInfo` / `createTracesTargetInfo`). Same `target_info`
-  # pattern as the metrics-pipeline series above, applied to the traces
-  # pipeline so dashboards joining trace metrics back to service identity
-  # have the equivalent meta-metric. Only emitted when any span-metrics
-  # feature is enabled — see the `Features.AnySpanMetrics()` gate in
-  # `createTracesTargetInfo` (the gate covers `application_span`,
-  # `application_span_otel`, and `application_span_sizes` but NOT
-  # `application_service_graph`).
+  # The trace-pipeline counterpart of `target_info`. Only emitted when any
+  # span-metrics feature is enabled — i.e. one of `application_span`,
+  # `application_span_otel`, or `application_span_sizes` (the
+  # `application_service_graph` feature does NOT trigger it).
   - id: metric.traces_target_info
     type: metric
     metric_name: traces_target_info
@@ -81,10 +72,8 @@ groups:
     attributes:
       - ref: source
 
-  # Source: pkg/export/otel/metrics.go (constant `TracesHostInfo`,
-  # `setupHostInfoMeter`). OBI-invented per-host meta-metric — there is no
-  # upstream / collector-contrib analogue. Emitted as `meter.Int64Gauge`
-  # with no unit set. The carried attribute key is upstream `host.id`
+  # OBI-invented per-host meta-metric — there is no upstream /
+  # collector-contrib analogue. Carries the upstream `host.id` attribute.
   - id: metric.traces_host_info
     type: metric
     metric_name: traces_host_info

--- a/schemas/obi/groups/obi_internal.yaml
+++ b/schemas/obi/groups/obi_internal.yaml
@@ -23,15 +23,6 @@ groups:
           `pkg/export/attributes/names/attrs.go` (`Source`) and
           `request.SourceMetric`.
         examples: [ "obi" ]
-      - id: cloud.host.id
-        type: string
-        stability: development
-        brief: >
-          Cloud-provider host identifier, attached to OBI's
-          `traces_host_info` meta-metric so dashboards can join trace
-          metrics back to per-host identity. Distinct from upstream
-          `host.id` (which is the OS-reported host identifier). Defined in
-          `pkg/export/otel/metrics.go` as `CloudHostIDKey`.
       - id: instance
         type: string
         stability: development
@@ -73,8 +64,10 @@ groups:
   # pattern as the metrics-pipeline series above, applied to the traces
   # pipeline so dashboards joining trace metrics back to service identity
   # have the equivalent meta-metric. Only emitted when any span-metrics
-  # feature (`application_span` or `application_service_graph`) is enabled
-  # — see the `Features.AnySpanMetrics()` gate in `createTracesTargetInfo`.
+  # feature is enabled — see the `Features.AnySpanMetrics()` gate in
+  # `createTracesTargetInfo` (the gate covers `application_span`,
+  # `application_span_otel`, and `application_span_sizes` but NOT
+  # `application_service_graph`).
   - id: metric.traces_target_info
     type: metric
     metric_name: traces_target_info
@@ -90,9 +83,8 @@ groups:
 
   # Source: pkg/export/otel/metrics.go (constant `TracesHostInfo`,
   # `setupHostInfoMeter`). OBI-invented per-host meta-metric — there is no
-  # upstream / collector-contrib analogue — so it lives next to the
-  # `cloud.host.id` attribute it carries. Emitted as `meter.Int64Gauge`
-  # with no unit set.
+  # upstream / collector-contrib analogue. Emitted as `meter.Int64Gauge`
+  # with no unit set. The carried attribute key is upstream `host.id`
   - id: metric.traces_host_info
     type: metric
     metric_name: traces_host_info
@@ -100,10 +92,10 @@ groups:
     unit: ""
     stability: development
     brief: >
-      OBI per-host meta-metric carrying the cloud host identifier so
-      dashboards can join trace metrics back to host / instance identity.
+      OBI per-host meta-metric carrying the host identifier so dashboards
+      can join trace metrics back to host / instance identity.
     attributes:
-      - ref: cloud.host.id
+      - ref: host.id
         requirement_level: opt_in
 
   # OBI deviation from upstream semconv: we currently emit `rpc.server.duration`
@@ -111,7 +103,9 @@ groups:
   # produces a duplicate-id / duplicate-metric-name warning during
   # `weaver registry check` (because the upstream registry also defines this
   # metric). The warning is non-fatal; it documents the deviation explicitly.
-  # TODO: drop this group once we update semconv to > 1.4.0
+  # TODO: drop this group once OBI emits `rpc.server.duration` in
+  # milliseconds (matching the semconv >= 1.38 unit specification — likely
+  # in lockstep with bumping the manifest's pinned semconv to >= 1.40.0).
   - id: metric.rpc.server.duration
     type: metric
     metric_name: rpc.server.duration

--- a/schemas/obi/groups/obi_internal.yaml
+++ b/schemas/obi/groups/obi_internal.yaml
@@ -49,12 +49,16 @@ groups:
           series exported via OBI's Prometheus exporter.
         examples: ["my-service"]
 
-  # Source: pkg/export/otel/metrics.go (constant `TargetInfo`).
+  # Source: pkg/export/otel/metrics.go (constant `TargetInfo`,
+  # `setupTargetInfo`). Emitted as `meter.Int64UpDownCounter(TargetInfo)`
+  # with no unit set; the registry mirrors that exact shape rather than
+  # the OTel-canonical `gauge` / `unit: "1"` Prometheus mapping so weaver
+  # validates against what OBI actually emits.
   - id: metric.target_info
     type: metric
     metric_name: target_info
-    instrument: gauge
-    unit: "1"
+    instrument: updowncounter
+    unit: ""
     stability: development
     brief: >
       `target_info` meta-metric in the Prometheus / OpenMetrics style.
@@ -75,7 +79,7 @@ groups:
     type: metric
     metric_name: traces_target_info
     instrument: updowncounter
-    unit: "1"
+    unit: ""
     stability: development
     brief: >
       OBI counterpart of `target_info` for the traces pipeline. Carries the
@@ -87,12 +91,13 @@ groups:
   # Source: pkg/export/otel/metrics.go (constant `TracesHostInfo`,
   # `setupHostInfoMeter`). OBI-invented per-host meta-metric — there is no
   # upstream / collector-contrib analogue — so it lives next to the
-  # `cloud.host.id` attribute it carries.
+  # `cloud.host.id` attribute it carries. Emitted as `meter.Int64Gauge`
+  # with no unit set.
   - id: metric.traces_host_info
     type: metric
     metric_name: traces_host_info
     instrument: gauge
-    unit: "1"
+    unit: ""
     stability: development
     brief: >
       OBI per-host meta-metric carrying the cloud host identifier so

--- a/schemas/obi/groups/service_graph.yaml
+++ b/schemas/obi/groups/service_graph.yaml
@@ -1,0 +1,131 @@
+groups:
+  - id: registry.obi.service_graph
+    type: attribute_group
+    display_name: Service Graph
+    brief: >
+      Attributes used by OBI's service-graph emission. The metric names and
+      label set match the output of the OTel collector-contrib
+      `servicegraphconnector` so the same dashboards consume both
+      OBI-emitted and connector-emitted data. Emitted when OBI's
+      `application_service_graph` metrics feature is enabled.
+
+      The OBI-specific `source` attribute is declared in `obi_internal.yaml`.
+
+      See:
+      https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/servicegraphconnector
+    attributes:
+      - id: server
+        type: string
+        stability: development
+        brief: Name of the service receiving the request.
+        examples: ["users-api"]
+      - id: client
+        type: string
+        stability: development
+        brief: Name of the service initiating the request.
+        examples: ["frontend"]
+      - id: connection_type
+        type:
+          allow_custom_values: true
+          members:
+            - id: messaging_system
+              value: messaging_system
+              stability: development
+            - id: database
+              value: database
+              stability: development
+            - id: virtual_node
+              value: virtual_node
+              stability: development
+        stability: development
+        brief: >
+          The connection type between the two services (mirroring the
+          servicegraphconnector values). Empty string represents a direct
+          HTTP/gRPC request.
+      - id: server_service_namespace
+        type: string
+        stability: development
+        brief: >
+          The service namespace of the server side. Equivalent to the
+          `service.namespace`-prefixed dimension defined by
+          `servicegraphconnector` when `service.namespace` is added to the
+          connector's `dimensions` list.
+        examples: ["integration-test"]
+      - id: client_service_namespace
+        type: string
+        stability: development
+        brief: >
+          The service namespace of the client side. Equivalent to the
+          `service.namespace`-prefixed dimension defined by
+          `servicegraphconnector` when `service.namespace` is added to the
+          connector's `dimensions` list.
+        examples: ["integration-test"]
+
+  # Source: pkg/export/otel/metrics_svc_graph.go (constant `ServiceGraphTotal`).
+  - id: metric.traces_service_graph_request_total
+    type: metric
+    metric_name: traces_service_graph_request_total
+    instrument: counter
+    unit: "1"
+    stability: development
+    brief: >
+      Total number of edges in the service graph, grouped by client / server.
+    attributes:
+      - ref: client
+      - ref: server
+      - ref: connection_type
+      - ref: client_service_namespace
+      - ref: server_service_namespace
+      - ref: source
+
+  # Source: pkg/export/otel/metrics_svc_graph.go (constant `ServiceGraphFailed`).
+  - id: metric.traces_service_graph_request_failed_total
+    type: metric
+    metric_name: traces_service_graph_request_failed_total
+    instrument: counter
+    unit: "1"
+    stability: development
+    brief: >
+      Total number of failed edges in the service graph, grouped by
+      client / server.
+    attributes:
+      - ref: client
+      - ref: server
+      - ref: connection_type
+      - ref: client_service_namespace
+      - ref: server_service_namespace
+      - ref: source
+
+  # Source: pkg/export/otel/metrics_svc_graph.go (constant `ServiceGraphServer`).
+  - id: metric.traces_service_graph_request_server
+    type: metric
+    metric_name: traces_service_graph_request_server
+    instrument: histogram
+    unit: "s"
+    stability: development
+    brief: >
+      Server-side request duration distribution per service-graph edge.
+    attributes:
+      - ref: client
+      - ref: server
+      - ref: connection_type
+      - ref: client_service_namespace
+      - ref: server_service_namespace
+      - ref: source
+
+  # Source: pkg/export/otel/metrics_svc_graph.go (constant `ServiceGraphClient`).
+  - id: metric.traces_service_graph_request_client
+    type: metric
+    metric_name: traces_service_graph_request_client
+    instrument: histogram
+    unit: "s"
+    stability: development
+    brief: >
+      Client-side request duration distribution per service-graph edge.
+    attributes:
+      - ref: client
+      - ref: server
+      - ref: connection_type
+      - ref: client_service_namespace
+      - ref: server_service_namespace
+      - ref: source

--- a/schemas/obi/groups/service_graph.yaml
+++ b/schemas/obi/groups/service_graph.yaml
@@ -61,7 +61,6 @@ groups:
           connector's `dimensions` list.
         examples: ["integration-test"]
 
-  # Source: pkg/export/otel/metrics_svc_graph.go (constant `ServiceGraphTotal`).
   - id: metric.traces_service_graph_request_total
     type: metric
     metric_name: traces_service_graph_request_total
@@ -78,7 +77,6 @@ groups:
       - ref: server_service_namespace
       - ref: source
 
-  # Source: pkg/export/otel/metrics_svc_graph.go (constant `ServiceGraphFailed`).
   - id: metric.traces_service_graph_request_failed_total
     type: metric
     metric_name: traces_service_graph_request_failed_total
@@ -96,7 +94,6 @@ groups:
       - ref: server_service_namespace
       - ref: source
 
-  # Source: pkg/export/otel/metrics_svc_graph.go (constant `ServiceGraphServer`).
   - id: metric.traces_service_graph_request_server
     type: metric
     metric_name: traces_service_graph_request_server
@@ -113,7 +110,6 @@ groups:
       - ref: server_service_namespace
       - ref: source
 
-  # Source: pkg/export/otel/metrics_svc_graph.go (constant `ServiceGraphClient`).
   - id: metric.traces_service_graph_request_client
     type: metric
     metric_name: traces_service_graph_request_client

--- a/schemas/obi/groups/spanmetrics.yaml
+++ b/schemas/obi/groups/spanmetrics.yaml
@@ -24,8 +24,7 @@ groups:
           Hint set on a span by the producer to tell downstream span-metrics
           processors that this span is already accounted for in upstream
           span-metrics emissions and should be excluded from aggregation,
-          to avoid double counting. Defined in
-          `pkg/export/attributes/names/attrs.go` as `SkipSpanMetrics`.
+          to avoid double counting.
       - id: span.name
         type: string
         stability: development
@@ -68,8 +67,6 @@ groups:
         stability: development
         brief: The span status code, mirrored from the originating span.
 
-  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsCallsOTel`,
-  # selected by `spanMetricsCallsName()` when not in legacy mode).
   - id: metric.traces_span_metrics_calls_total
     type: metric
     metric_name: traces_span_metrics_calls_total
@@ -84,9 +81,6 @@ groups:
       - ref: status.code
       - ref: source
 
-  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsLatencyOTel`,
-  # selected by `spanMetricsLatencyName()` when not in legacy mode). Unit
-  # `s` is set explicitly via `instrument.WithUnit("s")` on the histogram.
   - id: metric.traces_span_metrics_duration
     type: metric
     metric_name: traces_span_metrics_duration

--- a/schemas/obi/groups/spanmetrics.yaml
+++ b/schemas/obi/groups/spanmetrics.yaml
@@ -4,11 +4,9 @@ groups:
     display_name: Span Metrics
     brief: >
       Attributes used by OBI's span-metrics emission. The metric names match
-      the legacy output of the OTel collector-contrib `spanmetricsconnector`
-      (i.e. `_total` suffix on counters, `latency` rather than `duration`)
-      under the `traces.spanmetrics` namespace, so the same dashboards
-      consume both OBI-emitted and connector-emitted data. Emitted when
-      OBI's `application_span` metrics feature is enabled.
+      the output of the OTel collector-contrib `spanmetricsconnector` so the
+      same dashboards consume both OBI-emitted and connector-emitted data.
+      Emitted when OBI's `application_span_otel` metrics feature is enabled.
 
       Per-metric resource attributes (`service.name`, `service.namespace`,
       `service.instance.id`, `host.id`, `telemetry.sdk.language`, etc.) come
@@ -70,10 +68,11 @@ groups:
         stability: development
         brief: The span status code, mirrored from the originating span.
 
-  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsCalls`).
-  - id: metric.traces_spanmetrics_calls_total
+  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsCallsOTel`,
+  # selected by `spanMetricsCallsName()` when not in legacy mode).
+  - id: metric.traces_span_metrics_calls_total
     type: metric
-    metric_name: traces_spanmetrics_calls_total
+    metric_name: traces_span_metrics_calls_total
     instrument: counter
     unit: "1"
     stability: development
@@ -85,51 +84,20 @@ groups:
       - ref: status.code
       - ref: source
 
-  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsLatency`).
-  - id: metric.traces_spanmetrics_latency
+  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsLatencyOTel`,
+  # selected by `spanMetricsLatencyName()` when not in legacy mode). Unit
+  # `s` is set explicitly via `instrument.WithUnit("s")` on the histogram.
+  - id: metric.traces_span_metrics_duration
     type: metric
-    metric_name: traces_spanmetrics_latency
+    metric_name: traces_span_metrics_duration
     instrument: histogram
     unit: "s"
     stability: development
     brief: >
-      Latency distribution for observed spans, grouped by span name / kind /
-      status.
+      Duration distribution for observed spans, grouped by span name / kind
+      / status.
     attributes:
       - ref: span.name
       - ref: span.kind
       - ref: status.code
       - ref: source
-
-  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsRequestSizes`).
-  - id: metric.traces_spanmetrics_size_total
-    type: metric
-    metric_name: traces_spanmetrics_size_total
-    instrument: counter
-    unit: "By"
-    stability: development
-    brief: >
-      Total size in bytes of request payloads observed, grouped by span name
-      / kind / status.
-    attributes:
-      - ref: span.name
-      - ref: span.kind
-      - ref: status.code
-      - ref: source
-
-  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsResponseSizes`).
-  - id: metric.traces_spanmetrics_response_size_total
-    type: metric
-    metric_name: traces_spanmetrics_response_size_total
-    instrument: counter
-    unit: "By"
-    stability: development
-    brief: >
-      Total size in bytes of response payloads observed, grouped by span
-      name / kind / status.
-    attributes:
-      - ref: span.name
-      - ref: span.kind
-      - ref: status.code
-      - ref: source
-

--- a/schemas/obi/groups/spanmetrics.yaml
+++ b/schemas/obi/groups/spanmetrics.yaml
@@ -1,0 +1,135 @@
+groups:
+  - id: registry.obi.spanmetrics
+    type: attribute_group
+    display_name: Span Metrics
+    brief: >
+      Attributes used by OBI's span-metrics emission. The metric names match
+      the legacy output of the OTel collector-contrib `spanmetricsconnector`
+      (i.e. `_total` suffix on counters, `latency` rather than `duration`)
+      under the `traces.spanmetrics` namespace, so the same dashboards
+      consume both OBI-emitted and connector-emitted data. Emitted when
+      OBI's `application_span` metrics feature is enabled.
+
+      Per-metric resource attributes (`service.name`, `service.namespace`,
+      `service.instance.id`, `host.id`, `telemetry.sdk.language`, etc.) come
+      from upstream OpenTelemetry semantic conventions and are not
+      redeclared here. The OBI-specific `source` attribute is declared in
+      `obi_internal.yaml`.
+
+      See:
+      https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector
+    attributes:
+      - id: span.metrics.skip
+        type: boolean
+        stability: development
+        brief: >
+          Hint set on a span by the producer to tell downstream span-metrics
+          processors that this span is already accounted for in upstream
+          span-metrics emissions and should be excluded from aggregation,
+          to avoid double counting. Defined in
+          `pkg/export/attributes/names/attrs.go` as `SkipSpanMetrics`.
+      - id: span.name
+        type: string
+        stability: development
+        brief: The span name (matches the OTLP span name field).
+        examples: ["GET /api/users"]
+      - id: span.kind
+        type:
+          allow_custom_values: true
+          members:
+            - id: server
+              value: SPAN_KIND_SERVER
+              stability: development
+            - id: client
+              value: SPAN_KIND_CLIENT
+              stability: development
+            - id: producer
+              value: SPAN_KIND_PRODUCER
+              stability: development
+            - id: consumer
+              value: SPAN_KIND_CONSUMER
+              stability: development
+            - id: internal
+              value: SPAN_KIND_INTERNAL
+              stability: development
+        stability: development
+        brief: The span kind, mirrored from the originating span.
+      - id: status.code
+        type:
+          allow_custom_values: true
+          members:
+            - id: ok
+              value: STATUS_CODE_OK
+              stability: development
+            - id: error
+              value: STATUS_CODE_ERROR
+              stability: development
+            - id: unset
+              value: STATUS_CODE_UNSET
+              stability: development
+        stability: development
+        brief: The span status code, mirrored from the originating span.
+
+  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsCalls`).
+  - id: metric.traces_spanmetrics_calls_total
+    type: metric
+    metric_name: traces_spanmetrics_calls_total
+    instrument: counter
+    unit: "1"
+    stability: development
+    brief: >
+      Total number of spans observed, grouped by span name / kind / status.
+    attributes:
+      - ref: span.name
+      - ref: span.kind
+      - ref: status.code
+      - ref: source
+
+  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsLatency`).
+  - id: metric.traces_spanmetrics_latency
+    type: metric
+    metric_name: traces_spanmetrics_latency
+    instrument: histogram
+    unit: "s"
+    stability: development
+    brief: >
+      Latency distribution for observed spans, grouped by span name / kind /
+      status.
+    attributes:
+      - ref: span.name
+      - ref: span.kind
+      - ref: status.code
+      - ref: source
+
+  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsRequestSizes`).
+  - id: metric.traces_spanmetrics_size_total
+    type: metric
+    metric_name: traces_spanmetrics_size_total
+    instrument: counter
+    unit: "By"
+    stability: development
+    brief: >
+      Total size in bytes of request payloads observed, grouped by span name
+      / kind / status.
+    attributes:
+      - ref: span.name
+      - ref: span.kind
+      - ref: status.code
+      - ref: source
+
+  # Source: pkg/export/otel/metrics.go (constant `SpanMetricsResponseSizes`).
+  - id: metric.traces_spanmetrics_response_size_total
+    type: metric
+    metric_name: traces_spanmetrics_response_size_total
+    instrument: counter
+    unit: "By"
+    stability: development
+    brief: >
+      Total size in bytes of response payloads observed, grouped by span
+      name / kind / status.
+    attributes:
+      - ref: span.name
+      - ref: span.kind
+      - ref: status.code
+      - ref: source
+

--- a/schemas/obi/manifest.yaml
+++ b/schemas/obi/manifest.yaml
@@ -20,9 +20,8 @@ description: |
   registry forms the complete contract of what OBI emits.
 stability: development
 dependencies:
-  # The dependency version MUST stay in sync with the Go semconv import in
-  # `internal/test/integration/weaver.go`. A unit test
-  # (`TestSemconvVersionMatchesManifest`) asserts both sides match — bump
-  # them together.
+  # The dependency version MUST stay in sync with the upstream
+  # OpenTelemetry semantic conventions version OBI is built against. A
+  # CI guard asserts both sides match — bump them together.
   - schema_url: https://opentelemetry.io/schemas/1.38.0
     registry_path: https://github.com/open-telemetry/semantic-conventions.git@v1.38.0[model]

--- a/schemas/obi/manifest.yaml
+++ b/schemas/obi/manifest.yaml
@@ -8,7 +8,9 @@ description: |
 
   - Prometheus / OpenMetrics conventions (`target_info`, `instance`, `job`)
   - Span metrics matching the OTel collector-contrib `spanmetricsconnector`
-    output (emitted when the `application_span` metrics feature is enabled)
+    output (emitted when the `application_span_otel` metrics feature is
+    enabled — this registry pins the OTel-canonical names; the legacy
+    `application_span` underscored variants are not declared here)
   - Service-graph metrics matching the OTel collector-contrib
     `servicegraphconnector` output (emitted when the
     `application_service_graph` metrics feature is enabled)

--- a/schemas/obi/manifest.yaml
+++ b/schemas/obi/manifest.yaml
@@ -1,0 +1,26 @@
+schema_url: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/schemas/0.1.0
+description: |
+  Schema registry for the OpenTelemetry eBPF instrumentation (OBI).
+
+  Extends the upstream OpenTelemetry semantic conventions registry with the
+  metrics and attributes that OBI emits in addition to (or as overrides of)
+  the standard semconv set:
+
+  - Prometheus / OpenMetrics conventions (`target_info`, `instance`, `job`)
+  - Span metrics matching the OTel collector-contrib `spanmetricsconnector`
+    output (emitted when the `application_span` metrics feature is enabled)
+  - Service-graph metrics matching the OTel collector-contrib
+    `servicegraphconnector` output (emitted when the
+    `application_service_graph` metrics feature is enabled)
+  - OBI-internal markers consumed by downstream processors
+
+  Together with the upstream registry referenced in `dependencies`, this
+  registry forms the complete contract of what OBI emits.
+stability: development
+dependencies:
+  # The dependency version MUST stay in sync with the Go semconv import in
+  # `internal/test/integration/weaver.go`. A unit test
+  # (`TestSemconvVersionMatchesManifest`) asserts both sides match — bump
+  # them together.
+  - schema_url: https://opentelemetry.io/schemas/1.38.0
+    registry_path: https://github.com/open-telemetry/semantic-conventions.git@v1.38.0[model]


### PR DESCRIPTION
## Summary

Add A telemetry schema registry to describe and validate OBI exported telemetry and validate against it in weaver tests (currently on redis integration test)
Related to https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1759

Had to ignore some specific warnings because of incompatibility between service graph labels (server, client) which are defined as namespaces in otel semantic convention

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
