### PR TITLE
Add configurable OTEL exponential histogram settings

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -375,6 +375,15 @@ TODO: TLS
 | `metrics.reporters_cache_len` | `integer` | `OTEL_EBPF_METRICS_REPORT_CACHE_LEN` | `256` |  |  |  |
 | `metrics.ttl` | `duration` | `OTEL_EBPF_METRICS_TTL` | `5m` | `30s`, `5m`, `1ms`, etc |  | Specifies the time since a metric was updated for the last time until it is removed from the metrics set. |
 
+### `metrics.exponential_histogram`
+
+ExponentialHistogramConfig configures the precision and size of exponential histograms according to <https://opentelemetry.io/docs/specs/otel/metrics/sdk/#base2-exponential-bucket-histogram-aggregation>
+
+| YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
+|---|---|---|---|---|---|---|
+| `metrics.exponential_histogram.max_scale` | `integer` | `OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SCALE` | `20` |  |  | Sets the maximum resolution scale used by base-2 exponential histograms. Higher values create narrower buckets and more precision, but may require more buckets. Valid values are from -10 to 20. |
+| `metrics.exponential_histogram.max_size` | `integer` | `OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SIZE` | `160` |  |  | Sets the maximum number of buckets used for a base-2 exponential histogram. Higher values reduce bucket compaction and preserve more detail at the cost of larger metric payloads. |
+
 ## `name_resolver`
 
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
@@ -464,6 +473,15 @@ ReverseDNS is currently experimental. It is kept disabled by default and will be
 | `otel_metrics_export.protocol` | `string` | `OTEL_EXPORTER_OTLP_PROTOCOL` |  | ``, `debug`, `grpc`, `http/json`, `http/protobuf` |  |  |
 | `otel_metrics_export.reporters_cache_len` | `integer` | `OTEL_EBPF_METRICS_REPORT_CACHE_LEN` | `256` |  |  |  |
 | `otel_metrics_export.ttl` | `duration` | `OTEL_EBPF_METRICS_TTL` | `5m` | `30s`, `5m`, `1ms`, etc |  | Specifies the time since a metric was updated for the last time until it is removed from the metrics set. |
+
+### `otel_metrics_export.exponential_histogram`
+
+ExponentialHistogramConfig configures the precision and size of exponential histograms according to <https://opentelemetry.io/docs/specs/otel/metrics/sdk/#base2-exponential-bucket-histogram-aggregation>
+
+| YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
+|---|---|---|---|---|---|---|
+| `otel_metrics_export.exponential_histogram.max_scale` | `integer` | `OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SCALE` | `20` |  |  | Sets the maximum resolution scale used by base-2 exponential histograms. Higher values create narrower buckets and more precision, but may require more buckets. Valid values are from -10 to 20. |
+| `otel_metrics_export.exponential_histogram.max_size` | `integer` | `OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SIZE` | `160` |  |  | Sets the maximum number of buckets used for a base-2 exponential histogram. Higher values reduce bucket compaction and preserve more detail at the cost of larger metric payloads. |
 
 ## `otel_traces_export`
 

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -790,6 +790,24 @@
       "type": "object",
       "description": "EnrichmentConfig configures HTTP header and payload extraction with policy-based rules."
     },
+    "ExponentialHistogramConfig": {
+      "properties": {
+        "max_scale": {
+          "type": "integer",
+          "description": "Sets the maximum resolution scale used by base-2 exponential histograms. Higher values create narrower buckets and more precision, but may require more buckets. Valid values are from -10 to 20.",
+          "default": 20,
+          "x-env-var": "OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SCALE"
+        },
+        "max_size": {
+          "type": "integer",
+          "description": "Sets the maximum number of buckets used for a base-2 exponential histogram. Higher values reduce bucket compaction and preserve more detail at the cost of larger metric payloads.",
+          "default": 160,
+          "x-env-var": "OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SIZE"
+        }
+      },
+      "type": "object",
+      "description": "ExponentialHistogramConfig configures the precision and size of exponential histograms according to https://opentelemetry.io/docs/specs/otel/metrics/sdk/#base2-exponential-bucket-histogram-aggregation"
+    },
     "ExportModes": {
       "items": {
         "type": "string",
@@ -1621,6 +1639,9 @@
           "type": "string",
           "format": "uri",
           "x-env-var": "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"
+        },
+        "exponential_histogram": {
+          "$ref": "#/$defs/ExponentialHistogramConfig"
         },
         "extra_span_resource_attributes": {
           "items": {

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -344,50 +344,47 @@ func newMetricsReporter(
 	return &mr, nil
 }
 
-func (mr *MetricsReporter) otelMetricOptions(mlog *slog.Logger) []metric.Option {
+func (mr *MetricsReporter) otelMetricOptions() []metric.Option {
 	var opts []metric.Option
 	if !mr.jointMetricsCfg.Features.AppRED() {
 		return opts
 	}
-
-	useExponentialHistograms := isExponentialAggregation(mr.cfg, mlog)
-
 	if mr.is.HTTPEnabled() {
 		opts = append(opts,
-			metric.WithView(otelHistogramConfig(attributes.HTTPServerDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.HTTPClientDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.HTTPServerRequestSize.OTEL, mr.cfg.Buckets.RequestSizeHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.HTTPServerResponseSize.OTEL, mr.cfg.Buckets.ResponseSizeHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.HTTPClientRequestSize.OTEL, mr.cfg.Buckets.RequestSizeHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.HTTPClientResponseSize.OTEL, mr.cfg.Buckets.ResponseSizeHistogram, useExponentialHistograms)),
+			metric.WithView(mr.otelHistogramConfig(attributes.HTTPServerDuration.OTEL, mr.cfg.Buckets.DurationHistogram)),
+			metric.WithView(mr.otelHistogramConfig(attributes.HTTPClientDuration.OTEL, mr.cfg.Buckets.DurationHistogram)),
+			metric.WithView(mr.otelHistogramConfig(attributes.HTTPServerRequestSize.OTEL, mr.cfg.Buckets.RequestSizeHistogram)),
+			metric.WithView(mr.otelHistogramConfig(attributes.HTTPServerResponseSize.OTEL, mr.cfg.Buckets.ResponseSizeHistogram)),
+			metric.WithView(mr.otelHistogramConfig(attributes.HTTPClientRequestSize.OTEL, mr.cfg.Buckets.RequestSizeHistogram)),
+			metric.WithView(mr.otelHistogramConfig(attributes.HTTPClientResponseSize.OTEL, mr.cfg.Buckets.ResponseSizeHistogram)),
 		)
 	}
 
 	if mr.is.GRPCEnabled() {
 		opts = append(opts,
-			metric.WithView(otelHistogramConfig(attributes.RPCServerDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.RPCClientDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
+			metric.WithView(mr.otelHistogramConfig(attributes.RPCServerDuration.OTEL, mr.cfg.Buckets.DurationHistogram)),
+			metric.WithView(mr.otelHistogramConfig(attributes.RPCClientDuration.OTEL, mr.cfg.Buckets.DurationHistogram)),
 		)
 	}
 
 	if mr.is.DBEnabled() {
 		opts = append(opts,
-			metric.WithView(otelHistogramConfig(attributes.DBClientDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
+			metric.WithView(mr.otelHistogramConfig(attributes.DBClientDuration.OTEL, mr.cfg.Buckets.DurationHistogram)),
 		)
 	}
 
 	if mr.is.MQEnabled() {
 		opts = append(opts,
-			metric.WithView(otelHistogramConfig(attributes.MessagingPublishDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-			metric.WithView(otelHistogramConfig(attributes.MessagingProcessDuration.OTEL, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
+			metric.WithView(mr.otelHistogramConfig(attributes.MessagingPublishDuration.OTEL, mr.cfg.Buckets.DurationHistogram)),
+			metric.WithView(mr.otelHistogramConfig(attributes.MessagingProcessDuration.OTEL, mr.cfg.Buckets.DurationHistogram)),
 		)
 	}
 
 	if mr.is.GenAIEnabled() {
 		opts = append(opts,
-			metric.WithView(otelHistogramConfig(attributes.GenAIClientOperationDuration.OTEL, mr.cfg.Buckets.GenAIClientDurationHistogram, useExponentialHistograms)),
+			metric.WithView(mr.otelHistogramConfig(attributes.GenAIClientOperationDuration.OTEL, mr.cfg.Buckets.GenAIClientDurationHistogram)),
 			// the input tokens and output tokens are the same metric, we just need to distinguish the attributes, so we can write the token type
-			metric.WithView(otelHistogramConfig(attributes.GenAIClientInputTokenUsage.OTEL, mr.cfg.Buckets.GenAITokenUsageHistogram, useExponentialHistograms)),
+			metric.WithView(mr.otelHistogramConfig(attributes.GenAIClientInputTokenUsage.OTEL, mr.cfg.Buckets.GenAITokenUsageHistogram)),
 		)
 	}
 
@@ -406,15 +403,12 @@ func (mr *MetricsReporter) spanMetricsLatencyName() string {
 	return SpanMetricsLatencyOTel
 }
 
-func (mr *MetricsReporter) spanMetricOptions(mlog *slog.Logger) []metric.Option {
+func (mr *MetricsReporter) spanMetricOptions() []metric.Option {
 	if !mr.jointMetricsCfg.Features.SpanMetrics() {
 		return []metric.Option{}
 	}
-
-	useExponentialHistograms := isExponentialAggregation(mr.cfg, mlog)
-
 	return []metric.Option{
-		metric.WithView(otelHistogramConfig(mr.spanMetricsLatencyName(), mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
+		metric.WithView(mr.otelHistogramConfig(mr.spanMetricsLatencyName(), mr.cfg.Buckets.DurationHistogram)),
 	}
 }
 
@@ -706,8 +700,8 @@ func (mr *MetricsReporter) newMetricsInstance(service *svc.Attrs) Metrics {
 			metric.WithInterval(mr.cfg.Interval))),
 	}
 
-	opts = append(opts, mr.otelMetricOptions(mlog)...)
-	opts = append(opts, mr.spanMetricOptions(mlog)...)
+	opts = append(opts, mr.otelMetricOptions()...)
+	opts = append(opts, mr.spanMetricOptions()...)
 
 	return Metrics{
 		ctx:     mr.ctx,
@@ -752,16 +746,17 @@ func (mr *MetricsReporter) setupMetricExpirers(m *Metrics, meter instrument.Mete
 	return nil
 }
 
-func isExponentialAggregation(mc *otelcfg.MetricsConfig, mlog *slog.Logger) bool {
-	switch mc.HistogramAggregation {
+func (mr *MetricsReporter) isExponentialAggregation() bool {
+	switch mr.cfg.HistogramAggregation {
 	case otelcfg.HistogramAggregationExponential:
 		return true
 	case otelcfg.HistogramAggregationExplicit:
 	// do nothing
 	default:
-		mlog.Warn("invalid value for histogram aggregation. Accepted values are: "+
+		mr.log.Warn("invalid value for histogram aggregation. Accepted values are: "+
 			string(otelcfg.HistogramAggregationExponential)+", "+string(otelcfg.HistogramAggregationExplicit)+" (default). Using default",
-			"value", mc.HistogramAggregation)
+			"value", mr.cfg.HistogramAggregation)
+		mr.cfg.HistogramAggregation = otelcfg.HistogramAggregationExplicit
 	}
 	return false
 }
@@ -790,8 +785,11 @@ func instrumentMetricsExporter(internalMetrics imetrics.Reporter, in sdkmetric.E
 	}
 }
 
-func otelHistogramConfig(metricName string, buckets []float64, useExponentialHistogram bool) metric.View {
-	if useExponentialHistogram {
+func (mr *MetricsReporter) otelHistogramConfig(
+	metricName string,
+	buckets []float64,
+) metric.View {
+	if mr.isExponentialAggregation() {
 		return metric.NewView(
 			metric.Instrument{
 				Name:  metricName,
@@ -800,8 +798,8 @@ func otelHistogramConfig(metricName string, buckets []float64, useExponentialHis
 			metric.Stream{
 				Name: metricName,
 				Aggregation: sdkmetric.AggregationBase2ExponentialHistogram{
-					MaxScale: 20,
-					MaxSize:  160,
+					MaxScale: mr.cfg.ExponentialHistogram.MaxScale,
+					MaxSize:  mr.cfg.ExponentialHistogram.MaxSize,
 				},
 			})
 	}

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
@@ -153,13 +154,53 @@ func newSvcGraphMetricsReporter(
 	return &mr, nil
 }
 
-func (mr *SvcGraphMetricsReporter) graphMetricOptions(log *slog.Logger) []metric.Option {
-	useExponentialHistograms := isExponentialAggregation(mr.cfg, log)
-
+func (mr *SvcGraphMetricsReporter) graphMetricOptions() []metric.Option {
 	return []metric.Option{
-		metric.WithView(otelHistogramConfig(ServiceGraphClient, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
-		metric.WithView(otelHistogramConfig(ServiceGraphServer, mr.cfg.Buckets.DurationHistogram, useExponentialHistograms)),
+		metric.WithView(mr.otelHistogramConfig(ServiceGraphClient, mr.cfg.Buckets.DurationHistogram)),
+		metric.WithView(mr.otelHistogramConfig(ServiceGraphServer, mr.cfg.Buckets.DurationHistogram)),
 	}
+}
+
+func (mr *SvcGraphMetricsReporter) isExponentialAggregation() bool {
+	switch mr.cfg.HistogramAggregation {
+	case otelcfg.HistogramAggregationExponential:
+		return true
+	case otelcfg.HistogramAggregationExplicit:
+	// do nothing
+	default:
+		mr.log.Warn("invalid value for histogram aggregation. Accepted values are: "+
+			string(otelcfg.HistogramAggregationExponential)+", "+string(otelcfg.HistogramAggregationExplicit)+" (default). Using default",
+			"value", mr.cfg.HistogramAggregation)
+	}
+	return false
+}
+
+func (mr *SvcGraphMetricsReporter) otelHistogramConfig(metricName string, buckets []float64) metric.View {
+	if mr.isExponentialAggregation() {
+		return metric.NewView(
+			metric.Instrument{
+				Name:  metricName,
+				Scope: instrumentation.Scope{Name: reporterName},
+			},
+			metric.Stream{
+				Name: metricName,
+				Aggregation: sdkmetric.AggregationBase2ExponentialHistogram{
+					MaxScale: mr.cfg.ExponentialHistogram.MaxScale,
+					MaxSize:  mr.cfg.ExponentialHistogram.MaxSize,
+				},
+			})
+	}
+	return metric.NewView(
+		metric.Instrument{
+			Name:  metricName,
+			Scope: instrumentation.Scope{Name: reporterName},
+		},
+		metric.Stream{
+			Name: metricName,
+			Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+				Boundaries: buckets,
+			},
+		})
 }
 
 func (mr *SvcGraphMetricsReporter) setupGraphMeters(m *SvcGraphMetrics, meter instrument.Meter) error {
@@ -212,7 +253,7 @@ func (mr *SvcGraphMetricsReporter) newSvcGraphMetricsInstance(service *svc.Attrs
 			metric.WithInterval(mr.cfg.Interval))),
 	}
 
-	opts = append(opts, mr.graphMetricOptions(log)...)
+	opts = append(opts, mr.graphMetricOptions()...)
 
 	return &SvcGraphMetrics{
 		ctx:                      mr.ctx,

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -21,6 +21,8 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 
 	"go.opentelemetry.io/obi/internal/test/collector"
 	"go.opentelemetry.io/obi/pkg/appolly/app"
@@ -33,6 +35,7 @@ import (
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	otelmetric "go.opentelemetry.io/obi/pkg/export/otel/metric"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
@@ -40,6 +43,62 @@ import (
 )
 
 var fakeMux = sync.Mutex{}
+
+func TestOtelHistogramConfig_ExponentialHistogramUsesConfiguredMaxSizeAndScale(t *testing.T) {
+	const metricName = "test.histogram"
+
+	reporter := MetricsReporter{
+		cfg: &otelcfg.MetricsConfig{
+			HistogramAggregation: otelcfg.HistogramAggregationExponential,
+			ExponentialHistogram: otelcfg.ExponentialHistogramConfig{
+				MaxSize:  64,
+				MaxScale: 12,
+			},
+		},
+		log: mlog(),
+	}
+
+	view := reporter.otelHistogramConfig(metricName, nil)
+
+	stream, ok := view(otelmetric.Instrument{
+		Name:  metricName,
+		Scope: instrumentation.Scope{Name: reporterName},
+	})
+	require.True(t, ok)
+
+	aggregation, ok := stream.Aggregation.(sdkmetric.AggregationBase2ExponentialHistogram)
+	require.True(t, ok)
+	assert.Equal(t, int32(64), aggregation.MaxSize)
+	assert.Equal(t, int32(12), aggregation.MaxScale)
+}
+
+func TestOtelHistogramConfig_ExplicitHistogramUsesBuckets(t *testing.T) {
+	const metricName = "test.histogram"
+	buckets := []float64{1, 2, 4}
+
+	reporter := MetricsReporter{
+		cfg: &otelcfg.MetricsConfig{
+			HistogramAggregation: otelcfg.HistogramAggregationExplicit,
+			ExponentialHistogram: otelcfg.ExponentialHistogramConfig{
+				MaxSize:  160,
+				MaxScale: 20,
+			},
+		},
+		log: mlog(),
+	}
+
+	view := reporter.otelHistogramConfig(metricName, buckets)
+
+	stream, ok := view(otelmetric.Instrument{
+		Name:  metricName,
+		Scope: instrumentation.Scope{Name: reporterName},
+	})
+	require.True(t, ok)
+
+	aggregation, ok := stream.Aggregation.(sdkmetric.AggregationExplicitBucketHistogram)
+	require.True(t, ok)
+	assert.Equal(t, buckets, aggregation.Boundaries)
+}
 
 func TestMetrics_InternalInstrumentation(t *testing.T) {
 	defer otelcfg.RestoreEnvAfterExecution()()

--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -26,6 +26,17 @@ const (
 	HistogramAggregationExponential HistogramAggregation = "base2_exponential_bucket_histogram"
 )
 
+// ExponentialHistogramConfig configures the precision and size of exponential histograms
+// according to https://opentelemetry.io/docs/specs/otel/metrics/sdk/#base2-exponential-bucket-histogram-aggregation
+type ExponentialHistogramConfig struct {
+	// Sets the maximum number of buckets used for a base-2 exponential histogram.
+	// Higher values reduce bucket compaction and preserve more detail at the cost of larger metric payloads.
+	MaxSize int32 `yaml:"max_size" env:"OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SIZE" validate:"gt=0"`
+	// Sets the maximum resolution scale used by base-2 exponential histograms.
+	// Higher values create narrower buckets and more precision, but may require more buckets. Valid values are from -10 to 20.
+	MaxScale int32 `yaml:"max_scale" env:"OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SCALE" validate:"gte=-10,lte=20"`
+}
+
 func mlog() *slog.Logger {
 	return slog.With("component", "otelcfg.MetricsConfig")
 }
@@ -49,8 +60,9 @@ type MetricsConfig struct {
 	// InsecureSkipVerify enables skipping TLS certificate verification (not standard, so we don't follow the same naming convention)
 	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"OTEL_EBPF_INSECURE_SKIP_VERIFY"`
 
-	Buckets              export.Buckets       `yaml:"buckets"`
-	HistogramAggregation HistogramAggregation `yaml:"histogram_aggregation" env:"OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION"`
+	Buckets              export.Buckets             `yaml:"buckets"`
+	HistogramAggregation HistogramAggregation       `yaml:"histogram_aggregation" env:"OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION"`
+	ExponentialHistogram ExponentialHistogramConfig `yaml:"exponential_histogram"`
 
 	ReportersCacheLen int `yaml:"reporters_cache_len" env:"OTEL_EBPF_METRICS_REPORT_CACHE_LEN"`
 

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -223,6 +223,10 @@ var DefaultConfig = Config{
 		Buckets:              export.DefaultBuckets,
 		ReportersCacheLen:    ReporterLRUSize,
 		HistogramAggregation: otelcfg.HistogramAggregationExplicit,
+		ExponentialHistogram: otelcfg.ExponentialHistogramConfig{
+			MaxSize:  160,
+			MaxScale: 20,
+		},
 		Instrumentations: []instrumentations.Instrumentation{
 			instrumentations.InstrumentationALL,
 		},

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -56,6 +56,9 @@ otel_metrics_export:
   buckets:
     duration_histogram: [0, 1, 2]
   histogram_aggregation: base2_exponential_bucket_histogram
+  exponential_histogram:
+    max_size: 128
+    max_scale: 16
 prometheus_export:
   ttl: 1s
   buckets:
@@ -216,7 +219,11 @@ discovery:
 				instrumentations.InstrumentationALL,
 			},
 			HistogramAggregation: "base2_exponential_bucket_histogram",
-			TTL:                  5 * time.Minute,
+			ExponentialHistogram: otelcfg.ExponentialHistogramConfig{
+				MaxSize:  128,
+				MaxScale: 16,
+			},
+			TTL: 5 * time.Minute,
 		},
 		Traces: otelcfg.TracesConfig{
 			Protocol:          otelcfg.ProtocolUnset,
@@ -354,6 +361,49 @@ func TestConfig_ShutdownTimeout(t *testing.T) {
 	cfg, err := LoadConfig(bytes.NewReader(nil))
 	require.NoError(t, err)
 	assert.Equal(t, time.Minute, cfg.ShutdownTimeout)
+}
+
+func TestConfig_ExponentialHistogramConfigFromEnv(t *testing.T) {
+	t.Setenv("OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SIZE", "96")
+	t.Setenv("OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SCALE", "14")
+
+	cfg, err := LoadConfig(bytes.NewReader(nil))
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(96), cfg.OTELMetrics.ExponentialHistogram.MaxSize)
+	assert.Equal(t, int32(14), cfg.OTELMetrics.ExponentialHistogram.MaxScale)
+}
+
+func TestConfigValidate_ExponentialHistogramConfig(t *testing.T) {
+	t.Run("valid scale range", func(t *testing.T) {
+		cfg := loadConfig(t, envMap{
+			"OTEL_EBPF_EXECUTABLE_PATH":                         "foo",
+			"OTEL_EBPF_TRACE_PRINTER":                           "text",
+			"OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SCALE": "0",
+		})
+
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("invalid size", func(t *testing.T) {
+		cfg := loadConfig(t, envMap{
+			"OTEL_EBPF_EXECUTABLE_PATH":                        "foo",
+			"OTEL_EBPF_TRACE_PRINTER":                          "text",
+			"OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SIZE": "0",
+		})
+
+		require.Error(t, cfg.Validate())
+	})
+
+	t.Run("invalid scale", func(t *testing.T) {
+		cfg := loadConfig(t, envMap{
+			"OTEL_EBPF_EXECUTABLE_PATH":                         "foo",
+			"OTEL_EBPF_TRACE_PRINTER":                           "text",
+			"OTEL_EBPF_METRICS_EXPONENTIAL_HISTOGRAM_MAX_SCALE": "21",
+		})
+
+		require.Error(t, cfg.Validate())
+	})
 }
 
 func TestConfigValidate(t *testing.T) {


### PR DESCRIPTION
## Summary

By enabling buckets configuration of OTEL exponential histogram, users can have more control of their metrics cost by trading precision by less buckets.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
