### PR TITLE
Add configurable Prometheus native histogram settings

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -347,6 +347,16 @@ TODO: TLS
 | `internal_metrics.prometheus.service_cache_size` | `integer` |  | `10000` |  |  |  |
 | `internal_metrics.prometheus.ttl` | `duration` | `OTEL_EBPF_PROMETHEUS_TTL` | `5m` | `30s`, `5m`, `1ms`, etc |  | Specifies the time since a metric was updated for the last time until it is removed from the metrics set. |
 
+#### `internal_metrics.prometheus.native_histogram`
+
+NativeHistogramConfig holds configuration for native histograms
+
+| YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
+|---|---|---|---|---|---|---|
+| `internal_metrics.prometheus.native_histogram.bucket_factor` | `number` | `OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_BUCKET_FACTOR` | `1.1` |  |  |  |
+| `internal_metrics.prometheus.native_histogram.max_bucket_number` | `integer` | `OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MAX_BUCKET_NUMBER` | `100` |  |  |  |
+| `internal_metrics.prometheus.native_histogram.min_reset_duration` | `duration` | `OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MIN_RESET_DURATION` | `60m` | `30s`, `5m`, `1ms`, etc |  |  |
+
 ## `javaagent`
 
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
@@ -509,6 +519,16 @@ TODO: TLS
 | `prometheus_export.port` | `integer` | `OTEL_EBPF_PROMETHEUS_PORT` | `0` |  |  |  |
 | `prometheus_export.service_cache_size` | `integer` |  | `10000` |  |  |  |
 | `prometheus_export.ttl` | `duration` | `OTEL_EBPF_PROMETHEUS_TTL` | `5m` | `30s`, `5m`, `1ms`, etc |  | Specifies the time since a metric was updated for the last time until it is removed from the metrics set. |
+
+### `prometheus_export.native_histogram`
+
+NativeHistogramConfig holds configuration for native histograms
+
+| YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
+|---|---|---|---|---|---|---|
+| `prometheus_export.native_histogram.bucket_factor` | `number` | `OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_BUCKET_FACTOR` | `1.1` |  |  |  |
+| `prometheus_export.native_histogram.max_bucket_number` | `integer` | `OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MAX_BUCKET_NUMBER` | `100` |  |  |  |
+| `prometheus_export.native_histogram.min_reset_duration` | `duration` | `OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MIN_RESET_DURATION` | `60m` | `30s`, `5m`, `1ms`, etc |  |  |
 
 ## `routes`
 

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -1768,6 +1768,33 @@
       },
       "type": "object"
     },
+    "NativeHistogramConfig": {
+      "properties": {
+        "bucket_factor": {
+          "type": "number",
+          "default": 1.1,
+          "x-env-var": "OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_BUCKET_FACTOR"
+        },
+        "max_bucket_number": {
+          "type": "integer",
+          "default": 100,
+          "x-env-var": "OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MAX_BUCKET_NUMBER"
+        },
+        "min_reset_duration": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s|m)$",
+          "default": "60m",
+          "examples": [
+            "30s",
+            "5m",
+            "1ms"
+          ],
+          "x-env-var": "OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MIN_RESET_DURATION"
+        }
+      },
+      "type": "object",
+      "description": "NativeHistogramConfig holds configuration for native histograms"
+    },
     "NetworkConfig": {
       "properties": {
         "agent_ip": {
@@ -2053,6 +2080,10 @@
             "*"
           ],
           "x-env-var": "OTEL_EBPF_PROMETHEUS_INSTRUMENTATIONS"
+        },
+        "native_histogram": {
+          "$ref": "#/$defs/NativeHistogramConfig",
+          "description": "Configures native histogram bucket parameters. Uses recommended values if not specified."
         },
         "path": {
           "type": "string",

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -95,12 +95,6 @@ const (
 	telemetrySDKVersion    = "telemetry_sdk_version"
 	telemetryDistroNameKey = "telemetry_distro_name"
 	telemetryDistroVersion = "telemetry_distro_version"
-
-	// default values for the histogram configuration
-	// recommended values for native histogram migration
-	defaultHistogramBucketFactor     = 1.1
-	defaultHistogramMaxBucketNumber  = uint32(100)
-	defaultHistogramMinResetDuration = 1 * time.Hour
 )
 
 // metrics for OBI statistics
@@ -114,6 +108,13 @@ const (
 var (
 	obiInfoLabelNames = []string{LanguageLabel}
 )
+
+// NativeHistogramConfig holds configuration for native histograms
+type NativeHistogramConfig struct {
+	BucketFactor     float64       `yaml:"bucket_factor" env:"OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_BUCKET_FACTOR"`
+	MaxBucketNumber  uint32        `yaml:"max_bucket_number" env:"OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MAX_BUCKET_NUMBER"`
+	MinResetDuration time.Duration `yaml:"min_reset_duration" env:"OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MIN_RESET_DURATION"`
+}
 
 // TODO: TLS
 type PrometheusConfig struct {
@@ -145,6 +146,10 @@ type PrometheusConfig struct {
 	// Defaults to "always_off": do not attach exemplars.
 	// This mimics the OTEL_METRICS_EXEMPLAR_FILTER specification.
 	ExemplarFilter string `yaml:"exemplar_filter" env:"OTEL_EBPF_PROMETHEUS_EXEMPLAR_FILTER"`
+
+	// NativeHistogram configures native histogram bucket parameters.
+	// Uses recommended values if not specified.
+	NativeHistogram NativeHistogramConfig `yaml:"native_histogram"`
 
 	// Registry is only used for embedding OBI within third-party collectors.
 	// It must be nil when OBI runs as standalone
@@ -483,9 +488,9 @@ func newReporter(
 				Name:                            attributes.HTTPServerDuration.Prom,
 				Help:                            "duration of HTTP service calls from the server side, in seconds",
 				Buckets:                         cfg.Buckets.DurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrHTTPDuration)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		httpClientDuration: optionalHistogramProvider(is.HTTPEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -493,9 +498,9 @@ func newReporter(
 				Name:                            attributes.HTTPClientDuration.Prom,
 				Help:                            "duration of HTTP service calls from the client side, in seconds",
 				Buckets:                         cfg.Buckets.DurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrHTTPClientDuration)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		grpcDuration: optionalHistogramProvider(is.GRPCEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -503,9 +508,9 @@ func newReporter(
 				Name:                            attributes.RPCServerDuration.Prom,
 				Help:                            "duration of RCP service calls from the server side, in seconds",
 				Buckets:                         cfg.Buckets.DurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrGRPCDuration)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		grpcClientDuration: optionalHistogramProvider(is.GRPCEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -513,9 +518,9 @@ func newReporter(
 				Name:                            attributes.RPCClientDuration.Prom,
 				Help:                            "duration of GRPC service calls from the client side, in seconds",
 				Buckets:                         cfg.Buckets.DurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrGRPCClientDuration)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		dbClientDuration: optionalHistogramProvider(is.DBEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -523,9 +528,9 @@ func newReporter(
 				Name:                            attributes.DBClientDuration.Prom,
 				Help:                            "duration of db client operations, in seconds",
 				Buckets:                         cfg.Buckets.DurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrDBClientDuration)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		msgPublishDuration: optionalHistogramProvider(is.MQEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -533,9 +538,9 @@ func newReporter(
 				Name:                            attributes.MessagingPublishDuration.Prom,
 				Help:                            "duration of messaging client publish operations, in seconds",
 				Buckets:                         cfg.Buckets.DurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrMessagingPublishDuration)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		msgProcessDuration: optionalHistogramProvider(is.MQEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -543,9 +548,9 @@ func newReporter(
 				Name:                            attributes.MessagingProcessDuration.Prom,
 				Help:                            "duration of messaging client process operations, in seconds",
 				Buckets:                         cfg.Buckets.DurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrMessagingProcessDuration)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		httpRequestSize: optionalHistogramProvider(is.HTTPEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -553,9 +558,9 @@ func newReporter(
 				Name:                            attributes.HTTPServerRequestSize.Prom,
 				Help:                            "size, in bytes, of the HTTP request body as received at the server side",
 				Buckets:                         cfg.Buckets.RequestSizeHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrHTTPRequestSize)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		httpResponseSize: optionalHistogramProvider(is.HTTPEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -563,9 +568,9 @@ func newReporter(
 				Name:                            attributes.HTTPServerResponseSize.Prom,
 				Help:                            "size, in bytes, of the HTTP response body as received at the server side",
 				Buckets:                         cfg.Buckets.ResponseSizeHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrHTTPResponseSize)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		httpClientRequestSize: optionalHistogramProvider(is.HTTPEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -573,9 +578,9 @@ func newReporter(
 				Name:                            attributes.HTTPClientRequestSize.Prom,
 				Help:                            "size, in bytes, of the HTTP request body as sent from the client side",
 				Buckets:                         cfg.Buckets.RequestSizeHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrHTTPClientRequestSize)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		httpClientResponseSize: optionalHistogramProvider(is.HTTPEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -583,9 +588,9 @@ func newReporter(
 				Name:                            attributes.HTTPClientResponseSize.Prom,
 				Help:                            "size, in bytes, of the HTTP response body as sent from the client side",
 				Buckets:                         cfg.Buckets.ResponseSizeHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrHTTPClientResponseSize)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		spanMetricsLatency: optionalHistogramProvider(jointMetricsConfig.Features.SpanMetrics(), func() *Expirer[prometheus.Histogram] {
@@ -593,9 +598,9 @@ func newReporter(
 				Name:                            spanMetricsLatencyName(jointMetricsConfig),
 				Help:                            "duration of service calls (client and server), in seconds, in trace span metrics format",
 				Buckets:                         cfg.Buckets.DurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNamesSpans(extraSpanMetadataLabels)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		spanMetricsCallsTotal: optionalCounterProvider(jointMetricsConfig.Features.SpanMetrics(), func() *Expirer[prometheus.Counter] {
@@ -633,9 +638,9 @@ func newReporter(
 				Name:                            ServiceGraphClient,
 				Help:                            "duration of client service calls, in seconds, in trace service graph metrics format",
 				Buckets:                         cfg.Buckets.DurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNamesSvcGraph(attrSvcGraph)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		serviceGraphServer: optionalHistogramProvider(jointMetricsConfig.Features.ServiceGraph(), func() *Expirer[prometheus.Histogram] {
@@ -643,9 +648,9 @@ func newReporter(
 				Name:                            ServiceGraphServer,
 				Help:                            "duration of server service calls, in seconds, in trace service graph metrics format",
 				Buckets:                         cfg.Buckets.DurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNamesSvcGraph(attrSvcGraph)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		serviceGraphFailed: optionalCounterProvider(jointMetricsConfig.Features.ServiceGraph(), func() *Expirer[prometheus.Counter] {
@@ -687,9 +692,9 @@ func newReporter(
 				Name:                            attributes.GPUCudaKernelGridSize.Prom,
 				Help:                            "number of blocks in the NVIDIA GPU cuda kernel grid",
 				Buckets:                         cfg.Buckets.RequestSizeHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrCudaKernelGridSize)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		cudaKernelBlockSize: optionalHistogramProvider(is.GPUEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -697,9 +702,9 @@ func newReporter(
 				Name:                            attributes.GPUCudaKernelBlockSize.Prom,
 				Help:                            "number of threads in the NVIDIA GPU cuda kernel block",
 				Buckets:                         cfg.Buckets.RequestSizeHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrCudaKernelBlockSize)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		cudaMemoryCopySize: optionalHistogramProvider(is.GPUEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -707,9 +712,9 @@ func newReporter(
 				Name:                            attributes.GPUCudaMemoryCopies.Prom,
 				Help:                            "amount of NVIDIA GPU cuda to and from memory copies",
 				Buckets:                         cfg.Buckets.RequestSizeHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrCudaMemoryCopies)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		dnsLookupDuration: optionalHistogramProvider(is.DNSEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -717,9 +722,9 @@ func newReporter(
 				Name:                            attributes.DNSLookupDuration.Prom,
 				Help:                            "measures the time taken to perform a DNS lookup",
 				Buckets:                         cfg.Buckets.DurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrDNSLookupDuration)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		genAIClientDuration: optionalHistogramProvider(is.GenAIEnabled(), func() *Expirer[prometheus.Histogram] {
@@ -727,9 +732,9 @@ func newReporter(
 				Name:                            attributes.GenAIClientOperationDuration.Prom,
 				Help:                            "measures the time taken to perform a GenAI client request",
 				Buckets:                         cfg.Buckets.GenAIClientDurationHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrGenAIClientDuration)).MetricVec, clock.Time, cfg.TTL)
 		}),
 		// We make only one metric series, the input and output have the same name and attribute keys
@@ -738,9 +743,9 @@ func newReporter(
 				Name:                            attributes.GenAIClientInputTokenUsage.Prom,
 				Help:                            "number of input and output tokens used for a GenAI client request",
 				Buckets:                         cfg.Buckets.GenAITokenUsageHistogram,
-				NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-				NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-				NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrGenAIInputTokenUsage)).MetricVec, clock.Time, cfg.TTL)
 		}),
 	}

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -116,6 +116,13 @@ type NativeHistogramConfig struct {
 	MinResetDuration time.Duration `yaml:"min_reset_duration" env:"OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MIN_RESET_DURATION"`
 }
 
+var DefaultNativeHistogramConfig = NativeHistogramConfig{
+	// recommended values for native histogram migration
+	BucketFactor:     1.1,
+	MaxBucketNumber:  100,
+	MinResetDuration: time.Hour,
+}
+
 // TODO: TLS
 type PrometheusConfig struct {
 	Port int    `yaml:"port" env:"OTEL_EBPF_PROMETHEUS_PORT"`

--- a/pkg/export/prom/prom_native_histogram_test.go
+++ b/pkg/export/prom/prom_native_histogram_test.go
@@ -14,6 +14,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/connector"
@@ -21,40 +22,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
-	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 )
-
-func TestNativeHistogramConfigDefaultsWhenNil(t *testing.T) {
-	cfg := &PrometheusConfig{}
-
-	assert.Equal(t, defaultHistogramBucketFactor, cfg.HistogramBucketFactor())
-	assert.Equal(t, defaultHistogramMaxBucketNumber, cfg.HistogramMaxBucketNumber())
-	assert.Equal(t, defaultHistogramMinResetDuration, cfg.HistogramMinResetDuration())
-}
-
-func TestNativeHistogramConfigDefaultsWhenEmpty(t *testing.T) {
-	cfg := &PrometheusConfig{
-		NativeHistogram: &NativeHistogramConfig{},
-	}
-
-	assert.Equal(t, defaultHistogramBucketFactor, cfg.HistogramBucketFactor())
-	assert.Equal(t, defaultHistogramMaxBucketNumber, cfg.HistogramMaxBucketNumber())
-	assert.Equal(t, defaultHistogramMinResetDuration, cfg.HistogramMinResetDuration())
-}
-
-func TestNativeHistogramConfigCustomValues(t *testing.T) {
-	cfg := &PrometheusConfig{
-		NativeHistogram: &NativeHistogramConfig{
-			BucketFactor:     4.0,
-			MaxBucketNumber:  50,
-			MinResetDuration: 30 * time.Minute,
-		},
-	}
-
-	assert.Equal(t, 4.0, cfg.HistogramBucketFactor())
-	assert.Equal(t, uint32(50), cfg.HistogramMaxBucketNumber())
-	assert.Equal(t, 30*time.Minute, cfg.HistogramMinResetDuration())
-}
 
 // TestNativeHistogramBucketFactorDeterminesSchema verifies that BucketFactor controls
 // the native histogram resolution. Prometheus maps BucketFactor to a schema number
@@ -79,13 +47,10 @@ func TestNativeHistogramBucketFactorDeterminesSchema(t *testing.T) {
 		return m.GetHistogram().GetSchema()
 	}
 
-	assert.Equal(t, int32(3), observeAndGetSchema(t, defaultHistogramBucketFactor),
+	assert.Equal(t, int32(3), observeAndGetSchema(t, DefaultNativeHistogramConfig.BucketFactor),
 		"default BucketFactor=1.1 should map to schema=3")
 	assert.Equal(t, int32(-1), observeAndGetSchema(t, 4.0),
 		"BucketFactor=4.0 should map to schema=-1")
-
-	assert.Greater(t, observeAndGetSchema(t, defaultHistogramBucketFactor), observeAndGetSchema(t, 4.0),
-		"finer BucketFactor should produce a higher schema (more resolution)")
 }
 
 // TestNativeHistogramMaxBucketNumberDegrades verifies that a tight MaxBucketNumber
@@ -96,9 +61,9 @@ func TestNativeHistogramMaxBucketNumberDegrades(t *testing.T) {
 		h := prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:                            "test_maxbuckets",
 			Help:                            "test",
-			NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
+			NativeHistogramBucketFactor:     DefaultNativeHistogramConfig.BucketFactor,
 			NativeHistogramMaxBucketNumber:  maxBuckets,
-			NativeHistogramMinResetDuration: time.Hour,
+			NativeHistogramMinResetDuration: DefaultNativeHistogramConfig.MinResetDuration,
 		})
 		// Observations spanning many orders of magnitude force many distinct buckets.
 		for _, v := range []float64{1e-4, 1e-2, 1, 1e2, 1e4, 1e6, 1e8, 1e10} {
@@ -112,8 +77,8 @@ func TestNativeHistogramMaxBucketNumberDegrades(t *testing.T) {
 	schemaHighLimit := makeAndObserve(500)
 	schemaLowLimit := makeAndObserve(2)
 
-	assert.GreaterOrEqual(t, schemaHighLimit, schemaLowLimit,
-		"a higher MaxBucketNumber should maintain equal or finer resolution (schema)")
+	assert.Greater(t, schemaHighLimit, schemaLowLimit,
+		"a higher MaxBucketNumber should maintain finer resolution (schema)")
 }
 
 // TestNativeHistogramSchemaAppliedToExportedMetrics is an integration test that
@@ -122,17 +87,17 @@ func TestNativeHistogramMaxBucketNumberDegrades(t *testing.T) {
 func TestNativeHistogramSchemaAppliedToExportedMetrics(t *testing.T) {
 	for _, tc := range []struct {
 		name           string
-		nhCfg          *NativeHistogramConfig
+		nhCfg          NativeHistogramConfig
 		expectedSchema int32
 	}{
 		{
 			name:           "default config produces schema 3",
-			nhCfg:          nil,
+			nhCfg:          DefaultNativeHistogramConfig,
 			expectedSchema: 3,
 		},
 		{
 			name:           "BucketFactor=4.0 produces schema -1",
-			nhCfg:          &NativeHistogramConfig{BucketFactor: 4.0, MaxBucketNumber: 100, MinResetDuration: time.Hour},
+			nhCfg:          NativeHistogramConfig{BucketFactor: 4.0, MaxBucketNumber: 100, MinResetDuration: time.Hour},
 			expectedSchema: -1,
 		},
 	} {
@@ -148,6 +113,7 @@ func TestNativeHistogramSchemaAppliedToExportedMetrics(t *testing.T) {
 					Registry:         registry,
 					Instrumentations: []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
 					NativeHistogram:  tc.nhCfg,
+					ExemplarFilter:   "always_off",
 				},
 				&perapp.MetricsConfig{Features: export.FeatureApplicationRED},
 				&attributes.SelectorConfig{},

--- a/pkg/export/prom/prom_native_histogram_test.go
+++ b/pkg/export/prom/prom_native_histogram_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -23,63 +22,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
-
-// TestNativeHistogramBucketFactorDeterminesSchema verifies that BucketFactor controls
-// the native histogram resolution. Prometheus maps BucketFactor to a schema number
-// via floor(log2(log2(factor))): smaller factor → more buckets → higher (positive) schema.
-//
-// The expected schema values come from Prometheus' pickSchema function:
-//   - BucketFactor=1.1  → log2(log2(1.1)) ≈ log2(0.1375) ≈ -2.86 → floor=-3 → schema=3
-//   - BucketFactor=4.0  → log2(log2(4.0))  = log2(2)     = 1      → floor=1  → schema=-1
-func TestNativeHistogramBucketFactorDeterminesSchema(t *testing.T) {
-	observeAndGetSchema := func(t *testing.T, factor float64) int32 {
-		t.Helper()
-		h := prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:                            "test_schema",
-			Help:                            "test",
-			NativeHistogramBucketFactor:     factor,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: time.Hour,
-		})
-		h.Observe(0.1)
-		var m dto.Metric
-		require.NoError(t, h.Write(&m))
-		return m.GetHistogram().GetSchema()
-	}
-
-	assert.Equal(t, int32(3), observeAndGetSchema(t, DefaultNativeHistogramConfig.BucketFactor),
-		"default BucketFactor=1.1 should map to schema=3")
-	assert.Equal(t, int32(-1), observeAndGetSchema(t, 4.0),
-		"BucketFactor=4.0 should map to schema=-1")
-}
-
-// TestNativeHistogramMaxBucketNumberDegrades verifies that a tight MaxBucketNumber
-// forces Prometheus to merge buckets (reduce schema) when observations span many
-// orders of magnitude, while a large limit preserves the original resolution.
-func TestNativeHistogramMaxBucketNumberDegrades(t *testing.T) {
-	makeAndObserve := func(maxBuckets uint32) int32 {
-		h := prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:                            "test_maxbuckets",
-			Help:                            "test",
-			NativeHistogramBucketFactor:     DefaultNativeHistogramConfig.BucketFactor,
-			NativeHistogramMaxBucketNumber:  maxBuckets,
-			NativeHistogramMinResetDuration: DefaultNativeHistogramConfig.MinResetDuration,
-		})
-		// Observations spanning many orders of magnitude force many distinct buckets.
-		for _, v := range []float64{1e-4, 1e-2, 1, 1e2, 1e4, 1e6, 1e8, 1e10} {
-			h.Observe(v)
-		}
-		var m dto.Metric
-		require.NoError(t, h.Write(&m))
-		return m.GetHistogram().GetSchema()
-	}
-
-	schemaHighLimit := makeAndObserve(500)
-	schemaLowLimit := makeAndObserve(2)
-
-	assert.Greater(t, schemaHighLimit, schemaLowLimit,
-		"a higher MaxBucketNumber should maintain finer resolution (schema)")
-}
 
 // TestNativeHistogramSchemaAppliedToExportedMetrics is an integration test that
 // creates a full Prometheus reporter with a custom NativeHistogramConfig, sends an

--- a/pkg/export/prom/prom_native_histogram_test.go
+++ b/pkg/export/prom/prom_native_histogram_test.go
@@ -1,0 +1,190 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prom
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	"go.opentelemetry.io/obi/pkg/export/connector"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
+	"go.opentelemetry.io/obi/pkg/pipe/global"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+)
+
+func TestNativeHistogramConfigDefaultsWhenNil(t *testing.T) {
+	cfg := &PrometheusConfig{}
+
+	assert.Equal(t, defaultHistogramBucketFactor, cfg.HistogramBucketFactor())
+	assert.Equal(t, defaultHistogramMaxBucketNumber, cfg.HistogramMaxBucketNumber())
+	assert.Equal(t, defaultHistogramMinResetDuration, cfg.HistogramMinResetDuration())
+}
+
+func TestNativeHistogramConfigDefaultsWhenEmpty(t *testing.T) {
+	cfg := &PrometheusConfig{
+		NativeHistogram: &NativeHistogramConfig{},
+	}
+
+	assert.Equal(t, defaultHistogramBucketFactor, cfg.HistogramBucketFactor())
+	assert.Equal(t, defaultHistogramMaxBucketNumber, cfg.HistogramMaxBucketNumber())
+	assert.Equal(t, defaultHistogramMinResetDuration, cfg.HistogramMinResetDuration())
+}
+
+func TestNativeHistogramConfigCustomValues(t *testing.T) {
+	cfg := &PrometheusConfig{
+		NativeHistogram: &NativeHistogramConfig{
+			BucketFactor:     4.0,
+			MaxBucketNumber:  50,
+			MinResetDuration: 30 * time.Minute,
+		},
+	}
+
+	assert.Equal(t, 4.0, cfg.HistogramBucketFactor())
+	assert.Equal(t, uint32(50), cfg.HistogramMaxBucketNumber())
+	assert.Equal(t, 30*time.Minute, cfg.HistogramMinResetDuration())
+}
+
+// TestNativeHistogramBucketFactorDeterminesSchema verifies that BucketFactor controls
+// the native histogram resolution. Prometheus maps BucketFactor to a schema number
+// via floor(log2(log2(factor))): smaller factor → more buckets → higher (positive) schema.
+//
+// The expected schema values come from Prometheus' pickSchema function:
+//   - BucketFactor=1.1  → log2(log2(1.1)) ≈ log2(0.1375) ≈ -2.86 → floor=-3 → schema=3
+//   - BucketFactor=4.0  → log2(log2(4.0))  = log2(2)     = 1      → floor=1  → schema=-1
+func TestNativeHistogramBucketFactorDeterminesSchema(t *testing.T) {
+	observeAndGetSchema := func(t *testing.T, factor float64) int32 {
+		t.Helper()
+		h := prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "test_schema",
+			Help:                            "test",
+			NativeHistogramBucketFactor:     factor,
+			NativeHistogramMaxBucketNumber:  100,
+			NativeHistogramMinResetDuration: time.Hour,
+		})
+		h.Observe(0.1)
+		var m dto.Metric
+		require.NoError(t, h.Write(&m))
+		return m.GetHistogram().GetSchema()
+	}
+
+	assert.Equal(t, int32(3), observeAndGetSchema(t, defaultHistogramBucketFactor),
+		"default BucketFactor=1.1 should map to schema=3")
+	assert.Equal(t, int32(-1), observeAndGetSchema(t, 4.0),
+		"BucketFactor=4.0 should map to schema=-1")
+
+	assert.Greater(t, observeAndGetSchema(t, defaultHistogramBucketFactor), observeAndGetSchema(t, 4.0),
+		"finer BucketFactor should produce a higher schema (more resolution)")
+}
+
+// TestNativeHistogramMaxBucketNumberDegrades verifies that a tight MaxBucketNumber
+// forces Prometheus to merge buckets (reduce schema) when observations span many
+// orders of magnitude, while a large limit preserves the original resolution.
+func TestNativeHistogramMaxBucketNumberDegrades(t *testing.T) {
+	makeAndObserve := func(maxBuckets uint32) int32 {
+		h := prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:                            "test_maxbuckets",
+			Help:                            "test",
+			NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
+			NativeHistogramMaxBucketNumber:  maxBuckets,
+			NativeHistogramMinResetDuration: time.Hour,
+		})
+		// Observations spanning many orders of magnitude force many distinct buckets.
+		for _, v := range []float64{1e-4, 1e-2, 1, 1e2, 1e4, 1e6, 1e8, 1e10} {
+			h.Observe(v)
+		}
+		var m dto.Metric
+		require.NoError(t, h.Write(&m))
+		return m.GetHistogram().GetSchema()
+	}
+
+	schemaHighLimit := makeAndObserve(500)
+	schemaLowLimit := makeAndObserve(2)
+
+	assert.GreaterOrEqual(t, schemaHighLimit, schemaLowLimit,
+		"a higher MaxBucketNumber should maintain equal or finer resolution (schema)")
+}
+
+// TestNativeHistogramSchemaAppliedToExportedMetrics is an integration test that
+// creates a full Prometheus reporter with a custom NativeHistogramConfig, sends an
+// HTTP span, and verifies that the gathered histogram DTO uses the expected schema.
+func TestNativeHistogramSchemaAppliedToExportedMetrics(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		nhCfg          *NativeHistogramConfig
+		expectedSchema int32
+	}{
+		{
+			name:           "default config produces schema 3",
+			nhCfg:          nil,
+			expectedSchema: 3,
+		},
+		{
+			name:           "BucketFactor=4.0 produces schema -1",
+			nhCfg:          &NativeHistogramConfig{BucketFactor: 4.0, MaxBucketNumber: 100, MinResetDuration: time.Hour},
+			expectedSchema: -1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := prometheus.NewRegistry()
+			ctx := t.Context()
+			promInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
+			processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(10))
+
+			exporter, err := PrometheusEndpoint(
+				&global.ContextInfo{Prometheus: &connector.PrometheusManager{}},
+				&PrometheusConfig{
+					Registry:         registry,
+					Instrumentations: []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+					NativeHistogram:  tc.nhCfg,
+				},
+				&perapp.MetricsConfig{Features: export.FeatureApplicationRED},
+				&attributes.SelectorConfig{},
+				request.UnresolvedNames{},
+				promInput,
+				processEvents,
+			)(ctx)
+			require.NoError(t, err)
+			go exporter(ctx)
+
+			svcAttrs := svc.Attrs{
+				Features: export.FeatureApplicationRED,
+				UID:      svc.UID{Name: "test-svc", Instance: "inst-1"},
+			}
+			promInput.Send([]request.Span{{
+				Type:         request.EventTypeHTTP,
+				RequestStart: 0,
+				End:          100_000_000,
+				Service:      svcAttrs,
+			}})
+			awaitSpanProcessing()
+
+			mfs, err := registry.Gather()
+			require.NoError(t, err)
+
+			var schema *int32
+			for _, mf := range mfs {
+				if mf.GetName() != attributes.HTTPServerDuration.Prom {
+					continue
+				}
+				for _, m := range mf.GetMetric() {
+					s := m.GetHistogram().GetSchema()
+					schema = &s
+				}
+			}
+			require.NotNil(t, schema, "HTTP server duration metric not found in registry")
+			assert.Equal(t, tc.expectedSchema, *schema)
+		})
+	}
+}

--- a/pkg/export/prom/prom_stats.go
+++ b/pkg/export/prom/prom_stats.go
@@ -110,9 +110,9 @@ func newStatsReporter(
 			Help: "measures the smoothed TCP RTT as calculated by the kernel in seconds",
 			// TODO define a default bucket for stat metrics when we have enough metrics to have something standard
 			Buckets:                         []float64{0.0005, 0.001, 0.002, 0.005, 0.010, 0.025, 0.050, 0.100, 0.250, 0.500, 1.0},
-			NativeHistogramBucketFactor:     defaultHistogramBucketFactor,
-			NativeHistogramMaxBucketNumber:  defaultHistogramMaxBucketNumber,
-			NativeHistogramMinResetDuration: defaultHistogramMinResetDuration,
+			NativeHistogramBucketFactor:     DefaultNativeHistogramConfig.BucketFactor,
+			NativeHistogramMaxBucketNumber:  DefaultNativeHistogramConfig.MaxBucketNumber,
+			NativeHistogramMinResetDuration: DefaultNativeHistogramConfig.MinResetDuration,
 		}, labelNames(mr.tcpRttAttrs)).MetricVec, clock.Time, cfg.Config.TTL)
 		register = append(register, mr.tcpRtt)
 	}

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -252,6 +252,12 @@ var DefaultConfig = Config{
 	Prometheus: prom.PrometheusConfig{
 		Path:    "/metrics",
 		Buckets: export.DefaultBuckets,
+		NativeHistogram: prom.NativeHistogramConfig{
+			// recommended values for native histogram migration
+			BucketFactor:     1.1,
+			MaxBucketNumber:  100,
+			MinResetDuration: time.Hour,
+		},
 		Instrumentations: []instrumentations.Instrumentation{
 			instrumentations.InstrumentationALL,
 		},

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -250,14 +250,9 @@ var DefaultConfig = Config{
 		},
 	},
 	Prometheus: prom.PrometheusConfig{
-		Path:    "/metrics",
-		Buckets: export.DefaultBuckets,
-		NativeHistogram: prom.NativeHistogramConfig{
-			// recommended values for native histogram migration
-			BucketFactor:     1.1,
-			MaxBucketNumber:  100,
-			MinResetDuration: time.Hour,
-		},
+		Path:            "/metrics",
+		Buckets:         export.DefaultBuckets,
+		NativeHistogram: prom.DefaultNativeHistogramConfig,
 		Instrumentations: []instrumentations.Instrumentation{
 			instrumentations.InstrumentationALL,
 		},

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -247,6 +247,7 @@ discovery:
 			},
 			TTL:                         time.Second,
 			SpanMetricsServiceCacheSize: 10000,
+			NativeHistogram:             prom.DefaultNativeHistogramConfig,
 			Buckets: export.Buckets{
 				DurationHistogram:            export.DefaultBuckets.DurationHistogram,
 				RequestSizeHistogram:         []float64{0, 10, 20, 22},


### PR DESCRIPTION
## Summary

This way users can have more control of their metrics cost by trading precision by less buckets.

Provides Prometheus export feature parity with https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1966

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
