### PR TITLE
ci(daily-report): group similar errors

### DIFF
--- a/scripts/ci-analysis/ci_analysis_test.go
+++ b/scripts/ci-analysis/ci_analysis_test.go
@@ -172,6 +172,59 @@ func TestFingerprintErrorMsgPriority(t *testing.T) {
 	require.Equal(t, "data-race", fp)
 }
 
+func TestFingerprintCauseConsequenceSplit(t *testing.T) {
+	// testify explicitly reporting exit-status as the unexpected error:
+	// the consequence pattern IS the cause here, keep the label.
+	fp := fingerprintFromTestOutput(
+		"Received unexpected error: exit status 1",
+		"Error: Received unexpected error: exit status 1\n",
+		"suites_test.go:337",
+	)
+	require.Equal(t, "exit-error", fp)
+
+	// testify reports a generic assertion ("Condition never satisfied"),
+	// while a teardown WARN line in the surrounding snippet contains
+	// "exit status 1". The exit-error must NOT win — it's teardown noise
+	// after the real assertion already failed. Expect trace-site hash.
+	fp = fingerprintFromTestOutput(
+		"Condition never satisfied",
+		`WARN waiting for obi to stop. Will force remove error="exit status 1"`+"\n"+
+			`Error: "3" is not less than or equal to "2"`+"\n"+
+			"Error: Condition never satisfied\n",
+		"red_test.go:424",
+	)
+	require.Contains(t, fp, "unknown-")
+	require.NotEqual(t, "exit-error", fp)
+
+	// Cause pattern in snippet still wins when errorMsg matches nothing —
+	// a real panic must not be hidden behind a trace-site hash.
+	fp = fingerprintFromTestOutput(
+		"some unrelated assertion message",
+		"panic: runtime error: nil pointer dereference\nError: some unrelated assertion message\n",
+		"trace.go:1",
+	)
+	require.Equal(t, "panic", fp)
+
+	// No testify Error: at all (non-framework failure). Consequence
+	// patterns are the only signal — fall back to them.
+	fp = fingerprintFromTestOutput("", "process exited with exit status 137\n", "")
+	require.Equal(t, "exit-error", fp)
+
+	// Two failures at the same outer wrapper but with different teardown
+	// noise: must land in the same trace-site bucket.
+	fpA := fingerprintFromTestOutput(
+		"Condition never satisfied",
+		`error="exit status 1"`+"\nError: Condition never satisfied\n",
+		"red_test.go:424",
+	)
+	fpB := fingerprintFromTestOutput(
+		"Condition never satisfied",
+		"received signal: interrupt\nError: Condition never satisfied\n",
+		"red_test.go:424",
+	)
+	require.Equal(t, fpA, fpB)
+}
+
 func TestFingerprintUnknownHashing_TraceSite(t *testing.T) {
 	// Two failures at the same trace site should hash identically even
 	// when the error wording differs slightly.

--- a/scripts/ci-analysis/ci_analysis_test.go
+++ b/scripts/ci-analysis/ci_analysis_test.go
@@ -166,7 +166,7 @@ func TestFingerprintErrorMsgPriority(t *testing.T) {
 	fp := fingerprintFromTestOutput("connection refused", snippet, "")
 	require.Equal(t, "connection-refused", fp)
 
-	// When the error message has no recognised pattern, fall back to
+	// When the error message has no recognized pattern, fall back to
 	// the snippet scan.
 	fp = fingerprintFromTestOutput("zorblax not converged", "WARNING: DATA RACE\n", "")
 	require.Equal(t, "data-race", fp)

--- a/scripts/ci-analysis/ci_analysis_test.go
+++ b/scripts/ci-analysis/ci_analysis_test.go
@@ -238,6 +238,23 @@ func TestFingerprintUnknownHashing_TraceSite(t *testing.T) {
 	require.NotEqual(t, fp1, fp3)
 }
 
+func TestExtractErrorBlock_IgnoresUnanchoredErrorLines(t *testing.T) {
+	// Application log lines that contain "Error:" or "Error Trace:" must
+	// not be picked up as the testify framework error. Only indented
+	// labeled lines (testify's emission style) should match.
+	output := []string{
+		"Error: app log before testify\n",
+		"2026/04/29 13:48:19 ERROR Error Trace: spurious.go:1\n",
+		"        \tError Trace:\tfoo_test.go:42\n",
+		"        \tError:      \tReal testify failure\n",
+		"--- FAIL: TestX (0.50s)\n",
+		"Error: app log after the FAIL marker\n",
+	}
+	msg, trace := extractErrorBlock(output)
+	require.Equal(t, "foo_test.go:42", trace)
+	require.Equal(t, "Real testify failure", msg)
+}
+
 func TestExtractErrorBlock(t *testing.T) {
 	// testify-style output with Error Trace, Error: with a continuation
 	// line, then Test: label and FAIL marker.

--- a/scripts/ci-analysis/ci_analysis_test.go
+++ b/scripts/ci-analysis/ci_analysis_test.go
@@ -145,17 +145,80 @@ func TestWriteReport(t *testing.T) {
 
 func TestFingerprintUnknownHashing(t *testing.T) {
 	// Two different unknown errors should get different fingerprints.
-	fp1 := fingerprintFromTestOutput("some weird error A")
-	fp2 := fingerprintFromTestOutput("some weird error B")
+	fp1 := fingerprintFromTestOutput("", "some weird error A", "")
+	fp2 := fingerprintFromTestOutput("", "some weird error B", "")
 	require.Contains(t, fp1, "unknown-")
 	require.Contains(t, fp2, "unknown-")
 	require.NotEqual(t, fp1, fp2)
 
 	// Same error should get the same fingerprint.
-	require.Equal(t, fp1, fingerprintFromTestOutput("some weird error A"))
+	require.Equal(t, fp1, fingerprintFromTestOutput("", "some weird error A", ""))
 
-	// Empty snippet stays plain "unknown".
-	require.Equal(t, "unknown", fingerprintFromTestOutput(""))
+	// Empty inputs stay plain "unknown".
+	require.Equal(t, "unknown", fingerprintFromTestOutput("", "", ""))
+}
+
+func TestFingerprintErrorMsgPriority(t *testing.T) {
+	// Error message pattern wins over an incidental snippet pattern.
+	// Here the snippet contains a panic from teardown but the actual
+	// assertion was a connection-refused: connection-refused must win.
+	snippet := "panic: goroutine teardown\n    Error: connection refused\n"
+	fp := fingerprintFromTestOutput("connection refused", snippet, "")
+	require.Equal(t, "connection-refused", fp)
+
+	// When the error message has no recognised pattern, fall back to
+	// the snippet scan.
+	fp = fingerprintFromTestOutput("zorblax not converged", "WARNING: DATA RACE\n", "")
+	require.Equal(t, "data-race", fp)
+}
+
+func TestFingerprintUnknownHashing_TraceSite(t *testing.T) {
+	// Two failures at the same trace site should hash identically even
+	// when the error wording differs slightly.
+	fp1 := fingerprintFromTestOutput("expected 5 got 4", "", "foo_test.go:42")
+	fp2 := fingerprintFromTestOutput("expected 7 got 3", "", "foo_test.go:42")
+	require.Equal(t, fp1, fp2)
+	require.Contains(t, fp1, "unknown-")
+
+	// Different trace sites should hash differently.
+	fp3 := fingerprintFromTestOutput("expected 5 got 4", "", "bar_test.go:99")
+	require.NotEqual(t, fp1, fp3)
+}
+
+func TestExtractErrorBlock(t *testing.T) {
+	// testify-style output with Error Trace, Error: with a continuation
+	// line, then Test: label and FAIL marker.
+	output := []string{
+		"=== RUN   TestX\n",
+		"    file_test.go:25: \n",
+		"        \tError Trace:\tfoo_test.go:42\n",
+		"        \tError:      \tReceived unexpected error:\n",
+		"        \t            \tconnection refused\n",
+		"        \tTest:       \tTestX\n",
+		"--- FAIL: TestX (0.50s)\n",
+	}
+	msg, trace := extractErrorBlock(output)
+	require.Equal(t, "foo_test.go:42", trace)
+	require.Contains(t, msg, "Received unexpected error:")
+	require.Contains(t, msg, "connection refused")
+	// Continuation collection must stop at the Test: label.
+	require.NotContains(t, msg, "TestX")
+
+	// Output with no testify labels returns empty values.
+	msg, trace = extractErrorBlock([]string{"=== RUN   TestY\n", "panic: nope\n"})
+	require.Empty(t, msg)
+	require.Empty(t, trace)
+
+	// When multiple Error: blocks are present, the last one wins.
+	output = []string{
+		"        \tError Trace:\tfirst.go:10\n",
+		"        \tError:      \tearly failure\n",
+		"        \tError Trace:\tsecond.go:20\n",
+		"        \tError:      \tlate failure\n",
+	}
+	msg, trace = extractErrorBlock(output)
+	require.Equal(t, "second.go:20", trace)
+	require.Contains(t, msg, "late failure")
 }
 
 func TestClassifyOutcome(t *testing.T) {

--- a/scripts/ci-analysis/fingerprint.go
+++ b/scripts/ci-analysis/fingerprint.go
@@ -139,7 +139,7 @@ func extractErrorBlock(output []string) (errorMsg, traceSite string) {
 //     (e.g. an obi process being killed during teardown after an
 //     assertion already failed).
 //  4. No testify Error:: fall through to consequence patterns in the
-//     snippet so unframed failures still get a recognisable label.
+//     snippet so unframed failures still get a recognizable label.
 //  5. Final fallback: stable hash anchored on traceSite when present.
 func fingerprintFromTestOutput(errorMsg, snippet, traceSite string) string {
 	if errorMsg != "" {

--- a/scripts/ci-analysis/fingerprint.go
+++ b/scripts/ci-analysis/fingerprint.go
@@ -57,16 +57,93 @@ var snippetRE = func() *regexp.Regexp {
 	return regexp.MustCompile(strings.Join(parts, "|"))
 }()
 
-func fingerprintFromTestOutput(snippet string) string {
-	if snippet == "" {
-		return "unknown"
-	}
-	for _, ep := range errorPatterns {
-		if ep.regex.MatchString(snippet) {
-			return ep.fingerprint
+// errorTraceRE captures the file:line on the same line as a testify
+// "Error Trace:" label.
+var errorTraceRE = regexp.MustCompile(`Error Trace:\s+(\S+:\d+)`)
+
+// errorMsgRE captures the inline message after a testify "Error:" label.
+var errorMsgRE = regexp.MustCompile(`Error:\s+(.*)`)
+
+// labeledLineRE detects the start of a new testify-style labeled section,
+// used to stop collecting Error: continuation lines.
+var labeledLineRE = regexp.MustCompile(`^\s*(Error Trace|Error|Test|Messages):\s`)
+
+// extractErrorBlock walks failOutput looking for the last testify-style
+// Error Trace and Error message. Returns the trace site (e.g.
+// "foo_test.go:42") and the error message text including any indented
+// continuation lines beneath the Error: label. Either may be empty if
+// the test framework didn't emit testify-style output.
+func extractErrorBlock(output []string) (errorMsg, traceSite string) {
+	msgIdx := -1
+	for i := len(output) - 1; i >= 0; i-- {
+		if errorMsgRE.MatchString(output[i]) {
+			msgIdx = i
+			break
 		}
 	}
-	// Hash the first non-empty line to group identical unknown errors.
+	if msgIdx >= 0 {
+		if m := errorMsgRE.FindStringSubmatch(output[msgIdx]); len(m) >= 2 {
+			errorMsg = strings.TrimSpace(m[1])
+		}
+		for j := msgIdx + 1; j < len(output); j++ {
+			line := output[j]
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			if labeledLineRE.MatchString(line) || strings.Contains(line, "--- FAIL") {
+				break
+			}
+			if errorMsg == "" {
+				errorMsg = trimmed
+			} else {
+				errorMsg += " " + trimmed
+			}
+			if len(errorMsg) > 300 {
+				errorMsg = errorMsg[:300]
+				break
+			}
+		}
+	}
+
+	for i := len(output) - 1; i >= 0; i-- {
+		if m := errorTraceRE.FindStringSubmatch(output[i]); len(m) >= 2 {
+			traceSite = m[1]
+			break
+		}
+	}
+	return errorMsg, traceSite
+}
+
+// fingerprintFromTestOutput picks an error fingerprint for a failed test.
+// errorMsg (the testify Error: text, when present) takes precedence over
+// snippet because it pinpoints the assertion that actually failed; this
+// avoids attributing failures to incidental log noise. traceSite, if
+// available, anchors the unknown-XXXX hash so the same assertion site
+// groups together regardless of message wording.
+func fingerprintFromTestOutput(errorMsg, snippet, traceSite string) string {
+	if errorMsg != "" {
+		for _, ep := range errorPatterns {
+			if ep.regex.MatchString(errorMsg) {
+				return ep.fingerprint
+			}
+		}
+	}
+	if snippet != "" {
+		for _, ep := range errorPatterns {
+			if ep.regex.MatchString(snippet) {
+				return ep.fingerprint
+			}
+		}
+	}
+	if traceSite != "" {
+		h := sha256.Sum256([]byte(traceSite))
+		return fmt.Sprintf("unknown-%x", h[:4])
+	}
+	if errorMsg != "" {
+		h := sha256.Sum256([]byte(errorMsg))
+		return fmt.Sprintf("unknown-%x", h[:4])
+	}
 	for _, line := range strings.Split(snippet, "\n") {
 		if t := strings.TrimSpace(line); t != "" {
 			h := sha256.Sum256([]byte(t))

--- a/scripts/ci-analysis/fingerprint.go
+++ b/scripts/ci-analysis/fingerprint.go
@@ -23,28 +23,36 @@ type logError struct {
 	snippet     string
 }
 
-// errorPatterns is the ordered list of known CI failure patterns.
-// Add new patterns here — they automatically extend fingerprinting
-// and snippet extraction. First match wins.
-var errorPatterns = []struct {
+// errorPattern pairs a regex with its fingerprint label. consequence is
+// true for patterns that frequently appear as fallout from an earlier
+// failure (teardown noise, generic exit codes, cancellation signals).
+// Consequence patterns are only treated as the root cause when no cause
+// pattern matched and the test framework didn't surface its own error.
+type errorPattern struct {
 	regex       *regexp.Regexp
 	fingerprint string
-}{
-	{regexp.MustCompile(`(?i)port is already allocated`), "port-conflict"},
-	{regexp.MustCompile(`(?i)address already in use`), "port-conflict"},
-	{regexp.MustCompile(`(?i)Bind for .+ failed`), "port-conflict"},
-	{regexp.MustCompile(`(?i)DATA RACE`), "data-race"},
-	{regexp.MustCompile(`(?i)context deadline exceeded`), "timeout"},
-	{regexp.MustCompile(`(?i)test timed out after`), "timeout"},
-	{regexp.MustCompile(`(?i)no space left on device`), "disk-full"},
-	{regexp.MustCompile(`(?i)connection refused`), "connection-refused"},
-	{regexp.MustCompile(`(?i)Error response from daemon`), "docker-error"},
-	{regexp.MustCompile(`(?i)Cannot connect to the Docker daemon`), "docker-error"},
-	{regexp.MustCompile(`(?i)OCI runtime create failed`), "docker-error"},
-	{regexp.MustCompile(`(?i)panic:`), "panic"},
-	{regexp.MustCompile(`(?i)signal: killed`), "oom-killed"},
-	{regexp.MustCompile(`(?i)received signal: interrupt`), "cancelled"},
-	{regexp.MustCompile(`(?i)exit status \d+`), "exit-error"},
+	consequence bool
+}
+
+// errorPatterns is the ordered list of known CI failure patterns. Add
+// new patterns here — they automatically extend fingerprinting and
+// snippet extraction. First match wins within each priority tier.
+var errorPatterns = []errorPattern{
+	{regexp.MustCompile(`(?i)port is already allocated`), "port-conflict", false},
+	{regexp.MustCompile(`(?i)address already in use`), "port-conflict", false},
+	{regexp.MustCompile(`(?i)Bind for .+ failed`), "port-conflict", false},
+	{regexp.MustCompile(`(?i)DATA RACE`), "data-race", false},
+	{regexp.MustCompile(`(?i)context deadline exceeded`), "timeout", false},
+	{regexp.MustCompile(`(?i)test timed out after`), "timeout", false},
+	{regexp.MustCompile(`(?i)no space left on device`), "disk-full", false},
+	{regexp.MustCompile(`(?i)connection refused`), "connection-refused", false},
+	{regexp.MustCompile(`(?i)Error response from daemon`), "docker-error", false},
+	{regexp.MustCompile(`(?i)Cannot connect to the Docker daemon`), "docker-error", false},
+	{regexp.MustCompile(`(?i)OCI runtime create failed`), "docker-error", false},
+	{regexp.MustCompile(`(?i)panic:`), "panic", false},
+	{regexp.MustCompile(`(?i)signal: killed`), "oom-killed", false},
+	{regexp.MustCompile(`(?i)received signal: interrupt`), "cancelled", true},
+	{regexp.MustCompile(`(?i)exit status \d+`), "exit-error", true},
 }
 
 // snippetRE matches lines worth including in error snippets: Go test
@@ -116,11 +124,23 @@ func extractErrorBlock(output []string) (errorMsg, traceSite string) {
 }
 
 // fingerprintFromTestOutput picks an error fingerprint for a failed test.
-// errorMsg (the testify Error: text, when present) takes precedence over
-// snippet because it pinpoints the assertion that actually failed; this
-// avoids attributing failures to incidental log noise. traceSite, if
-// available, anchors the unknown-XXXX hash so the same assertion site
-// groups together regardless of message wording.
+//
+// Priority:
+//  1. Any pattern matching the testify Error: line (errorMsg) wins. When
+//     the framework explicitly surfaces a known error there, that's the
+//     cause regardless of whether the pattern is a cause or consequence
+//     (e.g. testify reporting "Received unexpected error: exit status 1"
+//     IS the assertion failure).
+//  2. Cause patterns matching the surrounding snippet (panic, port
+//     conflict, etc.). These dominate teardown noise.
+//  3. If a testify Error: was captured but matched nothing in (1) or
+//     (2), prefer an unknown-<trace-site> hash over consequence patterns
+//     in the snippet — those are usually fallout from the real failure
+//     (e.g. an obi process being killed during teardown after an
+//     assertion already failed).
+//  4. No testify Error:: fall through to consequence patterns in the
+//     snippet so unframed failures still get a recognisable label.
+//  5. Final fallback: stable hash anchored on traceSite when present.
 func fingerprintFromTestOutput(errorMsg, snippet, traceSite string) string {
 	if errorMsg != "" {
 		for _, ep := range errorPatterns {
@@ -131,6 +151,27 @@ func fingerprintFromTestOutput(errorMsg, snippet, traceSite string) string {
 	}
 	if snippet != "" {
 		for _, ep := range errorPatterns {
+			if ep.consequence {
+				continue
+			}
+			if ep.regex.MatchString(snippet) {
+				return ep.fingerprint
+			}
+		}
+	}
+	if errorMsg != "" {
+		if traceSite != "" {
+			h := sha256.Sum256([]byte(traceSite))
+			return fmt.Sprintf("unknown-%x", h[:4])
+		}
+		h := sha256.Sum256([]byte(errorMsg))
+		return fmt.Sprintf("unknown-%x", h[:4])
+	}
+	if snippet != "" {
+		for _, ep := range errorPatterns {
+			if !ep.consequence {
+				continue
+			}
 			if ep.regex.MatchString(snippet) {
 				return ep.fingerprint
 			}
@@ -138,10 +179,6 @@ func fingerprintFromTestOutput(errorMsg, snippet, traceSite string) string {
 	}
 	if traceSite != "" {
 		h := sha256.Sum256([]byte(traceSite))
-		return fmt.Sprintf("unknown-%x", h[:4])
-	}
-	if errorMsg != "" {
-		h := sha256.Sum256([]byte(errorMsg))
 		return fmt.Sprintf("unknown-%x", h[:4])
 	}
 	for _, line := range strings.Split(snippet, "\n") {

--- a/scripts/ci-analysis/fingerprint.go
+++ b/scripts/ci-analysis/fingerprint.go
@@ -16,7 +16,10 @@ import (
 	"strings"
 )
 
-const maxSnippetLen = 500
+const (
+	maxSnippetLen  = 500
+	maxErrorMsgLen = 300
+)
 
 type logError struct {
 	fingerprint string
@@ -66,15 +69,20 @@ var snippetRE = func() *regexp.Regexp {
 }()
 
 // errorTraceRE captures the file:line on the same line as a testify
-// "Error Trace:" label.
-var errorTraceRE = regexp.MustCompile(`Error Trace:\s+(\S+:\d+)`)
+// "Error Trace:" label. Anchored with `^\s+` so application log lines
+// that merely contain the substring (e.g. an app printing "Error Trace:
+// ..." mid-line) don't match — testify always indents its labeled
+// output. Multiline mode lets `^` match at line breaks inside multi-line
+// Output events.
+var errorTraceRE = regexp.MustCompile(`(?m)^\s+Error Trace:\s+(\S+:\d+)`)
 
 // errorMsgRE captures the inline message after a testify "Error:" label.
-var errorMsgRE = regexp.MustCompile(`Error:\s+(.*)`)
+// See errorTraceRE for the anchoring rationale.
+var errorMsgRE = regexp.MustCompile(`(?m)^\s+Error:\s+(.*)`)
 
 // labeledLineRE detects the start of a new testify-style labeled section,
 // used to stop collecting Error: continuation lines.
-var labeledLineRE = regexp.MustCompile(`^\s*(Error Trace|Error|Test|Messages):\s`)
+var labeledLineRE = regexp.MustCompile(`^\s+(Error Trace|Error|Test|Messages):\s`)
 
 // extractErrorBlock walks failOutput looking for the last testify-style
 // Error Trace and Error message. Returns the trace site (e.g.
@@ -107,8 +115,8 @@ func extractErrorBlock(output []string) (errorMsg, traceSite string) {
 			} else {
 				errorMsg += " " + trimmed
 			}
-			if len(errorMsg) > 300 {
-				errorMsg = errorMsg[:300]
+			if len(errorMsg) > maxErrorMsgLen {
+				errorMsg = errorMsg[:maxErrorMsgLen]
 				break
 			}
 		}
@@ -138,7 +146,7 @@ func extractErrorBlock(output []string) (errorMsg, traceSite string) {
 //     in the snippet — those are usually fallout from the real failure
 //     (e.g. an obi process being killed during teardown after an
 //     assertion already failed).
-//  4. No testify Error:: fall through to consequence patterns in the
+//  4. No testify Error: fall through to consequence patterns in the
 //     snippet so unframed failures still get a recognizable label.
 //  5. Final fallback: stable hash anchored on traceSite when present.
 func fingerprintFromTestOutput(errorMsg, snippet, traceSite string) string {

--- a/scripts/ci-analysis/parse.go
+++ b/scripts/ci-analysis/parse.go
@@ -198,7 +198,8 @@ func parseGotestsum(r io.Reader, meta RunMeta, shard string) ([]TestResult, erro
 		}
 		if r.Outcome == "failed" || r.Outcome == "flaky-passed" {
 			r.ErrorSnippet = extractErrorSnippet(ts.failOutput)
-			r.ErrorFingerprint = fingerprintFromTestOutput(r.ErrorSnippet)
+			errorMsg, traceSite := extractErrorBlock(ts.failOutput)
+			r.ErrorFingerprint = fingerprintFromTestOutput(errorMsg, r.ErrorSnippet, traceSite)
 		}
 		results = append(results, r)
 	}


### PR DESCRIPTION
## Summary

This PR makes it more likely to group similar errors by:

1. Group similar `unknown` fingerprints by hashing the file name and line number
2. Improve error attribution by preferring specific errors over general errors

Test run [here](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/25162112333) - compare against the [daily run](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/25151510047).

Notice that `TestSuite_Go` was previously marked as a generic `exit-error`, in the new run it is classified as `unknown-4fe9d98c` which is grouped with other similar failures due to the stable hashing.


## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
