### PR TITLE
Split ring buffer reader and parser into separate goroutines, reduce mutex overhead

### DIFF
--- a/pkg/ebpf/common/ringbuf.go
+++ b/pkg/ebpf/common/ringbuf.go
@@ -273,55 +273,73 @@ func (rbf *ringBufForwarder[T]) parserLoop(
 	workIdx <-chan int,
 	out *msg.Queue[[]T],
 ) {
+	pending := make([]int, 0, cap(workIdx))
+	parsed := make([]T, 0, cap(workIdx))
+
 	for {
-		var i int
-		var ok bool
+		pending = pending[:0]
+		parsed = parsed[:0]
+
+		// Block until at least one record is ready.
 		select {
 		case <-ctx.Done():
 			return
-		case i, ok = <-workIdx:
+		case i, ok := <-workIdx:
 			if !ok {
 				return
 			}
+			pending = append(pending, i)
+		}
+
+		// Drain any additional records that are already waiting.
+		for {
+			select {
+			case i, ok := <-workIdx:
+				if ok {
+					pending = append(pending, i)
+					continue
+				}
+			default:
+			}
+			break
 		}
 
 		if depth := len(workIdx); depth == cap(workIdx)-1 {
 			rbf.logger.Debug("parser falling behind: work queue full", "depth", depth+1)
 		}
 
-		rbf.parseAndAccumulate(ctx, i, records, freeIdx, out)
-	}
-}
-
-func (rbf *ringBufForwarder[T]) parseAndAccumulate(
-	ctx context.Context,
-	i int,
-	records []ringbuf.Record,
-	freeIdx chan<- int,
-	out *msg.Queue[[]T],
-) {
-	item, ignore, err := rbf.parse(&records[i])
-	freeIdx <- i
-
-	if err != nil {
-		rbf.logger.Debug("error parsing perf event", "error", err)
-		return
-	}
-	if ignore {
-		return
-	}
-
-	rbf.access.Lock()
-	rbf.items[rbf.itemsLen] = item
-	rbf.itemsLen++
-	if rbf.itemsLen == rbf.cfg.BatchLength {
-		rbf.logger.Debug("submitting batch (full)", "len", rbf.itemsLen)
-		rbf.flushEvents(ctx, out)
-		if rbf.ticker != nil {
-			rbf.ticker.Reset(rbf.cfg.BatchTimeout)
+		// Parse outside the lock, return each slot to the pool immediately.
+		for _, i := range pending {
+			item, ignore, err := rbf.parse(&records[i])
+			freeIdx <- i
+			if err != nil {
+				rbf.logger.Debug("error parsing perf event", "error", err)
+				continue
+			}
+			if !ignore {
+				parsed = append(parsed, item)
+			}
 		}
+
+		if len(parsed) == 0 {
+			continue
+		}
+
+		// Lock once to enqueue the whole batch.
+		rbf.access.Lock()
+		for _, item := range parsed {
+			rbf.items[rbf.itemsLen] = item
+			rbf.itemsLen++
+			if rbf.itemsLen == rbf.cfg.BatchLength {
+				rbf.logger.Debug("submitting batch (full)", "len", rbf.itemsLen)
+				rbf.flushEvents(ctx, out)
+				if rbf.ticker != nil {
+					rbf.ticker.Reset(rbf.cfg.BatchTimeout)
+				}
+			}
+		}
+		rbf.access.Unlock()
 	}
-	rbf.access.Unlock()
 }
 
 func (rbf *ringBufForwarder[T]) storeLastReadAt(t time.Time) {

--- a/pkg/ebpf/common/ringbuf.go
+++ b/pkg/ebpf/common/ringbuf.go
@@ -293,6 +293,10 @@ func (rbf *ringBufForwarder[T]) parserLoop(
 			pending = append(pending, i)
 		}
 
+		if depth := len(workIdx); depth == cap(workIdx)-1 {
+			rbf.logger.Debug("parser falling behind: work queue full", "depth", depth+1)
+		}
+
 		// Drain any additional records that are already waiting.
 		for {
 			select {
@@ -304,10 +308,6 @@ func (rbf *ringBufForwarder[T]) parserLoop(
 			default:
 			}
 			break
-		}
-
-		if depth := len(workIdx); depth == cap(workIdx)-1 {
-			rbf.logger.Debug("parser falling behind: work queue full", "depth", depth+1)
 		}
 
 		// Parse outside the lock, return each slot to the pool immediately.

--- a/pkg/ebpf/common/ringbuf.go
+++ b/pkg/ebpf/common/ringbuf.go
@@ -188,6 +188,8 @@ func (rbf *ringBufForwarder[T]) readAndForwardInner(ctx context.Context, eventsR
 	rbf.items = make([]T, rbf.cfg.BatchLength)
 	rbf.itemsLen = 0
 
+	// 2x: one batch for the parser to work on, one for the reader to fill concurrently.
+	// Smaller would stall the reader while waiting for the parser to finish.
 	poolSize := 2 * rbf.cfg.BatchLength
 	records := make([]ringbuf.Record, poolSize)
 	freeIdx := make(chan int, poolSize)

--- a/pkg/ebpf/common/ringbuf.go
+++ b/pkg/ebpf/common/ringbuf.go
@@ -134,7 +134,7 @@ func (rbf *ringBufForwarder[T]) sharedReadAndForward(ctx context.Context, closer
 	// user space.
 	eventsReader, err := readerFactory(rbf.ringbuffer)
 	if err != nil {
-		rbf.logger.Error("creating perf reader. Exiting", "error", err)
+		rbf.logger.Error("creating ring buffer reader. Exiting", "error", err)
 		return
 	}
 	// If the underlying context is closed, it closes the objects we have allocated for this bpf program
@@ -148,7 +148,7 @@ func (rbf *ringBufForwarder[T]) readAndForward(ctx context.Context, out *msg.Que
 	// user space.
 	eventsReader, err := readerFactory(rbf.ringbuffer)
 	if err != nil {
-		rbf.logger.Error("creating perf reader. Exiting", "error", err)
+		rbf.logger.Error("creating ring buffer reader. Exiting", "error", err)
 		return
 	}
 	rbf.closers = append(rbf.closers, eventsReader)
@@ -251,7 +251,7 @@ func (rbf *ringBufForwarder[T]) fillAndDispatch(
 			rbf.logger.Debug("ring buffer is closed")
 			return false
 		default:
-			rbf.logger.Error("error reading from perf reader", "error", err)
+			rbf.logger.Error("error reading from ring buffer", "error", err)
 			return true
 		}
 	}
@@ -313,7 +313,7 @@ func (rbf *ringBufForwarder[T]) parserLoop(
 			item, ignore, err := rbf.parse(&records[i])
 			freeIdx <- i
 			if err != nil {
-				rbf.logger.Debug("error parsing perf event", "error", err)
+				rbf.logger.Debug("error parsing ring buffer event", "error", err)
 				continue
 			}
 			if !ignore {

--- a/pkg/ebpf/common/ringbuf.go
+++ b/pkg/ebpf/common/ringbuf.go
@@ -137,9 +137,6 @@ func (rbf *ringBufForwarder[T]) sharedReadAndForward(ctx context.Context, closer
 		rbf.logger.Error("creating perf reader. Exiting", "error", err)
 		return
 	}
-	rbf.items = make([]T, rbf.cfg.BatchLength)
-	rbf.itemsLen = 0
-
 	// If the underlying context is closed, it closes the objects we have allocated for this bpf program
 	go rbf.bgListenSharedContextCancelation(ctx, closers, eventsReader)
 	rbf.readAndForwardInner(ctx, eventsReader, out)
@@ -156,9 +153,6 @@ func (rbf *ringBufForwarder[T]) readAndForward(ctx context.Context, out *msg.Que
 	}
 	rbf.closers = append(rbf.closers, eventsReader)
 	defer rbf.closeAllResources()
-
-	rbf.items = make([]T, rbf.cfg.BatchLength)
-	rbf.itemsLen = 0
 
 	// If the underlying context is closed, it closes the events reader
 	// so the function can exit.
@@ -185,45 +179,149 @@ func (rbf *ringBufForwarder[T]) flushOnAvailableBytes(ctx context.Context, event
 }
 
 func (rbf *ringBufForwarder[T]) readAndForwardInner(ctx context.Context, eventsReader ringBufReader, out *msg.Queue[[]T]) {
-	// Forwards periodically on timeout, if the batch is not full
 	if rbf.cfg.BatchTimeout > 0 {
 		rbf.ticker = time.NewTicker(rbf.cfg.BatchTimeout)
 		go rbf.bgFlushOnTimeout(ctx, out)
 	}
-
-	// Ensure we periodically flush any pending bytes
 	go rbf.flushOnAvailableBytes(ctx, eventsReader)
 
-	// Main loop:
-	// 1. Listen for content in the ring buffer
-	// 2. Decode binary data into HTTPRequestTrace instance
-	// 3. Accumulate the HTTPRequestTrace into a batch slice
-	// 4. When the length of the batch slice reaches cfg.BatchLength,
-	//    submit it to the next stage of the pipeline
+	rbf.items = make([]T, rbf.cfg.BatchLength)
+	rbf.itemsLen = 0
 
-	// We just log the first ring buffer read to check that the eBPF side is sending stuff
-	// Logging each message adds few information and a lot of noise to the debug logs
-	// in production systems with thousands of messages per second
+	poolSize := 2 * rbf.cfg.BatchLength
+	records := make([]ringbuf.Record, poolSize)
+	freeIdx := make(chan int, poolSize)
+	workIdx := make(chan int, poolSize)
+	for i := range poolSize {
+		freeIdx <- i
+	}
+
+	go rbf.parserLoop(ctx, records, freeIdx, workIdx, out)
+
 	rbf.logger.Debug("starting to read ring buffer")
+	rbf.readerLoop(ctx, eventsReader, records, freeIdx, workIdx)
+}
 
-	var record ringbuf.Record
+func (rbf *ringBufForwarder[T]) readerLoop(
+	ctx context.Context,
+	eventsReader ringBufReader,
+	records []ringbuf.Record,
+	freeIdx chan int,
+	workIdx chan<- int,
+) {
+	defer close(workIdx)
+
 	for {
-		err := eventsReader.ReadInto(&record)
-		if err != nil {
-			if errors.Is(err, ringbuf.ErrFlushed) {
-				rbf.logger.Debug("ring buffer already flushed")
-				continue
+		var i int
+		select {
+		case <-ctx.Done():
+			return
+		case i = <-freeIdx:
+		default:
+			rbf.logger.Debug("reader stalled: record pool exhausted",
+				"pool_size", len(records), "pending_parse", len(workIdx))
+			select {
+			case <-ctx.Done():
+				return
+			case i = <-freeIdx:
 			}
-			if errors.Is(err, ringbuf.ErrClosed) {
-				rbf.logger.Debug("ring buffer is closed")
+		}
+
+		if !rbf.fillAndDispatch(ctx, i, eventsReader, records, freeIdx, workIdx) {
+			return
+		}
+	}
+}
+
+func (rbf *ringBufForwarder[T]) fillAndDispatch(
+	ctx context.Context,
+	i int,
+	eventsReader ringBufReader,
+	records []ringbuf.Record,
+	freeIdx chan int,
+	workIdx chan<- int,
+) bool {
+	if err := eventsReader.ReadInto(&records[i]); err != nil {
+		freeIdx <- i
+		switch {
+		case errors.Is(err, ringbuf.ErrFlushed):
+			rbf.logger.Debug("ring buffer already flushed")
+			return true
+		case errors.Is(err, ringbuf.ErrClosed):
+			rbf.logger.Debug("ring buffer is closed")
+			return false
+		default:
+			rbf.logger.Error("error reading from perf reader", "error", err)
+			return true
+		}
+	}
+
+	rbf.storeLastReadAt(time.Now())
+
+	select {
+	case workIdx <- i:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (rbf *ringBufForwarder[T]) parserLoop(
+	ctx context.Context,
+	records []ringbuf.Record,
+	freeIdx chan<- int,
+	workIdx <-chan int,
+	out *msg.Queue[[]T],
+) {
+	for {
+		var i int
+		var ok bool
+		select {
+		case <-ctx.Done():
+			return
+		case i, ok = <-workIdx:
+			if !ok {
 				return
 			}
-			rbf.logger.Error("error reading from perf reader", "error", err)
-			continue
 		}
-		rbf.storeLastReadAt(time.Now())
-		rbf.processAndForward(ctx, record, out)
+
+		if depth := len(workIdx); depth == cap(workIdx)-1 {
+			rbf.logger.Debug("parser falling behind: work queue full", "depth", depth+1)
+		}
+
+		rbf.parseAndAccumulate(ctx, i, records, freeIdx, out)
 	}
+}
+
+func (rbf *ringBufForwarder[T]) parseAndAccumulate(
+	ctx context.Context,
+	i int,
+	records []ringbuf.Record,
+	freeIdx chan<- int,
+	out *msg.Queue[[]T],
+) {
+	item, ignore, err := rbf.parse(&records[i])
+	freeIdx <- i
+
+	if err != nil {
+		rbf.logger.Debug("error parsing perf event", "error", err)
+		return
+	}
+	if ignore {
+		return
+	}
+
+	rbf.access.Lock()
+	rbf.items[rbf.itemsLen] = item
+	rbf.itemsLen++
+	if rbf.itemsLen == rbf.cfg.BatchLength {
+		rbf.logger.Debug("submitting batch (full)", "len", rbf.itemsLen)
+		rbf.flushEvents(ctx, out)
+		if rbf.ticker != nil {
+			rbf.ticker.Reset(rbf.cfg.BatchTimeout)
+		}
+	}
+	rbf.access.Unlock()
 }
 
 func (rbf *ringBufForwarder[T]) storeLastReadAt(t time.Time) {
@@ -237,28 +335,6 @@ func (rbf *ringBufForwarder[T]) hasPendingReadIdleSince(now time.Time, interval 
 	}
 
 	return now.Sub(time.Unix(0, lastReadAtUnixNano)) > interval
-}
-
-func (rbf *ringBufForwarder[T]) processAndForward(ctx context.Context, record ringbuf.Record, out *msg.Queue[[]T]) {
-	rbf.access.Lock()
-	defer rbf.access.Unlock()
-	item, ignore, err := rbf.parse(&record)
-	if err != nil {
-		rbf.logger.Debug("error parsing perf event", "error", err)
-		return
-	}
-	if ignore {
-		return
-	}
-	rbf.items[rbf.itemsLen] = item
-	rbf.itemsLen++
-	if rbf.itemsLen == rbf.cfg.BatchLength {
-		rbf.logger.Debug("submitting batch (full)", "len", rbf.itemsLen)
-		rbf.flushEvents(ctx, out)
-		if rbf.ticker != nil {
-			rbf.ticker.Reset(rbf.cfg.BatchTimeout)
-		}
-	}
 }
 
 func (rbf *ringBufForwarder[T]) flushEvents(ctx context.Context, out *msg.Queue[[]T]) {

--- a/pkg/ebpf/common/ringbuf_bench_test.go
+++ b/pkg/ebpf/common/ringbuf_bench_test.go
@@ -30,7 +30,7 @@ const benchBatchLen = 100
 //
 //	go test -bench=BenchmarkForwardRingbuf -benchtime=5s ./pkg/ebpf/common/...
 func BenchmarkForwardRingbuf(b *testing.B) {
-	for _, latency := range []time.Duration{time.Microsecond, 10 * time.Microsecond} {
+	for _, latency := range []time.Duration{time.Microsecond, 10 * time.Microsecond, 100 * time.Microsecond} {
 		b.Run(fmt.Sprintf("latency=%v", latency), func(b *testing.B) {
 			benchForwardRingbuf(b, latency)
 		})
@@ -46,7 +46,9 @@ func benchForwardRingbuf(b *testing.B, latency time.Duration) {
 	n := ((b.N + benchBatchLen - 1) / benchBatchLen) * benchBatchLen
 
 	rb := &benchReader{n: n, latency: latency}
+	prevFactory := readerFactory
 	readerFactory = func(_ *ebpf.Map) (ringBufReader, error) { return rb, nil }
+	defer func() { readerFactory = prevFactory }()
 
 	cfg := &config.EBPFTracer{BatchLength: benchBatchLen}
 	parse := func(_ *ringbuf.Record) (request.Span, bool, error) {
@@ -59,7 +61,6 @@ func benchForwardRingbuf(b *testing.B, latency time.Duration) {
 	sub := out.Subscribe()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	fwd := ForwardRingbuf[request.Span](
 		cfg, nil, parse, nil,
@@ -67,14 +68,20 @@ func benchForwardRingbuf(b *testing.B, latency time.Duration) {
 		&metricsReporter{},
 	)
 
+	done := make(chan struct{})
 	b.ResetTimer()
-	go fwd(ctx, out)
+	go func() {
+		defer close(done)
+		fwd(ctx, out)
+	}()
 
 	for range batches {
 		<-sub
 	}
 
 	b.StopTimer()
+	cancel()
+	<-done
 	b.ReportMetric(float64(n)/b.Elapsed().Seconds(), "events/s")
 }
 

--- a/pkg/ebpf/common/ringbuf_bench_test.go
+++ b/pkg/ebpf/common/ringbuf_bench_test.go
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+)
+
+const benchBatchLen = 100
+
+// BenchmarkForwardRingbuf measures events/sec through the forwarder pipeline.
+//
+// latency is applied to both ReadInto (simulating BPF ring-buffer wake-up and
+// copy time) and parse (simulating span decoding). In the current design these
+// two phases run in separate goroutines; compare with benchstat against a commit
+// where they ran serially to see the parallelism gain.
+//
+//	go test -bench=BenchmarkForwardRingbuf -benchtime=5s ./pkg/ebpf/common/...
+func BenchmarkForwardRingbuf(b *testing.B) {
+	for _, latency := range []time.Duration{time.Microsecond, 10 * time.Microsecond} {
+		b.Run(fmt.Sprintf("latency=%v", latency), func(b *testing.B) {
+			benchForwardRingbuf(b, latency)
+		})
+	}
+}
+
+func benchForwardRingbuf(b *testing.B, latency time.Duration) {
+	b.Helper()
+
+	// Round up to a full batch so every flush is triggered by BatchLength events,
+	// not by a timeout. This avoids a stall on the last partial batch and keeps
+	// the measurement boundary clean.
+	n := ((b.N + benchBatchLen - 1) / benchBatchLen) * benchBatchLen
+
+	rb := &benchReader{n: n, latency: latency}
+	readerFactory = func(_ *ebpf.Map) (ringBufReader, error) { return rb, nil }
+
+	cfg := &config.EBPFTracer{BatchLength: benchBatchLen}
+	parse := func(_ *ringbuf.Record) (request.Span, bool, error) {
+		spin(latency)
+		return request.Span{Type: 1}, false, nil
+	}
+
+	batches := n / benchBatchLen
+	out := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(batches + 1))
+	sub := out.Subscribe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fwd := ForwardRingbuf[request.Span](
+		cfg, nil, parse, nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		&metricsReporter{},
+	)
+
+	b.ResetTimer()
+	go fwd(ctx, out)
+
+	for range batches {
+		<-sub
+	}
+
+	b.StopTimer()
+	b.ReportMetric(float64(n)/b.Elapsed().Seconds(), "events/s")
+}
+
+// benchReader delivers n records, each taking latency to produce, then closes.
+type benchReader struct {
+	n       int
+	latency time.Duration
+}
+
+func (r *benchReader) ReadInto(rec *ringbuf.Record) error {
+	if r.n == 0 {
+		return ringbuf.ErrClosed
+	}
+	r.n--
+	spin(r.latency)
+	rec.RawSample = nil
+	return nil
+}
+
+func (r *benchReader) Read() (ringbuf.Record, error) {
+	rec := ringbuf.Record{}
+	return rec, r.ReadInto(&rec)
+}
+
+func (r *benchReader) Close() error        { return nil }
+func (r *benchReader) AvailableBytes() int { return r.n }
+func (r *benchReader) Flush() error        { return nil }
+
+// spin burns CPU for approximately d without sleeping (avoids OS scheduler noise
+// for sub-millisecond durations).
+func spin(d time.Duration) {
+	if d == 0 {
+		return
+	}
+	end := time.Now().Add(d)
+	for time.Now().Before(end) {
+	}
+}

--- a/pkg/ebpf/common/ringbuf_test.go
+++ b/pkg/ebpf/common/ringbuf_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync/atomic"
@@ -176,6 +177,47 @@ func TestForwardRingbuf_Close(t *testing.T) {
 	// AND metrics haven't been updated
 	assert.Equal(t, 0, metrics.flushes)
 	assert.Equal(t, 0, metrics.flushedLen)
+}
+
+func TestForwardRingbuf_NoEventLoss(t *testing.T) {
+	const N = 10000
+	for _, batchLen := range []int{1, 10, 100} {
+		t.Run(fmt.Sprintf("batchLen=%d", batchLen), func(t *testing.T) {
+			ringBuf := replaceTestRingBuf()
+			cfg := &config.EBPFTracer{
+				BatchLength:  batchLen,
+				BatchTimeout: 10 * time.Millisecond,
+			}
+			out := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(N/batchLen + 10))
+			sub := out.Subscribe()
+
+			go ForwardRingbuf(
+				cfg, nil,
+				func(_ *ringbuf.Record) (request.Span, bool, error) {
+					return request.Span{Type: 1}, false, nil
+				},
+				nil,
+				slog.New(slog.NewTextHandler(io.Discard, nil)),
+				&metricsReporter{},
+			)(t.Context(), out)
+
+			for range N {
+				ringBuf.events <- HTTPRequestTrace{Type: 1}
+			}
+
+			received := 0
+			deadline := time.After(10 * time.Second)
+			for received < N {
+				select {
+				case batch := <-sub:
+					received += len(batch)
+				case <-deadline:
+					t.Fatalf("timeout: got %d/%d events", received, N)
+				}
+			}
+			assert.Equal(t, N, received)
+		})
+	}
 }
 
 func TestRingbufLastReadAtRace(t *testing.T) {


### PR DESCRIPTION
## Summary

Holding a mutex while doing work is an anti-pattern. We were holding `rbf.access` across the entire parse call on every event (and paying the context of locking unlocking the mutex).

This PR splits the work into two concurrent goroutines: a reader that drains the ring buffer into a record pool, and a parser that decodes and accumulates spans. The lock is now held only for the O(1) slice append, not during parse.

## Benchmark

`BenchmarkForwardRingbuf` vs main (`-benchtime=5s -count=10`, `benchstat`):

| parse cost | old | new | Δ |
|---|---|---|---|
| 1µs (HTTP trace decode) | 430k events/s | 727k events/s | **+69%** |
| 10µs (GoTracer + LRU lookup) | 49k events/s | 96k events/s | **+97%** |
| 100µs (unknown TCP protocol) | 5k events/s | 10k events/s | **+99%** |

p=0.000, n=10.


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
