### PR TITLE
fix(ebpf): fixed traceparent header parsing for 1KB+ http requests

### DIFF
--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -474,7 +474,8 @@ __obi_continue_protocol_http_tp(struct pt_regs *ctx,
 
         unsigned char *buf = (unsigned char *)tp_char_buf_mem();
         if (buf) {
-            const u16 buf_len = args->bytes_len & (TRACE_BUF_SIZE - 1);
+            u32 buf_len = args->bytes_len;
+            bpf_clamp_umax(buf_len, TRACE_BUF_SIZE - 1);
 
             bpf_probe_read(buf, buf_len, (void *)args->u_buf);
             // null terminate to make proper string

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -474,7 +474,7 @@ __obi_continue_protocol_http_tp(struct pt_regs *ctx,
 
         unsigned char *buf = (unsigned char *)tp_char_buf_mem();
         if (buf) {
-            u32 buf_len = args->bytes_len;
+            u16 buf_len = args->bytes_len;
             bpf_clamp_umax(buf_len, TRACE_BUF_SIZE - 1);
 
             bpf_probe_read(buf, buf_len, (void *)args->u_buf);

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -851,7 +851,7 @@ int obi_packet_extender_find_existing_tp(struct sk_msg_md *msg) {
 
     unsigned char *b = msg->data;
     const unsigned char *e = msg->data_end;
-    unsigned char *ptr = b + (niter * 1024);
+    unsigned char *ptr = b + (niter * k_max_chunk_size);
 
     if (ptr >= e) {
         return SK_PASS;

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -828,7 +828,8 @@ assign_parent_tp(const tailcall_ctx *t_ctx, tp_info_t *tp, unsigned char *span_i
 //k_tail_find_existing_tp
 SEC("sk_msg")
 int obi_packet_extender_find_existing_tp(struct sk_msg_md *msg) {
-    const u32 k_max_iter = 4; // iterate up to 4KB
+    const u32 k_max_iter = 4;          // iterate up to 4KB
+    const u32 k_max_chunk_size = 1024; // 1KB chunks per iteration
 
     tailcall_ctx *t_ctx = tailcall_ctx_mem();
 
@@ -858,7 +859,11 @@ int obi_packet_extender_find_existing_tp(struct sk_msg_md *msg) {
 
     bpf_dbg_printk("looking for traceparent header (iter=%u)", niter);
 
-    const u32 data_size = (e - ptr) & 0x3ff; // 1KB chunks per iteration
+    u32 data_size = e - ptr;
+
+    if (data_size > k_max_chunk_size) {
+        data_size = k_max_chunk_size;
+    }
 
     for (u32 i = 0; i < data_size; ++i) {
         if ((ptr + TP_SIZE >= e) || is_eoh(ptr)) {

--- a/internal/test/integration/components/http_proxy_server/Dockerfile
+++ b/internal/test/integration/components/http_proxy_server/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20@sha256:8f693eaa7e0a8e71560c9a82b55fd54c2ae920a2ba5d2cde28bac7d1c01c9ba5
+
+# Set the working directory to /build
+WORKDIR /
+
+# Copy the source code into the image for building
+COPY internal/test/integration/components/http_proxy_server .
+
+# Install dependencies from committed lockfile
+RUN npm ci
+
+EXPOSE 3030
+
+# Run the node app
+CMD [ "node", "app" ]

--- a/internal/test/integration/components/http_proxy_server/app.js
+++ b/internal/test/integration/components/http_proxy_server/app.js
@@ -1,0 +1,69 @@
+var express = require("express");
+const http = require("http");
+const net = require("net");
+const bodyParser = require("body-parser");
+var app = express();
+const port = 3030;
+
+const jsonParser = bodyParser.json()
+
+app.use(express.json({ limit: "50mb" }));
+
+function send({ host, port, rawRequest }) {
+  return new Promise((resolve, reject) => {
+    const client = net.createConnection(port, host);
+    let response = "";
+
+    client.on("connect", () => {
+      client.write(rawRequest);
+    });
+
+    client.on("data", (chunk) => {
+      response += chunk.toString("utf-8");
+    });
+
+    client.on("end", () => {
+      resolve(response);
+    });
+
+    client.on("error", (err) => {
+      reject(err);
+    });
+  });
+}
+
+app.get("/smoke", (req, res, next) => {
+  res.json("healthy");
+})
+
+app.get("/greeting", (req, res, next) => {
+  res.json("Hello!");
+});
+
+app.get("/bye", (req, res, next) => {
+  res.json(`Bye!`);
+});
+
+app.post("/dial", jsonParser, async (req, res, next) => {
+  if (!req.body || !req.body.rawRequest || !req.body.host) {
+    res.sendStatus(400);
+  }
+
+  try {
+    const [host, port] = req.body.host.split(":");
+    console.log("sending nested call: ", req.body.rawRequest);
+    const response = await send({ host: host, port: parseInt(port), rawRequest: req.body.rawRequest });
+    const status = response.split("\r\n")[0];
+    res.send({ status: status });
+  } catch (err) {
+    res.status(500).send({ error: err.message });
+  }
+});
+
+app.get(/^\/arbitrary.{1}$/, (req, res) => {
+  res.send(req.path);
+});
+
+app.listen(port, () => {
+  console.log("Server running on port " + port);
+});

--- a/internal/test/integration/components/http_proxy_server/package-lock.json
+++ b/internal/test/integration/components/http_proxy_server/package-lock.json
@@ -1,0 +1,827 @@
+{
+    "name": "nodejsserver",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "nodejsserver",
+            "version": "1.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "express": "^5.0.0"
+            }
+        },
+        "node_modules/accepts": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/body-parser": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "^3.1.2",
+                "content-type": "^1.0.5",
+                "debug": "^4.4.3",
+                "http-errors": "^2.0.0",
+                "iconv-lite": "^0.7.0",
+                "on-finished": "^2.4.1",
+                "qs": "^6.14.1",
+                "raw-body": "^3.0.1",
+                "type-is": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/content-disposition": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/content-type": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+            "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/cookie-signature": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+            "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.6.0"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/depd": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "license": "MIT"
+        },
+        "node_modules/encodeurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "license": "MIT"
+        },
+        "node_modules/etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/express": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+            "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "^2.0.0",
+                "body-parser": "^2.2.1",
+                "content-disposition": "^1.0.0",
+                "content-type": "^1.0.5",
+                "cookie": "^0.7.1",
+                "cookie-signature": "^1.2.1",
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "finalhandler": "^2.1.0",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.0",
+                "merge-descriptors": "^2.0.0",
+                "mime-types": "^3.0.0",
+                "on-finished": "^2.4.1",
+                "once": "^1.4.0",
+                "parseurl": "^1.3.3",
+                "proxy-addr": "^2.0.7",
+                "qs": "^6.14.0",
+                "range-parser": "^1.2.1",
+                "router": "^2.2.0",
+                "send": "^1.1.0",
+                "serve-static": "^2.2.0",
+                "statuses": "^2.0.1",
+                "type-is": "^2.0.1",
+                "vary": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/finalhandler": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+            "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "on-finished": "^2.4.1",
+                "parseurl": "^1.3.3",
+                "statuses": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/forwarded": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/fresh": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+            "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/http-errors": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "license": "MIT",
+            "dependencies": {
+                "depd": "~2.0.0",
+                "inherits": "~2.0.4",
+                "setprototypeof": "~1.2.0",
+                "statuses": "~2.0.2",
+                "toidentifier": "~1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
+        },
+        "node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/is-promise": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+            "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "license": "MIT"
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/media-typer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/merge-descriptors": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+            "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/path-to-regexp": {
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/qs": {
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/raw-body": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+            "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "~3.1.2",
+                "http-errors": "~2.0.1",
+                "iconv-lite": "~0.7.0",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/router": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+            "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.0",
+                "depd": "^2.0.0",
+                "is-promise": "^4.0.0",
+                "parseurl": "^1.3.3",
+                "path-to-regexp": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "license": "MIT"
+        },
+        "node_modules/send": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+            "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "etag": "^1.8.1",
+                "fresh": "^2.0.0",
+                "http-errors": "^2.0.1",
+                "mime-types": "^3.0.2",
+                "ms": "^2.1.3",
+                "on-finished": "^2.4.1",
+                "range-parser": "^1.2.1",
+                "statuses": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/serve-static": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+            "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "license": "MIT",
+            "dependencies": {
+                "encodeurl": "^2.0.0",
+                "escape-html": "^1.0.3",
+                "parseurl": "^1.3.3",
+                "send": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "license": "ISC"
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/statuses": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/toidentifier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/type-is": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "content-type": "^1.0.5",
+                "media-typer": "^1.1.0",
+                "mime-types": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
+        }
+    }
+}

--- a/internal/test/integration/components/http_proxy_server/package.json
+++ b/internal/test/integration/components/http_proxy_server/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "httpproxyserver",
+    "version": "1.0.0",
+    "description": "HTTP proxy server based on NodeJS Express",
+    "main": "app.js",
+    "scripts": {
+        "start": "node app.js"
+    },
+    "author": "The OpenTelemetry Authors",
+    "license": "Apache-2.0",
+    "dependencies": {
+        "express": "^5.0.0"
+    }
+}

--- a/internal/test/integration/docker-compose-large-http-req.yml
+++ b/internal/test/integration/docker-compose-large-http-req.yml
@@ -1,0 +1,96 @@
+version: "3.8"
+
+services:
+  httpproxyserver:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/http_proxy_server/Dockerfile
+    image: hatest-httpproxyserver
+    ports:
+      - "3035:3030"
+    environment:
+      OTEL_SERVICE_NAME: "httpproxyserver"
+    depends_on:
+      otelcol:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    command:
+      - --config=/configs/obi-config.yml
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security${SECURITY_CONFIG_SUFFIX}:/sys/kernel/security
+      - /sys/fs/cgroup:/sys/fs/cgroup
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-large-http-req:/var/run/obi
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:httpproxyserver"
+    pid: "service:httpproxyserver"
+    environment:
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_METRICS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf,application_host"
+      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf,application_host"
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "10ms"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_BPF_TRACK_REQUEST_HEADERS: "true"
+      OTEL_EBPF_BPF_CONTEXT_PROPAGATION: "all"
+    depends_on:
+      httpproxyserver:
+        condition: service_started
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.151.0@sha256:d57bfe8eee2378f31cb1193239fbcac521d54a5a071fca2bfc106916a32b892d
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318:4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.11.0@sha256:131bf4c9d8a0337782ea8b753249f4903afac01379f3cced87ceaf8ca82ab9f3
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.60@sha256:4fd2d70fa347d6a47e79fcb06b1c177e6079f92cba88b083153d56263082135e
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=debug

--- a/internal/test/integration/http_large_request_test.go
+++ b/internal/test/integration/http_large_request_test.go
@@ -1,0 +1,231 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+)
+
+type httpRequestSize struct {
+	size           int
+	tpHeaderOffset int
+}
+
+const traceBufSize = 1024 // This is identical to TRACE_BUF_SIZE defined in `bpf/common/http_buf_size.h`
+
+// This test will make sure that if a request belonging to an egress flow is slightly bigger than 1KB,
+// tpinjector.c:obi_packet_extender_find_existing_tp() will still parse the traceparent.
+func testLargeHTTPRequestEgress(t *testing.T) {
+	traceID := createTraceID()
+	parentID := createParentID()
+	traceparent := createTraceparent(traceID, parentID)
+
+	host := "localhost:3030"
+	path := "/greeting"
+	method := "GET"
+	headers := []string{
+		"Accept: */*",
+		"User-Agent: user_agent",
+		fmt.Sprintf("Traceparent: %s", traceparent),
+	}
+	reqSize := getHTTPRequestSize(t, host, method, path, headers...)
+
+	// In previous versions of OBI, obi_packet_extender_find_existing_tp() will only see:
+	// > GET /greeting HTTP/1.1\r\nHost: localhost:3030\r\nAccept: */*\r\nUser-Agent: user_agent\r\n
+	// which would make it unable to find the header traceparent.
+	// (Ref for the old bug: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/57e7cd462e0300e0acdd3cf76b146e4cd80e225f/bpf/tpinjector/tpinjector.c#L861)
+	headers = append(headers, generatePadHeader(t, reqSize, 0))
+
+	rawReq := createRawHTTPRequest(t, method, path, host, headers...)
+	dialReq := map[string]string{"rawRequest": rawReq, "host": host}
+
+	bytes, err := json.Marshal(dialReq)
+	require.NoError(t, err)
+	doHTTPPost(t, "http://localhost:3035/dial", 200, bytes)
+
+	assertRequestTraceID(t, method, path, traceID)
+}
+
+// This test will make sure that if a request belonging to an ingress flow is slighty bigger than 1KB,
+// bpf/generictracer/protocol_http.h:__obi_continue_protocol_http_tp() will still be able to find and
+// parse the traceparent.
+func testLargeHTTPRequestIngress(t *testing.T) {
+	traceID := createTraceID()
+	parentID := createParentID()
+	traceparent := createTraceparent(traceID, parentID)
+
+	host := "localhost:3035"
+	path := "/bye"
+	method := "GET"
+	headers := []string{
+		"Accept: */*",
+		"User-Agent: user_agent",
+		fmt.Sprintf("Traceparent: %s", traceparent),
+	}
+	reqSize := getHTTPRequestSize(t, host, method, path, headers...)
+
+	// In previous versions of __obi_continue_protocol_http_tp() where the bitwise operation is used
+	// `const u16 buf_len = args->bytes_len & (TRACE_BUF_SIZE - 1);`, the function will only be able to see:
+	// > GET /bye HTTP/1.1\r\nHost: localhost:3030\r\nAccept: */*\r\nUser-Agent: user_agent\r\nTraceparent:
+	// which will result in an empty trace id (ex: 00-ffffffffffffffffffffffffffffffff-0701cb90f152dc2e-01).
+	// (Ref for the old bug: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/57e7cd462e0300e0acdd3cf76b146e4cd80e225f/bpf/generictracer/protocol_http.h#L475)
+	headers = append(headers, generatePadHeader(t, reqSize, len("Traceparent: ")))
+
+	rawReq := createRawHTTPRequest(t, method, path, host, headers...)
+	sendRawHTTPRequest(t, host, rawReq, 200)
+
+	assertRequestTraceID(t, method, path, traceID)
+}
+
+// Send a large HTTP request with arbitrary size as egress
+func testLargeHTTPRequestEgressArbitrarySize(t *testing.T) {
+	traceID := createTraceID()
+	parentID := createParentID()
+	traceparent := createTraceparent(traceID, parentID)
+
+	host := "localhost:3030"
+	path := "/arbitrary1"
+	method := "GET"
+	headers := []string{
+		"Accept: */*",
+		"User-Agent: user_agent",
+		fmt.Sprintf("Traceparent: %s", traceparent),
+	}
+	reqSize := getHTTPRequestSize(t, host, method, path, headers...)
+	headers = append(headers, generatePadHeader(t, reqSize, rand.IntN(4096)))
+
+	rawReq := createRawHTTPRequest(t, method, path, host, headers...)
+	dialReq := map[string]string{"rawRequest": rawReq, "host": host}
+
+	bytes, err := json.Marshal(dialReq)
+	require.NoError(t, err)
+	doHTTPPost(t, "http://localhost:3035/dial", 200, bytes)
+
+	assertRequestTraceID(t, method, path, traceID)
+}
+
+// Send a large HTTP request with arbitrary size as ingress
+func testLargeHTTPRequestIngressArbitrarySize(t *testing.T) {
+	traceID := createTraceID()
+	parentID := createParentID()
+	traceparent := createTraceparent(traceID, parentID)
+
+	host := "localhost:3035"
+	path := "/arbitrary2"
+	method := "GET"
+	headers := []string{
+		"Accept: */*",
+		"User-Agent: user_agent",
+		fmt.Sprintf("Traceparent: %s", traceparent),
+	}
+	reqSize := getHTTPRequestSize(t, host, method, path, headers...)
+	headers = append(headers, generatePadHeader(t, reqSize, rand.IntN(4096)))
+
+	rawReq := createRawHTTPRequest(t, method, path, host, headers...)
+	sendRawHTTPRequest(t, host, rawReq, 200)
+
+	assertRequestTraceID(t, method, path, traceID)
+}
+
+func createRawHTTPRequest(t *testing.T, method, path, host string, headers ...string) string {
+	t.Helper()
+
+	var rawReq strings.Builder
+
+	fmt.Fprintf(&rawReq, "%s %s HTTP/1.1\r\n", strings.ToUpper(method), path)
+	fmt.Fprintf(&rawReq, "Host: %s\r\n", host)
+
+	for _, header := range headers {
+		fmt.Fprintf(&rawReq, "%s\r\n", header)
+	}
+
+	rawReq.WriteString("\r\n")
+
+	return rawReq.String()
+}
+
+func getHTTPRequestSize(t *testing.T, host, method, path string, headers ...string) httpRequestSize {
+	t.Helper()
+
+	rawReq := createRawHTTPRequest(t, host, method, path, headers...)
+	reqSize := len(rawReq)
+	tpHeaderOffset := strings.Index(strings.ToLower(rawReq), "traceparent")
+
+	return httpRequestSize{
+		size:           reqSize,
+		tpHeaderOffset: tpHeaderOffset,
+	}
+}
+
+func generatePadHeader(t *testing.T, reqSize httpRequestSize, tpHeaderSizeToTake int) string {
+	t.Helper()
+
+	padHeader := "pad: "
+
+	// Calculate how much bytes left to reach exactly 1KB
+	sizeToReach1KB := traceBufSize - (reqSize.size + len(padHeader) + len("\r\n"))
+	padSize := sizeToReach1KB + reqSize.tpHeaderOffset + tpHeaderSizeToTake
+
+	var value strings.Builder
+	for range padSize {
+		value.WriteString("A")
+	}
+
+	return fmt.Sprintf("%s%s", padHeader, value.String())
+}
+
+func sendRawHTTPRequest(t *testing.T, host, rawReq string, expectedStatus int) {
+	t.Helper()
+
+	conn, err := net.Dial("tcp", host)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	fmt.Fprint(conn, rawReq)
+	currentStatus, err := bufio.NewReader(conn).ReadString('\n')
+	require.NoError(t, err)
+	require.Contains(t, currentStatus, fmt.Sprintf("%d", expectedStatus))
+}
+
+func assertRequestTraceID(t *testing.T, method, path, traceID string) {
+	t.Helper()
+
+	var trace jaeger.Trace
+
+	operationName := fmt.Sprintf("%s %s", strings.ToUpper(method), path)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=httpproxyserver&operation=" + url.QueryEscape(operationName))
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+		traces := tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: path})
+		require.Len(ct, traces, 1)
+		trace = traces[0]
+	}, testTimeout, 100*time.Millisecond)
+
+	// Check the information of the parent span
+	res := trace.FindByOperationName(operationName, "server")
+	require.Len(t, res, 1)
+	parent := res[0]
+	require.NotEmpty(t, parent.TraceID)
+	require.Equal(t, traceID, parent.TraceID)
+}

--- a/internal/test/integration/http_large_request_test.go
+++ b/internal/test/integration/http_large_request_test.go
@@ -11,12 +11,14 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
 )
 
@@ -40,7 +42,7 @@ func testLargeHTTPRequestEgress(t *testing.T) {
 	headers := []string{
 		"Accept: */*",
 		"User-Agent: user_agent",
-		fmt.Sprintf("Traceparent: %s", traceparent),
+		"Traceparent: " + traceparent,
 	}
 	reqSize := getHTTPRequestSize(t, host, method, path, headers...)
 
@@ -60,7 +62,7 @@ func testLargeHTTPRequestEgress(t *testing.T) {
 	assertRequestTraceID(t, method, path, traceID)
 }
 
-// This test will make sure that if a request belonging to an ingress flow is slighty bigger than 1KB,
+// This test will make sure that if a request belonging to an ingress flow is slightly bigger than 1KB,
 // bpf/generictracer/protocol_http.h:__obi_continue_protocol_http_tp() will still be able to find and
 // parse the traceparent.
 func testLargeHTTPRequestIngress(t *testing.T) {
@@ -74,7 +76,7 @@ func testLargeHTTPRequestIngress(t *testing.T) {
 	headers := []string{
 		"Accept: */*",
 		"User-Agent: user_agent",
-		fmt.Sprintf("Traceparent: %s", traceparent),
+		"Traceparent: " + traceparent,
 	}
 	reqSize := getHTTPRequestSize(t, host, method, path, headers...)
 
@@ -103,7 +105,7 @@ func testLargeHTTPRequestEgressArbitrarySize(t *testing.T) {
 	headers := []string{
 		"Accept: */*",
 		"User-Agent: user_agent",
-		fmt.Sprintf("Traceparent: %s", traceparent),
+		"Traceparent: " + traceparent,
 	}
 	reqSize := getHTTPRequestSize(t, host, method, path, headers...)
 	headers = append(headers, generatePadHeader(t, reqSize, rand.IntN(4096)))
@@ -130,7 +132,7 @@ func testLargeHTTPRequestIngressArbitrarySize(t *testing.T) {
 	headers := []string{
 		"Accept: */*",
 		"User-Agent: user_agent",
-		fmt.Sprintf("Traceparent: %s", traceparent),
+		"Traceparent: " + traceparent,
 	}
 	reqSize := getHTTPRequestSize(t, host, method, path, headers...)
 	headers = append(headers, generatePadHeader(t, reqSize, rand.IntN(4096)))
@@ -158,7 +160,7 @@ func createRawHTTPRequest(t *testing.T, method, path, host string, headers ...st
 	return rawReq.String()
 }
 
-func getHTTPRequestSize(t *testing.T, host, method, path string, headers ...string) httpRequestSize {
+func getHTTPRequestSize(t *testing.T, host, method, path string, headers ...string) httpRequestSize { //nolint:unparam // the linter complains about "method" being always "GET"
 	t.Helper()
 
 	rawReq := createRawHTTPRequest(t, host, method, path, headers...)
@@ -198,10 +200,10 @@ func sendRawHTTPRequest(t *testing.T, host, rawReq string, expectedStatus int) {
 	fmt.Fprint(conn, rawReq)
 	currentStatus, err := bufio.NewReader(conn).ReadString('\n')
 	require.NoError(t, err)
-	require.Contains(t, currentStatus, fmt.Sprintf("%d", expectedStatus))
+	require.Contains(t, currentStatus, strconv.Itoa(expectedStatus))
 }
 
-func assertRequestTraceID(t *testing.T, method, path, traceID string) {
+func assertRequestTraceID(t *testing.T, method, path, traceID string) { //nolint:unparam // the linter complains about "method" being always "GET"
 	t.Helper()
 
 	var trace jaeger.Trace

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -890,6 +890,39 @@ func TestSuite_LogEnricherPythonAsync(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+// The idea behind this test suite is to make sure that when an HTTP request is bigger than 1KB,
+// the traceparent is detected and parsed correctly during an ingress flow (protocol_http kprob)
+// and an egress flow (tpinjector sk_msg kprobe).
+// In previous versions of OBI, tpinjector.c:obi_packet_extender_find_existing_tp()
+// and protocol_http.h:__obi_continue_protocol_http_tp() had problematic bitwise operations that
+// can change or corrupt the traceparent header when parsing a 1KB+ HTTP request.
+func TestSuite_LargeHTTPRequest(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-large-http-req.yml", path.Join(pathOutput, "test-suite-large-http-req.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3030`, `OTEL_EBPF_EXECUTABLE_PATH=`)
+	require.NoError(t, compose.Up())
+
+	t.Run("Large HTTP Request egress flow (kprobe: tpinjector[sk_msg])", func(t *testing.T) {
+		waitForTestComponents(t, "http://localhost:3035")
+		testLargeHTTPRequestEgress(t)
+	})
+
+	t.Run("Large HTTP Request ingress flow (kprobe: protocol_http)", func(t *testing.T) {
+		testLargeHTTPRequestIngress(t)
+	})
+
+	t.Run("Large HTTP Request egress flow with arbitrary size (kprobe: tpinjector[sk_msg])", func(t *testing.T) {
+		testLargeHTTPRequestEgressArbitrarySize(t)
+	})
+
+	t.Run("Large HTTP Request ingress flow with arbitrary size (kprobe: protocol_http)", func(t *testing.T) {
+		testLargeHTTPRequestIngressArbitrarySize(t)
+	})
+
+	require.NoError(t, compose.Close())
+}
+
 // Helpers
 
 var lockdownPath = "/sys/kernel/security/lockdown"


### PR DESCRIPTION
## Summary

This PR fixes two bugs in two kprobes:

1. During an ingress flow (an ingoing HTTP request with an included `traceparent` header), if the HTTP request size is more than 1KB+, there is a chance that `__obi_continue_protocol_http_tp()` in `bpf/generictracer/protocol_http.h` will fail to detect the `traceparent` header or detect only part of it (and corrupt it) due to this calculation `const u16 buf_len = args->bytes_len & (TRACE_BUF_SIZE - 1);`, a modulo won't ensure that we will always have a 1KB chunk if the request is more than 1KB, we should use a clamp.
2. This one is during an egress flow, an outgoing HTTP request with an included `traceparent` header and a size of 1KB+, there is a chance that the kprobe `obi_packet_extender_find_existing_tp()` in `bpf/tpinjector/tpinjector.c` will fail to detect the `traceparent` header which will lead to generating a new tp instead of harvesting the one in the request headers. This is also due to a wrong calculation of the chunk size `const u32 data_size = (e - ptr) & 0x3ff;`, the fix is to use a clamp function and not a modulo.

I also wrote integration tests for each scenario.

Linked issue #1976 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
