### PR TITLE
Implement Go generic TLS support

### DIFF
--- a/bpf/gotracer/go_common.h
+++ b/bpf/gotracer/go_common.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include "common/tp_info.h"
 #include <bpfcore/utils.h>
+#include <bpfcore/bpf_helpers.h>
 
 #include <common/go_addr_key.h>
 #include <common/map_sizing.h>
@@ -24,6 +24,7 @@
 #include <common/strings.h>
 #include <common/trace_util.h>
 #include <common/tracing.h>
+#include <common/tp_info.h>
 
 #include <gotracer/go_offsets.h>
 
@@ -417,8 +418,7 @@ static __always_inline u8 get_conn_info_from_fd(void *fd_ptr,
     return 0;
 }
 
-// HTTP black-box context propagation
-static __always_inline u8 get_conn_info(void *conn_ptr, connection_info_t *info) {
+static __always_inline void *fd_ptr_from_conn(void *conn_ptr) {
     if (conn_ptr) {
         void *fd_ptr = 0;
         off_table_t *ot = get_offsets_table();
@@ -428,9 +428,21 @@ static __always_inline u8 get_conn_info(void *conn_ptr, connection_info_t *info)
             sizeof(fd_ptr),
             (void *)(conn_ptr + go_offset_of(ot, (go_offset){.v = _conn_fd_pos}))); // find fd
 
+        return fd_ptr;
+    }
+
+    return 0;
+}
+
+// HTTP black-box context propagation
+static __always_inline u8 get_conn_info(void *conn_ptr, connection_info_t *info) {
+    if (conn_ptr) {
+        void *fd_ptr = fd_ptr_from_conn(conn_ptr);
         bpf_dbg_printk("Found fd, fd_ptr=%llx", fd_ptr);
 
-        return get_conn_info_from_fd(fd_ptr, info, true);
+        if (fd_ptr) {
+            return get_conn_info_from_fd(fd_ptr, info, true);
+        }
     }
 
     return 0;

--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -27,54 +27,23 @@
 #include <common/lw_thread.h>
 
 #include <gotracer/go_common.h>
-#include <gotracer/maps/mongo.h>
-#include <gotracer/maps/ongoing_fd_reads.h>
 
 #include <generictracer/k_tracer_defs.h>
 
 #include <logger/bpf_dbg.h>
 
 #include <maps/outgoing_trace_map.h>
-#include <maps/ongoing_tcp_req.h>
-#include <maps/ongoing_http2_connections.h>
 
 #include <gotracer/types/net_args.h>
+
+#include <gotracer/maps/ongoing_fd_reads.h>
+#include <gotracer/maps/ongoing_ssl_ops.h>
+
+#include <gotracer/go_net_common.h>
 
 #include <pid/pid_helpers.h>
 
 #include <shared/obi_ctx.h>
-
-static __always_inline bool already_handled_request_sorted(const connection_info_t *conn) {
-    if (conn) {
-        const bool *found = bpf_map_lookup_elem(&handled_by_go_conn, conn);
-        if (found) {
-            return true;
-        }
-    }
-    return false;
-}
-
-static __always_inline void
-cleanup_duplicate_generic_events_sorted(const pid_connection_info_t *pid_conn) {
-    if (!pid_conn) {
-        return;
-    }
-    bpf_map_delete_elem(&ongoing_http, pid_conn);
-    bpf_map_delete_elem(&ongoing_tcp_req, pid_conn);
-    bpf_map_delete_elem(&ongoing_http2_connections, pid_conn);
-}
-
-static __always_inline void
-cleanup_duplicate_generic_event_by_connection(const connection_info_t *conn) {
-    if (!conn) {
-        return;
-    }
-    const u64 id = bpf_get_current_pid_tgid();
-    pid_connection_info_t p_conn = {.conn = *conn, .pid = pid_from_pid_tgid(id)};
-    sort_connection_info(&p_conn.conn);
-
-    cleanup_duplicate_generic_events_sorted(&p_conn);
-}
 
 SEC("uprobe/netFdRead")
 int obi_uprobe_netFdRead(struct pt_regs *ctx) {
@@ -85,68 +54,16 @@ int obi_uprobe_netFdRead(struct pt_regs *ctx) {
     go_addr_key_t g_key = {};
     go_addr_key_from_id(&g_key, goroutine_addr);
 
-    // lookup a grpc connection
-    // Sets up the connection info to be grabbed and mapped over the transport to operateHeaders
-    void *tr = bpf_map_lookup_elem(&ongoing_grpc_operate_headers, &g_key);
-    bpf_dbg_printk("tr=%llx", tr);
-    if (tr) {
-        grpc_transports_t *t = bpf_map_lookup_elem(&ongoing_grpc_transports, tr);
-        bpf_dbg_printk("t=%llx", t);
-        if (t) {
-            if (t->conn.d_port == 0 && t->conn.s_port == 0) {
-                void *fd_ptr = GO_PARAM1(ctx);
-                get_conn_info_from_fd(fd_ptr,
-                                      &t->conn,
-                                      true); // ok to not check the result, we leave it as 0
-                cleanup_duplicate_generic_event_by_connection(&t->conn);
-            }
-        }
+    void *fd_ptr = GO_PARAM1(ctx);
+
+    if (already_handled_goroutine(&g_key, fd_ptr)) {
         return 0;
     }
 
-    // lookup active sql connection
-    sql_func_invocation_t *sql_conn = bpf_map_lookup_elem(&ongoing_sql_queries, &g_key);
-    bpf_dbg_printk("sql_conn=%llx", sql_conn);
-    if (sql_conn) {
-        void *fd_ptr = GO_PARAM1(ctx);
-        get_conn_info_from_fd(fd_ptr,
-                              &sql_conn->conn,
-                              true); // ok to not check the result, we leave it as 0
-        cleanup_duplicate_generic_event_by_connection(&sql_conn->conn);
+    net_args_t *ssl = bpf_map_lookup_elem(&ongoing_ssl_ops, &g_key);
+    if (ssl) {
+        bpf_dbg_printk("ssl read, not processing buffer");
         return 0;
-    }
-
-    mongo_go_client_req_t *mongo_conn = bpf_map_lookup_elem(&ongoing_mongo_requests, &g_key);
-    bpf_dbg_printk("mongo_conn=%llx", mongo_conn);
-    if (mongo_conn) {
-        void *fd_ptr = GO_PARAM1(ctx);
-        get_conn_info_from_fd(fd_ptr,
-                              &mongo_conn->conn,
-                              true); // ok to not check the result, we leave it as 0
-
-        cleanup_duplicate_generic_event_by_connection(&mongo_conn->conn);
-        return 0;
-    }
-
-    // lookup active HTTP connection
-    connection_info_t *conn = bpf_map_lookup_elem(&ongoing_server_connections, &g_key);
-    bpf_dbg_printk("conn=%llx", conn);
-    if (conn) {
-        if (conn->d_port == 0 && conn->s_port == 0) {
-            bpf_dbg_printk("Found existing server connection, parsing FD information for socket "
-                           "tuples, goroutine_addr=%llx",
-                           goroutine_addr);
-
-            void *fd_ptr = GO_PARAM1(ctx);
-            get_conn_info_from_fd(
-                fd_ptr, conn, true); // ok to not check the result, we leave it as 0
-            cleanup_duplicate_generic_event_by_connection(conn);
-
-            return 0;
-        }
-        //dbg_print_http_connection_info(conn);
-        // We cannot return here, HTTP servers are typically wrapping unknown protocols
-        // on the same goroutine.
     }
 
     bpf_tail_call(ctx, &jump_table, k_tail_continue_netfd_read);
@@ -248,6 +165,12 @@ int obi_uprobe_netFdWrite(struct pt_regs *ctx) {
 
     go_addr_key_t g_key = {};
     go_addr_key_from_id(&g_key, goroutine_addr);
+
+    net_args_t *ssl = bpf_map_lookup_elem(&ongoing_ssl_ops, &g_key);
+    if (ssl) {
+        bpf_dbg_printk("ssl write, not processing buffer");
+        return 0;
+    }
 
     void *fd_ptr = GO_PARAM1(ctx);
     u8 *buf = GO_PARAM2(ctx);

--- a/bpf/gotracer/go_net_common.h
+++ b/bpf/gotracer/go_net_common.h
@@ -1,0 +1,133 @@
+// Copyright The OpenTelemetry Authors
+// Copyright Grafana Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+#include <bpfcore/utils.h>
+
+#include <common/algorithm.h>
+#include <common/common.h>
+#include <common/connection_info.h>
+#include <common/go_addr_key.h>
+
+#include <gotracer/go_common.h>
+#include <gotracer/maps/mongo.h>
+
+#include <generictracer/k_tracer_defs.h>
+
+#include <logger/bpf_dbg.h>
+
+#include <maps/ongoing_tcp_req.h>
+#include <maps/ongoing_http2_connections.h>
+
+#include <pid/pid_helpers.h>
+
+static __always_inline bool already_handled_request_sorted(const connection_info_t *conn) {
+    if (conn) {
+        const bool *found = bpf_map_lookup_elem(&handled_by_go_conn, conn);
+        if (found) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static __always_inline void
+cleanup_duplicate_generic_events_sorted(const pid_connection_info_t *pid_conn) {
+    if (!pid_conn) {
+        return;
+    }
+    bpf_map_delete_elem(&ongoing_http, pid_conn);
+    bpf_map_delete_elem(&ongoing_tcp_req, pid_conn);
+    bpf_map_delete_elem(&ongoing_http2_connections, pid_conn);
+}
+
+static __always_inline void
+cleanup_duplicate_generic_event_by_connection(const connection_info_t *conn) {
+    if (!conn) {
+        return;
+    }
+    const u64 id = bpf_get_current_pid_tgid();
+    pid_connection_info_t p_conn = {.conn = *conn, .pid = pid_from_pid_tgid(id)};
+    sort_connection_info(&p_conn.conn);
+
+    cleanup_duplicate_generic_events_sorted(&p_conn);
+}
+
+static __always_inline bool already_handled_goroutine(go_addr_key_t *g_key, void *fd_ptr) {
+    // lookup a grpc connection
+    // Sets up the connection info to be grabbed and mapped over the transport to operateHeaders
+    void *tr = bpf_map_lookup_elem(&ongoing_grpc_operate_headers, g_key);
+    bpf_dbg_printk("tr=%llx", tr);
+    if (tr) {
+        grpc_transports_t *t = bpf_map_lookup_elem(&ongoing_grpc_transports, tr);
+        bpf_dbg_printk("t=%llx", t);
+        if (t) {
+            if (t->conn.d_port == 0 && t->conn.s_port == 0) {
+                get_conn_info_from_fd(fd_ptr,
+                                      &t->conn,
+                                      true); // ok to not check the result, we leave it as 0
+                cleanup_duplicate_generic_event_by_connection(&t->conn);
+            }
+        }
+        return true;
+    }
+
+    // lookup active sql connection
+    sql_func_invocation_t *sql_conn = bpf_map_lookup_elem(&ongoing_sql_queries, g_key);
+    bpf_dbg_printk("sql_conn=%llx", sql_conn);
+    if (sql_conn) {
+        get_conn_info_from_fd(fd_ptr,
+                              &sql_conn->conn,
+                              true); // ok to not check the result, we leave it as 0
+        cleanup_duplicate_generic_event_by_connection(&sql_conn->conn);
+        return true;
+    }
+
+    mongo_go_client_req_t *mongo_conn = bpf_map_lookup_elem(&ongoing_mongo_requests, g_key);
+    bpf_dbg_printk("mongo_conn=%llx", mongo_conn);
+    if (mongo_conn) {
+        get_conn_info_from_fd(fd_ptr,
+                              &mongo_conn->conn,
+                              true); // ok to not check the result, we leave it as 0
+
+        cleanup_duplicate_generic_event_by_connection(&mongo_conn->conn);
+        return true;
+    }
+
+    // lookup active HTTP connection
+    connection_info_t *conn = bpf_map_lookup_elem(&ongoing_server_connections, g_key);
+    bpf_dbg_printk("conn=%llx", conn);
+    if (conn) {
+        if (conn->d_port == 0 && conn->s_port == 0) {
+            bpf_dbg_printk("Found existing server connection, parsing FD information for socket "
+                           "tuples, goroutine_addr=%llx",
+                           g_key->addr);
+
+            get_conn_info_from_fd(
+                fd_ptr, conn, true); // ok to not check the result, we leave it as 0
+            cleanup_duplicate_generic_event_by_connection(conn);
+
+            return true;
+        }
+        //dbg_print_http_connection_info(conn);
+        // We cannot return true here, HTTP servers are typically wrapping unknown protocols
+        // on the same goroutine.
+    }
+
+    return false;
+}

--- a/bpf/gotracer/go_net_tls.c
+++ b/bpf/gotracer/go_net_tls.c
@@ -55,7 +55,7 @@ int obi_uprobe_cryptoTlsRead(struct pt_regs *ctx) {
     go_addr_key_from_id(&g_key, goroutine_addr);
 
     void *conn = GO_PARAM1(ctx);
-    void *buf = GO_PARAM2(ctx);
+    const void *buf = GO_PARAM2(ctx);
 
     bpf_printk("=== uprobe/cryptoTlsRead goroutine_addr=%lx, c=%llx, buf=%llx === ",
                goroutine_addr,
@@ -96,7 +96,7 @@ int obi_uprobe_cryptoTlsReadRet(struct pt_regs *ctx) {
     go_addr_key_t g_key = {};
     go_addr_key_from_id(&g_key, goroutine_addr);
 
-    u64 len = (u64)GO_PARAM1(ctx);
+    const u64 len = (u64)GO_PARAM1(ctx);
     void *err = GO_PARAM2(ctx);
 
     bpf_dbg_printk("=== uprobe/cryptoTlsRead returns goroutine_addr=%lx, size=%d, err=%llx === ",
@@ -112,7 +112,7 @@ int obi_uprobe_cryptoTlsReadRet(struct pt_regs *ctx) {
     if (args) {
         bpf_printk("buf = %s", args->byte_ptr);
 
-        u16 orig_dport = args->p_conn.conn.d_port;
+        const u16 orig_dport = args->p_conn.conn.d_port;
         sort_connection_info(&args->p_conn.conn);
 
         dbg_print_http_connection_info(&args->p_conn.conn);
@@ -147,7 +147,7 @@ int obi_uprobe_cryptoTlsWrite(struct pt_regs *ctx) {
 
     void *c = GO_PARAM1(ctx);
     void *buf = GO_PARAM2(ctx);
-    u64 len = (u64)GO_PARAM3(ctx);
+    const u64 len = (u64)GO_PARAM3(ctx);
 
     bpf_dbg_printk("=== uprobe/cryptoTlsWrite goroutine_addr=%lx, c=%llx, buf=%llx === ",
                    goroutine_addr,

--- a/bpf/gotracer/go_net_tls.c
+++ b/bpf/gotracer/go_net_tls.c
@@ -1,0 +1,135 @@
+// Copyright The OpenTelemetry Authors
+// Copyright Grafana Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build obi_bpf_ignore
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+#include <bpfcore/utils.h>
+
+#include <gotracer/go_common.h>
+#include <gotracer/maps/ongoing_ssl_ops.h>
+
+#include <gotracer/types/net_args.h>
+
+#include <gotracer/go_net_common.h>
+
+#include <logger/bpf_dbg.h>
+
+SEC("uprobe/cryptoTlsRead")
+int obi_uprobe_cryptoTlsRead(struct pt_regs *ctx) {
+    void *goroutine_addr = GOROUTINE_PTR(ctx);
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+
+    void *conn = GO_PARAM1(ctx);
+    void *buf = GO_PARAM2(ctx);
+
+    bpf_printk("=== uprobe/cryptoTlsRead goroutine_addr=%lx, c=%llx, buf=%llx === ",
+               goroutine_addr,
+               conn,
+               buf);
+
+    if (!buf) {
+        return 0;
+    }
+
+    net_args_t args = {0};
+
+    void *conn_conn = 0;
+    bpf_probe_read(&conn_conn, sizeof(conn_conn), conn + 8); // 8 skip embedded data structure class
+    bpf_dbg_printk("unwrapped conn %llx", conn_conn);
+    if (conn_conn) {
+        void *fd_ptr = fd_ptr_from_conn(conn_conn);
+
+        bpf_dbg_printk("found fd_ptr %llx", fd_ptr);
+
+        if (already_handled_goroutine(&g_key, fd_ptr)) {
+            return 0;
+        }
+
+        if (!get_conn_info(conn_conn, &args.p_conn.conn)) {
+            bpf_dbg_printk("cannot read connection info from %llx", conn_conn);
+            return 0;
+        }
+        const u64 id = bpf_get_current_pid_tgid();
+        args.p_conn.pid = pid_from_pid_tgid(id);
+        args.byte_ptr = (u64)buf;
+
+        dbg_print_http_connection_info(&args.p_conn.conn);
+
+        bpf_map_update_elem(&ongoing_ssl_ops, &g_key, &args, BPF_ANY);
+    }
+
+    return 0;
+}
+
+SEC("uprobe/cryptoTlsRead")
+int obi_uprobe_cryptoTlsReadRet(struct pt_regs *ctx) {
+    void *goroutine_addr = GOROUTINE_PTR(ctx);
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+
+    u64 len = (u64)GO_PARAM1(ctx);
+    void *err = GO_PARAM2(ctx);
+
+    bpf_dbg_printk("=== uprobe/cryptoTlsRead returns goroutine_addr=%lx, size=%d, err=%llx === ",
+                   goroutine_addr,
+                   len,
+                   err);
+
+    if (len == 0 || err != 0) {
+        goto done;
+    }
+
+    net_args_t *args = bpf_map_lookup_elem(&ongoing_ssl_ops, &g_key);
+    if (args) {
+        bpf_printk("buf = %s", args->byte_ptr);
+    }
+
+done:
+    bpf_map_delete_elem(&ongoing_ssl_ops, &g_key);
+
+    return 0;
+}
+
+SEC("uprobe/cryptoTlsWrite")
+int obi_uprobe_cryptoTlsWrite(struct pt_regs *ctx) {
+    void *goroutine_addr = GOROUTINE_PTR(ctx);
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+
+    bpf_dbg_printk("=== uprobe/cryptoTlsWrite goroutine_addr=%lx, c=%llx, buf=%llx === ",
+                   goroutine_addr,
+                   GO_PARAM1(ctx),
+                   GO_PARAM2(ctx));
+
+    net_args_t args = {0};
+    bpf_map_update_elem(&ongoing_ssl_ops, &g_key, &args, BPF_ANY);
+
+    return 0;
+}
+
+SEC("uprobe/cryptoTlsWrite")
+int obi_uprobe_cryptoTlsWriteRet(struct pt_regs *ctx) {
+    void *goroutine_addr = GOROUTINE_PTR(ctx);
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+
+    bpf_dbg_printk("=== uprobe/cryptoTlsWrite returns goroutine_addr=%lx", goroutine_addr);
+
+    bpf_map_delete_elem(&ongoing_ssl_ops, &g_key);
+    return 0;
+}

--- a/bpf/gotracer/go_net_tls.c
+++ b/bpf/gotracer/go_net_tls.c
@@ -28,6 +28,26 @@
 
 #include <logger/bpf_dbg.h>
 
+static __always_inline void *unwrap_conn(void *conn) {
+    void *conn_conn = 0;
+    bpf_probe_read(&conn_conn, sizeof(conn_conn), conn + 8); // 8 skip embedded data structure class
+    bpf_dbg_printk("unwrapped conn %llx", conn_conn);
+
+    return conn_conn;
+}
+
+static __always_inline bool should_process(void *conn_conn, go_addr_key_t *g_key) {
+    void *fd_ptr = fd_ptr_from_conn(conn_conn);
+
+    bpf_dbg_printk("found fd_ptr %llx", fd_ptr);
+
+    if (already_handled_goroutine(g_key, fd_ptr)) {
+        return false;
+    }
+
+    return true;
+}
+
 SEC("uprobe/cryptoTlsRead")
 int obi_uprobe_cryptoTlsRead(struct pt_regs *ctx) {
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -48,15 +68,9 @@ int obi_uprobe_cryptoTlsRead(struct pt_regs *ctx) {
 
     net_args_t args = {0};
 
-    void *conn_conn = 0;
-    bpf_probe_read(&conn_conn, sizeof(conn_conn), conn + 8); // 8 skip embedded data structure class
-    bpf_dbg_printk("unwrapped conn %llx", conn_conn);
+    void *conn_conn = unwrap_conn(conn);
     if (conn_conn) {
-        void *fd_ptr = fd_ptr_from_conn(conn_conn);
-
-        bpf_dbg_printk("found fd_ptr %llx", fd_ptr);
-
-        if (already_handled_goroutine(&g_key, fd_ptr)) {
+        if (!should_process(conn_conn, &g_key)) {
             return 0;
         }
 
@@ -97,6 +111,26 @@ int obi_uprobe_cryptoTlsReadRet(struct pt_regs *ctx) {
     net_args_t *args = bpf_map_lookup_elem(&ongoing_ssl_ops, &g_key);
     if (args) {
         bpf_printk("buf = %s", args->byte_ptr);
+
+        u16 orig_dport = args->p_conn.conn.d_port;
+        sort_connection_info(&args->p_conn.conn);
+
+        dbg_print_http_connection_info(&args->p_conn.conn);
+
+        // we don't need to mark the connection as SSL, the kprobes on send/receive
+        // never fire for Go programs, we are just calling the buffer handling.
+
+        bpf_map_delete_elem(&ongoing_ssl_ops, &g_key);
+        // doesn't return
+        handle_light_weight_thread_buf(ctx,
+                                       (lw_thread_t)goroutine_addr,
+                                       (protocol_selector_t){.http = 1, .http2 = 0, .tcp = 1},
+                                       &args->p_conn,
+                                       (void *)args->byte_ptr,
+                                       len,
+                                       WITH_SSL,
+                                       TCP_RECV,
+                                       orig_dport);
     }
 
 done:
@@ -111,13 +145,62 @@ int obi_uprobe_cryptoTlsWrite(struct pt_regs *ctx) {
     go_addr_key_t g_key = {};
     go_addr_key_from_id(&g_key, goroutine_addr);
 
+    void *c = GO_PARAM1(ctx);
+    void *buf = GO_PARAM2(ctx);
+    u64 len = (u64)GO_PARAM3(ctx);
+
     bpf_dbg_printk("=== uprobe/cryptoTlsWrite goroutine_addr=%lx, c=%llx, buf=%llx === ",
                    goroutine_addr,
-                   GO_PARAM1(ctx),
-                   GO_PARAM2(ctx));
+                   c,
+                   buf);
+
+    if (!buf || len <= 0) {
+        return 0;
+    }
+
+    bpf_dbg_printk("[%d] buf=%s", len, buf);
 
     net_args_t args = {0};
-    bpf_map_update_elem(&ongoing_ssl_ops, &g_key, &args, BPF_ANY);
+
+    void *conn_conn = unwrap_conn(c);
+    if (conn_conn) {
+        if (!should_process(conn_conn, &g_key)) {
+            return 0;
+        }
+
+        if (!get_conn_info(conn_conn, &args.p_conn.conn)) {
+            bpf_dbg_printk("cannot read connection info from %llx", conn_conn);
+            return 0;
+        }
+        const u64 id = bpf_get_current_pid_tgid();
+        args.p_conn.pid = pid_from_pid_tgid(id);
+        args.byte_ptr = (u64)buf;
+
+        dbg_print_http_connection_info(&args.p_conn.conn);
+
+        // we store this ongoing_ssl_ops, so the non TLS probes on netFD (go_net.c)
+        // skip this work. the return probes clean up
+        bpf_map_update_elem(&ongoing_ssl_ops, &g_key, &args, BPF_ANY);
+
+        u16 orig_dport = args.p_conn.conn.d_port;
+        sort_connection_info(&args.p_conn.conn);
+
+        dbg_print_http_connection_info(&args.p_conn.conn);
+
+        // we don't need to mark the connection as SSL, the kprobes on send/receive
+        // never fire for Go programs, we are just calling the buffer handling.
+
+        // doesn't return
+        handle_light_weight_thread_buf(ctx,
+                                       (lw_thread_t)goroutine_addr,
+                                       (protocol_selector_t){.http = 1, .http2 = 0, .tcp = 1},
+                                       &args.p_conn,
+                                       buf,
+                                       len,
+                                       WITH_SSL,
+                                       TCP_SEND,
+                                       orig_dport);
+    }
 
     return 0;
 }

--- a/bpf/gotracer/go_net_tls.c
+++ b/bpf/gotracer/go_net_tls.c
@@ -36,16 +36,16 @@ static __always_inline void *unwrap_conn(void *conn) {
     return conn_conn;
 }
 
-static __always_inline bool should_process(void *conn_conn, go_addr_key_t *g_key) {
+static __always_inline void *should_process(void *conn_conn, go_addr_key_t *g_key) {
     void *fd_ptr = fd_ptr_from_conn(conn_conn);
 
     bpf_dbg_printk("found fd_ptr %llx", fd_ptr);
 
     if (already_handled_goroutine(g_key, fd_ptr)) {
-        return false;
+        return 0;
     }
 
-    return true;
+    return fd_ptr;
 }
 
 SEC("uprobe/cryptoTlsRead")
@@ -70,19 +70,30 @@ int obi_uprobe_cryptoTlsRead(struct pt_regs *ctx) {
 
     void *conn_conn = unwrap_conn(conn);
     if (conn_conn) {
-        if (!should_process(conn_conn, &g_key)) {
+        void *fd_ptr = should_process(conn_conn, &g_key);
+        if (!fd_ptr) {
             return 0;
         }
 
-        if (!get_conn_info(conn_conn, &args.p_conn.conn)) {
+        if (!get_conn_info_from_fd(fd_ptr, &args.p_conn.conn, false)) {
             bpf_dbg_printk("cannot read connection info from %llx", conn_conn);
             return 0;
         }
+
         const u64 id = bpf_get_current_pid_tgid();
         args.p_conn.pid = pid_from_pid_tgid(id);
         args.byte_ptr = (u64)buf;
 
         dbg_print_http_connection_info(&args.p_conn.conn);
+
+        pid_connection_info_t p_conn = args.p_conn;
+
+        sort_connection_info(&p_conn.conn);
+
+        if (already_handled_request_sorted(&p_conn.conn)) {
+            cleanup_duplicate_generic_events_sorted(&p_conn);
+            return 0;
+        }
 
         bpf_map_update_elem(&ongoing_ssl_ops, &g_key, &args, BPF_ANY);
     }
@@ -116,11 +127,6 @@ int obi_uprobe_cryptoTlsReadRet(struct pt_regs *ctx) {
         sort_connection_info(&args->p_conn.conn);
 
         dbg_print_http_connection_info(&args->p_conn.conn);
-
-        if (already_handled_request_sorted(&args->p_conn.conn)) {
-            cleanup_duplicate_generic_events_sorted(&args->p_conn);
-            goto done;
-        }
 
         // we don't need to mark the connection as SSL, the kprobes on send/receive
         // never fire for Go programs, we are just calling the buffer handling.
@@ -169,11 +175,12 @@ int obi_uprobe_cryptoTlsWrite(struct pt_regs *ctx) {
 
     void *conn_conn = unwrap_conn(c);
     if (conn_conn) {
-        if (!should_process(conn_conn, &g_key)) {
+        void *fd_ptr = should_process(conn_conn, &g_key);
+        if (!fd_ptr) {
             return 0;
         }
 
-        if (!get_conn_info(conn_conn, &args.p_conn.conn)) {
+        if (!get_conn_info_from_fd(fd_ptr, &args.p_conn.conn, false)) {
             bpf_dbg_printk("cannot read connection info from %llx", conn_conn);
             return 0;
         }

--- a/bpf/gotracer/go_net_tls.c
+++ b/bpf/gotracer/go_net_tls.c
@@ -57,10 +57,10 @@ int obi_uprobe_cryptoTlsRead(struct pt_regs *ctx) {
     void *conn = GO_PARAM1(ctx);
     const void *buf = GO_PARAM2(ctx);
 
-    bpf_printk("=== uprobe/cryptoTlsRead goroutine_addr=%lx, c=%llx, buf=%llx === ",
-               goroutine_addr,
-               conn,
-               buf);
+    bpf_dbg_printk("=== uprobe/cryptoTlsRead goroutine_addr=%lx, c=%llx, buf=%llx === ",
+                   goroutine_addr,
+                   conn,
+                   buf);
 
     if (!buf) {
         return 0;
@@ -110,12 +110,17 @@ int obi_uprobe_cryptoTlsReadRet(struct pt_regs *ctx) {
 
     net_args_t *args = bpf_map_lookup_elem(&ongoing_ssl_ops, &g_key);
     if (args) {
-        bpf_printk("buf = %s", args->byte_ptr);
+        bpf_dbg_printk("buf = %s", args->byte_ptr);
 
         const u16 orig_dport = args->p_conn.conn.d_port;
         sort_connection_info(&args->p_conn.conn);
 
         dbg_print_http_connection_info(&args->p_conn.conn);
+
+        if (already_handled_request_sorted(&args->p_conn.conn)) {
+            cleanup_duplicate_generic_events_sorted(&args->p_conn);
+            goto done;
+        }
 
         // we don't need to mark the connection as SSL, the kprobes on send/receive
         // never fire for Go programs, we are just calling the buffer handling.
@@ -185,7 +190,10 @@ int obi_uprobe_cryptoTlsWrite(struct pt_regs *ctx) {
         u16 orig_dport = args.p_conn.conn.d_port;
         sort_connection_info(&args.p_conn.conn);
 
-        dbg_print_http_connection_info(&args.p_conn.conn);
+        if (already_handled_request_sorted(&args.p_conn.conn)) {
+            cleanup_duplicate_generic_events_sorted(&args.p_conn);
+            return 0;
+        }
 
         // we don't need to mark the connection as SSL, the kprobes on send/receive
         // never fire for Go programs, we are just calling the buffer handling.

--- a/bpf/gotracer/gotracer.c
+++ b/bpf/gotracer/gotracer.c
@@ -18,6 +18,7 @@
 
 #include "go_runtime.c"
 #include "go_net.c"
+#include "go_net_tls.c"
 #include "go_nethttp.c"
 #include "go_sql.c"
 #include "go_grpc.c"

--- a/bpf/gotracer/maps/ongoing_ssl_ops.h
+++ b/bpf/gotracer/maps/ongoing_ssl_ops.h
@@ -1,0 +1,21 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/common.h>
+#include <common/go_addr_key.h>
+#include <common/map_sizing.h>
+
+#include <gotracer/types/net_args.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, go_addr_key_t); // goroutine
+    __type(value, net_args_t);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} ongoing_ssl_ops SEC(".maps");

--- a/internal/test/integration/components/gogeneric/kafka.go
+++ b/internal/test/integration/components/gogeneric/kafka.go
@@ -5,16 +5,44 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
+
+func newKafkaTLSClient(brokers string) *kgo.Client {
+	for {
+		b := strings.Split(brokers, ",")
+		client, err := kgo.NewClient(
+			kgo.SeedBrokers(b...),
+			kgo.ConsumeTopics("my-topic"),
+			kgo.DefaultProduceTopic("my-topic"),
+			kgo.DialTLSConfig(&tls.Config{InsecureSkipVerify: true}), //nolint:gosec
+		)
+		if err == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), kafkaRetryDelay)
+			err = ensureTopics(ctx, client, "my-topic")
+			cancel()
+			if err == nil {
+				return client
+			}
+			client.Close()
+		}
+
+		log.Printf("Kafka TLS is not ready yet, retrying in %s: %v", kafkaRetryDelay, err)
+		time.Sleep(kafkaRetryDelay)
+	}
+}
 
 func ensureTopics(ctx context.Context, client *kgo.Client, topics ...string) error {
 	adm := kadm.NewClient(client)

--- a/internal/test/integration/components/gogeneric/main.go
+++ b/internal/test/integration/components/gogeneric/main.go
@@ -5,10 +5,17 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"flag"
 	"fmt"
 	"log"
+	"math/big"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -22,9 +29,11 @@ import (
 )
 
 var (
-	addr       = flag.String("addr", ":8080", "The address to bind to")
-	brokers    = flag.String("brokers", os.Getenv("KAFKA_PEERS"), "The Kafka brokers to connect to, as a comma separated list")
-	downstream = flag.String("downstream", os.Getenv("HTTP_PEER"), "Downstream service to test HTTP client")
+	addr        = flag.String("addr", ":8080", "The address to bind to")
+	tlsAddr     = flag.String("tls-addr", ":8443", "The address to bind to for TLS")
+	brokers     = flag.String("brokers", os.Getenv("KAFKA_PEERS"), "The Kafka brokers to connect to, as a comma separated list")
+	tlsBrokers  = flag.String("tls-brokers", os.Getenv("KAFKA_TLS_PEERS"), "Kafka brokers to connect to over TLS (port 9094), as a comma separated list")
+	downstream  = flag.String("downstream", os.Getenv("HTTP_PEER"), "Downstream service to test HTTP client")
 )
 
 const kafkaRetryDelay = 3 * time.Second
@@ -67,6 +76,12 @@ func main() {
 	app.Get("/produce/orders", producerHandlerWithTopic(client, "orders"))
 	app.Get("/consume", consumerHandler(client))
 
+	if *tlsBrokers != "" {
+		tlsClient := newKafkaTLSClient(*tlsBrokers)
+		app.Get("/produce/tls", producerHandlerWithTopic(tlsClient, "my-topic"))
+		app.Get("/produce/orders/tls", producerHandlerWithTopic(tlsClient, "orders"))
+	}
+
 	// Routes
 	app.Get("/", handleHome)
 	app.Get("/smoke", handleHome)
@@ -75,12 +90,61 @@ func main() {
 	app.Post("/api/echo", handleEcho)
 	app.Get("/ping", handlePingGoogle)
 	app.Get("/fastPing", handlePingGoogleFastHTTPFiber)
+	app.Get("/api/pingssl", handlePingGoogleFast)
+
+	// TLS listener using a self-signed cert generated at startup
+	if *tlsAddr != "" {
+		tlsCert, err := generateSelfSignedCert()
+		if err != nil {
+			log.Fatalf("Failed to generate TLS cert: %v", err)
+		}
+		tlsListener, err := tls.Listen("tcp", *tlsAddr, &tls.Config{
+			Certificates: []tls.Certificate{tlsCert},
+		})
+		if err != nil {
+			log.Fatalf("Failed to create TLS listener on %s: %v", *tlsAddr, err)
+		}
+		go func() {
+			log.Println("Starting TLS server on " + *tlsAddr)
+			if err := app.Listener(tlsListener); err != nil {
+				log.Fatalf("Failed to start TLS server: %v", err)
+			}
+		}()
+	}
 
 	// Start server
 	log.Println("Starting server on " + *addr)
 	if err := app.Listen(*addr); err != nil {
 		log.Fatalf("Failed to start server: %v", err)
 	}
+}
+
+func generateSelfSignedCert() (tls.Certificate, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"Test"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"localhost"},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	return tls.X509KeyPair(certPEM, keyPEM)
 }
 
 func newKafkaClient(brokers string) *kgo.Client {
@@ -202,4 +266,21 @@ func handlePingGoogleFastHTTP() http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"status":"OK"}`)
 	}
+}
+
+func handlePingGoogleFast(c *fiber.Ctx) error {
+	client := &fasthttp.Client{TLSConfig: &tls.Config{InsecureSkipVerify: true}} //nolint:gosec
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI("https://www.google.com")
+	if err := client.Do(req, resp); err != nil {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+
+	return c.SendString("OK")
 }

--- a/internal/test/integration/docker-compose-go-generic.yml
+++ b/internal/test/integration/docker-compose-go-generic.yml
@@ -17,16 +17,24 @@ services:
     ports:
       - "9093:9093"
       - "9092:9092"
+      - "9094:9094"   # SSL listener port      
     volumes:
       - "kafka-volume:/bitnami"
+      - "./components/javakafka-tls/certs:/bitnami/kafka/config/certs"   # mount certs
     environment:
       - KAFKA_BROKER_ID=1
       - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
       - ALLOW_PLAINTEXT_LISTENER=yes
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://kafka:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT,SSL:SSL
+      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093,SSL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://kafka:9093,SSL://kafka:9094
       - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT
+      - KAFKA_CFG_SSL_KEYSTORE_LOCATION=/bitnami/kafka/config/certs/kafka.keystore.jks
+      - KAFKA_CFG_SSL_KEYSTORE_PASSWORD=changeit
+      - KAFKA_CFG_SSL_KEY_PASSWORD=changeit
+      - KAFKA_CFG_SSL_TRUSTSTORE_LOCATION=/bitnami/kafka/config/certs/kafka.truststore.jks
+      - KAFKA_CFG_SSL_TRUSTSTORE_PASSWORD=changeit
+      - KAFKA_CFG_SSL_CLIENT_AUTH=none  # set to "required" for mTLS
     depends_on:
       - zookeeper
 
@@ -50,9 +58,12 @@ services:
     ports:
       - "8080:8080"
       - "8081:8081"
+      - "8443:8443"
     environment:
       LOG_LEVEL: DEBUG
       OTEL_RESOURCE_ATTRIBUTES: "service.version=1.0.0"
+      KAFKA_PEERS: "kafka:9092"
+      KAFKA_TLS_PEERS: "kafka:9094"
     depends_on:
       kafka:
         condition: service_started

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -85,6 +85,7 @@ func TestSuiteGoGeneric(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 	t.Run("Generic Go HTTP/TCP traces (all spans nested)", testGoGenericHTTPTraces)
+	t.Run("Generic Go HTTPS/TCP(TLS) traces (all spans nested)", testGoGenericHTTPSTraces)
 	require.NoError(t, compose.Close())
 }
 

--- a/internal/test/integration/traces_test.go
+++ b/internal/test/integration/traces_test.go
@@ -1661,7 +1661,7 @@ func testGoGenericHTTPTraces(t *testing.T) {
 	//
 	// 1. Go Generic client (Kafka) call nested within Go Generic Server (Fiber)
 	// 2. HTTP client call nested within Go Generic Server (Fiber)
-	// 2. HTTP non-Go library call nested within Go HTTP Server
+	// 3. HTTP non-Go library call nested within Go HTTP Server
 
 	for i := 0; i < 20; i++ {
 		ti.DoHTTPGet(t, "http://localhost:8080/produce", 200)
@@ -1767,6 +1767,89 @@ func testGoGenericHTTPTraces(t *testing.T) {
 				jaeger.Tag{Key: "http.request.method", Type: "string", Value: "GET"},
 				jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(200)},
 				jaeger.Tag{Key: "server.port", Type: "int64", Value: float64(3030)},
+				jaeger.Tag{Key: "span.kind", Type: "string", Value: "client"},
+			)
+			assert.Empty(ct, sd, sd.String())
+		}, testTimeout, 100*time.Millisecond)
+	})
+}
+
+func testGoGenericHTTPSTraces(t *testing.T) {
+	waitForTestComponents(t, "http://localhost:8080")
+
+	// We make requests such that we see all combinations
+	//
+	// 1. Go Generic client TLS (Kafka) call nested within Go Generic Server TLS (Fiber)
+	// 2. HTTPS non-Go library call nested within Go Generic Server TLS (Fiber)
+
+	for i := 0; i < 20; i++ {
+		ti.DoHTTPGet(t, "https://localhost:8443/produce/tls", 200)
+		ti.DoHTTPGet(t, "https://localhost:8443/api/pingssl", 200)
+	}
+
+	t.Run("Traces Go Generic HTTPS Server, Go Generic TCP TLS client", func(t *testing.T) {
+		var trace jaeger.Trace
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=GET%20%2Fproduce%2Ftls")
+			require.NoError(ct, err)
+			if resp == nil {
+				return
+			}
+			require.Equal(ct, http.StatusOK, resp.StatusCode)
+			var tq jaeger.TracesQuery
+			require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+			traces := tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/produce/tls"})
+			require.GreaterOrEqual(ct, len(traces), 1)
+			trace = traces[len(traces)-1]
+
+			res := trace.FindByOperationName("GET /produce/tls", "server")
+			require.Len(ct, res, 1)
+			server := res[0]
+			require.NotEmpty(ct, server.TraceID)
+
+			res = trace.FindByOperationName("publish my-topic", "producer")
+			require.Len(ct, res, 1)
+			client := res[0]
+			// Check parenthood
+			assert.Equal(ct, server.TraceID, client.TraceID)
+			sd := client.Diff(
+				jaeger.Tag{Key: "messaging.operation.type", Type: "string", Value: "publish"},
+				jaeger.Tag{Key: "messaging.system", Type: "string", Value: "kafka"},
+				jaeger.Tag{Key: "span.kind", Type: "string", Value: "producer"},
+			)
+			assert.Empty(ct, sd, sd.String())
+		}, testTimeout, 100*time.Millisecond)
+	})
+
+	t.Run("Traces Go Generic HTTPS Server, Go standard HTTPS client", func(t *testing.T) {
+		var trace jaeger.Trace
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=GET%20%2Fapi%2Fpingssl")
+			require.NoError(ct, err)
+			if resp == nil {
+				return
+			}
+			require.Equal(ct, http.StatusOK, resp.StatusCode)
+			var tq jaeger.TracesQuery
+			require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+			traces := tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/api/pingssl"})
+			require.GreaterOrEqual(ct, len(traces), 1)
+			trace = traces[len(traces)-1]
+
+			res := trace.FindByOperationName("GET /api/pingssl", "server")
+			require.Len(ct, res, 1)
+			server := res[0]
+			require.NotEmpty(ct, server.TraceID)
+
+			res = trace.FindByOperationName("GET /", "client")
+			require.Len(ct, res, 1)
+			client := res[0]
+			// Check parenthood
+			assert.Equal(ct, server.TraceID, client.TraceID)
+			sd := client.Diff(
+				jaeger.Tag{Key: "http.request.method", Type: "string", Value: "GET"},
+				jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(200)},
+				jaeger.Tag{Key: "server.port", Type: "int64", Value: float64(443)},
 				jaeger.Tag{Key: "span.kind", Type: "string", Value: "client"},
 			)
 			assert.Empty(ct, sd, sd.String())

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -400,6 +400,14 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 		"net.(*netFD).Write": {{
 			Start: p.bpfObjects.ObiUprobeNetFdWrite,
 		}},
+		"crypto/tls.(*Conn).Read": {{
+			Start: p.bpfObjects.ObiUprobeCryptoTlsRead,
+			End:   p.bpfObjects.ObiUprobeCryptoTlsReadRet,
+		}},
+		"crypto/tls.(*Conn).Write": {{
+			Start: p.bpfObjects.ObiUprobeCryptoTlsWrite,
+			End:   p.bpfObjects.ObiUprobeCryptoTlsWriteRet,
+		}},
 		"net.(*netFD).Close": {{
 			Start: p.bpfObjects.ObiUprobeNetFdClose,
 		}},


### PR DESCRIPTION
## Summary

This PR finishes the last remaining item for Generic Go support as described here https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1846. This allows us to stop adding new uprobes in Go and handle all protocols using the generic tracer handlers.

Closes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1031

Integration tests provided with TLS Kafka and HTTPS (incoming and outgoing).

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [X] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
