### PR TITLE
Fix gathering of listening sockets with iter_tcp

### DIFF
--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"sync"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -26,6 +28,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/internal/goexec"
+	"go.opentelemetry.io/obi/pkg/internal/netns"
 	"go.opentelemetry.io/obi/pkg/internal/netolly/ifaces"
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
@@ -482,6 +485,39 @@ func (p *Tracer) Iters() []*ebpfcommon.Iter {
 	return p.iters
 }
 
+func (p *Tracer) runItersForPids() {
+	iters := p.Iters()
+	if len(iters) == 0 {
+		return
+	}
+
+	seen := make(map[uint64]struct{})
+
+	for _, pids := range p.pidsFilter.CurrentPIDs(ebpfcommon.PIDTypeKProbes) {
+		for pid := range pids {
+			info, err := os.Stat(fmt.Sprintf("/proc/%d/ns/net", pid))
+			if err != nil {
+				p.log.Debug("netns stat failed", "pid", pid, "error", err)
+				continue
+			}
+
+			inode := info.Sys().(*syscall.Stat_t).Ino
+			if _, ok := seen[inode]; ok {
+				continue
+			}
+			seen[inode] = struct{}{}
+
+			for _, it := range iters {
+				if err := netns.WithNetNS(int(pid), func() error {
+					return it.Run(p.log)
+				}); err != nil {
+					p.log.Error("error running iterator in netns", "pid", pid, "error", err)
+				}
+			}
+		}
+	}
+}
+
 func (p *Tracer) Tracing() []*ebpfcommon.Tracing { return nil }
 
 func (p *Tracer) RecordInstrumentedLib(id uint64, closers []io.Closer) {
@@ -540,13 +576,7 @@ func (p *Tracer) Run(ctx context.Context, ebpfEventContext *ebpfcommon.EBPFEvent
 	go p.lookForTimeouts(ctx, parseContext, timeoutTicker, eventsChan)
 	defer timeoutTicker.Stop()
 
-	for _, it := range p.Iters() {
-		if it.Program == p.bpfObjects.ObiIterTcp {
-			if err := it.Run(p.log); err != nil {
-				p.log.Error("error running TCP iterator", "error", err)
-			}
-		}
-	}
+	p.runItersForPids()
 
 	p.log.Info("Launching p.Tracer")
 


### PR DESCRIPTION
## Summary

The `bpf_iter__tcp` iterator program only iterates sockets in the current network namespace. That means OBI is not able to list all of the sockets, since it's usually running in the host namespace (or in _a_ namespace). We need to enter the target pid netns and run it there.

## Validation

This was uncovered during the development of the `socktracer` - this is just a port of https://github.com/rafaelroquetto/opentelemetry-ebpf-instrumentation/blob/sk_verdict_new/pkg/internal/ebpf/socktracer/socktracer.go#L283 

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
