### PR TITLE
Restore non-fatal startup when embedded Java agent is missing

### DIFF
--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -87,7 +87,12 @@ func (ta *traceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 	ta.log = slog.With("component", "discover.traceAttacher")
 	ta.existingTracers = map[uint64]*ebpf.ProcessTracer{}
 	ta.nodeInjector = nodejs.NewNodeInjector(ta.Cfg)
-	ta.javaInjector = javaagent.NewJavaInjector(ta.Cfg)
+	javaInjector, err := javaagent.NewJavaInjector(ta.Cfg)
+	if err != nil {
+		ta.log.Warn("unable to inject OBI java agent, Java TLS telemetry generation will not work", "error", err)
+	} else {
+		ta.javaInjector = javaInjector
+	}
 	ta.processInstances = maps.MultiCounter[uint64]{}
 	ta.EbpfEventContext.CommonPIDsFilter = ebpfcommon.NewPIDsFilter(&ta.Cfg.Discovery, slog.With("component", "ebpfCommon.CommonPIDsFilter"), ta.Metrics)
 	ta.routeHarvester = harvest.NewRouteHarvester(&ta.Cfg.Discovery.RouteHarvestConfig, ta.Cfg.Discovery.DisabledRouteHarvesters, ta.Cfg.Discovery.RouteHarvesterTimeout)

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -49,16 +49,18 @@ type JavaInjector struct {
 	cfg *obi.Config
 }
 
-func NewJavaInjector(cfg *obi.Config) *JavaInjector {
+func NewJavaInjector(cfg *obi.Config) (*JavaInjector, error) {
 	if !cfg.Java.Enabled {
-		return nil
+		return nil, nil
 	}
-	ensureEmbeddedAgent()
+	if err := ensureEmbeddedAgent(); err != nil {
+		return nil, err
+	}
 
 	return &JavaInjector{
 		cfg: cfg,
 		log: slog.With("component", "javaagent.Injector"),
-	}
+	}, nil
 }
 
 func tempDirPath(root, dir string) (string, bool) {
@@ -197,12 +199,12 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 	return nil
 }
 
-func ensureEmbeddedAgent() {
+func ensureEmbeddedAgent() error {
 	if len(embeddedJavaAgentBytes) == 0 || strings.TrimSpace(string(embeddedJavaAgentBytes)) == javaAgentEmbedPlaceholder {
-		// Make sure to run `make java-docker-build` to build the Java Agent
-		// so that it can be embedded during build.
-		panic("embedded OBI java agent artifact is missing")
+		return errors.New("embedded OBI java agent artifact is missing from this build; Java TLS telemetry generation will be disabled")
 	}
+
+	return nil
 }
 
 // to be changed in tests

--- a/pkg/internal/java/java_inject_notlinux.go
+++ b/pkg/internal/java/java_inject_notlinux.go
@@ -9,5 +9,5 @@ package javaagent // import "go.opentelemetry.io/obi/pkg/internal/java"
 
 type JavaInjector struct{}
 
-func NewJavaInjector(_ any) *JavaInjector       { return nil }
-func (*JavaInjector) NewExecutable(_ any) error { return nil }
+func NewJavaInjector(_ any) (*JavaInjector, error) { return nil, nil }
+func (*JavaInjector) NewExecutable(_ any) error    { return nil }

--- a/pkg/internal/java/java_inject_test.go
+++ b/pkg/internal/java/java_inject_test.go
@@ -506,6 +506,55 @@ func TestJavaInjector_AttachOpts(t *testing.T) {
 	}
 }
 
+func TestNewJavaInjector_Disabled(t *testing.T) {
+	injector, err := NewJavaInjector(&obi.Config{
+		Java: obi.JavaConfig{
+			Enabled: false,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Nil(t, injector)
+}
+
+func TestNewJavaInjector_MissingEmbeddedAgent(t *testing.T) {
+	originalEmbeddedBytes := embeddedJavaAgentBytes
+	t.Cleanup(func() {
+		embeddedJavaAgentBytes = originalEmbeddedBytes
+	})
+
+	embeddedJavaAgentBytes = nil
+
+	injector, err := NewJavaInjector(&obi.Config{
+		Java: obi.JavaConfig{
+			Enabled: true,
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, injector)
+	assert.Contains(t, err.Error(), "embedded OBI java agent artifact is missing from this build")
+}
+
+func TestNewJavaInjector_PlaceholderEmbeddedAgent(t *testing.T) {
+	originalEmbeddedBytes := embeddedJavaAgentBytes
+	t.Cleanup(func() {
+		embeddedJavaAgentBytes = originalEmbeddedBytes
+	})
+
+	embeddedJavaAgentBytes = []byte(javaAgentEmbedPlaceholder + "\n")
+
+	injector, err := NewJavaInjector(&obi.Config{
+		Java: obi.JavaConfig{
+			Enabled: true,
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, injector)
+	assert.Contains(t, err.Error(), "embedded OBI java agent artifact is missing from this build")
+}
+
 func TestEnsureEmbeddedAgent_ForgotToEmbed(t *testing.T) {
 	originalEmbeddedBytes := embeddedJavaAgentBytes
 	t.Cleanup(func() {

--- a/pkg/internal/java/java_inject_test.go
+++ b/pkg/internal/java/java_inject_test.go
@@ -506,22 +506,26 @@ func TestJavaInjector_AttachOpts(t *testing.T) {
 	}
 }
 
-func TestEnsureEmbeddedAgentInCache_ForgotToEmbed(t *testing.T) {
+func TestEnsureEmbeddedAgent_ForgotToEmbed(t *testing.T) {
 	originalEmbeddedBytes := embeddedJavaAgentBytes
 	t.Cleanup(func() {
 		embeddedJavaAgentBytes = originalEmbeddedBytes
 	})
 
 	embeddedJavaAgentBytes = nil
-	assert.Panics(t, ensureEmbeddedAgent)
+	err := ensureEmbeddedAgent()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "embedded OBI java agent artifact is missing from this build")
 }
 
-func TestEnsureEmbeddedAgentInCache_PlaceholderBytesError(t *testing.T) {
+func TestEnsureEmbeddedAgent_PlaceholderBytesError(t *testing.T) {
 	originalEmbeddedBytes := embeddedJavaAgentBytes
 	t.Cleanup(func() {
 		embeddedJavaAgentBytes = originalEmbeddedBytes
 	})
 
 	embeddedJavaAgentBytes = []byte(javaAgentEmbedPlaceholder + "\n")
-	assert.Panics(t, ensureEmbeddedAgent)
+	err := ensureEmbeddedAgent()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "embedded OBI java agent artifact is missing from this build")
 }


### PR DESCRIPTION
## Motivation

OBI used to tolerate builds that omitted the embedded Java agent JAR: startup would log a warning and continue with Java injection disabled. After #1894, that degraded path regressed into a startup panic.

Because Java instrumentation is enabled by default, a build or packaging workflow that ships `obi` without the embedded agent now crashes the privileged OBI process at startup instead of continuing without Java TLS telemetry. That turns a packaging mistake into a service-impacting failure mode.

## History

The regression was introduced by #1894 (98515ab), which changed `NewJavaInjector` to unconditionally call `ensureEmbeddedAgent` and changed `ensureEmbeddedAgent` to panic when the embedded JAR is missing or still the placeholder.

Before that change, `traceAttacher` handled Java injector initialization failures by logging a warning and leaving Java injection disabled.

## What This PR Does

This PR restores the previous non-fatal startup behavior:

- changes `ensureEmbeddedAgent` to return an error instead of panicking
- changes `NewJavaInjector` to propagate that error to the caller
- restores `traceAttacher` startup handling so it logs a warning and continues without Java injection when the embedded agent is missing
- updates the focused unit tests to validate the error-return path instead of panic behavior

The runtime result is that misbuilt deployments still start, but Java TLS telemetry generation remains disabled until the binary is packaged with the embedded Java agent.

## Validation

- `go test ./pkg/internal/java -run 'TestEnsureEmbeddedAgent|TestJavaInjector_CopyAgent|TestJavaInjector_FindTempDir|TestJavaInjector_AttachOpts'`
- `go test ./pkg/appolly/discover -run TestNonexistent`
