### PR TITLE
prom: restore BPF internal metrics for Prometheus internal reporters

### DIFF
--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -236,7 +236,7 @@ func (pf *PIDsFilter) checkIfExportsOTelSpanMetrics(svc *svc.Attrs, span *reques
 
 // reportAvoidedService calls the appropriate internal metrics method based on telemetry type
 func (pf *PIDsFilter) reportAvoidedService(svc *svc.Attrs, telemetryType string) {
-	if _, ok := pf.metrics.(imetrics.NoopReporter); ok || pf.metrics == nil {
+	if pf.metrics == nil || imetrics.IsBuiltinNoopReporter(pf.metrics) {
 		return
 	}
 

--- a/pkg/export/imetrics/imetrics.go
+++ b/pkg/export/imetrics/imetrics.go
@@ -110,6 +110,19 @@ type Reporter interface {
 	BPFPacketStats(count, ignored uint64)
 }
 
+func IsBuiltinNoopReporter(reporter Reporter) bool {
+	if reporter == nil {
+		return false
+	}
+
+	switch reporter.(type) {
+	case NoopReporter, *NoopReporter:
+		return true
+	default:
+		return false
+	}
+}
+
 // NoopReporter is a metrics Reporter that just does nothing
 type NoopReporter struct{}
 

--- a/pkg/export/imetrics/imetrics_test.go
+++ b/pkg/export/imetrics/imetrics_test.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package imetrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsBuiltinNoopReporter(t *testing.T) {
+	t.Run("noop reporter value", func(t *testing.T) {
+		assert.True(t, IsBuiltinNoopReporter(NoopReporter{}))
+	})
+
+	t.Run("noop reporter pointer", func(t *testing.T) {
+		assert.True(t, IsBuiltinNoopReporter(&NoopReporter{}))
+	})
+
+	t.Run("prometheus reporter", func(t *testing.T) {
+		reporter := NewPrometheusReporter(&InternalMetricsConfig{}, nil, prometheus.NewRegistry())
+		assert.False(t, IsBuiltinNoopReporter(reporter))
+	})
+
+	t.Run("noop embedder is not builtin noop", func(t *testing.T) {
+		reporter := &noopEmbeddingReporter{}
+		assert.False(t, IsBuiltinNoopReporter(reporter))
+	})
+
+	t.Run("nil reporter", func(t *testing.T) {
+		assert.False(t, IsBuiltinNoopReporter(nil))
+	})
+}
+
+type noopEmbeddingReporter struct {
+	NoopReporter
+}
+
+func (n *noopEmbeddingReporter) BpfProbeLatency(_, _, _ string, _ float64) {}

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -781,7 +781,7 @@ func (mr *MetricsReporter) close() {
 func instrumentMetricsExporter(internalMetrics imetrics.Reporter, in sdkmetric.Exporter) sdkmetric.Exporter {
 	// avoid wrapping the instrumented exporter if we don't have
 	// internal instrumentation (NoopReporter)
-	if _, ok := internalMetrics.(imetrics.NoopReporter); ok || internalMetrics == nil {
+	if internalMetrics == nil || imetrics.IsBuiltinNoopReporter(internalMetrics) {
 		return in
 	}
 	return &instrumentedMetricsExporter{

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -183,7 +183,7 @@ func (tr *tracesOTELReceiver) provideLoop(ctx context.Context) {
 func instrumentTracesExporter(internalMetrics imetrics.Reporter, in exporter.Traces) exporter.Traces {
 	// avoid wrapping the instrumented exporter if we don't have
 	// internal instrumentation (NoopReporter)
-	if _, ok := internalMetrics.(imetrics.NoopReporter); ok || internalMetrics == nil {
+	if internalMetrics == nil || imetrics.IsBuiltinNoopReporter(internalMetrics) {
 		return in
 	}
 	return &instrumentedTracesExporter{

--- a/pkg/export/prom/prom_bpf.go
+++ b/pkg/export/prom/prom_bpf.go
@@ -8,6 +8,7 @@ import (
 	"encoding"
 	"log/slog"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/cilium/ebpf"
@@ -15,7 +16,6 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/export/connector"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
-	"go.opentelemetry.io/obi/pkg/export/otel"
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
@@ -33,6 +33,9 @@ type BPFCollector struct {
 	probeLatencyDesc *prometheus.Desc
 	mapSizeDesc      *prometheus.Desc
 	progs            map[ebpf.ProgramID]*BPFProgram
+	probeMetrics     func() []ProbeMetrics
+	mapMetrics       func() []BpfMapMetrics
+	mu               sync.Mutex
 }
 
 type BPFProgram struct {
@@ -66,17 +69,39 @@ func BPFMetrics(
 	mpCfg *perapp.MetricsConfig,
 ) swarm.InstanceFunc {
 	return func(_ context.Context) (swarm.RunFunc, error) {
-		if !bpfCollectorEnabled(cfg, mpCfg, ctxInfo.Metrics) {
+		promEnabled := promMetricsEnabled(cfg, mpCfg)
+		internalEnabled := internalMetricsEnabled(ctxInfo.Metrics)
+		if !promEnabled && !internalEnabled {
 			return swarm.EmptyRunFunc()
 		}
-		collector := newBPFCollector(ctxInfo, cfg, mpCfg)
-		return collector.start, nil
+
+		runFns := make([]swarm.RunFunc, 0, 2)
+		if promEnabled {
+			collector := newBPFCollectorFn(ctxInfo, cfg, mpCfg)
+			runFns = append(runFns, collector.startPrometheus)
+		}
+		if internalEnabled {
+			collector := newInternalBPFCollectorFn(ctxInfo, cfg, mpCfg)
+			runFns = append(runFns, collector.startInternalMetrics)
+		}
+
+		return func(ctx context.Context) {
+			for _, run := range runFns {
+				run(ctx)
+			}
+		}, nil
 	}
 }
 
-func internalMetricsOTELEnabled(internalMetrics imetrics.Reporter) bool {
-	_, ok := internalMetrics.(*otel.InternalMetricsReporter)
-	return ok
+var newBPFCollectorFn = newBPFCollector
+var newInternalBPFCollectorFn = newInternalBPFCollector
+
+func internalMetricsEnabled(internalMetrics imetrics.Reporter) bool {
+	if internalMetrics == nil || imetrics.IsBuiltinNoopReporter(internalMetrics) {
+		return false
+	}
+
+	return internalMetrics.BpfInternalMetricsScrapeInterval() > 0
 }
 
 func promMetricsEnabled(cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig) bool {
@@ -84,10 +109,18 @@ func promMetricsEnabled(cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig) bool
 }
 
 func bpfCollectorEnabled(cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig, internalMetrics imetrics.Reporter) bool {
-	return promMetricsEnabled(cfg, mpCfg) || internalMetricsOTELEnabled(internalMetrics)
+	return promMetricsEnabled(cfg, mpCfg) || internalMetricsEnabled(internalMetrics)
 }
 
 func newBPFCollector(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig) *BPFCollector {
+	return newCollector(ctxInfo, cfg, mpCfg, true)
+}
+
+func newInternalBPFCollector(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig) *BPFCollector {
+	return newCollector(ctxInfo, cfg, mpCfg, false)
+}
+
+func newCollector(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig, registerProm bool) *BPFCollector {
 	c := &BPFCollector{
 		promCfg:         cfg,
 		commonCfg:       mpCfg,
@@ -109,19 +142,24 @@ func newBPFCollector(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *
 			nil,
 		),
 	}
-	if promMetricsEnabled(cfg, mpCfg) {
+	c.probeMetrics = c.getProbeMetrics
+	c.mapMetrics = c.getMapMetrics
+	if registerProm && promMetricsEnabled(cfg, mpCfg) {
 		// Register the collector
 		c.promConnect.Register(cfg.Port, cfg.Path, c)
 	}
 	return c
 }
 
-func (bc *BPFCollector) start(ctx context.Context) {
-	if promMetricsEnabled(bc.promCfg, bc.commonCfg) {
-		bc.reportMetrics(ctx)
-	} else {
-		go bc.collectInternalMetrics(ctx)
+func (bc *BPFCollector) startPrometheus(ctx context.Context) {
+	bc.reportMetrics(ctx)
+}
+
+func (bc *BPFCollector) startInternalMetrics(ctx context.Context) {
+	if !internalMetricsEnabled(bc.internalMetrics) {
+		return
 	}
+	go bc.collectInternalMetrics(ctx)
 }
 
 func (bc *BPFCollector) reportMetrics(ctx context.Context) {
@@ -137,7 +175,7 @@ func (bc *BPFCollector) collectInternalMetrics(ctx context.Context) {
 			return
 
 		case <-ticker.C:
-			probeMetrics := bc.getProbeMetrics()
+			probeMetrics, mapMetrics := bc.collectMetrics()
 			for _, metric := range probeMetrics {
 				// TODO: this is not the most efficient way to report histogram metrics,
 				// but with otel metrics we don't have a way to report histograms based on count and latency, like filling buckets with prometheus.
@@ -147,7 +185,6 @@ func (bc *BPFCollector) collectInternalMetrics(ctx context.Context) {
 				}
 			}
 
-			mapMetrics := bc.getMapMetrics()
 			for _, metric := range mapMetrics {
 				bc.ctxInfo.Metrics.BpfMapEntries(metric.mapID, metric.mapName, metric.mapType, int(metric.entries))
 				bc.ctxInfo.Metrics.BpfMapMaxEntries(metric.mapID, metric.mapName, metric.mapType, metric.maxEntries)
@@ -162,7 +199,10 @@ func (bc *BPFCollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (bc *BPFCollector) Collect(ch chan<- prometheus.Metric) {
 	bc.log.Debug("Collecting eBPF metrics")
-	probeMetrics := bc.getProbeMetrics()
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+
+	probeMetrics := bc.probeMetrics()
 	for _, metric := range probeMetrics {
 		metric.program.updateBuckets(metric.latency, metric.count)
 
@@ -177,7 +217,7 @@ func (bc *BPFCollector) Collect(ch chan<- prometheus.Metric) {
 			metric.probeName,
 		)
 	}
-	mapMetrics := bc.getMapMetrics()
+	mapMetrics := bc.mapMetrics()
 	for _, metric := range mapMetrics {
 		ch <- prometheus.MustNewConstMetric(
 			bc.mapSizeDesc,
@@ -189,6 +229,13 @@ func (bc *BPFCollector) Collect(ch chan<- prometheus.Metric) {
 			strconv.FormatUint(uint64(metric.maxEntries), 10),
 		)
 	}
+}
+
+func (bc *BPFCollector) collectMetrics() ([]ProbeMetrics, []BpfMapMetrics) {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+
+	return bc.probeMetrics(), bc.mapMetrics()
 }
 
 func (bc *BPFCollector) getProbeMetrics() []ProbeMetrics {

--- a/pkg/export/prom/prom_bpf.go
+++ b/pkg/export/prom/prom_bpf.go
@@ -93,8 +93,10 @@ func BPFMetrics(
 	}
 }
 
-var newBPFCollectorFn = newBPFCollector
-var newInternalBPFCollectorFn = newInternalBPFCollector
+var (
+	newBPFCollectorFn         = newBPFCollector
+	newInternalBPFCollectorFn = newInternalBPFCollector
+)
 
 func internalMetricsEnabled(internalMetrics imetrics.Reporter) bool {
 	if internalMetrics == nil || imetrics.IsBuiltinNoopReporter(internalMetrics) {

--- a/pkg/export/prom/prom_bpf_test.go
+++ b/pkg/export/prom/prom_bpf_test.go
@@ -1,0 +1,394 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prom
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/connector"
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
+	"go.opentelemetry.io/obi/pkg/pipe/global"
+)
+
+func TestBPFCollectorEnabled(t *testing.T) {
+	cfg := &PrometheusConfig{}
+	mpCfg := &perapp.MetricsConfig{}
+
+	t.Run("disabled without reporter", func(t *testing.T) {
+		assert.False(t, bpfCollectorEnabled(cfg, mpCfg, nil))
+	})
+
+	t.Run("disabled with noop reporter", func(t *testing.T) {
+		assert.False(t, bpfCollectorEnabled(cfg, mpCfg, imetrics.NoopReporter{}))
+	})
+
+	t.Run("disabled with noop reporter pointer", func(t *testing.T) {
+		assert.False(t, bpfCollectorEnabled(cfg, mpCfg, &imetrics.NoopReporter{}))
+	})
+
+	t.Run("enabled with prometheus internal reporter", func(t *testing.T) {
+		internalMetrics := imetrics.NewPrometheusReporter(
+			&imetrics.InternalMetricsConfig{BpfMetricScrapeInterval: time.Millisecond},
+			nil,
+			prometheus.NewRegistry(),
+		)
+
+		assert.True(t, bpfCollectorEnabled(cfg, mpCfg, internalMetrics))
+	})
+
+	t.Run("enabled with prometheus manager-backed reporter", func(t *testing.T) {
+		internalMetrics := imetrics.NewPrometheusReporter(
+			&imetrics.InternalMetricsConfig{BpfMetricScrapeInterval: time.Millisecond},
+			&connector.PrometheusManager{},
+			nil,
+		)
+
+		assert.True(t, bpfCollectorEnabled(cfg, mpCfg, internalMetrics))
+	})
+
+	t.Run("disabled with zero-interval prometheus reporter", func(t *testing.T) {
+		internalMetrics := imetrics.NewPrometheusReporter(
+			&imetrics.InternalMetricsConfig{},
+			nil,
+			prometheus.NewRegistry(),
+		)
+
+		assert.False(t, bpfCollectorEnabled(cfg, mpCfg, internalMetrics))
+	})
+}
+
+func TestBPFMetricsCollectsInternalMetricsForPrometheusReporter(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	internalMetrics := imetrics.NewPrometheusReporter(
+		&imetrics.InternalMetricsConfig{BpfMetricScrapeInterval: time.Millisecond},
+		nil,
+		registry,
+	)
+	ctxInfo := &global.ContextInfo{Metrics: internalMetrics}
+
+	originalNewBPFCollector := newBPFCollectorFn
+	originalNewInternalBPFCollector := newInternalBPFCollectorFn
+	t.Cleanup(func() {
+		newBPFCollectorFn = originalNewBPFCollector
+		newInternalBPFCollectorFn = originalNewInternalBPFCollector
+	})
+
+	newInternalBPFCollectorFn = func(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig) *BPFCollector {
+		return &BPFCollector{
+			promCfg:         cfg,
+			commonCfg:       mpCfg,
+			internalMetrics: ctxInfo.Metrics,
+			ctxInfo:         ctxInfo,
+			probeMetrics: func() []ProbeMetrics {
+				return []ProbeMetrics{{
+					probeType: "kprobe",
+					probeName: "tcp_connect",
+					probeID:   "7",
+					latency:   0.25,
+					count:     1,
+				}}
+			},
+			mapMetrics: func() []BpfMapMetrics {
+				return []BpfMapMetrics{{
+					mapType:    "hash",
+					mapName:    "connections",
+					mapID:      "3",
+					maxEntries: 16,
+					entries:    4,
+				}}
+			},
+		}
+	}
+
+	runFn, err := BPFMetrics(ctxInfo, &PrometheusConfig{}, &perapp.MetricsConfig{})(context.Background())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	runFn(ctx)
+
+	require.Eventually(t, func() bool {
+		probeMetric := gatheredMetric(t, registry, "obi_bpf_probe_latency_seconds", map[string]string{
+			"probe_id":   "7",
+			"probe_type": "kprobe",
+			"probe_name": "tcp_connect",
+		})
+		mapEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_entries_total", map[string]string{
+			"map_id":   "3",
+			"map_name": "connections",
+			"map_type": "hash",
+		})
+		mapMaxEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_max_entries_total", map[string]string{
+			"map_id":   "3",
+			"map_name": "connections",
+			"map_type": "hash",
+		})
+
+		if probeMetric == nil || mapEntriesMetric == nil || mapMaxEntriesMetric == nil {
+			return false
+		}
+
+		return probeMetric.GetHistogram().GetSampleCount() >= 1 &&
+			mapEntriesMetric.GetGauge().GetValue() == 4 &&
+			mapMaxEntriesMetric.GetGauge().GetValue() == 16
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestBPFMetricsCollectsInternalMetricsWhenPrometheusEndpointEnabled(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	internalMetrics := imetrics.NewPrometheusReporter(
+		&imetrics.InternalMetricsConfig{BpfMetricScrapeInterval: time.Millisecond},
+		nil,
+		registry,
+	)
+	ctxInfo := &global.ContextInfo{Metrics: internalMetrics}
+	cfg := &PrometheusConfig{Port: 1}
+	mpCfg := &perapp.MetricsConfig{Features: export.FeatureEBPF}
+
+	originalNewBPFCollector := newBPFCollectorFn
+	originalNewInternalBPFCollector := newInternalBPFCollectorFn
+	t.Cleanup(func() {
+		newBPFCollectorFn = originalNewBPFCollector
+		newInternalBPFCollectorFn = originalNewInternalBPFCollector
+	})
+
+	var promCollector *BPFCollector
+	newBPFCollectorFn = func(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig) *BPFCollector {
+		var collected bool
+		promCollector = &BPFCollector{
+			promCfg:         cfg,
+			commonCfg:       mpCfg,
+			internalMetrics: ctxInfo.Metrics,
+			promConnect:     &connector.PrometheusManager{},
+			ctxInfo:         ctxInfo,
+			log:             slog.With("component", "prom.BPFCollector"),
+			probeLatencyDesc: prometheus.NewDesc(
+				prometheus.BuildFQName("bpf", "probe", "latency_seconds"),
+				"Latency of the probe in seconds",
+				[]string{"probe_id", "probe_type", "probe_name"},
+				nil,
+			),
+			mapSizeDesc: prometheus.NewDesc(
+				prometheus.BuildFQName("bpf", "map", "entries_total"),
+				"Number of entries in the map",
+				[]string{"map_id", "map_name", "map_type", "max_entries"},
+				nil,
+			),
+			probeMetrics: func() []ProbeMetrics {
+				count := uint64(0)
+				if !collected {
+					count = 1
+					collected = true
+				}
+				return []ProbeMetrics{{
+					probeType: "kprobe",
+					probeName: "tcp_connect",
+					probeID:   "7",
+					latency:   0.25,
+					count:     count,
+					program: &BPFProgram{
+						runTime:  250 * time.Millisecond,
+						runCount: 1,
+					},
+				}}
+			},
+			mapMetrics: func() []BpfMapMetrics {
+				return []BpfMapMetrics{{
+					mapType:    "hash",
+					mapName:    "connections",
+					mapID:      "3",
+					maxEntries: 16,
+					entries:    4,
+				}}
+			},
+		}
+		return promCollector
+	}
+
+	newInternalBPFCollectorFn = func(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig) *BPFCollector {
+		var collected bool
+		return &BPFCollector{
+			promCfg:         cfg,
+			commonCfg:       mpCfg,
+			internalMetrics: ctxInfo.Metrics,
+			ctxInfo:         ctxInfo,
+			probeMetrics: func() []ProbeMetrics {
+				count := uint64(0)
+				if !collected {
+					count = 1
+					collected = true
+				}
+				return []ProbeMetrics{{
+					probeType: "kprobe",
+					probeName: "tcp_connect",
+					probeID:   "7",
+					latency:   0.25,
+					count:     count,
+				}}
+			},
+			mapMetrics: func() []BpfMapMetrics {
+				return []BpfMapMetrics{{
+					mapType:    "hash",
+					mapName:    "connections",
+					mapID:      "3",
+					maxEntries: 16,
+					entries:    4,
+				}}
+			},
+		}
+	}
+
+	runFn, err := BPFMetrics(ctxInfo, cfg, mpCfg)(context.Background())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	runFn(ctx)
+
+	promMetricsCh := make(chan prometheus.Metric, 4)
+	promCollector.Collect(promMetricsCh)
+	close(promMetricsCh)
+
+	promProbeMetricFound := false
+	for metric := range promMetricsCh {
+		var promProbeMetric dto.Metric
+		require.NoError(t, metric.Write(&promProbeMetric))
+		if promProbeMetric.GetHistogram() == nil {
+			continue
+		}
+		require.Equal(t, uint64(1), promProbeMetric.GetHistogram().GetSampleCount())
+		promProbeMetricFound = true
+	}
+	require.True(t, promProbeMetricFound)
+
+	require.Eventually(t, func() bool {
+		probeMetric := gatheredMetric(t, registry, "obi_bpf_probe_latency_seconds", map[string]string{
+			"probe_id":   "7",
+			"probe_type": "kprobe",
+			"probe_name": "tcp_connect",
+		})
+		mapEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_entries_total", map[string]string{
+			"map_id":   "3",
+			"map_name": "connections",
+			"map_type": "hash",
+		})
+		mapMaxEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_max_entries_total", map[string]string{
+			"map_id":   "3",
+			"map_name": "connections",
+			"map_type": "hash",
+		})
+
+		if probeMetric == nil || mapEntriesMetric == nil || mapMaxEntriesMetric == nil {
+			return false
+		}
+
+		return probeMetric.GetHistogram().GetSampleCount() >= 1 &&
+			mapEntriesMetric.GetGauge().GetValue() == 4 &&
+			mapMaxEntriesMetric.GetGauge().GetValue() == 16
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestBPFMetricsDoesNotStartInternalCollectorForZeroIntervalReporter(t *testing.T) {
+	ctxInfo := &global.ContextInfo{
+		Metrics: imetrics.NewPrometheusReporter(
+			&imetrics.InternalMetricsConfig{},
+			nil,
+			prometheus.NewRegistry(),
+		),
+	}
+	cfg := &PrometheusConfig{Port: 1}
+	mpCfg := &perapp.MetricsConfig{Features: export.FeatureEBPF}
+
+	originalNewBPFCollector := newBPFCollectorFn
+	originalNewInternalBPFCollector := newInternalBPFCollectorFn
+	t.Cleanup(func() {
+		newBPFCollectorFn = originalNewBPFCollector
+		newInternalBPFCollectorFn = originalNewInternalBPFCollector
+	})
+
+	newBPFCollectorFn = func(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig) *BPFCollector {
+		return &BPFCollector{
+			promCfg:         cfg,
+			commonCfg:       mpCfg,
+			internalMetrics: ctxInfo.Metrics,
+			promConnect:     &connector.PrometheusManager{},
+			ctxInfo:         ctxInfo,
+		}
+	}
+
+	var internalCollectorStarted atomic.Bool
+	newInternalBPFCollectorFn = func(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig) *BPFCollector {
+		return &BPFCollector{
+			promCfg:         cfg,
+			commonCfg:       mpCfg,
+			internalMetrics: ctxInfo.Metrics,
+			ctxInfo:         ctxInfo,
+			probeMetrics: func() []ProbeMetrics {
+				internalCollectorStarted.Store(true)
+				return nil
+			},
+			mapMetrics: func() []BpfMapMetrics {
+				internalCollectorStarted.Store(true)
+				return nil
+			},
+		}
+	}
+
+	runFn, err := BPFMetrics(ctxInfo, cfg, mpCfg)(context.Background())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	require.NotPanics(t, func() {
+		runFn(ctx)
+	})
+
+	time.Sleep(10 * time.Millisecond)
+	assert.False(t, internalCollectorStarted.Load())
+}
+
+func gatheredMetric(t *testing.T, registry *prometheus.Registry, name string, labels map[string]string) *dto.Metric {
+	t.Helper()
+
+	metrics, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, family := range metrics {
+		if family.GetName() != name {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			if metricLabelsMatch(metric, labels) {
+				return metric
+			}
+		}
+	}
+
+	return nil
+}
+
+func metricLabelsMatch(metric *dto.Metric, labels map[string]string) bool {
+	if len(metric.GetLabel()) != len(labels) {
+		return false
+	}
+
+	for _, label := range metric.GetLabel() {
+		if labels[label.GetName()] != label.GetValue() {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
## Summary
- Route BPF internal metrics into the Prometheus internal reporter path again
- Restore collection of BPF internal metrics for Prometheus-backed internal reporters when a positive `bpf_metric_scrape_interval` is configured
- Keep the main Prometheus endpoint and internal Prometheus reporting on separate BPF collectors so mixed configurations do not share delta state

## Why
BPF internal metrics were no longer being collected for the Prometheus internal reporter path. The Prometheus internal reporter wiring had drifted so those metrics stopped flowing into the internal reporting pipeline.

## Impact
This restores the expected Prometheus-visible BPF internal metrics while preserving broader exporter behavior for other metric paths. It also avoids starting background BPF collection for zero-interval reporters and keeps builtin noop detection exact so custom reporters that embed `NoopReporter` are not misclassified.

## Validation performed
- `go test -v ./pkg/export/imetrics`
- `go test -run 'TestBPFCollectorEnabled|TestBPFMetricsCollectsInternalMetricsForPrometheusReporter|TestBPFMetricsCollectsInternalMetricsWhenPrometheusEndpointEnabled|TestBPFMetricsDoesNotStartInternalCollectorForZeroIntervalReporter' -v ./pkg/export/prom`
- `go test ./pkg/ebpf/common`
- `go test -run 'TestInstrument.*|Test.*Noop.*' -v ./pkg/export/otel`