### PR TITLE
Fix OTEL job and instance attribute keys

### DIFF
--- a/pkg/appolly/app/request/metric_attributes.go
+++ b/pkg/appolly/app/request/metric_attributes.go
@@ -327,11 +327,11 @@ func CudaMemcpy(val int) attribute.KeyValue {
 }
 
 func Job(val string) attribute.KeyValue {
-	return attribute.Key(attr.MessagingOpType).String(val)
+	return attribute.Key(attr.Job).String(val)
 }
 
 func Instance(val string) attribute.KeyValue {
-	return attribute.Key(attr.MessagingOpType).String(val)
+	return attribute.Key(attr.Instance).String(val)
 }
 
 func DNSAnswers(val string) attribute.KeyValue {

--- a/pkg/appolly/app/request/metric_attributes_test.go
+++ b/pkg/appolly/app/request/metric_attributes_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 )
 
 func TestHostFromSchemeHost(t *testing.T) {
@@ -57,4 +59,14 @@ func TestHostFromSchemeHost(t *testing.T) {
 		}
 		assert.Empty(t, HostFromSchemeHost(span))
 	})
+}
+
+func TestJobAndInstanceAttributesUseOwnKeys(t *testing.T) {
+	job := Job("checkout/api")
+	assert.Equal(t, string(attr.Job), string(job.Key))
+	assert.Equal(t, "checkout/api", job.Value.AsString())
+
+	instance := Instance("pod-123")
+	assert.Equal(t, string(attr.Instance), string(instance.Key))
+	assert.Equal(t, "pod-123", instance.Value.AsString())
 }

--- a/pkg/appolly/app/request/span_getters.go
+++ b/pkg/appolly/app/request/span_getters.go
@@ -260,7 +260,7 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 	case attr.Job:
 		getter = func(span *Span) attribute.KeyValue { return Job(span.Service.Job()) }
 	case attr.Instance:
-		getter = func(span *Span) attribute.KeyValue { return Job(span.Service.UID.Instance) }
+		getter = func(span *Span) attribute.KeyValue { return Instance(span.Service.UID.Instance) }
 	case attr.GraphQLDocument:
 		getter = func(s *Span) attribute.KeyValue {
 			if s.Type == EventTypeHTTP && s.SubType == HTTPSubtypeGraphQL && s.GraphQL != nil {

--- a/pkg/appolly/app/request/span_getters_test.go
+++ b/pkg/appolly/app/request/span_getters_test.go
@@ -523,3 +523,20 @@ func TestSpanOTELGetters_MessagingAttributes_NATS(t *testing.T) {
 	span.Method = MessagingProcess
 	assert.Equal(t, MessagingProcess, opTypeGetter(span).Value.AsString())
 }
+
+func TestSpanOTELGetters_Instance(t *testing.T) {
+	getter, ok := spanOTELGetters(attr.Instance)
+	require.True(t, ok, "getter should be found for Instance")
+
+	span := &Span{
+		Service: svc.Attrs{
+			UID: svc.UID{
+				Instance: "instance-42",
+			},
+		},
+	}
+
+	kv := getter(span)
+	assert.Equal(t, string(attr.Instance), string(kv.Key))
+	assert.Equal(t, "instance-42", kv.Value.AsString())
+}


### PR DESCRIPTION
## Summary
- map job and instance attributes to the correct OTEL resource attribute keys
- keep the rest of the attribute export path unchanged while correcting the emitted key names

## Why
The exporter was assigning job and instance values to the wrong OTEL attribute keys. That caused emitted resource attributes to use incorrect semantic-convention names even though the underlying values were present.

## Impact
This restores the expected OTEL attribute naming for job and instance resource fields, improving downstream compatibility and attribute interpretation without changing the underlying values.
