### PR TITLE
fix discover proc stat buffer race

### DIFF
--- a/pkg/appolly/discover/watcher_proc.go
+++ b/pkg/appolly/discover/watcher_proc.go
@@ -36,7 +36,16 @@ import (
 const (
 	defaultPollInterval = 5 * time.Second
 	emptyDuration       = time.Duration(0)
+	// procStatBufSize safely fits /proc/<pid>/stat for our parsing path.
+	procStatBufSize = 4096
 )
+
+// procStatBufPool amortizes stat buffer allocations across all procStatReader callers.
+var procStatBufPool = sync.Pool{
+	New: func() any {
+		return new([procStatBufSize]byte)
+	},
+}
 
 type WatchEventType int
 
@@ -444,11 +453,15 @@ func parseProcStatField(buf string, field int) string {
 	return ""
 }
 
-type procStatReader struct {
-	buf [4096]byte // 4KB buffer: safely fits /proc/self/stat (~52 fields * 20 chars + comm + spaces)
-}
+type procStatReader struct{}
 
 func (r *procStatReader) getProcStatField(pid app.PID, field int) string {
+	bufPtr, ok := procStatBufPool.Get().(*[procStatBufSize]byte)
+	if !ok {
+		bufPtr = new([procStatBufSize]byte)
+	}
+	defer procStatBufPool.Put(bufPtr)
+
 	path := fmt.Sprintf("/proc/%d/stat", pid)
 
 	f, err := os.Open(path)
@@ -458,12 +471,12 @@ func (r *procStatReader) getProcStatField(pid app.PID, field int) string {
 
 	defer f.Close()
 
-	nbytes, err := f.Read(r.buf[:])
+	nbytes, err := f.Read(bufPtr[:])
 	if err != nil {
 		return ""
 	}
 
-	return parseProcStatField(string(r.buf[:nbytes]), field)
+	return parseProcStatField(string(bufPtr[:nbytes]), field)
 }
 
 func ticksToNanosecond(ticks uint64) uint64 {

--- a/pkg/appolly/discover/watcher_proc_linux_test.go
+++ b/pkg/appolly/discover/watcher_proc_linux_test.go
@@ -4,10 +4,12 @@
 package discover
 
 import (
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -102,4 +104,36 @@ func TestProcessAge(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Less(t, age, expected)
+}
+
+func TestProcessAgeFuncConcurrent(t *testing.T) {
+	processAge := ProcessAgeFunc()
+	pid := app.PID(os.Getpid())
+
+	const goroutines = 8
+	const iterations = 100
+
+	errCh := make(chan error, goroutines)
+	var wg sync.WaitGroup
+
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for range iterations {
+				if age := processAge(pid); age <= 0 {
+					errCh <- fmt.Errorf("expected positive process age for pid %d", pid)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
## Summary
- remove the shared proc stat reader buffer race from the discovery path
- preserve the existing proc stat reading behavior while making concurrent access safe

## Why
The discovery proc stat reader reused shared buffer state across calls in a way that introduced a data race risk under concurrent access. That made the proc stat parsing path depend on unsynchronized shared mutable state.

## Impact
This keeps proc stat reading behavior the same while removing the concurrent buffer-sharing risk, making the discovery path safer under parallel use.
