### PR TITLE
fix(appolly): make export mode enables idempotent

### DIFF
--- a/pkg/appolly/services/export.go
+++ b/pkg/appolly/services/export.go
@@ -99,15 +99,15 @@ func (modes ExportModes) CanExportLogs() bool {
 //  modes.AllowMetrics() // export metrics only
 
 func (modes *ExportModes) AllowTraces() {
-	modes.blockSignal ^= blockTraces
+	modes.blockSignal &^= blockTraces
 }
 
 func (modes *ExportModes) AllowMetrics() {
-	modes.blockSignal ^= blockMetrics
+	modes.blockSignal &^= blockMetrics
 }
 
 func (modes *ExportModes) AllowLogs() {
-	modes.blockSignal ^= blockLogs
+	modes.blockSignal &^= blockLogs
 }
 
 func (modes *ExportModes) UnmarshalYAML(value *yaml.Node) error {
@@ -125,7 +125,7 @@ func (modes *ExportModes) UnmarshalYAML(value *yaml.Node) error {
 			return fmt.Errorf("ExportModes[%d]: unknown export mode %q", i, inner.Value)
 		} else {
 			// a given signal is defined. Remove it from the blocking list
-			modes.blockSignal ^= mode
+			modes.blockSignal &^= mode
 		}
 	}
 	return nil
@@ -147,7 +147,7 @@ func (modes *ExportModes) UnmarshalText(text []byte) error {
 		if mode, ok := modeForText[part]; !ok {
 			return fmt.Errorf("ExportModes: unknown export mode %q", part)
 		} else {
-			modes.blockSignal ^= mode
+			modes.blockSignal &^= mode
 		}
 	}
 	return nil

--- a/pkg/appolly/services/export_test.go
+++ b/pkg/appolly/services/export_test.go
@@ -146,3 +146,58 @@ func TestPragmaticExports(t *testing.T) {
 	assert.True(t, modes.CanExportMetrics(), "should allow exporting metrics after calling AllowMetrics and AllowLogs")
 	assert.True(t, modes.CanExportLogs(), "should allow exporting logs after calling AllowLogs")
 }
+
+func TestPragmaticExportsAreIdempotent(t *testing.T) {
+	t.Run("zero value remains allowed", func(t *testing.T) {
+		var modes ExportModes
+
+		modes.AllowTraces()
+		modes.AllowMetrics()
+		modes.AllowLogs()
+
+		assert.True(t, modes.CanExportTraces(), "should keep traces allowed on zero-value export modes")
+		assert.True(t, modes.CanExportMetrics(), "should keep metrics allowed on zero-value export modes")
+		assert.True(t, modes.CanExportLogs(), "should keep logs allowed on zero-value export modes")
+	})
+
+	t.Run("repeated calls stay allowed", func(t *testing.T) {
+		modes := NewExportModes()
+
+		modes.AllowTraces()
+		modes.AllowTraces()
+		modes.AllowMetrics()
+		modes.AllowMetrics()
+		modes.AllowLogs()
+		modes.AllowLogs()
+
+		assert.True(t, modes.CanExportTraces(), "should keep traces allowed after repeated AllowTraces calls")
+		assert.True(t, modes.CanExportMetrics(), "should keep metrics allowed after repeated AllowMetrics calls")
+		assert.True(t, modes.CanExportLogs(), "should keep logs allowed after repeated AllowLogs calls")
+	})
+}
+
+func TestExportModesUnmarshalDuplicateEntriesRemainAllowed(t *testing.T) {
+	t.Run("yaml duplicates", func(t *testing.T) {
+		var tc struct {
+			Exports ExportModes `yaml:"exports"`
+		}
+
+		err := yaml.Unmarshal([]byte(`exports: ["metrics", "metrics", "traces", "traces", "logs", "logs"]`), &tc)
+		require.NoError(t, err)
+
+		assert.True(t, tc.Exports.CanExportTraces(), "should keep traces allowed with duplicate YAML entries")
+		assert.True(t, tc.Exports.CanExportMetrics(), "should keep metrics allowed with duplicate YAML entries")
+		assert.True(t, tc.Exports.CanExportLogs(), "should keep logs allowed with duplicate YAML entries")
+	})
+
+	t.Run("text duplicates", func(t *testing.T) {
+		var modes ExportModes
+
+		err := modes.UnmarshalText([]byte("metrics, metrics, traces, traces, logs, logs"))
+		require.NoError(t, err)
+
+		assert.True(t, modes.CanExportTraces(), "should keep traces allowed with duplicate text entries")
+		assert.True(t, modes.CanExportMetrics(), "should keep metrics allowed with duplicate text entries")
+		assert.True(t, modes.CanExportLogs(), "should keep logs allowed with duplicate text entries")
+	})
+}


### PR DESCRIPTION
## Summary
- make `AllowTraces`, `AllowMetrics`, and `AllowLogs` clear their block bits instead of toggling them
- keep YAML and text parsing of export modes idempotent even when entries are repeated
- add regression coverage for repeated allow calls and duplicate config entries

## Why
The export mode helpers and parsing paths used XOR to remove blocked signals. That worked for a single occurrence, but a repeated call or duplicate config entry could flip the bit back on and silently disable a signal again.

## Impact
This makes export mode enabling idempotent. Repeated helper calls or duplicate `exports` entries now keep traces, metrics, and logs enabled as intended instead of accidentally turning them back off.

## Validation
- `go test ./pkg/appolly/services`
