### PR TITLE
fix(ci): correct workflow line continuation

### DIFF
--- a/.github/workflows/ghcr_publish_testing_images.yml
+++ b/.github/workflows/ghcr_publish_testing_images.yml
@@ -67,7 +67,7 @@ jobs:
             # tags are in the form rustserver-0.1.0, so we use "tr" to split and later remove any prefix
             LATEST_VERSION=$(echo "${TAGS}" | \
               jq -r '.tags[]' | \
-              tr "-" "\n" | \ 
+              tr "-" "\n" | \
               grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | \
               sort -V | \
               tail -n 1)


### PR DESCRIPTION
## Summary
- fix the shell line continuation in the testing-image publish workflow
- restore correct image tag parsing by removing the stray trailing whitespace after the continuation backslash

## Why
A workflow line in the image-tag parsing pipeline had a trailing space after the shell continuation backslash. That breaks the continuation and causes the downstream tag parsing command chain to be interpreted incorrectly.

## Impact
This restores the intended shell pipeline for image tag parsing in the workflow without changing the surrounding publish logic.
