### PR TITLE
fix(otelcfg): enable traces exporter from override endpoint

### DIFF
--- a/pkg/export/otel/otelcfg/config_traces.go
+++ b/pkg/export/otel/otelcfg/config_traces.go
@@ -103,7 +103,12 @@ func (m TracesConfig) MarshalYAML() (any, error) {
 // either the OTEL endpoint and OTEL traces endpoint is defined.
 // If not enabled, this node won't be instantiated
 func (m *TracesConfig) Enabled() bool {
-	return m.TracesConsumer != nil || m.CommonEndpoint != "" || m.TracesEndpoint != "" || m.GetProtocol() == ProtocolDebug
+	if m.TracesConsumer != nil || m.GetProtocol() == ProtocolDebug {
+		return true
+	}
+
+	ep, _ := m.OTLPTracesEndpoint()
+	return ep != ""
 }
 
 func (m *TracesConfig) GetProtocol() Protocol {

--- a/pkg/export/otel/otelcfg/config_traces.go
+++ b/pkg/export/otel/otelcfg/config_traces.go
@@ -103,7 +103,11 @@ func (m TracesConfig) MarshalYAML() (any, error) {
 // either the OTEL endpoint and OTEL traces endpoint is defined.
 // If not enabled, this node won't be instantiated
 func (m *TracesConfig) Enabled() bool {
-	if m.TracesConsumer != nil || m.GetProtocol() == ProtocolDebug {
+	if m.TracesConsumer != nil {
+		return true
+	}
+
+	if m.TracesProtocol == ProtocolDebug || (m.TracesProtocol == "" && m.Protocol == ProtocolDebug) {
 		return true
 	}
 

--- a/pkg/export/otel/otelcfg/config_traces_test.go
+++ b/pkg/export/otel/otelcfg/config_traces_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/caarlos0/env/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 

--- a/pkg/export/otel/otelcfg/config_traces_test.go
+++ b/pkg/export/otel/otelcfg/config_traces_test.go
@@ -319,11 +319,16 @@ func TestTracesConfig_Enabled(t *testing.T) {
 	tracesConsumer, err := consumer.NewTraces(func(context.Context, ptrace.Traces) error { return nil })
 	require.NoError(t, err)
 
+	providerCalls := 0
 	assert.True(t, (&TracesConfig{CommonEndpoint: "foo"}).Enabled())
 	assert.True(t, (&TracesConfig{TracesEndpoint: "foo"}).Enabled())
 	assert.True(t, (&TracesConfig{
-		OTLPEndpointProvider: func() (string, bool) { return "https://collector:4318", false },
+		OTLPEndpointProvider: func() (string, bool) {
+			providerCalls++
+			return "https://collector:4318", false
+		},
 	}).Enabled())
+	assert.Equal(t, 1, providerCalls)
 	assert.True(t, (&TracesConfig{TracesConsumer: tracesConsumer}).Enabled())
 	assert.True(t, (&TracesConfig{Protocol: ProtocolDebug}).Enabled())
 }

--- a/pkg/export/otel/otelcfg/config_traces_test.go
+++ b/pkg/export/otel/otelcfg/config_traces_test.go
@@ -4,6 +4,7 @@
 package otelcfg
 
 import (
+	"context"
 	"os"
 	"sync"
 	"testing"
@@ -11,6 +12,8 @@ import (
 	"github.com/caarlos0/env/v11"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 )
@@ -312,12 +315,23 @@ func TestTracesSetupHTTP_DoNotOverrideEnv(t *testing.T) {
 }
 
 func TestTracesConfig_Enabled(t *testing.T) {
+	tracesConsumer, err := consumer.NewTraces(func(context.Context, ptrace.Traces) error { return nil })
+	require.NoError(t, err)
+
 	assert.True(t, (&TracesConfig{CommonEndpoint: "foo"}).Enabled())
 	assert.True(t, (&TracesConfig{TracesEndpoint: "foo"}).Enabled())
+	assert.True(t, (&TracesConfig{
+		OTLPEndpointProvider: func() (string, bool) { return "https://collector:4318", false },
+	}).Enabled())
+	assert.True(t, (&TracesConfig{TracesConsumer: tracesConsumer}).Enabled())
+	assert.True(t, (&TracesConfig{Protocol: ProtocolDebug}).Enabled())
 }
 
 func TestTracesConfig_Disabled(t *testing.T) {
 	assert.False(t, (&TracesConfig{}).Enabled())
+	assert.False(t, (&TracesConfig{
+		OTLPEndpointProvider: func() (string, bool) { return "", false },
+	}).Enabled())
 }
 
 func TestNormalizeQueueConfig(t *testing.T) {


### PR DESCRIPTION
## Summary
- make trace exporter enablement honor the computed OTLP traces endpoint override
- add regression coverage for enabled and disabled configurations that use the endpoint provider path

## Why
The traces exporter enablement check only looked at the raw configured endpoint fields. When traces were configured through the OTLP endpoint override path, the computed traces endpoint could be non-empty while `Enabled()` still returned false, preventing the exporter from being instantiated.

## Impact
This restores the expected behavior for OTLP traces endpoint overrides: if the resolved traces endpoint is set, the traces exporter is enabled.

## Validation
- `go test ./pkg/export/otel/otelcfg`
