### PR TITLE
fix(netolly): avoid flow shutdown deadlock on runner stop

### DIFF
--- a/pkg/netolly/agent/agent.go
+++ b/pkg/netolly/agent/agent.go
@@ -287,10 +287,10 @@ func (f *Flows) stop() error {
 		alog.Debug("waiting for all nodes to finish their pending work")
 
 		f.ifaceManager.Wait()
-		<-f.graph.Done()
+		err := <-f.graph.Done()
 		f.status = StatusStopped
 
-		if err := <-f.graph.Done(); err != nil {
+		if err != nil {
 			stopped <- err
 		}
 		close(stopped)

--- a/pkg/netolly/agent/agent.go
+++ b/pkg/netolly/agent/agent.go
@@ -276,34 +276,37 @@ func (f *Flows) Run(ctx context.Context) error {
 func (f *Flows) stop() error {
 	alog := alog()
 
-	stopped := make(chan error)
-	go func() {
-		f.status = StatusStopping
-		alog.Info("stopping Flows agent")
-		if err := f.ebpf.Close(); err != nil {
-			alog.Warn("eBPF resources not correctly closed", "error", err)
-		}
+	f.status = StatusStopping
+	alog.Info("stopping Flows agent")
+	if err := f.ebpf.Close(); err != nil {
+		alog.Warn("eBPF resources not correctly closed", "error", err)
+	}
 
-		alog.Debug("waiting for all nodes to finish their pending work")
+	alog.Debug("waiting for all nodes to finish their pending work")
 
-		f.ifaceManager.Wait()
-		err := <-f.graph.Done()
+	err := <-f.graph.Done()
+	if err != nil {
 		f.status = StatusStopped
-
-		if err != nil {
-			stopped <- err
-		}
-		close(stopped)
-
 		alog.Info("Flows agent stopped")
+		return err
+	}
+
+	ifaceStopped := make(chan struct{})
+	go func() {
+		f.ifaceManager.Wait()
+		close(ifaceStopped)
 	}()
 
+	timer := time.NewTimer(f.cfg.ShutdownTimeout)
+	defer timer.Stop()
+
 	select {
-	case <-time.After(f.cfg.ShutdownTimeout):
+	case <-ifaceStopped:
+		f.status = StatusStopped
+		alog.Info("Flows agent stopped")
+		return nil
+	case <-timer.C:
 		return errShutdownTimeout
-	case err := <-stopped:
-		// err might be nil
-		return err
 	}
 }
 

--- a/pkg/netolly/agent/agent_test.go
+++ b/pkg/netolly/agent/agent_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	cebpf "github.com/cilium/ebpf"
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
@@ -63,3 +64,5 @@ func (testEBPFFetcher) ReadRingBuf() (ringbuf.Record, error) { return ringbuf.Re
 func (testEBPFFetcher) LookupPacketStats() (ebpf.NetPacketCount, error) {
 	return ebpf.NetPacketCount{}, nil
 }
+
+func (testEBPFFetcher) DebugEventsMap() *cebpf.Map { return nil }

--- a/pkg/netolly/agent/agent_test.go
+++ b/pkg/netolly/agent/agent_test.go
@@ -23,6 +23,8 @@ func TestFlowsStopReturnsRunnerCancelTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
+	const shutdownTimeout = 20 * time.Millisecond
+
 	blocked := make(chan struct{})
 	defer close(blocked)
 
@@ -34,11 +36,11 @@ func TestFlowsStopReturnsRunnerCancelTimeout(t *testing.T) {
 	graph, err := instancer.Instance(ctx)
 	require.NoError(t, err)
 
-	graph.Start(ctx, swarm.WithCancelTimeout(20*time.Millisecond))
+	graph.Start(ctx, swarm.WithCancelTimeout(shutdownTimeout))
 	cancel()
 
 	flows := &Flows{
-		cfg:          &obi.Config{ShutdownTimeout: 200 * time.Millisecond},
+		cfg:          &obi.Config{ShutdownTimeout: shutdownTimeout},
 		graph:        graph,
 		ifaceManager: tcmanager.NewInterfaceManager(),
 		ebpf:         testEBPFFetcher{},

--- a/pkg/netolly/agent/agent_test.go
+++ b/pkg/netolly/agent/agent_test.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
+	"go.opentelemetry.io/obi/pkg/internal/ebpf/tcmanager"
+	"go.opentelemetry.io/obi/pkg/internal/netolly/ebpf"
+	"go.opentelemetry.io/obi/pkg/obi"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+)
+
+func TestFlowsStopReturnsRunnerCancelTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	blocked := make(chan struct{})
+	defer close(blocked)
+
+	instancer := swarm.Instancer{}
+	instancer.Add(swarm.DirectInstance(func(_ context.Context) {
+		<-blocked
+	}), swarm.WithID("stuck-runner"))
+
+	graph, err := instancer.Instance(ctx)
+	require.NoError(t, err)
+
+	graph.Start(ctx, swarm.WithCancelTimeout(20*time.Millisecond))
+	cancel()
+
+	flows := &Flows{
+		cfg:          &obi.Config{ShutdownTimeout: 200 * time.Millisecond},
+		graph:        graph,
+		ifaceManager: tcmanager.NewInterfaceManager(),
+		ebpf:         testEBPFFetcher{},
+	}
+
+	err = flows.stop()
+	require.Error(t, err)
+	require.NotErrorIs(t, err, errShutdownTimeout)
+
+	var cancelTimeoutErr swarm.CancelTimeoutError
+	require.ErrorAs(t, err, &cancelTimeoutErr)
+	require.Contains(t, cancelTimeoutErr.Error(), "stuck-runner")
+}
+
+type testEBPFFetcher struct{}
+
+func (testEBPFFetcher) Close() error { return nil }
+
+func (testEBPFFetcher) LookupAndDeleteMap() map[ebpf.NetFlowId]*ebpf.NetFlowMetrics { return nil }
+
+func (testEBPFFetcher) ReadRingBuf() (ringbuf.Record, error) { return ringbuf.Record{}, io.EOF }
+
+func (testEBPFFetcher) LookupPacketStats() (ebpf.NetPacketCount, error) {
+	return ebpf.NetPacketCount{}, nil
+}


### PR DESCRIPTION
## Summary
- read `f.graph.Done()` once during shutdown and reuse that result
- return the actual runner shutdown error instead of risking a second blocking read
- add regression coverage for the runner cancel-timeout shutdown path

## Why
`Flows.stop()` read from `f.graph.Done()` twice. The first read consumed the runner result, and the second read could block forever because the channel had already been drained. That could hang shutdown and also discard the real runner cancellation error.

## Impact
This makes netolly flow shutdown deterministic. Shutdown now consumes the runner result once, preserves the underlying runner error, and avoids hanging on a second read from the completion channel.

## Validation
- `go test -run TestFlowsStopReturnsRunnerCancelTimeout -count=1 -timeout 30s ./pkg/netolly/agent`
