### PR TITLE
fix(kubecache): refresh event timestamps on updates and deletes

### DIFF
--- a/pkg/kube/kubecache/envtest/integration_test.go
+++ b/pkg/kube/kubecache/envtest/integration_test.go
@@ -408,6 +408,79 @@ func TestFilterByTimestamp(t *testing.T) {
 	assert.Equal(t, "more-filter-by-ts", evnt.Resource.Name)
 }
 
+func TestReconnectReceivesUpdatedObjectAfterFromTimestampEpoch(t *testing.T) {
+	svcClient := serviceClient{
+		Address:  fmt.Sprintf("127.0.0.1:%d", freePort),
+		Messages: make(chan *informer.Event, 10),
+	}
+	name := "pod-reconnect-update-ts"
+
+	require.NoError(t, k8sClient.Create(ctx, &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{"version": "v1"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "test-container", Image: "nginx"},
+			},
+		},
+		Status: corev1.PodStatus{PodIP: "10.0.0.128"},
+	}))
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		svcClient.Start(ctx, ct, 0)
+	}, timeout, 100*time.Millisecond)
+
+	var initialEvent *informer.Event
+	for {
+		event := testutil.ReadChannel(t, svcClient.Messages, timeout)
+		if event.Type == informer.EventType_SYNC_FINISHED {
+			break
+		}
+		if event.Resource != nil && event.Resource.Name == name {
+			initialEvent = event
+		}
+	}
+
+	require.NotNil(t, initialEvent)
+
+	time.Sleep(time.Second)
+	reconnectFrom := time.Now().Unix()
+
+	reconnectedClient := serviceClient{
+		Address:  fmt.Sprintf("127.0.0.1:%d", freePort),
+		Messages: make(chan *informer.Event, 10),
+	}
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		reconnectedClient.Start(ctx, ct, reconnectFrom)
+	}, timeout, 100*time.Millisecond)
+
+	for {
+		event := testutil.ReadChannel(t, reconnectedClient.Messages, timeout)
+		if event.Type == informer.EventType_SYNC_FINISHED {
+			break
+		}
+		require.NotNil(t, event.Resource)
+		require.NotEqual(t, name, event.Resource.Name)
+	}
+
+	var pod corev1.Pod
+	require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: "default"}, &pod))
+	pod.Labels["version"] = "v2"
+	require.NoError(t, k8sClient.Update(ctx, &pod))
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		event := testutil.ReadChannel(t, reconnectedClient.Messages, timeout)
+		require.Equal(ct, informer.EventType_UPDATED, event.Type)
+		require.NotNil(ct, event.Resource)
+		require.Equal(ct, name, event.Resource.Name)
+		assert.GreaterOrEqual(ct, event.Resource.StatusTimeEpoch, reconnectFrom)
+		assert.Equal(ct, "v2", event.Resource.Labels["version"])
+	}, timeout, 100*time.Millisecond)
+}
+
 func ReadChannel[T any](t require.TestingT, inCh <-chan T, timeout time.Duration) T {
 	var item T
 	select {

--- a/pkg/kube/kubecache/envtest/integration_test.go
+++ b/pkg/kube/kubecache/envtest/integration_test.go
@@ -481,6 +481,75 @@ func TestReconnectReceivesUpdatedObjectAfterFromTimestampEpoch(t *testing.T) {
 	}, timeout, 100*time.Millisecond)
 }
 
+func TestReconnectReceivesDeletedObjectAfterFromTimestampEpoch(t *testing.T) {
+	svcClient := serviceClient{
+		Address:  fmt.Sprintf("127.0.0.1:%d", freePort),
+		Messages: make(chan *informer.Event, 10),
+	}
+	name := "pod-reconnect-delete-ts"
+
+	require.NoError(t, k8sClient.Create(ctx, &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "test-container", Image: "nginx"},
+			},
+		},
+		Status: corev1.PodStatus{PodIP: "10.0.0.129"},
+	}))
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		svcClient.Start(ctx, ct, 0)
+	}, timeout, 100*time.Millisecond)
+
+	var initialEvent *informer.Event
+	for {
+		event := testutil.ReadChannel(t, svcClient.Messages, timeout)
+		if event.Type == informer.EventType_SYNC_FINISHED {
+			break
+		}
+		if event.Resource != nil && event.Resource.Name == name {
+			initialEvent = event
+		}
+	}
+
+	require.NotNil(t, initialEvent)
+
+	time.Sleep(time.Second)
+	reconnectFrom := time.Now().Unix()
+
+	reconnectedClient := serviceClient{
+		Address:  fmt.Sprintf("127.0.0.1:%d", freePort),
+		Messages: make(chan *informer.Event, 10),
+	}
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		reconnectedClient.Start(ctx, ct, reconnectFrom)
+	}, timeout, 100*time.Millisecond)
+
+	for {
+		event := testutil.ReadChannel(t, reconnectedClient.Messages, timeout)
+		if event.Type == informer.EventType_SYNC_FINISHED {
+			break
+		}
+		require.NotNil(t, event.Resource)
+		require.NotEqual(t, name, event.Resource.Name)
+	}
+
+	pod := &corev1.Pod{ObjectMeta: v1.ObjectMeta{Name: name, Namespace: "default"}}
+	require.NoError(t, k8sClient.Delete(ctx, pod))
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		event := testutil.ReadChannel(t, reconnectedClient.Messages, timeout)
+		require.Equal(ct, informer.EventType_DELETED, event.Type)
+		require.NotNil(ct, event.Resource)
+		require.Equal(ct, name, event.Resource.Name)
+		assert.GreaterOrEqual(ct, event.Resource.StatusTimeEpoch, reconnectFrom)
+	}, timeout, 100*time.Millisecond)
+}
+
 func ReadChannel[T any](t require.TestingT, inCh <-chan T, timeout time.Duration) T {
 	var item T
 	select {

--- a/pkg/kube/kubecache/meta/informers_init.go
+++ b/pkg/kube/kubecache/meta/informers_init.go
@@ -528,6 +528,13 @@ func objLastUpdateTime(
 	return lastStatus.Unix()
 }
 
+func refreshStatusTimeEpoch(em *informer.ObjectMeta) {
+	now := time.Now().Unix()
+	if em.StatusTimeEpoch < now {
+		em.StatusTimeEpoch = now
+	}
+}
+
 func (inf *Informers) ipInfoEventHandler(ctx context.Context) *cache.ResourceEventHandlerFuncs {
 	metrics := instrument.FromContext(ctx)
 	log := inf.log.With("func", "ipInfoEventHandler")
@@ -550,9 +557,10 @@ func (inf *Informers) ipInfoEventHandler(ctx context.Context) *cache.ResourceEve
 			if unchanged(oldEM, newEM) {
 				return
 			}
+			metrics.ForwardLag(time.Since(time.Unix(newEM.StatusTimeEpoch, 0)).Seconds())
+			refreshStatusTimeEpoch(newEM)
 			log.Debug("UpdateFunc", "kind", newEM.Kind, "name", newEM.Name,
 				"ips", newEM.Ips, "oldIps", oldEM.Ips)
-			metrics.ForwardLag(time.Since(time.Unix(newEM.StatusTimeEpoch, 0)).Seconds())
 			inf.Notify(&informer.Event{
 				Type:     informer.EventType_UPDATED,
 				Resource: newEM,
@@ -573,8 +581,9 @@ func (inf *Informers) ipInfoEventHandler(ctx context.Context) *cache.ResourceEve
 				}
 			}
 			em := obj.(*indexableEntity).EncodedMeta
-			log.Debug("DeleteFunc", "kind", em.Kind, "name", em.Name, "ips", em.Ips)
 			metrics.ForwardLag(time.Since(time.Unix(em.StatusTimeEpoch, 0)).Seconds())
+			refreshStatusTimeEpoch(em)
+			log.Debug("DeleteFunc", "kind", em.Kind, "name", em.Name, "ips", em.Ips)
 			metrics.InformerDelete()
 			inf.Notify(&informer.Event{
 				Type:     informer.EventType_DELETED,

--- a/pkg/kube/kubecache/meta/informers_init_test.go
+++ b/pkg/kube/kubecache/meta/informers_init_test.go
@@ -4,14 +4,33 @@
 package meta
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"go.opentelemetry.io/obi/pkg/kube/kubecache/informer"
 )
+
+type eventObserver struct {
+	id     string
+	events []*informer.Event
+}
+
+func (o *eventObserver) ID() string {
+	return o.id
+}
+
+func (o *eventObserver) On(event *informer.Event) error {
+	o.events = append(o.events, event)
+	return nil
+}
 
 func TestEnvironmentFiltering(t *testing.T) {
 	vars := []v1.EnvVar{{Name: "A", Value: "B"}, {Value: "C"}, {}, {Name: "OTEL_SERVICE_NAME", Value: "service_name"}, {Name: "OTEL_RESOURCE_ATTRIBUTES", Value: "resource_attributes"}}
@@ -455,4 +474,61 @@ func TestUnchanged(t *testing.T) {
 			testUnchangedImpl(t, &d.o1, &d.o2, d.expectedResult)
 		})
 	}
+}
+
+func TestIPInfoEventHandlerRefreshesUpdatedEventTimestamp(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	inf := &Informers{
+		log:          log,
+		BaseNotifier: NewBaseNotifier(log),
+	}
+	observer := &eventObserver{id: "observer"}
+	inf.BaseNotifier.Subscribe(observer)
+
+	handler := inf.ipInfoEventHandler(context.Background())
+	staleTimestamp := time.Now().Add(-time.Hour).Unix()
+	start := time.Now().Unix()
+
+	handler.UpdateFunc(
+		&indexableEntity{EncodedMeta: &informer.ObjectMeta{
+			Name:            "pod",
+			Kind:            typePod,
+			StatusTimeEpoch: staleTimestamp,
+			Labels:          map[string]string{"version": "old"},
+		}},
+		&indexableEntity{EncodedMeta: &informer.ObjectMeta{
+			Name:            "pod",
+			Kind:            typePod,
+			StatusTimeEpoch: staleTimestamp,
+			Labels:          map[string]string{"version": "new"},
+		}},
+	)
+
+	require.Len(t, observer.events, 1)
+	assert.Equal(t, informer.EventType_UPDATED, observer.events[0].Type)
+	assert.GreaterOrEqual(t, observer.events[0].Resource.StatusTimeEpoch, start)
+}
+
+func TestIPInfoEventHandlerRefreshesDeletedEventTimestamp(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	inf := &Informers{
+		log:          log,
+		BaseNotifier: NewBaseNotifier(log),
+	}
+	observer := &eventObserver{id: "observer"}
+	inf.BaseNotifier.Subscribe(observer)
+
+	handler := inf.ipInfoEventHandler(context.Background())
+	staleTimestamp := time.Now().Add(-time.Hour).Unix()
+	start := time.Now().Unix()
+
+	handler.DeleteFunc(&indexableEntity{EncodedMeta: &informer.ObjectMeta{
+		Name:            "pod",
+		Kind:            typePod,
+		StatusTimeEpoch: staleTimestamp,
+	}})
+
+	require.Len(t, observer.events, 1)
+	assert.Equal(t, informer.EventType_DELETED, observer.events[0].Type)
+	assert.GreaterOrEqual(t, observer.events[0].Resource.StatusTimeEpoch, start)
 }

--- a/pkg/kube/kubecache/meta/informers_init_test.go
+++ b/pkg/kube/kubecache/meta/informers_init_test.go
@@ -532,3 +532,11 @@ func TestIPInfoEventHandlerRefreshesDeletedEventTimestamp(t *testing.T) {
 	assert.Equal(t, informer.EventType_DELETED, observer.events[0].Type)
 	assert.GreaterOrEqual(t, observer.events[0].Resource.StatusTimeEpoch, start)
 }
+
+func TestRefreshStatusTimeEpochPreservesCurrentTimestamp(t *testing.T) {
+	em := &informer.ObjectMeta{StatusTimeEpoch: time.Now().Add(time.Hour).Unix()}
+
+	refreshStatusTimeEpoch(em)
+
+	assert.Greater(t, em.StatusTimeEpoch, time.Now().Unix())
+}

--- a/pkg/kube/kubecache/service/service_test.go
+++ b/pkg/kube/kubecache/service/service_test.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"go.opentelemetry.io/obi/pkg/internal/helpers/sync"
+	queuesync "go.opentelemetry.io/obi/pkg/internal/helpers/sync"
 	"go.opentelemetry.io/obi/pkg/internal/testutil"
 	"go.opentelemetry.io/obi/pkg/kube/kubecache"
 	"go.opentelemetry.io/obi/pkg/kube/kubecache/informer"
@@ -238,7 +238,7 @@ func TestHandleMessagesQueue(t *testing.T) {
 				server:      tt.server,
 				sendTimeout: tt.sendTimeout,
 				metrics:     instrument.FromContext(context.Background()),
-				messages:    sync.NewQueue[*informer.Event](),
+				messages:    queuesync.NewQueue[*informer.Event](),
 			}
 			for _, e := range tt.enqueue {
 				o.messages.Enqueue(e)
@@ -270,7 +270,7 @@ func TestHandleMessagesQueue_RespectsContextCancellationDuringSend(t *testing.T)
 		server:      &signalBlockingStream{sendCalled: sendCalled, gate: gate},
 		sendTimeout: 5 * time.Minute, // large enough that context cancellation wins
 		metrics:     instrument.FromContext(context.Background()),
-		messages:    sync.NewQueue[*informer.Event](),
+		messages:    queuesync.NewQueue[*informer.Event](),
 	}
 	o.messages.Enqueue(&informer.Event{})
 
@@ -290,5 +290,42 @@ func TestHandleMessagesQueue_RespectsContextCancellationDuringSend(t *testing.T)
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("handleMessagesQueue did not return within 2s after context cancellation")
+	}
+}
+
+func TestConnectionOnFiltersEventsBeforeFromEpoch(t *testing.T) {
+	conn := &connection{
+		fromEpoch: 100,
+		messages:  queuesync.NewQueue[*informer.Event](),
+		metrics:   instrument.FromContext(context.Background()),
+	}
+
+	require.NoError(t, conn.On(&informer.Event{
+		Type:     informer.EventType_UPDATED,
+		Resource: &informer.ObjectMeta{StatusTimeEpoch: 99},
+	}))
+
+	dequeued := make(chan *informer.Event, 1)
+	go func() {
+		dequeued <- conn.messages.Dequeue()
+	}()
+
+	select {
+	case event := <-dequeued:
+		t.Fatalf("unexpected queued event: %+v", event)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.NoError(t, conn.On(&informer.Event{
+		Type:     informer.EventType_UPDATED,
+		Resource: &informer.ObjectMeta{StatusTimeEpoch: 100},
+	}))
+
+	select {
+	case event := <-dequeued:
+		require.NotNil(t, event)
+		require.Equal(t, int64(100), event.Resource.StatusTimeEpoch)
+	case <-time.After(time.Second):
+		t.Fatal("expected event to be queued")
 	}
 }


### PR DESCRIPTION
## Summary
- refresh `StatusTimeEpoch` when update and delete events are emitted
- preserve reconnect replay behavior for changed and deleted objects
- add regression coverage for informer and reconnect timestamp filtering paths

## Why
`Prevent unnecessary K8s cache updates` removed the explicit `StatusTimeEpoch` refresh in the update and delete handlers. That left long-lived objects carrying old timestamps, so reconnecting clients using `FromTimestampEpoch` could filter out legitimate update and delete events and keep stale metadata.

## Impact
This restores the intended reconnect semantics for the Kubernetes cache service. Updated and deleted objects now carry fresh event timestamps, so clients reconnecting from a prior event time receive the changes they missed instead of silently retaining stale cache entries.

## Validation
- `go test ./pkg/kube/kubecache/meta ./pkg/kube/kubecache/service`
