### PR TITLE
bpf/gotracer: define named constants for known Go struct offsets

### DIFF
--- a/bpf/gotracer/go_offsets.h
+++ b/bpf/gotracer/go_offsets.h
@@ -7,12 +7,6 @@
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/bpf_core_read.h>
 
-#define GO_INTERFACE_DATA_OFFSET 8
-#define GO_SLICE_ARRAY_OFFSET 0
-#define GO_SLICE_LEN_OFFSET 8
-#define GO_SLICE_CAP_OFFSET 16
-#define GO_STRING_LEN_OFFSET 8
-
 #define MAX_GO_PROGRAMS 10000 // Max 10,000 go programs tracked
 
 // To be Injected from the user space during the eBPF program load & initialization
@@ -121,6 +115,11 @@ typedef enum {
 enum {
     _gin_fullpath_off_pre_17 = 56,
     _gin_fullpath_off_post_17 = 40,
+};
+
+// Fixed offsets defined by the Go runtime type layout.
+enum {
+    GO_STRING_LEN_OFFSET = 8,
 };
 
 typedef struct go_offset_t {

--- a/bpf/gotracer/go_offsets.h
+++ b/bpf/gotracer/go_offsets.h
@@ -118,7 +118,7 @@ enum {
 };
 
 // Fixed offsets defined by the Go runtime type layout.
-enum {
+enum : u32 {
     k_go_string_len_offset = 8,
 };
 

--- a/bpf/gotracer/go_offsets.h
+++ b/bpf/gotracer/go_offsets.h
@@ -119,7 +119,7 @@ enum {
 
 // Fixed offsets defined by the Go runtime type layout.
 enum {
-    GO_STRING_LEN_OFFSET = 8,
+    k_go_string_len_offset = 8,
 };
 
 typedef struct go_offset_t {

--- a/bpf/gotracer/go_offsets.h
+++ b/bpf/gotracer/go_offsets.h
@@ -7,6 +7,12 @@
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/bpf_core_read.h>
 
+#define GO_INTERFACE_DATA_OFFSET 8
+#define GO_SLICE_ARRAY_OFFSET 0
+#define GO_SLICE_LEN_OFFSET 8
+#define GO_SLICE_CAP_OFFSET 16
+#define GO_STRING_LEN_OFFSET 8
+
 #define MAX_GO_PROGRAMS 10000 // Max 10,000 go programs tracked
 
 // To be Injected from the user space during the eBPF program load & initialization

--- a/bpf/gotracer/go_str.h
+++ b/bpf/gotracer/go_str.h
@@ -20,6 +20,8 @@
 
 #include <common/algorithm.h>
 
+#include <gotracer/go_offsets.h>
+
 #include <logger/bpf_dbg.h>
 
 static __always_inline int
@@ -47,7 +49,7 @@ read_go_str(char *name, void *base_ptr, u8 offset, void *field, u64 max_size) {
     }
 
     u64 len = 0;
-    if (bpf_probe_read(&len, sizeof(len), (void *)(base_ptr + (offset + 8))) != 0) {
+    if (bpf_probe_read(&len, sizeof(len), (void *)(base_ptr + (offset + GO_STRING_LEN_OFFSET))) != 0) {
         bpf_dbg_printk("can't read len for %s", name);
         return 0;
     }
@@ -68,7 +70,7 @@ read_go_str(char *name, void *base_ptr, u8 offset, void *field, u64 max_size) {
 
 static __always_inline u64 peek_go_str_len(const char *name, const void *base_ptr, u8 offset) {
     u64 len = 0;
-    if (bpf_probe_read(&len, sizeof(len), (const void *)(base_ptr + (offset + 8))) != 0) {
+    if (bpf_probe_read(&len, sizeof(len), (const void *)(base_ptr + (offset + GO_STRING_LEN_OFFSET))) != 0) {
         bpf_dbg_printk("can't read len for %s", name);
         return 0;
     }

--- a/bpf/gotracer/go_str.h
+++ b/bpf/gotracer/go_str.h
@@ -72,7 +72,7 @@ read_go_str(char *name, void *base_ptr, u8 offset, void *field, u64 max_size) {
 static __always_inline u64 peek_go_str_len(const char *name, const void *base_ptr, u8 offset) {
     u64 len = 0;
     if (bpf_probe_read(
-            &len, sizeof(len), (const void *)(base_ptr + (offset + GO_STRING_LEN_OFFSET))) != 0) {
+            &len, sizeof(len), (const void *)(base_ptr + (offset + k_go_string_len_offset))) != 0) {
         bpf_dbg_printk("can't read len for %s", name);
         return 0;
     }

--- a/bpf/gotracer/go_str.h
+++ b/bpf/gotracer/go_str.h
@@ -49,7 +49,7 @@ read_go_str(char *name, void *base_ptr, u8 offset, void *field, u64 max_size) {
     }
 
     u64 len = 0;
-    if (bpf_probe_read(&len, sizeof(len), (void *)(base_ptr + (offset + GO_STRING_LEN_OFFSET))) !=
+    if (bpf_probe_read(&len, sizeof(len), (void *)(base_ptr + (offset + k_go_string_len_offset))) !=
         0) {
         bpf_dbg_printk("can't read len for %s", name);
         return 0;

--- a/bpf/gotracer/go_str.h
+++ b/bpf/gotracer/go_str.h
@@ -49,7 +49,8 @@ read_go_str(char *name, void *base_ptr, u8 offset, void *field, u64 max_size) {
     }
 
     u64 len = 0;
-    if (bpf_probe_read(&len, sizeof(len), (void *)(base_ptr + (offset + GO_STRING_LEN_OFFSET))) != 0) {
+    if (bpf_probe_read(&len, sizeof(len), (void *)(base_ptr + (offset + GO_STRING_LEN_OFFSET))) !=
+        0) {
         bpf_dbg_printk("can't read len for %s", name);
         return 0;
     }
@@ -70,7 +71,8 @@ read_go_str(char *name, void *base_ptr, u8 offset, void *field, u64 max_size) {
 
 static __always_inline u64 peek_go_str_len(const char *name, const void *base_ptr, u8 offset) {
     u64 len = 0;
-    if (bpf_probe_read(&len, sizeof(len), (const void *)(base_ptr + (offset + GO_STRING_LEN_OFFSET))) != 0) {
+    if (bpf_probe_read(
+            &len, sizeof(len), (const void *)(base_ptr + (offset + GO_STRING_LEN_OFFSET))) != 0) {
         bpf_dbg_printk("can't read len for %s", name);
         return 0;
     }


### PR DESCRIPTION
## Summary

Replace hardcoded offset `8` in `go_str.h` with named constants declared in `go_offsets.h`.

In Go, strings, slices, and interfaces have fixed in-memory layouts defined by the Go runtime spec. Previously, reading the string length field used a bare `8` literal, which could be confused with a dynamic offset that should be looked up from `go_offsets_map`. This change makes the intent explicit.

Partly addresses #1994 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
