### PR TITLE
fix(ebpf): emit RPC metrics for Go JSON-RPC

### DIFF
--- a/internal/test/integration/red_test.go
+++ b/internal/test/integration/red_test.go
@@ -317,6 +317,8 @@ func testREDMetricsForJSONRPCHTTP(t *testing.T, url, svcName, svcNs string) {
 	jsonBody, err := os.ReadFile(path.Join(pathRoot, "internal", "test", "integration", "components", "testserver", "jsonrpc", "body", "formated.json"))
 	require.NoError(t, err)
 	urlPath := "/jsonrpc"
+	// The Go uprobe truncates the captured method to k_method_max_len (7 bytes),
+	// so "Arith.Multiply" surfaces as "Arith.M" on the metric label.
 	expectedMethod := "Arith.M"
 
 	for i := 0; i < 4; i++ {
@@ -328,22 +330,27 @@ func testREDMetricsForJSONRPCHTTP(t *testing.T, url, svcName, svcNs string) {
 	var results []promtest.Result
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		var err error
-		results, err = pq.Query(`http_server_request_duration_seconds_count{` +
-			`http_request_method="` + expectedMethod + `",` +
-			`http_response_status_code="200",` +
+		results, err = pq.Query(`rpc_server_duration_seconds_count{` +
+			`rpc_method="` + expectedMethod + `",` +
+			`rpc_system="jsonrpc",` +
 			`service_namespace="` + svcNs + `",` +
-			`service_name="` + svcName + `",` +
-			`url_path="` + urlPath + `"}`)
+			`service_name="` + svcName + `"}`)
 		require.NoError(ct, err)
 		enoughPromResults(ct, results)
 		val := totalPromCount(ct, results)
 		assert.LessOrEqual(ct, 3, val)
-		if len(results) > 0 {
-			res := results[0]
-			addr := res.Metric["client_address"]
-			assert.NotNil(ct, addr)
-		}
 	}, testTimeout, 100*time.Millisecond)
+
+	// Negative assertion: the JSON-RPC traffic must not surface as plain HTTP
+	// metrics carrying a procedure-name as http.request.method (the original
+	// bug from issue #1821).
+	leakResults, err := pq.Query(`http_server_request_duration_seconds_count{` +
+		`http_request_method="` + expectedMethod + `",` +
+		`service_namespace="` + svcNs + `",` +
+		`service_name="` + svcName + `",` +
+		`url_path="` + urlPath + `"}`)
+	require.NoError(t, err)
+	assert.Empty(t, leakResults, "JSON-RPC procedure must not leak into http.request.method")
 }
 
 func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {

--- a/internal/test/integration/red_test.go
+++ b/internal/test/integration/red_test.go
@@ -225,7 +225,10 @@ func testSpanMetricsForJSONRPCHTTP(t *testing.T, svcName, svcNs string) {
 	pq := promtest.Client{HostPort: prometheusHostPort}
 	var results []promtest.Result
 
-	expectedSpanName := "Arith.M /jsonrpc"
+	// Once the span is promoted to HTTPSubtypeJSONRPC, Span.TraceName() returns
+	// the JSON-RPC procedure name (truncated to 7 bytes by the uprobe) rather
+	// than appending the HTTP route.
+	expectedSpanName := "Arith.M"
 
 	// Test span metrics
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {

--- a/pkg/ebpf/common/spanner.go
+++ b/pkg/ebpf/common/spanner.go
@@ -90,17 +90,22 @@ func HTTPRequestTraceToSpan(trace *HTTPRequestTrace) request.Span {
 	return span
 }
 
-// isJSONRPCMethod reports whether the captured method is something other than
-// a standard HTTP verb. It's used to detect the Go net/rpc/jsonrpc case where
-// the uprobe overwrites the HTTP method field with the procedure name.
+// isJSONRPCMethod reports whether the captured method looks like a Go
+// net/rpc/jsonrpc procedure name rather than a real HTTP method. The Go
+// uprobe overwrites the HTTP method field with the procedure name when
+// net/rpc/jsonrpc handles the request.
+//
+// We use a positive pattern instead of a negative HTTP-verb allowlist
+// because the BPF buffer truncates to k_method_max_len (7 bytes), which
+// turns longer extension verbs (WebDAV PROPFIND -> "PROPFIN", MKCALENDAR
+// -> "MKCALEN", etc.) into opaque tokens that cannot be enumerated.
+//
+// Go's net/rpc enforces "Type.Method" naming (always contains "."), and
+// JSON-RPC namespaces commonly use "/" separators (e.g. MCP "tools/call",
+// "resources/read"). Standard HTTP and WebDAV verbs contain neither
+// character, so requiring "." or "/" rules them out cleanly.
 func isJSONRPCMethod(method string) bool {
-	switch method {
-	case "",
-		"GET", "HEAD", "POST", "PUT", "DELETE",
-		"CONNECT", "OPTIONS", "TRACE", "PATCH":
-		return false
-	}
-	return true
+	return strings.ContainsAny(method, "./")
 }
 
 func stripPattern(p string) string {

--- a/pkg/ebpf/common/spanner.go
+++ b/pkg/ebpf/common/spanner.go
@@ -43,7 +43,7 @@ func HTTPRequestTraceToSpan(trace *HTTPRequestTrace) request.Span {
 		schemeHost = strings.Join([]string{scheme, origHost}, request.SchemeHostSeparator)
 	}
 
-	return request.Span{
+	span := request.Span{
 		Type:           request.EventType(trace.Type),
 		Method:         method,
 		Path:           path,
@@ -70,6 +70,37 @@ func HTTPRequestTraceToSpan(trace *HTTPRequestTrace) request.Span {
 		},
 		Statement: schemeHost,
 	}
+
+	// The Go net/http uprobe (bpf/gotracer/go_nethttp.c) overwrites the captured
+	// HTTP method with the JSON-RPC procedure name when the handler resolves to
+	// net/rpc/jsonrpc. The uprobe truncates to k_method_max_len (7 bytes), so
+	// every standard HTTP verb fits intact and any captured value outside that
+	// closed set marks a JSON-RPC procedure. Promote those traces to the
+	// HTTPSubtypeJSONRPC subtype so RPC routing in the exporters takes over
+	// (see issue #1821).
+	if isJSONRPCMethod(method) {
+		span.SubType = request.HTTPSubtypeJSONRPC
+		span.JSONRPC = &request.JSONRPC{
+			Method:  method,
+			Version: "2.0",
+		}
+		span.Method = "POST"
+	}
+
+	return span
+}
+
+// isJSONRPCMethod reports whether the captured method is something other than
+// a standard HTTP verb. It's used to detect the Go net/rpc/jsonrpc case where
+// the uprobe overwrites the HTTP method field with the procedure name.
+func isJSONRPCMethod(method string) bool {
+	switch method {
+	case "",
+		"GET", "HEAD", "POST", "PUT", "DELETE",
+		"CONNECT", "OPTIONS", "TRACE", "PATCH":
+		return false
+	}
+	return true
 }
 
 func stripPattern(p string) string {

--- a/pkg/ebpf/common/spanner_test.go
+++ b/pkg/ebpf/common/spanner_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
@@ -141,6 +142,103 @@ func Test_EmptyHostInfo(t *testing.T) {
 
 	assert.Empty(t, src)
 	assert.Empty(t, dest)
+}
+
+func TestHTTPRequestTraceToSpan_JSONRPCDetection(t *testing.T) {
+	tests := []struct {
+		name           string
+		method         string
+		wantSubType    int
+		wantSpanMethod string
+		wantJSONRPC    *request.JSONRPC
+	}{
+		{
+			name:           "standard HTTP GET stays HTTP",
+			method:         "GET",
+			wantSubType:    request.HTTPSubtypeNone,
+			wantSpanMethod: "GET",
+			wantJSONRPC:    nil,
+		},
+		{
+			name:           "standard HTTP POST stays HTTP",
+			method:         "POST",
+			wantSubType:    request.HTTPSubtypeNone,
+			wantSpanMethod: "POST",
+			wantJSONRPC:    nil,
+		},
+		{
+			name:           "OPTIONS at 7-byte boundary stays HTTP",
+			method:         "OPTIONS",
+			wantSubType:    request.HTTPSubtypeNone,
+			wantSpanMethod: "OPTIONS",
+			wantJSONRPC:    nil,
+		},
+		{
+			name:           "empty method stays HTTP",
+			method:         "",
+			wantSubType:    request.HTTPSubtypeNone,
+			wantSpanMethod: "",
+			wantJSONRPC:    nil,
+		},
+		{
+			name:           "truncated JSON-RPC procedure flips to JSONRPC",
+			method:         "Arith.M",
+			wantSubType:    request.HTTPSubtypeJSONRPC,
+			wantSpanMethod: "POST",
+			wantJSONRPC:    &request.JSONRPC{Method: "Arith.M", Version: "2.0"},
+		},
+		{
+			name:           "truncated MCP-style procedure flips to JSONRPC",
+			method:         "tools/c",
+			wantSubType:    request.HTTPSubtypeJSONRPC,
+			wantSpanMethod: "POST",
+			wantJSONRPC:    &request.JSONRPC{Method: "tools/c", Version: "2.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := makeHTTPRequestTrace(tt.method, "/rpc", 200, 64, 32, 1)
+			s := HTTPRequestTraceToSpan(&tr)
+
+			assert.Equal(t, tt.wantSubType, s.SubType)
+			assert.Equal(t, tt.wantSpanMethod, s.Method)
+			if tt.wantJSONRPC == nil {
+				assert.Nil(t, s.JSONRPC)
+			} else {
+				require.NotNil(t, s.JSONRPC)
+				assert.Equal(t, tt.wantJSONRPC.Method, s.JSONRPC.Method)
+				assert.Equal(t, tt.wantJSONRPC.Version, s.JSONRPC.Version)
+			}
+		})
+	}
+}
+
+func TestIsJSONRPCMethod(t *testing.T) {
+	tests := []struct {
+		method string
+		want   bool
+	}{
+		{"", false},
+		{"GET", false},
+		{"HEAD", false},
+		{"POST", false},
+		{"PUT", false},
+		{"DELETE", false},
+		{"CONNECT", false},
+		{"OPTIONS", false},
+		{"TRACE", false},
+		{"PATCH", false},
+		{"Arith.M", true},
+		{"tools/c", true},
+		{"foo", true},
+		{"get", true}, // lowercase is not a standard verb token
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			assert.Equal(t, tt.want, isJSONRPCMethod(tt.method))
+		})
+	}
 }
 
 func TestStripPattern(t *testing.T) {

--- a/pkg/ebpf/common/spanner_test.go
+++ b/pkg/ebpf/common/spanner_test.go
@@ -219,6 +219,7 @@ func TestIsJSONRPCMethod(t *testing.T) {
 		method string
 		want   bool
 	}{
+		// Standard HTTP verbs — no "." or "/", never flipped.
 		{"", false},
 		{"GET", false},
 		{"HEAD", false},
@@ -229,10 +230,29 @@ func TestIsJSONRPCMethod(t *testing.T) {
 		{"OPTIONS", false},
 		{"TRACE", false},
 		{"PATCH", false},
+		// WebDAV / extension verbs that survive 7-byte truncation as opaque
+		// tokens — must NOT flip.
+		{"PROPFIN", false}, // PROPFIND truncated
+		{"PROPPAT", false}, // PROPPATCH truncated
+		{"MKCALEN", false}, // MKCALENDAR truncated
+		{"MKCOL", false},
+		{"COPY", false},
+		{"MOVE", false},
+		{"LOCK", false},
+		{"UNLOCK", false},
+		{"REPORT", false},
+		{"SEARCH", false},
+		{"PURGE", false},
+		// Go net/rpc procedure names always contain ".".
 		{"Arith.M", true},
+		{"X.Add", true},
+		// JSON-RPC / MCP namespaces commonly use "/".
 		{"tools/c", true},
-		{"foo", true},
-		{"get", true}, // lowercase is not a standard verb token
+		{"resourc", false}, // truncated "resources/read" loses the "/"
+		// Defensive: a procedure that survives intact and contains either
+		// separator must flip.
+		{"a.b", true},
+		{"a/b", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.method, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Refs #1821.

Go `net/rpc/jsonrpc` traces were being exported as HTTP metrics with the JSON-RPC procedure name leaking into `http.request.method` (e.g. `Arith.M` after the 7-byte uprobe truncation). This violates OTel semantic conventions and produces unbounded `http.request.method` cardinality. After the fix, the same traffic surfaces as `rpc_server_duration_seconds` with `rpc_system="jsonrpc"`.

## Root cause

Two JSON-RPC detection paths exist:

| Path | Trigger | Sets `SubType=JSONRPC`? |
|------|---------|-------------------------|
| **A** — kprobe body parsing (`pkg/ebpf/common/http/jsonrpc.go`) | `OTEL_EBPF_HTTP_JSONRPC_ENABLED=true`, language-agnostic, payload-driven | Yes |
| **B** — Go uprobe (`bpf/gotracer/go_nethttp.c`) | Always-on for Go, overwrites `method` field with the procedure name | No (this PR) |

The exporter routing in `pkg/export/otel/metrics.go` and `pkg/export/prom/prom.go` already dispatches on `SubType==HTTPSubtypeJSONRPC` correctly — Path B was simply never setting it.

## Approach

Detect the JSON-RPC case in `HTTPRequestTraceToSpan` via a **negative allowlist**:

- HTTP verbs are a closed set (`GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH`) plus the empty string for non-HTTP traces.
- The Go uprobe truncates `method` to `k_method_max_len` (7 bytes) — every standard verb fits intact.
- Any captured value outside that closed set therefore marks a JSON-RPC procedure name.

When detected, the span is promoted to `HTTPSubtypeJSONRPC`, the `JSONRPC` struct is populated, and `Method` is reset to `"POST"` so the wire-level HTTP method (rather than the leaked procedure name) appears in trace attributes.

## Files

| File | Change |
|------|--------|
| `pkg/ebpf/common/spanner.go` | Add `isJSONRPCMethod` helper, promote spans in `HTTPRequestTraceToSpan` |
| `pkg/ebpf/common/spanner_test.go` | Unit tests for the helper (14 cases) and the spanner promotion path (6 cases) |
| `internal/test/integration/red_test.go` | Flip `testREDMetricsForJSONRPCHTTP` from asserting the buggy HTTP output to asserting `rpc_server_duration_seconds` + a negative assertion that the procedure name no longer leaks into `http.request.method` |

## Out of scope

- **#1799 (span name uses `Arith.Multiply` instead of `Arith` / `Multiply`)** — that's an `RPCService` getter concern, orthogonal to the metric routing fix here. Already assigned to @apatniv.
- **MCP detection on the Go path** — MCP requires payload parsing (Path A only). The Go uprobe surfaces MCP traffic as plain JSON-RPC, which is the closest accurate classification possible without parsing the body.

## Test plan

- [x] Unit tests pass locally (`go test ./pkg/ebpf/common/...`)
- [x] `go vet`, `go build`, `golangci-lint`, `gofmt` clean
- [ ] Integration test (`testREDMetricsForJSONRPCHTTP`) passes against running stack — CI will validate
- [ ] CLA signed (will action on EasyCLA bot prompt)

## Questions for maintainers

1. **Heuristic vs structural flag:** I went with the negative allowlist for simplicity. An alternative would be adding an `is_jsonrpc` flag to the BPF struct (`bpf/gotracer/types/nethttp.h`) and setting it in the uprobe. Happy to switch if you prefer the explicit signal.
2. **`rpc.jsonrpc.version`:** I default to `"2.0"` because OTel semconv references the JSON-RPC spec version. The Go `net/rpc/jsonrpc` package speaks 1.0 on the wire. Open to changing to `""` or `"1.0"` if you'd rather match wire reality.
3. **Negative assertion strictness:** The integration test asserts that `http_server_request_duration_seconds` is NOT emitted with the procedure-name as `http.request.method`. If you'd prefer a softer check, I can relax it.

First-time CNCF contributor — guidance very welcome on any of the above.
