### PR TITLE
Add `network.tcp.handshake.role` attribute to TCP failed connection metrics

### DIFF
--- a/bpf/statsolly/maps/sock_role.h
+++ b/bpf/statsolly/maps/sock_role.h
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, struct sock *);
+    __type(value, u8);
+    __uint(max_entries, 1 << 16);
+} sock_role SEC(".maps");

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -14,6 +14,7 @@
 
 #include <statsolly/types.h>
 #include <statsolly/maps/stats_events.h>
+#include <statsolly/maps/sock_role.h>
 
 #ifndef ECONNREFUSED
 #define ECONNREFUSED 111
@@ -42,16 +43,10 @@ enum tcp_fail_reason {
 };
 
 enum tcp_handshake_role {
+    role_unknown = 0,
     role_client = 1,
     role_server = 2,
 };
-
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __type(key, void *);
-    __type(value, u8);
-    __uint(max_entries, 1 << 16);
-} sock_role SEC(".maps");
 
 static __always_inline u8 sk_err_to_reason(const int err) {
     switch (err) {
@@ -89,7 +84,7 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
         return 0;
     }
 
-    struct sock *sk = (struct sock *)args->skaddr;
+    struct sock *const sk = (struct sock *)args->skaddr;
 
     if (args->oldstate == TCP_SYN_SENT || args->oldstate == TCP_SYN_RECV) {
         if (args->newstate == TCP_ESTABLISHED) {
@@ -105,8 +100,7 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
     // {TCP_LAST_ACK|TCP_TIME_WAIT}->TCP_CLOSE are normal close transitions
     // TCP_LISTEN->TCP_CLOSE is what happens when a listener socket is shut down
     if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT) {
-        bpf_map_delete_elem(&sock_role, &sk);
-        return 0;
+        goto cleanup;
     }
     if (args->oldstate == TCP_LISTEN) {
         return 0;
@@ -117,20 +111,20 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
     // with unread data sends RST without setting sk_err).
     // Exception: aborted connect (TCP_SYN_SENT -> TCP_CLOSE) never established, still a failure.
     if (err == 0 && args->oldstate != TCP_SYN_SENT) {
-        return 0;
+        goto cleanup;
     }
     const u8 reason = sk_err_to_reason(err);
 
     connection_info_t conn;
     if (!parse_sock_info(sk, &conn)) {
-        return 0;
+        goto cleanup;
     }
 
     bpf_d_printk("tcp failed: s_port=%d, d_port=%d, reason=%d", conn.s_port, conn.d_port, reason);
 
-    tcp_failed_connection_t *se = bpf_ringbuf_reserve(&stats_events, sizeof(*se), 0);
+    tcp_failed_connection_t *const se = bpf_ringbuf_reserve(&stats_events, sizeof(*se), 0);
     if (!se) {
-        return 0;
+        goto cleanup;
     }
 
     se->flags = k_event_stat_tcp_failed_connection;
@@ -145,11 +139,12 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
     } else if (args->oldstate == TCP_SYN_RECV) {
         se->role = role_server;
     } else {
-        se->role = 0;
+        se->role = role_unknown;
     }
-    bpf_map_delete_elem(&sock_role, &sk);
 
     bpf_ringbuf_submit(se, stats_events_flags());
 
+cleanup:
+    bpf_map_delete_elem(&sock_role, &sk);
     return 0;
 }

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -104,9 +104,11 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
 
     // {TCP_LAST_ACK|TCP_TIME_WAIT}->TCP_CLOSE are normal close transitions
     // TCP_LISTEN->TCP_CLOSE is what happens when a listener socket is shut down
-    if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT ||
-        args->oldstate == TCP_LISTEN) {
+    if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT) {
         bpf_map_delete_elem(&sock_role, &sk);
+        return 0;
+    }
+    if (args->oldstate == TCP_LISTEN) {
         return 0;
     }
 

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -41,6 +41,18 @@ enum tcp_fail_reason {
     reason_other = 255,
 };
 
+enum tcp_handshake_role {
+    role_client = 1,
+    role_server = 2,
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, void *);
+    __type(value, u8);
+    __uint(max_entries, 1 << 16);
+} sock_role SEC(".maps");
+
 static __always_inline u8 sk_err_to_reason(const int err) {
     switch (err) {
     case ECONNREFUSED:
@@ -63,7 +75,8 @@ static __always_inline u8 sk_err_to_reason(const int err) {
 typedef struct tcp_failed_connection {
     u8 flags; // Must be first, we use it to tell what kind of event we have on the ring buffer
     u8 reason;
-    u8 _pad[2];
+    u8 role;
+    u8 _pad[1];
     connection_info_t conn;
 } tcp_failed_connection_t;
 
@@ -76,6 +89,15 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
         return 0;
     }
 
+    struct sock *sk = (struct sock *)args->skaddr;
+
+    if (args->oldstate == TCP_SYN_SENT || args->oldstate == TCP_SYN_RECV) {
+        if (args->newstate == TCP_ESTABLISHED) {
+            const u8 role = (args->oldstate == TCP_SYN_SENT) ? role_client : role_server;
+            bpf_map_update_elem(&sock_role, &sk, &role, BPF_ANY);
+        }
+    }
+
     if (args->newstate != TCP_CLOSE) {
         return 0;
     }
@@ -84,10 +106,9 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
     // TCP_LISTEN->TCP_CLOSE is what happens when a listener socket is shut down
     if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT ||
         args->oldstate == TCP_LISTEN) {
+        bpf_map_delete_elem(&sock_role, &sk);
         return 0;
     }
-
-    struct sock *sk = (struct sock *)args->skaddr;
 
     const int err = BPF_CORE_READ(sk, sk_err);
     // Trust sk_err: err==0 means the kernel saw no problem (e.g. local close()
@@ -113,6 +134,18 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
     se->flags = k_event_stat_tcp_failed_connection;
     se->reason = reason;
     se->conn = conn;
+
+    const u8 *role_ptr = bpf_map_lookup_elem(&sock_role, &sk);
+    if (role_ptr) {
+        se->role = *role_ptr;
+    } else if (args->oldstate == TCP_SYN_SENT) {
+        se->role = role_client;
+    } else if (args->oldstate == TCP_SYN_RECV) {
+        se->role = role_server;
+    } else {
+        se->role = 0;
+    }
+    bpf_map_delete_elem(&sock_role, &sk);
 
     bpf_ringbuf_submit(se, stats_events_flags());
 

--- a/internal/test/integration/red_test_stat_metrics.go
+++ b/internal/test/integration/red_test_stat_metrics.go
@@ -45,7 +45,7 @@ func testStatMetricsTCPRttGo(t *testing.T) {
 func testStatMetricsTCPFailedConnectionGo(t *testing.T) {
 	pq := promtest.Client{HostPort: prometheusHostPort}
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		results, err := pq.Query(`obi_stat_tcp_failed_connections{dst_port="19999"}`)
+		results, err := pq.Query(`obi_stat_tcp_failed_connections{dst_port="19999",network_tcp_handshake_role="client"}`)
 		require.NoError(ct, err)
 		enoughPromResults(ct, results)
 		assert.Positive(ct, totalPromCount(ct, results))

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -463,6 +463,7 @@ func getDefinitions(
 			SubGroups: []*AttrReportGroup{&statsAttributes, &statsKubeAttributes},
 			Attributes: map[attr.Name]Default{
 				attr.TCPFailedConnectionReason: false,
+				attr.NetworkTCPHandshakeRole:   false,
 			},
 		},
 

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -294,4 +294,5 @@ const (
 // Stat metrics
 const (
 	TCPFailedConnectionReason = Name("reason")
+	NetworkTCPHandshakeRole   = Name("network.tcp.handshake.role")
 )

--- a/pkg/internal/statsolly/ebpf/stat.go
+++ b/pkg/internal/statsolly/ebpf/stat.go
@@ -39,6 +39,23 @@ const (
 	CodeOther             TCPFailReasonTypeCode = 255
 )
 
+type NetworkTCPHandshakeRoleType string
+
+const (
+	RoleUnknown NetworkTCPHandshakeRoleType = "unknown"
+	RoleClient  NetworkTCPHandshakeRoleType = "client"
+	RoleServer  NetworkTCPHandshakeRoleType = "server"
+)
+
+// NetworkTCPHandshakeRoleCode mirrors enum tcp_handshake_role in bpf/statsolly/tp_tcp.c.
+type NetworkTCPHandshakeRoleCode uint8
+
+const (
+	CodeRoleUnknown NetworkTCPHandshakeRoleCode = 0
+	CodeRoleClient  NetworkTCPHandshakeRoleCode = 1
+	CodeRoleServer  NetworkTCPHandshakeRoleCode = 2
+)
+
 // Stat contains accumulated metrics from a stat, with extra metadata
 // that is added from the user space
 // REMINDER: any attribute here must be also added to the functions StatGetters
@@ -59,4 +76,5 @@ type TCPRtt struct {
 
 type TCPFailedConnection struct {
 	Reason uint8 `json:"reason"`
+	Role   uint8 `json:"role"`
 }

--- a/pkg/internal/statsolly/ebpf/stat_getters.go
+++ b/pkg/internal/statsolly/ebpf/stat_getters.go
@@ -50,6 +50,14 @@ func StatGetters(name attr.Name) (attributes.Getter[*Stat, attribute.KeyValue], 
 			}
 			return attribute.String(string(attr.TCPFailedConnectionReason), tcpFailReasonStr(s.TCPFailedConnection.Reason))
 		}
+	case attr.NetworkTCPHandshakeRole:
+		getter = func(s *Stat) attribute.KeyValue {
+			if s.TCPFailedConnection == nil {
+				return attribute.String(string(attr.NetworkTCPHandshakeRole), string(RoleUnknown))
+			}
+			return attribute.String(string(attr.NetworkTCPHandshakeRole), networkTCPHandshakeRoleStr(s.TCPFailedConnection.Role))
+		}
+
 	default:
 		getter = func(s *Stat) attribute.KeyValue { return attribute.String(string(name), s.CommonAttrs.Metadata[name]) }
 	}
@@ -79,5 +87,16 @@ func tcpFailReasonStr(reason uint8) string {
 		return string(Other)
 	default:
 		return string(Unknown)
+	}
+}
+
+func networkTCPHandshakeRoleStr(role uint8) string {
+	switch NetworkTCPHandshakeRoleCode(role) {
+	case CodeRoleClient:
+		return string(RoleClient)
+	case CodeRoleServer:
+		return string(RoleServer)
+	default:
+		return string(RoleUnknown)
 	}
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
@@ -34,7 +34,8 @@ type StatsTCPFailedConnection struct {
 	_      structs.HostLayout
 	Flags  uint8
 	Reason uint8
-	Pad    [2]uint8
+	Role   uint8
+	Pad    [1]uint8
 	Conn   struct {
 		_      structs.HostLayout
 		S_addr [16]uint8 //nolint:revive,staticcheck

--- a/pkg/internal/statsolly/stats/tracer_ringbuf.go
+++ b/pkg/internal/statsolly/stats/tracer_ringbuf.go
@@ -120,6 +120,7 @@ func readTCPFailedConnectionsIntoStat(record *ringbuf.Record) (ebpf.Stat, error)
 		Type: ebpf.StatTypeTCPFailedConnection,
 		TCPFailedConnection: &ebpf.TCPFailedConnection{
 			Reason: event.Reason,
+			Role:   event.Role,
 		},
 		CommonAttrs: pipe.CommonAttrs{
 			SrcAddr: srcAddr,


### PR DESCRIPTION
## Summary

This PR adds a `network.tcp.handshake.role` attribute to the `obi_stat_tcp_failed_connections` metric, indicating whether the local endpoint was acting as a TCP client or server at the time of the failure.

Note: the `network.tcp.handshake.role` attribute name is taken from proposal issue https://github.com/open-telemetry/semantic-conventions/issues/3682 so it may change in the future (for example with `network.tcp.connection.role` or `network.tcp.role`).

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
