### PR TITLE
build: bump obi-generator to golang:1.25.9

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.8-alpine@sha256:8e02eb337d9e0ea459e041f1ee5eece41cbb61f1d83e7d883a3e2fb4862063fa AS base
+FROM golang:1.25.9-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS base
 FROM base AS dist
 
 WORKDIR /src


### PR DESCRIPTION
## Summary

Update obi-generator from golang 1.25.8 --> 1.25.9:

- https://hub.docker.com/layers/library/golang/1.25.9-alpine

Following `devdocs/go-version-upgrade.md`.

This PR is a source branch at origin so that the [Publish OBI Docker Generator Image](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/workflows/generator-image.yml) action can be run:

- https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/25388376148 (`0.2.12` published)

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
