### PR TITLE
bpf/gotracer: replace hardcoded interface data offset with named constant

### DIFF
--- a/bpf/gotracer/go_net_tls.c
+++ b/bpf/gotracer/go_net_tls.c
@@ -19,6 +19,8 @@
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/utils.h>
 
+#include <gotracer/go_offsets.h>
+
 #include <gotracer/go_common.h>
 #include <gotracer/maps/ongoing_ssl_ops.h>
 
@@ -30,7 +32,7 @@
 
 static __always_inline void *unwrap_conn(void *conn) {
     void *conn_conn = 0;
-    bpf_probe_read(&conn_conn, sizeof(conn_conn), conn + 8); // 8 skip embedded data structure class
+    bpf_probe_read(&conn_conn, sizeof(conn_conn), conn + k_go_iface_data_offset);
     bpf_dbg_printk("unwrapped conn %llx", conn_conn);
 
     return conn_conn;

--- a/bpf/gotracer/go_offsets.h
+++ b/bpf/gotracer/go_offsets.h
@@ -121,6 +121,7 @@ enum {
 enum : u32 {
     k_go_string_len_offset = 8,
     k_go_slice_len_offset = 8,
+    k_go_iface_data_offset = 8,
 };
 
 typedef struct go_offset_t {


### PR DESCRIPTION
Partly addresses #1994.

Replaces the hardcoded `8` literal in go_net_tls.c with the named constant `k_go_iface_data_offset`.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
