### PR TITLE
Go byte arr constant nethttp

### DIFF
--- a/bpf/gotracer/go_kafka_go.c
+++ b/bpf/gotracer/go_kafka_go.c
@@ -26,6 +26,8 @@
 
 #include <gotracer/types/kafka.h>
 
+#include <gotracer/go_offsets.h>
+
 #include <logger/bpf_dbg.h>
 
 #include <shared/obi_ctx.h>
@@ -196,7 +198,7 @@ int obi_uprobe_protocol_roundtrip_ret(struct pt_regs *ctx) {
 
                 void *conn_ptr = 0;
                 bpf_probe_read(
-                    &conn_ptr, sizeof(conn_ptr), (void *)(p_ptr->conn_ptr + 8)); // find conn
+                    &conn_ptr, sizeof(conn_ptr), (void *)(p_ptr->conn_ptr + k_go_iface_data_offset)); // find conn
                 bpf_dbg_printk("conn_ptr=%llx", conn_ptr);
                 if (conn_ptr) {
                     const u8 ok = get_conn_info(conn_ptr, &trace->conn);
@@ -252,7 +254,7 @@ int obi_uprobe_reader_read(struct pt_regs *ctx) {
 
         if (conn) {
             void *conn_ptr = 0;
-            bpf_probe_read(&conn_ptr, sizeof(conn_ptr), (void *)(conn + 8)); // find conn
+            bpf_probe_read(&conn_ptr, sizeof(conn_ptr), (void *)(conn + k_go_iface_data_offset)); // find conn
             bpf_dbg_printk("conn_ptr=%llx", conn_ptr);
             if (conn_ptr) {
                 const u8 ok = get_conn_info(conn_ptr, &r.conn);

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -269,7 +269,7 @@ int obi_uprobe_readRequestStart(struct pt_regs *ctx) {
         void *c_ptr = GO_PARAM1(ctx);
         if (c_ptr) {
             void *conn_conn_ptr =
-                c_ptr + 8 + go_offset_of(ot, (go_offset){.v = _c_rwc_pos}); // embedded struct
+                c_ptr + k_go_iface_data_offset + go_offset_of(ot, (go_offset){.v = _c_rwc_pos}); // embedded struct
             void *tls_state = 0;
             bpf_probe_read(&tls_state,
                            sizeof(tls_state),
@@ -863,7 +863,7 @@ int obi_uprobe_writeSubset(struct pt_regs *ctx) {
 
     s64 size = 0;
     bpf_probe_read(
-        &size, sizeof(s64), (void *)(io_writer_addr + io_writer_buf_ptr_pos + 8)); // grab size
+        &size, sizeof(s64), (void *)(io_writer_addr + io_writer_buf_ptr_pos + k_go_slice_len_offset)); // grab size
 
     s64 len = 0;
     bpf_probe_read(&len, sizeof(s64),
@@ -968,11 +968,11 @@ int obi_uprobe_http2serverConn_runHandler(struct pt_regs *ctx) {
     if (sc) {
         void *conn_ptr = 0;
         bpf_probe_read(
-            &conn_ptr, sizeof(void *), sc + go_offset_of(ot, (go_offset){.v = _sc_conn_pos}) + 8);
+            &conn_ptr, sizeof(void *), sc + go_offset_of(ot, (go_offset){.v = _sc_conn_pos}) + k_go_iface_data_offset);
         bpf_dbg_printk("conn_ptr=%llx", conn_ptr);
         if (conn_ptr) {
             void *conn_conn_ptr = 0;
-            bpf_probe_read(&conn_conn_ptr, sizeof(void *), conn_ptr + 8);
+            bpf_probe_read(&conn_conn_ptr, sizeof(void *), conn_ptr + k_go_iface_data_offset);
             bpf_dbg_printk("conn_conn_ptr=%llx", conn_conn_ptr);
             if (conn_conn_ptr) {
                 connection_info_t conn = {0};
@@ -1024,12 +1024,12 @@ static __always_inline void setup_http2_client_conn(void *goroutine_addr,
         const u64 cc_tconn_pos = go_offset_of(ot, (go_offset){.v = off_cc_tconn_pos});
         bpf_dbg_printk("cc_ptr=%llx, cc_tconn_ptr=%llx", cc_ptr, cc_ptr + cc_tconn_pos);
         void *tconn = cc_ptr + go_offset_of(ot, (go_offset){.v = off_cc_tconn_pos});
-        bpf_probe_read(&tconn, sizeof(tconn), (void *)(cc_ptr + cc_tconn_pos + 8));
+        bpf_probe_read(&tconn, sizeof(tconn), (void *)(cc_ptr + cc_tconn_pos + k_go_iface_data_offset));
         bpf_dbg_printk("tconn=%llx", tconn);
 
         if (tconn) {
             void *tconn_conn = 0;
-            bpf_probe_read(&tconn_conn, sizeof(tconn_conn), (void *)(tconn + 8));
+            bpf_probe_read(&tconn_conn, sizeof(tconn_conn), (void *)(tconn + k_go_iface_data_offset));
             bpf_dbg_printk("tconn_conn=%llx", tconn_conn);
 
             connection_info_t conn = {0};
@@ -1147,7 +1147,7 @@ on_http2FramerWriteHeaders(struct pt_regs *ctx, off_table_t *ot, u64 stream_id) 
             void *goroutine_addr = GOROUTINE_PTR(ctx);
 
             void *w_ptr = 0;
-            bpf_probe_read(&w_ptr, sizeof(w_ptr), (void *)(framer + framer_w_pos + 8));
+            bpf_probe_read(&w_ptr, sizeof(w_ptr), (void *)(framer + framer_w_pos + k_go_iface_data_offset));
             if (w_ptr) {
                 s64 n = 0;
                 bpf_probe_read(
@@ -1240,12 +1240,12 @@ int obi_uprobe_http2FramerWriteHeaders_returns(struct pt_regs *ctx) {
             goto done;
         }
 
-        bpf_probe_read(&w_ptr, sizeof(w_ptr), (void *)(f_info->framer_ptr + framer_w_pos + 8));
+        bpf_probe_read(&w_ptr, sizeof(w_ptr), (void *)(f_info->framer_ptr + framer_w_pos + k_go_iface_data_offset));
 
         bpf_dbg_printk("framer_ptr=%llx, w_ptr=%llx, framer_w_pos=%d",
                        f_info->framer_ptr,
                        w_ptr,
-                       framer_w_pos + 8);
+                       framer_w_pos + k_go_iface_data_offset);
 
         if (w_ptr) {
             void *buf_arr = 0;
@@ -1446,7 +1446,7 @@ int obi_uprobe_persistConnRoundTrip(struct pt_regs *ctx) {
     void *pc_ptr = GO_PARAM1(ctx);
     if (pc_ptr) {
         void *conn_conn_ptr =
-            pc_ptr + 8 + go_offset_of(ot, (go_offset){.v = _pc_conn_pos}); // embedded struct
+            pc_ptr + k_go_iface_data_offset + go_offset_of(ot, (go_offset){.v = _pc_conn_pos}); // embedded struct
         void *tls_state = 0;
         bpf_probe_read(
             &tls_state,


### PR DESCRIPTION
## Summary

Partly addresses #1994.

Replaces 10 hardcoded 8 literals in go_nethttp.c with the named constant k_go_iface_data_offset and k_go_slice_len_offset.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
