### PR TITLE
bgf/gotracer: replace hardcoded interface data with constant

### DIFF
--- a/bpf/gotracer/go_kafka_go.c
+++ b/bpf/gotracer/go_kafka_go.c
@@ -26,6 +26,8 @@
 
 #include <gotracer/types/kafka.h>
 
+#include <gotracer/go_offsets.h>
+
 #include <logger/bpf_dbg.h>
 
 #include <shared/obi_ctx.h>
@@ -195,8 +197,9 @@ int obi_uprobe_protocol_roundtrip_ret(struct pt_regs *ctx) {
                 trace->end_monotime_ns = bpf_ktime_get_ns();
 
                 void *conn_ptr = 0;
-                bpf_probe_read(
-                    &conn_ptr, sizeof(conn_ptr), (void *)(p_ptr->conn_ptr + 8)); // find conn
+                bpf_probe_read(&conn_ptr,
+                               sizeof(conn_ptr),
+                               (void *)(p_ptr->conn_ptr + k_go_iface_data_offset)); // find conn
                 bpf_dbg_printk("conn_ptr=%llx", conn_ptr);
                 if (conn_ptr) {
                     const u8 ok = get_conn_info(conn_ptr, &trace->conn);
@@ -252,7 +255,8 @@ int obi_uprobe_reader_read(struct pt_regs *ctx) {
 
         if (conn) {
             void *conn_ptr = 0;
-            bpf_probe_read(&conn_ptr, sizeof(conn_ptr), (void *)(conn + 8)); // find conn
+            bpf_probe_read(
+                &conn_ptr, sizeof(conn_ptr), (void *)(conn + k_go_iface_data_offset)); // find conn
             bpf_dbg_printk("conn_ptr=%llx", conn_ptr);
             if (conn_ptr) {
                 const u8 ok = get_conn_info(conn_ptr, &r.conn);


### PR DESCRIPTION
## Summary

Part of #1994.

Replaces the hardcoded `8` literal in `go_kafka_go.c` with `k_go_slice_len_offset`. The offset accesses the `len` field of a Go slice (`{ptr@0, len@8, cap@16}`), which is a fixed property of the Go
runtime type layout.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
