### PR TITLE
Skip loading unused eBPF programs when feature is disabled in StatsO11y

### DIFF
--- a/devdocs/metrics.md
+++ b/devdocs/metrics.md
@@ -104,9 +104,13 @@ To add a new metric, follow these guidelines:
 1. Decide on the hook point where you want to attach the eBPF probe. For example, you can use a kprobe on the `tcp_close` function to retrieve `srtt_us`.
 2. Add a unique flag that indicates an event related to the metric you want to calculate in [bpf/statsolly/types.h](../bpf/statsolly/types.h) and the corresponding Go constant in [stat.go](../pkg/internal/statsolly/ebpf/stat.go), for example, `k_event_stat_tcp_rtt` and `StatTypeTCPRtt`.
 3. Add the eBPF probe to the [bpf/statsolly](../bpf/statsolly/) folder. Here, the metric will be calculated and sent to userspace using the `stats_events` ringbuffer.
-4. In the [tracer_ringbuf.go](../pkg/internal/statsolly/stats/tracer_ringbuf.go), simply add a function that handles that metric. This function will convert the event to a `ebpf.Stat`.
-5. Then, modify the `Stat` struct accordingly, by adding a data structure containing all the necessary fields. For example `TCPRtt` struct.
-6. The only thing left is to create the appropriate data structures in the `Prometheus` and `OTEL` exporters by adding the appropriate attributes. Each exporter owns one observe-method per stat type (e.g. `observeTCPRtt`, `observeTCPFailedConnections`) that translates the `ebpf.Stat` into a given observation.
+4. Wire the probe into [stats_tracer.go](../pkg/internal/statsolly/ebpf/stats_tracer.go):
+    - add a program name constant (e.g. `progObiKprobeTCPCloseSrtt`) matching the C symbol;
+    - add a hook-point constant (kernel function name for kprobes, `group/name` for tracepoints);
+    - add an entry to the appropriate `kprobes` or `tracepoints` slice inside `NewStatsFetcher`, with `enabled` driven by the corresponding `features.StatsXxx()` predicate. Disabled probes are replaced with a dummy program and are not attached.
+5. In the [tracer_ringbuf.go](../pkg/internal/statsolly/stats/tracer_ringbuf.go), simply add a function that handles that metric. This function will convert the event to a `ebpf.Stat`.
+6. Then, modify the `Stat` struct accordingly, by adding a data structure containing all the necessary fields. For example `TCPRtt` struct.
+7. The only thing left is to create the appropriate data structures in the `Prometheus` and `OTEL` exporters by adding the appropriate attributes. Each exporter owns one observe-method per stat type (e.g. `observeTCPRtt`, `observeTCPFailedConnections`) that translates the `ebpf.Stat` into a given observation.
 
     - `statMetricsReporter` in [pkg/export/prom/prom_stats.go](../pkg/export/prom/prom_stats.go) for Prometheus
     - `statMetricsExporter` in [pkg/export/otel/metrics_stats.go](../pkg/export/otel/metrics_stats.go) for OTEL

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -45,7 +45,7 @@ const (
 	// Kprobes: kernel function names.
 	KprobeTCPClose = "tcp_close"
 
-	// Tracepoints: group/name.
+	// Tracepoints: group/name, are validated by TestTracepointConstantFormat
 	TracepointInetSockSetState = "sock/inet_sock_set_state"
 )
 
@@ -121,12 +121,8 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 			continue
 		}
 
-		parts := strings.SplitN(t.name, "/", 2)
-		if len(parts) != 2 {
-			closeAll(closables)
-			return nil, fmt.Errorf("invalid tracepoint %q: must be group/name", t.name)
-		}
-		l, err := link.Tracepoint(parts[0], parts[1], t.program, nil)
+		group, tp, _ := strings.Cut(t.name, "/")
+		l, err := link.Tracepoint(group, tp, t.program, nil)
 		if err != nil {
 			closeAll(closables)
 			return nil, fmt.Errorf("failed tracepoint attachment %s: %w", t.name, err)

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/rlimit"
 
@@ -32,6 +33,12 @@ type probe struct {
 	program *ebpf.Program
 	enabled bool
 }
+
+// Program names
+const (
+	progObiKprobeTCPCloseSrtt         = "obi_kprobe_tcp_close_srtt"
+	progObiTracepointInetSockSetState = "obi_tracepoint_inet_sock_set_state"
+)
 
 // Hook point names, grouped by attach type.
 const (
@@ -67,6 +74,8 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 	if err != nil {
 		return nil, fmt.Errorf("loading BPF data: %w", err)
 	}
+
+	fixupSpec(spec, features)
 
 	ebpfconvenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor)
 
@@ -161,4 +170,31 @@ func (m *StatsFetcher) StatsEventsMap() *ebpf.Map {
 
 func (m *StatsFetcher) DebugEventsMap() *ebpf.Map {
 	return m.objects.DebugEvents
+}
+
+// fixupSpec replaces disabled programs with no-op stubs before loading,
+// preventing unused eBPF code from being loaded into the kernel.
+func fixupSpec(spec *ebpf.CollectionSpec, features *export.Features) {
+	if !features.StatsTCPFailedConnections() {
+		spec.Programs[progObiTracepointInetSockSetState] = &ebpf.ProgramSpec{
+			Name: "stats_dummy_tp",
+			Type: ebpf.TracePoint,
+			Instructions: asm.Instructions{
+				asm.Mov.Imm(asm.R0, 0),
+				asm.Return(),
+			},
+			License: "Dual MIT/GPL",
+		}
+	}
+	if !features.StatsTCPRtt() {
+		spec.Programs[progObiKprobeTCPCloseSrtt] = &ebpf.ProgramSpec{
+			Name: "stats_dummy_kp",
+			Type: ebpf.Kprobe,
+			Instructions: asm.Instructions{
+				asm.Mov.Imm(asm.R0, 0),
+				asm.Return(),
+			},
+			License: "Dual MIT/GPL",
+		}
+	}
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer_test.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_test.go
@@ -8,7 +8,70 @@ package ebpf
 import (
 	"strings"
 	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"go.opentelemetry.io/obi/pkg/export"
 )
+
+func TestFixupSpec(t *testing.T) {
+	const origKpName = "real_kp"
+	const origTpName = "real_tp"
+
+	makeSpec := func() *ebpf.CollectionSpec {
+		return &ebpf.CollectionSpec{
+			Programs: map[string]*ebpf.ProgramSpec{
+				progObiKprobeTCPCloseSrtt:         {Name: origKpName, Type: ebpf.Kprobe},
+				progObiTracepointInetSockSetState: {Name: origTpName, Type: ebpf.TracePoint},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		features   export.Features
+		wantKpName string
+		wantTpName string
+	}{
+		{
+			name:       "all disabled",
+			features:   export.Features(0),
+			wantKpName: "stats_dummy_kp",
+			wantTpName: "stats_dummy_tp",
+		},
+		{
+			name:       "rtt only",
+			features:   export.FeatureStatsTCPRtt,
+			wantKpName: origKpName,
+			wantTpName: "stats_dummy_tp",
+		},
+		{
+			name:       "failed connections only",
+			features:   export.FeatureStatsTCPFailedConnections,
+			wantKpName: "stats_dummy_kp",
+			wantTpName: origTpName,
+		},
+		{
+			name:       "all enabled",
+			features:   export.FeatureStats,
+			wantKpName: origKpName,
+			wantTpName: origTpName,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := makeSpec()
+			fixupSpec(spec, &tc.features)
+			if got := spec.Programs[progObiKprobeTCPCloseSrtt].Name; got != tc.wantKpName {
+				t.Errorf("kprobe program: got %q, want %q", got, tc.wantKpName)
+			}
+			if got := spec.Programs[progObiTracepointInetSockSetState].Name; got != tc.wantTpName {
+				t.Errorf("tracepoint program: got %q, want %q", got, tc.wantTpName)
+			}
+		})
+	}
+}
 
 // TestTracepointConstantFormat validates that all tracepoint constants are in group/name format.
 // When adding a new tracepoint constant, add it to the hooks slice below.

--- a/pkg/internal/statsolly/ebpf/stats_tracer_test.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_test.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTracepointConstantFormat validates that all tracepoint constants are in group/name format.
+// When adding a new tracepoint constant, add it to the hooks slice below.
+func TestTracepointConstantFormat(t *testing.T) {
+	hooks := []string{
+		TracepointInetSockSetState,
+	}
+	for _, hook := range hooks {
+		if _, _, ok := strings.Cut(hook, "/"); !ok {
+			t.Errorf("tracepoint constant %q is not in group/name format", hook)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

When a statsolly feature (TCP RTT, TCP failed connections) is disabled, the corresponding eBPF program was still loaded into kernel memory.

This PR adds `fixupSpec`, which replaces disabled programs with minimal no-op stubs before `LoadSpec` runs which is combined with the existing `enabled` attachment guard. 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
