### PR TITLE
Promote Rafael Roquetto to the Maintainer role

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,6 +252,7 @@ Any [Maintainer] can merge the PR once the above criteria have been met.
 * [Mike Dame](https://github.com/damemi), Odigos
 * [Nikola Grcevski](https://github.com/grcevski), Grafana
 * [Nimrod Avni](https://github.com/NimrodAvni78), Coralogix
+* [Rafael Roquetto](https://github.com/rafaelroquetto), Grafana
 * [Tyler Yahn](https://github.com/MrAlias), Splunk
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
@@ -259,7 +260,6 @@ For more information about the maintainer role, see the [community repository](h
 ### Approvers
 
 * [Marc Tudurí](https://github.com/marctc), Grafana
-* [Rafael Roquetto](https://github.com/rafaelroquetto), Grafana
 * [Stephen Lang](https://github.com/skl), Grafana
 * [Giuseppe Ognibene](https://github.com/pinoOgni), Coralogix
 


### PR DESCRIPTION
Join me in celebrating the promotion of Rafael Roquetto (@rafaelroquetto) to the role of Maintainer :tada:

Based on his sustained contribution to the OBI project since its inception, the current maintainers feel he has demonstrated a continuous and dedicated commitment to the OBI project and community. Rafael has contributed roughly 100 commits spanning core instrumentation, parser and performance work, CI and test improvements, and contributor guidance. That commitment is also reflected in his consistent presence at SIG meetings, his active developer outreach and regular collaboration with fellow contributors, and the help he regularly provides to users in Slack. Rafael has also shown strong leadership in shaping the project’s position on AI and its use in development, and is leading that initiative within the community. We are excited to announce his promotion to the maintainer role and look forward to continuing to build OBI together!