### PR TITLE
Fix service name resolution

### DIFF
--- a/pkg/kube/store.go
+++ b/pkg/kube/store.go
@@ -72,7 +72,9 @@ const (
 var DefaultResourceLabels = ResourceLabels{
 	// If a user sets useLabelsForResourceAttributes: false in its OTEL operator config, is the task of the
 	// OTEL operator to provide empty values for this.
-	"service.name":      []string{"app.kubernetes.io/name"},
+	// app.kubernetes.io/instance has higher precedence than app.kubernetes.io/name per the OTel spec:
+	// https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#how-servicename-should-be-calculated
+	"service.name":      []string{"app.kubernetes.io/instance", "app.kubernetes.io/name"},
 	"service.namespace": []string{"app.kubernetes.io/part-of"},
 	"service.version":   []string{"app.kubernetes.io/version"},
 }

--- a/pkg/kube/store_test.go
+++ b/pkg/kube/store_test.go
@@ -499,6 +499,74 @@ func TestServiceInfo(t *testing.T) {
 	assert.Equal(t, "namespaceA", k8sNamespace)
 }
 
+func TestServiceNameLabelPriority(t *testing.T) {
+	newPod := func(labels map[string]string) informer.ObjectMeta {
+		return informer.ObjectMeta{
+			Name:      "podA",
+			Namespace: "ns",
+			Ips:       []string{"1.2.3.4"},
+			Kind:      "Pod",
+			Labels:    labels,
+			Pod: &informer.PodInfo{
+				Owners: []*informer.Owner{{Name: "my-deployment", Kind: "Deployment"}},
+				Containers: []*informer.ContainerInfo{{Id: "c1", Env: map[string]string{}}},
+			},
+		}
+	}
+
+	t.Run("instance label takes precedence over name label", func(t *testing.T) {
+		store := createTestStore()
+		pod := newPod(map[string]string{
+			"app.kubernetes.io/name":     "from-name",
+			"app.kubernetes.io/instance": "from-instance",
+		})
+		_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &pod})
+		name, _, _ := store.ServiceNameNamespaceForIP("1.2.3.4")
+		assert.Equal(t, "from-instance", name)
+	})
+
+	t.Run("name label used when instance label absent", func(t *testing.T) {
+		store := createTestStore()
+		pod := newPod(map[string]string{
+			"app.kubernetes.io/name": "from-name",
+		})
+		_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &pod})
+		name, _, _ := store.ServiceNameNamespaceForIP("1.2.3.4")
+		assert.Equal(t, "from-name", name)
+	})
+
+	t.Run("instance label alone sets service name", func(t *testing.T) {
+		store := createTestStore()
+		pod := newPod(map[string]string{
+			"app.kubernetes.io/instance": "from-instance",
+		})
+		_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &pod})
+		name, _, _ := store.ServiceNameNamespaceForIP("1.2.3.4")
+		assert.Equal(t, "from-instance", name)
+	})
+
+	t.Run("annotation overrides instance label", func(t *testing.T) {
+		store := createTestStore()
+		pod := newPod(map[string]string{
+			"app.kubernetes.io/instance": "from-instance",
+		})
+		pod.Annotations = map[string]string{
+			ServiceNameAnnotation: "from-annotation",
+		}
+		_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &pod})
+		name, _, _ := store.ServiceNameNamespaceForIP("1.2.3.4")
+		assert.Equal(t, "from-annotation", name)
+	})
+
+	t.Run("falls back to owner name when no labels set", func(t *testing.T) {
+		store := createTestStore()
+		pod := newPod(nil)
+		_ = store.On(&informer.Event{Type: informer.EventType_CREATED, Resource: &pod})
+		name, _, _ := store.ServiceNameNamespaceForIP("1.2.3.4")
+		assert.Equal(t, "my-deployment", name)
+	})
+}
+
 func TestMemoryCleanedUp(t *testing.T) {
 	deployment := informer.Owner{
 		Name: "service",

--- a/pkg/kube/store_test.go
+++ b/pkg/kube/store_test.go
@@ -508,7 +508,7 @@ func TestServiceNameLabelPriority(t *testing.T) {
 			Kind:      "Pod",
 			Labels:    labels,
 			Pod: &informer.PodInfo{
-				Owners: []*informer.Owner{{Name: "my-deployment", Kind: "Deployment"}},
+				Owners:     []*informer.Owner{{Name: "my-deployment", Kind: "Deployment"}},
 				Containers: []*informer.ContainerInfo{{Id: "c1", Env: map[string]string{}}},
 			},
 		}


### PR DESCRIPTION
## Summary

Changed the default configuration for pod labels to use for resolving service name from to be according to [the semantic conventions guidelines](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/#how-servicename-should-be-calculated). Resolve #2057 & Resolve #1893

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
