### PR TITLE
Fix slice bounds panic in Postgres BIND parser on truncated frame

### DIFF
--- a/pkg/ebpf/common/sql_detect_postgres.go
+++ b/pkg/ebpf/common/sql_detect_postgres.go
@@ -327,6 +327,14 @@ Loop:
 		case "BIND":
 			portal := strings.Clone(unix.ByteSliceToString(msg.data))
 			portalLen := len(portal) + 1 // +1 for the null terminator
+			if portalLen >= len(msg.data) {
+				// BIND message truncated by BPF ring buffer: portal name fills the
+				// captured buffer, leaving no room for the statement name. Skip the
+				// statement-name lookup rather than panicking on the slice expression.
+				slog.Debug("Postgres BIND message truncated; skipping portal mapping",
+					"portal_len", portalLen, "buf_len", len(msg.data))
+				continue
+			}
 			stmtName := strings.Clone(unix.ByteSliceToString(msg.data[portalLen:]))
 
 			parseCtx.postgresPortals.Add(postgresPortalsKey{

--- a/pkg/ebpf/common/sql_detect_postgres.go
+++ b/pkg/ebpf/common/sql_detect_postgres.go
@@ -325,16 +325,14 @@ Loop:
 
 			continue
 		case "BIND":
-			portal := strings.Clone(unix.ByteSliceToString(msg.data))
-			portalLen := len(portal) + 1 // +1 for the null terminator
+			portalStr := unix.ByteSliceToString(msg.data)
+			portalLen := len(portalStr) + 1 // +1 for the null terminator
 			if portalLen >= len(msg.data) {
-				// BIND message truncated by BPF ring buffer: portal name fills the
-				// captured buffer, leaving no room for the statement name. Skip the
-				// statement-name lookup rather than panicking on the slice expression.
 				slog.Debug("Postgres BIND message truncated; skipping portal mapping",
 					"portal_len", portalLen, "buf_len", len(msg.data))
 				continue
 			}
+			portal := strings.Clone(portalStr)
 			stmtName := strings.Clone(unix.ByteSliceToString(msg.data[portalLen:]))
 
 			parseCtx.postgresPortals.Add(postgresPortalsKey{

--- a/pkg/ebpf/common/sql_detect_postgres_test.go
+++ b/pkg/ebpf/common/sql_detect_postgres_test.go
@@ -134,45 +134,23 @@ func TestPostgresMessagesIteratorNoAllocs(t *testing.T) {
 	}
 }
 
-// TestPostgresHandleBindTruncatedDoesNotPanic reproduces the production crash
-// where the BPF ring buffer captures only the portal-name portion of a Postgres
-// BIND message (statement-name byte was lost to TCP segmentation). Without a
-// bounds check, msg.data[portalLen:] in the BIND case panics with
-// "slice bounds out of range [13:12]".
-//
-// Stack trace observed in production:
-//
-//	panic: runtime error: slice bounds out of range [13:12]
-//	  go.opentelemetry.io/obi/pkg/ebpf/common.handlePostgres(...)
-//	    sql_detect_postgres.go:330
-//	  go.opentelemetry.io/obi/pkg/ebpf/common.dispatchPostgres(...)
-//	    tcp_detect_transform.go:151
-//	  go.opentelemetry.io/obi/pkg/ebpf/common.ReadTCPRequestIntoSpan(...)
-//	    tcp_detect_transform.go:61
-//
-// Trigger: Rust application (sqlx / tokio-postgres) sending prepared-statement
-// BIND messages large enough that the BIND header arrives in one BPF event but
-// the body is captured truncated.
+// TestPostgresHandleBindTruncatedDoesNotPanic makes sure that if the BIND
+// message is truncated at the eBPF side, OBI won't crash after trying to read
+// beyond the buffer limits.
 func TestPostgresHandleBindTruncatedDoesNotPanic(t *testing.T) {
-	// Body = 12 bytes of portal-name with NO null terminator within the buffer.
-	// unix.ByteSliceToString reads to the end → portal length = 12,
-	// portalLen = len(portal)+1 = 13, but len(msg.data) = 12 → slice [13:12].
+	// Portal name with no null terminator inside the captured buffer.
 	body := []byte("abcdefghijkl")
-
-	// Postgres BIND wire frame: type byte + 4-byte length (length includes
-	// itself, excludes the type byte).
-	bind := []byte{'B', 0, 0, 0, byte(4 + len(body))}
-	bind = append(bind, body...)
-
+	bind := append([]byte{'B', 0, 0, 0, byte(4 + len(body))}, body...)
 	requestBuffer := largebuf.NewLargeBufferFrom(bind)
-	// Minimal valid response buffer (just the header bytes — content is not
-	// consulted on the panic path).
-	responseBuffer := largebuf.NewLargeBufferFrom([]byte{'B', 0, 0, 0, 4})
+
+	// ReadyForQuery (6 bytes): minimum to pass the response short-frame check
+	// so the request iterator actually reaches the BIND case.
+	responseBuffer := largebuf.NewLargeBufferFrom([]byte{'Z', 0, 0, 0, 5, 'I'})
 
 	cfg := config.EBPFTracer{HeuristicSQLDetect: true}
 	ctx := NewEBPFParseContext(&cfg, nil, nil)
 
 	require.NotPanics(t, func() {
 		_, _ = handlePostgres(ctx, &TCPRequestInfo{}, requestBuffer, responseBuffer)
-	}, "handlePostgres must not panic on a Postgres BIND message truncated mid-portal")
+	})
 }

--- a/pkg/ebpf/common/sql_detect_postgres_test.go
+++ b/pkg/ebpf/common/sql_detect_postgres_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
 
@@ -131,4 +132,47 @@ func TestPostgresMessagesIteratorNoAllocs(t *testing.T) {
 	if allocs != 0 {
 		t.Errorf("MessageIterator allocated %v allocs per run; want 0", allocs)
 	}
+}
+
+// TestPostgresHandleBindTruncatedDoesNotPanic reproduces the production crash
+// where the BPF ring buffer captures only the portal-name portion of a Postgres
+// BIND message (statement-name byte was lost to TCP segmentation). Without a
+// bounds check, msg.data[portalLen:] in the BIND case panics with
+// "slice bounds out of range [13:12]".
+//
+// Stack trace observed in production:
+//
+//	panic: runtime error: slice bounds out of range [13:12]
+//	  go.opentelemetry.io/obi/pkg/ebpf/common.handlePostgres(...)
+//	    sql_detect_postgres.go:330
+//	  go.opentelemetry.io/obi/pkg/ebpf/common.dispatchPostgres(...)
+//	    tcp_detect_transform.go:151
+//	  go.opentelemetry.io/obi/pkg/ebpf/common.ReadTCPRequestIntoSpan(...)
+//	    tcp_detect_transform.go:61
+//
+// Trigger: Rust application (sqlx / tokio-postgres) sending prepared-statement
+// BIND messages large enough that the BIND header arrives in one BPF event but
+// the body is captured truncated.
+func TestPostgresHandleBindTruncatedDoesNotPanic(t *testing.T) {
+	// Body = 12 bytes of portal-name with NO null terminator within the buffer.
+	// unix.ByteSliceToString reads to the end → portal length = 12,
+	// portalLen = len(portal)+1 = 13, but len(msg.data) = 12 → slice [13:12].
+	body := []byte("abcdefghijkl")
+
+	// Postgres BIND wire frame: type byte + 4-byte length (length includes
+	// itself, excludes the type byte).
+	bind := []byte{'B', 0, 0, 0, byte(4 + len(body))}
+	bind = append(bind, body...)
+
+	requestBuffer := largebuf.NewLargeBufferFrom(bind)
+	// Minimal valid response buffer (just the header bytes — content is not
+	// consulted on the panic path).
+	responseBuffer := largebuf.NewLargeBufferFrom([]byte{'B', 0, 0, 0, 4})
+
+	cfg := config.EBPFTracer{HeuristicSQLDetect: true}
+	ctx := NewEBPFParseContext(&cfg, nil, nil)
+
+	require.NotPanics(t, func() {
+		_, _ = handlePostgres(ctx, &TCPRequestInfo{}, requestBuffer, responseBuffer)
+	}, "handlePostgres must not panic on a Postgres BIND message truncated mid-portal")
 }


### PR DESCRIPTION
## Summary

Fix `slice bounds out of range` panic in `handlePostgres` BIND case when the
BPF ring buffer captures a Postgres BIND message truncated mid-portal.

## Stack trace (observed in production)

```
panic: runtime error: slice bounds out of range [13:12]

goroutine 497 [running]:
go.opentelemetry.io/obi/pkg/ebpf/common.handlePostgres(...)
  /src/vendor/go.opentelemetry.io/obi/pkg/ebpf/common/sql_detect_postgres.go:330
go.opentelemetry.io/obi/pkg/ebpf/common.dispatchPostgres(...)
  tcp_detect_transform.go:151
go.opentelemetry.io/obi/pkg/ebpf/common.ReadTCPRequestIntoSpan(...)
  tcp_detect_transform.go:61
```

## Root cause

`handlePostgres` BIND case (sql_detect_postgres.go:328-330):

```go
portal := strings.Clone(unix.ByteSliceToString(msg.data))
portalLen := len(portal) + 1   // +1 for the null terminator
stmtName := strings.Clone(unix.ByteSliceToString(msg.data[portalLen:]))
```

`unix.ByteSliceToString(msg.data)` reads to the end of the buffer when no null
terminator is present. When the BPF ring buffer truncates the BIND payload
mid-portal (TCP segmentation splits the BIND body across kernel reads), the
extracted portal occupies the entire buffer, so `portalLen = len(portal)+1`
becomes greater than `len(msg.data)`. The next slice expression
`msg.data[portalLen:]` panics.

## Trigger

Beyla 3.14.0 (current OBI HEAD as of 2026-05) on EKS amzn2023, kernel 6.12,
with a Rust application using ` sqlx`/`tokio-postgres` issuing prepared-statement
BIND messages to PostgreSQL. Observed crash rate ~1/min on the Beyla pod
co-located with the Postgres master node. Beyla pods on other nodes (with no
Postgres master, or with Postgres replicas only) did not panic.

## Fix

Add an explicit bounds check before the slice. When the captured frame contains
only the portal name (`portalLen >= len(msg.data)`), log a debug message and
`continue` with the next iterator message — there is no statement name to map
into `postgresPortals` because the body was truncated.

## Test

`TestPostgresHandleBindTruncatedDoesNotPanic` reproduces the truncated frame
(12-byte BIND body with no null terminator) and asserts that `handlePostgres`
does not panic. The test fails on `main` without the fix and passes with it.

## Files

- `pkg/ebpf/common/sql_detect_postgres.go` — 8-line bounds check
- `pkg/ebpf/common/sql_detect_postgres_test.go` — regression test