### PR TITLE
chore(renovate): pin compatibility docker fixtures

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -130,6 +130,18 @@
       "enabled": false
     },
     {
+      "description": "Disable Docker updates for the Python 3.9 uvloop compatibility fixture",
+      "matchFileNames": ["internal/test/integration/components/pythonasync-uvloop/Dockerfile-3.9"],
+      "matchDatasources": ["docker"],
+      "enabled": false
+    },
+    {
+      "description": "Disable Docker updates for the Ruby 3.0.2 / Puma 5 compatibility fixture",
+      "matchFileNames": ["internal/test/integration/components/rubytestserver/testapi/Dockerfile_ruby302_puma5"],
+      "matchDatasources": ["docker"],
+      "enabled": false
+    },
+    {
       "description": "Block Spring Boot major upgrades for JDK8 example (Spring Boot 3+ requires JDK 17+)",
       "matchFileNames": ["internal/test/integration/components/java_tls/jdk8/pom.xml"],
       "matchManagers": ["maven"],


### PR DESCRIPTION
Do not upgrade these docker images. They are used for compatibility testing.
