### PR TITLE
docs: updates JNA references to JNI

### DIFF
--- a/pkg/internal/java/README.md
+++ b/pkg/internal/java/README.md
@@ -67,7 +67,7 @@ The project consists of two main modules:
 The core instrumentation logic using ByteBuddy for bytecode manipulation:
 
 - **Instrumentations**: Socket, SocketChannel, SSLEngine, Netty
-- **eBPF Communication**: Via JNA and `ioctl` syscalls for minimal kernel impact
+- **eBPF Communication**: Via JNI to `libobijni.so`, which calls `ioctl` for minimal kernel impact
 - **Data Structures**: Connection tracking, SSL session management
 - **Utilities**: Optimized ByteBuffer extraction and manipulation
 
@@ -78,7 +78,6 @@ A lightweight loader that:
 - Extracts the agent JAR from resources
 - Loads the agent using a separate classloader to avoid conflicts with the
   target application
-- Ensures JNA is available in the bootstrap classloader
 - Handles agent attachment (both premain and agentmain)
 
 ```
@@ -275,7 +274,7 @@ jattach <PID of Java program> load instrument false "/path/to/obi-java-agent.jar
 ### Key Technologies
 
 - **ByteBuddy** - Bytecode manipulation and agent building
-- **JNA (Java Native Access)** - Native library calls (ioctl)
+- **JNI** - Native `libobijni.so` for `ioctl`, `gettid`, and direct `ByteBuffer` address access
 - **Caffeine** - High-performance LRU for keeping track of existing connections
 
 ### Adding New Instrumentations

--- a/pkg/internal/java/loader/build.gradle.kts
+++ b/pkg/internal/java/loader/build.gradle.kts
@@ -6,11 +6,6 @@ plugins {
     id("com.diffplug.spotless")
 }
 
-// We need this dependency to load the resource JNA shared libraries
-dependencies {
-    implementation("net.java.dev.jna:jna:5.18.1")
-}
-
 configure<SpotlessExtension> {
     java {
         // Use Google Java Format


### PR DESCRIPTION
## Summary

JNI replaced the usage of JNA, remove some dangling references.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
