### PR TITLE
Add `network.tcp.handshake.role` attribute to TCP RTT metric

### DIFF
--- a/bpf/statsolly/k_tcp.c
+++ b/bpf/statsolly/k_tcp.c
@@ -67,7 +67,8 @@ int BPF_KPROBE(obi_kprobe_tcp_close_srtt, struct sock *sk) {
     const u8 *role_ptr = bpf_map_lookup_elem(&sock_role, &sk);
     se->role = role_ptr ? *role_ptr : role_unknown;
 
-    bpf_d_printk("tcp rtt: s_port=%d, d_port=%d, srtt_us=%u", se->conn.s_port, se->conn.d_port, se->srtt_us);
+    bpf_d_printk(
+        "tcp rtt: s_port=%d, d_port=%d, srtt_us=%u", se->conn.s_port, se->conn.d_port, se->srtt_us);
     bpf_ringbuf_submit(se, stats_events_flags());
 
     return 0;

--- a/bpf/statsolly/k_tcp.c
+++ b/bpf/statsolly/k_tcp.c
@@ -14,6 +14,7 @@
 
 #include <statsolly/types.h>
 #include <statsolly/maps/stats_events.h>
+#include <statsolly/maps/sock_role.h>
 
 enum {
     k_usec_per_sec = 1000000ULL,
@@ -22,7 +23,8 @@ enum {
 
 typedef struct tcp_rtt {
     u8 flags; // Must be first, we use it to tell what kind of event we have on the ring buffer
-    u8 _pad[3];
+    u8 role;
+    u8 _pad[2];
     u32 srtt_us;
     connection_info_t conn;
 } tcp_rtt_t;
@@ -62,8 +64,10 @@ int BPF_KPROBE(obi_kprobe_tcp_close_srtt, struct sock *sk) {
     se->flags = k_event_stat_tcp_rtt;
     se->srtt_us = srtt_us;
     se->conn = conn;
+    const u8 *role_ptr = bpf_map_lookup_elem(&sock_role, &sk);
+    se->role = role_ptr ? *role_ptr : role_unknown;
 
-    bpf_d_printk("s_port=%d, d_port=%d, srtt_us=%u", se->conn.s_port, se->conn.d_port, se->srtt_us);
+    bpf_d_printk("tcp rtt: s_port=%d, d_port=%d, srtt_us=%u", se->conn.s_port, se->conn.d_port, se->srtt_us);
     bpf_ringbuf_submit(se, stats_events_flags());
 
     return 0;

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -74,7 +74,7 @@ const tcp_failed_connection_t *unused_tcp_failed_connection __attribute__((unuse
 
 // obi_tp_inet_sock_set_state_conn_role is the sole owner of the sock_role map.
 // It writes the role (client/server) when a connection is established and
-// it also handles all cleanup: any transition to TCP_CLOSE removes the entry, 
+// it also handles all cleanup: any transition to TCP_CLOSE removes the entry,
 // covering both normal graceful closes and abnormal ones.
 //
 // Attachment order invariant: this program must be attached AFTER
@@ -119,7 +119,8 @@ int obi_tp_inet_sock_set_state_tcp_failed_conn(struct trace_event_raw_inet_sock_
 
     // {TCP_LAST_ACK|TCP_TIME_WAIT}->TCP_CLOSE are normal close transitions
     // TCP_LISTEN->TCP_CLOSE is what happens when a listener socket is shut down
-    if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT || args->oldstate == TCP_LISTEN) {
+    if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT ||
+        args->oldstate == TCP_LISTEN) {
         return 0;
     }
 

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -42,12 +42,6 @@ enum tcp_fail_reason {
     reason_other = 255,
 };
 
-enum tcp_handshake_role {
-    role_unknown = 0,
-    role_client = 1,
-    role_server = 2,
-};
-
 static __always_inline u8 sk_err_to_reason(const int err) {
     switch (err) {
     case ECONNREFUSED:
@@ -78,6 +72,16 @@ typedef struct tcp_failed_connection {
 // Force tcp_failed_connection_t
 const tcp_failed_connection_t *unused_tcp_failed_connection __attribute__((unused));
 
+// obi_tp_inet_sock_set_state_conn_role is the sole owner of the sock_role map.
+// It writes the role (client/server) when a connection is established and
+// it also handles all cleanup: any transition to TCP_CLOSE removes the entry, 
+// covering both normal graceful closes and abnormal ones.
+//
+// Attachment order invariant: this program must be attached AFTER
+// obi_tp_inet_sock_set_state_tcp_failed_conn (or any future tp probes that need the role)
+// on the same tracepoint. BPF programs on a tracepoint run FIFO, so the probe(s) read sock_role first,
+// then this program deletes it. Reversing the order would cause tcp_failed_conn or any other probes
+// to see a stale NULL on the same TCP_CLOSE event.
 SEC("tracepoint/sock/inet_sock_set_state")
 int obi_tp_inet_sock_set_state_conn_role(struct trace_event_raw_inet_sock_set_state *args) {
     if (args->protocol != IPPROTO_TCP) {
@@ -93,9 +97,7 @@ int obi_tp_inet_sock_set_state_conn_role(struct trace_event_raw_inet_sock_set_st
         }
     }
 
-    // {TCP_LAST_ACK|TCP_TIME_WAIT}->TCP_CLOSE are normal close transitions
-    // TCP_LISTEN->TCP_CLOSE is what happens when a listener socket is shut down
-    if (args->newstate == TCP_CLOSE && (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT)) {
+    if (args->newstate == TCP_CLOSE) {
         bpf_map_delete_elem(&sock_role, &sk);
         return 0;
     }

--- a/bpf/statsolly/tp_tcp.c
+++ b/bpf/statsolly/tp_tcp.c
@@ -79,7 +79,7 @@ typedef struct tcp_failed_connection {
 const tcp_failed_connection_t *unused_tcp_failed_connection __attribute__((unused));
 
 SEC("tracepoint/sock/inet_sock_set_state")
-int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_state *args) {
+int obi_tp_inet_sock_set_state_conn_role(struct trace_event_raw_inet_sock_set_state *args) {
     if (args->protocol != IPPROTO_TCP) {
         return 0;
     }
@@ -93,16 +93,31 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
         }
     }
 
+    // {TCP_LAST_ACK|TCP_TIME_WAIT}->TCP_CLOSE are normal close transitions
+    // TCP_LISTEN->TCP_CLOSE is what happens when a listener socket is shut down
+    if (args->newstate == TCP_CLOSE && (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT)) {
+        bpf_map_delete_elem(&sock_role, &sk);
+        return 0;
+    }
+
+    return 0;
+}
+
+SEC("tracepoint/sock/inet_sock_set_state")
+int obi_tp_inet_sock_set_state_tcp_failed_conn(struct trace_event_raw_inet_sock_set_state *args) {
+    if (args->protocol != IPPROTO_TCP) {
+        return 0;
+    }
+
+    struct sock *const sk = (struct sock *)args->skaddr;
+
     if (args->newstate != TCP_CLOSE) {
         return 0;
     }
 
     // {TCP_LAST_ACK|TCP_TIME_WAIT}->TCP_CLOSE are normal close transitions
     // TCP_LISTEN->TCP_CLOSE is what happens when a listener socket is shut down
-    if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT) {
-        goto cleanup;
-    }
-    if (args->oldstate == TCP_LISTEN) {
+    if (args->oldstate == TCP_LAST_ACK || args->oldstate == TCP_TIME_WAIT || args->oldstate == TCP_LISTEN) {
         return 0;
     }
 
@@ -111,20 +126,20 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
     // with unread data sends RST without setting sk_err).
     // Exception: aborted connect (TCP_SYN_SENT -> TCP_CLOSE) never established, still a failure.
     if (err == 0 && args->oldstate != TCP_SYN_SENT) {
-        goto cleanup;
+        return 0;
     }
     const u8 reason = sk_err_to_reason(err);
 
     connection_info_t conn;
     if (!parse_sock_info(sk, &conn)) {
-        goto cleanup;
+        return 0;
     }
 
     bpf_d_printk("tcp failed: s_port=%d, d_port=%d, reason=%d", conn.s_port, conn.d_port, reason);
 
     tcp_failed_connection_t *const se = bpf_ringbuf_reserve(&stats_events, sizeof(*se), 0);
     if (!se) {
-        goto cleanup;
+        return 0;
     }
 
     se->flags = k_event_stat_tcp_failed_connection;
@@ -144,7 +159,5 @@ int obi_tracepoint_inet_sock_set_state(struct trace_event_raw_inet_sock_set_stat
 
     bpf_ringbuf_submit(se, stats_events_flags());
 
-cleanup:
-    bpf_map_delete_elem(&sock_role, &sk);
     return 0;
 }

--- a/bpf/statsolly/types.h
+++ b/bpf/statsolly/types.h
@@ -8,3 +8,9 @@ enum {
     k_event_stat_tcp_rtt = 1,               // StatTypeTCPRtt
     k_event_stat_tcp_failed_connection = 2, // StatTypeTCPFailedConnection
 };
+
+enum tcp_handshake_role {
+    role_unknown = 0,
+    role_client = 1,
+    role_server = 2,
+};

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -423,10 +423,6 @@ func getDefinitions(
 				attr.ErrorType:       true,
 			},
 		},
-		StatTCPRtt.Section: {
-			SubGroups:  []*AttrReportGroup{&statsAttributes, &statsKubeAttributes},
-			Attributes: map[attr.Name]Default{},
-		},
 		GenAIClientInputTokenUsage.Section: {
 			SubGroups: []*AttrReportGroup{&appAttributes},
 			Attributes: map[attr.Name]Default{
@@ -461,6 +457,12 @@ func getDefinitions(
 				attr.ErrorType:          true,
 				attr.ServerPort:         true,
 				attr.ServerAddr:         true,
+			},
+		},
+		StatTCPRtt.Section: {
+			SubGroups: []*AttrReportGroup{&statsAttributes, &statsKubeAttributes},
+			Attributes: map[attr.Name]Default{
+				attr.NetworkTCPHandshakeRole: false,
 			},
 		},
 		StatTCPFailedConnections.Section: {

--- a/pkg/internal/statsolly/ebpf/stat.go
+++ b/pkg/internal/statsolly/ebpf/stat.go
@@ -72,6 +72,7 @@ type Stat struct {
 
 type TCPRtt struct {
 	SrttUs uint32 `json:"srtt_us"`
+	Role   uint8  `json:"role"`
 }
 
 type TCPFailedConnection struct {

--- a/pkg/internal/statsolly/ebpf/stat_getters.go
+++ b/pkg/internal/statsolly/ebpf/stat_getters.go
@@ -52,13 +52,14 @@ func StatGetters(name attr.Name) (attributes.Getter[*Stat, attribute.KeyValue], 
 		}
 	case attr.NetworkTCPHandshakeRole:
 		getter = func(s *Stat) attribute.KeyValue {
-			if s.TCPFailedConnection != nil {
-				return attribute.String(string(attr.NetworkTCPHandshakeRole), networkTCPHandshakeRoleStr(s.TCPFailedConnection.Role))
+			var role uint8
+			switch s.Type {
+			case StatTypeTCPFailedConnection:
+				role = s.TCPFailedConnection.Role
+			case StatTypeTCPRtt:
+				role = s.TCPRtt.Role
 			}
-			if s.TCPRtt != nil {
-				return attribute.String(string(attr.NetworkTCPHandshakeRole), networkTCPHandshakeRoleStr(s.TCPRtt.Role))
-			}
-			return attribute.String(string(attr.NetworkTCPHandshakeRole), string(RoleUnknown))
+			return attribute.String(string(attr.NetworkTCPHandshakeRole), networkTCPHandshakeRoleStr(role))
 		}
 
 	default:

--- a/pkg/internal/statsolly/ebpf/stat_getters.go
+++ b/pkg/internal/statsolly/ebpf/stat_getters.go
@@ -52,10 +52,13 @@ func StatGetters(name attr.Name) (attributes.Getter[*Stat, attribute.KeyValue], 
 		}
 	case attr.NetworkTCPHandshakeRole:
 		getter = func(s *Stat) attribute.KeyValue {
-			if s.TCPFailedConnection == nil {
-				return attribute.String(string(attr.NetworkTCPHandshakeRole), string(RoleUnknown))
+			if s.TCPFailedConnection != nil {
+				return attribute.String(string(attr.NetworkTCPHandshakeRole), networkTCPHandshakeRoleStr(s.TCPFailedConnection.Role))
 			}
-			return attribute.String(string(attr.NetworkTCPHandshakeRole), networkTCPHandshakeRoleStr(s.TCPFailedConnection.Role))
+			if s.TCPRtt != nil {
+				return attribute.String(string(attr.NetworkTCPHandshakeRole), networkTCPHandshakeRoleStr(s.TCPRtt.Role))
+			}
+			return attribute.String(string(attr.NetworkTCPHandshakeRole), string(RoleUnknown))
 		}
 
 	default:

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -79,15 +79,32 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features, selector
 		return nil, fmt.Errorf("loading BPF data: %w", err)
 	}
 
+	// UndefinedGroup is intentional: we only need to check NetworkTCPHandshakeRole,
+	// which is a direct metric attribute.
 	attrSel, err := attributes.NewAttrSelector(attributes.UndefinedGroup, selectorCfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating attr selector: %w", err)
 	}
 
-	connRoleEnabled := slices.Contains(attrSel.For(attributes.StatTCPRtt), attr.NetworkTCPHandshakeRole) ||
+	// OR across both metrics: a single shared probe writes sock_role for both consumers,
+	// so the probe is needed if either metric has the attribute enabled.
+	connRoleAttrSelected := slices.Contains(attrSel.For(attributes.StatTCPRtt), attr.NetworkTCPHandshakeRole) ||
 		slices.Contains(attrSel.For(attributes.StatTCPFailedConnections), attr.NetworkTCPHandshakeRole)
+	connRoleUsed := (features.StatsTCPFailedConnections() || features.StatsTCPRtt()) && connRoleAttrSelected
 
-	fixupSpec(spec, features, connRoleEnabled)
+	var toDisable []string
+	if !features.StatsTCPFailedConnections() {
+		toDisable = append(toDisable, progObiTpInetSockSetStateTCPFailedConn)
+	}
+	if !connRoleUsed {
+		toDisable = append(toDisable, progObiTpInetSockSetStateConnRole)
+	}
+	if !features.StatsTCPRtt() {
+		toDisable = append(toDisable, progObiKprobeTCPCloseSrtt)
+	}
+	if err := fixupSpec(spec, toDisable); err != nil {
+		return nil, fmt.Errorf("fixing up BPF spec: %w", err)
+	}
 
 	ebpfconvenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor)
 
@@ -137,7 +154,7 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features, selector
 		{
 			name:    TracepointInetSockSetState,
 			program: objects.ObiTpInetSockSetStateConnRole,
-			enabled: (features.StatsTCPFailedConnections() || features.StatsTCPRtt()) && connRoleEnabled,
+			enabled: connRoleUsed,
 		},
 	} {
 		if !t.enabled {
@@ -193,38 +210,28 @@ func (m *StatsFetcher) DebugEventsMap() *ebpf.Map {
 
 // fixupSpec replaces disabled programs with no-op stubs before loading,
 // preventing unused eBPF code from being loaded into the kernel.
-func fixupSpec(spec *ebpf.CollectionSpec, features *export.Features, connRoleEnabled bool) {
-	if !features.StatsTCPFailedConnections() {
-		spec.Programs[progObiTpInetSockSetStateTCPFailedConn] = &ebpf.ProgramSpec{
-			Name: "stats_dummy_tp",
-			Type: ebpf.TracePoint,
-			Instructions: asm.Instructions{
-				asm.Mov.Imm(asm.R0, 0),
-				asm.Return(),
-			},
-			License: "Dual MIT/GPL",
+func fixupSpec(spec *ebpf.CollectionSpec, toDisable []string) error {
+	for _, name := range toDisable {
+		prog := spec.Programs[name]
+		if prog == nil {
+			return fmt.Errorf("unknown program name %s", name)
+		}
+		progType := prog.Type
+		var stubName string
+		switch progType {
+		case ebpf.TracePoint:
+			stubName = "stats_dummy_tp"
+		case ebpf.Kprobe:
+			stubName = "stats_dummy_kp"
+		default:
+			return fmt.Errorf("unsupported program type %v for %s", progType, name)
+		}
+		spec.Programs[name] = &ebpf.ProgramSpec{
+			Name:         stubName,
+			Type:         progType,
+			Instructions: asm.Instructions{asm.Mov.Imm(asm.R0, 0), asm.Return()},
+			License:      "Dual MIT/GPL",
 		}
 	}
-	if !(features.StatsTCPFailedConnections() || features.StatsTCPRtt()) || !connRoleEnabled {
-		spec.Programs[progObiTpInetSockSetStateConnRole] = &ebpf.ProgramSpec{
-			Name: "stats_dummy_tp",
-			Type: ebpf.TracePoint,
-			Instructions: asm.Instructions{
-				asm.Mov.Imm(asm.R0, 0),
-				asm.Return(),
-			},
-			License: "Dual MIT/GPL",
-		}
-	}
-	if !features.StatsTCPRtt() {
-		spec.Programs[progObiKprobeTCPCloseSrtt] = &ebpf.ProgramSpec{
-			Name: "stats_dummy_kp",
-			Type: ebpf.Kprobe,
-			Instructions: asm.Instructions{
-				asm.Mov.Imm(asm.R0, 0),
-				asm.Return(),
-			},
-			License: "Dual MIT/GPL",
-		}
-	}
+	return nil
 }

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -216,19 +216,9 @@ func fixupSpec(spec *ebpf.CollectionSpec, toDisable []string) error {
 		if prog == nil {
 			return fmt.Errorf("unknown program name %s", name)
 		}
-		progType := prog.Type
-		var stubName string
-		switch progType {
-		case ebpf.TracePoint:
-			stubName = "stats_dummy_tp"
-		case ebpf.Kprobe:
-			stubName = "stats_dummy_kp"
-		default:
-			return fmt.Errorf("unsupported program type %v for %s", progType, name)
-		}
 		spec.Programs[name] = &ebpf.ProgramSpec{
-			Name:         stubName,
-			Type:         progType,
+			Name:         "stats_dummy",
+			Type:         prog.Type,
 			Instructions: asm.Instructions{asm.Mov.Imm(asm.R0, 0), asm.Return()},
 			License:      "Dual MIT/GPL",
 		}

--- a/pkg/internal/statsolly/ebpf/stats_tracer.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 
@@ -20,6 +21,8 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	ebpfconvenience "go.opentelemetry.io/obi/pkg/internal/ebpf/convenience"
 )
 
@@ -36,8 +39,9 @@ type probe struct {
 
 // Program names
 const (
-	progObiKprobeTCPCloseSrtt         = "obi_kprobe_tcp_close_srtt"
-	progObiTracepointInetSockSetState = "obi_tracepoint_inet_sock_set_state"
+	progObiKprobeTCPCloseSrtt              = "obi_kprobe_tcp_close_srtt"
+	progObiTpInetSockSetStateConnRole      = "obi_tp_inet_sock_set_state_conn_role"
+	progObiTpInetSockSetStateTCPFailedConn = "obi_tp_inet_sock_set_state_tcp_failed_conn"
 )
 
 // Hook point names, grouped by attach type.
@@ -62,7 +66,7 @@ func tlog() *slog.Logger {
 	return slog.With("component", "ebpf.StatFetcher")
 }
 
-func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsFetcher, error) {
+func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features, selectorCfg *attributes.SelectorConfig) (*StatsFetcher, error) {
 	tlog := tlog()
 	if err := rlimit.RemoveMemlock(); err != nil {
 		tlog.Warn("can't remove mem lock. The agent could not be able to start eBPF programs",
@@ -75,7 +79,15 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 		return nil, fmt.Errorf("loading BPF data: %w", err)
 	}
 
-	fixupSpec(spec, features)
+	attrSel, err := attributes.NewAttrSelector(attributes.UndefinedGroup, selectorCfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating attr selector: %w", err)
+	}
+
+	connRoleEnabled := slices.Contains(attrSel.For(attributes.StatTCPRtt), attr.NetworkTCPHandshakeRole) ||
+		slices.Contains(attrSel.For(attributes.StatTCPFailedConnections), attr.NetworkTCPHandshakeRole)
+
+	fixupSpec(spec, features, connRoleEnabled)
 
 	ebpfconvenience.SetupMapSizes(spec, cfg.MapsConfig.GlobalScaleFactor)
 
@@ -110,11 +122,22 @@ func NewStatsFetcher(cfg *config.EBPFTracer, features *export.Features) (*StatsF
 	}
 
 	// tracepoints
+	// ObiTpInetSockSetStateTcpFailedConn (or any other probes that use role)
+	// must be attached before ObiTpInetSockSetStateConnRole.
+	// Both attach to the same tracepoint and BPF programs run FIFO:
+	// the probes read sock_role first, conn_role deletes it after.
+	// Swapping the order would cause tcp_failed_conn or any other probes
+	// to see NULL on the same TCP_CLOSE event that conn_role is cleaning up.
 	for _, t := range []probe{
 		{
 			name:    TracepointInetSockSetState,
-			program: objects.ObiTracepointInetSockSetState,
+			program: objects.ObiTpInetSockSetStateTcpFailedConn,
 			enabled: features.StatsTCPFailedConnections(),
+		},
+		{
+			name:    TracepointInetSockSetState,
+			program: objects.ObiTpInetSockSetStateConnRole,
+			enabled: (features.StatsTCPFailedConnections() || features.StatsTCPRtt()) && connRoleEnabled,
 		},
 	} {
 		if !t.enabled {
@@ -170,9 +193,20 @@ func (m *StatsFetcher) DebugEventsMap() *ebpf.Map {
 
 // fixupSpec replaces disabled programs with no-op stubs before loading,
 // preventing unused eBPF code from being loaded into the kernel.
-func fixupSpec(spec *ebpf.CollectionSpec, features *export.Features) {
+func fixupSpec(spec *ebpf.CollectionSpec, features *export.Features, connRoleEnabled bool) {
 	if !features.StatsTCPFailedConnections() {
-		spec.Programs[progObiTracepointInetSockSetState] = &ebpf.ProgramSpec{
+		spec.Programs[progObiTpInetSockSetStateTCPFailedConn] = &ebpf.ProgramSpec{
+			Name: "stats_dummy_tp",
+			Type: ebpf.TracePoint,
+			Instructions: asm.Instructions{
+				asm.Mov.Imm(asm.R0, 0),
+				asm.Return(),
+			},
+			License: "Dual MIT/GPL",
+		}
+	}
+	if !(features.StatsTCPFailedConnections() || features.StatsTCPRtt()) || !connRoleEnabled {
+		spec.Programs[progObiTpInetSockSetStateConnRole] = &ebpf.ProgramSpec{
 			Name: "stats_dummy_tp",
 			Type: ebpf.TracePoint,
 			Instructions: asm.Instructions{

--- a/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
 )
 
 type StatsFetcher struct{}
@@ -45,7 +46,7 @@ type StatsTCPFailedConnection struct {
 	}
 }
 
-func NewStatsFetcher(_ *config.EBPFTracer, _ *export.Features) (*StatsFetcher, error) {
+func NewStatsFetcher(_ *config.EBPFTracer, _ *export.Features, _ *attributes.SelectorConfig) (*StatsFetcher, error) {
 	return nil, nil
 }
 

--- a/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_nonlinux.go
@@ -20,7 +20,8 @@ type StatsFetcher struct{}
 type StatsTCPRtt struct {
 	_      structs.HostLayout
 	Flags  uint8
-	Pad    [3]uint8
+	Role   uint8
+	Pad    [2]uint8
 	SrttUs uint32
 	Conn   struct {
 		_      structs.HostLayout

--- a/pkg/internal/statsolly/ebpf/stats_tracer_test.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_test.go
@@ -21,8 +21,8 @@ func TestFixupSpec(t *testing.T) {
 	makeSpec := func() *ebpf.CollectionSpec {
 		return &ebpf.CollectionSpec{
 			Programs: map[string]*ebpf.ProgramSpec{
-				progObiKprobeTCPCloseSrtt:         {Name: origKpName, Type: ebpf.Kprobe},
-				progObiTracepointInetSockSetState: {Name: origTpName, Type: ebpf.TracePoint},
+				progObiKprobeTCPCloseSrtt:              {Name: origKpName, Type: ebpf.Kprobe},
+				progObiTpInetSockSetStateTCPFailedConn: {Name: origTpName, Type: ebpf.TracePoint},
 			},
 		}
 	}
@@ -62,11 +62,11 @@ func TestFixupSpec(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			spec := makeSpec()
-			fixupSpec(spec, &tc.features)
+			fixupSpec(spec, &tc.features, false)
 			if got := spec.Programs[progObiKprobeTCPCloseSrtt].Name; got != tc.wantKpName {
 				t.Errorf("kprobe program: got %q, want %q", got, tc.wantKpName)
 			}
-			if got := spec.Programs[progObiTracepointInetSockSetState].Name; got != tc.wantTpName {
+			if got := spec.Programs[progObiTpInetSockSetStateTCPFailedConn].Name; got != tc.wantTpName {
 				t.Errorf("tracepoint program: got %q, want %q", got, tc.wantTpName)
 			}
 		})

--- a/pkg/internal/statsolly/ebpf/stats_tracer_test.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_test.go
@@ -45,7 +45,7 @@ func TestFixupSpec(t *testing.T) {
 			name:      "disable kprobe only",
 			toDisable: []string{progObiKprobeTCPCloseSrtt},
 			want: map[string]string{
-				progObiKprobeTCPCloseSrtt:              "stats_dummy_kp",
+				progObiKprobeTCPCloseSrtt:              "stats_dummy",
 				progObiTpInetSockSetStateTCPFailedConn: origTpName,
 				progObiTpInetSockSetStateConnRole:      origConnRoleName,
 			},
@@ -55,7 +55,7 @@ func TestFixupSpec(t *testing.T) {
 			toDisable: []string{progObiTpInetSockSetStateTCPFailedConn},
 			want: map[string]string{
 				progObiKprobeTCPCloseSrtt:              origKpName,
-				progObiTpInetSockSetStateTCPFailedConn: "stats_dummy_tp",
+				progObiTpInetSockSetStateTCPFailedConn: "stats_dummy",
 				progObiTpInetSockSetStateConnRole:      origConnRoleName,
 			},
 		},
@@ -65,7 +65,7 @@ func TestFixupSpec(t *testing.T) {
 			want: map[string]string{
 				progObiKprobeTCPCloseSrtt:              origKpName,
 				progObiTpInetSockSetStateTCPFailedConn: origTpName,
-				progObiTpInetSockSetStateConnRole:      "stats_dummy_tp",
+				progObiTpInetSockSetStateConnRole:      "stats_dummy",
 			},
 		},
 		{
@@ -76,9 +76,9 @@ func TestFixupSpec(t *testing.T) {
 				progObiTpInetSockSetStateConnRole,
 			},
 			want: map[string]string{
-				progObiKprobeTCPCloseSrtt:              "stats_dummy_kp",
-				progObiTpInetSockSetStateTCPFailedConn: "stats_dummy_tp",
-				progObiTpInetSockSetStateConnRole:      "stats_dummy_tp",
+				progObiKprobeTCPCloseSrtt:              "stats_dummy",
+				progObiTpInetSockSetStateTCPFailedConn: "stats_dummy",
+				progObiTpInetSockSetStateConnRole:      "stats_dummy",
 			},
 		},
 	}

--- a/pkg/internal/statsolly/ebpf/stats_tracer_test.go
+++ b/pkg/internal/statsolly/ebpf/stats_tracer_test.go
@@ -10,66 +10,102 @@ import (
 	"testing"
 
 	"github.com/cilium/ebpf"
-
-	"go.opentelemetry.io/obi/pkg/export"
 )
 
 func TestFixupSpec(t *testing.T) {
 	const origKpName = "real_kp"
 	const origTpName = "real_tp"
+	const origConnRoleName = "real_conn_role"
 
 	makeSpec := func() *ebpf.CollectionSpec {
 		return &ebpf.CollectionSpec{
 			Programs: map[string]*ebpf.ProgramSpec{
 				progObiKprobeTCPCloseSrtt:              {Name: origKpName, Type: ebpf.Kprobe},
 				progObiTpInetSockSetStateTCPFailedConn: {Name: origTpName, Type: ebpf.TracePoint},
+				progObiTpInetSockSetStateConnRole:      {Name: origConnRoleName, Type: ebpf.TracePoint},
 			},
 		}
 	}
 
 	tests := []struct {
-		name       string
-		features   export.Features
-		wantKpName string
-		wantTpName string
+		name      string
+		toDisable []string
+		want      map[string]string
 	}{
 		{
-			name:       "all disabled",
-			features:   export.Features(0),
-			wantKpName: "stats_dummy_kp",
-			wantTpName: "stats_dummy_tp",
+			name:      "disable nothing",
+			toDisable: nil,
+			want: map[string]string{
+				progObiKprobeTCPCloseSrtt:              origKpName,
+				progObiTpInetSockSetStateTCPFailedConn: origTpName,
+				progObiTpInetSockSetStateConnRole:      origConnRoleName,
+			},
 		},
 		{
-			name:       "rtt only",
-			features:   export.FeatureStatsTCPRtt,
-			wantKpName: origKpName,
-			wantTpName: "stats_dummy_tp",
+			name:      "disable kprobe only",
+			toDisable: []string{progObiKprobeTCPCloseSrtt},
+			want: map[string]string{
+				progObiKprobeTCPCloseSrtt:              "stats_dummy_kp",
+				progObiTpInetSockSetStateTCPFailedConn: origTpName,
+				progObiTpInetSockSetStateConnRole:      origConnRoleName,
+			},
 		},
 		{
-			name:       "failed connections only",
-			features:   export.FeatureStatsTCPFailedConnections,
-			wantKpName: "stats_dummy_kp",
-			wantTpName: origTpName,
+			name:      "disable failed conn only",
+			toDisable: []string{progObiTpInetSockSetStateTCPFailedConn},
+			want: map[string]string{
+				progObiKprobeTCPCloseSrtt:              origKpName,
+				progObiTpInetSockSetStateTCPFailedConn: "stats_dummy_tp",
+				progObiTpInetSockSetStateConnRole:      origConnRoleName,
+			},
 		},
 		{
-			name:       "all enabled",
-			features:   export.FeatureStats,
-			wantKpName: origKpName,
-			wantTpName: origTpName,
+			name:      "disable conn role only",
+			toDisable: []string{progObiTpInetSockSetStateConnRole},
+			want: map[string]string{
+				progObiKprobeTCPCloseSrtt:              origKpName,
+				progObiTpInetSockSetStateTCPFailedConn: origTpName,
+				progObiTpInetSockSetStateConnRole:      "stats_dummy_tp",
+			},
+		},
+		{
+			name: "disable all",
+			toDisable: []string{
+				progObiKprobeTCPCloseSrtt,
+				progObiTpInetSockSetStateTCPFailedConn,
+				progObiTpInetSockSetStateConnRole,
+			},
+			want: map[string]string{
+				progObiKprobeTCPCloseSrtt:              "stats_dummy_kp",
+				progObiTpInetSockSetStateTCPFailedConn: "stats_dummy_tp",
+				progObiTpInetSockSetStateConnRole:      "stats_dummy_tp",
+			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			spec := makeSpec()
-			fixupSpec(spec, &tc.features, false)
-			if got := spec.Programs[progObiKprobeTCPCloseSrtt].Name; got != tc.wantKpName {
-				t.Errorf("kprobe program: got %q, want %q", got, tc.wantKpName)
+			if err := fixupSpec(spec, tc.toDisable); err != nil {
+				t.Fatalf("fixupSpec: %v", err)
 			}
-			if got := spec.Programs[progObiTpInetSockSetStateTCPFailedConn].Name; got != tc.wantTpName {
-				t.Errorf("tracepoint program: got %q, want %q", got, tc.wantTpName)
+			for prog, wantName := range tc.want {
+				if got := spec.Programs[prog].Name; got != wantName {
+					t.Errorf("program %s: got %q, want %q", prog, got, wantName)
+				}
 			}
 		})
+	}
+}
+
+func TestFixupSpecUnknownProgram(t *testing.T) {
+	spec := &ebpf.CollectionSpec{
+		Programs: map[string]*ebpf.ProgramSpec{
+			progObiKprobeTCPCloseSrtt: {Name: "real_kp", Type: ebpf.Kprobe},
+		},
+	}
+	if err := fixupSpec(spec, []string{"nonexistent_prog"}); err == nil {
+		t.Error("expected error for unknown program name, got nil")
 	}
 }
 

--- a/pkg/internal/statsolly/stats/tracer_ringbuf.go
+++ b/pkg/internal/statsolly/stats/tracer_ringbuf.go
@@ -91,6 +91,7 @@ func readTCPRttIntoStat(record *ringbuf.Record) (ebpf.Stat, error) {
 		Type: ebpf.StatTypeTCPRtt,
 		TCPRtt: &ebpf.TCPRtt{
 			SrttUs: event.SrttUs,
+			Role:   event.Role,
 		},
 		CommonAttrs: pipe.CommonAttrs{
 			SrcAddr: srcAddr,

--- a/pkg/statsolly/agent/agent.go
+++ b/pkg/statsolly/agent/agent.go
@@ -16,6 +16,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/logger"
 	"go.opentelemetry.io/obi/pkg/internal/statsolly/ebpf"
 	stats "go.opentelemetry.io/obi/pkg/internal/statsolly/stats"
@@ -101,7 +102,11 @@ func StatsAgent(ctxInfo *global.ContextInfo, cfg *obi.Config) (*Stats, error) {
 	}
 	alog.Debug("agent IP: " + agentIP.String())
 
-	statsFetcher, err = newFetcher(&cfg.EBPF, &cfg.Metrics.Features)
+	selectorCfg := &attributes.SelectorConfig{
+		SelectionCfg:            cfg.Attributes.Select,
+		ExtraGroupAttributesCfg: cfg.Attributes.ExtraGroupAttributes,
+	}
+	statsFetcher, err = newFetcher(&cfg.EBPF, &cfg.Metrics.Features, selectorCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +114,8 @@ func StatsAgent(ctxInfo *global.ContextInfo, cfg *obi.Config) (*Stats, error) {
 	return statsAgent(ctxInfo, cfg, statsFetcher, agentIP)
 }
 
-func newFetcher(cfg *config.EBPFTracer, features *export.Features) (ebpFetcher, error) {
-	return ebpf.NewStatsFetcher(cfg, features)
+func newFetcher(cfg *config.EBPFTracer, features *export.Features, selectorCfg *attributes.SelectorConfig) (ebpFetcher, error) {
+	return ebpf.NewStatsFetcher(cfg, features, selectorCfg)
 }
 
 // statsAgent is a private constructor with injectable dependencies, usable for tests


### PR DESCRIPTION
## Summary

This PR extends the existing TCP handshake role tracking (already available on `tcp.failed_connections` #2009) to the `tcp.rtt` metric.

Now the `inet_sock_set_state` tracepoint is split into two programs:
- `obi_tp_inet_sock_set_state_conn_role`: sole owner of the `sock_role` map, writes role on `SYN`, deletes on `TCP_CLOSE`
- `obi_tp_inet_sock_set_state_tcp_failed_conn`: reads role before `conn_role` cleans it up (attachment order is **FIFO**)

The `conn_role` probe is only loaded when at least one metric has the attribute enabled.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
