### PR TITLE
build: pin renovate vm docker base

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -142,6 +142,13 @@
       "enabled": false
     },
     {
+      "description": "Disable Docker updates for the VM test runtime base image",
+      "matchFileNames": ["internal/test/vm/Dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["alpine"],
+      "enabled": false
+    },
+    {
       "description": "Block Spring Boot major upgrades for JDK8 example (Spring Boot 3+ requires JDK 17+)",
       "matchFileNames": ["internal/test/integration/components/java_tls/jdk8/pom.xml"],
       "matchManagers": ["maven"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -144,8 +144,9 @@
     {
       "description": "Disable Docker updates for the VM test runtime base image",
       "matchFileNames": ["internal/test/vm/Dockerfile"],
+      "matchManagers": ["dockerfile"],
       "matchDatasources": ["docker"],
-      "matchPackageNames": ["alpine"],
+      "matchPackageNames": ["alpine", "library/alpine", "docker.io/library/alpine"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Disable Renovate Docker updates for `internal/test/vm/Dockerfile` when the package is `alpine`. Preserve the VM test runtime base that avoids the nested Docker/runc procfs regression: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/e92b0c2dd4d88b90d28b7b706eacbac2fabd2623/internal/test/vm/Dockerfile#L15-L18