### PR TITLE
Release v0.9.0

### DIFF
--- a/internal/test/integration/components/go_simple_grpc/go.mod
+++ b/internal/test/integration/components/go_simple_grpc/go.mod
@@ -2,11 +2,13 @@ module go.opentelemetry.io/obi/internal/test/integration/components/go_simple_gr
 
 go 1.25.6
 
-require google.golang.org/grpc v1.79.2
+require (
+	golang.org/x/sys v0.39.0
+	google.golang.org/grpc v1.79.2
+)
 
 require (
 	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect

--- a/pkg/ebpf/common/mongo_detect_transform_test.go
+++ b/pkg/ebpf/common/mongo_detect_transform_test.go
@@ -474,7 +474,7 @@ func TestParseOpMessageShortBufferReturnsError(t *testing.T) {
 	request, moreToCome, err := parseOpMessage(buf, 0, false, nil)
 
 	require.Error(t, err)
-	assert.EqualError(t, err, "packet too short for MongoDB flag bits")
+	require.EqualError(t, err, "packet too short for MongoDB flag bits")
 	assert.Nil(t, request)
 	assert.False(t, moreToCome)
 }
@@ -486,7 +486,7 @@ func TestParseSectionsDocSequenceShortReturnsError(t *testing.T) {
 	sections, err := parseSections(buf)
 
 	require.Error(t, err)
-	assert.EqualError(t, err, "not enough data for section[1] length")
+	require.EqualError(t, err, "not enough data for section[1] length")
 	assert.Nil(t, sections)
 }
 
@@ -496,7 +496,7 @@ func TestParseFirstFieldTypeAssertionReturnsError(t *testing.T) {
 	comm, collection, err := parseFirstField(field)
 
 	require.Error(t, err)
-	assert.EqualError(t, err, "MongoDB command 'insert' has non-string collection type int32")
+	require.EqualError(t, err, "MongoDB command 'insert' has non-string collection type int32")
 	assert.Empty(t, comm)
 	assert.Empty(t, collection)
 }

--- a/pkg/ebpf/common/sql_detect_postgres_test.go
+++ b/pkg/ebpf/common/sql_detect_postgres_test.go
@@ -178,8 +178,8 @@ func TestParsePostgresBindNames(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name:   "missing statement terminator",
-			data:   []byte("portal\x00stmt-without-nul"),
+			name:       "missing statement terminator",
+			data:       []byte("portal\x00stmt-without-nul"),
 			wantPortal: "portal",
 			wantStmt:   "stmt-without-nul",
 			wantOK:     true,

--- a/pkg/export/prom/prom_bpf_test.go
+++ b/pkg/export/prom/prom_bpf_test.go
@@ -86,18 +86,24 @@ func TestBPFMetricsCollectsInternalMetricsForPrometheusReporter(t *testing.T) {
 	})
 
 	newInternalBPFCollectorFn = func(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *perapp.MetricsConfig) *BPFCollector {
+		var collected bool
 		return &BPFCollector{
 			promCfg:         cfg,
 			commonCfg:       mpCfg,
 			internalMetrics: ctxInfo.Metrics,
 			ctxInfo:         ctxInfo,
 			probeMetrics: func() []ProbeMetrics {
+				count := uint64(0)
+				if !collected {
+					count = 3
+					collected = true
+				}
 				return []ProbeMetrics{{
 					probeType: "kprobe",
 					probeName: "tcp_connect",
 					probeID:   "7",
 					latency:   0.25,
-					count:     3,
+					count:     count,
 				}}
 			},
 			mapMetrics: func() []BpfMapMetrics {

--- a/pkg/internal/procs/proclang_linux_test.go
+++ b/pkg/internal/procs/proclang_linux_test.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package procs
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/internal/fastelf"
+)
+
+func TestMatchExeSymbols_InvalidStringOffset(t *testing.T) {
+	const symSize = 24
+
+	data := make([]byte, symSize+4)
+	binary.LittleEndian.PutUint32(data[0:4], 128)
+	data[4] = 0x02
+	binary.LittleEndian.PutUint64(data[8:16], 1)
+	binary.LittleEndian.PutUint64(data[16:24], 1)
+	copy(data[symSize:], []byte("x\x00"))
+
+	ctx := &fastelf.ElfContext{
+		Data: data,
+		Sections: []*fastelf.Elf64_Shdr{
+			{
+				Type:    fastelf.SHT_SYMTAB,
+				Link:    1,
+				Offset:  0,
+				Size:    symSize,
+				Entsize: symSize,
+			},
+			{
+				Offset: symSize,
+			},
+		},
+	}
+
+	assert.Equal(t, svc.InstrumentableGeneric, matchExeSymbols(ctx))
+}

--- a/pkg/internal/procs/proclang_test.go
+++ b/pkg/internal/procs/proclang_test.go
@@ -4,13 +4,11 @@
 package procs
 
 import (
-	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
-	"go.opentelemetry.io/obi/pkg/internal/fastelf"
 )
 
 func TestHighCertaintyModuleDetection(t *testing.T) {
@@ -79,33 +77,4 @@ func TestLastResortDetection(t *testing.T) {
 	assert.Equal(t, svc.InstrumentableGeneric, instrumentableLastResort("libstdc++"))
 	assert.Equal(t, svc.InstrumentableGeneric, instrumentableLastResort("libc++"))
 	assert.Equal(t, svc.InstrumentableGeneric, instrumentableLastResort("/usr/lib/libsomething.so"))
-}
-
-func TestMatchExeSymbols_InvalidStringOffset(t *testing.T) {
-	const symSize = 24
-
-	data := make([]byte, symSize+4)
-	binary.LittleEndian.PutUint32(data[0:4], 128)
-	data[4] = 0x02
-	binary.LittleEndian.PutUint64(data[8:16], 1)
-	binary.LittleEndian.PutUint64(data[16:24], 1)
-	copy(data[symSize:], []byte("x\x00"))
-
-	ctx := &fastelf.ElfContext{
-		Data: data,
-		Sections: []*fastelf.Elf64_Shdr{
-			{
-				Type:    fastelf.SHT_SYMTAB,
-				Link:    1,
-				Offset:  0,
-				Size:    symSize,
-				Entsize: symSize,
-			},
-			{
-				Offset: symSize,
-			},
-		},
-	}
-
-	assert.Equal(t, svc.InstrumentableGeneric, matchExeSymbols(ctx))
 }

--- a/scripts/generate-dir-matrix.sh
+++ b/scripts/generate-dir-matrix.sh
@@ -28,14 +28,14 @@ while IFS= read -r -d '' test_file; do
         seen_dirs["$dir"]=1
         test_dirs+=("$dir")
     fi
-done < <(find "$SEARCH_DIR" -name "*_test.go" -print0 | sort -z)
+done < <(find "$SEARCH_DIR" -name "*_test.go" -print0 | LC_ALL=C sort -z)
 
 if [ "${#test_dirs[@]}" -eq 0 ]; then
     echo "ERROR: No test directories found in $SEARCH_DIR" >&2
     exit 1
 fi
 
-mapfile -t sorted_dirs < <(printf '%s\n' "${test_dirs[@]}" | sort)
+mapfile -t sorted_dirs < <(printf '%s\n' "${test_dirs[@]}" | LC_ALL=C sort)
 
 DIR_COUNT="${#sorted_dirs[@]}"
 echo "Total test packages: $DIR_COUNT" >&2

--- a/versions.yaml
+++ b/versions.yaml
@@ -57,6 +57,7 @@ excluded-modules:
   - go.opentelemetry.io/obi/internal/test/oats/kafka
   - go.opentelemetry.io/obi/internal/test/oats/memcached
   - go.opentelemetry.io/obi/internal/test/oats/mongo
+  - go.opentelemetry.io/obi/internal/test/oats/nats
   - go.opentelemetry.io/obi/internal/test/oats/redis
   - go.opentelemetry.io/obi/internal/test/oats/sql
   - go.opentelemetry.io/obi/internal/tools

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   obi:
-    version: v0.8.0
+    version: v0.9.0
     modules:
       - go.opentelemetry.io/obi
 excluded-modules:


### PR DESCRIPTION
`v0.9.0` is a minor release with expanded protocol and AI instrumentation coverage, broader metrics and configuration controls, significant runtime and exporter fixes, and a set of security hardening changes merged ahead of the release.

### New instrumentation and extraction coverage

- Added support for NATS, AMQP 1.0, and MSSQL protocol detection and extraction. ([#1712](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1712), [#1921](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1921), [#1533](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1533))
- Added embedding, rerank, Qwen, and MCP extraction support, and expanded OpenAI-related HTTP extraction coverage. ([#1885](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1885), [#2056](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2056), [#1892](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1892), [#1867](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1867))
- Added Couchbase full query capture in `db.query.text`. ([#1824](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1824))
- Added Go generic TLS support. ([#1980](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1980))
- Added TCP failed connection metrics and later added the `network.tcp.handshake.role` attribute. ([#1825](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1825), [#2009](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2009))
- Added debug events to `netolly` and `statsolly` userspace. ([#1884](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1884))

### Security hardening

- Hardened Java TLS ioctl handling against unsafe user-space reads and oversized payloads, added validation around payload buffers, and added dedicated adversarial integration coverage. ([`4db1bde`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/4db1bde1724db9aa48268010b3c23135b29fad05))
- Guarded PostgreSQL `BIND` parsing against malformed and truncated payloads that could previously panic protocol processing. ([`8ac96fa`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/8ac96fa5a8840d2b141a5edd857e6228a1fc04e5))
- Added overflow, bounds, and type checks to Memcached and MongoDB parsing so malformed traffic is rejected safely instead of triggering unsafe parsing paths. ([`2374e15`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/2374e15e83e47bfcf976ccb180b395f4c99ad589), [`376ee7a`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/376ee7aca5b6a06dcabda4c4af0fa6e7403fe530))
- Clamped log enricher `writev` reads and hardened fast ELF parsing to avoid incorrect reads or panics on malformed inputs and binaries. ([`bf8060c`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/bf8060ce5276eae71081b7e96226950c17892453), [`735af17`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/735af170d7cb0c0ca20affd5d6943c440662ef58))
- Clamped the fallback message buffer size on CPU mismatch in `k_tracer`. ([`5d375cbc`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/5d375cbc8d5f5187c5f8bf78e4f78265c0a262d5))
- Hardened internal metrics handling and added new internal metrics coverage. ([`6be66f38`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/6be66f386808ca8ab549293d2de920db92aa744b))
- Removed committed Rails credentials and updated `github.com/jackc/pgx/v5` to a security-fixed version. ([#1929](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1929), [#1900](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1900))

### Runtime, tracing, and protocol fixes

- Fixed shared PID namespace disambiguation, preserved multiple PID tracer types, and fixed signed length handling in the `netFdReadRet` uprobe. ([#1875](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1875), [#1899](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1899), [#1880](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1880))
- Fixed race conditions and shutdown behavior in `netolly`, including packet stats handling, port guesser protocol inference, runner-stop shutdown, and false-positive TCP failed connection events. ([#1873](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1873), [#1896](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1896), [#1909](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1909), [#2000](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2000), [#1919](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1919))
- Fixed `appolly` selector and export-mode behavior, including `cmd_args`-only regex selectors, PID match preservation, proc stat buffer race handling, and idempotent export-mode enablement. ([#1910](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1910), [#1911](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1911), [#1995](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1995), [#1996](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1996))
- Fixed kube and cache handling, including kube reconnect initial interval logic and `k8s-cache` event timestamp refresh and informer timeout enforcement. ([#1907](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1907), [#2001](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2001), [#1934](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1934))
- Fixed `traceparent` parsing for large HTTP requests, restored full URL path reporting, improved service name resolution, and delayed SSL request cleanup until HTTP processing completes. ([#1977](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1977), [#2069](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2069), [#2065](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2065), [#1952](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1952))
- Fixed `iter_tcp`, handled unknown-protocol TCP large buffers, and improved Go tracer offset handling and constant naming. ([#1981](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1981), [#1998](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1998), [#2002](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2002), [#2004](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2004), [#2047](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2047), [#2054](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2054), [#2055](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2055))
- Added shared context for async Python and extracted a larger buffer from Java. ([#1940](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1940), [#1944](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1944))
- Fixed buggy register spill behavior. ([#1945](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1945))
- Demoted `Error attaching tcx` to a warning. ([#1895](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1895))
- Fixed the duplicate colon in the `ExportModes` error message. ([#1936](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1936))
- Fixed randomly failing Qwen behavior. ([#1915](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1915))
- Rejected malformed service responses in the generator. ([#1912](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1912))

### Metrics, exporters, and configuration

- Added `BatchMaxSize` and `QueueSize` controls. ([#1806](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1806))
- Added configurable OTEL histogram aggregation and Prometheus native histogram settings for better metrics cost and precision control. ([#1966](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1966), [#1968](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1968))
- Restored Prometheus BPF internal metrics and fixed OTEL job and instance attribute keys. ([#1992](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1992), [#1993](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1993))
- Fixed span metric labeling and metric-instance cleanup behavior, and fixed `cloud_host_id` overriding in the Prometheus exporter. ([#1930](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1930), [#1898](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1898), [#1939](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1939))
- Enabled the traces exporter from an override endpoint. ([#1999](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1999))
- Made database error response reporting optional and disabled by default. ([#2066](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2066))
- Generated configuration docs and later defined the OBI telemetry schema registry and improved weaver schema/tooling. ([#1754](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1754), [#1963](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1963), [#2059](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2059))

### Java and process instrumentation updates

- Fixed Java agent injection, skipped `$$Lambda` classes during agent loading, added multi-architecture Java agent build support, and restored non-fatal startup when the embedded Java agent is missing. ([#1894](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1894), [#1878](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1878), [#1931](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1931), [#1991](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1991))
- Fixed a queue leak in the Java agent `CappedConcurrentHashMap`, replaced it with a ring-buffer-backed implementation, and added concurrency tests and a benchmark. ([`32442596`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/32442596038ce2c2690438157282b101763b4c54))
- Fixed Go 1.26 symbol resolution for binaries without debug info. ([#1851](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1851))

### Performance and validation improvements

- Improved ring buffer throughput by splitting the reader and parser into separate goroutines and reducing mutex contention. ([#1975](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1975))
- Skipped loading unused eBPF programs when StatsO11y features are disabled. ([#2058](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2058))
- Added integration coverage for Go MQTT and expanded integration coverage around Java TLS hardening and log enricher regressions. ([#2060](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2060), [`4db1bde`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/4db1bde1724db9aa48268010b3c23135b29fad05), [`bf8060c`](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/bf8060ce5276eae71081b7e96226950c17892453))

### Build, CI, tests, and tooling

- Added `bpf2go` as a dependency of `make generate/all`, fixed the `statsolly` generate target, and added `nativeOnly` to additional make targets. ([#1864](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1864), [#1932](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1932), [#1953](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1953))
- Updated major Go dependencies and notices handling, including containerized notices generation for amd64 and arm64. ([#1887](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1887), [#1888](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1888))
- Bumped `dockertest` to v4 and fixed Prometheus unit tests. ([#1916](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1916), [#1942](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1942))
- Added a lint analyzer to catch `CollectT` misuse and fixed existing tests to use `CollectT` correctly. ([#1857](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1857), [#1855](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1855))
- Improved CI and test reporting by consolidating supervisor PR comments, adding daily test reporting, grouping similar daily-report failures, hardening the OATS test matrix, bounding `compose.Close()`, and reducing scrape interval during CI runs. ([#1856](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1856), [#1807](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1807), [#1972](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1972), [#1954](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1954), [#1949](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1949), [#1948](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1948))
- Updated build toolchains and CI wiring, including bumps to Go 1.25.9 and the `obi-generator` base image, and a fix for workflow line continuation. ([#2011](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2011), [#2010](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2010), [#1997](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1997))

### Docs and project maintenance

- Generated NGINX-Rails-SQL TLS certificates at runtime, documented excluded OTEL-instrumented services, added NetO11y/AppO11y/StatsO11y metrics docs, and updated JNA references to JNI. ([#1874](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1874), [#1983](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1983), [#1959](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1959), [#2089](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2089))
- Added issue templates, stale workflow, and component auto-labeler. ([#1852](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1852))
- Added human-managed renovate policy and fixture maintenance updates, and promoted Rafael Roquetto to maintainer. ([#2062](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2062), [#2074](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2074), [#2075](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2075), [#2063](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2063))

**Full Changelog**: [v0.8.0...ca4b3c3b](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/compare/v0.8.0...ca4b3c3b797bf475e6924a4679d79870eb08c908)