### PR TITLE
refactor(tracing): use explicit sentinel for traceparent position in bpf_strstr_tp_loop

### DIFF
--- a/bpf/common/trace_util.h
+++ b/bpf/common/trace_util.h
@@ -18,7 +18,7 @@ struct callback_ctx {
     u8 _pad[4];
 };
 
-enum { k_tp_pos_not_found = 0xffffffffu };
+enum : u32 { k_tp_pos_not_found = 0xFFFFFFFFU };
 
 static unsigned char *hex = (unsigned char *)"0123456789abcdef";
 static unsigned char *reverse_hex =

--- a/bpf/common/trace_util.h
+++ b/bpf/common/trace_util.h
@@ -18,6 +18,8 @@ struct callback_ctx {
     u8 _pad[4];
 };
 
+enum { k_tp_pos_not_found = 0xffffffffu };
+
 static unsigned char *hex = (unsigned char *)"0123456789abcdef";
 static unsigned char *reverse_hex =
     (unsigned char *)"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
@@ -101,13 +103,13 @@ static __always_inline unsigned char *bpf_strstr_tp_loop(unsigned char *buf, con
         return NULL;
     }
 
-    struct callback_ctx data = {.buf = buf, .pos = 0};
+    struct callback_ctx data = {.buf = buf, .pos = k_tp_pos_not_found};
 
     const u32 nr_loops = (u32)buf_len;
 
     bpf_loop(nr_loops, tp_match, &data, 0);
 
-    if (data.pos) {
+    if (data.pos != k_tp_pos_not_found) {
         return (data.pos > (TRACE_BUF_SIZE - TRACE_PARENT_HEADER_LEN)) ? NULL : &buf[data.pos];
     }
 


### PR DESCRIPTION
## Summary

Refine traceparent detection to support matches at offset 0.

## Description

This PR modifies the bpf_strstr_tp_loop logic to distinguish between a "header not found" state and a match located at the very beginning of the buffer.

Currently, the helper uses 0 as the initial value and checks for success via if (data.pos). This creates an ambiguity where a match occurring at offset 0 is indistinguishable from a "not found" result.

While this offset might not occur in the current HTTP request line parsing context, using a sentinel value (0xffffffff) makes the helper more generic for future cases where a match could occur at the very start of a buffer.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
