### PR TITLE
test(ebpf): add TestToRequestTraceLargeBuffers for large buffer path

### DIFF
--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -501,29 +501,76 @@ func TestHTTPRequestResponseToSpan_OpenAIEmbeddingDetectedByOpenAISpan(t *testin
 	assert.Equal(t, request.EmbeddingOperationName, span.GenAI.OpenAI.OperationName)
 }
 
-func TestToRequestTraceMissingLargeBuffers(t *testing.T) {
-	fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
-	var record BPFHTTPInfo
+func TestToRequestTraceLargeBuffers(t *testing.T) {
+	connInfo := BpfConnectionInfoT{
+		D_port: 1,
+		S_addr: [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 0, 1},
+		D_addr: [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 8, 8, 8, 8},
+	}
+	traceID := [16]uint8{'t', 'r', 'a', 'c', 'e', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '1'}
 
-	record.Type = 1
-	record.ReqMonotimeNs = 123450
-	record.StartMonotimeNs = 123456
-	record.EndMonotimeNs = 789012
-	record.Status = 200
-	record.HasLargeBuffers = 1 // This will trigger the missing large buffers branch
-	record.ConnInfo.D_port = 1
-	record.ConnInfo.S_addr = [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 0, 1}
-	record.ConnInfo.D_addr = [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 8, 8, 8, 8}
-	copy(record.Buf[:], "GET /hello HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	tests := []struct {
+		name         string
+		withLargeBuf bool
+		primaryBuf   string
+		largeRequest string
+		expectedPath string
+	}{
+		{
+			name:         "fallback to primary buffer when large buffer is absent",
+			withLargeBuf: false,
+			primaryBuf:   "GET /hello HTTP/1.1\r\nHost: example.com\r\n\r\n",
+			expectedPath: "/hello",
+		},
+		{
+			name:         "large buffer takes precedence over primary buffer",
+			withLargeBuf: true,
+			primaryBuf:   "GET /short HTTP/1.1\r\n\r\n",
+			largeRequest: "GET /from-large-buffer HTTP/1.1\r\nHost: example.com\r\n\r\n",
+			expectedPath: "/from-large-buffer",
+		},
+	}
 
-	buf := new(bytes.Buffer)
-	err := binary.Write(buf, binary.LittleEndian, &record)
-	require.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+			var record BPFHTTPInfo
 
-	pctx := NewEBPFParseContext(nil, nil, nil)
-	result, _, err := ReadHTTPInfoIntoSpan(pctx, &ringbuf.Record{RawSample: buf.Bytes()}, &fltr)
-	require.NoError(t, err)
+			record.Type = 1
+			record.ReqMonotimeNs = 123450
+			record.StartMonotimeNs = 123456
+			record.EndMonotimeNs = 789012
+			record.Status = 200
+			record.HasLargeBuffers = 1
+			record.ConnInfo = connInfo
+			record.Tp.TraceId = traceID
+			copy(record.Buf[:], tc.primaryBuf)
 
-	require.Equal(t, "/hello", result.Path)
-	require.Equal(t, 200, result.Status)
+			pctx := NewEBPFParseContext(nil, nil, nil)
+
+			if tc.withLargeBuf {
+				lbHdr := TCPLargeBufferHeader{
+					PacketType: packetTypeRequest,
+					Len:        uint32(len(tc.largeRequest)),
+					Action:     largeBufferActionInit,
+					Kind:       uint8(KindLayerApp),
+				}
+				lbHdr.Tp.TraceId = traceID
+				lbHdr.ConnInfo = connInfo
+
+				_, _, err := appendTCPLargeBuffer(pctx, toRingbufRecord(t, lbHdr, tc.largeRequest))
+				require.NoError(t, err)
+			}
+
+			buf := new(bytes.Buffer)
+			err := binary.Write(buf, binary.LittleEndian, &record)
+			require.NoError(t, err)
+
+			result, _, err := ReadHTTPInfoIntoSpan(pctx, &ringbuf.Record{RawSample: buf.Bytes()}, &fltr)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedPath, result.Path)
+			require.Equal(t, 200, result.Status)
+		})
+	}
 }

--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -500,3 +500,30 @@ func TestHTTPRequestResponseToSpan_OpenAIEmbeddingDetectedByOpenAISpan(t *testin
 	require.NotNil(t, span.GenAI.OpenAI, "span.GenAI.OpenAI should be set")
 	assert.Equal(t, request.EmbeddingOperationName, span.GenAI.OpenAI.OperationName)
 }
+
+func TestToRequestTraceMissingLargeBuffers(t *testing.T) {
+	fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+	var record BPFHTTPInfo
+
+	record.Type = 1
+	record.ReqMonotimeNs = 123450
+	record.StartMonotimeNs = 123456
+	record.EndMonotimeNs = 789012
+	record.Status = 200
+	record.HasLargeBuffers = 1 // This will trigger the missing large buffers branch
+	record.ConnInfo.D_port = 1
+	record.ConnInfo.S_addr = [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 0, 1}
+	record.ConnInfo.D_addr = [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 8, 8, 8, 8}
+	copy(record.Buf[:], "GET /hello HTTP/1.1\r\nHost: example.com\r\n\r\n")
+
+	buf := new(bytes.Buffer)
+	err := binary.Write(buf, binary.LittleEndian, &record)
+	require.NoError(t, err)
+
+	pctx := NewEBPFParseContext(nil, nil, nil)
+	result, _, err := ReadHTTPInfoIntoSpan(pctx, &ringbuf.Record{RawSample: buf.Bytes()}, &fltr)
+	require.NoError(t, err)
+
+	require.Equal(t, "/hello", result.Path)
+	require.Equal(t, 200, result.Status)
+}


### PR DESCRIPTION
## Summary

Add unit test for HTTP tracing with missing large buffers.

## Description

This PR adds TestToRequestTraceMissingLargeBuffers to verify how the Go parser handles records where the HasLargeBuffers flag is set.

The goal is to ensure that even when this flag is active, the primary buffer is still parsed correctly and basic request info is properly extracted to maintain parsing reliability.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
