### PR TITLE
Don't log enrich OTEL instrumented services

### DIFF
--- a/pkg/appolly/discover/finder.go
+++ b/pkg/appolly/discover/finder.go
@@ -169,7 +169,7 @@ func newCommonTracersGroup(cfg *obi.Config, metrics imetrics.Reporter, pidFilter
 
 	// Enables log enricher which handles trace-log correlation
 	if cfg.EBPF.LogEnricher.Enabled() {
-		logEnricher := logenricher.New(cfg)
+		logEnricher := logenricher.New(cfg, pidFilter)
 		if logEnricher != nil {
 			tracers = append(tracers, logEnricher)
 		}

--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -68,6 +68,10 @@ type PIDsFilter struct {
 }
 
 func (pf *PIDsFilter) OnAvoidedTraces(cb AvoidedTracesCB) (unsubscribe func()) {
+	if cb == nil {
+		return func() {}
+	}
+
 	pf.callbacksMu.Lock()
 	defer pf.callbacksMu.Unlock()
 

--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -5,7 +5,9 @@ package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common"
 
 import (
 	"log/slog"
+	"maps"
 	"sync"
+	"weak"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
@@ -34,12 +36,18 @@ type PIDInfo struct {
 	otherKnownPids []app.PID
 }
 
+type AvoidedTracesCB func(pid app.PID, ns uint32)
+
+type avoidedTracesCBMap map[uint64]AvoidedTracesCB
+
 type ServiceFilter interface {
 	AllowPID(app.PID, uint32, *svc.Attrs, PIDType)
 	BlockPID(app.PID, uint32)
 	ValidPID(app.PID, uint32, PIDType) bool
 	Filter(inputSpans []request.Span) []request.Span
 	CurrentPIDs(PIDType) map[uint32]map[app.PID]svc.Attrs
+
+	OnAvoidedTraces(cb AvoidedTracesCB) (unsubscribe func())
 }
 
 // PIDsFilter keeps a thread-safe copy of the PIDs whose traces are allowed to
@@ -53,6 +61,39 @@ type PIDsFilter struct {
 	ignoreOtelSpan      bool
 	defaultOtlpGRPCPort int
 	metrics             imetrics.Reporter
+
+	callbacksMu      sync.Mutex
+	avoidedTracesCBs avoidedTracesCBMap
+	nextCBID         uint64
+}
+
+func (pf *PIDsFilter) OnAvoidedTraces(cb AvoidedTracesCB) (unsubscribe func()) {
+	pf.callbacksMu.Lock()
+	defer pf.callbacksMu.Unlock()
+
+	if pf.avoidedTracesCBs == nil {
+		pf.avoidedTracesCBs = avoidedTracesCBMap{}
+	}
+
+	id := pf.nextCBID
+	pf.nextCBID++
+
+	pf.avoidedTracesCBs[id] = cb
+
+	weakPf := weak.Make(pf)
+
+	return func() {
+		live := weakPf.Value()
+
+		if live == nil {
+			return
+		}
+
+		live.callbacksMu.Lock()
+		defer live.callbacksMu.Unlock()
+
+		delete(live.avoidedTracesCBs, id)
+	}
 }
 
 func NewPIDsFilter(c *services.DiscoveryConfig, log *slog.Logger, metrics imetrics.Reporter) *PIDsFilter {
@@ -221,6 +262,10 @@ func (pf *IdentityPidsFilter) Filter(inputSpans []request.Span) []request.Span {
 	return inputSpans
 }
 
+func (pf *IdentityPidsFilter) OnAvoidedTraces(_ AvoidedTracesCB) (unsubscribe func()) {
+	return func() {}
+}
+
 func (pf *PIDsFilter) checkIfExportsOTel(svc *svc.Attrs, span *request.Span, defaultOtlpGRPCPort int) {
 	if !svc.ExportsOTelMetrics() && span.IsExportMetricsSpan(defaultOtlpGRPCPort) {
 		svc.SetExportsOTelMetrics()
@@ -228,6 +273,29 @@ func (pf *PIDsFilter) checkIfExportsOTel(svc *svc.Attrs, span *request.Span, def
 	} else if !svc.ExportsOTelTraces() && span.IsExportTracesSpan(defaultOtlpGRPCPort) {
 		svc.SetExportsOTelTraces()
 		pf.reportAvoidedService(svc, "traces")
+		pf.fireOnAvoidedTraces(span)
+	}
+}
+
+func (pf *PIDsFilter) fireOnAvoidedTraces(span *request.Span) {
+	cbs := avoidedTracesCBMap{}
+
+	func() {
+		pf.callbacksMu.Lock()
+		defer pf.callbacksMu.Unlock()
+
+		cbs = maps.Clone(pf.avoidedTracesCBs)
+	}()
+
+	if len(cbs) == 0 {
+		return
+	}
+
+	pid := span.Pid.UserPID
+	ns := span.Pid.Namespace
+
+	for _, cb := range cbs {
+		cb(pid, ns)
 	}
 }
 

--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -273,11 +273,11 @@ func (pf *PIDsFilter) checkIfExportsOTel(svc *svc.Attrs, span *request.Span, def
 	} else if !svc.ExportsOTelTraces() && span.IsExportTracesSpan(defaultOtlpGRPCPort) {
 		svc.SetExportsOTelTraces()
 		pf.reportAvoidedService(svc, "traces")
-		pf.fireOnAvoidedTraces(span)
+		pf.fireOnAvoidedTracesLocked(svc)
 	}
 }
 
-func (pf *PIDsFilter) fireOnAvoidedTraces(span *request.Span) {
+func (pf *PIDsFilter) fireOnAvoidedTracesLocked(svcAttrs *svc.Attrs) {
 	cbs := avoidedTracesCBMap{}
 
 	func() {
@@ -291,11 +291,18 @@ func (pf *PIDsFilter) fireOnAvoidedTraces(span *request.Span) {
 		return
 	}
 
-	pid := span.Pid.UserPID
-	ns := span.Pid.Namespace
+	targetUID := svcAttrs.UID
 
-	for _, cb := range cbs {
-		cb(pid, ns)
+	for ns, pidMap := range pf.current {
+		for pid, info := range pidMap {
+			if info.service == nil || info.service.UID != targetUID {
+				continue
+			}
+
+			for _, cb := range cbs {
+				cb(pid, ns)
+			}
+		}
 	}
 }
 

--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -38,6 +38,7 @@ type PIDInfo struct {
 
 type AvoidedTracesCB func(pid app.PID, ns uint32)
 
+// the map key here is just a monotonically increasing ID derived from nextCBID
 type avoidedTracesCBMap map[uint64]AvoidedTracesCB
 
 type ServiceFilter interface {
@@ -69,7 +70,7 @@ type PIDsFilter struct {
 
 func (pf *PIDsFilter) OnAvoidedTraces(cb AvoidedTracesCB) (unsubscribe func()) {
 	if cb == nil {
-		return func() {}
+		panic("PIDsFilter.OnAvoidedTraces called with nil callback")
 	}
 
 	pf.callbacksMu.Lock()
@@ -167,10 +168,13 @@ func (pf *PIDsFilter) normalizeTraceContext(span *request.Span) {
 
 func (pf *PIDsFilter) Filter(inputSpans []request.Span) []request.Span {
 	pf.mux.RLock()
-	defer pf.mux.RUnlock()
+
+	var pendingAvoidedTraces []*svc.Attrs
+
 	// todo: adaptive presizing as a function of the historical percentage
 	// of filtered spans
 	outputSpans := make([]request.Span, 0, len(inputSpans))
+
 	for i := range inputSpans {
 		span := &inputSpans[i]
 
@@ -186,7 +190,11 @@ func (pf *PIDsFilter) Filter(inputSpans []request.Span) []request.Span {
 		// of container layers. The Host PID is always the outer most layer.
 		if info, pidExists := ns[span.Pid.UserPID]; pidExists {
 			if pf.ignoreOtel {
+				alreadyExportsOTelTraces := info.service.ExportsOTelTraces()
 				pf.checkIfExportsOTel(info.service, span, pf.defaultOtlpGRPCPort)
+				if !alreadyExportsOTelTraces && info.service.ExportsOTelTraces() {
+					pendingAvoidedTraces = append(pendingAvoidedTraces, info.service)
+				}
 			}
 			if pf.ignoreOtelSpan {
 				pf.checkIfExportsOTelSpanMetrics(info.service, span, pf.defaultOtlpGRPCPort)
@@ -203,6 +211,13 @@ func (pf *PIDsFilter) Filter(inputSpans []request.Span) []request.Span {
 			"pids", pf.current, "spans", inputSpans,
 		)
 	}
+
+	pf.mux.RUnlock()
+
+	for _, s := range pendingAvoidedTraces {
+		pf.fireOnAvoidedTraces(s)
+	}
+
 	return outputSpans
 }
 
@@ -277,35 +292,47 @@ func (pf *PIDsFilter) checkIfExportsOTel(svc *svc.Attrs, span *request.Span, def
 	} else if !svc.ExportsOTelTraces() && span.IsExportTracesSpan(defaultOtlpGRPCPort) {
 		svc.SetExportsOTelTraces()
 		pf.reportAvoidedService(svc, "traces")
-		pf.fireOnAvoidedTracesLocked(svc)
 	}
 }
 
-func (pf *PIDsFilter) fireOnAvoidedTracesLocked(svcAttrs *svc.Attrs) {
-	cbs := avoidedTracesCBMap{}
+type avoidedTracesTarget struct {
+	pid app.PID
+	ns  uint32
+}
 
-	func() {
-		pf.callbacksMu.Lock()
-		defer pf.callbacksMu.Unlock()
+func (pf *PIDsFilter) collectAvoidedTracesTargets(uid svc.UID) []avoidedTracesTarget {
+	pf.mux.RLock()
+	defer pf.mux.RUnlock()
 
-		cbs = maps.Clone(pf.avoidedTracesCBs)
-	}()
+	var targets []avoidedTracesTarget
+
+	for ns, pidMap := range pf.current {
+		for pid, info := range pidMap {
+			if info.service == nil || info.service.UID != uid {
+				continue
+			}
+
+			targets = append(targets, avoidedTracesTarget{pid, ns})
+		}
+	}
+
+	return targets
+}
+
+func (pf *PIDsFilter) fireOnAvoidedTraces(svcAttrs *svc.Attrs) {
+	pf.callbacksMu.Lock()
+	cbs := maps.Clone(pf.avoidedTracesCBs)
+	pf.callbacksMu.Unlock()
 
 	if len(cbs) == 0 {
 		return
 	}
 
-	targetUID := svcAttrs.UID
+	targets := pf.collectAvoidedTracesTargets(svcAttrs.UID)
 
-	for ns, pidMap := range pf.current {
-		for pid, info := range pidMap {
-			if info.service == nil || info.service.UID != targetUID {
-				continue
-			}
-
-			for _, cb := range cbs {
-				cb(pid, ns)
-			}
+	for _, t := range targets {
+		for _, cb := range cbs {
+			cb(t.pid, t.ns)
 		}
 	}
 }

--- a/pkg/ebpf/common/pids_test.go
+++ b/pkg/ebpf/common/pids_test.go
@@ -284,29 +284,43 @@ type firedEvent struct {
 	ns  uint32
 }
 
+type firedEventSet map[firedEvent]int
+
+func makeFiredEventSet(events ...firedEvent) firedEventSet {
+	s := firedEventSet{}
+	for _, e := range events {
+		s[e]++
+	}
+	return s
+}
+
 func TestFilter_OnAvoidedTraces_SingleSubscriber(t *testing.T) {
 	const defaultOtlpPort = 4317
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid}, nil
+	}
 
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 
-	var fired []firedEvent
+	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
+	pf.AllowPID(33, 44, &sharedSvc, PIDTypeGo)
+
+	var fired firedEventSet = firedEventSet{}
 
 	pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
-		fired = append(fired, firedEvent{pid, ns})
+		fired[firedEvent{pid, ns}]++
 	})
-
-	s := svc.Attrs{}
 
 	metricsSpan := request.Span{
 		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/metrics",
 		RequestStart: 100, End: 200, Status: 200,
-		Pid: request.PidInfo{UserPID: 11, Namespace: 22},
+		Pid: request.PidInfo{UserPID: 33, Namespace: 44},
 	}
 
-	pf.checkIfExportsOTel(&s, &metricsSpan, defaultOtlpPort)
+	pf.checkIfExportsOTel(&sharedSvc, &metricsSpan, defaultOtlpPort)
 
-	assert.True(t, s.ExportsOTelMetrics())
-	assert.False(t, s.ExportsOTelTraces())
+	assert.True(t, sharedSvc.ExportsOTelMetrics())
+	assert.False(t, sharedSvc.ExportsOTelTraces())
 	assert.Empty(t, fired)
 
 	tracesSpan := request.Span{
@@ -315,80 +329,136 @@ func TestFilter_OnAvoidedTraces_SingleSubscriber(t *testing.T) {
 		Pid: request.PidInfo{UserPID: 33, Namespace: 44},
 	}
 
-	pf.checkIfExportsOTel(&s, &tracesSpan, defaultOtlpPort)
+	pf.checkIfExportsOTel(&sharedSvc, &tracesSpan, defaultOtlpPort)
 
-	assert.True(t, s.ExportsOTelTraces())
-	assert.Equal(t, []firedEvent{{app.PID(33), 44}}, fired)
+	assert.True(t, sharedSvc.ExportsOTelTraces())
+	assert.Equal(t, makeFiredEventSet(firedEvent{33, 44}), fired)
 
-	pf.checkIfExportsOTel(&s, &tracesSpan, defaultOtlpPort)
+	pf.checkIfExportsOTel(&sharedSvc, &tracesSpan, defaultOtlpPort)
 
-	assert.Len(t, fired, 1)
+	assert.Equal(t, makeFiredEventSet(firedEvent{33, 44}), fired)
+}
+
+func TestFilter_OnAvoidedTraces_FiresForAllPIDsOfSameService(t *testing.T) {
+	const defaultOtlpPort = 4317
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid}, nil
+	}
+
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+
+	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
+	otherSvc := svc.Attrs{UID: svc.UID{Name: "other-service"}}
+
+	pf.AllowPID(100, 1, &sharedSvc, PIDTypeKProbes)
+	pf.AllowPID(101, 1, &sharedSvc, PIDTypeKProbes)
+	pf.AllowPID(102, 1, &sharedSvc, PIDTypeKProbes)
+	pf.AllowPID(200, 1, &otherSvc, PIDTypeKProbes)
+
+	fired := firedEventSet{}
+
+	pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
+		fired[firedEvent{pid, ns}]++
+	})
+
+	tracesSpan := request.Span{
+		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
+		RequestStart: 100, End: 200, Status: 200,
+		Pid: request.PidInfo{UserPID: 100, Namespace: 1},
+	}
+
+	pf.checkIfExportsOTel(&sharedSvc, &tracesSpan, defaultOtlpPort)
+
+	expected := makeFiredEventSet(
+		firedEvent{100, 1},
+		firedEvent{101, 1},
+		firedEvent{102, 1},
+	)
+	assert.Equal(t, expected, fired)
 }
 
 func TestFilter_OnAvoidedTraces_MultipleSubscribers(t *testing.T) {
 	const defaultOtlpPort = 4317
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid}, nil
+	}
 
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 
-	var firedA, firedB []firedEvent
+	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
+	pf.AllowPID(77, 88, &sharedSvc, PIDTypeGo)
+
+	firedA := firedEventSet{}
+	firedB := firedEventSet{}
 
 	pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
-		firedA = append(firedA, firedEvent{pid, ns})
+		firedA[firedEvent{pid, ns}]++
 	})
 
 	pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
-		firedB = append(firedB, firedEvent{pid, ns})
+		firedB[firedEvent{pid, ns}]++
 	})
 
-	s := svc.Attrs{}
 	span := request.Span{
 		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
 		RequestStart: 100, End: 200, Status: 200,
 		Pid: request.PidInfo{UserPID: 77, Namespace: 88},
 	}
 
-	pf.checkIfExportsOTel(&s, &span, defaultOtlpPort)
+	pf.checkIfExportsOTel(&sharedSvc, &span, defaultOtlpPort)
 
-	assert.Equal(t, []firedEvent{{app.PID(77), 88}}, firedA)
-	assert.Equal(t, []firedEvent{{app.PID(77), 88}}, firedB)
+	expected := makeFiredEventSet(firedEvent{77, 88})
+	assert.Equal(t, expected, firedA)
+	assert.Equal(t, expected, firedB)
 }
 
 func TestFilter_OnAvoidedTraces_Unsubscribe(t *testing.T) {
 	const defaultOtlpPort = 4317
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid}, nil
+	}
 
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 
-	var firedA, firedB []firedEvent
+	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
+	pf.AllowPID(5, 6, &sharedSvc, PIDTypeGo)
+
+	firedA := firedEventSet{}
+	firedB := firedEventSet{}
 
 	unsubA := pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
-		firedA = append(firedA, firedEvent{pid, ns})
+		firedA[firedEvent{pid, ns}]++
 	})
 
 	pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
-		firedB = append(firedB, firedEvent{pid, ns})
+		firedB[firedEvent{pid, ns}]++
 	})
 
 	unsubA()
 
-	s := svc.Attrs{}
 	span := request.Span{
 		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
 		RequestStart: 100, End: 200, Status: 200,
 		Pid: request.PidInfo{UserPID: 5, Namespace: 6},
 	}
 
-	pf.checkIfExportsOTel(&s, &span, defaultOtlpPort)
+	pf.checkIfExportsOTel(&sharedSvc, &span, defaultOtlpPort)
 
 	assert.Empty(t, firedA)
-	assert.Equal(t, []firedEvent{{app.PID(5), 6}}, firedB)
+	assert.Equal(t, makeFiredEventSet(firedEvent{5, 6}), firedB)
 }
 
 func TestFilter_OnAvoidedTraces_NotRegistered(t *testing.T) {
 	const defaultOtlpPort = 4317
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid}, nil
+	}
 
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 
-	s := svc.Attrs{}
+	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
+	pf.AllowPID(1, 2, &sharedSvc, PIDTypeGo)
+
 	span := request.Span{
 		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
 		RequestStart: 100, End: 200, Status: 200,
@@ -396,10 +466,10 @@ func TestFilter_OnAvoidedTraces_NotRegistered(t *testing.T) {
 	}
 
 	assert.NotPanics(t, func() {
-		pf.checkIfExportsOTel(&s, &span, defaultOtlpPort)
+		pf.checkIfExportsOTel(&sharedSvc, &span, defaultOtlpPort)
 	})
 
-	assert.True(t, s.ExportsOTelTraces())
+	assert.True(t, sharedSvc.ExportsOTelTraces())
 }
 
 func TestFilter_Cleanup(t *testing.T) {

--- a/pkg/ebpf/common/pids_test.go
+++ b/pkg/ebpf/common/pids_test.go
@@ -279,6 +279,129 @@ func TestFilter_TriggersOTelSpanFiltering(t *testing.T) {
 	}
 }
 
+type firedEvent struct {
+	pid app.PID
+	ns  uint32
+}
+
+func TestFilter_OnAvoidedTraces_SingleSubscriber(t *testing.T) {
+	const defaultOtlpPort = 4317
+
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+
+	var fired []firedEvent
+
+	pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
+		fired = append(fired, firedEvent{pid, ns})
+	})
+
+	s := svc.Attrs{}
+
+	metricsSpan := request.Span{
+		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/metrics",
+		RequestStart: 100, End: 200, Status: 200,
+		Pid: request.PidInfo{UserPID: 11, Namespace: 22},
+	}
+
+	pf.checkIfExportsOTel(&s, &metricsSpan, defaultOtlpPort)
+
+	assert.True(t, s.ExportsOTelMetrics())
+	assert.False(t, s.ExportsOTelTraces())
+	assert.Empty(t, fired)
+
+	tracesSpan := request.Span{
+		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
+		RequestStart: 100, End: 200, Status: 200,
+		Pid: request.PidInfo{UserPID: 33, Namespace: 44},
+	}
+
+	pf.checkIfExportsOTel(&s, &tracesSpan, defaultOtlpPort)
+
+	assert.True(t, s.ExportsOTelTraces())
+	assert.Equal(t, []firedEvent{{app.PID(33), 44}}, fired)
+
+	pf.checkIfExportsOTel(&s, &tracesSpan, defaultOtlpPort)
+
+	assert.Len(t, fired, 1)
+}
+
+func TestFilter_OnAvoidedTraces_MultipleSubscribers(t *testing.T) {
+	const defaultOtlpPort = 4317
+
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+
+	var firedA, firedB []firedEvent
+
+	pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
+		firedA = append(firedA, firedEvent{pid, ns})
+	})
+
+	pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
+		firedB = append(firedB, firedEvent{pid, ns})
+	})
+
+	s := svc.Attrs{}
+	span := request.Span{
+		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
+		RequestStart: 100, End: 200, Status: 200,
+		Pid: request.PidInfo{UserPID: 77, Namespace: 88},
+	}
+
+	pf.checkIfExportsOTel(&s, &span, defaultOtlpPort)
+
+	assert.Equal(t, []firedEvent{{app.PID(77), 88}}, firedA)
+	assert.Equal(t, []firedEvent{{app.PID(77), 88}}, firedB)
+}
+
+func TestFilter_OnAvoidedTraces_Unsubscribe(t *testing.T) {
+	const defaultOtlpPort = 4317
+
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+
+	var firedA, firedB []firedEvent
+
+	unsubA := pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
+		firedA = append(firedA, firedEvent{pid, ns})
+	})
+
+	pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
+		firedB = append(firedB, firedEvent{pid, ns})
+	})
+
+	unsubA()
+
+	s := svc.Attrs{}
+	span := request.Span{
+		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
+		RequestStart: 100, End: 200, Status: 200,
+		Pid: request.PidInfo{UserPID: 5, Namespace: 6},
+	}
+
+	pf.checkIfExportsOTel(&s, &span, defaultOtlpPort)
+
+	assert.Empty(t, firedA)
+	assert.Equal(t, []firedEvent{{app.PID(5), 6}}, firedB)
+}
+
+func TestFilter_OnAvoidedTraces_NotRegistered(t *testing.T) {
+	const defaultOtlpPort = 4317
+
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+
+	s := svc.Attrs{}
+	span := request.Span{
+		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
+		RequestStart: 100, End: 200, Status: 200,
+		Pid: request.PidInfo{UserPID: 1, Namespace: 2},
+	}
+
+	assert.NotPanics(t, func() {
+		pf.checkIfExportsOTel(&s, &span, defaultOtlpPort)
+	})
+
+	assert.True(t, s.ExportsOTelTraces())
+}
+
 func TestFilter_Cleanup(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		switch pid {

--- a/pkg/ebpf/common/pids_test.go
+++ b/pkg/ebpf/common/pids_test.go
@@ -294,13 +294,28 @@ func makeFiredEventSet(events ...firedEvent) firedEventSet {
 	return s
 }
 
+func newAvoidedTracesTestFilter() *PIDsFilter {
+	return NewPIDsFilter(
+		&services.DiscoveryConfig{ExcludeOTelInstrumentedServices: true},
+		slog.With("env", "testing"),
+		&imetrics.NoopReporter{},
+	)
+}
+
+func tracesSpanFor(pid app.PID, ns uint32) request.Span {
+	return request.Span{
+		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
+		RequestStart: 100, End: 200, Status: 200,
+		Pid: request.PidInfo{UserPID: pid, Namespace: ns},
+	}
+}
+
 func TestFilter_OnAvoidedTraces_SingleSubscriber(t *testing.T) {
-	const defaultOtlpPort = 4317
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
 
-	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+	pf := newAvoidedTracesTestFilter()
 
 	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
 	pf.AllowPID(33, 44, &sharedSvc, PIDTypeGo)
@@ -317,35 +332,29 @@ func TestFilter_OnAvoidedTraces_SingleSubscriber(t *testing.T) {
 		Pid: request.PidInfo{UserPID: 33, Namespace: 44},
 	}
 
-	pf.checkIfExportsOTel(&sharedSvc, &metricsSpan, defaultOtlpPort)
+	pf.Filter([]request.Span{metricsSpan})
 
 	assert.True(t, sharedSvc.ExportsOTelMetrics())
 	assert.False(t, sharedSvc.ExportsOTelTraces())
 	assert.Empty(t, fired)
 
-	tracesSpan := request.Span{
-		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
-		RequestStart: 100, End: 200, Status: 200,
-		Pid: request.PidInfo{UserPID: 33, Namespace: 44},
-	}
-
-	pf.checkIfExportsOTel(&sharedSvc, &tracesSpan, defaultOtlpPort)
+	tracesSpan := tracesSpanFor(33, 44)
+	pf.Filter([]request.Span{tracesSpan})
 
 	assert.True(t, sharedSvc.ExportsOTelTraces())
 	assert.Equal(t, makeFiredEventSet(firedEvent{33, 44}), fired)
 
-	pf.checkIfExportsOTel(&sharedSvc, &tracesSpan, defaultOtlpPort)
+	pf.Filter([]request.Span{tracesSpan})
 
 	assert.Equal(t, makeFiredEventSet(firedEvent{33, 44}), fired)
 }
 
 func TestFilter_OnAvoidedTraces_FiresForAllPIDsOfSameService(t *testing.T) {
-	const defaultOtlpPort = 4317
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
 
-	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+	pf := newAvoidedTracesTestFilter()
 
 	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
 	otherSvc := svc.Attrs{UID: svc.UID{Name: "other-service"}}
@@ -361,13 +370,7 @@ func TestFilter_OnAvoidedTraces_FiresForAllPIDsOfSameService(t *testing.T) {
 		fired[firedEvent{pid, ns}]++
 	})
 
-	tracesSpan := request.Span{
-		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
-		RequestStart: 100, End: 200, Status: 200,
-		Pid: request.PidInfo{UserPID: 100, Namespace: 1},
-	}
-
-	pf.checkIfExportsOTel(&sharedSvc, &tracesSpan, defaultOtlpPort)
+	pf.Filter([]request.Span{tracesSpanFor(100, 1)})
 
 	expected := makeFiredEventSet(
 		firedEvent{100, 1},
@@ -378,12 +381,11 @@ func TestFilter_OnAvoidedTraces_FiresForAllPIDsOfSameService(t *testing.T) {
 }
 
 func TestFilter_OnAvoidedTraces_MultipleSubscribers(t *testing.T) {
-	const defaultOtlpPort = 4317
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
 
-	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+	pf := newAvoidedTracesTestFilter()
 
 	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
 	pf.AllowPID(77, 88, &sharedSvc, PIDTypeGo)
@@ -399,13 +401,7 @@ func TestFilter_OnAvoidedTraces_MultipleSubscribers(t *testing.T) {
 		firedB[firedEvent{pid, ns}]++
 	})
 
-	span := request.Span{
-		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
-		RequestStart: 100, End: 200, Status: 200,
-		Pid: request.PidInfo{UserPID: 77, Namespace: 88},
-	}
-
-	pf.checkIfExportsOTel(&sharedSvc, &span, defaultOtlpPort)
+	pf.Filter([]request.Span{tracesSpanFor(77, 88)})
 
 	expected := makeFiredEventSet(firedEvent{77, 88})
 	assert.Equal(t, expected, firedA)
@@ -413,12 +409,11 @@ func TestFilter_OnAvoidedTraces_MultipleSubscribers(t *testing.T) {
 }
 
 func TestFilter_OnAvoidedTraces_Unsubscribe(t *testing.T) {
-	const defaultOtlpPort = 4317
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
 
-	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+	pf := newAvoidedTracesTestFilter()
 
 	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
 	pf.AllowPID(5, 6, &sharedSvc, PIDTypeGo)
@@ -436,65 +431,35 @@ func TestFilter_OnAvoidedTraces_Unsubscribe(t *testing.T) {
 
 	unsubA()
 
-	span := request.Span{
-		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
-		RequestStart: 100, End: 200, Status: 200,
-		Pid: request.PidInfo{UserPID: 5, Namespace: 6},
-	}
-
-	pf.checkIfExportsOTel(&sharedSvc, &span, defaultOtlpPort)
+	pf.Filter([]request.Span{tracesSpanFor(5, 6)})
 
 	assert.Empty(t, firedA)
 	assert.Equal(t, makeFiredEventSet(firedEvent{5, 6}), firedB)
 }
 
 func TestFilter_OnAvoidedTraces_NilCallback(t *testing.T) {
-	const defaultOtlpPort = 4317
-	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
-		return []app.PID{pid}, nil
-	}
+	pf := newAvoidedTracesTestFilter()
 
-	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
-
-	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
-	pf.AllowPID(7, 8, &sharedSvc, PIDTypeGo)
-
-	unsub := pf.OnAvoidedTraces(nil)
-
-	assert.NotNil(t, unsub)
-	assert.NotPanics(t, unsub)
-
-	span := request.Span{
-		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
-		RequestStart: 100, End: 200, Status: 200,
-		Pid: request.PidInfo{UserPID: 7, Namespace: 8},
-	}
-
-	assert.NotPanics(t, func() {
-		pf.checkIfExportsOTel(&sharedSvc, &span, defaultOtlpPort)
-	})
-	assert.True(t, sharedSvc.ExportsOTelTraces())
+	assert.PanicsWithValue(t,
+		"PIDsFilter.OnAvoidedTraces called with nil callback",
+		func() {
+			pf.OnAvoidedTraces(nil)
+		},
+	)
 }
 
 func TestFilter_OnAvoidedTraces_NotRegistered(t *testing.T) {
-	const defaultOtlpPort = 4317
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
 
-	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+	pf := newAvoidedTracesTestFilter()
 
 	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
 	pf.AllowPID(1, 2, &sharedSvc, PIDTypeGo)
 
-	span := request.Span{
-		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
-		RequestStart: 100, End: 200, Status: 200,
-		Pid: request.PidInfo{UserPID: 1, Namespace: 2},
-	}
-
 	assert.NotPanics(t, func() {
-		pf.checkIfExportsOTel(&sharedSvc, &span, defaultOtlpPort)
+		pf.Filter([]request.Span{tracesSpanFor(1, 2)})
 	})
 
 	assert.True(t, sharedSvc.ExportsOTelTraces())

--- a/pkg/ebpf/common/pids_test.go
+++ b/pkg/ebpf/common/pids_test.go
@@ -305,7 +305,7 @@ func TestFilter_OnAvoidedTraces_SingleSubscriber(t *testing.T) {
 	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
 	pf.AllowPID(33, 44, &sharedSvc, PIDTypeGo)
 
-	var fired firedEventSet = firedEventSet{}
+	fired := firedEventSet{}
 
 	pf.OnAvoidedTraces(func(pid app.PID, ns uint32) {
 		fired[firedEvent{pid, ns}]++
@@ -446,6 +446,34 @@ func TestFilter_OnAvoidedTraces_Unsubscribe(t *testing.T) {
 
 	assert.Empty(t, firedA)
 	assert.Equal(t, makeFiredEventSet(firedEvent{5, 6}), firedB)
+}
+
+func TestFilter_OnAvoidedTraces_NilCallback(t *testing.T) {
+	const defaultOtlpPort = 4317
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid}, nil
+	}
+
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+
+	sharedSvc := svc.Attrs{UID: svc.UID{Name: "scoring-engine"}}
+	pf.AllowPID(7, 8, &sharedSvc, PIDTypeGo)
+
+	unsub := pf.OnAvoidedTraces(nil)
+
+	assert.NotNil(t, unsub)
+	assert.NotPanics(t, unsub)
+
+	span := request.Span{
+		Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces",
+		RequestStart: 100, End: 200, Status: 200,
+		Pid: request.PidInfo{UserPID: 7, Namespace: 8},
+	}
+
+	assert.NotPanics(t, func() {
+		pf.checkIfExportsOTel(&sharedSvc, &span, defaultOtlpPort)
+	})
+	assert.True(t, sharedSvc.ExportsOTelTraces())
 }
 
 func TestFilter_OnAvoidedTraces_NotRegistered(t *testing.T) {

--- a/pkg/ebpf/common/ringbuf_test.go
+++ b/pkg/ebpf/common/ringbuf_test.go
@@ -421,3 +421,7 @@ func (pf *TestPidsFilter) Filter(inputSpans []request.Span) []request.Span {
 	}
 	return inputSpans
 }
+
+func (pf *TestPidsFilter) OnAvoidedTraces(_ AvoidedTracesCB) (unsubscribe func()) {
+	return func() {}
+}

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -228,6 +229,9 @@ func (p *Tracer) addPID(key uint64) error {
 func (p *Tracer) removePID(key uint64) error {
 	p.log.Debug("removing pid", "pid", uint32(key), "ns", key>>32)
 	if err := p.bpfObjects.LogEnricherPids.Delete(key); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return nil
+		}
 		return fmt.Errorf("error removing pid %d (ns=%d) from bpf map: %w", uint32(key), key>>32, err)
 	}
 	return nil

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -45,18 +45,19 @@ type LogEvent struct {
 }
 
 type Tracer struct {
-	ctx         context.Context
-	cfg         *obi.Config
-	bpfObjects  BpfObjects
-	closers     []io.Closer
-	log         *slog.Logger
-	fdCache     *expirable.LRU[string, *os.File]
-	asyncWriter *shardedqueue.ShardedQueue[LogEvent]
-	pids        map[uint64][]uint64 // pid:[]nsPids
-	pidsMU      sync.Mutex
+	ctx                context.Context
+	cfg                *obi.Config
+	bpfObjects         BpfObjects
+	closers            []io.Closer
+	log                *slog.Logger
+	fdCache            *expirable.LRU[string, *os.File]
+	asyncWriter        *shardedqueue.ShardedQueue[LogEvent]
+	pids               map[uint64][]uint64 // pid:[]nsPids
+	pidsMU             sync.Mutex
+	avoidedTracesUnsub func()
 }
 
-func New(cfg *obi.Config) *Tracer {
+func New(cfg *obi.Config, pidFilter ebpfcommon.ServiceFilter) *Tracer {
 	logger := slog.With("component", "logenricher")
 
 	if !ebpfcommon.SupportsLogInjection(logger) {
@@ -85,6 +86,8 @@ func New(cfg *obi.Config) *Tracer {
 	)
 
 	tr.asyncWriter = asyncWriter
+
+	tr.avoidedTracesUnsub = pidFilter.OnAvoidedTraces(tr.BlockPID)
 
 	return tr
 }
@@ -230,7 +233,14 @@ func (p *Tracer) removePID(key uint64) error {
 	return nil
 }
 
-func (p *Tracer) AllowPID(pid app.PID, ns uint32, _ *svc.Attrs) {
+func (p *Tracer) AllowPID(pid app.PID, ns uint32, svcAttrs *svc.Attrs) {
+	if p.cfg.Discovery.ExcludeOTelInstrumentedServices &&
+		svcAttrs != nil && svcAttrs.ExportsOTelTraces() {
+		p.log.Debug("skipping log enrichment for OTel-instrumented service",
+			"pid", pid, "ns", ns, "service", svcAttrs.UID.Name)
+		return
+	}
+
 	p.pidsMU.Lock()
 	defer p.pidsMU.Unlock()
 
@@ -283,6 +293,12 @@ func (p *Tracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg
 	p.log.Debug("starting")
 
 	p.ctx = ctx
+
+	defer func() {
+		if p.avoidedTracesUnsub != nil {
+			p.avoidedTracesUnsub()
+		}
+	}()
 
 	ebpfcommon.ForwardRingbuf(
 		&p.cfg.EBPF,

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -88,7 +88,9 @@ func New(cfg *obi.Config, pidFilter ebpfcommon.ServiceFilter) *Tracer {
 
 	tr.asyncWriter = asyncWriter
 
-	tr.avoidedTracesUnsub = pidFilter.OnAvoidedTraces(tr.BlockPID)
+	if cfg.Discovery.ExcludeOTelInstrumentedServices {
+		tr.avoidedTracesUnsub = pidFilter.OnAvoidedTraces(tr.BlockPID)
+	}
 
 	return tr
 }

--- a/pkg/internal/ebpf/logenricher/logenricher_notlinux.go
+++ b/pkg/internal/ebpf/logenricher/logenricher_notlinux.go
@@ -23,7 +23,7 @@ import (
 
 type Tracer struct{}
 
-func New(_ *obi.Config) *Tracer                                          { return nil }
+func New(_ *obi.Config, _ ebpfcommon.ServiceFilter) *Tracer              { return nil }
 func (p *Tracer) AllowPID(_ app.PID, _ uint32, _ *svc.Attrs)             {}
 func (p *Tracer) BlockPID(_ app.PID, _ uint32)                           {}
 func (p *Tracer) LoadSpecs() ([]*ebpfcommon.SpecBundle, error)           { return nil, nil }


### PR DESCRIPTION
## Summary

Skip the log enrichment of processes we detect as "OTEL instrumented services". Otherwise, we end up enriching them with stale data (internally, we generate a span, enrich, and then drop the span).

Fixes https://github.com/grafana/beyla/issues/2783

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
