### PR TITLE
fix(lint): fix `ARGS[@]: unbound variable` in lint-dependency-policy.sh

### DIFF
--- a/scripts/lint-dependency-policy.sh
+++ b/scripts/lint-dependency-policy.sh
@@ -16,7 +16,6 @@ set -euo pipefail
 
 PROGNAME="$(basename "$0")"
 readonly PROGNAME
-declare -ar ARGS=("$@")
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly ROOT_DIR
 readonly DEFAULT_BASE_REF="main"
@@ -510,4 +509,4 @@ main() {
   echo "Dependency policy lint passed for ${#files[@]} Dockerfile(s)."
 }
 
-main "${ARGS[@]}"
+main "$@"


### PR DESCRIPTION
## Summary

This PR fixes the following issue on macOS:
```
make lint
...
### Linting dependency integrity policy
./scripts/lint-dependency-policy.sh: line 513: ARGS[@]: unbound variable
make: *** [lint-dependency-policy] Error 1
```

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
