### PR TITLE
Enrich OTEL instrumented service without spanID

### DIFF
--- a/devdocs/trace-log-correlation.md
+++ b/devdocs/trace-log-correlation.md
@@ -28,6 +28,8 @@ The logenricher hooks into write paths (`tty_write`, `pipe_write`, `ksys_write`,
 
 Because the original user buffer is zeroed out (step 3), the container log file will contain NULL characters in place of the original log line. This is expected — the enriched line is written separately by user-space, and the NULLs prevent the container runtime from capturing the un-enriched duplicate.
 
+OBI only fills `trace_id`/`span_id` fields that are not already present in the JSON — if the application's logger or SDK already injected them (e.g. via Python `LoggingInstrumentor`), those values are preserved. For services OBI detects as exporting OTel traces directly (see [exclude-otel-instrumented-services](exclude-otel-instrumented-services.md)), only `trace_id` is injected and `span_id` is never written: OBI's BPF-generated `span_id` would not match the SDK's actual span and would point at a span the SDK emits under a different ID.
+
 Both `ITER_UBUF` (kernel ≥ 6.0, used by `write()`) and `ITER_IOVEC` (all kernel versions, used by `writev()`) iterator types are supported. The `do_writev` kprobe captures the fd for `writev()` calls so `pipe_write` can resolve the file descriptor (registered as non-required — if the symbol isn't available, `write()`-based enrichment still works).
 
 ## The `traces_ctx_v1` map

--- a/internal/test/integration/components/pythonasync-uvloop/async_context_test.py
+++ b/internal/test/integration/components/pythonasync-uvloop/async_context_test.py
@@ -99,6 +99,17 @@ async def json_logger_gather():
     return {"status": "ok"}
 
 
+@app.get("/json_logger_otel_exporter")
+async def json_logger_otel_exporter():
+    try:
+        await http_client.post(f"{BACKEND_URL}/v1/traces", content=b"", timeout=5.0)
+    except Exception:
+        pass
+    await asyncio.sleep(0.05)
+    _emit_json_log("this is a json log from python async otel exporter")
+    return {"status": "ok"}
+
+
 @app.get("/to-thread/{req_id}")
 async def test_to_thread(req_id: int):
     def blocking_http_call(url: str):

--- a/internal/test/integration/components/pythonserver/main.py
+++ b/internal/test/integration/components/pythonserver/main.py
@@ -55,6 +55,10 @@ def black_hole():
 
     return "LIGHT!"
 
+@app.route("/v1/traces", methods=["POST"])
+def otlp_traces():
+    return Response(status=200)
+
 @app.route("/users", methods=['POST'])
 def users():
     content = request.json

--- a/internal/test/integration/log_enricher_test.go
+++ b/internal/test/integration/log_enricher_test.go
@@ -513,6 +513,91 @@ func testLogEnricherPythonAsyncEndpoint(t *testing.T, cl *client.Client, logEndp
 	}, testTimeout, 500*time.Millisecond)
 }
 
+// testLogEnricherPythonAsyncOTelInstrumented exercises the trace_id-only
+// behavior for services OBI detects as exporting OTel traces directly. The
+// server endpoint makes an outgoing POST to /v1/traces (a "fake" OTLP HTTP
+// endpoint on the backend) before logging, which triggers PIDsFilter's
+// checkIfExportsOTel via the resulting EventTypeHTTPClient span. After
+// detection fires, subsequent log lines from the same service must carry
+// trace_id but no span_id.
+func testLogEnricherPythonAsyncOTelInstrumented(t *testing.T) {
+	waitForTestComponentsNoMetrics(t, logEnricherPythonAsyncConstants.url+logEnricherPythonAsyncConstants.smokeEndpoint)
+
+	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err)
+	defer cl.Close()
+
+	const expectedMessage = "this is a json log from python async otel exporter"
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		errCh := make(chan error, len(logEnricherTestTraceparents))
+		var wg sync.WaitGroup
+		for _, tp := range logEnricherTestTraceparents {
+			wg.Add(1)
+			go func(tp struct{ traceID, parentID string }) {
+				defer wg.Done()
+				req, err := http.NewRequest(http.MethodGet,
+					logEnricherPythonAsyncConstants.url+"/json_logger_otel_exporter", nil)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				req.Header.Set("traceparent", fmt.Sprintf("00-%s-%s-01", tp.traceID, tp.parentID))
+				resp, err := http.DefaultClient.Do(req)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				resp.Body.Close()
+			}(tp)
+		}
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			assert.NoError(ct, err, "HTTP request failed")
+		}
+
+		containerID := testContainerID(ct, cl, logEnricherPythonAsyncConstants.containerImage)
+		if !assert.NotEmpty(ct, containerID, "could not find test container ID") {
+			return
+		}
+		logs := containerLogs(ct, cl, containerID)
+		if !assert.NotEmpty(ct, logs) {
+			return
+		}
+
+		// For each trace_id, track whether the latest matching log line carried
+		// a span_id. Once OBI detects the service as OTel-exporting, every
+		// subsequent log line for that service drops span_id.
+		lastHasSpanID := make(map[string]bool, len(logEnricherTestTraceparents))
+		seen := make(map[string]bool, len(logEnricherTestTraceparents))
+		for _, line := range logs {
+			var fields map[string]any
+			if json.Unmarshal([]byte(line), &fields) != nil {
+				continue
+			}
+			if fields["message"] != expectedMessage {
+				continue
+			}
+			tid, ok := fields["trace_id"].(string)
+			if !ok {
+				continue
+			}
+			seen[tid] = true
+			_, hasSpan := fields["span_id"]
+			lastHasSpanID[tid] = hasSpan
+		}
+
+		for _, tp := range logEnricherTestTraceparents {
+			assert.True(ct, seen[tp.traceID],
+				"expected an enriched log line for trace_id %s", tp.traceID)
+			assert.False(ct, lastHasSpanID[tp.traceID],
+				"latest log line for trace_id %s should not carry span_id once OBI flags the service as OTel-exporting",
+				tp.traceID)
+		}
+	}, 2*testTimeout, time.Second)
+}
+
 // testLogEnricherDotNet sends concurrent requests with distinct traceparent
 // headers and verifies each enriched log line contains the correct trace_id.
 // ASP.NET Core (Kestrel) dispatches requests on a thread pool, so concurrent

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -900,6 +900,12 @@ func TestSuite_LogEnricherPythonAsync(t *testing.T) {
 	t.Run("Log Enricher Python async", func(t *testing.T) {
 		testLogEnricherPythonAsync(t)
 	})
+	// Must run after the regular Python async test: this subtest causes OBI to
+	// flag the service as OTel-exporting, which persists for the rest of the
+	// container's lifetime.
+	t.Run("Log Enricher Python async OTel-instrumented", func(t *testing.T) {
+		testLogEnricherPythonAsyncOTelInstrumented(t)
+	})
 	require.NoError(t, compose.Close())
 }
 

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -230,16 +230,16 @@ func (p *Tracer) shouldOmitSpanID(hostPID uint32) bool {
 }
 
 func applyTraceContext(m map[string]any, traceID, spanID string, includeSpan bool) {
-	if includeSpan {
+	if _, present := m["trace_id"]; !present {
 		m["trace_id"] = traceID
-		m["span_id"] = spanID
+	}
+
+	if !includeSpan {
 		return
 	}
 
-	// for OTel-instrumented services we only inject trace_id as we can't derive
-	// the correct span_id to inject
-	if _, present := m["trace_id"]; !present {
-		m["trace_id"] = traceID
+	if _, present := m["span_id"]; !present {
+		m["span_id"] = spanID
 	}
 }
 

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -52,7 +53,8 @@ type Tracer struct {
 	log         *slog.Logger
 	fdCache     *expirable.LRU[string, *os.File]
 	asyncWriter *shardedqueue.ShardedQueue[LogEvent]
-	pids        map[uint64][]uint64 // pid:[]nsPids
+	pids        map[uint64][]uint64   // pid:[]nsPids
+	pidServices map[uint32]*svc.Attrs // host pid -> service attrs, for run-time OTel-export check in handle()
 	pidsMU      sync.Mutex
 }
 
@@ -70,7 +72,8 @@ func New(cfg *obi.Config) *Tracer {
 		fdCache: expirable.NewLRU[string, *os.File](cfg.EBPF.LogEnricher.CacheSize, func(_ string, f *os.File) {
 			f.Close()
 		}, cfg.EBPF.LogEnricher.CacheTTL),
-		pids: make(map[uint64][]uint64),
+		pids:        make(map[uint64][]uint64),
+		pidServices: make(map[uint32]*svc.Attrs),
 	}
 
 	asyncWriter := shardedqueue.NewShardedQueue[LogEvent](
@@ -214,6 +217,32 @@ func (p *Tracer) pidKey(nsid, pid uint32) uint64 {
 	return (uint64(nsid) << 32) | uint64(pid)
 }
 
+func (p *Tracer) shouldOmitSpanID(hostPID uint32) bool {
+	if !p.cfg.Discovery.ExcludeOTelInstrumentedServices {
+		return false
+	}
+
+	p.pidsMU.Lock()
+	s := p.pidServices[hostPID]
+	p.pidsMU.Unlock()
+
+	return s != nil && s.ExportsOTelTraces()
+}
+
+func applyTraceContext(m map[string]any, traceID, spanID string, includeSpan bool) {
+	if includeSpan {
+		m["trace_id"] = traceID
+		m["span_id"] = spanID
+		return
+	}
+
+	// for OTel-instrumented services we only inject trace_id as we can't derive
+	// the correct span_id to inject
+	if _, present := m["trace_id"]; !present {
+		m["trace_id"] = traceID
+	}
+}
+
 func (p *Tracer) addPID(key uint64) error {
 	p.log.Debug("adding pid", "pid", uint32(key), "ns", key>>32)
 	if err := p.bpfObjects.LogEnricherPids.Put(key, uint8(1)); err != nil {
@@ -225,14 +254,21 @@ func (p *Tracer) addPID(key uint64) error {
 func (p *Tracer) removePID(key uint64) error {
 	p.log.Debug("removing pid", "pid", uint32(key), "ns", key>>32)
 	if err := p.bpfObjects.LogEnricherPids.Delete(key); err != nil {
+		if errors.Is(err, ebpf.ErrKeyNotExist) {
+			return nil
+		}
 		return fmt.Errorf("error removing pid %d (ns=%d) from bpf map: %w", uint32(key), key>>32, err)
 	}
 	return nil
 }
 
-func (p *Tracer) AllowPID(pid app.PID, ns uint32, _ *svc.Attrs) {
+func (p *Tracer) AllowPID(pid app.PID, ns uint32, svcAttrs *svc.Attrs) {
 	p.pidsMU.Lock()
 	defer p.pidsMU.Unlock()
+
+	if svcAttrs != nil {
+		p.pidServices[uint32(pid)] = svcAttrs
+	}
 
 	pk := p.pidKey(ns, uint32(pid))
 	if err := p.addPID(pk); err != nil {
@@ -261,6 +297,8 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, _ *svc.Attrs) {
 func (p *Tracer) BlockPID(pid app.PID, ns uint32) {
 	p.pidsMU.Lock()
 	defer p.pidsMU.Unlock()
+
+	delete(p.pidServices, uint32(pid))
 
 	pk := p.pidKey(ns, uint32(pid))
 	if err := p.removePID(pk); err != nil {
@@ -371,16 +409,15 @@ func (p *Tracer) handle(e LogEvent) {
 	}
 
 	var (
-		b       bytes.Buffer
-		spanID  = trace.SpanID(e.orig.Ctx.SpanId)
-		traceID = trace.TraceID(e.orig.Ctx.TraceId)
+		b           bytes.Buffer
+		spanID      = trace.SpanID(e.orig.Ctx.SpanId)
+		traceID     = trace.TraceID(e.orig.Ctx.TraceId)
+		includeSpan = !p.shouldOmitSpanID(e.orig.Tgid)
 	)
 
 	var m map[string]any
 	if err := json.Unmarshal([]byte(e.logLine), &m); err == nil {
-		// JSON -> enrich with context
-		m["trace_id"] = traceID.String()
-		m["span_id"] = spanID.String()
+		applyTraceContext(m, traceID.String(), spanID.String(), includeSpan)
 
 		out, err2 := json.Marshal(m)
 		if err2 != nil {


### PR DESCRIPTION
## Summary

When services run their own OTel SDK and export OTLP traces directly, OBI's locally-generated `span_id` points at a span OBI discards, leaving log lines referencing a `span_id` that exists nowhere in the backend.

For services flagged as exporting OTel traces directly, the enricher now injects **only `trace_id`**, and only when not already present, leaving `span_id` to whatever the SDK's log-integration library provides.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
