### PR TITLE
Fix #2038: use basename for instrumentation_errors_total process_name label

### DIFF
--- a/pkg/ebpf/tracer_linux.go
+++ b/pkg/ebpf/tracer_linux.go
@@ -329,7 +329,7 @@ func (pt *ProcessTracer) NewExecutable(exe *link.Executable, ie *Instrumentable)
 		offsets:     ie.Offsets, // this is needed for the function offsets, not fields
 		modules:     map[uint64]struct{}{},
 		metrics:     pt.metrics,
-		processName: ie.FileInfo.CmdExePath,
+		processName: ie.FileInfo.ExecutableName(),
 	}
 
 	for _, p := range pt.Programs {


### PR DESCRIPTION
## Summary

Fixes #2038

The `instrumentation_errors_total` metric was using full executable paths as the `process_name` label, which could lead to unbounded cardinality growth and filesystem path exposure.

## Changes

- Use `FileInfo.ExecutableName()` to extract only the executable basename for the `process_name` label in the instrumenter struct
- This is consistent with how `attacher.go` already reports process names for `InstrumentProcess` and `InstrumentationError` calls
- Bounds the label cardinality and avoids exposing full filesystem paths

## Testing

- CI: Generate and checks pass, Unit tests pass
- The change uses the existing `ExecutableName()` method already used throughout `attacher.go` for the same purpose