### PR TITLE
Fix #2036: prevent nil map panic in SpanNameLimiter for zero-value service key

### DIFF
--- a/pkg/transform/span_name_limiter.go
+++ b/pkg/transform/span_name_limiter.go
@@ -95,7 +95,7 @@ func (l *spanNameLimiter) aggregate(spans []request.Span) []request.Span {
 	// assuming many spans from the same service could come in a row
 	// we can slightly optimize by avoiding the cache lookup for each span
 	var lastKey svc.ServiceNameNamespace
-	lastCount := &routesCount{}
+	lastCount := &routesCount{routes: map[string]struct{}{}}
 
 	output := spans
 	alreadyCopying := false

--- a/pkg/transform/span_name_limiter.go
+++ b/pkg/transform/span_name_limiter.go
@@ -95,13 +95,13 @@ func (l *spanNameLimiter) aggregate(spans []request.Span) []request.Span {
 	// assuming many spans from the same service could come in a row
 	// we can slightly optimize by avoiding the cache lookup for each span
 	var lastKey svc.ServiceNameNamespace
-	lastCount := &routesCount{routes: map[string]struct{}{}}
+	var lastCount *routesCount
 
 	output := spans
 	alreadyCopying := false
 	for i := 0; i < len(output); i++ {
 		span := &output[i]
-		if key := span.Service.UID.NameNamespace(); key != lastKey {
+		if key := span.Service.UID.NameNamespace(); lastCount == nil || key != lastKey {
 			lastKey = key
 			count, ok := l.spanNamesCount.Get(key)
 			if !ok {

--- a/pkg/transform/span_name_limiter_test.go
+++ b/pkg/transform/span_name_limiter_test.go
@@ -174,6 +174,36 @@ func TestSpanNameLimiter_ExpireOld(t *testing.T) {
 	})
 }
 
+func TestSpanNameLimiter_ZeroValueServiceKey(t *testing.T) {
+	// Regression test for #2036: aggregate must not panic when the first span
+	// in a batch has a zero-value ServiceNameNamespace key.
+	input := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
+	output := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
+	outCh := output.Subscribe()
+	runSpanNameLimiter, err := SpanNameLimiter(SpanNameLimiterConfig{
+		Limit:      maxCardinalityBeforeAggregation,
+		OTEL:       &otelcfg.MetricsConfig{TTL: time.Minute},
+		Prom:       &prom.PrometheusConfig{TTL: time.Minute},
+		MetricsCfg: &perapp.MetricsConfig{Features: export.FeatureSpanLegacy},
+	}, input, output)(t.Context())
+	require.NoError(t, err)
+
+	go runSpanNameLimiter(t.Context())
+
+	// Send spans with a zero-value service (empty namespace, name, instance).
+	// This must not panic due to writing to a nil map.
+	zeroSvc := svc.Attrs{} // zero-value UID
+	input.Send([]request.Span{
+		{Service: zeroSvc, Type: request.EventTypeHTTP, Method: "GET", Route: "/zero-1"},
+		{Service: zeroSvc, Type: request.EventTypeHTTP, Method: "GET", Route: "/zero-2"},
+	})
+
+	spans := testutil.ReadChannel(t, outCh, testTimeout)
+	require.Len(t, spans, 2)
+	assert.Equal(t, "GET /zero-1", spans[0].TraceName())
+	assert.Equal(t, "GET /zero-2", spans[1].TraceName())
+}
+
 func TestSpanNameLimiter_CopiesOutput(t *testing.T) {
 	// OBI has to mark as AGGREGATED only span metrics while the traces/spans need to
 	// keep the original, high-cardinality span name.

--- a/pkg/transform/span_name_limiter_test.go
+++ b/pkg/transform/span_name_limiter_test.go
@@ -176,12 +176,13 @@ func TestSpanNameLimiter_ExpireOld(t *testing.T) {
 
 func TestSpanNameLimiter_ZeroValueServiceKey(t *testing.T) {
 	// Regression test for #2036: aggregate must not panic when the first span
-	// in a batch has a zero-value ServiceNameNamespace key.
+	// in a batch has a zero-value ServiceNameNamespace key, and must properly
+	// track route counts in the cache across batches.
 	input := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	output := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
 	outCh := output.Subscribe()
 	runSpanNameLimiter, err := SpanNameLimiter(SpanNameLimiterConfig{
-		Limit:      maxCardinalityBeforeAggregation,
+		Limit:      3,
 		OTEL:       &otelcfg.MetricsConfig{TTL: time.Minute},
 		Prom:       &prom.PrometheusConfig{TTL: time.Minute},
 		MetricsCfg: &perapp.MetricsConfig{Features: export.FeatureSpanLegacy},
@@ -190,18 +191,28 @@ func TestSpanNameLimiter_ZeroValueServiceKey(t *testing.T) {
 
 	go runSpanNameLimiter(t.Context())
 
-	// Send spans with a zero-value service (empty namespace, name, instance).
-	// This must not panic due to writing to a nil map.
-	zeroSvc := svc.Attrs{} // zero-value UID
+	zeroSvc := svc.Attrs{} // zero-value UID => zero-value ServiceNameNamespace key
+
+	// First batch: must not panic, and routes are tracked in cache.
 	input.Send([]request.Span{
 		{Service: zeroSvc, Type: request.EventTypeHTTP, Method: "GET", Route: "/zero-1"},
 		{Service: zeroSvc, Type: request.EventTypeHTTP, Method: "GET", Route: "/zero-2"},
 	})
-
 	spans := testutil.ReadChannel(t, outCh, testTimeout)
 	require.Len(t, spans, 2)
 	assert.Equal(t, "GET /zero-1", spans[0].TraceName())
 	assert.Equal(t, "GET /zero-2", spans[1].TraceName())
+
+	// Second batch: the limit (3) is reached across batches, so new routes
+	// must be aggregated, proving counts are properly cached.
+	input.Send([]request.Span{
+		{Service: zeroSvc, Type: request.EventTypeHTTP, Method: "GET", Route: "/zero-3"},
+		{Service: zeroSvc, Type: request.EventTypeHTTP, Method: "GET", Route: "/zero-4"},
+	})
+	spans = testutil.ReadChannel(t, outCh, testTimeout)
+	require.Len(t, spans, 2)
+	assert.Equal(t, "GET /zero-3", spans[0].TraceName())
+	assert.Equal(t, "AGGREGATED", spans[1].TraceName())
 }
 
 func TestSpanNameLimiter_CopiesOutput(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #2036

`SpanNameLimiter.aggregate` panics when the first span in a batch has a zero-value `ServiceNameNamespace` key because the `routes` map is nil.

## Root Cause

- `lastCount` is initialized with `&routesCount{}` which has a nil `routes` map
- The map is only allocated when the service key changes
- If the first span's service key matches the zero-value `lastKey`, the map is never allocated
- Writing to the nil map causes a panic

## Fix

Initialize the `routes` map in `routesCount` at creation time to ensure it is never nil when written to.

## Testing

- Added regression test `TestSpanNameLimiter_ZeroValueServiceKey` covering the zero-value service key edge case
- Verified existing tests still pass