### PR TITLE
Fix #2015: add test for SQL++ error-message gating in span status messages

### DIFF
--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -791,6 +791,49 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		assert.Equal(t, ptrace.StatusCodeError, spans.At(0).Status().Code())
 		assert.Empty(t, spans.At(0).Status().Message())
 	})
+	t.Run("test SQL++ trace generation with error and db.response.error enabled", func(t *testing.T) {
+		span := request.Span{
+			Type:        request.EventTypeHTTPClient,
+			SubType:     request.HTTPSubtypeSQLPP,
+			Method:      "SELECT",
+			Route:       "travel-sample._default.nonexistent",
+			DBNamespace: "travel-sample",
+			DBSystem:    "couchbase",
+			Statement:   "SELECT * FROM `travel-sample`._default.nonexistent",
+			Host:        "localhost",
+			HostPort:    8093,
+			Status:      404,
+			DBError: request.DBError{
+				ErrorCode:   "12003",
+				Description: "Keyspace not found in CB datastore: default:travel-sample._default.nonexistent",
+			},
+		}
+		traceAttrs := map[attr.Name]struct{}{
+			attr.DBQueryText:     {},
+			attr.DBResponseError: {},
+		}
+		tAttrs := tracesgen.TraceAttributesSelector(&span, traceAttrs)
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
+
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+		attrs := spans.At(0).Attributes()
+		status := spans.At(0).Status()
+
+		// When db.response.error is explicitly enabled, the error description appears in the status message
+		assert.Equal(t, ptrace.StatusCodeError, status.Code())
+		assert.Equal(t, "Keyspace not found in CB datastore: default:travel-sample._default.nonexistent", status.Message())
+
+		// The db.response.error attribute itself is NOT included in the span attributes
+		// (it's only used to populate the status message)
+		ensureTraceAttrNotExists(t, attrs, attribute.Key(attr.DBResponseError))
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBOperation), "SELECT")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBCollectionName), "travel-sample._default.nonexistent")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBNamespace), "travel-sample")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBSystemName), "couchbase")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBQueryText), "SELECT * FROM `travel-sample`._default.nonexistent")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.ErrorType), "12003")
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBResponseStatusCode), "12003")
+	})
 	t.Run("test SQL++ trace generation with minimal attributes", func(t *testing.T) {
 		span := request.Span{
 			Type:     request.EventTypeHTTPClient,


### PR DESCRIPTION
## Summary

Fixes #2015

The core fix for issue #2015 (database error text exported in span status messages) was implemented in #2066 by making `db.response.error` an optional attribute that is off by default. This PR completes the issue's acceptance criteria by adding explicit test coverage for the SQL++ error-message export behavior.

## Changes

- Added test `test SQL++ trace generation with error and db.response.error enabled` in `pkg/export/otel/traces_test.go`

## What the test verifies

1. When `db.response.error` is explicitly enabled, the SQL++ error description correctly appears in the span status message (opt-in behavior)
2. The `db.response.error` attribute itself is NOT included in the span attributes (it's only used to populate the status message, then removed)
3. All other DB attributes (db.operation.name, db.collection.name, db.namespace, db.system.name, db.query.text, error.type, db.response.status_code) are correctly set

## Acceptance Criteria Coverage

| Criterion | Status |
|-----------|--------|
| SQL++ error messages not exported verbatim by default | Covered by existing test (`test SQL++ trace generation with error`) |
| Error-message export explicitly gated | Covered by this new test (verifies opt-in via `db.response.error`) |
| Tests cover SQL++ error-message export behavior | ✅ Completed by this PR |

## Validation

- [x] Unit tests pass (verified via fork CI)
- [x] Lint checks pass
- [x] Generate and checks pass
- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)