### PR TITLE
feat(tool): add LLM tool call detection for OpenAI, Anthropic, Gemini, and Qwen

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -326,6 +326,12 @@ type OpenAIError struct {
 	Type    string `json:"type"`
 }
 
+// ToolCall represents a tool invocation requested by an LLM.
+type ToolCall struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name"`
+}
+
 type VendorOpenAI struct {
 	OperationName    string          `json:"object"`
 	ResponseModel    string          `json:"model"`
@@ -341,6 +347,7 @@ type VendorOpenAI struct {
 	Items            json.RawMessage `json:"items"`
 	Metadata         json.RawMessage `json:"metadata"`
 	Data             json.RawMessage `json:"data"`
+	ToolCalls        []ToolCall      `json:"-"`
 }
 
 func (ai *VendorOpenAI) GetOutput() string {
@@ -387,8 +394,9 @@ func (air *OpenAIInput) GetInput() string {
 }
 
 type VendorAnthropic struct {
-	Input  AnthropicRequest
-	Output AnthropicResponse
+	Input     AnthropicRequest
+	Output    AnthropicResponse
+	ToolCalls []ToolCall `json:"-"`
 }
 
 type AnthropicRequest struct {
@@ -436,6 +444,7 @@ type VendorGemini struct {
 	Output    GeminiResponse
 	Model     string
 	Operation string
+	ToolCalls []ToolCall `json:"-"`
 }
 
 type GeminiRequest struct {

--- a/pkg/ebpf/common/http/anthropic.go
+++ b/pkg/ebpf/common/http/anthropic.go
@@ -16,6 +16,35 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
 
+type anthropicContentBlock struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func extractAnthropicToolCalls(content json.RawMessage) []request.ToolCall {
+	if len(content) == 0 {
+		return nil
+	}
+
+	var blocks []anthropicContentBlock
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return nil
+	}
+
+	var result []request.ToolCall
+	for i := range blocks {
+		if blocks[i].Type != "tool_use" || blocks[i].Name == "" {
+			continue
+		}
+		result = append(result, request.ToolCall{
+			ID:   blocks[i].ID,
+			Name: blocks[i].Name,
+		})
+	}
+	return result
+}
+
 func isAnthropic(hdr http.Header) bool {
 	isAnthropic := false
 	for _, header := range []string{
@@ -73,22 +102,30 @@ func AnthropicSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 	}
 
 	var parsedResponse request.AnthropicResponse
+	var streamToolCalls []request.ToolCall
 	if len(respB) > 0 && respB[0] == '{' {
 		if err := json.Unmarshal(respB, &parsedResponse); err != nil {
 			slog.Debug("failed to parse Anthropic response", "error", err)
 		}
 	} else {
 		reader := bytes.NewReader(respB)
-		if streamResponse, err := parseAnthropicStream(reader); err == nil {
+		if streamResponse, tc, err := parseAnthropicStream(reader); err == nil {
 			parsedResponse = *streamResponse
+			streamToolCalls = tc
 		}
+	}
+
+	toolCalls := extractAnthropicToolCalls(parsedResponse.Content)
+	if len(toolCalls) == 0 {
+		toolCalls = streamToolCalls
 	}
 
 	baseSpan.SubType = request.HTTPSubtypeAnthropic
 	baseSpan.GenAI = &request.GenAI{
 		Anthropic: &request.VendorAnthropic{
-			Input:  parsedRequest,
-			Output: parsedResponse,
+			Input:     parsedRequest,
+			Output:    parsedResponse,
+			ToolCalls: toolCalls,
 		},
 	}
 
@@ -136,11 +173,12 @@ type MessageDeltaEvent struct {
 }
 
 // parseAnthropicStream parses the SSE stream from Anthropic API and returns the complete response
-func parseAnthropicStream(reader io.Reader) (*request.AnthropicResponse, error) {
+func parseAnthropicStream(reader io.Reader) (*request.AnthropicResponse, []request.ToolCall, error) {
 	scanner := bufio.NewScanner(reader)
 	response := &request.AnthropicResponse{}
 
 	var contentBuilder strings.Builder
+	var toolCalls []request.ToolCall
 	var currentEvent string
 	var currentData string
 
@@ -150,8 +188,8 @@ func parseAnthropicStream(reader io.Reader) (*request.AnthropicResponse, error) 
 		// Skip empty lines (they separate events)
 		if line == "" {
 			if currentEvent != "" && currentData != "" {
-				if err := processEvent(currentEvent, currentData, response, &contentBuilder); err != nil {
-					return nil, fmt.Errorf("error processing event %s: %w", currentEvent, err)
+				if err := processEvent(currentEvent, currentData, response, &contentBuilder, &toolCalls); err != nil {
+					return nil, nil, fmt.Errorf("error processing event %s: %w", currentEvent, err)
 				}
 			}
 			currentEvent = ""
@@ -173,14 +211,14 @@ func parseAnthropicStream(reader io.Reader) (*request.AnthropicResponse, error) 
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading stream: %w", err)
+		return nil, nil, fmt.Errorf("error reading stream: %w", err)
 	}
 
 	response.Content = json.RawMessage(contentBuilder.String())
-	return response, nil
+	return response, toolCalls, nil
 }
 
-func processEvent(eventType, data string, response *request.AnthropicResponse, contentBuilder *strings.Builder) error {
+func processEvent(eventType, data string, response *request.AnthropicResponse, contentBuilder *strings.Builder, toolCalls *[]request.ToolCall) error {
 	switch eventType {
 	case "message_start":
 		var event MessageStartEvent
@@ -213,12 +251,24 @@ func processEvent(eventType, data string, response *request.AnthropicResponse, c
 		response.Usage.InputTokens += event.Usage.InputTokens
 		response.Usage.OutputTokens += event.Usage.OutputTokens
 
-	case "ping", "content_block_start", "content_block_stop", "message_stop":
-		// These events don't need processing
+	case "content_block_start":
+		var event struct {
+			ContentBlock anthropicContentBlock `json:"content_block"`
+		}
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			return err
+		}
+		if event.ContentBlock.Type == "tool_use" && event.ContentBlock.Name != "" {
+			*toolCalls = append(*toolCalls, request.ToolCall{
+				ID:   event.ContentBlock.ID,
+				Name: event.ContentBlock.Name,
+			})
+		}
+
+	case "ping", "content_block_stop", "message_stop":
 		return nil
 
 	default:
-		// Unknown event type - log but don't fail
 		return nil
 	}
 

--- a/pkg/ebpf/common/http/anthropic.go
+++ b/pkg/ebpf/common/http/anthropic.go
@@ -102,22 +102,18 @@ func AnthropicSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 	}
 
 	var parsedResponse request.AnthropicResponse
-	var streamToolCalls []request.ToolCall
+	var toolCalls []request.ToolCall
 	if len(respB) > 0 && respB[0] == '{' {
 		if err := json.Unmarshal(respB, &parsedResponse); err != nil {
 			slog.Debug("failed to parse Anthropic response", "error", err)
 		}
+		toolCalls = extractAnthropicToolCalls(parsedResponse.Content)
 	} else {
 		reader := bytes.NewReader(respB)
 		if streamResponse, tc, err := parseAnthropicStream(reader); err == nil {
 			parsedResponse = *streamResponse
-			streamToolCalls = tc
+			toolCalls = tc
 		}
-	}
-
-	toolCalls := extractAnthropicToolCalls(parsedResponse.Content)
-	if len(toolCalls) == 0 {
-		toolCalls = streamToolCalls
 	}
 
 	baseSpan.SubType = request.HTTPSubtypeAnthropic

--- a/pkg/ebpf/common/http/anthropic_test.go
+++ b/pkg/ebpf/common/http/anthropic_test.go
@@ -4,6 +4,7 @@
 package ebpfcommon
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -216,7 +217,7 @@ data: {"type":"message_stop"}
 
 `
 
-	resp, err := parseAnthropicStream(strings.NewReader(stream))
+	resp, _, err := parseAnthropicStream(strings.NewReader(stream))
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -260,4 +261,117 @@ func TestAnthropicSpan_NotAnthropic(t *testing.T) {
 	_, ok := AnthropicSpan(base, req, resp)
 
 	assert.False(t, ok)
+}
+
+func TestAnthropicToolCalls(t *testing.T) {
+	t.Run("single tool_use", func(t *testing.T) {
+		content := json.RawMessage(`[{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{}}]`)
+		result := extractAnthropicToolCalls(content)
+		require.Len(t, result, 1)
+		assert.Equal(t, "toolu_01", result[0].ID)
+		assert.Equal(t, "get_weather", result[0].Name)
+	})
+
+	t.Run("mixed content text and tool_use", func(t *testing.T) {
+		content := json.RawMessage(`[{"type":"text","text":"hello"},{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{}},{"type":"tool_use","id":"toolu_02","name":"get_time","input":{}}]`)
+		result := extractAnthropicToolCalls(content)
+		require.Len(t, result, 2)
+		assert.Equal(t, "toolu_01", result[0].ID)
+		assert.Equal(t, "get_weather", result[0].Name)
+		assert.Equal(t, "toolu_02", result[1].ID)
+		assert.Equal(t, "get_time", result[1].Name)
+	})
+
+	t.Run("no tool calls", func(t *testing.T) {
+		content := json.RawMessage(`[{"type":"text","text":"Hello"}]`)
+		result := extractAnthropicToolCalls(content)
+		assert.Empty(t, result)
+	})
+
+	t.Run("empty content", func(t *testing.T) {
+		assert.Nil(t, extractAnthropicToolCalls(nil))
+		assert.Nil(t, extractAnthropicToolCalls(json.RawMessage{}))
+	})
+}
+
+func TestAnthropicStreamToolCalls(t *testing.T) {
+	stream := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"usage":{"input_tokens":100,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me check the weather."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"location\":\"Beijing\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: content_block_start
+data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_02","name":"get_time"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"timezone\":\"UTC\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":2}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":50}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+
+	resp, toolCalls, err := parseAnthropicStream(strings.NewReader(stream))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "msg_01", resp.ID)
+	assert.Equal(t, "claude-sonnet-4-20250514", resp.Model)
+
+	require.Len(t, toolCalls, 2)
+	assert.Equal(t, "toolu_01", toolCalls[0].ID)
+	assert.Equal(t, "get_weather", toolCalls[0].Name)
+	assert.Equal(t, "toolu_02", toolCalls[1].ID)
+	assert.Equal(t, "get_time", toolCalls[1].Name)
+}
+
+func TestAnthropicStreamNoToolCalls(t *testing.T) {
+	stream := `event: message_start
+data: {"type":"message_start","message":{"id":"msg_02","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"usage":{"input_tokens":50,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":10}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+
+	resp, toolCalls, err := parseAnthropicStream(strings.NewReader(stream))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Empty(t, toolCalls)
+	assert.Equal(t, "msg_02", resp.ID)
 }

--- a/pkg/ebpf/common/http/gemini.go
+++ b/pkg/ebpf/common/http/gemini.go
@@ -78,6 +78,35 @@ func extractHostname(req *http.Request) string {
 	return host
 }
 
+type geminiPart struct {
+	FunctionCall *struct {
+		Name string `json:"name"`
+	} `json:"functionCall,omitempty"`
+}
+
+func extractGeminiFunctionCalls(resp *request.GeminiResponse) []request.ToolCall {
+	var result []request.ToolCall
+	for i := range resp.Candidates {
+		c := &resp.Candidates[i]
+		if c.Content == nil || len(c.Content.Parts) == 0 {
+			continue
+		}
+		var parts []geminiPart
+		if err := json.Unmarshal(c.Content.Parts, &parts); err != nil {
+			continue
+		}
+		for j := range parts {
+			if parts[j].FunctionCall == nil || parts[j].FunctionCall.Name == "" {
+				continue
+			}
+			result = append(result, request.ToolCall{
+				Name: parts[j].FunctionCall.Name,
+			})
+		}
+	}
+	return result
+}
+
 func GeminiSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {
 	if !isGemini(req, resp.Header) {
 		return *baseSpan, false
@@ -108,6 +137,7 @@ func GeminiSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 
 	model := extractGeminiModel(req)
 	operation := extractGeminiOperation(req)
+	toolCalls := extractGeminiFunctionCalls(&parsedResponse)
 
 	baseSpan.SubType = request.HTTPSubtypeGemini
 	baseSpan.GenAI = &request.GenAI{
@@ -116,6 +146,7 @@ func GeminiSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 			Output:    parsedResponse,
 			Model:     model,
 			Operation: operation,
+			ToolCalls: toolCalls,
 		},
 	}
 

--- a/pkg/ebpf/common/http/gemini_test.go
+++ b/pkg/ebpf/common/http/gemini_test.go
@@ -5,6 +5,7 @@ package ebpfcommon
 
 import (
 	"bufio"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -344,4 +345,72 @@ func TestIsGeminiURL(t *testing.T) {
 			assert.Equal(t, tt.want, isGeminiURL(req))
 		})
 	}
+}
+
+func TestGeminiFunctionCalls(t *testing.T) {
+	t.Run("single function call", func(t *testing.T) {
+		resp := &request.GeminiResponse{
+			Candidates: []request.GeminiCandidate{
+				{
+					Content: &request.GeminiContent{
+						Parts: json.RawMessage(`[{"functionCall":{"name":"get_weather"}}]`),
+						Role:  "model",
+					},
+					FinishReason: "STOP",
+				},
+			},
+		}
+		result := extractGeminiFunctionCalls(resp)
+		require.Len(t, result, 1)
+		assert.Equal(t, "get_weather", result[0].Name)
+		assert.Empty(t, result[0].ID)
+	})
+
+	t.Run("multiple function calls", func(t *testing.T) {
+		resp := &request.GeminiResponse{
+			Candidates: []request.GeminiCandidate{
+				{
+					Content: &request.GeminiContent{
+						Parts: json.RawMessage(`[{"functionCall":{"name":"get_weather"}},{"functionCall":{"name":"get_time"}}]`),
+						Role:  "model",
+					},
+					FinishReason: "STOP",
+				},
+			},
+		}
+		result := extractGeminiFunctionCalls(resp)
+		require.Len(t, result, 2)
+		assert.Equal(t, "get_weather", result[0].Name)
+		assert.Equal(t, "get_time", result[1].Name)
+	})
+
+	t.Run("no function calls", func(t *testing.T) {
+		resp := &request.GeminiResponse{
+			Candidates: []request.GeminiCandidate{
+				{
+					Content: &request.GeminiContent{
+						Parts: json.RawMessage(`[{"text":"Hello, how can I help?"}]`),
+						Role:  "model",
+					},
+					FinishReason: "STOP",
+				},
+			},
+		}
+		result := extractGeminiFunctionCalls(resp)
+		assert.Empty(t, result)
+	})
+
+	t.Run("empty candidates", func(t *testing.T) {
+		resp := &request.GeminiResponse{}
+		result := extractGeminiFunctionCalls(resp)
+		assert.Empty(t, result)
+
+		resp2 := &request.GeminiResponse{
+			Candidates: []request.GeminiCandidate{
+				{Content: nil},
+			},
+		}
+		result2 := extractGeminiFunctionCalls(resp2)
+		assert.Empty(t, result2)
+	})
 }

--- a/pkg/ebpf/common/http/openai.go
+++ b/pkg/ebpf/common/http/openai.go
@@ -14,6 +14,44 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
 
+type openAIToolCall struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name string `json:"name"`
+	} `json:"function"`
+}
+
+func extractToolCalls(choices json.RawMessage) []request.ToolCall {
+	if len(choices) == 0 {
+		return nil
+	}
+
+	var parsed []struct {
+		Message struct {
+			ToolCalls []openAIToolCall `json:"tool_calls"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(choices, &parsed); err != nil {
+		return nil
+	}
+
+	var result []request.ToolCall
+	for i := range parsed {
+		for j := range parsed[i].Message.ToolCalls {
+			tc := &parsed[i].Message.ToolCalls[j]
+			if tc.Function.Name == "" {
+				continue
+			}
+			result = append(result, request.ToolCall{
+				ID:   tc.ID,
+				Name: tc.Function.Name,
+			})
+		}
+	}
+	return result
+}
+
 func OpenAISpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {
 	// Check any of the well known response headers that OpenAI would use
 	isOpenAI := false
@@ -52,6 +90,7 @@ func OpenAISpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 	}
 
 	parsedResponse.Request = parsedRequest
+	parsedResponse.ToolCalls = extractToolCalls(parsedResponse.Choices)
 
 	// Override operation name for embedding requests.
 	if req.URL != nil {

--- a/pkg/ebpf/common/http/openai_test.go
+++ b/pkg/ebpf/common/http/openai_test.go
@@ -6,6 +6,7 @@ package ebpfcommon
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -304,6 +305,37 @@ const embeddingsResponseBody = `{
     "total_tokens": 5
   }
 }`
+
+func TestOpenAIToolCalls(t *testing.T) {
+	t.Run("single tool call", func(t *testing.T) {
+		choices := json.RawMessage(`[{"message":{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather"}}]},"finish_reason":"tool_calls"}]`)
+		result := extractToolCalls(choices)
+		require.Len(t, result, 1)
+		assert.Equal(t, "call_1", result[0].ID)
+		assert.Equal(t, "get_weather", result[0].Name)
+	})
+
+	t.Run("multiple tool calls", func(t *testing.T) {
+		choices := json.RawMessage(`[{"message":{"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_weather"}},{"id":"call_2","type":"function","function":{"name":"get_time"}}]},"finish_reason":"tool_calls"}]`)
+		result := extractToolCalls(choices)
+		require.Len(t, result, 2)
+		assert.Equal(t, "call_1", result[0].ID)
+		assert.Equal(t, "get_weather", result[0].Name)
+		assert.Equal(t, "call_2", result[1].ID)
+		assert.Equal(t, "get_time", result[1].Name)
+	})
+
+	t.Run("no tool calls", func(t *testing.T) {
+		choices := json.RawMessage(`[{"message":{"content":"Hello"},"finish_reason":"stop"}]`)
+		result := extractToolCalls(choices)
+		assert.Empty(t, result)
+	})
+
+	t.Run("empty or nil choices", func(t *testing.T) {
+		assert.Nil(t, extractToolCalls(nil))
+		assert.Nil(t, extractToolCalls(json.RawMessage{}))
+	})
+}
 
 func TestOpenAISpan_Embeddings(t *testing.T) {
 	req := makeRequest(t, http.MethodPost, "http://api.openai.com/v1/embeddings", embeddingsRequestBody)

--- a/pkg/ebpf/common/http/qwen.go
+++ b/pkg/ebpf/common/http/qwen.go
@@ -93,6 +93,7 @@ func QwenSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (r
 	}
 
 	parsedResponse.Request = parsedRequest
+	parsedResponse.ToolCalls = extractToolCalls(parsedResponse.Choices)
 
 	baseSpan.SubType = request.HTTPSubtypeQwen
 	baseSpan.GenAI = &request.GenAI{

--- a/pkg/ebpf/common/http/qwen_test.go
+++ b/pkg/ebpf/common/http/qwen_test.go
@@ -195,6 +195,54 @@ func TestQwenSpan_NotQwen(t *testing.T) {
 	assert.False(t, ok)
 }
 
+const qwenToolCallRequestBody = `{
+  "model":"qwen-plus",
+  "messages":[{"role":"user","content":"What is the weather in Beijing?"}],
+  "tools":[{"type":"function","function":{"name":"get_weather","parameters":{"type":"object","properties":{"location":{"type":"string"}}}}}]
+}`
+
+const qwenToolCallResponseBody = `{
+  "id":"chatcmpl-tool-456",
+  "object":"chat.completion",
+  "model":"qwen-plus",
+  "choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"call_abc","type":"function","function":{"name":"get_weather"}}]},"finish_reason":"tool_calls"}],
+  "usage":{"prompt_tokens":20,"completion_tokens":5,"total_tokens":25}
+}`
+
+func TestQwenSpan_ToolCalls(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions", qwenToolCallRequestBody)
+	resp := makePlainResponse(http.StatusOK, qwenHeaders(), qwenToolCallResponseBody)
+
+	base := &request.Span{}
+	span, ok := QwenSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Qwen)
+	assert.Equal(t, request.HTTPSubtypeQwen, span.SubType)
+
+	ai := span.GenAI.Qwen
+	assert.Equal(t, "chatcmpl-tool-456", ai.ID)
+	assert.Equal(t, "chat.completion", ai.OperationName)
+	assert.Equal(t, "qwen-plus", ai.Request.Model)
+	require.Len(t, ai.ToolCalls, 1)
+	assert.Equal(t, "call_abc", ai.ToolCalls[0].ID)
+	assert.Equal(t, "get_weather", ai.ToolCalls[0].Name)
+}
+
+func TestQwenSpan_NoToolCalls(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions", qwenCompatibleRequestBody)
+	resp := makePlainResponse(http.StatusOK, qwenHeaders(), qwenCompatibleResponseBody)
+
+	base := &request.Span{}
+	span, ok := QwenSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Qwen)
+	assert.Empty(t, span.GenAI.Qwen.ToolCalls)
+}
+
 func TestExtractQwenOperation(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -248,6 +248,7 @@ const (
 	GenAIMetadata     = Name("gen_ai.metadata")
 	GenAITools        = Name(semconv.GenAIToolDefinitionsKey)
 	GenAIToolName     = Name("gen_ai.tool.name")
+	GenAIToolCallID   = Name("gen_ai.tool.call.id")
 	GenAIPromptName   = Name("gen_ai.prompt.name")
 )
 

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -325,6 +325,33 @@ var (
 	spanMetricsSkip     = attribute.Bool(string(attr.SkipSpanMetrics), true)
 )
 
+// genAIToolCallAttributes returns trace attributes for LLM tool calls.
+func genAIToolCallAttributes(toolCalls []request.ToolCall) []attribute.KeyValue {
+	if len(toolCalls) == 0 {
+		return nil
+	}
+
+	var names []string
+	var ids []string
+	for _, tc := range toolCalls {
+		if tc.Name != "" {
+			names = append(names, tc.Name)
+		}
+		if tc.ID != "" {
+			ids = append(ids, tc.ID)
+		}
+	}
+
+	var attrs []attribute.KeyValue
+	if len(names) > 0 {
+		attrs = append(attrs, attribute.StringSlice(string(attr.GenAIToolName), names))
+	}
+	if len(ids) > 0 {
+		attrs = append(attrs, attribute.StringSlice(string(attr.GenAIToolCallID), ids))
+	}
+	return attrs
+}
+
 // mcpAttributes returns MCP span attributes following the OTEL MCP semantic conventions.
 func mcpAttributes(span *request.Span) []attribute.KeyValue {
 	if span.SubType != request.HTTPSubtypeMCP || span.GenAI == nil || span.GenAI.MCP == nil {
@@ -591,6 +618,7 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			if ai.OperationName == request.EmbeddingOperationName && ai.Request.Dimensions > 0 {
 				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.dimensions", ai.Request.Dimensions))
 			}
+			attrs = append(attrs, genAIToolCallAttributes(ai.ToolCalls)...)
 		}
 
 		if span.SubType == request.HTTPSubtypeAnthropic && span.GenAI != nil && span.GenAI.Anthropic != nil {
@@ -627,6 +655,7 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Output.Error.Type))
 				attrs = append(attrs, semconv.ErrorMessage(ai.Output.Error.Message))
 			}
+			attrs = append(attrs, genAIToolCallAttributes(ai.ToolCalls)...)
 		}
 
 		if span.SubType == request.HTTPSubtypeGemini && span.GenAI != nil && span.GenAI.Gemini != nil {
@@ -696,6 +725,7 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Output.Error.Status))
 				attrs = append(attrs, semconv.ErrorMessage(ai.Output.Error.Message))
 			}
+			attrs = append(attrs, genAIToolCallAttributes(ai.ToolCalls)...)
 		}
 
 		if span.SubType == request.HTTPSubtypeQwen && span.GenAI != nil && span.GenAI.Qwen != nil {
@@ -742,6 +772,7 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Error.Type))
 				attrs = append(attrs, semconv.ErrorMessage(ai.Error.Message))
 			}
+			attrs = append(attrs, genAIToolCallAttributes(ai.ToolCalls)...)
 		}
 
 		if span.SubType == request.HTTPSubtypeAWSBedrock && span.GenAI != nil && span.GenAI.Bedrock != nil {

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -326,6 +326,8 @@ var (
 )
 
 // genAIToolCallAttributes returns trace attributes for LLM tool calls.
+// Only tool calls with non-empty names are included. Names and IDs are kept
+// aligned so that the same index refers to the same tool call.
 func genAIToolCallAttributes(toolCalls []request.ToolCall) []attribute.KeyValue {
 	if len(toolCalls) == 0 {
 		return nil
@@ -333,12 +335,15 @@ func genAIToolCallAttributes(toolCalls []request.ToolCall) []attribute.KeyValue 
 
 	var names []string
 	var ids []string
+	hasIDs := false
 	for _, tc := range toolCalls {
-		if tc.Name != "" {
-			names = append(names, tc.Name)
+		if tc.Name == "" {
+			continue
 		}
+		names = append(names, tc.Name)
+		ids = append(ids, tc.ID)
 		if tc.ID != "" {
-			ids = append(ids, tc.ID)
+			hasIDs = true
 		}
 	}
 
@@ -346,7 +351,7 @@ func genAIToolCallAttributes(toolCalls []request.ToolCall) []attribute.KeyValue 
 	if len(names) > 0 {
 		attrs = append(attrs, attribute.StringSlice(string(attr.GenAIToolName), names))
 	}
-	if len(ids) > 0 {
+	if hasIDs {
 		attrs = append(attrs, attribute.StringSlice(string(attr.GenAIToolCallID), ids))
 	}
 	return attrs

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
@@ -36,4 +37,52 @@ func TestTraceAttributesSelector_DNSQuestionName(t *testing.T) {
 
 	optInAttrs := TraceAttributesSelector(span, defaultAttrs)
 	assert.Contains(t, optInAttrs, semconv.DNSQuestionName("example.com"))
+}
+
+func TestGenAIToolCallAttributes(t *testing.T) {
+	t.Run("nil tool calls", func(t *testing.T) {
+		assert.Nil(t, genAIToolCallAttributes(nil))
+	})
+
+	t.Run("empty tool calls", func(t *testing.T) {
+		assert.Nil(t, genAIToolCallAttributes([]request.ToolCall{}))
+	})
+
+	t.Run("single tool call with ID", func(t *testing.T) {
+		attrs := genAIToolCallAttributes([]request.ToolCall{
+			{ID: "call_1", Name: "get_weather"},
+		})
+		require.Len(t, attrs, 2)
+		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolName), []string{"get_weather"}), attrs[0])
+		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolCallID), []string{"call_1"}), attrs[1])
+	})
+
+	t.Run("multiple tool calls with IDs", func(t *testing.T) {
+		attrs := genAIToolCallAttributes([]request.ToolCall{
+			{ID: "call_1", Name: "get_weather"},
+			{ID: "call_2", Name: "get_time"},
+		})
+		require.Len(t, attrs, 2)
+		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolName), []string{"get_weather", "get_time"}), attrs[0])
+		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolCallID), []string{"call_1", "call_2"}), attrs[1])
+	})
+
+	t.Run("tool calls without IDs", func(t *testing.T) {
+		attrs := genAIToolCallAttributes([]request.ToolCall{
+			{Name: "get_weather"},
+			{Name: "get_time"},
+		})
+		require.Len(t, attrs, 1)
+		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolName), []string{"get_weather", "get_time"}), attrs[0])
+	})
+
+	t.Run("skips empty names", func(t *testing.T) {
+		attrs := genAIToolCallAttributes([]request.ToolCall{
+			{ID: "call_1", Name: ""},
+			{ID: "call_2", Name: "get_time"},
+		})
+		require.Len(t, attrs, 2)
+		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolName), []string{"get_time"}), attrs[0])
+		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolCallID), []string{"call_1", "call_2"}), attrs[1])
+	})
 }

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -83,6 +83,6 @@ func TestGenAIToolCallAttributes(t *testing.T) {
 		})
 		require.Len(t, attrs, 2)
 		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolName), []string{"get_time"}), attrs[0])
-		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolCallID), []string{"call_1", "call_2"}), attrs[1])
+		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolCallID), []string{"call_2"}), attrs[1])
 	})
 }


### PR DESCRIPTION
## Summary

Adds tool call detection for four major LLM providers, addressing part of the AI Agent Observability Support (issue #1854).

## Changes

### Data Model
- Added `ToolCall` struct with `ID` and `Name` fields
- Extended `VendorOpenAI`, `VendorAnthropic`, `VendorGemini` with `ToolCalls` field

### Detection Logic
- **OpenAI**: Extracts `tool_calls` from `choices[].message.tool_calls`
- **Anthropic**: Extracts `tool_use` blocks from response content (both streaming and non-streaming)
- **Gemini**: Extracts `functionCall` from `candidates[].content.parts[]`
- **Qwen**: Reuses OpenAI-compatible `extractToolCalls` for `choices[].message.tool_calls`

### Trace Attributes
- Generates `gen_ai.tool.name` (comma-separated for multiple calls)
- Generates `gen_ai.tool.call.id` (when single call with ID)


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
