### PR TITLE
Add regression tests for OBI exclusion scope

### DIFF
--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -747,6 +747,9 @@ func TestDefaultExclusionFilter(t *testing.T) {
 	assert.True(t, c[0].Path.MatchString("otelcol-contrib"))
 
 	assert.False(t, c[0].Path.MatchString("/usr/bin/obi/test"))
+	assert.False(t, c[0].Path.MatchString("myobi"))
+	assert.False(t, c[0].Path.MatchString("/usr/bin/myobi"))
+	assert.False(t, c[0].Path.MatchString("/usr/bin/obi-helper"))
 	assert.False(t, c[0].Path.MatchString("/usr/bin/otelcol-contrib/test"))
 
 	assert.True(t, c[0].Path.MatchString("/obi"))
@@ -763,6 +766,10 @@ func TestDefaultLegacyExclusionFilter(t *testing.T) {
 	assert.True(t, c[0].Path.MatchString("obi"))
 	assert.True(t, c[0].Path.MatchString("otelcol-contrib"))
 
+	assert.False(t, c[0].Path.MatchString("/usr/bin/obi/test"))
+	assert.False(t, c[0].Path.MatchString("myobi"))
+	assert.False(t, c[0].Path.MatchString("/usr/bin/myobi"))
+	assert.False(t, c[0].Path.MatchString("/usr/bin/obi-helper"))
 	assert.False(t, c[0].Path.MatchString("/usr/bin/otelcol-contrib/test"))
 
 	assert.True(t, c[0].Path.MatchString("/obi"))


### PR DESCRIPTION
Fixes #1254.

## What changed
- Added regression coverage for the default `exclude_instrument` glob so paths that only contain `obi` as a substring are not excluded.
- Added the same coverage for the legacy `default_exclude_services` regex path selector, including `/usr/bin/obi/test` and `obi` substring cases.

## Why
The default OBI exclusion should target the `obi` binary/path segment without excluding unrelated binaries whose paths merely contain the substring `obi`.

## Validation
- `gofmt -w pkg/obi/config_test.go`
- `git diff --check`
- `go test ./pkg/appolly/services`

Note: `go test ./pkg/obi` does not build in my local Windows environment because this package pulls Linux/eBPF-only symbols and generated BPF bindings that are unavailable there.