### PR TITLE
tests: fix failing weaver validation

### DIFF
--- a/internal/test/integration/configs/obi-config-with-jaeger-host.yml
+++ b/internal/test/integration/configs/obi-config-with-jaeger-host.yml
@@ -4,3 +4,7 @@ otel_metrics_export:
   endpoint: http://127.0.0.1:4018
 otel_traces_export:
   endpoint: http://127.0.0.1:4318
+attributes:
+  select:
+    dns_lookup_duration:
+      include: ["dns.question.name"]


### PR DESCRIPTION
## Summary

`main` tests are failing because of a merge race (https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/25867990398/job/76015217963)

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
