### PR TITLE
Exclude dns.question.name from weaver live-check

### DIFF
--- a/internal/test/integration/weaver.go
+++ b/internal/test/integration/weaver.go
@@ -52,6 +52,13 @@ var weaverIgnoredSignals = map[string]struct{}{
 	// >= 1.40.0 (which restores rpc duration to seconds).
 	"metric:rpc.server.duration": {},
 	"metric:rpc.client.duration": {},
+	// OBI keeps `dns.question.name` as opt-in on `dns.lookup.duration` to
+	// avoid unbounded label cardinality for services that query many
+	// distinct hostnames. Upstream semconv v1.38 declares the attribute
+	// as `requirement_level: required`, so live-check flags every emitted
+	// data point. Users who accept the cardinality can enable the
+	// attribute via the metrics attribute selection.
+	"metric:dns.lookup.duration": {},
 }
 
 // weaverIgnoredAdviceMessages suppresses specific advice messages that match


### PR DESCRIPTION
## Summary

Add metric:dns.lookup.duration to weaverIgnoredSignals. Upstream semconv v1.38 declares dns.question.name as a required attribute on this metric,but OBI keeps it opt-in to avoid unbounded label cardinality for services that query many distinct hostnames. Users who accept the cardinality canenable it via the metrics attribute selection.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
