### PR TITLE
ci(supervisor): remove PR comment feature

### DIFF
--- a/.github/workflows/supervisor_rerun-flaky.yml
+++ b/.github/workflows/supervisor_rerun-flaky.yml
@@ -1,6 +1,6 @@
 name: "CI Supervisor: Rerun flaky failures"
 
-on: # zizmor: ignore[dangerous-triggers] checks out only scripts/rerun-flaky.sh from default branch (explicit ref); GITHUB_TOKEN used for all ops
+on: # zizmor: ignore[dangerous-triggers] checks out only scripts/rerun-flaky.sh from default branch (explicit ref); GITHUB_TOKEN scoped to actions:write
   workflow_run:
     workflows:
       - "Pull request checks"
@@ -23,14 +23,12 @@ jobs:
   evaluate-and-rerun:
     name: Evaluate failed checks
     if: >
-      (github.event.workflow_run.conclusion == 'failure' ||
-      github.event.workflow_run.conclusion == 'timed_out') &&
-      github.event.workflow_run.actor.login != 'renovate[bot]'
+      github.event.workflow_run.conclusion == 'failure' ||
+      github.event.workflow_run.conclusion == 'timed_out'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       actions: write
-      pull-requests: write
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/scripts/rerun-flaky.sh
+++ b/scripts/rerun-flaky.sh
@@ -6,7 +6,7 @@
 # Called by .github/workflows/supervisor_rerun-flaky.yml
 #
 # Required environment variables:
-#   GH_TOKEN       - GitHub token with actions:write and pull-requests:write
+#   GH_TOKEN       - GitHub token with actions:write
 #   RUN_ID         - The workflow run ID that failed
 #   WORKFLOW_NAME  - The name of the failed workflow
 #   REPO           - The owner/repo string (e.g. open-telemetry/opentelemetry-ebpf-instrumentation)
@@ -14,35 +14,8 @@
 set -euo pipefail
 
 MAX_ATTEMPTS=2
-MARKER="<!-- ci-supervisor -->"
 
-# --- Resolve the associated PR ---
-RUN_DATA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}" \
-  --jq '{pr: .pull_requests[0].number, head_branch: .head_branch, head_owner: .head_repository.owner.login}')
-PR_NUMBER=$(echo "$RUN_DATA" | jq -r '.pr // empty')
-
-# Fallback for fork PRs: pull_requests array is often empty.
-# The commits/{sha}/pulls endpoint doesn't work for fork commits (the SHA
-# doesn't exist in the base repo). Instead, query by head={owner}:{branch}.
-if [ -z "$PR_NUMBER" ]; then
-  HEAD_BRANCH=$(echo "$RUN_DATA" | jq -r '.head_branch // empty')
-  HEAD_OWNER=$(echo "$RUN_DATA" | jq -r '.head_owner // empty')
-  if [ -n "$HEAD_OWNER" ] && [ -n "$HEAD_BRANCH" ]; then
-    echo "pull_requests empty — falling back to pulls?head=${HEAD_OWNER}:${HEAD_BRANCH} lookup"
-    PR_NUMBER=$(gh api "repos/${REPO}/pulls?state=open&head=${HEAD_OWNER}:${HEAD_BRANCH}&per_page=1" \
-      --jq '.[0].number // empty' || true)
-  fi
-fi
-
-if [ -z "$PR_NUMBER" ]; then
-  echo "No PR associated with run ${RUN_ID}. Exiting."
-  exit 0
-fi
-if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
-  echo "Invalid PR number: ${PR_NUMBER}. Exiting."
-  exit 1
-fi
-echo "PR #${PR_NUMBER} -- workflow: ${WORKFLOW_NAME}"
+echo "Evaluating run ${RUN_ID} -- workflow: ${WORKFLOW_NAME}"
 
 # --- Get run details ---
 RUN_JSON=$(gh run view "$RUN_ID" --repo "$REPO" --json attempt,jobs,name)
@@ -57,10 +30,11 @@ if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
   REASON="Maximum re-run attempts reached (attempt ${ATTEMPT} of ${MAX_ATTEMPTS})"
 fi
 
-# --- Build new table rows for this workflow's failed jobs ---
-NEW_ROWS=""
+# --- Scan this workflow's failed jobs ---
+FOUND_FAILURE=0
 
 while IFS=$'\t' read -r job_name job_conclusion; do
+  FOUND_FAILURE=1
   # Unrecoverable: lint/format/tidy failures won't be fixed by re-running
   if [ "$WORKFLOW_NAME" = "Pull request checks" ] \
      && echo "$job_name" | grep -qi "lint"; then
@@ -69,18 +43,9 @@ while IFS=$'\t' read -r job_name job_conclusion; do
       REASON="Lint job failed in '${WORKFLOW_NAME}' -- static analysis/style failure, re-run will not help"
     fi
   fi
-
-  if [ "$VERDICT" = "rerun" ]; then
-    rerunning="Yes"
-  else
-    rerunning="No"
-  fi
-
-  NEW_ROWS="${NEW_ROWS}| ${WORKFLOW_NAME} | ${job_name} | ${job_conclusion} | ${rerunning} | ${ATTEMPT}/${MAX_ATTEMPTS} |
-"
 done < <(echo "$RUN_JSON" | jq -r '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out") | [.name, .conclusion] | @tsv')
 
-if [ -z "$NEW_ROWS" ]; then
+if [ "$FOUND_FAILURE" -eq 0 ]; then
   echo "No failed or timed-out jobs found. Exiting."
   exit 0
 fi
@@ -91,39 +56,4 @@ if [ "$VERDICT" = "rerun" ]; then
   gh run rerun "$RUN_ID" --repo "$REPO" --failed
 else
   echo "Skipping re-run: ${REASON}"
-fi
-
-# --- Fetch existing sticky comment (if any) and merge rows ---
-EXISTING_COMMENT=$(gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" 2>/dev/null \
-  | jq -s --arg marker "$MARKER" '[.[][] | select(.body | startswith($marker))] | last | {id, body}' \
-  || echo '{}')
-EXISTING_COMMENT_ID=$(echo "$EXISTING_COMMENT" | jq -r '.id // empty')
-EXISTING_BODY=$(echo "$EXISTING_COMMENT" | jq -r '.body // empty')
-
-# Extract existing table rows, dropping rows that belong to the current workflow
-# (they'll be replaced by NEW_ROWS).
-KEPT_ROWS=""
-if [ -n "$EXISTING_BODY" ]; then
-  KEPT_ROWS=$(echo "$EXISTING_BODY" | grep '^|' | grep -v '^| Workflow' | grep -v '^|---' | grep -v "^| ${WORKFLOW_NAME} |" || true)
-  if [ -n "$KEPT_ROWS" ]; then
-    KEPT_ROWS="${KEPT_ROWS}
-"
-  fi
-fi
-
-# --- Build the full comment ---
-COMMENT_BODY="${MARKER}
-### CI Supervisor
-
-| Workflow | Job | Last state | Re-running? | Attempt |
-|----------|-----|-----------|-------------|---------|
-${KEPT_ROWS}${NEW_ROWS}"
-
-if [ -n "$EXISTING_COMMENT_ID" ]; then
-  gh api "repos/${REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
-    --method PATCH --field body="$COMMENT_BODY" > /dev/null
-  echo "Updated CI Supervisor comment (id: ${EXISTING_COMMENT_ID}) on PR #${PR_NUMBER}"
-else
-  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT_BODY"
-  echo "Posted CI Supervisor comment on PR #${PR_NUMBER}"
 fi


### PR DESCRIPTION
## Summary

Remove the CI supervisor's PR commenting, it's no longer required as auditing of flaky tests can be done via the daily report, and the comment is mostly noise on PRs (which often have genuine test failures).

Also re-enable the auto re-running of failed checks on renovate PRs as the comment noise is gone.

This workflow can't be tested as it must run from main for security reasons. The only risk is that the auto re-running of failed checks stops working.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
