### PR TITLE
fix(#2016): scope gRPC client connection cache by PID

### DIFF
--- a/bpf/gotracer/go_grpc.c
+++ b/bpf/gotracer/go_grpc.c
@@ -562,8 +562,11 @@ int obi_uprobe_transport_http2Client_NewStream(struct pt_regs *ctx) {
             bpf_probe_read(&conn_ptr_key, sizeof(conn_ptr_key), conn_ptr);
         }
 
+        go_addr_key_t cache_key = {};
+        go_addr_key_from_id(&cache_key, t_ptr);
+
         connection_info_t *cached_conn =
-            bpf_map_lookup_elem(&cached_grpc_client_connections, &t_ptr);
+            bpf_map_lookup_elem(&cached_grpc_client_connections, &cache_key);
         // reading the connection can be expensive for high volume of
         // new grpc client connections. We cache it, since most grpc client
         // connections are long lived.
@@ -595,7 +598,7 @@ int obi_uprobe_transport_http2Client_NewStream(struct pt_regs *ctx) {
                     if (ok) {
                         bpf_map_update_elem(&ongoing_client_connections, &g_key, &conn, BPF_ANY);
                         bpf_map_update_elem(
-                            &cached_grpc_client_connections, &t_ptr, &conn, BPF_ANY);
+                            &cached_grpc_client_connections, &cache_key, &conn, BPF_ANY);
 
                         if (conn_ptr_key) {
                             bpf_map_update_elem(

--- a/bpf/gotracer/go_grpc.c
+++ b/bpf/gotracer/go_grpc.c
@@ -562,6 +562,9 @@ int obi_uprobe_transport_http2Client_NewStream(struct pt_regs *ctx) {
             bpf_probe_read(&conn_ptr_key, sizeof(conn_ptr_key), conn_ptr);
         }
 
+        // PID-scoped cache key: uses the transport pointer as the address
+        // component to avoid stale entries when pointer values are recycled
+        // across different processes.
         go_addr_key_t cache_key = {};
         go_addr_key_from_id(&cache_key, t_ptr);
 

--- a/bpf/gotracer/maps/grpc.h
+++ b/bpf/gotracer/maps/grpc.h
@@ -35,7 +35,7 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __type(key, u64); // key: pointer to the client
+    __type(key, go_addr_key_t); // key: pid + pointer to the transport
     __type(value, connection_info_t);
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
 } cached_grpc_client_connections SEC(".maps");


### PR DESCRIPTION
## Summary

Fixes open-telemetry/opentelemetry-ebpf-instrumentation#2016

The `cached_grpc_client_connections` BPF map was keyed only by a raw transport pointer (`u64`), allowing stale connection metadata to leak across processes when pointer values are reused.

## Changes

- **`bpf/gotracer/maps/grpc.h`**: Change map key type from `u64` to `go_addr_key_t` (pid + pointer composite key)
- **`bpf/gotracer/go_grpc.c`**: Use `go_addr_key_from_id()` to construct the PID-scoped cache key for both lookup and update operations

## How it works

The `go_addr_key_t` struct combines the current process PID with the transport pointer address, ensuring that:
1. Cache entries cannot be shared across different processes even if pointer values are reused
2. The fix follows the same pattern used by other gRPC maps in the codebase (`ongoing_grpc_client_requests`, `ongoing_grpc_server_requests`, etc.)

The map remains `BPF_MAP_TYPE_LRU_HASH`, so within-process stale entries are naturally evicted when the map reaches capacity.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
