### PR TITLE
build: set obi-generator to go 1.25.10

### DIFF
--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS base
+FROM golang:1.25.10-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS base
 FROM base AS dist
 
 WORKDIR /src


### PR DESCRIPTION
## Summary

Renovate patched this to 1.26, I'm resetting it to 1.25.10 to match the upcoming go.mod change. It makes sense to publish a new obi-generator image using the same Go version that will be used in the main Dockerfile.

Following [devdocs/go-version-upgrade.md](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/go-version-upgrade.md).

obi-generator 0.2.13 [published](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/25930402520/job/76222524555).

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
