### PR TITLE
build: bump to go 1.25.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TAG=0.2.12@sha256:6f3e8b73b6b93e01380315cea5a4d31e270bf3f8d08ca61eba05240a12fbfe60
+ARG TAG=0.2.13@sha256:d7b46e5d965d29cf524afd32a53822a2950a747ca8dcceef42e5c80cad9df021
 
 # Build JNI native library using Go image (has gcc, no apt install needed)
 FROM golang:1.26.3@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b AS jni-builder

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # The generator is a container image that provides a reproducible environment for
 # building eBPF binaries
-GEN_IMG ?= ghcr.io/open-telemetry/obi-generator:0.2.12
+GEN_IMG ?= ghcr.io/open-telemetry/obi-generator:0.2.13
 
 OCI_BIN ?= docker
 

--- a/configs/offsets/gin/go.mod
+++ b/configs/offsets/gin/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/gin
 
-go 1.25.9
+go 1.25.10
 
 require github.com/gin-gonic/gin v1.12.0
 

--- a/configs/offsets/kafkago/go.mod
+++ b/configs/offsets/kafkago/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/kafkago
 
-go 1.25.9
+go 1.25.10
 
 require github.com/segmentio/kafka-go v0.4.51
 

--- a/configs/offsets/mongo/go.mod
+++ b/configs/offsets/mongo/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/mongo
 
-go 1.25.9
+go 1.25.10
 
 require go.mongodb.org/mongo-driver v1.17.9
 

--- a/configs/offsets/mongov2/go.mod
+++ b/configs/offsets/mongov2/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/mongov2
 
-go 1.25.9
+go 1.25.10
 
 require go.mongodb.org/mongo-driver/v2 v2.6.0
 

--- a/configs/offsets/mux/go.mod
+++ b/configs/offsets/mux/go.mod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/obi/configs/offsets/mux
 
-go 1.25.9
+go 1.25.10
 
 require github.com/gorilla/mux v1.8.1

--- a/configs/offsets/mysql/go.mod
+++ b/configs/offsets/mysql/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/mysql
 
-go 1.25.9
+go 1.25.10
 
 require github.com/go-sql-driver/mysql v1.10.0
 

--- a/configs/offsets/otelsdk/go.mod
+++ b/configs/offsets/otelsdk/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/otelsdk
 
-go 1.25.9
+go 1.25.10
 
 require go.opentelemetry.io/otel v1.43.0
 

--- a/configs/offsets/redis/go.mod
+++ b/configs/offsets/redis/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/redis
 
-go 1.25.9
+go 1.25.10
 
 require github.com/redis/go-redis/v9 v9.19.0
 

--- a/configs/offsets/sarama/go.mod
+++ b/configs/offsets/sarama/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/sarama
 
-go 1.25.9
+go 1.25.10
 
 require github.com/IBM/sarama v1.48.0
 

--- a/configs/offsets/shopify/go.mod
+++ b/configs/offsets/shopify/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/configs/offsets/shopify
 
-go 1.25.9
+go 1.25.10
 
 require github.com/Shopify/sarama v1.37.1
 

--- a/examples/http-header-enrichment-demo/app/go.mod
+++ b/examples/http-header-enrichment-demo/app/go.mod
@@ -1,3 +1,3 @@
 module go.opentelemetry.io/obi/examples/http-header-enrichment-demo/app
 
-go 1.25.9
+go 1.25.10

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396

--- a/internal/test/integration/components/go_grpc_server_mux/go.mod
+++ b/internal/test/integration/components/go_grpc_server_mux/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/go_grpc_server_mux
 
-go 1.25.9
+go 1.25.10
 
 require (
 	golang.org/x/net v0.52.0

--- a/internal/test/integration/components/go_otel/go.mod
+++ b/internal/test/integration/components/go_otel/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/go_otel
 
-go 1.25.9
+go 1.25.10
 
 require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0

--- a/internal/test/integration/components/go_otel_grpc/go.mod
+++ b/internal/test/integration/components/go_otel_grpc/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/go_otel_grpc
 
-go 1.25.9
+go 1.25.10
 
 require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0

--- a/internal/test/integration/components/gohttp2/client/go.mod
+++ b/internal/test/integration/components/gohttp2/client/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/go_http2/client
 
-go 1.25.9
+go 1.25.10
 
 require golang.org/x/net v0.53.0
 

--- a/internal/test/integration/components/gohttp2/server/go.mod
+++ b/internal/test/integration/components/gohttp2/server/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/go_http2/server
 
-go 1.25.9
+go 1.25.10
 
 require golang.org/x/net v0.53.0
 

--- a/internal/test/integration/components/gokafka-seg/go.mod
+++ b/internal/test/integration/components/gokafka-seg/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gokafka-seg
 
-go 1.25.9
+go 1.25.10
 
 require github.com/segmentio/kafka-go v0.4.50
 

--- a/internal/test/integration/components/gokafka/go.mod
+++ b/internal/test/integration/components/gokafka/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gokafka
 
-go 1.25.9
+go 1.25.10
 
 require github.com/IBM/sarama v1.48.0
 

--- a/internal/test/integration/components/gomongo/go.mod
+++ b/internal/test/integration/components/gomongo/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gomongo
 
-go 1.25.9
+go 1.25.10
 
 require go.mongodb.org/mongo-driver v1.17.9
 

--- a/internal/test/integration/components/gomongov2/go.mod
+++ b/internal/test/integration/components/gomongov2/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gomongov2
 
-go 1.25.9
+go 1.25.10
 
 require go.mongodb.org/mongo-driver/v2 v2.6.0
 

--- a/internal/test/integration/components/gomqtt/go.mod
+++ b/internal/test/integration/components/gomqtt/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gomqtt
 
-go 1.25.9
+go 1.25.10
 
 require github.com/eclipse/paho.mqtt.golang v1.5.1
 

--- a/internal/test/integration/components/gomysql-otelsql/go.mod
+++ b/internal/test/integration/components/gomysql-otelsql/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gomysql-otelsql
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/XSAM/otelsql v0.42.0

--- a/internal/test/integration/components/gomysql-tls/go.mod
+++ b/internal/test/integration/components/gomysql-tls/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gomysql
 
-go 1.25.9
+go 1.25.10
 
 require github.com/go-sql-driver/mysql v1.10.0
 

--- a/internal/test/integration/components/gomysql/go.mod
+++ b/internal/test/integration/components/gomysql/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gomysql
 
-go 1.25.9
+go 1.25.10
 
 require github.com/go-sql-driver/mysql v1.10.0
 

--- a/internal/test/integration/components/gopgx/go.mod
+++ b/internal/test/integration/components/gopgx/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gopgx
 
-go 1.25.9
+go 1.25.10
 
 require github.com/jackc/pgx/v5 v5.9.1
 

--- a/internal/test/integration/components/goredis/go.mod
+++ b/internal/test/integration/components/goredis/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/goredis
 
-go 1.25.9
+go 1.25.10
 
 require github.com/redis/go-redis/v9 v9.19.0
 

--- a/internal/test/integration/components/gosql/go.mod
+++ b/internal/test/integration/components/gosql/go.mod
@@ -1,5 +1,5 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/gosql
 
-go 1.25.9
+go 1.25.10
 
 require github.com/lib/pq v1.12.1

--- a/internal/test/integration/components/java_tls/wrapper/go.mod
+++ b/internal/test/integration/components/java_tls/wrapper/go.mod
@@ -1,3 +1,3 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/wrapper
 
-go 1.25.9
+go 1.25.10

--- a/internal/test/integration/components/old_grpc/backend/Dockerfile
+++ b/internal/test/integration/components/old_grpc/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9@sha256:8a7adc288b77e9b787cd2695029eb54d10ae80571b21d44fed68d067ad0a9c96 AS builder
+FROM golang:1.25.10@sha256:315d6d304226d0180a011ead57af82c9fe16f84fcf0eaa17d11034a53f63fbc4 AS builder
 
 WORKDIR /src/go.opentelemetry.io/obi/internal/test/integration/components/old_grpc/
 

--- a/internal/test/integration/components/old_grpc/backend/go.mod
+++ b/internal/test/integration/components/old_grpc/backend/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/old_grpc/backend
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/caarlos0/env/v7 v7.1.0

--- a/internal/test/integration/components/old_grpc/backend/internal/distributed-service-example/Dockerfile
+++ b/internal/test/integration/components/old_grpc/backend/internal/distributed-service-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9@sha256:8a7adc288b77e9b787cd2695029eb54d10ae80571b21d44fed68d067ad0a9c96 AS builder
+FROM golang:1.25.10@sha256:315d6d304226d0180a011ead57af82c9fe16f84fcf0eaa17d11034a53f63fbc4 AS builder
 
 WORKDIR /src
 

--- a/internal/test/integration/components/old_grpc/worker/Dockerfile
+++ b/internal/test/integration/components/old_grpc/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.9@sha256:8a7adc288b77e9b787cd2695029eb54d10ae80571b21d44fed68d067ad0a9c96 AS builder
+FROM golang:1.25.10@sha256:315d6d304226d0180a011ead57af82c9fe16f84fcf0eaa17d11034a53f63fbc4 AS builder
 
 WORKDIR /src
 

--- a/internal/test/integration/components/old_grpc/worker/go.mod
+++ b/internal/test/integration/components/old_grpc/worker/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/old_grpc/worker
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/caarlos0/env/v7 v7.1.0

--- a/internal/test/integration/components/sqlclient/go.mod
+++ b/internal/test/integration/components/sqlclient/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/integration/components/sqlclient
 
-go 1.25.9
+go 1.25.10
 
 require modernc.org/sqlite v1.50.0
 

--- a/internal/test/oats/ai/go.mod
+++ b/internal/test/oats/ai/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/ai
 
-go 1.25.9
+go 1.25.10
 
 require go.opentelemetry.io/obi/internal/test/oats/harness v0.0.0
 

--- a/internal/test/oats/amqp/go.mod
+++ b/internal/test/oats/amqp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/amqp
 
-go 1.25.9
+go 1.25.10
 
 require go.opentelemetry.io/obi/internal/test/oats/harness v0.0.0
 

--- a/internal/test/oats/http/go.mod
+++ b/internal/test/oats/http/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/http
 
-go 1.25.9
+go 1.25.10
 
 require go.opentelemetry.io/obi/internal/test/oats/harness v0.0.0
 

--- a/internal/test/oats/kafka/go.mod
+++ b/internal/test/oats/kafka/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/kafka
 
-go 1.25.9
+go 1.25.10
 
 require go.opentelemetry.io/obi/internal/test/oats/harness v0.0.0
 

--- a/internal/test/oats/memcached/go.mod
+++ b/internal/test/oats/memcached/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/memcached
 
-go 1.25.9
+go 1.25.10
 
 require go.opentelemetry.io/obi/internal/test/oats/harness v0.0.0
 

--- a/internal/test/oats/mongo/go.mod
+++ b/internal/test/oats/mongo/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/mongo
 
-go 1.25.9
+go 1.25.10
 
 require go.opentelemetry.io/obi/internal/test/oats/harness v0.0.0
 

--- a/internal/test/oats/nats/go.mod
+++ b/internal/test/oats/nats/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/nats
 
-go 1.25.9
+go 1.25.10
 
 require go.opentelemetry.io/obi/internal/test/oats/harness v0.0.0
 

--- a/internal/test/oats/redis/go.mod
+++ b/internal/test/oats/redis/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/redis
 
-go 1.25.9
+go 1.25.10
 
 require go.opentelemetry.io/obi/internal/test/oats/harness v0.0.0
 

--- a/internal/test/oats/sql/go.mod
+++ b/internal/test/oats/sql/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/test/oats/sql
 
-go 1.25.9
+go 1.25.10
 
 require go.opentelemetry.io/obi/internal/test/oats/harness v0.0.0
 

--- a/internal/tools/debug/go.mod
+++ b/internal/tools/debug/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/tools/debug
 
-go 1.25.9
+go 1.25.10
 
 require github.com/go-delve/delve v1.26.3
 

--- a/internal/tools/generator/go.mod
+++ b/internal/tools/generator/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/tools/generator
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/cilium/ebpf v0.21.0

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/obi/internal/tools
 
-go 1.25.9
+go 1.25.10
 
 require github.com/cilium/ebpf v0.20.0 // indirect
 


### PR DESCRIPTION
## Summary

Bump to go 1.25.10 as per `devdocs/go-version-upgrade.md`.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
