### PR TITLE
ci: introduce weekly flaky test report

### DIFF
--- a/.github/workflows/daily_test_analysis.yml
+++ b/.github/workflows/daily_test_analysis.yml
@@ -39,8 +39,26 @@ jobs:
           go-version-file: "go.mod"
           cache: false
 
+      - name: Compute snapshot date
+        id: date
+        run: echo "today=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
       - name: Generate test analysis report
         env:
           GH_TOKEN: ${{ github.token }}
           LOOKBACK_DAYS: ${{ inputs.lookback_days || '5' }}
+          SNAPSHOT_OUT: ${{ github.workspace }}/snapshot/snapshot.json
         run: bash scripts/ci-analysis/collect.sh >> "$GITHUB_STEP_SUMMARY"
+
+      # Snapshot is consumed by the weekly rollup workflow. Retention of 8
+      # days gives a one-day safety margin over the 7-day rollup window
+      # (the weekly job runs ~1h after the previous Monday's daily job).
+      # Date prefix makes the artifact list scannable; run_id keeps the
+      # name unique across manual workflow_dispatch reruns on the same day.
+      - name: Upload daily snapshot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-daily-snapshot-${{ steps.date.outputs.today }}-${{ github.run_id }}
+          path: snapshot/snapshot.json
+          retention-days: 8
+          if-no-files-found: error

--- a/.github/workflows/weekly_test_analysis.yml
+++ b/.github/workflows/weekly_test_analysis.yml
@@ -1,0 +1,62 @@
+name: "Weekly Test Analysis Report"
+
+on:
+  schedule:
+    # Mondays at 07:00 UTC — one hour after the daily run at 06:00, so the
+    # current Monday's daily snapshot is available before the rollup starts.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "Only include runs created on or after this date (YYYY-MM-DD); defaults to 7 days ago"
+        required: false
+        type: string
+
+# actions:read is needed to list daily workflow runs and download their
+# snapshot artifacts via the gh CLI.
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  rollup:
+    name: "Roll up weekly CI test results"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            scripts/ci-analysis/
+            go.mod
+            go.sum
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: false
+
+      - name: Compute snapshot date
+        id: date
+        run: echo "today=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate weekly test analysis report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SINCE: ${{ inputs.since || '' }}
+          SNAPSHOT_OUT: ${{ github.workspace }}/weekly-snapshot/snapshot.json
+        run: bash scripts/ci-analysis/weekly.sh >> "$GITHUB_STEP_SUMMARY"
+
+      # Retention of 32 days covers a future monthly rollup with safety
+      # margin (4 weeklies + ~4 days), mirroring the 8-day retention on
+      # daily snapshots vs. the 7-day weekly window.
+      - name: Upload weekly snapshot
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-weekly-snapshot-${{ steps.date.outputs.today }}-${{ github.run_id }}
+          path: weekly-snapshot/snapshot.json
+          retention-days: 32
+          if-no-files-found: error

--- a/scripts/ci-analysis/ci_analysis_test.go
+++ b/scripts/ci-analysis/ci_analysis_test.go
@@ -123,7 +123,7 @@ func TestWriteReport(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := writeReport(&buf, results, metaMap, "test/repo")
+	err := writeReport(&buf, "CI Test Analysis Report", results, metaMap, "test/repo")
 	require.NoError(t, err)
 
 	report := buf.String()
@@ -421,7 +421,7 @@ func TestWriteReport_RendersPackageQualifiedNames(t *testing.T) {
 		"1": {RunID: "1", Workflow: "Wf", Conclusion: "failure"},
 	}
 	var buf bytes.Buffer
-	require.NoError(t, writeReport(&buf, results, metaMap, "test/repo"))
+	require.NoError(t, writeReport(&buf, "CI Test Analysis Report", results, metaMap, "test/repo"))
 
 	out := buf.String()
 	require.Contains(t, out, "`a.TestNew`", "rows should include the package leaf; got:\n%s", out)
@@ -475,7 +475,7 @@ func TestWriteReport_PassRateMatchesConclusion(t *testing.T) {
 		"2": {RunID: "2", Workflow: "Wf", Conclusion: "success"},
 	}
 	var buf bytes.Buffer
-	require.NoError(t, writeReport(&buf, results, metaMap, "test/repo"))
+	require.NoError(t, writeReport(&buf, "CI Test Analysis Report", results, metaMap, "test/repo"))
 
 	report := buf.String()
 	// Workflow row format: | Wf | 2 | 1 | 1 | 0 | 100% |
@@ -493,7 +493,7 @@ func TestWriteReport_HardFailLowersPassRate(t *testing.T) {
 		"2": {RunID: "2", Workflow: "Wf", Conclusion: "success"},
 	}
 	var buf bytes.Buffer
-	require.NoError(t, writeReport(&buf, results, metaMap, "test/repo"))
+	require.NoError(t, writeReport(&buf, "CI Test Analysis Report", results, metaMap, "test/repo"))
 
 	require.Contains(t, buf.String(), "| Wf | 2 | 1 | 0 | 1 | 50% |")
 }

--- a/scripts/ci-analysis/collect.sh
+++ b/scripts/ci-analysis/collect.sh
@@ -11,6 +11,7 @@
 #   GITHUB_REPOSITORY - owner/repo string (auto-set by GitHub Actions)
 #   LOOKBACK_DAYS     - Number of days to look back (default: 5, max limited by artifact retention)
 #   SCRIPT_DIR        - Override for the directory containing this script
+#   SNAPSHOT_OUT      - Optional path to write a JSON snapshot for the weekly rollup
 
 set -euo pipefail
 
@@ -141,8 +142,13 @@ done
 echo "]" >> "$META_FILE"
 
 echo "Generating report..." >&2
-go run "${SCRIPT_DIR}/" \
+SNAPSHOT_ARGS=()
+if [ -n "${SNAPSHOT_OUT:-}" ]; then
+  SNAPSHOT_ARGS=(--snapshot-out="$SNAPSHOT_OUT")
+fi
+go run "${SCRIPT_DIR}/" daily \
   --reports-dir="$REPORTS_DIR" \
   --logs-dir="$LOGS_DIR" \
   --meta="$META_FILE" \
-  --repo="$GITHUB_REPOSITORY"
+  --repo="$GITHUB_REPOSITORY" \
+  "${SNAPSHOT_ARGS[@]}"

--- a/scripts/ci-analysis/daily.go
+++ b/scripts/ci-analysis/daily.go
@@ -17,9 +17,8 @@ func runDaily(args []string) {
 	metaFile := fs.String("meta", "", "JSON file with array of run metadata objects")
 	repo := fs.String("repo", "open-telemetry/opentelemetry-ebpf-instrumentation", "GitHub repository for linking")
 	snapshotOut := fs.String("snapshot-out", "", "Optional path to write a JSON snapshot for downstream rollups")
-	if err := fs.Parse(args); err != nil {
-		log.Fatalf("parsing flags: %v", err)
-	}
+	// ExitOnError handles parse failures internally — no need to check the return.
+	_ = fs.Parse(args)
 
 	if *reportsDir == "" {
 		log.Fatal("--reports-dir is required")

--- a/scripts/ci-analysis/daily.go
+++ b/scripts/ci-analysis/daily.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"time"
+)
+
+func runDaily(args []string) {
+	fs := flag.NewFlagSet("daily", flag.ExitOnError)
+	reportsDir := fs.String("reports-dir", "", "Directory containing gotestsum JSON report files (recursive)")
+	logsDir := fs.String("logs-dir", "", "Directory containing Docker log files for failed runs (recursive)")
+	metaFile := fs.String("meta", "", "JSON file with array of run metadata objects")
+	repo := fs.String("repo", "open-telemetry/opentelemetry-ebpf-instrumentation", "GitHub repository for linking")
+	snapshotOut := fs.String("snapshot-out", "", "Optional path to write a JSON snapshot for downstream rollups")
+	if err := fs.Parse(args); err != nil {
+		log.Fatalf("parsing flags: %v", err)
+	}
+
+	if *reportsDir == "" {
+		log.Fatal("--reports-dir is required")
+	}
+
+	metaMap, err := loadRunMeta(*metaFile)
+	if err != nil {
+		log.Fatalf("loading metadata: %v", err)
+	}
+
+	results, err := parseAllReports(*reportsDir, *logsDir, metaMap)
+	if err != nil {
+		log.Fatalf("parsing reports: %v", err)
+	}
+
+	if err := writeReport(os.Stdout, "CI Test Analysis Report", results, metaMap, *repo); err != nil {
+		log.Fatalf("writing report: %v", err)
+	}
+
+	if *snapshotOut != "" {
+		minDate, maxDate := dateRangeFromMeta(metaMap)
+		runs := make([]RunMeta, 0, len(metaMap))
+		for _, rm := range metaMap {
+			runs = append(runs, rm)
+		}
+		snap := Snapshot{
+			Version:     snapshotVersion,
+			Kind:        snapshotKindDaily,
+			GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+			PeriodStart: minDate,
+			PeriodEnd:   maxDate,
+			Runs:        runs,
+			Results:     results,
+		}
+		if err := writeSnapshot(*snapshotOut, snap); err != nil {
+			log.Fatalf("writing snapshot: %v", err)
+		}
+	}
+}

--- a/scripts/ci-analysis/main.go
+++ b/scripts/ci-analysis/main.go
@@ -2,45 +2,49 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // ci-analysis parses gotestsum JSON reports and Docker log artifacts from
-// GitHub Actions, then generates a Markdown flaky-test analysis report.
+// GitHub Actions and generates Markdown CI reliability reports.
 //
-// Usage:
+// Subcommands:
 //
-//	go run ./scripts/ci-analysis [flags]
-//	  --reports-dir  Directory containing gotestsum JSON report files (recursive)
-//	  --logs-dir     Directory containing Docker log files for failed runs (recursive)
-//	  --meta         JSON file with run metadata
-//	  --repo         GitHub repository for linking (default: open-telemetry/opentelemetry-ebpf-instrumentation)
+//	daily   Analyze the last few days of CI runs (run nightly).
+//	weekly  Roll up daily snapshots into a weekly report (run Mondays).
+//
+// Each subcommand can also persist a JSON snapshot for downstream rollups
+// (daily → weekly → monthly).
 package main
 
 import (
-	"flag"
+	"fmt"
 	"log"
 	"os"
 )
 
 func main() {
-	reportsDir := flag.String("reports-dir", "", "Directory containing gotestsum JSON report files (recursive)")
-	logsDir := flag.String("logs-dir", "", "Directory containing Docker log files for failed runs (recursive)")
-	metaFile := flag.String("meta", "", "JSON file with array of run metadata objects")
-	repo := flag.String("repo", "open-telemetry/opentelemetry-ebpf-instrumentation", "GitHub repository for linking")
-	flag.Parse()
-
-	if *reportsDir == "" {
-		log.Fatal("--reports-dir is required")
+	if len(os.Args) < 2 {
+		usageAndExit()
 	}
-
-	metaMap, err := loadRunMeta(*metaFile)
-	if err != nil {
-		log.Fatalf("loading metadata: %v", err)
+	cmd, args := os.Args[1], os.Args[2:]
+	switch cmd {
+	case "daily":
+		runDaily(args)
+	case "weekly":
+		runWeekly(args)
+	case "-h", "--help", "help":
+		usageAndExit()
+	default:
+		log.Printf("unknown subcommand: %q", cmd)
+		usageAndExit()
 	}
+}
 
-	results, err := parseAllReports(*reportsDir, *logsDir, metaMap)
-	if err != nil {
-		log.Fatalf("parsing reports: %v", err)
-	}
+func usageAndExit() {
+	fmt.Fprint(os.Stderr, `Usage: ci-analysis <subcommand> [flags]
 
-	if err := writeReport(os.Stdout, results, metaMap, *repo); err != nil {
-		log.Fatalf("writing report: %v", err)
-	}
+Subcommands:
+  daily    Analyze recent CI runs from downloaded artifacts
+  weekly   Roll up daily snapshots into a weekly report
+
+Run "ci-analysis <subcommand> -h" for subcommand flags.
+`)
+	os.Exit(2)
 }

--- a/scripts/ci-analysis/parse.go
+++ b/scripts/ci-analysis/parse.go
@@ -25,17 +25,19 @@ type TestEvent struct {
 }
 
 // TestResult is the parsed outcome for a single test in a single run.
+// JSON tags define the on-disk snapshot schema consumed by the weekly
+// rollup (see snapshot.go); changing them is a breaking change.
 type TestResult struct {
-	RunID    string
-	Workflow string
+	RunID    string `json:"run_id"`
+	Workflow string `json:"workflow"`
 	// Package is part of the test identity: unit-test shards run multiple Go
 	// packages in one gotestsum file, so two TestFoo entries in different
 	// packages must not be merged. Do not remove.
-	Package          string
-	Test             string
-	Outcome          string
-	ErrorFingerprint string
-	ErrorSnippet     string
+	Package          string `json:"package"`
+	Test             string `json:"test"`
+	Outcome          string `json:"outcome"`
+	ErrorFingerprint string `json:"error_fingerprint,omitempty"`
+	ErrorSnippet     string `json:"error_snippet,omitempty"`
 }
 
 // RunMeta contains metadata for each run being parsed.

--- a/scripts/ci-analysis/report.go
+++ b/scripts/ci-analysis/report.go
@@ -18,9 +18,12 @@ const (
 	maxTestsInList         = 8
 )
 
-func writeReport(w io.Writer, results []TestResult, metaMap map[string]RunMeta, repo string) error {
+func writeReport(w io.Writer, title string, results []TestResult, metaMap map[string]RunMeta, repo string) error {
+	if title == "" {
+		title = "CI Test Analysis Report"
+	}
 	if len(results) == 0 && len(metaMap) == 0 {
-		_, err := fmt.Fprintln(w, "# CI Test Analysis Report\n\nNo test data found for the analysis period.")
+		_, err := fmt.Fprintf(w, "# %s\n\nNo test data found for the analysis period.\n", title)
 		return err
 	}
 
@@ -34,7 +37,7 @@ func writeReport(w io.Writer, results []TestResult, metaMap map[string]RunMeta, 
 		fmt.Fprintf(w, format+"\n", args...)
 	}
 
-	p("# CI Test Analysis Report")
+	p("# %s", title)
 	p("")
 	p("**Period:** %s to %s", minDate, maxDate)
 	p("**Runs analyzed:** %d | **Tests tracked:** %d", len(metaMap), uniqueTests)

--- a/scripts/ci-analysis/snapshot.go
+++ b/scripts/ci-analysis/snapshot.go
@@ -1,0 +1,170 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// snapshotVersion is bumped when the on-disk schema changes incompatibly.
+// Consumers refuse snapshots with a higher version than they know about.
+const snapshotVersion = 1
+
+// Snapshot kinds. Daily snapshots feed the weekly rollup; weekly snapshots
+// will feed a future monthly rollup.
+const (
+	snapshotKindDaily  = "daily"
+	snapshotKindWeekly = "weekly"
+)
+
+// Snapshot is the persisted output of an analysis run. It contains enough
+// raw data for a downstream rollup to re-aggregate without re-fetching
+// from GitHub — important because GitHub artifact retention is shorter
+// than the rollup windows we want to report on.
+type Snapshot struct {
+	Version     int          `json:"version"`
+	Kind        string       `json:"kind"`
+	GeneratedAt string       `json:"generated_at"`
+	PeriodStart string       `json:"period_start"`
+	PeriodEnd   string       `json:"period_end"`
+	Runs        []RunMeta    `json:"runs"`
+	Results     []TestResult `json:"results"`
+}
+
+func writeSnapshot(path string, snap Snapshot) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("creating snapshot dir: %w", err)
+	}
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling snapshot: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("writing snapshot: %w", err)
+	}
+	return nil
+}
+
+func readSnapshot(path string) (Snapshot, error) {
+	var snap Snapshot
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return snap, err
+	}
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return snap, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	if snap.Version > snapshotVersion {
+		return snap, fmt.Errorf("%s: snapshot version %d is newer than supported version %d", path, snap.Version, snapshotVersion)
+	}
+	return snap, nil
+}
+
+// loadSnapshots walks dir and reads every *.json snapshot file beneath it.
+// File names are not significant — only the contents matter.
+func loadSnapshots(dir string) ([]Snapshot, error) {
+	var snaps []Snapshot
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+		s, err := readSnapshot(path)
+		if err != nil {
+			return err
+		}
+		snaps = append(snaps, s)
+		return nil
+	})
+	return snaps, err
+}
+
+// mergeSnapshots combines runs and results across snapshots, deduplicating
+// by run_id (for runs) and by (run_id, package, test) for results. Daily
+// snapshots overlap when the source workflow uses a multi-day lookback
+// window — the same run can appear in several daily snapshots — so dedup
+// is required to keep the rollup arithmetic correct.
+func mergeSnapshots(snaps []Snapshot) ([]RunMeta, []TestResult) {
+	runMap := map[string]RunMeta{}
+	type resultKey struct {
+		runID string
+		pkgTest
+	}
+	resultMap := map[resultKey]TestResult{}
+
+	for _, s := range snaps {
+		for _, rm := range s.Runs {
+			if _, exists := runMap[rm.RunID]; !exists {
+				runMap[rm.RunID] = rm
+			}
+		}
+		for _, r := range s.Results {
+			k := resultKey{r.RunID, pkgTest{r.Package, r.Test}}
+			if _, exists := resultMap[k]; !exists {
+				resultMap[k] = r
+			}
+		}
+	}
+
+	runs := make([]RunMeta, 0, len(runMap))
+	for _, rm := range runMap {
+		runs = append(runs, rm)
+	}
+	sort.Slice(runs, func(i, j int) bool {
+		if runs[i].CreatedAt != runs[j].CreatedAt {
+			return runs[i].CreatedAt < runs[j].CreatedAt
+		}
+		return runs[i].RunID < runs[j].RunID
+	})
+
+	results := make([]TestResult, 0, len(resultMap))
+	for _, r := range resultMap {
+		results = append(results, r)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].RunID != results[j].RunID {
+			return results[i].RunID < results[j].RunID
+		}
+		if results[i].Package != results[j].Package {
+			return results[i].Package < results[j].Package
+		}
+		return results[i].Test < results[j].Test
+	})
+	return runs, results
+}
+
+// filterByDate keeps runs whose CreatedAt is >= since, and the results that
+// belong to those runs. since may be a date prefix (YYYY-MM-DD) or full
+// RFC3339; both compare correctly under lexicographic ordering.
+func filterByDate(runs []RunMeta, results []TestResult, since string) ([]RunMeta, []TestResult) {
+	if since == "" {
+		return runs, results
+	}
+	keepRun := map[string]bool{}
+	filteredRuns := make([]RunMeta, 0, len(runs))
+	for _, rm := range runs {
+		if rm.CreatedAt >= since {
+			keepRun[rm.RunID] = true
+			filteredRuns = append(filteredRuns, rm)
+		}
+	}
+	filteredResults := make([]TestResult, 0, len(results))
+	for _, r := range results {
+		if keepRun[r.RunID] {
+			filteredResults = append(filteredResults, r)
+		}
+	}
+	return filteredRuns, filteredResults
+}

--- a/scripts/ci-analysis/snapshot.go
+++ b/scripts/ci-analysis/snapshot.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 // snapshotVersion is bumped when the on-disk schema changes incompatibly.
@@ -145,9 +146,25 @@ func mergeSnapshots(snaps []Snapshot) ([]RunMeta, []TestResult) {
 	return runs, results
 }
 
+// validateSince checks that since parses as either YYYY-MM-DD or RFC3339.
+// Both formats compare correctly under lexicographic ordering against the
+// RFC3339 timestamps stored in RunMeta.CreatedAt, so no normalization is
+// needed — only validation, to fail fast on typos rather than producing a
+// silently-empty report.
+func validateSince(since string) error {
+	if _, err := time.Parse("2006-01-02", since); err == nil {
+		return nil
+	}
+	if _, err := time.Parse(time.RFC3339, since); err == nil {
+		return nil
+	}
+	return fmt.Errorf("must be YYYY-MM-DD or RFC3339, got %q", since)
+}
+
 // filterByDate keeps runs whose CreatedAt is >= since, and the results that
 // belong to those runs. since may be a date prefix (YYYY-MM-DD) or full
-// RFC3339; both compare correctly under lexicographic ordering.
+// RFC3339; both compare correctly under lexicographic ordering. Callers
+// should call validateSince first to reject malformed input.
 func filterByDate(runs []RunMeta, results []TestResult, since string) ([]RunMeta, []TestResult) {
 	if since == "" {
 		return runs, results

--- a/scripts/ci-analysis/snapshot_test.go
+++ b/scripts/ci-analysis/snapshot_test.go
@@ -1,0 +1,112 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotRoundTrip(t *testing.T) {
+	snap := Snapshot{
+		Version:     snapshotVersion,
+		Kind:        snapshotKindDaily,
+		GeneratedAt: "2026-05-05T06:00:00Z",
+		PeriodStart: "2026-05-01",
+		PeriodEnd:   "2026-05-05",
+		Runs: []RunMeta{
+			{RunID: "1", CreatedAt: "2026-05-01T00:00:00Z", Workflow: "wf-A", Conclusion: "success"},
+		},
+		Results: []TestResult{
+			{RunID: "1", Workflow: "wf-A", Package: "pkg/x", Test: "TestX", Outcome: "passed"},
+		},
+	}
+
+	path := filepath.Join(t.TempDir(), "snapshot.json")
+	require.NoError(t, writeSnapshot(path, snap))
+
+	got, err := readSnapshot(path)
+	require.NoError(t, err)
+	require.Equal(t, snap, got)
+}
+
+func TestMergeSnapshotsDeduplicates(t *testing.T) {
+	// Two snapshots with overlapping runs and results.
+	// Dedup keys: run_id for runs, (run_id, package, test) for results.
+	// Run 2 appears in both snapshots and must collapse to one.
+	snapA := Snapshot{
+		Runs: []RunMeta{
+			{RunID: "1", CreatedAt: "2026-05-01T00:00:00Z", Workflow: "wf"},
+			{RunID: "2", CreatedAt: "2026-05-02T00:00:00Z", Workflow: "wf"},
+		},
+		Results: []TestResult{
+			{RunID: "1", Workflow: "wf", Package: "pkg", Test: "TestX", Outcome: "passed"},
+			{RunID: "2", Workflow: "wf", Package: "pkg", Test: "TestX", Outcome: "failed"},
+		},
+	}
+	snapB := Snapshot{
+		Runs: []RunMeta{
+			{RunID: "2", CreatedAt: "2026-05-02T00:00:00Z", Workflow: "wf"}, // duplicate
+			{RunID: "3", CreatedAt: "2026-05-03T00:00:00Z", Workflow: "wf"},
+		},
+		Results: []TestResult{
+			{RunID: "2", Workflow: "wf", Package: "pkg", Test: "TestX", Outcome: "failed"}, // duplicate
+			{RunID: "3", Workflow: "wf", Package: "pkg", Test: "TestX", Outcome: "passed"},
+		},
+	}
+
+	runs, results := mergeSnapshots([]Snapshot{snapA, snapB})
+	require.Len(t, runs, 3)
+	require.Len(t, results, 3)
+
+	// Same test name in a different package must not merge.
+	snapC := Snapshot{
+		Results: []TestResult{
+			{RunID: "1", Workflow: "wf", Package: "pkg/other", Test: "TestX", Outcome: "passed"},
+		},
+	}
+	_, results = mergeSnapshots([]Snapshot{snapA, snapC})
+	require.Len(t, results, 3) // pkg/TestX (run 1), pkg/TestX (run 2), pkg/other/TestX (run 1)
+}
+
+func TestFilterByDate(t *testing.T) {
+	runs := []RunMeta{
+		{RunID: "old", CreatedAt: "2026-04-20T00:00:00Z"},
+		{RunID: "new", CreatedAt: "2026-05-04T00:00:00Z"},
+	}
+	results := []TestResult{
+		{RunID: "old", Test: "TestX"},
+		{RunID: "new", Test: "TestX"},
+	}
+
+	gotRuns, gotResults := filterByDate(runs, results, "2026-05-01")
+	require.Len(t, gotRuns, 1)
+	require.Equal(t, "new", gotRuns[0].RunID)
+	require.Len(t, gotResults, 1)
+	require.Equal(t, "new", gotResults[0].RunID)
+}
+
+func TestLoadSnapshotsRecursive(t *testing.T) {
+	dir := t.TempDir()
+	snap1 := Snapshot{Version: snapshotVersion, Kind: snapshotKindDaily, Runs: []RunMeta{{RunID: "1"}}}
+	snap2 := Snapshot{Version: snapshotVersion, Kind: snapshotKindDaily, Runs: []RunMeta{{RunID: "2"}}}
+	require.NoError(t, writeSnapshot(filepath.Join(dir, "run-1", "snapshot.json"), snap1))
+	require.NoError(t, writeSnapshot(filepath.Join(dir, "run-2", "snapshot.json"), snap2))
+
+	snaps, err := loadSnapshots(dir)
+	require.NoError(t, err)
+	require.Len(t, snaps, 2)
+}
+
+func TestReadSnapshotRejectsFutureVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "future.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{"version": 999, "kind": "daily"}`), 0o644))
+
+	_, err := readSnapshot(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "newer than supported")
+}

--- a/scripts/ci-analysis/snapshot_test.go
+++ b/scripts/ci-analysis/snapshot_test.go
@@ -102,6 +102,23 @@ func TestLoadSnapshotsRecursive(t *testing.T) {
 	require.Len(t, snaps, 2)
 }
 
+func TestValidateSince(t *testing.T) {
+	t.Run("date-only", func(t *testing.T) {
+		require.NoError(t, validateSince("2026-05-18"))
+	})
+	t.Run("rfc3339", func(t *testing.T) {
+		require.NoError(t, validateSince("2026-05-18T06:00:00Z"))
+	})
+	t.Run("garbage", func(t *testing.T) {
+		err := validateSince("last-monday")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "YYYY-MM-DD or RFC3339")
+	})
+	t.Run("nearly-valid", func(t *testing.T) {
+		require.Error(t, validateSince("2026/05/18"))
+	})
+}
+
 func TestReadSnapshotRejectsFutureVersion(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "future.json")
 	require.NoError(t, os.WriteFile(path, []byte(`{"version": 999, "kind": "daily"}`), 0o644))

--- a/scripts/ci-analysis/weekly.go
+++ b/scripts/ci-analysis/weekly.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"time"
+)
+
+func runWeekly(args []string) {
+	fs := flag.NewFlagSet("weekly", flag.ExitOnError)
+	snapshotsDir := fs.String("snapshots-dir", "", "Directory containing daily snapshot JSON files (recursive)")
+	since := fs.String("since", "", "Only include runs created on or after this date (YYYY-MM-DD or RFC3339); defaults to 7 days ago UTC")
+	repo := fs.String("repo", "open-telemetry/opentelemetry-ebpf-instrumentation", "GitHub repository for linking")
+	snapshotOut := fs.String("snapshot-out", "", "Optional path to write a JSON snapshot for downstream rollups (e.g. monthly)")
+	title := fs.String("title", "Weekly CI Test Analysis Report", "Report title")
+	if err := fs.Parse(args); err != nil {
+		log.Fatalf("parsing flags: %v", err)
+	}
+
+	if *snapshotsDir == "" {
+		log.Fatal("--snapshots-dir is required")
+	}
+
+	if *since == "" {
+		*since = time.Now().UTC().AddDate(0, 0, -7).Format("2006-01-02")
+	}
+
+	snaps, err := loadSnapshots(*snapshotsDir)
+	if err != nil {
+		log.Fatalf("loading snapshots: %v", err)
+	}
+	if len(snaps) == 0 {
+		log.Printf("warning: no snapshot files found in %s", *snapshotsDir)
+	}
+
+	runs, results := mergeSnapshots(snaps)
+	runs, results = filterByDate(runs, results, *since)
+
+	metaMap := make(map[string]RunMeta, len(runs))
+	for _, rm := range runs {
+		metaMap[rm.RunID] = rm
+	}
+
+	if err := writeReport(os.Stdout, *title, results, metaMap, *repo); err != nil {
+		log.Fatalf("writing report: %v", err)
+	}
+
+	if *snapshotOut != "" {
+		minDate, maxDate := dateRangeFromMeta(metaMap)
+		snap := Snapshot{
+			Version:     snapshotVersion,
+			Kind:        snapshotKindWeekly,
+			GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+			PeriodStart: minDate,
+			PeriodEnd:   maxDate,
+			Runs:        runs,
+			Results:     results,
+		}
+		if err := writeSnapshot(*snapshotOut, snap); err != nil {
+			log.Fatalf("writing snapshot: %v", err)
+		}
+	}
+}

--- a/scripts/ci-analysis/weekly.go
+++ b/scripts/ci-analysis/weekly.go
@@ -17,9 +17,8 @@ func runWeekly(args []string) {
 	repo := fs.String("repo", "open-telemetry/opentelemetry-ebpf-instrumentation", "GitHub repository for linking")
 	snapshotOut := fs.String("snapshot-out", "", "Optional path to write a JSON snapshot for downstream rollups (e.g. monthly)")
 	title := fs.String("title", "Weekly CI Test Analysis Report", "Report title")
-	if err := fs.Parse(args); err != nil {
-		log.Fatalf("parsing flags: %v", err)
-	}
+	// ExitOnError handles parse failures internally — no need to check the return.
+	_ = fs.Parse(args)
 
 	if *snapshotsDir == "" {
 		log.Fatal("--snapshots-dir is required")
@@ -27,6 +26,8 @@ func runWeekly(args []string) {
 
 	if *since == "" {
 		*since = time.Now().UTC().AddDate(0, 0, -7).Format("2006-01-02")
+	} else if err := validateSince(*since); err != nil {
+		log.Fatalf("--since: %v", err)
 	}
 
 	snaps, err := loadSnapshots(*snapshotsDir)

--- a/scripts/ci-analysis/weekly.sh
+++ b/scripts/ci-analysis/weekly.sh
@@ -19,6 +19,12 @@ set -euo pipefail
 
 WORKFLOW_FILE="${WORKFLOW_FILE:-daily_test_analysis.yml}"
 LOOKBACK_RUNS="${LOOKBACK_RUNS:-15}"
+# GitHub caps per_page at 100; reject anything outside [1, 100] to fail fast
+# instead of producing a confusing gh api error.
+if ! [[ "$LOOKBACK_RUNS" =~ ^[0-9]+$ ]] || [ "$LOOKBACK_RUNS" -lt 1 ] || [ "$LOOKBACK_RUNS" -gt 100 ]; then
+  echo "Error: LOOKBACK_RUNS must be an integer between 1 and 100, got: $LOOKBACK_RUNS" >&2
+  exit 1
+fi
 SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR"' EXIT

--- a/scripts/ci-analysis/weekly.sh
+++ b/scripts/ci-analysis/weekly.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Roll up daily CI snapshots into a weekly report.
+# Downloads snapshot artifacts from recent runs of the daily workflow,
+# then runs the weekly subcommand to merge and re-aggregate them.
+#
+# Environment variables (all have defaults suitable for GitHub Actions):
+#   GH_TOKEN          - Auth token for gh CLI (set from github.token in the workflow)
+#   GITHUB_REPOSITORY - owner/repo string (auto-set by GitHub Actions)
+#   WORKFLOW_FILE     - Filename of the daily workflow (default: daily_test_analysis.yml)
+#   LOOKBACK_RUNS     - How many recent daily runs to pull artifacts from (default: 15)
+#   SINCE             - YYYY-MM-DD; only include runs on or after this date (default: 7 days ago)
+#   SNAPSHOT_OUT      - Optional path to write a JSON snapshot for a future monthly rollup
+#   SCRIPT_DIR        - Override for the directory containing this script
+
+set -euo pipefail
+
+WORKFLOW_FILE="${WORKFLOW_FILE:-daily_test_analysis.yml}"
+LOOKBACK_RUNS="${LOOKBACK_RUNS:-15}"
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+SNAPSHOTS_DIR="$WORK_DIR/snapshots"
+mkdir -p "$SNAPSHOTS_DIR"
+
+echo "Listing recent runs of ${WORKFLOW_FILE}..." >&2
+RUN_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/runs?status=success&per_page=${LOOKBACK_RUNS}" \
+  --jq '.workflow_runs[].id')
+
+if [ -z "$RUN_IDS" ]; then
+  echo "Warning: no successful daily runs found" >&2
+fi
+
+for RUN_ID in $RUN_IDS; do
+  echo "  Downloading snapshot from run ${RUN_ID}..." >&2
+  if ! gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
+    --pattern "ci-daily-snapshot-*" \
+    -D "$SNAPSHOTS_DIR/$RUN_ID" 2>/dev/null; then
+    echo "    (no snapshot artifact, skipping)" >&2
+  fi
+done
+
+SNAPSHOT_COUNT=$(find "$SNAPSHOTS_DIR" -name "*.json" -type f | wc -l | tr -d ' ')
+echo "Found $SNAPSHOT_COUNT snapshot file(s)" >&2
+
+echo "Generating weekly report..." >&2
+EXTRA_ARGS=()
+if [ -n "${SINCE:-}" ]; then
+  EXTRA_ARGS+=(--since="$SINCE")
+fi
+if [ -n "${SNAPSHOT_OUT:-}" ]; then
+  EXTRA_ARGS+=(--snapshot-out="$SNAPSHOT_OUT")
+fi
+go run "${SCRIPT_DIR}/" weekly \
+  --snapshots-dir="$SNAPSHOTS_DIR" \
+  --repo="$GITHUB_REPOSITORY" \
+  "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
## Summary

Rollup the daily flaky test reports each week.

1. Each daily report now uploads a snapshot json, retention is 8 days
2. Each weekly report processes the available daily json files, and produces a weekly json with 32 day retention (in case we decide to have a monthly rollup)

Both daily and weekly still produce STEP_SUMMARY reports, check the links below to see examples of these.

### Tested on an origin branch

[daily report test run](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/26035273535) - new daily json artifact was created:

```
Artifact ci-daily-snapshot-2026-05-18-26035273535 successfully finalized. Artifact ID 7058574574
Artifact ci-daily-snapshot-2026-05-18-26035273535 has been successfully uploaded! Final size is 110176 bytes. Artifact ID is 7058574574
```

[weekly report test run](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/26036043628) - I had to overwrite the contents of the daily workflow file with the weekly version in order to test on my origin branch, as the new weekly action won't be available in the action list before merge to main.

```
Listing recent runs of daily_test_analysis.yml...
  Downloading snapshot from run 26035273535...
  Downloading snapshot from run 26019027689...
    (no snapshot artifact, skipping)
  Downloading snapshot from run 25983945011...
    (no snapshot artifact, skipping)
  <repeated>
Found 1 snapshot file(s)
Generating weekly report...

---

Artifact ci-weekly-snapshot-2026-05-18-26036043628 successfully finalized. Artifact ID 7058916718
Artifact ci-weekly-snapshot-2026-05-18-26036043628 has been successfully uploaded! Final size is 99610 bytes. Artifact ID is 7058916718
```

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
