### PR TITLE
fix(2032): restore bounded eviction when metric TTL is zero

### DIFF
--- a/pkg/export/expire/expiry_map.go
+++ b/pkg/export/expire/expiry_map.go
@@ -69,11 +69,6 @@ func (ex *ExpiryMap[T]) GetOrCreate(lbls []string, instancer func() T) T {
 
 // DeleteExpired entries and return their label set
 func (ex *ExpiryMap[T]) DeleteExpired() []T {
-	// If TTL is 0, disable expiration completely
-	if ex.ttl == 0 {
-		return nil
-	}
-
 	var delKeys []string
 	var delEntries []T
 	ex.mt.RLock()

--- a/pkg/export/expire/expiry_map_test.go
+++ b/pkg/export/expire/expiry_map_test.go
@@ -4,40 +4,51 @@
 package expire
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExpiryMap_DisableExpiration(t *testing.T) {
-	// Mock clock that we can control
+func TestExpiryMap_ZeroTTLExpiresImmediately(t *testing.T) {
 	now := time.Now()
 	clock := func() time.Time { return now }
 
-	// Create expiry map with TTL=0 (should disable expiration)
 	em := NewExpiryMap[string](clock, 0)
 
-	// Add some entries
-	val1 := em.GetOrCreate([]string{"label1", "value1"}, func() string { return "entry1" })
-	val2 := em.GetOrCreate([]string{"label2", "value2"}, func() string { return "entry2" })
+	em.GetOrCreate([]string{"label1", "value1"}, func() string { return "entry1" })
+	em.GetOrCreate([]string{"label2", "value2"}, func() string { return "entry2" })
 
-	assert.Equal(t, "entry1", val1)
-	assert.Equal(t, "entry2", val2)
+	// Advance time by any amount
+	now = now.Add(1 * time.Nanosecond)
 
-	// Advance time significantly (would normally cause expiration)
-	now = now.Add(10 * time.Hour)
-
-	// Try to delete expired entries - should return empty slice when TTL=0
 	expired := em.DeleteExpired()
-	assert.Empty(t, expired, "No entries should expire when TTL=0")
+	assert.Len(t, expired, 2, "TTL=0 should expire entries immediately")
+	assert.Contains(t, expired, "entry1")
+	assert.Contains(t, expired, "entry2")
 
-	// Verify entries are still there
-	val1Again := em.GetOrCreate([]string{"label1", "value1"}, func() string { return "should_not_be_called" })
-	val2Again := em.GetOrCreate([]string{"label2", "value2"}, func() string { return "should_not_be_called" })
+	// Verify entries are gone
+	val1 := em.GetOrCreate([]string{"label1", "value1"}, func() string { return "new_entry1" })
+	val2 := em.GetOrCreate([]string{"label2", "value2"}, func() string { return "new_entry2" })
+	assert.Equal(t, "new_entry1", val1)
+	assert.Equal(t, "new_entry2", val2)
+}
 
-	assert.Equal(t, "entry1", val1Again)
-	assert.Equal(t, "entry2", val2Again)
+func TestExpiryMap_ZeroTTLBoundsHighCardinality(t *testing.T) {
+	now := time.Now()
+	clock := func() time.Time { return now }
+
+	em := NewExpiryMap[int](clock, 0)
+
+	for i := range 1000 {
+		em.GetOrCreate([]string{fmt.Sprintf("label_%d", i)}, func() int { return i })
+	}
+
+	now = now.Add(1 * time.Nanosecond)
+	expired := em.DeleteExpired()
+	assert.Len(t, expired, 1000)
+	assert.Empty(t, em.All(), "All entries should be evicted with TTL=0")
 }
 
 func TestExpiryMap_NormalExpiration(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix #2032 

- Remove the `ttl == 0` early return in `ExpiryMap.DeleteExpired()` that silently disabled all metric eviction
- `TTL=0` now means "expire immediately" (zero time-to-live), preventing unbounded memory growth under high-cardinality label sets
- Replace the old "disable expiration" test with tests verifying immediate expiration and high-cardinality eviction

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
