### PR TITLE
Improve TCP unmatched parsing performance

### DIFF
--- a/pkg/ebpf/common/amqp_detect_transform.go
+++ b/pkg/ebpf/common/amqp_detect_transform.go
@@ -46,11 +46,10 @@ func processAMQPBuffer(pkt *largebuf.LargeBuffer, direction uint8) (bool, []AMQP
 		return false, nil, nil
 	}
 
-	if !amqpparser.IsLikelyAMQP(pkt.UnsafeView()) {
+	reader := pkt.NewReader()
+	if !amqpparser.IsLikelyAMQP(&reader) {
 		return false, nil, nil
 	}
-
-	reader := pkt.NewReader()
 	result, err := amqpparser.Parse(&reader)
 	if err != nil {
 		if errors.Is(err, amqpparser.ErrNotAMQP) {

--- a/pkg/ebpf/common/amqp_detect_transform.go
+++ b/pkg/ebpf/common/amqp_detect_transform.go
@@ -46,6 +46,10 @@ func processAMQPBuffer(pkt *largebuf.LargeBuffer, direction uint8) (bool, []AMQP
 		return false, nil, nil
 	}
 
+	if !amqpparser.IsLikelyAMQP(pkt.UnsafeView()) {
+		return false, nil, nil
+	}
+
 	reader := pkt.NewReader()
 	result, err := amqpparser.Parse(&reader)
 	if err != nil {

--- a/pkg/ebpf/common/couchbase_detect_transform.go
+++ b/pkg/ebpf/common/couchbase_detect_transform.go
@@ -32,6 +32,8 @@ type CouchbaseInfo struct {
 	IsError    bool
 }
 
+var errInvalidCouchbase = errors.New("no valid Couchbase request packets found")
+
 // buildCouchbaseStatement builds a db.query.text string for a KV request packet.
 // See devdocs/protocols/tcp/couchbase.md for the full format specification.
 //
@@ -241,7 +243,7 @@ func processCouchbaseEvent(connInfo BpfConnectionInfoT, requestBuf []byte, respo
 	for reqPacket, err := range couchbasekv.ParsePackets(requestBuf) {
 		if err != nil {
 			if !hasPackets {
-				return nil, true, errors.New("no valid Couchbase request packets found")
+				return nil, true, errInvalidCouchbase
 			}
 			break
 		}

--- a/pkg/ebpf/common/fast_cgi_detect_transform.go
+++ b/pkg/ebpf/common/fast_cgi_detect_transform.go
@@ -122,17 +122,23 @@ func maybeFastCGI(b *largebuf.LargeBuffer) bool {
 	if b.Len() <= fastCGIRequestHeaderLen {
 		return false
 	}
-	view := b.UnsafeView()
 	// FastCGI 1.0: every record starts with version=1 and a record type in
 	// 1..11. Cheap 2-byte check that filters ~99.98% of non-FastCGI payloads
 	// before the more expensive REQUEST_METHOD substring scan.
-	if view[0] != fcgiVersion1 {
+
+	ver, err := b.U8At(0)
+
+	if err != nil || ver != fcgiVersion1 {
 		return false
 	}
-	if view[1] < fcgiFrameTypeBeginReq || view[1] > fcgiFrameTypeUnknown {
+
+	frameType, err := b.U8At(1)
+
+	if err != nil || frameType < fcgiFrameTypeBeginReq || frameType > fcgiFrameTypeUnknown {
 		return false
 	}
-	return bytes.Contains(view, []byte(requestMethodKey))
+
+	return bytes.Contains(b.UnsafeView(), []byte(requestMethodKey))
 }
 
 func parseHeader(b *largebuf.LargeBuffer) ([]byte, error) {

--- a/pkg/ebpf/common/fast_cgi_detect_transform.go
+++ b/pkg/ebpf/common/fast_cgi_detect_transform.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"strconv"
 	"unsafe"
@@ -25,7 +24,17 @@ const (
 	responseStatusKey       = "Status: "
 )
 
-const fcgiFrameTypeParams = 4
+const (
+	fcgiVersion1          = 1
+	fcgiFrameTypeBeginReq = 1
+	fcgiFrameTypeUnknown  = 11
+	fcgiFrameTypeParams   = 4
+)
+
+var (
+	errFastCGIPayloadTooShort  = errors.New("payload too short")
+	errFastCGIHeaderReadFailed = errors.New("failed to read FastCGI header")
+)
 
 // fastCGIHeader represents the structure of a FastCGI header
 type fastCGIHeader struct {
@@ -43,7 +52,7 @@ func readFastCGIHeader(b []byte) (*fastCGIHeader, error) {
 	// FastCGI header is always 8 bytes
 	headerBytes := make([]byte, fastCGIRequestHeaderLen)
 	if _, err := io.ReadFull(reader, headerBytes); err != nil {
-		return nil, fmt.Errorf("failed to read FastCGI header: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 
 	// Parse the header
@@ -51,22 +60,22 @@ func readFastCGIHeader(b []byte) (*fastCGIHeader, error) {
 	buffer := bytes.NewReader(headerBytes)
 
 	if err := binary.Read(buffer, binary.BigEndian, &header.Version); err != nil {
-		return nil, fmt.Errorf("failed to read version: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 	if err := binary.Read(buffer, binary.BigEndian, &header.Type); err != nil {
-		return nil, fmt.Errorf("failed to read type: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 	if err := binary.Read(buffer, binary.BigEndian, &header.RequestID); err != nil {
-		return nil, fmt.Errorf("failed to read request ID: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 	if err := binary.Read(buffer, binary.BigEndian, &header.ContentLength); err != nil {
-		return nil, fmt.Errorf("failed to read content length: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 	if err := binary.Read(buffer, binary.BigEndian, &header.PaddingLength); err != nil {
-		return nil, fmt.Errorf("failed to read padding length: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 	if err := binary.Read(buffer, binary.BigEndian, &header.Reserved); err != nil {
-		return nil, fmt.Errorf("failed to read reserved byte: %w", err)
+		return nil, errFastCGIHeaderReadFailed
 	}
 
 	return header, nil
@@ -113,34 +122,44 @@ func maybeFastCGI(b *largebuf.LargeBuffer) bool {
 	if b.Len() <= fastCGIRequestHeaderLen {
 		return false
 	}
-	return bytes.Contains(b.UnsafeView(), []byte(requestMethodKey))
+	view := b.UnsafeView()
+	// FastCGI 1.0: every record starts with version=1 and a record type in
+	// 1..11. Cheap 2-byte check that filters ~99.98% of non-FastCGI payloads
+	// before the more expensive REQUEST_METHOD substring scan.
+	if view[0] != fcgiVersion1 {
+		return false
+	}
+	if view[1] < fcgiFrameTypeBeginReq || view[1] > fcgiFrameTypeUnknown {
+		return false
+	}
+	return bytes.Contains(view, []byte(requestMethodKey))
 }
 
 func parseHeader(b *largebuf.LargeBuffer) ([]byte, error) {
 	r := b.NewReader()
 	for {
 		if r.Remaining() < fastCGIRequestHeaderLen {
-			return nil, errors.New("payload too short")
+			return nil, errFastCGIPayloadTooShort
 		}
 		hdrBytes, err := r.ReadN(fastCGIRequestHeaderLen)
 		if err != nil {
-			return nil, errors.New("payload too short")
+			return nil, errFastCGIPayloadTooShort
 		}
 		hdr, err := readFastCGIHeader(hdrBytes)
 		if err != nil {
-			return nil, errors.New("payload too short")
+			return nil, errFastCGIPayloadTooShort
 		}
 
 		if hdr.Type == fcgiFrameTypeParams {
 			if r.Remaining() == 0 {
-				return nil, errors.New("payload too short")
+				return nil, errFastCGIPayloadTooShort
 			}
 			rest, _ := r.ReadN(r.Remaining())
 			return rest, nil
 		}
 		payloadOffset := int(hdr.ContentLength) + int(hdr.PaddingLength)
 		if err := r.Skip(payloadOffset); err != nil {
-			return nil, errors.New("payload too short")
+			return nil, errFastCGIPayloadTooShort
 		}
 	}
 }

--- a/pkg/ebpf/common/fast_cgi_detect_transform_test.go
+++ b/pkg/ebpf/common/fast_cgi_detect_transform_test.go
@@ -42,6 +42,67 @@ func TestMaybeFastCGI(t *testing.T) {
 			inputLen: 100,
 			expected: false,
 		},
+		// The next group exercises the cheap header prefilter (version byte
+		// must be 1, record-type byte must be in 1..11). The buffers all
+		// contain the literal "REQUEST_METHOD" so the prefilter is the
+		// only thing that can reject them.
+		{
+			name:     "version byte zero",
+			input:    []byte{0, 1, 0, 0, 0, 8, 0, 0, 0, 'R', 'E', 'Q', 'U', 'E', 'S', 'T', '_', 'M', 'E', 'T', 'H', 'O', 'D'},
+			inputLen: 100,
+			expected: false,
+		},
+		{
+			name:     "version byte 2 (unsupported)",
+			input:    []byte{2, 1, 0, 0, 0, 8, 0, 0, 0, 'R', 'E', 'Q', 'U', 'E', 'S', 'T', '_', 'M', 'E', 'T', 'H', 'O', 'D'},
+			inputLen: 100,
+			expected: false,
+		},
+		{
+			name:     "version byte 255",
+			input:    []byte{255, 1, 0, 0, 0, 8, 0, 0, 0, 'R', 'E', 'Q', 'U', 'E', 'S', 'T', '_', 'M', 'E', 'T', 'H', 'O', 'D'},
+			inputLen: 100,
+			expected: false,
+		},
+		{
+			name:     "type byte zero (below valid range)",
+			input:    []byte{1, 0, 0, 0, 0, 8, 0, 0, 0, 'R', 'E', 'Q', 'U', 'E', 'S', 'T', '_', 'M', 'E', 'T', 'H', 'O', 'D'},
+			inputLen: 100,
+			expected: false,
+		},
+		{
+			name:     "type byte 12 (just above valid range)",
+			input:    []byte{1, 12, 0, 0, 0, 8, 0, 0, 0, 'R', 'E', 'Q', 'U', 'E', 'S', 'T', '_', 'M', 'E', 'T', 'H', 'O', 'D'},
+			inputLen: 100,
+			expected: false,
+		},
+		{
+			name:     "type byte 255 (well above valid range)",
+			input:    []byte{1, 255, 0, 0, 0, 8, 0, 0, 0, 'R', 'E', 'Q', 'U', 'E', 'S', 'T', '_', 'M', 'E', 'T', 'H', 'O', 'D'},
+			inputLen: 100,
+			expected: false,
+		},
+		{
+			name:     "type byte 1 (BEGIN_REQUEST, lower boundary) accepted",
+			input:    []byte{1, 1, 0, 0, 0, 8, 0, 0, 0, 'R', 'E', 'Q', 'U', 'E', 'S', 'T', '_', 'M', 'E', 'T', 'H', 'O', 'D'},
+			inputLen: 100,
+			expected: true,
+		},
+		{
+			name:     "type byte 11 (UNKNOWN_TYPE, upper boundary) accepted",
+			input:    []byte{1, 11, 0, 0, 0, 8, 0, 0, 0, 'R', 'E', 'Q', 'U', 'E', 'S', 'T', '_', 'M', 'E', 'T', 'H', 'O', 'D'},
+			inputLen: 100,
+			expected: true,
+		},
+		{
+			// Without the header prefilter this random-bytes buffer would be a
+			// false positive: it happens to contain "REQUEST_METHOD" but is
+			// clearly not FastCGI traffic.
+			name:     "random bytes containing REQUEST_METHOD literal are rejected",
+			input:    []byte{0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa, 0xf9, 0xf8, 0xf7, 'R', 'E', 'Q', 'U', 'E', 'S', 'T', '_', 'M', 'E', 'T', 'H', 'O', 'D'},
+			inputLen: 100,
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ebpf/common/http2grpc_transform.go
+++ b/pkg/ebpf/common/http2grpc_transform.go
@@ -557,7 +557,7 @@ func isHTTP2(data *largebuf.LargeBuffer, eventLen int) bool {
 	}
 
 	dataReader := data.NewReader()
-	framer := http2.NewFramer(io.Discard, &dataReader)
+	framer := http2.NewReusableFramer(io.Discard, &dataReader)
 
 	for {
 		f, err := framer.ReadFrame()

--- a/pkg/ebpf/common/http2grpc_transform.go
+++ b/pkg/ebpf/common/http2grpc_transform.go
@@ -488,8 +488,25 @@ const (
 
 const frameHeaderLen = 9
 
+// maxPlausibleHTTP2FrameLen is a deliberately loose upper bound on HTTP/2
+// frame payload length, chosen well above any realistic SETTINGS_MAX_FRAME_SIZE
+// negotiation. Per RFC 7540 6.5.2 the spec default is 2^14 and the absolute
+// maximum is 2^24 - 1; we pick 4 MiB so that eBPF captures starting after a
+// peer has bumped the limit (e.g. gRPC streaming workloads) still pass the
+// prefilter, while ~75% of random 24-bit length values are still rejected.
+// Bump this if real traffic is dropped — false negatives are worse than
+// false positives here, since the downstream parser rejects garbage anyway.
+const maxPlausibleHTTP2FrameLen = 1 << 22
+
 func readHTTP2Frame(buf []uint8, length int) (*frameHeader, bool) {
 	if length < frameHeaderLen {
+		return nil, false
+	}
+
+	// RFC 7540 4.1: the high bit of the stream-identifier word is reserved
+	// and MUST be 0 when sent. Real HTTP/2 implementations set it to 0;
+	// rejecting it filters ~50% of random byte sequences with one bit test.
+	if buf[5]&0x80 != 0 {
 		return nil, false
 	}
 
@@ -515,6 +532,69 @@ func isInvalidFrame(frame *frameHeader) bool {
 	return frame.Length == 0 && frame.Type == FrameData
 }
 
+// http2FlagsMask returns the bitmask of flag bits that have spec-defined
+// semantics for the given frame type. RFC 7540 4.1 requires senders to leave
+// all other flag bits zero (receivers MUST ignore them), so a non-zero bit
+// outside this mask is a strong signal that the bytes did not come from a
+// real HTTP/2 sender.
+func http2FlagsMask(t http2FrameType) uint8 {
+	switch t {
+	case FrameData:
+		return 0x09 // END_STREAM | PADDED
+	case FrameHeaders:
+		return 0x2D // END_STREAM | END_HEADERS | PADDED | PRIORITY
+	case FrameSettings, FramePing:
+		return 0x01 // ACK
+	case FramePushPromise:
+		return 0x0C // END_HEADERS | PADDED
+	case FrameContinuation:
+		return 0x04 // END_HEADERS
+	case FramePriority, FrameRSTStream, FrameGoAway, FrameWindowUpdate:
+		return 0x00 // no defined flags
+	}
+	return 0x00
+}
+
+// isPlausibleHTTP2Frame applies the per-frame-type stream-ID, payload-length
+// and flag constraints from RFC 7540 6 + 4.1. Real HTTP/2 implementations
+// cannot send frames that violate these rules, so we can safely abort the
+// prefilter walk when a candidate frame fails them — almost no random byte
+// sequence satisfies the fixed-length / stream-zero / known-flag rules.
+func isPlausibleHTTP2Frame(fr *frameHeader) bool {
+	// Reserved flag bits must be zero (4.1).
+	if fr.Flags & ^http2FlagsMask(fr.Type) != 0 {
+		return false
+	}
+
+	switch fr.Type {
+	case FrameData, FrameHeaders, FramePushPromise, FrameContinuation:
+		// 6.1 / 6.2 / 6.6 / 6.10: MUST be associated with a stream. Length
+		// is capped by SETTINGS_MAX_FRAME_SIZE.
+		return fr.StreamID != 0 && fr.Length <= maxPlausibleHTTP2FrameLen
+	case FramePriority:
+		// 6.3: stream-associated, length MUST be 5.
+		return fr.StreamID != 0 && fr.Length == 5
+	case FrameRSTStream:
+		// 6.4: stream-associated, length MUST be 4.
+		return fr.StreamID != 0 && fr.Length == 4
+	case FrameSettings:
+		// 6.5: MUST be on stream 0, length MUST be a multiple of 6 and
+		// bounded by SETTINGS_MAX_FRAME_SIZE.
+		return fr.StreamID == 0 && fr.Length%6 == 0 && fr.Length <= maxPlausibleHTTP2FrameLen
+	case FramePing:
+		// 6.7: MUST be on stream 0, length MUST be 8.
+		return fr.StreamID == 0 && fr.Length == 8
+	case FrameGoAway:
+		// 6.8: MUST be on stream 0, length MUST be at least 8 and bounded
+		// by SETTINGS_MAX_FRAME_SIZE.
+		return fr.StreamID == 0 && fr.Length >= 8 && fr.Length <= maxPlausibleHTTP2FrameLen
+	case FrameWindowUpdate:
+		// 6.9: length MUST be 4; allowed on any stream.
+		return fr.Length == 4
+	}
+	return false
+}
+
 func isLikelyHTTP2(data []uint8, eventLen int) bool {
 	pos := 0
 	l := min(eventLen, len(data))
@@ -525,6 +605,13 @@ func isLikelyHTTP2(data []uint8, eventLen int) bool {
 
 		fr, ok := readHTTP2Frame(data[pos:], l)
 		if !ok {
+			break
+		}
+
+		// A frame that violates the per-type spec rules cannot have come
+		// from a real HTTP/2 sender; bail out of the walk so random bytes
+		// can't accidentally land on a HEADERS frame later in the buffer.
+		if !isPlausibleHTTP2Frame(fr) {
 			break
 		}
 
@@ -557,7 +644,8 @@ func isHTTP2(data *largebuf.LargeBuffer, eventLen int) bool {
 	}
 
 	dataReader := data.NewReader()
-	framer := http2.NewReusableFramer(io.Discard, &dataReader)
+
+	framer := http2.NewFramer(io.Discard, &dataReader)
 
 	for {
 		f, err := framer.ReadFrame()

--- a/pkg/ebpf/common/http2grpc_transform.go
+++ b/pkg/ebpf/common/http2grpc_transform.go
@@ -494,7 +494,7 @@ const frameHeaderLen = 9
 // maximum is 2^24 - 1; we pick 4 MiB so that eBPF captures starting after a
 // peer has bumped the limit (e.g. gRPC streaming workloads) still pass the
 // prefilter, while ~75% of random 24-bit length values are still rejected.
-// Bump this if real traffic is dropped — false negatives are worse than
+// Bump this if real traffic is dropped - false negatives are worse than
 // false positives here, since the downstream parser rejects garbage anyway.
 const maxPlausibleHTTP2FrameLen = 1 << 22
 
@@ -558,7 +558,7 @@ func http2FlagsMask(t http2FrameType) uint8 {
 // isPlausibleHTTP2Frame applies the per-frame-type stream-ID, payload-length
 // and flag constraints from RFC 7540 6 + 4.1. Real HTTP/2 implementations
 // cannot send frames that violate these rules, so we can safely abort the
-// prefilter walk when a candidate frame fails them — almost no random byte
+// prefilter walk when a candidate frame fails them - almost no random byte
 // sequence satisfies the fixed-length / stream-zero / known-flag rules.
 func isPlausibleHTTP2Frame(fr *frameHeader) bool {
 	// Reserved flag bits must be zero (4.1).

--- a/pkg/ebpf/common/http2grpc_transform_test.go
+++ b/pkg/ebpf/common/http2grpc_transform_test.go
@@ -120,6 +120,18 @@ var isHTTP2TestCases = []struct {
 		expected:      true,
 		expectedQuick: true,
 	},
+	{
+		// Random garbage: byte[3]=0x01 (FrameHeaders), byte[5..8] starts
+		// 0x17 so the reserved bit is 0 and StreamID is non-zero. Before
+		// the 6.5.2 length bound and 4.1 flag-mask checks, this slipped
+		// through isLikelyHTTP2 as a "valid" HEADERS frame even though
+		// Length=0xA46E71 (~10MB) and Flags=0x6A sets reserved bits.
+		name:          "Random garbage misclassified as HEADERS",
+		input:         []byte{164, 110, 113, 1, 106, 23, 253, 162, 163, 72, 189, 1, 167, 129, 223, 103, 240, 248, 141, 115, 130, 57, 6, 202, 156, 118, 117, 222, 165, 192, 26, 203, 107, 74, 155, 217, 126, 137, 30, 182, 52, 167, 108, 198, 76, 221, 214, 85, 94, 8, 160, 220, 164, 214, 124, 156, 147, 43, 247, 227, 81, 115, 196, 184},
+		inputLen:      64,
+		expected:      false,
+		expectedQuick: false,
+	},
 }
 
 func TestHTTP2QuickDetection(t *testing.T) {

--- a/pkg/ebpf/common/kafka_detect_transform.go
+++ b/pkg/ebpf/common/kafka_detect_transform.go
@@ -23,8 +23,8 @@ const (
 )
 
 var (
-	errKafkaUnsupportedAPIKey            = errors.New("unsupported Kafka API key")
-	errKafkaNoResponseBufferForMetadata  = errors.New("no response buffer for metadata request")
+	errKafkaUnsupportedAPIKey           = errors.New("unsupported Kafka API key")
+	errKafkaNoResponseBufferForMetadata = errors.New("no response buffer for metadata request")
 )
 
 type PartitionInfo struct {

--- a/pkg/ebpf/common/kafka_detect_transform.go
+++ b/pkg/ebpf/common/kafka_detect_transform.go
@@ -22,6 +22,11 @@ const (
 	Fetch   Operation = 1
 )
 
+var (
+	errKafkaUnsupportedAPIKey            = errors.New("unsupported Kafka API key")
+	errKafkaNoResponseBufferForMetadata  = errors.New("no response buffer for metadata request")
+)
+
 type PartitionInfo struct {
 	Partition int
 	Offset    int64
@@ -73,7 +78,7 @@ func ProcessKafkaEvent(pkt *largebuf.LargeBuffer, rpkt *largebuf.LargeBuffer, ka
 	case kafkaparser.APIKeyMetadata:
 		return processMetadataResponse(rpkt, hdr, kafkaTopicUUIDToName)
 	default:
-		return nil, true, errors.New("unsupported Kafka API key")
+		return nil, true, errKafkaUnsupportedAPIKey
 	}
 }
 
@@ -153,7 +158,7 @@ func processFetchRequest(hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToNam
 
 func processMetadataResponse(rpkt *largebuf.LargeBuffer, hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (*KafkaInfo, bool, error) {
 	if rpkt == nil {
-		return nil, true, errors.New("no response buffer for metadata request")
+		return nil, true, errKafkaNoResponseBufferForMetadata
 	}
 	// only interested in response
 	r := rpkt.NewReader()
@@ -182,7 +187,7 @@ func ProcessKafkaRequest(pkt *largebuf.LargeBuffer, kafkaTopicUUIDToName *simple
 	case kafkaparser.APIKeyFetch:
 		return processFetchRequest(hdr, kafkaTopicUUIDToName)
 	default:
-		return nil, true, errors.New("unsupported Kafka API key")
+		return nil, true, errKafkaUnsupportedAPIKey
 	}
 }
 

--- a/pkg/ebpf/common/memcached_detect_transform.go
+++ b/pkg/ebpf/common/memcached_detect_transform.go
@@ -23,20 +23,22 @@ const (
 )
 
 // https://github.com/memcached/memcached/blob/master/doc/protocol.txt
-// memcachedFirstByte is the set of valid first-byte characters for any
+// memcachedFirstByteBitmap is the set of valid first-byte characters for any
 // memcached text-protocol frame: classic command letters (lowercase), classic
 // response keywords (uppercase first letters), numeric reply lines (digits),
 // plus the meta-protocol additions ('m' for mg/ms/md/me/ma/mn; 'H' for HD; 'M'
 // for ME/MN). O(1) prefilter that rejects ~87% of random byte values before
 // scanning for the CRLF line terminator.
-var memcachedFirstByte = [256]bool{
-	'a': true, 'c': true, 'd': true, 'f': true, 'g': true,
-	'i': true, 'm': true, 'p': true, 'r': true, 's': true,
-	't': true, 'v': true,
-	'V': true, 'E': true, 'S': true, 'N': true, 'D': true,
-	'T': true, 'O': true, 'C': true, 'H': true, 'M': true,
-	'0': true, '1': true, '2': true, '3': true, '4': true,
-	'5': true, '6': true, '7': true, '8': true, '9': true,
+var memcachedFirstByteBitmap = func() [4]uint64 {
+	var m [4]uint64
+	for _, c := range []byte("acdfgimprstvVESNDTOCHM0123456789") {
+		m[c>>6] |= 1 << (c & 63)
+	}
+	return m
+}()
+
+func isMemcachedFirstByte(b byte) bool {
+	return memcachedFirstByteBitmap[b>>6]&(1<<(b&63)) != 0
 }
 
 var (
@@ -71,7 +73,7 @@ func isMemcachedBuf(buf *largebuf.LargeBuffer) bool {
 	// letter, a response keyword, or a digit. Reject anything else without
 	// scanning the buffer for a CRLF that doesn't exist.
 	first, err := buf.U8At(0)
-	if err != nil || !memcachedFirstByte[first] {
+	if err != nil || !isMemcachedFirstByte(first) {
 		return false
 	}
 

--- a/pkg/ebpf/common/memcached_detect_transform.go
+++ b/pkg/ebpf/common/memcached_detect_transform.go
@@ -22,6 +22,23 @@ const (
 	minMemcachedFrameLen = 3
 )
 
+// https://github.com/memcached/memcached/blob/master/doc/protocol.txt
+// memcachedFirstByte is the set of valid first-byte characters for any
+// memcached text-protocol frame: classic command letters (lowercase), classic
+// response keywords (uppercase first letters), numeric reply lines (digits),
+// plus the meta-protocol additions ('m' for mg/ms/md/me/ma/mn; 'H' for HD; 'M'
+// for ME/MN). O(1) prefilter that rejects ~87% of random byte values before
+// scanning for the CRLF line terminator.
+var memcachedFirstByte = [256]bool{
+	'a': true, 'c': true, 'd': true, 'f': true, 'g': true,
+	'i': true, 'm': true, 'p': true, 'r': true, 's': true,
+	't': true, 'v': true,
+	'V': true, 'E': true, 'S': true, 'N': true, 'D': true,
+	'T': true, 'O': true, 'C': true, 'H': true, 'M': true,
+	'0': true, '1': true, '2': true, '3': true, '4': true,
+	'5': true, '6': true, '7': true, '8': true, '9': true,
+}
+
 var (
 	memcachedDelimBytes = []byte(memcachedDelim)
 	memcachedCommands   = map[string]struct{}{
@@ -47,6 +64,14 @@ type memcachedParseResult struct {
 
 func isMemcachedBuf(buf *largebuf.LargeBuffer) bool {
 	if buf.Len() < minMemcachedFrameLen {
+		return false
+	}
+
+	// Cheap prefilter: every memcached text frame starts with a command
+	// letter, a response keyword, or a digit. Reject anything else without
+	// scanning the buffer for a CRLF that doesn't exist.
+	first, err := buf.U8At(0)
+	if err != nil || !memcachedFirstByte[first] {
 		return false
 	}
 

--- a/pkg/ebpf/common/memcached_detect_transform_test.go
+++ b/pkg/ebpf/common/memcached_detect_transform_test.go
@@ -59,6 +59,37 @@ func TestIsMemcachedCommands(t *testing.T) {
 	}
 }
 
+func TestIsMemcachedFirstByte(t *testing.T) {
+	// Source of truth: the bitmap must accept exactly these 32 characters and
+	// nothing else.
+	const allowed = "acdfgimprstvVESNDTOCHM0123456789"
+
+	inAllowed := func(b byte) bool {
+		return bytes.IndexByte([]byte(allowed), b) >= 0
+	}
+
+	// Spot-check each allowed character explicitly so a failure points at the
+	// specific missing one.
+	for i := 0; i < len(allowed); i++ {
+		b := allowed[i]
+		assert.Truef(t, isMemcachedFirstByte(b), "expected %q (0x%02X) to be accepted", b, b)
+	}
+
+	// Exhaustive sweep across all 256 possible byte values to guarantee the
+	// bitmap doesn't accept anything outside the allowed set.
+	for b := 0; b < 256; b++ {
+		got := isMemcachedFirstByte(byte(b))
+		want := inAllowed(byte(b))
+		assert.Equalf(t, want, got, "byte 0x%02X (%q): want %v", b, byte(b), want)
+	}
+
+	// Sanity-check a handful of bytes that look plausible but must be rejected
+	// (uppercase letters that don't start any keyword, control bytes, high bit).
+	for _, b := range []byte{'A', 'B', 'Z', 'b', 'e', 'h', 'q', 'z', 0x00, 0x1F, 0x7F, 0x80, 0xFF, ' ', '\t', '\n', '\r', '+', '-'} {
+		assert.Falsef(t, isMemcachedFirstByte(b), "byte 0x%02X (%q) must be rejected", b, b)
+	}
+}
+
 func TestParseMemcachedRequest(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/pkg/ebpf/common/mongo_detect_transform.go
+++ b/pkg/ebpf/common/mongo_detect_transform.go
@@ -6,7 +6,6 @@ package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common"
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"strconv"
 	"unsafe"
 
@@ -19,6 +18,35 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
+)
+
+var (
+	errMongoPacketTooShortForHeader              = errors.New("packet too short for MongoDB header")
+	errMongoNoInFlightRequestForResponse         = errors.New("no in-flight MongoDB request found")
+	errMongoFailedToParseResponse                = errors.New("failed to parse MongoDB response")
+	errMongoNoRequestOrResponse                  = errors.New("no MongoDB request or response found in the message")
+	errMongoUnsupportedOpCode                    = errors.New("unsupported MongoDB operation code")
+	errMongoMoreToComeWithoutExhaustAllowed      = errors.New("MongoDB response with moreToCome flag set but exhaustAllowed is not set")
+	errMongoRequestExpectsMoreButResponseSent    = errors.New("MongoDB request expects more sections but response is sent")
+	errMongoRequestAfterAlreadyReceivingResponse = errors.New("MongoDB request received already started receiving response")
+	errMongoNewRequestWithoutMoreToCome          = errors.New("MongoDB request with moreToCome flag not set but got another request")
+	errMongoResponseWithoutPendingRequest        = errors.New("MongoDB response received but no pending request found")
+	errMongoPacketTooShortForFlagBits            = errors.New("packet too short for MongoDB flag bits")
+	errMongoFailedToParseSections                = errors.New("failed to parse MongoDB sections")
+	errMongoNoSections                           = errors.New("no MongoDB sections found in the message")
+	errMongoNotEnoughDataForSectionType          = errors.New("not enough data for MongoDB section type")
+	errMongoNotEnoughDataForSectionLength        = errors.New("not enough data for MongoDB section length")
+	errMongoUnsupportedSectionType               = errors.New("unsupported MongoDB section type")
+	errMongoInvalidMessageLength                 = errors.New("invalid MongoDB message length")
+	errMongoInvalidRequestID                     = errors.New("invalid MongoDB request ID")
+	errMongoInvalidResponseID                    = errors.New("invalid MongoDB response ID")
+	errMongoInvalidFlagBits                      = errors.New("invalid MongoDB flag bits")
+	errMongoNoRequestSections                    = errors.New("no MongoDB request sections found")
+	errMongoFirstSectionNotBody                  = errors.New("first MongoDB section is not of type body")
+	errMongoNoResponseBody                       = errors.New("no MongoDB body found in the response section")
+	errMongoNoOkField                            = errors.New("no 'ok' field found in MongoDB response")
+	errMongoHeartbeatIgnored                     = errors.New("MongoDB heartbeat operation is ignored")
+	errMongoNonStringCollectionType              = errors.New("MongoDB command has non-string collection type")
 )
 
 type mongoSpanInfo struct {
@@ -127,7 +155,7 @@ func requestTime(isResponse bool, startTime int64, endTime int64) int64 {
 
 func ProcessMongoEvent(buf []uint8, startTime int64, endTime int64, connInfo BpfConnectionInfoT, requests PendingMongoDBRequests) (*MongoRequestValue, bool, error) {
 	if len(buf) < msgHeaderSize {
-		return nil, false, errors.New("packet too short for MongoDB header")
+		return nil, false, errMongoPacketTooShortForHeader
 	}
 
 	header, err := parseMongoHeader(buf)
@@ -142,7 +170,7 @@ func ProcessMongoEvent(buf []uint8, startTime int64, endTime int64, connInfo Bpf
 	key := makeRequestKey(isResponse, header, connInfo)
 	inFlightRequest, ok := requests.Get(key)
 	if !ok && isResponse {
-		return nil, false, fmt.Errorf("no in-flight MongoDB request found for key %d", header.ResponseTo)
+		return nil, false, errMongoNoInFlightRequestForResponse
 	}
 	if isResponse && len(buf) == msgHeaderSize {
 		// TODO (mongo) currently the response is only the header, since the client sends only the first 16 bytes at first,
@@ -154,10 +182,10 @@ func ProcessMongoEvent(buf []uint8, startTime int64, endTime int64, connInfo Bpf
 	}
 	pendingRequest, moreToCome, err = parseMongoMessage(buf, *header, time, isResponse, inFlightRequest)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to parse MongoDB response: %w", err)
+		return nil, false, errMongoFailedToParseResponse
 	}
 	if pendingRequest == nil {
-		return nil, false, errors.New("no MongoDB request or response found in the message")
+		return nil, false, errMongoNoRequestOrResponse
 	}
 	if !moreToCome && isResponse {
 		// If this is a response and there are no more sections to come, we can finalize the request
@@ -172,7 +200,7 @@ func parseMongoMessage(buf []uint8, hdr msgHeader, time int64, isResponse bool, 
 	case opMsg:
 		return parseOpMessage(buf, time, isResponse, pendingRequest)
 	default:
-		return nil, false, fmt.Errorf("unsupported MongoDB operation code %d", hdr.OpCode)
+		return nil, false, errMongoUnsupportedOpCode
 	}
 }
 
@@ -182,19 +210,19 @@ func validateOpMsg(isResponse bool, flagBits int32, pendingRequest *MongoRequest
 	if isResponse {
 		exhaustAllowed := pendingRequest.Flags&flagExhaustAllowed != 0
 		if moreToCome && !exhaustAllowed {
-			return false, errors.New("MongoDB response with moreToCome flag set but exhaustAllowed is not set")
+			return false, errMongoMoreToComeWithoutExhaustAllowed
 		}
 		if pendingRequest.inRequest() && pendingRequest.Flags&flagMoreToCome != 0 {
-			return false, errors.New("MongoDB request expects more sections but response is sent")
+			return false, errMongoRequestExpectsMoreButResponseSent
 		}
 	} else {
 		switch {
 		case pendingRequest == nil:
 			return true, nil
 		case !pendingRequest.inRequest():
-			return false, errors.New("MongoDB request received already started receiving response")
+			return false, errMongoRequestAfterAlreadyReceivingResponse
 		case pendingRequest.Flags&flagMoreToCome == 0:
-			return false, errors.New("MongoDB request with moreToCome flag not set but got another request")
+			return false, errMongoNewRequestWithoutMoreToCome
 		}
 	}
 	return moreToCome, nil
@@ -203,7 +231,7 @@ func validateOpMsg(isResponse bool, flagBits int32, pendingRequest *MongoRequest
 func addSectionToMessage(isResponse bool, pendingRequest *MongoRequestValue, sections []mongoSection, flagBits int32, time int64) (*MongoRequestValue, error) {
 	if isResponse {
 		if pendingRequest == nil {
-			return nil, errors.New("MongoDB response received but no pending request found")
+			return nil, errMongoResponseWithoutPendingRequest
 		}
 		pendingRequest.ResponseSections = append(pendingRequest.ResponseSections, sections...)
 		pendingRequest.Flags = flagBits
@@ -236,7 +264,7 @@ func addSectionToMessage(isResponse bool, pendingRequest *MongoRequestValue, sec
 // +------------+-------------+------------------+
 func parseOpMessage(buf []uint8, time int64, isResponse bool, pendingRequest *MongoRequestValue) (*MongoRequestValue, bool, error) {
 	if len(buf) < msgHeaderSize+int32Size {
-		return nil, false, errors.New("packet too short for MongoDB flag bits")
+		return nil, false, errMongoPacketTooShortForFlagBits
 	}
 	flagBits := int32(binary.LittleEndian.Uint32(buf[msgHeaderSize : msgHeaderSize+int32Size]))
 	err := validateFlagBits(flagBits)
@@ -250,10 +278,10 @@ func parseOpMessage(buf []uint8, time int64, isResponse bool, pendingRequest *Mo
 	}
 	sections, err := parseSections(buf[msgHeaderSize+int32Size:])
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to parse MongoDB sections: %w", err)
+		return nil, false, errMongoFailedToParseSections
 	}
 	if len(sections) == 0 {
-		return nil, false, errors.New("no MongoDB sections found in the message")
+		return nil, false, errMongoNoSections
 	}
 	pendingRequest, err = addSectionToMessage(isResponse, pendingRequest, sections, flagBits, time)
 	if err != nil {
@@ -267,7 +295,7 @@ func parseSections(buf []uint8) ([]mongoSection, error) {
 	var sections []mongoSection
 	for offSet < len(buf) {
 		if len(buf[offSet:]) == 0 {
-			return nil, fmt.Errorf("not enough data for section[%d] type", len(sections))
+			return nil, errMongoNotEnoughDataForSectionType
 		}
 
 		sectionType := SectionType(buf[offSet])
@@ -288,17 +316,17 @@ func parseSections(buf []uint8) ([]mongoSection, error) {
 				Type: sectionTypeDocumentSequence,
 			})
 			if len(buf) < offSet+int32Size {
-				return nil, fmt.Errorf("not enough data for section[%d] length", len(sections))
+				return nil, errMongoNotEnoughDataForSectionLength
 			}
 			length := int(binary.LittleEndian.Uint32(buf[offSet : offSet+int32Size]))
 			offSet += length
 			// TODO (mongo) actually read documents? for now we just skip them
 		default:
-			return nil, errors.New("unsupported MongoDB section type: " + string(sectionType))
+			return nil, errMongoUnsupportedSectionType
 		}
 	}
 	if len(sections) == 0 {
-		return nil, errors.New("no MongoDB sections found in the message")
+		return nil, errMongoNoSections
 	}
 	return sections, nil
 }
@@ -339,13 +367,13 @@ func parseMongoHeader(pkt []byte) (*msgHeader, error) {
 
 func validateMsgHeader(header *msgHeader) error {
 	if header.MessageLength < msgHeaderSize {
-		return errors.New("invalid MongoDB message length")
+		return errMongoInvalidMessageLength
 	}
 	if header.RequestID < 0 {
-		return errors.New("invalid MongoDB request ID")
+		return errMongoInvalidRequestID
 	}
 	if header.ResponseTo < 0 {
-		return errors.New("invalid MongoDB response ID")
+		return errMongoInvalidResponseID
 	}
 	return nil
 }
@@ -355,7 +383,7 @@ The first 16 bits (0-15) are required and parsers MUST Error if an unknown bit i
 */
 func validateFlagBits(flagBits int32) error {
 	if uint16(flagBits&0xFFFF)&^allowedFlags != 0 {
-		return fmt.Errorf("invalid MongoDB flag bits: %d, allowed bits are: %d", flagBits, allowedFlags)
+		return errMongoInvalidFlagBits
 	}
 	return nil
 }
@@ -386,14 +414,14 @@ func mongoInfoFromEvent(event *TCPRequestInfo, requestBuffer *largebuf.LargeBuff
 func getMongoInfo(request *MongoRequestValue) (*mongoSpanInfo, error) {
 	spanInfo := &mongoSpanInfo{}
 	if request == nil || len(request.RequestSections) == 0 {
-		return nil, errors.New("no MongoDB request sections found")
+		return nil, errMongoNoRequestSections
 	}
 
 	// For simplicity, we assume the first section is the main one.
 	// In a real-world scenario, you might want to handle multiple sections.
 	requestSection := request.RequestSections[0]
 	if requestSection.Type != sectionTypeBody {
-		return nil, errors.New("first MongoDB section is not of type body")
+		return nil, errMongoFirstSectionNotBody
 	}
 	if len(requestSection.Body) == 0 {
 		// couldn't parse mongodb section, assume operation is *
@@ -418,11 +446,11 @@ func getMongoInfo(request *MongoRequestValue) (*mongoSpanInfo, error) {
 	} else {
 		responseSection := request.ResponseSections[0]
 		if len(responseSection.Body) == 0 {
-			return nil, errors.New("no MongoDB body found in the response section")
+			return nil, errMongoNoResponseBody
 		}
 		success, ok := findDoubleInBson(responseSection.Body, "ok")
 		if !ok {
-			return nil, errors.New("no 'ok' field found in MongoDB response")
+			return nil, errMongoNoOkField
 		}
 		spanInfo.Success = success == float64(1)
 		if spanInfo.Success {
@@ -515,12 +543,12 @@ func isCollectionCommand(comm string) bool {
 func parseFirstField(field bson.E) (string, string, error) {
 	comm := field.Key
 	if isHeartbeat(comm) {
-		return "", "", fmt.Errorf("MongoDB heartbeat operation '%s' is ignored", comm)
+		return "", "", errMongoHeartbeatIgnored
 	}
 	if isCollectionCommand(comm) {
 		collection, ok := field.Value.(string)
 		if !ok {
-			return "", "", fmt.Errorf("MongoDB command '%s' has non-string collection type %T", comm, field.Value)
+			return "", "", errMongoNonStringCollectionType
 		}
 		return comm, collection, nil
 	}

--- a/pkg/ebpf/common/mongo_detect_transform_test.go
+++ b/pkg/ebpf/common/mongo_detect_transform_test.go
@@ -486,7 +486,7 @@ func TestParseSectionsDocSequenceShortReturnsError(t *testing.T) {
 	sections, err := parseSections(buf)
 
 	require.Error(t, err)
-	require.EqualError(t, err, "not enough data for section[1] length")
+	require.EqualError(t, err, "not enough data for MongoDB section length")
 	assert.Nil(t, sections)
 }
 
@@ -496,7 +496,7 @@ func TestParseFirstFieldTypeAssertionReturnsError(t *testing.T) {
 	comm, collection, err := parseFirstField(field)
 
 	require.Error(t, err)
-	require.EqualError(t, err, "MongoDB command 'insert' has non-string collection type int32")
+	require.EqualError(t, err, "MongoDB command has non-string collection type")
 	assert.Empty(t, comm)
 	assert.Empty(t, collection)
 }
@@ -575,7 +575,7 @@ func TestGetMongoInfoFailForCollectionCommandWithNonStringCollection(t *testing.
 
 	_, err := getMongoInfo(&mongoRequest)
 	require.Error(t, err)
-	assert.EqualError(t, err, "MongoDB command 'find' has non-string collection type int32")
+	assert.EqualError(t, err, "MongoDB command has non-string collection type")
 }
 
 func TestGetMongoInfoOperationUnknownForEmptyRequestSection(t *testing.T) {

--- a/pkg/ebpf/common/mqtt_detect_transform.go
+++ b/pkg/ebpf/common/mqtt_detect_transform.go
@@ -53,12 +53,6 @@ func ProcessPossibleMQTTEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer, 
 	pktView := pkt.UnsafeView()
 	rpktView := rpkt.UnsafeView()
 
-	// Cheap prefilter: if neither buffer has a plausible MQTT fixed-header
-	// byte 0, skip the variable-length parsing entirely.
-	if !mqttparser.IsLikelyMQTT(pktView) && !mqttparser.IsLikelyMQTT(rpktView) {
-		return nil, true, errNotMQTT
-	}
-
 	m, ignore, err := ProcessMQTTEvent(pktView)
 	if err != nil {
 		// If we are getting the information in the response buffer, the event

--- a/pkg/ebpf/common/mqtt_detect_transform.go
+++ b/pkg/ebpf/common/mqtt_detect_transform.go
@@ -14,7 +14,13 @@ import (
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
 
-var errNotMQTT = errors.New("packet does not look like MQTT")
+var (
+	errPacketTooShortForMQTT     = errors.New("packet too short for MQTT")
+	errNoMQTTPacketsFound        = errors.New("no MQTT packets found")
+	errNoSpanWorthyMQTTPackets   = errors.New("no span-worthy MQTT packets found")
+	errUnsupportedMQTTPacketType = errors.New("unsupported MQTT packet type")
+	errNoMQTTSubscriptionsFound  = errors.New("no subscriptions found")
+)
 
 // MQTTInfo holds parsed information from an MQTT packet.
 type MQTTInfo struct {
@@ -69,7 +75,7 @@ func ProcessPossibleMQTTEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer, 
 // Returns MQTTInfo for span-worthy packets, or ignore=true for control packets.
 func ProcessMQTTEvent(pkt []byte) (*MQTTInfo, bool, error) {
 	if len(pkt) < mqttparser.MinPacketLen {
-		return nil, true, errors.New("packet too short for MQTT")
+		return nil, true, errPacketTooShortForMQTT
 	}
 
 	packets, err := mqttparser.ParseMQTTPackets(pkt)
@@ -78,7 +84,7 @@ func ProcessMQTTEvent(pkt []byte) (*MQTTInfo, bool, error) {
 	}
 
 	if len(packets) == 0 {
-		return nil, true, errors.New("no MQTT packets found")
+		return nil, true, errNoMQTTPacketsFound
 	}
 
 	// Process the first packet that we can extract span information from
@@ -99,7 +105,7 @@ func ProcessMQTTEvent(pkt []byte) (*MQTTInfo, bool, error) {
 		offset += packet.Length()
 	}
 
-	return nil, true, errors.New("no span-worthy MQTT packets found")
+	return nil, true, errNoSpanWorthyMQTTPackets
 }
 
 // processMQTTPacket processes a single MQTT packet based on its type.
@@ -129,7 +135,7 @@ func processMQTTPacket(pkt []byte, startOffset int, packet *mqttparser.MQTTContr
 		// Control packets - ignore for span creation
 		return nil, true, nil
 	default:
-		return nil, true, errors.New("unsupported MQTT packet type")
+		return nil, true, errUnsupportedMQTTPacketType
 	}
 }
 
@@ -154,7 +160,7 @@ func processSubscribePacket(pkt []byte, offset int, remainingLength int) (*MQTTI
 	}
 
 	if len(subscribe.Subscriptions) == 0 {
-		return nil, true, errors.New("no subscriptions found")
+		return nil, true, errNoMQTTSubscriptionsFound
 	}
 
 	// Use the first subscription for the span

--- a/pkg/ebpf/common/mqtt_detect_transform.go
+++ b/pkg/ebpf/common/mqtt_detect_transform.go
@@ -14,6 +14,8 @@ import (
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
 
+var errNotMQTT = errors.New("packet does not look like MQTT")
+
 // MQTTInfo holds parsed information from an MQTT packet.
 type MQTTInfo struct {
 	// PacketType is the MQTT packet type (PUBLISH, SUBSCRIBE, etc.)
@@ -48,11 +50,20 @@ func packetTypeToMethod(packetType mqttparser.PacketType) string {
 // Otherwise, returns MQTTInfo with the processed data. The ignore bool indicates whether the event
 // should be ignored for span creation (e.g., control packets like CONNECT).
 func ProcessPossibleMQTTEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer, rpkt *largebuf.LargeBuffer) (*MQTTInfo, bool, error) {
-	m, ignore, err := ProcessMQTTEvent(pkt.UnsafeView())
+	pktView := pkt.UnsafeView()
+	rpktView := rpkt.UnsafeView()
+
+	// Cheap prefilter: if neither buffer has a plausible MQTT fixed-header
+	// byte 0, skip the variable-length parsing entirely.
+	if !mqttparser.IsLikelyMQTT(pktView) && !mqttparser.IsLikelyMQTT(rpktView) {
+		return nil, true, errNotMQTT
+	}
+
+	m, ignore, err := ProcessMQTTEvent(pktView)
 	if err != nil {
 		// If we are getting the information in the response buffer, the event
 		// must be reversed and that's how we captured it.
-		m, ignore, err = ProcessMQTTEvent(rpkt.UnsafeView())
+		m, ignore, err = ProcessMQTTEvent(rpktView)
 		if err == nil && !ignore {
 			reverseTCPEvent(event)
 		}
@@ -98,7 +109,7 @@ func ProcessMQTTEvent(pkt []byte) (*MQTTInfo, bool, error) {
 }
 
 // processMQTTPacket processes a single MQTT packet based on its type.
-func processMQTTPacket(pkt []byte, startOffset int, packet mqttparser.MQTTControlPacket) (*MQTTInfo, bool, error) {
+func processMQTTPacket(pkt []byte, startOffset int, packet *mqttparser.MQTTControlPacket) (*MQTTInfo, bool, error) {
 	// Variable header starts after fixed header
 	varHeaderOffset := startOffset + packet.FixedHeader.Length
 

--- a/pkg/ebpf/common/nats_detect_transform.go
+++ b/pkg/ebpf/common/nats_detect_transform.go
@@ -17,21 +17,21 @@ import (
 
 // https://docs.nats.io/reference/reference-protocols/nats-protocol
 // https://docs.nats.io/reference/reference-protocols/nats-server-protocol
-// natsCmdFirstByte is the set of valid first-byte characters for any NATS
+// natsCmdFirstByteBitmap is the set of valid first-byte characters for any NATS
 // control frame: +OK, -ERR, PING, PONG, INFO, CONNECT, SUB, UNSUB, PUB, MSG,
 // HPUB, HMSG. Case-insensitive (lowercase variants accepted by the parser).
 // Used as an O(1) prefilter that rejects ~94% of random byte values.
-var natsCmdFirstByte = [256]bool{
-	'+': true, '-': true,
-	'P': true, 'p': true,
-	'I': true, 'i': true,
-	'C': true, 'c': true,
-	'S': true, 's': true,
-	'U': true, 'u': true,
-	'M': true, 'm': true,
-	'H': true, 'h': true,
-	// needed for NATS server protocol if we see any
-	'R': true, 'r': true,
+
+var natsCmdFirstByteBitmap = func() [4]uint64 {
+	var m [4]uint64
+	for _, c := range []byte("+-PpIiCcSsUuMmHhRr") {
+		m[c>>6] |= 1 << (c & 63)
+	}
+	return m
+}()
+
+func isNATSCmdFirstByte(b byte) bool {
+	return natsCmdFirstByteBitmap[b>>6]&(1<<(b&63)) != 0
 }
 
 var (
@@ -144,11 +144,13 @@ func ProcessNATSEvent(pkt *largebuf.LargeBuffer) (*NATSInfo, bool, error) {
 		return nil, true, errPacketTooShortForNATS
 	}
 
+	first, err := pkt.U8At(0)
+
 	// Cheap prefilter: every NATS frame starts with the first letter of one of
 	// the protocol commands (+OK, -ERR, PING/PONG/PUB, INFO, CONNECT, SUB,
 	// UNSUB, MSG, HPUB/HMSG). Reject anything else without invoking the
 	// frame parser.
-	if !natsCmdFirstByte[pkt.UnsafeView()[0]] {
+	if err != nil || !isNATSCmdFirstByte(first) {
 		return nil, true, errNotLikelyNATS
 	}
 

--- a/pkg/ebpf/common/nats_detect_transform.go
+++ b/pkg/ebpf/common/nats_detect_transform.go
@@ -15,6 +15,25 @@ import (
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
 
+// https://docs.nats.io/reference/reference-protocols/nats-protocol
+// https://docs.nats.io/reference/reference-protocols/nats-server-protocol
+// natsCmdFirstByte is the set of valid first-byte characters for any NATS
+// control frame: +OK, -ERR, PING, PONG, INFO, CONNECT, SUB, UNSUB, PUB, MSG,
+// HPUB, HMSG. Case-insensitive (lowercase variants accepted by the parser).
+// Used as an O(1) prefilter that rejects ~94% of random byte values.
+var natsCmdFirstByte = [256]bool{
+	'+': true, '-': true,
+	'P': true, 'p': true,
+	'I': true, 'i': true,
+	'C': true, 'c': true,
+	'S': true, 's': true,
+	'U': true, 'u': true,
+	'M': true, 'm': true,
+	'H': true, 'h': true,
+	// needed for NATS server protocol if we see any
+	'R': true, 'r': true,
+}
+
 var (
 	natsCRLF       = []byte("\r\n")
 	natsCmdOK      = []byte("+OK")
@@ -29,6 +48,37 @@ var (
 	natsCmdMsg     = []byte("MSG")
 	natsCmdHPub    = []byte("HPUB")
 	natsCmdHMsg    = []byte("HMSG")
+)
+
+var (
+	errMissingNatsTerminator               = errors.New("missing NATS control line terminator")
+	errPacketTooShortForNATS               = errors.New("packet too short for NATS")
+	errNotLikelyNATS                       = errors.New("packet does not look like NATS")
+	errEmptyNATSCommand                    = errors.New("empty NATS command")
+	errUnsupportedNATSCommand              = errors.New("unsupported NATS command")
+	errInvalidNATSJSONPayload              = errors.New("invalid NATS JSON payload")
+	errMissingNATSJSONPayload              = errors.New("missing NATS JSON payload")
+	errInvalidSUBControlLine               = errors.New("invalid SUB control line")
+	errInvalidUNSUBControlLine             = errors.New("invalid UNSUB control line")
+	errInvalidUNSUBMaxMsgs                 = errors.New("invalid UNSUB max_msgs")
+	errInvalidMSGControlLine               = errors.New("invalid MSG control line")
+	errInvalidMSGPayloadSize               = errors.New("invalid MSG payload size")
+	errInvalidHMSGControlLine              = errors.New("invalid HMSG control line")
+	errInvalidHMSGHeaderSize               = errors.New("invalid HMSG header size")
+	errInvalidHMSGTotalSize                = errors.New("invalid HMSG total size")
+	errHMSGHeaderSizeExceedsTotal          = errors.New("HMSG header size exceeds total size")
+	errInvalidIntegerField                 = errors.New("invalid integer field")
+	errInvalidNATSPayloadControlLine       = errors.New("invalid NATS payload control line")
+	errInvalidNATSPayloadSize              = errors.New("invalid NATS payload size")
+	errInvalidNATSHeaderPayloadControlLine = errors.New("invalid NATS header payload control line")
+	errInvalidNATSHeaderSize               = errors.New("invalid NATS header size")
+	errInvalidNATSTotalSize                = errors.New("invalid NATS total size")
+	errNATSHeaderSizeExceedsTotal          = errors.New("NATS header size exceeds total size")
+	errNegativeNATSPayloadSize             = errors.New("negative NATS payload size")
+	errTruncatedNATSPayload                = errors.New("truncated NATS payload")
+	errMissingNATSPayloadTerminator        = errors.New("missing NATS payload terminator")
+	errEmptyNATSControlLine                = errors.New("empty NATS control line")
+	errInvalidNATSSID                      = errors.New("invalid NATS sid")
 )
 
 type NATSInfo struct {
@@ -91,7 +141,15 @@ func ProcessPossibleNATSEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer, 
 // contains non-span control frames.
 func ProcessNATSEvent(pkt *largebuf.LargeBuffer) (*NATSInfo, bool, error) {
 	if pkt == nil || pkt.Len() == 0 {
-		return nil, true, errors.New("packet too short for NATS")
+		return nil, true, errPacketTooShortForNATS
+	}
+
+	// Cheap prefilter: every NATS frame starts with the first letter of one of
+	// the protocol commands (+OK, -ERR, PING/PONG/PUB, INFO, CONNECT, SUB,
+	// UNSUB, MSG, HPUB/HMSG). Reject anything else without invoking the
+	// frame parser.
+	if !natsCmdFirstByte[pkt.UnsafeView()[0]] {
+		return nil, true, errNotLikelyNATS
 	}
 
 	reader := pkt.NewReader()
@@ -123,7 +181,7 @@ func parseNATSFrame(reader *largebuf.LargeBufferReader) (natsFrame, error) {
 
 	fields := bytes.Fields(line)
 	if len(fields) == 0 {
-		return natsFrame{}, errors.New("empty NATS command")
+		return natsFrame{}, errEmptyNATSCommand
 	}
 
 	command := fields[0]
@@ -149,7 +207,7 @@ func parseNATSFrame(reader *largebuf.LargeBufferReader) (natsFrame, error) {
 	case equalFoldASCII(command, natsCmdHMsg):
 		return parseNATSHMSGFrame(reader, fields)
 	default:
-		return natsFrame{}, errors.New("unsupported NATS command")
+		return natsFrame{}, errUnsupportedNATSCommand
 	}
 }
 
@@ -167,7 +225,7 @@ func parseNATSInfoOrConnectFrame(command, line []byte) (natsFrame, error) {
 		Name string `json:"name"`
 	}
 	if err := json.Unmarshal(rest, &meta); err != nil {
-		return natsFrame{}, errors.New("invalid NATS JSON payload")
+		return natsFrame{}, errInvalidNATSJSONPayload
 	}
 
 	return natsFrame{clientID: meta.Name, valid: true}, nil
@@ -175,7 +233,7 @@ func parseNATSInfoOrConnectFrame(command, line []byte) (natsFrame, error) {
 
 func parseNATSSubFrame(fields [][]byte) (natsFrame, error) {
 	if len(fields) != 3 && len(fields) != 4 {
-		return natsFrame{}, errors.New("invalid SUB control line")
+		return natsFrame{}, errInvalidSUBControlLine
 	}
 	if err := validateNATSSID(fields[len(fields)-1]); err != nil {
 		return natsFrame{}, err
@@ -185,14 +243,14 @@ func parseNATSSubFrame(fields [][]byte) (natsFrame, error) {
 
 func parseNATSUnsubFrame(fields [][]byte) (natsFrame, error) {
 	if len(fields) != 2 && len(fields) != 3 {
-		return natsFrame{}, errors.New("invalid UNSUB control line")
+		return natsFrame{}, errInvalidUNSUBControlLine
 	}
 	if err := validateNATSSID(fields[1]); err != nil {
 		return natsFrame{}, err
 	}
 	if len(fields) == 3 {
 		if _, err := parseIntField(fields[2]); err != nil {
-			return natsFrame{}, errors.New("invalid UNSUB max_msgs")
+			return natsFrame{}, errInvalidUNSUBMaxMsgs
 		}
 	}
 	return natsFrame{valid: true}, nil
@@ -214,14 +272,14 @@ func parseNATSPUBFrame(reader *largebuf.LargeBufferReader, fields [][]byte) (nat
 
 func parseNATSMSGFrame(reader *largebuf.LargeBufferReader, fields [][]byte) (natsFrame, error) {
 	if len(fields) != 4 && len(fields) != 5 {
-		return natsFrame{}, errors.New("invalid MSG control line")
+		return natsFrame{}, errInvalidMSGControlLine
 	}
 	if err := validateNATSSID(fields[2]); err != nil {
 		return natsFrame{}, err
 	}
 	size, err := parseIntField(fields[len(fields)-1])
 	if err != nil {
-		return natsFrame{}, errors.New("invalid MSG payload size")
+		return natsFrame{}, errInvalidMSGPayloadSize
 	}
 	if err := consumeNATSPayload(reader, size); err != nil {
 		return natsFrame{}, err
@@ -248,21 +306,21 @@ func parseNATSHPUBFrame(reader *largebuf.LargeBufferReader, fields [][]byte) (na
 
 func parseNATSHMSGFrame(reader *largebuf.LargeBufferReader, fields [][]byte) (natsFrame, error) {
 	if len(fields) != 5 && len(fields) != 6 {
-		return natsFrame{}, errors.New("invalid HMSG control line")
+		return natsFrame{}, errInvalidHMSGControlLine
 	}
 	if err := validateNATSSID(fields[2]); err != nil {
 		return natsFrame{}, err
 	}
 	hdrSize, err := parseIntField(fields[len(fields)-2])
 	if err != nil {
-		return natsFrame{}, errors.New("invalid HMSG header size")
+		return natsFrame{}, errInvalidHMSGHeaderSize
 	}
 	totalSize, err := parseIntField(fields[len(fields)-1])
 	if err != nil {
-		return natsFrame{}, errors.New("invalid HMSG total size")
+		return natsFrame{}, errInvalidHMSGTotalSize
 	}
 	if hdrSize > totalSize {
-		return natsFrame{}, errors.New("HMSG header size exceeds total size")
+		return natsFrame{}, errHMSGHeaderSizeExceedsTotal
 	}
 	if err := consumeNATSPayload(reader, totalSize); err != nil {
 		return natsFrame{}, err
@@ -275,19 +333,19 @@ func parseNATSHMSGFrame(reader *largebuf.LargeBufferReader, fields [][]byte) (na
 
 func parseIntField(field []byte) (int, error) {
 	if len(field) == 0 {
-		return 0, errors.New("invalid integer field")
+		return 0, errInvalidIntegerField
 	}
 	return strconv.Atoi(unsafe.String(unsafe.SliceData(field), len(field)))
 }
 
 func parseNATSPayloadFields(fields [][]byte) (string, int, error) {
 	if len(fields) != 3 && len(fields) != 4 {
-		return "", 0, errors.New("invalid NATS payload control line")
+		return "", 0, errInvalidNATSPayloadControlLine
 	}
 
 	size, err := parseIntField(fields[len(fields)-1])
 	if err != nil {
-		return "", 0, errors.New("invalid NATS payload size")
+		return "", 0, errInvalidNATSPayloadSize
 	}
 
 	return string(fields[1]), size, nil
@@ -295,19 +353,19 @@ func parseNATSPayloadFields(fields [][]byte) (string, int, error) {
 
 func parseNATSHeaderPayloadFields(fields [][]byte) (string, int, error) {
 	if len(fields) != 4 && len(fields) != 5 {
-		return "", 0, errors.New("invalid NATS header payload control line")
+		return "", 0, errInvalidNATSHeaderPayloadControlLine
 	}
 
 	hdrSize, err := parseIntField(fields[len(fields)-2])
 	if err != nil {
-		return "", 0, errors.New("invalid NATS header size")
+		return "", 0, errInvalidNATSHeaderSize
 	}
 	totalSize, err := parseIntField(fields[len(fields)-1])
 	if err != nil {
-		return "", 0, errors.New("invalid NATS total size")
+		return "", 0, errInvalidNATSTotalSize
 	}
 	if hdrSize > totalSize {
-		return "", 0, errors.New("NATS header size exceeds total size")
+		return "", 0, errNATSHeaderSizeExceedsTotal
 	}
 
 	return string(fields[1]), totalSize, nil
@@ -315,19 +373,19 @@ func parseNATSHeaderPayloadFields(fields [][]byte) (string, int, error) {
 
 func consumeNATSPayload(reader *largebuf.LargeBufferReader, size int) error {
 	if size < 0 {
-		return errors.New("negative NATS payload size")
+		return errNegativeNATSPayloadSize
 	}
 
 	if err := reader.Skip(size); err != nil {
-		return errors.New("truncated NATS payload")
+		return errTruncatedNATSPayload
 	}
 
 	terminator, err := reader.ReadN(len(natsCRLF))
 	if err != nil {
-		return errors.New("truncated NATS payload")
+		return errTruncatedNATSPayload
 	}
 	if !bytes.Equal(terminator, natsCRLF) {
-		return errors.New("missing NATS payload terminator")
+		return errMissingNATSPayloadTerminator
 	}
 
 	return nil
@@ -336,22 +394,22 @@ func consumeNATSPayload(reader *largebuf.LargeBufferReader, size int) error {
 func readNATSControlLine(reader *largebuf.LargeBufferReader) ([]byte, error) {
 	crPos := reader.IndexByte('\r')
 	if crPos < 0 {
-		return nil, errors.New("missing NATS control line terminator")
+		return nil, errMissingNatsTerminator
 	}
 
 	line, err := reader.ReadN(crPos)
 	if err != nil {
-		return nil, errors.New("missing NATS control line terminator")
+		return nil, errMissingNatsTerminator
 	}
 
 	terminator, err := reader.ReadN(len(natsCRLF))
 	if err != nil || !bytes.Equal(terminator, natsCRLF) {
-		return nil, errors.New("missing NATS control line terminator")
+		return nil, errMissingNatsTerminator
 	}
 
 	line = bytes.TrimSpace(line)
 	if len(line) == 0 {
-		return nil, errors.New("empty NATS control line")
+		return nil, errEmptyNATSControlLine
 	}
 
 	return line, nil
@@ -359,12 +417,12 @@ func readNATSControlLine(reader *largebuf.LargeBufferReader) ([]byte, error) {
 
 func natsJSONPayload(line, command []byte) ([]byte, error) {
 	if len(line) <= len(command) {
-		return nil, errors.New("missing NATS JSON payload")
+		return nil, errMissingNATSJSONPayload
 	}
 
 	rest := bytes.TrimSpace(line[len(command):])
 	if !json.Valid(rest) {
-		return nil, errors.New("invalid NATS JSON payload")
+		return nil, errInvalidNATSJSONPayload
 	}
 
 	return rest, nil
@@ -372,7 +430,7 @@ func natsJSONPayload(line, command []byte) ([]byte, error) {
 
 func validateNATSSID(field []byte) error {
 	if !isASCIIAlnumBytes(field) {
-		return errors.New("invalid NATS sid")
+		return errInvalidNATSSID
 	}
 	return nil
 }

--- a/pkg/ebpf/common/sql_detect_mssql_test.go
+++ b/pkg/ebpf/common/sql_detect_mssql_test.go
@@ -171,8 +171,8 @@ func TestMSSQLBatchParsing(t *testing.T) {
 	}{
 		{
 			name:   "valid single-packet batch",
-			buf:    makeTDSPacket(kMSSQLBatch, 0x01, []byte{'S', 0, 'E', 0, 'L', 0, 'E', 0, 'C', 0, 'T', 0}),
-			wantOp: "SELECT", wantTable: "", wantStmt: "SELECT",
+			buf:    makeTDSPacket(kMSSQLBatch, 0x01, []byte{'S', 0, 'E', 0, 'L', 0, 'E', 0, 'C', 0, 'T', 0, ' ', 0, '1', 0}),
+			wantOp: "SELECT", wantTable: "", wantStmt: "SELECT 1",
 		},
 		{
 			name: "sql split across two TDS packets",

--- a/pkg/ebpf/common/sql_detect_postgres.go
+++ b/pkg/ebpf/common/sql_detect_postgres.go
@@ -39,14 +39,14 @@ const (
 )
 
 var (
-	errPGTooShort                       = errors.New("too short")
-	errPGTooShortStatement              = errors.New("too short, while parsing statement")
-	errPGTooShortPortal                 = errors.New("too short, while parsing portal")
-	errPGTooShortFormatCodes            = errors.New("too short, while parsing format codes")
-	errPGTooShortParams                 = errors.New("too short, while parsing params")
-	errPGRemainingTooShortHeader        = errors.New("remaining buffer too short for message header")
-	errPGMalformedMessage               = errors.New("malformed Postgres message")
-	errPGRemainingTooShortMessageData   = errors.New("remaining buffer too short for message data")
+	errPGTooShort                     = errors.New("too short")
+	errPGTooShortStatement            = errors.New("too short, while parsing statement")
+	errPGTooShortPortal               = errors.New("too short, while parsing portal")
+	errPGTooShortFormatCodes          = errors.New("too short, while parsing format codes")
+	errPGTooShortParams               = errors.New("too short, while parsing params")
+	errPGRemainingTooShortHeader      = errors.New("remaining buffer too short for message header")
+	errPGMalformedMessage             = errors.New("malformed Postgres message")
+	errPGRemainingTooShortMessageData = errors.New("remaining buffer too short for message data")
 )
 
 func isPostgres(b *largebuf.LargeBuffer) bool {

--- a/pkg/ebpf/common/sql_detect_postgres.go
+++ b/pkg/ebpf/common/sql_detect_postgres.go
@@ -38,6 +38,17 @@ const (
 	pgHeaderLen = 5
 )
 
+var (
+	errPGTooShort                       = errors.New("too short")
+	errPGTooShortStatement              = errors.New("too short, while parsing statement")
+	errPGTooShortPortal                 = errors.New("too short, while parsing portal")
+	errPGTooShortFormatCodes            = errors.New("too short, while parsing format codes")
+	errPGTooShortParams                 = errors.New("too short, while parsing params")
+	errPGRemainingTooShortHeader        = errors.New("remaining buffer too short for message header")
+	errPGMalformedMessage               = errors.New("malformed Postgres message")
+	errPGRemainingTooShortMessageData   = errors.New("remaining buffer too short for message data")
+)
+
 func isPostgres(b *largebuf.LargeBuffer) bool {
 	op, ok := isValidPostgresPayload(b)
 
@@ -80,13 +91,13 @@ func isValidPostgresPayload(b *largebuf.LargeBuffer) (byte, bool) {
 func msgBody(b *largebuf.LargeBuffer) ([]byte, error) {
 	size, err := b.I32BEAt(1)
 	if err != nil {
-		return nil, errors.New("too short")
+		return nil, errPGTooShort
 	}
 
 	msgSize := min(1+int(size), b.Len())
 
 	if msgSize < pgHeaderLen {
-		return nil, errors.New("too short")
+		return nil, errPGTooShort
 	}
 
 	return b.UnsafeViewAt(pgHeaderLen, msgSize-pgHeaderLen)
@@ -97,11 +108,11 @@ func msgBody(b *largebuf.LargeBuffer) ([]byte, error) {
 func msgBodyReader(b *largebuf.LargeBuffer) (largebuf.LargeBufferReader, error) {
 	size, err := b.I32BEAt(1)
 	if err != nil {
-		return largebuf.LargeBufferReader{}, errors.New("too short")
+		return largebuf.LargeBufferReader{}, errPGTooShort
 	}
 	end := min(1+int(size), b.Len())
 	if end < pgHeaderLen {
-		return largebuf.LargeBufferReader{}, errors.New("too short")
+		return largebuf.LargeBufferReader{}, errPGTooShort
 	}
 	return b.NewLimitedReader(pgHeaderLen, end)
 }
@@ -115,29 +126,29 @@ func parsePostgresBindCommand(b *largebuf.LargeBuffer) (string, string, []string
 
 	stmtBytes, err := r.ReadCStr()
 	if err != nil {
-		return "", "", nil, errors.New("too short, while parsing statement")
+		return "", "", nil, errPGTooShortStatement
 	}
 
 	portalBytes, err := r.ReadCStr()
 	if err != nil {
-		return "", "", nil, errors.New("too short, while parsing portal")
+		return "", "", nil, errPGTooShortPortal
 	}
 
 	// skip format codes: Int16 count + count*Int16 entries
 	formats, err := r.ReadI16BE()
 	if err != nil {
-		return "", "", nil, errors.New("too short, while parsing format codes")
+		return "", "", nil, errPGTooShortFormatCodes
 	}
 	if formats > 0 {
 		if err := r.Skip(2 * int(formats)); err != nil {
-			return "", "", nil, errors.New("too short, while parsing format codes")
+			return "", "", nil, errPGTooShortFormatCodes
 		}
 	}
 
 	// parse parameter values: Int16 count + repeated (Int32 length + bytes)
 	params, err := r.ReadI16BE()
 	if err != nil {
-		return "", "", nil, errors.New("too short, while parsing params")
+		return "", "", nil, errPGTooShortParams
 	}
 	if params <= 0 {
 		return string(stmtBytes), string(portalBytes), nil, nil
@@ -146,7 +157,7 @@ func parsePostgresBindCommand(b *largebuf.LargeBuffer) (string, string, []string
 	for range int(params) {
 		argLen, err := r.ReadI32BE()
 		if err != nil {
-			return "", "", nil, errors.New("too short, while parsing params")
+			return "", "", nil, errPGTooShortParams
 		}
 		if argLen < 0 {
 			// NULL parameter value (-1 in the protocol)
@@ -155,7 +166,7 @@ func parsePostgresBindCommand(b *largebuf.LargeBuffer) (string, string, []string
 		n := min(int(argLen), r.Remaining())
 		arg, err := r.ReadN(n)
 		if err != nil {
-			return "", "", nil, errors.New("too short, while parsing params")
+			return "", "", nil, errPGTooShortParams
 		}
 		args = append(args, string(arg))
 	}
@@ -239,7 +250,7 @@ func (it *postgresMessageIterator) next() (msg postgresMessage) {
 		return
 	}
 	if it.r.Remaining() < sqlprune.PostgresHdrSize {
-		it.err = errors.New("remaining buffer too short for message header")
+		it.err = errPGRemainingTooShortHeader
 		return
 	}
 
@@ -254,13 +265,13 @@ func (it *postgresMessageIterator) next() (msg postgresMessage) {
 	size := int32(binary.BigEndian.Uint32(hdrBuf[1:5]))
 
 	if size < sqlprune.PostgresHdrSize-1 {
-		it.err = errors.New("malformed Postgres message")
+		it.err = errPGMalformedMessage
 		return
 	}
 
 	payloadSize := size - sqlprune.PostgresHdrSize + 1
 	if it.r.Remaining() < int(payloadSize) {
-		it.err = fmt.Errorf("remaining buffer too short for message data: expected %d bytes, got %d", payloadSize, it.r.Remaining())
+		it.err = errPGRemainingTooShortMessageData
 		return
 	}
 

--- a/pkg/ebpf/common/sql_detect_transform.go
+++ b/pkg/ebpf/common/sql_detect_transform.go
@@ -75,6 +75,34 @@ var sqlKeywords = [][]byte{
 
 var sqlExecuteKeyword = []byte("EXECUTE ")
 
+const minSQLPrintableRun = len("SELECT 1")
+
+// isSQLByte reports whether b is a byte that can appear inside a SQL statement
+// (printable ASCII plus the common whitespace characters).
+func isSQLByte(b byte) bool {
+	return (b >= 0x20 && b < 0x7f) || b == '\t' || b == '\n' || b == '\r'
+}
+
+// firstSQLRun returns the start index of the first contiguous run of at least
+// minLen SQL-plausible bytes in buf, or -1 if no such run exists.
+func firstSQLRun(buf []byte, minLen int) int {
+	if len(buf) < minLen {
+		return -1
+	}
+	run := 0
+	for i, b := range buf {
+		if isSQLByte(b) {
+			run++
+			if run >= minLen {
+				return i - minLen + 1
+			}
+		} else {
+			run = 0
+		}
+	}
+	return -1
+}
+
 func detectSQLPayload(useHeuristics bool, b *largebuf.LargeBuffer) (string, string, string, request.SQLKind) {
 	sqlKind := sqlKind(b)
 
@@ -101,16 +129,25 @@ func detectSQLPayload(useHeuristics bool, b *largebuf.LargeBuffer) (string, stri
 }
 
 func detectSQL(buf []byte) (string, string, string) {
+	// Cheap prefilter: most SQL wire protocols carry a small binary header
+	// followed by the statement as plain text. If no printable-ASCII run long
+	// enough to fit the shortest valid SQL exists, skip the case-fold scan.
+	start := firstSQLRun(buf, minSQLPrintableRun)
+	if start < 0 {
+		return "", "", ""
+	}
+	scan := buf[start:]
+
 	minIdx := -1
 	for _, q := range sqlKeywords {
-		i := asciiIndexFold(buf, q)
+		i := asciiIndexFold(scan, q)
 		if i >= 0 && (minIdx < 0 || i < minIdx) {
 			minIdx = i
 		}
 	}
 
 	if minIdx >= 0 {
-		sql := cstr(buf[minIdx:])
+		sql := cstr(scan[minIdx:])
 		op, table := sqlprune.SQLParseOperationAndTable(sql)
 		return op, table, sql
 	}

--- a/pkg/ebpf/common/sql_detect_transform_test.go
+++ b/pkg/ebpf/common/sql_detect_transform_test.go
@@ -231,3 +231,108 @@ func TestIsASCII(t *testing.T) {
 		})
 	}
 }
+
+func TestMinSQLPrintableRun(t *testing.T) {
+	// Pinned to the length of "SELECT 1" so that the shortest detectable SQL
+	// statement just clears the prefilter threshold. If this changes, audit
+	// the SQL detection tests in tcp_detect_transform_test.go.
+	assert.Len(t, "SELECT 1", minSQLPrintableRun)
+}
+
+func TestIsSQLByte(t *testing.T) {
+	t.Run("accepts every printable ASCII byte in [0x20, 0x7F)", func(t *testing.T) {
+		for b := 0x20; b < 0x7f; b++ {
+			assert.Truef(t, isSQLByte(byte(b)), "byte 0x%02X should be accepted", b)
+		}
+	})
+
+	t.Run("accepts tab, LF, and CR", func(t *testing.T) {
+		for _, b := range []byte{'\t', '\n', '\r'} {
+			assert.Truef(t, isSQLByte(b), "whitespace 0x%02X should be accepted", b)
+		}
+	})
+
+	t.Run("rejects control bytes other than tab/LF/CR", func(t *testing.T) {
+		for _, b := range []byte{0x00, 0x01, '\b', '\v', '\f', 0x1B, 0x1F} {
+			assert.Falsef(t, isSQLByte(b), "control byte 0x%02X should be rejected", b)
+		}
+	})
+
+	t.Run("rejects DEL (0x7F)", func(t *testing.T) {
+		// 0x7F sits just outside the [0x20, 0x7F) printable range.
+		assert.False(t, isSQLByte(0x7f))
+	})
+
+	t.Run("rejects bytes with the high bit set", func(t *testing.T) {
+		for _, b := range []byte{0x80, 0xA5, 0xC2, 0xFE, 0xFF} {
+			assert.Falsef(t, isSQLByte(b), "high-bit byte 0x%02X should be rejected", b)
+		}
+	})
+}
+
+func TestFirstSQLRun(t *testing.T) {
+	t.Run("returns -1 when the buffer is shorter than minLen", func(t *testing.T) {
+		assert.Equal(t, -1, firstSQLRun([]byte("hi"), 5))
+		assert.Equal(t, -1, firstSQLRun(nil, 1))
+		assert.Equal(t, -1, firstSQLRun([]byte{}, 1))
+	})
+
+	t.Run("returns 0 when the whole buffer is printable", func(t *testing.T) {
+		assert.Equal(t, 0, firstSQLRun([]byte("SELECT 1"), 8))
+		assert.Equal(t, 0, firstSQLRun([]byte("SELECT * FROM users"), 8))
+	})
+
+	t.Run("returns 0 when the buffer is exactly minLen and all printable", func(t *testing.T) {
+		assert.Equal(t, 0, firstSQLRun([]byte("ABCDEFGH"), 8))
+	})
+
+	t.Run("returns the start of a qualifying run that follows a binary prefix", func(t *testing.T) {
+		// 5 bytes of binary, then "SELECT 1" (8 printable bytes).
+		buf := append([]byte{0x00, 0x01, 0xff, 0xfe, 0x80}, []byte("SELECT 1")...)
+		assert.Equal(t, 5, firstSQLRun(buf, 8))
+	})
+
+	t.Run("returns -1 when no printable run reaches minLen", func(t *testing.T) {
+		// Three 4-byte printable islands separated by binary; none qualifies.
+		buf := []byte("ABCD\x00XYZW\xffPQRS")
+		assert.Equal(t, -1, firstSQLRun(buf, 8))
+	})
+
+	t.Run("skips a short run and finds a later qualifying one", func(t *testing.T) {
+		// 4 printable bytes, a binary byte, then 8 printable bytes.
+		buf := append([]byte("ABCD\x00"), []byte("SELECT 1")...)
+		assert.Equal(t, 5, firstSQLRun(buf, 8))
+	})
+
+	t.Run("counts tab, LF, and CR as part of a run", func(t *testing.T) {
+		// "S\tE\nL\rE\tCT" = 9 bytes, all SQL-plausible.
+		buf := []byte("S\tE\nL\rE\tCT")
+		assert.Equal(t, 0, firstSQLRun(buf, 8))
+	})
+
+	t.Run("returns the earliest qualifying run when several exist", func(t *testing.T) {
+		// Two 8+ byte printable runs separated by binary; the first one wins.
+		buf := append([]byte("FIRSTONE\x00"), []byte("SECONDONE")...)
+		assert.Equal(t, 0, firstSQLRun(buf, 8))
+	})
+
+	t.Run("returns the correct offset when a single binary byte precedes a qualifying run", func(t *testing.T) {
+		// Exercises the i - minLen + 1 arithmetic at the boundary.
+		buf := []byte("\x00SELECT 1")
+		assert.Equal(t, 1, firstSQLRun(buf, 8))
+	})
+
+	t.Run("DEL byte interrupts a run", func(t *testing.T) {
+		// 0x7F is not SQL-plausible, so "SELECT" (6 chars) is too short and
+		// the run only qualifies starting at the space after 0x7F.
+		buf := []byte("SELECT\x7f 1 FROM x")
+		assert.Equal(t, 7, firstSQLRun(buf, 8))
+	})
+
+	t.Run("high-bit bytes interrupt a run", func(t *testing.T) {
+		// Half of a UTF-8 emoji in the middle of otherwise-printable text.
+		buf := []byte("SELECT\xc2\xa9 1 FROM x")
+		// The qualifying run starts at the space (index 8) and runs to end.
+		assert.Equal(t, 8, firstSQLRun(buf, 8))
+	})
+}

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -406,12 +406,14 @@ func matchAMQP(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer,
 }
 
 func matchMQTT(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
-	pktView := requestBuffer.UnsafeView()
-	rpktView := responseBuffer.UnsafeView()
+	isLikelyMQTT := func(pkt *largebuf.LargeBuffer) bool {
+		first, err := pkt.U8At(0)
 
+		return err == nil && mqttparser.IsLikelyMQTT(first, pkt.Len())
+	}
 	// Cheap prefilter: if neither buffer has a plausible MQTT fixed-header
 	// byte 0, skip the variable-length parsing entirely.
-	if !mqttparser.IsLikelyMQTT(pktView) && !mqttparser.IsLikelyMQTT(rpktView) {
+	if !isLikelyMQTT(requestBuffer) && !isLikelyMQTT(responseBuffer) {
 		return request.Span{}, false, false, nil
 	}
 

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/amqpparser"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser"
+	"go.opentelemetry.io/obi/pkg/internal/ebpf/mqttparser"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
@@ -405,6 +406,15 @@ func matchAMQP(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer,
 }
 
 func matchMQTT(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	pktView := requestBuffer.UnsafeView()
+	rpktView := responseBuffer.UnsafeView()
+
+	// Cheap prefilter: if neither buffer has a plausible MQTT fixed-header
+	// byte 0, skip the variable-length parsing entirely.
+	if !mqttparser.IsLikelyMQTT(pktView) && !mqttparser.IsLikelyMQTT(rpktView) {
+		return request.Span{}, false, false, nil
+	}
+
 	if !isMQTT(requestBuffer) && !isMQTT(responseBuffer) {
 		return request.Span{}, false, false, nil
 	}

--- a/pkg/ebpf/common/tcp_detect_transform_test.go
+++ b/pkg/ebpf/common/tcp_detect_transform_test.go
@@ -110,6 +110,62 @@ func TestTCPReqParsing(t *testing.T) {
 	assert.Contains(t, output.String(), "![<]")
 }
 
+func BenchmarkReadTCPRequestIntoSpan_RandomGarbage(b *testing.B) {
+	benchReadTCPRequestIntoSpanRandomGarbage(b, false)
+}
+
+func BenchmarkReadTCPRequestIntoSpan_SQLRandomGarbage(b *testing.B) {
+	benchReadTCPRequestIntoSpanRandomGarbage(b, true)
+}
+
+func benchReadTCPRequestIntoSpanRandomGarbage(b *testing.B, heuristic bool) {
+	const (
+		corpusSize     = 1024
+		parserCacheLen = 1024
+	)
+
+	cfg := config.EBPFTracer{
+		HeuristicSQLDetect:                  heuristic,
+		CouchbaseDBCacheSize:                parserCacheLen,
+		MySQLPreparedStatementsCacheSize:    parserCacheLen,
+		PostgresPreparedStatementsCacheSize: parserCacheLen,
+		MSSQLPreparedStatementsCacheSize:    parserCacheLen,
+		MongoRequestsCacheSize:              parserCacheLen,
+		KafkaTopicUUIDCacheSize:             parserCacheLen,
+	}
+	ctx := NewEBPFParseContext(&cfg, nil, nil)
+	fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+	rng := rand.New(rand.NewPCG(1, 2))
+
+	records := make([]ringbuf.Record, corpusSize)
+	for i := range records {
+		tri := makeTCPReq("", 8080)
+		fillRandomGarbage(rng, tri.Buf[:])
+		fillRandomGarbage(rng, tri.Rbuf[:])
+		tri.Len = uint32(len(tri.Buf))
+		tri.RespLen = uint32(len(tri.Rbuf))
+		tri.ProtocolType = ProtocolTypeUnknown
+		tri.EventSource = GenericEventSourceTypeKProbes
+		tri.ConnInfo.S_port = uint16(20000 + i)
+
+		binaryRecord := bytes.Buffer{}
+		require.NoError(b, binary.Write(&binaryRecord, binary.LittleEndian, tri))
+		records[i] = ringbuf.Record{RawSample: binaryRecord.Bytes()}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		span, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &records[i%len(records)], &fltr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = span
+		_ = ignore
+	}
+}
+
 func TestSQLDetection(t *testing.T) {
 	for _, s := range [][]byte{
 		[]byte("SELECT * from accounts"), []byte("SELECT/*My comment*/ * from accounts"),
@@ -140,7 +196,7 @@ func TestSQLDetectionFails(t *testing.T) {
 }
 
 func TestSQLDetectionDoesntFailForDetectedKind(t *testing.T) {
-	for _, s := range [][]byte{[]byte("SELECT"), []byte("DELETE {} ")} {
+	for _, s := range [][]byte{[]byte("SELECT 1"), []byte("DELETE {}")} {
 		op, table, _ := detectSQL(s)
 		assert.True(t, validSQL(op, table, request.DBPostgres))
 	}
@@ -455,6 +511,12 @@ func randomString(length int) string {
 
 func randomStringWithSub(sub string) string {
 	return fmt.Sprintf("%s%s%s", randomString(rand.IntN(10)), sub, randomString(rand.IntN(20)))
+}
+
+func fillRandomGarbage(rng *rand.Rand, buf []byte) {
+	for i := range buf {
+		buf[i] = byte(rng.Uint64())
+	}
 }
 
 func TestReadTCPRequestIntoSpan_CouchbaseKeyNotFound(t *testing.T) {

--- a/pkg/internal/ebpf/amqpparser/frame.go
+++ b/pkg/internal/ebpf/amqpparser/frame.go
@@ -5,7 +5,6 @@ package amqpparser // import "go.opentelemetry.io/obi/pkg/internal/ebpf/amqppars
 
 import (
 	"errors"
-	"fmt"
 
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
@@ -48,9 +47,19 @@ const (
 	descriptorSASLOutcome    descriptor = 0x44
 )
 
-// errIncompleteFrame signals the buffer ends before the full frame body; callers may
-// try to recover the performative from the available prefix.
-var errIncompleteFrame = errors.New("incomplete AMQP frame")
+var (
+	errIncompleteFrame   = errors.New("incomplete AMQP frame")
+	errTooShort          = errors.New("packet too short")
+	errInvalidFrameSize  = errors.New("invalid frame size")
+	errInvalidDataOffset = errors.New("invalid AMQP frame data offset")
+	errInvalidBodyOffset = errors.New("invalid AMQP frame body offset")
+	errInvalidType       = errors.New("invalid AMQP frame type")
+	errBodyTooShort      = errors.New("AMQP frame body too short")
+	errNotDescribed      = errors.New("AMQP performative is not described")
+	errTruncated         = errors.New("AMQP ulong descriptor truncated")
+	errBadEncoding       = errors.New("unsupported AMQP descriptor encoding")
+	errUnknownDescriptor = errors.New("unknown AMQP performative descriptor")
+)
 
 type frameType uint8
 
@@ -70,7 +79,7 @@ func (h frameHeader) bodyOffset() int {
 func parseFrameHeader(r *largebuf.LargeBufferReader) (frameHeader, error) {
 	remaining := r.Remaining()
 	if remaining < frameHeaderSize {
-		return frameHeader{}, fmt.Errorf("packet too short for AMQP frame header: have %d bytes, need %d", remaining, frameHeaderSize)
+		return frameHeader{}, errTooShort
 	}
 
 	size, err := r.ReadU32BE()
@@ -78,7 +87,7 @@ func parseFrameHeader(r *largebuf.LargeBufferReader) (frameHeader, error) {
 		return frameHeader{}, err
 	}
 	if size < frameHeaderSize {
-		return frameHeader{}, fmt.Errorf("invalid AMQP frame size %d (must be >= %d)", size, frameHeaderSize)
+		return frameHeader{}, errInvalidFrameSize
 	}
 
 	doff, err := r.ReadU8()
@@ -86,7 +95,7 @@ func parseFrameHeader(r *largebuf.LargeBufferReader) (frameHeader, error) {
 		return frameHeader{}, err
 	}
 	if doff < minDataOffsetWords {
-		return frameHeader{}, fmt.Errorf("invalid AMQP frame data offset %d (must be >= %d)", doff, minDataOffsetWords)
+		return frameHeader{}, errInvalidDataOffset
 	}
 
 	ft, err := r.ReadU8()
@@ -104,13 +113,13 @@ func parseFrameHeader(r *largebuf.LargeBufferReader) (frameHeader, error) {
 	}
 
 	if h.bodyOffset() > int(h.Size) {
-		return frameHeader{}, fmt.Errorf("invalid AMQP frame body offset %d (exceeds frame size %d)", h.bodyOffset(), h.Size)
+		return frameHeader{}, errInvalidBodyOffset
 	}
 
 	switch h.Type {
 	case frameTypeAMQP, frameTypeSASL:
 	default:
-		return frameHeader{}, fmt.Errorf("invalid AMQP frame type 0x%02X", byte(h.Type))
+		return frameHeader{}, errInvalidType
 	}
 
 	if int(size) > remaining {
@@ -147,7 +156,7 @@ func parseDescriptor(r *largebuf.LargeBufferReader, ft frameType, bodyLen int) (
 		return 0, false, nil
 	}
 	if bodyLen < smallULongDescriptorSize {
-		return 0, false, fmt.Errorf("AMQP frame body too short for performative: %d bytes", bodyLen)
+		return 0, false, errBodyTooShort
 	}
 
 	constructor, err := r.ReadU8()
@@ -155,7 +164,7 @@ func parseDescriptor(r *largebuf.LargeBufferReader, ft frameType, bodyLen int) (
 		return 0, false, err
 	}
 	if constructor != describedTypeConstructor {
-		return 0, false, fmt.Errorf("AMQP performative is not described (first byte 0x%02X)", constructor)
+		return 0, false, errNotDescribed
 	}
 
 	formatCode, err := r.ReadU8()
@@ -173,7 +182,7 @@ func parseDescriptor(r *largebuf.LargeBufferReader, ft frameType, bodyLen int) (
 		desc = descriptor(value)
 	case formatCodeULong:
 		if bodyLen < uLongDescriptorSize {
-			return 0, false, fmt.Errorf("AMQP ulong descriptor truncated: %d bytes, need %d", bodyLen, uLongDescriptorSize)
+			return 0, false, errTruncated
 		}
 		value, err := r.ReadU64BE()
 		if err != nil {
@@ -181,11 +190,11 @@ func parseDescriptor(r *largebuf.LargeBufferReader, ft frameType, bodyLen int) (
 		}
 		desc = descriptor(value)
 	default:
-		return 0, false, fmt.Errorf("unsupported AMQP descriptor encoding 0x%02X", formatCode)
+		return 0, false, errBadEncoding
 	}
 
 	if !isKnownPerformativeDescriptor(ft, desc) {
-		return 0, false, fmt.Errorf("unknown AMQP performative descriptor 0x%X on frame type 0x%02X", uint64(desc), byte(ft))
+		return 0, false, errUnknownDescriptor
 	}
 
 	return desc, true, nil

--- a/pkg/internal/ebpf/amqpparser/protocol.go
+++ b/pkg/internal/ebpf/amqpparser/protocol.go
@@ -5,6 +5,7 @@ package amqpparser // import "go.opentelemetry.io/obi/pkg/internal/ebpf/amqppars
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 
@@ -42,6 +43,50 @@ type protocolHeader struct {
 func startsWithMagic(r *largebuf.LargeBufferReader) bool {
 	data, err := r.Peek(len(amqpMagic))
 	return err == nil && bytes.Equal(data, amqpMagic)
+}
+
+// IsLikelyAMQP is an O(1) prefilter that reports whether buf could plausibly
+// start an AMQP 1.0 conversation. It accepts either the connection preamble
+// ("AMQP" magic) or a structurally valid frame header. The full Parse should
+// still be invoked to confirm — this only filters out obviously non-AMQP
+// payloads cheaply.
+// https://docs.oasis-open.org/amqp/core/v1.0/csprd01/amqp-core-transport-v1.0-csprd01.html
+func IsLikelyAMQP(buf []byte) bool {
+	if len(buf) >= len(amqpMagic) && bytes.Equal(buf[:len(amqpMagic)], amqpMagic) {
+		return true
+	}
+
+	if len(buf) < frameHeaderSize {
+		return false
+	}
+
+	// Frame header: size(u32 BE) | doff(u8) | type(u8) | channel(u16).
+	// type 0x00 (AMQP) or 0x01 (SASL) alone filters out ~99% of random bytes.
+	if binary.BigEndian.Uint32(buf[0:4]) < frameHeaderSize {
+		return false
+	}
+	if buf[4] < minDataOffsetWords {
+		return false
+	}
+	ft := buf[5]
+	if ft != byte(frameTypeAMQP) && ft != byte(frameTypeSASL) {
+		return false
+	}
+
+	// If this frame carries a performative (size > bodyOffset) and that byte
+	// is in the captured buffer, it must begin with the described-type
+	// constructor (0x00). Heartbeat / idle frames have size == bodyOffset and
+	// no body at all (AMQP 1.0 2.4.5), so the byte at bodyOffset belongs to
+	// the next frame and must not be validated.
+	size := binary.BigEndian.Uint32(buf[0:4])
+	bodyOffset := int(buf[4]) * dataOffsetUnit
+	if int(size) > bodyOffset && bodyOffset < len(buf) {
+		if buf[bodyOffset] != describedTypeConstructor {
+			return false
+		}
+	}
+
+	return true
 }
 
 // parseProtocolHeader validates and parses an AMQP 1.0 protocol header.

--- a/pkg/internal/ebpf/amqpparser/protocol.go
+++ b/pkg/internal/ebpf/amqpparser/protocol.go
@@ -45,30 +45,45 @@ func startsWithMagic(r *largebuf.LargeBufferReader) bool {
 	return err == nil && bytes.Equal(data, amqpMagic)
 }
 
-// IsLikelyAMQP is an O(1) prefilter that reports whether buf could plausibly
-// start an AMQP 1.0 conversation. It accepts either the connection preamble
-// ("AMQP" magic) or a structurally valid frame header. The full Parse should
-// still be invoked to confirm — this only filters out obviously non-AMQP
-// payloads cheaply.
+// IsLikelyAMQP is an O(1) prefilter that reports whether the buffer behind r
+// could plausibly start an AMQP 1.0 conversation. It accepts either the
+// connection preamble ("AMQP" magic) or a structurally valid frame header.
+// The full Parse should still be invoked to confirm - this only filters out
+// obviously non-AMQP payloads cheaply. The reader's cursor is not advanced,
+// so the caller can pass the same reader straight to Parse on success.
 // https://docs.oasis-open.org/amqp/core/v1.0/csprd01/amqp-core-transport-v1.0-csprd01.html
-func IsLikelyAMQP(buf []byte) bool {
-	if len(buf) >= len(amqpMagic) && bytes.Equal(buf[:len(amqpMagic)], amqpMagic) {
-		return true
+func IsLikelyAMQP(r *largebuf.LargeBufferReader) bool {
+	if r == nil {
+		return false
+	}
+	remaining := r.Remaining()
+
+	if remaining >= len(amqpMagic) {
+		head, err := r.Peek(len(amqpMagic))
+		if err == nil && bytes.Equal(head, amqpMagic) {
+			return true
+		}
 	}
 
-	if len(buf) < frameHeaderSize {
+	if remaining < frameHeaderSize {
+		return false
+	}
+
+	hdr, err := r.Peek(frameHeaderSize)
+	if err != nil {
 		return false
 	}
 
 	// Frame header: size(u32 BE) | doff(u8) | type(u8) | channel(u16).
 	// type 0x00 (AMQP) or 0x01 (SASL) alone filters out ~99% of random bytes.
-	if binary.BigEndian.Uint32(buf[0:4]) < frameHeaderSize {
+	size := binary.BigEndian.Uint32(hdr[0:4])
+	if size < frameHeaderSize {
 		return false
 	}
-	if buf[4] < minDataOffsetWords {
+	if hdr[4] < minDataOffsetWords {
 		return false
 	}
-	ft := buf[5]
+	ft := hdr[5]
 	if ft != byte(frameTypeAMQP) && ft != byte(frameTypeSASL) {
 		return false
 	}
@@ -78,10 +93,13 @@ func IsLikelyAMQP(buf []byte) bool {
 	// constructor (0x00). Heartbeat / idle frames have size == bodyOffset and
 	// no body at all (AMQP 1.0 2.4.5), so the byte at bodyOffset belongs to
 	// the next frame and must not be validated.
-	size := binary.BigEndian.Uint32(buf[0:4])
-	bodyOffset := int(buf[4]) * dataOffsetUnit
-	if int(size) > bodyOffset && bodyOffset < len(buf) {
-		if buf[bodyOffset] != describedTypeConstructor {
+	bodyOffset := int(hdr[4]) * dataOffsetUnit
+	if int(size) > bodyOffset && bodyOffset < remaining {
+		body, err := r.Peek(bodyOffset + 1)
+		if err != nil {
+			return false
+		}
+		if body[bodyOffset] != describedTypeConstructor {
 			return false
 		}
 	}

--- a/pkg/internal/ebpf/amqpparser/protocol_test.go
+++ b/pkg/internal/ebpf/amqpparser/protocol_test.go
@@ -69,70 +69,78 @@ func makeFrameHeader(size uint32, doff, ft byte) []byte {
 }
 
 func TestIsLikelyAMQP(t *testing.T) {
+	likely := func(buf []byte) bool {
+		return IsLikelyAMQP(newLargeBufferReader(buf))
+	}
+
 	t.Run("accepts AMQP preamble", func(t *testing.T) {
-		assert.True(t, IsLikelyAMQP(makeProtocolHeader(protocolIDAMQP)))
-		assert.True(t, IsLikelyAMQP(makeProtocolHeader(protocolIDAMQPTLS)))
-		assert.True(t, IsLikelyAMQP(makeProtocolHeader(protocolIDSASL)))
+		assert.True(t, likely(makeProtocolHeader(protocolIDAMQP)))
+		assert.True(t, likely(makeProtocolHeader(protocolIDAMQPTLS)))
+		assert.True(t, likely(makeProtocolHeader(protocolIDSASL)))
 	})
 
 	t.Run("accepts preamble even when only the magic is present", func(t *testing.T) {
 		// IsLikelyAMQP is a coarse prefilter, so the bare 4-byte magic counts.
-		assert.True(t, IsLikelyAMQP([]byte("AMQP")))
+		assert.True(t, likely([]byte("AMQP")))
 	})
 
 	t.Run("accepts a valid AMQP frame with in-buffer performative", func(t *testing.T) {
-		assert.True(t, IsLikelyAMQP(makeFrame(frameTypeAMQP, descriptorOpen)))
+		assert.True(t, likely(makeFrame(frameTypeAMQP, descriptorOpen)))
 	})
 
 	t.Run("accepts a valid SASL frame with in-buffer performative", func(t *testing.T) {
-		assert.True(t, IsLikelyAMQP(makeFrame(frameTypeSASL, descriptorSASLMechanisms)))
+		assert.True(t, likely(makeFrame(frameTypeSASL, descriptorSASLMechanisms)))
 	})
 
 	t.Run("accepts a frame header whose body falls outside the captured buffer", func(t *testing.T) {
 		// Real eBPF captures often truncate the payload; a header-only buffer
 		// must still pass the prefilter.
 		hdr := makeFrameHeader(1024, minDataOffsetWords, byte(frameTypeAMQP))
-		assert.True(t, IsLikelyAMQP(hdr))
+		assert.True(t, likely(hdr))
 	})
 
 	t.Run("accepts a frame header with extended data-offset that overruns buffer", func(t *testing.T) {
 		// doff*4 > len(buf), so the constructor check is skipped.
 		hdr := makeFrameHeader(64, 4, byte(frameTypeAMQP))
-		assert.True(t, IsLikelyAMQP(hdr))
+		assert.True(t, likely(hdr))
+	})
+
+	t.Run("rejects a nil reader", func(t *testing.T) {
+		assert.False(t, IsLikelyAMQP(nil))
 	})
 
 	t.Run("rejects buffers shorter than the AMQP magic", func(t *testing.T) {
-		assert.False(t, IsLikelyAMQP(nil))
-		assert.False(t, IsLikelyAMQP([]byte{}))
-		assert.False(t, IsLikelyAMQP([]byte{'A'}))
-		assert.False(t, IsLikelyAMQP([]byte{'A', 'M', 'Q'}))
+		assert.False(t, likely(nil))
+		assert.False(t, likely([]byte{}))
+		assert.False(t, likely([]byte{'A'}))
+		assert.False(t, likely([]byte{'A', 'M', 'Q'}))
 	})
 
 	t.Run("rejects 4-7 byte buffers that are not AMQP magic", func(t *testing.T) {
 		// Too short for a frame header and not the preamble.
-		assert.False(t, IsLikelyAMQP([]byte{'H', 'T', 'T', 'P'}))
-		assert.False(t, IsLikelyAMQP([]byte{0, 0, 0, 8, 2, 0, 0}))
+		assert.False(t, likely([]byte{'H', 'T', 'T', 'P'}))
+		assert.False(t, likely([]byte{0, 0, 0, 8, 2, 0, 0}))
 	})
 
 	t.Run("rejects frame size smaller than the header", func(t *testing.T) {
 		// size < 8 is structurally impossible per spec.
 		hdr := makeFrameHeader(7, minDataOffsetWords, byte(frameTypeAMQP))
-		assert.False(t, IsLikelyAMQP(hdr))
+		assert.False(t, likely(hdr))
 	})
 
 	t.Run("rejects data-offset below the minimum", func(t *testing.T) {
 		// doff < 2 means the body would overlap the header.
 		hdr := makeFrameHeader(64, 1, byte(frameTypeAMQP))
-		assert.False(t, IsLikelyAMQP(hdr))
+		assert.False(t, likely(hdr))
 		hdr = makeFrameHeader(64, 0, byte(frameTypeAMQP))
-		assert.False(t, IsLikelyAMQP(hdr))
+		assert.False(t, likely(hdr))
 	})
 
 	t.Run("rejects unknown frame types", func(t *testing.T) {
 		// Only 0x00 (AMQP) and 0x01 (SASL) are valid.
 		for _, ft := range []byte{0x02, 0x10, 0x7f, 0xff} {
 			hdr := makeFrameHeader(64, minDataOffsetWords, ft)
-			assert.Falsef(t, IsLikelyAMQP(hdr), "frame type 0x%02X should be rejected", ft)
+			assert.Falsef(t, likely(hdr), "frame type 0x%02X should be rejected", ft)
 		}
 	})
 
@@ -140,23 +148,23 @@ func TestIsLikelyAMQP(t *testing.T) {
 		frame := makeFrame(frameTypeAMQP, descriptorOpen)
 		// Corrupt the body's first byte; everything else stays valid.
 		frame[frameHeaderSize] = 0x42
-		assert.False(t, IsLikelyAMQP(frame))
+		assert.False(t, likely(frame))
 	})
 
 	t.Run("rejects an all-zero buffer", func(t *testing.T) {
 		// size=0 fails the >= frameHeaderSize check.
-		assert.False(t, IsLikelyAMQP(make([]byte, 16)))
+		assert.False(t, likely(make([]byte, 16)))
 	})
 
 	t.Run("rejects HTTP request bytes", func(t *testing.T) {
 		// Realistic non-AMQP traffic: "GET / HTTP/1.1\r\n".
-		assert.False(t, IsLikelyAMQP([]byte("GET / HTTP/1.1\r\nHost: x\r\n\r\n")))
+		assert.False(t, likely([]byte("GET / HTTP/1.1\r\nHost: x\r\n\r\n")))
 	})
 
 	t.Run("accepts a bare heartbeat frame", func(t *testing.T) {
 		// AMQP 1.0 2.4.5: an empty frame (size == bodyOffset) is the idle
 		// heartbeat and must not be rejected.
-		assert.True(t, IsLikelyAMQP(makeHeartbeatFrame()))
+		assert.True(t, likely(makeHeartbeatFrame()))
 	})
 
 	t.Run("accepts a heartbeat frame even when the next frame's bytes follow", func(t *testing.T) {
@@ -164,6 +172,14 @@ func TestIsLikelyAMQP(t *testing.T) {
 		// any frame, which on a heartbeat is actually the next frame's first
 		// size byte. The check must skip bodies when size == bodyOffset.
 		buf := append(makeHeartbeatFrame(), makeFrame(frameTypeAMQP, descriptorOpen)...)
-		assert.True(t, IsLikelyAMQP(buf))
+		assert.True(t, likely(buf))
+	})
+
+	t.Run("does not advance the reader cursor on success", func(t *testing.T) {
+		// Callers rely on being able to pass the same reader to Parse after
+		// the prefilter passes; the cursor must still be at offset 0.
+		r := newLargeBufferReader(makeFrame(frameTypeAMQP, descriptorOpen))
+		assert.True(t, IsLikelyAMQP(r))
+		assert.Equal(t, 0, r.ReadOffset(), "IsLikelyAMQP must be non-destructive")
 	})
 }

--- a/pkg/internal/ebpf/amqpparser/protocol_test.go
+++ b/pkg/internal/ebpf/amqpparser/protocol_test.go
@@ -4,6 +4,7 @@
 package amqpparser
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,5 +55,115 @@ func TestParseProtocolHeader(t *testing.T) {
 		// 0-9-1 uses version bytes {0, 0, 9, 1}; spec requires {1, 0, 0} for AMQP 1.0.
 		_, err := parseProtocolHeader(newLargeBufferReader([]byte{'A', 'M', 'Q', 'P', 0, 0, 9, 1}))
 		require.Error(t, err)
+	})
+}
+
+// makeFrameHeader builds a bare 8-byte AMQP frame header with the given size,
+// data-offset (in 4-byte words), and frame type. Channel is zero.
+func makeFrameHeader(size uint32, doff, ft byte) []byte {
+	hdr := make([]byte, frameHeaderSize)
+	binary.BigEndian.PutUint32(hdr[0:4], size)
+	hdr[4] = doff
+	hdr[5] = ft
+	return hdr
+}
+
+func TestIsLikelyAMQP(t *testing.T) {
+	t.Run("accepts AMQP preamble", func(t *testing.T) {
+		assert.True(t, IsLikelyAMQP(makeProtocolHeader(protocolIDAMQP)))
+		assert.True(t, IsLikelyAMQP(makeProtocolHeader(protocolIDAMQPTLS)))
+		assert.True(t, IsLikelyAMQP(makeProtocolHeader(protocolIDSASL)))
+	})
+
+	t.Run("accepts preamble even when only the magic is present", func(t *testing.T) {
+		// IsLikelyAMQP is a coarse prefilter, so the bare 4-byte magic counts.
+		assert.True(t, IsLikelyAMQP([]byte("AMQP")))
+	})
+
+	t.Run("accepts a valid AMQP frame with in-buffer performative", func(t *testing.T) {
+		assert.True(t, IsLikelyAMQP(makeFrame(frameTypeAMQP, descriptorOpen)))
+	})
+
+	t.Run("accepts a valid SASL frame with in-buffer performative", func(t *testing.T) {
+		assert.True(t, IsLikelyAMQP(makeFrame(frameTypeSASL, descriptorSASLMechanisms)))
+	})
+
+	t.Run("accepts a frame header whose body falls outside the captured buffer", func(t *testing.T) {
+		// Real eBPF captures often truncate the payload; a header-only buffer
+		// must still pass the prefilter.
+		hdr := makeFrameHeader(1024, minDataOffsetWords, byte(frameTypeAMQP))
+		assert.True(t, IsLikelyAMQP(hdr))
+	})
+
+	t.Run("accepts a frame header with extended data-offset that overruns buffer", func(t *testing.T) {
+		// doff*4 > len(buf), so the constructor check is skipped.
+		hdr := makeFrameHeader(64, 4, byte(frameTypeAMQP))
+		assert.True(t, IsLikelyAMQP(hdr))
+	})
+
+	t.Run("rejects buffers shorter than the AMQP magic", func(t *testing.T) {
+		assert.False(t, IsLikelyAMQP(nil))
+		assert.False(t, IsLikelyAMQP([]byte{}))
+		assert.False(t, IsLikelyAMQP([]byte{'A'}))
+		assert.False(t, IsLikelyAMQP([]byte{'A', 'M', 'Q'}))
+	})
+
+	t.Run("rejects 4-7 byte buffers that are not AMQP magic", func(t *testing.T) {
+		// Too short for a frame header and not the preamble.
+		assert.False(t, IsLikelyAMQP([]byte{'H', 'T', 'T', 'P'}))
+		assert.False(t, IsLikelyAMQP([]byte{0, 0, 0, 8, 2, 0, 0}))
+	})
+
+	t.Run("rejects frame size smaller than the header", func(t *testing.T) {
+		// size < 8 is structurally impossible per spec.
+		hdr := makeFrameHeader(7, minDataOffsetWords, byte(frameTypeAMQP))
+		assert.False(t, IsLikelyAMQP(hdr))
+	})
+
+	t.Run("rejects data-offset below the minimum", func(t *testing.T) {
+		// doff < 2 means the body would overlap the header.
+		hdr := makeFrameHeader(64, 1, byte(frameTypeAMQP))
+		assert.False(t, IsLikelyAMQP(hdr))
+		hdr = makeFrameHeader(64, 0, byte(frameTypeAMQP))
+		assert.False(t, IsLikelyAMQP(hdr))
+	})
+
+	t.Run("rejects unknown frame types", func(t *testing.T) {
+		// Only 0x00 (AMQP) and 0x01 (SASL) are valid.
+		for _, ft := range []byte{0x02, 0x10, 0x7f, 0xff} {
+			hdr := makeFrameHeader(64, minDataOffsetWords, ft)
+			assert.Falsef(t, IsLikelyAMQP(hdr), "frame type 0x%02X should be rejected", ft)
+		}
+	})
+
+	t.Run("rejects in-buffer performative not starting with the described-type constructor", func(t *testing.T) {
+		frame := makeFrame(frameTypeAMQP, descriptorOpen)
+		// Corrupt the body's first byte; everything else stays valid.
+		frame[frameHeaderSize] = 0x42
+		assert.False(t, IsLikelyAMQP(frame))
+	})
+
+	t.Run("rejects an all-zero buffer", func(t *testing.T) {
+		// size=0 fails the >= frameHeaderSize check.
+		assert.False(t, IsLikelyAMQP(make([]byte, 16)))
+	})
+
+	t.Run("rejects HTTP request bytes", func(t *testing.T) {
+		// Realistic non-AMQP traffic: "GET / HTTP/1.1\r\n".
+		assert.False(t, IsLikelyAMQP([]byte("GET / HTTP/1.1\r\nHost: x\r\n\r\n")))
+	})
+
+	t.Run("accepts a bare heartbeat frame", func(t *testing.T) {
+		// AMQP 1.0 2.4.5: an empty frame (size == bodyOffset) is the idle
+		// heartbeat and must not be rejected.
+		assert.True(t, IsLikelyAMQP(makeHeartbeatFrame()))
+	})
+
+	t.Run("accepts a heartbeat frame even when the next frame's bytes follow", func(t *testing.T) {
+		// Regression: the prefilter previously inspected buf[bodyOffset] for
+		// any frame, which on a heartbeat is actually the next frame's first
+		// size byte. The check must skip bodies when size == bodyOffset.
+		buf := append(makeHeartbeatFrame(), makeFrame(frameTypeAMQP, descriptorOpen)...)
+		assert.True(t, IsLikelyAMQP(buf))
 	})
 }

--- a/pkg/internal/ebpf/couchbasekv/header.go
+++ b/pkg/internal/ebpf/couchbasekv/header.go
@@ -5,8 +5,16 @@ package couchbasekv // import "go.opentelemetry.io/obi/pkg/internal/ebpf/couchba
 
 import (
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"iter"
+)
+
+var (
+	errPacketTooShort   = errors.New("packet too short")
+	errInvalidMagic     = errors.New("invalid magic byte")
+	errInvalidKeyLength = errors.New("invalid key length")
+	errInvalidDataType  = errors.New("invalid data type")
+	errInvalidBodyType  = errors.New("invalid body length")
 )
 
 // Header is a view into a 24-byte memcached binary protocol header.
@@ -84,12 +92,12 @@ func (h Header) IsResponse() bool { return h.Magic().IsResponse() }
 // underlying memory of pkt.
 func ParseHeader(pkt []byte) (Header, error) {
 	if len(pkt) < HeaderLen {
-		return nil, fmt.Errorf("packet too short for header: got %d bytes, need %d", len(pkt), HeaderLen)
+		return nil, errPacketTooShort
 	}
 
 	magic := Magic(pkt[0])
 	if !magic.IsValid() {
-		return nil, fmt.Errorf("invalid magic byte: 0x%02x", pkt[0])
+		return nil, errInvalidMagic
 	}
 
 	h := Header(pkt[:HeaderLen])
@@ -240,17 +248,16 @@ func (p Packet) valueEnd() int {
 // validateHeader checks for basic validity of the parsed header.
 func validateHeader(h Header) error {
 	if int(h.KeyLen()) > MaxKeyLen {
-		return fmt.Errorf("invalid key length: %d > max(%d)", h.KeyLen(), MaxKeyLen)
+		return errInvalidKeyLength
 	}
 
 	if !h.DataType().IsValid() {
-		return fmt.Errorf("invalid data type: 0x%02x has reserved bits set", byte(h.DataType()))
+		return errInvalidDataType
 	}
 
 	minBodyLen := int(h.FramingExtrasLen()) + int(h.ExtrasLen()) + int(h.KeyLen())
 	if int(h.BodyLen()) < minBodyLen {
-		return fmt.Errorf("invalid body length: %d < framingExtras(%d) + extras(%d) + key(%d)",
-			h.BodyLen(), h.FramingExtrasLen(), h.ExtrasLen(), h.KeyLen())
+		return errInvalidBodyType
 	}
 
 	return nil

--- a/pkg/internal/ebpf/kafkaparser/common.go
+++ b/pkg/internal/ebpf/kafkaparser/common.go
@@ -30,6 +30,35 @@ const (
 	KafkaMaxPayloadLen = 20 * 1024 * 1024 // 20 MB max, 1MB is default for most Kafka installations
 )
 
+var (
+	errKafkaPacketTooShortForRequestHeader  = errors.New("packet too short for Kafka request header")
+	errKafkaInvalidClientIDSize             = errors.New("invalid client ID size")
+	errKafkaPacketTooShortForClientID       = errors.New("packet too short for client ID")
+	errKafkaPacketTooShortForResponseHeader = errors.New("packet too short for Kafka response header")
+	errKafkaTaggedFieldValueExceedsBuffer   = errors.New("tagged field value exceeds buffer")
+	errKafkaVarintIncomplete                = errors.New("data ended before varint was complete")
+	errKafkaIllegalVarint                   = errors.New("illegal varint")
+	errKafkaReqMessageSizeTooSmall          = errors.New("invalid Kafka request header: message size too small")
+	errKafkaReqAPIVersionNegative           = errors.New("invalid Kafka request header: API version is negative")
+	errKafkaReqMessageSizeTooLarge          = errors.New("invalid Kafka request header: message size exceeds maximum payload length")
+	errKafkaReqUnsupportedFetchVersion      = errors.New("invalid Kafka request header: unsupported API key version for Fetch")
+	errKafkaReqUnsupportedProduceVersion    = errors.New("invalid Kafka request header: unsupported API key version for Produce")
+	errKafkaReqUnsupportedMetadataVersion   = errors.New("invalid Kafka request header: unsupported API key version for Metadata")
+	errKafkaReqUnsupportedAPIKey            = errors.New("invalid Kafka request header: unsupported API key")
+	errKafkaReqCorrelationIDNegative        = errors.New("invalid Kafka request header: correlation ID is negative")
+	errKafkaRespSizeTooSmall                = errors.New("invalid Kafka response header: size too small")
+	errKafkaRespMessageSizeTooLarge         = errors.New("invalid Kafka response header: message size exceeds maximum payload length")
+	errKafkaRespCorrelationIDNegative       = errors.New("invalid Kafka response header: correlation ID is negative")
+	errKafkaRespCorrelationIDMismatch       = errors.New("invalid Kafka response header: correlation ID does not match request header")
+	errKafkaPacketTooShortForTopicUUID      = errors.New("packet too short for topic UUID")
+	errKafkaStringSizeExceedsPacket         = errors.New("string size exceeds packet size")
+	errKafkaInvalidCharactersInString       = errors.New("invalid characters in string")
+	errKafkaPacketTooShortForStringLength   = errors.New("packet too short for string length")
+	errKafkaInvalidStringSize               = errors.New("invalid string size")
+	errKafkaDataTooShortForInt32            = errors.New("data too short for int32")
+	errKafkaDataTooShortForInt64            = errors.New("data too short for int64")
+)
+
 type KafkaAPIKey int8
 
 const (
@@ -93,7 +122,7 @@ func (h KafkaRequestHeader) NewBodyReader() (largebuf.LargeBufferReader, error) 
 
 func NewKafkaRequestHeader(lb *largebuf.LargeBuffer) (KafkaRequestHeader, error) {
 	if lb.Len() < MinKafkaRequestLen {
-		return KafkaRequestHeader{}, errors.New("packet too short for Kafka request header")
+		return KafkaRequestHeader{}, errKafkaPacketTooShortForRequestHeader
 	}
 
 	h := KafkaRequestHeader{lb: lb}
@@ -109,12 +138,12 @@ func NewKafkaRequestHeader(lb *largebuf.LargeBuffer) (KafkaRequestHeader, error)
 	}
 
 	if clientIDLen < 0 {
-		return KafkaRequestHeader{}, errors.New("invalid client ID size")
+		return KafkaRequestHeader{}, errKafkaInvalidClientIDSize
 	}
 
 	clientIDEnd := 14 + int(clientIDLen)
 	if lb.Len() < clientIDEnd {
-		return KafkaRequestHeader{}, errors.New("packet too short for client ID")
+		return KafkaRequestHeader{}, errKafkaPacketTooShortForClientID
 	}
 
 	h.clientIDLen = clientIDLen
@@ -137,7 +166,7 @@ type KafkaResponseHeader struct {
 
 func ParseKafkaResponseHeader(r *largebuf.LargeBufferReader, requestHeader KafkaRequestHeader) (*KafkaResponseHeader, error) {
 	if r.Remaining() < MinKafkaResponseLen {
-		return nil, errors.New("packet too short for Kafka response header")
+		return nil, errKafkaPacketTooShortForResponseHeader
 	}
 	msgSizeBytes, err := r.ReadN(Int32Len)
 	if err != nil {
@@ -203,7 +232,7 @@ func skipTaggedFieldsAt(lb *largebuf.LargeBuffer, off int) (int, error) {
 			return 0, err
 		}
 		if tagLen < 0 || tagLen > lb.Len()-off-n {
-			return 0, errors.New("tagged field value exceeds buffer")
+			return 0, errKafkaTaggedFieldValueExceedsBuffer
 		}
 		off += n + tagLen
 	}
@@ -217,7 +246,7 @@ func readUVarintAt(lb *largebuf.LargeBuffer, off int) (int, int, error) {
 	for {
 		b, err := lb.U8At(off + n)
 		if err != nil {
-			return 0, 0, errors.New("data ended before varint was complete")
+			return 0, 0, errKafkaVarintIncomplete
 		}
 		n++
 		if b&0x80 == 0 {
@@ -227,60 +256,60 @@ func readUVarintAt(lb *largebuf.LargeBuffer, off int) (int, int, error) {
 		value |= int(b&0x7F) << shift
 		shift += 7
 		if shift > 28 {
-			return 0, 0, errors.New("illegal varint")
+			return 0, 0, errKafkaIllegalVarint
 		}
 	}
 }
 
 func (h KafkaRequestHeader) validate() error {
 	if h.MessageSize() < int32(MinKafkaRequestLen) {
-		return errors.New("invalid Kafka request header: message size too small")
+		return errKafkaReqMessageSizeTooSmall
 	}
 
 	if h.APIVersion() < 0 {
-		return errors.New("invalid Kafka request header: API version is negative")
+		return errKafkaReqAPIVersionNegative
 	}
 
 	if h.MessageSize() > KafkaMaxPayloadLen {
-		return errors.New("invalid Kafka request header: message size exceeds maximum payload length")
+		return errKafkaReqMessageSizeTooLarge
 	}
 
 	switch h.APIKey() {
 	case APIKeyFetch:
 		if h.APIVersion() > 18 { // latest: Fetch Request (Version: 17)
-			return errors.New("invalid Kafka request header: unsupported API key version for Fetch")
+			return errKafkaReqUnsupportedFetchVersion
 		}
 	case APIKeyProduce:
 		if h.APIVersion() > 13 { // latest: Produce Request (Version: 13)
-			return errors.New("invalid Kafka request header: unsupported API key version for Produce")
+			return errKafkaReqUnsupportedProduceVersion
 		}
 	case APIKeyMetadata:
 		if h.APIVersion() < 10 || h.APIVersion() > 13 { // latest: Metadata Request (Version: 13), only versions 10-13 contain topic_id which we are interested in
-			return errors.New("invalid Kafka request header: unsupported API key version for Metadata")
+			return errKafkaReqUnsupportedMetadataVersion
 		}
 	default:
-		return errors.New("invalid Kafka request header: unsupported API key")
+		return errKafkaReqUnsupportedAPIKey
 	}
 	if h.CorrelationID() < 0 {
-		return errors.New("invalid Kafka request header: correlation ID is negative")
+		return errKafkaReqCorrelationIDNegative
 	}
 	return nil
 }
 
 func validateKafkaResponseHeader(header *KafkaResponseHeader, requestHeader KafkaRequestHeader) error {
 	if header.MessageSize < MinKafkaResponseLen {
-		return errors.New("invalid Kafka response header: size too small")
+		return errKafkaRespSizeTooSmall
 	}
 
 	if header.MessageSize > KafkaMaxPayloadLen {
-		return errors.New("invalid Kafka response header: message size exceeds maximum payload length")
+		return errKafkaRespMessageSizeTooLarge
 	}
 
 	if header.CorrelationID < 0 {
-		return errors.New("invalid Kafka response header: correlation ID is negative")
+		return errKafkaRespCorrelationIDNegative
 	}
 	if header.CorrelationID != requestHeader.CorrelationID() {
-		return errors.New("invalid Kafka response header: correlation ID does not match request header")
+		return errKafkaRespCorrelationIDMismatch
 	}
 	return nil
 }
@@ -321,7 +350,7 @@ func readArrayLength(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (
 func readUUID(r *largebuf.LargeBufferReader) (*UUID, error) {
 	b, err := r.ReadN(UUIDLen)
 	if err != nil {
-		return nil, errors.New("packet too short for topic UUID")
+		return nil, errKafkaPacketTooShortForTopicUUID
 	}
 	var uuid UUID
 	copy(uuid[:], b)
@@ -337,14 +366,14 @@ func readString(r *largebuf.LargeBufferReader, header KafkaRequestHeader, nullab
 		return "", nil // return empty string for null
 	}
 	if r.Remaining() < size {
-		return "", errors.New("string size exceeds packet size")
+		return "", errKafkaStringSizeExceedsPacket
 	}
 	b, err := r.ReadN(size)
 	if err != nil {
-		return "", errors.New("string size exceeds packet size")
+		return "", errKafkaStringSizeExceedsPacket
 	}
 	if !validateKafkaString(b, size) {
-		return "", errors.New("invalid characters in string")
+		return "", errKafkaInvalidCharactersInString
 	}
 	return string(b), nil
 }
@@ -364,18 +393,18 @@ func readStringLength(r *largebuf.LargeBufferReader, header KafkaRequestHeader, 
 	if !isFlexible(header) {
 		// length is stored as a fixed size int16
 		if r.Remaining() < Int16Len {
-			return 0, errors.New("packet too short for string length")
+			return 0, errKafkaPacketTooShortForStringLength
 		}
 		b, err := r.ReadN(Int16Len)
 		if err != nil {
-			return 0, errors.New("packet too short for string length")
+			return 0, errKafkaPacketTooShortForStringLength
 		}
 		size := int16(binary.BigEndian.Uint16(b))
 		if nullable && size == -1 {
 			return 0, nil // return 0 for null
 		}
 		if size < 1 {
-			return 0, errors.New("invalid string size")
+			return 0, errKafkaInvalidStringSize
 		}
 		return int(size), nil
 	}
@@ -389,11 +418,11 @@ func readStringLength(r *largebuf.LargeBufferReader, header KafkaRequestHeader, 
 		return 0, nil // return 0 for null
 	}
 	if size <= 0 {
-		return 0, errors.New("invalid string size")
+		return 0, errKafkaInvalidStringSize
 	}
 	size-- // size is stored as a varint, so we subtract 1
 	if size < 0 {
-		return 0, errors.New("invalid string size")
+		return 0, errKafkaInvalidStringSize
 	}
 	return size, nil
 }
@@ -403,7 +432,7 @@ func readUnsignedVarint(r *largebuf.LargeBufferReader) (int, error) {
 	i := 0
 	for {
 		if r.Remaining() == 0 {
-			return 0, errors.New("data ended before varint was complete")
+			return 0, errKafkaVarintIncomplete
 		}
 		b, err := r.ReadN(1)
 		if err != nil {
@@ -416,7 +445,7 @@ func readUnsignedVarint(r *largebuf.LargeBufferReader) (int, error) {
 		value |= int(b[0]&0x7F) << i
 		i += 7
 		if i > 28 {
-			return 0, errors.New("illegal varint")
+			return 0, errKafkaIllegalVarint
 		}
 	}
 }
@@ -424,7 +453,7 @@ func readUnsignedVarint(r *largebuf.LargeBufferReader) (int, error) {
 func readInt32(r *largebuf.LargeBufferReader) (int, error) {
 	b, err := r.ReadN(Int32Len)
 	if err != nil {
-		return 0, errors.New("data too short for int32")
+		return 0, errKafkaDataTooShortForInt32
 	}
 	return int(binary.BigEndian.Uint32(b)), nil
 }
@@ -432,7 +461,7 @@ func readInt32(r *largebuf.LargeBufferReader) (int, error) {
 func readInt64(r *largebuf.LargeBufferReader) (int64, error) {
 	b, err := r.ReadN(Int64Len)
 	if err != nil {
-		return 0, errors.New("data too short for int64")
+		return 0, errKafkaDataTooShortForInt64
 	}
 	return int64(binary.BigEndian.Uint64(b)), nil
 }

--- a/pkg/internal/ebpf/kafkaparser/fetch.go
+++ b/pkg/internal/ebpf/kafkaparser/fetch.go
@@ -23,19 +23,24 @@ type FetchRequest struct {
 	Topics []*FetchTopic
 }
 
+var (
+	errOffsetExceedsPacketSize = errors.New("offset exceeds packet size")
+	errNoTopics                = errors.New("no Topics found in fetch request")
+)
+
 func ParseFetchRequest(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (*FetchRequest, error) {
 	if err := fetchRequestSkipUntilTopics(r, header); err != nil {
 		return nil, err
 	}
 	if r.Remaining() == 0 {
-		return nil, errors.New("offset exceeds packet size")
+		return nil, errOffsetExceedsPacketSize
 	}
 	topics, err := parseFetchTopics(r, header)
 	if err != nil {
 		return nil, err
 	}
 	if len(topics) == 0 {
-		return nil, errors.New("no Topics found in fetch request")
+		return nil, errNoTopics
 	}
 	return &FetchRequest{
 		Topics: topics,

--- a/pkg/internal/ebpf/kafkaparser/metadata.go
+++ b/pkg/internal/ebpf/kafkaparser/metadata.go
@@ -27,6 +27,8 @@ type MetadataResponse struct {
 	Topics []*MetadataTopic
 }
 
+var errNoTopicsInMetadata = errors.New("no Topics found in metadata response")
+
 func ParseMetadataResponse(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (*MetadataResponse, error) {
 	if err := metadataResponseSkipUntilTopics(r, header); err != nil {
 		return nil, err
@@ -36,7 +38,7 @@ func ParseMetadataResponse(r *largebuf.LargeBufferReader, header KafkaRequestHea
 		return nil, err
 	}
 	if len(topics) == 0 {
-		return nil, errors.New("no Topics found in metadata response")
+		return nil, errNoTopicsInMetadata
 	}
 	return &MetadataResponse{
 		Topics: topics,

--- a/pkg/internal/ebpf/kafkaparser/produce.go
+++ b/pkg/internal/ebpf/kafkaparser/produce.go
@@ -19,6 +19,8 @@ type ProduceRequest struct {
 	Topics []*ProduceTopic
 }
 
+var errNoTopicsInProduce = errors.New("no Topics found in produce request")
+
 func ParseProduceRequest(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (*ProduceRequest, error) {
 	if err := produceRequestSkipUntilTopics(r, header); err != nil {
 		return nil, err
@@ -28,7 +30,7 @@ func ParseProduceRequest(r *largebuf.LargeBufferReader, header KafkaRequestHeade
 		return nil, err
 	}
 	if len(topics) == 0 {
-		return nil, errors.New("no Topics found in produce request")
+		return nil, errNoTopicsInProduce
 	}
 	return &ProduceRequest{
 		Topics: topics,

--- a/pkg/internal/ebpf/mqttparser/header.go
+++ b/pkg/internal/ebpf/mqttparser/header.go
@@ -77,12 +77,12 @@ type FixedHeader struct {
 // is obviously not MQTT.
 // https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
 // https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html
-func IsLikelyMQTT(pkt []byte) bool {
-	if len(pkt) < MinPacketLen {
+func IsLikelyMQTT(first byte, pktLen int) bool {
+	if pktLen < MinPacketLen {
 		return false
 	}
-	pt := PacketType((pkt[0] >> 4) & 0x0F)
-	flags := pkt[0] & 0x0F
+	pt := PacketType((first >> 4) & 0x0F)
+	flags := first & 0x0F
 	switch pt {
 	case PacketTypePUBLISH:
 		// QoS occupies bits 2-1 of the flag nibble; QoS=3 is invalid.

--- a/pkg/internal/ebpf/mqttparser/header.go
+++ b/pkg/internal/ebpf/mqttparser/header.go
@@ -11,6 +11,12 @@ const (
 	MinPacketLen = 2 // fixed header (1 byte) + remaining length (1 byte)
 )
 
+var (
+	errIncompletePacket  = errors.New("incomplete packet")
+	errPacketTooShort    = errors.New("packet too short for MQTT fixed header")
+	errInvalidPacketType = errors.New("invalid MQTT packet type")
+)
+
 type (
 	// PacketType is the type of MQTT Control Packet.
 	PacketType uint8
@@ -64,10 +70,46 @@ type FixedHeader struct {
 	Length int
 }
 
+// IsLikelyMQTT is an O(1) prefilter that validates the MQTT fixed-header byte 0
+// against the strict per-type flag constraints from the MQTT 3.1.1 / 5.0 spec.
+// Roughly 90% of random byte values fail this check, allowing callers to avoid
+// the more expensive remaining-length + variable-header parsing when a payload
+// is obviously not MQTT.
+// https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html
+// https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html
+func IsLikelyMQTT(pkt []byte) bool {
+	if len(pkt) < MinPacketLen {
+		return false
+	}
+	pt := PacketType((pkt[0] >> 4) & 0x0F)
+	flags := pkt[0] & 0x0F
+	switch pt {
+	case PacketTypePUBLISH:
+		// QoS occupies bits 2-1 of the flag nibble; QoS=3 is invalid.
+		return (flags>>1)&0x03 != 3
+	case PacketTypePUBREL, PacketTypeSUBSCRIBE, PacketTypeUNSUBSCRIBE:
+		return flags == 0x02
+	case PacketTypeCONNECT,
+		PacketTypeCONNACK,
+		PacketTypePUBACK,
+		PacketTypePUBREC,
+		PacketTypePUBCOMP,
+		PacketTypeSUBACK,
+		PacketTypeUNSUBACK,
+		PacketTypePINGREQ,
+		PacketTypePINGRESP,
+		PacketTypeDISCONNECT,
+		PacketTypeAUTH:
+		return flags == 0x00
+	default:
+		return false
+	}
+}
+
 // ParseMQTTPackets parses multiple MQTT packets from a single byte slice, as
 // there may be cases where multiple MQTT packets are present in one TCP segment.
-func ParseMQTTPackets(segment []byte) ([]MQTTControlPacket, error) {
-	var packets []MQTTControlPacket
+func ParseMQTTPackets(segment []byte) ([]*MQTTControlPacket, error) {
+	var packets []*MQTTControlPacket
 	offset := 0
 
 	for offset < len(segment) {
@@ -81,7 +123,7 @@ func ParseMQTTPackets(segment []byte) ([]MQTTControlPacket, error) {
 		}
 
 		if offset+packet.Length() > len(segment) {
-			return packets, errors.New("incomplete packet")
+			return packets, errIncompletePacket
 		}
 
 		packets = append(packets, packet)
@@ -92,9 +134,9 @@ func ParseMQTTPackets(segment []byte) ([]MQTTControlPacket, error) {
 }
 
 // NewMQTTControlPacket parses the MQTT fixed header from a packet.
-func NewMQTTControlPacket(pkt []byte) (MQTTControlPacket, error) {
+func NewMQTTControlPacket(pkt []byte) (*MQTTControlPacket, error) {
 	if len(pkt) < MinPacketLen {
-		return MQTTControlPacket{}, errors.New("packet too short for MQTT fixed header")
+		return nil, errPacketTooShort
 	}
 
 	// Parse first byte: packet type (bits 7-4) and flags (bits 3-0)
@@ -104,17 +146,17 @@ func NewMQTTControlPacket(pkt []byte) (MQTTControlPacket, error) {
 
 	// Validate packet type (0 is reserved, valid range is 1-15)
 	if packetType < PacketTypeCONNECT || packetType > PacketTypeAUTH {
-		return MQTTControlPacket{}, errors.New("invalid MQTT packet type")
+		return nil, errInvalidPacketType
 	}
 
 	// Parse remaining length (variable-length encoding)
 	r := NewPacketReader(pkt, 1)
 	rl, err := r.ReadVariableByteInteger()
 	if err != nil {
-		return MQTTControlPacket{}, err
+		return nil, err
 	}
 
-	return MQTTControlPacket{
+	return &MQTTControlPacket{
 		FixedHeader: FixedHeader{
 			PacketType:      packetType,
 			Flags:           flags,

--- a/pkg/internal/ebpf/mqttparser/packet_connect.go
+++ b/pkg/internal/ebpf/mqttparser/packet_connect.go
@@ -32,13 +32,19 @@ type ConnectPacket struct {
 	ClientID string
 }
 
+var (
+	errInsufficientConnectData = errors.New("insufficient data for CONNECT packet")
+	errUnrecognizedMQTTProtocolName  = errors.New("unrecognized mqtt protocol name")
+	errUnrecognizedMQTTProtocolLevel = errors.New("unrecognized mqtt protocol level")
+)
+
 // ParseConnectPacket parses an MQTT CONNECT packet.
 // offset should point to the start of the variable header (after fixed header).
 func ParseConnectPacket(pkt []byte, offset Offset) (*ConnectPacket, Offset, error) {
 	var connect ConnectPacket
 
 	if offset >= len(pkt) {
-		return &connect, offset, errors.New("insufficient data for CONNECT packet")
+		return &connect, offset, errInsufficientConnectData
 	}
 
 	r := NewConnectPacketReader(pkt, offset)
@@ -183,7 +189,7 @@ func NewProtocolName(name string) (ProtocolName, error) {
 	case string(ProtocolNameMQTT), string(ProtocolNameMQIsdp):
 		return ProtocolName(name), nil
 	default:
-		return "", fmt.Errorf("%q is not a recognized mqtt protocol name", name)
+		return "", errUnrecognizedMQTTProtocolName
 	}
 }
 
@@ -208,7 +214,7 @@ func NewProtocolLevel(level uint8) (ProtocolLevel, error) {
 	case 5:
 		return ProtocolLevelMQTT50, nil
 	}
-	return 0, fmt.Errorf("%d is not a recognized mqtt protocol level", level)
+	return 0, errUnrecognizedMQTTProtocolLevel
 }
 
 func (pl ProtocolLevel) String() string {

--- a/pkg/internal/ebpf/mqttparser/packet_connect.go
+++ b/pkg/internal/ebpf/mqttparser/packet_connect.go
@@ -33,7 +33,7 @@ type ConnectPacket struct {
 }
 
 var (
-	errInsufficientConnectData = errors.New("insufficient data for CONNECT packet")
+	errInsufficientConnectData       = errors.New("insufficient data for CONNECT packet")
 	errUnrecognizedMQTTProtocolName  = errors.New("unrecognized mqtt protocol name")
 	errUnrecognizedMQTTProtocolLevel = errors.New("unrecognized mqtt protocol level")
 )

--- a/pkg/internal/ebpf/mqttparser/packet_publish.go
+++ b/pkg/internal/ebpf/mqttparser/packet_publish.go
@@ -27,6 +27,8 @@ type PublishPacket struct {
 	PacketID uint16
 }
 
+var errInsufficientPublishData = errors.New("insufficient data for PUBLISH packet")
+
 // ParsePublishPacket parses an MQTT PUBLISH packet.
 // offset should point to the start of the variable header (after fixed header).
 // flags should contain the flags byte from the fixed header.
@@ -34,7 +36,7 @@ func ParsePublishPacket(pkt []byte, offset Offset, flags uint8) (*PublishPacket,
 	var publish PublishPacket
 
 	if offset >= len(pkt) {
-		return &publish, offset, errors.New("insufficient data for PUBLISH packet")
+		return &publish, offset, errInsufficientPublishData
 	}
 
 	r := NewPublishPacketReader(pkt, offset)

--- a/pkg/internal/ebpf/mqttparser/packet_subscribe.go
+++ b/pkg/internal/ebpf/mqttparser/packet_subscribe.go
@@ -8,10 +8,10 @@ import (
 )
 
 var (
-	errSubscribeInsufficientData    = errors.New("insufficient data for SUBSCRIBE packet")
-	errSubscribeReadTopicFilter     = errors.New("failed to read topic filter")
-	errSubscribeReadOptions         = errors.New("failed to read subscription options")
-	errSubscribeRequiresAtLeastOne  = errors.New("SUBSCRIBE packet must contain at least one subscription")
+	errSubscribeInsufficientData   = errors.New("insufficient data for SUBSCRIBE packet")
+	errSubscribeReadTopicFilter    = errors.New("failed to read topic filter")
+	errSubscribeReadOptions        = errors.New("failed to read subscription options")
+	errSubscribeRequiresAtLeastOne = errors.New("SUBSCRIBE packet must contain at least one subscription")
 )
 
 // Subscription represents a single topic subscription with its QoS level.

--- a/pkg/internal/ebpf/mqttparser/packet_subscribe.go
+++ b/pkg/internal/ebpf/mqttparser/packet_subscribe.go
@@ -7,6 +7,13 @@ import (
 	"errors"
 )
 
+var (
+	errSubscribeInsufficientData    = errors.New("insufficient data for SUBSCRIBE packet")
+	errSubscribeReadTopicFilter     = errors.New("failed to read topic filter")
+	errSubscribeReadOptions         = errors.New("failed to read subscription options")
+	errSubscribeRequiresAtLeastOne  = errors.New("SUBSCRIBE packet must contain at least one subscription")
+)
+
 // Subscription represents a single topic subscription with its QoS level.
 type Subscription struct {
 	// TopicFilter is the topic filter string for the subscription.
@@ -41,7 +48,7 @@ func ParseSubscribePacket(pkt []byte, offset Offset, remainingLength int) (*Subs
 	var subscribe SubscribePacket
 
 	if offset+remainingLength > len(pkt) {
-		return &subscribe, offset, errors.New("insufficient data for SUBSCRIBE packet")
+		return &subscribe, offset, errSubscribeInsufficientData
 	}
 
 	// Create a bounded slice to prevent reading beyond this packet
@@ -136,7 +143,7 @@ func (r *SubscribePacketReader) readSubscriptions(targetVersion ProtocolLevel) (
 			if targetVersion < ProtocolLevelMQTT50 {
 				return nil, ErrProtocolMismatch
 			}
-			return nil, errors.New("failed to read topic filter")
+			return nil, errSubscribeReadTopicFilter
 		}
 
 		options, err := r.ReadUint8()
@@ -147,7 +154,7 @@ func (r *SubscribePacketReader) readSubscriptions(targetVersion ProtocolLevel) (
 			if targetVersion < ProtocolLevelMQTT50 {
 				return nil, ErrProtocolMismatch
 			}
-			return nil, errors.New("failed to read subscription options")
+			return nil, errSubscribeReadOptions
 		}
 
 		// In MQTT 3.1.1, options byte contains only QoS (0, 1, or 2).
@@ -166,7 +173,7 @@ func (r *SubscribePacketReader) readSubscriptions(targetVersion ProtocolLevel) (
 		if targetVersion < ProtocolLevelMQTT50 {
 			return nil, ErrProtocolMismatch
 		}
-		return nil, errors.New("SUBSCRIBE packet must contain at least one subscription")
+		return nil, errSubscribeRequiresAtLeastOne
 	}
 
 	return subscriptions, nil

--- a/pkg/internal/ebpf/mqttparser/reader.go
+++ b/pkg/internal/ebpf/mqttparser/reader.go
@@ -5,7 +5,13 @@ package mqttparser // import "go.opentelemetry.io/obi/pkg/internal/ebpf/mqttpars
 
 import (
 	"errors"
-	"fmt"
+)
+
+var (
+	errNotEnoughData          = errors.New("not enough data for variable byte integer")
+	errBadIntEncoding         = errors.New("variable byte integer encoding exceeds 4 bytes or incomplete")
+	errNotEnoughStringLen     = errors.New("not enough data for string length")
+	errNotEnoughStringContent = errors.New("not enough data for string content")
 )
 
 // PacketReader provides primitive binary reading operations for MQTT packets.
@@ -39,7 +45,7 @@ func (r *PacketReader) Remaining() int {
 // Skip advances the offset by n bytes.
 func (r *PacketReader) Skip(n int) error {
 	if r.offset+n > len(r.pkt) {
-		return fmt.Errorf("not enough data to skip by %d bytes, remaining: %d", n, r.Remaining())
+		return errNotEnoughData
 	}
 	r.offset += n
 	return nil
@@ -48,7 +54,7 @@ func (r *PacketReader) Skip(n int) error {
 // ReadUint8 reads a single byte.
 func (r *PacketReader) ReadUint8() (uint8, error) {
 	if r.offset >= len(r.pkt) {
-		return 0, errors.New("not enough data for uint8")
+		return 0, errNotEnoughData
 	}
 	value := r.pkt[r.offset]
 	r.offset++
@@ -58,7 +64,7 @@ func (r *PacketReader) ReadUint8() (uint8, error) {
 // ReadUint16 reads a big-endian 16-bit unsigned integer.
 func (r *PacketReader) ReadUint16() (uint16, error) {
 	if r.offset+2 > len(r.pkt) {
-		return 0, errors.New("not enough data for uint16")
+		return 0, errNotEnoughData
 	}
 	value := uint16(r.pkt[r.offset])<<8 | uint16(r.pkt[r.offset+1])
 	r.offset += 2
@@ -73,7 +79,7 @@ func (r *PacketReader) ReadUint16() (uint16, error) {
 //   - Maximum 4 bytes (max value: 268,435,455 = 2^28 - 1)
 func (r *PacketReader) ReadVariableByteInteger() (int, error) {
 	if r.offset >= len(r.pkt) {
-		return 0, errors.New("not enough data for variable byte integer")
+		return 0, errNotEnoughData
 	}
 
 	multiplier := 1 // Multiplier for current byte position (1, 128, 128^2, 128^3)
@@ -94,18 +100,18 @@ func (r *PacketReader) ReadVariableByteInteger() (int, error) {
 		pos++
 	}
 
-	return 0, errors.New("variable byte integer encoding exceeds 4 bytes or incomplete")
+	return 0, errBadIntEncoding
 }
 
 // ReadString reads an MQTT string (2-byte length prefix + UTF-8 string).
 func (r *PacketReader) ReadString() (string, error) {
 	strLen, err := r.ReadUint16()
 	if err != nil {
-		return "", errors.New("not enough data for string length")
+		return "", errNotEnoughStringLen
 	}
 
 	if r.offset+int(strLen) > len(r.pkt) {
-		return "", errors.New("not enough data for string content")
+		return "", errNotEnoughStringContent
 	}
 
 	str := string(r.pkt[r.offset : r.offset+int(strLen)])


### PR DESCRIPTION
## Summary

Users have reported that on high request volume they are missing some amount of traces and metrics. After investigations we discovered that we have a lot of events in the BPF logs where we cannot get enough data on the ring buffer. This means that we are unable to drain the ring buffer in userspace fast enough to keep up with the volume of data. 

This proved to be a relatively recent regression after we started adding all the new protocol detectors. From the linked Beyla issue https://github.com/grafana/beyla/issues/2707 we saw that the majority of the events are TCP, rather than HTTP which would explain why things got slower.

I added a benchmark that tests the worst case scenario for TCP, by creating random stream of bytes and passing it down the protocol detectors. The main overhead were allocations and missed opportunities to easily discard not matching protocols. One thing we have to pay attention to in the future is that doing `fmt.Errorf` and 'errors.New` on regular protocol parsing is allocating new error every time. Since most of the time the protocols don't match at least some of the detectors, this adds up over time.

Heuristic SQL detection is also very slow, since we iterate over all of the buffers looking for the SQL statements, but this is off by default.

Here are some benchmark results before and after my changes:

Before:
```
BenchmarkReadTCPRequestIntoSpan_RandomGarbage-24       	 9618645	      3560 ns/op	   28376 B/op	      27 allocs/op
```
<img width="2556" height="444" alt="image" src="https://github.com/user-attachments/assets/9e957c50-7128-462c-a21d-12e4a3e15809" />

After (around 6x improvement):
```
BenchmarkReadTCPRequestIntoSpan_RandomGarbage-24    	53958400	       624.9 ns/op	     190 B/op	       4 allocs/op
```
<img width="2556" height="444" alt="image" src="https://github.com/user-attachments/assets/4323070e-b3ea-4289-9681-f4cd153bd576" />

I've split the protocol by protocol changes in separate commits. Most of the changes are effectively replacing `fmt.Errorf` and `errors.New` with global constants.

More work is needed in the future to look into specific protocols and investigate how much overhead does the actual parsing take for various protocols.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [X] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
