### PR TITLE
Do not propagate via TCP options when disabled

### DIFF
--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -393,6 +393,10 @@ static __always_inline void bpf_sock_ops_active_est_cb(struct bpf_sock_ops *skop
 }
 
 static __always_inline void bpf_sock_ops_passive_est_cb(struct bpf_sock_ops *skops) {
+    if (!(inject_flags & k_inject_tcp_options)) {
+        return;
+    }
+
     bpf_sock_ops_set_flags(skops, BPF_SOCK_OPS_PARSE_ALL_HDR_OPT_CB_FLAG);
 }
 
@@ -456,6 +460,10 @@ static __always_inline void bpf_sock_ops_write_hdr_cb(struct bpf_sock_ops *skops
 }
 
 static __always_inline void bpf_sock_ops_parse_hdr_cb(struct bpf_sock_ops *skops) {
+    if (!(inject_flags & k_inject_tcp_options)) {
+        return;
+    }
+
     struct tp_option opt = {};
     opt.kind = k_tcp_option_kind_otel;
 


### PR DESCRIPTION
## Summary

When `context_propagation` does not list `tcp` as a means, we shouldn't be using it as a source for context propagation. This brings it inline with HTTP headers context propagation.

Fixes #2024 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
