### PR TITLE
fix(2119): enable TCP options propagation for Go gRPC client connections

### DIFF
--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -910,6 +910,7 @@ int obi_packet_extender(struct sk_msg_md *msg) {
     if (is_go_grpc_client_conn(&t_ctx->p_conn)) {
         bpf_msg_pull_data(msg, 0, msg->size, 0);
         fill_msg_buffers(msg, &t_ctx->p_conn, &e_key);
+        bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
         return SK_PASS;
     }
 
@@ -1195,6 +1196,9 @@ int obi_packet_extender_detect_h2(struct sk_msg_md *msg) {
 
             tp_info_pid_t *go_tp = get_tp_info_pid(&t_ctx->e_key);
             if (go_tp && go_tp->valid && go_tp->written) {
+                if (inject_flags & k_inject_tcp_options) {
+                    schedule_write_tcp_option(msg, go_tp);
+                }
                 h2_resume_after(msg, t_ctx, pos + k_h2_frame_header_len + f.payload_len);
                 return SK_PASS;
             }


### PR DESCRIPTION
#2119 

The sk_msg program (obi_packet_extender) was returning early for Go gRPC client connections without entering the H2 detection chain. This meant TCP options — the cross-language context propagation mechanism — were never scheduled, breaking distributed tracing when a Go gRPC client calls a non-Go server.

Two changes:
1. After filling msg buffers for Go gRPC client connections, tail-call into the H2 frame scanner instead of returning immediately.
2. In the H2 detector, when a Go uprobe trace parent is found (valid and written), schedule TCP options so the trace context reaches the remote non-Go service via the kernel TCP option path.

The H2 scanner also resolves the stream_id from the frame header, fixing the mismatch where the initial egress key used stream_id=0 which could not match per-stream entries stored by the Go uprobe.

## Summary

Describe the change briefly.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
