### PR TITLE
Release v0.9.1

### DIFF
--- a/examples/apache/docker-compose.yml
+++ b/examples/apache/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - edge-apache
 
   obi:
-    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.9.0@sha256:26f82b148dfe8cb0530561ab72a3cb5490b3ae5df556a33c27984af2e28542cf}
+    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.9.1}
     container_name: obi-apache-example
     command:
       - --config=/config/obi-config.yaml

--- a/examples/http-header-enrichment-demo/docker-compose.yaml
+++ b/examples/http-header-enrichment-demo/docker-compose.yaml
@@ -46,7 +46,7 @@ services:
       - "4317:4317"
 
   obi:
-    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.9.0@sha256:26f82b148dfe8cb0530561ab72a3cb5490b3ae5df556a33c27984af2e28542cf}
+    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.9.1}
     privileged: true
     pid: "host"
     environment:

--- a/examples/nginx/docker-compose.yml
+++ b/examples/nginx/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - edge-nginx
 
   obi:
-    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.9.0@sha256:26f82b148dfe8cb0530561ab72a3cb5490b3ae5df556a33c27984af2e28542cf}
+    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.9.1}
     container_name: obi-nginx-example
     command:
       - --config=/config/obi-config.yaml

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,12 +3,13 @@
 
 module-sets:
   obi:
-    version: v0.9.0
+    version: v0.9.1
     modules:
       - go.opentelemetry.io/obi
 excluded-modules:
   - github.com/hashicorp/go-version
   - github.com/hashicorp/golang-lru/v2
+  - grpc-relay
   - go.opentelemetry.io/collector/cmd/builder
   - go.opentelemetry.io/obi/configs/offsets/gin
   - go.opentelemetry.io/obi/configs/offsets/kafkago


### PR DESCRIPTION
## Summary
- Bump module set `obi` from `v0.9.0` to `v0.9.1` in `versions.yaml`.
- Add the test-only `grpc-relay` module (added in #1832 after v0.9.0) to `excluded-modules` so `make prerelease` / `verify-mods` pass.
- Update `OBI_IMAGE` defaults in the apache, nginx, and http-header-enrichment-demo example compose files to `otel/ebpf-instrument:v0.9.1`. The pinned `@sha256` digest is dropped — it will be re-pinned once the v0.9.1 image is published.

This follows the process in [RELEASING.md](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/RELEASING.md). The `make prerelease MODSET=obi` run on this branch produced an empty commit (no crosslink dependencies in a single-module set), so only the version bump commit is included.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, maintainer runs `make add-tags MODSET=obi COMMIT=<merge-sha>` and pushes the `v0.9.1` tag to `open-telemetry`
- [ ] Release workflow produces a draft release with multi-arch tarballs, SBOMs, and `SHA256SUMS`
- [ ] Image digests for the example compose files are re-pinned in a follow-up after publication

🤖 Generated with [Claude Code](https://claude.com/claude-code)