### PR TITLE
ci: enable all VM verifier tests, fix verifier errors on RHEL kernels

### DIFF
--- a/.github/workflows/slash_command_all_vm_tests.yml
+++ b/.github/workflows/slash_command_all_vm_tests.yml
@@ -58,12 +58,14 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           REF: ${{ steps.pr.outputs.sha }}
+          PR_NUMBER: ${{ github.event.issue.number }}
         run: |
           gh workflow run workflow_integration_tests_vm.yml \
             --repo "${OWNER}/${REPO}" \
             --ref main \
             -f ref="${REF}" \
-            -f all_kernels=true
+            -f all_kernels=true \
+            -f pr_number="${PR_NUMBER}"
 
       - name: Comment back with run URL
         env:
@@ -74,6 +76,6 @@ jobs:
           REF: ${{ steps.pr.outputs.sha }}
         run: |
           URL="https://github.com/${OWNER}/${REPO}/actions/workflows/workflow_integration_tests_vm.yml?query=event%3Aworkflow_dispatch"
-          BODY="Dispatched **Integration tests VM** on all kernels for \`${REF}\`. Watch progress: ${URL}"
+          BODY="Dispatched **Integration tests VM** on all kernels for \`${REF}\` (PR #${PR_NUMBER}). Watch progress: ${URL}"
           gh api -X POST "repos/${OWNER}/${REPO}/issues/${PR_NUMBER}/comments" \
             -f body="${BODY}" >/dev/null

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -1,4 +1,6 @@
 name: Integration tests VM
+run-name: >-
+  Integration tests VM${{ inputs.pr_number && format(' · PR #{0}', inputs.pr_number) || '' }}${{ inputs.ref && format(' @ {0}', inputs.ref) || '' }}
 
 on:
   push:
@@ -23,6 +25,10 @@ on:
         required: false
         type: boolean
         default: false
+      pr_number:
+        description: "PR number this dispatch is associated with (informational; surfaced in run-name)"
+        required: false
+        type: string
     secrets:
       DOCKER_TOKEN_EBPF_INSTRUMENTATION:
         description: "Docker Hub token for pulling images (optional)"
@@ -38,6 +44,10 @@ on:
         required: false
         type: boolean
         default: false
+      pr_number:
+        description: "PR number this dispatch is associated with (informational; surfaced in run-name)"
+        required: false
+        type: string
 
 concurrency:
   group: pr-integration-vm-${{ github.head_ref || github.run_id }}
@@ -137,10 +147,11 @@ jobs:
 
       - name: Cache Docker images
         id: docker-images-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 # zizmor: ignore[cache-poisoning] keyed on hash of compose+Dockerfile inputs
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5 # zizmor: ignore[cache-poisoning] keyed on hash of compose+Dockerfile+source inputs
         with:
           path: compiled-tests/docker-images.tar
-          key: vm-docker-images-${{ hashFiles('internal/test/integration/docker-compose-multiexec*.yml', 'internal/test/integration/**/Dockerfile*') }}
+          # OBI binary bakes bpf/cmd/pkg sources; hash them too or source changes reuse stale images.
+          key: vm-docker-images-${{ hashFiles('internal/test/integration/docker-compose-multiexec*.yml', 'internal/test/integration/**/Dockerfile*', 'bpf/**', 'cmd/**', 'pkg/**', 'go.mod', 'go.sum') }}
 
       - name: Pre-build Docker images
         if: steps.docker-images-cache.outputs.cache-hit != 'true'

--- a/bpf/common/h2_defs.h
+++ b/bpf/common/h2_defs.h
@@ -20,9 +20,9 @@ enum {
     k_h2_max_frame_len = 65535,
     k_h2_max_frame_scan = 4,
     k_h2_max_payload = k_kprobes_http2_buf_size - k_h2_frame_header_len,
-    // Max HEADERS frames injected per sk_msg packet — bounded by the
-    // 33 tail-call budget (≈4 hops per frame: detect → find → create → write)
-    k_h2_max_frames_per_packet = 8,
+    // Max HEADERS frames injected per sk_msg packet — bounded by 33 tail-call budget.
+    // ≤5 hops per frame (detect → scan → validate → create → write).
+    k_h2_max_frames_per_packet = 6,
     k_h2_max_hpack_scan = 192,
     k_h2_default_max_frame_size = 16384,
 

--- a/bpf/common/h2_defs.h
+++ b/bpf/common/h2_defs.h
@@ -20,8 +20,7 @@ enum {
     k_h2_max_frame_len = 65535,
     k_h2_max_frame_scan = 4,
     k_h2_max_payload = k_kprobes_http2_buf_size - k_h2_frame_header_len,
-    // Max HEADERS frames injected per sk_msg packet — bounded by 33 tail-call budget.
-    // ≤5 hops per frame (detect → scan → validate → create → write).
+    // Capped by the 33 tail-call budget (≤5 hops per frame).
     k_h2_max_frames_per_packet = 6,
     k_h2_max_hpack_scan = 192,
     k_h2_default_max_frame_size = 16384,

--- a/bpf/rdns/rdns_xdp.c
+++ b/bpf/rdns/rdns_xdp.c
@@ -150,7 +150,7 @@ static __always_inline void submit_dns_packet(struct xdp_md *ctx, const unsigned
     unsigned char *buf = bpf_ringbuf_reserve(&ring_buffer, RB_RECORD_LEN, 0);
 
     if (!buf) {
-        bpf_dbg_printk("Failed to reserve %u bytes in the ring buffer\n", RB_RECORD_LEN);
+        bpf_d_printk("Failed to reserve %u bytes in the ring buffer", RB_RECORD_LEN);
 
         return;
     }
@@ -190,36 +190,18 @@ static __always_inline void parse_dns_response(struct xdp_md *ctx,
 
     if (g_bpf_debug) {
         [[maybe_unused]] const __u16 id = bpf_ntohs(*(const __be16 *)(data));
-        [[maybe_unused]] const __u8 ra = get_bit(flags1, RA_OFFSET);
         [[maybe_unused]] const __u8 aa = get_bit(flags0, AA_OFFSET);
         [[maybe_unused]] const __u8 tc = get_bit(flags0, TC_OFFSET);
         [[maybe_unused]] const __u8 rd = get_bit(flags0, RD_OFFSET);
-
-        bpf_dbg_printk("Found possible DNS response: %x!\n", id);
-        bpf_dbg_printk("flags[0]=%x\n", flags0);
-        if (bpf_core_enum_value_exists(enum bpf_func_id___x, BPF_FUNC_trace_vprintk___x)) {
-            bpf_dbg_printk("id=%x, qr=%u, opcode=%u, aa=%u, tc=%u, rd=%u, ra=%u\n",
-                           id,
-                           qr,
-                           opcode,
-                           aa,
-                           tc,
-                           rd,
-                           ra);
-            bpf_dbg_printk("flags[1]=%x, z=%u, rcode=%u, qdcount=%u, ancount=%u\n",
-                           flags1,
-                           z,
-                           rcode,
-                           qdcount,
-                           ancount);
-        } else {
-            bpf_dbg_printk("id=%x, qr=%u, opcode=%u\n", id, qr, opcode);
-            bpf_dbg_printk("aa=%u, tc=%u, rd=%u\n", aa, tc, rd);
-            bpf_dbg_printk("ra=%u\n", ra);
-            bpf_dbg_printk("flags[1]=%x\n", flags1);
-            bpf_dbg_printk("z=%u, rcode=%u\n", z, rcode);
-            bpf_dbg_printk("qdcount=%u, ancount=%u\n", qdcount, ancount);
-        }
+        [[maybe_unused]] const __u8 ra = get_bit(flags1, RA_OFFSET);
+        bpf_d_printk("Found possible DNS response: %x!", id);
+        bpf_d_printk("flags[0]=%x", flags0);
+        bpf_d_printk("id=%x, qr=%u, opcode=%u", id, qr, opcode);
+        bpf_d_printk("aa=%u, tc=%u, rd=%u", aa, tc, rd);
+        bpf_d_printk("ra=%u", ra);
+        bpf_d_printk("flags[1]=%x", flags1);
+        bpf_d_printk("z=%u, rcode=%u", z, rcode);
+        bpf_d_printk("qdcount=%u, ancount=%u", qdcount, ancount);
     }
 
     // Parse question sections
@@ -231,7 +213,7 @@ static __always_inline void parse_dns_response(struct xdp_md *ctx,
         const __u32 qsection_size = validate_qsection(ctx, ptr);
 
         if (qsection_size == 0) {
-            bpf_dbg_printk("invalid qsection, bailing...\n");
+            bpf_d_printk("invalid qsection, bailing");
             return;
         }
 
@@ -239,7 +221,7 @@ static __always_inline void parse_dns_response(struct xdp_md *ctx,
         ptr += qsection_size;
     }
 
-    bpf_dbg_printk("found qsection, dns_packet_size=%u\n", dns_packet_size);
+    bpf_d_printk("found qsection, dns_packet_size=%u", dns_packet_size);
 
     // Submit valid DNS packet to ring buffer
     submit_dns_packet(ctx, data);
@@ -265,7 +247,7 @@ int dns_response_tracker(struct xdp_md *ctx) {
     // Validate packet size
     const __u16 udp_len = bpf_ntohs(udp->len);
 
-    bpf_dbg_printk("udp_len=%u\n", udp_len);
+    bpf_d_printk("udp_len=%u", udp_len);
 
     if (udp_len < (UDP_HDR_SIZE + DNS_HDR_SIZE)) {
         return XDP_PASS;

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -1284,8 +1284,29 @@ pull_hpack_window(struct sk_msg_md *msg, const u32 hpack_start, const u32 hpack_
     return bpf_msg_pull_data(msg, hpack_start, hpack_start + pull_len, 0) == 0;
 }
 
-// Find first 0x00 + valid name_len position. Validation deferred to validate_h2_tp tail call to keep this loop body cheap.
-// Returns position [0, k_h2_max_hpack_scan) on hit, k_h2_max_hpack_scan on miss.
+// Fingerprints: full traceparent name + value-length byte (0x37). Lets the scan
+// short-circuit on near-certain hits without invoking validate per candidate.
+enum {
+    k_h2_nlb_plain = k_hpack_tp_name_len,
+    k_h2_nlb_huffman = k_hpack_tp_name_huffman_len | 0x80,
+};
+static const u64 k_h2_tp_fp_plain_lo = 0x7261706563617274ULL; // "tracepar" (LE)
+static const u32 k_h2_tp_fp_plain_hi = 0x37746e65U;           // "ent" + 0x37 (LE)
+static const u64 k_h2_tp_fp_huffman = 0x3fa9851d6b21834dULL;  // huffman("traceparent") (LE)
+
+static __always_inline bool match_h2_tp_plain(const unsigned char *p) {
+    return *(const u64 *)(p + k_hpack_tp_name_offset) == k_h2_tp_fp_plain_lo &&
+           *(const u32 *)(p + k_hpack_tp_name_offset + 8) == k_h2_tp_fp_plain_hi;
+}
+
+static __always_inline bool match_h2_tp_huffman(const unsigned char *p) {
+    return *(const u64 *)(p + k_hpack_tp_name_offset) == k_h2_tp_fp_huffman &&
+           p[k_hpack_tp_name_offset + k_hpack_tp_name_huffman_len] == k_hpack_value_len_tp;
+}
+
+// Scan for traceparent in the HPACK window. Returns its offset within the window or
+// k_h2_max_hpack_scan if not found. Full-name+0x37 fingerprint match keeps the loop
+// body cheap and makes validate_h2_tp a near-formality.
 static __always_inline u32 find_first_h2_tp_candidate(struct sk_msg_md *msg,
                                                       const u32 hpack_start,
                                                       const u32 hpack_len) {
@@ -1312,10 +1333,12 @@ static __always_inline u32 find_first_h2_tp_candidate(struct sk_msg_md *msg,
             continue;
         }
         const u8 nlb = p[1];
-        if (nlb != k_hpack_tp_name_len && nlb != (k_hpack_tp_name_huffman_len | 0x80)) {
-            continue;
+        if (nlb == k_h2_nlb_plain && match_h2_tp_plain(p)) {
+            return i;
         }
-        return i;
+        if (nlb == k_h2_nlb_huffman && match_h2_tp_huffman(p)) {
+            return i;
+        }
     }
     return k_h2_max_hpack_scan;
 }
@@ -1411,6 +1434,7 @@ int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg) {
             msg, t_ctx, t_ctx->h2_frame_offset + k_h2_frame_header_len + t_ctx->h2_payload_len);
         return SK_PASS;
     }
+
     bpf_tail_call_static(msg, &extender_jump_table, k_tail_create_h2_tp);
     return SK_PASS;
 }

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -107,6 +107,7 @@ enum {
     k_tail_write_h2_traceparent,
     k_tail_create_h2_tp,
     k_tail_find_existing_h2_tp,
+    k_tail_validate_h2_tp,
     k_tail_detect_h2,
 };
 
@@ -116,11 +117,12 @@ int obi_packet_extender_create_tp(struct sk_msg_md *msg);
 int obi_packet_extender_write_h2_tp(struct sk_msg_md *msg);
 int obi_packet_extender_create_h2_tp(struct sk_msg_md *msg);
 int obi_packet_extender_find_existing_h2_tp(struct sk_msg_md *msg);
+int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg);
 int obi_packet_extender_detect_h2(struct sk_msg_md *msg);
 
 struct {
     __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-    __uint(max_entries, 7);
+    __uint(max_entries, 8);
     __uint(key_size, sizeof(u32));
     __array(values, int(void *));
 } extender_jump_table SEC(".maps") = {
@@ -132,6 +134,7 @@ struct {
             [k_tail_write_h2_traceparent] = (void *)&obi_packet_extender_write_h2_tp,
             [k_tail_create_h2_tp] = (void *)&obi_packet_extender_create_h2_tp,
             [k_tail_find_existing_h2_tp] = (void *)&obi_packet_extender_find_existing_h2_tp,
+            [k_tail_validate_h2_tp] = (void *)&obi_packet_extender_validate_h2_tp,
             [k_tail_detect_h2] = (void *)&obi_packet_extender_detect_h2,
         },
 };
@@ -147,10 +150,11 @@ typedef struct tailcall_ctx {
     u32 h2_hpack_offset;          // start of HPACK bytes (after PADDED/PRIORITY prefix)
     u32 h2_hpack_len;             // HPACK length (frame payload minus prefix and trailing pad)
     u32 h2_scan_pos;              // resume offset for detect_h2 across tail calls
+    u32 h2_tp_candidate_pos;      // HPACK candidate offset (>= k_h2_max_hpack_scan = none)
     u8 niter;                     // HTTP/1 find-existing scan iteration counter
     u8 h2_frames;                 // H2 frames already injected this packet (capped)
     bool has_parent_tp;           // true if parent_tp holds a valid context
-    u8 _pad[1];
+    u8 _pad[5];
 } tailcall_ctx;
 
 SCRATCH_MEM(tailcall_ctx);
@@ -1230,119 +1234,164 @@ static __always_inline bool decode_tp_value(const unsigned char *val, tp_info_t 
     return true;
 }
 
-// Returns wire offset of span_id hex (>0) if HPACK traceparent found, else 0.
-// Handles plaintext (0x0b name) and huffman (0x88 + 8 bytes) encodings.
-// Mirrors parse_hpack_traceparent in protocol_http2.h — sk_msg uses
-// bpf_msg_pull_data, kprobe uses bpf_probe_read; can't share code.
-static __always_inline u32 find_existing_h2_traceparent(struct sk_msg_md *msg,
-                                                        const u32 hpack_start,
-                                                        const u32 hpack_len,
-                                                        tp_info_t *tp) {
-    // Outer loop uses the huffman entry size (smaller); the plaintext branch
-    // adds 3 more bytes. pull_len uses the plaintext size so a plaintext
-    // entry at the last scan pos still fits
-    enum { k_min_entry_huffman = k_h2_tp_hpack_huffman_size };
-    enum { k_min_entry_plain = k_h2_tp_hpack_size };
-
-    if (hpack_len < k_min_entry_huffman) {
+static __always_inline u32 validate_h2_tp_plain(const unsigned char *p,
+                                                const unsigned char *end,
+                                                tp_info_t *tp) {
+    if ((void *)(p + k_h2_tp_hpack_size) > (void *)end) {
         return 0;
     }
+    if (bpf_memcmp(p + k_hpack_tp_name_offset, k_hpack_tp_name, k_hpack_tp_name_len) != 0) {
+        return 0;
+    }
+    if (p[k_hpack_tp_name_offset + k_hpack_tp_name_len] != k_hpack_value_len_tp) {
+        return 0;
+    }
+    if (!decode_tp_value(p + k_hpack_tp_val_offset, tp)) {
+        return 0;
+    }
+    return k_hpack_tp_val_offset + k_tp_val_span_id_start;
+}
 
+static __always_inline u32 validate_h2_tp_huffman(const unsigned char *p,
+                                                  const unsigned char *end,
+                                                  tp_info_t *tp) {
+    if ((void *)(p + k_h2_tp_hpack_huffman_size) > (void *)end) {
+        return 0;
+    }
+    if (bpf_memcmp(p + k_hpack_tp_name_offset, k_hpack_tp_huffman, k_hpack_tp_name_huffman_len) !=
+        0) {
+        return 0;
+    }
+    if (p[k_hpack_tp_name_offset + k_hpack_tp_name_huffman_len] != k_hpack_value_len_tp) {
+        return 0;
+    }
+    if (!decode_tp_value(p + k_hpack_tp_val_offset_huffman, tp)) {
+        return 0;
+    }
+    return k_hpack_tp_val_offset_huffman + k_tp_val_span_id_start;
+}
+
+// Pull the HPACK scan window into linear data. Idempotent across tail calls.
+static __always_inline bool
+pull_hpack_window(struct sk_msg_md *msg, const u32 hpack_start, const u32 hpack_len) {
+    enum { k_min_entry_plain = k_h2_tp_hpack_size };
+    if (hpack_len < k_h2_tp_hpack_huffman_size) {
+        return false;
+    }
     const u32 pull_len = hpack_len < (k_h2_max_hpack_scan + k_min_entry_plain)
                              ? hpack_len
                              : (k_h2_max_hpack_scan + k_min_entry_plain);
-    const long pull_err = bpf_msg_pull_data(msg, hpack_start, hpack_start + pull_len, 0);
-    if (pull_err != 0) {
-        return 0;
-    }
+    return bpf_msg_pull_data(msg, hpack_start, hpack_start + pull_len, 0) == 0;
+}
 
+// Find first 0x00 + valid name_len position. Validation deferred to validate_h2_tp tail call to keep this loop body cheap.
+// Returns position [0, k_h2_max_hpack_scan) on hit, k_h2_max_hpack_scan on miss.
+static __always_inline u32 find_first_h2_tp_candidate(struct sk_msg_md *msg,
+                                                      const u32 hpack_start,
+                                                      const u32 hpack_len) {
+    enum { k_min_entry_huffman = k_h2_tp_hpack_huffman_size };
+
+    if (!pull_hpack_window(msg, hpack_start, hpack_len)) {
+        return k_h2_max_hpack_scan;
+    }
     const unsigned char *data = msg->data;
     const unsigned char *end = msg->data_end;
-
     if (!data) {
-        return 0;
+        return k_h2_max_hpack_scan;
     }
 
     for (u32 i = 0; i < k_h2_max_hpack_scan; i++) {
         if (i + k_min_entry_huffman > hpack_len) {
             break;
         }
-
         const unsigned char *p = data + i;
-
         if ((void *)(p + k_min_entry_huffman) > (void *)end) {
             break;
         }
-
-        if (*p != k_hpack_literal_no_index) {
+        if (p[0] != k_hpack_literal_no_index) {
             continue;
         }
-
-        const u8 name_len_byte = p[1];
-
-        // Plaintext name: [0x00][0x0b]["traceparent"][0x37][value]
-        if (name_len_byte == k_hpack_tp_name_len) {
-            if (bpf_memcmp(p + k_hpack_tp_name_offset, k_hpack_tp_name, k_hpack_tp_name_len) != 0) {
-                continue;
-            }
-            if (p[k_hpack_tp_name_offset + k_hpack_tp_name_len] != k_hpack_value_len_tp) {
-                continue;
-            }
-            if ((void *)(p + k_min_entry_plain) > (void *)end) {
-                continue;
-            }
-            if (!decode_tp_value(p + k_hpack_tp_val_offset, tp)) {
-                continue;
-            }
-            bpf_dbg_printk("h2: found existing traceparent (plaintext)");
-            return hpack_start + i + k_hpack_tp_val_offset + k_tp_val_span_id_start;
+        const u8 nlb = p[1];
+        if (nlb != k_hpack_tp_name_len && nlb != (k_hpack_tp_name_huffman_len | 0x80)) {
+            continue;
         }
-
-        // Huffman name: [0x00][0x88][8 huffman bytes][0x37][value]
-        if (name_len_byte == (k_hpack_tp_name_huffman_len | 0x80)) {
-            if (bpf_memcmp(p + k_hpack_tp_name_offset,
-                           k_hpack_tp_huffman,
-                           k_hpack_tp_name_huffman_len) != 0) {
-                continue;
-            }
-            if (p[k_hpack_tp_name_offset + k_hpack_tp_name_huffman_len] != k_hpack_value_len_tp) {
-                continue;
-            }
-            if (!decode_tp_value(p + k_hpack_tp_val_offset_huffman, tp)) {
-                continue;
-            }
-            bpf_dbg_printk("h2: found existing traceparent (huffman)");
-            return hpack_start + i + k_hpack_tp_val_offset_huffman + k_tp_val_span_id_start;
-        }
+        return i;
     }
-
-    return 0;
+    return k_h2_max_hpack_scan;
 }
 
-// k_tail_find_existing_h2_tp
-// Scan HPACK for existing traceparent. Adopt if found, else tail-call create.
-// Separate tail call: 192-byte scan + find_parent_trace exceeds 512-byte stack.
+// Validation is a separate tail call: inlining it under the 192-iter scan blows older verifiers' complexity budget.
 SEC("sk_msg")
 int obi_packet_extender_find_existing_h2_tp(struct sk_msg_md *msg) {
     bpf_dbg_printk("=== sk_msg find existing h2 tp ===");
-
     tailcall_ctx *t_ctx = tailcall_ctx_mem();
     if (!t_ctx) {
         return SK_PASS;
     }
+    t_ctx->h2_tp_candidate_pos =
+        find_first_h2_tp_candidate(msg, t_ctx->h2_hpack_offset, t_ctx->h2_hpack_len);
+    bpf_tail_call_static(msg, &extender_jump_table, k_tail_validate_h2_tp);
+    return SK_PASS;
+}
 
-    const u32 hpack_start = t_ctx->h2_hpack_offset;
-    const u32 hpack_len = t_ctx->h2_hpack_len;
-
+// Re-walks with a loop counter: a pkt pointer offset by a value loaded from the stack loses its verified range.
+SEC("sk_msg")
+int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg) {
+    bpf_dbg_printk("=== sk_msg validate h2 tp ===");
+    tailcall_ctx *t_ctx = tailcall_ctx_mem();
+    if (!t_ctx) {
+        return SK_PASS;
+    }
+    const u32 target = t_ctx->h2_tp_candidate_pos;
+    if (target >= k_h2_max_hpack_scan) {
+        bpf_tail_call_static(msg, &extender_jump_table, k_tail_create_h2_tp);
+        return SK_PASS;
+    }
     tp_info_pid_t *tp_p = (tp_info_pid_t *)tp_info_mem();
     if (!tp_p) {
         return SK_PASS;
     }
+    const u32 hpack_start = t_ctx->h2_hpack_offset;
+    const u32 hpack_len = t_ctx->h2_hpack_len;
+    if (!pull_hpack_window(msg, hpack_start, hpack_len)) {
+        bpf_tail_call_static(msg, &extender_jump_table, k_tail_create_h2_tp);
+        return SK_PASS;
+    }
+    const unsigned char *data = msg->data;
+    const unsigned char *end = msg->data_end;
+    if (!data) {
+        bpf_tail_call_static(msg, &extender_jump_table, k_tail_create_h2_tp);
+        return SK_PASS;
+    }
 
-    const u32 span_id_offset = find_existing_h2_traceparent(msg, hpack_start, hpack_len, &tp_p->tp);
-    if (span_id_offset) {
+    u32 off = 0;
+    for (u32 i = 0; i < k_h2_max_hpack_scan; i++) {
+        if (i + k_h2_tp_hpack_huffman_size > hpack_len) {
+            break;
+        }
+        const unsigned char *p = data + i;
+        if ((void *)(p + k_h2_tp_hpack_huffman_size) > (void *)end) {
+            break;
+        }
+        if (i > target) {
+            break;
+        }
+        if (i != target) {
+            continue;
+        }
+        const u8 nlb = p[1];
+        if (nlb == k_hpack_tp_name_len) {
+            off = validate_h2_tp_plain(p, end, &tp_p->tp);
+        } else if (nlb == (k_hpack_tp_name_huffman_len | 0x80)) {
+            off = validate_h2_tp_huffman(p, end, &tp_p->tp);
+        }
+        break;
+    }
+
+    if (off) {
         init_tp_ctx_parent_tp(t_ctx);
         bpf_memset(tp_p->tp.parent_id, 0, sizeof(tp_p->tp.parent_id));
+        const u32 span_id_offset = hpack_start + target + off;
         if (apply_parent_tp(t_ctx, &tp_p->tp)) {
             if (bpf_msg_pull_data(msg, span_id_offset, span_id_offset + SPAN_ID_CHAR_LEN, 0) == 0) {
                 unsigned char *d = msg->data;
@@ -1352,7 +1401,6 @@ int obi_packet_extender_find_existing_h2_tp(struct sk_msg_md *msg) {
                 }
             }
         }
-
         tp_p->tp.ts = bpf_ktime_get_ns();
         tp_p->valid = 1;
         tp_p->written = 1;
@@ -1363,7 +1411,6 @@ int obi_packet_extender_find_existing_h2_tp(struct sk_msg_md *msg) {
             msg, t_ctx, t_ctx->h2_frame_offset + k_h2_frame_header_len + t_ctx->h2_payload_len);
         return SK_PASS;
     }
-
     bpf_tail_call_static(msg, &extender_jump_table, k_tail_create_h2_tp);
     return SK_PASS;
 }

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -1271,7 +1271,6 @@ static __always_inline u32 validate_h2_tp_huffman(const unsigned char *p,
     return k_hpack_tp_val_offset_huffman + k_tp_val_span_id_start;
 }
 
-// Pull the HPACK scan window into linear data. Idempotent across tail calls.
 static __always_inline bool
 pull_hpack_window(struct sk_msg_md *msg, const u32 hpack_start, const u32 hpack_len) {
     enum { k_min_entry_plain = k_h2_tp_hpack_size };
@@ -1284,8 +1283,7 @@ pull_hpack_window(struct sk_msg_md *msg, const u32 hpack_start, const u32 hpack_
     return bpf_msg_pull_data(msg, hpack_start, hpack_start + pull_len, 0) == 0;
 }
 
-// Fingerprints: full traceparent name + value-length byte (0x37). Lets the scan
-// short-circuit on near-certain hits without invoking validate per candidate.
+// Fingerprints for full traceparent name + value-length byte (0x37).
 enum {
     k_h2_nlb_plain = k_hpack_tp_name_len,
     k_h2_nlb_huffman = k_hpack_tp_name_huffman_len | 0x80,
@@ -1304,9 +1302,7 @@ static __always_inline bool match_h2_tp_huffman(const unsigned char *p) {
            p[k_hpack_tp_name_offset + k_hpack_tp_name_huffman_len] == k_hpack_value_len_tp;
 }
 
-// Scan for traceparent in the HPACK window. Returns its offset within the window or
-// k_h2_max_hpack_scan if not found. Full-name+0x37 fingerprint match keeps the loop
-// body cheap and makes validate_h2_tp a near-formality.
+// Returns offset of the traceparent name in HPACK, or k_h2_max_hpack_scan if not found.
 static __always_inline u32 find_first_h2_tp_candidate(struct sk_msg_md *msg,
                                                       const u32 hpack_start,
                                                       const u32 hpack_len) {
@@ -1343,7 +1339,7 @@ static __always_inline u32 find_first_h2_tp_candidate(struct sk_msg_md *msg,
     return k_h2_max_hpack_scan;
 }
 
-// Validation is a separate tail call: inlining it under the 192-iter scan blows older verifiers' complexity budget.
+// Validate via a separate tail call — inlining under the 192-iter scan blows older verifiers.
 SEC("sk_msg")
 int obi_packet_extender_find_existing_h2_tp(struct sk_msg_md *msg) {
     bpf_dbg_printk("=== sk_msg find existing h2 tp ===");
@@ -1357,7 +1353,7 @@ int obi_packet_extender_find_existing_h2_tp(struct sk_msg_md *msg) {
     return SK_PASS;
 }
 
-// Re-walks with a loop counter: a pkt pointer offset by a value loaded from the stack loses its verified range.
+// Walk with a loop counter — pkt pointer offset by a stack-loaded scalar loses its verified range.
 SEC("sk_msg")
 int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg) {
     bpf_dbg_printk("=== sk_msg validate h2 tp ===");

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -1284,13 +1284,23 @@ pull_hpack_window(struct sk_msg_md *msg, const u32 hpack_start, const u32 hpack_
 }
 
 // Fingerprints for full traceparent name + value-length byte (0x37).
+// Values match what *(u32/u64 *)p loads on the build target, so the comparisons
+// work on bpfel and bpfeb.
 enum {
     k_h2_nlb_plain = k_hpack_tp_name_len,
     k_h2_nlb_huffman = k_hpack_tp_name_huffman_len | 0x80,
 };
-static const u64 k_h2_tp_fp_plain_lo = 0x7261706563617274ULL; // "tracepar" (LE)
-static const u32 k_h2_tp_fp_plain_hi = 0x37746e65U;           // "ent" + 0x37 (LE)
-static const u64 k_h2_tp_fp_huffman = 0x3fa9851d6b21834dULL;  // huffman("traceparent") (LE)
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+static const u64 k_h2_tp_fp_plain_lo = 0x7261706563617274ULL; // "tracepar"
+static const u32 k_h2_tp_fp_plain_hi = 0x37746e65U;           // "ent" + 0x37
+static const u64 k_h2_tp_fp_huffman = 0x3fa9851d6b21834dULL;  // huffman("traceparent")
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+static const u64 k_h2_tp_fp_plain_lo = 0x7472616365706172ULL; // "tracepar"
+static const u32 k_h2_tp_fp_plain_hi = 0x656e7437U;           // "ent" + 0x37
+static const u64 k_h2_tp_fp_huffman = 0x4d83216b1d85a93fULL;  // huffman("traceparent")
+#else
+#error "unsupported __BYTE_ORDER__"
+#endif
 
 static __always_inline bool match_h2_tp_plain(const unsigned char *p) {
     return *(const u64 *)(p + k_hpack_tp_name_offset) == k_h2_tp_fp_plain_lo &&

--- a/internal/test/integration/components/docker/compose.go
+++ b/internal/test/integration/components/docker/compose.go
@@ -129,6 +129,17 @@ func (c *Compose) commandContext(ctx context.Context, args ...string) error {
 	return cmd.Run()
 }
 
+// Exec runs `docker exec <container> <args...>`. Use when there's no Compose handle.
+func Exec(ctx context.Context, container string, args ...string) (string, error) {
+	cmdArgs := append([]string{"exec", container}, args...)
+	out, err := exec.CommandContext(ctx, "docker", cmdArgs...).CombinedOutput()
+	if err != nil {
+		return strings.TrimSpace(string(out)),
+			fmt.Errorf("docker exec %s %v: %w; output: %s", container, args, err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 func (c *Compose) ExecOutput(service string, args ...string) (string, error) {
 	cmdArgs := []string{"compose", "--ansi", "never", "-f", c.Path, "exec", "-T", service}
 	cmdArgs = append(cmdArgs, args...)

--- a/internal/test/integration/components/weaver/service.yml
+++ b/internal/test/integration/components/weaver/service.yml
@@ -17,19 +17,17 @@
 # volumes resolve against the file that declares them, so the consuming
 # compose must own its own bind mount or the registry path would be wrong.
 #
-# weaver writes its consolidated live-check report to `/tmp/live_check.json`
-# inside the container (see `--output /tmp` in the command below). The test
-# harness pulls it out with `docker cp` after `/stop`, before
-# `compose.Close()` removes the container. This avoids a host bind-mount
-# whose UID would mismatch weaver's non-root container UID.
+# weaver writes its live-check report to /tmp/weaver-out/live_check.json,
+# bind-mounted to /tmp/obi-weaver-out on the docker host. Test harness reads
+# directly from the host path — docker cp from a stopped container on RHEL
+# overlayfs returned sparse files with mid-stream NUL holes. user: 0 lets
+# the container write into the docker-managed bind mount source regardless
+# of host ownership.
 services:
   weaver:
     image: otel/weaver:v0.23.0@sha256:7984ecb55b859eb3034ae9d836c4eeda137e2bdd0873b7ba2bb6c3d24d6ff457
     container_name: weaver
-    # Run with the registry mount as the working dir so relative
-    # `registry_path` entries in `manifest.yaml` (e.g. the `.deps/upstream-*`
-    # cache) resolve correctly without the manifest having to embed the
-    # in-container mount point.
+    user: "0:0"
     working_dir: /obi-registry
     command:
       - registry
@@ -45,15 +43,10 @@ services:
       - json
       - --diagnostic-format
       - json
-      # Write the final consolidated live-check report to /tmp inside the
-      # container (always present in the upstream image). With `--output`,
-      # weaver buffers per-entity Rego findings internally and emits a
-      # single `live_check.json` at /stop time, leaving stdout empty. The
-      # test harness extracts it with `docker cp` — no host bind mount
-      # required, so we don't have to wrestle with the UID mismatch
-      # between weaver's non-root container user and the runner user.
       - --output
-      - /tmp
+      - /tmp/weaver-out
+    volumes:
+      - /tmp/obi-weaver-out:/tmp/weaver-out
     ports:
       - "4320:4320" # admin port (for /stop from test host)
     healthcheck:

--- a/internal/test/integration/weaver.go
+++ b/internal/test/integration/weaver.go
@@ -135,6 +135,11 @@ func runWeaverValidation(t *testing.T) {
 			"only stopping the weaver container so compose teardown is clean")
 	}
 
+	// Bind-mount source matches weaver service.yml.
+	const hostReport = "/tmp/obi-weaver-out/live_check.json"
+	// Drop stale report from prior test so a weaver crash before /stop fails loudly instead of reading old data.
+	_ = os.Remove(hostReport)
+
 	ctx, cancel := context.WithTimeout(context.Background(), weaverTimeout)
 	defer cancel()
 
@@ -171,23 +176,19 @@ func runWeaverValidation(t *testing.T) {
 	}
 
 	reportPath := weaverReportPath(t)
-	cpCmd := exec.CommandContext(ctx, "docker", "cp",
-		weaverContainer+":/tmp/live_check.json", reportPath)
-	if out, err := cpCmd.CombinedOutput(); err != nil {
-		t.Errorf("failed to copy weaver report from container: %v; output: %s",
-			err, strings.TrimSpace(string(out)))
-		return
-	}
-	t.Logf("weaver report saved to %s", reportPath)
-
-	rawReport, err := os.ReadFile(reportPath)
+	rawReport, err := os.ReadFile(hostReport)
 	if err != nil {
-		t.Errorf("failed to read weaver report at %s: %v", reportPath, err)
+		t.Errorf("failed to read weaver report at %s: %v", hostReport, err)
 		return
 	}
 	if len(rawReport) == 0 {
-		t.Errorf("weaver report file %s is empty", reportPath)
+		t.Errorf("weaver report file %s is empty", hostReport)
 		return
+	}
+	if err := os.WriteFile(reportPath, rawReport, 0o644); err != nil {
+		t.Logf("warn: failed to archive weaver report to %s: %v", reportPath, err)
+	} else {
+		t.Logf("weaver report saved to %s", reportPath)
 	}
 	var report weaverReport
 	if err := json.Unmarshal(rawReport, &report); err != nil {

--- a/internal/test/integration/weaver.go
+++ b/internal/test/integration/weaver.go
@@ -138,7 +138,10 @@ func runWeaverValidation(t *testing.T) {
 	// Bind-mount source matches weaver service.yml.
 	const hostReport = "/tmp/obi-weaver-out/live_check.json"
 	// Drop stale report from prior test so a weaver crash before /stop fails loudly instead of reading old data.
-	_ = os.Remove(hostReport)
+	if err := os.Remove(hostReport); err != nil && !os.IsNotExist(err) {
+		t.Errorf("failed to remove stale weaver report at %s: %v", hostReport, err)
+		return
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), weaverTimeout)
 	defer cancel()

--- a/internal/test/integration/weaver.go
+++ b/internal/test/integration/weaver.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
 )
 
 const (
@@ -135,11 +137,13 @@ func runWeaverValidation(t *testing.T) {
 			"only stopping the weaver container so compose teardown is clean")
 	}
 
-	// Bind-mount source matches weaver service.yml.
+	// weaver writes the report as root; delete via docker exec, not os.Remove.
 	const hostReport = "/tmp/obi-weaver-out/live_check.json"
-	// Drop stale report from prior test so a weaver crash before /stop fails loudly instead of reading old data.
-	if err := os.Remove(hostReport); err != nil && !os.IsNotExist(err) {
-		t.Errorf("failed to remove stale weaver report at %s: %v", hostReport, err)
+	const containerReport = "/tmp/weaver-out/live_check.json"
+	rmCtx, rmCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer rmCancel()
+	if _, err := docker.Exec(rmCtx, weaverContainer, "rm", "-f", containerReport); err != nil {
+		t.Errorf("removing stale weaver report: %v", err)
 		return
 	}
 

--- a/internal/test/vm/kernels.yaml
+++ b/internal/test/vm/kernels.yaml
@@ -67,21 +67,17 @@ kernels:
     pr_integration: false
     pr_verifier: true
 
-  # TODO: fix bpf program loading on rhel8.x (kernel 4.18) because
-  # obi_packet_extender_find_existing_h2_tp exhausts the verifier
-  # complexity limit (>1M insns) — older verifier explores more states
-  # than 5.14+.
   - id: "rhel8.9"
     lvh_tag: "rhel8.9-20260504.013701"
     digest: "sha256:1f13a2a66f66aeb0928aa500086ac73748dc2722d13cf2aa6924dbb1b063236a"
     pr_integration: false
-    pr_verifier: false
+    pr_verifier: true
 
   - id: "rhel8.10"
     lvh_tag: "rhel8.10-20260504.013701"
     digest: "sha256:78f0c417577c1bcdd994496f7da36585e17da19c93b59d4a16b9b39a891a7328"
     pr_integration: false
-    pr_verifier: false
+    pr_verifier: true
 
   - id: "rhel9.6"
     lvh_tag: "rhel9.6-20260504.013701"

--- a/pkg/obi/os.go
+++ b/pkg/obi/os.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -26,10 +27,10 @@ const (
 
 var kernelVersion = ebpfcommon.KernelVersion
 
-// parseOSReleaseIsRHEL checks whether os-release content indicates an RHEL-based distro.
+var rhelIDs = []string{"rhel", "centos", "rocky", "alma"}
+
 func parseOSReleaseIsRHEL(data []byte) bool {
 	content := strings.ToLower(string(data))
-	// matches ID="rhel" or ID_LIKE containing "rhel" (e.g. Rocky, AlmaLinux, CentOS set ID_LIKE="rhel ...")
 	for _, line := range strings.Split(content, "\n") {
 		var val string
 		switch {
@@ -40,22 +41,32 @@ func parseOSReleaseIsRHEL(data []byte) bool {
 		default:
 			continue
 		}
-		val = strings.Trim(val, "\"'")
-		if strings.Contains(val, "rhel") || strings.Contains(val, "centos") ||
-			strings.Contains(val, "rocky") || strings.Contains(val, "alma") {
-			return true
+		val = strings.Trim(val, `"'`)
+		for _, id := range rhelIDs {
+			if strings.Contains(val, id) {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-// isRHELBased is a var so tests can override it.
+// .elN matches vendor-built RHEL-family kernels (4.18.0-553.el8.x86_64).
+// (Red Hat X.Y.Z-N) catches RHEL kernels rebuilt with stripped localversion — gcc banner remains.
+var rhelKernelRE = regexp.MustCompile(`\.el\d+(_\d+)?\b|\(Red Hat \d+\.\d+\.\d+-\d+\)`)
+
+func parseProcVersionIsRHEL(data []byte) bool {
+	return rhelKernelRE.Match(data)
+}
+
 var isRHELBased = func() bool {
-	data, err := os.ReadFile("/etc/os-release")
-	if err != nil {
-		return false
+	if data, err := os.ReadFile("/etc/os-release"); err == nil && parseOSReleaseIsRHEL(data) {
+		return true
 	}
-	return parseOSReleaseIsRHEL(data)
+	if data, err := os.ReadFile("/proc/version"); err == nil && parseProcVersionIsRHEL(data) {
+		return true
+	}
+	return false
 }
 
 // hasBTF checks whether the kernel exposes BTF information by looking for the

--- a/pkg/obi/os.go
+++ b/pkg/obi/os.go
@@ -102,17 +102,15 @@ var hasBTF = func() bool {
 	return false
 }
 
-// checkOSSupport contains the actual logic
-// tests call this directly.
+// checkOSSupport contains the actual logic; tests call it directly.
 func checkOSSupport() error {
 	major, minor := kernelVersion()
-	maj, mnr := minKernMaj, minKernMin
-	if isRHELBased() {
-		maj, mnr = minRHELKernMaj, minRHELKernMin
-	}
-	if major < maj || (major == maj && minor < mnr) {
+	general := major > minKernMaj || (major == minKernMaj && minor >= minKernMin)
+	// isRHELBased only consulted at 4.18 so distro misclassification can't pass other unsupported kernels.
+	rhel418 := major == minRHELKernMaj && minor == minRHELKernMin && isRHELBased()
+	if !general && !rhel418 {
 		return fmt.Errorf("kernel version %d.%d not supported. Minimum required version is %d.%d",
-			major, minor, maj, mnr)
+			major, minor, minKernMaj, minKernMin)
 	}
 
 	if !hasBTF() {

--- a/pkg/obi/os.go
+++ b/pkg/obi/os.go
@@ -51,8 +51,7 @@ func parseOSReleaseIsRHEL(data []byte) bool {
 	return false
 }
 
-// .elN matches vendor-built RHEL-family kernels (4.18.0-553.el8.x86_64).
-// (Red Hat X.Y.Z-N) catches RHEL kernels rebuilt with stripped localversion — gcc banner remains.
+// Matches RHEL release tag (.elN) or rebuilt RHEL kernels via the gcc banner.
 var rhelKernelRE = regexp.MustCompile(`\.el\d+(_\d+)?\b|\(Red Hat \d+\.\d+\.\d+-\d+\)`)
 
 func parseProcVersionIsRHEL(data []byte) bool {
@@ -106,7 +105,7 @@ var hasBTF = func() bool {
 func checkOSSupport() error {
 	major, minor := kernelVersion()
 	general := major > minKernMaj || (major == minKernMaj && minor >= minKernMin)
-	// isRHELBased only consulted at 4.18 so distro misclassification can't pass other unsupported kernels.
+	// RHEL relaxation only applies at the 4.18 floor.
 	rhel418 := major == minRHELKernMaj && minor == minRHELKernMin && isRHELBased()
 	if !general && !rhel418 {
 		return fmt.Errorf("kernel version %d.%d not supported. Minimum required version is %d.%d",

--- a/pkg/obi/os_test.go
+++ b/pkg/obi/os_test.go
@@ -120,6 +120,28 @@ func TestParseOSReleaseIsRHEL(t *testing.T) {
 	}
 }
 
+func TestParseProcVersionIsRHEL(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "RHEL 8 release tag", content: "Linux version 4.18.0-553.el8.x86_64 (mockbuild@x86-vm-29) #1 SMP\n", want: true},
+		{name: "Rocky el8_8", content: "Linux version 4.18.0-477.10.1.el8_8.x86_64 (gcc 8.5.0)\n", want: true},
+		{name: "AlmaLinux 9", content: "Linux version 5.14.0-284.30.1.el9_2.x86_64 (mockbuild@) #1 SMP\n", want: true},
+		{name: "rebuilt RHEL 8 with stripped localversion", content: "Linux version 4.18.0 (root@buildkitsandbox) (gcc version 8.5.0 20210514 (Red Hat 8.5.0-28) (GCC)) #1 SMP\n", want: true},
+		// Fedora's Red Hat gcc banner matches too — harmless false positive: Fedora kernels are >= 5.8 so general min passes either way.
+		{name: "Fedora with Red Hat gcc (cosmetic false positive)", content: "Linux version 5.14.10-300.fc35.x86_64 (mockbuild) (gcc (GCC) 11.2.1 20210728 (Red Hat 11.2.1-1))\n", want: true},
+		{name: "Ubuntu", content: "Linux version 5.15.0-92-generic (buildd@bos03-amd64-003) (gcc-11)\n", want: false},
+		{name: "Debian", content: "Linux version 6.1.0-13-amd64 (debian-kernel@lists.debian.org) (gcc-12)\n", want: false},
+		{name: "empty", content: "", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseProcVersionIsRHEL([]byte(tc.content)))
+		})
+	}
+}
+
 func TestOSCapabilitiesError_Empty(t *testing.T) {
 	var capErr osCapabilitiesError
 

--- a/pkg/obi/os_test.go
+++ b/pkg/obi/os_test.go
@@ -130,7 +130,7 @@ func TestParseProcVersionIsRHEL(t *testing.T) {
 		{name: "Rocky el8_8", content: "Linux version 4.18.0-477.10.1.el8_8.x86_64 (gcc 8.5.0)\n", want: true},
 		{name: "AlmaLinux 9", content: "Linux version 5.14.0-284.30.1.el9_2.x86_64 (mockbuild@) #1 SMP\n", want: true},
 		{name: "rebuilt RHEL 8 with stripped localversion", content: "Linux version 4.18.0 (root@buildkitsandbox) (gcc version 8.5.0 20210514 (Red Hat 8.5.0-28) (GCC)) #1 SMP\n", want: true},
-		// Fedora's Red Hat gcc banner matches too — harmless false positive: Fedora kernels are >= 5.8 so general min passes either way.
+		// Fedora gcc banner matches; harmless since Fedora kernels are >= 5.8.
 		{name: "Fedora with Red Hat gcc (cosmetic false positive)", content: "Linux version 5.14.10-300.fc35.x86_64 (mockbuild) (gcc (GCC) 11.2.1 20210728 (Red Hat 11.2.1-1))\n", want: true},
 		{name: "Ubuntu", content: "Linux version 5.15.0-92-generic (buildd@bos03-amd64-003) (gcc-11)\n", want: false},
 		{name: "Debian", content: "Linux version 6.1.0-13-amd64 (debian-kernel@lists.debian.org) (gcc-12)\n", want: false},


### PR DESCRIPTION
## Summary

[detect RHEL kernels from /proc/version](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/8e8de4f557eae252c97fd4ba386fccccc4e7097a)
[reduce tpinjector verifier complexity](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/b36c4bf858dbd05617b3f2bb043f7a6deb9dc4ea)
[drop ringbuf debug events from rdns XDP debug prints](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/166291c44d019402bca76e044cbe02d4b721c0f7)
[bind-mount weaver report](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/75c350ac13d7277e6ed05d6fd89b9b29b5a76ae0)
[enable RHEL verifier matrix and polish VM workflows](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/commit/c174d7a395bf56fce82245dbd9c59f5c160ff4e5)

best reviewed by commit

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
