### PR TITLE
Update to LLVM22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ IMG ?= $(IMG_REGISTRY)/$(IMG_ORG)/$(IMG_NAME):$(VERSION)
 
 # The generator is a container image that provides a reproducible environment for
 # building eBPF binaries
-GEN_IMG ?= ghcr.io/open-telemetry/obi-generator:0.2.13
+GEN_IMG ?= ghcr.io/open-telemetry/obi-generator:0.2.14
 
 OCI_BIN ?= docker
 

--- a/bpf/common/trace_util.h
+++ b/bpf/common/trace_util.h
@@ -69,13 +69,24 @@ static __always_inline void encode_hex(unsigned char *dst, const unsigned char *
 }
 
 static __always_inline bool is_traceparent(const unsigned char *p) {
-    if (((p[0] == 'T') || (p[0] == 't')) && (p[1] == 'r') && (p[2] == 'a') && (p[3] == 'c') &&
-        (p[4] == 'e') && ((p[5] == 'p') || (p[5] == 'P')) && (p[6] == 'a') && (p[7] == 'r') &&
-        (p[8] == 'e') && (p[9] == 'n') && (p[10] == 't') && (p[11] == ':') && (p[12] == ' ')) {
-        return true;
+    if ((p[0] | 0x20) != 't') {
+        return false;
     }
 
-    return false;
+    u64 w0;
+    __builtin_memcpy(&w0, p, sizeof(w0)); // "Tracepar"
+    u32 w1;
+    __builtin_memcpy(&w1, p + 8, sizeof(w1)); // "ent:"
+    u8 w2 = p[12];                            // " "
+
+    w0 |= 0x2020202020202020ULL;
+    w1 |= 0x20202020U;
+
+    const u64 want0 = 't' | ('r' << 8) | ('a' << 16) | ((u64)'c' << 24) | ((u64)'e' << 32) |
+                      ((u64)'p' << 40) | ((u64)'a' << 48) | ((u64)'r' << 56);
+    const u32 want1 = 'e' | ('n' << 8) | ('t' << 16) | (':' << 24);
+
+    return ((w0 ^ want0) | (w1 ^ want1) | (u8)(w2 ^ ' ')) == 0;
 }
 
 static __always_inline bool is_eoh(const unsigned char *p) {

--- a/bpf/common/trace_util.h
+++ b/bpf/common/trace_util.h
@@ -69,24 +69,13 @@ static __always_inline void encode_hex(unsigned char *dst, const unsigned char *
 }
 
 static __always_inline bool is_traceparent(const unsigned char *p) {
-    if ((p[0] | 0x20) != 't') {
-        return false;
+    if (((p[0] == 'T') || (p[0] == 't')) && (p[1] == 'r') && (p[2] == 'a') && (p[3] == 'c') &&
+        (p[4] == 'e') && ((p[5] == 'p') || (p[5] == 'P')) && (p[6] == 'a') && (p[7] == 'r') &&
+        (p[8] == 'e') && (p[9] == 'n') && (p[10] == 't') && (p[11] == ':') && (p[12] == ' ')) {
+        return true;
     }
 
-    u64 w0;
-    __builtin_memcpy(&w0, p, sizeof(w0)); // "Tracepar"
-    u32 w1;
-    __builtin_memcpy(&w1, p + 8, sizeof(w1)); // "ent:"
-    u8 w2 = p[12];                            // " "
-
-    w0 |= 0x2020202020202020ULL;
-    w1 |= 0x20202020U;
-
-    const u64 want0 = 't' | ('r' << 8) | ('a' << 16) | ((u64)'c' << 24) | ((u64)'e' << 32) |
-                      ((u64)'p' << 40) | ((u64)'a' << 48) | ((u64)'r' << 56);
-    const u32 want1 = 'e' | ('n' << 8) | ('t' << 16) | (':' << 24);
-
-    return ((w0 ^ want0) | (w1 ^ want1) | (u8)(w2 ^ ' ')) == 0;
+    return false;
 }
 
 static __always_inline bool is_eoh(const unsigned char *p) {

--- a/bpf/gotracer/types/otel_types.h
+++ b/bpf/gotracer/types/otel_types.h
@@ -12,8 +12,6 @@
 
 #include <common/common.h>
 
-#include <logger/bpf_dbg.h>
-
 volatile const u64 attr_type_invalid;
 
 volatile const u64 attr_type_bool;
@@ -39,7 +37,6 @@ static __always_inline bool set_attr_value(otel_attribute_t *attr,
     // String values
     if (vtype == attr_type_string) {
         if (go_attr_value->string.len >= OTEL_ATTRIBUTE_VALUE_MAX_LEN) {
-            bpf_dbg_printk("Attribute string value is too long");
             return false;
         }
         const long res =
@@ -88,7 +85,6 @@ convert_go_otel_attributes(void *attrs_buf, u64 slice_len, otel_attributes_t *en
         bpf_probe_read_user(&go_str, sizeof(struct go_string), &go_attr[go_attr_index].key);
         if (go_str.len >= OTEL_ATTRIBUTE_KEY_MAX_LEN) {
             // key string is too large
-            bpf_dbg_printk("Attribute key string is too long\n");
             continue;
         }
 

--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -9,7 +9,10 @@ ENV PROTOC_AARCH_64_SHA256="56af3fc2e43a0230802e6fadb621d890ba506c5c17a1ae1070f6
 
 ARG TARGETARCH
 
-RUN apk add clang llvm20 wget unzip curl make bash git
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+
+RUN apk add clang22 llvm22 wget unzip curl make bash git
 RUN apk cache purge
 
 COPY internal/tools/generator/ internal/tools/generator/
@@ -39,9 +42,9 @@ RUN --mount=type=cache,target=/go/pkg \
 
 RUN cat <<EOF > /generate.sh
 #!/bin/sh
-export PATH="/usr/lib/llvm20/bin:\$PATH"
+export PATH="/usr/lib/llvm22/bin:\$PATH"
 export BPF2GO=/go/bin/bpf2go
-export BPF_CLANG=clang
+export BPF_CLANG=clang-22
 export BPF_CFLAGS="-O2 -g -Wall -Werror"
 export GOCACHE=/tmp/go-build
 make generate


### PR DESCRIPTION
## Summary

Update the generator image to LLVM22.

LLVM22 generates code that trips 5.10. I traced this to a few `bpf_dbg_printk` inside loops, which I removed: bpf_dbg_printk inside loops are a bad idea, because they themselves carry branching, pointer tracking and ringbuffer flushes - none of which is desirable when a loop is being unrolled.

I'd avoid this pattern in the general case anyway, as it's not LLVM22 exclusive.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
