### PR TITLE
Pin VM test images by sha256 digest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,22 @@
       "/^\\.github\\/.*-requirements\\.txt$/"
     ]
   },
+  "customManagers": [
+    {
+      // Keep the LVH kernel images in internal/test/vm/kernels.yaml pinned to
+      // both a dated tag and the corresponding sha256 manifest digest. The
+      // tag is the human-readable handle; the digest is what `docker pull`
+      // actually resolves against (see lvh/pull-kernel.sh). Renovate updates
+      // both fields together whenever a newer tag is published on quay.io.
+      "customType": "regex",
+      "managerFilePatterns": ["/^internal\\/test\\/vm\\/kernels\\.yaml$/"],
+      "matchStrings": [
+        "lvh_tag:\\s+\"(?<currentValue>[^\"]+)\"\\s*\\n\\s*digest:\\s+\"(?<currentDigest>sha256:[a-f0-9]{64})\""
+      ],
+      "depNameTemplate": "quay.io/lvh-images/kernel-images",
+      "datasourceTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "description": "Run `go mod tidy` and rewrite import paths on any Go module update",
@@ -121,6 +137,14 @@
       "matchFileNames": ["internal/test/**"],
       "matchUpdateTypes": ["patch", "digest"],
       "enabled": false
+    },
+    {
+      "description": "Re-enable LVH kernel image updates: kernels.yaml is supply-chain-critical, must stay pinned to current dated tag + digest",
+      "matchFileNames": ["internal/test/vm/kernels.yaml"],
+      "matchPackageNames": ["quay.io/lvh-images/kernel-images"],
+      "enabled": true,
+      "groupName": "LVH kernel images",
+      "schedule": ["before 6am on Tuesday"]
     },
     {
       "description": "Disable Go 1.17 testserver updates",

--- a/internal/test/vm/kernels.yaml
+++ b/internal/test/vm/kernels.yaml
@@ -2,52 +2,68 @@
 #
 # All entries come from cilium/little-vm-helper-images
 # (quay.io/lvh-images/kernel-images:<lvh_tag>).
-# Pinned to dated tags for reproducibility.
+# Pulls are always content-addressed: every entry must carry both `lvh_tag`
+# (human-readable, used in paths/keys) and `digest` (what docker actually
+# resolves). This defends against an attacker re-pushing a dated LVH tag.
+# Renovate keeps both fields in sync; do not hand-edit one without the other.
 #
 # Fields:
 #   id              human-readable identifier (used in matrix output + paths)
 #   lvh_tag         exact LVH tag, e.g. "6.12-20260504.013701"
+#   digest          REQUIRED sha256 manifest digest for <lvh_tag> on quay.io,
+#                   format "sha256:<64-hex>". To regenerate manually:
+#                     docker buildx imagetools inspect \
+#                       quay.io/lvh-images/kernel-images:<lvh_tag> \
+#                       --format '{{json .Manifest.Digest}}'
 #   pr_integration  include in PR VM integration matrix
 #   pr_verifier     include in PR BPF verifier matrix
 
 kernels:
   - id: "5.10-lts"
     lvh_tag: "5.10-20260504.013701"
+    digest: "sha256:e01204a8fc968e148621cf83f56e69f3aa5ecc8257da0c1f6e1e35b45756a930"
     pr_integration: false
     pr_verifier: true
 
   - id: "5.15-lts"
     lvh_tag: "5.15-20260504.013701"
+    digest: "sha256:c24903a7e9ca7c701c9dfeb7e67615c5c14edeca7f3f38c70d5758a19c392ed1"
     pr_integration: true
     pr_verifier: true
 
   - id: "6.1-lts"
     lvh_tag: "6.1-20260504.013701"
+    digest: "sha256:82e880228dc876add1aa745482930977b70053a4a3308a56ebbc602c7efdb523"
     pr_integration: false
     pr_verifier: true
 
   - id: "6.6-lts"
     lvh_tag: "6.6-20260504.013701"
+    digest: "sha256:79d8ab575391293b02c466616eca0c54e8b01d063d4afcbd5eac7170aa191cf3"
     pr_integration: false
     pr_verifier: true
 
   - id: "6.12-lts"
     lvh_tag: "6.12-20260504.013701"
+    digest: "sha256:1d6101dd77c2c2cffe80fc6506c8700f55feddec46daf0112f62f21f2456af18"
     pr_integration: false
     pr_verifier: true
 
   - id: "6.18-lts"
     lvh_tag: "6.18-20260504.013701"
+    digest: "sha256:6958ecd1cd961786df693b7916cc0609e808cd1472938787c27643bf5a5f63a5"
     pr_integration: true
     pr_verifier: true
 
   - id: "bpf"
     lvh_tag: "bpf-20260504.013701"
+    digest: "sha256:21e872d793eae8a2dc479441ba5c469addb7d2952f12c2bd0b21ae357320aa95"
     pr_integration: false
     pr_verifier: true
 
   - id: "bpf-next"
     lvh_tag: "bpf-next-20260504.013701"
+    digest: "sha256:40231968a3ee126aac7de79a4bce0ec0cdf308d3562a7e0955f211e15c1ea0d8"
     pr_integration: false
     pr_verifier: true
 
@@ -57,15 +73,18 @@ kernels:
   # than 5.14+.
   - id: "rhel8.9"
     lvh_tag: "rhel8.9-20260504.013701"
+    digest: "sha256:1f13a2a66f66aeb0928aa500086ac73748dc2722d13cf2aa6924dbb1b063236a"
     pr_integration: false
     pr_verifier: false
 
   - id: "rhel8.10"
     lvh_tag: "rhel8.10-20260504.013701"
+    digest: "sha256:78f0c417577c1bcdd994496f7da36585e17da19c93b59d4a16b9b39a891a7328"
     pr_integration: false
     pr_verifier: false
 
   - id: "rhel9.6"
     lvh_tag: "rhel9.6-20260504.013701"
+    digest: "sha256:0671573da156d1370aad031e67b20a0aa879bd392425e189523897daf74fdbeb"
     pr_integration: false
     pr_verifier: true

--- a/internal/test/vm/lvh/pull-kernel.sh
+++ b/internal/test/vm/lvh/pull-kernel.sh
@@ -13,6 +13,10 @@
 #   OBI_KERNELS_YAML  path to kernels.yaml (default: ../kernels.yaml relative to this script)
 #   OUT_DIR           output directory (default: ./out)
 #
+# Every kernels.yaml entry MUST carry a `digest: "sha256:<64-hex>"` field;
+# pulls are always content-addressed against quay.io to defend against an
+# attacker re-pushing a dated LVH tag. Renovate keeps the digests fresh.
+#
 # Outputs in $OUT_DIR:
 #   vmlinuz-${id}-${arch}                  (kernel image)
 #   vmlinuz-${id}-${arch}.config           (kernel config)
@@ -44,9 +48,19 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 LVH_TAG=$(yq ".kernels[] | select(.id == \"${KERNEL_ID}\") | .lvh_tag // \"\"" "$OBI_KERNELS_YAML")
+LVH_DIGEST=$(yq ".kernels[] | select(.id == \"${KERNEL_ID}\") | .digest // \"\"" "$OBI_KERNELS_YAML")
 
 if [ -z "$LVH_TAG" ] || [ "$LVH_TAG" = "null" ]; then
     echo "pull-kernel.sh: kernel id '${KERNEL_ID}' missing or has no lvh_tag in ${OBI_KERNELS_YAML}" >&2
+    exit 1
+fi
+
+if [ -z "$LVH_DIGEST" ] || [ "$LVH_DIGEST" = "null" ]; then
+    echo "pull-kernel.sh: kernel id '${KERNEL_ID}' has no digest in ${OBI_KERNELS_YAML} (every entry must pin sha256:<64-hex>)" >&2
+    exit 1
+fi
+if ! [[ "$LVH_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "pull-kernel.sh: invalid digest format for kernel id '${KERNEL_ID}': '${LVH_DIGEST}' (want sha256:<64-hex>)" >&2
     exit 1
 fi
 
@@ -54,11 +68,12 @@ mkdir -p "$OUT_DIR"
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"; docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
 
-IMAGE="${LVH_REGISTRY}:${LVH_TAG}"
-echo "pull-kernel.sh: pulling ${IMAGE} (${DOCKER_PLATFORM})" >&2
-docker pull --quiet --platform "$DOCKER_PLATFORM" "$IMAGE" >&2
+PULL_REF="${LVH_REGISTRY}@${LVH_DIGEST}"
+IMAGE="${LVH_REGISTRY}:${LVH_TAG}@${LVH_DIGEST}"
+echo "pull-kernel.sh: pulling ${PULL_REF} (${DOCKER_PLATFORM})" >&2
+docker pull --quiet --platform "$DOCKER_PLATFORM" "$PULL_REF" >&2
 
-CID="$(docker create --platform "$DOCKER_PLATFORM" "$IMAGE")"
+CID="$(docker create --platform "$DOCKER_PLATFORM" "$PULL_REF")"
 docker cp "${CID}:/data" "${WORKDIR}/" >&2
 
 KVER_DIR="$(ls -d ${WORKDIR}/data/kernels/*/ | head -1)"
@@ -96,6 +111,7 @@ cat > "${OUT_DIR}/${ART_BASE}.buildinfo" <<EOF
   "kernel_branch": "${KVER}",
   "source": "lvh",
   "lvh_tag": "${LVH_TAG}",
+  "lvh_digest": "${LVH_DIGEST}",
   "lvh_image": "${IMAGE}",
   "target_arch": "${ARCH}",
   "pulled_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",


### PR DESCRIPTION
## Summary

For security enforcement, makes the usage of digests in VM test images.

- Makes `digest:` mandatory in `kernels.yaml`; `pull-kernel.sh` always pulls `quay.io/lvh-images/kernel-images@sha256:...` so a re-pushed dated tag can't smuggle a different kernel into VM CI.
- Populate digests for all current entries (fetched from quay.io).
- Teach Renovate to keep the (tag, digest) pairs in sync via a regex customManager, with a packageRule override so the blanket `internal/test/**` no-digest rule doesn't silence it.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
