### PR TITLE
ci: sample bpftool during integration tests

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -135,14 +135,14 @@ jobs:
       - name: Install bpftool (PoC eBPF metrics)
         run: |
           sudo apt-get update
-          sudo apt-get install -y linux-tools-common linux-tools-generic jq
-          if ! command -v bpftool >/dev/null 2>&1; then
-            BPFTOOL_BIN=$(find /usr/lib/linux-tools -maxdepth 2 -name bpftool -type f | head -n1)
-            if [ -n "$BPFTOOL_BIN" ]; then
-              sudo ln -sf "$BPFTOOL_BIN" /usr/local/sbin/bpftool
-            fi
+          sudo apt-get install -y linux-tools-generic jq
+          BPFTOOL_BIN=$(find /usr/lib/linux-tools -maxdepth 2 -name bpftool -type f | head -n1)
+          if [ -z "$BPFTOOL_BIN" ]; then
+            echo "Could not find bpftool binary under /usr/lib/linux-tools" >&2
+            exit 1
           fi
-          sudo bpftool version
+          sudo ln -sf "$BPFTOOL_BIN" /usr/local/sbin/bpftool
+          sudo /usr/local/sbin/bpftool version
 
       - name: Start bpftool sampler (PoC eBPF metrics)
         env:

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -136,11 +136,15 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y linux-tools-generic jq
-          BPFTOOL_BIN=$(find /usr/lib/linux-tools -maxdepth 2 -name bpftool -type f | head -n1)
+          BPFTOOL_BIN=$(find /usr/lib -maxdepth 3 -name bpftool 2>/dev/null \
+            | grep linux-tools | head -n1)
           if [ -z "$BPFTOOL_BIN" ]; then
-            echo "Could not find bpftool binary under /usr/lib/linux-tools" >&2
+            echo "Could not find bpftool binary. Diagnostics:" >&2
+            dpkg -l | grep linux-tools >&2 || true
+            find /usr/lib -maxdepth 3 -name bpftool 2>/dev/null >&2 || true
             exit 1
           fi
+          echo "Using bpftool: $BPFTOOL_BIN"
           sudo ln -sf "$BPFTOOL_BIN" /usr/local/sbin/bpftool
           sudo /usr/local/sbin/bpftool version
 

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -199,7 +199,15 @@ jobs:
         if: always()
         env:
           BPF_SAMPLE_DIR: /tmp/bpfsamples
-        run: bash ./scripts/bpf-metrics-summary.sh "$BPF_SAMPLE_DIR" || true
+          MATRIX_ID: ${{ matrix.id }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          TEST_LOG="/home/runner/reports/test-run-${RUN_NUMBER}-${MATRIX_ID}.log"
+          ARGS=(--in "$BPF_SAMPLE_DIR" --shard "$MATRIX_ID" --out-json "$BPF_SAMPLE_DIR/summary.json")
+          if [ -f "$TEST_LOG" ]; then
+            ARGS+=(--testlog "$TEST_LOG")
+          fi
+          bash ./scripts/bpf-metrics-summary.sh "${ARGS[@]}" || true
 
       - name: Upload eBPF metrics snapshots (PoC)
         if: always()
@@ -261,19 +269,27 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq
 
+      # Match only numeric shard IDs so this job's own aggregate artifact
+      # (uploaded later in this same job on reruns sharing a run_number)
+      # is not pulled back in.
       - name: Download per-shard eBPF metrics artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: bpf-metrics-*-${{ github.run_number }}
+          pattern: bpf-metrics-[0-9]*-${{ github.run_number }}
           path: ./all-shards
 
       - name: Aggregate and emit summary
-        run: bash ./scripts/bpf-metrics-aggregate.sh ./all-shards /tmp/bpf-metrics-aggregate.md
+        run: |
+          mkdir -p /tmp/bpf-aggregate
+          bash ./scripts/bpf-metrics-aggregate.sh \
+            --in ./all-shards \
+            --out-md /tmp/bpf-aggregate/aggregate.md \
+            --out-json /tmp/bpf-aggregate/aggregate.json
 
       - name: Upload aggregated summary
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bpf-metrics-aggregate-${{ github.run_number }}
-          path: /tmp/bpf-metrics-aggregate.md
+          path: /tmp/bpf-aggregate/
           retention-days: 30

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -132,6 +132,29 @@ jobs:
       - name: Check disk usage before tests
         run: df -h
 
+      - name: Install bpftool (PoC eBPF metrics)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y linux-tools-common linux-tools-generic jq
+          if ! command -v bpftool >/dev/null 2>&1; then
+            BPFTOOL_BIN=$(find /usr/lib/linux-tools -maxdepth 2 -name bpftool -type f | head -n1)
+            if [ -n "$BPFTOOL_BIN" ]; then
+              sudo ln -sf "$BPFTOOL_BIN" /usr/local/sbin/bpftool
+            fi
+          fi
+          sudo bpftool version
+
+      - name: Start bpftool sampler (PoC eBPF metrics)
+        env:
+          BPF_SAMPLE_DIR: /tmp/bpfsamples
+          BPF_SAMPLE_INTERVAL: "2"
+        run: |
+          mkdir -p "$BPF_SAMPLE_DIR"
+          nohup bash ./scripts/bpf-metrics-sampler.sh "$BPF_SAMPLE_DIR" "$BPF_SAMPLE_INTERVAL" \
+            >"$BPF_SAMPLE_DIR/sampler.log" 2>&1 &
+          echo $! > "$BPF_SAMPLE_DIR/sampler.pid"
+          echo "Sampler started, PID $(cat "$BPF_SAMPLE_DIR/sampler.pid")"
+
       - name: Run integration tests
         env:
           MATRIX_ID: ${{ matrix.id }}
@@ -155,6 +178,32 @@ jobs:
               --jsonfile=/home/runner/reports/test-run-"${RUN_NUMBER}"-"${MATRIX_ID}".log \
               -- -race -count=1 -timeout 40m \
               -run="^(${MATRIX_TEST_PATTERN})$" ./internal/test/integration
+
+      - name: Stop bpftool sampler (PoC eBPF metrics)
+        if: always()
+        env:
+          BPF_SAMPLE_DIR: /tmp/bpfsamples
+        run: |
+          if [ -f "$BPF_SAMPLE_DIR/sampler.pid" ]; then
+            kill "$(cat "$BPF_SAMPLE_DIR/sampler.pid")" 2>/dev/null || true
+          fi
+          shopt -s nullglob
+          snaps=("$BPF_SAMPLE_DIR"/snap-*.json)
+          echo "Sample count: ${#snaps[@]}"
+
+      - name: Build eBPF metrics summary (PoC)
+        if: always()
+        env:
+          BPF_SAMPLE_DIR: /tmp/bpfsamples
+        run: bash ./scripts/bpf-metrics-summary.sh "$BPF_SAMPLE_DIR" || true
+
+      - name: Upload eBPF metrics snapshots (PoC)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bpf-metrics-${{ matrix.id }}-${{ github.run_number }}
+          path: /tmp/bpfsamples/
+          retention-days: 5
 
       - name: Process coverage data
         run: make itest-coverage-data
@@ -188,3 +237,39 @@ jobs:
       - name: Check final disk usage
         if: always()
         run: df -h
+
+  bpf-metrics-aggregate:
+    name: Aggregate eBPF metrics (PoC)
+    needs: [test]
+    # Run after the matrix completes, including when shards fail, but skip
+    # entirely if the matrix was cancelled or skipped (nothing to aggregate).
+    if: ${{ !cancelled() && (needs.test.result == 'success' || needs.test.result == 'failure') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Download per-shard eBPF metrics artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: bpf-metrics-*-${{ github.run_number }}
+          path: ./all-shards
+
+      - name: Aggregate and emit summary
+        run: bash ./scripts/bpf-metrics-aggregate.sh ./all-shards /tmp/bpf-metrics-aggregate.md
+
+      - name: Upload aggregated summary
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bpf-metrics-aggregate-${{ github.run_number }}
+          path: /tmp/bpf-metrics-aggregate.md
+          retention-days: 30

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -189,7 +189,19 @@ jobs:
           BPF_SAMPLE_DIR: /tmp/bpfsamples
         run: |
           if [ -f "$BPF_SAMPLE_DIR/sampler.pid" ]; then
-            kill "$(cat "$BPF_SAMPLE_DIR/sampler.pid")" 2>/dev/null || true
+            SAMPLER_PID=$(cat "$BPF_SAMPLE_DIR/sampler.pid")
+            kill "$SAMPLER_PID" 2>/dev/null || true
+            # Wait up to 5s for SIGTERM handler + EXIT trap to finish so the
+            # summary doesn't read snapshots mid-write and the sysctl gets
+            # restored. Force kill if it overruns.
+            for _ in $(seq 1 50); do
+              kill -0 "$SAMPLER_PID" 2>/dev/null || break
+              sleep 0.1
+            done
+            if kill -0 "$SAMPLER_PID" 2>/dev/null; then
+              echo "Sampler $SAMPLER_PID did not exit after 5s; sending SIGKILL"
+              kill -9 "$SAMPLER_PID" 2>/dev/null || true
+            fi
           fi
           shopt -s nullglob
           snaps=("$BPF_SAMPLE_DIR"/snap-*.json)

--- a/scripts/bpf-metrics-aggregate.sh
+++ b/scripts/bpf-metrics-aggregate.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # PoC: aggregate per-shard bpftool snapshot directories into one summary.
 #
 # Expects an input dir containing one subdirectory per shard, each holding

--- a/scripts/bpf-metrics-aggregate.sh
+++ b/scripts/bpf-metrics-aggregate.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# PoC: aggregate per-shard bpftool snapshot directories into one summary.
+#
+# Expects an input dir containing one subdirectory per shard, each holding
+# snap-*.json files (as produced by bpf-metrics-sampler.sh). The standard
+# layout from actions/download-artifact with no `name:` filter is:
+#   <in_dir>/bpf-metrics-<shard_id>-<run>/snap-*.json
+#
+# Emits markdown to $GITHUB_STEP_SUMMARY (or stdout) and writes a copy to
+# <out_file> for upload as a workflow-level artifact.
+#
+# Usage: ./scripts/bpf-metrics-aggregate.sh <in_dir> <out_file>
+#
+# NOTE: This sums bytes_memlock across ALL eBPF objects on the runner, not
+# just OBI's. See bpf-metrics-summary.sh for the same caveat.
+set -euo pipefail
+
+IN_DIR="${1:-./all-shards}"
+OUT_FILE="${2:-/tmp/bpf-metrics-aggregate.md}"
+
+: > "$OUT_FILE"
+
+emit() {
+  printf '%s\n' "$1" >> "$OUT_FILE"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+shopt -s nullglob
+shard_dirs=("$IN_DIR"/bpf-metrics-*)
+
+if [ ${#shard_dirs[@]} -eq 0 ]; then
+  emit "## eBPF metrics (aggregate)"
+  emit ""
+  emit "_No per-shard artifacts found under \`$IN_DIR\`._"
+  exit 0
+fi
+
+emit "## eBPF metrics — aggregate across ${#shard_dirs[@]} shards"
+emit ""
+emit "| shard | snapshots | peak memlock (bytes) | peak memlock (MiB) | maps@peak | progs@peak |"
+emit "| --- | ---: | ---: | ---: | ---: | ---: |"
+
+best_total=-1
+best_shard=""
+best_snapshot=""
+
+for shard_dir in "${shard_dirs[@]}"; do
+  shard_name=$(basename "$shard_dir")
+  # Strip the bpf-metrics- prefix and the trailing -<run> suffix for display.
+  shard_label=${shard_name#bpf-metrics-}
+  shard_label=${shard_label%-*}
+
+  snapshots=("$shard_dir"/snap-*.json)
+  if [ ${#snapshots[@]} -eq 0 ]; then
+    emit "| $shard_label | 0 | n/a | n/a | n/a | n/a |"
+    continue
+  fi
+
+  shard_peak_snap=""
+  shard_peak_total=-1
+  for f in "${snapshots[@]}"; do
+    total=$(jq '[.maps[]?.bytes_memlock // 0] | add // 0' "$f" 2>/dev/null || echo 0)
+    if [ "$total" -gt "$shard_peak_total" ]; then
+      shard_peak_total=$total
+      shard_peak_snap=$f
+    fi
+  done
+
+  maps_at_peak=$(jq '.maps | length' "$shard_peak_snap")
+  progs_at_peak=$(jq '.progs | length' "$shard_peak_snap")
+  mib=$(awk -v t="$shard_peak_total" 'BEGIN{printf "%.2f", t/1024/1024}')
+
+  emit "| $shard_label | ${#snapshots[@]} | $shard_peak_total | $mib | $maps_at_peak | $progs_at_peak |"
+
+  if [ "$shard_peak_total" -gt "$best_total" ]; then
+    best_total=$shard_peak_total
+    best_shard=$shard_label
+    best_snapshot=$shard_peak_snap
+  fi
+done
+
+emit ""
+
+if [ -z "$best_snapshot" ]; then
+  emit "_No snapshots contained map data._"
+  exit 0
+fi
+
+best_mib=$(awk -v t="$best_total" 'BEGIN{printf "%.2f", t/1024/1024}')
+emit "### Overall peak: shard \`$best_shard\` — **$best_total** bytes ($best_mib MiB)"
+emit ""
+emit "Snapshot: \`$(basename "$best_snapshot")\` from \`$best_shard\`"
+emit ""
+emit "#### Top 20 maps by \`bytes_memlock\` at overall peak"
+emit ""
+emit "| name | type | max_entries | bytes_memlock |"
+emit "| --- | --- | ---: | ---: |"
+
+while IFS= read -r line; do emit "$line"; done < <(jq -r '
+  .maps
+  | map({
+      name: (.name // "<unnamed>"),
+      type: (.type // "?"),
+      max_entries: (.max_entries // 0),
+      bytes_memlock: (.bytes_memlock // 0)
+    })
+  | sort_by(-.bytes_memlock)
+  | .[0:20]
+  | .[]
+  | "| \(.name) | \(.type) | \(.max_entries) | \(.bytes_memlock) |"
+' "$best_snapshot")
+
+emit ""
+emit "#### Top 10 programs by \`run_time_ns\` at overall peak"
+emit ""
+emit "| name | type | run_cnt | run_time_ns |"
+emit "| --- | --- | ---: | ---: |"
+
+while IFS= read -r line; do emit "$line"; done < <(jq -r '
+  .progs
+  | map({
+      name: (.name // "<unnamed>"),
+      type: (.type // "?"),
+      run_cnt: (.run_cnt // 0),
+      run_time_ns: (.run_time_ns // 0)
+    })
+  | sort_by(-.run_time_ns)
+  | .[0:10]
+  | .[]
+  | "| \(.name) | \(.type) | \(.run_cnt) | \(.run_time_ns) |"
+' "$best_snapshot")

--- a/scripts/bpf-metrics-aggregate.sh
+++ b/scripts/bpf-metrics-aggregate.sh
@@ -64,20 +64,44 @@ MERGED_JSON=$(jq -s '
     suites: (
       [.[] | .shard as $sh | .suites[]? | . + {shard: $sh}]
       | group_by(.name)
+      | map(
+          sort_by(-.peak_bytes) as $by_peak
+          | {
+              name: $by_peak[0].name,
+              peak_bytes: $by_peak[0].peak_bytes,
+              peak_shard: $by_peak[0].shard,
+              peak_duration_s: $by_peak[0].duration_s,
+              peak_snapshots_in_window: $by_peak[0].snapshots_in_window,
+              peak_series: $by_peak[0].series,
+              peak_result: $by_peak[0].result
+            }
+        )
+      | sort_by(-.peak_bytes)
+    ),
+    peak_maps: (
+      [.[] | .peak.maps_grouped[]?]
+      | group_by(.name)
       | map({
           name: .[0].name,
-          observations: length,
-          peak_bytes: ([.[].peak_bytes] | max),
-          peak_shard: (sort_by(-.peak_bytes) | .[0].shard),
-          total_snapshots_in_window: ([.[].snapshots_in_window] | add),
-          per_shard: map({
-            shard: .shard,
-            peak_bytes: .peak_bytes,
-            snapshots_in_window: .snapshots_in_window,
-            series: .series
-          })
+          type: .[0].type,
+          max_total_memlock: ([.[].total_memlock] | max),
+          max_count: ([.[].count] | max),
+          max_entries: ([.[].max_entries] | max),
+          observed_in_shards: length
         })
-      | sort_by(-.peak_bytes)
+      | sort_by(-.max_total_memlock)
+    ),
+    peak_progs: (
+      [.[] | .peak.progs_grouped[]?]
+      | group_by(.name)
+      | map({
+          name: .[0].name,
+          type: .[0].type,
+          max_total_run_time_ns: ([.[].total_run_time_ns] | max),
+          max_total_run_cnt: ([.[].total_run_cnt] | max),
+          observed_in_shards: length
+        })
+      | sort_by(-.max_total_run_time_ns)
     )
   }
 ' "${summaries[@]}")
@@ -137,10 +161,10 @@ sparkline_from_json() {
 if [ "$total_suites" -gt 0 ]; then
   emit "### Top suites by peak memlock (across all shards)"
   emit ""
-  emit "Sparkline shows the per-shard peak series for the suite, ordered by shard."
+  emit "Each suite only runs on one shard. \`peak shard\` is where it ran. \`trend\` is the in-shard sampler series for that suite."
   emit ""
-  emit "| suite | peak memlock (MiB) | peak shard | shards seen | trend across shards |"
-  emit "| --- | ---: | --- | ---: | --- |"
+  emit "| suite | duration (s) | peak memlock (MiB) | peak shard | trend |"
+  emit "| --- | ---: | ---: | --- | --- |"
 
   rows=$(jq -r '
     .suites
@@ -148,17 +172,58 @@ if [ "$total_suites" -gt 0 ]; then
     | .[]
     | [
         .name,
+        (.peak_duration_s // 0),
         (.peak_bytes / 1024 / 1024 * 100 | round / 100),
         .peak_shard,
-        .observations,
-        ([.per_shard | sort_by(.shard) | .[] | .peak_bytes] | tojson)
+        (.peak_series | tojson)
       ] | @tsv
   ' <<< "$MERGED_JSON")
 
-  while IFS=$'\t' read -r name peak_mib shard observations series; do
+  while IFS=$'\t' read -r name duration_s peak_mib shard series; do
     spark=$(sparkline_from_json <<< "$series")
-    emit "| \`$name\` | $peak_mib | $shard | $observations | $spark |"
+    emit "| \`$name\` | $duration_s | $peak_mib | $shard | $spark |"
   done <<< "$rows"
+  emit ""
+fi
+
+# Cross-shard top-N maps & progs: max value per name across all shards' peaks.
+peak_map_count=$(jq -r '.peak_maps | length' <<< "$MERGED_JSON")
+if [ "$peak_map_count" -gt 0 ]; then
+  emit "<details><summary>Top 20 maps at peak (max across all shards)</summary>"
+  emit ""
+  emit "_Per-name max of the \`total bytes_memlock\` observed in any shard's peak snapshot. \`observed in N shards\` indicates how many shards saw the map at all._"
+  emit ""
+  emit "| name | type | max total bytes_memlock (MiB) | max instances per shard | max_entries | observed in N shards |"
+  emit "| --- | --- | ---: | ---: | ---: | ---: |"
+
+  while IFS= read -r line; do emit "$line"; done < <(jq -r '
+    .peak_maps
+    | .[0:20]
+    | .[]
+    | "| \(.name) | \(.type) | \((.max_total_memlock / 1024 / 1024 * 100 | round / 100)) | \(.max_count) | \(.max_entries) | \(.observed_in_shards) |"
+  ' <<< "$MERGED_JSON")
+
+  emit ""
+  emit "</details>"
+  emit ""
+fi
+
+peak_prog_count=$(jq -r '.peak_progs | length' <<< "$MERGED_JSON")
+if [ "$peak_prog_count" -gt 0 ]; then
+  emit "<details><summary>Top 10 programs at peak (max run_time_ns across all shards)</summary>"
+  emit ""
+  emit "| name | type | max run_time_ns | max run_cnt | observed in N shards |"
+  emit "| --- | --- | ---: | ---: | ---: |"
+
+  while IFS= read -r line; do emit "$line"; done < <(jq -r '
+    .peak_progs
+    | .[0:10]
+    | .[]
+    | "| \(.name) | \(.type) | \(.max_total_run_time_ns) | \(.max_total_run_cnt) | \(.observed_in_shards) |"
+  ' <<< "$MERGED_JSON")
+
+  emit ""
+  emit "</details>"
   emit ""
 fi
 
@@ -167,7 +232,7 @@ emit ""
 emit "- **memlock** is the bytes the kernel locks on behalf of an eBPF map (\`bpftool map show -j\` → \`bytes_memlock\`). It tracks closely with map sizing in the source."
 emit "- **Map names** are truncated to 15 characters by the kernel's \`BPF_OBJ_NAME_LEN\`."
 emit "- **Per-suite attribution** intersects the per-shard sampler timeline with gotestsum's test-event log. Snapshots that fall inside a top-level test's run-to-pass window are attributed to that suite. Peak values include any concurrent residue from prior tests whose teardown is still in flight, so treat absolute numbers as upper bounds, not minimums."
-emit "- **Trend** sparklines encode the per-shard peak series for that suite, ordered by shard label, using 8 unicode block heights."
+emit "- **Trend** sparklines on the suite table show the in-shard sampler series during that suite's run window."
 emit ""
 emit "</details>"
 

--- a/scripts/bpf-metrics-aggregate.sh
+++ b/scripts/bpf-metrics-aggregate.sh
@@ -2,135 +2,175 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# PoC: aggregate per-shard bpftool snapshot directories into one summary.
+# PoC: aggregate per-shard summary JSON sidecars (produced by
+# bpf-metrics-summary.sh --out-json) into a single workflow-level report.
 #
-# Expects an input dir containing one subdirectory per shard, each holding
-# snap-*.json files (as produced by bpf-metrics-sampler.sh). The standard
-# layout from actions/download-artifact with no `name:` filter is:
-#   <in_dir>/bpf-metrics-<shard_id>-<run>/snap-*.json
+# Usage:
+#   bpf-metrics-aggregate.sh --in <dir-of-shard-dirs> --out-md <file> --out-json <file>
 #
-# Emits markdown to $GITHUB_STEP_SUMMARY (or stdout) and writes a copy to
-# <out_file> for upload as a workflow-level artifact.
-#
-# Usage: ./scripts/bpf-metrics-aggregate.sh <in_dir> <out_file>
-#
-# NOTE: This sums bytes_memlock across ALL eBPF objects on the runner, not
-# just OBI's. See bpf-metrics-summary.sh for the same caveat.
+# Input layout (as produced by actions/download-artifact with a pattern):
+#   <in>/bpf-metrics-<shard>-<run>/summary.json
+#   <in>/bpf-metrics-<shard>-<run>/snap-*.json (ignored here)
+
 set -euo pipefail
 
-IN_DIR="${1:-./all-shards}"
-OUT_FILE="${2:-/tmp/bpf-metrics-aggregate.md}"
+IN_DIR=""
+OUT_MD=""
+OUT_JSON=""
 
-: > "$OUT_FILE"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --in) IN_DIR="$2"; shift 2 ;;
+    --out-md) OUT_MD="$2"; shift 2 ;;
+    --out-json) OUT_JSON="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+IN_DIR="${IN_DIR:-./all-shards}"
+OUT_MD="${OUT_MD:-/tmp/bpf-metrics-aggregate.md}"
+
+: > "$OUT_MD"
 
 emit() {
-  printf '%s\n' "$1" >> "$OUT_FILE"
+  printf '%s\n' "$1" >> "$OUT_MD"
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
   fi
 }
 
 shopt -s nullglob
-shard_dirs=("$IN_DIR"/bpf-metrics-*)
+summaries=("$IN_DIR"/*/summary.json)
 
-if [ ${#shard_dirs[@]} -eq 0 ]; then
-  emit "## eBPF metrics (aggregate)"
+if [ ${#summaries[@]} -eq 0 ]; then
+  emit "## bpftool aggregate"
   emit ""
-  emit "_No per-shard artifacts found under \`$IN_DIR\`._"
+  emit "_No per-shard summary JSON sidecars found under \`$IN_DIR\`._"
+  if [ -n "$OUT_JSON" ]; then
+    printf '{"shards":0,"suites":[]}\n' > "$OUT_JSON"
+  fi
   exit 0
 fi
 
-emit "## eBPF metrics — aggregate across ${#shard_dirs[@]} shards"
+MERGED_JSON=$(jq -s '
+  {
+    shards: length,
+    per_shard: map({
+      shard: .shard,
+      snapshots: .snapshots,
+      window: .window,
+      peak: .peak
+    }),
+    suites: (
+      [.[] | .shard as $sh | .suites[]? | . + {shard: $sh}]
+      | group_by(.name)
+      | map({
+          name: .[0].name,
+          observations: length,
+          peak_bytes: ([.[].peak_bytes] | max),
+          peak_shard: (sort_by(-.peak_bytes) | .[0].shard),
+          total_snapshots_in_window: ([.[].snapshots_in_window] | add),
+          per_shard: map({
+            shard: .shard,
+            peak_bytes: .peak_bytes,
+            snapshots_in_window: .snapshots_in_window,
+            series: .series
+          })
+        })
+      | sort_by(-.peak_bytes)
+    )
+  }
+' "${summaries[@]}")
+
+emit "## bpftool aggregate"
 emit ""
-emit "| shard | snapshots | peak memlock (bytes) | peak memlock (MiB) | maps@peak | progs@peak |"
-emit "| --- | ---: | ---: | ---: | ---: | ---: |"
-
-best_total=-1
-best_shard=""
-best_snapshot=""
-
-for shard_dir in "${shard_dirs[@]}"; do
-  shard_name=$(basename "$shard_dir")
-  # Strip the bpf-metrics- prefix and the trailing -<run> suffix for display.
-  shard_label=${shard_name#bpf-metrics-}
-  shard_label=${shard_label%-*}
-
-  snapshots=("$shard_dir"/snap-*.json)
-  if [ ${#snapshots[@]} -eq 0 ]; then
-    emit "| $shard_label | 0 | n/a | n/a | n/a | n/a |"
-    continue
-  fi
-
-  shard_peak_snap=""
-  shard_peak_total=-1
-  for f in "${snapshots[@]}"; do
-    total=$(jq '[.maps[]?.bytes_memlock // 0] | add // 0' "$f" 2>/dev/null || echo 0)
-    if [ "$total" -gt "$shard_peak_total" ]; then
-      shard_peak_total=$total
-      shard_peak_snap=$f
-    fi
-  done
-
-  maps_at_peak=$(jq '.maps | length' "$shard_peak_snap")
-  progs_at_peak=$(jq '.progs | length' "$shard_peak_snap")
-  mib=$(awk -v t="$shard_peak_total" 'BEGIN{printf "%.2f", t/1024/1024}')
-
-  emit "| $shard_label | ${#snapshots[@]} | $shard_peak_total | $mib | $maps_at_peak | $progs_at_peak |"
-
-  if [ "$shard_peak_total" -gt "$best_total" ]; then
-    best_total=$shard_peak_total
-    best_shard=$shard_label
-    best_snapshot=$shard_peak_snap
-  fi
-done
-
+emit "_Data source: \`bpftool map show -j\` + \`bpftool prog show -j\`, sampled across all integration test shards._"
+emit "_Future data sources for this section may include bpftop and OBI's own internal metrics._"
 emit ""
 
-if [ -z "$best_snapshot" ]; then
-  emit "_No snapshots contained map data._"
-  exit 0
+shard_count=$(jq -r '.shards' <<< "$MERGED_JSON")
+total_suites=$(jq -r '.suites | length' <<< "$MERGED_JSON")
+
+emit "**Run overview**"
+emit ""
+emit "| metric | value |"
+emit "| --- | ---: |"
+emit "| shards reporting | $shard_count |"
+emit "| suites observed | $total_suites |"
+emit ""
+
+emit "**Per-shard peaks**"
+emit ""
+emit "| shard | peak memlock (MiB) | maps at peak | progs at peak |"
+emit "| --- | ---: | ---: | ---: |"
+
+while IFS= read -r line; do emit "$line"; done < <(jq -r '
+  .per_shard
+  | sort_by(.shard)
+  | .[]
+  | "| \(.shard) | \((.peak.total_bytes_memlock / 1024 / 1024 * 100 | round / 100)) | \(.peak.maps) | \(.peak.progs) |"
+' <<< "$MERGED_JSON")
+emit ""
+
+# Sparkline helper, identical to the one in summary.sh.
+sparkline_from_json() {
+  jq -r '
+    if length == 0 then ""
+    else
+      . as $vals
+      | ($vals | min) as $lo
+      | ($vals | max) as $hi
+      | ($hi - $lo) as $rng
+      | ["▁","▂","▃","▄","▅","▆","▇","█"] as $chars
+      | $vals
+      | map(
+          if $rng == 0 then 3
+          else ((. - $lo) / $rng * 7) | floor
+          end
+          | $chars[.]
+        )
+      | join("")
+    end
+  '
+}
+
+if [ "$total_suites" -gt 0 ]; then
+  emit "### Top suites by peak memlock (across all shards)"
+  emit ""
+  emit "Sparkline shows the per-shard peak series for the suite, ordered by shard."
+  emit ""
+  emit "| suite | peak memlock (MiB) | peak shard | shards seen | trend across shards |"
+  emit "| --- | ---: | --- | ---: | --- |"
+
+  rows=$(jq -r '
+    .suites
+    | .[0:30]
+    | .[]
+    | [
+        .name,
+        (.peak_bytes / 1024 / 1024 * 100 | round / 100),
+        .peak_shard,
+        .observations,
+        ([.per_shard | sort_by(.shard) | .[] | .peak_bytes] | tojson)
+      ] | @tsv
+  ' <<< "$MERGED_JSON")
+
+  while IFS=$'\t' read -r name peak_mib shard observations series; do
+    spark=$(sparkline_from_json <<< "$series")
+    emit "| \`$name\` | $peak_mib | $shard | $observations | $spark |"
+  done <<< "$rows"
+  emit ""
 fi
 
-best_mib=$(awk -v t="$best_total" 'BEGIN{printf "%.2f", t/1024/1024}')
-emit "### Overall peak: shard \`$best_shard\` — **$best_total** bytes ($best_mib MiB)"
+emit "<details><summary>How to interpret this report</summary>"
 emit ""
-emit "Snapshot: \`$(basename "$best_snapshot")\` from \`$best_shard\`"
+emit "- **memlock** is the bytes the kernel locks on behalf of an eBPF map (\`bpftool map show -j\` → \`bytes_memlock\`). It tracks closely with map sizing in the source."
+emit "- **Map names** are truncated to 15 characters by the kernel's \`BPF_OBJ_NAME_LEN\`."
+emit "- **Per-suite attribution** intersects the per-shard sampler timeline with gotestsum's test-event log. Snapshots that fall inside a top-level test's run-to-pass window are attributed to that suite. Peak values include any concurrent residue from prior tests whose teardown is still in flight, so treat absolute numbers as upper bounds, not minimums."
+emit "- **Trend** sparklines encode the per-shard peak series for that suite, ordered by shard label, using 8 unicode block heights."
 emit ""
-emit "#### Top 20 maps by \`bytes_memlock\` at overall peak"
-emit ""
-emit "| name | type | max_entries | bytes_memlock |"
-emit "| --- | --- | ---: | ---: |"
+emit "</details>"
 
-while IFS= read -r line; do emit "$line"; done < <(jq -r '
-  .maps
-  | map({
-      name: (.name // "<unnamed>"),
-      type: (.type // "?"),
-      max_entries: (.max_entries // 0),
-      bytes_memlock: (.bytes_memlock // 0)
-    })
-  | sort_by(-.bytes_memlock)
-  | .[0:20]
-  | .[]
-  | "| \(.name) | \(.type) | \(.max_entries) | \(.bytes_memlock) |"
-' "$best_snapshot")
-
-emit ""
-emit "#### Top 10 programs by \`run_time_ns\` at overall peak"
-emit ""
-emit "| name | type | run_cnt | run_time_ns |"
-emit "| --- | --- | ---: | ---: |"
-
-while IFS= read -r line; do emit "$line"; done < <(jq -r '
-  .progs
-  | map({
-      name: (.name // "<unnamed>"),
-      type: (.type // "?"),
-      run_cnt: (.run_cnt // 0),
-      run_time_ns: (.run_time_ns // 0)
-    })
-  | sort_by(-.run_time_ns)
-  | .[0:10]
-  | .[]
-  | "| \(.name) | \(.type) | \(.run_cnt) | \(.run_time_ns) |"
-' "$best_snapshot")
+if [ -n "$OUT_JSON" ]; then
+  printf '%s\n' "$MERGED_JSON" > "$OUT_JSON"
+fi

--- a/scripts/bpf-metrics-sampler.sh
+++ b/scripts/bpf-metrics-sampler.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # PoC: poll bpftool periodically and append JSON snapshots to an output dir.
 # Each snapshot is one file: <out_dir>/snap-<unix_ts>.json with shape:
 #   { "ts": <unix>, "maps": [...], "progs": [...] }

--- a/scripts/bpf-metrics-sampler.sh
+++ b/scripts/bpf-metrics-sampler.sh
@@ -51,7 +51,10 @@ while true; do
   # downstream scripts can still parse the file.
   maps=$("${BPFTOOL[@]}" map show -j 2>/dev/null || echo '[]')
   progs=$("${BPFTOOL[@]}" prog show -j 2>/dev/null || echo '[]')
-  printf '{"ts":%s,"maps":%s,"progs":%s}\n' "$ts" "$maps" "$progs" \
-    > "$OUT_DIR/snap-$ts.json"
+  # Write to a temp file then rename so readers never observe a partial
+  # snapshot, even if we get SIGTERM'd mid-write.
+  tmp="$OUT_DIR/.snap-$ts.json.tmp"
+  printf '{"ts":%s,"maps":%s,"progs":%s}\n' "$ts" "$maps" "$progs" > "$tmp"
+  mv "$tmp" "$OUT_DIR/snap-$ts.json"
   sleep "$INTERVAL"
 done

--- a/scripts/bpf-metrics-sampler.sh
+++ b/scripts/bpf-metrics-sampler.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# PoC: poll bpftool periodically and append JSON snapshots to an output dir.
+# Each snapshot is one file: <out_dir>/snap-<unix_ts>.json with shape:
+#   { "ts": <unix>, "maps": [...], "progs": [...] }
+#
+# Intended to be run in the background while an integration test executes:
+#   ./scripts/bpf-metrics-sampler.sh /tmp/bpfsamples 2 &
+#   SAMPLER_PID=$!
+#   ... run test ...
+#   kill "$SAMPLER_PID" || true
+#
+# Caveats:
+# - Filenames embed a 1-second resolution timestamp; intervals < 1s would
+#   cause snapshot collisions. The default is 2s.
+# - INTERVAL is passed to `sleep` verbatim; validate before invoking.
+# - Captures ALL eBPF objects on the runner, not just OBI's. Acceptable for
+#   GH Actions runners where nothing else loads eBPF; for a richer signal,
+#   filter by PID using `.pids[].pid` from `bpftool prog show -j`.
+set -euo pipefail
+
+OUT_DIR="${1:-/tmp/bpfsamples}"
+INTERVAL="${2:-2}"
+
+if ! [[ "$INTERVAL" =~ ^[0-9]+$ ]] || [ "$INTERVAL" -lt 1 ]; then
+  echo "INTERVAL must be a positive integer (seconds), got: $INTERVAL" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+
+# bpftool typically needs root; on GH runners passwordless sudo is fine.
+BPFTOOL=(sudo bpftool)
+
+# Enable BPF stats (run_time_ns / run_cnt) for the duration of the sampler.
+# Best-effort: requires CAP_SYS_ADMIN and may be a no-op on locked-down hosts.
+sudo sysctl -w kernel.bpf_stats_enabled=1 >/dev/null 2>&1 || true
+
+# EXIT trap restores the sysctl on SIGTERM (the default `kill`). It does NOT
+# fire on SIGKILL — acceptable because GH runners are torn down after the job.
+cleanup() {
+  sudo sysctl -w kernel.bpf_stats_enabled=0 >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+while true; do
+  ts=$(date +%s)
+  # Both queries are best-effort; emit empty arrays on failure so the
+  # downstream scripts can still parse the file.
+  maps=$("${BPFTOOL[@]}" map show -j 2>/dev/null || echo '[]')
+  progs=$("${BPFTOOL[@]}" prog show -j 2>/dev/null || echo '[]')
+  printf '{"ts":%s,"maps":%s,"progs":%s}\n' "$ts" "$maps" "$progs" \
+    > "$OUT_DIR/snap-$ts.json"
+  sleep "$INTERVAL"
+done

--- a/scripts/bpf-metrics-summary.sh
+++ b/scripts/bpf-metrics-summary.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # PoC: read snapshots produced by bpf-metrics-sampler.sh and emit a markdown
 # summary to stdout (or to $GITHUB_STEP_SUMMARY if set).
 #

--- a/scripts/bpf-metrics-summary.sh
+++ b/scripts/bpf-metrics-summary.sh
@@ -2,25 +2,35 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# PoC: read snapshots produced by bpf-metrics-sampler.sh and emit a markdown
-# summary to stdout (or to $GITHUB_STEP_SUMMARY if set).
+# PoC: process per-shard bpftool snapshots into a markdown report + JSON
+# sidecar. When a gotestsum json log is provided, also produces per-suite
+# attribution showing which top-level tests are the heaviest eBPF consumers.
 #
-# NOTE: This sums bytes_memlock across ALL eBPF objects on the runner, not
-# just OBI's. On a GH Actions runner this is a fair proxy because no other
-# eBPF programs are loaded, but for production tracking we would filter
-# by the OBI process PID via `bpftool prog show -j` -> `.pids[].pid`.
+# Usage:
+#   bpf-metrics-summary.sh --in <snapshot_dir> [--testlog <gotestsum.jsonl>] [--out-json <file>]
+#
+# Emits markdown to $GITHUB_STEP_SUMMARY (or stdout). Optionally writes a
+# machine-readable JSON sidecar for downstream aggregation/rollup.
+
 set -euo pipefail
 
-IN_DIR="${1:-/tmp/bpfsamples}"
+IN_DIR=""
+TEST_LOG=""
+OUT_JSON=""
+SHARD_LABEL=""
 
-shopt -s nullglob
-# Bash globs expand in lexically sorted order, which matches numerical
-# order here since snap-*.json filenames embed a fixed-width unix timestamp.
-snapshots=("$IN_DIR"/snap-*.json)
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --in) IN_DIR="$2"; shift 2 ;;
+    --testlog) TEST_LOG="$2"; shift 2 ;;
+    --out-json) OUT_JSON="$2"; shift 2 ;;
+    --shard) SHARD_LABEL="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
 
-if [ ${#snapshots[@]} -eq 0 ]; then
-  echo "No snapshots found in $IN_DIR" >&2
-  exit 0
+if [ -z "$IN_DIR" ]; then
+  IN_DIR="${1:-/tmp/bpfsamples}"
 fi
 
 emit() {
@@ -31,72 +41,228 @@ emit() {
   fi
 }
 
-# Find the snapshot with the highest total bytes_memlock.
-peak_snapshot=""
-peak_total=-1
+shopt -s nullglob
+snapshots=("$IN_DIR"/snap-*.json)
+
+if [ ${#snapshots[@]} -eq 0 ]; then
+  emit "## bpftool snapshot${SHARD_LABEL:+ (shard $SHARD_LABEL)}"
+  emit ""
+  emit "_No snapshots found in \`$IN_DIR\`._"
+  if [ -n "$OUT_JSON" ]; then
+    printf '{"shard":"%s","snapshots":0,"suites":[]}\n' "$SHARD_LABEL" > "$OUT_JSON"
+  fi
+  exit 0
+fi
+
+# Build a per-snapshot index of total bytes_memlock keyed by ts.
+# Format: one line per snapshot: "<ts> <total_bytes>"
+SNAP_INDEX=$(mktemp)
+trap 'rm -f "$SNAP_INDEX"' EXIT
+
 for f in "${snapshots[@]}"; do
   total=$(jq '[.maps[]?.bytes_memlock // 0] | add // 0' "$f" 2>/dev/null || echo 0)
-  if [ "$total" -gt "$peak_total" ]; then
-    peak_total=$total
-    peak_snapshot=$f
-  fi
-done
+  ts=$(jq -r '.ts' "$f" 2>/dev/null || basename "$f" | sed 's/snap-//;s/.json//')
+  printf '%s %s %s\n' "$ts" "$total" "$f"
+done | sort -n > "$SNAP_INDEX"
 
-first_snapshot=${snapshots[0]}
-last_snapshot=${snapshots[-1]}
+# Peak snapshot across the whole shard (for top-N maps/progs).
+peak_line=$(sort -k2,2 -n "$SNAP_INDEX" | tail -1)
+peak_total=$(awk '{print $2}' <<< "$peak_line")
+peak_snapshot=$(awk '{print $3}' <<< "$peak_line")
+peak_ts=$(awk '{print $1}' <<< "$peak_line")
+first_ts=$(head -1 "$SNAP_INDEX" | awk '{print $1}')
+last_ts=$(tail -1 "$SNAP_INDEX" | awk '{print $1}')
 sample_count=${#snapshots[@]}
-
-peak_map_count=$(jq '.maps | length' "$peak_snapshot")
-peak_prog_count=$(jq '.progs | length' "$peak_snapshot")
-peak_ts=$(jq -r '.ts' "$peak_snapshot")
-first_ts=$(jq -r '.ts' "$first_snapshot")
-last_ts=$(jq -r '.ts' "$last_snapshot")
 peak_mib=$(awk -v t="$peak_total" 'BEGIN{printf "%.2f", t/1024/1024}')
 
-emit "## eBPF metrics (PoC)"
-emit ""
-emit "- Snapshots taken: **$sample_count**"
-emit "- Window: $first_ts → $last_ts (unix)"
-emit "- Peak snapshot @ ts=$peak_ts"
-emit "  - Total \`bytes_memlock\`: **$peak_total** bytes ($peak_mib MiB)"
-emit "  - Maps loaded: $peak_map_count"
-emit "  - Programs loaded: $peak_prog_count"
-emit ""
-emit "### Top 20 maps by \`bytes_memlock\` at peak"
-emit ""
-emit "| name | type | max_entries | bytes_memlock |"
-emit "| --- | --- | ---: | ---: |"
+# Convert byte values to MiB for jq pipelines below.
+b2mib='(./1024/1024 * 100 | round / 100)'
 
-while IFS= read -r line; do emit "$line"; done < <(jq -r '
+# Suite-level attribution (optional): parse gotestsum jsonfile if given.
+# Top-level tests are .Test values that contain no '/'. We collect each
+# such test's [start_ts, end_ts] then bucket snapshots into those windows.
+SUITES_JSON="[]"
+if [ -n "$TEST_LOG" ] && [ -f "$TEST_LOG" ]; then
+  # Build per-suite { name, start, end } from gotestsum events.
+  SUITE_WINDOWS=$(jq -s -r '
+    map(select(.Test != null and (.Test | contains("/") | not)))
+    | group_by(.Test)
+    | map({
+        name: .[0].Test,
+        start: (map(select(.Action == "run")) | .[0].Time // null),
+        end:   (map(select(.Action == "pass" or .Action == "fail" or .Action == "skip")) | .[0].Time // null),
+        result: (map(select(.Action == "pass" or .Action == "fail" or .Action == "skip")) | .[0].Action // "unknown")
+      })
+    | map(select(.start != null))
+  ' < <(jq -c 'select(.Test != null and (.Action == "run" or .Action == "pass" or .Action == "fail" or .Action == "skip"))' "$TEST_LOG"))
+
+  # For each suite window, find snapshot totals within and compute stats.
+  # We pass the snapshot index in via --rawfile and parse it inside jq.
+  SUITES_JSON=$(jq --rawfile snaps "$SNAP_INDEX" '
+    def parse_ts: sub("\\.[0-9]+"; "") | fromdateiso8601;
+    def snap_lines: $snaps | split("\n") | map(select(length > 0));
+    def snap_series:
+      snap_lines | map(split(" ") | { ts: (.[0] | tonumber), total: (.[1] | tonumber) });
+    . as $suites
+    | snap_series as $series
+    | $suites
+    | map(
+        .start_ts = (.start | parse_ts)
+        | .end_ts = (if .end then (.end | parse_ts) else .start_ts end)
+      )
+    | map(
+        . as $s
+        | ($series | map(select(.ts >= $s.start_ts and .ts <= $s.end_ts))) as $window
+        | .snapshots_in_window = ($window | length)
+        | .peak_bytes = ($window | map(.total) | max // 0)
+        | .series = ($window | map(.total))
+      )
+    | map(del(.start_ts, .end_ts))
+  ' <<< "$SUITE_WINDOWS")
+fi
+
+# Sparkline encoder: takes a JSON array of numbers via stdin, emits a string.
+sparkline_from_json() {
+  jq -r '
+    if length == 0 then ""
+    else
+      . as $vals
+      | ($vals | min) as $lo
+      | ($vals | max) as $hi
+      | ($hi - $lo) as $rng
+      | ["▁","▂","▃","▄","▅","▆","▇","█"] as $chars
+      | $vals
+      | map(
+          if $rng == 0 then 3
+          else ((. - $lo) / $rng * 7) | floor
+          end
+          | $chars[.]
+        )
+      | join("")
+    end
+  '
+}
+
+# --- Markdown output ---
+
+emit "## bpftool snapshot${SHARD_LABEL:+ (shard $SHARD_LABEL)}"
+emit ""
+emit "_Data source: \`bpftool map show -j\` + \`bpftool prog show -j\`._"
+emit "_Future data sources for this section may include bpftop and OBI's own internal metrics._"
+emit ""
+emit "**Shard overview**"
+emit ""
+emit "| metric | value |"
+emit "| --- | ---: |"
+emit "| snapshots | $sample_count |"
+emit "| window (unix) | $first_ts → $last_ts |"
+emit "| peak memlock (MiB) | $peak_mib |"
+emit "| maps at peak | $(jq '.maps | length' "$peak_snapshot") |"
+emit "| programs at peak | $(jq '.progs | length' "$peak_snapshot") |"
+emit ""
+
+# Per-suite table (only if we have test attribution).
+if [ "$(jq 'length' <<< "$SUITES_JSON")" -gt 0 ]; then
+  emit "### Top suites by peak memlock"
+  emit ""
+  emit "| suite | duration (s) | peak memlock (MiB) | snapshots in window | trend |"
+  emit "| --- | ---: | ---: | ---: | --- |"
+
+  # Build rows sorted by peak descending. Skip suites with no snapshots in window.
+  rows=$(jq -r '
+    map(select(.snapshots_in_window > 0))
+    | sort_by(-.peak_bytes)
+    | .[]
+    | [
+        .name,
+        ((.series | length) // 0),
+        (.peak_bytes / 1024 / 1024 * 100 | round / 100),
+        .snapshots_in_window,
+        (.series | tojson)
+      ] | @tsv
+  ' <<< "$SUITES_JSON")
+
+  while IFS=$'\t' read -r name samples_count peak_mib_v snaps_v series_json; do
+    spark=$(sparkline_from_json <<< "$series_json")
+    emit "| \`$name\` | $samples_count | $peak_mib_v | $snaps_v | $spark |"
+  done <<< "$rows"
+  emit ""
+fi
+
+# Top-N maps at peak (dedupe by name, count instances of the same name).
+emit "<details><summary>Top 20 maps at peak (by total bytes_memlock)</summary>"
+emit ""
+emit "_Map names are limited to 15 characters by the kernel's \`BPF_OBJ_NAME_LEN\`. The \`count\` column shows how many distinct map instances share that truncated name (typically one per OBI process running concurrently)._"
+emit ""
+emit "| name | type | count | total bytes_memlock (MiB) | max_entries |"
+emit "| --- | --- | ---: | ---: | ---: |"
+
+while IFS= read -r line; do emit "$line"; done < <(jq -r --arg b2mib_label "MiB" '
   .maps
+  | group_by(.name // "<unnamed>")
   | map({
-      name: (.name // "<unnamed>"),
-      type: (.type // "?"),
-      max_entries: (.max_entries // 0),
-      bytes_memlock: (.bytes_memlock // 0)
+      name: (.[0].name // "<unnamed>"),
+      type: (.[0].type // "?"),
+      count: length,
+      total_memlock: ([.[].bytes_memlock // 0] | add),
+      max_entries: ([.[].max_entries // 0] | max)
     })
-  | sort_by(-.bytes_memlock)
+  | sort_by(-.total_memlock)
   | .[0:20]
   | .[]
-  | "| \(.name) | \(.type) | \(.max_entries) | \(.bytes_memlock) |"
+  | "| \(.name) | \(.type) | \(.count) | \((.total_memlock / 1024 / 1024 * 100 | round / 100)) | \(.max_entries) |"
 ' "$peak_snapshot")
 
 emit ""
-emit "### Top 10 programs by \`run_time_ns\` at peak"
+emit "</details>"
 emit ""
-emit "| name | type | run_cnt | run_time_ns |"
-emit "| --- | --- | ---: | ---: |"
+
+emit "<details><summary>Top 10 programs at peak (by run_time_ns)</summary>"
+emit ""
+emit "| name | type | count | total run_cnt | total run_time_ns |"
+emit "| --- | --- | ---: | ---: | ---: |"
 
 while IFS= read -r line; do emit "$line"; done < <(jq -r '
   .progs
+  | group_by(.name // "<unnamed>")
   | map({
-      name: (.name // "<unnamed>"),
-      type: (.type // "?"),
-      run_cnt: (.run_cnt // 0),
-      run_time_ns: (.run_time_ns // 0)
+      name: (.[0].name // "<unnamed>"),
+      type: (.[0].type // "?"),
+      count: length,
+      total_run_cnt: ([.[].run_cnt // 0] | add),
+      total_run_time_ns: ([.[].run_time_ns // 0] | add)
     })
-  | sort_by(-.run_time_ns)
+  | sort_by(-.total_run_time_ns)
   | .[0:10]
   | .[]
-  | "| \(.name) | \(.type) | \(.run_cnt) | \(.run_time_ns) |"
+  | "| \(.name) | \(.type) | \(.count) | \(.total_run_cnt) | \(.total_run_time_ns) |"
 ' "$peak_snapshot")
+
+emit ""
+emit "</details>"
+
+# --- JSON sidecar ---
+
+if [ -n "$OUT_JSON" ]; then
+  jq -n \
+    --arg shard "$SHARD_LABEL" \
+    --argjson sample_count "$sample_count" \
+    --argjson first_ts "$first_ts" \
+    --argjson last_ts "$last_ts" \
+    --argjson peak_bytes "$peak_total" \
+    --argjson peak_ts "$peak_ts" \
+    --argjson suites "$SUITES_JSON" \
+    --slurpfile peak_snap "$peak_snapshot" \
+    '{
+       shard: $shard,
+       snapshots: $sample_count,
+       window: { start: $first_ts, end: $last_ts },
+       peak: {
+         ts: $peak_ts,
+         total_bytes_memlock: $peak_bytes,
+         maps: ($peak_snap[0].maps | length),
+         progs: ($peak_snap[0].progs | length)
+       },
+       suites: $suites
+     }' > "$OUT_JSON"
+fi

--- a/scripts/bpf-metrics-summary.sh
+++ b/scripts/bpf-metrics-summary.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# PoC: read snapshots produced by bpf-metrics-sampler.sh and emit a markdown
+# summary to stdout (or to $GITHUB_STEP_SUMMARY if set).
+#
+# NOTE: This sums bytes_memlock across ALL eBPF objects on the runner, not
+# just OBI's. On a GH Actions runner this is a fair proxy because no other
+# eBPF programs are loaded, but for production tracking we would filter
+# by the OBI process PID via `bpftool prog show -j` -> `.pids[].pid`.
+set -euo pipefail
+
+IN_DIR="${1:-/tmp/bpfsamples}"
+
+shopt -s nullglob
+# Bash globs expand in lexically sorted order, which matches numerical
+# order here since snap-*.json filenames embed a fixed-width unix timestamp.
+snapshots=("$IN_DIR"/snap-*.json)
+
+if [ ${#snapshots[@]} -eq 0 ]; then
+  echo "No snapshots found in $IN_DIR" >&2
+  exit 0
+fi
+
+emit() {
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"
+  else
+    printf '%s\n' "$1"
+  fi
+}
+
+# Find the snapshot with the highest total bytes_memlock.
+peak_snapshot=""
+peak_total=-1
+for f in "${snapshots[@]}"; do
+  total=$(jq '[.maps[]?.bytes_memlock // 0] | add // 0' "$f" 2>/dev/null || echo 0)
+  if [ "$total" -gt "$peak_total" ]; then
+    peak_total=$total
+    peak_snapshot=$f
+  fi
+done
+
+first_snapshot=${snapshots[0]}
+last_snapshot=${snapshots[-1]}
+sample_count=${#snapshots[@]}
+
+peak_map_count=$(jq '.maps | length' "$peak_snapshot")
+peak_prog_count=$(jq '.progs | length' "$peak_snapshot")
+peak_ts=$(jq -r '.ts' "$peak_snapshot")
+first_ts=$(jq -r '.ts' "$first_snapshot")
+last_ts=$(jq -r '.ts' "$last_snapshot")
+peak_mib=$(awk -v t="$peak_total" 'BEGIN{printf "%.2f", t/1024/1024}')
+
+emit "## eBPF metrics (PoC)"
+emit ""
+emit "- Snapshots taken: **$sample_count**"
+emit "- Window: $first_ts → $last_ts (unix)"
+emit "- Peak snapshot @ ts=$peak_ts"
+emit "  - Total \`bytes_memlock\`: **$peak_total** bytes ($peak_mib MiB)"
+emit "  - Maps loaded: $peak_map_count"
+emit "  - Programs loaded: $peak_prog_count"
+emit ""
+emit "### Top 20 maps by \`bytes_memlock\` at peak"
+emit ""
+emit "| name | type | max_entries | bytes_memlock |"
+emit "| --- | --- | ---: | ---: |"
+
+while IFS= read -r line; do emit "$line"; done < <(jq -r '
+  .maps
+  | map({
+      name: (.name // "<unnamed>"),
+      type: (.type // "?"),
+      max_entries: (.max_entries // 0),
+      bytes_memlock: (.bytes_memlock // 0)
+    })
+  | sort_by(-.bytes_memlock)
+  | .[0:20]
+  | .[]
+  | "| \(.name) | \(.type) | \(.max_entries) | \(.bytes_memlock) |"
+' "$peak_snapshot")
+
+emit ""
+emit "### Top 10 programs by \`run_time_ns\` at peak"
+emit ""
+emit "| name | type | run_cnt | run_time_ns |"
+emit "| --- | --- | ---: | ---: |"
+
+while IFS= read -r line; do emit "$line"; done < <(jq -r '
+  .progs
+  | map({
+      name: (.name // "<unnamed>"),
+      type: (.type // "?"),
+      run_cnt: (.run_cnt // 0),
+      run_time_ns: (.run_time_ns // 0)
+    })
+  | sort_by(-.run_time_ns)
+  | .[0:10]
+  | .[]
+  | "| \(.name) | \(.type) | \(.run_cnt) | \(.run_time_ns) |"
+' "$peak_snapshot")

--- a/scripts/bpf-metrics-summary.sh
+++ b/scripts/bpf-metrics-summary.sh
@@ -41,6 +41,14 @@ emit() {
   fi
 }
 
+iso_utc() {
+  # GNU date (Linux) accepts -d; BSD date (macOS) uses -r. Fall back to the
+  # raw unix timestamp only if neither form is available.
+  date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || echo "$1"
+}
+
 shopt -s nullglob
 snapshots=("$IN_DIR"/snap-*.json)
 
@@ -109,6 +117,7 @@ if [ -n "$TEST_LOG" ] && [ -f "$TEST_LOG" ]; then
     | map(
         .start_ts = (.start | parse_ts)
         | .end_ts = (if .end then (.end | parse_ts) else .start_ts end)
+        | .duration_s = (.end_ts - .start_ts)
       )
     | map(
         . as $s
@@ -155,8 +164,9 @@ emit ""
 emit "| metric | value |"
 emit "| --- | ---: |"
 emit "| snapshots | $sample_count |"
-emit "| window (unix) | $first_ts → $last_ts |"
+emit "| window (UTC) | $(iso_utc "$first_ts") → $(iso_utc "$last_ts") |"
 emit "| peak memlock (MiB) | $peak_mib |"
+emit "| peak (UTC) | $(iso_utc "$peak_ts") |"
 emit "| maps at peak | $(jq '.maps | length' "$peak_snapshot") |"
 emit "| programs at peak | $(jq '.progs | length' "$peak_snapshot") |"
 emit ""
@@ -175,29 +185,23 @@ if [ "$(jq 'length' <<< "$SUITES_JSON")" -gt 0 ]; then
     | .[]
     | [
         .name,
-        ((.series | length) // 0),
+        (.duration_s // 0),
         (.peak_bytes / 1024 / 1024 * 100 | round / 100),
         .snapshots_in_window,
         (.series | tojson)
       ] | @tsv
   ' <<< "$SUITES_JSON")
 
-  while IFS=$'\t' read -r name samples_count peak_mib_v snaps_v series_json; do
+  while IFS=$'\t' read -r name duration_s peak_mib_v snaps_v series_json; do
     spark=$(sparkline_from_json <<< "$series_json")
-    emit "| \`$name\` | $samples_count | $peak_mib_v | $snaps_v | $spark |"
+    emit "| \`$name\` | $duration_s | $peak_mib_v | $snaps_v | $spark |"
   done <<< "$rows"
   emit ""
 fi
 
-# Top-N maps at peak (dedupe by name, count instances of the same name).
-emit "<details><summary>Top 20 maps at peak (by total bytes_memlock)</summary>"
-emit ""
-emit "_Map names are limited to 15 characters by the kernel's \`BPF_OBJ_NAME_LEN\`. The \`count\` column shows how many distinct map instances share that truncated name (typically one per OBI process running concurrently)._"
-emit ""
-emit "| name | type | count | total bytes_memlock (MiB) | max_entries |"
-emit "| --- | --- | ---: | ---: | ---: |"
-
-while IFS= read -r line; do emit "$line"; done < <(jq -r --arg b2mib_label "MiB" '
+# Group peak-snapshot maps & progs by name once, used by both markdown
+# and the JSON sidecar (so the aggregator can merge across shards).
+PEAK_MAPS_GROUPED=$(jq '
   .maps
   | group_by(.name // "<unnamed>")
   | map({
@@ -208,10 +212,33 @@ while IFS= read -r line; do emit "$line"; done < <(jq -r --arg b2mib_label "MiB"
       max_entries: ([.[].max_entries // 0] | max)
     })
   | sort_by(-.total_memlock)
-  | .[0:20]
+' "$peak_snapshot")
+
+PEAK_PROGS_GROUPED=$(jq '
+  .progs
+  | group_by(.name // "<unnamed>")
+  | map({
+      name: (.[0].name // "<unnamed>"),
+      type: (.[0].type // "?"),
+      count: length,
+      total_run_cnt: ([.[].run_cnt // 0] | add),
+      total_run_time_ns: ([.[].run_time_ns // 0] | add)
+    })
+  | sort_by(-.total_run_time_ns)
+' "$peak_snapshot")
+
+emit "<details><summary>Top 20 maps at peak (by total bytes_memlock)</summary>"
+emit ""
+emit "_Map names are limited to 15 characters by the kernel's \`BPF_OBJ_NAME_LEN\`. The \`count\` column shows how many distinct map instances share that truncated name (typically one per OBI process running concurrently)._"
+emit ""
+emit "| name | type | count | total bytes_memlock (MiB) | max_entries |"
+emit "| --- | --- | ---: | ---: | ---: |"
+
+while IFS= read -r line; do emit "$line"; done < <(jq -r '
+  .[0:20]
   | .[]
   | "| \(.name) | \(.type) | \(.count) | \((.total_memlock / 1024 / 1024 * 100 | round / 100)) | \(.max_entries) |"
-' "$peak_snapshot")
+' <<< "$PEAK_MAPS_GROUPED")
 
 emit ""
 emit "</details>"
@@ -223,20 +250,10 @@ emit "| name | type | count | total run_cnt | total run_time_ns |"
 emit "| --- | --- | ---: | ---: | ---: |"
 
 while IFS= read -r line; do emit "$line"; done < <(jq -r '
-  .progs
-  | group_by(.name // "<unnamed>")
-  | map({
-      name: (.[0].name // "<unnamed>"),
-      type: (.[0].type // "?"),
-      count: length,
-      total_run_cnt: ([.[].run_cnt // 0] | add),
-      total_run_time_ns: ([.[].run_time_ns // 0] | add)
-    })
-  | sort_by(-.total_run_time_ns)
-  | .[0:10]
+  .[0:10]
   | .[]
   | "| \(.name) | \(.type) | \(.count) | \(.total_run_cnt) | \(.total_run_time_ns) |"
-' "$peak_snapshot")
+' <<< "$PEAK_PROGS_GROUPED")
 
 emit ""
 emit "</details>"
@@ -252,6 +269,8 @@ if [ -n "$OUT_JSON" ]; then
     --argjson peak_bytes "$peak_total" \
     --argjson peak_ts "$peak_ts" \
     --argjson suites "$SUITES_JSON" \
+    --argjson peak_maps "$PEAK_MAPS_GROUPED" \
+    --argjson peak_progs "$PEAK_PROGS_GROUPED" \
     --slurpfile peak_snap "$peak_snapshot" \
     '{
        shard: $shard,
@@ -261,7 +280,9 @@ if [ -n "$OUT_JSON" ]; then
          ts: $peak_ts,
          total_bytes_memlock: $peak_bytes,
          maps: ($peak_snap[0].maps | length),
-         progs: ($peak_snap[0].progs | length)
+         progs: ($peak_snap[0].progs | length),
+         maps_grouped: $peak_maps,
+         progs_grouped: $peak_progs
        },
        suites: $suites
      }' > "$OUT_JSON"


### PR DESCRIPTION
## Summary

The goal with this PR is to gather eBPF map memory consumption data from the integration tests in CI. We're already running extensive tests, so may as well take advantage of the environment and gather runtime data from it.

This can be extended in future with daily/weekly rollups, and/or other data sources (bpftop, obi metrics).

Example aggregate report included in the description below (each shard produces a report both in markdown and json format, then this is aggregated once all shards are completed).

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->

---

# Example report ([source](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/26577888773?pr=2176))

## bpftool aggregate

_Data source: `bpftool map show -j` + `bpftool prog show -j`, sampled across all integration test shards._
_Future data sources for this section may include bpftop and OBI's own internal metrics._

**Run overview**

| metric | value |
| --- | ---: |
| shards reporting | 10 |
| suites observed | 113 |

**Per-shard peaks**

| shard | peak memlock (MiB) | maps at peak | progs at peak |
| --- | ---: | ---: | ---: |
| 0 | 214.91 | 106 | 140 |
| 1 | 282.21 | 161 | 204 |
| 2 | 300.4 | 183 | 238 |
| 3 | 282.21 | 161 | 202 |
| 4 | 282.21 | 161 | 202 |
| 5 | 214.91 | 106 | 142 |
| 6 | 282.21 | 161 | 206 |
| 7 | 301.9 | 184 | 238 |
| 8 | 282.21 | 161 | 210 |
| 9 | 300.4 | 183 | 238 |

### Top suites by peak memlock (across all shards)

Each suite only runs on one shard. `peak shard` is where it ran. `trend` is the in-shard sampler series for that suite.

| suite | duration (s) | peak memlock (MiB) | peak shard | trend |
| --- | ---: | ---: | --- | --- |
| `TestMultiProcessAppCPHeadersOnly` | 346 | 301.9 | 7 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▄▅▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇███▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ |
| `TestSuite_GRPCRelay` | 215 | 301.87 | 7 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▅▇▇▇▇▇▇▇▇█▆▆▃▁▁▁▁▁▁▁▁▁▁▁ |
| `TestMultiProcessAppCP` | 311 | 300.4 | 9 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▄▅▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇██▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ |
| `TestMultiProcessAppCPTCPOnly` | 285 | 300.4 | 2 | ▁▁▁▁▁▁▁▁▁▁▃▄▅▅▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇███▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▆▆▆▆▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ |
| `TestAvoidedServicesMetrics` | 37 | 282.21 | 2 | ▁▄▇█████████▅▅▅▅▅▁▁ |
| `TestCloudResourceMetadata_AWS` | 108 | 282.21 | 3 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▆███████████████████▆▆▆▁▁▁▁▁▁ |
| `TestCloudResourceMetadata_Azure` | 131 | 282.21 | 8 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▇████████████████████████████▆▆▆▁▁▁▁▁▁ |
| `TestCloudResourceMetadata_GCP` | 131 | 282.21 | 6 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▇███████████████████████████▄▄▁▁▁▁▁▁ |
| `TestHTTPGoOTelAvoidsInstrumentedApp` | 133 | 282.21 | 3 | ▁▁▄▇███████████████████████████████████████████████████████▅▅▅▅▅▁▁ |
| `TestHTTPGoOTelDisabledOptInstrumentedApp` | 189 | 282.21 | 4 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆████████████████████████████████████████████████████████████▅▅▅▅▅▁▁ |
| `TestHTTPGoOTelInstrumentedApp` | 110 | 282.21 | 2 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▅█████████████████████▅▅▁▁▁▁▁▁ |
| `TestMultiProcess` | 427 | 282.21 | 6 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▆████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▆▆▆▆▆▆▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ |
| `TestPerAppFeatures` | 110 | 282.21 | 8 | ▁▁▁▁▁▁▁▁▄▅▅▆█████████████████████████████████▆▆▂▁▁▁▁▁▁ |
| `TestSuite_PrometheusScrape` | 69 | 282.21 | 6 | ▁▁▄▆███████████████████████▆▆▁▁▁▁▁▁ |
| `TestSuite_PythonAsyncUvloop_3_14` | 215 | 282.21 | 9 | ▁▁▁▁▁▁▁▁▁▁▁▁▄▇█████████████████████████████████████████████████████████████████████████████████████▅▅▅▅▅▁▁ |
| `TestSuite_PythonAsyncUvloop_3_9` | 209 | 282.21 | 1 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▆██████████████████████████████████████████████████████████████████████████████▆▆▆▁▁▁▁▁▁ |
| `TestSuite_LogEnricherGoGRPC` | 128 | 222.15 | 4 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅█████▁▁▁▁▁▁▁ |
| `TestInstrumentationErrors` | 165 | 220.83 | 8 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆█▃▃▃▃▃▁▁▁ |
| `TestHTTP2GoWithHTTPProtocols` | 55 | 216.41 | 7 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███▄▄▃▁▁▁▁ |
| `TestSuiteNestedTraces` | 39 | 216.41 | 7 | ▁▁▁▁▁▁▁▆█████▂▁▁▁▁▁▁ |
| `TestSuite_NoDebugInfo` | 167 | 216.41 | 7 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄████████████████████████████████████████████████████▁▁▁▁▁▁ |
| `TestSuiteClientPromScrape` | 25 | 214.91 | 3 | ▁▁▁▁▁▁▁▇█▁▁▁ |
| `TestSuiteNoRoutesLowCardinality` | 27 | 214.91 | 3 | ▁▆██████▁▁▁▁▁ |
| `TestGRPCMux` | 156 | 214.91 | 1 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅██▁▁▁▁▁▁▁ |
| `TestGRPCMuxTLS` | 146 | 214.91 | 9 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▆██▁▁▁▁▁▁ |
| `TestHTTP2Go` | 158 | 214.91 | 3 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███▄▄▄▁▁▁ |
| `TestHTTPGoOTelAvoidsInstrumentedAppGRPC` | 59 | 214.91 | 9 | ▁▁▁▁▁▁▁▁▁▁▁▁▆███████████▁▁▁▁▁▁ |
| `TestHTTPGoOTelInstrumentedAppGRPC` | 153 | 214.91 | 6 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅███▁▁▁▁▁▁ |
| `TestSuiteGoGeneric` | 69 | 214.91 | 4 | ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▅████████▁▁▁▁▁▁▁ |
| `TestSuiteNoRoutes` | 86 | 214.91 | 6 | ▁▁███████████████████████████████████▁▁▁▁▁▁ |

<details><summary>Top 20 maps at peak (max across all shards)</summary>

_Per-name max of the `total bytes_memlock` observed in any shard's peak snapshot. `observed in N shards` indicates how many shards saw the map at all._

| name | type | max total bytes_memlock (MiB) | max instances per shard | max_entries | observed in N shards |
| --- | --- | ---: | ---: | ---: | ---: |
| ongoing_http2_g | lru_hash | 32.13 | 2 | 30000 | 10 |
| go_offsets_map | lru_hash | 21.12 | 3 | 10000 | 10 |
| ongoing_tcp_req | lru_hash | 18.35 | 1 | 30000 | 10 |
| events | ringbuf | 17.09 | 2 | 16777216 | 10 |
| ongoing_http | lru_hash | 14.92 | 1 | 30000 | 10 |
| ongoing_sql_que | lru_hash | 6.02 | 3 | 10000 | 10 |
| ongoing_grpc_tr | lru_hash | 4.87 | 3 | 10000 | 10 |
| trace_map | lru_hash | 4.62 | 1 | 30000 | 10 |
| ongoing_redis_r | lru_hash | 4.45 | 1 | 10000 | 10 |
| cp_support_conn | lru_hash | 4.16 | 1 | 30000 | 10 |
| server_traces | lru_hash | 4.16 | 1 | 30000 | 10 |
| server_traces_a | lru_hash | 4.16 | 1 | 30000 | 10 |
| kafka_requests | lru_hash | 3.99 | 1 | 10000 | 10 |
| ongoing_produce | lru_hash | 3.86 | 2 | 10000 | 10 |
| ongoing_client_ | lru_hash | 3.73 | 3 | 10000 | 10 |
| ongoing_http2_c | lru_hash | 3.73 | 3 | 10000 | 10 |
| go_trace_map | lru_hash | 3.71 | 1 | 30000 | 10 |
| ongoing_http_se | lru_hash | 3.68 | 1 | 10000 | 10 |
| sock_filter_buf | lru_hash | 3.61 | 1 | 10000 | 8 |
| connection_trac | lru_hash | 3.48 | 1 | 30000 | 10 |

</details>

<details><summary>Top 10 programs at peak (max run_time_ns across all shards)</summary>

| name | type | max run_time_ns | max run_cnt | observed in N shards |
| --- | --- | ---: | ---: | ---: |
| kprobe_skb_consume_udp | kprobe | 241439451 | 29657 | 10 |
| kprobe_ip_send_skb | kprobe | 227033191 | 24804 | 10 |
| obi_kprobe_sock_recvmsg | kprobe | 174235147 | 155224 | 8 |
| obi_kretprobe_sock_recvmsg | kprobe | 148119354 | 155224 | 8 |
| obi_kprobe_tcp_cleanup_rbuf | kprobe | 134962105 | 137431 | 8 |
| obi_kprobe_tcp_recvmsg | kprobe | 131139819 | 137338 | 8 |
| obi_kretprobe_tcp_recvmsg | kprobe | 129406523 | 137326 | 8 |
| obi_uprobe_netFdWrite | kprobe | 98662698 | 1614 | 10 |
| obi_rb_ary_shift | kprobe | 73802735 | 3405 | 8 |
| obi_kprobe_tcp_sendmsg | kprobe | 73118349 | 56807 | 8 |

</details>

<details><summary>How to interpret this report</summary>

- **memlock** is the bytes the kernel locks on behalf of an eBPF map (`bpftool map show -j` → `bytes_memlock`). It tracks closely with map sizing in the source.
- **Map names** are truncated to 15 characters by the kernel's `BPF_OBJ_NAME_LEN`.
- **Per-suite attribution** intersects the per-shard sampler timeline with gotestsum's test-event log. Snapshots that fall inside a top-level test's run-to-pass window are attributed to that suite. Peak values include any concurrent residue from prior tests whose teardown is still in flight, so treat absolute numbers as upper bounds, not minimums.
- **Trend** sparklines on the suite table show the in-shard sampler series during that suite's run window.

</details>