### PR TITLE
Document src.port=0 known limitation in StatsO11y metrics

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -128,11 +128,11 @@ OBI currently documents the following Go library compatibility baselines:
 
 OBI currently documents the following statistical instrumentation support:
 
-| Metric | Scope | Notes |
-|:-------|:------|:------|
-| TCP RTT | Node-wide statistical metric collection | Calculated from the kernel TCP `srtt_us` field |
-| TCP Failed Connections | Node-wide statistical metric collection | Counts the TCP failed connections between 2 endpoints |
-| TCP Retransmits | Node-wide statistical metric collection | Counts data-segment and client-SYN retransmits. Server-side SYN-ACK retransmits are a separate event and not counted here. |
+| Metric | Scope | Description | Limitations |
+|:-------|:------|:------------|:------------|
+| TCP RTT | Node-wide statistical metric collection | Calculated from the kernel TCP `srtt_us` field | `src.port` may be `0` on the RST-receiver side; see [devdocs/metrics.md](devdocs/metrics.md) |
+| TCP Failed Connections | Node-wide statistical metric collection | Counts TCP failed connections between two endpoints | `src.port` may be `0` on the RST-receiver side; see [devdocs/metrics.md](devdocs/metrics.md) |
+| TCP Retransmits | Node-wide statistical metric collection | Counts data-segment and client-SYN retransmits | Server-side SYN-ACK retransmits are a separate event and not counted |
 
 ## Context Propagation Frameworks
 

--- a/devdocs/metrics.md
+++ b/devdocs/metrics.md
@@ -115,6 +115,26 @@ To add a new metric, follow these guidelines:
     - `statMetricsReporter` in [pkg/export/prom/prom_stats.go](../pkg/export/prom/prom_stats.go) for Prometheus
     - `statMetricsExporter` in [pkg/export/otel/metrics_stats.go](../pkg/export/otel/metrics_stats.go) for OTEL
 
+### Known limitations
+
+#### `src.port` may be reported as `0`
+
+The `src.port` attribute (disabled by default) can be `0` in metrics whose probes fire near socket teardown: specifically `obi_stat_tcp_rtt_seconds` and `obi_stat_tcp_failed_connections`. Metrics measured while the socket is still active (retransmits) are not affected. The root cause is a kernel-side race between the application's `close()` path and RST processing.
+
+When a socket **receives** a RST and is orphaned (`SOCK_DEAD` set), the kernel calls:
+
+```
+tcp_done()
+  └── inet_csk_destroy_sock()
+        └── inet_put_port()  <-- zeroes skc_num (the source port)
+```
+
+This happens outside the application's `close()` call. By the time `parse_sock_info` in [bpf/common/sockaddr.h](../bpf/common/sockaddr.h) reads `skc_num`, it is already `0`.
+
+The RST **sender** is not affected because it goes through the normal application `close()` path where the port is still valid at probe time.
+
+StatsO11y probes fire at different points relative to `inet_put_port()`, so the behaviour is not uniform across metrics. For example, `obi_kprobe_tcp_close_srtt` (kprobe on `tcp_close`) may still observe a valid port in some RST-receiver scenarios, while `obi_tracepoint_inet_sock_set_state` (tracepoint on `inet_sock_set_state`) consistently sees `0`. Metrics with `src_port="0"` still carry useful signal — `dst_port`, `src_address`, `dst_address`, `reason`, and `network_tcp_handshake_role` remain valid.
+
 ### Final notes
 
 We decided to create a component separate from **AppO11y** and **NetO11y**, focusing only on **statistical metrics** calculated for all applications running on the node. This is because statistical metrics are important if correlated to all applications, and also because some hook points can cause unreliable PID calculations and lead to false positives.


### PR DESCRIPTION
## Summary

This PR documents a known limitation where `src.port` can be reported as 0 in `obi_stat_tcp_rtt_seconds` and `obi_stat_tcp_failed_connections`. Related discussion #2071.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
