### PR TITLE
fix metrics exporter memory leak

### DIFF
--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -312,8 +312,8 @@ func newMetricsReporter(
 			}
 
 			go func() {
-				if err := v.provider.ForceFlush(ctx); err != nil {
-					llog.Warn("error flushing evicted metrics provider", "error", err)
+				if err := v.provider.Shutdown(ctx); err != nil {
+					llog.Warn("error shutting down evicted metrics provider", "error", err)
 				}
 			}()
 		}, mr.newMetricSet)
@@ -699,7 +699,7 @@ func (mr *MetricsReporter) newMetricsInstance(service *svc.Attrs) Metrics {
 
 	opts := []metric.Option{
 		metric.WithResource(resources),
-		metric.WithReader(metric.NewPeriodicReader(mr.exporter,
+		metric.WithReader(metric.NewPeriodicReader(sharedExporter{mr.exporter},
 			metric.WithInterval(mr.cfg.Interval))),
 	}
 
@@ -773,6 +773,15 @@ func (mr *MetricsReporter) close() {
 		mlog().Debug("Metrics reporter closed")
 	}()
 }
+
+// sharedExporter wraps an sdkmetric.Exporter so that Shutdown is a no-op.
+// Per-service MeterProviders own a PeriodicReader that cascades Shutdown into
+// the exporter; without this wrapper, evicting one service would shut down the
+// exporter shared by every other service. The owning MetricsReporter calls
+// Shutdown on the underlying exporter directly from its own close().
+type sharedExporter struct{ sdkmetric.Exporter }
+
+func (sharedExporter) Shutdown(_ context.Context) error { return nil }
 
 // instrumentMetricsExporter checks whether the context is configured to report internal metrics and,
 // in this case, wraps the passed metrics exporter inside an instrumented exporter

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -137,8 +137,8 @@ func newSvcGraphMetricsReporter(
 			v.cleanupAllMetricsInstances()
 
 			go func() {
-				if err := v.provider.ForceFlush(ctx); err != nil {
-					llog.Warn("error flushing evicted metrics provider", "error", err)
+				if err := v.provider.Shutdown(ctx); err != nil {
+					llog.Warn("error shutting down evicted metrics provider", "error", err)
 				}
 			}()
 		}, mr.newMetricSet)
@@ -253,7 +253,7 @@ func (mr *SvcGraphMetricsReporter) newSvcGraphMetricsInstance(service *svc.Attrs
 
 	opts := []metric.Option{
 		metric.WithResource(resources),
-		metric.WithReader(metric.NewPeriodicReader(mr.exporter,
+		metric.WithReader(metric.NewPeriodicReader(sharedExporter{mr.exporter},
 			metric.WithInterval(mr.cfg.Interval))),
 	}
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2138

`PeriodicReader` spawns a goroutine that is never closed, TTL eviction also calls `ForceFlush` and not `Shutdown`,  which doesn't cancel the context and leaves the goroutine dangling

The underlying exporter is shared across multiple `MeterProviders`, we can't shut it down directly or else other calls will fail with an error of the exporter is already shut down. Instead we wrap the each of them in a `sharedExporter` which noops the shutdown, still allowing the context to cancel and the goroutine to exit, but not actually shutting down the shared exporter

the `MetricsReporter.Close` method still shuts down the underlying exporter

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
