### PR TITLE
Dockertest: make renovate to take care of image versions

### DIFF
--- a/internal/test/integration/cloud_test.go
+++ b/internal/test/integration/cloud_test.go
@@ -67,8 +67,8 @@ func setupAWSMockIMDS(t *testing.T, net dockertest.Network) {
 	t.Helper()
 
 	t.Log("Starting AWS EC2 Metadata Mock container...")
-	mockIMDS, err := dockerPool.Run(t.Context(), "amazon/amazon-ec2-metadata-mock",
-		dockertest.WithTag(versionAWSMetaMock),
+	mockIMDS, err := dockerPool.Run(t.Context(), imgAWSMetaMock.Repository(),
+		dockertest.WithTag(imgAWSMetaMock.Tag()),
 		dockertest.WithName(fmt.Sprintf("mock-imds-test-%d", time.Now().UnixNano())),
 		dockertest.WithMounts([]string{
 			pathRoot + "/internal/test/integration/configs/aws-metadata-mock.json:/config/aws-metadata-mock.json",
@@ -108,8 +108,8 @@ func setupMockAzureIMDS(t *testing.T, imdsSubnet dockertest.Network) {
 	t.Helper()
 	t.Log("Starting Azure IMDS Mock container...")
 
-	mockIMDS, err := dockerPool.Run(t.Context(), "nginx",
-		dockertest.WithTag(versionNginx),
+	mockIMDS, err := dockerPool.Run(t.Context(), imgNginx.Repository(),
+		dockertest.WithTag(imgNginx.Tag()),
 		dockertest.WithName(fmt.Sprintf("mock-imds-nginx-%d", time.Now().UnixNano())),
 		dockertest.WithMounts([]string{
 			pathRoot + "/internal/test/integration/components/azure-imds/nginx.conf:/etc/nginx/nginx.conf",
@@ -148,8 +148,8 @@ func setupMockGCPIMDS(t *testing.T, net dockertest.Network) {
 	t.Helper()
 	t.Log("Starting GCP IMDS Mock container...")
 
-	mockIMDS, err := dockerPool.Run(t.Context(), "nginx",
-		dockertest.WithTag(versionNginx),
+	mockIMDS, err := dockerPool.Run(t.Context(), imgNginx.Repository(),
+		dockertest.WithTag(imgNginx.Tag()),
 		dockertest.WithName(fmt.Sprintf("mock-imds-gcp-nginx-%d", time.Now().UnixNano())),
 		dockertest.WithMounts([]string{
 			pathRoot + "/internal/test/integration/components/gcp-imds/nginx.conf:/etc/nginx/nginx.conf",

--- a/internal/test/integration/dockerutil_test.go
+++ b/internal/test/integration/dockerutil_test.go
@@ -28,19 +28,20 @@ import (
 	"github.com/moby/moby/client"
 	"github.com/ory/dockertest/v4"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/obi/internal/test/tools/img"
 )
 
 const (
-	versionPrometheus  = "v2.55.1"
-	versionJaeger      = "1.60"
-	versionCollector   = "0.144.0"
-	versionAWSMetaMock = "v1.9.2"
-	versionNginx       = "1.29.5"
-	// versionWeaver MUST match the digest pinned in
+	imgPrometheus  = img.Docker("quay.io/prometheus/prometheus:v2.55.1@sha256:2659f4c2ebb718e7695cb9b25ffa7d6be64db013daba13e05c875451cf51b0d3")
+	imgJaeger      = img.Docker("jaegertracing/all-in-one:1.60@sha256:4fd2d70fa347d6a47e79fcb06b1c177e6079f92cba88b083153d56263082135e")
+	imgCollector   = img.Docker("otel/opentelemetry-collector-contrib:0.144.0@sha256:213886eb6407af91b87fa47551c3632be1a6419ff3a5114ef1e6fc364628496f")
+	imgAWSMetaMock = img.Docker("amazon/amazon-ec2-metadata-mock:v1.9.2@sha256:55cc3b9fb46d7e30aec202fc8ccab5391f7f9fc7169ae7dc726aae82562d61c4")
+	imgNginx       = img.Docker("library/nginx:1.29.5@sha256:0236ee02dcbce00b9bd83e0f5fbc51069e7e1161bd59d99885b3ae1734f3392e")
+	// imgWeaver MUST match the digest pinned in
 	// `internal/test/integration/components/weaver/service.yml` so the
 	// programmatic-setup tests run weaver with the same image as the
 	// compose-driven ones.
-	versionWeaver = "v0.23.0@sha256:7984ecb55b859eb3034ae9d836c4eeda137e2bdd0873b7ba2bb6c3d24d6ff457"
+	imgWeaver = img.Docker("otel/weaver:v0.23.0@sha256:7984ecb55b859eb3034ae9d836c4eeda137e2bdd0873b7ba2bb6c3d24d6ff457")
 )
 
 // setupDockerNetwork initializes a custom network for the test.
@@ -98,8 +99,8 @@ func setupContainerPrometheus(t *testing.T, net dockertest.Network, configFile s
 	t.Helper()
 
 	t.Log("Starting Prometheus container...")
-	prometheus, err := dockerPool.Run(t.Context(), "quay.io/prometheus/prometheus",
-		dockertest.WithTag(versionPrometheus),
+	prometheus, err := dockerPool.Run(t.Context(), imgPrometheus.Repository(),
+		dockertest.WithTag(imgPrometheus.Tag()),
 		dockertest.WithName(fmt.Sprintf("prometheus-otel-test-%d", time.Now().UnixNano())),
 		dockertest.WithMounts([]string{
 			filepath.Join(pathRoot, "internal/test/integration/configs") + ":/etc/prometheus",
@@ -131,8 +132,8 @@ func setupContainerJaeger(t *testing.T, net dockertest.Network) {
 	t.Helper()
 
 	t.Log("Starting Jaeger container...")
-	jaeger, err := dockerPool.Run(t.Context(), "jaegertracing/all-in-one",
-		dockertest.WithTag(versionJaeger),
+	jaeger, err := dockerPool.Run(t.Context(), imgJaeger.Repository(),
+		dockertest.WithTag(imgJaeger.Tag()),
 		dockertest.WithName(fmt.Sprintf("jaeger-otel-test-%d", time.Now().UnixNano())),
 		dockertest.WithEnv([]string{
 			"COLLECTOR_OTLP_ENABLED=true",
@@ -162,8 +163,8 @@ func setupContainerCollector(t *testing.T, net dockertest.Network, configFile st
 	t.Helper()
 
 	t.Log("Starting OpenTelemetry Collector container...")
-	otelcol, err := dockerPool.Run(t.Context(), "otel/opentelemetry-collector-contrib",
-		dockertest.WithTag(versionCollector),
+	otelcol, err := dockerPool.Run(t.Context(), imgCollector.Repository(),
+		dockertest.WithTag(imgCollector.Tag()),
 		dockertest.WithName(fmt.Sprintf("otelcol-otel-test-%d", time.Now().UnixNano())),
 		dockertest.WithCmd([]string{"--config=/etc/otelcol-config/" + configFile}),
 		dockertest.WithMounts([]string{
@@ -197,8 +198,8 @@ func setupContainerWeaver(t *testing.T, net dockertest.Network) {
 	t.Helper()
 
 	t.Log("Starting weaver container...")
-	w, err := dockerPool.Run(t.Context(), "otel/weaver",
-		dockertest.WithTag(versionWeaver),
+	w, err := dockerPool.Run(t.Context(), imgWeaver.Repository(),
+		dockertest.WithTag(imgWeaver.Tag()),
 		dockertest.WithName(weaverContainer),
 		dockertest.WithCmd([]string{
 			"registry", "live-check",

--- a/internal/test/integration/dockerutil_test.go
+++ b/internal/test/integration/dockerutil_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/moby/moby/client"
 	"github.com/ory/dockertest/v4"
 	"github.com/stretchr/testify/require"
+
 	"go.opentelemetry.io/obi/internal/test/tools/img"
 )
 

--- a/internal/test/tools/img/img.go
+++ b/internal/test/tools/img/img.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package img // import "go.opentelemetry.io/obi/internal/test/img"
+package img // import "go.opentelemetry.io/obi/internal/test/tools/img"
 
 import "strings"
 

--- a/internal/test/tools/img/img.go
+++ b/internal/test/tools/img/img.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package img // import "go.opentelemetry.io/obi/internal/test/img"
+
+import "strings"
+
+// Docker provides Repository and Tag helper methods for a complete image coordinates.
+// It aims facilitating auto-update of image numbers and pinned digests from Renovate
+type Docker string
+
+func (d Docker) sepIndex() int {
+	s := string(d)
+	colon := strings.IndexByte(s, ':')
+	at := strings.IndexByte(s, '@')
+	switch {
+	case colon == -1:
+		return at
+	case at == -1:
+		return colon
+	default:
+		return min(colon, at)
+	}
+}
+
+func (d Docker) Repository() string {
+	i := d.sepIndex()
+	if i == -1 {
+		return string(d)
+	}
+	return string(d[:i])
+}
+
+func (d Docker) Tag() string {
+	i := d.sepIndex()
+	if i == -1 {
+		return ""
+	}
+	return string(d[i+1:])
+}

--- a/internal/test/tools/img/img_test.go
+++ b/internal/test/tools/img/img_test.go
@@ -1,0 +1,30 @@
+package img
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsing(t *testing.T) {
+	t.Run("full coords", func(t *testing.T) {
+		i := Docker("foo/bar:latest@sha256:123456")
+		assert.Equal(t, "foo/bar", i.Repository())
+		assert.Equal(t, "latest@sha256:123456", i.Tag())
+	})
+	t.Run("no sha", func(t *testing.T) {
+		i := Docker("foo/bar:latest")
+		assert.Equal(t, "foo/bar", i.Repository())
+		assert.Equal(t, "latest", i.Tag())
+	})
+	t.Run("no tag, only sha", func(t *testing.T) {
+		i := Docker("foo/bar@sha256:123456")
+		assert.Equal(t, "foo/bar", i.Repository())
+		assert.Equal(t, "sha256:123456", i.Tag())
+	})
+	t.Run("no tag, no sha", func(t *testing.T) {
+		i := Docker("foo/bar")
+		assert.Equal(t, "foo/bar", i.Repository())
+		assert.Empty(t, i.Tag())
+	})
+}

--- a/internal/test/tools/img/img_test.go
+++ b/internal/test/tools/img/img_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package img
 
 import (


### PR DESCRIPTION
## Summary

Renovate is usually taking care of integration testing images when they are defined as docker-compose files or Kubernetes deployments.

With the addition of `dockertest` as a new testing tool, images were being defined as Go constants and renovate ignored them.

This PR defines a new type that will be captured by renovate.json's custom managers and facilitates the split repository/tag integration with dockertest functions.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
