### PR TITLE
ci: use crun instead of runc

### DIFF
--- a/internal/test/vm/Dockerfile
+++ b/internal/test/vm/Dockerfile
@@ -38,10 +38,15 @@ RUN mkdir -p /etc/docker && cat <<'EOF' > /etc/docker/daemon.json
 }
 EOF
 
-# Default iptables symlink to legacy; modules-load may relink to nft on
-# RHEL kernels that lack CONFIG_IP_NF_NAT modules.
-RUN ln -sf /sbin/iptables-legacy /sbin/iptables && \
-    ln -sf /sbin/ip6tables-legacy /sbin/ip6tables
+# Default iptables to the legacy backend; modules-load may relink to nft on
+# RHEL kernels that lack CONFIG_IP_NF_NAT modules. Docker shells out to the
+# `iptables` it finds on PATH (Alpine 3.23 ships it at /usr/sbin/iptables,
+# pointing at the nft wrapper), so we must overwrite that exact binary rather
+# than a fixed /sbin path — otherwise the symlink dangles and docker silently
+# keeps using nft while we load only the legacy NAT modules.
+RUN for t in iptables ip6tables; do \
+        ln -sf "$(command -v ${t}-legacy)" "$(command -v ${t})"; \
+    done
 
 # Module-load service: LVH kernels ship loadable modules for overlayfs,
 # br_netfilter, nf_tables, etc. Runs before localmount because /etc/fstab
@@ -89,6 +94,17 @@ start() {
         eend 1 "overlay module not loaded; check /lib/modules/${KREL} contents"
         return 1
     fi
+    # Repoint the iptables/ip6tables CLI docker shells out to. Resolve the
+    # binary docker actually runs (Alpine 3.23 keeps these in /usr/sbin, not
+    # /sbin) instead of hardcoding a directory, so a missing variant yields a
+    # no-op rather than a dangling link that leaves docker on the wrong backend.
+    set_ipt_backend() {
+        for t in iptables ip6tables; do
+            target="$(command -v "${t}-$1" 2>/dev/null)" || continue
+            link="$(command -v "$t" 2>/dev/null)" || link="/usr/sbin/$t"
+            ln -sf "$target" "$link"
+        done
+    }
     # Pick iptables backend at runtime. xt_nat (DNAT/SNAT target) doesn't
     # autoload on RHEL kernels so we modprobe it explicitly; if missing,
     # fall through to the nft branch.
@@ -97,16 +113,14 @@ start() {
         modprobe xt_MASQUERADE 2>/dev/null || true
         modprobe xt_REDIRECT 2>/dev/null || true
         modprobe nf_nat 2>/dev/null || true
-        ln -sf /sbin/iptables-legacy /sbin/iptables
-        ln -sf /sbin/ip6tables-legacy /sbin/ip6tables
+        set_ipt_backend legacy
         einfo "iptables backend: legacy"
     elif modprobe nf_tables 2>/dev/null \
         && modprobe nft_compat 2>/dev/null \
         && modprobe nft_chain_nat 2>/dev/null; then
         modprobe nft_masq 2>/dev/null || true
         modprobe nf_nat 2>/dev/null || true
-        ln -sf /sbin/iptables-nft /sbin/iptables
-        ln -sf /sbin/ip6tables-nft /sbin/ip6tables
+        set_ipt_backend nft
         einfo "iptables backend: nft"
     else
         ewarn "neither legacy nor nft NAT modules available; docker NAT will fail"

--- a/internal/test/vm/Dockerfile
+++ b/internal/test/vm/Dockerfile
@@ -1,19 +1,21 @@
 FROM golang:1.26.3@sha256:efaccb5b497e90df3ebe5216cc25cd9f98e73874e2d638b56e38d4a3f098c41c AS goimage
 
-FROM alpine:3.20@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805
+FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 # Import the Go toolchain from the pinned golang image while keeping Alpine as runtime base.
 COPY --from=goimage /usr/local/go /usr/local/go
 ENV PATH="/usr/local/go/bin:${PATH}"
 
-# Install Docker/runc from the pinned Alpine 3.20 base image
-# The procfs security checks in newer runc (CVE-2025-52881, CVE-2025-52565,
-# CVE-2025-31133) prevent containers from starting in nested virtualization.
-# Even buildkit containers fail to boot, so insecure buildx approach is not viable.
+# Use crun instead of runc as the OCI runtime. Newer runc (CVE-2025-52881,
+# CVE-2025-52565, CVE-2025-31133) hardened its procfs validation in a way
+# that fires under nested KVM, blocking container start. crun's procfs
+# handling takes a different path that currently passes in this environment,
+# letting us stay on current Alpine instead of pinning to 3.20.
 RUN apk update && apk add --no-cache \
     agetty \
     bash \
     ca-certificates \
+    crun \
     docker \
     docker-cli-compose \
     git \
@@ -21,6 +23,20 @@ RUN apk update && apk add --no-cache \
     iptables-legacy \
     make \
     openrc
+
+# Point dockerd at crun. The runc binary from the docker package is left
+# in place as a fallback runtime so individual containers can opt back in
+# via `--runtime=runc` if a test ever needs it.
+RUN mkdir -p /etc/docker && cat <<'EOF' > /etc/docker/daemon.json
+{
+  "default-runtime": "crun",
+  "runtimes": {
+    "crun": {
+      "path": "/usr/bin/crun"
+    }
+  }
+}
+EOF
 
 # Default iptables symlink to legacy; modules-load may relink to nft on
 # RHEL kernels that lack CONFIG_IP_NF_NAT modules.


### PR DESCRIPTION
## Summary

The VM integration tests are currently locked to an older Alpine version to avoid an error `unsafe procfs detected` from runc.

As KVM is [not available](https://cloud-native.slack.com/archives/C08P4HUFQ6M/p1779989273662129?thread_ts=1779988812.462079&cid=C08P4HUFQ6M) on the CNCF ARM GitHub self-hosted runners, this PR instead swaps out the OCI runtime from `runc` to `crun` (an alternative runtime created by RedHat).

This should allow us to continue to run different kernels in CI, whilst also bringing in the latest version of Alpine for security updates.

Fixes #872.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
