### PR TITLE
best effort parsing of large buffers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/invopop/jsonschema v0.13.0
+	github.com/json-iterator/go v1.1.12
 	github.com/klauspost/compress v1.18.6
 	github.com/lib/pq v1.12.3
 	github.com/moby/moby/api v1.54.2
@@ -162,7 +163,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/knadh/koanf/providers/confmap v1.0.0 // indirect

--- a/pkg/ebpf/common/http/anthropic.go
+++ b/pkg/ebpf/common/http/anthropic.go
@@ -83,30 +83,24 @@ func AnthropicSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 		return *baseSpan, false
 	}
 
-	reqB, err := io.ReadAll(req.Body)
-	if err != nil {
+	reqB, ok := readHTTPRequestBody("AnthropicSpan", req, baseSpan)
+	if !ok {
 		return *baseSpan, false
 	}
-	req.Body = io.NopCloser(bytes.NewBuffer(reqB))
 
-	respB, err := getResponseBody(resp)
-	if err != nil && len(respB) == 0 {
+	respB, ok := readHTTPResponseBody("AnthropicSpan", resp, baseSpan)
+	if !ok {
 		return *baseSpan, false
 	}
 
 	slog.Debug("Anthropic", "request", string(reqB), "response", string(respB))
 
-	var parsedRequest request.AnthropicRequest
-	if err := json.Unmarshal(reqB, &parsedRequest); err != nil {
-		slog.Debug("failed to parse Anthropic request", "error", err)
-	}
+	parsedRequest := parseAnthropicRequest(reqB)
 
 	var parsedResponse request.AnthropicResponse
 	var toolCalls []request.ToolCall
 	if len(respB) > 0 && respB[0] == '{' {
-		if err := json.Unmarshal(respB, &parsedResponse); err != nil {
-			slog.Debug("failed to parse Anthropic response", "error", err)
-		}
+		parsedResponse = parseAnthropicResponse(respB)
 		toolCalls = extractAnthropicToolCalls(parsedResponse.Content)
 	} else {
 		reader := bytes.NewReader(respB)

--- a/pkg/ebpf/common/http/bedrock.go
+++ b/pkg/ebpf/common/http/bedrock.go
@@ -4,9 +4,6 @@
 package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -39,29 +36,26 @@ func BedrockSpan(baseSpan *request.Span, req *http.Request, resp *http.Response)
 		return *baseSpan, false
 	}
 
-	reqB, err := io.ReadAll(req.Body)
-	if err != nil {
+	reqB, ok := readHTTPRequestBody("BedrockSpan", req, baseSpan)
+	if !ok {
 		return *baseSpan, false
 	}
-	req.Body = io.NopCloser(bytes.NewBuffer(reqB))
 
-	respB, err := getResponseBody(resp)
-	if err != nil && len(respB) == 0 {
+	respB, ok := readHTTPResponseBody("BedrockSpan", resp, baseSpan)
+	if !ok {
 		return *baseSpan, false
 	}
 
 	slog.Debug("Bedrock", "request", string(reqB), "response", string(respB))
 
 	var parsedRequest request.BedrockRequest
-	if err := json.Unmarshal(reqB, &parsedRequest); err != nil {
-		slog.Debug("failed to parse Bedrock request", "error", err)
+	if len(reqB) > 0 && !unmarshalJSON(reqB, &parsedRequest) {
+		slog.Debug("failed to parse Bedrock request, continuing with partial fields")
 	}
 
 	var parsedResponse request.BedrockResponse
-	if len(respB) > 0 {
-		if err := json.Unmarshal(respB, &parsedResponse); err != nil {
-			slog.Debug("failed to parse Bedrock response", "error", err)
-		}
+	if len(respB) > 0 && !unmarshalJSON(respB, &parsedResponse) {
+		slog.Debug("failed to parse Bedrock response, continuing with partial fields")
 	}
 
 	// Token counts are reliably present in response headers for successful calls.

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -4,9 +4,6 @@
 package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -61,39 +58,16 @@ func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 		return *baseSpan, false
 	}
 
-	// Request body parsing is best-effort: since the provider is already
-	// confirmed by hostname+path, a body read failure should not prevent
-	// classification — otherwise the request falls through to downstream
-	// detectors and may be misclassified.
-	var reqB []byte
-	if req.Body != nil {
-		var err error
-		reqB, err = io.ReadAll(req.Body)
-		if err != nil {
-			slog.Debug("EmbeddingSpan: failed to read request body, continuing without it", "provider", provider, "error", err)
-		}
-		req.Body = io.NopCloser(bytes.NewBuffer(reqB))
-	}
-
-	// Response body parsing is best-effort: truncated responses may fail
-	// to parse but should not prevent provider detection.
-	respB, err := getResponseBody(resp)
-	if err != nil {
-		slog.Debug("EmbeddingSpan: failed to read response body, continuing without it", "provider", provider, "error", err)
-	}
+	reqB := readHTTPRequestBodyLenient("EmbeddingSpan", req, baseSpan, "provider", provider)
+	respB := readHTTPResponseBodyLenient("EmbeddingSpan", resp, baseSpan, "provider", provider)
 
 	slog.Debug("Embedding", "provider", provider, "request", string(reqB), "response", string(respB))
 
-	var parsedRequest request.EmbeddingRequest
-	if err := json.Unmarshal(reqB, &parsedRequest); err != nil {
-		slog.Debug("failed to parse embedding request", "provider", provider, "error", err)
-	}
+	parsedRequest := parseEmbeddingRequest(reqB)
 
 	var parsedResponse request.EmbeddingResponse
-	if len(respB) > 0 {
-		if err := json.Unmarshal(respB, &parsedResponse); err != nil {
-			slog.Debug("failed to parse embedding response", "provider", provider, "error", err)
-		}
+	if len(respB) > 0 && !unmarshalJSON(respB, &parsedResponse) {
+		slog.Debug("failed to parse embedding response", "provider", provider)
 	}
 
 	baseSpan.SubType = request.HTTPSubtypeEmbedding

--- a/pkg/ebpf/common/http/gemini.go
+++ b/pkg/ebpf/common/http/gemini.go
@@ -4,9 +4,7 @@
 package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -112,27 +110,26 @@ func GeminiSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 		return *baseSpan, false
 	}
 
-	reqB, err := io.ReadAll(req.Body)
-	if err != nil {
+	reqB, ok := readHTTPRequestBody("GeminiSpan", req, baseSpan)
+	if !ok {
 		return *baseSpan, false
 	}
-	req.Body = io.NopCloser(bytes.NewBuffer(reqB))
 
-	respB, err := getResponseBody(resp)
-	if err != nil && len(respB) == 0 {
+	respB, ok := readHTTPResponseBody("GeminiSpan", resp, baseSpan)
+	if !ok {
 		return *baseSpan, false
 	}
 
 	slog.Debug("Gemini", "request", string(reqB), "response", string(respB))
 
 	var parsedRequest request.GeminiRequest
-	if err := json.Unmarshal(reqB, &parsedRequest); err != nil {
-		slog.Debug("failed to parse Gemini request", "error", err)
+	if !unmarshalJSON(reqB, &parsedRequest) {
+		slog.Debug("failed to parse Gemini request, continuing with partial fields")
 	}
 
 	var parsedResponse request.GeminiResponse
-	if err := json.Unmarshal(respB, &parsedResponse); err != nil {
-		slog.Debug("failed to parse Gemini response", "error", err)
+	if !unmarshalJSON(respB, &parsedResponse) {
+		slog.Debug("failed to parse Gemini response, continuing with partial fields")
 	}
 
 	model := extractGeminiModel(req)

--- a/pkg/ebpf/common/http/openai.go
+++ b/pkg/ebpf/common/http/openai.go
@@ -4,9 +4,7 @@
 package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -66,27 +64,26 @@ func OpenAISpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 		return *baseSpan, false
 	}
 
-	reqB, err := io.ReadAll(req.Body)
-	if err != nil {
+	reqB, ok := readHTTPRequestBody("OpenAISpan", req, baseSpan, "headers", resp.Header)
+	if !ok {
 		return *baseSpan, false
 	}
-	req.Body = io.NopCloser(bytes.NewBuffer(reqB))
 
-	respB, err := getResponseBody(resp)
-	if err != nil && len(respB) == 0 {
+	respB, ok := readHTTPResponseBody("OpenAISpan", resp, baseSpan, "headers", resp.Header)
+	if !ok {
 		return *baseSpan, false
 	}
 
 	slog.Debug("OpenAI", "request", string(reqB), "response", string(respB))
 
-	var parsedRequest request.OpenAIInput
-	if err := json.Unmarshal(reqB, &parsedRequest); err != nil {
-		slog.Debug("failed to parse OpenAI request", "error", err)
-	}
+	parsedRequest := parseOpenAIInput(reqB)
+	parsedResponse := parseVendorOpenAI(respB)
 
-	var parsedResponse request.VendorOpenAI
-	if err := json.Unmarshal(respB, &parsedResponse); err != nil {
-		slog.Debug("failed to parse OpenAI response", "error", err)
+	if parsedResponse.ResponseModel == "" {
+		parsedResponse.ResponseModel = parsedRequest.Model
+	}
+	if parsedRequest.Model == "" {
+		parsedRequest.Model = parsedResponse.ResponseModel
 	}
 
 	parsedResponse.Request = parsedRequest

--- a/pkg/ebpf/common/http/openai_test.go
+++ b/pkg/ebpf/common/http/openai_test.go
@@ -252,6 +252,47 @@ func TestOpenAISpan_UsageTokenHelpers(t *testing.T) {
 	assert.Equal(t, 15, u2.GetOutputTokens())
 }
 
+func TestOpenAISpan_PartialRequestBody(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "http://api.openai.com/v1/chat/completions", nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(completionsRequestBody))
+
+	truncated := completionsRequestBody[:len(completionsRequestBody)-len(`,"temperature":1.0}`)]
+	req.Body = &partialReadCloser{
+		data: []byte(truncated),
+		err:  io.ErrUnexpectedEOF,
+	}
+
+	resp := makeGzipResponse(t, http.StatusOK, openAIHeaders(), completionsResponseBody)
+	base := &request.Span{ContentLength: int64(len(completionsRequestBody))}
+	span, ok := OpenAISpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI.OpenAI)
+	assert.Equal(t, "gpt-4o-mini", span.GenAI.OpenAI.Request.Model)
+	assert.Equal(t, "chatcmpl-DBTg5Ms2mJhaAhZ56Wq8QSf2djw3S", span.GenAI.OpenAI.ID)
+}
+
+func TestOpenAISpan_PartialResponseBody(t *testing.T) {
+	req := makeRequest(t, http.MethodPost, "http://api.openai.com/v1/chat/completions", completionsRequestBody)
+
+	truncated := completionsResponseBody[:300]
+	h := openAIHeaders()
+	h.Del("Content-Encoding")
+	resp := makePlainResponse(http.StatusOK, h, truncated)
+
+	base := &request.Span{}
+	span, ok := OpenAISpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI.OpenAI)
+	assert.Equal(t, "chatcmpl-DBTg5Ms2mJhaAhZ56Wq8QSf2djw3S", span.GenAI.OpenAI.ID)
+	assert.Equal(t, request.ChatOperationName, span.GenAI.OpenAI.OperationName)
+	assert.Equal(t, "gpt-4o-mini-2024-07-18", span.GenAI.OpenAI.ResponseModel)
+	assert.Equal(t, 0, span.GenAI.OpenAI.Usage.GetInputTokens())
+}
+
 func TestOpenAISpan_GetOutput(t *testing.T) {
 	// output field populated (responses API) - normalized to semconv schema
 	ai := &request.VendorOpenAI{Output: []byte(`[{"type":"message","status":"completed","content":[{"type":"output_text","text":"Arrr!"}],"role":"assistant"}]`)}

--- a/pkg/ebpf/common/http/partial_json.go
+++ b/pkg/ebpf/common/http/partial_json.go
@@ -1,0 +1,227 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+)
+
+var jsonBestEffort = jsoniter.ConfigCompatibleWithStandardLibrary
+
+const (
+	// modelSearchWindow limits model-field regex to the start of the body so
+	// we don't match "model" keys inside user prompts or message content.
+	modelSearchWindow = 200
+	// responseHeaderSearchWindow limits regex extraction for top-level response
+	// fields (id, model, object) so we don't match nested values in payloads.
+	responseHeaderSearchWindow = 800
+)
+
+var jsonStringFieldRegexpCache sync.Map
+
+func jsonStringFieldRegexp(field string) *regexp.Regexp {
+	if cached, ok := jsonStringFieldRegexpCache.Load(field); ok {
+		return cached.(*regexp.Regexp)
+	}
+	re := regexp.MustCompile(`"` + field + `"\s*:\s*"([^"]+)"`)
+	actual, _ := jsonStringFieldRegexpCache.LoadOrStore(field, re)
+	return actual.(*regexp.Regexp)
+}
+
+// extractJSONStringField returns the string value for a top-level JSON field
+// using regex. window limits the search range; 0 searches the full body.
+func extractJSONStringField(body []byte, field string, window int) string {
+	if len(body) == 0 {
+		return ""
+	}
+	search := body
+	if window > 0 && len(search) > window {
+		search = search[:window]
+	}
+	if matches := jsonStringFieldRegexp(field).FindSubmatch(search); len(matches) == 2 {
+		return strings.TrimSpace(string(matches[1]))
+	}
+	return ""
+}
+
+// extractModelField tries the early body window first, then the full captured
+// prefix. Used only when jsoniter could not reach model before truncation.
+func extractModelField(body []byte) string {
+	if model := extractJSONStringField(body, "model", modelSearchWindow); model != "" {
+		return model
+	}
+	return extractJSONStringField(body, "model", 0)
+}
+
+// unmarshalJSONBestEffort unmarshals body into v using json-iterator, which
+// populates fields seen before truncation even when the JSON is incomplete.
+func unmarshalJSONBestEffort(body []byte, v any) {
+	if len(body) == 0 {
+		return
+	}
+	_ = jsonBestEffort.Unmarshal(body, v)
+}
+
+func readHTTPRequestBody(component string, req *http.Request, baseSpan *request.Span, emptyLogAttrs ...any) ([]byte, bool) {
+	if req == nil || req.Body == nil {
+		return nil, true
+	}
+	body, err := io.ReadAll(req.Body)
+	req.Body = io.NopCloser(bytes.NewBuffer(body))
+	if err == nil {
+		return body, true
+	}
+	if len(body) == 0 {
+		if len(emptyLogAttrs) > 0 {
+			slog.Debug(component+": request body is empty", emptyLogAttrs...)
+		}
+		return nil, false
+	}
+	logTruncatedRequestBody(component, err, len(body), req, baseSpan)
+	return body, true
+}
+
+func readHTTPResponseBody(component string, resp *http.Response, baseSpan *request.Span, emptyLogAttrs ...any) ([]byte, bool) {
+	body, err := getResponseBody(resp)
+	if err == nil {
+		return body, true
+	}
+	if len(body) == 0 {
+		if len(emptyLogAttrs) > 0 {
+			slog.Debug(component+": response body is empty", emptyLogAttrs...)
+		}
+		return nil, false
+	}
+	logTruncatedResponseBody(component, err, len(body), resp, baseSpan)
+	return body, true
+}
+
+// readHTTPRequestBodyLenient reads the request body without aborting when the
+// read fails with no bytes — used when classification already succeeded.
+func readHTTPRequestBodyLenient(component string, req *http.Request, baseSpan *request.Span, logAttrs ...any) []byte {
+	if req == nil || req.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(req.Body)
+	req.Body = io.NopCloser(bytes.NewBuffer(body))
+	if err == nil {
+		return body
+	}
+	if len(body) == 0 {
+		logAttrs = append(logAttrs, "error", err)
+		slog.Debug(component+": failed to read request body, continuing without it", logAttrs...)
+		return nil
+	}
+	logTruncatedRequestBody(component, err, len(body), req, baseSpan)
+	return body
+}
+
+// readHTTPResponseBodyLenient reads the response body without aborting when
+// the read fails with no bytes.
+func readHTTPResponseBodyLenient(component string, resp *http.Response, baseSpan *request.Span, logAttrs ...any) []byte {
+	body, err := getResponseBody(resp)
+	if err == nil {
+		return body
+	}
+	if len(body) == 0 {
+		logAttrs = append(logAttrs, "error", err)
+		slog.Debug(component+": failed to read response body, continuing without it", logAttrs...)
+		return nil
+	}
+	logTruncatedResponseBody(component, err, len(body), resp, baseSpan)
+	return body
+}
+
+func logTruncatedRequestBody(component string, err error, got int, req *http.Request, baseSpan *request.Span) {
+	slog.Debug(component+": truncated request body, continuing with partial data",
+		"error", err,
+		"bytes", got,
+		"contentLength", req.ContentLength,
+		"spanContentLength", baseSpan.ContentLength,
+	)
+}
+
+func logTruncatedResponseBody(component string, err error, got int, resp *http.Response, baseSpan *request.Span) {
+	slog.Debug(component+": truncated response body, continuing with partial data",
+		"error", err,
+		"bytes", got,
+		"contentLength", resp.ContentLength,
+		"spanResponseLength", baseSpan.ResponseLength,
+	)
+}
+
+func parseOpenAIInput(body []byte) request.OpenAIInput {
+	var parsed request.OpenAIInput
+	unmarshalJSONBestEffort(body, &parsed)
+	if parsed.Model == "" {
+		parsed.Model = extractModelField(body)
+	}
+	return parsed
+}
+
+func parseVendorOpenAI(body []byte) request.VendorOpenAI {
+	var parsed request.VendorOpenAI
+	unmarshalJSONBestEffort(body, &parsed)
+	if parsed.ID == "" {
+		parsed.ID = extractJSONStringField(body, "id", responseHeaderSearchWindow)
+	}
+	if parsed.ResponseModel == "" {
+		parsed.ResponseModel = extractJSONStringField(body, "model", responseHeaderSearchWindow)
+	}
+	if parsed.OperationName == "" {
+		parsed.OperationName = extractJSONStringField(body, "object", responseHeaderSearchWindow)
+	}
+	return parsed
+}
+
+func parseAnthropicRequest(body []byte) request.AnthropicRequest {
+	var parsed request.AnthropicRequest
+	unmarshalJSONBestEffort(body, &parsed)
+	if parsed.Model == "" {
+		parsed.Model = extractModelField(body)
+	}
+	return parsed
+}
+
+func parseAnthropicResponse(body []byte) request.AnthropicResponse {
+	var parsed request.AnthropicResponse
+	unmarshalJSONBestEffort(body, &parsed)
+	if parsed.ID == "" {
+		parsed.ID = extractJSONStringField(body, "id", responseHeaderSearchWindow)
+	}
+	if parsed.Model == "" {
+		parsed.Model = extractJSONStringField(body, "model", responseHeaderSearchWindow)
+	}
+	if parsed.Type == "" {
+		parsed.Type = extractJSONStringField(body, "type", responseHeaderSearchWindow)
+	}
+	return parsed
+}
+
+func parseEmbeddingRequest(body []byte) request.EmbeddingRequest {
+	var parsed request.EmbeddingRequest
+	unmarshalJSONBestEffort(body, &parsed)
+	if parsed.Model == "" {
+		parsed.Model = extractModelField(body)
+	}
+	return parsed
+}
+
+// unmarshalJSON is a thin wrapper for callers that only need a success flag.
+func unmarshalJSON(body []byte, v any) bool {
+	if len(body) == 0 {
+		return false
+	}
+	return jsonBestEffort.Unmarshal(body, v) == nil
+}

--- a/pkg/ebpf/common/http/partial_json_test.go
+++ b/pkg/ebpf/common/http/partial_json_test.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractModelField(t *testing.T) {
+	full := `{"messages":[{"role":"user","content":"hi"}],"model":"gpt-4o-mini","temperature":1.0}`
+	truncated := full[:len(full)-len(`,"temperature":1.0}`)]
+
+	assert.Equal(t, "gpt-4o-mini", extractModelField([]byte(full)))
+	assert.Equal(t, "gpt-4o-mini", extractModelField([]byte(truncated)))
+	assert.Empty(t, extractModelField(nil))
+}
+
+func TestExtractJSONStringField_respectsWindow(t *testing.T) {
+	body := []byte(`{"nested":{"id":"inner"},"id":"outer"}`)
+	assert.Equal(t, "inner", extractJSONStringField(body, "id", 0))
+	assert.NotEmpty(t, extractJSONStringField(body, "id", 50))
+}
+
+func TestParseOpenAIInput_truncated(t *testing.T) {
+	body := []byte(`{"model":"gpt-5-mini","input":"hello`)
+	parsed := parseOpenAIInput(body)
+	assert.Equal(t, "gpt-5-mini", parsed.Model)
+}
+
+func TestParseVendorOpenAI_truncated(t *testing.T) {
+	body := []byte(`{"id":"resp_123","object":"response","model":"gpt-5-mini","output":[`)
+	parsed := parseVendorOpenAI(body)
+	assert.Equal(t, "resp_123", parsed.ID)
+	assert.Equal(t, "response", parsed.OperationName)
+	assert.Equal(t, "gpt-5-mini", parsed.ResponseModel)
+}
+
+func TestParseAnthropicRequest_truncated(t *testing.T) {
+	body := []byte(`{"model":"claude-3-opus","messages":[{"role":"user","content":"hi"}`)
+	parsed := parseAnthropicRequest(body)
+	assert.Equal(t, "claude-3-opus", parsed.Model)
+}
+
+func TestParseEmbeddingRequest_truncated(t *testing.T) {
+	body := []byte(`{"model":"text-embedding-3-small","input":"food`)
+	parsed := parseEmbeddingRequest(body)
+	assert.Equal(t, "text-embedding-3-small", parsed.Model)
+}

--- a/pkg/ebpf/common/http/qwen.go
+++ b/pkg/ebpf/common/http/qwen.go
@@ -4,9 +4,7 @@
 package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
 
 import (
-	"bytes"
 	"encoding/json"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -28,40 +26,20 @@ func QwenSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (r
 		return *baseSpan, false
 	}
 
-	reqB, err := io.ReadAll(req.Body)
-	if err != nil && len(reqB) == 0 {
+	reqB, ok := readHTTPRequestBody("QwenSpan", req, baseSpan)
+	if !ok {
 		return *baseSpan, false
 	}
-	if err != nil {
-		slog.Debug("failed to fully read Qwen request body", "error", err)
-	}
-	req.Body = io.NopCloser(bytes.NewBuffer(reqB))
 
-	respB, err := getResponseBody(resp)
-	if err != nil && len(respB) == 0 {
+	respB, ok := readHTTPResponseBody("QwenSpan", resp, baseSpan)
+	if !ok {
 		return *baseSpan, false
 	}
 
 	slog.Debug("Qwen", "request", string(reqB), "response", string(respB))
 
-	var parsedRequest request.OpenAIInput
-	if err := json.Unmarshal(reqB, &parsedRequest); err != nil {
-		slog.Debug("failed to parse Qwen request", "error", err)
-	}
-	if parsedRequest.Model == "" {
-		window := reqB
-		if len(window) > modelSearchWindow {
-			window = window[:modelSearchWindow]
-		}
-		if matches := modelFieldRegexp.FindSubmatch(window); len(matches) == 2 {
-			parsedRequest.Model = strings.TrimSpace(string(matches[1]))
-		}
-	}
-
-	var parsedResponse request.VendorOpenAI
-	if err := json.Unmarshal(respB, &parsedResponse); err != nil {
-		slog.Debug("failed to parse Qwen response", "error", err)
-	}
+	parsedRequest := parseOpenAIInput(reqB)
+	parsedResponse := parseVendorOpenAI(respB)
 
 	if parsedResponse.ID == "" {
 		var responseID struct {

--- a/pkg/ebpf/common/http/responses.go
+++ b/pkg/ebpf/common/http/responses.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -66,31 +67,32 @@ func requestPath(req *http.Request) string {
 // key buried inside a user prompt, message content, or document text.
 var modelFieldRegexp = regexp.MustCompile(`"model"\s*:\s*"([^"]+)"`)
 
-// modelSearchWindow limits the search window for model field extraction
-// to avoid matching "model" keys buried inside user-provided content.
-const modelSearchWindow = 200
-
 // getResponseBody tries to read the body as plain text and then
 // if it's encoded in compressed format, it tries to decompress
 func getResponseBody(resp *http.Response) ([]byte, error) {
-	respB, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
+	respB, readErr := io.ReadAll(resp.Body)
+	if readErr != nil && len(respB) == 0 {
+		return nil, readErr
 	}
 	resp.Body = io.NopCloser(bytes.NewBuffer(respB))
 
 	// http.ReadResponse does NOT auto-decompress Content-Encoding
 	// (only http.Transport does, and only for gzip). Decompress manually.
 	body := respB
+	var decErr error
 	if enc := resp.Header.Get("Content-Encoding"); enc != "" && len(respB) > 0 {
 		dec, err := decompressBody(enc, respB)
-		if err != nil {
+		if err != nil && len(dec) == 0 {
 			return nil, fmt.Errorf("decompress error (enc=%s, truncated body?): %w", enc, err)
 		}
 		body = dec
+		decErr = err
 	}
 
-	return body, nil
+	if decErr != nil {
+		return body, decErr
+	}
+	return body, readErr
 }
 
 // decompressBody decompresses b according to the Content-Encoding value.
@@ -138,7 +140,7 @@ func decompressBody(encoding string, b []byte) ([]byte, error) {
 
 func readBodyWithLimit(reader io.Reader, limit int64) ([]byte, error) {
 	body, err := io.ReadAll(io.LimitReader(reader, limit+1))
-	if err != nil {
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, err
 	}
 
@@ -146,5 +148,5 @@ func readBodyWithLimit(reader io.Reader, limit int64) ([]byte, error) {
 		return nil, errResponseBodyTooLarge
 	}
 
-	return body, nil
+	return body, err
 }


### PR DESCRIPTION
## Summary

Use besteffort parsing of the genai request and response, similar to how qwen was already handled, but consistently across all parsing. Even if the buffer size is smaller then the request/response - parse it as much of the attributes (like operation and request model) as possible.

addressing https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2174

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [X] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
