### PR TITLE
Add various validate tags to config structs

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -136,7 +136,7 @@ DiscoveryConfig for the discover.ProcessFinder pipeline
 | `discovery.excluded_linux_system_paths` | `string`[] |  | `/lib/systemd/`, `/usr/lib/systemd/`, `/usr/libexec/`, `/sbin/`, `/usr/sbin/` |  |  | Executable paths for which we don't run language detection and cannot be selected using the path or language selection criteria |
 | `discovery.instrument` | [`GlobAttributes`](#globattributes)[] |  |  |  |  | Selects the services to instrument via Globs. If this section is set, both the Services and ExcludeServices section is ignored. If the user defined the OTEL_EBPF_INSTRUMENT_COMMAND or OTEL_EBPF_INSTRUMENT_PORTS variables, they will be automatically added to the instrument criteria, with the lowest preference. |
 | `discovery.min_process_age` | `duration` | `OTEL_EBPF_MIN_PROCESS_AGE` | `5s` | `30s`, `5m`, `1ms`, etc |  | Min process age to be considered for discovery. |
-| `discovery.poll_interval` | `duration` | `OTEL_EBPF_DISCOVERY_POLL_INTERVAL` | `0s` | `30s`, `5m`, `1ms`, etc |  | Specifies, for the poll service watcher, the interval time between process inspections |
+| `discovery.poll_interval` | `duration` | `OTEL_EBPF_DISCOVERY_POLL_INTERVAL` | `0s` | `30s`, `5m`, `1ms`, etc |  | Specifies, for the poll service watcher, the interval time between process inspections. 0 is treated as a default (5s) by the process watcher. |
 | `discovery.route_harvester_timeout` | `duration` | `OTEL_EBPF_ROUTE_HARVESTER_TIMEOUT` | `10s` | `30s`, `5m`, `1ms`, etc |  |  |
 | `discovery.services` | [`RegexSelector`](#regexselector)[] |  |  |  | Yes | Selection. If the user defined the OTEL_EBPF_EXECUTABLE_PATH or OTEL_EBPF_OPEN_PORT variables, they will be automatically added to the services definition criteria, with the lowest preference.  Use Instrument instead |
 | `discovery.skip_go_specific_tracers` | `boolean` | `OTEL_EBPF_SKIP_GO_SPECIFIC_TRACERS` | `false` |  |  | This can be enabled to use generic HTTP tracers only, no Go-specifics will be used: |
@@ -337,7 +337,7 @@ AttributesConfig stores the user-provided section for filtering either Applicati
 
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
 |---|---|---|---|---|---|---|
-| `health_check.port` | `integer` | `OTEL_EBPF_HEALTH_CHECK_PORT` | `0` |  |  |  |
+| `health_check.port` | `integer` | `OTEL_EBPF_HEALTH_CHECK_PORT` | `0` |  |  | 0 (default) means disabled |
 
 ## `internal_metrics`
 
@@ -363,7 +363,7 @@ TODO: TLS
 | `internal_metrics.prometheus.features` | `string`[] | `OTEL_EBPF_PROMETHEUS_FEATURES` | `0` | `*`, `all`, `application`, `application_host`, `application_service_graph`, `application_span`, `application_span_otel`, `application_span_sizes`, `ebpf`, `network`, `network_inter_zone`, `stats`, `stats_tcp_failed_connections`, `stats_tcp_retransmits`, `stats_tcp_rtt` | Yes | Features specifies which metric features to export. Accepted values: application, network, application_span, application_service_graph, ...  use top-level MetricsConfig.Features instead. |
 | `internal_metrics.prometheus.instrumentations` | `string`[] | `OTEL_EBPF_PROMETHEUS_INSTRUMENTATIONS` | `*` | `*`, `amqp`, `couchbase`, `dns`, `genai`, `gpu`, `grpc`, `http`, `kafka`, `memcached`, `mongo`, `mqtt`, `nats`, `redis`, `sql` |  | Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql... |
 | `internal_metrics.prometheus.path` | `string` | `OTEL_EBPF_PROMETHEUS_PATH` | `/internal/metrics` |  |  |  |
-| `internal_metrics.prometheus.port` | `integer` | `OTEL_EBPF_PROMETHEUS_PORT` | `0` |  |  |  |
+| `internal_metrics.prometheus.port` | `integer` | `OTEL_EBPF_PROMETHEUS_PORT` | `0` |  |  | 0 means disabled |
 | `internal_metrics.prometheus.service_cache_size` | `integer` |  | `10000` |  |  |  |
 | `internal_metrics.prometheus.ttl` | `duration` | `OTEL_EBPF_PROMETHEUS_TTL` | `5m` | `30s`, `5m`, `1ms`, etc |  | Specifies the time since a metric was updated for the last time until it is removed from the metrics set. |
 
@@ -554,7 +554,7 @@ TODO: TLS
 | `prometheus_export.features` | `string`[] | `OTEL_EBPF_PROMETHEUS_FEATURES` | `0` | `*`, `all`, `application`, `application_host`, `application_service_graph`, `application_span`, `application_span_otel`, `application_span_sizes`, `ebpf`, `network`, `network_inter_zone`, `stats`, `stats_tcp_failed_connections`, `stats_tcp_retransmits`, `stats_tcp_rtt` | Yes | Features specifies which metric features to export. Accepted values: application, network, application_span, application_service_graph, ...  use top-level MetricsConfig.Features instead. |
 | `prometheus_export.instrumentations` | `string`[] | `OTEL_EBPF_PROMETHEUS_INSTRUMENTATIONS` | `*` | `*`, `amqp`, `couchbase`, `dns`, `genai`, `gpu`, `grpc`, `http`, `kafka`, `memcached`, `mongo`, `mqtt`, `nats`, `redis`, `sql` |  | Allows configuration of which instrumentations should be enabled, e.g. http, grpc, sql... |
 | `prometheus_export.path` | `string` | `OTEL_EBPF_PROMETHEUS_PATH` | `/internal/metrics` |  |  |  |
-| `prometheus_export.port` | `integer` | `OTEL_EBPF_PROMETHEUS_PORT` | `0` |  |  |  |
+| `prometheus_export.port` | `integer` | `OTEL_EBPF_PROMETHEUS_PORT` | `0` |  |  | 0 means disabled |
 | `prometheus_export.service_cache_size` | `integer` |  | `10000` |  |  |  |
 | `prometheus_export.ttl` | `duration` | `OTEL_EBPF_PROMETHEUS_TTL` | `5m` | `30s`, `5m`, `1ms`, etc |  | Specifies the time since a metric was updated for the last time until it is removed from the metrics set. |
 
@@ -576,9 +576,9 @@ RoutesConfig allows grouping URLs sharing a given pattern.
 |---|---|---|---|---|---|---|
 | `routes.ignore_mode` | `string` |  |  | `all`, `metrics`, `traces` | Yes | To be removed and replaced by a collector-like filtering mechanism |
 | `routes.ignored_patterns` | `string`[] |  |  |  | Yes | To be removed and replaced by a collector-like filtering mechanism |
-| `routes.max_path_segment_cardinality` | `integer` |  | `10` |  |  | Max allowed path segment cardinality (per service) for the heuristic matcher |
+| `routes.max_path_segment_cardinality` | `integer` |  | `10` |  |  | Max allowed path segment cardinality (per service) for the heuristic matcher 0 = disabled |
 | `routes.patterns` | `string`[] |  |  |  |  | Defines the URL path patterns that will match to a route |
-| `routes.unmatched` | `string` |  | `heuristic` | `heuristic`, `low-cardinality`, `path`, `unset`, `wildcard` |  | Specifies what to do when a route pattern is not matched |
+| `routes.unmatched` | `string` |  | `heuristic` | `heuristic`, `low-cardinality`, `path`, `unset`, `wildcard` |  | Specifies what to do when a route pattern is not matched. Empty string is treated the same as "wildcard". |
 | `routes.wildcard_char` | `string` |  | `*` |  |  | Character that will be used to replace route segments |
 
 ## `stats`

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -493,7 +493,7 @@
         "poll_interval": {
           "type": "string",
           "pattern": "^[0-9]+(ms|s|m)$",
-          "description": "Specifies, for the poll service watcher, the interval time between process inspections",
+          "description": "Specifies, for the poll service watcher, the interval time between process inspections. 0 is treated as a default (5s) by the process watcher.",
           "default": "0s",
           "examples": [
             "30s",
@@ -1260,6 +1260,7 @@
       "properties": {
         "port": {
           "type": "integer",
+          "description": "0 (default) means disabled",
           "default": 0,
           "x-env-var": "OTEL_EBPF_HEALTH_CHECK_PORT"
         }
@@ -2158,6 +2159,7 @@
         },
         "port": {
           "type": "integer",
+          "description": "0 means disabled",
           "default": 0,
           "x-env-var": "OTEL_EBPF_PROMETHEUS_PORT"
         },
@@ -2480,7 +2482,7 @@
         },
         "max_path_segment_cardinality": {
           "type": "integer",
-          "description": "Max allowed path segment cardinality (per service) for the heuristic matcher",
+          "description": "Max allowed path segment cardinality (per service) for the heuristic matcher 0 = disabled",
           "default": 10
         },
         "patterns": {
@@ -2499,7 +2501,7 @@
             "unset",
             "wildcard"
           ],
-          "description": "Specifies what to do when a route pattern is not matched",
+          "description": "Specifies what to do when a route pattern is not matched. Empty string is treated the same as \"wildcard\".",
           "default": "heuristic"
         },
         "wildcard_char": {

--- a/pkg/appolly/services/criteria.go
+++ b/pkg/appolly/services/criteria.go
@@ -104,8 +104,8 @@ type DiscoveryConfig struct {
 	DefaultExcludeInstrument GlobDefinitionCriteria `yaml:"default_exclude_instrument"`
 
 	// PollInterval specifies, for the poll service watcher, the interval time between
-	// process inspections
-	PollInterval time.Duration `yaml:"poll_interval" env:"OTEL_EBPF_DISCOVERY_POLL_INTERVAL"`
+	// process inspections. 0 is treated as a default (5s) by the process watcher.
+	PollInterval time.Duration `yaml:"poll_interval" env:"OTEL_EBPF_DISCOVERY_POLL_INTERVAL" validate:"gte=0"`
 
 	// This can be enabled to use generic HTTP tracers only, no Go-specifics will be used:
 	SkipGoSpecificTracers bool `yaml:"skip_go_specific_tracers" env:"OTEL_EBPF_SKIP_GO_SPECIFIC_TRACERS"`
@@ -118,15 +118,15 @@ type DiscoveryConfig struct {
 
 	// DefaultOtlpGRPCPort specifies the default OTLP gRPC port (4317) to fallback on when missing environment variables on service, for
 	// checking for grpc export requests, defaults to 4317
-	DefaultOtlpGRPCPort int `yaml:"default_otlp_grpc_port" env:"OTEL_EBPF_DEFAULT_OTLP_GRPC_PORT"`
+	DefaultOtlpGRPCPort int `yaml:"default_otlp_grpc_port" env:"OTEL_EBPF_DEFAULT_OTLP_GRPC_PORT" validate:"gte=0,lte=65535"`
 
 	// Min process age to be considered for discovery.
-	MinProcessAge time.Duration `yaml:"min_process_age" env:"OTEL_EBPF_MIN_PROCESS_AGE"`
+	MinProcessAge time.Duration `yaml:"min_process_age" env:"OTEL_EBPF_MIN_PROCESS_AGE" validate:"gte=0"`
 
 	// Disables generation of span metrics of services which are already instrumented
 	ExcludeOTelInstrumentedServicesSpanMetrics bool `yaml:"exclude_otel_instrumented_services_span_metrics" env:"OTEL_EBPF_EXCLUDE_OTEL_INSTRUMENTED_SERVICES_SPAN_METRICS"`
 
-	RouteHarvesterTimeout time.Duration `yaml:"route_harvester_timeout" env:"OTEL_EBPF_ROUTE_HARVESTER_TIMEOUT"`
+	RouteHarvesterTimeout time.Duration `yaml:"route_harvester_timeout" env:"OTEL_EBPF_ROUTE_HARVESTER_TIMEOUT" validate:"gt=0"`
 
 	DisabledRouteHarvesters []RouteHarvesterLanguage `yaml:"disabled_route_harvesters"`
 

--- a/pkg/appolly/services/samplerconfig.go
+++ b/pkg/appolly/services/samplerconfig.go
@@ -25,7 +25,7 @@ const (
 // https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_traces_sampler
 // We don't support, yet, the jaeger and xray samplers.
 type SamplerConfig struct {
-	Name SamplerName `yaml:"name" env:"OTEL_TRACES_SAMPLER"`
+	Name SamplerName `yaml:"name" env:"OTEL_TRACES_SAMPLER" validate:"omitempty,oneof=always_on always_off traceidratio parentbased_always_on parentbased_always_off parentbased_traceidratio"`
 	Arg  string      `yaml:"arg" env:"OTEL_TRACES_SAMPLER_ARG"`
 }
 

--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -124,10 +124,10 @@ type EBPFTracer struct {
 	// Maximum time allowed for two requests to be correlated as parent -> child
 	// Some programs (e.g. load generators) keep on generating requests from the same thread in perpetuity,
 	// which can generate very large traces. We want to mark the parent trace as invalid if this happens.
-	MaxTransactionTime time.Duration `yaml:"max_transaction_time" env:"OTEL_EBPF_BPF_MAX_TRANSACTION_TIME"`
+	MaxTransactionTime time.Duration `yaml:"max_transaction_time" env:"OTEL_EBPF_BPF_MAX_TRANSACTION_TIME" validate:"gt=0"`
 
 	// DNS timeout after which we report failed event
-	DNSRequestTimeout time.Duration `yaml:"dns_request_timeout" env:"OTEL_EBPF_BPF_DNS_REQUEST_TIMEOUT"`
+	DNSRequestTimeout time.Duration `yaml:"dns_request_timeout" env:"OTEL_EBPF_BPF_DNS_REQUEST_TIMEOUT" validate:"gt=0"`
 
 	// Log trace-context enricher config
 	LogEnricher LogEnricherConfig `yaml:"log_enricher"`

--- a/pkg/export/imetrics/imetrics.go
+++ b/pkg/export/imetrics/imetrics.go
@@ -51,20 +51,11 @@ const (
 	InstrumentationErrorInvalidTracepoint              = "invalid_tracepoint"
 )
 
-func (t InternalMetricsExporter) Valid() bool {
-	switch t {
-	case InternalMetricsExporterDisabled, InternalMetricsExporterPrometheus, InternalMetricsExporterOTEL:
-		return true
-	}
-
-	return false
-}
-
 // InternalMetricsConfig options for the different metrics exporters
 type InternalMetricsConfig struct {
 	Prometheus              PrometheusConfig        `yaml:"prometheus,omitempty"`
-	Exporter                InternalMetricsExporter `yaml:"exporter,omitempty" env:"OTEL_EBPF_INTERNAL_METRICS_EXPORTER"`
-	BpfMetricScrapeInterval time.Duration           `yaml:"bpf_metric_scrape_interval" env:"OTEL_EBPF_BPF_METRIC_SCRAPE_INTERVAL"`
+	Exporter                InternalMetricsExporter `yaml:"exporter,omitempty" env:"OTEL_EBPF_INTERNAL_METRICS_EXPORTER" validate:"omitempty,oneof=disabled prometheus otel"`
+	BpfMetricScrapeInterval time.Duration           `yaml:"bpf_metric_scrape_interval" env:"OTEL_EBPF_BPF_METRIC_SCRAPE_INTERVAL" validate:"omitempty,gt=0"`
 }
 
 // Reporter of internal metrics

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -21,7 +21,7 @@ import (
 var pipelineBufferLengths = []float64{0, 10, 20, 40, 80, 160, 320}
 
 type PrometheusConfig struct {
-	Port int    `yaml:"port,omitempty" env:"OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT"`
+	Port int    `yaml:"port,omitempty" env:"OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT" validate:"gte=0,lte=65535"`
 	Path string `yaml:"path,omitempty" env:"OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PATH"`
 }
 

--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -64,12 +64,12 @@ type MetricsConfig struct {
 	HistogramAggregation HistogramAggregation       `yaml:"histogram_aggregation" env:"OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION"`
 	ExponentialHistogram ExponentialHistogramConfig `yaml:"exponential_histogram"`
 
-	ReportersCacheLen int `yaml:"reporters_cache_len" env:"OTEL_EBPF_METRICS_REPORT_CACHE_LEN"`
+	ReportersCacheLen int `yaml:"reporters_cache_len" env:"OTEL_EBPF_METRICS_REPORT_CACHE_LEN" validate:"omitempty,gt=0"`
 
 	// SDKLogLevel works independently from the global LogLevel because it prints GBs of logs in Debug mode
 	// and the Info messages leak internal details that are not usually valuable for the final user.
 	// Accepted values: debug, info, warn, error (case-insensitive).
-	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL"`
+	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL" validate:"omitempty,oneofci=debug info warn error"`
 
 	// Features specifies which metric features to export. Accepted values: application, network,
 	// application_span, application_service_graph, ...

--- a/pkg/export/otel/otelcfg/config_traces.go
+++ b/pkg/export/otel/otelcfg/config_traces.go
@@ -40,7 +40,7 @@ type TracesConfig struct {
 
 	// BatchMaxSize is the maximum number of spans that the batcher will accumulate
 	// before flushing a batch to the sending queue.
-	BatchMaxSize int `yaml:"batch_max_size" env:"OTEL_EBPF_OTLP_TRACES_BATCH_MAX_SIZE"`
+	BatchMaxSize int `yaml:"batch_max_size" env:"OTEL_EBPF_OTLP_TRACES_BATCH_MAX_SIZE" validate:"omitempty,gt=0"`
 
 	// QueueSize is the maximum number of spans that the sending queue will hold
 	// before applying back-pressure. It must be >= `2 * BatchMaxSize`, otherwise the
@@ -54,17 +54,17 @@ type TracesConfig struct {
 	// Configuration options for BackOffConfig of the traces exporter.
 	// See https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configretry/backoff.go
 	// BackOffInitialInterval the time to wait after the first failure before retrying.
-	BackOffInitialInterval time.Duration `yaml:"backoff_initial_interval" env:"OTEL_EBPF_BACKOFF_INITIAL_INTERVAL"`
+	BackOffInitialInterval time.Duration `yaml:"backoff_initial_interval" env:"OTEL_EBPF_BACKOFF_INITIAL_INTERVAL" validate:"omitempty,gt=0"`
 	// BackOffMaxInterval specifies the upper bound on backoff interval.
-	BackOffMaxInterval time.Duration `yaml:"backoff_max_interval" env:"OTEL_EBPF_BACKOFF_MAX_INTERVAL"`
+	BackOffMaxInterval time.Duration `yaml:"backoff_max_interval" env:"OTEL_EBPF_BACKOFF_MAX_INTERVAL" validate:"omitempty,gt=0"`
 	// BackOffMaxElapsedTime specifies the maximum amount of time (including retries) spent trying to send a request/batch.
-	BackOffMaxElapsedTime time.Duration `yaml:"backoff_max_elapsed_time" env:"OTEL_EBPF_BACKOFF_MAX_ELAPSED_TIME"`
-	ReportersCacheLen     int           `yaml:"reporters_cache_len" env:"OTEL_EBPF_TRACES_REPORT_CACHE_LEN"`
+	BackOffMaxElapsedTime time.Duration `yaml:"backoff_max_elapsed_time" env:"OTEL_EBPF_BACKOFF_MAX_ELAPSED_TIME" validate:"omitempty,gt=0"`
+	ReportersCacheLen     int           `yaml:"reporters_cache_len" env:"OTEL_EBPF_TRACES_REPORT_CACHE_LEN" validate:"omitempty,gt=0"`
 
 	// SDKLogLevel works independently from the global LogLevel because it prints GBs of logs in Debug mode
 	// and the Info messages leak internal details that are not usually valuable for the final user.
 	// Accepted values: debug, info, warn, error (case-insensitive). dpanic/panic/fatal are mapped to error.
-	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL"`
+	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL" validate:"omitempty,oneofci=debug info warn error"`
 
 	// OTLPEndpointProvider allows overriding the OTLP Endpoint. It needs to return an endpoint and
 	// a boolean indicating if the endpoint is common for both traces and metrics

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -111,9 +111,9 @@ var (
 
 // NativeHistogramConfig holds configuration for native histograms
 type NativeHistogramConfig struct {
-	BucketFactor     float64       `yaml:"bucket_factor" env:"OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_BUCKET_FACTOR"`
-	MaxBucketNumber  uint32        `yaml:"max_bucket_number" env:"OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MAX_BUCKET_NUMBER"`
-	MinResetDuration time.Duration `yaml:"min_reset_duration" env:"OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MIN_RESET_DURATION"`
+	BucketFactor     float64       `yaml:"bucket_factor" env:"OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_BUCKET_FACTOR" validate:"gt=1"`
+	MaxBucketNumber  uint32        `yaml:"max_bucket_number" env:"OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MAX_BUCKET_NUMBER" validate:"gt=0"`
+	MinResetDuration time.Duration `yaml:"min_reset_duration" env:"OTEL_EBPF_PROMETHEUS_NATIVE_HISTOGRAM_MIN_RESET_DURATION" validate:"gt=0"`
 }
 
 var DefaultNativeHistogramConfig = NativeHistogramConfig{
@@ -125,7 +125,8 @@ var DefaultNativeHistogramConfig = NativeHistogramConfig{
 
 // TODO: TLS
 type PrometheusConfig struct {
-	Port int    `yaml:"port" env:"OTEL_EBPF_PROMETHEUS_PORT"`
+	// 0 means disabled
+	Port int    `yaml:"port" env:"OTEL_EBPF_PROMETHEUS_PORT" validate:"gte=0,lte=65535"`
 	Path string `yaml:"path" env:"OTEL_EBPF_PROMETHEUS_PATH"`
 
 	DisableBuildInfo bool `yaml:"disable_build_info" env:"OTEL_EBPF_PROMETHEUS_DISABLE_BUILD_INFO"`
@@ -144,7 +145,7 @@ type PrometheusConfig struct {
 	// TTL specifies the time since a metric was updated for the last time until it is
 	// removed from the metrics set.
 	TTL                         time.Duration `yaml:"ttl" env:"OTEL_EBPF_PROMETHEUS_TTL"`
-	SpanMetricsServiceCacheSize int           `yaml:"service_cache_size"`
+	SpanMetricsServiceCacheSize int           `yaml:"service_cache_size" validate:"gt=0"`
 
 	AllowServiceGraphSelfReferences bool `yaml:"allow_service_graph_self_references" env:"OTEL_EBPF_PROMETHEUS_ALLOW_SERVICE_GRAPH_SELF_REFERENCES"`
 

--- a/pkg/kube/kubecache/config.go
+++ b/pkg/kube/kubecache/config.go
@@ -30,11 +30,11 @@ type Config struct {
 	// LogLevel can be one of: debug, info, warn, error
 	LogLevel LogLevel `yaml:"log_level" env:"OTEL_EBPF_K8S_CACHE_LOG_LEVEL"`
 	// Port where the service is going to listen to
-	Port int `yaml:"port" env:"OTEL_EBPF_K8S_CACHE_PORT" validate:"gte=0"`
+	Port int `yaml:"port" env:"OTEL_EBPF_K8S_CACHE_PORT" validate:"gte=0,lte=65535"`
 	// MaxConnection is the maximum number of concurrent clients that the service can handle at the same time
 	MaxConnections int `yaml:"max_connections" env:"OTEL_EBPF_K8S_CACHE_MAX_CONNECTIONS" validate:"gte=0"`
 	// ProfilePort is the port where the pprof server is going to listen to. 0 (default) means disabled
-	ProfilePort int `yaml:"profile_port" env:"OTEL_EBPF_K8S_CACHE_PROFILE_PORT" validate:"gte=0"`
+	ProfilePort int `yaml:"profile_port" env:"OTEL_EBPF_K8S_CACHE_PROFILE_PORT" validate:"gte=0,lte=65535"`
 	// InformerResyncPeriod is the time interval between complete resyncs of the informers
 	InformerResyncPeriod time.Duration `yaml:"informer_resync_period" env:"OTEL_EBPF_K8S_CACHE_INFORMER_RESYNC_PERIOD" validate:"gte=0"`
 	// SendTimeout is the maximum duration to wait to receive an event before dropping the connection.

--- a/pkg/kube/kubecache/instrument/server.go
+++ b/pkg/kube/kubecache/instrument/server.go
@@ -12,7 +12,7 @@ import (
 const defaultMetricsPath = "/metrics"
 
 type InternalMetricsConfig struct {
-	Port int    `yaml:"port,omitempty" env:"OTEL_EBPF_K8S_CACHE_INTERNAL_METRICS_PROMETHEUS_PORT"`
+	Port int    `yaml:"port,omitempty" env:"OTEL_EBPF_K8S_CACHE_INTERNAL_METRICS_PROMETHEUS_PORT" validate:"gte=0,lte=65535"`
 	Path string `yaml:"path,omitempty" env:"OTEL_EBPF_K8S_CACHE_INTERNAL_METRICS_PROMETHEUS_PATH"`
 }
 

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -416,7 +416,7 @@ type Config struct {
 	ChannelSendTimeout      time.Duration `yaml:"channel_send_timeout" env:"OTEL_EBPF_CHANNEL_SEND_TIMEOUT"`
 	ChannelSendTimeoutPanic bool          `yaml:"channel_send_timeout_panic" env:"OTEL_EBPF_CHANNEL_SEND_TIMEOUT_PANIC"`
 
-	ProfilePort     int                            `yaml:"profile_port" env:"OTEL_EBPF_PROFILE_PORT"`
+	ProfilePort     int                            `yaml:"profile_port" env:"OTEL_EBPF_PROFILE_PORT" validate:"gte=0,lte=65535"`
 	InternalMetrics imetrics.InternalMetricsConfig `yaml:"internal_metrics"`
 
 	// LogConfig enables the logging of the configuration on startup.
@@ -429,7 +429,8 @@ type Config struct {
 }
 
 type HealthCheckConfig struct {
-	Port int `yaml:"port" env:"OTEL_EBPF_HEALTH_CHECK_PORT"`
+	// 0 (default) means disabled
+	Port int `yaml:"port" env:"OTEL_EBPF_HEALTH_CHECK_PORT" validate:"gte=0,lte=65535"`
 }
 
 func (c *Config) Unmarshal(component *confmap.Conf) error {
@@ -711,10 +712,6 @@ func (c *Config) Validate() error {
 		if c.Metrics.Features.ResolveSpanMetricsConflict() {
 			slog.Warn("application_span and application_span_otel cannot be used together, application_span_otel is selected automatically")
 		}
-	}
-
-	if len(c.Routes.WildcardChar) > 1 {
-		return ConfigError("wildcard_char can only be a single character, multiple characters are not allowed")
 	}
 
 	if c.InternalMetrics.Exporter == imetrics.InternalMetricsExporterOTEL && c.InternalMetrics.Prometheus.Port != 0 {

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -784,6 +784,18 @@ func (c *Config) ExternalLogger(handler slog.Handler, debugMode bool) {
 // 3 - Environment variables
 func LoadConfig(file io.Reader) (*Config, error) {
 	cfg := DefaultConfig
+	// Note: deep-copy each pointer field so YAML/env unmarshal cannot mutate DefaultConfig through shared
+	// pointers. This is a one-level copy: slice fields inside (e.g. Patterns, Sources) still share
+	// their underlying arrays, which is safe because YAML unmarshal replaces slices rather than
+	// appending to them.
+	if cfg.Routes != nil {
+		routesCopy := *cfg.Routes
+		cfg.Routes = &routesCopy
+	}
+	if cfg.NameResolver != nil {
+		nrCopy := *cfg.NameResolver
+		cfg.NameResolver = &nrCopy
+	}
 	if file != nil {
 		cfgBuf, err := io.ReadAll(file)
 		if err != nil {

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -625,6 +625,103 @@ routes:
 	}
 }
 
+func TestConfigValidate_SDKLogLevel(t *testing.T) {
+	t.Run("lowercase accepted", func(t *testing.T) {
+		cfg := loadConfig(t, envMap{"OTEL_EBPF_EXECUTABLE_PATH": "foo", "OTEL_EBPF_TRACE_PRINTER": "text", "OTEL_EBPF_SDK_LOG_LEVEL": "debug"})
+		require.NoError(t, cfg.Validate())
+	})
+	t.Run("uppercase accepted", func(t *testing.T) {
+		cfg := loadConfig(t, envMap{"OTEL_EBPF_EXECUTABLE_PATH": "foo", "OTEL_EBPF_TRACE_PRINTER": "text", "OTEL_EBPF_SDK_LOG_LEVEL": "DEBUG"})
+		require.NoError(t, cfg.Validate())
+	})
+	t.Run("mixed case accepted", func(t *testing.T) {
+		cfg := loadConfig(t, envMap{"OTEL_EBPF_EXECUTABLE_PATH": "foo", "OTEL_EBPF_TRACE_PRINTER": "text", "OTEL_EBPF_SDK_LOG_LEVEL": "Warn"})
+		require.NoError(t, cfg.Validate())
+	})
+	t.Run("invalid value rejected", func(t *testing.T) {
+		cfg := loadConfig(t, envMap{"OTEL_EBPF_EXECUTABLE_PATH": "foo", "OTEL_EBPF_TRACE_PRINTER": "text", "OTEL_EBPF_SDK_LOG_LEVEL": "verbose"})
+		require.Error(t, cfg.Validate())
+	})
+}
+
+func TestConfigValidate_SamplerName(t *testing.T) {
+	t.Run("valid sampler accepted", func(t *testing.T) {
+		userConfig := bytes.NewBufferString(`executable_path: foo
+trace_printer: text
+otel_traces_export:
+  sampler:
+    name: parentbased_always_on
+`)
+		cfg, err := LoadConfig(userConfig)
+		require.NoError(t, err)
+		require.NoError(t, cfg.Validate())
+	})
+	t.Run("invalid sampler rejected", func(t *testing.T) {
+		userConfig := bytes.NewBufferString(`executable_path: foo
+trace_printer: text
+otel_traces_export:
+  sampler:
+    name: invalid_sampler
+`)
+		cfg, err := LoadConfig(userConfig)
+		require.NoError(t, err)
+		require.Error(t, cfg.Validate())
+	})
+}
+
+func TestConfigValidate_Ports(t *testing.T) {
+	t.Run("profile port out of range rejected", func(t *testing.T) {
+		cfg := loadConfig(t, envMap{"OTEL_EBPF_EXECUTABLE_PATH": "foo", "OTEL_EBPF_TRACE_PRINTER": "text", "OTEL_EBPF_PROFILE_PORT": "99999"})
+		require.Error(t, cfg.Validate())
+	})
+	t.Run("health check port out of range rejected", func(t *testing.T) {
+		userConfig := bytes.NewBufferString(`executable_path: foo
+trace_printer: text
+health_check:
+  port: 99999
+`)
+		cfg, err := LoadConfig(userConfig)
+		require.NoError(t, err)
+		require.Error(t, cfg.Validate())
+	})
+}
+
+func TestConfigValidate_RouteHarvesterTimeout(t *testing.T) {
+	t.Run("zero timeout rejected", func(t *testing.T) {
+		userConfig := bytes.NewBufferString(`executable_path: foo
+trace_printer: text
+discovery:
+  route_harvester_timeout: 0s
+`)
+		cfg, err := LoadConfig(userConfig)
+		require.NoError(t, err)
+		require.Error(t, cfg.Validate())
+	})
+}
+
+func TestConfigValidate_NameResolver(t *testing.T) {
+	t.Run("zero cache len rejected", func(t *testing.T) {
+		userConfig := bytes.NewBufferString(`executable_path: foo
+trace_printer: text
+name_resolver:
+  cache_len: 0
+`)
+		cfg, err := LoadConfig(userConfig)
+		require.NoError(t, err)
+		require.Error(t, cfg.Validate())
+	})
+	t.Run("zero cache ttl rejected", func(t *testing.T) {
+		userConfig := bytes.NewBufferString(`executable_path: foo
+trace_printer: text
+name_resolver:
+  cache_expiry: 0s
+`)
+		cfg, err := LoadConfig(userConfig)
+		require.NoError(t, err)
+		require.Error(t, cfg.Validate())
+	})
+}
+
 func TestConfig_OtelGoAutoEnv(t *testing.T) {
 	// OTEL_GO_AUTO_TARGET_EXE is an alias to OTEL_EBPF_AUTO_TARGET_EXE
 	// (Compatibility with OpenTelemetry)

--- a/pkg/transform/name_resolver.go
+++ b/pkg/transform/name_resolver.go
@@ -62,11 +62,11 @@ type NameResolverConfig struct {
 	Sources []Source `yaml:"sources" env:"OTEL_EBPF_NAME_RESOLVER_SOURCES" envSeparator:"," envDefault:"k8s"`
 	// CacheLen specifies the max size of the LRU cache that is checked before
 	// performing the name lookup. Default: 256
-	CacheLen int `yaml:"cache_len" env:"OTEL_EBPF_NAME_RESOLVER_CACHE_LEN"`
+	CacheLen int `yaml:"cache_len" env:"OTEL_EBPF_NAME_RESOLVER_CACHE_LEN" validate:"gt=0"`
 	// CacheTTL specifies the time-to-live of a cached IP->hostname entry. After the
 	// cached entry becomes older than this time, the IP->hostname entry will be looked
 	// up again.
-	CacheTTL time.Duration `yaml:"cache_expiry" env:"OTEL_EBPF_NAME_RESOLVER_CACHE_TTL"`
+	CacheTTL time.Duration `yaml:"cache_expiry" env:"OTEL_EBPF_NAME_RESOLVER_CACHE_TTL" validate:"gt=0"`
 }
 
 type NameResolver struct {

--- a/pkg/transform/routes.go
+++ b/pkg/transform/routes.go
@@ -53,18 +53,20 @@ const wildCard = "/**"
 
 // RoutesConfig allows grouping URLs sharing a given pattern.
 type RoutesConfig struct {
-	// Unmatch specifies what to do when a route pattern is not matched
-	Unmatch UnmatchType `yaml:"unmatched"`
+	// Unmatch specifies what to do when a route pattern is not matched.
+	// Empty string is treated the same as "wildcard".
+	Unmatch UnmatchType `yaml:"unmatched" validate:"omitempty,oneof=unset path wildcard heuristic low-cardinality"`
 	// Patterns defines the URL path patterns that will match to a route
 	Patterns []string `yaml:"patterns"`
 	// Deprecated: To be removed and replaced by a collector-like filtering mechanism
 	IgnorePatterns []string `yaml:"ignored_patterns"`
 	// Deprecated: To be removed and replaced by a collector-like filtering mechanism
-	IgnoredEvents IgnoreMode `yaml:"ignore_mode"`
+	IgnoredEvents IgnoreMode `yaml:"ignore_mode" validate:"omitempty,oneof=metrics traces all"`
 	// Character that will be used to replace route segments
-	WildcardChar string `yaml:"wildcard_char,omitempty" jsonschema:"maxLength=1"`
+	WildcardChar string `yaml:"wildcard_char,omitempty" jsonschema:"maxLength=1" validate:"max=1"`
 	// Max allowed path segment cardinality (per service) for the heuristic matcher
-	MaxPathSegmentCardinality int `yaml:"max_path_segment_cardinality"`
+	// 0 = disabled
+	MaxPathSegmentCardinality int `yaml:"max_path_segment_cardinality" validate:"gte=0"`
 }
 
 func RoutesProvider(rc *RoutesConfig, input, output *msg.Queue[[]request.Span]) swarm.InstanceFunc {


### PR DESCRIPTION
## Summary

This PR adds validate struct tags to config fields.

It also fixes `DefaultConfig` mutation: `Config.Routes` and `Config.NameResolver` are pointer fields, so a shallow copy shares the underlying struct with `DefaultConfig`. YAML unmarshal would overwrite it permanently. LoadConfig now deep-copies both before unmarshalling (I guess it was undetected because no validate tag enforced `WildcardChar` length, and I noticed it during tests).

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
