### PR TITLE
test: fix flaky TestForwardRingbuf_NoEventLoss

### DIFF
--- a/pkg/ebpf/common/ringbuf_test.go
+++ b/pkg/ebpf/common/ringbuf_test.go
@@ -202,9 +202,14 @@ func TestForwardRingbuf_NoEventLoss(t *testing.T) {
 				&metricsReporter{},
 			)(t.Context(), out)
 
-			for range N {
-				ringBuf.events <- HTTPRequestTrace{Type: 1}
-			}
+			// Feed events from a separate goroutine so we consume concurrently.
+			// Producing everything up front before consuming would let the output queue
+			// fill up and deadlock the whole pipeline.
+			go func() {
+				for range N {
+					ringBuf.events <- HTTPRequestTrace{Type: 1}
+				}
+			}()
 
 			received := 0
 			deadline := time.After(10 * time.Second)


### PR DESCRIPTION
## Summary

TestForwardRingbuf_NoEventLoss is flaky ([example](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/26640699734/job/78515319715?pr=2194)):

```
goroutine 540 [sync.Mutex.Lock, 9 minutes]:
```

The deadlock may be caused by feeding in ALL events first, then consuming, rather than doing both concurrently.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
