### PR TITLE
test: fix flaky gRPC_relay_chain_context_propagation

### DIFF
--- a/internal/test/integration/grpc_relay_test.go
+++ b/internal/test/integration/grpc_relay_test.go
@@ -140,14 +140,14 @@ func testGRPCRelayChainContextPropagation(t *testing.T) {
 			defer resp.Body.Close()
 			require.NoError(ctt, json.NewDecoder(resp.Body).Decode(&tq))
 			require.NotEmpty(ctt, tq.Data)
+			svcs := traceServices(tq.Data[0])
+			for _, svc := range expectedRelayServices {
+				require.Contains(ctt, svcs, svc, "trace missing service %s", svc)
+			}
 		}, 30*time.Second, time.Second)
 
-		// Pick the trace and check it spans all expected services.
+		// Pick the completed trace for the structural checks below.
 		trace = tq.Data[0]
-		svcs := traceServices(trace)
-		for _, svc := range expectedRelayServices {
-			require.Contains(ct, svcs, svc, "trace missing service %s", svc)
-		}
 
 		// All checks inside the loop so we retry if Jaeger hasn't
 		// indexed all spans yet.


### PR DESCRIPTION
## Summary

`gRPC_relay_chain_context_propagation` is flaky ([example](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/26643001571/job/78521492450?pr=2196)). Fix by moving the assertion inside the eventually block.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
