### PR TITLE
Fix grpc_relay dotnet dockerfile using bundled protoc

### DIFF
--- a/internal/test/integration/components/grpc_relay/dotnet/Dockerfile
+++ b/internal/test/integration/components/grpc_relay/dotnet/Dockerfile
@@ -1,4 +1,10 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0@sha256:ebecce75fb42c4c14db108f88054d20a93b0b9e6dfbacad56c8f744c342cf9ef AS builder
+# Grpc.Tools' bundled linux_arm64/protoc segfaults under dotnet publish (grpc/grpc#38538).
+# Use the distro protoc instead; Grpc.Tools' grpc_csharp_plugin is kept for codegen.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+ENV Protobuf_ProtocFullPath=/usr/bin/protoc
 WORKDIR /build
 COPY internal/test/integration/components/grpc_relay/dotnet .
 RUN dotnet publish -c Release -o /out


### PR DESCRIPTION
## Summary

On mac, the grpc_relay test fails when trying to publish the dotnet image:

```
#84 [dotnet-relay builder 4/4] RUN dotnet publish -c Release -o /out
#84 3.886   Restored /build/dotnetrelay.csproj (in 3.19 sec).
#84 4.139 /root/.nuget/packages/grpc.tools/2.80.0/build/_protobuf/Google.Protobuf.Tools.targets(291,5): error MSB6006: "/root/.nuget/packages/grpc.tools/2.80.0/tools/linux_arm64/protoc" exited with code 139. [/build/dotnetrelay.csproj]
#84 ERROR: process "/bin/sh -c dotnet publish -c Release -o /out" did not complete successfully: exit code: 1
------
 > [dotnet-relay builder 4/4] RUN dotnet publish -c Release -o /out:
0.483   Determining projects to restore...
3.886   Restored /build/dotnetrelay.csproj (in 3.19 sec).
4.139 /root/.nuget/packages/grpc.tools/2.80.0/build/_protobuf/Google.Protobuf.Tools.targets(291,5): error MSB6006: "/root/.nuget/packages/grpc.tools/2.80.0/tools/linux_arm64/protoc" exited with code 139. [/build/dotnetrelay.csproj]
------
Dockerfile:4

--------------------

   2 |     WORKDIR /build

   3 |     COPY internal/test/integration/components/grpc_relay/dotnet .

   4 | >>> RUN dotnet publish -c Release -o /out

   5 |     

   6 |     FROM mcr.microsoft.com/dotnet/aspnet:8.0@sha256:93154e00cb227f2fad30724455ecd1e77f46afc9a0273590af652ac220664e54

--------------------
```

it seems that that this is a known issue https://github.com/grpc/grpc/issues/38538

Using the distro protoc instead seems to fix the issue for me (running in a lima vm on mac)

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
