### PR TITLE
Improve redis parsing performance

### DIFF
--- a/pkg/ebpf/common/redis_detect_transform.go
+++ b/pkg/ebpf/common/redis_detect_transform.go
@@ -17,7 +17,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
-	"go.opentelemetry.io/obi/pkg/internal/split"
 )
 
 const (
@@ -120,40 +119,39 @@ func isValidRedisChar(c byte) bool {
 }
 
 func parseRedisRequest(buf []byte) (string, string, bool) {
-	lines := split.NewBytesIterator(buf, redisDelimBytes)
-
-	_, eof := lines.Next()
-
-	if eof {
+	// We need at least two CRLF-delimited lines: a first delimiter must exist with
+	// content following it. Walking the buffer directly with bytes.Index avoids the
+	// generic split.Iterator's per-call indirect dispatch and the double scan its
+	// peek-then-Reset pattern required.
+	firstDelim := bytes.Index(buf, redisDelimBytes)
+	if firstDelim < 0 || firstDelim+len(redisDelimBytes) >= len(buf) {
 		return "", "", false
 	}
-
-	// we need at least 2 lines
-	if _, eof = lines.Next(); eof {
-		return "", "", false
-	}
-
-	// we are good, start over
-	lines.Reset()
-
-	line, _ := lines.Next()
 
 	// It's not a command, something else?
-	if line[0] != '*' {
+	if buf[0] != '*' {
 		return "", "", true
 	}
 
 	op := ""
 
 	var text strings.Builder
+	// The assembled text is always shorter than the raw frame (it drops the RESP
+	// length markers and CRLFs), so a single Grow sizes the builder once and avoids
+	// the geometric re-allocations Write would otherwise trigger as tokens accumulate.
+	text.Grow(len(buf))
 
 	read := false
 
-	for {
-		line, eof = lines.Next()
-
-		if eof {
-			break
+	// Resume past the array-header line; subsequent lines alternate length markers
+	// and data tokens.
+	for pos := firstDelim + len(redisDelimBytes); pos < len(buf); {
+		line := buf[pos:]
+		if rel := bytes.Index(line, redisDelimBytes); rel >= 0 {
+			end := rel + len(redisDelimBytes)
+			line, pos = line[:end], pos+end
+		} else {
+			pos = len(buf)
 		}
 
 		if bytes.Equal(line, redisDelimBytes) {

--- a/pkg/ebpf/common/redis_detect_transform_test.go
+++ b/pkg/ebpf/common/redis_detect_transform_test.go
@@ -4,6 +4,7 @@
 package ebpfcommon
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -17,6 +18,12 @@ type crlfTest struct {
 	testStr string
 	result  bool
 }
+
+var (
+	benchmarkRedisOp   string
+	benchmarkRedisText string
+	benchmarkRedisOK   bool
+)
 
 func TestCRLFMatching(t *testing.T) {
 	for _, ts := range []crlfTest{
@@ -33,6 +40,95 @@ func TestCRLFMatching(t *testing.T) {
 		})
 		assert.Equal(t, res, ts.result)
 	}
+}
+
+func BenchmarkParseRedisRequest(b *testing.B) {
+	tests := []struct {
+		name   string
+		input  []byte
+		wantOK bool
+	}{
+		{
+			name:   "get",
+			input:  redisBenchmarkCommand("GET", "session-key"),
+			wantOK: true,
+		},
+		{
+			name:   "set",
+			input:  redisBenchmarkCommand("SET", "session-key", "session-value"),
+			wantOK: true,
+		},
+		{
+			name:   "mget_many_keys",
+			input:  redisBenchmarkMGet(32),
+			wantOK: true,
+		},
+		{
+			name:   "pipeline_get",
+			input:  redisBenchmarkPipeline(16, "GET", "session-key"),
+			wantOK: true,
+		},
+		{
+			name: "client_setinfo",
+			input: []byte(fmt.Sprintf(
+				"*4\r\n$6\r\nclient\r\n$7\r\nsetinfo\r\n$8\r\nLIB-NAME\r\n$19\r\n%s(,go1.22.2)\r\n*4\r\n$6\r\nclient\r\n$7\r\nsetinfo\r\n$7\r\nLIB-VER\r\n$5\r\n9.5.1\r\n",
+				"go-redis",
+			)),
+			wantOK: true,
+		},
+		{
+			name:   "short_invalid",
+			input:  []byte("2"),
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tt.input)))
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				op, text, ok := parseRedisRequest(tt.input)
+				if ok != tt.wantOK {
+					b.Fatalf("parseRedisRequest ok = %v, want %v", ok, tt.wantOK)
+				}
+				benchmarkRedisOp = op
+				benchmarkRedisText = text
+				benchmarkRedisOK = ok
+			}
+		})
+	}
+}
+
+func redisBenchmarkCommand(args ...string) []byte {
+	buf := bytes.Buffer{}
+	fmt.Fprintf(&buf, "*%d\r\n", len(args))
+	for _, arg := range args {
+		fmt.Fprintf(&buf, "$%d\r\n%s\r\n", len(arg), arg)
+	}
+
+	return buf.Bytes()
+}
+
+func redisBenchmarkMGet(keys int) []byte {
+	args := make([]string, 0, keys+1)
+	args = append(args, "MGET")
+	for i := 0; i < keys; i++ {
+		args = append(args, fmt.Sprintf("session-key:%02d", i))
+	}
+
+	return redisBenchmarkCommand(args...)
+}
+
+func redisBenchmarkPipeline(commands int, args ...string) []byte {
+	buf := bytes.Buffer{}
+	for i := 0; i < commands; i++ {
+		buf.Write(redisBenchmarkCommand(args...))
+	}
+
+	return buf.Bytes()
 }
 
 func TestRedisParsing(t *testing.T) {


### PR DESCRIPTION
## Summary

Continuing on improving the performance of the user-space protocol parsers, I've looked at redis parsing this time and I have a change that improves the amount of allocated objects and reduces the overhead of the split iterator.

### Benchmark runs
Before:
```
go test -run='^$' -bench=BenchmarkParseRedisRequest \
  -benchtime=30s -benchmem \
  -cpuprofile=cpu.prof -memprofile=mem.prof \
  ./pkg/ebpf/common/
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/obi/pkg/ebpf/common
cpu: AMD Ryzen AI 9 HX PRO 370 w/ Radeon 890M       
BenchmarkParseRedisRequest/get-24         	342034111	       104.7 ns/op	 296.13 MB/s	      32 B/op	       3 allocs/op
BenchmarkParseRedisRequest/set-24         	257092147	       148.8 ns/op	 342.64 MB/s	      64 B/op	       4 allocs/op
BenchmarkParseRedisRequest/mget_many_keys-24         	24595459	      1474 ns/op	 466.19 MB/s	    1464 B/op	       8 allocs/op
BenchmarkParseRedisRequest/pipeline_get-24           	24674752	      1409 ns/op	 352.11 MB/s	    1024 B/op	       8 allocs/op
BenchmarkParseRedisRequest/client_setinfo-24         	95770690	       364.7 ns/op	 334.56 MB/s	     256 B/op	       6 allocs/op
BenchmarkParseRedisRequest/short_invalid-24          	1000000000	         9.540 ns/op	 104.82 MB/s	       0 B/op	       0 allocs/op
PASS
```
<img width="2553" height="584" alt="image" src="https://github.com/user-attachments/assets/f4042f24-c7d3-4fac-8fef-260f1dbf01fe" />


After:
```
go test -run='^$' -bench=BenchmarkParseRedisRequest \
  -benchtime=30s -benchmem \
  -cpuprofile=cpu.prof -memprofile=mem.prof \
  ./pkg/ebpf/common/
goos: linux
goarch: amd64
pkg: go.opentelemetry.io/obi/pkg/ebpf/common
cpu: AMD Ryzen AI 9 HX PRO 370 w/ Radeon 890M       
BenchmarkParseRedisRequest/get-24         	468508639	        75.36 ns/op	 411.35 MB/s	      35 B/op	       2 allocs/op
BenchmarkParseRedisRequest/set-24         	336658911	       103.1 ns/op	 494.65 MB/s	      67 B/op	       2 allocs/op
BenchmarkParseRedisRequest/mget_many_keys-24         	37628612	      1005 ns/op	 683.73 MB/s	     708 B/op	       2 allocs/op
BenchmarkParseRedisRequest/pipeline_get-24           	32370256	      1079 ns/op	 459.49 MB/s	     515 B/op	       2 allocs/op
BenchmarkParseRedisRequest/client_setinfo-24         	146674290	       241.2 ns/op	 505.78 MB/s	     136 B/op	       2 allocs/op
BenchmarkParseRedisRequest/short_invalid-24          	1000000000	         2.124 ns/op	 470.73 MB/s	       0 B/op	       0 allocs/op
PASS
```
<img width="2553" height="584" alt="image" src="https://github.com/user-attachments/assets/5acbd268-ecbf-49cb-8c84-6a17becff97d" />


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
