### PR TITLE
test: Account for net delay jitter in RTT test

### DIFF
--- a/internal/test/integration/red_test_stat_metrics.go
+++ b/internal/test/integration/red_test_stat_metrics.go
@@ -25,8 +25,9 @@ func testStatMetricsTCPRtt(t *testing.T, port string) {
 		// Per-series division avoids dilution from other fast connections
 		// (e.g. health checks) that share the same dst_port label. A non-empty
 		// response means at least one connection was captured with RTT >= 100ms.
+		// Threshold is 90ms rather than 100ms to absorb the +/- 1ms timestamp jitter.
 		avgQuery := `(obi_stat_tcp_rtt_seconds_sum{dst_port="` + port + `"} /` +
-			` obi_stat_tcp_rtt_seconds_count{dst_port="` + port + `"}) >= 0.1`
+			` obi_stat_tcp_rtt_seconds_count{dst_port="` + port + `"}) >= 0.09`
 		avgResults, err := pq.Query(avgQuery)
 		require.NoError(ct, err)
 		enoughPromResults(ct, avgResults)


### PR DESCRIPTION
## Summary

Debugging `TestStat_GoStatMetrics/Go_Stat_Metrics_TCP_RTT_tests` test failure:

- https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/26753898294/job/78853703139?pr=2208

Kernel-measured RTT with millisecond accuracy might see a "100ms" delay as "99ms", which can cause the `>= 0.1` assertion to fail.

Relax the assertion to `>= 0.09` (90ms) to cater for measurement jitter.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
