### PR TITLE
Fix SQL++ DB query text getter

### DIFF
--- a/pkg/appolly/app/request/span_getters.go
+++ b/pkg/appolly/app/request/span_getters.go
@@ -302,8 +302,16 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 		}
 	case attr.DBQueryText:
 		getter = func(s *Span) attribute.KeyValue {
-			if s.Type == EventTypeHTTPClient && (s.SubType == HTTPSubtypeElasticsearch && s.Elasticsearch != nil) || s.SubType == HTTPSubtypeSQLPP {
-				return DBQueryText(s.Elasticsearch.DBQueryText)
+			if s.Type != EventTypeHTTPClient {
+				return DBQueryText("")
+			}
+			switch s.SubType {
+			case HTTPSubtypeElasticsearch:
+				if s.Elasticsearch != nil {
+					return DBQueryText(s.Elasticsearch.DBQueryText)
+				}
+			case HTTPSubtypeSQLPP:
+				return DBQueryText(s.Statement)
 			}
 			return DBQueryText("")
 		}

--- a/pkg/appolly/app/request/span_getters_test.go
+++ b/pkg/appolly/app/request/span_getters_test.go
@@ -503,6 +503,71 @@ func TestSpanOTELGetters_JSONRPCAttributes(t *testing.T) {
 	}
 }
 
+func TestSpanOTELGetters_DBQueryText(t *testing.T) {
+	getter, ok := spanOTELGetters(attr.DBQueryText)
+	require.True(t, ok, "getter should be found for DBQueryText")
+
+	tests := []struct {
+		name     string
+		span     *Span
+		expected string
+	}{
+		{
+			name: "SQL++ HTTP client span uses statement",
+			span: &Span{
+				Type:      EventTypeHTTPClient,
+				SubType:   HTTPSubtypeSQLPP,
+				Statement: "SELECT * FROM bucket.scope.collection",
+			},
+			expected: "SELECT * FROM bucket.scope.collection",
+		},
+		{
+			name: "SQL++ HTTP client span without statement returns empty",
+			span: &Span{
+				Type:    EventTypeHTTPClient,
+				SubType: HTTPSubtypeSQLPP,
+			},
+			expected: "",
+		},
+		{
+			name: "Elasticsearch HTTP client span uses Elasticsearch query",
+			span: &Span{
+				Type:    EventTypeHTTPClient,
+				SubType: HTTPSubtypeElasticsearch,
+				Elasticsearch: &Elasticsearch{
+					DBQueryText: `{"query":{"match_all":{}}}`,
+				},
+			},
+			expected: `{"query":{"match_all":{}}}`,
+		},
+		{
+			name: "Elasticsearch HTTP client span without Elasticsearch state returns empty",
+			span: &Span{
+				Type:    EventTypeHTTPClient,
+				SubType: HTTPSubtypeElasticsearch,
+			},
+			expected: "",
+		},
+		{
+			name: "SQL++ subtype on non HTTP client span returns empty",
+			span: &Span{
+				Type:      EventTypeHTTP,
+				SubType:   HTTPSubtypeSQLPP,
+				Statement: "SELECT * FROM bucket",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := getter(tt.span)
+			assert.Equal(t, string(attr.DBQueryText), string(kv.Key))
+			assert.Equal(t, tt.expected, kv.Value.AsString())
+		})
+	}
+}
+
 func TestSpanOTELGetters_MessagingAttributes_NATS(t *testing.T) {
 	span := &Span{
 		Type:   EventTypeNATSClient,

--- a/pkg/appolly/app/request/span_getters_test.go
+++ b/pkg/appolly/app/request/span_getters_test.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 func TestSpanOTELGetters_K8SClientNamespace(t *testing.T) {
@@ -561,7 +562,8 @@ func TestSpanOTELGetters_DBQueryText(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			kv := getter(tt.span)
+			var kv attribute.KeyValue
+			assert.NotPanics(t, func() { kv = getter(tt.span) })
 			assert.Equal(t, string(attr.DBQueryText), string(kv.Key))
 			assert.Equal(t, tt.expected, kv.Value.AsString())
 		})

--- a/pkg/appolly/app/request/span_getters_test.go
+++ b/pkg/appolly/app/request/span_getters_test.go
@@ -10,9 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/otel/attribute"
+
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 func TestSpanOTELGetters_K8SClientNamespace(t *testing.T) {


### PR DESCRIPTION
## Summary

This fixes the `db.query.text` getter for SQL++ HTTP client spans so it reads from `Span.Statement` instead of dereferencing Elasticsearch-specific state.

The getter now:

- only considers HTTP client spans for this attribute
- keeps Elasticsearch query text sourced from `Span.Elasticsearch.DBQueryText`
- reads SQL++ query text from `Span.Statement`
- safely returns an empty value when subtype-specific state is absent

Fixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2018

## Testing

- `go test ./pkg/appolly/app/request`
