### PR TITLE
fix: preserve exe_path_regexp during metadata normalization

### DIFF
--- a/pkg/appolly/discover/matcher.go
+++ b/pkg/appolly/discover/matcher.go
@@ -357,7 +357,7 @@ func normalizeRegexCriteria(finderCriteria services.RegexDefinitionCriteria) []s
 	criteria := make([]services.Selector, 0, len(finderCriteria))
 	for i := range finderCriteria {
 		fc := &finderCriteria[i]
-		if !fc.Path.IsSet() && fc.OpenPorts.Len() == 0 && (len(fc.Metadata) > 0 || len(fc.PodLabels) > 0 || len(fc.PodAnnotations) > 0) {
+		if !fc.Path.IsSet() && !fc.PathRegexp.IsSet() && fc.OpenPorts.Len() == 0 && (len(fc.Metadata) > 0 || len(fc.PodLabels) > 0 || len(fc.PodAnnotations) > 0) {
 			// match any executable path
 			if err := fc.Path.UnmarshalText([]byte(".")); err != nil {
 				panic("bug! " + err.Error())

--- a/pkg/appolly/discover/matcher_test.go
+++ b/pkg/appolly/discover/matcher_test.go
@@ -301,6 +301,49 @@ func TestCriteriaMatcher_Exclude_Metadata(t *testing.T) {
 	testMatch(t, matches[1], "", "", services.ProcessInfo{Pid: 3, ExePath: "server"})
 }
 
+func TestCriteriaMatcher_MetadataWithDeprecatedPathRegexp(t *testing.T) {
+	pipeConfig := obi.Config{}
+	require.NoError(t, yaml.Unmarshal([]byte(`discovery:
+  services:
+  - name: server
+    exe_path_regexp: "^/bin/server$"
+    k8s_namespace: prod
+`), &pipeConfig))
+
+	criteria := FindingCriteria(&pipeConfig)
+	require.Len(t, criteria, 1)
+	assert.False(t, criteria[0].GetPath().IsSet())
+	assert.True(t, criteria[0].GetPathRegexp().IsSet())
+
+	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+	filteredProcesses := filteredProcessesQu.Subscribe()
+	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, criteria, nil)(t.Context())
+	require.NoError(t, err)
+	go matcherFunc(t.Context())
+	defer func() {
+		discoveredProcesses.Close()
+		testutil.DrainUntilClosed(filteredProcesses)
+	}()
+
+	processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
+		exePath := map[app.PID]string{
+			1: "/bin/server",
+			2: "/bin/worker",
+		}[pp.pid]
+		return &services.ProcessInfo{Pid: pp.pid, ExePath: exePath}, nil
+	}
+
+	discoveredProcesses.Send([]Event[ProcessAttrs]{
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 1, metadata: map[string]string{services.AttrNamespace: "prod"}}},
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 2, metadata: map[string]string{services.AttrNamespace: "prod"}}},
+	})
+
+	matches := testutil.ReadChannel(t, filteredProcesses, testTimeout)
+	require.Len(t, matches, 1)
+	testMatch(t, matches[0], "server", "", services.ProcessInfo{Pid: 1, ExePath: "/bin/server"})
+}
+
 func TestCriteriaMatcher_MustMatchAllAttributes(t *testing.T) {
 	pipeConfig := obi.Config{}
 	require.NoError(t, yaml.Unmarshal([]byte(`discovery:


### PR DESCRIPTION
## Summary
- Preserve deprecated `exe_path_regexp` during regex selector metadata normalization.
- Add regression coverage for metadata selectors that use `exe_path_regexp`.

## Root Cause
Metadata-only regex selector normalization synthesized `exe_path="."` without checking whether the deprecated path regexp was already set. Since executable matching prefers `exe_path` over `exe_path_regexp`, that normalized wildcard bypassed the intended regexp constraint.

## Validation
- `go test ./pkg/appolly/discover -run TestCriteriaMatcher_MetadataWithDeprecatedPathRegexp -count=1`
- `go test ./pkg/appolly/discover -count=1`
- `go test -race ./pkg/appolly/discover -count=1`
- `go test ./pkg/appolly/... -count=1`
- `gofmt -l pkg/appolly/discover/matcher.go pkg/appolly/discover/matcher_test.go`
- `make go-mod-tidy`
- `make license-header-check`

Fixes #2042