### PR TITLE
fix(2013): reject mixed glob and numeric attribute filters

### DIFF
--- a/pkg/filter/attribute_test.go
+++ b/pkg/filter/attribute_test.go
@@ -586,6 +586,8 @@ func TestAttributeFilter_VerificationError(t *testing.T) {
 		{"obi.ip": MatchDefinition{}},
 		// valid attribute with double match definition
 		{"obi.ip": MatchDefinition{Match: "foo", NotMatch: "foo"}},
+		// valid attribute with invalid mixed glob and numeric comparisons
+		{"http.response.status_code": MatchDefinition{Match: "2*", GreaterEquals: intPtr(200)}},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {

--- a/pkg/filter/matcher.go
+++ b/pkg/filter/matcher.go
@@ -89,13 +89,17 @@ type MatchDefinition struct {
 
 func (md *MatchDefinition) Validate() error {
 	hasGlob := md.Match != "" || md.NotMatch != ""
-	hasNumeric := md.GreaterThan != nil || md.LessThan != nil || md.Equals != nil || md.NotEquals != nil || md.GreaterEquals != nil || md.LessEquals != nil
+	hasNumeric := md.GreaterThan != nil || md.LessThan != nil || md.Equals != nil ||
+		md.NotEquals != nil || md.GreaterEquals != nil || md.LessEquals != nil
 
 	if !hasGlob && !hasNumeric {
 		return errors.New("attribute must include a match/not_match clause or numeric comparison")
 	}
 	if md.Match != "" && md.NotMatch != "" {
 		return errors.New("attribute can't include bot match or not_match clauses")
+	}
+	if hasGlob && hasNumeric {
+		return errors.New("attribute can't combine match/not_match clauses with numeric comparisons")
 	}
 	return nil
 }

--- a/pkg/filter/matcher.go
+++ b/pkg/filter/matcher.go
@@ -96,7 +96,7 @@ func (md *MatchDefinition) Validate() error {
 		return errors.New("attribute must include a match/not_match clause or numeric comparison")
 	}
 	if md.Match != "" && md.NotMatch != "" {
-		return errors.New("attribute can't include bot match or not_match clauses")
+		return errors.New("attribute can't include both match and not_match clauses")
 	}
 	if hasGlob && hasNumeric {
 		return errors.New("attribute can't combine match/not_match clauses with numeric comparisons")

--- a/pkg/filter/matcher_test.go
+++ b/pkg/filter/matcher_test.go
@@ -39,6 +39,16 @@ func TestMatchDefinition_Validate(t *testing.T) {
 	require.NoError(t, (&MatchDefinition{NotMatch: "foo"}).Validate())
 	require.Error(t, (&MatchDefinition{Match: "foo", NotMatch: "foo"}).Validate())
 	require.Error(t, (&MatchDefinition{}).Validate())
+
+	status := 200
+	require.ErrorContains(t,
+		(&MatchDefinition{Match: "2*", GreaterEquals: &status}).Validate(),
+		"attribute can't combine match/not_match clauses with numeric comparisons",
+	)
+	require.ErrorContains(t,
+		(&MatchDefinition{NotMatch: "5*", LessThan: &status}).Validate(),
+		"attribute can't combine match/not_match clauses with numeric comparisons",
+	)
 }
 
 func TestMatches_GreaterEquals(t *testing.T) {


### PR DESCRIPTION
## Summary

Reject attribute filter configurations that combine `match`/`not_match` glob clauses with numeric comparisons.

## Root Cause

`MatchDefinition` validation previously allowed mixed glob-plus-numeric definitions, but `buildMatcher` only populated numeric comparison fields in the numeric-only branch. When a glob clause was present, numeric comparisons were silently dropped.

## Impact

Mixed configurations now fail validation instead of behaving more permissively than configured. This makes the invalid configuration explicit and prevents accidental export of telemetry that numeric thresholds were expected to exclude.

Fixes #2013.

## Validation

- `go test ./pkg/filter`
- `gofmt -l pkg/filter/matcher.go pkg/filter/matcher_test.go pkg/filter/attribute_test.go`
