### PR TITLE
fix(java,bpf): limit SSL receive packets to bytes read

### DIFF
--- a/bpf/generictracer/k_tracer_defs.h
+++ b/bpf/generictracer/k_tracer_defs.h
@@ -62,7 +62,7 @@ static __always_inline call_protocol_args_t *make_protocol_args(const pid_connec
     __builtin_memset(args->small_buf, 0, sizeof(args->small_buf));
     if (bytes_len > 0) {
         u32 small_buf_len = (u32)bytes_len;
-        bpf_clamp_umax(small_buf_len, MIN_HTTP2_SIZE);
+        bpf_clamp_umax(small_buf_len, sizeof(args->small_buf));
         bpf_probe_read(args->small_buf, small_buf_len, (void *)args->u_buf);
     }
 

--- a/bpf/generictracer/k_tracer_defs.h
+++ b/bpf/generictracer/k_tracer_defs.h
@@ -44,6 +44,10 @@ static __always_inline call_protocol_args_t *make_protocol_args(const pid_connec
                                                                 u8 ssl,
                                                                 u8 direction,
                                                                 u16 orig_dport) {
+    if (bytes_len <= 0) {
+        return 0;
+    }
+
     call_protocol_args_t *args = protocol_args();
     if (!args) {
         return 0;
@@ -60,11 +64,9 @@ static __always_inline call_protocol_args_t *make_protocol_args(const pid_connec
 
     args->pid_conn = *info;
     __builtin_memset(args->small_buf, 0, sizeof(args->small_buf));
-    if (bytes_len > 0) {
-        u32 small_buf_len = (u32)bytes_len;
-        bpf_clamp_umax(small_buf_len, sizeof(args->small_buf));
-        bpf_probe_read(args->small_buf, small_buf_len, (void *)args->u_buf);
-    }
+    u32 small_buf_len = (u32)bytes_len;
+    bpf_clamp_umax(small_buf_len, sizeof(args->small_buf));
+    bpf_probe_read(args->small_buf, small_buf_len, (void *)args->u_buf);
 
     return args;
 }

--- a/bpf/generictracer/k_tracer_defs.h
+++ b/bpf/generictracer/k_tracer_defs.h
@@ -59,7 +59,12 @@ static __always_inline call_protocol_args_t *make_protocol_args(const pid_connec
     args->protocol_type = protocol_type_for_conn_info(info);
 
     args->pid_conn = *info;
-    bpf_probe_read(args->small_buf, MIN_HTTP2_SIZE, (void *)args->u_buf);
+    __builtin_memset(args->small_buf, 0, sizeof(args->small_buf));
+    if (bytes_len > 0) {
+        u32 small_buf_len = (u32)bytes_len;
+        bpf_clamp_umax(small_buf_len, MIN_HTTP2_SIZE);
+        bpf_probe_read(args->small_buf, small_buf_len, (void *)args->u_buf);
+    }
 
     return args;
 }

--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/ebpf/ProxyInputStream.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/ebpf/ProxyInputStream.java
@@ -28,9 +28,8 @@ public class ProxyInputStream extends InputStream {
   public int read(byte[] b) throws IOException {
     int len = delegate.read(b);
     if (len > 0) {
-      NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + b.length);
-      int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, b.length);
-      IOCTLPacket.writePacketBuffer(p, wOff, b);
+      NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + len);
+      writeReadPacket(p, socket, b, 0, len);
       Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
     }
     return len;
@@ -41,11 +40,15 @@ public class ProxyInputStream extends InputStream {
     int bytesRead = delegate.read(b, off, len);
     if (bytesRead > 0) {
       NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + bytesRead);
-      int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, bytesRead);
-      IOCTLPacket.writePacketBuffer(p, wOff, b, off, bytesRead);
+      writeReadPacket(p, socket, b, off, bytesRead);
       Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
     }
     return bytesRead;
+  }
+
+  static int writeReadPacket(NativeMemory p, Socket socket, byte[] b, int off, int len) {
+    int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, len);
+    return IOCTLPacket.writePacketBuffer(p, wOff, b, off, len);
   }
 
   @Override

--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SSLSocketStreamInst.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SSLSocketStreamInst.java
@@ -81,6 +81,11 @@ public class SSLSocketStreamInst {
                             .and(ElementMatchers.takesArgument(0, byte[].class))));
   }
 
+  static int writeReadPacket(NativeMemory p, Socket socket, byte[] b, int off, int len) {
+    int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, len);
+    return IOCTLPacket.writePacketBuffer(p, wOff, b, off, len);
+  }
+
   public static final class InputStreamReadAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void read(
@@ -104,9 +109,8 @@ public class SSLSocketStreamInst {
         }
         if (socket != null) {
           try {
-            NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + b.length);
-            int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, b.length);
-            IOCTLPacket.writePacketBuffer(p, wOff, b);
+            NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + len);
+            writeReadPacket(p, socket, b, 0, len);
             Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
           } catch (Throwable t) {
             if (SSLStorage.debugOn) {
@@ -142,9 +146,7 @@ public class SSLSocketStreamInst {
         if (socket != null) {
           try {
             NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + bytesRead);
-            int wOff =
-                IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, bytesRead);
-            IOCTLPacket.writePacketBuffer(p, wOff, b, off, bytesRead);
+            writeReadPacket(p, socket, b, off, bytesRead);
             Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
           } catch (Throwable t) {
             if (SSLStorage.debugOn) {

--- a/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/ebpf/ProxyInputStreamTest.java
+++ b/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/ebpf/ProxyInputStreamTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.obi.java.ebpf;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ProxyInputStreamTest {
+
+  @Test
+  void readPacketUsesBytesReadForPartialBuffer() {
+    byte[] buffer = {10, 20, 30, 40, 50};
+    int bytesRead = 3;
+    NativeMemory packet = new NativeMemory(IOCTLPacket.packetPrefixSize + bytesRead + 1, true);
+
+    int end = ProxyInputStream.writeReadPacket(packet, null, buffer, 0, bytesRead);
+
+    assertEquals(IOCTLPacket.packetPrefixSize + bytesRead, end);
+    assertEquals(bytesRead, packet.getInt(IOCTLPacket.packetPrefixSize - Integer.BYTES));
+    for (int i = 0; i < bytesRead; i++) {
+      assertEquals(buffer[i], packet.getBuffer().get(IOCTLPacket.packetPrefixSize + i));
+    }
+    assertEquals(0, packet.getBuffer().get(IOCTLPacket.packetPrefixSize + bytesRead));
+  }
+}

--- a/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/SSLSocketStreamInstTest.java
+++ b/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/SSLSocketStreamInstTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.obi.java.instrumentations;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.opentelemetry.obi.java.ebpf.IOCTLPacket;
+import io.opentelemetry.obi.java.ebpf.NativeMemory;
+import org.junit.jupiter.api.Test;
+
+class SSLSocketStreamInstTest {
+
+  @Test
+  void inputStreamReadPacketUsesBytesReadForPartialBuffer() {
+    byte[] buffer = {10, 20, 30, 40, 50};
+    int bytesRead = 3;
+    NativeMemory packet = new NativeMemory(IOCTLPacket.packetPrefixSize + bytesRead + 1, true);
+
+    int end = SSLSocketStreamInst.writeReadPacket(packet, null, buffer, 0, bytesRead);
+
+    assertEquals(IOCTLPacket.packetPrefixSize + bytesRead, end);
+    assertEquals(bytesRead, packet.getInt(IOCTLPacket.packetPrefixSize - Integer.BYTES));
+    for (int i = 0; i < bytesRead; i++) {
+      assertEquals(buffer[i], packet.getBuffer().get(IOCTLPacket.packetPrefixSize + i));
+    }
+    assertEquals(0, packet.getBuffer().get(IOCTLPacket.packetPrefixSize + bytesRead));
+  }
+}


### PR DESCRIPTION
## Summary

- Use the actual `read(byte[])` return value when sizing and copying `SSLSocketStreamInst` SSL receive packets.
- Apply the same partial-read fix to the `ProxyInputStream.read(byte[])` SSL receive path.
- Bound BPF protocol sniff-buffer reads to the reported payload length so short Java IOCTL packets do not read beyond the copied payload.
- Add focused Java tests for partial-buffer receive packet construction.

## Why

`InputStream.read(byte[])` can return fewer bytes than the destination buffer length. The previous Java agent code used the full buffer length when building native IOCTL packets, which could cause stale trailing bytes from the application buffer to be treated as payload by OBI. BPF has only the packet length supplied by the Java agent, so it cannot recover the true bytes-read count downstream.

The BPF sniff-buffer change keeps protocol detection bounded to the payload length that Java reports, avoiding inspection past short Java IOCTL payloads.

Fixes #2019

## Validation

- `make java-clean`
- `make java-verify`
- `make generate`
- `make compile`
- `git diff --check`

`make clang-tidy` was also run, but the repository-wide target currently fails on pre-existing unrelated diagnostics in files such as `bpf/common/common.c`, `bpf/common/sockaddr.h`, and `bpf/tpinjector/tpinjector.c`; it processed the touched `bpf/generictracer/k_tracer_defs.h` without reporting a diagnostic there.