### PR TITLE
Add UDS support for the OTLP exporter and the health check endpoint

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -338,6 +338,7 @@ AttributesConfig stores the user-provided section for filtering either Applicati
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
 |---|---|---|---|---|---|---|
 | `health_check.port` | `integer` | `OTEL_EBPF_HEALTH_CHECK_PORT` | `0` |  |  | 0 (default) means disabled |
+| `health_check.unix_socket_path` | `string` | `OTEL_EBPF_HEALTH_CHECK_UNIX_SOCKET_PATH` |  |  |  | when set, the health endpoint binds this unix socket (a filesystem path or a leading-'@' abstract name) instead of the TCP port |
 
 ## `internal_metrics`
 

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -1264,6 +1264,11 @@
           "description": "0 (default) means disabled",
           "default": 0,
           "x-env-var": "OTEL_EBPF_HEALTH_CHECK_PORT"
+        },
+        "unix_socket_path": {
+          "type": "string",
+          "description": "when set, the health endpoint binds this unix socket (a filesystem path or a leading-'@' abstract name) instead of the TCP port",
+          "x-env-var": "OTEL_EBPF_HEALTH_CHECK_UNIX_SOCKET_PATH"
         }
       },
       "type": "object"

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	go.opentelemetry.io/collector/component/componenttest v0.151.0
 	go.opentelemetry.io/collector/config/configgrpc v0.151.0
 	go.opentelemetry.io/collector/config/confighttp v0.151.0
+	go.opentelemetry.io/collector/config/configmiddleware v1.57.0
 	go.opentelemetry.io/collector/config/configopaque v1.57.0
 	go.opentelemetry.io/collector/config/configoptional v1.57.0
 	go.opentelemetry.io/collector/config/configretry v1.57.0
@@ -61,6 +62,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterhelper v0.151.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.151.0
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.151.0
+	go.opentelemetry.io/collector/extension/extensionmiddleware v0.151.0
 	go.opentelemetry.io/collector/pdata v1.57.0
 	go.opentelemetry.io/collector/receiver v1.57.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.151.0
@@ -201,7 +203,6 @@ require (
 	go.opentelemetry.io/collector/client v1.57.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v1.57.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.57.0 // indirect
-	go.opentelemetry.io/collector/config/configmiddleware v1.57.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.57.0 // indirect
 	go.opentelemetry.io/collector/confmap/xconfmap v0.151.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.151.0 // indirect
@@ -211,7 +212,6 @@ require (
 	go.opentelemetry.io/collector/exporter/xexporter v0.151.0 // indirect
 	go.opentelemetry.io/collector/extension v1.57.0 // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.57.0 // indirect
-	go.opentelemetry.io/collector/extension/extensionmiddleware v0.151.0 // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.151.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.57.0 // indirect
 	go.opentelemetry.io/collector/internal/componentalias v0.151.0 // indirect

--- a/internal/test/integration/configs/obi-config-otlp-uds.yml
+++ b/internal/test/integration/configs/obi-config-otlp-uds.yml
@@ -1,0 +1,8 @@
+routes:
+  unmatched: path
+otel_metrics_export:
+  endpoint: unix:///var/run/obi-otlp/metrics.sock
+attributes:
+  select:
+    "*":
+      include: ["*"]

--- a/internal/test/integration/configs/otelcol-config-otlp-uds.yml
+++ b/internal/test/integration/configs/otelcol-config-otlp-uds.yml
@@ -1,0 +1,17 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: /var/run/obi-otlp/metrics.sock
+        transport: unix
+exporters:
+  prometheus:
+    endpoint: "otelcol:9464"
+    resource_to_telemetry_conversion:
+      enabled: true
+    enable_open_metrics: true
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]

--- a/internal/test/integration/docker-compose-otlp-uds.yml
+++ b/internal/test/integration/docker-compose-otlp-uds.yml
@@ -1,0 +1,65 @@
+services:
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/testserver/Dockerfile
+    image: hatest-testserver
+    ports:
+      - "8080:8080"
+    environment:
+      LOG_LEVEL: DEBUG
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    command:
+      - --config=/configs/obi-config-otlp-uds.yml
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security${SECURITY_CONFIG_SUFFIX}:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-otlp-uds:/var/run/obi-otlp
+    image: hatest-obi
+    privileged: true
+    pid: "host"
+    environment:
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: "500ms"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_HOSTNAME: "obi"
+    depends_on:
+      otelcol:
+        condition: service_started
+
+  # otelcol receives OTLP/HTTP over the unix socket in the shared volume and re-exposes the
+  # metrics to Prometheus. It runs as root so it can create the socket in the shared dir.
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.153.0@sha256:93aad750175cbf1a973ae1c5886c3371f4d800f61be25cdd26870b8441ffe9fa
+    container_name: otel-col
+    user: "0:0"
+    command: ["--config=/etc/otelcol-config/otelcol-config-otlp-uds.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+      - ../../../testoutput/run-otlp-uds:/var/run/obi-otlp
+    ports:
+      - "9464"
+    depends_on:
+      prometheus:
+        condition: service_started
+
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.12.0@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config-promscrape-otel.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"

--- a/internal/test/integration/otlp_uds_test.go
+++ b/internal/test/integration/otlp_uds_test.go
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
+)
+
+func TestOTLPMetricsOverUDS(t *testing.T) {
+	// otelcol binds its OTLP listener on a socket in this shared dir; remove any socket left by a
+	// previous run so the bind succeeds (Close only prunes anonymous volumes, not the bind mount).
+	socketDir := path.Join(pathOutput, "run-otlp-uds")
+	require.NoError(t, os.RemoveAll(socketDir))
+	require.NoError(t, os.MkdirAll(socketDir, 0o755))
+
+	compose, err := docker.ComposeSuite("docker-compose-otlp-uds.yml", path.Join(pathOutput, "test-suite-otlp-uds.log"))
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+
+	// waitForTestComponents returns only once a /smoke request's RED metric has reached Prometheus,
+	// i.e. after OBI pushed it over the unix socket to otelcol — the end-to-end assertion.
+	t.Run("RED metrics reach Prometheus over a unix-socket OTLP endpoint", func(t *testing.T) {
+		waitForTestComponents(t, "http://localhost:8080")
+	})
+
+	require.NoError(t, compose.Close())
+}

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -330,10 +330,11 @@ type OTLPOptions struct {
 	Insecure bool
 	// BaseURLPath, only for traces export, excludes the /v1/traces suffix.
 	// E.g. for a URLPath == "/otlp/v1/traces", BaseURLPath will be = "/otlp"
-	BaseURLPath   string
-	URLPath       string
-	SkipTLSVerify bool
-	Headers       map[string]string
+	BaseURLPath    string
+	URLPath        string
+	SkipTLSVerify  bool
+	Headers        map[string]string
+	UnixSocketAddr string
 }
 
 func (o *OTLPOptions) AsMetricHTTP() []otlpmetrichttp.Option {
@@ -351,6 +352,9 @@ func (o *OTLPOptions) AsMetricHTTP() []otlpmetrichttp.Option {
 	}
 	if len(o.Headers) > 0 {
 		opts = append(opts, otlpmetrichttp.WithHeaders(o.Headers))
+	}
+	if o.UnixSocketAddr != "" {
+		opts = append(opts, otlpmetrichttp.WithHTTPClient(unixHTTPClient(o.UnixSocketAddr)))
 	}
 	return opts
 }

--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -164,7 +164,52 @@ func (m *MetricsConfig) EndpointEnabled() bool {
 	return ep != ""
 }
 
+func unixMetricsHTTPOptions(cfg *MetricsConfig, addr string) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	if err := validateUnixSocketAddr(addr); err != nil {
+		return opts, err
+	}
+
+	setMetricsProtocol(cfg)
+	opts.UnixSocketAddr = addr
+	opts.Endpoint = "localhost"
+	opts.Insecure = true
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envMetricsHeaders))
+
+	return opts, nil
+}
+
+func unixMetricsGRPCOptions(cfg *MetricsConfig, addr string) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	if err := validateUnixSocketAddr(addr); err != nil {
+		return opts, err
+	}
+
+	setMetricsProtocol(cfg)
+	opts.UnixSocketAddr = addr
+	opts.Endpoint = grpcUnixTarget(addr)
+	opts.Insecure = true
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envMetricsHeaders))
+
+	return opts, nil
+}
+
 func httpMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
+	rawEndpoint, _ := cfg.OTLPMetricsEndpoint()
+	if addr, ok := unixSocketEndpoint(rawEndpoint); ok {
+		return unixMetricsHTTPOptions(cfg, addr)
+	}
+
 	opts := OTLPOptions{Headers: map[string]string{}}
 	log := mlog().With("transport", "http")
 	murl, isCommon, err := parseMetricsEndpoint(cfg)
@@ -176,7 +221,7 @@ func httpMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
 
 	setMetricsProtocol(cfg)
 	opts.Endpoint = murl.Host
-	if murl.Scheme == "http" || murl.Scheme == "unix" {
+	if murl.Scheme == "http" {
 		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
 		opts.Insecure = true
 	}
@@ -207,6 +252,11 @@ func httpMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
 }
 
 func grpcMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
+	rawEndpoint, _ := cfg.OTLPMetricsEndpoint()
+	if addr, ok := unixSocketEndpoint(rawEndpoint); ok {
+		return unixMetricsGRPCOptions(cfg, addr)
+	}
+
 	opts := OTLPOptions{Headers: map[string]string{}}
 	log := mlog().With("transport", "grpc")
 	murl, _, err := parseMetricsEndpoint(cfg)
@@ -218,7 +268,7 @@ func grpcMetricEndpointOptions(cfg *MetricsConfig) (OTLPOptions, error) {
 
 	setMetricsProtocol(cfg)
 	opts.Endpoint = murl.Host
-	if murl.Scheme == "http" || murl.Scheme == "unix" {
+	if murl.Scheme == "http" {
 		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
 		opts.Insecure = true
 	}

--- a/pkg/export/otel/otelcfg/config_traces.go
+++ b/pkg/export/otel/otelcfg/config_traces.go
@@ -171,7 +171,52 @@ func ParseTracesEndpoint(cfg *TracesConfig) (*url.URL, bool, error) {
 	return murl, isCommon, nil
 }
 
+func unixTracesHTTPOptions(cfg *TracesConfig, addr string) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	if err := validateUnixSocketAddr(addr); err != nil {
+		return opts, err
+	}
+
+	setTracesProtocol(cfg)
+	opts.UnixSocketAddr = addr
+	opts.Scheme = "http"
+	opts.Endpoint = "localhost"
+	opts.Insecure = true
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envTracesHeaders))
+
+	return opts, nil
+}
+
+func unixTracesGRPCOptions(cfg *TracesConfig, addr string) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	if err := validateUnixSocketAddr(addr); err != nil {
+		return opts, err
+	}
+
+	opts.UnixSocketAddr = addr
+	opts.Endpoint = grpcUnixTarget(addr)
+	opts.Insecure = true
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envTracesHeaders))
+
+	return opts, nil
+}
+
 func HTTPTracesEndpointOptions(cfg *TracesConfig) (OTLPOptions, error) {
+	rawEndpoint, _ := cfg.OTLPTracesEndpoint()
+	if addr, ok := unixSocketEndpoint(rawEndpoint); ok {
+		return unixTracesHTTPOptions(cfg, addr)
+	}
+
 	opts := OTLPOptions{Headers: map[string]string{}}
 	log := tlog().With("transport", "http")
 
@@ -185,7 +230,7 @@ func HTTPTracesEndpointOptions(cfg *TracesConfig) (OTLPOptions, error) {
 	setTracesProtocol(cfg)
 	opts.Scheme = murl.Scheme
 	opts.Endpoint = murl.Host
-	if murl.Scheme == "http" || murl.Scheme == "unix" {
+	if murl.Scheme == "http" {
 		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
 		opts.Insecure = true
 	}
@@ -213,6 +258,11 @@ func HTTPTracesEndpointOptions(cfg *TracesConfig) (OTLPOptions, error) {
 }
 
 func GRPCTracesEndpointOptions(cfg *TracesConfig) (OTLPOptions, error) {
+	rawEndpoint, _ := cfg.OTLPTracesEndpoint()
+	if addr, ok := unixSocketEndpoint(rawEndpoint); ok {
+		return unixTracesGRPCOptions(cfg, addr)
+	}
+
 	opts := OTLPOptions{Headers: map[string]string{}}
 	log := tlog().With("transport", "grpc")
 	murl, _, err := ParseTracesEndpoint(cfg)
@@ -223,7 +273,7 @@ func GRPCTracesEndpointOptions(cfg *TracesConfig) (OTLPOptions, error) {
 	log.Debug("Configuring exporter", "protocol",
 		cfg.Protocol, "tracesProtocol", cfg.TracesProtocol, "endpoint", murl.Host)
 	opts.Endpoint = murl.Host
-	if murl.Scheme == "http" || murl.Scheme == "unix" {
+	if murl.Scheme == "http" {
 		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
 		opts.Insecure = true
 	}

--- a/pkg/export/otel/otelcfg/uds.go
+++ b/pkg/export/otel/otelcfg/uds.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg // import "go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+const unixSchemePrefix = "unix://"
+
+// sockaddr_un.sun_path is 108 bytes.
+// pathname sockets need a trailing NUL;
+// abstract names do not.
+const unixPathMax = 108
+
+func unixSocketEndpoint(endpoint string) (string, bool) {
+	if !strings.HasPrefix(endpoint, unixSchemePrefix) {
+		return "", false
+	}
+
+	return strings.TrimPrefix(endpoint, unixSchemePrefix), true
+}
+
+func validateUnixSocketAddr(addr string) error {
+	switch {
+	case addr == "":
+		return errors.New("unix socket address is empty")
+	case strings.HasPrefix(addr, "@"):
+		if len(addr) > unixPathMax {
+			return fmt.Errorf("abstract unix socket name %q exceeds the %d-byte limit", addr, unixPathMax)
+		}
+	case strings.HasPrefix(addr, "/"):
+		if len(addr) > unixPathMax-1 {
+			return fmt.Errorf("unix socket path %q exceeds the %d-byte limit", addr, unixPathMax-1)
+		}
+	default:
+		return fmt.Errorf("unix socket address %q must be an absolute path or an abstract name (leading '@')", addr)
+	}
+
+	return nil
+}
+
+func UnixTransport(addr string) *http.Transport {
+	return &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", addr)
+		},
+	}
+}
+
+func unixHTTPClient(addr string) *http.Client {
+	return &http.Client{Transport: UnixTransport(addr)}
+}
+
+func grpcUnixTarget(addr string) string {
+	if name, ok := strings.CutPrefix(addr, "@"); ok {
+		return "unix-abstract:" + name
+	}
+
+	return "unix://" + addr
+}

--- a/pkg/export/otel/otelcfg/uds_test.go
+++ b/pkg/export/otel/otelcfg/uds_test.go
@@ -1,0 +1,125 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+)
+
+func TestUnixSocketEndpoint(t *testing.T) {
+	for _, tc := range []struct {
+		endpoint string
+		addr     string
+		ok       bool
+	}{
+		{endpoint: "unix:///var/run/obi.sock", addr: "/var/run/obi.sock", ok: true},
+		{endpoint: "unix://@obi", addr: "@obi", ok: true},
+		{endpoint: "http://localhost:4318", ok: false},
+		{endpoint: "localhost:4317", ok: false},
+	} {
+		addr, ok := unixSocketEndpoint(tc.endpoint)
+		assert.Equal(t, tc.ok, ok, tc.endpoint)
+		assert.Equal(t, tc.addr, addr, tc.endpoint)
+	}
+}
+
+func TestValidateUnixSocketAddr(t *testing.T) {
+	require.NoError(t, validateUnixSocketAddr("/var/run/obi.sock"))
+	require.NoError(t, validateUnixSocketAddr("@obi"))
+
+	require.Error(t, validateUnixSocketAddr(""))
+	require.Error(t, validateUnixSocketAddr("relative/path.sock"))
+	require.Error(t, validateUnixSocketAddr("/"+strings.Repeat("a", unixPathMax)))
+	require.Error(t, validateUnixSocketAddr("@"+strings.Repeat("a", unixPathMax)))
+}
+
+func TestGRPCUnixTarget(t *testing.T) {
+	assert.Equal(t, "unix:///var/run/obi.sock", grpcUnixTarget("/var/run/obi.sock"))
+	assert.Equal(t, "unix-abstract:obi", grpcUnixTarget("@obi"))
+}
+
+func TestUnixMetricsEndpointOptions(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+
+	t.Run("http abstract", func(t *testing.T) {
+		opts, err := httpMetricEndpointOptions(&MetricsConfig{MetricsEndpoint: "unix://@obi"})
+		require.NoError(t, err)
+		assert.Equal(t, OTLPOptions{Endpoint: "localhost", Insecure: true, UnixSocketAddr: "@obi", Headers: map[string]string{}}, opts)
+	})
+
+	t.Run("grpc path", func(t *testing.T) {
+		opts, err := grpcMetricEndpointOptions(&MetricsConfig{MetricsEndpoint: "unix:///var/run/obi.sock"})
+		require.NoError(t, err)
+		assert.Equal(t, OTLPOptions{Endpoint: "unix:///var/run/obi.sock", Insecure: true, UnixSocketAddr: "/var/run/obi.sock", Headers: map[string]string{}}, opts)
+	})
+
+	t.Run("invalid address", func(t *testing.T) {
+		_, err := httpMetricEndpointOptions(&MetricsConfig{MetricsEndpoint: "unix://relative.sock"})
+		require.Error(t, err)
+	})
+}
+
+func TestUnixTracesEndpointOptions(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+
+	t.Run("http abstract", func(t *testing.T) {
+		opts, err := HTTPTracesEndpointOptions(&TracesConfig{TracesEndpoint: "unix://@obi"})
+		require.NoError(t, err)
+		assert.Equal(t, OTLPOptions{Scheme: "http", Endpoint: "localhost", Insecure: true, UnixSocketAddr: "@obi", Headers: map[string]string{}}, opts)
+	})
+
+	t.Run("grpc path", func(t *testing.T) {
+		opts, err := GRPCTracesEndpointOptions(&TracesConfig{TracesEndpoint: "unix:///var/run/obi.sock"})
+		require.NoError(t, err)
+		assert.Equal(t, OTLPOptions{Endpoint: "unix:///var/run/obi.sock", Insecure: true, UnixSocketAddr: "/var/run/obi.sock", Headers: map[string]string{}}, opts)
+	})
+}
+
+func TestUnixSocketMetricsExporter(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+
+	lis, err := net.Listen("unix", "@obi-test-metrics")
+	require.NoError(t, err)
+	defer lis.Close()
+
+	gotPath := make(chan string, 1)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case gotPath <- r.URL.Path:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	})}
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Close()
+
+	instancer := MetricsExporterInstancer{Cfg: &MetricsConfig{
+		MetricsEndpoint:  "unix://@obi-test-metrics",
+		Instrumentations: []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+	}}
+	exp, err := instancer.Instantiate(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = exp.Shutdown(context.Background()) })
+
+	require.NoError(t, exp.Export(context.Background(), &metricdata.ResourceMetrics{}))
+
+	select {
+	case path := <-gotPath:
+		assert.Equal(t, "/v1/metrics", path)
+	case <-time.After(5 * time.Second):
+		t.Fatal("metrics request not received over unix socket")
+	}
+}

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
 	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
@@ -16,6 +17,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configmiddleware"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
@@ -27,6 +29,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	"go.opentelemetry.io/collector/extension/extensionmiddleware"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -148,8 +151,32 @@ func (emptyHost) GetExtensions() map[component.ID]component.Component {
 	return nil
 }
 
+// udsHost exposes the udsMiddleware extension so confighttp can resolve it at exp.Start
+type udsHost struct {
+	extensions map[component.ID]component.Component
+}
+
+func (h udsHost) GetExtensions() map[component.ID]component.Component {
+	return h.extensions
+}
+
+// udsMiddleware replaces the HTTP client transport with one that dials a unix socket
+type udsMiddleware struct {
+	addr string
+}
+
+func (udsMiddleware) Start(context.Context, component.Host) error { return nil }
+
+func (udsMiddleware) Shutdown(context.Context) error { return nil }
+
+func (m udsMiddleware) GetHTTPRoundTripper(context.Context) (extensionmiddleware.WrapHTTPRoundTripperFunc, error) {
+	return func(_ context.Context, _ http.RoundTripper) (http.RoundTripper, error) {
+		return otelcfg.UnixTransport(m.addr), nil
+	}, nil
+}
+
 func (tr *tracesOTELReceiver) provideLoop(ctx context.Context) {
-	exp, err := getTracesExporter(ctx, tr.cfg, tr.ctxInfo.Metrics)
+	exp, host, err := getTracesExporter(ctx, tr.cfg, tr.ctxInfo.Metrics)
 	if err != nil {
 		slog.Error("error creating traces exporter", "error", err)
 		return
@@ -160,7 +187,7 @@ func (tr *tracesOTELReceiver) provideLoop(ctx context.Context) {
 			slog.Error("error shutting down traces exporter", "error", err)
 		}
 	}()
-	err = exp.Start(ctx, emptyHost{})
+	err = exp.Start(ctx, host)
 	if err != nil {
 		slog.Error("error starting traces exporter", "error", err)
 		return
@@ -193,11 +220,11 @@ func instrumentTracesExporter(internalMetrics imetrics.Reporter, in exporter.Tra
 }
 
 //nolint:cyclop
-func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetrics.Reporter) (exporter.Traces, error) {
+func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetrics.Reporter) (exporter.Traces, component.Host, error) {
 	if cfg.TracesConsumer != nil {
 		newType, err := component.NewType("traces")
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		set := getTraceSettings(newType, cfg.SDKLogLevel)
 		exp, err := exporterhelper.NewTraces(ctx, set, cfg,
@@ -205,10 +232,10 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 			exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 		)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		exp = instrumentTracesExporter(im, exp)
-		return exp, nil
+		return exp, emptyHost{}, nil
 	}
 	switch proto := cfg.GetProtocol(); proto {
 	case otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf, "": // zero value defaults to HTTP for backwards-compatibility
@@ -218,7 +245,7 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		opts, err := otelcfg.HTTPTracesEndpointOptions(&cfg)
 		if err != nil {
 			slog.Error("can't get HTTP traces endpoint options", "error", err)
-			return nil, err
+			return nil, nil, err
 		}
 		factory := otlphttpexporter.NewFactory()
 		config := factory.CreateDefaultConfig().(*otlphttpexporter.Config)
@@ -232,41 +259,54 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 			},
 			Headers: convertHeaders(opts.Headers),
 		}
+		host := component.Host(emptyHost{})
+		if opts.UnixSocketAddr != "" {
+			mwID := component.MustNewID("obi_uds")
+			config.ClientConfig.Middlewares = []configmiddleware.Config{{ID: mwID}}
+			host = udsHost{extensions: map[component.ID]component.Component{
+				mwID: udsMiddleware{addr: opts.UnixSocketAddr},
+			}}
+		}
 		slog.Debug("getTracesExporter: confighttp.ClientConfig created", "endpoint", config.ClientConfig.Endpoint)
 		set := getTraceSettings(factory.Type(), cfg.SDKLogLevel)
 		exp, err := factory.CreateTraces(ctx, set, config)
 		if err != nil {
 			slog.Error("can't create OTLP HTTP traces exporter", "error", err)
-			return nil, err
+			return nil, nil, err
 		}
 		exp = instrumentTracesExporter(im, exp)
 		// TODO: remove this once the batcher helper is added to otlphttpexporter
-		return exporterhelper.NewTraces(ctx, set, cfg,
+		wrapped, err := exporterhelper.NewTraces(ctx, set, cfg,
 			exp.ConsumeTraces,
 			exporterhelper.WithStart(exp.Start),
 			exporterhelper.WithShutdown(exp.Shutdown),
 			exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
 			exporterhelper.WithQueue(config.QueueConfig),
 			exporterhelper.WithRetry(config.RetryConfig))
+		return wrapped, host, err
 	case otelcfg.ProtocolGRPC:
 		slog.Debug("instantiating GRPC TracesReporter", "protocol", proto)
 		var err error
 		opts, err := otelcfg.GRPCTracesEndpointOptions(&cfg)
 		if err != nil {
 			slog.Error("can't get GRPC traces endpoint options", "error", err)
-			return nil, err
+			return nil, nil, err
 		}
-		endpoint, _, err := otelcfg.ParseTracesEndpoint(&cfg)
-		if err != nil {
-			slog.Error("can't parse GRPC traces endpoint", "error", err)
-			return nil, err
+		grpcEndpoint := opts.Endpoint
+		if opts.UnixSocketAddr == "" {
+			endpoint, _, perr := otelcfg.ParseTracesEndpoint(&cfg)
+			if perr != nil {
+				slog.Error("can't parse GRPC traces endpoint", "error", perr)
+				return nil, nil, perr
+			}
+			grpcEndpoint = endpoint.String()
 		}
 		factory := otlpexporter.NewFactory()
 		config := factory.CreateDefaultConfig().(*otlpexporter.Config)
 		config.QueueConfig = getQueueConfig(cfg)
 		config.RetryConfig = getRetrySettings(cfg)
 		config.ClientConfig = configgrpc.ClientConfig{
-			Endpoint: endpoint.String(),
+			Endpoint: grpcEndpoint,
 			TLS: configtls.ClientConfig{
 				Insecure:           opts.Insecure,
 				InsecureSkipVerify: cfg.InsecureSkipVerify,
@@ -276,10 +316,10 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		set := getTraceSettings(factory.Type(), cfg.SDKLogLevel)
 		exp, err := factory.CreateTraces(ctx, set, config)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		exp = instrumentTracesExporter(im, exp)
-		return exp, nil
+		return exp, emptyHost{}, nil
 	case otelcfg.ProtocolDebug:
 		slog.Debug("instantiating Debug TracesReporter", "protocol", proto)
 		factory := debugexporter.NewFactory()
@@ -289,13 +329,13 @@ func getTracesExporter(ctx context.Context, cfg otelcfg.TracesConfig, im imetric
 		set := getTraceSettings(factory.Type(), cfg.SDKLogLevel)
 		exp, err := factory.CreateTraces(ctx, set, config)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return exp, nil
+		return exp, emptyHost{}, nil
 	default:
 		slog.Error(fmt.Sprintf("invalid protocol value: %q. Accepted values are: %s, %s, %s",
 			proto, otelcfg.ProtocolGRPC, otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf))
-		return nil, fmt.Errorf("invalid protocol value: %q", proto)
+		return nil, nil, fmt.Errorf("invalid protocol value: %q", proto)
 	}
 }
 

--- a/pkg/export/otel/uds_traces_test.go
+++ b/pkg/export/otel/uds_traces_test.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+)
+
+func TestUnixSocketTracesExporter(t *testing.T) {
+	lis, err := net.Listen("unix", "@obi-test-traces")
+	require.NoError(t, err)
+	defer lis.Close()
+
+	gotPath := make(chan string, 1)
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case gotPath <- r.URL.Path:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	})}
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Close()
+
+	cfg := otelcfg.TracesConfig{
+		TracesEndpoint:   "unix://@obi-test-traces",
+		Instrumentations: []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+	}
+	exp, host, err := getTracesExporter(context.Background(), cfg, nil)
+	require.NoError(t, err)
+	require.NoError(t, exp.Start(context.Background(), host))
+	t.Cleanup(func() { _ = exp.Shutdown(context.Background()) })
+
+	traces := ptrace.NewTraces()
+	traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty().SetName("test")
+	require.NoError(t, exp.ConsumeTraces(context.Background(), traces))
+
+	select {
+	case path := <-gotPath:
+		assert.Equal(t, "/v1/traces", path)
+	case <-time.After(5 * time.Second):
+		t.Fatal("traces request not received over unix socket")
+	}
+}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -55,6 +55,16 @@ func ListenAndServe(ctx context.Context, port int) error {
 	return Serve(ctx, lis)
 }
 
+func ListenAndServeUDS(ctx context.Context, addr string) error {
+	lis, err := net.Listen("unix", addr)
+	if err != nil {
+		log().With("addr", addr).Error("can't bind health endpoint", "err", err)
+		return nil
+	}
+
+	return Serve(ctx, lis)
+}
+
 func Serve(ctx context.Context, lis net.Listener) error {
 	mux := http.NewServeMux()
 	mux.Handle(path, &endpoint{start: time.Now()})

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -71,6 +71,39 @@ func TestServeEndToEnd(t *testing.T) {
 	require.NoError(t, <-srvErr)
 }
 
+func TestServeEndToEndUDS(t *testing.T) {
+	const addr = "@obi-health-test"
+	lis, err := net.Listen("unix", addr)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srvErr := make(chan error, 1)
+	go func() {
+		srvErr <- Serve(ctx, lis)
+	}()
+
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", addr)
+		},
+	}}
+
+	resp, err := client.Get("http://localhost" + path)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body response
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, schemaVersion, body.SchemaVersion)
+
+	cancel()
+	require.NoError(t, <-srvErr)
+}
+
 func snapshotFor(t *testing.T, e *endpoint) response {
 	t.Helper()
 

--- a/pkg/instrumenter/instrumenter.go
+++ b/pkg/instrumenter/instrumenter.go
@@ -42,6 +42,19 @@ func Run(
 	return RunWithContextInfo(ctx, cfg, ctxInfo, opts...)
 }
 
+func startHealthCheck(ctx context.Context, g *errgroup.Group, cfg obi.HealthCheckConfig) {
+	switch {
+	case cfg.UnixSocketPath != "":
+		g.Go(func() error {
+			return health.ListenAndServeUDS(ctx, cfg.UnixSocketPath)
+		})
+	case cfg.Port != 0:
+		g.Go(func() error {
+			return health.ListenAndServe(ctx, cfg.Port)
+		})
+	}
+}
+
 func RunWithContextInfo(
 	ctx context.Context, cfg *obi.Config, ctxInfo *global.ContextInfo,
 	opts ...Option,
@@ -59,11 +72,7 @@ func RunWithContextInfo(
 	// if one of nodes fail, the other should stop
 	g, ctx := errgroup.WithContext(ctx)
 
-	if cfg.HealthCheck.Port != 0 {
-		g.Go(func() error {
-			return health.ListenAndServe(ctx, cfg.HealthCheck.Port)
-		})
-	}
+	startHealthCheck(ctx, g, cfg.HealthCheck)
 
 	if app {
 		g.Go(func() error {

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -431,6 +431,9 @@ type Config struct {
 type HealthCheckConfig struct {
 	// 0 (default) means disabled
 	Port int `yaml:"port" env:"OTEL_EBPF_HEALTH_CHECK_PORT" validate:"gte=0,lte=65535"`
+	// when set, the health endpoint binds this unix socket (a filesystem path or a leading-'@'
+	// abstract name) instead of the TCP port
+	UnixSocketPath string `yaml:"unix_socket_path" env:"OTEL_EBPF_HEALTH_CHECK_UNIX_SOCKET_PATH"`
 }
 
 func (c *Config) Unmarshal(component *confmap.Conf) error {


### PR DESCRIPTION
## Summary

Allow unix socket endpoints to be specified as valid OTLP export URLs. The particular use case for this is to be able to drive OBI as a subprocess and communicate with it without paying the cost of a round trip inside the kernel TCP stack when operating in loopback, but that's just one use-case and is not limited to it.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
