### PR TITLE
Fix stale Kafka traceparent contaminating later trace context (#2046)

### DIFF
--- a/bpf/gotracer/go_kafka_go.c
+++ b/bpf/gotracer/go_kafka_go.c
@@ -57,6 +57,23 @@ int obi_uprobe_writer_write_messages(struct pt_regs *ctx) {
     return 0;
 }
 
+SEC("uprobe/writer_write_messages_ret")
+int obi_uprobe_writer_write_messages_ret(struct pt_regs *ctx) {
+    void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
+    bpf_dbg_printk("=== uprobe/writer_write_messages_ret ===");
+    bpf_dbg_printk("goroutine_addr=%llx", goroutine_addr);
+
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+
+    // Drop the goroutine-keyed traceparent so casgstatus can't re-install this
+    // produce's context after the request ends (issue #2046).
+    bpf_map_delete_elem(&produce_traceparents_by_goroutine, &g_key);
+    obi_ctx__del(bpf_get_current_pid_tgid());
+
+    return 0;
+}
+
 SEC("uprobe/writer_produce")
 int obi_uprobe_writer_produce(struct pt_regs *ctx) {
     void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);

--- a/internal/test/integration/components/gokafka-seg/main.go
+++ b/internal/test/integration/components/gokafka-seg/main.go
@@ -51,6 +51,41 @@ func producerHandlerWithTopic(kafkaWriter *kafka.Writer, topic string) func(http
 	})
 }
 
+// Marker log lines for the issue #2046 traceparent-contamination regression test.
+const (
+	kafkaTPPositiveControlMsg = "kafka-tp-positive-control"
+	kafkaTPAfterProduceMsg    = "kafka-tp-after-produce"
+)
+
+func logJSON(message string) {
+	fmt.Printf(`{"message":"%s","level":"INFO"}`+"\n", message)
+}
+
+// traceparentProbeHandler logs once from the request goroutine (positive control),
+// then runs a Kafka produce followed by a log line on a worker goroutine that has
+// no request context of its own (issue #2046).
+func traceparentProbeHandler(kafkaWriter *kafka.Writer) func(http.ResponseWriter, *http.Request) {
+	return http.HandlerFunc(func(wrt http.ResponseWriter, _ *http.Request) {
+		logJSON(kafkaTPPositiveControlMsg)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			err := kafkaWriter.WriteMessages(context.Background(), kafka.Message{
+				Key:   []byte("tp-probe"),
+				Value: []byte("tp-probe"),
+			})
+			if err != nil {
+				fmt.Printf("error %v\n", err)
+			}
+			logJSON(kafkaTPAfterProduceMsg)
+		}()
+		<-done
+
+		_, _ = wrt.Write([]byte("ok\n"))
+	})
+}
+
 func getKafkaWriter(kafkaURL, topic string) *kafka.Writer {
 	return &kafka.Writer{
 		Addr:     kafka.TCP(kafkaURL),
@@ -122,6 +157,10 @@ func main() {
 	// Add handle func for producer.
 	http.HandleFunc("/ping", producerHandler(kafkaWriter))
 	http.HandleFunc("/withTopic", producerHandlerWithTopic(kafkaWriter2, topic))
+	http.HandleFunc("/traceparent_probe", traceparentProbeHandler(kafkaWriter))
+	http.HandleFunc("/smoke", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok\n"))
+	})
 
 	// Run the web server.
 	fmt.Println("started test server on port 8080 ...")

--- a/internal/test/integration/configs/obi-config-go-kafka-traceparent.yml
+++ b/internal/test/integration/configs/obi-config-go-kafka-traceparent.yml
@@ -1,0 +1,14 @@
+attributes:
+  kubernetes:
+    cluster_name: obi-k8s-test-cluster
+  select:
+    "*":
+      include: ["*"]
+ebpf:
+  log_enricher:
+    services:
+      - service:
+        - exe_path: testserver
+discovery:
+  min_process_age: "0s"
+log_config: "yaml"

--- a/internal/test/integration/docker-compose-go-kafka-traceparent.yml
+++ b/internal/test/integration/docker-compose-go-kafka-traceparent.yml
@@ -1,0 +1,94 @@
+services:
+  zookeeper:
+    restart: always
+    container_name: kafka-tp-zookeeper
+    image: docker.io/bitnamilegacy/zookeeper:3.9@sha256:46d5bcbdf4434f40b7a453a7f53e6ea436a770981433c173ab782c0b13a5fb87
+    networks:
+      - shared
+    ports:
+      - "2181:2181"
+    volumes:
+      - "zookeeper-tp-volume:/bitnami"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+
+  kafka:
+    restart: always
+    container_name: kafka-tp
+    image: docker.io/bitnamilegacy/kafka:3.9@sha256:55df55bfc7ed5980447387620afa3498eab3985a4d8c731013d82b3fa8b43bff
+    networks:
+      - shared
+    ports:
+      - "9093:9093"
+    volumes:
+      - "kafka-tp-volume:/bitnami"
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT
+    depends_on:
+      - zookeeper
+
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/gokafka-seg/Dockerfile
+    image: hatest-testserver-go-kafka-traceparent
+    networks:
+      - shared
+    environment:
+      kafkaURL: "kafka:9092"
+      topic: "my-topic"
+      groupID: "1"
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    depends_on:
+      kafka:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - /sys/kernel/security:/sys/kernel/security:ro
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-go-kafka-traceparent:/var/run/obi
+      - /sys/fs/bpf:/sys/fs/bpf
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    networks:
+      - shared
+    pid: "host"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config-go-kafka-traceparent.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_BPF_TRACK_REQUEST_HEADERS: "true"
+      OTEL_EBPF_METRICS_FEATURES: "application,application_process"
+      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_process"
+    depends_on:
+      testserver:
+        condition: service_started
+
+networks:
+  shared:
+
+volumes:
+  kafka-tp-volume:
+  zookeeper-tp-volume:

--- a/internal/test/integration/go_kafka_traceparent_test.go
+++ b/internal/test/integration/go_kafka_traceparent_test.go
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Must match the marker messages emitted by the gokafka-seg test server.
+const (
+	kafkaTPURL                = "http://localhost:8389"
+	kafkaTPContainerImage     = "hatest-testserver-go-kafka-traceparent"
+	kafkaTPPositiveControlMsg = "kafka-tp-positive-control"
+	kafkaTPAfterProduceMsg    = "kafka-tp-after-produce"
+	// Fixed W3C traceparent injected on the request so the in-handler line is
+	// enriched with a known trace_id.
+	kafkaTPTraceID = "11112222333344445555666677778888"
+	kafkaTPSpanID  = "1234567890abcdef"
+)
+
+// testGoKafkaTraceparent is a regression test for issue #2046: a stale Kafka
+// produce traceparent must not leak into later work on the reused goroutine.
+//
+// /traceparent_probe logs once from the request goroutine (which carries the
+// injected HTTP-server trace context: positive control, proves the log enricher
+// is active) and once from a worker goroutine after a Kafka produce. The worker
+// has no request context of its own, so its line must not be enriched. Before the
+// fix, casgstatus re-installs the stale goroutine-keyed traceparent and the
+// worker line inherits the produce's trace_id.
+func testGoKafkaTraceparent(t *testing.T) {
+	waitForTestComponentsNoMetrics(t, kafkaTPURL+"/smoke")
+
+	cl, err := client.New(client.FromEnv)
+	require.NoError(t, err)
+	defer cl.Close()
+
+	traceparent := fmt.Sprintf("00-%s-%s-01", kafkaTPTraceID, kafkaTPSpanID)
+	fire := func() {
+		req, reqErr := http.NewRequest(http.MethodGet, kafkaTPURL+"/traceparent_probe", nil)
+		if reqErr != nil {
+			return
+		}
+		req.Header.Set("traceparent", traceparent)
+		if resp, doErr := http.DefaultClient.Do(req); doErr == nil {
+			resp.Body.Close()
+		}
+	}
+
+	// Gate on the enricher being provably active: the in-handler line must be
+	// enriched with the injected trace_id, otherwise the absence check below
+	// could pass vacuously.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		fire()
+		containerID := testContainerID(ct, cl, kafkaTPContainerImage)
+		if !assert.NotEmpty(ct, containerID, "could not find test container ID") {
+			return
+		}
+		enriched := 0
+		for _, line := range containerLogs(ct, cl, containerID) {
+			var fields map[string]string
+			if json.Unmarshal([]byte(line), &fields) != nil {
+				continue
+			}
+			if fields["message"] == kafkaTPPositiveControlMsg && fields["trace_id"] == kafkaTPTraceID {
+				enriched++
+			}
+		}
+		assert.Positive(ct, enriched, "log enricher has not enriched the in-handler line yet")
+	}, 2*testTimeout, time.Second)
+
+	// Contamination is timing-dependent, so drive a batch to give a buggy build
+	// many opportunities to leak the produce trace context into the worker line.
+	const batch = 60
+	for i := 0; i < batch; i++ {
+		fire()
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	// Wait for the worker lines to flush, then count how many leaked a trace
+	// context (the count is monotonic, so it is safe to assert once flushed).
+	var contaminated, afterProduce int
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		containerID := testContainerID(ct, cl, kafkaTPContainerImage)
+		if !assert.NotEmpty(ct, containerID) {
+			return
+		}
+		contaminated, afterProduce = 0, 0
+		for _, line := range containerLogs(ct, cl, containerID) {
+			var fields map[string]string
+			if json.Unmarshal([]byte(line), &fields) != nil {
+				continue
+			}
+			if fields["message"] == kafkaTPAfterProduceMsg {
+				afterProduce++
+				if fields["trace_id"] != "" {
+					contaminated++
+				}
+			}
+		}
+		assert.GreaterOrEqual(ct, afterProduce, batch, "waiting for worker log lines to flush")
+	}, 2*testTimeout, time.Second)
+
+	require.Zero(t, contaminated,
+		"%d of %d worker log lines leaked a Kafka produce trace_id after the produce ended (issue #2046)",
+		contaminated, afterProduce)
+}

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -548,6 +548,18 @@ func TestSuite_PythonKafka(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_GoKafkaTraceparent(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-go-kafka-traceparent.yml", path.Join(pathOutput, "test-suite-go-kafka-traceparent.log"))
+	// Discover by executable name: the Kafka broker and Zookeeper are Java processes
+	// (Zookeeper's admin server also listens on 8080), so port-based discovery is
+	// ambiguous under pid:host. Match only the Go "testserver" binary.
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=`, `OTEL_EBPF_EXECUTABLE_PATH=testserver`, `TEST_SERVICE_PORTS=8389:8080`)
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+	t.Run("Go Kafka stale traceparent contamination (#2046)", testGoKafkaTraceparent)
+	require.NoError(t, compose.Close())
+}
+
 func TestSuite_PythonMQTT(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-mqtt.yml", path.Join(pathOutput, "test-suite-python-mqtt.log"))
 	require.NoError(t, err)

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -510,6 +510,7 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 		// Kafka Go
 		"github.com/segmentio/kafka-go.(*Writer).WriteMessages": {{ // runs on the same gorountine as other requests, finds traceparent info
 			Start: p.bpfObjects.ObiUprobeWriterWriteMessages,
+			End:   p.bpfObjects.ObiUprobeWriterWriteMessagesRet,
 		}},
 		"github.com/segmentio/kafka-go.(*Writer).produce": {{ // stores the current topic
 			Start: p.bpfObjects.ObiUprobeWriterProduce,


### PR DESCRIPTION
Fixes #2046.

The Go Kafka instrumentation stores a traceparent in
`produce_traceparents_by_goroutine` on `WriteMessages` but never removes it, so
after the produce ends `runtime.casgstatus` can still reinstall it into the
shared `traces_ctx_v1` and unrelated work on the same goroutine inherits the
old trace context.

The change adds a return uprobe on `(*Writer).WriteMessages` that deletes the
goroutine-keyed entry and clears the per-thread context on return.

A note on the approach: the issue suggested cleaning up on the produce/roundTrip
paths. I tried a single return probe instead, since as far as I could tell those
paths can run on a different goroutine than the `WriteMessages` caller, which
would make a goroutine-keyed delete there miss the entry (including the async
writer). Deleting on the `WriteMessages` return also lines up with the
set-on-entry/delete-on-return pattern the other Go instrumentations use.

I also added an integration test that produces and then logs from a worker
goroutine, checking via the log enricher that the log line does not pick up the
produce trace_id.
