### PR TITLE
fix(java): forward proxy output stream packet ranges

### DIFF
--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/ebpf/ProxyInputStream.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/ebpf/ProxyInputStream.java
@@ -28,9 +28,7 @@ public class ProxyInputStream extends InputStream {
   public int read(byte[] b) throws IOException {
     int len = delegate.read(b);
     if (len > 0) {
-      NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + len);
-      writeReadPacket(p, socket, b, 0, len);
-      Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
+      forwardRead(b, 0, len);
     }
     return len;
   }
@@ -39,11 +37,15 @@ public class ProxyInputStream extends InputStream {
   public int read(byte[] b, int off, int len) throws IOException {
     int bytesRead = delegate.read(b, off, len);
     if (bytesRead > 0) {
-      NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + bytesRead);
-      writeReadPacket(p, socket, b, off, bytesRead);
-      Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
+      forwardRead(b, off, bytesRead);
     }
     return bytesRead;
+  }
+
+  void forwardRead(byte[] b, int off, int len) {
+    NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + len);
+    writeReadPacket(p, socket, b, off, len);
+    Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
   }
 
   static int writeReadPacket(NativeMemory p, Socket socket, byte[] b, int off, int len) {

--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/ebpf/ProxyOutputStream.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/ebpf/ProxyOutputStream.java
@@ -24,24 +24,24 @@ public class ProxyOutputStream extends OutputStream {
     delegate.write(b);
   }
 
-  private void writeWrapper(byte[] b) {
-    if (b.length > 0) {
-      NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + b.length);
-      int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.SEND, socket, b.length);
-      IOCTLPacket.writePacketBuffer(p, wOff, b);
+  void forwardWrite(byte[] b, int off, int len) {
+    if (len > 0) {
+      NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + len);
+      int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.SEND, socket, len);
+      IOCTLPacket.writePacketBuffer(p, wOff, b, off, len);
       Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
     }
   }
 
   @Override
   public void write(byte[] b) throws IOException {
-    writeWrapper(b);
+    forwardWrite(b, 0, b.length);
     delegate.write(b);
   }
 
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
-    writeWrapper(b);
+    forwardWrite(b, off, len);
     delegate.write(b, off, len);
   }
 

--- a/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/ebpf/ProxyInputStreamTest.java
+++ b/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/ebpf/ProxyInputStreamTest.java
@@ -5,12 +5,15 @@
 
 package io.opentelemetry.obi.java.ebpf;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 class ProxyInputStreamTest {
-
   @Test
   void readPacketUsesBytesReadForPartialBuffer() {
     byte[] buffer = {10, 20, 30, 40, 50};
@@ -25,5 +28,50 @@ class ProxyInputStreamTest {
       assertEquals(buffer[i], packet.getBuffer().get(IOCTLPacket.packetPrefixSize + i));
     }
     assertEquals(0, packet.getBuffer().get(IOCTLPacket.packetPrefixSize + bytesRead));
+  }
+
+  @Test
+  void readByteArrayForwardsActualReadLength() throws Exception {
+    CapturingProxyInputStream stream =
+        new CapturingProxyInputStream(new ByteArrayInputStream(new byte[] {1, 2}));
+    byte[] buffer = new byte[8];
+
+    int bytesRead = stream.read(buffer);
+
+    assertEquals(2, bytesRead);
+    assertEquals(0, stream.forwardedOffset);
+    assertEquals(2, stream.forwardedLength);
+    assertArrayEquals(new byte[] {1, 2}, stream.forwardedBytes);
+  }
+
+  @Test
+  void readByteArrayWithOffsetForwardsOffsetAndBytesRead() throws Exception {
+    CapturingProxyInputStream stream =
+        new CapturingProxyInputStream(new ByteArrayInputStream(new byte[] {3, 4}));
+    byte[] buffer = new byte[8];
+
+    int bytesRead = stream.read(buffer, 3, 4);
+
+    assertEquals(2, bytesRead);
+    assertEquals(3, stream.forwardedOffset);
+    assertEquals(2, stream.forwardedLength);
+    assertArrayEquals(new byte[] {3, 4}, stream.forwardedBytes);
+  }
+
+  private static class CapturingProxyInputStream extends ProxyInputStream {
+    private int forwardedOffset = -1;
+    private int forwardedLength = -1;
+    private byte[] forwardedBytes;
+
+    CapturingProxyInputStream(InputStream delegate) {
+      super(delegate, null);
+    }
+
+    @Override
+    void forwardRead(byte[] b, int off, int len) {
+      forwardedOffset = off;
+      forwardedLength = len;
+      forwardedBytes = Arrays.copyOfRange(b, off, off + len);
+    }
   }
 }

--- a/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/ebpf/ProxyOutputStreamTest.java
+++ b/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/ebpf/ProxyOutputStreamTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.obi.java.ebpf;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class ProxyOutputStreamTest {
+  @Test
+  void writeByteArrayForwardsFullArray() throws Exception {
+    ByteArrayOutputStream delegate = new ByteArrayOutputStream();
+    CapturingProxyOutputStream stream = new CapturingProxyOutputStream(delegate);
+    byte[] buffer = new byte[] {1, 2, 3};
+
+    stream.write(buffer);
+
+    assertEquals(0, stream.forwardedOffset);
+    assertEquals(3, stream.forwardedLength);
+    assertArrayEquals(buffer, stream.forwardedBytes);
+    assertArrayEquals(buffer, delegate.toByteArray());
+  }
+
+  @Test
+  void writeByteArrayWithOffsetForwardsOffsetAndLength() throws Exception {
+    ByteArrayOutputStream delegate = new ByteArrayOutputStream();
+    CapturingProxyOutputStream stream = new CapturingProxyOutputStream(delegate);
+    byte[] buffer = new byte[] {1, 2, 3, 4};
+
+    stream.write(buffer, 1, 2);
+
+    assertEquals(1, stream.forwardedOffset);
+    assertEquals(2, stream.forwardedLength);
+    assertArrayEquals(new byte[] {2, 3}, stream.forwardedBytes);
+    assertArrayEquals(new byte[] {2, 3}, delegate.toByteArray());
+  }
+
+  private static class CapturingProxyOutputStream extends ProxyOutputStream {
+    private int forwardedOffset = -1;
+    private int forwardedLength = -1;
+    private byte[] forwardedBytes;
+
+    CapturingProxyOutputStream(ByteArrayOutputStream delegate) {
+      super(delegate, null);
+    }
+
+    @Override
+    void forwardWrite(byte[] b, int off, int len) {
+      forwardedOffset = off;
+      forwardedLength = len;
+      forwardedBytes = Arrays.copyOfRange(b, off, off + len);
+    }
+  }
+}


### PR DESCRIPTION
## What changed

Following #2218, this PR fixes the remaining send/output range forwarding issue.

- `ProxyOutputStream.write(byte[], off, len)` now forwards the caller-provided offset and length instead of the full backing array.
- `ProxyOutputStream.write(byte[])` uses the same range-aware forwarding helper for full-array writes.
- `ProxyInputStream` routes read forwarding through a shared helper while preserving the bytes-read packet encoding from #2218.
- Added focused tests for input forwarding coverage and output offset writes.

## Why

Before this PR, the output proxy could forward stale bytes from reused application buffers into OBI telemetry when callers used `write(byte[], off, len)`. The input-side stale-byte issue was fixed by #2218; this PR preserves and regression-tests that behavior.

Resolves #2025.

## Validation

- `gradle :agent:test --tests io.opentelemetry.obi.java.ebpf.ProxyInputStreamTest --tests io.opentelemetry.obi.java.ebpf.ProxyOutputStreamTest -PnativeOnly=true --no-daemon`
- `gradle :agent:spotlessCheck -PnativeOnly=true --no-daemon`