### PR TITLE
fix(nodeJS): bound stalled NodeJS inspector I/O

### DIFF
--- a/pkg/internal/nodejs/injector.go
+++ b/pkg/internal/nodejs/injector.go
@@ -39,6 +39,8 @@ type evalParams struct {
 	IncludeCommandLineAPI bool   `json:"includeCommandLineAPI"`
 }
 
+const inspectorRequestTimeout = 5 * time.Second
+
 // IMPORTANT: the code in this file needs to run in the network namespace of the
 // target process in order to be able to connect to its inspector port - the
 // network namespace switching is done by the withNetNS function, which locks
@@ -166,6 +168,10 @@ func upgradeConn(conn net.Conn, wsURL string) (*websocket.Conn, *http.Response, 
 }
 
 func sendEvaluate(wsConn *websocket.Conn, exp string, id int) error {
+	return sendEvaluateWithTimeout(wsConn, exp, id, inspectorRequestTimeout)
+}
+
+func sendEvaluateWithTimeout(wsConn *websocket.Conn, exp string, id int, timeout time.Duration) error {
 	req := cdpRequest{
 		ID:     id,
 		Method: "Runtime.evaluate",
@@ -178,6 +184,16 @@ func sendEvaluate(wsConn *websocket.Conn, exp string, id int) error {
 	data, err := json.Marshal(req)
 	if err != nil {
 		return fmt.Errorf("failed to serialize request: %w", err)
+	}
+
+	deadline := time.Now().Add(timeout)
+
+	if err := wsConn.SetWriteDeadline(deadline); err != nil {
+		return fmt.Errorf("websocket write deadline error: %w", err)
+	}
+
+	if err := wsConn.SetReadDeadline(deadline); err != nil {
+		return fmt.Errorf("websocket read deadline error: %w", err)
 	}
 
 	if err := wsConn.WriteMessage(websocket.TextMessage, data); err != nil {

--- a/pkg/internal/nodejs/injector.go
+++ b/pkg/internal/nodejs/injector.go
@@ -111,10 +111,21 @@ func connectWait(ip string, port int, timeout time.Duration, interval time.Durat
 }
 
 func httpGet(conn net.Conn, path string) ([]byte, error) {
+	return httpGetWithTimeout(conn, path, inspectorRequestTimeout)
+}
+
+func httpGetWithTimeout(conn net.Conn, path string, timeout time.Duration) ([]byte, error) {
 	req, err := http.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return []byte{}, fmt.Errorf("request error: %w", err)
 	}
+
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return []byte{}, fmt.Errorf("connection deadline error: %w", err)
+	}
+	defer func() {
+		_ = conn.SetDeadline(time.Time{})
+	}()
 
 	if err = req.Write(conn); err != nil {
 		return []byte{}, fmt.Errorf("error writing request: %w", err)
@@ -157,7 +168,16 @@ func (i *NodeInjector) requestDebuggerURL(conn net.Conn) (string, error) {
 }
 
 func upgradeConn(conn net.Conn, wsURL string) (*websocket.Conn, *http.Response, error) {
+	return upgradeConnWithTimeout(conn, wsURL, inspectorRequestTimeout)
+}
+
+func upgradeConnWithTimeout(conn net.Conn, wsURL string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return nil, nil, fmt.Errorf("connection deadline error: %w", err)
+	}
+
 	dialer := websocket.Dialer{
+		HandshakeTimeout: timeout,
 		NetDial: func(_, _ string) (net.Conn, error) {
 			return conn, nil
 		},

--- a/pkg/internal/nodejs/injector.go
+++ b/pkg/internal/nodejs/injector.go
@@ -175,6 +175,9 @@ func upgradeConnWithTimeout(conn net.Conn, wsURL string, timeout time.Duration) 
 	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
 		return nil, nil, fmt.Errorf("connection deadline error: %w", err)
 	}
+	defer func() {
+		_ = conn.SetDeadline(time.Time{})
+	}()
 
 	dialer := websocket.Dialer{
 		HandshakeTimeout: timeout,
@@ -211,6 +214,10 @@ func sendEvaluateWithTimeout(wsConn *websocket.Conn, exp string, id int, timeout
 	if err := wsConn.SetWriteDeadline(deadline); err != nil {
 		return fmt.Errorf("websocket write deadline error: %w", err)
 	}
+	defer func() {
+		_ = wsConn.SetWriteDeadline(time.Time{})
+		_ = wsConn.SetReadDeadline(time.Time{})
+	}()
 
 	if err := wsConn.SetReadDeadline(deadline); err != nil {
 		return fmt.Errorf("websocket read deadline error: %w", err)

--- a/pkg/internal/nodejs/injector_test.go
+++ b/pkg/internal/nodejs/injector_test.go
@@ -1,0 +1,129 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nodejs
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	testEvaluateTimeout           = 50 * time.Millisecond
+	testEvaluateSlowResponseDelay = 4 * testEvaluateTimeout
+	testEvaluateReturnTimeout     = time.Second
+)
+
+func TestSendEvaluateTimesOutWhenInspectorDoesNotRespond(t *testing.T) {
+	done := make(chan struct{})
+	wsConn := newTestInspectorConn(t, func(conn *websocket.Conn) {
+		defer conn.Close()
+
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+
+		<-done
+	})
+	defer close(done)
+
+	err := runSendEvaluateWithTimeout(t, wsConn, testEvaluateTimeout)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	assertTimeoutError(t, err)
+}
+
+func TestSendEvaluateTimesOutWhenInspectorRespondsTooSlowly(t *testing.T) {
+	done := make(chan struct{})
+	wsConn := newTestInspectorConn(t, func(conn *websocket.Conn) {
+		defer conn.Close()
+
+		if _, _, err := conn.ReadMessage(); err != nil {
+			return
+		}
+
+		select {
+		case <-time.After(testEvaluateSlowResponseDelay):
+		case <-done:
+			return
+		}
+
+		_ = conn.WriteJSON(cdpResponse{
+			ID: 1,
+			Result: map[string]any{
+				"result": map[string]any{
+					"type":  "number",
+					"value": 2,
+				},
+			},
+		})
+	})
+	defer close(done)
+
+	err := runSendEvaluateWithTimeout(t, wsConn, testEvaluateTimeout)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	assertTimeoutError(t, err)
+}
+
+func newTestInspectorConn(t *testing.T, handle func(*websocket.Conn)) *websocket.Conn {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+
+		handle(conn)
+	}))
+	t.Cleanup(srv.Close)
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = wsConn.Close()
+	})
+
+	return wsConn
+}
+
+func runSendEvaluateWithTimeout(t *testing.T, wsConn *websocket.Conn, timeout time.Duration) error {
+	t.Helper()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- sendEvaluateWithTimeout(wsConn, "1+1", 1, timeout)
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(testEvaluateReturnTimeout):
+		_ = wsConn.Close()
+		t.Fatal("sendEvaluateWithTimeout did not return")
+		return nil
+	}
+}
+
+func assertTimeoutError(t *testing.T, err error) {
+	t.Helper()
+
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+}

--- a/pkg/internal/nodejs/injector_test.go
+++ b/pkg/internal/nodejs/injector_test.go
@@ -4,10 +4,12 @@
 package nodejs
 
 import (
+	"bufio"
 	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -16,9 +18,9 @@ import (
 )
 
 const (
-	testEvaluateTimeout           = 50 * time.Millisecond
-	testEvaluateSlowResponseDelay = 4 * testEvaluateTimeout
-	testEvaluateReturnTimeout     = time.Second
+	testInspectorTimeout          = 50 * time.Millisecond
+	testEvaluateSlowResponseDelay = 4 * testInspectorTimeout
+	testInspectorOperationTimeout = time.Second
 )
 
 func TestSendEvaluateTimesOutWhenInspectorDoesNotRespond(t *testing.T) {
@@ -34,7 +36,7 @@ func TestSendEvaluateTimesOutWhenInspectorDoesNotRespond(t *testing.T) {
 	})
 	defer close(done)
 
-	err := runSendEvaluateWithTimeout(t, wsConn, testEvaluateTimeout)
+	err := runSendEvaluateWithTimeout(t, wsConn, testInspectorTimeout)
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -68,7 +70,75 @@ func TestSendEvaluateTimesOutWhenInspectorRespondsTooSlowly(t *testing.T) {
 	})
 	defer close(done)
 
-	err := runSendEvaluateWithTimeout(t, wsConn, testEvaluateTimeout)
+	err := runSendEvaluateWithTimeout(t, wsConn, testInspectorTimeout)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	assertTimeoutError(t, err)
+}
+
+func TestHTTPGetTimesOutWhenInspectorDoesNotRespond(t *testing.T) {
+	conn := newPipeInspectorConn(t, func(conn net.Conn, done <-chan struct{}) {
+		defer conn.Close()
+
+		if !readHTTPRequest(conn) {
+			return
+		}
+
+		<-done
+	})
+
+	err := runWithOperationTimeout(t, "httpGetWithTimeout", func() error {
+		_, err := httpGetWithTimeout(conn, "/json/list", testInspectorTimeout)
+		return err
+	})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	assertTimeoutError(t, err)
+}
+
+func TestHTTPGetTimesOutWhenInspectorResponseBodyStalls(t *testing.T) {
+	conn := newPipeInspectorConn(t, func(conn net.Conn, done <-chan struct{}) {
+		defer conn.Close()
+
+		if !readHTTPRequest(conn) {
+			return
+		}
+
+		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{"))
+		<-done
+	})
+
+	err := runWithOperationTimeout(t, "httpGetWithTimeout", func() error {
+		_, err := httpGetWithTimeout(conn, "/json/list", testInspectorTimeout)
+		return err
+	})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	assertTimeoutError(t, err)
+}
+
+func TestUpgradeConnTimesOutWhenInspectorDoesNotRespond(t *testing.T) {
+	conn := newPipeInspectorConn(t, func(conn net.Conn, done <-chan struct{}) {
+		defer conn.Close()
+
+		if !readHTTPRequest(conn) {
+			return
+		}
+
+		<-done
+	})
+
+	err := runWithOperationTimeout(t, "upgradeConnWithTimeout", func() error {
+		wsConn, _, err := upgradeConnWithTimeout(conn, "ws://127.0.0.1/json", testInspectorTimeout)
+		if wsConn != nil {
+			_ = wsConn.Close()
+		}
+
+		return err
+	})
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -101,20 +171,59 @@ func newTestInspectorConn(t *testing.T, handle func(*websocket.Conn)) *websocket
 	return wsConn
 }
 
+func newPipeInspectorConn(t *testing.T, handle func(net.Conn, <-chan struct{})) net.Conn {
+	t.Helper()
+
+	clientConn, serverConn := net.Pipe()
+	done := make(chan struct{})
+	handlerDone := make(chan struct{})
+
+	go func() {
+		defer close(handlerDone)
+		handle(serverConn, done)
+	}()
+
+	t.Cleanup(func() {
+		close(done)
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+		<-handlerDone
+	})
+
+	return clientConn
+}
+
+func readHTTPRequest(conn net.Conn) bool {
+	req, err := http.ReadRequest(bufio.NewReader(conn))
+	if err != nil {
+		return false
+	}
+
+	_ = req.Body.Close()
+	return true
+}
+
 func runSendEvaluateWithTimeout(t *testing.T, wsConn *websocket.Conn, timeout time.Duration) error {
+	t.Helper()
+
+	return runWithOperationTimeout(t, "sendEvaluateWithTimeout", func() error {
+		return sendEvaluateWithTimeout(wsConn, "1+1", 1, timeout)
+	})
+}
+
+func runWithOperationTimeout(t *testing.T, name string, run func() error) error {
 	t.Helper()
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- sendEvaluateWithTimeout(wsConn, "1+1", 1, timeout)
+		errCh <- run()
 	}()
 
 	select {
 	case err := <-errCh:
 		return err
-	case <-time.After(testEvaluateReturnTimeout):
-		_ = wsConn.Close()
-		t.Fatal("sendEvaluateWithTimeout did not return")
+	case <-time.After(testInspectorOperationTimeout):
+		t.Fatalf("%s did not return", name)
 		return nil
 	}
 }
@@ -123,7 +232,13 @@ func assertTimeoutError(t *testing.T, err error) {
 	t.Helper()
 
 	var netErr net.Error
-	if !errors.As(err, &netErr) || !netErr.Timeout() {
-		t.Fatalf("expected timeout error, got %v", err)
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return
 	}
+
+	if os.IsTimeout(err) {
+		return
+	}
+
+	t.Fatalf("expected timeout error, got %v", err)
 }

--- a/pkg/internal/nodejs/injector_test.go
+++ b/pkg/internal/nodejs/injector_test.go
@@ -77,6 +77,17 @@ func TestSendEvaluateTimesOutWhenInspectorRespondsTooSlowly(t *testing.T) {
 	assertTimeoutError(t, err)
 }
 
+func TestSendEvaluateClearsDeadlines(t *testing.T) {
+	wsConn := newRespondingTestInspectorConn(t)
+
+	if err := runSendEvaluateWithTimeout(t, wsConn, testInspectorTimeout); err != nil {
+		t.Fatalf("send evaluate: %v", err)
+	}
+
+	time.Sleep(2 * testInspectorTimeout)
+	assertWebSocketUsable(t, wsConn)
+}
+
 func TestHTTPGetTimesOutWhenInspectorDoesNotRespond(t *testing.T) {
 	conn := newPipeInspectorConn(t, func(conn net.Conn, done <-chan struct{}) {
 		defer conn.Close()
@@ -145,6 +156,27 @@ func TestUpgradeConnTimesOutWhenInspectorDoesNotRespond(t *testing.T) {
 	assertTimeoutError(t, err)
 }
 
+func TestUpgradeConnClearsDeadline(t *testing.T) {
+	srv := newRespondingTestInspectorServer(t)
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial websocket server: %v", err)
+	}
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	wsConn, _, err := upgradeConnWithTimeout(conn, wsURL, testInspectorTimeout)
+	if err != nil {
+		_ = conn.Close()
+		t.Fatalf("upgrade websocket: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = wsConn.Close()
+	})
+
+	time.Sleep(2 * testInspectorTimeout)
+	assertWebSocketUsable(t, wsConn)
+}
+
 func newTestInspectorConn(t *testing.T, handle func(*websocket.Conn)) *websocket.Conn {
 	t.Helper()
 
@@ -169,6 +201,57 @@ func newTestInspectorConn(t *testing.T, handle func(*websocket.Conn)) *websocket
 	})
 
 	return wsConn
+}
+
+func newRespondingTestInspectorConn(t *testing.T) *websocket.Conn {
+	t.Helper()
+
+	srv := newRespondingTestInspectorServer(t)
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	wsConn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = wsConn.Close()
+	})
+
+	return wsConn
+}
+
+func newRespondingTestInspectorServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+
+			if err := conn.WriteJSON(cdpResponse{
+				ID: 1,
+				Result: map[string]any{
+					"result": map[string]any{
+						"type":  "number",
+						"value": 2,
+					},
+				},
+			}); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
 }
 
 func newPipeInspectorConn(t *testing.T, handle func(net.Conn, <-chan struct{})) net.Conn {
@@ -225,6 +308,22 @@ func runWithOperationTimeout(t *testing.T, name string, run func() error) error 
 	case <-time.After(testInspectorOperationTimeout):
 		t.Fatalf("%s did not return", name)
 		return nil
+	}
+}
+
+func assertWebSocketUsable(t *testing.T, wsConn *websocket.Conn) {
+	t.Helper()
+
+	err := runWithOperationTimeout(t, "websocket use after deadline", func() error {
+		if err := wsConn.WriteMessage(websocket.TextMessage, []byte(`{"id":1}`)); err != nil {
+			return err
+		}
+
+		_, _, err := wsConn.ReadMessage()
+		return err
+	})
+	if err != nil {
+		t.Fatalf("expected websocket to remain usable: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- bound NodeJS inspector `Runtime.evaluate` websocket requests with read/write deadlines
- bound inspector discovery HTTP reads for `/json/version` and `/json/list`
- bound the websocket upgrade/handshake path
- added tests for no-response and slow-response inspector behavior across evaluation, discovery, and upgrade paths

## Root Cause

The NodeJS injector performs synchronous inspector I/O while running under the network namespace switch used for the target process. Some inspector paths previously used blocking reads without deadlines, so an inspector-like endpoint that accepted a connection but stopped responding could block the attacher loop and keep the namespace-switched goroutine pinned to an OS thread indefinitely.

## Impact

Stalled NodeJS inspector endpoints now fail cleanly after the configured inspector request timeout instead of blocking injection indefinitely.

Resolves #2039.

## Validation

- `go test ./pkg/internal/nodejs -count=1`
