### PR TITLE
fix: clear stale traceparent parent ids

### DIFF
--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -495,11 +495,22 @@ __obi_continue_protocol_http_tp(struct pt_regs *ctx,
                 unsigned char *t_id = extract_trace_id(res);
                 unsigned char *s_id = extract_span_id(res);
                 unsigned char *f_id = extract_flags(res);
+                const bool is_client = meta && meta->type == EVENT_HTTP_CLIENT;
+                unsigned char previous_trace_id[TRACE_ID_SIZE_BYTES] = {};
+
+                if (is_client) {
+                    __builtin_memcpy(
+                        previous_trace_id, tp_p->tp.trace_id, sizeof(previous_trace_id));
+                }
 
                 decode_hex(tp_p->tp.trace_id, t_id, TRACE_ID_CHAR_LEN);
                 decode_hex((unsigned char *)&tp_p->tp.flags, f_id, FLAGS_CHAR_LEN);
                 if (meta && meta->type != EVENT_HTTP_CLIENT) {
                     decode_hex(tp_p->tp.parent_id, s_id, SPAN_ID_CHAR_LEN);
+                } else if (is_client && bpf_memcmp(previous_trace_id,
+                                                   tp_p->tp.trace_id,
+                                                   sizeof(previous_trace_id)) != 0) {
+                    __builtin_memset(tp_p->tp.parent_id, 0, sizeof(tp_p->tp.parent_id));
                 }
 
                 if (g_bpf_debug) {

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -17,6 +17,7 @@
 #include <common/lw_thread.h>
 #include <common/ringbuf.h>
 #include <common/runtime.h>
+#include <common/scratch_mem.h>
 #include <common/trace_helpers.h>
 #include <common/trace_lifecycle.h>
 #include <common/trace_parent.h>
@@ -36,6 +37,8 @@
 #include <maps/tp_char_buf_mem.h>
 
 volatile const u32 high_request_volume;
+
+SCRATCH_MEM_SIZED(http_previous_trace_id, TRACE_ID_SIZE_BYTES);
 
 // empty_http_info zeroes and return the unique percpu copy in the map
 // this function assumes that a given thread is not trying to use many
@@ -496,20 +499,22 @@ __obi_continue_protocol_http_tp(struct pt_regs *ctx,
                 unsigned char *s_id = extract_span_id(res);
                 unsigned char *f_id = extract_flags(res);
                 const bool is_client = meta && meta->type == EVENT_HTTP_CLIENT;
-                unsigned char previous_trace_id[TRACE_ID_SIZE_BYTES] = {};
+                unsigned char *previous_trace_id = NULL;
 
-                if (is_client) {
-                    __builtin_memcpy(
-                        previous_trace_id, tp_p->tp.trace_id, sizeof(previous_trace_id));
+                if (is_client && valid_trace(tp_p->tp.trace_id)) {
+                    previous_trace_id = (unsigned char *)http_previous_trace_id_mem();
+                    if (previous_trace_id) {
+                        __builtin_memcpy(previous_trace_id, tp_p->tp.trace_id, TRACE_ID_SIZE_BYTES);
+                    }
                 }
 
                 decode_hex(tp_p->tp.trace_id, t_id, TRACE_ID_CHAR_LEN);
                 decode_hex((unsigned char *)&tp_p->tp.flags, f_id, FLAGS_CHAR_LEN);
                 if (meta && meta->type != EVENT_HTTP_CLIENT) {
                     decode_hex(tp_p->tp.parent_id, s_id, SPAN_ID_CHAR_LEN);
-                } else if (is_client && bpf_memcmp(previous_trace_id,
-                                                   tp_p->tp.trace_id,
-                                                   sizeof(previous_trace_id)) != 0) {
+                } else if (previous_trace_id &&
+                           bpf_memcmp(previous_trace_id, tp_p->tp.trace_id, TRACE_ID_SIZE_BYTES) !=
+                               0) {
                     __builtin_memset(tp_p->tp.parent_id, 0, sizeof(tp_p->tp.parent_id));
                 }
 

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -1084,6 +1084,7 @@ int obi_packet_extender_find_existing_tp(struct sk_msg_md *msg) {
             // if we got to this point, we managed to parse a valid
             // 'Traceparent: ...' header that we can utilise
 
+            bpf_memset(tp_p->tp.parent_id, 0, sizeof(tp_p->tp.parent_id));
             assign_parent_tp(t_ctx, &tp_p->tp, span_id);
 
             tp_p->tp.ts = bpf_ktime_get_ns();

--- a/internal/test/integration/traceparent_extraction_test.go
+++ b/internal/test/integration/traceparent_extraction_test.go
@@ -134,6 +134,18 @@ func testWithTraceparent(t *testing.T) {
 	// Verify we have spans from all 3 services in the chain
 	require.GreaterOrEqual(t, len(trace.Spans), 3,
 		"Should have spans from all services in the chain (a, b, c)")
+
+	serviceAClientSpans := trace.FindByOperationNameServiceAndKind("GET /with-tp", "tpclient-a", "client")
+	require.GreaterOrEqual(t, len(serviceAClientSpans), 1, "should find tpclient-a client span")
+	requireNoChildOfReference(t, serviceAClientSpans[0],
+		"tpclient-a client span should not inherit a parent from the generated server trace")
+
+	serviceBServerSpans := trace.FindByOperationNameServiceAndKind("GET /with-tp", "tpclient-b", "server")
+	require.GreaterOrEqual(t, len(serviceBServerSpans), 1, "should find tpclient-b server span")
+	serviceBClientSpans := trace.FindByOperationNameServiceAndKind("GET /with-tp", "tpclient-b", "client")
+	require.GreaterOrEqual(t, len(serviceBClientSpans), 1, "should find tpclient-b client span")
+	requireChildOfReference(t, serviceBClientSpans[0], serviceBServerSpans[0],
+		"tpclient-b client span should keep the matching in-process parent")
 }
 
 // testWithForwardedTraceparent validates that when the SAME Traceparent is forwarded
@@ -182,4 +194,24 @@ func testWithForwardedTraceparent(t *testing.T) {
 	// Verify we have spans from all 3 services in the chain
 	require.GreaterOrEqual(t, len(trace.Spans), 3,
 		"Should have spans from all services in the chain (a, b, c)")
+}
+
+func requireNoChildOfReference(t *testing.T, span jaeger.Span, msgAndArgs ...any) {
+	t.Helper()
+
+	for _, ref := range span.References {
+		require.NotEqual(t, "CHILD_OF", ref.RefType, msgAndArgs...)
+	}
+}
+
+func requireChildOfReference(t *testing.T, child, parent jaeger.Span, msgAndArgs ...any) {
+	t.Helper()
+
+	for _, ref := range child.References {
+		if ref.RefType == "CHILD_OF" {
+			require.Equal(t, parent.SpanID, ref.SpanID, msgAndArgs...)
+			return
+		}
+	}
+	require.Fail(t, "missing CHILD_OF reference", msgAndArgs...)
 }


### PR DESCRIPTION
## Summary

Fixes stale `parent_id` propagation in existing-traceparent paths. The original sock_msg tpinjector path now clears `parent_id` before parent assignment so reused scratch state cannot leak a previous parent when no matching parent trace exists.

While adding behavioral regression coverage for the review feedback, the test exposed the same stale-parent class in the generic HTTP client existing-traceparent path: a parsed client `traceparent` can switch trace IDs after generated in-process parent state already exists. That path now clears `parent_id` when the parsed client trace ID differs from the previous in-process trace ID.

Resolves #2020.

## Changes

- Clear `tp_p->tp.parent_id` before calling `assign_parent_tp()` in `obi_packet_extender_find_existing_tp()`.
- Clear the generic HTTP client `parent_id` when an existing `traceparent` changes the trace ID away from the current in-process trace.
- Extend `TestTraceparentExtraction` with parent relationship assertions for the reused-traceparent path, including the mismatched-parent case and the matching downstream parent case.

## Validation

- `make generate/all`
- `go test -count=1 ./pkg/internal/ebpf/tpinjector`
- `go test -count=1 -tags=bpf_verifier_tests ./pkg/internal/ebpf/verifier`
- `go test -v -count=1 -run TestTraceparentExtraction -tags=integration -timeout 20m ./internal/test/integration`
- True-positive check: temporarily removing the generic-tracer fix makes `TestTraceparentExtraction/with_traceparent` fail on the new parent assertion, then it passes again with the fix restored.