### PR TITLE
Add OTLP span link export plumbing

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -991,6 +991,12 @@ type RetrievalUsage struct {
 	PromptTokens int `json:"prompt_tokens,omitempty"`
 }
 
+type SpanLink struct {
+	TraceID    trace.TraceID `json:"traceID"`
+	SpanID     trace.SpanID  `json:"spanID"`
+	TraceFlags uint8         `json:"traceFlags,string"`
+}
+
 // GetInputTokens returns the input token count, preferring prompt_tokens
 // and falling back to total_tokens. Returns zero when not reported.
 func (r *VendorRetrieval) GetInputTokens() int {
@@ -1027,6 +1033,7 @@ type Span struct {
 	SpanID            trace.SpanID   `json:"spanID"`
 	ParentSpanID      trace.SpanID   `json:"parentSpanID"`
 	TraceFlags        uint8          `json:"traceFlags,string"`
+	Links             []SpanLink     `json:"links,omitempty"`
 	Pid               PidInfo        `json:"-"`
 	PeerName          string         `json:"peerName"`
 	HostName          string         `json:"hostName"`

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -83,6 +83,109 @@ func groupFromSpanAndAttributes(span *request.Span, attrs []attribute.KeyValue) 
 	return groups
 }
 
+func TestGenerateTracesSpanLinks(t *testing.T) {
+	start := time.Now()
+	traceID, err := trace.TraceIDFromHex("eae56fbbec9505c102e8aabfc6b5c481")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("89cbc1f60aab3b04")
+	require.NoError(t, err)
+	linkTraceID, err := trace.TraceIDFromHex("1ae56fbbec9505c102e8aabfc6b5c482")
+	require.NoError(t, err)
+	linkSpanID, err := trace.SpanIDFromHex("19cbc1f60aab3b04")
+	require.NoError(t, err)
+
+	validLink := request.SpanLink{
+		TraceID:    linkTraceID,
+		SpanID:     linkSpanID,
+		TraceFlags: 3,
+	}
+
+	t.Run("without subspans", func(t *testing.T) {
+		span := &request.Span{
+			Type:         request.EventTypeHTTP,
+			RequestStart: start.UnixNano(),
+			Start:        start.UnixNano(),
+			End:          start.Add(3 * time.Second).UnixNano(),
+			Method:       "GET",
+			Route:        "/test",
+			Status:       200,
+			TraceID:      traceID,
+			SpanID:       spanID,
+			Links:        []request.SpanLink{validLink},
+		}
+
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(span, []attribute.KeyValue{}), reporterName)
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+
+		require.Equal(t, 1, spans.Len())
+		require.Equal(t, 1, spans.At(0).Links().Len())
+		assert.Equal(t, spanID.String(), spans.At(0).SpanID().String())
+
+		link := spans.At(0).Links().At(0)
+		assert.Equal(t, linkTraceID.String(), link.TraceID().String())
+		assert.Equal(t, linkSpanID.String(), link.SpanID().String())
+		assert.Equal(t, uint32(validLink.TraceFlags), link.Flags())
+	})
+
+	t.Run("with subspans", func(t *testing.T) {
+		span := &request.Span{
+			Type:         request.EventTypeHTTP,
+			RequestStart: start.UnixNano(),
+			Start:        start.Add(time.Second).UnixNano(),
+			End:          start.Add(3 * time.Second).UnixNano(),
+			Method:       "GET",
+			Route:        "/test",
+			Status:       200,
+			TraceID:      traceID,
+			SpanID:       spanID,
+			Links:        []request.SpanLink{validLink},
+		}
+
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(span, []attribute.KeyValue{}), reporterName)
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+
+		require.Equal(t, 3, spans.Len())
+		assert.Equal(t, "in queue", spans.At(0).Name())
+		assert.Equal(t, "processing", spans.At(1).Name())
+		assert.Equal(t, "GET /test", spans.At(2).Name())
+		assert.Equal(t, 0, spans.At(0).Links().Len())
+		assert.Equal(t, 0, spans.At(2).Links().Len())
+		require.Equal(t, 1, spans.At(1).Links().Len())
+		assert.Equal(t, spanID.String(), spans.At(1).SpanID().String())
+
+		link := spans.At(1).Links().At(0)
+		assert.Equal(t, linkTraceID.String(), link.TraceID().String())
+		assert.Equal(t, linkSpanID.String(), link.SpanID().String())
+	})
+
+	t.Run("ignores invalid link ids", func(t *testing.T) {
+		span := &request.Span{
+			Type:         request.EventTypeHTTP,
+			RequestStart: start.UnixNano(),
+			Start:        start.UnixNano(),
+			End:          start.Add(3 * time.Second).UnixNano(),
+			Method:       "GET",
+			Route:        "/test",
+			Status:       200,
+			TraceID:      traceID,
+			SpanID:       spanID,
+			Links: []request.SpanLink{
+				{TraceID: linkTraceID},
+				{SpanID: linkSpanID},
+				validLink,
+			},
+		}
+
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(span, []attribute.KeyValue{}), reporterName)
+		links := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Links()
+
+		require.Equal(t, 1, links.Len())
+		assert.Equal(t, linkTraceID.String(), links.At(0).TraceID().String())
+		assert.Equal(t, linkSpanID.String(), links.At(0).SpanID().String())
+		assert.Equal(t, uint32(validLink.TraceFlags), links.At(0).Flags())
+	})
+}
+
 func TestGenerateTraces(t *testing.T) {
 	t.Run("test with subtraces - with parent spanId", func(t *testing.T) {
 		start := time.Now()

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -199,6 +199,9 @@ func GenerateTracesWithAttributes(
 		if statusMessage != "" {
 			s.Status().SetMessage(statusMessage)
 		}
+		if !hasSubSpans {
+			appendSpanLinks(s, span.Links)
+		}
 		s.SetEndTimestamp(pcommon.NewTimestampFromTime(t.End))
 	}
 	return traces
@@ -233,6 +236,20 @@ func createSubSpans(span *request.Span, parentSpanID pcommon.SpanID, traceID pco
 		spP.SetSpanID(pcommon.SpanID(idgen.RandomSpanID()))
 	}
 	spP.SetParentSpanID(parentSpanID)
+	appendSpanLinks(spP, span.Links)
+}
+
+func appendSpanLinks(dst ptrace.Span, links []request.SpanLink) {
+	for _, spanLink := range links {
+		if !spanLink.TraceID.IsValid() || !spanLink.SpanID.IsValid() {
+			continue
+		}
+
+		link := dst.Links().AppendEmpty()
+		link.SetTraceID(pcommon.TraceID(spanLink.TraceID))
+		link.SetSpanID(pcommon.SpanID(spanLink.SpanID))
+		link.SetFlags(uint32(spanLink.TraceFlags))
+	}
 }
 
 var emptyUID = svc.UID{}


### PR DESCRIPTION
## Summary
- add `request.SpanLink` and `request.Span.Links` for internal span-link transport
- export valid span links as OTLP span links, including trace flags
- attach links to the span matching `request.SpanID`, including the processing child when queue/processing subspans are expanded

Part of #2238.

## Scope
This intentionally does not add Go channel probes, channel events, offset handling, configuration, pending-link caches, or docs.

## Tests
- `go test ./pkg/export/otel ./pkg/appolly/app/request`
- `go test ./pkg/export/otel/tracesgen`