### PR TITLE
fix: stop exporting GraphQL documents by default

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -1090,7 +1090,6 @@ func spanAttributes(s *Span) SpanAttributes {
 			"serverPort":  strconv.Itoa(s.HostPort),
 		}
 		if s.SubType == HTTPSubtypeGraphQL && s.GraphQL != nil {
-			attrs["graphqlDocument"] = s.GraphQL.Document
 			attrs["graphqlOperationName"] = s.GraphQL.OperationName
 			attrs["graphqlOperationType"] = s.GraphQL.OperationType
 		}

--- a/pkg/appolly/app/request/span_test.go
+++ b/pkg/appolly/app/request/span_test.go
@@ -691,6 +691,22 @@ func TestSerializeJSONSpans(t *testing.T) {
 	}
 }
 
+func TestSpanAttributesGraphQLOmitsDocument(t *testing.T) {
+	attrs := spanAttributes(&Span{
+		Type:    EventTypeHTTP,
+		SubType: HTTPSubtypeGraphQL,
+		GraphQL: &GraphQL{
+			Document:      `mutation ChangeEmail { updateUser(email: "secret@example.com") { id } }`,
+			OperationName: "ChangeEmail",
+			OperationType: "mutation",
+		},
+	})
+
+	assert.NotContains(t, attrs, "graphqlDocument")
+	assert.Equal(t, "ChangeEmail", attrs["graphqlOperationName"])
+	assert.Equal(t, "mutation", attrs["graphqlOperationType"])
+}
+
 func TestDetectsOTelExport(t *testing.T) {
 	const defaultOtlpGRPCPort = 4317
 	// Metrics

--- a/pkg/ebpf/common/http/graphql_test.go
+++ b/pkg/ebpf/common/http/graphql_test.go
@@ -4,7 +4,13 @@
 package ebpfcommon
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
 
 func TestParseGraphQLRequest(t *testing.T) {
@@ -131,5 +137,44 @@ func TestParseGraphQLRequest(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGraphQLSpanExtractsOperationMetadata(t *testing.T) {
+	const document = `mutation ChangeEmail { updateUser(email: "secret@example.com") { id } }`
+
+	body, err := json.Marshal(graphQLRequest{Query: document})
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/graphql", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+
+	span, ok := GraphQLSpan(&request.Span{Type: request.EventTypeHTTP}, req, nil)
+	if !ok {
+		t.Fatal("expected GraphQL span")
+	}
+	if span.SubType != request.HTTPSubtypeGraphQL {
+		t.Fatalf("SubType = %d, want %d", span.SubType, request.HTTPSubtypeGraphQL)
+	}
+	if span.GraphQL == nil {
+		t.Fatal("GraphQL metadata is nil")
+	}
+	if span.GraphQL.OperationType != "mutation" {
+		t.Errorf("OperationType = %q, want mutation", span.GraphQL.OperationType)
+	}
+	if span.GraphQL.OperationName != "ChangeEmail" {
+		t.Errorf("OperationName = %q, want ChangeEmail", span.GraphQL.OperationName)
+	}
+
+	restoredBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("failed to read restored body: %v", err)
+	}
+	if string(restoredBody) != string(body) {
+		t.Errorf("restored body = %q, want %q", restoredBody, body)
 	}
 }

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -383,6 +383,7 @@ func getDefinitions(
 			Attributes: map[attr.Name]Default{
 				attr.DNSQuestionName:   true,
 				attr.DBQueryText:       false,
+				attr.GraphQLDocument:   false,
 				attr.HTTPUrlQuery:      false,
 				attr.GenAIInput:        false,
 				attr.GenAIOutput:       false,

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -467,7 +467,9 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			attrs = append(attrs, semconv.HTTPRoute(span.Route))
 		}
 		if span.SubType == request.HTTPSubtypeGraphQL && span.GraphQL != nil {
-			attrs = append(attrs, semconv.GraphQLDocument(span.GraphQL.Document))
+			if _, ok := optionalAttrs[attr.GraphQLDocument]; ok {
+				attrs = append(attrs, semconv.GraphQLDocument(span.GraphQL.Document))
+			}
 			attrs = append(attrs, semconv.GraphQLOperationName(span.GraphQL.OperationName))
 			attrs = append(attrs, request.GraphqlOperationType(span.GraphQL.OperationType))
 		}

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -39,6 +39,54 @@ func TestTraceAttributesSelector_DNSQuestionName(t *testing.T) {
 	assert.Contains(t, optInAttrs, semconv.DNSQuestionName("example.com"))
 }
 
+func TestTraceAttributesSelector_GraphQLDocumentSelection(t *testing.T) {
+	const document = `mutation ChangeEmail { updateUser(email: "secret@example.com") { id } }`
+
+	span := &request.Span{
+		Type:    request.EventTypeHTTP,
+		SubType: request.HTTPSubtypeGraphQL,
+		Method:  "POST",
+		Path:    "/graphql",
+		Status:  200,
+		GraphQL: &request.GraphQL{
+			Document:      document,
+			OperationName: "ChangeEmail",
+			OperationType: "mutation",
+		},
+	}
+
+	defaultAttrs, err := UserSelectedAttributes(&attributes.SelectorConfig{})
+	require.NoError(t, err)
+	assert.NotContains(t, defaultAttrs, attr.GraphQLDocument)
+
+	defaultSelected := AttrsToMap(TraceAttributesSelector(span, defaultAttrs))
+	_, ok := defaultSelected.Get(string(semconv.GraphQLDocumentKey))
+	assert.False(t, ok)
+
+	operationName, ok := defaultSelected.Get(string(semconv.GraphQLOperationNameKey))
+	require.True(t, ok)
+	assert.Equal(t, "ChangeEmail", operationName.Str())
+
+	operationType, ok := defaultSelected.Get(string(semconv.GraphQLOperationTypeKey))
+	require.True(t, ok)
+	assert.Equal(t, "mutation", operationType.Str())
+
+	optInAttrs, err := UserSelectedAttributes(&attributes.SelectorConfig{
+		SelectionCfg: attributes.Selection{
+			attributes.Traces.Section: attributes.InclusionLists{
+				Include: []string{string(attr.GraphQLDocument)},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, optInAttrs, attr.GraphQLDocument)
+
+	optInSelected := AttrsToMap(TraceAttributesSelector(span, optInAttrs))
+	selectedDocument, ok := optInSelected.Get(string(semconv.GraphQLDocumentKey))
+	require.True(t, ok)
+	assert.Equal(t, document, selectedDocument.Str())
+}
+
 func TestGenAIToolCallAttributes(t *testing.T) {
 	t.Run("nil tool calls", func(t *testing.T) {
 		assert.Nil(t, genAIToolCallAttributes(nil))


### PR DESCRIPTION
## Summary

- stop exporting full GraphQL documents by default from OTLP trace attributes
- keep GraphQL operation name/type attributes available by default
- allow `graphql.document` only through explicit trace attribute selection
- cover GraphQL parsing, span serialization, and trace attribute selection in tests

Fixes #2030

## Testing

- `go test ./pkg/ebpf/common/http ./pkg/appolly/app/request ./pkg/export/otel/tracesgen ./pkg/export/attributes`
- local PoC based on #2030 confirmed `graphql.document` is omitted by default and emitted only after explicit opt-in