### PR TITLE
fix(2031): initialize failed-connect tcp ringbuf records

### DIFF
--- a/bpf/generictracer/failed_connect.h
+++ b/bpf/generictracer/failed_connect.h
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+
+#include <common/common.h>
+#include <common/connection_info.h>
+#include <common/event_defs.h>
+#include <common/protocol_defs.h>
+
+static __always_inline void init_failed_connect_tcp_req(tcp_req_t *req,
+                                                        const pid_connection_info_t *pid_conn,
+                                                        u16 orig_dport,
+                                                        u64 connect_ts,
+                                                        u64 end_ts,
+                                                        u64 trace_ts,
+                                                        u64 extra_id,
+                                                        const pid_info *pid) {
+    __builtin_memset(req, 0, sizeof(*req));
+
+    req->flags = EVENT_FAILED_CONNECT;
+    req->conn_info = pid_conn->conn;
+    fixup_connection_info(&req->conn_info, TCP_SEND, orig_dport);
+    req->ssl = 0;
+    req->direction = TCP_SEND;
+    req->start_monotime_ns = connect_ts;
+    req->end_monotime_ns = end_ts;
+    req->resp_len = 0;
+    req->len = 0;
+    req->req_len = req->len;
+    req->extra_id = extra_id;
+    req->protocol_type = 0;
+    req->pid = *pid;
+    req->buf[0] = '\0';
+
+    req->tp.ts = trace_ts;
+}

--- a/bpf/generictracer/failed_connect.h
+++ b/bpf/generictracer/failed_connect.h
@@ -31,7 +31,7 @@ static __always_inline void init_failed_connect_tcp_req(tcp_req_t *req,
     req->len = 0;
     req->req_len = req->len;
     req->extra_id = extra_id;
-    req->protocol_type = 0;
+    req->protocol_type = k_protocol_type_unknown;
     req->pid = *pid;
     req->buf[0] = '\0';
 

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -20,8 +20,8 @@
 #include <maps/ongoing_tcp_req.h>
 #include <maps/tp_info_mem.h>
 
-#include <generictracer/protocol_common.h>
 #include <generictracer/failed_connect.h>
+#include <generictracer/protocol_common.h>
 #include <generictracer/protocol_kafka.h>
 #include <generictracer/protocol_mysql.h>
 #include <generictracer/protocol_postgres.h>
@@ -233,11 +233,10 @@ static __always_inline void failed_to_connect_event(pid_connection_info_t *pid_c
     if (req) {
         pid_info pid = {};
         task_pid(&pid);
-        const u64 end_ts = bpf_ktime_get_ns();
-        const u64 trace_ts = bpf_ktime_get_ns();
+        const u64 event_ts = bpf_ktime_get_ns();
         const u64 extra_id = extra_runtime_id();
         init_failed_connect_tcp_req(
-            req, pid_conn, orig_dport, connect_ts, end_ts, trace_ts, extra_id, &pid);
+            req, pid_conn, orig_dport, connect_ts, event_ts, event_ts, extra_id, &pid);
 
         bpf_dbg_printk("TCP connect failed event");
 

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -21,6 +21,7 @@
 #include <maps/tp_info_mem.h>
 
 #include <generictracer/protocol_common.h>
+#include <generictracer/failed_connect.h>
 #include <generictracer/protocol_kafka.h>
 #include <generictracer/protocol_mysql.h>
 #include <generictracer/protocol_postgres.h>
@@ -230,22 +231,13 @@ static __always_inline void failed_to_connect_event(pid_connection_info_t *pid_c
                                                     u64 connect_ts) {
     tcp_req_t *req = bpf_ringbuf_reserve(&events, sizeof(tcp_req_t), 0);
     if (req) {
-        req->flags = EVENT_FAILED_CONNECT;
-        req->conn_info = pid_conn->conn;
-        fixup_connection_info(&req->conn_info, TCP_SEND, orig_dport);
-        req->ssl = 0;
-        req->direction = TCP_SEND;
-        req->start_monotime_ns = connect_ts;
-        req->end_monotime_ns = bpf_ktime_get_ns();
-        req->resp_len = 0;
-        req->len = 0;
-        req->req_len = req->len;
-        req->extra_id = extra_runtime_id();
-        req->protocol_type = 0;
-        task_pid(&req->pid);
-        req->buf[0] = '\0';
-
-        req->tp.ts = bpf_ktime_get_ns();
+        pid_info pid = {};
+        task_pid(&pid);
+        const u64 end_ts = bpf_ktime_get_ns();
+        const u64 trace_ts = bpf_ktime_get_ns();
+        const u64 extra_id = extra_runtime_id();
+        init_failed_connect_tcp_req(
+            req, pid_conn, orig_dport, connect_ts, end_ts, trace_ts, extra_id, &pid);
 
         bpf_dbg_printk("TCP connect failed event");
 

--- a/bpf/tests/test_failed_connect_event.c
+++ b/bpf/tests/test_failed_connect_event.c
@@ -1,0 +1,107 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Run me with: make test_failed_connect_event && ./test_failed_connect_event
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <generictracer/failed_connect.h>
+
+static unsigned int failed_assertions;
+
+static void assert_true(bool condition, const char *message) {
+    if (condition) {
+        printf("PASS: %s\n", message);
+        return;
+    }
+
+    failed_assertions++;
+    printf("FAIL: %s\n", message);
+}
+
+static void assert_tcp_req_equal(const tcp_req_t *actual, const tcp_req_t *expected) {
+    const unsigned char *actual_bytes = (const unsigned char *)actual;
+    const unsigned char *expected_bytes = (const unsigned char *)expected;
+
+    for (size_t i = 0; i < sizeof(*actual); i++) {
+        if (actual_bytes[i] == expected_bytes[i]) {
+            continue;
+        }
+
+        printf("FAIL: tcp_req_t byte %zu: got 0x%02x, want 0x%02x\n",
+               i,
+               actual_bytes[i],
+               expected_bytes[i]);
+        failed_assertions++;
+        return;
+    }
+
+    printf("PASS: tcp_req_t contains only expected bytes\n");
+}
+
+static connection_info_t test_connection_info(void) {
+    connection_info_t conn = {
+        .s_port = 40100,
+        .d_port = 443,
+    };
+
+    for (size_t i = 0; i < sizeof(conn.s_addr); i++) {
+        conn.s_addr[i] = (unsigned char)(i + 1);
+        conn.d_addr[i] = (unsigned char)(0x80 + i);
+    }
+
+    return conn;
+}
+
+static void test_failed_connect_record_is_fully_initialized(void) {
+    const u16 orig_dport = 443;
+    const u64 connect_ts = 123456789;
+    const u64 end_ts = 123456999;
+    const u64 trace_ts = 123457111;
+    const u64 extra_id = 0xaabbccddeeff0011;
+
+    const pid_info pid = {
+        .host_pid = 1001,
+        .user_pid = 2002,
+        .ns = 3003,
+    };
+    const pid_connection_info_t pid_conn = {
+        .conn = test_connection_info(),
+        .pid = pid.host_pid,
+    };
+
+    tcp_req_t actual;
+    __builtin_memset(&actual, 0xff, sizeof(actual));
+    init_failed_connect_tcp_req(
+        &actual, &pid_conn, orig_dport, connect_ts, end_ts, trace_ts, extra_id, &pid);
+
+    tcp_req_t expected = {};
+    expected.flags = EVENT_FAILED_CONNECT;
+    expected.conn_info = pid_conn.conn;
+    fixup_connection_info(&expected.conn_info, TCP_SEND, orig_dport);
+    expected.direction = TCP_SEND;
+    expected.start_monotime_ns = connect_ts;
+    expected.end_monotime_ns = end_ts;
+    expected.extra_id = extra_id;
+    expected.pid = pid;
+    expected.tp.ts = trace_ts;
+
+    assert_tcp_req_equal(&actual, &expected);
+    assert_true(actual.buf[0] == '\0', "request buffer is empty");
+    assert_true(actual.rbuf[0] == '\0', "response buffer is empty");
+    assert_true(actual.tp.flags == 0, "trace flags do not retain stale bytes");
+}
+
+int main(void) {
+    test_failed_connect_record_is_fully_initialized();
+
+    if (failed_assertions != 0) {
+        printf("%u failed assertions\n", failed_assertions);
+        return 1;
+    }
+
+    return 0;
+}

--- a/bpf/tests/test_failed_connect_event.c
+++ b/bpf/tests/test_failed_connect_event.c
@@ -1,7 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// Run me with: make test_failed_connect_event && ./test_failed_connect_event
+// Run from repo root:
+//   make -C bpf/tests test_failed_connect_event && bpf/tests/test_failed_connect_event
+// Run from bpf/tests:
+//   make test_failed_connect_event && ./test_failed_connect_event
 
 #include <stdbool.h>
 #include <stddef.h>


### PR DESCRIPTION
## Summary
- zero-initialize failed-connect `tcp_req_t` records before populating event fields
- factor failed-connect initialization into a testable helper used by the eBPF path
- add a C functional test that pre-fills a record with stale bytes and verifies the final serialized struct is fully initialized

## Issue
Resolves #2031.

## Validation
- `make test_failed_connect_event`
- `./test_failed_connect_event`
- `go test -count=1 ./pkg/internal/ebpf/generictracer`
- `make generate`