### PR TITLE
Replace server.address default attribute by 'server'

### DIFF
--- a/internal/test/integration/red_test_client.go
+++ b/internal/test/integration/red_test_client.go
@@ -24,7 +24,7 @@ func testClientWithMethodAndStatusCode(t *testing.T, method string, statusCode i
 		labels = fmt.Sprintf(`http_request_method="%s",`, method) +
 			fmt.Sprintf(`http_response_status_code="%d",`, statusCode) +
 			`http_route="/oss/",` +
-			`server_address="grafana.com",` +
+			`server="grafana.com",` +
 			`service_namespace="integration-test",` +
 			`service_name="pingclient"`
 	)
@@ -67,7 +67,7 @@ func testClientWithMethodAndStatusCode(t *testing.T, method string, statusCode i
 	require.Len(t, spans, 1)
 	parent := spans[0]
 
-	addr, ok := jaeger.FindIn(parent.Tags, "server.address")
+	addr, ok := jaeger.FindIn(parent.Tags, "server")
 	assert.True(t, ok)
 	assert.Equal(t, "grafana.com", addr.Value)
 

--- a/internal/test/integration/red_test_nodeclient.go
+++ b/internal/test/integration/red_test_nodeclient.go
@@ -84,7 +84,7 @@ func testNodeClientWithMethodAndStatusCode(t *testing.T, method string, statusCo
 		jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(statusCode)},
 		jaeger.Tag{Key: "url.full", Type: "string", Value: urlFull},
 		jaeger.Tag{Key: "server.port", Type: "int64", Value: float64(port)},
-		jaeger.Tag{Key: "server.address", Type: "string", Value: "grafana.com"},
+		jaeger.Tag{Key: "server", Type: "string", Value: "grafana.com"},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "client"},
 	)
 	assert.Empty(t, sd, sd.String())

--- a/internal/test/oats/sql/yaml/oats_sql_go_mysql.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_mysql.yaml
@@ -35,11 +35,11 @@ expected:
       db.collection.name: nonexistent_table
       db.system.name: other_sql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: == 0
-  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_mysql_otelsql.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_mysql_otelsql.yaml
@@ -14,11 +14,11 @@ expected:
       db.collection.name: students
       db.system.name: other_sql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: == 0
-  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_mysql_tls.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_mysql_tls.yaml
@@ -14,11 +14,11 @@ expected:
       db.collection.name: students
       db.system.name: other_sql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: == 0
-  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server="mysqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_pgx.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_pgx.yaml
@@ -32,16 +32,16 @@ expected:
       db.system.name: other_sql
   metrics:
   # SELECT metrics
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: == 0
-  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'
   # UPDATE metrics
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="UPDATE", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="UPDATE", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="UPDATE", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="UPDATE", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_pgx_pool.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_pgx_pool.yaml
@@ -14,7 +14,7 @@ expected:
       db.collection.name: accounting.contacts
       db.system.name: other_sql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_pgx_stdlib.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_pgx_stdlib.yaml
@@ -14,7 +14,7 @@ expected:
       db.collection.name: accounting.contacts
       db.system.name: other_sql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_postgres.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_postgres.yaml
@@ -14,11 +14,11 @@ expected:
       db.collection.name: accounting.contacts
       db.system.name: other_sql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: == 0
-  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server="sqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_other_langs.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_other_langs.yaml
@@ -22,5 +22,5 @@ expected:
     value: == 0
   - promql: db_client_operation_duration_seconds_bucket{le="10", db_system_name="postgresql"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_system_name="postgresql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_system_name="postgresql", server="sqlserver"}
     value: '> 0'

--- a/pkg/appolly/instrumenter_test.go
+++ b/pkg/appolly/instrumenter_test.go
@@ -131,7 +131,7 @@ func TestBasicPipeline(t *testing.T) {
 			string(semconv.ServiceNamespaceKey): "ns",
 			string(attr.HTTPURLScheme):          "http",
 			string(attr.ServerPort):             "8080",
-			string(attr.ServerAddr):             event.Attributes["server.address"],
+			string(attr.Server):                 event.Attributes["server"],
 		},
 		ResourceAttributes: map[string]string{
 			string(semconv.HostIDKey):               "host-id",
@@ -348,7 +348,7 @@ func TestRouteConsolidation(t *testing.T) {
 			string(semconv.HTTPRouteKey):        "/user/{id}",
 			string(attr.HTTPURLScheme):          "http",
 			string(attr.ServerPort):             "8080",
-			string(attr.ServerAddr):             events["/user/{id}"].Attributes["server.address"],
+			string(attr.Server):                 events["/user/{id}"].Attributes["server"],
 		},
 		ResourceAttributes: map[string]string{
 			string(semconv.HostIDKey):               "host-id",
@@ -376,7 +376,7 @@ func TestRouteConsolidation(t *testing.T) {
 			string(semconv.HTTPRouteKey):        "/products/{id}/push",
 			string(attr.HTTPURLScheme):          "http",
 			string(attr.ServerPort):             "8080",
-			string(attr.ServerAddr):             events["/products/{id}/push"].Attributes["server.address"],
+			string(attr.Server):                 events["/products/{id}/push"].Attributes["server"],
 		},
 		ResourceAttributes: map[string]string{
 			string(semconv.HostIDKey):               "host-id",
@@ -404,7 +404,7 @@ func TestRouteConsolidation(t *testing.T) {
 			string(semconv.HTTPRouteKey):        "/**",
 			string(attr.HTTPURLScheme):          "http",
 			string(attr.ServerPort):             "8080",
-			string(attr.ServerAddr):             events["/**"].Attributes["server.address"],
+			string(attr.Server):                 events["/**"].Attributes["server"],
 		},
 		ResourceAttributes: map[string]string{
 			string(semconv.HostIDKey):               "host-id",
@@ -473,7 +473,7 @@ func TestGRPCPipeline(t *testing.T) {
 			string(semconv.RPCMethodKey):         "/foo/bar",
 			string(attr.ClientAddr):              "1.1.1.1",
 			string(attr.ServerPort):              "8080",
-			string(attr.ServerAddr):              event.Attributes["server.address"],
+			string(attr.Server):                  event.Attributes["server"],
 		},
 		ResourceAttributes: map[string]string{
 			string(semconv.HostIDKey):               "host-id",
@@ -578,7 +578,7 @@ func TestBasicPipelineInfo(t *testing.T) {
 			string(semconv.ServiceNamespaceKey): "",
 			string(attr.HTTPURLScheme):          "http",
 			string(attr.ServerPort):             "8080",
-			string(attr.ServerAddr):             event.Attributes["server.address"],
+			string(attr.Server):                 event.Attributes["server"],
 		},
 		ResourceAttributes: map[string]string{
 			string(semconv.HostIDKey):               "host-id",
@@ -681,7 +681,7 @@ func TestSpanAttributeFilterNode(t *testing.T) {
 			string(attr.HTTPUrlPath):            "/user/1234",
 			string(attr.HTTPURLScheme):          "http",
 			string(attr.ServerPort):             "8080",
-			string(attr.ServerAddr):             events["/user/1234"]["server.address"],
+			string(attr.Server):                 events["/user/1234"]["server"],
 		},
 		"/user/4321": {
 			string(semconv.ServiceNameKey):      "svc-3",
@@ -692,7 +692,7 @@ func TestSpanAttributeFilterNode(t *testing.T) {
 			string(attr.HTTPUrlPath):            "/user/4321",
 			string(attr.HTTPURLScheme):          "http",
 			string(attr.ServerPort):             "8080",
-			string(attr.ServerAddr):             events["/user/1234"]["server.address"],
+			string(attr.Server):                 events["/user/1234"]["server"],
 		},
 	}, events)
 

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -274,7 +274,7 @@ func getDefinitions(
 		nil,
 		map[attr.Name]Default{
 			attr.ClientAddr: false,
-			attr.ServerAddr: true,
+			attr.Server:     true,
 			attr.ServerPort: true,
 		},
 		extraGroupAttributes[GroupServerInfo],
@@ -284,7 +284,7 @@ func getDefinitions(
 		false,
 		nil,
 		map[attr.Name]Default{
-			attr.ServerAddr: true,
+			attr.Server:     true,
 			attr.ServerPort: true,
 		},
 		extraGroupAttributes[GroupHTTPClientInfo],
@@ -294,7 +294,7 @@ func getDefinitions(
 		false,
 		nil,
 		map[attr.Name]Default{
-			attr.ServerAddr: true,
+			attr.Server: true,
 		},
 		extraGroupAttributes[GroupGRPCClientInfo],
 	)
@@ -318,7 +318,7 @@ func getDefinitions(
 			attr.MessagingSystem:      true,
 			attr.MessagingDestination: true,
 			attr.MessagingOpName:      true,
-			attr.ServerAddr:           true,
+			attr.Server:               true,
 		},
 		extraGroupAttributes[GroupMessaging],
 	)
@@ -367,7 +367,7 @@ func getDefinitions(
 		DBClientDuration.Section: {
 			SubGroups: []*AttrReportGroup{&appAttributes},
 			Attributes: map[attr.Name]Default{
-				attr.ServerAddr:   true,
+				attr.Server:       true,
 				attr.DBOperation:  true,
 				attr.DBSystemName: true,
 				attr.ErrorType:    true,
@@ -434,7 +434,7 @@ func getDefinitions(
 				attr.GenAIRequestModel:   true,
 				attr.GenAIResponseModel:  true,
 				attr.ServerPort:          true,
-				attr.ServerAddr:          true,
+				attr.Server:              true,
 			},
 		},
 		GenAIClientOutputTokenUsage.Section: {
@@ -446,7 +446,7 @@ func getDefinitions(
 				attr.GenAIRequestModel:    true,
 				attr.GenAIResponseModel:   true,
 				attr.ServerPort:           true,
-				attr.ServerAddr:           true,
+				attr.Server:               true,
 			},
 		},
 		GenAIClientOperationDuration.Section: {
@@ -458,7 +458,7 @@ func getDefinitions(
 				attr.GenAIResponseModel: true,
 				attr.ErrorType:          true,
 				attr.ServerPort:         true,
-				attr.ServerAddr:         true,
+				attr.Server:             true,
 			},
 		},
 		StatTCPRtt.Section: {

--- a/pkg/export/attributes/attr_selector_test.go
+++ b/pkg/export/attributes/attr_selector_test.go
@@ -223,7 +223,7 @@ func TestExtraGroupAttributes(t *testing.T) {
 		"k8s.pod.uid",
 		"k8s.replicaset.name",
 		"k8s.statefulset.name",
-		"server.address",
+		"server",
 		"server.port",
 		"service.name",
 		"url.scheme",


### PR DESCRIPTION
## Summary

Addresses https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2035

For some metrics, we were defaulting `server.address` attribute, which is high-cardinality because in case of unresolved hostnames, it shows an IP address.

This PR replaces them by `server`, which only resolves to a hostname, or to `unresolved`.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
