### PR TITLE
fix(2041): skip target info when metrics export is disabled

### DIFF
--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -1181,6 +1181,10 @@ func (mr *MetricsReporter) createTargetMetrics(service *svc.Attrs) {
 		return
 	}
 
+	if !service.ExportModes.CanExportMetrics() {
+		return
+	}
+
 	targetMetrics := mr.ensureTargetMetrics(service)
 
 	if targetMetrics == nil {

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
+	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
@@ -1519,6 +1520,68 @@ func TestHandleProcessEventCreated(t *testing.T) {
 			// Verify service map state
 			assert.Equal(t, tm, reporter.targetMetrics,
 				"Service map should match expected state")
+		})
+	}
+}
+
+func TestHandleProcessEventCreatedMetricsExportDisabled(t *testing.T) {
+	exportsEmpty := services.NewExportModes()
+	tracesOnly := services.NewExportModes()
+	tracesOnly.AllowTraces()
+
+	for _, tt := range []struct {
+		name        string
+		exportModes services.ExportModes
+	}{
+		{
+			name:        "exports empty",
+			exportModes: exportsEmpty,
+		},
+		{
+			name:        "traces only",
+			exportModes: tracesOnly,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockEventsStore := newMockEventMetrics()
+			reporter := &MetricsReporter{
+				cfg:                &otelcfg.MetricsConfig{},
+				log:                slog.Default(),
+				jointMetricsCfg:    &perapp.MetricsConfig{Features: export.FeatureApplicationRED},
+				targetMetrics:      make(map[svc.UID]*TargetMetrics),
+				pidTracker:         NewPidServiceTracker(),
+				createEventMetrics: mockEventsStore.createEventMetrics,
+				deleteEventMetrics: mockEventsStore.deleteEventMetrics,
+			}
+
+			uid := svc.UID{Name: "metrics-disabled-service-" + tt.name, Namespace: "default", Instance: "instance-1"}
+			event := exec.ProcessEvent{
+				Type: exec.ProcessEventCreated,
+				File: exec.New(exec.Init{
+					Pid: 1234,
+					Service: svc.Attrs{
+						Features:    export.FeatureApplicationRED,
+						ExportModes: tt.exportModes,
+						UID:         uid,
+						HostName:    "test-host",
+					},
+				}),
+			}
+
+			reporter.onProcessEvent(&event)
+
+			assert.Empty(t, mockEventsStore.createCalls)
+			assert.Empty(t, mockEventsStore.deleteCalls)
+			assert.Empty(t, reporter.targetMetrics)
+			assert.True(t, reporter.pidTracker.ServiceLive(uid))
+
+			terminated := exec.ProcessEvent{Type: exec.ProcessEventTerminated, File: event.File}
+			reporter.onProcessEvent(&terminated)
+
+			assert.Empty(t, mockEventsStore.createCalls)
+			assert.Empty(t, mockEventsStore.deleteCalls)
+			assert.Empty(t, reporter.targetMetrics)
+			assert.False(t, reporter.pidTracker.ServiceLive(uid))
 		})
 	}
 }

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -1371,6 +1371,10 @@ func (r *metricsReporter) disassociatePIDFromService(pid app.PID) (bool, svc.UID
 }
 
 func (r *metricsReporter) createTargetInfos(service *svc.Attrs) {
+	if service == nil || !service.ExportModes.CanExportMetrics() {
+		return
+	}
+
 	r.createTargetInfo(service)
 	r.createTracesTargetInfo(service)
 }
@@ -1381,7 +1385,12 @@ func (r *metricsReporter) deleteTargetInfoMetrics(service *svc.Attrs) {
 }
 
 func (r *metricsReporter) deleteTargetInfos(uid svc.UID, service *svc.Attrs) {
-	r.deleteEventMetrics(r.origService(uid, service))
+	orig := r.origService(uid, service)
+	if orig == nil || !orig.ExportModes.CanExportMetrics() {
+		return
+	}
+
+	r.deleteEventMetrics(orig)
 }
 
 func (r *metricsReporter) handleProcessEvent(pe exec.ProcessEvent, log *slog.Logger) {
@@ -1398,10 +1407,14 @@ func (r *metricsReporter) handleProcessEvent(pe exec.ProcessEvent, log *slog.Log
 			r.pidsTracker.ReplaceUID(staleUID, uid)
 			if origAttrs, ok := r.serviceMap[staleUID]; ok {
 				log.Debug("updating service attributes for", "service", uid)
-				r.deleteEventMetrics(&origAttrs)
+				if origAttrs.ExportModes.CanExportMetrics() {
+					r.deleteEventMetrics(&origAttrs)
+				}
 				delete(r.serviceMap, staleUID)
 				r.serviceMap[uid] = snap
-				r.createEventMetrics(&snap)
+				if snap.ExportModes.CanExportMetrics() {
+					r.createEventMetrics(&snap)
+				}
 				// we don't setup the pid again, we just replaced the metrics it's associated with
 			}
 			return
@@ -1412,10 +1425,14 @@ func (r *metricsReporter) handleProcessEvent(pe exec.ProcessEvent, log *slog.Log
 		// the old target info
 		if origAttrs, ok := r.serviceMap[uid]; ok {
 			log.Debug("updating stale attributes for", "service", uid)
-			r.deleteEventMetrics(&origAttrs)
+			if origAttrs.ExportModes.CanExportMetrics() {
+				r.deleteEventMetrics(&origAttrs)
+			}
 		}
 
-		r.createEventMetrics(&snap)
+		if snap.ExportModes.CanExportMetrics() {
+			r.createEventMetrics(&snap)
+		}
 		r.serviceMap[uid] = snap
 		r.setupPIDToServiceRelationship(pid, uid)
 	} else {

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -1380,6 +1380,10 @@ func (r *metricsReporter) createTargetInfos(service *svc.Attrs) {
 }
 
 func (r *metricsReporter) deleteTargetInfoMetrics(service *svc.Attrs) {
+	if service == nil || !service.ExportModes.CanExportMetrics() {
+		return
+	}
+
 	r.deleteTargetInfoMetric(service)
 	r.deleteTracesTargetInfoMetric(service)
 }
@@ -1407,14 +1411,10 @@ func (r *metricsReporter) handleProcessEvent(pe exec.ProcessEvent, log *slog.Log
 			r.pidsTracker.ReplaceUID(staleUID, uid)
 			if origAttrs, ok := r.serviceMap[staleUID]; ok {
 				log.Debug("updating service attributes for", "service", uid)
-				if origAttrs.ExportModes.CanExportMetrics() {
-					r.deleteEventMetrics(&origAttrs)
-				}
+				r.deleteEventMetrics(&origAttrs)
 				delete(r.serviceMap, staleUID)
 				r.serviceMap[uid] = snap
-				if snap.ExportModes.CanExportMetrics() {
-					r.createEventMetrics(&snap)
-				}
+				r.createEventMetrics(&snap)
 				// we don't setup the pid again, we just replaced the metrics it's associated with
 			}
 			return
@@ -1425,14 +1425,10 @@ func (r *metricsReporter) handleProcessEvent(pe exec.ProcessEvent, log *slog.Log
 		// the old target info
 		if origAttrs, ok := r.serviceMap[uid]; ok {
 			log.Debug("updating stale attributes for", "service", uid)
-			if origAttrs.ExportModes.CanExportMetrics() {
-				r.deleteEventMetrics(&origAttrs)
-			}
+			r.deleteEventMetrics(&origAttrs)
 		}
 
-		if snap.ExportModes.CanExportMetrics() {
-			r.createEventMetrics(&snap)
-		}
+		r.createEventMetrics(&snap)
 		r.serviceMap[uid] = snap
 		r.setupPIDToServiceRelationship(pid, uid)
 	} else {

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -1186,13 +1186,12 @@ func TestHandleProcessEventCreatedMetricsExportDisabled(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			mockEventsStore := newMockEventMetrics()
 			reporter := &metricsReporter{
-				serviceMap:         make(map[svc.UID]svc.Attrs),
-				pidsTracker:        otel.NewPidServiceTracker(),
-				createEventMetrics: mockEventsStore.createEventMetrics,
-				deleteEventMetrics: mockEventsStore.deleteEventMetrics,
+				serviceMap:  make(map[svc.UID]svc.Attrs),
+				pidsTracker: otel.NewPidServiceTracker(),
 			}
+			reporter.createEventMetrics = reporter.createTargetInfos
+			reporter.deleteEventMetrics = reporter.deleteTargetInfoMetrics
 
 			uid := svc.UID{Name: "metrics-disabled-service-" + tt.name, Namespace: "default", Instance: "instance-1"}
 			service := svc.Attrs{
@@ -1210,8 +1209,6 @@ func TestHandleProcessEventCreatedMetricsExportDisabled(t *testing.T) {
 
 			reporter.handleProcessEvent(event, slog.Default())
 
-			assert.Empty(t, mockEventsStore.createCalls)
-			assert.Empty(t, mockEventsStore.deleteCalls)
 			assert.Equal(t, map[svc.UID]svc.Attrs{uid: service}, reporter.serviceMap)
 			assert.True(t, reporter.pidsTracker.ServiceLive(uid))
 
@@ -1220,10 +1217,53 @@ func TestHandleProcessEventCreatedMetricsExportDisabled(t *testing.T) {
 				File: event.File,
 			}, slog.Default())
 
-			assert.Empty(t, mockEventsStore.createCalls)
-			assert.Empty(t, mockEventsStore.deleteCalls)
 			assert.Empty(t, reporter.serviceMap)
 			assert.False(t, reporter.pidsTracker.ServiceLive(uid))
+		})
+	}
+}
+
+func TestTargetInfoHelpersSkipMetricsExportDisabled(t *testing.T) {
+	exportsEmpty := services.NewExportModes()
+	tracesOnly := services.NewExportModes()
+	tracesOnly.AllowTraces()
+
+	for _, tt := range []struct {
+		name        string
+		exportModes services.ExportModes
+	}{
+		{
+			name:        "exports empty",
+			exportModes: exportsEmpty,
+		},
+		{
+			name:        "traces only",
+			exportModes: tracesOnly,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			uid := svc.UID{Name: "metrics-disabled-service-" + tt.name, Namespace: "default", Instance: "instance-1"}
+			service := svc.Attrs{
+				ExportModes: tt.exportModes,
+				UID:         uid,
+				HostName:    "test-host",
+			}
+			mockEventsStore := newMockEventMetrics()
+			reporter := &metricsReporter{
+				serviceMap:         map[svc.UID]svc.Attrs{uid: service},
+				deleteEventMetrics: mockEventsStore.deleteEventMetrics,
+			}
+
+			assert.NotPanics(t, func() {
+				reporter.createTargetInfos(&service)
+			})
+			assert.NotPanics(t, func() {
+				reporter.deleteTargetInfoMetrics(&service)
+			})
+
+			reporter.deleteTargetInfos(uid, &service)
+
+			assert.Empty(t, mockEventsStore.deleteCalls)
 		})
 	}
 }

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
+	"go.opentelemetry.io/obi/pkg/appolly/services"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
@@ -1162,6 +1163,67 @@ func TestHandleProcessEventCreated(t *testing.T) {
 			// Verify service map state
 			assert.Equal(t, tt.expectedMap, reporter.serviceMap,
 				"Service map should match expected state")
+		})
+	}
+}
+
+func TestHandleProcessEventCreatedMetricsExportDisabled(t *testing.T) {
+	exportsEmpty := services.NewExportModes()
+	tracesOnly := services.NewExportModes()
+	tracesOnly.AllowTraces()
+
+	for _, tt := range []struct {
+		name        string
+		exportModes services.ExportModes
+	}{
+		{
+			name:        "exports empty",
+			exportModes: exportsEmpty,
+		},
+		{
+			name:        "traces only",
+			exportModes: tracesOnly,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockEventsStore := newMockEventMetrics()
+			reporter := &metricsReporter{
+				serviceMap:         make(map[svc.UID]svc.Attrs),
+				pidsTracker:        otel.NewPidServiceTracker(),
+				createEventMetrics: mockEventsStore.createEventMetrics,
+				deleteEventMetrics: mockEventsStore.deleteEventMetrics,
+			}
+
+			uid := svc.UID{Name: "metrics-disabled-service-" + tt.name, Namespace: "default", Instance: "instance-1"}
+			service := svc.Attrs{
+				ExportModes: tt.exportModes,
+				UID:         uid,
+				HostName:    "test-host",
+			}
+			event := exec.ProcessEvent{
+				Type: exec.ProcessEventCreated,
+				File: exec.New(exec.Init{
+					Pid:     1234,
+					Service: service,
+				}),
+			}
+
+			reporter.handleProcessEvent(event, slog.Default())
+
+			assert.Empty(t, mockEventsStore.createCalls)
+			assert.Empty(t, mockEventsStore.deleteCalls)
+			assert.Equal(t, map[svc.UID]svc.Attrs{uid: service}, reporter.serviceMap)
+			assert.True(t, reporter.pidsTracker.ServiceLive(uid))
+
+			reporter.handleProcessEvent(exec.ProcessEvent{
+				Type: exec.ProcessEventTerminated,
+				File: event.File,
+			}, slog.Default())
+
+			assert.Empty(t, mockEventsStore.createCalls)
+			assert.Empty(t, mockEventsStore.deleteCalls)
+			assert.Empty(t, reporter.serviceMap)
+			assert.False(t, reporter.pidsTracker.ServiceLive(uid))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Gate OTEL process-event target-info metrics on per-service metric export mode.
- Gate Prometheus `target_info` and `traces_target_info` creation and stale cleanup paths the same way.
- Add exporter tests for metrics-disabled services with both `exports: []` and traces-only export modes.

## Root Cause

Span-derived metrics already respected `CanExportMetrics()`, but process-event target-info creation paths emitted metadata metrics without checking the service export mode. That allowed services with metrics disabled to still appear in metrics outputs.

Resolves #2041.

## Validation

- `go test -run TestHandleProcessEventCreatedMetricsExportDisabled -timeout 2m ./pkg/export/otel`
- `go test -run TestHandleProcessEventCreatedMetricsExportDisabled -timeout 2m ./pkg/export/prom`
- `go test -count=1 ./pkg/export/otel`
- `go test -count=1 ./pkg/export/prom`