### PR TITLE
(DynamicSelector-Phase1) Move DynamicPIDSelector to global context

### DIFF
--- a/pkg/appolly/discover/dynamic_pid_selector.go
+++ b/pkg/appolly/discover/dynamic_pid_selector.go
@@ -10,12 +10,15 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
+	"go.opentelemetry.io/obi/pkg/selection"
 )
 
+var _ selection.PIDSelector = (*DynamicPIDSelector)(nil)
+
 // DynamicPIDSelector holds the runtime set of target PIDs for OBI. It is preloaded from
-// config target_pids and updated at runtime via AddPIDs/RemovePIDs. Only the discover
-// matcher uses it for matching; the instrumenter (or appolly) holds a reference and
-// calls AddPIDs/RemovePIDs directly.
+// config target_pids and updated at runtime via AddPIDs/RemovePIDs. The discover matcher
+// uses it for matching; embedders hold a reference via ContextInfo.DynamicPIDSelector
+// and call AddPIDs/RemovePIDs on the concrete selector directly.
 //
 // Pending add/remove PIDs are accumulated in slices and drained by goroutines into
 // RemovedNotify() and AddedPIDsNotify(), so callers never block and nothing is dropped.

--- a/pkg/instrumenter/instrumenter.go
+++ b/pkg/instrumenter/instrumenter.go
@@ -65,7 +65,7 @@ func RunWithContextInfo(
 
 	// Enable App O11y when config enables it or when the caller passed a dynamic PID selector
 	// (allows an "empty" instrumenter that only instruments PIDs added via the selector).
-	app := cfg.Enabled(obi.FeatureAppO11y) || ctxInfo.AppO11y.DynamicPIDSelector != nil
+	app := cfg.Enabled(obi.FeatureAppO11y) || ctxInfo.DynamicPIDSelector != nil
 	net := cfg.Enabled(obi.FeatureNetO11y)
 	stats := cfg.Enabled(obi.FeatureStatsO11y)
 

--- a/pkg/instrumenter/opts.go
+++ b/pkg/instrumenter/opts.go
@@ -13,12 +13,12 @@ import (
 // Option that override the instantiation of the instrumenter
 type Option func(info *global.ContextInfo)
 
-// WithDynamicPIDSelector passes the given dynamic PID selector into the App O11y pipeline. The caller
-// creates it with discover.NewDynamicPIDSelector(), passes it here, and then calls AddPIDs/RemovePIDs/GetPIDs
-// on it directly—no callback or reference to the instrumenter is needed.
+// WithDynamicPIDSelector passes the given dynamic PID selector into the shared runtime context.
+// The caller creates it with discover.NewDynamicPIDSelector(), passes it here, and then calls
+// AddPIDs/RemovePIDs/GetPIDs on the concrete selector directly.
 func WithDynamicPIDSelector(sel *discover.DynamicPIDSelector) Option {
 	return func(info *global.ContextInfo) {
-		info.AppO11y.DynamicPIDSelector = sel
+		info.DynamicPIDSelector = sel
 	}
 }
 

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -99,11 +99,10 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *obi.Config) (
 	}
 
 	var sel *discover.DynamicPIDSelector
-	if v := ctxInfo.AppO11y.DynamicPIDSelector; v != nil {
+	if v := ctxInfo.DynamicPIDSelector; v != nil {
 		if s, ok := v.(*discover.DynamicPIDSelector); ok {
 			sel = s
 		}
-		// If v is not a *DynamicPIDSelector, sel stays nil and we use static config target_pids.
 	}
 	// When sel is nil, finder gets nil: config target_pids are used as static criteria (FindingCriteria(cfg, false)).
 	instr := &Instrumenter{

--- a/pkg/internal/appolly/appolly_test.go
+++ b/pkg/internal/appolly/appolly_test.go
@@ -48,12 +48,12 @@ func TestProcessEventsLoopDoesntBlock(t *testing.T) {
 }
 
 // TestInstrumenter_WithDynamicPIDSelector verifies that when the caller passes a selector via
-// ContextInfo.AppO11y.DynamicPIDSelector, New uses it and the caller can add/remove PIDs on it directly.
+// ContextInfo.DynamicPIDSelector, New uses it and the caller can add/remove PIDs on it directly.
 func TestInstrumenter_WithDynamicPIDSelector(t *testing.T) {
 	sel := discover.NewDynamicPIDSelector()
 	ctxInfo := &global.ContextInfo{
-		Prometheus: &connector.PrometheusManager{},
-		AppO11y:    global.AppO11y{DynamicPIDSelector: sel},
+		Prometheus:         &connector.PrometheusManager{},
+		DynamicPIDSelector: sel,
 	}
 	_, err := New(
 		t.Context(),

--- a/pkg/pipe/global/context.go
+++ b/pkg/pipe/global/context.go
@@ -17,6 +17,7 @@ import (
 	statsebpf "go.opentelemetry.io/obi/pkg/internal/statsolly/ebpf"
 	"go.opentelemetry.io/obi/pkg/kube"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
+	"go.opentelemetry.io/obi/pkg/selection"
 )
 
 // ContextInfo stores some context information that must be shared across some nodes of the
@@ -65,14 +66,16 @@ type ContextInfo struct {
 
 	// OTELMetricsExporter allows sharing the same OTEL exporter through diverse metrics export nodes (Application, Network...)
 	OTELMetricsExporter *otelcfg.MetricsExporterInstancer
+
+	// DynamicPIDSelector, when set, is the shared runtime PID set for dynamic instrumentation.
+	// The caller creates it (e.g. discover.NewDynamicPIDSelector()), passes it via
+	// instrumenter.WithDynamicPIDSelector, and calls AddPIDs/RemovePIDs/GetPIDs on the
+	// concrete implementation directly.
+	DynamicPIDSelector selection.PIDSelector
 }
 
 // AppO11y stores context information that is only required for application observability.
 type AppO11y struct {
 	// ReportRoutes sets whether the metrics should set the http.route attribute
 	ReportRoutes bool
-	// DynamicPIDSelector, when set, is the runtime PID set used for discovery. The caller creates it
-	// (e.g. discover.NewDynamicPIDSelector()), passes it via instrumenter.WithDynamicPIDSelector, and
-	// calls AddPIDs/RemovePIDs/GetPIDs on it directly. The instrumenter does not implement an updater interface.
-	DynamicPIDSelector any
 }

--- a/pkg/selection/pid_selector.go
+++ b/pkg/selection/pid_selector.go
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package selection // import "go.opentelemetry.io/obi/pkg/selection"
+
+import (
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+)
+
+// PIDSelector is the read-only contract for runtime dynamic PID membership.
+// Implementations notify subscribers when PIDs enter or leave the selected set.
+type PIDSelector interface {
+	GetPIDs() ([]app.PID, bool)
+	AddedPIDsNotify() <-chan []app.PID
+	RemovedNotify() <-chan []app.PID
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2234

This moves the `DynamicPIDSelector` concrete type up one level from `contextInfo.AppO11y.DynamicPIDSelector` to `contextInfo.DynamicPIDSelector` and creates a `PIDSelector` interface that will be used in the later Phase 3 for implementing signal-aware views.

This is technically a breaking change for anyone that was directly accessing `contextInfo.AppO11y.DynamicPIDSelector`, but that was not the documented intended use case for it to be in that location

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
