### PR TITLE
Add internal config v2 schema parser

### DIFF
--- a/internal/config/schema/errors.go
+++ b/internal/config/schema/errors.go
@@ -26,6 +26,8 @@ func (e *NotV2Error) Is(target error) bool {
 	return ok
 }
 
+// UnsupportedVersionError reports an OBI v2 version field whose value is present
+// but not handled by this package.
 type UnsupportedVersionError struct {
 	Version string
 }
@@ -34,8 +36,12 @@ func (e *UnsupportedVersionError) Error() string {
 	return fmt.Sprintf("unsupported OBI config version %q", e.Version)
 }
 
+// SectionNotAllowedError reports a configuration section that is structurally
+// valid OBI v2 but invalid for the selected deployment parser.
 type SectionNotAllowedError struct {
-	Mode    string
+	// Mode is the deployment mode whose parser rejected the section.
+	Mode string
+	// Section is the YAML key that is not allowed in Mode.
 	Section string
 }
 

--- a/internal/config/schema/errors.go
+++ b/internal/config/schema/errors.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package schema
+
+import "fmt"
+
+// NotV2Error reports input that does not contain an OBI v2 configuration.
+//
+// It is distinct from UnsupportedVersionError: NotV2Error means no usable OBI v2
+// version marker was found, while UnsupportedVersionError means a version marker
+// was found but is not supported by this package.
+type NotV2Error struct {
+	Reason string
+}
+
+func (e *NotV2Error) Error() string {
+	if e == nil || e.Reason == "" {
+		return "configuration is not OBI config v2"
+	}
+	return "configuration is not OBI config v2: " + e.Reason
+}
+
+func (e *NotV2Error) Is(target error) bool {
+	_, ok := target.(*NotV2Error)
+	return ok
+}
+
+type UnsupportedVersionError struct {
+	Version string
+}
+
+func (e *UnsupportedVersionError) Error() string {
+	return fmt.Sprintf("unsupported OBI config version %q", e.Version)
+}
+
+type SectionNotAllowedError struct {
+	Mode    string
+	Section string
+}
+
+func (e *SectionNotAllowedError) Error() string {
+	if e.Mode == string(validationModeReceiver) {
+		return fmt.Sprintf(
+			"section %q is not allowed in %s mode; remove it from the receiver config or run this config in standalone mode",
+			e.Section,
+			e.Mode,
+		)
+	}
+	return fmt.Sprintf("section %q is not allowed in %s mode", e.Section, e.Mode)
+}

--- a/internal/config/schema/errors.go
+++ b/internal/config/schema/errors.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package schema
+package schema // import "go.opentelemetry.io/obi/internal/config/schema"
 
 import "fmt"
 

--- a/internal/config/schema/errors.go
+++ b/internal/config/schema/errors.go
@@ -36,22 +36,16 @@ func (e *UnsupportedVersionError) Error() string {
 	return fmt.Sprintf("unsupported OBI config version %q", e.Version)
 }
 
-// SectionNotAllowedError reports a configuration section that is structurally
-// valid OBI v2 but invalid for the selected deployment parser.
+// SectionNotAllowedError reports a standalone-only configuration section in a
+// receiver-embedded OBI config.
 type SectionNotAllowedError struct {
-	// Mode is the deployment mode whose parser rejected the section.
-	Mode string
-	// Section is the YAML key that is not allowed in Mode.
+	// Section is the YAML key that is not allowed in receiver config.
 	Section string
 }
 
 func (e *SectionNotAllowedError) Error() string {
-	if e.Mode == string(validationModeReceiver) {
-		return fmt.Sprintf(
-			"section %q is not allowed in %s mode; remove it from the receiver config or run this config in standalone mode",
-			e.Section,
-			e.Mode,
-		)
-	}
-	return fmt.Sprintf("section %q is not allowed in %s mode", e.Section, e.Mode)
+	return fmt.Sprintf(
+		"section %q is not allowed in receiver config; remove it from the receiver config or run this config in standalone mode",
+		e.Section,
+	)
 }

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -28,11 +28,10 @@ import (
 // package.
 const SupportedVersion = "2.0"
 
-type validationMode string
-
 const (
-	validationModeStandalone validationMode = "standalone"
-	validationModeReceiver   validationMode = "receiver"
+	sectionEnrich      = "enrich"
+	sectionCorrelation = "correlation"
+	sectionDaemon      = "daemon"
 )
 
 // Document is the top-level OpenTelemetry declarative configuration document
@@ -107,11 +106,8 @@ type RuleRefinement struct {
 // appear beside version at the top level instead of under an extension.capture
 // object.
 type receiverConfig struct {
-	Version     string `yaml:"version"`
-	Capture     `yaml:",inline"`
-	Enrich      map[string]any `yaml:"enrich,omitempty"`
-	Correlation map[string]any `yaml:"correlation,omitempty"`
-	Daemon      map[string]any `yaml:"daemon,omitempty"`
+	Version string `yaml:"version"`
+	Capture `yaml:",inline"`
 }
 
 // ParseStandaloneYAML decodes a standalone OBI v2 declarative document.
@@ -173,18 +169,15 @@ func ParseReceiverYAML(data []byte) (*Extension, error) {
 			return nil, &UnsupportedVersionError{Version: version}
 		}
 		if section, ok := disallowedReceiverSection(root); ok {
-			return nil, &SectionNotAllowedError{Mode: string(validationModeReceiver), Section: section}
+			return nil, &SectionNotAllowedError{Section: section}
 		}
 		var receiver receiverConfig
 		if err := decode(root, &receiver); err != nil {
 			return nil, err
 		}
 		cfg := Extension{
-			Version:     receiver.Version,
-			Capture:     receiver.Capture,
-			Enrich:      receiver.Enrich,
-			Correlation: receiver.Correlation,
-			Daemon:      receiver.Daemon,
+			Version: receiver.Version,
+			Capture: receiver.Capture,
 		}
 		if err := ValidateReceiver(&cfg); err != nil {
 			return nil, err
@@ -205,54 +198,48 @@ func ParseReceiverYAML(data []byte) (*Extension, error) {
 
 // ValidateStandalone checks version support for a standalone OBI extension.
 func ValidateStandalone(cfg *Extension) error {
-	return validate(cfg, validationModeStandalone)
+	return validateVersion(cfg)
 }
 
 // ValidateReceiver checks version support and receiver section boundaries for an
 // already decoded OBI extension.
 func ValidateReceiver(cfg *Extension) error {
-	return validate(cfg, validationModeReceiver)
+	if err := validateVersion(cfg); err != nil {
+		return err
+	}
+	if cfg.Enrich != nil {
+		return &SectionNotAllowedError{Section: sectionEnrich}
+	}
+	if cfg.Correlation != nil {
+		return &SectionNotAllowedError{Section: sectionCorrelation}
+	}
+	if cfg.Daemon != nil {
+		return &SectionNotAllowedError{Section: sectionDaemon}
+	}
+	return nil
 }
 
-// validate checks version support and deployment-specific section boundaries for
-// an already decoded OBI extension.
-func validate(cfg *Extension, mode validationMode) error {
+func validateVersion(cfg *Extension) error {
 	if cfg == nil {
 		return errors.New("missing OBI config")
 	}
 	if cfg.Version != SupportedVersion {
 		return &UnsupportedVersionError{Version: cfg.Version}
 	}
-	if mode == validationModeReceiver {
-		for _, section := range []string{"enrich", "correlation", "daemon"} {
-			if hasStandaloneSection(cfg, section) {
-				return &SectionNotAllowedError{Mode: string(mode), Section: section}
-			}
-		}
-	}
 	return nil
 }
 
 func disallowedReceiverSection(root *yaml.Node) (string, bool) {
-	for _, section := range []string{"enrich", "correlation", "daemon"} {
-		if _, ok := mappingValue(root, section); ok {
-			return section, true
-		}
+	if _, ok := mappingValue(root, sectionEnrich); ok {
+		return sectionEnrich, true
+	}
+	if _, ok := mappingValue(root, sectionCorrelation); ok {
+		return sectionCorrelation, true
+	}
+	if _, ok := mappingValue(root, sectionDaemon); ok {
+		return sectionDaemon, true
 	}
 	return "", false
-}
-
-func hasStandaloneSection(cfg *Extension, section string) bool {
-	switch section {
-	case "enrich":
-		return cfg.Enrich != nil
-	case "correlation":
-		return cfg.Correlation != nil
-	case "daemon":
-		return cfg.Daemon != nil
-	default:
-		return false
-	}
 }
 
 func looksLikeV1(root *yaml.Node) bool {

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -9,10 +9,10 @@
 //   - a receiver-embedded OBI configuration with version and capture sections at
 //     the top level
 //
-// This package validates only the version, shape, and deployment-mode section
-// boundaries needed to route the configuration. It intentionally leaves nested
-// OBI sections as map values so migration and validation layers can preserve and
-// inspect the original keys.
+// This package validates only the version, shape, and deployment-specific
+// section boundaries needed to route the configuration. It intentionally leaves
+// nested OBI sections as map values so migration and validation layers can
+// preserve and inspect the original keys.
 package schema // import "go.opentelemetry.io/obi/internal/config/schema"
 
 import (
@@ -26,18 +26,11 @@ import (
 // package.
 const SupportedVersion = "2.0"
 
-// DeploymentMode identifies where an OBI v2 configuration will run.
-type DeploymentMode string
+type validationMode string
 
 const (
-	// DeploymentModeStandalone allows the full OBI extension, including sections
-	// that manage enrichment, correlation, and daemon behavior.
-	DeploymentModeStandalone DeploymentMode = "standalone"
-
-	// DeploymentModeReceiver allows only receiver-embeddable capture settings.
-	// Standalone-only sections are rejected because the Collector owns those
-	// concerns in receiver deployments.
-	DeploymentModeReceiver DeploymentMode = "receiver"
+	validationModeStandalone validationMode = "standalone"
+	validationModeReceiver   validationMode = "receiver"
 )
 
 // Document is the top-level OpenTelemetry declarative configuration document
@@ -46,7 +39,7 @@ const (
 // OBI-specific settings are available through Extensions.OBI. Other declarative
 // configuration sections are retained as maps because this package only needs to
 // locate and validate the OBI extension. Raw aliases the decoded YAML map passed
-// to ParseMap, or the map decoded by ParseYAML.
+// to ParseStandaloneMap, or the map decoded by ParseStandaloneYAML.
 type Document struct {
 	FileFormat     string         `yaml:"file_format"`
 	Resource       map[string]any `yaml:"resource"`
@@ -143,12 +136,12 @@ func (e *UnsupportedVersionError) Error() string {
 }
 
 type SectionNotAllowedError struct {
-	Mode    DeploymentMode
+	Mode    string
 	Section string
 }
 
 func (e *SectionNotAllowedError) Error() string {
-	if e.Mode == DeploymentModeReceiver {
+	if e.Mode == string(validationModeReceiver) {
 		return fmt.Sprintf(
 			"section %q is not allowed in %s mode; remove it from the receiver config or run this config in standalone mode",
 			e.Section,
@@ -162,14 +155,15 @@ func (e *SectionNotAllowedError) Error() string {
 //
 // Full declarative documents return both a Document and its OBI Extension.
 // Receiver-embedded configurations return a nil Document and the synthesized OBI
-// Extension. The mode controls validation of standalone-only sections.
-func ParseYAML(data []byte, mode DeploymentMode) (*Document, *Extension, error) {
-	var raw map[string]any
-	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return nil, nil, fmt.Errorf("parsing config v2 YAML: %w", err)
+// Extension. Standalone-only sections are rejected for receiver-embedded
+// configurations.
+func ParseYAML(data []byte) (*Document, *Extension, error) {
+	raw, err := parseYAML(data)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	return ParseMap(raw, mode)
+	return ParseMap(raw)
 }
 
 // ParseMap parses a decoded YAML map as an OBI v2 configuration.
@@ -179,31 +173,21 @@ func ParseYAML(data []byte, mode DeploymentMode) (*Document, *Extension, error) 
 // where top-level capture sections are moved under Extension.Capture. Missing v2
 // markers return NotV2Error; present but unsupported markers return
 // UnsupportedVersionError.
-func ParseMap(raw map[string]any, mode DeploymentMode) (*Document, *Extension, error) {
+func ParseMap(raw map[string]any) (*Document, *Extension, error) {
 	if len(raw) == 0 {
 		return nil, nil, &NotV2Error{Reason: "missing OBI v2 version field"}
 	}
 
-	if version, ok := nestedString(raw, "extensions", "obi", "version"); ok {
-		if version != SupportedVersion {
-			return nil, nil, &UnsupportedVersionError{Version: version}
+	if _, ok := nestedValue(raw, "extensions", "obi", "version"); ok {
+		return ParseStandaloneMap(raw)
+	}
+
+	if _, ok := nestedValue(raw, "version"); ok {
+		cfg, err := ParseReceiverMap(raw)
+		if err != nil {
+			return nil, nil, err
 		}
-		return parseDocument(raw, mode)
-	}
-
-	if version, ok := nestedString(raw, "version"); ok {
-		if version != SupportedVersion {
-			return nil, nil, &UnsupportedVersionError{Version: version}
-		}
-		return parseReceiver(raw, mode)
-	}
-
-	if version, ok := nestedValue(raw, "extensions", "obi", "version"); ok {
-		return nil, nil, &UnsupportedVersionError{Version: fmt.Sprint(version)}
-	}
-
-	if version, ok := nestedValue(raw, "version"); ok {
-		return nil, nil, &UnsupportedVersionError{Version: fmt.Sprint(version)}
+		return nil, cfg, nil
 	}
 
 	if looksLikeV1(raw) {
@@ -213,19 +197,97 @@ func ParseMap(raw map[string]any, mode DeploymentMode) (*Document, *Extension, e
 	return nil, nil, &NotV2Error{Reason: "missing OBI v2 version field"}
 }
 
-// Validate checks version support and deployment-mode section boundaries for an
-// already decoded OBI extension.
-func Validate(cfg *Extension, mode DeploymentMode) error {
+// ParseStandaloneYAML decodes a standalone OBI v2 declarative document.
+func ParseStandaloneYAML(data []byte) (*Document, *Extension, error) {
+	raw, err := parseYAML(data)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return ParseStandaloneMap(raw)
+}
+
+// ParseStandaloneMap parses a standalone OBI v2 declarative document.
+func ParseStandaloneMap(raw map[string]any) (*Document, *Extension, error) {
+	if len(raw) == 0 {
+		return nil, nil, &NotV2Error{Reason: "missing extensions.obi.version field"}
+	}
+
+	if version, ok := nestedString(raw, "extensions", "obi", "version"); ok {
+		if version != SupportedVersion {
+			return nil, nil, &UnsupportedVersionError{Version: version}
+		}
+		return parseDocument(raw)
+	}
+
+	if version, ok := nestedValue(raw, "extensions", "obi", "version"); ok {
+		return nil, nil, &UnsupportedVersionError{Version: fmt.Sprint(version)}
+	}
+
+	if looksLikeV1(raw) {
+		return nil, nil, &NotV2Error{Reason: "detected legacy v1 config shape"}
+	}
+
+	return nil, nil, &NotV2Error{Reason: "missing extensions.obi.version field"}
+}
+
+// ParseReceiverYAML decodes a receiver-embedded OBI v2 configuration.
+func ParseReceiverYAML(data []byte) (*Extension, error) {
+	raw, err := parseYAML(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseReceiverMap(raw)
+}
+
+// ParseReceiverMap parses a receiver-embedded OBI v2 configuration.
+func ParseReceiverMap(raw map[string]any) (*Extension, error) {
+	if len(raw) == 0 {
+		return nil, &NotV2Error{Reason: "missing top-level OBI v2 version field"}
+	}
+
+	if version, ok := nestedString(raw, "version"); ok {
+		if version != SupportedVersion {
+			return nil, &UnsupportedVersionError{Version: version}
+		}
+		return parseReceiver(raw)
+	}
+
+	if version, ok := nestedValue(raw, "version"); ok {
+		return nil, &UnsupportedVersionError{Version: fmt.Sprint(version)}
+	}
+
+	if looksLikeV1(raw) {
+		return nil, &NotV2Error{Reason: "detected legacy v1 config shape"}
+	}
+
+	return nil, &NotV2Error{Reason: "missing top-level OBI v2 version field"}
+}
+
+// ValidateStandalone checks version support for a standalone OBI extension.
+func ValidateStandalone(cfg *Extension) error {
+	return validate(cfg, validationModeStandalone)
+}
+
+// ValidateReceiver checks version support and receiver section boundaries.
+func ValidateReceiver(cfg *Extension) error {
+	return validate(cfg, validationModeReceiver)
+}
+
+// validate checks version support and deployment-specific section boundaries for
+// an already decoded OBI extension.
+func validate(cfg *Extension, mode validationMode) error {
 	if cfg == nil {
 		return errors.New("missing OBI config")
 	}
 	if cfg.Version != SupportedVersion {
 		return &UnsupportedVersionError{Version: cfg.Version}
 	}
-	if mode == DeploymentModeReceiver {
+	if mode == validationModeReceiver {
 		for _, section := range []string{"enrich", "correlation", "daemon"} {
 			if hasStandaloneSection(cfg, section) {
-				return &SectionNotAllowedError{Mode: mode, Section: section}
+				return &SectionNotAllowedError{Mode: string(mode), Section: section}
 			}
 		}
 	}
@@ -234,7 +296,7 @@ func Validate(cfg *Extension, mode DeploymentMode) error {
 
 // parseDocument decodes the full declarative layout and wires Raw fields to the
 // corresponding source maps.
-func parseDocument(raw map[string]any, mode DeploymentMode) (*Document, *Extension, error) {
+func parseDocument(raw map[string]any) (*Document, *Extension, error) {
 	var doc Document
 	if err := decode(raw, &doc); err != nil {
 		return nil, nil, err
@@ -246,7 +308,7 @@ func parseDocument(raw map[string]any, mode DeploymentMode) (*Document, *Extensi
 
 	doc.Extensions.OBI.Raw = nestedMap(raw, "extensions", "obi")
 	doc.Extensions.OBI.Capture.Raw = nestedMap(raw, "extensions", "obi", "capture")
-	if err := Validate(doc.Extensions.OBI, mode); err != nil {
+	if err := ValidateStandalone(doc.Extensions.OBI); err != nil {
 		return nil, nil, err
 	}
 	return &doc, doc.Extensions.OBI, nil
@@ -255,7 +317,7 @@ func parseDocument(raw map[string]any, mode DeploymentMode) (*Document, *Extensi
 // parseReceiver adapts the receiver-embedded layout into Extension. Capture
 // sections are accepted at the top level in receiver configuration files, but the
 // resulting value uses the same Extension shape as full documents.
-func parseReceiver(raw map[string]any, mode DeploymentMode) (*Document, *Extension, error) {
+func parseReceiver(raw map[string]any) (*Extension, error) {
 	receiver := map[string]any{
 		"version":     raw["version"],
 		"capture":     map[string]any{},
@@ -273,14 +335,14 @@ func parseReceiver(raw map[string]any, mode DeploymentMode) (*Document, *Extensi
 
 	var cfg Extension
 	if err := decode(receiver, &cfg); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	cfg.Raw = raw
 	cfg.Capture.Raw = capture
-	if err := Validate(&cfg, mode); err != nil {
-		return nil, nil, err
+	if err := ValidateReceiver(&cfg); err != nil {
+		return nil, err
 	}
-	return nil, &cfg, nil
+	return &cfg, nil
 }
 
 func hasStandaloneSection(cfg *Extension, section string) bool {
@@ -336,6 +398,14 @@ func captureKeys() []string {
 		"channels",
 		"telemetry",
 	}
+}
+
+func parseYAML(data []byte) (map[string]any, error) {
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing config v2 YAML: %w", err)
+	}
+	return raw, nil
 }
 
 func decode(raw map[string]any, dst any) error {

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -151,52 +151,6 @@ func (e *SectionNotAllowedError) Error() string {
 	return fmt.Sprintf("section %q is not allowed in %s mode", e.Section, e.Mode)
 }
 
-// ParseYAML decodes data as YAML and parses it as an OBI v2 configuration.
-//
-// Full declarative documents return both a Document and its OBI Extension.
-// Receiver-embedded configurations return a nil Document and the synthesized OBI
-// Extension. Standalone-only sections are rejected for receiver-embedded
-// configurations.
-func ParseYAML(data []byte) (*Document, *Extension, error) {
-	raw, err := parseYAML(data)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return ParseMap(raw)
-}
-
-// ParseMap parses a decoded YAML map as an OBI v2 configuration.
-//
-// A map with extensions.obi.version is treated as a full declarative document. A
-// map with a top-level version is treated as a receiver-embedded configuration,
-// where top-level capture sections are moved under Extension.Capture. Missing v2
-// markers return NotV2Error; present but unsupported markers return
-// UnsupportedVersionError.
-func ParseMap(raw map[string]any) (*Document, *Extension, error) {
-	if len(raw) == 0 {
-		return nil, nil, &NotV2Error{Reason: "missing OBI v2 version field"}
-	}
-
-	if _, ok := nestedValue(raw, "extensions", "obi", "version"); ok {
-		return ParseStandaloneMap(raw)
-	}
-
-	if _, ok := nestedValue(raw, "version"); ok {
-		cfg, err := ParseReceiverMap(raw)
-		if err != nil {
-			return nil, nil, err
-		}
-		return nil, cfg, nil
-	}
-
-	if looksLikeV1(raw) {
-		return nil, nil, &NotV2Error{Reason: "detected legacy v1 config shape"}
-	}
-
-	return nil, nil, &NotV2Error{Reason: "missing OBI v2 version field"}
-}
-
 // ParseStandaloneYAML decodes a standalone OBI v2 declarative document.
 func ParseStandaloneYAML(data []byte) (*Document, *Extension, error) {
 	raw, err := parseYAML(data)

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -38,8 +38,7 @@ const (
 //
 // OBI-specific settings are available through Extensions.OBI. Other declarative
 // configuration sections are retained as maps because this package only needs to
-// locate and validate the OBI extension. Raw aliases the decoded YAML map passed
-// to ParseStandaloneMap, or the map decoded by ParseStandaloneYAML.
+// locate and validate the OBI extension.
 type Document struct {
 	FileFormat     string         `yaml:"file_format"`
 	Resource       map[string]any `yaml:"resource"`
@@ -47,7 +46,6 @@ type Document struct {
 	TracerProvider map[string]any `yaml:"tracer_provider"`
 	MeterProvider  map[string]any `yaml:"meter_provider"`
 	Extensions     Extensions     `yaml:"extensions"`
-	Raw            map[string]any `yaml:"-"`
 }
 
 // Extensions holds declarative configuration extensions recognized by this
@@ -59,24 +57,19 @@ type Extensions struct {
 // Extension is the OBI v2 extension configuration.
 //
 // Capture is valid in all deployment modes. Enrich, Correlation, and Daemon are
-// standalone-only sections and are rejected when validating receiver mode. Raw
-// aliases the source map for this extension in full documents and the top-level
-// source map in receiver-embedded configurations.
+// standalone-only sections and are rejected when validating receiver mode.
 type Extension struct {
 	Version     string         `yaml:"version"`
 	Capture     Capture        `yaml:"capture"`
 	Enrich      map[string]any `yaml:"enrich,omitempty"`
 	Correlation map[string]any `yaml:"correlation,omitempty"`
 	Daemon      map[string]any `yaml:"daemon,omitempty"`
-	Raw         map[string]any `yaml:"-"`
 }
 
 // Capture contains receiver-embeddable OBI capture settings.
 //
 // The individual sections remain map values so callers can preserve unknown
-// fields and apply schema-specific validation or migration elsewhere. Raw aliases
-// the source capture map in full documents and the synthesized capture map in
-// receiver-embedded configurations.
+// fields and apply schema-specific validation or migration elsewhere.
 type Capture struct {
 	Policy          map[string]any `yaml:"policy"`
 	Rules           []Rule         `yaml:"rules"`
@@ -88,7 +81,6 @@ type Capture struct {
 	Safety          map[string]any `yaml:"safety"`
 	Channels        map[string]any `yaml:"channels"`
 	Telemetry       map[string]any `yaml:"telemetry"`
-	Raw             map[string]any `yaml:"-"`
 }
 
 // Rule describes one capture policy rule.
@@ -106,38 +98,47 @@ type RuleRefinement struct {
 	HTTP    map[string]any `yaml:"http,omitempty"`
 }
 
+type receiverConfig struct {
+	Version     string `yaml:"version"`
+	Capture     `yaml:",inline"`
+	Enrich      map[string]any `yaml:"enrich,omitempty"`
+	Correlation map[string]any `yaml:"correlation,omitempty"`
+	Daemon      map[string]any `yaml:"daemon,omitempty"`
+}
+
 // ParseStandaloneYAML decodes a standalone OBI v2 declarative document.
 func ParseStandaloneYAML(data []byte) (*Document, *Extension, error) {
-	raw, err := parseYAML(data)
+	root, err := parseYAML(data)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return ParseStandaloneMap(raw)
-}
-
-// ParseStandaloneMap parses a standalone OBI v2 declarative document.
-func ParseStandaloneMap(raw map[string]any) (*Document, *Extension, error) {
-	if len(raw) == 0 {
-		return nil, nil, &NotV2Error{Reason: "missing extensions.obi.version field"}
-	}
-
-	if version, ok := nestedString(raw, "extensions", "obi", "version"); ok {
+	if version, ok := nestedScalar(root, "extensions", "obi", "version"); ok {
 		if version != SupportedVersion {
 			return nil, nil, &UnsupportedVersionError{Version: version}
 		}
-		return parseDocument(raw)
+		var doc Document
+		if err := decode(root, &doc); err != nil {
+			return nil, nil, err
+		}
+		if doc.Extensions.OBI == nil {
+			return nil, nil, &NotV2Error{Reason: "missing extensions.obi"}
+		}
+		if err := ValidateStandalone(doc.Extensions.OBI); err != nil {
+			return nil, nil, err
+		}
+		return &doc, doc.Extensions.OBI, nil
 	}
 
-	if version, ok := nestedValue(raw, "extensions", "obi", "version"); ok {
-		return nil, nil, &UnsupportedVersionError{Version: fmt.Sprint(version)}
+	if version, ok := nestedVersion(root, "extensions", "obi", "version"); ok {
+		return nil, nil, &UnsupportedVersionError{Version: version}
 	}
 
-	if _, ok := nestedValue(raw, "version"); ok {
+	if _, ok := nestedVersion(root, "version"); ok {
 		return nil, nil, &NotV2Error{Reason: "missing extensions.obi.version field"}
 	}
 
-	if looksLikeV1(raw) {
+	if looksLikeV1(root) {
 		return nil, nil, &NotV2Error{Reason: "detected legacy v1 config shape"}
 	}
 
@@ -146,32 +147,37 @@ func ParseStandaloneMap(raw map[string]any) (*Document, *Extension, error) {
 
 // ParseReceiverYAML decodes a receiver-embedded OBI v2 configuration.
 func ParseReceiverYAML(data []byte) (*Extension, error) {
-	raw, err := parseYAML(data)
+	root, err := parseYAML(data)
 	if err != nil {
 		return nil, err
 	}
 
-	return ParseReceiverMap(raw)
-}
-
-// ParseReceiverMap parses a receiver-embedded OBI v2 configuration.
-func ParseReceiverMap(raw map[string]any) (*Extension, error) {
-	if len(raw) == 0 {
-		return nil, &NotV2Error{Reason: "missing top-level OBI v2 version field"}
-	}
-
-	if version, ok := nestedString(raw, "version"); ok {
+	if version, ok := nestedScalar(root, "version"); ok {
 		if version != SupportedVersion {
 			return nil, &UnsupportedVersionError{Version: version}
 		}
-		return parseReceiver(raw)
+		var receiver receiverConfig
+		if err := decode(root, &receiver); err != nil {
+			return nil, err
+		}
+		cfg := Extension{
+			Version:     receiver.Version,
+			Capture:     receiver.Capture,
+			Enrich:      receiver.Enrich,
+			Correlation: receiver.Correlation,
+			Daemon:      receiver.Daemon,
+		}
+		if err := ValidateReceiver(&cfg); err != nil {
+			return nil, err
+		}
+		return &cfg, nil
 	}
 
-	if version, ok := nestedValue(raw, "version"); ok {
-		return nil, &UnsupportedVersionError{Version: fmt.Sprint(version)}
+	if version, ok := nestedVersion(root, "version"); ok {
+		return nil, &UnsupportedVersionError{Version: version}
 	}
 
-	if looksLikeV1(raw) {
+	if looksLikeV1(root) {
 		return nil, &NotV2Error{Reason: "detected legacy v1 config shape"}
 	}
 
@@ -207,63 +213,7 @@ func validate(cfg *Extension, mode validationMode) error {
 	return nil
 }
 
-// parseDocument decodes the full declarative layout and wires Raw fields to the
-// corresponding source maps.
-func parseDocument(raw map[string]any) (*Document, *Extension, error) {
-	var doc Document
-	if err := decode(raw, &doc); err != nil {
-		return nil, nil, err
-	}
-	doc.Raw = raw
-	if doc.Extensions.OBI == nil {
-		return nil, nil, &NotV2Error{Reason: "missing extensions.obi"}
-	}
-
-	doc.Extensions.OBI.Raw = nestedMap(raw, "extensions", "obi")
-	doc.Extensions.OBI.Capture.Raw = nestedMap(raw, "extensions", "obi", "capture")
-	if err := ValidateStandalone(doc.Extensions.OBI); err != nil {
-		return nil, nil, err
-	}
-	return &doc, doc.Extensions.OBI, nil
-}
-
-// parseReceiver adapts the receiver-embedded layout into Extension. Capture
-// sections are accepted at the top level in receiver configuration files, but the
-// resulting value uses the same Extension shape as full documents.
-func parseReceiver(raw map[string]any) (*Extension, error) {
-	receiver := map[string]any{
-		"version":     raw["version"],
-		"capture":     map[string]any{},
-		"enrich":      raw["enrich"],
-		"correlation": raw["correlation"],
-		"daemon":      raw["daemon"],
-	}
-
-	capture := receiver["capture"].(map[string]any)
-	for _, key := range captureKeys() {
-		if value, ok := raw[key]; ok {
-			capture[key] = value
-		}
-	}
-
-	var cfg Extension
-	if err := decode(receiver, &cfg); err != nil {
-		return nil, err
-	}
-	cfg.Raw = raw
-	cfg.Capture.Raw = capture
-	if err := ValidateReceiver(&cfg); err != nil {
-		return nil, err
-	}
-	return &cfg, nil
-}
-
 func hasStandaloneSection(cfg *Extension, section string) bool {
-	if cfg.Raw != nil {
-		_, ok := cfg.Raw[section]
-		return ok
-	}
-
 	switch section {
 	case "enrich":
 		return cfg.Enrich != nil
@@ -276,7 +226,7 @@ func hasStandaloneSection(cfg *Extension, section string) bool {
 	}
 }
 
-func looksLikeV1(raw map[string]any) bool {
+func looksLikeV1(root *yaml.Node) bool {
 	for _, key := range []string{
 		"ebpf",
 		"discovery",
@@ -289,78 +239,70 @@ func looksLikeV1(raw map[string]any) bool {
 		"stats",
 		"javaagent",
 	} {
-		if _, ok := raw[key]; ok {
+		if _, ok := mappingValue(root, key); ok {
 			return true
 		}
 	}
 	return false
 }
 
-// captureKeys lists top-level receiver-embedded sections that belong under
-// Extension.Capture in the normalized representation.
-func captureKeys() []string {
-	return []string{
-		"policy",
-		"rules",
-		"instrumentation",
-		"runtimes",
-		"network",
-		"limits",
-		"engine",
-		"safety",
-		"channels",
-		"telemetry",
-	}
-}
-
-func parseYAML(data []byte) (map[string]any, error) {
-	var raw map[string]any
-	if err := yaml.Unmarshal(data, &raw); err != nil {
+func parseYAML(data []byte) (*yaml.Node, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parsing config v2 YAML: %w", err)
 	}
-	return raw, nil
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0], nil
+	}
+	return &doc, nil
 }
 
-func decode(raw map[string]any, dst any) error {
-	buf, err := yaml.Marshal(raw)
-	if err != nil {
-		return fmt.Errorf("marshaling config v2 YAML: %w", err)
-	}
-	if err := yaml.Unmarshal(buf, dst); err != nil {
+func decode(node *yaml.Node, dst any) error {
+	if err := node.Decode(dst); err != nil {
 		return fmt.Errorf("decoding config v2 YAML: %w", err)
 	}
 	return nil
 }
 
-func nestedMap(raw map[string]any, path ...string) map[string]any {
-	value, ok := nestedValue(raw, path...)
-	if !ok {
-		return nil
+func nestedScalar(root *yaml.Node, path ...string) (string, bool) {
+	value, ok := nestedNode(root, path...)
+	if !ok || value.Kind != yaml.ScalarNode || value.ShortTag() != "!!str" {
+		return "", false
 	}
-	result, _ := value.(map[string]any)
-	return result
+	return value.Value, true
 }
 
-func nestedString(raw map[string]any, path ...string) (string, bool) {
-	value, ok := nestedValue(raw, path...)
+func nestedVersion(root *yaml.Node, path ...string) (string, bool) {
+	value, ok := nestedNode(root, path...)
 	if !ok {
 		return "", false
 	}
-	result, ok := value.(string)
-	return result, ok
+	if value.Kind == yaml.ScalarNode {
+		return value.Value, true
+	}
+	return value.ShortTag(), true
 }
 
-func nestedValue(raw map[string]any, path ...string) (any, bool) {
-	cur := any(raw)
+func nestedNode(root *yaml.Node, path ...string) (*yaml.Node, bool) {
+	cur := root
 	for _, key := range path {
-		next, ok := cur.(map[string]any)
+		next, ok := mappingValue(cur, key)
 		if !ok {
 			return nil, false
 		}
-		cur, ok = next[key]
-		if !ok {
-			return nil, false
-		}
+		cur = next
 	}
 	return cur, true
+}
+
+func mappingValue(node *yaml.Node, key string) (*yaml.Node, bool) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil, false
+	}
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1], true
+		}
+	}
+	return nil, false
 }

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -106,51 +106,6 @@ type RuleRefinement struct {
 	HTTP    map[string]any `yaml:"http,omitempty"`
 }
 
-// NotV2Error reports input that does not contain an OBI v2 configuration.
-//
-// It is distinct from UnsupportedVersionError: NotV2Error means no usable OBI v2
-// version marker was found, while UnsupportedVersionError means a version marker
-// was found but is not supported by this package.
-type NotV2Error struct {
-	Reason string
-}
-
-func (e *NotV2Error) Error() string {
-	if e == nil || e.Reason == "" {
-		return "configuration is not OBI config v2"
-	}
-	return "configuration is not OBI config v2: " + e.Reason
-}
-
-func (e *NotV2Error) Is(target error) bool {
-	_, ok := target.(*NotV2Error)
-	return ok
-}
-
-type UnsupportedVersionError struct {
-	Version string
-}
-
-func (e *UnsupportedVersionError) Error() string {
-	return fmt.Sprintf("unsupported OBI config version %q", e.Version)
-}
-
-type SectionNotAllowedError struct {
-	Mode    string
-	Section string
-}
-
-func (e *SectionNotAllowedError) Error() string {
-	if e.Mode == string(validationModeReceiver) {
-		return fmt.Sprintf(
-			"section %q is not allowed in %s mode; remove it from the receiver config or run this config in standalone mode",
-			e.Section,
-			e.Mode,
-		)
-	}
-	return fmt.Sprintf("section %q is not allowed in %s mode", e.Section, e.Mode)
-}
-
 // ParseStandaloneYAML decodes a standalone OBI v2 declarative document.
 func ParseStandaloneYAML(data []byte) (*Document, *Extension, error) {
 	raw, err := parseYAML(data)

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -1,0 +1,313 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package schema // import "go.opentelemetry.io/obi/internal/config/schema"
+
+import (
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+const SupportedVersion = "2.0"
+
+type DeploymentMode string
+
+const (
+	DeploymentModeStandalone DeploymentMode = "standalone"
+	DeploymentModeReceiver   DeploymentMode = "receiver"
+)
+
+type Document struct {
+	FileFormat     string         `yaml:"file_format"`
+	Resource       map[string]any `yaml:"resource"`
+	Propagator     map[string]any `yaml:"propagator"`
+	TracerProvider map[string]any `yaml:"tracer_provider"`
+	MeterProvider  map[string]any `yaml:"meter_provider"`
+	Extensions     Extensions     `yaml:"extensions"`
+	Raw            map[string]any `yaml:"-"`
+}
+
+type Extensions struct {
+	OBI *Extension `yaml:"obi"`
+}
+
+type Extension struct {
+	Version     string         `yaml:"version"`
+	Capture     Capture        `yaml:"capture"`
+	Enrich      map[string]any `yaml:"enrich,omitempty"`
+	Correlation map[string]any `yaml:"correlation,omitempty"`
+	Daemon      map[string]any `yaml:"daemon,omitempty"`
+	Raw         map[string]any `yaml:"-"`
+}
+
+type Capture struct {
+	Policy          map[string]any `yaml:"policy"`
+	Rules           []Rule         `yaml:"rules"`
+	Instrumentation map[string]any `yaml:"instrumentation"`
+	Runtimes        map[string]any `yaml:"runtimes"`
+	Network         map[string]any `yaml:"network"`
+	Limits          map[string]any `yaml:"limits"`
+	Engine          map[string]any `yaml:"engine"`
+	Safety          map[string]any `yaml:"safety"`
+	Channels        map[string]any `yaml:"channels"`
+	Telemetry       map[string]any `yaml:"telemetry"`
+	Raw             map[string]any `yaml:"-"`
+}
+
+type Rule struct {
+	Action      string         `yaml:"action"`
+	Name        string         `yaml:"name"`
+	Description string         `yaml:"description"`
+	Match       map[string]any `yaml:"match"`
+	Refine      RuleRefinement `yaml:"refine"`
+}
+
+type RuleRefinement struct {
+	Exports map[string]any `yaml:"exports,omitempty"`
+	HTTP    map[string]any `yaml:"http,omitempty"`
+}
+
+type NotV2Error struct {
+	Reason string
+}
+
+func (e *NotV2Error) Error() string {
+	if e == nil || e.Reason == "" {
+		return "configuration is not OBI config v2"
+	}
+	return "configuration is not OBI config v2: " + e.Reason
+}
+
+func (e *NotV2Error) Is(target error) bool {
+	_, ok := target.(*NotV2Error)
+	return ok
+}
+
+type UnsupportedVersionError struct {
+	Version string
+}
+
+func (e *UnsupportedVersionError) Error() string {
+	return fmt.Sprintf("unsupported OBI config version %q", e.Version)
+}
+
+type SectionNotAllowedError struct {
+	Mode    DeploymentMode
+	Section string
+}
+
+func (e *SectionNotAllowedError) Error() string {
+	if e.Mode == DeploymentModeReceiver {
+		return fmt.Sprintf(
+			"section %q is not allowed in %s mode; remove it from the receiver config or run this config in standalone mode",
+			e.Section,
+			e.Mode,
+		)
+	}
+	return fmt.Sprintf("section %q is not allowed in %s mode", e.Section, e.Mode)
+}
+
+func ParseYAML(data []byte, mode DeploymentMode) (*Document, *Extension, error) {
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, nil, fmt.Errorf("parsing config v2 YAML: %w", err)
+	}
+
+	return ParseMap(raw, mode)
+}
+
+func ParseMap(raw map[string]any, mode DeploymentMode) (*Document, *Extension, error) {
+	if len(raw) == 0 {
+		return nil, nil, &NotV2Error{Reason: "missing OBI v2 version field"}
+	}
+
+	if version, ok := nestedString(raw, "extensions", "obi", "version"); ok {
+		if version != SupportedVersion {
+			return nil, nil, &UnsupportedVersionError{Version: version}
+		}
+		return parseDocument(raw, mode)
+	}
+
+	if version, ok := nestedString(raw, "version"); ok {
+		if version != SupportedVersion {
+			return nil, nil, &UnsupportedVersionError{Version: version}
+		}
+		return parseReceiver(raw, mode)
+	}
+
+	if version, ok := nestedValue(raw, "extensions", "obi", "version"); ok {
+		return nil, nil, &UnsupportedVersionError{Version: fmt.Sprint(version)}
+	}
+
+	if version, ok := nestedValue(raw, "version"); ok {
+		return nil, nil, &UnsupportedVersionError{Version: fmt.Sprint(version)}
+	}
+
+	if looksLikeV1(raw) {
+		return nil, nil, &NotV2Error{Reason: "detected legacy v1 config shape"}
+	}
+
+	return nil, nil, &NotV2Error{Reason: "missing OBI v2 version field"}
+}
+
+func Validate(cfg *Extension, mode DeploymentMode) error {
+	if cfg == nil {
+		return errors.New("missing OBI config")
+	}
+	if cfg.Version != SupportedVersion {
+		return &UnsupportedVersionError{Version: cfg.Version}
+	}
+	if mode == DeploymentModeReceiver {
+		for _, section := range []string{"enrich", "correlation", "daemon"} {
+			if hasStandaloneSection(cfg, section) {
+				return &SectionNotAllowedError{Mode: mode, Section: section}
+			}
+		}
+	}
+	return nil
+}
+
+func parseDocument(raw map[string]any, mode DeploymentMode) (*Document, *Extension, error) {
+	var doc Document
+	if err := decode(raw, &doc); err != nil {
+		return nil, nil, err
+	}
+	doc.Raw = raw
+	if doc.Extensions.OBI == nil {
+		return nil, nil, &NotV2Error{Reason: "missing extensions.obi"}
+	}
+
+	doc.Extensions.OBI.Raw = nestedMap(raw, "extensions", "obi")
+	doc.Extensions.OBI.Capture.Raw = nestedMap(raw, "extensions", "obi", "capture")
+	if err := Validate(doc.Extensions.OBI, mode); err != nil {
+		return nil, nil, err
+	}
+	return &doc, doc.Extensions.OBI, nil
+}
+
+func parseReceiver(raw map[string]any, mode DeploymentMode) (*Document, *Extension, error) {
+	receiver := map[string]any{
+		"version":     raw["version"],
+		"capture":     map[string]any{},
+		"enrich":      raw["enrich"],
+		"correlation": raw["correlation"],
+		"daemon":      raw["daemon"],
+	}
+
+	capture := receiver["capture"].(map[string]any)
+	for _, key := range captureKeys() {
+		if value, ok := raw[key]; ok {
+			capture[key] = value
+		}
+	}
+
+	var cfg Extension
+	if err := decode(receiver, &cfg); err != nil {
+		return nil, nil, err
+	}
+	cfg.Raw = raw
+	cfg.Capture.Raw = capture
+	if err := Validate(&cfg, mode); err != nil {
+		return nil, nil, err
+	}
+	return nil, &cfg, nil
+}
+
+func hasStandaloneSection(cfg *Extension, section string) bool {
+	if cfg.Raw != nil {
+		_, ok := cfg.Raw[section]
+		return ok
+	}
+
+	switch section {
+	case "enrich":
+		return cfg.Enrich != nil
+	case "correlation":
+		return cfg.Correlation != nil
+	case "daemon":
+		return cfg.Daemon != nil
+	default:
+		return false
+	}
+}
+
+func looksLikeV1(raw map[string]any) bool {
+	for _, key := range []string{
+		"ebpf",
+		"discovery",
+		"otel_metrics_export",
+		"otel_traces_export",
+		"prometheus_export",
+		"attributes",
+		"routes",
+		"network",
+		"stats",
+		"javaagent",
+	} {
+		if _, ok := raw[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func captureKeys() []string {
+	return []string{
+		"policy",
+		"rules",
+		"instrumentation",
+		"runtimes",
+		"network",
+		"limits",
+		"engine",
+		"safety",
+		"channels",
+		"telemetry",
+	}
+}
+
+func decode(raw map[string]any, dst any) error {
+	buf, err := yaml.Marshal(raw)
+	if err != nil {
+		return fmt.Errorf("marshaling config v2 YAML: %w", err)
+	}
+	if err := yaml.Unmarshal(buf, dst); err != nil {
+		return fmt.Errorf("decoding config v2 YAML: %w", err)
+	}
+	return nil
+}
+
+func nestedMap(raw map[string]any, path ...string) map[string]any {
+	value, ok := nestedValue(raw, path...)
+	if !ok {
+		return nil
+	}
+	result, _ := value.(map[string]any)
+	return result
+}
+
+func nestedString(raw map[string]any, path ...string) (string, bool) {
+	value, ok := nestedValue(raw, path...)
+	if !ok {
+		return "", false
+	}
+	result, ok := value.(string)
+	return result, ok
+}
+
+func nestedValue(raw map[string]any, path ...string) (any, bool) {
+	cur := any(raw)
+	for _, key := range path {
+		next, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur, ok = next[key]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -1,6 +1,18 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Package schema parses OBI configuration documents that use the v2 schema.
+//
+// The parser recognizes both supported layouts:
+//   - a full OpenTelemetry declarative configuration document with the OBI
+//     extension at extensions.obi
+//   - a receiver-embedded OBI configuration with version and capture sections at
+//     the top level
+//
+// This package validates only the version, shape, and deployment-mode section
+// boundaries needed to route the configuration. It intentionally leaves nested
+// OBI sections as map values so migration and validation layers can preserve and
+// inspect the original keys.
 package schema // import "go.opentelemetry.io/obi/internal/config/schema"
 
 import (
@@ -10,15 +22,31 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// SupportedVersion is the OBI configuration schema version handled by this
+// package.
 const SupportedVersion = "2.0"
 
+// DeploymentMode identifies where an OBI v2 configuration will run.
 type DeploymentMode string
 
 const (
+	// DeploymentModeStandalone allows the full OBI extension, including sections
+	// that manage enrichment, correlation, and daemon behavior.
 	DeploymentModeStandalone DeploymentMode = "standalone"
-	DeploymentModeReceiver   DeploymentMode = "receiver"
+
+	// DeploymentModeReceiver allows only receiver-embeddable capture settings.
+	// Standalone-only sections are rejected because the Collector owns those
+	// concerns in receiver deployments.
+	DeploymentModeReceiver DeploymentMode = "receiver"
 )
 
+// Document is the top-level OpenTelemetry declarative configuration document
+// that contains extensions.obi.
+//
+// OBI-specific settings are available through Extensions.OBI. Other declarative
+// configuration sections are retained as maps because this package only needs to
+// locate and validate the OBI extension. Raw aliases the decoded YAML map passed
+// to ParseMap, or the map decoded by ParseYAML.
 type Document struct {
 	FileFormat     string         `yaml:"file_format"`
 	Resource       map[string]any `yaml:"resource"`
@@ -29,10 +57,18 @@ type Document struct {
 	Raw            map[string]any `yaml:"-"`
 }
 
+// Extensions holds declarative configuration extensions recognized by this
+// package.
 type Extensions struct {
 	OBI *Extension `yaml:"obi"`
 }
 
+// Extension is the OBI v2 extension configuration.
+//
+// Capture is valid in all deployment modes. Enrich, Correlation, and Daemon are
+// standalone-only sections and are rejected when validating receiver mode. Raw
+// aliases the source map for this extension in full documents and the top-level
+// source map in receiver-embedded configurations.
 type Extension struct {
 	Version     string         `yaml:"version"`
 	Capture     Capture        `yaml:"capture"`
@@ -42,6 +78,12 @@ type Extension struct {
 	Raw         map[string]any `yaml:"-"`
 }
 
+// Capture contains receiver-embeddable OBI capture settings.
+//
+// The individual sections remain map values so callers can preserve unknown
+// fields and apply schema-specific validation or migration elsewhere. Raw aliases
+// the source capture map in full documents and the synthesized capture map in
+// receiver-embedded configurations.
 type Capture struct {
 	Policy          map[string]any `yaml:"policy"`
 	Rules           []Rule         `yaml:"rules"`
@@ -56,6 +98,7 @@ type Capture struct {
 	Raw             map[string]any `yaml:"-"`
 }
 
+// Rule describes one capture policy rule.
 type Rule struct {
 	Action      string         `yaml:"action"`
 	Name        string         `yaml:"name"`
@@ -64,11 +107,17 @@ type Rule struct {
 	Refine      RuleRefinement `yaml:"refine"`
 }
 
+// RuleRefinement holds per-rule overrides that apply after a rule matches.
 type RuleRefinement struct {
 	Exports map[string]any `yaml:"exports,omitempty"`
 	HTTP    map[string]any `yaml:"http,omitempty"`
 }
 
+// NotV2Error reports input that does not contain an OBI v2 configuration.
+//
+// It is distinct from UnsupportedVersionError: NotV2Error means no usable OBI v2
+// version marker was found, while UnsupportedVersionError means a version marker
+// was found but is not supported by this package.
 type NotV2Error struct {
 	Reason string
 }
@@ -109,6 +158,11 @@ func (e *SectionNotAllowedError) Error() string {
 	return fmt.Sprintf("section %q is not allowed in %s mode", e.Section, e.Mode)
 }
 
+// ParseYAML decodes data as YAML and parses it as an OBI v2 configuration.
+//
+// Full declarative documents return both a Document and its OBI Extension.
+// Receiver-embedded configurations return a nil Document and the synthesized OBI
+// Extension. The mode controls validation of standalone-only sections.
 func ParseYAML(data []byte, mode DeploymentMode) (*Document, *Extension, error) {
 	var raw map[string]any
 	if err := yaml.Unmarshal(data, &raw); err != nil {
@@ -118,6 +172,13 @@ func ParseYAML(data []byte, mode DeploymentMode) (*Document, *Extension, error) 
 	return ParseMap(raw, mode)
 }
 
+// ParseMap parses a decoded YAML map as an OBI v2 configuration.
+//
+// A map with extensions.obi.version is treated as a full declarative document. A
+// map with a top-level version is treated as a receiver-embedded configuration,
+// where top-level capture sections are moved under Extension.Capture. Missing v2
+// markers return NotV2Error; present but unsupported markers return
+// UnsupportedVersionError.
 func ParseMap(raw map[string]any, mode DeploymentMode) (*Document, *Extension, error) {
 	if len(raw) == 0 {
 		return nil, nil, &NotV2Error{Reason: "missing OBI v2 version field"}
@@ -152,6 +213,8 @@ func ParseMap(raw map[string]any, mode DeploymentMode) (*Document, *Extension, e
 	return nil, nil, &NotV2Error{Reason: "missing OBI v2 version field"}
 }
 
+// Validate checks version support and deployment-mode section boundaries for an
+// already decoded OBI extension.
 func Validate(cfg *Extension, mode DeploymentMode) error {
 	if cfg == nil {
 		return errors.New("missing OBI config")
@@ -169,6 +232,8 @@ func Validate(cfg *Extension, mode DeploymentMode) error {
 	return nil
 }
 
+// parseDocument decodes the full declarative layout and wires Raw fields to the
+// corresponding source maps.
 func parseDocument(raw map[string]any, mode DeploymentMode) (*Document, *Extension, error) {
 	var doc Document
 	if err := decode(raw, &doc); err != nil {
@@ -187,6 +252,9 @@ func parseDocument(raw map[string]any, mode DeploymentMode) (*Document, *Extensi
 	return &doc, doc.Extensions.OBI, nil
 }
 
+// parseReceiver adapts the receiver-embedded layout into Extension. Capture
+// sections are accepted at the top level in receiver configuration files, but the
+// resulting value uses the same Extension shape as full documents.
 func parseReceiver(raw map[string]any, mode DeploymentMode) (*Document, *Extension, error) {
 	receiver := map[string]any{
 		"version":     raw["version"],
@@ -253,6 +321,8 @@ func looksLikeV1(raw map[string]any) bool {
 	return false
 }
 
+// captureKeys lists top-level receiver-embedded sections that belong under
+// Extension.Capture in the normalized representation.
 func captureKeys() []string {
 	return []string{
 		"policy",

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -156,6 +156,9 @@ func ParseReceiverYAML(data []byte) (*Extension, error) {
 		if version != SupportedVersion {
 			return nil, &UnsupportedVersionError{Version: version}
 		}
+		if section, ok := disallowedReceiverSection(root); ok {
+			return nil, &SectionNotAllowedError{Mode: string(validationModeReceiver), Section: section}
+		}
 		var receiver receiverConfig
 		if err := decode(root, &receiver); err != nil {
 			return nil, err
@@ -211,6 +214,15 @@ func validate(cfg *Extension, mode validationMode) error {
 		}
 	}
 	return nil
+}
+
+func disallowedReceiverSection(root *yaml.Node) (string, bool) {
+	for _, section := range []string{"enrich", "correlation", "daemon"} {
+		if _, ok := mappingValue(root, section); ok {
+			return section, true
+		}
+	}
+	return "", false
 }
 
 func hasStandaloneSection(cfg *Extension, section string) bool {

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -251,7 +251,6 @@ func looksLikeV1(root *yaml.Node) bool {
 		"prometheus_export",
 		"attributes",
 		"routes",
-		"network",
 		"stats",
 		"javaagent",
 	} {

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -224,6 +224,10 @@ func ParseStandaloneMap(raw map[string]any) (*Document, *Extension, error) {
 		return nil, nil, &UnsupportedVersionError{Version: fmt.Sprint(version)}
 	}
 
+	if _, ok := nestedValue(raw, "version"); ok {
+		return nil, nil, &NotV2Error{Reason: "missing extensions.obi.version field"}
+	}
+
 	if looksLikeV1(raw) {
 		return nil, nil, &NotV2Error{Reason: "detected legacy v1 config shape"}
 	}

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -3,11 +3,13 @@
 
 // Package schema parses OBI configuration documents that use the v2 schema.
 //
-// The parser recognizes both supported layouts:
+// Callers choose the parser that matches the deployment target. The package does
+// not auto-detect deployment mode because standalone and receiver deployments
+// allow different sections:
 //   - a full OpenTelemetry declarative configuration document with the OBI
-//     extension at extensions.obi
+//     extension at extensions.obi, parsed by ParseStandaloneYAML
 //   - a receiver-embedded OBI configuration with version and capture sections at
-//     the top level
+//     the top level, parsed by ParseReceiverYAML
 //
 // This package validates only the version, shape, and deployment-specific
 // section boundaries needed to route the configuration. It intentionally leaves
@@ -36,9 +38,9 @@ const (
 // Document is the top-level OpenTelemetry declarative configuration document
 // that contains extensions.obi.
 //
-// OBI-specific settings are available through Extensions.OBI. Other declarative
-// configuration sections are retained as maps because this package only needs to
-// locate and validate the OBI extension.
+// OBI-specific settings are available through Extensions.OBI. Declarative
+// configuration sections that can influence later conversion are retained as maps
+// because this package only needs to locate and validate the OBI extension.
 type Document struct {
 	FileFormat     string         `yaml:"file_format"`
 	Resource       map[string]any `yaml:"resource"`
@@ -57,7 +59,9 @@ type Extensions struct {
 // Extension is the OBI v2 extension configuration.
 //
 // Capture is valid in all deployment modes. Enrich, Correlation, and Daemon are
-// standalone-only sections and are rejected when validating receiver mode.
+// standalone-only sections and are rejected when parsing receiver-embedded
+// configuration. ParseReceiverYAML synthesizes this shape from top-level receiver
+// capture sections.
 type Extension struct {
 	Version     string         `yaml:"version"`
 	Capture     Capture        `yaml:"capture"`
@@ -68,8 +72,9 @@ type Extension struct {
 
 // Capture contains receiver-embeddable OBI capture settings.
 //
-// The individual sections remain map values so callers can preserve unknown
-// fields and apply schema-specific validation or migration elsewhere.
+// Known capture sections remain map values so callers can preserve unknown fields
+// inside those sections and apply schema-specific validation or migration
+// elsewhere.
 type Capture struct {
 	Policy          map[string]any `yaml:"policy"`
 	Rules           []Rule         `yaml:"rules"`
@@ -98,6 +103,9 @@ type RuleRefinement struct {
 	HTTP    map[string]any `yaml:"http,omitempty"`
 }
 
+// receiverConfig mirrors the receiver-embedded layout, where capture sections
+// appear beside version at the top level instead of under an extension.capture
+// object.
 type receiverConfig struct {
 	Version     string `yaml:"version"`
 	Capture     `yaml:",inline"`
@@ -107,6 +115,10 @@ type receiverConfig struct {
 }
 
 // ParseStandaloneYAML decodes a standalone OBI v2 declarative document.
+//
+// The document must contain extensions.obi.version equal to SupportedVersion.
+// Missing v2 markers return NotV2Error; present but unsupported markers return
+// UnsupportedVersionError.
 func ParseStandaloneYAML(data []byte) (*Document, *Extension, error) {
 	root, err := parseYAML(data)
 	if err != nil {
@@ -146,6 +158,10 @@ func ParseStandaloneYAML(data []byte) (*Document, *Extension, error) {
 }
 
 // ParseReceiverYAML decodes a receiver-embedded OBI v2 configuration.
+//
+// Receiver capture sections are accepted at the top level and normalized into
+// Extension.Capture. Standalone-only keys are rejected by presence before decode
+// so null or malformed values still report SectionNotAllowedError.
 func ParseReceiverYAML(data []byte) (*Extension, error) {
 	root, err := parseYAML(data)
 	if err != nil {
@@ -192,7 +208,8 @@ func ValidateStandalone(cfg *Extension) error {
 	return validate(cfg, validationModeStandalone)
 }
 
-// ValidateReceiver checks version support and receiver section boundaries.
+// ValidateReceiver checks version support and receiver section boundaries for an
+// already decoded OBI extension.
 func ValidateReceiver(cfg *Extension) error {
 	return validate(cfg, validationModeReceiver)
 }

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -1,0 +1,283 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseYAMLStandaloneDocument(t *testing.T) {
+	t.Parallel()
+
+	doc, cfg, err := ParseYAML([]byte(`
+file_format: "1.0"
+resource:
+  attributes:
+    service.namespace: checkout
+propagator:
+  composite: [tracecontext, baggage]
+tracer_provider:
+  sampler:
+    parent_based:
+      root:
+        always_on: {}
+meter_provider:
+  readers:
+    - periodic: {}
+instrumentation/development:
+  ignored: true
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      policy:
+        default_action: include
+      rules:
+        - action: include
+          name: checkout
+          match:
+            process:
+              exe_path_glob: ["/usr/bin/checkout"]
+          refine:
+            exports:
+              traces: false
+              metrics: true
+            http:
+              routes:
+                unmatched: wildcard
+                patterns: ["/orders/{id}"]
+              filters:
+                traces:
+                  status_code: ["5*"]
+`), DeploymentModeStandalone)
+
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.NotNil(t, cfg)
+	require.Equal(t, "1.0", doc.FileFormat)
+	require.Equal(t, SupportedVersion, cfg.Version)
+	require.Equal(t, map[string]any{
+		"root": map[string]any{
+			"always_on": map[string]any{},
+		},
+	}, nestedMap(doc.TracerProvider, "sampler", "parent_based"))
+	require.Equal(t, []any{map[string]any{"periodic": map[string]any{}}}, doc.MeterProvider["readers"])
+	require.Equal(t, "include", cfg.Capture.Policy["default_action"])
+	require.Len(t, cfg.Capture.Rules, 1)
+	require.Equal(t, map[string]any{"traces": false, "metrics": true}, cfg.Capture.Rules[0].Refine.Exports)
+	require.Equal(t, map[string]any{
+		"routes": map[string]any{
+			"unmatched": "wildcard",
+			"patterns":  []any{"/orders/{id}"},
+		},
+		"filters": map[string]any{
+			"traces": map[string]any{
+				"status_code": []any{"5*"},
+			},
+		},
+	}, cfg.Capture.Rules[0].Refine.HTTP)
+}
+
+func TestParseYAMLReceiverEmbedded(t *testing.T) {
+	t.Parallel()
+
+	doc, cfg, err := ParseYAML([]byte(`
+version: "2.0"
+policy:
+  default_action: exclude
+rules:
+  - action: include
+    match:
+      process:
+        open_ports: 8080,8443
+instrumentation:
+  http:
+    enabled:
+      traces: true
+      metrics: false
+channels:
+  buffer_len: 123
+`), DeploymentModeReceiver)
+
+	require.NoError(t, err)
+	require.Nil(t, doc)
+	require.NotNil(t, cfg)
+	require.Equal(t, SupportedVersion, cfg.Version)
+	require.Equal(t, "exclude", cfg.Capture.Policy["default_action"])
+	require.Len(t, cfg.Capture.Rules, 1)
+	require.Equal(t, "8080,8443", nestedMap(cfg.Capture.Rules[0].Match, "process")["open_ports"])
+	require.Equal(t, map[string]any{"buffer_len": 123}, cfg.Capture.Channels)
+	require.True(t, nestedMap(cfg.Capture.Instrumentation, "http", "enabled")["traces"].(bool))
+	require.False(t, nestedMap(cfg.Capture.Instrumentation, "http", "enabled")["metrics"].(bool))
+}
+
+func TestReceiverRejectsStandaloneSections(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{"enrich", "correlation", "daemon"}
+	for _, section := range tests {
+		t.Run(section, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := ParseMap(map[string]any{
+				"version": "2.0",
+				section:   map[string]any{},
+			}, DeploymentModeReceiver)
+
+			var notAllowed *SectionNotAllowedError
+			require.ErrorAs(t, err, &notAllowed)
+			require.Equal(t, DeploymentModeReceiver, notAllowed.Mode)
+			require.Equal(t, section, notAllowed.Section)
+			require.Contains(t, err.Error(), "standalone mode")
+		})
+	}
+}
+
+func TestStandaloneAllowsStandaloneSections(t *testing.T) {
+	t.Parallel()
+
+	_, cfg, err := ParseYAML([]byte(`
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      policy:
+        default_action: include
+    enrich: {}
+    correlation: {}
+    daemon: {}
+`), DeploymentModeStandalone)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+}
+
+func TestUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		yaml string
+		mode DeploymentMode
+		want string
+	}{
+		{
+			name: "document",
+			yaml: `
+file_format: "1.0"
+extensions:
+  obi:
+    version: "3.0"
+`,
+			mode: DeploymentModeStandalone,
+			want: "3.0",
+		},
+		{
+			name: "receiver",
+			yaml: `
+version: "3.0"
+`,
+			mode: DeploymentModeReceiver,
+			want: "3.0",
+		},
+		{
+			name: "non string",
+			yaml: `
+version: 2.0
+`,
+			mode: DeploymentModeReceiver,
+			want: "2",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := ParseYAML([]byte(test.yaml), test.mode)
+
+			var unsupported *UnsupportedVersionError
+			require.ErrorAs(t, err, &unsupported)
+			require.Equal(t, test.want, unsupported.Version)
+		})
+	}
+}
+
+func TestNotV2(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "empty",
+			yaml: "",
+			want: "missing OBI v2 version field",
+		},
+		{
+			name: "missing version",
+			yaml: "file_format: \"1.0\"\n",
+			want: "missing OBI v2 version field",
+		},
+		{
+			name: "v1",
+			yaml: `
+ebpf: {}
+discovery: {}
+otel_metrics_export: {}
+otel_traces_export: {}
+prometheus_export: {}
+network: {}
+stats: {}
+`,
+			want: "detected legacy v1 config shape",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := ParseYAML([]byte(test.yaml), DeploymentModeStandalone)
+
+			var notV2 *NotV2Error
+			require.ErrorAs(t, err, &notV2)
+			require.Contains(t, err.Error(), test.want)
+		})
+	}
+}
+
+func TestParseMapPreservesDocumentRaw(t *testing.T) {
+	t.Parallel()
+
+	raw := map[string]any{
+		"file_format": "1.0",
+		"extensions": map[string]any{
+			"obi": map[string]any{
+				"version": "2.0",
+				"capture": map[string]any{
+					"policy": map[string]any{
+						"default_action": "include",
+					},
+				},
+			},
+		},
+	}
+
+	doc, cfg, err := ParseMap(raw, DeploymentModeStandalone)
+
+	require.NoError(t, err)
+	doc.Raw["added"] = true
+	cfg.Raw["added_to_extension"] = true
+	cfg.Capture.Raw["added_to_capture"] = true
+
+	require.True(t, raw["added"].(bool))
+	require.True(t, raw["extensions"].(map[string]any)["obi"].(map[string]any)["added_to_extension"].(bool))
+	require.True(t, cfg.Raw["capture"].(map[string]any)["added_to_capture"].(bool))
+}

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -261,6 +261,31 @@ stats: {}
 	}
 }
 
+func TestSpecificParsersRejectWrongLayout(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ParseStandaloneYAML([]byte(`
+version: "2.0"
+policy:
+  default_action: include
+network: {}
+`))
+	var standaloneNotV2 *NotV2Error
+	require.ErrorAs(t, err, &standaloneNotV2)
+	require.Contains(t, err.Error(), "missing extensions.obi.version field")
+
+	_, err = ParseReceiverYAML([]byte(`
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture: {}
+`))
+	var receiverNotV2 *NotV2Error
+	require.ErrorAs(t, err, &receiverNotV2)
+	require.Contains(t, err.Error(), "missing top-level OBI v2 version field")
+}
+
 func TestParseYAMLAutoDetectsLayout(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -116,18 +116,32 @@ channels:
 func TestReceiverRejectsStandaloneSections(t *testing.T) {
 	t.Parallel()
 
-	tests := []string{"enrich", "correlation", "daemon"}
-	for _, section := range tests {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "map", value: "{}"},
+		{name: "implicit null", value: ""},
+		{name: "explicit null", value: "null"},
+		{name: "list", value: "[]"},
+	}
+	for _, section := range []string{"enrich", "correlation", "daemon"} {
 		t.Run(section, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := ParseReceiverYAML([]byte("version: \"2.0\"\n" + section + ": {}\n"))
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					t.Parallel()
 
-			var notAllowed *SectionNotAllowedError
-			require.ErrorAs(t, err, &notAllowed)
-			require.Equal(t, string(validationModeReceiver), notAllowed.Mode)
-			require.Equal(t, section, notAllowed.Section)
-			require.Contains(t, err.Error(), "standalone mode")
+					_, err := ParseReceiverYAML([]byte("version: \"2.0\"\n" + section + ": " + test.value + "\n"))
+
+					var notAllowed *SectionNotAllowedError
+					require.ErrorAs(t, err, &notAllowed)
+					require.Equal(t, string(validationModeReceiver), notAllowed.Mode)
+					require.Equal(t, section, notAllowed.Section)
+					require.Contains(t, err.Error(), "standalone mode")
+				})
+			}
 		})
 	}
 }

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -215,7 +215,7 @@ version: 2.0
 	}
 }
 
-func TestNotV2(t *testing.T) {
+func TestStandaloneNotV2(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -226,12 +226,12 @@ func TestNotV2(t *testing.T) {
 		{
 			name: "empty",
 			yaml: "",
-			want: "missing OBI v2 version field",
+			want: "missing extensions.obi.version field",
 		},
 		{
 			name: "missing version",
 			yaml: "file_format: \"1.0\"\n",
-			want: "missing OBI v2 version field",
+			want: "missing extensions.obi.version field",
 		},
 		{
 			name: "v1",
@@ -252,7 +252,53 @@ stats: {}
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, _, err := ParseYAML([]byte(test.yaml))
+			_, _, err := ParseStandaloneYAML([]byte(test.yaml))
+
+			var notV2 *NotV2Error
+			require.ErrorAs(t, err, &notV2)
+			require.Contains(t, err.Error(), test.want)
+		})
+	}
+}
+
+func TestReceiverNotV2(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "empty",
+			yaml: "",
+			want: "missing top-level OBI v2 version field",
+		},
+		{
+			name: "missing version",
+			yaml: "policy: {}\n",
+			want: "missing top-level OBI v2 version field",
+		},
+		{
+			name: "v1",
+			yaml: `
+ebpf: {}
+discovery: {}
+otel_metrics_export: {}
+otel_traces_export: {}
+prometheus_export: {}
+network: {}
+stats: {}
+`,
+			want: "detected legacy v1 config shape",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseReceiverYAML([]byte(test.yaml))
 
 			var notV2 *NotV2Error
 			require.ErrorAs(t, err, &notV2)
@@ -284,31 +330,6 @@ extensions:
 	var receiverNotV2 *NotV2Error
 	require.ErrorAs(t, err, &receiverNotV2)
 	require.Contains(t, err.Error(), "missing top-level OBI v2 version field")
-}
-
-func TestParseYAMLAutoDetectsLayout(t *testing.T) {
-	t.Parallel()
-
-	doc, cfg, err := ParseYAML([]byte(`
-file_format: "1.0"
-extensions:
-  obi:
-    version: "2.0"
-    capture: {}
-`))
-	require.NoError(t, err)
-	require.NotNil(t, doc)
-	require.NotNil(t, cfg)
-
-	doc, cfg, err = ParseYAML([]byte(`
-version: "2.0"
-policy:
-  default_action: include
-`))
-	require.NoError(t, err)
-	require.Nil(t, doc)
-	require.NotNil(t, cfg)
-	require.Equal(t, "include", cfg.Capture.Policy["default_action"])
 }
 
 func TestParseMapPreservesDocumentRaw(t *testing.T) {

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -125,7 +125,7 @@ func TestReceiverRejectsStandaloneSections(t *testing.T) {
 		{name: "explicit null", value: "null"},
 		{name: "list", value: "[]"},
 	}
-	for _, section := range []string{"enrich", "correlation", "daemon"} {
+	for _, section := range []string{sectionEnrich, sectionCorrelation, sectionDaemon} {
 		t.Run(section, func(t *testing.T) {
 			t.Parallel()
 
@@ -137,8 +137,8 @@ func TestReceiverRejectsStandaloneSections(t *testing.T) {
 
 					var notAllowed *SectionNotAllowedError
 					require.ErrorAs(t, err, &notAllowed)
-					require.Equal(t, string(validationModeReceiver), notAllowed.Mode)
 					require.Equal(t, section, notAllowed.Section)
+					require.Contains(t, err.Error(), "receiver config")
 					require.Contains(t, err.Error(), "standalone mode")
 				})
 			}
@@ -164,6 +164,44 @@ extensions:
 
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
+}
+
+func TestValidateReceiverRejectsDecodedStandaloneSections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     Extension
+		section string
+	}{
+		{
+			name:    sectionEnrich,
+			cfg:     Extension{Version: SupportedVersion, Enrich: map[string]any{}},
+			section: sectionEnrich,
+		},
+		{
+			name:    sectionCorrelation,
+			cfg:     Extension{Version: SupportedVersion, Correlation: map[string]any{}},
+			section: sectionCorrelation,
+		},
+		{
+			name:    sectionDaemon,
+			cfg:     Extension{Version: SupportedVersion, Daemon: map[string]any{}},
+			section: sectionDaemon,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateReceiver(&test.cfg)
+
+			var notAllowed *SectionNotAllowedError
+			require.ErrorAs(t, err, &notAllowed)
+			require.Equal(t, test.section, notAllowed.Section)
+		})
+	}
 }
 
 func TestUnsupportedVersion(t *testing.T) {

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -121,10 +121,7 @@ func TestReceiverRejectsStandaloneSections(t *testing.T) {
 		t.Run(section, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := ParseReceiverMap(map[string]any{
-				"version": "2.0",
-				section:   map[string]any{},
-			})
+			_, err := ParseReceiverYAML([]byte("version: \"2.0\"\n" + section + ": {}\n"))
 
 			var notAllowed *SectionNotAllowedError
 			require.ErrorAs(t, err, &notAllowed)
@@ -198,7 +195,7 @@ version: 2.0
 				_, err := ParseReceiverYAML(data)
 				return err
 			},
-			want: "2",
+			want: "2.0",
 		},
 	}
 
@@ -332,31 +329,11 @@ extensions:
 	require.Contains(t, err.Error(), "missing top-level OBI v2 version field")
 }
 
-func TestParseMapPreservesDocumentRaw(t *testing.T) {
-	t.Parallel()
-
-	raw := map[string]any{
-		"file_format": "1.0",
-		"extensions": map[string]any{
-			"obi": map[string]any{
-				"version": "2.0",
-				"capture": map[string]any{
-					"policy": map[string]any{
-						"default_action": "include",
-					},
-				},
-			},
-		},
+func nestedMap(raw map[string]any, path ...string) map[string]any {
+	cur := raw
+	for _, key := range path {
+		next, _ := cur[key].(map[string]any)
+		cur = next
 	}
-
-	doc, cfg, err := ParseStandaloneMap(raw)
-
-	require.NoError(t, err)
-	doc.Raw["added"] = true
-	cfg.Raw["added_to_extension"] = true
-	cfg.Capture.Raw["added_to_capture"] = true
-
-	require.True(t, raw["added"].(bool))
-	require.True(t, raw["extensions"].(map[string]any)["obi"].(map[string]any)["added_to_extension"].(bool))
-	require.True(t, cfg.Raw["capture"].(map[string]any)["added_to_capture"].(bool))
+	return cur
 }

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseYAMLStandaloneDocument(t *testing.T) {
+func TestParseStandaloneYAMLDocument(t *testing.T) {
 	t.Parallel()
 
-	doc, cfg, err := ParseYAML([]byte(`
+	doc, cfg, err := ParseStandaloneYAML([]byte(`
 file_format: "1.0"
 resource:
   attributes:
@@ -52,7 +52,7 @@ extensions:
               filters:
                 traces:
                   status_code: ["5*"]
-`), DeploymentModeStandalone)
+`))
 
 	require.NoError(t, err)
 	require.NotNil(t, doc)
@@ -81,10 +81,10 @@ extensions:
 	}, cfg.Capture.Rules[0].Refine.HTTP)
 }
 
-func TestParseYAMLReceiverEmbedded(t *testing.T) {
+func TestParseReceiverYAMLEmbedded(t *testing.T) {
 	t.Parallel()
 
-	doc, cfg, err := ParseYAML([]byte(`
+	cfg, err := ParseReceiverYAML([]byte(`
 version: "2.0"
 policy:
   default_action: exclude
@@ -100,10 +100,9 @@ instrumentation:
       metrics: false
 channels:
   buffer_len: 123
-`), DeploymentModeReceiver)
+`))
 
 	require.NoError(t, err)
-	require.Nil(t, doc)
 	require.NotNil(t, cfg)
 	require.Equal(t, SupportedVersion, cfg.Version)
 	require.Equal(t, "exclude", cfg.Capture.Policy["default_action"])
@@ -122,14 +121,14 @@ func TestReceiverRejectsStandaloneSections(t *testing.T) {
 		t.Run(section, func(t *testing.T) {
 			t.Parallel()
 
-			_, _, err := ParseMap(map[string]any{
+			_, err := ParseReceiverMap(map[string]any{
 				"version": "2.0",
 				section:   map[string]any{},
-			}, DeploymentModeReceiver)
+			})
 
 			var notAllowed *SectionNotAllowedError
 			require.ErrorAs(t, err, &notAllowed)
-			require.Equal(t, DeploymentModeReceiver, notAllowed.Mode)
+			require.Equal(t, string(validationModeReceiver), notAllowed.Mode)
 			require.Equal(t, section, notAllowed.Section)
 			require.Contains(t, err.Error(), "standalone mode")
 		})
@@ -139,7 +138,7 @@ func TestReceiverRejectsStandaloneSections(t *testing.T) {
 func TestStandaloneAllowsStandaloneSections(t *testing.T) {
 	t.Parallel()
 
-	_, cfg, err := ParseYAML([]byte(`
+	_, cfg, err := ParseStandaloneYAML([]byte(`
 file_format: "1.0"
 extensions:
   obi:
@@ -150,7 +149,7 @@ extensions:
     enrich: {}
     correlation: {}
     daemon: {}
-`), DeploymentModeStandalone)
+`))
 
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
@@ -160,10 +159,10 @@ func TestUnsupportedVersion(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		yaml string
-		mode DeploymentMode
-		want string
+		name  string
+		yaml  string
+		parse func([]byte) error
+		want  string
 	}{
 		{
 			name: "document",
@@ -173,7 +172,10 @@ extensions:
   obi:
     version: "3.0"
 `,
-			mode: DeploymentModeStandalone,
+			parse: func(data []byte) error {
+				_, _, err := ParseStandaloneYAML(data)
+				return err
+			},
 			want: "3.0",
 		},
 		{
@@ -181,7 +183,10 @@ extensions:
 			yaml: `
 version: "3.0"
 `,
-			mode: DeploymentModeReceiver,
+			parse: func(data []byte) error {
+				_, err := ParseReceiverYAML(data)
+				return err
+			},
 			want: "3.0",
 		},
 		{
@@ -189,7 +194,10 @@ version: "3.0"
 			yaml: `
 version: 2.0
 `,
-			mode: DeploymentModeReceiver,
+			parse: func(data []byte) error {
+				_, err := ParseReceiverYAML(data)
+				return err
+			},
 			want: "2",
 		},
 	}
@@ -198,7 +206,7 @@ version: 2.0
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, _, err := ParseYAML([]byte(test.yaml), test.mode)
+			err := test.parse([]byte(test.yaml))
 
 			var unsupported *UnsupportedVersionError
 			require.ErrorAs(t, err, &unsupported)
@@ -244,13 +252,38 @@ stats: {}
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, _, err := ParseYAML([]byte(test.yaml), DeploymentModeStandalone)
+			_, _, err := ParseYAML([]byte(test.yaml))
 
 			var notV2 *NotV2Error
 			require.ErrorAs(t, err, &notV2)
 			require.Contains(t, err.Error(), test.want)
 		})
 	}
+}
+
+func TestParseYAMLAutoDetectsLayout(t *testing.T) {
+	t.Parallel()
+
+	doc, cfg, err := ParseYAML([]byte(`
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture: {}
+`))
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.NotNil(t, cfg)
+
+	doc, cfg, err = ParseYAML([]byte(`
+version: "2.0"
+policy:
+  default_action: include
+`))
+	require.NoError(t, err)
+	require.Nil(t, doc)
+	require.NotNil(t, cfg)
+	require.Equal(t, "include", cfg.Capture.Policy["default_action"])
 }
 
 func TestParseMapPreservesDocumentRaw(t *testing.T) {
@@ -270,7 +303,7 @@ func TestParseMapPreservesDocumentRaw(t *testing.T) {
 		},
 	}
 
-	doc, cfg, err := ParseMap(raw, DeploymentModeStandalone)
+	doc, cfg, err := ParseStandaloneMap(raw)
 
 	require.NoError(t, err)
 	doc.Raw["added"] = true

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -329,6 +329,15 @@ func TestReceiverNotV2(t *testing.T) {
 			want: "missing top-level OBI v2 version field",
 		},
 		{
+			name: "missing version with network capture",
+			yaml: `
+network:
+  capture:
+    enabled: true
+`,
+			want: "missing top-level OBI v2 version field",
+		},
+		{
 			name: "v1",
 			yaml: `
 ebpf: {}


### PR DESCRIPTION
## Summary

Adds the first internal implementation slice for config v2 from #2251:

- add hidden `internal/config/schema` parser/model types for the OBI v2 extension shape
- support standalone OTel declarative documents and receiver-embedded capture config
- add structured not-v2, unsupported-version, and receiver-only validation errors
- cover version detection, standalone vs receiver validation, raw map preservation, and rule/refine parsing with unit tests

## Context

Parent issue: #2251

This is the first serial implementation PR from the "Internal config schema package" item in the config v2 landing plan. It is based on the accepted v2 design from #1351 and the implementation PoC from #2080, but intentionally keeps the change internal-only.

## Scope

This PR does not add a public `pkg/config/v2` package, CLI commands, runtime v2 parsing, Collector receiver v2 parsing, generated artifacts, or user-facing config v2 docs.

## Tests

- `go test ./internal/config/schema`
- `go test ./internal/config/...`
- `go test -race ./internal/config/schema`
- `go vet ./internal/config/schema`
- `go tool golangci-lint run ./internal/config/schema --timeout=6m -v`