### PR TITLE
Add lint-fix import and collectt fixers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,10 +141,12 @@ lint: lint-run
 
 .PHONY: lint-fix
 lint-fix: LINT_EXTRA_ARGS = --fix
-lint-fix: lint-run
+lint-fix: lint-fix-run
 
-.PHONY: lint-run
+.PHONY: lint-run lint-fix-run
 lint-run: vanity-import-check lint-dependency-policy lint-collectt
+lint-fix-run: vanity-import-fix-check lint-dependency-policy lint-collectt
+lint-run lint-fix-run:
 	@echo "### Linting code"
 	go tool $(TOOLS_MODFILE) golangci-lint run ./... --timeout=6m $(LINT_EXTRA_ARGS)
 
@@ -870,8 +872,9 @@ check-ebpf-ver-synced:
 		exit 1; \
 	fi
 
-.PHONY: vanity-import-check
-vanity-import-check:
+.PHONY: vanity-import-check vanity-import-fix-check
+vanity-import-fix-check: vanity-import-fix
+vanity-import-check vanity-import-fix-check:
 	go tool $(TOOLS_MODFILE) porto --include-internal --skip-dirs "^NOTICES$$" -l . || ( echo "(run: make vanity-import-fix)"; exit 1 )
 
 .PHONY: vanity-import-fix

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ lint-fix: lint-fix-run
 
 .PHONY: lint-run lint-fix-run
 lint-run: vanity-import-check lint-dependency-policy lint-collectt
-lint-fix-run: vanity-import-fix-check lint-dependency-policy lint-collectt
+lint-fix-run: vanity-import-fix-check lint-dependency-policy lint-collectt-fix
 lint-run lint-fix-run:
 	@echo "### Linting code"
 	go tool $(TOOLS_MODFILE) golangci-lint run ./... --timeout=6m $(LINT_EXTRA_ARGS)
@@ -170,6 +170,11 @@ lint-dependency-policy:
 lint-collectt:
 	@echo "### Checking EventuallyWithT callbacks use CollectT"
 	go run ./internal/test/analyzer/collectt/cmd/collecttlint ./...
+
+.PHONY: lint-collectt-fix
+lint-collectt-fix:
+	@echo "### Fixing EventuallyWithT callbacks to use CollectT"
+	go run ./internal/test/analyzer/collectt/cmd/collecttlint -fix ./...
 
 MARKDOWNIMAGE := $(shell awk '$$4=="markdown" {print $$2}' $(DEPENDENCIES_DOCKERFILE))
 .PHONY: lint-markdown

--- a/Makefile
+++ b/Makefile
@@ -140,12 +140,13 @@ lint: LINT_EXTRA_ARGS =
 lint: lint-run
 
 .PHONY: lint-fix
-lint-fix: LINT_EXTRA_ARGS = --fix
 lint-fix: lint-fix-run
 
 .PHONY: lint-run lint-fix-run
 lint-run: vanity-import-check lint-dependency-policy lint-collectt
+lint-fix-run: LINT_EXTRA_ARGS = --fix
 lint-fix-run: vanity-import-fix-check lint-dependency-policy lint-collectt-fix
+.NOTPARALLEL: lint-fix-run
 lint-run lint-fix-run:
 	@echo "### Linting code"
 	go tool $(TOOLS_MODFILE) golangci-lint run ./... --timeout=6m $(LINT_EXTRA_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,8 @@ lint-collectt:
 lint-collectt-fix:
 	@echo "### Fixing EventuallyWithT callbacks to use CollectT"
 	go run ./internal/test/analyzer/collectt/cmd/collecttlint -fix ./...
+	@echo "### Checking EventuallyWithT callbacks use CollectT"
+	go run ./internal/test/analyzer/collectt/cmd/collecttlint ./...
 
 MARKDOWNIMAGE := $(shell awk '$$4=="markdown" {print $$2}' $(DEPENDENCIES_DOCKERFILE))
 .PHONY: lint-markdown

--- a/internal/test/analyzer/collectt/collectt.go
+++ b/internal/test/analyzer/collectt/collectt.go
@@ -30,8 +30,7 @@ func run(pass *analysis.Pass) (any, error) {
 		call := n.(*ast.CallExpr)
 
 		// Match *.EventuallyWithT(t, func(ct *assert.CollectT) { ... }, ...)
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != "EventuallyWithT" {
+		if !isEventuallyWithTCall(call) {
 			return
 		}
 
@@ -69,6 +68,7 @@ func run(pass *analysis.Pass) (any, error) {
 		if collectTObj == nil {
 			return
 		}
+		collectTName := collectTParam.Names[0].Name
 
 		// Walk the callback body looking for assert/require calls whose
 		// first argument is the outer *testing.T instead of the CollectT param.
@@ -82,47 +82,59 @@ func run(pass *analysis.Pass) (any, error) {
 			if !ok {
 				return true
 			}
+			nestedEventuallyWithT := isEventuallyWithTCall(innerCall)
 
 			// Check the receiver is an assert or require package.
 			if !isAssertOrRequire(pass, innerSel) {
-				return true
+				return !nestedEventuallyWithT
 			}
 
 			// The first argument to assert/require methods is the TestingT.
 			if len(innerCall.Args) == 0 {
-				return true
+				return !nestedEventuallyWithT
 			}
 
 			argObj := resolveIdentFromInfo(pass, innerCall.Args[0])
 			if argObj == nil {
-				return true
+				return !nestedEventuallyWithT
 			}
 
 			// Flag if the first arg resolves to the outer *testing.T
 			// rather than the callback's *assert.CollectT parameter.
 			if argObj == outerTObj && argObj != collectTObj {
-				collectTName := collectTParam.Names[0].Name
-				pass.Report(analysis.Diagnostic{
-					Pos: innerCall.Args[0].Pos(),
-					End: innerCall.Args[0].End(),
-					Message: "use " + collectTName + " instead of " + outerTIdent.Name +
-						" inside EventuallyWithT callback",
-					SuggestedFixes: []analysis.SuggestedFix{{
-						Message: "Use CollectT callback parameter",
-						TextEdits: []analysis.TextEdit{{
-							Pos:     innerCall.Args[0].Pos(),
-							End:     innerCall.Args[0].End(),
-							NewText: []byte(collectTName),
-						}},
-					}},
-				})
+				reportCollectTDiagnostic(pass, innerCall.Args[0], outerTIdent.Name, collectTName)
 			}
 
-			return true
+			return !nestedEventuallyWithT
 		})
 	})
 
 	return nil, nil
+}
+
+func reportCollectTDiagnostic(pass *analysis.Pass, arg ast.Expr, outerTName, collectTName string) {
+	diagnostic := analysis.Diagnostic{
+		Pos: arg.Pos(),
+		End: arg.End(),
+	}
+
+	if collectTName == "_" {
+		diagnostic.Message = "name and use the CollectT callback parameter instead of " + outerTName +
+			" inside EventuallyWithT callback"
+	} else {
+		diagnostic.Message = "use " + collectTName + " instead of " + outerTName +
+			" inside EventuallyWithT callback"
+		diagnostic.SuggestedFixes = []analysis.SuggestedFix{{
+			Message: "Use CollectT callback parameter",
+			TextEdits: []analysis.TextEdit{{
+				Pos:     arg.Pos(),
+				End:     arg.End(),
+				NewText: []byte(collectTName),
+			}},
+		}}
+	}
+
+	pass.Report(diagnostic)
 }
 
 // resolveIdentFromInfo looks up the types.Object for an expression via TypesInfo.
@@ -132,6 +144,11 @@ func resolveIdentFromInfo(pass *analysis.Pass, expr ast.Expr) types.Object {
 		return nil
 	}
 	return pass.TypesInfo.ObjectOf(ident)
+}
+
+func isEventuallyWithTCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "EventuallyWithT"
 }
 
 // isAssertOrRequire checks whether a selector expression refers to a

--- a/internal/test/analyzer/collectt/collectt.go
+++ b/internal/test/analyzer/collectt/collectt.go
@@ -42,6 +42,10 @@ func run(pass *analysis.Pass) (any, error) {
 
 		// The first argument should be the outer *testing.T.
 		outerT := call.Args[0]
+		outerTIdent, ok := outerT.(*ast.Ident)
+		if !ok {
+			return
+		}
 		outerTObj := resolveIdentFromInfo(pass, outerT)
 		if outerTObj == nil {
 			return
@@ -97,11 +101,21 @@ func run(pass *analysis.Pass) (any, error) {
 			// Flag if the first arg resolves to the outer *testing.T
 			// rather than the callback's *assert.CollectT parameter.
 			if argObj == outerTObj && argObj != collectTObj {
-				pass.Reportf(innerCall.Args[0].Pos(),
-					"use %s instead of %s inside EventuallyWithT callback",
-					collectTParam.Names[0].Name,
-					outerT.(*ast.Ident).Name,
-				)
+				collectTName := collectTParam.Names[0].Name
+				pass.Report(analysis.Diagnostic{
+					Pos: innerCall.Args[0].Pos(),
+					End: innerCall.Args[0].End(),
+					Message: "use " + collectTName + " instead of " + outerTIdent.Name +
+						" inside EventuallyWithT callback",
+					SuggestedFixes: []analysis.SuggestedFix{{
+						Message: "Use CollectT callback parameter",
+						TextEdits: []analysis.TextEdit{{
+							Pos:     innerCall.Args[0].Pos(),
+							End:     innerCall.Args[0].End(),
+							NewText: []byte(collectTName),
+						}},
+					}},
+				})
 			}
 
 			return true

--- a/internal/test/analyzer/collectt/collectt_test.go
+++ b/internal/test/analyzer/collectt/collectt_test.go
@@ -13,5 +13,5 @@ import (
 
 func TestAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, collectt.Analyzer, "example")
+	analysistest.RunWithSuggestedFixes(t, testdata, collectt.Analyzer, "example")
 }

--- a/internal/test/analyzer/collectt/testdata/src/example/example.go
+++ b/internal/test/analyzer/collectt/testdata/src/example/example.go
@@ -23,8 +23,8 @@ func TestBuggyUsage(t *testing.T) {
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		require.Len(t, []int{1}, 1)  // want `use ct instead of t inside EventuallyWithT callback`
 		require.NotEmpty(t, "hello") // want `use ct instead of t inside EventuallyWithT callback`
-		assert.Less(t, 1, 2)        // want `use ct instead of t inside EventuallyWithT callback`
-		require.Equal(ct, 1, 1)     // this is fine
+		assert.Less(t, 1, 2)         // want `use ct instead of t inside EventuallyWithT callback`
+		require.Equal(ct, 1, 1)      // this is fine
 	}, time.Minute, time.Second)
 }
 
@@ -59,5 +59,19 @@ func TestAssertEventuallyWithT(t *testing.T) {
 	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 		require.Equal(t, 1, 1) // want `use ct instead of t inside EventuallyWithT callback`
 		assert.Equal(ct, 1, 1)
+	}, time.Minute, time.Second)
+}
+
+func TestBlankCollectTParam(t *testing.T) {
+	require.EventuallyWithT(t, func(_ *assert.CollectT) {
+		require.NoError(t, nil) // want `name and use the CollectT callback parameter instead of t inside EventuallyWithT callback`
+	}, time.Minute, time.Second)
+}
+
+func TestNestedEventuallyWithT(t *testing.T) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.EventuallyWithT(t, func(ctt *assert.CollectT) { // want `use ct instead of t inside EventuallyWithT callback`
+			require.Equal(t, 1, 1) // want `use ctt instead of t inside EventuallyWithT callback`
+		}, time.Minute, time.Second)
 	}, time.Minute, time.Second)
 }

--- a/internal/test/analyzer/collectt/testdata/src/example/example.go.golden
+++ b/internal/test/analyzer/collectt/testdata/src/example/example.go.golden
@@ -61,3 +61,17 @@ func TestAssertEventuallyWithT(t *testing.T) {
 		assert.Equal(ct, 1, 1)
 	}, time.Minute, time.Second)
 }
+
+func TestBlankCollectTParam(t *testing.T) {
+	require.EventuallyWithT(t, func(_ *assert.CollectT) {
+		require.NoError(t, nil) // want `name and use the CollectT callback parameter instead of t inside EventuallyWithT callback`
+	}, time.Minute, time.Second)
+}
+
+func TestNestedEventuallyWithT(t *testing.T) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.EventuallyWithT(ct, func(ctt *assert.CollectT) { // want `use ct instead of t inside EventuallyWithT callback`
+			require.Equal(ctt, 1, 1) // want `use ctt instead of t inside EventuallyWithT callback`
+		}, time.Minute, time.Second)
+	}, time.Minute, time.Second)
+}

--- a/internal/test/analyzer/collectt/testdata/src/example/example.go.golden
+++ b/internal/test/analyzer/collectt/testdata/src/example/example.go.golden
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package example
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCorrectUsage(t *testing.T) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.NoError(ct, nil)
+		require.Equal(ct, 1, 1)
+		assert.Less(ct, 1, 2)
+	}, time.Minute, time.Second)
+}
+
+func TestBuggyUsage(t *testing.T) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.Len(ct, []int{1}, 1)  // want `use ct instead of t inside EventuallyWithT callback`
+		require.NotEmpty(ct, "hello") // want `use ct instead of t inside EventuallyWithT callback`
+		assert.Less(ct, 1, 2)         // want `use ct instead of t inside EventuallyWithT callback`
+		require.Equal(ct, 1, 1)       // this is fine
+	}, time.Minute, time.Second)
+}
+
+func TestMixedUsage(t *testing.T) {
+	// Assertions outside EventuallyWithT are fine.
+	require.NoError(t, nil)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.Equal(ct, 1, 1)
+		require.Len(ct, []int{}, 0) // want `use ct instead of t inside EventuallyWithT callback`
+	}, time.Minute, time.Second)
+
+	// Also fine — outside the callback.
+	require.Equal(t, 1, 1)
+}
+
+func TestDifferentParamName(t *testing.T) {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		require.Equal(collect, 1, 1) // want `use collect instead of t inside EventuallyWithT callback`
+		assert.Equal(collect, 1, 1)
+	}, time.Minute, time.Second)
+}
+
+func TestShadowedT(t *testing.T) {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.Equal(t, 1, 1) // no diagnostic — t is the CollectT param, not the outer *testing.T
+		assert.Less(t, 1, 2)
+	}, time.Minute, time.Second)
+}
+
+func TestAssertEventuallyWithT(t *testing.T) {
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.Equal(ct, 1, 1) // want `use ct instead of t inside EventuallyWithT callback`
+		assert.Equal(ct, 1, 1)
+	}, time.Minute, time.Second)
+}


### PR DESCRIPTION
## Summary

- Route `lint-fix` through explicit fix-specific targets.
- Run `vanity-import-fix` before the vanity import check on the fix path.
- Add suggested fixes to the collectt analyzer so incorrect `EventuallyWithT` assertion targets can be rewritten automatically.
- Add `lint-collectt-fix` and have `lint-fix` use it before `golangci-lint --fix`.

## Why

`lint-fix` previously used the same check-first dependency path as `lint`, so fixable vanity import issues could fail before their fixer ran. The collectt analyzer also reported mechanically fixable issues but did not expose suggested fixes for `singlechecker -fix`.

## Validation

- `go test ./internal/test/analyzer/collectt`
- `make -n lint-collectt-fix`
- `make -n lint-fix`
- `make -n -j8 lint-fix`
- `make -n lint`
