### PR TITLE
Add internal config v2 conversion foundation

### DIFF
--- a/internal/config/convert/export.go
+++ b/internal/config/convert/export.go
@@ -1,0 +1,303 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert // import "go.opentelemetry.io/obi/internal/config/convert"
+
+import (
+	"encoding"
+	"fmt"
+
+	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+// RuntimeToV2 converts an already-loaded v1 runtime configuration into the
+// internal config v2 document shape.
+func RuntimeToV2(cfg *obi.Config) (*schema.Document, *schema.Extension) {
+	if cfg == nil {
+		defaultConfig := obi.DefaultConfig
+		cfg = &defaultConfig
+	}
+
+	ext := &schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Policy:          capturePolicy(cfg),
+			Instrumentation: captureInstrumentation(cfg),
+			Runtimes:        captureRuntimes(cfg),
+			Network:         captureNetwork(cfg),
+			Limits:          captureLimits(cfg),
+			Engine:          captureEngine(cfg),
+			Safety:          captureSafety(cfg),
+			Channels:        captureChannels(cfg),
+		},
+		Daemon: daemon(cfg),
+	}
+
+	doc := &schema.Document{
+		FileFormat: "1.0",
+		Resource:   map[string]any{},
+		Propagator: map[string]any{},
+		Extensions: schema.Extensions{OBI: ext},
+	}
+
+	return doc, ext
+}
+
+func capturePolicy(cfg *obi.Config) map[string]any {
+	return map[string]any{
+		"default_action":  "include",
+		"match_order":     "first_match_wins",
+		"poll_interval":   cfg.Discovery.PollInterval.String(),
+		"min_process_age": cfg.Discovery.MinProcessAge.String(),
+	}
+}
+
+func captureInstrumentation(cfg *obi.Config) map[string]any {
+	tracesSelection := instrumentations.NewInstrumentationSelection(cfg.Traces.Instrumentations)
+	metricsSelection := instrumentations.NewInstrumentationSelection(metricsInstrumentations(cfg))
+	appMetricsEnabled := cfg.Metrics.Features.AnyAppO11yMetric()
+
+	instrumentation := make(map[string]any, len(protocolMappings))
+	for _, mapping := range protocolMappings {
+		instrumentation[mapping.name] = map[string]any{
+			"enabled": protocolEnabled(tracesSelection, metricsSelection, appMetricsEnabled, mapping),
+		}
+	}
+
+	http := instrumentation["http"].(map[string]any)
+	http["track_request_headers"] = cfg.EBPF.TrackRequestHeaders
+	http["request_timeout"] = cfg.EBPF.HTTPRequestTimeout.String()
+	http["buffer_size"] = cfg.EBPF.BufferSizes.HTTP
+
+	sql := instrumentation["sql"].(map[string]any)
+	sql["heuristic_detect"] = cfg.EBPF.HeuristicSQLDetect
+	sql["mysql"] = map[string]any{
+		"buffer_size":                    cfg.EBPF.BufferSizes.MySQL,
+		"prepared_statements_cache_size": cfg.EBPF.MySQLPreparedStatementsCacheSize,
+	}
+	sql["postgres"] = map[string]any{
+		"buffer_size":                    cfg.EBPF.BufferSizes.Postgres,
+		"prepared_statements_cache_size": cfg.EBPF.PostgresPreparedStatementsCacheSize,
+	}
+	sql["mssql"] = map[string]any{
+		"buffer_size":                    cfg.EBPF.BufferSizes.MSSQL,
+		"prepared_statements_cache_size": cfg.EBPF.MSSQLPreparedStatementsCacheSize,
+	}
+
+	redis := instrumentation["redis"].(map[string]any)
+	redis["db_cache"] = map[string]any{
+		"enabled":  cfg.EBPF.RedisDBCache.Enabled,
+		"max_size": cfg.EBPF.RedisDBCache.MaxSize,
+	}
+
+	kafka := instrumentation["kafka"].(map[string]any)
+	kafka["buffer_size"] = cfg.EBPF.BufferSizes.Kafka
+	kafka["topic_uuid_cache_size"] = cfg.EBPF.KafkaTopicUUIDCacheSize
+
+	mongo := instrumentation["mongo"].(map[string]any)
+	mongo["requests_cache_size"] = cfg.EBPF.MongoRequestsCacheSize
+
+	couchbase := instrumentation["couchbase"].(map[string]any)
+	couchbase["db_cache_size"] = cfg.EBPF.CouchbaseDBCacheSize
+
+	dns := instrumentation["dns"].(map[string]any)
+	dns["request_timeout"] = cfg.EBPF.DNSRequestTimeout.String()
+
+	gpu := instrumentation["gpu"].(map[string]any)
+	gpu["enabled_mode"] = textValue(cfg.EBPF.InstrumentCuda)
+
+	return instrumentation
+}
+
+func metricsInstrumentations(cfg *obi.Config) []instrumentations.Instrumentation {
+	combined := append([]instrumentations.Instrumentation{}, cfg.OTELMetrics.Instrumentations...)
+	for _, instr := range cfg.Prometheus.Instrumentations {
+		if !containsInstrumentation(combined, instr) {
+			combined = append(combined, instr)
+		}
+	}
+	return combined
+}
+
+func containsInstrumentation(list []instrumentations.Instrumentation, needle instrumentations.Instrumentation) bool {
+	for _, item := range list {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func protocolEnabled(
+	tracesSelection instrumentations.InstrumentationSelection,
+	metricsSelection instrumentations.InstrumentationSelection,
+	appMetricsEnabled bool,
+	mapping protocolMapping,
+) map[string]any {
+	metricsEnabled := protocolSelected(metricsSelection, mapping.instr)
+	if mapping.appMetrics {
+		metricsEnabled = metricsEnabled && appMetricsEnabled
+	}
+
+	return map[string]any{
+		"traces":  protocolSelected(tracesSelection, mapping.instr),
+		"metrics": metricsEnabled,
+	}
+}
+
+func protocolSelected(selection instrumentations.InstrumentationSelection, instr instrumentations.Instrumentation) bool {
+	return selection&instrumentations.NewInstrumentationSelection([]instrumentations.Instrumentation{instr}) != 0
+}
+
+func captureRuntimes(cfg *obi.Config) map[string]any {
+	return map[string]any{
+		"go": map[string]any{
+			"enabled": !cfg.Discovery.SkipGoSpecificTracers,
+			"filter":  map[string]any{},
+		},
+		"nodejs": map[string]any{
+			"enabled": cfg.NodeJS.Enabled,
+			"filter":  map[string]any{},
+		},
+		"java": map[string]any{
+			"enabled": cfg.Java.Enabled,
+			"filter":  map[string]any{},
+			"debug": map[string]any{
+				"enabled":                  cfg.Java.Debug,
+				"bytecode_instrumentation": cfg.Java.DebugInstrumentation,
+			},
+			"attach_timeout": cfg.Java.Timeout.String(),
+		},
+	}
+}
+
+func captureNetwork(cfg *obi.Config) map[string]any {
+	return map[string]any{
+		"capture": map[string]any{
+			"enabled":     cfg.NetworkFlows.Enable || cfg.Metrics.Features.AnyNetwork(),
+			"source":      cfg.NetworkFlows.Source,
+			"buffer_size": cfg.EBPF.BufferSizes.TCP,
+			"endpoint_identity": map[string]any{
+				"agent_ip":           cfg.NetworkFlows.AgentIP,
+				"agent_ip_interface": cfg.NetworkFlows.AgentIPIface,
+				"agent_ip_family":    cfg.NetworkFlows.AgentIPType,
+			},
+			"selection": map[string]any{
+				"interfaces": map[string]any{
+					"include": cfg.NetworkFlows.Interfaces,
+					"exclude": cfg.NetworkFlows.ExcludeInterfaces,
+				},
+				"protocols": map[string]any{
+					"include": cfg.NetworkFlows.Protocols,
+					"exclude": cfg.NetworkFlows.ExcludeProtocols,
+				},
+				"direction": cfg.NetworkFlows.Direction,
+			},
+			"flow_lifecycle": map[string]any{
+				"max_tracked_flows": cfg.NetworkFlows.CacheMaxFlows,
+				"active_timeout":    cfg.NetworkFlows.CacheActiveTimeout.String(),
+				"deduplication": map[string]any{
+					"strategy":       cfg.NetworkFlows.Deduper,
+					"first_come_ttl": cfg.NetworkFlows.DeduperFCTTL.String(),
+				},
+				"sampling": cfg.NetworkFlows.Sampling,
+			},
+			"interface_discovery": map[string]any{
+				"mode":          cfg.NetworkFlows.ListenInterfaces,
+				"poll_interval": cfg.NetworkFlows.ListenPollPeriod.String(),
+			},
+			"diagnostics": map[string]any{
+				"print_flows": cfg.NetworkFlows.Print,
+			},
+		},
+	}
+}
+
+func captureLimits(cfg *obi.Config) map[string]any {
+	return map[string]any{
+		"network_packets":   cfg.NetworkFlows.CacheMaxFlows,
+		"metric_span_names": cfg.Attributes.MetricSpanNameAggregationLimit,
+	}
+}
+
+func captureEngine(cfg *obi.Config) map[string]any {
+	return map[string]any{
+		"debug": map[string]any{
+			"bpf":            cfg.EBPF.BpfDebug,
+			"protocol_print": cfg.EBPF.ProtocolDebug,
+		},
+		"pid_filter": map[string]any{
+			"disabled": cfg.Discovery.BPFPidFilterOff,
+		},
+		"batching": map[string]any{
+			"wakeup_len":    cfg.EBPF.WakeupLen,
+			"batch_length":  cfg.EBPF.BatchLength,
+			"batch_timeout": cfg.EBPF.BatchTimeout.String(),
+		},
+		"propagation": map[string]any{
+			"context_propagation":      textValue(cfg.EBPF.ContextPropagation),
+			"override_bpfloop_enabled": cfg.EBPF.OverrideBPFLoopEnabled,
+			"disable_black_box_cp":     cfg.EBPF.DisableBlackBoxCP,
+		},
+		"traffic": map[string]any{
+			"control_backend":     textValue(cfg.EBPF.TCBackend),
+			"high_request_volume": cfg.EBPF.HighRequestVolume,
+		},
+		"transactions": map[string]any{
+			"max_duration": cfg.EBPF.MaxTransactionTime.String(),
+		},
+		"bpf_filesystem": map[string]any{
+			"path": cfg.EBPF.BPFFSPath,
+		},
+	}
+}
+
+func captureSafety(cfg *obi.Config) map[string]any {
+	return map[string]any{
+		"enforce_system_capabilities": cfg.EnforceSysCaps,
+	}
+}
+
+func captureChannels(cfg *obi.Config) map[string]any {
+	return map[string]any{
+		"buffer_len":            cfg.ChannelBufferLen,
+		"send_timeout":          cfg.ChannelSendTimeout.String(),
+		"panic_on_send_timeout": cfg.ChannelSendTimeoutPanic,
+	}
+}
+
+func daemon(cfg *obi.Config) map[string]any {
+	return map[string]any{
+		"logging": map[string]any{
+			"level":              cfg.LogLevel,
+			"format":             cfg.LogConfig,
+			"debug_trace_output": cfg.TracePrinter,
+		},
+		"profiling": map[string]any{
+			"port": cfg.ProfilePort,
+		},
+		"shutdown": map[string]any{
+			"timeout": cfg.ShutdownTimeout.String(),
+		},
+		"internal_metrics": map[string]any{
+			"exporter": cfg.InternalMetrics.Exporter,
+			"prometheus": map[string]any{
+				"port": cfg.InternalMetrics.Prometheus.Port,
+				"path": cfg.InternalMetrics.Prometheus.Path,
+			},
+			"bpf": map[string]any{
+				"scrape_interval": cfg.InternalMetrics.BpfMetricScrapeInterval.String(),
+			},
+		},
+	}
+}
+
+func textValue(v encoding.TextMarshaler) any {
+	raw, err := v.MarshalText()
+	if err != nil {
+		return fmt.Sprint(v)
+	}
+	return string(raw)
+}

--- a/internal/config/convert/export.go
+++ b/internal/config/convert/export.go
@@ -85,10 +85,6 @@ func captureInstrumentation(cfg *obi.Config) map[string]any {
 		"buffer_size":                    cfg.EBPF.BufferSizes.Postgres,
 		"prepared_statements_cache_size": cfg.EBPF.PostgresPreparedStatementsCacheSize,
 	}
-	sql["mssql"] = map[string]any{
-		"buffer_size":                    cfg.EBPF.BufferSizes.MSSQL,
-		"prepared_statements_cache_size": cfg.EBPF.MSSQLPreparedStatementsCacheSize,
-	}
 
 	redis := instrumentation["redis"].(map[string]any)
 	redis["db_cache"] = map[string]any{

--- a/internal/config/convert/export.go
+++ b/internal/config/convert/export.go
@@ -31,15 +31,19 @@ func RuntimeToV2(cfg *obi.Config) (*schema.Document, *schema.Extension) {
 			Engine:          captureEngine(cfg),
 			Safety:          captureSafety(cfg),
 			Channels:        captureChannels(cfg),
+			Rules:           []schema.Rule{},
+			Telemetry:       map[string]any{},
 		},
 		Daemon: daemon(cfg),
 	}
 
 	doc := &schema.Document{
-		FileFormat: "1.0",
-		Resource:   map[string]any{},
-		Propagator: map[string]any{},
-		Extensions: schema.Extensions{OBI: ext},
+		FileFormat:     "1.0",
+		Resource:       map[string]any{},
+		Propagator:     map[string]any{},
+		TracerProvider: map[string]any{},
+		MeterProvider:  map[string]any{},
+		Extensions:     schema.Extensions{OBI: ext},
 	}
 
 	return doc, ext
@@ -55,14 +59,14 @@ func capturePolicy(cfg *obi.Config) map[string]any {
 }
 
 func captureInstrumentation(cfg *obi.Config) map[string]any {
-	tracesSelection := instrumentations.NewInstrumentationSelection(cfg.Traces.Instrumentations)
-	metricsSelection := instrumentations.NewInstrumentationSelection(metricsInstrumentations(cfg))
+	tracesInstrumentations := cfg.Traces.Instrumentations
+	metricsInstrs := metricsInstrumentations(cfg)
 	appMetricsEnabled := cfg.Metrics.Features.AnyAppO11yMetric()
 
 	instrumentation := make(map[string]any, len(protocolMappings))
 	for _, mapping := range protocolMappings {
 		instrumentation[mapping.name] = map[string]any{
-			"enabled": protocolEnabled(tracesSelection, metricsSelection, appMetricsEnabled, mapping),
+			"enabled": protocolEnabled(tracesInstrumentations, metricsInstrs, appMetricsEnabled, mapping),
 		}
 	}
 
@@ -131,24 +135,32 @@ func containsInstrumentation(list []instrumentations.Instrumentation, needle ins
 }
 
 func protocolEnabled(
-	tracesSelection instrumentations.InstrumentationSelection,
-	metricsSelection instrumentations.InstrumentationSelection,
+	tracesInstrumentations []instrumentations.Instrumentation,
+	metricsInstrumentations []instrumentations.Instrumentation,
 	appMetricsEnabled bool,
 	mapping protocolMapping,
 ) map[string]any {
-	metricsEnabled := protocolSelected(metricsSelection, mapping.instr)
+	metricsEnabled := protocolSelected(metricsInstrumentations, mapping, mapping.metricWildcard)
 	if mapping.appMetrics {
 		metricsEnabled = metricsEnabled && appMetricsEnabled
 	}
 
 	return map[string]any{
-		"traces":  protocolSelected(tracesSelection, mapping.instr),
+		"traces":  protocolSelected(tracesInstrumentations, mapping, true),
 		"metrics": metricsEnabled,
 	}
 }
 
-func protocolSelected(selection instrumentations.InstrumentationSelection, instr instrumentations.Instrumentation) bool {
-	return selection&instrumentations.NewInstrumentationSelection([]instrumentations.Instrumentation{instr}) != 0
+func protocolSelected(list []instrumentations.Instrumentation, mapping protocolMapping, wildcard bool) bool {
+	for _, instr := range list {
+		if instr == mapping.instr {
+			return true
+		}
+		if instr == instrumentations.InstrumentationALL && wildcard {
+			return true
+		}
+	}
+	return false
 }
 
 func captureRuntimes(cfg *obi.Config) map[string]any {

--- a/internal/config/convert/export.go
+++ b/internal/config/convert/export.go
@@ -116,13 +116,31 @@ func captureInstrumentation(cfg *obi.Config) map[string]any {
 }
 
 func metricsInstrumentations(cfg *obi.Config) []instrumentations.Instrumentation {
-	combined := append([]instrumentations.Instrumentation{}, cfg.OTELMetrics.Instrumentations...)
-	for _, instr := range cfg.Prometheus.Instrumentations {
-		if !containsInstrumentation(combined, instr) {
-			combined = append(combined, instr)
+	var combined []instrumentations.Instrumentation
+	if cfg.OTELMetrics.EndpointEnabled() {
+		combined = appendMetricInstrumentations(combined, cfg.OTELMetrics.Instrumentations)
+	}
+	if cfg.Prometheus.EndpointEnabled() {
+		combined = appendMetricInstrumentations(combined, cfg.Prometheus.Instrumentations)
+	}
+	if len(combined) != 0 {
+		return combined
+	}
+
+	combined = appendMetricInstrumentations(combined, cfg.OTELMetrics.Instrumentations)
+	return appendMetricInstrumentations(combined, cfg.Prometheus.Instrumentations)
+}
+
+func appendMetricInstrumentations(
+	dst []instrumentations.Instrumentation,
+	src []instrumentations.Instrumentation,
+) []instrumentations.Instrumentation {
+	for _, instr := range src {
+		if !containsInstrumentation(dst, instr) {
+			dst = append(dst, instr)
 		}
 	}
-	return combined
+	return dst
 }
 
 func containsInstrumentation(list []instrumentations.Instrumentation, needle instrumentations.Instrumentation) bool {

--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -240,6 +240,47 @@ func TestRuntimeToV2CustomConfig(t *testing.T) {
 	require.Equal(t, "4s", value(t, ext.Daemon, "internal_metrics", "bpf", "scrape_interval"))
 }
 
+func TestRuntimeToV2MetricInstrumentationsUseEnabledExporters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ignores disabled exporter defaults", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := obi.DefaultConfig
+		cfg.OTELMetrics.MetricsEndpoint = "http://localhost:4318"
+		cfg.OTELMetrics.Instrumentations = []instrumentations.Instrumentation{
+			instrumentations.InstrumentationHTTP,
+		}
+
+		_, ext := RuntimeToV2(&cfg)
+
+		require.Equal(t, true, value(t, ext.Capture.Instrumentation, "http", "enabled", "metrics"))
+		require.Equal(t, false, value(t, ext.Capture.Instrumentation, "grpc", "enabled", "metrics"))
+		require.Equal(t, false, value(t, ext.Capture.Instrumentation, "sql", "enabled", "metrics"))
+		require.Equal(t, false, value(t, ext.Capture.Instrumentation, "redis", "enabled", "metrics"))
+	})
+
+	t.Run("unions enabled exporters", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := obi.DefaultConfig
+		cfg.OTELMetrics.MetricsEndpoint = "http://localhost:4318"
+		cfg.OTELMetrics.Instrumentations = []instrumentations.Instrumentation{
+			instrumentations.InstrumentationHTTP,
+		}
+		cfg.Prometheus.Port = 9090
+		cfg.Prometheus.Instrumentations = []instrumentations.Instrumentation{
+			instrumentations.InstrumentationRedis,
+		}
+
+		_, ext := RuntimeToV2(&cfg)
+
+		require.Equal(t, true, value(t, ext.Capture.Instrumentation, "http", "enabled", "metrics"))
+		require.Equal(t, true, value(t, ext.Capture.Instrumentation, "redis", "enabled", "metrics"))
+		require.Equal(t, false, value(t, ext.Capture.Instrumentation, "grpc", "enabled", "metrics"))
+	})
+}
+
 func TestRuntimeToV2DocumentParsesAsStandaloneV2(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -207,6 +207,7 @@ func TestRuntimeToV2CustomConfig(t *testing.T) {
 	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "grpc", "enabled", "metrics"))
 	require.Equal(t, uint32(100), value(t, ext.Capture.Instrumentation, "http", "buffer_size"))
 	require.Equal(t, uint32(101), value(t, ext.Capture.Instrumentation, "sql", "mysql", "buffer_size"))
+	require.NotContains(t, value(t, ext.Capture.Instrumentation, "sql"), "mssql")
 	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "redis", "db_cache", "enabled"))
 	require.Equal(t, 204, value(t, ext.Capture.Instrumentation, "kafka", "topic_uuid_cache_size"))
 	require.Equal(t, "on", value(t, ext.Capture.Instrumentation, "gpu", "enabled_mode"))

--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -26,9 +26,15 @@ func TestRuntimeToV2DefaultConfig(t *testing.T) {
 
 	require.Equal(t, "1.0", doc.FileFormat)
 	require.Same(t, ext, doc.Extensions.OBI)
+	require.NotNil(t, doc.Resource)
+	require.NotNil(t, doc.Propagator)
+	require.NotNil(t, doc.TracerProvider)
+	require.NotNil(t, doc.MeterProvider)
 	require.Equal(t, schema.SupportedVersion, ext.Version)
 	require.Nil(t, ext.Enrich)
 	require.Nil(t, ext.Correlation)
+	require.NotNil(t, ext.Capture.Rules)
+	require.NotNil(t, ext.Capture.Telemetry)
 
 	require.Equal(t, "include", value(t, ext.Capture.Policy, "default_action"))
 	require.Equal(t, "first_match_wins", value(t, ext.Capture.Policy, "match_order"))
@@ -54,7 +60,18 @@ func TestRuntimeToV2DefaultConfig(t *testing.T) {
 	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "http", "enabled", "traces"))
 	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "http", "enabled", "metrics"))
 	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "dns", "enabled", "traces"))
-	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "dns", "enabled", "metrics"))
+	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "dns", "enabled", "metrics"))
+	require.ElementsMatch(t, []string{
+		"http",
+		"grpc",
+		"sql",
+		"redis",
+		"kafka",
+		"mongo",
+		"couchbase",
+		"dns",
+		"gpu",
+	}, keys(ext.Capture.Instrumentation))
 
 	require.Equal(t, true, value(t, ext.Capture.Runtimes, "go", "enabled"))
 	require.Equal(t, true, value(t, ext.Capture.Runtimes, "nodejs", "enabled"))
@@ -136,6 +153,7 @@ func TestRuntimeToV2CustomConfig(t *testing.T) {
 	}
 	cfg.Prometheus.Instrumentations = []instrumentations.Instrumentation{
 		instrumentations.InstrumentationRedis,
+		instrumentations.InstrumentationDNS,
 	}
 	cfg.Metrics.Features = export.FeatureApplicationRED | export.FeatureNetwork
 
@@ -183,6 +201,8 @@ func TestRuntimeToV2CustomConfig(t *testing.T) {
 	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "kafka", "enabled", "metrics"))
 	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "redis", "enabled", "traces"))
 	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "redis", "enabled", "metrics"))
+	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "dns", "enabled", "traces"))
+	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "dns", "enabled", "metrics"))
 	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "grpc", "enabled", "traces"))
 	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "grpc", "enabled", "metrics"))
 	require.Equal(t, uint32(100), value(t, ext.Capture.Instrumentation, "http", "buffer_size"))
@@ -227,9 +247,17 @@ func TestRuntimeToV2DocumentParsesAsStandaloneV2(t *testing.T) {
 
 	data, err := yaml.Marshal(doc)
 	require.NoError(t, err)
+	require.NotContains(t, string(data), "tracer_provider: null")
+	require.NotContains(t, string(data), "meter_provider: null")
+	require.NotContains(t, string(data), "rules: null")
+	require.NotContains(t, string(data), "telemetry: null")
 
 	parsedDoc, parsedExt, err := schema.ParseStandaloneYAML(data)
 	require.NoError(t, err)
+	require.NotNil(t, parsedDoc.TracerProvider)
+	require.NotNil(t, parsedDoc.MeterProvider)
+	require.NotNil(t, parsedExt.Capture.Rules)
+	require.NotNil(t, parsedExt.Capture.Telemetry)
 	require.Equal(t, "1.0", parsedDoc.FileFormat)
 	require.Equal(t, schema.SupportedVersion, parsedExt.Version)
 	require.Equal(t, "include", parsedExt.Capture.Policy["default_action"])
@@ -247,4 +275,12 @@ func value(t *testing.T, root any, path ...string) any {
 		require.Truef(t, ok, "missing key %q in %v", key, path)
 	}
 	return cur
+}
+
+func keys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for key := range m {
+		out = append(out, key)
+	}
+	return out
 }

--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -1,0 +1,250 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/debug"
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+func TestRuntimeToV2DefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	doc, ext := RuntimeToV2(nil)
+
+	require.Equal(t, "1.0", doc.FileFormat)
+	require.Same(t, ext, doc.Extensions.OBI)
+	require.Equal(t, schema.SupportedVersion, ext.Version)
+	require.Nil(t, ext.Enrich)
+	require.Nil(t, ext.Correlation)
+
+	require.Equal(t, "include", value(t, ext.Capture.Policy, "default_action"))
+	require.Equal(t, "first_match_wins", value(t, ext.Capture.Policy, "match_order"))
+	require.Equal(t, "0s", value(t, ext.Capture.Policy, "poll_interval"))
+	require.Equal(t, "5s", value(t, ext.Capture.Policy, "min_process_age"))
+
+	require.Equal(t, 500, value(t, ext.Capture.Engine, "batching", "wakeup_len"))
+	require.Equal(t, 100, value(t, ext.Capture.Engine, "batching", "batch_length"))
+	require.Equal(t, "1s", value(t, ext.Capture.Engine, "batching", "batch_timeout"))
+	require.Equal(t, "auto", value(t, ext.Capture.Engine, "traffic", "control_backend"))
+	require.Equal(t, "/sys/fs/bpf/", value(t, ext.Capture.Engine, "bpf_filesystem", "path"))
+
+	require.Equal(t, 50, value(t, ext.Capture.Channels, "buffer_len"))
+	require.Equal(t, "1m0s", value(t, ext.Capture.Channels, "send_timeout"))
+	require.Equal(t, false, value(t, ext.Capture.Safety, "enforce_system_capabilities"))
+	require.Equal(t, 100, value(t, ext.Capture.Limits, "metric_span_names"))
+
+	require.Equal(t, false, value(t, ext.Capture.Network, "capture", "enabled"))
+	require.Equal(t, obi.EbpfSourceSock, value(t, ext.Capture.Network, "capture", "source"))
+	require.Equal(t, []string{"lo"}, value(t, ext.Capture.Network, "capture", "selection", "interfaces", "exclude"))
+	require.Equal(t, "both", value(t, ext.Capture.Network, "capture", "selection", "direction"))
+
+	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "http", "enabled", "traces"))
+	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "http", "enabled", "metrics"))
+	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "dns", "enabled", "traces"))
+	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "dns", "enabled", "metrics"))
+
+	require.Equal(t, true, value(t, ext.Capture.Runtimes, "go", "enabled"))
+	require.Equal(t, true, value(t, ext.Capture.Runtimes, "nodejs", "enabled"))
+	require.Equal(t, true, value(t, ext.Capture.Runtimes, "java", "enabled"))
+
+	require.Equal(t, obi.LogLevelInfo, value(t, ext.Daemon, "logging", "level"))
+	require.Equal(t, debug.TracePrinterDisabled, value(t, ext.Daemon, "logging", "debug_trace_output"))
+	require.Equal(t, "10s", value(t, ext.Daemon, "shutdown", "timeout"))
+	require.Equal(t, imetrics.InternalMetricsExporterDisabled, value(t, ext.Daemon, "internal_metrics", "exporter"))
+	require.Equal(t, "/internal/metrics", value(t, ext.Daemon, "internal_metrics", "prometheus", "path"))
+}
+
+func TestRuntimeToV2CustomConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := obi.DefaultConfig
+	cfg.ChannelBufferLen = 77
+	cfg.ChannelSendTimeout = 2 * time.Second
+	cfg.ChannelSendTimeoutPanic = true
+	cfg.EnforceSysCaps = true
+	cfg.LogLevel = obi.LogLevelDebug
+	cfg.LogConfig = obi.LogConfigOptionJSON
+	cfg.TracePrinter = debug.TracePrinterJSON
+	cfg.ShutdownTimeout = 3 * time.Second
+	cfg.ProfilePort = 6060
+	cfg.InternalMetrics.Exporter = imetrics.InternalMetricsExporterPrometheus
+	cfg.InternalMetrics.Prometheus.Port = 9090
+	cfg.InternalMetrics.Prometheus.Path = "/debug/metrics"
+	cfg.InternalMetrics.BpfMetricScrapeInterval = 4 * time.Second
+
+	cfg.Discovery.PollInterval = 5 * time.Second
+	cfg.Discovery.MinProcessAge = 6 * time.Second
+	cfg.Discovery.BPFPidFilterOff = true
+	cfg.Discovery.SkipGoSpecificTracers = true
+	cfg.NodeJS.Enabled = false
+	cfg.Java.Enabled = false
+	cfg.Java.Debug = true
+	cfg.Java.DebugInstrumentation = true
+	cfg.Java.Timeout = 7 * time.Second
+
+	cfg.EBPF.BpfDebug = true
+	cfg.EBPF.ProtocolDebug = true
+	cfg.EBPF.WakeupLen = 8
+	cfg.EBPF.BatchLength = 9
+	cfg.EBPF.BatchTimeout = 10 * time.Second
+	cfg.EBPF.ContextPropagation = config.ContextPropagationAll
+	cfg.EBPF.OverrideBPFLoopEnabled = true
+	cfg.EBPF.DisableBlackBoxCP = true
+	cfg.EBPF.TCBackend = config.TCBackendTCX
+	cfg.EBPF.HighRequestVolume = true
+	cfg.EBPF.BPFFSPath = "/tmp/bpf"
+	cfg.EBPF.MaxTransactionTime = 11 * time.Second
+	cfg.EBPF.TrackRequestHeaders = true
+	cfg.EBPF.HTTPRequestTimeout = 12 * time.Second
+	cfg.EBPF.BufferSizes.HTTP = 100
+	cfg.EBPF.BufferSizes.MySQL = 101
+	cfg.EBPF.BufferSizes.Postgres = 102
+	cfg.EBPF.BufferSizes.MSSQL = 103
+	cfg.EBPF.BufferSizes.Kafka = 104
+	cfg.EBPF.BufferSizes.TCP = 105
+	cfg.EBPF.HeuristicSQLDetect = true
+	cfg.EBPF.MySQLPreparedStatementsCacheSize = 200
+	cfg.EBPF.PostgresPreparedStatementsCacheSize = 201
+	cfg.EBPF.MSSQLPreparedStatementsCacheSize = 202
+	cfg.EBPF.RedisDBCache.Enabled = true
+	cfg.EBPF.RedisDBCache.MaxSize = 203
+	cfg.EBPF.KafkaTopicUUIDCacheSize = 204
+	cfg.EBPF.MongoRequestsCacheSize = 205
+	cfg.EBPF.CouchbaseDBCacheSize = 206
+	cfg.EBPF.DNSRequestTimeout = 13 * time.Second
+	cfg.EBPF.InstrumentCuda = config.CudaModeOn
+
+	cfg.Traces.Instrumentations = []instrumentations.Instrumentation{
+		instrumentations.InstrumentationHTTP,
+		instrumentations.InstrumentationKafka,
+	}
+	cfg.OTELMetrics.Instrumentations = []instrumentations.Instrumentation{
+		instrumentations.InstrumentationHTTP,
+	}
+	cfg.Prometheus.Instrumentations = []instrumentations.Instrumentation{
+		instrumentations.InstrumentationRedis,
+	}
+	cfg.Metrics.Features = export.FeatureApplicationRED | export.FeatureNetwork
+
+	cfg.NetworkFlows.Source = obi.EbpfSourceTC
+	cfg.NetworkFlows.AgentIP = "192.0.2.1"
+	cfg.NetworkFlows.AgentIPIface = obi.NetworkAgentIPIfaceLocal
+	cfg.NetworkFlows.AgentIPType = "ipv4"
+	cfg.NetworkFlows.Interfaces = []string{"eth0"}
+	cfg.NetworkFlows.ExcludeInterfaces = []string{"lo", "docker0"}
+	cfg.NetworkFlows.Protocols = []string{"tcp"}
+	cfg.NetworkFlows.ExcludeProtocols = []string{"udp"}
+	cfg.NetworkFlows.CacheMaxFlows = 300
+	cfg.NetworkFlows.CacheActiveTimeout = 14 * time.Second
+	cfg.NetworkFlows.Deduper = "none"
+	cfg.NetworkFlows.DeduperFCTTL = 15 * time.Second
+	cfg.NetworkFlows.Direction = "egress"
+	cfg.NetworkFlows.Sampling = 16
+	cfg.NetworkFlows.ListenInterfaces = obi.NetworkListenInterfacesPoll
+	cfg.NetworkFlows.ListenPollPeriod = 17 * time.Second
+	cfg.NetworkFlows.Print = true
+	cfg.Attributes.MetricSpanNameAggregationLimit = 400
+
+	_, ext := RuntimeToV2(&cfg)
+
+	require.Equal(t, 77, value(t, ext.Capture.Channels, "buffer_len"))
+	require.Equal(t, "2s", value(t, ext.Capture.Channels, "send_timeout"))
+	require.Equal(t, true, value(t, ext.Capture.Channels, "panic_on_send_timeout"))
+	require.Equal(t, true, value(t, ext.Capture.Safety, "enforce_system_capabilities"))
+	require.Equal(t, 400, value(t, ext.Capture.Limits, "metric_span_names"))
+
+	require.Equal(t, "5s", value(t, ext.Capture.Policy, "poll_interval"))
+	require.Equal(t, "6s", value(t, ext.Capture.Policy, "min_process_age"))
+	require.Equal(t, true, value(t, ext.Capture.Engine, "pid_filter", "disabled"))
+	require.Equal(t, 8, value(t, ext.Capture.Engine, "batching", "wakeup_len"))
+	require.Equal(t, 9, value(t, ext.Capture.Engine, "batching", "batch_length"))
+	require.Equal(t, "10s", value(t, ext.Capture.Engine, "batching", "batch_timeout"))
+	require.Equal(t, "all", value(t, ext.Capture.Engine, "propagation", "context_propagation"))
+	require.Equal(t, "tcx", value(t, ext.Capture.Engine, "traffic", "control_backend"))
+	require.Equal(t, true, value(t, ext.Capture.Engine, "traffic", "high_request_volume"))
+	require.Equal(t, "/tmp/bpf", value(t, ext.Capture.Engine, "bpf_filesystem", "path"))
+
+	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "http", "enabled", "traces"))
+	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "http", "enabled", "metrics"))
+	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "kafka", "enabled", "traces"))
+	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "kafka", "enabled", "metrics"))
+	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "redis", "enabled", "traces"))
+	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "redis", "enabled", "metrics"))
+	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "grpc", "enabled", "traces"))
+	require.Equal(t, false, value(t, ext.Capture.Instrumentation, "grpc", "enabled", "metrics"))
+	require.Equal(t, uint32(100), value(t, ext.Capture.Instrumentation, "http", "buffer_size"))
+	require.Equal(t, uint32(101), value(t, ext.Capture.Instrumentation, "sql", "mysql", "buffer_size"))
+	require.Equal(t, true, value(t, ext.Capture.Instrumentation, "redis", "db_cache", "enabled"))
+	require.Equal(t, 204, value(t, ext.Capture.Instrumentation, "kafka", "topic_uuid_cache_size"))
+	require.Equal(t, "on", value(t, ext.Capture.Instrumentation, "gpu", "enabled_mode"))
+
+	require.Equal(t, false, value(t, ext.Capture.Runtimes, "go", "enabled"))
+	require.Equal(t, false, value(t, ext.Capture.Runtimes, "nodejs", "enabled"))
+	require.Equal(t, false, value(t, ext.Capture.Runtimes, "java", "enabled"))
+	require.Equal(t, true, value(t, ext.Capture.Runtimes, "java", "debug", "bytecode_instrumentation"))
+	require.Equal(t, "7s", value(t, ext.Capture.Runtimes, "java", "attach_timeout"))
+
+	require.Equal(t, true, value(t, ext.Capture.Network, "capture", "enabled"))
+	require.Equal(t, obi.EbpfSourceTC, value(t, ext.Capture.Network, "capture", "source"))
+	require.Equal(t, uint32(105), value(t, ext.Capture.Network, "capture", "buffer_size"))
+	require.Equal(t, "192.0.2.1", value(t, ext.Capture.Network, "capture", "endpoint_identity", "agent_ip"))
+	require.Equal(t, obi.AgentTypeIface(obi.NetworkAgentIPIfaceLocal), value(t, ext.Capture.Network, "capture", "endpoint_identity", "agent_ip_interface"))
+	require.Equal(t, []string{"eth0"}, value(t, ext.Capture.Network, "capture", "selection", "interfaces", "include"))
+	require.Equal(t, []string{"udp"}, value(t, ext.Capture.Network, "capture", "selection", "protocols", "exclude"))
+	require.Equal(t, "egress", value(t, ext.Capture.Network, "capture", "selection", "direction"))
+	require.Equal(t, 300, value(t, ext.Capture.Network, "capture", "flow_lifecycle", "max_tracked_flows"))
+	require.Equal(t, "none", value(t, ext.Capture.Network, "capture", "flow_lifecycle", "deduplication", "strategy"))
+	require.Equal(t, "15s", value(t, ext.Capture.Network, "capture", "flow_lifecycle", "deduplication", "first_come_ttl"))
+	require.Equal(t, true, value(t, ext.Capture.Network, "capture", "diagnostics", "print_flows"))
+
+	require.Equal(t, obi.LogLevelDebug, value(t, ext.Daemon, "logging", "level"))
+	require.Equal(t, obi.LogConfigOptionJSON, value(t, ext.Daemon, "logging", "format"))
+	require.Equal(t, debug.TracePrinterJSON, value(t, ext.Daemon, "logging", "debug_trace_output"))
+	require.Equal(t, 6060, value(t, ext.Daemon, "profiling", "port"))
+	require.Equal(t, "3s", value(t, ext.Daemon, "shutdown", "timeout"))
+	require.Equal(t, imetrics.InternalMetricsExporterPrometheus, value(t, ext.Daemon, "internal_metrics", "exporter"))
+	require.Equal(t, 9090, value(t, ext.Daemon, "internal_metrics", "prometheus", "port"))
+	require.Equal(t, "4s", value(t, ext.Daemon, "internal_metrics", "bpf", "scrape_interval"))
+}
+
+func TestRuntimeToV2DocumentParsesAsStandaloneV2(t *testing.T) {
+	t.Parallel()
+
+	doc, _ := RuntimeToV2(nil)
+
+	data, err := yaml.Marshal(doc)
+	require.NoError(t, err)
+
+	parsedDoc, parsedExt, err := schema.ParseStandaloneYAML(data)
+	require.NoError(t, err)
+	require.Equal(t, "1.0", parsedDoc.FileFormat)
+	require.Equal(t, schema.SupportedVersion, parsedExt.Version)
+	require.Equal(t, "include", parsedExt.Capture.Policy["default_action"])
+	require.Equal(t, "auto", value(t, parsedExt.Capture.Engine, "traffic", "control_backend"))
+}
+
+func value(t *testing.T, root any, path ...string) any {
+	t.Helper()
+
+	cur := root
+	for _, key := range path {
+		m, ok := cur.(map[string]any)
+		require.Truef(t, ok, "expected map at %q in %v", key, path)
+		cur, ok = m[key]
+		require.Truef(t, ok, "missing key %q in %v", key, path)
+	}
+	return cur
+}

--- a/internal/config/convert/protocols.go
+++ b/internal/config/convert/protocols.go
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert // import "go.opentelemetry.io/obi/internal/config/convert"
+
+import "go.opentelemetry.io/obi/pkg/export/instrumentations"
+
+type protocolMapping struct {
+	name       string
+	instr      instrumentations.Instrumentation
+	appMetrics bool
+}
+
+var protocolMappings = []protocolMapping{
+	{name: "http", instr: instrumentations.InstrumentationHTTP, appMetrics: true},
+	{name: "grpc", instr: instrumentations.InstrumentationGRPC, appMetrics: true},
+	{name: "sql", instr: instrumentations.InstrumentationSQL, appMetrics: true},
+	{name: "redis", instr: instrumentations.InstrumentationRedis, appMetrics: true},
+	{name: "kafka", instr: instrumentations.InstrumentationKafka, appMetrics: true},
+	{name: "mqtt", instr: instrumentations.InstrumentationMQTT, appMetrics: true},
+	{name: "nats", instr: instrumentations.InstrumentationNATS, appMetrics: true},
+	{name: "amqp", instr: instrumentations.InstrumentationAMQP, appMetrics: true},
+	{name: "mongo", instr: instrumentations.InstrumentationMongo, appMetrics: true},
+	{name: "couchbase", instr: instrumentations.InstrumentationCouchbase, appMetrics: true},
+	{name: "memcached", instr: instrumentations.InstrumentationMemcached, appMetrics: true},
+	{name: "dns", instr: instrumentations.InstrumentationDNS, appMetrics: false},
+	{name: "gpu", instr: instrumentations.InstrumentationGPU, appMetrics: true},
+	{name: "genai", instr: instrumentations.InstrumentationGenAI, appMetrics: true},
+}

--- a/internal/config/convert/protocols.go
+++ b/internal/config/convert/protocols.go
@@ -6,24 +6,20 @@ package convert // import "go.opentelemetry.io/obi/internal/config/convert"
 import "go.opentelemetry.io/obi/pkg/export/instrumentations"
 
 type protocolMapping struct {
-	name       string
-	instr      instrumentations.Instrumentation
-	appMetrics bool
+	name           string
+	instr          instrumentations.Instrumentation
+	appMetrics     bool
+	metricWildcard bool
 }
 
 var protocolMappings = []protocolMapping{
-	{name: "http", instr: instrumentations.InstrumentationHTTP, appMetrics: true},
-	{name: "grpc", instr: instrumentations.InstrumentationGRPC, appMetrics: true},
-	{name: "sql", instr: instrumentations.InstrumentationSQL, appMetrics: true},
-	{name: "redis", instr: instrumentations.InstrumentationRedis, appMetrics: true},
-	{name: "kafka", instr: instrumentations.InstrumentationKafka, appMetrics: true},
-	{name: "mqtt", instr: instrumentations.InstrumentationMQTT, appMetrics: true},
-	{name: "nats", instr: instrumentations.InstrumentationNATS, appMetrics: true},
-	{name: "amqp", instr: instrumentations.InstrumentationAMQP, appMetrics: true},
-	{name: "mongo", instr: instrumentations.InstrumentationMongo, appMetrics: true},
-	{name: "couchbase", instr: instrumentations.InstrumentationCouchbase, appMetrics: true},
-	{name: "memcached", instr: instrumentations.InstrumentationMemcached, appMetrics: true},
+	{name: "http", instr: instrumentations.InstrumentationHTTP, appMetrics: true, metricWildcard: true},
+	{name: "grpc", instr: instrumentations.InstrumentationGRPC, appMetrics: true, metricWildcard: true},
+	{name: "sql", instr: instrumentations.InstrumentationSQL, appMetrics: true, metricWildcard: true},
+	{name: "redis", instr: instrumentations.InstrumentationRedis, appMetrics: true, metricWildcard: true},
+	{name: "kafka", instr: instrumentations.InstrumentationKafka, appMetrics: true, metricWildcard: true},
+	{name: "mongo", instr: instrumentations.InstrumentationMongo, appMetrics: true, metricWildcard: true},
+	{name: "couchbase", instr: instrumentations.InstrumentationCouchbase, appMetrics: true, metricWildcard: true},
 	{name: "dns", instr: instrumentations.InstrumentationDNS, appMetrics: false},
-	{name: "gpu", instr: instrumentations.InstrumentationGPU, appMetrics: true},
-	{name: "genai", instr: instrumentations.InstrumentationGenAI, appMetrics: true},
+	{name: "gpu", instr: instrumentations.InstrumentationGPU, appMetrics: true, metricWildcard: true},
 }


### PR DESCRIPTION
## Summary

Adds the second internal implementation slice for config v2 from #2251:

- add `internal/config/convert` for internal v1 runtime/default config to hidden v2 document conversion
- convert core capture foundation fields: policy, engine, channels, safety, limits, runtime toggles, protocol enablement, basic network capture, and daemon basics
- keep the conversion internal-only and parser-compatible with the `internal/config/schema` package added in #2252

## Context

Parent issue: #2251

This implements the "Internal v1-to-v2 conversion foundation" part of the serial config v2 landing plan. The issue originally named this package as `internal/configconv`, but this PR uses `internal/config/convert` instead so config v2 internals stay grouped under `internal/config/...` with clear call sites such as `convert.RuntimeToV2(cfg)`.

## Scope

This PR intentionally does not add public config v2 APIs, CLI commands, runtime v2 parsing, Collector receiver v2 parsing, generated artifacts, or user-facing config v2 docs.

This PR also leaves the larger parity work to later slices: discovery rule conversion, filters, attributes/enrichment, correlation, stats, HTTP enrichment, GenAI payload extraction, and top-level OTel pipeline conversion are not included here.

## Tests

- `make generate`
- `go test ./internal/config/schema ./internal/config/convert`
- `go test ./internal/config/...`
- `go test ./cmd/check-config-v2-parity`