### PR TITLE
fix(2259): share the java_tasks map with the tpinjector program

### DIFF
--- a/bpf/maps/java_tasks.h
+++ b/bpf/maps/java_tasks.h
@@ -8,10 +8,12 @@
 #include <bpfcore/bpf_helpers.h>
 
 #include <common/map_sizing.h>
+#include <common/pin_internal.h>
 
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __type(key, pid_key_t);   // the client thread
     __type(value, pid_key_t); // the server thread
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } java_tasks SEC(".maps");

--- a/internal/test/integration/docker-compose-java-dist.yml
+++ b/internal/test/integration/docker-compose-java-dist.yml
@@ -9,6 +9,15 @@ services:
       LOG_LEVEL: DEBUG
       OTEL_SERVICE_NAME: testserver
 
+  downstream:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/testserver/Dockerfile
+    image: hatest-testserver
+    environment:
+      STD_PORT: "8086"
+      LOG_LEVEL: DEBUG
+
   obi:
     build:
       context: ../../..

--- a/internal/test/integration/java_dist_test.go
+++ b/internal/test/integration/java_dist_test.go
@@ -51,6 +51,31 @@ func testJavaNestedTraces(t *testing.T, slug string) {
 	}, 2*time.Minute, 5*time.Second)
 }
 
+func testJavaNestedTracesPlainHTTP(t *testing.T, slug string) {
+	t.Log("checking server to client nesting over plain HTTP for [/api/" + slug + "]")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		for i := 0; i < 10; i++ {
+			ti.DoHTTPGet(ct, "http://localhost:8081/api/"+slug+"?url=http://downstream:8086/rolldice/1", 200)
+		}
+
+		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=GET%20%2Fapi%2F" + slug)
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+		traces := tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/api/" + slug})
+		require.GreaterOrEqual(ct, len(traces), 10)
+		nested := 0
+		for _, trace := range traces {
+			nested += len(trace.FindByOperationName("GET /rolldice/1", "client"))
+		}
+		require.GreaterOrEqual(ct, nested*10, len(traces)*8)
+	}, 2*time.Minute, 5*time.Second)
+}
+
 func TestJavaNestedTraces(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-java-dist.yml", path.Join(pathOutput, "test-suite-java-dist.log"))
 	require.NoError(t, err)
@@ -64,6 +89,12 @@ func TestJavaNestedTraces(t *testing.T) {
 	for _, slug := range []string{"request", "async-request", "async-request-c", "async-request-fj"} {
 		t.Run("Nested traces for "+slug, func(t *testing.T) {
 			testJavaNestedTraces(t, slug)
+		})
+	}
+
+	for _, slug := range []string{"async-request-c", "async-request-fj"} {
+		t.Run("Nested traces over plain HTTP for "+slug, func(t *testing.T) {
+			testJavaNestedTracesPlainHTTP(t, slug)
 		})
 	}
 


### PR DESCRIPTION
## What

Adds `OBI_PIN_INTERNAL` to the `java_tasks` BPF map, plus integration coverage for executor handoffs with a plain-HTTP downstream.

Fixes #2259

## Why

`find_parent_java_trace` walks `java_tasks` from two BPF objects: generictracer, which also populates the map from its ioctl handler, and tpinjector via `common/trace_parent.h`. With `OTEL_EBPF_BPF_CONTEXT_PROPAGATION=all` the tpinjector sk_msg program decides the traceparent of plain-HTTP client requests, and without a pinning attribute it resolves a private, always empty copy of the map, so any Java client call running on a different thread than the server read loses its trace context (measured ~95% of pool-handoff requests broken, details in #2259). `server_traces` already uses the same internal pinning.

The existing async cases in `TestJavaNestedTraces` did not catch this because they call httpbin over TLS, and the TLS path resolves the parent through the generictracer ioctl handler, which sees the populated map.

## Test

The new `Nested traces over plain HTTP` cases drive `/api/async-request-c` and `/api/async-request-fj` against a local plain-HTTP target (a second testserver instance on a port outside the instrumented range) and require at least 80% of the returned server traces to contain the nested client span. The ratio assertion matters: the first request on a fresh connection correlates through the connect-time path even without the fix, so a single-request assertion can pass by luck on main.

Verified locally: on main without the map change both new cases fail for the full retry window (nested ratio stays under 10%); with it the whole `TestJavaNestedTraces` suite passes, including the weaver validation.