### PR TITLE
fix(2262): inline IOCTLPacket calls in the SSLSocket read advices

### DIFF
--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SSLSocketStreamInst.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/SSLSocketStreamInst.java
@@ -81,11 +81,9 @@ public class SSLSocketStreamInst {
                             .and(ElementMatchers.takesArgument(0, byte[].class))));
   }
 
-  static int writeReadPacket(NativeMemory p, Socket socket, byte[] b, int off, int len) {
-    int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, len);
-    return IOCTLPacket.writePacketBuffer(p, wOff, b, off, len);
-  }
-
+  // The advice bytecode below is inlined into sun.security.ssl classes, which live in the
+  // bootstrap classloader: it must only reference bootstrap-injected classes (see
+  // Agent.injectBootstrapClasses), never SSLSocketStreamInst itself.
   public static final class InputStreamReadAdvice {
     @Advice.OnMethodExit(suppress = Throwable.class)
     public static void read(
@@ -110,7 +108,8 @@ public class SSLSocketStreamInst {
         if (socket != null) {
           try {
             NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + len);
-            writeReadPacket(p, socket, b, 0, len);
+            int wOff = IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, len);
+            IOCTLPacket.writePacketBuffer(p, wOff, b, 0, len);
             Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
           } catch (Throwable t) {
             if (SSLStorage.debugOn) {
@@ -146,7 +145,9 @@ public class SSLSocketStreamInst {
         if (socket != null) {
           try {
             NativeMemory p = new NativeMemory(IOCTLPacket.packetPrefixSize + bytesRead);
-            writeReadPacket(p, socket, b, off, bytesRead);
+            int wOff =
+                IOCTLPacket.writePacketPrefix(p, 0, OperationType.RECEIVE, socket, bytesRead);
+            IOCTLPacket.writePacketBuffer(p, wOff, b, off, bytesRead);
             Agent.NativeLib.ioctl(0, Agent.IOCTL_CMD, p.getAddress());
           } catch (Throwable t) {
             if (SSLStorage.debugOn) {

--- a/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/SSLSocketStreamInstTest.java
+++ b/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/SSLSocketStreamInstTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import io.opentelemetry.obi.java.ebpf.IOCTLPacket;
 import io.opentelemetry.obi.java.ebpf.NativeMemory;
+import io.opentelemetry.obi.java.ebpf.OperationType;
+import java.net.Socket;
 import org.junit.jupiter.api.Test;
 
 class SSLSocketStreamInstTest {
@@ -19,7 +21,10 @@ class SSLSocketStreamInstTest {
     int bytesRead = 3;
     NativeMemory packet = new NativeMemory(IOCTLPacket.packetPrefixSize + bytesRead + 1, true);
 
-    int end = SSLSocketStreamInst.writeReadPacket(packet, null, buffer, 0, bytesRead);
+    // same call sequence the read advices inline
+    int wOff =
+        IOCTLPacket.writePacketPrefix(packet, 0, OperationType.RECEIVE, (Socket) null, bytesRead);
+    int end = IOCTLPacket.writePacketBuffer(packet, wOff, buffer, 0, bytesRead);
 
     assertEquals(IOCTLPacket.packetPrefixSize + bytesRead, end);
     assertEquals(bytesRead, packet.getInt(IOCTLPacket.packetPrefixSize - Integer.BYTES));


### PR DESCRIPTION
Resolves #2262

## Problem

#2262: a Java app making blocking HTTPS calls (`HttpsURLConnection` or classic Apache HttpClient, the JSSE `SSLSocket` path) over keep-alive connections gets almost no client spans, and the few captured ones have status 499 with an empty response.

The read advices of `SSLSocketStreamInst` are inlined by ByteBuddy into `sun.security.ssl.SSLSocketImpl$AppInputStream`, a bootstrap-classloader class, but they called the static helper `SSLSocketStreamInst.writeReadPacket(...)`. `SSLSocketStreamInst` is not bootstrap-injected (only the classes force-loaded by `Agent.initClassesThatNeedToBeBootstrapped` are), so every read advice threw `NoClassDefFoundError`, silently swallowed by the `Throwable` handler, and the decrypted response never reached eBPF. Full analysis in the issue.

## Fix

Inline the `IOCTLPacket.writePacketPrefix(RECEIVE)` + `writePacketBuffer` calls in both read advices, exactly like the working write advices do, and delete the helper. The inlined code only references bootstrap-injected classes; a comment documents the constraint. The existing unit test (from #2218) keeps guarding the bytes-read semantics through the same call sequence the advices now inline.

## Validation

Per-request oracle (Spring Boot app calling an nginx TLS downstream with keep-alive, unique URL path ids, platform threads, concurrency 40), same main checkout:

| build | client spans | statuses |
|---|---|---|
| main | 24/398 (374 requests with no span) | all 499, responseLen 0 |
| this fix | 388/400, every span parented to its own request's server span | all 200 |

The remaining 12 are the last in-flight request per keep-alive connection, submitted only on the next event on that connection (the delayed-finish facet noted in the issue, out of scope here).

The existing Java TLS integration tests do not cover this path (they use netty/WebClient, the `SSLEngine` path, where helper resolution works); unit tests and spotless pass.
