### PR TITLE
Add OpenShift cluster name auto-detection

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -84,7 +84,7 @@ InstanceIDConfig configures how OBI will get the Instance ID of the traces/metri
 
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
 |---|---|---|---|---|---|---|
-| `attributes.kubernetes.cluster_name` | `string` | `OTEL_EBPF_KUBE_CLUSTER_NAME` |  |  |  | Overrides cluster name. If empty, the NetO11y module will try to retrieve it from the Cloud Provider Metadata (EC2, GCP and Azure), and leave it empty if it fails to. |
+| `attributes.kubernetes.cluster_name` | `string` | `OTEL_EBPF_KUBE_CLUSTER_NAME` |  |  |  | Overrides cluster name. If empty, OBI will try to retrieve it from node labels, the OpenShift Infrastructure CR, or cloud provider metadata (EC2, GCP, Azure), and leave it empty if all fail. |
 | `attributes.kubernetes.disable_informers` | `string`[] | `OTEL_EBPF_KUBE_DISABLE_INFORMERS` |  |  |  | Allows selectively disabling some informers. Accepted value is a list that might contain node or service. Disabling any of them will cause metadata to be incomplete but will reduce the load of the Kube API. Pods informer can't be disabled. For that purpose, you should disable the whole kubernetes metadata decoration. |
 | `attributes.kubernetes.drop_external` | `boolean` | `OTEL_EBPF_NETWORK_DROP_EXTERNAL` | `false` |  |  | Will drop, in NetO11y component, any flow where the source or destination IPs are not matched to any kubernetes entity, assuming they are cluster-external |
 | `attributes.kubernetes.enable` | `string` | `OTEL_EBPF_KUBE_METADATA_ENABLE` | `autodetect` | `autodetect`, `false`, `true` |  |  |

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -1443,7 +1443,7 @@
       "properties": {
         "cluster_name": {
           "type": "string",
-          "description": "Overrides cluster name. If empty, the NetO11y module will try to retrieve it from the Cloud Provider Metadata (EC2, GCP and Azure), and leave it empty if it fails to.",
+          "description": "Overrides cluster name. If empty, OBI will try to retrieve it from node labels, the OpenShift Infrastructure CR, or cloud provider metadata (EC2, GCP, Azure), and leave it empty if all fail.",
           "x-env-var": "OTEL_EBPF_KUBE_CLUSTER_NAME"
         },
         "disable_informers": {

--- a/devdocs/k8s-cache.md
+++ b/devdocs/k8s-cache.md
@@ -232,6 +232,17 @@ rules:
 discovery. If you disable those in your OBI config you can drop the
 corresponding rules too.
 
+On OpenShift, OBI can auto-detect the cluster name from the Infrastructure CR.
+This requires an additional rule:
+
+```yaml
+  - apiGroups: ["config.openshift.io"]
+    resources: ["infrastructures"]
+    verbs: ["get"]
+```
+
+Without it, the fetcher fails gracefully and the next provider is tried.
+
 ## Internal metrics
 
 When `OTEL_EBPF_K8S_CACHE_INTERNAL_METRICS_PROMETHEUS_PORT` is set, the

--- a/pkg/kube/informer_provider.go
+++ b/pkg/kube/informer_provider.go
@@ -107,6 +107,10 @@ func (mp *MetadataProvider) ForceDisable() {
 	mp.cfg.Enable = kubeflags.EnabledFalse
 }
 
+func (mp *MetadataProvider) RestConfig() (*rest.Config, error) {
+	return loadKubeConfig(mp.cfg.KubeConfigPath)
+}
+
 func (mp *MetadataProvider) KubeClient() (kubernetes.Interface, error) {
 	restCfg, err := loadKubeConfig(mp.cfg.KubeConfigPath)
 	if err != nil {

--- a/pkg/transform/clustername.go
+++ b/pkg/transform/clustername.go
@@ -146,7 +146,8 @@ func openshiftClusterNameFetcher(k8sInformer *kube.MetadataProvider) clusterName
 		}
 
 		client := &http.Client{Timeout: time.Second, Transport: transport}
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.Host+openshiftInfraPath, nil)
+		endpoint := strings.TrimRight(cfg.Host, "/") + openshiftInfraPath
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 		if err != nil {
 			return "", fmt.Errorf("creating request: %w", err)
 		}
@@ -158,12 +159,16 @@ func openshiftClusterNameFetcher(k8sInformer *kube.MetadataProvider) clusterName
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return "", fmt.Errorf("OpenShift API returned %d %s", resp.StatusCode, resp.Status)
+			return "", fmt.Errorf("OpenShift API returned %s", resp.Status)
 		}
 
 		var infra openshiftInfrastructureResponse
 		if err := json.NewDecoder(resp.Body).Decode(&infra); err != nil {
 			return "", fmt.Errorf("decoding infrastructure response: %w", err)
+		}
+
+		if infra.Status.InfrastructureName == "" {
+			return "", fmt.Errorf("OpenShift Infrastructure CR has empty infrastructureName")
 		}
 
 		return infra.Status.InfrastructureName, nil

--- a/pkg/transform/clustername.go
+++ b/pkg/transform/clustername.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -168,7 +169,7 @@ func openshiftClusterNameFetcher(k8sInformer *kube.MetadataProvider) clusterName
 		}
 
 		if infra.Status.InfrastructureName == "" {
-			return "", fmt.Errorf("OpenShift Infrastructure CR has empty infrastructureName")
+			return "", errors.New("OpenShift Infrastructure CR has empty infrastructureName")
 		}
 
 		return infra.Status.InfrastructureName, nil

--- a/pkg/transform/clustername.go
+++ b/pkg/transform/clustername.go
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	gcpMetadataURL   = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-name"
-	azureMetadataURL = "http://169.254.169.254/metadata/instance/compute/resourceGroupName?api-version=2017-08-01&format=text"
+	gcpMetadataURL       = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-name"
+	azureMetadataURL     = "http://169.254.169.254/metadata/instance/compute/resourceGroupName?api-version=2017-08-01&format=text"
+	openshiftInfraPath   = "/apis/config.openshift.io/v1/infrastructures/cluster"
 )
 
 var (
@@ -124,8 +125,6 @@ func eksClusterNameFetcher(ctx context.Context) (string, error) {
 	}
 	return "", fmt.Errorf("did not find any cluster attribute in %+v", resource.Attributes())
 }
-
-const openshiftInfraPath = "/apis/config.openshift.io/v1/infrastructures/cluster"
 
 type openshiftInfrastructureResponse struct {
 	Status struct {

--- a/pkg/transform/clustername.go
+++ b/pkg/transform/clustername.go
@@ -10,17 +10,15 @@ package transform // import "go.opentelemetry.io/obi/pkg/transform"
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
 	"go.opentelemetry.io/contrib/detectors/aws/eks"
+	"k8s.io/client-go/rest"
 
 	attr2 "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/kube"
@@ -49,7 +47,7 @@ func fetchClusterName(ctx context.Context, k8sInformer *kube.MetadataProvider) s
 		"EC2":       eksClusterNameFetcher,
 		"GCP":       gcpClusterNameFetcher,
 		"Azure":     azureClusterNameFetcher,
-		"OpenShift": openshiftClusterNameFetcher,
+		"OpenShift": openshiftClusterNameFetcher(k8sInformer),
 	}
 	for provider, fetch := range clusterNameFetchers {
 		log := log.With("provider", provider)
@@ -122,11 +120,7 @@ func eksClusterNameFetcher(ctx context.Context) (string, error) {
 	return "", fmt.Errorf("did not find any cluster attribute in %+v", resource.Attributes())
 }
 
-const (
-	saTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	saCACertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	openshiftInfraPath = "/apis/config.openshift.io/v1/infrastructures/cluster"
-)
+const openshiftInfraPath = "/apis/config.openshift.io/v1/infrastructures/cluster"
 
 type openshiftInfrastructureResponse struct {
 	Status struct {
@@ -134,59 +128,41 @@ type openshiftInfrastructureResponse struct {
 	} `json:"status"`
 }
 
-func openshiftClusterNameFetcher(ctx context.Context) (string, error) {
-	host := os.Getenv("KUBERNETES_SERVICE_HOST")
-	port := os.Getenv("KUBERNETES_SERVICE_PORT")
-	if host == "" || port == "" {
-		return "", fmt.Errorf("KUBERNETES_SERVICE_HOST/PORT not set")
-	}
+func openshiftClusterNameFetcher(k8sInformer *kube.MetadataProvider) clusterNameFetcher {
+	return func(ctx context.Context) (string, error) {
+		cfg, err := k8sInformer.RestConfig()
+		if err != nil {
+			return "", fmt.Errorf("loading kube config: %w", err)
+		}
 
-	token, err := os.ReadFile(saTokenPath)
-	if err != nil {
-		return "", fmt.Errorf("reading service account token: %w", err)
-	}
+		transport, err := rest.TransportFor(cfg)
+		if err != nil {
+			return "", fmt.Errorf("creating transport: %w", err)
+		}
 
-	caCert, err := os.ReadFile(saCACertPath)
-	if err != nil {
-		return "", fmt.Errorf("reading service account CA cert: %w", err)
-	}
-	caCertPool := x509.NewCertPool()
-	if !caCertPool.AppendCertsFromPEM(caCert) {
-		return "", fmt.Errorf("failed to parse CA certificate")
-	}
+		client := &http.Client{Timeout: time.Second, Transport: transport}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.Host+openshiftInfraPath, nil)
+		if err != nil {
+			return "", fmt.Errorf("creating request: %w", err)
+		}
 
-	client := &http.Client{
-		Timeout: time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: caCertPool,
-			},
-		},
-	}
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", fmt.Errorf("requesting OpenShift infrastructure CR: %w", err)
+		}
+		defer resp.Body.Close()
 
-	url := fmt.Sprintf("https://%s:%s%s", host, port, openshiftInfraPath)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return "", fmt.Errorf("creating request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+string(token))
+		if resp.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("OpenShift API returned %d %s", resp.StatusCode, resp.Status)
+		}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("requesting OpenShift infrastructure CR: %w", err)
-	}
-	defer resp.Body.Close()
+		var infra openshiftInfrastructureResponse
+		if err := json.NewDecoder(resp.Body).Decode(&infra); err != nil {
+			return "", fmt.Errorf("decoding infrastructure response: %w", err)
+		}
 
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("OpenShift API returned %d %s", resp.StatusCode, resp.Status)
+		return infra.Status.InfrastructureName, nil
 	}
-
-	var infra openshiftInfrastructureResponse
-	if err := json.NewDecoder(resp.Body).Decode(&infra); err != nil {
-		return "", fmt.Errorf("decoding infrastructure response: %w", err)
-	}
-
-	return infra.Status.InfrastructureName, nil
 }
 
 func nodeLabelsClusterNameFetcher(k8sInformer *kube.MetadataProvider) func(ctx context.Context) (string, error) {

--- a/pkg/transform/clustername.go
+++ b/pkg/transform/clustername.go
@@ -17,17 +17,18 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/contrib/detectors/aws/eks"
 	"k8s.io/client-go/rest"
+
+	"go.opentelemetry.io/contrib/detectors/aws/eks"
 
 	attr2 "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/kube"
 )
 
 const (
-	gcpMetadataURL       = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-name"
-	azureMetadataURL     = "http://169.254.169.254/metadata/instance/compute/resourceGroupName?api-version=2017-08-01&format=text"
-	openshiftInfraPath   = "/apis/config.openshift.io/v1/infrastructures/cluster"
+	gcpMetadataURL     = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-name"
+	azureMetadataURL   = "http://169.254.169.254/metadata/instance/compute/resourceGroupName?api-version=2017-08-01&format=text"
+	openshiftInfraPath = "/apis/config.openshift.io/v1/infrastructures/cluster"
 )
 
 var (

--- a/pkg/transform/clustername.go
+++ b/pkg/transform/clustername.go
@@ -38,18 +38,23 @@ var metadataClient = http.Client{Timeout: time.Second}
 
 type clusterNameFetcher func(context.Context) (string, error)
 
-// fetchClusterName tries to automatically detect the cluster name from
+// fetchClusterName tries to automatically guess the cluster name from
 // node labels, cloud providers (EC2, GCP, Azure), or OpenShift.
+// TODO: consider other providers (Alibaba, Oracle, etc...)
 func fetchClusterName(ctx context.Context, k8sInformer *kube.MetadataProvider) string {
 	log := klog().With("func", "fetchClusterName")
-	clusterNameFetchers := map[string]clusterNameFetcher{
-		"Label":     nodeLabelsClusterNameFetcher(k8sInformer),
-		"EC2":       eksClusterNameFetcher,
-		"GCP":       gcpClusterNameFetcher,
-		"Azure":     azureClusterNameFetcher,
-		"OpenShift": openshiftClusterNameFetcher(k8sInformer),
+	clusterNameFetchers := []struct {
+		provider string
+		fetch    clusterNameFetcher
+	}{
+		{"Label", nodeLabelsClusterNameFetcher(k8sInformer)},
+		{"OpenShift", openshiftClusterNameFetcher(k8sInformer)},
+		{"EC2", eksClusterNameFetcher},
+		{"GCP", gcpClusterNameFetcher},
+		{"Azure", azureClusterNameFetcher},
 	}
-	for provider, fetch := range clusterNameFetchers {
+	for _, f := range clusterNameFetchers {
+		provider, fetch := f.provider, f.fetch
 		log := log.With("provider", provider)
 		log.Debug("trying to retrieve cluster name")
 		if name, err := fetch(ctx); err != nil {

--- a/pkg/transform/clustername.go
+++ b/pkg/transform/clustername.go
@@ -10,9 +10,13 @@ package transform // import "go.opentelemetry.io/obi/pkg/transform"
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -36,16 +40,16 @@ var metadataClient = http.Client{Timeout: time.Second}
 
 type clusterNameFetcher func(context.Context) (string, error)
 
-// fetchClusterName tries to automatically guess the cluster name from three major
-// cloud providers: EC2, GCP, Azure.
-// TODO: consider other providers (Alibaba, Oracle, etc...)
+// fetchClusterName tries to automatically detect the cluster name from
+// node labels, cloud providers (EC2, GCP, Azure), or OpenShift.
 func fetchClusterName(ctx context.Context, k8sInformer *kube.MetadataProvider) string {
 	log := klog().With("func", "fetchClusterName")
 	clusterNameFetchers := map[string]clusterNameFetcher{
-		"Label": nodeLabelsClusterNameFetcher(k8sInformer),
-		"EC2":   eksClusterNameFetcher,
-		"GCP":   gcpClusterNameFetcher,
-		"Azure": azureClusterNameFetcher,
+		"Label":     nodeLabelsClusterNameFetcher(k8sInformer),
+		"EC2":       eksClusterNameFetcher,
+		"GCP":       gcpClusterNameFetcher,
+		"Azure":     azureClusterNameFetcher,
+		"OpenShift": openshiftClusterNameFetcher,
 	}
 	for provider, fetch := range clusterNameFetchers {
 		log := log.With("provider", provider)
@@ -116,6 +120,73 @@ func eksClusterNameFetcher(ctx context.Context) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("did not find any cluster attribute in %+v", resource.Attributes())
+}
+
+const (
+	saTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	saCACertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	openshiftInfraPath = "/apis/config.openshift.io/v1/infrastructures/cluster"
+)
+
+type openshiftInfrastructureResponse struct {
+	Status struct {
+		InfrastructureName string `json:"infrastructureName"`
+	} `json:"status"`
+}
+
+func openshiftClusterNameFetcher(ctx context.Context) (string, error) {
+	host := os.Getenv("KUBERNETES_SERVICE_HOST")
+	port := os.Getenv("KUBERNETES_SERVICE_PORT")
+	if host == "" || port == "" {
+		return "", fmt.Errorf("KUBERNETES_SERVICE_HOST/PORT not set")
+	}
+
+	token, err := os.ReadFile(saTokenPath)
+	if err != nil {
+		return "", fmt.Errorf("reading service account token: %w", err)
+	}
+
+	caCert, err := os.ReadFile(saCACertPath)
+	if err != nil {
+		return "", fmt.Errorf("reading service account CA cert: %w", err)
+	}
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return "", fmt.Errorf("failed to parse CA certificate")
+	}
+
+	client := &http.Client{
+		Timeout: time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: caCertPool,
+			},
+		},
+	}
+
+	url := fmt.Sprintf("https://%s:%s%s", host, port, openshiftInfraPath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+string(token))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("requesting OpenShift infrastructure CR: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("OpenShift API returned %d %s", resp.StatusCode, resp.Status)
+	}
+
+	var infra openshiftInfrastructureResponse
+	if err := json.NewDecoder(resp.Body).Decode(&infra); err != nil {
+		return "", fmt.Errorf("decoding infrastructure response: %w", err)
+	}
+
+	return infra.Status.InfrastructureName, nil
 }
 
 func nodeLabelsClusterNameFetcher(k8sInformer *kube.MetadataProvider) func(ctx context.Context) (string, error) {

--- a/pkg/transform/clustername_test.go
+++ b/pkg/transform/clustername_test.go
@@ -74,4 +74,20 @@ func TestOpenshiftClusterNameFetcher(t *testing.T) {
 		_, err := fetcher(t.Context())
 		assert.ErrorContains(t, err, "OpenShift API returned 404")
 	})
+
+	t.Run("returns error on empty infrastructureName", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":{"infrastructureName":""}}`))
+		}))
+		defer srv.Close()
+
+		mp := kube.NewMetadataProvider(kube.MetadataConfig{
+			KubeConfigPath: newTestKubeConfig(t, srv.URL),
+		}, imetrics.NoopReporter{})
+
+		fetcher := openshiftClusterNameFetcher(mp)
+		_, err := fetcher(t.Context())
+		assert.ErrorContains(t, err, "empty infrastructureName")
+	})
 }

--- a/pkg/transform/clustername_test.go
+++ b/pkg/transform/clustername_test.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package transform
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	"go.opentelemetry.io/obi/pkg/kube"
+)
+
+func newTestKubeConfig(t *testing.T, serverURL string) string {
+	t.Helper()
+	kubeconfig := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: ` + serverURL + `
+    insecure-skip-tls-verify: true
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+users:
+- name: test
+  user: {}
+`
+	p := filepath.Join(t.TempDir(), "kubeconfig")
+	require.NoError(t, os.WriteFile(p, []byte(kubeconfig), 0o600))
+	return p
+}
+
+func TestOpenshiftClusterNameFetcher(t *testing.T) {
+	t.Run("returns infrastructureName on success", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, openshiftInfraPath, r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":{"infrastructureName":"my-cluster"}}`))
+		}))
+		defer srv.Close()
+
+		mp := kube.NewMetadataProvider(kube.MetadataConfig{
+			KubeConfigPath: newTestKubeConfig(t, srv.URL),
+		}, imetrics.NoopReporter{})
+
+		fetcher := openshiftClusterNameFetcher(mp)
+		name, err := fetcher(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, "my-cluster", name)
+	})
+
+	t.Run("returns error on non-200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		mp := kube.NewMetadataProvider(kube.MetadataConfig{
+			KubeConfigPath: newTestKubeConfig(t, srv.URL),
+		}, imetrics.NoopReporter{})
+
+		fetcher := openshiftClusterNameFetcher(mp)
+		_, err := fetcher(t.Context())
+		assert.ErrorContains(t, err, "OpenShift API returned 404")
+	})
+}

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -37,8 +37,9 @@ func klog() *slog.Logger {
 type KubernetesDecorator struct {
 	Enable kubeflags.EnableFlag `yaml:"enable" env:"OTEL_EBPF_KUBE_METADATA_ENABLE" validate:"oneof=true false autodetect"`
 
-	// ClusterName overrides cluster name. If empty, the NetO11y module will try to retrieve
-	// it from the Cloud Provider Metadata (EC2, GCP and Azure), and leave it empty if it fails to.
+	// ClusterName overrides cluster name. If empty, OBI will try to retrieve it from node labels,
+	// the OpenShift Infrastructure CR, or cloud provider metadata (EC2, GCP, Azure),
+	// and leave it empty if all fail.
 	ClusterName string `yaml:"cluster_name" env:"OTEL_EBPF_KUBE_CLUSTER_NAME"`
 
 	// KubeconfigPath specifies the path to the kubeconfig file. If unset, it will look in the usual location.


### PR DESCRIPTION
## Summary
- Auto-detect cluster name on OpenShift by querying the `Infrastructure` CR (`config.openshift.io/v1`) and reading `status.infrastructureName`
- Reuses the existing kube REST config via a new `MetadataProvider.RestConfig()` method, matching the pattern used by the node labels fetcher
- Uses an ordered slice instead of a map for cluster name fetchers, ensuring deterministic iteration: Label, OpenShift, EC2, GCP, Azure
- Adds unit tests for the OpenShift fetcher (success and error paths)
- Updates `cluster_name` config docs and k8s-cache RBAC docs to reflect the new provider

## RBAC

On OpenShift, the service account needs access to the Infrastructure CR:

```yaml
- apiGroups: ["config.openshift.io"]
  resources: ["infrastructures"]
  verbs: ["get"]
```

Without this, the OpenShift fetcher fails gracefully and the next provider is tried.

## Test plan
- [x] Deploy on an OpenShift cluster (CRC) and verify `k8s.cluster.name` is populated from `infrastructureName`
- [x] Verify behavior when RBAC permissions for `config.openshift.io` are not granted (graceful fallback, warns that you can specify cluster name via env var)
- [x] Unit tests for OpenShift fetcher: success response parsing and non-200 error handling

**AI disclosure:** Claude Code was used to assist with boilerplate, test scaffolding, and iteration. All code was reviewed, understood, and tested by the author.