### PR TITLE
Remove environment-based language detection to fix false positives from k8s Service Links

### DIFF
--- a/pkg/internal/procs/proclang.go
+++ b/pkg/internal/procs/proclang.go
@@ -48,13 +48,6 @@ func instrumentableFromModuleMap(moduleName string) svc.InstrumentableType {
 	return instrumentableFromModuleMapSharedLib(moduleName)
 }
 
-func instrumentableFromEnviron(environ string) svc.InstrumentableType {
-	if strings.Contains(environ, "ASPNET") || strings.Contains(environ, "DOTNET") {
-		return svc.InstrumentableDotnet
-	}
-	return svc.InstrumentableGeneric
-}
-
 func instrumentableFromSymbolName(symbol string) svc.InstrumentableType {
 	if strings.Contains(symbol, "rust_panic") {
 		return svc.InstrumentableRust

--- a/pkg/internal/procs/proclang_linux.go
+++ b/pkg/internal/procs/proclang_linux.go
@@ -58,15 +58,6 @@ func FindProcLanguage(pid app.PID) svc.InstrumentableType {
 		return t
 	}
 
-	bytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
-	if err != nil {
-		return svc.InstrumentableGeneric
-	}
-	t = instrumentableFromEnviron(string(bytes))
-	if t != svc.InstrumentableGeneric {
-		return t
-	}
-
 	// Last resort to tell Generic from C++ (and maybe others in the future)
 	for _, m := range maps {
 		t := instrumentableLastResort(m.Pathname)

--- a/pkg/internal/procs/proclang_test.go
+++ b/pkg/internal/procs/proclang_test.go
@@ -57,13 +57,6 @@ func TestSymbolDetection(t *testing.T) {
 	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromSymbolName("rust"))
 }
 
-func TestEnvironDetection(t *testing.T) {
-	assert.Equal(t, svc.InstrumentableDotnet, instrumentableFromEnviron("ASPNETCORE_HTTP_PORTS=8080"))
-	assert.Equal(t, svc.InstrumentableDotnet, instrumentableFromEnviron("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=true"))
-	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromEnviron("SOME_ENV_VAR=123"))
-	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromEnviron("DOT=1"))
-}
-
 func TestPathDetection(t *testing.T) {
 	assert.Equal(t, svc.InstrumentablePHP, instrumentableFromPath("php"))
 	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromPath("python"))


### PR DESCRIPTION
## Summary

Fixes #2215

- Deleted `instrumentableFromEnviron()` which did a loose substring match for `ASPNET`/`DOTNET` in any env var name
- Removed the `/proc/{pid}/environ` read and call from `FindProcLanguage()` in `proclang_linux.go`
- Removed the now-obsolete `TestEnvironDetection` test

## Why

Kubernetes Service Links (enabled by default) inject env vars like `SAMPLE_DOTNET_APP_SERVICE_HOST` into every pod in a namespace when a service name contains "dotnet". This caused the shell/generic process to be misidentified as `dotnet`.

As suggested by @grcevski, removing env-based detection altogether is the right fix — it was unreliable since env vars can be injected by external systems (k8s service links, OTel injector, etc.) regardless of the actual runtime. .NET processes are still correctly identified via the `libcoreclr.so` shared library check, which is a much stronger signal.

## Test plan

- All existing tests in `pkg/internal/procs/` pass
- `TestEnvironDetection` removed as the function no longer exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)