### PR TITLE
Add Go runtime hchan offset discovery

### DIFF
--- a/bpf/gotracer/go_offsets.h
+++ b/bpf/gotracer/go_offsets.h
@@ -85,6 +85,10 @@ typedef enum {
     _tracer_delegate_pos,
     _tracer_attribute_opt_off,
     _error_string_off,
+    // go runtime channels
+    _hchan_dataqsiz_pos,
+    _hchan_sendx_pos,
+    _hchan_recvx_pos,
     // go jsonrpc
     _jsonrpc_request_header_service_method_pos,
     // go mongodb

--- a/configs/offsets/tracker_input.json
+++ b/configs/offsets/tracker_input.json
@@ -29,7 +29,8 @@
       "bufio.Reader": ["buf", "w"],
       "runtime.moduledata": ["pcHeader", "pclntable", "minpc", "maxpc", "text", "etext"],
       "runtime.mstats": ["numgc", "numforcedgc"],
-      "runtime.gcControllerState": ["[1.19.0]memoryLimit", "gcPercent"]
+      "runtime.gcControllerState": ["[1.19.0]memoryLimit", "gcPercent"],
+      "runtime.hchan": ["dataqsiz", "sendx", "recvx"]
     }
   },
   "golang.org/x/net": {

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -277,6 +277,10 @@ func (p *Tracer) RegisterOffsets(fileInfo *exec.FileInfo, offsets *goexec.Offset
 		goexec.GrpcClientStreamStream,
 		// go manual spans
 		goexec.GoTracerDelegatePos,
+		// go runtime channels
+		goexec.HchanDataqsizPos,
+		goexec.HchanSendxPos,
+		goexec.HchanRecvxPos,
 		// go jsonrpc
 		goexec.GoJsonrpcRequestHeaderServiceMethodPos,
 		// go mongodb

--- a/pkg/internal/goexec/offsets.go
+++ b/pkg/internal/goexec/offsets.go
@@ -26,6 +26,26 @@ type FuncOffsets struct {
 
 type FieldOffsets map[GoOffset]any
 
+// HasGoChannelOffsets reports whether all runtime.hchan offsets needed for Go channel
+// span linking are available for an inspected executable.
+func (o *Offsets) HasGoChannelOffsets() bool {
+	if o == nil {
+		return false
+	}
+
+	for _, field := range []GoOffset{
+		HchanDataqsizPos,
+		HchanSendxPos,
+		HchanRecvxPos,
+	} {
+		if _, ok := o.Field[field].(uint64); !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 // InspectOffsets gets the memory addresses/offsets of the instrumenting function, as well as the required
 // parameters fields to be read from the eBPF code
 func InspectOffsets(execElf *exec.FileInfo, funcs []string) (*Offsets, error) {

--- a/pkg/internal/goexec/offsets.json
+++ b/pkg/internal/goexec/offsets.json
@@ -4,7 +4,7 @@
       "buf": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -16,7 +16,7 @@
       "w": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -30,7 +30,7 @@
       "buf": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -42,7 +42,7 @@
       "n": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -54,7 +54,7 @@
       "wr": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -68,7 +68,7 @@
       "val": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -82,7 +82,7 @@
       "ci": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -96,7 +96,7 @@
       "conn": {
         "versions": {
           "oldest": "1.40.0",
-          "newest": "1.48.2"
+          "newest": "1.50.2"
         },
         "offsets": [
           {
@@ -108,7 +108,7 @@
       "correlationID": {
         "versions": {
           "oldest": "1.40.0",
-          "newest": "1.48.2"
+          "newest": "1.50.2"
         },
         "offsets": [
           {
@@ -122,7 +122,7 @@
       "Conn": {
         "versions": {
           "oldest": "1.40.0",
-          "newest": "1.48.2"
+          "newest": "1.50.2"
         },
         "offsets": [
           {
@@ -136,7 +136,7 @@
       "correlationID": {
         "versions": {
           "oldest": "1.40.0",
-          "newest": "1.48.2"
+          "newest": "1.50.2"
         },
         "offsets": [
           {
@@ -272,7 +272,7 @@
       "config": {
         "versions": {
           "oldest": "5.0.0",
-          "newest": "5.9.2"
+          "newest": "5.10.0"
         },
         "offsets": [
           {
@@ -286,7 +286,7 @@
       "Host": {
         "versions": {
           "oldest": "5.0.0",
-          "newest": "5.9.2"
+          "newest": "5.10.0"
         },
         "offsets": [
           {
@@ -328,7 +328,7 @@
       "bw": {
         "versions": {
           "oldest": "9.0.0",
-          "newest": "9.19.0"
+          "newest": "9.20.0"
         },
         "offsets": [
           {
@@ -496,7 +496,7 @@
       "delegate": {
         "versions": {
           "oldest": "1.10.0",
-          "newest": "1.43.0"
+          "newest": "1.44.0"
         },
         "offsets": [
           {
@@ -514,7 +514,7 @@
       "fr": {
         "versions": {
           "oldest": "0.12.0",
-          "newest": "0.54.0"
+          "newest": "0.55.0"
         },
         "offsets": [
           {
@@ -554,7 +554,7 @@
       "nextStreamID": {
         "versions": {
           "oldest": "0.12.0",
-          "newest": "0.54.0"
+          "newest": "0.55.0"
         },
         "offsets": [
           {
@@ -582,7 +582,7 @@
       "tconn": {
         "versions": {
           "oldest": "0.12.0",
-          "newest": "0.54.0"
+          "newest": "0.55.0"
         },
         "offsets": [
           {
@@ -596,7 +596,7 @@
       "w": {
         "versions": {
           "oldest": "0.12.0",
-          "newest": "0.54.0"
+          "newest": "0.55.0"
         },
         "offsets": [
           {
@@ -610,7 +610,7 @@
       "Fields": {
         "versions": {
           "oldest": "0.12.0",
-          "newest": "0.54.0"
+          "newest": "0.55.0"
         },
         "offsets": [
           {
@@ -624,7 +624,7 @@
       "conn": {
         "versions": {
           "oldest": "0.12.0",
-          "newest": "0.54.0"
+          "newest": "0.55.0"
         },
         "offsets": [
           {
@@ -638,7 +638,7 @@
       "w": {
         "versions": {
           "oldest": "0.12.0",
-          "newest": "0.54.0"
+          "newest": "0.55.0"
         },
         "offsets": [
           {
@@ -896,7 +896,7 @@
       "IP": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -908,7 +908,7 @@
       "Port": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -922,7 +922,7 @@
       "conn": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -936,7 +936,7 @@
       "fd": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -950,7 +950,7 @@
       "laddr": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -962,7 +962,7 @@
       "raddr": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -976,7 +976,7 @@
       "ContentLength": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -988,7 +988,7 @@
       "Header": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1000,7 +1000,7 @@
       "Method": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1012,7 +1012,7 @@
       "URL": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1026,7 +1026,7 @@
       "ContentLength": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1038,7 +1038,7 @@
       "StatusCode": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1052,7 +1052,7 @@
       "rwc": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1064,7 +1064,7 @@
       "tlsState": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1078,7 +1078,7 @@
       "fr": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1118,7 +1118,7 @@
       "nextStreamID": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1158,7 +1158,7 @@
       "tconn": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1172,7 +1172,7 @@
       "w": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1190,7 +1190,7 @@
       "Fields": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1204,7 +1204,7 @@
       "conn": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1218,7 +1218,7 @@
       "conn": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1230,7 +1230,7 @@
       "tlsState": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1244,7 +1244,7 @@
       "ServiceMethod": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1258,7 +1258,7 @@
       "R": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1272,7 +1272,7 @@
       "Host": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1284,7 +1284,7 @@
       "Path": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1296,7 +1296,7 @@
       "Scheme": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1318,16 +1318,50 @@
             "since": "1.17.0"
           }
         ]
-      },
-      "memoryLimit": {
+      }
+    },
+    "runtime.hchan": {
+      "dataqsiz": {
         "versions": {
-          "oldest": "1.19.0",
+          "oldest": "1.17.0",
           "newest": "1.26.4"
         },
         "offsets": [
           {
             "offset": 8,
-            "since": "1.19.0"
+            "since": "1.17.0"
+          }
+        ]
+      },
+      "recvx": {
+        "versions": {
+          "oldest": "1.17.0",
+          "newest": "1.26.4"
+        },
+        "offsets": [
+          {
+            "offset": 48,
+            "since": "1.17.0"
+          },
+          {
+            "offset": 56,
+            "since": "1.23.0"
+          }
+        ]
+      },
+      "sendx": {
+        "versions": {
+          "oldest": "1.17.0",
+          "newest": "1.26.4"
+        },
+        "offsets": [
+          {
+            "offset": 40,
+            "since": "1.17.0"
+          },
+          {
+            "offset": 48,
+            "since": "1.23.0"
           }
         ]
       }
@@ -1336,7 +1370,7 @@
       "etext": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1348,7 +1382,7 @@
       "maxpc": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1360,7 +1394,7 @@
       "minpc": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1372,7 +1406,7 @@
       "pcHeader": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1384,7 +1418,7 @@
       "pclntable": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {
@@ -1396,7 +1430,7 @@
       "text": {
         "versions": {
           "oldest": "1.17.0",
-          "newest": "1.26.3"
+          "newest": "1.26.4"
         },
         "offsets": [
           {

--- a/pkg/internal/goexec/offsets.json
+++ b/pkg/internal/goexec/offsets.json
@@ -1318,6 +1318,18 @@
             "since": "1.17.0"
           }
         ]
+      },
+      "memoryLimit": {
+        "versions": {
+          "oldest": "1.19.0",
+          "newest": "1.26.4"
+        },
+        "offsets": [
+          {
+            "offset": 8,
+            "since": "1.19.0"
+          }
+        ]
       }
     },
     "runtime.hchan": {

--- a/pkg/internal/goexec/offsets_test.go
+++ b/pkg/internal/goexec/offsets_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"go.opentelemetry.io/obi/pkg/internal/testutil"
 )
 
@@ -21,4 +23,23 @@ func TestProcessNotFound(t *testing.T) {
 		}
 	}()
 	testutil.ReadChannel(t, finish, 5*time.Second)
+}
+
+func TestOffsets_HasGoChannelOffsets(t *testing.T) {
+	assert.False(t, (*Offsets)(nil).HasGoChannelOffsets())
+	assert.False(t, (&Offsets{}).HasGoChannelOffsets())
+	assert.False(t, (&Offsets{Field: FieldOffsets{
+		HchanDataqsizPos: uint64(8),
+		HchanSendxPos:    uint64(48),
+	}}).HasGoChannelOffsets())
+	assert.False(t, (&Offsets{Field: FieldOffsets{
+		HchanDataqsizPos: uint64(8),
+		HchanSendxPos:    uint64(48),
+		HchanRecvxPos:    int64(56),
+	}}).HasGoChannelOffsets())
+	assert.True(t, (&Offsets{Field: FieldOffsets{
+		HchanDataqsizPos: uint64(8),
+		HchanSendxPos:    uint64(48),
+		HchanRecvxPos:    uint64(56),
+	}}).HasGoChannelOffsets())
 }

--- a/pkg/internal/goexec/structmembers.go
+++ b/pkg/internal/goexec/structmembers.go
@@ -107,6 +107,10 @@ const (
 	GoTracerDelegatePos
 	GoTracerAttributeOptOffset
 	GoErrorStringOffset
+	// go runtime channels
+	HchanDataqsizPos
+	HchanSendxPos
+	HchanRecvxPos
 	// go jsonrpc
 	GoJsonrpcRequestHeaderServiceMethodPos
 	// go mongodb
@@ -424,6 +428,14 @@ var structMembers = map[string]structInfo{
 		lib: "go.opentelemetry.io/otel",
 		fields: map[string]GoOffset{
 			"delegate": GoTracerDelegatePos,
+		},
+	},
+	"runtime.hchan": {
+		lib: "go",
+		fields: map[string]GoOffset{
+			"dataqsiz": HchanDataqsizPos,
+			"sendx":    HchanSendxPos,
+			"recvx":    HchanRecvxPos,
 		},
 	},
 	"go.mongodb.org/mongo-driver/mongo.Collection": {

--- a/pkg/internal/goexec/structmembers_test.go
+++ b/pkg/internal/goexec/structmembers_test.go
@@ -82,6 +82,9 @@ func TestGoOffsetsFromDwarf(t *testing.T) {
 		MethodPtrPos:      uint64(0),
 		TCPAddrIPPtrPos:   uint64(0),
 		TCPAddrPortPtrPos: uint64(24),
+		HchanDataqsizPos:  uint64(8),
+		HchanSendxPos:     uint64(48),
+		HchanRecvxPos:     uint64(56),
 	}, offsets)
 }
 
@@ -103,11 +106,14 @@ func TestGoOffsetsWithoutDwarf(t *testing.T) {
 	require.NoError(t, err)
 	// this test might fail if a future Go version updates the internal structure of the used structs.
 	mustMatch(t, FieldOffsets{
-		URLPtrPos:    uint64(16),
-		PathPtrPos:   uint64(56),
-		ConnFdPos:    uint64(0),
-		FdLaddrPos:   uint64(96),
-		MethodPtrPos: uint64(0),
+		URLPtrPos:        uint64(16),
+		PathPtrPos:       uint64(56),
+		ConnFdPos:        uint64(0),
+		FdLaddrPos:       uint64(96),
+		MethodPtrPos:     uint64(0),
+		HchanDataqsizPos: uint64(8),
+		HchanSendxPos:    uint64(48),
+		HchanRecvxPos:    uint64(56),
 	}, offsets)
 }
 

--- a/pkg/internal/goexec/structmembers_test.go
+++ b/pkg/internal/goexec/structmembers_test.go
@@ -106,14 +106,16 @@ func TestGoOffsetsWithoutDwarf(t *testing.T) {
 	require.NoError(t, err)
 	// this test might fail if a future Go version updates the internal structure of the used structs.
 	mustMatch(t, FieldOffsets{
-		URLPtrPos:        uint64(16),
-		PathPtrPos:       uint64(56),
-		ConnFdPos:        uint64(0),
-		FdLaddrPos:       uint64(96),
-		MethodPtrPos:     uint64(0),
-		HchanDataqsizPos: uint64(8),
-		HchanSendxPos:    uint64(48),
-		HchanRecvxPos:    uint64(56),
+		URLPtrPos:                         uint64(16),
+		PathPtrPos:                        uint64(56),
+		ConnFdPos:                         uint64(0),
+		FdLaddrPos:                        uint64(96),
+		MethodPtrPos:                      uint64(0),
+		HchanDataqsizPos:                  uint64(8),
+		HchanSendxPos:                     uint64(48),
+		HchanRecvxPos:                     uint64(56),
+		RuntimeGCControllerMemoryLimitPos: uint64(8),
+		RuntimeGCControllerGCPercentPos:   uint64(0),
 	}, offsets)
 }
 


### PR DESCRIPTION
## Summary
- add `runtime.hchan` offset discovery for `dataqsiz`, `sendx`, and `recvx`
- keep the BPF/Go offset enum alignment for the new channel offsets
- load the new offsets into the Go tracer offset table and expose `Offsets.HasGoChannelOffsets()` for later probe gating

Part of #2238. This is the second slice after #2239.

## Scope
This slice intentionally does not add any user-facing configuration. It also does not add Go channel probes, channel-link events, pending-link reconstruction, span-link attachment logic, runtime behavior docs, or the runnable example stack. Those remain follow-up slices.

## Validation
- `make update-offsets`