### PR TITLE
Deprecate ip context propagation value and remove undocumented http alias

### DIFF
--- a/cmd/config-docs/main.go
+++ b/cmd/config-docs/main.go
@@ -689,22 +689,22 @@ func (g *DocGenerator) valuesString(original, resolved *Schema) string {
 		return ""
 	}
 
-	// Collect enum values from oneOf
+	// Collect enum values from oneOf (skip deprecated branches)
 	if len(s.OneOf) > 0 {
-		var allEnums []string
+		var allEnums, descs []string
 		for _, alt := range s.OneOf {
+			if alt.Deprecated {
+				continue
+			}
 			for _, e := range alt.Enum {
 				allEnums = append(allEnums, fmt.Sprintf("`%v`", e))
+			}
+			if alt.Description != "" {
+				descs = append(descs, alt.Description)
 			}
 		}
 		if len(allEnums) > 0 {
 			return strings.Join(unique(allEnums), ", ")
-		}
-		var descs []string
-		for _, alt := range s.OneOf {
-			if alt.Description != "" {
-				descs = append(descs, alt.Description)
-			}
 		}
 		if len(descs) > 0 {
 			return strings.Join(descs, "; ")
@@ -811,10 +811,24 @@ func (g *DocGenerator) defaultString(s *Schema) string {
 	}
 }
 
-// deprecatedString returns "Yes" if either schema is deprecated, empty otherwise.
+// deprecatedString returns "Yes" if the field is deprecated, "deprecated values: <v1>, <v2>" if
+// specific oneOf branches are deprecated, or empty otherwise.
 func (g *DocGenerator) deprecatedString(original, resolved *Schema) string {
 	if (original != nil && original.Deprecated) || (resolved != nil && resolved.Deprecated) {
 		return "Yes"
+	}
+	if resolved != nil {
+		var vals []string
+		for _, alt := range resolved.OneOf {
+			if alt.Deprecated {
+				for _, e := range alt.Enum {
+					vals = append(vals, fmt.Sprintf("`%v`", e))
+				}
+			}
+		}
+		if len(vals) > 0 {
+			return "deprecated values: " + strings.Join(vals, ", ")
+		}
 	}
 	return ""
 }

--- a/cmd/config-docs/main_test.go
+++ b/cmd/config-docs/main_test.go
@@ -173,6 +173,14 @@ func TestValuesString(t *testing.T) {
 		assert.Empty(t, result)
 	})
 
+	t.Run("oneOf skips deprecated branches", func(t *testing.T) {
+		s := &Schema{OneOf: []*Schema{
+			{Enum: []any{"a", "b"}},
+			{Enum: []any{"old"}, Deprecated: true},
+		}}
+		assert.Equal(t, "`a`, `b`", g.valuesString(s, s))
+	})
+
 	t.Run("nil", func(t *testing.T) {
 		assert.Empty(t, g.valuesString(nil, nil))
 	})
@@ -220,6 +228,27 @@ func TestDeprecatedString(t *testing.T) {
 	assert.Equal(t, "Yes", g.deprecatedString(nil, &Schema{Deprecated: true}))
 	assert.Empty(t, g.deprecatedString(&Schema{Deprecated: false}, nil))
 	assert.Empty(t, g.deprecatedString(nil, nil))
+
+	t.Run("deprecated oneOf branch emits values prefix", func(t *testing.T) {
+		s := &Schema{OneOf: []*Schema{
+			{Enum: []any{"a", "b"}},
+			{Enum: []any{"old"}, Deprecated: true},
+		}}
+		assert.Equal(t, "deprecated values: `old`", g.deprecatedString(nil, s))
+	})
+
+	t.Run("multiple deprecated values", func(t *testing.T) {
+		s := &Schema{OneOf: []*Schema{
+			{Enum: []any{"a"}},
+			{Enum: []any{"x", "y"}, Deprecated: true},
+		}}
+		assert.Equal(t, "deprecated values: `x`, `y`", g.deprecatedString(nil, s))
+	})
+
+	t.Run("no deprecated oneOf branch returns empty", func(t *testing.T) {
+		s := &Schema{OneOf: []*Schema{{Enum: []any{"a", "b"}}}}
+		assert.Empty(t, g.deprecatedString(nil, s))
+	})
 }
 
 func TestEnvVar(t *testing.T) {

--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -157,7 +157,7 @@ EBPFTracer configuration for eBPF programs
 | `ebpf.batch_timeout` | `duration` | `OTEL_EBPF_BPF_BATCH_TIMEOUT` | `1s` | `30s`, `5m`, `1ms`, etc |  | Specifies the timeout to forward the data batch if it didn't reach the BatchLength size |
 | `ebpf.bpf_debug` | `boolean` | `OTEL_EBPF_BPF_DEBUG` | `false` |  |  | Enables logging of eBPF program events |
 | `ebpf.bpf_fs_path` | `string` | `OTEL_EBPF_BPF_FS_PATH` | `/sys/fs/bpf/` |  |  | BPF path used to pin eBPF maps |
-| `ebpf.context_propagation` | `string` | `OTEL_EBPF_BPF_CONTEXT_PROPAGATION` | `disabled` | ``, `all`, `disabled` | deprecated values: `ip` | Enables distributed context propagation. Can be a combination of: headers/http, tcp (e.g., "headers,tcp" or "all") |
+| `ebpf.context_propagation` | `string` | `OTEL_EBPF_BPF_CONTEXT_PROPAGATION` | `disabled` | ``, `all`, `disabled` | deprecated values: `ip` | Enables distributed context propagation. Can be a combination of: headers, tcp (e.g., "headers,tcp" or "all") |
 | `ebpf.couchbase_db_cache_size` | `integer` | `OTEL_EBPF_COUCHBASE_DB_CACHE_SIZE` | `1024` |  |  |  |
 | `ebpf.disable_black_box_cp` | `boolean` | `OTEL_EBPF_BPF_DISABLE_BLACK_BOX_CP` | `false` |  |  | Disables OBI black-box context propagation. Used for testing purposes only. |
 | `ebpf.dns_request_timeout` | `duration` | `OTEL_EBPF_BPF_DNS_REQUEST_TIMEOUT` | `5s` | `30s`, `5m`, `1ms`, etc |  | DNS timeout after which we report failed event |

--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -157,7 +157,7 @@ EBPFTracer configuration for eBPF programs
 | `ebpf.batch_timeout` | `duration` | `OTEL_EBPF_BPF_BATCH_TIMEOUT` | `1s` | `30s`, `5m`, `1ms`, etc |  | Specifies the timeout to forward the data batch if it didn't reach the BatchLength size |
 | `ebpf.bpf_debug` | `boolean` | `OTEL_EBPF_BPF_DEBUG` | `false` |  |  | Enables logging of eBPF program events |
 | `ebpf.bpf_fs_path` | `string` | `OTEL_EBPF_BPF_FS_PATH` | `/sys/fs/bpf/` |  |  | BPF path used to pin eBPF maps |
-| `ebpf.context_propagation` | `string` | `OTEL_EBPF_BPF_CONTEXT_PROPAGATION` | `disabled` | ``, `all`, `disabled` |  | Enables distributed context propagation. Can be a combination of: headers, tcp (e.g., "headers,tcp" or "all") |
+| `ebpf.context_propagation` | `string` | `OTEL_EBPF_BPF_CONTEXT_PROPAGATION` | `disabled` | ``, `all`, `disabled` |  | Enables distributed context propagation. Can be a combination of: headers/http, tcp (e.g., "headers,tcp" or "all") |
 | `ebpf.couchbase_db_cache_size` | `integer` | `OTEL_EBPF_COUCHBASE_DB_CACHE_SIZE` | `1024` |  |  |  |
 | `ebpf.disable_black_box_cp` | `boolean` | `OTEL_EBPF_BPF_DISABLE_BLACK_BOX_CP` | `false` |  |  | Disables OBI black-box context propagation. Used for testing purposes only. |
 | `ebpf.dns_request_timeout` | `duration` | `OTEL_EBPF_BPF_DNS_REQUEST_TIMEOUT` | `5s` | `30s`, `5m`, `1ms`, etc |  | DNS timeout after which we report failed event |

--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -157,7 +157,7 @@ EBPFTracer configuration for eBPF programs
 | `ebpf.batch_timeout` | `duration` | `OTEL_EBPF_BPF_BATCH_TIMEOUT` | `1s` | `30s`, `5m`, `1ms`, etc |  | Specifies the timeout to forward the data batch if it didn't reach the BatchLength size |
 | `ebpf.bpf_debug` | `boolean` | `OTEL_EBPF_BPF_DEBUG` | `false` |  |  | Enables logging of eBPF program events |
 | `ebpf.bpf_fs_path` | `string` | `OTEL_EBPF_BPF_FS_PATH` | `/sys/fs/bpf/` |  |  | BPF path used to pin eBPF maps |
-| `ebpf.context_propagation` | `string` | `OTEL_EBPF_BPF_CONTEXT_PROPAGATION` | `disabled` | ``, `all`, `disabled` |  | Enables distributed context propagation. Can be a combination of: headers/http, tcp (e.g., "headers,tcp" or "all") |
+| `ebpf.context_propagation` | `string` | `OTEL_EBPF_BPF_CONTEXT_PROPAGATION` | `disabled` | ``, `all`, `disabled` | deprecated values: `ip` | Enables distributed context propagation. Can be a combination of: headers/http, tcp (e.g., "headers,tcp" or "all") |
 | `ebpf.couchbase_db_cache_size` | `integer` | `OTEL_EBPF_COUCHBASE_DB_CACHE_SIZE` | `1024` |  |  |  |
 | `ebpf.disable_black_box_cp` | `boolean` | `OTEL_EBPF_BPF_DISABLE_BLACK_BOX_CP` | `false` |  |  | Disables OBI black-box context propagation. Used for testing purposes only. |
 | `ebpf.dns_request_timeout` | `duration` | `OTEL_EBPF_BPF_DNS_REQUEST_TIMEOUT` | `5s` | `30s`, `5m`, `1ms`, etc |  | DNS timeout after which we report failed event |

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -262,16 +262,24 @@
         {
           "type": "string",
           "pattern": "^(headers|http|tcp)(,(headers|http|tcp))*$",
-          "description": "List of propagation methods to enable (headers/http for HTTP headers, tcp for TCP options), separated by commas",
+          "description": "Comma-separated list of propagation methods (headers/http for HTTP headers, tcp for TCP options)",
           "examples": [
             "headers",
             "tcp",
             "headers,tcp"
           ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "ip"
+          ],
+          "description": "IP options injection has been removed and has no effect",
+          "deprecated": true
         }
       ],
       "title": "Context Propagation Mode",
-      "description": "Configures distributed context propagation. Can be 'all' to enable all methods, 'disabled'/'' to disable, or a list of specific methods: 'headers' (or 'http') for HTTP headers, 'tcp' for TCP options."
+      "description": "Configures distributed context propagation. Can be 'all' to enable all methods, 'disabled'/'' to disable, or a comma-separated list of methods: 'headers' (or 'http') for HTTP headers, 'tcp' for TCP options (e.g. \"headers,tcp\")."
     },
     "CustomRoutesConfig": {
       "properties": {

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -261,8 +261,8 @@
         },
         {
           "type": "string",
-          "pattern": "^(headers|http|tcp)(,(headers|http|tcp))*$",
-          "description": "Comma-separated list of propagation methods (headers/http for HTTP headers, tcp for TCP options)",
+          "pattern": "^(headers|tcp)(,(headers|tcp))*$",
+          "description": "Comma-separated list of propagation methods (headers for HTTP headers, tcp for TCP options)",
           "examples": [
             "headers",
             "tcp",
@@ -279,7 +279,7 @@
         }
       ],
       "title": "Context Propagation Mode",
-      "description": "Configures distributed context propagation. Can be 'all' to enable all methods, 'disabled'/'' to disable, or a comma-separated list of methods: 'headers' (or 'http') for HTTP headers, 'tcp' for TCP options (e.g. \"headers,tcp\")."
+      "description": "Configures distributed context propagation. Can be 'all' to enable all methods, 'disabled'/'' to disable, or a comma-separated list of methods: 'headers' for HTTP headers, 'tcp' for TCP options (e.g. \"headers,tcp\")."
     },
     "CustomRoutesConfig": {
       "properties": {
@@ -613,7 +613,7 @@
         },
         "context_propagation": {
           "$ref": "#/$defs/ContextPropagationMode",
-          "description": "Enables distributed context propagation. Can be a combination of: headers/http, tcp (e.g., \"headers,tcp\" or \"all\")",
+          "description": "Enables distributed context propagation. Can be a combination of: headers, tcp (e.g., \"headers,tcp\" or \"all\")",
           "default": "disabled",
           "x-env-var": "OTEL_EBPF_BPF_CONTEXT_PROPAGATION"
         },

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -605,7 +605,7 @@
         },
         "context_propagation": {
           "$ref": "#/$defs/ContextPropagationMode",
-          "description": "Enables distributed context propagation. Can be a combination of: headers, tcp (e.g., \"headers,tcp\" or \"all\")",
+          "description": "Enables distributed context propagation. Can be a combination of: headers/http, tcp (e.g., \"headers,tcp\" or \"all\")",
           "default": "disabled",
           "x-env-var": "OTEL_EBPF_BPF_CONTEXT_PROPAGATION"
         },

--- a/devdocs/config/version-2.0/obi-extension.schema.json
+++ b/devdocs/config/version-2.0/obi-extension.schema.json
@@ -490,13 +490,25 @@
               "additionalProperties": false,
               "properties": {
                 "context_propagation": {
-                  "type": "string",
-                  "enum": [
-                    "disabled",
-                    "headers",
-                    "http",
-                    "tcp",
-                    "all"
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "disabled",
+                        "headers",
+                        "http",
+                        "tcp",
+                        "all"
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "ip"
+                      ],
+                      "deprecated": true,
+                      "description": "IP options injection has been removed and has no effect"
+                    }
                   ],
                   "default": "disabled",
                   "description": "Context propagation mode.\nValues include: `disabled`, `headers` (or `http`), `tcp`, `all`.\nIf omitted, `disabled` is used.\n"

--- a/devdocs/config/version-2.0/obi-extension.schema.json
+++ b/devdocs/config/version-2.0/obi-extension.schema.json
@@ -496,7 +496,6 @@
                       "enum": [
                         "disabled",
                         "headers",
-                        "http",
                         "tcp",
                         "all"
                       ]
@@ -511,7 +510,7 @@
                     }
                   ],
                   "default": "disabled",
-                  "description": "Context propagation mode.\nValues include: `disabled`, `headers` (or `http`), `tcp`, `all`.\nIf omitted, `disabled` is used.\n"
+                  "description": "Context propagation mode.\nValues include: `disabled`, `headers`, `tcp`, `all`.\nIf omitted, `disabled` is used.\n"
                 },
                 "override_bpfloop_enabled": {
                   "type": "boolean",

--- a/devdocs/config/version-2.0/obi-extension.schema.json
+++ b/devdocs/config/version-2.0/obi-extension.schema.json
@@ -494,12 +494,12 @@
                   "enum": [
                     "disabled",
                     "headers",
+                    "http",
                     "tcp",
-                    "ip",
                     "all"
                   ],
                   "default": "disabled",
-                  "description": "Context propagation mode.\nValues include: `disabled`, `headers`, `tcp`, `ip`, `all`.\nIf omitted, `disabled` is used.\n"
+                  "description": "Context propagation mode.\nValues include: `disabled`, `headers` (or `http`), `tcp`, `all`.\nIf omitted, `disabled` is used.\n"
                 },
                 "override_bpfloop_enabled": {
                   "type": "boolean",

--- a/devdocs/context-propagation.md
+++ b/devdocs/context-propagation.md
@@ -39,10 +39,10 @@ Context propagation allows distributed tracing by injecting trace context (trace
 
 Context propagation is controlled via `OTEL_EBPF_BPF_CONTEXT_PROPAGATION` which accepts a comma-separated list:
 
-- `headers` - Inject HTTP headers
+- `headers` (or `http`) - Inject HTTP headers
 - `tcp` - Inject TCP options
-- `all` - Enable all methods (default)
-- `disabled` - Disable context propagation
+- `all` - Enable all methods
+- `disabled` - Disable context propagation (default)
 
 Examples:
 

--- a/devdocs/context-propagation.md
+++ b/devdocs/context-propagation.md
@@ -39,7 +39,7 @@ Context propagation allows distributed tracing by injecting trace context (trace
 
 Context propagation is controlled via `OTEL_EBPF_BPF_CONTEXT_PROPAGATION` which accepts a comma-separated list:
 
-- `headers` (or `http`) - Inject HTTP headers
+- `headers` - Inject HTTP headers
 - `tcp` - Inject TCP options
 - `all` - Enable all methods
 - `disabled` - Disable context propagation (default)

--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -30,7 +30,6 @@ const (
 	StrContextPropagationDisabled = "disabled"
 	StrContextPropagationAll      = "all"
 	StrContextPropagationHeaders  = "headers"
-	StrContextPropagationHTTP     = "http"
 	StrContextPropagationTCP      = "tcp"
 )
 
@@ -79,7 +78,7 @@ type EBPFTracer struct {
 	HTTPRequestTimeout time.Duration `yaml:"http_request_timeout" env:"OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT" validate:"gte=0"`
 
 	// Enables distributed context propagation.
-	// Can be a combination of: headers/http, tcp (e.g., "headers,tcp" or "all")
+	// Can be a combination of: headers, tcp (e.g., "headers,tcp" or "all")
 	ContextPropagation ContextPropagationMode `yaml:"context_propagation" env:"OTEL_EBPF_BPF_CONTEXT_PROPAGATION"`
 
 	// Skips checking the kernel version for bpf_loop functionality. Some modified kernels have this
@@ -229,14 +228,14 @@ func (m *ContextPropagationMode) UnmarshalText(text []byte) error {
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
 		switch part {
-		case StrContextPropagationHeaders, StrContextPropagationHTTP:
+		case StrContextPropagationHeaders:
 			result |= ContextPropagationHeaders
 		case StrContextPropagationTCP:
 			result |= ContextPropagationTCP
 		case "ip":
 			slog.Warn("context_propagation value 'ip' is deprecated and has no effect; IP options injection has been removed")
 		default:
-			return fmt.Errorf("invalid value for context_propagation: '%s' (valid: all, disabled, headers, http, tcp)", part)
+			return fmt.Errorf("invalid value for context_propagation: '%s' (valid: all, disabled, headers, tcp)", part)
 		}
 	}
 
@@ -268,7 +267,7 @@ func (m ContextPropagationMode) MarshalText() ([]byte, error) {
 }
 
 func (ContextPropagationMode) JSONSchema() *jsonschema.Schema {
-	options := []string{StrContextPropagationHeaders, StrContextPropagationHTTP, StrContextPropagationTCP}
+	options := []string{StrContextPropagationHeaders, StrContextPropagationTCP}
 	optionsStr := strings.Join(options, "|")
 	optionsRegexp := fmt.Sprintf("^(%s)(,(%s))*$", optionsStr, optionsStr)
 	return &jsonschema.Schema{
@@ -280,7 +279,7 @@ func (ContextPropagationMode) JSONSchema() *jsonschema.Schema {
 			},
 			{
 				Type:        "string",
-				Description: "Comma-separated list of propagation methods (headers/http for HTTP headers, tcp for TCP options)",
+				Description: "Comma-separated list of propagation methods (headers for HTTP headers, tcp for TCP options)",
 				Examples:    []any{"headers", "tcp", "headers,tcp"},
 				Pattern:     optionsRegexp,
 			},
@@ -292,6 +291,6 @@ func (ContextPropagationMode) JSONSchema() *jsonschema.Schema {
 			},
 		},
 		Title:       "Context Propagation Mode",
-		Description: "Configures distributed context propagation. Can be 'all' to enable all methods, 'disabled'/'' to disable, or a comma-separated list of methods: 'headers' (or 'http') for HTTP headers, 'tcp' for TCP options (e.g. \"headers,tcp\").",
+		Description: "Configures distributed context propagation. Can be 'all' to enable all methods, 'disabled'/'' to disable, or a comma-separated list of methods: 'headers' for HTTP headers, 'tcp' for TCP options (e.g. \"headers,tcp\").",
 	}
 }

--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -270,22 +270,28 @@ func (m ContextPropagationMode) MarshalText() ([]byte, error) {
 func (ContextPropagationMode) JSONSchema() *jsonschema.Schema {
 	options := []string{StrContextPropagationHeaders, StrContextPropagationHTTP, StrContextPropagationTCP}
 	optionsStr := strings.Join(options, "|")
-	OptionsRegexp := fmt.Sprintf("^(%s)(,(%s))*$", optionsStr, optionsStr)
+	optionsRegexp := fmt.Sprintf("^(%s)(,(%s))*$", optionsStr, optionsStr)
 	return &jsonschema.Schema{
 		OneOf: []*jsonschema.Schema{
 			{
 				Type:        "string",
-				Enum:        []any{StrContextPropagationAll, StrContextPropagationDisabled, "", StrContextPropagationHeaders, StrContextPropagationHTTP, StrContextPropagationTCP},
+				Enum:        []any{StrContextPropagationAll, StrContextPropagationDisabled, ""},
 				Description: "Enable all propagation methods, disable propagation, or use empty string for disabled",
 			},
 			{
 				Type:        "string",
-				Description: "List of propagation methods to enable (headers/http for HTTP headers, tcp for TCP options), separated by commas",
+				Description: "Comma-separated list of propagation methods (headers/http for HTTP headers, tcp for TCP options)",
 				Examples:    []any{"headers", "tcp", "headers,tcp"},
-				Pattern:     OptionsRegexp,
+				Pattern:     optionsRegexp,
+			},
+			{
+				Type:        "string",
+				Enum:        []any{"ip"},
+				Deprecated:  true,
+				Description: "IP options injection has been removed and has no effect",
 			},
 		},
 		Title:       "Context Propagation Mode",
-		Description: "Configures distributed context propagation. Can be 'all' to enable all methods, 'disabled'/'' to disable, or a list of specific methods: 'headers' (or 'http') for HTTP headers, 'tcp' for TCP options.",
+		Description: "Configures distributed context propagation. Can be 'all' to enable all methods, 'disabled'/'' to disable, or a comma-separated list of methods: 'headers' (or 'http') for HTTP headers, 'tcp' for TCP options (e.g. \"headers,tcp\").",
 	}
 }

--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -79,7 +79,7 @@ type EBPFTracer struct {
 	HTTPRequestTimeout time.Duration `yaml:"http_request_timeout" env:"OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT" validate:"gte=0"`
 
 	// Enables distributed context propagation.
-	// Can be a combination of: headers, tcp (e.g., "headers,tcp" or "all")
+	// Can be a combination of: headers/http, tcp (e.g., "headers,tcp" or "all")
 	ContextPropagation ContextPropagationMode `yaml:"context_propagation" env:"OTEL_EBPF_BPF_CONTEXT_PROPAGATION"`
 
 	// Skips checking the kernel version for bpf_loop functionality. Some modified kernels have this
@@ -236,7 +236,7 @@ func (m *ContextPropagationMode) UnmarshalText(text []byte) error {
 		case "ip":
 			slog.Warn("context_propagation value 'ip' is deprecated and has no effect; IP options injection has been removed")
 		default:
-			return fmt.Errorf("invalid value for context_propagation: '%s' (valid: all, disabled, headers, tcp)", part)
+			return fmt.Errorf("invalid value for context_propagation: '%s' (valid: all, disabled, headers, http, tcp)", part)
 		}
 	}
 
@@ -275,7 +275,7 @@ func (ContextPropagationMode) JSONSchema() *jsonschema.Schema {
 		OneOf: []*jsonschema.Schema{
 			{
 				Type:        "string",
-				Enum:        []any{StrContextPropagationAll, StrContextPropagationDisabled, ""},
+				Enum:        []any{StrContextPropagationAll, StrContextPropagationDisabled, "", StrContextPropagationHeaders, StrContextPropagationHTTP, StrContextPropagationTCP},
 				Description: "Enable all propagation methods, disable propagation, or use empty string for disabled",
 			},
 			{

--- a/pkg/config/ebpf_tracer_test.go
+++ b/pkg/config/ebpf_tracer_test.go
@@ -32,11 +32,6 @@ func TestContextPropagationMode_UnmarshalText(t *testing.T) {
 			want:  ContextPropagationHeaders,
 		},
 		{
-			name:  "http alias",
-			input: "http",
-			want:  ContextPropagationHeaders,
-		},
-		{
 			name:  "tcp only",
 			input: "tcp",
 			want:  ContextPropagationTCP,


### PR DESCRIPTION
## Summary

This PR deprecates the `ip` value (IP options injection was already removed), the runtime now emits a warning and no-ops instead of rejecting the config.

It also removes "http" from the parser. It is technically a breaking change for anyone who had `context_propagation: http` in their config, but `http` was never documented or surfaced in any schema, so exposure is expected to be zero.

Finally, it also updates JSON schemas (main and v2) and the doc generator so deprecated values are surfaced in the "Deprecated" column ("deprecated values:...") of generated docs rather than silently dropped from the values list.

Note: it fixes also the doc: `disabled` is the default, not `all`.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
