### PR TITLE
(DynamicSelector-Phase2) Extend dynamic selection to network and stats

### DIFF
--- a/pkg/filter/dynamic_pid.go
+++ b/pkg/filter/dynamic_pid.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filter // import "go.opentelemetry.io/obi/pkg/filter"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/obi/pkg/internal/pipe"
+	"go.opentelemetry.io/obi/pkg/kube"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm/swarms"
+	"go.opentelemetry.io/obi/pkg/selection"
+)
+
+// ByDynamicPID provides a pipeline node that keeps only records whose source or destination IP
+// belongs to a dynamically selected application (via DynamicPIDSelector). When the selector is nil,
+// the node is bypassed.
+func ByDynamicPID[T any](
+	ctx context.Context,
+	selector selection.PIDSelector,
+	k8sInformer *kube.MetadataProvider,
+	attrs func(T) *pipe.CommonAttrs,
+	input, output *msg.Queue[[]T],
+) swarm.InstanceFunc {
+	return func(_ context.Context) (swarm.RunFunc, error) {
+		if selector == nil {
+			return swarm.Bypass(input, output)
+		}
+		var store *kube.Store
+		if k8sInformer != nil && k8sInformer.IsKubeEnabled() {
+			var err error
+			store, err = k8sInformer.Get(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
+		tracker := selection.NewDynamicAppIPs(selector, store)
+		in := input.Subscribe(msg.SubscriberName("filter.ByDynamicPID"))
+		return func(loopCtx context.Context) {
+			tracker.Run(loopCtx)
+			defer output.Close()
+			swarms.ForEachInput(loopCtx, in, nil, func(items []T) {
+				out := filterByDynamicPID(items, attrs, tracker)
+				if len(out) > 0 {
+					output.SendCtx(loopCtx, out)
+				}
+			})
+		}, nil
+	}
+}
+
+func filterByDynamicPID[T any](items []T, attrs func(T) *pipe.CommonAttrs, tracker *selection.DynamicAppIPs) []T {
+	writeIdx := 0
+	for readIdx := range items {
+		if tracker.Allows(attrs(items[readIdx])) {
+			items[writeIdx] = items[readIdx]
+			writeIdx++
+		}
+	}
+	return items[:writeIdx]
+}

--- a/pkg/filter/dynamic_pid.go
+++ b/pkg/filter/dynamic_pid.go
@@ -18,20 +18,19 @@ import (
 // belongs to a dynamically selected application (via DynamicPIDSelector). When the selector is nil,
 // the node is bypassed.
 func ByDynamicPID[T any](
-	ctx context.Context,
 	selector selection.PIDSelector,
 	k8sInformer *kube.MetadataProvider,
 	attrs func(T) *pipe.CommonAttrs,
 	input, output *msg.Queue[[]T],
 ) swarm.InstanceFunc {
-	return func(_ context.Context) (swarm.RunFunc, error) {
+	return func(instantiateCtx context.Context) (swarm.RunFunc, error) {
 		if selector == nil {
 			return swarm.Bypass(input, output)
 		}
 		var store *kube.Store
 		if k8sInformer != nil && k8sInformer.IsKubeEnabled() {
 			var err error
-			store, err = k8sInformer.Get(ctx)
+			store, err = k8sInformer.Get(instantiateCtx)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/instrumenter/instrumenter.go
+++ b/pkg/instrumenter/instrumenter.go
@@ -66,8 +66,8 @@ func RunWithContextInfo(
 	// Enable App O11y when config enables it or when the caller passed a dynamic PID selector
 	// (allows an "empty" instrumenter that only instruments PIDs added via the selector).
 	app := cfg.Enabled(obi.FeatureAppO11y) || ctxInfo.DynamicPIDSelector != nil
-	net := cfg.Enabled(obi.FeatureNetO11y)
-	stats := cfg.Enabled(obi.FeatureStatsO11y)
+	net := cfg.Enabled(obi.FeatureNetO11y) || ctxInfo.DynamicPIDSelector != nil
+	stats := cfg.Enabled(obi.FeatureStatsO11y) || ctxInfo.DynamicPIDSelector != nil
 
 	// if one of nodes fail, the other should stop
 	g, ctx := errgroup.WithContext(ctx)

--- a/pkg/netolly/agent/pipeline.go
+++ b/pkg/netolly/agent/pipeline.go
@@ -108,6 +108,11 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 		return flow.Decorate(ifaceNamer, commonDecoratedFlows, decoratedFlows), nil
 	}, swarm.WithID("FlowDecorator"))
 
+	dynamicFilteredFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "dynamicFilteredFlows")
+	swi.Add(filter.ByDynamicPID(ctx, f.ctxInfo.DynamicPIDSelector, f.ctxInfo.K8sInformer,
+		recordAttrs, decoratedFlows, dynamicFilteredFlows),
+		swarm.WithID("DynamicPIDFilter"))
+
 	filteredFlows := f.ctxInfo.OverrideNetExportQueue
 	if filteredFlows == nil {
 		filteredFlows = msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "filteredFlows")
@@ -119,7 +124,7 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 		ebpf.RecordStringGetters(ebpf.RecordGettersConfig{
 			PortGuessPolicy: f.cfg.NetworkFlows.GuessPorts,
 		}),
-		decoratedFlows,
+		dynamicFilteredFlows,
 		filteredFlows,
 	), swarm.WithID("AttributeFilter"))
 

--- a/pkg/netolly/agent/pipeline.go
+++ b/pkg/netolly/agent/pipeline.go
@@ -109,7 +109,7 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 	}, swarm.WithID("FlowDecorator"))
 
 	dynamicFilteredFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "dynamicFilteredFlows")
-	swi.Add(filter.ByDynamicPID(ctx, f.ctxInfo.DynamicPIDSelector, f.ctxInfo.K8sInformer,
+	swi.Add(filter.ByDynamicPID(f.ctxInfo.DynamicPIDSelector, f.ctxInfo.K8sInformer,
 		recordAttrs, decoratedFlows, dynamicFilteredFlows),
 		swarm.WithID("DynamicPIDFilter"))
 

--- a/pkg/selection/dynamic_app_ips.go
+++ b/pkg/selection/dynamic_app_ips.go
@@ -1,0 +1,159 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package selection // import "go.opentelemetry.io/obi/pkg/selection"
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/internal/helpers/container"
+	"go.opentelemetry.io/obi/pkg/internal/pipe"
+	"go.opentelemetry.io/obi/pkg/kube"
+)
+
+func selLog() *slog.Logger {
+	return slog.With("component", "selection.DynamicAppIPs")
+}
+
+// DynamicAppIPs tracks pod/container IPs for PIDs in a DynamicPIDSelector. It is used by
+// NetO11y and StatsO11y to restrict exported metrics to dynamically selected applications.
+type DynamicAppIPs struct {
+	selector PIDSelector
+	store    *kube.Store
+
+	mu         sync.RWMutex
+	allowedIPs map[string]int
+	pidToIPs   map[app.PID][]string
+}
+
+// NewDynamicAppIPs creates a tracker for the given selector and optional Kubernetes store.
+func NewDynamicAppIPs(selector PIDSelector, store *kube.Store) *DynamicAppIPs {
+	return &DynamicAppIPs{
+		selector:   selector,
+		store:      store,
+		allowedIPs: map[string]int{},
+		pidToIPs:   map[app.PID][]string{},
+	}
+}
+
+// Run listens for PID add/remove notifications and keeps the allowed IP set in sync.
+// It also preloads any PIDs already present in the selector.
+func (d *DynamicAppIPs) Run(ctx context.Context) {
+	if d.selector == nil {
+		return
+	}
+	d.refreshAll()
+
+	go d.loop(ctx, d.selector.AddedPIDsNotify(), d.addBatch)
+	go d.loop(ctx, d.selector.RemovedNotify(), d.removeBatch)
+}
+
+func (d *DynamicAppIPs) loop(ctx context.Context, ch <-chan []app.PID, fn func([]app.PID)) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case pids, ok := <-ch:
+			if !ok {
+				return
+			}
+			fn(pids)
+		}
+	}
+}
+
+func (d *DynamicAppIPs) refreshAll() {
+	pids, ok := d.selector.GetPIDs()
+	if !ok {
+		return
+	}
+	pidList := make([]app.PID, len(pids))
+	copy(pidList, pids)
+	d.addBatch(pidList)
+}
+
+func (d *DynamicAppIPs) addBatch(pids []app.PID) {
+	for _, pid := range pids {
+		ips := d.resolveIPs(pid)
+		if len(ips) == 0 {
+			selLog().Debug("no IPs resolved for dynamically selected PID", "pid", pid)
+			continue
+		}
+		d.mu.Lock()
+		if prevIPs, ok := d.pidToIPs[pid]; ok {
+			d.decrementIPsLocked(prevIPs)
+		}
+		d.pidToIPs[pid] = ips
+		d.incrementIPsLocked(ips)
+		d.mu.Unlock()
+	}
+}
+
+func (d *DynamicAppIPs) removeBatch(pids []app.PID) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, pid := range pids {
+		ips, ok := d.pidToIPs[pid]
+		if !ok {
+			continue
+		}
+		delete(d.pidToIPs, pid)
+		d.decrementIPsLocked(ips)
+		if d.store != nil {
+			d.store.DeleteProcess(pid)
+		}
+	}
+}
+
+func (d *DynamicAppIPs) incrementIPsLocked(ips []string) {
+	for _, ip := range ips {
+		d.allowedIPs[ip]++
+	}
+}
+
+func (d *DynamicAppIPs) decrementIPsLocked(ips []string) {
+	for _, ip := range ips {
+		d.allowedIPs[ip]--
+		if d.allowedIPs[ip] <= 0 {
+			delete(d.allowedIPs, ip)
+		}
+	}
+}
+
+func (d *DynamicAppIPs) resolveIPs(pid app.PID) []string {
+	if d.store == nil {
+		return nil
+	}
+	d.store.AddProcess(pid)
+	info, err := container.InfoForPID(pid)
+	if err != nil {
+		selLog().Debug("can't read container info for PID", "pid", pid, "error", err)
+		return nil
+	}
+	meta, _ := d.store.PodContainerByPIDNs(info.PIDNamespace, pid)
+	if meta == nil {
+		return nil
+	}
+	return append([]string(nil), meta.Meta.Ips...)
+}
+
+// Allows returns whether a flow/stat record should be exported for the current dynamic selection.
+// When the selector is empty, nothing is allowed (exclusive mode, matching DynamicMatcher).
+func (d *DynamicAppIPs) Allows(attrs *pipe.CommonAttrs) bool {
+	if d.selector == nil {
+		return true
+	}
+	if pids, ok := d.selector.GetPIDs(); !ok || len(pids) == 0 {
+		return false
+	}
+	src := attrs.SrcAddr.IP().String()
+	dst := attrs.DstAddr.IP().String()
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	_, srcOk := d.allowedIPs[src]
+	_, dstOk := d.allowedIPs[dst]
+	return srcOk || dstOk
+}

--- a/pkg/selection/dynamic_app_ips_test.go
+++ b/pkg/selection/dynamic_app_ips_test.go
@@ -1,0 +1,108 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package selection
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/internal/pipe"
+)
+
+type stubPIDSelector struct {
+	pids    []app.PID
+	addedCh chan []app.PID
+	removed chan []app.PID
+}
+
+func (s *stubPIDSelector) GetPIDs() ([]app.PID, bool) {
+	if len(s.pids) == 0 {
+		return nil, false
+	}
+	out := make([]app.PID, len(s.pids))
+	copy(out, s.pids)
+	return out, true
+}
+
+func (s *stubPIDSelector) AddedPIDsNotify() <-chan []app.PID { return s.addedCh }
+func (s *stubPIDSelector) RemovedNotify() <-chan []app.PID   { return s.removed }
+
+func TestDynamicAppIPs_Allows_emptySelectorBlocks(t *testing.T) {
+	sel := &stubPIDSelector{}
+	tracker := NewDynamicAppIPs(sel, nil)
+
+	attrs := &pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("10.0.0.1")),
+		DstAddr: pipe.IPAddr(net.ParseIP("10.0.0.2")),
+	}
+	assert.False(t, tracker.Allows(attrs))
+
+	sel.pids = []app.PID{42}
+	assert.False(t, tracker.Allows(attrs))
+}
+
+func TestDynamicAppIPs_Allows_matchingIP(t *testing.T) {
+	sel := &stubPIDSelector{pids: []app.PID{99}}
+	tracker := NewDynamicAppIPs(sel, nil)
+	tracker.addBatch([]app.PID{99})
+	tracker.mu.Lock()
+	tracker.pidToIPs[99] = []string{"10.1.1.5"}
+	tracker.allowedIPs["10.1.1.5"] = 1
+	tracker.mu.Unlock()
+
+	src := pipe.IPAddr(net.ParseIP("10.1.1.5"))
+	dst := pipe.IPAddr(net.ParseIP("10.2.2.2"))
+	assert.True(t, tracker.Allows(&pipe.CommonAttrs{SrcAddr: src, DstAddr: dst}))
+	assert.False(t, tracker.Allows(&pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("10.3.3.3")),
+		DstAddr: dst,
+	}))
+}
+
+func TestDynamicAppIPs_removeBatch(t *testing.T) {
+	sel := &stubPIDSelector{pids: []app.PID{1}}
+	tracker := NewDynamicAppIPs(sel, nil)
+	tracker.mu.Lock()
+	tracker.pidToIPs[1] = []string{"10.0.0.1"}
+	tracker.allowedIPs["10.0.0.1"] = 1
+	tracker.mu.Unlock()
+
+	tracker.removeBatch([]app.PID{1})
+	pids, ok := sel.GetPIDs()
+	require.True(t, ok)
+	require.Equal(t, []app.PID{1}, pids)
+
+	attrs := &pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("10.0.0.1")),
+		DstAddr: pipe.IPAddr(net.ParseIP("10.0.0.2")),
+	}
+	assert.False(t, tracker.Allows(attrs))
+}
+
+func TestDynamicAppIPs_sharedPodIP(t *testing.T) {
+	sel := &stubPIDSelector{pids: []app.PID{1, 2}}
+	tracker := NewDynamicAppIPs(sel, nil)
+
+	tracker.mu.Lock()
+	tracker.pidToIPs[1] = []string{"10.0.0.5"}
+	tracker.pidToIPs[2] = []string{"10.0.0.5"}
+	tracker.allowedIPs["10.0.0.5"] = 2
+	tracker.mu.Unlock()
+
+	attrs := &pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("10.0.0.5")),
+		DstAddr: pipe.IPAddr(net.ParseIP("10.0.0.9")),
+	}
+	assert.True(t, tracker.Allows(attrs))
+
+	tracker.removeBatch([]app.PID{1})
+	assert.True(t, tracker.Allows(attrs))
+
+	tracker.removeBatch([]app.PID{2})
+	assert.False(t, tracker.Allows(attrs))
+}

--- a/pkg/statsolly/agent/pipeline.go
+++ b/pkg/statsolly/agent/pipeline.go
@@ -70,11 +70,16 @@ func (s *Stats) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 	swi.Add(decorate.Decorate(s.agentIP, statAttrs, cidrDecoratedStats, decoratedStats),
 		swarm.WithID("StatsDecorator"))
 
+	dynamicFilteredStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "dynamicFilteredStats")
+	swi.Add(filter.ByDynamicPID(ctx, s.ctxInfo.DynamicPIDSelector, s.ctxInfo.K8sInformer,
+		statAttrs, decoratedStats, dynamicFilteredStats),
+		swarm.WithID("DynamicPIDFilter"))
+
 	filteredStats := s.ctxInfo.OverrideStatsExportQueue
 	if filteredStats == nil {
 		filteredStats = msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "filteredStats")
 	}
-	swi.Add(filter.ByAttribute(s.cfg.Filters.Stats, nil, selectorCfg.ExtraGroupAttributesCfg, ebpf.StatStringGetters, decoratedStats, filteredStats),
+	swi.Add(filter.ByAttribute(s.cfg.Filters.Stats, nil, selectorCfg.ExtraGroupAttributesCfg, ebpf.StatStringGetters, dynamicFilteredStats, filteredStats),
 		swarm.WithID("AttributeFilter"))
 
 	// Terminal nodes export the stats record information out of the pipeline: OTEL, Prom and printer.

--- a/pkg/statsolly/agent/pipeline.go
+++ b/pkg/statsolly/agent/pipeline.go
@@ -71,7 +71,7 @@ func (s *Stats) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 		swarm.WithID("StatsDecorator"))
 
 	dynamicFilteredStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "dynamicFilteredStats")
-	swi.Add(filter.ByDynamicPID(ctx, s.ctxInfo.DynamicPIDSelector, s.ctxInfo.K8sInformer,
+	swi.Add(filter.ByDynamicPID(s.ctxInfo.DynamicPIDSelector, s.ctxInfo.K8sInformer,
 		statAttrs, decoratedStats, dynamicFilteredStats),
 		swarm.WithID("DynamicPIDFilter"))
 


### PR DESCRIPTION
## Summary

Phase 2 of https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2234

This adds global dynamic pid selection to network and stats metrics.

The previous PR https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2250 moved the DynamicSelector from an AppO11y field to a global ContextField so it can be accessed by other pipelines. This means that any PID added via `selector.AddPIDs()` will be enabled for traces, network, and stats.

It works by adding a new filter node used by network and stats metrics to check if the data is in the allowed list of PIDs by IP. It adds a new IP-PID mapper helper, which keeps track of which PIDs are associated with which IP. It keeps a count of how many PIDs map to an IP, so that process exit events (such as sidecars) don't necessarily remove the IP from the map.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
