### PR TITLE
Expand config v2 capture export docs

### DIFF
--- a/cmd/check-config-v2-parity/main.go
+++ b/cmd/check-config-v2-parity/main.go
@@ -316,10 +316,96 @@ func mustMapNetworkFiltersPerSignal(cur map[string]any, ex map[string]any) error
 	return nil
 }
 
-func mustMapPayloadExtractionMembership(cur map[string]any, ex map[string]any, extractor string) error {
-	currentValue, ok := get(cur, "ebpf", "payload_extraction", "http", extractor, "enabled")
+func mustMapStatsFiltersPerSignal(cur map[string]any, ex map[string]any) error {
+	currentValue, ok := get(cur, "filter", "stats")
 	if !ok {
-		return fmt.Errorf("missing current key [ebpf payload_extraction http %s enabled]", extractor)
+		return errors.New("missing current key [filter stats]")
+	}
+
+	signals := []string{"traces", "metrics"}
+	for _, signal := range signals {
+		exampleValue, ok := get(ex, "obi", "capture", "network", "stats", "filters", signal)
+		if !ok {
+			return fmt.Errorf("missing example key [obi capture network stats filters %s]", signal)
+		}
+		if fmt.Sprintf("%v", currentValue) != fmt.Sprintf("%v", exampleValue) {
+			return fmt.Errorf("filter.stats mismatch for signal %s", signal)
+		}
+	}
+
+	return nil
+}
+
+func mustMapStatsFeatureDefaults(ex map[string]any) error {
+	enabledValue, ok := get(ex, "obi", "capture", "network", "stats", "enabled")
+	if !ok {
+		return errors.New("missing example key [obi capture network stats enabled]")
+	}
+	wantEnabled := obi.DefaultConfig.Enabled(obi.FeatureStatsO11y)
+	gotEnabled := fmt.Sprintf("%v", enabledValue) == "true"
+	if gotEnabled != wantEnabled {
+		return fmt.Errorf("stats enabled mismatch: current=%v example=%v", wantEnabled, gotEnabled)
+	}
+
+	featuresValue, ok := get(ex, "obi", "capture", "network", "stats", "features")
+	if !ok {
+		return errors.New("missing example key [obi capture network stats features]")
+	}
+
+	want := []string{}
+	features := obi.DefaultConfig.Metrics.Features
+	if features.StatsTCPRtt() {
+		want = append(want, "tcp_rtt")
+	}
+	if features.StatsTCPFailedConnections() {
+		want = append(want, "tcp_failed_connections")
+	}
+	if features.StatsTCPRetransmits() {
+		want = append(want, "tcp_retransmits")
+	}
+	if features.StatsTCPIo() {
+		want = append(want, "tcp_io")
+	}
+
+	got := toStringSlice(featuresValue)
+	if !sameStringSet(got, want) {
+		return fmt.Errorf("stats features mismatch: current=%v example=%v", want, got)
+	}
+
+	return nil
+}
+
+func sameStringSet(got []string, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := map[string]int{}
+	for _, item := range got {
+		seen[item]++
+	}
+	for _, item := range want {
+		seen[item]--
+		if seen[item] < 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func mustMapPayloadExtractionMembership(cur map[string]any, ex map[string]any, extractor string) error {
+	return mustMapPayloadExtractionMembershipAt(cur, ex,
+		[]string{"ebpf", "payload_extraction", "http", extractor, "enabled"}, extractor)
+}
+
+func mustMapPayloadExtractionMembershipAt(
+	cur map[string]any,
+	ex map[string]any,
+	curPath []string,
+	extractor string,
+) error {
+	currentValue, ok := get(cur, curPath...)
+	if !ok {
+		return fmt.Errorf("missing current key %v", curPath)
 	}
 
 	enabledValue, ok := get(ex, "obi", "capture", "instrumentation", "http", "payload_extraction", "enabled")
@@ -393,6 +479,8 @@ func parityChecks() []parityCheck {
 		{[]string{"ebpf", "mysql_prepared_statements_cache_size"}, []string{"obi", "capture", "instrumentation", "sql", "mysql", "prepared_statements_cache_size"}},
 		{[]string{"ebpf", "buffer_sizes", "postgres"}, []string{"obi", "capture", "instrumentation", "sql", "postgres", "buffer_size"}},
 		{[]string{"ebpf", "postgres_prepared_statements_cache_size"}, []string{"obi", "capture", "instrumentation", "sql", "postgres", "prepared_statements_cache_size"}},
+		{[]string{"ebpf", "buffer_sizes", "mssql"}, []string{"obi", "capture", "instrumentation", "sql", "mssql", "buffer_size"}},
+		{[]string{"ebpf", "mssql_prepared_statements_cache_size"}, []string{"obi", "capture", "instrumentation", "sql", "mssql", "prepared_statements_cache_size"}},
 		{[]string{"ebpf", "redis_db_cache", "enabled"}, []string{"obi", "capture", "instrumentation", "redis", "db_cache", "enabled"}},
 		{[]string{"ebpf", "buffer_sizes", "kafka"}, []string{"obi", "capture", "instrumentation", "kafka", "buffer_size"}},
 
@@ -406,16 +494,36 @@ func parityChecks() []parityCheck {
 		{[]string{"network", "deduper"}, []string{"obi", "capture", "network", "capture", "flow_lifecycle", "deduplication", "strategy"}},
 		{[]string{"network", "deduper_fc_ttl"}, []string{"obi", "capture", "network", "capture", "flow_lifecycle", "deduplication", "first_come_ttl"}},
 		{[]string{"network", "sampling"}, []string{"obi", "capture", "network", "capture", "flow_lifecycle", "sampling"}},
+		{[]string{"network", "guess_ports"}, []string{"obi", "capture", "network", "capture", "flow_lifecycle", "guess_ports"}},
 		{[]string{"network", "direction"}, []string{"obi", "capture", "network", "capture", "selection", "direction"}},
 		{[]string{"network", "listen_interfaces"}, []string{"obi", "capture", "network", "capture", "interface_discovery", "mode"}},
 		{[]string{"network", "listen_poll_period"}, []string{"obi", "capture", "network", "capture", "interface_discovery", "poll_interval"}},
 		{[]string{"network", "geo_ip", "cache_expiry"}, []string{"obi", "capture", "network", "capture", "enrichment", "geo_ip", "cache", "ttl"}},
+		{[]string{"network", "geo_ip", "cache_len"}, []string{"obi", "capture", "network", "capture", "enrichment", "geo_ip", "cache", "size"}},
+		{[]string{"network", "geo_ip", "ipinfo", "path"}, []string{"obi", "capture", "network", "capture", "enrichment", "geo_ip", "ipinfo", "path"}},
+		{[]string{"network", "geo_ip", "maxmind", "country_path"}, []string{"obi", "capture", "network", "capture", "enrichment", "geo_ip", "maxmind", "country_path"}},
+		{[]string{"network", "geo_ip", "maxmind", "asn_path"}, []string{"obi", "capture", "network", "capture", "enrichment", "geo_ip", "maxmind", "asn_path"}},
 		{[]string{"network", "reverse_dns", "cache_expiry"}, []string{"obi", "capture", "network", "capture", "enrichment", "reverse_dns", "cache", "ttl"}},
+		{[]string{"network", "reverse_dns", "cache_len"}, []string{"obi", "capture", "network", "capture", "enrichment", "reverse_dns", "cache", "size"}},
+		{[]string{"network", "reverse_dns", "type"}, []string{"obi", "capture", "network", "capture", "enrichment", "reverse_dns", "mode"}},
 		{[]string{"network", "print_flows"}, []string{"obi", "capture", "network", "capture", "diagnostics", "print_flows"}},
 		{[]string{"discovery", "min_process_age"}, []string{"obi", "capture", "policy", "min_process_age"}},
 		{[]string{"discovery", "route_harvester_timeout"}, []string{"obi", "capture", "instrumentation", "http", "routes", "discovery", "timeout"}},
 		{[]string{"discovery", "disabled_route_harvesters"}, []string{"obi", "capture", "instrumentation", "http", "routes", "discovery", "disabled_languages"}},
 		{[]string{"discovery", "route_harvester_advanced", "java_harvest_delay"}, []string{"obi", "capture", "instrumentation", "http", "routes", "discovery", "java", "delay"}},
+
+		{[]string{"stats", "agent_ip"}, []string{"obi", "capture", "network", "stats", "endpoint_identity", "agent_ip"}},
+		{[]string{"stats", "agent_ip_iface"}, []string{"obi", "capture", "network", "stats", "endpoint_identity", "agent_ip_interface"}},
+		{[]string{"stats", "agent_ip_type"}, []string{"obi", "capture", "network", "stats", "endpoint_identity", "agent_ip_family"}},
+		{[]string{"stats", "geo_ip", "cache_expiry"}, []string{"obi", "capture", "network", "stats", "enrichment", "geo_ip", "cache", "ttl"}},
+		{[]string{"stats", "geo_ip", "cache_len"}, []string{"obi", "capture", "network", "stats", "enrichment", "geo_ip", "cache", "size"}},
+		{[]string{"stats", "geo_ip", "ipinfo", "path"}, []string{"obi", "capture", "network", "stats", "enrichment", "geo_ip", "ipinfo", "path"}},
+		{[]string{"stats", "geo_ip", "maxmind", "country_path"}, []string{"obi", "capture", "network", "stats", "enrichment", "geo_ip", "maxmind", "country_path"}},
+		{[]string{"stats", "geo_ip", "maxmind", "asn_path"}, []string{"obi", "capture", "network", "stats", "enrichment", "geo_ip", "maxmind", "asn_path"}},
+		{[]string{"stats", "reverse_dns", "cache_expiry"}, []string{"obi", "capture", "network", "stats", "enrichment", "reverse_dns", "cache", "ttl"}},
+		{[]string{"stats", "reverse_dns", "cache_len"}, []string{"obi", "capture", "network", "stats", "enrichment", "reverse_dns", "cache", "size"}},
+		{[]string{"stats", "reverse_dns", "type"}, []string{"obi", "capture", "network", "stats", "enrichment", "reverse_dns", "mode"}},
+		{[]string{"stats", "print_stats"}, []string{"obi", "capture", "network", "stats", "diagnostics", "print_stats"}},
 
 		{[]string{"name_resolver", "cache_len"}, []string{"obi", "enrich", "service_name", "cache", "size"}},
 		{[]string{"name_resolver", "cache_expiry"}, []string{"obi", "enrich", "service_name", "cache", "ttl"}},
@@ -426,9 +534,15 @@ func parityChecks() []parityCheck {
 		{[]string{"attributes", "kubernetes", "informers_resync_period"}, []string{"obi", "enrich", "enrichers", "kubernetes", "informers", "resync_period"}},
 
 		{[]string{"routes", "unmatched"}, []string{"obi", "capture", "instrumentation", "http", "routes", "unmatched"}},
+		{[]string{"routes", "patterns"}, []string{"obi", "capture", "instrumentation", "http", "routes", "patterns"}},
+		{[]string{"routes", "ignored_patterns"}, []string{"obi", "capture", "instrumentation", "http", "routes", "ignored_patterns"}},
 		{[]string{"routes", "wildcard_char"}, []string{"obi", "capture", "instrumentation", "http", "routes", "wildcard_char"}},
 		{[]string{"routes", "max_path_segment_cardinality"}, []string{"obi", "capture", "instrumentation", "http", "routes", "max_path_segment_cardinality"}},
 		{[]string{"ebpf", "payload_extraction", "http", "sqlpp", "endpoint_patterns"}, []string{"obi", "capture", "instrumentation", "http", "payload_extraction", "sqlpp", "endpoint_patterns"}},
+		{[]string{"ebpf", "payload_extraction", "http", "enrichment", "policy", "default_action", "headers"}, []string{"obi", "capture", "instrumentation", "http", "payload_extraction", "enrichment", "policy", "default_action", "headers"}},
+		{[]string{"ebpf", "payload_extraction", "http", "enrichment", "policy", "default_action", "body"}, []string{"obi", "capture", "instrumentation", "http", "payload_extraction", "enrichment", "policy", "default_action", "body"}},
+		{[]string{"ebpf", "payload_extraction", "http", "enrichment", "policy", "obfuscation_string"}, []string{"obi", "capture", "instrumentation", "http", "payload_extraction", "enrichment", "policy", "obfuscation_string"}},
+		{[]string{"ebpf", "payload_extraction", "http", "enrichment", "rules"}, []string{"obi", "capture", "instrumentation", "http", "payload_extraction", "enrichment", "rules"}},
 
 		{[]string{"otel_metrics_export", "histogram_aggregation"}, []string{"meter_provider", "readers", "0", "periodic", "exporter", "otlp_grpc", "default_histogram_aggregation"}},
 		{[]string{"otel_metrics_export", "reporters_cache_len"}, []string{"obi", "capture", "telemetry", "metrics", "reporters_cache_len"}},
@@ -451,6 +565,8 @@ func parityChecks() []parityCheck {
 		{[]string{"shutdown_timeout"}, []string{"obi", "daemon", "shutdown", "timeout"}},
 		{[]string{"profile_port"}, []string{"obi", "daemon", "profiling", "port"}},
 		{[]string{"enforce_sys_caps"}, []string{"obi", "capture", "safety", "enforce_system_capabilities"}},
+		{[]string{"ebpf", "force_bpf_map_reader"}, []string{"obi", "capture", "engine", "traffic", "force_map_reader"}},
+		{[]string{"ebpf", "maps_config", "global_scale_factor"}, []string{"obi", "capture", "engine", "maps", "global_scale_factor"}},
 		{[]string{"channel_buffer_len"}, []string{"obi", "capture", "channels", "buffer_len"}},
 		{[]string{"channel_send_timeout"}, []string{"obi", "capture", "channels", "send_timeout"}},
 		{[]string{"channel_send_timeout_panic"}, []string{"obi", "capture", "channels", "panic_on_send_timeout"}},
@@ -475,6 +591,7 @@ func verifyDefaults(cur map[string]any, ex map[string]any) ([]error, int) {
 		}
 	}
 
+	derivedChecks := 0
 	if err := mustEqDurationToMilliseconds(
 		cur,
 		ex,
@@ -483,34 +600,69 @@ func verifyDefaults(cur map[string]any, ex map[string]any) ([]error, int) {
 	); err != nil {
 		failures = append(failures, err)
 	}
+	derivedChecks++
 
 	if err := mustMapExcludedSystemPaths(cur, ex); err != nil {
 		failures = append(failures, err)
 	}
+	derivedChecks++
 
 	if err := mustMapAlreadyInstrumentedExclusion(cur, ex); err != nil {
 		failures = append(failures, err)
 	}
+	derivedChecks++
 
 	if err := mustMapGoSpecificTracers(cur, ex); err != nil {
 		failures = append(failures, err)
 	}
+	derivedChecks++
 
 	if err := mustMapApplicationFiltersPerInstrumentation(cur, ex); err != nil {
 		failures = append(failures, err)
 	}
+	derivedChecks++
 
 	if err := mustMapNetworkFiltersPerSignal(cur, ex); err != nil {
 		failures = append(failures, err)
 	}
+	derivedChecks++
 
-	for _, extractor := range []string{"graphql", "elasticsearch", "aws", "sqlpp"} {
+	if err := mustMapStatsFiltersPerSignal(cur, ex); err != nil {
+		failures = append(failures, err)
+	}
+	derivedChecks++
+
+	if err := mustMapStatsFeatureDefaults(ex); err != nil {
+		failures = append(failures, err)
+	}
+	derivedChecks++
+
+	for _, extractor := range []string{"graphql", "elasticsearch", "aws", "sqlpp", "jsonrpc", "enrichment"} {
 		if err := mustMapPayloadExtractionMembership(cur, ex, extractor); err != nil {
 			failures = append(failures, err)
 		}
+		derivedChecks++
 	}
 
-	return failures, len(checks) + 10
+	for _, extractor := range []string{
+		"openai",
+		"anthropic",
+		"gemini",
+		"qwen",
+		"bedrock",
+		"mcp",
+		"embedding",
+		"rerank",
+		"retrieval",
+	} {
+		if err := mustMapPayloadExtractionMembershipAt(cur, ex,
+			[]string{"ebpf", "payload_extraction", "http", "genai", extractor, "enabled"}, extractor); err != nil {
+			failures = append(failures, err)
+		}
+		derivedChecks++
+	}
+
+	return failures, len(checks) + derivedChecks
 }
 
 func run(args []string) error {

--- a/cmd/check-config-v2-parity/main_test.go
+++ b/cmd/check-config-v2-parity/main_test.go
@@ -73,7 +73,7 @@ func TestVerifyDefaultsCurrentExample(t *testing.T) {
 	if len(failures) > 0 {
 		t.Fatalf("expected current defaults to match v2 example, got %d failures: %v", len(failures), failures)
 	}
-	if mappedChecks != len(parityChecks())+10 {
+	if mappedChecks != len(parityChecks())+23 {
 		t.Fatalf("unexpected mapped check count: %d", mappedChecks)
 	}
 }

--- a/devdocs/config/version-2.0/config-v2.md
+++ b/devdocs/config/version-2.0/config-v2.md
@@ -274,6 +274,47 @@ The extra nesting was removed for the following reasons:
 - Removing the indirection saves one nesting level on every rule users write, with no loss of meaning.
 - `capture.policy` and `capture.rules` read naturally as "the capture policy" and "the capture rules", reinforcing the parent section's meaning rather than fighting it.
 
+#### Effective discovery selector export shape
+
+The v1-to-v2 export path writes effective discovery selectors into `capture.rules`.
+It does not only copy `discovery.instrument` literally. It uses the same effective selector inputs as runtime discovery:
+
+- `target_pids` becomes a single include rule that matches `process.target_pids`.
+- Modern glob selectors from `discovery.instrument`, `discovery.exclude_instrument`, and environment auto-target fields become include/exclude rules with `*_glob` match fields.
+- Legacy regex selectors from `discovery.services`, `discovery.exclude_services`, `executable_path`, and `open_port` become include/exclude rules with `*_regex` match fields.
+- Default excludes and already-instrumented-service detection become explicit exclude rules.
+
+Known `match.process` fields exported today:
+
+| v2 field | Value shape | Source |
+|---|---|---|
+| `open_ports` | String int/range list, for example `"8080,9090-9091"` | v1 `open_ports` / `open_port` |
+| `target_pids` | Integer array | v1 `target_pids` |
+| `language_glob` | String array | v1 glob `languages` |
+| `language_regex` | String regex | legacy v1 regex `languages` |
+| `cmd_args_glob` | String array | v1 glob `cmd_args` |
+| `cmd_args_regex` | String regex | legacy v1 regex `cmd_args` |
+| `exe_path_glob` | String array | v1 glob `exe_path` and excluded system paths |
+| `exe_path_regex` | String regex | legacy v1 regex `exe_path` / `exe_path_regexp` and `executable_path` |
+| `containers_only` | Boolean | v1 `containers_only` |
+| `exports_otlp` | Object with `port` and `protocol` | v1 `exclude_otel_instrumented_services` |
+
+Known `match.kubernetes` fields exported today:
+
+| v2 field | Value shape | Source |
+|---|---|---|
+| `namespace_glob` | String array | v1 `k8s_namespace` in glob selectors |
+| `namespace_regex` | String regex | legacy v1 `k8s_namespace` in regex selectors |
+| `metadata_glob` | Map of Kubernetes metadata key to string array | Non-namespace v1 Kubernetes metadata in glob selectors |
+| `metadata_regex` | Map of Kubernetes metadata key to regex string | Non-namespace v1 Kubernetes metadata in legacy regex selectors |
+| `pod_labels` | Map of pod label key to string array | v1 `k8s_pod_labels` in glob selectors |
+| `pod_labels_regex` | Map of pod label key to regex string | legacy v1 `k8s_pod_labels` in regex selectors |
+| `pod_annotations` | Map of pod annotation key to string array | v1 `k8s_pod_annotations` in glob selectors |
+| `pod_annotations_regex` | Map of pod annotation key to regex string | legacy v1 `k8s_pod_annotations` in regex selectors |
+
+`metadata_glob` and `metadata_regex` intentionally exclude `k8s_namespace`; namespace has first-class fields because it is the most common Kubernetes selector.
+Other allowed metadata keys currently include `k8s_pod_name`, `k8s_deployment_name`, `k8s_replicaset_name`, `k8s_daemonset_name`, `k8s_statefulset_name`, `k8s_job_name`, `k8s_cronjob_name`, `k8s_owner_name`, `k8s_container_name`, and `container_name`.
+
 #### Per-workload refinement: `refine` on include rules
 
 Include rules may carry an optional `refine` block that overrides global defaults for matched workloads.
@@ -412,7 +453,7 @@ For example, SQL has `mysql` and `postgres` for driver-specific controls, HTTP h
 HTTP `payload_extraction` uses the same list-based enablement model as other instrumentation selectors:
 
 - `payload_extraction.enabled` is the only enablement surface.
-- Concrete values currently supported are `graphql`, `elasticsearch`, `aws`, and `sqlpp`.
+- Concrete values currently supported are `graphql`, `elasticsearch`, `aws`, `sqlpp`, `openai`, `anthropic`, `gemini`, `qwen`, `bedrock`, `mcp`, `embedding`, `rerank`, `retrieval`, `jsonrpc`, and `enrichment`.
 - Nested extractor blocks are for tuning, not duplicate enablement. For example, `payload_extraction.sqlpp.endpoint_patterns` refines SQL++ matching after `sqlpp` is enabled in the list.
 - If future aliases or families are needed, they should be added as values in the same `enabled` list rather than introducing parallel knobs.
 
@@ -429,6 +470,13 @@ Java also includes additional runtime-specific configuration such as debug contr
 
 The `capture.network` section defines how network observability is configured, including endpoint identity, selection criteria, flow lifecycle controls, interface discovery behavior, enrichment options, and diagnostics.
 This section is the primary user control for defining how OBI captures and processes network telemetry.
+
+The current shape separates packet/flow capture from TCP stats capture:
+
+- `capture.network.capture` controls network flow capture and flow-derived telemetry.
+- `capture.network.stats` controls TCP stats telemetry. `enabled` is the stats master switch, and `features` lists enabled stats families: `tcp_rtt`, `tcp_failed_connections`, `tcp_retransmits`, and `tcp_io`.
+
+`tcp_io` can produce substantially more events than the other stats families, so users should opt into it deliberately when they need per-send/per-receive I/O stats.
 
 ### `capture.engine` Section
 
@@ -526,7 +574,9 @@ Important mapping notes:
 - Some mappings are non-1:1:
   - `filter.application` fans out to `capture.instrumentation.<protocol>.filters.{traces,metrics}`.
   - `filter.network` fans out to `capture.network.capture.filters.{traces,metrics}`.
-  - `metrics.features` maps to `capture.instrumentation.<protocol>.enabled.metrics` + `capture.network.capture.enabled`.
+  - `filter.stats` fans out to `capture.network.stats.filters.{traces,metrics}`.
+  - `metrics.features` maps to `capture.instrumentation.<protocol>.enabled.metrics`, `capture.network.capture.enabled`, and `capture.network.stats.{enabled,features}`.
+  - Discovery selectors are exported as effective `capture.rules` after legacy/new selector precedence is resolved.
   - `discovery.skip_go_specific_tracers` maps to `capture.runtimes.go.enabled` with inverted semantics.
 
 | v1 field | v2 canonical location | Notes |
@@ -540,41 +590,70 @@ Important mapping notes:
 | `channel_send_timeout_panic` | `extensions.obi.capture.channels.panic_on_send_timeout` | Move + rename |
 | `discovery.bpf_pid_filter_off` | `extensions.obi.capture.engine.pid_filter.disabled` | Move + rename |
 | `discovery.default_otlp_grpc_port` | `extensions.obi.capture.rules[].match.process.exports_otlp.port` | Move + reshape |
+| `discovery.default_exclude_instrument` | `extensions.obi.capture.rules[]` (exclude rules with glob selectors) | Move + reshape |
+| `discovery.default_exclude_services` | `extensions.obi.capture.rules[]` (exclude rules with legacy regex selectors) | Legacy move + reshape |
 | `discovery.disabled_route_harvesters` | `extensions.obi.capture.instrumentation.http.routes.discovery.disabled_languages` | Move + rename |
+| `discovery.exclude_instrument` | `extensions.obi.capture.rules[]` (exclude rules with glob selectors) | Move + reshape |
 | `discovery.exclude_otel_instrumented_services` | `extensions.obi.capture.rules[].match.process.exports_otlp` (exclude rule) | Move + reshape |
+| `discovery.exclude_services` | `extensions.obi.capture.rules[]` (exclude rules with legacy regex selectors) | Legacy move + reshape |
 | `discovery.excluded_linux_system_paths` | `extensions.obi.capture.rules[].match.process.exe_path_glob` (exclude rule) | Move + reshape |
+| `discovery.instrument` | `extensions.obi.capture.rules[]` (include rules with glob selectors) | Move + reshape |
 | `discovery.min_process_age` | `extensions.obi.capture.policy.min_process_age` | Move |
 | `discovery.route_harvester_advanced.java_harvest_delay` | `extensions.obi.capture.instrumentation.http.routes.discovery.java.delay` | Move + rename |
 | `discovery.route_harvester_timeout` | `extensions.obi.capture.instrumentation.http.routes.discovery.timeout` | Move + rename |
+| `discovery.services` | `extensions.obi.capture.rules[]` (include rules with legacy regex selectors) | Legacy move + reshape |
 | `discovery.skip_go_specific_tracers` | `extensions.obi.capture.runtimes.go.enabled` | Inverted boolean mapping |
 | `ebpf.batch_length` | `extensions.obi.capture.engine.batching.batch_length` | Move |
 | `ebpf.batch_timeout` | `extensions.obi.capture.engine.batching.batch_timeout` | Move |
 | `ebpf.bpf_fs_path` | `extensions.obi.capture.engine.bpf_filesystem.path` | Move + rename |
 | `ebpf.buffer_sizes.http` | `extensions.obi.capture.instrumentation.http.buffer_size` | Move |
 | `ebpf.buffer_sizes.kafka` | `extensions.obi.capture.instrumentation.kafka.buffer_size` | Move |
+| `ebpf.buffer_sizes.mssql` | `extensions.obi.capture.instrumentation.sql.mssql.buffer_size` | Move |
 | `ebpf.buffer_sizes.mysql` | `extensions.obi.capture.instrumentation.sql.mysql.buffer_size` | Move |
 | `ebpf.buffer_sizes.postgres` | `extensions.obi.capture.instrumentation.sql.postgres.buffer_size` | Move |
 | `ebpf.dns_request_timeout` | `extensions.obi.capture.instrumentation.dns.request_timeout` | Move |
+| `ebpf.force_bpf_map_reader` | `extensions.obi.capture.engine.traffic.force_map_reader` | Move + rename |
 | `ebpf.heuristic_sql_detect` | `extensions.obi.capture.instrumentation.sql.heuristic_detect` | Move + rename |
 | `ebpf.kafka_topic_uuid_cache_size` | `extensions.obi.capture.instrumentation.kafka.topic_uuid_cache_size` | Move |
 | `ebpf.log_enricher.cache_size` | `extensions.obi.correlation.log_trace_annotation.cache.size` | Move + rename |
 | `ebpf.log_enricher.cache_ttl` | `extensions.obi.correlation.log_trace_annotation.cache.ttl` | Move + rename |
 | `ebpf.log_enricher.async_writer_workers` | `extensions.obi.correlation.log_trace_annotation.async_writer.workers` | Move + rename |
 | `ebpf.log_enricher.async_writer_channel_len` | `extensions.obi.correlation.log_trace_annotation.async_writer.channel_len` | Move + rename |
+| `ebpf.maps_config.global_scale_factor` | `extensions.obi.capture.engine.maps.global_scale_factor` | Move + rename |
 | `ebpf.max_transaction_time` | `extensions.obi.capture.engine.transactions.max_duration` | Move + rename |
+| `ebpf.mssql_prepared_statements_cache_size` | `extensions.obi.capture.instrumentation.sql.mssql.prepared_statements_cache_size` | Move |
 | `ebpf.mysql_prepared_statements_cache_size` | `extensions.obi.capture.instrumentation.sql.mysql.prepared_statements_cache_size` | Move |
 | `ebpf.payload_extraction.http.graphql.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `graphql` | Move + normalize |
 | `ebpf.payload_extraction.http.elasticsearch.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `elasticsearch` | Move + normalize |
 | `ebpf.payload_extraction.http.aws.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `aws` | Move + normalize |
 | `ebpf.payload_extraction.http.sqlpp.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `sqlpp` | Move + normalize |
 | `ebpf.payload_extraction.http.sqlpp.endpoint_patterns` | `extensions.obi.capture.instrumentation.http.payload_extraction.sqlpp.endpoint_patterns` | Move |
+| `ebpf.payload_extraction.http.genai.openai.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `openai` | Move + normalize |
+| `ebpf.payload_extraction.http.genai.anthropic.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `anthropic` | Move + normalize |
+| `ebpf.payload_extraction.http.genai.gemini.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `gemini` | Move + normalize |
+| `ebpf.payload_extraction.http.genai.qwen.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `qwen` | Move + normalize |
+| `ebpf.payload_extraction.http.genai.bedrock.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `bedrock` | Move + normalize |
+| `ebpf.payload_extraction.http.genai.mcp.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `mcp` | Move + normalize |
+| `ebpf.payload_extraction.http.genai.embedding.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `embedding` | Move + normalize |
+| `ebpf.payload_extraction.http.genai.rerank.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `rerank` | Move + normalize |
+| `ebpf.payload_extraction.http.genai.retrieval.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `retrieval` | Move + normalize |
+| `ebpf.payload_extraction.http.jsonrpc.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `jsonrpc` | Move + normalize |
+| `ebpf.payload_extraction.http.enrichment.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `enrichment` | Move + normalize |
+| `ebpf.payload_extraction.http.enrichment.policy.default_action.headers` | `extensions.obi.capture.instrumentation.http.payload_extraction.enrichment.policy.default_action.headers` | Move |
+| `ebpf.payload_extraction.http.enrichment.policy.default_action.body` | `extensions.obi.capture.instrumentation.http.payload_extraction.enrichment.policy.default_action.body` | Move |
+| `ebpf.payload_extraction.http.enrichment.policy.obfuscation_string` | `extensions.obi.capture.instrumentation.http.payload_extraction.enrichment.policy.obfuscation_string` | Move |
+| `ebpf.payload_extraction.http.enrichment.rules` | `extensions.obi.capture.instrumentation.http.payload_extraction.enrichment.rules` | Move |
 | `ebpf.postgres_prepared_statements_cache_size` | `extensions.obi.capture.instrumentation.sql.postgres.prepared_statements_cache_size` | Move |
 | `ebpf.redis_db_cache.enabled` | `extensions.obi.capture.instrumentation.redis.db_cache.enabled` | Move |
 | `ebpf.traffic_control_backend` | `extensions.obi.capture.engine.traffic.control_backend` | Move + rename |
 | `ebpf.wakeup_len` | `extensions.obi.capture.engine.batching.wakeup_len` | Move |
 | `enforce_sys_caps` | `extensions.obi.capture.safety.enforce_system_capabilities` | Move + rename |
+| `executable_path` | `extensions.obi.capture.rules[].match.process.exe_path_regex` (include rule) | Legacy fallback selector |
+| `open_port` | `extensions.obi.capture.rules[].match.process.open_ports` (include rule) | Fallback selector |
+| `target_pids` | `extensions.obi.capture.rules[].match.process.target_pids` (include rule) | Fallback selector |
 | `filter.application` | `extensions.obi.capture.instrumentation.<protocol>.filters.{traces,metrics}` | Fan-out to all protocols/signals |
 | `filter.network` | `extensions.obi.capture.network.capture.filters.{traces,metrics}` | Fan-out to both signals |
+| `filter.stats` | `extensions.obi.capture.network.stats.filters.{traces,metrics}` | Fan-out to both signals |
 | `internal_metrics.bpf_metric_scrape_interval` | `extensions.obi.daemon.internal_metrics.bpf.scrape_interval` | Move + rename |
 | `internal_metrics.exporter` | `extensions.obi.daemon.internal_metrics.exporter` | Move |
 | `internal_metrics.prometheus.path` | `extensions.obi.daemon.internal_metrics.prometheus.path` | Move |
@@ -584,7 +663,7 @@ Important mapping notes:
 | `javaagent.enabled` | `extensions.obi.capture.runtimes.java.enabled` | Simplified to boolean |
 | `log_config` | `extensions.obi.daemon.logging.format` | Move + rename |
 | `log_level` | `extensions.obi.daemon.logging.level` | Move |
-| `metrics.features` | `extensions.obi.capture.instrumentation.<protocol>.enabled.metrics` + `extensions.obi.capture.network.capture.enabled` | Split mapping |
+| `metrics.features` | `extensions.obi.capture.instrumentation.<protocol>.enabled.metrics` + `extensions.obi.capture.network.capture.enabled` + `extensions.obi.capture.network.stats.{enabled,features}` | Split mapping |
 | `name_resolver.cache_expiry` | `extensions.obi.enrich.service_name.cache.ttl` | Move + rename |
 | `name_resolver.cache_len` | `extensions.obi.enrich.service_name.cache.size` | Move + rename |
 | `network.agent_ip` | `extensions.obi.capture.network.capture.endpoint_identity.agent_ip` | Move |
@@ -592,15 +671,23 @@ Important mapping notes:
 | `network.agent_ip_type` | `extensions.obi.capture.network.capture.endpoint_identity.agent_ip_family` | Move + rename |
 | `network.cache_active_timeout` | `extensions.obi.capture.network.capture.flow_lifecycle.active_timeout` | Move + rename |
 | `network.cache_max_flows` | `extensions.obi.capture.network.capture.flow_lifecycle.max_tracked_flows` | Move + rename |
+| `network.cidrs` | `extensions.obi.capture.network.capture.selection.cidrs` | Move |
 | `network.deduper` | `extensions.obi.capture.network.capture.flow_lifecycle.deduplication.strategy` | Move + rename |
 | `network.deduper_fc_ttl` | `extensions.obi.capture.network.capture.flow_lifecycle.deduplication.first_come_ttl` | Move + rename |
 | `network.direction` | `extensions.obi.capture.network.capture.selection.direction` | Move |
 | `network.enable` | `extensions.obi.capture.network.capture.enabled` | Move + rename |
 | `network.geo_ip.cache_expiry` | `extensions.obi.capture.network.capture.enrichment.geo_ip.cache.ttl` | Move + rename |
+| `network.geo_ip.cache_len` | `extensions.obi.capture.network.capture.enrichment.geo_ip.cache.size` | Move + rename |
+| `network.geo_ip.ipinfo.path` | `extensions.obi.capture.network.capture.enrichment.geo_ip.ipinfo.path` | Move |
+| `network.geo_ip.maxmind.asn_path` | `extensions.obi.capture.network.capture.enrichment.geo_ip.maxmind.asn_path` | Move |
+| `network.geo_ip.maxmind.country_path` | `extensions.obi.capture.network.capture.enrichment.geo_ip.maxmind.country_path` | Move |
+| `network.guess_ports` | `extensions.obi.capture.network.capture.flow_lifecycle.guess_ports` | Move |
 | `network.listen_interfaces` | `extensions.obi.capture.network.capture.interface_discovery.mode` | Move + reshape |
 | `network.listen_poll_period` | `extensions.obi.capture.network.capture.interface_discovery.poll_interval` | Move + rename |
 | `network.print_flows` | `extensions.obi.capture.network.capture.diagnostics.print_flows` | Move |
 | `network.reverse_dns.cache_expiry` | `extensions.obi.capture.network.capture.enrichment.reverse_dns.cache.ttl` | Move + rename |
+| `network.reverse_dns.cache_len` | `extensions.obi.capture.network.capture.enrichment.reverse_dns.cache.size` | Move + rename |
+| `network.reverse_dns.type` | `extensions.obi.capture.network.capture.enrichment.reverse_dns.mode` | Move + rename |
 | `network.sampling` | `extensions.obi.capture.network.capture.flow_lifecycle.sampling` | Move |
 | `network.source` | `extensions.obi.capture.network.capture.source` | Move |
 | `nodejs.enabled` | `extensions.obi.capture.runtimes.nodejs.enabled` | Simplified to boolean |
@@ -625,6 +712,19 @@ Important mapping notes:
 | `routes.unmatched` | `extensions.obi.capture.instrumentation.http.routes.unmatched` | Move |
 | `routes.wildcard_char` | `extensions.obi.capture.instrumentation.http.routes.wildcard_char` | Move |
 | `shutdown_timeout` | `extensions.obi.daemon.shutdown.timeout` | Move |
+| `stats.agent_ip` | `extensions.obi.capture.network.stats.endpoint_identity.agent_ip` | Move |
+| `stats.agent_ip_iface` | `extensions.obi.capture.network.stats.endpoint_identity.agent_ip_interface` | Move + rename |
+| `stats.agent_ip_type` | `extensions.obi.capture.network.stats.endpoint_identity.agent_ip_family` | Move + rename |
+| `stats.cidrs` | `extensions.obi.capture.network.stats.selection.cidrs` | Move |
+| `stats.geo_ip.cache_expiry` | `extensions.obi.capture.network.stats.enrichment.geo_ip.cache.ttl` | Move + rename |
+| `stats.geo_ip.cache_len` | `extensions.obi.capture.network.stats.enrichment.geo_ip.cache.size` | Move + rename |
+| `stats.geo_ip.ipinfo.path` | `extensions.obi.capture.network.stats.enrichment.geo_ip.ipinfo.path` | Move |
+| `stats.geo_ip.maxmind.asn_path` | `extensions.obi.capture.network.stats.enrichment.geo_ip.maxmind.asn_path` | Move |
+| `stats.geo_ip.maxmind.country_path` | `extensions.obi.capture.network.stats.enrichment.geo_ip.maxmind.country_path` | Move |
+| `stats.print_stats` | `extensions.obi.capture.network.stats.diagnostics.print_stats` | Move |
+| `stats.reverse_dns.cache_expiry` | `extensions.obi.capture.network.stats.enrichment.reverse_dns.cache.ttl` | Move + rename |
+| `stats.reverse_dns.cache_len` | `extensions.obi.capture.network.stats.enrichment.reverse_dns.cache.size` | Move + rename |
+| `stats.reverse_dns.type` | `extensions.obi.capture.network.stats.enrichment.reverse_dns.mode` | Move + rename |
 | `trace_printer` | `extensions.obi.daemon.logging.debug_trace_output` | Move + rename |
 
 ## Related docs

--- a/devdocs/config/version-2.0/examples/default-configuration.yaml
+++ b/devdocs/config/version-2.0/examples/default-configuration.yaml
@@ -150,6 +150,49 @@ extensions:
                 - /sbin/*
                 - /usr/sbin/*
 
+        # Example (commented): effective glob selector exported from discovery.instrument
+        # and top-level auto-target fields.
+        #
+        # - action: include
+        #   name: checkout-glob
+        #   match:
+        #     process:
+        #       open_ports: "8080,9090-9091"
+        #       target_pids: [1234, 5678]
+        #       language_glob: [go, java]
+        #       cmd_args_glob: ["*--serve*"]
+        #       exe_path_glob: ["/usr/bin/checkout"]
+        #       containers_only: true
+        #     kubernetes:
+        #       namespace_glob: ["shop-*"]
+        #       metadata_glob:
+        #         k8s_deployment_name: ["checkout-*"]
+        #         k8s_container_name: ["checkout"]
+        #       pod_labels:
+        #         app: ["checkout"]
+        #       pod_annotations:
+        #         team: ["payments"]
+        #
+        # Example (commented): legacy regex selector exported from discovery.services
+        # or top-level executable_path/open_port fallback.
+        #
+        # - action: include
+        #   name: checkout-regex
+        #   match:
+        #     process:
+        #       open_ports: "8080"
+        #       language_regex: "go|java"
+        #       cmd_args_regex: "--serve"
+        #       exe_path_regex: "^/srv/checkout$"
+        #     kubernetes:
+        #       namespace_regex: "^shop$"
+        #       metadata_regex:
+        #         k8s_deployment_name: "^checkout-.+$"
+        #       pod_labels_regex:
+        #         app: "^checkout$"
+        #       pod_annotations_regex:
+        #         team: "^payments$"
+
         # Example (commented): per-workload refinement on include rules.
         # The `refine` block overrides global defaults for workloads matched by this rule.
         # Use this to disable signals, add per-service HTTP routes, or tighten filters
@@ -234,11 +277,20 @@ extensions:
           # HTTP payload-level extraction features.
           payload_extraction:
             # List-based enablement, consistent with other instrumentation selectors.
-            # Supported values today: graphql, elasticsearch, aws, sqlpp.
+            # Supported values today: graphql, elasticsearch, aws, sqlpp,
+            # openai, anthropic, gemini, qwen, bedrock, mcp, embedding,
+            # rerank, retrieval, jsonrpc, enrichment.
             enabled: []
             sqlpp:
               endpoint_patterns:
                 - /query/service
+            enrichment:
+              policy:
+                default_action:
+                  headers: exclude
+                  body: exclude
+                obfuscation_string: "***"
+              rules: []
         # gRPC protocol instrumentation toggle.
         grpc:
           enabled:
@@ -260,6 +312,9 @@ extensions:
             buffer_size: 0
             prepared_statements_cache_size: 1024
           postgres:
+            buffer_size: 0
+            prepared_statements_cache_size: 1024
+          mssql:
             buffer_size: 0
             prepared_statements_cache_size: 1024
         # Redis instrumentation and DB cache behavior.
@@ -403,6 +458,8 @@ extensions:
               first_come_ttl: 0s
             # Packet sampling rate (0 means disabled/default behavior).
             sampling: 0
+            # How to assign client/server ports when connection initiator is unknown.
+            guess_ports: disable
           # How interface changes are detected.
           interface_discovery:
             # watch (event-based) or poll.
@@ -427,6 +484,38 @@ extensions:
           # Debug/diagnostics output controls.
           diagnostics:
             print_flows: false
+        stats:
+          # Master switch for TCP stats observability.
+          enabled: false
+          # Supported values: tcp_rtt, tcp_failed_connections, tcp_retransmits, tcp_io.
+          features: []
+          endpoint_identity:
+            agent_ip: ""
+            agent_ip_interface: external
+            agent_ip_family: any
+          selection:
+            # Optional CIDR definitions for src/dst stats grouping attributes.
+            cidrs: []
+          filters:
+            traces: {}
+            metrics: {}
+          enrichment:
+            geo_ip:
+              ipinfo:
+                path: ""
+              maxmind:
+                country_path: ""
+                asn_path: ""
+              cache:
+                size: 512
+                ttl: 1h0m0s
+            reverse_dns:
+              mode: none
+              cache:
+                size: 256
+                ttl: 1h0m0s
+          diagnostics:
+            print_stats: false
 
       # limits constrains cardinality and memory growth during capture.
       limits:
@@ -451,8 +540,11 @@ extensions:
         traffic:
           control_backend: auto
           high_request_volume: false
+          force_map_reader: auto
         transactions:
           max_duration: 5m0s
+        maps:
+          global_scale_factor: 0
         bpf_filesystem:
           path: /sys/fs/bpf/
 

--- a/devdocs/config/version-2.0/obi-extension.schema.json
+++ b/devdocs/config/version-2.0/obi-extension.schema.json
@@ -105,6 +105,168 @@
         }
       }
     },
+    "StringList": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string"
+      }
+    },
+    "StringListMap": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/StringList"
+      }
+    },
+    "RegexMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "IntEnum": {
+      "description": "Comma-separated integer/range list, or an explicit integer array.",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^\\s*\\d+\\s*(-\\s*\\d+\\s*)?(,\\s*\\d+\\s*(-\\s*\\d+\\s*)?)*$",
+          "description": "Comma-separated integers or integer ranges, for example `80,443,8000-8999`."
+        },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      ]
+    },
+    "CIDRDefinitions": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "string",
+            "description": "CIDR range. The CIDR string is used as the attribute value."
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "cidr": {
+                "type": "string",
+                "description": "CIDR range."
+              },
+              "name": {
+                "type": "string",
+                "description": "Human-readable attribute value for this CIDR."
+              }
+            },
+            "required": [
+              "cidr"
+            ]
+          }
+        ]
+      },
+      "default": [],
+      "description": "CIDR definitions used for source/destination grouping attributes."
+    },
+    "GeoIPEnrichment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ipinfo": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "type": "string",
+              "default": "",
+              "description": "IPinfo database path."
+            }
+          }
+        },
+        "maxmind": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "country_path": {
+              "type": "string",
+              "default": "",
+              "description": "MaxMind country database path."
+            },
+            "asn_path": {
+              "type": "string",
+              "default": "",
+              "description": "MaxMind ASN database path."
+            }
+          }
+        },
+        "cache": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 512,
+              "description": "GeoIP cache size."
+            },
+            "ttl": {
+              "type": "string",
+              "default": "1h0m0s",
+              "description": "GeoIP cache TTL."
+            }
+          }
+        }
+      }
+    },
+    "ReverseDNSEnrichment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "none",
+            "local",
+            "ebpf"
+          ],
+          "default": "none",
+          "description": "Reverse DNS lookup mode."
+        },
+        "cache": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "size": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 256,
+              "description": "Reverse DNS cache size."
+            },
+            "ttl": {
+              "type": "string",
+              "default": "1h0m0s",
+              "description": "Reverse DNS cache TTL."
+            }
+          }
+        }
+      }
+    },
+    "NetworkEnrichment": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "geo_ip": {
+          "$ref": "#/$defs/GeoIPEnrichment"
+        },
+        "reverse_dns": {
+          "$ref": "#/$defs/ReverseDNSEnrichment"
+        }
+      }
+    },
     "SelectionExportsOTLP": {
       "type": "object",
       "description": "Match predicate for detecting workloads that already export OTLP.",
@@ -131,13 +293,46 @@
       "description": "Process-level selection predicates.",
       "additionalProperties": true,
       "properties": {
-        "exe_path_glob": {
+        "open_ports": {
+          "$ref": "#/$defs/IntEnum",
+          "description": "Open port selector. Accepts comma-separated ports/ranges or an integer array.\n"
+        },
+        "target_pids": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "type": "string"
+            "type": "integer",
+            "minimum": 0
           },
+          "description": "Process IDs selected explicitly.\n"
+        },
+        "language_glob": {
+          "$ref": "#/$defs/StringList",
+          "description": "Glob patterns matched against detected runtime language.\n"
+        },
+        "language_regex": {
+          "type": "string",
+          "description": "Regular expression matched against detected runtime language.\n"
+        },
+        "cmd_args_glob": {
+          "$ref": "#/$defs/StringList",
+          "description": "Glob patterns matched against process command-line arguments.\n"
+        },
+        "cmd_args_regex": {
+          "type": "string",
+          "description": "Regular expression matched against process command-line arguments.\n"
+        },
+        "exe_path_glob": {
+          "$ref": "#/$defs/StringList",
           "description": "Glob patterns matched against process executable paths.\n"
+        },
+        "exe_path_regex": {
+          "type": "string",
+          "description": "Regular expression matched against process executable paths.\n"
+        },
+        "containers_only": {
+          "type": "boolean",
+          "description": "Restrict selection to processes running in containers.\n"
         },
         "exports_otlp": {
           "$ref": "#/$defs/SelectionExportsOTLP",
@@ -151,12 +346,36 @@
       "additionalProperties": true,
       "properties": {
         "namespace_glob": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "string"
-          },
+          "$ref": "#/$defs/StringList",
           "description": "Glob patterns matched against Kubernetes namespace names.\n"
+        },
+        "namespace_regex": {
+          "type": "string",
+          "description": "Regular expression matched against Kubernetes namespace names.\n"
+        },
+        "metadata_glob": {
+          "$ref": "#/$defs/StringListMap",
+          "description": "Glob patterns for non-namespace Kubernetes metadata keys.\n"
+        },
+        "metadata_regex": {
+          "$ref": "#/$defs/RegexMap",
+          "description": "Regular expressions for non-namespace Kubernetes metadata keys.\n"
+        },
+        "pod_labels": {
+          "$ref": "#/$defs/StringListMap",
+          "description": "Glob patterns for Kubernetes pod labels.\n"
+        },
+        "pod_labels_regex": {
+          "$ref": "#/$defs/RegexMap",
+          "description": "Regular expressions for Kubernetes pod labels.\n"
+        },
+        "pod_annotations": {
+          "$ref": "#/$defs/StringListMap",
+          "description": "Glob patterns for Kubernetes pod annotations.\n"
+        },
+        "pod_annotations_regex": {
+          "$ref": "#/$defs/RegexMap",
+          "description": "Regular expressions for Kubernetes pod annotations.\n"
         }
       }
     },
@@ -531,6 +750,16 @@
                   "type": "boolean",
                   "default": false,
                   "description": "Optimize capture behavior for high request volume workloads.\nIf omitted, false is used.\n"
+                },
+                "force_map_reader": {
+                  "type": "string",
+                  "enum": [
+                    "auto",
+                    "batch",
+                    "legacy"
+                  ],
+                  "default": "auto",
+                  "description": "Force the network-flow per-CPU map reader implementation.\nIf omitted, `auto` is used.\n"
                 }
               }
             },
@@ -542,6 +771,19 @@
                   "type": "string",
                   "default": "5m0s",
                   "description": "Maximum duration allowed for correlating request/response transactions.\nIf omitted, `5m0s` is used.\n"
+                }
+              }
+            },
+            "maps": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "global_scale_factor": {
+                  "type": "integer",
+                  "minimum": -3,
+                  "maximum": 3,
+                  "default": 0,
+                  "description": "Global eBPF map size scale factor.\nIf omitted, `0` is used.\n"
                 }
               }
             },
@@ -924,7 +1166,18 @@
                   "graphql",
                   "elasticsearch",
                   "aws",
-                  "sqlpp"
+                  "sqlpp",
+                  "openai",
+                  "anthropic",
+                  "gemini",
+                  "qwen",
+                  "bedrock",
+                  "mcp",
+                  "embedding",
+                  "rerank",
+                  "retrieval",
+                  "jsonrpc",
+                  "enrichment"
                 ]
               },
               "default": [],
@@ -943,6 +1196,59 @@
                     "/query/service"
                   ],
                   "description": "Endpoint patterns eligible for SQL++ payload extraction.\nIf omitted, `/query/service` is used.\n"
+                }
+              }
+            },
+            "enrichment": {
+              "type": "object",
+              "description": "HTTP header and body enrichment policy and rules.",
+              "additionalProperties": false,
+              "properties": {
+                "policy": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "default_action": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "headers": {
+                          "type": "string",
+                          "enum": [
+                            "include",
+                            "exclude",
+                            "obfuscate"
+                          ],
+                          "default": "exclude",
+                          "description": "Default action for HTTP headers."
+                        },
+                        "body": {
+                          "type": "string",
+                          "enum": [
+                            "include",
+                            "exclude",
+                            "obfuscate"
+                          ],
+                          "default": "exclude",
+                          "description": "Default action for HTTP body payloads."
+                        }
+                      }
+                    },
+                    "obfuscation_string": {
+                      "type": "string",
+                      "default": "***",
+                      "description": "Replacement string used by obfuscation rules."
+                    }
+                  }
+                },
+                "rules": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "default": [],
+                  "description": "Ordered HTTP parsing/enrichment rules."
                 }
               }
             }
@@ -1077,6 +1383,24 @@
               "minimum": 0,
               "default": 1024,
               "description": "PostgreSQL prepared statements cache size.\nIf omitted, `1024` is used.\n"
+            }
+          }
+        },
+        "mssql": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "buffer_size": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "description": "MSSQL parser buffer size.\nIf omitted, `0` is used.\n"
+            },
+            "prepared_statements_cache_size": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 1024,
+              "description": "MSSQL prepared statements cache size.\nIf omitted, `1024` is used.\n"
             }
           }
         }
@@ -1450,9 +1774,253 @@
               "default": "socket_filter",
               "description": "Network capture source implementation.\nValues include: `socket_filter`, `tc`.\nIf omitted, `socket_filter` is used.\n"
             },
+            "buffer_size": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "description": "TCP parser/capture buffer size.\nIf omitted, `0` is used.\n"
+            },
+            "endpoint_identity": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "agent_ip": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Agent IP override for network flow telemetry."
+                },
+                "agent_ip_interface": {
+                  "type": "string",
+                  "default": "external",
+                  "description": "Interface selection for deriving the agent IP."
+                },
+                "agent_ip_family": {
+                  "type": "string",
+                  "enum": [
+                    "any",
+                    "ipv4",
+                    "ipv6"
+                  ],
+                  "default": "any",
+                  "description": "IP family used for derived agent IP selection."
+                }
+              }
+            },
+            "selection": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "interfaces": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "include": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": []
+                    },
+                    "exclude": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": [
+                        "lo"
+                      ]
+                    }
+                  }
+                },
+                "protocols": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "include": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": []
+                    },
+                    "exclude": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": []
+                    }
+                  }
+                },
+                "cidrs": {
+                  "$ref": "#/$defs/CIDRDefinitions"
+                },
+                "direction": {
+                  "type": "string",
+                  "enum": [
+                    "ingress",
+                    "egress",
+                    "both"
+                  ],
+                  "default": "both"
+                }
+              }
+            },
             "filters": {
               "$ref": "#/$defs/SignalFilters",
               "description": "Signal-specific filters applied to network capture output.\nIf omitted, no filtering is applied.\n"
+            },
+            "flow_lifecycle": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "max_tracked_flows": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "default": 5000
+                },
+                "active_timeout": {
+                  "type": "string",
+                  "default": "5s"
+                },
+                "deduplication": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "strategy": {
+                      "type": "string",
+                      "default": "first_come"
+                    },
+                    "first_come_ttl": {
+                      "type": "string",
+                      "default": "0s"
+                    }
+                  }
+                },
+                "sampling": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 0
+                },
+                "guess_ports": {
+                  "type": "string",
+                  "enum": [
+                    "disable",
+                    "ordinal"
+                  ],
+                  "default": "disable",
+                  "description": "Port guessing policy for unknown-initiator flows."
+                }
+              }
+            },
+            "interface_discovery": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "enum": [
+                    "watch",
+                    "poll"
+                  ],
+                  "default": "watch"
+                },
+                "poll_interval": {
+                  "type": "string",
+                  "default": "10s"
+                }
+              }
+            },
+            "enrichment": {
+              "$ref": "#/$defs/NetworkEnrichment"
+            },
+            "diagnostics": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "print_flows": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            }
+          }
+        },
+        "stats": {
+          "type": "object",
+          "description": "TCP stats capture controls.",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable TCP stats telemetry.\nIf omitted, false is used.\n"
+            },
+            "features": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "tcp_rtt",
+                  "tcp_failed_connections",
+                  "tcp_retransmits",
+                  "tcp_io"
+                ]
+              },
+              "default": [],
+              "description": "Enabled TCP stats families.\nIf omitted, no stats families are enabled.\n"
+            },
+            "endpoint_identity": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "agent_ip": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Agent IP override for stats telemetry."
+                },
+                "agent_ip_interface": {
+                  "type": "string",
+                  "default": "external",
+                  "description": "Interface selection for deriving the agent IP."
+                },
+                "agent_ip_family": {
+                  "type": "string",
+                  "enum": [
+                    "any",
+                    "ipv4",
+                    "ipv6"
+                  ],
+                  "default": "any",
+                  "description": "IP family used for derived agent IP selection."
+                }
+              }
+            },
+            "selection": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cidrs": {
+                  "$ref": "#/$defs/CIDRDefinitions"
+                }
+              }
+            },
+            "filters": {
+              "$ref": "#/$defs/SignalFilters",
+              "description": "Signal-specific filters applied to stats telemetry.\nIf omitted, no filtering is applied.\n"
+            },
+            "enrichment": {
+              "$ref": "#/$defs/NetworkEnrichment"
+            },
+            "diagnostics": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "print_stats": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

Follow-up for open-telemetry/opentelemetry-ebpf-instrumentation#2269 and the capture export cleanup notes in https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2251#issuecomment-4652952564.

- document the effective config v2 `capture.rules` export shape for v1 discovery selectors, including legacy regex selectors and non-namespace Kubernetes metadata
- expand the config v2 default example and extension schema for payload extraction, MSSQL, network capture cleanup, TCP stats, map reader selection, and map scale factor
- extend the config v2 default parity checker so these documented defaults stay tied to current v1 defaults

## Validation

- `jq empty devdocs/config/version-2.0/obi-extension.schema.json`
- `go test ./cmd/check-config-v2-parity`
- `make check-config-v2-parity`
- `make lint-markdown`