### PR TITLE
Document directional config v2 HTTP route refinements

### DIFF
--- a/devdocs/config/version-2.0/config-v2.md
+++ b/devdocs/config/version-2.0/config-v2.md
@@ -296,7 +296,7 @@ This was rejected because:
 Current overridable fields in `refine`:
 
 - `exports`: override which signals (`traces`, `metrics`) are emitted for this workload.
-- `http.routes`: override HTTP route patterns and fallback policy for this workload.
+- `http.routes`: define direction-scoped custom HTTP route patterns for this workload.
 - `http.filters`: replace HTTP trace/metric filters for this workload.
 
 New fields can be added to the `refine` vocabulary deliberately as use cases emerge.
@@ -326,11 +326,17 @@ capture:
       refine:
         http:
           routes:
-            unmatched: wildcard
-            patterns:
-              - /orders/{id}
-              - /orders/{id}/items
+            incoming:
+              patterns:
+                - /orders/{id}
+                - /orders/{id}/items
+            outgoing:
+              patterns:
+                - /inventory/{id}
 ```
+
+`incoming` applies to HTTP requests handled by the matched workload, equivalent to v1 `routes.incoming`.
+`outgoing` applies to HTTP requests made by the matched workload, equivalent to v1 `routes.outgoing`.
 
 Sampling overrides are **not** part of the `refine` block.
 Per-workload sampling is handled via `tracer_provider.sampler` using the `obi_rule_based` custom sampler, which matches on resource attributes.

--- a/devdocs/config/version-2.0/examples/default-configuration.yaml
+++ b/devdocs/config/version-2.0/examples/default-configuration.yaml
@@ -168,12 +168,15 @@ extensions:
         #       traces: true
         #       metrics: false
         #     http:
-        #       # Per-workload HTTP route patterns (override global patterns for this service).
+        #       # Per-workload HTTP route patterns for requests handled by or made by this workload.
         #       routes:
-        #         unmatched: wildcard
-        #         patterns:
-        #           - /cart/{id}
-        #           - /cart/{id}/items
+        #         incoming:
+        #           patterns:
+        #             - /cart/{id}
+        #             - /cart/{id}/items
+        #         outgoing:
+        #           patterns:
+        #             - /checkout/{id}
         #       # Per-workload HTTP filters (replace global filters for this service).
         #       filters:
         #         traces:

--- a/devdocs/config/version-2.0/obi-extension.schema.json
+++ b/devdocs/config/version-2.0/obi-extension.schema.json
@@ -198,37 +198,41 @@
         },
         "http": {
           "type": "object",
-          "description": "HTTP-specific per-workload overrides.\nFields here take precedence over the global `instrumentation.http` values for matched workloads.\n",
+          "description": "HTTP-specific per-workload configuration for matched workloads.\n",
           "additionalProperties": false,
           "properties": {
             "routes": {
               "type": "object",
-              "description": "Per-workload HTTP route override.\nIf omitted, global route configuration applies.\n",
+              "description": "Per-workload direction-scoped HTTP route patterns.\nIf omitted, global route configuration applies.\n",
               "additionalProperties": false,
               "properties": {
-                "unmatched": {
-                  "type": "string",
-                  "enum": [
-                    "heuristic",
-                    "wildcard",
-                    "random_hash",
-                    "disabled"
-                  ],
-                  "description": "Fallback policy when no explicit route pattern matches.\nIf omitted, global `instrumentation.http.routes.unmatched` applies.\n"
+                "incoming": {
+                  "type": "object",
+                  "description": "HTTP route patterns for requests handled by the matched workload.\nEquivalent to v1 `routes.incoming`.\n",
+                  "additionalProperties": false,
+                  "properties": {
+                    "patterns": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Explicit incoming route patterns for this workload.\n"
+                    }
+                  }
                 },
-                "patterns": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Explicit route patterns for this workload.\nThese are merged with (and take precedence over) global patterns.\nIf omitted, global patterns apply.\n"
-                },
-                "ignored_patterns": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  },
-                  "description": "Route patterns to ignore for this workload.\nIf omitted, global ignored patterns apply.\n"
+                "outgoing": {
+                  "type": "object",
+                  "description": "HTTP route patterns for requests made by the matched workload.\nEquivalent to v1 `routes.outgoing`.\n",
+                  "additionalProperties": false,
+                  "properties": {
+                    "patterns": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Explicit outgoing route patterns for this workload.\n"
+                    }
+                  }
                 }
               }
             },

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -47,8 +47,10 @@ extensions:
               metrics: true
             http:
               routes:
-                unmatched: wildcard
-                patterns: ["/orders/{id}"]
+                incoming:
+                  patterns: ["/orders/{id}"]
+                outgoing:
+                  patterns: ["/inventory/{id}"]
               filters:
                 traces:
                   status_code: ["5*"]
@@ -70,8 +72,12 @@ extensions:
 	require.Equal(t, map[string]any{"traces": false, "metrics": true}, cfg.Capture.Rules[0].Refine.Exports)
 	require.Equal(t, map[string]any{
 		"routes": map[string]any{
-			"unmatched": "wildcard",
-			"patterns":  []any{"/orders/{id}"},
+			"incoming": map[string]any{
+				"patterns": []any{"/orders/{id}"},
+			},
+			"outgoing": map[string]any{
+				"patterns": []any{"/inventory/{id}"},
+			},
 		},
 		"filters": map[string]any{
 			"traces": map[string]any{


### PR DESCRIPTION
## Summary

This updates the config v2 docs and schema for per-workload HTTP route refinements to preserve route direction explicitly.

The previous draft shape used `refine.http.routes.patterns`, which is directionless. That does not safely represent the v1 per-selector route config because v1 distinguishes routes for requests handled by a workload from routes for requests made by that workload.

The new shape is:

```yaml
refine:
  http:
    routes:
      incoming:
        patterns: []
      outgoing:
        patterns: []
```

`incoming` maps to requests handled by the matched workload, and `outgoing` maps to requests made by the matched workload.

## Details

- Updates the config v2 design doc and default example to use direction-scoped route refinements.
- Updates the v2 extension JSON schema to accept `incoming.patterns` and `outgoing.patterns` under per-workload `http.routes`.
- Removes per-workload `unmatched`, directionless `patterns`, and `ignored_patterns` from the refinement schema for now.
- Leaves global `capture.instrumentation.http.routes` unchanged.

This is intentionally limited to the docs/schema contract. Import/export runtime parity for v1 `routes.incoming` and `routes.outgoing` remains a later config-v2 slice.

## Tests

- `go test ./internal/config/schema`
- `python3 devdocs/config/version-2.0/validate_example.py`
- `make lint-markdown`
- `go test ./cmd/check-config-v2-parity`