### PR TITLE
fix kafka-go span operation mapping

### DIFF
--- a/internal/test/oats/kafka/yaml/oats_go_kafka-go-topic.yaml
+++ b/internal/test/oats/kafka/yaml/oats_go_kafka-go-topic.yaml
@@ -7,18 +7,16 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="logging"}'
+  - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="logging" && kind = producer }'
     equals: publish logging
     attributes:
-      span.kind: producer
       messaging.destination.name: logging
       messaging.operation.type: publish
       messaging.system: kafka
       server.port: '9092'
-  - traceql: '{ .messaging.operation.type = "process" && .messaging.destination.name="logging"}'
+  - traceql: '{ .messaging.operation.type = "process" && .messaging.destination.name="logging" && kind = consumer }'
     equals: process logging
     attributes:
-      span.kind: consumer
       messaging.destination.name: logging
       messaging.operation.type: process
       messaging.system: kafka

--- a/internal/test/oats/kafka/yaml/oats_go_kafka-go-topic.yaml
+++ b/internal/test/oats/kafka/yaml/oats_go_kafka-go-topic.yaml
@@ -10,6 +10,7 @@ expected:
   - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="logging"}'
     equals: publish logging
     attributes:
+      span.kind: producer
       messaging.destination.name: logging
       messaging.operation.type: publish
       messaging.system: kafka
@@ -17,6 +18,7 @@ expected:
   - traceql: '{ .messaging.operation.type = "process" && .messaging.destination.name="logging"}'
     equals: process logging
     attributes:
+      span.kind: consumer
       messaging.destination.name: logging
       messaging.operation.type: process
       messaging.system: kafka

--- a/internal/test/oats/kafka/yaml/oats_go_kafka-go.yaml
+++ b/internal/test/oats/kafka/yaml/oats_go_kafka-go.yaml
@@ -7,18 +7,16 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="logging"}'
+  - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="logging" && kind = producer }'
     equals: publish logging
     attributes:
-      span.kind: producer
       messaging.destination.name: logging
       messaging.operation.type: publish
       messaging.system: kafka
       server.port: '9092'
-  - traceql: '{ .messaging.operation.type = "process" && .messaging.destination.name="logging"}'
+  - traceql: '{ .messaging.operation.type = "process" && .messaging.destination.name="logging" && kind = consumer }'
     equals: process logging
     attributes:
-      span.kind: consumer
       messaging.destination.name: logging
       messaging.operation.type: process
       messaging.system: kafka

--- a/internal/test/oats/kafka/yaml/oats_go_kafka-go.yaml
+++ b/internal/test/oats/kafka/yaml/oats_go_kafka-go.yaml
@@ -10,6 +10,7 @@ expected:
   - traceql: '{ .messaging.operation.type = "publish" && .messaging.destination.name="logging"}'
     equals: publish logging
     attributes:
+      span.kind: producer
       messaging.destination.name: logging
       messaging.operation.type: publish
       messaging.system: kafka
@@ -17,6 +18,7 @@ expected:
   - traceql: '{ .messaging.operation.type = "process" && .messaging.destination.name="logging"}'
     equals: process logging
     attributes:
+      span.kind: consumer
       messaging.destination.name: logging
       messaging.operation.type: process
       messaging.system: kafka

--- a/pkg/ebpf/common/go_kafka_transform.go
+++ b/pkg/ebpf/common/go_kafka_transform.go
@@ -14,6 +14,12 @@ import (
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
 
+const (
+	// Keep these values aligned with k_kafka_api_* in bpf/gotracer/types/kafka.h.
+	kafkaGoAPIFetch uint8 = iota
+	kafkaGoAPIProduce
+)
+
 func ReadGoSaramaRequestIntoSpan(record *ringbuf.Record) (request.Span, bool, error) {
 	event, err := ReinterpretCast[GoSaramaClientInfo](record.RawSample)
 	if err != nil {
@@ -75,10 +81,7 @@ func ReadGoKafkaGoRequestIntoSpan(record *ringbuf.Record) (request.Span, bool, e
 		hostPort = int(event.Conn.D_port)
 	}
 
-	op := Produce
-	if event.Op == 1 {
-		op = Fetch
-	}
+	op := kafkaGoOperation(event.Op)
 
 	return request.Span{
 		Type:          request.EventTypeKafkaClient,
@@ -103,4 +106,12 @@ func ReadGoKafkaGoRequestIntoSpan(record *ringbuf.Record) (request.Span, bool, e
 			Namespace: event.Pid.Ns,
 		},
 	}, false, nil
+}
+
+func kafkaGoOperation(apiKey uint8) Operation {
+	if apiKey == kafkaGoAPIProduce {
+		return Produce
+	}
+
+	return Fetch
 }

--- a/pkg/ebpf/common/go_kafka_transform_test.go
+++ b/pkg/ebpf/common/go_kafka_transform_test.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/ebpf/ringbuf"
+)
+
+func TestReadGoKafkaGoRequestIntoSpanOperation(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiKey   uint8
+		method   string
+		spanKind string
+	}{
+		{
+			name:     "fetch",
+			apiKey:   kafkaGoAPIFetch,
+			method:   request.MessagingProcess,
+			spanKind: "SPAN_KIND_CONSUMER",
+		},
+		{
+			name:     "produce",
+			apiKey:   kafkaGoAPIProduce,
+			method:   request.MessagingPublish,
+			spanKind: "SPAN_KIND_PRODUCER",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := GoKafkaGoClientInfo{Op: tt.apiKey}
+			copy(event.Topic[:], "test-topic")
+
+			var raw bytes.Buffer
+			require.NoError(t, binary.Write(&raw, binary.LittleEndian, event))
+
+			span, ignore, err := ReadGoKafkaGoRequestIntoSpan(&ringbuf.Record{RawSample: raw.Bytes()})
+
+			require.NoError(t, err)
+			assert.False(t, ignore)
+			assert.Equal(t, request.EventTypeKafkaClient, span.Type)
+			assert.Equal(t, "github.com/segmentio/kafka-go", span.Statement)
+			assert.Equal(t, tt.method, span.Method)
+			assert.Equal(t, "test-topic", span.Path)
+			assert.Equal(t, tt.method+" test-topic", span.TraceName())
+			assert.Equal(t, tt.spanKind, span.ServiceGraphKind())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fixes Kafka-Go spans being reported with reversed messaging operations.
The eBPF event uses 0 for fetch and 1 for produce, but the Go transform interpreted them in the opposite order. This caused:
Produce spans to appear as Consumer/process
Fetch spans to appear as Producer/publish
This change aligns the Go mapping with the eBPF enum and adds regression coverage for both operations, including span name, topic, client ID, and Producer/Consumer kind. Existing Kafka-Go OATS scenarios now also validate span.kind.

## Validation Testing

- `go test ./pkg/ebpf/common`
- `go test ./pkg/appolly/app/request`
- `go test ./pkg/export/otel/tracesgen`


- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->

fixes 
https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2299
