### PR TITLE
Add internal `jvmtools` fork

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,8 @@ linters:
       - ^configs
       # this is temporarily imported code that does not rely on us
       - ^pkg/export/otel/metric
+      # copied jvmtools fork; keep upstream code changes scoped to follow-up PRs
+      - ^pkg/internal/jvmtools
     presets:
       - std-error-handling
     # Log a warning if an exclusion rule is unused.

--- a/NOTICE
+++ b/NOTICE
@@ -5,6 +5,10 @@ inspired by Grafana Beyla (https://github.com/grafana/beyla).
 Copyright Grafana Labs.
 
 The Initial Developer of some parts of the product, which are copied from, derived from, or
+inspired by Grafana jvmtools (https://github.com/grafana/jvmtools).
+Copyright Grafana Labs.
+
+The Initial Developer of some parts of the product, which are copied from, derived from, or
 inspired by OpenTelemetry Go Automatic Instrumentation (https://github.com/open-telemetry/opentelemetry-go-instrumentation).
 Copyright The OpenTelemetry Authors.
 

--- a/NOTICES/amd64/go.opentelemetry.io/obi/NOTICE
+++ b/NOTICES/amd64/go.opentelemetry.io/obi/NOTICE
@@ -5,6 +5,10 @@ inspired by Grafana Beyla (https://github.com/grafana/beyla).
 Copyright Grafana Labs.
 
 The Initial Developer of some parts of the product, which are copied from, derived from, or
+inspired by Grafana jvmtools (https://github.com/grafana/jvmtools).
+Copyright Grafana Labs.
+
+The Initial Developer of some parts of the product, which are copied from, derived from, or
 inspired by OpenTelemetry Go Automatic Instrumentation (https://github.com/open-telemetry/opentelemetry-go-instrumentation).
 Copyright The OpenTelemetry Authors.
 

--- a/NOTICES/arm64/go.opentelemetry.io/obi/NOTICE
+++ b/NOTICES/arm64/go.opentelemetry.io/obi/NOTICE
@@ -5,6 +5,10 @@ inspired by Grafana Beyla (https://github.com/grafana/beyla).
 Copyright Grafana Labs.
 
 The Initial Developer of some parts of the product, which are copied from, derived from, or
+inspired by Grafana jvmtools (https://github.com/grafana/jvmtools).
+Copyright Grafana Labs.
+
+The Initial Developer of some parts of the product, which are copied from, derived from, or
 inspired by OpenTelemetry Go Automatic Instrumentation (https://github.com/open-telemetry/opentelemetry-go-instrumentation).
 Copyright The OpenTelemetry Authors.
 

--- a/pkg/internal/jvmtools/README.md
+++ b/pkg/internal/jvmtools/README.md
@@ -1,0 +1,16 @@
+# Internal jvmtools Fork
+
+This directory contains a minimal fork of `github.com/grafana/jvmtools` copied
+from version `v0.0.5`.
+
+Only the JVM attach code currently used by OBI is included:
+
+- `jvm/cmd.go`
+- `jvm/cmd_hotspot.go`
+- `jvm/cmd_openj9.go`
+- `jvm/linux_tools.go`
+- `util/psutil.go`
+
+The CLI, scripts, dynamic-agent-loading flag flip code, and ptrace/ELF helpers
+are intentionally omitted. The initial copy is behavior-preserving; local
+changes should remain scoped to OBI's JVM attach needs.

--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -1,0 +1,105 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package jvm // import "go.opentelemetry.io/obi/pkg/internal/jvmtools/jvm"
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"go.opentelemetry.io/obi/pkg/internal/jvmtools/util"
+)
+
+type JAttacher struct {
+	logger     *slog.Logger
+	j9attacher *j9Attacher
+	myUID      int
+	myGID      int
+	myPID      int
+}
+
+func NewJAttacher(logger *slog.Logger) *JAttacher {
+	return &JAttacher{
+		logger:     logger,
+		j9attacher: nil,
+	}
+}
+
+func (j *JAttacher) Init() {
+	myUID := syscall.Geteuid()
+	myGID := syscall.Getegid()
+	myPID := os.Getpid()
+
+	j.myUID = myUID
+	j.myGID = myGID
+	j.myPID = myPID
+}
+
+func (j *JAttacher) Cleanup() error {
+	if j.j9attacher != nil {
+		j.j9attacher.detach()
+	}
+	if err := syscall.Seteuid(j.myUID); err != nil {
+		j.logger.Error("failed to restore uid", "error", err)
+	}
+	if err := syscall.Setegid(j.myGID); err != nil {
+		j.logger.Error("failed to restore gid", "error", err)
+	}
+
+	util.EnterNS(j.myPID, "net")
+	util.EnterNS(j.myPID, "ipc")
+	util.EnterNS(j.myPID, "mnt")
+
+	return nil
+}
+
+func (j *JAttacher) Attach(pid int, argv []string, ignoreOnJ9 bool) (io.ReadCloser, error) {
+	targetUID := j.myUID
+	targetGID := j.myGID
+	var nspid int
+
+	if util.GetProcessInfo(pid, &targetUID, &targetGID, &nspid) != nil {
+		return nil, fmt.Errorf("process not found: %v", pid)
+	}
+
+	// Container support: switch to the target namespaces.
+	// Network and IPC namespaces are essential for OpenJ9 connection.
+	util.EnterNS(pid, "net")
+	util.EnterNS(pid, "ipc")
+	mntChanged := util.EnterNS(pid, "mnt")
+
+	// In HotSpot, dynamic attach is allowed only for the clients with the same euid/egid.
+	// If we are running under root, switch to the required euid/egid automatically.
+	if (j.myGID != targetGID && syscall.Setegid(int(targetGID)) != nil) ||
+		(j.myUID != targetUID && syscall.Seteuid(int(targetUID)) != nil) {
+		return nil, errors.New("failed to change credentials to match the target process")
+	}
+
+	attachPid := pid
+	if mntChanged > 0 {
+		attachPid = nspid
+	}
+
+	tmpPath := util.GetTmpPath(attachPid)
+
+	// Make write() return EPIPE instead of abnormal process termination
+	signal.Ignore(syscall.SIGPIPE)
+
+	if isOpenJ9Process(tmpPath, attachPid) {
+		if ignoreOnJ9 {
+			return nil, nil
+		}
+		j9attacher := newJ9Attacher(j.logger)
+		j.j9attacher = j9attacher
+		return j.j9attacher.jattachOpenJ9(tmpPath, pid, nspid, argv)
+	}
+
+	return jattachHotspot(pid, nspid, attachPid, argv, tmpPath, j.logger)
+}

--- a/pkg/internal/jvmtools/jvm/cmd_hotspot.go
+++ b/pkg/internal/jvmtools/jvm/cmd_hotspot.go
@@ -1,0 +1,107 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package jvm // import "go.opentelemetry.io/obi/pkg/internal/jvmtools/jvm"
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"syscall"
+	"time"
+)
+
+// Check if remote JVM has already opened socket for Dynamic Attach
+func checkSocket(pid int, tmpPath string) bool {
+	path := fmt.Sprintf("%s/.java_pid%d", tmpPath, pid)
+	info, err := os.Stat(path)
+	return err == nil && (info.Mode()&os.ModeSocket != 0)
+}
+
+// Check if a file is owned by current user
+func getFileOwner(path string) (uid int) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return -1
+	}
+	stat := info.Sys().(*syscall.Stat_t)
+	return int(stat.Uid)
+}
+
+// Force remote JVM to start Attach listener.
+// HotSpot will start Attach listener in response to SIGQUIT if it sees .attach_pid file
+func startAttachMechanism(pid, nspid, attachPid int, tmpPath string) bool {
+	path := fmt.Sprintf("/proc/%d/cwd/.attach_pid%d", attachPid, nspid)
+	fd, err := os.Create(path)
+	if err != nil || (fd.Close() == nil && getFileOwner(path) != os.Geteuid()) {
+		os.Remove(path)
+		path = fmt.Sprintf("%s/.attach_pid%d", tmpPath, nspid)
+		fd, err = os.Create(path)
+		if err != nil {
+			return false
+		}
+		fd.Close()
+	}
+
+	syscall.Kill(pid, syscall.SIGQUIT)
+
+	ts := 20 * time.Millisecond
+	for i := 0; i < 300; i++ {
+		time.Sleep(ts)
+		if checkSocket(nspid, tmpPath) {
+			os.Remove(path)
+			return true
+		}
+		ts += 20 * time.Millisecond
+	}
+
+	os.Remove(path)
+	return false
+}
+
+// Connect to UNIX domain socket created by JVM for Dynamic Attach
+func connectSocket(pid int, tmpPath string) (net.Conn, error) {
+	return net.Dial("unix", fmt.Sprintf("%s/.java_pid%d", tmpPath, pid))
+}
+
+// Send command with arguments to socket
+func writeHotspotCommand(conn net.Conn, args []string) error {
+	request := make([]byte, 0)
+
+	request = append(request, byte('1'))
+	request = append(request, byte(0))
+
+	for i := 0; i < 4; i++ {
+		if i < len(args) {
+			request = append(request, []byte(args[i])...)
+		}
+		request = append(request, byte(0))
+	}
+
+	_, err := conn.Write(request)
+	return err
+}
+
+func jattachHotspot(pid, nspid, attachPid int, args []string, tmpPath string, logger *slog.Logger) (io.ReadCloser, error) {
+	if !checkSocket(nspid, tmpPath) && !startAttachMechanism(pid, nspid, attachPid, tmpPath) {
+		return nil, errors.New("could not start the attach mechanism")
+	}
+
+	conn, err := connectSocket(nspid, tmpPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to JVM socket: %w", err)
+	}
+
+	logger.Debug("connected to the JVM")
+
+	if err := writeHotspotCommand(conn, args); err != nil {
+		return nil, fmt.Errorf("error writing to the JVM socket: %w", err)
+	}
+
+	return conn, nil
+}

--- a/pkg/internal/jvmtools/jvm/cmd_openj9.go
+++ b/pkg/internal/jvmtools/jvm/cmd_openj9.go
@@ -1,0 +1,426 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+// Converted from C code from the jattach project
+package jvm // import "go.opentelemetry.io/obi/pkg/internal/jvmtools/jvm"
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+const (
+	MaxNotifyFiles = 256
+)
+
+type j9Attacher struct {
+	notifyLock [MaxNotifyFiles]int
+	logger     *slog.Logger
+	fd         int
+}
+
+func newJ9Attacher(logger *slog.Logger) *j9Attacher {
+	return &j9Attacher{
+		logger: logger,
+	}
+}
+
+// Translate HotSpot command to OpenJ9 equivalent
+func translateCommand(argv []string) string {
+	if len(argv) == 0 {
+		return ""
+	}
+
+	argc := len(argv)
+	cmd := argv[0]
+	var result string
+
+	switch cmd {
+	case "load":
+		if argc >= 2 {
+			arg3 := ""
+			if argc > 3 {
+				arg3 = argv[3]
+			}
+			if argc > 2 && argv[2] == "true" {
+				result = fmt.Sprintf("ATTACH_LOADAGENTPATH(%s,%s)", argv[1], arg3)
+			} else {
+				result = fmt.Sprintf("ATTACH_LOADAGENT(%s,%s)", argv[1], arg3)
+			}
+		}
+
+	case "jcmd":
+		arg1 := "help"
+		if argc > 1 {
+			arg1 = argv[1]
+		}
+		result = fmt.Sprintf("ATTACH_DIAGNOSTICS:%s", arg1)
+		for i := 2; i < argc; i++ {
+			result += "," + argv[i]
+		}
+
+	case "threaddump":
+		arg1 := ""
+		if argc > 1 {
+			arg1 = argv[1]
+		}
+		result = fmt.Sprintf("ATTACH_DIAGNOSTICS:Thread.print,%s", arg1)
+
+	case "dumpheap":
+		arg1 := ""
+		if argc > 1 {
+			arg1 = argv[1]
+		}
+		result = fmt.Sprintf("ATTACH_DIAGNOSTICS:Dump.heap,%s", arg1)
+
+	case "inspectheap":
+		arg1 := ""
+		if argc > 1 {
+			arg1 = argv[1]
+		}
+		result = fmt.Sprintf("ATTACH_DIAGNOSTICS:GC.class_histogram,%s", arg1)
+
+	case "datadump":
+		arg1 := ""
+		if argc > 1 {
+			arg1 = argv[1]
+		}
+		result = fmt.Sprintf("ATTACH_DIAGNOSTICS:Dump.java,%s", arg1)
+
+	case "properties":
+		result = "ATTACH_GETSYSTEMPROPERTIES"
+
+	case "agentProperties":
+		result = "ATTACH_GETAGENTPROPERTIES"
+
+	default:
+		result = cmd
+	}
+
+	return result
+}
+
+// Send command with arguments to socket
+func writeCommand(fd int, cmd string) error {
+	data := []byte(cmd)
+	data = append(data, 0) // null terminator
+
+	off := 0
+	for off < len(data) {
+		n, err := syscall.Write(fd, data[off:])
+		if err != nil || n <= 0 {
+			return fmt.Errorf("write failed")
+		}
+		off += n
+	}
+	return nil
+}
+
+func closeWithErrno(fd int) {
+	syscall.Close(fd)
+}
+
+func acquireLock(tmpPath, subdir, filename string) (int, error) {
+	path := filepath.Join(tmpPath, ".com_ibm_tools_attach", subdir, filename)
+
+	fd, err := syscall.Open(path, syscall.O_WRONLY|syscall.O_CREAT, 0666)
+	if err != nil {
+		return -1, err
+	}
+
+	if err := syscall.Flock(fd, syscall.LOCK_EX); err != nil {
+		syscall.Close(fd)
+		return -1, err
+	}
+
+	return fd, nil
+}
+
+func releaseLock(lockFd int) {
+	syscall.Flock(lockFd, syscall.LOCK_UN)
+	syscall.Close(lockFd)
+}
+
+func createAttachSocket() (int, int, error) {
+	// Try IPv6 socket first, then fall back to IPv4
+	s, err := syscall.Socket(syscall.AF_INET6, syscall.SOCK_STREAM, 0)
+	if err == nil {
+		addr := &syscall.SockaddrInet6{}
+		if err := syscall.Bind(s, addr); err == nil {
+			if err := syscall.Listen(s, 0); err == nil {
+				sa, err := syscall.Getsockname(s)
+				if err == nil {
+					if sa6, ok := sa.(*syscall.SockaddrInet6); ok {
+						return s, int(sa6.Port), nil
+					}
+				}
+			}
+		}
+		closeWithErrno(s)
+	}
+
+	// Fall back to IPv4
+	s, err = syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		return -1, 0, err
+	}
+
+	addr := &syscall.SockaddrInet4{}
+	if err := syscall.Bind(s, addr); err != nil {
+		closeWithErrno(s)
+		return -1, 0, err
+	}
+
+	if err := syscall.Listen(s, 0); err != nil {
+		closeWithErrno(s)
+		return -1, 0, err
+	}
+
+	sa, err := syscall.Getsockname(s)
+	if err != nil {
+		closeWithErrno(s)
+		return -1, 0, err
+	}
+
+	if sa4, ok := sa.(*syscall.SockaddrInet4); ok {
+		return s, int(sa4.Port), nil
+	}
+
+	closeWithErrno(s)
+	return -1, 0, fmt.Errorf("failed to get socket port")
+}
+
+func closeAttachSocket(tmpPath string, s, pid int) {
+	path := filepath.Join(tmpPath, ".com_ibm_tools_attach", strconv.Itoa(pid), "replyInfo")
+	syscall.Unlink(path)
+	syscall.Close(s)
+}
+
+func randomKey() uint64 {
+	key := uint64(time.Now().Unix()) * 0xc6a4a7935bd1e995
+
+	fd, err := syscall.Open("/dev/urandom", syscall.O_RDONLY, 0)
+	if err == nil {
+		buf := make([]byte, 8)
+		syscall.Read(fd, buf)
+		syscall.Close(fd)
+
+		for i := 0; i < 8; i++ {
+			key ^= uint64(buf[i]) << (uint(i) * 8)
+		}
+	}
+
+	return key
+}
+
+func writeReplyInfo(tmpPath string, pid, port int, key uint64) error {
+	path := filepath.Join(tmpPath, ".com_ibm_tools_attach", strconv.Itoa(pid), "replyInfo")
+
+	fd, err := syscall.Open(path, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer syscall.Close(fd)
+
+	content := fmt.Sprintf("%016x\n%d\n", key, port)
+	syscall.Write(fd, []byte(content))
+
+	return nil
+}
+
+func notifySemaphore(tmpPath string, value, notifyCount int) error {
+	path := filepath.Join(tmpPath, ".com_ibm_tools_attach", "_notifier")
+
+	semKey, err := ftok(path, 0xa1)
+	if err != nil {
+		return err
+	}
+
+	semID, err := semget(semKey, 1, IPC_CREAT|0666)
+	if err != nil {
+		return err
+	}
+
+	flags := int16(0)
+	if value < 0 {
+		flags = IPC_NOWAIT
+	}
+
+	sb := createSembuf(0, int16(value), flags)
+
+	for range notifyCount {
+		semop(semID, []sembuf{sb})
+	}
+
+	return nil
+}
+
+func acceptClient(s int, key uint64) (int, error) {
+	tv := syscall.Timeval{Sec: 5, Usec: 0}
+	syscall.SetsockoptTimeval(s, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv)
+
+	nfd, _, err := syscall.Accept(s)
+	if err != nil {
+		return -1, fmt.Errorf("JVM did not respond: %w", err)
+	}
+
+	buf := make([]byte, 35)
+	off := 0
+	for off < len(buf) {
+		n, err := syscall.Read(nfd, buf[off:])
+		if err != nil || n <= 0 {
+			syscall.Close(nfd)
+			return -1, fmt.Errorf("the JVM connection was prematurely closed")
+		}
+		off += n
+	}
+
+	expected := fmt.Sprintf("ATTACH_CONNECTED %016x ", key)
+	if !bytes.Equal(buf[:len(expected)], []byte(expected)) {
+		syscall.Close(nfd)
+		return -1, fmt.Errorf("unexpected JVM response %s", buf[:len(expected)])
+	}
+
+	// Reset the timeout, as the command execution may take arbitrary long time
+	tv0 := syscall.Timeval{Sec: 0, Usec: 0}
+	syscall.SetsockoptTimeval(nfd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv0)
+
+	return nfd, nil
+}
+
+func (j *j9Attacher) lockNotificationFiles(tmpPath string) int {
+	count := 0
+	path := filepath.Join(tmpPath, ".com_ibm_tools_attach")
+
+	dir, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer dir.Close()
+
+	entries, err := dir.Readdir(-1) // all files
+	if err != nil {
+		return 0
+	}
+
+	for _, entry := range entries {
+		if count >= MaxNotifyFiles {
+			break
+		}
+		name := entry.Name()
+		if len(name) > 0 && name[0] >= '1' && name[0] <= '9' && entry.IsDir() {
+			if fd, err := acquireLock(tmpPath, name, "attachNotificationSync"); err == nil {
+				j.notifyLock[count] = fd
+				count++
+			}
+		}
+	}
+
+	return count
+}
+
+func (j *j9Attacher) unlockNotificationFiles(count int) {
+	for i := range count {
+		if j.notifyLock[i] >= 0 {
+			releaseLock(j.notifyLock[i])
+		}
+	}
+}
+
+func isOpenJ9Process(tmpPath string, pid int) bool {
+	path := filepath.Join(tmpPath, ".com_ibm_tools_attach", strconv.Itoa(pid), "attachInfo")
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func (j *j9Attacher) detach() {
+	if j.fd == 0 {
+		return
+	}
+
+	if writeCommand(j.fd, "ATTACH_DETACHED") != nil {
+		return
+	}
+
+	buf := make([]byte, 256)
+	for {
+		n, err := syscall.Read(j.fd, buf)
+		if err != nil || n <= 0 || buf[n-1] == 0 {
+			break
+		}
+	}
+}
+
+func (j *j9Attacher) jattachOpenJ9(tmpPath string, pid, nspid int, argv []string) (io.ReadCloser, error) {
+	attachLock, err := acquireLock(tmpPath, "", "_attachlock")
+	if err != nil {
+		return nil, fmt.Errorf("could not acquire attach lock: %w", err)
+	}
+
+	notifyCount := 0
+	s := -1
+	var port int
+
+	defer func() {
+		if s >= 0 {
+			closeAttachSocket(tmpPath, s, nspid)
+		}
+		if notifyCount > 0 {
+			j.unlockNotificationFiles(notifyCount)
+			notifySemaphore(tmpPath, -1, notifyCount)
+		}
+		releaseLock(attachLock)
+	}()
+
+	s, port, err = createAttachSocket()
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen to attach socket: %w", err)
+	}
+
+	key := randomKey()
+	if err := writeReplyInfo(tmpPath, nspid, port, key); err != nil {
+		return nil, fmt.Errorf("could not write replyInfo: %w", err)
+	}
+
+	notifyCount = j.lockNotificationFiles(tmpPath)
+	if err := notifySemaphore(tmpPath, 1, notifyCount); err != nil {
+		return nil, fmt.Errorf("could not notify semaphore: %w", err)
+	}
+
+	fd, err := acceptClient(s, key)
+	if err != nil {
+		return nil, err
+	}
+
+	j.fd = fd
+
+	closeAttachSocket(tmpPath, s, nspid)
+	s = -1
+	j.unlockNotificationFiles(notifyCount)
+	notifySemaphore(tmpPath, -1, notifyCount)
+	notifyCount = 0
+	releaseLock(attachLock)
+	attachLock = -1
+
+	j.logger.Info("Connected to remote JVM")
+
+	cmd := translateCommand(argv)
+
+	if err := writeCommand(fd, cmd); err != nil {
+		syscall.Close(fd)
+		return nil, fmt.Errorf("error writing to socket: %w", err)
+	}
+
+	reader := os.NewFile(uintptr(fd), "socket")
+
+	return reader, nil
+}

--- a/pkg/internal/jvmtools/jvm/linux_tools.go
+++ b/pkg/internal/jvmtools/jvm/linux_tools.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package jvm // import "go.opentelemetry.io/obi/pkg/internal/jvmtools/jvm"
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	SYS_SEMGET = 64
+	SYS_SEMOP  = 65
+	IPC_CREAT  = 01000
+	IPC_NOWAIT = 04000
+)
+
+type sembuf struct {
+	Num uint16
+	Op  int16
+	Flg int16
+}
+
+// System V semaphore operations for Linux
+func semget(key, nsems, semflg int) (int, error) {
+	r1, _, errno := syscall.Syscall(SYS_SEMGET, uintptr(key), uintptr(nsems), uintptr(semflg))
+	if int(r1) == -1 {
+		return -1, errno
+	}
+	return int(r1), nil
+}
+
+func semop(semid int, sops []sembuf) error {
+	_, _, errno := syscall.Syscall(SYS_SEMOP, uintptr(semid), uintptr(unsafe.Pointer(&sops[0])), uintptr(len(sops)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func createSembuf(num uint16, op int16, flg int16) sembuf {
+	return sembuf{
+		Num: num,
+		Op:  op,
+		Flg: flg,
+	}
+}
+
+// Ftok uses the given pathname (which must refer to an existing, accessible file) and
+// the least significant 8 bits of proj_id (which must be nonzero) to generate
+// a key_t type System V IPC key.
+func ftok(pathname string, projectid uint8) (int, error) {
+	var stat = syscall.Stat_t{}
+	if err := syscall.Stat(pathname, &stat); err != nil {
+		return 0, err
+	}
+	return int(uint(projectid&0xff)<<24 | uint((stat.Dev&0xff)<<16) | (uint(stat.Ino) & 0xffff)), nil
+}

--- a/pkg/internal/jvmtools/util/psutil.go
+++ b/pkg/internal/jvmtools/util/psutil.go
@@ -1,0 +1,169 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package util // import "go.opentelemetry.io/obi/pkg/internal/jvmtools/util"
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	syscall "golang.org/x/sys/unix"
+)
+
+// Constants
+const MaxPath = 4096
+
+// Called just once to fill in tmpPath buffer
+func GetTmpPath(pid int) string {
+	var tmpPath string
+	// Try user-provided alternative path first
+	vmTmpPath := os.Getenv("JVM_TMP_PATH")
+	if vmTmpPath != "" && len(vmTmpPath) < MaxPath-100 {
+		return vmTmpPath
+	}
+
+	if getTmpPathR(pid, &tmpPath) != nil {
+		tmpPath = "/tmp"
+	}
+
+	return tmpPath
+}
+
+func getTmpPathR(pid int, buf *string) error {
+	*buf = fmt.Sprintf("/proc/%d/root/tmp", pid)
+
+	// Check if the remote /tmp can be accessed via /proc/[pid]/root
+	_, err := os.Stat(*buf)
+	return err
+}
+
+func GetProcessInfo(pid int, uid *int, gid *int, nspid *int) error {
+	// Parse /proc/pid/status to find process credentials
+	path := fmt.Sprintf("/proc/%d/status", pid)
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	nspidFound := false
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "Uid:") {
+			fields := strings.Fields(line[4:])
+			if len(fields) > 1 {
+				*uid = int(parseUint32(fields[1]))
+			}
+		} else if strings.HasPrefix(line, "Gid:") {
+			fields := strings.Fields(line[4:])
+			if len(fields) > 1 {
+				*gid = int(parseUint32(fields[1]))
+			}
+		} else if strings.HasPrefix(line, "NStgid:") {
+			fields := strings.Fields(line[7:])
+			if len(fields) > 0 {
+				*nspid = parseInt(fields[len(fields)-1])
+				nspidFound = true
+			}
+		}
+	}
+
+	if !nspidFound {
+		*nspid = altLookupNspid(pid)
+	}
+
+	return scanner.Err()
+}
+
+func parseUint32(s string) uint32 {
+	val, _ := strconv.ParseUint(s, 10, 32)
+	return uint32(val)
+}
+
+func parseInt(s string) int {
+	val, _ := strconv.Atoi(s)
+	return val
+}
+
+func altLookupNspid(pid int) int {
+	path := fmt.Sprintf("/proc/%d/ns/pid", pid)
+
+	// Don't bother looking for container PID if we are already in the same PID namespace
+	oldnsStat, _ := os.Stat("/proc/self/ns/pid")
+	newnsStat, _ := os.Stat(path)
+	if os.SameFile(oldnsStat, newnsStat) {
+		return pid
+	}
+
+	// Otherwise browse all PIDs in the namespace of the target process
+	// trying to find which one corresponds to the host PID
+	path = fmt.Sprintf("/proc/%d/root/proc", pid)
+	dir, err := os.Open(path)
+	if err != nil {
+		return pid
+	}
+	defer dir.Close()
+
+	entries, _ := dir.Readdirnames(0)
+	for _, entry := range entries {
+		if entry[0] >= '1' && entry[0] <= '9' {
+			// Check if /proc/<container-pid>/sched points back to <host-pid>
+			schedPath := fmt.Sprintf("/proc/%d/root/proc/%s/sched", pid, entry)
+			if schedGetHostPid(schedPath) == pid {
+				pid, _ = strconv.Atoi(entry)
+				break
+			}
+		}
+	}
+
+	return pid
+}
+
+func schedGetHostPid(path string) int {
+	file, err := os.Open(path)
+	if err != nil {
+		return -1
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	if scanner.Scan() {
+		line := scanner.Text()
+		if c := strings.LastIndex(line, "("); c != -1 {
+			return parseInt(line[c+1:])
+		}
+	}
+
+	return -1
+}
+
+func EnterNS(pid int, nsType string) int {
+	path := fmt.Sprintf("/proc/%d/ns/%s", pid, nsType)
+	selfPath := fmt.Sprintf("/proc/self/ns/%s", nsType)
+
+	oldnsStat, _ := os.Stat(selfPath)
+	newnsStat, _ := os.Stat(path)
+	if os.SameFile(oldnsStat, newnsStat) {
+		return 0
+	}
+
+	newns, err := os.Open(path)
+	if err != nil {
+		return -1
+	}
+	defer newns.Close()
+
+	// Some ancient Linux distributions do not have setns() function
+	if _, _, err := syscall.RawSyscall(syscall.SYS_SETNS, newns.Fd(), syscall.CLONE_NEWNET, 0); err != 0 {
+		return -1
+	}
+
+	return 1
+}


### PR DESCRIPTION
## Summary

This is PR 1 for resolving #2034. It adds a minimal internal fork of `github.com/grafana/jvmtools@v0.0.5` under `pkg/internal/jvmtools`.

The copied subset is limited to the JVM attach code OBI currently needs:

- HotSpot attach
- OpenJ9 attach
- Linux semaphore helpers
- `/proc` process-info helpers

It intentionally excludes the `jvmtools` CLI, scripts, dynamic-agent-loading flag flip code, and ptrace/ELF helpers.

## Behavior

No OBI runtime path imports this fork yet, so this PR should be behavior-preserving. Follow-up PRs will switch imports, add context-aware HotSpot attach support, and thread route-harvest timeouts into Java route extraction.

## Validation

- `go test ./pkg/internal/jvmtools/...`
- `make license-header-check`
- `env GOOS=darwin go list ./pkg/internal/jvmtools/...`
- `make lint-markdown`
- `make vanity-import-check`
- `git diff --check`