### PR TITLE
Add config v2 runtime import foundation

### DIFF
--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/debug"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/filter"
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/transform"
 )
@@ -22,6 +23,8 @@ var v2AppMetricsFeatureMask = export.AppO11yFeatures |
 var v2NetworkMetricsFeatureMask = export.FeatureNetwork |
 	export.FeatureNetworkInterZone |
 	export.FeatureNetworkFlowPackets
+
+var v2StatsMetricsFeatureMask = export.FeatureStats
 
 // V2ToRuntime converts a hidden config v2 extension shape into an OBI runtime
 // configuration. It is an internal conversion foundation and is not wired into
@@ -60,7 +63,8 @@ func applyV2Capture(cfg *obi.Config, src *schema.Extension) {
 	applyV2Channels(cfg, src.Capture.Channels, completeChannels(src.Capture.Channels))
 	applyV2Engine(cfg, src.Capture.Engine, completeEngine(src.Capture.Engine))
 	applyV2Instrumentation(cfg, src.Capture.Instrumentation)
-	applyV2NetworkCapture(cfg, src.Capture.Network, completeNetworkCapture(src.Capture.Network.Capture))
+	applyV2NetworkCapture(cfg, src.Capture.Network.Capture, completeNetworkCapture(src.Capture.Network.Capture))
+	applyV2NetworkStats(cfg, src.Capture.Network.Stats, completeNetworkStats(src.Capture.Network.Stats))
 	applyV2Runtimes(cfg, src.Capture.Runtimes, completeRuntimes(src.Capture.Runtimes))
 	applyV2CaptureTelemetry(cfg, src.Capture.Telemetry, completeCaptureTelemetry(src.Capture.Telemetry))
 }
@@ -381,8 +385,7 @@ func applySignalEnablement(
 	return out
 }
 
-func applyV2NetworkCapture(cfg *obi.Config, networkCfg schema.CaptureNetwork, complete bool) {
-	capture := networkCfg.Capture
+func applyV2NetworkCapture(cfg *obi.Config, capture schema.NetworkCapture, complete bool) {
 	if zeroValue(capture) && !complete {
 		return
 	}
@@ -478,6 +481,91 @@ func applyPartialV2NetworkCapture(cfg *obi.Config, capture schema.NetworkCapture
 	}
 	if capture.Diagnostics.PrintFlows {
 		cfg.NetworkFlows.Print = true
+	}
+}
+
+func applyV2NetworkStats(cfg *obi.Config, stats schema.NetworkStats, complete bool) {
+	if zeroValue(stats) && !complete {
+		return
+	}
+
+	if complete || completeNetworkStats(stats) {
+		applyFullV2NetworkStats(cfg, stats)
+		return
+	}
+
+	applyPartialV2NetworkStats(cfg, stats)
+}
+
+func applyFullV2NetworkStats(cfg *obi.Config, stats schema.NetworkStats) {
+	cfg.Stats.AgentIP = stats.EndpointIdentity.AgentIP
+	cfg.Stats.AgentIPIface = obi.AgentTypeIface(stats.EndpointIdentity.AgentIPInterface)
+	cfg.Stats.AgentIPType = string(stats.EndpointIdentity.AgentIPFamily)
+	cfg.Stats.CIDRs = cloneRuntimeCIDRDefinitions(cfg.Stats.CIDRs, stats.Selection.CIDRs)
+	cfg.Filters.Stats = attributeFilterMap(stats.Filters.Metrics)
+	applyFullV2StatsEnrichment(cfg, stats.Enrichment)
+	cfg.Stats.Print = stats.Diagnostics.PrintStats
+}
+
+func applyPartialV2NetworkStats(cfg *obi.Config, stats schema.NetworkStats) {
+	if stats.EndpointIdentity.AgentIP != "" {
+		cfg.Stats.AgentIP = stats.EndpointIdentity.AgentIP
+	}
+	if stats.EndpointIdentity.AgentIPInterface != "" {
+		cfg.Stats.AgentIPIface = obi.AgentTypeIface(stats.EndpointIdentity.AgentIPInterface)
+	}
+	if stats.EndpointIdentity.AgentIPFamily != "" {
+		cfg.Stats.AgentIPType = string(stats.EndpointIdentity.AgentIPFamily)
+	}
+	if stats.Selection.CIDRs != nil {
+		cfg.Stats.CIDRs = cloneRuntimeCIDRDefinitions(cfg.Stats.CIDRs, stats.Selection.CIDRs)
+	}
+	if stats.Filters.Metrics != nil {
+		cfg.Filters.Stats = attributeFilterMap(stats.Filters.Metrics)
+	}
+	if !zeroValue(stats.Enrichment) {
+		applyPartialV2StatsEnrichment(cfg, stats.Enrichment)
+	}
+	if stats.Diagnostics.PrintStats {
+		cfg.Stats.Print = true
+	}
+}
+
+func applyFullV2StatsEnrichment(cfg *obi.Config, enrichment schema.NetworkEnrichment) {
+	cfg.Stats.GeoIP.IPInfo.Path = enrichment.GeoIP.IPInfo.Path
+	cfg.Stats.GeoIP.MaxMindInfo.CountryPath = enrichment.GeoIP.MaxMind.CountryPath
+	cfg.Stats.GeoIP.MaxMindInfo.ASNPath = enrichment.GeoIP.MaxMind.ASNPath
+	cfg.Stats.GeoIP.CacheLen = enrichment.GeoIP.Cache.Size
+	cfg.Stats.GeoIP.CacheTTL = enrichment.GeoIP.Cache.TTL.TimeDuration()
+	cfg.Stats.ReverseDNS.Type = string(enrichment.ReverseDNS.Mode)
+	cfg.Stats.ReverseDNS.CacheLen = enrichment.ReverseDNS.Cache.Size
+	cfg.Stats.ReverseDNS.CacheTTL = enrichment.ReverseDNS.Cache.TTL.TimeDuration()
+}
+
+func applyPartialV2StatsEnrichment(cfg *obi.Config, enrichment schema.NetworkEnrichment) {
+	if enrichment.GeoIP.IPInfo.Path != "" {
+		cfg.Stats.GeoIP.IPInfo.Path = enrichment.GeoIP.IPInfo.Path
+	}
+	if enrichment.GeoIP.MaxMind.CountryPath != "" {
+		cfg.Stats.GeoIP.MaxMindInfo.CountryPath = enrichment.GeoIP.MaxMind.CountryPath
+	}
+	if enrichment.GeoIP.MaxMind.ASNPath != "" {
+		cfg.Stats.GeoIP.MaxMindInfo.ASNPath = enrichment.GeoIP.MaxMind.ASNPath
+	}
+	if enrichment.GeoIP.Cache.Size != 0 {
+		cfg.Stats.GeoIP.CacheLen = enrichment.GeoIP.Cache.Size
+	}
+	if !zeroValue(enrichment.GeoIP.Cache.TTL) {
+		cfg.Stats.GeoIP.CacheTTL = enrichment.GeoIP.Cache.TTL.TimeDuration()
+	}
+	if enrichment.ReverseDNS.Mode != "" {
+		cfg.Stats.ReverseDNS.Type = string(enrichment.ReverseDNS.Mode)
+	}
+	if enrichment.ReverseDNS.Cache.Size != 0 {
+		cfg.Stats.ReverseDNS.CacheLen = enrichment.ReverseDNS.Cache.Size
+	}
+	if !zeroValue(enrichment.ReverseDNS.Cache.TTL) {
+		cfg.Stats.ReverseDNS.CacheTTL = enrichment.ReverseDNS.Cache.TTL.TimeDuration()
 	}
 }
 
@@ -729,6 +817,7 @@ func applyV2MetricsEnablement(cfg *obi.Config, src *schema.Extension) {
 	)
 	networkConfigured := !zeroValue(src.Capture.Network.Capture)
 	networkMetricsEnabled := src.Capture.Network.Capture.Enabled
+	statsFeatures, statsConfigured := statsMetricsEnablement(src.Capture.Network.Stats)
 	if appConfigured {
 		cfg.Metrics.Features &^= v2AppMetricsFeatureMask
 		if appMetricsEnabled {
@@ -740,6 +829,10 @@ func applyV2MetricsEnablement(cfg *obi.Config, src *schema.Extension) {
 		if networkMetricsEnabled {
 			cfg.Metrics.Features |= export.FeatureNetwork
 		}
+	}
+	if statsConfigured {
+		cfg.Metrics.Features &^= v2StatsMetricsFeatureMask
+		cfg.Metrics.Features |= statsFeatures
 	}
 }
 
@@ -806,6 +899,13 @@ func completeNetworkCapture(capture schema.NetworkCapture) bool {
 		!zeroValue(capture.InterfaceDiscovery)
 }
 
+func completeNetworkStats(stats schema.NetworkStats) bool {
+	return stats.Features != nil &&
+		!zeroValue(stats.EndpointIdentity) &&
+		stats.Selection.CIDRs != nil &&
+		!zeroValue(stats.Enrichment)
+}
+
 func completeRuntimes(runtimes schema.CaptureRuntimes) bool {
 	return !zeroValue(runtimes.Java.AttachTimeout) &&
 		(runtimes.Go.Enabled ||
@@ -844,6 +944,33 @@ func protocolEnablement(instrumentation schema.Instrumentation, name protocolNam
 	}
 }
 
+func statsMetricsEnablement(stats schema.NetworkStats) (export.Features, bool) {
+	if stats.Features != nil {
+		return statsFeatureMask(stats.Features), true
+	}
+	if stats.Enabled {
+		return export.FeatureStats, true
+	}
+	return 0, false
+}
+
+func statsFeatureMask(features []string) export.Features {
+	out := export.Features(0)
+	for _, feature := range features {
+		switch feature {
+		case statsFeatureTCPRtt:
+			out |= export.FeatureStatsTCPRtt
+		case statsFeatureTCPFailedConnections:
+			out |= export.FeatureStatsTCPFailedConnections
+		case statsFeatureTCPRetransmits:
+			out |= export.FeatureStatsTCPRetransmits
+		case statsFeatureTCPIo:
+			out |= export.FeatureStatsTCPIo
+		}
+	}
+	return out
+}
+
 func signalEnabled(enablement schema.ProtocolEnablement, signal string) bool {
 	switch signal {
 	case "traces":
@@ -867,6 +994,52 @@ func cloneStrings(values []string) []string {
 		return nil
 	}
 	return append([]string(nil), values...)
+}
+
+type runtimeCIDRDefinition interface {
+	~struct {
+		CIDR string `yaml:"cidr" json:"cidr"`
+		Name string `yaml:"name" json:"name"`
+	}
+}
+
+type runtimeCIDRDefinitionValue struct {
+	CIDR string `yaml:"cidr" json:"cidr"`
+	Name string `yaml:"name" json:"name"`
+}
+
+func cloneRuntimeCIDRDefinitions[T runtimeCIDRDefinition](_ []T, definitions schema.CIDRDefinitions) []T {
+	if definitions == nil {
+		return nil
+	}
+	out := make([]T, 0, len(definitions))
+	for _, definition := range definitions {
+		out = append(out, T(runtimeCIDRDefinitionValue{
+			CIDR: definition.CIDR,
+			Name: definition.Name,
+		}))
+	}
+	return out
+}
+
+func attributeFilterMap(in schema.AttributeFilters) filter.AttributeFamilyConfig {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(filter.AttributeFamilyConfig, len(in))
+	for key, def := range in {
+		out[key] = filter.MatchDefinition{
+			Match:         def.Match,
+			NotMatch:      def.NotMatch,
+			Equals:        def.Equals,
+			NotEquals:     def.NotEquals,
+			GreaterEquals: def.GreaterEquals,
+			GreaterThan:   def.GreaterThan,
+			LessEquals:    def.LessEquals,
+			LessThan:      def.LessThan,
+		}
+	}
+	return out
 }
 
 func cloneSources(values []transform.Source) []transform.Source {

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -1,0 +1,877 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert // import "go.opentelemetry.io/obi/internal/config/convert"
+
+import (
+	"reflect"
+
+	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/appolly/services"
+	obiconfig "go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/debug"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/obi"
+	"go.opentelemetry.io/obi/pkg/transform"
+)
+
+var v2AppMetricsFeatureMask = export.AppO11yFeatures |
+	export.FeatureApplicationRuntime
+
+var v2NetworkMetricsFeatureMask = export.FeatureNetwork |
+	export.FeatureNetworkInterZone |
+	export.FeatureNetworkFlowPackets
+
+// V2ToRuntime converts a hidden config v2 extension shape into an OBI runtime
+// configuration. It is an internal conversion foundation and is not wired into
+// runtime loading.
+func V2ToRuntime(src *schema.Extension) (*obi.Config, error) {
+	if err := schema.ValidateStandalone(src); err != nil {
+		return nil, err
+	}
+
+	cfg := runtimeConfigDefaults()
+	applyV2Capture(&cfg, src)
+	applyV2Standalone(&cfg, src)
+	applyV2MetricsEnablement(&cfg, src)
+	cfg.Attributes.Select.Normalize()
+
+	return &cfg, nil
+}
+
+func runtimeConfigDefaults() obi.Config {
+	cfg := obi.DefaultConfig
+	if cfg.Routes != nil {
+		routes := *cfg.Routes
+		cfg.Routes = &routes
+	}
+	if cfg.NameResolver != nil {
+		nameResolver := *cfg.NameResolver
+		cfg.NameResolver = &nameResolver
+	}
+	return cfg
+}
+
+func applyV2Capture(cfg *obi.Config, src *schema.Extension) {
+	applyV2Policy(cfg, src.Capture.Policy, completePolicy(src.Capture.Policy))
+	applyV2Limits(cfg, src.Capture.Limits, completeLimits(src.Capture.Limits))
+	applyV2Safety(cfg, src.Capture.Safety, !zeroValue(src.Capture.Safety))
+	applyV2Channels(cfg, src.Capture.Channels, completeChannels(src.Capture.Channels))
+	applyV2Engine(cfg, src.Capture.Engine, completeEngine(src.Capture.Engine))
+	applyV2Instrumentation(cfg, src.Capture.Instrumentation)
+	applyV2NetworkCapture(cfg, src.Capture.Network, completeNetworkCapture(src.Capture.Network.Capture))
+	applyV2Runtimes(cfg, src.Capture.Runtimes, completeRuntimes(src.Capture.Runtimes))
+	applyV2CaptureTelemetry(cfg, src.Capture.Telemetry, completeCaptureTelemetry(src.Capture.Telemetry))
+}
+
+func applyV2Policy(cfg *obi.Config, policy schema.CapturePolicy, complete bool) {
+	if zeroValue(policy) && !complete {
+		return
+	}
+
+	if complete || completePolicy(policy) {
+		cfg.Discovery.PollInterval = policy.PollInterval.TimeDuration()
+		cfg.Discovery.MinProcessAge = policy.MinProcessAge.TimeDuration()
+		return
+	}
+
+	if !zeroValue(policy.PollInterval) {
+		cfg.Discovery.PollInterval = policy.PollInterval.TimeDuration()
+	}
+	if !zeroValue(policy.MinProcessAge) {
+		cfg.Discovery.MinProcessAge = policy.MinProcessAge.TimeDuration()
+	}
+}
+
+func applyV2Limits(cfg *obi.Config, limits schema.CaptureLimits, complete bool) {
+	if zeroValue(limits) && !complete {
+		return
+	}
+
+	if complete || completeLimits(limits) {
+		cfg.Attributes.MetricSpanNameAggregationLimit = limits.MetricSpanNames
+		cfg.NetworkFlows.CacheMaxFlows = limits.NetworkPackets
+		return
+	}
+
+	if limits.MetricSpanNames != 0 {
+		cfg.Attributes.MetricSpanNameAggregationLimit = limits.MetricSpanNames
+	}
+	if limits.NetworkPackets != 0 {
+		cfg.NetworkFlows.CacheMaxFlows = limits.NetworkPackets
+	}
+}
+
+func applyV2Safety(cfg *obi.Config, safety schema.CaptureSafety, complete bool) {
+	if zeroValue(safety) && !complete {
+		return
+	}
+
+	if complete {
+		cfg.EnforceSysCaps = safety.EnforceSystemCapabilities
+		return
+	}
+
+	if safety.EnforceSystemCapabilities {
+		cfg.EnforceSysCaps = true
+	}
+}
+
+func applyV2Channels(cfg *obi.Config, channels schema.CaptureChannels, complete bool) {
+	if zeroValue(channels) && !complete {
+		return
+	}
+
+	if complete || completeChannels(channels) {
+		cfg.ChannelBufferLen = channels.BufferLen
+		cfg.ChannelSendTimeout = channels.SendTimeout.TimeDuration()
+		cfg.ChannelSendTimeoutPanic = channels.PanicOnSendTimeout
+		return
+	}
+
+	if channels.BufferLen != 0 {
+		cfg.ChannelBufferLen = channels.BufferLen
+	}
+	if !zeroValue(channels.SendTimeout) {
+		cfg.ChannelSendTimeout = channels.SendTimeout.TimeDuration()
+	}
+	if channels.PanicOnSendTimeout {
+		cfg.ChannelSendTimeoutPanic = true
+	}
+}
+
+func applyV2Engine(cfg *obi.Config, engine schema.CaptureEngine, complete bool) {
+	if zeroValue(engine) && !complete {
+		return
+	}
+
+	if complete || completeEngine(engine) {
+		applyFullV2Engine(cfg, engine)
+		return
+	}
+
+	applyPartialV2Engine(cfg, engine)
+}
+
+func applyFullV2Engine(cfg *obi.Config, engine schema.CaptureEngine) {
+	cfg.EBPF.BpfDebug = engine.Debug.BPF
+	cfg.EBPF.ProtocolDebug = engine.Debug.ProtocolPrint
+	cfg.Discovery.BPFPidFilterOff = engine.PIDFilter.Disabled
+	cfg.EBPF.WakeupLen = engine.Batching.WakeupLen
+	cfg.EBPF.BatchLength = engine.Batching.BatchLength
+	cfg.EBPF.BatchTimeout = engine.Batching.BatchTimeout.TimeDuration()
+	cfg.EBPF.ContextPropagation = engine.Propagation.ContextPropagation
+	cfg.EBPF.OverrideBPFLoopEnabled = engine.Propagation.OverrideBPFLoopEnabled
+	cfg.EBPF.DisableBlackBoxCP = engine.Propagation.DisableBlackBoxCP
+	cfg.EBPF.TCBackend = engine.Traffic.ControlBackend
+	cfg.EBPF.HighRequestVolume = engine.Traffic.HighRequestVolume
+	cfg.EBPF.ForceBPFMapReader = engine.Traffic.ForceMapReader
+	cfg.EBPF.MaxTransactionTime = engine.Transactions.MaxDuration.TimeDuration()
+	cfg.EBPF.MapsConfig.GlobalScaleFactor = engine.Maps.GlobalScaleFactor
+	cfg.EBPF.BPFFSPath = engine.BPFFileSystem.Path
+}
+
+func applyPartialV2Engine(cfg *obi.Config, engine schema.CaptureEngine) {
+	if engine.Debug.BPF {
+		cfg.EBPF.BpfDebug = true
+	}
+	if engine.Debug.ProtocolPrint {
+		cfg.EBPF.ProtocolDebug = true
+	}
+	if engine.PIDFilter.Disabled {
+		cfg.Discovery.BPFPidFilterOff = true
+	}
+	if engine.Batching.WakeupLen != 0 {
+		cfg.EBPF.WakeupLen = engine.Batching.WakeupLen
+	}
+	if engine.Batching.BatchLength != 0 {
+		cfg.EBPF.BatchLength = engine.Batching.BatchLength
+	}
+	if !zeroValue(engine.Batching.BatchTimeout) {
+		cfg.EBPF.BatchTimeout = engine.Batching.BatchTimeout.TimeDuration()
+	}
+	if !zeroValue(engine.Propagation.ContextPropagation) {
+		cfg.EBPF.ContextPropagation = engine.Propagation.ContextPropagation
+	}
+	if engine.Propagation.OverrideBPFLoopEnabled {
+		cfg.EBPF.OverrideBPFLoopEnabled = true
+	}
+	if engine.Propagation.DisableBlackBoxCP {
+		cfg.EBPF.DisableBlackBoxCP = true
+	}
+	if !zeroValue(engine.Traffic.ControlBackend) {
+		cfg.EBPF.TCBackend = engine.Traffic.ControlBackend
+	}
+	if engine.Traffic.HighRequestVolume {
+		cfg.EBPF.HighRequestVolume = true
+	}
+	if !zeroValue(engine.Traffic.ForceMapReader) {
+		cfg.EBPF.ForceBPFMapReader = engine.Traffic.ForceMapReader
+	}
+	if !zeroValue(engine.Transactions.MaxDuration) {
+		cfg.EBPF.MaxTransactionTime = engine.Transactions.MaxDuration.TimeDuration()
+	}
+	if engine.Maps.GlobalScaleFactor != 0 {
+		cfg.EBPF.MapsConfig.GlobalScaleFactor = engine.Maps.GlobalScaleFactor
+	}
+	if engine.BPFFileSystem.Path != "" {
+		cfg.EBPF.BPFFSPath = engine.BPFFileSystem.Path
+	}
+}
+
+func applyV2Instrumentation(cfg *obi.Config, instrumentation schema.Instrumentation) {
+	if zeroValue(instrumentation) {
+		return
+	}
+
+	complete := completeInstrumentation(instrumentation)
+	if !complete {
+		applyPartialV2Instrumentation(cfg, instrumentation)
+		applyProtocolEnablement(cfg, instrumentation, complete)
+		return
+	}
+
+	applyFullV2Instrumentation(cfg, instrumentation)
+	applyProtocolEnablement(cfg, instrumentation, complete)
+}
+
+func applyFullV2Instrumentation(cfg *obi.Config, instrumentation schema.Instrumentation) {
+	cfg.EBPF.TrackRequestHeaders = instrumentation.HTTP.TrackRequestHeaders
+	cfg.EBPF.HTTPRequestTimeout = instrumentation.HTTP.RequestTimeout.TimeDuration()
+	cfg.EBPF.BufferSizes.HTTP = instrumentation.HTTP.BufferSize
+
+	cfg.EBPF.HeuristicSQLDetect = instrumentation.SQL.HeuristicDetect
+	cfg.EBPF.BufferSizes.MySQL = instrumentation.SQL.MySQL.BufferSize
+	cfg.EBPF.MySQLPreparedStatementsCacheSize = instrumentation.SQL.MySQL.PreparedStatementsCacheSize
+	cfg.EBPF.BufferSizes.Postgres = instrumentation.SQL.Postgres.BufferSize
+	cfg.EBPF.PostgresPreparedStatementsCacheSize = instrumentation.SQL.Postgres.PreparedStatementsCacheSize
+	cfg.EBPF.BufferSizes.MSSQL = instrumentation.SQL.MSSQL.BufferSize
+	cfg.EBPF.MSSQLPreparedStatementsCacheSize = instrumentation.SQL.MSSQL.PreparedStatementsCacheSize
+
+	cfg.EBPF.RedisDBCache.Enabled = instrumentation.Redis.DBCache.Enabled
+	cfg.EBPF.RedisDBCache.MaxSize = instrumentation.Redis.DBCache.MaxSize
+
+	cfg.EBPF.BufferSizes.Kafka = instrumentation.Kafka.BufferSize
+	cfg.EBPF.KafkaTopicUUIDCacheSize = instrumentation.Kafka.TopicUUIDCacheSize
+
+	cfg.EBPF.MongoRequestsCacheSize = instrumentation.Mongo.RequestsCacheSize
+	cfg.EBPF.CouchbaseDBCacheSize = instrumentation.Couchbase.DBCacheSize
+	cfg.EBPF.DNSRequestTimeout = instrumentation.DNS.RequestTimeout.TimeDuration()
+	cfg.EBPF.InstrumentCuda = instrumentation.GPU.EnabledMode
+}
+
+func applyPartialV2Instrumentation(cfg *obi.Config, instrumentation schema.Instrumentation) {
+	if !zeroValue(instrumentation.HTTP) {
+		if instrumentation.HTTP.TrackRequestHeaders {
+			cfg.EBPF.TrackRequestHeaders = true
+		}
+		if !zeroValue(instrumentation.HTTP.RequestTimeout) {
+			cfg.EBPF.HTTPRequestTimeout = instrumentation.HTTP.RequestTimeout.TimeDuration()
+		}
+		if instrumentation.HTTP.BufferSize != 0 {
+			cfg.EBPF.BufferSizes.HTTP = instrumentation.HTTP.BufferSize
+		}
+	}
+
+	if !zeroValue(instrumentation.SQL) {
+		if instrumentation.SQL.HeuristicDetect {
+			cfg.EBPF.HeuristicSQLDetect = true
+		}
+		if instrumentation.SQL.MySQL.BufferSize != 0 {
+			cfg.EBPF.BufferSizes.MySQL = instrumentation.SQL.MySQL.BufferSize
+		}
+		if instrumentation.SQL.MySQL.PreparedStatementsCacheSize != 0 {
+			cfg.EBPF.MySQLPreparedStatementsCacheSize = instrumentation.SQL.MySQL.PreparedStatementsCacheSize
+		}
+		if instrumentation.SQL.Postgres.BufferSize != 0 {
+			cfg.EBPF.BufferSizes.Postgres = instrumentation.SQL.Postgres.BufferSize
+		}
+		if instrumentation.SQL.Postgres.PreparedStatementsCacheSize != 0 {
+			cfg.EBPF.PostgresPreparedStatementsCacheSize = instrumentation.SQL.Postgres.PreparedStatementsCacheSize
+		}
+		if instrumentation.SQL.MSSQL.BufferSize != 0 {
+			cfg.EBPF.BufferSizes.MSSQL = instrumentation.SQL.MSSQL.BufferSize
+		}
+		if instrumentation.SQL.MSSQL.PreparedStatementsCacheSize != 0 {
+			cfg.EBPF.MSSQLPreparedStatementsCacheSize = instrumentation.SQL.MSSQL.PreparedStatementsCacheSize
+		}
+	}
+
+	if !zeroValue(instrumentation.Redis.DBCache) {
+		if instrumentation.Redis.DBCache.Enabled {
+			cfg.EBPF.RedisDBCache.Enabled = true
+		}
+		if instrumentation.Redis.DBCache.MaxSize != 0 {
+			cfg.EBPF.RedisDBCache.MaxSize = instrumentation.Redis.DBCache.MaxSize
+		}
+	}
+
+	if instrumentation.Kafka.BufferSize != 0 {
+		cfg.EBPF.BufferSizes.Kafka = instrumentation.Kafka.BufferSize
+	}
+	if instrumentation.Kafka.TopicUUIDCacheSize != 0 {
+		cfg.EBPF.KafkaTopicUUIDCacheSize = instrumentation.Kafka.TopicUUIDCacheSize
+	}
+	if instrumentation.Mongo.RequestsCacheSize != 0 {
+		cfg.EBPF.MongoRequestsCacheSize = instrumentation.Mongo.RequestsCacheSize
+	}
+	if instrumentation.Couchbase.DBCacheSize != 0 {
+		cfg.EBPF.CouchbaseDBCacheSize = instrumentation.Couchbase.DBCacheSize
+	}
+	if !zeroValue(instrumentation.DNS.RequestTimeout) {
+		cfg.EBPF.DNSRequestTimeout = instrumentation.DNS.RequestTimeout.TimeDuration()
+	}
+	if !zeroValue(instrumentation.GPU.EnabledMode) {
+		cfg.EBPF.InstrumentCuda = instrumentation.GPU.EnabledMode
+	}
+}
+
+func applyProtocolEnablement(cfg *obi.Config, instrumentation schema.Instrumentation, complete bool) {
+	cfg.Traces.Instrumentations = applySignalEnablement(cfg.Traces.Instrumentations, instrumentation, "traces", complete)
+	cfg.OTELMetrics.Instrumentations = applySignalEnablement(cfg.OTELMetrics.Instrumentations, instrumentation, "metrics", complete)
+	cfg.Prometheus.Instrumentations = applySignalEnablement(cfg.Prometheus.Instrumentations, instrumentation, "metrics", complete)
+}
+
+func applySignalEnablement(
+	current []instrumentations.Instrumentation,
+	instrumentation schema.Instrumentation,
+	signal string,
+	complete bool,
+) []instrumentations.Instrumentation {
+	selected := map[instrumentations.Instrumentation]bool{}
+	hadWildcard := false
+	for _, instr := range current {
+		if instr == instrumentations.InstrumentationALL {
+			hadWildcard = true
+			for _, candidate := range runtimeInstrumentations {
+				selected[candidate] = true
+			}
+			continue
+		}
+		selected[instr] = true
+	}
+
+	for _, mapping := range protocolMappings {
+		enablement := protocolEnablement(instrumentation, mapping.name)
+		enabled := signalEnabled(enablement, signal)
+		if !complete && !enabled {
+			continue
+		}
+		selected[mapping.instr] = enabled
+	}
+
+	allEnabled := true
+	for _, candidate := range runtimeInstrumentations {
+		if !selected[candidate] {
+			allEnabled = false
+			break
+		}
+	}
+	if hadWildcard && allEnabled {
+		return []instrumentations.Instrumentation{instrumentations.InstrumentationALL}
+	}
+
+	out := make([]instrumentations.Instrumentation, 0, len(runtimeInstrumentations))
+	for _, candidate := range runtimeInstrumentations {
+		if selected[candidate] {
+			out = append(out, candidate)
+		}
+	}
+	return out
+}
+
+func applyV2NetworkCapture(cfg *obi.Config, networkCfg schema.CaptureNetwork, complete bool) {
+	capture := networkCfg.Capture
+	if zeroValue(capture) && !complete {
+		return
+	}
+
+	if complete || completeNetworkCapture(capture) {
+		applyFullV2NetworkCapture(cfg, capture)
+		return
+	}
+
+	applyPartialV2NetworkCapture(cfg, capture)
+}
+
+func applyFullV2NetworkCapture(cfg *obi.Config, capture schema.NetworkCapture) {
+	cfg.NetworkFlows.Enable = capture.Enabled
+	cfg.NetworkFlows.Source = string(capture.Source)
+	cfg.EBPF.BufferSizes.TCP = capture.BufferSize
+	cfg.NetworkFlows.AgentIP = capture.EndpointIdentity.AgentIP
+	cfg.NetworkFlows.AgentIPIface = obi.AgentTypeIface(capture.EndpointIdentity.AgentIPInterface)
+	cfg.NetworkFlows.AgentIPType = string(capture.EndpointIdentity.AgentIPFamily)
+	cfg.NetworkFlows.Interfaces = cloneStrings(capture.Selection.Interfaces.Include)
+	cfg.NetworkFlows.ExcludeInterfaces = cloneStrings(capture.Selection.Interfaces.Exclude)
+	cfg.NetworkFlows.Protocols = cloneStrings(capture.Selection.Protocols.Include)
+	cfg.NetworkFlows.ExcludeProtocols = cloneStrings(capture.Selection.Protocols.Exclude)
+	cfg.NetworkFlows.Direction = string(capture.Selection.Direction)
+	cfg.NetworkFlows.CacheMaxFlows = capture.FlowLifecycle.MaxTrackedFlows
+	cfg.NetworkFlows.CacheActiveTimeout = capture.FlowLifecycle.ActiveTimeout.TimeDuration()
+	cfg.NetworkFlows.Deduper = string(capture.FlowLifecycle.Deduplication.Strategy)
+	cfg.NetworkFlows.DeduperFCTTL = capture.FlowLifecycle.Deduplication.FirstComeTTL.TimeDuration()
+	cfg.NetworkFlows.Sampling = capture.FlowLifecycle.Sampling
+	cfg.NetworkFlows.GuessPorts = capture.FlowLifecycle.GuessPorts
+	cfg.NetworkFlows.ListenInterfaces = string(capture.InterfaceDiscovery.Mode)
+	cfg.NetworkFlows.ListenPollPeriod = capture.InterfaceDiscovery.PollInterval.TimeDuration()
+	cfg.NetworkFlows.Print = capture.Diagnostics.PrintFlows
+}
+
+func applyPartialV2NetworkCapture(cfg *obi.Config, capture schema.NetworkCapture) {
+	if capture.Enabled {
+		cfg.NetworkFlows.Enable = true
+	}
+	if !zeroValue(capture.Source) {
+		cfg.NetworkFlows.Source = string(capture.Source)
+	}
+	if capture.BufferSize != 0 {
+		cfg.EBPF.BufferSizes.TCP = capture.BufferSize
+	}
+	if capture.EndpointIdentity.AgentIP != "" {
+		cfg.NetworkFlows.AgentIP = capture.EndpointIdentity.AgentIP
+	}
+	if capture.EndpointIdentity.AgentIPInterface != "" {
+		cfg.NetworkFlows.AgentIPIface = obi.AgentTypeIface(capture.EndpointIdentity.AgentIPInterface)
+	}
+	if capture.EndpointIdentity.AgentIPFamily != "" {
+		cfg.NetworkFlows.AgentIPType = string(capture.EndpointIdentity.AgentIPFamily)
+	}
+	if capture.Selection.Interfaces.Include != nil {
+		cfg.NetworkFlows.Interfaces = cloneStrings(capture.Selection.Interfaces.Include)
+	}
+	if capture.Selection.Interfaces.Exclude != nil {
+		cfg.NetworkFlows.ExcludeInterfaces = cloneStrings(capture.Selection.Interfaces.Exclude)
+	}
+	if capture.Selection.Protocols.Include != nil {
+		cfg.NetworkFlows.Protocols = cloneStrings(capture.Selection.Protocols.Include)
+	}
+	if capture.Selection.Protocols.Exclude != nil {
+		cfg.NetworkFlows.ExcludeProtocols = cloneStrings(capture.Selection.Protocols.Exclude)
+	}
+	if capture.Selection.Direction != "" {
+		cfg.NetworkFlows.Direction = string(capture.Selection.Direction)
+	}
+	if capture.FlowLifecycle.MaxTrackedFlows != 0 {
+		cfg.NetworkFlows.CacheMaxFlows = capture.FlowLifecycle.MaxTrackedFlows
+	}
+	if !zeroValue(capture.FlowLifecycle.ActiveTimeout) {
+		cfg.NetworkFlows.CacheActiveTimeout = capture.FlowLifecycle.ActiveTimeout.TimeDuration()
+	}
+	if capture.FlowLifecycle.Deduplication.Strategy != "" {
+		cfg.NetworkFlows.Deduper = string(capture.FlowLifecycle.Deduplication.Strategy)
+	}
+	if !zeroValue(capture.FlowLifecycle.Deduplication.FirstComeTTL) {
+		cfg.NetworkFlows.DeduperFCTTL = capture.FlowLifecycle.Deduplication.FirstComeTTL.TimeDuration()
+	}
+	if capture.FlowLifecycle.Sampling != 0 {
+		cfg.NetworkFlows.Sampling = capture.FlowLifecycle.Sampling
+	}
+	if capture.FlowLifecycle.GuessPorts != "" {
+		cfg.NetworkFlows.GuessPorts = capture.FlowLifecycle.GuessPorts
+	}
+	if capture.InterfaceDiscovery.Mode != "" {
+		cfg.NetworkFlows.ListenInterfaces = string(capture.InterfaceDiscovery.Mode)
+	}
+	if !zeroValue(capture.InterfaceDiscovery.PollInterval) {
+		cfg.NetworkFlows.ListenPollPeriod = capture.InterfaceDiscovery.PollInterval.TimeDuration()
+	}
+	if capture.Diagnostics.PrintFlows {
+		cfg.NetworkFlows.Print = true
+	}
+}
+
+func applyV2Runtimes(cfg *obi.Config, runtimes schema.CaptureRuntimes, complete bool) {
+	if zeroValue(runtimes) && !complete {
+		return
+	}
+
+	if complete || completeRuntimes(runtimes) {
+		applyFullV2Runtimes(cfg, runtimes)
+		return
+	}
+
+	applyPartialV2Runtimes(cfg, runtimes)
+}
+
+func applyFullV2Runtimes(cfg *obi.Config, runtimes schema.CaptureRuntimes) {
+	cfg.Discovery.SkipGoSpecificTracers = !runtimes.Go.Enabled
+	cfg.NodeJS.Enabled = runtimes.NodeJS.Enabled
+	cfg.Java.Enabled = runtimes.Java.Enabled
+	cfg.Java.Debug = runtimes.Java.Debug.Enabled
+	cfg.Java.DebugInstrumentation = runtimes.Java.Debug.BytecodeInstrumentation
+	cfg.Java.Timeout = runtimes.Java.AttachTimeout.TimeDuration()
+}
+
+func applyPartialV2Runtimes(cfg *obi.Config, runtimes schema.CaptureRuntimes) {
+	if runtimes.Go.Enabled {
+		cfg.Discovery.SkipGoSpecificTracers = false
+	}
+	if runtimes.NodeJS.Enabled {
+		cfg.NodeJS.Enabled = true
+	}
+	if runtimes.Java.Enabled {
+		cfg.Java.Enabled = true
+	}
+	if runtimes.Java.Debug.Enabled {
+		cfg.Java.Debug = true
+	}
+	if runtimes.Java.Debug.BytecodeInstrumentation {
+		cfg.Java.DebugInstrumentation = true
+	}
+	if !zeroValue(runtimes.Java.AttachTimeout) {
+		cfg.Java.Timeout = runtimes.Java.AttachTimeout.TimeDuration()
+	}
+}
+
+func applyV2CaptureTelemetry(cfg *obi.Config, telemetry schema.CaptureTelemetry, complete bool) {
+	if zeroValue(telemetry) && !complete {
+		return
+	}
+
+	if complete || completeCaptureTelemetry(telemetry) {
+		applyFullV2CaptureTelemetry(cfg, telemetry)
+		return
+	}
+
+	applyPartialV2CaptureTelemetry(cfg, telemetry)
+}
+
+func applyFullV2CaptureTelemetry(cfg *obi.Config, telemetry schema.CaptureTelemetry) {
+	cfg.Traces.ReportersCacheLen = telemetry.Traces.ReportersCacheLen
+	cfg.OTELMetrics.ReportersCacheLen = telemetry.Metrics.ReportersCacheLen
+	cfg.OTELMetrics.TTL = telemetry.Metrics.TTL.TimeDuration()
+}
+
+func applyPartialV2CaptureTelemetry(cfg *obi.Config, telemetry schema.CaptureTelemetry) {
+	if telemetry.Traces.ReportersCacheLen != 0 {
+		cfg.Traces.ReportersCacheLen = telemetry.Traces.ReportersCacheLen
+	}
+	if telemetry.Metrics.ReportersCacheLen != 0 {
+		cfg.OTELMetrics.ReportersCacheLen = telemetry.Metrics.ReportersCacheLen
+	}
+	if !zeroValue(telemetry.Metrics.TTL) {
+		cfg.OTELMetrics.TTL = telemetry.Metrics.TTL.TimeDuration()
+	}
+}
+
+func applyV2Standalone(cfg *obi.Config, src *schema.Extension) {
+	applyV2EnrichServiceName(cfg, src.Enrich)
+	applyV2Correlation(cfg, src.Correlation)
+	applyV2Daemon(cfg, src.Daemon)
+}
+
+func applyV2EnrichServiceName(cfg *obi.Config, enrich *schema.Enrich) {
+	if enrich == nil || zeroValue(enrich.ServiceName) {
+		return
+	}
+
+	serviceName := enrich.ServiceName
+	if cfg.NameResolver == nil {
+		cfg.NameResolver = &transform.NameResolverConfig{}
+	}
+
+	cfg.NameResolver.Sources = cloneSources(serviceName.Sources)
+	cfg.NameResolver.CacheLen = serviceName.Cache.Size
+	cfg.NameResolver.CacheTTL = serviceName.Cache.TTL.TimeDuration()
+	cfg.Attributes.RenameUnresolvedHosts = serviceName.UnresolvedHosts.Names.Default
+	cfg.Attributes.RenameUnresolvedHostsOutgoing = serviceName.UnresolvedHosts.Names.Outgoing
+	cfg.Attributes.RenameUnresolvedHostsIncoming = serviceName.UnresolvedHosts.Names.Incoming
+}
+
+func applyV2Correlation(cfg *obi.Config, correlation *schema.Correlation) {
+	if correlation == nil || zeroValue(correlation.LogTraceAnnotation) {
+		return
+	}
+
+	if !completeLogTraceAnnotation(correlation.LogTraceAnnotation) {
+		applyPartialV2Correlation(cfg, correlation.LogTraceAnnotation)
+		return
+	}
+
+	applyFullV2Correlation(cfg, correlation.LogTraceAnnotation)
+}
+
+func applyFullV2Correlation(cfg *obi.Config, logTrace schema.LogTraceAnnotation) {
+	if logTrace.Enabled {
+		cfg.EBPF.LogEnricher.Services = []obiconfig.LogEnricherServiceConfig{
+			{Service: services.GlobDefinitionCriteria{{Path: services.NewGlob("*")}}},
+		}
+	} else {
+		cfg.EBPF.LogEnricher.Services = nil
+	}
+	cfg.EBPF.LogEnricher.CacheTTL = logTrace.Cache.TTL.TimeDuration()
+	cfg.EBPF.LogEnricher.CacheSize = logTrace.Cache.Size
+	cfg.EBPF.LogEnricher.AsyncWriterWorkers = logTrace.AsyncWriter.Workers
+	cfg.EBPF.LogEnricher.AsyncWriterChannelLen = logTrace.AsyncWriter.ChannelLen
+}
+
+func applyPartialV2Correlation(cfg *obi.Config, logTrace schema.LogTraceAnnotation) {
+	if logTrace.Enabled {
+		cfg.EBPF.LogEnricher.Services = []obiconfig.LogEnricherServiceConfig{
+			{Service: services.GlobDefinitionCriteria{{Path: services.NewGlob("*")}}},
+		}
+	}
+	if !zeroValue(logTrace.Cache.TTL) {
+		cfg.EBPF.LogEnricher.CacheTTL = logTrace.Cache.TTL.TimeDuration()
+	}
+	if logTrace.Cache.Size != 0 {
+		cfg.EBPF.LogEnricher.CacheSize = logTrace.Cache.Size
+	}
+	if logTrace.AsyncWriter.Workers != 0 {
+		cfg.EBPF.LogEnricher.AsyncWriterWorkers = logTrace.AsyncWriter.Workers
+	}
+	if logTrace.AsyncWriter.ChannelLen != 0 {
+		cfg.EBPF.LogEnricher.AsyncWriterChannelLen = logTrace.AsyncWriter.ChannelLen
+	}
+}
+
+func completeLogTraceAnnotation(logTrace schema.LogTraceAnnotation) bool {
+	return !zeroValue(logTrace.Cache) && !zeroValue(logTrace.AsyncWriter)
+}
+
+func applyV2Daemon(cfg *obi.Config, daemon *schema.Daemon) {
+	if daemon == nil || zeroValue(*daemon) {
+		return
+	}
+
+	if !completeDaemon(*daemon) {
+		applyPartialV2Daemon(cfg, *daemon)
+		return
+	}
+
+	applyFullV2Daemon(cfg, *daemon)
+}
+
+func applyFullV2Daemon(cfg *obi.Config, daemon schema.Daemon) {
+	if !zeroValue(daemon.Logging) {
+		cfg.LogLevel = obi.LogLevel(daemon.Logging.Level)
+		cfg.LogConfig = obi.LogConfigOption(daemon.Logging.Format)
+		cfg.TracePrinter = daemon.Logging.DebugTraceOutput
+	}
+	if cfg.TracePrinter == "" {
+		cfg.TracePrinter = debug.TracePrinterDisabled
+	}
+
+	cfg.ProfilePort = daemon.Profiling.Port
+	cfg.ShutdownTimeout = daemon.Shutdown.Timeout.TimeDuration()
+	cfg.InternalMetrics.Exporter = daemon.InternalMetrics.Exporter
+	cfg.InternalMetrics.Prometheus.Port = daemon.InternalMetrics.Prometheus.Port
+	cfg.InternalMetrics.Prometheus.Path = daemon.InternalMetrics.Prometheus.Path
+	cfg.InternalMetrics.BpfMetricScrapeInterval = daemon.InternalMetrics.BPF.ScrapeInterval.TimeDuration()
+
+	prometheus := daemon.Telemetry.Metrics.Prometheus
+	cfg.Prometheus.AllowServiceGraphSelfReferences = prometheus.AllowServiceGraphSelfReferences
+	cfg.Prometheus.SpanMetricsServiceCacheSize = prometheus.SpanMetricsServiceCacheSize
+	cfg.Prometheus.ExtraResourceLabels = cloneStrings(prometheus.ExtraResourceAttributes)
+	cfg.Prometheus.ExtraSpanResourceLabels = cloneStrings(prometheus.ExtraSpanResourceAttributes)
+}
+
+func applyPartialV2Daemon(cfg *obi.Config, daemon schema.Daemon) {
+	if !zeroValue(daemon.Logging) {
+		if daemon.Logging.Level != "" {
+			cfg.LogLevel = obi.LogLevel(daemon.Logging.Level)
+		}
+		if daemon.Logging.Format != "" {
+			cfg.LogConfig = obi.LogConfigOption(daemon.Logging.Format)
+		}
+		if daemon.Logging.DebugTraceOutput != "" {
+			cfg.TracePrinter = daemon.Logging.DebugTraceOutput
+		}
+	}
+	if daemon.Profiling.Port != 0 {
+		cfg.ProfilePort = daemon.Profiling.Port
+	}
+	if !zeroValue(daemon.Shutdown.Timeout) {
+		cfg.ShutdownTimeout = daemon.Shutdown.Timeout.TimeDuration()
+	}
+	if !zeroValue(daemon.InternalMetrics) {
+		if daemon.InternalMetrics.Exporter != "" {
+			cfg.InternalMetrics.Exporter = daemon.InternalMetrics.Exporter
+		}
+		if daemon.InternalMetrics.Prometheus.Port != 0 {
+			cfg.InternalMetrics.Prometheus.Port = daemon.InternalMetrics.Prometheus.Port
+		}
+		if daemon.InternalMetrics.Prometheus.Path != "" {
+			cfg.InternalMetrics.Prometheus.Path = daemon.InternalMetrics.Prometheus.Path
+		}
+		if !zeroValue(daemon.InternalMetrics.BPF.ScrapeInterval) {
+			cfg.InternalMetrics.BpfMetricScrapeInterval = daemon.InternalMetrics.BPF.ScrapeInterval.TimeDuration()
+		}
+	}
+
+	prometheus := daemon.Telemetry.Metrics.Prometheus
+	if prometheus.AllowServiceGraphSelfReferences {
+		cfg.Prometheus.AllowServiceGraphSelfReferences = true
+	}
+	if prometheus.SpanMetricsServiceCacheSize != 0 {
+		cfg.Prometheus.SpanMetricsServiceCacheSize = prometheus.SpanMetricsServiceCacheSize
+	}
+	if prometheus.ExtraResourceAttributes != nil {
+		cfg.Prometheus.ExtraResourceLabels = cloneStrings(prometheus.ExtraResourceAttributes)
+	}
+	if prometheus.ExtraSpanResourceAttributes != nil {
+		cfg.Prometheus.ExtraSpanResourceLabels = cloneStrings(prometheus.ExtraSpanResourceAttributes)
+	}
+}
+
+func completeDaemon(daemon schema.Daemon) bool {
+	return !zeroValue(daemon.Logging) &&
+		!zeroValue(daemon.Shutdown) &&
+		!zeroValue(daemon.InternalMetrics) &&
+		!zeroValue(daemon.Telemetry)
+}
+
+func applyV2MetricsEnablement(cfg *obi.Config, src *schema.Extension) {
+	appMetricsEnabled, appConfigured := appMetricsEnablement(
+		src.Capture.Instrumentation,
+		completeInstrumentation(src.Capture.Instrumentation),
+	)
+	networkConfigured := !zeroValue(src.Capture.Network.Capture)
+	networkMetricsEnabled := src.Capture.Network.Capture.Enabled
+	if appConfigured {
+		cfg.Metrics.Features &^= v2AppMetricsFeatureMask
+		if appMetricsEnabled {
+			cfg.Metrics.Features |= export.FeatureApplicationRED
+		}
+	}
+	if networkConfigured {
+		cfg.Metrics.Features &^= v2NetworkMetricsFeatureMask
+		if networkMetricsEnabled {
+			cfg.Metrics.Features |= export.FeatureNetwork
+		}
+	}
+}
+
+func appMetricsEnablement(instrumentation schema.Instrumentation, complete bool) (bool, bool) {
+	if zeroValue(instrumentation) {
+		return false, false
+	}
+
+	configured := complete
+	enabled := false
+	for _, mapping := range protocolMappings {
+		enablement := protocolEnablement(instrumentation, mapping.name)
+		metricsEnabled := signalEnabled(enablement, "metrics")
+		if !complete && !metricsEnabled {
+			continue
+		}
+		configured = true
+		if metricsEnabled && mapping.appMetrics {
+			enabled = true
+		}
+	}
+	return enabled, configured
+}
+
+func completeInstrumentation(instrumentation schema.Instrumentation) bool {
+	return !zeroValue(instrumentation.HTTP) &&
+		!zeroValue(instrumentation.GRPC) &&
+		!zeroValue(instrumentation.SQL) &&
+		!zeroValue(instrumentation.Redis) &&
+		!zeroValue(instrumentation.Kafka) &&
+		!zeroValue(instrumentation.Mongo) &&
+		!zeroValue(instrumentation.Couchbase) &&
+		!zeroValue(instrumentation.DNS) &&
+		!zeroValue(instrumentation.GPU)
+}
+
+func completePolicy(policy schema.CapturePolicy) bool {
+	return !zeroValue(policy.PollInterval) &&
+		!zeroValue(policy.MinProcessAge)
+}
+
+func completeLimits(limits schema.CaptureLimits) bool {
+	return limits.MetricSpanNames != 0 &&
+		limits.NetworkPackets != 0
+}
+
+func completeChannels(channels schema.CaptureChannels) bool {
+	return channels.BufferLen != 0 &&
+		!zeroValue(channels.SendTimeout)
+}
+
+func completeEngine(engine schema.CaptureEngine) bool {
+	return !zeroValue(engine.Batching) &&
+		!zeroValue(engine.Traffic.ControlBackend) &&
+		!zeroValue(engine.Transactions.MaxDuration) &&
+		engine.BPFFileSystem.Path != ""
+}
+
+func completeNetworkCapture(capture schema.NetworkCapture) bool {
+	return !zeroValue(capture.Source) &&
+		!zeroValue(capture.EndpointIdentity) &&
+		!zeroValue(capture.Selection) &&
+		!zeroValue(capture.FlowLifecycle) &&
+		!zeroValue(capture.InterfaceDiscovery)
+}
+
+func completeRuntimes(runtimes schema.CaptureRuntimes) bool {
+	return !zeroValue(runtimes.Java.AttachTimeout) &&
+		(runtimes.Go.Enabled ||
+			runtimes.NodeJS.Enabled ||
+			runtimes.Java.Enabled ||
+			!zeroValue(runtimes.Java.Debug))
+}
+
+func completeCaptureTelemetry(telemetry schema.CaptureTelemetry) bool {
+	return !zeroValue(telemetry.Traces) &&
+		!zeroValue(telemetry.Metrics)
+}
+
+func protocolEnablement(instrumentation schema.Instrumentation, name protocolName) schema.ProtocolEnablement {
+	switch name {
+	case protocolHTTP:
+		return instrumentation.HTTP.Enabled
+	case protocolGRPC:
+		return instrumentation.GRPC.Enabled
+	case protocolSQL:
+		return instrumentation.SQL.Enabled
+	case protocolRedis:
+		return instrumentation.Redis.Enabled
+	case protocolKafka:
+		return instrumentation.Kafka.Enabled
+	case protocolMongo:
+		return instrumentation.Mongo.Enabled
+	case protocolCouchbase:
+		return instrumentation.Couchbase.Enabled
+	case protocolDNS:
+		return instrumentation.DNS.Enabled
+	case protocolGPU:
+		return instrumentation.GPU.Enabled
+	default:
+		return schema.ProtocolEnablement{}
+	}
+}
+
+func signalEnabled(enablement schema.ProtocolEnablement, signal string) bool {
+	switch signal {
+	case "traces":
+		return enablement.Traces
+	case "metrics":
+		return enablement.Metrics
+	default:
+		return false
+	}
+}
+
+func zeroValue(value any) bool {
+	if value == nil {
+		return true
+	}
+	return reflect.ValueOf(value).IsZero()
+}
+
+func cloneStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	return append([]string(nil), values...)
+}
+
+func cloneSources(values []transform.Source) []transform.Source {
+	if values == nil {
+		return nil
+	}
+	return append([]transform.Source(nil), values...)
+}

--- a/internal/config/convert/import_test.go
+++ b/internal/config/convert/import_test.go
@@ -1,0 +1,418 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/appolly/services"
+	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/debug"
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/obi"
+	"go.opentelemetry.io/obi/pkg/transform"
+)
+
+func TestV2ToRuntimeDefaultExportFoundation(t *testing.T) {
+	t.Parallel()
+
+	_, ext := RuntimeToV2(nil)
+
+	got, err := V2ToRuntime(ext)
+	require.NoError(t, err)
+
+	require.Equal(t, obi.DefaultConfig.ChannelBufferLen, got.ChannelBufferLen)
+	require.Equal(t, obi.DefaultConfig.ChannelSendTimeout, got.ChannelSendTimeout)
+	require.Equal(t, obi.DefaultConfig.EnforceSysCaps, got.EnforceSysCaps)
+	require.Equal(t, obi.DefaultConfig.EBPF.WakeupLen, got.EBPF.WakeupLen)
+	require.Equal(t, obi.DefaultConfig.EBPF.BatchLength, got.EBPF.BatchLength)
+	require.Equal(t, obi.DefaultConfig.EBPF.BatchTimeout, got.EBPF.BatchTimeout)
+	require.Equal(t, obi.DefaultConfig.EBPF.ContextPropagation, got.EBPF.ContextPropagation)
+	require.Equal(t, obi.DefaultConfig.EBPF.TCBackend, got.EBPF.TCBackend)
+	require.Equal(t, obi.DefaultConfig.EBPF.ForceBPFMapReader, got.EBPF.ForceBPFMapReader)
+	require.Equal(t, obi.DefaultConfig.EBPF.MapsConfig, got.EBPF.MapsConfig)
+	require.Equal(t, obi.DefaultConfig.EBPF.InstrumentCuda, got.EBPF.InstrumentCuda)
+	require.Equal(t, obi.DefaultConfig.NetworkFlows.Source, got.NetworkFlows.Source)
+	require.Equal(t, obi.DefaultConfig.NetworkFlows.ExcludeInterfaces, got.NetworkFlows.ExcludeInterfaces)
+	require.Equal(t, obi.DefaultConfig.NodeJS.Enabled, got.NodeJS.Enabled)
+	require.Equal(t, obi.DefaultConfig.Java.Enabled, got.Java.Enabled)
+	require.Equal(t, obi.DefaultConfig.LogLevel, got.LogLevel)
+	require.Equal(t, obi.DefaultConfig.InternalMetrics, got.InternalMetrics)
+	require.Equal(t, export.FeatureApplicationRED, got.Metrics.Features)
+	require.Contains(t, got.Traces.Instrumentations, instrumentations.InstrumentationHTTP)
+	require.Contains(t, got.Traces.Instrumentations, instrumentations.InstrumentationSunRPC)
+	require.NotContains(t, got.Traces.Instrumentations, instrumentations.InstrumentationDNS)
+	require.Contains(t, got.OTELMetrics.Instrumentations, instrumentations.InstrumentationHTTP)
+	require.NotContains(t, got.OTELMetrics.Instrumentations, instrumentations.InstrumentationDNS)
+}
+
+func TestV2ToRuntimeCustomFoundation(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultRuntimeConfig()
+	cfg.ChannelBufferLen = 77
+	cfg.ChannelSendTimeout = 2 * time.Second
+	cfg.ChannelSendTimeoutPanic = true
+	cfg.EnforceSysCaps = true
+
+	cfg.Discovery.PollInterval = 5 * time.Second
+	cfg.Discovery.MinProcessAge = 6 * time.Second
+	cfg.Discovery.BPFPidFilterOff = true
+	cfg.Discovery.SkipGoSpecificTracers = true
+	cfg.NodeJS.Enabled = false
+	cfg.Java.Enabled = false
+	cfg.Java.Debug = true
+	cfg.Java.DebugInstrumentation = true
+	cfg.Java.Timeout = 7 * time.Second
+
+	cfg.EBPF.BpfDebug = true
+	cfg.EBPF.ProtocolDebug = true
+	cfg.EBPF.WakeupLen = 8
+	cfg.EBPF.BatchLength = 9
+	cfg.EBPF.BatchTimeout = 10 * time.Second
+	cfg.EBPF.ContextPropagation = config.ContextPropagationAll
+	cfg.EBPF.OverrideBPFLoopEnabled = true
+	cfg.EBPF.DisableBlackBoxCP = true
+	cfg.EBPF.TCBackend = config.TCBackendTCX
+	cfg.EBPF.HighRequestVolume = true
+	cfg.EBPF.ForceBPFMapReader = config.MapReaderLegacy
+	cfg.EBPF.MapsConfig.GlobalScaleFactor = 2
+	cfg.EBPF.BPFFSPath = "/tmp/bpf"
+	cfg.EBPF.MaxTransactionTime = 11 * time.Second
+	cfg.EBPF.TrackRequestHeaders = true
+	cfg.EBPF.HTTPRequestTimeout = 12 * time.Second
+	cfg.EBPF.BufferSizes.HTTP = 100
+	cfg.EBPF.BufferSizes.MySQL = 101
+	cfg.EBPF.BufferSizes.Postgres = 102
+	cfg.EBPF.BufferSizes.MSSQL = 103
+	cfg.EBPF.BufferSizes.Kafka = 104
+	cfg.EBPF.BufferSizes.TCP = 105
+	cfg.EBPF.HeuristicSQLDetect = true
+	cfg.EBPF.MySQLPreparedStatementsCacheSize = 200
+	cfg.EBPF.PostgresPreparedStatementsCacheSize = 201
+	cfg.EBPF.MSSQLPreparedStatementsCacheSize = 202
+	cfg.EBPF.RedisDBCache.Enabled = true
+	cfg.EBPF.RedisDBCache.MaxSize = 203
+	cfg.EBPF.KafkaTopicUUIDCacheSize = 204
+	cfg.EBPF.MongoRequestsCacheSize = 205
+	cfg.EBPF.CouchbaseDBCacheSize = 206
+	cfg.EBPF.DNSRequestTimeout = 13 * time.Second
+	cfg.EBPF.InstrumentCuda = config.CudaModeOn
+
+	cfg.Traces.ReportersCacheLen = 301
+	cfg.Traces.Instrumentations = []instrumentations.Instrumentation{
+		instrumentations.InstrumentationHTTP,
+		instrumentations.InstrumentationKafka,
+	}
+	cfg.OTELMetrics.ReportersCacheLen = 302
+	cfg.OTELMetrics.TTL = 303 * time.Second
+	cfg.OTELMetrics.Instrumentations = []instrumentations.Instrumentation{
+		instrumentations.InstrumentationHTTP,
+	}
+	cfg.Prometheus.Instrumentations = []instrumentations.Instrumentation{
+		instrumentations.InstrumentationRedis,
+		instrumentations.InstrumentationDNS,
+	}
+	cfg.Metrics.Features = export.FeatureApplicationRED | export.FeatureNetwork
+
+	cfg.NetworkFlows.Enable = true
+	cfg.NetworkFlows.Source = obi.EbpfSourceTC
+	cfg.NetworkFlows.AgentIP = "192.0.2.1"
+	cfg.NetworkFlows.AgentIPIface = obi.NetworkAgentIPIfaceLocal
+	cfg.NetworkFlows.AgentIPType = "ipv4"
+	cfg.NetworkFlows.Interfaces = []string{"eth0"}
+	cfg.NetworkFlows.ExcludeInterfaces = []string{"lo", "docker0"}
+	cfg.NetworkFlows.Protocols = []string{"tcp"}
+	cfg.NetworkFlows.ExcludeProtocols = []string{"udp"}
+	cfg.NetworkFlows.CacheMaxFlows = 300
+	cfg.NetworkFlows.CacheActiveTimeout = 14 * time.Second
+	cfg.NetworkFlows.Deduper = "none"
+	cfg.NetworkFlows.DeduperFCTTL = 15 * time.Second
+	cfg.NetworkFlows.Direction = "egress"
+	cfg.NetworkFlows.Sampling = 16
+	cfg.NetworkFlows.ListenInterfaces = obi.NetworkListenInterfacesPoll
+	cfg.NetworkFlows.ListenPollPeriod = 17 * time.Second
+	cfg.NetworkFlows.Print = true
+	cfg.Attributes.MetricSpanNameAggregationLimit = 400
+
+	cfg.NameResolver.Sources = []transform.Source{transform.SourceDNS, transform.SourceK8s}
+	cfg.NameResolver.CacheLen = 501
+	cfg.NameResolver.CacheTTL = 502 * time.Second
+	cfg.Attributes.RenameUnresolvedHosts = "unknown"
+	cfg.Attributes.RenameUnresolvedHostsOutgoing = "unknown-out"
+	cfg.Attributes.RenameUnresolvedHostsIncoming = "unknown-in"
+
+	cfg.EBPF.LogEnricher.Services = []config.LogEnricherServiceConfig{
+		{Service: services.GlobDefinitionCriteria{{Path: services.NewGlob("*")}}},
+	}
+	cfg.EBPF.LogEnricher.CacheTTL = 601 * time.Second
+	cfg.EBPF.LogEnricher.CacheSize = 602
+	cfg.EBPF.LogEnricher.AsyncWriterWorkers = 603
+	cfg.EBPF.LogEnricher.AsyncWriterChannelLen = 604
+
+	cfg.LogLevel = obi.LogLevelDebug
+	cfg.LogConfig = obi.LogConfigOptionJSON
+	cfg.TracePrinter = debug.TracePrinterJSON
+	cfg.ProfilePort = 6060
+	cfg.ShutdownTimeout = 18 * time.Second
+	cfg.InternalMetrics.Exporter = imetrics.InternalMetricsExporterPrometheus
+	cfg.InternalMetrics.Prometheus.Port = 9090
+	cfg.InternalMetrics.Prometheus.Path = "/debug/metrics"
+	cfg.InternalMetrics.BpfMetricScrapeInterval = 19 * time.Second
+	cfg.Prometheus.AllowServiceGraphSelfReferences = true
+	cfg.Prometheus.SpanMetricsServiceCacheSize = 701
+	cfg.Prometheus.ExtraResourceLabels = []string{"cloud.region"}
+	cfg.Prometheus.ExtraSpanResourceLabels = []string{"service.version"}
+
+	_, ext := RuntimeToV2(&cfg)
+
+	got, err := V2ToRuntime(ext)
+	require.NoError(t, err)
+
+	require.Equal(t, 77, got.ChannelBufferLen)
+	require.Equal(t, 2*time.Second, got.ChannelSendTimeout)
+	require.True(t, got.ChannelSendTimeoutPanic)
+	require.True(t, got.EnforceSysCaps)
+	require.Equal(t, 5*time.Second, got.Discovery.PollInterval)
+	require.Equal(t, 6*time.Second, got.Discovery.MinProcessAge)
+	require.True(t, got.Discovery.BPFPidFilterOff)
+	require.True(t, got.Discovery.SkipGoSpecificTracers)
+	require.False(t, got.NodeJS.Enabled)
+	require.False(t, got.Java.Enabled)
+	require.True(t, got.Java.DebugInstrumentation)
+	require.Equal(t, 7*time.Second, got.Java.Timeout)
+
+	require.Equal(t, config.ContextPropagationAll, got.EBPF.ContextPropagation)
+	require.Equal(t, config.TCBackendTCX, got.EBPF.TCBackend)
+	require.Equal(t, config.MapReaderLegacy, got.EBPF.ForceBPFMapReader)
+	require.Equal(t, 2, got.EBPF.MapsConfig.GlobalScaleFactor)
+	require.Equal(t, uint32(100), got.EBPF.BufferSizes.HTTP)
+	require.Equal(t, uint32(103), got.EBPF.BufferSizes.MSSQL)
+	require.Equal(t, 202, got.EBPF.MSSQLPreparedStatementsCacheSize)
+	require.Equal(t, config.CudaModeOn, got.EBPF.InstrumentCuda)
+
+	require.Contains(t, got.Traces.Instrumentations, instrumentations.InstrumentationKafka)
+	require.NotContains(t, got.Traces.Instrumentations, instrumentations.InstrumentationRedis)
+	require.Contains(t, got.OTELMetrics.Instrumentations, instrumentations.InstrumentationHTTP)
+	require.NotContains(t, got.OTELMetrics.Instrumentations, instrumentations.InstrumentationKafka)
+	require.Contains(t, got.Prometheus.Instrumentations, instrumentations.InstrumentationDNS)
+	require.Equal(t, export.FeatureApplicationRED|export.FeatureNetwork, got.Metrics.Features)
+
+	require.True(t, got.NetworkFlows.Enable)
+	require.Equal(t, obi.EbpfSourceTC, got.NetworkFlows.Source)
+	require.Equal(t, "192.0.2.1", got.NetworkFlows.AgentIP)
+	require.Equal(t, obi.AgentTypeIface(obi.NetworkAgentIPIfaceLocal), got.NetworkFlows.AgentIPIface)
+	require.Equal(t, []string{"eth0"}, got.NetworkFlows.Interfaces)
+	require.Equal(t, []string{"udp"}, got.NetworkFlows.ExcludeProtocols)
+	require.Equal(t, 300, got.NetworkFlows.CacheMaxFlows)
+	require.Equal(t, 14*time.Second, got.NetworkFlows.CacheActiveTimeout)
+	require.Equal(t, "none", got.NetworkFlows.Deduper)
+	require.Equal(t, 15*time.Second, got.NetworkFlows.DeduperFCTTL)
+	require.Equal(t, "egress", got.NetworkFlows.Direction)
+	require.Equal(t, 16, got.NetworkFlows.Sampling)
+	require.True(t, got.NetworkFlows.Print)
+	require.Equal(t, 400, got.Attributes.MetricSpanNameAggregationLimit)
+	require.Equal(t, 301, got.Traces.ReportersCacheLen)
+	require.Equal(t, 302, got.OTELMetrics.ReportersCacheLen)
+	require.Equal(t, 303*time.Second, got.OTELMetrics.TTL)
+
+	require.Equal(t, []transform.Source{transform.SourceDNS, transform.SourceK8s}, got.NameResolver.Sources)
+	require.Equal(t, 501, got.NameResolver.CacheLen)
+	require.Equal(t, 502*time.Second, got.NameResolver.CacheTTL)
+	require.Equal(t, "unknown-out", got.Attributes.RenameUnresolvedHostsOutgoing)
+
+	require.True(t, got.EBPF.LogEnricher.Enabled())
+	require.Equal(t, 601*time.Second, got.EBPF.LogEnricher.CacheTTL)
+	require.Equal(t, 602, got.EBPF.LogEnricher.CacheSize)
+	require.Equal(t, 603, got.EBPF.LogEnricher.AsyncWriterWorkers)
+	require.Equal(t, 604, got.EBPF.LogEnricher.AsyncWriterChannelLen)
+
+	require.Equal(t, obi.LogLevelDebug, got.LogLevel)
+	require.Equal(t, obi.LogConfigOptionJSON, got.LogConfig)
+	require.Equal(t, debug.TracePrinterJSON, got.TracePrinter)
+	require.Equal(t, 6060, got.ProfilePort)
+	require.Equal(t, 18*time.Second, got.ShutdownTimeout)
+	require.Equal(t, imetrics.InternalMetricsExporterPrometheus, got.InternalMetrics.Exporter)
+	require.Equal(t, 9090, got.InternalMetrics.Prometheus.Port)
+	require.Equal(t, "/debug/metrics", got.InternalMetrics.Prometheus.Path)
+	require.Equal(t, 19*time.Second, got.InternalMetrics.BpfMetricScrapeInterval)
+	require.True(t, got.Prometheus.AllowServiceGraphSelfReferences)
+	require.Equal(t, 701, got.Prometheus.SpanMetricsServiceCacheSize)
+	require.Equal(t, []string{"cloud.region"}, got.Prometheus.ExtraResourceLabels)
+	require.Equal(t, []string{"service.version"}, got.Prometheus.ExtraSpanResourceLabels)
+}
+
+func TestV2ToRuntimePreservesDefaultsForMissingSections(t *testing.T) {
+	t.Parallel()
+
+	got, err := V2ToRuntime(&schema.Extension{Version: schema.SupportedVersion})
+	require.NoError(t, err)
+
+	require.Equal(t, obi.DefaultConfig.ChannelBufferLen, got.ChannelBufferLen)
+	require.Equal(t, obi.DefaultConfig.EBPF.BatchLength, got.EBPF.BatchLength)
+	require.Equal(t, obi.DefaultConfig.Metrics.Features, got.Metrics.Features)
+	require.Equal(t, obi.DefaultConfig.NetworkFlows.Enable, got.NetworkFlows.Enable)
+}
+
+func TestV2ToRuntimePartialInstrumentationPreservesDefaults(t *testing.T) {
+	t.Parallel()
+
+	got, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Instrumentation: schema.Instrumentation{
+				HTTP: schema.HTTPInstrumentation{
+					TrackRequestHeaders: true,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.True(t, got.EBPF.TrackRequestHeaders)
+	require.Equal(t, obi.DefaultConfig.Traces.Instrumentations, got.Traces.Instrumentations)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.Instrumentations, got.OTELMetrics.Instrumentations)
+	require.Equal(t, obi.DefaultConfig.Prometheus.Instrumentations, got.Prometheus.Instrumentations)
+	require.Equal(t, obi.DefaultConfig.Metrics.Features, got.Metrics.Features)
+	require.Equal(t, obi.DefaultConfig.EBPF.MySQLPreparedStatementsCacheSize, got.EBPF.MySQLPreparedStatementsCacheSize)
+}
+
+func TestV2ToRuntimePartialCaptureSectionsPreserveDefaults(t *testing.T) {
+	t.Parallel()
+
+	got, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Policy: schema.CapturePolicy{
+				MinProcessAge: schema.Duration(6 * time.Second),
+			},
+			Limits: schema.CaptureLimits{
+				MetricSpanNames: 400,
+			},
+			Safety: schema.CaptureSafety{
+				EnforceSystemCapabilities: true,
+			},
+			Channels: schema.CaptureChannels{
+				BufferLen: 77,
+			},
+			Engine: schema.CaptureEngine{
+				Debug: schema.EngineDebug{
+					BPF: true,
+				},
+			},
+			Network: schema.CaptureNetwork{
+				Capture: schema.NetworkCapture{
+					Enabled: true,
+				},
+			},
+			Runtimes: schema.CaptureRuntimes{
+				Java: schema.JavaRuntime{
+					Debug: schema.JavaDebug{
+						Enabled: true,
+					},
+				},
+			},
+			Telemetry: schema.CaptureTelemetry{
+				Traces: schema.TracesTelemetry{
+					ReportersCacheLen: 301,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 6*time.Second, got.Discovery.MinProcessAge)
+	require.Equal(t, obi.DefaultConfig.Discovery.PollInterval, got.Discovery.PollInterval)
+	require.Equal(t, 400, got.Attributes.MetricSpanNameAggregationLimit)
+	require.Equal(t, obi.DefaultConfig.NetworkFlows.CacheMaxFlows, got.NetworkFlows.CacheMaxFlows)
+	require.True(t, got.EnforceSysCaps)
+
+	require.Equal(t, 77, got.ChannelBufferLen)
+	require.Equal(t, obi.DefaultConfig.ChannelSendTimeout, got.ChannelSendTimeout)
+	require.Equal(t, obi.DefaultConfig.ChannelSendTimeoutPanic, got.ChannelSendTimeoutPanic)
+
+	require.True(t, got.EBPF.BpfDebug)
+	require.Equal(t, obi.DefaultConfig.EBPF.WakeupLen, got.EBPF.WakeupLen)
+	require.Equal(t, obi.DefaultConfig.EBPF.BatchLength, got.EBPF.BatchLength)
+	require.Equal(t, obi.DefaultConfig.EBPF.TCBackend, got.EBPF.TCBackend)
+	require.Equal(t, obi.DefaultConfig.EBPF.ForceBPFMapReader, got.EBPF.ForceBPFMapReader)
+	require.Equal(t, obi.DefaultConfig.EBPF.MaxTransactionTime, got.EBPF.MaxTransactionTime)
+
+	require.True(t, got.NetworkFlows.Enable)
+	require.Equal(t, obi.DefaultConfig.NetworkFlows.Source, got.NetworkFlows.Source)
+	require.Equal(t, obi.DefaultConfig.NetworkFlows.ExcludeInterfaces, got.NetworkFlows.ExcludeInterfaces)
+	require.Equal(t, obi.DefaultConfig.NetworkFlows.CacheActiveTimeout, got.NetworkFlows.CacheActiveTimeout)
+	require.Equal(t, obi.DefaultConfig.NetworkFlows.Deduper, got.NetworkFlows.Deduper)
+	require.Equal(t, obi.DefaultConfig.NetworkFlows.ListenInterfaces, got.NetworkFlows.ListenInterfaces)
+	require.Equal(t, export.FeatureApplicationRED|export.FeatureNetwork, got.Metrics.Features)
+
+	require.True(t, got.Java.Debug)
+	require.Equal(t, obi.DefaultConfig.Discovery.SkipGoSpecificTracers, got.Discovery.SkipGoSpecificTracers)
+	require.Equal(t, obi.DefaultConfig.NodeJS.Enabled, got.NodeJS.Enabled)
+	require.Equal(t, obi.DefaultConfig.Java.Enabled, got.Java.Enabled)
+	require.Equal(t, obi.DefaultConfig.Java.Timeout, got.Java.Timeout)
+
+	require.Equal(t, 301, got.Traces.ReportersCacheLen)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.ReportersCacheLen, got.OTELMetrics.ReportersCacheLen)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.TTL, got.OTELMetrics.TTL)
+}
+
+func TestV2ToRuntimeOmittedCaptureSiblingsPreserveDefaults(t *testing.T) {
+	t.Parallel()
+
+	_, ext := RuntimeToV2(nil)
+	ext.Capture.Limits = schema.CaptureLimits{}
+	ext.Capture.Channels = schema.CaptureChannels{}
+	ext.Capture.Runtimes = schema.CaptureRuntimes{}
+	ext.Capture.Telemetry = schema.CaptureTelemetry{}
+
+	got, err := V2ToRuntime(ext)
+	require.NoError(t, err)
+
+	require.Equal(t, obi.DefaultConfig.Attributes.MetricSpanNameAggregationLimit, got.Attributes.MetricSpanNameAggregationLimit)
+	require.Equal(t, obi.DefaultConfig.NetworkFlows.CacheMaxFlows, got.NetworkFlows.CacheMaxFlows)
+	require.Equal(t, obi.DefaultConfig.ChannelBufferLen, got.ChannelBufferLen)
+	require.Equal(t, obi.DefaultConfig.ChannelSendTimeout, got.ChannelSendTimeout)
+	require.Equal(t, obi.DefaultConfig.ChannelSendTimeoutPanic, got.ChannelSendTimeoutPanic)
+	require.Equal(t, obi.DefaultConfig.Discovery.SkipGoSpecificTracers, got.Discovery.SkipGoSpecificTracers)
+	require.Equal(t, obi.DefaultConfig.NodeJS.Enabled, got.NodeJS.Enabled)
+	require.Equal(t, obi.DefaultConfig.Java.Enabled, got.Java.Enabled)
+	require.Equal(t, obi.DefaultConfig.Java.Timeout, got.Java.Timeout)
+	require.Equal(t, obi.DefaultConfig.Traces.ReportersCacheLen, got.Traces.ReportersCacheLen)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.ReportersCacheLen, got.OTELMetrics.ReportersCacheLen)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.TTL, got.OTELMetrics.TTL)
+}
+
+func TestV2ToRuntimePartialStandaloneSectionsPreserveDefaults(t *testing.T) {
+	t.Parallel()
+
+	got, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Correlation: &schema.Correlation{
+			LogTraceAnnotation: schema.LogTraceAnnotation{
+				Enabled: true,
+			},
+		},
+		Daemon: &schema.Daemon{
+			Logging: schema.Logging{
+				Level: schema.LogLevelDebug,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, obi.LogLevelDebug, got.LogLevel)
+	require.Equal(t, obi.DefaultConfig.ShutdownTimeout, got.ShutdownTimeout)
+	require.Equal(t, obi.DefaultConfig.InternalMetrics, got.InternalMetrics)
+	require.Equal(t, obi.DefaultConfig.Prometheus.SpanMetricsServiceCacheSize, got.Prometheus.SpanMetricsServiceCacheSize)
+	require.True(t, got.EBPF.LogEnricher.Enabled())
+	require.Equal(t, obi.DefaultConfig.EBPF.LogEnricher.CacheTTL, got.EBPF.LogEnricher.CacheTTL)
+	require.Equal(t, obi.DefaultConfig.EBPF.LogEnricher.AsyncWriterWorkers, got.EBPF.LogEnricher.AsyncWriterWorkers)
+}

--- a/internal/config/convert/import_test.go
+++ b/internal/config/convert/import_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 
 	"go.opentelemetry.io/obi/internal/config/schema"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
@@ -16,6 +17,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/debug"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/filter"
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/transform"
 )
@@ -112,6 +114,7 @@ func TestV2ToRuntimeCustomFoundation(t *testing.T) {
 		instrumentations.InstrumentationKafka,
 	}
 	cfg.OTELMetrics.ReportersCacheLen = 302
+	cfg.OTELMetrics.MetricsEndpoint = "http://localhost:4318"
 	cfg.OTELMetrics.TTL = 303 * time.Second
 	cfg.OTELMetrics.Instrumentations = []instrumentations.Instrumentation{
 		instrumentations.InstrumentationHTTP,
@@ -120,7 +123,11 @@ func TestV2ToRuntimeCustomFoundation(t *testing.T) {
 		instrumentations.InstrumentationRedis,
 		instrumentations.InstrumentationDNS,
 	}
-	cfg.Metrics.Features = export.FeatureApplicationRED | export.FeatureNetwork
+	cfg.Prometheus.Port = 9090
+	cfg.Metrics.Features = export.FeatureApplicationRED |
+		export.FeatureNetwork |
+		export.FeatureStatsTCPRtt |
+		export.FeatureStatsTCPRetransmits
 
 	cfg.NetworkFlows.Enable = true
 	cfg.NetworkFlows.Source = obi.EbpfSourceTC
@@ -141,6 +148,24 @@ func TestV2ToRuntimeCustomFoundation(t *testing.T) {
 	cfg.NetworkFlows.ListenPollPeriod = 17 * time.Second
 	cfg.NetworkFlows.Print = true
 	cfg.Attributes.MetricSpanNameAggregationLimit = 400
+
+	require.NoError(t, yaml.Unmarshal([]byte("- cidr: 192.0.2.0/24\n  name: docs\n"), &cfg.Stats.CIDRs))
+	cfg.Stats.AgentIP = "198.51.100.1"
+	cfg.Stats.AgentIPIface = obi.NetworkAgentIPIfaceLocal
+	cfg.Stats.AgentIPType = "ipv4"
+	cfg.Stats.GeoIP.IPInfo.Path = "/var/lib/stats-ipinfo.mmdb"
+	cfg.Stats.GeoIP.MaxMindInfo.CountryPath = "/var/lib/stats-country.mmdb"
+	cfg.Stats.GeoIP.MaxMindInfo.ASNPath = "/var/lib/stats-asn.mmdb"
+	cfg.Stats.GeoIP.CacheLen = 81
+	cfg.Stats.GeoIP.CacheTTL = 82 * time.Second
+	cfg.Stats.ReverseDNS.Type = "ebpf"
+	cfg.Stats.ReverseDNS.CacheLen = 83
+	cfg.Stats.ReverseDNS.CacheTTL = 84 * time.Second
+	cfg.Stats.Print = true
+	srtt := 1024
+	cfg.Filters.Stats = filter.AttributeFamilyConfig{
+		"srtt": {GreaterThan: &srtt},
+	}
 
 	cfg.NameResolver.Sources = []transform.Source{transform.SourceDNS, transform.SourceK8s}
 	cfg.NameResolver.CacheLen = 501
@@ -203,7 +228,13 @@ func TestV2ToRuntimeCustomFoundation(t *testing.T) {
 	require.Contains(t, got.OTELMetrics.Instrumentations, instrumentations.InstrumentationHTTP)
 	require.NotContains(t, got.OTELMetrics.Instrumentations, instrumentations.InstrumentationKafka)
 	require.Contains(t, got.Prometheus.Instrumentations, instrumentations.InstrumentationDNS)
-	require.Equal(t, export.FeatureApplicationRED|export.FeatureNetwork, got.Metrics.Features)
+	require.Equal(t,
+		export.FeatureApplicationRED|
+			export.FeatureNetwork|
+			export.FeatureStatsTCPRtt|
+			export.FeatureStatsTCPRetransmits,
+		got.Metrics.Features,
+	)
 
 	require.True(t, got.NetworkFlows.Enable)
 	require.Equal(t, obi.EbpfSourceTC, got.NetworkFlows.Source)
@@ -222,6 +253,23 @@ func TestV2ToRuntimeCustomFoundation(t *testing.T) {
 	require.Equal(t, 301, got.Traces.ReportersCacheLen)
 	require.Equal(t, 302, got.OTELMetrics.ReportersCacheLen)
 	require.Equal(t, 303*time.Second, got.OTELMetrics.TTL)
+
+	require.Equal(t, "198.51.100.1", got.Stats.AgentIP)
+	require.Equal(t, obi.AgentTypeIface(obi.NetworkAgentIPIfaceLocal), got.Stats.AgentIPIface)
+	require.Equal(t, "ipv4", got.Stats.AgentIPType)
+	require.Len(t, got.Stats.CIDRs, 1)
+	require.Equal(t, "192.0.2.0/24", got.Stats.CIDRs[0].CIDR)
+	require.Equal(t, "docs", got.Stats.CIDRs[0].Name)
+	require.Equal(t, filter.MatchDefinition{GreaterThan: &srtt}, got.Filters.Stats["srtt"])
+	require.Equal(t, "/var/lib/stats-ipinfo.mmdb", got.Stats.GeoIP.IPInfo.Path)
+	require.Equal(t, "/var/lib/stats-country.mmdb", got.Stats.GeoIP.MaxMindInfo.CountryPath)
+	require.Equal(t, "/var/lib/stats-asn.mmdb", got.Stats.GeoIP.MaxMindInfo.ASNPath)
+	require.Equal(t, 81, got.Stats.GeoIP.CacheLen)
+	require.Equal(t, 82*time.Second, got.Stats.GeoIP.CacheTTL)
+	require.Equal(t, "ebpf", got.Stats.ReverseDNS.Type)
+	require.Equal(t, 83, got.Stats.ReverseDNS.CacheLen)
+	require.Equal(t, 84*time.Second, got.Stats.ReverseDNS.CacheTTL)
+	require.True(t, got.Stats.Print)
 
 	require.Equal(t, []transform.Source{transform.SourceDNS, transform.SourceK8s}, got.NameResolver.Sources)
 	require.Equal(t, 501, got.NameResolver.CacheLen)
@@ -311,6 +359,14 @@ func TestV2ToRuntimePartialCaptureSectionsPreserveDefaults(t *testing.T) {
 				Capture: schema.NetworkCapture{
 					Enabled: true,
 				},
+				Stats: schema.NetworkStats{
+					EndpointIdentity: schema.EndpointIdentity{
+						AgentIP: "198.51.100.1",
+					},
+					Diagnostics: schema.StatsDiagnostics{
+						PrintStats: true,
+					},
+				},
 			},
 			Runtimes: schema.CaptureRuntimes{
 				Java: schema.JavaRuntime{
@@ -352,6 +408,11 @@ func TestV2ToRuntimePartialCaptureSectionsPreserveDefaults(t *testing.T) {
 	require.Equal(t, obi.DefaultConfig.NetworkFlows.Deduper, got.NetworkFlows.Deduper)
 	require.Equal(t, obi.DefaultConfig.NetworkFlows.ListenInterfaces, got.NetworkFlows.ListenInterfaces)
 	require.Equal(t, export.FeatureApplicationRED|export.FeatureNetwork, got.Metrics.Features)
+	require.Equal(t, "198.51.100.1", got.Stats.AgentIP)
+	require.Equal(t, obi.DefaultConfig.Stats.AgentIPIface, got.Stats.AgentIPIface)
+	require.Equal(t, obi.DefaultConfig.Stats.AgentIPType, got.Stats.AgentIPType)
+	require.True(t, got.Stats.Print)
+	require.Equal(t, obi.DefaultConfig.Stats.ReverseDNS.CacheTTL, got.Stats.ReverseDNS.CacheTTL)
 
 	require.True(t, got.Java.Debug)
 	require.Equal(t, obi.DefaultConfig.Discovery.SkipGoSpecificTracers, got.Discovery.SkipGoSpecificTracers)

--- a/internal/config/convert/protocols.go
+++ b/internal/config/convert/protocols.go
@@ -26,6 +26,24 @@ type protocolMapping struct {
 	metricWildcard bool
 }
 
+var runtimeInstrumentations = []instrumentations.Instrumentation{
+	instrumentations.InstrumentationHTTP,
+	instrumentations.InstrumentationGRPC,
+	instrumentations.InstrumentationSQL,
+	instrumentations.InstrumentationRedis,
+	instrumentations.InstrumentationKafka,
+	instrumentations.InstrumentationMQTT,
+	instrumentations.InstrumentationNATS,
+	instrumentations.InstrumentationAMQP,
+	instrumentations.InstrumentationGPU,
+	instrumentations.InstrumentationMongo,
+	instrumentations.InstrumentationDNS,
+	instrumentations.InstrumentationCouchbase,
+	instrumentations.InstrumentationGenAI,
+	instrumentations.InstrumentationMemcached,
+	instrumentations.InstrumentationSunRPC,
+}
+
 var protocolMappings = []protocolMapping{
 	{name: protocolHTTP, instr: instrumentations.InstrumentationHTTP, appMetrics: true, metricWildcard: true},
 	{name: protocolGRPC, instr: instrumentations.InstrumentationGRPC, appMetrics: true, metricWildcard: true},


### PR DESCRIPTION
## Summary
- Add an internal `convert.V2ToRuntime` foundation that converts the hidden config v2 extension shape into `obi.Config`.
- Cover core capture settings, protocol enablement, basic network capture, capture telemetry, and standalone daemon/correlation/service-name basics.
- Keep advanced import parity for later slices, including rules/selectors, filters, stats, payload extraction, Kubernetes/resource identity, and top-level OTel pipeline behavior.

This PR implements step 5, "Internal v2-to-runtime conversion foundation", from #2251, the config v2 steel-thread landing plan. It follows the step 3 export-conversion parity work that landed in #2269 and #2288 by adding the first reverse-direction conversion from the hidden config v2 extension shape back into `obi.Config`.

The shape is informed by the earlier PoC in #2080, but this PR intentionally keeps the runtime import side narrow: it establishes the internal foundation needed for follow-on import parity without wiring config v2 into public/runtime loading paths.

## Scope
This stays internal-only for the config v2 steel thread in #2251. It does not add public config v2 APIs, CLI commands, runtime v2 parsing, Collector receiver v2 parsing, generated artifacts, or user-facing config v2 docs.

## Tests
- `make generate`
- `go test ./internal/config/convert`
- `go test ./internal/config/...`
- `go test ./cmd/check-config-v2-parity`
- `make check-config-v2-parity`