### PR TITLE
Harden internal jvmtools fork

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,8 +29,6 @@ linters:
       - ^configs
       # this is temporarily imported code that does not rely on us
       - ^pkg/export/otel/metric
-      # copied jvmtools fork; keep upstream code changes scoped to follow-up PRs
-      - ^pkg/internal/jvmtools
     presets:
       - std-error-handling
     # Log a warning if an exclusion rule is unused.

--- a/pkg/internal/jvmtools/README.md
+++ b/pkg/internal/jvmtools/README.md
@@ -14,3 +14,6 @@ Only the JVM attach code currently used by OBI is included:
 The CLI, scripts, dynamic-agent-loading flag flip code, and ptrace/ELF helpers
 are intentionally omitted. The initial copy is behavior-preserving; local
 changes should remain scoped to OBI's JVM attach needs.
+
+The attach implementation is Linux-only. Non-Linux files provide stubs so Go
+package discovery and validation can still list the internal fork packages.

--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -26,6 +26,10 @@ type JAttacher struct {
 }
 
 func NewJAttacher(logger *slog.Logger) *JAttacher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	return &JAttacher{
 		logger:     logger,
 		j9attacher: nil,
@@ -49,18 +53,15 @@ func (j *JAttacher) Cleanup() error {
 		cleanupErr = errors.Join(cleanupErr, j.j9attacher.detach())
 	}
 	if err := syscall.Seteuid(j.myUID); err != nil {
-		j.logger.Error("failed to restore uid", "error", err)
 		cleanupErr = errors.Join(cleanupErr, err)
 	}
 	if err := syscall.Setegid(j.myGID); err != nil {
-		j.logger.Error("failed to restore gid", "error", err)
 		cleanupErr = errors.Join(cleanupErr, err)
 	}
 
 	for _, nsType := range []string{"net", "ipc", "mnt"} {
 		if util.EnterNS(j.myPID, nsType) < 0 {
 			err := fmt.Errorf("failed to restore %s namespace", nsType)
-			j.logger.Error("failed to restore namespace", "namespace", nsType)
 			cleanupErr = errors.Join(cleanupErr, err)
 		}
 	}

--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -43,21 +43,29 @@ func (j *JAttacher) Init() {
 }
 
 func (j *JAttacher) Cleanup() error {
+	var cleanupErr error
+
 	if j.j9attacher != nil {
-		j.j9attacher.detach()
+		cleanupErr = errors.Join(cleanupErr, j.j9attacher.detach())
 	}
 	if err := syscall.Seteuid(j.myUID); err != nil {
 		j.logger.Error("failed to restore uid", "error", err)
+		cleanupErr = errors.Join(cleanupErr, err)
 	}
 	if err := syscall.Setegid(j.myGID); err != nil {
 		j.logger.Error("failed to restore gid", "error", err)
+		cleanupErr = errors.Join(cleanupErr, err)
 	}
 
-	util.EnterNS(j.myPID, "net")
-	util.EnterNS(j.myPID, "ipc")
-	util.EnterNS(j.myPID, "mnt")
+	for _, nsType := range []string{"net", "ipc", "mnt"} {
+		if util.EnterNS(j.myPID, nsType) < 0 {
+			err := fmt.Errorf("failed to restore %s namespace", nsType)
+			j.logger.Error("failed to restore namespace", "namespace", nsType)
+			cleanupErr = errors.Join(cleanupErr, err)
+		}
+	}
 
-	return nil
+	return cleanupErr
 }
 
 func (j *JAttacher) Attach(pid int, argv []string, ignoreOnJ9 bool) (io.ReadCloser, error) {
@@ -65,20 +73,27 @@ func (j *JAttacher) Attach(pid int, argv []string, ignoreOnJ9 bool) (io.ReadClos
 	targetGID := j.myGID
 	var nspid int
 
-	if util.GetProcessInfo(pid, &targetUID, &targetGID, &nspid) != nil {
-		return nil, fmt.Errorf("process not found: %v", pid)
+	if err := util.GetProcessInfo(pid, &targetUID, &targetGID, &nspid); err != nil {
+		return nil, fmt.Errorf("process not found: %d: %w", pid, err)
 	}
 
 	// Container support: switch to the target namespaces.
 	// Network and IPC namespaces are essential for OpenJ9 connection.
-	util.EnterNS(pid, "net")
-	util.EnterNS(pid, "ipc")
+	if util.EnterNS(pid, "net") < 0 {
+		return nil, errors.New("failed to enter target net namespace")
+	}
+	if util.EnterNS(pid, "ipc") < 0 {
+		return nil, errors.New("failed to enter target ipc namespace")
+	}
 	mntChanged := util.EnterNS(pid, "mnt")
+	if mntChanged < 0 {
+		return nil, errors.New("failed to enter target mnt namespace")
+	}
 
 	// In HotSpot, dynamic attach is allowed only for the clients with the same euid/egid.
 	// If we are running under root, switch to the required euid/egid automatically.
-	if (j.myGID != targetGID && syscall.Setegid(int(targetGID)) != nil) ||
-		(j.myUID != targetUID && syscall.Seteuid(int(targetUID)) != nil) {
+	if (j.myGID != targetGID && syscall.Setegid(targetGID) != nil) ||
+		(j.myUID != targetUID && syscall.Seteuid(targetUID) != nil) {
 		return nil, errors.New("failed to change credentials to match the target process")
 	}
 
@@ -98,7 +113,7 @@ func (j *JAttacher) Attach(pid int, argv []string, ignoreOnJ9 bool) (io.ReadClos
 		}
 		j9attacher := newJ9Attacher(j.logger)
 		j.j9attacher = j9attacher
-		return j.j9attacher.jattachOpenJ9(tmpPath, pid, nspid, argv)
+		return j.j9attacher.jattachOpenJ9(tmpPath, nspid, argv)
 	}
 
 	return jattachHotspot(pid, nspid, attachPid, argv, tmpPath, j.logger)

--- a/pkg/internal/jvmtools/jvm/cmd_hotspot.go
+++ b/pkg/internal/jvmtools/jvm/cmd_hotspot.go
@@ -24,7 +24,7 @@ func checkSocket(pid int, tmpPath string) bool {
 }
 
 // Check if a file is owned by current user
-func getFileOwner(path string) (uid int) {
+func getFileOwner(path string) int {
 	info, err := os.Stat(path)
 	if err != nil {
 		return -1
@@ -38,29 +38,38 @@ func getFileOwner(path string) (uid int) {
 func startAttachMechanism(pid, nspid, attachPid int, tmpPath string) bool {
 	path := fmt.Sprintf("/proc/%d/cwd/.attach_pid%d", attachPid, nspid)
 	fd, err := os.Create(path)
-	if err != nil || (fd.Close() == nil && getFileOwner(path) != os.Geteuid()) {
-		os.Remove(path)
+	if err == nil {
+		err = fd.Close()
+	}
+	if err != nil || getFileOwner(path) != os.Geteuid() {
+		_ = os.Remove(path)
 		path = fmt.Sprintf("%s/.attach_pid%d", tmpPath, nspid)
 		fd, err = os.Create(path)
 		if err != nil {
 			return false
 		}
-		fd.Close()
+		if err := fd.Close(); err != nil {
+			_ = os.Remove(path)
+			return false
+		}
 	}
 
-	syscall.Kill(pid, syscall.SIGQUIT)
+	if err := syscall.Kill(pid, syscall.SIGQUIT); err != nil {
+		_ = os.Remove(path)
+		return false
+	}
 
 	ts := 20 * time.Millisecond
 	for i := 0; i < 300; i++ {
 		time.Sleep(ts)
 		if checkSocket(nspid, tmpPath) {
-			os.Remove(path)
+			_ = os.Remove(path)
 			return true
 		}
 		ts += 20 * time.Millisecond
 	}
 
-	os.Remove(path)
+	_ = os.Remove(path)
 	return false
 }
 
@@ -100,6 +109,7 @@ func jattachHotspot(pid, nspid, attachPid int, args []string, tmpPath string, lo
 	logger.Debug("connected to the JVM")
 
 	if err := writeHotspotCommand(conn, args); err != nil {
+		_ = conn.Close()
 		return nil, fmt.Errorf("error writing to the JVM socket: %w", err)
 	}
 

--- a/pkg/internal/jvmtools/jvm/cmd_notlinux.go
+++ b/pkg/internal/jvmtools/jvm/cmd_notlinux.go
@@ -1,0 +1,30 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package jvm // import "go.opentelemetry.io/obi/pkg/internal/jvmtools/jvm"
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+)
+
+var errUnsupported = errors.New("jvmtools attach is only supported on linux")
+
+type JAttacher struct{}
+
+func NewJAttacher(_ *slog.Logger) *JAttacher {
+	return &JAttacher{}
+}
+
+func (*JAttacher) Init() {}
+
+func (*JAttacher) Cleanup() error {
+	return nil
+}
+
+func (*JAttacher) Attach(_ int, _ []string, _ bool) (io.ReadCloser, error) {
+	return nil, errUnsupported
+}

--- a/pkg/internal/jvmtools/jvm/cmd_openj9.go
+++ b/pkg/internal/jvmtools/jvm/cmd_openj9.go
@@ -32,6 +32,10 @@ type j9Attacher struct {
 }
 
 func newJ9Attacher(logger *slog.Logger) *j9Attacher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	j := &j9Attacher{
 		logger: logger,
 		fd:     -1,
@@ -489,7 +493,7 @@ func (j *j9Attacher) jattachOpenJ9(tmpPath string, nspid int, argv []string) (re
 	}
 	attachLock = -1
 
-	j.logger.Info("Connected to remote JVM")
+	j.logger.Info("connected to remote JVM")
 
 	cmd := translateCommand(argv)
 

--- a/pkg/internal/jvmtools/jvm/cmd_openj9.go
+++ b/pkg/internal/jvmtools/jvm/cmd_openj9.go
@@ -8,12 +8,15 @@ package jvm // import "go.opentelemetry.io/obi/pkg/internal/jvmtools/jvm"
 
 import (
 	"bytes"
+	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -29,9 +32,12 @@ type j9Attacher struct {
 }
 
 func newJ9Attacher(logger *slog.Logger) *j9Attacher {
-	return &j9Attacher{
+	j := &j9Attacher{
 		logger: logger,
+		fd:     -1,
 	}
+
+	return j
 }
 
 // Translate HotSpot command to OpenJ9 equivalent
@@ -63,38 +69,35 @@ func translateCommand(argv []string) string {
 		if argc > 1 {
 			arg1 = argv[1]
 		}
-		result = fmt.Sprintf("ATTACH_DIAGNOSTICS:%s", arg1)
-		for i := 2; i < argc; i++ {
-			result += "," + argv[i]
-		}
+		result = "ATTACH_DIAGNOSTICS:" + strings.Join(append([]string{arg1}, argv[2:]...), ",")
 
 	case "threaddump":
 		arg1 := ""
 		if argc > 1 {
 			arg1 = argv[1]
 		}
-		result = fmt.Sprintf("ATTACH_DIAGNOSTICS:Thread.print,%s", arg1)
+		result = "ATTACH_DIAGNOSTICS:Thread.print," + arg1
 
 	case "dumpheap":
 		arg1 := ""
 		if argc > 1 {
 			arg1 = argv[1]
 		}
-		result = fmt.Sprintf("ATTACH_DIAGNOSTICS:Dump.heap,%s", arg1)
+		result = "ATTACH_DIAGNOSTICS:Dump.heap," + arg1
 
 	case "inspectheap":
 		arg1 := ""
 		if argc > 1 {
 			arg1 = argv[1]
 		}
-		result = fmt.Sprintf("ATTACH_DIAGNOSTICS:GC.class_histogram,%s", arg1)
+		result = "ATTACH_DIAGNOSTICS:GC.class_histogram," + arg1
 
 	case "datadump":
 		arg1 := ""
 		if argc > 1 {
 			arg1 = argv[1]
 		}
-		result = fmt.Sprintf("ATTACH_DIAGNOSTICS:Dump.java,%s", arg1)
+		result = "ATTACH_DIAGNOSTICS:Dump.java," + arg1
 
 	case "properties":
 		result = "ATTACH_GETSYSTEMPROPERTIES"
@@ -117,8 +120,11 @@ func writeCommand(fd int, cmd string) error {
 	off := 0
 	for off < len(data) {
 		n, err := syscall.Write(fd, data[off:])
-		if err != nil || n <= 0 {
-			return fmt.Errorf("write failed")
+		if err != nil {
+			return fmt.Errorf("write failed: %w", err)
+		}
+		if n <= 0 {
+			return fmt.Errorf("write failed: %w", io.ErrShortWrite)
 		}
 		off += n
 	}
@@ -126,28 +132,30 @@ func writeCommand(fd int, cmd string) error {
 }
 
 func closeWithErrno(fd int) {
-	syscall.Close(fd)
+	_ = syscall.Close(fd)
 }
 
 func acquireLock(tmpPath, subdir, filename string) (int, error) {
 	path := filepath.Join(tmpPath, ".com_ibm_tools_attach", subdir, filename)
 
-	fd, err := syscall.Open(path, syscall.O_WRONLY|syscall.O_CREAT, 0666)
+	fd, err := syscall.Open(path, syscall.O_WRONLY|syscall.O_CREAT, 0o666)
 	if err != nil {
 		return -1, err
 	}
 
 	if err := syscall.Flock(fd, syscall.LOCK_EX); err != nil {
-		syscall.Close(fd)
+		err = errors.Join(err, syscall.Close(fd))
 		return -1, err
 	}
 
 	return fd, nil
 }
 
-func releaseLock(lockFd int) {
-	syscall.Flock(lockFd, syscall.LOCK_UN)
-	syscall.Close(lockFd)
+func releaseLock(lockFd int) error {
+	return errors.Join(
+		syscall.Flock(lockFd, syscall.LOCK_UN),
+		syscall.Close(lockFd),
+	)
 }
 
 func createAttachSocket() (int, int, error) {
@@ -160,7 +168,7 @@ func createAttachSocket() (int, int, error) {
 				sa, err := syscall.Getsockname(s)
 				if err == nil {
 					if sa6, ok := sa.(*syscall.SockaddrInet6); ok {
-						return s, int(sa6.Port), nil
+						return s, sa6.Port, nil
 					}
 				}
 			}
@@ -192,31 +200,33 @@ func createAttachSocket() (int, int, error) {
 	}
 
 	if sa4, ok := sa.(*syscall.SockaddrInet4); ok {
-		return s, int(sa4.Port), nil
+		return s, sa4.Port, nil
 	}
 
 	closeWithErrno(s)
-	return -1, 0, fmt.Errorf("failed to get socket port")
+	return -1, 0, errors.New("failed to get socket port")
 }
 
-func closeAttachSocket(tmpPath string, s, pid int) {
+func closeAttachSocket(tmpPath string, s, pid int) error {
 	path := filepath.Join(tmpPath, ".com_ibm_tools_attach", strconv.Itoa(pid), "replyInfo")
-	syscall.Unlink(path)
-	syscall.Close(s)
+	var err error
+	if unlinkErr := syscall.Unlink(path); unlinkErr != nil && !errors.Is(unlinkErr, syscall.ENOENT) {
+		err = errors.Join(err, unlinkErr)
+	}
+
+	return errors.Join(err, syscall.Close(s))
 }
 
 func randomKey() uint64 {
 	key := uint64(time.Now().Unix()) * 0xc6a4a7935bd1e995
 
-	fd, err := syscall.Open("/dev/urandom", syscall.O_RDONLY, 0)
-	if err == nil {
-		buf := make([]byte, 8)
-		syscall.Read(fd, buf)
-		syscall.Close(fd)
+	var buf [8]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return key
+	}
 
-		for i := 0; i < 8; i++ {
-			key ^= uint64(buf[i]) << (uint(i) * 8)
-		}
+	for i, b := range buf {
+		key ^= uint64(b) << (uint(i) * 8)
 	}
 
 	return key
@@ -225,19 +235,15 @@ func randomKey() uint64 {
 func writeReplyInfo(tmpPath string, pid, port int, key uint64) error {
 	path := filepath.Join(tmpPath, ".com_ibm_tools_attach", strconv.Itoa(pid), "replyInfo")
 
-	fd, err := syscall.Open(path, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_TRUNC, 0600)
-	if err != nil {
-		return err
-	}
-	defer syscall.Close(fd)
-
 	content := fmt.Sprintf("%016x\n%d\n", key, port)
-	syscall.Write(fd, []byte(content))
-
-	return nil
+	return os.WriteFile(path, []byte(content), 0o600)
 }
 
 func notifySemaphore(tmpPath string, value, notifyCount int) error {
+	if notifyCount <= 0 {
+		return nil
+	}
+
 	path := filepath.Join(tmpPath, ".com_ibm_tools_attach", "_notifier")
 
 	semKey, err := ftok(path, 0xa1)
@@ -245,20 +251,22 @@ func notifySemaphore(tmpPath string, value, notifyCount int) error {
 		return err
 	}
 
-	semID, err := semget(semKey, 1, IPC_CREAT|0666)
+	semID, err := semget(semKey, 1, ipcCreate|0o666)
 	if err != nil {
 		return err
 	}
 
 	flags := int16(0)
 	if value < 0 {
-		flags = IPC_NOWAIT
+		flags = ipcNoWait
 	}
 
 	sb := createSembuf(0, int16(value), flags)
 
 	for range notifyCount {
-		semop(semID, []sembuf{sb})
+		if err := semop(semID, []sembuf{sb}); err != nil {
+			return fmt.Errorf("semop failed: %w", err)
+		}
 	}
 
 	return nil
@@ -266,33 +274,42 @@ func notifySemaphore(tmpPath string, value, notifyCount int) error {
 
 func acceptClient(s int, key uint64) (int, error) {
 	tv := syscall.Timeval{Sec: 5, Usec: 0}
-	syscall.SetsockoptTimeval(s, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv)
+	if err := syscall.SetsockoptTimeval(s, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv); err != nil {
+		return -1, fmt.Errorf("could not set JVM response timeout: %w", err)
+	}
 
 	nfd, _, err := syscall.Accept(s)
 	if err != nil {
-		return -1, fmt.Errorf("JVM did not respond: %w", err)
+		return -1, fmt.Errorf("jvm did not respond: %w", err)
 	}
 
 	buf := make([]byte, 35)
 	off := 0
 	for off < len(buf) {
 		n, err := syscall.Read(nfd, buf[off:])
-		if err != nil || n <= 0 {
-			syscall.Close(nfd)
-			return -1, fmt.Errorf("the JVM connection was prematurely closed")
+		if err != nil {
+			_ = syscall.Close(nfd)
+			return -1, fmt.Errorf("the JVM connection was prematurely closed: %w", err)
+		}
+		if n <= 0 {
+			_ = syscall.Close(nfd)
+			return -1, fmt.Errorf("the JVM connection was prematurely closed: %w", io.ErrUnexpectedEOF)
 		}
 		off += n
 	}
 
 	expected := fmt.Sprintf("ATTACH_CONNECTED %016x ", key)
 	if !bytes.Equal(buf[:len(expected)], []byte(expected)) {
-		syscall.Close(nfd)
+		_ = syscall.Close(nfd)
 		return -1, fmt.Errorf("unexpected JVM response %s", buf[:len(expected)])
 	}
 
 	// Reset the timeout, as the command execution may take arbitrary long time
 	tv0 := syscall.Timeval{Sec: 0, Usec: 0}
-	syscall.SetsockoptTimeval(nfd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv0)
+	if err := syscall.SetsockoptTimeval(nfd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv0); err != nil {
+		_ = syscall.Close(nfd)
+		return -1, fmt.Errorf("could not reset JVM response timeout: %w", err)
+	}
 
 	return nfd, nil
 }
@@ -328,12 +345,17 @@ func (j *j9Attacher) lockNotificationFiles(tmpPath string) int {
 	return count
 }
 
-func (j *j9Attacher) unlockNotificationFiles(count int) {
+func (j *j9Attacher) unlockNotificationFiles(count int) error {
+	var err error
+
 	for i := range count {
 		if j.notifyLock[i] >= 0 {
-			releaseLock(j.notifyLock[i])
+			err = errors.Join(err, releaseLock(j.notifyLock[i]))
+			j.notifyLock[i] = -1
 		}
 	}
+
+	return err
 }
 
 func isOpenJ9Process(tmpPath string, pid int) bool {
@@ -342,25 +364,64 @@ func isOpenJ9Process(tmpPath string, pid int) bool {
 	return err == nil
 }
 
-func (j *j9Attacher) detach() {
-	if j.fd == 0 {
-		return
+type j9Reader struct {
+	attacher *j9Attacher
+}
+
+func (r *j9Reader) Read(p []byte) (int, error) {
+	if r.attacher.fd < 0 {
+		return 0, os.ErrClosed
 	}
 
-	if writeCommand(j.fd, "ATTACH_DETACHED") != nil {
-		return
+	n, err := syscall.Read(r.attacher.fd, p)
+	if n == 0 && err == nil {
+		return 0, io.EOF
+	}
+
+	return n, err
+}
+
+func (r *j9Reader) Close() error {
+	return r.attacher.detach()
+}
+
+func (j *j9Attacher) closeFD() error {
+	if j.fd < 0 {
+		return nil
+	}
+
+	fd := j.fd
+	j.fd = -1
+	return syscall.Close(fd)
+}
+
+func (j *j9Attacher) detach() error {
+	if j.fd < 0 {
+		return nil
+	}
+
+	fd := j.fd
+	j.fd = -1
+
+	var detachErr error
+	if err := writeCommand(fd, "ATTACH_DETACHED"); err != nil {
+		detachErr = errors.Join(detachErr, err)
 	}
 
 	buf := make([]byte, 256)
-	for {
-		n, err := syscall.Read(j.fd, buf)
-		if err != nil || n <= 0 || buf[n-1] == 0 {
-			break
+	if detachErr == nil {
+		for {
+			n, err := syscall.Read(fd, buf)
+			if err != nil || n <= 0 || buf[n-1] == 0 {
+				break
+			}
 		}
 	}
+
+	return errors.Join(detachErr, syscall.Close(fd))
 }
 
-func (j *j9Attacher) jattachOpenJ9(tmpPath string, pid, nspid int, argv []string) (io.ReadCloser, error) {
+func (j *j9Attacher) jattachOpenJ9(tmpPath string, nspid int, argv []string) (reader io.ReadCloser, err error) {
 	attachLock, err := acquireLock(tmpPath, "", "_attachlock")
 	if err != nil {
 		return nil, fmt.Errorf("could not acquire attach lock: %w", err)
@@ -371,14 +432,23 @@ func (j *j9Attacher) jattachOpenJ9(tmpPath string, pid, nspid int, argv []string
 	var port int
 
 	defer func() {
+		var cleanupErr error
 		if s >= 0 {
-			closeAttachSocket(tmpPath, s, nspid)
+			cleanupErr = errors.Join(cleanupErr, closeAttachSocket(tmpPath, s, nspid))
 		}
 		if notifyCount > 0 {
-			j.unlockNotificationFiles(notifyCount)
-			notifySemaphore(tmpPath, -1, notifyCount)
+			cleanupErr = errors.Join(cleanupErr, j.unlockNotificationFiles(notifyCount))
+			cleanupErr = errors.Join(cleanupErr, notifySemaphore(tmpPath, -1, notifyCount))
 		}
-		releaseLock(attachLock)
+		if attachLock >= 0 {
+			cleanupErr = errors.Join(cleanupErr, releaseLock(attachLock))
+		}
+		if err != nil {
+			cleanupErr = errors.Join(cleanupErr, j.closeFD())
+		}
+		if cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+		}
 	}()
 
 	s, port, err = createAttachSocket()
@@ -403,24 +473,29 @@ func (j *j9Attacher) jattachOpenJ9(tmpPath string, pid, nspid int, argv []string
 
 	j.fd = fd
 
-	closeAttachSocket(tmpPath, s, nspid)
+	if err := closeAttachSocket(tmpPath, s, nspid); err != nil {
+		return nil, fmt.Errorf("could not close attach socket: %w", err)
+	}
 	s = -1
-	j.unlockNotificationFiles(notifyCount)
-	notifySemaphore(tmpPath, -1, notifyCount)
+	if err := j.unlockNotificationFiles(notifyCount); err != nil {
+		return nil, fmt.Errorf("could not unlock OpenJ9 notification files: %w", err)
+	}
+	if err := notifySemaphore(tmpPath, -1, notifyCount); err != nil {
+		return nil, fmt.Errorf("could not release OpenJ9 notify semaphore: %w", err)
+	}
 	notifyCount = 0
-	releaseLock(attachLock)
+	if err := releaseLock(attachLock); err != nil {
+		return nil, fmt.Errorf("could not release OpenJ9 attach lock: %w", err)
+	}
 	attachLock = -1
 
 	j.logger.Info("Connected to remote JVM")
 
 	cmd := translateCommand(argv)
 
-	if err := writeCommand(fd, cmd); err != nil {
-		syscall.Close(fd)
-		return nil, fmt.Errorf("error writing to socket: %w", err)
+	if writeErr := writeCommand(fd, cmd); writeErr != nil {
+		return nil, errors.Join(fmt.Errorf("error writing to socket: %w", writeErr), j.closeFD())
 	}
 
-	reader := os.NewFile(uintptr(fd), "socket")
-
-	return reader, nil
+	return &j9Reader{attacher: j}, nil
 }

--- a/pkg/internal/jvmtools/jvm/cmd_openj9.go
+++ b/pkg/internal/jvmtools/jvm/cmd_openj9.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -255,14 +257,14 @@ func notifySemaphore(tmpPath string, value, notifyCount int) error {
 		return err
 	}
 
-	semID, err := semget(semKey, 1, ipcCreate|0o666)
+	semID, err := semget(semKey, 1, unix.IPC_CREAT|0o666)
 	if err != nil {
 		return err
 	}
 
 	flags := int16(0)
 	if value < 0 {
-		flags = ipcNoWait
+		flags = unix.IPC_NOWAIT
 	}
 
 	sb := createSembuf(0, int16(value), flags)

--- a/pkg/internal/jvmtools/jvm/cmd_openj9.go
+++ b/pkg/internal/jvmtools/jvm/cmd_openj9.go
@@ -364,6 +364,13 @@ func (j *j9Attacher) unlockNotificationFiles(count int) error {
 	return err
 }
 
+func (j *j9Attacher) releaseNotificationFiles(tmpPath string, count int) error {
+	return errors.Join(
+		j.unlockNotificationFiles(count),
+		notifySemaphore(tmpPath, -1, count),
+	)
+}
+
 func isOpenJ9Process(tmpPath string, pid int) bool {
 	path := filepath.Join(tmpPath, ".com_ibm_tools_attach", strconv.Itoa(pid), "attachInfo")
 	_, err := os.Stat(path)
@@ -379,12 +386,20 @@ func (r *j9Reader) Read(p []byte) (int, error) {
 		return 0, os.ErrClosed
 	}
 
-	n, err := syscall.Read(r.attacher.fd, p)
-	if n == 0 && err == nil {
-		return 0, io.EOF
-	}
+	for {
+		n, err := syscall.Read(r.attacher.fd, p)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil {
+			return 0, err
+		}
+		if n == 0 {
+			return 0, io.EOF
+		}
 
-	return n, err
+		return n, nil
+	}
 }
 
 func (r *j9Reader) Close() error {
@@ -443,8 +458,7 @@ func (j *j9Attacher) jattachOpenJ9(tmpPath string, nspid int, argv []string) (re
 			cleanupErr = errors.Join(cleanupErr, closeAttachSocket(tmpPath, s, nspid))
 		}
 		if notifyCount > 0 {
-			cleanupErr = errors.Join(cleanupErr, j.unlockNotificationFiles(notifyCount))
-			cleanupErr = errors.Join(cleanupErr, notifySemaphore(tmpPath, -1, notifyCount))
+			cleanupErr = errors.Join(cleanupErr, j.releaseNotificationFiles(tmpPath, notifyCount))
 		}
 		if attachLock >= 0 {
 			cleanupErr = errors.Join(cleanupErr, releaseLock(attachLock))
@@ -479,21 +493,23 @@ func (j *j9Attacher) jattachOpenJ9(tmpPath string, nspid int, argv []string) (re
 
 	j.fd = fd
 
-	if err := closeAttachSocket(tmpPath, s, nspid); err != nil {
-		return nil, fmt.Errorf("could not close attach socket: %w", err)
-	}
+	closeErr := closeAttachSocket(tmpPath, s, nspid)
 	s = -1
-	if err := j.unlockNotificationFiles(notifyCount); err != nil {
-		return nil, fmt.Errorf("could not unlock OpenJ9 notification files: %w", err)
+	if closeErr != nil {
+		return nil, fmt.Errorf("could not close attach socket: %w", closeErr)
 	}
-	if err := notifySemaphore(tmpPath, -1, notifyCount); err != nil {
-		return nil, fmt.Errorf("could not release OpenJ9 notify semaphore: %w", err)
-	}
+
+	notifyErr := j.releaseNotificationFiles(tmpPath, notifyCount)
 	notifyCount = 0
-	if err := releaseLock(attachLock); err != nil {
-		return nil, fmt.Errorf("could not release OpenJ9 attach lock: %w", err)
+	if notifyErr != nil {
+		return nil, fmt.Errorf("could not release OpenJ9 notification files: %w", notifyErr)
 	}
+
+	releaseErr := releaseLock(attachLock)
 	attachLock = -1
+	if releaseErr != nil {
+		return nil, fmt.Errorf("could not release OpenJ9 attach lock: %w", releaseErr)
+	}
 
 	j.logger.Info("connected to remote JVM")
 

--- a/pkg/internal/jvmtools/jvm/cmd_openj9_test.go
+++ b/pkg/internal/jvmtools/jvm/cmd_openj9_test.go
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package jvm
+
+import (
+	"errors"
+	"log/slog"
+	"syscall"
+	"testing"
+)
+
+func TestNewJ9AttacherUsesNegativeFDSentinel(t *testing.T) {
+	attacher := newJ9Attacher(slog.Default())
+
+	if attacher.fd >= 0 {
+		t.Fatalf("expected negative fd sentinel, got %d", attacher.fd)
+	}
+}
+
+func TestWriteCommandPreservesSyscallError(t *testing.T) {
+	err := writeCommand(-1, "ATTACH_DETACHED")
+
+	if !errors.Is(err, syscall.EBADF) {
+		t.Fatalf("expected EBADF, got %v", err)
+	}
+}

--- a/pkg/internal/jvmtools/jvm/cmd_openj9_test.go
+++ b/pkg/internal/jvmtools/jvm/cmd_openj9_test.go
@@ -27,3 +27,16 @@ func TestWriteCommandPreservesSyscallError(t *testing.T) {
 		t.Fatalf("expected EBADF, got %v", err)
 	}
 }
+
+func TestJ9ReaderReadReturnsZeroCountOnSyscallError(t *testing.T) {
+	attacher := newJ9Attacher(slog.Default())
+	attacher.fd = 1 << 30
+
+	n, err := (&j9Reader{attacher: attacher}).Read(make([]byte, 1))
+	if n != 0 {
+		t.Fatalf("expected zero byte count, got %d", n)
+	}
+	if !errors.Is(err, syscall.EBADF) {
+		t.Fatalf("expected EBADF, got %v", err)
+	}
+}

--- a/pkg/internal/jvmtools/jvm/linux_tools.go
+++ b/pkg/internal/jvmtools/jvm/linux_tools.go
@@ -6,15 +6,15 @@
 package jvm // import "go.opentelemetry.io/obi/pkg/internal/jvmtools/jvm"
 
 import (
-	"syscall"
+	"errors"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
-	SYS_SEMGET = 64
-	SYS_SEMOP  = 65
-	IPC_CREAT  = 01000
-	IPC_NOWAIT = 04000
+	ipcCreate = unix.IPC_CREAT
+	ipcNoWait = unix.IPC_NOWAIT
 )
 
 type sembuf struct {
@@ -25,7 +25,7 @@ type sembuf struct {
 
 // System V semaphore operations for Linux
 func semget(key, nsems, semflg int) (int, error) {
-	r1, _, errno := syscall.Syscall(SYS_SEMGET, uintptr(key), uintptr(nsems), uintptr(semflg))
+	r1, _, errno := unix.Syscall(unix.SYS_SEMGET, uintptr(key), uintptr(nsems), uintptr(semflg))
 	if int(r1) == -1 {
 		return -1, errno
 	}
@@ -33,7 +33,11 @@ func semget(key, nsems, semflg int) (int, error) {
 }
 
 func semop(semid int, sops []sembuf) error {
-	_, _, errno := syscall.Syscall(SYS_SEMOP, uintptr(semid), uintptr(unsafe.Pointer(&sops[0])), uintptr(len(sops)))
+	if len(sops) == 0 {
+		return errors.New("semop requires at least one operation")
+	}
+
+	_, _, errno := unix.Syscall(unix.SYS_SEMOP, uintptr(semid), uintptr(unsafe.Pointer(&sops[0])), uintptr(len(sops)))
 	if errno != 0 {
 		return errno
 	}
@@ -52,8 +56,8 @@ func createSembuf(num uint16, op int16, flg int16) sembuf {
 // the least significant 8 bits of proj_id (which must be nonzero) to generate
 // a key_t type System V IPC key.
 func ftok(pathname string, projectid uint8) (int, error) {
-	var stat = syscall.Stat_t{}
-	if err := syscall.Stat(pathname, &stat); err != nil {
+	var stat unix.Stat_t
+	if err := unix.Stat(pathname, &stat); err != nil {
 		return 0, err
 	}
 	return int(uint(projectid&0xff)<<24 | uint((stat.Dev&0xff)<<16) | (uint(stat.Ino) & 0xffff)), nil

--- a/pkg/internal/jvmtools/jvm/linux_tools.go
+++ b/pkg/internal/jvmtools/jvm/linux_tools.go
@@ -12,11 +12,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const (
-	ipcCreate = unix.IPC_CREAT
-	ipcNoWait = unix.IPC_NOWAIT
-)
-
 type sembuf struct {
 	Num uint16
 	Op  int16

--- a/pkg/internal/jvmtools/jvm/linux_tools_test.go
+++ b/pkg/internal/jvmtools/jvm/linux_tools_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package jvm
+
+import "testing"
+
+func TestSemopRejectsEmptyOperations(t *testing.T) {
+	if err := semop(0, nil); err == nil {
+		t.Fatal("expected empty semop to fail")
+	}
+}

--- a/pkg/internal/jvmtools/util/psutil.go
+++ b/pkg/internal/jvmtools/util/psutil.go
@@ -12,13 +12,13 @@ import (
 	"strconv"
 	"strings"
 
-	syscall "golang.org/x/sys/unix"
+	"golang.org/x/sys/unix"
 )
 
 // Constants
 const MaxPath = 4096
 
-// Called just once to fill in tmpPath buffer
+// GetTmpPath returns the target JVM temporary directory path.
 func GetTmpPath(pid int) string {
 	var tmpPath string
 	// Try user-provided alternative path first
@@ -56,17 +56,18 @@ func GetProcessInfo(pid int, uid *int, gid *int, nspid *int) error {
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "Uid:") {
+		switch {
+		case strings.HasPrefix(line, "Uid:"):
 			fields := strings.Fields(line[4:])
 			if len(fields) > 1 {
 				*uid = int(parseUint32(fields[1]))
 			}
-		} else if strings.HasPrefix(line, "Gid:") {
+		case strings.HasPrefix(line, "Gid:"):
 			fields := strings.Fields(line[4:])
 			if len(fields) > 1 {
 				*gid = int(parseUint32(fields[1]))
 			}
-		} else if strings.HasPrefix(line, "NStgid:") {
+		case strings.HasPrefix(line, "NStgid:"):
 			fields := strings.Fields(line[7:])
 			if len(fields) > 0 {
 				*nspid = parseInt(fields[len(fields)-1])
@@ -111,9 +112,13 @@ func altLookupNspid(pid int) int {
 	}
 	defer dir.Close()
 
-	entries, _ := dir.Readdirnames(0)
+	entries, err := dir.Readdirnames(0)
+	if err != nil {
+		return pid
+	}
+
 	for _, entry := range entries {
-		if entry[0] >= '1' && entry[0] <= '9' {
+		if len(entry) > 0 && entry[0] >= '1' && entry[0] <= '9' {
 			// Check if /proc/<container-pid>/sched points back to <host-pid>
 			schedPath := fmt.Sprintf("/proc/%d/root/proc/%s/sched", pid, entry)
 			if schedGetHostPid(schedPath) == pid {
@@ -144,9 +149,27 @@ func schedGetHostPid(path string) int {
 	return -1
 }
 
+func namespaceFlag(nsType string) (int, bool) {
+	switch nsType {
+	case "net":
+		return unix.CLONE_NEWNET, true
+	case "ipc":
+		return unix.CLONE_NEWIPC, true
+	case "mnt":
+		return unix.CLONE_NEWNS, true
+	default:
+		return 0, false
+	}
+}
+
 func EnterNS(pid int, nsType string) int {
+	nsFlag, ok := namespaceFlag(nsType)
+	if !ok {
+		return -1
+	}
+
 	path := fmt.Sprintf("/proc/%d/ns/%s", pid, nsType)
-	selfPath := fmt.Sprintf("/proc/self/ns/%s", nsType)
+	selfPath := "/proc/self/ns/" + nsType
 
 	oldnsStat, _ := os.Stat(selfPath)
 	newnsStat, _ := os.Stat(path)
@@ -161,7 +184,7 @@ func EnterNS(pid int, nsType string) int {
 	defer newns.Close()
 
 	// Some ancient Linux distributions do not have setns() function
-	if _, _, err := syscall.RawSyscall(syscall.SYS_SETNS, newns.Fd(), syscall.CLONE_NEWNET, 0); err != 0 {
+	if err := unix.Setns(int(newns.Fd()), nsFlag); err != nil {
 		return -1
 	}
 

--- a/pkg/internal/jvmtools/util/psutil_notlinux.go
+++ b/pkg/internal/jvmtools/util/psutil_notlinux.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package util // import "go.opentelemetry.io/obi/pkg/internal/jvmtools/util"
+
+import "errors"
+
+const MaxPath = 4096
+
+var errUnsupported = errors.New("jvmtools process helpers are only supported on linux")
+
+func GetTmpPath(_ int) string {
+	return ""
+}
+
+func GetProcessInfo(_ int, _ *int, _ *int, _ *int) error {
+	return errUnsupported
+}
+
+func EnterNS(_ int, _ string) int {
+	return -1
+}

--- a/pkg/internal/jvmtools/util/psutil_test.go
+++ b/pkg/internal/jvmtools/util/psutil_test.go
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package util
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestNamespaceFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		want int
+		ok   bool
+	}{
+		{name: "net", want: unix.CLONE_NEWNET, ok: true},
+		{name: "ipc", want: unix.CLONE_NEWIPC, ok: true},
+		{name: "mnt", want: unix.CLONE_NEWNS, ok: true},
+		{name: "pid", ok: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := namespaceFlag(test.name)
+			if ok != test.ok {
+				t.Fatalf("namespaceFlag(%q) ok = %v, want %v", test.name, ok, test.ok)
+			}
+			if got != test.want {
+				t.Fatalf("namespaceFlag(%q) = %d, want %d", test.name, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #2034 and #2307 for the copied `pkg/internal/jvmtools` fork.

This PR:

- removes the broad `pkg/internal/jvmtools` golangci exclusion by making the copied package pass repo lint
- fixes namespace switching to pass the matching `setns` namespace flag for `net`, `ipc`, and `mnt`
- uses architecture-provided Linux semaphore syscall constants and rejects empty `semop` operation slices
- preserves OpenJ9 write errors and propagates notify/cleanup failures instead of silently swallowing them
- changes OpenJ9 fd handling to use a negative disconnected sentinel and deterministic close/detach ownership
- closes HotSpot sockets on command-write failure
- adds non-Linux package stubs so `go list ./pkg/internal/jvmtools/...` works off Linux
- adds focused tests for namespace mapping, semaphore guard behavior, and OpenJ9 fd/write error handling

## Review Notes

I also re-reviewed the copied package beyond the #2307 follow-up checklist. Additional fixes included here:

- return/propagate namespace entry and cleanup failures from the attacher instead of ignoring them
- close the HotSpot connection if command writing fails
- prevent OpenJ9 accepted-fd leaks on setup errors after `accept`
- fix the deferred OpenJ9 attach-lock cleanup so it does not release fd `-1` after the success path already released the lock
- handle replyInfo writes, random-key reads, socket timeout setup/reset, and notification release errors explicitly

## Validation

- `make generate`
- `go test ./pkg/internal/jvmtools/...`
- `env GOOS=darwin go list ./pkg/internal/jvmtools/...`
- `env GOOS=darwin go test ./pkg/internal/jvmtools/...`
- `env GOARCH=arm64 go test -exec=/bin/true ./pkg/internal/jvmtools/...`
- `env GOCACHE=/tmp/obi-go-build GOLANGCI_LINT_CACHE=/tmp/obi-golangci-cache go tool -modfile=/home/tyler/.codex/worktrees/6481/obi/internal/tools/go.mod golangci-lint run ./pkg/internal/jvmtools/... --timeout=6m`
- `make license-header-check`
- `make vanity-import-check`