### PR TITLE
(DynamicSelector-Phase3) Refactor DynamicPIDSelector into signal-aware views

### DIFF
--- a/pkg/appolly/discover/dynamic_pid_selector.go
+++ b/pkg/appolly/discover/dynamic_pid_selector.go
@@ -5,6 +5,7 @@ package discover // import "go.opentelemetry.io/obi/pkg/appolly/discover"
 
 import (
 	"iter"
+	"slices"
 	"sync"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
@@ -13,177 +14,329 @@ import (
 	"go.opentelemetry.io/obi/pkg/selection"
 )
 
-var _ selection.PIDSelector = (*DynamicPIDSelector)(nil)
+type dynamicPIDSignal uint8
 
-// DynamicPIDSelector holds the runtime set of target PIDs for OBI. It is preloaded from
-// config target_pids and updated at runtime via AddPIDs/RemovePIDs. The discover matcher
-// uses it for matching; embedders hold a reference via ContextInfo.DynamicPIDSelector
-// and call AddPIDs/RemovePIDs on the concrete selector directly.
-//
-// Pending add/remove PIDs are accumulated in slices and drained by goroutines into
-// RemovedNotify() and AddedPIDsNotify(), so callers never block and nothing is dropped.
-type DynamicPIDSelector struct {
-	mu   sync.RWMutex
-	pids []uint32
+const (
+	signalTraces dynamicPIDSignal = 1 << iota
+	signalAppMetrics
+	signalNetworkMetrics
+	signalStatsMetrics
+)
 
-	removedCh      chan []app.PID // consumer receives from this
-	removedPending []app.PID      // PIDs to send on next drain
-	removedMu      sync.Mutex
-	removedCond    *sync.Cond
+const (
+	appSignalMask dynamicPIDSignal = signalTraces | signalAppMetrics
+	allSignalMask dynamicPIDSignal = appSignalMask | signalNetworkMetrics | signalStatsMetrics
+)
 
-	addedCh      chan []app.PID // consumer receives from this
-	addedPending []app.PID      // PIDs to send on next drain
+type dynamicPIDNotifier struct {
+	addedCh   chan []app.PID
+	removedCh chan []app.PID
+
+	addedPending []app.PID
 	addedMu      sync.Mutex
 	addedCond    *sync.Cond
+
+	removedPending []app.PID
+	removedMu      sync.Mutex
+	removedCond    *sync.Cond
 }
 
-// NewDynamicPIDSelector creates a new dynamic PID selector (initially empty).
-// It starts goroutines that drain pending add/remove PIDs to the notify channels.
+func newDynamicPIDNotifier() *dynamicPIDNotifier {
+	n := &dynamicPIDNotifier{
+		addedCh:   make(chan []app.PID, 1),
+		removedCh: make(chan []app.PID, 1),
+	}
+	n.addedCond = sync.NewCond(&n.addedMu)
+	n.removedCond = sync.NewCond(&n.removedMu)
+	go n.drainAdded()
+	go n.drainRemoved()
+	return n
+}
+
+func (n *dynamicPIDNotifier) notifyAdded(pids []app.PID) {
+	if len(pids) == 0 {
+		return
+	}
+	n.addedMu.Lock()
+	n.addedPending = append(n.addedPending, pids...)
+	n.addedCond.Signal()
+	n.addedMu.Unlock()
+}
+
+func (n *dynamicPIDNotifier) notifyRemoved(pids []app.PID) {
+	if len(pids) == 0 {
+		return
+	}
+	n.removedMu.Lock()
+	n.removedPending = append(n.removedPending, pids...)
+	n.removedCond.Signal()
+	n.removedMu.Unlock()
+}
+
+func (n *dynamicPIDNotifier) drainAdded() {
+	for {
+		n.addedMu.Lock()
+		for len(n.addedPending) == 0 {
+			n.addedCond.Wait()
+		}
+		batch := append([]app.PID(nil), n.addedPending...)
+		n.addedPending = n.addedPending[:0]
+		n.addedMu.Unlock()
+		n.addedCh <- batch
+	}
+}
+
+func (n *dynamicPIDNotifier) drainRemoved() {
+	for {
+		n.removedMu.Lock()
+		for len(n.removedPending) == 0 {
+			n.removedCond.Wait()
+		}
+		batch := append([]app.PID(nil), n.removedPending...)
+		n.removedPending = n.removedPending[:0]
+		n.removedMu.Unlock()
+		n.removedCh <- batch
+	}
+}
+
+type dynamicPIDSignalView struct {
+	parent   *DynamicPIDSelector
+	mask     dynamicPIDSignal
+	notifier *dynamicPIDNotifier
+}
+
+func (v *dynamicPIDSignalView) AddPIDs(pids ...uint32) {
+	v.parent.addSignals(v.mask, pids...)
+}
+
+func (v *dynamicPIDSignalView) RemovePIDs(pids ...uint32) {
+	v.parent.removeSignals(v.mask, pids...)
+}
+
+func (v *dynamicPIDSignalView) GetPIDs() ([]app.PID, bool) {
+	return v.parent.getPIDs(v.mask)
+}
+
+func (v *dynamicPIDSignalView) IncludesPID(pid app.PID) bool {
+	return v.parent.includesPID(v.mask, pid)
+}
+
+func (v *dynamicPIDSignalView) AddedPIDsNotify() <-chan []app.PID {
+	return v.notifier.addedCh
+}
+
+func (v *dynamicPIDSignalView) RemovedNotify() <-chan []app.PID {
+	return v.notifier.removedCh
+}
+
+// AsSelector returns a services.Selector that matches when the process PID is in this dynamic view.
+func (v *dynamicPIDSignalView) AsSelector() services.Selector {
+	return &dynamicPIDCriteriaAdapter{selector: v}
+}
+
+// DynamicPIDSelector holds one runtime selector object with per-signal PID views. The root Add/Remove
+// methods preserve legacy behavior by applying to all supported signals.
+type DynamicPIDSelector struct {
+	mu    sync.RWMutex
+	byPID map[app.PID]dynamicPIDSignal
+
+	rootView           dynamicPIDSignalView
+	tracesView         dynamicPIDSignalView
+	appMetricsView     dynamicPIDSignalView
+	networkMetricsView dynamicPIDSignalView
+	statsMetricsView   dynamicPIDSignalView
+	appSignalsView     dynamicPIDSignalView
+}
+
+var _ selection.MultiSignalPIDSelector = (*DynamicPIDSelector)(nil)
+
+func newDynamicPIDSignalView(parent *DynamicPIDSelector, mask dynamicPIDSignal) dynamicPIDSignalView {
+	return dynamicPIDSignalView{
+		parent:   parent,
+		mask:     mask,
+		notifier: newDynamicPIDNotifier(),
+	}
+}
+
+// NewDynamicPIDSelector creates a new selector whose root Add/Remove methods apply to all signals.
 func NewDynamicPIDSelector() *DynamicPIDSelector {
 	d := &DynamicPIDSelector{
-		removedCh: make(chan []app.PID, 1),
-		addedCh:   make(chan []app.PID, 1),
+		byPID: map[app.PID]dynamicPIDSignal{},
 	}
-	d.removedCond = sync.NewCond(&d.removedMu)
-	d.addedCond = sync.NewCond(&d.addedMu)
-	go d.drainRemoved()
-	go d.drainAdded()
+	d.rootView = newDynamicPIDSignalView(d, allSignalMask)
+	d.tracesView = newDynamicPIDSignalView(d, signalTraces)
+	d.appMetricsView = newDynamicPIDSignalView(d, signalAppMetrics)
+	d.networkMetricsView = newDynamicPIDSignalView(d, signalNetworkMetrics)
+	d.statsMetricsView = newDynamicPIDSignalView(d, signalStatsMetrics)
+	d.appSignalsView = newDynamicPIDSignalView(d, appSignalMask)
 	return d
 }
 
-// RemovedNotify returns the channel on which removed PIDs are sent when RemovePIDs is called.
-// The matcher uses this to emit synthetic deletes. Safe to call from multiple goroutines.
-func (d *DynamicPIDSelector) RemovedNotify() <-chan []app.PID {
-	return d.removedCh
+func (d *DynamicPIDSelector) views() []*dynamicPIDSignalView {
+	return []*dynamicPIDSignalView{
+		&d.rootView,
+		&d.tracesView,
+		&d.appMetricsView,
+		&d.networkMetricsView,
+		&d.statsMetricsView,
+		&d.appSignalsView,
+	}
 }
 
-// AddedPIDsNotify returns the channel on which newly added PIDs are sent when AddPIDs is called.
-// The process watcher uses this to forget those PIDs from its tracked state so they are re-emitted
-// as new on the next poll (supporting adding an already-seen process to the dynamic set).
-func (d *DynamicPIDSelector) AddedPIDsNotify() <-chan []app.PID {
-	return d.addedCh
+func (d *DynamicPIDSelector) addSignals(mask dynamicPIDSignal, pids ...uint32) {
+	if len(pids) == 0 {
+		return
+	}
+	addedByView := map[*dynamicPIDSignalView][]app.PID{}
+
+	d.mu.Lock()
+	for _, rawPID := range pids {
+		pid := app.PID(rawPID)
+		oldMask := d.byPID[pid]
+		newMask := oldMask | mask
+		if newMask == oldMask {
+			continue
+		}
+		d.byPID[pid] = newMask
+		for _, view := range d.views() {
+			if !view.contains(oldMask) && view.contains(newMask) {
+				addedByView[view] = append(addedByView[view], pid)
+			}
+		}
+	}
+	d.mu.Unlock()
+
+	for view, batch := range addedByView {
+		view.notifier.notifyAdded(batch)
+	}
 }
 
-// GetPIDs returns a copy of the current PID list and true when non-empty.
-func (d *DynamicPIDSelector) GetPIDs() ([]app.PID, bool) {
+func (d *DynamicPIDSelector) removeSignals(mask dynamicPIDSignal, pids ...uint32) {
+	if len(pids) == 0 {
+		return
+	}
+	removedByView := map[*dynamicPIDSignalView][]app.PID{}
+
+	d.mu.Lock()
+	for _, rawPID := range pids {
+		pid := app.PID(rawPID)
+		oldMask, ok := d.byPID[pid]
+		if !ok {
+			continue
+		}
+		newMask := oldMask &^ mask
+		if newMask == oldMask {
+			continue
+		}
+		if newMask == 0 {
+			delete(d.byPID, pid)
+		} else {
+			d.byPID[pid] = newMask
+		}
+		for _, view := range d.views() {
+			if view.contains(oldMask) && !view.contains(newMask) {
+				removedByView[view] = append(removedByView[view], pid)
+			}
+		}
+	}
+	d.mu.Unlock()
+
+	for view, batch := range removedByView {
+		view.notifier.notifyRemoved(batch)
+	}
+}
+
+func (d *DynamicPIDSelector) getPIDs(mask dynamicPIDSignal) ([]app.PID, bool) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	if len(d.pids) == 0 {
+	if len(d.byPID) == 0 {
 		return nil, false
 	}
-	out := make([]app.PID, len(d.pids))
-	for i, p := range d.pids {
-		out[i] = app.PID(p)
+	out := make([]app.PID, 0, len(d.byPID))
+	for pid, signals := range d.byPID {
+		if signals&mask != 0 {
+			out = append(out, pid)
+		}
 	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	slices.Sort(out)
 	return out, true
 }
 
-// AddPIDs adds PIDs to the set (deduplicated). Newly added PIDs are sent on AddedPIDsNotify()
-// so the process watcher can forget them and re-emit them as new on the next poll.
+func (d *DynamicPIDSelector) includesPID(mask dynamicPIDSignal, pid app.PID) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.byPID[pid]&mask != 0
+}
+
+func (v *dynamicPIDSignalView) contains(mask dynamicPIDSignal) bool {
+	return mask&v.mask != 0
+}
+
+// AddPIDs adds PIDs to all supported signals (legacy root behavior).
 func (d *DynamicPIDSelector) AddPIDs(pids ...uint32) {
-	if len(pids) == 0 {
-		return
-	}
-	d.mu.Lock()
-	existing := make(map[uint32]struct{}, len(d.pids))
-	for _, p := range d.pids {
-		existing[p] = struct{}{}
-	}
-	var added []app.PID
-	for _, u := range pids {
-		if _, ok := existing[u]; !ok {
-			existing[u] = struct{}{}
-			d.pids = append(d.pids, u)
-			added = append(added, app.PID(u))
-		}
-	}
-	d.mu.Unlock()
-	d.notifyAdded(added)
+	d.rootView.AddPIDs(pids...)
 }
 
-// RemovePIDs removes PIDs from the set and sends them on RemovedNotify() for the matcher.
+// RemovePIDs removes PIDs from all supported signals (legacy root behavior).
 func (d *DynamicPIDSelector) RemovePIDs(pids ...uint32) {
-	if len(pids) == 0 {
-		return
-	}
-	toRemove := make(map[uint32]struct{})
-	for _, u := range pids {
-		toRemove[u] = struct{}{}
-	}
-	d.mu.Lock()
-	newPids := d.pids[:0]
-	removedPIDs := make([]app.PID, 0, len(pids))
-	for _, p := range d.pids {
-		if _, remove := toRemove[p]; !remove {
-			newPids = append(newPids, p)
-			continue
-		}
-		removedPIDs = append(removedPIDs, app.PID(p))
-	}
-	d.pids = newPids
-	d.mu.Unlock()
-	d.notifyRemoved(removedPIDs)
+	d.rootView.RemovePIDs(pids...)
 }
 
-func (d *DynamicPIDSelector) notifyRemoved(removedPIDs []app.PID) {
-	if len(removedPIDs) == 0 {
-		return
-	}
-	d.removedMu.Lock()
-	d.removedPending = append(d.removedPending, removedPIDs...)
-	d.removedCond.Signal()
-	d.removedMu.Unlock()
+// GetPIDs returns PIDs selected for any supported signal.
+func (d *DynamicPIDSelector) GetPIDs() ([]app.PID, bool) {
+	return d.rootView.GetPIDs()
 }
 
-func (d *DynamicPIDSelector) notifyAdded(addedPIDs []app.PID) {
-	if len(addedPIDs) == 0 {
-		return
-	}
-	d.addedMu.Lock()
-	d.addedPending = append(d.addedPending, addedPIDs...)
-	d.addedCond.Signal()
-	d.addedMu.Unlock()
+// IncludesPID reports whether pid is selected for any supported signal.
+func (d *DynamicPIDSelector) IncludesPID(pid app.PID) bool {
+	return d.rootView.IncludesPID(pid)
 }
 
-// drainRemoved runs in a goroutine; it sends the current pending removed PIDs and clears the slice.
-func (d *DynamicPIDSelector) drainRemoved() {
-	for {
-		d.removedMu.Lock()
-		for len(d.removedPending) == 0 {
-			d.removedCond.Wait()
-		}
-		batch := append([]app.PID(nil), d.removedPending...)
-		d.removedPending = d.removedPending[:0]
-		d.removedMu.Unlock()
-		d.removedCh <- batch
-	}
+// AddedPIDsNotify returns the channel on which PIDs are sent when they enter the root view.
+func (d *DynamicPIDSelector) AddedPIDsNotify() <-chan []app.PID {
+	return d.rootView.AddedPIDsNotify()
 }
 
-// drainAdded runs in a goroutine; it sends the current pending added PIDs and clears the slice.
-func (d *DynamicPIDSelector) drainAdded() {
-	for {
-		d.addedMu.Lock()
-		for len(d.addedPending) == 0 {
-			d.addedCond.Wait()
-		}
-		batch := append([]app.PID(nil), d.addedPending...)
-		d.addedPending = d.addedPending[:0]
-		d.addedMu.Unlock()
-		d.addedCh <- batch
-	}
+// RemovedNotify returns the channel on which PIDs are sent when they leave the root view.
+func (d *DynamicPIDSelector) RemovedNotify() <-chan []app.PID {
+	return d.rootView.RemovedNotify()
 }
 
-// AsSelector returns a services.Selector that matches when the process PID is in this dynamic set.
-// The matcher uses it to treat runtime PIDs as a supplement to config criteria.
+// Traces returns the mutable selector view for trace signals.
+func (d *DynamicPIDSelector) Traces() selection.MutablePIDSelector {
+	return &d.tracesView
+}
+
+// AppMetrics returns the mutable selector view for application metrics signals.
+func (d *DynamicPIDSelector) AppMetrics() selection.MutablePIDSelector {
+	return &d.appMetricsView
+}
+
+// NetworkMetrics returns the mutable selector view for network metrics signals.
+func (d *DynamicPIDSelector) NetworkMetrics() selection.MutablePIDSelector {
+	return &d.networkMetricsView
+}
+
+// StatsMetrics returns the mutable selector view for stats metrics signals.
+func (d *DynamicPIDSelector) StatsMetrics() selection.MutablePIDSelector {
+	return &d.statsMetricsView
+}
+
+func (d *DynamicPIDSelector) appSignals() *dynamicPIDSignalView {
+	return &d.appSignalsView
+}
+
+// AsSelector preserves the legacy root-selector behavior.
 func (d *DynamicPIDSelector) AsSelector() services.Selector {
-	return &dynamicPIDCriteriaAdapter{d: d}
+	return d.rootView.AsSelector()
 }
 
-// dynamicPIDCriteriaAdapter implements services.Selector by delegating only GetPIDs to the
-// DynamicPIDSelector; all other methods return empty/zero so the matcher treats "PID in dynamic set"
-// as a match.
+// dynamicPIDCriteriaAdapter implements services.Selector by delegating only GetPIDs to a runtime PID selector.
 type dynamicPIDCriteriaAdapter struct {
-	d *DynamicPIDSelector
+	selector selection.PIDSelector
 }
 
 func (a *dynamicPIDCriteriaAdapter) GetName() string                       { return "" }
@@ -192,7 +345,7 @@ func (a *dynamicPIDCriteriaAdapter) GetPath() services.StringMatcher       { ret
 func (a *dynamicPIDCriteriaAdapter) GetPathRegexp() services.StringMatcher { return &emptyMatcher{} }
 func (a *dynamicPIDCriteriaAdapter) GetOpenPorts() *services.IntEnum       { return &services.IntEnum{} }
 func (a *dynamicPIDCriteriaAdapter) GetLanguages() services.StringMatcher  { return &emptyMatcher{} }
-func (a *dynamicPIDCriteriaAdapter) GetPIDs() ([]app.PID, bool)            { return a.d.GetPIDs() }
+func (a *dynamicPIDCriteriaAdapter) GetPIDs() ([]app.PID, bool)            { return a.selector.GetPIDs() }
 func (a *dynamicPIDCriteriaAdapter) GetCmdArgs() services.StringMatcher    { return &emptyMatcher{} }
 func (a *dynamicPIDCriteriaAdapter) IsContainersOnly() bool                { return false }
 func (a *dynamicPIDCriteriaAdapter) RangeMetadata() iter.Seq2[string, services.StringMatcher] {

--- a/pkg/appolly/discover/dynamic_pid_selector_test.go
+++ b/pkg/appolly/discover/dynamic_pid_selector_test.go
@@ -73,6 +73,85 @@ func TestDynamicPIDSelector_AddPIDs_RemovePIDs_GetPIDs(t *testing.T) {
 	assert.Nil(t, pids)
 }
 
+func TestDynamicPIDSelector_Subviews(t *testing.T) {
+	d := NewDynamicPIDSelector()
+
+	d.Traces().AddPIDs(1, 2)
+	d.AppMetrics().AddPIDs(2, 3)
+	d.NetworkMetrics().AddPIDs(4)
+	d.StatsMetrics().AddPIDs(5)
+
+	rootPIDs, ok := d.GetPIDs()
+	require.True(t, ok)
+	assert.Equal(t, []app.PID{1, 2, 3, 4, 5}, rootPIDs)
+
+	tracesPIDs, ok := d.Traces().GetPIDs()
+	require.True(t, ok)
+	assert.Equal(t, []app.PID{1, 2}, tracesPIDs)
+
+	appMetricPIDs, ok := d.AppMetrics().GetPIDs()
+	require.True(t, ok)
+	assert.Equal(t, []app.PID{2, 3}, appMetricPIDs)
+
+	appSignalPIDs, ok := d.appSignals().GetPIDs()
+	require.True(t, ok)
+	assert.Equal(t, []app.PID{1, 2, 3}, appSignalPIDs)
+
+	assert.True(t, d.Traces().IncludesPID(1))
+	assert.False(t, d.Traces().IncludesPID(3))
+	assert.True(t, d.AppMetrics().IncludesPID(3))
+	assert.False(t, d.NetworkMetrics().IncludesPID(3))
+}
+
+func TestDynamicPIDSelector_AppUnionNotifications(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	tracesAdded := d.Traces().AddedPIDsNotify()
+	metricsAdded := d.AppMetrics().AddedPIDsNotify()
+	appAdded := d.appSignals().AddedPIDsNotify()
+	rootAdded := d.AddedPIDsNotify()
+
+	d.Traces().AddPIDs(42)
+	assert.Equal(t, []app.PID{42}, <-tracesAdded)
+	assert.Equal(t, []app.PID{42}, <-appAdded)
+	assert.Equal(t, []app.PID{42}, <-rootAdded)
+
+	d.AppMetrics().AddPIDs(42)
+	assert.Equal(t, []app.PID{42}, <-metricsAdded)
+	select {
+	case <-appAdded:
+		t.Fatal("expected no app-union add when PID already selected for traces")
+	default:
+	}
+	select {
+	case <-rootAdded:
+		t.Fatal("expected no root add when PID already selected by another signal")
+	default:
+	}
+
+	tracesRemoved := d.Traces().RemovedNotify()
+	metricsRemoved := d.AppMetrics().RemovedNotify()
+	appRemoved := d.appSignals().RemovedNotify()
+	rootRemoved := d.RemovedNotify()
+
+	d.Traces().RemovePIDs(42)
+	assert.Equal(t, []app.PID{42}, <-tracesRemoved)
+	select {
+	case <-appRemoved:
+		t.Fatal("expected no app-union remove while metrics still selected")
+	default:
+	}
+	select {
+	case <-rootRemoved:
+		t.Fatal("expected no root remove while another signal still selected")
+	default:
+	}
+
+	d.AppMetrics().RemovePIDs(42)
+	assert.Equal(t, []app.PID{42}, <-metricsRemoved)
+	assert.Equal(t, []app.PID{42}, <-appRemoved)
+	assert.Equal(t, []app.PID{42}, <-rootRemoved)
+}
+
 func TestDynamicPIDSelector_RemovePIDs_Notify(t *testing.T) {
 	d := NewDynamicPIDSelector()
 	d.AddPIDs(42, 100)

--- a/pkg/instrumenter/opts.go
+++ b/pkg/instrumenter/opts.go
@@ -13,9 +13,12 @@ import (
 // Option that override the instantiation of the instrumenter
 type Option func(info *global.ContextInfo)
 
-// WithDynamicPIDSelector passes the given dynamic PID selector into the shared runtime context.
-// The caller creates it with discover.NewDynamicPIDSelector(), passes it here, and then calls
-// AddPIDs/RemovePIDs/GetPIDs on the concrete selector directly.
+// WithDynamicPIDSelector passes the given dynamic PID selector into OBI. The caller creates it with
+// discover.NewDynamicPIDSelector(), passes it here, and then calls AddPIDs/RemovePIDs/GetPIDs on it
+// directly, or targets specific signals via subviews such as Traces(), AppMetrics(),
+// NetworkMetrics(), and StatsMetrics().
+//
+// Root AddPIDs/RemovePIDs preserve the legacy behavior and apply to all supported signals.
 func WithDynamicPIDSelector(sel *discover.DynamicPIDSelector) Option {
 	return func(info *global.ContextInfo) {
 		info.DynamicPIDSelector = sel

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -103,12 +103,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *obi.Config) (
 		return nil, fmt.Errorf("can't instantiate instrumentation pipeline: %w", err)
 	}
 
-	var sel *discover.DynamicPIDSelector
-	if v := ctxInfo.DynamicPIDSelector; v != nil {
-		if s, ok := v.(*discover.DynamicPIDSelector); ok {
-			sel = s
-		}
-	}
+	sel, _ := ctxInfo.DynamicPIDSelector.(*discover.DynamicPIDSelector)
 	// When sel is nil, finder gets nil: config target_pids are used as static criteria (FindingCriteria(cfg, false)).
 	instr := &Instrumenter{
 		config:             config,

--- a/pkg/pipe/global/context.go
+++ b/pkg/pipe/global/context.go
@@ -67,11 +67,9 @@ type ContextInfo struct {
 	// OTELMetricsExporter allows sharing the same OTEL exporter through diverse metrics export nodes (Application, Network...)
 	OTELMetricsExporter *otelcfg.MetricsExporterInstancer
 
-	// DynamicPIDSelector, when set, is the shared runtime PID set for dynamic instrumentation.
-	// The caller creates it (e.g. discover.NewDynamicPIDSelector()), passes it via
-	// instrumenter.WithDynamicPIDSelector, and calls AddPIDs/RemovePIDs/GetPIDs on the
-	// concrete implementation directly.
-	DynamicPIDSelector selection.PIDSelector
+	// DynamicPIDSelector, when set, restricts App O11y, NetO11y, and StatsO11y signals to
+	// the runtime-selected PIDs for each signal view. Pass via instrumenter.WithDynamicPIDSelector.
+	DynamicPIDSelector selection.MultiSignalPIDSelector
 }
 
 // AppO11y stores context information that is only required for application observability.

--- a/pkg/selection/dynamic_app_ips_test.go
+++ b/pkg/selection/dynamic_app_ips_test.go
@@ -29,6 +29,15 @@ func (s *stubPIDSelector) GetPIDs() ([]app.PID, bool) {
 	return out, true
 }
 
+func (s *stubPIDSelector) IncludesPID(pid app.PID) bool {
+	for _, p := range s.pids {
+		if p == pid {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *stubPIDSelector) AddedPIDsNotify() <-chan []app.PID { return s.addedCh }
 func (s *stubPIDSelector) RemovedNotify() <-chan []app.PID   { return s.removed }
 

--- a/pkg/selection/pid_selector.go
+++ b/pkg/selection/pid_selector.go
@@ -7,10 +7,28 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 )
 
-// PIDSelector is the read-only contract for runtime dynamic PID membership.
-// Implementations notify subscribers when PIDs enter or leave the selected set.
+// PIDSelector is the read-only contract for runtime dynamic PID membership in one signal view.
+// Implementations notify subscribers when PIDs enter or leave the view.
 type PIDSelector interface {
 	GetPIDs() ([]app.PID, bool)
+	IncludesPID(app.PID) bool
 	AddedPIDsNotify() <-chan []app.PID
 	RemovedNotify() <-chan []app.PID
+}
+
+// MutablePIDSelector allows callers to add or remove runtime PIDs for a given signal view.
+type MutablePIDSelector interface {
+	PIDSelector
+	AddPIDs(...uint32)
+	RemovePIDs(...uint32)
+}
+
+// MultiSignalPIDSelector exposes one root selector with subviews for each supported signal.
+// *discover.DynamicPIDSelector implements this interface.
+type MultiSignalPIDSelector interface {
+	MutablePIDSelector
+	Traces() MutablePIDSelector
+	AppMetrics() MutablePIDSelector
+	NetworkMetrics() MutablePIDSelector
+	StatsMetrics() MutablePIDSelector
 }


### PR DESCRIPTION
## Summary

This implements phase 3 of https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2234

Previous PRs:
1. https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2250
2. https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2279

This refactors the DynamicSelector backend implementation into signal specific views, introducing hierarchical interfaces that support the following uses:

```go
sel := discover.NewDynamicPIDSelector()
sel.Traces().AddPIDs(1234)           // traces only
sel.NetworkMetrics().AddPIDs(5678)   // network metrics only
sel.AddPIDs(9999)                    // all signals (legacy root behavior)
```

These signal specific paths are not enforced yet (everything is still global), they will be in the next phase

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
