### PR TITLE
Restrict `/all-vm-tests` to users with write permission and prevent Docker secret exposure on dispatched refs

### DIFF
--- a/.github/workflows/slash_command_all_vm_tests.yml
+++ b/.github/workflows/slash_command_all_vm_tests.yml
@@ -1,7 +1,7 @@
 name: "Slash: /all-vm-tests"
 
 # Listens for /all-vm-tests on PR comments. Validates commenter has write
-# access, resolves PR head SHA, then dispatches Integration tests VM with
+# access, verifies actual write permission, resolves PR head SHA, then dispatches Integration tests VM with
 # all_kernels=true. Posts a reply with the run URL.
 on:
   issue_comment:
@@ -24,9 +24,34 @@ jobs:
        github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     permissions:
-      actions: write       # dispatch the VM workflow
-      pull-requests: write # comment back with run URL
+      actions: write        # dispatch the VM workflow
+      # The collaborator permission lookup uses the token's implicit metadata read access.
+      # issues:write covers both the acknowledgement reaction and the run URL comment.
+      issues: write
+      pull-requests: read   # resolve PR metadata
     steps:
+      - name: Check commenter permission
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+        run: |
+          PERMISSION=$(gh api "repos/${OWNER}/${REPO}/collaborators/${COMMENTER}/permission" --jq .permission 2>/dev/null || true)
+          if [ -z "${PERMISSION}" ]; then
+            echo "could not verify ${COMMENTER}'s repository permission; /all-vm-tests requires write permission" >&2
+            exit 1
+          fi
+
+          case "${PERMISSION}" in
+            admin|maintain|write)
+              ;;
+            *)
+              echo "${COMMENTER} has ${PERMISSION:-no} permission, but /all-vm-tests requires write permission" >&2
+              exit 1
+              ;;
+          esac
+
       - name: React with eyes (acknowledge command)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -106,20 +106,21 @@ jobs:
       - name: Check for Docker Hub token
         id: check-docker-token
         run: |
-          if [ -n "${DOCKER_TOKEN}" ]; then
+          if [ "${ALLOW_DOCKER_TOKEN}" = "true" ] && [ -n "${DOCKER_TOKEN}" ]; then
             echo "has_token=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_token=false" >> "$GITHUB_OUTPUT"
           fi
         env:
-          DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION }}
+          DOCKER_TOKEN: ${{ (github.event_name != 'workflow_dispatch' || !inputs.ref) && secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION || '' }}
+          ALLOW_DOCKER_TOKEN: ${{ github.event_name != 'workflow_dispatch' || !inputs.ref }}
 
       - name: Log in to Docker Hub
         if: steps.check-docker-token.outputs.has_token == 'true'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ vars.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION }}
+          password: ${{ (github.event_name != 'workflow_dispatch' || !inputs.ref) && secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION || '' }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 # zizmor: ignore[cache-poisoning] go.sum verifies module integrity


### PR DESCRIPTION
### Motivation

- Prevent a malicious PR from causing repository secrets to be exposed by a slash-command that dispatched a privileged workflow using a PR head `ref` and then checked out and executed PR-controlled code.
- Ensure the slash-command only runs when the commenter has actual repository write/admin/maintain permission rather than relying on `author_association` alone.
- Avoid performing secret-backed Docker login when the VM integration workflow is run via `workflow_dispatch` with an arbitrary `ref` to stop dispatched runs from receiving `DOCKER_TOKEN_EBPF_INSTRUMENTATION` when they will execute untrusted code.

### Description

- In `.github/workflows/slash_command_all_vm_tests.yml` changed job permissions to the minimal needed (`actions: write`, `issues: write`, `pull-requests: read`) and added a live permission check step that calls the GitHub API via `gh api repos/{owner}/{repo}/collaborators/{user}/permission` and requires `admin|maintain|write` before continuing. 
- In `.github/workflows/workflow_integration_tests_vm.yml` added an `ALLOW_DOCKER_TOKEN` guard computed as `github.event_name != 'workflow_dispatch' || inputs.ref == ''` and used it to gate the Docker Hub login step so that `secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION` is not applied to manually-dispatched runs that reference an arbitrary `ref`.
- Kept the dispatch behavior (the slash command still resolves the PR head SHA and dispatches the VM workflow) but added the above authorization and secret-safety controls to eliminate the secret-exposure attack surface.

### Testing

- Parsed both workflows with Ruby YAML (`ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) ... }'`) to ensure the modified files are valid YAML and parsing succeeded. 
