### PR TITLE
Fix top-level JSON fallback extraction

### DIFF
--- a/pkg/ebpf/common/http/partial_json.go
+++ b/pkg/ebpf/common/http/partial_json.go
@@ -5,12 +5,11 @@ package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
-	"regexp"
 	"strings"
-	"sync"
 
 	jsoniter "github.com/json-iterator/go"
 
@@ -20,27 +19,16 @@ import (
 var jsonBestEffort = jsoniter.ConfigCompatibleWithStandardLibrary
 
 const (
-	// modelSearchWindow limits model-field regex to the start of the body so
-	// we don't match "model" keys inside user prompts or message content.
+	// modelSearchWindow limits extraction for top-level request model
+	// fields to the start of the request payload.
 	modelSearchWindow = 200
-	// responseHeaderSearchWindow limits regex extraction for top-level response
-	// fields (id, model, object) so we don't match nested values in payloads.
+	// responseHeaderSearchWindow limits extraction for top-level response
+	// fields (id, model, object) to the start of the response payload.
 	responseHeaderSearchWindow = 800
 )
 
-var jsonStringFieldRegexpCache sync.Map
-
-func jsonStringFieldRegexp(field string) *regexp.Regexp {
-	if cached, ok := jsonStringFieldRegexpCache.Load(field); ok {
-		return cached.(*regexp.Regexp)
-	}
-	re := regexp.MustCompile(`"` + field + `"\s*:\s*"([^"]+)"`)
-	actual, _ := jsonStringFieldRegexpCache.LoadOrStore(field, re)
-	return actual.(*regexp.Regexp)
-}
-
-// extractJSONStringField returns the string value for a top-level JSON field
-// using regex. window limits the search range; 0 searches the full body.
+// extractJSONStringField returns the string value for a top-level JSON field.
+// window limits the search range; 0 searches the full body.
 func extractJSONStringField(body []byte, field string, window int) string {
 	if len(body) == 0 {
 		return ""
@@ -49,18 +37,81 @@ func extractJSONStringField(body []byte, field string, window int) string {
 	if window > 0 && len(search) > window {
 		search = search[:window]
 	}
-	if matches := jsonStringFieldRegexp(field).FindSubmatch(search); len(matches) == 2 {
-		return strings.TrimSpace(string(matches[1]))
+
+	dec := json.NewDecoder(bytes.NewReader(search))
+	root, err := dec.Token()
+	if err != nil || root != json.Delim('{') {
+		return ""
 	}
+
+	for dec.More() {
+		keyToken, err := dec.Token()
+		if err != nil {
+			return ""
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return ""
+		}
+
+		if key != field {
+			if err := skipJSONValue(dec); err != nil {
+				return ""
+			}
+			continue
+		}
+
+		value, err := dec.Token()
+		if err != nil {
+			return ""
+		}
+		if value, ok := value.(string); ok {
+			return strings.TrimSpace(value)
+		}
+		return ""
+	}
+
 	return ""
 }
 
-// extractModelField tries the early body window first, then the full captured
-// prefix. Used only when jsoniter could not reach model before truncation.
-func extractModelField(body []byte) string {
-	if model := extractJSONStringField(body, "model", modelSearchWindow); model != "" {
-		return model
+func skipJSONValue(dec *json.Decoder) error {
+	value, err := dec.Token()
+	if err != nil {
+		return err
 	}
+
+	delim, ok := value.(json.Delim)
+	if !ok {
+		return nil
+	}
+
+	switch delim {
+	case '{':
+		for dec.More() {
+			if _, err := dec.Token(); err != nil {
+				return err
+			}
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+		}
+	case '[':
+		for dec.More() {
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+		}
+	default:
+		return nil
+	}
+
+	_, err = dec.Token()
+	return err
+}
+
+// extractModelField searches the top-level model field in the captured body.
+// Used only when jsoniter could not reach model before truncation.
+func extractModelField(body []byte) string {
 	return extractJSONStringField(body, "model", 0)
 }
 

--- a/pkg/ebpf/common/http/partial_json_test.go
+++ b/pkg/ebpf/common/http/partial_json_test.go
@@ -4,6 +4,7 @@
 package ebpfcommon
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,8 +21,24 @@ func TestExtractModelField(t *testing.T) {
 
 func TestExtractJSONStringField_respectsWindow(t *testing.T) {
 	body := []byte(`{"nested":{"id":"inner"},"id":"outer"}`)
-	assert.Equal(t, "inner", extractJSONStringField(body, "id", 0))
-	assert.NotEmpty(t, extractJSONStringField(body, "id", 50))
+	assert.Equal(t, "outer", extractJSONStringField(body, "id", 0))
+	assert.Empty(t, extractJSONStringField(body, "id", 30))
+}
+
+func TestExtractJSONStringField_ignoresNestedField(t *testing.T) {
+	body := []byte(`{"nested":{"id":"inner","model":"attacker"},"id":"outer","model":"gpt-5-mini"}`)
+	assert.Equal(t, "outer", extractJSONStringField(body, "id", 0))
+	assert.Equal(t, "gpt-5-mini", extractModelField(body))
+}
+
+func TestExtractModelField_ignoresNestedModelWithoutTopLevel(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":{"model":"attacker"}}]}`)
+	assert.Empty(t, extractModelField(body))
+}
+
+func TestExtractModelField_ignoresNestedModelAfterSearchWindow(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"` + strings.Repeat("x", 220) + `","metadata":{"model":"attacker"}}]}`)
+	assert.Empty(t, extractModelField(body))
 }
 
 func TestParseOpenAIInput_truncated(t *testing.T) {

--- a/pkg/ebpf/common/http/rerank.go
+++ b/pkg/ebpf/common/http/rerank.go
@@ -61,21 +61,11 @@ func rerankProviderFromHost(req *http.Request) string {
 	return "unknown"
 }
 
-// extractModelFromPartialJSON attempts to extract the model field from
-// potentially truncated JSON using a simple regex.  This is a fallback
-// when standard json.Unmarshal fails due to eBPF buffer truncation.
-// Limits the search to the first modelSearchWindow bytes to avoid matching
-// "model" fields inside user-provided documents or query text.
+// extractModelFromPartialJSON attempts to extract the top-level model field
+// from potentially truncated JSON. This is a fallback when standard
+// json.Unmarshal fails due to eBPF buffer truncation.
 func extractModelFromPartialJSON(data []byte) string {
-	window := data
-	if len(window) > modelSearchWindow {
-		window = window[:modelSearchWindow]
-	}
-	m := modelFieldRegexp.FindSubmatch(window)
-	if m != nil {
-		return strings.TrimSpace(string(m[1]))
-	}
-	return ""
+	return extractJSONStringField(data, "model", modelSearchWindow)
 }
 
 // hasTopLevelRerankSignals uses a streaming JSON decoder to check for

--- a/pkg/ebpf/common/http/responses.go
+++ b/pkg/ebpf/common/http/responses.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 
 	"github.com/andybalholm/brotli"
@@ -59,13 +58,6 @@ func requestPath(req *http.Request) string {
 	}
 	return req.RequestURI
 }
-
-// modelFieldRegexp extracts the top-level "model" value from a (possibly
-// truncated) JSON request body.  It is a best-effort fallback used only when
-// json.Unmarshal cannot parse the body.  We limit the search window to
-// modelSearchWindow bytes so that we don't accidentally match a "model"
-// key buried inside a user prompt, message content, or document text.
-var modelFieldRegexp = regexp.MustCompile(`"model"\s*:\s*"([^"]+)"`)
 
 // getResponseBody tries to read the body as plain text and then
 // if it's encoded in compressed format, it tries to decompress


### PR DESCRIPTION
### Motivation

- A regex-based fallback scanned the captured request/response prefix for fields like `model` and `id` and could match nested, attacker-controlled keys, allowing injected values to surface as GenAI telemetry attributes. 
- The intent is to preserve best-effort parsing for truncated JSON while only promoting genuine top-level fields into telemetry. 
- The change prevents nested or late-occurring keys from being misinterpreted as top-level fields and thus reduces telemetry integrity/high-cardinality risk.

### Description

- Replace the unanchored regex fallback with a streaming JSON top-level extractor using `json.Decoder` that only returns string values for top-level keys and respects a configurable search `window`.
- Add `skipJSONValue(dec *json.Decoder)` to advance the decoder past non-matching values safely, and make `extractModelField` use the top-level extractor.
- Update `rerank` logic to reuse the new `extractJSONStringField` (removing the old `modelFieldRegexp` and `regexp` import) so rerank model fallback only considers top-level model keys in the request prefix.
- Add regression tests that assert nested `id`/`model` keys are ignored (including nested `model` after the previous search window) while preserving existing truncated top-level parsing behavior.

### Testing

- Ran targeted unit tests with `go test ./pkg/ebpf/common/http -run 'TestExtract|TestParse(OpenAI|Vendor|Anthropic|Embedding)'`, which passed. 
- Ran the full package tests with `go test ./pkg/ebpf/common/http`, which passed. 