### PR TITLE
Fix HTTP/2 HPACK traceparent plaintext bounds

### DIFF
--- a/bpf/generictracer/protocol_http2.h
+++ b/bpf/generictracer/protocol_http2.h
@@ -87,6 +87,9 @@ static __always_inline u8 parse_hpack_traceparent(const unsigned char *data,
         const u8 name_len_byte = data[i + 1];
 
         if (name_len_byte == k_hpack_tp_name_len) { // plaintext
+            if (i + k_h2_tp_hpack_size > data_len) {
+                continue;
+            }
             if (bpf_memcmp(
                     &data[i + k_hpack_tp_name_offset], k_hpack_tp_name, k_hpack_tp_name_len) != 0) {
                 continue;


### PR DESCRIPTION
### Motivation

- The HPACK traceparent parser could read a plaintext traceparent entry larger than the supplied HPACK block, which allows bytes outside the frame-local HPACK block to be interpreted as trace context.

### Description

- Add a frame-local bounds check in `parse_hpack_traceparent` to ensure `i + k_h2_tp_hpack_size <= data_len` before inspecting a plaintext traceparent entry in `bpf/generictracer/protocol_http2.h`, preventing reads past the provided `data_len`.

### Testing

- Built the C tests in `bpf/tests` via `make -C bpf/tests`, which succeeded.
