### PR TITLE
Add configurable hostname fetcher to NodeMeta

### DIFF
--- a/pkg/appolly/meta/meta_node.go
+++ b/pkg/appolly/meta/meta_node.go
@@ -26,10 +26,11 @@ func nslog() *slog.Logger {
 
 var connectionTimeout = 2 * time.Second
 
-// FallbackHostIDAttr, when non-empty, enables a hostname-based fallback
+// VendorHostnameAttr, when non-empty, enables a hostname-based fallback
 // for resource attribution. The hostname is resolved via FQDN lookup and stored
-// under this attribute name. Empty by default — vendors activate it by setting their own key
-var FallbackHostIDAttr = ""
+// as a Metadata entry under this attribute name, not in the HostID field.
+// Empty by default — vendors activate it by setting their own key.
+var VendorHostnameAttr = ""
 
 // some attributes from the node need to be filtered out, becausee ither
 // - they are not common to all the services and is going to be specified for each service instance

--- a/pkg/appolly/meta/meta_node.go
+++ b/pkg/appolly/meta/meta_node.go
@@ -26,6 +26,11 @@ func nslog() *slog.Logger {
 
 var connectionTimeout = 2 * time.Second
 
+// FallbackHostIDAttr, when non-empty, enables a hostname-based fallback
+// for resource attribution. The hostname is resolved via FQDN lookup and stored
+// under this attribute name. Empty by default — vendors activate it by setting their own key
+var FallbackHostIDAttr = ""
+
 // some attributes from the node need to be filtered out, becausee ither
 // - they are not common to all the services and is going to be specified for each service instance
 // - they are explicitly added later in the exporters and we don't want duplications
@@ -73,6 +78,7 @@ func NewNodeMeta(
 		// some fetchers will only retrieve the host name while others
 		// will retrieve also host attributes that will be merged
 		// in order of the priority below (the later the highest)
+		hostnameFetcher,
 		linuxLocalFetcher,
 		kubeNodeFetcher(kubeInformer),
 		otelNodeFetcher(azurevm.New()),

--- a/pkg/appolly/meta/meta_node_hostname.go
+++ b/pkg/appolly/meta/meta_node_hostname.go
@@ -12,22 +12,28 @@ import (
 )
 
 func hostnameFetcher(_ context.Context) (NodeMeta, error) {
-	if FallbackHostIDAttr == "" {
+	if VendorHostnameAttr == "" {
 		return NodeMeta{}, nil
 	}
 	resolver := hostname.CreateResolver("", "", true)
 	fullHostName, _, err := resolver.Query()
-	if err != nil || fullHostName == "" {
-		slog.Warn("can't resolve hostname for fallback",
+	if err != nil {
+		slog.Warn("can't resolve hostname for fallback attribute",
 			"component", "meta.hostnameFetcher",
-			"attribute", FallbackHostIDAttr,
+			"attribute", VendorHostnameAttr,
 			"error", err)
+		return NodeMeta{}, nil
+	}
+	if fullHostName == "" {
+		slog.Warn("resolved empty hostname for fallback attribute",
+			"component", "meta.hostnameFetcher",
+			"attribute", VendorHostnameAttr)
 		return NodeMeta{}, nil
 	}
 	return NodeMeta{
 		Metadata: []Entry{
 			{
-				Key:   attr.Name(FallbackHostIDAttr),
+				Key:   attr.Name(VendorHostnameAttr),
 				Value: fullHostName,
 			},
 		},

--- a/pkg/appolly/meta/meta_node_hostname.go
+++ b/pkg/appolly/meta/meta_node_hostname.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package meta // import "go.opentelemetry.io/obi/pkg/appolly/meta"
+
+import (
+	"context"
+	"log/slog"
+
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/internal/traces/hostname"
+)
+
+func hostnameFetcher(_ context.Context) (NodeMeta, error) {
+	if FallbackHostIDAttr == "" {
+		return NodeMeta{}, nil
+	}
+	resolver := hostname.CreateResolver("", "", true)
+	fullHostName, _, err := resolver.Query()
+	if err != nil || fullHostName == "" {
+		slog.Warn("can't resolve hostname for fallback",
+			"component", "meta.hostnameFetcher",
+			"attribute", FallbackHostIDAttr,
+			"error", err)
+		return NodeMeta{}, nil
+	}
+	return NodeMeta{
+		Metadata: []Entry{
+			{
+				Key:   attr.Name(FallbackHostIDAttr),
+				Value: fullHostName,
+			},
+		},
+	}, nil
+}

--- a/pkg/appolly/meta/meta_node_test.go
+++ b/pkg/appolly/meta/meta_node_test.go
@@ -91,6 +91,26 @@ func TestHostIDOverride(t *testing.T) {
 	assert.Equal(t, "host_override", nm.HostID)
 }
 
+func TestHostnameFetcher_Disabled(t *testing.T) {
+	FallbackHostIDAttr = ""
+	defer func() { FallbackHostIDAttr = "" }()
+
+	nm, err := hostnameFetcher(t.Context())
+	assert.NoError(t, err)
+	assert.Empty(t, nm.Metadata)
+}
+
+func TestHostnameFetcher_Enabled(t *testing.T) {
+	FallbackHostIDAttr = "test.host.id"
+	defer func() { FallbackHostIDAttr = "" }()
+
+	nm, err := hostnameFetcher(t.Context())
+	assert.NoError(t, err)
+	require.Len(t, nm.Metadata, 1)
+	assert.Equal(t, attr.Name("test.host.id"), nm.Metadata[0].Key)
+	assert.NotEmpty(t, nm.Metadata[0].Value)
+}
+
 func makeFetcherThatFailsNTimes(failCount int, key, value string) fetcher {
 	attempts := atomic.Int32{}
 	return func(_ context.Context) (NodeMeta, error) {

--- a/pkg/appolly/meta/meta_node_test.go
+++ b/pkg/appolly/meta/meta_node_test.go
@@ -92,8 +92,8 @@ func TestHostIDOverride(t *testing.T) {
 }
 
 func TestHostnameFetcher_Disabled(t *testing.T) {
-	FallbackHostIDAttr = ""
-	defer func() { FallbackHostIDAttr = "" }()
+	VendorHostnameAttr = ""
+	defer func() { VendorHostnameAttr = "" }()
 
 	nm, err := hostnameFetcher(t.Context())
 	assert.NoError(t, err)
@@ -101,8 +101,8 @@ func TestHostnameFetcher_Disabled(t *testing.T) {
 }
 
 func TestHostnameFetcher_Enabled(t *testing.T) {
-	FallbackHostIDAttr = "test.host.id"
-	defer func() { FallbackHostIDAttr = "" }()
+	VendorHostnameAttr = "test.host.id"
+	defer func() { VendorHostnameAttr = "" }()
 
 	nm, err := hostnameFetcher(t.Context())
 	assert.NoError(t, err)

--- a/pkg/appolly/meta/meta_node_test.go
+++ b/pkg/appolly/meta/meta_node_test.go
@@ -96,7 +96,7 @@ func TestHostnameFetcher_Disabled(t *testing.T) {
 	defer func() { VendorHostnameAttr = "" }()
 
 	nm, err := hostnameFetcher(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, nm.Metadata)
 }
 
@@ -105,7 +105,7 @@ func TestHostnameFetcher_Enabled(t *testing.T) {
 	defer func() { VendorHostnameAttr = "" }()
 
 	nm, err := hostnameFetcher(t.Context())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Len(t, nm.Metadata, 1)
 	assert.Equal(t, attr.Name("test.host.id"), nm.Metadata[0].Key)
 	assert.NotEmpty(t, nm.Metadata[0].Value)

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -1269,7 +1269,9 @@ func (r *metricsReporter) labelValuesSpans(span *request.Span) []string {
 	return values
 }
 
-func labelNamesTargetInfo(kubeEnabled, dockerEnabled bool, nodeMeta *meta.NodeMeta, extraMetadataLabelNames []attr.Name) []string {
+// baseTargetInfoNames is the shared source of truth for labelNamesTargetInfo and
+// labelValuesTargetInfo, ensuring both apply identical deduplication against nodeMeta.Metadata.
+func baseTargetInfoNames(kubeEnabled, dockerEnabled bool) []string {
 	names := []string{
 		hostIDKey,
 		hostNameKey,
@@ -1285,16 +1287,28 @@ func labelNamesTargetInfo(kubeEnabled, dockerEnabled bool, nodeMeta *meta.NodeMe
 		sourceKey,
 		osTypeKey,
 	}
-
 	if kubeEnabled {
 		names = appendK8sLabelNames(names)
 	}
 	if dockerEnabled {
 		names = appendDockerLabelNames(names)
 	}
+	return names
+}
 
+func labelNamesTargetInfo(kubeEnabled, dockerEnabled bool, nodeMeta *meta.NodeMeta, extraMetadataLabelNames []attr.Name) []string {
+	names := baseTargetInfoNames(kubeEnabled, dockerEnabled)
+
+	existing := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		existing[n] = struct{}{}
+	}
 	for _, entry := range nodeMeta.Metadata {
-		names = append(names, entry.Key.Prom())
+		prom := entry.Key.Prom()
+		if _, ok := existing[prom]; !ok {
+			names = append(names, prom)
+			existing[prom] = struct{}{}
+		}
 	}
 
 	for _, mdn := range extraMetadataLabelNames {
@@ -1329,8 +1343,16 @@ func (r *metricsReporter) labelValuesTargetInfo(service *svc.Attrs) []string {
 		values = appendDockerLabelValuesService(values, service)
 	}
 
+	existing := make(map[string]struct{})
+	for _, n := range baseTargetInfoNames(r.kubeEnabled, r.dockerEnabled) {
+		existing[n] = struct{}{}
+	}
 	for _, entry := range r.nodeMeta.Metadata {
-		values = append(values, entry.Value)
+		prom := entry.Key.Prom()
+		if _, ok := existing[prom]; !ok {
+			values = append(values, entry.Value)
+			existing[prom] = struct{}{}
+		}
 	}
 
 	for _, k := range r.extraMetadataLabels {


### PR DESCRIPTION
## Summary

- Adds `VendorHostnameAttr` variable (empty by default): vendors set this to their own attribute key to activate the fetcher
- Adds `hostnameFetcher` that resolves the machine hostname via FQDN lookup and injects it into `NodeMeta.Metadata` under the configured attribute name
- Registers `hostnameFetcher` first in the `NewNodeMeta()` chain (lowest priority, so cloud/kube fetchers take precedence)
- Uses `hostname.CreateResolver` for DNS-based resolution
- Refactors `labelNamesTargetInfo` and `labelValuesTargetInfo` to skip metadata entries that duplicate existing `target_info` label names

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->