### PR TITLE
Read bufWriter buf capacity field from correct address

### DIFF
--- a/bpf/gotracer/go_grpc.c
+++ b/bpf/gotracer/go_grpc.c
@@ -883,7 +883,7 @@ int obi_uprobe_grpcFramerWriteHeaders_returns(struct pt_regs *ctx) {
                 &cap,
                 sizeof(cap),
                 (void *)(w_ptr +
-                         go_offset_of(ot, (go_offset){.v = _grpc_transport_buf_writer_offset_pos}) +
+                         go_offset_of(ot, (go_offset){.v = _grpc_transport_buf_writer_buf_pos}) +
                          16)); // the offset of the capacity is 2 * 8 bytes from the buf
 
             bpf_clamp_umax(off, MAX_W_PTR_OFFSET);


### PR DESCRIPTION
## Summary

Go BPF probe for `traceparent` propagation was reading grpc buffer capacity from wrong field of `bufWriter` struct, as described in [issue 2300](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2300)

PR fixes this. Verified by adding temporary logs printing `cap` value.

Before: `app-a-314424  [001] ...11  6651.457452: bpf_trace_printk: grpcFramerWriteHeaders_returns: cap=11051512`
After: `app-a-202328  [000] ...11  5005.878517: bpf_trace_printk: grpcFramerWriteHeaders_returns: cap=32768` -> correct value

Verified that with the fix in this PR crashes from linked issue are gone.

## Validation

- [X ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ X] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
