### PR TITLE
CI: add AL2023 kernels to matrix

### DIFF
--- a/.github/workflows/bpf_verifier.yml
+++ b/.github/workflows/bpf_verifier.yml
@@ -109,6 +109,48 @@ jobs:
         with:
           artifact-name: bpf-generated-arm-${{ github.run_id }}
 
+  al2023:
+    name: Kernel al2023-${{ matrix.nvr }}
+    needs: generate-bpf
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - nvr: "6.1.172-216.329.amzn2023"
+            pkg: "kernel"
+          - nvr: "6.12.88-119.157.amzn2023"
+            pkg: "kernel6.12"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - uses: ./.github/actions/free-disk
+        with:
+          docker-prune: 'false'
+
+      - name: Download generated BPF files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bpf-generated-${{ github.run_id }}
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 # zizmor: ignore[cache-poisoning] go.sum verifies module integrity
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Install QEMU
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends qemu-utils qemu-system-x86 cpio
+
+      - name: Run BPF verifier on AL2023 kernel
+        env:
+          GOTOOLCHAIN: auto
+        run: sudo -E bash internal/test/vm/lvh/al2023/run.sh "${{ matrix.nvr }}" "${{ matrix.pkg }}"
+
   host-arm64:
     name: Host kernel (arm64)
     # Runs verifier suite directly on the runner's own kernel — no VM, no

--- a/internal/test/vm/lvh/al2023/Dockerfile
+++ b/internal/test/vm/lvh/al2023/Dockerfile
@@ -1,0 +1,41 @@
+# Extract vmlinuz + modules from an Amazon Linux 2023 kernel RPM.
+# Consumed by run.sh via `docker buildx build --output type=local`.
+# Build: --build-arg KERNEL_NVR=<version>-<release>.amzn2023
+#        --build-arg KERNEL_PKG=<kernel | kernel6.12 | ...>
+ARG KERNEL_NVR
+ARG KERNEL_PKG=kernel
+
+FROM amazonlinux:2023@sha256:267b42d61c8eb5537270b62ec97b73bb104708d9245d343b5eeb1d92f0f65d3d AS extract
+ARG KERNEL_NVR
+ARG KERNEL_PKG
+ARG TARGETARCH
+
+RUN dnf install -y --setopt=install_weak_deps=False cpio findutils && dnf clean all
+
+WORKDIR /work
+
+# Download kernel + modules-extra RPMs without installing, then unpack and
+# re-layout into /data/kernels/<KREL>/{boot,lib/modules} for the consumer.
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) RPM_ARCH=x86_64 ;; \
+        arm64) RPM_ARCH=aarch64 ;; \
+        *) echo "unsupported arch ${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    dnf install -y --downloadonly --downloaddir=/work \
+        "${KERNEL_PKG}-${KERNEL_NVR}.${RPM_ARCH}" \
+        "${KERNEL_PKG}-modules-extra-${KERNEL_NVR}.${RPM_ARCH}"; \
+    mkdir -p /work/extracted; cd /work/extracted; \
+    for rpm in /work/*.rpm; do rpm2cpio "$rpm" | cpio -idm 2>/dev/null; done; \
+    KREL="$(ls /work/extracted/lib/modules | head -1)"; \
+    [ -n "$KREL" ] || { echo "no kernel modules dir found" >&2; exit 1; }; \
+    mkdir -p "/data/kernels/${KREL}/boot" "/data/kernels/${KREL}/lib/modules"; \
+    cp "/work/extracted/lib/modules/${KREL}/vmlinuz" \
+       "/data/kernels/${KREL}/boot/vmlinuz-${KREL}" 2>/dev/null \
+      || cp "/work/extracted/boot/vmlinuz-${KREL}" \
+            "/data/kernels/${KREL}/boot/vmlinuz-${KREL}"; \
+    cp -a "/work/extracted/lib/modules/${KREL}" \
+          "/data/kernels/${KREL}/lib/modules/${KREL}"
+
+FROM scratch
+COPY --from=extract /data /data

--- a/internal/test/vm/lvh/al2023/run.sh
+++ b/internal/test/vm/lvh/al2023/run.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Run the BPF verifier test suite against an Amazon Linux 2023 kernel.
+#
+# AL2023 ships without CONFIG_NET_9P, so the standard launchvm 9p-virtfs
+# path doesn't apply. This script self-contains the entire flow:
+#   1. Extract vmlinuz + modules from AL2023 kernel RPM (Dockerfile here).
+#   2. Cross-compile verifier.test on the host (BPF .o files are
+#      go:embed'd via bpf2go, so the binary is fully self-contained).
+#   3. Pack a minimal initramfs (static busybox + verifier.test + tiny
+#      init that mounts /proc /sys /sys/fs/bpf, runs the binary, prints
+#      OBI-VERIFIER-RESULT: <exit> on the serial console, powers off).
+#   4. Boot the kernel with qemu, parse the result line.
+#
+# Usage: run.sh <kernel_nvr> [kernel_pkg]
+# Example: run.sh 6.1.172-216.329.amzn2023
+#          run.sh 6.12.88-119.157.amzn2023 kernel6.12
+set -euo pipefail
+
+KERNEL_NVR="${1:?usage: run.sh <kernel_nvr> [kernel_pkg]}"
+KERNEL_PKG="${2:-kernel}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# 1. Build the kernel-extract image and copy out vmlinuz + initramfs.
+KSTAGE="${WORKDIR}/kstage"
+mkdir -p "${KSTAGE}"
+echo "run.sh: extracting AL2023 kernel ${KERNEL_NVR} (${KERNEL_PKG})" >&2
+docker buildx build \
+    --platform linux/amd64 \
+    --build-arg "KERNEL_NVR=${KERNEL_NVR}" \
+    --build-arg "KERNEL_PKG=${KERNEL_PKG}" \
+    --output "type=local,dest=${KSTAGE}" \
+    "${SCRIPT_DIR}" >&2
+
+KVER_DIR="$(ls -d ${KSTAGE}/data/kernels/*/ | head -1)"
+KREL="$(basename "$KVER_DIR")"
+VMLINUZ="${KVER_DIR}boot/vmlinuz-${KREL}"
+
+# 2. Cross-compile the verifier test binary (self-contained, no /obi needed).
+TEST_BIN="${WORKDIR}/verifier.test"
+echo "run.sh: compiling verifier.test" >&2
+(cd "${REPO_ROOT}" && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go test -c -tags=bpf_verifier_tests \
+        -o "${TEST_BIN}" \
+        ./pkg/internal/ebpf/verifier/)
+
+# 3. Stage the initramfs.
+IRD="${WORKDIR}/initramfs"
+mkdir -p "${IRD}"/{bin,proc,sys,dev}
+mkdir -p "${IRD}/sys/fs/bpf" "${IRD}/sys/kernel/debug" "${IRD}/sys/kernel/tracing"
+
+# Static (musl) busybox so it runs without any libc.
+docker run --rm --platform linux/amd64 -v "${IRD}/bin":/out \
+    busybox:musl sh -c 'cp /bin/busybox /out/busybox' >&2
+
+cp "${TEST_BIN}" "${IRD}/verifier.test"
+chmod +x "${IRD}/verifier.test"
+
+cat > "${IRD}/init" <<'INIT'
+#!/bin/busybox sh
+/bin/busybox mount -t proc proc /proc
+/bin/busybox mount -t sysfs sysfs /sys
+/bin/busybox mount -t bpf bpf /sys/fs/bpf
+/bin/busybox mount -t tracefs tracefs /sys/kernel/tracing 2>/dev/null
+/bin/busybox mount -t debugfs debugfs /sys/kernel/debug 2>/dev/null
+/bin/busybox mount -t devtmpfs devtmpfs /dev 2>/dev/null
+ulimit -l unlimited 2>/dev/null
+echo "OBI-VERIFIER-BEGIN"
+/verifier.test -test.v
+RESULT=$?
+/bin/busybox sync
+echo "OBI-VERIFIER-RESULT: ${RESULT}"
+# Halt deterministically; /init returning would cause kernel panic.
+echo 1 > /proc/sys/kernel/sysrq 2>/dev/null
+echo o > /proc/sysrq-trigger 2>/dev/null
+/bin/busybox poweroff -f 2>/dev/null
+while :; do /bin/busybox sleep 1; done
+INIT
+chmod +x "${IRD}/init"
+
+IRD_IMG="${WORKDIR}/initramfs.cpio.gz"
+(cd "${IRD}" && find . | cpio -o -H newc 2>/dev/null | gzip -1) > "${IRD_IMG}"
+
+# 4. Boot.
+if [ -e /dev/kvm ]; then
+    ACCEL="-enable-kvm -cpu host"
+else
+    ACCEL="-accel tcg,thread=multi -cpu Skylake-Client"  # x86-64-v2 for AL2023 glibc
+fi
+QEMU_LOG="${WORKDIR}/qemu.log"
+echo "run.sh: launching qemu" >&2
+timeout 1500 qemu-system-x86_64 ${ACCEL} -m 2G -smp 2 \
+    -kernel "${VMLINUZ}" \
+    -initrd "${IRD_IMG}" \
+    -append "earlyprintk=ttyS0 console=ttyS0 panic=3 rdinit=/init" \
+    -no-reboot -nographic 2>&1 | tee "${QEMU_LOG}"
+
+RESULT="$(grep -oE 'OBI-VERIFIER-RESULT: [0-9]+' "${QEMU_LOG}" | tail -1 | awk '{print $NF}')"
+if [ -z "$RESULT" ]; then
+    echo "run.sh: no result line found in qemu output" >&2
+    exit 1
+fi
+echo "run.sh: OBI-VERIFIER-RESULT=${RESULT}" >&2
+exit "${RESULT}"


### PR DESCRIPTION
## Summary

AL2023 kernels have certain backports (eg. ITER_UBUF defined in the enum but old style struct iov_iter), add coverage by unpacking kernels directly

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
