### PR TITLE
Fix java attach sequence

### DIFF
--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 
 	"go.opentelemetry.io/obi/pkg/internal/jvmtools/util"
@@ -22,7 +22,6 @@ type JAttacher struct {
 	j9attacher *j9Attacher
 	myUID      int
 	myGID      int
-	myPID      int
 }
 
 func NewJAttacher(logger *slog.Logger) *JAttacher {
@@ -37,13 +36,8 @@ func NewJAttacher(logger *slog.Logger) *JAttacher {
 }
 
 func (j *JAttacher) Init() {
-	myUID := syscall.Geteuid()
-	myGID := syscall.Getegid()
-	myPID := os.Getpid()
-
-	j.myUID = myUID
-	j.myGID = myGID
-	j.myPID = myPID
+	j.myUID = syscall.Geteuid()
+	j.myGID = syscall.Getegid()
 }
 
 func (j *JAttacher) Cleanup() error {
@@ -52,6 +46,12 @@ func (j *JAttacher) Cleanup() error {
 	if j.j9attacher != nil {
 		cleanupErr = errors.Join(cleanupErr, j.j9attacher.detach())
 	}
+
+	// Credentials (euid/egid) are switched process-wide during Attach, so they
+	// must be restored here. Namespaces are NOT restored: the namespace switch
+	// happens only on the dedicated sacrificial thread spawned by Attach, which
+	// is destroyed once attach completes — the runtime's pool threads never
+	// leave their original namespaces, so there is nothing to roll back.
 	if err := syscall.Seteuid(j.myUID); err != nil {
 		cleanupErr = errors.Join(cleanupErr, err)
 	}
@@ -59,12 +59,9 @@ func (j *JAttacher) Cleanup() error {
 		cleanupErr = errors.Join(cleanupErr, err)
 	}
 
-	for _, nsType := range []string{"net", "ipc", "mnt"} {
-		if util.EnterNS(j.myPID, nsType) < 0 {
-			err := fmt.Errorf("failed to restore %s namespace", nsType)
-			cleanupErr = errors.Join(cleanupErr, err)
-		}
-	}
+	// No need to restore the pid namespace, since we do this on a
+	// locked thread that's never unlocked, which means the Go runtime
+	// will destroy it when the goroutine ends.
 
 	return cleanupErr
 }
@@ -74,10 +71,48 @@ func (j *JAttacher) Attach(pid int, argv []string, ignoreOnJ9 bool) (io.ReadClos
 	targetGID := j.myGID
 	var nspid int
 
+	// Resolve the target's credentials and in-namespace PID from the host
+	// namespace, before we move anywhere.
 	if err := util.GetProcessInfo(pid, &targetUID, &targetGID, &nspid); err != nil {
 		return nil, fmt.Errorf("process not found: %d: %w", pid, err)
 	}
 
+	// Entering the target's mount namespace requires setns(CLONE_NEWNS), which
+	// the kernel refuses for any thread that shares filesystem attributes with
+	// the rest of the Go runtime's thread pool (see util.EnterNS). We therefore
+	// run the entire namespace-sensitive attach sequence on a dedicated OS
+	// thread that is locked and never unlocked: when this goroutine returns,
+	// the runtime destroys the thread instead of recycling one that is stranded
+	// in the target's namespaces with an unshared, private filesystem context.
+	//
+	// The attach result is an fd-backed io.ReadCloser (a unix socket conn for
+	// HotSpot, or a raw fd reader for OpenJ9). Once established, that fd belongs
+	// to the process and can be read from any thread, so the caller is free to
+	// consume it after this sacrificial thread is gone.
+	type attachResult struct {
+		reader io.ReadCloser
+		err    error
+	}
+	resultCh := make(chan attachResult, 1)
+
+	go func() {
+		runtime.LockOSThread()
+		// Deliberately no runtime.UnlockOSThread: this thread is tainted by the
+		// namespace switch and CLONE_FS unshare, so we let it die with the
+		// goroutine rather than return it to the pool.
+		reader, err := j.attachInNamespace(pid, nspid, targetUID, targetGID, argv, ignoreOnJ9)
+		resultCh <- attachResult{reader: reader, err: err}
+	}()
+
+	res := <-resultCh
+	return res.reader, res.err
+}
+
+// attachInNamespace performs the namespace switch, credential change and JVM
+// handshake. It MUST be called from a goroutine pinned to a dedicated,
+// never-unlocked OS thread (see Attach), because it both joins the target's
+// mount namespace and unshares CLONE_FS on the calling thread.
+func (j *JAttacher) attachInNamespace(pid, nspid, targetUID, targetGID int, argv []string, ignoreOnJ9 bool) (io.ReadCloser, error) {
 	// Container support: switch to the target namespaces.
 	// Network and IPC namespaces are essential for OpenJ9 connection.
 	if util.EnterNS(pid, "net") < 0 {

--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os/signal"
 	"runtime"
+	"runtime/debug"
 	"syscall"
 
 	"go.opentelemetry.io/obi/pkg/internal/jvmtools/util"
@@ -96,6 +97,17 @@ func (j *JAttacher) Attach(pid int, argv []string, ignoreOnJ9 bool) (io.ReadClos
 	resultCh := make(chan attachResult, 1)
 
 	go func() {
+		// This goroutine runs independently of the caller's goroutine, so a
+		// panic here would escape the callers' own recover take down the whole process.
+		// Convert it into an attach error instead.
+		defer func() {
+			if r := recover(); r != nil {
+				j.logger.Error("recovered from panic during JVM attach",
+					"pid", pid, "panic", r, "stack", string(debug.Stack()))
+				resultCh <- attachResult{err: fmt.Errorf("panic during JVM attach: %v", r)}
+			}
+		}()
+
 		runtime.LockOSThread()
 		// Deliberately no runtime.UnlockOSThread: this thread is tainted by the
 		// namespace switch and CLONE_FS unshare, so we let it die with the

--- a/pkg/internal/jvmtools/jvm/cmd_openj9.go
+++ b/pkg/internal/jvmtools/jvm/cmd_openj9.go
@@ -271,6 +271,15 @@ func notifySemaphore(tmpPath string, value, notifyCount int) error {
 
 	for range notifyCount {
 		if err := semop(semID, []sembuf{sb}); err != nil {
+			// The restore path decrements with IPC_NOWAIT. The JVMs we notified
+			// consume the posts themselves as they wake up, so the semaphore is
+			// frequently already at zero by the time we try to take our posts
+			// back. EAGAIN ("resource temporarily unavailable") is the kernel
+			// signalling there is nothing left to decrement. The original C code
+			// was handling this, but it was missed in translation.
+			if value < 0 && errors.Is(err, unix.EAGAIN) {
+				return nil
+			}
 			return fmt.Errorf("semop failed: %w", err)
 		}
 	}

--- a/pkg/internal/jvmtools/jvm/cmd_openj9.go
+++ b/pkg/internal/jvmtools/jvm/cmd_openj9.go
@@ -275,7 +275,7 @@ func notifySemaphore(tmpPath string, value, notifyCount int) error {
 			// consume the posts themselves as they wake up, so the semaphore is
 			// frequently already at zero by the time we try to take our posts
 			// back. EAGAIN ("resource temporarily unavailable") is the kernel
-			// signalling there is nothing left to decrement. The original C code
+			// signaling there is nothing left to decrement. The original C code
 			// was handling this, but it was missed in translation.
 			if value < 0 && errors.Is(err, unix.EAGAIN) {
 				return nil

--- a/pkg/internal/jvmtools/util/psutil.go
+++ b/pkg/internal/jvmtools/util/psutil.go
@@ -183,6 +183,20 @@ func EnterNS(pid int, nsType string) int {
 	}
 	defer newns.Close()
 
+	// Joining a mount namespace via setns(CLONE_NEWNS) is rejected by the
+	// kernel with EINVAL whenever the calling thread shares its filesystem
+	// attributes (CLONE_FS: root dir, cwd, umask) with another thread. That is
+	// always true on the Go runtime's thread pool, so give this thread a
+	// private copy of those attributes first. The caller MUST have pinned the
+	// goroutine to a dedicated, never-unlocked OS thread (see jvm.Attach):
+	// once unshared and moved into a foreign namespace, the thread cannot be
+	// safely recycled.
+	if nsFlag == unix.CLONE_NEWNS {
+		if err := unix.Unshare(unix.CLONE_FS); err != nil {
+			return -1
+		}
+	}
+
 	// Some ancient Linux distributions do not have setns() function
 	if err := unix.Setns(int(newns.Fd()), nsFlag); err != nil {
 		return -1


### PR DESCRIPTION
## Summary

This PR fixes the bug exposed by [this PR](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2326). Our jvmtools implementation never worked properly for switching the PID namespace and doing an explicit test on < 0 result caught it. I think the issue is intermittent, which is why the tests passed on the original PR.

I believe this should resolve https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1362 as well, but I need to test a bit more. When I've confimed, I'll close that issue as well. 

So instead of trying to switch the namespace on potentially reused (tainted) threads, I now created a sacrificial thread that is used only for the attach, never unlocked which forces the Go runtime to nuke it after the goroutine finishes.

Closes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1362

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
