### PR TITLE
ci: fix weaver-out dir

### DIFF
--- a/internal/test/integration/dockerutil_test.go
+++ b/internal/test/integration/dockerutil_test.go
@@ -210,15 +210,17 @@ func setupContainerWeaver(t *testing.T, net dockertest.Network) {
 			"--admin-port", "4320",
 			"--format", "json",
 			"--diagnostic-format", "json",
-			"--output", "/tmp",
+			"--output", "/tmp/weaver-out",
 		}),
 		dockertest.WithMounts([]string{
 			filepath.Join(pathRoot, "schemas/obi") + ":/obi-registry:ro",
+			"/tmp/obi-weaver-out:/tmp/weaver-out",
 		}),
 		dockertest.WithPortBindings(portBindings("4320/tcp", "4320")),
 		dockertest.WithContainerConfig(func(config *container.Config) {
 			config.WorkingDir = "/obi-registry"
 			config.ExposedPorts = exposedPorts("4317/tcp", "4320/tcp")
+			config.User = "0:0"
 		}),
 		dockertest.WithoutReuse(),
 	)


### PR DESCRIPTION
## Summary

#2171 changed the weaver-out dir but missed updating the same in `internal/test/integration/dockerutil_test.go`, causing flaky failures.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
