### PR TITLE
Clear log enricher PID cache on block

### DIFF
--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -310,6 +310,7 @@ func (p *Tracer) BlockPID(pid app.PID, ns uint32) {
 				p.log.Error(err.Error())
 			}
 		}
+		delete(p.pids, pk)
 		return
 	}
 

--- a/pkg/internal/ebpf/logenricher/logenricher_test.go
+++ b/pkg/internal/ebpf/logenricher/logenricher_test.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
 	"github.com/stretchr/testify/assert"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
@@ -39,6 +41,51 @@ func newTestTracer(t *testing.T, exclude bool) *Tracer {
 		pidServices: map[uint32]*exec.FileInfo{},
 		pidsMU:      sync.Mutex{},
 	}
+}
+
+func TestBlockPIDClearsNamespacedPIDCache(t *testing.T) {
+	tr := newTestTracer(t, false)
+
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("removing memlock failed: %v", err)
+	}
+
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Name:       "le_pids_test",
+		Type:       ebpf.Hash,
+		KeySize:    8,
+		ValueSize:  1,
+		MaxEntries: 4,
+	})
+	if err != nil {
+		t.Skipf("ebpf map create failed: %v", err)
+	}
+	t.Cleanup(func() {
+		assert.NoError(t, m.Close())
+	})
+	tr.bpfObjects.LogEnricherPids = m
+
+	const (
+		ns    = 1
+		pid   = 12345
+		nsPID = 2345
+	)
+
+	pk := tr.pidKey(ns, pid)
+	nsPk := tr.pidKey(ns, nsPID)
+	tr.pids[pk] = []uint64{nsPk}
+
+	assert.NoError(t, m.Put(pk, uint8(1)))
+	assert.NoError(t, m.Put(nsPk, uint8(1)))
+
+	tr.BlockPID(pid, ns)
+
+	_, ok := tr.pids[pk]
+	assert.False(t, ok)
+
+	var value uint8
+	assert.ErrorIs(t, m.Lookup(pk, &value), ebpf.ErrKeyNotExist)
+	assert.ErrorIs(t, m.Lookup(nsPk, &value), ebpf.ErrKeyNotExist)
 }
 
 func TestShouldOmitSpanID_FeatureDisabled(t *testing.T) {

--- a/pkg/internal/ebpf/logenricher/logenricher_test.go
+++ b/pkg/internal/ebpf/logenricher/logenricher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
@@ -61,7 +62,9 @@ func TestBlockPIDClearsNamespacedPIDCache(t *testing.T) {
 		t.Skipf("ebpf map create failed: %v", err)
 	}
 	t.Cleanup(func() {
-		assert.NoError(t, m.Close())
+		if err := m.Close(); err != nil {
+			t.Errorf("close eBPF map: %v", err)
+		}
 	})
 	tr.bpfObjects.LogEnricherPids = m
 
@@ -75,8 +78,8 @@ func TestBlockPIDClearsNamespacedPIDCache(t *testing.T) {
 	nsPk := tr.pidKey(ns, nsPID)
 	tr.pids[pk] = []uint64{nsPk}
 
-	assert.NoError(t, m.Put(pk, uint8(1)))
-	assert.NoError(t, m.Put(nsPk, uint8(1)))
+	require.NoError(t, m.Put(pk, uint8(1)))
+	require.NoError(t, m.Put(nsPk, uint8(1)))
 
 	tr.BlockPID(pid, ns)
 
@@ -84,8 +87,8 @@ func TestBlockPIDClearsNamespacedPIDCache(t *testing.T) {
 	assert.False(t, ok)
 
 	var value uint8
-	assert.ErrorIs(t, m.Lookup(pk, &value), ebpf.ErrKeyNotExist)
-	assert.ErrorIs(t, m.Lookup(nsPk, &value), ebpf.ErrKeyNotExist)
+	require.ErrorIs(t, m.Lookup(pk, &value), ebpf.ErrKeyNotExist)
+	require.ErrorIs(t, m.Lookup(nsPk, &value), ebpf.ErrKeyNotExist)
 }
 
 func TestShouldOmitSpanID_FeatureDisabled(t *testing.T) {


### PR DESCRIPTION
## Summary

- Clear the log enricher's cached namespaced PID associations when `BlockPID` removes the corresponding BPF map entries.
- Add regression coverage for the block path so cache entries and BPF keys are cleaned up together.

## Motivation

`AllowPID` stores namespaced PID aliases in the log enricher's in-memory `pids` cache so `BlockPID` can remove every BPF map key associated with the process. The previous block path deleted those BPF entries but kept the cache entry, which allowed process churn to grow memory after services were blocked.

Fixes #2021.

## Testing

- `go test ./pkg/internal/ebpf/logenricher -count=1`
