### PR TITLE
Keep HTTP/2 preface bounds aligned

### DIFF
--- a/bpf/generictracer/http2_grpc.h
+++ b/bpf/generictracer/http2_grpc.h
@@ -71,6 +71,19 @@ static __always_inline u8 is_http2_or_grpc(unsigned char *p, u32 len) {
     return has_preface(p, len);
 }
 
+static __always_inline void skip_http2_preface(call_protocol_args_t *args) {
+    if (args->bytes_len < MIN_HTTP2_SIZE) {
+        return;
+    }
+
+    if (!has_preface(args->small_buf, MIN_HTTP2_SIZE)) {
+        return;
+    }
+
+    args->u_buf += MIN_HTTP2_SIZE;
+    args->bytes_len -= MIN_HTTP2_SIZE;
+}
+
 static __always_inline u8 http_grpc_stream_ended(const frame_header_t *frame) {
     return is_headers_frame(frame) &&
            ((frame->flags & k_flag_data_end_stream) == k_flag_data_end_stream);

--- a/bpf/generictracer/protocol_handler.c
+++ b/bpf/generictracer/protocol_handler.c
@@ -50,10 +50,7 @@ int obi_handle_buf_with_args(void *ctx) {
             data.flags |= http2_conn_flag_ssl;
         }
         bpf_map_update_elem(&ongoing_http2_connections, &args->pid_conn, &data, BPF_ANY);
-        // if we detected the preface, parse any grpc past the preface
-        if (has_preface(args->small_buf, args->bytes_len) && args->bytes_len > MIN_HTTP2_SIZE) {
-            args->u_buf = args->u_buf + MIN_HTTP2_SIZE;
-        }
+        skip_http2_preface(args);
     }
 
     http2_conn_info_data_t *h2g = bpf_map_lookup_elem(&ongoing_http2_connections, &args->pid_conn);

--- a/bpf/tests/bpf_http2_preface_bounds.c
+++ b/bpf/tests/bpf_http2_preface_bounds.c
@@ -1,0 +1,97 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <generictracer/http2_grpc.h>
+
+static void assert_int_eq(int expected, int actual, const char *message) {
+    if (expected != actual) {
+        fprintf(stderr, "FAIL: %s\n  expected %d, got %d\n", message, expected, actual);
+        exit(1);
+    }
+}
+
+static void assert_u64_eq(u64 expected, u64 actual, const char *message) {
+    if (expected != actual) {
+        fprintf(stderr,
+                "FAIL: %s\n  expected %llu, got %llu\n",
+                message,
+                (unsigned long long)expected,
+                (unsigned long long)actual);
+        exit(1);
+    }
+}
+
+static call_protocol_args_t protocol_args_for(unsigned char *buf, int len) {
+    call_protocol_args_t args = {
+        .bytes_len = len,
+        .u_buf = (u64)buf,
+    };
+
+    const size_t small_buf_len =
+        len < (int)sizeof(args.small_buf) ? (size_t)len : sizeof(args.small_buf);
+    __builtin_memcpy(args.small_buf, buf, small_buf_len);
+
+    return args;
+}
+
+static void write_preface(unsigned char *buf) {
+    __builtin_memcpy(buf, HTTP2_GRPC_PREFACE, MIN_HTTP2_SIZE);
+}
+
+static void test_short_buffer_keeps_original_bounds(void) {
+    unsigned char buf[MIN_HTTP2_SIZE - 1] = {0};
+    __builtin_memcpy(buf, HTTP2_GRPC_PREFACE, sizeof(buf));
+    call_protocol_args_t args = protocol_args_for(buf, sizeof(buf));
+
+    skip_http2_preface(&args);
+
+    assert_u64_eq((u64)buf, args.u_buf, "short buffer keeps original pointer");
+    assert_int_eq((int)sizeof(buf), args.bytes_len, "short buffer keeps original length");
+}
+
+static void test_non_preface_keeps_original_bounds(void) {
+    unsigned char buf[MIN_HTTP2_SIZE + 1] = {0};
+    call_protocol_args_t args = protocol_args_for(buf, sizeof(buf));
+
+    skip_http2_preface(&args);
+
+    assert_u64_eq((u64)buf, args.u_buf, "non-preface keeps original pointer");
+    assert_int_eq((int)sizeof(buf), args.bytes_len, "non-preface keeps original length");
+}
+
+static void test_preface_only_leaves_empty_payload(void) {
+    unsigned char buf[MIN_HTTP2_SIZE] = {0};
+    write_preface(buf);
+    call_protocol_args_t args = protocol_args_for(buf, sizeof(buf));
+
+    skip_http2_preface(&args);
+
+    assert_u64_eq((u64)(buf + MIN_HTTP2_SIZE), args.u_buf, "preface-only skips pointer");
+    assert_int_eq(0, args.bytes_len, "preface-only leaves no payload bytes");
+}
+
+static void test_preface_short_payload_keeps_effective_length(void) {
+    unsigned char buf[MIN_HTTP2_SIZE + 1] = {0};
+    write_preface(buf);
+    buf[MIN_HTTP2_SIZE] = 0xff;
+    call_protocol_args_t args = protocol_args_for(buf, sizeof(buf));
+
+    skip_http2_preface(&args);
+
+    assert_u64_eq((u64)(buf + MIN_HTTP2_SIZE), args.u_buf, "short payload skips pointer");
+    assert_int_eq(1, args.bytes_len, "short payload shrinks length with pointer");
+}
+
+int main(void) {
+    test_short_buffer_keeps_original_bounds();
+    test_non_preface_keeps_original_bounds();
+    test_preface_only_leaves_empty_payload();
+    test_preface_short_payload_keeps_effective_length();
+
+    return 0;
+}


### PR DESCRIPTION
## What changed

This updates the HTTP/2 preface skip path to keep `call_protocol_args_t` bounds consistent. When the generic tracer detects and skips the HTTP/2 client connection preface, it now advances `u_buf` and also subtracts the preface size from `bytes_len`.

The preface skip logic is centralized in `skip_http2_preface`, and the protocol handler uses that helper instead of shifting the pointer inline.

## Why

The previous code advanced the user buffer pointer past the 24-byte HTTP/2 preface but left `bytes_len` unchanged. That allowed later HTTP/2 frame parsing to reason about more bytes than remained after the pointer shift, which is especially visible for preface-only or short-payload reads.

Keeping the pointer and length aligned makes the later frame-walker bounds match the effective payload being parsed.

Fixes #2040.

## Tests

- `make generate`
- `make compile`
- `make -C bpf/tests`
- `bpf/tests/bpf_http2_preface_bounds`
- `clang-tidy bpf/generictracer/protocol_handler.c -line-filter='[{"name":"bpf/generictracer/protocol_handler.c","lines":[[53,53]]},{"name":"bpf/generictracer/http2_grpc.h","lines":[[74,85]]}]' -- -Ibpf`
- `docker run --rm --privileged --ulimit memlock=-1 -v $PWD:/src -w /src golang:1.26-bookworm go test -v -count=1 -tags=bpf_verifier_tests ./pkg/internal/ebpf/verifier/...`