### PR TITLE
Bound avoided-services metric cardinality

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -350,6 +350,15 @@ InternalMetricsConfig options for the different metrics exporters
 | `internal_metrics.bpf_metric_scrape_interval` | `duration` | `OTEL_EBPF_BPF_METRIC_SCRAPE_INTERVAL` | `15s` | `30s`, `5m`, `1ms`, etc |  |  |
 | `internal_metrics.exporter` | `string` | `OTEL_EBPF_INTERNAL_METRICS_EXPORTER` | `disabled` | `disabled`, `otel`, `prometheus` |  |  |
 
+### `internal_metrics.avoided_services`
+
+AvoidedServicesConfig controls the avoided-services internal metric.
+
+| YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
+|---|---|---|---|---|---|---|
+| `internal_metrics.avoided_services.disabled` | `boolean` | `OTEL_EBPF_INTERNAL_METRICS_AVOIDED_SERVICES_DISABLED` | `false` |  |  | Disables the avoided-services internal metric. |
+| `internal_metrics.avoided_services.limit` | `integer` | `OTEL_EBPF_INTERNAL_METRICS_AVOIDED_SERVICES_LIMIT` | `2000` |  |  | Bounds the number of avoided-services metric series, including the overflow series. 0 uses the OpenTelemetry default metric cardinality limit. |
+
 ### `internal_metrics.prometheus`
 
 TODO: TLS

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -109,6 +109,24 @@
       "type": "object",
       "description": "AttributesConfig stores the user-provided section for filtering either Application or Network records by attribute values"
     },
+    "AvoidedServicesConfig": {
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "description": "Disables the avoided-services internal metric.",
+          "default": false,
+          "x-env-var": "OTEL_EBPF_INTERNAL_METRICS_AVOIDED_SERVICES_DISABLED"
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Bounds the number of avoided-services metric series, including the overflow series. 0 uses the OpenTelemetry default metric cardinality limit.",
+          "default": 2000,
+          "x-env-var": "OTEL_EBPF_INTERNAL_METRICS_AVOIDED_SERVICES_LIMIT"
+        }
+      },
+      "type": "object",
+      "description": "AvoidedServicesConfig controls the avoided-services internal metric."
+    },
     "BedrockConfig": {
       "properties": {
         "enabled": {
@@ -1370,6 +1388,9 @@
     },
     "InternalMetricsConfig": {
       "properties": {
+        "avoided_services": {
+          "$ref": "#/$defs/AvoidedServicesConfig"
+        },
         "bpf_metric_scrape_interval": {
           "type": "string",
           "pattern": "^[0-9]+(ms|s|m)$",

--- a/devdocs/exclude-otel-instrumented-services.md
+++ b/devdocs/exclude-otel-instrumented-services.md
@@ -99,10 +99,12 @@ Once a service has its `ExportsOTelMetrics` / `ExportsOTelTraces` /
 
 Each detection event increments the `obi.avoided.services` internal metric
 (Prometheus name: `obi_avoided_services`). Normal series are labeled with the
-service identity and the telemetry type that was avoided (`metrics` or
-`traces`). When the configured cardinality limit is reached, additional
-detections are reported through the OpenTelemetry overflow attribute
-`otel.metric.overflow=true` (Prometheus label:
+logical service name, service namespace, and the telemetry type that was
+avoided (`metrics` or `traces`). The service instance ID is intentionally not
+reported because it is unique per service instance and would churn backend
+time series. When the configured cardinality limit is reached, additional
+detections are collapsed before export and reported through the OpenTelemetry
+overflow attribute `otel.metric.overflow=true` (Prometheus label:
 `otel_metric_overflow="true"`). Span-metrics suppression is reported under the
 `metrics` label, not a separate one — the `metrics_span` detection path in
 `reportAvoidedService` routes through `AvoidInstrumentationMetrics`, which

--- a/devdocs/exclude-otel-instrumented-services.md
+++ b/devdocs/exclude-otel-instrumented-services.md
@@ -98,12 +98,15 @@ Once a service has its `ExportsOTelMetrics` / `ExportsOTelTraces` /
 - Prometheus — RED-metrics and span-metrics filters in [`pkg/export/prom/prom.go`](../pkg/export/prom/prom.go).
 
 Each detection event increments the `obi.avoided.services` internal metric
-(Prometheus name: `obi_avoided_services`), labeled with the service identity
-and the telemetry type that was avoided (`metrics` or `traces`). Span-metrics
-suppression is reported under the `metrics` label, not a separate one — the
-`metrics_span` detection path in `reportAvoidedService` routes through
-`AvoidInstrumentationMetrics`, which emits `metrics`. It's emitted from
-`reportAvoidedService` in
+(Prometheus name: `obi_avoided_services`). Normal series are labeled with the
+service identity and the telemetry type that was avoided (`metrics` or
+`traces`). When the configured cardinality limit is reached, additional
+detections are reported through the OpenTelemetry overflow attribute
+`otel.metric.overflow=true` (Prometheus label:
+`otel_metric_overflow="true"`). Span-metrics suppression is reported under the
+`metrics` label, not a separate one — the `metrics_span` detection path in
+`reportAvoidedService` routes through `AvoidInstrumentationMetrics`, which
+emits `metrics`. It's emitted from `reportAvoidedService` in
 [`pkg/ebpf/common/pids.go`](../pkg/ebpf/common/pids.go) and is the
 authoritative signal for whether detection has fired for a given service.
 

--- a/internal/test/integration/internal_metrics_test.go
+++ b/internal/test/integration/internal_metrics_test.go
@@ -134,9 +134,6 @@ func checkAvoidedServicesMetrics(t *testing.T) {
 		assert.Condition(ct, func() bool {
 			return labelMap["telemetry_type"] == "metrics" || labelMap["telemetry_type"] == "traces"
 		}, "telemetry_type label should be either 'metrics' or 'traces'")
-		// service_instance_id can be empty, but should be present
-		_, ok = labelMap["service_instance_id"]
-		assert.True(ct, ok, "service_instance_id label should be present")
 
 		if metric.Gauge != nil {
 			assert.Greater(ct, metric.Gauge.GetValue(), float64(0), "Expected avoided service metric value to be > 0")

--- a/pkg/export/imetrics/avoided_services.go
+++ b/pkg/export/imetrics/avoided_services.go
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package imetrics
+
+// AvoidedServicesConfig controls the avoided-services internal metric.
+type AvoidedServicesConfig struct {
+	// Disabled disables the avoided-services internal metric.
+	Disabled bool `yaml:"disabled" env:"OTEL_EBPF_INTERNAL_METRICS_AVOIDED_SERVICES_DISABLED"`
+	// Limit bounds the number of avoided-services metric series, including the overflow series.
+	// 0 uses the OpenTelemetry default metric cardinality limit.
+	Limit int `yaml:"limit" env:"OTEL_EBPF_INTERNAL_METRICS_AVOIDED_SERVICES_LIMIT" validate:"gte=0"`
+}

--- a/pkg/export/imetrics/avoided_services.go
+++ b/pkg/export/imetrics/avoided_services.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package imetrics
+package imetrics // import "go.opentelemetry.io/obi/pkg/export/imetrics"
 
 // AvoidedServicesConfig controls the avoided-services internal metric.
 type AvoidedServicesConfig struct {

--- a/pkg/export/imetrics/imetrics.go
+++ b/pkg/export/imetrics/imetrics.go
@@ -54,6 +54,7 @@ const (
 // InternalMetricsConfig options for the different metrics exporters
 type InternalMetricsConfig struct {
 	Prometheus              PrometheusConfig        `yaml:"prometheus,omitempty"`
+	AvoidedServices         AvoidedServicesConfig   `yaml:"avoided_services,omitempty"`
 	Exporter                InternalMetricsExporter `yaml:"exporter,omitempty" env:"OTEL_EBPF_INTERNAL_METRICS_EXPORTER" validate:"omitempty,oneof=disabled prometheus otel"`
 	BpfMetricScrapeInterval time.Duration           `yaml:"bpf_metric_scrape_interval" env:"OTEL_EBPF_BPF_METRIC_SCRAPE_INTERVAL" validate:"omitempty,gt=0"`
 }

--- a/pkg/export/imetrics/imetrics_test.go
+++ b/pkg/export/imetrics/imetrics_test.go
@@ -87,7 +87,6 @@ func TestPrometheusReporterAvoidedServicesBounded(t *testing.T) {
 			overflowRecords++
 			assert.Empty(t, labels["service_name"])
 			assert.Empty(t, labels["service_namespace"])
-			assert.Empty(t, labels["service_instance_id"])
 			assert.Empty(t, labels["telemetry_type"])
 			continue
 		}
@@ -95,12 +94,11 @@ func TestPrometheusReporterAvoidedServicesBounded(t *testing.T) {
 		assert.Equal(t, "false", labels[avoidedsvc.PrometheusOverflowLabel])
 		labelSets[labels["service_name"]+"/"+
 			labels["service_namespace"]+"/"+
-			labels["service_instance_id"]+"/"+
 			labels["telemetry_type"]] = struct{}{}
 	}
 
-	assert.Contains(t, labelSets, "svc-0/ns-0/inst-0/metrics")
-	assert.Contains(t, labelSets, "svc-0/ns-0/inst-0/traces")
+	assert.Contains(t, labelSets, "svc-0/ns-0/metrics")
+	assert.Contains(t, labelSets, "svc-0/ns-0/traces")
 	assert.Equal(t, 1, overflowRecords)
 }
 

--- a/pkg/export/imetrics/imetrics_test.go
+++ b/pkg/export/imetrics/imetrics_test.go
@@ -10,6 +10,9 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/internal/avoidedsvc"
 )
 
 func TestIsBuiltinNoopReporter(t *testing.T) {
@@ -61,3 +64,79 @@ type noopEmbeddingReporter struct {
 }
 
 func (n *noopEmbeddingReporter) BpfProbeStats(_, _, _ string, _ uint64, _ float64) {}
+
+func TestPrometheusReporterAvoidedServicesBounded(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	reporter := NewPrometheusReporter(&InternalMetricsConfig{
+		AvoidedServices: AvoidedServicesConfig{Limit: 3},
+	}, nil, registry)
+
+	reporter.AvoidInstrumentationMetrics("svc-0", "ns-0", "inst-0")
+	reporter.AvoidInstrumentationTraces("svc-0", "ns-0", "inst-0")
+	reporter.AvoidInstrumentationMetrics("svc-1", "ns-1", "inst-1")
+	reporter.AvoidInstrumentationTraces("svc-1", "ns-1", "inst-1")
+
+	metrics := gatherAvoidedServices(t, registry)
+	require.Len(t, metrics, 3)
+
+	labelSets := map[string]struct{}{}
+	overflowRecords := 0
+	for _, metric := range metrics {
+		labels := metricLabels(metric)
+		if labels[avoidedsvc.PrometheusOverflowLabel] == "true" {
+			overflowRecords++
+			assert.Empty(t, labels["service_name"])
+			assert.Empty(t, labels["service_namespace"])
+			assert.Empty(t, labels["service_instance_id"])
+			assert.Empty(t, labels["telemetry_type"])
+			continue
+		}
+
+		assert.Equal(t, "false", labels[avoidedsvc.PrometheusOverflowLabel])
+		labelSets[labels["service_name"]+"/"+
+			labels["service_namespace"]+"/"+
+			labels["service_instance_id"]+"/"+
+			labels["telemetry_type"]] = struct{}{}
+	}
+
+	assert.Contains(t, labelSets, "svc-0/ns-0/inst-0/metrics")
+	assert.Contains(t, labelSets, "svc-0/ns-0/inst-0/traces")
+	assert.Equal(t, 1, overflowRecords)
+}
+
+func TestPrometheusReporterAvoidedServicesDisabled(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	reporter := NewPrometheusReporter(&InternalMetricsConfig{
+		AvoidedServices: AvoidedServicesConfig{Disabled: true},
+	}, nil, registry)
+
+	reporter.AvoidInstrumentationMetrics("svc-0", "ns-0", "inst-0")
+
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		assert.NotEqual(t, attr.VendorPrefix+"_avoided_services", mf.GetName())
+	}
+}
+
+func gatherAvoidedServices(t *testing.T, registry *prometheus.Registry) []*dto.Metric {
+	t.Helper()
+
+	mfs, err := registry.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() == attr.VendorPrefix+"_avoided_services" {
+			return mf.GetMetric()
+		}
+	}
+	require.Fail(t, "missing avoided services metric")
+	return nil
+}
+
+func metricLabels(metric *dto.Metric) map[string]string {
+	labels := map[string]string{}
+	for _, pair := range metric.GetLabel() {
+		labels[pair.GetName()] = pair.GetValue()
+	}
+	return labels
+}

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/buildinfo"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/connector"
+	"go.opentelemetry.io/obi/pkg/internal/avoidedsvc"
 )
 
 // pipelineBufferLengths buckets for histogram metrics about the number of traces submitted from one stage to another
@@ -37,6 +38,7 @@ type PrometheusReporter struct {
 	instrumentedProcesses            *prometheus.GaugeVec
 	instrumentationErrors            *prometheus.CounterVec
 	avoidedServices                  *prometheus.GaugeVec
+	avoidedServicesLimiter           *avoidedsvc.Limiter
 	buildInfo                        prometheus.Gauge
 	bpfProbeExecutions               *prometheus.CounterVec
 	bpfProbeLatencySum               *prometheus.CounterVec
@@ -93,10 +95,6 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			Name: attr.VendorPrefix + "_instrumentation_errors_total",
 			Help: "Total number of instrumentation errors by process name and error type",
 		}, []string{"process_name", "error_type"}),
-		avoidedServices: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: attr.VendorPrefix + "_avoided_services",
-			Help: "Services avoided due to existing OpenTelemetry instrumentation",
-		}, []string{"service_name", "service_namespace", "service_instance_id", "telemetry_type"}),
 		buildInfo: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: attr.VendorPrefix + "_internal_build_info",
 			Help: "A metric with a constant '1' value labeled by version, revision, branch, " +
@@ -148,6 +146,19 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			Help: "Ratio [0-1] between the unread messages of an internal Go channel and its total capacity",
 		}, []string{"subscriber"}),
 	}
+	if !cfg.AvoidedServices.Disabled {
+		pr.avoidedServicesLimiter = avoidedsvc.NewLimiter(cfg.AvoidedServices.Limit)
+		pr.avoidedServices = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: attr.VendorPrefix + "_avoided_services",
+			Help: "Services avoided due to existing OpenTelemetry instrumentation",
+		}, []string{
+			"service_name",
+			"service_namespace",
+			"service_instance_id",
+			"telemetry_type",
+			avoidedsvc.PrometheusOverflowLabel,
+		})
+	}
 	metrics := []prometheus.Collector{
 		pr.tracerFlushes,
 		pr.otelMetricExports,
@@ -157,7 +168,6 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 		pr.prometheusRequests,
 		pr.instrumentedProcesses,
 		pr.instrumentationErrors,
-		pr.avoidedServices,
 		pr.buildInfo,
 		pr.bpfProbeExecutions,
 		pr.bpfProbeLatencySum,
@@ -167,6 +177,9 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 		pr.bpfPacketCount,
 		pr.bpfIgnoredPacketCount,
 		pr.queueCapacityRatio,
+	}
+	if pr.avoidedServices != nil {
+		metrics = append(metrics, pr.avoidedServices)
 	}
 	if registry != nil {
 		registry.MustRegister(metrics...)
@@ -221,7 +234,12 @@ func (p *PrometheusReporter) InstrumentationError(processName string, errorType 
 }
 
 func (p *PrometheusReporter) recordAvoidedService(serviceName, serviceNamespace, serviceInstanceID, telemetryType string) {
-	p.avoidedServices.WithLabelValues(serviceName, serviceNamespace, serviceInstanceID, telemetryType).Set(1)
+	if p.avoidedServices == nil {
+		return
+	}
+
+	labels := p.avoidedServicesLimiter.Labels(serviceName, serviceNamespace, serviceInstanceID, telemetryType)
+	p.avoidedServices.WithLabelValues(labels.PrometheusValues()...).Set(1)
 }
 
 func (p *PrometheusReporter) AvoidInstrumentationMetrics(serviceName, serviceNamespace, serviceInstanceID string) {

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -154,7 +154,6 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 		}, []string{
 			"service_name",
 			"service_namespace",
-			"service_instance_id",
 			"telemetry_type",
 			avoidedsvc.PrometheusOverflowLabel,
 		})

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -22,6 +22,7 @@ import (
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/internal/avoidedsvc"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 )
 
@@ -36,6 +37,7 @@ type InternalMetricsReporter struct {
 	instrumentedProcesses            instrument.Int64UpDownCounter
 	instrumentationErrors            instrument.Int64Counter
 	avoidedServices                  instrument.Int64Gauge
+	avoidedServicesLimiter           *avoidedsvc.Limiter
 	buildInfo                        instrument.Int64Gauge
 	bpfProbeExecutions               instrument.Int64Counter
 	bpfProbeLatencySum               instrument.Float64Counter
@@ -125,12 +127,17 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		return nil, err
 	}
 
-	avoidedServices, err := meter.Int64Gauge(
-		attr.VendorPrefix+".avoided.services",
-		instrument.WithDescription("Services avoided due to existing OpenTelemetry instrumentation"),
-	)
-	if err != nil {
-		return nil, err
+	var avoidedServices instrument.Int64Gauge
+	var avoidedServicesLimiter *avoidedsvc.Limiter
+	if !internalMetrics.AvoidedServices.Disabled {
+		avoidedServices, err = meter.Int64Gauge(
+			attr.VendorPrefix+".avoided.services",
+			instrument.WithDescription("Services avoided due to existing OpenTelemetry instrumentation"),
+		)
+		if err != nil {
+			return nil, err
+		}
+		avoidedServicesLimiter = avoidedsvc.NewLimiter(internalMetrics.AvoidedServices.Limit)
 	}
 
 	buildInfo, err := meter.Int64Gauge(
@@ -220,6 +227,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		instrumentedProcesses:            instrumentedProcesses,
 		instrumentationErrors:            instrumentationErrors,
 		avoidedServices:                  avoidedServices,
+		avoidedServicesLimiter:           avoidedServicesLimiter,
 		buildInfo:                        buildInfo,
 		bpfProbeExecutions:               bpfProbeExecutions,
 		bpfProbeLatencySum:               bpfProbeLatencySum,
@@ -302,11 +310,23 @@ func newResourceInternal(nodeMeta *meta.NodeMeta) *resource.Resource {
 }
 
 func (p *InternalMetricsReporter) recordAvoidedService(serviceName, serviceNamespace, serviceInstanceID, telemetryType string) {
-	attrs := []attribute.KeyValue{
-		semconv.ServiceName(serviceName),
-		semconv.ServiceNamespace(serviceNamespace),
-		semconv.ServiceInstanceID(serviceInstanceID),
-		attribute.String("telemetry.type", telemetryType),
+	if p.avoidedServices == nil {
+		return
+	}
+
+	labels := p.avoidedServicesLimiter.Labels(serviceName, serviceNamespace, serviceInstanceID, telemetryType)
+	var attrs []attribute.KeyValue
+	if labels.Overflow {
+		attrs = []attribute.KeyValue{
+			attribute.Bool(avoidedsvc.OverflowAttribute, true),
+		}
+	} else {
+		attrs = []attribute.KeyValue{
+			semconv.ServiceName(labels.ServiceName),
+			semconv.ServiceNamespace(labels.ServiceNamespace),
+			semconv.ServiceInstanceID(labels.ServiceInstanceID),
+			attribute.String("telemetry.type", labels.TelemetryType),
+		}
 	}
 
 	p.avoidedServices.Record(p.ctx, 1, instrument.WithAttributes(attrs...))

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -324,7 +324,6 @@ func (p *InternalMetricsReporter) recordAvoidedService(serviceName, serviceNames
 		attrs = []attribute.KeyValue{
 			semconv.ServiceName(labels.ServiceName),
 			semconv.ServiceNamespace(labels.ServiceNamespace),
-			semconv.ServiceInstanceID(labels.ServiceInstanceID),
 			attribute.String("telemetry.type", labels.TelemetryType),
 		}
 	}

--- a/pkg/export/otel/metrics_internal_test.go
+++ b/pkg/export/otel/metrics_internal_test.go
@@ -15,6 +15,7 @@ import (
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/internal/avoidedsvc"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 )
 
@@ -99,4 +100,113 @@ func TestInternalMetricsReporterQueueBufferUtilization(t *testing.T) {
 	require.Len(t, records, 1)
 	assert.Equal(t, "traces", records[0].Attributes["subscriber"])
 	assert.InDelta(t, 0.42, records[0].FloatVal, 0.001)
+}
+
+func TestInternalMetricsReporterAvoidedServicesBounded(t *testing.T) {
+	metricRecords := make(chan collector.MetricRecord, 16)
+	mcfg := &otelcfg.MetricsConfig{
+		Interval:        10 * time.Millisecond,
+		MetricsConsumer: testMetricsConsumer(metricRecords),
+	}
+	ctxInfo := &global.ContextInfo{
+		NodeMeta:            meta.NodeMeta{HostID: "test-host"},
+		OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg},
+	}
+
+	reporter, err := NewInternalMetricsReporter(
+		t.Context(),
+		ctxInfo,
+		mcfg,
+		&imetrics.InternalMetricsConfig{
+			BpfMetricScrapeInterval: time.Millisecond,
+			AvoidedServices:         imetrics.AvoidedServicesConfig{Limit: 3},
+		},
+	)
+	require.NoError(t, err)
+
+	reporter.AvoidInstrumentationMetrics("svc-0", "ns-0", "inst-0")
+	reporter.AvoidInstrumentationTraces("svc-0", "ns-0", "inst-0")
+	reporter.AvoidInstrumentationMetrics("svc-1", "ns-1", "inst-1")
+	reporter.AvoidInstrumentationTraces("svc-1", "ns-1", "inst-1")
+
+	records := readNMetricsByName(t, metricRecords, time.Second, attr.VendorPrefix+".avoided.services", 3)
+	require.Len(t, records, 3)
+
+	labelSets := map[string]struct{}{}
+	overflowRecords := 0
+	for _, record := range records {
+		assert.Equal(t, int64(1), record.IntVal)
+		if record.Attributes[avoidedsvc.OverflowAttribute] == "true" {
+			overflowRecords++
+			assert.NotContains(t, record.Attributes, string(attr.ServiceName))
+			assert.NotContains(t, record.Attributes, string(attr.ServiceNamespace))
+			assert.NotContains(t, record.Attributes, string(attr.ServiceInstanceID))
+			assert.NotContains(t, record.Attributes, "telemetry.type")
+			continue
+		}
+
+		assert.NotContains(t, record.Attributes, avoidedsvc.OverflowAttribute)
+		labelSets[record.Attributes[string(attr.ServiceName)]+"/"+
+			record.Attributes[string(attr.ServiceNamespace)]+"/"+
+			record.Attributes[string(attr.ServiceInstanceID)]+"/"+
+			record.Attributes["telemetry.type"]] = struct{}{}
+	}
+
+	assert.Contains(t, labelSets, "svc-0/ns-0/inst-0/metrics")
+	assert.Contains(t, labelSets, "svc-0/ns-0/inst-0/traces")
+	assert.Equal(t, 1, overflowRecords)
+}
+
+func TestInternalMetricsReporterAvoidedServicesDisabled(t *testing.T) {
+	metricRecords := make(chan collector.MetricRecord, 16)
+	mcfg := &otelcfg.MetricsConfig{
+		Interval:        10 * time.Millisecond,
+		MetricsConsumer: testMetricsConsumer(metricRecords),
+	}
+	ctxInfo := &global.ContextInfo{
+		NodeMeta:            meta.NodeMeta{HostID: "test-host"},
+		OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg},
+	}
+
+	reporter, err := NewInternalMetricsReporter(
+		t.Context(),
+		ctxInfo,
+		mcfg,
+		&imetrics.InternalMetricsConfig{
+			BpfMetricScrapeInterval: time.Millisecond,
+			AvoidedServices:         imetrics.AvoidedServicesConfig{Disabled: true},
+		},
+	)
+	require.NoError(t, err)
+
+	assert.Nil(t, reporter.avoidedServices)
+	assert.Nil(t, reporter.avoidedServicesLimiter)
+
+	reporter.AvoidInstrumentationMetrics("svc-0", "ns-0", "inst-0")
+}
+
+func readNMetricsByName(
+	t require.TestingT,
+	inCh <-chan collector.MetricRecord,
+	timeout time.Duration,
+	name string,
+	numRecords int,
+) []collector.MetricRecord {
+	records := []collector.MetricRecord{}
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	for len(records) < numRecords {
+		select {
+		case item := <-inCh:
+			if item.Name == name {
+				records = append(records, item)
+			}
+		case <-deadline.C:
+			require.Failf(t, "timeout while waiting for metric records", "missing metric: %s", name)
+			return records
+		}
+	}
+
+	return records
 }

--- a/pkg/export/otel/metrics_internal_test.go
+++ b/pkg/export/otel/metrics_internal_test.go
@@ -146,14 +146,14 @@ func TestInternalMetricsReporterAvoidedServicesBounded(t *testing.T) {
 		}
 
 		assert.NotContains(t, record.Attributes, avoidedsvc.OverflowAttribute)
+		assert.NotContains(t, record.Attributes, string(attr.ServiceInstanceID))
 		labelSets[record.Attributes[string(attr.ServiceName)]+"/"+
 			record.Attributes[string(attr.ServiceNamespace)]+"/"+
-			record.Attributes[string(attr.ServiceInstanceID)]+"/"+
 			record.Attributes["telemetry.type"]] = struct{}{}
 	}
 
-	assert.Contains(t, labelSets, "svc-0/ns-0/inst-0/metrics")
-	assert.Contains(t, labelSets, "svc-0/ns-0/inst-0/traces")
+	assert.Contains(t, labelSets, "svc-0/ns-0/metrics")
+	assert.Contains(t, labelSets, "svc-0/ns-0/traces")
 	assert.Equal(t, 1, overflowRecords)
 }
 

--- a/pkg/internal/avoidedsvc/limiter.go
+++ b/pkg/internal/avoidedsvc/limiter.go
@@ -18,33 +18,30 @@ const (
 
 // Labels contains the bounded label values for one avoided-services metric point.
 type Labels struct {
-	ServiceName       string
-	ServiceNamespace  string
-	ServiceInstanceID string
-	TelemetryType     string
-	Overflow          bool
+	ServiceName      string
+	ServiceNamespace string
+	TelemetryType    string
+	Overflow         bool
 }
 
 // PrometheusValues returns values ordered for the Prometheus avoided-services GaugeVec.
 func (l Labels) PrometheusValues() []string {
 	if l.Overflow {
-		return []string{"", "", "", "", prometheusOverflowTrue}
+		return []string{"", "", "", prometheusOverflowTrue}
 	}
 
 	return []string{
 		l.ServiceName,
 		l.ServiceNamespace,
-		l.ServiceInstanceID,
 		l.TelemetryType,
 		prometheusOverflowFalse,
 	}
 }
 
 type identity struct {
-	serviceName       string
-	serviceNamespace  string
-	serviceInstanceID string
-	telemetryType     string
+	serviceName      string
+	serviceNamespace string
+	telemetryType    string
 }
 
 type Limiter struct {
@@ -70,22 +67,20 @@ func LimitOrDefault(limit int) int {
 }
 
 // Labels returns either the original labels or the OpenTelemetry overflow label set.
-func (l *Limiter) Labels(serviceName, serviceNamespace, serviceInstanceID, telemetryType string) Labels {
+func (l *Limiter) Labels(serviceName, serviceNamespace, _ string, telemetryType string) Labels {
 	labels := Labels{
-		ServiceName:       serviceName,
-		ServiceNamespace:  serviceNamespace,
-		ServiceInstanceID: serviceInstanceID,
-		TelemetryType:     telemetryType,
+		ServiceName:      serviceName,
+		ServiceNamespace: serviceNamespace,
+		TelemetryType:    telemetryType,
 	}
 	if l == nil {
 		return labels
 	}
 
 	id := identity{
-		serviceName:       serviceName,
-		serviceNamespace:  serviceNamespace,
-		serviceInstanceID: serviceInstanceID,
-		telemetryType:     telemetryType,
+		serviceName:      serviceName,
+		serviceNamespace: serviceNamespace,
+		telemetryType:    telemetryType,
 	}
 
 	l.mux.Lock()

--- a/pkg/internal/avoidedsvc/limiter.go
+++ b/pkg/internal/avoidedsvc/limiter.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package avoidedsvc
+package avoidedsvc // import "go.opentelemetry.io/obi/pkg/internal/avoidedsvc"
 
 import "sync"
 

--- a/pkg/internal/avoidedsvc/limiter.go
+++ b/pkg/internal/avoidedsvc/limiter.go
@@ -1,0 +1,102 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package avoidedsvc
+
+import "sync"
+
+const (
+	// DefaultLimit follows the OpenTelemetry metric cardinality limit default.
+	DefaultLimit = 2000
+	// OverflowAttribute is the OpenTelemetry metric overflow attribute.
+	OverflowAttribute = "otel.metric.overflow"
+	// PrometheusOverflowLabel is the Prometheus-safe form of OverflowAttribute.
+	PrometheusOverflowLabel = "otel_metric_overflow"
+	prometheusOverflowTrue  = "true"
+	prometheusOverflowFalse = "false"
+)
+
+// Labels contains the bounded label values for one avoided-services metric point.
+type Labels struct {
+	ServiceName       string
+	ServiceNamespace  string
+	ServiceInstanceID string
+	TelemetryType     string
+	Overflow          bool
+}
+
+// PrometheusValues returns values ordered for the Prometheus avoided-services GaugeVec.
+func (l Labels) PrometheusValues() []string {
+	if l.Overflow {
+		return []string{"", "", "", "", prometheusOverflowTrue}
+	}
+
+	return []string{
+		l.ServiceName,
+		l.ServiceNamespace,
+		l.ServiceInstanceID,
+		l.TelemetryType,
+		prometheusOverflowFalse,
+	}
+}
+
+type identity struct {
+	serviceName       string
+	serviceNamespace  string
+	serviceInstanceID string
+	telemetryType     string
+}
+
+type Limiter struct {
+	limit int
+	seen  map[identity]struct{}
+	mux   sync.Mutex
+}
+
+// NewLimiter creates a limiter that bounds avoided-services metric series.
+func NewLimiter(limit int) *Limiter {
+	return &Limiter{
+		limit: LimitOrDefault(limit),
+		seen:  map[identity]struct{}{},
+	}
+}
+
+// LimitOrDefault returns the configured limit or the OpenTelemetry default.
+func LimitOrDefault(limit int) int {
+	if limit <= 0 {
+		return DefaultLimit
+	}
+	return limit
+}
+
+// Labels returns either the original labels or the OpenTelemetry overflow label set.
+func (l *Limiter) Labels(serviceName, serviceNamespace, serviceInstanceID, telemetryType string) Labels {
+	labels := Labels{
+		ServiceName:       serviceName,
+		ServiceNamespace:  serviceNamespace,
+		ServiceInstanceID: serviceInstanceID,
+		TelemetryType:     telemetryType,
+	}
+	if l == nil {
+		return labels
+	}
+
+	id := identity{
+		serviceName:       serviceName,
+		serviceNamespace:  serviceNamespace,
+		serviceInstanceID: serviceInstanceID,
+		telemetryType:     telemetryType,
+	}
+
+	l.mux.Lock()
+	defer l.mux.Unlock()
+	if _, ok := l.seen[id]; ok {
+		return labels
+	}
+	if len(l.seen) >= l.limit-1 {
+		return Labels{Overflow: true}
+	}
+
+	l.seen[id] = struct{}{}
+	return labels
+}

--- a/pkg/internal/avoidedsvc/limiter_test.go
+++ b/pkg/internal/avoidedsvc/limiter_test.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package avoidedsvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimiterIgnoresServiceInstanceID(t *testing.T) {
+	limiter := NewLimiter(3)
+
+	assert.False(t, limiter.Labels("svc", "ns", "inst-0", "metrics").Overflow)
+	assert.False(t, limiter.Labels("svc", "ns", "inst-1", "metrics").Overflow)
+	assert.False(t, limiter.Labels("svc", "ns", "inst-0", "traces").Overflow)
+	assert.True(t, limiter.Labels("other", "ns", "inst-0", "metrics").Overflow)
+}

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -35,6 +35,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 	"go.opentelemetry.io/obi/pkg/export/prom"
 	"go.opentelemetry.io/obi/pkg/filter"
+	"go.opentelemetry.io/obi/pkg/internal/avoidedsvc"
 	"go.opentelemetry.io/obi/pkg/kube"
 	"go.opentelemetry.io/obi/pkg/kube/kubeflags"
 	"go.opentelemetry.io/obi/pkg/transform"
@@ -270,6 +271,9 @@ var DefaultConfig = Config{
 	TracePrinter: debug.TracePrinterDisabled,
 	InternalMetrics: imetrics.InternalMetricsConfig{
 		Exporter: imetrics.InternalMetricsExporterDisabled,
+		AvoidedServices: imetrics.AvoidedServicesConfig{
+			Limit: avoidedsvc.DefaultLimit,
+		},
 		Prometheus: imetrics.PrometheusConfig{
 			Port: 0, // disabled by default
 			Path: "/internal/metrics",

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -30,6 +30,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 	"go.opentelemetry.io/obi/pkg/export/prom"
+	"go.opentelemetry.io/obi/pkg/internal/avoidedsvc"
 	"go.opentelemetry.io/obi/pkg/internal/pipe/cidr"
 	"go.opentelemetry.io/obi/pkg/kube"
 	"go.opentelemetry.io/obi/pkg/kube/kubeflags"
@@ -273,6 +274,9 @@ discovery:
 		},
 		InternalMetrics: imetrics.InternalMetricsConfig{
 			Exporter: imetrics.InternalMetricsExporterDisabled,
+			AvoidedServices: imetrics.AvoidedServicesConfig{
+				Limit: avoidedsvc.DefaultLimit,
+			},
 			Prometheus: imetrics.PrometheusConfig{
 				Port: 3210,
 				Path: "/internal/metrics",


### PR DESCRIPTION
## Summary

This bounds the cardinality of the internal `avoided_services` metric so repeated detection of already-instrumented services cannot create unbounded backend-visible series.

The change adds a small internal limiter shared by the Prometheus and OTEL internal metrics reporters. The limiter keeps normal labels for the logical service (`service.name`, `service.namespace`) and avoided telemetry type until the configured series limit is reached, then records additional detections through the OpenTelemetry overflow attribute (`otel.metric.overflow=true`). The Prometheus exporter uses the equivalent `otel_metric_overflow` label.

The metric intentionally does not report `service.instance.id` / `service_instance_id`; that value is unique per service instance and would turn service-instance churn into time-series churn in Prometheus-compatible backends.

The new configuration lives under `internal_metrics.avoided_services`:

- `disabled`: disables the avoided-services internal metric
- `limit`: bounds avoided-services metric series, including the overflow series; defaults to the OTel metric cardinality default of `2000`

Docs and generated config schema have been updated alongside focused Prometheus and OTEL internal-metrics tests.

Fixes #2037.

## Validation

- `go test ./pkg/internal/avoidedsvc ./pkg/export/imetrics ./pkg/export/otel`
- `go test ./pkg/obi`
- `make check-config-schema`
- `make lint-markdown`
