### PR TITLE
GenAI: capture MCP tool-call arguments and results

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -729,15 +729,18 @@ func (b *VendorBedrock) GetStopReason() string {
 
 // MCPCall holds parsed data from a Model Context Protocol request/response.
 type MCPCall struct {
-	Method       string `json:"method"`
-	ToolName     string `json:"toolName,omitempty"`
-	ResourceURI  string `json:"resourceUri,omitempty"`
-	PromptName   string `json:"promptName,omitempty"`
-	SessionID    string `json:"sessionId,omitempty"`
-	ProtocolVer  string `json:"protocolVer,omitempty"`
-	RequestID    string `json:"requestId,omitempty"`
-	ErrorCode    int    `json:"errorCode,omitempty"`
-	ErrorMessage string `json:"errorMessage,omitempty"`
+	Method            string `json:"method"`
+	ToolName          string `json:"toolName,omitempty"`
+	ToolType          string `json:"toolType,omitempty"`
+	ToolCallArguments string `json:"toolCallArguments,omitempty"`
+	ToolCallResult    string `json:"toolCallResult,omitempty"`
+	ResourceURI       string `json:"resourceUri,omitempty"`
+	PromptName        string `json:"promptName,omitempty"`
+	SessionID         string `json:"sessionId,omitempty"`
+	ProtocolVer       string `json:"protocolVer,omitempty"`
+	RequestID         string `json:"requestId,omitempty"`
+	ErrorCode         int    `json:"errorCode,omitempty"`
+	ErrorMessage      string `json:"errorMessage,omitempty"`
 }
 
 // OperationName returns the GenAI operation name for the MCP method.

--- a/pkg/ebpf/common/http/mcp.go
+++ b/pkg/ebpf/common/http/mcp.go
@@ -49,7 +49,8 @@ const mcpSessionHeader = "Mcp-Session-Id"
 // Param structures for extracting method-specific fields.
 
 type mcpToolCallParams struct {
-	Name string `json:"name"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
 }
 
 type mcpResourceParams struct {
@@ -66,6 +67,10 @@ type mcpInitializeParams struct {
 
 type mcpInitializeResult struct {
 	ProtocolVersion string `json:"protocolVersion"`
+}
+
+type mcpToolCallResult struct {
+	Content json.RawMessage `json:"content,omitempty"`
 }
 
 // MCPSpanFromParsed detects MCP signals in a pre-parsed JSON-RPC request and
@@ -169,6 +174,10 @@ func parseMCPParams(rpcReq jsonRPCRequest, result *request.MCPCall) {
 		var p mcpToolCallParams
 		if json.Unmarshal(rpcReq.Params, &p) == nil {
 			result.ToolName = p.Name
+			result.ToolType = "function"
+			if len(p.Arguments) > 0 {
+				result.ToolCallArguments = string(p.Arguments)
+			}
 		}
 	case "resources/read", "resources/subscribe", "resources/unsubscribe":
 		var p mcpResourceParams
@@ -227,6 +236,13 @@ func applyMCPResponse(resp jsonRPCResponse, result *request.MCPCall) {
 		var initResult mcpInitializeResult
 		if json.Unmarshal(resp.Result, &initResult) == nil && initResult.ProtocolVersion != "" {
 			result.ProtocolVer = initResult.ProtocolVersion
+		}
+	}
+
+	if result.Method == "tools/call" && len(resp.Result) > 0 {
+		var toolResult mcpToolCallResult
+		if json.Unmarshal(resp.Result, &toolResult) == nil && len(toolResult.Content) > 0 {
+			result.ToolCallResult = string(toolResult.Content)
 		}
 	}
 }

--- a/pkg/ebpf/common/http/mcp_test.go
+++ b/pkg/ebpf/common/http/mcp_test.go
@@ -154,6 +154,9 @@ func TestMCPSpan_ToolCall(t *testing.T) {
 	assert.Equal(t, request.HTTPSubtypeMCP, span.SubType)
 	assert.Equal(t, "tools/call", mcp.Method)
 	assert.Equal(t, "get-weather", mcp.ToolName)
+	assert.Equal(t, "function", mcp.ToolType)
+	assert.JSONEq(t, `{"location": "San Francisco"}`, mcp.ToolCallArguments)
+	assert.JSONEq(t, `[{"type": "text", "text": "Sunny, 72°F"}]`, mcp.ToolCallResult)
 	assert.Equal(t, "sess-abc-123", mcp.SessionID)
 	assert.Equal(t, "1", mcp.RequestID)
 	assert.Equal(t, 0, mcp.ErrorCode)
@@ -175,6 +178,9 @@ func TestMCPSpan_ToolCallError(t *testing.T) {
 	mcp := span.GenAI.MCP
 	assert.Equal(t, "tools/call", mcp.Method)
 	assert.Equal(t, "get-weather", mcp.ToolName)
+	assert.Equal(t, "function", mcp.ToolType)
+	assert.JSONEq(t, `{"location": "San Francisco"}`, mcp.ToolCallArguments)
+	assert.Empty(t, mcp.ToolCallResult)
 	assert.Equal(t, -32602, mcp.ErrorCode)
 	assert.Equal(t, "Unknown tool: nonexistent", mcp.ErrorMessage)
 }

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -242,10 +242,13 @@ const (
 	GenAIInstructions = Name(semconv.GenAISystemInstructionsKey)
 	GenAIOutput       = Name(semconv.GenAIOutputMessagesKey)
 	GenAIMetadata     = Name("gen_ai.metadata")
-	GenAITools        = Name(semconv.GenAIToolDefinitionsKey)
-	GenAIToolName     = Name("gen_ai.tool.name")
-	GenAIToolCallID   = Name("gen_ai.tool.call.id")
-	GenAIPromptName   = Name("gen_ai.prompt.name")
+	GenAITools             = Name(semconv.GenAIToolDefinitionsKey)
+	GenAIToolName          = Name("gen_ai.tool.name")
+	GenAIToolType          = Name("gen_ai.tool.type")
+	GenAIToolCallID        = Name("gen_ai.tool.call.id")
+	GenAIToolCallArguments = Name("gen_ai.tool.call.arguments")
+	GenAIToolCallResult    = Name("gen_ai.tool.call.result")
+	GenAIPromptName        = Name("gen_ai.prompt.name")
 )
 
 // OBI specific GPU events

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -238,10 +238,10 @@ const (
 	CloudRegion = Name(semconv.CloudRegionKey)
 
 	// GenAI
-	GenAIInput        = Name(semconv.GenAIInputMessagesKey)
-	GenAIInstructions = Name(semconv.GenAISystemInstructionsKey)
-	GenAIOutput       = Name(semconv.GenAIOutputMessagesKey)
-	GenAIMetadata     = Name("gen_ai.metadata")
+	GenAIInput             = Name(semconv.GenAIInputMessagesKey)
+	GenAIInstructions      = Name(semconv.GenAISystemInstructionsKey)
+	GenAIOutput            = Name(semconv.GenAIOutputMessagesKey)
+	GenAIMetadata          = Name("gen_ai.metadata")
 	GenAITools             = Name(semconv.GenAIToolDefinitionsKey)
 	GenAIToolName          = Name("gen_ai.tool.name")
 	GenAIToolType          = Name("gen_ai.tool.type")

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -387,7 +387,9 @@ func genAIToolCallAttributes(toolCalls []request.ToolCall) []attribute.KeyValue 
 }
 
 // mcpAttributes returns MCP span attributes following the OTEL MCP semantic conventions.
-func mcpAttributes(span *request.Span) []attribute.KeyValue {
+// Tool call arguments and results are gated behind optionalAttrs (GenAIInput/GenAIOutput)
+// because they may be large or contain sensitive data.
+func mcpAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
 	if span.SubType != request.HTTPSubtypeMCP || span.GenAI == nil || span.GenAI.MCP == nil {
 		return nil
 	}
@@ -398,6 +400,16 @@ func mcpAttributes(span *request.Span) []attribute.KeyValue {
 	}
 	if mcp.ToolName != "" {
 		attrs = append(attrs, attribute.String(string(attr.GenAIToolName), mcp.ToolName))
+	}
+	if mcp.ToolType != "" {
+		attrs = append(attrs, attribute.String(string(attr.GenAIToolType), mcp.ToolType))
+	}
+	// Gate potentially large/sensitive tool call data behind optionalAttrs
+	if _, ok := optionalAttrs[attr.GenAIInput]; ok && mcp.ToolCallArguments != "" {
+		attrs = append(attrs, attribute.String(string(attr.GenAIToolCallArguments), mcp.ToolCallArguments))
+	}
+	if _, ok := optionalAttrs[attr.GenAIOutput]; ok && mcp.ToolCallResult != "" {
+		attrs = append(attrs, attribute.String(string(attr.GenAIToolCallResult), mcp.ToolCallResult))
 	}
 	if mcp.ResourceURI != "" {
 		attrs = append(attrs, attribute.String(string(attr.MCPResourceURI), mcp.ResourceURI))
@@ -488,7 +500,7 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			attrs = append(attrs, semconv.GraphQLOperationName(span.GraphQL.OperationName))
 			attrs = append(attrs, request.GraphqlOperationType(span.GraphQL.OperationType))
 		}
-		attrs = append(attrs, mcpAttributes(span)...)
+		attrs = append(attrs, mcpAttributes(span, optionalAttrs)...)
 		attrs = append(attrs, jsonRPCAttributes(span)...)
 		attrs = append(attrs, httpEnrichmentAttributes(span)...)
 	case request.EventTypeGRPC:
@@ -1006,7 +1018,7 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			}
 		}
 
-		attrs = append(attrs, mcpAttributes(span)...)
+		attrs = append(attrs, mcpAttributes(span, optionalAttrs)...)
 
 		if span.SubType == request.HTTPSubtypeEmbedding && span.GenAI != nil && span.GenAI.Embedding != nil {
 			ai := span.GenAI.Embedding


### PR DESCRIPTION
## Changes

Add support for capturing MCP tool-call arguments, results, and tool type. This enriches MCP spans with the actual parameters passed to tool invocations and their return values.

### New fields in MCPCall:
- `ToolType` - the type of tool (e.g. "function")
- `ToolCallArguments` - JSON string of tool call arguments
- `ToolCallResult` - JSON string of tool call result

### Implementation details:
- Parse `arguments` from `tools/call` request params
- Parse `content` from `tools/call` response result
- Gate argument/result attributes behind `GenAIInput`/`GenAIOutput` optional attrs (may contain sensitive data)
- Add `gen_ai.tool.type`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` attribute constants

Relates to #2267