### PR TITLE
GenAI: extract retrieval top_k from multi-vendor formats

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -983,6 +983,22 @@ type RetrievalRequest struct {
 	CollectionName  string `json:"collectionName,omitempty"`
 	CollectionSnake string `json:"collection_name,omitempty"`
 	Namespace       string `json:"namespace,omitempty"`
+	// TopK / limit for similarity search results.
+	// Pinecone/Qdrant use "topK"/"top_k", Milvus/Chroma use "limit".
+	TopK      int `json:"topK,omitempty"`
+	TopKSnake int `json:"top_k,omitempty"`
+	Limit     int `json:"limit,omitempty"`
+}
+
+// GetTopK returns the top-k value from whichever field was populated.
+func (r *RetrievalRequest) GetTopK() int {
+	if r.TopK > 0 {
+		return r.TopK
+	}
+	if r.TopKSnake > 0 {
+		return r.TopKSnake
+	}
+	return r.Limit
 }
 
 // RetrievalResponse captures the common fields from vector search response

--- a/pkg/ebpf/common/http/retrieval_test.go
+++ b/pkg/ebpf/common/http/retrieval_test.go
@@ -76,6 +76,7 @@ func TestRetrievalSpan_Pinecone(t *testing.T) {
 	assert.Equal(t, "pinecone", ai.Provider)
 	assert.Equal(t, "retrieval", ai.OperationName())
 	assert.Equal(t, "ns1", ai.GetCollection())
+	assert.Equal(t, 3, ai.Input.GetTopK())
 }
 
 func TestRetrievalSpan_Qdrant(t *testing.T) {
@@ -92,6 +93,7 @@ func TestRetrievalSpan_Qdrant(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, span.GenAI.Retrieval)
 	assert.Equal(t, "qdrant", span.GenAI.Retrieval.Provider)
+	assert.Equal(t, 5, span.GenAI.Retrieval.Input.GetTopK())
 }
 
 func TestRetrievalSpan_Milvus(t *testing.T) {
@@ -109,6 +111,7 @@ func TestRetrievalSpan_Milvus(t *testing.T) {
 	require.NotNil(t, span.GenAI.Retrieval)
 	assert.Equal(t, "zilliz", span.GenAI.Retrieval.Provider)
 	assert.Equal(t, "documents", span.GenAI.Retrieval.GetCollection())
+	assert.Equal(t, 10, span.GenAI.Retrieval.Input.GetTopK())
 }
 
 func TestRetrievalSpan_UnknownHost_GenericDetection(t *testing.T) {

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -1053,6 +1053,9 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			if collection := ai.GetCollection(); collection != "" {
 				attrs = append(attrs, semconv.GenAIDataSourceID(collection))
 			}
+			if topK := ai.Input.GetTopK(); topK > 0 {
+				attrs = append(attrs, attribute.Int("gen_ai.retrieval.top_k", topK))
+			}
 		}
 
 		attrs = append(attrs, jsonRPCAttributes(span)...)


### PR DESCRIPTION
## Changes

Add unified top-k extraction for vector retrieval operations:

- `RetrievalRequest.TopK` (Pinecone), `.TopKSnake` (Qdrant), `.Limit` (Milvus/Chroma)
- `GetTopK()` getter returns first non-zero value
- Emit `gen_ai.retrieval.top_k` span attribute

Relates to #2267