### PR TITLE
GenAI: derive embedding dimensions from response data

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -395,6 +395,22 @@ func (ai *VendorOpenAI) GetOutput() string {
 	return normalizeOpenAIOutput(ai)
 }
 
+func (ai *VendorOpenAI) GetEmbeddingDimensions() int {
+	if ai.Request.Dimensions > 0 {
+		return ai.Request.Dimensions
+	}
+	if len(ai.Data) == 0 {
+		return 0
+	}
+	var data []struct {
+		Embedding []json.Number `json:"embedding"`
+	}
+	if err := json.Unmarshal(ai.Data, &data); err != nil || len(data) == 0 {
+		return 0
+	}
+	return len(data[0].Embedding)
+}
+
 type OpenAIInput struct {
 	Input           string          `json:"input"`
 	Prompt          string          `json:"prompt"`

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -696,8 +696,8 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Error.Type))
 			}
 			if ai.OperationName == request.EmbeddingOperationName {
-				if ai.Request.Dimensions > 0 {
-					attrs = append(attrs, semconv.GenAIEmbeddingsDimensionCount(ai.Request.Dimensions))
+				if dims := ai.GetEmbeddingDimensions(); dims > 0 {
+					attrs = append(attrs, semconv.GenAIEmbeddingsDimensionCount(dims))
 				}
 				if ai.Request.EncodingFormat != "" {
 					attrs = append(attrs, semconv.GenAIRequestEncodingFormats(ai.Request.EncodingFormat))
@@ -924,6 +924,14 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			if _, ok := optionalAttrs[attr.GenAIMetadata]; ok {
 				if len(ai.Metadata) > 0 {
 					attrs = append(attrs, request.Metadata(string(ai.Metadata)))
+				}
+			}
+			if ai.OperationName == request.EmbeddingOperationName {
+				if dims := ai.GetEmbeddingDimensions(); dims > 0 {
+					attrs = append(attrs, semconv.GenAIEmbeddingsDimensionCount(dims))
+				}
+				if ai.Request.EncodingFormat != "" {
+					attrs = append(attrs, semconv.GenAIRequestEncodingFormats(ai.Request.EncodingFormat))
 				}
 			}
 			if ai.Error.Type != "" {


### PR DESCRIPTION
## Changes

Add `GetEmbeddingDimensions()` method to `VendorOpenAI`:

- Returns `Request.Dimensions` when explicitly set
- Falls back to deriving dimensions from the first embedding vector in response data
- Replaces direct field access in trace generation for more robust dimension reporting

Relates to #2267