### PR TITLE
Simplify internal structure of msg.Queue

### DIFF
--- a/pkg/pipe/msg/queue.go
+++ b/pkg/pipe/msg/queue.go
@@ -20,6 +20,12 @@ const defaultSendTimeout = time.Minute
 
 const unnamed = "(unnamed)"
 
+// bypassMu serializes all the routing changes (Bypass and Subscribe) across every
+// queue. These operations only happen while the pipeline is being wired up, so a
+// single global lock keeps the bookkeeping trivially correct without complicating
+// the Send hot path (which never acquires it).
+var bypassMu sync.Mutex
+
 type queueConfig struct {
 	channelBufferLen int
 	closingAttempts  int
@@ -86,25 +92,48 @@ type dst[T any] struct {
 	ch   chan T
 }
 
+// sink holds the mutable, shared delivery state of a group of queues connected through Bypass.
+// When a Queue is bypassed to another Queue, the *sink reference is transferred to the destination.
+// So e.g. in a chain of a->b->c->d bypassing queues, invoking a.Send will directly deliver
+// the message to d's subscribers.
+type sink[T any] struct {
+	mt sync.Mutex
+	// cfg is the configuration of the queue that owns this sink (the final destination of the
+	// bypass group). It drives the channel buffer length and the send timeout behavior.
+	cfg *queueConfig
+	// dsts are the subscriber channels of all the queues in the group.
+	dsts []dst[T]
+	// members are all the queues currently routing into this sink. When two groups merge, the
+	// members of the source group are re-pointed here, so every queue always references the
+	// current destination sink directly.
+	members []*Queue[T]
+	closed  atomic.Bool
+
+	sendTimeout *time.Timer
+	logger      *slog.Logger
+}
+
 // Queue is a simple message queue that allows sending messages to multiple subscribers.
 // It also allows bypassing messages to other queues, so that a message sent to one queue
 // can be received by subscribers of another queue.
 // If a message is sent to a queue that has no subscribers, it will not block the sender and the
 // message will be lost. This is by design, as the queue is meant to be used for fire-and-forget
 type Queue[T any] struct {
-	mt  sync.Mutex
 	cfg *queueConfig
 
-	dsts             []dst[T]
+	// sink points to the shared delivery state of this queue's bypass chain. It is never nil and,
+	// after one or more Bypass calls, points directly to the final destination of the chain.
+	sink *sink[T]
+
+	// routeNames is the sequence of queue names from this queue to its sink's destination,
+	// used only for building human-readable diagnostics about blocked send paths.
+	routeNames []string
+
+	// bypassed is set the first time Bypass is invoked on this queue, to enforce that a queue
+	// can only bypass to a single destination.
+	bypassed bool
+
 	remainingClosers int
-
-	// linked list of bypassing queues
-	// For simplicity, a Queue instance can only bypass to a single queue, despite multiple queues can bypass to it
-	bypassTo *Queue[T]
-	closed   atomic.Bool
-
-	sendTimeout *time.Timer
-	logger      *slog.Logger
 }
 
 // NewQueue creates a new Queue instance with the given options.
@@ -113,12 +142,18 @@ func NewQueue[T any](opts ...QueueOpts) *Queue[T] {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	return &Queue[T]{
+	q := &Queue[T]{
 		cfg:              &cfg,
+		routeNames:       []string{cfg.name},
 		remainingClosers: cfg.closingAttempts,
-		sendTimeout:      time.NewTimer(cfg.sendTimeout),
-		logger:           slog.With("queueName", cfg.name),
 	}
+	q.sink = &sink[T]{
+		cfg:         &cfg,
+		members:     []*Queue[T]{q},
+		sendTimeout: time.NewTimer(cfg.sendTimeout),
+		logger:      slog.With("queueName", cfg.name),
+	}
+	return q
 }
 
 // SendCtx sends a message to all subscribers of this queue, and interrupts the operation if the
@@ -130,7 +165,8 @@ func NewQueue[T any](opts ...QueueOpts) *Queue[T] {
 // the SendCtx operation would block for all the subscribers until all the internal channels
 // of the Queue room for a new message.
 func (q *Queue[T]) SendCtx(ctx context.Context, o T) {
-	q.chainedSend(ctx, o, node{name: q.cfg.name})
+	q.assertNotClosed()
+	q.sink.send(ctx, o, q.routeNames)
 }
 
 // Send is analogous to SendCtx(context.Background()).
@@ -139,36 +175,33 @@ func (q *Queue[T]) SendCtx(ctx context.Context, o T) {
 //
 // Deprecated: use SendCtx instead.
 func (q *Queue[T]) Send(o T) {
-	q.chainedSend(context.Background(), o, node{name: q.cfg.name})
+	q.assertNotClosed()
+	q.sink.send(context.Background(), o, q.routeNames)
 }
 
-func (q *Queue[T]) chainedSend(ctx context.Context, o T, source node) {
-	q.assertNotClosed()
-	if q.bypassTo != nil {
-		q.bypassTo.chainedSend(ctx, o, node{name: q.bypassTo.cfg.name, source: &source})
-		return
-	}
-
-	// Subscribe appends to q.dsts under q.mt. Snapshot the subscriber list here so this Send
+// send delivers the message to all the subscribers of the sink. route is the path of queue names
+// that lead to this sink, used only to build diagnostics when a subscriber blocks.
+func (s *sink[T]) send(ctx context.Context, o T, route []string) {
+	// Subscribe appends to s.dsts under s.mt. Snapshot the subscriber list here so this Send
 	// iterates a stable copy: concurrent Subscribe is safe and we avoid racing on the slice
 	// header. Do not hold the mutex while writing to subscriber channels (Send can block).
-	q.mt.Lock()
-	if len(q.dsts) == 0 {
-		q.mt.Unlock()
+	s.mt.Lock()
+	if len(s.dsts) == 0 {
+		s.mt.Unlock()
 		// this can happen in dead paths (which are valid for disabled pipeline branches),
 		// exiting early to save timeout management
 		return
 	}
-	dsts := make([]dst[T], len(q.dsts))
-	copy(dsts, q.dsts)
-	q.mt.Unlock()
+	dsts := make([]dst[T], len(s.dsts))
+	copy(dsts, s.dsts)
+	s.mt.Unlock()
 
-	if q.cfg.panicOnTimeout {
+	if s.cfg.panicOnTimeout {
 		// instead of directly panicking in sendTimeout, we first warn at 90% sendTimeout,
 		// to get logged about other blocked senders before panicking
-		q.sendTimeout.Reset(9 * q.cfg.sendTimeout / 10)
+		s.sendTimeout.Reset(9 * s.cfg.sendTimeout / 10)
 	} else {
-		q.sendTimeout.Reset(q.cfg.sendTimeout)
+		s.sendTimeout.Reset(s.cfg.sendTimeout)
 	}
 	var blocked []dst[T]
 	for _, d := range dsts {
@@ -177,24 +210,22 @@ func (q *Queue[T]) chainedSend(ctx context.Context, o T, source node) {
 			return
 		case d.ch <- o:
 			// good!
-		case <-q.sendTimeout.C:
-			bypassPath := node{name: d.name, source: &source}
-
-			q.logger.Warn("an internal queue seems to be blocked. You might need to change "+
+		case <-s.sendTimeout.C:
+			s.logger.Warn("an internal queue seems to be blocked. You might need to change "+
 				"some of the following configuration options: OTEL_EBPF_OTLP_TRACES_BATCH_MAX_SIZE, "+
 				"OTEL_EBPF_OTLP_TRACES_QUEUE_SIZE, OTEL_EBPF_CHANNEL_BUFFER_LEN, OTEL_EBPF_CHANNEL_SEND_TIMEOUT, "+
 				"OTEL_EBPF_BPF_BATCH_LENGTH, OTEL_EBPF_BPF_BATCH_TIMEOUT",
-				slog.Duration("timeout", q.cfg.sendTimeout),
+				slog.Duration("timeout", s.cfg.sendTimeout),
 				slog.Int("queueLen", len(d.ch)),
 				slog.Int("queueCap", cap(d.ch)),
-				slog.String("sendPath", bypassPath.String()),
+				slog.String("sendPath", sendPath(route, d.name)),
 				slog.String("subscriber", d.name),
 			)
 			blocked = append(blocked, d)
 		}
 	}
 
-	if !q.cfg.panicOnTimeout {
+	if !s.cfg.panicOnTimeout {
 		// if we don't configure the queue to panic on timeout, we wait
 		// for the messages to be delivered
 		for _, d := range blocked {
@@ -207,17 +238,16 @@ func (q *Queue[T]) chainedSend(ctx context.Context, o T, source node) {
 		}
 	} else {
 		// if we confirm that the blocker candidates are actually blocked, we panic
-		q.sendTimeout.Reset(q.cfg.sendTimeout / 10)
+		s.sendTimeout.Reset(s.cfg.sendTimeout / 10)
 		for _, d := range blocked {
 			select {
 			case <-ctx.Done():
 				return
 			case d.ch <- o:
 				// good!
-			case <-q.sendTimeout.C:
-				bypassPath := node{name: d.name, source: &source}
+			case <-s.sendTimeout.C:
 				panic(fmt.Sprintf("sending through queue path %s. Subscriber channel %s is blocked",
-					bypassPath.String(), d.name))
+					sendPath(route, d.name), d.name))
 			}
 		}
 	}
@@ -236,12 +266,6 @@ func SubscriberName(nodeName string) SubscribeOpt {
 	}
 }
 
-func withRawOpts(opts subscribeOpts) SubscribeOpt {
-	return func(o *subscribeOpts) {
-		*o = opts
-	}
-}
-
 // Subscribe to this queue. This will return a channel that will receive messages.
 // It's important to notice that, if Subscribe is invoked after Send, the sent message
 // will be lost.
@@ -251,62 +275,84 @@ func withRawOpts(opts subscribeOpts) SubscribeOpt {
 // not deliver to a subscriber that Subscribe'd immediately after the snapshot (that subscriber
 // misses that message).
 func (q *Queue[T]) Subscribe(options ...SubscribeOpt) <-chan T {
-	q.assertNotClosed()
-	q.mt.Lock()
-	defer q.mt.Unlock()
-
 	opts := subscribeOpts{subscriber: unnamed}
 	for _, opt := range options {
 		opt(&opts)
 	}
 
-	if q.bypassTo != nil {
-		return q.bypassTo.Subscribe(withRawOpts(opts))
-	}
+	// hold bypassMu so q.sink can't be re-pointed by a concurrent Bypass while we subscribe to it
+	bypassMu.Lock()
+	defer bypassMu.Unlock()
+	q.assertNotClosed()
 
-	ch := make(chan T, q.cfg.channelBufferLen)
-	q.dsts = append(q.dsts, dst[T]{ch: ch, name: opts.subscriber})
+	s := q.sink
+	// this mutex is also needed so we don't have race conditions in Send's copy(dsts, s.dsts)
+	s.mt.Lock()
+	defer s.mt.Unlock()
+	ch := make(chan T, s.cfg.channelBufferLen)
+	s.dsts = append(s.dsts, dst[T]{ch: ch, name: opts.subscriber})
 	return ch
 }
 
 // Bypass allows this queue to bypass messages to another queue. This means that
 // messages sent to this queue will also be sent to the other queue.
+// A given queue can only Bypass once, but multiple queues can bypass to the same destination.
 // This operation does not control for graph cycles. It might result in an internal mutex deadlock.
 func (q *Queue[T]) Bypass(to *Queue[T]) {
-	q.assertNotClosed()
-	q.mt.Lock()
-	defer q.mt.Unlock()
 	if q == to {
 		panic(q.cfg.name + ": this queue can't bypass to itself")
 	}
-	q.assertNotBypassing()
 
-	q.bypassTo = to
-	// will copy all the subscribers of the queue to the last queue in the
-	// bypassing chain
-	last := to
-	last.mt.Lock()
-	for last.bypassTo != nil {
-		l := last
-		last = last.bypassTo
-		last.mt.Lock()
-		l.mt.Unlock()
+	bypassMu.Lock()
+	defer bypassMu.Unlock()
+	q.assertNotClosed()
+	if q.bypassed {
+		panic(fmt.Sprintf("queue %s is already bypassing data", q.cfg.name))
 	}
-	last.dsts = append(last.dsts, q.dsts...)
-	q.dsts = nil
-	q.sendTimeout = nil
-	last.mt.Unlock()
+	q.bypassed = true
+
+	srcSink := q.sink
+	dstSink := to.sink
+	if srcSink == dstSink {
+		// q and to already belong to the same bypass group: nothing to merge
+		return
+	}
+
+	srcSink.mt.Lock()
+	defer srcSink.mt.Unlock()
+	dstSink.mt.Lock()
+	defer dstSink.mt.Unlock()
+
+	// move all the subscribers of the source group into the destination group
+	dstSink.dsts = append(dstSink.dsts, srcSink.dsts...)
+	srcSink.dsts = nil
+
+	// re-point every queue of the source group to the destination sink, so future Sends and
+	// Subscribes reach the destination directly, and extend their diagnostic route with to's route
+	for _, m := range srcSink.members {
+		m.sink = dstSink
+		m.routeNames = append(m.routeNames, to.routeNames...)
+	}
+	dstSink.members = append(dstSink.members, srcSink.members...)
+	srcSink.members = nil
+
+	// the source sink is no longer a delivery point: stop its now-orphaned timer
+	if srcSink.sendTimeout != nil {
+		srcSink.sendTimeout.Stop()
+		srcSink.sendTimeout = nil
+	}
 }
 
-// Close all the subscribers of this queue. This will close all the channels
-// or will close the bypassed channel
+// Close all the subscribers of this queue. This will close all the channels of the queue's
+// bypass group.
 func (q *Queue[T]) Close() {
-	q.mt.Lock()
-	defer q.mt.Unlock()
-	if q.sendTimeout != nil {
-		q.sendTimeout.Stop()
-	}
-	q.close()
+	bypassMu.Lock()
+	s := q.sink
+	bypassMu.Unlock()
+
+	s.mt.Lock()
+	defer s.mt.Unlock()
+	s.close()
 }
 
 // MarkCloseable decreases the internal counter of submitters, and if it reaches 0,
@@ -314,61 +360,49 @@ func (q *Queue[T]) Close() {
 // This method is useful for multiple nodes sending messages to the same queue, and
 // willing to close it only when all
 func (q *Queue[T]) MarkCloseable() {
-	q.mt.Lock()
-	defer q.mt.Unlock()
+	bypassMu.Lock()
 	q.remainingClosers--
-	if q.remainingClosers <= 0 {
-		q.close()
-	}
-}
+	doClose := q.remainingClosers <= 0
+	s := q.sink
+	bypassMu.Unlock()
 
-func (q *Queue[T]) close() {
-	if q.closed.Swap(true) {
+	if !doClose {
 		return
 	}
-	if q.bypassTo != nil {
-		q.bypassTo.Close()
-	} else {
-		for _, d := range q.dsts {
-			close(d.ch)
-		}
-		q.dsts = nil
-	}
+	s.mt.Lock()
+	defer s.mt.Unlock()
+	s.close()
 }
 
-func (q *Queue[T]) assertNotBypassing() {
-	if q.bypassTo != nil {
-		panic(fmt.Sprintf("queue %s already bypassing data to queue %s", q.cfg.name, q.bypassTo.cfg.name))
+// close stops the send timer and closes all the subscriber channels of the sink.
+// It must be invoked while holding s.mt.
+func (s *sink[T]) close() {
+	if s.closed.Swap(true) {
+		return
 	}
+	if s.sendTimeout != nil {
+		s.sendTimeout.Stop()
+	}
+	for _, d := range s.dsts {
+		close(d.ch)
+	}
+	s.dsts = nil
 }
 
 func (q *Queue[T]) assertNotClosed() {
-	if q.closed.Load() {
+	if q.sink.closed.Load() {
 		panic(q.cfg.name + ": queue is closed")
 	}
 }
 
-// node allows debugging the submission chain as a linked list that
-// is purely allocated in the function call stack
-type node struct {
-	name   string
-	source *node
-}
-
-func (n *node) String() string {
-	p := n
-	names := []string{p.name}
-	for p.source != nil {
-		p = p.source
-		names = append(names, p.name)
-	}
+// sendPath renders the diagnostic path of a message, from its origin queue to the blocked
+// subscriber, e.g. "src->middle->dst->subscriber".
+func sendPath(route []string, subscriber string) string {
 	sb := strings.Builder{}
-	sb.WriteString(names[len(names)-1])
-	// reverse-iterate the names so we can go from in-memory "dst, ..., source" stack
-	// to print-format "source -> ... -> dst"
-	for i := len(names) - 2; i >= 0; i-- {
+	for _, name := range route {
+		sb.WriteString(name)
 		sb.WriteString("->")
-		sb.WriteString(names[i])
 	}
+	sb.WriteString(subscriber)
 	return sb.String()
 }

--- a/pkg/pipe/msg/queue_test.go
+++ b/pkg/pipe/msg/queue_test.go
@@ -408,24 +408,27 @@ func TestBlockingPanics(t *testing.T) {
 	})
 }
 
-func TestNodeString(t *testing.T) {
+func TestSendPath(t *testing.T) {
 	type tc struct {
 		expect string
-		start  node
+		route  []string
 	}
 	testCases := []tc{{
-		expect: "name-only",
-		start:  node{name: "name-only"},
+		expect: "subscriber",
+		route:  nil,
 	}, {
-		expect: "src->dst",
-		start:  node{name: "dst", source: &node{name: "src"}},
+		expect: "src->subscriber",
+		route:  []string{"src"},
 	}, {
-		expect: "src->middle->dst",
-		start:  node{name: "dst", source: &node{name: "middle", source: &node{name: "src"}}},
+		expect: "src->dst->subscriber",
+		route:  []string{"src", "dst"},
+	}, {
+		expect: "src->middle->dst->subscriber",
+		route:  []string{"src", "middle", "dst"},
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.expect, func(t *testing.T) {
-			assert.Equal(t, tc.expect, tc.start.String())
+			assert.Equal(t, tc.expect, sendPath(tc.route, "subscriber"))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

This is in preparation for addressing issue #1970 .

### Current status:
Each queue holds a `bypassTo *Queue` attribute that chains all the bypassing queues. Each `Send` operation has to iterate through all the `bypassTo` chan until we reach the final node that is not bypassed to any other node.

### This PR
Extracts the internal behavior of a Queue into a `sink` type. When a queue is bypassed to a destination queue, the source `*sink` is moved to the destination, and we add logic to make sure that all the subscribers of the bypassing group are present in this `*sink` instance.

### Expected improvement
Negligible performance improvement (`Send` doesn't need to keep iterating through a linked list of bypasses).

More important, now the internal _bypass queues_ structure is simpler so it becomes easier to debug.

I expect that this simplification of the internal structure will also simplify the management of internal metrics for the queues graph (issue #1970)

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
