### PR TITLE
Fix unit tests in Darwin

### DIFF
--- a/pkg/export/otel/otelcfg/uds_test.go
+++ b/pkg/export/otel/otelcfg/uds_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -91,9 +92,19 @@ func TestUnixTracesEndpointOptions(t *testing.T) {
 func TestUnixSocketMetricsExporter(t *testing.T) {
 	defer RestoreEnvAfterExecution()()
 
-	lis, err := net.Listen("unix", "@obi-test-metrics")
+	// On Linux "@"-prefixed names are abstract sockets (no filesystem entry,
+	// cleaned up by the kernel). macOS doesn't support abstract sockets, so this
+	// becomes a regular socket file in the working directory; remove any leftover
+	// from an interrupted previous run before listening.
+	const sockAddr = "@obi-test-metrics"
+	_ = os.Remove(sockAddr)
+
+	lis, err := net.Listen("unix", sockAddr)
 	require.NoError(t, err)
-	defer lis.Close()
+	t.Cleanup(func() {
+		_ = lis.Close()
+		_ = os.Remove(sockAddr)
+	})
 
 	gotPath := make(chan string, 1)
 	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/export/otel/uds_traces_test.go
+++ b/pkg/export/otel/uds_traces_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -20,9 +21,19 @@ import (
 )
 
 func TestUnixSocketTracesExporter(t *testing.T) {
-	lis, err := net.Listen("unix", "@obi-test-traces")
+	// On Linux "@"-prefixed names are abstract sockets (no filesystem entry,
+	// cleaned up by the kernel). macOS doesn't support abstract sockets, so this
+	// becomes a regular socket file in the working directory; remove any leftover
+	// from an interrupted previous run before listening.
+	const sockAddr = "@obi-test-traces"
+	_ = os.Remove(sockAddr)
+
+	lis, err := net.Listen("unix", sockAddr)
 	require.NoError(t, err)
-	defer lis.Close()
+	t.Cleanup(func() {
+		_ = lis.Close()
+		_ = os.Remove(sockAddr)
+	})
 
 	gotPath := make(chan string, 1)
 	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -72,9 +73,19 @@ func TestServeEndToEnd(t *testing.T) {
 }
 
 func TestServeEndToEndUDS(t *testing.T) {
-	const addr = "@obi-health-test"
-	lis, err := net.Listen("unix", addr)
+	// On Linux "@"-prefixed names are abstract sockets (no filesystem entry,
+	// cleaned up by the kernel). macOS doesn't support abstract sockets, so this
+	// becomes a regular socket file in the working directory; remove any leftover
+	// from an interrupted previous run before listening.
+	const sockAddr = "@obi-health-test"
+	_ = os.Remove(sockAddr)
+
+	lis, err := net.Listen("unix", sockAddr)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = lis.Close()
+		_ = os.Remove(sockAddr)
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -86,7 +97,7 @@ func TestServeEndToEndUDS(t *testing.T) {
 
 	client := &http.Client{Transport: &http.Transport{
 		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			return (&net.Dialer{}).DialContext(ctx, "unix", addr)
+			return (&net.Dialer{}).DialContext(ctx, "unix", sockAddr)
 		},
 	}}
 

--- a/pkg/internal/procs/procmaps_test.go
+++ b/pkg/internal/procs/procmaps_test.go
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// some tests here rely on concrete values for os.GetPageSize() that might differ in non-Linux environments
+//go:build linux
+
 package procs
 
 import (


### PR DESCRIPTION
## Summary

We recently added few unit tests that relied in platform-dependent behaviours.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
