### PR TITLE
Emit `url.query` with automatic redaction for non-Go HTTP spans

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -60,12 +60,12 @@ Attributes configures the decoration of some extra attributes that will be added
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
 |---|---|---|---|---|---|---|
 | `attributes.extra_group_attributes` | [`ExtraGroupAttributesMap`](#extragroupattributesmap) |  |  |  |  | Map of attribute group names to arrays of attribute names. Only 'k8s_app_meta' is currently supported as a key. |
-| `attributes.extra_redact_query_params` | `string`[] | `OTEL_EBPF_EXTRA_REDACT_QUERY_PARAMS` |  |  |  | Lists additional query-parameter keys whose values are replaced with REDACTED in url.full and url.query, on top of the built-in semconv-mandated set (X-Amz-Signature, X-Goog-Signature, sig, …). The built-in set is always applied. |
 | `attributes.metric_span_names_limit` | `integer` | `OTEL_EBPF_METRIC_SPAN_NAMES_LIMIT` | `100` |  |  | Works PER SERVICE and only relates to span_metrics. When the span_name cardinality surpasses this limit, the span_name will be reported as AGGREGATED. If the value <= 0, it is disabled. |
 | `attributes.rename_unresolved_hosts` | `string` | `OTEL_EBPF_RENAME_UNRESOLVED_HOSTS` | `unresolved` |  |  | Will replace HostName and PeerName attributes when they are empty or contain unresolved IP addresses to reduce cardinality. Set this value to the empty string to disable this feature. |
 | `attributes.rename_unresolved_hosts_incoming` | `string` | `OTEL_EBPF_RENAME_UNRESOLVED_HOSTS_INCOMING` | `incoming` |  |  |  |
 | `attributes.rename_unresolved_hosts_outgoing` | `string` | `OTEL_EBPF_RENAME_UNRESOLVED_HOSTS_OUTGOING` | `outgoing` |  |  |  |
 | `attributes.select` | `map[string]object` |  |  |  |  | Selection specifies which attributes are allowed for each signal. The key is usually the metric name (either in Prometheus or OpenTelemetry format); the key "traces" selects optional attributes for exported OTLP traces. The key "resource" selects exported resource attributes. The value is the enumeration of included/excluded attribute globs |
+| `attributes.sensitive_query_params` | [`SensitiveQueryParamsConfig`](#sensitivequeryparamsconfig) |  |  |  |  | Controls which query-parameter keys are redacted in url.full and url.query. |
 
 ### `attributes.host_id`
 
@@ -766,6 +766,15 @@ RegexSelector that specify a given instrumented service. Each instance has to de
 | `routes` | [`CustomRoutesConfig`](#customroutesconfig) |  |  |
 | `sampler` | [`SamplerConfig`](#samplerconfig) |  | Sampler standard configuration <https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/#otel_traces_sampler> We don't support, yet, the jaeger and xray samplers. |
 | `target_pids` | `integer`[] |  | Allows selecting processes by PID. When non-empty, the process PID must be in this list (in addition to any path/port criteria). |
+
+### SensitiveQueryParamsConfig
+
+SensitiveQueryParamsConfig controls which query-parameter keys are redacted. The effective list is DefaultSensitiveQueryParams + Add - Remove. When both Add and Remove are empty, DefaultSensitiveQueryParams is used unchanged.
+
+| Field | Type | Values | Description |
+|---|---|---|---|
+| `add` | `string`[] |  |  |
+| `remove` | `string`[] |  |  |
 
 ### CustomRoutesConfig
 

--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -60,6 +60,7 @@ Attributes configures the decoration of some extra attributes that will be added
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
 |---|---|---|---|---|---|---|
 | `attributes.extra_group_attributes` | [`ExtraGroupAttributesMap`](#extragroupattributesmap) |  |  |  |  | Map of attribute group names to arrays of attribute names. Only 'k8s_app_meta' is currently supported as a key. |
+| `attributes.extra_redact_query_params` | `string`[] | `OTEL_EBPF_EXTRA_REDACT_QUERY_PARAMS` |  |  |  | Lists additional query-parameter keys whose values are replaced with REDACTED in url.full and url.query, on top of the built-in semconv-mandated set (X-Amz-Signature, X-Goog-Signature, sig, …). The built-in set is always applied. |
 | `attributes.metric_span_names_limit` | `integer` | `OTEL_EBPF_METRIC_SPAN_NAMES_LIMIT` | `100` |  |  | Works PER SERVICE and only relates to span_metrics. When the span_name cardinality surpasses this limit, the span_name will be reported as AGGREGATED. If the value <= 0, it is disabled. |
 | `attributes.rename_unresolved_hosts` | `string` | `OTEL_EBPF_RENAME_UNRESOLVED_HOSTS` | `unresolved` |  |  | Will replace HostName and PeerName attributes when they are empty or contain unresolved IP addresses to reduce cardinality. Set this value to the empty string to disable this feature. |
 | `attributes.rename_unresolved_hosts_incoming` | `string` | `OTEL_EBPF_RENAME_UNRESOLVED_HOSTS_INCOMING` | `incoming` |  |  |  |

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -53,6 +53,14 @@
         "extra_group_attributes": {
           "$ref": "#/$defs/ExtraGroupAttributesMap"
         },
+        "extra_redact_query_params": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Lists additional query-parameter keys whose values are replaced with REDACTED in url.full and url.query, on top of the built-in semconv-mandated set (X-Amz-Signature, X-Goog-Signature, sig, …). The built-in set is always applied.",
+          "x-env-var": "OTEL_EBPF_EXTRA_REDACT_QUERY_PARAMS"
+        },
         "host_id": {
           "$ref": "#/$defs/HostIDConfig"
         },

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -53,24 +53,6 @@
         "extra_group_attributes": {
           "$ref": "#/$defs/ExtraGroupAttributesMap"
         },
-        "sensitive_query_params": {
-          "type": "object",
-          "description": "Controls which query-parameter keys are redacted in url.full and url.query. The effective list is the OBI built-in list plus 'add' minus 'remove'.",
-          "properties": {
-            "add": {
-              "type": "array",
-              "items": {"type": "string"},
-              "description": "Extra keys to redact on top of the built-in list.",
-              "x-env-var": "OTEL_EBPF_SENSITIVE_QUERY_PARAMS_ADD"
-            },
-            "remove": {
-              "type": "array",
-              "items": {"type": "string"},
-              "description": "Keys to remove from the built-in list (e.g. to clear false positives).",
-              "x-env-var": "OTEL_EBPF_SENSITIVE_QUERY_PARAMS_REMOVE"
-            }
-          }
-        },
         "host_id": {
           "$ref": "#/$defs/HostIDConfig"
         },
@@ -107,6 +89,10 @@
         },
         "select": {
           "$ref": "#/$defs/Selection"
+        },
+        "sensitive_query_params": {
+          "$ref": "#/$defs/SensitiveQueryParamsConfig",
+          "description": "Controls which query-parameter keys are redacted in url.full and url.query."
         }
       },
       "type": "object",
@@ -2649,6 +2635,24 @@
       },
       "type": "object",
       "description": "Selection specifies which attributes are allowed for each signal. The key is usually the metric name (either in Prometheus or OpenTelemetry format); the key \"traces\" selects optional attributes for exported OTLP traces. The key \"resource\" selects exported resource attributes. The value is the enumeration of included/excluded attribute globs"
+    },
+    "SensitiveQueryParamsConfig": {
+      "properties": {
+        "add": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "remove": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object",
+      "description": "SensitiveQueryParamsConfig controls which query-parameter keys are redacted. The effective list is DefaultSensitiveQueryParams + Add - Remove. When both Add and Remove are empty, DefaultSensitiveQueryParams is used unchanged."
     },
     "StatsConfig": {
       "properties": {

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -53,13 +53,23 @@
         "extra_group_attributes": {
           "$ref": "#/$defs/ExtraGroupAttributesMap"
         },
-        "extra_redact_query_params": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Lists additional query-parameter keys whose values are replaced with REDACTED in url.full and url.query, on top of the built-in semconv-mandated set (X-Amz-Signature, X-Goog-Signature, sig, …). The built-in set is always applied.",
-          "x-env-var": "OTEL_EBPF_EXTRA_REDACT_QUERY_PARAMS"
+        "sensitive_query_params": {
+          "type": "object",
+          "description": "Controls which query-parameter keys are redacted in url.full and url.query. The effective list is the OBI built-in list plus 'add' minus 'remove'.",
+          "properties": {
+            "add": {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "Extra keys to redact on top of the built-in list.",
+              "x-env-var": "OTEL_EBPF_SENSITIVE_QUERY_PARAMS_ADD"
+            },
+            "remove": {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "Keys to remove from the built-in list (e.g. to clear false positives).",
+              "x-env-var": "OTEL_EBPF_SENSITIVE_QUERY_PARAMS_REMOVE"
+            }
+          }
         },
         "host_id": {
           "$ref": "#/$defs/HostIDConfig"

--- a/devdocs/features.md
+++ b/devdocs/features.md
@@ -99,27 +99,3 @@ OBI has support for several asynchronous frameworks that allow it to propagate c
 | Java Thread pool    |   Java    |           JDK 8+ | N/A                                               | Stable
 | Java Virtual Threads |  Java    |          JDK 21+ | Log enrichment is skipped on virtual threads      | Stable
 | Python asyncio      |  Python   |    Python >= 3.9 | Only works with uvloop event loop                 | Stable
-
-## Migration Notes
-
-### url.query now emitted by default
-
-`url.query` is now included in HTTP spans by default, aligning with the OTel semconv
-"Conditionally Required" status. Previously it was opt-in.
-
-Sensitive query-parameter values are automatically replaced with `REDACTED` for the five keys
-mandated by OTel semconv (`X-Amz-Signature`, `X-Amz-Credential`, `X-Amz-Security-Token`,
-`X-Goog-Signature`, `sig`). Additional keys can be added via `attributes.extra_redact_query_params`
-(env: `OTEL_EBPF_EXTRA_REDACT_QUERY_PARAMS`).
-
-For HTTP client spans, `url.full` now contains query parameters with sensitive values
-redacted (same key list). Previously the entire query string was stripped from `url.full`.
-
-**If you need to opt out** (e.g. high-cardinality query strings, privacy requirements):
-
-```yaml
-attributes:
-  select:
-    traces:
-      exclude: [url.query]
-```

--- a/devdocs/features.md
+++ b/devdocs/features.md
@@ -99,3 +99,27 @@ OBI has support for several asynchronous frameworks that allow it to propagate c
 | Java Thread pool    |   Java    |           JDK 8+ | N/A                                               | Stable
 | Java Virtual Threads |  Java    |          JDK 21+ | Log enrichment is skipped on virtual threads      | Stable
 | Python asyncio      |  Python   |    Python >= 3.9 | Only works with uvloop event loop                 | Stable
+
+## Migration Notes
+
+### url.query now emitted by default
+
+`url.query` is now included in HTTP spans by default, aligning with the OTel semconv
+"Conditionally Required" status. Previously it was opt-in.
+
+Sensitive query-parameter values are automatically replaced with `REDACTED` for the five keys
+mandated by OTel semconv (`X-Amz-Signature`, `X-Amz-Credential`, `X-Amz-Security-Token`,
+`X-Goog-Signature`, `sig`). Additional keys can be added via `attributes.extra_redact_query_params`
+(env: `OTEL_EBPF_EXTRA_REDACT_QUERY_PARAMS`).
+
+For HTTP client spans, `url.full` now contains query parameters with sensitive values
+redacted (same key list). Previously the entire query string was stripped from `url.full`.
+
+**If you need to opt out** (e.g. high-cardinality query strings, privacy requirements):
+
+```yaml
+attributes:
+  select:
+    traces:
+      exclude: [url.query]
+```

--- a/internal/test/integration/php_fm_test.go
+++ b/internal/test/integration/php_fm_test.go
@@ -134,7 +134,7 @@ func testHTTPTracesPHP(t *testing.T) {
 
 	var trace jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		resp, err := http.Get(jaegerQueryURL + "?service=nginx&operation=GET%20%2F")
+		resp, err := http.Get(jaegerQueryURL + "?service=php-fpm&operation=GET%20%2F")
 		require.NoError(ct, err)
 		if resp == nil {
 			return
@@ -171,6 +171,58 @@ func testHTTPTracesPHP(t *testing.T) {
 		require.NotEmpty(ct, parent.TraceID)
 		require.Equal(ct, traceID, parent.TraceID)
 		require.NotEmpty(ct, parent.SpanID)
+	}, testTimeout, 100*time.Millisecond)
+
+	// Verify that query parameters from the FastCGI QUERY_STRING field are
+	// propagated to the php-fpm server span as url.query.
+	// Use a unique marker value to avoid matching stale traces from earlier requests.
+	ti.DoHTTPGet(t, "http://localhost:8080/?obi_urlquery_test=1", 200)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=php-fpm&operation=GET%20%2F")
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		defer resp.Body.Close()
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+
+		// Find any trace that has a php-fpm server span carrying url.query.
+		traces := tq.FindBySpan(jaeger.Tag{Key: "url.query", Type: "string", Value: "obi_urlquery_test=1"})
+		require.GreaterOrEqual(ct, len(traces), 1)
+
+		phpSpans := traces[0].FindByOperationNameAndService("GET /", "php-fpm")
+		require.GreaterOrEqual(ct, len(phpSpans), 1)
+		tag, ok := jaeger.FindIn(phpSpans[0].Tags, "url.query")
+		require.True(ct, ok, "url.query tag missing from php-fpm server span")
+		assert.Equal(ct, "obi_urlquery_test=1", tag.Value)
+	}, testTimeout, 100*time.Millisecond)
+
+	// Verify that sensitive query-parameter values are redacted.
+	// "sig" is in the default redact list, so its value must appear as REDACTED.
+	ti.DoHTTPGet(t, "http://localhost:8080/?obi_urlquery_test=2&sig=secret123", 200)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=php-fpm&operation=GET%20%2F")
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		defer resp.Body.Close()
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+
+		traces := tq.FindBySpan(jaeger.Tag{Key: "url.query", Type: "string", Value: "obi_urlquery_test=2&sig=REDACTED"})
+		require.GreaterOrEqual(ct, len(traces), 1)
+
+		phpSpans := traces[0].FindByOperationNameAndService("GET /", "php-fpm")
+		require.GreaterOrEqual(ct, len(phpSpans), 1)
+		tag, ok := jaeger.FindIn(phpSpans[0].Tags, "url.query")
+		require.True(ct, ok, "url.query tag missing from php-fpm server span")
+		assert.Equal(ct, "obi_urlquery_test=2&sig=REDACTED", tag.Value)
 	}, testTimeout, 100*time.Millisecond)
 }
 

--- a/pkg/appolly/instrumenter.go
+++ b/pkg/appolly/instrumenter.go
@@ -66,9 +66,9 @@ func newGraphBuilder(
 	}
 
 	selectorCfg := &attributes.SelectorConfig{
-		SelectionCfg:              config.Attributes.Select,
-		ExtraGroupAttributesCfg:   config.Attributes.ExtraGroupAttributes,
-		ExtraRedactQueryParamsCfg: config.Attributes.ExtraRedactQueryParams,
+		SelectionCfg:            config.Attributes.Select,
+		ExtraGroupAttributesCfg: config.Attributes.ExtraGroupAttributes,
+		SensitiveQueryParamsCfg: config.Attributes.SensitiveQueryParams,
 	}
 
 	// Second, we register instancers for each pipe node, as well as communication queues between them

--- a/pkg/appolly/instrumenter.go
+++ b/pkg/appolly/instrumenter.go
@@ -65,9 +65,14 @@ func newGraphBuilder(
 		ctxInfo: ctxInfo,
 	}
 
+	redactQueryParams := config.Attributes.RedactQueryParams
+	if redactQueryParams == nil {
+		redactQueryParams = attributes.DefaultRedactQueryParams
+	}
 	selectorCfg := &attributes.SelectorConfig{
 		SelectionCfg:            config.Attributes.Select,
 		ExtraGroupAttributesCfg: config.Attributes.ExtraGroupAttributes,
+		RedactQueryParams:       redactQueryParams,
 	}
 
 	// Second, we register instancers for each pipe node, as well as communication queues between them

--- a/pkg/appolly/instrumenter.go
+++ b/pkg/appolly/instrumenter.go
@@ -65,14 +65,10 @@ func newGraphBuilder(
 		ctxInfo: ctxInfo,
 	}
 
-	redactQueryParams := config.Attributes.RedactQueryParams
-	if redactQueryParams == nil {
-		redactQueryParams = attributes.DefaultRedactQueryParams
-	}
 	selectorCfg := &attributes.SelectorConfig{
-		SelectionCfg:            config.Attributes.Select,
-		ExtraGroupAttributesCfg: config.Attributes.ExtraGroupAttributes,
-		RedactQueryParams:       redactQueryParams,
+		SelectionCfg:              config.Attributes.Select,
+		ExtraGroupAttributesCfg:   config.Attributes.ExtraGroupAttributes,
+		ExtraRedactQueryParamsCfg: config.Attributes.ExtraRedactQueryParams,
 	}
 
 	// Second, we register instancers for each pipe node, as well as communication queues between them

--- a/pkg/ebpf/common/fast_cgi_detect_transform.go
+++ b/pkg/ebpf/common/fast_cgi_detect_transform.go
@@ -187,14 +187,10 @@ func detectFastCGI(b, rb *largebuf.LargeBuffer) (string, string, int) {
 			return "", "", -1
 		}
 		uri := kv[requestURIKey]
-		if uri == "" {
-			// Default to "/" when REQUEST_URI is absent (older nginx configs) or
-			// when the buffer was truncated before REQUEST_URI could be parsed.
-			// In the truncation case this may report the wrong path, but it is
-			// the best we can do without the full packet.
-			uri = "/"
-		}
 		if qs := kv[queryStringKey]; qs != "" && strings.IndexByte(uri, '?') < 0 {
+			if uri == "" {
+				uri = "/"
+			}
 			uri = uri + "?" + qs
 		}
 

--- a/pkg/ebpf/common/fast_cgi_detect_transform.go
+++ b/pkg/ebpf/common/fast_cgi_detect_transform.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"io"
 	"strconv"
+	"strings"
 	"unsafe"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
@@ -20,6 +21,7 @@ const (
 	fastCGIRequestHeaderLen = 8
 	requestMethodKey        = "REQUEST_METHOD"
 	requestURIKey           = "REQUEST_URI"
+	queryStringKey          = "QUERY_STRING"
 	responseError           = 7 // FCGI_STDERR
 	responseStatusKey       = "Status: "
 )
@@ -185,6 +187,16 @@ func detectFastCGI(b, rb *largebuf.LargeBuffer) (string, string, int) {
 			return "", "", -1
 		}
 		uri := kv[requestURIKey]
+		if uri == "" {
+			// Default to "/" when REQUEST_URI is absent (older nginx configs) or
+			// when the buffer was truncated before REQUEST_URI could be parsed.
+			// In the truncation case this may report the wrong path, but it is
+			// the best we can do without the full packet.
+			uri = "/"
+		}
+		if qs := kv[queryStringKey]; qs != "" && strings.IndexByte(uri, '?') < 0 {
+			uri = uri + "?" + qs
+		}
 
 		// Translate the status code into HTTP, 200 OK, 500 ERR
 		status := 200
@@ -231,7 +243,8 @@ func TCPToFastCGIToSpan(trace *TCPRequestInfo, op, uri string, status int) reque
 	return request.Span{
 		Type:          reqType,
 		Method:        op,
-		Path:          uri,
+		Path:          removeQuery(uri),
+		FullPath:      uri,
 		Peer:          peer,
 		PeerPort:      int(trace.ConnInfo.S_port),
 		Host:          hostname,

--- a/pkg/ebpf/common/fast_cgi_detect_transform_test.go
+++ b/pkg/ebpf/common/fast_cgi_detect_transform_test.go
@@ -198,7 +198,7 @@ func TestDetectFastCGI(t *testing.T) {
 			inputLen:       152,
 			outputLen:      20,
 			expectedMethod: "GET",
-			expectedPath:   "",
+			expectedPath:   "/",
 			expectedResult: 200,
 		},
 		{
@@ -252,13 +252,43 @@ func TestDetectFastCGI(t *testing.T) {
 			expectedResult: 404,
 		},
 		{
+			// FastCGI passes REQUEST_URI and QUERY_STRING as independent CGI parameters.
+			// OBI must reconstruct the full URI so the server span carries url.query.
+			name: "REQUEST_URI and QUERY_STRING combined",
+			// Packet: BEGIN_REQUEST (16 bytes) + PARAMS header (8 bytes) + params (57 bytes)
+			// Params: REQUEST_METHOD=GET, REQUEST_URI=/, QUERY_STRING=cmd=BLABLA
+			input:          []byte{1, 1, 0, 1, 0, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 4, 0, 1, 0, 57, 0, 0, 14, 3, 82, 69, 81, 85, 69, 83, 84, 95, 77, 69, 84, 72, 79, 68, 71, 69, 84, 11, 1, 82, 69, 81, 85, 69, 83, 84, 95, 85, 82, 73, 47, 12, 10, 81, 85, 69, 82, 89, 95, 83, 84, 82, 73, 78, 71, 99, 109, 100, 61, 66, 76, 65, 66, 76, 65},
+			output:         []byte{1, 0, 1, 0, 0},
+			inputLen:       200,
+			outputLen:      20,
+			expectedMethod: "GET",
+			expectedPath:   "/?cmd=BLABLA",
+			expectedResult: 200,
+		},
+		{
+			// When REQUEST_URI already contains '?', QUERY_STRING must not be appended
+			// again — the dedup guard prevents double query strings.
+			name: "REQUEST_URI already contains query string, QUERY_STRING ignored",
+			// Packet: BEGIN_REQUEST (16 bytes) + PARAMS header (8 bytes) + params (65 bytes)
+			// Params: REQUEST_METHOD=GET, REQUEST_URI=/?existing=1, QUERY_STRING=other=2
+			input:          []byte{1, 1, 0, 1, 0, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 4, 0, 1, 0, 65, 0, 0, 14, 3, 82, 69, 81, 85, 69, 83, 84, 95, 77, 69, 84, 72, 79, 68, 71, 69, 84, 11, 12, 82, 69, 81, 85, 69, 83, 84, 95, 85, 82, 73, 47, 63, 101, 120, 105, 115, 116, 105, 110, 103, 61, 49, 12, 7, 81, 85, 69, 82, 89, 95, 83, 84, 82, 73, 78, 71, 111, 116, 104, 101, 114, 61, 50},
+			output:         []byte{1, 0, 1, 0, 0},
+			inputLen:       200,
+			outputLen:      20,
+			expectedMethod: "GET",
+			expectedPath:   "/?existing=1",
+			expectedResult: 200,
+		},
+		{
+			// REQUEST_URI=/ping is in the packet but truncated at inputLen=100.
+			// OBI defaults to "/" when REQUEST_URI is absent from the parsed portion.
 			name:           "Not enough data",
 			input:          []byte{1, 1, 0, 1, 0, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 4, 0, 1, 1, 217, 7, 0, 12, 0, 81, 85, 69, 82, 89, 95, 83, 84, 82, 73, 78, 71, 14, 3, 82, 69, 81, 85, 69, 83, 84, 95, 77, 69, 84, 72, 79, 68, 71, 69, 84, 12, 0, 67, 79, 78, 84, 69, 78, 84, 95, 84, 89, 80, 69, 14, 0, 67, 79, 78, 84, 69, 78, 84, 95, 76, 69, 78, 71, 84, 72, 11, 5, 83, 67, 82, 73, 80, 84, 95, 78, 65, 77, 69, 47, 112, 105, 110, 103, 11, 5, 82, 69, 81, 85, 69, 83, 84, 95, 85, 82, 73, 47, 112, 105, 110, 103, 12, 5, 68, 79, 67, 85, 77, 69, 78, 84, 95, 85, 82, 73, 47, 112, 105, 110, 103, 13, 13, 68, 79, 67, 85, 77, 69, 78, 84, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			output:         []byte{1, 7, 1, 0, 0},
 			inputLen:       100,
 			outputLen:      1,
 			expectedMethod: "GET",
-			expectedPath:   "",
+			expectedPath:   "/",
 			expectedResult: 200,
 		},
 		{
@@ -281,6 +311,45 @@ func TestDetectFastCGI(t *testing.T) {
 			assert.Equal(t, tt.expectedMethod, method)
 			assert.Equal(t, tt.expectedPath, path)
 			assert.Equal(t, tt.expectedResult, status)
+		})
+	}
+}
+
+func TestTCPToFastCGIToSpanPathSplit(t *testing.T) {
+	tests := []struct {
+		name         string
+		uri          string
+		expectedPath string
+		expectedFull string
+	}{
+		{
+			name:         "query stripped from Path, preserved in FullPath",
+			uri:          "/?cmd=BLABLA",
+			expectedPath: "/",
+			expectedFull: "/?cmd=BLABLA",
+		},
+		{
+			// When REQUEST_URI is absent, detectFastCGI defaults to "/", so
+			// TCPToFastCGIToSpan never receives a URI starting with "?".
+			// This case documents what would happen if the default is bypassed.
+			name:         "path defaults to / when uri is root-less",
+			uri:          "/",
+			expectedPath: "/",
+			expectedFull: "/",
+		},
+		{
+			name:         "no query string unchanged",
+			uri:          "/ping",
+			expectedPath: "/ping",
+			expectedFull: "/ping",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := TCPToFastCGIToSpan(&TCPRequestInfo{}, "GET", tt.uri, 200)
+			assert.Equal(t, tt.expectedPath, span.Path)
+			assert.Equal(t, tt.expectedFull, span.FullPath)
 		})
 	}
 }

--- a/pkg/ebpf/common/fast_cgi_detect_transform_test.go
+++ b/pkg/ebpf/common/fast_cgi_detect_transform_test.go
@@ -190,6 +190,7 @@ func TestDetectFastCGI(t *testing.T) {
 		expectedMethod string
 		expectedPath   string
 		expectedResult int
+		extraCheck     func(t *testing.T, path string)
 	}{
 		{
 			name:           "Older PHP, small frame",
@@ -198,7 +199,7 @@ func TestDetectFastCGI(t *testing.T) {
 			inputLen:       152,
 			outputLen:      20,
 			expectedMethod: "GET",
-			expectedPath:   "/",
+			expectedPath:   "",
 			expectedResult: 200,
 		},
 		{
@@ -278,17 +279,21 @@ func TestDetectFastCGI(t *testing.T) {
 			expectedMethod: "GET",
 			expectedPath:   "/?existing=1",
 			expectedResult: 200,
+			// Confirm QUERY_STRING=other=2 was not appended to the path.
+			extraCheck: func(t *testing.T, path string) {
+				assert.NotContains(t, path, "other=2")
+			},
 		},
 		{
 			// REQUEST_URI=/ping is in the packet but truncated at inputLen=100.
-			// OBI defaults to "/" when REQUEST_URI is absent from the parsed portion.
+			// Path stays empty when REQUEST_URI is absent and there is no QUERY_STRING.
 			name:           "Not enough data",
 			input:          []byte{1, 1, 0, 1, 0, 8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 4, 0, 1, 1, 217, 7, 0, 12, 0, 81, 85, 69, 82, 89, 95, 83, 84, 82, 73, 78, 71, 14, 3, 82, 69, 81, 85, 69, 83, 84, 95, 77, 69, 84, 72, 79, 68, 71, 69, 84, 12, 0, 67, 79, 78, 84, 69, 78, 84, 95, 84, 89, 80, 69, 14, 0, 67, 79, 78, 84, 69, 78, 84, 95, 76, 69, 78, 71, 84, 72, 11, 5, 83, 67, 82, 73, 80, 84, 95, 78, 65, 77, 69, 47, 112, 105, 110, 103, 11, 5, 82, 69, 81, 85, 69, 83, 84, 95, 85, 82, 73, 47, 112, 105, 110, 103, 12, 5, 68, 79, 67, 85, 77, 69, 78, 84, 95, 85, 82, 73, 47, 112, 105, 110, 103, 13, 13, 68, 79, 67, 85, 77, 69, 78, 84, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			output:         []byte{1, 7, 1, 0, 0},
 			inputLen:       100,
 			outputLen:      1,
 			expectedMethod: "GET",
-			expectedPath:   "/",
+			expectedPath:   "",
 			expectedResult: 200,
 		},
 		{
@@ -311,6 +316,9 @@ func TestDetectFastCGI(t *testing.T) {
 			assert.Equal(t, tt.expectedMethod, method)
 			assert.Equal(t, tt.expectedPath, path)
 			assert.Equal(t, tt.expectedResult, status)
+			if tt.extraCheck != nil {
+				tt.extraCheck(t, path)
+			}
 		})
 	}
 }
@@ -342,6 +350,14 @@ func TestTCPToFastCGIToSpanPathSplit(t *testing.T) {
 			uri:          "/ping",
 			expectedPath: "/ping",
 			expectedFull: "/ping",
+		},
+		{
+			// When REQUEST_URI is absent from FastCGI params and QUERY_STRING is also
+			// absent, detectFastCGI returns "" and the span carries no path at all.
+			name:         "empty uri when REQUEST_URI and QUERY_STRING both absent",
+			uri:          "",
+			expectedPath: "",
+			expectedFull: "",
 		},
 	}
 

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -23,7 +23,7 @@ import (
 
 func removeQuery(url string) string {
 	idx := strings.IndexByte(url, '?')
-	if idx > 0 {
+	if idx >= 0 {
 		return url[:idx]
 	}
 	return url

--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -574,3 +574,22 @@ func TestToRequestTraceLargeBuffers(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveQuery(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"/path?key=val", "/path"},
+		{"/path", "/path"},
+		{"/?key=val", "/"},
+		// Edge case: url starts with '?' (no path prefix) — idx==0, must still strip.
+		{"?key=val", ""},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.want, removeQuery(tc.input))
+		})
+	}
+}

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -403,10 +403,12 @@ func getDefinitions(
 		},
 		Traces.Section: {
 			Attributes: map[attr.Name]Default{
-				attr.DNSQuestionName:   true,
-				attr.DBQueryText:       false,
-				attr.GraphQLDocument:   false,
-				attr.HTTPUrlQuery:      false,
+				attr.DNSQuestionName: true,
+				attr.DBQueryText:     false,
+				attr.GraphQLDocument: false,
+				// url.query is Conditionally Required by OTel semconv (emitted when a query string is present).
+				// You can opt out via attributes.select.traces.exclude: [url.query].
+				attr.HTTPUrlQuery:      true,
 				attr.GenAIInput:        false,
 				attr.GenAIOutput:       false,
 				attr.GenAIInstructions: false,

--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -81,10 +81,23 @@ func parseExtraAttrGroup(group string) (AttrGroups, error) {
 	}
 }
 
+// DefaultRedactQueryParams is the built-in set of query-parameter keys whose
+// values are replaced with REDACTED when url.query or url.full is emitted.
+// Users can override this list via the redact_query_params config field;
+// set to an empty slice to disable all redaction.
+var DefaultRedactQueryParams = []string{
+	"sig", "Signature", "AWSAccessKeyId", "token", "key", "password",
+	"secret", "api_key", "apikey", "access_token", "auth",
+}
+
 // SelectorConfig defines settings for filtering attributes and adding additional attributes
 type SelectorConfig struct {
 	SelectionCfg            Selection
 	ExtraGroupAttributesCfg map[string][]attr.Name
+	// RedactQueryParams lists query-parameter keys whose values are replaced
+	// with REDACTED in url.full and url.query. Nil means use DefaultRedactQueryParams.
+	// Set to []string{} to disable all redaction.
+	RedactQueryParams []string
 }
 
 // AttrSelector returns, for each metric, the attributes that have to be reported

--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -81,29 +81,54 @@ func parseExtraAttrGroup(group string) (AttrGroups, error) {
 	}
 }
 
-// DefaultRedactQueryParams is the built-in set of query-parameter keys whose
-// values are replaced with REDACTED when url.query or url.full is emitted.
-// All five entries are mandated by the OTel HTTP semconv (matching is case-sensitive):
-// https://opentelemetry.io/docs/specs/semconv/http/http-spans/
-// This list is always applied. Users can extend it via the
-// extra_redact_query_params config field (OTEL_EBPF_EXTRA_REDACT_QUERY_PARAMS);
-// the built-in set cannot be disabled or overridden.
-var DefaultRedactQueryParams = []string{
-	// OTel semconv mandated — do not remove.
-	"X-Amz-Signature",
-	"X-Amz-Credential",
-	"X-Amz-Security-Token",
-	"X-Goog-Signature",
-	"sig", // Microsoft Azure SAS token
+// DefaultSensitiveQueryParams is the built-in list of query-parameter keys whose values
+// are redacted by default. Users can extend or narrow it via SensitiveQueryParamsConfig.
+var DefaultSensitiveQueryParams = []string{
+	// OTel semconv-recommended — https://opentelemetry.io/docs/specs/semconv/http/http-spans/
+	"X-Amz-Signature", "X-Amz-Credential", "X-Amz-Security-Token",
+	"X-Goog-Signature", "sig",
+	// Common sensitive parameters
+	"token", "access_token", "refresh_token", "id_token", "jwt",
+	"session", "sid", "signature",
+	"api_key", "apikey", "client_secret", "secret",
+	"password", "pass", "pwd",
+	"reset_token", "invite_token", "verify_token",
+	"otp", "totp", "mfa_code", "verification_code",
+	"SAMLResponse", "assertion",
+	"card", "cc", "pan", "cvv",
+	"ssn", "tax_id",
+}
+
+// SensitiveQueryParamsConfig controls which query-parameter keys are redacted.
+// The effective list is DefaultSensitiveQueryParams + Add - Remove.
+// When both Add and Remove are empty, DefaultSensitiveQueryParams is used unchanged.
+type SensitiveQueryParamsConfig struct {
+	Add    []string `yaml:"add" env:"OTEL_EBPF_SENSITIVE_QUERY_PARAMS_ADD" envSeparator:","`
+	Remove []string `yaml:"remove" env:"OTEL_EBPF_SENSITIVE_QUERY_PARAMS_REMOVE" envSeparator:","`
+}
+
+func (c SensitiveQueryParamsConfig) Effective() []string {
+	if len(c.Add) == 0 && len(c.Remove) == 0 {
+		return DefaultSensitiveQueryParams
+	}
+	removeSet := make(map[string]struct{}, len(c.Remove))
+	for _, k := range c.Remove {
+		removeSet[k] = struct{}{}
+	}
+	result := make([]string, 0, len(DefaultSensitiveQueryParams)+len(c.Add))
+	for _, k := range DefaultSensitiveQueryParams {
+		if _, skip := removeSet[k]; !skip {
+			result = append(result, k)
+		}
+	}
+	return append(result, c.Add...)
 }
 
 // SelectorConfig defines settings for filtering attributes and adding additional attributes
 type SelectorConfig struct {
 	SelectionCfg            Selection
 	ExtraGroupAttributesCfg map[string][]attr.Name
-	// ExtraRedactQueryParamsCfg lists user-supplied query keys to redact
-	// in url.full and url.query, in addition to DefaultRedactQueryParams.
-	ExtraRedactQueryParamsCfg []string
+	SensitiveQueryParamsCfg SensitiveQueryParamsConfig
 }
 
 // AttrSelector returns, for each metric, the attributes that have to be reported

--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -101,10 +101,9 @@ var DefaultRedactQueryParams = []string{
 type SelectorConfig struct {
 	SelectionCfg            Selection
 	ExtraGroupAttributesCfg map[string][]attr.Name
-	// RedactQueryParams lists query-parameter keys whose values are replaced
-	// with REDACTED in url.full and url.query. Nil means use DefaultRedactQueryParams.
-	// Set to []string{} to disable all redaction.
-	RedactQueryParams []string
+	// ExtraRedactQueryParamsCfg lists user-supplied query keys to redact
+	// in url.full and url.query, in addition to DefaultRedactQueryParams.
+	ExtraRedactQueryParamsCfg []string
 }
 
 // AttrSelector returns, for each metric, the attributes that have to be reported

--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -83,11 +83,18 @@ func parseExtraAttrGroup(group string) (AttrGroups, error) {
 
 // DefaultRedactQueryParams is the built-in set of query-parameter keys whose
 // values are replaced with REDACTED when url.query or url.full is emitted.
-// Users can override this list via the redact_query_params config field;
-// set to an empty slice to disable all redaction.
+// All five entries are mandated by the OTel HTTP semconv (matching is case-sensitive):
+// https://opentelemetry.io/docs/specs/semconv/http/http-spans/
+// This list is always applied. Users can extend it via the
+// extra_redact_query_params config field (OTEL_EBPF_EXTRA_REDACT_QUERY_PARAMS);
+// the built-in set cannot be disabled or overridden.
 var DefaultRedactQueryParams = []string{
-	"sig", "Signature", "AWSAccessKeyId", "token", "key", "password",
-	"secret", "api_key", "apikey", "access_token", "auth",
+	// OTel semconv mandated — do not remove.
+	"X-Amz-Signature",
+	"X-Amz-Credential",
+	"X-Amz-Security-Token",
+	"X-Goog-Signature",
+	"sig", // Microsoft Azure SAS token
 }
 
 // SelectorConfig defines settings for filtering attributes and adding additional attributes

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -114,7 +114,7 @@ func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, e
 }
 
 func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Traces, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler) {
-	spanGroups := tracesgen.GroupSpans(ctx, spans, traceAttrs, sampler, tr.is, tr.selectorCfg.ExtraRedactQueryParamsCfg...)
+	spanGroups := tracesgen.GroupSpans(ctx, spans, traceAttrs, sampler, tr.is, tr.selectorCfg.SensitiveQueryParamsCfg.Effective()...)
 
 	for _, spanGroup := range spanGroups {
 		if len(spanGroup) > 0 {

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -114,7 +114,7 @@ func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, e
 }
 
 func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Traces, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler) {
-	spanGroups := tracesgen.GroupSpans(ctx, spans, traceAttrs, sampler, tr.is)
+	spanGroups := tracesgen.GroupSpans(ctx, spans, traceAttrs, sampler, tr.is, tr.selectorCfg.RedactQueryParams...)
 
 	for _, spanGroup := range spanGroups {
 		if len(spanGroup) > 0 {

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -114,7 +114,7 @@ func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, e
 }
 
 func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Traces, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler) {
-	spanGroups := tracesgen.GroupSpans(ctx, spans, traceAttrs, sampler, tr.is, tr.selectorCfg.RedactQueryParams...)
+	spanGroups := tracesgen.GroupSpans(ctx, spans, traceAttrs, sampler, tr.is, tr.selectorCfg.ExtraRedactQueryParamsCfg...)
 
 	for _, spanGroup := range spanGroups {
 		if len(spanGroup) > 0 {

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -1877,7 +1877,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
 
 		attrs := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes()
-		ensureTraceStrAttr(t, attrs, semconv.URLFullKey, "https://api.example.com/external/api")
+		ensureTraceStrAttr(t, attrs, semconv.URLFullKey, "https://api.example.com/external/api?foo=bar")
 	})
 	t.Run("test HTTP client url.full includes query with opt-in", func(t *testing.T) {
 		span := request.Span{
@@ -1956,7 +1956,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
 
 		attrs := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes()
-		ensureTraceStrAttr(t, attrs, semconv.URLFullKey, "https://upstream.example.com/external/api")
+		ensureTraceStrAttr(t, attrs, semconv.URLFullKey, "https://upstream.example.com/external/api?foo=bar")
 	})
 	t.Run("test JSON-RPC server span with error", func(t *testing.T) {
 		span := request.Span{

--- a/pkg/export/otel/tracesgen/queryscrub.go
+++ b/pkg/export/otel/tracesgen/queryscrub.go
@@ -5,22 +5,38 @@ package tracesgen // import "go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
 
 import "strings"
 
-// scrubQuery replaces the values of sensitiveKeys in the raw query string qs
-// with REDACTED, preserving parameter order and non-sensitive values.
-// Returns qs unchanged when sensitiveKeys is empty or qs is empty.
-func scrubQuery(qs string, sensitiveKeys []string) string {
-	if len(sensitiveKeys) == 0 || qs == "" {
+// Returns nil when keys is empty so callers can short-circuit cheaply.
+func buildRedactSet(keys []string) map[string]struct{} {
+	if len(keys) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		set[k] = struct{}{}
+	}
+	return set
+}
+
+// Returns qs unchanged when redactSet is nil/empty or qs is empty.
+func scrubQuery(qs string, redactSet map[string]struct{}) string {
+	if len(redactSet) == 0 || qs == "" {
 		return qs
 	}
-	redact := make(map[string]struct{}, len(sensitiveKeys))
-	for _, k := range sensitiveKeys {
-		redact[strings.ToLower(k)] = struct{}{}
-	}
 	var b strings.Builder
-	for i, part := range strings.Split(qs, "&") {
-		if i > 0 {
+	b.Grow(len(qs))
+	rest := qs
+	first := true
+	for rest != "" {
+		var part string
+		if i := strings.IndexByte(rest, '&'); i >= 0 {
+			part, rest = rest[:i], rest[i+1:]
+		} else {
+			part, rest = rest, ""
+		}
+		if !first {
 			b.WriteByte('&')
 		}
+		first = false
 		key, val, hasVal := strings.Cut(part, "=")
 		if !hasVal {
 			b.WriteString(part)
@@ -28,7 +44,7 @@ func scrubQuery(qs string, sensitiveKeys []string) string {
 		}
 		b.WriteString(key)
 		b.WriteByte('=')
-		if _, sensitive := redact[strings.ToLower(key)]; sensitive {
+		if _, isSensitive := redactSet[key]; isSensitive {
 			b.WriteString("REDACTED")
 		} else {
 			b.WriteString(val)

--- a/pkg/export/otel/tracesgen/queryscrub.go
+++ b/pkg/export/otel/tracesgen/queryscrub.go
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tracesgen // import "go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
+
+import "strings"
+
+// scrubQuery replaces the values of sensitiveKeys in the raw query string qs
+// with REDACTED, preserving parameter order and non-sensitive values.
+// Returns qs unchanged when sensitiveKeys is empty or qs is empty.
+func scrubQuery(qs string, sensitiveKeys []string) string {
+	if len(sensitiveKeys) == 0 || qs == "" {
+		return qs
+	}
+	redact := make(map[string]struct{}, len(sensitiveKeys))
+	for _, k := range sensitiveKeys {
+		redact[strings.ToLower(k)] = struct{}{}
+	}
+	var b strings.Builder
+	for i, part := range strings.Split(qs, "&") {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		key, val, hasVal := strings.Cut(part, "=")
+		if !hasVal {
+			b.WriteString(part)
+			continue
+		}
+		b.WriteString(key)
+		b.WriteByte('=')
+		if _, sensitive := redact[strings.ToLower(key)]; sensitive {
+			b.WriteString("REDACTED")
+		} else {
+			b.WriteString(val)
+		}
+	}
+	return b.String()
+}

--- a/pkg/export/otel/tracesgen/queryscrub.go
+++ b/pkg/export/otel/tracesgen/queryscrub.go
@@ -3,7 +3,10 @@
 
 package tracesgen // import "go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 // Returns nil when keys is empty so callers can short-circuit cheaply.
 func buildRedactSet(keys []string) map[string]struct{} {
@@ -22,33 +25,44 @@ func scrubQuery(qs string, redactSet map[string]struct{}) string {
 	if len(redactSet) == 0 || qs == "" {
 		return qs
 	}
+
 	var b strings.Builder
 	b.Grow(len(qs))
+
 	rest := qs
-	first := true
 	for rest != "" {
-		var part string
+		part := rest
 		if i := strings.IndexByte(rest, '&'); i >= 0 {
 			part, rest = rest[:i], rest[i+1:]
 		} else {
-			part, rest = rest, ""
+			rest = ""
 		}
-		if !first {
-			b.WriteByte('&')
-		}
-		first = false
+
 		key, val, hasVal := strings.Cut(part, "=")
 		if !hasVal {
 			b.WriteString(part)
-			continue
-		}
-		b.WriteString(key)
-		b.WriteByte('=')
-		if _, isSensitive := redactSet[key]; isSensitive {
-			b.WriteString("REDACTED")
 		} else {
-			b.WriteString(val)
+			b.WriteString(key)
+			b.WriteByte('=')
+			// Percent-decode the key so ?X-Amz-Signatur%65=v is caught alongside
+			// ?X-Amz-Signature=v. The raw key is preserved in the output; only the value
+			// is replaced. url.QueryUnescape returns the input string unchanged (no
+			// allocation) when no percent-sequences are present.
+			lookupKey := key
+			if decoded, err := url.QueryUnescape(key); err == nil {
+				lookupKey = decoded
+			}
+			if _, isSensitive := redactSet[lookupKey]; isSensitive {
+				b.WriteString("REDACTED")
+			} else {
+				b.WriteString(val)
+			}
+		}
+
+		if rest != "" {
+			b.WriteByte('&')
 		}
 	}
+
 	return b.String()
 }

--- a/pkg/export/otel/tracesgen/queryscrub_test.go
+++ b/pkg/export/otel/tracesgen/queryscrub_test.go
@@ -37,10 +37,11 @@ func TestScrubQuery(t *testing.T) {
 			want: "q=hello&token=REDACTED&AWSAccessKeyId=REDACTED&page=2",
 		},
 		{
-			name: "case-insensitive key matching",
+			// OTel semconv requires case-sensitive matching — SIG != sig
+			name: "case-sensitive key matching: wrong case not redacted",
 			qs:   "SIG=abc123&cmd=test",
 			keys: sensitiveKeys,
-			want: "SIG=REDACTED&cmd=test",
+			want: "SIG=abc123&cmd=test",
 		},
 		{
 			name: "empty sensitive list passes through unchanged",
@@ -66,11 +67,17 @@ func TestScrubQuery(t *testing.T) {
 			keys: sensitiveKeys,
 			want: "z=1&a=2&sig=REDACTED&m=3",
 		},
+		{
+			name: "all params redacted produces non-empty string",
+			qs:   "sig=secret&token=abc",
+			keys: sensitiveKeys,
+			want: "sig=REDACTED&token=REDACTED",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, scrubQuery(tc.qs, tc.keys))
+			assert.Equal(t, tc.want, scrubQuery(tc.qs, buildRedactSet(tc.keys)))
 		})
 	}
 }

--- a/pkg/export/otel/tracesgen/queryscrub_test.go
+++ b/pkg/export/otel/tracesgen/queryscrub_test.go
@@ -73,6 +73,21 @@ func TestScrubQuery(t *testing.T) {
 			keys: sensitiveKeys,
 			want: "sig=REDACTED&token=REDACTED",
 		},
+		{
+			// Percent-encoded key name must still be redacted; raw key preserved in output.
+			// e.g. ?si%67=secret where %67 decodes to 'g', making the key "sig".
+			name: "percent-encoded key name matched and redacted",
+			qs:   "cmd=test&si%67=secret",
+			keys: sensitiveKeys,
+			want: "cmd=test&si%67=REDACTED",
+		},
+		{
+			// Invalid percent-encoding falls back to raw key comparison (no match here).
+			name: "invalid percent-encoding falls back to raw key — no false redaction",
+			qs:   "si%ZZg=value&cmd=test",
+			keys: sensitiveKeys,
+			want: "si%ZZg=value&cmd=test",
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/export/otel/tracesgen/queryscrub_test.go
+++ b/pkg/export/otel/tracesgen/queryscrub_test.go
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tracesgen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScrubQuery(t *testing.T) {
+	sensitiveKeys := []string{"sig", "token", "AWSAccessKeyId"}
+
+	tests := []struct {
+		name string
+		qs   string
+		keys []string
+		want string
+	}{
+		{
+			name: "sensitive key redacted",
+			qs:   "cmd=OBIWANKENOBI&sig=abc123",
+			keys: sensitiveKeys,
+			want: "cmd=OBIWANKENOBI&sig=REDACTED",
+		},
+		{
+			name: "non-sensitive keys unchanged",
+			qs:   "cmd=OBIWANKENOBI&page=1",
+			keys: sensitiveKeys,
+			want: "cmd=OBIWANKENOBI&page=1",
+		},
+		{
+			name: "multiple sensitive keys",
+			qs:   "q=hello&token=secret&AWSAccessKeyId=AKID&page=2",
+			keys: sensitiveKeys,
+			want: "q=hello&token=REDACTED&AWSAccessKeyId=REDACTED&page=2",
+		},
+		{
+			name: "case-insensitive key matching",
+			qs:   "SIG=abc123&cmd=test",
+			keys: sensitiveKeys,
+			want: "SIG=REDACTED&cmd=test",
+		},
+		{
+			name: "empty sensitive list passes through unchanged",
+			qs:   "sig=secret&cmd=test",
+			keys: nil,
+			want: "sig=secret&cmd=test",
+		},
+		{
+			name: "empty query string",
+			qs:   "",
+			keys: sensitiveKeys,
+			want: "",
+		},
+		{
+			name: "key with no value preserved",
+			qs:   "flag&cmd=test",
+			keys: sensitiveKeys,
+			want: "flag&cmd=test",
+		},
+		{
+			name: "parameter order preserved",
+			qs:   "z=1&a=2&sig=secret&m=3",
+			keys: sensitiveKeys,
+			want: "z=1&a=2&sig=REDACTED&m=3",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, scrubQuery(tc.qs, tc.keys))
+		})
+	}
+}

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -74,13 +75,9 @@ func UserSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr.Na
 }
 
 // GroupSpans must remain public for collectors embedding OBI.
-// redactKeys is the merged list of query-parameter keys to scrub; within OBI
-// this is built as DefaultRedactQueryParams + ExtraRedactQueryParams by
-// instrumenter.go. Embedders calling GroupSpans directly must pass
-// attributes.DefaultRedactQueryParams explicitly to get the same behaviour,
-// otherwise no scrubbing is applied.
 func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection, redactKeys ...string) map[svc.UID][]TraceSpanAndAttributes {
 	spanGroups := map[svc.UID][]TraceSpanAndAttributes{}
+	redactSet := buildRedactSet(slices.Concat(attributes.DefaultRedactQueryParams, redactKeys))
 
 	for i := range spans {
 		span := &spans[i]
@@ -91,7 +88,7 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 			continue
 		}
 
-		finalAttrs := TraceAttributesSelector(span, traceAttrs, redactKeys...)
+		finalAttrs := traceAttributesSelectorInternal(span, traceAttrs, redactSet)
 
 		spanSampler := func() trace.Sampler {
 			if span.Service.Sampler != nil {
@@ -504,7 +501,7 @@ func httpEnrichmentAttributes(span *request.Span) []attribute.KeyValue {
 }
 
 //nolint:cyclop
-func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]struct{}, redactKeys ...string) []attribute.KeyValue {
+func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.Name]struct{}, redactSet map[string]struct{}) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
 
 	switch span.Type {
@@ -537,7 +534,7 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 		}
 		if _, ok := optionalAttrs[attr.HTTPUrlQuery]; ok {
 			if idx := strings.IndexByte(span.FullPath, '?'); idx != -1 {
-				if qs := scrubQuery(span.FullPath[idx+1:], redactKeys); qs != "" {
+				if qs := scrubQuery(span.FullPath[idx+1:], redactSet); qs != "" {
 					attrs = append(attrs, request.HTTPUrlQuery(qs))
 				}
 			}
@@ -594,17 +591,15 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 		// Strip or scrub query parameters from url.full to avoid leaking sensitive
 		// data (tokens, PII). When url.query is opted in, known sensitive keys are
 		// redacted (REDACTED) rather than the entire string being dropped.
-		var queryString string
+		var scrubbedQS string
 		if idx := strings.IndexByte(urlPath, '?'); idx >= 0 {
-			queryString = scrubQuery(urlPath[idx+1:], redactKeys)
 			if _, ok := optionalAttrs[attr.HTTPUrlQuery]; !ok {
 				urlPath = urlPath[:idx]
+			} else if qs := scrubQuery(urlPath[idx+1:], redactSet); qs != "" {
+				urlPath = urlPath[:idx+1] + qs
+				scrubbedQS = qs
 			} else {
-				if queryString != "" {
-					urlPath = urlPath[:idx+1] + queryString
-				} else {
-					urlPath = urlPath[:idx]
-				}
+				urlPath = urlPath[:idx]
 			}
 		}
 		url := urlPath
@@ -624,8 +619,8 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			request.HTTPResponseBodySize(span.ResponseBodyLength()),
 		}
 
-		if _, ok := optionalAttrs[attr.HTTPUrlQuery]; ok && queryString != "" {
-			attrs = append(attrs, request.HTTPUrlQuery(queryString))
+		if scrubbedQS != "" {
+			attrs = append(attrs, request.HTTPUrlQuery(scrubbedQS))
 		}
 
 		if span.SubType == request.HTTPSubtypeElasticsearch && span.Elasticsearch != nil {
@@ -1384,6 +1379,11 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 	}
 
 	return attrs
+}
+
+// TraceAttributesSelector returns the []attribute.KeyValue for a single span.
+func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]struct{}, redactKeys ...string) []attribute.KeyValue {
+	return traceAttributesSelectorInternal(span, optionalAttrs, buildRedactSet(slices.Concat(attributes.DefaultRedactQueryParams, redactKeys)))
 }
 
 func spanKind(span *request.Span) trace2.SpanKind {

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -533,7 +533,7 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			attrs = append(attrs, request.GraphqlOperationType(span.GraphQL.OperationType))
 		}
 		if _, ok := optionalAttrs[attr.HTTPUrlQuery]; ok {
-			if idx := strings.IndexByte(span.FullPath, '?'); idx != -1 {
+			if idx := strings.IndexByte(span.FullPath, '?'); idx >= 0 {
 				if qs := scrubQuery(span.FullPath[idx+1:], redactSet); qs != "" {
 					attrs = append(attrs, request.HTTPUrlQuery(qs))
 				}

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -77,7 +76,7 @@ func UserSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr.Na
 // GroupSpans must remain public for collectors embedding OBI.
 func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection, redactKeys ...string) map[svc.UID][]TraceSpanAndAttributes {
 	spanGroups := map[svc.UID][]TraceSpanAndAttributes{}
-	redactSet := buildRedactSet(slices.Concat(attributes.DefaultRedactQueryParams, redactKeys))
+	redactSet := buildRedactSet(redactKeys)
 
 	for i := range spans {
 		span := &spans[i]
@@ -588,14 +587,11 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		if span.FullPath != "" {
 			urlPath = span.FullPath
 		}
-		// Strip or scrub query parameters from url.full to avoid leaking sensitive
-		// data (tokens, PII). When url.query is opted in, known sensitive keys are
-		// redacted (REDACTED) rather than the entire string being dropped.
+		// Scrub sensitive query parameters from url.full. The scrubbed query is always
+		// included in url.full when present; the selector only gates the separate url.query attribute.
 		var scrubbedQS string
 		if idx := strings.IndexByte(urlPath, '?'); idx >= 0 {
-			if _, ok := optionalAttrs[attr.HTTPUrlQuery]; !ok {
-				urlPath = urlPath[:idx]
-			} else if qs := scrubQuery(urlPath[idx+1:], redactSet); qs != "" {
+			if qs := scrubQuery(urlPath[idx+1:], redactSet); qs != "" {
 				urlPath = urlPath[:idx+1] + qs
 				scrubbedQS = qs
 			} else {
@@ -620,7 +616,9 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		}
 
 		if scrubbedQS != "" {
-			attrs = append(attrs, request.HTTPUrlQuery(scrubbedQS))
+			if _, ok := optionalAttrs[attr.HTTPUrlQuery]; ok {
+				attrs = append(attrs, request.HTTPUrlQuery(scrubbedQS))
+			}
 		}
 
 		if span.SubType == request.HTTPSubtypeElasticsearch && span.Elasticsearch != nil {
@@ -1383,7 +1381,7 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 
 // TraceAttributesSelector returns the []attribute.KeyValue for a single span.
 func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]struct{}, redactKeys ...string) []attribute.KeyValue {
-	return traceAttributesSelectorInternal(span, optionalAttrs, buildRedactSet(slices.Concat(attributes.DefaultRedactQueryParams, redactKeys)))
+	return traceAttributesSelectorInternal(span, optionalAttrs, buildRedactSet(redactKeys))
 }
 
 func spanKind(span *request.Span) trace2.SpanKind {

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -73,8 +73,13 @@ func UserSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr.Na
 	return traceAttrs, err
 }
 
-// GroupSpans must remain public for collectors embedding OBI
-func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection) map[svc.UID][]TraceSpanAndAttributes {
+// GroupSpans must remain public for collectors embedding OBI.
+// redactKeys is the merged list of query-parameter keys to scrub; within OBI
+// this is built as DefaultRedactQueryParams + ExtraRedactQueryParams by
+// instrumenter.go. Embedders calling GroupSpans directly must pass
+// attributes.DefaultRedactQueryParams explicitly to get the same behaviour,
+// otherwise no scrubbing is applied.
+func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection, redactKeys ...string) map[svc.UID][]TraceSpanAndAttributes {
 	spanGroups := map[svc.UID][]TraceSpanAndAttributes{}
 
 	for i := range spans {
@@ -86,7 +91,7 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 			continue
 		}
 
-		finalAttrs := TraceAttributesSelector(span, traceAttrs)
+		finalAttrs := TraceAttributesSelector(span, traceAttrs, redactKeys...)
 
 		spanSampler := func() trace.Sampler {
 			if span.Service.Sampler != nil {
@@ -499,7 +504,7 @@ func httpEnrichmentAttributes(span *request.Span) []attribute.KeyValue {
 }
 
 //nolint:cyclop
-func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
+func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]struct{}, redactKeys ...string) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
 
 	switch span.Type {
@@ -507,12 +512,14 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 		attrs = []attribute.KeyValue{
 			request.HTTPRequestMethod(span.Method),
 			request.HTTPResponseStatusCode(span.Status),
-			request.HTTPUrlPath(span.Path),
 			request.ClientAddr(request.PeerAsClient(span)),
 			request.ServerAddr(request.SpanHost(span)),
 			request.ServerPort(span.HostPort),
 			request.HTTPRequestBodySize(int(span.RequestBodyLength())),
 			request.HTTPResponseBodySize(span.ResponseBodyLength()),
+		}
+		if span.Path != "" {
+			attrs = append(attrs, request.HTTPUrlPath(span.Path))
 		}
 		scheme := request.HTTPScheme(span)
 		if scheme != "" {
@@ -527,6 +534,13 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 			}
 			attrs = append(attrs, semconv.GraphQLOperationName(span.GraphQL.OperationName))
 			attrs = append(attrs, request.GraphqlOperationType(span.GraphQL.OperationType))
+		}
+		if _, ok := optionalAttrs[attr.HTTPUrlQuery]; ok {
+			if idx := strings.IndexByte(span.FullPath, '?'); idx != -1 {
+				if qs := scrubQuery(span.FullPath[idx+1:], redactKeys); qs != "" {
+					attrs = append(attrs, request.HTTPUrlQuery(qs))
+				}
+			}
 		}
 		attrs = append(attrs, mcpAttributes(span, optionalAttrs)...)
 		attrs = append(attrs, jsonRPCAttributes(span)...)
@@ -577,13 +591,20 @@ func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]str
 		if span.FullPath != "" {
 			urlPath = span.FullPath
 		}
-		// Strip query parameters from url.full by default to avoid leaking
-		// sensitive data (tokens, PII). Include them only when explicitly opted in.
+		// Strip or scrub query parameters from url.full to avoid leaking sensitive
+		// data (tokens, PII). When url.query is opted in, known sensitive keys are
+		// redacted (REDACTED) rather than the entire string being dropped.
 		var queryString string
-		if idx := strings.IndexByte(urlPath, '?'); idx > 0 {
-			queryString = urlPath[idx+1:]
+		if idx := strings.IndexByte(urlPath, '?'); idx >= 0 {
+			queryString = scrubQuery(urlPath[idx+1:], redactKeys)
 			if _, ok := optionalAttrs[attr.HTTPUrlQuery]; !ok {
 				urlPath = urlPath[:idx]
+			} else {
+				if queryString != "" {
+					urlPath = urlPath[:idx+1] + queryString
+				} else {
+					urlPath = urlPath[:idx]
+				}
 			}
 		}
 		url := urlPath

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -172,6 +172,30 @@ func TestHTTPServerSpanURLQuery(t *testing.T) {
 		assert.False(t, ok, "url.query should be absent when explicitly excluded")
 	})
 
+	t.Run("url.full keeps scrubbed query even when url.query is excluded", func(t *testing.T) {
+		excludeCfg := &attributes.SelectorConfig{
+			SelectionCfg: attributes.Selection{
+				attributes.Traces.Section: attributes.InclusionLists{
+					Exclude: []string{string(attr.HTTPUrlQuery)},
+				},
+			},
+		}
+		span := &request.Span{
+			Type: request.EventTypeHTTPClient, Method: "GET", Path: "/", FullPath: "/?cmd=BLABLA&sig=secret",
+			Host: "example.com", HostPort: 80, Status: 200,
+		}
+		excludeAttrs, err := UserSelectedAttributes(excludeCfg)
+		require.NoError(t, err)
+		selected := AttrsToMap(TraceAttributesSelector(span, excludeAttrs, "sig"))
+		_, ok := selected.Get("url.query")
+		assert.False(t, ok, "url.query should be absent when excluded")
+		urlFull, ok := selected.Get("url.full")
+		require.True(t, ok, "url.full should be present")
+		assert.Contains(t, urlFull.Str(), "cmd=BLABLA")
+		assert.Contains(t, urlFull.Str(), "sig=REDACTED")
+		assert.NotContains(t, urlFull.Str(), "secret")
+	})
+
 	t.Run("url.path omitted when path is unobservable", func(t *testing.T) {
 		// FastCGI spans with no REQUEST_URI (truncated buffer or older nginx config)
 		// produce Path="". OTel semconv says omit the attribute rather than emit "".

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -142,16 +142,17 @@ func TestHTTPServerSpanURLQuery(t *testing.T) {
 		assert.NotContains(t, val.Str(), "abc123")
 	})
 
-	t.Run("DefaultRedactQueryParams applied even without explicit redactKeys", func(t *testing.T) {
-		// TraceAttributesSelector always merges DefaultRedactQueryParams so callers
-		// cannot accidentally emit sensitive values by omitting redactKeys.
+	t.Run("no redaction when no sensitive params passed to TraceAttributesSelector", func(t *testing.T) {
+		// TraceAttributesSelector is the single-span public API; callers must pass
+		// sensitive params explicitly. The default list flows through GroupSpans via
+		// SensitiveQueryParams in DefaultConfig.
 		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/", FullPath: "/?sig=abc123", Status: 200}
 		optInAttrs, err := UserSelectedAttributes(optInCfg)
 		require.NoError(t, err)
 		selected := AttrsToMap(TraceAttributesSelector(span, optInAttrs))
 		val, ok := selected.Get("url.query")
 		require.True(t, ok)
-		assert.Equal(t, "sig=REDACTED", val.Str())
+		assert.Equal(t, "sig=abc123", val.Str())
 	})
 
 	t.Run("url.query suppressed when explicitly excluded", func(t *testing.T) {

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -96,23 +96,24 @@ func TestHTTPServerSpanURLQuery(t *testing.T) {
 		},
 	}
 
-	t.Run("url.query absent by default", func(t *testing.T) {
+	t.Run("url.query present by default", func(t *testing.T) {
+		// url.query is Conditionally Required per OTel semconv, so it is on by default.
 		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/", FullPath: "/?cmd=BLABLA", Status: 200}
+		defaultAttrs, err := UserSelectedAttributes(&attributes.SelectorConfig{})
+		require.NoError(t, err)
+		selected := AttrsToMap(TraceAttributesSelector(span, defaultAttrs))
+		val, ok := selected.Get("url.query")
+		require.True(t, ok)
+		assert.Equal(t, "cmd=BLABLA", val.Str())
+	})
+
+	t.Run("url.query absent when no query string", func(t *testing.T) {
+		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/health", FullPath: "/health", Status: 200}
 		defaultAttrs, err := UserSelectedAttributes(&attributes.SelectorConfig{})
 		require.NoError(t, err)
 		selected := AttrsToMap(TraceAttributesSelector(span, defaultAttrs))
 		_, ok := selected.Get("url.query")
 		assert.False(t, ok)
-	})
-
-	t.Run("url.query present when opted in", func(t *testing.T) {
-		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/", FullPath: "/?cmd=BLABLA", Status: 200}
-		optInAttrs, err := UserSelectedAttributes(optInCfg)
-		require.NoError(t, err)
-		selected := AttrsToMap(TraceAttributesSelector(span, optInAttrs))
-		val, ok := selected.Get("url.query")
-		require.True(t, ok)
-		assert.Equal(t, "cmd=BLABLA", val.Str())
 	})
 
 	t.Run("sensitive key redacted in url.query", func(t *testing.T) {

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -87,6 +87,112 @@ func TestTraceAttributesSelector_GraphQLDocumentSelection(t *testing.T) {
 	assert.Equal(t, document, selectedDocument.Str())
 }
 
+func TestHTTPServerSpanURLQuery(t *testing.T) {
+	optInCfg := &attributes.SelectorConfig{
+		SelectionCfg: attributes.Selection{
+			attributes.Traces.Section: attributes.InclusionLists{
+				Include: []string{string(attr.HTTPUrlQuery)},
+			},
+		},
+	}
+
+	t.Run("url.query absent by default", func(t *testing.T) {
+		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/", FullPath: "/?cmd=BLABLA", Status: 200}
+		defaultAttrs, err := UserSelectedAttributes(&attributes.SelectorConfig{})
+		require.NoError(t, err)
+		selected := AttrsToMap(TraceAttributesSelector(span, defaultAttrs))
+		_, ok := selected.Get("url.query")
+		assert.False(t, ok)
+	})
+
+	t.Run("url.query present when opted in", func(t *testing.T) {
+		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/", FullPath: "/?cmd=BLABLA", Status: 200}
+		optInAttrs, err := UserSelectedAttributes(optInCfg)
+		require.NoError(t, err)
+		selected := AttrsToMap(TraceAttributesSelector(span, optInAttrs))
+		val, ok := selected.Get("url.query")
+		require.True(t, ok)
+		assert.Equal(t, "cmd=BLABLA", val.Str())
+	})
+
+	t.Run("sensitive key redacted in url.query", func(t *testing.T) {
+		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/", FullPath: "/?cmd=OBIWANKENOBI&sig=abc123", Status: 200}
+		optInAttrs, err := UserSelectedAttributes(optInCfg)
+		require.NoError(t, err)
+		selected := AttrsToMap(TraceAttributesSelector(span, optInAttrs, "sig", "token"))
+		val, ok := selected.Get("url.query")
+		require.True(t, ok)
+		assert.Equal(t, "cmd=OBIWANKENOBI&sig=REDACTED", val.Str())
+	})
+
+	t.Run("sensitive key also scrubbed from url.full on client span", func(t *testing.T) {
+		// url.full is a client-span attribute; server spans use url.path instead.
+		span := &request.Span{
+			Type: request.EventTypeHTTPClient, Method: "GET", Path: "/", FullPath: "/?cmd=OBIWANKENOBI&sig=abc123",
+			Host: "example.com", HostPort: 80, Status: 200,
+		}
+		optInAttrs, err := UserSelectedAttributes(optInCfg)
+		require.NoError(t, err)
+		selected := AttrsToMap(TraceAttributesSelector(span, optInAttrs, "sig"))
+		val, ok := selected.Get("url.full")
+		require.True(t, ok)
+		assert.Contains(t, val.Str(), "cmd=OBIWANKENOBI")
+		assert.Contains(t, val.Str(), "sig=REDACTED")
+		assert.NotContains(t, val.Str(), "abc123")
+	})
+
+	t.Run("DefaultRedactQueryParams applied even without explicit redactKeys", func(t *testing.T) {
+		// TraceAttributesSelector always merges DefaultRedactQueryParams so callers
+		// cannot accidentally emit sensitive values by omitting redactKeys.
+		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/", FullPath: "/?sig=abc123", Status: 200}
+		optInAttrs, err := UserSelectedAttributes(optInCfg)
+		require.NoError(t, err)
+		selected := AttrsToMap(TraceAttributesSelector(span, optInAttrs))
+		val, ok := selected.Get("url.query")
+		require.True(t, ok)
+		assert.Equal(t, "sig=REDACTED", val.Str())
+	})
+
+	t.Run("url.query suppressed when explicitly excluded", func(t *testing.T) {
+		// Operators can opt out of url.query via:
+		//   attributes.select.traces.exclude: [url.query]
+		excludeCfg := &attributes.SelectorConfig{
+			SelectionCfg: attributes.Selection{
+				attributes.Traces.Section: attributes.InclusionLists{
+					Exclude: []string{string(attr.HTTPUrlQuery)},
+				},
+			},
+		}
+		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/", FullPath: "/?cmd=BLABLA", Status: 200}
+		excludeAttrs, err := UserSelectedAttributes(excludeCfg)
+		require.NoError(t, err)
+		selected := AttrsToMap(TraceAttributesSelector(span, excludeAttrs))
+		_, ok := selected.Get("url.query")
+		assert.False(t, ok, "url.query should be absent when explicitly excluded")
+	})
+
+	t.Run("url.path omitted when path is unobservable", func(t *testing.T) {
+		// FastCGI spans with no REQUEST_URI (truncated buffer or older nginx config)
+		// produce Path="". OTel semconv says omit the attribute rather than emit "".
+		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "", FullPath: "", Status: 200}
+		defaultAttrs, err := UserSelectedAttributes(&attributes.SelectorConfig{})
+		require.NoError(t, err)
+		selected := AttrsToMap(TraceAttributesSelector(span, defaultAttrs))
+		_, ok := selected.Get("url.path")
+		assert.False(t, ok, "url.path must be omitted when path is unobservable")
+	})
+
+	t.Run("url.query absent when FullPath is empty", func(t *testing.T) {
+		// Same truncation scenario: FullPath="" means there is no query string to emit.
+		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "", FullPath: "", Status: 200}
+		defaultAttrs, err := UserSelectedAttributes(&attributes.SelectorConfig{})
+		require.NoError(t, err)
+		selected := AttrsToMap(TraceAttributesSelector(span, defaultAttrs))
+		_, ok := selected.Get("url.query")
+		assert.False(t, ok, "url.query must be absent when FullPath is empty")
+	})
+}
+
 func TestGenAIToolCallAttributes(t *testing.T) {
 	t.Run("nil tool calls", func(t *testing.T) {
 		assert.Nil(t, genAIToolCallAttributes(nil))

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -117,13 +117,13 @@ func TestHTTPServerSpanURLQuery(t *testing.T) {
 	})
 
 	t.Run("sensitive key redacted in url.query", func(t *testing.T) {
-		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/", FullPath: "/?cmd=OBIWANKENOBI&sig=abc123", Status: 200}
+		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/", FullPath: "/?cmd=OBIWANKENOBI&signature=abc123", Status: 200}
 		optInAttrs, err := UserSelectedAttributes(optInCfg)
 		require.NoError(t, err)
-		selected := AttrsToMap(TraceAttributesSelector(span, optInAttrs, "sig", "token"))
+		selected := AttrsToMap(TraceAttributesSelector(span, optInAttrs, "signature"))
 		val, ok := selected.Get("url.query")
 		require.True(t, ok)
-		assert.Equal(t, "cmd=OBIWANKENOBI&sig=REDACTED", val.Str())
+		assert.Equal(t, "cmd=OBIWANKENOBI&signature=REDACTED", val.Str())
 	})
 
 	t.Run("sensitive key also scrubbed from url.full on client span", func(t *testing.T) {

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -617,8 +617,8 @@ type Attributes struct {
 	MetricSpanNameAggregationLimit int `yaml:"metric_span_names_limit" env:"OTEL_EBPF_METRIC_SPAN_NAMES_LIMIT"`
 
 	// RedactQueryParams lists query-parameter keys whose values are replaced with REDACTED
-	// in url.full and url.query. When unset, a built-in list of well-known sensitive keys
-	// (sig, token, password, …) is applied. Set to an empty list to disable all redaction.
+	// in url.full and url.query. When unset, a built-in list of well-known sensitive keys is applied.
+	// Set to an empty list to disable all redaction.
 	RedactQueryParams []string `yaml:"redact_query_params" env:"OTEL_EBPF_REDACT_QUERY_PARAMS" envSeparator:","`
 }
 

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -616,10 +616,10 @@ type Attributes struct {
 	// If the value <= 0, it is disabled.
 	MetricSpanNameAggregationLimit int `yaml:"metric_span_names_limit" env:"OTEL_EBPF_METRIC_SPAN_NAMES_LIMIT"`
 
-	// RedactQueryParams lists query-parameter keys whose values are replaced with REDACTED
-	// in url.full and url.query. When unset, a built-in list of well-known sensitive keys is applied.
-	// Set to an empty list to disable all redaction.
-	RedactQueryParams []string `yaml:"redact_query_params" env:"OTEL_EBPF_REDACT_QUERY_PARAMS" envSeparator:","`
+	// ExtraRedactQueryParams lists additional query-parameter keys whose values are replaced
+	// with REDACTED in url.full and url.query, on top of the built-in semconv-mandated set
+	// (X-Amz-Signature, X-Goog-Signature, sig, …). The built-in set is always applied.
+	ExtraRedactQueryParams []string `yaml:"extra_redact_query_params" env:"OTEL_EBPF_EXTRA_REDACT_QUERY_PARAMS" envSeparator:","`
 }
 
 type HostIDConfig struct {

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -616,10 +616,8 @@ type Attributes struct {
 	// If the value <= 0, it is disabled.
 	MetricSpanNameAggregationLimit int `yaml:"metric_span_names_limit" env:"OTEL_EBPF_METRIC_SPAN_NAMES_LIMIT"`
 
-	// ExtraRedactQueryParams lists additional query-parameter keys whose values are replaced
-	// with REDACTED in url.full and url.query, on top of the built-in semconv-mandated set
-	// (X-Amz-Signature, X-Goog-Signature, sig, …). The built-in set is always applied.
-	ExtraRedactQueryParams []string `yaml:"extra_redact_query_params" env:"OTEL_EBPF_EXTRA_REDACT_QUERY_PARAMS" envSeparator:","`
+	// SensitiveQueryParams controls which query-parameter keys are redacted in url.full and url.query.
+	SensitiveQueryParams attributes.SensitiveQueryParamsConfig `yaml:"sensitive_query_params"`
 }
 
 type HostIDConfig struct {

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -615,6 +615,11 @@ type Attributes struct {
 	// When the span_name cardinality surpasses this limit, the span_name will be reported as AGGREGATED.
 	// If the value <= 0, it is disabled.
 	MetricSpanNameAggregationLimit int `yaml:"metric_span_names_limit" env:"OTEL_EBPF_METRIC_SPAN_NAMES_LIMIT"`
+
+	// RedactQueryParams lists query-parameter keys whose values are replaced with REDACTED
+	// in url.full and url.query. When unset, a built-in list of well-known sensitive keys
+	// (sig, token, password, …) is applied. Set to an empty list to disable all redaction.
+	RedactQueryParams []string `yaml:"redact_query_params" env:"OTEL_EBPF_REDACT_QUERY_PARAMS" envSeparator:","`
 }
 
 type HostIDConfig struct {


### PR DESCRIPTION
## Summary

partially addresses #2073 

This PR emits `url.query` in all http spans by default, aligning with otel semconv:
- generic tracer (non-Go): `url.query` populated from the raw request-target
- sensitive query parameters values (from https://opentelemetry.io/docs/specs/semconv/http/http-spans/) are replaced with `REDACTED`.  A user can extend the list using `attributes.extra_redact_query_params`.
- `url.full` on http client spans now includes the query string with the sensitive values redacted.

Moreover, for fastcgi spans, now the full URL is visible in `url.path` and `url.query`

**Breaking changes**: `url.query` is now on by default and that `url.full` now carries query parameters. We should document it in the release notes or somewhere else. 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
