### PR TITLE
Add direct Go channel handoff probes

### DIFF
--- a/bpf/gotracer/go_runtime.c
+++ b/bpf/gotracer/go_runtime.c
@@ -30,6 +30,8 @@
 #include <gotracer/maps/redis.h>
 #include <gotracer/maps/runtime.h>
 
+#include <maps/go_ongoing_http_client_requests.h>
+
 #include <gotracer/types/grpc.h>
 #include <gotracer/types/nethttp.h>
 
@@ -216,6 +218,13 @@ static __always_inline bool current_obi_handoff(struct pt_regs *ctx, chan_handof
         return true;
     }
 
+    http_func_invocation_t *http_client_inv =
+        bpf_map_lookup_elem(&go_ongoing_http_client_requests, &g_key);
+    if (http_client_inv && valid_tp_info(&http_client_inv->tp)) {
+        tp_clone(&handoff->tp, &http_client_inv->tp);
+        return true;
+    }
+
     tp_info_t *kafka_go_tp = bpf_map_lookup_elem(&produce_traceparents_by_goroutine, &g_key);
     if (valid_tp_info(kafka_go_tp)) {
         tp_clone(&handoff->tp, kafka_go_tp);
@@ -237,6 +246,15 @@ static __always_inline bool current_obi_handoff(struct pt_regs *ctx, chan_handof
     sql_func_invocation_t *sql = bpf_map_lookup_elem(&ongoing_sql_queries, &g_key);
     if (sql && valid_tp_info(&sql->tp)) {
         tp_clone(&handoff->tp, &sql->tp);
+        return true;
+    }
+
+    obi_ctx_info_t *obi_ctx = obi_ctx__get(bpf_get_current_pid_tgid());
+    if (obi_ctx && valid_trace(obi_ctx->trace_id) && valid_span(obi_ctx->span_id)) {
+        __builtin_memcpy(handoff->tp.trace_id, obi_ctx->trace_id, sizeof(handoff->tp.trace_id));
+        __builtin_memcpy(handoff->tp.span_id, obi_ctx->span_id, sizeof(handoff->tp.span_id));
+        *((u64 *)handoff->tp.parent_id) = 0;
+        handoff->tp.flags = 0;
         return true;
     }
 
@@ -287,9 +305,9 @@ static __always_inline bool read_channel_dataqsiz(void *chan_ptr, u64 *dataqsiz)
     return bpf_probe_read_user(dataqsiz, sizeof(*dataqsiz), chan_ptr + dataqsiz_off) == 0;
 }
 
-static __always_inline void record_direct_channel_sender(u64 chan_ptr,
+static __always_inline void record_direct_channel_sender(const go_addr_key_t *chan_key,
                                                          const chan_handoff_t *handoff) {
-    direct_chan_handoff_t *existing = bpf_map_lookup_elem(&direct_channel_senders, &chan_ptr);
+    direct_chan_handoff_t *existing = bpf_map_lookup_elem(&direct_channel_senders, chan_key);
     direct_chan_handoff_t value = {};
 
     // More than one waiter on the same channel cannot be paired safely by channel pointer alone.
@@ -299,12 +317,12 @@ static __always_inline void record_direct_channel_sender(u64 chan_ptr,
         __builtin_memcpy(&value.handoff, handoff, sizeof(value.handoff));
     }
 
-    bpf_map_update_elem(&direct_channel_senders, &chan_ptr, &value, BPF_ANY);
+    bpf_map_update_elem(&direct_channel_senders, chan_key, &value, BPF_ANY);
 }
 
-static __always_inline void record_direct_channel_receiver(u64 chan_ptr,
+static __always_inline void record_direct_channel_receiver(const go_addr_key_t *chan_key,
                                                            const chan_handoff_t *handoff) {
-    direct_chan_handoff_t *existing = bpf_map_lookup_elem(&direct_channel_receivers, &chan_ptr);
+    direct_chan_handoff_t *existing = bpf_map_lookup_elem(&direct_channel_receivers, chan_key);
     direct_chan_handoff_t value = {};
 
     if (existing || !handoff) {
@@ -313,18 +331,18 @@ static __always_inline void record_direct_channel_receiver(u64 chan_ptr,
         __builtin_memcpy(&value.handoff, handoff, sizeof(value.handoff));
     }
 
-    bpf_map_update_elem(&direct_channel_receivers, &chan_ptr, &value, BPF_ANY);
+    bpf_map_update_elem(&direct_channel_receivers, chan_key, &value, BPF_ANY);
 }
 
-static __always_inline void emit_direct_channel_handoff(u64 chan_ptr) {
-    direct_chan_handoff_t *sender = bpf_map_lookup_elem(&direct_channel_senders, &chan_ptr);
-    direct_chan_handoff_t *receiver = bpf_map_lookup_elem(&direct_channel_receivers, &chan_ptr);
+static __always_inline void emit_direct_channel_handoff(const go_addr_key_t *chan_key) {
+    direct_chan_handoff_t *sender = bpf_map_lookup_elem(&direct_channel_senders, chan_key);
+    direct_chan_handoff_t *receiver = bpf_map_lookup_elem(&direct_channel_receivers, chan_key);
     if (sender && receiver && !sender->ambiguous && !receiver->ambiguous) {
         emit_channel_handoff(&sender->handoff, &receiver->handoff);
     }
 
-    bpf_map_delete_elem(&direct_channel_senders, &chan_ptr);
-    bpf_map_delete_elem(&direct_channel_receivers, &chan_ptr);
+    bpf_map_delete_elem(&direct_channel_senders, chan_key);
+    bpf_map_delete_elem(&direct_channel_receivers, chan_key);
 }
 
 static __always_inline int channel_send_start(struct pt_regs *ctx) {
@@ -347,11 +365,14 @@ static __always_inline int channel_send_start(struct pt_regs *ctx) {
         return 0;
     }
 
+    go_addr_key_t chan_key = {};
+    go_addr_key_from_id(&chan_key, (void *)chan_ptr);
+
     chan_handoff_t sender = {};
     if (current_obi_handoff(ctx, &sender)) {
-        record_direct_channel_sender(chan_ptr, &sender);
+        record_direct_channel_sender(&chan_key, &sender);
     } else {
-        record_direct_channel_sender(chan_ptr, NULL);
+        record_direct_channel_sender(&chan_key, NULL);
     }
 
     return 0;
@@ -368,11 +389,14 @@ static __always_inline int channel_send_return(struct pt_regs *ctx) {
     }
 
     u64 dataqsiz = 0;
+    go_addr_key_t chan_key = {};
+    go_addr_key_from_id(&chan_key, (void *)invocation->chan_ptr);
+
     if (read_channel_dataqsiz((void *)invocation->chan_ptr, &dataqsiz) && dataqsiz == 0) {
-        emit_direct_channel_handoff(invocation->chan_ptr);
+        emit_direct_channel_handoff(&chan_key);
     }
 
-    bpf_map_delete_elem(&direct_channel_senders, &invocation->chan_ptr);
+    bpf_map_delete_elem(&direct_channel_senders, &chan_key);
     bpf_map_delete_elem(&chansend_invocations, &g_key);
     return 0;
 }
@@ -400,10 +424,13 @@ static __always_inline int channel_recv_start(struct pt_regs *ctx) {
     }
 
     if (dataqsiz == 0) {
+        go_addr_key_t chan_key = {};
+        go_addr_key_from_id(&chan_key, (void *)chan_ptr);
+
         if (have_receiver) {
-            record_direct_channel_receiver(chan_ptr, &receiver);
+            record_direct_channel_receiver(&chan_key, &receiver);
         } else {
-            record_direct_channel_receiver(chan_ptr, NULL);
+            record_direct_channel_receiver(&chan_key, NULL);
         }
     }
 
@@ -421,11 +448,14 @@ static __always_inline int channel_recv_return(struct pt_regs *ctx) {
     }
 
     u64 dataqsiz = 0;
+    go_addr_key_t chan_key = {};
+    go_addr_key_from_id(&chan_key, (void *)invocation->chan_ptr);
+
     if (read_channel_dataqsiz((void *)invocation->chan_ptr, &dataqsiz) && dataqsiz == 0) {
-        emit_direct_channel_handoff(invocation->chan_ptr);
+        emit_direct_channel_handoff(&chan_key);
     }
 
-    bpf_map_delete_elem(&direct_channel_receivers, &invocation->chan_ptr);
+    bpf_map_delete_elem(&direct_channel_receivers, &chan_key);
     bpf_map_delete_elem(&chanrecv_invocations, &g_key);
     return 0;
 }

--- a/bpf/gotracer/go_runtime.c
+++ b/bpf/gotracer/go_runtime.c
@@ -30,12 +30,12 @@
 #include <gotracer/maps/redis.h>
 #include <gotracer/maps/runtime.h>
 
-#include <maps/go_ongoing_http_client_requests.h>
-
 #include <gotracer/types/grpc.h>
 #include <gotracer/types/nethttp.h>
 
 #include <logger/bpf_dbg.h>
+
+#include <maps/go_ongoing_http_client_requests.h>
 
 #include <pid/pid_helpers.h>
 
@@ -291,7 +291,7 @@ static __always_inline void emit_channel_handoff(chan_handoff_t *sender, chan_ha
     bpf_ringbuf_submit(trace, get_flags());
 }
 
-static __always_inline bool read_channel_dataqsiz(void *chan_ptr, u64 *dataqsiz) {
+static __always_inline bool read_channel_dataqsiz(const void *chan_ptr, u64 *dataqsiz) {
     if (!chan_ptr || !dataqsiz) {
         return false;
     }
@@ -312,9 +312,9 @@ static __always_inline void record_direct_channel_sender(const go_addr_key_t *ch
 
     // More than one waiter on the same channel cannot be paired safely by channel pointer alone.
     if (existing || !handoff) {
-        value.ambiguous = 1;
+        value.ambiguous = true;
     } else {
-        __builtin_memcpy(&value.handoff, handoff, sizeof(value.handoff));
+        value.handoff = *handoff;
     }
 
     bpf_map_update_elem(&direct_channel_senders, chan_key, &value, BPF_ANY);
@@ -326,9 +326,9 @@ static __always_inline void record_direct_channel_receiver(const go_addr_key_t *
     direct_chan_handoff_t value = {};
 
     if (existing || !handoff) {
-        value.ambiguous = 1;
+        value.ambiguous = true;
     } else {
-        __builtin_memcpy(&value.handoff, handoff, sizeof(value.handoff));
+        value.handoff = *handoff;
     }
 
     bpf_map_update_elem(&direct_channel_receivers, chan_key, &value, BPF_ANY);

--- a/bpf/gotracer/go_runtime.c
+++ b/bpf/gotracer/go_runtime.c
@@ -17,7 +17,9 @@
 
 #include <bpfcore/utils.h>
 
+#include <common/common.h>
 #include <common/ringbuf.h>
+#include <common/trace_helpers.h>
 
 #include <gotracer/go_common.h>
 
@@ -178,6 +180,284 @@ done:
     bpf_map_delete_elem(&newproc1, &c_key);
 
     return 0;
+}
+
+static __always_inline bool valid_tp_info(const tp_info_t *tp) {
+    return tp && valid_trace(tp->trace_id) && valid_span(tp->span_id);
+}
+
+static __always_inline bool current_obi_handoff(struct pt_regs *ctx, chan_handoff_t *handoff) {
+    if (!handoff) {
+        return false;
+    }
+
+    void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+
+    grpc_srv_func_invocation_t *grpc_server_inv =
+        bpf_map_lookup_elem(&ongoing_grpc_server_requests, &g_key);
+    if (grpc_server_inv && valid_tp_info(&grpc_server_inv->tp)) {
+        tp_clone(&handoff->tp, &grpc_server_inv->tp);
+        return true;
+    }
+
+    grpc_client_func_invocation_t *grpc_client_inv =
+        bpf_map_lookup_elem(&ongoing_grpc_client_requests, &g_key);
+    if (grpc_client_inv && valid_tp_info(&grpc_client_inv->tp)) {
+        tp_clone(&handoff->tp, &grpc_client_inv->tp);
+        return true;
+    }
+
+    server_http_func_invocation_t *http_server_inv =
+        bpf_map_lookup_elem(&ongoing_http_server_requests, &g_key);
+    if (http_server_inv && valid_tp_info(&http_server_inv->tp)) {
+        tp_clone(&handoff->tp, &http_server_inv->tp);
+        return true;
+    }
+
+    tp_info_t *kafka_go_tp = bpf_map_lookup_elem(&produce_traceparents_by_goroutine, &g_key);
+    if (valid_tp_info(kafka_go_tp)) {
+        tp_clone(&handoff->tp, kafka_go_tp);
+        return true;
+    }
+
+    mongo_go_client_req_t *mongo = bpf_map_lookup_elem(&ongoing_mongo_requests, &g_key);
+    if (mongo && valid_tp_info(&mongo->tp)) {
+        tp_clone(&handoff->tp, &mongo->tp);
+        return true;
+    }
+
+    redis_client_req_t *redis = bpf_map_lookup_elem(&ongoing_redis_requests, &g_key);
+    if (redis && valid_tp_info(&redis->tp)) {
+        tp_clone(&handoff->tp, &redis->tp);
+        return true;
+    }
+
+    sql_func_invocation_t *sql = bpf_map_lookup_elem(&ongoing_sql_queries, &g_key);
+    if (sql && valid_tp_info(&sql->tp)) {
+        tp_clone(&handoff->tp, &sql->tp);
+        return true;
+    }
+
+    return false;
+}
+
+static __always_inline bool same_span_context(const tp_info_t *a, const tp_info_t *b) {
+    if (!a || !b) {
+        return false;
+    }
+
+    return *((u64 *)a->span_id) == *((u64 *)b->span_id) &&
+           *((u64 *)a->trace_id) == *((u64 *)b->trace_id) &&
+           *((u64 *)(a->trace_id + 8)) == *((u64 *)(b->trace_id + 8));
+}
+
+static __always_inline void emit_channel_handoff(chan_handoff_t *sender, chan_handoff_t *receiver) {
+    if (!sender || !receiver || !valid_tp_info(&sender->tp) || !valid_tp_info(&receiver->tp)) {
+        return;
+    }
+
+    if (same_span_context(&sender->tp, &receiver->tp)) {
+        return;
+    }
+
+    channel_link_trace_t *trace = bpf_ringbuf_reserve(&events, sizeof(*trace), 0);
+    if (!trace) {
+        return;
+    }
+
+    trace->type = EVENT_GO_CHANNEL_LINK;
+    tp_clone(&trace->sender_tp, &sender->tp);
+    tp_clone(&trace->receiver_tp, &receiver->tp);
+    bpf_ringbuf_submit(trace, get_flags());
+}
+
+static __always_inline bool read_channel_dataqsiz(void *chan_ptr, u64 *dataqsiz) {
+    if (!chan_ptr || !dataqsiz) {
+        return false;
+    }
+
+    off_table_t *ot = get_offsets_table();
+    const u64 dataqsiz_off = go_offset_of(ot, (go_offset){.v = _hchan_dataqsiz_pos});
+    if (dataqsiz_off == (u64)-1) {
+        return false;
+    }
+
+    return bpf_probe_read_user(dataqsiz, sizeof(*dataqsiz), chan_ptr + dataqsiz_off) == 0;
+}
+
+static __always_inline void record_direct_channel_sender(u64 chan_ptr,
+                                                         const chan_handoff_t *handoff) {
+    direct_chan_handoff_t *existing = bpf_map_lookup_elem(&direct_channel_senders, &chan_ptr);
+    direct_chan_handoff_t value = {};
+
+    // More than one waiter on the same channel cannot be paired safely by channel pointer alone.
+    if (existing || !handoff) {
+        value.ambiguous = 1;
+    } else {
+        __builtin_memcpy(&value.handoff, handoff, sizeof(value.handoff));
+    }
+
+    bpf_map_update_elem(&direct_channel_senders, &chan_ptr, &value, BPF_ANY);
+}
+
+static __always_inline void record_direct_channel_receiver(u64 chan_ptr,
+                                                           const chan_handoff_t *handoff) {
+    direct_chan_handoff_t *existing = bpf_map_lookup_elem(&direct_channel_receivers, &chan_ptr);
+    direct_chan_handoff_t value = {};
+
+    if (existing || !handoff) {
+        value.ambiguous = 1;
+    } else {
+        __builtin_memcpy(&value.handoff, handoff, sizeof(value.handoff));
+    }
+
+    bpf_map_update_elem(&direct_channel_receivers, &chan_ptr, &value, BPF_ANY);
+}
+
+static __always_inline void emit_direct_channel_handoff(u64 chan_ptr) {
+    direct_chan_handoff_t *sender = bpf_map_lookup_elem(&direct_channel_senders, &chan_ptr);
+    direct_chan_handoff_t *receiver = bpf_map_lookup_elem(&direct_channel_receivers, &chan_ptr);
+    if (sender && receiver && !sender->ambiguous && !receiver->ambiguous) {
+        emit_channel_handoff(&sender->handoff, &receiver->handoff);
+    }
+
+    bpf_map_delete_elem(&direct_channel_senders, &chan_ptr);
+    bpf_map_delete_elem(&direct_channel_receivers, &chan_ptr);
+}
+
+static __always_inline int channel_send_start(struct pt_regs *ctx) {
+    const u64 chan_ptr = (u64)GO_PARAM1(ctx);
+    if (!chan_ptr) {
+        return 0;
+    }
+
+    void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+
+    chan_func_invocation_t invocation = {.chan_ptr = chan_ptr};
+    if (bpf_map_update_elem(&chansend_invocations, &g_key, &invocation, BPF_ANY)) {
+        return 0;
+    }
+
+    u64 dataqsiz = 0;
+    if (!read_channel_dataqsiz((void *)chan_ptr, &dataqsiz) || dataqsiz != 0) {
+        return 0;
+    }
+
+    chan_handoff_t sender = {};
+    if (current_obi_handoff(ctx, &sender)) {
+        record_direct_channel_sender(chan_ptr, &sender);
+    } else {
+        record_direct_channel_sender(chan_ptr, NULL);
+    }
+
+    return 0;
+}
+
+static __always_inline int channel_send_return(struct pt_regs *ctx) {
+    void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+
+    chan_func_invocation_t *invocation = bpf_map_lookup_elem(&chansend_invocations, &g_key);
+    if (!invocation) {
+        return 0;
+    }
+
+    u64 dataqsiz = 0;
+    if (read_channel_dataqsiz((void *)invocation->chan_ptr, &dataqsiz) && dataqsiz == 0) {
+        emit_direct_channel_handoff(invocation->chan_ptr);
+    }
+
+    bpf_map_delete_elem(&direct_channel_senders, &invocation->chan_ptr);
+    bpf_map_delete_elem(&chansend_invocations, &g_key);
+    return 0;
+}
+
+static __always_inline int channel_recv_start(struct pt_regs *ctx) {
+    const u64 chan_ptr = (u64)GO_PARAM1(ctx);
+    if (!chan_ptr) {
+        return 0;
+    }
+
+    u64 dataqsiz = 0;
+    if (!read_channel_dataqsiz((void *)chan_ptr, &dataqsiz)) {
+        return 0;
+    }
+
+    chan_func_invocation_t invocation = {.chan_ptr = chan_ptr};
+    chan_handoff_t receiver = {};
+    bool have_receiver = current_obi_handoff(ctx, &receiver);
+
+    void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+    if (bpf_map_update_elem(&chanrecv_invocations, &g_key, &invocation, BPF_ANY)) {
+        return 0;
+    }
+
+    if (dataqsiz == 0) {
+        if (have_receiver) {
+            record_direct_channel_receiver(chan_ptr, &receiver);
+        } else {
+            record_direct_channel_receiver(chan_ptr, NULL);
+        }
+    }
+
+    return 0;
+}
+
+static __always_inline int channel_recv_return(struct pt_regs *ctx) {
+    void *goroutine_addr = (void *)GOROUTINE_PTR(ctx);
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+
+    chan_func_invocation_t *invocation = bpf_map_lookup_elem(&chanrecv_invocations, &g_key);
+    if (!invocation) {
+        return 0;
+    }
+
+    u64 dataqsiz = 0;
+    if (read_channel_dataqsiz((void *)invocation->chan_ptr, &dataqsiz) && dataqsiz == 0) {
+        emit_direct_channel_handoff(invocation->chan_ptr);
+    }
+
+    bpf_map_delete_elem(&direct_channel_receivers, &invocation->chan_ptr);
+    bpf_map_delete_elem(&chanrecv_invocations, &g_key);
+    return 0;
+}
+
+SEC("uprobe/runtime_chansend1")
+int obi_uprobe_runtime_chansend1(struct pt_regs *ctx) {
+    return channel_send_start(ctx);
+}
+
+SEC("uprobe/runtime_chansend1_return")
+int obi_uprobe_runtime_chansend1_return(struct pt_regs *ctx) {
+    return channel_send_return(ctx);
+}
+
+SEC("uprobe/runtime_chanrecv1")
+int obi_uprobe_runtime_chanrecv1(struct pt_regs *ctx) {
+    return channel_recv_start(ctx);
+}
+
+SEC("uprobe/runtime_chanrecv1_return")
+int obi_uprobe_runtime_chanrecv1_return(struct pt_regs *ctx) {
+    return channel_recv_return(ctx);
+}
+
+SEC("uprobe/runtime_chanrecv2")
+int obi_uprobe_runtime_chanrecv2(struct pt_regs *ctx) {
+    return channel_recv_start(ctx);
+}
+
+SEC("uprobe/runtime_chanrecv2_return")
+int obi_uprobe_runtime_chanrecv2_return(struct pt_regs *ctx) {
+    return channel_recv_return(ctx);
 }
 
 enum gstatus {

--- a/bpf/gotracer/maps/runtime.h
+++ b/bpf/gotracer/maps/runtime.h
@@ -6,9 +6,9 @@
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_helpers.h>
 
+#include <common/event_defs.h>
 #include <common/go_addr_key.h>
 #include <common/map_sizing.h>
-#include <common/event_defs.h>
 #include <common/pin_internal.h>
 #include <common/tp_info.h>
 #include <gotracer/go_constants.h>
@@ -24,7 +24,7 @@ typedef struct chan_handoff {
 
 typedef struct direct_chan_handoff {
     chan_handoff_t handoff;
-    u8 ambiguous;
+    bool ambiguous;
     u8 _pad[7];
 } direct_chan_handoff_t;
 

--- a/bpf/gotracer/maps/runtime.h
+++ b/bpf/gotracer/maps/runtime.h
@@ -53,7 +53,7 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __type(key, u64);
+    __type(key, go_addr_key_t);
     __type(value, direct_chan_handoff_t);
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
     __uint(pinning, OBI_PIN_INTERNAL);
@@ -61,7 +61,7 @@ struct {
 
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __type(key, u64);
+    __type(key, go_addr_key_t);
     __type(value, direct_chan_handoff_t);
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
     __uint(pinning, OBI_PIN_INTERNAL);

--- a/bpf/gotracer/maps/runtime.h
+++ b/bpf/gotracer/maps/runtime.h
@@ -6,10 +6,27 @@
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_helpers.h>
 
+#include <common/go_addr_key.h>
+#include <common/map_sizing.h>
 #include <common/event_defs.h>
 #include <common/pin_internal.h>
+#include <common/tp_info.h>
 #include <gotracer/go_constants.h>
 #include <pid/types/pid_info.h>
+
+typedef struct chan_func_invocation {
+    u64 chan_ptr;
+} chan_func_invocation_t;
+
+typedef struct chan_handoff {
+    tp_info_t tp;
+} chan_handoff_t;
+
+typedef struct direct_chan_handoff {
+    chan_handoff_t handoff;
+    u8 ambiguous;
+    u8 _pad[7];
+} direct_chan_handoff_t;
 
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
@@ -17,6 +34,38 @@ struct {
     __type(value, u32);
     __uint(max_entries, 5000);
 } mptr_to_root_tid SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, go_addr_key_t);
+    __type(value, chan_func_invocation_t);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} chansend_invocations SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, go_addr_key_t);
+    __type(value, chan_func_invocation_t);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} chanrecv_invocations SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u64);
+    __type(value, direct_chan_handoff_t);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} direct_channel_senders SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u64);
+    __type(value, direct_chan_handoff_t);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} direct_channel_receivers SEC(".maps");
 
 typedef struct go_runtime_metric_target {
     u64 memstats_addr;

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -58,6 +58,8 @@ type Tracer struct {
 	supportsBPFLoop         bool
 	runtimeMetricTargetKeys map[runtimeMetricTargetKey]BpfPidInfo
 	runtimeMetrics          *msg.Queue[[]runtimemetrics.RuntimeMetricSnapshot]
+	goChannelOffsetsByIno   map[uint64]bool
+	currentBinaryIno        uint64
 }
 
 func New(
@@ -86,6 +88,7 @@ func New(
 		supportsBPFLoop:         ebpfcommon.SupportsEBPFLoops(log, cfg.EBPF.OverrideBPFLoopEnabled),
 		runtimeMetricTargetKeys: map[runtimeMetricTargetKey]BpfPidInfo{},
 		runtimeMetrics:          runtimeMetrics,
+		goChannelOffsetsByIno:   map[uint64]bool{},
 	}
 }
 
@@ -203,6 +206,8 @@ func (p *Tracer) SetupTailCalls() {
 }
 
 func (p *Tracer) RegisterOffsets(fileInfo *exec.FileInfo, offsets *goexec.Offsets) {
+	p.recordGoChannelOffsetAvailability(fileInfo, offsets)
+
 	offTable := BpfOffTableT{}
 	// Set the field offsets and the logLevel for the Go BPF program in a map
 	for _, field := range []goexec.GoOffset{
@@ -344,6 +349,26 @@ func (p *Tracer) RegisterOffsets(fileInfo *exec.FileInfo, offsets *goexec.Offset
 	}
 }
 
+func (p *Tracer) recordGoChannelOffsetAvailability(fileInfo *exec.FileInfo, offsets *goexec.Offsets) {
+	if p == nil || fileInfo == nil {
+		return
+	}
+
+	if p.goChannelOffsetsByIno == nil {
+		p.goChannelOffsetsByIno = map[uint64]bool{}
+	}
+
+	ino := fileInfo.Ino()
+	hasOffsets := offsets.HasGoChannelOffsets()
+	p.goChannelOffsetsByIno[ino] = hasOffsets
+	p.currentBinaryIno = ino
+
+	if !hasOffsets && p.log != nil {
+		p.log.Debug("skipping Go channel link probes for binary with missing runtime.hchan offsets",
+			"pid", fileInfo.Pid(), "ino", ino, "cmd", fileInfo.CmdExePath())
+	}
+}
+
 // registerRuntimeMetricTarget writes per-process Go runtime global addresses
 // into BPF. Offsets stay inode-scoped in go_offsets_map, but these addresses
 // are process-scoped for PIE/ASLR and must follow the PID allow lifecycle.
@@ -421,7 +446,17 @@ func runtimeMetricPIDInfo(pid app.PID, ns uint32) (BpfPidInfo, error) {
 	return pidInfo, nil
 }
 
-func (p *Tracer) ProcessBinary(_ *exec.FileInfo) {}
+func (p *Tracer) ProcessBinary(fileInfo *exec.FileInfo) {
+	if p == nil {
+		return
+	}
+	if fileInfo == nil {
+		p.currentBinaryIno = 0
+		return
+	}
+
+	p.currentBinaryIno = fileInfo.Ino()
+}
 
 func (p *Tracer) AddCloser(c ...io.Closer) {
 	p.closers = append(p.closers, c...)
@@ -773,6 +808,21 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 		}},
 	}
 
+	if p.goChannelLinkProbesEnabled() {
+		m["runtime.chansend1"] = []*ebpfcommon.ProbeDesc{{
+			Start: p.bpfObjects.ObiUprobeRuntimeChansend1,
+			End:   p.bpfObjects.ObiUprobeRuntimeChansend1Return,
+		}}
+		m["runtime.chanrecv1"] = []*ebpfcommon.ProbeDesc{{
+			Start: p.bpfObjects.ObiUprobeRuntimeChanrecv1,
+			End:   p.bpfObjects.ObiUprobeRuntimeChanrecv1Return,
+		}}
+		m["runtime.chanrecv2"] = []*ebpfcommon.ProbeDesc{{
+			Start: p.bpfObjects.ObiUprobeRuntimeChanrecv2,
+			End:   p.bpfObjects.ObiUprobeRuntimeChanrecv2Return,
+		}}
+	}
+
 	// HTTP Header extraction
 	// with bpf_loop we scan the buffer with a single uprobe - this is less overhead
 	// otherwise we have a probe per header net/textproto.(*Reader).readContinuedLineSlice
@@ -830,6 +880,14 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 	}
 
 	return m
+}
+
+func (p *Tracer) goChannelLinkProbesEnabled() bool {
+	if p == nil || p.currentBinaryIno == 0 {
+		return false
+	}
+
+	return p.goChannelOffsetsByIno[p.currentBinaryIno]
 }
 
 func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {

--- a/pkg/internal/ebpf/gotracer/gotracer_test.go
+++ b/pkg/internal/ebpf/gotracer/gotracer_test.go
@@ -1,0 +1,95 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gotracer
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
+	"go.opentelemetry.io/obi/pkg/internal/goexec"
+)
+
+func TestGoChannelLinkProbesRequireChannelOffsets(t *testing.T) {
+	disableContextPropagationForTest(t)
+
+	tracer := &Tracer{
+		log:                   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		goChannelOffsetsByIno: map[uint64]bool{},
+	}
+
+	assertNoGoChannelLinkProbes(t, tracer.GoProbes())
+
+	tracer.recordGoChannelOffsetAvailability(
+		exec.New(exec.Init{Ino: 1}),
+		&goexec.Offsets{Field: goexec.FieldOffsets{
+			goexec.HchanDataqsizPos: uint64(8),
+			goexec.HchanSendxPos:    uint64(48),
+		}},
+	)
+	assertNoGoChannelLinkProbes(t, tracer.GoProbes())
+
+	tracer.recordGoChannelOffsetAvailability(exec.New(exec.Init{Ino: 2}), goChannelOffsets())
+	probes := tracer.GoProbes()
+	for _, symbol := range goChannelLinkProbeSymbols() {
+		require.Contains(t, probes, symbol)
+	}
+}
+
+func TestProcessBinarySelectsRecordedChannelOffsetState(t *testing.T) {
+	tracer := &Tracer{
+		goChannelOffsetsByIno: map[uint64]bool{
+			1: true,
+			2: false,
+		},
+	}
+
+	tracer.ProcessBinary(exec.New(exec.Init{Ino: 1}))
+	assert.True(t, tracer.goChannelLinkProbesEnabled())
+
+	tracer.ProcessBinary(exec.New(exec.Init{Ino: 2}))
+	assert.False(t, tracer.goChannelLinkProbesEnabled())
+
+	tracer.ProcessBinary(nil)
+	assert.False(t, tracer.goChannelLinkProbesEnabled())
+}
+
+func goChannelOffsets() *goexec.Offsets {
+	return &goexec.Offsets{Field: goexec.FieldOffsets{
+		goexec.HchanDataqsizPos: uint64(8),
+		goexec.HchanSendxPos:    uint64(48),
+		goexec.HchanRecvxPos:    uint64(56),
+	}}
+}
+
+func goChannelLinkProbeSymbols() []string {
+	return []string{
+		"runtime.chansend1",
+		"runtime.chanrecv1",
+		"runtime.chanrecv2",
+	}
+}
+
+func assertNoGoChannelLinkProbes(t *testing.T, probes map[string][]*ebpfcommon.ProbeDesc) {
+	t.Helper()
+
+	for _, symbol := range goChannelLinkProbeSymbols() {
+		assert.NotContains(t, probes, symbol)
+	}
+}
+
+func disableContextPropagationForTest(t *testing.T) {
+	t.Helper()
+
+	previous := ebpfcommon.IntegrityModeOverride
+	ebpfcommon.IntegrityModeOverride = true
+	t.Cleanup(func() {
+		ebpfcommon.IntegrityModeOverride = previous
+	})
+}


### PR DESCRIPTION
## Summary

This adds the next #2238 feature slice for direct unbuffered Go channel handoffs.

The Go tracer now registers `runtime.chansend1`, `runtime.chanrecv1`, and `runtime.chanrecv2` probes when `runtime.hchan` offsets are available for a binary. The new runtime probes capture active OBI span contexts on channel send/receive and emit the existing `EVENT_GO_CHANNEL_LINK` record for direct unbuffered channel handoffs.

## Scope

This intentionally does not add buffered channel slot correlation, `runtime.selectgo` support, docs/examples, or feature configuration. The SIG decided no feature flag or configuration is needed for now, so this slice gates runtime channel probe attachment on offset availability.

Included here:

- add direct channel sender/receiver state maps and invocation tracking
- emit receiver-side channel-link events for unbuffered channel handoffs
- ignore nil channels, buffered channels, invalid span contexts, and self-links
- mark multiple waiters on the same channel pointer as ambiguous rather than guessing
- record per-binary channel offset availability before Go probe registration
- cover probe-registration gating with focused unit tests

## Validation

- `make generate`
- `clang-format -i bpf/gotracer/go_runtime.c bpf/gotracer/maps/runtime.h`
- `go test -count=1 ./pkg/ebpf/common ./pkg/runtimemetrics ./pkg/internal/ebpf/gotracer`
- `make compile`