### PR TITLE
Split Go Renovate dependency groups

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -105,10 +105,105 @@
       "enabled": false
     },
     {
-      "groupName": "Go",
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["patch", "digest", "minor"],
       "schedule": ["before 6am on Monday"]
+    },
+    {
+      "groupName": "OpenTelemetry Collector Go packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["go.opentelemetry.io/collector{/,}**"],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "groupName": "OpenTelemetry Go packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["go.opentelemetry.io/otel{/,}**"],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "groupName": "OpenTelemetry Go contrib packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["go.opentelemetry.io/contrib{/,}**"],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "groupName": "golang.org/x packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["golang.org/x{/,}**"],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "groupName": "google.golang.org packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["google.golang.org{/,}**"],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "groupName": "Google Cloud Go packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "cloud.google.com/go{/,}**",
+        "github.com/GoogleCloudPlatform{/,}**"
+      ],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "groupName": "Prometheus Go packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/prometheus{/,}**"],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "groupName": "AWS Go packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/aws{/,}**"],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "groupName": "Docker Go packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/containers{/,}**",
+        "github.com/containerd{/,}**",
+        "github.com/distribution{/,}**",
+        "github.com/docker{/,}**",
+        "github.com/moby{/,}**",
+        "github.com/opencontainers{/,}**"
+      ],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "groupName": "Kubernetes Go packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "k8s.io{/,}**",
+        "sigs.k8s.io{/,}**"
+      ],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "groupName": "go-openapi packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/go-openapi{/,}**"],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "description": "Group validator and translation packages from go-playground",
+      "groupName": "go-playground validator packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/go-playground/locales{/,}**",
+        "github.com/go-playground/universal-translator{/,}**",
+        "github.com/go-playground/validator{/,}**"
+      ],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
+    },
+    {
+      "groupName": "Uber Go packages",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["go.uber.org{/,}**"],
+      "matchUpdateTypes": ["patch", "digest", "minor"]
     },
     {
       "description": "Block Go language major upgrades in go.mod files (these require coordinated manual changes)",


### PR DESCRIPTION
## Summary

Split Renovate's Go module update grouping into targeted package-family groups instead of one broad Go dependency PR.

The Go module schedule remains on Monday, but unrelated Go dependencies can now update independently. Related ecosystems that are typically released or consumed together still stay grouped, including OpenTelemetry Collector, OpenTelemetry Go, OpenTelemetry contrib, golang.org/x, google.golang.org, Google Cloud, Prometheus, AWS, Docker/container packages, Kubernetes, go-openapi, go-playground validator packages, and Uber Go packages.

## Motivation

The previous broad Go grouping meant that one blocking module upgrade prevented all other Go dependency updates from merging. These narrower groups reduce that blast radius while keeping noisy or coupled dependency families together.

## Validation

- `sed '/^[[:space:]]*\\/\\//d' .github/renovate.json5 | jq empty`