### PR TITLE
(DynamicSelector-Phase4) Propagate signal ownership through app discovery and lifecycle consumers

### DIFF
--- a/pkg/appolly/app/svc/svc.go
+++ b/pkg/appolly/app/svc/svc.go
@@ -109,6 +109,11 @@ type Attrs struct {
 	// UserPID and HostPID fields of the request.PidInfo struct.
 	ProcPID app.PID
 
+	// DynamicSelectorPID is the PID whose dynamic signal selection controls this process.
+	// It usually matches ProcPID, but children discovered through a selected parent can inherit
+	// the parent's runtime signal selection.
+	DynamicSelectorPID app.PID
+
 	// HostName running the process. It will default to the OBI host and will be overridden
 	// by other metadata if available (e.g., Pod Name, Node Name, etc...)
 	HostName string

--- a/pkg/appolly/discover/finder.go
+++ b/pkg/appolly/discover/finder.go
@@ -88,13 +88,17 @@ func (pf *ProcessFinder) Start(ctx context.Context, opts ...ProcessFinderStartOp
 	tracerEvents := msgh.QueueFromConfig[Event[*ebpf.Instrumentable]](pf.cfg, "tracerEvents")
 
 	configCriteria := FindingCriteria(pf.cfg)
+	var appDynamicSelector *dynamicPIDSignalView
+	if startConfig.dynamicPIDSelector != nil {
+		appDynamicSelector = startConfig.dynamicPIDSelector.appSignals()
+	}
 
 	swi := swarm.Instancer{}
 	processEvents := msgh.QueueFromConfig[[]Event[ProcessAttrs]](pf.cfg, "processEvents")
 
 	var addedPIDsCh <-chan []app.PID
-	if startConfig.dynamicPIDSelector != nil {
-		addedPIDsCh = startConfig.dynamicPIDSelector.AddedPIDsNotify()
+	if appDynamicSelector != nil {
+		addedPIDsCh = appDynamicSelector.AddedPIDsNotify()
 	}
 	swi.Add(swarm.DirectInstance(ProcessWatcherFunc(pf.cfg, pf.ebpfEventContext, processEvents, configCriteria, addedPIDsCh)),
 		swarm.WithID("ProcessWatcher"))
@@ -124,7 +128,7 @@ func (pf *ProcessFinder) Start(ctx context.Context, opts ...ProcessFinderStartOp
 	criteriaFilteredEvents := msgh.QueueFromConfig[[]Event[ProcessMatch]](pf.cfg, "criteriaFilteredEvents")
 	swi.Add(criteriaMatcherProvider(pf.cfg, langEnrichedEvents, criteriaFilteredEvents, configCriteria, startConfig.dynamicPIDSelector),
 		swarm.WithID("CriteriaMatcher"))
-	swi.Add(dynamicMatcherProvider(langEnrichedEvents, criteriaFilteredEvents, startConfig.dynamicPIDSelector),
+	swi.Add(dynamicMatcherProvider(langEnrichedEvents, criteriaFilteredEvents, appDynamicSelector),
 		swarm.WithID("DynamicMatcher"))
 
 	executableTypes := msgh.QueueFromConfig[[]Event[ebpf.Instrumentable]](pf.cfg, "executableTypes")

--- a/pkg/appolly/discover/matcher.go
+++ b/pkg/appolly/discover/matcher.go
@@ -81,7 +81,10 @@ type ProcessMatch struct {
 	Criteria            []services.Selector
 	LogEnricherCriteria []services.Selector
 	Process             *services.ProcessInfo
-	DynamicSelectorPID  app.PID
+	// DynamicSelectorPID is the runtime dynamic-selection owner PID. It is set by DynamicMatcher
+	// on direct matches and inherited unchanged by child processes matched via PPid. CriteriaMatcher
+	// leaves it zero so static discovery continues to use ProcPID downstream.
+	DynamicSelectorPID app.PID
 }
 
 func (pm ProcessMatch) LogEnricherEnabled() bool {

--- a/pkg/appolly/discover/matcher.go
+++ b/pkg/appolly/discover/matcher.go
@@ -81,6 +81,7 @@ type ProcessMatch struct {
 	Criteria            []services.Selector
 	LogEnricherCriteria []services.Selector
 	Process             *services.ProcessInfo
+	DynamicSelectorPID  app.PID
 }
 
 func (pm ProcessMatch) LogEnricherEnabled() bool {

--- a/pkg/appolly/discover/matcher_dynamic.go
+++ b/pkg/appolly/discover/matcher_dynamic.go
@@ -15,7 +15,7 @@ import (
 
 type DynamicMatcher struct {
 	Log                *slog.Logger
-	DynamicPIDSelector services.Selector
+	DynamicPIDSelector *dynamicPIDSignalView
 	Input              <-chan []Event[ProcessAttrs]
 	Output             *msg.Queue[[]Event[ProcessMatch]]
 	ProcessHistory     map[app.PID]ProcessMatch
@@ -27,7 +27,7 @@ type DynamicMatcher struct {
 func dynamicMatcherProvider(
 	input *msg.Queue[[]Event[ProcessAttrs]],
 	output *msg.Queue[[]Event[ProcessMatch]],
-	dynamicPIDs *DynamicPIDSelector,
+	dynamicPIDs *dynamicPIDSignalView,
 ) swarm.InstanceFunc {
 	if dynamicPIDs == nil {
 		emptyFunc, _ := swarm.EmptyRunFunc()
@@ -36,7 +36,7 @@ func dynamicMatcherProvider(
 
 	dynamicMatcher := &DynamicMatcher{
 		Log:                slog.With("component", "discover.DynamicMatcher"),
-		DynamicPIDSelector: dynamicPIDs.AsSelector(),
+		DynamicPIDSelector: dynamicPIDs,
 		Input:              input.Subscribe(msg.SubscriberName("discover.DynamicMatcher")),
 		Output:             output,
 		ProcessHistory:     map[app.PID]ProcessMatch{},
@@ -130,20 +130,15 @@ func (m *DynamicMatcher) filterCreated(obj ProcessAttrs) (Event[ProcessMatch], b
 
 func (m *DynamicMatcher) matchDynamicCriteria(obj ProcessAttrs, proc *services.ProcessInfo) *ProcessMatch {
 	criteria := make([]services.Selector, 0, 1)
-	if pids, ok := m.DynamicPIDSelector.GetPIDs(); ok && len(pids) > 0 {
-		for _, p := range pids {
-			if p == proc.Pid {
-				criteria = append(criteria, m.DynamicPIDSelector)
-				break
-			}
-		}
+	if m.DynamicPIDSelector.IncludesPID(proc.Pid) {
+		criteria = append(criteria, m.DynamicPIDSelector.AsSelector())
 	}
 
 	if len(criteria) > 0 {
 		m.Log.Debug("found process", "pid", proc.Pid, "comm", proc.ExePath, "metadata",
 			obj.metadata, "podLabels", obj.podLabels, "criteria", criteria)
 
-		return &ProcessMatch{Criteria: criteria, Process: proc}
+		return &ProcessMatch{Criteria: criteria, Process: proc, DynamicSelectorPID: proc.Pid}
 	}
 
 	return nil

--- a/pkg/appolly/discover/matcher_test.go
+++ b/pkg/appolly/discover/matcher_test.go
@@ -49,7 +49,7 @@ func TestMatchersMutuallyExclusive(t *testing.T) {
 
 		swi := swarm.Instancer{}
 		swi.Add(criteriaMatcherProvider(&pipeConfig, inQ, outQ, cfgCriteria, sel), swarm.WithID("CriteriaMatcher"))
-		swi.Add(dynamicMatcherProvider(inQ, outQ, sel), swarm.WithID("DynamicMatcher"))
+		swi.Add(dynamicMatcherProvider(inQ, outQ, sel.appSignals()), swarm.WithID("DynamicMatcher"))
 		runner, err := swi.Instance(t.Context())
 		require.NoError(t, err)
 		runner.Start(t.Context())
@@ -729,7 +729,7 @@ func TestCriteriaMatcher_DynamicTargetPIDs(t *testing.T) {
 	processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
 		return &services.ProcessInfo{Pid: pp.pid, ExePath: "/any/exe", OpenPorts: pp.openPorts}, nil
 	}
-	runFn, err := dynamicMatcherProvider(discoveredProcesses, filteredProcessesQu, dynamicSelector)(t.Context())
+	runFn, err := dynamicMatcherProvider(discoveredProcesses, filteredProcessesQu, dynamicSelector.appSignals())(t.Context())
 	require.NoError(t, err)
 	go runFn(t.Context())
 	time.Sleep(50 * time.Millisecond)
@@ -742,6 +742,7 @@ func TestCriteriaMatcher_DynamicTargetPIDs(t *testing.T) {
 	matches := testutil.ReadChannel(t, filteredProcesses, testTimeout)
 	require.Len(t, matches, 1)
 	assert.Equal(t, app.PID(42), matches[0].Obj.Process.Pid)
+	assert.Equal(t, app.PID(42), matches[0].Obj.DynamicSelectorPID)
 
 	dynamicSelector.AddPIDs(100)
 	discoveredProcesses.Send([]Event[ProcessAttrs]{
@@ -778,7 +779,7 @@ func TestCriteriaMatcher_DynamicTargetPIDs_RemoveNotification(t *testing.T) {
 	processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
 		return &services.ProcessInfo{Pid: pp.pid, ExePath: "/any/exe", OpenPorts: pp.openPorts}, nil
 	}
-	runFn, err := dynamicMatcherProvider(discoveredProcesses, filteredProcessesQu, dynamicSelector)(t.Context())
+	runFn, err := dynamicMatcherProvider(discoveredProcesses, filteredProcessesQu, dynamicSelector.appSignals())(t.Context())
 	require.NoError(t, err)
 	go runFn(t.Context())
 	time.Sleep(50 * time.Millisecond)

--- a/pkg/appolly/discover/matcher_test.go
+++ b/pkg/appolly/discover/matcher_test.go
@@ -442,6 +442,48 @@ func TestCriteriaMatcherMissingPort(t *testing.T) {
 	require.Len(t, matches, 2)
 	testMatch(t, matches[0], "port-only", "foo", services.ProcessInfo{Pid: 1, ExePath: "/bin/weird33", OpenPorts: []uint32{80}, PPid: 0})
 	testMatch(t, matches[1], "port-only", "foo", services.ProcessInfo{Pid: 3, ExePath: "/bin/weird33", OpenPorts: []uint32{}, PPid: 1})
+	assert.Zero(t, matches[0].Obj.DynamicSelectorPID)
+	assert.Zero(t, matches[1].Obj.DynamicSelectorPID)
+}
+
+func TestDynamicMatcher_ChildInheritsDynamicSelectorPID(t *testing.T) {
+	dynamicSelector := NewDynamicPIDSelector()
+	dynamicSelector.AddPIDs(100)
+
+	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+	filteredProcesses := filteredProcessesQu.Subscribe()
+	processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
+		proc := map[app.PID]struct {
+			Exe  string
+			PPid app.PID
+		}{
+			100: {Exe: "/bin/parent", PPid: 0},
+			101: {Exe: "/bin/child", PPid: 100},
+		}[pp.pid]
+		return &services.ProcessInfo{Pid: pp.pid, ExePath: proc.Exe, PPid: proc.PPid, OpenPorts: pp.openPorts}, nil
+	}
+	runFn, err := dynamicMatcherProvider(discoveredProcesses, filteredProcessesQu, dynamicSelector.appSignals())(t.Context())
+	require.NoError(t, err)
+	go runFn(t.Context())
+	time.Sleep(50 * time.Millisecond)
+	defer filteredProcessesQu.Close()
+
+	discoveredProcesses.Send([]Event[ProcessAttrs]{
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 100}},
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 101}},
+	})
+	matches := testutil.ReadChannel(t, filteredProcesses, testTimeout)
+	require.Len(t, matches, 2)
+
+	assert.Equal(t, app.PID(100), matches[0].Obj.Process.Pid)
+	assert.Equal(t, app.PID(100), matches[0].Obj.DynamicSelectorPID)
+
+	assert.Equal(t, app.PID(101), matches[1].Obj.Process.Pid)
+	assert.Equal(t, app.PID(100), matches[1].Obj.DynamicSelectorPID)
+
+	discoveredProcesses.Close()
+	testutil.DrainUntilClosed(filteredProcesses)
 }
 
 func TestCriteriaMatcherContainersOnly(t *testing.T) {

--- a/pkg/appolly/discover/typer.go
+++ b/pkg/appolly/discover/typer.go
@@ -144,6 +144,7 @@ func (t *typer) makeServiceAttrs(processMatch *ProcessMatch) svc.Attrs {
 			Namespace: namespace,
 		},
 		ProcPID:            processMatch.Process.Pid,
+		DynamicSelectorPID: processMatch.DynamicSelectorPID,
 		ExportModes:        exportModes,
 		Sampler:            samplerFromConfig(samplerConfig),
 		PathTrie:           clusterurl.NewPathTrie(routesCfg.MaxPathSegmentCardinality, wildcard),

--- a/pkg/netolly/agent/pipeline.go
+++ b/pkg/netolly/agent/pipeline.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/netolly/flowdef"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+	"go.opentelemetry.io/obi/pkg/selection"
 )
 
 func recordAttrs(r *ebpf.Record) *pipe.CommonAttrs { return &r.CommonAttrs }
@@ -109,7 +110,11 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 	}, swarm.WithID("FlowDecorator"))
 
 	dynamicFilteredFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "dynamicFilteredFlows")
-	swi.Add(filter.ByDynamicPID(f.ctxInfo.DynamicPIDSelector, f.ctxInfo.K8sInformer,
+	var dynamicSelector selection.PIDSelector
+	if f.ctxInfo.DynamicPIDSelector != nil {
+		dynamicSelector = f.ctxInfo.DynamicPIDSelector.NetworkMetrics()
+	}
+	swi.Add(filter.ByDynamicPID(dynamicSelector, f.ctxInfo.K8sInformer,
 		recordAttrs, decoratedFlows, dynamicFilteredFlows),
 		swarm.WithID("DynamicPIDFilter"))
 

--- a/pkg/statsolly/agent/pipeline.go
+++ b/pkg/statsolly/agent/pipeline.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/internal/statsolly/export"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+	"go.opentelemetry.io/obi/pkg/selection"
 )
 
 func statAttrs(s *ebpf.Stat) *pipe.CommonAttrs { return &s.CommonAttrs }
@@ -71,7 +72,11 @@ func (s *Stats) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 		swarm.WithID("StatsDecorator"))
 
 	dynamicFilteredStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "dynamicFilteredStats")
-	swi.Add(filter.ByDynamicPID(s.ctxInfo.DynamicPIDSelector, s.ctxInfo.K8sInformer,
+	var dynamicSelector selection.PIDSelector
+	if s.ctxInfo.DynamicPIDSelector != nil {
+		dynamicSelector = s.ctxInfo.DynamicPIDSelector.StatsMetrics()
+	}
+	swi.Add(filter.ByDynamicPID(dynamicSelector, s.ctxInfo.K8sInformer,
 		statAttrs, decoratedStats, dynamicFilteredStats),
 		swarm.WithID("DynamicPIDFilter"))
 


### PR DESCRIPTION
This implements phase 3 of https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2234

Previous PRs:
1. https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2250
2. https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2279
3. https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2340

This PR wires up the actual per-signal ownership for AppO11y, Network, and Stats Metrics. AppO11y still uses a union view for app traces+metrics (will be split in the next PR). Dynamic/Parent pid tracking is added for `appolly/app/svc/svc.go` and `discover/matcher.go` with the `DynamicSelectorPID` field.

## Summary

Describe the change briefly.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
