### PR TITLE
Propagate route harvest cancellation

### DIFF
--- a/pkg/internal/transform/route/harvest/harvester.go
+++ b/pkg/internal/transform/route/harvest/harvester.go
@@ -5,6 +5,7 @@ package harvest // import "go.opentelemetry.io/obi/pkg/internal/transform/route/
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -28,7 +29,7 @@ type RouteHarvester struct {
 	mux      *sync.Mutex
 
 	// testing related
-	javaExtractRoutes func(fileInfo *exec.FileInfo) (*RouteHarvesterResult, error)
+	javaExtractRoutes func(ctx context.Context, fileInfo *exec.FileInfo) (*RouteHarvesterResult, error)
 	nodeExtractRoutes func(pid app.PID) (*RouteHarvesterResult, error)
 }
 
@@ -108,7 +109,7 @@ func (h *RouteHarvester) HarvestRoutes(fileInfo *exec.FileInfo) (*RouteHarvester
 		switch fileInfo.SDKLanguage() {
 		case svc.InstrumentableJava:
 			if _, ok := h.disabled[svc.InstrumentableJava]; !ok {
-				r, err := h.javaExtractRoutes(fileInfo)
+				r, err := h.javaExtractRoutes(ctx, fileInfo)
 				if err != nil {
 					resultChan <- result{err: err}
 					return
@@ -138,6 +139,10 @@ func (h *RouteHarvester) HarvestRoutes(fileInfo *exec.FileInfo) (*RouteHarvester
 	// Wait for either completion or timeout
 	select {
 	case result := <-resultChan:
+		if errors.Is(result.err, context.DeadlineExceeded) {
+			h.log.Warn("route harvesting timed out", "timeout", h.timeout, "pid", fileInfo.Pid())
+			return nil, &HarvestError{Message: "route harvesting timed out"}
+		}
 		return result.r, result.err
 	case <-ctx.Done():
 		h.log.Warn("route harvesting timed out", "timeout", h.timeout, "pid", fileInfo.Pid())

--- a/pkg/internal/transform/route/harvest/harvester_test.go
+++ b/pkg/internal/transform/route/harvest/harvester_test.go
@@ -4,6 +4,7 @@
 package harvest
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -21,7 +22,7 @@ import (
 )
 
 // successfulExtractRoutes simulates a successful route extraction
-func successfulExtractRoutes(app.PID) (*RouteHarvesterResult, error) {
+func successfulExtractRoutes(context.Context, app.PID) (*RouteHarvesterResult, error) {
 	return &RouteHarvesterResult{
 		Routes: []string{"/api/users", "/api/orders"},
 		Kind:   CompleteRoutes,
@@ -29,28 +30,28 @@ func successfulExtractRoutes(app.PID) (*RouteHarvesterResult, error) {
 }
 
 // errorExtractRoutes simulates an error during route extraction
-func errorExtractRoutes(app.PID) (*RouteHarvesterResult, error) {
+func errorExtractRoutes(context.Context, app.PID) (*RouteHarvesterResult, error) {
 	return nil, errors.New("failed to connect to Java process")
 }
 
 // timeoutExtractRoutes simulates a slow operation that will timeout
-func timeoutExtractRoutes(app.PID) (*RouteHarvesterResult, error) {
-	// Sleep longer than any reasonable timeout
-	time.Sleep(5 * time.Second)
-	return &RouteHarvesterResult{
-		Routes: []string{"/api/delayed"},
-		Kind:   CompleteRoutes,
-	}, nil
+func timeoutExtractRoutes(ctx context.Context, _ app.PID) (*RouteHarvesterResult, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
 }
 
 // panicExtractRoutes simulates a panic during route extraction
-func panicExtractRoutes(app.PID) (*RouteHarvesterResult, error) {
+func panicExtractRoutes(context.Context, app.PID) (*RouteHarvesterResult, error) {
 	panic("unexpected error in java route extraction")
 }
 
 // slowButSuccessfulExtractRoutes simulates a slow but successful operation
-func slowButSuccessfulExtractRoutes(app.PID) (*RouteHarvesterResult, error) {
-	time.Sleep(50 * time.Millisecond) // Slow but within timeout
+func slowButSuccessfulExtractRoutes(ctx context.Context, _ app.PID) (*RouteHarvesterResult, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(50 * time.Millisecond): // Slow but within timeout
+	}
 	return &RouteHarvesterResult{
 		Routes: []string{"/api/slow"},
 		Kind:   PartialRoutes,
@@ -58,17 +59,25 @@ func slowButSuccessfulExtractRoutes(app.PID) (*RouteHarvesterResult, error) {
 }
 
 // emptyResultExtractRoutes simulates successful extraction with no routes
-func emptyResultExtractRoutes(app.PID) (*RouteHarvesterResult, error) {
+func emptyResultExtractRoutes(context.Context, app.PID) (*RouteHarvesterResult, error) {
 	return &RouteHarvesterResult{
 		Routes: []string{},
 		Kind:   CompleteRoutes,
 	}, nil
 }
 
-func javaExtract(fn func(app.PID) (*RouteHarvesterResult, error)) func(*exec.FileInfo) (*RouteHarvesterResult, error) {
-	return func(fileInfo *exec.FileInfo) (*RouteHarvesterResult, error) {
-		return fn(fileInfo.Pid())
+func javaExtract(fn func(context.Context, app.PID) (*RouteHarvesterResult, error)) func(context.Context, *exec.FileInfo) (*RouteHarvesterResult, error) {
+	return func(ctx context.Context, fileInfo *exec.FileInfo) (*RouteHarvesterResult, error) {
+		return fn(ctx, fileInfo.Pid())
 	}
+}
+
+func successfulNodeExtractRoutes(pid app.PID) (*RouteHarvesterResult, error) {
+	return successfulExtractRoutes(context.Background(), pid)
+}
+
+func errorNodeExtractRoutes(pid app.PID) (*RouteHarvesterResult, error) {
+	return errorExtractRoutes(context.Background(), pid)
 }
 
 func createTestFileInfo(language svc.InstrumentableType) *exec.FileInfo {
@@ -130,6 +139,24 @@ func TestHarvestRoutes_Timeout(t *testing.T) {
 	assert.Greater(t, elapsed, 90*time.Millisecond)
 }
 
+func TestHarvestRoutes_ContextDeadlineResultReturnsTimeout(t *testing.T) {
+	harvester := NewRouteHarvester(&services.RouteHarvestingConfig{}, []services.RouteHarvesterLanguage{}, 1*time.Second)
+	harvester.javaExtractRoutes = func(context.Context, *exec.FileInfo) (*RouteHarvesterResult, error) {
+		return nil, context.DeadlineExceeded
+	}
+
+	fileInfo := createTestFileInfo(svc.InstrumentableJava)
+
+	result, err := harvester.HarvestRoutes(fileInfo)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+
+	var harvestErr *HarvestError
+	require.ErrorAs(t, err, &harvestErr)
+	assert.Equal(t, "route harvesting timed out", harvestErr.Message)
+}
+
 func TestHarvestRoutes_Panic(t *testing.T) {
 	harvester := NewRouteHarvester(&services.RouteHarvestingConfig{}, []services.RouteHarvesterLanguage{}, 1*time.Second)
 	harvester.javaExtractRoutes = javaExtract(panicExtractRoutes)
@@ -178,7 +205,7 @@ func TestHarvestRoutes_EmptyResult(t *testing.T) {
 func TestHarvestRoutes_NonJavaLanguage(t *testing.T) {
 	harvester := NewRouteHarvester(&services.RouteHarvestingConfig{}, []services.RouteHarvesterLanguage{}, 1*time.Second)
 	// javaExtractRoutes should not be called for non-Java languages
-	harvester.javaExtractRoutes = func(_ *exec.FileInfo) (*RouteHarvesterResult, error) {
+	harvester.javaExtractRoutes = func(context.Context, *exec.FileInfo) (*RouteHarvesterResult, error) {
 		t.Fatal("javaExtractRoutes should not be called for non-Java languages")
 		return nil, nil
 	}
@@ -193,7 +220,14 @@ func TestHarvestRoutes_NonJavaLanguage(t *testing.T) {
 
 func TestHarvestRoutes_MultipleTimeouts(t *testing.T) {
 	harvester := NewRouteHarvester(&services.RouteHarvestingConfig{}, []services.RouteHarvesterLanguage{}, 50*time.Millisecond)
-	harvester.javaExtractRoutes = javaExtract(timeoutExtractRoutes)
+
+	exited := make(chan struct{}, 3)
+	harvester.javaExtractRoutes = func(ctx context.Context, fileInfo *exec.FileInfo) (*RouteHarvesterResult, error) {
+		defer func() {
+			exited <- struct{}{}
+		}()
+		return timeoutExtractRoutes(ctx, fileInfo.Pid())
+	}
 
 	fileInfo := createTestFileInfo(svc.InstrumentableJava)
 
@@ -208,11 +242,15 @@ func TestHarvestRoutes_MultipleTimeouts(t *testing.T) {
 		require.ErrorAs(t, err, &harvestErr, "iteration %d should return HarvestError", i)
 		assert.Equal(t, "route harvesting timed out", harvestErr.Message, "iteration %d should have timeout message", i)
 	}
+
+	require.Eventually(t, func() bool {
+		return len(exited) == 3
+	}, time.Second, time.Millisecond)
 }
 
 func TestHarvestNodejsRoutes_Successful(t *testing.T) {
 	harvester := NewRouteHarvester(&services.RouteHarvestingConfig{}, []services.RouteHarvesterLanguage{}, 1*time.Second)
-	harvester.nodeExtractRoutes = successfulExtractRoutes
+	harvester.nodeExtractRoutes = successfulNodeExtractRoutes
 
 	fileInfo := createTestFileInfo(svc.InstrumentableNodejs)
 
@@ -226,7 +264,7 @@ func TestHarvestNodejsRoutes_Successful(t *testing.T) {
 
 func TestHarvestNodejsRoutes_Error(t *testing.T) {
 	harvester := NewRouteHarvester(&services.RouteHarvestingConfig{}, []services.RouteHarvesterLanguage{}, 1*time.Second)
-	harvester.nodeExtractRoutes = errorExtractRoutes
+	harvester.nodeExtractRoutes = errorNodeExtractRoutes
 
 	fileInfo := createTestFileInfo(svc.InstrumentableNodejs)
 

--- a/pkg/internal/transform/route/harvest/java.go
+++ b/pkg/internal/transform/route/harvest/java.go
@@ -6,6 +6,7 @@
 package harvest // import "go.opentelemetry.io/obi/pkg/internal/transform/route/harvest"
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 
@@ -23,8 +24,8 @@ func NewJavaRoutesHarvester() *JavaRoutes {
 	}
 }
 
-func (h *JavaRoutes) ExtractRoutes(fileInfo *exec.FileInfo) (*RouteHarvesterResult, error) {
-	routes, err := javaharvest.ExtractRoutes(fileInfo)
+func (h *JavaRoutes) ExtractRoutes(ctx context.Context, fileInfo *exec.FileInfo) (*RouteHarvesterResult, error) {
+	routes, err := javaharvest.ExtractRoutes(ctx, fileInfo)
 	if err != nil {
 		return nil, fmt.Errorf("extracting Java routes from class files: %w", err)
 	}

--- a/pkg/internal/transform/route/harvest/java/archive.go
+++ b/pkg/internal/transform/route/harvest/java/archive.go
@@ -5,6 +5,7 @@ package java // import "go.opentelemetry.io/obi/pkg/internal/transform/route/har
 
 import (
 	"archive/zip"
+	"context"
 	"errors"
 	"io"
 	"os"
@@ -12,8 +13,11 @@ import (
 	"strings"
 )
 
-func (e *Extractor) scanDir(root string) {
+func (e *Extractor) scanDir(ctx context.Context, root string) error {
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err != nil {
 			e.log.Debug("error walking Java classpath directory", "path", path, "error", err)
 			return nil
@@ -25,49 +29,70 @@ func (e *Extractor) scanDir(root string) {
 			return filepath.SkipAll
 		}
 		if strings.EqualFold(filepath.Ext(path), ".class") {
-			e.scanClassFile(path)
+			if err := e.scanClassFile(ctx, path); err != nil {
+				return err
+			}
 		}
 		return nil
 	})
 	if err != nil && !errors.Is(err, filepath.SkipAll) {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
 		e.log.Debug("error scanning Java classpath directory", "path", root, "error", err)
 	}
+	return nil
 }
 
-func (e *Extractor) scanClassFile(path string) {
+func (e *Extractor) scanClassFile(ctx context.Context, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		e.log.Debug("error stating Java class file", "path", path, "error", err)
-		return
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if info.Size() > MaxJavaClassScanBytes {
 		e.log.Info("java class file scan limit reached", "path", path, "size", info.Size(), "limit", MaxJavaClassScanBytes)
-		return
+		return nil
 	}
 
 	data, err := os.ReadFile(path)
 	if err != nil {
 		e.log.Debug("error reading Java class file", "path", path, "error", err)
-		return
+		return nil
 	}
-	e.scanClassBytes(path, data)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return e.scanClassBytes(ctx, path, data)
 }
 
-func (e *Extractor) scanArchive(path string) {
+func (e *Extractor) scanArchive(ctx context.Context, path string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		e.log.Debug("error stating Java archive", "path", path, "error", err)
-		return
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if info.Size() > MaxJavaArchiveScanBytes {
 		e.log.Info("java archive scan limit reached", "path", path, "size", info.Size(), "limit", MaxJavaArchiveScanBytes)
-		return
+		return nil
 	}
 
 	reader, err := zip.OpenReader(path)
 	if err != nil {
 		e.log.Debug("error opening Java archive", "path", path, "error", err)
-		return
+		return nil
 	}
 	defer func() {
 		if err := reader.Close(); err != nil {
@@ -76,8 +101,11 @@ func (e *Extractor) scanArchive(path string) {
 	}()
 
 	for _, file := range reader.File {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if e.classLimitReached() || e.routeLimitReached() {
-			return
+			return nil
 		}
 		if !scanArchiveClassEntry(file.Name) {
 			continue
@@ -86,8 +114,11 @@ func (e *Extractor) scanArchive(path string) {
 			e.log.Info("java class file scan limit reached", "path", file.Name, "size", file.UncompressedSize64, "limit", MaxJavaClassScanBytes)
 			continue
 		}
-		e.scanZipClass(path, file)
+		if err := e.scanZipClass(ctx, path, file); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 func scanArchiveClassEntry(name string) bool {
@@ -104,11 +135,14 @@ func scanArchiveClassEntry(name string) bool {
 	return true
 }
 
-func (e *Extractor) scanZipClass(archivePath string, file *zip.File) {
+func (e *Extractor) scanZipClass(ctx context.Context, archivePath string, file *zip.File) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	reader, err := file.Open()
 	if err != nil {
 		e.log.Debug("error opening Java class entry", "archive", archivePath, "path", file.Name, "error", err)
-		return
+		return nil
 	}
 	defer func() {
 		if err := reader.Close(); err != nil {
@@ -119,22 +153,32 @@ func (e *Extractor) scanZipClass(archivePath string, file *zip.File) {
 	data, err := io.ReadAll(io.LimitReader(reader, MaxJavaClassScanBytes+1))
 	if err != nil {
 		e.log.Debug("error reading Java class entry", "archive", archivePath, "path", file.Name, "error", err)
-		return
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if int64(len(data)) > MaxJavaClassScanBytes {
 		e.log.Info("java class file scan limit reached", "path", file.Name, "size", len(data), "limit", MaxJavaClassScanBytes)
-		return
+		return nil
 	}
-	e.scanClassBytes(archivePath+":"+file.Name, data)
+	return e.scanClassBytes(ctx, archivePath+":"+file.Name, data)
 }
 
-func (e *Extractor) scanClassBytes(name string, data []byte) {
+func (e *Extractor) scanClassBytes(ctx context.Context, name string, data []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	e.classesScanned++
 
 	class, err := parseClassFile(data)
 	if err != nil {
 		e.log.Debug("error parsing Java class file", "path", name, "error", err)
-		return
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	e.addRoutes(routesFromClass(class))
+	return nil
 }

--- a/pkg/internal/transform/route/harvest/java/archive_test.go
+++ b/pkg/internal/transform/route/harvest/java/archive_test.go
@@ -5,6 +5,7 @@ package java
 
 import (
 	"archive/zip"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,7 +84,7 @@ func TestScanDir(t *testing.T) {
 	writeClassFixture(t, filepath.Join(root, "com", "example", "ignored.txt"), "com/example/JaxController.class")
 
 	extractor := NewExtractor()
-	extractor.scanDir(root)
+	require.NoError(t, extractor.scanDir(context.Background(), root))
 
 	assert.ElementsMatch(t, springControllerRoutes, mapKeys(extractor.routes))
 	assert.Equal(t, 1, extractor.classesScanned)
@@ -94,8 +95,20 @@ func TestScanDirSkipsOversizedClassFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(root, "Large.class"), make([]byte, MaxJavaClassScanBytes+1), 0o644))
 
 	extractor := NewExtractor()
-	extractor.scanDir(root)
+	require.NoError(t, extractor.scanDir(context.Background(), root))
 
+	assert.Empty(t, extractor.routes)
+	assert.Zero(t, extractor.classesScanned)
+}
+
+func TestScanDirReturnsContextErrorWhenCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	extractor := NewExtractor()
+	err := extractor.scanDir(ctx, t.TempDir())
+
+	require.ErrorIs(t, err, context.Canceled)
 	assert.Empty(t, extractor.routes)
 	assert.Zero(t, extractor.classesScanned)
 }
@@ -110,7 +123,7 @@ func TestScanArchive(t *testing.T) {
 	})
 
 	extractor := NewExtractor()
-	extractor.scanArchive(path)
+	require.NoError(t, extractor.scanArchive(context.Background(), path))
 
 	assert.ElementsMatch(t, springControllerRoutes, mapKeys(extractor.routes))
 	assert.Equal(t, 1, extractor.classesScanned)
@@ -123,8 +136,25 @@ func TestScanArchiveSkipsOversizedClassEntries(t *testing.T) {
 	})
 
 	extractor := NewExtractor()
-	extractor.scanArchive(path)
+	require.NoError(t, extractor.scanArchive(context.Background(), path))
 
+	assert.Empty(t, extractor.routes)
+	assert.Zero(t, extractor.classesScanned)
+}
+
+func TestScanArchiveReturnsContextErrorWhenCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	path := filepath.Join(t.TempDir(), "app.jar")
+	writeZip(t, path, []zipEntry{
+		{name: "com/example/SpringController.class", data: classFixture(t, "com/example/SpringController.class")},
+	})
+
+	extractor := NewExtractor()
+	err := extractor.scanArchive(ctx, path)
+
+	require.ErrorIs(t, err, context.Canceled)
 	assert.Empty(t, extractor.routes)
 	assert.Zero(t, extractor.classesScanned)
 }

--- a/pkg/internal/transform/route/harvest/java/extractor.go
+++ b/pkg/internal/transform/route/harvest/java/extractor.go
@@ -5,6 +5,7 @@
 package java // import "go.opentelemetry.io/obi/pkg/internal/transform/route/harvest/java"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -31,8 +32,8 @@ type Extractor struct {
 	routeLimitLogged bool
 }
 
-func ExtractRoutes(fileInfo *exec.FileInfo) ([]string, error) {
-	return NewExtractor().ExtractRoutes(fileInfo)
+func ExtractRoutes(ctx context.Context, fileInfo *exec.FileInfo) ([]string, error) {
+	return NewExtractor().ExtractRoutes(ctx, fileInfo)
 }
 
 func NewExtractor() *Extractor {
@@ -42,7 +43,10 @@ func NewExtractor() *Extractor {
 	}
 }
 
-func (e *Extractor) ExtractRoutes(fileInfo *exec.FileInfo) ([]string, error) {
+func (e *Extractor) ExtractRoutes(ctx context.Context, fileInfo *exec.FileInfo) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if fileInfo == nil {
 		return nil, errors.New("java route harvesting requires process file info")
 	}
@@ -56,14 +60,21 @@ func (e *Extractor) ExtractRoutes(fileInfo *exec.FileInfo) ([]string, error) {
 	}
 
 	for _, root := range roots {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if e.routeLimitReached() || e.classLimitReached() {
 			break
 		}
 		if root.dir {
-			e.scanDir(root.path)
+			if err := e.scanDir(ctx, root.path); err != nil {
+				return nil, err
+			}
 			continue
 		}
-		e.scanArchive(root.path)
+		if err := e.scanArchive(ctx, root.path); err != nil {
+			return nil, err
+		}
 	}
 
 	return sortRoutes(mapKeys(e.routes)), nil

--- a/pkg/internal/transform/route/harvest/java/extractor_test.go
+++ b/pkg/internal/transform/route/harvest/java/extractor_test.go
@@ -4,6 +4,7 @@
 package java
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +43,7 @@ var expectedRoutes = []string{
 func TestExtractRoutesFromSpringBootJar(t *testing.T) {
 	fileInfo := javaFileInfo(t, []string{"-jar", "/spring-boot-app.jar"}, nil)
 
-	routes, err := ExtractRoutes(fileInfo)
+	routes, err := ExtractRoutes(context.Background(), fileInfo)
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expectedRoutes, routes)
@@ -55,7 +56,7 @@ func TestExtractRoutesFromSpringBootJar(t *testing.T) {
 func TestExtractRoutesFromWarClasses(t *testing.T) {
 	fileInfo := javaFileInfo(t, []string{"-jar", "/war-app.jar"}, nil)
 
-	routes, err := ExtractRoutes(fileInfo)
+	routes, err := ExtractRoutes(context.Background(), fileInfo)
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expectedRoutes, routes)
@@ -66,7 +67,7 @@ func TestExtractRoutesFromExplicitClasspathDirectory(t *testing.T) {
 		envClasspath: "/does-not-exist",
 	})
 
-	routes, err := ExtractRoutes(fileInfo)
+	routes, err := ExtractRoutes(context.Background(), fileInfo)
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expectedRoutes, routes)
@@ -77,7 +78,7 @@ func TestExtractRoutesFromEnvClasspath(t *testing.T) {
 		envClasspath: "/classes",
 	})
 
-	routes, err := ExtractRoutes(fileInfo)
+	routes, err := ExtractRoutes(context.Background(), fileInfo)
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expectedRoutes, routes)
@@ -86,7 +87,7 @@ func TestExtractRoutesFromEnvClasspath(t *testing.T) {
 func TestExtractRoutesFromSingleClasspathJar(t *testing.T) {
 	fileInfo := javaFileInfo(t, []string{"-cp", "/regular-app.jar", "com.example.Main"}, nil)
 
-	routes, err := ExtractRoutes(fileInfo)
+	routes, err := ExtractRoutes(context.Background(), fileInfo)
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expectedRoutes, routes)
@@ -95,7 +96,7 @@ func TestExtractRoutesFromSingleClasspathJar(t *testing.T) {
 func TestExtractRoutesFromMultipleClasspathJars(t *testing.T) {
 	fileInfo := javaFileInfo(t, []string{"-cp", "/regular-app.jar:/spring-boot-app.jar", "com.example.Main"}, nil)
 
-	routes, err := ExtractRoutes(fileInfo)
+	routes, err := ExtractRoutes(context.Background(), fileInfo)
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expectedRoutes, routes)
@@ -104,10 +105,20 @@ func TestExtractRoutesFromMultipleClasspathJars(t *testing.T) {
 func TestExtractRoutesFromWildcardClasspathJars(t *testing.T) {
 	fileInfo := javaFileInfo(t, []string{"-cp", "/*", "com.example.Main"}, nil)
 
-	routes, err := ExtractRoutes(fileInfo)
+	routes, err := ExtractRoutes(context.Background(), fileInfo)
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, expectedRoutes, routes)
+}
+
+func TestExtractRoutesReturnsContextErrorWhenCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	routes, err := ExtractRoutes(ctx, javaFileInfo(t, []string{"-jar", "/spring-boot-app.jar"}, nil))
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, routes)
 }
 
 func TestSortRoutesPrefersStaticRoutesBeforeWildcardRoutes(t *testing.T) {

--- a/pkg/internal/transform/route/harvest/java_notlinux.go
+++ b/pkg/internal/transform/route/harvest/java_notlinux.go
@@ -5,7 +5,11 @@
 
 package harvest // import "go.opentelemetry.io/obi/pkg/internal/transform/route/harvest"
 
-import "go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+import (
+	"context"
+
+	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+)
 
 type JavaRoutes struct{}
 
@@ -13,6 +17,6 @@ func NewJavaRoutesHarvester() *JavaRoutes {
 	return &JavaRoutes{}
 }
 
-func (h *JavaRoutes) ExtractRoutes(_ *exec.FileInfo) (*RouteHarvesterResult, error) {
+func (h *JavaRoutes) ExtractRoutes(_ context.Context, _ *exec.FileInfo) (*RouteHarvesterResult, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

- Thread the route harvest timeout context into Java route extraction.
- Use the context-aware JVM attach path for Java route harvesting.
- Close the route output reader when the harvest context is canceled so blocked reads can unwind.
- Add tests for repeated Java harvest timeouts and canceled blocked route output reads.

## Why

This completes the route-harvester integration step for #2034 after the internal JVM attach path gained context support. Previously, the harvester could return on timeout while the Java extraction worker continued blocked in the background. Passing the timeout context through attach and output reading gives the worker a cancellation path instead of accumulating retained workers across repeated timeouts.

Fixes #2034.

## Validation

- `make generate`
- `go test ./pkg/internal/transform/route/harvest`
- `go test ./pkg/internal/jvmtools/...`
- `GOOS=darwin go test -c -o /tmp/harvest-darwin.test ./pkg/internal/transform/route/harvest`
- `go test ./pkg/internal/transform/route/...`