### PR TITLE
Queue metrics

### DIFF
--- a/pkg/export/imetrics/imetrics.go
+++ b/pkg/export/imetrics/imetrics.go
@@ -99,6 +99,9 @@ type Reporter interface {
 	// BPFPacketStats sets the counters of how many packets have been internally accounted vs how many packets
 	// have been ignored due to internal BPF map collisions
 	BPFPacketStats(count, ignored uint64)
+	// QueueBufferUtilization shows the ratio [0-1] between the unread messages of an internal Go channel
+	// and its total capacity
+	QueueBufferUtilization(subscriber string, ratio float64)
 }
 
 func IsBuiltinNoopReporter(reporter Reporter) bool {
@@ -135,3 +138,4 @@ func (n NoopReporter) BpfMapMaxEntries(_, _, _ string, _ int)            {}
 func (n NoopReporter) BpfInternalMetricsScrapeInterval() time.Duration   { return 0 }
 func (n NoopReporter) InformerLag(_ float64)                             {}
 func (n NoopReporter) BPFPacketStats(_, _ uint64)                        {}
+func (n NoopReporter) QueueBufferUtilization(_ string, _ float64)        {}

--- a/pkg/export/imetrics/imetrics_test.go
+++ b/pkg/export/imetrics/imetrics_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsBuiltinNoopReporter(t *testing.T) {
@@ -32,6 +34,26 @@ func TestIsBuiltinNoopReporter(t *testing.T) {
 	t.Run("nil reporter", func(t *testing.T) {
 		assert.False(t, IsBuiltinNoopReporter(nil))
 	})
+}
+
+func TestPrometheusReporterQueueBufferUtilization(t *testing.T) {
+	reporter := NewPrometheusReporter(&InternalMetricsConfig{}, nil, prometheus.NewRegistry())
+
+	gaugeValue := func(subscriber string) float64 {
+		var m dto.Metric
+		require.NoError(t, reporter.queueCapacityRatio.WithLabelValues(subscriber).Write(&m))
+		return m.GetGauge().GetValue()
+	}
+
+	reporter.QueueBufferUtilization("traces", 0.42)
+	reporter.QueueBufferUtilization("metrics", 0.1)
+
+	assert.InDelta(t, 0.42, gaugeValue("traces"), 0.001)
+	assert.InDelta(t, 0.1, gaugeValue("metrics"), 0.001)
+
+	// a later update overwrites the previous value for the same subscriber
+	reporter.QueueBufferUtilization("traces", 0.9)
+	assert.InDelta(t, 0.9, gaugeValue("traces"), 0.001)
 }
 
 type noopEmbeddingReporter struct {

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -50,6 +50,8 @@ type PrometheusReporter struct {
 	totalIgnoredPackets   uint64
 	bpfPacketCount        prometheus.Counter
 	bpfIgnoredPacketCount prometheus.Counter
+
+	queueCapacityRatio *prometheus.GaugeVec
 }
 
 func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.PrometheusManager, registry *prometheus.Registry) *PrometheusReporter {
@@ -141,6 +143,10 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			Name: attr.VendorPrefix + "_bpf_network_packets_total",
 			Help: "How many network packets have been internally accounted",
 		}),
+		queueCapacityRatio: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: attr.VendorPrefix + "_queue_capacity_ratio",
+			Help: "Ratio [0-1] between the unread messages of an internal Go channel and its total capacity",
+		}, []string{"subscriber"}),
 	}
 	metrics := []prometheus.Collector{
 		pr.tracerFlushes,
@@ -160,6 +166,7 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 		pr.informerLag,
 		pr.bpfPacketCount,
 		pr.bpfIgnoredPacketCount,
+		pr.queueCapacityRatio,
 	}
 	if registry != nil {
 		registry.MustRegister(metrics...)
@@ -250,4 +257,8 @@ func (p *PrometheusReporter) BPFPacketStats(count, ignored uint64) {
 	p.bpfPacketCount.Add(float64(count - p.totalPackets))
 	p.bpfIgnoredPacketCount.Add(float64(ignored - p.totalIgnoredPackets))
 	p.totalPackets, p.totalIgnoredPackets = count, ignored
+}
+
+func (p *PrometheusReporter) QueueBufferUtilization(subscriber string, ratio float64) {
+	p.queueCapacityRatio.WithLabelValues(subscriber).Set(ratio)
 }

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -48,6 +48,8 @@ type InternalMetricsReporter struct {
 	totalIgnoredPackets   uint64
 	bpfPacketCount        instrument.Int64Counter
 	bpfIgnoredPacketCount instrument.Int64Counter
+
+	queueCapacityRatio instrument.Float64Gauge
 }
 
 func imlog() *slog.Logger {
@@ -201,6 +203,13 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		return nil, err
 	}
 
+	queueCapacityRatio, err := meter.Float64Gauge(
+		attr.VendorPrefix+".queue.capacity.ratio",
+		instrument.WithUnit("Ratio [0-1] between the unread messages of an internal Go channel and its total capacity"))
+	if err != nil {
+		return nil, err
+	}
+
 	return &InternalMetricsReporter{
 		ctx:                              ctx,
 		tracerFlushes:                    tracerFlushes,
@@ -220,6 +229,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		informerLag:                      informerLag,
 		bpfPacketCount:                   bpfPacketCount,
 		bpfIgnoredPacketCount:            bpfIgnoredPacketCount,
+		queueCapacityRatio:               queueCapacityRatio,
 	}, nil
 }
 
@@ -351,4 +361,8 @@ func (p *InternalMetricsReporter) BPFPacketStats(count, ignored uint64) {
 	p.bpfPacketCount.Add(p.ctx, int64(count-p.totalPackets))
 	p.bpfIgnoredPacketCount.Add(p.ctx, int64(ignored-p.totalIgnoredPackets))
 	p.totalPackets, p.totalIgnoredPackets = count, ignored
+}
+
+func (p *InternalMetricsReporter) QueueBufferUtilization(subscriber string, ratio float64) {
+	p.queueCapacityRatio.Record(p.ctx, ratio, instrument.WithAttributes(attribute.String("subscriber", subscriber)))
 }

--- a/pkg/export/otel/metrics_internal_test.go
+++ b/pkg/export/otel/metrics_internal_test.go
@@ -71,3 +71,32 @@ func TestInternalMetricsReporterBpfProbeStats(t *testing.T) {
 
 	assert.Empty(t, expected)
 }
+
+func TestInternalMetricsReporterQueueBufferUtilization(t *testing.T) {
+	metricRecords := make(chan collector.MetricRecord, 16)
+	mcfg := &otelcfg.MetricsConfig{
+		Interval:        10 * time.Millisecond,
+		MetricsConsumer: testMetricsConsumer(metricRecords),
+	}
+	ctxInfo := &global.ContextInfo{
+		NodeMeta:            meta.NodeMeta{HostID: "test-host"},
+		OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg},
+	}
+
+	reporter, err := NewInternalMetricsReporter(
+		t.Context(),
+		ctxInfo,
+		mcfg,
+		&imetrics.InternalMetricsConfig{BpfMetricScrapeInterval: time.Millisecond},
+	)
+	require.NoError(t, err)
+
+	reporter.QueueBufferUtilization("traces", 0.42)
+
+	records := readMetricsByName(t, metricRecords, time.Second,
+		attr.VendorPrefix+".queue.capacity.ratio",
+	)
+	require.Len(t, records, 1)
+	assert.Equal(t, "traces", records[0].Attributes["subscriber"])
+	assert.InDelta(t, 0.42, records[0].FloatVal, 0.001)
+}

--- a/pkg/pipe/msg/queue.go
+++ b/pkg/pipe/msg/queue.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
 )
 
 // if a Send operation takes more than this time, we panic informing about a deadlock
@@ -32,7 +34,8 @@ type queueConfig struct {
 	name             string
 	sendTimeout      time.Duration
 	panicOnTimeout   bool
-	gaugeProvisioner gaugeProvisioner
+	// maps any implementation of imetrics.Reporter's QueueBufferUtilization(subscriber string, ratio float64)
+	utilizationGauge func(string, float64)
 }
 
 var defaultQueueConfig = queueConfig{
@@ -41,10 +44,9 @@ var defaultQueueConfig = queueConfig{
 	name:             unnamed,
 	sendTimeout:      defaultSendTimeout,
 	panicOnTimeout:   false,
-	gaugeProvisioner: noopGaugeProvisioner,
+	// default to noop
+	utilizationGauge: func(string, float64) {},
 }
-
-func noopGaugeProvisioner(string) gauge { return func(float64) {} }
 
 // QueueOpts allow configuring some operation of a queue
 type QueueOpts func(*queueConfig)
@@ -91,20 +93,16 @@ func ClosingAttempts(attempts int) QueueOpts {
 	}
 }
 
-func MetricProvisioner(p gaugeProvisioner) QueueOpts {
+func InternalMetrics(p imetrics.Reporter) QueueOpts {
 	return func(c *queueConfig) {
-		c.gaugeProvisioner = p
+		c.utilizationGauge = p.QueueBufferUtilization
 	}
 }
 
-type gauge func(float64)
-
-type gaugeProvisioner func(subscriberName string) gauge
-
 type dst[T any] struct {
-	name       string
-	ch         chan T
-	chCapRatio gauge
+	name  string
+	ch    chan T
+	gauge func(string, float64)
 }
 
 // sink holds the mutable, shared delivery state of a group of queues connected through Bypass.
@@ -159,7 +157,7 @@ func NewQueue[T any](opts ...QueueOpts) *Queue[T] {
 	}
 	// if channel capacity is set to zero, disable capacity ratio metrics to avoid divisions by zero
 	if cfg.channelBufferLen <= 0 {
-		cfg.gaugeProvisioner = noopGaugeProvisioner
+		cfg.utilizationGauge = func(string, float64) {}
 	}
 
 	q := &Queue[T]{
@@ -226,7 +224,7 @@ func (s *sink[T]) send(ctx context.Context, o T, route []string) {
 	var blocked []dst[T]
 	for _, d := range dsts {
 		// report channel len/capacity ratio metrics
-		d.chCapRatio(float64(len(d.ch)+1) / float64(cap(d.ch)))
+		d.gauge(d.name, float64(len(d.ch)+1)/float64(cap(d.ch)))
 		select {
 		case <-ctx.Done():
 			return
@@ -313,9 +311,9 @@ func (q *Queue[T]) Subscribe(options ...SubscribeOpt) <-chan T {
 	defer s.mt.Unlock()
 	ch := make(chan T, s.cfg.channelBufferLen)
 	s.dsts = append(s.dsts, dst[T]{
-		ch:         ch,
-		name:       opts.subscriber,
-		chCapRatio: q.cfg.gaugeProvisioner(opts.subscriber),
+		ch:    ch,
+		name:  opts.subscriber,
+		gauge: s.cfg.utilizationGauge,
 	})
 	return ch
 }
@@ -354,10 +352,6 @@ func (q *Queue[T]) Bypass(to *Queue[T]) {
 	for _, m := range srcSink.members {
 		m.sink = dstSink
 		m.routeNames = append(m.routeNames, to.routeNames...)
-	}
-	// rename all the source->dest attribute in the source sinks' metrics
-	for i := range srcSink.dsts {
-		srcSink.dsts[i].chCapRatio = q.cfg.gaugeProvisioner(srcSink.dsts[i].name)
 	}
 
 	// move all the subscribers of the source group into the destination group

--- a/pkg/pipe/msg/queue.go
+++ b/pkg/pipe/msg/queue.go
@@ -32,6 +32,7 @@ type queueConfig struct {
 	name             string
 	sendTimeout      time.Duration
 	panicOnTimeout   bool
+	gaugeProvisioner gaugeProvisioner
 }
 
 var defaultQueueConfig = queueConfig{
@@ -40,7 +41,10 @@ var defaultQueueConfig = queueConfig{
 	name:             unnamed,
 	sendTimeout:      defaultSendTimeout,
 	panicOnTimeout:   false,
+	gaugeProvisioner: noopGaugeProvisioner,
 }
+
+func noopGaugeProvisioner(string) gauge { return func(float64) {} }
 
 // QueueOpts allow configuring some operation of a queue
 type QueueOpts func(*queueConfig)
@@ -87,9 +91,20 @@ func ClosingAttempts(attempts int) QueueOpts {
 	}
 }
 
+func MetricProvisioner(p gaugeProvisioner) QueueOpts {
+	return func(c *queueConfig) {
+		c.gaugeProvisioner = p
+	}
+}
+
+type gauge func(float64)
+
+type gaugeProvisioner func(subscriberName string) gauge
+
 type dst[T any] struct {
-	name string
-	ch   chan T
+	name       string
+	ch         chan T
+	chCapRatio gauge
 }
 
 // sink holds the mutable, shared delivery state of a group of queues connected through Bypass.
@@ -142,6 +157,11 @@ func NewQueue[T any](opts ...QueueOpts) *Queue[T] {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+	// if channel capacity is set to zero, disable capacity ratio metrics to avoid divisions by zero
+	if cfg.channelBufferLen <= 0 {
+		cfg.gaugeProvisioner = noopGaugeProvisioner
+	}
+
 	q := &Queue[T]{
 		cfg:              &cfg,
 		routeNames:       []string{cfg.name},
@@ -205,6 +225,8 @@ func (s *sink[T]) send(ctx context.Context, o T, route []string) {
 	}
 	var blocked []dst[T]
 	for _, d := range dsts {
+		// report channel len/capacity ratio metrics
+		d.chCapRatio(float64(len(d.ch)+1) / float64(cap(d.ch)))
 		select {
 		case <-ctx.Done():
 			return
@@ -290,7 +312,11 @@ func (q *Queue[T]) Subscribe(options ...SubscribeOpt) <-chan T {
 	s.mt.Lock()
 	defer s.mt.Unlock()
 	ch := make(chan T, s.cfg.channelBufferLen)
-	s.dsts = append(s.dsts, dst[T]{ch: ch, name: opts.subscriber})
+	s.dsts = append(s.dsts, dst[T]{
+		ch:         ch,
+		name:       opts.subscriber,
+		chCapRatio: q.cfg.gaugeProvisioner(opts.subscriber),
+	})
 	return ch
 }
 
@@ -323,16 +349,21 @@ func (q *Queue[T]) Bypass(to *Queue[T]) {
 	dstSink.mt.Lock()
 	defer dstSink.mt.Unlock()
 
-	// move all the subscribers of the source group into the destination group
-	dstSink.dsts = append(dstSink.dsts, srcSink.dsts...)
-	srcSink.dsts = nil
-
 	// re-point every queue of the source group to the destination sink, so future Sends and
 	// Subscribes reach the destination directly, and extend their diagnostic route with to's route
 	for _, m := range srcSink.members {
 		m.sink = dstSink
 		m.routeNames = append(m.routeNames, to.routeNames...)
 	}
+	// rename all the source->dest attribute in the source sinks' metrics
+	for i := range srcSink.dsts {
+		srcSink.dsts[i].chCapRatio = q.cfg.gaugeProvisioner(srcSink.dsts[i].name)
+	}
+
+	// move all the subscribers of the source group into the destination group
+	dstSink.dsts = append(dstSink.dsts, srcSink.dsts...)
+	srcSink.dsts = nil
+
 	dstSink.members = append(dstSink.members, srcSink.members...)
 	srcSink.members = nil
 

--- a/pkg/pipe/msg/queue_test.go
+++ b/pkg/pipe/msg/queue_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/testutil"
 )
 
@@ -434,11 +435,11 @@ func TestSendPath(t *testing.T) {
 }
 
 func TestMetrics_CapacityGauge(t *testing.T) {
-	fp := &fakeProvisioner{gauges: map[string]*float64{}}
+	fp := &fakeProvisioner{gauges: map[string]float64{}}
 	q := NewQueue[int](
 		Name("head"),
 		ChannelBufferLen(100),
-		MetricProvisioner(fp.provide))
+		InternalMetrics(fp))
 
 	// Two subscribers: one that works normally and another that is blocked
 	working := q.Subscribe(SubscriberName("working"))
@@ -475,22 +476,22 @@ func TestMetrics_CapacityGauge(t *testing.T) {
 
 func TestMetrics_Labels(t *testing.T) {
 	t.Run("direct subscription", func(t *testing.T) {
-		fp := &fakeProvisioner{gauges: map[string]*float64{}}
+		fp := &fakeProvisioner{gauges: map[string]float64{}}
 		q := NewQueue[int](
 			Name("head"),
 			ChannelBufferLen(5),
-			MetricProvisioner(fp.provide))
+			InternalMetrics(fp))
 		q.Subscribe(SubscriberName("subs"))
 		q.SendCtx(t.Context(), 1)
 		assert.InDelta(t, 0.2, fp.GaugeFor("subs"), 0.001)
 	})
 	t.Run("bypasses subscription", func(t *testing.T) {
-		fp := &fakeProvisioner{gauges: map[string]*float64{}}
-		h1 := NewQueue[int](Name("head1"), ChannelBufferLen(5), MetricProvisioner(fp.provide))
-		h2 := NewQueue[int](Name("head2"), ChannelBufferLen(5), MetricProvisioner(fp.provide))
-		m1 := NewQueue[int](Name("mid1"), ChannelBufferLen(5), MetricProvisioner(fp.provide))
-		m2 := NewQueue[int](Name("mid2"), ChannelBufferLen(5), MetricProvisioner(fp.provide))
-		ta := NewQueue[int](Name("tail"), ChannelBufferLen(5), MetricProvisioner(fp.provide))
+		fp := &fakeProvisioner{gauges: map[string]float64{}}
+		h1 := NewQueue[int](Name("head1"), ChannelBufferLen(5), InternalMetrics(fp))
+		h2 := NewQueue[int](Name("head2"), ChannelBufferLen(5), InternalMetrics(fp))
+		m1 := NewQueue[int](Name("mid1"), ChannelBufferLen(5), InternalMetrics(fp))
+		m2 := NewQueue[int](Name("mid2"), ChannelBufferLen(5), InternalMetrics(fp))
+		ta := NewQueue[int](Name("tail"), ChannelBufferLen(5), InternalMetrics(fp))
 		// interleaving subscriptions and bypasses. All the gauges
 		// should be labeled as src="head", dst="subsX"
 		h1.Bypass(m1)
@@ -516,20 +517,19 @@ func TestMetrics_Labels(t *testing.T) {
 
 // implementation of fake gauge metrics for testing
 type fakeProvisioner struct {
-	gauges map[string]*float64
+	imetrics.NoopReporter
+	mt     sync.RWMutex
+	gauges map[string]float64
 }
 
 func (fp *fakeProvisioner) GaugeFor(subscriber string) float64 {
-	if v, ok := fp.gauges[subscriber]; ok {
-		return *v
-	}
-	return 0
+	fp.mt.RLock()
+	defer fp.mt.RUnlock()
+	return fp.gauges[subscriber]
 }
 
-func (fp *fakeProvisioner) provide(subscriber string) gauge {
-	value := float64(0)
-	fp.gauges[subscriber] = &value
-	return func(v float64) {
-		value = v
-	}
+func (fp *fakeProvisioner) QueueBufferUtilization(name string, val float64) {
+	fp.mt.Lock()
+	defer fp.mt.Unlock()
+	fp.gauges[name] = val
 }

--- a/pkg/pipe/msg/queue_test.go
+++ b/pkg/pipe/msg/queue_test.go
@@ -432,3 +432,104 @@ func TestSendPath(t *testing.T) {
 		})
 	}
 }
+
+func TestMetrics_CapacityGauge(t *testing.T) {
+	fp := &fakeProvisioner{gauges: map[string]*float64{}}
+	q := NewQueue[int](
+		Name("head"),
+		ChannelBufferLen(100),
+		MetricProvisioner(fp.provide))
+
+	// Two subscribers: one that works normally and another that is blocked
+	working := q.Subscribe(SubscriberName("working"))
+	blocked := q.Subscribe(SubscriberName("blocked"))
+
+	for i := 0; i < 50; i++ {
+		q.SendCtx(t.Context(), i)
+		// working channel reads values as long as they arrive
+		testutil.ReadChannel(t, working, timeout)
+	}
+	// working gauge will stay in 0.01 (metric is not cleaned up after last read)
+	assert.InDelta(t, 0.01, fp.GaugeFor("working"), 0.0001)
+	// blocked gauge reaches 0.5
+	assert.InDelta(t, 0.5, fp.GaugeFor("blocked"), 0.0001)
+
+	// send another batch
+	for i := 0; i < 50; i++ {
+		q.SendCtx(t.Context(), i)
+		testutil.ReadChannel(t, working, timeout)
+	}
+	assert.InDelta(t, 0.01, fp.GaugeFor("working"), 0.0001)
+	// blocked gauge reaches 1 (max)
+	assert.InDelta(t, 1.0, fp.GaugeFor("blocked"), 0.0001)
+
+	// unblock blocked subscriber --> metrics should go to lowest value
+	for i := 0; i < 100; i++ {
+		testutil.ReadChannel(t, blocked, timeout)
+	}
+	// send a last message to force update of metrics
+	q.SendCtx(t.Context(), 0)
+	assert.InDelta(t, 0.01, fp.GaugeFor("blocked"), 0.0001)
+	assert.InDelta(t, 0.01, fp.GaugeFor("working"), 0.0001)
+}
+
+func TestMetrics_Labels(t *testing.T) {
+	t.Run("direct subscription", func(t *testing.T) {
+		fp := &fakeProvisioner{gauges: map[string]*float64{}}
+		q := NewQueue[int](
+			Name("head"),
+			ChannelBufferLen(5),
+			MetricProvisioner(fp.provide))
+		q.Subscribe(SubscriberName("subs"))
+		q.SendCtx(t.Context(), 1)
+		assert.InDelta(t, 0.2, fp.GaugeFor("subs"), 0.001)
+	})
+	t.Run("bypasses subscription", func(t *testing.T) {
+		fp := &fakeProvisioner{gauges: map[string]*float64{}}
+		h1 := NewQueue[int](Name("head1"), ChannelBufferLen(5), MetricProvisioner(fp.provide))
+		h2 := NewQueue[int](Name("head2"), ChannelBufferLen(5), MetricProvisioner(fp.provide))
+		m1 := NewQueue[int](Name("mid1"), ChannelBufferLen(5), MetricProvisioner(fp.provide))
+		m2 := NewQueue[int](Name("mid2"), ChannelBufferLen(5), MetricProvisioner(fp.provide))
+		ta := NewQueue[int](Name("tail"), ChannelBufferLen(5), MetricProvisioner(fp.provide))
+		// interleaving subscriptions and bypasses. All the gauges
+		// should be labeled as src="head", dst="subsX"
+		h1.Bypass(m1)
+		m1.Bypass(ta)
+		// invert bypassing order
+		m2.Bypass(ta)
+		h2.Bypass(m2)
+		h1.Subscribe(SubscriberName("subs1"))
+		h2.Subscribe(SubscriberName("subs2"))
+		m1.Subscribe(SubscriberName("subs3"))
+		m2.Subscribe(SubscriberName("subs4"))
+		ta.Subscribe(SubscriberName("subs5"))
+
+		h1.SendCtx(t.Context(), 1)
+		h1.SendCtx(t.Context(), 2)
+		assert.InDelta(t, 0.4, fp.GaugeFor("subs1"), 0.001)
+		assert.InDelta(t, 0.4, fp.GaugeFor("subs2"), 0.001)
+		assert.InDelta(t, 0.4, fp.GaugeFor("subs3"), 0.001)
+		assert.InDelta(t, 0.4, fp.GaugeFor("subs4"), 0.001)
+		assert.InDelta(t, 0.4, fp.GaugeFor("subs5"), 0.001)
+	})
+}
+
+// implementation of fake gauge metrics for testing
+type fakeProvisioner struct {
+	gauges map[string]*float64
+}
+
+func (fp *fakeProvisioner) GaugeFor(subscriber string) float64 {
+	if v, ok := fp.gauges[subscriber]; ok {
+		return *v
+	}
+	return 0
+}
+
+func (fp *fakeProvisioner) provide(subscriber string) gauge {
+	value := float64(0)
+	fp.gauges[subscriber] = &value
+	return func(v float64) {
+		value = v
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1970 

Some users under high load scenarios get eventual crashes because OBI detects that the internal pipeline channels got blocked for too long because some nodes can't deal with the input load.

This metric help diagnosing the issue as it provides internal runtime metrics about the occupancy of the buffered channels that enable the communication between nodes.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
