### PR TITLE
build(obi-generator): bump to go 1.25.11 and block renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -311,6 +311,13 @@
       "enabled": false
     },
     {
+      "description": "Disable Docker updates for obi-generator",
+      "matchFileNames": ["generator.Dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["golang"],
+      "enabled": false
+    },
+    {
       "description": "Block Spring Boot major upgrades for JDK8 example (Spring Boot 3+ requires JDK 17+)",
       "matchFileNames": ["internal/test/integration/components/java_tls/jdk8/pom.xml"],
       "matchManagers": ["maven"],

--- a/generator.Dockerfile
+++ b/generator.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine@sha256:f1ddd9fe14fffc091dd98cb4bfa999f32c5fc77d2f2305ea9f0e2595c5437c14 AS base
+FROM golang:1.25.11-alpine@sha256:523c3effe300580ed375e43f43b1c9b091b68e935a7c3a92bfcc4e7ed55b18c2 AS base
 FROM base AS dist
 
 WORKDIR /src


### PR DESCRIPTION
## Summary

This PR bumps obi-generator from 1.25.10 --> 1.25.11:

1. Undo renovate auto-bump, as it is out of sync with the published image
2. Prevent renovate from auto-bumping the obi-generator in future
3. Manually pin obi-generator to go 1.25.11

This is prep for creating a new obi-generator image and upgrading OBI to go 1.25.11.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
