### PR TITLE
fix(postgres): detect connections with multi-message TCP segments

### DIFF
--- a/bpf/generictracer/protocol_postgres.h
+++ b/bpf/generictracer/protocol_postgres.h
@@ -124,18 +124,38 @@ static __always_inline u8 is_postgres(connection_info_t *conn_info,
     size_t message_size = 0;
     struct postgres_hdr hdr;
     bool includes_known_command = false;
+    bool malformed = false;
 
     for (u8 i = 0; i < k_pg_messages_in_packet_max; i++) {
+        // Stop when fewer than a full header remains. Any trailing bytes belong
+        // to a message split across TCP segments, which is expected.
         if (message_size + k_pg_hdr_size > data_len) {
             break;
         }
 
         hdr = postgres_parse_hdr(data + message_size);
 
-        message_size += hdr.message_len + 1;
-        if (hdr.message_len == 0) {
+        // The length field is a 4-byte integer that counts itself, so a valid
+        // Postgres message length is always >= 4. A smaller value means this is
+        // not a Postgres stream (or we are misaligned), so reject it.
+        if (hdr.message_len < 4) {
+            malformed = true;
             break;
         }
+
+        const size_t full_message_size = (size_t)hdr.message_len + 1;
+
+        // Only count messages that fit entirely within the captured segment. A
+        // declared length that overruns the buffer is either a message split
+        // across TCP segments (legitimate) or bogus data whose bytes happen to
+        // decode to a large length (e.g. the ASCII "OST " of an HTTP "POST"
+        // request). Either way, stop here and classify on the complete messages
+        // seen so far.
+        if (message_size + full_message_size > data_len) {
+            break;
+        }
+
+        message_size += full_message_size;
 
         switch (hdr.message_type) {
         case k_pg_msg_query:
@@ -149,15 +169,15 @@ static __always_inline u8 is_postgres(connection_info_t *conn_info,
         }
     }
 
-    if (message_size != data_len) {
-        bpf_dbg_printk("is_postgres: message length mismatch: message_size=%d data_len=%u",
-                       message_size,
-                       data_len);
-        return 0;
-    }
-
-    if (!includes_known_command) {
-        bpf_dbg_printk("is_postgres: no known command found");
+    // Classify as Postgres once we have parsed at least one well-formed frontend
+    // command message. We deliberately do NOT require message_size == data_len:
+    // request segments routinely concatenate several messages, exceed
+    // k_pg_messages_in_packet_max, or end with a message split across TCP
+    // segments, all of which leave message_size != data_len on a valid stream.
+    if (malformed || !includes_known_command) {
+        bpf_dbg_printk("is_postgres: not postgres (malformed=%d, known_command=%d)",
+                       malformed,
+                       includes_known_command);
         return 0;
     }
 

--- a/bpf/tests/bpf_postgres_detection.c
+++ b/bpf/tests/bpf_postgres_detection.c
@@ -50,7 +50,10 @@ enum protocol_type {
 };
 
 #define BPF_ANY 0
+
+#ifndef __always_inline
 #define __always_inline inline
+#endif
 
 static void bpf_probe_read(void *dst, u32 size, const void *src) {
     memcpy(dst, src, size);

--- a/bpf/tests/bpf_postgres_detection.c
+++ b/bpf/tests/bpf_postgres_detection.c
@@ -1,0 +1,326 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The following code is copied from bpf/generictracer/protocol_postgres.h and
+ * adapted to run as a host unit test. The function under test is:
+ *
+ *   static __always_inline u8 is_postgres(connection_info_t *conn_info,
+ *                                         const unsigned char *data,
+ *                                         u32 data_len,
+ *                                         enum protocol_type *protocol_type);
+ *
+ * Together with its helper postgres_parse_hdr(). The BPF-only helpers
+ * (bpf_probe_read, bpf_ntohl, bpf_dbg_printk, bpf_map_update_elem and the
+ * protocol_cache map) are mocked below. The real header cannot be #included
+ * directly on a non-BPF target because its map definitions use SEC(".maps").
+ *
+ * These tests reproduce https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1464
+ * where request segments that concatenate several Postgres messages, exceed the
+ * per-segment message limit, or end with a message split across TCP segments
+ * were rejected because the parser required message_size == data_len.
+ */
+
+#include <arpa/inet.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+
+// ---------------------------------------------------------------------------
+// Mocks for the BPF runtime helpers used by is_postgres / postgres_parse_hdr.
+// ---------------------------------------------------------------------------
+
+typedef struct connection_info {
+    u32 src_ip;
+    u32 dst_ip;
+    u16 src_port;
+    u16 dst_port;
+} connection_info_t;
+
+enum protocol_type {
+    k_protocol_type_unknown = 0,
+    k_protocol_type_http,
+    k_protocol_type_postgres,
+};
+
+#define BPF_ANY 0
+#define __always_inline inline
+
+static void bpf_probe_read(void *dst, u32 size, const void *src) {
+    memcpy(dst, src, size);
+}
+
+#define bpf_ntohl(x) ntohl(x)
+
+// Discard the formatted debug output, mirroring bpf_dbg_printk when BPF debug
+// is disabled.
+#define bpf_dbg_printk(...) ((void)0)
+
+// protocol_cache and bpf_map_update_elem are irrelevant to the classification
+// decision, so they are reduced to no-ops here.
+static int protocol_cache;
+static long bpf_map_update_elem(void *map, const void *key, const void *value, u64 flags) {
+    (void)map;
+    (void)key;
+    (void)value;
+    (void)flags;
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Code under test (copied verbatim from protocol_postgres.h).
+// ---------------------------------------------------------------------------
+
+struct postgres_hdr {
+    u32 message_len;
+    u8 message_type;
+    u8 _pad[3];
+};
+
+enum {
+    k_pg_hdr_size = 5,
+    k_pg_messages_in_packet_max = 10,
+
+    k_pg_msg_bind = 'B',
+    k_pg_msg_execute = 'E',
+    k_pg_msg_parse = 'P',
+    k_pg_msg_query = 'Q',
+};
+
+static __always_inline struct postgres_hdr postgres_parse_hdr(const unsigned char *data) {
+    struct postgres_hdr hdr = {};
+
+    u8 header[k_pg_hdr_size] = {};
+    bpf_probe_read(header, k_pg_hdr_size, data);
+
+    u32 message_len_le;
+    __builtin_memcpy(&message_len_le, header + 1, sizeof(message_len_le));
+
+    hdr.message_type = header[0];
+    hdr.message_len = bpf_ntohl(message_len_le);
+
+    return hdr;
+}
+
+static __always_inline u8 is_postgres(connection_info_t *conn_info,
+                                      const unsigned char *data,
+                                      u32 data_len,
+                                      enum protocol_type *protocol_type) {
+    if (*protocol_type != k_protocol_type_postgres && *protocol_type != k_protocol_type_unknown) {
+        return 0;
+    }
+
+    if (data_len < k_pg_hdr_size) {
+        bpf_dbg_printk("is_postgres: data_len is too short: %d", data_len);
+        return 0;
+    }
+
+    size_t message_size = 0;
+    struct postgres_hdr hdr;
+    bool includes_known_command = false;
+    bool malformed = false;
+
+    for (u8 i = 0; i < k_pg_messages_in_packet_max; i++) {
+        if (message_size + k_pg_hdr_size > data_len) {
+            break;
+        }
+
+        hdr = postgres_parse_hdr(data + message_size);
+
+        if (hdr.message_len < 4) {
+            malformed = true;
+            break;
+        }
+
+        const size_t full_message_size = (size_t)hdr.message_len + 1;
+
+        if (message_size + full_message_size > data_len) {
+            break;
+        }
+
+        message_size += full_message_size;
+
+        switch (hdr.message_type) {
+        case k_pg_msg_query:
+        case k_pg_msg_parse:
+        case k_pg_msg_bind:
+        case k_pg_msg_execute:
+            includes_known_command = true;
+            break;
+        default:
+            break;
+        }
+    }
+
+    if (malformed || !includes_known_command) {
+        bpf_dbg_printk("is_postgres: not postgres (malformed=%d, known_command=%d)",
+                       malformed,
+                       includes_known_command);
+        return 0;
+    }
+
+    *protocol_type = k_protocol_type_postgres;
+    bpf_map_update_elem(&protocol_cache, conn_info, protocol_type, BPF_ANY);
+
+    bpf_dbg_printk("is_postgres: postgres! message_type=%u", hdr.message_type);
+    return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Test harness.
+// ---------------------------------------------------------------------------
+
+static int failures = 0;
+
+static void check(const char *name, u8 expected, u8 actual) {
+    if (expected != actual) {
+        fprintf(stderr, "FAIL: %s\n  expected is_postgres=%u, got %u\n", name, expected, actual);
+        failures++;
+    } else {
+        printf("ok: %s\n", name);
+    }
+}
+
+// Appends a Postgres v3 message (1 type byte + 4-byte big-endian length that
+// counts itself + body) to buf at *off. body_len is the number of payload bytes
+// after the header. Returns the total bytes written.
+static u32 put_msg(unsigned char *buf, u32 *off, u8 type, u32 body_len) {
+    buf[*off] = type;
+    u32 declared = body_len + 4; // length field counts itself but not the type byte
+    u32 be = htonl(declared);
+    memcpy(buf + *off + 1, &be, sizeof(be));
+    for (u32 i = 0; i < body_len; i++) {
+        buf[*off + k_pg_hdr_size + i] = (unsigned char)('a' + (i % 26));
+    }
+    u32 total = k_pg_hdr_size + body_len;
+    *off += total;
+    return total;
+}
+
+static u8 classify(const unsigned char *data, u32 len) {
+    connection_info_t conn = {0};
+    enum protocol_type pt = k_protocol_type_unknown;
+    return is_postgres(&conn, data, len, &pt);
+}
+
+static void test_simple_query_exact_fill(void) {
+    unsigned char buf[64] = {0};
+    u32 off = 0;
+    put_msg(buf, &off, k_pg_msg_query, 9); // "SELECT 1\0"
+    check("simple query, exact fill", 1, classify(buf, off));
+}
+
+static void test_extended_protocol_multi_message(void) {
+    unsigned char buf[256] = {0};
+    u32 off = 0;
+    put_msg(buf, &off, k_pg_msg_parse, 20);
+    put_msg(buf, &off, k_pg_msg_bind, 30);
+    put_msg(buf, &off, 'D', 10); // Describe (not a known frontend command)
+    put_msg(buf, &off, k_pg_msg_execute, 6);
+    put_msg(buf, &off, 'S', 0); // Sync (len == 4, empty body)
+    check("extended protocol, multiple complete messages", 1, classify(buf, off));
+}
+
+static void test_more_than_loop_limit(void) {
+    unsigned char buf[512] = {0};
+    u32 off = 0;
+    put_msg(buf, &off, k_pg_msg_query, 8); // known command in the first slot
+    for (int i = 0; i < 15; i++) {
+        put_msg(buf, &off, 'S', 0); // many small Sync messages, exceeding the limit
+    }
+    check("more than k_pg_messages_in_packet_max messages", 1, classify(buf, off));
+}
+
+static void test_trailing_partial_message(void) {
+    unsigned char buf[128] = {0};
+    u32 off = 0;
+    put_msg(buf, &off, k_pg_msg_query, 10); // complete query
+    // Now a Bind whose declared body extends past the captured buffer.
+    buf[off] = k_pg_msg_bind;
+    u32 be = htonl(4 + 200); // declares a 200-byte body we will not fully include
+    memcpy(buf + off + 1, &be, sizeof(be));
+    off += k_pg_hdr_size + 8; // include only 8 bytes of the partial Bind body
+    check("trailing message split across segments", 1, classify(buf, off));
+}
+
+static void test_http_post_rejected(void) {
+    const char *http = "POST /v1/data HTTP/1.1\r\nHost: example\r\n\r\n{\"k\":1}";
+    check("HTTP POST request is not postgres",
+          0,
+          classify((const unsigned char *)http, (u32)strlen(http)));
+}
+
+static void test_startup_message_rejected(void) {
+    // StartupMessage: Int32 length + Int32 protocol(0x00030000) + params. No type byte.
+    unsigned char buf[32] = {0};
+    u32 len = htonl(20);
+    u32 proto = htonl(0x00030000);
+    memcpy(buf, &len, 4);
+    memcpy(buf + 4, &proto, 4);
+    memcpy(buf + 8, "user\0x\0", 7);
+    check("startup message is not classified", 0, classify(buf, 20));
+}
+
+static void test_response_only_segment_rejected(void) {
+    // Backend response messages carry no frontend command, so a response-only
+    // segment must not classify the connection from this side.
+    unsigned char buf[256] = {0};
+    u32 off = 0;
+    put_msg(buf, &off, 'T', 30); // RowDescription
+    put_msg(buf, &off, 'D', 40); // DataRow
+    put_msg(buf, &off, 'C', 12); // CommandComplete
+    put_msg(buf, &off, 'Z', 1);  // ReadyForQuery
+    check("response-only segment has no frontend command", 0, classify(buf, off));
+}
+
+static void test_too_short_rejected(void) {
+    unsigned char buf[4] = {'Q', 0, 0, 0};
+    check("buffer shorter than a header", 0, classify(buf, sizeof(buf)));
+}
+
+static void test_malformed_length_rejected(void) {
+    // A message that declares a length < 4 cannot be valid Postgres.
+    unsigned char buf[16] = {0};
+    buf[0] = k_pg_msg_query;
+    u32 be = htonl(2); // invalid: smaller than the 4-byte length field
+    memcpy(buf + 1, &be, sizeof(be));
+    check("message length below minimum is rejected", 0, classify(buf, 12));
+}
+
+static void test_multi_message_not_exact_fill(void) {
+    // Reproduces the reported case: several complete frontend messages followed
+    // by the start of another message, so message_size != data_len.
+    unsigned char buf[256] = {0};
+    u32 off = 0;
+    put_msg(buf, &off, k_pg_msg_parse, 40);
+    put_msg(buf, &off, k_pg_msg_bind, 50);
+    put_msg(buf, &off, k_pg_msg_execute, 12);
+    off += 3; // a few trailing bytes of a following, not-yet-complete message
+    check("concatenated messages not filling the segment", 1, classify(buf, off));
+}
+
+int main(void) {
+    test_simple_query_exact_fill();
+    test_extended_protocol_multi_message();
+    test_more_than_loop_limit();
+    test_trailing_partial_message();
+    test_http_post_rejected();
+    test_startup_message_rejected();
+    test_response_only_segment_rejected();
+    test_too_short_rejected();
+    test_malformed_length_rejected();
+    test_multi_message_not_exact_fill();
+
+    if (failures > 0) {
+        fprintf(stderr, "%d test(s) failed\n", failures);
+        return 1;
+    }
+    printf("all postgres detection tests passed\n");
+    return 0;
+}

--- a/devdocs/protocols/tcp/README.md
+++ b/devdocs/protocols/tcp/README.md
@@ -11,4 +11,5 @@ This directory contains documentation for the supported protocol parsers that OB
 - [NATS](nats.md): NATS protocol parser.
 - [AMQP](amqp.md): AMQP 1.0 protocol parser.
 - [SunRPC](sunrpc.md): ONC RPC (Sun RPC) protocol parser.
+- [PostgreSQL](postgres.md): PostgreSQL protocol parser.
 - [New Tracer](new-tcp-tracer.md): how to add a new TCP protocol based BPF tracer to OBI.

--- a/devdocs/protocols/tcp/postgres.md
+++ b/devdocs/protocols/tcp/postgres.md
@@ -1,0 +1,98 @@
+# OBI PostgreSQL protocol parser
+
+This document describes the PostgreSQL protocol parser that OBI provides.
+
+## Protocol Overview
+
+PostgreSQL uses the [frontend/backend protocol (version 3)](https://www.postgresql.org/docs/current/protocol-message-formats.html).
+After the startup handshake, every message exchanged over the connection has the
+same shape:
+
+```
+[ 1 byte: message type ] [ 4 bytes: length ] [ ...body... ]
+       e.g. 'Q'             big-endian Int32      payload
+```
+
+Two details are important for the parser:
+
+- The **length** field is encoded in network byte order (big-endian).
+- The length field **counts itself** (its own 4 bytes) but **not** the leading
+  type byte. So a message that declares a length of `13` occupies `1 + 13 = 14`
+  bytes on the wire, and the smallest valid length is `4` (a message with an
+  empty body, such as `Sync`).
+
+A single TCP segment frequently carries **several concatenated messages**. For
+example, an extended-protocol query is sent as `Parse` + `Bind` + `Describe` +
+`Execute` + `Sync` in one segment.
+
+The frontend (client) message types OBI uses to recognise a connection are:
+
+- `'Q'` — Query (simple query)
+- `'P'` — Parse, `'B'` — Bind, `'E'` — Execute (extended query)
+
+## Protocol Detection
+
+Detection happens in the kernel in `is_postgres`
+([protocol_postgres.h](../../../bpf/generictracer/protocol_postgres.h)). It walks
+up to `k_pg_messages_in_packet_max` (10) messages in the captured segment,
+following each message's declared length, and classifies the connection as
+PostgreSQL when **all** of the following hold:
+
+1. At least one frontend command message (`Q`/`P`/`B`/`E`) is seen.
+2. Every parsed message is structurally valid: its declared length is `>= 4`.
+3. Only messages that **fit entirely** within the captured segment are counted.
+
+A message whose declared length overruns the buffer is **not** counted — it is
+either a message split across TCP segments (legitimate) or bogus data, and the
+parser stops and decides based on the complete messages seen so far.
+
+### Why `message_size == data_len` is not required
+
+An earlier version of the parser only classified a connection when the sum of
+the parsed message lengths exactly matched the segment size
+(`message_size == data_len`). That rejected several common, valid cases and
+caused PostgreSQL connections to go undetected (see
+[issue #1464](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1464)):
+
+- **Multiple concatenated messages** whose total does not exactly fill the
+  segment.
+- **More than 10 messages** in a single segment: the parser stops at the loop
+  limit, so `message_size < data_len`.
+- **A final message split across TCP segments**: the tail is incomplete, so the
+  totals never match.
+
+Requiring a well-formed frontend command instead of an exact size match fixes
+these cases.
+
+### Avoiding false positives
+
+Relaxing the size check could let non-PostgreSQL traffic be misclassified, so
+the "fits entirely within the segment" rule (point 3 above) doubles as the guard
+against it. Text-based protocols are rejected naturally: their bytes are
+printable ASCII, so when interpreted as a big-endian length they produce huge
+values that cannot fit in the segment.
+
+For example, an HTTP `POST` request begins with the bytes `P`, `O`, `S`, `T`.
+The `'P'` looks like a `Parse` command, but the following four bytes `"OST "`
+decode to a length of `0x4F535420` (~1.3 billion). That message cannot fit in
+the segment, so it is not counted, no frontend command is recorded, and the
+connection is correctly rejected. Only binary data with small, self-consistent,
+chained lengths — i.e. genuine PostgreSQL — passes the filter.
+
+## Protocol Parsing
+
+Once a connection is classified as PostgreSQL, request and response bytes are
+streamed to userspace and parsed there. The entry points are
+`isPostgres` / `isValidPostgresPayload` and the query/statement handling in
+[sql_detect_postgres.go](../../../pkg/ebpf/common/sql_detect_postgres.go), driven
+from [sql_detect_transform.go](../../../pkg/ebpf/common/sql_detect_transform.go).
+SQL statement normalisation and pruning live in the
+[sqlprune package](../../../pkg/internal/sqlprune).
+
+## Tests
+
+The kernel-side classifier has a host-compilable unit test in
+[bpf_postgres_detection.c](../../../bpf/tests/bpf_postgres_detection.c) that
+covers the detection and false-positive cases above. End-to-end coverage with a
+real PostgreSQL server lives in the `TestSuite_PythonPostgres` integration
+suite.

--- a/internal/test/integration/components/pythonsql/main.py
+++ b/internal/test/integration/components/pythonsql/main.py
@@ -55,6 +55,28 @@ async def error():
     conn.close()
     return {"status": "OK"}
 
+# Reproduces https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1464.
+#
+# psycopg's pipeline mode batches several extended-protocol statements into the
+# same TCP send. Each parameterized statement is a Parse/Bind/Describe/Execute
+# group, so a handful of them (plus the trailing Sync) easily exceeds the
+# k_pg_messages_in_packet_max (10) messages the eBPF classifier walks in a
+# single segment. The classifier used to require message_size == data_len and
+# rejected such segments, so the connection was never recognized as Postgres and
+# produced no traces. accounting.invoices is queried only here, so a trace for
+# it proves this multi-message connection was classified.
+@app.get("/pipeline")
+async def pipeline():
+    conn = psycopg.connect(**DB_CONFIG)
+    try:
+        with conn.pipeline():
+            with conn.cursor() as cur:
+                for i in range(1, 6):
+                    cur.execute("SELECT * FROM accounting.invoices WHERE id = %s", (i,))
+    finally:
+        conn.close()
+    return {"status": "OK"}
+
 if __name__ == "__main__":
     print(f"Server running: port={8080} process_id={os.getpid()}")
     uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/internal/test/integration/red_test_python_sql.go
+++ b/internal/test/integration/red_test_python_sql.go
@@ -57,6 +57,7 @@ func assertHTTPRequests(t *testing.T, comm, urlPath string) {
 	require.Empty(t, traces, "expected no HTTP traces, got %d", len(traces))
 }
 
+//nolint:unparam // reason: reserve the posibility to use op != "SELECT" in future tests
 func assertSQLOperation(t *testing.T, comm, op, table, db string) {
 	t.Helper()
 

--- a/internal/test/integration/red_test_python_sql.go
+++ b/internal/test/integration/red_test_python_sql.go
@@ -196,6 +196,21 @@ func testPythonSQLError(t *testing.T, comm, url, db string) {
 	assertSQLOperationErrored(t, comm, "SELECT", "obi.nonexisting", db)
 }
 
+// testPythonSQLPipeline exercises the regression from issue #1464: the
+// /pipeline endpoint batches several extended-protocol statements into one TCP
+// segment (more than k_pg_messages_in_packet_max Postgres messages), which the
+// eBPF classifier used to reject. accounting.invoices is only queried by this
+// endpoint, so finding its span proves the multi-message connection was
+// classified as Postgres.
+func testPythonSQLPipeline(t *testing.T, comm, url, db string) {
+	t.Helper()
+
+	urlPath := "/pipeline"
+	ti.DoHTTPGet(t, url+urlPath, 200)
+
+	assertSQLOperation(t, comm, "SELECT", "accounting.invoices", db)
+}
+
 func testPythonPostgres(t *testing.T) {
 	testCaseURL := "http://localhost:8381"
 	comm := "python3.14"
@@ -207,6 +222,7 @@ func testPythonPostgres(t *testing.T) {
 	assertHTTPRequests(t, comm, "/query")
 	testPythonSQLQuery(t, comm, testCaseURL, table, db)
 	testPythonSQLPreparedStatements(t, comm, testCaseURL, table, db)
+	testPythonSQLPipeline(t, comm, testCaseURL, db)
 	testPythonSQLError(t, comm, testCaseURL, db)
 }
 


### PR DESCRIPTION
  ## Summary

  Fixes #1464.

  PostgreSQL connections were frequently not detected, so no traces were emitted
  for them. The kernel-side protocol classifier `is_postgres`
  (`bpf/generictracer/protocol_postgres.h`) required the parsed messages to fill
  the captured TCP segment **exactly** (`message_size == data_len`) before
  accepting a connection as Postgres. That exact-match requirement rejected
  several common, valid cases:

  - **Multiple concatenated messages** whose total doesn't exactly fill the segment.
  - **More than `k_pg_messages_in_packet_max` (10) messages** in one segment: the
    walk stops at the loop limit, so `message_size < data_len`.
    totals never match.

  ### The fix

  Classify a connection as Postgres as soon as we parse **at least one
  well-formed frontend command message** (`Q`/`P`/`B`/`E`), instead of requiring
  an exact size match. While walking the segment we now:

  - Only count messages that **fit entirely** within the captured segment.
  - Validate each message's declared length is `>= 4` (the length field counts
    itself, so anything smaller can't be Postgres).

  ### Why this doesn't introduce false positives

  The "must fit entirely within the segment" rule doubles as the guard against
  misclassifying other protocols. Text-based protocols are rejected naturally:
  their bytes are printable ASCII, so when interpreted as a big-endian length they
  yield huge values that cannot fit in the segment. For example, an HTTP `POST`
  request starts with `P` (which looks like a `Parse` command), but the following
  four bytes `"OST "` decode to a length of `0x4F535420` (~1.3 billion); that
  message can't fit, so it's not counted, no frontend command is recorded, and the
  connection is correctly rejected. Only binary data with small, self-consistent,
  chained lengths — i.e. genuine Postgres — passes the filter.

  ### Tests

  - **Unit test** (`bpf/tests/bpf_postgres_detection.c`): a host-compilable test
    for the classifier covering the three regression scenarios above plus the
    false-positive guards (HTTP, startup message, response-only segment,
    too-short buffer, invalid length).
  - **Integration test**: a new `/pipeline` endpoint on the Python Postgres test
    server uses psycopg pipeline mode to batch several extended-protocol
    statements into one TCP segment (more than 10 Postgres messages), reproducing
    the issue. `TestSuite_PythonPostgres` asserts a `SELECT accounting.invoices`
    trace appears — `accounting.invoices` is queried only by this endpoint, so its
    trace proves the multi-message connection was classified.

  ### Docs

  Adds `devdocs/protocols/tcp/postgres.md` documenting the (previously
  undocumented) Postgres parser and the detection heuristic.

  ## Validation

  - [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
  - [ ] If this enhances / fixes / changes a core feature, I have updated the [features
  documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support
  matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.