### PR TITLE
fix(ci): disable base64 line wrapping

### DIFF
--- a/.github/workflows/generator-image.yml
+++ b/.github/workflows/generator-image.yml
@@ -62,7 +62,7 @@ jobs:
             echo "Fetching latest version from ${{ env.REGISTRY }}/${{ env.IMAGE }}..."
           
             # Get authentication token for GHCR
-            TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64)
+            TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64 --wrap=0)
           
             # Fetch tags from GHCR API
             TAGS=$(curl -s -H "Authorization: Bearer $TOKEN" \


### PR DESCRIPTION
## Summary

OBI Generator image publishing workflow is broken due to a line break introduced by base64's default encoding width.

This PR disables the line wrapping completely, so that `GITHUB_TOKEN` stays valid when encoded.

Pushed to an origin branch so that I can run the workflow directly on this PR to validate the fix:

- https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/27821129772

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
