### PR TITLE
Fix Rails and Sinatra split route matcher

### DIFF
--- a/pkg/internal/transform/route/matcher.go
+++ b/pkg/internal/transform/route/matcher.go
@@ -33,11 +33,46 @@ type node struct {
 	// Child nodes for a given path folder
 	Child map[string]*node
 
-	// Wildcard is a child subtree that, if not nil, matches any path folder
-	Wildcard *node
+	// Patterns are child subtrees matching a single path folder. A pattern with an
+	// empty prefix (e.g. ":id" or "{id}") matches any folder; a pattern with a literal
+	// prefix (e.g. "@:username", common in Rails or Sinatra) matches folders starting
+	// with that text, since the placeholder always runs to the end of the folder.
+	// As multiple partial patterns can be defined in the same path position, we store
+	// them as a slice and evaluate them in definition order, e.g.:
+	// /users/admin:userid/info
+	// /users/:userid/info
+	// It is up to the user to declare the more specific patterns first, since a
+	// catch-all (empty prefix) would otherwise shadow any pattern defined after it.
+	Patterns []*partialPattern
 
 	// AnyPath node is a node identified by '*', which terminates the search matching what's found
 	AnyPath *node
+}
+
+// partialPattern matches a single path folder against a placeholder that runs to
+// the end of the folder. When prefix is empty it is a catch-all wildcard
+// (":id"/"{id}") matching any folder; otherwise it matches folders starting with
+// the literal prefix (e.g. "@:username"), which must hold at least one extra
+// character for the placeholder.
+type partialPattern struct {
+	// prefix is the literal text before the placeholder (empty for a catch-all)
+	prefix string
+	// node is the child subtree reached when the folder matches
+	node *node
+}
+
+// matches reports whether the given path folder satisfies the pattern. A catch-all
+// (empty prefix) matches any folder. Otherwise the folder must start with the literal
+// prefix and hold at least one more character for the placeholder value. Additionally,
+// the prefix must not be merely a sub-prefix of a longer word in the folder (e.g. the
+// prefix "prefix" matches "prefix:1234" but not "prefixbutlonger:1234"): a colon boundary
+// is required between the end of the prefix and the start of the placeholder value, so
+// the match is rejected when both are word characters.
+func (w *partialPattern) matches(folder string) bool {
+	if w.prefix == "" {
+		return true
+	}
+	return len(folder) > len(w.prefix) && strings.HasPrefix(folder, w.prefix)
 }
 
 // NewMatcher creates a new Matcher that would allow validating given URL paths towards
@@ -67,12 +102,15 @@ func find(path []string, pathNode *node) string {
 	if child, ok := pathNode.Child[path[0]]; ok {
 		return find(path[1:], child)
 	}
+	// otherwise, try the pattern children in definition order; the first match wins,
+	// so more specific patterns (e.g. "@:username") must be declared before a catch-all
+	for _, w := range pathNode.Patterns {
+		if w.matches(path[0]) {
+			return find(path[1:], w.node)
+		}
+	}
 	if pathNode.AnyPath != nil {
 		return pathNode.FullRoute
-	}
-	// otherwise, keep searching through the wildcard child, if any
-	if pathNode.Wildcard != nil {
-		return find(path[1:], pathNode.Wildcard)
 	}
 	return ""
 }
@@ -84,19 +122,23 @@ func appendRoute(fullRoute string, path []string, pathNode *node) {
 		return
 	}
 	currentName := path[0]
-	// if the current token is a wildcard, add it as a child and keep processing the
-	// wildcard node
+	// if the current token is a full-folder wildcard (":id"/"{id}"), register it as a
+	// catch-all pattern (empty prefix)
 	if wildcard.MatchString(currentName) {
-		if pathNode.Wildcard == nil {
-			pathNode.Wildcard = &node{Child: map[string]*node{}}
-		}
-		appendRoute(fullRoute, path[1:], pathNode.Wildcard)
+		appendRoute(fullRoute, path[1:], pathNode.pattern(""))
 		return
 	}
 
 	if currentName == "*" {
 		pathNode.FullRoute = fullRoute
 		pathNode.AnyPath = &node{Child: map[string]*node{}}
+		return
+	}
+
+	// if the current token has a literal prefix before a colon placeholder (e.g. "@:username"),
+	// register it as a pattern matching any folder starting with that prefix
+	if prefix, ok := colonPrefix(currentName); ok {
+		appendRoute(fullRoute, path[1:], pathNode.pattern(prefix))
 		return
 	}
 
@@ -108,6 +150,34 @@ func appendRoute(fullRoute string, path []string, pathNode *node) {
 		pathNode.Child[currentName] = child
 	}
 	appendRoute(fullRoute, path[1:], child)
+}
+
+// pattern returns the child subtree for a pattern with the given literal prefix,
+// creating it if necessary. Patterns sharing the same prefix (e.g. ":id" and
+// ":userId", or "@:user" and "@:name") are merged into one node so their subtrees
+// combine. New prefixes are appended, preserving definition order for matching.
+func (n *node) pattern(prefix string) *node {
+	for _, w := range n.Patterns {
+		if w.prefix == prefix {
+			return w.node
+		}
+	}
+	w := &partialPattern{prefix: prefix, node: &node{Child: map[string]*node{}}}
+	n.Patterns = append(n.Patterns, w)
+	return w.node
+}
+
+// colonPrefix detects a path folder that has literal text before a ":var"
+// placeholder (e.g. "@:username") and returns that literal prefix. The placeholder
+// is assumed to run to the end of the folder, so any text after the colon is
+// ignored. It returns false when the folder has no colon, or when the colon is at
+// the start (a full wildcard like ":id", handled elsewhere).
+func colonPrefix(segment string) (prefix string, ok bool) {
+	colon := strings.IndexByte(segment, ':')
+	if colon <= 0 {
+		return "", false
+	}
+	return segment[:colon], true
 }
 
 // tokenizes and normalizes the resulting slice, so we make sure

--- a/pkg/internal/transform/route/matcher_test.go
+++ b/pkg/internal/transform/route/matcher_test.go
@@ -40,3 +40,39 @@ func TestFind(t *testing.T) {
 	assert.Equal(t, "/snow/mobile/*", m.Find("/snow/mobile"))
 	assert.Equal(t, "/snow/mobile/*", m.Find("/snow/mobile/long"))
 }
+
+func TestFindPartialSegmentWildcard(t *testing.T) {
+	m := NewMatcher([]string{
+		"/@:username/lists/:id",
+		"/@:username/followers",
+	})
+
+	// the motivating case: prefix before a colon placeholder
+	assert.Equal(t, "/@:username/lists/:id", m.Find("/@gouthamve/lists/my-list"))
+	assert.Equal(t, "/@:username/lists/:id", m.Find("/@alice/lists/42"))
+	assert.Equal(t, "/@:username/followers", m.Find("/@bob/followers"))
+
+	// the literal prefix is still required, and the placeholder needs at least one char
+	assert.Empty(t, m.Find("/gouthamve/lists/my-list"))
+	assert.Empty(t, m.Find("/@/followers"))
+}
+
+// TestFindPatternsInDefinitionOrder documents that patterns sharing a path
+// position are evaluated in definition order: it is up to the user to declare the
+// more specific pattern before a catch-all that would otherwise shadow it.
+func TestFindPatternsInDefinitionOrder(t *testing.T) {
+	// specific pattern declared first: it takes precedence over the catch-all
+	specificFirst := NewMatcher([]string{
+		"/@:username/profile",
+		"/:section/profile",
+	})
+	assert.Equal(t, "/@:username/profile", specificFirst.Find("/@carol/profile"))
+	assert.Equal(t, "/:section/profile", specificFirst.Find("/settings/profile"))
+
+	// catch-all declared first: it shadows the more specific pattern that follows
+	catchAllFirst := NewMatcher([]string{
+		"/:section/profile",
+		"/@:username/profile",
+	})
+	assert.Equal(t, "/:section/profile", catchAllFirst.Find("/@carol/profile"))
+}

--- a/pkg/internal/transform/route/part_matcher.go
+++ b/pkg/internal/transform/route/part_matcher.go
@@ -106,9 +106,11 @@ func (rm *PartialRouteMatcher) findPartialRecursive(tokens []string, node *node,
 		return rm.findPartialRecursive(tokens, child, consumed+1)
 	}
 
-	// Try wildcard match
-	if node.Wildcard != nil {
-		return rm.findPartialRecursive(tokens, node.Wildcard, consumed+1)
+	// Try pattern match in definition order; the first matching pattern wins
+	for _, w := range node.Patterns {
+		if w.matches(currentToken) {
+			return rm.findPartialRecursive(tokens, w.node, consumed+1)
+		}
 	}
 
 	// No match found


### PR DESCRIPTION
## Summary

Related issue: https://github.com/grafana/beyla/issues/2183

Context, we were assuming that routes were always defined as `/foo/:variable/bar`, but in Ruby on Rails and Sinatra you can define split routes like `/foo/static_prefix:variable/bar`

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
