### PR TITLE
(DynamicSelector-Phase5) Gate AppO11y Traces and Metrics Separately

### DIFF
--- a/pkg/appolly/dynamic_signal_gate.go
+++ b/pkg/appolly/dynamic_signal_gate.go
@@ -116,12 +116,13 @@ func (g *dynamicSignalProcessEventGate) handleProcessEvent(pe exec.ProcessEvent)
 	switch pe.Type {
 	case exec.ProcessEventCreated:
 		g.current[pid] = pe.File
+		if g.forwarded[pid] {
+			return
+		}
 		if g.selector.IncludesPID(processEventSignalPID(pe.File)) {
 			g.forwarded[pid] = true
 			g.output.Send(pe)
-			return
 		}
-		g.forwarded[pid] = false
 	case exec.ProcessEventTerminated:
 		if g.forwarded[pid] {
 			g.output.Send(pe)

--- a/pkg/appolly/dynamic_signal_gate.go
+++ b/pkg/appolly/dynamic_signal_gate.go
@@ -1,0 +1,162 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package appolly // import "go.opentelemetry.io/obi/pkg/appolly"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm/swarms"
+	"go.opentelemetry.io/obi/pkg/selection"
+)
+
+func dynamicSignalPID(service *request.Span) app.PID {
+	if service.Service.DynamicSelectorPID != 0 {
+		return service.Service.DynamicSelectorPID
+	}
+	return service.Service.ProcPID
+}
+
+func processEventSignalPID(file *exec.FileInfo) app.PID {
+	snap := file.ServiceAttrs()
+	if snap.DynamicSelectorPID != 0 {
+		return snap.DynamicSelectorPID
+	}
+	return file.Pid()
+}
+
+// DynamicSignalSpanGate marks spans as traces/metrics-ignored according to the runtime signal views.
+func DynamicSignalSpanGate(
+	selector selection.MultiSignalPIDSelector,
+	input, output *msg.Queue[[]request.Span],
+) swarm.InstanceFunc {
+	return func(_ context.Context) (swarm.RunFunc, error) {
+		if selector == nil {
+			return swarm.Bypass(input, output)
+		}
+		in := input.Subscribe(msg.SubscriberName("appolly.DynamicSignalSpanGate"))
+		tracesSelector := selector.Traces()
+		metricsSelector := selector.AppMetrics()
+		return func(ctx context.Context) {
+			defer output.Close()
+			swarms.ForEachInput(ctx, in, nil, func(spans []request.Span) {
+				for i := range spans {
+					pid := dynamicSignalPID(&spans[i])
+					if !tracesSelector.IncludesPID(pid) {
+						request.SetIgnoreTraces(&spans[i])
+					}
+					if !metricsSelector.IncludesPID(pid) {
+						request.SetIgnoreMetrics(&spans[i])
+					}
+				}
+				output.SendCtx(ctx, spans)
+			})
+		}, nil
+	}
+}
+
+type dynamicSignalProcessEventGate struct {
+	input    <-chan exec.ProcessEvent
+	output   *msg.Queue[exec.ProcessEvent]
+	selector selection.PIDSelector
+
+	current   map[app.PID]*exec.FileInfo
+	forwarded map[app.PID]bool
+}
+
+// DynamicSignalProcessEventGate forwards process events only for PIDs selected for app metrics.
+// It also synthesizes create/delete events when app-metrics selection changes for a process that
+// stays instrumented due to traces still being enabled.
+func DynamicSignalProcessEventGate(
+	selector selection.MultiSignalPIDSelector,
+	input, output *msg.Queue[exec.ProcessEvent],
+) swarm.InstanceFunc {
+	return func(_ context.Context) (swarm.RunFunc, error) {
+		if selector == nil {
+			return swarm.Bypass(input, output)
+		}
+		gate := &dynamicSignalProcessEventGate{
+			input:     input.Subscribe(msg.SubscriberName("appolly.DynamicSignalProcessEventGate")),
+			output:    output,
+			selector:  selector.AppMetrics(),
+			current:   map[app.PID]*exec.FileInfo{},
+			forwarded: map[app.PID]bool{},
+		}
+		return gate.run, nil
+	}
+}
+
+func (g *dynamicSignalProcessEventGate) run(ctx context.Context) {
+	defer g.output.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case pe, ok := <-g.input:
+			if !ok {
+				return
+			}
+			g.handleProcessEvent(pe)
+		case added := <-g.selector.AddedPIDsNotify():
+			g.handleSelectorAdd(added)
+		case removed := <-g.selector.RemovedNotify():
+			g.handleSelectorRemove(removed)
+		}
+	}
+}
+
+func (g *dynamicSignalProcessEventGate) handleProcessEvent(pe exec.ProcessEvent) {
+	pid := pe.File.Pid()
+	switch pe.Type {
+	case exec.ProcessEventCreated:
+		g.current[pid] = pe.File
+		if g.selector.IncludesPID(processEventSignalPID(pe.File)) {
+			g.forwarded[pid] = true
+			g.output.Send(pe)
+			return
+		}
+		g.forwarded[pid] = false
+	case exec.ProcessEventTerminated:
+		if g.forwarded[pid] {
+			g.output.Send(pe)
+		}
+		delete(g.current, pid)
+		delete(g.forwarded, pid)
+	}
+}
+
+func (g *dynamicSignalProcessEventGate) handleSelectorAdd(added []app.PID) {
+	if len(added) == 0 {
+		return
+	}
+	for _, signalPID := range added {
+		for pid, file := range g.current {
+			if g.forwarded[pid] || processEventSignalPID(file) != signalPID {
+				continue
+			}
+			g.forwarded[pid] = true
+			g.output.Send(exec.ProcessEvent{Type: exec.ProcessEventCreated, File: file})
+		}
+	}
+}
+
+func (g *dynamicSignalProcessEventGate) handleSelectorRemove(removed []app.PID) {
+	if len(removed) == 0 {
+		return
+	}
+	for _, signalPID := range removed {
+		for pid, file := range g.current {
+			if !g.forwarded[pid] || processEventSignalPID(file) != signalPID {
+				continue
+			}
+			g.forwarded[pid] = false
+			g.output.Send(exec.ProcessEvent{Type: exec.ProcessEventTerminated, File: file})
+		}
+	}
+}

--- a/pkg/appolly/dynamic_signal_gate_test.go
+++ b/pkg/appolly/dynamic_signal_gate_test.go
@@ -1,0 +1,120 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package appolly
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/appolly/discover"
+	execpkg "go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/internal/testutil"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+)
+
+const gateTestTimeout = time.Second
+
+func TestDynamicSignalSpanGate(t *testing.T) {
+	sel := discover.NewDynamicPIDSelector()
+	sel.Traces().AddPIDs(1)
+	sel.AppMetrics().AddPIDs(2)
+	sel.Traces().AddPIDs(3)
+	sel.AppMetrics().AddPIDs(3)
+
+	input := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(4))
+	output := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(4))
+	outCh := output.Subscribe()
+
+	runFn, err := DynamicSignalSpanGate(sel, input, output)(t.Context())
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go runFn(ctx)
+
+	input.Send([]request.Span{
+		{Service: svc.Attrs{ProcPID: 10, DynamicSelectorPID: 1}},
+		{Service: svc.Attrs{ProcPID: 20, DynamicSelectorPID: 2}},
+		{Service: svc.Attrs{ProcPID: 30, DynamicSelectorPID: 3}},
+	})
+
+	got := testutil.ReadChannel(t, outCh, gateTestTimeout)
+	require.Len(t, got, 3)
+	assert.False(t, request.IgnoreTraces(&got[0]))
+	assert.True(t, request.IgnoreMetrics(&got[0]))
+
+	assert.True(t, request.IgnoreTraces(&got[1]))
+	assert.False(t, request.IgnoreMetrics(&got[1]))
+
+	assert.False(t, request.IgnoreTraces(&got[2]))
+	assert.False(t, request.IgnoreMetrics(&got[2]))
+}
+
+func TestDynamicSignalProcessEventGate(t *testing.T) {
+	sel := discover.NewDynamicPIDSelector()
+	sel.Traces().AddPIDs(1)
+	sel.AppMetrics().AddPIDs(2)
+
+	input := msg.NewQueue[execpkg.ProcessEvent](msg.ChannelBufferLen(8))
+	output := msg.NewQueue[execpkg.ProcessEvent](msg.ChannelBufferLen(8))
+	outCh := output.Subscribe()
+
+	runFn, err := DynamicSignalProcessEventGate(sel, input, output)(t.Context())
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go runFn(ctx)
+
+	file1 := execpkg.New(execpkg.Init{
+		Service: svc.Attrs{ProcPID: 100, DynamicSelectorPID: 1},
+		Pid:     100,
+	})
+	file2 := execpkg.New(execpkg.Init{
+		Service: svc.Attrs{ProcPID: 200, DynamicSelectorPID: 2},
+		Pid:     200,
+	})
+	file3 := execpkg.New(execpkg.Init{
+		Service: svc.Attrs{ProcPID: 300, DynamicSelectorPID: 1},
+		Pid:     300,
+	})
+
+	input.Send(execpkg.ProcessEvent{Type: execpkg.ProcessEventCreated, File: file1})
+	input.Send(execpkg.ProcessEvent{Type: execpkg.ProcessEventCreated, File: file2})
+	input.Send(execpkg.ProcessEvent{Type: execpkg.ProcessEventCreated, File: file3})
+
+	got := testutil.ReadChannel(t, outCh, gateTestTimeout)
+	assert.Equal(t, app.PID(200), got.File.Pid())
+	testutil.ChannelEmpty(t, outCh, 100*time.Millisecond)
+
+	sel.AppMetrics().AddPIDs(1)
+	got = testutil.ReadChannel(t, outCh, gateTestTimeout)
+	got2 := testutil.ReadChannel(t, outCh, gateTestTimeout)
+	assert.Equal(t, execpkg.ProcessEventCreated, got.Type)
+	assert.Equal(t, execpkg.ProcessEventCreated, got2.Type)
+	assert.ElementsMatch(t, []app.PID{100, 300}, []app.PID{got.File.Pid(), got2.File.Pid()})
+
+	sel.AppMetrics().RemovePIDs(2)
+	got = testutil.ReadChannel(t, outCh, gateTestTimeout)
+	assert.Equal(t, execpkg.ProcessEventTerminated, got.Type)
+	assert.Equal(t, app.PID(200), got.File.Pid())
+}
+
+func TestDynamicSignalSpanGate_BypassWhenSelectorNil(t *testing.T) {
+	input := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(2))
+	output := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(2))
+	output.Subscribe()
+
+	runFn, err := DynamicSignalSpanGate(nil, input, output)(t.Context())
+	require.NoError(t, err)
+	go runFn(t.Context())
+
+	input.Send([]request.Span{{Service: svc.Attrs{ProcPID: 1}}})
+	time.Sleep(50 * time.Millisecond)
+}

--- a/pkg/appolly/dynamic_signal_gate_test.go
+++ b/pkg/appolly/dynamic_signal_gate_test.go
@@ -106,6 +106,43 @@ func TestDynamicSignalProcessEventGate(t *testing.T) {
 	assert.Equal(t, app.PID(200), got.File.Pid())
 }
 
+func TestDynamicSignalProcessEventGate_DuplicateCreateBeforeRemoveNotify(t *testing.T) {
+	sel := discover.NewDynamicPIDSelector()
+	sel.AppMetrics().AddPIDs(1)
+
+	output := msg.NewQueue[execpkg.ProcessEvent](msg.ChannelBufferLen(4))
+	outCh := output.Subscribe()
+
+	gate := &dynamicSignalProcessEventGate{
+		output:    output,
+		selector:  sel.AppMetrics(),
+		current:   map[app.PID]*execpkg.FileInfo{},
+		forwarded: map[app.PID]bool{},
+	}
+
+	file := execpkg.New(execpkg.Init{
+		Service: svc.Attrs{ProcPID: 100, DynamicSelectorPID: 1},
+		Pid:     100,
+	})
+
+	gate.handleProcessEvent(execpkg.ProcessEvent{Type: execpkg.ProcessEventCreated, File: file})
+	got := testutil.ReadChannel(t, outCh, gateTestTimeout)
+	assert.Equal(t, execpkg.ProcessEventCreated, got.Type)
+
+	sel.AppMetrics().RemovePIDs(1)
+
+	// Duplicate create (e.g. K8s re-enrichment) before RemovedNotify is processed.
+	gate.handleProcessEvent(execpkg.ProcessEvent{Type: execpkg.ProcessEventCreated, File: file})
+
+	assert.True(t, gate.forwarded[100], "duplicate create must not clear forwarded state")
+
+	gate.handleSelectorRemove([]app.PID{1})
+
+	got = testutil.ReadChannel(t, outCh, gateTestTimeout)
+	assert.Equal(t, execpkg.ProcessEventTerminated, got.Type)
+	assert.Equal(t, app.PID(100), got.File.Pid())
+}
+
 func TestDynamicSignalSpanGate_BypassWhenSelectorNil(t *testing.T) {
 	input := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(2))
 	output := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(2))

--- a/pkg/appolly/instrumenter.go
+++ b/pkg/appolly/instrumenter.go
@@ -115,13 +115,16 @@ func newGraphBuilder(
 	if exportableSpans == nil {
 		exportableSpans = msg2.QueueFromConfig[[]request.Span](config, "exportableSpans")
 	}
+	attrFilteredSpans := msg2.QueueFromConfig[[]request.Span](config, "attrFilteredSpans")
 	swi.Add(filter.ByAttribute(config.Filters.Application,
 		nil,
 		selectorCfg.ExtraGroupAttributesCfg,
 		spanPtrPromGetters(config),
 		nameResolverToAttrFilter,
-		exportableSpans),
+		attrFilteredSpans),
 		swarm.WithID("AttributesFilter"))
+	swi.Add(DynamicSignalSpanGate(ctxInfo.DynamicPIDSelector, attrFilteredSpans, exportableSpans),
+		swarm.WithID("DynamicSignalSpanGate"))
 
 	swi.Add(otel.TracesReceiver(
 		ctxInfo, config.Traces, config.SpanMetricsEnabledForTraces(), selectorCfg, exportableSpans,
@@ -130,7 +133,7 @@ func newGraphBuilder(
 		swarm.WithID("PrinterNode"))
 
 	// some nodes (ipNodesFilter, span name limiter...) are only passed to the metrics export nodes.
-	// Nodes directly handling raw traces will still get the unfiltered exportableSpans queue.
+	// The exportableSpans queue already carries any dynamic per-signal trace/metrics gating.
 	// If no metrics exporter is configured, we will not start the metrics subpipeline to save resources.
 	jointMetricsConfig := JoinMetricsConfig(config)
 	exportingMetrics := jointMetricsConfig.Features.AnyAppO11yMetric() &&
@@ -159,6 +162,10 @@ func setupMetricsSubPipeline(
 	jointMetricsConfig *perapp.MetricsConfig,
 	runtimeMetrics *msg.Queue[[]runtimemetrics.RuntimeMetricSnapshot],
 ) {
+	metricsProcessEvents := msg2.QueueFromConfig[exec.ProcessEvent](config, "metricsProcessEvents")
+	swi.Add(DynamicSignalProcessEventGate(ctxInfo.DynamicPIDSelector, processEventsCh, metricsProcessEvents),
+		swarm.WithID("DynamicSignalProcessEventGate"))
+
 	unresolvedCfg := request.UnresolvedNames{
 		Generic:  config.Attributes.RenameUnresolvedHosts,
 		Outgoing: config.Attributes.RenameUnresolvedHostsOutgoing,
@@ -183,7 +190,7 @@ func setupMetricsSubPipeline(
 			selectorCfg,
 			unresolvedCfg,
 			spanNameAggregatedMetrics,
-			processEventsCh,
+			metricsProcessEvents,
 		), swarm.WithID("OTELMetricsExport"))
 
 		swi.Add(otel.ReportSvcGraphMetrics(
@@ -192,7 +199,7 @@ func setupMetricsSubPipeline(
 			jointMetricsConfig,
 			unresolvedCfg,
 			spanNameAggregatedMetrics,
-			processEventsCh,
+			metricsProcessEvents,
 		), swarm.WithID("OTELSvcGraphMetricsExport"))
 	}
 
@@ -204,7 +211,7 @@ func setupMetricsSubPipeline(
 			selectorCfg,
 			unresolvedCfg,
 			spanNameAggregatedMetrics,
-			processEventsCh,
+			metricsProcessEvents,
 			runtimeMetrics,
 		), swarm.WithID("PrometheusEndpoint"))
 	}


### PR DESCRIPTION
## Summary

Implements phase 5 of https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2234

Previous PRs:
1. https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2250
2. https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2279
3. https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2340
4. https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2421

This adds the final signal split for app signals (metrics+traces) with 2 new filter nodes that are inserted in the trace and metrics pipelines

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
