### PR TITLE
Add internal metrics for events ringbuffer writes

### DIFF
--- a/bpf/common/ringbuf.h
+++ b/bpf/common/ringbuf.h
@@ -27,7 +27,6 @@ typedef struct ringbuf_write_count_t {
     u64 failed;
 } ringbuf_write_count;
 
-// Per-CPU counters of attempted and failed writes to the events ringbuffer.
 struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
     __type(key, u32);

--- a/bpf/common/ringbuf.h
+++ b/bpf/common/ringbuf.h
@@ -28,7 +28,6 @@ typedef struct ringbuf_write_count_t {
 } ringbuf_write_count;
 
 // Per-CPU counters of attempted and failed writes to the events ringbuffer.
-// OBI_PIN_INTERNAL, like events itself, so all tracers share one instance.
 struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
     __type(key, u32);

--- a/bpf/common/ringbuf.h
+++ b/bpf/common/ringbuf.h
@@ -22,6 +22,21 @@ struct {
     __uint(pinning, OBI_PIN_INTERNAL);
 } events SEC(".maps");
 
+typedef struct ringbuf_write_count_t {
+    u64 total;
+    u64 failed;
+} ringbuf_write_count;
+
+// Per-CPU counters of attempted and failed writes to the events ringbuffer.
+// OBI_PIN_INTERNAL, like events itself, so all tracers share one instance.
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, u32);
+    __type(value, ringbuf_write_count);
+    __uint(max_entries, 1);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} rb_write_stats SEC(".maps");
+
 // To be Injected from the user space during the eBPF program load & initialization
 volatile const u32 wakeup_data_bytes;
 
@@ -36,4 +51,19 @@ static __always_inline long get_flags() {
 
     const u64 sz = bpf_ringbuf_query(&events, BPF_RB_AVAIL_DATA);
     return sz >= wakeup_data_bytes ? BPF_RB_FORCE_WAKEUP : BPF_RB_NO_WAKEUP;
+}
+
+// Records one events-ringbuffer write attempt, flagged failed when the
+// reserve/output did not reach userspace. Call after each write on &events.
+static __always_inline void account_ringbuf_write(bool failed) {
+    const u32 key = 0;
+    ringbuf_write_count *stats = bpf_map_lookup_elem(&rb_write_stats, &key);
+    if (!stats) {
+        return;
+    }
+
+    stats->total++;
+    if (failed) {
+        stats->failed++;
+    }
 }

--- a/bpf/generictracer/dns.h
+++ b/bpf/generictracer/dns.h
@@ -189,6 +189,7 @@ static __always_inline u8 handle_dns(struct __sk_buff *skb,
         };
 
         dns_req_t *req = bpf_ringbuf_reserve(&events, sizeof(dns_req_t), 0);
+        account_ringbuf_write(req == NULL);
 
         if (req) {
             u32 len = skb->len - dns_off;
@@ -232,6 +233,7 @@ static __always_inline u8 handle_dns_buf(const unsigned char *buf,
         }
 
         dns_req_t *req = bpf_ringbuf_reserve(&events, sizeof(dns_req_t), 0);
+        account_ringbuf_write(req == NULL);
         if (req) {
             populate_dns_record(req, p_conn, orig_dport, size, qr, hdr.id, conn_pid);
 

--- a/bpf/generictracer/protocol_common.h
+++ b/bpf/generictracer/protocol_common.h
@@ -54,7 +54,9 @@ static __always_inline u32 large_buf_emit_chunks(tcp_large_buffer_t *large_buf,
         u32 total_size = sizeof(tcp_large_buffer_t) + payload_size;
         bpf_clamp_umax(total_size, k_large_buf_max_size);
 
-        if (bpf_ringbuf_output(&events, large_buf, total_size, get_flags()) != 0) {
+        const long rb_err = bpf_ringbuf_output(&events, large_buf, total_size, get_flags());
+        account_ringbuf_write(rb_err != 0);
+        if (rb_err != 0) {
             break;
         }
 

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -117,6 +117,7 @@ static __always_inline void finish_http(http_info_t *info, pid_connection_info_t
         info->submitted = 1;
         bpf_map_update_elem(&ongoing_http, pid_conn, info, BPF_ANY);
         http_info_t *trace = bpf_ringbuf_reserve(&events, sizeof(http_info_t), 0);
+        account_ringbuf_write(trace == NULL);
         if (trace) {
             bpf_dbg_printk("Sending trace %lx, response length %d", info, info->resp_len);
 

--- a/bpf/generictracer/protocol_http2.h
+++ b/bpf/generictracer/protocol_http2.h
@@ -287,6 +287,7 @@ http2_grpc_end(http2_conn_stream_t *stream, http2_grpc_request_t *prev_info, voi
         //dbg_print_http_connection_info(&stream->pid_conn.conn); // commented out since GitHub CI doesn't like this call
 
         http2_grpc_request_t *trace = bpf_ringbuf_reserve(&events, sizeof(http2_grpc_request_t), 0);
+        account_ringbuf_write(trace == NULL);
         if (trace) {
             bpf_probe_read(prev_info->ret_data, k_kprobes_http2_ret_buf_size, u_buf);
             __builtin_memcpy(trace, prev_info, sizeof(http2_grpc_request_t));

--- a/bpf/generictracer/protocol_kafka.h
+++ b/bpf/generictracer/protocol_kafka.h
@@ -400,7 +400,7 @@ static __always_inline int kafka_send_large_buffer(tcp_req_t *req,
         lb->len = k_kafka_hdr_message_size;
 
         const u32 total_size = sizeof(tcp_large_buffer_t) + sizeof(void *);
-        bpf_ringbuf_output(&events, lb, total_size, get_flags());
+        account_ringbuf_write(bpf_ringbuf_output(&events, lb, total_size, get_flags()) != 0);
 
         max_available_bytes -= k_kafka_hdr_message_size;
         consumed_bytes += k_kafka_hdr_message_size;

--- a/bpf/generictracer/protocol_mysql.h
+++ b/bpf/generictracer/protocol_mysql.h
@@ -181,7 +181,7 @@ static __always_inline int mysql_send_large_buffer(tcp_req_t *req,
 
         const u32 total_size = sizeof(tcp_large_buffer_t) + sizeof(void *);
 
-        bpf_ringbuf_output(&events, lb, total_size, get_flags());
+        account_ringbuf_write(bpf_ringbuf_output(&events, lb, total_size, get_flags()) != 0);
 
         lb->action = k_large_buf_action_append;
     }

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -143,7 +143,8 @@ static __always_inline void finish_ongoing_tcp_req(pid_connection_info_t *pid_co
         existing_tcp->resp_len = 0;
 
         bpf_dbg_printk("Sending pending TCP trace on close: len=%d", existing_tcp->len);
-        bpf_ringbuf_output(&events, existing_tcp, sizeof(*existing_tcp), get_flags());
+        account_ringbuf_write(
+            bpf_ringbuf_output(&events, existing_tcp, sizeof(*existing_tcp), get_flags()) != 0);
     }
 
     cleanup_trace_info(existing_tcp, pid_conn);
@@ -236,6 +237,7 @@ static __always_inline void failed_to_connect_event(pid_connection_info_t *pid_c
                                                     u16 orig_dport,
                                                     u64 connect_ts) {
     tcp_req_t *req = bpf_ringbuf_reserve(&events, sizeof(tcp_req_t), 0);
+    account_ringbuf_write(req == NULL);
     if (req) {
         pid_info pid = {};
         task_pid(&pid);
@@ -367,6 +369,7 @@ static __always_inline void handle_unknown_tcp_connection(pid_connection_info_t 
             existing->end_monotime_ns = bpf_ktime_get_ns();
             existing->resp_len = bytes_len;
             tcp_req_t *trace = bpf_ringbuf_reserve(&events, sizeof(tcp_req_t), 0);
+            account_ringbuf_write(trace == NULL);
             if (trace) {
                 bpf_dbg_printk("Sending TCP trace: existing=%lx, resp_length=%d",
                                existing,

--- a/pkg/export/imetrics/imetrics.go
+++ b/pkg/export/imetrics/imetrics.go
@@ -103,9 +103,9 @@ type Reporter interface {
 	// QueueBufferUtilization shows the ratio [0-1] between the unread messages of an internal Go channel
 	// and its total capacity
 	QueueBufferUtilization(subscriber string, ratio float64)
-	// BPFRingbufWriteStats sets the counters of how many writes to the events ringbuffer have been attempted
+	// BPFRingbufWriteStats sets the counters of how many writes to the given ringbuffer have been attempted
 	// vs how many of them failed because the buffer was full (the userspace reader couldn't keep up)
-	BPFRingbufWriteStats(total, failed uint64)
+	BPFRingbufWriteStats(ringbuf string, total, failed uint64)
 }
 
 func IsBuiltinNoopReporter(reporter Reporter) bool {
@@ -143,4 +143,4 @@ func (n NoopReporter) BpfInternalMetricsScrapeInterval() time.Duration   { retur
 func (n NoopReporter) InformerLag(_ float64)                             {}
 func (n NoopReporter) BPFPacketStats(_, _ uint64)                        {}
 func (n NoopReporter) QueueBufferUtilization(_ string, _ float64)        {}
-func (n NoopReporter) BPFRingbufWriteStats(_, _ uint64)                  {}
+func (n NoopReporter) BPFRingbufWriteStats(_ string, _, _ uint64)        {}

--- a/pkg/export/imetrics/imetrics.go
+++ b/pkg/export/imetrics/imetrics.go
@@ -103,6 +103,9 @@ type Reporter interface {
 	// QueueBufferUtilization shows the ratio [0-1] between the unread messages of an internal Go channel
 	// and its total capacity
 	QueueBufferUtilization(subscriber string, ratio float64)
+	// BPFRingbufWriteStats sets the counters of how many writes to the events ringbuffer have been attempted
+	// vs how many of them failed because the buffer was full (the userspace reader couldn't keep up)
+	BPFRingbufWriteStats(total, failed uint64)
 }
 
 func IsBuiltinNoopReporter(reporter Reporter) bool {
@@ -140,3 +143,4 @@ func (n NoopReporter) BpfInternalMetricsScrapeInterval() time.Duration   { retur
 func (n NoopReporter) InformerLag(_ float64)                             {}
 func (n NoopReporter) BPFPacketStats(_, _ uint64)                        {}
 func (n NoopReporter) QueueBufferUtilization(_ string, _ float64)        {}
+func (n NoopReporter) BPFRingbufWriteStats(_, _ uint64)                  {}

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -54,6 +54,11 @@ type PrometheusReporter struct {
 	bpfIgnoredPacketCount prometheus.Counter
 
 	queueCapacityRatio *prometheus.GaugeVec
+
+	totalRingbufWrites        uint64
+	totalRingbufWriteFailures uint64
+	bpfRingbufWriteCount      prometheus.Counter
+	bpfRingbufWriteFailures   prometheus.Counter
 }
 
 func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.PrometheusManager, registry *prometheus.Registry) *PrometheusReporter {
@@ -145,6 +150,14 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			Name: attr.VendorPrefix + "_queue_capacity_ratio",
 			Help: "Ratio [0-1] between the unread messages of an internal Go channel and its total capacity",
 		}, []string{"subscriber"}),
+		bpfRingbufWriteCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: attr.VendorPrefix + "_bpf_ringbuf_writes_total",
+			Help: "How many writes to the events ringbuffer from the generic tracer have been attempted",
+		}),
+		bpfRingbufWriteFailures: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: attr.VendorPrefix + "_bpf_ringbuf_write_failures_total",
+			Help: "How many writes to the events ringbuffer from the generic tracer failed because the buffer was full",
+		}),
 	}
 	if !cfg.AvoidedServices.Disabled {
 		pr.avoidedServicesLimiter = avoidedsvc.NewLimiter(cfg.AvoidedServices.Limit)
@@ -176,6 +189,8 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 		pr.bpfPacketCount,
 		pr.bpfIgnoredPacketCount,
 		pr.queueCapacityRatio,
+		pr.bpfRingbufWriteCount,
+		pr.bpfRingbufWriteFailures,
 	}
 	if pr.avoidedServices != nil {
 		metrics = append(metrics, pr.avoidedServices)
@@ -278,4 +293,10 @@ func (p *PrometheusReporter) BPFPacketStats(count, ignored uint64) {
 
 func (p *PrometheusReporter) QueueBufferUtilization(subscriber string, ratio float64) {
 	p.queueCapacityRatio.WithLabelValues(subscriber).Set(ratio)
+}
+
+func (p *PrometheusReporter) BPFRingbufWriteStats(total, failed uint64) {
+	p.bpfRingbufWriteCount.Add(float64(total - p.totalRingbufWrites))
+	p.bpfRingbufWriteFailures.Add(float64(failed - p.totalRingbufWriteFailures))
+	p.totalRingbufWrites, p.totalRingbufWriteFailures = total, failed
 }

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -152,7 +152,7 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 		}, []string{"subscriber"}),
 		bpfRingbufWriteCount: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: attr.VendorPrefix + "_bpf_ringbuf_writes_total",
-			Help: "How many writes to the ringbuffer from the generic tracer have been attempted",
+			Help: "How many writes to the named ringbuffer have been attempted",
 		}, []string{"ringbuf"}),
 		bpfRingbufWriteFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: attr.VendorPrefix + "_bpf_ringbuf_write_failures_total",

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -156,7 +156,7 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 		}, []string{"ringbuf"}),
 		bpfRingbufWriteFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: attr.VendorPrefix + "_bpf_ringbuf_write_failures_total",
-			Help: "How many writes to the ringbuffer from the generic tracer failed because the buffer was full",
+			Help: "How many writes to the named ringbuffer failed because the buffer was full",
 		}, []string{"ringbuf"}),
 		totalRingbufWrites:        map[string]uint64{},
 		totalRingbufWriteFailures: map[string]uint64{},

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -55,10 +55,10 @@ type PrometheusReporter struct {
 
 	queueCapacityRatio *prometheus.GaugeVec
 
-	totalRingbufWrites        uint64
-	totalRingbufWriteFailures uint64
-	bpfRingbufWriteCount      prometheus.Counter
-	bpfRingbufWriteFailures   prometheus.Counter
+	totalRingbufWrites        map[string]uint64
+	totalRingbufWriteFailures map[string]uint64
+	bpfRingbufWriteCount      *prometheus.CounterVec
+	bpfRingbufWriteFailures   *prometheus.CounterVec
 }
 
 func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.PrometheusManager, registry *prometheus.Registry) *PrometheusReporter {
@@ -150,14 +150,16 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			Name: attr.VendorPrefix + "_queue_capacity_ratio",
 			Help: "Ratio [0-1] between the unread messages of an internal Go channel and its total capacity",
 		}, []string{"subscriber"}),
-		bpfRingbufWriteCount: prometheus.NewCounter(prometheus.CounterOpts{
+		bpfRingbufWriteCount: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: attr.VendorPrefix + "_bpf_ringbuf_writes_total",
-			Help: "How many writes to the events ringbuffer from the generic tracer have been attempted",
-		}),
-		bpfRingbufWriteFailures: prometheus.NewCounter(prometheus.CounterOpts{
+			Help: "How many writes to the ringbuffer from the generic tracer have been attempted",
+		}, []string{"ringbuf"}),
+		bpfRingbufWriteFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: attr.VendorPrefix + "_bpf_ringbuf_write_failures_total",
-			Help: "How many writes to the events ringbuffer from the generic tracer failed because the buffer was full",
-		}),
+			Help: "How many writes to the ringbuffer from the generic tracer failed because the buffer was full",
+		}, []string{"ringbuf"}),
+		totalRingbufWrites:        map[string]uint64{},
+		totalRingbufWriteFailures: map[string]uint64{},
 	}
 	if !cfg.AvoidedServices.Disabled {
 		pr.avoidedServicesLimiter = avoidedsvc.NewLimiter(cfg.AvoidedServices.Limit)
@@ -295,8 +297,9 @@ func (p *PrometheusReporter) QueueBufferUtilization(subscriber string, ratio flo
 	p.queueCapacityRatio.WithLabelValues(subscriber).Set(ratio)
 }
 
-func (p *PrometheusReporter) BPFRingbufWriteStats(total, failed uint64) {
-	p.bpfRingbufWriteCount.Add(float64(total - p.totalRingbufWrites))
-	p.bpfRingbufWriteFailures.Add(float64(failed - p.totalRingbufWriteFailures))
-	p.totalRingbufWrites, p.totalRingbufWriteFailures = total, failed
+func (p *PrometheusReporter) BPFRingbufWriteStats(ringbuf string, total, failed uint64) {
+	p.bpfRingbufWriteCount.WithLabelValues(ringbuf).Add(float64(total - p.totalRingbufWrites[ringbuf]))
+	p.bpfRingbufWriteFailures.WithLabelValues(ringbuf).Add(float64(failed - p.totalRingbufWriteFailures[ringbuf]))
+	p.totalRingbufWrites[ringbuf] = total
+	p.totalRingbufWriteFailures[ringbuf] = failed
 }

--- a/pkg/export/imetrics/iprom_test.go
+++ b/pkg/export/imetrics/iprom_test.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package imetrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func counterValue(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, c.Write(&m))
+	return m.GetCounter().GetValue()
+}
+
+func TestPrometheusReporterBPFRingbufWriteStats(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	reporter := NewPrometheusReporter(&InternalMetricsConfig{}, nil, reg)
+
+	reporter.BPFRingbufWriteStats(10, 2)
+	assert.InDelta(t, 10, counterValue(t, reporter.bpfRingbufWriteCount), 0)
+	assert.InDelta(t, 2, counterValue(t, reporter.bpfRingbufWriteFailures), 0)
+
+	// The BPF counters are absolute running totals, so the reporter must record
+	// only the delta since the previous scrape, not the absolute value again.
+	reporter.BPFRingbufWriteStats(15, 5)
+	assert.InDelta(t, 15, counterValue(t, reporter.bpfRingbufWriteCount), 0)
+	assert.InDelta(t, 5, counterValue(t, reporter.bpfRingbufWriteFailures), 0)
+}

--- a/pkg/export/imetrics/iprom_test.go
+++ b/pkg/export/imetrics/iprom_test.go
@@ -23,13 +23,13 @@ func TestPrometheusReporterBPFRingbufWriteStats(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	reporter := NewPrometheusReporter(&InternalMetricsConfig{}, nil, reg)
 
-	reporter.BPFRingbufWriteStats(10, 2)
-	assert.InDelta(t, 10, counterValue(t, reporter.bpfRingbufWriteCount), 0)
-	assert.InDelta(t, 2, counterValue(t, reporter.bpfRingbufWriteFailures), 0)
+	reporter.BPFRingbufWriteStats("events", 10, 2)
+	assert.InDelta(t, 10, counterValue(t, reporter.bpfRingbufWriteCount.WithLabelValues("events")), 0)
+	assert.InDelta(t, 2, counterValue(t, reporter.bpfRingbufWriteFailures.WithLabelValues("events")), 0)
 
 	// The BPF counters are absolute running totals, so the reporter must record
 	// only the delta since the previous scrape, not the absolute value again.
-	reporter.BPFRingbufWriteStats(15, 5)
-	assert.InDelta(t, 15, counterValue(t, reporter.bpfRingbufWriteCount), 0)
-	assert.InDelta(t, 5, counterValue(t, reporter.bpfRingbufWriteFailures), 0)
+	reporter.BPFRingbufWriteStats("events", 15, 5)
+	assert.InDelta(t, 15, counterValue(t, reporter.bpfRingbufWriteCount.WithLabelValues("events")), 0)
+	assert.InDelta(t, 5, counterValue(t, reporter.bpfRingbufWriteFailures.WithLabelValues("events")), 0)
 }

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -52,6 +52,11 @@ type InternalMetricsReporter struct {
 	bpfIgnoredPacketCount instrument.Int64Counter
 
 	queueCapacityRatio instrument.Float64Gauge
+
+	totalRingbufWrites        uint64
+	totalRingbufWriteFailures uint64
+	bpfRingbufWriteCount      instrument.Int64Counter
+	bpfRingbufWriteFailures   instrument.Int64Counter
 }
 
 func imlog() *slog.Logger {
@@ -217,6 +222,24 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		return nil, err
 	}
 
+	bpfRingbufWriteCount, err := meter.Int64Counter(
+		attr.VendorPrefix+".bpf.ringbuf.writes.total",
+		instrument.WithDescription("How many writes to the events ringbuffer from the generic tracer have been attempted"),
+		instrument.WithUnit("{write}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	bpfRingbufWriteFailures, err := meter.Int64Counter(
+		attr.VendorPrefix+".bpf.ringbuf.write.failures.total",
+		instrument.WithDescription("How many writes to the events ringbuffer from the generic tracer failed because the buffer was full"),
+		instrument.WithUnit("{write}"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &InternalMetricsReporter{
 		ctx:                              ctx,
 		tracerFlushes:                    tracerFlushes,
@@ -238,6 +261,8 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		bpfPacketCount:                   bpfPacketCount,
 		bpfIgnoredPacketCount:            bpfIgnoredPacketCount,
 		queueCapacityRatio:               queueCapacityRatio,
+		bpfRingbufWriteCount:             bpfRingbufWriteCount,
+		bpfRingbufWriteFailures:          bpfRingbufWriteFailures,
 	}, nil
 }
 
@@ -384,4 +409,10 @@ func (p *InternalMetricsReporter) BPFPacketStats(count, ignored uint64) {
 
 func (p *InternalMetricsReporter) QueueBufferUtilization(subscriber string, ratio float64) {
 	p.queueCapacityRatio.Record(p.ctx, ratio, instrument.WithAttributes(attribute.String("subscriber", subscriber)))
+}
+
+func (p *InternalMetricsReporter) BPFRingbufWriteStats(total, failed uint64) {
+	p.bpfRingbufWriteCount.Add(p.ctx, int64(total-p.totalRingbufWrites))
+	p.bpfRingbufWriteFailures.Add(p.ctx, int64(failed-p.totalRingbufWriteFailures))
+	p.totalRingbufWrites, p.totalRingbufWriteFailures = total, failed
 }

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -233,7 +233,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 
 	bpfRingbufWriteFailures, err := meter.Int64Counter(
 		attr.VendorPrefix+".bpf.ringbuf.write.failures.total",
-		instrument.WithDescription("How many writes to the ringbuffer from the generic tracer failed because the buffer was full"),
+		instrument.WithDescription("How many writes to the named ringbuffer failed because the buffer was full"),
 		instrument.WithUnit("{write}"),
 	)
 	if err != nil {

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -53,8 +53,8 @@ type InternalMetricsReporter struct {
 
 	queueCapacityRatio instrument.Float64Gauge
 
-	totalRingbufWrites        uint64
-	totalRingbufWriteFailures uint64
+	totalRingbufWrites        map[string]uint64
+	totalRingbufWriteFailures map[string]uint64
 	bpfRingbufWriteCount      instrument.Int64Counter
 	bpfRingbufWriteFailures   instrument.Int64Counter
 }
@@ -224,7 +224,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 
 	bpfRingbufWriteCount, err := meter.Int64Counter(
 		attr.VendorPrefix+".bpf.ringbuf.writes.total",
-		instrument.WithDescription("How many writes to the events ringbuffer from the generic tracer have been attempted"),
+		instrument.WithDescription("How many writes to the ringbuffer from the generic tracer have been attempted"),
 		instrument.WithUnit("{write}"),
 	)
 	if err != nil {
@@ -233,7 +233,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 
 	bpfRingbufWriteFailures, err := meter.Int64Counter(
 		attr.VendorPrefix+".bpf.ringbuf.write.failures.total",
-		instrument.WithDescription("How many writes to the events ringbuffer from the generic tracer failed because the buffer was full"),
+		instrument.WithDescription("How many writes to the ringbuffer from the generic tracer failed because the buffer was full"),
 		instrument.WithUnit("{write}"),
 	)
 	if err != nil {
@@ -263,6 +263,8 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		queueCapacityRatio:               queueCapacityRatio,
 		bpfRingbufWriteCount:             bpfRingbufWriteCount,
 		bpfRingbufWriteFailures:          bpfRingbufWriteFailures,
+		totalRingbufWrites:               map[string]uint64{},
+		totalRingbufWriteFailures:        map[string]uint64{},
 	}, nil
 }
 
@@ -411,8 +413,10 @@ func (p *InternalMetricsReporter) QueueBufferUtilization(subscriber string, rati
 	p.queueCapacityRatio.Record(p.ctx, ratio, instrument.WithAttributes(attribute.String("subscriber", subscriber)))
 }
 
-func (p *InternalMetricsReporter) BPFRingbufWriteStats(total, failed uint64) {
-	p.bpfRingbufWriteCount.Add(p.ctx, int64(total-p.totalRingbufWrites))
-	p.bpfRingbufWriteFailures.Add(p.ctx, int64(failed-p.totalRingbufWriteFailures))
-	p.totalRingbufWrites, p.totalRingbufWriteFailures = total, failed
+func (p *InternalMetricsReporter) BPFRingbufWriteStats(ringbuf string, total, failed uint64) {
+	attrs := instrument.WithAttributes(attribute.String("ringbuf", ringbuf))
+	p.bpfRingbufWriteCount.Add(p.ctx, int64(total-p.totalRingbufWrites[ringbuf]), attrs)
+	p.bpfRingbufWriteFailures.Add(p.ctx, int64(failed-p.totalRingbufWriteFailures[ringbuf]), attrs)
+	p.totalRingbufWrites[ringbuf] = total
+	p.totalRingbufWriteFailures[ringbuf] = failed
 }

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -224,7 +224,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 
 	bpfRingbufWriteCount, err := meter.Int64Counter(
 		attr.VendorPrefix+".bpf.ringbuf.writes.total",
-		instrument.WithDescription("How many writes to the ringbuffer from the generic tracer have been attempted"),
+		instrument.WithDescription("How many writes to the named ringbuffer have been attempted"),
 		instrument.WithUnit("{write}"),
 	)
 	if err != nil {

--- a/pkg/export/otel/metrics_internal_test.go
+++ b/pkg/export/otel/metrics_internal_test.go
@@ -210,3 +210,43 @@ func readNMetricsByName(
 
 	return records
 }
+
+func TestInternalMetricsReporterBPFRingbufWriteStats(t *testing.T) {
+	metricRecords := make(chan collector.MetricRecord, 16)
+	mcfg := &otelcfg.MetricsConfig{
+		Interval:        10 * time.Millisecond,
+		MetricsConsumer: testMetricsConsumer(metricRecords),
+	}
+	ctxInfo := &global.ContextInfo{
+		NodeMeta:            meta.NodeMeta{HostID: "test-host"},
+		OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg},
+	}
+
+	reporter, err := NewInternalMetricsReporter(
+		t.Context(),
+		ctxInfo,
+		mcfg,
+		&imetrics.InternalMetricsConfig{BpfMetricScrapeInterval: time.Millisecond},
+	)
+	require.NoError(t, err)
+
+	reporter.BPFRingbufWriteStats(10, 2)
+
+	records := readMetricsByName(t, metricRecords, time.Second,
+		attr.VendorPrefix+".bpf.ringbuf.writes.total",
+		attr.VendorPrefix+".bpf.ringbuf.write.failures.total",
+	)
+	assert.Len(t, records, 2)
+
+	expected := map[string]int64{
+		attr.VendorPrefix + ".bpf.ringbuf.writes.total":         10,
+		attr.VendorPrefix + ".bpf.ringbuf.write.failures.total": 2,
+	}
+	for _, record := range records {
+		want, ok := expected[record.Name]
+		require.True(t, ok, "unexpected metric %q", record.Name)
+		assert.Equal(t, want, record.IntVal)
+		delete(expected, record.Name)
+	}
+	assert.Empty(t, expected)
+}

--- a/pkg/export/otel/metrics_internal_test.go
+++ b/pkg/export/otel/metrics_internal_test.go
@@ -230,7 +230,7 @@ func TestInternalMetricsReporterBPFRingbufWriteStats(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	reporter.BPFRingbufWriteStats(10, 2)
+	reporter.BPFRingbufWriteStats("events", 10, 2)
 
 	records := readMetricsByName(t, metricRecords, time.Second,
 		attr.VendorPrefix+".bpf.ringbuf.writes.total",
@@ -246,6 +246,7 @@ func TestInternalMetricsReporterBPFRingbufWriteStats(t *testing.T) {
 		want, ok := expected[record.Name]
 		require.True(t, ok, "unexpected metric %q", record.Name)
 		assert.Equal(t, want, record.IntVal)
+		assert.Equal(t, "events", record.Attributes["ringbuf"])
 		delete(expected, record.Name)
 	}
 	assert.Empty(t, expected)

--- a/pkg/export/prom/prom_bpf.go
+++ b/pkg/export/prom/prom_bpf.go
@@ -36,6 +36,10 @@ type BPFCollector struct {
 	probeMetrics     func() []ProbeMetrics
 	mapMetrics       func() []BpfMapMetrics
 	mu               sync.Mutex
+
+	// populated by getMapMetrics under mu, as a side effect of the map scan
+	ringbufWrites   ringbufWriteCount
+	ringbufWritesOK bool
 }
 
 type BPFProgram struct {
@@ -177,7 +181,7 @@ func (bc *BPFCollector) collectInternalMetrics(ctx context.Context) {
 			return
 
 		case <-ticker.C:
-			probeMetrics, mapMetrics := bc.collectMetrics()
+			probeMetrics, mapMetrics, ringbufWrites, ringbufWritesOK := bc.collectMetrics()
 			for _, metric := range probeMetrics {
 				if metric.count == 0 {
 					continue
@@ -196,8 +200,39 @@ func (bc *BPFCollector) collectInternalMetrics(ctx context.Context) {
 				bc.ctxInfo.Metrics.BpfMapEntries(metric.mapID, metric.mapName, metric.mapType, int(metric.entries))
 				bc.ctxInfo.Metrics.BpfMapMaxEntries(metric.mapID, metric.mapName, metric.mapType, metric.maxEntries)
 			}
+
+			if ringbufWritesOK {
+				bc.ctxInfo.Metrics.BPFRingbufWriteStats(ringbufWrites.Total, ringbufWrites.Failed)
+			}
 		}
 	}
+}
+
+// BPF map names are truncated to 15 chars in the kernel; keep within that.
+const ringbufWriteStatsMapName = "rb_write_stats"
+
+type ringbufWriteCount struct {
+	Total  uint64
+	Failed uint64
+}
+
+// sumRingbufWriteStats sums the shared rb_write_stats per-CPU map onto the
+// collector. Called from getMapMetrics so it reuses the existing map scan.
+func (bc *BPFCollector) sumRingbufWriteStats(m *ebpf.Map) {
+	var perCPU []ringbufWriteCount
+	if err := m.Lookup(uint32(0), &perCPU); err != nil {
+		bc.log.Debug("failed to read ringbuf write stats", "error", err)
+		return
+	}
+
+	var sum ringbufWriteCount
+	for _, c := range perCPU {
+		sum.Total += c.Total
+		sum.Failed += c.Failed
+	}
+
+	bc.ringbufWrites = sum
+	bc.ringbufWritesOK = true
 }
 
 func (bc *BPFCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -238,11 +273,15 @@ func (bc *BPFCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (bc *BPFCollector) collectMetrics() ([]ProbeMetrics, []BpfMapMetrics) {
+func (bc *BPFCollector) collectMetrics() ([]ProbeMetrics, []BpfMapMetrics, ringbufWriteCount, bool) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
-	return bc.probeMetrics(), bc.mapMetrics()
+	// mapMetrics() populates ringbufWrites/ringbufWritesOK as a side effect.
+	probeMetrics := bc.probeMetrics()
+	mapMetrics := bc.mapMetrics()
+
+	return probeMetrics, mapMetrics, bc.ringbufWrites, bc.ringbufWritesOK
 }
 
 func (bc *BPFCollector) getProbeMetrics() []ProbeMetrics {
@@ -332,6 +371,7 @@ func getFuncName(info *ebpf.ProgramInfo, id ebpf.ProgramID, log *slog.Logger) st
 }
 
 func (bc *BPFCollector) getMapMetrics() []BpfMapMetrics {
+	bc.ringbufWritesOK = false
 	mapMetrics := make([]BpfMapMetrics, 0)
 	for id := ebpf.MapID(0); ; {
 		nextID, err := ebpf.MapGetNextID(id)
@@ -350,6 +390,11 @@ func (bc *BPFCollector) getMapMetrics() []BpfMapMetrics {
 		info, err := m.Info()
 		if err != nil {
 			bc.log.Debug("failed to get map info", "ID", id, "error", err)
+			continue
+		}
+
+		if info.Name == ringbufWriteStatsMapName {
+			bc.sumRingbufWriteStats(m)
 			continue
 		}
 

--- a/pkg/export/prom/prom_bpf.go
+++ b/pkg/export/prom/prom_bpf.go
@@ -202,13 +202,12 @@ func (bc *BPFCollector) collectInternalMetrics(ctx context.Context) {
 			}
 
 			if ringbufWritesOK {
-				bc.ctxInfo.Metrics.BPFRingbufWriteStats(ringbufWrites.Total, ringbufWrites.Failed)
+				bc.ctxInfo.Metrics.BPFRingbufWriteStats("events", ringbufWrites.Total, ringbufWrites.Failed)
 			}
 		}
 	}
 }
 
-// BPF map names are truncated to 15 chars in the kernel; keep within that.
 const ringbufWriteStatsMapName = "rb_write_stats"
 
 type ringbufWriteCount struct {

--- a/pkg/export/prom/prom_bpf.go
+++ b/pkg/export/prom/prom_bpf.go
@@ -37,7 +37,6 @@ type BPFCollector struct {
 	mapMetrics       func() []BpfMapMetrics
 	mu               sync.Mutex
 
-	// populated by getMapMetrics under mu, as a side effect of the map scan
 	ringbufWrites   ringbufWriteCount
 	ringbufWritesOK bool
 }


### PR DESCRIPTION
## Summary

Part of #1969.

Under load, OBI's eBPF probes can produce span events faster than the userspace reader drains the `events` ringbuffer. When that happens the buffer fills and writes are silently dropped, with no signal that telemetry is being lost.

This adds two internal metrics that count writes to the `events` ringbuffer and how many of them failed because the buffer was full, so operators can detect when the reader is falling behind:

- Prometheus: `obi_bpf_ringbuf_writes_total`, `obi_bpf_ringbuf_write_failures_total`
- OTEL: `obi.bpf.ringbuf.writes.total`, `obi.bpf.ringbuf.write.failures.total`

## Scope

Only the generic tracer's `events` write sites are instrumented here; the metric descriptions say "from the generic tracer" so the counters aren't read as covering every write. The Go tracers write to the same shared map and can be wired through the same helper in a follow-up.

## Details

- A per-CPU map (`rb_write_stats`) holds attempted and failed write counts. It sits next to the `events` map in `bpf/common/ringbuf.h` and is `OBI_PIN_INTERNAL`, so all tracers share one instance.
- A helper, `account_ringbuf_write(failed)`, is called at each generic-tracer write site: `failed` is `bpf_ringbuf_reserve` returning `NULL`, or `bpf_ringbuf_output` returning non-zero.
- The internal-metrics scrape loop reads the map (folded into the existing per-map scan), sums the per-CPU counters, and forwards them through a new `BPFRingbufWriteStats` method on `imetrics.Reporter`.
- Both exporters implement it, converting the absolute BPF counters to deltas — the same approach as the existing `BPFPacketStats`.

Follows the process from #1969: new method on the `imetrics` interface (and `NoopReporter`), integrate it, then add the metric to both exporters in their respective formats (`snake_case` for Prometheus, `dot.format` for OTEL).

## Validation

- [x] I have read and followed the contributing guidelines
- [x] N/A — internal self-metrics, not a core user-facing feature; the existing internal metrics aren't documented in features.md / SUPPORT_MATRIX, so nothing to update there

Built and tested locally (Fedora, podman):
- `make docker-generate`, `make compile`
- `make test` (full `-short -race ./...` — all packages green, incl. the new ringbuf reporter tests)
- `make lint`
- `clang-format` / `clang-tidy` on the changed `bpf/` files