### PR TITLE
(DynamicSelector) Support dynamic resource attributes

### DIFF
--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -79,6 +79,8 @@ type traceAttacher struct {
 
 	// Is able to find process lifetime duration
 	processAgeFunc func(app.PID) time.Duration
+
+	DynamicPIDSelector *DynamicPIDSelector
 }
 
 func traceAttacherProvider(ta *traceAttacher) swarm.InstanceFunc {
@@ -368,6 +370,10 @@ func (ta *traceAttacher) updateTracerProbes(tracer *ebpf.ProcessTracer, ie *ebpf
 func (ta *traceAttacher) monitorPIDs(tracer *ebpf.ProcessTracer, ie *ebpf.Instrumentable) {
 	ie.CopyToServiceAttributes()
 
+	if ta.DynamicPIDSelector != nil {
+		ta.registerDynamicFileInfo(ie)
+	}
+
 	// allowing the tracer to forward traces from the discovered PID and its children processes
 	tracer.AllowPID(ie.FileInfo.Pid(), ie.FileInfo.Ns(), ie.FileInfo)
 	for _, pid := range ie.ChildPids {
@@ -406,7 +412,35 @@ func (ta *traceAttacher) monitorPIDs(tracer *ebpf.ProcessTracer, ie *ebpf.Instru
 	}
 }
 
+func (ta *traceAttacher) registerDynamicFileInfo(ie *ebpf.Instrumentable) {
+	owner := ie.FileInfo.ServiceAttrs().DynamicSelectorPID
+	if owner == 0 {
+		owner = ie.FileInfo.Pid()
+	}
+	ta.DynamicPIDSelector.RegisterFileInfo(owner, ie.FileInfo)
+	ta.DynamicPIDSelector.RegisterFileInfo(ie.FileInfo.Pid(), ie.FileInfo)
+	for _, pid := range ie.ChildPids {
+		ta.DynamicPIDSelector.RegisterFileInfo(pid, ie.FileInfo)
+	}
+}
+
+func (ta *traceAttacher) unregisterDynamicFileInfo(ie *ebpf.Instrumentable) {
+	if ta.DynamicPIDSelector == nil {
+		return
+	}
+	owner := ie.FileInfo.ServiceAttrs().DynamicSelectorPID
+	if owner == 0 {
+		owner = ie.FileInfo.Pid()
+	}
+	ta.DynamicPIDSelector.UnregisterFileInfo(owner, ie.FileInfo)
+	ta.DynamicPIDSelector.UnregisterFileInfo(ie.FileInfo.Pid(), ie.FileInfo)
+	for _, pid := range ie.ChildPids {
+		ta.DynamicPIDSelector.UnregisterFileInfo(pid, ie.FileInfo)
+	}
+}
+
 func (ta *traceAttacher) notifyProcessDeletion(ie *ebpf.Instrumentable) {
+	ta.unregisterDynamicFileInfo(ie)
 	if tracer, ok := ta.existingTracers[ie.FileInfo.Ino()]; ok {
 		ta.log.Info("process ended for already instrumented executable",
 			"cmd", ie.FileInfo.CmdExePath(),

--- a/pkg/appolly/discover/dynamic_pid_selector.go
+++ b/pkg/appolly/discover/dynamic_pid_selector.go
@@ -5,11 +5,13 @@ package discover // import "go.opentelemetry.io/obi/pkg/appolly/discover"
 
 import (
 	"iter"
+	"maps"
 	"slices"
 	"sync"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 	"go.opentelemetry.io/obi/pkg/selection"
 )
@@ -27,6 +29,19 @@ const (
 	appSignalMask dynamicPIDSignal = signalTraces | signalAppMetrics
 	allSignalMask dynamicPIDSignal = appSignalMask | signalNetworkMetrics | signalStatsMetrics
 )
+
+// TODO: support per-signal attribute overrides; attributes are currently shared across all signals.
+
+type dynamicPIDAttributes struct {
+	serviceName        string
+	serviceNamespace   string
+	resourceAttributes map[string]string
+}
+
+type dynamicPIDRecord struct {
+	signals dynamicPIDSignal
+	attrs   dynamicPIDAttributes
+}
 
 type dynamicPIDNotifier struct {
 	addedCh   chan []app.PID
@@ -106,7 +121,11 @@ type dynamicPIDSignalView struct {
 }
 
 func (v *dynamicPIDSignalView) AddPIDs(pids ...uint32) {
-	v.parent.addSignals(v.mask, pids...)
+	v.parent.addSignals(v.mask, nil, pids...)
+}
+
+func (v *dynamicPIDSignalView) AddPID(pid uint32, opts selection.DynamicPIDOptions) {
+	v.parent.addSignals(v.mask, &opts, pid)
 }
 
 func (v *dynamicPIDSignalView) RemovePIDs(pids ...uint32) {
@@ -129,16 +148,25 @@ func (v *dynamicPIDSignalView) RemovedNotify() <-chan []app.PID {
 	return v.notifier.removedCh
 }
 
+// SelectorForPID returns a services.Selector for pid when it is in this view, carrying the
+// PID's shared service name and resource attributes.
+func (v *dynamicPIDSignalView) SelectorForPID(pid app.PID) services.Selector {
+	if !v.IncludesPID(pid) {
+		return nil
+	}
+	return v.parent.selectorForPID(pid)
+}
+
 // AsSelector returns a services.Selector that matches when the process PID is in this dynamic view.
 func (v *dynamicPIDSignalView) AsSelector() services.Selector {
-	return &dynamicPIDCriteriaAdapter{selector: v}
+	return &dynamicPIDCriteriaAdapter{view: v}
 }
 
 // DynamicPIDSelector holds one runtime selector object with per-signal PID views. The root Add/Remove
 // methods preserve legacy behavior by applying to all supported signals.
 type DynamicPIDSelector struct {
 	mu    sync.RWMutex
-	byPID map[app.PID]dynamicPIDSignal
+	byPID map[app.PID]dynamicPIDRecord
 
 	rootView           dynamicPIDSignalView
 	tracesView         dynamicPIDSignalView
@@ -161,7 +189,7 @@ func newDynamicPIDSignalView(parent *DynamicPIDSelector, mask dynamicPIDSignal) 
 // NewDynamicPIDSelector creates a new selector whose root Add/Remove methods apply to all signals.
 func NewDynamicPIDSelector() *DynamicPIDSelector {
 	d := &DynamicPIDSelector{
-		byPID: map[app.PID]dynamicPIDSignal{},
+		byPID: map[app.PID]dynamicPIDRecord{},
 	}
 	d.rootView = newDynamicPIDSignalView(d, allSignalMask)
 	d.tracesView = newDynamicPIDSignalView(d, signalTraces)
@@ -183,7 +211,7 @@ func (d *DynamicPIDSelector) views() []*dynamicPIDSignalView {
 	}
 }
 
-func (d *DynamicPIDSelector) addSignals(mask dynamicPIDSignal, pids ...uint32) {
+func (d *DynamicPIDSelector) addSignals(mask dynamicPIDSignal, opts *selection.DynamicPIDOptions, pids ...uint32) {
 	if len(pids) == 0 {
 		return
 	}
@@ -192,12 +220,23 @@ func (d *DynamicPIDSelector) addSignals(mask dynamicPIDSignal, pids ...uint32) {
 	d.mu.Lock()
 	for _, rawPID := range pids {
 		pid := app.PID(rawPID)
-		oldMask := d.byPID[pid]
+		rec := d.byPID[pid]
+		oldMask := rec.signals
+
+		if opts != nil {
+			rec.attrs = attrsFromOptions(*opts)
+		}
+
 		newMask := oldMask | mask
 		if newMask == oldMask {
+			if opts != nil {
+				d.byPID[pid] = rec
+			}
 			continue
 		}
-		d.byPID[pid] = newMask
+		rec.signals = newMask
+		d.byPID[pid] = rec
+
 		for _, view := range d.views() {
 			if !view.contains(oldMask) && view.contains(newMask) {
 				addedByView[view] = append(addedByView[view], pid)
@@ -220,10 +259,11 @@ func (d *DynamicPIDSelector) removeSignals(mask dynamicPIDSignal, pids ...uint32
 	d.mu.Lock()
 	for _, rawPID := range pids {
 		pid := app.PID(rawPID)
-		oldMask, ok := d.byPID[pid]
+		rec, ok := d.byPID[pid]
 		if !ok {
 			continue
 		}
+		oldMask := rec.signals
 		newMask := oldMask &^ mask
 		if newMask == oldMask {
 			continue
@@ -231,7 +271,8 @@ func (d *DynamicPIDSelector) removeSignals(mask dynamicPIDSignal, pids ...uint32
 		if newMask == 0 {
 			delete(d.byPID, pid)
 		} else {
-			d.byPID[pid] = newMask
+			rec.signals = newMask
+			d.byPID[pid] = rec
 		}
 		for _, view := range d.views() {
 			if view.contains(oldMask) && !view.contains(newMask) {
@@ -253,8 +294,8 @@ func (d *DynamicPIDSelector) getPIDs(mask dynamicPIDSignal) ([]app.PID, bool) {
 		return nil, false
 	}
 	out := make([]app.PID, 0, len(d.byPID))
-	for pid, signals := range d.byPID {
-		if signals&mask != 0 {
+	for pid, rec := range d.byPID {
+		if rec.signals&mask != 0 {
 			out = append(out, pid)
 		}
 	}
@@ -268,11 +309,51 @@ func (d *DynamicPIDSelector) getPIDs(mask dynamicPIDSignal) ([]app.PID, bool) {
 func (d *DynamicPIDSelector) includesPID(mask dynamicPIDSignal, pid app.PID) bool {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	return d.byPID[pid]&mask != 0
+	return d.byPID[pid].signals&mask != 0
+}
+
+func (d *DynamicPIDSelector) selectorForPID(pid app.PID) services.Selector {
+	d.mu.RLock()
+	rec, ok := d.byPID[pid]
+	d.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	return newDynamicPIDCriteriaAdapter(pid, rec.attrs)
+}
+
+// GetPID returns the shared attributes for a tracked PID.
+func (d *DynamicPIDSelector) GetPID(pid uint32) (selection.DynamicPIDEntry, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	rec, ok := d.byPID[app.PID(pid)]
+	if !ok {
+		return selection.DynamicPIDEntry{}, false
+	}
+	return entryFromRecord(app.PID(pid), rec.attrs), true
+}
+
+// SetPID updates shared attributes for a PID that is already tracked by the selector.
+func (d *DynamicPIDSelector) SetPID(entry selection.DynamicPIDEntry) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.byPID[entry.PID]; !ok {
+		return false
+	}
+	d.byPID[entry.PID] = dynamicPIDRecord{
+		signals: d.byPID[entry.PID].signals,
+		attrs:   attrsFromEntry(entry),
+	}
+	return true
 }
 
 func (v *dynamicPIDSignalView) contains(mask dynamicPIDSignal) bool {
 	return mask&v.mask != 0
+}
+
+// AddPID adds a PID to all supported signals with optional shared attributes.
+func (d *DynamicPIDSelector) AddPID(pid uint32, opts selection.DynamicPIDOptions) {
+	d.rootView.AddPID(pid, opts)
 }
 
 // AddPIDs adds PIDs to all supported signals (legacy root behavior).
@@ -334,20 +415,47 @@ func (d *DynamicPIDSelector) AsSelector() services.Selector {
 	return d.rootView.AsSelector()
 }
 
-// dynamicPIDCriteriaAdapter implements services.Selector by delegating only GetPIDs to a runtime PID selector.
-type dynamicPIDCriteriaAdapter struct {
-	selector selection.PIDSelector
+// ResourceAttributesFromSelector returns resource attributes configured on a dynamic PID
+// selector criteria, or nil when the selector is not from DynamicPIDSelector.
+func ResourceAttributesFromSelector(selector services.Selector) map[attr.Name]string {
+	adapter, ok := selector.(*dynamicPIDCriteriaAdapter)
+	if !ok || len(adapter.attrs.resourceAttributes) == 0 {
+		return nil
+	}
+	out := make(map[attr.Name]string, len(adapter.attrs.resourceAttributes))
+	for k, v := range adapter.attrs.resourceAttributes {
+		out[attr.Name(k)] = v
+	}
+	return out
 }
 
-func (a *dynamicPIDCriteriaAdapter) GetName() string                       { return "" }
-func (a *dynamicPIDCriteriaAdapter) GetNamespace() string                  { return "" }
-func (a *dynamicPIDCriteriaAdapter) GetPath() services.StringMatcher       { return &emptyMatcher{} }
+// dynamicPIDCriteriaAdapter implements services.Selector for a dynamically selected PID.
+type dynamicPIDCriteriaAdapter struct {
+	pid   app.PID
+	attrs dynamicPIDAttributes
+	view  *dynamicPIDSignalView
+}
+
+func newDynamicPIDCriteriaAdapter(pid app.PID, attrs dynamicPIDAttributes) *dynamicPIDCriteriaAdapter {
+	return &dynamicPIDCriteriaAdapter{pid: pid, attrs: cloneAttrs(attrs)}
+}
+
+func (a *dynamicPIDCriteriaAdapter) GetName() string      { return a.attrs.serviceName }
+func (a *dynamicPIDCriteriaAdapter) GetNamespace() string { return a.attrs.serviceNamespace }
+func (a *dynamicPIDCriteriaAdapter) GetPath() services.StringMatcher {
+	return &emptyMatcher{}
+}
 func (a *dynamicPIDCriteriaAdapter) GetPathRegexp() services.StringMatcher { return &emptyMatcher{} }
 func (a *dynamicPIDCriteriaAdapter) GetOpenPorts() *services.IntEnum       { return &services.IntEnum{} }
 func (a *dynamicPIDCriteriaAdapter) GetLanguages() services.StringMatcher  { return &emptyMatcher{} }
-func (a *dynamicPIDCriteriaAdapter) GetPIDs() ([]app.PID, bool)            { return a.selector.GetPIDs() }
-func (a *dynamicPIDCriteriaAdapter) GetCmdArgs() services.StringMatcher    { return &emptyMatcher{} }
-func (a *dynamicPIDCriteriaAdapter) IsContainersOnly() bool                { return false }
+func (a *dynamicPIDCriteriaAdapter) GetPIDs() ([]app.PID, bool) {
+	if a.view != nil {
+		return a.view.GetPIDs()
+	}
+	return []app.PID{a.pid}, true
+}
+func (a *dynamicPIDCriteriaAdapter) GetCmdArgs() services.StringMatcher { return &emptyMatcher{} }
+func (a *dynamicPIDCriteriaAdapter) IsContainersOnly() bool             { return false }
 func (a *dynamicPIDCriteriaAdapter) RangeMetadata() iter.Seq2[string, services.StringMatcher] {
 	return emptyMetadataSeq2
 }
@@ -364,8 +472,11 @@ func (a *dynamicPIDCriteriaAdapter) GetExportModes() services.ExportModes {
 	return services.ExportModeUnset
 }
 
-func (a *dynamicPIDCriteriaAdapter) GetSamplerConfig() *services.SamplerConfig     { return nil }
-func (a *dynamicPIDCriteriaAdapter) GetRoutesConfig() *services.CustomRoutesConfig { return nil }
+func (a *dynamicPIDCriteriaAdapter) GetSamplerConfig() *services.SamplerConfig { return nil }
+func (a *dynamicPIDCriteriaAdapter) GetRoutesConfig() *services.CustomRoutesConfig {
+	return nil
+}
+
 func (a *dynamicPIDCriteriaAdapter) MetricsConfig() perapp.SvcMetricsConfig {
 	return perapp.SvcMetricsConfig{}
 }
@@ -376,3 +487,36 @@ func (emptyMatcher) IsSet() bool               { return false }
 func (emptyMatcher) MatchString(_ string) bool { return false }
 
 func emptyMetadataSeq2(_ func(string, services.StringMatcher) bool) {}
+
+func attrsFromOptions(opts selection.DynamicPIDOptions) dynamicPIDAttributes {
+	return dynamicPIDAttributes{
+		serviceName:        opts.ServiceName,
+		serviceNamespace:   opts.ServiceNamespace,
+		resourceAttributes: maps.Clone(opts.ResourceAttributes),
+	}
+}
+
+func attrsFromEntry(entry selection.DynamicPIDEntry) dynamicPIDAttributes {
+	return dynamicPIDAttributes{
+		serviceName:        entry.ServiceName,
+		serviceNamespace:   entry.ServiceNamespace,
+		resourceAttributes: maps.Clone(entry.ResourceAttributes),
+	}
+}
+
+func entryFromRecord(pid app.PID, attrs dynamicPIDAttributes) selection.DynamicPIDEntry {
+	return selection.DynamicPIDEntry{
+		PID:                pid,
+		ServiceName:        attrs.serviceName,
+		ServiceNamespace:   attrs.serviceNamespace,
+		ResourceAttributes: maps.Clone(attrs.resourceAttributes),
+	}
+}
+
+func cloneAttrs(attrs dynamicPIDAttributes) dynamicPIDAttributes {
+	return dynamicPIDAttributes{
+		serviceName:        attrs.serviceName,
+		serviceNamespace:   attrs.serviceNamespace,
+		resourceAttributes: maps.Clone(attrs.resourceAttributes),
+	}
+}

--- a/pkg/appolly/discover/dynamic_pid_selector.go
+++ b/pkg/appolly/discover/dynamic_pid_selector.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
@@ -168,6 +169,11 @@ type DynamicPIDSelector struct {
 	mu    sync.RWMutex
 	byPID map[app.PID]dynamicPIDRecord
 
+	fileInfoMu        sync.RWMutex
+	fileInfoByPID     map[app.PID]*exec.FileInfo
+	onFileInfoUpdated func(*exec.FileInfo)
+	attrsUpdatedCh    chan app.PID
+
 	rootView           dynamicPIDSignalView
 	tracesView         dynamicPIDSignalView
 	appMetricsView     dynamicPIDSignalView
@@ -189,7 +195,9 @@ func newDynamicPIDSignalView(parent *DynamicPIDSelector, mask dynamicPIDSignal) 
 // NewDynamicPIDSelector creates a new selector whose root Add/Remove methods apply to all signals.
 func NewDynamicPIDSelector() *DynamicPIDSelector {
 	d := &DynamicPIDSelector{
-		byPID: map[app.PID]dynamicPIDRecord{},
+		byPID:          map[app.PID]dynamicPIDRecord{},
+		fileInfoByPID:  map[app.PID]*exec.FileInfo{},
+		attrsUpdatedCh: make(chan app.PID, 64),
 	}
 	d.rootView = newDynamicPIDSignalView(d, allSignalMask)
 	d.tracesView = newDynamicPIDSignalView(d, signalTraces)
@@ -198,6 +206,51 @@ func NewDynamicPIDSelector() *DynamicPIDSelector {
 	d.statsMetricsView = newDynamicPIDSignalView(d, signalStatsMetrics)
 	d.appSignalsView = newDynamicPIDSignalView(d, appSignalMask)
 	return d
+}
+
+// SetOnFileInfoUpdated registers a hook invoked after SetPID updates a live FileInfo. OBI uses this
+// to re-send process events so metrics exporters refresh target_info and related series.
+func (d *DynamicPIDSelector) SetOnFileInfoUpdated(fn func(*exec.FileInfo)) {
+	d.fileInfoMu.Lock()
+	d.onFileInfoUpdated = fn
+	d.fileInfoMu.Unlock()
+}
+
+// AttrsUpdatedNotify reports PIDs whose shared attributes changed.
+func (d *DynamicPIDSelector) AttrsUpdatedNotify() <-chan app.PID {
+	return d.attrsUpdatedCh
+}
+
+func (d *DynamicPIDSelector) notifyAttrsUpdated(pid app.PID) {
+	select {
+	case d.attrsUpdatedCh <- pid:
+	default:
+	}
+}
+
+// RegisterFileInfo records the live FileInfo for a dynamically selected PID after instrumentation.
+func (d *DynamicPIDSelector) RegisterFileInfo(pid app.PID, fi *exec.FileInfo) {
+	if fi == nil {
+		return
+	}
+	d.fileInfoMu.Lock()
+	d.fileInfoByPID[pid] = fi
+	if owner := fi.ServiceAttrs().DynamicSelectorPID; owner != 0 && owner != pid {
+		d.fileInfoByPID[owner] = fi
+	}
+	d.fileInfoMu.Unlock()
+}
+
+// UnregisterFileInfo drops FileInfo references for pid and its dynamic selector owner PID.
+func (d *DynamicPIDSelector) UnregisterFileInfo(pid app.PID, fi *exec.FileInfo) {
+	d.fileInfoMu.Lock()
+	delete(d.fileInfoByPID, pid)
+	if fi != nil {
+		if owner := fi.ServiceAttrs().DynamicSelectorPID; owner != 0 {
+			delete(d.fileInfoByPID, owner)
+		}
+	}
+	d.fileInfoMu.Unlock()
 }
 
 func (d *DynamicPIDSelector) views() []*dynamicPIDSignalView {
@@ -216,6 +269,7 @@ func (d *DynamicPIDSelector) addSignals(mask dynamicPIDSignal, opts *selection.D
 		return
 	}
 	addedByView := map[*dynamicPIDSignalView][]app.PID{}
+	var attrsUpdated []app.PID
 
 	d.mu.Lock()
 	for _, rawPID := range pids {
@@ -231,6 +285,7 @@ func (d *DynamicPIDSelector) addSignals(mask dynamicPIDSignal, opts *selection.D
 		if newMask == oldMask {
 			if opts != nil {
 				d.byPID[pid] = rec
+				attrsUpdated = append(attrsUpdated, pid)
 			}
 			continue
 		}
@@ -247,6 +302,9 @@ func (d *DynamicPIDSelector) addSignals(mask dynamicPIDSignal, opts *selection.D
 
 	for view, batch := range addedByView {
 		view.notifier.notifyAdded(batch)
+	}
+	for _, pid := range attrsUpdated {
+		d.notifyAttrsUpdated(pid)
 	}
 }
 
@@ -333,18 +391,65 @@ func (d *DynamicPIDSelector) GetPID(pid uint32) (selection.DynamicPIDEntry, bool
 	return entryFromRecord(app.PID(pid), rec.attrs), true
 }
 
-// SetPID updates shared attributes for a PID that is already tracked by the selector.
+// SetPID updates shared attributes for a PID that is already tracked by the selector and, when
+// the process is instrumented, applies them to its live FileInfo.
 func (d *DynamicPIDSelector) SetPID(entry selection.DynamicPIDEntry) bool {
+	attrs := attrsFromEntry(entry)
+
 	d.mu.Lock()
-	defer d.mu.Unlock()
-	if _, ok := d.byPID[entry.PID]; !ok {
+	rec, ok := d.byPID[entry.PID]
+	if !ok {
+		d.mu.Unlock()
 		return false
 	}
 	d.byPID[entry.PID] = dynamicPIDRecord{
-		signals: d.byPID[entry.PID].signals,
-		attrs:   attrsFromEntry(entry),
+		signals: rec.signals,
+		attrs:   attrs,
 	}
+	d.mu.Unlock()
+
+	d.applyAttrsToInstrumented(entry.PID, attrs)
+	d.notifyAttrsUpdated(entry.PID)
 	return true
+}
+
+func (d *DynamicPIDSelector) applyAttrsToInstrumented(pid app.PID, attrs dynamicPIDAttributes) {
+	d.fileInfoMu.RLock()
+	fi := d.fileInfoByPID[pid]
+	cb := d.onFileInfoUpdated
+	d.fileInfoMu.RUnlock()
+	if fi == nil {
+		return
+	}
+	updated := false
+	if attrs.serviceName != "" || attrs.serviceNamespace != "" {
+		uid := fi.ServiceAttrs().UID
+		if attrs.serviceName != "" {
+			uid.Name = attrs.serviceName
+		}
+		if attrs.serviceNamespace != "" {
+			uid.Namespace = attrs.serviceNamespace
+		}
+		fi.SetUID(uid)
+		updated = true
+	}
+	if len(attrs.resourceAttributes) > 0 {
+		snap := fi.ServiceAttrs()
+		metadata := snap.Metadata
+		if metadata == nil {
+			metadata = map[attr.Name]string{}
+		} else {
+			metadata = maps.Clone(metadata)
+		}
+		for k, v := range attrs.resourceAttributes {
+			metadata[attr.Name(k)] = v
+		}
+		fi.SetMetadata(metadata)
+		updated = true
+	}
+	if updated && cb != nil {
+		cb(fi)
+	}
 }
 
 func (v *dynamicPIDSignalView) contains(mask dynamicPIDSignal) bool {

--- a/pkg/appolly/discover/dynamic_pid_selector_test.go
+++ b/pkg/appolly/discover/dynamic_pid_selector_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/selection"
 )
@@ -276,4 +278,63 @@ func TestDynamicPIDSelector_AttributesSharedAcrossSignals(t *testing.T) {
 	assert.Equal(t, "shared-svc", entry.ServiceName)
 	assert.True(t, d.Traces().IncludesPID(42))
 	assert.True(t, d.AppMetrics().IncludesPID(42))
+}
+
+func TestDynamicPIDSelector_SetPID_UpdatesFileInfo(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	d.AddPIDs(42)
+
+	fi := exec.New(exec.Init{
+		Pid: 42,
+		Service: svc.Attrs{
+			UID:                svc.UID{Name: "old"},
+			DynamicSelectorPID: 42,
+		},
+	})
+	d.RegisterFileInfo(42, fi)
+
+	entry := selection.DynamicPIDEntry{
+		PID:         42,
+		ServiceName: "live-svc",
+		ResourceAttributes: map[string]string{
+			"team": "payments",
+		},
+	}
+	require.True(t, d.SetPID(entry))
+
+	snap := fi.ServiceAttrs()
+	assert.Equal(t, "live-svc", snap.UID.Name)
+	assert.Equal(t, "payments", snap.Metadata["team"])
+}
+
+func TestDynamicPIDSelector_SetPID_NotifiesFileInfoUpdate(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	d.AddPIDs(42)
+
+	fi := exec.New(exec.Init{Pid: 42, Service: svc.Attrs{DynamicSelectorPID: 42}})
+	d.RegisterFileInfo(42, fi)
+
+	var notified *exec.FileInfo
+	d.SetOnFileInfoUpdated(func(updated *exec.FileInfo) { notified = updated })
+
+	require.True(t, d.SetPID(selection.DynamicPIDEntry{
+		PID:         42,
+		ServiceName: "metrics-svc",
+	}))
+	assert.Same(t, fi, notified)
+}
+
+func TestDynamicPIDSelector_SetPID_NotifiesAttrsUpdated(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	d.AddPIDs(7)
+
+	ch := d.AttrsUpdatedNotify()
+	require.True(t, d.SetPID(selection.DynamicPIDEntry{PID: 7, ServiceName: "net-svc"}))
+
+	select {
+	case pid := <-ch:
+		assert.Equal(t, app.PID(7), pid)
+	default:
+		t.Fatal("expected attrs updated notification")
+	}
 }

--- a/pkg/appolly/discover/dynamic_pid_selector_test.go
+++ b/pkg/appolly/discover/dynamic_pid_selector_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/selection"
 )
 
 // pidMultisetEqual reports whether a and b contain the same PIDs with the same multiplicity.
@@ -205,4 +207,73 @@ func TestDynamicPIDSelector_QueueNoDrop(t *testing.T) {
 	d.AddPIDs(10, 20)
 	d.AddPIDs(30)
 	readPIDNotifyBatchesUntil(t, addedCh, []app.PID{10, 20, 30})
+}
+
+func TestDynamicPIDSelector_AddPID_WithOptions(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	d.Traces().AddPID(42, selection.DynamicPIDOptions{
+		ServiceName:      "custom-svc",
+		ServiceNamespace: "custom-ns",
+		ResourceAttributes: map[string]string{
+			"deployment.environment": "staging",
+		},
+	})
+
+	entry, ok := d.GetPID(42)
+	require.True(t, ok)
+	assert.Equal(t, app.PID(42), entry.PID)
+	assert.Equal(t, "custom-svc", entry.ServiceName)
+	assert.Equal(t, "custom-ns", entry.ServiceNamespace)
+	assert.Equal(t, "staging", entry.ResourceAttributes["deployment.environment"])
+	assert.True(t, d.Traces().IncludesPID(42))
+	assert.False(t, d.AppMetrics().IncludesPID(42))
+
+	selector := d.appSignals().SelectorForPID(42)
+	require.NotNil(t, selector)
+	assert.Equal(t, "custom-svc", selector.GetName())
+	attrs := ResourceAttributesFromSelector(selector)
+	assert.Equal(t, "staging", attrs[attr.Name("deployment.environment")])
+}
+
+func TestDynamicPIDSelector_GetPID_SetPID(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	d.AddPIDs(42)
+
+	entry, ok := d.GetPID(42)
+	require.True(t, ok)
+	assert.Equal(t, app.PID(42), entry.PID)
+	assert.Empty(t, entry.ServiceName)
+
+	entry.ServiceName = "my app"
+	entry.ResourceAttributes = map[string]string{"team": "platform"}
+	require.True(t, d.SetPID(entry))
+
+	updated, ok := d.GetPID(42)
+	require.True(t, ok)
+	assert.Equal(t, "my app", updated.ServiceName)
+	assert.Equal(t, "platform", updated.ResourceAttributes["team"])
+
+	assert.False(t, d.SetPID(selection.DynamicPIDEntry{PID: 99, ServiceName: "missing"}))
+}
+
+func TestDynamicPIDSelector_AddPID_UpdatesExistingAttributes(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	d.Traces().AddPID(42, selection.DynamicPIDOptions{ServiceName: "first"})
+	d.Traces().AddPID(42, selection.DynamicPIDOptions{ServiceName: "updated"})
+
+	entry, ok := d.GetPID(42)
+	require.True(t, ok)
+	assert.Equal(t, "updated", entry.ServiceName)
+}
+
+func TestDynamicPIDSelector_AttributesSharedAcrossSignals(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	d.Traces().AddPID(42, selection.DynamicPIDOptions{ServiceName: "shared-svc"})
+
+	d.AppMetrics().AddPIDs(42)
+	entry, ok := d.GetPID(42)
+	require.True(t, ok)
+	assert.Equal(t, "shared-svc", entry.ServiceName)
+	assert.True(t, d.Traces().IncludesPID(42))
+	assert.True(t, d.AppMetrics().IncludesPID(42))
 }

--- a/pkg/appolly/discover/exec/file.go
+++ b/pkg/appolly/discover/exec/file.go
@@ -186,14 +186,20 @@ func (fi *FileInfo) ApplyEnvVariables(envVars map[string]string) {
 	defer fi.mu.Unlock()
 
 	fi.service.EnvVars = envVars
-	m := map[attr.Name]string{}
+	m := maps.Clone(fi.service.Metadata)
+	if m == nil {
+		m = map[attr.Name]string{}
+	}
 	allVars := map[string]string{}
 
 	if resourceAttrs, ok := fi.service.EnvVars[envResourceAttrs]; ok {
 		attributes.ParseOTELResourceVariable(resourceAttrs, func(k, v string) { allVars[k] = v })
 		for k, v := range allVars {
 			if v != "" && !strings.HasPrefix(v, "$") {
-				m[attr.Name(k)] = v
+				key := attr.Name(k)
+				if _, exists := m[key]; !exists {
+					m[key] = v
+				}
 			}
 		}
 	}

--- a/pkg/appolly/discover/exec/file_test.go
+++ b/pkg/appolly/discover/exec/file_test.go
@@ -65,11 +65,26 @@ func TestApplyEnvVariables(t *testing.T) {
 			envVars:    map[string]string{"OTEL_RESOURCE_ATTRIBUTES": "service.namespace=${test-ns},service.name=$(otel-ns)"},
 			expectMeta: map[attr.Name]string{},
 		},
+		{
+			name: "Pre-set metadata is preserved over env resource attributes",
+			envVars: map[string]string{
+				"OTEL_RESOURCE_ATTRIBUTES": "deployment.environment=prod,custom.attr=from-env",
+			},
+			expectMeta: map[attr.Name]string{
+				"deployment.environment": "staging",
+				"custom.attr":            "from-env",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fi := New(Init{})
+			if tt.name == "Pre-set metadata is preserved over env resource attributes" {
+				fi.SetMetadata(map[attr.Name]string{
+					"deployment.environment": "staging",
+				})
+			}
 			fi.ApplyEnvVariables(tt.envVars)
 			snap := fi.ServiceAttrs()
 			if got := snap.UID.Name; got != tt.expectName {

--- a/pkg/appolly/discover/finder.go
+++ b/pkg/appolly/discover/finder.go
@@ -148,6 +148,7 @@ func (pf *ProcessFinder) Start(ctx context.Context, opts ...ProcessFinderStartOp
 		Metrics:             pf.ctxInfo.Metrics,
 		SpanSignalsShortcut: pf.tracesInput,
 		RuntimeMetrics:      pf.runtimeMetrics,
+		DynamicPIDSelector:  startConfig.dynamicPIDSelector,
 
 		InputInstrumentables: storedExecutableTypes,
 		EbpfEventContext:     pf.ebpfEventContext,

--- a/pkg/appolly/discover/matcher_dynamic.go
+++ b/pkg/appolly/discover/matcher_dynamic.go
@@ -129,19 +129,23 @@ func (m *DynamicMatcher) filterCreated(obj ProcessAttrs) (Event[ProcessMatch], b
 }
 
 func (m *DynamicMatcher) matchDynamicCriteria(obj ProcessAttrs, proc *services.ProcessInfo) *ProcessMatch {
-	criteria := make([]services.Selector, 0, 1)
-	if m.DynamicPIDSelector.IncludesPID(proc.Pid) {
-		criteria = append(criteria, m.DynamicPIDSelector.AsSelector())
+	if !m.DynamicPIDSelector.IncludesPID(proc.Pid) {
+		return nil
 	}
 
-	if len(criteria) > 0 {
-		m.Log.Debug("found process", "pid", proc.Pid, "comm", proc.ExePath, "metadata",
-			obj.metadata, "podLabels", obj.podLabels, "criteria", criteria)
-
-		return &ProcessMatch{Criteria: criteria, Process: proc, DynamicSelectorPID: proc.Pid}
+	selector := m.DynamicPIDSelector.SelectorForPID(proc.Pid)
+	if selector == nil {
+		return nil
 	}
 
-	return nil
+	m.Log.Debug("found process", "pid", proc.Pid, "comm", proc.ExePath, "metadata",
+		obj.metadata, "podLabels", obj.podLabels, "criteria", []services.Selector{selector})
+
+	return &ProcessMatch{
+		Criteria:           []services.Selector{selector},
+		Process:            proc,
+		DynamicSelectorPID: proc.Pid,
+	}
 }
 
 func (m *DynamicMatcher) filterDeleted(obj ProcessAttrs) (Event[ProcessMatch], bool) {

--- a/pkg/appolly/discover/matcher_test.go
+++ b/pkg/appolly/discover/matcher_test.go
@@ -15,10 +15,12 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/internal/testutil"
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+	"go.opentelemetry.io/obi/pkg/selection"
 	"go.opentelemetry.io/obi/pkg/transform"
 )
 
@@ -847,6 +849,43 @@ func TestCriteriaMatcher_DynamicTargetPIDs_RemoveNotification(t *testing.T) {
 	assert.Equal(t, app.PID(42), matches[0].Obj.Process.Pid)
 
 	// Stop matcher so next test does not race on global processInfo (close input, drain output).
+	discoveredProcesses.Close()
+	testutil.DrainUntilClosed(filteredProcesses)
+}
+
+func TestCriteriaMatcher_DynamicTargetPIDs_WithOptions(t *testing.T) {
+	dynamicSelector := NewDynamicPIDSelector()
+	dynamicSelector.Traces().AddPID(42, selection.DynamicPIDOptions{
+		ServiceName:      "runtime-svc",
+		ServiceNamespace: "runtime-ns",
+		ResourceAttributes: map[string]string{
+			"custom.attr": "value",
+		},
+	})
+
+	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+	filteredProcesses := filteredProcessesQu.Subscribe()
+	processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
+		return &services.ProcessInfo{Pid: pp.pid, ExePath: "/any/exe", OpenPorts: pp.openPorts}, nil
+	}
+	runFn, err := dynamicMatcherProvider(discoveredProcesses, filteredProcessesQu, dynamicSelector.appSignals())(t.Context())
+	require.NoError(t, err)
+	go runFn(t.Context())
+	time.Sleep(50 * time.Millisecond)
+	defer filteredProcessesQu.Close()
+
+	discoveredProcesses.Send([]Event[ProcessAttrs]{
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 42, openPorts: []uint32{}}},
+	})
+	matches := testutil.ReadChannel(t, filteredProcesses, testTimeout)
+	require.Len(t, matches, 1)
+	require.Len(t, matches[0].Obj.Criteria, 1)
+	assert.Equal(t, "runtime-svc", matches[0].Obj.Criteria[0].GetName())
+	assert.Equal(t, "runtime-ns", matches[0].Obj.Criteria[0].GetNamespace())
+	attrs := ResourceAttributesFromSelector(matches[0].Obj.Criteria[0])
+	assert.Equal(t, "value", attrs[attr.Name("custom.attr")])
+
 	discoveredProcesses.Close()
 	testutil.DrainUntilClosed(filteredProcesses)
 }

--- a/pkg/appolly/discover/typer.go
+++ b/pkg/appolly/discover/typer.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -19,6 +20,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/ebpf"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/goexec"
 	"go.opentelemetry.io/obi/pkg/internal/procs"
@@ -101,6 +103,7 @@ func (t *typer) makeServiceAttrs(processMatch *ProcessMatch) svc.Attrs {
 	var samplerConfig *services.SamplerConfig
 	var routesConfig *services.CustomRoutesConfig
 	svcFeatures := t.cfg.Metrics.Features
+	var metadata map[attr.Name]string
 
 	for _, s := range processMatch.Criteria {
 		if n := s.GetName(); n != "" {
@@ -109,6 +112,13 @@ func (t *typer) makeServiceAttrs(processMatch *ProcessMatch) svc.Attrs {
 
 		if n := s.GetNamespace(); n != "" {
 			namespace = n
+		}
+
+		if m := ResourceAttributesFromSelector(s); len(m) > 0 {
+			if metadata == nil {
+				metadata = make(map[attr.Name]string, len(m))
+			}
+			maps.Copy(metadata, m)
 		}
 
 		if m := s.GetExportModes(); m != services.ExportModeUnset {
@@ -143,6 +153,7 @@ func (t *typer) makeServiceAttrs(processMatch *ProcessMatch) svc.Attrs {
 			Name:      name,
 			Namespace: namespace,
 		},
+		Metadata:           metadata,
 		ProcPID:            processMatch.Process.Pid,
 		DynamicSelectorPID: processMatch.DynamicSelectorPID,
 		ExportModes:        exportModes,

--- a/pkg/appolly/discover/typer_test.go
+++ b/pkg/appolly/discover/typer_test.go
@@ -17,8 +17,10 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/export"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 	"go.opentelemetry.io/obi/pkg/obi"
+	"go.opentelemetry.io/obi/pkg/selection"
 	"go.opentelemetry.io/obi/pkg/transform"
 )
 
@@ -83,6 +85,29 @@ func TestMakeServiceAttrs(t *testing.T) {
 	assert.NotNil(t, attrs2.Sampler)
 	assert.NotNil(t, attrs2.CustomInRouteMatcher)
 	assert.NotNil(t, attrs2.CustomOutRouteMatcher)
+}
+
+func TestMakeServiceAttrs_DynamicPIDOptions(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	d.Traces().AddPID(42, selection.DynamicPIDOptions{
+		ServiceName:      "dynamic-svc",
+		ServiceNamespace: "dynamic-ns",
+		ResourceAttributes: map[string]string{
+			"deployment.environment": "prod",
+		},
+	})
+	selector := d.appSignals().SelectorForPID(42)
+	require.NotNil(t, selector)
+
+	ty := typer{cfg: &obi.Config{Routes: &transform.RoutesConfig{}}}
+	attrs := ty.makeServiceAttrs(&ProcessMatch{
+		Process:            &services.ProcessInfo{Pid: 42},
+		Criteria:           []services.Selector{selector},
+		DynamicSelectorPID: 42,
+	})
+	assert.Equal(t, "dynamic-svc", attrs.UID.Name)
+	assert.Equal(t, "dynamic-ns", attrs.UID.Namespace)
+	assert.Equal(t, "prod", attrs.Metadata[attr.Name("deployment.environment")])
 }
 
 func TestMakeServiceAttrs_FeaturesMatchingMultipleCriteria(t *testing.T) {

--- a/pkg/instrumenter/opts.go
+++ b/pkg/instrumenter/opts.go
@@ -14,11 +14,12 @@ import (
 type Option func(info *global.ContextInfo)
 
 // WithDynamicPIDSelector passes the given dynamic PID selector into OBI. The caller creates it with
-// discover.NewDynamicPIDSelector(), passes it here, and then calls AddPIDs/RemovePIDs/GetPIDs on it
-// directly, or targets specific signals via subviews such as Traces(), AppMetrics(),
-// NetworkMetrics(), and StatsMetrics().
+// discover.NewDynamicPIDSelector(), passes it here, and then calls AddPIDs, AddPID, GetPID, SetPID,
+// RemovePIDs, or GetPIDs on it directly, or targets specific signals via subviews such as Traces(),
+// AppMetrics(), NetworkMetrics(), and StatsMetrics().
 //
 // Root AddPIDs/RemovePIDs preserve the legacy behavior and apply to all supported signals.
+// Service name and resource attributes set via AddPID or SetPID are shared across all signals.
 func WithDynamicPIDSelector(sel *discover.DynamicPIDSelector) Option {
 	return func(info *global.ContextInfo) {
 		info.DynamicPIDSelector = sel

--- a/pkg/instrumenter/opts.go
+++ b/pkg/instrumenter/opts.go
@@ -20,6 +20,8 @@ type Option func(info *global.ContextInfo)
 //
 // Root AddPIDs/RemovePIDs preserve the legacy behavior and apply to all supported signals.
 // Service name and resource attributes set via AddPID or SetPID are shared across all signals.
+// SetPID updates live FileInfo for instrumented PIDs; traces and app metrics read it at export time.
+// Network and stats metrics decorate flow records by pod IP when the PID is in that signal view.
 func WithDynamicPIDSelector(sel *discover.DynamicPIDSelector) Option {
 	return func(info *global.ContextInfo) {
 		info.DynamicPIDSelector = sel

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -106,6 +106,11 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *obi.Config) (
 
 	sel, _ := ctxInfo.DynamicPIDSelector.(*discover.DynamicPIDSelector)
 	// When sel is nil, finder gets nil: config target_pids are used as static criteria (FindingCriteria(cfg, false)).
+	if sel != nil {
+		sel.SetOnFileInfoUpdated(func(fi *exec.FileInfo) {
+			processEventsInput.Send(exec.ProcessEvent{Type: exec.ProcessEventCreated, File: fi})
+		})
+	}
 	instr := &Instrumenter{
 		config:             config,
 		ctxInfo:            ctxInfo,

--- a/pkg/internal/pipe/transform/dynamicpid/decorator.go
+++ b/pkg/internal/pipe/transform/dynamicpid/decorator.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package dynamicpid // import "go.opentelemetry.io/obi/pkg/internal/pipe/transform/dynamicpid"
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/obi/pkg/internal/pipe"
+	"go.opentelemetry.io/obi/pkg/kube"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm/swarms"
+	"go.opentelemetry.io/obi/pkg/selection"
+)
+
+func log() *slog.Logger { return slog.With("component", "dynamicpid.MetadataDecorator") }
+
+// MetadataDecoratorProvider applies service identity and resource attributes from a dynamic PID
+// selector to flow records whose source or destination IP belongs to a selected application.
+func MetadataDecoratorProvider[T any](
+	multiSel selection.MultiSignalPIDSelector,
+	signalSel selection.PIDSelector,
+	k8sInformer *kube.MetadataProvider,
+	getAttrs func(T) *pipe.CommonAttrs,
+	input, output *msg.Queue[[]T],
+) swarm.InstanceFunc {
+	return func(instantiateCtx context.Context) (swarm.RunFunc, error) {
+		if multiSel == nil {
+			return swarm.Bypass(input, output)
+		}
+		var store *kube.Store
+		if k8sInformer != nil && k8sInformer.IsKubeEnabled() {
+			var err error
+			store, err = k8sInformer.Get(instantiateCtx)
+			if err != nil {
+				return nil, err
+			}
+		}
+		tracker := selection.NewDynamicFlowAttrs(multiSel, signalSel, store)
+		in := input.Subscribe(msg.SubscriberName("dynamicpid.MetadataDecorator"))
+		return func(ctx context.Context) {
+			tracker.Run(ctx)
+			defer output.Close()
+			swarms.ForEachInput(ctx, in, log().Debug, func(items []T) {
+				for _, item := range items {
+					tracker.Apply(getAttrs(item))
+				}
+				output.Send(items)
+			})
+		}, nil
+	}
+}

--- a/pkg/netolly/agent/pipeline.go
+++ b/pkg/netolly/agent/pipeline.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/internal/pipe/decorate"
 	"go.opentelemetry.io/obi/pkg/internal/pipe/geoip"
 	"go.opentelemetry.io/obi/pkg/internal/pipe/rdns"
+	"go.opentelemetry.io/obi/pkg/internal/pipe/transform/dynamicpid"
 	"go.opentelemetry.io/obi/pkg/internal/pipe/transform/k8s"
 	"go.opentelemetry.io/obi/pkg/netolly/flowdef"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
@@ -114,8 +115,12 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 	if f.ctxInfo.DynamicPIDSelector != nil {
 		dynamicSelector = f.ctxInfo.DynamicPIDSelector.NetworkMetrics()
 	}
+	dynamicDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "dynamicDecoratedFlows")
+	swi.Add(dynamicpid.MetadataDecoratorProvider(f.ctxInfo.DynamicPIDSelector, dynamicSelector,
+		f.ctxInfo.K8sInformer, recordAttrs, decoratedFlows, dynamicDecoratedFlows),
+		swarm.WithID("DynamicPIDMetadataDecorator"))
 	swi.Add(filter.ByDynamicPID(dynamicSelector, f.ctxInfo.K8sInformer,
-		recordAttrs, decoratedFlows, dynamicFilteredFlows),
+		recordAttrs, dynamicDecoratedFlows, dynamicFilteredFlows),
 		swarm.WithID("DynamicPIDFilter"))
 
 	filteredFlows := f.ctxInfo.OverrideNetExportQueue

--- a/pkg/selection/dynamic_app_ips.go
+++ b/pkg/selection/dynamic_app_ips.go
@@ -77,7 +77,7 @@ func (d *DynamicAppIPs) refreshAll() {
 
 func (d *DynamicAppIPs) addBatch(pids []app.PID) {
 	for _, pid := range pids {
-		ips := d.resolveIPs(pid)
+		ips := ResolveContainerIPs(d.store, pid)
 		if len(ips) == 0 {
 			selLog().Debug("no IPs resolved for dynamically selected PID", "pid", pid)
 			continue
@@ -123,17 +123,18 @@ func (d *DynamicAppIPs) decrementIPsLocked(ips []string) {
 	}
 }
 
-func (d *DynamicAppIPs) resolveIPs(pid app.PID) []string {
-	if d.store == nil {
+// ResolveContainerIPs returns pod IPs for a PID when a Kubernetes store is available.
+func ResolveContainerIPs(store *kube.Store, pid app.PID) []string {
+	if store == nil {
 		return nil
 	}
-	d.store.AddProcess(pid)
+	store.AddProcess(pid)
 	info, err := container.InfoForPID(pid)
 	if err != nil {
 		selLog().Debug("can't read container info for PID", "pid", pid, "error", err)
 		return nil
 	}
-	meta, _ := d.store.PodContainerByPIDNs(info.PIDNamespace, pid)
+	meta, _ := store.PodContainerByPIDNs(info.PIDNamespace, pid)
 	if meta == nil {
 		return nil
 	}

--- a/pkg/selection/dynamic_flow_attrs.go
+++ b/pkg/selection/dynamic_flow_attrs.go
@@ -1,0 +1,172 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package selection // import "go.opentelemetry.io/obi/pkg/selection"
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/internal/pipe"
+	"go.opentelemetry.io/obi/pkg/kube"
+)
+
+type flowIPDecoration struct {
+	serviceName      string
+	serviceNamespace string
+	resourceAttrs    map[attr.Name]string
+}
+
+// DynamicFlowAttrs maps dynamically selected application IPs to service identity and resource
+// attributes for NetO11y and StatsO11y decoration.
+type DynamicFlowAttrs struct {
+	multiSel  MultiSignalPIDSelector
+	signalSel PIDSelector
+	store     *kube.Store
+
+	mu      sync.RWMutex
+	ipDecor map[string]flowIPDecoration
+}
+
+// NewDynamicFlowAttrs creates a tracker for the given signal view and optional Kubernetes store.
+func NewDynamicFlowAttrs(multiSel MultiSignalPIDSelector, signalSel PIDSelector, store *kube.Store) *DynamicFlowAttrs {
+	return &DynamicFlowAttrs{
+		multiSel:  multiSel,
+		signalSel: signalSel,
+		store:     store,
+		ipDecor:   map[string]flowIPDecoration{},
+	}
+}
+
+// Run keeps the IP decoration map in sync with PID membership and attribute updates.
+func (d *DynamicFlowAttrs) Run(ctx context.Context) {
+	if d.multiSel == nil || d.signalSel == nil {
+		return
+	}
+	d.rebuild()
+
+	go d.loop(ctx, d.signalSel.AddedPIDsNotify(), d.rebuild)
+	go d.loop(ctx, d.signalSel.RemovedNotify(), d.rebuild)
+	go d.loopAttrs(ctx)
+}
+
+func (d *DynamicFlowAttrs) loop(ctx context.Context, ch <-chan []app.PID, fn func()) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+			fn()
+		}
+	}
+}
+
+func (d *DynamicFlowAttrs) loopAttrs(ctx context.Context) {
+	ch := d.multiSel.AttrsUpdatedNotify()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+			d.rebuild()
+		}
+	}
+}
+
+func (d *DynamicFlowAttrs) rebuild() {
+	pids, ok := d.signalSel.GetPIDs()
+	if !ok {
+		d.mu.Lock()
+		d.ipDecor = map[string]flowIPDecoration{}
+		d.mu.Unlock()
+		return
+	}
+
+	next := map[string]flowIPDecoration{}
+	for _, pid := range pids {
+		entry, ok := d.multiSel.GetPID(uint32(pid))
+		if !ok {
+			continue
+		}
+		dec := decorationFromEntry(entry)
+		if dec.isEmpty() {
+			continue
+		}
+		for _, ip := range ResolveContainerIPs(d.store, pid) {
+			next[ip] = dec
+		}
+	}
+
+	d.mu.Lock()
+	d.ipDecor = next
+	d.mu.Unlock()
+}
+
+func (d *DynamicFlowAttrs) Apply(a *pipe.CommonAttrs) {
+	if a == nil {
+		return
+	}
+	d.mu.RLock()
+	srcDec, srcOk := d.ipDecor[a.SrcAddr.IP().String()]
+	dstDec, dstOk := d.ipDecor[a.DstAddr.IP().String()]
+	d.mu.RUnlock()
+	if !srcOk && !dstOk {
+		return
+	}
+	if a.Metadata == nil {
+		a.Metadata = map[attr.Name]string{}
+	}
+	if srcOk {
+		applyFlowDecoration(srcDec, a, true)
+	}
+	if dstOk {
+		applyFlowDecoration(dstDec, a, false)
+	}
+}
+
+func decorationFromEntry(entry DynamicPIDEntry) flowIPDecoration {
+	dec := flowIPDecoration{
+		serviceName:      entry.ServiceName,
+		serviceNamespace: entry.ServiceNamespace,
+	}
+	if len(entry.ResourceAttributes) > 0 {
+		dec.resourceAttrs = make(map[attr.Name]string, len(entry.ResourceAttributes))
+		for k, v := range entry.ResourceAttributes {
+			dec.resourceAttrs[attr.Name(k)] = v
+		}
+	}
+	return dec
+}
+
+func (d flowIPDecoration) isEmpty() bool {
+	return d.serviceName == "" && d.serviceNamespace == "" && len(d.resourceAttrs) == 0
+}
+
+func applyFlowDecoration(dec flowIPDecoration, a *pipe.CommonAttrs, src bool) {
+	if src {
+		if dec.serviceName != "" {
+			a.Metadata[attr.ServiceName] = dec.serviceName
+		}
+		if dec.serviceNamespace != "" {
+			a.Metadata[attr.ServiceNamespace] = dec.serviceNamespace
+		}
+	} else {
+		if dec.serviceName != "" {
+			a.Metadata[attr.ServicePeerName] = dec.serviceName
+		}
+		if dec.serviceNamespace != "" {
+			a.Metadata[attr.ServicePeerNamespace] = dec.serviceNamespace
+		}
+	}
+	for k, v := range dec.resourceAttrs {
+		a.Metadata[k] = v
+	}
+}

--- a/pkg/selection/dynamic_flow_attrs_test.go
+++ b/pkg/selection/dynamic_flow_attrs_test.go
@@ -1,0 +1,108 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package selection
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/internal/pipe"
+)
+
+type stubMultiPIDSelector struct {
+	stubPIDSelector
+	entries     map[app.PID]DynamicPIDEntry
+	attrsUpdate chan app.PID
+}
+
+func (s *stubMultiPIDSelector) AddPID(uint32, DynamicPIDOptions) {}
+func (s *stubMultiPIDSelector) AddPIDs(...uint32)                {}
+func (s *stubMultiPIDSelector) RemovePIDs(...uint32)             {}
+func (s *stubMultiPIDSelector) Traces() MutablePIDSelector       { return s }
+func (s *stubMultiPIDSelector) AppMetrics() MutablePIDSelector   { return s }
+func (s *stubMultiPIDSelector) NetworkMetrics() MutablePIDSelector {
+	return s
+}
+func (s *stubMultiPIDSelector) StatsMetrics() MutablePIDSelector { return s }
+
+func (s *stubMultiPIDSelector) GetPID(pid uint32) (DynamicPIDEntry, bool) {
+	entry, ok := s.entries[app.PID(pid)]
+	return entry, ok
+}
+
+func (s *stubMultiPIDSelector) SetPID(entry DynamicPIDEntry) bool {
+	if s.entries == nil {
+		s.entries = map[app.PID]DynamicPIDEntry{}
+	}
+	if _, ok := s.entries[entry.PID]; !ok {
+		return false
+	}
+	s.entries[entry.PID] = entry
+	return true
+}
+
+func (s *stubMultiPIDSelector) AttrsUpdatedNotify() <-chan app.PID {
+	if s.attrsUpdate == nil {
+		s.attrsUpdate = make(chan app.PID, 1)
+	}
+	return s.attrsUpdate
+}
+
+func TestDynamicFlowAttrs_Apply_srcAndDst(t *testing.T) {
+	sel := &stubMultiPIDSelector{
+		stubPIDSelector: stubPIDSelector{pids: []app.PID{42}},
+		entries: map[app.PID]DynamicPIDEntry{
+			42: {
+				PID:              42,
+				ServiceName:      "payments",
+				ServiceNamespace: "prod",
+				ResourceAttributes: map[string]string{
+					"team": "checkout",
+				},
+			},
+		},
+	}
+	tracker := NewDynamicFlowAttrs(sel, sel, nil)
+	tracker.mu.Lock()
+	tracker.ipDecor["10.0.0.5"] = decorationFromEntry(sel.entries[42])
+	tracker.mu.Unlock()
+
+	srcFlow := &pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("10.0.0.5")),
+		DstAddr: pipe.IPAddr(net.ParseIP("10.0.0.9")),
+	}
+	tracker.Apply(srcFlow)
+	require.NotNil(t, srcFlow.Metadata)
+	assert.Equal(t, "payments", srcFlow.Metadata[attr.ServiceName])
+	assert.Equal(t, "prod", srcFlow.Metadata[attr.ServiceNamespace])
+	assert.Equal(t, "checkout", srcFlow.Metadata[attr.Name("team")])
+
+	dstFlow := &pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("10.0.0.9")),
+		DstAddr: pipe.IPAddr(net.ParseIP("10.0.0.5")),
+	}
+	tracker.Apply(dstFlow)
+	require.NotNil(t, dstFlow.Metadata)
+	assert.Equal(t, "payments", dstFlow.Metadata[attr.ServicePeerName])
+	assert.Equal(t, "prod", dstFlow.Metadata[attr.ServicePeerNamespace])
+}
+
+func TestDynamicFlowAttrs_rebuild_clearsWhenEmpty(t *testing.T) {
+	sel := &stubMultiPIDSelector{stubPIDSelector: stubPIDSelector{}}
+	tracker := NewDynamicFlowAttrs(sel, sel, nil)
+	tracker.mu.Lock()
+	tracker.ipDecor["10.0.0.1"] = flowIPDecoration{serviceName: "old"}
+	tracker.mu.Unlock()
+
+	tracker.rebuild()
+
+	tracker.mu.RLock()
+	assert.Empty(t, tracker.ipDecor)
+	tracker.mu.RUnlock()
+}

--- a/pkg/selection/dynamic_pid_attributes.go
+++ b/pkg/selection/dynamic_pid_attributes.go
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package selection // import "go.opentelemetry.io/obi/pkg/selection"
+
+import "go.opentelemetry.io/obi/pkg/appolly/app"
+
+// DynamicPIDOptions holds optional service identity and resource attributes when adding
+// a PID to a signal view. Attributes are shared across all signals for the same PID.
+type DynamicPIDOptions struct {
+	ServiceName        string
+	ServiceNamespace   string
+	ResourceAttributes map[string]string
+}
+
+// DynamicPIDEntry describes a tracked PID and its shared attributes. Use GetPID to read and
+// SetPID to update attributes for a PID that is already in the selector.
+type DynamicPIDEntry struct {
+	PID                app.PID
+	ServiceName        string
+	ServiceNamespace   string
+	ResourceAttributes map[string]string
+}

--- a/pkg/selection/pid_selector.go
+++ b/pkg/selection/pid_selector.go
@@ -34,4 +34,6 @@ type MultiSignalPIDSelector interface {
 	StatsMetrics() MutablePIDSelector
 	GetPID(pid uint32) (DynamicPIDEntry, bool)
 	SetPID(entry DynamicPIDEntry) bool
+	// AttrsUpdatedNotify reports PIDs whose shared attributes changed via SetPID or AddPID with options.
+	AttrsUpdatedNotify() <-chan app.PID
 }

--- a/pkg/selection/pid_selector.go
+++ b/pkg/selection/pid_selector.go
@@ -20,6 +20,7 @@ type PIDSelector interface {
 type MutablePIDSelector interface {
 	PIDSelector
 	AddPIDs(...uint32)
+	AddPID(pid uint32, opts DynamicPIDOptions)
 	RemovePIDs(...uint32)
 }
 
@@ -31,4 +32,6 @@ type MultiSignalPIDSelector interface {
 	AppMetrics() MutablePIDSelector
 	NetworkMetrics() MutablePIDSelector
 	StatsMetrics() MutablePIDSelector
+	GetPID(pid uint32) (DynamicPIDEntry, bool)
+	SetPID(entry DynamicPIDEntry) bool
 }

--- a/pkg/statsolly/agent/pipeline.go
+++ b/pkg/statsolly/agent/pipeline.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/internal/pipe/decorate"
 	"go.opentelemetry.io/obi/pkg/internal/pipe/geoip"
 	"go.opentelemetry.io/obi/pkg/internal/pipe/rdns"
+	"go.opentelemetry.io/obi/pkg/internal/pipe/transform/dynamicpid"
 	"go.opentelemetry.io/obi/pkg/internal/pipe/transform/k8s"
 	"go.opentelemetry.io/obi/pkg/internal/statsolly/ebpf"
 	"go.opentelemetry.io/obi/pkg/internal/statsolly/export"
@@ -76,8 +77,12 @@ func (s *Stats) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 	if s.ctxInfo.DynamicPIDSelector != nil {
 		dynamicSelector = s.ctxInfo.DynamicPIDSelector.StatsMetrics()
 	}
+	dynamicDecoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "dynamicDecoratedStats")
+	swi.Add(dynamicpid.MetadataDecoratorProvider(s.ctxInfo.DynamicPIDSelector, dynamicSelector,
+		s.ctxInfo.K8sInformer, statAttrs, decoratedStats, dynamicDecoratedStats),
+		swarm.WithID("DynamicPIDMetadataDecorator"))
 	swi.Add(filter.ByDynamicPID(dynamicSelector, s.ctxInfo.K8sInformer,
-		statAttrs, decoratedStats, dynamicFilteredStats),
+		statAttrs, dynamicDecoratedStats, dynamicFilteredStats),
 		swarm.WithID("DynamicPIDFilter"))
 
 	filteredStats := s.ctxInfo.OverrideStatsExportQueue


### PR DESCRIPTION
## Summary

This adds support for custom, dynamic attributes through the DynamicSelector API. For example:

```go
sel.Traces().AddPID(1234, selection.DynamicPIDOptions{
    ServiceName:      "checkout-api",
    ServiceNamespace:   "production",
    ResourceAttributes: map[string]string{
        "deployment.environment": "prod",
        "service.version":        "1.2.3",
        "team":                   "payments",
    },
})
```

New dynamic selector methods `GetPID()` and `SetPID()` are intended to be used to post-instrumentation checks and updates.

Resource attributes are *per-pid*, not per-signal, meaning that while you can use the individual signal views to set and modify a process's attributes (like above with `sel.Traces().AddPID()`) those attributes are intentionally shared among all signals that the PID is enabled for. This is for 2 reasons:

1. Technical: it fits will into the global signal bitmask approach implemented by https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2234, meaning that individual signals don't need to share unique copies of attribute maps
2. Ideological: The point of OTel is to make cross-signal correlations based on resource attributes. There isn't a good reason to support unique attributes (that can't be handled by a downstream collector)

This works by essentially fleshing out the existing DynamicSelector adapter that was used in the AppO11y pipeline to retrieve any set values as stored in the selector.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
