### PR TITLE
Increase bpf verifier tests timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ test-privileged: $(ENVTEST)
 .PHONY: run-bpf-verifier-vm
 run-bpf-verifier-vm:
 	@echo "### Running BPF verifier tests"
-	go test -v -count=1 -tags=bpf_verifier_tests ./pkg/internal/ebpf/verifier/...
+	go test -v -count=1 -timeout 20m -tags=bpf_verifier_tests ./pkg/internal/ebpf/verifier/...
 
 .PHONY: cov-exclude-generated
 cov-exclude-generated:


### PR DESCRIPTION
## Summary

BPF verifier tests seem to be timing out from time to time, checking if increasing the timeout will help. Example renovate CI job: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/27922964371/job/82738898225

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [X] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
