### PR TITLE
Fix usdt compile error on some clang versions

### DIFF
--- a/bpf/common/usdt.h
+++ b/bpf/common/usdt.h
@@ -70,26 +70,26 @@ static __always_inline struct obi_usdt_spec *obi_usdt_spec_for_ctx(struct pt_reg
 static __always_inline int obi_usdt_read_user_value(u64 addr, u8 arg_bitshift, unsigned long *val) {
     *val = 0;
 
-    switch ((64 - arg_bitshift) / 8) {
-    case 1: {
+    switch (arg_bitshift) {
+    case 56: {
         u8 tmp = 0;
         int err = bpf_probe_read_user(&tmp, sizeof(tmp), (void *)addr);
         *val = tmp;
         return err;
     }
-    case 2: {
+    case 48: {
         u16 tmp = 0;
         int err = bpf_probe_read_user(&tmp, sizeof(tmp), (void *)addr);
         *val = tmp;
         return err;
     }
-    case 4: {
+    case 32: {
         u32 tmp = 0;
         int err = bpf_probe_read_user(&tmp, sizeof(tmp), (void *)addr);
         *val = tmp;
         return err;
     }
-    case 8:
+    case 0:
         return bpf_probe_read_user(val, sizeof(*val), (void *)addr);
     default:
         return k_obi_usdt_arg_err_bad_size;


### PR DESCRIPTION
## Summary

Certain clang versions fail to compile the new swtch added to usdt.h with:
```
../../../../bpf/common/usdt.h:73:33: error: unsupported signed division, please convert to unsigned div/mod.
   73 |     switch ((64 - arg_bitshift) / 8) {
      |                         
```

Fixed to manually calculate the constants instead of the arithmetic in the switch statement.

While the math doesn't produce the same value for all arg_bitshift, e.g. 47 would be rejected now, but previously it would match to 2, the obi_usdt_arg_bitshift_ok() function only allows these shift offsets, so 47 would've been a weird case to correctly handle.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
