### PR TITLE
(DynamicSelector) Gate runtime metrics with AppMetrics

### DIFF
--- a/pkg/appolly/dynamic_signal_gate.go
+++ b/pkg/appolly/dynamic_signal_gate.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm"
 	"go.opentelemetry.io/obi/pkg/pipe/swarm/swarms"
+	"go.opentelemetry.io/obi/pkg/runtimemetrics"
 	"go.opentelemetry.io/obi/pkg/selection"
 )
 
@@ -28,6 +29,13 @@ func processEventSignalPID(file *exec.FileInfo) app.PID {
 		return snap.DynamicSelectorPID
 	}
 	return file.Pid()
+}
+
+func runtimeMetricSignalPID(snapshot runtimemetrics.RuntimeMetricSnapshot) app.PID {
+	if snapshot.Service.DynamicSelectorPID != 0 {
+		return snapshot.Service.DynamicSelectorPID
+	}
+	return snapshot.PID
 }
 
 // DynamicSignalSpanGate marks spans as traces/metrics-ignored according to the runtime signal views.
@@ -58,6 +66,44 @@ func DynamicSignalSpanGate(
 			})
 		}, nil
 	}
+}
+
+// DynamicSignalRuntimeMetricsGate forwards runtime metric snapshots only for PIDs selected
+// for app metrics.
+func DynamicSignalRuntimeMetricsGate(
+	selector selection.MultiSignalPIDSelector,
+	input, output *msg.Queue[[]runtimemetrics.RuntimeMetricSnapshot],
+) swarm.InstanceFunc {
+	return func(_ context.Context) (swarm.RunFunc, error) {
+		if selector == nil {
+			return swarm.Bypass(input, output)
+		}
+		in := input.Subscribe(msg.SubscriberName("appolly.DynamicSignalRuntimeMetricsGate"))
+		metricsSelector := selector.AppMetrics()
+		return func(ctx context.Context) {
+			defer output.Close()
+			swarms.ForEachInput(ctx, in, nil, func(snapshots []runtimemetrics.RuntimeMetricSnapshot) {
+				out := filterRuntimeMetricSnapshots(snapshots, metricsSelector)
+				if len(out) > 0 {
+					output.SendCtx(ctx, out)
+				}
+			})
+		}, nil
+	}
+}
+
+func filterRuntimeMetricSnapshots(
+	snapshots []runtimemetrics.RuntimeMetricSnapshot,
+	selector selection.PIDSelector,
+) []runtimemetrics.RuntimeMetricSnapshot {
+	writeIdx := 0
+	for readIdx := range snapshots {
+		if selector.IncludesPID(runtimeMetricSignalPID(snapshots[readIdx])) {
+			snapshots[writeIdx] = snapshots[readIdx]
+			writeIdx++
+		}
+	}
+	return snapshots[:writeIdx]
 }
 
 type dynamicSignalProcessEventGate struct {

--- a/pkg/appolly/dynamic_signal_gate_test.go
+++ b/pkg/appolly/dynamic_signal_gate_test.go
@@ -18,6 +18,7 @@ import (
 	execpkg "go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/internal/testutil"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
+	"go.opentelemetry.io/obi/pkg/runtimemetrics"
 )
 
 const gateTestTimeout = time.Second
@@ -141,6 +142,50 @@ func TestDynamicSignalProcessEventGate_DuplicateCreateBeforeRemoveNotify(t *test
 	got = testutil.ReadChannel(t, outCh, gateTestTimeout)
 	assert.Equal(t, execpkg.ProcessEventTerminated, got.Type)
 	assert.Equal(t, app.PID(100), got.File.Pid())
+}
+
+func TestDynamicSignalRuntimeMetricsGate(t *testing.T) {
+	sel := discover.NewDynamicPIDSelector()
+	sel.AppMetrics().AddPIDs(1)
+	sel.Traces().AddPIDs(2)
+
+	input := msg.NewQueue[[]runtimemetrics.RuntimeMetricSnapshot](msg.ChannelBufferLen(4))
+	output := msg.NewQueue[[]runtimemetrics.RuntimeMetricSnapshot](msg.ChannelBufferLen(4))
+	outCh := output.Subscribe()
+
+	runFn, err := DynamicSignalRuntimeMetricsGate(sel, input, output)(t.Context())
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go runFn(ctx)
+
+	input.Send([]runtimemetrics.RuntimeMetricSnapshot{
+		{Service: svc.Attrs{ProcPID: 10, DynamicSelectorPID: 1}, PID: 10},
+		{Service: svc.Attrs{ProcPID: 20, DynamicSelectorPID: 2}, PID: 20},
+		{Service: svc.Attrs{ProcPID: 30}, PID: 30},
+	})
+
+	got := testutil.ReadChannel(t, outCh, gateTestTimeout)
+	require.Len(t, got, 1)
+	assert.Equal(t, app.PID(10), got[0].PID)
+	assert.Equal(t, app.PID(1), runtimeMetricSignalPID(got[0]))
+}
+
+func TestDynamicSignalRuntimeMetricsGate_BypassWhenSelectorNil(t *testing.T) {
+	input := msg.NewQueue[[]runtimemetrics.RuntimeMetricSnapshot](msg.ChannelBufferLen(2))
+	output := msg.NewQueue[[]runtimemetrics.RuntimeMetricSnapshot](msg.ChannelBufferLen(2))
+	outCh := output.Subscribe()
+
+	runFn, err := DynamicSignalRuntimeMetricsGate(nil, input, output)(t.Context())
+	require.NoError(t, err)
+	go runFn(t.Context())
+
+	input.Send([]runtimemetrics.RuntimeMetricSnapshot{
+		{Service: svc.Attrs{ProcPID: 10}, PID: 10},
+	})
+	got := testutil.ReadChannel(t, outCh, gateTestTimeout)
+	require.Len(t, got, 1)
+	assert.Equal(t, app.PID(10), got[0].PID)
 }
 
 func TestDynamicSignalSpanGate_BypassWhenSelectorNil(t *testing.T) {

--- a/pkg/appolly/instrumenter.go
+++ b/pkg/appolly/instrumenter.go
@@ -206,6 +206,14 @@ func setupMetricsSubPipeline(
 
 	runtimeMetricsEnabled := runtimemetrics.EnabledFeatures(jointMetricsConfig.Features)
 
+	runtimeMetricsInput := runtimeMetrics
+	if runtimeMetrics != nil {
+		gatedRuntimeMetrics := msg2.QueueFromConfig[[]runtimemetrics.RuntimeMetricSnapshot](config, "gatedRuntimeMetrics")
+		swi.Add(DynamicSignalRuntimeMetricsGate(ctxInfo.DynamicPIDSelector, runtimeMetrics, gatedRuntimeMetrics),
+			swarm.WithID("DynamicSignalRuntimeMetricsGate"))
+		runtimeMetricsInput = gatedRuntimeMetrics
+	}
+
 	if jointMetricsConfig.Features.AppOrSpan() ||
 		jointMetricsConfig.Features.ServiceGraph() ||
 		runtimeMetricsEnabled.Any() {
@@ -217,7 +225,7 @@ func setupMetricsSubPipeline(
 			unresolvedCfg,
 			spanNameAggregatedMetrics,
 			metricsProcessEvents,
-			runtimeMetrics,
+			runtimeMetricsInput,
 		), swarm.WithID("PrometheusEndpoint"))
 	}
 
@@ -227,7 +235,7 @@ func setupMetricsSubPipeline(
 			&config.OTELMetrics,
 			jointMetricsConfig,
 			selectorCfg,
-			runtimeMetrics,
+			runtimeMetricsInput,
 		), swarm.WithID("OTELRuntimeMetricsExport"))
 	}
 }


### PR DESCRIPTION
## Summary

Pointed out in https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2442#discussion_r3443360508, the dynamic selector signal views design in #2234 didn't factor in runtime metrics (available now for Go, and soon JVM too). This gates them under the `selector.AppMetrics()` view

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
