### PR TITLE
Import config v2 capture rules

### DIFF
--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -4,6 +4,7 @@
 package convert // import "go.opentelemetry.io/obi/internal/config/convert"
 
 import (
+	"fmt"
 	"reflect"
 	"slices"
 	"strings"
@@ -33,6 +34,9 @@ var v2StatsMetricsFeatureMask = export.FeatureStats
 // runtime loading.
 func V2ToRuntime(src *schema.Extension) (*obi.Config, error) {
 	if err := schema.ValidateStandalone(src); err != nil {
+		return nil, err
+	}
+	if err := validateV2RulePatterns(src.Capture.Rules); err != nil {
 		return nil, err
 	}
 
@@ -164,6 +168,112 @@ func collectV2ExportsOTLPExclusionRule(rules *runtimeDiscoveryRules, rule schema
 	return true
 }
 
+func validateV2RulePatterns(rules []schema.Rule) error {
+	for i, rule := range rules {
+		path := fmt.Sprintf("capture.rules[%d].match", i)
+		if err := validateV2RuleProcessGlobPatterns(path+".process", rule.Match.Process); err != nil {
+			return err
+		}
+		if err := validateV2RuleProcessRegexPatterns(path+".process", rule.Match.Process); err != nil {
+			return err
+		}
+		if err := validateV2RuleKubernetesGlobPatterns(path+".kubernetes", rule.Match.Kubernetes); err != nil {
+			return err
+		}
+		if err := validateV2RuleKubernetesRegexPatterns(path+".kubernetes", rule.Match.Kubernetes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateV2RuleProcessGlobPatterns(path string, match schema.RuleProcessMatch) error {
+	if err := validateGlobAttr(path+".language_glob", match.LanguageGlob); err != nil {
+		return err
+	}
+	if err := validateGlobAttr(path+".cmd_args_glob", match.CmdArgsGlob); err != nil {
+		return err
+	}
+	return validateGlobAttr(path+".exe_path_glob", match.ExePathGlob)
+}
+
+func validateV2RuleProcessRegexPatterns(path string, match schema.RuleProcessMatch) error {
+	if err := validateRegexpAttr(path+".language_regex", match.LanguageRegex); err != nil {
+		return err
+	}
+	if err := validateRegexpAttr(path+".cmd_args_regex", match.CmdArgsRegex); err != nil {
+		return err
+	}
+	return validateRegexpAttr(path+".exe_path_regex", match.ExePathRegex)
+}
+
+func validateV2RuleKubernetesGlobPatterns(path string, match schema.RuleKubernetesMatch) error {
+	if err := validateGlobAttr(path+".namespace_glob", match.NamespaceGlob); err != nil {
+		return err
+	}
+	if err := validateGlobAttrMap(path+".metadata_glob", match.MetadataGlob); err != nil {
+		return err
+	}
+	if err := validateGlobAttrMap(path+".pod_labels", match.PodLabels); err != nil {
+		return err
+	}
+	return validateGlobAttrMap(path+".pod_annotations", match.PodAnnotations)
+}
+
+func validateV2RuleKubernetesRegexPatterns(path string, match schema.RuleKubernetesMatch) error {
+	if err := validateRegexpAttr(path+".namespace_regex", match.NamespaceRegex); err != nil {
+		return err
+	}
+	if err := validateRegexpAttrMap(path+".metadata_regex", match.MetadataRegex); err != nil {
+		return err
+	}
+	if err := validateRegexpAttrMap(path+".pod_labels_regex", match.PodLabelsRegex); err != nil {
+		return err
+	}
+	return validateRegexpAttrMap(path+".pod_annotations_regex", match.PodAnnotationsRegex)
+}
+
+func validateGlobAttr(path string, values []string) error {
+	if len(values) == 0 {
+		return nil
+	}
+	var attr services.GlobAttr
+	pattern := globPattern(values)
+	if err := attr.UnmarshalText([]byte(pattern)); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return nil
+}
+
+func validateGlobAttrMap(path string, values map[string][]string) error {
+	for key, value := range values {
+		if err := validateGlobAttr(fmt.Sprintf("%s[%q]", path, key), value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRegexpAttr(path, value string) error {
+	if value == "" {
+		return nil
+	}
+	var attr services.RegexpAttr
+	if err := attr.UnmarshalText([]byte(value)); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return nil
+}
+
+func validateRegexpAttrMap(path string, values map[string]string) error {
+	for key, value := range values {
+		if err := validateRegexpAttr(fmt.Sprintf("%s[%q]", path, key), value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func selectorFromRule(rule schema.Rule) (*services.GlobAttributes, *services.RegexSelector, bool) {
 	if rule.Match.Process.ExportsOTLP != nil || ruleMatchEmpty(rule.Match) {
 		return nil, nil, false
@@ -287,11 +397,16 @@ func globAttr(values []string) services.GlobAttr {
 	switch len(values) {
 	case 0:
 		return services.GlobAttr{}
-	case 1:
-		return services.NewGlob(values[0])
 	default:
-		return services.NewGlob("{" + strings.Join(values, ",") + "}")
+		return services.NewGlob(globPattern(values))
 	}
+}
+
+func globPattern(values []string) string {
+	if len(values) == 1 {
+		return values[0]
+	}
+	return "{" + strings.Join(values, ",") + "}"
 }
 
 func globAttrMap(values map[string][]string) map[string]*services.GlobAttr {

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -5,6 +5,8 @@ package convert // import "go.opentelemetry.io/obi/internal/config/convert"
 
 import (
 	"reflect"
+	"slices"
+	"strings"
 
 	"go.opentelemetry.io/obi/internal/config/schema"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
@@ -58,6 +60,7 @@ func runtimeConfigDefaults() obi.Config {
 
 func applyV2Capture(cfg *obi.Config, src *schema.Extension) {
 	applyV2Policy(cfg, src.Capture.Policy, completePolicy(src.Capture.Policy))
+	applyV2Rules(cfg, src.Capture.Rules)
 	applyV2Limits(cfg, src.Capture.Limits, completeLimits(src.Capture.Limits))
 	applyV2Safety(cfg, src.Capture.Safety, !zeroValue(src.Capture.Safety))
 	applyV2Channels(cfg, src.Capture.Channels, completeChannels(src.Capture.Channels))
@@ -86,6 +89,270 @@ func applyV2Policy(cfg *obi.Config, policy schema.CapturePolicy, complete bool) 
 	if !zeroValue(policy.MinProcessAge) {
 		cfg.Discovery.MinProcessAge = policy.MinProcessAge.TimeDuration()
 	}
+}
+
+type runtimeDiscoveryRules struct {
+	includeGlobs                    services.GlobDefinitionCriteria
+	excludeGlobs                    services.GlobDefinitionCriteria
+	includeRegex                    services.RegexDefinitionCriteria
+	excludeRegex                    services.RegexDefinitionCriteria
+	excludeOTelInstrumentedServices bool
+	defaultOTLPGRPCPort             int
+}
+
+func applyV2Rules(cfg *obi.Config, rules []schema.Rule) {
+	if rules == nil {
+		return
+	}
+
+	applyRuntimeDiscoveryRules(cfg, runtimeDiscoveryRulesFromV2(rules))
+}
+
+func runtimeDiscoveryRulesFromV2(rules []schema.Rule) runtimeDiscoveryRules {
+	var converted runtimeDiscoveryRules
+	for _, rule := range rules {
+		if collectV2ExportsOTLPExclusionRule(&converted, rule) {
+			continue
+		}
+		globSelector, regexSelector, ok := selectorFromRule(rule)
+		if !ok {
+			continue
+		}
+
+		switch rule.Action {
+		case schema.CaptureActionInclude:
+			if regexSelector != nil {
+				converted.includeRegex = append(converted.includeRegex, *regexSelector)
+			} else {
+				converted.includeGlobs = append(converted.includeGlobs, *globSelector)
+			}
+		case schema.CaptureActionExclude:
+			if regexSelector != nil {
+				converted.excludeRegex = append(converted.excludeRegex, *regexSelector)
+			} else {
+				converted.excludeGlobs = append(converted.excludeGlobs, *globSelector)
+			}
+		}
+	}
+	return converted
+}
+
+func applyRuntimeDiscoveryRules(cfg *obi.Config, rules runtimeDiscoveryRules) {
+	// A present v2 rules section is authoritative for runtime selector state,
+	// including the default exclusions emitted by RuntimeToV2.
+	cfg.Discovery.Instrument = rules.includeGlobs
+	cfg.Discovery.ExcludeInstrument = rules.excludeGlobs
+	cfg.Discovery.DefaultExcludeInstrument = nil
+	cfg.Discovery.Services = rules.includeRegex
+	cfg.Discovery.ExcludeServices = rules.excludeRegex
+	cfg.Discovery.DefaultExcludeServices = nil
+	cfg.Discovery.ExcludeOTelInstrumentedServices = rules.excludeOTelInstrumentedServices
+	if rules.excludeOTelInstrumentedServices {
+		cfg.Discovery.DefaultOtlpGRPCPort = rules.defaultOTLPGRPCPort
+	}
+}
+
+// The v2 exports_otlp exclusion rule is the exported form of this runtime
+// boolean/port pair, not a general selector.
+func collectV2ExportsOTLPExclusionRule(rules *runtimeDiscoveryRules, rule schema.Rule) bool {
+	if rule.Action != schema.CaptureActionExclude || !ruleMatchOnlyExportsOTLP(rule.Match) {
+		return false
+	}
+
+	rules.excludeOTelInstrumentedServices = true
+	rules.defaultOTLPGRPCPort = rule.Match.Process.ExportsOTLP.Port
+	return true
+}
+
+func selectorFromRule(rule schema.Rule) (*services.GlobAttributes, *services.RegexSelector, bool) {
+	if rule.Match.Process.ExportsOTLP != nil || ruleMatchEmpty(rule.Match) {
+		return nil, nil, false
+	}
+
+	if ruleUsesRegex(rule.Match) {
+		if ruleUsesGlob(rule.Match) {
+			return nil, nil, false
+		}
+		selector := regexSelectorFromRule(rule)
+		applyV2RegexRuleRefinement(&selector, rule.Refine)
+		return nil, &selector, true
+	}
+
+	selector := globSelectorFromRule(rule)
+	applyV2GlobRuleRefinement(&selector, rule.Refine)
+	return &selector, nil, true
+}
+
+func ruleMatchOnlyExportsOTLP(match schema.RuleMatch) bool {
+	if match.Process.ExportsOTLP == nil {
+		return false
+	}
+	match.Process.ExportsOTLP = nil
+	return ruleMatchEmpty(match)
+}
+
+func ruleUsesRegex(match schema.RuleMatch) bool {
+	return match.Process.LanguageRegex != "" ||
+		match.Process.CmdArgsRegex != "" ||
+		match.Process.ExePathRegex != "" ||
+		match.Kubernetes.NamespaceRegex != "" ||
+		len(match.Kubernetes.MetadataRegex) > 0 ||
+		len(match.Kubernetes.PodLabelsRegex) > 0 ||
+		len(match.Kubernetes.PodAnnotationsRegex) > 0
+}
+
+func ruleUsesGlob(match schema.RuleMatch) bool {
+	return len(match.Process.LanguageGlob) > 0 ||
+		len(match.Process.CmdArgsGlob) > 0 ||
+		len(match.Process.ExePathGlob) > 0 ||
+		len(match.Kubernetes.NamespaceGlob) > 0 ||
+		len(match.Kubernetes.MetadataGlob) > 0 ||
+		len(match.Kubernetes.PodLabels) > 0 ||
+		len(match.Kubernetes.PodAnnotations) > 0
+}
+
+func globSelectorFromRule(rule schema.Rule) services.GlobAttributes {
+	match := rule.Match
+	return services.GlobAttributes{
+		OpenPorts:      intEnumValue(match.Process.OpenPorts),
+		PIDs:           slices.Clone(match.Process.TargetPIDs),
+		Languages:      globAttr(match.Process.LanguageGlob),
+		CmdArgs:        globAttr(match.Process.CmdArgsGlob),
+		Path:           globAttr(match.Process.ExePathGlob),
+		ContainersOnly: match.Process.ContainersOnly,
+		Metadata:       globMetadata(match.Kubernetes),
+		PodLabels:      globAttrMap(match.Kubernetes.PodLabels),
+		PodAnnotations: globAttrMap(match.Kubernetes.PodAnnotations),
+	}
+}
+
+func regexSelectorFromRule(rule schema.Rule) services.RegexSelector {
+	match := rule.Match
+	return services.RegexSelector{
+		OpenPorts:      intEnumValue(match.Process.OpenPorts),
+		PIDs:           slices.Clone(match.Process.TargetPIDs),
+		Languages:      regexpAttr(match.Process.LanguageRegex),
+		CmdArgs:        regexpAttr(match.Process.CmdArgsRegex),
+		Path:           regexpAttr(match.Process.ExePathRegex),
+		ContainersOnly: match.Process.ContainersOnly,
+		Metadata:       regexMetadata(match.Kubernetes),
+		PodLabels:      regexpAttrMap(match.Kubernetes.PodLabelsRegex),
+		PodAnnotations: regexpAttrMap(match.Kubernetes.PodAnnotationsRegex),
+	}
+}
+
+func applyV2GlobRuleRefinement(selector *services.GlobAttributes, refine schema.RuleRefinement) {
+	if refine.Exports != nil {
+		selector.ExportModes = exportModesFromRefinement(*refine.Exports)
+	}
+	if refine.HTTP != nil && !zeroValue(refine.HTTP.Routes) {
+		selector.Routes = &services.CustomRoutesConfig{
+			Incoming: cloneStrings(refine.HTTP.Routes.Incoming.Patterns),
+			Outgoing: cloneStrings(refine.HTTP.Routes.Outgoing.Patterns),
+		}
+	}
+}
+
+func applyV2RegexRuleRefinement(selector *services.RegexSelector, refine schema.RuleRefinement) {
+	if refine.Exports != nil {
+		selector.ExportModes = exportModesFromRefinement(*refine.Exports)
+	}
+	if refine.HTTP != nil && !zeroValue(refine.HTTP.Routes) {
+		selector.Routes = &services.CustomRoutesConfig{
+			Incoming: cloneStrings(refine.HTTP.Routes.Incoming.Patterns),
+			Outgoing: cloneStrings(refine.HTTP.Routes.Outgoing.Patterns),
+		}
+	}
+}
+
+func exportModesFromRefinement(refine schema.ExportModeRefinement) services.ExportModes {
+	modes := services.NewExportModes()
+	if refine.Traces {
+		modes.AllowTraces()
+	}
+	if refine.Metrics {
+		modes.AllowMetrics()
+	}
+	return modes
+}
+
+func intEnumValue(in *services.IntEnum) services.IntEnum {
+	if in == nil {
+		return services.IntEnum{}
+	}
+	return *in
+}
+
+func globAttr(values []string) services.GlobAttr {
+	switch len(values) {
+	case 0:
+		return services.GlobAttr{}
+	case 1:
+		return services.NewGlob(values[0])
+	default:
+		return services.NewGlob("{" + strings.Join(values, ",") + "}")
+	}
+}
+
+func globAttrMap(values map[string][]string) map[string]*services.GlobAttr {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]*services.GlobAttr, len(values))
+	for key, value := range values {
+		attr := globAttr(value)
+		out[key] = &attr
+	}
+	return out
+}
+
+func globMetadata(match schema.RuleKubernetesMatch) services.MetadataGlobMap {
+	out := globAttrMap(match.MetadataGlob)
+	if out == nil {
+		out = services.MetadataGlobMap{}
+	}
+	if len(match.NamespaceGlob) > 0 {
+		attr := globAttr(match.NamespaceGlob)
+		out[services.AttrNamespace] = &attr
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func regexpAttr(value string) services.RegexpAttr {
+	if value == "" {
+		return services.RegexpAttr{}
+	}
+	return services.NewRegexp(value)
+}
+
+func regexpAttrMap(values map[string]string) map[string]*services.RegexpAttr {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]*services.RegexpAttr, len(values))
+	for key, value := range values {
+		attr := regexpAttr(value)
+		out[key] = &attr
+	}
+	return out
+}
+
+func regexMetadata(match schema.RuleKubernetesMatch) services.MetadataRegexMap {
+	out := regexpAttrMap(match.MetadataRegex)
+	if out == nil {
+		out = services.MetadataRegexMap{}
+	}
+	if match.NamespaceRegex != "" {
+		attr := regexpAttr(match.NamespaceRegex)
+		out[services.AttrNamespace] = &attr
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func applyV2Limits(cfg *obi.Config, limits schema.CaptureLimits, complete bool) {

--- a/internal/config/convert/import_test.go
+++ b/internal/config/convert/import_test.go
@@ -297,6 +297,192 @@ func TestV2ToRuntimeCustomFoundation(t *testing.T) {
 	require.Equal(t, []string{"service.version"}, got.Prometheus.ExtraSpanResourceLabels)
 }
 
+func TestV2ToRuntimeImportsRules(t *testing.T) {
+	t.Parallel()
+
+	openPorts := services.IntEnum{Ranges: []services.IntRange{{Start: 8080}}}
+	got, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Rules: []schema.Rule{
+				{
+					Action: schema.CaptureActionInclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{
+							OpenPorts:      &openPorts,
+							TargetPIDs:     []uint32{1234},
+							LanguageGlob:   []string{"go", "python"},
+							CmdArgsGlob:    []string{"serve"},
+							ExePathGlob:    []string{"/srv/*"},
+							ContainersOnly: true,
+						},
+						Kubernetes: schema.RuleKubernetesMatch{
+							NamespaceGlob:  []string{"prod"},
+							MetadataGlob:   map[string][]string{"k8s.deployment.name": {"checkout*"}},
+							PodLabels:      map[string][]string{"app": {"checkout"}},
+							PodAnnotations: map[string][]string{"team": {"payments"}},
+						},
+					},
+					Refine: schema.RuleRefinement{
+						Exports: &schema.ExportModeRefinement{Traces: true, Metrics: false},
+						HTTP: &schema.HTTPRefinement{
+							Routes: schema.HTTPRefinementRoutes{
+								Incoming: schema.HTTPRefinementRoute{Patterns: []string{"/orders/{id}"}},
+								Outgoing: schema.HTTPRefinementRoute{Patterns: []string{"/inventory/{id}"}},
+							},
+						},
+					},
+				},
+				{
+					Action: schema.CaptureActionExclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{
+							ExportsOTLP: &schema.RuleExportsOTLP{Port: 4317, Protocol: "protobuf"},
+						},
+					},
+				},
+				{
+					Action: schema.CaptureActionExclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{
+							ExePathRegex: "^/usr/bin/.*",
+						},
+						Kubernetes: schema.RuleKubernetesMatch{
+							NamespaceRegex: "kube-.*",
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, got.Discovery.Instrument, 1)
+	include := got.Discovery.Instrument[0]
+	require.Equal(t, []uint32{1234}, include.PIDs)
+	require.True(t, include.OpenPorts.Matches(8080))
+	require.Equal(t, "{go,python}", globString(include.Languages))
+	require.Equal(t, "serve", globString(include.CmdArgs))
+	require.Equal(t, "/srv/*", globString(include.Path))
+	require.True(t, include.ContainersOnly)
+	require.Equal(t, "prod", globString(*include.Metadata[services.AttrNamespace]))
+	require.Equal(t, "checkout*", globString(*include.Metadata["k8s.deployment.name"]))
+	require.Equal(t, "checkout", globString(*include.PodLabels["app"]))
+	require.True(t, include.ExportModes.CanExportTraces())
+	require.False(t, include.ExportModes.CanExportMetrics())
+	require.Equal(t, []string{"/orders/{id}"}, include.Routes.Incoming)
+	require.Equal(t, []string{"/inventory/{id}"}, include.Routes.Outgoing)
+
+	require.True(t, got.Discovery.ExcludeOTelInstrumentedServices)
+	require.Equal(t, 4317, got.Discovery.DefaultOtlpGRPCPort)
+	require.Len(t, got.Discovery.ExcludeServices, 1)
+	exclude := got.Discovery.ExcludeServices[0]
+	require.Equal(t, "^/usr/bin/.*", regexString(exclude.Path))
+	require.Equal(t, "kube-.*", regexString(*exclude.Metadata[services.AttrNamespace]))
+}
+
+func TestV2ToRuntimeSkipsUnsupportedExportsOTLPRules(t *testing.T) {
+	t.Parallel()
+
+	got, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Rules: []schema.Rule{
+				{
+					Action: schema.CaptureActionInclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{
+							ExportsOTLP: &schema.RuleExportsOTLP{Port: 4317, Protocol: "protobuf"},
+						},
+					},
+				},
+				{
+					Action: schema.CaptureActionExclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{
+							ExePathGlob: []string{"/srv/*"},
+							ExportsOTLP: &schema.RuleExportsOTLP{Port: 4317, Protocol: "protobuf"},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, got.Discovery.Instrument)
+	require.Empty(t, got.Discovery.ExcludeInstrument)
+	require.False(t, got.Discovery.ExcludeOTelInstrumentedServices)
+}
+
+func TestV2ToRuntimeSkipsMixedGlobRegexRules(t *testing.T) {
+	t.Parallel()
+
+	got, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Rules: []schema.Rule{
+				{
+					Action: schema.CaptureActionInclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{
+							ExePathGlob: []string{"/srv/*"},
+						},
+						Kubernetes: schema.RuleKubernetesMatch{
+							NamespaceRegex: "prod-.*",
+						},
+					},
+				},
+				{
+					Action: schema.CaptureActionExclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{
+							LanguageRegex: "go|java",
+						},
+						Kubernetes: schema.RuleKubernetesMatch{
+							PodLabels: map[string][]string{"app": {"checkout"}},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, got.Discovery.Instrument)
+	require.Empty(t, got.Discovery.Services)
+	require.Empty(t, got.Discovery.ExcludeInstrument)
+	require.Empty(t, got.Discovery.ExcludeServices)
+}
+
+func TestV2ToRuntimeRulesPresenceControlsSelectorReplacement(t *testing.T) {
+	t.Parallel()
+
+	missing, err := V2ToRuntime(&schema.Extension{Version: schema.SupportedVersion})
+	require.NoError(t, err)
+	require.Equal(t, obi.DefaultConfig.Discovery.DefaultExcludeInstrument, missing.Discovery.DefaultExcludeInstrument)
+	require.Equal(t, obi.DefaultConfig.Discovery.DefaultExcludeServices, missing.Discovery.DefaultExcludeServices)
+	require.Equal(t,
+		obi.DefaultConfig.Discovery.ExcludeOTelInstrumentedServices,
+		missing.Discovery.ExcludeOTelInstrumentedServices,
+	)
+
+	empty, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Rules: []schema.Rule{},
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, empty.Discovery.Instrument)
+	require.Empty(t, empty.Discovery.ExcludeInstrument)
+	require.Empty(t, empty.Discovery.DefaultExcludeInstrument)
+	require.Empty(t, empty.Discovery.Services)
+	require.Empty(t, empty.Discovery.ExcludeServices)
+	require.Empty(t, empty.Discovery.DefaultExcludeServices)
+	require.False(t, empty.Discovery.ExcludeOTelInstrumentedServices)
+}
+
 func TestV2ToRuntimePreservesDefaultsForMissingSections(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/convert/import_test.go
+++ b/internal/config/convert/import_test.go
@@ -455,6 +455,80 @@ func TestV2ToRuntimeSkipsMixedGlobRegexRules(t *testing.T) {
 	require.Empty(t, got.Discovery.ExcludeServices)
 }
 
+func TestV2ToRuntimeRejectsMalformedRulePatterns(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		match   schema.RuleMatch
+		wantErr string
+	}{
+		{
+			name: "glob",
+			match: schema.RuleMatch{
+				Process: schema.RuleProcessMatch{ExePathGlob: []string{"["}},
+			},
+			wantErr: "capture.rules[0].match.process.exe_path_glob",
+		},
+		{
+			name: "regex",
+			match: schema.RuleMatch{
+				Process: schema.RuleProcessMatch{ExePathRegex: "["},
+			},
+			wantErr: "capture.rules[0].match.process.exe_path_regex",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := V2ToRuntime(&schema.Extension{
+				Version: schema.SupportedVersion,
+				Capture: schema.Capture{
+					Rules: []schema.Rule{
+						{
+							Action: schema.CaptureActionInclude,
+							Match:  tc.match,
+						},
+					},
+				},
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestV2ToRuntimeDefaultIncludeUsesOnlyExclusions(t *testing.T) {
+	t.Parallel()
+
+	got, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Policy: schema.CapturePolicy{
+				DefaultAction: schema.CaptureActionInclude,
+				MatchOrder:    schema.MatchOrderFirstMatchWins,
+			},
+			Rules: []schema.Rule{
+				{
+					Action: schema.CaptureActionExclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{
+							ExePathGlob: []string{"*/obi", "obi"},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, got.Discovery.Instrument)
+	require.Empty(t, got.Discovery.Services)
+	require.Len(t, got.Discovery.ExcludeInstrument, 1)
+	require.Equal(t, "{*/obi,obi}", globString(got.Discovery.ExcludeInstrument[0].Path))
+	require.Empty(t, got.Discovery.ExcludeServices)
+}
+
 func TestV2ToRuntimeRulesPresenceControlsSelectorReplacement(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Implements the first review-sized slice of step 6, "Expand import conversion parity", from #2251.

This PR is intentionally scoped to capture rule import parity:

- import advanced capture rule selectors into runtime discovery selectors
- support glob and regex process selectors, Kubernetes namespace/metadata/label/annotation selectors, target PIDs, ports, and containers-only matching
- import OTLP-export exclusion rules back to `ExcludeOTelInstrumentedServices` and `DefaultOtlpGRPCPort`
- import per-rule export refinements and direction-aware HTTP route refinements

This stays internal-only and does not add CLI support, runtime v2 loading, receiver support, generated docs, or public config v2 APIs.

## Non-goals

To keep this under the review-size limit in #2251, the following step-6 areas are left for follow-up PRs:

- document-level resource/tracer_provider/meter_provider import
- global HTTP route, payload extraction, and enrichment import
- enrichment attribute and Kubernetes import
- network capture/stats import parity
- mechanical round-trip/audit coverage for the remaining import/export gaps

## Tests

- `go test ./internal/config/...`
- `go test ./cmd/check-config-v2-parity`
- `make check-config-v2-parity`
