### PR TITLE
Guard Docker major Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -222,8 +222,52 @@
     {
       "groupName": "Docker",
       "matchManagers": ["dockerfile"],
-      "matchUpdateTypes": ["patch", "digest", "minor", "major"],
+      "matchUpdateTypes": ["patch", "digest", "minor"],
       "schedule": ["before 6am on Tuesday"]
+    },
+    {
+      "description": "Require manual approval for remaining Docker image major upgrades because Dockerfile versions define runtime compatibility test coverage",
+      "groupName": "Docker major updates",
+      "matchManagers": ["dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "schedule": ["before 6am on Tuesday"]
+    },
+    {
+      "description": "Block high-risk Docker image major upgrades for runtime and service compatibility fixtures",
+      "matchManagers": ["dockerfile"],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "debian",
+        "docker.io/library/debian",
+        "docker.io/library/eclipse-temurin",
+        "docker.io/library/gcc",
+        "docker.io/library/gradle",
+        "docker.io/library/mysql",
+        "docker.io/library/node",
+        "docker.io/library/redis",
+        "docker.io/library/ruby",
+        "eclipse-temurin",
+        "gcc",
+        "gradle",
+        "library/debian",
+        "library/eclipse-temurin",
+        "library/gcc",
+        "library/gradle",
+        "library/mysql",
+        "library/node",
+        "library/redis",
+        "library/ruby",
+        "mcr.microsoft.com/dotnet/aspnet",
+        "mcr.microsoft.com/dotnet/sdk",
+        "mysql",
+        "node",
+        "redis",
+        "ruby"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     },
     {
       "groupName": "Github Actions",


### PR DESCRIPTION
## Summary

- Limit the grouped Docker Renovate rule to patch, digest, and minor updates.
- Route remaining Docker image major updates through Dependency Dashboard approval.
- Block major updates for runtime and service fixture images that encode compatibility coverage.

## Motivation

Renovate PR #2168 grouped unrelated Docker major updates into one change. That made the PR difficult to review and caused host integration failures across runtime fixtures such as .NET, Redis, and the gRPC relay components.

Dockerfile major version bumps in this repository often change the tested runtime or service compatibility surface. Those updates should happen in focused PRs with targeted integration validation rather than as one broad maintenance batch.