### PR TITLE
Detect HTTP2 for pre-existing connections

### DIFF
--- a/bpf/generictracer/http2_grpc.h
+++ b/bpf/generictracer/http2_grpc.h
@@ -33,7 +33,11 @@ typedef struct frame_header {
     u32 stream_id : 31;
 } __attribute__((packed)) frame_header_t;
 
-enum { k_flag_data_end_stream = 0x1, k_frame_header_len = 9 };
+enum {
+    k_flag_data_end_stream = 0x1,
+    k_frame_header_len = 9,
+    k_max_plausible_h2_frame_len = 1 << 14, // (RFC 7540 6.5.2)
+};
 
 _Static_assert(sizeof(frame_header_t) == k_frame_header_len, "frame_header_t size mismatch");
 
@@ -59,6 +63,14 @@ static __always_inline u8 is_headers_frame(const frame_header_t *frame) {
     return frame->type == FrameHeaders && frame->stream_id;
 }
 
+static __always_inline u8 is_http2_headers_start(const unsigned char *p, u32 len) {
+    frame_header_t frame;
+    if (!read_http2_grpc_frame_header(&frame, p, len)) {
+        return 0;
+    }
+    return is_headers_frame(&frame) && frame.length <= k_max_plausible_h2_frame_len;
+}
+
 static __always_inline u8 has_preface(unsigned char *p, u32 len) {
     if (len < MIN_HTTP2_SIZE) {
         return 0;
@@ -68,7 +80,7 @@ static __always_inline u8 has_preface(unsigned char *p, u32 len) {
 }
 
 static __always_inline u8 is_http2_or_grpc(unsigned char *p, u32 len) {
-    return has_preface(p, len);
+    return has_preface(p, len) || is_http2_headers_start(p, len);
 }
 
 static __always_inline void skip_http2_preface(call_protocol_args_t *args) {

--- a/bpf/generictracer/protocol_handler.c
+++ b/bpf/generictracer/protocol_handler.c
@@ -40,17 +40,19 @@ int obi_handle_buf_with_args(void *ctx) {
         if (!args->protocols.http2) {
             return 0;
         }
-        bpf_dbg_printk("Found HTTP2 or gRPC connection");
-        http2_conn_info_data_t data = {
-            .id = 0,
-            .flags = http2_conn_flag_new,
-        };
-        data.id = uniqueHTTP2ConnId(&args->pid_conn);
-        if (args->ssl) {
-            data.flags |= http2_conn_flag_ssl;
+        if (!bpf_map_lookup_elem(&ongoing_http2_connections, &args->pid_conn)) {
+            bpf_dbg_printk("Found HTTP2 or gRPC connection");
+            http2_conn_info_data_t data = {
+                .id = 0,
+                .flags = http2_conn_flag_new,
+            };
+            data.id = uniqueHTTP2ConnId(&args->pid_conn);
+            if (args->ssl) {
+                data.flags |= http2_conn_flag_ssl;
+            }
+            bpf_map_update_elem(&ongoing_http2_connections, &args->pid_conn, &data, BPF_ANY);
+            skip_http2_preface(args);
         }
-        bpf_map_update_elem(&ongoing_http2_connections, &args->pid_conn, &data, BPF_ANY);
-        skip_http2_preface(args);
     }
 
     http2_conn_info_data_t *h2g = bpf_map_lookup_elem(&ongoing_http2_connections, &args->pid_conn);

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -840,13 +840,14 @@ static __always_inline void wrap_http2_traceparent(struct sk_msg_md *msg,
         bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
         return;
     }
-    if (msg->size < k_h2_preface_check_len) {
+    if (msg->size >= k_h2_preface_check_len &&
+        bpf_msg_pull_data(msg, 0, k_h2_preface_check_len, 0) == 0 &&
+        is_http2_preface(msg->data, msg->data_end)) {
+        bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
         return;
     }
-    if (bpf_msg_pull_data(msg, 0, k_h2_preface_check_len, 0) != 0) {
-        return;
-    }
-    if (is_http2_preface(msg->data, msg->data_end)) {
+    h2_frame_info_t f;
+    if (parse_h2_frame_at(msg, 0, msg->size, &f) && f.is_headers_end) {
         bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
     }
 }


### PR DESCRIPTION
## Summary

Describe the change briefly.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
