### PR TITLE
Import config v2 document telemetry sections

### DIFF
--- a/internal/config/convert/import_document.go
+++ b/internal/config/convert/import_document.go
@@ -72,7 +72,7 @@ func stringResourceAttribute(attr otelconfx.AttributeNameValue) (string, bool) {
 }
 
 func applyV2TracerProvider(cfg *obi.Config, provider *otelconfx.TracerProvider) {
-	if provider == nil {
+	if provider == nil || !exportedTracerProvider(provider) {
 		return
 	}
 
@@ -98,6 +98,11 @@ func applyV2TracerProvider(cfg *obi.Config, provider *otelconfx.TracerProvider) 
 		cfg.Traces.TracesEndpoint = *batch.Exporter.OTLPGrpc.Endpoint
 	}
 	cfg.Traces.TracesProtocol = otelcfg.ProtocolGRPC
+}
+
+func exportedTracerProvider(provider *otelconfx.TracerProvider) bool {
+	return provider.Limits == nil &&
+		provider.TracerConfiguratorDevelopment == nil
 }
 
 func exportedBatchSpanProcessor(provider *otelconfx.TracerProvider) (*otelconfx.BatchSpanProcessor, bool) {
@@ -128,7 +133,8 @@ func exportedOTLPGrpcExporter(exporter *otelconfx.OTLPGrpcExporter) bool {
 	return exporter.Compression == nil &&
 		exporter.Headers == nil &&
 		exporter.HeadersList == nil &&
-		exporter.Timeout == nil
+		exporter.Timeout == nil &&
+		exportedGrpcTLS(exporter.Tls)
 }
 
 func samplerConfigFromV2(sampler *otelconfx.Sampler) (services.SamplerConfig, bool) {
@@ -206,7 +212,7 @@ func traceIDRatioSamplerConfig(
 }
 
 func applyV2MeterProvider(cfg *obi.Config, provider *otelconfx.MeterProvider) {
-	if provider == nil {
+	if provider == nil || !exportedMeterProvider(provider) {
 		return
 	}
 
@@ -221,6 +227,12 @@ func applyV2MeterProvider(cfg *obi.Config, provider *otelconfx.MeterProvider) {
 	if pull != nil {
 		applyV2PullMetricReader(cfg, pull)
 	}
+}
+
+func exportedMeterProvider(provider *otelconfx.MeterProvider) bool {
+	return provider.ExemplarFilter == nil &&
+		provider.MeterConfiguratorDevelopment == nil &&
+		len(provider.Views) == 0
 }
 
 func exportedMetricReaders(
@@ -270,7 +282,8 @@ func exportedOTLPGrpcMetricExporter(exporter *otelconfx.OTLPGrpcMetricExporter) 
 		exporter.Headers == nil &&
 		exporter.HeadersList == nil &&
 		exporter.TemporalityPreference == nil &&
-		exporter.Timeout == nil
+		exporter.Timeout == nil &&
+		exportedGrpcTLS(exporter.Tls)
 }
 
 func exportedPullMetricReader(reader *otelconfx.PullMetricReader) bool {
@@ -310,6 +323,16 @@ func applyV2PullMetricReader(cfg *obi.Config, reader *otelconfx.PullMetricReader
 	if exporter.Port != nil {
 		cfg.Prometheus.Port = *exporter.Port
 	}
+}
+
+func exportedGrpcTLS(tls *otelconfx.GrpcTls) bool {
+	if tls == nil {
+		return true
+	}
+
+	return tls.CaFile == nil &&
+		tls.CertFile == nil &&
+		tls.KeyFile == nil
 }
 
 func countTrue(values ...bool) int {

--- a/internal/config/convert/import_document.go
+++ b/internal/config/convert/import_document.go
@@ -1,0 +1,323 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert // import "go.opentelemetry.io/obi/internal/config/convert"
+
+import (
+	"errors"
+	"strconv"
+	"time"
+
+	otelconfx "go.opentelemetry.io/contrib/otelconf/x"
+
+	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/appolly/services"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+// DocumentToRuntime converts a standalone v2 document into an OBI runtime
+// configuration. It imports the OBI extension plus the document-level
+// OpenTelemetry sections emitted by RuntimeToV2.
+func DocumentToRuntime(src *schema.Document) (*obi.Config, error) {
+	if src == nil {
+		return nil, errors.New("missing OBI document")
+	}
+
+	cfg, err := V2ToRuntime(src.Extensions.OBI)
+	if err != nil {
+		return nil, err
+	}
+
+	applyV2Resource(cfg, src.Resource)
+	applyV2TracerProvider(cfg, src.TracerProvider)
+	applyV2MeterProvider(cfg, src.MeterProvider)
+
+	return cfg, nil
+}
+
+func applyV2Resource(cfg *obi.Config, resource *otelconfx.Resource) {
+	if resource == nil || !exportedResource(resource) {
+		return
+	}
+
+	for _, attr := range resource.Attributes {
+		value, ok := stringResourceAttribute(attr)
+		if !ok {
+			continue
+		}
+
+		switch attr.Name {
+		case "host.name":
+			cfg.Attributes.InstanceID.OverrideHostname = value
+		case "host.id":
+			cfg.Attributes.HostID.Override = value
+		}
+	}
+}
+
+func exportedResource(resource *otelconfx.Resource) bool {
+	return resource.AttributesList == nil &&
+		resource.DetectionDevelopment == nil &&
+		resource.SchemaUrl == nil
+}
+
+func stringResourceAttribute(attr otelconfx.AttributeNameValue) (string, bool) {
+	if attr.Type != nil && *attr.Type != otelconfx.AttributeTypeString {
+		return "", false
+	}
+
+	value, ok := attr.Value.(string)
+	return value, ok
+}
+
+func applyV2TracerProvider(cfg *obi.Config, provider *otelconfx.TracerProvider) {
+	if provider == nil {
+		return
+	}
+
+	if sampler, ok := samplerConfigFromV2(provider.Sampler); ok {
+		cfg.Traces.SamplerConfig = sampler
+	}
+
+	batch, ok := exportedBatchSpanProcessor(provider)
+	if !ok {
+		return
+	}
+
+	if batch.MaxQueueSize != nil {
+		cfg.Traces.QueueSize = *batch.MaxQueueSize
+	}
+	if batch.MaxExportBatchSize != nil {
+		cfg.Traces.BatchMaxSize = *batch.MaxExportBatchSize
+	}
+	if batch.ScheduleDelay != nil {
+		cfg.Traces.BatchTimeout = time.Duration(*batch.ScheduleDelay) * time.Millisecond
+	}
+	if batch.Exporter.OTLPGrpc.Endpoint != nil {
+		cfg.Traces.TracesEndpoint = *batch.Exporter.OTLPGrpc.Endpoint
+	}
+	cfg.Traces.TracesProtocol = otelcfg.ProtocolGRPC
+}
+
+func exportedBatchSpanProcessor(provider *otelconfx.TracerProvider) (*otelconfx.BatchSpanProcessor, bool) {
+	if len(provider.Processors) != 1 {
+		return nil, false
+	}
+
+	processor := provider.Processors[0]
+	if processor.Batch == nil || processor.Simple != nil {
+		return nil, false
+	}
+
+	exporter := processor.Batch.Exporter
+	if processor.Batch.ExportTimeout != nil ||
+		exporter.OTLPGrpc == nil ||
+		exporter.OTLPHttp != nil ||
+		exporter.OTLPFileDevelopment != nil ||
+		!zeroValue(exporter.Console) ||
+		exporter.AdditionalProperties != nil ||
+		!exportedOTLPGrpcExporter(exporter.OTLPGrpc) {
+		return nil, false
+	}
+
+	return processor.Batch, true
+}
+
+func exportedOTLPGrpcExporter(exporter *otelconfx.OTLPGrpcExporter) bool {
+	return exporter.Compression == nil &&
+		exporter.Headers == nil &&
+		exporter.HeadersList == nil &&
+		exporter.Timeout == nil
+}
+
+func samplerConfigFromV2(sampler *otelconfx.Sampler) (services.SamplerConfig, bool) {
+	if sampler == nil {
+		return services.SamplerConfig{}, false
+	}
+	if sampler.CompositeDevelopment != nil ||
+		sampler.JaegerRemoteDevelopment != nil ||
+		sampler.ProbabilityDevelopment != nil ||
+		sampler.AdditionalProperties != nil {
+		return services.SamplerConfig{}, false
+	}
+
+	alwaysOff := !zeroValue(sampler.AlwaysOff)
+	alwaysOn := !zeroValue(sampler.AlwaysOn)
+	traceIDRatio := sampler.TraceIDRatioBased != nil
+	parentBased := sampler.ParentBased != nil
+	if countTrue(alwaysOff, alwaysOn, traceIDRatio, parentBased) != 1 {
+		return services.SamplerConfig{}, false
+	}
+
+	switch {
+	case alwaysOn:
+		return services.SamplerConfig{Name: services.SamplerAlwaysOn}, true
+	case alwaysOff:
+		return services.SamplerConfig{Name: services.SamplerAlwaysOff}, true
+	case traceIDRatio:
+		return traceIDRatioSamplerConfig(sampler.TraceIDRatioBased, services.SamplerTraceIDRatio)
+	default:
+		return parentBasedSamplerConfig(sampler.ParentBased)
+	}
+}
+
+func parentBasedSamplerConfig(sampler *otelconfx.ParentBasedSampler) (services.SamplerConfig, bool) {
+	if sampler.Root == nil ||
+		sampler.LocalParentSampled != nil ||
+		sampler.LocalParentNotSampled != nil ||
+		sampler.RemoteParentSampled != nil ||
+		sampler.RemoteParentNotSampled != nil {
+		return services.SamplerConfig{}, false
+	}
+
+	root, ok := samplerConfigFromV2(sampler.Root)
+	if !ok {
+		return services.SamplerConfig{}, false
+	}
+
+	switch root.Name {
+	case services.SamplerAlwaysOn:
+		return services.SamplerConfig{Name: services.SamplerParentBasedAlwaysOn}, true
+	case services.SamplerAlwaysOff:
+		return services.SamplerConfig{Name: services.SamplerParentBasedAlwaysOff}, true
+	case services.SamplerTraceIDRatio:
+		return services.SamplerConfig{
+			Name: services.SamplerParentBasedTraceIDRatio,
+			Arg:  root.Arg,
+		}, true
+	default:
+		return services.SamplerConfig{}, false
+	}
+}
+
+func traceIDRatioSamplerConfig(
+	sampler *otelconfx.TraceIDRatioBasedSampler,
+	name services.SamplerName,
+) (services.SamplerConfig, bool) {
+	if sampler == nil || sampler.Ratio == nil {
+		return services.SamplerConfig{}, false
+	}
+
+	return services.SamplerConfig{
+		Name: name,
+		Arg:  strconv.FormatFloat(*sampler.Ratio, 'f', -1, 64),
+	}, true
+}
+
+func applyV2MeterProvider(cfg *obi.Config, provider *otelconfx.MeterProvider) {
+	if provider == nil {
+		return
+	}
+
+	periodic, pull, ok := exportedMetricReaders(provider.Readers)
+	if !ok {
+		return
+	}
+
+	if periodic != nil {
+		applyV2PeriodicMetricReader(cfg, periodic)
+	}
+	if pull != nil {
+		applyV2PullMetricReader(cfg, pull)
+	}
+}
+
+func exportedMetricReaders(
+	readers []otelconfx.MetricReader,
+) (*otelconfx.PeriodicMetricReader, *otelconfx.PullMetricReader, bool) {
+	if len(readers) > 2 {
+		return nil, nil, false
+	}
+
+	var periodic *otelconfx.PeriodicMetricReader
+	var pull *otelconfx.PullMetricReader
+	for _, reader := range readers {
+		switch {
+		case reader.Periodic != nil && reader.Pull == nil:
+			if periodic != nil || !exportedPeriodicMetricReader(reader.Periodic) {
+				return nil, nil, false
+			}
+			periodic = reader.Periodic
+		case reader.Pull != nil && reader.Periodic == nil:
+			if pull != nil || !exportedPullMetricReader(reader.Pull) {
+				return nil, nil, false
+			}
+			pull = reader.Pull
+		default:
+			return nil, nil, false
+		}
+	}
+
+	return periodic, pull, true
+}
+
+func exportedPeriodicMetricReader(reader *otelconfx.PeriodicMetricReader) bool {
+	exporter := reader.Exporter
+	return reader.CardinalityLimits == nil &&
+		reader.Producers == nil &&
+		reader.Timeout == nil &&
+		exporter.OTLPGrpc != nil &&
+		exporter.OTLPHttp == nil &&
+		exporter.OTLPFileDevelopment == nil &&
+		exporter.Console == nil &&
+		exporter.AdditionalProperties == nil &&
+		exportedOTLPGrpcMetricExporter(exporter.OTLPGrpc)
+}
+
+func exportedOTLPGrpcMetricExporter(exporter *otelconfx.OTLPGrpcMetricExporter) bool {
+	return exporter.Compression == nil &&
+		exporter.Headers == nil &&
+		exporter.HeadersList == nil &&
+		exporter.TemporalityPreference == nil &&
+		exporter.Timeout == nil
+}
+
+func exportedPullMetricReader(reader *otelconfx.PullMetricReader) bool {
+	exporter := reader.Exporter
+	return reader.CardinalityLimits == nil &&
+		reader.Producers == nil &&
+		exporter.PrometheusDevelopment != nil &&
+		exporter.AdditionalProperties == nil &&
+		exportedPrometheusDevelopmentExporter(exporter.PrometheusDevelopment)
+}
+
+func exportedPrometheusDevelopmentExporter(exporter *otelconfx.ExperimentalPrometheusMetricExporter) bool {
+	return exporter.Host == nil &&
+		exporter.TranslationStrategy == nil &&
+		exporter.WithResourceConstantLabels == nil &&
+		exporter.WithoutScopeInfo == nil &&
+		exporter.WithoutTargetInfo == nil
+}
+
+func applyV2PeriodicMetricReader(cfg *obi.Config, reader *otelconfx.PeriodicMetricReader) {
+	if reader.Interval != nil {
+		cfg.OTELMetrics.Interval = time.Duration(*reader.Interval) * time.Millisecond
+	}
+
+	exporter := reader.Exporter.OTLPGrpc
+	if exporter.Endpoint != nil {
+		cfg.OTELMetrics.MetricsEndpoint = *exporter.Endpoint
+	}
+	if exporter.DefaultHistogramAggregation != nil {
+		cfg.OTELMetrics.HistogramAggregation = otelcfg.HistogramAggregation(*exporter.DefaultHistogramAggregation)
+	}
+	cfg.OTELMetrics.MetricsProtocol = otelcfg.ProtocolGRPC
+}
+
+func applyV2PullMetricReader(cfg *obi.Config, reader *otelconfx.PullMetricReader) {
+	exporter := reader.Exporter.PrometheusDevelopment
+	if exporter.Port != nil {
+		cfg.Prometheus.Port = *exporter.Port
+	}
+}
+
+func countTrue(values ...bool) int {
+	var count int
+	for _, value := range values {
+		if value {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/config/convert/import_document_test.go
+++ b/internal/config/convert/import_document_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	otelconfx "go.opentelemetry.io/contrib/otelconf/x"
 
 	"go.opentelemetry.io/obi/internal/config/schema"

--- a/internal/config/convert/import_document_test.go
+++ b/internal/config/convert/import_document_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	otelconfx "go.opentelemetry.io/contrib/otelconf/x"
 
 	"go.opentelemetry.io/obi/internal/config/schema"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
@@ -105,5 +106,201 @@ func TestDocumentToRuntimeSkipsUnsupportedMetricReaderShapes(t *testing.T) {
 	require.Equal(t, obi.DefaultConfig.OTELMetrics.MetricsEndpoint, got.OTELMetrics.MetricsEndpoint)
 	require.Equal(t, obi.DefaultConfig.OTELMetrics.MetricsProtocol, got.OTELMetrics.MetricsProtocol)
 	require.Equal(t, obi.DefaultConfig.OTELMetrics.GetInterval(), got.OTELMetrics.GetInterval())
+	require.Equal(t, obi.DefaultConfig.Prometheus.Port, got.Prometheus.Port)
+}
+
+func TestDocumentToRuntimeSkipsUnsupportedTracerProviderShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*otelconfx.TracerProvider)
+	}{
+		{
+			name: "span limits",
+			mutate: func(provider *otelconfx.TracerProvider) {
+				limit := 12
+				provider.Limits = &otelconfx.SpanLimits{
+					AttributeCountLimit: &limit,
+				}
+			},
+		},
+		{
+			name: "tracer configurator",
+			mutate: func(provider *otelconfx.TracerProvider) {
+				provider.TracerConfiguratorDevelopment = &otelconfx.ExperimentalTracerConfigurator{}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc := documentWithRuntimeTelemetry()
+			tt.mutate(doc.TracerProvider)
+
+			got, err := DocumentToRuntime(doc)
+			require.NoError(t, err)
+
+			requireDefaultTraceProvider(t, got)
+		})
+	}
+}
+
+func TestDocumentToRuntimeSkipsUnsupportedMeterProviderShapes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mutate func(*otelconfx.MeterProvider)
+	}{
+		{
+			name: "exemplar filter",
+			mutate: func(provider *otelconfx.MeterProvider) {
+				filter := otelconfx.ExemplarFilterAlwaysOn
+				provider.ExemplarFilter = &filter
+			},
+		},
+		{
+			name: "meter configurator",
+			mutate: func(provider *otelconfx.MeterProvider) {
+				provider.MeterConfiguratorDevelopment = &otelconfx.ExperimentalMeterConfigurator{}
+			},
+		},
+		{
+			name: "views",
+			mutate: func(provider *otelconfx.MeterProvider) {
+				provider.Views = []otelconfx.View{{}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc := documentWithRuntimeTelemetry()
+			tt.mutate(doc.MeterProvider)
+
+			got, err := DocumentToRuntime(doc)
+			require.NoError(t, err)
+
+			requireDefaultMeterProvider(t, got)
+		})
+	}
+}
+
+func TestDocumentToRuntimeSkipsUnsupportedTraceOTLPGrpcTLS(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range unsupportedTLSFields() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc := documentWithRuntimeTelemetry()
+			tt.mutate(doc.TracerProvider.Processors[0].Batch.Exporter.OTLPGrpc.Tls)
+
+			got, err := DocumentToRuntime(doc)
+			require.NoError(t, err)
+
+			requireDefaultTraceExporter(t, got)
+		})
+	}
+}
+
+func TestDocumentToRuntimeSkipsUnsupportedMetricOTLPGrpcTLS(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range unsupportedTLSFields() {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc := documentWithRuntimeTelemetry()
+			tt.mutate(doc.MeterProvider.Readers[0].Periodic.Exporter.OTLPGrpc.Tls)
+
+			got, err := DocumentToRuntime(doc)
+			require.NoError(t, err)
+
+			requireDefaultMeterProvider(t, got)
+		})
+	}
+}
+
+func documentWithRuntimeTelemetry() *schema.Document {
+	cfg := defaultRuntimeConfig()
+	cfg.Traces.TracesEndpoint = "http://traces.example:4317"
+	cfg.Traces.BatchMaxSize = 907
+	cfg.Traces.QueueSize = 908
+	cfg.Traces.BatchTimeout = 909 * time.Millisecond
+	cfg.Traces.SamplerConfig.Name = services.SamplerTraceIDRatio
+	cfg.Traces.SamplerConfig.Arg = "0.25"
+
+	cfg.OTELMetrics.MetricsEndpoint = "https://metrics.example:4317"
+	cfg.OTELMetrics.Interval = 914 * time.Millisecond
+	cfg.OTELMetrics.HistogramAggregation = otelcfg.HistogramAggregationExponential
+
+	cfg.Prometheus.Port = 917
+
+	doc, _ := RuntimeToV2(&cfg)
+	return doc
+}
+
+func unsupportedTLSFields() []struct {
+	name   string
+	mutate func(*otelconfx.GrpcTls)
+} {
+	return []struct {
+		name   string
+		mutate func(*otelconfx.GrpcTls)
+	}{
+		{
+			name: "CA file",
+			mutate: func(tls *otelconfx.GrpcTls) {
+				caFile := "/tmp/ca.pem"
+				tls.CaFile = &caFile
+			},
+		},
+		{
+			name: "cert file",
+			mutate: func(tls *otelconfx.GrpcTls) {
+				certFile := "/tmp/cert.pem"
+				tls.CertFile = &certFile
+			},
+		},
+		{
+			name: "key file",
+			mutate: func(tls *otelconfx.GrpcTls) {
+				keyFile := "/tmp/key.pem"
+				tls.KeyFile = &keyFile
+			},
+		},
+	}
+}
+
+func requireDefaultTraceProvider(t *testing.T, got *obi.Config) {
+	t.Helper()
+
+	requireDefaultTraceExporter(t, got)
+	require.Equal(t, obi.DefaultConfig.Traces.SamplerConfig, got.Traces.SamplerConfig)
+}
+
+func requireDefaultTraceExporter(t *testing.T, got *obi.Config) {
+	t.Helper()
+
+	require.Equal(t, obi.DefaultConfig.Traces.TracesEndpoint, got.Traces.TracesEndpoint)
+	require.Equal(t, obi.DefaultConfig.Traces.TracesProtocol, got.Traces.TracesProtocol)
+	require.Equal(t, obi.DefaultConfig.Traces.QueueSize, got.Traces.QueueSize)
+	require.Equal(t, obi.DefaultConfig.Traces.BatchMaxSize, got.Traces.BatchMaxSize)
+	require.Equal(t, obi.DefaultConfig.Traces.BatchTimeout, got.Traces.BatchTimeout)
+}
+
+func requireDefaultMeterProvider(t *testing.T, got *obi.Config) {
+	t.Helper()
+
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.MetricsEndpoint, got.OTELMetrics.MetricsEndpoint)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.MetricsProtocol, got.OTELMetrics.MetricsProtocol)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.GetInterval(), got.OTELMetrics.GetInterval())
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.HistogramAggregation, got.OTELMetrics.HistogramAggregation)
 	require.Equal(t, obi.DefaultConfig.Prometheus.Port, got.Prometheus.Port)
 }

--- a/internal/config/convert/import_document_test.go
+++ b/internal/config/convert/import_document_test.go
@@ -1,0 +1,109 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/appolly/services"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+func TestDocumentToRuntimeImportsExportedDocumentSections(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultRuntimeConfig()
+	cfg.ChannelBufferLen = 77
+
+	cfg.Attributes.InstanceID.OverrideHostname = "host-override"
+	cfg.Attributes.HostID.Override = "host-id-1"
+
+	cfg.Traces.TracesEndpoint = "http://traces.example:4317"
+	cfg.Traces.BatchMaxSize = 907
+	cfg.Traces.QueueSize = 908
+	cfg.Traces.BatchTimeout = 909 * time.Millisecond
+	cfg.Traces.SamplerConfig.Name = services.SamplerTraceIDRatio
+	cfg.Traces.SamplerConfig.Arg = "0.25"
+
+	cfg.OTELMetrics.MetricsEndpoint = "https://metrics.example:4317"
+	cfg.OTELMetrics.Interval = 914 * time.Millisecond
+	cfg.OTELMetrics.HistogramAggregation = otelcfg.HistogramAggregationExponential
+
+	cfg.Prometheus.Port = 917
+
+	doc, _ := RuntimeToV2(&cfg)
+
+	got, err := DocumentToRuntime(doc)
+	require.NoError(t, err)
+
+	require.Equal(t, 77, got.ChannelBufferLen)
+	require.Equal(t, "host-override", got.Attributes.InstanceID.OverrideHostname)
+	require.Equal(t, "host-id-1", got.Attributes.HostID.Override)
+
+	require.Equal(t, "http://traces.example:4317", got.Traces.TracesEndpoint)
+	require.Equal(t, otelcfg.ProtocolGRPC, got.Traces.TracesProtocol)
+	require.Equal(t, 908, got.Traces.QueueSize)
+	require.Equal(t, 907, got.Traces.BatchMaxSize)
+	require.Equal(t, 909*time.Millisecond, got.Traces.BatchTimeout)
+	require.Equal(t, services.SamplerConfig{
+		Name: services.SamplerTraceIDRatio,
+		Arg:  "0.25",
+	}, got.Traces.SamplerConfig)
+
+	require.Equal(t, "https://metrics.example:4317", got.OTELMetrics.MetricsEndpoint)
+	require.Equal(t, otelcfg.ProtocolGRPC, got.OTELMetrics.MetricsProtocol)
+	require.Equal(t, 914*time.Millisecond, got.OTELMetrics.Interval)
+	require.Equal(t, otelcfg.HistogramAggregationExponential, got.OTELMetrics.HistogramAggregation)
+	require.Equal(t, 917, got.Prometheus.Port)
+}
+
+func TestDocumentToRuntimePreservesDefaultsForMissingDocumentSections(t *testing.T) {
+	t.Parallel()
+
+	got, err := DocumentToRuntime(&schema.Document{
+		Extensions: schema.Extensions{
+			OBI: &schema.Extension{Version: schema.SupportedVersion},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, obi.DefaultConfig.Attributes.InstanceID.OverrideHostname, got.Attributes.InstanceID.OverrideHostname)
+	require.Equal(t, obi.DefaultConfig.Attributes.HostID.Override, got.Attributes.HostID.Override)
+	require.Equal(t, obi.DefaultConfig.Traces.TracesEndpoint, got.Traces.TracesEndpoint)
+	require.Equal(t, obi.DefaultConfig.Traces.TracesProtocol, got.Traces.TracesProtocol)
+	require.Equal(t, obi.DefaultConfig.Traces.QueueSize, got.Traces.QueueSize)
+	require.Equal(t, obi.DefaultConfig.Traces.BatchMaxSize, got.Traces.BatchMaxSize)
+	require.Equal(t, obi.DefaultConfig.Traces.BatchTimeout, got.Traces.BatchTimeout)
+	require.Equal(t, obi.DefaultConfig.Traces.SamplerConfig, got.Traces.SamplerConfig)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.MetricsEndpoint, got.OTELMetrics.MetricsEndpoint)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.MetricsProtocol, got.OTELMetrics.MetricsProtocol)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.GetInterval(), got.OTELMetrics.GetInterval())
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.HistogramAggregation, got.OTELMetrics.HistogramAggregation)
+	require.Equal(t, obi.DefaultConfig.Prometheus.Port, got.Prometheus.Port)
+}
+
+func TestDocumentToRuntimeSkipsUnsupportedMetricReaderShapes(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultRuntimeConfig()
+	cfg.OTELMetrics.MetricsEndpoint = "https://metrics.example:4317"
+	cfg.OTELMetrics.Interval = 914 * time.Millisecond
+	cfg.Prometheus.Port = 917
+
+	doc, _ := RuntimeToV2(&cfg)
+	doc.MeterProvider.Readers = append(doc.MeterProvider.Readers, doc.MeterProvider.Readers[0])
+
+	got, err := DocumentToRuntime(doc)
+	require.NoError(t, err)
+
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.MetricsEndpoint, got.OTELMetrics.MetricsEndpoint)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.MetricsProtocol, got.OTELMetrics.MetricsProtocol)
+	require.Equal(t, obi.DefaultConfig.OTELMetrics.GetInterval(), got.OTELMetrics.GetInterval())
+	require.Equal(t, obi.DefaultConfig.Prometheus.Port, got.Prometheus.Port)
+}


### PR DESCRIPTION
Depends on #2462.

## What

This adds an internal `DocumentToRuntime` entry point for standalone config v2 documents. It starts from the existing OBI extension import path, then applies the document-level OpenTelemetry sections emitted by `RuntimeToV2`.

The document import covers resource host overrides, tracer sampler and batch OTLP gRPC settings, meter periodic OTLP gRPC settings, default histogram aggregation, and the Prometheus development pull port.

Unsupported provider shapes are intentionally skipped instead of being partially interpreted, keeping the importer scoped to the exported config shape.

## Validation

- `make generate`
- `go test ./internal/config/...`
- `go test ./cmd/check-config-v2-parity`
- `make check-config-v2-parity`