### PR TITLE
Import config v2 HTTP settings

### DIFF
--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -623,9 +623,7 @@ func applyV2Instrumentation(cfg *obi.Config, instrumentation schema.Instrumentat
 }
 
 func applyFullV2Instrumentation(cfg *obi.Config, instrumentation schema.Instrumentation) {
-	cfg.EBPF.TrackRequestHeaders = instrumentation.HTTP.TrackRequestHeaders
-	cfg.EBPF.HTTPRequestTimeout = instrumentation.HTTP.RequestTimeout.TimeDuration()
-	cfg.EBPF.BufferSizes.HTTP = instrumentation.HTTP.BufferSize
+	applyFullV2HTTPInstrumentation(cfg, instrumentation.HTTP)
 
 	cfg.EBPF.HeuristicSQLDetect = instrumentation.SQL.HeuristicDetect
 	cfg.EBPF.BufferSizes.MySQL = instrumentation.SQL.MySQL.BufferSize
@@ -649,15 +647,7 @@ func applyFullV2Instrumentation(cfg *obi.Config, instrumentation schema.Instrume
 
 func applyPartialV2Instrumentation(cfg *obi.Config, instrumentation schema.Instrumentation) {
 	if !zeroValue(instrumentation.HTTP) {
-		if instrumentation.HTTP.TrackRequestHeaders {
-			cfg.EBPF.TrackRequestHeaders = true
-		}
-		if !zeroValue(instrumentation.HTTP.RequestTimeout) {
-			cfg.EBPF.HTTPRequestTimeout = instrumentation.HTTP.RequestTimeout.TimeDuration()
-		}
-		if instrumentation.HTTP.BufferSize != 0 {
-			cfg.EBPF.BufferSizes.HTTP = instrumentation.HTTP.BufferSize
-		}
+		applyPartialV2HTTPInstrumentation(cfg, instrumentation.HTTP)
 	}
 
 	if !zeroValue(instrumentation.SQL) {
@@ -710,6 +700,210 @@ func applyPartialV2Instrumentation(cfg *obi.Config, instrumentation schema.Instr
 	}
 	if !zeroValue(instrumentation.GPU.EnabledMode) {
 		cfg.EBPF.InstrumentCuda = instrumentation.GPU.EnabledMode
+	}
+}
+
+func applyFullV2HTTPInstrumentation(cfg *obi.Config, http schema.HTTPInstrumentation) {
+	cfg.EBPF.TrackRequestHeaders = http.TrackRequestHeaders
+	cfg.EBPF.HTTPRequestTimeout = http.RequestTimeout.TimeDuration()
+	cfg.EBPF.BufferSizes.HTTP = http.BufferSize
+
+	applyV2HTTPFilters(cfg, http.Filters, true)
+	applyFullV2HTTPRoutes(cfg, http.Routes)
+	applyFullV2HTTPPayloadExtraction(cfg, http.PayloadExtraction)
+}
+
+func applyPartialV2HTTPInstrumentation(cfg *obi.Config, http schema.HTTPInstrumentation) {
+	if http.TrackRequestHeaders {
+		cfg.EBPF.TrackRequestHeaders = true
+	}
+	if !zeroValue(http.RequestTimeout) {
+		cfg.EBPF.HTTPRequestTimeout = http.RequestTimeout.TimeDuration()
+	}
+	if http.BufferSize != 0 {
+		cfg.EBPF.BufferSizes.HTTP = http.BufferSize
+	}
+	applyV2HTTPFilters(cfg, http.Filters, false)
+	applyPartialV2HTTPRoutes(cfg, http.Routes)
+	applyPartialV2HTTPPayloadExtraction(cfg, http.PayloadExtraction)
+}
+
+func applyV2HTTPFilters(cfg *obi.Config, filters schema.SignalFilters, complete bool) {
+	if zeroValue(filters) && !complete {
+		return
+	}
+	if !reflect.DeepEqual(filters.Traces, filters.Metrics) {
+		return
+	}
+	cfg.Filters.Application = attributeFilterMap(filters.Traces)
+}
+
+func applyFullV2HTTPRoutes(cfg *obi.Config, routes schema.HTTPRoutes) {
+	applyV2HTTPRouteDiscovery(cfg, routes.Discovery, true)
+	if !hasV2HTTPRouteConfig(routes) {
+		cfg.Routes = nil
+		return
+	}
+
+	cfg.Routes = &transform.RoutesConfig{}
+	applyV2HTTPRouteConfig(cfg.Routes, routes)
+}
+
+func applyPartialV2HTTPRoutes(cfg *obi.Config, routes schema.HTTPRoutes) {
+	if zeroValue(routes) {
+		return
+	}
+	applyV2HTTPRouteDiscovery(cfg, routes.Discovery, false)
+	if !hasV2HTTPRouteConfig(routes) {
+		return
+	}
+	if cfg.Routes == nil {
+		cfg.Routes = &transform.RoutesConfig{}
+	}
+	applyV2HTTPRouteConfig(cfg.Routes, routes)
+}
+
+func applyV2HTTPRouteDiscovery(cfg *obi.Config, discovery schema.HTTPRouteDiscovery, complete bool) {
+	if zeroValue(discovery) && !complete {
+		return
+	}
+	if complete || !zeroValue(discovery.Timeout) {
+		cfg.Discovery.RouteHarvesterTimeout = discovery.Timeout.TimeDuration()
+	}
+	if complete || discovery.DisabledLanguages != nil {
+		cfg.Discovery.DisabledRouteHarvesters = cloneRouteHarvesterLanguages(discovery.DisabledLanguages)
+	}
+	if complete || !zeroValue(discovery.Java.Delay) {
+		cfg.Discovery.RouteHarvestConfig.JavaHarvestDelay = discovery.Java.Delay.TimeDuration()
+	}
+}
+
+func hasV2HTTPRouteConfig(routes schema.HTTPRoutes) bool {
+	return routes.Unmatched != nil ||
+		routes.Patterns != nil ||
+		routes.IgnoredPatterns != nil ||
+		routes.IgnoreMode != nil ||
+		routes.WildcardChar != nil ||
+		routes.MaxPathSegmentCardinality != nil
+}
+
+func applyV2HTTPRouteConfig(dst *transform.RoutesConfig, routes schema.HTTPRoutes) {
+	if routes.Unmatched != nil {
+		dst.Unmatch = *routes.Unmatched
+	}
+	if routes.Patterns != nil {
+		dst.Patterns = cloneStrings(*routes.Patterns)
+	}
+	if routes.IgnoredPatterns != nil {
+		dst.IgnorePatterns = cloneStrings(*routes.IgnoredPatterns)
+	}
+	if routes.IgnoreMode != nil {
+		dst.IgnoredEvents = *routes.IgnoreMode
+	}
+	if routes.WildcardChar != nil {
+		dst.WildcardChar = *routes.WildcardChar
+	}
+	if routes.MaxPathSegmentCardinality != nil {
+		dst.MaxPathSegmentCardinality = *routes.MaxPathSegmentCardinality
+	}
+}
+
+func applyFullV2HTTPPayloadExtraction(cfg *obi.Config, payload schema.PayloadExtraction) {
+	http := &cfg.EBPF.PayloadExtraction.HTTP
+	applyV2HTTPPayloadExtractorMembership(http, payload.Enabled)
+	http.SQLPP.EndpointPatterns = cloneStrings(payload.SQLPP.EndpointPatterns)
+	applyFullV2HTTPEnrichment(http, payload.Enrichment)
+}
+
+func applyPartialV2HTTPPayloadExtraction(cfg *obi.Config, payload schema.PayloadExtraction) {
+	if zeroValue(payload) {
+		return
+	}
+
+	http := &cfg.EBPF.PayloadExtraction.HTTP
+	if payload.Enabled != nil {
+		applyV2HTTPPayloadExtractorMembership(http, payload.Enabled)
+	}
+	if payload.SQLPP.EndpointPatterns != nil {
+		http.SQLPP.EndpointPatterns = cloneStrings(payload.SQLPP.EndpointPatterns)
+	}
+	if !zeroValue(payload.Enrichment) {
+		applyPartialV2HTTPEnrichment(http, payload.Enrichment)
+	}
+}
+
+func applyV2HTTPPayloadExtractorMembership(http *obiconfig.HTTPConfig, enabled []string) {
+	http.GraphQL.Enabled = false
+	http.Elasticsearch.Enabled = false
+	http.AWS.Enabled = false
+	http.SQLPP.Enabled = false
+	http.GenAI.OpenAI.Enabled = false
+	http.GenAI.Anthropic.Enabled = false
+	http.GenAI.Gemini.Enabled = false
+	http.GenAI.Qwen.Enabled = false
+	http.GenAI.Bedrock.Enabled = false
+	http.GenAI.MCP.Enabled = false
+	http.GenAI.Embedding.Enabled = false
+	http.GenAI.Rerank.Enabled = false
+	http.GenAI.Retrieval.Enabled = false
+	http.JSONRPC.Enabled = false
+	http.Enrichment.Enabled = false
+
+	for _, extractor := range enabled {
+		switch extractor {
+		case payloadExtractorGraphQL:
+			http.GraphQL.Enabled = true
+		case payloadExtractorElasticsearch:
+			http.Elasticsearch.Enabled = true
+		case payloadExtractorAWS:
+			http.AWS.Enabled = true
+		case payloadExtractorSQLPP:
+			http.SQLPP.Enabled = true
+		case payloadExtractorOpenAI:
+			http.GenAI.OpenAI.Enabled = true
+		case payloadExtractorAnthropic:
+			http.GenAI.Anthropic.Enabled = true
+		case payloadExtractorGemini:
+			http.GenAI.Gemini.Enabled = true
+		case payloadExtractorQwen:
+			http.GenAI.Qwen.Enabled = true
+		case payloadExtractorBedrock:
+			http.GenAI.Bedrock.Enabled = true
+		case payloadExtractorMCP:
+			http.GenAI.MCP.Enabled = true
+		case payloadExtractorEmbedding:
+			http.GenAI.Embedding.Enabled = true
+		case payloadExtractorRerank:
+			http.GenAI.Rerank.Enabled = true
+		case payloadExtractorRetrieval:
+			http.GenAI.Retrieval.Enabled = true
+		case payloadExtractorJSONRPC:
+			http.JSONRPC.Enabled = true
+		case payloadExtractorEnrichment:
+			http.Enrichment.Enabled = true
+		}
+	}
+}
+
+func applyFullV2HTTPEnrichment(http *obiconfig.HTTPConfig, enrichment schema.HTTPEnrichment) {
+	http.Enrichment.Policy.DefaultAction.Headers = enrichment.Policy.DefaultAction.Headers
+	http.Enrichment.Policy.DefaultAction.Body = enrichment.Policy.DefaultAction.Body
+	http.Enrichment.Policy.ObfuscationString = enrichment.Policy.ObfuscationString
+	http.Enrichment.Rules = cloneHTTPParsingRules(enrichment.Rules)
+}
+
+func applyPartialV2HTTPEnrichment(http *obiconfig.HTTPConfig, enrichment schema.HTTPEnrichment) {
+	if !zeroValue(enrichment.Policy.DefaultAction.Headers) {
+		http.Enrichment.Policy.DefaultAction.Headers = enrichment.Policy.DefaultAction.Headers
+	}
+	if !zeroValue(enrichment.Policy.DefaultAction.Body) {
+		http.Enrichment.Policy.DefaultAction.Body = enrichment.Policy.DefaultAction.Body
+	}
+	if enrichment.Policy.ObfuscationString != "" {
+		http.Enrichment.Policy.ObfuscationString = enrichment.Policy.ObfuscationString
+	}
+	if enrichment.Rules != nil {
+		http.Enrichment.Rules = cloneHTTPParsingRules(enrichment.Rules)
 	}
 }
 
@@ -1376,6 +1570,20 @@ func cloneStrings(values []string) []string {
 		return nil
 	}
 	return append([]string(nil), values...)
+}
+
+func cloneRouteHarvesterLanguages(values []services.RouteHarvesterLanguage) []services.RouteHarvesterLanguage {
+	if values == nil {
+		return nil
+	}
+	return append([]services.RouteHarvesterLanguage(nil), values...)
+}
+
+func cloneHTTPParsingRules(values []obiconfig.HTTPParsingRule) []obiconfig.HTTPParsingRule {
+	if values == nil {
+		return nil
+	}
+	return append([]obiconfig.HTTPParsingRule(nil), values...)
 }
 
 type runtimeCIDRDefinition interface {

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -39,6 +39,12 @@ func V2ToRuntime(src *schema.Extension) (*obi.Config, error) {
 	if err := validateV2RulePatterns(src.Capture.Rules); err != nil {
 		return nil, err
 	}
+	if err := validateV2HTTPFilters(src.Capture.Instrumentation.HTTP.Filters); err != nil {
+		return nil, err
+	}
+	if err := validateV2HTTPPayloadExtraction(src.Capture.Instrumentation.HTTP.PayloadExtraction); err != nil {
+		return nil, err
+	}
 
 	cfg := runtimeConfigDefaults()
 	applyV2Capture(&cfg, src)
@@ -185,6 +191,52 @@ func validateV2RulePatterns(rules []schema.Rule) error {
 		}
 	}
 	return nil
+}
+
+func validateV2HTTPFilters(filters schema.SignalFilters) error {
+	if len(filters.Traces) == 0 || len(filters.Metrics) == 0 {
+		return nil
+	}
+	if reflect.DeepEqual(filters.Traces, filters.Metrics) {
+		return nil
+	}
+	return fmt.Errorf("capture.instrumentation.http.filters: trace and metric filters cannot differ")
+}
+
+func validateV2HTTPPayloadExtraction(payload schema.PayloadExtraction) error {
+	for i, extractor := range payload.Enabled {
+		if !validV2HTTPPayloadExtractor(extractor) {
+			return fmt.Errorf(
+				"capture.instrumentation.http.payload_extraction.enabled[%d]: unknown payload extractor %q",
+				i,
+				extractor,
+			)
+		}
+	}
+	return nil
+}
+
+func validV2HTTPPayloadExtractor(extractor string) bool {
+	switch extractor {
+	case payloadExtractorGraphQL,
+		payloadExtractorElasticsearch,
+		payloadExtractorAWS,
+		payloadExtractorSQLPP,
+		payloadExtractorOpenAI,
+		payloadExtractorAnthropic,
+		payloadExtractorGemini,
+		payloadExtractorQwen,
+		payloadExtractorBedrock,
+		payloadExtractorMCP,
+		payloadExtractorEmbedding,
+		payloadExtractorRerank,
+		payloadExtractorRetrieval,
+		payloadExtractorJSONRPC,
+		payloadExtractorEnrichment:
+		return true
+	default:
+		return false
+	}
 }
 
 func validateV2RuleProcessGlobPatterns(path string, match schema.RuleProcessMatch) error {
@@ -732,10 +784,14 @@ func applyV2HTTPFilters(cfg *obi.Config, filters schema.SignalFilters, complete 
 	if zeroValue(filters) && !complete {
 		return
 	}
-	if !reflect.DeepEqual(filters.Traces, filters.Metrics) {
-		return
+	cfg.Filters.Application = attributeFilterMap(v2HTTPFilterMap(filters))
+}
+
+func v2HTTPFilterMap(filters schema.SignalFilters) schema.AttributeFilters {
+	if len(filters.Traces) != 0 {
+		return filters.Traces
 	}
-	cfg.Filters.Application = attributeFilterMap(filters.Traces)
+	return filters.Metrics
 }
 
 func applyFullV2HTTPRoutes(cfg *obi.Config, routes schema.HTTPRoutes) {

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -4,6 +4,7 @@
 package convert // import "go.opentelemetry.io/obi/internal/config/convert"
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -200,7 +201,7 @@ func validateV2HTTPFilters(filters schema.SignalFilters) error {
 	if reflect.DeepEqual(filters.Traces, filters.Metrics) {
 		return nil
 	}
-	return fmt.Errorf("capture.instrumentation.http.filters: trace and metric filters cannot differ")
+	return errors.New("capture.instrumentation.http.filters: trace and metric filters cannot differ")
 }
 
 func validateV2HTTPPayloadExtraction(payload schema.PayloadExtraction) error {

--- a/internal/config/convert/import_http_test.go
+++ b/internal/config/convert/import_http_test.go
@@ -1,0 +1,149 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/services"
+	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/filter"
+	"go.opentelemetry.io/obi/pkg/transform"
+)
+
+func TestV2ToRuntimeHTTPRoutesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultRuntimeConfig()
+	cfg.Routes.Unmatch = transform.UnmatchPath
+	cfg.Routes.Patterns = []string{"/products/{id}", "/orders/{id}"}
+	cfg.Routes.IgnorePatterns = []string{"/health", "/ready"}
+	cfg.Routes.IgnoredEvents = transform.IgnoreTraces
+	cfg.Routes.WildcardChar = "#"
+	cfg.Routes.MaxPathSegmentCardinality = 22
+	cfg.Discovery.RouteHarvesterTimeout = 23 * time.Second
+	cfg.Discovery.DisabledRouteHarvesters = []services.RouteHarvesterLanguage{
+		services.RouteHarvesterLanguageJava,
+		services.RouteHarvesterLanguageNodejs,
+	}
+	cfg.Discovery.RouteHarvestConfig.JavaHarvestDelay = 24 * time.Second
+
+	_, ext := RuntimeToV2(&cfg)
+
+	got, err := V2ToRuntime(ext)
+	require.NoError(t, err)
+
+	require.NotNil(t, got.Routes)
+	require.Equal(t, cfg.Routes, got.Routes)
+	require.Equal(t, cfg.Discovery.RouteHarvesterTimeout, got.Discovery.RouteHarvesterTimeout)
+	require.Equal(t, cfg.Discovery.DisabledRouteHarvesters, got.Discovery.DisabledRouteHarvesters)
+	require.Equal(t, cfg.Discovery.RouteHarvestConfig.JavaHarvestDelay, got.Discovery.RouteHarvestConfig.JavaHarvestDelay)
+}
+
+func TestV2ToRuntimeHTTPNilRoutesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultRuntimeConfig()
+	cfg.Routes = nil
+	cfg.Discovery.RouteHarvesterTimeout = 25 * time.Second
+	cfg.Discovery.DisabledRouteHarvesters = []services.RouteHarvesterLanguage{
+		services.RouteHarvesterLanguageGo,
+	}
+	cfg.Discovery.RouteHarvestConfig.JavaHarvestDelay = 26 * time.Second
+
+	_, ext := RuntimeToV2(&cfg)
+
+	got, err := V2ToRuntime(ext)
+	require.NoError(t, err)
+
+	require.Nil(t, got.Routes)
+	require.Equal(t, cfg.Discovery.RouteHarvesterTimeout, got.Discovery.RouteHarvesterTimeout)
+	require.Equal(t, cfg.Discovery.DisabledRouteHarvesters, got.Discovery.DisabledRouteHarvesters)
+	require.Equal(t, cfg.Discovery.RouteHarvestConfig.JavaHarvestDelay, got.Discovery.RouteHarvestConfig.JavaHarvestDelay)
+}
+
+func TestV2ToRuntimeHTTPPayloadExtractionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultRuntimeConfig()
+	http := &cfg.EBPF.PayloadExtraction.HTTP
+	http.GraphQL.Enabled = true
+	http.Elasticsearch.Enabled = true
+	http.AWS.Enabled = true
+	http.SQLPP.Enabled = true
+	http.SQLPP.EndpointPatterns = []string{"/query", "/analytics"}
+	http.GenAI.OpenAI.Enabled = true
+	http.GenAI.Anthropic.Enabled = true
+	http.GenAI.Gemini.Enabled = true
+	http.GenAI.Qwen.Enabled = true
+	http.GenAI.Bedrock.Enabled = true
+	http.GenAI.MCP.Enabled = true
+	http.GenAI.Embedding.Enabled = true
+	http.GenAI.Rerank.Enabled = true
+	http.GenAI.Retrieval.Enabled = true
+	http.JSONRPC.Enabled = true
+	http.Enrichment.Enabled = true
+	http.Enrichment.Policy.DefaultAction.Headers = config.HTTPParsingActionInclude
+	http.Enrichment.Policy.DefaultAction.Body = config.HTTPParsingActionObfuscate
+	http.Enrichment.Policy.ObfuscationString = "[redacted]"
+	jsonPath, err := config.NewJSONPathExpr("$.secret")
+	require.NoError(t, err)
+	http.Enrichment.Rules = []config.HTTPParsingRule{
+		{
+			Action: config.HTTPParsingActionObfuscate,
+			Type:   config.HTTPParsingRuleTypeBody,
+			Scope:  config.HTTPParsingScopeRequest,
+			Match: config.HTTPParsingMatch{
+				ObfuscationJSONPaths: []config.JSONPathExpr{jsonPath},
+				Methods:              []config.HTTPMethod{config.HTTPMethodPOST},
+			},
+		},
+	}
+
+	_, ext := RuntimeToV2(&cfg)
+
+	got, err := V2ToRuntime(ext)
+	require.NoError(t, err)
+
+	gotHTTP := got.EBPF.PayloadExtraction.HTTP
+	require.True(t, gotHTTP.GraphQL.Enabled)
+	require.True(t, gotHTTP.Elasticsearch.Enabled)
+	require.True(t, gotHTTP.AWS.Enabled)
+	require.True(t, gotHTTP.SQLPP.Enabled)
+	require.Equal(t, []string{"/query", "/analytics"}, gotHTTP.SQLPP.EndpointPatterns)
+	require.True(t, gotHTTP.GenAI.OpenAI.Enabled)
+	require.True(t, gotHTTP.GenAI.Anthropic.Enabled)
+	require.True(t, gotHTTP.GenAI.Gemini.Enabled)
+	require.True(t, gotHTTP.GenAI.Qwen.Enabled)
+	require.True(t, gotHTTP.GenAI.Bedrock.Enabled)
+	require.True(t, gotHTTP.GenAI.MCP.Enabled)
+	require.True(t, gotHTTP.GenAI.Embedding.Enabled)
+	require.True(t, gotHTTP.GenAI.Rerank.Enabled)
+	require.True(t, gotHTTP.GenAI.Retrieval.Enabled)
+	require.True(t, gotHTTP.JSONRPC.Enabled)
+	require.True(t, gotHTTP.Enrichment.Enabled)
+	require.Equal(t, http.Enrichment.Policy, gotHTTP.Enrichment.Policy)
+	require.Equal(t, http.Enrichment.Rules, gotHTTP.Enrichment.Rules)
+}
+
+func TestV2ToRuntimeHTTPApplicationFiltersRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	statusCode := 500
+	cfg := defaultRuntimeConfig()
+	cfg.Filters.Application = filter.AttributeFamilyConfig{
+		"http.status_code": {Equals: &statusCode},
+		"service.name":     {Match: "checkout-*"},
+	}
+
+	_, ext := RuntimeToV2(&cfg)
+
+	got, err := V2ToRuntime(ext)
+	require.NoError(t, err)
+
+	require.Equal(t, cfg.Filters.Application, got.Filters.Application)
+}

--- a/internal/config/convert/import_http_test.go
+++ b/internal/config/convert/import_http_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/obi/internal/config/schema"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/filter"
@@ -146,4 +147,80 @@ func TestV2ToRuntimeHTTPApplicationFiltersRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, cfg.Filters.Application, got.Filters.Application)
+}
+
+func TestV2ToRuntimeHTTPApplicationFiltersImportsOneSignal(t *testing.T) {
+	t.Parallel()
+
+	statusCode := 500
+	filters := schema.AttributeFilters{
+		"http.status_code": {Equals: &statusCode},
+		"service.name":     {Match: "checkout-*"},
+	}
+
+	got, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Instrumentation: schema.Instrumentation{
+				HTTP: schema.HTTPInstrumentation{
+					Filters: schema.SignalFilters{
+						Traces: filters,
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, filter.AttributeFamilyConfig{
+		"http.status_code": {Equals: &statusCode},
+		"service.name":     {Match: "checkout-*"},
+	}, got.Filters.Application)
+}
+
+func TestV2ToRuntimeHTTPApplicationFiltersRejectsConflictingSignals(t *testing.T) {
+	t.Parallel()
+
+	statusCode := 500
+	_, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Instrumentation: schema.Instrumentation{
+				HTTP: schema.HTTPInstrumentation{
+					Filters: schema.SignalFilters{
+						Traces: schema.AttributeFilters{
+							"service.name": {Match: "checkout-*"},
+						},
+						Metrics: schema.AttributeFilters{
+							"http.status_code": {Equals: &statusCode},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.ErrorContains(t, err, "capture.instrumentation.http.filters")
+}
+
+func TestV2ToRuntimeHTTPPayloadExtractionRejectsUnknownEnabled(t *testing.T) {
+	t.Parallel()
+
+	_, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Instrumentation: schema.Instrumentation{
+				HTTP: schema.HTTPInstrumentation{
+					PayloadExtraction: schema.PayloadExtraction{
+						Enabled: []string{
+							payloadExtractorGraphQL,
+							"unknown",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.ErrorContains(t, err, `capture.instrumentation.http.payload_extraction.enabled[1]: unknown payload extractor "unknown"`)
 }


### PR DESCRIPTION
Depends on #2462

## What changed
- Import v2 global HTTP route configuration and route harvester discovery settings into the runtime config.
- Import HTTP payload extraction memberships, SQL++ endpoint patterns, and HTTP enrichment policy/rules from the v2 shape.
- Import application HTTP filters when the exported trace and metric filter maps match.

## Validation
- `make generate`
- `go test ./internal/config/...`
- `go test ./cmd/check-config-v2-parity`
- `make check-config-v2-parity`