### PR TITLE
Import v2 enrichment config

### DIFF
--- a/internal/config/convert/enrich.go
+++ b/internal/config/convert/enrich.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert
+
+import (
+	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/kube/kubeflags"
+)
+
+func v2KubernetesMode(mode kubeflags.EnableFlag) schema.KubernetesMode {
+	switch mode {
+	case kubeflags.EnabledTrue:
+		return schema.KubernetesModeEnabled
+	case kubeflags.EnabledFalse:
+		return schema.KubernetesModeDisabled
+	case kubeflags.EnabledAutodetect, "":
+		return schema.KubernetesModeAutodetect
+	default:
+		return schema.KubernetesMode(mode)
+	}
+}
+
+func runtimeKubernetesMode(mode schema.KubernetesMode) kubeflags.EnableFlag {
+	switch mode {
+	case schema.KubernetesModeEnabled:
+		return kubeflags.EnabledTrue
+	case schema.KubernetesModeDisabled:
+		return kubeflags.EnabledFalse
+	case schema.KubernetesModeAutodetect:
+		return kubeflags.EnabledAutodetect
+	default:
+		return kubeflags.EnableFlag(mode)
+	}
+}

--- a/internal/config/convert/enrich.go
+++ b/internal/config/convert/enrich.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package convert
+package convert // import "go.opentelemetry.io/obi/internal/config/convert"
 
 import (
 	"go.opentelemetry.io/obi/internal/config/schema"

--- a/internal/config/convert/export.go
+++ b/internal/config/convert/export.go
@@ -599,7 +599,7 @@ func enrich(cfg *obi.Config) *schema.Enrich {
 	return &schema.Enrich{
 		Enrichers: schema.Enrichers{
 			Kubernetes: schema.KubernetesEnricher{
-				Mode:                cfg.Attributes.Kubernetes.Enable,
+				Mode:                v2KubernetesMode(cfg.Attributes.Kubernetes.Enable),
 				ClusterName:         cfg.Attributes.Kubernetes.ClusterName,
 				ServiceNameTemplate: cfg.Attributes.Kubernetes.ServiceNameTemplate,
 				Auth: schema.KubernetesAuth{

--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -23,7 +23,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/filter"
-	"go.opentelemetry.io/obi/pkg/kube/kubeflags"
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/transform"
 )
@@ -104,7 +103,7 @@ func TestRuntimeToV2DefaultConfig(t *testing.T) {
 	require.Equal(t, 256, value(t, ext.Capture.Telemetry, "metrics", "reporters_cache_len"))
 	require.Equal(t, schema.Duration(5*time.Minute), value(t, ext.Capture.Telemetry, "metrics", "ttl"))
 
-	require.Equal(t, kubeflags.EnabledAutodetect, value(t, ext.Enrich, "enrichers", "kubernetes", "mode"))
+	require.Equal(t, schema.KubernetesModeAutodetect, value(t, ext.Enrich, "enrichers", "kubernetes", "mode"))
 	require.Equal(t, schema.Duration(30*time.Second), value(t, ext.Enrich, "enrichers", "kubernetes", "informers", "initial_sync_timeout"))
 	require.Equal(t, schema.Duration(30*time.Minute), value(t, ext.Enrich, "enrichers", "kubernetes", "informers", "resync_period"))
 	require.Equal(t, []transform.Source{transform.SourceK8s}, value(t, ext.Enrich, "service_name", "sources"))
@@ -393,7 +392,7 @@ func TestRuntimeToV2CustomConfig(t *testing.T) {
 	require.Equal(t, schema.Duration(15*time.Second), value(t, ext.Capture.Network, "capture", "flow_lifecycle", "deduplication", "first_come_ttl"))
 	require.Equal(t, true, value(t, ext.Capture.Network, "capture", "diagnostics", "print_flows"))
 
-	require.Equal(t, kubeflags.EnabledTrue, value(t, ext.Enrich, "enrichers", "kubernetes", "mode"))
+	require.Equal(t, schema.KubernetesModeEnabled, value(t, ext.Enrich, "enrichers", "kubernetes", "mode"))
 	require.Equal(t, "cluster-a", value(t, ext.Enrich, "enrichers", "kubernetes", "cluster_name"))
 	require.Equal(t, "/etc/kube/config", value(t, ext.Enrich, "enrichers", "kubernetes", "auth", "kubeconfig_path"))
 	require.Equal(t, schema.Duration(42*time.Second), value(t, ext.Enrich, "enrichers", "kubernetes", "informers", "initial_sync_timeout"))

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	obiconfig "go.opentelemetry.io/obi/pkg/config"
 	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/debug"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/filter"
@@ -1026,9 +1027,127 @@ func applyPartialV2CaptureTelemetry(cfg *obi.Config, telemetry schema.CaptureTel
 }
 
 func applyV2Standalone(cfg *obi.Config, src *schema.Extension) {
+	applyV2EnrichAttributes(cfg, src.Enrich)
+	applyV2KubernetesEnricher(cfg, src.Enrich)
 	applyV2EnrichServiceName(cfg, src.Enrich)
 	applyV2Correlation(cfg, src.Correlation)
 	applyV2Daemon(cfg, src.Daemon)
+}
+
+func applyV2EnrichAttributes(cfg *obi.Config, enrich *schema.Enrich) {
+	if enrich == nil || zeroValue(enrich.Attributes) {
+		return
+	}
+
+	attrs := enrich.Attributes
+	if completeEnrichmentAttributes(attrs) {
+		applyFullV2EnrichAttributes(cfg, attrs)
+		return
+	}
+
+	applyPartialV2EnrichAttributes(cfg, attrs)
+}
+
+func applyFullV2EnrichAttributes(cfg *obi.Config, attrs schema.EnrichmentAttributes) {
+	cfg.Attributes.Select = cloneAttributeSelection(attrs.Select)
+	cfg.Attributes.ExtraGroupAttributes = cloneExtraGroupAttributes(attrs.ExtraGroupAttributes)
+	cfg.Attributes.MetadataRetry.Timeout = attrs.MetadataRetry.Timeout.TimeDuration()
+	cfg.Attributes.MetadataRetry.StartInterval = attrs.MetadataRetry.StartInterval.TimeDuration()
+	cfg.Attributes.MetadataRetry.MaxInterval = attrs.MetadataRetry.MaxInterval.TimeDuration()
+}
+
+func applyPartialV2EnrichAttributes(cfg *obi.Config, attrs schema.EnrichmentAttributes) {
+	if attrs.Select != nil {
+		cfg.Attributes.Select = cloneAttributeSelection(attrs.Select)
+	}
+	if attrs.ExtraGroupAttributes != nil {
+		cfg.Attributes.ExtraGroupAttributes = cloneExtraGroupAttributes(attrs.ExtraGroupAttributes)
+	}
+	if !zeroValue(attrs.MetadataRetry.Timeout) {
+		cfg.Attributes.MetadataRetry.Timeout = attrs.MetadataRetry.Timeout.TimeDuration()
+	}
+	if !zeroValue(attrs.MetadataRetry.StartInterval) {
+		cfg.Attributes.MetadataRetry.StartInterval = attrs.MetadataRetry.StartInterval.TimeDuration()
+	}
+	if !zeroValue(attrs.MetadataRetry.MaxInterval) {
+		cfg.Attributes.MetadataRetry.MaxInterval = attrs.MetadataRetry.MaxInterval.TimeDuration()
+	}
+}
+
+func applyV2KubernetesEnricher(cfg *obi.Config, enrich *schema.Enrich) {
+	if enrich == nil || zeroValue(enrich.Enrichers.Kubernetes) {
+		return
+	}
+
+	kubernetes := enrich.Enrichers.Kubernetes
+	if completeKubernetesEnricher(kubernetes) {
+		applyFullV2KubernetesEnricher(cfg, kubernetes)
+		return
+	}
+
+	applyPartialV2KubernetesEnricher(cfg, kubernetes)
+}
+
+func applyFullV2KubernetesEnricher(cfg *obi.Config, kubernetes schema.KubernetesEnricher) {
+	cfg.Attributes.Kubernetes.Enable = kubernetes.Mode
+	cfg.Attributes.Kubernetes.ClusterName = kubernetes.ClusterName
+	cfg.Attributes.Kubernetes.KubeconfigPath = kubernetes.Auth.KubeconfigPath
+	cfg.Attributes.Kubernetes.InformersSyncTimeout = kubernetes.Informers.InitialSyncTimeout.TimeDuration()
+	cfg.Attributes.Kubernetes.ReconnectInitialInterval = kubernetes.Informers.ReconnectInitialInterval.TimeDuration()
+	cfg.Attributes.Kubernetes.InformersResyncPeriod = kubernetes.Informers.ResyncPeriod.TimeDuration()
+	cfg.Attributes.Kubernetes.DropExternal = kubernetes.DropExternal
+	cfg.Attributes.Kubernetes.DisableInformers = cloneStrings(kubernetes.Informers.Disabled)
+	cfg.Attributes.Kubernetes.MetaCacheAddress = kubernetes.MetadataCache.Address
+	cfg.Attributes.Kubernetes.MetaRestrictLocalNode = kubernetes.MetadataCache.RestrictLocalNode
+	cfg.Attributes.Kubernetes.MetaSourceLabels.ServiceName = kubernetes.MetadataCache.SourceLabels.ServiceName
+	cfg.Attributes.Kubernetes.MetaSourceLabels.ServiceNamespace = kubernetes.MetadataCache.SourceLabels.ServiceNamespace
+	cfg.Attributes.Kubernetes.ResourceLabels = cloneStringMap(kubernetes.ResourceLabels)
+	cfg.Attributes.Kubernetes.ServiceNameTemplate = kubernetes.ServiceNameTemplate
+}
+
+func applyPartialV2KubernetesEnricher(cfg *obi.Config, kubernetes schema.KubernetesEnricher) {
+	if kubernetes.Mode != "" {
+		cfg.Attributes.Kubernetes.Enable = kubernetes.Mode
+	}
+	if kubernetes.ClusterName != "" {
+		cfg.Attributes.Kubernetes.ClusterName = kubernetes.ClusterName
+	}
+	if kubernetes.ServiceNameTemplate != "" {
+		cfg.Attributes.Kubernetes.ServiceNameTemplate = kubernetes.ServiceNameTemplate
+	}
+	if kubernetes.Auth.KubeconfigPath != "" {
+		cfg.Attributes.Kubernetes.KubeconfigPath = kubernetes.Auth.KubeconfigPath
+	}
+	if !zeroValue(kubernetes.Informers.InitialSyncTimeout) {
+		cfg.Attributes.Kubernetes.InformersSyncTimeout = kubernetes.Informers.InitialSyncTimeout.TimeDuration()
+	}
+	if !zeroValue(kubernetes.Informers.ReconnectInitialInterval) {
+		cfg.Attributes.Kubernetes.ReconnectInitialInterval = kubernetes.Informers.ReconnectInitialInterval.TimeDuration()
+	}
+	if !zeroValue(kubernetes.Informers.ResyncPeriod) {
+		cfg.Attributes.Kubernetes.InformersResyncPeriod = kubernetes.Informers.ResyncPeriod.TimeDuration()
+	}
+	if kubernetes.Informers.Disabled != nil {
+		cfg.Attributes.Kubernetes.DisableInformers = cloneStrings(kubernetes.Informers.Disabled)
+	}
+	if kubernetes.DropExternal {
+		cfg.Attributes.Kubernetes.DropExternal = kubernetes.DropExternal
+	}
+	if kubernetes.ResourceLabels != nil {
+		cfg.Attributes.Kubernetes.ResourceLabels = cloneStringMap(kubernetes.ResourceLabels)
+	}
+	if kubernetes.MetadataCache.Address != "" {
+		cfg.Attributes.Kubernetes.MetaCacheAddress = kubernetes.MetadataCache.Address
+	}
+	if kubernetes.MetadataCache.RestrictLocalNode {
+		cfg.Attributes.Kubernetes.MetaRestrictLocalNode = kubernetes.MetadataCache.RestrictLocalNode
+	}
+	if kubernetes.MetadataCache.SourceLabels.ServiceName != "" {
+		cfg.Attributes.Kubernetes.MetaSourceLabels.ServiceName = kubernetes.MetadataCache.SourceLabels.ServiceName
+	}
+	if kubernetes.MetadataCache.SourceLabels.ServiceNamespace != "" {
+		cfg.Attributes.Kubernetes.MetaSourceLabels.ServiceNamespace = kubernetes.MetadataCache.SourceLabels.ServiceNamespace
+	}
 }
 
 func applyV2EnrichServiceName(cfg *obi.Config, enrich *schema.Enrich) {
@@ -1299,6 +1418,56 @@ func completeRuntimes(runtimes schema.CaptureRuntimes) bool {
 func completeCaptureTelemetry(telemetry schema.CaptureTelemetry) bool {
 	return !zeroValue(telemetry.Traces) &&
 		!zeroValue(telemetry.Metrics)
+}
+
+func completeEnrichmentAttributes(attrs schema.EnrichmentAttributes) bool {
+	return !zeroValue(attrs.MetadataRetry.Timeout) &&
+		!zeroValue(attrs.MetadataRetry.StartInterval) &&
+		!zeroValue(attrs.MetadataRetry.MaxInterval)
+}
+
+func completeKubernetesEnricher(kubernetes schema.KubernetesEnricher) bool {
+	return kubernetes.Mode != "" &&
+		!zeroValue(kubernetes.Informers.InitialSyncTimeout) &&
+		!zeroValue(kubernetes.Informers.ReconnectInitialInterval) &&
+		!zeroValue(kubernetes.Informers.ResyncPeriod) &&
+		kubernetes.ResourceLabels != nil
+}
+
+func cloneStringMap(values map[string][]string) map[string][]string {
+	if values == nil {
+		return nil
+	}
+	out := make(map[string][]string, len(values))
+	for key, value := range values {
+		out[key] = cloneStrings(value)
+	}
+	return out
+}
+
+func cloneAttributeSelection(values attributes.Selection) attributes.Selection {
+	if values == nil {
+		return nil
+	}
+	out := make(attributes.Selection, len(values))
+	for section, inclusionLists := range values {
+		out[section] = attributes.InclusionLists{
+			Include: cloneStrings(inclusionLists.Include),
+			Exclude: cloneStrings(inclusionLists.Exclude),
+		}
+	}
+	return out
+}
+
+func cloneExtraGroupAttributes(values schema.ExtraGroupAttributes) obi.ExtraGroupAttributesMap {
+	if values == nil {
+		return nil
+	}
+	out := make(obi.ExtraGroupAttributesMap, len(values))
+	for group, names := range values {
+		out[group] = append(out[group], names...)
+	}
+	return out
 }
 
 func protocolEnablement(instrumentation schema.Instrumentation, name protocolName) schema.ProtocolEnablement {

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -1089,7 +1089,7 @@ func applyV2KubernetesEnricher(cfg *obi.Config, enrich *schema.Enrich) {
 }
 
 func applyFullV2KubernetesEnricher(cfg *obi.Config, kubernetes schema.KubernetesEnricher) {
-	cfg.Attributes.Kubernetes.Enable = kubernetes.Mode
+	cfg.Attributes.Kubernetes.Enable = runtimeKubernetesMode(kubernetes.Mode)
 	cfg.Attributes.Kubernetes.ClusterName = kubernetes.ClusterName
 	cfg.Attributes.Kubernetes.KubeconfigPath = kubernetes.Auth.KubeconfigPath
 	cfg.Attributes.Kubernetes.InformersSyncTimeout = kubernetes.Informers.InitialSyncTimeout.TimeDuration()
@@ -1107,7 +1107,7 @@ func applyFullV2KubernetesEnricher(cfg *obi.Config, kubernetes schema.Kubernetes
 
 func applyPartialV2KubernetesEnricher(cfg *obi.Config, kubernetes schema.KubernetesEnricher) {
 	if kubernetes.Mode != "" {
-		cfg.Attributes.Kubernetes.Enable = kubernetes.Mode
+		cfg.Attributes.Kubernetes.Enable = runtimeKubernetesMode(kubernetes.Mode)
 	}
 	if kubernetes.ClusterName != "" {
 		cfg.Attributes.Kubernetes.ClusterName = kubernetes.ClusterName
@@ -1421,8 +1421,7 @@ func completeCaptureTelemetry(telemetry schema.CaptureTelemetry) bool {
 }
 
 func completeEnrichmentAttributes(attrs schema.EnrichmentAttributes) bool {
-	return !zeroValue(attrs.MetadataRetry.Timeout) &&
-		!zeroValue(attrs.MetadataRetry.StartInterval) &&
+	return !zeroValue(attrs.MetadataRetry.StartInterval) &&
 		!zeroValue(attrs.MetadataRetry.MaxInterval)
 }
 
@@ -1430,7 +1429,6 @@ func completeKubernetesEnricher(kubernetes schema.KubernetesEnricher) bool {
 	return kubernetes.Mode != "" &&
 		!zeroValue(kubernetes.Informers.InitialSyncTimeout) &&
 		!zeroValue(kubernetes.Informers.ReconnectInitialInterval) &&
-		!zeroValue(kubernetes.Informers.ResyncPeriod) &&
 		kubernetes.ResourceLabels != nil
 }
 

--- a/internal/config/convert/import_enrich_test.go
+++ b/internal/config/convert/import_enrich_test.go
@@ -26,7 +26,7 @@ func TestV2ToRuntimeEnrichAttributesAndKubernetesRoundTrip(t *testing.T) {
 	cfg.Attributes.Kubernetes.KubeconfigPath = "/etc/kube/config"
 	cfg.Attributes.Kubernetes.InformersSyncTimeout = 42 * time.Second
 	cfg.Attributes.Kubernetes.ReconnectInitialInterval = 43 * time.Second
-	cfg.Attributes.Kubernetes.InformersResyncPeriod = 44 * time.Second
+	cfg.Attributes.Kubernetes.InformersResyncPeriod = 0
 	cfg.Attributes.Kubernetes.DropExternal = true
 	cfg.Attributes.Kubernetes.DisableInformers = []string{"node", "service"}
 	cfg.Attributes.Kubernetes.MetaCacheAddress = "kube-cache:8999"
@@ -39,7 +39,7 @@ func TestV2ToRuntimeEnrichAttributesAndKubernetesRoundTrip(t *testing.T) {
 	}
 	cfg.Attributes.Kubernetes.ServiceNameTemplate = "{{ .Meta.Name }}"
 	cfg.Attributes.MetadataRetry = meta.RetryConfig{
-		Timeout:       45 * time.Second,
+		Timeout:       0,
 		StartInterval: 46 * time.Millisecond,
 		MaxInterval:   47 * time.Second,
 	}
@@ -66,6 +66,53 @@ func TestV2ToRuntimeEnrichAttributesAndKubernetesRoundTrip(t *testing.T) {
 	require.Equal(t, cfg.Attributes.MetadataRetry, got.Attributes.MetadataRetry)
 	require.Equal(t, cfg.Attributes.Select, got.Attributes.Select)
 	require.Equal(t, cfg.Attributes.ExtraGroupAttributes, got.Attributes.ExtraGroupAttributes)
+}
+
+func TestV2ToRuntimeKubernetesMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode schema.KubernetesMode
+		want kubeflags.EnableFlag
+	}{
+		{
+			name: "enabled",
+			mode: schema.KubernetesModeEnabled,
+			want: kubeflags.EnabledTrue,
+		},
+		{
+			name: "disabled",
+			mode: schema.KubernetesModeDisabled,
+			want: kubeflags.EnabledFalse,
+		},
+		{
+			name: "autodetect",
+			mode: schema.KubernetesModeAutodetect,
+			want: kubeflags.EnabledAutodetect,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ext := &schema.Extension{
+				Version: schema.SupportedVersion,
+				Enrich: &schema.Enrich{
+					Enrichers: schema.Enrichers{
+						Kubernetes: schema.KubernetesEnricher{
+							Mode: test.mode,
+						},
+					},
+				},
+			}
+
+			got, err := V2ToRuntime(ext)
+			require.NoError(t, err)
+			require.Equal(t, test.want, got.Attributes.Kubernetes.Enable)
+		})
+	}
 }
 
 func TestV2ToRuntimeEmptyEnrichPreservesDefaults(t *testing.T) {

--- a/internal/config/convert/import_enrich_test.go
+++ b/internal/config/convert/import_enrich_test.go
@@ -1,0 +1,89 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/appolly/meta"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/kube/kubeflags"
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+func TestV2ToRuntimeEnrichAttributesAndKubernetesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultRuntimeConfig()
+	cfg.Attributes.Kubernetes.Enable = kubeflags.EnabledTrue
+	cfg.Attributes.Kubernetes.ClusterName = "cluster-a"
+	cfg.Attributes.Kubernetes.KubeconfigPath = "/etc/kube/config"
+	cfg.Attributes.Kubernetes.InformersSyncTimeout = 42 * time.Second
+	cfg.Attributes.Kubernetes.ReconnectInitialInterval = 43 * time.Second
+	cfg.Attributes.Kubernetes.InformersResyncPeriod = 44 * time.Second
+	cfg.Attributes.Kubernetes.DropExternal = true
+	cfg.Attributes.Kubernetes.DisableInformers = []string{"node", "service"}
+	cfg.Attributes.Kubernetes.MetaCacheAddress = "kube-cache:8999"
+	cfg.Attributes.Kubernetes.MetaRestrictLocalNode = true
+	cfg.Attributes.Kubernetes.MetaSourceLabels.ServiceName = "app.kubernetes.io/name"
+	cfg.Attributes.Kubernetes.MetaSourceLabels.ServiceNamespace = "app.kubernetes.io/part-of"
+	cfg.Attributes.Kubernetes.ResourceLabels = map[string][]string{
+		"service.name":    {"app"},
+		"service.version": {"version", "release"},
+	}
+	cfg.Attributes.Kubernetes.ServiceNameTemplate = "{{ .Meta.Name }}"
+	cfg.Attributes.MetadataRetry = meta.RetryConfig{
+		Timeout:       45 * time.Second,
+		StartInterval: 46 * time.Millisecond,
+		MaxInterval:   47 * time.Second,
+	}
+	cfg.Attributes.Select = attributes.Selection{
+		"traces": attributes.InclusionLists{
+			Include: []string{"http.route"},
+			Exclude: []string{"url.full"},
+		},
+		"http.server.duration": attributes.InclusionLists{
+			Include: []string{"k8s.*"},
+			Exclude: []string{"k8s.pod.uid"},
+		},
+	}
+	cfg.Attributes.Select.Normalize()
+	cfg.Attributes.ExtraGroupAttributes = obi.ExtraGroupAttributesMap{
+		"k8s_app_meta": []attr.Name{attr.K8sPodName, attr.K8sNamespaceName},
+	}
+
+	_, ext := RuntimeToV2(&cfg)
+	got, err := V2ToRuntime(ext)
+	require.NoError(t, err)
+
+	require.Equal(t, cfg.Attributes.Kubernetes, got.Attributes.Kubernetes)
+	require.Equal(t, cfg.Attributes.MetadataRetry, got.Attributes.MetadataRetry)
+	require.Equal(t, cfg.Attributes.Select, got.Attributes.Select)
+	require.Equal(t, cfg.Attributes.ExtraGroupAttributes, got.Attributes.ExtraGroupAttributes)
+}
+
+func TestV2ToRuntimeEmptyEnrichPreservesDefaults(t *testing.T) {
+	t.Parallel()
+
+	ext := &schema.Extension{
+		Version: schema.SupportedVersion,
+		Enrich: &schema.Enrich{
+			Enrichers:  schema.Enrichers{},
+			Attributes: schema.EnrichmentAttributes{},
+		},
+	}
+
+	got, err := V2ToRuntime(ext)
+	require.NoError(t, err)
+
+	require.Equal(t, obi.DefaultConfig.Attributes.Kubernetes, got.Attributes.Kubernetes)
+	require.Equal(t, obi.DefaultConfig.Attributes.MetadataRetry, got.Attributes.MetadataRetry)
+	require.Equal(t, obi.DefaultConfig.Attributes.Select, got.Attributes.Select)
+	require.Equal(t, obi.DefaultConfig.Attributes.ExtraGroupAttributes, got.Attributes.ExtraGroupAttributes)
+}

--- a/internal/config/schema/enrich.go
+++ b/internal/config/schema/enrich.go
@@ -4,9 +4,10 @@
 package schema // import "go.opentelemetry.io/obi/internal/config/schema"
 
 import (
+	"go.yaml.in/yaml/v3"
+
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
-	"go.opentelemetry.io/obi/pkg/kube/kubeflags"
 	"go.opentelemetry.io/obi/pkg/transform"
 )
 
@@ -22,9 +23,26 @@ type Enrichers struct {
 	Kubernetes KubernetesEnricher `yaml:"kubernetes"`
 }
 
+// KubernetesMode describes Kubernetes metadata enricher activation.
+type KubernetesMode string
+
+const (
+	// KubernetesModeAutodetect enables the enricher when Kubernetes is detected.
+	KubernetesModeAutodetect KubernetesMode = "autodetect"
+	// KubernetesModeEnabled always enables the Kubernetes enricher.
+	KubernetesModeEnabled KubernetesMode = "enabled"
+	// KubernetesModeDisabled disables the Kubernetes enricher.
+	KubernetesModeDisabled KubernetesMode = "disabled"
+)
+
+// UnmarshalYAML parses and validates a Kubernetes enricher mode.
+func (m *KubernetesMode) UnmarshalYAML(value *yaml.Node) error {
+	return unmarshalEnum(value, "mode", m, KubernetesModeAutodetect, KubernetesModeEnabled, KubernetesModeDisabled)
+}
+
 // KubernetesEnricher describes Kubernetes metadata enrichment settings.
 type KubernetesEnricher struct {
-	Mode                kubeflags.EnableFlag    `yaml:"mode"`
+	Mode                KubernetesMode          `yaml:"mode"`
 	ClusterName         string                  `yaml:"cluster_name"`
 	ServiceNameTemplate string                  `yaml:"service_name_template"`
 	Auth                KubernetesAuth          `yaml:"auth"`


### PR DESCRIPTION
Depends on #2462

## Summary

- Import standalone `enrich.attributes` into runtime attribute settings.
- Import `enrich.enrichers.kubernetes` fields exported by `RuntimeToV2`.
- Add focused round-trip and default-preservation tests for enrichment import parity.

## Validation

- `make generate`
- `go test ./internal/config/...`
- `go test ./cmd/check-config-v2-parity`
- `make check-config-v2-parity`
