### PR TITLE
Add path-based conditional triggers to CI workflows

### DIFF
--- a/.github/workflows/bpf_verifier.yml
+++ b/.github/workflows/bpf_verifier.yml
@@ -7,12 +7,16 @@ on:
     branches: [main, release-*]
     paths:
       - ".github/workflows/bpf_verifier.yml"
+      - ".github/actions/generate-bpf/**"
+      - ".github/actions/free-disk/**"
+      - ".github/actions/setup-lvh-kernel/**"
       - "bpf/**"
       - "**.go"
       - "go.mod"
       - "go.sum"
       - "internal/test/vm/**"
       - "scripts/kernel-matrix-json.sh"
+      - "Makefile"
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/bpf_verifier.yml
+++ b/.github/workflows/bpf_verifier.yml
@@ -5,6 +5,14 @@ on:
     branches: [main, release-*]
   pull_request:
     branches: [main, release-*]
+    paths:
+      - ".github/workflows/bpf_verifier.yml"
+      - "bpf/**"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "internal/test/vm/**"
+      - "scripts/kernel-matrix-json.sh"
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,22 @@ on:
     branches: [main, release-*]
   pull_request:
     branches: [main, release-*]
+    paths:
+      - ".github/workflows/pull_request.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "bpf/**"
+      - "cmd/**"
+      - "collector/**"
+      - "configs/**"
+      - "internal/**"
+      - "pkg/**"
+      - "schemas/**"
+      - "scripts/**"
+      - "Makefile"
+      - "Dockerfile"
+      - "**/*Dockerfile*"
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,6 +7,7 @@ on:
     branches: [main, release-*]
     paths:
       - ".github/workflows/pull_request.yml"
+      - ".github/actions/generate-bpf/**"
       - "**.go"
       - "go.mod"
       - "go.sum"

--- a/.github/workflows/pull_request_docker_build_test.yml
+++ b/.github/workflows/pull_request_docker_build_test.yml
@@ -7,11 +7,14 @@ on:
       - ".github/workflows/pull_request_docker_build_test.yml"
       - "Dockerfile"
       - "k8scache.Dockerfile"
+      - "dependencies.Dockerfile"
+      - ".dockerignore"
       - "**.go"
       - "go.mod"
       - "go.sum"
       - "bpf/**"
       - "pkg/internal/java/**"
+      - "Makefile"
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/pull_request_docker_build_test.yml
+++ b/.github/workflows/pull_request_docker_build_test.yml
@@ -3,6 +3,15 @@ name: Build test
 on:
   pull_request:
     branches: [main, release-*]
+    paths:
+      - ".github/workflows/pull_request_docker_build_test.yml"
+      - "Dockerfile"
+      - "k8scache.Dockerfile"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "bpf/**"
+      - "pkg/internal/java/**"
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/pull_request_privileged.yml
+++ b/.github/workflows/pull_request_privileged.yml
@@ -16,6 +16,7 @@ on:
       - "internal/**"
       - "pkg/**"
       - "scripts/**"
+      - "Makefile"
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/pull_request_privileged.yml
+++ b/.github/workflows/pull_request_privileged.yml
@@ -5,6 +5,17 @@ on:
     branches: [main, release-*]
   pull_request:
     branches: [main, release-*]
+    paths:
+      - ".github/workflows/pull_request_privileged.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "bpf/**"
+      - "cmd/**"
+      - "configs/**"
+      - "internal/**"
+      - "pkg/**"
+      - "scripts/**"
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,6 +5,17 @@ on:
     branches: [main, release-*]
   pull_request:
     branches: [main, release-*]
+    paths:
+      - ".github/workflows/unit_tests.yml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "bpf/**"
+      - "cmd/**"
+      - "configs/**"
+      - "internal/**"
+      - "pkg/**"
+      - "scripts/**"
   workflow_call:
     inputs:
       ref:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,6 +7,7 @@ on:
     branches: [main, release-*]
     paths:
       - ".github/workflows/unit_tests.yml"
+      - ".github/actions/generate-bpf/**"
       - "**.go"
       - "go.mod"
       - "go.sum"
@@ -16,6 +17,7 @@ on:
       - "internal/**"
       - "pkg/**"
       - "scripts/**"
+      - "Makefile"
   workflow_call:
     inputs:
       ref:


### PR DESCRIPTION
## Summary

Several workflows had no path filters and fired on every PR, including documentation-only changes. 

This PR adds `paths:` guards to some workflows so CI is skipped when only irrelevant files change.

Note: path lists may be incomplete or overly restrictive.



## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
