### PR TITLE
Sign release artifacts with cosign bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,12 +316,13 @@ jobs:
     secrets:
       DOCKER_TOKEN_EBPF_INSTRUMENTATION: ${{ secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION }}
 
-  build-artifacts:
+  build-artifacts-and-sign:
     name: Build Release Artifacts
     needs: tests-passed
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -334,6 +335,12 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache: false
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Print Cosign version
+        run: cosign version
 
       - name: Build amd64 release artifacts
         env:
@@ -444,6 +451,32 @@ jobs:
           RELEASE_VERSION: ${{ inputs.tag || github.ref_name }}
         run: make release-checksums RELEASE_VERSION="${RELEASE_VERSION}"
 
+      - name: Sign release artifacts
+        env:
+          RELEASE_VERSION: ${{ inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          artifacts=(
+            "dist/obi-${RELEASE_VERSION}-linux-amd64.tar.gz"
+            "dist/obi-${RELEASE_VERSION}-linux-arm64.tar.gz"
+            "dist/obi-${RELEASE_VERSION}-source-generated.tar.gz"
+            "dist/obi-${RELEASE_VERSION}-linux-amd64.cyclonedx.json"
+            "dist/obi-${RELEASE_VERSION}-linux-arm64.cyclonedx.json"
+            "dist/obi-${RELEASE_VERSION}-source-generated.cyclonedx.json"
+            "dist/obi-java-agent-${RELEASE_VERSION}.cyclonedx.json"
+            "dist/SHA256SUMS"
+          )
+
+          for artifact in "${artifacts[@]}"; do
+            if [ ! -f "${artifact}" ]; then
+              echo "ERROR: expected release artifact missing: ${artifact}"
+              exit 1
+            fi
+
+            cosign sign-blob --yes --bundle "${artifact}.bundle.json" "${artifact}"
+          done
+
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -453,7 +486,7 @@ jobs:
 
   release:
     name: Draft Release
-    needs: build-artifacts
+    needs: build-artifacts-and-sign
     runs-on: ubuntu-latest
     permissions:
       contents: write # https://github.com/softprops/action-gh-release#permissions
@@ -479,4 +512,5 @@ jobs:
             dist/obi-*-linux-*.tar.gz \
             dist/obi-*-source-generated.tar.gz \
             dist/*.cyclonedx.json \
-            dist/SHA256SUMS
+            dist/SHA256SUMS \
+            dist/*.bundle.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,28 +452,10 @@ jobs:
         run: make release-checksums RELEASE_VERSION="${RELEASE_VERSION}"
 
       - name: Sign release artifacts
-        env:
-          RELEASE_VERSION: ${{ inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
 
-          artifacts=(
-            "dist/obi-${RELEASE_VERSION}-linux-amd64.tar.gz"
-            "dist/obi-${RELEASE_VERSION}-linux-arm64.tar.gz"
-            "dist/obi-${RELEASE_VERSION}-source-generated.tar.gz"
-            "dist/obi-${RELEASE_VERSION}-linux-amd64.cyclonedx.json"
-            "dist/obi-${RELEASE_VERSION}-linux-arm64.cyclonedx.json"
-            "dist/obi-${RELEASE_VERSION}-source-generated.cyclonedx.json"
-            "dist/obi-java-agent-${RELEASE_VERSION}.cyclonedx.json"
-            "dist/SHA256SUMS"
-          )
-
-          for artifact in "${artifacts[@]}"; do
-            if [ ! -f "${artifact}" ]; then
-              echo "ERROR: expected release artifact missing: ${artifact}"
-              exit 1
-            fi
-
+          for artifact in dist/*; do
             cosign sign-blob --yes --bundle "${artifact}.bundle.json" "${artifact}"
           done
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Each release includes:
 #### Download and Verify
 
 Install [Cosign](https://docs.sigstore.dev/cosign/installation/) if you do not already have it.
-OBI release blobs are signed by the GitHub Actions release workflow with the
-GitHub Actions OIDC issuer. The identity regexp below matches the same
-repository identity used for container image verification.
+OBI release blobs are signed with GitHub Actions OIDC. The identity regexp
+below matches the same repository-level identity used for container image
+verification.
 
 ```bash
 # Set your desired version (find latest at https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases)
@@ -126,9 +126,10 @@ cosign verify-blob "${CHECKSUMS}" \
 ```
 
 Successful Cosign verification confirms that the local file matches the signed
-payload, the signing certificate identity matches the OBI release workflow, the
-certificate was issued by GitHub Actions OIDC, and the Sigstore bundle includes
-the transparency log material needed for offline verification.
+payload, the signing certificate identity matches this repository's GitHub
+Actions identity, the certificate was issued by GitHub Actions OIDC, and the
+Sigstore bundle includes the transparency log material needed for offline
+verification.
 
 Then verify the downloaded files against the signed checksum manifest:
 
@@ -145,8 +146,9 @@ obi-v${VERSION}-linux-${ARCH}.tar.gz: OK
 If Cosign or checksum verification fails, stop and do not run or compile the
 artifact. Confirm the version, artifact name, bundle name, and architecture,
 then re-download the artifact and bundle from the same release. If verification
-still fails, open a security-sensitive report with the release version and
-failed verification output.
+still fails, use the GitHub Security tab's "Report a vulnerability" flow for
+this repository with the release version and failed verification output. Do not
+open a public issue with potentially sensitive details.
 
 Extract the archive:
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,20 @@ Each release includes:
 
 - `obi-v<version>-linux-amd64.tar.gz` - Linux AMD64/x86_64 archive
 - `obi-v<version>-linux-arm64.tar.gz` - Linux ARM64 archive
+- `obi-v<version>-source-generated.tar.gz` - generated source archive
 - `obi-v<version>-linux-amd64.cyclonedx.json` - CycloneDX SBOM for the AMD64 archive
 - `obi-v<version>-linux-arm64.cyclonedx.json` - CycloneDX SBOM for the ARM64 archive
 - `obi-v<version>-source-generated.cyclonedx.json` - CycloneDX SBOM for the source-generated archive
 - `obi-java-agent-v<version>.cyclonedx.json` - CycloneDX SBOM for the embedded Java agent and its Java dependencies
 - `SHA256SUMS` - Checksums for verification of the release archives and SBOM assets
+- `<asset>.bundle.json` - Sigstore bundle for each signed archive, SBOM, and `SHA256SUMS`
 
 #### Download and Verify
+
+Install [Cosign](https://docs.sigstore.dev/cosign/installation/) if you do not already have it.
+OBI release blobs are signed by the GitHub Actions release workflow with the
+GitHub Actions OIDC issuer. The identity regexp below matches the same
+repository identity used for container image verification.
 
 ```bash
 # Set your desired version (find latest at https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases)
@@ -84,23 +91,49 @@ export VERSION=1.0.0
 # For Intel/AMD 64-bit: amd64
 # For ARM 64-bit: arm64
 export ARCH=amd64  # Change to arm64 for ARM systems
+
+export RELEASE_TAG=v${VERSION}
+export BASE_URL="https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/${RELEASE_TAG}"
+export ARTIFACT="obi-${RELEASE_TAG}-linux-${ARCH}.tar.gz"
+export BUNDLE="${ARTIFACT}.bundle.json"
+export CHECKSUMS=SHA256SUMS
+export CHECKSUMS_BUNDLE="${CHECKSUMS}.bundle.json"
+export CERTIFICATE_IDENTITY_REGEXP="https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/"
+export CERTIFICATE_OIDC_ISSUER="https://token.actions.githubusercontent.com"
 ```
 
-Download the archive and checksum manifest:
+Download the archive, checksum manifest, and their Sigstore bundles:
 
 ```bash
-# Download the archive for your architecture
-wget https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/v${VERSION}/obi-v${VERSION}-linux-${ARCH}.tar.gz
-
-# Download checksums
-wget https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/v${VERSION}/SHA256SUMS
+wget "${BASE_URL}/${ARTIFACT}"
+wget "${BASE_URL}/${BUNDLE}"
+wget "${BASE_URL}/${CHECKSUMS}"
+wget "${BASE_URL}/${CHECKSUMS_BUNDLE}"
 ```
 
-Verify the downloaded release assets:
+Verify the signatures before using the downloaded files:
 
 ```bash
-# Verify the archive you downloaded
-sha256sum -c SHA256SUMS --ignore-missing
+cosign verify-blob "${ARTIFACT}" \
+  --bundle "${BUNDLE}" \
+  --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEXP}" \
+  --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}"
+
+cosign verify-blob "${CHECKSUMS}" \
+  --bundle "${CHECKSUMS_BUNDLE}" \
+  --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEXP}" \
+  --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}"
+```
+
+Successful Cosign verification confirms that the local file matches the signed
+payload, the signing certificate identity matches the OBI release workflow, the
+certificate was issued by GitHub Actions OIDC, and the Sigstore bundle includes
+the transparency log material needed for offline verification.
+
+Then verify the downloaded files against the signed checksum manifest:
+
+```bash
+sha256sum -c "${CHECKSUMS}" --ignore-missing
 ```
 
 Successful verification prints an `OK` result for each file you downloaded:
@@ -109,9 +142,11 @@ Successful verification prints an `OK` result for each file you downloaded:
 obi-v${VERSION}-linux-${ARCH}.tar.gz: OK
 ```
 
-If verification fails, `sha256sum` reports `FAILED` instead. Re-download the
-affected files and make sure you are verifying assets from the same release
-version before proceeding.
+If Cosign or checksum verification fails, stop and do not run or compile the
+artifact. Confirm the version, artifact name, bundle name, and architecture,
+then re-download the artifact and bundle from the same release. If verification
+still fails, open a security-sensitive report with the release version and
+failed verification output.
 
 Extract the archive:
 
@@ -140,14 +175,17 @@ Download the SBOMs you want to inspect:
 
 ```bash
 # SBOM for the binary archive you downloaded
-wget https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/v${VERSION}/obi-v${VERSION}-linux-${ARCH}.cyclonedx.json
+wget "${BASE_URL}/obi-${RELEASE_TAG}-linux-${ARCH}.cyclonedx.json"
 
 # SBOM for the embedded Java agent and its Java dependencies
-wget https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases/download/v${VERSION}/obi-java-agent-v${VERSION}.cyclonedx.json
+wget "${BASE_URL}/obi-java-agent-${RELEASE_TAG}.cyclonedx.json"
 
 # Optional: verify the downloaded SBOM files against SHA256SUMS too
-sha256sum -c SHA256SUMS --ignore-missing
+sha256sum -c "${CHECKSUMS}" --ignore-missing
 ```
+
+Release SBOMs also have matching `.bundle.json` files and can be verified with
+the same `cosign verify-blob` command pattern shown above.
 
 Inspect the SBOM contents with common tools:
 


### PR DESCRIPTION
- Addresses #2479 by adding keyless `cosign sign-blob` signing for release archives, SBOMs, and `SHA256SUMS`.
- Uses the same repo-level Cosign certificate identity regexp as the container image verification examples.
- Documents copy-pasteable `cosign verify-blob` and checksum verification commands for binary downloads in `README.md`.

Note that the OpenTelemetry standalone OBI setup page https://opentelemetry.io/docs/zero-code/obi/setup/standalone/ lives outside this repository. I guess it should be updated after a release.

Testing on my fork: 
- job run: https://github.com/pellared/opentelemetry-ebpf-instrumentation/actions/runs/28120341628/job/83280732219
- artifacts: https://github.com/pellared/opentelemetry-ebpf-instrumentation/actions/runs/28120341628/artifacts/7860093032

```sh
$ cosign verify-blob obi-v0.1.1-linux-amd64.tar.gz \
    --bundle obi-v0.1.1-linux-amd64.tar.gz.bundle.json \
    --certificate-identity-regexp https://github.com/pellared/opentelemetry-ebpf-instrumentation \
    --certificate-oidc-issuer https://token.actions.githubusercontent.com
Verified OK
```

