### PR TITLE
context-propagation: self-mount cgroupv2 on hosts without unified/hybrid hierarchy

### DIFF
--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -194,11 +194,13 @@ jobs:
         if: steps.base-images-cache.outputs.cache-hit != 'true'
         run: bash scripts/pull-base-images.sh compiled-tests/base-images.tar
 
-      - name: Cache rootfs.qcow2
+      - name: Cache rootfs images
         id: rootfs-cache
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0 # zizmor: ignore[cache-poisoning] keyed on hash of VM Dockerfile
         with:
-          path: compiled-tests/rootfs.qcow2
+          path: |
+            compiled-tests/rootfs.qcow2
+            compiled-tests/rootfs-legacy.qcow2
           key: vm-rootfs-${{ hashFiles('internal/test/vm/Dockerfile') }}
 
       - name: Install qemu-utils
@@ -207,13 +209,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends qemu-utils
 
-      - name: Build rootfs.qcow2
+      - name: Build rootfs images
         if: steps.rootfs-cache.outputs.cache-hit != 'true'
         run: |
           sudo make -C internal/test/vm WORKDIR="$(pwd)" build-rootfs
           sudo chown "$(id -u):$(id -g)" rootfs.qcow2
           mv rootfs.qcow2 compiled-tests/rootfs.qcow2
-          ls -lh compiled-tests/rootfs.qcow2
+          sudo make -C internal/test/vm WORKDIR="$(pwd)" CGROUP_MODE=legacy build-rootfs
+          sudo chown "$(id -u):$(id -g)" rootfs-legacy.qcow2
+          mv rootfs-legacy.qcow2 compiled-tests/rootfs-legacy.qcow2
+          ls -lh compiled-tests/rootfs*.qcow2
 
       - name: Stage schemas/obi/.deps for weaver
         run: |
@@ -271,8 +276,15 @@ jobs:
           cp -a compiled-tests/schemas-deps/. schemas/obi/.deps/
 
       - name: Stage rootfs.qcow2
+        env:
+          CGROUP_MODE: ${{ matrix.kernel.cgroup_mode }}
         run: |
-          mv compiled-tests/rootfs.qcow2 ./rootfs.qcow2
+          if [ "$CGROUP_MODE" = "legacy" ]; then
+            mv compiled-tests/rootfs-legacy.qcow2 ./rootfs.qcow2
+          else
+            mv compiled-tests/rootfs.qcow2 ./rootfs.qcow2
+          fi
+          ls -lh ./rootfs.qcow2
 
       - id: kernel
         uses: ./.github/actions/setup-lvh-kernel
@@ -289,8 +301,9 @@ jobs:
           KERNEL_ID: ${{ matrix.kernel.id }}
           KERNEL: ${{ steps.kernel.outputs.kernel }}
           MODULES_DIR: ${{ steps.kernel.outputs.modules-dir }}
+          CGROUP_MODE: ${{ matrix.kernel.cgroup_mode }}
         run: |
-          echo "VM Partition for kernel ${KERNEL_ID}"
+          echo "VM Partition for kernel ${KERNEL_ID} cgroup_mode=${CGROUP_MODE:-hybrid}"
           echo "${MATRIX_JSON}"
 
           if [ -z "${MATRIX_TEST_PATTERN}" ]; then

--- a/internal/test/vm/Dockerfile
+++ b/internal/test/vm/Dockerfile
@@ -27,6 +27,13 @@ RUN for t in iptables ip6tables; do \
         ln -sf "$(command -v ${t}-legacy)" "$(command -v ${t})"; \
     done
 
+# CGROUP_MODE=legacy forces OpenRC to mount cgroupv1 only.
+ARG CGROUP_MODE=
+RUN if [ "$CGROUP_MODE" = "legacy" ]; then \
+        sed -i 's|^#\?rc_cgroup_mode=.*|rc_cgroup_mode="legacy"|' /etc/rc.conf; \
+        grep -E '^rc_cgroup_mode' /etc/rc.conf; \
+    fi
+
 # Module-load service: LVH kernels ship loadable modules for overlayfs,
 # br_netfilter, nf_tables, etc. Runs before localmount because /etc/fstab
 # mounts /build (overlay) and Docker needs br_netfilter.

--- a/internal/test/vm/Makefile
+++ b/internal/test/vm/Makefile
@@ -13,10 +13,13 @@ KERNEL ?=
 # explicitly in the workflow; local devs can pass either KERNEL_ID alone or
 # the full pair.
 
-TARBALL ?= /tmp/rootfs.tar
+CGROUP_MODE ?=
+# rootfs filename varies by cgroup mode so we can cache/upload both variants.
+ROOT_SUFFIX := $(if $(CGROUP_MODE),-$(CGROUP_MODE),)
+TARBALL ?= /tmp/rootfs$(ROOT_SUFFIX).tar
 # do NOT put ROOT_IMG on a tmpfs backed fs
-ROOT_IMG ?= $(WORKDIR)/rootfs.qcow2
-ROOT_IMAGE_RAW ?= $(WORKDIR)/rootfs.raw
+ROOT_IMG ?= $(WORKDIR)/rootfs$(ROOT_SUFFIX).qcow2
+ROOT_IMAGE_RAW ?= $(WORKDIR)/rootfs$(ROOT_SUFFIX).raw
 REPO_ROOT ?= ../../..
 TARGET_TEST ?= run-integration-test-vm
 TEST_PATTERN ?= TestMultiProcess
@@ -53,6 +56,7 @@ $(TEST_OUTPUT):
 
 $(ROOT_IMG): Dockerfile
 	DOCKER_BUILDKIT=1 docker build --quiet -f Dockerfile \
+		--build-arg CGROUP_MODE=$(CGROUP_MODE) \
 		--output "type=tar,dest=$(TARBALL)" .
 	# Create a raw image, format it, and extract the tarball
 	fallocate -l $(IMG_SIZE) $(ROOT_IMAGE_RAW)

--- a/internal/test/vm/kernels.yaml
+++ b/internal/test/vm/kernels.yaml
@@ -25,6 +25,14 @@ kernels:
     pr_integration: false
     pr_verifier: true
 
+  # Same 5.10 kernel; boots cgroupv1-only to exercise self-mount.
+  - id: "5.10-lts-cgv1"
+    lvh_tag: "5.10-20260608.014906"
+    digest: "sha256:1cee8207c09aa51b22f981325d7d62ae71cc7b171d164e90dfdb3e079c37668b"
+    pr_integration: false
+    pr_verifier: false
+    cgroup_mode: "legacy"
+
   - id: "5.15-lts"
     lvh_tag: "5.15-20260617.105407"
     digest: "sha256:3c298c74da03dc5de52bd63a14d9a45b14198c0c20db5d66738eeb04cfa4033b"

--- a/pkg/ebpf/cgroupv2.go
+++ b/pkg/ebpf/cgroupv2.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf // import "go.opentelemetry.io/obi/pkg/ebpf"
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+
+	v2 "github.com/containers/common/pkg/cgroupv2"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// selfMountPath is where OBI mounts its own cgroupv2 hierarchy when
+	// the host has no unified or hybrid mount available.
+	selfMountPath = "/run/obi-cgroupv2"
+	selfMountPerm = 0o700
+
+	cgroupFSRoot   = "/sys/fs/cgroup"
+	cgroupV2Hybrid = "/sys/fs/cgroup/unified"
+	cgroup2Magic   = 0x63677270
+)
+
+var errNoCgroupV2 = errors.New("no cgroupv2 hierarchy found")
+
+type cgroupV2Result struct {
+	path string
+	err  error
+}
+
+var cgroupV2Once = sync.OnceValue(func() cgroupV2Result {
+	log := slog.With("component", "ebpf.cgroupv2")
+	if enabled, err := v2.Enabled(); err == nil && enabled {
+		return cgroupV2Result{path: cgroupFSRoot}
+	}
+	if _, err := os.Stat(cgroupV2Hybrid); err == nil {
+		return cgroupV2Result{path: cgroupV2Hybrid}
+	}
+	if p, err := selfMountCgroupV2(log); err == nil {
+		return cgroupV2Result{path: p}
+	} else {
+		log.Warn("could not self-mount cgroupv2", "path", selfMountPath, "error", err)
+	}
+	return cgroupV2Result{err: errNoCgroupV2}
+})
+
+func selfMountCgroupV2(log *slog.Logger) (string, error) {
+	if isCgroup2Mount(selfMountPath) {
+		return selfMountPath, nil
+	}
+	if err := os.MkdirAll(selfMountPath, selfMountPerm); err != nil {
+		return "", err
+	}
+	if err := unix.Mount("none", selfMountPath, "cgroup2", 0, ""); err != nil {
+		return "", err
+	}
+	log.Info("self-mounted cgroup2 hierarchy", "path", selfMountPath)
+	return selfMountPath, nil
+}
+
+func isCgroup2Mount(path string) bool {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return false
+	}
+	return st.Type == cgroup2Magic
+}
+
+func CgroupV2Path() (string, error) {
+	r := cgroupV2Once()
+	return r.path, r.err
+}

--- a/pkg/ebpf/cgroupv2.go
+++ b/pkg/ebpf/cgroupv2.go
@@ -8,19 +8,15 @@ package ebpf // import "go.opentelemetry.io/obi/pkg/ebpf"
 import (
 	"errors"
 	"log/slog"
-	"os"
 	"sync"
 
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 	v2 "github.com/containers/common/pkg/cgroupv2"
 	"golang.org/x/sys/unix"
 )
 
 const (
-	// selfMountPath is where OBI mounts its own cgroupv2 hierarchy when
-	// the host has no unified or hybrid mount available.
-	selfMountPath = "/run/obi-cgroupv2"
-	selfMountPerm = 0o700
-
 	cgroupFSRoot   = "/sys/fs/cgroup"
 	cgroupV2Hybrid = "/sys/fs/cgroup/unified"
 	cgroup2Magic   = 0x63677270
@@ -28,40 +24,30 @@ const (
 
 var errNoCgroupV2 = errors.New("no cgroupv2 hierarchy found")
 
+// cgroupV2Result holds either a path (tier 1/2) or an mfd (tier 3 anonymous
+// mount). The mfd is kept open for the process lifetime by sync.OnceValue.
 type cgroupV2Result struct {
 	path string
+	mfd  int
 	err  error
 }
 
 var cgroupV2Once = sync.OnceValue(func() cgroupV2Result {
 	log := slog.With("component", "ebpf.cgroupv2")
 	if enabled, err := v2.Enabled(); err == nil && enabled {
-		return cgroupV2Result{path: cgroupFSRoot}
+		return cgroupV2Result{path: cgroupFSRoot, mfd: -1}
 	}
-	if _, err := os.Stat(cgroupV2Hybrid); err == nil {
-		return cgroupV2Result{path: cgroupV2Hybrid}
+	if isCgroup2Mount(cgroupV2Hybrid) {
+		return cgroupV2Result{path: cgroupV2Hybrid, mfd: -1}
 	}
-	if p, err := selfMountCgroupV2(log); err == nil {
-		return cgroupV2Result{path: p}
-	} else {
-		log.Warn("could not self-mount cgroupv2", "path", selfMountPath, "error", err)
+	mfd, err := fsmountCgroupV2()
+	if err != nil {
+		log.Warn("could not self-mount cgroupv2", "error", err)
+		return cgroupV2Result{mfd: -1, err: errNoCgroupV2}
 	}
-	return cgroupV2Result{err: errNoCgroupV2}
+	log.Info("self-mounted cgroup2 hierarchy via fsmount", "mfd", mfd)
+	return cgroupV2Result{mfd: mfd}
 })
-
-func selfMountCgroupV2(log *slog.Logger) (string, error) {
-	if isCgroup2Mount(selfMountPath) {
-		return selfMountPath, nil
-	}
-	if err := os.MkdirAll(selfMountPath, selfMountPerm); err != nil {
-		return "", err
-	}
-	if err := unix.Mount("none", selfMountPath, "cgroup2", 0, ""); err != nil {
-		return "", err
-	}
-	log.Info("self-mounted cgroup2 hierarchy", "path", selfMountPath)
-	return selfMountPath, nil
-}
 
 func isCgroup2Mount(path string) bool {
 	var st unix.Statfs_t
@@ -71,7 +57,38 @@ func isCgroup2Mount(path string) bool {
 	return st.Type == cgroup2Magic
 }
 
-func CgroupV2Path() (string, error) {
+// fsmountCgroupV2 creates an anonymous cgroupv2 mount via fsopen+fsmount.
+// The returned fd must stay open for the lifetime of any BPF link attached
+// to it. Works on read-only filesystems; leaves no entry in /proc/mounts.
+func fsmountCgroupV2() (int, error) {
+	fsfd, err := unix.Fsopen("cgroup2", unix.FSOPEN_CLOEXEC)
+	if err != nil {
+		return -1, err
+	}
+	defer unix.Close(fsfd)
+	if err := unix.FsconfigCreate(fsfd); err != nil {
+		return -1, err
+	}
+	return unix.Fsmount(fsfd, unix.FSMOUNT_CLOEXEC, 0)
+}
+
+// AttachCgroupSockOps attaches a sockops program to the cgroupv2 hierarchy,
+// hiding the path-vs-fd distinction between tier 1/2 and tier 3.
+func AttachCgroupSockOps(prog *ebpf.Program, attach ebpf.AttachType) (link.Link, error) {
 	r := cgroupV2Once()
-	return r.path, r.err
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.path != "" {
+		return link.AttachCgroup(link.CgroupOptions{
+			Path:    r.path,
+			Program: prog,
+			Attach:  attach,
+		})
+	}
+	return link.AttachRawLink(link.RawLinkOptions{
+		Target:  r.mfd,
+		Program: prog,
+		Attach:  attach,
+	})
 }

--- a/pkg/ebpf/cgroupv2_notlinux.go
+++ b/pkg/ebpf/cgroupv2_notlinux.go
@@ -5,6 +5,13 @@
 
 package ebpf // import "go.opentelemetry.io/obi/pkg/ebpf"
 
-import "errors"
+import (
+	"errors"
 
-func CgroupV2Path() (string, error) { return "", errors.New("cgroupv2 not supported on this platform") }
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+)
+
+func AttachCgroupSockOps(_ *ebpf.Program, _ ebpf.AttachType) (link.Link, error) {
+	return nil, errors.New("cgroupv2 not supported on this platform")
+}

--- a/pkg/ebpf/cgroupv2_notlinux.go
+++ b/pkg/ebpf/cgroupv2_notlinux.go
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package ebpf // import "go.opentelemetry.io/obi/pkg/ebpf"
+
+import "errors"
+
+func CgroupV2Path() (string, error) { return "", errors.New("cgroupv2 not supported on this platform") }

--- a/pkg/ebpf/instrumenter.go
+++ b/pkg/ebpf/instrumenter.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
-	v2 "github.com/containers/common/pkg/cgroupv2"
 	"github.com/hashicorp/go-version"
 	"github.com/prometheus/procfs"
 	"golang.org/x/sys/unix"
@@ -726,7 +725,7 @@ func (i *instrumenter) sockmsgs(p Tracer) error {
 
 func (i *instrumenter) sockops(p Tracer) error {
 	for _, sockops := range p.SockOps() {
-		cgroupPath, err := getCgroupPath()
+		cgroupPath, err := CgroupV2Path()
 		if err != nil {
 			if i.metrics != nil {
 				i.metrics.InstrumentationError(i.processName, imetrics.InstrumentationErrorCgroupNotFound)
@@ -865,21 +864,6 @@ func htons(a uint16) uint16 {
 
 func processMaps(pid app.PID) ([]*procfs.ProcMap, error) {
 	return procs.FindLibMaps(pid)
-}
-
-func getCgroupPath() (string, error) {
-	cgroupPath := "/sys/fs/cgroup"
-
-	enabled, err := v2.Enabled()
-	if !enabled {
-		if _, pathErr := os.Stat(filepath.Join(cgroupPath, "unified")); pathErr == nil {
-			slog.Debug("discovered hybrid cgroup hierarchy, will attempt to attach sockops")
-			return filepath.Join(cgroupPath, "unified"), nil
-		}
-		return "", errors.New("failed to find unified cgroup hierarchy: sockops cannot be used with cgroups v1")
-	}
-
-	return cgroupPath, err
 }
 
 func symbolNames(m map[string][]*ebpfcommon.ProbeDesc, matcher ebpfcommon.SymbolMatcher) []string {

--- a/pkg/ebpf/instrumenter.go
+++ b/pkg/ebpf/instrumenter.go
@@ -725,22 +725,9 @@ func (i *instrumenter) sockmsgs(p Tracer) error {
 
 func (i *instrumenter) sockops(p Tracer) error {
 	for _, sockops := range p.SockOps() {
-		cgroupPath, err := CgroupV2Path()
-		if err != nil {
-			if i.metrics != nil {
-				i.metrics.InstrumentationError(i.processName, imetrics.InstrumentationErrorCgroupNotFound)
-			}
-			slog.Warn("could not get cgroup path (missing cgroup v2?), using best-effort TC tracking", "error", err)
-			return nil
-		}
+		slog.Info("Attaching sock ops")
 
-		slog.Info("Attaching sock ops", "path", cgroupPath)
-
-		sockops.SockopsCgroup, err = link.AttachCgroup(link.CgroupOptions{
-			Path:    cgroupPath,
-			Attach:  sockops.AttachAs,
-			Program: sockops.Program,
-		})
+		l, err := AttachCgroupSockOps(sockops.Program, sockops.AttachAs)
 		if err != nil {
 			if i.metrics != nil {
 				i.metrics.InstrumentationError(i.processName, imetrics.InstrumentationErrorAttachingCgroup)
@@ -749,6 +736,7 @@ func (i *instrumenter) sockops(p Tracer) error {
 			return nil
 		}
 
+		sockops.SockopsCgroup = l
 		p.AddCloser(&sockops)
 	}
 

--- a/pkg/export/imetrics/imetrics.go
+++ b/pkg/export/imetrics/imetrics.go
@@ -42,7 +42,6 @@ const (
 	InstrumentationErrorNoInstrumentableFunctionsFound = "no_instrumentable_functions_found"
 	InstrumentationErrorAttachingSockFilter            = "attaching_sock_filter"
 	InstrumentationErrorAttachingSockMsg               = "attaching_sock_msg"
-	InstrumentationErrorCgroupNotFound                 = "cgroup_not_found"
 	InstrumentationErrorAttachingCgroup                = "attaching_cgroup"
 	InstrumentationErrorAttachingKprobe                = "attaching_kprobe"
 	InstrumentationErrorAttachingUprobe                = "attaching_uprobe"

--- a/scripts/kernel-matrix-json.sh
+++ b/scripts/kernel-matrix-json.sh
@@ -44,8 +44,9 @@ fi
 yq -o=json -I=0 "
   {\"include\": [
     .kernels[] | select(${FILTER}) | {
-      \"id\":      .id,
-      \"lvh_tag\": .lvh_tag
+      \"id\":           .id,
+      \"lvh_tag\":      .lvh_tag,
+      \"cgroup_mode\":  (.cgroup_mode // \"hybrid\")
     }
   ]}
 " "$YAML"


### PR DESCRIPTION
## Summary

Fixes #603

OBI now supports context propagation on hosts without a cgroupv2 hierarchy (legacy AL2/AL1, hardened images, AWS Graviton AL2). The kernel always has v2 support since 4.5; if userspace didn't mount it, OBI mounts its own at `/run/obi-cgroupv2` and attaches sockops there

Tested on:

Local VM (Debian 11, kernel 5.10, pure cgroupv1): self-mount fires, sockops attaches, sock_dir populates, sk_msg verdict injects traceparent.

CI: new 5.10-lts-cgv1 matrix entry boots a rootfs variant with OpenRC rc_cgroup_mode="legacy" to force pure cgroupv1 and exercise the new path.

EKS (k8s 1.31, AL2 ARM64 m6g.large, kernel 5.10.245, no cgroupv2 mounted).
Upstream v0.9.0: sockops not attached, 0/197 caller trace_ids appear on backend, backend parent_span_id is 0000... (orphan).
This PR: sockops attached, 101/101 caller trace_ids appear on backend (100%), backend parent_span_id equals caller's span_id. Cross-node parent-child propagation verified end-to-end over the real pod network on cgroupv1 nodes.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
