### PR TITLE
Forward host processes through kube discovery

### DIFF
--- a/pkg/appolly/discover/watcher_kube.go
+++ b/pkg/appolly/discover/watcher_kube.go
@@ -5,6 +5,7 @@ package discover // import "go.opentelemetry.io/obi/pkg/appolly/discover"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -177,6 +178,9 @@ func (wk *watcherKubeEnricher) onNewProcess(procInfo ProcessAttrs) (ProcessAttrs
 	if err != nil {
 		// it is expected for any process not running inside a container
 		wk.log.Debug("can't get container info for PID", "pid", procInfo.pid, "error", err)
+		if errors.Is(err, container.ErrContainerNotFound) {
+			return procInfo, true
+		}
 		return ProcessAttrs{}, false
 	}
 

--- a/pkg/appolly/discover/watcher_kube_test.go
+++ b/pkg/appolly/discover/watcher_kube_test.go
@@ -122,6 +122,47 @@ func TestWatcherKubeEnricher(t *testing.T) {
 	}
 }
 
+func TestWatcherKubeEnricherForwardsProcessesWithoutContainer(t *testing.T) {
+	fInformer := &fakeInformer{}
+	store := kube.NewStore(fInformer, kube.ResourceLabels{}, nil, imetrics.NoopReporter{})
+	input := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+	defer input.Close()
+	output := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+	outputCh := output.Subscribe()
+	defer output.Close()
+
+	wk := watcherKubeEnricher{
+		log:                slog.With("component", "discover.watcherKubeEnricher"),
+		store:              store,
+		containerByPID:     map[app.PID]container.Info{},
+		processByContainer: map[string][]ProcessAttrs{},
+		podsInfoCh:         make(chan Event[*informer.ObjectMeta], 10),
+		input:              input.Subscribe(),
+		output:             output,
+	}
+
+	prevContainerInfoForPID := containerInfoForPID
+	containerInfoForPID = func(_ app.PID) (container.Info, error) {
+		return container.Info{}, fmt.Errorf("looking up container: %w", container.ErrContainerNotFound)
+	}
+	t.Cleanup(func() {
+		containerInfoForPID = prevContainerInfoForPID
+	})
+
+	wk.enrichProcessEvent([]Event[ProcessAttrs]{
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 1, openPorts: []uint32{10248}}},
+	})
+
+	events := testutil.ReadChannel(t, outputCh, timeout)
+	require.Len(t, events, 1)
+	assert.Equal(t, Event[ProcessAttrs]{
+		Type: EventCreated,
+		Obj:  ProcessAttrs{pid: 1, openPorts: []uint32{10248}},
+	}, events[0])
+	assert.Empty(t, wk.containerByPID)
+	assert.Empty(t, wk.processByContainer)
+}
+
 func TestWatcherKubeEnricherWithMatcher(t *testing.T) {
 	containerInfoForPID = fakeContainerInfo
 	processInfo = fakeProcessInfo

--- a/pkg/internal/helpers/container/container.go
+++ b/pkg/internal/helpers/container/container.go
@@ -6,6 +6,7 @@ package container // import "go.opentelemetry.io/obi/pkg/internal/helpers/contai
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -20,6 +21,9 @@ var (
 	procRoot        = "/proc/"
 	namespaceFinder = procs.FindNamespace
 )
+
+// ErrContainerNotFound is returned when a process has no supported container cgroup entry.
+var ErrContainerNotFound = errors.New("container not found")
 
 // Info that we need to keep from a container: its ContainerID in Kubernetes and
 // the PIDNamespace of its processes.
@@ -69,7 +73,7 @@ func InfoForPID(pid app.PID) (Info, error) {
 			return Info{PIDNamespace: ns, ContainerID: cgroupID}, nil
 		}
 	}
-	return Info{}, fmt.Errorf("%s: couldn't find any docker entry for process with PID %d", cgroupFile, pid)
+	return Info{}, fmt.Errorf("%s: couldn't find any docker entry for process with PID %d: %w", cgroupFile, pid, ErrContainerNotFound)
 }
 
 // look for a cgroup ID on all the possible formats

--- a/pkg/internal/helpers/container/container.go
+++ b/pkg/internal/helpers/container/container.go
@@ -73,7 +73,7 @@ func InfoForPID(pid app.PID) (Info, error) {
 			return Info{PIDNamespace: ns, ContainerID: cgroupID}, nil
 		}
 	}
-	return Info{}, fmt.Errorf("%s: couldn't find any docker entry for process with PID %d: %w", cgroupFile, pid, ErrContainerNotFound)
+	return Info{}, ErrContainerNotFound
 }
 
 // look for a cgroup ID on all the possible formats

--- a/pkg/internal/helpers/container/container_test.go
+++ b/pkg/internal/helpers/container/container_test.go
@@ -96,9 +96,11 @@ func TestContainerID(t *testing.T) {
 		t.Run(fmt.Sprintf("must not find container. PID %d", pid), func(t *testing.T) {
 			_, err := InfoForPID(pid)
 			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrContainerNotFound)
 		})
 	}
 
 	_, err := InfoForPID(12345)
 	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrContainerNotFound)
 }


### PR DESCRIPTION
## What changed

This keeps Kubernetes metadata enrichment from dropping host processes when the process has no supported container cgroup entry. Those processes now continue through discovery undecorated, so explicit PID or path selectors can still instrument node-level processes such as kubelet while Kubernetes metadata enrichment remains enabled.

The container helper now exposes a sentinel `ErrContainerNotFound` error. The Kubernetes watcher forwards only that expected host-process case and keeps the previous drop behavior for other container lookup failures such as `/proc` read or namespace errors.

Fixes #2486.

## Validation

- `make generate`
- `go test ./pkg/appolly/discover`
- `go test ./pkg/internal/helpers/container`