### PR TITLE
Document Go channel span links

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -143,6 +143,7 @@ OBI currently documents the following asynchronous or runtime-specific context p
 | Framework | Runtime | Baseline | Limitations | Status |
 |:----------|:--------|:---------|:------------|:-------|
 | Go goroutines | Go | Go `1.18+` | Up to 3 nested levels of goroutines | Stable |
+| Go channel span links | Go | Go `1.17+` | Receiver-side links only; supports `runtime.chansend1`, `runtime.chanrecv1`, and `runtime.chanrecv2`; `select` paths are not supported; requires `runtime.hchan` offsets | Experimental |
 | Node.js async hooks | Node.js | Node.js `8.0+` | Custom handling of `SIGUSR1` might interfere | Stable |
 | Ruby Puma server | Ruby | Ruby applications served by Puma | Only works with Puma server | Stable |
 | Java thread pool | Java | JDK `8+` | None documented | Stable |

--- a/devdocs/README.md
+++ b/devdocs/README.md
@@ -15,6 +15,7 @@ This directory contains documentation that is not useful for our users but might
 - [BPF print format](bpf-print-format.md): it explains a uniform standard for all BPF print debug statements across the project.
 - [Dependency Integrity Policy](dependency-integrity-policy.md): required dependency pinning and verification rules for Dockerfiles.
 - [Python asyncio and uvloop Context Propagation](python-asyncio-context-propagation.md): architecture and implementation of Python async context propagation for `asyncio` workloads, including applications running on `uvloop`.
+- [Go Channel Span Links](go-channel-span-links.md): receiver-side span links for supported Go channel handoffs.
 - [Trace-Profile Correlation](trace-profile-correlation.md): standard communication channel for correlating profiles to OBI traces.
 - [Kubernetes Metadata Cache Service (`k8s-cache`)](k8s-cache.md): what the standalone metadata cache service is, why it exists, and how to deploy it alongside OBI.
 - [Metrics](./metrics.md): how the NetO11y, AppO11y, and StatsO11y pipelines turn eBPF events into exported metrics, and where to edit when adding a new one.

--- a/devdocs/features.md
+++ b/devdocs/features.md
@@ -54,6 +54,23 @@ To turn this off and fallback to the normal network based instrumentation for Go
 | github.com/IBM/sarama          |   Kafka    |               >= 1.37 | All     |  Yes   |                 No |         N/A
 | go.mongodb.org/mongo-driver    |  MongoDB   | >= v1.10.1, >= v2.0.1 | All     |  Yes   |                 No |         N/A
 
+### Go Channel Span Links
+
+OBI can emit experimental receiver-side span links for work handed off between
+goroutines through Go channels. When both sides of a supported channel handoff
+have active OBI-generated spans, the receiver span gets an OpenTelemetry span
+link to the sender span. OBI does not add a reciprocal link to the sender span,
+does not rewrite trace IDs, and does not change parent-child relationships.
+
+The channel-link probes are registered only when Go-specific tracers are active
+and OBI can resolve the `runtime.hchan` offsets required for the target binary.
+If those offsets are unavailable, OBI skips the channel-link probes for that
+binary instead of failing instrumentation. There is no separate user-facing
+configuration flag for this feature; it is enabled by default.
+
+For implementation details, supported runtime functions, and current
+limitations, see [Go channel span links](go-channel-span-links.md).
+
 ## Payload Capture
 
 OBI can capture full request and response payloads for some protocols and forward them to userspace for richer analysis
@@ -94,6 +111,7 @@ OBI has support for several asynchronous frameworks that allow it to propagate c
 | Framework           | Languages |         Versions | Limitations                                       | Status
 |:--------------------|:---------:|-----------------:|:--------------------------------------------------|:-------------
 | Go Routines         |    Go     |       Go >= 1.18 | up to 3 nested levels of goroutines               | Stable
+| Go channel span links |  Go     |       Go >= 1.17 | `select` paths are not supported                  | Experimental
 | Node.js Async Hooks |  Node.js  |   Node.js >= 8.0 | Custom handling of SIGUSR1 signal might interfere | Stable
 | Ruby Puma Server    |   Ruby    |              N/A | Only works with Puma server                       | Stable
 | Java Thread pool    |   Java    |           JDK 8+ | N/A                                               | Stable

--- a/devdocs/go-channel-span-links.md
+++ b/devdocs/go-channel-span-links.md
@@ -1,0 +1,60 @@
+# Go Channel Span Links
+
+OBI can emit experimental OpenTelemetry span links for Go channel handoffs. The
+feature models asynchronous causality: when one goroutine sends work through a
+Go channel and another goroutine receives it, the receiver span can link to the
+sender span.
+
+## Behavior
+
+OBI emits receiver-side links only. The receiver span links to the sender span,
+but the sender span is not changed. OBI does not rewrite trace IDs, does not
+rewrite parent span IDs, and does not model channel handoffs as parent-child
+relationships. Linked spans remain in separate traces unless they already shared
+a trace for another reason.
+
+Links are attached only to OBI-generated spans. If a span is expanded into
+queue and processing subspans, the link is attached to the processing subspan
+whose span ID matches the receiver work.
+
+## Probe Gating
+
+There is no separate user-facing configuration flag for Go channel span links.
+The feature is enabled by default. Runtime channel probes are registered when
+Go-specific tracing is enabled and OBI can resolve all `runtime.hchan` offsets
+needed by the target binary:
+
+- `qcount`
+- `dataqsiz`
+- `sendx`
+- `recvx`
+
+If any required `runtime.hchan` offset is unavailable, OBI skips channel-link
+probes for that binary instead of failing instrumentation. Disabling Go-specific
+tracers also disables channel-link probes.
+
+## Supported Handoffs
+
+OBI currently instruments these Go runtime functions:
+
+- `runtime.chansend1`
+- `runtime.chanrecv1`
+- `runtime.chanrecv2`
+
+The supported handoff shapes are:
+
+- direct unbuffered channel handoffs
+- buffered channel handoffs correlated by `runtime.hchan` buffer slot
+
+`runtime.selectgo` and `select`-based channel paths are not supported yet.
+
+## Limits
+
+Pending links are kept in a bounded userspace cache while OBI waits for the
+receiver span to be parsed. The cache holds up to 1024 receiver spans and
+expires entries after five minutes. Links are deduplicated, invalid span
+contexts are ignored, and self-links are dropped.
+
+OBI also honors the OpenTelemetry span link count limit. The default comes from
+the OpenTelemetry SDK, and users can override it with
+`OTEL_SPAN_LINK_COUNT_LIMIT`.


### PR DESCRIPTION
## Summary

This documents the Go channel handoff span-link behavior added for #2238. The docs now describe the experimental receiver-side link model, supported Go runtime channel functions, direct and buffered handoff coverage, offset-based probe gating, and the current unsupported `select` path.

The support matrix also now lists Go channel span links as experimental context propagation support so the shipped behavior has an explicit compatibility entry.

Closes #2238.

## Validation

- `make lint-markdown`
- `go test -count=1 ./pkg/internal/goexec ./pkg/export/otel/tracesgen ./pkg/appolly/app/request`
