### PR TITLE
Reject symlinked Java classpath paths under proc roots

### DIFF
--- a/pkg/internal/transform/route/harvest/java/archive.go
+++ b/pkg/internal/transform/route/harvest/java/archive.go
@@ -48,9 +48,12 @@ func (e *Extractor) scanClassFile(ctx context.Context, path string) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err != nil {
 		e.log.Debug("error stating Java class file", "path", path, "error", err)
+		return nil
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
 		return nil
 	}
 	if err := ctx.Err(); err != nil {

--- a/pkg/internal/transform/route/harvest/java/archive_test.go
+++ b/pkg/internal/transform/route/harvest/java/archive_test.go
@@ -101,6 +101,19 @@ func TestScanDirSkipsOversizedClassFiles(t *testing.T) {
 	assert.Zero(t, extractor.classesScanned)
 }
 
+func TestScanDirSkipsSymlinkedClassFiles(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "SpringController.class")
+	writeClassFixture(t, outside, "com/example/SpringController.class")
+	require.NoError(t, os.Symlink(outside, filepath.Join(root, "SpringController.class")))
+
+	extractor := NewExtractor()
+	require.NoError(t, extractor.scanDir(context.Background(), root))
+
+	assert.Empty(t, extractor.routes)
+	assert.Zero(t, extractor.classesScanned)
+}
+
 func TestScanDirReturnsContextErrorWhenCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/pkg/internal/transform/route/harvest/java/classpath.go
+++ b/pkg/internal/transform/route/harvest/java/classpath.go
@@ -198,7 +198,10 @@ func resolveProcessPath(root, cwd, path string) (string, bool) {
 		return "", false
 	}
 
-	if isProcRoot(root) {
+	if procRootPath(root) {
+		if pathHasSymlink(root, containerPath) {
+			return "", false
+		}
 		if _, err := os.Stat(hostPath); err != nil {
 			return "", false
 		}
@@ -218,6 +221,28 @@ func resolveProcessPath(root, cwd, path string) (string, bool) {
 	}
 
 	return hostEval, true
+}
+
+var procRootPath = isProcRoot
+
+func pathHasSymlink(root, containerPath string) bool {
+	parts := strings.Split(strings.TrimPrefix(containerPath, string(filepath.Separator)), string(filepath.Separator))
+	path := root
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		path = filepath.Join(path, part)
+		info, err := os.Lstat(path)
+		if err != nil {
+			return false
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func isProcRoot(root string) bool {

--- a/pkg/internal/transform/route/harvest/java/classpath_test.go
+++ b/pkg/internal/transform/route/harvest/java/classpath_test.go
@@ -212,6 +212,22 @@ func TestResolveProcessPath(t *testing.T) {
 		assert.False(t, ok)
 		assert.Empty(t, path)
 	})
+
+	t.Run("rejects symlink components for proc roots", func(t *testing.T) {
+		outside := filepath.Join(t.TempDir(), "outside")
+		require.NoError(t, os.MkdirAll(outside, 0o755))
+		writeFile(t, filepath.Join(outside, "app.jar"))
+		require.NoError(t, os.Symlink(outside, filepath.Join(root, "app", "escape")))
+
+		oldProcRootPath := procRootPath
+		procRootPath = func(string) bool { return true }
+		t.Cleanup(func() { procRootPath = oldProcRootPath })
+
+		path, ok := resolveProcessPath(root, "/app", "escape/app.jar")
+
+		assert.False(t, ok)
+		assert.Empty(t, path)
+	})
 }
 
 func TestIsProcRoot(t *testing.T) {


### PR DESCRIPTION
### Motivation

- Prevent a monitored Java process from causing the agent to resolve and scan host filesystem paths by embedding absolute symlinked entries in its classpath under `/proc/<pid>/root`.
- Address a logic gap where proc-root resolution performed only `os.Stat` on the lexical host path while later scan operations followed symlinks and could traverse outside the intended process root.

### Description

- Update `resolveProcessPath` to reject proc-root resolutions that contain symlink components by adding a `pathHasSymlink(root, containerPath)` check before `os.Stat` for `/proc/<pid>/root` paths.
- Introduce `procRootPath` indirection (defaulting to `isProcRoot`) to allow deterministic test coverage of the proc-root branch.
- Add unit testing for rejection of symlink components for proc roots in `classpath_test.go` that exercises the proc-root symlink-rejection behavior.

### Testing

- Ran `make generate BPF_GEN_ALL=pkg/ebpf/common/bpf_bpfel.go` successfully to ensure generated artifacts were available.
- Ran `go test ./pkg/internal/transform/route/harvest/java` and the package tests (including the new regression test) passed (`ok`).