### PR TITLE
fix(ebpf): close USDT probes on unlink

### DIFF
--- a/pkg/ebpf/instrumenter.go
+++ b/pkg/ebpf/instrumenter.go
@@ -510,6 +510,7 @@ func (i *instrumenter) usdtProbes(pid app.PID, ns uint32, p Tracer) error {
 		elfFile.Close()
 	}
 
+	i.closables = append(i.closables, usdtClosers...)
 	p.AddCloser(usdtClosers...)
 	return nil
 }


### PR DESCRIPTION
### Motivation

- USDT probe attachments were only registered as tracer-wide closers via `AddCloser` and not stored on the per-executable `instrumenter.closables`, which caused USDT links and IP-map cleanup to survive `UnlinkExecutable` and leak BPF links/file descriptors and stale IP-map state.

### Description

- Add the per-executable tracking of USDT closers by appending `usdtClosers` to `i.closables` in `pkg/ebpf/instrumenter.go` before also registering them with `p.AddCloser(...)`, so `UnlinkExecutable` will run per-executable cleanup for USDT probes.

### Testing

- `go test ./pkg/ebpf -run 'TestUSDTLinkCloser|TestUSDTIPMapPIDs'`
