### PR TITLE
Fix route pattern fallback matching

### DIFF
--- a/pkg/internal/transform/route/matcher.go
+++ b/pkg/internal/transform/route/matcher.go
@@ -106,7 +106,9 @@ func find(path []string, pathNode *node) string {
 	// so more specific patterns (e.g. "@:username") must be declared before a catch-all
 	for _, w := range pathNode.Patterns {
 		if w.matches(path[0]) {
-			return find(path[1:], w.node)
+			if fullRoute := find(path[1:], w.node); fullRoute != "" {
+				return fullRoute
+			}
 		}
 	}
 	if pathNode.AnyPath != nil {

--- a/pkg/internal/transform/route/matcher_test.go
+++ b/pkg/internal/transform/route/matcher_test.go
@@ -76,3 +76,14 @@ func TestFindPatternsInDefinitionOrder(t *testing.T) {
 	})
 	assert.Equal(t, "/:section/profile", catchAllFirst.Find("/@carol/profile"))
 }
+
+func TestFindPatternFallsBackToAnyPath(t *testing.T) {
+	m := NewMatcher([]string{
+		"/admin/*",
+		"/admin/:id/settings",
+	})
+
+	assert.Equal(t, "/admin/*", m.Find("/admin"))
+	assert.Equal(t, "/admin/*", m.Find("/admin/token"))
+	assert.Equal(t, "/admin/:id/settings", m.Find("/admin/token/settings"))
+}


### PR DESCRIPTION
### Motivation

- The route matcher could follow the first matching parameter/prefix pattern and return immediately even if the recursive search failed, which allowed narrower patterns to shadow broader `*` fallback routes.
- This regression affected `IgnorePatterns` usage and could cause paths that should be ignored to be exported, so the matcher must backtrack and honor `AnyPath` (`*`) when appropriate.

### Description

- Update `find` in `pkg/internal/transform/route/matcher.go` to only accept a pattern subtree match when the recursive `find` call returns a non-empty route, otherwise continue checking later patterns and the `AnyPath` fallback by returning `fullRoute` only when it is not empty.
- Add `TestFindPatternFallsBackToAnyPath` in `pkg/internal/transform/route/matcher_test.go` to cover the overlapping routes `"/admin/*"` and `"/admin/:id/settings"` and ensure `/admin/token` matches the broad wildcard while `/admin/token/settings` matches the specific route.

### Testing

- Ran `go test ./pkg/internal/transform/route` which passed and validated the new unit test and existing cases.