### PR TITLE
Scope base image cache by input ref

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -85,7 +85,16 @@ jobs:
         id: cache-key
         env:
           ARCH: ${{ runner.arch }}
-        run: echo "key=base-images-${ARCH}-$(bash scripts/discover-integration-images.sh --base-images | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          INPUT_REF: ${{ inputs.ref || '' }}
+        run: |
+          if [ -n "${INPUT_REF}" ]; then
+            REF_SCOPE="input-ref-$(printf '%s' "${INPUT_REF}" | sha256sum | cut -d' ' -f1)"
+          else
+            REF_SCOPE="event-ref"
+          fi
+
+          IMAGE_SCOPE="$(bash scripts/discover-integration-images.sh --base-images | sha256sum | cut -d' ' -f1)"
+          echo "key=base-images-${ARCH}-${REF_SCOPE}-${IMAGE_SCOPE}" >> "$GITHUB_OUTPUT"
 
       - name: Cache base images
         id: base-images-cache

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -92,7 +92,16 @@ jobs:
         id: cache-key
         env:
           ARCH: ${{ runner.arch }}
-        run: echo "key=base-images-${ARCH}-$(bash scripts/discover-integration-images.sh --base-images | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          INPUT_REF: ${{ inputs.ref || '' }}
+        run: |
+          if [ -n "${INPUT_REF}" ]; then
+            REF_SCOPE="input-ref-$(printf '%s' "${INPUT_REF}" | sha256sum | cut -d' ' -f1)"
+          else
+            REF_SCOPE="event-ref"
+          fi
+
+          IMAGE_SCOPE="$(bash scripts/discover-integration-images.sh --base-images | sha256sum | cut -d' ' -f1)"
+          echo "key=base-images-${ARCH}-${REF_SCOPE}-${IMAGE_SCOPE}" >> "$GITHUB_OUTPUT"
 
       - name: Cache base images
         id: base-images-cache

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -181,7 +181,16 @@ jobs:
         id: cache-key
         env:
           ARCH: ${{ runner.arch }}
-        run: echo "key=base-images-${ARCH}-$(bash scripts/discover-integration-images.sh --base-images | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          INPUT_REF: ${{ inputs.ref || '' }}
+        run: |
+          if [ -n "${INPUT_REF}" ]; then
+            REF_SCOPE="input-ref-$(printf '%s' "${INPUT_REF}" | sha256sum | cut -d' ' -f1)"
+          else
+            REF_SCOPE="event-ref"
+          fi
+
+          IMAGE_SCOPE="$(bash scripts/discover-integration-images.sh --base-images | sha256sum | cut -d' ' -f1)"
+          echo "key=base-images-${ARCH}-${REF_SCOPE}-${IMAGE_SCOPE}" >> "$GITHUB_OUTPUT"
 
       - name: Cache base images
         id: base-images-cache


### PR DESCRIPTION
### Motivation

- Prevent a CI cache-poisoning vector where untrusted checked-out refs can populate or restore a base-image cache key that trusted runs also use. 
- Isolate caches produced by dispatched/called runs that check out an explicit `inputs.ref` so attacker-controlled refs cannot poison the shared trusted cache namespace.

### Description

- Compute the base-image cache key using an additional `REF_SCOPE` component derived from `inputs.ref`, where `REF_SCOPE` is `ref-<sha256(inputs.ref)>` for explicit input refs and `event-ref` for normal trusted runs. 
- Applied this key change to `workflow_integration_tests_vm.yml`, `pull_request_integration_tests.yml`, and `pull_request_integration_tests_arm.yml` by replacing the single `IMAGE_SCOPE` key with `base-images-${ARCH}-${REF_SCOPE}-${IMAGE_SCOPE}`. 
- Kept the rest of the cache/restore and `pull-base-images.sh` behavior unchanged so existing functionality and build outcomes are preserved.

### Testing

- Ran `git diff --check` and found no whitespace or merge issues. (success) 
- Validated workflow YAML syntax with `ruby -e 'require "yaml"; ...'` for the three modified workflows. (success) 