### PR TITLE
Avoid GenAI error text in span status

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -1586,38 +1586,10 @@ func SpanStatusMessage(span *Span) string {
 		if span.SubType == HTTPSubtypeMCP && span.GenAI != nil && span.GenAI.MCP != nil && span.GenAI.MCP.ErrorMessage != "" {
 			return span.GenAI.MCP.ErrorMessage
 		}
-		if msg := genAIErrorMessage(span); msg != "" {
-			return msg
-		}
 	case EventTypeDNS:
 		if span.Status != 0 {
 			return dnsparser.RCode(span.Status).String()
 		}
-	}
-	return ""
-}
-
-func genAIErrorMessage(span *Span) string {
-	if span.GenAI == nil {
-		return ""
-	}
-	if span.GenAI.OpenAI != nil && span.GenAI.OpenAI.Error.Message != "" {
-		return span.GenAI.OpenAI.Error.Message
-	}
-	if span.GenAI.Anthropic != nil && span.GenAI.Anthropic.Output.Error != nil && span.GenAI.Anthropic.Output.Error.Message != "" {
-		return span.GenAI.Anthropic.Output.Error.Message
-	}
-	if span.GenAI.Gemini != nil && span.GenAI.Gemini.Output.Error != nil && span.GenAI.Gemini.Output.Error.Message != "" {
-		return span.GenAI.Gemini.Output.Error.Message
-	}
-	if span.GenAI.Qwen != nil && span.GenAI.Qwen.Error.Message != "" {
-		return span.GenAI.Qwen.Error.Message
-	}
-	if span.GenAI.Bedrock != nil && span.GenAI.Bedrock.Output.ErrorMessage != "" {
-		return span.GenAI.Bedrock.Output.ErrorMessage
-	}
-	if span.GenAI.Rerank != nil && span.GenAI.Rerank.Output.Error != nil && span.GenAI.Rerank.Output.Error.Message != "" {
-		return span.GenAI.Rerank.Output.Error.Message
 	}
 	return ""
 }

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -1223,7 +1223,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		topSpan := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 		spanAttrs := topSpan.Attributes()
 		ensureTraceStrAttr(t, spanAttrs, semconv.ErrorTypeKey, "insufficient_quota")
-		assert.Equal(t, "You exceeded your current quota, please check your plan and billing details.", topSpan.Status().Message())
+		assert.Empty(t, topSpan.Status().Message())
 		ensureTraceAttrNotExists(t, spanAttrs, attribute.Key("error.message"))
 	})
 
@@ -1447,7 +1447,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		ensureTraceStrAttr(t, spanAttrs, semconv.GenAISystemInstructionsKey, `[{"type":"text","content":"Be concise."}]`)
 		ensureTraceStrAttr(t, spanAttrs, semconv.GenAIToolDefinitionsKey, `[{"type":"function","name":"calculator","description":"Performs arithmetic"}]`)
 		ensureTraceStrAttr(t, spanAttrs, semconv.ErrorTypeKey, "authentication_error")
-		assert.Equal(t, "invalid x-api-key", topSpan.Status().Message())
+		assert.Empty(t, topSpan.Status().Message())
 		ensureTraceAttrNotExists(t, spanAttrs, attribute.Key("error.message"))
 	})
 
@@ -1590,7 +1590,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		ensureTraceStrAttr(t, spanAttrs, semconv.GenAISystemInstructionsKey, `[{"type":"text","content":"Be concise."}]`)
 		ensureTraceStrAttr(t, spanAttrs, semconv.GenAIToolDefinitionsKey, `[{"type":"function","name":"get_weather"}]`)
 		ensureTraceStrAttr(t, spanAttrs, semconv.ErrorTypeKey, "NOT_FOUND")
-		assert.Equal(t, "model not found", topSpan.Status().Message())
+		assert.Empty(t, topSpan.Status().Message())
 		ensureTraceAttrNotExists(t, spanAttrs, attribute.Key("error.message"))
 	})
 
@@ -1781,7 +1781,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		ensureTraceStrAttr(t, spanAttrs, semconv.GenAISystemInstructionsKey, `[{"type":"text","content":"Be concise."}]`)
 		ensureTraceStrAttr(t, spanAttrs, semconv.GenAIToolDefinitionsKey, `[{"type":"function","name":"get_weather","description":"Get weather"}]`)
 		ensureTraceStrAttr(t, spanAttrs, semconv.ErrorTypeKey, "ValidationException")
-		assert.Equal(t, "The provided model identifier is invalid.", topSpan.Status().Message())
+		assert.Empty(t, topSpan.Status().Message())
 		ensureTraceAttrNotExists(t, spanAttrs, attribute.Key("error.message"))
 	})
 


### PR DESCRIPTION
### Motivation
- Prevent exporting raw GenAI provider error messages via `status.message`. Unlike DB error status messages, which are derived from the optional `db.response.error` attribute only when selected, GenAI provider error text was copied directly into the OTLP status message and bypassed `attributes.select.traces`.

### Description
- Remove the provider-specific GenAI fallback from `SpanStatusMessage` so `genAIErrorMessage` is no longer returned into span status for HTTP spans.  
- Remove the now-unused `genAIErrorMessage` helper from `pkg/appolly/app/request/span.go`.  
- Update tests in `pkg/export/otel/traces_test.go` to assert `topSpan.Status().Message()` is empty for GenAI error cases while keeping `error.type` and other non-sensitive attributes intact.  
- Preserve existing behavior for JSON-RPC, MCP (`MCP.ErrorMessage`), and DNS status paths.

### Testing
- `go test ./pkg/appolly/app/request -run TestSpanStatusMessage` 
- `go test ./pkg/export/otel -run TestGenerateTracesAttributes`
