### PR TITLE
Fix Weaver integration image pin mismatch

### DIFF
--- a/internal/test/integration/components/weaver/service.yml
+++ b/internal/test/integration/components/weaver/service.yml
@@ -25,7 +25,7 @@
 # of host ownership.
 services:
   weaver:
-    image: otel/weaver:v0.23.0@sha256:7984ecb55b859eb3034ae9d836c4eeda137e2bdd0873b7ba2bb6c3d24d6ff457
+    image: otel/weaver:v0.24.1@sha256:263964a7d444e77812f7a2d654e17683c4760a968c91278acdb7a44c20ccd572
     container_name: weaver
     user: "0:0"
     working_dir: /obi-registry


### PR DESCRIPTION
### Motivation

- Restore consistency between programmatic and compose-driven integration tests by ensuring the Weaver image pin in `internal/test/integration/components/weaver/service.yml` matches the `imgWeaver` constant in `internal/test/integration/dockerutil_test.go`.

### Description
- Update the `weaver` service image in `internal/test/integration/components/weaver/service.yml` to `otel/weaver:v0.24.1@sha256:263964a7d444e77812f7a2d654e17683c4760a968c91278acdb7a44c20ccd572` so it matches the `imgWeaver` definition.

