### PR TITLE
Preserve truncated request body read errors

### DIFF
--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -327,24 +327,46 @@ func HTTPInfoEventToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo) (reques
 	// We probe a single byte instead of ReadAll to avoid allocating and
 	// copying the entire body on the happy path.
 	if req.ContentLength > 0 {
-		var probe [1]byte
-		n, _ := req.Body.Read(probe[:])
-		if n == 0 {
-			// Body is empty despite Content-Length > 0; attempt recovery
-			// from the raw buffer.
-			if recovered := recoverJSONBodyFromBuffer(requestBuffer); len(recovered) > 0 {
-				if int64(len(recovered)) > req.ContentLength {
-					recovered = recovered[:req.ContentLength]
-				}
-				req.Body = io.NopCloser(bytes.NewBuffer(recovered))
-			}
-		} else {
-			// Body is present (happy path); prepend the consumed byte.
-			req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(probe[:1]), req.Body))
-		}
+		recoverRequestBody(req, requestBuffer)
 	}
 
 	return httpRequestResponseToSpan(parseCtx, event, req, resp), false, nil
+}
+
+func recoverRequestBody(req *http.Request, requestBuffer *largebuf.LargeBuffer) {
+	var probe [1]byte
+	n, err := req.Body.Read(probe[:])
+	if n > 0 {
+		// Body is present (happy path); prepend the consumed byte.
+		req.Body = io.NopCloser(io.MultiReader(bytes.NewReader(probe[:1]), req.Body))
+		return
+	}
+
+	// Body is empty despite Content-Length > 0; attempt recovery
+	// from the raw buffer.
+	if recovered := recoverJSONBodyFromBuffer(requestBuffer); len(recovered) > 0 {
+		if int64(len(recovered)) > req.ContentLength {
+			recovered = recovered[:req.ContentLength]
+		}
+		req.Body = io.NopCloser(bytes.NewBuffer(recovered))
+		return
+	}
+
+	if err != nil {
+		req.Body = readErrorCloser{err: err}
+	}
+}
+
+type readErrorCloser struct {
+	err error
+}
+
+func (r readErrorCloser) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (r readErrorCloser) Close() error {
+	return nil
 }
 
 // recoverJSONBodyFromBuffer scans the raw request buffer for a JSON object

--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -6,6 +6,7 @@ package ebpfcommon
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -594,6 +595,35 @@ func TestRemoveQuery(t *testing.T) {
 			require.Equal(t, tc.want, removeQuery(tc.input))
 		})
 	}
+}
+
+func TestRecoverRequestBodyPreservesProbeErrorWhenRecoveryFails(t *testing.T) {
+	readErr := errors.New("truncated request body")
+	req := &http.Request{
+		ContentLength: 10,
+		Body:          readErrorCloser{err: readErr},
+	}
+	requestBuffer := largebuf.NewLargeBufferFrom([]byte("POST /v1/chat/completions HTTP/1.1\r\nContent-Length: 10\r\n\r\n"))
+
+	recoverRequestBody(req, requestBuffer)
+
+	body, err := io.ReadAll(req.Body)
+	require.ErrorIs(t, err, readErr)
+	require.Empty(t, body)
+}
+
+func TestRecoverRequestBodyPrependsProbeByte(t *testing.T) {
+	req := &http.Request{
+		ContentLength: 4,
+		Body:          io.NopCloser(strings.NewReader("body")),
+	}
+	requestBuffer := largebuf.NewLargeBufferFrom([]byte("POST /v1/chat/completions HTTP/1.1\r\nContent-Length: 4\r\n\r\nbody"))
+
+	recoverRequestBody(req, requestBuffer)
+
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, "body", string(body))
 }
 
 func TestDechunkBody(t *testing.T) {


### PR DESCRIPTION
### Motivation

- A one-byte probe read from `req.Body` could consume an EOF/error and be ignored, which left downstream readers observing an empty body with a `nil` error instead of the original truncation error. 
- This changed downstream GenAI detectors' behavior when a request had a `Content-Length > 0` but the captured request body was truncated or missing.

### Description

- Move the probe/recovery logic into a new helper `recoverRequestBody(req, requestBuffer)` to centralize behavior and reduce accidental error swallowing. 
- Introduce `readErrorCloser` that implements `io.ReadCloser` to preserve and re-expose the original probe `Read` error to downstream readers when JSON recovery fails. 
- Keep the happy-path behavior of prepending a consumed probe byte via `io.MultiReader` when the probe read returned bytes. 
- Add focused unit tests `TestRecoverRequestBodyPreservesProbeErrorWhenRecoveryFails` and `TestRecoverRequestBodyPrependsProbeByte` validating error preservation and happy-path byte prepending.

### Testing

- Ran `go test ./pkg/ebpf/common` which completed successfully. 
