### PR TITLE
Fix Go channel probe offset discovery

### DIFF
--- a/pkg/appolly/discover/typer.go
+++ b/pkg/appolly/discover/typer.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/ebpf"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	"go.opentelemetry.io/obi/pkg/internal/ebpf/gotracer"
 	"go.opentelemetry.io/obi/pkg/internal/goexec"
 	"go.opentelemetry.io/obi/pkg/internal/procs"
 	"go.opentelemetry.io/obi/pkg/internal/transform/route/clusterurl"
@@ -318,11 +319,20 @@ func (t *typer) loadAllGoFunctionNames() {
 	t.allGoFunctions = nil
 	for _, p := range newGoTracersGroup(nil, t.cfg, t.metrics) {
 		for symbolName := range p.GoProbes() {
-			// avoid duplicating function names
-			if _, ok := uniqueFunctions[symbolName]; !ok {
-				uniqueFunctions[symbolName] = struct{}{}
-				t.allGoFunctions = append(t.allGoFunctions, symbolName)
-			}
+			t.addGoFunctionName(uniqueFunctions, symbolName)
 		}
 	}
+
+	for _, symbolName := range gotracer.GoChannelLinkProbeSymbols() {
+		t.addGoFunctionName(uniqueFunctions, symbolName)
+	}
+}
+
+func (t *typer) addGoFunctionName(uniqueFunctions map[string]struct{}, symbolName string) {
+	if _, ok := uniqueFunctions[symbolName]; ok {
+		return
+	}
+
+	uniqueFunctions[symbolName] = struct{}{}
+	t.allGoFunctions = append(t.allGoFunctions, symbolName)
 }

--- a/pkg/appolly/discover/typer_test.go
+++ b/pkg/appolly/discover/typer_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
+	"go.opentelemetry.io/obi/pkg/internal/ebpf/gotracer"
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/selection"
 	"go.opentelemetry.io/obi/pkg/transform"
@@ -51,6 +52,15 @@ func (d dummyCriterion) GetRoutesConfig() *services.CustomRoutesConfig          
 
 func (d dummyCriterion) MetricsConfig() perapp.SvcMetricsConfig {
 	return perapp.SvcMetricsConfig{Features: d.features}
+}
+
+func TestLoadAllGoFunctionNamesIncludesChannelLinkSymbols(t *testing.T) {
+	ty := typer{cfg: &obi.Config{Routes: &transform.RoutesConfig{}}}
+	ty.loadAllGoFunctionNames()
+
+	for _, symbol := range gotracer.GoChannelLinkProbeSymbols() {
+		assert.Contains(t, ty.allGoFunctions, symbol)
+	}
 }
 
 func TestMakeServiceAttrs(t *testing.T) {

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -481,6 +481,17 @@ func (p *Tracer) AddCloser(c ...io.Closer) {
 	p.closers = append(p.closers, c...)
 }
 
+var goChannelLinkProbeSymbols = []string{
+	"runtime.chansend1",
+	"runtime.chanrecv1",
+	"runtime.chanrecv2",
+}
+
+// GoChannelLinkProbeSymbols returns the Go runtime symbols used to correlate direct channel handoffs.
+func GoChannelLinkProbeSymbols() []string {
+	return append([]string(nil), goChannelLinkProbeSymbols...)
+}
+
 func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 	m := map[string][]*ebpfcommon.ProbeDesc{
 		// Go runtime
@@ -828,15 +839,15 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 	}
 
 	if p.goChannelLinkProbesEnabled() {
-		m["runtime.chansend1"] = []*ebpfcommon.ProbeDesc{{
+		m[goChannelLinkProbeSymbols[0]] = []*ebpfcommon.ProbeDesc{{
 			Start: p.bpfObjects.ObiUprobeRuntimeChansend1,
 			End:   p.bpfObjects.ObiUprobeRuntimeChansend1Return,
 		}}
-		m["runtime.chanrecv1"] = []*ebpfcommon.ProbeDesc{{
+		m[goChannelLinkProbeSymbols[1]] = []*ebpfcommon.ProbeDesc{{
 			Start: p.bpfObjects.ObiUprobeRuntimeChanrecv1,
 			End:   p.bpfObjects.ObiUprobeRuntimeChanrecv1Return,
 		}}
-		m["runtime.chanrecv2"] = []*ebpfcommon.ProbeDesc{{
+		m[goChannelLinkProbeSymbols[2]] = []*ebpfcommon.ProbeDesc{{
 			Start: p.bpfObjects.ObiUprobeRuntimeChanrecv2,
 			End:   p.bpfObjects.ObiUprobeRuntimeChanrecv2Return,
 		}}

--- a/pkg/internal/ebpf/gotracer/gotracer_test.go
+++ b/pkg/internal/ebpf/gotracer/gotracer_test.go
@@ -38,7 +38,7 @@ func TestGoChannelLinkProbesRequireChannelOffsets(t *testing.T) {
 
 	tracer.recordGoChannelOffsetAvailability(exec.New(exec.Init{Ino: 2}), goChannelOffsets())
 	probes := tracer.GoProbes()
-	for _, symbol := range goChannelLinkProbeSymbols() {
+	for _, symbol := range GoChannelLinkProbeSymbols() {
 		require.Contains(t, probes, symbol)
 	}
 }
@@ -81,18 +81,10 @@ func goChannelOffsets() *goexec.Offsets {
 	}}
 }
 
-func goChannelLinkProbeSymbols() []string {
-	return []string{
-		"runtime.chansend1",
-		"runtime.chanrecv1",
-		"runtime.chanrecv2",
-	}
-}
-
 func assertNoGoChannelLinkProbes(t *testing.T, probes map[string][]*ebpfcommon.ProbeDesc) {
 	t.Helper()
 
-	for _, symbol := range goChannelLinkProbeSymbols() {
+	for _, symbol := range GoChannelLinkProbeSymbols() {
 		assert.NotContains(t, probes, symbol)
 	}
 }


### PR DESCRIPTION
### Motivation

- Discovery builds the list of Go symbols to inspect before per-executable `hchan` offsets are recorded, which caused `runtime.chansend1`, `runtime.chanrecv1`, and `runtime.chanrecv2` to be omitted from the initial offset inspection and therefore never have return offsets discovered. 
- The intent of the change is to ensure those runtime channel-handoff symbols are always included in symbol-discovery while preserving the existing per-binary conditional attachment behavior that only enables the runtime probes when offsets are available.

### Description

- Introduce a shared symbol list `goChannelLinkProbeSymbols` and exported accessor `GoChannelLinkProbeSymbols()` in `pkg/internal/ebpf/gotracer` and use it where appropriate instead of duplicating literal symbol strings. 
- Change `gotracer.GoProbes()` to index the conditional probe map by the shared symbol list, keeping actual probe attachment conditional on recorded offsets via `goChannelLinkProbesEnabled()`. 
- Update discovery so `typer.loadAllGoFunctionNames()` always adds the channel-link symbols to `t.allGoFunctions` (using a new helper `addGoFunctionName`) so `goexec.InspectOffsets` is asked for their offsets during discovery. 
- Add a unit test in `pkg/appolly/discover/typer_test.go` to assert discovery includes the channel-link symbols and update existing gotracer tests to reference the shared symbol accessor.

### Testing
- `go test ./pkg/internal/ebpf/gotracer ./pkg/appolly/discover`
- `go test ./pkg/internal/ebpf/gotracer -run 'TestGoChannel|TestProcessBinary'`
