### PR TITLE
harvest/js: extend Node.js route harvesting with variable and template literal matching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cilium/ebpf v0.20.0
 	github.com/containers/common v0.64.2
+	github.com/dop251/goja v0.0.0-20260618133527-c9b2ea77db59
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/stdr v1.2.2
@@ -159,6 +160,7 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.25.5 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/btree v1.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396 h1
 github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396/go.mod h1:2VCDG9kHYQ5vfYUqeoB7foVlcvIvB7rp9LxTELLD1qU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
-github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
-github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
@@ -80,6 +80,8 @@ github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf
 github.com/docker/go-connections v0.7.0/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dop251/goja v0.0.0-20260618133527-c9b2ea77db59 h1:DjKLmvKK9u15djHZ88N8M0DhgnHVgJJ8bnEe0h7Lga8=
+github.com/dop251/goja v0.0.0-20260618133527-c9b2ea77db59/go.mod h1:Sc+QOu1WruvaaeT/cxFez/pXHpI9ZDjg/E8QNfSVveI=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
@@ -155,6 +157,8 @@ github.com/go-playground/validator/v10 v10.30.3 h1:4MU6YkEwx7GbcPJOZxrtbu+QfF3pJ
 github.com/go-playground/validator/v10 v10.30.3/go.mod h1:4Axh7oCNGcoGkqLoE4YWt6n20mcEIsPRlB7vPk3lpyc=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=

--- a/pkg/internal/transform/route/harvest/js.go
+++ b/pkg/internal/transform/route/harvest/js.go
@@ -473,6 +473,16 @@ func (e *RouteExtractor) scanFile(filePath string) error {
 		return err
 	}
 
+	// Fallback pass: resolve routes whose path comes from a variable or a
+	// template literal, which the line-based regex harvesters cannot match.
+	src, ok, err := readJSFileForScan(filePath)
+	if err != nil {
+		return err
+	}
+	if ok {
+		e.routes = append(e.routes, e.resolveASTRoutes(filePath, src)...)
+	}
+
 	return nil
 }
 

--- a/pkg/internal/transform/route/harvest/js_ast.go
+++ b/pkg/internal/transform/route/harvest/js_ast.go
@@ -1,0 +1,180 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package harvest // import "go.opentelemetry.io/obi/pkg/internal/transform/route/harvest"
+
+import (
+	"io"
+	"strings"
+
+	"github.com/dop251/goja/ast"
+	"github.com/dop251/goja/file"
+	"github.com/dop251/goja/parser"
+	"github.com/dop251/goja/token"
+)
+
+// readJSFileForScan returns the bounded contents of a JS/TS file using the same
+// safety guards as the line scanner. ok is false for non-regular or oversized
+// files that should be skipped.
+func readJSFileForScan(path string) (string, bool, error) {
+	f, ok, err := openJSFileForScan(path)
+	if err != nil || !ok {
+		return "", ok, err
+	}
+	defer f.Close()
+
+	b, err := io.ReadAll(io.LimitReader(f, MaxJSFileScanBytes))
+	if err != nil {
+		return "", false, err
+	}
+	return string(b), true, nil
+}
+
+// astRouteMethods maps the JS route-registration method name to the HTTP method
+// it represents. It mirrors the verbs handled by the regex harvesters.
+var astRouteMethods = map[string]string{
+	"get":     "GET",
+	"post":    "POST",
+	"put":     "PUT",
+	"patch":   "PATCH",
+	"delete":  "DELETE",
+	"del":     "DELETE",
+	"head":    "HEAD",
+	"options": "OPTIONS",
+	"all":     "ALL",
+}
+
+// resolveASTRoutes parses a JS source file and extracts routes whose path is
+// supplied through a string variable or a template literal. The line-based
+// regex harvesters only match quoted string literals, so this acts as a
+// fallback for the cases highlighted in
+// https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/929.
+//
+// It returns nil when the source cannot be parsed (for example TypeScript),
+// leaving the regex-based results untouched.
+func (e *RouteExtractor) resolveASTRoutes(filePath, src string) []RoutePattern {
+	prog, err := parser.ParseFile(nil, filePath, src, 0)
+	if err != nil {
+		return nil
+	}
+
+	// First pass: collect string-valued variable bindings so identifiers used
+	// as route paths can be resolved regardless of declaration order.
+	strVars := map[string]string{}
+	walk(prog, func(n ast.Node) {
+		b, ok := n.(*ast.Binding)
+		if !ok {
+			return
+		}
+		id, ok := b.Target.(*ast.Identifier)
+		if !ok {
+			return
+		}
+		if s, ok := stringValue(b.Initializer, nil); ok {
+			strVars[id.Name.String()] = s
+		}
+	})
+
+	// Second pass: find route registration calls whose first argument is a
+	// variable or template literal and resolve it.
+	var routes []RoutePattern
+	walk(prog, func(n ast.Node) {
+		call, ok := n.(*ast.CallExpression)
+		if !ok || len(call.ArgumentList) == 0 {
+			return
+		}
+		method, ok := routeMethod(call.Callee)
+		if !ok {
+			return
+		}
+		first := call.ArgumentList[0]
+		// Plain string literals are already handled by the regex pass.
+		if _, isLit := first.(*ast.StringLiteral); isLit {
+			return
+		}
+		path, ok := stringValue(first, strVars)
+		if !ok || !strings.HasPrefix(path, "/") {
+			return
+		}
+		routes = append(routes, RoutePattern{
+			Method: method,
+			Path:   path,
+			File:   filePath,
+			Line:   lineOf(prog, call.Idx0()),
+		})
+	})
+	return routes
+}
+
+// routeMethod reports whether callee is a method call like `app.get` /
+// `router.post` and, if so, returns the corresponding HTTP method.
+func routeMethod(callee ast.Expression) (string, bool) {
+	dot, ok := callee.(*ast.DotExpression)
+	if !ok {
+		return "", false
+	}
+	method, ok := astRouteMethods[strings.ToLower(dot.Identifier.Name.String())]
+	return method, ok
+}
+
+// stringValue resolves expr to a constant string when possible. Identifiers are
+// resolved against vars (when non-nil); template literals are resolved by
+// substituting their static parts and any interpolated variable that itself
+// resolves to a string, replacing unresolved interpolations with a `:param`
+// placeholder so the route shape is preserved. Binary `+` expressions are
+// resolved by concatenating both sides when both can be resolved.
+func stringValue(expr ast.Expression, vars map[string]string) (string, bool) {
+	switch v := expr.(type) {
+	case *ast.StringLiteral:
+		return v.Value.String(), true
+	case *ast.Identifier:
+		if vars == nil {
+			return "", false
+		}
+		s, ok := vars[v.Name.String()]
+		return s, ok
+	case *ast.TemplateLiteral:
+		return templateValue(v, vars)
+	case *ast.BinaryExpression:
+		if v.Operator == token.PLUS {
+			left, ok1 := stringValue(v.Left, vars)
+			right, ok2 := stringValue(v.Right, vars)
+			if ok1 && ok2 {
+				return left + right, true
+			}
+		}
+	}
+	return "", false
+}
+
+// templateValue renders a template literal into a route path. Static elements
+// are emitted verbatim; each interpolation is replaced by its resolved string
+// value, or by a `:name` placeholder when the interpolated expression is a bare
+// identifier that cannot be resolved.
+func templateValue(tmpl *ast.TemplateLiteral, vars map[string]string) (string, bool) {
+	var b strings.Builder
+	for i, el := range tmpl.Elements {
+		b.WriteString(el.Parsed.String())
+		if i < len(tmpl.Expressions) {
+			expr := tmpl.Expressions[i]
+			if s, ok := stringValue(expr, vars); ok {
+				b.WriteString(s)
+				continue
+			}
+			if id, ok := expr.(*ast.Identifier); ok {
+				b.WriteString(":" + id.Name.String())
+				continue
+			}
+			return "", false
+		}
+	}
+	return b.String(), true
+}
+
+// lineOf returns the 1-based source line for idx within prog.
+func lineOf(prog *ast.Program, idx file.Idx) int {
+	if prog.File == nil {
+		return 0
+	}
+	return prog.File.Position(int(idx) - prog.File.Base()).Line
+}

--- a/pkg/internal/transform/route/harvest/js_ast_test.go
+++ b/pkg/internal/transform/route/harvest/js_ast_test.go
@@ -1,0 +1,134 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package harvest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveASTRoutes_StringConcatenationLiterals(t *testing.T) {
+	routes := scanJSContent(t, "app.post('/api' + '/orders', handler);\n")
+	assertHasRoute(t, routes, "POST", "/api/orders")
+}
+
+func TestResolveASTRoutes_StringConcatenationVariableAndLiteral(t *testing.T) {
+	routes := scanJSContent(t, "const base = '/api';\napp.put(base + '/settings', handler);\n")
+	assertHasRoute(t, routes, "PUT", "/api/settings")
+}
+
+func TestRouteExtractor_VariableRoutesApp(t *testing.T) {
+	extractor := NewRouteExtractor()
+	exampleFile := filepath.Join("nodejs", "test_files", "variable-routes-app.js")
+	require.NoError(t, extractor.scanFile(exampleFile))
+
+	routes := extractor.GetRoutes()
+	require.NotEmpty(t, routes)
+
+	expected := []struct{ method, path string }{
+		{"GET", "/users"},
+		{"GET", "/api/v1/products"},
+		{"DELETE", "/users/:id"},
+		{"POST", "/api/orders"},
+		{"PUT", "/api/settings"},
+		{"GET", "/health"},
+	}
+	for _, e := range expected {
+		assertHasRoute(t, routes, e.method, e.path)
+	}
+}
+
+func scanJSContent(t *testing.T, content string) []RoutePattern {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "app.js")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	extractor := NewRouteExtractor()
+	require.NoError(t, extractor.scanFile(path))
+	return extractor.GetRoutes()
+}
+
+func assertHasRoute(t *testing.T, routes []RoutePattern, method, path string) {
+	t.Helper()
+	for _, r := range routes {
+		if r.Method == method && r.Path == path {
+			return
+		}
+	}
+	t.Fatalf("expected route %s %s, got %v", method, path, routes)
+}
+
+func TestResolveASTRoutes_VariablePath(t *testing.T) {
+	routes := scanJSContent(t, `
+const usersPath = '/users';
+app.get(usersPath, (req, res) => res.send('ok'));
+`)
+	assertHasRoute(t, routes, "GET", "/users")
+}
+
+func TestResolveASTRoutes_VariableDeclaredAfterUse(t *testing.T) {
+	// Variable resolution must not depend on declaration order.
+	routes := scanJSContent(t, `
+router.post(createPath, handler);
+const createPath = '/api/items';
+`)
+	assertHasRoute(t, routes, "POST", "/api/items")
+}
+
+func TestResolveASTRoutes_TemplateLiteralWithResolvedVar(t *testing.T) {
+	routes := scanJSContent(t, "const ver = 'v1';\napp.get(`/api/${ver}/users`, handler);\n")
+	assertHasRoute(t, routes, "GET", "/api/v1/users")
+}
+
+func TestResolveASTRoutes_TemplateLiteralWithUnresolvedParam(t *testing.T) {
+	// An interpolated identifier that cannot be resolved becomes a :param
+	// placeholder so the route shape is preserved.
+	routes := scanJSContent(t, "app.delete(`/users/${id}`, handler);\n")
+	assertHasRoute(t, routes, "DELETE", "/users/:id")
+}
+
+func TestResolveASTRoutes_NestedInsideFunction(t *testing.T) {
+	// The walker must descend into function bodies.
+	routes := scanJSContent(t, `
+function registerRoutes(app) {
+  const p = '/health';
+  app.get(p, handler);
+}
+`)
+	assertHasRoute(t, routes, "GET", "/health")
+}
+
+func TestResolveASTRoutes_LineNumberIsSet(t *testing.T) {
+	routes := scanJSContent(t, "const p = '/x';\napp.get(p, handler);\n")
+	require.NotEmpty(t, routes)
+	for _, r := range routes {
+		if r.Path == "/x" {
+			assert.Positive(t, r.Line, "line number should be set")
+			assert.NotEmpty(t, r.File, "file should be set")
+		}
+	}
+}
+
+func TestResolveASTRoutes_SkipsUnparseableSource(t *testing.T) {
+	// TypeScript-style annotations are not valid JS; the AST pass must return
+	// nil without error rather than emitting bogus routes.
+	got := (&RouteExtractor{}).resolveASTRoutes("app.ts", `app.get(p: string, handler);`)
+	assert.Nil(t, got)
+}
+
+func TestResolveASTRoutes_IgnoresStringLiteralArgs(t *testing.T) {
+	// Plain string literals are handled by the regex pass; the AST pass should
+	// not re-emit them.
+	got := (&RouteExtractor{}).resolveASTRoutes("app.js", `app.get('/literal', handler);`)
+	assert.Empty(t, got)
+}
+
+func TestResolveASTRoutes_IgnoresUnknownMethod(t *testing.T) {
+	got := (&RouteExtractor{}).resolveASTRoutes("app.js", `const p = '/x'; app.listen(p);`)
+	assert.Empty(t, got)
+}

--- a/pkg/internal/transform/route/harvest/js_ast_walk.go
+++ b/pkg/internal/transform/route/harvest/js_ast_walk.go
@@ -1,0 +1,177 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package harvest // import "go.opentelemetry.io/obi/pkg/internal/transform/route/harvest"
+
+import (
+	"reflect"
+
+	"github.com/dop251/goja/ast"
+)
+
+// walk performs a depth-first traversal of the AST rooted at n, invoking fn for
+// every node visited (including n itself).
+func walk(n ast.Node, fn func(ast.Node)) {
+	if n == nil {
+		return
+	}
+	fn(n)
+	for _, c := range children(n) {
+		walk(c, fn)
+	}
+}
+
+// children returns the direct child nodes of n. It only needs to descend
+// through the container nodes that can hold route registrations or variable
+// declarations; leaf nodes return nil.
+func children(n ast.Node) []ast.Node {
+	switch v := n.(type) {
+	case *ast.Program:
+		return statements(v.Body)
+	case *ast.BlockStatement:
+		return statements(v.List)
+	case *ast.ExpressionStatement:
+		return []ast.Node{v.Expression}
+	case *ast.VariableStatement:
+		return bindings(v.List)
+	case *ast.VariableDeclaration:
+		return bindings(v.List)
+	case *ast.LexicalDeclaration:
+		return bindings(v.List)
+	case *ast.Binding:
+		return nodes(v.Initializer)
+	case *ast.IfStatement:
+		return nodes(v.Test, v.Consequent, v.Alternate)
+	case *ast.ForStatement:
+		return nodes(v.Initializer, v.Test, v.Update, v.Body)
+	case *ast.ForInStatement:
+		return nodes(v.Into, v.Source, v.Body)
+	case *ast.ForOfStatement:
+		return nodes(v.Into, v.Source, v.Body)
+	case *ast.WhileStatement:
+		return nodes(v.Test, v.Body)
+	case *ast.DoWhileStatement:
+		return nodes(v.Test, v.Body)
+	case *ast.ReturnStatement:
+		return nodes(v.Argument)
+	case *ast.ThrowStatement:
+		return nodes(v.Argument)
+	case *ast.LabelledStatement:
+		return nodes(v.Statement)
+	case *ast.WithStatement:
+		return nodes(v.Object, v.Body)
+	case *ast.SwitchStatement:
+		out := nodes(v.Discriminant)
+		for _, c := range v.Body {
+			out = append(out, c)
+		}
+		return out
+	case *ast.CaseStatement:
+		return append(nodes(v.Test), statements(v.Consequent)...)
+	case *ast.TryStatement:
+		out := nodes(v.Body, v.Finally)
+		if v.Catch != nil {
+			out = append(out, v.Catch)
+		}
+		return out
+	case *ast.CatchStatement:
+		return nodes(v.Body)
+	case *ast.FunctionDeclaration:
+		if v.Function != nil {
+			return []ast.Node{v.Function}
+		}
+	case *ast.FunctionLiteral:
+		return nodes(v.Body)
+	case *ast.ArrowFunctionLiteral:
+		return nodes(v.Body)
+	case *ast.ExpressionBody:
+		return nodes(v.Expression)
+	case *ast.CallExpression:
+		return append(nodes(v.Callee), expressions(v.ArgumentList)...)
+	case *ast.NewExpression:
+		return append(nodes(v.Callee), expressions(v.ArgumentList)...)
+	case *ast.AssignExpression:
+		return nodes(v.Left, v.Right)
+	case *ast.BinaryExpression:
+		return nodes(v.Left, v.Right)
+	case *ast.ConditionalExpression:
+		return nodes(v.Test, v.Consequent, v.Alternate)
+	case *ast.SequenceExpression:
+		return expressions(v.Sequence)
+	case *ast.UnaryExpression:
+		return nodes(v.Operand)
+	case *ast.AwaitExpression:
+		return nodes(v.Argument)
+	case *ast.YieldExpression:
+		return nodes(v.Argument)
+	case *ast.DotExpression:
+		return nodes(v.Left)
+	case *ast.BracketExpression:
+		return nodes(v.Left, v.Member)
+	case *ast.TemplateLiteral:
+		return expressions(v.Expressions)
+	case *ast.ArrayLiteral:
+		return expressions(v.Value)
+	case *ast.ObjectLiteral:
+		out := make([]ast.Node, 0, len(v.Value))
+		for _, p := range v.Value {
+			if kv, ok := p.(*ast.PropertyKeyed); ok {
+				out = append(out, kv.Value)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func statements(in []ast.Statement) []ast.Node {
+	out := make([]ast.Node, 0, len(in))
+	for _, s := range in {
+		if s != nil {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func expressions(in []ast.Expression) []ast.Node {
+	out := make([]ast.Node, 0, len(in))
+	for _, e := range in {
+		if e != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func bindings(in []*ast.Binding) []ast.Node {
+	out := make([]ast.Node, 0, len(in))
+	for _, b := range in {
+		if b != nil {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// nodes builds a child slice from individual nodes, skipping nil interfaces.
+func nodes(in ...ast.Node) []ast.Node {
+	out := make([]ast.Node, 0, len(in))
+	for _, n := range in {
+		if isNil(n) {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// isNil reports whether n is either an untyped nil interface or an interface
+// wrapping a nil pointer, both of which goja uses for absent optional nodes.
+func isNil(n ast.Node) bool {
+	if n == nil {
+		return true
+	}
+	v := reflect.ValueOf(n)
+	return v.Kind() == reflect.Ptr && v.IsNil()
+}

--- a/pkg/internal/transform/route/harvest/nodejs/test_files/variable-routes-app.js
+++ b/pkg/internal/transform/route/harvest/nodejs/test_files/variable-routes-app.js
@@ -1,0 +1,29 @@
+// Example Express.js app that registers routes using variables, template
+// literals, and string concatenation — patterns the AST pass handles.
+const express = require('express');
+const app = express();
+
+const API_BASE = '/api';
+const VERSION = 'v1';
+
+// Variable declared before use
+const usersPath = '/users';
+app.get(usersPath, (req, res) => res.json([]));
+
+// Template literal with a resolved variable
+app.get(`${API_BASE}/${VERSION}/products`, (req, res) => res.json([]));
+
+// Template literal with an unresolved identifier — becomes :param placeholder
+app.delete(`/users/${id}`, (req, res) => res.status(204).send());
+
+// String concatenation: two literals
+app.post('/api' + '/orders', (req, res) => res.json({ created: true }));
+
+// String concatenation: variable + literal
+app.put(API_BASE + '/settings', (req, res) => res.json({ updated: true }));
+
+// Variable declared after use (declaration-order independence)
+router.get(healthPath, (req, res) => res.send('ok'));
+const healthPath = '/health';
+
+app.listen(3000);


### PR DESCRIPTION
## Summary

Follow-up to #929. The regex-based Node.js route harvester only matches routes with literal string paths. This PR adds an AST-based fallback pass (using goja's parser) that runs after the regex scan and picks up routes whose path is a variable reference, a template literal, or a binary string concatenation — patterns the line-based regexes cannot match.

New files:
- `js_ast.go`: two-pass resolver — first pass collects string-valued variable bindings (declaration-order independent), second pass resolves non-literal route call arguments; unresolved template interpolations become `:param` placeholders
- `js_ast_walk.go`: depth-first AST walker over goja's node types, descending into function bodies, control flow, and arrow functions
- `nodejs/test_files/variable-routes-app.js`: integration test fixture

Changed files:
- `js.go`: calls `resolveASTRoutes` after the regex scan in `scanFile()`
- `go.mod`/`go.sum`: adds `github.com/dop251/goja` as an explicit dependency

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.