### PR TITLE
Redact legacy AWS signed URL query keys

### DIFF
--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -86,6 +86,7 @@ func parseExtraAttrGroup(group string) (AttrGroups, error) {
 var DefaultSensitiveQueryParams = []string{
 	// OTel semconv-recommended — https://opentelemetry.io/docs/specs/semconv/http/http-spans/
 	"X-Amz-Signature", "X-Amz-Credential", "X-Amz-Security-Token",
+	"AWSAccessKeyId", "Signature", "SecurityToken",
 	"X-Goog-Signature", "sig",
 	// Common sensitive parameters
 	"token", "access_token", "refresh_token", "id_token", "jwt",

--- a/pkg/export/attributes/attr_selector_test.go
+++ b/pkg/export/attributes/attr_selector_test.go
@@ -196,6 +196,12 @@ func TestDefault(t *testing.T) {
 	assert.Equal(t, p.For(NetworkFlow), p.For(NetworkFlowPackets))
 }
 
+func TestDefaultSensitiveQueryParamsIncludesLegacyAWSSignedURLKeys(t *testing.T) {
+	assert.Contains(t, DefaultSensitiveQueryParams, "AWSAccessKeyId")
+	assert.Contains(t, DefaultSensitiveQueryParams, "Signature")
+	assert.Contains(t, DefaultSensitiveQueryParams, "SecurityToken")
+}
+
 func TestExtraGroupAttributes(t *testing.T) {
 	var g AttrGroups
 	g.Add(GroupKubernetes)

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -142,6 +142,16 @@ func TestHTTPServerSpanURLQuery(t *testing.T) {
 		assert.NotContains(t, val.Str(), "abc123")
 	})
 
+	t.Run("legacy AWS signed URL keys redacted by default list", func(t *testing.T) {
+		span := &request.Span{Type: request.EventTypeHTTP, Method: "GET", Path: "/", FullPath: "/?AWSAccessKeyId=AKID&Signature=secret&SecurityToken=session&cmd=ok", Status: 200}
+		optInAttrs, err := UserSelectedAttributes(optInCfg)
+		require.NoError(t, err)
+		selected := AttrsToMap(TraceAttributesSelector(span, optInAttrs, attributes.DefaultSensitiveQueryParams...))
+		val, ok := selected.Get("url.query")
+		require.True(t, ok)
+		assert.Equal(t, "AWSAccessKeyId=REDACTED&Signature=REDACTED&SecurityToken=REDACTED&cmd=ok", val.Str())
+	})
+
 	t.Run("no redaction when no sensitive params passed to TraceAttributesSelector", func(t *testing.T) {
 		// TraceAttributesSelector is the single-span public API; callers must pass
 		// sensitive params explicitly. The default list flows through GroupSpans via


### PR DESCRIPTION
### Motivation

- The default query-parameter redaction list omitted legacy AWS signed-URL keys such as `AWSAccessKeyId` and the case-sensitive `Signature`, allowing those values to be exported unredacted when `url.query`/`url.full` are emitted by default.
- The scrubber performs exact, case-sensitive lookups on decoded keys, so adding the legacy keys is necessary to prevent credential leakage for signed URLs.

### Description

- Add `"AWSAccessKeyId"` and `"Signature"` to `DefaultSensitiveQueryParams` in `pkg/export/attributes/attr_selector.go` so exact-match redaction covers legacy AWS signed-URL parameters.
- Add `TestDefaultSensitiveQueryParamsIncludesLegacyAWSSignedURLKeys` in `pkg/export/attributes/attr_selector_test.go` to assert the default list contains the new entries.
- Add a span-level test in `pkg/export/otel/tracesgen/tracesgen_test.go` that verifies `url.query` redacts `AWSAccessKeyId` and `Signature` when the default sensitive list is applied.

### Testing
- `go test ./pkg/export/attributes ./pkg/export/otel/tracesgen -run 'TestDefaultSensitiveQueryParamsIncludesLegacyAWSSignedURLKeys|TestHTTPServerSpanURLQuery' -count=1`
- `go test ./pkg/export/attributes ./pkg/export/otel/tracesgen -count=1`