### PR TITLE
Preserve text glob patterns during export

### DIFF
--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -649,6 +649,22 @@ func TestRuntimeToV2EffectiveDiscoveryCriteria(t *testing.T) {
 		require.Equal(t, []string{"go", "java"}, value(t, ext.Capture.Rules[0].Match, "process", "language_glob"))
 	})
 
+	t.Run("env-backed top-level glob selectors", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := minimalSelectionConfig()
+		require.NoError(t, cfg.AutoTargetExe.UnmarshalText([]byte("/srv/*")))
+		require.NoError(t, cfg.AutoTargetLanguage.UnmarshalText([]byte("{go,java}")))
+
+		_, ext := RuntimeToV2(&cfg)
+
+		require.Equal(t, schema.CaptureActionExclude, value(t, ext.Capture.Policy, "default_action"))
+		require.Len(t, ext.Capture.Rules, 1)
+		require.Equal(t, schema.CaptureActionInclude, ext.Capture.Rules[0].Action)
+		require.Equal(t, []string{"/srv/*"}, value(t, ext.Capture.Rules[0].Match, "process", "exe_path_glob"))
+		require.Equal(t, []string{"go", "java"}, value(t, ext.Capture.Rules[0].Match, "process", "language_glob"))
+	})
+
 	t.Run("target pids selector", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/appolly/services/attr_glob.go
+++ b/pkg/appolly/services/attr_glob.go
@@ -173,13 +173,16 @@ func (p GlobAttr) MarshalYAML() (any, error) {
 
 func (p *GlobAttr) UnmarshalText(text []byte) error {
 	if len(text) == 0 {
+		p.str = ""
 		p.glob = nil
 		return nil
 	}
-	re, err := glob.Compile(string(text))
+	pattern := string(text)
+	re, err := glob.Compile(pattern)
 	if err != nil {
-		return fmt.Errorf("invalid regular expression %q: %w", string(text), err)
+		return fmt.Errorf("invalid regular expression %q: %w", pattern, err)
 	}
+	p.str = pattern
 	p.glob = re
 	return nil
 }

--- a/pkg/appolly/services/attr_glob_test.go
+++ b/pkg/appolly/services/attr_glob_test.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlobAttrUnmarshalTextPreservesPatternForMarshalYAML(t *testing.T) {
+	t.Parallel()
+
+	var attr GlobAttr
+	require.NoError(t, attr.UnmarshalText([]byte("{go,java}")))
+
+	value, err := attr.MarshalYAML()
+
+	require.NoError(t, err)
+	require.Equal(t, "{go,java}", value)
+	require.True(t, attr.MatchString("go"))
+	require.False(t, attr.MatchString("python"))
+}


### PR DESCRIPTION
### Motivation

- Runtime v2 export serialized glob selectors via `GlobAttr.MarshalYAML()` but `GlobAttr.UnmarshalText()` (used for env/text-backed values) compiled the pattern without preserving its original text, causing exported rules to lose their glob strings.
- The change ensures env/text-provided glob selectors round-trip through marshal/unmarshal so exported v2 configs remain equivalent to the original runtime selection criteria.

### Description

- Populate the internal `str` field in `GlobAttr.UnmarshalText` and clear it for empty input so that `MarshalYAML` returns the original pattern for env/text-loaded globs (`pkg/appolly/services/attr_glob.go`).
- Add a unit test verifying that `UnmarshalText` preserves the pattern for subsequent `MarshalYAML` and that matching still works (`pkg/appolly/services/attr_glob_test.go`).
- Add an integration-style unit case to `internal/config/convert/export_test.go` asserting that env-backed top-level `AutoTargetExe` and `AutoTargetLanguage` selectors are exported with `exe_path_glob` and `language_glob` set correctly.

### Testing
- `go test ./pkg/appolly/services -run TestGlobAttrUnmarshalTextPreservesPatternForMarshalYAML -count=1 -v`
- `go test ./pkg/appolly/services -count=1`
- `go test ./internal/config/convert -run TestRuntimeToV2EffectiveDiscoveryCriteria -count=1 -v`
