### PR TITLE
Add AST-based route harvesting for Node.js variable paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cilium/ebpf v0.20.0
 	github.com/containers/common v0.64.2
+	github.com/dop251/goja v0.0.0-20260618133527-c9b2ea77db59
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/stdr v1.2.2
@@ -159,6 +160,7 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.25.5 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/btree v1.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396 h1
 github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396/go.mod h1:2VCDG9kHYQ5vfYUqeoB7foVlcvIvB7rp9LxTELLD1qU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
-github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
-github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
@@ -80,6 +80,8 @@ github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf
 github.com/docker/go-connections v0.7.0/go.mod h1:no1qkHdjq7kLMGUXYAduOhYPSJxxvgWBh7ogVvptn3Q=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dop251/goja v0.0.0-20260618133527-c9b2ea77db59 h1:DjKLmvKK9u15djHZ88N8M0DhgnHVgJJ8bnEe0h7Lga8=
+github.com/dop251/goja v0.0.0-20260618133527-c9b2ea77db59/go.mod h1:Sc+QOu1WruvaaeT/cxFez/pXHpI9ZDjg/E8QNfSVveI=
 github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
 github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
@@ -155,6 +157,8 @@ github.com/go-playground/validator/v10 v10.30.3 h1:4MU6YkEwx7GbcPJOZxrtbu+QfF3pJ
 github.com/go-playground/validator/v10 v10.30.3/go.mod h1:4Axh7oCNGcoGkqLoE4YWt6n20mcEIsPRlB7vPk3lpyc=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
 github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=

--- a/pkg/internal/transform/route/harvest/js.go
+++ b/pkg/internal/transform/route/harvest/js.go
@@ -473,6 +473,16 @@ func (e *RouteExtractor) scanFile(filePath string) error {
 		return err
 	}
 
+	// Fallback pass: resolve routes whose path comes from a variable or a
+	// template literal, which the line-based regex harvesters cannot match.
+	src, ok, err := readJSFileForScan(filePath)
+	if err != nil {
+		return err
+	}
+	if ok {
+		e.routes = append(e.routes, e.resolveASTRoutes(filePath, src)...)
+	}
+
 	return nil
 }
 

--- a/pkg/internal/transform/route/harvest/js_ast.go
+++ b/pkg/internal/transform/route/harvest/js_ast.go
@@ -1,0 +1,495 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package harvest // import "go.opentelemetry.io/obi/pkg/internal/transform/route/harvest"
+
+import (
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/dop251/goja/ast"
+	"github.com/dop251/goja/file"
+	"github.com/dop251/goja/parser"
+	"github.com/dop251/goja/token"
+)
+
+// readJSFileForScan returns the bounded contents of a JS/TS file using the same
+// safety guards as the line scanner. ok is false for non-regular or oversized
+// files that should be skipped.
+func readJSFileForScan(path string) (string, bool, error) {
+	f, ok, err := openJSFileForScan(path)
+	if err != nil || !ok {
+		return "", ok, err
+	}
+	defer f.Close()
+
+	b, err := io.ReadAll(io.LimitReader(f, MaxJSFileScanBytes))
+	if err != nil {
+		return "", false, err
+	}
+	return string(b), true, nil
+}
+
+// astRouteMethods maps the JS route-registration method name to the HTTP method
+// it represents. It mirrors the verbs handled by the regex harvesters.
+var astRouteMethods = map[string]string{
+	"get":     "GET",
+	"post":    "POST",
+	"put":     "PUT",
+	"patch":   "PATCH",
+	"delete":  "DELETE",
+	"del":     "DELETE",
+	"head":    "HEAD",
+	"options": "OPTIONS",
+	"all":     "ALL",
+}
+
+// resolveASTRoutes parses a JS source file and extracts routes whose path is
+// supplied through a string variable or a template literal. The line-based
+// regex harvesters only match quoted string literals, so this acts as a
+// fallback for the cases highlighted in
+// https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/929.
+//
+// It returns nil when the source cannot be parsed (for example TypeScript),
+// leaving the regex-based results untouched.
+func (e *RouteExtractor) resolveASTRoutes(filePath, src string) []RoutePattern {
+	return e.resolveASTRoutesInner(filePath, src, map[string]bool{filePath: true})
+}
+
+func (e *RouteExtractor) resolveASTRoutesInner(filePath, src string, visited map[string]bool) []RoutePattern {
+	prog, err := parser.ParseFile(nil, filePath, src, 0)
+	if err != nil {
+		return nil
+	}
+
+	dir := filepath.Dir(filePath)
+
+	// First pass: collect all possible string values for each variable.
+	// Repeated until stable to resolve chained dependencies.
+	// strVars stores both simple names ("x" → values) and flattened object
+	// property access ("obj.key" → values) for dot-notation and destructuring.
+	strVars := map[string][]string{}
+	for {
+		added := 0
+		walk(prog, func(n ast.Node) {
+			switch v := n.(type) {
+			case *ast.Binding:
+				added += e.firstPassBinding(v, strVars, dir, visited)
+			case *ast.AssignExpression:
+				id, ok := v.Left.(*ast.Identifier)
+				if !ok {
+					return
+				}
+				name := id.Name.String()
+				if _, exists := strVars[name]; exists {
+					return
+				}
+				if vals := stringValues(v.Right, strVars); len(vals) > 0 {
+					strVars[name] = vals
+					added++
+				}
+			case *ast.ForOfStatement:
+				name := loopVarName(v.Into)
+				if name == "" || strVars[name] != nil {
+					return
+				}
+				vals := stringValues(v.Source, strVars)
+				if len(vals) > 0 {
+					strVars[name] = vals
+					added++
+				} else if e.log != nil {
+					e.log.Debug("unresolvable loop source", "file", filePath)
+				}
+			}
+		})
+		if added == 0 {
+			break
+		}
+	}
+
+	// Second pass: find route registration calls whose first argument is a
+	// variable, template literal, or expression — resolve to all possible paths.
+	var routes []RoutePattern
+	walk(prog, func(n ast.Node) {
+		call, ok := n.(*ast.CallExpression)
+		if !ok || len(call.ArgumentList) == 0 {
+			return
+		}
+		method, ok := routeMethod(call.Callee)
+		if !ok {
+			return
+		}
+		first := call.ArgumentList[0]
+		// Plain string literals and no-interpolation template literals are already
+		// handled by the regex pass.
+		if _, isLit := first.(*ast.StringLiteral); isLit {
+			return
+		}
+		if tmpl, isTmpl := first.(*ast.TemplateLiteral); isTmpl && len(tmpl.Expressions) == 0 {
+			return
+		}
+		paths := stringValues(first, strVars)
+		if len(paths) == 0 && e.log != nil {
+			e.log.Debug("unresolvable route path", "file", filePath, "line", lineOf(prog, call.Idx0()))
+		}
+		for _, path := range paths {
+			if !strings.HasPrefix(path, "/") {
+				continue
+			}
+			routes = append(routes, RoutePattern{
+				Method: method,
+				Path:   path,
+				File:   filePath,
+				Line:   lineOf(prog, call.Idx0()),
+			})
+		}
+	})
+	return routes
+}
+
+// firstPassBinding processes a single *ast.Binding node during the first pass,
+// updating strVars with newly resolvable string values. Returns the number of
+// new entries added so the caller can detect fixpoint.
+func (e *RouteExtractor) firstPassBinding(v *ast.Binding, strVars map[string][]string, dir string, visited map[string]bool) int {
+	added := 0
+	switch target := v.Target.(type) {
+	case *ast.Identifier:
+		name := target.Name.String()
+		if obj, ok := v.Initializer.(*ast.ObjectLiteral); ok {
+			for _, prop := range obj.Value {
+				kv, ok := prop.(*ast.PropertyKeyed)
+				if !ok {
+					continue
+				}
+				key := propKeyName(kv.Key)
+				if key == "" {
+					continue
+				}
+				flatKey := name + "." + key
+				if _, exists := strVars[flatKey]; exists {
+					continue
+				}
+				if vals := stringValues(kv.Value, strVars); len(vals) > 0 {
+					strVars[flatKey] = vals
+					added++
+				}
+			}
+			return added
+		}
+		if reqPath := requireLiteralPath(v.Initializer); reqPath != "" {
+			exports := e.requireExports(dir, reqPath, visited)
+			for key, vals := range exports {
+				flatKey := name + "." + key
+				if _, exists := strVars[flatKey]; exists {
+					continue
+				}
+				strVars[flatKey] = vals
+				added++
+			}
+			return added
+		}
+		if _, exists := strVars[name]; exists {
+			return 0
+		}
+		if vals := stringValues(v.Initializer, strVars); len(vals) > 0 {
+			strVars[name] = vals
+			added++
+		}
+
+	case *ast.ObjectPattern:
+		var exportMap map[string][]string
+		srcName := ""
+
+		if reqPath := requireLiteralPath(v.Initializer); reqPath != "" {
+			exportMap = e.requireExports(dir, reqPath, visited)
+		} else if id, ok := v.Initializer.(*ast.Identifier); ok {
+			srcName = id.Name.String()
+		}
+
+		for _, prop := range target.Properties {
+			switch p := prop.(type) {
+			case *ast.PropertyShort:
+				key := p.Name.Name.String()
+				localName := key
+				var vals []string
+				if exportMap != nil {
+					vals = exportMap[key]
+				} else if srcName != "" {
+					vals = strVars[srcName+"."+key]
+				}
+				if len(vals) > 0 {
+					if _, exists := strVars[localName]; !exists {
+						strVars[localName] = vals
+						added++
+					}
+				}
+			case *ast.PropertyKeyed:
+				objKey := propKeyName(p.Key)
+				if objKey == "" {
+					continue
+				}
+				localName := identName(p.Value)
+				if localName == "" {
+					continue
+				}
+				var vals []string
+				if exportMap != nil {
+					vals = exportMap[objKey]
+				} else if srcName != "" {
+					vals = strVars[srcName+"."+objKey]
+				}
+				if len(vals) > 0 {
+					if _, exists := strVars[localName]; !exists {
+						strVars[localName] = vals
+						added++
+					}
+				}
+			}
+		}
+	}
+	return added
+}
+
+// requireExports reads and parses a required JS file, returning its exported
+// string values keyed by export name. Only handles relative paths and the
+// common module.exports = {...} / exports.key = '...' patterns.
+func (e *RouteExtractor) requireExports(dir, reqPath string, visited map[string]bool) map[string][]string {
+	if !strings.HasPrefix(reqPath, "./") && !strings.HasPrefix(reqPath, "../") {
+		return nil
+	}
+	base := filepath.Join(dir, reqPath)
+	candidates := []string{base, base + ".js", base + "/index.js"}
+
+	var src, resolved string
+	for _, candidate := range candidates {
+		if visited[candidate] {
+			continue
+		}
+		s, ok, err := readJSFileForScan(candidate)
+		if err != nil || !ok {
+			continue
+		}
+		src = s
+		resolved = candidate
+		break
+	}
+	if resolved == "" {
+		return nil
+	}
+
+	// Extend visited to prevent circular requires in deeper recursion.
+	inner := make(map[string]bool, len(visited)+1)
+	for k := range visited {
+		inner[k] = true
+	}
+	inner[resolved] = true
+
+	prog, err := parser.ParseFile(nil, resolved, src, 0)
+	if err != nil {
+		return nil
+	}
+
+	exports := map[string][]string{}
+	walk(prog, func(n ast.Node) {
+		assign, ok := n.(*ast.AssignExpression)
+		if !ok {
+			return
+		}
+		dot, ok := assign.Left.(*ast.DotExpression)
+		if !ok {
+			return
+		}
+		leftID, ok := dot.Left.(*ast.Identifier)
+		if !ok {
+			return
+		}
+		prop := dot.Identifier.Name.String()
+		switch leftID.Name.String() {
+		case "module":
+			if prop != "exports" {
+				return
+			}
+			obj, ok := assign.Right.(*ast.ObjectLiteral)
+			if !ok {
+				return
+			}
+			for _, p := range obj.Value {
+				kv, ok := p.(*ast.PropertyKeyed)
+				if !ok {
+					continue
+				}
+				key := propKeyName(kv.Key)
+				if key == "" {
+					continue
+				}
+				if vals := stringValues(kv.Value, nil); len(vals) > 0 {
+					exports[key] = vals
+				}
+			}
+		case "exports":
+			if vals := stringValues(assign.Right, nil); len(vals) > 0 {
+				exports[prop] = vals
+			}
+		}
+	})
+	return exports
+}
+
+// routeMethod reports whether callee is a method call like `app.get` /
+// `router.post` and, if so, returns the corresponding HTTP method.
+func routeMethod(callee ast.Expression) (string, bool) {
+	dot, ok := callee.(*ast.DotExpression)
+	if !ok {
+		return "", false
+	}
+	method, ok := astRouteMethods[strings.ToLower(dot.Identifier.Name.String())]
+	return method, ok
+}
+
+// stringValues returns all possible string values for expr. Most expressions
+// yield 0 or 1 values; ConditionalExpressions yield one per branch.
+func stringValues(expr ast.Expression, vars map[string][]string) []string {
+	if expr == nil {
+		return nil
+	}
+	switch v := expr.(type) {
+	case *ast.StringLiteral:
+		return []string{v.Value.String()}
+	case *ast.Identifier:
+		if vars == nil {
+			return nil
+		}
+		return vars[v.Name.String()]
+	case *ast.DotExpression:
+		if vars == nil {
+			return nil
+		}
+		if id, ok := v.Left.(*ast.Identifier); ok {
+			return vars[id.Name.String()+"."+v.Identifier.Name.String()]
+		}
+	case *ast.TemplateLiteral:
+		return templateValues(v, vars)
+	case *ast.BinaryExpression:
+		if v.Operator == token.PLUS {
+			return concatProduct(stringValues(v.Left, vars), stringValues(v.Right, vars))
+		}
+	case *ast.ConditionalExpression:
+		return append(stringValues(v.Consequent, vars), stringValues(v.Alternate, vars)...)
+	case *ast.ArrayLiteral:
+		var out []string
+		for _, el := range v.Value {
+			out = append(out, stringValues(el, vars)...)
+		}
+		return out
+	}
+	return nil
+}
+
+// templateValues renders a template literal into all possible route paths.
+// When an interpolation resolves to multiple values the results are expanded
+// via cartesian product. Unresolvable interpolations become :name or :param.
+func templateValues(tmpl *ast.TemplateLiteral, vars map[string][]string) []string {
+	results := []string{""}
+	for i, el := range tmpl.Elements {
+		static := el.Parsed.String()
+		for j := range results {
+			results[j] += static
+		}
+		if i >= len(tmpl.Expressions) {
+			continue
+		}
+		expr := tmpl.Expressions[i]
+		vals := stringValues(expr, vars)
+		if len(vals) == 0 {
+			placeholder := ":param"
+			if id, ok := expr.(*ast.Identifier); ok {
+				placeholder = ":" + id.Name.String()
+			}
+			for j := range results {
+				results[j] += placeholder
+			}
+		} else {
+			results = concatProduct(results, vals)
+		}
+	}
+	return results
+}
+
+// concatProduct returns the pairwise concatenation of every element in lefts
+// with every element in rights — the cartesian product under string addition.
+func concatProduct(lefts, rights []string) []string {
+	out := make([]string, 0, len(lefts)*len(rights))
+	for _, l := range lefts {
+		for _, r := range rights {
+			out = append(out, l+r)
+		}
+	}
+	return out
+}
+
+// loopVarName extracts the simple identifier name from a for-of / for-in
+// Into clause. Returns "" for complex patterns (destructuring, etc.).
+func loopVarName(into ast.ForInto) string {
+	switch v := into.(type) {
+	case *ast.ForDeclaration:
+		if id, ok := v.Target.(*ast.Identifier); ok {
+			return id.Name.String()
+		}
+	case *ast.ForIntoVar:
+		if v.Binding != nil {
+			if id, ok := v.Binding.Target.(*ast.Identifier); ok {
+				return id.Name.String()
+			}
+		}
+	case *ast.ForIntoExpression:
+		if id, ok := v.Expression.(*ast.Identifier); ok {
+			return id.Name.String()
+		}
+	}
+	return ""
+}
+
+// requireLiteralPath returns the argument string if expr is a require('...') call
+// with a single string literal argument, otherwise "".
+func requireLiteralPath(expr ast.Expression) string {
+	call, ok := expr.(*ast.CallExpression)
+	if !ok || len(call.ArgumentList) != 1 {
+		return ""
+	}
+	callee, ok := call.Callee.(*ast.Identifier)
+	if !ok || callee.Name.String() != "require" {
+		return ""
+	}
+	str, ok := call.ArgumentList[0].(*ast.StringLiteral)
+	if !ok {
+		return ""
+	}
+	return str.Value.String()
+}
+
+// propKeyName returns the string key from a PropertyKeyed.Key expression.
+// goja represents all static property keys as StringLiteral. Returns "" for
+// computed keys (e.g. { [expr]: value }).
+func propKeyName(key ast.Expression) string {
+	if str, ok := key.(*ast.StringLiteral); ok {
+		return str.Value.String()
+	}
+	return ""
+}
+
+// identName returns the identifier name if expr is a plain *ast.Identifier.
+func identName(expr ast.Expression) string {
+	if id, ok := expr.(*ast.Identifier); ok {
+		return id.Name.String()
+	}
+	return ""
+}
+
+// lineOf returns the 1-based source line for idx within prog.
+func lineOf(prog *ast.Program, idx file.Idx) int {
+	if prog.File == nil {
+		return 0
+	}
+	return prog.File.Position(int(idx) - prog.File.Base()).Line
+}

--- a/pkg/internal/transform/route/harvest/js_ast_test.go
+++ b/pkg/internal/transform/route/harvest/js_ast_test.go
@@ -1,0 +1,425 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package harvest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveASTRoutes_StringConcatenationLiterals(t *testing.T) {
+	routes := scanJSContent(t, "app.post('/api' + '/orders', handler);\n")
+	assertHasRoute(t, routes, "POST", "/api/orders")
+}
+
+func TestResolveASTRoutes_StringConcatenationVariableAndLiteral(t *testing.T) {
+	routes := scanJSContent(t, "const base = '/api';\napp.put(base + '/settings', handler);\n")
+	assertHasRoute(t, routes, "PUT", "/api/settings")
+}
+
+func TestRouteExtractor_VariableRoutesApp(t *testing.T) {
+	extractor := NewRouteExtractor()
+	exampleFile := filepath.Join("nodejs", "test_files", "variable-routes-app.js")
+	require.NoError(t, extractor.scanFile(exampleFile))
+
+	routes := extractor.GetRoutes()
+	require.NotEmpty(t, routes)
+
+	expected := []struct{ method, path string }{
+		{"GET", "/users"},
+		{"GET", "/api/v1/products"},
+		{"DELETE", "/users/:id"},
+		{"POST", "/api/orders"},
+		{"PUT", "/api/settings"},
+		{"GET", "/health"},
+	}
+	for _, e := range expected {
+		assertHasRoute(t, routes, e.method, e.path)
+	}
+}
+
+func scanJSContent(t *testing.T, content string) []RoutePattern {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "app.js")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	extractor := NewRouteExtractor()
+	require.NoError(t, extractor.scanFile(path))
+	return extractor.GetRoutes()
+}
+
+// scanJSDir creates multiple files in a temp directory and scans the named entrypoint.
+func scanJSDir(t *testing.T, files map[string]string, entrypoint string) []RoutePattern {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600))
+	}
+	extractor := NewRouteExtractor()
+	require.NoError(t, extractor.scanFile(filepath.Join(dir, entrypoint)))
+	return extractor.GetRoutes()
+}
+
+func assertHasRoute(t *testing.T, routes []RoutePattern, method, path string) {
+	t.Helper()
+	for _, r := range routes {
+		if r.Method == method && r.Path == path {
+			return
+		}
+	}
+	t.Fatalf("expected route %s %s, got %v", method, path, routes)
+}
+
+func TestResolveASTRoutes_VariablePath(t *testing.T) {
+	routes := scanJSContent(t, `
+const usersPath = '/users';
+app.get(usersPath, (req, res) => res.send('ok'));
+`)
+	assertHasRoute(t, routes, "GET", "/users")
+}
+
+func TestResolveASTRoutes_VariableDeclaredAfterUse(t *testing.T) {
+	// Variable resolution must not depend on declaration order.
+	routes := scanJSContent(t, `
+router.post(createPath, handler);
+const createPath = '/api/items';
+`)
+	assertHasRoute(t, routes, "POST", "/api/items")
+}
+
+func TestResolveASTRoutes_TemplateLiteralWithResolvedVar(t *testing.T) {
+	routes := scanJSContent(t, "const ver = 'v1';\napp.get(`/api/${ver}/users`, handler);\n")
+	assertHasRoute(t, routes, "GET", "/api/v1/users")
+}
+
+func TestResolveASTRoutes_TemplateLiteralWithUnresolvedParam(t *testing.T) {
+	// An interpolated identifier that cannot be resolved becomes a :param
+	// placeholder so the route shape is preserved.
+	routes := scanJSContent(t, "app.delete(`/users/${id}`, handler);\n")
+	assertHasRoute(t, routes, "DELETE", "/users/:id")
+}
+
+func TestResolveASTRoutes_NestedInsideFunction(t *testing.T) {
+	// The walker must descend into function bodies.
+	routes := scanJSContent(t, `
+function registerRoutes(app) {
+  const p = '/health';
+  app.get(p, handler);
+}
+`)
+	assertHasRoute(t, routes, "GET", "/health")
+}
+
+func TestResolveASTRoutes_LineNumberIsSet(t *testing.T) {
+	routes := scanJSContent(t, "const p = '/x';\napp.get(p, handler);\n")
+	require.NotEmpty(t, routes)
+	for _, r := range routes {
+		if r.Path == "/x" {
+			assert.Positive(t, r.Line, "line number should be set")
+			assert.NotEmpty(t, r.File, "file should be set")
+		}
+	}
+}
+
+func TestResolveASTRoutes_SkipsUnparseableSource(t *testing.T) {
+	// TypeScript-style annotations are not valid JS; the AST pass must return
+	// nil without error rather than emitting bogus routes.
+	got := (&RouteExtractor{}).resolveASTRoutes("app.ts", `app.get(p: string, handler);`)
+	assert.Nil(t, got)
+}
+
+func TestResolveASTRoutes_IgnoresStringLiteralArgs(t *testing.T) {
+	// Plain string literals are handled by the regex pass; the AST pass should
+	// not re-emit them.
+	got := (&RouteExtractor{}).resolveASTRoutes("app.js", `app.get('/literal', handler);`)
+	assert.Empty(t, got)
+}
+
+func TestResolveASTRoutes_IgnoresUnknownMethod(t *testing.T) {
+	got := (&RouteExtractor{}).resolveASTRoutes("app.js", `const p = '/x'; app.listen(p);`)
+	assert.Empty(t, got)
+}
+
+func TestResolveASTRoutes_IgnoresTemplateLiteralWithoutInterpolation(t *testing.T) {
+	// Backtick strings with no ${} are already caught by the regex pass; the
+	// AST pass must not re-emit them to avoid duplicates in GetRoutes().
+	got := (&RouteExtractor{}).resolveASTRoutes("app.js", "app.get(`/static`, handler);")
+	assert.Empty(t, got)
+}
+
+func TestResolveASTRoutes_ChainedVariableDependency(t *testing.T) {
+	routes := scanJSContent(t, `
+const base = '/api';
+const full = base + '/users';
+app.get(full, handler);
+`)
+	assertHasRoute(t, routes, "GET", "/api/users")
+}
+
+func TestResolveASTRoutes_AssignExpression(t *testing.T) {
+	routes := scanJSContent(t, `
+let path;
+path = '/orders';
+app.post(path, handler);
+`)
+	assertHasRoute(t, routes, "POST", "/orders")
+}
+
+func TestResolveASTRoutes_ComplexTemplateExpressionBecomesParam(t *testing.T) {
+	routes := scanJSContent(t, "app.get(`/users/${req.params.id}`, handler);\n")
+	assertHasRoute(t, routes, "GET", "/users/:param")
+}
+
+func TestResolveASTRoutes_ConditionalExpression(t *testing.T) {
+	routes := scanJSContent(t, `
+const path = isAdmin ? '/admin/users' : '/users';
+app.get(path, handler);
+`)
+	assertHasRoute(t, routes, "GET", "/admin/users")
+	assertHasRoute(t, routes, "GET", "/users")
+}
+
+func TestResolveASTRoutes_TemplateLiteralWithConditionalInterpolation(t *testing.T) {
+	// Cartesian product: template literal whose interpolation resolves to
+	// multiple values produces one route per combination.
+	routes := scanJSContent(t, "const role = isAdmin ? 'admin' : 'user';\napp.get(`/${role}/profile`, handler);\n")
+	assertHasRoute(t, routes, "GET", "/admin/profile")
+	assertHasRoute(t, routes, "GET", "/user/profile")
+}
+
+func TestResolveASTRoutes_RouteInsideIfBlock(t *testing.T) {
+	routes := scanJSContent(t, `
+const devPath = '/debug';
+if (env === 'development') {
+  app.get(devPath, handler);
+}
+`)
+	assertHasRoute(t, routes, "GET", "/debug")
+}
+
+func TestResolveASTRoutes_RouteInsideForOfLoop(t *testing.T) {
+	routes := scanJSContent(t, `
+const itemsPath = '/items';
+for (const entry of enabledRoutes) {
+  app.get(itemsPath, handler);
+}
+`)
+	assertHasRoute(t, routes, "GET", "/items")
+}
+
+func TestResolveASTRoutes_RouteInsideTryCatch(t *testing.T) {
+	routes := scanJSContent(t, `
+const safePath = '/safe';
+try {
+  app.get(safePath, handler);
+} catch (e) {
+  console.error(e);
+}
+`)
+	assertHasRoute(t, routes, "GET", "/safe")
+}
+
+func TestResolveASTRoutes_RouteInsideSwitch(t *testing.T) {
+	routes := scanJSContent(t, `
+const switchPath = '/switched';
+switch (env) {
+  case 'prod':
+    app.get(switchPath, handler);
+    break;
+}
+`)
+	assertHasRoute(t, routes, "GET", "/switched")
+}
+
+func TestResolveASTRoutes_RouteWithAwait(t *testing.T) {
+	routes := scanJSContent(t, `
+const asyncPath = '/async';
+async function setup() {
+  await app.get(asyncPath, handler);
+}
+`)
+	assertHasRoute(t, routes, "GET", "/async")
+}
+
+func TestResolveASTRoutes_ForOfLiteralArray(t *testing.T) {
+	routes := scanJSContent(t, `
+for (const p of ['/users', '/items']) {
+  app.get(p, handler);
+}
+`)
+	assertHasRoute(t, routes, "GET", "/users")
+	assertHasRoute(t, routes, "GET", "/items")
+}
+
+func TestResolveASTRoutes_ForOfVariable(t *testing.T) {
+	routes := scanJSContent(t, `
+const paths = ['/orders', '/products'];
+for (const p of paths) {
+  app.post(p, handler);
+}
+`)
+	assertHasRoute(t, routes, "POST", "/orders")
+	assertHasRoute(t, routes, "POST", "/products")
+}
+
+func TestResolveASTRoutes_ObjectLiteralPropertyAccess(t *testing.T) {
+	routes := scanJSContent(t, `
+const cfg = { base: '/api/v2' };
+app.get(cfg.base, handler);
+`)
+	assertHasRoute(t, routes, "GET", "/api/v2")
+}
+
+func TestResolveASTRoutes_ObjectDestructuring(t *testing.T) {
+	routes := scanJSContent(t, `
+const cfg = { path: '/admin' };
+const { path } = cfg;
+app.delete(path, handler);
+`)
+	assertHasRoute(t, routes, "DELETE", "/admin")
+}
+
+func TestResolveASTRoutes_ObjectDestructuringRenamed(t *testing.T) {
+	routes := scanJSContent(t, `
+const cfg = { path: '/reports' };
+const { path: localPath } = cfg;
+app.get(localPath, handler);
+`)
+	assertHasRoute(t, routes, "GET", "/reports")
+}
+
+func TestResolveASTRoutes_RequireExports(t *testing.T) {
+	routes := scanJSDir(t, map[string]string{
+		"config.js": "module.exports = { basePath: '/api/v1' };\n",
+		"app.js":    "const cfg = require('./config');\napp.get(cfg.basePath, handler);\n",
+	}, "app.js")
+	assertHasRoute(t, routes, "GET", "/api/v1")
+}
+
+func TestResolveASTRoutes_RequireDestructure(t *testing.T) {
+	routes := scanJSDir(t, map[string]string{
+		"routes.js": "module.exports = { BASE: '/v2', HEALTH: '/healthz' };\n",
+		"app.js":    "const { BASE, HEALTH } = require('./routes');\napp.get(BASE + '/users', handler);\napp.get(HEALTH, handler);\n",
+	}, "app.js")
+	assertHasRoute(t, routes, "GET", "/v2/users")
+	assertHasRoute(t, routes, "GET", "/healthz")
+}
+
+func TestResolveASTRoutes_RequireNamedExports(t *testing.T) {
+	routes := scanJSDir(t, map[string]string{
+		"paths.js":  "exports.root = '/root';\nexports.sub = '/sub';\n",
+		"server.js": "const p = require('./paths');\napp.get(p.root, handler);\napp.put(p.sub, handler);\n",
+	}, "server.js")
+	assertHasRoute(t, routes, "GET", "/root")
+	assertHasRoute(t, routes, "PUT", "/sub")
+}
+
+func TestResolveASTRoutes_ForOfVarDeclaration(t *testing.T) {
+	routes := scanJSContent(t, `
+for (var p of ['/stock', '/catalog']) {
+  app.get(p, handler);
+}
+`)
+	assertHasRoute(t, routes, "GET", "/stock")
+	assertHasRoute(t, routes, "GET", "/catalog")
+}
+
+func TestResolveASTRoutes_ForOfExistingVar(t *testing.T) {
+	routes := scanJSContent(t, `
+let p;
+const routePaths = ['/profiles', '/settings'];
+for (p of routePaths) {
+  app.get(p, handler);
+}
+`)
+	assertHasRoute(t, routes, "GET", "/profiles")
+	assertHasRoute(t, routes, "GET", "/settings")
+}
+
+func TestResolveASTRoutes_StringLiteralObjectKey(t *testing.T) {
+	routes := scanJSContent(t, `
+const cfg = { 'base': '/catalog' };
+app.get(cfg.base, handler);
+`)
+	assertHasRoute(t, routes, "GET", "/catalog")
+}
+
+func TestResolveASTRoutes_RouteInsideWhileLoop(t *testing.T) {
+	routes := scanJSContent(t, `
+const loopPath = '/loop';
+while (condition) {
+  app.get(loopPath, handler);
+  break;
+}
+`)
+	assertHasRoute(t, routes, "GET", "/loop")
+}
+
+func TestResolveASTRoutes_RouteInsideDoWhile(t *testing.T) {
+	routes := scanJSContent(t, `
+const oncePath = '/once';
+do {
+  app.get(oncePath, handler);
+} while (false);
+`)
+	assertHasRoute(t, routes, "GET", "/once")
+}
+
+func TestResolveASTRoutes_RouteInsideForLoop(t *testing.T) {
+	routes := scanJSContent(t, `
+const forPath = '/items';
+for (let i = 0; i < 1; i++) {
+  app.get(forPath, handler);
+}
+`)
+	assertHasRoute(t, routes, "GET", "/items")
+}
+
+func TestResolveASTRoutes_RequireNonExistent(t *testing.T) {
+	routes := scanJSContent(t, `const cfg = require('./nonexistent'); app.get(cfg.path, handler);`)
+	assert.Empty(t, routes)
+}
+
+func TestResolveASTRoutes_RequireNodeModule(t *testing.T) {
+	routes := scanJSContent(t, `const express = require('express'); app.get(express.path, handler);`)
+	assert.Empty(t, routes)
+}
+
+func TestResolveASTRoutes_RequireExportsMixedProps(t *testing.T) {
+	routes := scanJSDir(t, map[string]string{
+		"cfg.js": "const path = '/ignored';\nmodule.exports = { path, base: '/mixed' };\n",
+		"app.js": "const c = require('./cfg');\napp.get(c.base, handler);\n",
+	}, "app.js")
+	assertHasRoute(t, routes, "GET", "/mixed")
+}
+
+func TestResolveASTRoutes_RequireDestructureStringKey(t *testing.T) {
+	routes := scanJSDir(t, map[string]string{
+		"cfg.js": "module.exports = { 'api-path': '/v2/api' };\n",
+		"app.js": "const { 'api-path': apiPath } = require('./cfg');\napp.get(apiPath, handler);\n",
+	}, "app.js")
+	assertHasRoute(t, routes, "GET", "/v2/api")
+}
+
+func TestResolveASTRoutes_NestedDestructuringSkipped(t *testing.T) {
+	got := (&RouteExtractor{}).resolveASTRoutes("app.js", `
+const outer = { inner: { sub: '/deep' } };
+const { inner: { sub } } = outer;
+app.get(sub, handler);
+`)
+	assert.Empty(t, got)
+}
+
+func TestResolveASTRoutes_ComputedObjectKeySkipped(t *testing.T) {
+	routes := scanJSContent(t, `
+const name = 'dynamic';
+const cfg = { [name]: '/skip', base: '/keep' };
+app.get(cfg.base, handler);
+`)
+	assertHasRoute(t, routes, "GET", "/keep")
+}

--- a/pkg/internal/transform/route/harvest/js_ast_walk.go
+++ b/pkg/internal/transform/route/harvest/js_ast_walk.go
@@ -1,0 +1,177 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package harvest // import "go.opentelemetry.io/obi/pkg/internal/transform/route/harvest"
+
+import (
+	"reflect"
+
+	"github.com/dop251/goja/ast"
+)
+
+// walk performs a depth-first traversal of the AST rooted at n, invoking fn for
+// every node visited (including n itself).
+func walk(n ast.Node, fn func(ast.Node)) {
+	if n == nil {
+		return
+	}
+	fn(n)
+	for _, c := range children(n) {
+		walk(c, fn)
+	}
+}
+
+// children returns the direct child nodes of n. It only needs to descend
+// through the container nodes that can hold route registrations or variable
+// declarations; leaf nodes return nil.
+func children(n ast.Node) []ast.Node {
+	switch v := n.(type) {
+	case *ast.Program:
+		return statements(v.Body)
+	case *ast.BlockStatement:
+		return statements(v.List)
+	case *ast.ExpressionStatement:
+		return []ast.Node{v.Expression}
+	case *ast.VariableStatement:
+		return bindings(v.List)
+	case *ast.VariableDeclaration:
+		return bindings(v.List)
+	case *ast.LexicalDeclaration:
+		return bindings(v.List)
+	case *ast.Binding:
+		return nodes(v.Initializer)
+	case *ast.IfStatement:
+		return nodes(v.Test, v.Consequent, v.Alternate)
+	case *ast.ForStatement:
+		return nodes(v.Initializer, v.Test, v.Update, v.Body)
+	case *ast.ForInStatement:
+		return nodes(v.Into, v.Source, v.Body)
+	case *ast.ForOfStatement:
+		return nodes(v.Into, v.Source, v.Body)
+	case *ast.WhileStatement:
+		return nodes(v.Test, v.Body)
+	case *ast.DoWhileStatement:
+		return nodes(v.Test, v.Body)
+	case *ast.ReturnStatement:
+		return nodes(v.Argument)
+	case *ast.ThrowStatement:
+		return nodes(v.Argument)
+	case *ast.LabelledStatement:
+		return nodes(v.Statement)
+	case *ast.WithStatement:
+		return nodes(v.Object, v.Body)
+	case *ast.SwitchStatement:
+		out := nodes(v.Discriminant)
+		for _, c := range v.Body {
+			out = append(out, c)
+		}
+		return out
+	case *ast.CaseStatement:
+		return append(nodes(v.Test), statements(v.Consequent)...)
+	case *ast.TryStatement:
+		out := nodes(v.Body, v.Finally)
+		if v.Catch != nil {
+			out = append(out, v.Catch)
+		}
+		return out
+	case *ast.CatchStatement:
+		return nodes(v.Body)
+	case *ast.FunctionDeclaration:
+		if v.Function != nil {
+			return []ast.Node{v.Function}
+		}
+	case *ast.FunctionLiteral:
+		return nodes(v.Body)
+	case *ast.ArrowFunctionLiteral:
+		return nodes(v.Body)
+	case *ast.ExpressionBody:
+		return nodes(v.Expression)
+	case *ast.CallExpression:
+		return append(nodes(v.Callee), expressions(v.ArgumentList)...)
+	case *ast.NewExpression:
+		return append(nodes(v.Callee), expressions(v.ArgumentList)...)
+	case *ast.AssignExpression:
+		return nodes(v.Left, v.Right)
+	case *ast.BinaryExpression:
+		return nodes(v.Left, v.Right)
+	case *ast.ConditionalExpression:
+		return nodes(v.Test, v.Consequent, v.Alternate)
+	case *ast.SequenceExpression:
+		return expressions(v.Sequence)
+	case *ast.UnaryExpression:
+		return nodes(v.Operand)
+	case *ast.AwaitExpression:
+		return nodes(v.Argument)
+	case *ast.YieldExpression:
+		return nodes(v.Argument)
+	case *ast.DotExpression:
+		return nodes(v.Left)
+	case *ast.BracketExpression:
+		return nodes(v.Left, v.Member)
+	case *ast.TemplateLiteral:
+		return expressions(v.Expressions)
+	case *ast.ArrayLiteral:
+		return expressions(v.Value)
+	case *ast.ObjectLiteral:
+		out := make([]ast.Node, 0, len(v.Value))
+		for _, p := range v.Value {
+			if kv, ok := p.(*ast.PropertyKeyed); ok {
+				out = append(out, kv.Value)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func statements(in []ast.Statement) []ast.Node {
+	out := make([]ast.Node, 0, len(in))
+	for _, s := range in {
+		if s != nil {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func expressions(in []ast.Expression) []ast.Node {
+	out := make([]ast.Node, 0, len(in))
+	for _, e := range in {
+		if e != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func bindings(in []*ast.Binding) []ast.Node {
+	out := make([]ast.Node, 0, len(in))
+	for _, b := range in {
+		if b != nil {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// nodes builds a child slice from individual nodes, skipping nil interfaces.
+func nodes(in ...ast.Node) []ast.Node {
+	out := make([]ast.Node, 0, len(in))
+	for _, n := range in {
+		if isNil(n) {
+			continue
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+// isNil reports whether n is either an untyped nil interface or an interface
+// wrapping a nil pointer, both of which goja uses for absent optional nodes.
+func isNil(n ast.Node) bool {
+	if n == nil {
+		return true
+	}
+	v := reflect.ValueOf(n)
+	return v.Kind() == reflect.Ptr && v.IsNil()
+}

--- a/pkg/internal/transform/route/harvest/nodejs/test_files/variable-routes-app.js
+++ b/pkg/internal/transform/route/harvest/nodejs/test_files/variable-routes-app.js
@@ -1,0 +1,23 @@
+// Example Express.js app that registers routes using variables, template
+// literals, and string concatenation — patterns the AST pass handles.
+const express = require('express');
+const app = express();
+
+const API_BASE = '/api';
+const VERSION = 'v1';
+
+const usersPath = '/users';
+app.get(usersPath, (req, res) => res.json([]));
+
+app.get(`${API_BASE}/${VERSION}/products`, (req, res) => res.json([]));
+
+app.delete(`/users/${id}`, (req, res) => res.status(204).send());
+
+app.post('/api' + '/orders', (req, res) => res.json({ created: true }));
+
+app.put(API_BASE + '/settings', (req, res) => res.json({ updated: true }));
+
+router.get(healthPath, (req, res) => res.send('ok'));
+const healthPath = '/health';
+
+app.listen(3000);


### PR DESCRIPTION
#### Summary

The existing regex-based route harvester only matched hardcoded string paths like `app.get('/users', handler)`. It missed routes where the path came from a variable, a template literal, or string concatenation.

This PR adds an AST-based fallback pass using Goja's parser that handles those cases:

- variable: `const p = '/users'; app.get(p, handler)`
- template literal: `app.get(/api/${version}/users, handler)`
- string concatenation: `app.get('/api' + '/users', handler)`
- object property access and destructuring
- loop variables from `for...of`
- cross-file paths via `require()`

#### Link to tracking issue
Fixes #929

#### Testing
Added unit tests in `pkg/internal/transform/route/harvest/js_ast_test.go` covering variable paths, template literals, string concatenation, object property access, destructuring, loop variables, and cross-file require(). All tests pass with go test `./pkg/internal/transform/route/harvest/....`

#### Authorship

- [x] I, a human, wrote this pull request description myself.

<!-- markdownlint-disable-file MD041 -->
