### PR TITLE
Pin AL2023 BusyBox image via dependency inventory

### DIFF
--- a/dependencies.Dockerfile
+++ b/dependencies.Dockerfile
@@ -1,4 +1,5 @@
 # This is a renovate-friendly source of Docker images.
+FROM busybox:musl@sha256:19b646668802469d968a05342a601e78da4322a414a7c09b1c9ee25165042138 AS busybox-musl
 FROM davidanson/markdownlint-cli2:v0.22.1@sha256:0ed9a5f4c77ef447da2a2ac6e67caf74b214a7f80288819565e8b7d2ac148fe5 AS markdown
 FROM gradle:9.6.0-jdk21-noble@sha256:9cb63c2ebb4121e92aa7ed9b781a0ee154bd7ea3e45f97dbeabf7b1d3f910667 AS gradle-java
 FROM ghcr.io/astral-sh/uv:python3.9-trixie-slim@sha256:b0c547dc901317540957794bf099c1cc2229edd1a8610d672388d035eb815c5b AS python39

--- a/internal/test/vm/lvh/al2023/run.sh
+++ b/internal/test/vm/lvh/al2023/run.sh
@@ -24,6 +24,11 @@ KERNEL_PKG="${2:-kernel}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+BUSYBOX_IMAGE="$(awk '$1=="FROM" && $4=="busybox-musl" {print $2}' "${REPO_ROOT}/dependencies.Dockerfile")"
+if [ -z "${BUSYBOX_IMAGE}" ]; then
+    echo "Unable to find busybox-musl image in dependencies.Dockerfile" >&2
+    exit 1
+fi
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
 
@@ -58,7 +63,7 @@ mkdir -p "${IRD}/sys/fs/bpf" "${IRD}/sys/kernel/debug" "${IRD}/sys/kernel/tracin
 
 # Static (musl) busybox so it runs without any libc.
 docker run --rm --platform linux/amd64 -v "${IRD}/bin":/out \
-    busybox:musl sh -c 'cp /bin/busybox /out/busybox' >&2
+    "${BUSYBOX_IMAGE}" sh -c 'cp /bin/busybox /out/busybox' >&2
 
 cp "${TEST_BIN}" "${IRD}/verifier.test"
 chmod +x "${IRD}/verifier.test"


### PR DESCRIPTION
### Motivation

- Prevent a CI supply-chain integrity weakness by pinning the BusyBox image used to build the AL2023 verifier initramfs to an immutable digest, avoiding mutable tag retargeting that could allow a compromised image to falsify verifier results.
- Keep the pinned BusyBox image visible to Renovate so future digest updates are handled by the normal Dockerfile dependency flow.

### Description

- Add `busybox:musl` to `dependencies.Dockerfile` as the `busybox-musl` stage, pinned to the digest for the `busybox:musl` tag.
- Update `internal/test/vm/lvh/al2023/run.sh` to resolve the BusyBox image from `dependencies.Dockerfile` at runtime instead of hard-coding the reference in the script.
- Preserve the existing `--platform linux/amd64` selection and BusyBox copy behavior for the AL2023 verifier initramfs.

### Testing

- `bash -n internal/test/vm/lvh/al2023/run.sh`
- `awk '$1=="FROM" && $4=="busybox-musl" {print $2}' dependencies.Dockerfile`
- `./scripts/lint-dependency-policy.sh --all`