### PR TITLE
Avoid eager MQTT response buffer access

### DIFF
--- a/pkg/ebpf/common/mqtt_detect_transform.go
+++ b/pkg/ebpf/common/mqtt_detect_transform.go
@@ -57,13 +57,16 @@ func packetTypeToMethod(packetType mqttparser.PacketType) string {
 // should be ignored for span creation (e.g., control packets like CONNECT).
 func ProcessPossibleMQTTEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer, rpkt *largebuf.LargeBuffer) (*MQTTInfo, bool, error) {
 	pktView := pkt.UnsafeView()
-	rpktView := rpkt.UnsafeView()
 
 	m, ignore, err := ProcessMQTTEvent(pktView)
 	if err != nil {
+		if rpkt == nil {
+			return m, ignore, err
+		}
+
 		// If we are getting the information in the response buffer, the event
 		// must be reversed and that's how we captured it.
-		m, ignore, err = ProcessMQTTEvent(rpktView)
+		m, ignore, err = ProcessMQTTEvent(rpkt.UnsafeView())
 		if err == nil && !ignore {
 			reverseTCPEvent(event)
 		}

--- a/pkg/ebpf/common/mqtt_detect_transform_test.go
+++ b/pkg/ebpf/common/mqtt_detect_transform_test.go
@@ -270,6 +270,21 @@ func TestProcessPossibleMQTTEvent(t *testing.T) {
 			},
 		},
 		{
+			name: "PUBLISH in request buffer without response buffer",
+			request: []byte{
+				0x30,       // PUBLISH, QoS 0
+				0x0c,       // Remaining length: 12
+				0x00, 0x0a, // Topic length: 10
+				't', 'e', 's', 't', '/', 't', 'o', 'p', 'i', 'c',
+			},
+			expected: &MQTTInfo{
+				PacketType: mqttparser.PacketTypePUBLISH,
+				Topic:      "test/topic",
+				QoS:        mqttparser.QoSAtMostOnce,
+				PacketID:   0,
+			},
+		},
+		{
 			name:    "PUBLISH in response buffer (reversed)",
 			request: []byte{},
 			response: []byte{
@@ -291,12 +306,21 @@ func TestProcessPossibleMQTTEvent(t *testing.T) {
 			response: []byte{0x00, 0x00, 0x00},
 			err:      true,
 		},
+		{
+			name:    "Invalid request without response buffer",
+			request: []byte{0x00, 0x00, 0x00},
+			err:     true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			event := &TCPRequestInfo{}
-			res, _, err := ProcessPossibleMQTTEvent(event, largebuf.NewLargeBufferFrom(tt.request), largebuf.NewLargeBufferFrom(tt.response))
+			var response *largebuf.LargeBuffer
+			if tt.response != nil {
+				response = largebuf.NewLargeBufferFrom(tt.response)
+			}
+			res, _, err := ProcessPossibleMQTTEvent(event, largebuf.NewLargeBufferFrom(tt.request), response)
 			if tt.err {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
### Motivation

- A previous change eagerly dereferenced the response buffer via `rpkt.UnsafeView()` at function entry which can panic if `rpkt` is `nil` even when the request buffer (`pkt`) contains a valid MQTT packet. 
- The goal is to make `ProcessPossibleMQTTEvent` robust for callers that may pass a nil response buffer while preserving existing behavior when the response buffer is present.

### Description

- In `pkg/ebpf/common/mqtt_detect_transform.go` defer the response-buffer dereference and replace the eager `rpkt.UnsafeView()` with a lazy call inside the error path: `ProcessMQTTEvent(rpkt.UnsafeView())`.
- In `pkg/ebpf/common/mqtt_detect_transform_test.go` add a regression test case `PUBLISH in request buffer without response buffer` and adjust the test harness to pass a `nil` `*largebuf.LargeBuffer` when `response` is absent so the function is exercised with a `nil` response buffer.
- Applied formatting (`gofmt`) to the modified files.

### Testing

- `go test ./pkg/internal/ebpf/mqttparser`
- `go test ./pkg/internal/largebuf`
- `go test ./pkg/ebpf/common -run TestProcessPossibleMQTTEvent`