### PR TITLE
Limit SunRPC record fragments

### DIFF
--- a/pkg/internal/sunrpcparser/parser.go
+++ b/pkg/internal/sunrpcparser/parser.go
@@ -38,8 +38,9 @@ const (
 	rmLastFrag = 0x80000000
 	rmFragLen  = 0x7fffffff
 
-	maxRecordSize   = 1 << 20
-	maxMessagesRead = 32
+	maxRecordSize      = 1 << 20
+	maxRecordFragments = 64
+	maxMessagesRead    = 32
 )
 
 var (
@@ -164,6 +165,14 @@ func readRecord(r *largebuf.LargeBufferReader) ([]byte, error) {
 
 		last := hdr&rmLastFrag != 0
 		length := int(hdr & rmFragLen)
+		// Keep this guard scoped to parser work: reject records that require
+		// too many fragment headers, but do not reject zero-length non-final
+		// fragments because RFC 5531 record marking permits them. Payload size
+		// limits stay separate below so allocation bounds and iteration bounds
+		// are enforced by the checks that match each concern.
+		if len(parts) >= maxRecordFragments {
+			return nil, ErrNotSunRPC
+		}
 		if length < 0 || length > maxRecordSize || total+length > maxRecordSize {
 			return nil, ErrNotSunRPC
 		}

--- a/pkg/internal/sunrpcparser/parser_test.go
+++ b/pkg/internal/sunrpcparser/parser_test.go
@@ -197,6 +197,62 @@ func TestIsLikelySunRPC_acceptsValidCall(t *testing.T) {
 	assert.True(t, IsLikelySunRPC(&reader))
 }
 
+func TestParse_fragmentedCALL(t *testing.T) {
+	record := buildCallRecord(t, callParams{
+		xid:        1,
+		prog:       ProgramPortmapper,
+		vers:       2,
+		proc:       0,
+		authFlavor: authNull,
+	})
+	payload := wrapTCPRecordFragments(record[:8], record[8:])
+	buf := largebuf.NewLargeBufferFrom(payload)
+	reader := buf.NewReader()
+
+	res, err := Parse(&reader)
+	require.NoError(t, err)
+	require.NotNil(t, res.Call)
+	assert.Equal(t, uint32(ProgramPortmapper), res.Call.Program)
+}
+
+func TestParse_rejectsTooManyRecordFragments(t *testing.T) {
+	record := buildCallRecord(t, callParams{
+		xid:        1,
+		prog:       ProgramPortmapper,
+		vers:       2,
+		proc:       0,
+		authFlavor: authNull,
+	})
+	fragments := make([][]byte, 0, maxRecordFragments+1)
+	for range maxRecordFragments {
+		fragments = append(fragments, nil)
+	}
+	fragments = append(fragments, record)
+
+	buf := largebuf.NewLargeBufferFrom(wrapTCPRecordFragments(fragments...))
+	reader := buf.NewReader()
+
+	_, err := Parse(&reader)
+	assert.ErrorIs(t, err, ErrNotSunRPC)
+}
+
+func TestParse_acceptsEmptyNonFinalRecordFragment(t *testing.T) {
+	record := buildCallRecord(t, callParams{
+		xid:        1,
+		prog:       ProgramPortmapper,
+		vers:       2,
+		proc:       0,
+		authFlavor: authNull,
+	})
+	buf := largebuf.NewLargeBufferFrom(wrapTCPRecordFragments(nil, record))
+	reader := buf.NewReader()
+
+	res, err := Parse(&reader)
+	require.NoError(t, err)
+	require.NotNil(t, res.Call)
+	assert.Equal(t, uint32(ProgramPortmapper), res.Call.Program)
+}
+
 func buildReplyRecord(t *testing.T, xid uint32, body []byte) []byte {
 	t.Helper()
 
@@ -263,9 +319,30 @@ func buildAcceptedReplyRecord(t *testing.T, xid uint32, acceptStat uint32) []byt
 }
 
 func wrapTCPRecord(record []byte) []byte {
-	hdr := make([]byte, 4)
-	binary.BigEndian.PutUint32(hdr, rmLastFrag|uint32(len(record)))
-	return append(hdr, record...)
+	return wrapTCPRecordFragments(record)
+}
+
+// wrapTCPRecordFragments encodes one RPC-over-TCP record using RFC 5531
+// record marking. Each fragment is prefixed with a 32-bit header whose high bit
+// marks the final fragment and whose low 31 bits hold the fragment length.
+// Empty non-final fragments are legal and are useful for exercising parser
+// behavior around fragmented records without changing the reassembled payload.
+func wrapTCPRecordFragments(fragments ...[]byte) []byte {
+	var out []byte
+	for i, fragment := range fragments {
+		// Record marking has 31 length bits. Guard before converting so an
+		// oversized test fixture cannot wrap, truncate, or set the final bit.
+		if len(fragment) > rmFragLen {
+			panic("SunRPC test fragment exceeds record-marking length")
+		}
+		hdr := uint32(len(fragment))
+		if i == len(fragments)-1 {
+			hdr |= rmLastFrag
+		}
+		out = appendU32(out, hdr)
+		out = append(out, fragment...)
+	}
+	return out
 }
 
 func appendU32(b []byte, v uint32) []byte {


### PR DESCRIPTION
### Motivation

- Prevent a CPU and allocation amplification vector in the SunRPC-over-TCP parser where many tiny fragments could force unbounded loop iterations and slice growth.
- Bound parser work per record while preserving valid fragmented SunRPC records, including zero-byte record-marking fragments allowed by RFC 5531.

### Description

- Add a per-record fragment cap `maxRecordFragments = 64` and wire it into the SunRPC reader to reject pathological records early in `readRecord` in `pkg/internal/sunrpcparser/parser.go` by returning `ErrNotSunRPC` when the cap is exceeded.
- Accept empty non-final fragments within the fragment cap so legal RM records are still parsed while parser work remains bounded.
- Add unit tests in `pkg/internal/sunrpcparser/parser_test.go` to cover a valid fragmented `CALL`, rejection of too many fragments, and acceptance of empty non-final fragments.
- Strengthen the fragment-limit regression test so it uses zero-byte fragments followed by a valid final record, ensuring the failure is caused by the cap rather than an invalid reassembled payload.
- Add the `wrapTCPRecordFragments` test helper for constructing multi-fragment records.

### Testing

- `go test ./pkg/internal/sunrpcparser`