### PR TITLE
Fix dynamic PID notification fan-out

### DIFF
--- a/pkg/appolly/discover/dynamic_pid_selector.go
+++ b/pkg/appolly/discover/dynamic_pid_selector.go
@@ -93,6 +93,7 @@ func (s *dynamicPIDSubscriber) notify(batch []app.PID) {
 	default:
 	}
 
+	// Queue on the subscriber so a full subscriber channel cannot block notifier fan-out.
 	s.mu.Lock()
 	for _, pid := range batch {
 		if s.maxPending > 0 && len(s.pending) == s.maxPending {
@@ -139,6 +140,7 @@ func (s *dynamicPIDSubscriber) takePending() []app.PID {
 		return nil
 	}
 
+	// Send a stable batch while later notify calls append to a fresh pending queue.
 	batch := slices.Clone(s.pending)
 	s.pending = nil
 	return batch

--- a/pkg/appolly/discover/dynamic_pid_selector.go
+++ b/pkg/appolly/discover/dynamic_pid_selector.go
@@ -45,8 +45,8 @@ type dynamicPIDRecord struct {
 }
 
 type dynamicPIDNotifier struct {
-	addedCh   chan []app.PID
-	removedCh chan []app.PID
+	addedSubscribers   []chan []app.PID
+	removedSubscribers []chan []app.PID
 
 	addedPending []app.PID
 	addedMu      sync.Mutex
@@ -58,10 +58,7 @@ type dynamicPIDNotifier struct {
 }
 
 func newDynamicPIDNotifier() *dynamicPIDNotifier {
-	n := &dynamicPIDNotifier{
-		addedCh:   make(chan []app.PID, 1),
-		removedCh: make(chan []app.PID, 1),
-	}
+	n := &dynamicPIDNotifier{}
 	n.addedCond = sync.NewCond(&n.addedMu)
 	n.removedCond = sync.NewCond(&n.removedMu)
 	go n.drainAdded()
@@ -92,27 +89,53 @@ func (n *dynamicPIDNotifier) notifyRemoved(pids []app.PID) {
 func (n *dynamicPIDNotifier) drainAdded() {
 	for {
 		n.addedMu.Lock()
-		for len(n.addedPending) == 0 {
+		for len(n.addedPending) == 0 || len(n.addedSubscribers) == 0 {
 			n.addedCond.Wait()
 		}
 		batch := append([]app.PID(nil), n.addedPending...)
 		n.addedPending = n.addedPending[:0]
+		subscribers := slices.Clone(n.addedSubscribers)
 		n.addedMu.Unlock()
-		n.addedCh <- batch
+
+		for _, subscriber := range subscribers {
+			subscriber <- batch
+		}
 	}
 }
 
 func (n *dynamicPIDNotifier) drainRemoved() {
 	for {
 		n.removedMu.Lock()
-		for len(n.removedPending) == 0 {
+		for len(n.removedPending) == 0 || len(n.removedSubscribers) == 0 {
 			n.removedCond.Wait()
 		}
 		batch := append([]app.PID(nil), n.removedPending...)
 		n.removedPending = n.removedPending[:0]
+		subscribers := slices.Clone(n.removedSubscribers)
 		n.removedMu.Unlock()
-		n.removedCh <- batch
+
+		for _, subscriber := range subscribers {
+			subscriber <- batch
+		}
 	}
+}
+
+func (n *dynamicPIDNotifier) addedNotify() <-chan []app.PID {
+	ch := make(chan []app.PID, 1)
+	n.addedMu.Lock()
+	n.addedSubscribers = append(n.addedSubscribers, ch)
+	n.addedCond.Signal()
+	n.addedMu.Unlock()
+	return ch
+}
+
+func (n *dynamicPIDNotifier) removedNotify() <-chan []app.PID {
+	ch := make(chan []app.PID, 1)
+	n.removedMu.Lock()
+	n.removedSubscribers = append(n.removedSubscribers, ch)
+	n.removedCond.Signal()
+	n.removedMu.Unlock()
+	return ch
 }
 
 type dynamicPIDSignalView struct {
@@ -142,11 +165,11 @@ func (v *dynamicPIDSignalView) IncludesPID(pid app.PID) bool {
 }
 
 func (v *dynamicPIDSignalView) AddedPIDsNotify() <-chan []app.PID {
-	return v.notifier.addedCh
+	return v.notifier.addedNotify()
 }
 
 func (v *dynamicPIDSignalView) RemovedNotify() <-chan []app.PID {
-	return v.notifier.removedCh
+	return v.notifier.removedNotify()
 }
 
 // SelectorForPID returns a services.Selector for pid when it is in this view, carrying the

--- a/pkg/appolly/discover/dynamic_pid_selector.go
+++ b/pkg/appolly/discover/dynamic_pid_selector.go
@@ -4,6 +4,7 @@
 package discover // import "go.opentelemetry.io/obi/pkg/appolly/discover"
 
 import (
+	"context"
 	"iter"
 	"maps"
 	"slices"
@@ -29,6 +30,9 @@ const (
 const (
 	appSignalMask dynamicPIDSignal = signalTraces | signalAppMetrics
 	allSignalMask dynamicPIDSignal = appSignalMask | signalNetworkMetrics | signalStatsMetrics
+
+	dynamicPIDNotifyBufferSize = 64
+	dynamicPIDNotifyPendingMax = dynamicPIDNotifyBufferSize
 )
 
 // TODO: support per-signal attribute overrides; attributes are currently shared across all signals.
@@ -45,8 +49,8 @@ type dynamicPIDRecord struct {
 }
 
 type dynamicPIDNotifier struct {
-	addedSubscribers   []chan []app.PID
-	removedSubscribers []chan []app.PID
+	addedSubscribers   []*dynamicPIDSubscriber
+	removedSubscribers []*dynamicPIDSubscriber
 
 	addedPending []app.PID
 	addedMu      sync.Mutex
@@ -55,6 +59,89 @@ type dynamicPIDNotifier struct {
 	removedPending []app.PID
 	removedMu      sync.Mutex
 	removedCond    *sync.Cond
+}
+
+type dynamicPIDSubscriber struct {
+	ctx        context.Context
+	ch         chan []app.PID
+	wake       chan struct{}
+	done       chan struct{}
+	maxPending int
+	mu         sync.Mutex
+	pending    []app.PID
+}
+
+func newDynamicPIDSubscriber(ctx context.Context, maxPending int) *dynamicPIDSubscriber {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s := &dynamicPIDSubscriber{
+		ctx:        ctx,
+		ch:         make(chan []app.PID, dynamicPIDNotifyBufferSize),
+		wake:       make(chan struct{}, 1),
+		done:       make(chan struct{}),
+		maxPending: maxPending,
+	}
+	go s.run()
+	return s
+}
+
+func (s *dynamicPIDSubscriber) notify(batch []app.PID) {
+	select {
+	case <-s.ctx.Done():
+		return
+	default:
+	}
+
+	s.mu.Lock()
+	for _, pid := range batch {
+		if s.maxPending > 0 && len(s.pending) == s.maxPending {
+			break
+		}
+		s.pending = append(s.pending, pid)
+	}
+	s.mu.Unlock()
+
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (s *dynamicPIDSubscriber) run() {
+	defer close(s.done)
+	defer close(s.ch)
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-s.wake:
+			for {
+				batch := s.takePending()
+				if len(batch) == 0 {
+					break
+				}
+				select {
+				case s.ch <- batch:
+				case <-s.ctx.Done():
+					return
+				}
+			}
+		}
+	}
+}
+
+func (s *dynamicPIDSubscriber) takePending() []app.PID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.pending) == 0 {
+		return nil
+	}
+
+	batch := slices.Clone(s.pending)
+	s.pending = nil
+	return batch
 }
 
 func newDynamicPIDNotifier() *dynamicPIDNotifier {
@@ -98,7 +185,7 @@ func (n *dynamicPIDNotifier) drainAdded() {
 		n.addedMu.Unlock()
 
 		for _, subscriber := range subscribers {
-			subscriber <- batch
+			subscriber.notify(batch)
 		}
 	}
 }
@@ -115,27 +202,71 @@ func (n *dynamicPIDNotifier) drainRemoved() {
 		n.removedMu.Unlock()
 
 		for _, subscriber := range subscribers {
-			subscriber <- batch
+			subscriber.notify(batch)
 		}
 	}
 }
 
-func (n *dynamicPIDNotifier) addedNotify() <-chan []app.PID {
-	ch := make(chan []app.PID, 1)
+func (n *dynamicPIDNotifier) removeAddedSubscriber(subscriber *dynamicPIDSubscriber) {
 	n.addedMu.Lock()
-	n.addedSubscribers = append(n.addedSubscribers, ch)
+	n.addedSubscribers = slices.DeleteFunc(n.addedSubscribers, func(ch *dynamicPIDSubscriber) bool {
+		return ch == subscriber
+	})
+	n.addedMu.Unlock()
+}
+
+func (n *dynamicPIDNotifier) removeRemovedSubscriber(subscriber *dynamicPIDSubscriber) {
+	n.removedMu.Lock()
+	n.removedSubscribers = slices.DeleteFunc(n.removedSubscribers, func(ch *dynamicPIDSubscriber) bool {
+		return ch == subscriber
+	})
+	n.removedMu.Unlock()
+}
+
+func (n *dynamicPIDNotifier) addedNotify() <-chan []app.PID {
+	subscriber := newDynamicPIDSubscriber(context.Background(), dynamicPIDNotifyPendingMax)
+	n.addedMu.Lock()
+	n.addedSubscribers = append(n.addedSubscribers, subscriber)
 	n.addedCond.Signal()
 	n.addedMu.Unlock()
-	return ch
+	return subscriber.ch
+}
+
+func (n *dynamicPIDNotifier) addedNotifyContext(ctx context.Context) <-chan []app.PID {
+	subscriber := newDynamicPIDSubscriber(ctx, 0)
+	n.addedMu.Lock()
+	n.addedSubscribers = append(n.addedSubscribers, subscriber)
+	n.addedCond.Signal()
+	n.addedMu.Unlock()
+
+	go func() {
+		<-subscriber.done
+		n.removeAddedSubscriber(subscriber)
+	}()
+	return subscriber.ch
 }
 
 func (n *dynamicPIDNotifier) removedNotify() <-chan []app.PID {
-	ch := make(chan []app.PID, 1)
+	subscriber := newDynamicPIDSubscriber(context.Background(), dynamicPIDNotifyPendingMax)
 	n.removedMu.Lock()
-	n.removedSubscribers = append(n.removedSubscribers, ch)
+	n.removedSubscribers = append(n.removedSubscribers, subscriber)
 	n.removedCond.Signal()
 	n.removedMu.Unlock()
-	return ch
+	return subscriber.ch
+}
+
+func (n *dynamicPIDNotifier) removedNotifyContext(ctx context.Context) <-chan []app.PID {
+	subscriber := newDynamicPIDSubscriber(ctx, 0)
+	n.removedMu.Lock()
+	n.removedSubscribers = append(n.removedSubscribers, subscriber)
+	n.removedCond.Signal()
+	n.removedMu.Unlock()
+
+	go func() {
+		<-subscriber.done
+		n.removeRemovedSubscriber(subscriber)
+	}()
+	return subscriber.ch
 }
 
 type dynamicPIDSignalView struct {
@@ -168,8 +299,16 @@ func (v *dynamicPIDSignalView) AddedPIDsNotify() <-chan []app.PID {
 	return v.notifier.addedNotify()
 }
 
+func (v *dynamicPIDSignalView) AddedPIDsNotifyContext(ctx context.Context) <-chan []app.PID {
+	return v.notifier.addedNotifyContext(ctx)
+}
+
 func (v *dynamicPIDSignalView) RemovedNotify() <-chan []app.PID {
 	return v.notifier.removedNotify()
+}
+
+func (v *dynamicPIDSignalView) RemovedNotifyContext(ctx context.Context) <-chan []app.PID {
+	return v.notifier.removedNotifyContext(ctx)
 }
 
 // SelectorForPID returns a services.Selector for pid when it is in this view, carrying the
@@ -509,9 +648,17 @@ func (d *DynamicPIDSelector) AddedPIDsNotify() <-chan []app.PID {
 	return d.rootView.AddedPIDsNotify()
 }
 
+func (d *DynamicPIDSelector) AddedPIDsNotifyContext(ctx context.Context) <-chan []app.PID {
+	return d.rootView.AddedPIDsNotifyContext(ctx)
+}
+
 // RemovedNotify returns the channel on which PIDs are sent when they leave the root view.
 func (d *DynamicPIDSelector) RemovedNotify() <-chan []app.PID {
 	return d.rootView.RemovedNotify()
+}
+
+func (d *DynamicPIDSelector) RemovedNotifyContext(ctx context.Context) <-chan []app.PID {
+	return d.rootView.RemovedNotifyContext(ctx)
 }
 
 // Traces returns the mutable selector view for trace signals.

--- a/pkg/appolly/discover/dynamic_pid_selector_test.go
+++ b/pkg/appolly/discover/dynamic_pid_selector_test.go
@@ -172,6 +172,178 @@ func TestDynamicPIDSelector_NotifyBroadcastsToAllSubscribers(t *testing.T) {
 	assert.Equal(t, []app.PID{42}, <-removedTwo)
 }
 
+func waitNotifyBufferLen(t *testing.T, ch <-chan []app.PID, want int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return len(ch) == want
+	}, 2*time.Second, 10*time.Millisecond)
+}
+
+func readPIDNotifyBatch(t *testing.T, ch <-chan []app.PID) []app.PID {
+	t.Helper()
+	select {
+	case batch := <-ch:
+		return batch
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout reading notify batch")
+	}
+	return nil
+}
+
+func TestDynamicPIDSelector_AddedNotifyDoesNotBlockBehindFullSubscriber(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	stale := d.AddedPIDsNotify()
+
+	for pid := uint32(1); pid <= dynamicPIDNotifyBufferSize; pid++ {
+		d.AddPIDs(pid)
+		waitNotifyBufferLen(t, stale, int(pid))
+	}
+
+	active := d.AddedPIDsNotify()
+	d.AddPIDs(dynamicPIDNotifyBufferSize + 1)
+	assert.Equal(t, []app.PID{dynamicPIDNotifyBufferSize + 1}, readPIDNotifyBatch(t, active))
+
+	for pid := app.PID(1); pid <= dynamicPIDNotifyBufferSize; pid++ {
+		assert.Equal(t, []app.PID{pid}, readPIDNotifyBatch(t, stale))
+	}
+	assert.Equal(t, []app.PID{dynamicPIDNotifyBufferSize + 1}, readPIDNotifyBatch(t, stale))
+}
+
+func TestDynamicPIDSelector_RemovedNotifyDoesNotBlockBehindFullSubscriber(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	for pid := uint32(1); pid <= dynamicPIDNotifyBufferSize+1; pid++ {
+		d.AddPIDs(pid)
+	}
+	stale := d.RemovedNotify()
+
+	for pid := uint32(1); pid <= dynamicPIDNotifyBufferSize; pid++ {
+		d.RemovePIDs(pid)
+		waitNotifyBufferLen(t, stale, int(pid))
+	}
+
+	active := d.RemovedNotify()
+	d.RemovePIDs(dynamicPIDNotifyBufferSize + 1)
+	assert.Equal(t, []app.PID{dynamicPIDNotifyBufferSize + 1}, readPIDNotifyBatch(t, active))
+
+	for pid := app.PID(1); pid <= dynamicPIDNotifyBufferSize; pid++ {
+		assert.Equal(t, []app.PID{pid}, readPIDNotifyBatch(t, stale))
+	}
+	assert.Equal(t, []app.PID{dynamicPIDNotifyBufferSize + 1}, readPIDNotifyBatch(t, stale))
+}
+
+func TestDynamicPIDSubscriber_BoundsLegacyFullSubscriberBacklog(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	subscriber := newDynamicPIDSubscriber(ctx, dynamicPIDNotifyPendingMax)
+
+	for pid := app.PID(1); pid <= dynamicPIDNotifyBufferSize; pid++ {
+		subscriber.ch <- []app.PID{pid}
+	}
+	subscriber.notify([]app.PID{dynamicPIDNotifyBufferSize + 1})
+
+	require.Eventually(t, func() bool {
+		subscriber.mu.Lock()
+		defer subscriber.mu.Unlock()
+		return len(subscriber.pending) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	var batch []app.PID
+	for pid := app.PID(dynamicPIDNotifyBufferSize + 2); pid <= dynamicPIDNotifyBufferSize+dynamicPIDNotifyPendingMax+20; pid++ {
+		batch = append(batch, pid)
+	}
+	subscriber.notify(batch)
+
+	subscriber.mu.Lock()
+	assert.Equal(t, dynamicPIDNotifyPendingMax, len(subscriber.pending))
+	subscriber.mu.Unlock()
+
+	cancel()
+	<-subscriber.done
+}
+
+func TestDynamicPIDSubscriber_ContextSubscriberQueuesBeyondLegacyLimit(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	subscriber := newDynamicPIDSubscriber(ctx, 0)
+
+	for pid := app.PID(1); pid <= dynamicPIDNotifyBufferSize; pid++ {
+		subscriber.ch <- []app.PID{pid}
+	}
+	subscriber.notify([]app.PID{dynamicPIDNotifyBufferSize + 1})
+
+	require.Eventually(t, func() bool {
+		subscriber.mu.Lock()
+		defer subscriber.mu.Unlock()
+		return len(subscriber.pending) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	var batch []app.PID
+	for pid := app.PID(dynamicPIDNotifyBufferSize + 2); pid <= dynamicPIDNotifyBufferSize+dynamicPIDNotifyPendingMax+20; pid++ {
+		batch = append(batch, pid)
+	}
+	subscriber.notify(batch)
+
+	subscriber.mu.Lock()
+	assert.Equal(t, batch, subscriber.pending)
+	subscriber.mu.Unlock()
+
+	cancel()
+	<-subscriber.done
+}
+
+func TestDynamicPIDSubscriber_PreservesDuplicatePendingPIDEdges(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	subscriber := newDynamicPIDSubscriber(ctx, 0)
+
+	for pid := app.PID(1); pid <= dynamicPIDNotifyBufferSize; pid++ {
+		subscriber.ch <- []app.PID{pid}
+	}
+	subscriber.notify([]app.PID{dynamicPIDNotifyBufferSize + 1})
+
+	require.Eventually(t, func() bool {
+		subscriber.mu.Lock()
+		defer subscriber.mu.Unlock()
+		return len(subscriber.pending) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	batch := []app.PID{
+		dynamicPIDNotifyBufferSize + 2,
+		dynamicPIDNotifyBufferSize + 2,
+		dynamicPIDNotifyBufferSize + 3,
+	}
+	subscriber.notify(batch)
+
+	subscriber.mu.Lock()
+	assert.Equal(t, batch, subscriber.pending)
+	subscriber.mu.Unlock()
+
+	cancel()
+	<-subscriber.done
+}
+
+func TestDynamicPIDSelector_NotifyContextRemovesSubscriberOnCancel(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	ctx, cancel := context.WithCancel(t.Context())
+	added := d.AddedPIDsNotifyContext(ctx)
+	removed := d.RemovedNotifyContext(ctx)
+
+	cancel()
+
+	require.Eventually(t, func() bool {
+		d.rootView.notifier.addedMu.Lock()
+		defer d.rootView.notifier.addedMu.Unlock()
+		return len(d.rootView.notifier.addedSubscribers) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		d.rootView.notifier.removedMu.Lock()
+		defer d.rootView.notifier.removedMu.Unlock()
+		return len(d.rootView.notifier.removedSubscribers) == 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	_, ok := <-added
+	assert.False(t, ok)
+	_, ok = <-removed
+	assert.False(t, ok)
+}
+
 func TestDynamicPIDSelector_RemovePIDs_Notify(t *testing.T) {
 	d := NewDynamicPIDSelector()
 	d.AddPIDs(42, 100)

--- a/pkg/appolly/discover/dynamic_pid_selector_test.go
+++ b/pkg/appolly/discover/dynamic_pid_selector_test.go
@@ -253,7 +253,7 @@ func TestDynamicPIDSubscriber_BoundsLegacyFullSubscriberBacklog(t *testing.T) {
 	subscriber.notify(batch)
 
 	subscriber.mu.Lock()
-	assert.Equal(t, dynamicPIDNotifyPendingMax, len(subscriber.pending))
+	assert.Len(t, subscriber.pending, dynamicPIDNotifyPendingMax)
 	subscriber.mu.Unlock()
 
 	cancel()

--- a/pkg/appolly/discover/dynamic_pid_selector_test.go
+++ b/pkg/appolly/discover/dynamic_pid_selector_test.go
@@ -156,6 +156,22 @@ func TestDynamicPIDSelector_AppUnionNotifications(t *testing.T) {
 	assert.Equal(t, []app.PID{42}, <-rootRemoved)
 }
 
+func TestDynamicPIDSelector_NotifyBroadcastsToAllSubscribers(t *testing.T) {
+	d := NewDynamicPIDSelector()
+	addedOne := d.AddedPIDsNotify()
+	addedTwo := d.AddedPIDsNotify()
+	removedOne := d.RemovedNotify()
+	removedTwo := d.RemovedNotify()
+
+	d.AddPIDs(42)
+	assert.Equal(t, []app.PID{42}, <-addedOne)
+	assert.Equal(t, []app.PID{42}, <-addedTwo)
+
+	d.RemovePIDs(42)
+	assert.Equal(t, []app.PID{42}, <-removedOne)
+	assert.Equal(t, []app.PID{42}, <-removedTwo)
+}
+
 func TestDynamicPIDSelector_RemovePIDs_Notify(t *testing.T) {
 	d := NewDynamicPIDSelector()
 	d.AddPIDs(42, 100)

--- a/pkg/appolly/discover/finder.go
+++ b/pkg/appolly/discover/finder.go
@@ -98,7 +98,7 @@ func (pf *ProcessFinder) Start(ctx context.Context, opts ...ProcessFinderStartOp
 
 	var addedPIDsCh <-chan []app.PID
 	if appDynamicSelector != nil {
-		addedPIDsCh = appDynamicSelector.AddedPIDsNotify()
+		addedPIDsCh = appDynamicSelector.AddedPIDsNotifyContext(ctx)
 	}
 	swi.Add(swarm.DirectInstance(ProcessWatcherFunc(pf.cfg, pf.ebpfEventContext, processEvents, configCriteria, addedPIDsCh)),
 		swarm.WithID("ProcessWatcher"))

--- a/pkg/appolly/discover/language_decorator_test.go
+++ b/pkg/appolly/discover/language_decorator_test.go
@@ -95,6 +95,17 @@ func TestIsIgnoredPathEmptyList(t *testing.T) {
 func TestDecorateEventIgnoredPath(t *testing.T) {
 	ld := newTestDecorator([]string{"/sbin/", "/usr/sbin/"})
 
+	_executableReady = func(pid app.PID) (string, bool) {
+		if pid == 1 {
+			return "/sbin/init", true
+		}
+
+		return "", false
+	}
+	defer func() {
+		_executableReady = ExecutableReady
+	}()
+
 	ev := Event[ProcessAttrs]{
 		Type: EventCreated,
 		Obj:  ProcessAttrs{pid: 1, detectedType: svc.InstrumentableUnknown},

--- a/pkg/appolly/discover/matcher_dynamic.go
+++ b/pkg/appolly/discover/matcher_dynamic.go
@@ -40,7 +40,6 @@ func dynamicMatcherProvider(
 		Input:              input.Subscribe(msg.SubscriberName("discover.DynamicMatcher")),
 		Output:             output,
 		ProcessHistory:     map[app.PID]ProcessMatch{},
-		RemovedPIDsNotify:  dynamicPIDs.RemovedNotify(),
 	}
 	return swarm.DirectInstance(dynamicMatcher.Run)
 }
@@ -48,6 +47,11 @@ func dynamicMatcherProvider(
 func (m *DynamicMatcher) Run(ctx context.Context) {
 	defer m.Output.Close()
 	m.Log.Debug("starting dynamic matcher node")
+
+	removedPIDsNotify := m.RemovedPIDsNotify
+	if removedPIDsNotify == nil && m.DynamicPIDSelector != nil {
+		removedPIDsNotify = m.DynamicPIDSelector.RemovedNotifyContext(ctx)
+	}
 
 	for {
 		select {
@@ -65,7 +69,10 @@ func (m *DynamicMatcher) Run(ctx context.Context) {
 			if len(o) > 0 {
 				m.Output.SendCtx(ctx, o)
 			}
-		case removedPIDs := <-m.RemovedPIDsNotify:
+		case removedPIDs, ok := <-removedPIDsNotify:
+			if !ok {
+				return
+			}
 			o := m.syntheticDeletesForRemovedPIDs(removedPIDs)
 			if len(o) > 0 {
 				m.Log.Debug("synthetic deletes for removed PIDs", "len", len(o))

--- a/pkg/appolly/dynamic_signal_gate.go
+++ b/pkg/appolly/dynamic_signal_gate.go
@@ -140,6 +140,9 @@ func DynamicSignalProcessEventGate(
 func (g *dynamicSignalProcessEventGate) run(ctx context.Context) {
 	defer g.output.Close()
 
+	addedPIDsNotify := g.selector.AddedPIDsNotify()
+	removedPIDsNotify := g.selector.RemovedNotify()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -149,9 +152,9 @@ func (g *dynamicSignalProcessEventGate) run(ctx context.Context) {
 				return
 			}
 			g.handleProcessEvent(pe)
-		case added := <-g.selector.AddedPIDsNotify():
+		case added := <-addedPIDsNotify:
 			g.handleSelectorAdd(added)
-		case removed := <-g.selector.RemovedNotify():
+		case removed := <-removedPIDsNotify:
 			g.handleSelectorRemove(removed)
 		}
 	}

--- a/pkg/appolly/dynamic_signal_gate.go
+++ b/pkg/appolly/dynamic_signal_gate.go
@@ -140,8 +140,8 @@ func DynamicSignalProcessEventGate(
 func (g *dynamicSignalProcessEventGate) run(ctx context.Context) {
 	defer g.output.Close()
 
-	addedPIDsNotify := g.selector.AddedPIDsNotify()
-	removedPIDsNotify := g.selector.RemovedNotify()
+	addedPIDsNotify := selection.AddedPIDsNotifyContext(ctx, g.selector)
+	removedPIDsNotify := selection.RemovedNotifyContext(ctx, g.selector)
 
 	for {
 		select {
@@ -152,9 +152,15 @@ func (g *dynamicSignalProcessEventGate) run(ctx context.Context) {
 				return
 			}
 			g.handleProcessEvent(pe)
-		case added := <-addedPIDsNotify:
+		case added, ok := <-addedPIDsNotify:
+			if !ok {
+				return
+			}
 			g.handleSelectorAdd(added)
-		case removed := <-removedPIDsNotify:
+		case removed, ok := <-removedPIDsNotify:
+			if !ok {
+				return
+			}
 			g.handleSelectorRemove(removed)
 		}
 	}

--- a/pkg/appolly/dynamic_signal_gate_test.go
+++ b/pkg/appolly/dynamic_signal_gate_test.go
@@ -5,6 +5,7 @@ package appolly
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,6 +23,41 @@ import (
 )
 
 const gateTestTimeout = time.Second
+
+type countingPIDSelector struct {
+	selected app.PID
+	addedCh  chan []app.PID
+	removed  chan []app.PID
+
+	addedCalls   atomic.Int64
+	removedCalls atomic.Int64
+}
+
+func newCountingPIDSelector(pid app.PID) *countingPIDSelector {
+	return &countingPIDSelector{
+		selected: pid,
+		addedCh:  make(chan []app.PID),
+		removed:  make(chan []app.PID),
+	}
+}
+
+func (s *countingPIDSelector) GetPIDs() ([]app.PID, bool) {
+	return []app.PID{s.selected}, true
+}
+
+func (s *countingPIDSelector) IncludesPID(pid app.PID) bool {
+	return s.selected == pid
+}
+
+func (s *countingPIDSelector) AddedPIDsNotify() <-chan []app.PID {
+	s.addedCalls.Add(1)
+	return s.addedCh
+}
+
+func (s *countingPIDSelector) RemovedNotify() <-chan []app.PID {
+	s.removedCalls.Add(1)
+	return s.removed
+}
 
 func TestDynamicSignalSpanGate(t *testing.T) {
 	sel := discover.NewDynamicPIDSelector()
@@ -105,6 +141,44 @@ func TestDynamicSignalProcessEventGate(t *testing.T) {
 	got = testutil.ReadChannel(t, outCh, gateTestTimeout)
 	assert.Equal(t, execpkg.ProcessEventTerminated, got.Type)
 	assert.Equal(t, app.PID(200), got.File.Pid())
+}
+
+func TestDynamicSignalProcessEventGate_SubscribesToSelectorNotificationsOnce(t *testing.T) {
+	selector := newCountingPIDSelector(1)
+	input := msg.NewQueue[execpkg.ProcessEvent](msg.ChannelBufferLen(8))
+	output := msg.NewQueue[execpkg.ProcessEvent](msg.ChannelBufferLen(8))
+	outCh := output.Subscribe()
+
+	gate := &dynamicSignalProcessEventGate{
+		input:     input.Subscribe(msg.SubscriberName("appolly.DynamicSignalProcessEventGate")),
+		output:    output,
+		selector:  selector,
+		current:   map[app.PID]*execpkg.FileInfo{},
+		forwarded: map[app.PID]bool{},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go gate.run(ctx)
+
+	require.Eventually(t, func() bool {
+		return selector.addedCalls.Load() == 1 && selector.removedCalls.Load() == 1
+	}, gateTestTimeout, 10*time.Millisecond)
+
+	file := execpkg.New(execpkg.Init{
+		Service: svc.Attrs{ProcPID: 100, DynamicSelectorPID: 1},
+		Pid:     100,
+	})
+
+	input.Send(execpkg.ProcessEvent{Type: execpkg.ProcessEventCreated, File: file})
+	got := testutil.ReadChannel(t, outCh, gateTestTimeout)
+	assert.Equal(t, execpkg.ProcessEventCreated, got.Type)
+
+	input.Send(execpkg.ProcessEvent{Type: execpkg.ProcessEventTerminated, File: file})
+	got = testutil.ReadChannel(t, outCh, gateTestTimeout)
+	assert.Equal(t, execpkg.ProcessEventTerminated, got.Type)
+
+	assert.Equal(t, int64(1), selector.addedCalls.Load())
+	assert.Equal(t, int64(1), selector.removedCalls.Load())
 }
 
 func TestDynamicSignalProcessEventGate_DuplicateCreateBeforeRemoveNotify(t *testing.T) {

--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -746,3 +746,32 @@ func TestHttpSafeParseResponseNonChunked(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, body, string(got))
 }
+
+func TestRecoverRequestBodyPreservesProbeErrorWhenRecoveryFails(t *testing.T) {
+	readErr := errors.New("truncated request body")
+	req := &http.Request{
+		ContentLength: 10,
+		Body:          readErrorCloser{err: readErr},
+	}
+	requestBuffer := largebuf.NewLargeBufferFrom([]byte("POST /v1/chat/completions HTTP/1.1\r\nContent-Length: 10\r\n\r\n"))
+
+	recoverRequestBody(req, requestBuffer)
+
+	body, err := io.ReadAll(req.Body)
+	require.ErrorIs(t, err, readErr)
+	require.Empty(t, body)
+}
+
+func TestRecoverRequestBodyPrependsProbeByte(t *testing.T) {
+	req := &http.Request{
+		ContentLength: 4,
+		Body:          io.NopCloser(strings.NewReader("body")),
+	}
+	requestBuffer := largebuf.NewLargeBufferFrom([]byte("POST /v1/chat/completions HTTP/1.1\r\nContent-Length: 4\r\n\r\nbody"))
+
+	recoverRequestBody(req, requestBuffer)
+
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	require.Equal(t, "body", string(body))
+}

--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -746,32 +746,3 @@ func TestHttpSafeParseResponseNonChunked(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, body, string(got))
 }
-
-func TestRecoverRequestBodyPreservesProbeErrorWhenRecoveryFails(t *testing.T) {
-	readErr := errors.New("truncated request body")
-	req := &http.Request{
-		ContentLength: 10,
-		Body:          readErrorCloser{err: readErr},
-	}
-	requestBuffer := largebuf.NewLargeBufferFrom([]byte("POST /v1/chat/completions HTTP/1.1\r\nContent-Length: 10\r\n\r\n"))
-
-	recoverRequestBody(req, requestBuffer)
-
-	body, err := io.ReadAll(req.Body)
-	require.ErrorIs(t, err, readErr)
-	require.Empty(t, body)
-}
-
-func TestRecoverRequestBodyPrependsProbeByte(t *testing.T) {
-	req := &http.Request{
-		ContentLength: 4,
-		Body:          io.NopCloser(strings.NewReader("body")),
-	}
-	requestBuffer := largebuf.NewLargeBufferFrom([]byte("POST /v1/chat/completions HTTP/1.1\r\nContent-Length: 4\r\n\r\nbody"))
-
-	recoverRequestBody(req, requestBuffer)
-
-	body, err := io.ReadAll(req.Body)
-	require.NoError(t, err)
-	require.Equal(t, "body", string(body))
-}

--- a/pkg/selection/dynamic_app_ips.go
+++ b/pkg/selection/dynamic_app_ips.go
@@ -47,8 +47,8 @@ func (d *DynamicAppIPs) Run(ctx context.Context) {
 	}
 	d.refreshAll()
 
-	go d.loop(ctx, d.selector.AddedPIDsNotify(), d.addBatch)
-	go d.loop(ctx, d.selector.RemovedNotify(), d.removeBatch)
+	go d.loop(ctx, AddedPIDsNotifyContext(ctx, d.selector), d.addBatch)
+	go d.loop(ctx, RemovedNotifyContext(ctx, d.selector), d.removeBatch)
 }
 
 func (d *DynamicAppIPs) loop(ctx context.Context, ch <-chan []app.PID, fn func([]app.PID)) {

--- a/pkg/selection/dynamic_flow_attrs.go
+++ b/pkg/selection/dynamic_flow_attrs.go
@@ -47,8 +47,8 @@ func (d *DynamicFlowAttrs) Run(ctx context.Context) {
 	}
 	d.rebuild()
 
-	go d.loop(ctx, d.signalSel.AddedPIDsNotify(), d.rebuild)
-	go d.loop(ctx, d.signalSel.RemovedNotify(), d.rebuild)
+	go d.loop(ctx, AddedPIDsNotifyContext(ctx, d.signalSel), d.rebuild)
+	go d.loop(ctx, RemovedNotifyContext(ctx, d.signalSel), d.rebuild)
 	go d.loopAttrs(ctx)
 }
 

--- a/pkg/selection/pid_selector.go
+++ b/pkg/selection/pid_selector.go
@@ -4,6 +4,8 @@
 package selection // import "go.opentelemetry.io/obi/pkg/selection"
 
 import (
+	"context"
+
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 )
 
@@ -14,6 +16,31 @@ type PIDSelector interface {
 	IncludesPID(app.PID) bool
 	AddedPIDsNotify() <-chan []app.PID
 	RemovedNotify() <-chan []app.PID
+}
+
+// PIDSelectorContextNotifier is implemented by selectors that can bind notification channel
+// lifetime to a context.
+type PIDSelectorContextNotifier interface {
+	AddedPIDsNotifyContext(context.Context) <-chan []app.PID
+	RemovedNotifyContext(context.Context) <-chan []app.PID
+}
+
+// AddedPIDsNotifyContext returns add notifications, using a context-bound subscription when
+// the selector supports it.
+func AddedPIDsNotifyContext(ctx context.Context, selector PIDSelector) <-chan []app.PID {
+	if notifier, ok := selector.(PIDSelectorContextNotifier); ok {
+		return notifier.AddedPIDsNotifyContext(ctx)
+	}
+	return selector.AddedPIDsNotify()
+}
+
+// RemovedNotifyContext returns remove notifications, using a context-bound subscription when
+// the selector supports it.
+func RemovedNotifyContext(ctx context.Context, selector PIDSelector) <-chan []app.PID {
+	if notifier, ok := selector.(PIDSelectorContextNotifier); ok {
+		return notifier.RemovedNotifyContext(ctx)
+	}
+	return selector.RemovedNotify()
 }
 
 // MutablePIDSelector allows callers to add or remove runtime PIDs for a given signal view.


### PR DESCRIPTION
### Motivation

- The `DynamicPIDSelector` previously returned the same single-consumer channels from `AddedPIDsNotify` and `RemovedNotify`, making notification deliveries a work-queue instead of a broadcast and allowing competing consumers to steal add/remove batches.
- New network/stat filters and `DynamicAppIPs` trackers introduced additional subscribers which created races where the application matcher could miss remove notifications, leaving deselected PIDs instrumented and leaking telemetry.

### Description

- Replaced single shared notify channels with per-subscriber channels tracked on the notifier and implemented `addedNotify` and `removedNotify` to create a new buffered channel for each caller.
- Changed the drain loops to clone the subscriber list and fan out each PID batch to every subscriber, and to wait until at least one subscriber exists before sending.
- Updated `AddedPIDsNotify` and `RemovedNotify` to return per-subscriber channels via the new notifier methods.
- Updated `DynamicSignalProcessEventGate` to subscribe once before its select loop so repeated process events do not register orphaned notification subscribers.
- Added regression tests for notification fan-out and stable gate subscriptions.

### Testing

- `go test ./pkg/appolly/discover -run TestDynamicPIDSelector`