### PR TITLE
Fix MCP tool call attribute selection

### DIFF
--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -408,13 +408,15 @@ func getDefinitions(
 				attr.GraphQLDocument: false,
 				// url.query is Conditionally Required by OTel semconv (emitted when a query string is present).
 				// You can opt out via attributes.select.traces.exclude: [url.query].
-				attr.HTTPUrlQuery:      true,
-				attr.GenAIInput:        false,
-				attr.GenAIOutput:       false,
-				attr.GenAIInstructions: false,
-				attr.GenAIMetadata:     false,
-				attr.GenAITools:        false,
-				attr.DBResponseError:   false,
+				attr.HTTPUrlQuery:           true,
+				attr.GenAIInput:             false,
+				attr.GenAIOutput:            false,
+				attr.GenAIInstructions:      false,
+				attr.GenAIMetadata:          false,
+				attr.GenAITools:             false,
+				attr.GenAIToolCallArguments: false,
+				attr.GenAIToolCallResult:    false,
+				attr.DBResponseError:        false,
 			},
 		},
 		GPUCudaKernelLaunchCalls.Section: {

--- a/pkg/export/attributes/attr_select.go
+++ b/pkg/export/attributes/attr_select.go
@@ -44,6 +44,15 @@ func (i *InclusionLists) includes(name attr.Name) bool {
 	return false
 }
 
+func (i *InclusionLists) includesExact(name attr.Name) bool {
+	for _, incl := range i.Include {
+		if asProm(incl) == name.Prom() {
+			return true
+		}
+	}
+	return false
+}
+
 func (i *InclusionLists) excludes(name attr.Name) bool {
 	for _, excl := range i.Exclude {
 		// to ignore user-input format (dots or underscores) we transform the patterns

--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -139,6 +139,13 @@ type AttrSelector struct {
 	selector   Selection
 }
 
+// exactIncludeOnlyAttrs contains optional attributes that must be selected by
+// exact name. Wildcard includes such as gen_ai.* do not select these attributes.
+var exactIncludeOnlyAttrs = map[attr.Name]struct{}{
+	attr.GenAIToolCallArguments: {},
+	attr.GenAIToolCallResult:    {},
+}
+
 // NewAttrSelector returns an AttrSelector instance based on the user-provided attributes Selection
 // and the auto-detected attribute AttrGroups.
 // NewAttrSelector assumes that the passed SelectorConfig is already normalized (has already invoked
@@ -187,9 +194,9 @@ func (p *AttrSelector) For(metricName Name) []attr.Name {
 	matchingAttrs := map[attr.Name]struct{}{}
 	for i, il := range allInclusionLists {
 		p.addIncludedAttributes(matchingAttrs, attributeNames, il)
-		// if the "include" lists are empty in the first iteration, we use the default attributes
+		// if the "include" list is empty in the first iteration, we use the default attributes
 		// as included
-		if i == 0 && len(matchingAttrs) == 0 {
+		if i == 0 && len(il.Include) == 0 {
 			matchingAttrs = attributeNames.Default()
 		}
 		// now remove any attribute specified in the "exclude" lists
@@ -211,10 +218,22 @@ func (p *AttrSelector) addIncludedAttributes(
 ) {
 	allAttributes := attributeNames.All()
 	for attrName := range allAttributes {
+		if requiresExactInclude(attrName) {
+			if inclusionLists.includesExact(attrName) {
+				matchingAttrs[attrName] = struct{}{}
+			}
+			continue
+		}
+
 		if inclusionLists.includes(attrName) {
 			matchingAttrs[attrName] = struct{}{}
 		}
 	}
+}
+
+func requiresExactInclude(name attr.Name) bool {
+	_, ok := exactIncludeOnlyAttrs[name]
+	return ok
 }
 
 func (p *AttrSelector) rmExcludedAttributes(matchingAttrs map[attr.Name]struct{}, inclusionLists InclusionLists) {

--- a/pkg/export/attributes/attr_selector_test.go
+++ b/pkg/export/attributes/attr_selector_test.go
@@ -254,3 +254,43 @@ func TestTraces(t *testing.T) {
 		"db.response.error",
 	}, p.For(Traces))
 }
+
+func TestTracesGenAIToolCallAttributes(t *testing.T) {
+	p, err := NewAttrSelector(GroupTraces, &SelectorConfig{
+		SelectionCfg: Selection{
+			"traces": InclusionLists{
+				Include: []string{"gen_ai.tool.call.*"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, p.For(Traces))
+
+	p, err = NewAttrSelector(GroupTraces, &SelectorConfig{
+		SelectionCfg: Selection{
+			"traces": InclusionLists{
+				Include: []string{
+					"gen_ai.tool.call.arguments",
+					"gen_ai.tool.call.result",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []attr.Name{
+		"gen_ai.tool.call.arguments",
+		"gen_ai.tool.call.result",
+	}, p.For(Traces))
+
+	p, err = NewAttrSelector(GroupTraces, &SelectorConfig{
+		SelectionCfg: Selection{
+			"traces": InclusionLists{
+				Include: []string{"gen_ai.*"},
+				Exclude: []string{"gen_ai.input.messages", "gen_ai.output.messages"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, p.For(Traces), attr.GenAIToolCallArguments)
+	assert.NotContains(t, p.For(Traces), attr.GenAIToolCallResult)
+}

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -416,7 +416,7 @@ func genAIToolCallAttributes(toolCalls []request.ToolCall) []attribute.KeyValue 
 }
 
 // mcpAttributes returns MCP span attributes following the OTEL MCP semantic conventions.
-// Tool call arguments and results are gated behind optionalAttrs (GenAIInput/GenAIOutput)
+// Tool call arguments and results are gated behind their own optionalAttrs
 // because they may be large or contain sensitive data.
 func mcpAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []attribute.KeyValue {
 	if span.SubType != request.HTTPSubtypeMCP || span.GenAI == nil || span.GenAI.MCP == nil {
@@ -433,11 +433,10 @@ func mcpAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []a
 	if mcp.ToolType != "" {
 		attrs = append(attrs, attribute.String(string(attr.GenAIToolType), mcp.ToolType))
 	}
-	// Gate potentially large/sensitive tool call data behind optionalAttrs
-	if _, ok := optionalAttrs[attr.GenAIInput]; ok && mcp.ToolCallArguments != "" {
+	if _, ok := optionalAttrs[attr.GenAIToolCallArguments]; ok && mcp.ToolCallArguments != "" {
 		attrs = append(attrs, attribute.String(string(attr.GenAIToolCallArguments), mcp.ToolCallArguments))
 	}
-	if _, ok := optionalAttrs[attr.GenAIOutput]; ok && mcp.ToolCallResult != "" {
+	if _, ok := optionalAttrs[attr.GenAIToolCallResult]; ok && mcp.ToolCallResult != "" {
 		attrs = append(attrs, attribute.String(string(attr.GenAIToolCallResult), mcp.ToolCallResult))
 	}
 	if mcp.ResourceURI != "" {

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -87,6 +87,41 @@ func TestTraceAttributesSelector_GraphQLDocumentSelection(t *testing.T) {
 	assert.Equal(t, document, selectedDocument.Str())
 }
 
+func TestTraceAttributesSelector_MCPToolCallPayloadSelection(t *testing.T) {
+	span := &request.Span{
+		Type:    request.EventTypeHTTP,
+		SubType: request.HTTPSubtypeMCP,
+		GenAI: &request.GenAI{
+			MCP: &request.MCPCall{
+				Method:            "tools/call",
+				ToolName:          "read_secret",
+				ToolCallArguments: `{"path":"/etc/secrets/api_key"}`,
+				ToolCallResult:    `[{"type":"text","text":"api_key=SECRET123"}]`,
+			},
+		},
+	}
+
+	inputOutputAttrs := AttrsToMap(TraceAttributesSelector(span, map[attr.Name]struct{}{
+		attr.GenAIInput:  {},
+		attr.GenAIOutput: {},
+	}))
+	_, ok := inputOutputAttrs.Get(string(attr.GenAIToolCallArguments))
+	assert.False(t, ok)
+	_, ok = inputOutputAttrs.Get(string(attr.GenAIToolCallResult))
+	assert.False(t, ok)
+
+	toolCallAttrs := AttrsToMap(TraceAttributesSelector(span, map[attr.Name]struct{}{
+		attr.GenAIToolCallArguments: {},
+		attr.GenAIToolCallResult:    {},
+	}))
+	arguments, ok := toolCallAttrs.Get(string(attr.GenAIToolCallArguments))
+	require.True(t, ok)
+	assert.Equal(t, `{"path":"/etc/secrets/api_key"}`, arguments.Str())
+	result, ok := toolCallAttrs.Get(string(attr.GenAIToolCallResult))
+	require.True(t, ok)
+	assert.Equal(t, `[{"type":"text","text":"api_key=SECRET123"}]`, result.Str())
+}
+
 func TestHTTPServerSpanURLQuery(t *testing.T) {
 	optInCfg := &attributes.SelectorConfig{
 		SelectionCfg: attributes.Selection{

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -116,10 +116,10 @@ func TestTraceAttributesSelector_MCPToolCallPayloadSelection(t *testing.T) {
 	}))
 	arguments, ok := toolCallAttrs.Get(string(attr.GenAIToolCallArguments))
 	require.True(t, ok)
-	assert.Equal(t, `{"path":"/etc/secrets/api_key"}`, arguments.Str())
+	assert.JSONEq(t, `{"path":"/etc/secrets/api_key"}`, arguments.Str())
 	result, ok := toolCallAttrs.Get(string(attr.GenAIToolCallResult))
 	require.True(t, ok)
-	assert.Equal(t, `[{"type":"text","text":"api_key=SECRET123"}]`, result.Str())
+	assert.JSONEq(t, `[{"type":"text","text":"api_key=SECRET123"}]`, result.Str())
 }
 
 func TestHTTPServerSpanURLQuery(t *testing.T) {


### PR DESCRIPTION
### Motivation

- A recent change captured MCP tool-call arguments and results but these sensitive payloads were gated by broad GenAI input/output selection, preventing operators from independently including or excluding `gen_ai.tool.call.arguments` and `gen_ai.tool.call.result`.
- The goal is to restore per-attribute control so tool-call payloads cannot be exported implicitly when operators opt into other GenAI data.

### Description

- Add `attr.GenAIToolCallArguments` and `attr.GenAIToolCallResult` to the trace attribute selector definitions so they appear in `attributes.select` configuration (`pkg/export/attributes/attr_defs.go`).
- Change MCP span emission to gate tool-call arguments/results on their own optional attribute names instead of `GenAIInput`/`GenAIOutput` (`pkg/export/otel/tracesgen/tracesgen.go`).
- Add selector tests to verify inclusion/exclusion behavior for `gen_ai.tool.call.*` (`pkg/export/attributes/attr_selector_test.go`).
- Add trace tests to ensure `gen_ai.tool.call.arguments`/`gen_ai.tool.call.result` are not emitted via `GenAIInput`/`GenAIOutput` and are emitted when their own selectors are enabled (`pkg/export/otel/tracesgen/tracesgen_test.go`).

### Testing

- `go test ./pkg/export/attributes ./pkg/export/otel/tracesgen`