### PR TITLE
Resume HTTP/2 traceparent scan after invalid candidate

### DIFF
--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -150,7 +150,7 @@ typedef struct tailcall_ctx {
     u32 h2_hpack_offset;          // start of HPACK bytes (after PADDED/PRIORITY prefix)
     u32 h2_hpack_len;             // HPACK length (frame payload minus prefix and trailing pad)
     u32 h2_scan_pos;              // resume offset for detect_h2 across tail calls
-    u32 h2_tp_candidate_pos;      // HPACK candidate scan offset (>= k_h2_max_hpack_scan = none)
+    u32 h2_tp_candidate_pos;      // HPACK scan start or found candidate offset (>= max = none)
     u8 niter;                     // HTTP/1 find-existing scan iteration counter
     u8 h2_frames;                 // H2 frames already injected this packet (capped)
     u8 h2_tp_retries;             // malformed HPACK traceparent candidates retried this packet

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -150,11 +150,12 @@ typedef struct tailcall_ctx {
     u32 h2_hpack_offset;          // start of HPACK bytes (after PADDED/PRIORITY prefix)
     u32 h2_hpack_len;             // HPACK length (frame payload minus prefix and trailing pad)
     u32 h2_scan_pos;              // resume offset for detect_h2 across tail calls
-    u32 h2_tp_candidate_pos;      // HPACK candidate offset (>= k_h2_max_hpack_scan = none)
+    u32 h2_tp_candidate_pos;      // HPACK candidate scan offset (>= k_h2_max_hpack_scan = none)
     u8 niter;                     // HTTP/1 find-existing scan iteration counter
     u8 h2_frames;                 // H2 frames already injected this packet (capped)
+    u8 h2_tp_retries;             // malformed HPACK traceparent candidates retried this packet
     bool has_parent_tp;           // true if parent_tp holds a valid context
-    u8 _pad[5];
+    u8 _pad[4];
 } tailcall_ctx;
 
 SCRATCH_MEM(tailcall_ctx);
@@ -912,6 +913,7 @@ int obi_packet_extender(struct sk_msg_md *msg) {
     t_ctx->niter = 0;
     t_ctx->h2_scan_pos = 0;
     t_ctx->h2_frames = 0;
+    t_ctx->h2_tp_retries = 0;
 
     // skip H2 here — it uses HPACK for per-stream traceparents
     tp_info_pid_t *tp_pid = get_tp_info_pid(&e_key);
@@ -1166,7 +1168,7 @@ int obi_packet_extender_detect_h2(struct sk_msg_md *msg) {
         return SK_PASS;
     }
 
-    if (t_ctx->h2_frames >= k_h2_max_frames_per_packet) {
+    if (t_ctx->h2_frames + t_ctx->h2_tp_retries >= k_h2_max_frames_per_packet) {
         return SK_PASS;
     }
 
@@ -1213,6 +1215,7 @@ int obi_packet_extender_detect_h2(struct sk_msg_md *msg) {
                 return SK_PASS;
             }
 
+            t_ctx->h2_tp_candidate_pos = 0;
             bpf_tail_call_static(msg, &extender_jump_table, k_tail_find_existing_h2_tp);
             return SK_PASS;
         }
@@ -1313,10 +1316,11 @@ static __always_inline bool match_h2_tp_huffman(const unsigned char *p) {
            p[k_hpack_tp_name_offset + k_hpack_tp_name_huffman_len] == k_hpack_value_len_tp;
 }
 
-// Returns offset of the traceparent name in HPACK, or k_h2_max_hpack_scan if not found.
-static __always_inline u32 find_first_h2_tp_candidate(struct sk_msg_md *msg,
-                                                      const u32 hpack_start,
-                                                      const u32 hpack_len) {
+// Returns offset of the next traceparent name in HPACK, or k_h2_max_hpack_scan if not found.
+static __always_inline u32 find_next_h2_tp_candidate(struct sk_msg_md *msg,
+                                                     const u32 hpack_start,
+                                                     const u32 hpack_len,
+                                                     const u32 scan_start) {
     enum { k_min_entry_huffman = k_h2_tp_hpack_huffman_size };
 
     if (!pull_hpack_window(msg, hpack_start, hpack_len)) {
@@ -1329,6 +1333,9 @@ static __always_inline u32 find_first_h2_tp_candidate(struct sk_msg_md *msg,
     }
 
     for (u32 i = 0; i < k_h2_max_hpack_scan; i++) {
+        if (i < scan_start) {
+            continue;
+        }
         if (i + k_min_entry_huffman > hpack_len) {
             break;
         }
@@ -1358,8 +1365,8 @@ int obi_packet_extender_find_existing_h2_tp(struct sk_msg_md *msg) {
     if (!t_ctx) {
         return SK_PASS;
     }
-    t_ctx->h2_tp_candidate_pos =
-        find_first_h2_tp_candidate(msg, t_ctx->h2_hpack_offset, t_ctx->h2_hpack_len);
+    t_ctx->h2_tp_candidate_pos = find_next_h2_tp_candidate(
+        msg, t_ctx->h2_hpack_offset, t_ctx->h2_hpack_len, t_ctx->h2_tp_candidate_pos);
     bpf_tail_call_static(msg, &extender_jump_table, k_tail_validate_h2_tp);
     return SK_PASS;
 }
@@ -1395,6 +1402,7 @@ int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg) {
     }
 
     u32 off = 0;
+    u32 next_candidate_pos = target + 1;
     for (u32 i = 0; i < k_h2_max_hpack_scan; i++) {
         if (i + k_h2_tp_hpack_huffman_size > hpack_len) {
             break;
@@ -1411,8 +1419,10 @@ int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg) {
         }
         const u8 nlb = p[1];
         if (nlb == k_hpack_tp_name_len) {
+            next_candidate_pos = target + k_h2_tp_hpack_size;
             off = validate_h2_tp_plain(p, end, &tp_p->tp);
         } else if (nlb == (k_hpack_tp_name_huffman_len | 0x80)) {
+            next_candidate_pos = target + k_h2_tp_hpack_huffman_size;
             off = validate_h2_tp_huffman(p, end, &tp_p->tp);
         }
         break;
@@ -1442,7 +1452,15 @@ int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg) {
         return SK_PASS;
     }
 
-    bpf_tail_call_static(msg, &extender_jump_table, k_tail_create_h2_tp);
+    if (next_candidate_pos >= k_h2_max_hpack_scan ||
+        t_ctx->h2_frames + t_ctx->h2_tp_retries + 1 >= k_h2_max_frames_per_packet) {
+        bpf_tail_call_static(msg, &extender_jump_table, k_tail_create_h2_tp);
+        return SK_PASS;
+    }
+
+    t_ctx->h2_tp_retries++;
+    t_ctx->h2_tp_candidate_pos = next_candidate_pos;
+    bpf_tail_call_static(msg, &extender_jump_table, k_tail_find_existing_h2_tp);
     return SK_PASS;
 }
 

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -1316,11 +1316,11 @@ static __always_inline bool match_h2_tp_huffman(const unsigned char *p) {
            p[k_hpack_tp_name_offset + k_hpack_tp_name_huffman_len] == k_hpack_value_len_tp;
 }
 
-// Returns offset of the next traceparent name in HPACK, or k_h2_max_hpack_scan if not found.
-static __always_inline u32 find_next_h2_tp_candidate(struct sk_msg_md *msg,
-                                                     const u32 hpack_start,
-                                                     const u32 hpack_len,
-                                                     const u32 scan_start) {
+// Returns offset of the traceparent name in the pulled HPACK window, or k_h2_max_hpack_scan if
+// not found.
+static __always_inline u32 find_first_h2_tp_candidate(struct sk_msg_md *msg,
+                                                      const u32 hpack_start,
+                                                      const u32 hpack_len) {
     enum { k_min_entry_huffman = k_h2_tp_hpack_huffman_size };
 
     if (!pull_hpack_window(msg, hpack_start, hpack_len)) {
@@ -1333,9 +1333,6 @@ static __always_inline u32 find_next_h2_tp_candidate(struct sk_msg_md *msg,
     }
 
     for (u32 i = 0; i < k_h2_max_hpack_scan; i++) {
-        if (i < scan_start) {
-            continue;
-        }
         if (i + k_min_entry_huffman > hpack_len) {
             break;
         }
@@ -1365,13 +1362,36 @@ int obi_packet_extender_find_existing_h2_tp(struct sk_msg_md *msg) {
     if (!t_ctx) {
         return SK_PASS;
     }
-    t_ctx->h2_tp_candidate_pos = find_next_h2_tp_candidate(
-        msg, t_ctx->h2_hpack_offset, t_ctx->h2_hpack_len, t_ctx->h2_tp_candidate_pos);
+    const u32 scan_start = t_ctx->h2_tp_candidate_pos;
+    if (scan_start >= k_h2_max_hpack_scan || scan_start >= t_ctx->h2_hpack_len) {
+        t_ctx->h2_tp_candidate_pos = k_h2_max_hpack_scan;
+        bpf_tail_call_static(msg, &extender_jump_table, k_tail_validate_h2_tp);
+        return SK_PASS;
+    }
+
+    u32 search_len = t_ctx->h2_hpack_len - scan_start;
+    const u32 max_search_len = k_h2_max_hpack_scan - scan_start + k_h2_tp_hpack_huffman_size - 1;
+    if (search_len > max_search_len) {
+        search_len = max_search_len;
+    }
+
+    const u32 candidate =
+        find_first_h2_tp_candidate(msg, t_ctx->h2_hpack_offset + scan_start, search_len);
+    if (candidate < k_h2_max_hpack_scan) {
+        const u32 candidate_pos = scan_start + candidate;
+        if (candidate_pos < k_h2_max_hpack_scan) {
+            t_ctx->h2_tp_candidate_pos = candidate_pos;
+            bpf_tail_call_static(msg, &extender_jump_table, k_tail_validate_h2_tp);
+            return SK_PASS;
+        }
+    }
+
+    t_ctx->h2_tp_candidate_pos = k_h2_max_hpack_scan;
     bpf_tail_call_static(msg, &extender_jump_table, k_tail_validate_h2_tp);
     return SK_PASS;
 }
 
-// Walk with a loop counter — pkt pointer offset by a stack-loaded scalar loses its verified range.
+// Pull the candidate window directly so packet access stays at fixed offsets.
 SEC("sk_msg")
 int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg) {
     bpf_dbg_printk("=== sk_msg validate h2 tp ===");
@@ -1390,42 +1410,31 @@ int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg) {
     }
     const u32 hpack_start = t_ctx->h2_hpack_offset;
     const u32 hpack_len = t_ctx->h2_hpack_len;
-    if (!pull_hpack_window(msg, hpack_start, hpack_len)) {
+    if (target >= hpack_len) {
+        bpf_tail_call_static(msg, &extender_jump_table, k_tail_create_h2_tp);
+        return SK_PASS;
+    }
+
+    if (!pull_hpack_window(msg, hpack_start + target, hpack_len - target)) {
         bpf_tail_call_static(msg, &extender_jump_table, k_tail_create_h2_tp);
         return SK_PASS;
     }
     const unsigned char *data = msg->data;
     const unsigned char *end = msg->data_end;
-    if (!data) {
+    if (!data || (void *)(data + k_h2_tp_hpack_huffman_size) > (void *)end) {
         bpf_tail_call_static(msg, &extender_jump_table, k_tail_create_h2_tp);
         return SK_PASS;
     }
 
     u32 off = 0;
     u32 next_candidate_pos = target + 1;
-    for (u32 i = 0; i < k_h2_max_hpack_scan; i++) {
-        if (i + k_h2_tp_hpack_huffman_size > hpack_len) {
-            break;
-        }
-        const unsigned char *p = data + i;
-        if ((void *)(p + k_h2_tp_hpack_huffman_size) > (void *)end) {
-            break;
-        }
-        if (i > target) {
-            break;
-        }
-        if (i != target) {
-            continue;
-        }
-        const u8 nlb = p[1];
-        if (nlb == k_hpack_tp_name_len) {
-            next_candidate_pos = target + k_h2_tp_hpack_size;
-            off = validate_h2_tp_plain(p, end, &tp_p->tp);
-        } else if (nlb == (k_hpack_tp_name_huffman_len | 0x80)) {
-            next_candidate_pos = target + k_h2_tp_hpack_huffman_size;
-            off = validate_h2_tp_huffman(p, end, &tp_p->tp);
-        }
-        break;
+    const u8 nlb = data[1];
+    if (nlb == k_hpack_tp_name_len) {
+        next_candidate_pos = target + k_h2_tp_hpack_size;
+        off = validate_h2_tp_plain(data, end, &tp_p->tp);
+    } else if (nlb == (k_hpack_tp_name_huffman_len | 0x80)) {
+        next_candidate_pos = target + k_h2_tp_hpack_huffman_size;
+        off = validate_h2_tp_huffman(data, end, &tp_p->tp);
     }
 
     if (off) {


### PR DESCRIPTION
### Motivation

- The HTTP/2 HPACK detector previously stopped at the first name/value-length fingerprint match and validated only that candidate.
- When that first candidate looked like `traceparent` but had an invalid value, OBI created and injected a new traceparent instead of continuing to a later valid one.
- Continuing after malformed candidates prevents duplicate traceparent injection while still adopting an existing valid context when one is present later in the HPACK block.

### Description

- Initialize the per-frame HPACK candidate scan offset when starting detection for a `HEADERS` frame.
- Retry malformed HPACK traceparent candidates by advancing past the full literal entry before scanning again:
  - `k_h2_tp_hpack_size` for plain `traceparent` names.
  - `k_h2_tp_hpack_huffman_size` for Huffman-encoded `traceparent` names.
- Count malformed-candidate retries against the existing HTTP/2 per-packet tail-call budget, preserving room for create/write tail calls.
- Keep the retry path verifier-friendly by shifting the pulled HPACK window for each retry instead of making the 192-byte scan loop skip to a saved scalar offset.
- Validate a found candidate from its pulled candidate window directly, so packet access stays at fixed offsets and avoids verifier state explosion on arm64.

### Testing

- `clang-format --dry-run --Werror bpf/tpinjector/tpinjector.c`
- `make generate`
