### PR TITLE
Fix chunked response size overflow

### DIFF
--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -466,8 +466,8 @@ func dechunkBody(data []byte) []byte {
 			break
 		}
 
-		chunkSize, err := strconv.ParseInt(sizeLine, 16, 64)
-		if err != nil || chunkSize < 0 {
+		chunkSize, err := strconv.ParseUint(sizeLine, 16, 64)
+		if err != nil {
 			break
 		}
 		if chunkSize == 0 {
@@ -475,13 +475,14 @@ func dechunkBody(data []byte) []byte {
 		}
 
 		chunkStart := pos + lineEnd + 2 // skip past \r\n
-		chunkEnd := chunkStart + int(chunkSize)
-
-		if chunkEnd > len(data) {
+		available := len(data) - chunkStart
+		if chunkSize > uint64(available) {
 			// Truncated chunk: take whatever is available.
 			result = append(result, data[chunkStart:]...)
 			break
 		}
+
+		chunkEnd := chunkStart + int(chunkSize)
 
 		result = append(result, data[chunkStart:chunkEnd]...)
 

--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -675,6 +675,12 @@ func TestDechunkBody(t *testing.T) {
 		expected := event1 + event2 + event3[:len(event3)/2]
 		assert.Equal(t, expected, string(got))
 	})
+
+	t.Run("oversized chunk size is treated as truncated", func(t *testing.T) {
+		chunked := "7fffffffffffffff\r\nA"
+		got := dechunkBody([]byte(chunked))
+		assert.Equal(t, "A", string(got))
+	})
 }
 
 func TestHttpSafeParseResponseChunked(t *testing.T) {


### PR DESCRIPTION
### Motivation

- The manual chunked HTTP decoder parsed the chunk size as a signed `int64` and added it to a slice index without checking for overflow, allowing an attacker-controlled large chunk size to cause a runtime panic and crash the agent.

### Description

- Parse the chunk-size line with `strconv.ParseUint` and remove the signed-negative check to avoid incorrect casting.
- Compute `available := len(data) - chunkStart` and treat any `chunkSize` greater than `available` as a truncated chunk before converting to `int` and slicing.
- Add a regression test in `TestDechunkBody` that asserts an oversized advertised chunk (`"7fffffffffffffff\r\nA"`) is treated as truncated and returns the available bytes.

### Testing

- `go test ./pkg/ebpf/common -run 'TestDechunkBody|TestHttpSafeParseResponseChunked'`