### PR TITLE
Export selector route refinements

### DIFF
--- a/internal/config/convert/export_parity.go
+++ b/internal/config/convert/export_parity.go
@@ -394,7 +394,14 @@ func selectorRefinement(action schema.CaptureAction, selector services.Selector)
 	if exports := exportModeRefinement(selector.GetExportModes()); exports != nil {
 		refine.Exports = exports
 	}
-	// TODO(#2251): add a direction-aware v2 route refinement shape for selector routes.
+	if routes := selector.GetRoutesConfig(); routes != nil && (len(routes.Incoming) > 0 || len(routes.Outgoing) > 0) {
+		refine.HTTP = &schema.HTTPRefinement{
+			Routes: schema.HTTPRefinementRoutes{
+				Incoming: schema.HTTPRefinementRoute{Patterns: cloneStrings(routes.Incoming)},
+				Outgoing: schema.HTTPRefinementRoute{Patterns: cloneStrings(routes.Outgoing)},
+			},
+		}
+	}
 	return refine
 }
 

--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -624,7 +624,9 @@ func TestRuntimeToV2AdvancedCaptureParity(t *testing.T) {
 	require.Equal(t, []string{"payments"}, value(t, ext.Capture.Rules[3].Match, "kubernetes", "pod_annotations", "team"))
 	require.NotNil(t, ext.Capture.Rules[3].Refine.Exports)
 	require.Equal(t, schema.ExportModeRefinement{Traces: false, Metrics: true}, *ext.Capture.Rules[3].Refine.Exports)
-	require.Nil(t, ext.Capture.Rules[3].Refine.HTTP)
+	require.NotNil(t, ext.Capture.Rules[3].Refine.HTTP)
+	require.Equal(t, []string{"/orders/{id}"}, ext.Capture.Rules[3].Refine.HTTP.Routes.Incoming.Patterns)
+	require.Equal(t, []string{"/inventory/{id}"}, ext.Capture.Rules[3].Refine.HTTP.Routes.Outgoing.Patterns)
 }
 
 func TestRuntimeToV2EffectiveDiscoveryCriteria(t *testing.T) {


### PR DESCRIPTION
## Summary

- Export per-selector HTTP route overrides into `capture.rules[].refine.http.routes`.
- Preserve incoming and outgoing route patterns using the existing direction-aware config v2 shape.
- Replace the stale #2251 TODO with coverage in the advanced capture parity test.

## Validation

- `go test ./internal/config/convert`
- `go test ./internal/config/...`
- `make check-config-v2-parity`
