### PR TITLE
Fix daemon log format config conversion

### DIFF
--- a/cmd/check-config-v2-parity/main.go
+++ b/cmd/check-config-v2-parity/main.go
@@ -559,7 +559,8 @@ func parityChecks() []parityCheck {
 		{[]string{"prometheus_export", "extra_resource_attributes"}, []string{"obi", "daemon", "telemetry", "metrics", "prometheus", "extra_resource_attributes"}},
 		{[]string{"prometheus_export", "extra_span_resource_attributes"}, []string{"obi", "daemon", "telemetry", "metrics", "prometheus", "extra_span_resource_attributes"}},
 
-		{[]string{"log_config"}, []string{"obi", "daemon", "logging", "format"}},
+		{[]string{"log_config"}, []string{"obi", "daemon", "logging", "config_format"}},
+		{[]string{"log_format"}, []string{"obi", "daemon", "logging", "format"}},
 		{[]string{"log_level"}, []string{"obi", "daemon", "logging", "level"}},
 		{[]string{"trace_printer"}, []string{"obi", "daemon", "logging", "debug_trace_output"}},
 		{[]string{"shutdown_timeout"}, []string{"obi", "daemon", "shutdown", "timeout"}},

--- a/devdocs/config/version-2.0/config-v2.md
+++ b/devdocs/config/version-2.0/config-v2.md
@@ -557,7 +557,7 @@ The name `daemon` was chosen over `process` (too generic), `agent` (overloaded i
 
 `daemon` contains:
 
-- `logging`: OBI process log level, format, and debug trace output mode.
+- `logging`: OBI process log level, format, startup configuration output format, and debug trace output mode.
 - `profiling`: optional pprof endpoint for the OBI process.
 - `shutdown`: graceful shutdown timeout.
 - `internal_metrics`: OBI daemon's own metrics export (Prometheus or OTLP).
@@ -667,7 +667,8 @@ Important mapping notes:
 | `javaagent.debug` | `extensions.obi.capture.runtimes.java.debug.enabled` | Move + rename |
 | `javaagent.debug_instrumentation` | `extensions.obi.capture.runtimes.java.debug.bytecode_instrumentation` | Move + rename |
 | `javaagent.enabled` | `extensions.obi.capture.runtimes.java.enabled` | Simplified to boolean |
-| `log_config` | `extensions.obi.daemon.logging.format` | Move + rename |
+| `log_config` | `extensions.obi.daemon.logging.config_format` | Move + rename |
+| `log_format` | `extensions.obi.daemon.logging.format` | Move + rename |
 | `log_level` | `extensions.obi.daemon.logging.level` | Move |
 | `metrics.features` | `extensions.obi.capture.instrumentation.<protocol>.enabled.metrics` + `extensions.obi.capture.network.capture.enabled` + `extensions.obi.capture.network.stats.{enabled,features}` | Split mapping |
 | `name_resolver.cache_expiry` | `extensions.obi.enrich.service_name.cache.ttl` | Move + rename |

--- a/devdocs/config/version-2.0/examples/default-configuration.yaml
+++ b/devdocs/config/version-2.0/examples/default-configuration.yaml
@@ -678,10 +678,11 @@ extensions:
     # Standalone-mode only: not valid in Collector receiver deployments.
     # In receiver mode the Collector manages these concerns.
     daemon:
-      # Logging behavior and startup config dump.
+      # Logging behavior and startup configuration output.
       logging:
         level: INFO
-        format: ""
+        format: text
+        config_format: ""
         debug_trace_output: disabled
       # Optional profiling endpoint.
       profiling:

--- a/devdocs/config/version-2.0/obi-extension.schema.json
+++ b/devdocs/config/version-2.0/obi-extension.schema.json
@@ -894,7 +894,7 @@
       "properties": {
         "logging": {
           "type": "object",
-          "description": "Logging behavior and debug-output controls.",
+          "description": "Logging behavior, startup configuration output, and debug-output controls.",
           "additionalProperties": false,
           "properties": {
             "level": {
@@ -912,11 +912,21 @@
               "type": "string",
               "enum": [
                 "",
+                "text",
+                "json"
+              ],
+              "default": "text",
+              "description": "OBI log output format.\nValues include: `text`, `json`.\nIf omitted, `text` is used.\n"
+            },
+            "config_format": {
+              "type": "string",
+              "enum": [
+                "",
                 "yaml",
                 "json"
               ],
               "default": "",
-              "description": "Startup configuration log format. Empty string disables startup config logging.\nValues include: `yaml`, `json`.\nIf omitted, empty string is used.\n"
+              "description": "Format used when writing startup configuration to logs. Empty string disables startup configuration logging.\nValues include: `yaml`, `json`.\nIf omitted, empty string is used.\n"
             },
             "debug_trace_output": {
               "type": "string",

--- a/internal/config/convert/export.go
+++ b/internal/config/convert/export.go
@@ -6,6 +6,7 @@ package convert // import "go.opentelemetry.io/obi/internal/config/convert"
 import (
 	"net/url"
 	"strconv"
+	"strings"
 
 	otelconfx "go.opentelemetry.io/contrib/otelconf/x"
 
@@ -680,7 +681,8 @@ func daemon(cfg *obi.Config) *schema.Daemon {
 	return &schema.Daemon{
 		Logging: schema.Logging{
 			Level:            schema.LogLevel(cfg.LogLevel),
-			Format:           schema.LogFormat(cfg.LogConfig),
+			Format:           logFormat(cfg.LogFormat),
+			ConfigFormat:     configFormat(cfg.LogConfig),
 			DebugTraceOutput: cfg.TracePrinter,
 		},
 		Profiling: schema.Profiling{
@@ -709,6 +711,28 @@ func daemon(cfg *obi.Config) *schema.Daemon {
 				},
 			},
 		},
+	}
+}
+
+func logFormat(format obi.LogFormat) schema.LogFormat {
+	switch strings.ToLower(string(format)) {
+	case string(schema.LogFormatJSON):
+		return schema.LogFormatJSON
+	case string(schema.LogFormatText):
+		return schema.LogFormatText
+	default:
+		return schema.LogFormatText
+	}
+}
+
+func configFormat(format obi.LogConfigOption) schema.ConfigFormat {
+	switch format {
+	case obi.LogConfigOptionJSON:
+		return schema.ConfigFormatJSON
+	case obi.LogConfigOptionYAML:
+		return schema.ConfigFormatYAML
+	default:
+		return schema.ConfigFormatUnset
 	}
 }
 

--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -117,6 +117,8 @@ func TestRuntimeToV2DefaultConfig(t *testing.T) {
 	require.Equal(t, 8, value(t, ext.Correlation, "log_trace_annotation", "async_writer", "workers"))
 
 	require.Equal(t, schema.LogLevelInfo, value(t, ext.Daemon, "logging", "level"))
+	require.Equal(t, schema.LogFormatText, value(t, ext.Daemon, "logging", "format"))
+	require.Equal(t, schema.ConfigFormatUnset, value(t, ext.Daemon, "logging", "config_format"))
 	require.Equal(t, debug.TracePrinterDisabled, value(t, ext.Daemon, "logging", "debug_trace_output"))
 	require.Equal(t, schema.Duration(10*time.Second), value(t, ext.Daemon, "shutdown", "timeout"))
 	require.Equal(t, imetrics.InternalMetricsExporterDisabled, value(t, ext.Daemon, "internal_metrics", "exporter"))
@@ -165,7 +167,8 @@ func TestRuntimeToV2CustomConfig(t *testing.T) {
 	cfg.ChannelSendTimeoutPanic = true
 	cfg.EnforceSysCaps = true
 	cfg.LogLevel = obi.LogLevelDebug
-	cfg.LogConfig = obi.LogConfigOptionJSON
+	cfg.LogFormat = obi.LogFormatJSON
+	cfg.LogConfig = obi.LogConfigOptionYAML
 	cfg.TracePrinter = debug.TracePrinterJSON
 	cfg.ShutdownTimeout = 3 * time.Second
 	cfg.ProfilePort = 6060
@@ -423,6 +426,7 @@ func TestRuntimeToV2CustomConfig(t *testing.T) {
 
 	require.Equal(t, schema.LogLevelDebug, value(t, ext.Daemon, "logging", "level"))
 	require.Equal(t, schema.LogFormatJSON, value(t, ext.Daemon, "logging", "format"))
+	require.Equal(t, schema.ConfigFormatYAML, value(t, ext.Daemon, "logging", "config_format"))
 	require.Equal(t, debug.TracePrinterJSON, value(t, ext.Daemon, "logging", "debug_trace_output"))
 	require.Equal(t, 6060, value(t, ext.Daemon, "profiling", "port"))
 	require.Equal(t, schema.Duration(3*time.Second), value(t, ext.Daemon, "shutdown", "timeout"))
@@ -433,6 +437,30 @@ func TestRuntimeToV2CustomConfig(t *testing.T) {
 	require.Equal(t, 918, value(t, ext.Daemon, "telemetry", "metrics", "prometheus", "span_metrics_service_cache_size"))
 	require.Equal(t, []string{"cloud.region"}, value(t, ext.Daemon, "telemetry", "metrics", "prometheus", "extra_resource_attributes"))
 	require.Equal(t, []string{"service.version", "k8s.cluster.name", "deployment.environment"}, value(t, ext.Daemon, "telemetry", "metrics", "prometheus", "extra_span_resource_attributes"))
+}
+
+func TestRuntimeToV2NormalizesLogFormat(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultRuntimeConfig()
+	cfg.LogFormat = obi.LogFormat("JSON")
+
+	_, ext := RuntimeToV2(&cfg)
+
+	require.Equal(t, schema.LogFormatJSON, value(t, ext.Daemon, "logging", "format"))
+}
+
+func TestRuntimeToV2FallsBackOnUnsupportedLogFormats(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultRuntimeConfig()
+	cfg.LogFormat = obi.LogFormat("console")
+	cfg.LogConfig = obi.LogConfigOption("text")
+
+	_, ext := RuntimeToV2(&cfg)
+
+	require.Equal(t, schema.LogFormatText, value(t, ext.Daemon, "logging", "format"))
+	require.Equal(t, schema.ConfigFormatUnset, value(t, ext.Daemon, "logging", "config_format"))
 }
 
 func TestRuntimeToV2AdvancedCaptureParity(t *testing.T) {

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -1539,9 +1539,18 @@ func applyV2Daemon(cfg *obi.Config, daemon *schema.Daemon) {
 
 func applyFullV2Daemon(cfg *obi.Config, daemon schema.Daemon) {
 	if !zeroValue(daemon.Logging) {
-		cfg.LogLevel = obi.LogLevel(daemon.Logging.Level)
-		cfg.LogConfig = obi.LogConfigOption(daemon.Logging.Format)
-		cfg.TracePrinter = daemon.Logging.DebugTraceOutput
+		if daemon.Logging.Level != "" {
+			cfg.LogLevel = obi.LogLevel(daemon.Logging.Level)
+		}
+		if daemon.Logging.Format != "" {
+			cfg.LogFormat = obi.LogFormat(daemon.Logging.Format)
+		}
+		if daemon.Logging.ConfigFormat != "" {
+			cfg.LogConfig = obi.LogConfigOption(daemon.Logging.ConfigFormat)
+		}
+		if daemon.Logging.DebugTraceOutput != "" {
+			cfg.TracePrinter = daemon.Logging.DebugTraceOutput
+		}
 	}
 	if cfg.TracePrinter == "" {
 		cfg.TracePrinter = debug.TracePrinterDisabled
@@ -1567,7 +1576,10 @@ func applyPartialV2Daemon(cfg *obi.Config, daemon schema.Daemon) {
 			cfg.LogLevel = obi.LogLevel(daemon.Logging.Level)
 		}
 		if daemon.Logging.Format != "" {
-			cfg.LogConfig = obi.LogConfigOption(daemon.Logging.Format)
+			cfg.LogFormat = obi.LogFormat(daemon.Logging.Format)
+		}
+		if daemon.Logging.ConfigFormat != "" {
+			cfg.LogConfig = obi.LogConfigOption(daemon.Logging.ConfigFormat)
 		}
 		if daemon.Logging.DebugTraceOutput != "" {
 			cfg.TracePrinter = daemon.Logging.DebugTraceOutput
@@ -1610,10 +1622,26 @@ func applyPartialV2Daemon(cfg *obi.Config, daemon schema.Daemon) {
 }
 
 func completeDaemon(daemon schema.Daemon) bool {
-	return !zeroValue(daemon.Logging) &&
-		!zeroValue(daemon.Shutdown) &&
-		!zeroValue(daemon.InternalMetrics) &&
-		!zeroValue(daemon.Telemetry)
+	return completeDaemonLogging(daemon.Logging) &&
+		!zeroValue(daemon.Shutdown.Timeout) &&
+		completeInternalMetrics(daemon.InternalMetrics) &&
+		completeDaemonTelemetry(daemon.Telemetry)
+}
+
+func completeDaemonLogging(logging schema.Logging) bool {
+	return logging.Level != "" &&
+		logging.Format != "" &&
+		logging.DebugTraceOutput != ""
+}
+
+func completeInternalMetrics(metrics schema.InternalMetrics) bool {
+	return metrics.Exporter != "" &&
+		metrics.Prometheus.Path != "" &&
+		!zeroValue(metrics.BPF.ScrapeInterval)
+}
+
+func completeDaemonTelemetry(telemetry schema.DaemonTelemetry) bool {
+	return telemetry.Metrics.Prometheus.SpanMetricsServiceCacheSize != 0
 }
 
 func applyV2MetricsEnablement(cfg *obi.Config, src *schema.Extension) {

--- a/internal/config/convert/import_test.go
+++ b/internal/config/convert/import_test.go
@@ -46,6 +46,8 @@ func TestV2ToRuntimeDefaultExportFoundation(t *testing.T) {
 	require.Equal(t, obi.DefaultConfig.NodeJS.Enabled, got.NodeJS.Enabled)
 	require.Equal(t, obi.DefaultConfig.Java.Enabled, got.Java.Enabled)
 	require.Equal(t, obi.DefaultConfig.LogLevel, got.LogLevel)
+	require.Equal(t, obi.DefaultConfig.LogFormat, got.LogFormat)
+	require.Equal(t, obi.DefaultConfig.LogConfig, got.LogConfig)
 	require.Equal(t, obi.DefaultConfig.InternalMetrics, got.InternalMetrics)
 	require.Equal(t, export.FeatureApplicationRED, got.Metrics.Features)
 	require.Contains(t, got.Traces.Instrumentations, instrumentations.InstrumentationHTTP)
@@ -183,7 +185,8 @@ func TestV2ToRuntimeCustomFoundation(t *testing.T) {
 	cfg.EBPF.LogEnricher.AsyncWriterChannelLen = 604
 
 	cfg.LogLevel = obi.LogLevelDebug
-	cfg.LogConfig = obi.LogConfigOptionJSON
+	cfg.LogFormat = obi.LogFormatJSON
+	cfg.LogConfig = obi.LogConfigOptionYAML
 	cfg.TracePrinter = debug.TracePrinterJSON
 	cfg.ProfilePort = 6060
 	cfg.ShutdownTimeout = 18 * time.Second
@@ -283,7 +286,8 @@ func TestV2ToRuntimeCustomFoundation(t *testing.T) {
 	require.Equal(t, 604, got.EBPF.LogEnricher.AsyncWriterChannelLen)
 
 	require.Equal(t, obi.LogLevelDebug, got.LogLevel)
-	require.Equal(t, obi.LogConfigOptionJSON, got.LogConfig)
+	require.Equal(t, obi.LogFormatJSON, got.LogFormat)
+	require.Equal(t, obi.LogConfigOptionYAML, got.LogConfig)
 	require.Equal(t, debug.TracePrinterJSON, got.TracePrinter)
 	require.Equal(t, 6060, got.ProfilePort)
 	require.Equal(t, 18*time.Second, got.ShutdownTimeout)
@@ -709,6 +713,27 @@ func TestV2ToRuntimeOmittedCaptureSiblingsPreserveDefaults(t *testing.T) {
 	require.Equal(t, obi.DefaultConfig.Traces.ReportersCacheLen, got.Traces.ReportersCacheLen)
 	require.Equal(t, obi.DefaultConfig.OTELMetrics.ReportersCacheLen, got.OTELMetrics.ReportersCacheLen)
 	require.Equal(t, obi.DefaultConfig.OTELMetrics.TTL, got.OTELMetrics.TTL)
+}
+
+func TestV2ToRuntimeCompleteDaemonOmittedLoggingFieldsPreserveDefaults(t *testing.T) {
+	t.Parallel()
+
+	_, ext := RuntimeToV2(nil)
+	ext.Daemon.Logging = schema.Logging{
+		ConfigFormat: schema.ConfigFormatYAML,
+	}
+	ext.Daemon.Telemetry.Metrics.Prometheus.AllowServiceGraphSelfReferences = true
+	ext.Daemon.Telemetry.Metrics.Prometheus.SpanMetricsServiceCacheSize = 0
+
+	got, err := V2ToRuntime(ext)
+	require.NoError(t, err)
+
+	require.Equal(t, obi.DefaultConfig.LogLevel, got.LogLevel)
+	require.Equal(t, obi.DefaultConfig.LogFormat, got.LogFormat)
+	require.Equal(t, obi.LogConfigOptionYAML, got.LogConfig)
+	require.Equal(t, obi.DefaultConfig.TracePrinter, got.TracePrinter)
+	require.True(t, got.Prometheus.AllowServiceGraphSelfReferences)
+	require.Equal(t, obi.DefaultConfig.Prometheus.SpanMetricsServiceCacheSize, got.Prometheus.SpanMetricsServiceCacheSize)
 }
 
 func TestV2ToRuntimePartialStandaloneSectionsPreserveDefaults(t *testing.T) {

--- a/internal/config/schema/daemon.go
+++ b/internal/config/schema/daemon.go
@@ -44,21 +44,39 @@ type LogFormat string
 const (
 	// LogFormatUnset leaves the default logging format unchanged.
 	LogFormatUnset LogFormat = ""
-	// LogFormatYAML emits YAML-like text logs.
-	LogFormatYAML LogFormat = "yaml"
+	// LogFormatText emits plain text logs.
+	LogFormatText LogFormat = "text"
 	// LogFormatJSON emits JSON logs.
 	LogFormatJSON LogFormat = "json"
 )
 
 // UnmarshalYAML parses and validates a daemon log format.
 func (f *LogFormat) UnmarshalYAML(value *yaml.Node) error {
-	return unmarshalEnum(value, "format", f, LogFormatUnset, LogFormatYAML, LogFormatJSON)
+	return unmarshalEnum(value, "format", f, LogFormatUnset, LogFormatText, LogFormatJSON)
+}
+
+// ConfigFormat describes startup configuration log encoding.
+type ConfigFormat string
+
+const (
+	// ConfigFormatUnset disables startup configuration logging.
+	ConfigFormatUnset ConfigFormat = ""
+	// ConfigFormatYAML emits the startup configuration as YAML.
+	ConfigFormatYAML ConfigFormat = "yaml"
+	// ConfigFormatJSON emits the startup configuration as JSON.
+	ConfigFormatJSON ConfigFormat = "json"
+)
+
+// UnmarshalYAML parses and validates a startup configuration log format.
+func (f *ConfigFormat) UnmarshalYAML(value *yaml.Node) error {
+	return unmarshalEnum(value, "config_format", f, ConfigFormatUnset, ConfigFormatYAML, ConfigFormatJSON)
 }
 
 // Logging describes daemon logging settings.
 type Logging struct {
 	Level            LogLevel           `yaml:"level"`
 	Format           LogFormat          `yaml:"format"`
+	ConfigFormat     ConfigFormat       `yaml:"config_format"`
 	DebugTraceOutput debug.TracePrinter `yaml:"debug_trace_output"`
 }
 

--- a/internal/config/schema/daemon_test.go
+++ b/internal/config/schema/daemon_test.go
@@ -53,7 +53,7 @@ func TestDaemonEnumsYAML(t *testing.T) {
 			name:    "empty log format",
 			valid:   "format: \"\"\n",
 			want:    string(LogFormatUnset),
-			invalid: "format: text\n",
+			invalid: "format: yaml\n",
 			err:     "invalid format",
 			parse: func(data []byte) (string, error) {
 				var doc struct {
@@ -61,6 +61,34 @@ func TestDaemonEnumsYAML(t *testing.T) {
 				}
 				err := yaml.Unmarshal(data, &doc)
 				return string(doc.Format), err
+			},
+		},
+		{
+			name:    "text log format",
+			valid:   "format: text\n",
+			want:    string(LogFormatText),
+			invalid: "format: yaml\n",
+			err:     "invalid format",
+			parse: func(data []byte) (string, error) {
+				var doc struct {
+					Format LogFormat `yaml:"format"`
+				}
+				err := yaml.Unmarshal(data, &doc)
+				return string(doc.Format), err
+			},
+		},
+		{
+			name:    "config format",
+			valid:   "config_format: yaml\n",
+			want:    string(ConfigFormatYAML),
+			invalid: "config_format: text\n",
+			err:     "invalid config_format",
+			parse: func(data []byte) (string, error) {
+				var doc struct {
+					ConfigFormat ConfigFormat `yaml:"config_format"`
+				}
+				err := yaml.Unmarshal(data, &doc)
+				return string(doc.ConfigFormat), err
 			},
 		},
 	}


### PR DESCRIPTION
### Motivation

- The v1-to-v2 conversion was populating `daemon.logging.format` from `LogConfig` instead of `LogFormat`, causing converted configs to lose the intended log output format.
- The change preserves the semantic split where `LogFormat` controls text vs JSON output and `LogConfig` controls startup configuration logging.

### Description

- Export conversion now writes `daemon.logging.format` from `cfg.LogFormat` and maps `cfg.LogConfig` to the shorter `daemon.logging.config_format` field (`internal/config/convert/export.go`).
- Import conversion now maps `daemon.logging.format` and `daemon.logging.config_format` back into the runtime logging settings for both full and partial daemon conversions (`internal/config/convert/import.go`).
- The v2 daemon logging schema accepts `text` and `json` log output formats, plus `yaml` and `json` startup configuration logging formats (`internal/config/schema/daemon.go`).
- Tests, docs, schema artifacts, the parity checker, and the v2 default example were updated to reflect the proper logging mapping and terminology.

### Testing

- `go test ./internal/config/convert ./internal/config/schema`
- `go test ./pkg/ebpf/common`
- `python3 devdocs/config/version-2.0/validate_example.py --config devdocs/config/version-2.0/examples/default-configuration.yaml`
- `make lint-markdown`