### PR TITLE
Check hidden config v2 artifacts

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,6 +15,7 @@ on:
       - "cmd/**"
       - "collector/**"
       - "configs/**"
+      - "devdocs/config/version-2.0/**"
       - "internal/**"
       - "pkg/**"
       - "schemas/**"
@@ -83,7 +84,7 @@ jobs:
         run: make prereqs
 
       - name: Run checks
-        run: make go-mod-tidy license-header-check notices-update check-go-mod check-ebpf-ver-synced check-config-schema check-config-v2-parity check-clean-work-tree
+        run: make go-mod-tidy license-header-check notices-update check-go-mod check-ebpf-ver-synced check-config-schema check-config-v2-artifacts check-clean-work-tree
 
   clang-format:
     name: Clang format

--- a/Makefile
+++ b/Makefile
@@ -902,6 +902,12 @@ regenerate-port-lookup:
 CONFIG_SCHEMA_FILE ?= devdocs/config/config-schema.json
 CONFIG_DOCS_FILE ?= devdocs/config/CONFIG.md
 
+# Hidden pre-release config v2 artifacts. Keep generated/artifact-only updates
+# separate from conversion logic so reviewers can inspect drift intentionally.
+CONFIG_V2_DIR ?= devdocs/config/version-2.0
+CONFIG_V2_SCHEMA_FILE ?= $(CONFIG_V2_DIR)/obi-extension.schema.json
+CONFIG_V2_EXAMPLE_FILE ?= $(CONFIG_V2_DIR)/examples/default-configuration.yaml
+
 .PHONY: generate-config-schema
 generate-config-schema:
 	@echo "### Generating JSON schema for OBI configuration"
@@ -939,4 +945,9 @@ check-config-schema:
 .PHONY: check-config-v2-parity
 check-config-v2-parity:
 	@echo "### Checking config v2 default parity"
-	go run ./cmd/check-config-v2-parity
+	go run ./cmd/check-config-v2-parity -v2-default $(CONFIG_V2_EXAMPLE_FILE)
+
+.PHONY: check-config-v2-artifacts
+check-config-v2-artifacts: check-config-v2-parity
+	@echo "### Checking hidden config v2 artifacts"
+	go run ./cmd/check-config-v2-artifacts -schema $(CONFIG_V2_SCHEMA_FILE) -example $(CONFIG_V2_EXAMPLE_FILE)

--- a/cmd/check-config-v2-artifacts/main.go
+++ b/cmd/check-config-v2-artifacts/main.go
@@ -1,0 +1,145 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"go.opentelemetry.io/obi/internal/config/convert"
+	configschema "go.opentelemetry.io/obi/internal/config/schema"
+)
+
+const (
+	defaultSchemaPath  = "devdocs/config/version-2.0/obi-extension.schema.json"
+	defaultExamplePath = "devdocs/config/version-2.0/examples/default-configuration.yaml"
+)
+
+func run(args []string) error {
+	flags := flag.NewFlagSet("check-config-v2-artifacts", flag.ContinueOnError)
+	schemaPath := flags.String("schema", defaultSchemaPath, "path to the hidden config v2 OBI extension schema")
+	examplePath := flags.String("example", defaultExamplePath, "path to the hidden config v2 default example")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected argument %q", flags.Arg(0))
+	}
+
+	if err := checkSchemaArtifact(*schemaPath); err != nil {
+		return err
+	}
+	if err := checkExampleArtifact(*examplePath); err != nil {
+		return err
+	}
+
+	fmt.Printf("config v2 artifacts verified: %s, %s\n", *schemaPath, *examplePath)
+	return nil
+}
+
+func checkSchemaArtifact(path string) error {
+	root, err := readJSONMap(path)
+	if err != nil {
+		return err
+	}
+
+	if got := stringValue(root, "$schema"); got != "https://json-schema.org/draft/2020-12/schema" {
+		return fmt.Errorf("%s: unexpected $schema %q", path, got)
+	}
+	if got := stringValue(root, "$id"); got == "" {
+		return fmt.Errorf("%s: missing $id", path)
+	}
+	if got := stringValue(root, "title"); got == "" {
+		return fmt.Errorf("%s: missing title", path)
+	}
+	if got := stringValue(root, "type"); got != "object" {
+		return fmt.Errorf("%s: unexpected root type %q", path, got)
+	}
+	if _, ok := mapValue(root, "$defs"); !ok {
+		return fmt.Errorf("%s: missing $defs", path)
+	}
+
+	properties, ok := mapValue(root, "properties")
+	if !ok {
+		return fmt.Errorf("%s: missing properties", path)
+	}
+	version, ok := mapValue(properties, "version")
+	if !ok {
+		return fmt.Errorf("%s: missing properties.version", path)
+	}
+	if got := stringValue(version, "const"); got != configschema.SupportedVersion {
+		return fmt.Errorf("%s: unexpected properties.version.const %q", path, got)
+	}
+
+	return nil
+}
+
+func checkExampleArtifact(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	doc, ext, err := configschema.ParseStandaloneYAML(data)
+	if err != nil {
+		return fmt.Errorf("%s: parse standalone config v2 example: %w", path, err)
+	}
+	if doc == nil || ext == nil {
+		return fmt.Errorf("%s: missing standalone config v2 document or extension", path)
+	}
+	if ext.Version != configschema.SupportedVersion {
+		return fmt.Errorf("%s: unexpected extension version %q", path, ext.Version)
+	}
+	cfg, err := convert.DocumentToRuntime(doc)
+	if err != nil {
+		return fmt.Errorf("%s: import standalone config v2 example: %w", path, err)
+	}
+	if cfg == nil {
+		return fmt.Errorf("%s: imported standalone config v2 example produced nil runtime config", path)
+	}
+
+	return nil
+}
+
+func readJSONMap(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var root map[string]any
+	if err := decoder.Decode(&root); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("parse %s: trailing JSON content", path)
+	}
+	return root, nil
+}
+
+func mapValue(root map[string]any, key string) (map[string]any, bool) {
+	value, ok := root[key].(map[string]any)
+	return value, ok
+}
+
+func stringValue(root map[string]any, key string) string {
+	value, ok := root[key].(string)
+	if !ok {
+		return ""
+	}
+	return value
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/check-config-v2-artifacts/main_test.go
+++ b/cmd/check-config-v2-artifacts/main_test.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunCurrentArtifacts(t *testing.T) {
+	err := run([]string{
+		"-schema", filepath.Join("..", "..", defaultSchemaPath),
+		"-example", filepath.Join("..", "..", defaultExamplePath),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckSchemaArtifactRejectsWrongVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "schema.json")
+	writeFile(t, path, `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opentelemetry.io/obi/schemas/obi-extension.schema.json",
+  "title": "OBI Extension Configuration",
+  "type": "object",
+  "properties": {
+    "version": {
+      "const": "1.0"
+    }
+  },
+  "$defs": {}
+}
+`)
+
+	err := checkSchemaArtifact(path)
+	if err == nil {
+		t.Fatal("expected schema version failure")
+	}
+	if !strings.Contains(err.Error(), "properties.version.const") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCheckExampleArtifactRejectsReceiverShape(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "receiver.yaml")
+	writeFile(t, path, "version: \"2.0\"\ncapture: {}\n")
+
+	err := checkExampleArtifact(path)
+	if err == nil {
+		t.Fatal("expected standalone parser failure")
+	}
+	if !strings.Contains(err.Error(), "missing extensions.obi.version") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func writeFile(t *testing.T, path string, contents string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses step 7 of #2251 by adding hidden config v2 artifact check plumbing without exposing any release binary command or public runtime behavior.

- Add an internal `check-config-v2-artifacts` tool that verifies the local OBI extension schema marker/version and proves the default v2 example parses as standalone config and imports to runtime config.
- Add `make check-config-v2-artifacts`, which runs the existing default parity checker before artifact validation.
- Wire PR hygiene CI to the consolidated target and include `devdocs/config/version-2.0/**` in the workflow path filter so artifact-only changes run the same checks.

## Validation

- [x] `go test ./cmd/check-config-v2-artifacts ./cmd/check-config-v2-parity`
- [x] `make check-config-v2-artifacts`
- [x] `go test ./internal/config/...`
- [x] `python3 devdocs/config/version-2.0/validate_example.py --skip-otel`
