### PR TITLE
Weaver: document undocumented produced attributes + violate on extends_namespace

### DIFF
--- a/internal/test/integration/weaver.go
+++ b/internal/test/integration/weaver.go
@@ -65,7 +65,7 @@ var weaverIgnoredAdviceMessages = map[string]struct{}{
 	"Namespace 'iface' collides with existing attribute 'iface.direction'": {},
 }
 
-// actionableAdviceTypes lists the weaver `advice_type` values OBI treats as
+// actionableAdviceTypes lists the weaver finding-type values OBI treats as
 // failures in addition to `violation`-level advice. Hoisted here (rather than
 // matched as an inline string literal) so the coupling to weaver's advice-type
 // vocabulary lives in one documented place and is easy to extend.
@@ -114,7 +114,7 @@ type weaverStatistics struct {
 type weaverAdvice struct {
 	Message    string `json:"message"`
 	Level      string `json:"level"`
-	AdviceType string `json:"advice_type"`
+	AdviceType string `json:"id"`
 	SignalType string `json:"signal_type"`
 	SignalName string `json:"signal_name"`
 }

--- a/internal/test/integration/weaver.go
+++ b/internal/test/integration/weaver.go
@@ -65,6 +65,24 @@ var weaverIgnoredAdviceMessages = map[string]struct{}{
 	"Namespace 'iface' collides with existing attribute 'iface.direction'": {},
 }
 
+// actionableAdviceTypes lists the weaver `advice_type` values OBI treats as
+// failures in addition to `violation`-level advice. Hoisted here (rather than
+// matched as an inline string literal) so the coupling to weaver's advice-type
+// vocabulary lives in one documented place and is easy to extend.
+//
+//   - "extends_namespace": an attribute emitted under an existing semconv
+//     namespace but declared in no registry (upstream semconv or
+//     `schemas/obi/`). Weaver classifies these as `information`-level, so
+//     without this they would silently pass; OBI requires every emitted
+//     attribute to be declared.
+//
+// NOTE: these strings come from weaver's rego policy output. If a weaver
+// version bump renames them, enforcement silently weakens — re-verify when
+// bumping the pinned weaver image.
+var actionableAdviceTypes = map[string]struct{}{
+	"extends_namespace": {},
+}
+
 func SemconvVersion() string {
 	// semconv.SchemaURL is "https://opentelemetry.io/schemas/1.41.0"
 	return semconv.SchemaURL[strings.LastIndex(semconv.SchemaURL, "/")+1:]
@@ -96,6 +114,7 @@ type weaverStatistics struct {
 type weaverAdvice struct {
 	Message    string `json:"message"`
 	Level      string `json:"level"`
+	AdviceType string `json:"advice_type"`
 	SignalType string `json:"signal_type"`
 	SignalName string `json:"signal_name"`
 }
@@ -105,8 +124,9 @@ type weaverLiveCheckResult struct {
 }
 
 type adviceInfo struct {
-	Level   string
-	Signals map[string]struct{} // set of "signal_type:signal_name"
+	Level      string
+	AdviceType string
+	Signals    map[string]struct{} // set of "signal_type:signal_name"
 }
 
 // runWeaverValidation stops the weaver container (which runs as a service in
@@ -232,8 +252,10 @@ func validateWeaverReport(t *testing.T, report *weaverReport) {
 	adviceByMsg := collectAdviceInfo(report.Samples)
 
 	// Log all advisory messages grouped by level, and count actionable
-	// violations (excluding signals listed in weaverIgnoredSignals).
-	var actionableViolations int
+	// advisories: advice that is `violation`-level OR whose advice_type is in
+	// actionableAdviceTypes (e.g. extends_namespace), after applying the ignore
+	// lists.
+	var actionableAdvisories int
 	t.Logf("  advisory details:")
 	for _, level := range []string{"violation", "improvement", "information"} {
 		for msg, count := range stats.AdviceMessageCounts {
@@ -250,7 +272,7 @@ func validateWeaverReport(t *testing.T, report *weaverReport) {
 				}
 				t.Logf("    [%s] [%dx] %s (signals: unknown)%s", level, count, msg, suffix)
 				if !msgIgnored {
-					actionableViolations += count
+					actionableAdvisories += count
 				}
 				continue
 			}
@@ -259,22 +281,24 @@ func validateWeaverReport(t *testing.T, report *weaverReport) {
 			}
 			signals := sortedSignals(info.Signals)
 			ignored := msgIgnored || allSignalsIgnored(info.Signals)
+			_, typeActionable := actionableAdviceTypes[info.AdviceType]
 			suffix := ""
 			if ignored {
 				suffix = " [ignored]"
 			}
 			t.Logf("    [%s] [%dx] %s (signals: %s)%s", level, count, msg, strings.Join(signals, ", "), suffix)
-			if level == "violation" && !ignored {
-				actionableViolations += count
+			if (level == "violation" || typeActionable) && !ignored {
+				actionableAdvisories += count
 			}
 		}
 	}
 
-	t.Logf("  violations: %d total, %d actionable (after ignoring %v)",
-		violations, actionableViolations, sortedSignals(weaverIgnoredSignals))
+	t.Logf("  advisories: %d violation(s), %d actionable (after ignoring %v)",
+		violations, actionableAdvisories, sortedSignals(weaverIgnoredSignals))
 
-	assert.Zero(t, actionableViolations,
-		"weaver found %d actionable semantic convention violation(s)", actionableViolations)
+	assert.Zero(t, actionableAdvisories,
+		"weaver found %d actionable semantic convention advisory(ies) "+
+			"(violations or undeclared attributes under existing semconv namespaces)", actionableAdvisories)
 }
 
 // collectAdviceInfo scans all weaver samples to build a complete map from
@@ -309,8 +333,9 @@ func extractAdviceInfo(data json.RawMessage, result map[string]*adviceInfo) {
 					info, exists := result[a.Message]
 					if !exists {
 						info = &adviceInfo{
-							Level:   a.Level,
-							Signals: make(map[string]struct{}),
+							Level:      a.Level,
+							AdviceType: a.AdviceType,
+							Signals:    make(map[string]struct{}),
 						}
 						result[a.Message] = info
 					}

--- a/schemas/obi/groups/traces.yaml
+++ b/schemas/obi/groups/traces.yaml
@@ -1,0 +1,35 @@
+groups:
+  - id: registry.obi.traces
+    type: attribute_group
+    display_name: OBI Application Span Attributes
+    brief: >
+      Attributes OBI emits on application spans that are not part of upstream
+      OpenTelemetry semantic conventions — captured HTTP request/response
+      bodies and ONC/Sun RPC auth flavor. Attributes already defined by
+      upstream semconv (`http.*`, …) are not redeclared here.
+    attributes:
+      - id: http.request.body.content
+        type: string
+        stability: development
+        brief: >
+          Captured HTTP request body content. Only populated when OBI's body
+          capture is enabled and subject to OBI's body-extraction rules
+          (size limits, content-type filtering, obfuscation).
+        examples: ['{"user":"alice"}']
+      - id: http.response.body.content
+        type: string
+        stability: development
+        brief: >
+          Captured HTTP response body content. Only populated when OBI's body
+          capture is enabled and subject to OBI's body-extraction rules
+          (size limits, content-type filtering, obfuscation).
+        examples: ['{"status":"ok"}']
+      - id: onc_rpc.auth.flavor
+        type: string
+        stability: development
+        brief: ONC/Sun RPC authentication flavor observed on the call.
+        note: >
+          OBI extension attribute, emitted on Sun RPC spans until upstream
+          semconv adds an official ONC RPC auth flavor attribute, at which
+          point this key will be migrated to the semconv name.
+        examples: ["AUTH_NONE", "AUTH_SYS"]

--- a/schemas/obi/groups/traces.yaml
+++ b/schemas/obi/groups/traces.yaml
@@ -15,6 +15,12 @@ groups:
           Captured HTTP request body content. Only populated when OBI's body
           capture is enabled and subject to OBI's body-extraction rules
           (size limits, content-type filtering, obfuscation).
+        note: >
+          Tracks the upstream semantic-conventions proposal
+          https://github.com/open-telemetry/semantic-conventions/pull/3521
+          ("add http.{request,response}.body.content"). Declared in the OBI
+          registry until that proposal is merged and released, at which point
+          this attribute moves to upstream semconv.
         examples: ['{"user":"alice"}']
       - id: http.response.body.content
         type: string
@@ -23,6 +29,12 @@ groups:
           Captured HTTP response body content. Only populated when OBI's body
           capture is enabled and subject to OBI's body-extraction rules
           (size limits, content-type filtering, obfuscation).
+        note: >
+          Tracks the upstream semantic-conventions proposal
+          https://github.com/open-telemetry/semantic-conventions/pull/3521
+          ("add http.{request,response}.body.content"). Declared in the OBI
+          registry until that proposal is merged and released, at which point
+          this attribute moves to upstream semconv.
         examples: ['{"status":"ok"}']
       - id: onc_rpc.auth.flavor
         type: string


### PR DESCRIPTION
## Summary

OBI produces a few attributes which are not part of the semconv. weaver does not take it as a violation since its under a known namespace. this both fixes this and adds `extends_namespace` advisories to produce weaver errors. and adds the undocumented attributes to OBIs schema registry

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
