### PR TITLE
feat: add Gemini SSE streaming response parsing

### DIFF
--- a/pkg/ebpf/common/http/gemini.go
+++ b/pkg/ebpf/common/http/gemini.go
@@ -4,6 +4,7 @@
 package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
 
 import (
+	"bytes"
 	"encoding/json"
 	"log/slog"
 	"net"
@@ -128,14 +129,25 @@ func GeminiSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 	}
 
 	var parsedResponse request.GeminiResponse
-	if !unmarshalJSON(respB, &parsedResponse) {
-		slog.Debug("failed to parse Gemini response, continuing with partial fields")
+	var toolCalls []request.ToolCall
+
+	if looksLikeJSON(respB) {
+		if !unmarshalJSON(respB, &parsedResponse) {
+			slog.Debug("failed to parse Gemini response, continuing with partial fields")
+		}
+		toolCalls = extractGeminiFunctionCalls(&parsedResponse)
+	} else {
+		reader := bytes.NewReader(respB)
+		streamResp, streamTools := parseGeminiStream(reader)
+		if streamResp != nil {
+			parsedResponse = *streamResp
+		}
+		toolCalls = streamTools
 	}
 
 	model := extractGeminiModel(req)
 	operation := extractGeminiOperation(req)
 	isStream := isGeminiStream(req)
-	toolCalls := extractGeminiFunctionCalls(&parsedResponse)
 
 	baseSpan.SubType = request.HTTPSubtypeGemini
 	baseSpan.GenAI = &request.GenAI{

--- a/pkg/ebpf/common/http/gemini_stream.go
+++ b/pkg/ebpf/common/http/gemini_stream.go
@@ -36,7 +36,9 @@ type geminiStreamContent struct {
 }
 
 type geminiTextPart struct {
-	Text string `json:"text"`
+	Text             string `json:"text"`
+	Thought          bool   `json:"thought,omitempty"`
+	ThoughtSignature string `json:"thoughtSignature,omitempty"`
 }
 
 type geminiFunctionCallPart struct {
@@ -44,15 +46,33 @@ type geminiFunctionCallPart struct {
 }
 
 type geminiFunctionCallData struct {
-	Name string          `json:"name"`
-	Args json.RawMessage `json:"args,omitempty"`
+	Name         string          `json:"name"`
+	Args         json.RawMessage `json:"args,omitempty"`
+	PartialArgs  string          `json:"partialArgs,omitempty"`
+	WillContinue *bool           `json:"willContinue,omitempty"`
+}
+
+// geminiStreamError represents a bare error envelope that Gemini may send on
+// an HTTP 200 stream (as observed by the official Go client).
+type geminiStreamError struct {
+	Error *request.GeminiError `json:"error"`
 }
 
 // candidatePart is a single ordered part in a candidate's content.
-// Either text is non-empty (text part) or fcRaw is non-nil (function-call part).
+// Either textBuilder is non-nil (text part) or fcRaw is non-nil (function-call part).
 type candidatePart struct {
-	text  string
-	fcRaw json.RawMessage
+	textBuilder *strings.Builder
+	thought     bool
+	fcRaw       json.RawMessage
+}
+
+// fcAggregator accumulates streaming function call arguments for Vertex AI's
+// streamFunctionCallArguments feature where args arrive across multiple chunks.
+type fcAggregator struct {
+	name       string
+	argsAccum  strings.Builder
+	hasFullArg bool            // true if args came as a complete JSON object
+	fullArg    json.RawMessage // stored when args is a complete JSON object
 }
 
 // candidateAggregator accumulates streamed parts for a single candidate
@@ -60,6 +80,56 @@ type candidatePart struct {
 type candidateAggregator struct {
 	parts        []candidatePart
 	finishReason string
+	// activeFC tracks a function call being built across multiple stream chunks
+	// (Vertex AI streamFunctionCallArguments).
+	activeFC *fcAggregator
+}
+
+// flushActiveFC finalizes any in-progress function call aggregation and
+// appends the result to the candidate's parts list. Returns the function
+// call name for toolCalls tracking (empty if nothing was flushed).
+func (ca *candidateAggregator) flushActiveFC() string {
+	if ca.activeFC == nil {
+		return ""
+	}
+	fc := ca.activeFC
+	ca.activeFC = nil
+
+	if fc.name == "" {
+		return ""
+	}
+
+	var raw json.RawMessage
+	if fc.hasFullArg {
+		// Complete args arrived as a JSON object.
+		raw = buildFunctionCallRaw(fc.name, fc.fullArg)
+	} else if fc.argsAccum.Len() > 0 {
+		// Partial args were accumulated as string fragments.
+		raw = buildFunctionCallRaw(fc.name, json.RawMessage(fc.argsAccum.String()))
+	} else {
+		// Name-only function call with no args.
+		raw = buildFunctionCallRaw(fc.name, nil)
+	}
+
+	ca.parts = append(ca.parts, candidatePart{fcRaw: raw})
+	return fc.name
+}
+
+// buildFunctionCallRaw constructs the raw JSON for a function call part.
+func buildFunctionCallRaw(name string, args json.RawMessage) json.RawMessage {
+	type fcData struct {
+		Name string          `json:"name"`
+		Args json.RawMessage `json:"args,omitempty"`
+	}
+	type fcWrapper struct {
+		FunctionCall fcData `json:"functionCall"`
+	}
+	w := fcWrapper{FunctionCall: fcData{Name: name, Args: args}}
+	raw, err := json.Marshal(w)
+	if err != nil {
+		return nil
+	}
+	return raw
 }
 
 // parseGeminiStream parses the SSE stream from Gemini APIs and returns
@@ -69,6 +139,10 @@ type candidateAggregator struct {
 // intentionally only support this observed single-line framing
 // (consistent with the OpenAI SSE parser) rather than the full
 // multi-line SSE spec.
+//
+// Error handling: bare {"error": ...} records on an HTTP 200 stream
+// are treated as API errors (consistent with the official Google Gen AI
+// Go client behavior).
 func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.ToolCall) {
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 0, 256*1024), 256*1024)
@@ -78,12 +152,17 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 	var modelVersion string
 	var responseID string
 	var usage *request.GeminiUsage
+	var streamError *request.GeminiError
 
 	for scanner.Scan() {
 		line := scanner.Text()
 
 		data, ok := extractSSEData(line)
 		if !ok {
+			// Check for bare error envelope (not wrapped in "data:" prefix).
+			if err := tryParseErrorLine(line); err != nil {
+				streamError = err
+			}
 			continue
 		}
 
@@ -91,6 +170,14 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
 			slog.Debug("parseGeminiStream: failed to parse chunk", "error", err)
 			continue
+		}
+
+		// Check if this data line is itself an error envelope.
+		if chunk.Candidates == nil && chunk.UsageMetadata == nil {
+			if err := tryParseErrorLine(data); err != nil {
+				streamError = err
+				continue
+			}
 		}
 
 		if chunk.ModelVersion != "" {
@@ -124,22 +211,26 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 			for _, rawPart := range c.Content.Parts {
 				var textPart geminiTextPart
 				if err := json.Unmarshal(rawPart, &textPart); err == nil && textPart.Text != "" {
-					if n := len(agg.parts); n > 0 && agg.parts[n-1].fcRaw == nil {
-						agg.parts[n-1].text += textPart.Text
-					} else {
-						agg.parts = append(agg.parts, candidatePart{text: textPart.Text})
+					// Flush any active function call before appending text.
+					if name := agg.flushActiveFC(); name != "" {
+						toolCalls = append(toolCalls, request.ToolCall{Name: name})
 					}
+					appendTextPart(agg, textPart)
 					continue
 				}
 
 				var fcPart geminiFunctionCallPart
-				if err := json.Unmarshal(rawPart, &fcPart); err == nil && fcPart.FunctionCall != nil && fcPart.FunctionCall.Name != "" {
-					toolCalls = append(toolCalls, request.ToolCall{
-						Name: fcPart.FunctionCall.Name,
-					})
-					agg.parts = append(agg.parts, candidatePart{fcRaw: rawPart})
+				if err := json.Unmarshal(rawPart, &fcPart); err == nil && fcPart.FunctionCall != nil {
+					processFunctionCallPart(agg, fcPart.FunctionCall, &toolCalls)
 				}
 			}
+		}
+	}
+
+	// Flush any remaining active function calls.
+	for _, agg := range candidates {
+		if name := agg.flushActiveFC(); name != "" {
+			toolCalls = append(toolCalls, request.ToolCall{Name: name})
 		}
 	}
 
@@ -155,10 +246,108 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 	if usage != nil {
 		resp.UsageMetadata = *usage
 	}
+	if streamError != nil {
+		resp.Error = streamError
+	}
 
 	resp.Candidates = buildGeminiCandidates(candidates)
 
 	return resp, toolCalls
+}
+
+// appendTextPart adds a text fragment to the candidate aggregator, coalescing
+// only with the previous part when both are text parts with equivalent metadata
+// (thought flag). Uses strings.Builder for efficient concatenation.
+func appendTextPart(agg *candidateAggregator, tp geminiTextPart) {
+	n := len(agg.parts)
+	// Coalesce with previous text part only if metadata (thought) matches.
+	if n > 0 && agg.parts[n-1].textBuilder != nil && agg.parts[n-1].thought == tp.Thought {
+		agg.parts[n-1].textBuilder.WriteString(tp.Text)
+		return
+	}
+	b := &strings.Builder{}
+	b.WriteString(tp.Text)
+	agg.parts = append(agg.parts, candidatePart{
+		textBuilder: b,
+		thought:     tp.Thought,
+	})
+}
+
+// processFunctionCallPart handles a function call part, supporting both
+// complete single-chunk calls and Vertex AI's streaming function call
+// arguments where the name arrives first and args follow in subsequent chunks.
+func processFunctionCallPart(agg *candidateAggregator, fc *geminiFunctionCallData, toolCalls *[]request.ToolCall) {
+	if fc.Name != "" {
+		// New named function call: flush any previous active FC.
+		if name := agg.flushActiveFC(); name != "" {
+			*toolCalls = append(*toolCalls, request.ToolCall{Name: name})
+		}
+
+		// If the call has complete args and no continuation, store directly.
+		if len(fc.Args) > 0 && fc.PartialArgs == "" {
+			agg.activeFC = &fcAggregator{
+				name:       fc.Name,
+				hasFullArg: true,
+				fullArg:    fc.Args,
+			}
+			// If willContinue is nil or false, this is a complete call.
+			if fc.WillContinue == nil || !*fc.WillContinue {
+				if name := agg.flushActiveFC(); name != "" {
+					*toolCalls = append(*toolCalls, request.ToolCall{Name: name})
+				}
+			}
+			return
+		}
+
+		// Start aggregation (name only, or name with partial args).
+		agg.activeFC = &fcAggregator{name: fc.Name}
+		if fc.PartialArgs != "" {
+			agg.activeFC.argsAccum.WriteString(fc.PartialArgs)
+		}
+
+		// If no continuation expected and no partial args, flush immediately.
+		if fc.WillContinue == nil && fc.PartialArgs == "" && len(fc.Args) == 0 {
+			if name := agg.flushActiveFC(); name != "" {
+				*toolCalls = append(*toolCalls, request.ToolCall{Name: name})
+			}
+		}
+		return
+	}
+
+	// Continuation fragment (no name): append to active function call.
+	if agg.activeFC == nil {
+		return
+	}
+	if fc.PartialArgs != "" {
+		agg.activeFC.argsAccum.WriteString(fc.PartialArgs)
+	} else if len(fc.Args) > 0 {
+		// Args as JSON in continuation.
+		agg.activeFC.argsAccum.Write(fc.Args)
+	}
+
+	// If willContinue is explicitly false or absent, the call is complete.
+	if fc.WillContinue == nil || !*fc.WillContinue {
+		if name := agg.flushActiveFC(); name != "" {
+			*toolCalls = append(*toolCalls, request.ToolCall{Name: name})
+		}
+	}
+}
+
+// tryParseErrorLine attempts to parse a line as a bare Gemini error envelope.
+// Returns the error if found, nil otherwise.
+func tryParseErrorLine(line string) *request.GeminiError {
+	line = strings.TrimSpace(line)
+	if line == "" || line[0] != '{' {
+		return nil
+	}
+	var envelope geminiStreamError
+	if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+		return nil
+	}
+	if envelope.Error != nil && (envelope.Error.Code != 0 || envelope.Error.Status != "" || envelope.Error.Message != "") {
+		return envelope.Error
+	}
+	return nil
 }
 
 // extractSSEData extracts the JSON payload from an SSE data line.
@@ -209,14 +398,10 @@ func buildGeminiCandidates(aggs map[int]*candidateAggregator) []request.GeminiCa
 
 // buildGeminiStreamParts constructs the parts JSON from ordered candidate
 // parts, preserving the original text/function-call ordering and coalescing
-// only adjacent text fragments.
+// only adjacent text fragments with equivalent metadata (thought flag).
 func buildGeminiStreamParts(parts []candidatePart) json.RawMessage {
 	if len(parts) == 0 {
 		return nil
-	}
-
-	type textPartJSON struct {
-		Text string `json:"text"`
 	}
 
 	var rawParts []json.RawMessage
@@ -225,9 +410,9 @@ func buildGeminiStreamParts(parts []candidatePart) json.RawMessage {
 			rawParts = append(rawParts, p.fcRaw)
 			continue
 		}
-		if p.text != "" {
-			raw, err := json.Marshal(textPartJSON{Text: p.text})
-			if err == nil {
+		if p.textBuilder != nil && p.textBuilder.Len() > 0 {
+			raw := marshalTextPart(p.textBuilder.String(), p.thought)
+			if raw != nil {
 				rawParts = append(rawParts, raw)
 			}
 		}
@@ -238,6 +423,29 @@ func buildGeminiStreamParts(parts []candidatePart) json.RawMessage {
 	}
 
 	raw, err := json.Marshal(rawParts)
+	if err != nil {
+		return nil
+	}
+	return raw
+}
+
+// marshalTextPart marshals a text part, including thought metadata if present.
+func marshalTextPart(text string, thought bool) json.RawMessage {
+	if thought {
+		type thoughtPartJSON struct {
+			Text    string `json:"text"`
+			Thought bool   `json:"thought"`
+		}
+		raw, err := json.Marshal(thoughtPartJSON{Text: text, Thought: true})
+		if err != nil {
+			return nil
+		}
+		return raw
+	}
+	type textPartJSON struct {
+		Text string `json:"text"`
+	}
+	raw, err := json.Marshal(textPartJSON{Text: text})
 	if err != nil {
 		return nil
 	}

--- a/pkg/ebpf/common/http/gemini_stream.go
+++ b/pkg/ebpf/common/http/gemini_stream.go
@@ -25,9 +25,10 @@ type geminiStreamChunk struct {
 }
 
 type geminiStreamCandidate struct {
-	Index        int                  `json:"index"`
-	Content      *geminiStreamContent `json:"content"`
-	FinishReason string               `json:"finishReason"`
+	Index         int                  `json:"index"`
+	Content       *geminiStreamContent `json:"content"`
+	FinishReason  string               `json:"finishReason"`
+	SafetyRatings json.RawMessage      `json:"safetyRatings,omitempty"`
 }
 
 type geminiStreamContent struct {
@@ -35,20 +36,27 @@ type geminiStreamContent struct {
 	Role  string            `json:"role"`
 }
 
-type geminiTextPart struct {
-	Text             string `json:"text"`
-	Thought          bool   `json:"thought,omitempty"`
-	ThoughtSignature string `json:"thoughtSignature,omitempty"`
-}
-
-type geminiFunctionCallPart struct {
-	FunctionCall *geminiFunctionCallData `json:"functionCall"`
+// geminiStreamPart is a unified view of a single streamed content part. A part
+// is either a text part (optionally a thought summary, optionally carrying a
+// thoughtSignature) or a function-call part. The outer thoughtSignature applies
+// to whichever kind the part is.
+type geminiStreamPart struct {
+	Text             string                  `json:"text"`
+	Thought          bool                    `json:"thought"`
+	ThoughtSignature string                  `json:"thoughtSignature"`
+	FunctionCall     *geminiFunctionCallData `json:"functionCall"`
 }
 
 type geminiFunctionCallData struct {
-	Name         string          `json:"name"`
-	Args         json.RawMessage `json:"args,omitempty"`
-	PartialArgs  string          `json:"partialArgs,omitempty"`
+	Name string          `json:"name"`
+	Args json.RawMessage `json:"args,omitempty"`
+	// PartialArgs is intentionally a RawMessage because Vertex AI's
+	// streamFunctionCallArguments feature sends it as an array of
+	// {jsonPath, <typed value>} objects, while some observations use a plain
+	// string fragment. Decoding into a concrete type would fail on the array
+	// shape and drop the whole part, so we keep it raw and interpret it in
+	// addPartialArgs.
+	PartialArgs  json.RawMessage `json:"partialArgs,omitempty"`
 	WillContinue *bool           `json:"willContinue,omitempty"`
 }
 
@@ -63,16 +71,103 @@ type geminiStreamError struct {
 type candidatePart struct {
 	textBuilder *strings.Builder
 	thought     bool
-	fcRaw       json.RawMessage
+	// signature holds the part's thoughtSignature. Signed parts must remain
+	// distinct (Gemini requires signatures to stay on their exact parts and
+	// says signed parts must not be merged).
+	signature string
+	fcRaw     json.RawMessage
 }
 
 // fcAggregator accumulates streaming function call arguments for Vertex AI's
 // streamFunctionCallArguments feature where args arrive across multiple chunks.
 type fcAggregator struct {
-	name       string
-	argsAccum  strings.Builder
+	name      string
+	signature string
+	// argsAccum accumulates string-fragment style partial args (legacy shape).
+	argsAccum strings.Builder
+	// argsObj reconstructs args from Vertex AI's {jsonPath, value} partialArgs
+	// array elements.
+	argsObj    map[string]any
 	hasFullArg bool            // true if args came as a complete JSON object
 	fullArg    json.RawMessage // stored when args is a complete JSON object
+}
+
+// addPartialArgs interprets a raw partialArgs value, supporting both the
+// Vertex AI array-of-objects shape ([{jsonPath, <typed value>}, ...]) and the
+// plain string-fragment shape. Unknown shapes are ignored rather than fatal.
+func (fc *fcAggregator) addPartialArgs(raw json.RawMessage) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" {
+		return
+	}
+	switch trimmed[0] {
+	case '"':
+		// String-fragment shape: concatenate the decoded fragment.
+		var frag string
+		if err := json.Unmarshal(raw, &frag); err == nil {
+			fc.argsAccum.WriteString(frag)
+		}
+	case '[':
+		// Vertex AI array shape: each element carries a jsonPath and a typed
+		// value. Reconstruct the args object from paths and values.
+		var elems []map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &elems); err != nil {
+			return
+		}
+		if fc.argsObj == nil {
+			fc.argsObj = map[string]any{}
+		}
+		for _, elem := range elems {
+			pathRaw, ok := elem["jsonPath"]
+			if !ok {
+				continue
+			}
+			var path string
+			if err := json.Unmarshal(pathRaw, &path); err != nil {
+				continue
+			}
+			// The value is carried in the first non-jsonPath field. This is
+			// robust to the exact typed-value key (stringValue, numberValue,
+			// value, ...) since we keep the raw JSON value verbatim.
+			var value any
+			for k, v := range elem {
+				if k == "jsonPath" {
+					continue
+				}
+				_ = json.Unmarshal(v, &value)
+				break
+			}
+			setByJSONPath(fc.argsObj, path, value)
+		}
+	}
+}
+
+// setByJSONPath assigns value at a simple dotted JSON path (e.g. "$.a.b") into
+// the target map, creating intermediate objects as needed. Array indices and
+// complex expressions are not supported and are skipped.
+func setByJSONPath(m map[string]any, path string, value any) {
+	path = strings.TrimPrefix(path, "$")
+	path = strings.TrimPrefix(path, ".")
+	if path == "" {
+		return
+	}
+	keys := strings.Split(path, ".")
+	cur := m
+	for i, k := range keys {
+		if k == "" {
+			return
+		}
+		if i == len(keys)-1 {
+			cur[k] = value
+			return
+		}
+		next, ok := cur[k].(map[string]any)
+		if !ok {
+			next = map[string]any{}
+			cur[k] = next
+		}
+		cur = next
+	}
 }
 
 // candidateAggregator accumulates streamed parts for a single candidate
@@ -80,6 +175,9 @@ type fcAggregator struct {
 type candidateAggregator struct {
 	parts        []candidatePart
 	finishReason string
+	// safetyRatings preserves the raw safetyRatings block from the stream,
+	// consistent with the non-streaming GeminiCandidate.SafetyRatings field.
+	safetyRatings json.RawMessage
 	// activeFC tracks a function call being built across multiple stream chunks
 	// (Vertex AI streamFunctionCallArguments).
 	activeFC *fcAggregator
@@ -103,29 +201,38 @@ func (ca *candidateAggregator) flushActiveFC() string {
 	switch {
 	case fc.hasFullArg:
 		// Complete args arrived as a JSON object.
-		raw = buildFunctionCallRaw(fc.name, fc.fullArg)
+		raw = buildFunctionCallRaw(fc.name, fc.fullArg, fc.signature)
+	case len(fc.argsObj) > 0:
+		// Args reconstructed from Vertex AI partialArgs array elements.
+		if b, err := json.Marshal(fc.argsObj); err == nil {
+			raw = buildFunctionCallRaw(fc.name, b, fc.signature)
+		} else {
+			raw = buildFunctionCallRaw(fc.name, nil, fc.signature)
+		}
 	case fc.argsAccum.Len() > 0:
 		// Partial args were accumulated as string fragments.
-		raw = buildFunctionCallRaw(fc.name, json.RawMessage(fc.argsAccum.String()))
+		raw = buildFunctionCallRaw(fc.name, json.RawMessage(fc.argsAccum.String()), fc.signature)
 	default:
 		// Name-only function call with no args.
-		raw = buildFunctionCallRaw(fc.name, nil)
+		raw = buildFunctionCallRaw(fc.name, nil, fc.signature)
 	}
 
 	ca.parts = append(ca.parts, candidatePart{fcRaw: raw})
 	return fc.name
 }
 
-// buildFunctionCallRaw constructs the raw JSON for a function call part.
-func buildFunctionCallRaw(name string, args json.RawMessage) json.RawMessage {
+// buildFunctionCallRaw constructs the raw JSON for a function call part,
+// preserving the outer thoughtSignature when present.
+func buildFunctionCallRaw(name string, args json.RawMessage, signature string) json.RawMessage {
 	type fcData struct {
 		Name string          `json:"name"`
 		Args json.RawMessage `json:"args,omitempty"`
 	}
 	type fcWrapper struct {
-		FunctionCall fcData `json:"functionCall"`
+		FunctionCall     fcData `json:"functionCall"`
+		ThoughtSignature string `json:"thoughtSignature,omitempty"`
 	}
-	w := fcWrapper{FunctionCall: fcData{Name: name, Args: args}}
+	w := fcWrapper{FunctionCall: fcData{Name: name, Args: args}, ThoughtSignature: signature}
 	raw, err := json.Marshal(w)
 	if err != nil {
 		return nil
@@ -205,24 +312,33 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 			if c.FinishReason != "" {
 				agg.finishReason = c.FinishReason
 			}
+			if len(c.SafetyRatings) > 0 {
+				agg.safetyRatings = c.SafetyRatings
+			}
 			if c.Content == nil {
 				continue
 			}
 
 			for _, rawPart := range c.Content.Parts {
-				var textPart geminiTextPart
-				if err := json.Unmarshal(rawPart, &textPart); err == nil && textPart.Text != "" {
+				var part geminiStreamPart
+				if err := json.Unmarshal(rawPart, &part); err != nil {
+					slog.Debug("parseGeminiStream: failed to parse part", "error", err)
+					continue
+				}
+
+				if part.FunctionCall != nil {
+					processFunctionCallPart(agg, part.FunctionCall, part.ThoughtSignature, &toolCalls)
+					continue
+				}
+
+				// Text part, including signature-only parts (empty text with a
+				// thoughtSignature) that must be preserved.
+				if part.Text != "" || part.ThoughtSignature != "" {
 					// Flush any active function call before appending text.
 					if name := agg.flushActiveFC(); name != "" {
 						toolCalls = append(toolCalls, request.ToolCall{Name: name})
 					}
-					appendTextPart(agg, textPart)
-					continue
-				}
-
-				var fcPart geminiFunctionCallPart
-				if err := json.Unmarshal(rawPart, &fcPart); err == nil && fcPart.FunctionCall != nil {
-					processFunctionCallPart(agg, fcPart.FunctionCall, &toolCalls)
+					appendTextPart(agg, part)
 				}
 			}
 		}
@@ -258,11 +374,15 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 
 // appendTextPart adds a text fragment to the candidate aggregator, coalescing
 // only with the previous part when both are text parts with equivalent metadata
-// (thought flag). Uses strings.Builder for efficient concatenation.
-func appendTextPart(agg *candidateAggregator, tp geminiTextPart) {
+// (thought flag) and neither carries a thoughtSignature. Signed parts stay
+// distinct. Uses strings.Builder for efficient concatenation.
+func appendTextPart(agg *candidateAggregator, tp geminiStreamPart) {
 	n := len(agg.parts)
-	// Coalesce with previous text part only if metadata (thought) matches.
-	if n > 0 && agg.parts[n-1].textBuilder != nil && agg.parts[n-1].thought == tp.Thought {
+	// Coalesce with the previous text part only when metadata matches and
+	// neither the previous nor the current part is signed.
+	if n > 0 && agg.parts[n-1].textBuilder != nil &&
+		agg.parts[n-1].thought == tp.Thought &&
+		agg.parts[n-1].signature == "" && tp.ThoughtSignature == "" {
 		agg.parts[n-1].textBuilder.WriteString(tp.Text)
 		return
 	}
@@ -271,13 +391,15 @@ func appendTextPart(agg *candidateAggregator, tp geminiTextPart) {
 	agg.parts = append(agg.parts, candidatePart{
 		textBuilder: b,
 		thought:     tp.Thought,
+		signature:   tp.ThoughtSignature,
 	})
 }
 
 // processFunctionCallPart handles a function call part, supporting both
 // complete single-chunk calls and Vertex AI's streaming function call
 // arguments where the name arrives first and args follow in subsequent chunks.
-func processFunctionCallPart(agg *candidateAggregator, fc *geminiFunctionCallData, toolCalls *[]request.ToolCall) {
+// signature is the part's outer thoughtSignature (if any).
+func processFunctionCallPart(agg *candidateAggregator, fc *geminiFunctionCallData, signature string, toolCalls *[]request.ToolCall) {
 	if fc.Name != "" {
 		// New named function call: flush any previous active FC.
 		if name := agg.flushActiveFC(); name != "" {
@@ -285,9 +407,10 @@ func processFunctionCallPart(agg *candidateAggregator, fc *geminiFunctionCallDat
 		}
 
 		// If the call has complete args and no continuation, store directly.
-		if len(fc.Args) > 0 && fc.PartialArgs == "" {
+		if len(fc.Args) > 0 && len(fc.PartialArgs) == 0 {
 			agg.activeFC = &fcAggregator{
 				name:       fc.Name,
+				signature:  signature,
 				hasFullArg: true,
 				fullArg:    fc.Args,
 			}
@@ -301,13 +424,11 @@ func processFunctionCallPart(agg *candidateAggregator, fc *geminiFunctionCallDat
 		}
 
 		// Start aggregation (name only, or name with partial args).
-		agg.activeFC = &fcAggregator{name: fc.Name}
-		if fc.PartialArgs != "" {
-			agg.activeFC.argsAccum.WriteString(fc.PartialArgs)
-		}
+		agg.activeFC = &fcAggregator{name: fc.Name, signature: signature}
+		agg.activeFC.addPartialArgs(fc.PartialArgs)
 
 		// If no continuation expected and no partial args, flush immediately.
-		if fc.WillContinue == nil && fc.PartialArgs == "" && len(fc.Args) == 0 {
+		if fc.WillContinue == nil && len(fc.PartialArgs) == 0 && len(fc.Args) == 0 {
 			if name := agg.flushActiveFC(); name != "" {
 				*toolCalls = append(*toolCalls, request.ToolCall{Name: name})
 			}
@@ -319,8 +440,8 @@ func processFunctionCallPart(agg *candidateAggregator, fc *geminiFunctionCallDat
 	if agg.activeFC == nil {
 		return
 	}
-	if fc.PartialArgs != "" {
-		agg.activeFC.argsAccum.WriteString(fc.PartialArgs)
+	if len(fc.PartialArgs) > 0 {
+		agg.activeFC.addPartialArgs(fc.PartialArgs)
 	} else if len(fc.Args) > 0 {
 		// Args as JSON in continuation.
 		agg.activeFC.argsAccum.Write(fc.Args)
@@ -391,7 +512,8 @@ func buildGeminiCandidates(aggs map[int]*candidateAggregator) []request.GeminiCa
 				Parts: parts,
 				Role:  "model",
 			},
-			FinishReason: agg.finishReason,
+			FinishReason:  agg.finishReason,
+			SafetyRatings: agg.safetyRatings,
 		}
 	}
 	return result
@@ -411,8 +533,10 @@ func buildGeminiStreamParts(parts []candidatePart) json.RawMessage {
 			rawParts = append(rawParts, p.fcRaw)
 			continue
 		}
-		if p.textBuilder != nil && p.textBuilder.Len() > 0 {
-			raw := marshalTextPart(p.textBuilder.String(), p.thought)
+		// Emit a text part when it has content or a signature to preserve
+		// (signature-only parts must not be dropped).
+		if p.textBuilder != nil && (p.textBuilder.Len() > 0 || p.signature != "") {
+			raw := marshalTextPart(p.textBuilder.String(), p.thought, p.signature)
 			if raw != nil {
 				rawParts = append(rawParts, raw)
 			}
@@ -430,23 +554,15 @@ func buildGeminiStreamParts(parts []candidatePart) json.RawMessage {
 	return raw
 }
 
-// marshalTextPart marshals a text part, including thought metadata if present.
-func marshalTextPart(text string, thought bool) json.RawMessage {
-	if thought {
-		type thoughtPartJSON struct {
-			Text    string `json:"text"`
-			Thought bool   `json:"thought"`
-		}
-		raw, err := json.Marshal(thoughtPartJSON{Text: text, Thought: true})
-		if err != nil {
-			return nil
-		}
-		return raw
-	}
+// marshalTextPart marshals a text part, including thought and thoughtSignature
+// metadata when present.
+func marshalTextPart(text string, thought bool, signature string) json.RawMessage {
 	type textPartJSON struct {
-		Text string `json:"text"`
+		Text             string `json:"text,omitempty"`
+		Thought          bool   `json:"thought,omitempty"`
+		ThoughtSignature string `json:"thoughtSignature,omitempty"`
 	}
-	raw, err := json.Marshal(textPartJSON{Text: text})
+	raw, err := json.Marshal(textPartJSON{Text: text, Thought: thought, ThoughtSignature: signature})
 	if err != nil {
 		return nil
 	}

--- a/pkg/ebpf/common/http/gemini_stream.go
+++ b/pkg/ebpf/common/http/gemini_stream.go
@@ -19,6 +19,10 @@ import (
 // candidate indices, consistent with the openai_stream.go guard.
 const maxGeminiStreamCandidates = 256
 
+// maxPartialArgArrayIndex bounds array indices in JSONPath expressions from
+// partialArgs to prevent unbounded memory allocation from malformed paths.
+const maxPartialArgArrayIndex = 1024
+
 type geminiStreamChunk struct {
 	Candidates    []geminiStreamCandidate `json:"candidates"`
 	UsageMetadata *request.GeminiUsage    `json:"usageMetadata"`
@@ -230,7 +234,7 @@ func setAtFrags(container any, frags []jsonpath.Frag, value any) any {
 		return m
 	case jsonpath.Nth:
 		idx := int(f)
-		if idx < 0 {
+		if idx < 0 || idx >= maxPartialArgArrayIndex {
 			return container
 		}
 		s, _ := container.([]any)

--- a/pkg/ebpf/common/http/gemini_stream.go
+++ b/pkg/ebpf/common/http/gemini_stream.go
@@ -13,6 +13,10 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
 
+// maxGeminiStreamCandidates bounds allocations derived from response-provided
+// candidate indices, consistent with the openai_stream.go guard.
+const maxGeminiStreamCandidates = 256
+
 type geminiStreamChunk struct {
 	Candidates    []geminiStreamCandidate `json:"candidates"`
 	UsageMetadata *request.GeminiUsage    `json:"usageMetadata"`
@@ -44,11 +48,17 @@ type geminiFunctionCallData struct {
 	Args json.RawMessage `json:"args,omitempty"`
 }
 
-// candidateAggregator accumulates streamed text and function-call parts
-// for a single candidate index.
+// candidatePart is a single ordered part in a candidate's content.
+// Either text is non-empty (text part) or fcRaw is non-nil (function-call part).
+type candidatePart struct {
+	text  string
+	fcRaw json.RawMessage
+}
+
+// candidateAggregator accumulates streamed parts for a single candidate
+// index, preserving the original part ordering.
 type candidateAggregator struct {
-	content      strings.Builder
-	fcParts      []json.RawMessage
+	parts        []candidatePart
 	finishReason string
 }
 
@@ -95,6 +105,9 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 
 		for i := range chunk.Candidates {
 			c := &chunk.Candidates[i]
+			if c.Index < 0 || c.Index >= maxGeminiStreamCandidates {
+				continue
+			}
 			agg := candidates[c.Index]
 			if agg == nil {
 				agg = &candidateAggregator{}
@@ -111,7 +124,11 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 			for _, rawPart := range c.Content.Parts {
 				var textPart geminiTextPart
 				if err := json.Unmarshal(rawPart, &textPart); err == nil && textPart.Text != "" {
-					agg.content.WriteString(textPart.Text)
+					if n := len(agg.parts); n > 0 && agg.parts[n-1].fcRaw == nil {
+						agg.parts[n-1].text += textPart.Text
+					} else {
+						agg.parts = append(agg.parts, candidatePart{text: textPart.Text})
+					}
 					continue
 				}
 
@@ -120,7 +137,7 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 					toolCalls = append(toolCalls, request.ToolCall{
 						Name: fcPart.FunctionCall.Name,
 					})
-					agg.fcParts = append(agg.fcParts, rawPart)
+					agg.parts = append(agg.parts, candidatePart{fcRaw: rawPart})
 				}
 			}
 		}
@@ -178,7 +195,7 @@ func buildGeminiCandidates(aggs map[int]*candidateAggregator) []request.GeminiCa
 
 	result := make([]request.GeminiCandidate, maxIdx+1)
 	for idx, agg := range aggs {
-		parts := buildGeminiStreamParts(agg.content.String(), agg.fcParts)
+		parts := buildGeminiStreamParts(agg.parts)
 		result[idx] = request.GeminiCandidate{
 			Content: &request.GeminiContent{
 				Parts: parts,
@@ -190,10 +207,11 @@ func buildGeminiCandidates(aggs map[int]*candidateAggregator) []request.GeminiCa
 	return result
 }
 
-// buildGeminiStreamParts constructs the parts JSON from aggregated text
-// and raw function-call parts (preserving arguments).
-func buildGeminiStreamParts(text string, fcParts []json.RawMessage) json.RawMessage {
-	if text == "" && len(fcParts) == 0 {
+// buildGeminiStreamParts constructs the parts JSON from ordered candidate
+// parts, preserving the original text/function-call ordering and coalescing
+// only adjacent text fragments.
+func buildGeminiStreamParts(parts []candidatePart) json.RawMessage {
+	if len(parts) == 0 {
 		return nil
 	}
 
@@ -201,16 +219,25 @@ func buildGeminiStreamParts(text string, fcParts []json.RawMessage) json.RawMess
 		Text string `json:"text"`
 	}
 
-	var parts []json.RawMessage
-	if text != "" {
-		raw, err := json.Marshal(textPartJSON{Text: text})
-		if err == nil {
-			parts = append(parts, raw)
+	var rawParts []json.RawMessage
+	for _, p := range parts {
+		if p.fcRaw != nil {
+			rawParts = append(rawParts, p.fcRaw)
+			continue
+		}
+		if p.text != "" {
+			raw, err := json.Marshal(textPartJSON{Text: p.text})
+			if err == nil {
+				rawParts = append(rawParts, raw)
+			}
 		}
 	}
-	parts = append(parts, fcParts...)
 
-	raw, err := json.Marshal(parts)
+	if len(rawParts) == 0 {
+		return nil
+	}
+
+	raw, err := json.Marshal(rawParts)
 	if err != nil {
 		return nil
 	}

--- a/pkg/ebpf/common/http/gemini_stream.go
+++ b/pkg/ebpf/common/http/gemini_stream.go
@@ -1,0 +1,168 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strings"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+)
+
+type geminiStreamChunk struct {
+	Candidates    []geminiStreamCandidate `json:"candidates"`
+	UsageMetadata *request.GeminiUsage    `json:"usageMetadata"`
+	ModelVersion  string                  `json:"modelVersion"`
+	ResponseID    string                  `json:"responseId"`
+}
+
+type geminiStreamCandidate struct {
+	Content      *geminiStreamContent `json:"content"`
+	FinishReason string               `json:"finishReason"`
+}
+
+type geminiStreamContent struct {
+	Parts []json.RawMessage `json:"parts"`
+	Role  string            `json:"role"`
+}
+
+type geminiTextPart struct {
+	Text string `json:"text"`
+}
+
+type geminiFunctionCallPart struct {
+	FunctionCall *struct {
+		Name string `json:"name"`
+	} `json:"functionCall"`
+}
+
+// parseGeminiStream parses the SSE stream from Gemini APIs and returns
+// the aggregated response with usage statistics and tool calls.
+func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.ToolCall) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 256*1024), 256*1024)
+
+	var contentBuilder strings.Builder
+	var toolCalls []request.ToolCall
+	var finishReason string
+	var modelVersion string
+	var responseID string
+	var usage *request.GeminiUsage
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		data := strings.TrimPrefix(line, "data: ")
+
+		var chunk geminiStreamChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			slog.Debug("parseGeminiStream: failed to parse chunk", "error", err)
+			continue
+		}
+
+		if chunk.ModelVersion != "" {
+			modelVersion = chunk.ModelVersion
+		}
+		if chunk.ResponseID != "" {
+			responseID = chunk.ResponseID
+		}
+		if chunk.UsageMetadata != nil && chunk.UsageMetadata.TotalTokenCount > 0 {
+			usage = chunk.UsageMetadata
+		}
+
+		if len(chunk.Candidates) == 0 {
+			continue
+		}
+
+		candidate := &chunk.Candidates[0]
+		if candidate.FinishReason != "" {
+			finishReason = candidate.FinishReason
+		}
+		if candidate.Content == nil {
+			continue
+		}
+
+		for _, rawPart := range candidate.Content.Parts {
+			var textPart geminiTextPart
+			if err := json.Unmarshal(rawPart, &textPart); err == nil && textPart.Text != "" {
+				contentBuilder.WriteString(textPart.Text)
+				continue
+			}
+
+			var fcPart geminiFunctionCallPart
+			if err := json.Unmarshal(rawPart, &fcPart); err == nil && fcPart.FunctionCall != nil && fcPart.FunctionCall.Name != "" {
+				toolCalls = append(toolCalls, request.ToolCall{
+					Name: fcPart.FunctionCall.Name,
+				})
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		slog.Debug("parseGeminiStream: scanner error", "error", err)
+	}
+
+	resp := &request.GeminiResponse{
+		ModelVersion: modelVersion,
+		ResponseID:   responseID,
+	}
+
+	if usage != nil {
+		resp.UsageMetadata = *usage
+	}
+
+	// Build the aggregated candidate with parts.
+	parts := buildGeminiStreamParts(contentBuilder.String(), toolCalls)
+	if parts != nil || finishReason != "" {
+		resp.Candidates = []request.GeminiCandidate{
+			{
+				Content: &request.GeminiContent{
+					Parts: parts,
+					Role:  "model",
+				},
+				FinishReason: finishReason,
+			},
+		}
+	}
+
+	return resp, toolCalls
+}
+
+// buildGeminiStreamParts constructs the parts JSON from aggregated text and tool calls.
+func buildGeminiStreamParts(text string, toolCalls []request.ToolCall) json.RawMessage {
+	if text == "" && len(toolCalls) == 0 {
+		return nil
+	}
+
+	type textPartJSON struct {
+		Text string `json:"text"`
+	}
+	type fcNameJSON struct {
+		Name string `json:"name"`
+	}
+	type fcPartJSON struct {
+		FunctionCall fcNameJSON `json:"functionCall"`
+	}
+
+	var parts []any
+	if text != "" {
+		parts = append(parts, textPartJSON{Text: text})
+	}
+	for i := range toolCalls {
+		parts = append(parts, fcPartJSON{FunctionCall: fcNameJSON{Name: toolCalls[i].Name}})
+	}
+
+	raw, err := json.Marshal(parts)
+	if err != nil {
+		return nil
+	}
+	return raw
+}

--- a/pkg/ebpf/common/http/gemini_stream.go
+++ b/pkg/ebpf/common/http/gemini_stream.go
@@ -100,13 +100,14 @@ func (ca *candidateAggregator) flushActiveFC() string {
 	}
 
 	var raw json.RawMessage
-	if fc.hasFullArg {
+	switch {
+	case fc.hasFullArg:
 		// Complete args arrived as a JSON object.
 		raw = buildFunctionCallRaw(fc.name, fc.fullArg)
-	} else if fc.argsAccum.Len() > 0 {
+	case fc.argsAccum.Len() > 0:
 		// Partial args were accumulated as string fragments.
 		raw = buildFunctionCallRaw(fc.name, json.RawMessage(fc.argsAccum.String()))
-	} else {
+	default:
 		// Name-only function call with no args.
 		raw = buildFunctionCallRaw(fc.name, nil)
 	}

--- a/pkg/ebpf/common/http/gemini_stream.go
+++ b/pkg/ebpf/common/http/gemini_stream.go
@@ -10,6 +10,8 @@ import (
 	"log/slog"
 	"strings"
 
+	jsonpath "github.com/ohler55/ojg/jp"
+
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
 
@@ -85,11 +87,32 @@ type fcAggregator struct {
 	signature string
 	// argsAccum accumulates string-fragment style partial args (legacy shape).
 	argsAccum strings.Builder
-	// argsObj reconstructs args from Vertex AI's {jsonPath, value} partialArgs
-	// array elements.
-	argsObj    map[string]any
+	// argsObj reconstructs args from Vertex AI's {jsonPath, <typed value>}
+	// partialArgs array elements.
+	argsObj map[string]any
+	// strFrags accumulates streamed string fragments per jsonPath. Vertex AI
+	// splits a single string argument across multiple PartialArg elements that
+	// share a jsonPath and set willContinue=true until the final fragment, so
+	// the fragments must be concatenated rather than overwritten.
+	strFrags   map[string]string
 	hasFullArg bool            // true if args came as a complete JSON object
 	fullArg    json.RawMessage // stored when args is a complete JSON object
+}
+
+// geminiPartialArg mirrors a single Vertex AI PartialArg element from the
+// streamFunctionCallArguments feature. Each element targets a JSONPath within
+// the reconstructed arguments object and carries exactly one typed value from
+// the value union (stringValue / numberValue / boolValue / nullValue). A string
+// value may be split across multiple elements sharing a jsonPath, with
+// willContinue=true on every fragment except the last.
+// See https://docs.cloud.google.com/vertex-ai/generative-ai/docs/reference/rpc/google.cloud.aiplatform.v1#partialarg
+type geminiPartialArg struct {
+	JSONPath     string          `json:"jsonPath"`
+	StringValue  *string         `json:"stringValue"`
+	NumberValue  *float64        `json:"numberValue"`
+	BoolValue    *bool           `json:"boolValue"`
+	NullValue    json.RawMessage `json:"nullValue"`
+	WillContinue *bool           `json:"willContinue"`
 }
 
 // addPartialArgs interprets a raw partialArgs value, supporting both the
@@ -108,65 +131,116 @@ func (fc *fcAggregator) addPartialArgs(raw json.RawMessage) {
 			fc.argsAccum.WriteString(frag)
 		}
 	case '[':
-		// Vertex AI array shape: each element carries a jsonPath and a typed
-		// value. Reconstruct the args object from paths and values.
-		var elems []map[string]json.RawMessage
+		// Vertex AI array shape: each element carries a jsonPath and exactly
+		// one typed value from the value union.
+		var elems []geminiPartialArg
 		if err := json.Unmarshal(raw, &elems); err != nil {
 			return
 		}
-		if fc.argsObj == nil {
-			fc.argsObj = map[string]any{}
-		}
-		for _, elem := range elems {
-			pathRaw, ok := elem["jsonPath"]
-			if !ok {
-				continue
-			}
-			var path string
-			if err := json.Unmarshal(pathRaw, &path); err != nil {
-				continue
-			}
-			// The value is carried in the first non-jsonPath field. This is
-			// robust to the exact typed-value key (stringValue, numberValue,
-			// value, ...) since we keep the raw JSON value verbatim.
-			var value any
-			for k, v := range elem {
-				if k == "jsonPath" {
-					continue
-				}
-				_ = json.Unmarshal(v, &value)
-				break
-			}
-			setByJSONPath(fc.argsObj, path, value)
+		for i := range elems {
+			fc.applyPartialArg(&elems[i])
 		}
 	}
 }
 
-// setByJSONPath assigns value at a simple dotted JSON path (e.g. "$.a.b") into
-// the target map, creating intermediate objects as needed. Array indices and
-// complex expressions are not supported and are skipped.
-func setByJSONPath(m map[string]any, path string, value any) {
-	path = strings.TrimPrefix(path, "$")
-	path = strings.TrimPrefix(path, ".")
-	if path == "" {
+// applyPartialArg decodes one PartialArg's typed value and assigns it at the
+// element's jsonPath. String values are accumulated per path across fragments
+// (Vertex AI streams them with willContinue=true until the final fragment) so
+// that a trailing empty terminator does not clobber the accumulated text; other
+// typed values are assigned directly.
+func (fc *fcAggregator) applyPartialArg(arg *geminiPartialArg) {
+	if arg.JSONPath == "" {
 		return
 	}
-	keys := strings.Split(path, ".")
-	cur := m
-	for i, k := range keys {
-		if k == "" {
-			return
+	if fc.argsObj == nil {
+		fc.argsObj = map[string]any{}
+	}
+	switch {
+	case arg.StringValue != nil:
+		if fc.strFrags == nil {
+			fc.strFrags = map[string]string{}
 		}
-		if i == len(keys)-1 {
-			cur[k] = value
-			return
+		acc := fc.strFrags[arg.JSONPath] + *arg.StringValue
+		fc.strFrags[arg.JSONPath] = acc
+		setByJSONPath(fc.argsObj, arg.JSONPath, acc)
+		// Once the provider signals the fragment sequence is complete, drop
+		// the per-path accumulator so a later argument at the same path starts
+		// fresh.
+		if arg.WillContinue == nil || !*arg.WillContinue {
+			delete(fc.strFrags, arg.JSONPath)
 		}
-		next, ok := cur[k].(map[string]any)
-		if !ok {
-			next = map[string]any{}
-			cur[k] = next
+	case arg.NumberValue != nil:
+		setByJSONPath(fc.argsObj, arg.JSONPath, *arg.NumberValue)
+	case arg.BoolValue != nil:
+		setByJSONPath(fc.argsObj, arg.JSONPath, *arg.BoolValue)
+	case arg.NullValue != nil:
+		setByJSONPath(fc.argsObj, arg.JSONPath, nil)
+	}
+}
+
+// setByJSONPath assigns value at the given JSONPath within the target map,
+// creating intermediate objects and arrays as needed. It reuses the shared
+// github.com/ohler55/ojg/jp parser so array segments (e.g. "$.items[0].id")
+// are handled per the Vertex AI contract instead of a hand-rolled dotted-key
+// parser. Invalid paths are skipped rather than fatal.
+func setByJSONPath(m map[string]any, path string, value any) {
+	expr, err := jsonpath.ParseString(path)
+	if err != nil {
+		return
+	}
+	frags := stripRootFrags([]jsonpath.Frag(expr))
+	if len(frags) == 0 {
+		return
+	}
+	setAtFrags(m, frags, value)
+}
+
+// stripRootFrags drops the leading root ("$") or current-node ("@") markers
+// from a parsed JSONPath so the remaining fragments describe the location
+// relative to the target map.
+func stripRootFrags(frags []jsonpath.Frag) []jsonpath.Frag {
+	for len(frags) > 0 {
+		switch frags[0].(type) {
+		case jsonpath.Root, jsonpath.At:
+			frags = frags[1:]
+		default:
+			return frags
 		}
-		cur = next
+	}
+	return frags
+}
+
+// setAtFrags recursively assigns value at the location described by frags
+// within container, creating intermediate maps and arrays (including nested
+// array elements) as needed. It returns the possibly reallocated container so
+// callers can reattach a grown slice. Only plain object-key (Child) and array
+// index (Nth) fragments are supported; other fragment kinds stop the descent.
+func setAtFrags(container any, frags []jsonpath.Frag, value any) any {
+	if len(frags) == 0 {
+		return value
+	}
+	switch f := frags[0].(type) {
+	case jsonpath.Child:
+		m, ok := container.(map[string]any)
+		if !ok || m == nil {
+			m = map[string]any{}
+		}
+		key := string(f)
+		m[key] = setAtFrags(m[key], frags[1:], value)
+		return m
+	case jsonpath.Nth:
+		idx := int(f)
+		if idx < 0 {
+			return container
+		}
+		s, _ := container.([]any)
+		for len(s) <= idx {
+			s = append(s, nil)
+		}
+		s[idx] = setAtFrags(s[idx], frags[1:], value)
+		return s
+	default:
+		return container
 	}
 }
 

--- a/pkg/ebpf/common/http/gemini_stream.go
+++ b/pkg/ebpf/common/http/gemini_stream.go
@@ -21,6 +21,7 @@ type geminiStreamChunk struct {
 }
 
 type geminiStreamCandidate struct {
+	Index        int                  `json:"index"`
 	Content      *geminiStreamContent `json:"content"`
 	FinishReason string               `json:"finishReason"`
 }
@@ -35,20 +36,35 @@ type geminiTextPart struct {
 }
 
 type geminiFunctionCallPart struct {
-	FunctionCall *struct {
-		Name string `json:"name"`
-	} `json:"functionCall"`
+	FunctionCall *geminiFunctionCallData `json:"functionCall"`
+}
+
+type geminiFunctionCallData struct {
+	Name string          `json:"name"`
+	Args json.RawMessage `json:"args,omitempty"`
+}
+
+// candidateAggregator accumulates streamed text and function-call parts
+// for a single candidate index.
+type candidateAggregator struct {
+	content      strings.Builder
+	fcParts      []json.RawMessage
+	finishReason string
 }
 
 // parseGeminiStream parses the SSE stream from Gemini APIs and returns
 // the aggregated response with usage statistics and tool calls.
+//
+// SSE framing: Gemini emits one JSON object per "data:" line. We
+// intentionally only support this observed single-line framing
+// (consistent with the OpenAI SSE parser) rather than the full
+// multi-line SSE spec.
 func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.ToolCall) {
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 0, 256*1024), 256*1024)
 
-	var contentBuilder strings.Builder
+	candidates := make(map[int]*candidateAggregator)
 	var toolCalls []request.ToolCall
-	var finishReason string
 	var modelVersion string
 	var responseID string
 	var usage *request.GeminiUsage
@@ -56,11 +72,10 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 	for scanner.Scan() {
 		line := scanner.Text()
 
-		if !strings.HasPrefix(line, "data: ") {
+		data, ok := extractSSEData(line)
+		if !ok {
 			continue
 		}
-
-		data := strings.TrimPrefix(line, "data: ")
 
 		var chunk geminiStreamChunk
 		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
@@ -74,34 +89,39 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 		if chunk.ResponseID != "" {
 			responseID = chunk.ResponseID
 		}
-		if chunk.UsageMetadata != nil && chunk.UsageMetadata.TotalTokenCount > 0 {
+		if chunk.UsageMetadata != nil && geminiUsageHasTokens(chunk.UsageMetadata) {
 			usage = chunk.UsageMetadata
 		}
 
-		if len(chunk.Candidates) == 0 {
-			continue
-		}
+		for i := range chunk.Candidates {
+			c := &chunk.Candidates[i]
+			agg := candidates[c.Index]
+			if agg == nil {
+				agg = &candidateAggregator{}
+				candidates[c.Index] = agg
+			}
 
-		candidate := &chunk.Candidates[0]
-		if candidate.FinishReason != "" {
-			finishReason = candidate.FinishReason
-		}
-		if candidate.Content == nil {
-			continue
-		}
-
-		for _, rawPart := range candidate.Content.Parts {
-			var textPart geminiTextPart
-			if err := json.Unmarshal(rawPart, &textPart); err == nil && textPart.Text != "" {
-				contentBuilder.WriteString(textPart.Text)
+			if c.FinishReason != "" {
+				agg.finishReason = c.FinishReason
+			}
+			if c.Content == nil {
 				continue
 			}
 
-			var fcPart geminiFunctionCallPart
-			if err := json.Unmarshal(rawPart, &fcPart); err == nil && fcPart.FunctionCall != nil && fcPart.FunctionCall.Name != "" {
-				toolCalls = append(toolCalls, request.ToolCall{
-					Name: fcPart.FunctionCall.Name,
-				})
+			for _, rawPart := range c.Content.Parts {
+				var textPart geminiTextPart
+				if err := json.Unmarshal(rawPart, &textPart); err == nil && textPart.Text != "" {
+					agg.content.WriteString(textPart.Text)
+					continue
+				}
+
+				var fcPart geminiFunctionCallPart
+				if err := json.Unmarshal(rawPart, &fcPart); err == nil && fcPart.FunctionCall != nil && fcPart.FunctionCall.Name != "" {
+					toolCalls = append(toolCalls, request.ToolCall{
+						Name: fcPart.FunctionCall.Name,
+					})
+					agg.fcParts = append(agg.fcParts, rawPart)
+				}
 			}
 		}
 	}
@@ -119,46 +139,76 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 		resp.UsageMetadata = *usage
 	}
 
-	// Build the aggregated candidate with parts.
-	parts := buildGeminiStreamParts(contentBuilder.String(), toolCalls)
-	if parts != nil || finishReason != "" {
-		resp.Candidates = []request.GeminiCandidate{
-			{
-				Content: &request.GeminiContent{
-					Parts: parts,
-					Role:  "model",
-				},
-				FinishReason: finishReason,
-			},
-		}
-	}
+	resp.Candidates = buildGeminiCandidates(candidates)
 
 	return resp, toolCalls
 }
 
-// buildGeminiStreamParts constructs the parts JSON from aggregated text and tool calls.
-func buildGeminiStreamParts(text string, toolCalls []request.ToolCall) json.RawMessage {
-	if text == "" && len(toolCalls) == 0 {
+// extractSSEData extracts the JSON payload from an SSE data line.
+// It handles both "data: " (with space) and "data:" (without space) prefixes.
+func extractSSEData(line string) (string, bool) {
+	if strings.HasPrefix(line, "data: ") {
+		return line[6:], true
+	}
+	if strings.HasPrefix(line, "data:") {
+		return line[5:], true
+	}
+	return "", false
+}
+
+// geminiUsageHasTokens returns true when any of the exported token
+// fields are populated, not just totalTokenCount.
+func geminiUsageHasTokens(u *request.GeminiUsage) bool {
+	return u.PromptTokenCount > 0 || u.CandidatesTokenCount > 0 || u.TotalTokenCount > 0
+}
+
+// buildGeminiCandidates constructs the final candidate list from the
+// per-index aggregators, ordered by candidate index.
+func buildGeminiCandidates(aggs map[int]*candidateAggregator) []request.GeminiCandidate {
+	if len(aggs) == 0 {
+		return nil
+	}
+
+	maxIdx := 0
+	for idx := range aggs {
+		if idx > maxIdx {
+			maxIdx = idx
+		}
+	}
+
+	result := make([]request.GeminiCandidate, maxIdx+1)
+	for idx, agg := range aggs {
+		parts := buildGeminiStreamParts(agg.content.String(), agg.fcParts)
+		result[idx] = request.GeminiCandidate{
+			Content: &request.GeminiContent{
+				Parts: parts,
+				Role:  "model",
+			},
+			FinishReason: agg.finishReason,
+		}
+	}
+	return result
+}
+
+// buildGeminiStreamParts constructs the parts JSON from aggregated text
+// and raw function-call parts (preserving arguments).
+func buildGeminiStreamParts(text string, fcParts []json.RawMessage) json.RawMessage {
+	if text == "" && len(fcParts) == 0 {
 		return nil
 	}
 
 	type textPartJSON struct {
 		Text string `json:"text"`
 	}
-	type fcNameJSON struct {
-		Name string `json:"name"`
-	}
-	type fcPartJSON struct {
-		FunctionCall fcNameJSON `json:"functionCall"`
-	}
 
-	var parts []any
+	var parts []json.RawMessage
 	if text != "" {
-		parts = append(parts, textPartJSON{Text: text})
+		raw, err := json.Marshal(textPartJSON{Text: text})
+		if err == nil {
+			parts = append(parts, raw)
+		}
 	}
-	for i := range toolCalls {
-		parts = append(parts, fcPartJSON{FunctionCall: fcNameJSON{Name: toolCalls[i].Name}})
-	}
+	parts = append(parts, fcParts...)
 
 	raw, err := json.Marshal(parts)
 	if err != nil {

--- a/pkg/ebpf/common/http/gemini_stream_test.go
+++ b/pkg/ebpf/common/http/gemini_stream_test.go
@@ -1,0 +1,103 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGeminiStream_CompleteResponse(t *testing.T) {
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"AI \"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_abc\"}\n\n" +
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"uses \"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_abc\"}\n\n" +
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"machine learning.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15},\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_abc\"}\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	assert.Equal(t, "gemini-2.0-flash", resp.ModelVersion)
+	assert.Equal(t, "resp_abc", resp.ResponseID)
+	assert.Equal(t, 10, resp.UsageMetadata.PromptTokenCount)
+	assert.Equal(t, 5, resp.UsageMetadata.CandidatesTokenCount)
+	assert.Equal(t, 15, resp.UsageMetadata.TotalTokenCount)
+	assert.Empty(t, toolCalls)
+
+	require.Len(t, resp.Candidates, 1)
+	assert.Equal(t, "STOP", resp.Candidates[0].FinishReason)
+	assert.Equal(t, "model", resp.Candidates[0].Content.Role)
+
+	// Verify aggregated text content.
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	assert.Equal(t, "AI uses machine learning.", parts[0].Text)
+}
+
+func TestParseGeminiStream_TruncatedNoUsage(t *testing.T) {
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello\"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\"}\n\n" +
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" world\"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\"}\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	assert.Equal(t, "gemini-2.0-flash", resp.ModelVersion)
+	assert.Equal(t, 0, resp.UsageMetadata.TotalTokenCount)
+	assert.Empty(t, toolCalls)
+
+	require.Len(t, resp.Candidates, 1)
+	assert.Empty(t, resp.Candidates[0].FinishReason)
+
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	assert.Equal(t, "Hello world", parts[0].Text)
+}
+
+func TestParseGeminiStream_ToolCalls(t *testing.T) {
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"get_weather\",\"args\":{\"location\":\"NYC\"}}}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":8,\"candidatesTokenCount\":3,\"totalTokenCount\":11},\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_tc\"}\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	assert.Equal(t, "resp_tc", resp.ResponseID)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "get_weather", toolCalls[0].Name)
+	assert.Equal(t, "STOP", resp.Candidates[0].FinishReason)
+}
+
+func TestParseGeminiStream_EmptyStream(t *testing.T) {
+	resp, toolCalls := parseGeminiStream(strings.NewReader(""))
+
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.ModelVersion)
+	assert.Empty(t, resp.ResponseID)
+	assert.Equal(t, 0, resp.UsageMetadata.TotalTokenCount)
+	assert.Empty(t, resp.Candidates)
+	assert.Empty(t, toolCalls)
+}
+
+func TestParseGeminiStream_MultipleTextParts(t *testing.T) {
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"First \"},{\"text\":\"and second.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":5,\"candidatesTokenCount\":4,\"totalTokenCount\":9},\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_multi\"}\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	assert.Equal(t, "resp_multi", resp.ResponseID)
+	assert.Empty(t, toolCalls)
+
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	assert.Equal(t, "First and second.", parts[0].Text)
+}

--- a/pkg/ebpf/common/http/gemini_stream_test.go
+++ b/pkg/ebpf/common/http/gemini_stream_test.go
@@ -31,7 +31,6 @@ func TestParseGeminiStream_CompleteResponse(t *testing.T) {
 	assert.Equal(t, "STOP", resp.Candidates[0].FinishReason)
 	assert.Equal(t, "model", resp.Candidates[0].Content.Role)
 
-	// Verify aggregated text content.
 	var parts []struct {
 		Text string `json:"text"`
 	}
@@ -100,4 +99,93 @@ func TestParseGeminiStream_MultipleTextParts(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
 	require.Len(t, parts, 1)
 	assert.Equal(t, "First and second.", parts[0].Text)
+}
+
+func TestParseGeminiStream_MultipleCandidates(t *testing.T) {
+	stream := "data: {\"candidates\":[{\"index\":0,\"content\":{\"parts\":[{\"text\":\"Answer A \"}],\"role\":\"model\"}},{\"index\":1,\"content\":{\"parts\":[{\"text\":\"Answer B \"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\"}\n\n" +
+		"data: {\"candidates\":[{\"index\":0,\"content\":{\"parts\":[{\"text\":\"continued.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"},{\"index\":1,\"content\":{\"parts\":[{\"text\":\"also done.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":12,\"candidatesTokenCount\":8,\"totalTokenCount\":20},\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_mc\"}\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	assert.Equal(t, "resp_mc", resp.ResponseID)
+	assert.Equal(t, 12, resp.UsageMetadata.PromptTokenCount)
+	assert.Empty(t, toolCalls)
+
+	require.Len(t, resp.Candidates, 2)
+
+	// Candidate 0
+	assert.Equal(t, "STOP", resp.Candidates[0].FinishReason)
+	var parts0 []struct {
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts0))
+	require.Len(t, parts0, 1)
+	assert.Equal(t, "Answer A continued.", parts0[0].Text)
+
+	// Candidate 1
+	assert.Equal(t, "STOP", resp.Candidates[1].FinishReason)
+	var parts1 []struct {
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[1].Content.Parts, &parts1))
+	require.Len(t, parts1, 1)
+	assert.Equal(t, "Answer B also done.", parts1[0].Text)
+}
+
+func TestParseGeminiStream_FunctionCallArguments(t *testing.T) {
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"get_weather\",\"args\":{\"location\":\"NYC\",\"unit\":\"celsius\"}}}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15},\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_fca\"}\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "get_weather", toolCalls[0].Name)
+
+	// Verify the function call arguments are preserved in the parts output.
+	require.Len(t, resp.Candidates, 1)
+	var parts []struct {
+		FunctionCall *struct {
+			Name string          `json:"name"`
+			Args json.RawMessage `json:"args"`
+		} `json:"functionCall"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].FunctionCall)
+	assert.Equal(t, "get_weather", parts[0].FunctionCall.Name)
+	assert.Contains(t, string(parts[0].FunctionCall.Args), "NYC")
+	assert.Contains(t, string(parts[0].FunctionCall.Args), "celsius")
+}
+
+func TestParseGeminiStream_PartialUsageMetadata(t *testing.T) {
+	// Usage with promptTokenCount only (totalTokenCount is 0).
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Done.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":0,\"totalTokenCount\":0},\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_pu\"}\n\n"
+
+	resp, _ := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	assert.Equal(t, 7, resp.UsageMetadata.PromptTokenCount)
+	assert.Equal(t, 0, resp.UsageMetadata.CandidatesTokenCount)
+}
+
+func TestParseGeminiStream_DataPrefixWithoutSpace(t *testing.T) {
+	// SSE "data:" without space after colon.
+	stream := "data:{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"no space\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":3,\"candidatesTokenCount\":2,\"totalTokenCount\":5},\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_ns\"}\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	assert.Equal(t, "gemini-2.0-flash", resp.ModelVersion)
+	assert.Equal(t, "resp_ns", resp.ResponseID)
+	assert.Equal(t, 5, resp.UsageMetadata.TotalTokenCount)
+	assert.Empty(t, toolCalls)
+
+	require.Len(t, resp.Candidates, 1)
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	assert.Equal(t, "no space", parts[0].Text)
 }

--- a/pkg/ebpf/common/http/gemini_stream_test.go
+++ b/pkg/ebpf/common/http/gemini_stream_test.go
@@ -189,3 +189,63 @@ func TestParseGeminiStream_DataPrefixWithoutSpace(t *testing.T) {
 	require.Len(t, parts, 1)
 	assert.Equal(t, "no space", parts[0].Text)
 }
+
+func TestParseGeminiStream_NegativeCandidateIndex(t *testing.T) {
+	// A malformed response with a negative candidate index must not panic.
+	stream := "data: {\"candidates\":[{\"index\":-1,\"content\":{\"parts\":[{\"text\":\"bad\"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\"}\n\n"
+
+	resp, _ := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Candidates)
+}
+
+func TestParseGeminiStream_OversizedCandidateIndex(t *testing.T) {
+	// A malformed response with an oversized candidate index must not cause
+	// excessive allocation.
+	stream := "data: {\"candidates\":[{\"index\":99999,\"content\":{\"parts\":[{\"text\":\"bad\"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\"}\n\n"
+
+	resp, _ := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	assert.Empty(t, resp.Candidates)
+}
+
+func TestParseGeminiStream_InterleavedTextAndFunctionCall(t *testing.T) {
+	// Parts arrive across chunks in order: text, functionCall, text.
+	// The parser must preserve this ordering rather than emitting all
+	// text first.
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Before call \"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\"}\n\n" +
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"get_weather\",\"args\":{\"location\":\"NYC\"}}}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\"}\n\n" +
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"after call.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":8,\"totalTokenCount\":18},\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_interleave\"}\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "get_weather", toolCalls[0].Name)
+
+	require.Len(t, resp.Candidates, 1)
+	var parts []struct {
+		Text         string `json:"text"`
+		FunctionCall *struct {
+			Name string          `json:"name"`
+			Args json.RawMessage `json:"args"`
+		} `json:"functionCall"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 3)
+
+	// Part 0: text "Before call "
+	assert.Equal(t, "Before call ", parts[0].Text)
+	assert.Nil(t, parts[0].FunctionCall)
+
+	// Part 1: function call
+	assert.NotNil(t, parts[1].FunctionCall)
+	assert.Equal(t, "get_weather", parts[1].FunctionCall.Name)
+	assert.Empty(t, parts[1].Text)
+
+	// Part 2: text "after call."
+	assert.Equal(t, "after call.", parts[2].Text)
+	assert.Nil(t, parts[2].FunctionCall)
+}

--- a/pkg/ebpf/common/http/gemini_stream_test.go
+++ b/pkg/ebpf/common/http/gemini_stream_test.go
@@ -249,3 +249,137 @@ func TestParseGeminiStream_InterleavedTextAndFunctionCall(t *testing.T) {
 	assert.Equal(t, "after call.", parts[2].Text)
 	assert.Nil(t, parts[2].FunctionCall)
 }
+
+func TestParseGeminiStream_StringsBuilderPerformance(t *testing.T) {
+	// Verify that large text accumulation works without error (strings.Builder).
+	var sb strings.Builder
+	sb.WriteString("data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"")
+	// 1000 chunks of text to exercise Builder path.
+	for i := 0; i < 1000; i++ {
+		sb.WriteString("chunk ")
+	}
+	sb.WriteString("\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":1,\"candidatesTokenCount\":1,\"totalTokenCount\":2},\"modelVersion\":\"gemini-2.0-flash\"}\n\n")
+	stream := sb.String()
+
+	resp, _ := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	require.Len(t, resp.Candidates, 1)
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	assert.True(t, len(parts[0].Text) > 5000) // 1000 * "chunk " = 6000 chars
+}
+
+func TestParseGeminiStream_ErrorEnvelopeBare(t *testing.T) {
+	// Bare error JSON record (not wrapped in "data:" prefix) after valid data.
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"partial\"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\"}\n\n" +
+		"{\"error\":{\"code\":429,\"message\":\"Resource exhausted\",\"status\":\"RESOURCE_EXHAUSTED\"}}\n"
+
+	resp, _ := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, 429, resp.Error.Code)
+	assert.Equal(t, "RESOURCE_EXHAUSTED", resp.Error.Status)
+	assert.Equal(t, "Resource exhausted", resp.Error.Message)
+
+	// The valid data chunk before the error should still be captured.
+	require.Len(t, resp.Candidates, 1)
+}
+
+func TestParseGeminiStream_ErrorEnvelopeInDataLine(t *testing.T) {
+	// Error envelope arriving inside a "data:" SSE line (no candidates).
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hello\"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\"}\n\n" +
+		"data: {\"error\":{\"code\":500,\"message\":\"Internal error\",\"status\":\"INTERNAL\"}}\n\n"
+
+	resp, _ := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, 500, resp.Error.Code)
+	assert.Equal(t, "INTERNAL", resp.Error.Status)
+}
+
+func TestParseGeminiStream_StreamingFunctionCallArguments(t *testing.T) {
+	// Vertex AI streamFunctionCallArguments: name arrives first, then
+	// partialArgs in subsequent chunks, last chunk without willContinue.
+	chunk1 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","partialArgs":"{\"loc","willContinue":true}}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+	chunk2 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"partialArgs":"ation\": \"NYC","willContinue":true}}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+	chunk3 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"partialArgs":"\"}"}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8},"modelVersion":"gemini-2.0-flash","responseId":"resp_sfc"}` + "\n\n"
+	stream := chunk1 + chunk2 + chunk3
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "get_weather", toolCalls[0].Name)
+
+	// The aggregated function call should contain the full args.
+	require.Len(t, resp.Candidates, 1)
+	var parts []struct {
+		FunctionCall *struct {
+			Name string          `json:"name"`
+			Args json.RawMessage `json:"args"`
+		} `json:"functionCall"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].FunctionCall)
+	assert.Equal(t, "get_weather", parts[0].FunctionCall.Name)
+	assert.Contains(t, string(parts[0].FunctionCall.Args), "location")
+	assert.Contains(t, string(parts[0].FunctionCall.Args), "NYC")
+}
+
+func TestParseGeminiStream_ThoughtToAnswerBoundary(t *testing.T) {
+	// Gemini thinking model: thought parts (thought:true) followed by
+	// answer parts (no thought flag). They must NOT be coalesced.
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Let me think...\",\"thought\":true}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\"}\n\n" +
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" reasoning step.\",\"thought\":true}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\"}\n\n" +
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"The answer is 42.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":5,\"candidatesTokenCount\":10,\"totalTokenCount\":15},\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_think\"}\n\n"
+
+	resp, _ := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	require.Len(t, resp.Candidates, 1)
+
+	var parts []struct {
+		Text    string `json:"text"`
+		Thought bool   `json:"thought"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	// Should have 2 parts: thought (coalesced) and answer (separate).
+	require.Len(t, parts, 2)
+
+	// Part 0: coalesced thought
+	assert.Equal(t, "Let me think... reasoning step.", parts[0].Text)
+	assert.True(t, parts[0].Thought)
+
+	// Part 1: answer (no thought flag)
+	assert.Equal(t, "The answer is 42.", parts[1].Text)
+	assert.False(t, parts[1].Thought)
+}
+
+func TestParseGeminiStream_StreamingFCNameOnly(t *testing.T) {
+	// A function call with only name (no args at all) should still be captured.
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"name\":\"list_items\"}}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":5,\"candidatesTokenCount\":2,\"totalTokenCount\":7},\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_noarg\"}\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "list_items", toolCalls[0].Name)
+
+	require.Len(t, resp.Candidates, 1)
+	var parts []struct {
+		FunctionCall *struct {
+			Name string `json:"name"`
+		} `json:"functionCall"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].FunctionCall)
+	assert.Equal(t, "list_items", parts[0].FunctionCall.Name)
+}

--- a/pkg/ebpf/common/http/gemini_stream_test.go
+++ b/pkg/ebpf/common/http/gemini_stream_test.go
@@ -270,7 +270,7 @@ func TestParseGeminiStream_StringsBuilderPerformance(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
 	require.Len(t, parts, 1)
-	assert.True(t, len(parts[0].Text) > 5000) // 1000 * "chunk " = 6000 chars
+	assert.Greater(t, len(parts[0].Text), 5000) // 1000 * "chunk " = 6000 chars
 }
 
 func TestParseGeminiStream_ErrorEnvelopeBare(t *testing.T) {

--- a/pkg/ebpf/common/http/gemini_stream_test.go
+++ b/pkg/ebpf/common/http/gemini_stream_test.go
@@ -539,6 +539,7 @@ func TestParseGeminiStream_StreamingFunctionCallStringFragments(t *testing.T) {
 	require.NoError(t, json.Unmarshal(parts[0].FunctionCall.Args, &args))
 	assert.Equal(t, "USA", args["country"])
 }
+
 func TestParseGeminiStream_OversizedArrayIndex(t *testing.T) {
 	// A malformed partialArgs path with an oversized array index must not
 	// cause excessive allocation. The path is silently skipped while other

--- a/pkg/ebpf/common/http/gemini_stream_test.go
+++ b/pkg/ebpf/common/http/gemini_stream_test.go
@@ -539,3 +539,38 @@ func TestParseGeminiStream_StreamingFunctionCallStringFragments(t *testing.T) {
 	require.NoError(t, json.Unmarshal(parts[0].FunctionCall.Args, &args))
 	assert.Equal(t, "USA", args["country"])
 }
+func TestParseGeminiStream_OversizedArrayIndex(t *testing.T) {
+	// A malformed partialArgs path with an oversized array index must not
+	// cause excessive allocation. The path is silently skipped while other
+	// valid data in the same stream is still processed correctly.
+	chunk1 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"bad_func","partialArgs":[{"jsonPath":"$.items[1000000000].id","numberValue":1}],"willContinue":true}}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+	// A valid second argument at a normal path.
+	chunk2 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"partialArgs":[{"jsonPath":"$.name","stringValue":"ok"}]}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8},"modelVersion":"gemini-2.0-flash","responseId":"resp_oai"}` + "\n\n"
+	stream := chunk1 + chunk2
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "bad_func", toolCalls[0].Name)
+	require.Len(t, resp.Candidates, 1)
+
+	var parts []struct {
+		FunctionCall *struct {
+			Name string          `json:"name"`
+			Args json.RawMessage `json:"args"`
+		} `json:"functionCall"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].FunctionCall)
+	assert.Equal(t, "bad_func", parts[0].FunctionCall.Name)
+
+	// The oversized array index path is skipped, but the valid "name" path
+	// should still be present in the reconstructed args.
+	var args map[string]any
+	require.NoError(t, json.Unmarshal(parts[0].FunctionCall.Args, &args))
+	assert.Equal(t, "ok", args["name"])
+	// "items" should not be present (oversized index was skipped).
+	assert.Nil(t, args["items"])
+}

--- a/pkg/ebpf/common/http/gemini_stream_test.go
+++ b/pkg/ebpf/common/http/gemini_stream_test.go
@@ -250,27 +250,25 @@ func TestParseGeminiStream_InterleavedTextAndFunctionCall(t *testing.T) {
 	assert.Nil(t, parts[2].FunctionCall)
 }
 
-func TestParseGeminiStream_StringsBuilderPerformance(t *testing.T) {
-	// Verify that large text accumulation works without error (strings.Builder).
-	var sb strings.Builder
-	sb.WriteString("data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"")
-	// 1000 chunks of text to exercise Builder path.
-	for i := 0; i < 1000; i++ {
-		sb.WriteString("chunk ")
-	}
-	sb.WriteString("\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":1,\"candidatesTokenCount\":1,\"totalTokenCount\":2},\"modelVersion\":\"gemini-2.0-flash\"}\n\n")
-	stream := sb.String()
+func TestParseGeminiStream_ManyTextChunks(t *testing.T) {
+	const chunk = `data: {"candidates":[{"content":{"parts":[{"text":"chunk "}],"role":"model"}}]}` + "\n\n"
 
-	resp, _ := parseGeminiStream(strings.NewReader(stream))
+	var stream strings.Builder
+	for range 1000 {
+		stream.WriteString(chunk)
+	}
+
+	resp, _ := parseGeminiStream(strings.NewReader(stream.String()))
 
 	require.NotNil(t, resp)
 	require.Len(t, resp.Candidates, 1)
+
 	var parts []struct {
 		Text string `json:"text"`
 	}
 	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
 	require.Len(t, parts, 1)
-	assert.Greater(t, len(parts[0].Text), 5000) // 1000 * "chunk " = 6000 chars
+	assert.Equal(t, strings.Repeat("chunk ", 1000), parts[0].Text)
 }
 
 func TestParseGeminiStream_ErrorEnvelopeBare(t *testing.T) {
@@ -304,11 +302,12 @@ func TestParseGeminiStream_ErrorEnvelopeInDataLine(t *testing.T) {
 }
 
 func TestParseGeminiStream_StreamingFunctionCallArguments(t *testing.T) {
-	// Vertex AI streamFunctionCallArguments: name arrives first, then
-	// partialArgs in subsequent chunks, last chunk without willContinue.
-	chunk1 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","partialArgs":"{\"loc","willContinue":true}}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
-	chunk2 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"partialArgs":"ation\": \"NYC","willContinue":true}}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
-	chunk3 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"partialArgs":"\"}"}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8},"modelVersion":"gemini-2.0-flash","responseId":"resp_sfc"}` + "\n\n"
+	// Vertex AI streamFunctionCallArguments: the name arrives first, then
+	// partialArgs arrive as arrays of {jsonPath, <typed value>} objects in
+	// subsequent chunks, with willContinue absent on the final fragment.
+	chunk1 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","partialArgs":[{"jsonPath":"$.location","stringValue":"NYC"}],"willContinue":true}}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+	chunk2 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"partialArgs":[{"jsonPath":"$.unit","stringValue":"celsius"}],"willContinue":true}}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+	chunk3 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"partialArgs":[{"jsonPath":"$.days","numberValue":3}]}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8},"modelVersion":"gemini-2.0-flash","responseId":"resp_sfc"}` + "\n\n"
 	stream := chunk1 + chunk2 + chunk3
 
 	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
@@ -317,7 +316,8 @@ func TestParseGeminiStream_StreamingFunctionCallArguments(t *testing.T) {
 	require.Len(t, toolCalls, 1)
 	assert.Equal(t, "get_weather", toolCalls[0].Name)
 
-	// The aggregated function call should contain the full args.
+	// The aggregated function call should reconstruct args from the paths and
+	// typed values across all fragments.
 	require.Len(t, resp.Candidates, 1)
 	var parts []struct {
 		FunctionCall *struct {
@@ -329,8 +329,12 @@ func TestParseGeminiStream_StreamingFunctionCallArguments(t *testing.T) {
 	require.Len(t, parts, 1)
 	require.NotNil(t, parts[0].FunctionCall)
 	assert.Equal(t, "get_weather", parts[0].FunctionCall.Name)
-	assert.Contains(t, string(parts[0].FunctionCall.Args), "location")
-	assert.Contains(t, string(parts[0].FunctionCall.Args), "NYC")
+
+	var args map[string]any
+	require.NoError(t, json.Unmarshal(parts[0].FunctionCall.Args, &args))
+	assert.Equal(t, "NYC", args["location"])
+	assert.Equal(t, "celsius", args["unit"])
+	assert.InEpsilon(t, float64(3), args["days"], 0.0001)
 }
 
 func TestParseGeminiStream_ThoughtToAnswerBoundary(t *testing.T) {
@@ -382,4 +386,83 @@ func TestParseGeminiStream_StreamingFCNameOnly(t *testing.T) {
 	require.Len(t, parts, 1)
 	require.NotNil(t, parts[0].FunctionCall)
 	assert.Equal(t, "list_items", parts[0].FunctionCall.Name)
+}
+
+func TestParseGeminiStream_ThoughtSignaturePreserved(t *testing.T) {
+	// Two thought parts with distinct thoughtSignatures must NOT be merged,
+	// and each signature must be carried through to the output.
+	stream := `data: {"candidates":[{"content":{"parts":[{"text":"step one","thought":true,"thoughtSignature":"sigA"}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n" +
+		`data: {"candidates":[{"content":{"parts":[{"text":"step two","thought":true,"thoughtSignature":"sigB"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":4,"totalTokenCount":7},"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+
+	resp, _ := parseGeminiStream(strings.NewReader(stream))
+	require.NotNil(t, resp)
+	require.Len(t, resp.Candidates, 1)
+
+	var parts []struct {
+		Text             string `json:"text"`
+		Thought          bool   `json:"thought"`
+		ThoughtSignature string `json:"thoughtSignature"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 2)
+	assert.Equal(t, "step one", parts[0].Text)
+	assert.Equal(t, "sigA", parts[0].ThoughtSignature)
+	assert.Equal(t, "step two", parts[1].Text)
+	assert.Equal(t, "sigB", parts[1].ThoughtSignature)
+}
+
+func TestParseGeminiStream_SignatureOnlyPart(t *testing.T) {
+	// A part with empty text but a thoughtSignature must be preserved (not
+	// dropped by the empty-text guard) and kept distinct from adjacent text.
+	stream := `data: {"candidates":[{"content":{"parts":[{"text":"answer"},{"text":"","thoughtSignature":"sigOnly"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2},"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+
+	resp, _ := parseGeminiStream(strings.NewReader(stream))
+	require.NotNil(t, resp)
+	require.Len(t, resp.Candidates, 1)
+
+	var parts []struct {
+		Text             string `json:"text"`
+		ThoughtSignature string `json:"thoughtSignature"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 2)
+	assert.Equal(t, "answer", parts[0].Text)
+	assert.Empty(t, parts[0].ThoughtSignature)
+	assert.Empty(t, parts[1].Text)
+	assert.Equal(t, "sigOnly", parts[1].ThoughtSignature)
+}
+
+func TestParseGeminiStream_FunctionCallSignaturePreserved(t *testing.T) {
+	// A function-call part carrying an outer thoughtSignature must retain it
+	// when the response is rebuilt.
+	stream := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","args":{"location":"NYC"}},"thoughtSignature":"fcSig"}],"role":"model"},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":2,"totalTokenCount":4},"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+	require.NotNil(t, resp)
+	require.Len(t, toolCalls, 1)
+	require.Len(t, resp.Candidates, 1)
+
+	var parts []struct {
+		ThoughtSignature string `json:"thoughtSignature"`
+		FunctionCall     *struct {
+			Name string `json:"name"`
+		} `json:"functionCall"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].FunctionCall)
+	assert.Equal(t, "get_weather", parts[0].FunctionCall.Name)
+	assert.Equal(t, "fcSig", parts[0].ThoughtSignature)
+}
+
+func TestParseGeminiStream_SafetyRatingsPreserved(t *testing.T) {
+	// safetyRatings present on a streamed candidate must be preserved in the
+	// rebuilt response, matching the non-streaming path.
+	stream := `data: {"candidates":[{"content":{"parts":[{"text":"hi"}],"role":"model"},"finishReason":"STOP","safetyRatings":[{"category":"HARM_CATEGORY_HATE_SPEECH","probability":"NEGLIGIBLE"}]}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":1,"totalTokenCount":2},"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+
+	resp, _ := parseGeminiStream(strings.NewReader(stream))
+	require.NotNil(t, resp)
+	require.Len(t, resp.Candidates, 1)
+	require.NotNil(t, resp.Candidates[0].SafetyRatings)
+	assert.Contains(t, string(resp.Candidates[0].SafetyRatings), "HARM_CATEGORY_HATE_SPEECH")
 }

--- a/pkg/ebpf/common/http/gemini_stream_test.go
+++ b/pkg/ebpf/common/http/gemini_stream_test.go
@@ -466,3 +466,76 @@ func TestParseGeminiStream_SafetyRatingsPreserved(t *testing.T) {
 	require.NotNil(t, resp.Candidates[0].SafetyRatings)
 	assert.Contains(t, string(resp.Candidates[0].SafetyRatings), "HARM_CATEGORY_HATE_SPEECH")
 }
+
+func TestParseGeminiStream_StreamingFunctionCallArrayPath(t *testing.T) {
+	// Vertex AI streamFunctionCallArguments with array segments in the
+	// jsonPath. Array indices are part of the PartialArg contract (the schema
+	// example uses $.foo.bar[0].data), so the reconstructed arguments must
+	// place values inside real JSON arrays rather than under bracket-suffixed
+	// object keys like "items[0]".
+	chunk1 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"create_order","partialArgs":[{"jsonPath":"$.items[0].id","numberValue":7}],"willContinue":true}}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+	chunk2 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"partialArgs":[{"jsonPath":"$.items[0].name","stringValue":"widget"}],"willContinue":true}}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+	chunk3 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"partialArgs":[{"jsonPath":"$.items[1].id","numberValue":9}]}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8},"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+	stream := chunk1 + chunk2 + chunk3
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+	require.NotNil(t, resp)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "create_order", toolCalls[0].Name)
+	require.Len(t, resp.Candidates, 1)
+
+	var parts []struct {
+		FunctionCall *struct {
+			Name string          `json:"name"`
+			Args json.RawMessage `json:"args"`
+		} `json:"functionCall"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].FunctionCall)
+
+	// items must be reconstructed as a JSON array of objects, not as
+	// bracket-suffixed keys.
+	var args struct {
+		Items []struct {
+			ID   float64 `json:"id"`
+			Name string  `json:"name"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(parts[0].FunctionCall.Args, &args))
+	require.Len(t, args.Items, 2)
+	assert.InEpsilon(t, float64(7), args.Items[0].ID, 0.0001)
+	assert.Equal(t, "widget", args.Items[0].Name)
+	assert.InEpsilon(t, float64(9), args.Items[1].ID, 0.0001)
+}
+
+func TestParseGeminiStream_StreamingFunctionCallStringFragments(t *testing.T) {
+	// Vertex AI splits a single string argument across multiple PartialArg
+	// elements sharing a jsonPath, each with willContinue=true until the final
+	// terminator (willContinue=false). The fragments must be concatenated, and
+	// the trailing empty terminator must not clobber the accumulated value.
+	chunk1 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"set_country","partialArgs":[{"jsonPath":"$.country","stringValue":"US","willContinue":true}],"willContinue":true}}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+	chunk2 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"partialArgs":[{"jsonPath":"$.country","stringValue":"A","willContinue":true}],"willContinue":true}}],"role":"model"}}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+	chunk3 := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"partialArgs":[{"jsonPath":"$.country","stringValue":"","willContinue":false}]}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8},"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+	stream := chunk1 + chunk2 + chunk3
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+	require.NotNil(t, resp)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "set_country", toolCalls[0].Name)
+	require.Len(t, resp.Candidates, 1)
+
+	var parts []struct {
+		FunctionCall *struct {
+			Name string          `json:"name"`
+			Args json.RawMessage `json:"args"`
+		} `json:"functionCall"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].FunctionCall)
+
+	var args map[string]any
+	require.NoError(t, json.Unmarshal(parts[0].FunctionCall.Args, &args))
+	assert.Equal(t, "USA", args["country"])
+}

--- a/pkg/ebpf/common/http/gemini_test.go
+++ b/pkg/ebpf/common/http/gemini_test.go
@@ -414,3 +414,43 @@ func TestGeminiFunctionCalls(t *testing.T) {
 		assert.Empty(t, result2)
 	})
 }
+
+func TestGeminiSpan_StreamResponse(t *testing.T) {
+	streamBody := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hello \"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_stream\"}\n\n" +
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"from stream.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":12,\"candidatesTokenCount\":6,\"totalTokenCount\":18},\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_stream\"}\n\n"
+
+	req := makeRequest(t, http.MethodPost, "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:streamGenerateContent", geminiRequestBody)
+	resp := makePlainResponse(http.StatusOK, http.Header{
+		"Content-Type":          []string{"text/event-stream"},
+		"X-Gemini-Service-Tier": []string{"standard"},
+	}, streamBody)
+
+	base := &request.Span{}
+	span, ok := GeminiSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Gemini)
+
+	ai := span.GenAI.Gemini
+	assert.Equal(t, request.HTTPSubtypeGemini, span.SubType)
+	assert.True(t, ai.IsStream)
+	assert.Equal(t, "gemini-2.0-flash", ai.Model)
+	assert.Equal(t, "stream_generate_content", ai.Operation)
+	assert.Equal(t, "gemini-2.0-flash", ai.Output.ModelVersion)
+	assert.Equal(t, "resp_stream", ai.Output.ResponseID)
+	assert.Equal(t, 12, ai.Output.UsageMetadata.PromptTokenCount)
+	assert.Equal(t, 6, ai.Output.UsageMetadata.CandidatesTokenCount)
+	assert.Equal(t, 18, ai.Output.UsageMetadata.TotalTokenCount)
+
+	require.Len(t, ai.Output.Candidates, 1)
+	assert.Equal(t, "STOP", ai.Output.Candidates[0].FinishReason)
+
+	var parts []struct {
+		Text string `json:"text"`
+	}
+	require.NoError(t, json.Unmarshal(ai.Output.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	assert.Equal(t, "Hello from stream.", parts[0].Text)
+	assert.NotEmpty(t, ai.GetOutput())
+}


### PR DESCRIPTION
#2394 

#1854 

Implement parseGeminiStream() to handle Server-Sent Events responses from Gemini's streamGenerateContent endpoint. This adds streaming support comparable to what exists for OpenAI and Anthropic providers.

Changes:
- New gemini_stream.go with SSE parsing and text/functionCall aggregation
- Modified GeminiSpan() to dispatch between JSON and SSE responses
- Comprehensive test coverage for streaming scenarios


## Summary

Describe the change briefly.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
