### PR TITLE
Release v0.10.0

### DIFF
--- a/internal/test/integration/components/grpc_relay/go/go.mod
+++ b/internal/test/integration/components/grpc_relay/go/go.mod
@@ -1,4 +1,4 @@
-module grpc-relay
+module go.opentelemetry.io/obi/internal/test/integration/components/grpc-relay/go
 
 go 1.25.8
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   obi:
-    version: v0.9.0
+    version: v0.10.0
     modules:
       - go.opentelemetry.io/obi
 excluded-modules:

--- a/versions.yaml
+++ b/versions.yaml
@@ -7,6 +7,10 @@ module-sets:
     modules:
       - go.opentelemetry.io/obi
 excluded-modules:
+  - github.com/GoogleCloudPlatform/microservices-demo/src/checkoutservice
+  - github.com/GoogleCloudPlatform/microservices-demo/src/frontend
+  - github.com/GoogleCloudPlatform/microservices-demo/src/productcatalogservice
+  - github.com/GoogleCloudPlatform/microservices-demo/src/shippingservice
   - github.com/hashicorp/go-version
   - github.com/hashicorp/golang-lru/v2
   - go.opentelemetry.io/collector/cmd/builder
@@ -24,6 +28,7 @@ excluded-modules:
   - go.opentelemetry.io/obi/examples/http-header-enrichment-demo/app
   - go.opentelemetry.io/obi/internal/test/benchmarks/goshorturl
   - go.opentelemetry.io/obi/internal/test/benchmarks/goshorturl/memsql
+  - go.opentelemetry.io/obi/internal/test/integration/components/go-runtime-metrics-server
   - go.opentelemetry.io/obi/internal/test/integration/components/go-stat-metrics-client
   - go.opentelemetry.io/obi/internal/test/integration/components/go-stat-metrics-server
   - go.opentelemetry.io/obi/internal/test/integration/components/go_grpc_server_mux
@@ -45,6 +50,8 @@ excluded-modules:
   - go.opentelemetry.io/obi/internal/test/integration/components/gopgx-stdlib
   - go.opentelemetry.io/obi/internal/test/integration/components/goredis
   - go.opentelemetry.io/obi/internal/test/integration/components/gosql
+  - go.opentelemetry.io/obi/internal/test/integration/components/gosunrpc
+  - go.opentelemetry.io/obi/internal/test/integration/components/grpc-relay/go
   - go.opentelemetry.io/obi/internal/test/integration/components/old_grpc/backend
   - go.opentelemetry.io/obi/internal/test/integration/components/old_grpc/worker
   - go.opentelemetry.io/obi/internal/test/integration/components/sqlclient


### PR DESCRIPTION
`v0.10.0` is a minor release with new gRPC/HTTP2 context propagation, Go channel span links, Go and JVM runtime metrics, SunRPC and expanded GenAI instrumentation, signal-specific dynamic process selection, configuration v2 groundwork, and extensive reliability and security hardening.

### New instrumentation and context propagation

- Added gRPC/HTTP2 context propagation through `sk_msg` HPACK injection. ([#1832](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1832))
- Added span links for direct and buffered Go channel handoffs, including runtime offset discovery, event reconstruction, OTLP export, and documentation. ([#2239](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2239), [#2272](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2272), [#2281](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2281), [#2417](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2417), [#2432](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2432), [#2491](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2491))
- Added SunRPC/ONC RPC protocol detection and extraction. ([#2210](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2210))
- Added a health-check endpoint for monitoring OBI pipeline liveness, with Unix domain socket support for both health checks and OTLP export. ([#2136](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2136), [#2224](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2224))
- Added automatic OpenShift cluster-name detection. ([#2268](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2268))
- Added multi-segment `iovec` support to the log enricher and split NUL-delimited log lines. ([#2078](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2078))

### Generative AI and extraction coverage

- Aligned GenAI attributes with the OpenTelemetry semantic conventions and normalized OpenAI, Anthropic, Gemini, Qwen, and Bedrock messages into the common parts-based representation. ([#2005](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2005))
- Added LLM tool-call detection for OpenAI, Anthropic, Gemini, and Qwen. ([#2118](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2118))
- Added vector retrieval observability for RAG pipelines, including Pinecone, Qdrant, Milvus, Zilliz, Chroma, Weaviate, and generic retrieval endpoints. ([#2087](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2087))
- Added MCP tool-call argument and result extraction with independent attribute-selection controls for potentially sensitive payloads. ([#2408](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2408), [#2518](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2518))
- Added extraction for retrieval `top_k`, nested rerank formats, and embedding dimensions derived from response data. ([#2409](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2409), [#2410](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2410), [#2411](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2411))
- Added SSE streaming support for OpenAI-compatible, Anthropic, and Qwen responses, increased the accumulated HTTP capture limit to 256 KiB, and improved recovery from truncated TLS and request-body captures. ([#2394](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2394), [#2407](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2407), [#2505](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2505))
- Added JSON-RPC details to span debug output and fixed top-level JSON fallback extraction. ([#2385](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2385), [#2353](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2353))

### Runtime metrics and dynamic process selection

- Added initial Go runtime metrics for memory limits, completed GC cycles, `GOMAXPROCS`, and `GOGC`. ([#2255](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2255))
- Added HotSpot JVM memory metrics using GCTracer uprobes and USDT probes, together with the generic USDT attachment support needed to collect them. ([#2305](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2305))
- Expanded the dynamic PID selector into signal-specific views for application traces, application metrics, network metrics, and stats metrics. ([#2250](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2250), [#2279](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2279), [#2340](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2340), [#2421](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2421), [#2442](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2442))
- Added per-process service identity and resource attributes to the dynamic selector and gated runtime metrics through its application-metrics view. ([#2458](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2458), [#2461](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2461))

### Metrics, exporters, and configuration

- Added TCP byte-transfer and retransmission metrics, a network flow packet counter, and a configurable StatsO11y ring-buffer wakeup threshold. ([#2157](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2157), [#2124](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2124), [#2294](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2294), [#2198](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2198))
- Added internal pipeline queue occupancy metrics to help diagnose backpressure and blocked-node failures. ([#2430](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2430))
- Added resource-attribute selection for metric and trace target information. ([#2403](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2403))
- Made TCP RTT histograms respect the configured histogram aggregation. ([#2105](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2105))
- Added configuration v2 design, schema, migration documentation, typed builders, parity validation, and internal bidirectional conversion for capture rules, telemetry, HTTP settings, network metadata, and enrichment. Configuration v2 remains internal groundwork and is not yet a public runtime configuration interface. ([#1351](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1351), [#2252](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2252), [#2253](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2253), [#2288](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2288), [#2321](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2321), [#2322](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2322), [#2462](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2462), [#2465](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2465), [#2466](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2466), [#2467](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2467), [#2468](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2468))
- Added selector-specific route refinements to config v2 export and fixed daemon log-format conversion. ([#2523](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2523), [#2524](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2524))

### Security hardening

- Bounded protocol and trace-context parsing to fresh, frame-local data, including Go `readMimeHeader`, UDP DNS, Kafka request headers, SSL payloads, Java SSL receive packets, and HTTP/2 HPACK traceparent entries. ([#2233](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2233), [#2230](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2230), [#2235](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2235), [#2237](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2237), [#2218](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2218), [#2359](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2359))
- Corrected Java proxy stream range handling so reused application buffers cannot contribute stale bytes to telemetry. ([#2229](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2229))
- Bounded Node.js inspector I/O and fallback JavaScript source scanning to prevent stalled endpoints, special files, or oversized sources from blocking instrumentation. ([#2231](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2231), [#2244](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2244))
- Rejected symlinked Java classpath paths below process roots to prevent monitored processes from redirecting route harvesting into host filesystem paths. ([#2499](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2499))
- Hardened user-space protocol processing against resource exhaustion and panics by bounding SunRPC fragments and safely handling oversized chunked HTTP response lengths and missing MQTT response buffers. ([#2516](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2516), [#2520](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2520), [#2515](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2515))
- Switched Go connection and manual-span helpers to explicit user-memory reads for pointers originating in instrumented processes. ([#2192](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2192), [#2522](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2522))
- Restricted privileged VM-test dispatches to users with write access and prevented Docker credentials from being exposed to workflows executing arbitrary dispatched refs. ([#2352](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2352))
- Added automatic query-parameter redaction for emitted URLs, including legacy AWS signed-URL credentials. ([#2415](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2415), [#2509](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2509))
- Prevented raw GenAI provider errors from bypassing attribute selection through span status messages. ([#2503](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2503))
- Updated security-affected Go, Java, JavaScript, and Python dependencies, including gRPC, pgx, Flask, Werkzeug, Requests, urllib3, and `@grpc/grpc-js`. ([#2106](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2106), [#2107](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2107), [#2308](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2308), [#2309](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2309), [#2311](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2311), [#2316](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2316), [#2317](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2317), [#2318](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2318), [#2319](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2319))

### Runtime, tracing, and protocol fixes

- Fixed stale trace context across Kafka requests, Go HTTP processing, and gRPC client connections. ([#2226](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2226), [#2232](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2232), [#2131](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2131))
- Fixed Java trace correlation across virtual-thread mounts, added context-aware JVM attachment, and improved attach sequencing. ([#2261](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2261), [#2360](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2360), [#2388](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2388))
- Added support for JDK 26 and 27. ([#2287](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2287))
- Moved JVM attachment tooling to a hardened internal fork. ([#2307](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2307), [#2326](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2326), [#2351](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2351))
- Fixed route harvesting and matching behavior for Rails, Sinatra, Java, wildcard fallbacks, and cancellation. ([#2364](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2364), [#2440](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2440), [#2423](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2423), [#2501](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2501))
- Fixed metrics exporter memory growth, stale reporter-pool cache entries, OTEL Collector shutdown hangs, and readiness-check connection and goroutine leaks. ([#2184](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2184), [#2354](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2354), [#2387](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2387), [#2436](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2436))
- Fixed SQL++ query text extraction, Kafka operation mapping, and JSON-RPC span names. ([#2214](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2214), [#2306](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2306), [#1967](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1967))
- Removed environment-based language detection that could produce false positives from Kubernetes Service Links. ([#2271](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2271))
- Fixed forwarding of host processes through Kubernetes discovery. ([#2490](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2490))
- Fixed USDT probe cleanup when links are closed. ([#2500](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2500))

### Behavior changes and compatibility notes

- `url.query` is now emitted by default for HTTP spans when present, and client `url.full` includes the query string. Sensitive values are automatically redacted, the redaction list can be extended with `attributes.extra_redact_query_params`, and `url.query` can be excluded through trace attribute selection. ([#2415](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2415))
- GraphQL documents are no longer exported by default. ([#2240](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2240))
- Java route harvesting is disabled by default while JVM-blocking edge cases are investigated. ([#2303](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2303))
- The `ip` context-propagation value is deprecated and now warns without enabling propagation. The undocumented `http` alias has been removed; use `headers` instead. ([#2278](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2278))
- The dynamic selector moved from the AppO11y-specific context to the global context and now exposes signal-specific views. Direct users of the previous internal field will need to migrate to the selector API. ([#2250](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2250), [#2340](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2340))

### Performance and validation improvements

- Improved Redis, Memcached, and unmatched TCP parsing performance. ([#2202](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2202), [#2197](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2197), [#2148](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2148))
- Improved large-buffer parsing and reduced queue allocation and locking overhead. ([#2191](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2191), [#2397](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2397), [#2413](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2413))
- Expanded verifier testing across RHEL and Amazon Linux 2023 kernels and increased verifier-test coverage and reliability. ([#2171](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2171), [#2386](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2386), [#2484](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2484))

### Build, CI, docs, and project maintenance

- Added cosign bundles when signing release artifacts. ([#2480](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2480))
- Updated the project to Go 1.25.11 and LLVM 22. ([#2439](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2439), [#2172](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2172))
- Added the OBI Store Demo example. ([#2257](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2257))
- Added the OpenTelemetry eBPF Instrumentation Generative AI Policy. ([#2152](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2152))
- Added `k8s-cache` documentation and updated developer checklists for adding NetO11y and StatsO11y metrics. ([#1886](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1886), [#2339](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2339))

**Full Changelog**: [v0.9.0...v0.10.0](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/compare/v0.9.0...v0.10.0)