### PR TITLE
Scope context propagation socket capture to monitored processes

### DIFF
--- a/bpf/tpinjector/sock_iter.c
+++ b/bpf/tpinjector/sock_iter.c
@@ -6,13 +6,44 @@
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/bpf_endian.h>
 
+#include <common/connection_info.h>
 #include <common/protocol_defs.h>
+#include <common/sockaddr.h>
 
 #include <logger/bpf_dbg.h>
 
 #include <maps/sock_dir.h>
+#include <maps/sock_pids.h>
 
 char __license[] SEC("license") = "Dual MIT/GPL";
+
+// Mirrors pid.h's filter_pids. Set for this (separate) collection via
+// tpinjector.iterConstants(). When PID filtering is off we keep the legacy
+// behaviour of tracking every existing socket.
+volatile const s32 filter_pids = 0;
+
+// Whether a pre-existing socket belongs to a monitored process. See
+// sock_belongs_to_monitored_pid() in tpinjector.c for the full rationale:
+// claiming unrelated sockets collides with other sockmap users such as Cilium
+// (https://github.com/grafana/beyla/issues/2691). sock_pids is populated in process context by kprobe/tcp_connect,
+// so at startup it only holds connections OBI has already seen connect; truly
+// pre-existing connections are intentionally left untracked rather than risk
+// capturing foreign sockets.
+static __always_inline bool iter_sock_is_monitored(struct sock_common *skc) {
+    if (!filter_pids) {
+        return true;
+    }
+
+    connection_info_t conn = {};
+    // struct sock starts with struct sock_common (__sk_common at offset 0), so
+    // skc can be read as a struct sock * by parse_sock_info.
+    if (!parse_sock_info((struct sock *)skc, &conn)) {
+        return false;
+    }
+    sort_connection_info(&conn);
+
+    return bpf_map_lookup_elem(&sock_pids, &conn) != NULL;
+}
 
 // max IPv6+port: "[ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]:65535" = 48 chars
 enum { k_addr_buf_len = 48 };
@@ -96,6 +127,10 @@ int obi_sk_iter_tcp(struct bpf_iter__tcp *ctx) {
     char dst_buf[k_addr_buf_len] = {};
 
     format_sock_addrs(skc, src_buf, dst_buf);
+
+    if (!iter_sock_is_monitored(skc)) {
+        return 0;
+    }
 
     struct seq_file *seq = ctx->meta->seq;
 

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -36,6 +36,7 @@
 #include <maps/msg_buffers.h>
 #include <maps/outgoing_trace_map.h>
 #include <maps/sock_dir.h>
+#include <maps/sock_pids.h>
 #include <maps/tp_info_mem.h>
 
 #include <tpinjector/h2_parse.h>
@@ -388,8 +389,38 @@ static __always_inline void bpf_sock_ops_set_flags(struct bpf_sock_ops *skops, u
     bpf_sock_ops_cb_flags_set(skops, skops->bpf_sock_ops_cb_flags | flags);
 }
 
+// Only sockets belonging to a process we monitor should be claimed into our
+// sockhash and routed through the sk_msg verdict. Claiming every socket in the
+// cgroup (the previous behaviour) puts unrelated sockets — including those
+// managed by another sockmap user such as Cilium's socket-LB / L7 proxy — under
+// our sk_msg verdict, corrupting and stalling those connections (beyla#2691).
+//
+// The owning PID is not reliably available here: ACTIVE_ESTABLISHED runs in
+// softirq for non-loopback sockets, so bpf_get_current_pid_tgid()/valid_pid()
+// would read an unrelated task. Instead we consult sock_pids, which is keyed by
+// the (sorted) connection tuple and populated in process context, gated by
+// valid_pid(), from kprobe/tcp_connect (see store_sock_pid in k_tracer.c). That
+// kprobe runs before the connection establishes, so the entry is present by the
+// time this callback fires.
+static __always_inline bool sock_belongs_to_monitored_pid(struct bpf_sock_ops *skops) {
+    // PID filtering disabled (OTEL_EBPF_BPF_PID_FILTER_OFF) keeps the legacy
+    // behaviour of tracking every socket.
+    if (!filter_pids) {
+        return true;
+    }
+
+    connection_info_t conn = get_connection_info_ops(skops);
+    sort_connection_info(&conn);
+
+    return bpf_map_lookup_elem(&sock_pids, &conn) != NULL;
+}
+
 // Helper that writes in the sock map for a sock_ops program
 static __always_inline void bpf_sock_ops_active_est_cb(struct bpf_sock_ops *skops) {
+    if (!sock_belongs_to_monitored_pid(skops)) {
+        return;
+    }
+
     const u64 cookie = bpf_get_socket_cookie(skops);
 
     bpf_sock_hash_update(skops, &sock_dir, (void *)&cookie, BPF_ANY);

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -393,7 +393,7 @@ static __always_inline void bpf_sock_ops_set_flags(struct bpf_sock_ops *skops, u
 // sockhash and routed through the sk_msg verdict. Claiming every socket in the
 // cgroup (the previous behaviour) puts unrelated sockets — including those
 // managed by another sockmap user such as Cilium's socket-LB / L7 proxy — under
-// our sk_msg verdict, corrupting and stalling those connections (beyla#2691).
+// our sk_msg verdict, corrupting and stalling those connections (https://github.com/grafana/beyla/issues/2691).
 //
 // The owning PID is not reliably available here: ACTIVE_ESTABLISHED runs in
 // softirq for non-loopback sockets, so bpf_get_current_pid_tgid()/valid_pid()

--- a/pkg/internal/ebpf/tpinjector/sockmap_coexistence_privileged_test.go
+++ b/pkg/internal/ebpf/tpinjector/sockmap_coexistence_privileged_test.go
@@ -3,48 +3,22 @@
 
 //go:build linux && privileged_tests
 
-// Reproducer for grafana/beyla#2691 ("Beyla sock_ops/sk_msg programs
-// conflicting with Cilium L7 LB generating stalled connections").
+// Privileged reproducer and regression guard for https://github.com/grafana/beyla/issues/2691
 //
-// Root cause being demonstrated
-// -----------------------------
-// tpinjector's `obi_sockmap_tracker` (SEC("sockops"), attached to the *root*
-// cgroup in production) inserts EVERY outgoing established socket into the
-// `sock_dir` SOCKHASH (bpf/tpinjector/tpinjector.c, BPF_SOCK_OPS_ACTIVE_-
-// ESTABLISHED_CB -> bpf_sock_hash_update), and `obi_packet_extender`
-// (SEC("sk_msg")) is attached as the verdict program over that sockhash.
+// OBI propagates trace context by claiming TCP sockets into the sock_dir
+// sockhash and running an sk_msg verdict over them. Claiming sockets it does not
+// own collides with another sockmap user on the same host (e.g. Cilium's
+// socket-LB) and stalls those connections. These tests assert OBI only claims
+// sockets of monitored processes — for both the live sockops path and the
+// startup iterator — with PID-filter-off positive controls.
 //
-// Crucially, the sockops callback has NO PID/process gate: the socket is
-// claimed regardless of whether it belongs to a monitored process. The
-// `filter_pids` / valid_pid() check only runs *later*, inside the sk_msg
-// program, to decide whether to inject — by then the socket is already a
-// member of OBI's sockhash and is being routed through OBI's sk_msg verdict.
-//
-// That indiscriminate capture is the surface that collides with another
-// sockmap consumer on the same host/cgroup — e.g. Cilium's socket-LB / L7 LB,
-// which also redirects sockets via sockhash + an sk_msg/sk_skb verdict. Two
-// verdict programs fighting over the same socket's psock (and OBI rewriting
-// bytes with bpf_msg_push_data on streams Cilium has spliced) is what stalls
-// connections. The reporter confirmed: context_propagation=disabled => no
-// stall; context_propagation=headers => stall.
-//
-// What this test asserts
-// ----------------------
-// With PID filtering ON (filter_pids=1) and NO monitored process registered,
-// a plain loopback TCP connection opened by an UNRELATED (bystander) process
-// must NOT be claimed into OBI's sock_dir sockhash. Today it IS claimed, so
-// this test FAILS on current code — that failure is the reproduction. Once the
-// sockops program is scoped to monitored sockets only, the test passes and
-// becomes the regression guard.
-//
-// NOTE: authored from static analysis; it must be run on Linux via
-//   make test-privileged
-// (e.g. `go test -tags=linux,privileged_tests ./pkg/internal/ebpf/tpinjector/`).
+// Linux + root only: run with `make test-privileged`.
 
 package tpinjector
 
 import (
 	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -74,12 +48,9 @@ func requireCgroupV2(t *testing.T) {
 	}
 }
 
-// currentCgroupV2Path returns the cgroup v2 (unified) directory the test
-// process already belongs to. Attaching the sockops program here exercises the
-// exact production attach type (AttachCGroupSockOps) without creating or moving
-// cgroups — robust inside a (privileged) container as well as on a bare host.
-// In production OBI attaches at the root cgroup; the bug is identical at any
-// level of the hierarchy because the sockops callback has no PID gate.
+// currentCgroupV2Path returns the cgroup v2 dir the test process already lives
+// in. Attaching the sockops here uses the real production attach type without
+// creating/moving cgroups, so it works inside a privileged container too.
 func currentCgroupV2Path(t *testing.T) string {
 	t.Helper()
 	data, err := os.ReadFile("/proc/self/cgroup")
@@ -165,14 +136,9 @@ func attachSockmap(t *testing.T, objs *BpfObjects, cgPath string) {
 	})
 }
 
-// loopbackRoundTrip opens a loopback TCP connection from THIS process (the
-// bystander) and exchanges a small non-HTTP payload, so the client socket goes
-// through BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB while it lives in the cgroup.
-// openLoopbackConn establishes a loopback TCP connection from THIS process (the
-// bystander), exchanges a byte so both ends reach ESTABLISHED (firing
-// BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB on the client socket), and returns it still
-// OPEN. The caller must keep it open while measuring: a socket is auto-removed
-// from the sockhash on close, so measuring after close would miss the capture.
+// openLoopbackConn opens a loopback TCP connection from THIS (bystander) process
+// and returns it still OPEN. Keep it open while measuring: the kernel removes a
+// socket from the sockhash on close, so measuring after close misses the capture.
 func openLoopbackConn(t *testing.T) func() {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -226,14 +192,9 @@ func countSockhashEntries(t *testing.T, m *ebpf.Map) int {
 	return count
 }
 
-// TestSockmap_DoesNotClaimBystanderSockets reproduces grafana/beyla#2691.
-//
-// EXPECTED ON CURRENT CODE: FAIL — the bystander socket is found in sock_dir,
-// proving tpinjector claims sockets of non-monitored processes into its
-// sockmap and routes them through its sk_msg verdict program. That is the
-// precondition for the Cilium socket-LB / sk_msg conflict that stalls
-// connections. Fixing the sockops program to only track monitored sockets
-// makes this pass.
+// TestSockmap_DoesNotClaimBystanderSockets is the core reproducer/guard: with
+// PID filtering on and no monitored process, a bystander connection must not be
+// claimed into sock_dir. Fails pre-fix (socket captured), passes post-fix.
 func TestSockmap_DoesNotClaimBystanderSockets(t *testing.T) {
 	requireCgroupV2(t)
 
@@ -241,34 +202,27 @@ func TestSockmap_DoesNotClaimBystanderSockets(t *testing.T) {
 	cgPath := currentCgroupV2Path(t)
 	attachSockmap(t, objs, cgPath)
 
-	// Baseline before generating any traffic of our own.
 	before := countSockhashEntries(t, objs.SockDir)
 
-	// Open a bystander connection and KEEP it open while we measure.
 	closeConn := openLoopbackConn(t)
 	defer closeConn()
 
-	// Desired (post-fix) behaviour: a bystander, non-monitored connection is
-	// NOT pulled into OBI's sockhash, so the count does not grow. On current
-	// code the count DOES grow (the active-established socket is captured while
-	// the connection is open), so this assertion FAILS — which is the
-	// reproduction of beyla#2691.
+	// The bystander connection must not grow sock_dir. Pre-fix it does (the
+	// socket is captured while open), which is the beyla#2691 reproduction.
 	assert.Never(t, func() bool {
 		return countSockhashEntries(t, objs.SockDir) > before
 	}, time.Second, 50*time.Millisecond,
-		"BUG (beyla#2691): tpinjector claimed a bystander (non-monitored) "+
+		"BUG: tpinjector claimed a bystander (non-monitored) "+
 			"socket into sock_dir even with filter_pids=1. Every cgroup socket "+
 			"is captured into OBI's sockhash and run through its sk_msg verdict, "+
 			"which collides with Cilium's socket-LB sockmap and stalls connections.")
 }
 
-// TestSockmap_CapturesWhenPidFilterOff is the positive control for the fix: with
-// PID filtering OFF (the legacy "track everything" mode) the sockops MUST still
-// capture sockets into sock_dir. It guards against a regression where the
-// monitored-only gating accidentally disables capture altogether — which would
-// silently break context propagation. The faithful "monitored process IS
-// captured" path (sock_pids populated by kprobe/tcp_connect) is exercised by the
-// end-to-end traceparent integration tests.
+// TestSockmap_CapturesWhenPidFilterOff is the positive control: with PID
+// filtering off ("track everything"), the sockops must still capture sockets,
+// so a green TestSockmap_DoesNotClaimBystanderSockets can't just mean capture is
+// broken. The monitored-process-IS-captured path is covered by the end-to-end
+// traceparent integration tests.
 func TestSockmap_CapturesWhenPidFilterOff(t *testing.T) {
 	requireCgroupV2(t)
 
@@ -286,4 +240,77 @@ func TestSockmap_CapturesWhenPidFilterOff(t *testing.T) {
 	}, time.Second, 50*time.Millisecond,
 		"with filter_pids=0 the sockops must still capture sockets into sock_dir; "+
 			"if this fails the capture machinery (or the fix's gate) is broken")
+}
+
+// --- startup iterator (sock_iter.c) -----------------------------------------
+
+// loadTPInjectorIter loads the sock_iter collection (the startup TCP iterator)
+// with the given filterPids value, pinning stripped so it loads standalone.
+func loadTPInjectorIter(t *testing.T, filterPids int32) *BpfIterObjects {
+	t.Helper()
+	require.NoError(t, rlimit.RemoveMemlock())
+
+	spec, err := LoadBpfIter()
+	require.NoError(t, err)
+
+	for _, m := range spec.Maps {
+		m.Pinning = ebpf.PinNone
+	}
+	setVar(t, spec, "filter_pids", filterPids)
+	_ = trySetVar(spec, "g_bpf_debug", int32(0))
+
+	objs := &BpfIterObjects{}
+	require.NoError(t, spec.LoadAndAssign(objs, nil))
+	t.Cleanup(func() { objs.Close() })
+	return objs
+}
+
+// driveIter attaches the iter/tcp program and reads it to completion, which
+// makes the kernel invoke the program once per existing TCP socket. Skips on
+// kernels too old to attach iter/tcp + sockhash (< 6.4).
+func driveIter(t *testing.T, prog *ebpf.Program) {
+	t.Helper()
+	it, err := link.AttachIter(link.IterOptions{Program: prog})
+	if err != nil {
+		t.Skipf("cannot attach iter/tcp (needs kernel >= 6.4): %v", err)
+	}
+	defer it.Close()
+
+	r, err := it.Open()
+	require.NoError(t, err)
+	defer r.Close()
+	_, err = io.ReadAll(r)
+	require.NoError(t, err)
+}
+
+// TestSockmapIter_DoesNotTrackBystanderSockets is the iterator counterpart: the
+// startup iterator must not pull pre-existing, non-monitored sockets into
+// sock_dir. Filter on + empty sock_pids => driving it adds nothing (pre-fix it
+// added every existing socket).
+func TestSockmapIter_DoesNotTrackBystanderSockets(t *testing.T) {
+	objs := loadTPInjectorIter(t, 1) // PID filtering ON
+
+	closeConn := openLoopbackConn(t)
+	defer closeConn()
+
+	driveIter(t, objs.ObiSkIterTcp)
+
+	assert.Equal(t, 0, countSockhashEntries(t, objs.SockDir),
+		"BUG: the startup iterator tracked pre-existing bystander "+
+			"sockets into sock_dir despite filter_pids=1 and an empty sock_pids.")
+}
+
+// TestSockmapIter_TracksWhenPidFilterOff is the positive control: with PID
+// filtering OFF the iterator must still track existing sockets, guarding
+// against the gate disabling startup tracking entirely.
+func TestSockmapIter_TracksWhenPidFilterOff(t *testing.T) {
+	objs := loadTPInjectorIter(t, 0) // PID filtering OFF -> track everything
+
+	closeConn := openLoopbackConn(t)
+	defer closeConn()
+
+	driveIter(t, objs.ObiSkIterTcp)
+
+	assert.Positive(t, countSockhashEntries(t, objs.SockDir),
+		"with filter_pids=0 the iterator must track existing sockets into sock_dir")
 }

--- a/pkg/internal/ebpf/tpinjector/sockmap_coexistence_privileged_test.go
+++ b/pkg/internal/ebpf/tpinjector/sockmap_coexistence_privileged_test.go
@@ -1,0 +1,262 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && privileged_tests
+
+// Reproducer for grafana/beyla#2691 ("Beyla sock_ops/sk_msg programs
+// conflicting with Cilium L7 LB generating stalled connections").
+//
+// Root cause being demonstrated
+// -----------------------------
+// tpinjector's `obi_sockmap_tracker` (SEC("sockops"), attached to the *root*
+// cgroup in production) inserts EVERY outgoing established socket into the
+// `sock_dir` SOCKHASH (bpf/tpinjector/tpinjector.c, BPF_SOCK_OPS_ACTIVE_-
+// ESTABLISHED_CB -> bpf_sock_hash_update), and `obi_packet_extender`
+// (SEC("sk_msg")) is attached as the verdict program over that sockhash.
+//
+// Crucially, the sockops callback has NO PID/process gate: the socket is
+// claimed regardless of whether it belongs to a monitored process. The
+// `filter_pids` / valid_pid() check only runs *later*, inside the sk_msg
+// program, to decide whether to inject — by then the socket is already a
+// member of OBI's sockhash and is being routed through OBI's sk_msg verdict.
+//
+// That indiscriminate capture is the surface that collides with another
+// sockmap consumer on the same host/cgroup — e.g. Cilium's socket-LB / L7 LB,
+// which also redirects sockets via sockhash + an sk_msg/sk_skb verdict. Two
+// verdict programs fighting over the same socket's psock (and OBI rewriting
+// bytes with bpf_msg_push_data on streams Cilium has spliced) is what stalls
+// connections. The reporter confirmed: context_propagation=disabled => no
+// stall; context_propagation=headers => stall.
+//
+// What this test asserts
+// ----------------------
+// With PID filtering ON (filter_pids=1) and NO monitored process registered,
+// a plain loopback TCP connection opened by an UNRELATED (bystander) process
+// must NOT be claimed into OBI's sock_dir sockhash. Today it IS claimed, so
+// this test FAILS on current code — that failure is the reproduction. Once the
+// sockops program is scoped to monitored sockets only, the test passes and
+// becomes the regression guard.
+//
+// NOTE: authored from static analysis; it must be run on Linux via
+//   make test-privileged
+// (e.g. `go test -tags=linux,privileged_tests ./pkg/internal/ebpf/tpinjector/`).
+
+package tpinjector
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+const cgroupFSRoot = "/sys/fs/cgroup"
+
+// requireCgroupV2 skips the test unless the host exposes a unified (v2)
+// cgroup hierarchy at /sys/fs/cgroup, which is what OBI attaches sockops to.
+func requireCgroupV2(t *testing.T) {
+	t.Helper()
+	var st unix.Statfs_t
+	require.NoError(t, unix.Statfs(cgroupFSRoot, &st))
+	const cgroup2Magic = 0x63677270
+	if st.Type != cgroup2Magic {
+		t.Skipf("%s is not a cgroup v2 mount (magic=%#x); skipping", cgroupFSRoot, st.Type)
+	}
+}
+
+// currentCgroupV2Path returns the cgroup v2 (unified) directory the test
+// process already belongs to. Attaching the sockops program here exercises the
+// exact production attach type (AttachCGroupSockOps) without creating or moving
+// cgroups — robust inside a (privileged) container as well as on a bare host.
+// In production OBI attaches at the root cgroup; the bug is identical at any
+// level of the hierarchy because the sockops callback has no PID gate.
+func currentCgroupV2Path(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("/proc/self/cgroup")
+	require.NoError(t, err)
+	for _, line := range strings.Split(string(data), "\n") {
+		// The unified-hierarchy entry is "0::<path>".
+		if rel, ok := strings.CutPrefix(line, "0::"); ok {
+			return filepath.Join(cgroupFSRoot, rel)
+		}
+	}
+	t.Skip("no cgroup v2 (unified) membership found in /proc/self/cgroup")
+	return ""
+}
+
+// loadTPInjector loads the real tpinjector collection with PID filtering ON and
+// HTTP-header injection enabled (the "headers" mode the reporter saw stall),
+// stripping map pinning so it can load outside the OBI bpffs layout.
+func loadTPInjector(t *testing.T) *BpfObjects {
+	t.Helper()
+	require.NoError(t, rlimit.RemoveMemlock())
+
+	spec, err := LoadBpf()
+	require.NoError(t, err)
+
+	// The production maps are pinned (OBI_PIN_INTERNAL); a standalone test has
+	// no bpffs layout, so disable pinning across the collection.
+	for _, m := range spec.Maps {
+		m.Pinning = ebpf.PinNone
+	}
+
+	// Mirror tpinjector.constants(): filtering ON, headers injection ON.
+	setVar(t, spec, "filter_pids", int32(1))
+	setVar(t, spec, "inject_flags", uint32(1)) // k_inject_http_headers
+	setVar(t, spec, "max_transaction_time", uint64((10 * time.Second).Nanoseconds()))
+	_ = trySetVar(spec, "g_bpf_debug", int32(0)) // best-effort; name may vary
+
+	objs := &BpfObjects{}
+	require.NoError(t, spec.LoadAndAssign(objs, nil))
+	t.Cleanup(func() { objs.Close() })
+	return objs
+}
+
+func setVar(t *testing.T, spec *ebpf.CollectionSpec, name string, val any) {
+	t.Helper()
+	require.NoError(t, trySetVar(spec, name, val), "setting const %q", name)
+}
+
+func trySetVar(spec *ebpf.CollectionSpec, name string, val any) error {
+	v, ok := spec.Variables[name]
+	if !ok {
+		return errors.New("variable not found: " + name)
+	}
+	return v.Set(val)
+}
+
+// attachSockmap attaches the sockops tracker to the cgroup and the sk_msg
+// verdict program to the sock_dir sockhash — exactly as instrumenter.sockops /
+// instrumenter.sockmsgs do in production (pkg/ebpf/instrumenter.go).
+func attachSockmap(t *testing.T, objs *BpfObjects, cgPath string) {
+	t.Helper()
+
+	cg, err := link.AttachCgroup(link.CgroupOptions{
+		Path:    cgPath,
+		Program: objs.ObiSockmapTracker,
+		Attach:  ebpf.AttachCGroupSockOps,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { cg.Close() })
+
+	err = link.RawAttachProgram(link.RawAttachProgramOptions{
+		Target:  objs.SockDir.FD(),
+		Program: objs.ObiPacketExtender,
+		Attach:  ebpf.AttachSkMsgVerdict,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = link.RawDetachProgram(link.RawDetachProgramOptions{
+			Target:  objs.SockDir.FD(),
+			Program: objs.ObiPacketExtender,
+			Attach:  ebpf.AttachSkMsgVerdict,
+		})
+	})
+}
+
+// loopbackRoundTrip opens a loopback TCP connection from THIS process (the
+// bystander) and exchanges a small non-HTTP payload, so the client socket goes
+// through BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB while it lives in the cgroup.
+// openLoopbackConn establishes a loopback TCP connection from THIS process (the
+// bystander), exchanges a byte so both ends reach ESTABLISHED (firing
+// BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB on the client socket), and returns it still
+// OPEN. The caller must keep it open while measuring: a socket is auto-removed
+// from the sockhash on close, so measuring after close would miss the capture.
+func openLoopbackConn(t *testing.T) func() {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			accepted <- nil
+			return
+		}
+		buf := make([]byte, 16)
+		n, _ := c.Read(buf)
+		_, _ = c.Write(buf[:n])
+		accepted <- c
+	}()
+
+	conn, err := net.DialTimeout("tcp", ln.Addr().String(), 2*time.Second)
+	require.NoError(t, err)
+	require.NoError(t, conn.SetDeadline(time.Now().Add(2*time.Second)))
+	_, err = conn.Write([]byte("ping"))
+	require.NoError(t, err)
+	_, _ = conn.Read(make([]byte, 16))
+
+	srv := <-accepted
+	return func() {
+		conn.Close()
+		if srv != nil {
+			srv.Close()
+		}
+		ln.Close()
+	}
+}
+
+// countSockhashEntries counts keys in a SOCKHASH. Userspace cannot Lookup the
+// socket *values* of a sockhash, but GetNextKey (key-only iteration) works.
+func countSockhashEntries(t *testing.T, m *ebpf.Map) int {
+	t.Helper()
+	var key, next uint64
+	count := 0
+	err := m.NextKey(nil, &next)
+	for err == nil {
+		count++
+		key = next
+		err = m.NextKey(key, &next)
+	}
+	if !errors.Is(err, ebpf.ErrKeyNotExist) {
+		require.NoError(t, err)
+	}
+	return count
+}
+
+// TestSockmap_DoesNotClaimBystanderSockets reproduces grafana/beyla#2691.
+//
+// EXPECTED ON CURRENT CODE: FAIL — the bystander socket is found in sock_dir,
+// proving tpinjector claims sockets of non-monitored processes into its
+// sockmap and routes them through its sk_msg verdict program. That is the
+// precondition for the Cilium socket-LB / sk_msg conflict that stalls
+// connections. Fixing the sockops program to only track monitored sockets
+// makes this pass.
+func TestSockmap_DoesNotClaimBystanderSockets(t *testing.T) {
+	requireCgroupV2(t)
+
+	objs := loadTPInjector(t)
+	cgPath := currentCgroupV2Path(t)
+	attachSockmap(t, objs, cgPath)
+
+	// Baseline before generating any traffic of our own.
+	before := countSockhashEntries(t, objs.SockDir)
+
+	// Open a bystander connection and KEEP it open while we measure.
+	closeConn := openLoopbackConn(t)
+	defer closeConn()
+
+	// Desired (post-fix) behaviour: a bystander, non-monitored connection is
+	// NOT pulled into OBI's sockhash, so the count does not grow. On current
+	// code the count DOES grow (the active-established socket is captured while
+	// the connection is open), so this assertion FAILS — which is the
+	// reproduction of beyla#2691.
+	assert.Never(t, func() bool {
+		return countSockhashEntries(t, objs.SockDir) > before
+	}, time.Second, 50*time.Millisecond,
+		"BUG (beyla#2691): tpinjector claimed a bystander (non-monitored) "+
+			"socket into sock_dir even with filter_pids=1. Every cgroup socket "+
+			"is captured into OBI's sockhash and run through its sk_msg verdict, "+
+			"which collides with Cilium's socket-LB sockmap and stalls connections.")
+}

--- a/pkg/internal/ebpf/tpinjector/sockmap_coexistence_privileged_test.go
+++ b/pkg/internal/ebpf/tpinjector/sockmap_coexistence_privileged_test.go
@@ -94,10 +94,11 @@ func currentCgroupV2Path(t *testing.T) string {
 	return ""
 }
 
-// loadTPInjector loads the real tpinjector collection with PID filtering ON and
-// HTTP-header injection enabled (the "headers" mode the reporter saw stall),
-// stripping map pinning so it can load outside the OBI bpffs layout.
-func loadTPInjector(t *testing.T) *BpfObjects {
+// loadTPInjector loads the real tpinjector collection with HTTP-header
+// injection enabled (the "headers" mode the reporter saw stall) and the given
+// filterPids value, stripping map pinning so it can load outside the OBI bpffs
+// layout.
+func loadTPInjector(t *testing.T, filterPids int32) *BpfObjects {
 	t.Helper()
 	require.NoError(t, rlimit.RemoveMemlock())
 
@@ -110,8 +111,8 @@ func loadTPInjector(t *testing.T) *BpfObjects {
 		m.Pinning = ebpf.PinNone
 	}
 
-	// Mirror tpinjector.constants(): filtering ON, headers injection ON.
-	setVar(t, spec, "filter_pids", int32(1))
+	// Mirror tpinjector.constants(): headers injection ON.
+	setVar(t, spec, "filter_pids", filterPids)
 	setVar(t, spec, "inject_flags", uint32(1)) // k_inject_http_headers
 	setVar(t, spec, "max_transaction_time", uint64((10 * time.Second).Nanoseconds()))
 	_ = trySetVar(spec, "g_bpf_debug", int32(0)) // best-effort; name may vary
@@ -236,7 +237,7 @@ func countSockhashEntries(t *testing.T, m *ebpf.Map) int {
 func TestSockmap_DoesNotClaimBystanderSockets(t *testing.T) {
 	requireCgroupV2(t)
 
-	objs := loadTPInjector(t)
+	objs := loadTPInjector(t, 1) // PID filtering ON
 	cgPath := currentCgroupV2Path(t)
 	attachSockmap(t, objs, cgPath)
 
@@ -259,4 +260,30 @@ func TestSockmap_DoesNotClaimBystanderSockets(t *testing.T) {
 			"socket into sock_dir even with filter_pids=1. Every cgroup socket "+
 			"is captured into OBI's sockhash and run through its sk_msg verdict, "+
 			"which collides with Cilium's socket-LB sockmap and stalls connections.")
+}
+
+// TestSockmap_CapturesWhenPidFilterOff is the positive control for the fix: with
+// PID filtering OFF (the legacy "track everything" mode) the sockops MUST still
+// capture sockets into sock_dir. It guards against a regression where the
+// monitored-only gating accidentally disables capture altogether — which would
+// silently break context propagation. The faithful "monitored process IS
+// captured" path (sock_pids populated by kprobe/tcp_connect) is exercised by the
+// end-to-end traceparent integration tests.
+func TestSockmap_CapturesWhenPidFilterOff(t *testing.T) {
+	requireCgroupV2(t)
+
+	objs := loadTPInjector(t, 0) // PID filtering OFF -> track everything
+	cgPath := currentCgroupV2Path(t)
+	attachSockmap(t, objs, cgPath)
+
+	before := countSockhashEntries(t, objs.SockDir)
+
+	closeConn := openLoopbackConn(t)
+	defer closeConn()
+
+	assert.Eventually(t, func() bool {
+		return countSockhashEntries(t, objs.SockDir) > before
+	}, time.Second, 50*time.Millisecond,
+		"with filter_pids=0 the sockops must still capture sockets into sock_dir; "+
+			"if this fails the capture machinery (or the fix's gate) is broken")
 }

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -101,7 +101,13 @@ func (p *Tracer) constants() map[string]any {
 }
 
 func (p *Tracer) iterConstants() map[string]any {
+	filterPids := int32(1)
+	if p.cfg.Discovery.BPFPidFilterOff {
+		filterPids = 0
+	}
+
 	return map[string]any{
+		"filter_pids": filterPids,
 		"g_bpf_debug": p.cfg.EBPF.BpfDebug,
 	}
 }

--- a/pkg/internal/ebpf/tpinjector/tpinjector_test.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector_test.go
@@ -113,11 +113,15 @@ func TestTracer_Constants(t *testing.T) {
 			_, ok = c["g_bpf_debug"]
 			assert.True(t, ok, "g_bpf_debug should be present")
 
-			// Spec 1 (sock_iter) carries only the debug flag.
+			// Spec 1 (sock_iter) carries the debug flag and filter_pids, the
+			// latter gating which pre-existing sockets the iterator tracks.
 			iterC := bundles[1].Constants
 			_, ok = iterC["g_bpf_debug"]
 			assert.True(t, ok, "iter g_bpf_debug should be present")
-			assert.Len(t, iterC, 1, "iter spec should have only g_bpf_debug")
+			iterFilterPids, ok := iterC["filter_pids"]
+			assert.True(t, ok, "iter filter_pids should be present")
+			assert.Equal(t, tt.expectedFilterPids, iterFilterPids)
+			assert.Len(t, iterC, 2, "iter spec should have g_bpf_debug and filter_pids")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes grafana/beyla#2691 ("sock_ops/sk_msg programs
conflicting with Cilium L7 LB generating stalled connections").

When context propagation is enabled, `tpinjector` claims TCP sockets into the
`sock_dir` sockhash and runs an `sk_msg` verdict (`obi_packet_extender`) over
them to inject `traceparent`. Both capture paths claimed **every** socket in the
cgroup, regardless of whether it belonged to a process OBI monitors:

- `obi_sockmap_tracker` (sockops) on `BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB` called
  `bpf_sock_hash_update` unconditionally. The `valid_pid()` gate only runs later,
  in the `sk_msg` program — by then the socket is already in the sockhash.
- `obi_sk_iter_tcp` (startup iter/tcp) added every existing socket too.

On hosts where another component manages the same sockets via sockmap — e.g.
Cilium's socket-LB / L7 proxy — both run an `sk_msg`/`sk_skb` verdict over the
same sockets and OBI additionally rewrites bytes with `bpf_msg_push_data`,
corrupting/stalling those connections. Reporter confirmed:
`context_propagation=disabled` → no stall; `=headers` → stall.

This is the sockmap-layer analogue of the existing TC-layer Cilium handling
(`EnsureCiliumCompatibility`), which had no counterpart here.

### Fix

Only claim sockets owned by a monitored process. The owning PID isn't reliable
in the sockops callback (ACTIVE_ESTABLISHED runs in softirq for non-loopback
sockets), so we consult `sock_pids` — keyed by the connection tuple and
populated in process context, gated by `valid_pid()`, from `kprobe/tcp_connect`
(`store_sock_pid`), which runs before establishment.

- `tpinjector.c`: `bpf_sock_ops_active_est_cb` now gates on
  `sock_belongs_to_monitored_pid()`.
- `sock_iter.c`: `obi_sk_iter_tcp` now gates on `iter_sock_is_monitored()`;
  `iterConstants()` propagates `filter_pids` to the iter collection.
- `filter_pids == 0` (PID filter off) preserves the legacy "track everything"
  behavior.

### Behavior change

Connections open **before** OBI starts aren't in `sock_pids`, so the startup
iterator no longer tracks them. This is intentional: such sockets can't be
attributed to a monitored process, and tracking them is exactly what triggers
the Cilium conflict.

### Tests

New privileged tests (`sockmap_coexistence_privileged_test.go`) load the real
BPF objects, attach them, and drive loopback traffic:

- `TestSockmap_DoesNotClaimBystanderSockets` — fails pre-fix, passes post-fix.
- `TestSockmapIter_DoesNotTrackBystanderSockets` — iterator counterpart.
- `*_CapturesWhenPidFilterOff` / `*_TracksWhenPidFilterOff` — positive controls
  ensuring the fix didn't disable capture entirely.

Run: `make test-privileged`. Verified on kernel 7.0. The monitored-IS-captured
path remains covered by the end-to-end traceparent integration suites.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
