### PR TITLE
Fix empty `telemetry.distro.version` in published Docker images

### DIFF
--- a/.github/workflows/publish_dockerhub_k8s_cache_main.yml
+++ b/.github/workflows/publish_dockerhub_k8s_cache_main.yml
@@ -48,6 +48,10 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
+      - name: Compute short SHA
+        id: short_sha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -87,6 +91,9 @@ jobs:
           file: ./k8scache.Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            RELEASE_VERSION=${{ inputs.ref || steps.short_sha.outputs.sha }}
+            RELEASE_REVISION=${{ steps.short_sha.outputs.sha }}
           outputs: type=image,"name=ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }},docker.io/otel/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/publish_dockerhub_main.yml
+++ b/.github/workflows/publish_dockerhub_main.yml
@@ -48,6 +48,10 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
+      - name: Compute short SHA
+        id: short_sha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -87,6 +91,9 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            RELEASE_VERSION=${{ inputs.ref || steps.short_sha.outputs.sha }}
+            RELEASE_REVISION=${{ steps.short_sha.outputs.sha }}
           outputs: type=image,"name=ghcr.io/${{ github.repository }}/${{ env.IMAGE_NAME }},docker.io/otel/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/pull_request_docker_build_test.yml
+++ b/.github/workflows/pull_request_docker_build_test.yml
@@ -55,6 +55,10 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
 
+      - name: Compute short SHA
+        id: short_sha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
@@ -65,3 +69,6 @@ jobs:
           file: ./${{ matrix.file }}
           push: false
           platforms: ${{ matrix.platform }}
+          build-args: |
+            RELEASE_VERSION=${{ inputs.ref || github.ref_name }}
+            RELEASE_REVISION=${{ steps.short_sha.outputs.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,9 @@ RUN gradle build -x buildNativeLib-amd64 -x buildNativeLib-aarch64 --no-daemon
 # Build the autoinstrumenter binary
 FROM ghcr.io/open-telemetry/obi-generator:${TAG} AS builder
 
-# TODO: embed software version in executable
-
 ARG TARGETARCH
+ARG RELEASE_VERSION=unset
+ARG RELEASE_REVISION=unset
 
 ENV GOARCH=$TARGETARCH
 
@@ -67,7 +67,6 @@ COPY go.mod go.sum ./
 # Cache module cache.
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
-COPY .git/ .git/
 COPY bpf/ bpf/
 COPY cmd/ cmd/
 COPY pkg/ pkg/
@@ -78,7 +77,7 @@ COPY --from=javaagent-builder /build/build/obi-java-agent.jar /src/pkg/internal/
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
 	/generate.sh \
-	&& make compile
+	&& make compile RELEASE_VERSION=${RELEASE_VERSION} RELEASE_REVISION=${RELEASE_REVISION}
 
 # Create final image from minimal + built binary
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ GOOS ?= linux
 GOARCH ?= $(shell go env GOARCH || echo amd64)
 
 # RELEASE_VERSION will contain the tag name, or the branch name if current commit is not a tag
-RELEASE_VERSION := $(shell git describe --all | cut -d/ -f2)
-RELEASE_REVISION := $(shell git rev-parse --short HEAD )
+RELEASE_VERSION ?= $(shell git describe --all | cut -d/ -f2-)
+RELEASE_REVISION ?= $(shell git rev-parse --short HEAD )
 BUILDINFO_PKG ?= go.opentelemetry.io/obi/pkg/buildinfo
 TEST_OUTPUT ?= ./testoutput
 RELEASE_DIR ?= ./dist
@@ -412,7 +412,10 @@ java-verify: java-spotless-check java-test java-build
 image-build:
 	@echo "### Building the auto-instrumenter image"
 	$(call check_defined, IMG_ORG, Your Docker repository user name)
-	$(OCI_BIN) buildx build --load -t ${IMG} .
+	$(OCI_BIN) buildx build --load -t ${IMG} \
+		--build-arg RELEASE_VERSION=${RELEASE_VERSION} \
+		--build-arg RELEASE_REVISION=${RELEASE_REVISION} \
+		.
 
 # generator-image-build is only used for local development. GH actions that build and publish the image don't make use of it
 .PHONY: generator-image-build

--- a/k8scache.Dockerfile
+++ b/k8scache.Dockerfile
@@ -2,6 +2,8 @@
 FROM golang:1.26.4@sha256:f96cc555eb8db430159a3aa6797cd5bae561945b7b0fe7d0e284c63a3b291609 AS builder
 
 ARG TARGETARCH
+ARG RELEASE_VERSION=unset
+ARG RELEASE_REVISION=unset
 ENV GOARCH=$TARGETARCH
 
 WORKDIR /opt/app-root
@@ -14,10 +16,9 @@ COPY NOTICE NOTICE
 COPY Makefile Makefile
 COPY cmd/ cmd/
 COPY pkg/ pkg/
-COPY .git/ .git/
 
 # Build
-RUN make compile-cache
+RUN make compile-cache RELEASE_VERSION=${RELEASE_VERSION} RELEASE_REVISION=${RELEASE_REVISION}
 
 # Create final image from minimal + built binary
 FROM scratch


### PR DESCRIPTION
## Summary

The current obi docker image has an empty `telemetry.distro.version` resource attribute and blank `Version=` in startup logs.

This PR fixes it and passes `RELEASE_VERSION` and `RELEASE_REVISION` as Docker build ARGs from CI, where the correct tag or commit SHA is already known, rather than computing them with git inside the container.

Release tag builds (e.g. v0.10.1) embed the full semver tag; snapshot builds (push to main) embed the 7-char commit SHA rather than the literal string "main"; local make image-build derives the value from git on the host as before.

Notes: 
- binary release tarballs produced by `make release` were never affected because that job checks out with full history on the host where git describe works correctly.
- In the Makefile we now have  `cut -d/ -f2-` so branch names containing slashes (e.g. pgn/...) are not silently truncated when building locally.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
