### PR TITLE
Test Weaver namespace advisory enforcement

### DIFF
--- a/internal/test/integration/weaver.go
+++ b/internal/test/integration/weaver.go
@@ -251,11 +251,7 @@ func validateWeaverReport(t *testing.T, report *weaverReport) {
 	// Build message → {level, signals} lookup from the sample data.
 	adviceByMsg := collectAdviceInfo(report.Samples)
 
-	// Log all advisory messages grouped by level, and count actionable
-	// advisories: advice that is `violation`-level OR whose advice_type is in
-	// actionableAdviceTypes (e.g. extends_namespace), after applying the ignore
-	// lists.
-	var actionableAdvisories int
+	// Log all advisory messages grouped by level.
 	t.Logf("  advisory details:")
 	for _, level := range []string{"violation", "improvement", "information"} {
 		for msg, count := range stats.AdviceMessageCounts {
@@ -271,9 +267,6 @@ func validateWeaverReport(t *testing.T, report *weaverReport) {
 					suffix = " [ignored]"
 				}
 				t.Logf("    [%s] [%dx] %s (signals: unknown)%s", level, count, msg, suffix)
-				if !msgIgnored {
-					actionableAdvisories += count
-				}
 				continue
 			}
 			if info.Level != level {
@@ -281,24 +274,57 @@ func validateWeaverReport(t *testing.T, report *weaverReport) {
 			}
 			signals := sortedSignals(info.Signals)
 			ignored := msgIgnored || allSignalsIgnored(info.Signals)
-			_, typeActionable := actionableAdviceTypes[info.AdviceType]
 			suffix := ""
 			if ignored {
 				suffix = " [ignored]"
 			}
 			t.Logf("    [%s] [%dx] %s (signals: %s)%s", level, count, msg, strings.Join(signals, ", "), suffix)
-			if (level == "violation" || typeActionable) && !ignored {
-				actionableAdvisories += count
-			}
 		}
 	}
 
+	actionableAdvisories := countActionableAdvisories(stats, adviceByMsg)
 	t.Logf("  advisories: %d violation(s), %d actionable (after ignoring %v)",
 		violations, actionableAdvisories, sortedSignals(weaverIgnoredSignals))
 
 	assert.Zero(t, actionableAdvisories,
 		"weaver found %d actionable semantic convention advisory(ies) "+
 			"(violations or undeclared attributes under existing semconv namespaces)", actionableAdvisories)
+}
+
+func isActionableAdvice(level, adviceType string) bool {
+	if level == "violation" {
+		return true
+	}
+
+	_, actionable := actionableAdviceTypes[adviceType]
+	return actionable
+}
+
+func countActionableAdvisories(stats *weaverStatistics, adviceByMsg map[string]*adviceInfo) int {
+	var count int
+	for _, level := range []string{"violation", "improvement", "information"} {
+		for msg, occurrences := range stats.AdviceMessageCounts {
+			_, messageIgnored := weaverIgnoredAdviceMessages[msg]
+			info := adviceByMsg[msg]
+			if info == nil {
+				if level == "violation" && !messageIgnored {
+					count += occurrences
+				}
+				continue
+			}
+			if info.Level != level {
+				continue
+			}
+			if messageIgnored || allSignalsIgnored(info.Signals) {
+				continue
+			}
+			if isActionableAdvice(level, info.AdviceType) {
+				count += occurrences
+			}
+		}
+	}
+
+	return count
 }
 
 // collectAdviceInfo scans all weaver samples to build a complete map from

--- a/internal/test/integration/weaver_test.go
+++ b/internal/test/integration/weaver_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +17,32 @@ import (
 // upstreamSemconvSchemaURLPrefix uniquely identifies the upstream OpenTelemetry
 // semantic conventions registry among `schemas/obi/manifest.yaml` dependencies.
 const upstreamSemconvSchemaURLPrefix = "https://opentelemetry.io/schemas/"
+
+func TestExtendsNamespaceAdviceIsActionable(t *testing.T) {
+	const message = "Attribute 'http.custom' extends an existing namespace"
+
+	report := weaverReport{
+		Samples: []json.RawMessage{json.RawMessage(`{
+			"span": {
+				"live_check_result": {
+					"all_advice": [{
+						"id": "extends_namespace",
+						"message": "Attribute 'http.custom' extends an existing namespace",
+						"level": "information",
+						"signal_type": "span",
+						"signal_name": "GET /test"
+					}]
+				}
+			}
+		}`)},
+		Statistics: weaverStatistics{
+			AdviceMessageCounts: map[string]int{message: 1},
+		},
+	}
+
+	adviceByMsg := collectAdviceInfo(report.Samples)
+	require.Equal(t, 1, countActionableAdvisories(&report.Statistics, adviceByMsg))
+}
 
 // TestSemconvVersionMatchesManifest guards against drift between the Go-side
 // semconv import and the upstream-semconv dependency pinned in the OBI


### PR DESCRIPTION
## Summary

I added focused regression coverage for Weaver namespace-extension advisories:

- extract actionable-advisory counting into a helper used by `validateWeaverReport`
- construct a synthetic Weaver report containing an information-level `extends_namespace` finding
- assert that the report produces one actionable advisory

## Motivation

#2526 corrected the serialized finding field from `advice_type` to `id`, but the live integration checks no longer emit an `extends_namespace` advisory after the missing attributes were registered. That meant the enforcement path could regress while CI remained green.

The synthetic report locks down both Weaver's serialized `id` field and OBI's decision to treat `extends_namespace` findings as actionable despite their information level.

## Validation

- `go test ./internal/test/integration -run TestExtendsNamespaceAdviceIsActionable -count=1`
- `make lint`