### PR TITLE
Harden fastelf parsing against malformed ELF offsets

### DIFF
--- a/pkg/internal/fastelf/fastelf.go
+++ b/pkg/internal/fastelf/fastelf.go
@@ -320,6 +320,53 @@ func NewElfContextFromData(data []byte) (*ElfContext, error) {
 	return &ctx, nil
 }
 
+func uint64Offset(data []byte, offset uint64) (int, bool) {
+	if offset > uint64(len(data)) || offset > math.MaxInt {
+		return 0, false
+	}
+
+	return int(offset), true
+}
+
+// SectionData returns a section's contents when its declared range fits in data.
+func (ctx *ElfContext) SectionData(sec *Elf64_Shdr) ([]byte, bool) {
+	if sec == nil {
+		return nil, false
+	}
+
+	offset, ok := uint64Offset(ctx.Data, sec.Offset)
+	if !ok || sec.Size > uint64(len(ctx.Data)-offset) {
+		return nil, false
+	}
+
+	size := int(sec.Size)
+
+	return ctx.Data[offset : offset+size], true
+}
+
+// SymbolTableBounds returns a symbol table range that is safe to iterate.
+func (ctx *ElfContext) SymbolTableBounds(sec *Elf64_Shdr) (offset, entrySize, entryCount int, ok bool) {
+	if sec == nil {
+		return 0, 0, 0, false
+	}
+
+	offset, ok = uint64Offset(ctx.Data, sec.Offset)
+	if !ok {
+		return 0, 0, 0, false
+	}
+
+	symbolSize := uint64(unsafe.Sizeof(Elf64_Sym{}))
+	if sec.Entsize < symbolSize || sec.Entsize > math.MaxInt {
+		return 0, 0, 0, false
+	}
+
+	if sec.Size > uint64(len(ctx.Data)-offset) {
+		return 0, 0, 0, false
+	}
+
+	return offset, int(sec.Entsize), int(sec.Size / sec.Entsize), true
+}
+
 func (ctx *ElfContext) Close() error {
 	if ctx.file != nil {
 		defer ctx.file.Close()
@@ -354,20 +401,18 @@ func (ctx *ElfContext) HasSymbol(symbol string) bool {
 			continue
 		}
 
-		if int(strtab.Offset) >= len(ctx.Data) {
+		strs, ok := ctx.SectionData(strtab)
+		if !ok {
 			continue
 		}
 
-		strs := ctx.Data[strtab.Offset:]
-
-		if sec.Entsize == 0 {
+		symOffset, symEntrySize, symCount, ok := ctx.SymbolTableBounds(sec)
+		if !ok {
 			continue
 		}
-
-		symCount := int(sec.Size / sec.Entsize)
 
 		for i := range symCount {
-			sym := ReadStruct[Elf64_Sym](ctx.Data, int(sec.Offset)+i*int(sec.Entsize))
+			sym := ReadStruct[Elf64_Sym](ctx.Data, symOffset+i*symEntrySize)
 
 			if sym == nil || SymType(sym.Info) != STT_FUNC || sym.Size == 0 || sym.Value == 0 {
 				continue
@@ -405,11 +450,12 @@ func (ctx *ElfContext) shstrtabData() []byte {
 
 	shstrtab := ctx.Sections[ctx.Hdr.Shstrndx]
 
-	if shstrtab == nil || int(shstrtab.Offset) >= len(ctx.Data) {
+	data, ok := ctx.SectionData(shstrtab)
+	if !ok {
 		return nil
 	}
 
-	return ctx.Data[shstrtab.Offset:]
+	return data
 }
 
 func (ctx *ElfContext) section(sectionName string) *Elf64_Shdr {

--- a/pkg/internal/fastelf/fastelf_test.go
+++ b/pkg/internal/fastelf/fastelf_test.go
@@ -80,6 +80,18 @@ func TestFastElf_FileNoSections(t *testing.T) {
 	require.NoError(t, ctx.Close())
 }
 
+func TestFastElf_HasSectionMalformedStringTable(t *testing.T) {
+	ctx := &ElfContext{
+		Hdr:  &Elf64_Ehdr{},
+		Data: []byte{0},
+		Sections: []*Elf64_Shdr{
+			{Offset: ^uint64(0), Size: 1},
+		},
+	}
+
+	require.False(t, ctx.HasSection(".text"))
+}
+
 func TestGetCString_OutOfRangeOffset(t *testing.T) {
 	require.Empty(t, GetCString([]byte("abc\x00"), 100))
 }
@@ -144,11 +156,50 @@ func TestFastElf_HasSymbol_StrtabOffsetBeyondData(t *testing.T) {
 		Data: []byte("strtab\x00"),
 		Sections: []*Elf64_Shdr{
 			{Type: SHT_SYMTAB, Link: 1, Size: 64, Entsize: 24},
-			{Offset: 9999},
+			{Offset: ^uint64(0), Size: 1},
 		},
 	}
 
 	require.False(t, ctx.HasSymbol("setprogname"))
+}
+
+func TestFastElf_SymbolTableBounds(t *testing.T) {
+	symbolSize := uint64(unsafe.Sizeof(Elf64_Sym{}))
+	ctx := &ElfContext{Data: make([]byte, symbolSize)}
+
+	tests := []struct {
+		name      string
+		section   *Elf64_Shdr
+		wantCount int
+		wantOK    bool
+	}{
+		{
+			name:      "valid table",
+			section:   &Elf64_Shdr{Size: symbolSize, Entsize: symbolSize},
+			wantCount: 1,
+			wantOK:    true,
+		},
+		{
+			name:    "offset overflows int",
+			section: &Elf64_Shdr{Offset: ^uint64(0), Size: symbolSize, Entsize: symbolSize},
+		},
+		{
+			name:    "size exceeds data",
+			section: &Elf64_Shdr{Size: ^uint64(0), Entsize: symbolSize},
+		},
+		{
+			name:    "entry smaller than symbol",
+			section: &Elf64_Shdr{Size: symbolSize, Entsize: symbolSize - 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, count, ok := ctx.SymbolTableBounds(tt.section)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantCount, count)
+		})
+	}
 }
 
 /* ---- minimal.S

--- a/pkg/internal/procs/proclang_linux.go
+++ b/pkg/internal/procs/proclang_linux.go
@@ -234,20 +234,18 @@ func matchExeSymbols(ctx *fastelf.ElfContext) svc.InstrumentableType {
 
 		strtab := ctx.Sections[sec.Link]
 
-		if strtab == nil || int(strtab.Offset) >= len(ctx.Data) {
+		strs, ok := ctx.SectionData(strtab)
+		if !ok {
 			continue
 		}
 
-		strs := ctx.Data[strtab.Offset:]
-
-		if sec.Entsize == 0 {
+		symOffset, symEntrySize, symCount, ok := ctx.SymbolTableBounds(sec)
+		if !ok {
 			continue
 		}
-
-		symCount := int(sec.Size / sec.Entsize)
 
 		for i := range symCount {
-			sym := fastelf.ReadStruct[fastelf.Elf64_Sym](ctx.Data, int(sec.Offset)+i*int(sec.Entsize))
+			sym := fastelf.ReadStruct[fastelf.Elf64_Sym](ctx.Data, symOffset+i*symEntrySize)
 
 			if sym == nil ||
 				fastelf.SymType(sym.Info) != fastelf.STT_FUNC ||

--- a/pkg/internal/procs/proclang_linux_test.go
+++ b/pkg/internal/procs/proclang_linux_test.go
@@ -50,6 +50,28 @@ func TestMatchExeSymbols_InvalidStringOffset(t *testing.T) {
 	assert.Equal(t, svc.InstrumentableGeneric, matchExeSymbols(ctx))
 }
 
+func TestMatchExeSymbols_InvalidStringTableOffset(t *testing.T) {
+	const symSize = 24
+
+	ctx := &fastelf.ElfContext{
+		Data: make([]byte, symSize),
+		Sections: []*fastelf.Elf64_Shdr{
+			{
+				Type:    fastelf.SHT_SYMTAB,
+				Link:    1,
+				Size:    symSize,
+				Entsize: symSize,
+			},
+			{
+				Offset: ^uint64(0),
+				Size:   1,
+			},
+		},
+	}
+
+	assert.Equal(t, svc.InstrumentableGeneric, matchExeSymbols(ctx))
+}
+
 func TestFindExeSymbolsExactLookup(t *testing.T) {
 	const symbolName = "main.exactLookupTarget"
 


### PR DESCRIPTION
### Motivation

- The `fastelf` parser previously trusted section/symbol offsets and used unsafe slicing and pointer conversions, which can panic on crafted or corrupted ELF binaries when called against arbitrary processes.
- The intent is to minimally harden parsing and indexing to reject out-of-range or negative offsets and avoid panics while preserving the fast path and existing behavior for well-formed ELF files.

### Testing

- `go test ./pkg/internal/fastelf ./pkg/internal/procs`