### PR TITLE
Tighten release artifact Cosign verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,8 @@ Each release includes:
 #### Download and Verify
 
 Install [Cosign](https://docs.sigstore.dev/cosign/installation/) if you do not already have it.
-OBI release blobs are signed with GitHub Actions OIDC. The identity regexp
-below matches the same repository-level identity used for container image
-verification.
+OBI release blobs are signed with GitHub Actions OIDC. The certificate identity
+below matches the release workflow at the release tag.
 
 ```bash
 # Set your desired version (find latest at https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases)
@@ -98,7 +97,8 @@ export ARTIFACT="obi-${RELEASE_TAG}-linux-${ARCH}.tar.gz"
 export BUNDLE="${ARTIFACT}.bundle.json"
 export CHECKSUMS=SHA256SUMS
 export CHECKSUMS_BUNDLE="${CHECKSUMS}.bundle.json"
-export CERTIFICATE_IDENTITY_REGEXP="https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/"
+export REPOSITORY=open-telemetry/opentelemetry-ebpf-instrumentation
+export CERTIFICATE_IDENTITY="https://github.com/${REPOSITORY}/.github/workflows/release.yml@refs/tags/${RELEASE_TAG}"
 export CERTIFICATE_OIDC_ISSUER="https://token.actions.githubusercontent.com"
 ```
 
@@ -116,20 +116,20 @@ Verify the signatures before using the downloaded files:
 ```bash
 cosign verify-blob "${ARTIFACT}" \
   --bundle "${BUNDLE}" \
-  --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEXP}" \
+  --certificate-identity "${CERTIFICATE_IDENTITY}" \
   --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}"
 
 cosign verify-blob "${CHECKSUMS}" \
   --bundle "${CHECKSUMS_BUNDLE}" \
-  --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEXP}" \
+  --certificate-identity "${CERTIFICATE_IDENTITY}" \
   --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}"
 ```
 
 Successful Cosign verification confirms that the local file matches the signed
 payload, the signing certificate identity matches this repository's GitHub
-Actions identity, the certificate was issued by GitHub Actions OIDC, and the
-Sigstore bundle includes the transparency log material needed for offline
-verification.
+Actions release workflow and tag, the certificate was issued by GitHub Actions
+OIDC, and the Sigstore bundle includes the transparency log material needed for
+offline verification.
 
 Then verify the downloaded files against the signed checksum manifest:
 
@@ -227,12 +227,13 @@ OBI is also available as container images:
 ```bash
 # Set your desired version.
 export VERSION=v0.7.0
+export CERTIFICATE_IDENTITY="https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/.github/workflows/publish_dockerhub_main.yml@refs/tags/${VERSION}"
 
 # (Optional) Verify the signature of the container image
-cosign verify --certificate-identity-regexp 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' otel/ebpf-instrument:${VERSION}
+cosign verify --certificate-identity "${CERTIFICATE_IDENTITY}" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' otel/ebpf-instrument:${VERSION}
 
 # (Optional) Verify the same release from GHCR
-cosign verify --certificate-identity-regexp 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:${VERSION}
+cosign verify --certificate-identity "${CERTIFICATE_IDENTITY}" --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:${VERSION}
 
 # Pull the image
 docker pull otel/ebpf-instrument:${VERSION}
@@ -249,7 +250,7 @@ docker run --privileged otel/ebpf-instrument:${VERSION}
 Successful `cosign verify` output states that the claims were validated and
 returns the signed image digest. If verification fails, confirm that the image
 tag exists in the registry you queried and that you are using the GitHub OIDC
-issuer and identity regexp shown above.
+issuer and certificate identity shown above.
 
 ## Examples
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -175,9 +175,9 @@ Once the workflow completes successfully, a draft release is automatically creat
    - Open the published CycloneDX SBOMs with your preferred SBOM tooling if you want to inspect release dependencies
    - Use the dedicated Java agent SBOM when you need the full Java dependency graph for the JAR embedded inside `obi`
    - Verify signed container images from both registries before publication:
-     `cosign verify --certificate-identity-regexp 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' otel/ebpf-instrument:<tag>`
+     `cosign verify --certificate-identity 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/.github/workflows/publish_dockerhub_main.yml@refs/tags/<tag>' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' otel/ebpf-instrument:<tag>`
    - Verify the matching GHCR image as well:
-     `cosign verify --certificate-identity-regexp 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:<tag>`
+     `cosign verify --certificate-identity 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/.github/workflows/publish_dockerhub_main.yml@refs/tags/<tag>' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:<tag>`
    - Review auto-generated release notes for accuracy
 4. Edit release notes if necessary to add context, highlight important changes, or improve clarity
 5. Once satisfied with artifacts and release notes, click "Publish release" to make it immutable and publicly available
@@ -245,7 +245,8 @@ release_tag=vX.Y.Z
 gh workflow run release.yml \
   --repo open-telemetry/opentelemetry-ebpf-instrumentation \
   --ref "${release_tag}" \
-  --raw-field tag="${release_tag}"
+  --raw-field tag="${release_tag}" \
+  --raw-field latest=false
 ```
 
 Using the release tag for `--ref` is required. Dispatching from the default branch would give the signed artifacts a `refs/heads/main` certificate identity instead of the `refs/tags/${release_tag}` identity required by the verification command above.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -145,6 +145,8 @@ Once the workflow completes successfully, a draft release is automatically creat
 
      release_tag=vX.Y.Z
      repository=open-telemetry/opentelemetry-ebpf-instrumentation
+     certificate_identity="https://github.com/${repository}/.github/workflows/release.yml"
+     certificate_identity="${certificate_identity}@refs/tags/${release_tag}"
      release_dir="$(mktemp -d)"
 
      gh release download "${release_tag}" \
@@ -161,7 +163,7 @@ Once the workflow completes successfully, a draft release is automatically creat
        "${release_dir}"/SHA256SUMS; do
        cosign verify-blob "${artifact}" \
          --bundle "${artifact}.bundle.json" \
-         --certificate-identity-regexp 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/' \
+         --certificate-identity "${certificate_identity}" \
          --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
      done
 
@@ -236,12 +238,17 @@ The `dist/` directory will contain:
 
 ### Manual Release Trigger
 
-If you need to re-trigger the release workflow (for example, if the workflow previously failed due to a temporary issue), you can use the manual trigger:
+If you need to re-trigger the release workflow (for example, if the workflow previously failed due to a temporary issue), dispatch it from the release tag:
 
-1. Go to the [Release workflow](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/workflows/release.yml)
-2. Click "Run workflow"
-3. Enter the tag name (e.g., `v1.2.3`) in the required input field
-4. Click "Run workflow"
+```console
+release_tag=vX.Y.Z
+gh workflow run release.yml \
+  --repo open-telemetry/opentelemetry-ebpf-instrumentation \
+  --ref "${release_tag}" \
+  --raw-field tag="${release_tag}"
+```
+
+Using the release tag for `--ref` is required. Dispatching from the default branch would give the signed artifacts a `refs/heads/main` certificate identity instead of the `refs/tags/${release_tag}` identity required by the verification command above.
 
 The manual trigger will validate the tag format, run the full test suite, and create a draft release with the same requirements as the automatic trigger.
 


### PR DESCRIPTION
### Motivation

- Fix a supply-chain verification weakness in `RELEASING.md` where `cosign` verification used a repository-prefix `--certificate-identity-regexp` and could accept OIDC signatures from non-release workflows in the same repository.

### Description

- Update `RELEASING.md` to construct `certificate_identity="https://github.com/${repository}/.github/workflows/release.yml@refs/tags/${release_tag}"` and use `--certificate-identity "${certificate_identity}"` in `cosign verify-blob` so verification is bound to the release workflow and tag.

### Testing

- `make lint-markdown`
