### PR TITLE
Add Config v2 validation and migration CLI

### DIFF
--- a/cmd/obi/configcmd.go
+++ b/cmd/obi/configcmd.go
@@ -1,0 +1,180 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/obi/internal/config/convert"
+	configschema "go.opentelemetry.io/obi/internal/config/schema"
+)
+
+const (
+	configCommandExitSuccess = 0
+	configCommandExitFailure = 1
+	configCommandExitUsage   = 2
+)
+
+type configValidationMode string
+
+const (
+	configValidationModeStandalone configValidationMode = "standalone"
+	configValidationModeReceiver   configValidationMode = "receiver"
+)
+
+func runConfigCommand(args []string, stdout, stderr io.Writer) (bool, int) {
+	if len(args) == 0 || args[0] != "config" {
+		return false, configCommandExitSuccess
+	}
+
+	if len(args) < 2 {
+		configCommandUsage(stderr)
+		return true, configCommandExitUsage
+	}
+
+	switch args[1] {
+	case "help", "-h", "--help":
+		configCommandUsage(stdout)
+		return true, configCommandExitSuccess
+	case "validate":
+		return true, runConfigValidate(args[2:], stdout, stderr)
+	case "migrate":
+		return true, runConfigMigrate(args[2:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown config subcommand %q\n", args[1])
+		configCommandUsage(stderr)
+		return true, configCommandExitUsage
+	}
+}
+
+func configCommandUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: obi config <validate|migrate> ...")
+}
+
+func runConfigValidate(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("obi config validate", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	flags.Usage = func() {
+		fmt.Fprintln(stderr, "usage: obi config validate [--mode=standalone|receiver] <path>")
+	}
+	mode := flags.String("mode", string(configValidationModeStandalone), "validation mode: standalone or receiver")
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return configCommandExitSuccess
+		}
+		return configCommandExitUsage
+	}
+	if flags.NArg() != 1 {
+		flags.Usage()
+		return configCommandExitUsage
+	}
+
+	validationMode := configValidationMode(*mode)
+	if validationMode != configValidationModeStandalone && validationMode != configValidationModeReceiver {
+		fmt.Fprintf(stderr, "invalid validation mode %q: expected standalone or receiver\n", *mode)
+		return configCommandExitUsage
+	}
+
+	data, err := os.ReadFile(flags.Arg(0))
+	if err != nil {
+		fmt.Fprintf(stderr, "read configuration: %v\n", err)
+		return configCommandExitFailure
+	}
+	if err := validateConfigData(data, validationMode); err != nil {
+		fmt.Fprintf(stderr, "invalid configuration: %v\n", err)
+		return configCommandExitFailure
+	}
+
+	fmt.Fprintln(stdout, "configuration is valid")
+	return configCommandExitSuccess
+}
+
+func validateConfigData(data []byte, mode configValidationMode) error {
+	switch mode {
+	case configValidationModeStandalone:
+		doc, _, err := configschema.ParseStandaloneYAML(data)
+		if err != nil {
+			return err
+		}
+		if _, err := convert.DocumentToRuntime(doc); err != nil {
+			return err
+		}
+	case configValidationModeReceiver:
+		ext, err := configschema.ParseReceiverYAML(data)
+		if err != nil {
+			return err
+		}
+		if _, err := convert.V2ToRuntime(ext); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid validation mode %q", mode)
+	}
+	return nil
+}
+
+func runConfigMigrate(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("obi config migrate", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	flags.Usage = func() {
+		fmt.Fprintln(stderr, "usage: obi config migrate [--from=v1] [--to=v2] <path>")
+	}
+	from := flags.String("from", "v1", "source configuration version")
+	to := flags.String("to", "v2", "destination configuration version")
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return configCommandExitSuccess
+		}
+		return configCommandExitUsage
+	}
+	if *from != "v1" || *to != "v2" {
+		fmt.Fprintln(stderr, "only migration from v1 to v2 is supported")
+		return configCommandExitUsage
+	}
+	if flags.NArg() != 1 {
+		flags.Usage()
+		return configCommandExitUsage
+	}
+
+	data, err := os.ReadFile(flags.Arg(0))
+	if err != nil {
+		fmt.Fprintf(stderr, "read configuration: %v\n", err)
+		return configCommandExitFailure
+	}
+	encoded, report, err := migrateConfigData(data)
+	if err != nil {
+		fmt.Fprintf(stderr, "migrate configuration: %v\n", err)
+		return configCommandExitFailure
+	}
+
+	if report != "" {
+		fmt.Fprint(stderr, report)
+	}
+	fmt.Fprint(stdout, encoded)
+	return configCommandExitSuccess
+}
+
+func migrateConfigData(data []byte) (string, string, error) {
+	encoded, notices, err := convert.MigrateV1YAML(data)
+	if err != nil {
+		return "", "", err
+	}
+
+	var report strings.Builder
+	report.WriteString("migrated v1 configuration to config v2\n")
+	report.WriteString("mapping report:\n")
+	if len(notices) == 0 {
+		report.WriteString("- no non-trivial structural rewrites detected\n")
+	} else {
+		for _, notice := range notices {
+			fmt.Fprintf(&report, "- %s: %s\n", notice.Source, notice.Message)
+		}
+	}
+	return string(encoded), report.String(), nil
+}

--- a/cmd/obi/configcmd_test.go
+++ b/cmd/obi/configcmd_test.go
@@ -1,0 +1,147 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const validStandaloneV2 = `
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture: {}
+`
+
+const validReceiverV2 = `
+version: "2.0"
+`
+
+func TestValidateConfigData(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateConfigData([]byte(validStandaloneV2), configValidationModeStandalone))
+	require.NoError(t, validateConfigData([]byte(validReceiverV2), configValidationModeReceiver))
+
+	err := validateConfigData([]byte(validReceiverV2+"daemon: {}\n"), configValidationModeReceiver)
+	require.ErrorContains(t, err, `section "daemon" is not allowed in receiver config`)
+
+	err = validateConfigData([]byte(`
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      policy:
+        default_action: drop
+`), configValidationModeStandalone)
+	require.ErrorContains(t, err, "invalid action")
+
+	err = validateConfigData([]byte(`
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    daemon:
+      profiling:
+        port: 99999
+`), configValidationModeStandalone)
+	require.ErrorContains(t, err, "ProfilePort")
+}
+
+func TestRunConfigCommandExitCodes(t *testing.T) {
+	t.Parallel()
+
+	validV2 := writeConfigFile(t, validStandaloneV2)
+	invalidV2 := writeConfigFile(t, `
+file_format: "1.0"
+extensions:
+  obi:
+    version: "3.0"
+`)
+	validV1 := writeConfigFile(t, `
+open_port: 8080
+otel_traces_export:
+  endpoint: http://localhost:4317
+  protocol: grpc
+`)
+	invalidV1 := writeConfigFile(t, "unknown_setting: true\n")
+
+	tests := []struct {
+		name string
+		args []string
+		code int
+	}{
+		{name: "usage", args: []string{"config"}, code: configCommandExitUsage},
+		{name: "valid", args: []string{"config", "validate", validV2}, code: configCommandExitSuccess},
+		{name: "invalid", args: []string{"config", "validate", invalidV2}, code: configCommandExitFailure},
+		{name: "migrate", args: []string{"config", "migrate", validV1}, code: configCommandExitSuccess},
+		{name: "migration failure", args: []string{"config", "migrate", invalidV1}, code: configCommandExitFailure},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			handled, code := runConfigCommand(test.args, &stdout, &stderr)
+
+			require.True(t, handled)
+			require.Equal(t, test.code, code)
+		})
+	}
+}
+
+func TestMigrateConfigDataReport(t *testing.T) {
+	t.Parallel()
+
+	encoded, report, err := migrateConfigData([]byte(`
+discovery:
+  instrument:
+    - open_ports: 8080
+ebpf:
+  track_request_headers: true
+filter:
+  application:
+    http.request.method:
+      match: GET
+network:
+  enable: true
+  source: socket_filter
+otel_metrics_export:
+  endpoint: http://localhost:4317
+  protocol: grpc
+otel_traces_export:
+  endpoint: http://localhost:4317
+  protocol: grpc
+attributes:
+  rename_unresolved_hosts: unknown
+log_level: DEBUG
+`))
+
+	require.NoError(t, err)
+	require.Contains(t, encoded, `version: "2.0"`)
+	require.NotContains(t, encoded, "additionalproperties")
+	require.Contains(t, encoded, "meter_provider:")
+	require.Contains(t, encoded, "track_request_headers: true")
+	require.Contains(t, encoded, "source: socket_filter")
+	require.Contains(t, encoded, "default: unknown")
+	require.Contains(t, encoded, "level: DEBUG")
+	require.Contains(t, report, "filter.application: fanned out to protocol and signal filters")
+	require.NoError(t, validateConfigData([]byte(encoded), configValidationModeStandalone))
+}
+
+func writeConfigFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config.yml")
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	return path
+}

--- a/cmd/obi/main.go
+++ b/cmd/obi/main.go
@@ -24,6 +24,13 @@ import (
 )
 
 func main() {
+	if handled, exitCode := runConfigCommand(os.Args[1:], os.Stdout, os.Stderr); handled {
+		if exitCode != configCommandExitSuccess {
+			os.Exit(exitCode)
+		}
+		return
+	}
+
 	lvl := slog.LevelVar{}
 	lvl.Set(slog.LevelInfo)
 

--- a/devdocs/config/version-2.0/migration.md
+++ b/devdocs/config/version-2.0/migration.md
@@ -78,14 +78,29 @@ The `obi` command needs to have a configuration migration tool added to it.
 It needs to support semantics like the following.
 
 ```shell
-obi config migrate --from v1 --to v2
+obi config migrate --from=v1 --to=v2 ./path/to/config.yml
 ```
 
-- Read v1 or mixed legacy input.
+- Read supported v1 file-based input.
 - Produce canonical v2 output.
-- Emit a mapping report (moved, renamed, split/fan-out, inverted semantics).
-- Emit warnings for deprecated aliases.
-- Fail only when rewrite is non-deterministic.
+- Emit a mapping report for non-trivial structural rewrites (split/fan-out,
+  selector shape changes, inverted semantics, and applied feature aliases).
+- Include applied deprecated feature aliases in the mapping report.
+- Fail when a configured field cannot be preserved by the current v2 contract.
+
+The command writes only the migrated YAML document to standard output. It
+writes the mapping report to standard error, so the output can be redirected
+directly into source control:
+
+```shell
+obi config migrate ./obi-v1.yml > ./obi-v2.yml
+```
+
+Migration is file-only and deterministic. It does not apply ambient OBI or
+OpenTelemetry environment variables. Resolve `${...}` and `$(...)`
+interpolation before running the command. Unknown v1 fields and fields outside
+the supported migration contract fail with their source paths instead of being
+dropped.
 
 ### What non-deterministic means
 
@@ -97,7 +112,8 @@ A small set of mappings are structurally non-trivial:
 - **Inverted boolean**: `discovery.skip_go_specific_tracers: true` maps to `capture.runtimes.go.enabled: false`. The migration tool applies the inversion and emits a note.
 - **Sampler**: `otel_traces_export.sampler.name` and `.arg` migrate to `tracer_provider.sampler`. Simple cases (e.g., `always_on`, `trace_id_ratio_based`) map directly to built-in OTel declarative sampler types. Custom or workload-specific sampler configs may require operator intervention and use of the `obi_rule_based` sampler plugin.
 
-Only mappings that cannot be resolved without operator input cause migration to fail with a non-deterministic error.
+Mappings that cannot be resolved without operator input and source settings
+outside the supported migration contract cause migration to fail.
 
 ## Validation CLI
 
@@ -108,11 +124,34 @@ It needs to support semantics like the following.
 obi config validate ./path/to/config
 ```
 
-- Read v1 or later configuration as input via an argument
-- Parse and validate the configuration
-- Emit warnings for invalid configuration detected
-- Emit warnings for deprecated configuration versions
-- In receiver context (detected via flag or auto-detection), reject standalone-only sections (`enrich`, `correlation`, `daemon`) with an explicit error identifying the section and remediation steps
+- Read Config v2 from the path argument.
+- Parse and validate the supported typed configuration.
+- Return actionable errors for invalid configuration.
+- In receiver mode, reject standalone-only sections (`enrich`, `correlation`, `daemon`) with an explicit error identifying the section and remediation steps.
+
+Validation accepts Config v2 only. Use `--mode=receiver` for a
+receiver-embedded OBI fragment; the default mode validates a standalone
+declarative document:
+
+```shell
+obi config validate ./obi-v2.yml
+obi config validate --mode=receiver ./obi-receiver-v2.yml
+```
+
+The receiver input is the OBI receiver fragment beginning with `version`, not
+an entire Collector service configuration. Validation rejects malformed typed
+fields, unsupported versions, trailing YAML documents, and standalone-only
+sections in receiver mode. It parses and converts configuration without
+starting OBI. The supported declarative subset and handling of fields outside
+that subset remain part of the Config v2 release gate.
+
+Both commands use stable exit codes:
+
+| Exit code | Meaning |
+|---|---|
+| `0` | The command succeeded, or help was requested. |
+| `1` | Input, validation, migration, or file I/O failed. |
+| `2` | Command usage or flags were invalid. |
 
 ## Rollout strategy
 

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -53,6 +53,9 @@ func V2ToRuntime(src *schema.Extension) (*obi.Config, error) {
 	applyV2Standalone(&cfg, src)
 	applyV2MetricsEnablement(&cfg, src)
 	cfg.Attributes.Select.Normalize()
+	if err := cfg.ValidateValues(); err != nil {
+		return nil, fmt.Errorf("validate converted config v2 values: %w", err)
+	}
 
 	return &cfg, nil
 }
@@ -179,6 +182,13 @@ func collectV2ExportsOTLPExclusionRule(rules *runtimeDiscoveryRules, rule schema
 func validateV2RulePatterns(rules []schema.Rule) error {
 	for i, rule := range rules {
 		path := fmt.Sprintf("capture.rules[%d].match", i)
+		if rule.Match.Process.ExportsOTLP != nil &&
+			(rule.Action != schema.CaptureActionExclude || !ruleMatchOnlyExportsOTLP(rule.Match)) {
+			return fmt.Errorf("%s.process.exports_otlp: only a dedicated exclude rule is supported", path)
+		}
+		if ruleUsesRegex(rule.Match) && ruleUsesGlob(rule.Match) {
+			return fmt.Errorf("%s: glob and regex selectors cannot be combined", path)
+		}
 		if err := validateV2RuleProcessGlobPatterns(path+".process", rule.Match.Process); err != nil {
 			return err
 		}

--- a/internal/config/convert/import_document.go
+++ b/internal/config/convert/import_document.go
@@ -5,6 +5,7 @@ package convert // import "go.opentelemetry.io/obi/internal/config/convert"
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -32,6 +33,9 @@ func DocumentToRuntime(src *schema.Document) (*obi.Config, error) {
 	applyV2Resource(cfg, src.Resource)
 	applyV2TracerProvider(cfg, src.TracerProvider)
 	applyV2MeterProvider(cfg, src.MeterProvider)
+	if err := cfg.ValidateValues(); err != nil {
+		return nil, fmt.Errorf("validate converted config v2 values: %w", err)
+	}
 
 	return cfg, nil
 }

--- a/internal/config/convert/import_document_test.go
+++ b/internal/config/convert/import_document_test.go
@@ -28,7 +28,7 @@ func TestDocumentToRuntimeImportsExportedDocumentSections(t *testing.T) {
 
 	cfg.Traces.TracesEndpoint = "http://traces.example:4317"
 	cfg.Traces.BatchMaxSize = 907
-	cfg.Traces.QueueSize = 908
+	cfg.Traces.QueueSize = 1908
 	cfg.Traces.BatchTimeout = 909 * time.Millisecond
 	cfg.Traces.SamplerConfig.Name = services.SamplerTraceIDRatio
 	cfg.Traces.SamplerConfig.Arg = "0.25"
@@ -50,7 +50,7 @@ func TestDocumentToRuntimeImportsExportedDocumentSections(t *testing.T) {
 
 	require.Equal(t, "http://traces.example:4317", got.Traces.TracesEndpoint)
 	require.Equal(t, otelcfg.ProtocolGRPC, got.Traces.TracesProtocol)
-	require.Equal(t, 908, got.Traces.QueueSize)
+	require.Equal(t, 1908, got.Traces.QueueSize)
 	require.Equal(t, 907, got.Traces.BatchMaxSize)
 	require.Equal(t, 909*time.Millisecond, got.Traces.BatchTimeout)
 	require.Equal(t, services.SamplerConfig{
@@ -232,7 +232,7 @@ func documentWithRuntimeTelemetry() *schema.Document {
 	cfg := defaultRuntimeConfig()
 	cfg.Traces.TracesEndpoint = "http://traces.example:4317"
 	cfg.Traces.BatchMaxSize = 907
-	cfg.Traces.QueueSize = 908
+	cfg.Traces.QueueSize = 1908
 	cfg.Traces.BatchTimeout = 909 * time.Millisecond
 	cfg.Traces.SamplerConfig.Name = services.SamplerTraceIDRatio
 	cfg.Traces.SamplerConfig.Arg = "0.25"

--- a/internal/config/convert/import_test.go
+++ b/internal/config/convert/import_test.go
@@ -322,7 +322,7 @@ func TestV2ToRuntimeImportsRules(t *testing.T) {
 						},
 						Kubernetes: schema.RuleKubernetesMatch{
 							NamespaceGlob:  []string{"prod"},
-							MetadataGlob:   map[string][]string{"k8s.deployment.name": {"checkout*"}},
+							MetadataGlob:   map[string][]string{services.AttrDeploymentName: {"checkout*"}},
 							PodLabels:      map[string][]string{"app": {"checkout"}},
 							PodAnnotations: map[string][]string{"team": {"payments"}},
 						},
@@ -370,7 +370,7 @@ func TestV2ToRuntimeImportsRules(t *testing.T) {
 	require.Equal(t, "/srv/*", globString(include.Path))
 	require.True(t, include.ContainersOnly)
 	require.Equal(t, "prod", globString(*include.Metadata[services.AttrNamespace]))
-	require.Equal(t, "checkout*", globString(*include.Metadata["k8s.deployment.name"]))
+	require.Equal(t, "checkout*", globString(*include.Metadata[services.AttrDeploymentName]))
 	require.Equal(t, "checkout", globString(*include.PodLabels["app"]))
 	require.True(t, include.ExportModes.CanExportTraces())
 	require.False(t, include.ExportModes.CanExportMetrics())
@@ -385,10 +385,10 @@ func TestV2ToRuntimeImportsRules(t *testing.T) {
 	require.Equal(t, "kube-.*", regexString(*exclude.Metadata[services.AttrNamespace]))
 }
 
-func TestV2ToRuntimeSkipsUnsupportedExportsOTLPRules(t *testing.T) {
+func TestV2ToRuntimeRejectsUnsupportedExportsOTLPRules(t *testing.T) {
 	t.Parallel()
 
-	got, err := V2ToRuntime(&schema.Extension{
+	_, err := V2ToRuntime(&schema.Extension{
 		Version: schema.SupportedVersion,
 		Capture: schema.Capture{
 			Rules: []schema.Rule{
@@ -412,17 +412,14 @@ func TestV2ToRuntimeSkipsUnsupportedExportsOTLPRules(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
-
-	require.Empty(t, got.Discovery.Instrument)
-	require.Empty(t, got.Discovery.ExcludeInstrument)
-	require.False(t, got.Discovery.ExcludeOTelInstrumentedServices)
+	require.EqualError(t, err,
+		"capture.rules[0].match.process.exports_otlp: only a dedicated exclude rule is supported")
 }
 
-func TestV2ToRuntimeSkipsMixedGlobRegexRules(t *testing.T) {
+func TestV2ToRuntimeRejectsMixedGlobRegexRules(t *testing.T) {
 	t.Parallel()
 
-	got, err := V2ToRuntime(&schema.Extension{
+	_, err := V2ToRuntime(&schema.Extension{
 		Version: schema.SupportedVersion,
 		Capture: schema.Capture{
 			Rules: []schema.Rule{
@@ -451,12 +448,7 @@ func TestV2ToRuntimeSkipsMixedGlobRegexRules(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
-
-	require.Empty(t, got.Discovery.Instrument)
-	require.Empty(t, got.Discovery.Services)
-	require.Empty(t, got.Discovery.ExcludeInstrument)
-	require.Empty(t, got.Discovery.ExcludeServices)
+	require.EqualError(t, err, "capture.rules[0].match: glob and regex selectors cannot be combined")
 }
 
 func TestV2ToRuntimeRejectsMalformedRulePatterns(t *testing.T) {

--- a/internal/config/convert/migrate.go
+++ b/internal/config/convert/migrate.go
@@ -1,0 +1,459 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert // import "go.opentelemetry.io/obi/internal/config/convert"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+	legacyyaml "gopkg.in/yaml.v3"
+
+	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/appolly/services"
+	"go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+// MigrationNotice describes a deterministic structural rewrite performed while
+// converting a v1 configuration.
+type MigrationNotice struct {
+	Source  string
+	Message string
+}
+
+var environmentInterpolationPattern = regexp.MustCompile(
+	`\$?\$[\{\(](?:env:)?[a-zA-Z_][a-zA-Z0-9_]*(?::-[^}\)]*)?[\}\)]`,
+)
+
+// MigrateV1YAML converts deterministic, file-only v1 configuration into the
+// canonical config v2 document shape.
+func MigrateV1YAML(data []byte) ([]byte, []MigrationNotice, error) {
+	root, err := parseV1YAML(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := validateV1YAMLStructure(root); err != nil {
+		return nil, nil, err
+	}
+	if containsEnvironmentInterpolation(root) {
+		return nil, nil, errors.New(
+			"environment interpolation is not supported during deterministic migration; resolve ${...} and $(...) values first",
+		)
+	}
+	if legacyMappingValue(root, "extensions") != nil {
+		return nil, nil, errors.New("input contains config v2 extensions; --from=v1 requires a v1 configuration")
+	}
+
+	cfg, err := loadV1FileConfig(data)
+	if err != nil {
+		return nil, nil, err
+	}
+	unsupported := unsupportedV1Paths(root)
+	unsupported = append(unsupported, unsupportedRuntimePaths(root, cfg)...)
+	slices.Sort(unsupported)
+	unsupported = slices.Compact(unsupported)
+	if len(unsupported) > 0 {
+		return nil, nil, fmt.Errorf(
+			"v1 fields outside the supported migration contract: %s",
+			strings.Join(unsupported, ", "),
+		)
+	}
+
+	doc, _ := RuntimeToV2(cfg)
+	encoded, err := marshalMigratedDocument(doc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("encode config v2 document: %w", err)
+	}
+	parsed, _, err := schema.ParseStandaloneYAML(encoded)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse migrated config v2 document: %w", err)
+	}
+	if _, err := DocumentToRuntime(parsed); err != nil {
+		return nil, nil, fmt.Errorf("import migrated config v2 document: %w", err)
+	}
+
+	return encoded, migrationNotices(root), nil
+}
+
+func marshalMigratedDocument(doc *schema.Document) ([]byte, error) {
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return nil, err
+	}
+	removeGeneratedAdditionalProperties(&node)
+
+	var output bytes.Buffer
+	encoder := yaml.NewEncoder(&output)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&node); err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}
+
+func removeGeneratedAdditionalProperties(node *yaml.Node) {
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+	if node.Kind != yaml.MappingNode {
+		return
+	}
+
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		switch node.Content[i].Value {
+		case "tracer_provider", "meter_provider":
+			removeAdditionalProperties(node.Content[i+1])
+		}
+	}
+}
+
+func removeAdditionalProperties(node *yaml.Node) {
+	if node.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(node.Content); {
+			if node.Content[i].Value == "additionalproperties" {
+				node.Content = append(node.Content[:i], node.Content[i+2:]...)
+				continue
+			}
+			removeAdditionalProperties(node.Content[i+1])
+			i += 2
+		}
+		return
+	}
+	for _, child := range node.Content {
+		removeAdditionalProperties(child)
+	}
+}
+
+func validateV1YAMLStructure(node *legacyyaml.Node) error {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == legacyyaml.AliasNode {
+		return errors.New("YAML aliases are not supported during deterministic migration")
+	}
+	if node.Kind == legacyyaml.MappingNode {
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i]
+			if key.Tag == "!!merge" || key.Value == "<<" {
+				return errors.New("YAML merge keys are not supported during deterministic migration")
+			}
+		}
+	}
+	for _, child := range node.Content {
+		if err := validateV1YAMLStructure(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func containsEnvironmentInterpolation(node *legacyyaml.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == legacyyaml.ScalarNode &&
+		environmentInterpolationPattern.MatchString(node.Value) {
+		for _, match := range environmentInterpolationPattern.FindAllString(node.Value, -1) {
+			if !strings.HasPrefix(match, "$$") {
+				return true
+			}
+		}
+	}
+	for _, child := range node.Content {
+		if containsEnvironmentInterpolation(child) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseV1YAML(data []byte) (*legacyyaml.Node, error) {
+	decoder := legacyyaml.NewDecoder(bytes.NewReader(data))
+	var document legacyyaml.Node
+	if err := decoder.Decode(&document); err != nil {
+		return nil, fmt.Errorf("parse v1 configuration: %w", err)
+	}
+	var trailing legacyyaml.Node
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("parse v1 configuration: multiple YAML documents are not supported")
+		}
+		return nil, fmt.Errorf("parse v1 configuration: %w", err)
+	}
+	if document.Kind == legacyyaml.DocumentNode && len(document.Content) > 0 {
+		return document.Content[0], nil
+	}
+	return &document, nil
+}
+
+func loadV1FileConfig(data []byte) (*obi.Config, error) {
+	cfg := obi.DefaultConfig
+	if cfg.Routes != nil {
+		routes := *cfg.Routes
+		cfg.Routes = &routes
+	}
+	if cfg.NameResolver != nil {
+		resolver := *cfg.NameResolver
+		cfg.NameResolver = &resolver
+	}
+
+	decoder := legacyyaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("decode v1 configuration: %w", err)
+	}
+
+	cfg.Attributes.Select.Normalize()
+	if cfg.OTELMetrics.EndpointEnabled() && cfg.OTELMetrics.DeprFeatures != 0 {
+		cfg.Metrics.Features = cfg.OTELMetrics.DeprFeatures
+	} else if cfg.Prometheus.EndpointEnabled() && cfg.Prometheus.DeprFeatures != 0 {
+		cfg.Metrics.Features = cfg.Prometheus.DeprFeatures
+	}
+	if cfg.NetworkFlows.Enable {
+		cfg.Metrics.Features |= export.FeatureNetwork
+	}
+	return &cfg, nil
+}
+
+func unsupportedV1Paths(root *legacyyaml.Node) []string {
+	patterns := [][]string{
+		{"attributes", "instance_id", "dns"},
+		{"attributes", "sensitive_query_params"},
+		{"discovery", "exclude_otel_instrumented_services_span_metrics"},
+		{"discovery", "instrument", "*", "metrics"},
+		{"discovery", "instrument", "*", "name"},
+		{"discovery", "instrument", "*", "namespace"},
+		{"discovery", "instrument", "*", "sampler"},
+		{"discovery", "services", "*", "metrics"},
+		{"discovery", "services", "*", "name"},
+		{"discovery", "services", "*", "namespace"},
+		{"discovery", "services", "*", "sampler"},
+		{"ebpf", "log_enricher", "services"},
+		{"ebpf", "stats_wakeup_data_bytes"},
+		{"health_check"},
+		{"internal_metrics", "avoided_services"},
+		{"jvm_runtime_metrics"},
+		{"otel_metrics_export", "allow_service_graph_self_references"},
+		{"otel_metrics_export", "buckets"},
+		{"otel_metrics_export", "exponential_histogram"},
+		{"otel_metrics_export", "extra_span_resource_attributes"},
+		{"otel_metrics_export", "insecure_skip_verify"},
+		{"otel_metrics_export", "instrumentations"},
+		{"otel_metrics_export", "otel_sdk_log_level"},
+		{"otel_traces_export", "backoff_initial_interval"},
+		{"otel_traces_export", "backoff_max_elapsed_time"},
+		{"otel_traces_export", "backoff_max_interval"},
+		{"otel_traces_export", "insecure_skip_verify"},
+		{"otel_traces_export", "instrumentations"},
+		{"otel_traces_export", "otel_sdk_log_level"},
+		{"prometheus_export", "buckets"},
+		{"prometheus_export", "disable_build_info"},
+		{"prometheus_export", "exemplar_filter"},
+		{"prometheus_export", "instrumentations"},
+		{"prometheus_export", "native_histogram"},
+		{"prometheus_export", "path"},
+		{"prometheus_export", "ttl"},
+		{"service_name"},
+		{"service_namespace"},
+	}
+
+	var unsupported []string
+	for _, pattern := range patterns {
+		unsupported = append(unsupported, findV1Paths(root, pattern, "")...)
+	}
+	for _, path := range [][]string{{"routes"}, {"name_resolver"}} {
+		node, source := v1NodeAtPath(root, path)
+		if node != nil && node.Tag == "!!null" {
+			unsupported = append(unsupported, source)
+		}
+	}
+	unsupported = append(unsupported, unsupportedMetricFeaturePaths(root)...)
+	return unsupported
+}
+
+func unsupportedMetricFeaturePaths(root *legacyyaml.Node) []string {
+	patterns := [][]string{
+		{"metrics", "features"},
+		{"otel_metrics_export", "features"},
+		{"prometheus_export", "features"},
+	}
+	allowed := map[string]struct{}{
+		"application":                  {},
+		"network":                      {},
+		"stats":                        {},
+		"stats_tcp_failed_connections": {},
+		"stats_tcp_io":                 {},
+		"stats_tcp_retransmits":        {},
+		"stats_tcp_rtt":                {},
+	}
+
+	var unsupported []string
+	for _, pattern := range patterns {
+		node, path := v1NodeAtPath(root, pattern)
+		if node == nil || node.Kind != legacyyaml.SequenceNode {
+			continue
+		}
+		for i, feature := range node.Content {
+			if _, ok := allowed[feature.Value]; !ok {
+				unsupported = append(unsupported, fmt.Sprintf("%s[%d]", path, i))
+			}
+		}
+	}
+	return unsupported
+}
+
+func unsupportedRuntimePaths(root *legacyyaml.Node, cfg *obi.Config) []string {
+	var unsupported []string
+	traceProtocol, _ := v1NodeAtPath(root, []string{"otel_traces_export", "protocol"})
+	if (cfg.Traces.Enabled() || traceProtocol != nil) && cfg.Traces.GetProtocol() != otelcfg.ProtocolGRPC {
+		unsupported = append(unsupported, "otel_traces_export.protocol")
+	}
+	metricsProtocol, _ := v1NodeAtPath(root, []string{"otel_metrics_export", "protocol"})
+	if (cfg.OTELMetrics.EndpointEnabled() || metricsProtocol != nil) &&
+		cfg.OTELMetrics.GetProtocol() != otelcfg.ProtocolGRPC {
+		unsupported = append(unsupported, "otel_metrics_export.protocol")
+	}
+
+	sampler := cfg.Traces.SamplerConfig
+	switch sampler.Name {
+	case "", services.SamplerAlwaysOn, services.SamplerAlwaysOff, services.SamplerParentBasedAlwaysOn, services.SamplerParentBasedAlwaysOff:
+	case services.SamplerTraceIDRatio, services.SamplerParentBasedTraceIDRatio:
+		ratio, err := strconv.ParseFloat(sampler.Arg, 64)
+		if err != nil || math.IsNaN(ratio) || math.IsInf(ratio, 0) || ratio < 0 || ratio > 1 {
+			unsupported = append(unsupported, "otel_traces_export.sampler.arg")
+		}
+	default:
+		unsupported = append(unsupported, "otel_traces_export.sampler.name")
+	}
+	if path := unsupportedNetworkFeaturePath(root, cfg); path != "" {
+		unsupported = append(unsupported, path)
+	}
+	return unsupported
+}
+
+func unsupportedNetworkFeaturePath(root *legacyyaml.Node, cfg *obi.Config) string {
+	if cfg.Enabled(obi.FeatureNetO11y) || !cfg.Metrics.Features.AnyNetwork() {
+		return ""
+	}
+
+	path := []string{"metrics", "features"}
+	if cfg.OTELMetrics.EndpointEnabled() && cfg.OTELMetrics.DeprFeatures != 0 {
+		path = []string{"otel_metrics_export", "features"}
+	} else if cfg.Prometheus.EndpointEnabled() && cfg.Prometheus.DeprFeatures != 0 {
+		path = []string{"prometheus_export", "features"}
+	}
+	node, source := v1NodeAtPath(root, path)
+	if node == nil || node.Kind != legacyyaml.SequenceNode {
+		return strings.Join(path, ".")
+	}
+	for i, feature := range node.Content {
+		if feature.Value == "network" {
+			return fmt.Sprintf("%s[%d]", source, i)
+		}
+	}
+	return strings.Join(path, ".")
+}
+
+func migrationNotices(root *legacyyaml.Node) []MigrationNotice {
+	rules := []struct {
+		path    []string
+		message string
+	}{
+		{path: []string{"executable_path"}, message: "rewrote the legacy selector as an extensions.obi.capture.rules entry"},
+		{path: []string{"open_port"}, message: "rewrote the legacy selector as an extensions.obi.capture.rules entry"},
+		{path: []string{"target_pids"}, message: "rewrote the legacy selector as an extensions.obi.capture.rules entry"},
+		{path: []string{"discovery", "instrument"}, message: "moved selectors to extensions.obi.capture.rules"},
+		{path: []string{"discovery", "services"}, message: "rewrote legacy selectors as extensions.obi.capture.rules"},
+		{path: []string{"discovery", "exclude_services"}, message: "rewrote legacy selectors as extensions.obi.capture.rules"},
+		{path: []string{"discovery", "exclude_otel_instrumented_services"}, message: "rewrote the exclusion as an extensions.obi.capture.rules entry"},
+		{path: []string{"discovery", "excluded_linux_system_paths"}, message: "rewrote paths as extensions.obi.capture.rules entries"},
+		{path: []string{"discovery", "skip_go_specific_tracers"}, message: "inverted into extensions.obi.capture.runtimes.go.enabled"},
+		{path: []string{"filter", "application"}, message: "fanned out to protocol and signal filters"},
+		{path: []string{"filter", "network"}, message: "fanned out to network signal filters"},
+		{path: []string{"filter", "stats"}, message: "fanned out to stats signal filters"},
+		{path: []string{"otel_metrics_export"}, message: "moved the metric pipeline to meter_provider"},
+		{path: []string{"otel_metrics_export", "features"}, message: "applied the deprecated feature alias to capture enablement"},
+		{path: []string{"otel_traces_export"}, message: "moved the trace pipeline to tracer_provider"},
+		{path: []string{"prometheus_export", "features"}, message: "applied the deprecated feature alias to capture enablement"},
+	}
+
+	var notices []MigrationNotice
+	for _, rule := range rules {
+		paths := findV1Paths(root, rule.path, "")
+		for _, path := range paths {
+			notices = append(notices, MigrationNotice{Source: path, Message: rule.message})
+		}
+	}
+	slices.SortFunc(notices, func(a, b MigrationNotice) int {
+		if result := strings.Compare(a.Source, b.Source); result != 0 {
+			return result
+		}
+		return strings.Compare(a.Message, b.Message)
+	})
+	return notices
+}
+
+func findV1Paths(node *legacyyaml.Node, pattern []string, prefix string) []string {
+	if len(pattern) == 0 {
+		return []string{prefix}
+	}
+	if pattern[0] == "*" {
+		if node == nil || node.Kind != legacyyaml.SequenceNode {
+			return nil
+		}
+		var paths []string
+		for i, child := range node.Content {
+			paths = append(paths, findV1Paths(child, pattern[1:], fmt.Sprintf("%s[%d]", prefix, i))...)
+		}
+		return paths
+	}
+
+	child := legacyMappingValue(node, pattern[0])
+	if child == nil {
+		return nil
+	}
+	next := pattern[0]
+	if prefix != "" {
+		next = prefix + "." + pattern[0]
+	}
+	return findV1Paths(child, pattern[1:], next)
+}
+
+func v1NodeAtPath(root *legacyyaml.Node, path []string) (*legacyyaml.Node, string) {
+	node := root
+	var parts []string
+	for _, key := range path {
+		node = legacyMappingValue(node, key)
+		if node == nil {
+			return nil, ""
+		}
+		parts = append(parts, key)
+	}
+	return node, strings.Join(parts, ".")
+}
+
+func legacyMappingValue(node *legacyyaml.Node, key string) *legacyyaml.Node {
+	if node == nil || node.Kind != legacyyaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}

--- a/internal/config/convert/migrate_test.go
+++ b/internal/config/convert/migrate_test.go
@@ -1,0 +1,276 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/config/schema"
+)
+
+func TestMigrateV1YAMLDoesNotApplyEnvironmentOverrides(t *testing.T) {
+	t.Setenv("OTEL_EBPF_OPEN_PORT", "9090")
+
+	input := []byte(`
+open_port: 8080
+otel_traces_export:
+  endpoint: http://localhost:4317
+  protocol: grpc
+`)
+	got, _, err := MigrateV1YAML(input)
+
+	require.NoError(t, err)
+	require.Contains(t, string(got), `open_ports: "8080"`)
+	require.NotContains(t, string(got), `open_ports: "9090"`)
+	again, _, err := MigrateV1YAML(input)
+	require.NoError(t, err)
+	require.Equal(t, got, again)
+}
+
+func TestMigrateV1YAMLRejectsEnvironmentInterpolation(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := MigrateV1YAML([]byte(`
+open_port: ${APP_PORT:-8080}
+`))
+
+	require.ErrorContains(t, err, "environment interpolation is not supported")
+}
+
+func TestMigrateV1YAMLRejectsAllEnvironmentInterpolationForms(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := MigrateV1YAML([]byte(`
+attributes:
+  kubernetes:
+    cluster_name: $(CLUSTER_NAME)
+`))
+
+	require.ErrorContains(t, err, "environment interpolation is not supported")
+}
+
+func TestMigrateV1YAMLIgnoresInterpolationSyntaxInComments(t *testing.T) {
+	t.Parallel()
+
+	got, _, err := MigrateV1YAML([]byte(`
+# ${IGNORED} and $(ALSO_IGNORED)
+attributes:
+  kubernetes:
+    cluster_name: $${LITERAL}
+`))
+
+	require.NoError(t, err)
+	require.Contains(t, string(got), `$${LITERAL}`)
+}
+
+func TestMigrateV1YAMLRejectsAliasesAndMergeKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   string
+		expected string
+	}{
+		{
+			name: "alias",
+			config: `
+routes:
+  patterns: &patterns [/users/:id]
+  ignored_patterns: *patterns
+`,
+			expected: "YAML aliases are not supported",
+		},
+		{
+			name: "merge key",
+			config: `
+routes:
+  <<: &defaults
+    unmatched: path
+`,
+			expected: "YAML merge keys are not supported",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := MigrateV1YAML([]byte(test.config))
+
+			require.ErrorContains(t, err, test.expected)
+		})
+	}
+}
+
+func TestMigrateV1YAMLRejectsUnknownV1Fields(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := MigrateV1YAML([]byte(`
+open_port: 8080
+unknown_setting: true
+`))
+
+	require.ErrorContains(t, err, "field unknown_setting not found")
+
+	_, _, err = MigrateV1YAML([]byte(`
+extensions:
+  obi:
+    version: "2.0"
+`))
+	require.ErrorContains(t, err, "input contains config v2 extensions")
+}
+
+func TestMigrateV1YAMLReportsUnsupportedFieldsInOrder(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := MigrateV1YAML([]byte(`
+service_name: checkout
+prometheus_export:
+  path: /custom-metrics
+discovery:
+  instrument:
+    - open_ports: 8080
+      sampler:
+        name: always_on
+`))
+
+	require.EqualError(t, err, "v1 fields outside the supported migration contract: "+
+		"discovery.instrument[0].sampler, prometheus_export.path, service_name")
+}
+
+func TestMigrateV1YAMLRejectsNullPointerSections(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := MigrateV1YAML([]byte(`
+routes: null
+name_resolver: null
+`))
+
+	require.EqualError(t, err, "v1 fields outside the supported migration contract: name_resolver, routes")
+}
+
+func TestMigrateV1YAMLRejectsUnsupportedMetricFeature(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := MigrateV1YAML([]byte(`
+metrics:
+  features: [application, application_service_graph]
+`))
+
+	require.EqualError(t, err, "v1 fields outside the supported migration contract: metrics.features[1]")
+}
+
+func TestMigrateV1YAMLRejectsNonGRPCTransport(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := MigrateV1YAML([]byte(`
+open_port: 8080
+otel_traces_export:
+  endpoint: http://localhost:4318
+  protocol: http/protobuf
+`))
+
+	require.EqualError(t, err, "v1 fields outside the supported migration contract: otel_traces_export.protocol")
+}
+
+func TestMigrateV1YAMLRejectsNonGRPCProtocolWithoutEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		config   string
+		expected string
+	}{
+		{
+			name: "traces",
+			config: `
+otel_traces_export:
+  protocol: http/protobuf
+`,
+			expected: "otel_traces_export.protocol",
+		},
+		{
+			name: "metrics",
+			config: `
+otel_metrics_export:
+  protocol: http/json
+`,
+			expected: "otel_metrics_export.protocol",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := MigrateV1YAML([]byte(test.config))
+
+			require.EqualError(t, err, "v1 fields outside the supported migration contract: "+test.expected)
+		})
+	}
+}
+
+func TestMigrateV1YAMLRejectsNonFiniteSamplerRatio(t *testing.T) {
+	t.Parallel()
+
+	for _, ratio := range []string{"NaN", "+Inf", "-Inf"} {
+		t.Run(ratio, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := MigrateV1YAML([]byte(`
+otel_traces_export:
+  sampler:
+    name: traceidratio
+    arg: "` + ratio + `"
+`))
+
+			require.EqualError(t, err, "v1 fields outside the supported migration contract: "+
+				"otel_traces_export.sampler.arg")
+		})
+	}
+}
+
+func TestMigrateV1YAMLRejectsImplicitNetworkCaptureEnablement(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := MigrateV1YAML([]byte(`
+metrics:
+  features: [network]
+network:
+  enable: false
+`))
+
+	require.EqualError(t, err, "v1 fields outside the supported migration contract: metrics.features[0]")
+
+	_, _, err = MigrateV1YAML([]byte(`
+metrics:
+  features: [network]
+network:
+  enable: false
+otel_metrics_export:
+  endpoint: http://localhost:4317
+  protocol: grpc
+`))
+	require.NoError(t, err)
+}
+
+func TestMigrateV1YAMLPreservesAdditionalPropertiesMapKey(t *testing.T) {
+	t.Parallel()
+
+	encoded, _, err := MigrateV1YAML([]byte(`
+filter:
+  application:
+    additionalproperties:
+      match: foo
+`))
+	require.NoError(t, err)
+
+	doc, _, err := schema.ParseStandaloneYAML(encoded)
+	require.NoError(t, err)
+	cfg, err := DocumentToRuntime(doc)
+	require.NoError(t, err)
+	require.Equal(t, "foo", cfg.Filters.Application["additionalproperties"].Match)
+}

--- a/internal/config/schema/correlation.go
+++ b/internal/config/schema/correlation.go
@@ -11,6 +11,7 @@ type Correlation struct {
 // LogTraceAnnotation describes log trace annotation settings.
 type LogTraceAnnotation struct {
 	Enabled     bool        `yaml:"enabled"`
+	Filter      any         `yaml:"filter,omitempty"`
 	Cache       Cache       `yaml:"cache"`
 	AsyncWriter AsyncWriter `yaml:"async_writer"`
 }

--- a/internal/config/schema/enrich.go
+++ b/internal/config/schema/enrich.go
@@ -21,6 +21,7 @@ type Enrich struct {
 // Enrichers groups metadata enricher settings.
 type Enrichers struct {
 	Kubernetes KubernetesEnricher `yaml:"kubernetes"`
+	DNS        any                `yaml:"dns,omitempty"`
 }
 
 // KubernetesMode describes Kubernetes metadata enricher activation.
@@ -89,6 +90,7 @@ type ServiceName struct {
 	UnresolvedHosts UnresolvedHosts    `yaml:"unresolved_hosts"`
 	Sources         []transform.Source `yaml:"sources"`
 	Cache           Cache              `yaml:"cache"`
+	Rules           any                `yaml:"rules,omitempty"`
 }
 
 // UnresolvedHosts describes names assigned to unresolved hosts.
@@ -109,6 +111,7 @@ type EnrichmentAttributes struct {
 	Select               attributes.Selection `yaml:"select"`
 	ExtraGroupAttributes ExtraGroupAttributes `yaml:"extra_group_attributes"`
 	MetadataRetry        MetadataRetry        `yaml:"metadata_retry"`
+	Rules                any                  `yaml:"rules,omitempty"`
 }
 
 // ExtraGroupAttributes maps OBI attribute group names to extra attribute names.

--- a/internal/config/schema/runtimes.go
+++ b/internal/config/schema/runtimes.go
@@ -13,11 +13,13 @@ type CaptureRuntimes struct {
 // Runtime describes generic language runtime capture settings.
 type Runtime struct {
 	Enabled bool `yaml:"enabled"`
+	Filter  any  `yaml:"filter,omitempty"`
 }
 
 // JavaRuntime describes Java runtime capture and debug settings.
 type JavaRuntime struct {
 	Enabled       bool      `yaml:"enabled"`
+	Filter        any       `yaml:"filter,omitempty"`
 	Debug         JavaDebug `yaml:"debug"`
 	AttachTimeout Duration  `yaml:"attach_timeout"`
 }

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -19,8 +19,10 @@
 package schema // import "go.opentelemetry.io/obi/internal/config/schema"
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 
 	"go.yaml.in/yaml/v3"
 
@@ -141,17 +143,23 @@ func ParseStandaloneYAML(data []byte) (*Document, *Extension, error) {
 		if version != SupportedVersion {
 			return nil, nil, &UnsupportedVersionError{Version: version}
 		}
+		obiNode, ok := nestedNode(root, "extensions", "obi")
+		if !ok {
+			return nil, nil, &NotV2Error{Reason: "missing extensions.obi"}
+		}
+		var ext Extension
+		if err := decodeStrict(obiNode, &ext); err != nil {
+			return nil, nil, err
+		}
 		var doc Document
 		if err := decode(root, &doc); err != nil {
 			return nil, nil, err
 		}
-		if doc.Extensions.OBI == nil {
-			return nil, nil, &NotV2Error{Reason: "missing extensions.obi"}
-		}
-		if err := ValidateStandalone(doc.Extensions.OBI); err != nil {
+		doc.Extensions.OBI = &ext
+		if err := ValidateStandalone(&ext); err != nil {
 			return nil, nil, err
 		}
-		return &doc, doc.Extensions.OBI, nil
+		return &doc, &ext, nil
 	}
 
 	if version, ok := nestedVersion(root, "extensions", "obi", "version"); ok {
@@ -188,7 +196,7 @@ func ParseReceiverYAML(data []byte) (*Extension, error) {
 			return nil, &SectionNotAllowedError{Section: section}
 		}
 		var receiver receiverConfig
-		if err := decode(root, &receiver); err != nil {
+		if err := decodeStrict(root, &receiver); err != nil {
 			return nil, err
 		}
 		cfg := Extension{
@@ -278,8 +286,19 @@ func looksLikeV1(root *yaml.Node) bool {
 }
 
 func parseYAML(data []byte) (*yaml.Node, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	var doc yaml.Node
-	if err := yaml.Unmarshal(data, &doc); err != nil {
+	if err := decoder.Decode(&doc); err != nil {
+		if errors.Is(err, io.EOF) {
+			return &doc, nil
+		}
+		return nil, fmt.Errorf("parsing config v2 YAML: %w", err)
+	}
+	var trailing yaml.Node
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("parsing config v2 YAML: multiple YAML documents are not supported")
+		}
 		return nil, fmt.Errorf("parsing config v2 YAML: %w", err)
 	}
 	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
@@ -290,6 +309,19 @@ func parseYAML(data []byte) (*yaml.Node, error) {
 
 func decode(node *yaml.Node, dst any) error {
 	if err := node.Decode(dst); err != nil {
+		return fmt.Errorf("decoding config v2 YAML: %w", err)
+	}
+	return nil
+}
+
+func decodeStrict(node *yaml.Node, dst any) error {
+	data, err := yaml.Marshal(node)
+	if err != nil {
+		return fmt.Errorf("encoding config v2 YAML for strict decoding: %w", err)
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(dst); err != nil {
 		return fmt.Errorf("decoding config v2 YAML: %w", err)
 	}
 	return nil

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -243,6 +243,40 @@ func TestReceiverRejectsStandaloneSections(t *testing.T) {
 	}
 }
 
+func TestParsersRejectUnknownOBIFields(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ParseStandaloneYAML([]byte(`
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    caputre: {}
+`))
+	require.ErrorContains(t, err, "field caputre not found")
+
+	_, err = ParseReceiverYAML([]byte(`
+version: "2.0"
+policy:
+  default_actoin: include
+`))
+	require.ErrorContains(t, err, "field default_actoin not found")
+}
+
+func TestParsersRejectMultipleDocuments(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`
+version: "2.0"
+---
+version: "2.0"
+`)
+
+	_, err := ParseReceiverYAML(data)
+
+	require.ErrorContains(t, err, "multiple YAML documents are not supported")
+}
+
 func TestStandaloneAllowsStandaloneSections(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -647,10 +647,9 @@ func (e ConfigError) Error() string {
 	return string(e)
 }
 
-// Validate configuration
-//
-//nolint:cyclop
-func (c *Config) Validate() error {
+// ValidateValues checks configuration invariants that do not depend on the
+// runtime environment or on a complete export pipeline.
+func (c *Config) ValidateValues() error {
 	validate := validator.New(validator.WithRequiredStructEnabled())
 
 	// for future custom validations
@@ -688,6 +687,17 @@ func (c *Config) Validate() error {
 
 	if err := c.Traces.NormalizeQueueConfig(); err != nil {
 		return ConfigError(err.Error())
+	}
+
+	return nil
+}
+
+// Validate configuration
+//
+//nolint:cyclop
+func (c *Config) Validate() error {
+	if err := c.ValidateValues(); err != nil {
+		return err
 	}
 
 	if !c.Enabled(FeatureNetO11y) && !c.Enabled(FeatureAppO11y) && !c.Enabled(FeatureStatsO11y) {


### PR DESCRIPTION
## Summary

- add `obi config validate` for standalone Config v2 documents and
  receiver-embedded OBI fragments
- add deterministic, file-only `obi config migrate` support for the v1
  surface that the current Config v2 contract can preserve
- keep command output suitable for CI and source control with stable exit
  codes, canonical YAML on stdout, and mapping diagnostics on stderr
- validate converted host-independent runtime values and reject rule shapes
  that the runtime converter cannot preserve
- document command syntax, output streams, limitations, and exit codes

## Config v2 release gate

This PR implements #2534, the CLI slice of the atomic Config v2 gate tracked
by #2251. Opening this draft does not declare Config v2 ready for public use.
The commands must not be released as an independent public surface.

Coordinated merge and release readiness depends on:

- [ ] reducing or splitting this initial draft to satisfy #2251's review-size
      budget before it is marked ready
- [ ] #2535 enabling standalone Config v2 runtime loading
- [ ] #2536 enabling Config v2 in the existing Collector receiver
- [ ] #594 defining and enforcing the supported OpenTelemetry declarative
      configuration subset, including parsed-but-unsupported fields
- [ ] #1282 resolving protocol- and signal-scoped filtering semantics
- [ ] #2211 resolving canonical OBI configuration ownership and placement
- [ ] #747 resolving or explicitly deferring remaining route semantics
- [ ] #1758 publishing complete migration guidance, changed defaults,
      unsupported-field behavior, and equivalent v1/v2 examples
- [ ] publishing the schema, default example, CLI documentation, and
      migration artifacts in the #2251 release window
- [ ] explicitly recording the #923 per-process configuration deferral unless
      maintainers select a bounded deliverable

Until those items are resolved, `validate` and `migrate` exercise the current
internal schema and conversion contract only. Migrated files are not loadable
through normal standalone or receiver startup until #2535 and #2536 land.

In particular, #594 must resolve strict handling for documented fields that
are not represented by the current typed model and for OpenTelemetry-owned
shapes outside the converter's supported subset. This draft intentionally
does not claim those ambiguous shapes are release-ready.

## Validation

- `go test ./pkg/obi ./internal/config/... ./cmd/obi`
- `go tool -modfile=internal/tools/go.mod golangci-lint run ./cmd/obi ./internal/config/... ./pkg/obi --timeout=6m`
- `make check-config-v2-artifacts`
- `make lint-markdown`
- `make license-header-check`
- `make go-mod-tidy`

Addresses #2534.
