### PR TITLE
fix: workaround ioctl(FIONREAD) wrongly returning zero when context propagation is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,7 +237,7 @@ update-offsets:
 BPF_ROOT = pkg/
 
 # Find all generated Go and object files (used as Make targets)
-BPF_GEN_GO := $(shell find $(BPF_ROOT) -type f \( -name 'bpf_*_bpfe[lb].go' -o -name 'net_*_bpfe[lb].go' -o -name 'netsk_*_bpfe[lb].go' -o -name 'stats_*_bpfe[lb].go' \))
+BPF_GEN_GO := $(shell find $(BPF_ROOT) -type f \( -name 'bpf*_bpfe[lb].go' -o -name 'net_*_bpfe[lb].go' -o -name 'netsk_*_bpfe[lb].go' -o -name 'stats_*_bpfe[lb].go' \))
 BPF_GEN_OBJ := $(BPF_GEN_GO:.go=.o)
 BPF_GEN_ALL := $(if $(BPF_GEN_GO),$(BPF_GEN_GO) $(BPF_GEN_OBJ))
 

--- a/bpf/maps/tracked_sock_cookies.h
+++ b/bpf/maps/tracked_sock_cookies.h
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/pin_internal.h>
+
+// Cookies of sockets inserted into sock_dir; the FIONREAD fixup uses them
+// to identify affected sockets. LRU so stale entries age out
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, 65535);
+    __uint(key_size, sizeof(u64));
+    __uint(value_size, sizeof(u8));
+    __uint(pinning, OBI_PIN_INTERNAL);
+} tracked_sock_cookies SEC(".maps");

--- a/bpf/tpinjector/fionread_fixup.c
+++ b/bpf/tpinjector/fionread_fixup.c
@@ -1,0 +1,121 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_core_read.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <logger/bpf_dbg.h>
+
+#include <maps/tracked_sock_cookies.h>
+
+char __license[] SEC("license") = "Dual MIT/GPL";
+
+// Kernels with commit 929e30f93125 report FIONREAD=0 for sockets in a
+// sockhash without a verdict program; rewrite the user-visible result with
+// the real queue length (tcp_inq) after the kernel's put_user
+enum { k_fionread = 0x541B };
+
+typedef struct fionread_fix {
+    u64 arg;
+    struct sock *sk;
+} fionread_fix_t;
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __uint(max_entries, 10240);
+    __uint(key_size, sizeof(u64));
+    __uint(value_size, sizeof(fionread_fix_t));
+} fionread_inflight SEC(".maps");
+
+SEC("tracepoint/syscalls/sys_enter_ioctl")
+int obi_fionread_fixup_enter(struct trace_event_raw_sys_enter *ctx) {
+    if ((u32)ctx->args[1] != k_fionread) {
+        return 0;
+    }
+
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    struct fdtable *fdt = BPF_CORE_READ(task, files, fdt);
+    const u32 fd = (u32)ctx->args[0];
+
+    if (fd >= BPF_CORE_READ(fdt, max_fds)) {
+        return 0;
+    }
+
+    struct file **fd_arr = BPF_CORE_READ(fdt, fd);
+    struct file *file = NULL;
+    bpf_probe_read_kernel(&file, sizeof(file), fd_arr + fd);
+
+    if (!file) {
+        return 0;
+    }
+
+    struct socket *sock = BPF_CORE_READ(file, private_data);
+    if (!sock) {
+        return 0;
+    }
+
+    struct sock *sk = BPF_CORE_READ(sock, sk);
+    if (!sk) {
+        return 0;
+    }
+
+    // a non-socket file's private_data cannot yield a tracked cookie
+    const u64 cookie = BPF_CORE_READ(sk, __sk_common.skc_cookie.counter);
+
+    if (!bpf_map_lookup_elem(&tracked_sock_cookies, &cookie)) {
+        return 0;
+    }
+
+    const u64 id = bpf_get_current_pid_tgid();
+    fionread_fix_t fix = {.arg = ctx->args[2], .sk = sk};
+    bpf_map_update_elem(&fionread_inflight, &id, &fix, BPF_ANY);
+
+    return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_ioctl")
+int obi_fionread_fixup_exit(struct trace_event_raw_sys_exit *ctx) {
+    const u64 id = bpf_get_current_pid_tgid();
+    const fionread_fix_t *fix = bpf_map_lookup_elem(&fionread_inflight, &id);
+
+    if (!fix) {
+        return 0;
+    }
+
+    struct sock *sk = fix->sk;
+    void *arg = (void *)fix->arg;
+
+    bpf_map_delete_elem(&fionread_inflight, &id);
+
+    if (ctx->ret != 0) {
+        return 0;
+    }
+
+    // mirrors tcp_inq(); the fd is held for the whole syscall so sk is live
+    const u8 state = BPF_CORE_READ(sk, __sk_common.skc_state);
+
+    if (state == TCP_SYN_SENT || state == TCP_SYN_RECV) {
+        return 0;
+    }
+
+    struct tcp_sock *tp = (struct tcp_sock *)sk;
+    const u32 rcv_nxt = BPF_CORE_READ(tp, rcv_nxt);
+    const u32 copied_seq = BPF_CORE_READ(tp, copied_seq);
+    int inq = (int)(rcv_nxt - copied_seq);
+
+    const unsigned long flags = BPF_CORE_READ(sk, __sk_common.skc_flags);
+
+    if (inq > 0 && (flags & (1UL << SOCK_DONE))) {
+        inq--;
+    }
+
+    if (inq < 0) {
+        inq = 0;
+    }
+
+    const long err = bpf_probe_write_user(arg, &inq, sizeof(inq));
+    bpf_dbg_printk("fionread fix inq=%d err=%ld", inq, err);
+
+    return 0;
+}

--- a/bpf/tpinjector/sock_iter.c
+++ b/bpf/tpinjector/sock_iter.c
@@ -11,6 +11,7 @@
 #include <logger/bpf_dbg.h>
 
 #include <maps/sock_dir.h>
+#include <maps/tracked_sock_cookies.h>
 
 char __license[] SEC("license") = "Dual MIT/GPL";
 
@@ -105,6 +106,8 @@ int obi_sk_iter_tcp(struct bpf_iter__tcp *ctx) {
 
     if (bpf_map_update_elem(&sock_dir, &cookie, skc, BPF_NOEXIST) != 0) {
         bpf_dbg_printk("Failed to track sock cookie=%llu", cookie);
+    } else {
+        bpf_map_update_elem(&tracked_sock_cookies, &cookie, &(u8){1}, BPF_ANY);
     }
 
     return 0;

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -37,6 +37,7 @@
 #include <maps/outgoing_trace_map.h>
 #include <maps/sock_dir.h>
 #include <maps/tp_info_mem.h>
+#include <maps/tracked_sock_cookies.h>
 
 #include <tpinjector/h2_parse.h>
 #include <tpinjector/maps/sk_h2_conn_flag.h>
@@ -393,7 +394,9 @@ static __always_inline void bpf_sock_ops_set_flags(struct bpf_sock_ops *skops, u
 static __always_inline void bpf_sock_ops_active_est_cb(struct bpf_sock_ops *skops) {
     const u64 cookie = bpf_get_socket_cookie(skops);
 
-    bpf_sock_hash_update(skops, &sock_dir, (void *)&cookie, BPF_ANY);
+    if (bpf_sock_hash_update(skops, &sock_dir, (void *)&cookie, BPF_ANY) == 0) {
+        bpf_map_update_elem(&tracked_sock_cookies, &cookie, &(u8){1}, BPF_ANY);
+    }
     bpf_sock_ops_set_flags(skops, BPF_SOCK_OPS_WRITE_HDR_OPT_CB_FLAG);
 }
 

--- a/pkg/ebpf/instrumenter.go
+++ b/pkg/ebpf/instrumenter.go
@@ -749,10 +749,14 @@ func (i *instrumenter) tracepoints(p KprobesTracer) error {
 		slog.Debug("going to add syscall", "function", sfunc, "probes", sprobes)
 
 		if err := i.tracepoint(sfunc, sprobes); err != nil {
-			if i.metrics != nil {
-				i.metrics.InstrumentationError(i.processName, imetrics.InstrumentationErrorInvalidTracepoint)
+			if sprobes.Required {
+				if i.metrics != nil {
+					i.metrics.InstrumentationError(i.processName, imetrics.InstrumentationErrorInvalidTracepoint)
+				}
+				return fmt.Errorf("instrumenting function %q: %w", sfunc, err)
 			}
-			return fmt.Errorf("instrumenting function %q: %w", sfunc, err)
+
+			slog.Debug("error instrumenting tracepoint", "function", sfunc, "error", err)
 		}
 		p.AddCloser(i.closables...)
 	}

--- a/pkg/internal/ebpf/tpinjector/fionread_check.go
+++ b/pkg/internal/ebpf/tpinjector/fionread_check.go
@@ -1,0 +1,160 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package tpinjector // import "go.opentelemetry.io/obi/pkg/internal/ebpf/tpinjector"
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"golang.org/x/sys/unix"
+
+	ebpfconvenience "go.opentelemetry.io/obi/pkg/internal/ebpf/convenience"
+)
+
+// Detects kernels where sockhash insertion breaks FIONREAD (commit
+// 929e30f93125). cookies non-nil: register the probe socket so an attached
+// fixup applies and the corrected behavior is measured
+func sockhashFIONREADProbe(cookies *ebpf.Map) (bool, error) {
+	sockHash, err := ebpf.NewMap(&ebpf.MapSpec{
+		Name:       "obi_fionread_p",
+		Type:       ebpf.SockHash,
+		KeySize:    8,
+		ValueSize:  4,
+		MaxEntries: 2,
+	})
+	if err != nil {
+		return false, fmt.Errorf("creating probe sockhash: %w", err)
+	}
+	defer sockHash.Close()
+
+	lsn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return false, fmt.Errorf("listening on loopback: %w", err)
+	}
+	defer lsn.Close()
+
+	client, err := net.Dial("tcp", lsn.Addr().String())
+	if err != nil {
+		return false, fmt.Errorf("connecting to probe listener: %w", err)
+	}
+	defer client.Close()
+
+	server, err := lsn.Accept()
+	if err != nil {
+		return false, fmt.Errorf("accepting probe connection: %w", err)
+	}
+	defer server.Close()
+
+	raw, err := client.(*net.TCPConn).SyscallConn()
+	if err != nil {
+		return false, fmt.Errorf("getting raw conn: %w", err)
+	}
+	var fd int
+	if err := raw.Control(func(f uintptr) { fd = int(f) }); err != nil {
+		return false, fmt.Errorf("getting socket fd: %w", err)
+	}
+
+	key := uint64(1)
+	if err := sockHash.Update(&key, uint32(fd), ebpf.UpdateAny); err != nil {
+		return false, fmt.Errorf("inserting socket into probe sockhash: %w", err)
+	}
+
+	if cookies != nil {
+		cookie, err := unix.GetsockoptUint64(fd, unix.SOL_SOCKET, unix.SO_COOKIE)
+		if err != nil {
+			return false, fmt.Errorf("getting socket cookie: %w", err)
+		}
+		if err := cookies.Update(&cookie, uint8(1), ebpf.UpdateAny); err != nil {
+			return false, fmt.Errorf("registering probe cookie: %w", err)
+		}
+		defer cookies.Delete(&cookie) //nolint:errcheck
+	}
+
+	const payload = 4096
+	if _, err := server.Write(make([]byte, payload)); err != nil {
+		return false, fmt.Errorf("writing probe payload: %w", err)
+	}
+
+	// FIONREAD itself is under test, so readiness must come from MSG_PEEK
+	buf := make([]byte, payload)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		n, _, err := unix.Recvfrom(fd, buf, unix.MSG_PEEK|unix.MSG_DONTWAIT)
+		if err == nil && n == payload {
+			break
+		}
+		if time.Now().After(deadline) {
+			return false, errors.New("probe payload never became readable")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// TIOCINQ == FIONREAD on Linux; x/sys/unix lacks a FIONREAD alias
+	avail, err := unix.IoctlGetInt(fd, unix.TIOCINQ)
+	if err != nil {
+		return false, fmt.Errorf("ioctl(FIONREAD): %w", err)
+	}
+
+	return avail != payload, nil
+}
+
+func (p *Tracer) kernelBreaksFIONREAD() bool {
+	p.fionreadOnce.Do(func() {
+		broken, err := sockhashFIONREADProbe(nil)
+		if err != nil {
+			p.log.Warn("FIONREAD sockhash probe failed", "error", err)
+			return
+		}
+		p.fionreadBroken = broken
+		if broken {
+			p.log.Warn("kernel misreports ioctl(FIONREAD) for sockets in a sockhash " +
+				"(kernel commit 929e30f93125, present in 6.6.128+, 6.12.75+, 6.18.14+ and 6.19+); " +
+				"enabling BPF compensation for tracked sockets")
+		}
+	})
+	return p.fionreadBroken
+}
+
+// test-load on a throwaway copy so LoadSpecs can skip the bundle on kernels
+// that reject bpf_probe_write_user (lockdown)
+func loadableFIONREADFixup() (*ebpf.CollectionSpec, error) {
+	spec, err := LoadBpfFionreadFixup()
+	if err != nil {
+		return nil, err
+	}
+	test := spec.Copy()
+	for _, m := range test.Maps {
+		if m.Pinning == ebpfconvenience.PinInternal {
+			m.Pinning = ebpf.PinNone
+		}
+	}
+	coll, err := ebpf.NewCollection(test)
+	if err != nil {
+		return nil, err
+	}
+	coll.Close()
+	return spec, nil
+}
+
+// end-to-end check that the attached fixup actually corrects FIONREAD
+func (p *Tracer) verifyFIONREADFix() {
+	stillBroken, err := sockhashFIONREADProbe(p.bpfObjects.TrackedSockCookies)
+	if err != nil {
+		p.log.Warn("cannot verify FIONREAD compensation", "error", err)
+		return
+	}
+	if stillBroken {
+		p.log.Error("FIONREAD compensation is ineffective (attach failed or blocked?); " +
+			"applications sizing reads via FIONREAD (nginx, Java, .NET) may stall or " +
+			"truncate transfers; set context_propagation: disabled " +
+			"(OTEL_EBPF_BPF_CONTEXT_PROPAGATION=disabled) to avoid impact")
+		return
+	}
+	p.log.Info("FIONREAD compensation verified")
+}

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"sync"
 
 	"github.com/cilium/ebpf"
 
@@ -23,14 +24,19 @@ import (
 
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 Bpf ../../../../bpf/tpinjector/tpinjector.c -- -I../../../../bpf -I../../../../bpf
 //go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 BpfIter ../../../../bpf/tpinjector/sock_iter.c -- -I../../../../bpf -I../../../../bpf
+//go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 BpfFionreadFixup ../../../../bpf/tpinjector/fionread_fixup.c -- -I../../../../bpf -I../../../../bpf
 
 type Tracer struct {
-	cfg            *obi.Config
-	bpfObjects     BpfObjects
-	bpfIterObjects BpfIterObjects
-	closers        []io.Closer
-	log            *slog.Logger
-	iters          []*ebpfcommon.Iter
+	cfg                     *obi.Config
+	bpfObjects              BpfObjects
+	bpfIterObjects          BpfIterObjects
+	bpfFionreadFixupObjects BpfFionreadFixupObjects
+	closers                 []io.Closer
+	log                     *slog.Logger
+	iters                   []*ebpfcommon.Iter
+	fionreadOnce            sync.Once
+	fionreadBroken          bool
+	fionreadFixupEnabled    bool
 }
 
 func New(cfg *obi.Config) *Tracer {
@@ -73,6 +79,25 @@ func (p *Tracer) LoadSpecs() ([]*ebpfcommon.SpecBundle, error) {
 			Objects:   &p.bpfIterObjects,
 			Constants: p.iterConstants(),
 		})
+	}
+
+	// kernel lockdown rejects bpf_probe_write_user at load time
+	if p.kernelBreaksFIONREAD() {
+		fixupSpec, err := loadableFIONREADFixup()
+		if err != nil {
+			p.log.Error("kernel misreports FIONREAD for sockets in a sockhash and the BPF "+
+				"compensation cannot be loaded (kernel lockdown?); applications sizing reads "+
+				"via FIONREAD (nginx, Java, .NET) may stall or truncate transfers; "+
+				"set context_propagation: disabled (OTEL_EBPF_BPF_CONTEXT_PROPAGATION=disabled) "+
+				"to avoid impact", "error", err)
+		} else {
+			bundles = append(bundles, &ebpfcommon.SpecBundle{
+				Spec:      fixupSpec,
+				Objects:   &p.bpfFionreadFixupObjects,
+				Constants: map[string]any{"g_bpf_debug": p.cfg.EBPF.BpfDebug},
+			})
+			p.fionreadFixupEnabled = true
+		}
 	}
 
 	return bundles, nil
@@ -124,8 +149,16 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {
 	return nil
 }
 
+// Tracepoints returns the FIONREAD fixup probes; not Required so a failed
+// attach cannot drop the tracer
 func (p *Tracer) Tracepoints() map[string]ebpfcommon.ProbeDesc {
-	return nil
+	if !p.fionreadFixupEnabled {
+		return nil
+	}
+	return map[string]ebpfcommon.ProbeDesc{
+		"syscalls/sys_enter_ioctl": {Start: p.bpfFionreadFixupObjects.ObiFionreadFixupEnter},
+		"syscalls/sys_exit_ioctl":  {Start: p.bpfFionreadFixupObjects.ObiFionreadFixupExit},
+	}
 }
 
 func (p *Tracer) UProbes() map[string]map[string][]*ebpfcommon.ProbeDesc {
@@ -196,6 +229,10 @@ func (p *Tracer) AlreadyInstrumentedLib(uint64) bool {
 func (p *Tracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg.Queue[[]request.Span]) {
 	p.log.Debug("tpinjector started")
 
+	if p.fionreadFixupEnabled {
+		p.verifyFIONREADFix()
+	}
+
 	for _, it := range p.Iters() {
 		if err := it.Run(p.log); err != nil {
 			p.log.Error("error running iterator", "error", err)
@@ -206,6 +243,7 @@ func (p *Tracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg
 
 	p.bpfObjects.Close()
 	p.bpfIterObjects.Close()
+	p.bpfFionreadFixupObjects.Close()
 
 	p.log.Debug("tpinjector terminated")
 }

--- a/pkg/internal/ebpf/verifier/bpf_verifier_test.go
+++ b/pkg/internal/ebpf/verifier/bpf_verifier_test.go
@@ -218,6 +218,12 @@ func TestBPFVerifierWithConstants(t *testing.T) {
 		t.Logf("skipping tpinjector/BpfIter: kernel %d.%d < 5.11", major, minor)
 	}
 
+	// tpinjector/BpfFionreadFixup uses bpf_probe_write_user, rejected at load time
+	// under kernel lockdown - none of the CI kernels run locked down
+	forEachCombination(t, "tpinjector/BpfFionreadFixup", tpinjectorbpf.LoadBpfFionreadFixup, []constOption{
+		{"g_bpf_debug", []any{true, false}},
+	})
+
 	// watcher
 	forEachCombination(t, "watcher/Bpf", watcherbpf.LoadBpf, []constOption{
 		{"g_bpf_debug", []any{true, false}},


### PR DESCRIPTION
## Summary

On certain kernels, ioctl(FIONREAD) returns zero for sockets with sockmaps when no verdict program is attached. This PR works around it by replacing the return value with the existing byte count so applications relying on ioctl(FIONREAD) won't hang anymore.

Fixes: https://github.com/grafana/beyla/issues/2941 , https://github.com/grafana/alloy/issues/6085

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
