### PR TITLE
fix: create individual execute_tool spans per tool call for semconv compliance

### DIFF
--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -775,7 +775,7 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 				}
 			}
 		}
-		
+
 		if span.SubType == request.HTTPSubtypeAnthropic && span.GenAI != nil && span.GenAI.Anthropic != nil {
 			ai := span.GenAI.Anthropic
 			attrs = append(attrs, semconv.GenAIProviderNameAnthropic)
@@ -845,7 +845,7 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Output.Error.Type))
 			}
 		}
-		
+
 		if span.SubType == request.HTTPSubtypeGemini && span.GenAI != nil && span.GenAI.Gemini != nil {
 			ai := span.GenAI.Gemini
 			attrs = append(attrs, semconv.GenAIProviderNameGCPGemini)
@@ -922,7 +922,7 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Output.Error.Status))
 			}
 		}
-		
+
 		if span.SubType == request.HTTPSubtypeQwen && span.GenAI != nil && span.GenAI.Qwen != nil {
 			ai := span.GenAI.Qwen
 			attrs = append(attrs, semconv.GenAIProviderNameKey.String(attr.QwenProviderName))
@@ -1006,7 +1006,7 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Error.Type))
 			}
 		}
-		
+
 		if span.SubType == request.HTTPSubtypeAWSBedrock && span.GenAI != nil && span.GenAI.Bedrock != nil {
 			ai := span.GenAI.Bedrock
 			attrs = append(attrs, semconv.GenAIProviderNameAWSBedrock)

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -231,6 +231,11 @@ func generateTracesWithAttributes(
 			appendSpanLinks(s, span.Links)
 		}
 		s.SetEndTimestamp(pcommon.NewTimestampFromTime(t.End))
+
+		// Create individual execute_tool child spans per tool call (OTel GenAI semconv compliance)
+		if toolCalls := getSpanToolCalls(span); len(toolCalls) > 0 {
+			createToolCallSpans(toolCalls, spanID, traceID, &ss, start, t.End)
+		}
 	}
 	return traces
 }
@@ -383,36 +388,49 @@ var (
 	spanMetricsSkip     = attribute.Bool(string(attr.SkipSpanMetrics), true)
 )
 
-// genAIToolCallAttributes returns trace attributes for LLM tool calls.
-// Only tool calls with non-empty names are included. Names and IDs are kept
-// aligned so that the same index refers to the same tool call.
-func genAIToolCallAttributes(toolCalls []request.ToolCall) []attribute.KeyValue {
-	if len(toolCalls) == 0 {
+// getSpanToolCalls extracts tool calls from a GenAI span regardless of vendor.
+func getSpanToolCalls(span *request.Span) []request.ToolCall {
+	if span.GenAI == nil {
 		return nil
 	}
+	switch {
+	case span.GenAI.OpenAI != nil:
+		return span.GenAI.OpenAI.ToolCalls
+	case span.GenAI.Anthropic != nil:
+		return span.GenAI.Anthropic.ToolCalls
+	case span.GenAI.Gemini != nil:
+		return span.GenAI.Gemini.ToolCalls
+	case span.GenAI.Qwen != nil:
+		return span.GenAI.Qwen.ToolCalls
+	default:
+		return nil
+	}
+}
 
-	var names []string
-	var ids []string
-	hasIDs := false
+// createToolCallSpans creates individual execute_tool child spans for each tool call,
+// following the OTel GenAI semantic conventions where gen_ai.tool.name is a single string
+// per span rather than an aggregated string array.
+func createToolCallSpans(toolCalls []request.ToolCall, parentSpanID pcommon.SpanID, traceID pcommon.TraceID, ss *ptrace.ScopeSpans, start, end time.Time) {
 	for _, tc := range toolCalls {
 		if tc.Name == "" {
 			continue
 		}
-		names = append(names, tc.Name)
-		ids = append(ids, tc.ID)
+		sp := ss.Spans().AppendEmpty()
+		sp.SetName("execute_tool " + tc.Name)
+		sp.SetKind(ptrace.SpanKindInternal)
+		sp.SetTraceID(traceID)
+		sp.SetSpanID(pcommon.SpanID(idgen.RandomSpanID()))
+		sp.SetParentSpanID(parentSpanID)
+		sp.SetStartTimestamp(pcommon.NewTimestampFromTime(start))
+		sp.SetEndTimestamp(pcommon.NewTimestampFromTime(end))
+
+		attrs := sp.Attributes()
+		attrs.PutStr(string(semconv.GenAIOperationNameKey), "execute_tool")
+		attrs.PutStr(string(attr.GenAIToolName), tc.Name)
 		if tc.ID != "" {
-			hasIDs = true
+			attrs.PutStr(string(attr.GenAIToolCallID), tc.ID)
 		}
 	}
-
-	var attrs []attribute.KeyValue
-	if len(names) > 0 {
-		attrs = append(attrs, attribute.StringSlice(string(attr.GenAIToolName), names))
-	}
-	if hasIDs {
-		attrs = append(attrs, attribute.StringSlice(string(attr.GenAIToolCallID), ids))
-	}
-	return attrs
 }
 
 // mcpAttributes returns MCP span attributes following the OTEL MCP semantic conventions.
@@ -756,9 +774,8 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 					attrs = append(attrs, semconv.GenAIRequestEncodingFormats(ai.Request.EncodingFormat))
 				}
 			}
-			attrs = append(attrs, genAIToolCallAttributes(ai.ToolCalls)...)
 		}
-
+		
 		if span.SubType == request.HTTPSubtypeAnthropic && span.GenAI != nil && span.GenAI.Anthropic != nil {
 			ai := span.GenAI.Anthropic
 			attrs = append(attrs, semconv.GenAIProviderNameAnthropic)
@@ -827,9 +844,8 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			if ai.Output.Error != nil && ai.Output.Error.Type != "" {
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Output.Error.Type))
 			}
-			attrs = append(attrs, genAIToolCallAttributes(ai.ToolCalls)...)
 		}
-
+		
 		if span.SubType == request.HTTPSubtypeGemini && span.GenAI != nil && span.GenAI.Gemini != nil {
 			ai := span.GenAI.Gemini
 			attrs = append(attrs, semconv.GenAIProviderNameGCPGemini)
@@ -905,9 +921,8 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			if ai.Output.Error != nil && ai.Output.Error.Status != "" {
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Output.Error.Status))
 			}
-			attrs = append(attrs, genAIToolCallAttributes(ai.ToolCalls)...)
 		}
-
+		
 		if span.SubType == request.HTTPSubtypeQwen && span.GenAI != nil && span.GenAI.Qwen != nil {
 			ai := span.GenAI.Qwen
 			attrs = append(attrs, semconv.GenAIProviderNameKey.String(attr.QwenProviderName))
@@ -990,9 +1005,8 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			if ai.Error.Type != "" {
 				attrs = append(attrs, semconv.ErrorTypeKey.String(ai.Error.Type))
 			}
-			attrs = append(attrs, genAIToolCallAttributes(ai.ToolCalls)...)
 		}
-
+		
 		if span.SubType == request.HTTPSubtypeAWSBedrock && span.GenAI != nil && span.GenAI.Bedrock != nil {
 			ai := span.GenAI.Bedrock
 			attrs = append(attrs, semconv.GenAIProviderNameAWSBedrock)

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -5,11 +5,13 @@ package tracesgen
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
@@ -264,50 +266,100 @@ func TestHTTPServerSpanURLQuery(t *testing.T) {
 	})
 }
 
-func TestGenAIToolCallAttributes(t *testing.T) {
-	t.Run("nil tool calls", func(t *testing.T) {
-		assert.Nil(t, genAIToolCallAttributes(nil))
+func TestCreateToolCallSpans(t *testing.T) {
+	t.Run("nil tool calls creates no spans", func(t *testing.T) {
+		ss := ptrace.NewScopeSpans()
+		traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		parentSpanID := pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		now := time.Now()
+		createToolCallSpans(nil, parentSpanID, traceID, &ss, now, now)
+		assert.Equal(t, 0, ss.Spans().Len())
 	})
 
-	t.Run("empty tool calls", func(t *testing.T) {
-		assert.Nil(t, genAIToolCallAttributes([]request.ToolCall{}))
+	t.Run("empty tool calls creates no spans", func(t *testing.T) {
+		ss := ptrace.NewScopeSpans()
+		traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		parentSpanID := pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		now := time.Now()
+		createToolCallSpans([]request.ToolCall{}, parentSpanID, traceID, &ss, now, now)
+		assert.Equal(t, 0, ss.Spans().Len())
 	})
 
 	t.Run("single tool call with ID", func(t *testing.T) {
-		attrs := genAIToolCallAttributes([]request.ToolCall{
+		ss := ptrace.NewScopeSpans()
+		traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		parentSpanID := pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		start := time.Now()
+		end := start.Add(100 * time.Millisecond)
+		createToolCallSpans([]request.ToolCall{
 			{ID: "call_1", Name: "get_weather"},
-		})
-		require.Len(t, attrs, 2)
-		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolName), []string{"get_weather"}), attrs[0])
-		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolCallID), []string{"call_1"}), attrs[1])
+		}, parentSpanID, traceID, &ss, start, end)
+
+		require.Equal(t, 1, ss.Spans().Len())
+		sp := ss.Spans().At(0)
+		assert.Equal(t, "execute_tool get_weather", sp.Name())
+		assert.Equal(t, ptrace.SpanKindInternal, sp.Kind())
+		assert.Equal(t, traceID, sp.TraceID())
+		assert.Equal(t, parentSpanID, sp.ParentSpanID())
+		assert.Equal(t, pcommon.NewTimestampFromTime(start), sp.StartTimestamp())
+		assert.Equal(t, pcommon.NewTimestampFromTime(end), sp.EndTimestamp())
+
+		attrs := sp.Attributes()
+		opName, ok := attrs.Get("gen_ai.operation.name")
+		require.True(t, ok)
+		assert.Equal(t, "execute_tool", opName.Str())
+
+		toolName, ok := attrs.Get("gen_ai.tool.name")
+		require.True(t, ok)
+		assert.Equal(t, "get_weather", toolName.Str())
+
+		toolCallID, ok := attrs.Get("gen_ai.tool.call.id")
+		require.True(t, ok)
+		assert.Equal(t, "call_1", toolCallID.Str())
 	})
 
-	t.Run("multiple tool calls with IDs", func(t *testing.T) {
-		attrs := genAIToolCallAttributes([]request.ToolCall{
+	t.Run("multiple tool calls", func(t *testing.T) {
+		ss := ptrace.NewScopeSpans()
+		traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		parentSpanID := pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		start := time.Now()
+		end := start.Add(100 * time.Millisecond)
+		createToolCallSpans([]request.ToolCall{
 			{ID: "call_1", Name: "get_weather"},
 			{ID: "call_2", Name: "get_time"},
-		})
-		require.Len(t, attrs, 2)
-		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolName), []string{"get_weather", "get_time"}), attrs[0])
-		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolCallID), []string{"call_1", "call_2"}), attrs[1])
-	})
+		}, parentSpanID, traceID, &ss, start, end)
 
-	t.Run("tool calls without IDs", func(t *testing.T) {
-		attrs := genAIToolCallAttributes([]request.ToolCall{
-			{Name: "get_weather"},
-			{Name: "get_time"},
-		})
-		require.Len(t, attrs, 1)
-		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolName), []string{"get_weather", "get_time"}), attrs[0])
+		require.Equal(t, 2, ss.Spans().Len())
+		assert.Equal(t, "execute_tool get_weather", ss.Spans().At(0).Name())
+		assert.Equal(t, "execute_tool get_time", ss.Spans().At(1).Name())
 	})
 
 	t.Run("skips empty names", func(t *testing.T) {
-		attrs := genAIToolCallAttributes([]request.ToolCall{
+		ss := ptrace.NewScopeSpans()
+		traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		parentSpanID := pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		now := time.Now()
+		createToolCallSpans([]request.ToolCall{
 			{ID: "call_1", Name: ""},
 			{ID: "call_2", Name: "get_time"},
-		})
-		require.Len(t, attrs, 2)
-		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolName), []string{"get_time"}), attrs[0])
-		assert.Equal(t, attribute.StringSlice(string(attr.GenAIToolCallID), []string{"call_2"}), attrs[1])
+		}, parentSpanID, traceID, &ss, now, now)
+
+		require.Equal(t, 1, ss.Spans().Len())
+		assert.Equal(t, "execute_tool get_time", ss.Spans().At(0).Name())
+	})
+
+	t.Run("tool call without ID omits gen_ai.tool.call.id", func(t *testing.T) {
+		ss := ptrace.NewScopeSpans()
+		traceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		parentSpanID := pcommon.SpanID([8]byte{1, 2, 3, 4, 5, 6, 7, 8})
+		now := time.Now()
+		createToolCallSpans([]request.ToolCall{
+			{Name: "get_weather"},
+		}, parentSpanID, traceID, &ss, now, now)
+
+		require.Equal(t, 1, ss.Spans().Len())
+		sp := ss.Spans().At(0)
+		_, ok := sp.Attributes().Get("gen_ai.tool.call.id")
+		assert.False(t, ok, "gen_ai.tool.call.id should not be present when ID is empty")
 	})
 }


### PR DESCRIPTION
## Summary

Align `gen_ai.tool.name` attribute with OTel GenAI semantic conventions.

## Problem

The OTel semconv defines `gen_ai.tool.name` as type `string` (used on individual `execute_tool` spans), but OBI was aggregating all tool call names into a `string[]` attribute on the parent inference span. This was flagged as a schema validation violation in PR #2583.

## Solution

- Remove the aggregated `string[]` approach (`genAIToolCallAttributes`)
- Create individual `execute_tool` INTERNAL child spans per tool call
- Each child span carries:
  - `gen_ai.operation.name`: `execute_tool`
  - `gen_ai.tool.name`: tool name (single string)
  - `gen_ai.tool.call.id`: tool call ID (when available)
- Child spans inherit the parent's trace ID and use the parent span as their parent
- Timing: child spans share the parent span's start/end timestamps (eBPF cannot determine per-tool-call timing)

## Changes

- `pkg/export/otel/tracesgen/tracesgen.go`:
  - Remove `genAIToolCallAttributes()` function and its 4 call sites (OpenAI, Anthropic, Gemini, Qwen)
  - Add `createToolCallSpans()` to generate individual INTERNAL child spans
  - Add `getSpanToolCalls()` helper to extract tool calls from any vendor
  - Call `createToolCallSpans` in `generateTracesWithAttributes` loop
- `pkg/export/otel/tracesgen/tracesgen_test.go`:
  - Remove `TestGenAIToolCallAttributes`
  - Add `TestCreateToolCallSpans` covering nil/empty/single/multiple/skip-empty-names/no-ID cases

## Testing

- All unit tests pass locally
- CI on fork repo passed (Lint, Unit tests, etc.)

## Related

- Resolves schema validation violation found in #2583
- Reference: [OTel GenAI semconv registry](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/registry.yaml) defines `gen_ai.tool.name` as `type: string`
