### PR TITLE
Limit sock_iter to only add active socket connections

### DIFF
--- a/bpf/tpinjector/maps/iter_listening_ports.h
+++ b/bpf/tpinjector/maps/iter_listening_ports.h
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/map_sizing.h>
+#include <common/sock_port_ns.h>
+
+// A duplicate map for listening ports, to ensure the tcp_iter and sock_iter
+// can operate independently.
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, struct sock_port_ns);
+    __type(value, bool);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+} iter_listening_ports SEC(".maps");

--- a/bpf/tpinjector/sock_iter.c
+++ b/bpf/tpinjector/sock_iter.c
@@ -7,10 +7,13 @@
 #include <bpfcore/bpf_endian.h>
 
 #include <common/protocol_defs.h>
+#include <common/sock_port_ns.h>
 
 #include <logger/bpf_dbg.h>
 
 #include <maps/sock_dir.h>
+
+#include <tpinjector/maps/iter_listening_ports.h>
 
 char __license[] SEC("license") = "Dual MIT/GPL";
 
@@ -82,11 +85,49 @@ static __always_inline void format_sock_addrs(struct sock_common *skc,
     }
 }
 
+// First pass, we record every local listening port into iter_listening_ports.
+SEC("iter/tcp")
+int obi_sk_iter_tcp_listen(struct bpf_iter__tcp *ctx) {
+    struct sock_common *skc = ctx->sk_common;
+
+    if (!skc) {
+        return 0;
+    }
+
+    u8 skc_state = BPF_CORE_READ(skc, skc_state);
+
+    if (skc_state != TCP_LISTEN) {
+        return 0;
+    }
+
+    struct sock_port_ns pn = sock_port_ns_from_skc(skc);
+    bpf_map_update_elem(&iter_listening_ports, &pn, &(bool){true}, BPF_ANY);
+
+    struct seq_file *seq = ctx->meta->seq;
+    BPF_SEQ_PRINTF(seq, "Listening port=%u netns=%u\n", pn.port, pn.netns);
+
+    return 0;
+}
+
+// Second pass, track only active client connections in sock_dir.
 SEC("iter/tcp")
 int obi_sk_iter_tcp(struct bpf_iter__tcp *ctx) {
     struct sock_common *skc = ctx->sk_common;
 
     if (!skc) {
+        return 0;
+    }
+
+    // don't look at sockets that aren't established
+    u8 skc_state = BPF_CORE_READ(skc, skc_state);
+    if (skc_state != TCP_ESTABLISHED) {
+        return 0;
+    }
+
+    // skip passive sockets, their local port is a listening port we
+    // found in the prior pass
+    struct sock_port_ns pn = sock_port_ns_from_skc(skc);
+    if (bpf_map_lookup_elem(&iter_listening_ports, &pn) != 0) {
         return 0;
     }
 

--- a/bpf/tpinjector/sock_iter.c
+++ b/bpf/tpinjector/sock_iter.c
@@ -142,8 +142,6 @@ int obi_sk_iter_tcp(struct bpf_iter__tcp *ctx) {
 
     BPF_SEQ_PRINTF(seq, "Tracking socket cookie=%llu src=%s dst=%s\n", cookie, src_buf, dst_buf);
 
-    bpf_d_printk("Tracking socket cookie=%llu src=%s dst=%s", cookie, src_buf, dst_buf);
-
     if (bpf_map_update_elem(&sock_dir, &cookie, skc, BPF_NOEXIST) != 0) {
         bpf_dbg_printk("Failed to track sock cookie=%llu", cookie);
     }

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -537,22 +537,16 @@ int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
     return 1;
 }
 
-// Pass-through ingress verdict for the sock_dir sockhash.
-//
 // We only use the sockhash for the egress sk_msg injection path and never
 // inspect ingress traffic. However, kernels with commit 929e30f93125 report
-// FIONREAD=0 for a socket that lives in a sockhash but has no verdict program
-// attached: the ioctl consults the sk_psock ingress queue, which is only wired
-// up when a verdict program exists. Applications that poll FIONREAD before
+// FIONREAD=0 for a socket that lives in a sockhash. but has no verdict program
+// attached. Applications that poll FIONREAD before
 // read() then see zero bytes and stop reading.
 //
-// Attaching this no-op verdict makes the kernel route ingress through the
-// psock ingress path so FIONREAD accounts for the pending bytes. SK_PASS
-// delivers the data to the socket unchanged, so the receive side behaves as if
-// the socket were never in the map.
+// Attaching this no-op verdict works around the kernel bug until it's fixed.
 SEC("sk_skb/verdict")
 int obi_sk_skb_verdict(struct __sk_buff *skb) {
-    bpf_dbg_printk("=== sk_skb verdict === len=%u", skb->len);
+    (void)skb;
     return SK_PASS;
 }
 

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -537,6 +537,25 @@ int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
     return 1;
 }
 
+// Pass-through ingress verdict for the sock_dir sockhash.
+//
+// We only use the sockhash for the egress sk_msg injection path and never
+// inspect ingress traffic. However, kernels with commit 929e30f93125 report
+// FIONREAD=0 for a socket that lives in a sockhash but has no verdict program
+// attached: the ioctl consults the sk_psock ingress queue, which is only wired
+// up when a verdict program exists. Applications that poll FIONREAD before
+// read() then see zero bytes and stop reading.
+//
+// Attaching this no-op verdict makes the kernel route ingress through the
+// psock ingress path so FIONREAD accounts for the pending bytes. SK_PASS
+// delivers the data to the socket unchanged, so the receive side behaves as if
+// the socket were never in the map.
+SEC("sk_skb/verdict")
+int obi_sk_skb_verdict(struct __sk_buff *skb) {
+    bpf_dbg_printk("=== sk_skb verdict === len=%u", skb->len);
+    return SK_PASS;
+}
+
 // This code is copied from the kprobe on tcp_sendmsg and it's called from
 // the sock_msg program, which does the packet extension for injecting the
 // Traceparent. Since the sock_msg runs before the kprobe on tcp_sendmsg, we

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -537,19 +537,6 @@ int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
     return 1;
 }
 
-// We only use the sockhash for the egress sk_msg injection path and never
-// inspect ingress traffic. However, kernels with commit 929e30f93125 report
-// FIONREAD=0 for a socket that lives in a sockhash. but has no verdict program
-// attached. Applications that poll FIONREAD before
-// read() then see zero bytes and stop reading.
-//
-// Attaching this no-op verdict works around the kernel bug until it's fixed.
-SEC("sk_skb/verdict")
-int obi_sk_skb_verdict(struct __sk_buff *skb) {
-    (void)skb;
-    return SK_PASS;
-}
-
 // This code is copied from the kprobe on tcp_sendmsg and it's called from
 // the sock_msg program, which does the packet extension for injecting the
 // Traceparent. Since the sock_msg runs before the kprobe on tcp_sendmsg, we

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -147,6 +147,11 @@ func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg {
 			MapFD:    p.bpfObjects.SockDir.FD(),
 			AttachAs: ebpf.AttachSkMsgVerdict,
 		},
+		{
+			Program:  p.bpfObjects.ObiSkSkbVerdict,
+			MapFD:    p.bpfObjects.SockDir.FD(),
+			AttachAs: ebpf.AttachSkSKBVerdict,
+		},
 	}
 }
 

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -147,11 +147,11 @@ func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg {
 			MapFD:    p.bpfObjects.SockDir.FD(),
 			AttachAs: ebpf.AttachSkMsgVerdict,
 		},
-		{
-			Program:  p.bpfObjects.ObiSkSkbVerdict,
-			MapFD:    p.bpfObjects.SockDir.FD(),
-			AttachAs: ebpf.AttachSkSKBVerdict,
-		},
+		// {
+		// 	Program:  p.bpfObjects.ObiSkSkbVerdict,
+		// 	MapFD:    p.bpfObjects.SockDir.FD(),
+		// 	AttachAs: ebpf.AttachSkSKBVerdict,
+		// },
 	}
 }
 

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -147,11 +147,6 @@ func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg {
 			MapFD:    p.bpfObjects.SockDir.FD(),
 			AttachAs: ebpf.AttachSkMsgVerdict,
 		},
-		// {
-		// 	Program:  p.bpfObjects.ObiSkSkbVerdict,
-		// 	MapFD:    p.bpfObjects.SockDir.FD(),
-		// 	AttachAs: ebpf.AttachSkSKBVerdict,
-		// },
 	}
 }
 

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -179,7 +179,13 @@ func (p *Tracer) Iters() []*ebpfcommon.Iter {
 		return p.iters
 	}
 
-	p.iters = []*ebpfcommon.Iter{{Program: p.bpfIterObjects.ObiSkIterTcp}}
+	// The ordering matters, we don't want to add passive listeners to
+	// the map, so we first find the listening ports and then we discard
+	// the established with those listening ports.
+	p.iters = []*ebpfcommon.Iter{
+		{Program: p.bpfIterObjects.ObiSkIterTcpListen},
+		{Program: p.bpfIterObjects.ObiSkIterTcp},
+	}
 
 	return p.iters
 }


### PR DESCRIPTION
## Summary

While investigating the issue fixed in https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2580, I noticed that part of the problem was that the socket iterator was adding all existing sockets to the sock hash map, including passive (server) sockets we currently don't handle.

This PR filters out the not established (listen) and server sockets before we add them to the sock hash map. The tpinjector.c code already filters on active only. The fix is needed on the socket iterator only.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
