### PR TITLE
netolly: fix RingBufTracer "queue is closed" panic on shutdown

### DIFF
--- a/pkg/internal/netolly/flow/tracer_ringbuf.go
+++ b/pkg/internal/netolly/flow/tracer_ringbuf.go
@@ -87,7 +87,7 @@ func (m *RingBufTracer) TraceLoop(out *msg.Queue[[]*ebpf.Record]) swarm.RunFunc 
 				rtlog.Debug("exiting trace loop due to context cancellation")
 				return
 			default:
-				if err := m.listenAndForwardRingBuffer(debugging, out); err != nil {
+				if err := m.listenAndForwardRingBuffer(ctx, debugging, out); err != nil {
 					if errors.Is(err, ringbuf.ErrClosed) {
 						rtlog.Debug("Received signal, exiting..")
 						return
@@ -100,7 +100,7 @@ func (m *RingBufTracer) TraceLoop(out *msg.Queue[[]*ebpf.Record]) swarm.RunFunc 
 	}
 }
 
-func (m *RingBufTracer) listenAndForwardRingBuffer(debugging bool, forwardCh *msg.Queue[[]*ebpf.Record]) error {
+func (m *RingBufTracer) listenAndForwardRingBuffer(ctx context.Context, debugging bool, forwardCh *msg.Queue[[]*ebpf.Record]) error {
 	event, err := m.ringBuffer.ReadRingBuf()
 	if err != nil {
 		return fmt.Errorf("reading from ring buffer: %w", err)
@@ -120,7 +120,7 @@ func (m *RingBufTracer) listenAndForwardRingBuffer(debugging bool, forwardCh *ms
 		m.mapFlusher.Flush()
 	}
 
-	forwardCh.Send([]*ebpf.Record{ebpf.NewRecord(readFlow.Id, readFlow.Metrics)})
+	forwardCh.SendCtx(ctx, []*ebpf.Record{ebpf.NewRecord(readFlow.Id, readFlow.Metrics)})
 
 	return nil
 }

--- a/pkg/netolly/agent/pipeline.go
+++ b/pkg/netolly/agent/pipeline.go
@@ -51,8 +51,10 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 	}
 
 	swi := &swarm.Instancer{}
-	// Start nodes: those generating flow records (reading them from eBPF)
-	ebpfFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "ebpfFlows")
+	// Start nodes: those generating flow records (reading them from eBPF).
+	// ebpfFlows has two senders (MapTracer and RingBufTracer), so it must only be
+	// closed after both of them have marked it closeable, hence ClosingAttempts(2).
+	ebpfFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "ebpfFlows", msg.ClosingAttempts(2))
 	swi.Add(swarm.DirectInstance(newMapTracer(f, ebpfFlows)), swarm.WithID("MapTracer"))
 	swi.Add(swarm.DirectInstance(newRingBufTracer(f, ebpfFlows)), swarm.WithID("RingBufTracer"))
 


### PR DESCRIPTION
## Summary

The netolly flow pipeline creates a single `ebpfFlows` queue that has **two senders**: `MapTracer` and `RingBufTracer`. Both mark the queue closeable on shutdown, but the queue was created with the default `ClosingAttempts` of `1`. On context cancellation, `MapTracer` could close the queue first, so a subsequent `Send()` from `RingBufTracer` would panic with `queue is closed`.

This PR applies two fixes:

1. **`pkg/netolly/agent/pipeline.go`** — create the `ebpfFlows` queue with `msg.ClosingAttempts(2)`, so the queue is only closed after *both* senders have marked it closeable.
2. **`pkg/internal/netolly/flow/tracer_ringbuf.go`** — replace the deprecated `Send(...)` with `SendCtx(ctx, ...)` (with `ctx` threaded through the function signature), so in-flight sends are dropped once the context is cancelled, mirroring `MapTracer.evictFlows`.

Fixes #2606

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
