### PR TITLE
fix(ebpf): share puma correlation maps across BPF collections

### DIFF
--- a/bpf/maps/puma_tasks.h
+++ b/bpf/maps/puma_tasks.h
@@ -8,6 +8,7 @@
 
 #include <common/connection_info.h>
 #include <common/map_sizing.h>
+#include <common/pin_internal.h>
 #include <common/puma_task_id.h>
 
 struct {
@@ -15,6 +16,7 @@ struct {
     __type(key, puma_task_id_t); // the array and item pair
     __type(value, connection_info_part_t);
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } puma_task_connections SEC(".maps");
 
 struct {
@@ -22,4 +24,5 @@ struct {
     __type(key, u64);              // the pid:tgid
     __type(value, puma_task_id_t); // the array and item pair
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
 } puma_worker_tasks SEC(".maps");


### PR DESCRIPTION
## Summary

Fixes #2582.

The Puma/Ruby trace-correlation support from #968 stores its correlation entries in `puma_task_connections` and `puma_worker_tasks` (`bpf/maps/puma_tasks.h`), but both maps were declared without `__uint(pinning, OBI_PIN_INTERNAL)`. Maps are only shared across BPF collections when they are `PinInternal` (`ResolveMaps()` in `pkg/internal/ebpf/convenience/convenience.go` routes them through `MapReplacements`), so:

- the **writers** (ruby uprobes `obi_rb_obj_call_init_kw` / `obi_rb_ary_shift`, in a per-executable generictracer instance) populate one map instance, while
- the **reader** (`find_puma_parent_trace()` via `common/trace_parent.h`, reached from the tpinjector sk_msg path with `context_propagation: all`, and from other generictracer instances) looks up a different, empty instance.

The lookup therefore misses 100% of the time and a fresh trace id is minted for every outgoing request from Puma — exactly the scenario #968 was written to fix. All other maps consumed by the `find_parent_trace` chain already follow the pinning convention (`server_traces`, `server_traces_aux`, `java_vt_threads`); the two puma maps appear to be an omission.

This PR pins both maps internally (2 lines + include). Generated BPF bindings are gitignored in this repo, so the diff is the 3-line header change only; verified locally with `make docker-generate` (idempotent on second run) and `clang-format --dry-run --Werror`.

## Validation

Reproduction from #2582 (Rails 7.2 / Puma 6.6, `workers 2` / `threads 5` / `queue_requests true`, single keep-alive client connection, distinct recognizable traceparent per request, downstream Go service echoes the traceparent it received; `context_propagation: all`):

| | before | after (this patch) |
|---|---|---|
| idle-20s rounds (reactor reads, worker writes) | 0/10 | **10/10** |
| rapid keep-alive reuse (~0.2s apart) | 1/10 (first request on the fresh connection only) | **10/10** |
| `find_puma_parent_trace` debug | `task_id=0` on all lookups, `found item` ×0 | non-zero on every request, `found item` throughout |

The "before" failure signature that pinpoints the unshared maps — the same thread stores and then misses the same key 6 ms later:

```
03:30:28.569 "stored item to id correlation, id = 2a7700002a7e, item ffff8c1fcbd8" pid=10878 comm="puma srv tp 001"
03:30:28.575 "puma lookup: task_id=0 [find_puma_parent_trace]"                    pid=10878 comm="puma srv tp 001"
```

Note on test coverage: single-request-per-connection tests pass without the puma maps (fresh connection → worker reads directly → pinned `server_traces` legacy path), which is likely why this wasn't caught. A regression test needs a reused keep-alive connection so the reactor performs the read — happy to work on one as a follow-up if useful.

**AI disclosure** (per `AI-POLICY.md`): root-cause analysis, patch, and validation were AI-assisted (Claude Code); all changes and test results were personally reviewed and reproduced by the submitter.

## Validation checklist

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed (bugfix — no feature surface or support-matrix change)
