### PR TITLE
Add OBI nightly releases + sha based image tags on main

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -14,8 +14,7 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   # Derive the dated nightly version string (nightly-<YYYYMMDD>).

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,61 @@
+name: Nightly Release
+
+# Publishes nightly multi-arch images for both the OBI and k8s-cache components,
+# modelled on the OpenTelemetry Collector nightly release
+# (https://github.com/open-telemetry/opentelemetry-collector-releases/blob/main/.github/workflows/nightly-release.yaml).
+#
+# Tag scheme agreed in the SIG (issue #2553):
+#   - Versioned (immutable):  nightly-<YYYYMMDD>  e.g. nightly-20260708
+#   - Ephemeral (mutable):    nightly             (always points at the latest nightly)
+
+on:
+  schedule:
+    # Every day at 02:00 UTC.
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Derive the dated nightly version string (nightly-<YYYYMMDD>).
+  compute-version:
+    name: Compute nightly version
+    if: github.repository == 'open-telemetry/opentelemetry-ebpf-instrumentation'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Compute nightly version
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION="nightly-$(date -u +'%Y%m%d')"
+          echo "Nightly version: ${VERSION}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+  nightly-obi:
+    name: Publish nightly OBI image
+    needs: compute-version
+    uses: ./.github/workflows/publish_dockerhub_main.yml
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    with:
+      nightly_version: ${{ needs.compute-version.outputs.version }}
+    secrets:
+      DOCKER_TOKEN_EBPF_INSTRUMENTATION: ${{ secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION }}
+
+  nightly-k8s-cache:
+    name: Publish nightly k8s-cache image
+    needs: compute-version
+    uses: ./.github/workflows/publish_dockerhub_k8s_cache_main.yml
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    with:
+      nightly_version: ${{ needs.compute-version.outputs.version }}
+    secrets:
+      DOCKER_TOKEN_EBPF_INSTRUMENTATION: ${{ secrets.DOCKER_TOKEN_EBPF_INSTRUMENTATION }}

--- a/.github/workflows/publish_dockerhub_k8s_cache_main.yml
+++ b/.github/workflows/publish_dockerhub_k8s_cache_main.yml
@@ -83,13 +83,13 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=semver,pattern=v{{version}},value=${{ inputs.ref }}
+            type=semver,pattern=v{{version}},value=${{ inputs.ref }},enable=${{ inputs.ref != '' }}
             type=raw,value=latest,enable=${{ inputs.latest == true }}
             type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
-            type=ref,event=branch
+            type=ref,event=branch,enable=${{ inputs.nightly_version == '' }}
             type=ref,event=tag
-            type=sha,prefix=,format=short
+            type=sha,prefix=,format=short,enable=${{ inputs.nightly_version == '' && inputs.ref == '' }}
 
       - name: Build and push by digest
         id: build
@@ -165,13 +165,13 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=semver,pattern=v{{version}},value=${{ inputs.ref }}
+            type=semver,pattern=v{{version}},value=${{ inputs.ref }},enable=${{ inputs.ref != '' }}
             type=raw,value=latest,enable=${{ inputs.latest == true }}
             type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
-            type=ref,event=branch
+            type=ref,event=branch,enable=${{ inputs.nightly_version == '' }}
             type=ref,event=tag
-            type=sha,prefix=,format=short
+            type=sha,prefix=,format=short,enable=${{ inputs.nightly_version == '' && inputs.ref == '' }}
 
       - name: Create manifest list and push
         env:

--- a/.github/workflows/publish_dockerhub_k8s_cache_main.yml
+++ b/.github/workflows/publish_dockerhub_k8s_cache_main.yml
@@ -88,7 +88,7 @@ jobs:
             type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch,enable=${{ inputs.nightly_version == '' }}
-            type=ref,event=tag
+            type=ref,event=tag,enable=${{ inputs.nightly_version == '' }}
             type=sha,prefix=,format=short,enable=${{ inputs.nightly_version == '' && inputs.ref == '' }}
 
       - name: Build and push by digest
@@ -170,7 +170,7 @@ jobs:
             type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch,enable=${{ inputs.nightly_version == '' }}
-            type=ref,event=tag
+            type=ref,event=tag,enable=${{ inputs.nightly_version == '' }}
             type=sha,prefix=,format=short,enable=${{ inputs.nightly_version == '' && inputs.ref == '' }}
 
       - name: Create manifest list and push

--- a/.github/workflows/publish_dockerhub_k8s_cache_main.yml
+++ b/.github/workflows/publish_dockerhub_k8s_cache_main.yml
@@ -15,6 +15,11 @@ on:
         required: false
         type: boolean
         default: false
+      nightly_version:
+        description: "When set, publish nightly tags '<nightly_version>' and 'nightly' instead of release tags (e.g. 0.11.0-nightly.abc1234)"
+        required: false
+        type: string
+        default: ""
     secrets:
       DOCKER_TOKEN_EBPF_INSTRUMENTATION:
         description: "Docker Hub access token for otel"
@@ -80,6 +85,8 @@ jobs:
           tags: |
             type=semver,pattern=v{{version}},value=${{ inputs.ref }}
             type=raw,value=latest,enable=${{ inputs.latest == true }}
+            type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
+            type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch
             type=ref,event=tag
 
@@ -159,6 +166,8 @@ jobs:
           tags: |
             type=semver,pattern=v{{version}},value=${{ inputs.ref }}
             type=raw,value=latest,enable=${{ inputs.latest == true }}
+            type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
+            type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch
             type=ref,event=tag
 

--- a/.github/workflows/publish_dockerhub_k8s_cache_main.yml
+++ b/.github/workflows/publish_dockerhub_k8s_cache_main.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
         default: false
       nightly_version:
-        description: "When set, publish nightly tags '<nightly_version>' and 'nightly' instead of release tags (e.g. 0.11.0-nightly.abc1234)"
+        description: "When set, publish nightly tags '<nightly_version>' and 'nightly' instead of release tags (e.g. nightly-20260708)"
         required: false
         type: string
         default: ""
@@ -89,6 +89,7 @@ jobs:
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch
             type=ref,event=tag
+            type=sha,prefix=,format=short
 
       - name: Build and push by digest
         id: build
@@ -170,6 +171,7 @@ jobs:
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch
             type=ref,event=tag
+            type=sha,prefix=,format=short
 
       - name: Create manifest list and push
         env:

--- a/.github/workflows/publish_dockerhub_main.yml
+++ b/.github/workflows/publish_dockerhub_main.yml
@@ -83,13 +83,13 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=semver,pattern=v{{version}},value=${{ inputs.ref }}
+            type=semver,pattern=v{{version}},value=${{ inputs.ref }},enable=${{ inputs.ref != '' }}
             type=raw,value=latest,enable=${{ inputs.latest == true }}
             type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
-            type=ref,event=branch
+            type=ref,event=branch,enable=${{ inputs.nightly_version == '' }}
             type=ref,event=tag
-            type=sha,prefix=,format=short
+            type=sha,prefix=,format=short,enable=${{ inputs.nightly_version == '' && inputs.ref == '' }}
 
       - name: Build and push by digest
         id: build
@@ -165,13 +165,13 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=semver,pattern=v{{version}},value=${{ inputs.ref }}
+            type=semver,pattern=v{{version}},value=${{ inputs.ref }},enable=${{ inputs.ref != '' }}
             type=raw,value=latest,enable=${{ inputs.latest == true }}
             type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
-            type=ref,event=branch
+            type=ref,event=branch,enable=${{ inputs.nightly_version == '' }}
             type=ref,event=tag
-            type=sha,prefix=,format=short
+            type=sha,prefix=,format=short,enable=${{ inputs.nightly_version == '' && inputs.ref == '' }}
 
       - name: Create manifest list and push
         env:

--- a/.github/workflows/publish_dockerhub_main.yml
+++ b/.github/workflows/publish_dockerhub_main.yml
@@ -88,7 +88,7 @@ jobs:
             type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch,enable=${{ inputs.nightly_version == '' }}
-            type=ref,event=tag
+            type=ref,event=tag,enable=${{ inputs.nightly_version == '' }}
             type=sha,prefix=,format=short,enable=${{ inputs.nightly_version == '' && inputs.ref == '' }}
 
       - name: Build and push by digest
@@ -170,7 +170,7 @@ jobs:
             type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch,enable=${{ inputs.nightly_version == '' }}
-            type=ref,event=tag
+            type=ref,event=tag,enable=${{ inputs.nightly_version == '' }}
             type=sha,prefix=,format=short,enable=${{ inputs.nightly_version == '' && inputs.ref == '' }}
 
       - name: Create manifest list and push

--- a/.github/workflows/publish_dockerhub_main.yml
+++ b/.github/workflows/publish_dockerhub_main.yml
@@ -15,6 +15,11 @@ on:
         required: false
         type: boolean
         default: false
+      nightly_version:
+        description: "When set, publish nightly tags '<nightly_version>' and 'nightly' instead of release tags (e.g. 0.11.0-nightly.abc1234)"
+        required: false
+        type: string
+        default: ""
     secrets:
       DOCKER_TOKEN_EBPF_INSTRUMENTATION:
         description: "Docker Hub access token for otel"
@@ -80,6 +85,8 @@ jobs:
           tags: |
             type=semver,pattern=v{{version}},value=${{ inputs.ref }}
             type=raw,value=latest,enable=${{ inputs.latest == true }}
+            type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
+            type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch
             type=ref,event=tag
 
@@ -159,6 +166,8 @@ jobs:
           tags: |
             type=semver,pattern=v{{version}},value=${{ inputs.ref }}
             type=raw,value=latest,enable=${{ inputs.latest == true }}
+            type=raw,value=${{ inputs.nightly_version }},enable=${{ inputs.nightly_version != '' }}
+            type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch
             type=ref,event=tag
 

--- a/.github/workflows/publish_dockerhub_main.yml
+++ b/.github/workflows/publish_dockerhub_main.yml
@@ -16,7 +16,7 @@ on:
         type: boolean
         default: false
       nightly_version:
-        description: "When set, publish nightly tags '<nightly_version>' and 'nightly' instead of release tags (e.g. 0.11.0-nightly.abc1234)"
+        description: "When set, publish nightly tags '<nightly_version>' and 'nightly' instead of release tags (e.g. nightly-20260708)"
         required: false
         type: string
         default: ""
@@ -89,6 +89,7 @@ jobs:
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch
             type=ref,event=tag
+            type=sha,prefix=,format=short
 
       - name: Build and push by digest
         id: build
@@ -170,6 +171,7 @@ jobs:
             type=raw,value=nightly,enable=${{ inputs.nightly_version != '' }}
             type=ref,event=branch
             type=ref,event=tag
+            type=sha,prefix=,format=short
 
       - name: Create manifest list and push
         env:


### PR DESCRIPTION
## Summary

Resolves #2553 

## Changes
- created a new `Nightly Release` pipeline which runs at `"0 2 * * *"` (every day at 2AM UTC) and publishes 2 tags, daily `nightly-<YYYYMMDD>` and a mutable `nightly`
- added a `type=sha,prefix=,format=short` tag to the metadata step, which on every master push will release an exact `ebpf-instrument:aaaaaaa` style image tag (short commit sha)

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
