### PR TITLE
Simplify hostname resolver

### DIFF
--- a/pkg/internal/traces/hostname/hostname.go
+++ b/pkg/internal/traces/hostname/hostname.go
@@ -79,11 +79,9 @@ type fallbackResolver struct {
 
 // Query returns the full and the short host name, or error if none of both can't be returned.
 // This implementation assumes the full host name may fail since it can depend on an external
-// service (e.g. a DNS server). If the full name resolution fails, it considers the following
-// fallback actions (in priority):
-// 1 - return the previous successful full name resolution
-// 2 - ask for the full hostname to the OS (and consider the returned value as successful)
-// 3 - The short host name if it has never been successfully resolved.
+// Query returns the full hostname, or an error if no hostname can be resolved.
+// If full hostname resolution fails or returns a localhost name, it falls back
+// to the internal hostname and then the short hostname.
 func (r *fallbackResolver) Query() (string, error) {
 	if r.overriddenFull != "" {
 		return r.overriddenFull, nil

--- a/pkg/internal/traces/hostname/hostname.go
+++ b/pkg/internal/traces/hostname/hostname.go
@@ -111,7 +111,10 @@ func (r *fallbackResolver) Query() (string, error) {
 			}
 		}
 	}
-	return full, nil
+if full == "" {
+	return "", errors.New("can't resolve either full or short hostname")
+}
+return full, nil
 }
 
 func isLocalhost(name string) bool {

--- a/pkg/internal/traces/hostname/hostname.go
+++ b/pkg/internal/traces/hostname/hostname.go
@@ -7,11 +7,8 @@ package hostname // import "go.opentelemetry.io/obi/pkg/internal/traces/hostname
 
 import (
 	"errors"
-	"fmt"
 	"log/slog"
-	"maps"
 	"os"
-	"sync"
 )
 
 var fullHostnameResolver = getFqdnHostname
@@ -20,40 +17,10 @@ func logger() *slog.Logger {
 	return slog.With("component", "HostnameResolver")
 }
 
-// Resolver provides full and short name resolving functionalities
+// Resolver provides full name resolving functionalities
 type Resolver interface {
-	// Query returns the full and the short hostname, or error if the process has not been completed
-	Query() (full, short string, err error)
-	Long() string
-}
-
-// ChangeType represents the type of hostname change
-type ChangeType int
-
-const (
-	// Short is the short hostname
-	Short ChangeType = iota
-	// Full is the FDQN hostname
-	Full
-	// ShortAndFull both were changed
-	ShortAndFull
-)
-
-// ChangeNotification is the struct being sent through the notification channel
-type ChangeNotification struct {
-	What ChangeType
-}
-
-// ChangeNotifier allows observer to register a channel to be notified of when the hostname is updated
-type ChangeNotifier interface {
-	AddObserver(name string, ch chan<- ChangeNotification)
-	RemoveObserver(name string)
-}
-
-// ResolverChangeNotifier is a sum of both Resolver and ChangeNotifier interfaces
-type ResolverChangeNotifier interface {
-	Resolver
-	ChangeNotifier
+	// Query returns the full hostname, or error if the process has not been completed
+	Query() (string, error)
 }
 
 // CreateResolver creates a HostnameResolver.
@@ -65,7 +32,7 @@ type ResolverChangeNotifier interface {
 // If the full hostname resolution process fails (e.g. due to a temporary DNS failure), it
 // returns the previous successful resolution (or the short hostname if it has never worked
 // previously).
-func CreateResolver(overrideFull, overrideShort string, dnsResolution bool) ResolverChangeNotifier {
+func CreateResolver(overrideFull, overrideShort string, dnsResolution bool) Resolver {
 	var resolver *fallbackResolver
 	if dnsResolution {
 		resolver = newDNSResolver(overrideFull)
@@ -74,7 +41,6 @@ func CreateResolver(overrideFull, overrideShort string, dnsResolution bool) Reso
 	}
 
 	resolver.short = os.Hostname
-	resolver.observers = map[string]chan<- ChangeNotification{}
 
 	if overrideShort != "" {
 		resolver.short = func() (string, error) {
@@ -88,9 +54,9 @@ func CreateResolver(overrideFull, overrideShort string, dnsResolution bool) Reso
 
 func newDNSResolver(overrideFull string) *fallbackResolver {
 	return &fallbackResolver{
-		full:          fullHostnameResolver,
-		internal:      internalHostname,
-		overridenFull: overrideFull,
+		full:           fullHostnameResolver,
+		internal:       internalHostname,
+		overriddenFull: overrideFull,
 	}
 }
 
@@ -103,9 +69,9 @@ func newInternalResolver(overrideFull string) *fallbackResolver {
 		return "", errors.New("internal hostname resolution did not work")
 	}
 	return &fallbackResolver{
-		internal:      internalResolver,
-		full:          fullResolver,
-		overridenFull: overrideFull,
+		internal:       internalResolver,
+		full:           fullResolver,
+		overriddenFull: overrideFull,
 	}
 }
 
@@ -114,14 +80,10 @@ func newInternalResolver(overrideFull string) *fallbackResolver {
 // If the Full name resolution is "localhost" (known problem in some wrong FQDN configurations)
 // the "internal" name resolver is applied.
 type fallbackResolver struct {
-	sync.Mutex
-	lastShort     string
-	lastFull      string
-	overridenFull string
-	short         func() (string, error)
-	internal      func() (string, error)
-	full          func(string) (string, error)
-	observers     map[string]chan<- ChangeNotification
+	overriddenFull string
+	short          func() (string, error)
+	internal       func() (string, error)
+	full           func(string) (string, error)
 }
 
 // Query returns the full and the short host name, or error if none of both can't be returned.
@@ -131,34 +93,34 @@ type fallbackResolver struct {
 // 1 - return the previous successful full name resolution
 // 2 - ask for the full hostname to the OS (and consider the returned value as successful)
 // 3 - The short host name if it has never been successfully resolved.
-func (r *fallbackResolver) Query() (string, string, error) {
+func (r *fallbackResolver) Query() (string, error) {
+	if r.overriddenFull != "" {
+		return r.overriddenFull, nil
+	}
 	log := logger()
 	short, err := r.short()
-	var full string
-	if r.overridenFull != "" {
-		log.Debug("overriding full hostname", "value", r.overridenFull)
-		full = r.overridenFull
-	} else {
+	if err != nil {
+		log.Debug("failed to resolve short hostname", "error", err)
+	}
+	full, err := r.full(short)
+	if err != nil {
+		log.Debug("failed to resolve full hostname", "error", err)
+	}
+	if full == "" || isLocalhost(full) {
+		full, err = r.internal()
 		if err != nil {
-			log.Debug("failed to resolve short hostname", "error", err)
-		} else {
-			full, err = r.full(short)
+			log.Debug("internal hostname resolution failed", "error", err)
+			full = short
 		}
-		// Fixes some wrong FQDN configurations that return "localhost". We bypass the FQDN resolution and cache
-		// and just return the full hostname as queried by the kernel (the old behavior of the agent)
-		if r.lastFull == "" && (full == "" || isLocalhost(full)) {
-			// In this edge case, the hostname could flip under some network name instability circumstances
-			log.Debug("using internal hostname")
-			full, err = r.internal()
-			if err != nil {
-				log.Debug("internal hostname resolution failed", "error", err)
-			}
-			if isLocalhost(full) {
+		if isLocalhost(full) {
+			if isLocalhost(short) {
 				full = ""
+			} else {
+				full = short
 			}
 		}
 	}
-	return r.updateAndGet(full, short, err)
+	return full, nil
 }
 
 func isLocalhost(name string) bool {
@@ -166,89 +128,5 @@ func isLocalhost(name string) bool {
 	case "localhost", "ip6-localhost", "ip6-loopback", "ipv6-localhost", "ipv6-loopback": //nolint:goconst
 		return true
 	}
-
 	return false
-}
-
-func (r *fallbackResolver) updateAndGet(queriedFull, queriedShort string, cause error) (full, short string, err error) {
-	var shouldNotify bool
-	var what ChangeType
-	// only change if different
-	if queriedShort != "" && r.lastShort != queriedShort {
-		r.lastShort = queriedShort
-		shouldNotify = true
-		what = Short
-	}
-
-	// only change if different
-	if queriedFull != "" && r.lastFull != queriedFull {
-		r.lastFull = queriedFull
-		shouldNotify = true
-		if what == Short {
-			what = ShortAndFull
-		} else {
-			what = Full
-		}
-	}
-
-	if r.lastFull == "" {
-		full = r.lastShort
-	} else {
-		full = r.lastFull
-	}
-
-	if r.lastShort == "" && full == "" {
-		err = fmt.Errorf("can't query neither full nor short hostname: %w", cause)
-	}
-
-	// this is to avoid loops of query->update->query because we update when we query which is not a very good idea...
-	// fix this query side-effect later
-	if shouldNotify && err == nil {
-		r.notifyObservers(what)
-	}
-
-	return full, r.lastShort, err
-}
-
-func (r *fallbackResolver) Long() string {
-	if r.lastFull == "" {
-		_, _, _ = r.Query()
-	}
-
-	return r.lastFull
-}
-
-func (r *fallbackResolver) AddObserver(name string, ch chan<- ChangeNotification) {
-	r.Lock()
-	defer r.Unlock()
-
-	r.observers[name] = ch
-	logger().Debug("Observer added", "name", name, "newLen", len(r.observers))
-}
-
-func (r *fallbackResolver) RemoveObserver(name string) {
-	r.Lock()
-	defer r.Unlock()
-
-	delete(r.observers, name)
-	logger().Debug("Observer removed", "name", name, "newLen", len(r.observers))
-}
-
-func (r *fallbackResolver) notifyObservers(change ChangeType) {
-	// copy map so we don't change while iterating
-	observers := make(map[string]chan<- ChangeNotification)
-	r.Lock()
-	maps.Copy(observers, r.observers)
-	r.Unlock()
-
-	log := logger()
-	log.Debug("Notifying observers", "change", change)
-	for name, ch := range observers {
-		// don't block while trying to write
-		select {
-		case ch <- ChangeNotification{What: change}:
-			log.Debug("observed notified", "name", name, "change", change)
-		default:
-		}
-	}
 }

--- a/pkg/internal/traces/hostname/hostname.go
+++ b/pkg/internal/traces/hostname/hostname.go
@@ -24,7 +24,7 @@ type Resolver interface {
 }
 
 // CreateResolver creates a HostnameResolver.
-// If overrideFull or overrideShort are not empty strings, the hostname won't resolve automatically but will use
+// If overrideFull is not an empty string, the hostname won't resolve automatically but will use
 // the passed values.
 // If dnsResolution is true, returns a HostnameResolver that attempts to resolve the Fully Qualified Domain Name
 // as the full hostname.
@@ -32,23 +32,14 @@ type Resolver interface {
 // If the full hostname resolution process fails (e.g. due to a temporary DNS failure), it
 // returns the previous successful resolution (or the short hostname if it has never worked
 // previously).
-func CreateResolver(overrideFull, overrideShort string, dnsResolution bool) Resolver {
+func CreateResolver(overrideFull string, dnsResolution bool) Resolver {
 	var resolver *fallbackResolver
 	if dnsResolution {
 		resolver = newDNSResolver(overrideFull)
 	} else {
 		resolver = newInternalResolver(overrideFull)
 	}
-
 	resolver.short = os.Hostname
-
-	if overrideShort != "" {
-		resolver.short = func() (string, error) {
-			logger().Debug("using overriding short host name",
-				"value", overrideShort)
-			return overrideShort, nil
-		}
-	}
 	return resolver
 }
 

--- a/pkg/internal/traces/hostname/hostname.go
+++ b/pkg/internal/traces/hostname/hostname.go
@@ -109,10 +109,10 @@ func (r *fallbackResolver) Query() (string, error) {
 			}
 		}
 	}
-if full == "" {
-	return "", errors.New("can't resolve either full or short hostname")
-}
-return full, nil
+	if full == "" {
+		return "", errors.New("can't resolve either full or short hostname")
+	}
+	return full, nil
 }
 
 func isLocalhost(name string) bool {

--- a/pkg/internal/traces/hostname/hostname_test.go
+++ b/pkg/internal/traces/hostname/hostname_test.go
@@ -23,18 +23,14 @@ const (
 
 // Fake functions for testing
 
-func workingFull(_ string) (string, error)     { return fullName, nil }
-func workingFull2(_ string) (string, error)    { return fullName2, nil }
-func failingFull(_ string) (string, error)     { return "", errors.New("catapun") }
-func misbehavingFull(_ string) (string, error) { return "", nil } // Doesn't fail but returns empty hostname
-func workingShort() (string, error)            { return shortName, nil }
-func workingShort2() (string, error)           { return shortName2, nil }
-func failingShort() (string, error)            { return "", errors.New("patapam") }
-func misbehavingShort() (string, error)        { return "", nil } // Doesn't fail but returns empty hostname
-func localhostFull(_ string) (string, error)   { return "localhost", nil }
-func localhostShort() (string, error)          { return "localhost", nil }
-func internalFull() (string, error)            { return fullName, nil }
-func internal() (string, error)                { return internalName, nil }
+func workingFull(_ string) (string, error)   { return fullName, nil }
+func failingFull(_ string) (string, error)   { return "", errors.New("catapun") }
+func workingShort() (string, error)          { return shortName, nil }
+func failingShort() (string, error)          { return "", errors.New("patapam") }
+func localhostFull(_ string) (string, error) { return "localhost", nil }
+func localhostShort() (string, error)        { return "localhost", nil }
+func internalFull() (string, error)          { return fullName, nil }
+func internal() (string, error)              { return internalName, nil }
 
 // Actual tests
 

--- a/pkg/internal/traces/hostname/hostname_test.go
+++ b/pkg/internal/traces/hostname/hostname_test.go
@@ -38,25 +38,12 @@ func internal() (string, error)                { return internalName, nil }
 
 // Actual tests
 
-func TestHostnameResolver_Update(t *testing.T) {
-	// Given a Hostname Resolver
+func TestHostnameResolver_Query(t *testing.T) {
 	resolver := fallbackResolver{full: workingFull, internal: internal, short: workingShort}
 
-	// That has correctly resolved the hostnames
-	full, short, err := resolver.Query()
+	full, err := resolver.Query()
 	require.NoError(t, err)
 	assert.Equal(t, fullName, full)
-	assert.Equal(t, shortName, short)
-
-	// When the hostname changes
-	resolver.full = workingFull2
-	resolver.short = workingShort2
-
-	// The hostname query return the hostnames
-	full, short, err = resolver.Query()
-	require.NoError(t, err)
-	assert.Equal(t, fullName2, full)
-	assert.Equal(t, shortName2, short)
 }
 
 func TestHostnameResolver_FullFails(t *testing.T) {
@@ -64,29 +51,10 @@ func TestHostnameResolver_FullFails(t *testing.T) {
 	resolver := fallbackResolver{full: failingFull, internal: failingShort, short: workingShort}
 
 	// When the names are queried
-	full, short, err := resolver.Query()
+	full, err := resolver.Query()
 	// The short name is fallen back as full name
 	require.NoError(t, err)
 	assert.Equal(t, shortName, full)
-	assert.Equal(t, shortName, short)
-
-	// When the problem is resolved
-	resolver.full = workingFull
-
-	// The hostname query return the real full hostname
-	full, short, err = resolver.Query()
-	require.NoError(t, err)
-	assert.Equal(t, fullName, full)
-	assert.Equal(t, shortName, short)
-
-	// And if the full name doesn't work again
-	resolver.full = failingFull
-
-	// The stored full hostname is returned anyway
-	full, short, err = resolver.Query()
-	require.NoError(t, err)
-	assert.Equal(t, fullName, full)
-	assert.Equal(t, shortName, short)
 }
 
 func TestHostnameResolver_FullFailsFallingBackInInternal(t *testing.T) {
@@ -94,38 +62,10 @@ func TestHostnameResolver_FullFailsFallingBackInInternal(t *testing.T) {
 	resolver := fallbackResolver{full: failingFull, internal: internal, short: workingShort}
 
 	// When the names are queried
-	full, short, err := resolver.Query()
+	full, err := resolver.Query()
 	// The internal name is fallen back as full name
 	require.NoError(t, err)
 	assert.Equal(t, internalName, full)
-	assert.Equal(t, shortName, short)
-
-	// When the problem is resolved
-	resolver.full = workingFull
-
-	// The hostname query return the real full hostname
-	full, short, err = resolver.Query()
-	require.NoError(t, err)
-	assert.Equal(t, fullName, full)
-	assert.Equal(t, shortName, short)
-
-	// And if the full name doesn't work again
-	resolver.full = failingFull
-
-	// The stored full hostname is returned anyway
-	full, short, err = resolver.Query()
-	require.NoError(t, err)
-	assert.Equal(t, fullName, full)
-	assert.Equal(t, shortName, short)
-
-	// But if the full changes after bringing back to life
-	resolver.full = workingFull2
-
-	// The full hostname is updated
-	full, short, err = resolver.Query()
-	require.NoError(t, err)
-	assert.Equal(t, fullName2, full)
-	assert.Equal(t, shortName, short)
 }
 
 func TestHostnameResolver_FullIsLocalhost(t *testing.T) {
@@ -158,20 +98,18 @@ func TestHostnameResolver_FullIsLocalhost(t *testing.T) {
 			resolver := fallbackResolver{full: fullResolver, short: workingShort, internal: internalFull}
 
 			// When the names are queried
-			full, short, err := resolver.Query()
+			full, err := resolver.Query()
 			// The internal kernel name is fallen back as full name
 			require.NoError(t, err)
 			assert.Equal(t, fullName, full)
-			assert.Equal(t, shortName, short)
 
 			// And if the full name stop working
 			resolver.full = failingFull
 
 			// The stored full kernel hostname is returned anyway
-			full, short, err = resolver.Query()
+			full, err = resolver.Query()
 			require.NoError(t, err)
 			assert.Equal(t, fullName, full)
-			assert.Equal(t, shortName, short)
 		})
 	}
 }
@@ -181,133 +119,34 @@ func TestHostnameResolver_FullAndInternalAreLocalhost(t *testing.T) {
 	resolver := fallbackResolver{full: localhostFull, short: workingShort, internal: localhostShort}
 
 	// When the names are queried
-	full, short, err := resolver.Query()
+	full, err := resolver.Query()
 	// The short name is fallen back as full name
 	require.NoError(t, err)
 	assert.Equal(t, shortName, full)
-	assert.Equal(t, shortName, short)
 
 	// And if the full name stop working
 	resolver.full = failingFull
 
 	// The short hostname is returned anyway
-	full, short, err = resolver.Query()
+	full, err = resolver.Query()
 	require.NoError(t, err)
 	assert.Equal(t, shortName, full)
-	assert.Equal(t, shortName, short)
 
 	// And when the internal full name starts working
 	resolver.internal = internal
 
 	// The stored full kernel hostname is returned
-	full, short, err = resolver.Query()
+	full, err = resolver.Query()
 	require.NoError(t, err)
 	assert.Equal(t, internalName, full)
-	assert.Equal(t, shortName, short)
 
 	// And when the full hostname starts working
 	resolver.full = workingFull
 
 	// The full hostname is returned
-	full, short, err = resolver.Query()
+	full, err = resolver.Query()
 	require.NoError(t, err)
 	assert.Equal(t, fullName, full)
-	assert.Equal(t, shortName, short)
-}
-
-func TestHostnameResolver_FailureOnFirstInvocation(t *testing.T) {
-	tests := []struct {
-		name          string
-		fqdn          func(string) (string, error)
-		os            func() (string, error)
-		expectedFull  string
-		expectedShort string
-		expectedError func(t assert.TestingT, err error, msgAndArgs ...any) bool
-	}{
-		{
-			"fails all the hostname resolution",
-			failingFull, failingShort, "", "", assert.Error,
-		},
-		{
-			"short hostname fails",
-			workingFull, failingShort, "", "", assert.Error,
-		},
-		{
-			"full hostname fails and it provisionally gets the short name as fallback",
-			failingFull, workingShort, shortName, shortName, assert.NoError,
-		},
-		{
-			"misbehaving hostname resolution",
-			misbehavingFull, misbehavingShort, "", "", assert.Error,
-		},
-		{
-			"short hostname misbehaves",
-			workingFull, misbehavingShort, fullName, "", assert.NoError,
-		},
-		{
-			"full hostname misbehaves and it provisionally gets the short name as fallback",
-			misbehavingFull, workingShort, shortName, shortName, assert.NoError,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			// Given a resolver
-			resolver := fallbackResolver{short: test.os, internal: failingShort, full: test.fqdn}
-
-			// That fails (total or partially) on the first invocation
-			full, short, err := resolver.Query()
-			test.expectedError(t, err)
-			assert.Equal(t, test.expectedFull, full)
-			assert.Equal(t, test.expectedShort, short)
-
-			// When it gets recovered
-			resolver.full = workingFull2
-			resolver.short = workingShort2
-
-			// The hostname query return the hostnames
-			full, short, err = resolver.Query()
-			require.NoError(t, err)
-			assert.Equal(t, fullName2, full)
-			assert.Equal(t, shortName2, short)
-		})
-	}
-}
-
-func TestHostnameResolver_FailureRelyingOnCachedValues(t *testing.T) {
-	tests := []struct {
-		name string
-		fqdn func(string) (string, error)
-		os   func() (string, error)
-	}{
-		{"fails all the hostname resolution", failingFull, failingShort},
-		{"short hostname fails", workingFull, failingShort},
-		{"full hostname fails", failingFull, workingShort},
-		{"misbehaving all the hostname resolution", misbehavingFull, misbehavingShort},
-		{"short hostname misbehaving", workingFull, misbehavingShort},
-		{"full hostname misbehaving", misbehavingFull, workingShort},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			// Given a Hostname Resolver
-			resolver := fallbackResolver{full: workingFull, internal: internal, short: workingShort}
-
-			// That has correctly resolved the hostnames
-			full, short, err := resolver.Query()
-			require.NoError(t, err)
-			assert.Equal(t, fullName, full)
-			assert.Equal(t, shortName, short)
-
-			// When it fails
-			resolver.full = test.fqdn
-			resolver.short = test.os
-
-			// The hostname query return the cached hostnames
-			full, short, err = resolver.Query()
-			require.NoError(t, err)
-			assert.Equal(t, fullName, full)
-			assert.Equal(t, shortName, short)
-		})
-	}
 }
 
 func TestDNSResolver(t *testing.T) {
@@ -315,10 +154,9 @@ func TestDNSResolver(t *testing.T) {
 	resolver := CreateResolver("", "", true)
 
 	// resolves host names to some non-null hostnames
-	full, short, err := resolver.Query()
+	full, err := resolver.Query()
 	require.NoError(t, err)
 	assert.NotEmpty(t, full)
-	assert.NotEmpty(t, short)
 }
 
 func TestDNSResolver_Override(t *testing.T) {
@@ -326,10 +164,9 @@ func TestDNSResolver_Override(t *testing.T) {
 	resolver := CreateResolver("my-hostname.host.com", "my-hostname", true)
 
 	// resolves host names to the overridden hostnames
-	full, short, err := resolver.Query()
+	full, err := resolver.Query()
 	require.NoError(t, err)
 	assert.Equal(t, "my-hostname.host.com", full)
-	assert.Equal(t, "my-hostname", short)
 }
 
 func TestDNSResolver_OverrideLocalhost(t *testing.T) {
@@ -337,10 +174,9 @@ func TestDNSResolver_OverrideLocalhost(t *testing.T) {
 	resolver := CreateResolver("localhost", "", true)
 
 	// anyway resolves host names to the overridden hostname
-	full, short, err := resolver.Query()
+	full, err := resolver.Query()
 	require.NoError(t, err)
 	assert.Equal(t, "localhost", full)
-	assert.NotEmpty(t, short)
 }
 
 func TestInternalResolver(t *testing.T) {
@@ -348,10 +184,9 @@ func TestInternalResolver(t *testing.T) {
 	resolver := CreateResolver("", "", false)
 
 	// resolves host names to some non-null hostnames
-	full, short, err := resolver.Query()
+	full, err := resolver.Query()
 	require.NoError(t, err)
 	assert.NotEmpty(t, full)
-	assert.NotEmpty(t, short)
 }
 
 func TestInternalResolver_Override(t *testing.T) {
@@ -359,10 +194,9 @@ func TestInternalResolver_Override(t *testing.T) {
 	resolver := CreateResolver("my-hostname.host.com", "my-hostname", false)
 
 	// resolves host names to the overridden hostnames
-	full, short, err := resolver.Query()
+	full, err := resolver.Query()
 	require.NoError(t, err)
 	assert.Equal(t, "my-hostname.host.com", full)
-	assert.Equal(t, "my-hostname", short)
 }
 
 func TestInternalResolver_OverrideLocalhost(t *testing.T) {
@@ -370,14 +204,7 @@ func TestInternalResolver_OverrideLocalhost(t *testing.T) {
 	resolver := CreateResolver("localhost", "", false)
 
 	// anyway resolves host names to the overridden hostname
-	full, short, err := resolver.Query()
+	full, err := resolver.Query()
 	require.NoError(t, err)
 	assert.Equal(t, "localhost", full)
-	assert.NotEmpty(t, short)
-}
-
-func TestFallbackResolver_LongTriggersResolution(t *testing.T) {
-	resolver := CreateResolver("", "", false)
-
-	assert.NotEmpty(t, resolver.Long())
 }

--- a/pkg/internal/traces/hostname/hostname_test.go
+++ b/pkg/internal/traces/hostname/hostname_test.go
@@ -147,7 +147,7 @@ func TestHostnameResolver_FullAndInternalAreLocalhost(t *testing.T) {
 
 func TestDNSResolver(t *testing.T) {
 	// invoking a New Hostname Resolver without any overriding configuration
-	resolver := CreateResolver("", "", true)
+	resolver := CreateResolver("", true)
 
 	// resolves host names to some non-null hostnames
 	full, err := resolver.Query()
@@ -157,7 +157,7 @@ func TestDNSResolver(t *testing.T) {
 
 func TestDNSResolver_Override(t *testing.T) {
 	// invoking a New Hostname Resolver without any overriding configuration
-	resolver := CreateResolver("my-hostname.host.com", "my-hostname", true)
+	resolver := CreateResolver("my-hostname.host.com", true)
 
 	// resolves host names to the overridden hostnames
 	full, err := resolver.Query()
@@ -167,7 +167,7 @@ func TestDNSResolver_Override(t *testing.T) {
 
 func TestDNSResolver_OverrideLocalhost(t *testing.T) {
 	// invoking a New Hostname Resolver overridden with a non-recommended host name
-	resolver := CreateResolver("localhost", "", true)
+	resolver := CreateResolver("localhost", true)
 
 	// anyway resolves host names to the overridden hostname
 	full, err := resolver.Query()
@@ -177,7 +177,7 @@ func TestDNSResolver_OverrideLocalhost(t *testing.T) {
 
 func TestInternalResolver(t *testing.T) {
 	// invoking a New Hostname Resolver without any overriding configuration
-	resolver := CreateResolver("", "", false)
+	resolver := CreateResolver("", false)
 
 	// resolves host names to some non-null hostnames
 	full, err := resolver.Query()
@@ -187,7 +187,7 @@ func TestInternalResolver(t *testing.T) {
 
 func TestInternalResolver_Override(t *testing.T) {
 	// invoking a New Hostname Resolver without any overriding configuration
-	resolver := CreateResolver("my-hostname.host.com", "my-hostname", false)
+	resolver := CreateResolver("my-hostname.host.com", false)
 
 	// resolves host names to the overridden hostnames
 	full, err := resolver.Query()
@@ -197,7 +197,7 @@ func TestInternalResolver_Override(t *testing.T) {
 
 func TestInternalResolver_OverrideLocalhost(t *testing.T) {
 	// invoking a New Hostname Resolver overridden with a non-recommended host name
-	resolver := CreateResolver("localhost", "", false)
+	resolver := CreateResolver("localhost", false)
 
 	// anyway resolves host names to the overridden hostname
 	full, err := resolver.Query()

--- a/pkg/internal/traces/read_decorator.go
+++ b/pkg/internal/traces/read_decorator.go
@@ -68,9 +68,8 @@ type HostInstance struct {
 }
 
 func NewHostInstance(cfg *config.InstanceIDConfig) HostInstance {
-	// TODO: periodically update in case the current OBI instance is created from a VM snapshot running as a different hostname
 	resolver := hostname.CreateResolver(cfg.OverrideHostname, "", cfg.HostnameDNSResolution)
-	fullHostName, _, err := resolver.Query()
+	fullHostName, err := resolver.Query()
 	log := rlog().With("function", "instance_ID_hostNamePIDDecorator")
 	if err != nil {
 		log.Warn("can't read hostname. Leaving empty. Consider overriding"+

--- a/pkg/internal/traces/read_decorator.go
+++ b/pkg/internal/traces/read_decorator.go
@@ -68,7 +68,7 @@ type HostInstance struct {
 }
 
 func NewHostInstance(cfg *config.InstanceIDConfig) HostInstance {
-	resolver := hostname.CreateResolver(cfg.OverrideHostname, "", cfg.HostnameDNSResolution)
+	resolver := hostname.CreateResolver(cfg.OverrideHostname, cfg.HostnameDNSResolution)
 	fullHostName, err := resolver.Query()
 	log := rlog().With("function", "instance_ID_hostNamePIDDecorator")
 	if err != nil {

--- a/pkg/internal/traces/read_decorator_test.go
+++ b/pkg/internal/traces/read_decorator_test.go
@@ -21,10 +21,10 @@ import (
 const testTimeout = 5 * time.Second
 
 func TestReadDecorator(t *testing.T) {
-	localHostname, _, err := hostname.CreateResolver("", "", false).Query()
+	localHostname, err := hostname.CreateResolver("", "", false).Query()
 	require.NoError(t, err)
 	require.NotEmpty(t, localHostname)
-	dnsHostname, _, err := hostname.CreateResolver("", "", true).Query()
+	dnsHostname, err := hostname.CreateResolver("", "", true).Query()
 	require.NoError(t, err)
 	require.NotEmpty(t, dnsHostname)
 

--- a/pkg/internal/traces/read_decorator_test.go
+++ b/pkg/internal/traces/read_decorator_test.go
@@ -21,10 +21,10 @@ import (
 const testTimeout = 5 * time.Second
 
 func TestReadDecorator(t *testing.T) {
-	localHostname, err := hostname.CreateResolver("", "", false).Query()
+	localHostname, err := hostname.CreateResolver("", false).Query()
 	require.NoError(t, err)
 	require.NotEmpty(t, localHostname)
-	dnsHostname, err := hostname.CreateResolver("", "", true).Query()
+	dnsHostname, err := hostname.CreateResolver("", true).Query()
 	require.NoError(t, err)
 	require.NotEmpty(t, dnsHostname)
 


### PR DESCRIPTION
## Summary

The hostname resolver was overengineered for a use case that is never happening, because we currently invoke the `Query()` method only once, during startup, and we keep using the full hostname for the whole lifespan of the OBI instance, so this PR:

- Removes the logic of "notifying when a hostname dynamically changes" (never happens because we don't invoke Query() more than once)
- Removes the subscribers/notifications logic, because no entity was subscribed to it.
- Removes the `short` hostname return value, as it was never used outside of the resolver.
- Removes the logic to override `short` hostname, as it is not possible to override it from the user side.

We removed the "update" logic from the unit tests but kept untouched the logic refering to the first query (try full hostname then backup to internal hostname then backup to logic, and avoid localhosts).

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
