### PR TITLE
tracers: don't add/remove pids for tracers that failed loading

### DIFF
--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/cilium/ebpf/link"
@@ -246,6 +247,8 @@ func (ta *traceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 		return false
 	}
 
+	ta.dropUnloadedTracers(tracer.Programs)
+
 	ie.Tracer = tracer
 
 	if err := tracer.NewExecutable(exe, ie); err != nil {
@@ -275,12 +278,23 @@ func (ta *traceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 	return true
 }
 
+// dropUnloadedTracers keeps only the common tracers that survived ProcessTracer.Init in
+// loadedPrograms, so PID notifications never reach a tracer without loaded BPF objects
+func (ta *traceAttacher) dropUnloadedTracers(loadedPrograms []ebpf.Tracer) {
+	if ta.commonTracersLoaded {
+		return
+	}
+	ta.commonTracers = slices.DeleteFunc(ta.commonTracers, func(ct ebpf.Tracer) bool {
+		return !slices.Contains(loadedPrograms, ct)
+	})
+	ta.commonTracersLoaded = true
+}
+
 func (ta *traceAttacher) withCommonTracersGroup(tracers []ebpf.Tracer) []ebpf.Tracer {
 	if ta.commonTracersLoaded {
 		return tracers
 	}
 
-	ta.commonTracersLoaded = true
 	ta.commonTracers = newCommonTracersGroup(ta.Cfg, ta.Metrics, ta.EbpfEventContext.CommonPIDsFilter)
 
 	return append(tracers, ta.commonTracers...)

--- a/pkg/appolly/discover/attacher_linux_test.go
+++ b/pkg/appolly/discover/attacher_linux_test.go
@@ -1,0 +1,78 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package discover
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	execpkg "go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/ebpf"
+	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	"go.opentelemetry.io/obi/pkg/internal/helpers/maps"
+	"go.opentelemetry.io/obi/pkg/obi"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+)
+
+type failingLoadTracer struct {
+	recordingTracer
+}
+
+func (f *failingLoadTracer) LoadSpecs() ([]*ebpfcommon.SpecBundle, error) {
+	return nil, errors.New("BPF load failure")
+}
+
+// After an optional common tracer fails during ProcessTracer.Init, it must be
+// pruned from ta.commonTracers so that only successfully loaded common tracers
+// receive AllowPID and BlockPID notifications.
+func TestCommonTracersPrunedAfterLoadFailure(t *testing.T) {
+	okTracer := &recordingTracer{}
+	failedTracer := &failingLoadTracer{}
+
+	cfg := &obi.Config{}
+	tracer := ebpf.NewProcessTracer(ebpf.Generic, []ebpf.Tracer{okTracer, failedTracer}, cfg, imetrics.NoopReporter{})
+	require.NoError(t, tracer.Init(&ebpfcommon.EBPFEventContext{}, cfg))
+	require.Equal(t, []ebpf.Tracer{okTracer}, tracer.Programs)
+
+	tracerEvents := msg.NewQueue[Event[*ebpf.Instrumentable]](msg.ChannelBufferLen(10))
+	ta := &traceAttacher{
+		log:                slog.With("component", t.Name()),
+		Metrics:            imetrics.NoopReporter{},
+		commonTracers:      []ebpf.Tracer{okTracer, failedTracer},
+		existingTracers:    map[uint64]*ebpf.ProcessTracer{},
+		processInstances:   maps.MultiCounter[uint64]{},
+		OutputTracerEvents: tracerEvents,
+	}
+
+	ta.dropUnloadedTracers(tracer.Programs)
+	assert.Equal(t, []ebpf.Tracer{okTracer}, ta.commonTracers)
+
+	fileInfo := execpkg.New(execpkg.Init{
+		Service:    svc.Attrs{UID: svc.UID{Name: "svc", Namespace: "ns"}},
+		CmdExePath: "/bin/test",
+		Pid:        42,
+		Ino:        1234,
+		Ns:         17,
+	})
+	ie := &ebpf.Instrumentable{FileInfo: fileInfo}
+
+	ta.monitorPIDs(tracer, ie)
+	assert.NotEmpty(t, okTracer.allowed)
+	assert.Empty(t, failedTracer.allowed)
+
+	ta.existingTracers[fileInfo.Ino()] = tracer
+	ta.processInstances.Inc(fileInfo.Ino())
+
+	ta.notifyProcessDeletion(ie)
+	assert.NotEmpty(t, okTracer.blocked)
+	assert.Empty(t, failedTracer.blocked)
+}

--- a/pkg/appolly/discover/attacher_linux_test.go
+++ b/pkg/appolly/discover/attacher_linux_test.go
@@ -39,6 +39,7 @@ func TestCommonTracersPrunedAfterLoadFailure(t *testing.T) {
 	failedTracer := &failingLoadTracer{}
 
 	cfg := &obi.Config{}
+	cfg.EBPF.BPFFSPath = t.TempDir()
 	tracer := ebpf.NewProcessTracer(ebpf.Generic, []ebpf.Tracer{okTracer, failedTracer}, cfg, imetrics.NoopReporter{})
 	require.NoError(t, tracer.Init(&ebpfcommon.EBPFEventContext{}, cfg))
 	require.Equal(t, []ebpf.Tracer{okTracer}, tracer.Programs)

--- a/pkg/appolly/discover/attacher_test.go
+++ b/pkg/appolly/discover/attacher_test.go
@@ -32,10 +32,14 @@ type blockedPID struct {
 }
 
 type recordingTracer struct {
+	allowed []blockedPID
 	blocked []blockedPID
 }
 
-func (r *recordingTracer) AllowPID(app.PID, uint32, *execpkg.FileInfo) {}
+func (r *recordingTracer) AllowPID(pid app.PID, ns uint32, _ *execpkg.FileInfo) {
+	r.allowed = append(r.allowed, blockedPID{pid: pid, ns: ns})
+}
+
 func (r *recordingTracer) BlockPID(pid app.PID, ns uint32) {
 	r.blocked = append(r.blocked, blockedPID{pid: pid, ns: ns})
 }

--- a/pkg/ebpf/tracer_linux.go
+++ b/pkg/ebpf/tracer_linux.go
@@ -218,7 +218,7 @@ func (pt *ProcessTracer) loadTracer(eventContext *common.EBPFEventContext, p Tra
 
 	if err != nil && (strings.Contains(err.Error(), "unknown func bpf_probe_write_user") ||
 		strings.Contains(err.Error(), "cannot use helper bpf_probe_write_user")) {
-		plog.Warn("Failed to enable Go write memory distributed tracing context-propagation" +
+		plog.Warn("Failed to enable Go write memory distributed tracing context-propagation " +
 			"and/or log enricher on a Linux Kernel without write memory support. " +
 			"To avoid seeing this message, please ensure you have correctly mounted /sys/kernel/security " +
 			"and ensure OBI has the SYS_ADMIN linux capability. " +

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -248,6 +248,9 @@ func applyTraceContext(m map[string]any, traceID, spanID string, includeSpan boo
 
 func (p *Tracer) addPID(key uint64) error {
 	p.log.Debug("adding pid", "pid", uint32(key), "ns", key>>32)
+	if p.bpfObjects.LogEnricherPids == nil {
+		return fmt.Errorf("BPF objects not loaded, cannot add pid %d (ns=%d)", uint32(key), key>>32)
+	}
 	if err := p.bpfObjects.LogEnricherPids.Put(key, uint8(1)); err != nil {
 		return fmt.Errorf("error adding pid %d (ns=%d) to bpf map: %w", uint32(key), key>>32, err)
 	}
@@ -256,6 +259,9 @@ func (p *Tracer) addPID(key uint64) error {
 
 func (p *Tracer) removePID(key uint64) error {
 	p.log.Debug("removing pid", "pid", uint32(key), "ns", key>>32)
+	if p.bpfObjects.LogEnricherPids == nil {
+		return fmt.Errorf("BPF objects not loaded, cannot remove pid %d (ns=%d)", uint32(key), key>>32)
+	}
 	if err := p.bpfObjects.LogEnricherPids.Delete(key); err != nil {
 		if errors.Is(err, ebpf.ErrKeyNotExist) {
 			return nil

--- a/pkg/internal/ebpf/logenricher/logenricher_test.go
+++ b/pkg/internal/ebpf/logenricher/logenricher_test.go
@@ -91,6 +91,13 @@ func TestBlockPIDClearsNamespacedPIDCache(t *testing.T) {
 	require.ErrorIs(t, m.Lookup(nsPk, &value), ebpf.ErrKeyNotExist)
 }
 
+func TestPIDOpsWithoutLoadedObjectsDoNotPanic(t *testing.T) {
+	tr := newTestTracer(t, false)
+
+	require.Error(t, tr.addPID(tr.pidKey(1, 42)))
+	require.Error(t, tr.removePID(tr.pidKey(1, 42)))
+}
+
 func TestShouldOmitSpanID_FeatureDisabled(t *testing.T) {
 	tr := newTestTracer(t, false)
 


### PR DESCRIPTION
## Summary

don't add/remove pids for tracers that failed loading

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
