### PR TITLE
rdns: fallthrough to dns on rdns cache miss

### DIFF
--- a/pkg/transform/name_resolver.go
+++ b/pkg/transform/name_resolver.go
@@ -281,9 +281,9 @@ func (nr *NameResolver) dnsResolve(svc *svc.Attrs, ip string) (string, string, s
 	}
 
 	if nr.sources.Has(ResolverRDNS) && nr.dnsCache != nil {
-		n := nr.resolveRDNS(ip)
-		n = nr.cleanName(svc, ip, n)
-		return n, svc.UID.Namespace, ""
+		if n := nr.resolveRDNS(ip); n != "" {
+			return nr.cleanName(svc, ip, n), svc.UID.Namespace, ""
+		}
 	}
 
 	if nr.sources.Has(ResolverDNS) {

--- a/pkg/transform/name_resolver_test.go
+++ b/pkg/transform/name_resolver_test.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	memorystore "go.opentelemetry.io/obi/pkg/internal/rdns/store"
 	"go.opentelemetry.io/obi/pkg/kube"
 	"go.opentelemetry.io/obi/pkg/kube/kubecache/informer"
 )
@@ -584,4 +586,27 @@ func TestResolver(t *testing.T) {
 			assert.Equal(t, tt.expectedNamespace, ns)
 		})
 	}
+}
+
+func TestRDNSMissFallsThroughToDNS(t *testing.T) {
+	dnsCache, err := memorystore.NewInMemory(10)
+	require.NoError(t, err)
+	dnsCache.StorePair("10.0.0.1", "redis.example.internal")
+
+	nr := NameResolver{
+		dnsCache: dnsCache,
+		cache:    expirable.NewLRU[string, string](10, nil, 5*time.Hour),
+		sources:  resolverSources([]Source{SourceRDNS, SourceDNS}),
+		logger:   nrlog(),
+	}
+	svcAttrs := svc.Attrs{UID: svc.UID{Name: "test-service", Namespace: "default"}}
+
+	name, ns, _ := nr.dnsResolve(&svcAttrs, "10.0.0.1")
+	assert.Equal(t, "redis.example.internal", name)
+	assert.Equal(t, "default", ns)
+
+	// rdns cache miss must reach the dns source, which returns the IP on PTR failure
+	name, ns, _ = nr.dnsResolve(&svcAttrs, "10.0.0.99")
+	assert.Equal(t, "10.0.0.99", name)
+	assert.Equal(t, "default", ns)
 }


### PR DESCRIPTION
## Summary

when sources are "k8s,rdns,dns", the rdns branch returns unconditionally so the dns resolver was never hit

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
