### PR TITLE
postgres: cache db namespace on client startup

### DIFF
--- a/internal/test/integration/red_test_python_sql.go
+++ b/internal/test/integration/red_test_python_sql.go
@@ -97,6 +97,15 @@ func assertSQLOperation(t *testing.T, comm, op, table, db string) {
 		tag, found = jaeger.FindIn(span.Tags, "db.collection.name")
 		assert.True(ct, found)
 		assert.Equal(ct, table, tag.Value)
+
+		// "sqltest" is the dbname in the test server's StartupMessage
+		tag, found = jaeger.FindIn(span.Tags, "db.namespace")
+		if db == "postgresql" {
+			assert.True(ct, found)
+			assert.Equal(ct, "sqltest", tag.Value)
+		} else {
+			assert.False(ct, found)
+		}
 	}, testTimeout, 100*time.Millisecond)
 }
 
@@ -167,6 +176,14 @@ func assertSQLOperationErrored(t *testing.T, comm, op, table, db string) {
 		tag, found = jaeger.FindIn(span.Tags, "otel.status_description")
 		assert.True(ct, found)
 		assert.Equal(ct, expectedData[db]["otel.status_description"], tag.Value)
+
+		tag, found = jaeger.FindIn(span.Tags, "db.namespace")
+		if db == "postgresql" {
+			assert.True(ct, found)
+			assert.Equal(ct, "sqltest", tag.Value)
+		} else {
+			assert.False(ct, found)
+		}
 	}, testTimeout, 100*time.Millisecond)
 }
 

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -250,6 +250,7 @@ type EBPFParseContext struct {
 	mysqlPreparedStatements    *simplelru.LRU[mysqlPreparedStatementsKey, string]
 	postgresPreparedStatements *simplelru.LRU[postgresPreparedStatementsKey, string]
 	postgresPortals            *simplelru.LRU[postgresPortalsKey, string]
+	postgresDBNames            *simplelru.LRU[BpfConnectionInfoT, string]
 	mssqlPreparedStatements    *simplelru.LRU[mssqlPreparedStatementsKey, string]
 	kafkaTopicUUIDToName       *simplelru.LRU[kafkaparser.UUID, string]
 	payloadExtraction          config.PayloadExtraction
@@ -345,6 +346,7 @@ func NewEBPFParseContext(cfg *config.EBPFTracer, spansChan *msg.Queue[[]request.
 
 	h2c, _ := lru.New[uint64, h2Connection](1024 * 10)
 	largeBuffers := expirable.NewLRU[largeBufferKey, *largebuf.LargeBuffer](1024, nil, 5*time.Minute)
+	postgresDBNames, _ := simplelru.NewLRU[BpfConnectionInfoT, string](4096, nil)
 
 	if spansChan != nil {
 		emitSpans = func(spans []request.Span) {
@@ -422,6 +424,7 @@ func NewEBPFParseContext(cfg *config.EBPFTracer, spansChan *msg.Queue[[]request.
 		mysqlPreparedStatements:    mysqlPreparedStatements,
 		postgresPreparedStatements: postgresPreparedStatements,
 		postgresPortals:            postgresPortals,
+		postgresDBNames:            postgresDBNames,
 		mssqlPreparedStatements:    mssqlPreparedStatements,
 		kafkaTopicUUIDToName:       kafkaTopicUUIDToName,
 		payloadExtraction:          payloadExtraction,

--- a/pkg/ebpf/common/sql_detect_postgres.go
+++ b/pkg/ebpf/common/sql_detect_postgres.go
@@ -36,6 +36,14 @@ const (
 	// pgHeaderLen is the size of the Postgres message header:
 	// 1 byte type + 4 bytes length field.
 	pgHeaderLen = 5
+
+	// StartupMessage major protocol version (3.x: 3.0 since PG 7.4, 3.2 since PG 18)
+	pgStartupProtocolMajor = 3
+	// pgStartupMinLen: 4 bytes length + 4 bytes protocol + 1 byte terminator
+	pgStartupMinLen     = 9
+	pgStartupMaxLen     = 10000
+	pgSSLRequestCode    = 80877103
+	pgGSSENCRequestCode = 80877104
 )
 
 var (
@@ -213,6 +221,67 @@ func postgresPreparedStatements(b *largebuf.LargeBuffer) (string, string, string
 	}
 
 	return op, table, sql
+}
+
+// StartupMessage: Int32 length, Int32 protocol, then null-terminated key/value pairs
+func parsePostgresStartup(b *largebuf.LargeBuffer) (string, bool) {
+	r := b.NewReader()
+	// BPF drops 1-byte reads, so a refused SSL/GSSENC negotiation ('N') glues its request to the startup
+	for range 3 {
+		msgLen, err := r.ReadI32BE()
+		if err != nil || msgLen < 8 || msgLen > pgStartupMaxLen {
+			return "", false
+		}
+		code, err := r.ReadI32BE()
+		if err != nil {
+			return "", false
+		}
+		if (code == pgSSLRequestCode || code == pgGSSENCRequestCode) && msgLen == 8 {
+			continue
+		}
+		// trailing bytes past the startup's own length = some other length-prefixed protocol
+		if code>>16 != pgStartupProtocolMajor || msgLen < pgStartupMinLen ||
+			int(msgLen)-8 < r.Remaining() {
+			return "", false
+		}
+		return parsePostgresStartupParams(&r)
+	}
+	return "", false
+}
+
+func parsePostgresStartupParams(r *largebuf.LargeBufferReader) (string, bool) {
+	var db, user string
+	for {
+		key, err := r.ReadCStr()
+		if err != nil || len(key) == 0 {
+			break
+		}
+		val, err := r.ReadCStr()
+		if err != nil {
+			break
+		}
+		switch string(key) {
+		case "database":
+			db = string(val)
+		case "user":
+			user = string(val)
+		}
+	}
+	if db == "" {
+		// the database name defaults to the user name in the Postgres protocol
+		db = user
+	}
+	return db, db != ""
+}
+
+func postgresDBForConn(parseCtx *EBPFParseContext, connInfo BpfConnectionInfoT) string {
+	if parseCtx.postgresDBNames == nil {
+		return ""
+	}
+	if db, ok := parseCtx.postgresDBNames.Get(connInfo); ok {
+		return db
+	}
+	return ""
 }
 
 type postgresMessage struct {
@@ -402,5 +471,7 @@ Loop:
 		return span, errFallback
 	}
 
-	return TCPToSQLToSpan(event, op, table, stmt, request.DBPostgres, msg.typ, sqlError), nil
+	span = TCPToSQLToSpan(event, op, table, stmt, request.DBPostgres, msg.typ, sqlError)
+	span.DBNamespace = postgresDBForConn(parseCtx, event.ConnInfo)
+	return span, nil
 }

--- a/pkg/ebpf/common/sql_detect_postgres.go
+++ b/pkg/ebpf/common/sql_detect_postgres.go
@@ -244,31 +244,33 @@ func parsePostgresStartup(b *largebuf.LargeBuffer) (string, bool) {
 			int(msgLen)-8 < r.Remaining() {
 			return "", false
 		}
-		return parsePostgresStartupParams(&r)
+		return parsePostgresStartupParams(&r, r.Remaining() == int(msgLen)-8)
 	}
 	return "", false
 }
 
-func parsePostgresStartupParams(r *largebuf.LargeBufferReader) (string, bool) {
+func parsePostgresStartupParams(r *largebuf.LargeBufferReader, complete bool) (string, bool) {
 	var db, user string
 	for {
 		key, err := r.ReadCStr()
 		if err != nil || len(key) == 0 {
 			break
 		}
+		// ReadCStr may return the reader's scratch buffer, which the next read reuses
+		k := string(key)
 		val, err := r.ReadCStr()
 		if err != nil {
 			break
 		}
-		switch string(key) {
+		switch k {
 		case "database":
 			db = string(val)
 		case "user":
 			user = string(val)
 		}
 	}
-	if db == "" {
-		// the database name defaults to the user name in the Postgres protocol
+	if db == "" && complete {
+		// the database name defaults to the user name, but a truncated capture may hide an explicit database param
 		db = user
 	}
 	return db, db != ""

--- a/pkg/ebpf/common/sql_detect_postgres_test.go
+++ b/pkg/ebpf/common/sql_detect_postgres_test.go
@@ -4,6 +4,7 @@
 package ebpfcommon
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -192,6 +193,95 @@ func TestParsePostgresBindNames(t *testing.T) {
 			assert.Equal(t, tt.wantOK, ok)
 			assert.Equal(t, tt.wantPortal, portal)
 			assert.Equal(t, tt.wantStmt, stmt)
+		})
+	}
+}
+
+func pgStartupMessage(params ...string) []byte {
+	body := []byte{0, 3, 0, 0} // protocol 3.0
+	for _, p := range params {
+		body = append(body, p...)
+		body = append(body, 0)
+	}
+	body = append(body, 0)
+	msg := binary.BigEndian.AppendUint32(nil, uint32(4+len(body)))
+	return append(msg, body...)
+}
+
+func TestParsePostgresStartup(t *testing.T) {
+	tests := []struct {
+		name   string
+		buf    []byte
+		wantDB string
+		wantOK bool
+	}{
+		{
+			name:   "database parameter",
+			buf:    pgStartupMessage("user", "postgres", "database", "mydb"),
+			wantDB: "mydb",
+			wantOK: true,
+		},
+		{
+			name:   "database defaults to user",
+			buf:    pgStartupMessage("user", "postgres", "application_name", "psql"),
+			wantDB: "postgres",
+			wantOK: true,
+		},
+		{
+			name:   "protocol 3.2",
+			buf:    append([]byte{0, 0, 0, 23, 0, 3, 0, 2}, "database\x00mydb\x00\x00"...),
+			wantDB: "mydb",
+			wantOK: true,
+		},
+		{
+			name: "SSLRequest is not a startup",
+			// length 8, request code 80877103
+			buf: []byte{0, 0, 0, 8, 0x04, 0xd2, 0x16, 0x2f},
+		},
+		{
+			// sslmode=prefer: BPF drops the 1-byte 'N' refusal, gluing both messages
+			name:   "SSLRequest glued to startup",
+			buf:    append([]byte{0, 0, 0, 8, 0x04, 0xd2, 0x16, 0x2f}, pgStartupMessage("user", "postgres", "database", "sqltest")...),
+			wantDB: "sqltest",
+			wantOK: true,
+		},
+		{
+			name:   "GSSENC and SSLRequest glued to startup",
+			buf:    append([]byte{0, 0, 0, 8, 0x04, 0xd2, 0x16, 0x30, 0, 0, 0, 8, 0x04, 0xd2, 0x16, 0x2f}, pgStartupMessage("database", "mydb")...),
+			wantDB: "mydb",
+			wantOK: true,
+		},
+		{
+			name: "SSLRequest glued to garbage",
+			buf:  append([]byte{0, 0, 0, 8, 0x04, 0xd2, 0x16, 0x2f}, 0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe, 0xff),
+		},
+		{
+			name: "trailing bytes rejected (Kafka-like framing)",
+			buf:  append(pgStartupMessage("user", "postgres"), 0xff),
+		},
+		{
+			name: "wrong protocol version",
+			buf:  []byte{0, 0, 0, 9, 0, 2, 0, 0, 0},
+		},
+		{
+			name: "truncated before parameters",
+			buf:  []byte{0, 0, 0, 20, 0, 3, 0, 0},
+		},
+		{
+			name: "regular typed message",
+			buf:  append([]byte{'Q', 0, 0, 0, 11}, append([]byte("SELECT"), 0)...),
+		},
+		{
+			name: "empty buffer",
+			buf:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, ok := parsePostgresStartup(largebuf.NewLargeBufferFrom(tt.buf))
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantDB, db)
 		})
 	}
 }

--- a/pkg/ebpf/common/sql_detect_postgres_test.go
+++ b/pkg/ebpf/common/sql_detect_postgres_test.go
@@ -268,6 +268,23 @@ func TestParsePostgresStartup(t *testing.T) {
 			buf:  []byte{0, 0, 0, 20, 0, 3, 0, 0},
 		},
 		{
+			// cut mid-"database" pair: the explicit db name is lost, user alone must not be trusted
+			name: "truncated capture does not fall back to user",
+			buf: func() []byte {
+				m := pgStartupMessage("user", "postgres", "database", "mydb")
+				return m[:len(m)-10]
+			}(),
+		},
+		{
+			name: "truncated capture with database already captured",
+			buf: func() []byte {
+				m := pgStartupMessage("database", "mydb", "application_name", "psql")
+				return m[:len(m)-8]
+			}(),
+			wantDB: "mydb",
+			wantOK: true,
+		},
+		{
 			name: "regular typed message",
 			buf:  append([]byte{'Q', 0, 0, 0, 11}, append([]byte("SELECT"), 0)...),
 		},
@@ -282,6 +299,50 @@ func TestParsePostgresStartup(t *testing.T) {
 			db, ok := parsePostgresStartup(largebuf.NewLargeBufferFrom(tt.buf))
 			assert.Equal(t, tt.wantOK, ok)
 			assert.Equal(t, tt.wantDB, db)
+		})
+	}
+}
+
+func chunkedLargeBuffer(buf []byte, chunkSize int) *largebuf.LargeBuffer {
+	lb := largebuf.NewLargeBuffer()
+	for len(buf) > 0 {
+		n := min(chunkSize, len(buf))
+		lb.AppendChunk(buf[:n])
+		buf = buf[n:]
+	}
+	return lb
+}
+
+// BPF captures can cut the StartupMessage at any byte; the parser must never
+// panic and must never invent a namespace it didn't fully read
+func TestParsePostgresStartupTruncationSafety(t *testing.T) {
+	buffers := map[string][]byte{
+		"plain":      pgStartupMessage("user", "postgres", "database", "mydb", "application_name", "psql"),
+		"ssl glued":  append([]byte{0, 0, 0, 8, 0x04, 0xd2, 0x16, 0x2f}, pgStartupMessage("user", "postgres", "database", "mydb")...),
+		"gssenc+ssl": append([]byte{0, 0, 0, 8, 0x04, 0xd2, 0x16, 0x30, 0, 0, 0, 8, 0x04, 0xd2, 0x16, 0x2f}, pgStartupMessage("database", "mydb")...),
+		"proto 3.2":  append([]byte{0, 0, 0, 23, 0, 3, 0, 2}, "database\x00mydb\x00\x00"...),
+	}
+
+	for name, full := range buffers {
+		t.Run(name, func(t *testing.T) {
+			for i := range len(full) + 1 {
+				prefix := full[:i]
+
+				db, ok := parsePostgresStartup(largebuf.NewLargeBufferFrom(prefix))
+				if ok {
+					// only the explicitly captured name is acceptable, never a user fallback
+					assert.Equal(t, "mydb", db, "prefix of %d bytes", i)
+				}
+
+				// same prefix split into tiny chunks exercises every cross-chunk read path
+				cdb, cok := parsePostgresStartup(chunkedLargeBuffer(prefix, 3))
+				assert.Equal(t, ok, cok, "chunked parse diverges at prefix %d", i)
+				assert.Equal(t, db, cdb, "chunked parse diverges at prefix %d", i)
+			}
+
+			db, ok := parsePostgresStartup(largebuf.NewLargeBufferFrom(full))
+			assert.True(t, ok)
+			assert.Equal(t, "mydb", db)
 		})
 	}
 }

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -177,7 +177,11 @@ func dispatchMSSQL(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuf
 // detectGenericProtocol runs deterministic protocol detection for unclassified events:
 // SQL, FastCGI, MongoDB, Couchbase, and Memcached noreply.
 func detectGenericProtocol(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
-	if span, ignore, matched, err := matchSQL(cfg, event, requestBuffer, responseBuffer); matched {
+	if span, ignore, matched, err := matchPostgresStartup(parseCtx, event, requestBuffer, responseBuffer); matched {
+		return span, ignore, matched, err
+	}
+
+	if span, ignore, matched, err := matchSQL(parseCtx, cfg, event, requestBuffer, responseBuffer); matched {
 		return span, ignore, matched, err
 	}
 
@@ -200,18 +204,46 @@ func detectGenericProtocol(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, e
 	return request.Span{}, false, false, nil
 }
 
-func matchSQL(cfg *config.EBPFTracer, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+// caches the connection's database name for the SQL spans that follow
+func matchPostgresStartup(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	if parseCtx.postgresDBNames == nil {
+		return request.Span{}, false, false, nil
+	}
+
+	if db, ok := parsePostgresStartup(requestBuffer); ok {
+		parseCtx.postgresDBNames.Add(event.ConnInfo, db)
+		return request.Span{}, true, true, nil
+	}
+
+	// caught reversed in the middle of communication
+	if db, ok := parsePostgresStartup(responseBuffer); ok {
+		parseCtx.postgresDBNames.Add(reverseTCPConnInfo(event.ConnInfo), db)
+		return request.Span{}, true, true, nil
+	}
+
+	return request.Span{}, false, false, nil
+}
+
+func matchSQL(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
 	op, table, sql, kind := detectSQLPayload(cfg.HeuristicSQLDetect, requestBuffer)
 
 	if validSQL(op, table, kind) {
-		return TCPToSQLToSpan(event, op, table, sql, kind, "", nil), false, true, nil
+		span := TCPToSQLToSpan(event, op, table, sql, kind, "", nil)
+		if kind == request.DBPostgres {
+			span.DBNamespace = postgresDBForConn(parseCtx, event.ConnInfo)
+		}
+		return span, false, true, nil
 	}
 
 	op, table, sql, kind = detectSQLPayload(cfg.HeuristicSQLDetect, responseBuffer)
 
 	if validSQL(op, table, kind) {
 		reverseTCPEvent(event)
-		return TCPToSQLToSpan(event, op, table, sql, kind, "", nil), false, true, nil
+		span := TCPToSQLToSpan(event, op, table, sql, kind, "", nil)
+		if kind == request.DBPostgres {
+			span.DBNamespace = postgresDBForConn(parseCtx, event.ConnInfo)
+		}
+		return span, false, true, nil
 	}
 
 	return request.Span{}, false, false, nil

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -220,7 +220,7 @@ func matchPostgresStartup(parseCtx *EBPFParseContext, event *TCPRequestInfo, req
 	return request.Span{}, false, false, nil
 }
 
-func matchSQL(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+func matchSQL(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
 	if span, ignore, matched, err := matchPostgresStartup(parseCtx, event, requestBuffer, responseBuffer); matched {
 		return span, ignore, matched, err
 	}

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -177,10 +177,6 @@ func dispatchMSSQL(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuf
 // detectGenericProtocol runs deterministic protocol detection for unclassified events:
 // SQL, FastCGI, MongoDB, Couchbase, and Memcached noreply.
 func detectGenericProtocol(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
-	if span, ignore, matched, err := matchPostgresStartup(parseCtx, event, requestBuffer, responseBuffer); matched {
-		return span, ignore, matched, err
-	}
-
 	if span, ignore, matched, err := matchSQL(parseCtx, cfg, event, requestBuffer, responseBuffer); matched {
 		return span, ignore, matched, err
 	}
@@ -225,6 +221,10 @@ func matchPostgresStartup(parseCtx *EBPFParseContext, event *TCPRequestInfo, req
 }
 
 func matchSQL(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
+	if span, ignore, matched, err := matchPostgresStartup(parseCtx, event, requestBuffer, responseBuffer); matched {
+		return span, ignore, matched, err
+	}
+
 	op, table, sql, kind := detectSQLPayload(cfg.HeuristicSQLDetect, requestBuffer)
 
 	if validSQL(op, table, kind) {

--- a/pkg/ebpf/common/tcp_detect_transform_test.go
+++ b/pkg/ebpf/common/tcp_detect_transform_test.go
@@ -68,6 +68,59 @@ func TestReadTCPRequestIntoSpan_SQLServerTrafficIsServerSpan(t *testing.T) {
 	assert.Equal(t, "accounts", span.Path)
 }
 
+func pgWireMsg(typ byte, body string) []byte {
+	msg := binary.BigEndian.AppendUint32([]byte{typ}, uint32(4+len(body)+1))
+	msg = append(msg, body...)
+	return append(msg, 0)
+}
+
+func TestReadTCPRequestIntoSpan_PostgresStartupSetsDBNamespace(t *testing.T) {
+	cfg := config.EBPFTracer{HeuristicSQLDetect: true, PostgresPreparedStatementsCacheSize: 16}
+	ctx := NewEBPFParseContext(&cfg, nil, nil)
+	fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+
+	readSpan := func(t *testing.T, r TCPRequestInfo) (request.Span, bool) {
+		binaryRecord := bytes.Buffer{}
+		require.NoError(t, binary.Write(&binaryRecord, binary.LittleEndian, r))
+		span, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &ringbuf.Record{RawSample: binaryRecord.Bytes()}, &fltr)
+		require.NoError(t, err)
+		return span, ignore
+	}
+
+	startup := makeTCPReq(string(pgStartupMessage("user", "postgres", "database", "mydb")), 5432)
+	_, ignore := readSpan(t, startup)
+	assert.True(t, ignore, "startup message should not produce a span")
+
+	t.Run("heuristic SQL path", func(t *testing.T) {
+		query := makeTCPReq(string(pgWireMsg(kPostgresQuery, "SELECT * FROM accounts")), 5432)
+		span, ignore := readSpan(t, query)
+		assert.False(t, ignore)
+		assert.Equal(t, request.EventTypeSQLClient, span.Type)
+		assert.Equal(t, "SELECT", span.Method)
+		assert.Equal(t, "mydb", span.DBNamespace)
+	})
+
+	t.Run("kernel-assigned Postgres path", func(t *testing.T) {
+		query := makeTCPReq(string(pgWireMsg(kPostgresQuery, "SELECT * FROM accounts")), 5432)
+		query.ProtocolType = ProtocolTypePostgres
+		resp := pgWireMsg(kPostgresCommand, "SELECT 1")
+		query.RespLen = uint32(len(resp))
+		copy(query.Rbuf[:], resp)
+		span, ignore := readSpan(t, query)
+		assert.False(t, ignore)
+		assert.Equal(t, request.EventTypeSQLClient, span.Type)
+		assert.Equal(t, "SELECT", span.Method)
+		assert.Equal(t, "mydb", span.DBNamespace)
+	})
+
+	t.Run("unknown connection has no namespace", func(t *testing.T) {
+		query := makeTCPReq(string(pgWireMsg(kPostgresQuery, "SELECT * FROM accounts")), 5433)
+		span, ignore := readSpan(t, query)
+		assert.False(t, ignore)
+		assert.Empty(t, span.DBNamespace)
+	})
+}
+
 func TestTCPReqParsing(t *testing.T) {
 	sql := "Not a sql or any known protocol"
 	r := makeTCPReq(sql, 343534)

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -1184,6 +1184,9 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			attrs = append(attrs, request.ErrorType(span.SQLError.SQLState))
 			attrs = append(attrs, attributes.DBResponseErrorAttr(optionalAttrs, span.SQLErrorDescription())...)
 		}
+		if span.DBNamespace != "" {
+			attrs = append(attrs, request.DBNamespace(span.DBNamespace))
+		}
 	case request.EventTypeRedisServer, request.EventTypeRedisClient:
 		attrs = []attribute.KeyValue{
 			request.ServerAddr(request.HostAsServer(span)),


### PR DESCRIPTION
## Summary

postgres: cache db namespace on client startup

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
