### PR TITLE
fix: never log structs carrying the process environment

### DIFF
--- a/pkg/appolly/app/svc/svc.go
+++ b/pkg/appolly/app/svc/svc.go
@@ -142,7 +142,8 @@ func (i *Attrs) GetUID() UID {
 	return i.UID
 }
 
-func (i *Attrs) String() string {
+// value receiver so nested Attrs values (e.g. Span.Service) never reflection-dump EnvVars
+func (i Attrs) String() string {
 	return i.Job()
 }
 

--- a/pkg/appolly/app/svc/svc.go
+++ b/pkg/appolly/app/svc/svc.go
@@ -4,6 +4,8 @@
 package svc // import "go.opentelemetry.io/obi/pkg/appolly/app/svc"
 
 import (
+	"log/slog"
+
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 
@@ -142,9 +144,15 @@ func (i *Attrs) GetUID() UID {
 	return i.UID
 }
 
-// value receiver so nested Attrs values (e.g. Span.Service) never reflection-dump EnvVars
+// String uses a value receiver so nested Attrs values (e.g. Span.Service) never reflection-dump EnvVars
 func (i Attrs) String() string {
 	return i.Job()
+}
+
+// LogValue implements slog.LogValuer: JSON handlers marshal exported fields
+// instead of calling String, so without it they would emit EnvVars
+func (i Attrs) LogValue() slog.Value {
+	return slog.StringValue(i.Job())
 }
 
 func (i *Attrs) Job() string {

--- a/pkg/appolly/app/svc/svc_test.go
+++ b/pkg/appolly/app/svc/svc_test.go
@@ -4,6 +4,7 @@
 package svc
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,4 +13,21 @@ import (
 func TestToString(t *testing.T) {
 	assert.Equal(t, "thens/thename", (&Attrs{UID: UID{Namespace: "thens", Name: "thename"}}).String())
 	assert.Equal(t, "thename", (&Attrs{UID: UID{Name: "thename"}}).String())
+}
+
+func TestFormattingExcludesEnvVars(t *testing.T) {
+	a := Attrs{
+		UID:     UID{Namespace: "ns", Name: "svc"},
+		EnvVars: map[string]string{"SOME_VAR": "some-value"},
+	}
+	nested := struct{ Service Attrs }{Service: a}
+
+	for name, out := range map[string]string{
+		"value":   fmt.Sprintf("%+v", a),
+		"pointer": fmt.Sprintf("%+v", &a),
+		"nested":  fmt.Sprintf("%+v", nested),
+	} {
+		assert.NotContains(t, out, "some-value", name)
+		assert.NotContains(t, out, "SOME_VAR", name)
+	}
 }

--- a/pkg/appolly/app/svc/svc_test.go
+++ b/pkg/appolly/app/svc/svc_test.go
@@ -4,7 +4,10 @@
 package svc
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,5 +32,30 @@ func TestFormattingExcludesEnvVars(t *testing.T) {
 	} {
 		assert.NotContains(t, out, "some-value", name)
 		assert.NotContains(t, out, "SOME_VAR", name)
+	}
+}
+
+// the JSON handler does not use String(): without LogValue it marshals every exported field
+func TestSlogExcludesEnvVars(t *testing.T) {
+	a := Attrs{
+		UID:     UID{Namespace: "ns", Name: "svc"},
+		EnvVars: map[string]string{"SOME_VAR": "some-value"},
+	}
+
+	for name, newHandler := range map[string]func(io.Writer) slog.Handler{
+		"text": func(w io.Writer) slog.Handler { return slog.NewTextHandler(w, nil) },
+		"json": func(w io.Writer) slog.Handler { return slog.NewJSONHandler(w, nil) },
+	} {
+		var buf bytes.Buffer
+		log := slog.New(newHandler(&buf))
+
+		log.Info("value", "service", a)
+		log.Info("pointer", "service", &a)
+		log.With("service", &a).Info("with")
+
+		out := buf.String()
+		assert.NotContains(t, out, "some-value", name)
+		assert.NotContains(t, out, "SOME_VAR", name)
+		assert.Contains(t, out, "ns/svc", name)
 	}
 }

--- a/pkg/appolly/discover/watcher_proc.go
+++ b/pkg/appolly/discover/watcher_proc.go
@@ -170,7 +170,7 @@ func (pa *pollAccounter) run(ctx context.Context) {
 			log.Warn("can't get system processes", "error", err)
 		} else {
 			if events := pa.snapshot(procs); len(events) > 0 {
-				log.Debug("new process watching events", "events", events)
+				log.Debug("new process watching events", "len", len(events))
 				pa.output.Send(events)
 			}
 		}

--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -156,7 +156,7 @@ func (pf *PIDsFilter) Filter(inputSpans []request.Span) []request.Span {
 	if len(outputSpans) != len(inputSpans) {
 		pf.log.Debug("filtered spans from processes that did not match discovery",
 			"function", "PIDsFilter.Filter", "inLen", len(inputSpans), "outLen", len(outputSpans),
-			"pids", pf.current, "spans", inputSpans,
+			"pids", pf.current,
 		)
 	}
 	return outputSpans

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -1289,7 +1289,7 @@ func (mr *MetricsReporter) onSpan(spans []request.Span) {
 		reporter, err := mr.reporters.For(&s.Service)
 		if err != nil {
 			mlog().Error("unexpected error creating OTEL resource. Ignoring metric",
-				"error", err, "service", s.Service)
+				"error", err, "service", s.Service.UID)
 			continue
 		}
 		reporter.record(s, mr)

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -468,7 +468,7 @@ func (mr *SvcGraphMetricsReporter) onSpan(spans []request.Span) {
 		reporter, err := mr.reporters.For(&s.Service)
 		if err != nil {
 			mr.log.Error("unexpected error creating OTEL resource. Ignoring metric",
-				"error", err, "service", s.Service)
+				"error", err, "service", s.Service.UID)
 			continue
 		}
 		reporter.record(s, mr)

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -318,11 +318,11 @@ mainLoop:
 		case podEvent := <-md.podsInfoCh:
 			switch podEvent.Type {
 			case EventCreated:
-				md.log.Debug("created pod event", "event", podEvent.Obj)
+				md.log.Debug("created pod event", "pod", podEvent.Obj.Name, "namespace", podEvent.Obj.Namespace)
 				md.handlePodUpdateEvent(podEvent.Obj)
 			case EventDeleted:
 				md.cleanupPodData(podEvent.Obj)
-				md.log.Debug("deleted pod event", "event", podEvent.Obj)
+				md.log.Debug("deleted pod event", "pod", podEvent.Obj.Name, "namespace", podEvent.Obj.Namespace)
 			}
 		}
 	}
@@ -339,7 +339,7 @@ func (md *procEventMetadataDecorator) getContainerInfo(pid app.PID) (container.I
 }
 
 func (md *procEventMetadataDecorator) handlePodUpdateEvent(pod *informer.ObjectMeta) {
-	md.log.Debug("pod update event", "pod", pod)
+	md.log.Debug("pod update event", "pod", pod.Name, "namespace", pod.Namespace)
 	for _, cnt := range pod.Pod.Containers {
 		md.log.Debug("looking up running process for pod container", "container", cnt.Id)
 		if peMap, ok := md.tracker.info(cnt.Id); ok {


### PR DESCRIPTION
## Summary

Spans and serviceAttrs embed EnvVars which, when logged, dumps the whole environ of the process.
Log uids and counts instead, also give Attrs a value-receiver String() so nested values can't dump everything either

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
