### PR TITLE
Support stable declarative config scope

### DIFF
--- a/cmd/check-config-v2-parity/main.go
+++ b/cmd/check-config-v2-parity/main.go
@@ -79,7 +79,14 @@ func mustEq(cur map[string]any, ex map[string]any, curPath []string, exPath []st
 		return fmt.Errorf("missing example key %v", exPath)
 	}
 
-	if fmt.Sprintf("%v", cv) != fmt.Sprintf("%v", ev) {
+	current := fmt.Sprintf("%v", cv)
+	example := fmt.Sprintf("%v", ev)
+	if len(curPath) == 1 && curPath[0] == "log_level" && len(exPath) == 1 && exPath[0] == "log_level" {
+		if strings.EqualFold(current, example) {
+			return nil
+		}
+	}
+	if current != example {
 		return fmt.Errorf("mismatch current %v=%v example %v=%v", curPath, cv, exPath, ev)
 	}
 	return nil
@@ -561,7 +568,7 @@ func parityChecks() []parityCheck {
 
 		{[]string{"log_config"}, []string{"obi", "daemon", "logging", "config_format"}},
 		{[]string{"log_format"}, []string{"obi", "daemon", "logging", "format"}},
-		{[]string{"log_level"}, []string{"obi", "daemon", "logging", "level"}},
+		{[]string{"log_level"}, []string{"log_level"}},
 		{[]string{"trace_printer"}, []string{"obi", "daemon", "logging", "debug_trace_output"}},
 		{[]string{"shutdown_timeout"}, []string{"obi", "daemon", "shutdown", "timeout"}},
 		{[]string{"profile_port"}, []string{"obi", "daemon", "profiling", "port"}},

--- a/devdocs/config/version-2.0/config-v2.md
+++ b/devdocs/config/version-2.0/config-v2.md
@@ -127,10 +127,27 @@ To ground this redesign in user needs, we start with the top user journeys and e
 
 ### High-level shape
 
-At a high level, the target configuration shape is a standard [OpenTelemetry declarative configuration](https://github.com/open-telemetry/opentelemetry-configuration) document with a root `file_format` field and top-level sections for `resource`, `propagator`, `tracer_provider`, and `meter_provider`.
+At a high level, the target configuration shape is a standard [OpenTelemetry declarative configuration](https://github.com/open-telemetry/opentelemetry-configuration) document with a root `file_format` field and top-level sections for `resource`, `propagator`, `tracer_provider`, `meter_provider`, and `log_level`.
 All OBI-specific configuration lives under `extensions.obi`.
 
 The root `file_format` follows the declarative schema version (`major.minor`), not the upstream release tag. For the current stable declarative shape, the correct value is `file_format: "1.0"` rather than `1.0.0`, `1.0.0-rc.3`, or `1.0.0-rc.1`.
+OBI validates this value and rejects unsupported declarative file-format versions.
+
+### Stable declarative support scope
+
+OBI adopts the standard declarative fields incrementally. For the first stable v2 configuration milestone, OBI supports:
+
+| Declarative section | Stable v2 behavior |
+| --- | --- |
+| `file_format` | Required and restricted to `"1.0"`. |
+| `resource` | Partial: string `host.name` overrides OBI hostname and string `host.id` overrides OBI host ID. Other attributes are currently ignored. |
+| `tracer_provider.sampler` | Partial: `always_on`, `always_off`, `trace_id_ratio_based`, and simple `parent_based` roots that use those samplers. |
+| `tracer_provider.processors` | Partial: one batch processor with one OTLP/gRPC exporter. |
+| `meter_provider.readers` | Partial: at most one periodic OTLP/gRPC reader and one Prometheus development pull reader. |
+| `log_level` | Supported for OBI daemon logging. OTel `trace*` and `debug*` severities map to `DEBUG`; `info*` to `INFO`; `warn*` to `WARN`; `error*` and `fatal*` to `ERROR`. `extensions.obi.daemon.logging.level` is not part of v2; use the top-level field. |
+| `propagator`, `attribute_limits`, `disabled`, `distribution`, `instrumentation/development`, `logger_provider` | Parsed by the declarative model but not applied to OBI runtime behavior in the stable milestone. |
+
+Environment-variable substitution depends on the loader. The upstream `otelconf/x.ParseYAML` path expands `${VAR}`, `${env:VAR}`, and `${VAR:-fallback}` before decoding. OBI's internal `schema.ParseStandaloneYAML` parser decodes the supplied bytes directly, so callers using that parser must perform any desired substitution before calling it.
 
 The `extensions.obi` block is divided by deployment scope:
 
@@ -139,6 +156,7 @@ The `extensions.obi` block is divided by deployment scope:
 
 ```yaml
 file_format: '1.0'
+log_level: info
 
 resource: {}
 propagator: {}
@@ -557,7 +575,7 @@ The name `daemon` was chosen over `process` (too generic), `agent` (overloaded i
 
 `daemon` contains:
 
-- `logging`: OBI process log level, format, startup configuration output format, and debug trace output mode.
+- `logging`: OBI process log format, startup configuration output format, and debug trace output mode. Use top-level `log_level` for OBI process log verbosity.
 - `profiling`: optional pprof endpoint for the OBI process.
 - `shutdown`: graceful shutdown timeout.
 - `internal_metrics`: OBI daemon's own metrics export (Prometheus or OTLP).
@@ -669,7 +687,7 @@ Important mapping notes:
 | `javaagent.enabled` | `extensions.obi.capture.runtimes.java.enabled` | Simplified to boolean |
 | `log_config` | `extensions.obi.daemon.logging.config_format` | Move + rename |
 | `log_format` | `extensions.obi.daemon.logging.format` | Move + rename |
-| `log_level` | `extensions.obi.daemon.logging.level` | Move |
+| `log_level` | Top-level `log_level` | Move to standard field |
 | `metrics.features` | `extensions.obi.capture.instrumentation.<protocol>.enabled.metrics` + `extensions.obi.capture.network.capture.enabled` + `extensions.obi.capture.network.stats.{enabled,features}` | Split mapping |
 | `name_resolver.cache_expiry` | `extensions.obi.enrich.service_name.cache.ttl` | Move + rename |
 | `name_resolver.cache_len` | `extensions.obi.enrich.service_name.cache.size` | Move + rename |

--- a/devdocs/config/version-2.0/examples/default-configuration.yaml
+++ b/devdocs/config/version-2.0/examples/default-configuration.yaml
@@ -5,6 +5,9 @@
 # This tracks the declarative schema major.minor, not an upstream release tag.
 file_format: '1.0'
 
+# Standard OTel declarative log level for OBI daemon logging.
+log_level: info
+
 # Standard OTel resource attributes (service.name, service.namespace, etc.).
 resource: {}
 # Global propagation format configuration (tracecontext, baggage, b3, etc.).
@@ -674,13 +677,12 @@ extensions:
           workers: 8
           channel_len: 500
 
-    # daemon controls the OBI process itself: logging, profiling, shutdown, and internal metrics.
+    # daemon controls the OBI process itself: log formatting, profiling, shutdown, and internal metrics.
     # Standalone-mode only: not valid in Collector receiver deployments.
     # In receiver mode the Collector manages these concerns.
     daemon:
-      # Logging behavior and startup configuration output.
+      # Logging output behavior. Use top-level log_level for verbosity.
       logging:
-        level: INFO
         format: text
         config_format: ""
         debug_trace_output: disabled

--- a/devdocs/config/version-2.0/migration.md
+++ b/devdocs/config/version-2.0/migration.md
@@ -27,10 +27,20 @@ It will be up to these callers to determine:
 
 ### Integration with `otelconf`
 
-It is assumed that users that need SDK will use the `go.opentelemetry.io/contrib/otelconf` package to parse top-level objects of the declarative config accordingly.
-SDK object construction is outside the v2 configuration package scope and configuration for that portion of the configuration will be ignored.
-The OBI v2 configuration package only parses and validates `extensions.obi`.
-It does not merge or translate `instrumentation/development` into OBI-owned settings.
+The OBI v2 configuration package models top-level OpenTelemetry declarative sections with `go.opentelemetry.io/contrib/otelconf/x` and imports the narrow subset OBI supports directly:
+
+- `file_format` is validated and currently restricted to `"1.0"`.
+- `resource` imports string `host.name` and `host.id`.
+- `tracer_provider` imports the supported sampler subset and one batch OTLP/gRPC span exporter.
+- `meter_provider` imports one periodic OTLP/gRPC reader and one Prometheus development pull reader.
+- Top-level `log_level` configures OBI daemon logging.
+
+The v2 extension does not define `extensions.obi.daemon.logging.level`; OBI log
+verbosity is sourced only from the standard top-level `log_level` field.
+
+SDK object construction is outside the v2 configuration package scope. Unsupported declarative sections and fields are parsed when `otelconf/x` models them, but they are not merged into OBI-owned runtime settings. OBI also does not merge or translate `instrumentation/development` into OBI-owned settings.
+
+Environment-variable substitution is loader-specific. `otelconf/x.ParseYAML` expands `${VAR}`, `${env:VAR}`, and `${VAR:-fallback}` before decoding. The internal OBI `schema.ParseStandaloneYAML` parser decodes the bytes it is given directly, so callers using that parser must perform any desired substitution first.
 
 ### Deployment-mode validation
 
@@ -49,7 +59,7 @@ The presence of `enrich`, `correlation`, and `daemon` is not required — these 
 
 Based on the structure of the configuration, the version of that configuration can be determined from:
 
-- Root `version` identifies OTel declarative document contract.
+- Root `file_format` identifies the OTel declarative document contract.
 - `extensions.obi.version` identifies OBI extension contract.
 
 From this, the v2 configuration package will behave as follows:

--- a/devdocs/config/version-2.0/obi-extension.schema.json
+++ b/devdocs/config/version-2.0/obi-extension.schema.json
@@ -894,20 +894,9 @@
       "properties": {
         "logging": {
           "type": "object",
-          "description": "Logging behavior, startup configuration output, and debug-output controls.",
+          "description": "Log output formatting, startup configuration output, and debug-output controls.",
           "additionalProperties": false,
           "properties": {
-            "level": {
-              "type": "string",
-              "enum": [
-                "DEBUG",
-                "INFO",
-                "WARN",
-                "ERROR"
-              ],
-              "default": "INFO",
-              "description": "OBI log level.\nValues include: `DEBUG`, `INFO`, `WARN`, `ERROR`.\nIf omitted, `INFO` is used.\n"
-            },
             "format": {
               "type": "string",
               "enum": [

--- a/internal/config/convert/export.go
+++ b/internal/config/convert/export.go
@@ -56,6 +56,7 @@ func RuntimeToV2(cfg *obi.Config) (*schema.Document, *schema.Extension) {
 		},
 		Extensions: schema.Extensions{OBI: ext},
 	}
+	doc.SetLogLevel(logLevel(cfg.LogLevel))
 
 	return doc, ext
 }
@@ -680,7 +681,6 @@ func correlation(cfg *obi.Config) *schema.Correlation {
 func daemon(cfg *obi.Config) *schema.Daemon {
 	return &schema.Daemon{
 		Logging: schema.Logging{
-			Level:            schema.LogLevel(cfg.LogLevel),
 			Format:           logFormat(cfg.LogFormat),
 			ConfigFormat:     configFormat(cfg.LogConfig),
 			DebugTraceOutput: cfg.TracePrinter,
@@ -711,6 +711,19 @@ func daemon(cfg *obi.Config) *schema.Daemon {
 				},
 			},
 		},
+	}
+}
+
+func logLevel(level obi.LogLevel) otelconfx.SeverityNumber {
+	switch level {
+	case obi.LogLevelDebug:
+		return otelconfx.SeverityNumberDebug
+	case obi.LogLevelWarn:
+		return otelconfx.SeverityNumberWarn
+	case obi.LogLevelError:
+		return otelconfx.SeverityNumberError
+	default:
+		return otelconfx.SeverityNumberInfo
 	}
 }
 

--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 
+	otelconfx "go.opentelemetry.io/contrib/otelconf/x"
+
 	"go.opentelemetry.io/obi/internal/config/schema"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/config"
@@ -33,6 +35,8 @@ func TestRuntimeToV2DefaultConfig(t *testing.T) {
 	doc, ext := RuntimeToV2(nil)
 
 	require.Equal(t, "1.0", doc.FileFormat)
+	require.NotNil(t, doc.LogLevel)
+	require.Equal(t, otelconfx.SeverityNumberInfo, *doc.LogLevel)
 	require.Same(t, ext, doc.Extensions.OBI)
 	require.NotNil(t, doc.Resource)
 	require.NotNil(t, doc.Propagator)
@@ -116,7 +120,6 @@ func TestRuntimeToV2DefaultConfig(t *testing.T) {
 	require.Equal(t, 128, value(t, ext.Correlation, "log_trace_annotation", "cache", "size"))
 	require.Equal(t, 8, value(t, ext.Correlation, "log_trace_annotation", "async_writer", "workers"))
 
-	require.Equal(t, schema.LogLevelInfo, value(t, ext.Daemon, "logging", "level"))
 	require.Equal(t, schema.LogFormatText, value(t, ext.Daemon, "logging", "format"))
 	require.Equal(t, schema.ConfigFormatUnset, value(t, ext.Daemon, "logging", "config_format"))
 	require.Equal(t, debug.TracePrinterDisabled, value(t, ext.Daemon, "logging", "debug_trace_output"))
@@ -424,7 +427,8 @@ func TestRuntimeToV2CustomConfig(t *testing.T) {
 	require.Equal(t, 905, value(t, ext.Correlation, "log_trace_annotation", "async_writer", "workers"))
 	require.Equal(t, 906, value(t, ext.Correlation, "log_trace_annotation", "async_writer", "channel_len"))
 
-	require.Equal(t, schema.LogLevelDebug, value(t, ext.Daemon, "logging", "level"))
+	require.NotNil(t, doc.LogLevel)
+	require.Equal(t, otelconfx.SeverityNumberDebug, *doc.LogLevel)
 	require.Equal(t, schema.LogFormatJSON, value(t, ext.Daemon, "logging", "format"))
 	require.Equal(t, schema.ConfigFormatYAML, value(t, ext.Daemon, "logging", "config_format"))
 	require.Equal(t, debug.TracePrinterJSON, value(t, ext.Daemon, "logging", "debug_trace_output"))
@@ -866,6 +870,9 @@ func TestRuntimeToV2DocumentParsesAsStandaloneV2(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, parsedDoc.TracerProvider.Processors)
 	require.NotEmpty(t, parsedDoc.MeterProvider.Readers)
+	require.True(t, parsedDoc.HasLogLevel())
+	require.NotNil(t, parsedDoc.LogLevel)
+	require.Equal(t, otelconfx.SeverityNumberInfo, *parsedDoc.LogLevel)
 	require.NotNil(t, parsedExt.Capture.Rules)
 	require.Equal(t, "1.0", parsedDoc.FileFormat)
 	require.Equal(t, schema.SupportedVersion, parsedExt.Version)

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -1539,9 +1539,6 @@ func applyV2Daemon(cfg *obi.Config, daemon *schema.Daemon) {
 
 func applyFullV2Daemon(cfg *obi.Config, daemon schema.Daemon) {
 	if !zeroValue(daemon.Logging) {
-		if daemon.Logging.Level != "" {
-			cfg.LogLevel = obi.LogLevel(daemon.Logging.Level)
-		}
 		if daemon.Logging.Format != "" {
 			cfg.LogFormat = obi.LogFormat(daemon.Logging.Format)
 		}
@@ -1572,9 +1569,6 @@ func applyFullV2Daemon(cfg *obi.Config, daemon schema.Daemon) {
 
 func applyPartialV2Daemon(cfg *obi.Config, daemon schema.Daemon) {
 	if !zeroValue(daemon.Logging) {
-		if daemon.Logging.Level != "" {
-			cfg.LogLevel = obi.LogLevel(daemon.Logging.Level)
-		}
 		if daemon.Logging.Format != "" {
 			cfg.LogFormat = obi.LogFormat(daemon.Logging.Format)
 		}
@@ -1629,8 +1623,7 @@ func completeDaemon(daemon schema.Daemon) bool {
 }
 
 func completeDaemonLogging(logging schema.Logging) bool {
-	return logging.Level != "" &&
-		logging.Format != "" &&
+	return logging.Format != "" &&
 		logging.DebugTraceOutput != ""
 }
 

--- a/internal/config/convert/import_document.go
+++ b/internal/config/convert/import_document.go
@@ -5,7 +5,9 @@ package convert // import "go.opentelemetry.io/obi/internal/config/convert"
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	otelconfx "go.opentelemetry.io/contrib/otelconf/x"
@@ -32,8 +34,41 @@ func DocumentToRuntime(src *schema.Document) (*obi.Config, error) {
 	applyV2Resource(cfg, src.Resource)
 	applyV2TracerProvider(cfg, src.TracerProvider)
 	applyV2MeterProvider(cfg, src.MeterProvider)
+	if err := applyV2LogLevel(cfg, src); err != nil {
+		return nil, err
+	}
 
 	return cfg, nil
+}
+
+func applyV2LogLevel(cfg *obi.Config, src *schema.Document) error {
+	if !src.HasLogLevel() || src.LogLevel == nil {
+		return nil
+	}
+
+	level, err := logLevelFromSeverityNumber(*src.LogLevel)
+	if err != nil {
+		return err
+	}
+	cfg.LogLevel = level
+	return nil
+}
+
+func logLevelFromSeverityNumber(severity otelconfx.SeverityNumber) (obi.LogLevel, error) {
+	switch strings.ToLower(string(severity)) {
+	case "trace", "trace2", "trace3", "trace4",
+		"debug", "debug2", "debug3", "debug4":
+		return obi.LogLevelDebug, nil
+	case "info", "info2", "info3", "info4":
+		return obi.LogLevelInfo, nil
+	case "warn", "warn2", "warn3", "warn4":
+		return obi.LogLevelWarn, nil
+	case "error", "error2", "error3", "error4",
+		"fatal", "fatal2", "fatal3", "fatal4":
+		return obi.LogLevelError, nil
+	default:
+		return "", fmt.Errorf("unsupported log_level %q", severity)
+	}
 }
 
 func applyV2Resource(cfg *obi.Config, resource *otelconfx.Resource) {

--- a/internal/config/convert/import_document_test.go
+++ b/internal/config/convert/import_document_test.go
@@ -33,6 +33,8 @@ func TestDocumentToRuntimeImportsExportedDocumentSections(t *testing.T) {
 	cfg.Traces.SamplerConfig.Name = services.SamplerTraceIDRatio
 	cfg.Traces.SamplerConfig.Arg = "0.25"
 
+	cfg.LogLevel = obi.LogLevelDebug
+
 	cfg.OTELMetrics.MetricsEndpoint = "https://metrics.example:4317"
 	cfg.OTELMetrics.Interval = 914 * time.Millisecond
 	cfg.OTELMetrics.HistogramAggregation = otelcfg.HistogramAggregationExponential
@@ -57,6 +59,7 @@ func TestDocumentToRuntimeImportsExportedDocumentSections(t *testing.T) {
 		Name: services.SamplerTraceIDRatio,
 		Arg:  "0.25",
 	}, got.Traces.SamplerConfig)
+	require.Equal(t, obi.LogLevelDebug, got.LogLevel)
 
 	require.Equal(t, "https://metrics.example:4317", got.OTELMetrics.MetricsEndpoint)
 	require.Equal(t, otelcfg.ProtocolGRPC, got.OTELMetrics.MetricsProtocol)
@@ -88,6 +91,88 @@ func TestDocumentToRuntimePreservesDefaultsForMissingDocumentSections(t *testing
 	require.Equal(t, obi.DefaultConfig.OTELMetrics.GetInterval(), got.OTELMetrics.GetInterval())
 	require.Equal(t, obi.DefaultConfig.OTELMetrics.HistogramAggregation, got.OTELMetrics.HistogramAggregation)
 	require.Equal(t, obi.DefaultConfig.Prometheus.Port, got.Prometheus.Port)
+}
+
+func TestDocumentToRuntimeImportsTopLevelLogLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		level string
+		want  obi.LogLevel
+	}{
+		{name: "trace", level: "trace4", want: obi.LogLevelDebug},
+		{name: "debug", level: "debug", want: obi.LogLevelDebug},
+		{name: "info", level: "info", want: obi.LogLevelInfo},
+		{name: "warn", level: "warn3", want: obi.LogLevelWarn},
+		{name: "error", level: "error2", want: obi.LogLevelError},
+		{name: "fatal", level: "fatal", want: obi.LogLevelError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc, _, err := schema.ParseStandaloneYAML([]byte(`
+file_format: "1.0"
+log_level: ` + tt.level + `
+extensions:
+  obi:
+    version: "2.0"
+    daemon:
+      logging:
+        format: json
+`))
+			require.NoError(t, err)
+
+			got, err := DocumentToRuntime(doc)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.want, got.LogLevel)
+			require.Equal(t, obi.LogFormatJSON, got.LogFormat)
+		})
+	}
+}
+
+func TestDocumentToRuntimeUsesDefaultLogLevelWhenTopLevelLogLevelOmitted(t *testing.T) {
+	t.Parallel()
+
+	doc, _, err := schema.ParseStandaloneYAML([]byte(`
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    daemon:
+      logging:
+        format: json
+`))
+	require.NoError(t, err)
+	require.False(t, doc.HasLogLevel())
+	require.NotNil(t, doc.LogLevel)
+
+	got, err := DocumentToRuntime(doc)
+	require.NoError(t, err)
+
+	require.Equal(t, obi.DefaultConfig.LogLevel, got.LogLevel)
+	require.Equal(t, obi.LogFormatJSON, got.LogFormat)
+}
+
+func TestDocumentToRuntimeRejectsUnsupportedTopLevelLogLevel(t *testing.T) {
+	t.Parallel()
+
+	doc, _, err := schema.ParseStandaloneYAML([]byte(`
+file_format: "1.0"
+log_level: verbose
+extensions:
+  obi:
+    version: "2.0"
+`))
+	require.NoError(t, err)
+
+	_, err = DocumentToRuntime(doc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported log_level")
+	require.Contains(t, err.Error(), "verbose")
 }
 
 func TestDocumentToRuntimeSkipsUnsupportedMetricReaderShapes(t *testing.T) {

--- a/internal/config/convert/import_test.go
+++ b/internal/config/convert/import_test.go
@@ -285,7 +285,7 @@ func TestV2ToRuntimeCustomFoundation(t *testing.T) {
 	require.Equal(t, 603, got.EBPF.LogEnricher.AsyncWriterWorkers)
 	require.Equal(t, 604, got.EBPF.LogEnricher.AsyncWriterChannelLen)
 
-	require.Equal(t, obi.LogLevelDebug, got.LogLevel)
+	require.Equal(t, obi.DefaultConfig.LogLevel, got.LogLevel)
 	require.Equal(t, obi.LogFormatJSON, got.LogFormat)
 	require.Equal(t, obi.LogConfigOptionYAML, got.LogConfig)
 	require.Equal(t, debug.TracePrinterJSON, got.TracePrinter)
@@ -748,13 +748,14 @@ func TestV2ToRuntimePartialStandaloneSectionsPreserveDefaults(t *testing.T) {
 		},
 		Daemon: &schema.Daemon{
 			Logging: schema.Logging{
-				Level: schema.LogLevelDebug,
+				Format: schema.LogFormatJSON,
 			},
 		},
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, obi.LogLevelDebug, got.LogLevel)
+	require.Equal(t, obi.DefaultConfig.LogLevel, got.LogLevel)
+	require.Equal(t, obi.LogFormatJSON, got.LogFormat)
 	require.Equal(t, obi.DefaultConfig.ShutdownTimeout, got.ShutdownTimeout)
 	require.Equal(t, obi.DefaultConfig.InternalMetrics, got.InternalMetrics)
 	require.Equal(t, obi.DefaultConfig.Prometheus.SpanMetricsServiceCacheSize, got.Prometheus.SpanMetricsServiceCacheSize)

--- a/internal/config/schema/daemon.go
+++ b/internal/config/schema/daemon.go
@@ -4,6 +4,8 @@
 package schema // import "go.opentelemetry.io/obi/internal/config/schema"
 
 import (
+	"fmt"
+
 	"go.yaml.in/yaml/v3"
 
 	"go.opentelemetry.io/obi/pkg/export/debug"
@@ -17,25 +19,6 @@ type Daemon struct {
 	Shutdown        Shutdown        `yaml:"shutdown"`
 	InternalMetrics InternalMetrics `yaml:"internal_metrics"`
 	Telemetry       DaemonTelemetry `yaml:"telemetry"`
-}
-
-// LogLevel describes daemon log verbosity.
-type LogLevel string
-
-const (
-	// LogLevelDebug enables debug logging.
-	LogLevelDebug LogLevel = "DEBUG"
-	// LogLevelInfo enables info logging.
-	LogLevelInfo LogLevel = "INFO"
-	// LogLevelWarn enables warning logging.
-	LogLevelWarn LogLevel = "WARN"
-	// LogLevelError enables error logging.
-	LogLevelError LogLevel = "ERROR"
-)
-
-// UnmarshalYAML parses and validates a daemon log level.
-func (l *LogLevel) UnmarshalYAML(value *yaml.Node) error {
-	return unmarshalEnum(value, "level", l, LogLevelDebug, LogLevelInfo, LogLevelWarn, LogLevelError)
 }
 
 // LogFormat describes daemon log encoding.
@@ -74,10 +57,18 @@ func (f *ConfigFormat) UnmarshalYAML(value *yaml.Node) error {
 
 // Logging describes daemon logging settings.
 type Logging struct {
-	Level            LogLevel           `yaml:"level"`
 	Format           LogFormat          `yaml:"format"`
 	ConfigFormat     ConfigFormat       `yaml:"config_format"`
 	DebugTraceOutput debug.TracePrinter `yaml:"debug_trace_output"`
+}
+
+// UnmarshalYAML validates daemon logging settings.
+func (l *Logging) UnmarshalYAML(value *yaml.Node) error {
+	if _, ok := mappingValue(value, "level"); ok {
+		return fmt.Errorf("unsupported daemon logging field %q; use top-level log_level", "level")
+	}
+	type plain Logging
+	return value.Decode((*plain)(l))
 }
 
 // Profiling describes daemon profiling settings.

--- a/internal/config/schema/daemon_test.go
+++ b/internal/config/schema/daemon_test.go
@@ -22,20 +22,6 @@ func TestDaemonEnumsYAML(t *testing.T) {
 		parse   func([]byte) (string, error)
 	}{
 		{
-			name:    "log level",
-			valid:   "level: WARN\n",
-			want:    string(LogLevelWarn),
-			invalid: "level: TRACE\n",
-			err:     "invalid level",
-			parse: func(data []byte) (string, error) {
-				var doc struct {
-					Level LogLevel `yaml:"level"`
-				}
-				err := yaml.Unmarshal(data, &doc)
-				return string(doc.Level), err
-			},
-		},
-		{
 			name:    "log format",
 			valid:   "format: json\n",
 			want:    string(LogFormatJSON),

--- a/internal/config/schema/errors.go
+++ b/internal/config/schema/errors.go
@@ -36,6 +36,16 @@ func (e *UnsupportedVersionError) Error() string {
 	return fmt.Sprintf("unsupported OBI config version %q", e.Version)
 }
 
+// UnsupportedFileFormatError reports an OpenTelemetry declarative file_format
+// value whose version is present but not handled by this package.
+type UnsupportedFileFormatError struct {
+	FileFormat string
+}
+
+func (e *UnsupportedFileFormatError) Error() string {
+	return fmt.Sprintf("unsupported OpenTelemetry config file_format %q", e.FileFormat)
+}
+
 // SectionNotAllowedError reports a standalone-only configuration section in a
 // receiver-embedded OBI config.
 type SectionNotAllowedError struct {

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -27,9 +27,15 @@ import (
 	otelconfx "go.opentelemetry.io/contrib/otelconf/x"
 )
 
-// SupportedVersion is the OBI configuration schema version handled by this
-// package.
-const SupportedVersion = "2.0"
+const (
+	// SupportedFileFormat is the OpenTelemetry declarative configuration file
+	// format version handled by this package.
+	SupportedFileFormat = "1.0"
+
+	// SupportedVersion is the OBI configuration schema version handled by this
+	// package.
+	SupportedVersion = "2.0"
+)
 
 const (
 	sectionEnrich      = "enrich"
@@ -46,6 +52,7 @@ const (
 type Document struct {
 	otelconfx.OpenTelemetryConfiguration `yaml:",inline"`
 	Extensions                           Extensions `yaml:"extensions"`
+	logLevelSet                          bool
 }
 
 // UnmarshalYAML decodes OpenTelemetry-owned fields with otelconf/x and the OBI
@@ -55,6 +62,7 @@ func (d *Document) UnmarshalYAML(node *yaml.Node) error {
 		Extensions Extensions `yaml:"extensions"`
 	}
 	var ext extensionDocument
+	_, logLevelSet := mappingValue(node, "log_level")
 	if err := node.Decode(&d.OpenTelemetryConfiguration); err != nil {
 		return err
 	}
@@ -62,7 +70,21 @@ func (d *Document) UnmarshalYAML(node *yaml.Node) error {
 		return err
 	}
 	d.Extensions = ext.Extensions
+	d.logLevelSet = logLevelSet
 	return nil
+}
+
+// HasLogLevel reports whether the document explicitly declared top-level
+// log_level. otelconf/x defaults omitted log_level to info, so callers need this
+// signal to avoid treating the default as user intent.
+func (d *Document) HasLogLevel() bool {
+	return d != nil && d.logLevelSet
+}
+
+// SetLogLevel assigns a top-level log_level value and marks it as explicit.
+func (d *Document) SetLogLevel(level otelconfx.SeverityNumber) {
+	d.LogLevel = &level
+	d.logLevelSet = true
 }
 
 // MarshalYAML emits the OpenTelemetry document fields and extensions. The
@@ -143,6 +165,9 @@ func ParseStandaloneYAML(data []byte) (*Document, *Extension, error) {
 		}
 		var doc Document
 		if err := decode(root, &doc); err != nil {
+			return nil, nil, err
+		}
+		if err := validateFileFormat(doc.FileFormat); err != nil {
 			return nil, nil, err
 		}
 		if doc.Extensions.OBI == nil {
@@ -241,6 +266,13 @@ func validateVersion(cfg *Extension) error {
 	}
 	if cfg.Version != SupportedVersion {
 		return &UnsupportedVersionError{Version: cfg.Version}
+	}
+	return nil
+}
+
+func validateFileFormat(fileFormat string) error {
+	if fileFormat != SupportedFileFormat {
+		return &UnsupportedFileFormatError{FileFormat: fileFormat}
 	}
 	return nil
 }

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -15,6 +15,7 @@ func TestParseStandaloneYAMLDocument(t *testing.T) {
 
 	doc, cfg, err := ParseStandaloneYAML([]byte(`
 file_format: "1.0"
+log_level: debug
 resource:
   attributes:
     - name: service.namespace
@@ -72,6 +73,9 @@ extensions:
 	require.NotNil(t, doc)
 	require.NotNil(t, cfg)
 	require.Equal(t, "1.0", doc.FileFormat)
+	require.True(t, doc.HasLogLevel())
+	require.NotNil(t, doc.LogLevel)
+	require.Equal(t, "debug", string(*doc.LogLevel))
 	require.Equal(t, SupportedVersion, cfg.Version)
 	require.NotNil(t, doc.InstrumentationDevelopment)
 	require.Len(t, doc.Resource.Attributes, 1)
@@ -99,6 +103,23 @@ extensions:
 		Outgoing: HTTPRefinementRoute{Patterns: []string{"/inventory/{id}"}},
 	}, cfg.Capture.Rules[0].Refine.HTTP.Routes)
 	require.Equal(t, AttributeFilter{Match: "5*"}, cfg.Capture.Rules[0].Refine.HTTP.Filters.Traces["status_code"])
+}
+
+func TestParseStandaloneYAMLRejectsDaemonLoggingLevel(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ParseStandaloneYAML([]byte(`
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    daemon:
+      logging:
+        level: INFO
+`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unsupported daemon logging field "level"`)
+	require.Contains(t, err.Error(), "top-level log_level")
 }
 
 func TestParseReceiverYAMLEmbedded(t *testing.T) {
@@ -208,6 +229,23 @@ extensions:
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid histogram aggregation")
 	require.Contains(t, err.Error(), "made-up")
+}
+
+func TestParseStandaloneRejectsUnsupportedFileFormat(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ParseStandaloneYAML([]byte(`
+file_format: "1.1"
+extensions:
+  obi:
+    version: "2.0"
+    capture: {}
+`))
+
+	var unsupported *UnsupportedFileFormatError
+	require.ErrorAs(t, err, &unsupported)
+	require.Equal(t, "1.1", unsupported.FileFormat)
+	require.Contains(t, err.Error(), "file_format")
 }
 
 func TestReceiverRejectsStandaloneSections(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #594.

This PR implements the stable OBI v2 declarative configuration scope agreed in the July 2026 OBI SIG discussion:

- validate top-level `file_format` and restrict the supported declarative document version to `"1.0"`
- import and export OBI daemon verbosity through the standard top-level `log_level` field
- reject `extensions.obi.daemon.logging.level` so v2 has a single log-level location
- document the stable declarative support matrix and current environment-variable substitution behavior
- add `log_level: info` to the v2 default configuration example

The remaining accepted work is split into focused follow-ups:

- #2626 tracks fuller global `resource` support
- #923 tracks per-process/resource-by-selection declarative configuration
- #2627 tracks richer exporter, processor, and reader support after stable v2
- #2628 tracks later `attribute_limits` support

## Validation

- `go test -p 1 ./internal/config/schema ./internal/config/convert`
- `go test -p 1 ./cmd/check-config-v2-artifacts ./cmd/check-config-v2-parity`
- `make check-config-v2-artifacts`
- `make lint-markdown`
- `jq empty devdocs/config/version-2.0/obi-extension.schema.json`