### PR TITLE
Fix / Document invalid enum attribute values and enforce weaver `undefined_enum_variant`

### DIFF
--- a/internal/test/integration/docker-compose-ruby-3.0.2-puma5.yml
+++ b/internal/test/integration/docker-compose-ruby-3.0.2-puma5.yml
@@ -8,7 +8,7 @@ services:
       - "${TEST_SERVICE_PORTS}"
     environment:
       OTEL_SERVICE_NAME: "my-ruby-app"
-      OTEL_RESOURCE_ATTRIBUTES: "cloud.region=ca,deployment.environment.name=to"
+      OTEL_RESOURCE_ATTRIBUTES: "cloud.region=ca,deployment.environment.name=staging"
     depends_on:
       otelcol:
         condition: service_started

--- a/internal/test/integration/docker-compose-ruby-nginx-sql.yml
+++ b/internal/test/integration/docker-compose-ruby-nginx-sql.yml
@@ -16,7 +16,7 @@ services:
       - "3041:3040"
     environment:
       OTEL_SERVICE_NAME: "my-ruby-app"
-      OTEL_RESOURCE_ATTRIBUTES: "cloud.region=ca,deployment.environment.name=to"
+      OTEL_RESOURCE_ATTRIBUTES: "cloud.region=ca,deployment.environment.name=staging"
     depends_on:
       certgen:
         condition: service_completed_successfully

--- a/internal/test/integration/docker-compose-ruby.yml
+++ b/internal/test/integration/docker-compose-ruby.yml
@@ -7,7 +7,7 @@ services:
       - "${TEST_SERVICE_PORTS}"
     environment:
       OTEL_SERVICE_NAME: "my-ruby-app"
-      OTEL_RESOURCE_ATTRIBUTES: "cloud.region=ca,deployment.environment.name=to"
+      OTEL_RESOURCE_ATTRIBUTES: "cloud.region=ca,deployment.environment.name=staging"
     depends_on:
       otelcol:
         condition: service_started

--- a/internal/test/integration/red_test_python_aws_sqs.go
+++ b/internal/test/integration/red_test_python_aws_sqs.go
@@ -90,8 +90,15 @@ func assertSQSOperation(t require.TestingT, op, expectedQueueURL, expectedMessag
 	require.Equal(t, "obi-queue", tag.Value)
 
 	tag, found = jaeger.FindIn(span.Tags, "messaging.operation.type")
-	require.True(t, found)
-	require.Equal(t, expectedOperationType, tag.Value)
+	if expectedOperationType == "" {
+		// messaging.operation.type is a semconv enum: it is omitted rather
+		// than emitted empty for operations with no mapped type (e.g.
+		// CreateQueue, DeleteQueue).
+		require.False(t, found, "messaging.operation.type should be omitted when the operation type is unknown")
+	} else {
+		require.True(t, found)
+		require.Equal(t, expectedOperationType, tag.Value)
+	}
 
 	tag, found = jaeger.FindIn(span.Tags, "messaging.operation.name")
 	require.True(t, found)

--- a/internal/test/integration/red_test_ruby.go
+++ b/internal/test/integration/red_test_ruby.go
@@ -70,7 +70,7 @@ func testREDMetricsForRubyHTTPLibrary(t *testing.T, url string, comm string) {
 		var err error
 		results, err = pq.Query(`target_info{` +
 			`cloud_region="ca",` +
-			`deployment_environment_name="to"}`)
+			`deployment_environment_name="staging"}`)
 		require.NoError(ct, err)
 		enoughPromResults(ct, results)
 		val := totalPromCount(ct, results)

--- a/internal/test/oats/ai/yaml/oats_open_ai_test.yaml
+++ b/internal/test/oats/ai/yaml/oats_open_ai_test.yaml
@@ -22,11 +22,12 @@ expected:
       gen_ai.response.model: gpt-5-mini-2025-08-07
   # Error returned by OpenAI
   - traceql: '{ .error.type = "insufficient_quota" && .gen_ai.request.model = "gpt-5-mini"}'
-    equals: POST /v1/responses
+    equals: response gpt-5-mini
     attributes:
       gen_ai.input.messages: '[{"role":"user","parts":[{"type":"text","content":"How do I check if a Python object is an instance of a class?"}]}]'
       gen_ai.system_instructions: '[{"type":"text","content":"You are a coding assistant that talks like a pirate."}]'
       gen_ai.provider.name: openai
+      gen_ai.operation.name: response
   # Chat completion
   - traceql: '{ .gen_ai.provider.name = "openai" && .gen_ai.request.model = "gpt-4o-mini"}'
     equals: chat gpt-4o-mini

--- a/internal/test/weavercheck/weavercheck.go
+++ b/internal/test/weavercheck/weavercheck.go
@@ -75,22 +75,43 @@ var IgnoredAdviceMessages = map[string]struct{}{
 	"Namespace 'iface' collides with existing attribute 'iface.direction'": {},
 }
 
+// Weaver finding-type identifiers (from weaver's rego policy output) that
+// OBI's enforcement logic matches on.
+//
+// NOTE: these strings come from weaver's rego policy output. If a weaver
+// version bump renames them, enforcement silently weakens — re-verify when
+// bumping the pinned weaver image.
+const (
+	adviceTypeExtendsNamespace     = "extends_namespace"
+	adviceTypeUndefinedEnumVariant = "undefined_enum_variant"
+)
+
 // actionableAdviceTypes lists the weaver finding-type values OBI treats as
 // failures in addition to `violation`-level advice. Hoisted here (rather than
 // matched as an inline string literal) so the coupling to weaver's advice-type
 // vocabulary lives in one documented place and is easy to extend.
 //
-//   - "extends_namespace": an attribute emitted under an existing semconv
+//   - extends_namespace: an attribute emitted under an existing semconv
 //     namespace but declared in no registry (upstream semconv or
 //     `schemas/obi/`). Weaver classifies these as `information`-level, so
 //     without this they would silently pass; OBI requires every emitted
 //     attribute to be declared.
 //
-// NOTE: these strings come from weaver's rego policy output. If a weaver
-// version bump renames them, enforcement silently weakens — re-verify when
-// bumping the pinned weaver image.
+//   - undefined_enum_variant: an enumerated attribute emitted with a value
+//     outside the members declared for it in the registry (e.g. an empty
+//     string for `messaging.operation.type`, or an HTTP status code leaking
+//     into a gRPC status attribute). Weaver classifies these as
+//     `information`-level because enums are open; OBI treats them as emitter
+//     bugs — when OBI has no valid value for an enumerated attribute it must
+//     omit the attribute instead. Values OBI intentionally emits beyond the
+//     pinned upstream members are declared in the registry override groups
+//     under `schemas/obi/groups/` (closed enums gain the extra members;
+//     attributes whose value space is open-ended are re-typed as strings —
+//     see schemas/obi/README.md), so weaver itself accepts them and this
+//     check stays a pure bug detector.
 var actionableAdviceTypes = map[string]struct{}{
-	"extends_namespace": {},
+	adviceTypeExtendsNamespace:     {},
+	adviceTypeUndefinedEnumVariant: {},
 }
 
 // Report is the top-level JSON structure emitted by weaver with --format json.
@@ -248,9 +269,8 @@ func Validate(t TestingT, report *Report) {
 				continue
 			}
 			signals := sortedSignals(info.Signals)
-			ignored := msgIgnored || allSignalsIgnored(info.Signals)
 			suffix := ""
-			if ignored {
+			if msgIgnored || allSignalsIgnored(info.Signals) {
 				suffix = " [ignored]"
 			}
 			t.Logf("    [%s] [%dx] %s (signals: %s)%s", level, count, msg, strings.Join(signals, ", "), suffix)
@@ -266,16 +286,16 @@ func Validate(t TestingT, report *Report) {
 			"(violations or undeclared attributes under existing semconv namespaces)", actionableAdvisories)
 }
 
-// isActionableAdvice reports whether an advisory at the given level and
-// advice type must fail validation: `violation`-level advice always is, and
-// so is any advice type listed in actionableAdviceTypes (e.g.
-// `extends_namespace`, which weaver classifies as information-level).
-func isActionableAdvice(level, adviceType string) bool {
-	if level == "violation" {
+// isActionableAdvice reports whether an advisory must fail validation:
+// `violation`-level advice always is, and so is any advice type listed in
+// actionableAdviceTypes (e.g. `extends_namespace`, which weaver classifies as
+// information-level).
+func isActionableAdvice(info *adviceInfo) bool {
+	if info.Level == "violation" {
 		return true
 	}
 
-	_, actionable := actionableAdviceTypes[adviceType]
+	_, actionable := actionableAdviceTypes[info.AdviceType]
 	return actionable
 }
 
@@ -296,7 +316,7 @@ func countActionableAdvisories(stats *Statistics, adviceByMsg map[string]*advice
 			continue
 		}
 		ignored := messageIgnored || allSignalsIgnored(info.Signals)
-		if isActionableAdvice(info.Level, info.AdviceType) && !ignored {
+		if isActionableAdvice(info) && !ignored {
 			count += occurrences
 		}
 	}

--- a/internal/test/weavercheck/weavercheck_test.go
+++ b/internal/test/weavercheck/weavercheck_test.go
@@ -38,3 +38,95 @@ func TestExtendsNamespaceAdviceIsActionable(t *testing.T) {
 	adviceByMsg := collectAdviceInfo(report.Samples)
 	require.Equal(t, 1, countActionableAdvisories(&report.Statistics, adviceByMsg))
 }
+
+// TestUndefinedEnumVariantAdviceIsActionable exercises weaver's serialized
+// finding ID so information-level out-of-enum values (e.g. an empty
+// messaging.operation.type or an HTTP status leaking into a gRPC status
+// attribute) cannot silently bypass semantic convention validation.
+func TestUndefinedEnumVariantAdviceIsActionable(t *testing.T) {
+	const message = "Enum value '200' is not defined in the registry"
+
+	report := Report{
+		Samples: []json.RawMessage{json.RawMessage(`{
+			"span": {
+				"live_check_result": {
+					"all_advice": [{
+						"id": "undefined_enum_variant",
+						"message": "Enum value '200' is not defined in the registry",
+						"level": "information",
+						"signal_type": "span",
+						"signal_name": "routeguide.RouteGuide/GetFeature"
+					}]
+				}
+			}
+		}`)},
+		Statistics: Statistics{
+			AdviceMessageCounts: map[string]int{message: 1},
+		},
+	}
+
+	adviceByMsg := collectAdviceInfo(report.Samples)
+	require.Equal(t, 1, countActionableAdvisories(&report.Statistics, adviceByMsg))
+}
+
+// TestUndefinedEnumVariantEmptyValueIsActionable pins that an empty value on
+// an enumerated attribute — always an emitter bug (the attribute must be
+// omitted instead) — fails validation. Values OBI emits on purpose are
+// declared in the registry override groups under schemas/obi/groups/ (see
+// schemas/obi/README.md), so weaver itself accepts them and no finding is
+// produced; anything weaver still flags is a bug by definition.
+func TestUndefinedEnumVariantEmptyValueIsActionable(t *testing.T) {
+	const message = "Enum attribute 'messaging.operation.type' has value '' which is not documented."
+
+	report := Report{
+		Samples: []json.RawMessage{json.RawMessage(`{
+			"span": {
+				"live_check_result": {
+					"all_advice": [{
+						"id": "undefined_enum_variant",
+						"message": "Enum attribute 'messaging.operation.type' has value '' which is not documented.",
+						"level": "information",
+						"signal_type": "span",
+						"signal_name": "publish"
+					}]
+				}
+			}
+		}`)},
+		Statistics: Statistics{
+			AdviceMessageCounts: map[string]int{message: 2},
+		},
+	}
+
+	adviceByMsg := collectAdviceInfo(report.Samples)
+	require.Equal(t, 2, countActionableAdvisories(&report.Statistics, adviceByMsg),
+		"empty enum values are emitter bugs and must stay actionable")
+}
+
+// TestInformationAdviceWithoutActionableTypeIsNotCounted pins the inverse:
+// information-level advice whose type is not in actionableAdviceTypes must
+// not fail validation.
+func TestInformationAdviceWithoutActionableTypeIsNotCounted(t *testing.T) {
+	const message = "Attribute 'http.request.method' is deprecated, use ..."
+
+	report := Report{
+		Samples: []json.RawMessage{json.RawMessage(`{
+			"span": {
+				"live_check_result": {
+					"all_advice": [{
+						"id": "deprecated",
+						"message": "Attribute 'http.request.method' is deprecated, use ...",
+						"level": "information",
+						"signal_type": "span",
+						"signal_name": "GET /test"
+					}]
+				}
+			}
+		}`)},
+		Statistics: Statistics{
+			AdviceMessageCounts: map[string]int{message: 1},
+		},
+	}
+
+	adviceByMsg := collectAdviceInfo(report.Samples)
+	require.Equal(t, 0, countActionableAdvisories(&report.Statistics, adviceByMsg))
+}

--- a/pkg/appolly/app/request/grpc_status.go
+++ b/pkg/appolly/app/request/grpc_status.go
@@ -4,12 +4,14 @@
 package request // import "go.opentelemetry.io/obi/pkg/appolly/app/request"
 
 import (
-	"strconv"
-
 	grpc_codes "google.golang.org/grpc/codes"
 )
 
 // GRPCStatusCodeString returns the canonical gRPC status code string per semconv.
+// It returns "" when status is not a valid gRPC code (0-16) — e.g. an HTTP
+// status that leaked through protocol detection, or a failed eBPF status read.
+// Callers must then omit the attribute instead of emitting a made-up value
+// that would violate the semconv gRPC status enum.
 func GRPCStatusCodeString(status int) string {
 	switch grpc_codes.Code(status) {
 	case grpc_codes.OK:
@@ -47,6 +49,6 @@ func GRPCStatusCodeString(status int) string {
 	case grpc_codes.Unauthenticated:
 		return "UNAUTHENTICATED"
 	default:
-		return "CODE(" + strconv.FormatInt(int64(status), 10) + ")"
+		return ""
 	}
 }

--- a/pkg/appolly/app/request/grpc_status_test.go
+++ b/pkg/appolly/app/request/grpc_status_test.go
@@ -14,5 +14,11 @@ func TestGRPCStatusCodeString(t *testing.T) {
 	assert.Equal(t, "OK", GRPCStatusCodeString(int(grpc_codes.OK)))
 	assert.Equal(t, "INVALID_ARGUMENT", GRPCStatusCodeString(int(grpc_codes.InvalidArgument)))
 	assert.Equal(t, "DEADLINE_EXCEEDED", GRPCStatusCodeString(int(grpc_codes.DeadlineExceeded)))
-	assert.Equal(t, "CODE(99)", GRPCStatusCodeString(99))
+	assert.Equal(t, "UNAUTHENTICATED", GRPCStatusCodeString(int(grpc_codes.Unauthenticated)))
+	// values outside the gRPC status enum (0-16) return "" so callers omit
+	// the attribute instead of emitting an invalid enum variant
+	assert.Empty(t, GRPCStatusCodeString(99))
+	assert.Empty(t, GRPCStatusCodeString(200)) // HTTP status leaked through protocol detection
+	assert.Empty(t, GRPCStatusCodeString(0xFFFF))
+	assert.Empty(t, GRPCStatusCodeString(-1))
 }

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -783,11 +783,13 @@ type JSONRPC struct {
 
 // GenAI operation name constants aligned with OTel semantic conventions.
 const (
-	ChatOperationName        = "chat"
-	CompletionOperationName  = "text_completion"
-	GenerationOperationName  = "generation"
-	InvokeModelOperationName = "invoke_model"
-	EmbeddingOperationName   = "embeddings"
+	ChatOperationName         = "chat"
+	CompletionOperationName   = "text_completion"
+	GenerationOperationName   = "generation"
+	InvokeModelOperationName  = "invoke_model"
+	EmbeddingOperationName    = "embeddings"
+	ResponseOperationName     = "response"
+	ConversationOperationName = "conversation"
 )
 
 // VendorEmbedding represents a generic embedding API provider such as

--- a/pkg/appolly/app/request/span_getters.go
+++ b/pkg/appolly/app/request/span_getters.go
@@ -221,7 +221,9 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 				}
 				return ErrorType("error")
 			}
-			return ErrorType("")
+			// error.type only applies to failed requests: return an invalid
+			// KeyValue so the attribute is omitted instead of emitted empty.
+			return attribute.KeyValue{}
 		}
 	case attr.MessagingSystem:
 		getter = func(span *Span) attribute.KeyValue {
@@ -272,17 +274,23 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 		}
 	case attr.MessagingOpType:
 		getter = func(span *Span) attribute.KeyValue {
+			opType := ""
 			switch span.Type {
 			case EventTypeKafkaClient, EventTypeKafkaServer,
 				EventTypeMQTTClient, EventTypeMQTTServer,
 				EventTypeNATSClient, EventTypeNATSServer,
 				EventTypeAMQPClient:
-				return MessagingOperationType(span.Method)
+				opType = span.Method
 			}
 			if span.Type == EventTypeHTTPClient && span.SubType == HTTPSubtypeAWSSQS && span.AWS != nil {
-				return MessagingOperationType(span.AWS.SQS.OperationType)
+				opType = span.AWS.SQS.OperationType
 			}
-			return MessagingOperationType("")
+			if opType == "" {
+				// messaging.operation.type is a semconv enum: omit the
+				// attribute rather than emitting an empty (invalid) variant.
+				return attribute.KeyValue{}
+			}
+			return MessagingOperationType(opType)
 		}
 	case attr.MessagingMessageID:
 		getter = func(span *Span) attribute.KeyValue {
@@ -487,11 +495,22 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 		}
 	case attr.GenAIOperationName:
 		getter = func(s *Span) attribute.KeyValue {
-			return semconv.GenAIOperationNameKey.String(s.GenAIOperationName())
+			if op := s.GenAIOperationName(); op != "" {
+				return semconv.GenAIOperationNameKey.String(op)
+			}
+			// Omit gen_ai.operation.name rather than emitting an empty value
+			// (required on the gen_ai client metrics when present, and an
+			// empty string carries no information).
+			return attribute.KeyValue{}
 		}
 	case attr.GenAIProviderName:
 		getter = func(s *Span) attribute.KeyValue {
-			return semconv.GenAIProviderNameKey.String(s.GenAIProviderName())
+			if provider := s.GenAIProviderName(); provider != "" {
+				return semconv.GenAIProviderNameKey.String(provider)
+			}
+			// gen_ai.provider.name is a semconv enum: omit the attribute
+			// rather than emitting an empty (invalid) variant.
+			return attribute.KeyValue{}
 		}
 	case attr.GenAITokenTypeInput:
 		getter = func(_ *Span) attribute.KeyValue {
@@ -529,12 +548,19 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 				return semconv.RPCResponseStatusCode(SunRPCResponseStatusCode(s.Status))
 			}
 			if s.Type == EventTypeGRPC || s.Type == EventTypeGRPCClient {
-				return semconv.RPCResponseStatusCode(GRPCStatusCodeString(s.Status))
+				// GRPCStatusCodeString returns "" for statuses outside the
+				// gRPC enum (e.g. an HTTP code that leaked through protocol
+				// detection): omit the attribute instead of inventing a value.
+				if code := GRPCStatusCodeString(s.Status); code != "" {
+					return semconv.RPCResponseStatusCode(code)
+				}
+				return attribute.KeyValue{}
 			}
 			if s.SubType == HTTPSubtypeJSONRPC && s.JSONRPC != nil && s.JSONRPC.ErrorCode != 0 {
 				return semconv.RPCResponseStatusCode(strconv.Itoa(s.JSONRPC.ErrorCode))
 			}
-			return semconv.RPCResponseStatusCode("")
+			// No status to report: omit the attribute instead of emitting "".
+			return attribute.KeyValue{}
 		}
 	}
 	// default: unlike the Prometheus getters, we don't check here for service name nor k8s metadata
@@ -551,7 +577,16 @@ func spanPromGetters(attrName attr.Name) attributes.Getter[*Span, string] {
 		return func(s *Span) string { return s.SunRPCProcedureRouteForExport() }
 	}
 	if otelGetter, ok := spanOTELGetters(attrName); ok {
-		return func(span *Span) string { return otelGetter(span).Value.Emit() }
+		return func(span *Span) string {
+			// OTEL getters return an invalid (zero) KeyValue to signal
+			// "omit this attribute". Prometheus label sets are fixed, so
+			// map omission to the empty string rather than Value.Emit()'s
+			// "unknown" placeholder for invalid values.
+			if kv := otelGetter(span); kv.Valid() {
+				return kv.Value.Emit()
+			}
+			return ""
+		}
 	}
 	// unlike the OTEL getters, when the attribute is not found, we need to look for it
 	// in the metadata section

--- a/pkg/appolly/app/request/span_getters_test.go
+++ b/pkg/appolly/app/request/span_getters_test.go
@@ -491,6 +491,9 @@ func TestSpanOTELGetters_JSONRPCAttributes(t *testing.T) {
 		attrName attr.Name
 		span     *Span
 		expected string
+		// omitted asserts the getter returns an invalid (zero) KeyValue so
+		// the attribute is dropped instead of being emitted empty.
+		omitted bool
 	}{
 		{
 			name:     "protocol version - JSON-RPC span",
@@ -526,7 +529,7 @@ func TestSpanOTELGetters_JSONRPCAttributes(t *testing.T) {
 			name:     "response status code - non-JSON-RPC span",
 			attrName: attr.RPCResponseStatusCode,
 			span:     nonJSONRPCSpan,
-			expected: "",
+			omitted:  true,
 		},
 		{
 			name:     "response status code - JSON-RPC span without error",
@@ -535,7 +538,7 @@ func TestSpanOTELGetters_JSONRPCAttributes(t *testing.T) {
 				SubType: HTTPSubtypeJSONRPC,
 				JSONRPC: &JSONRPC{Version: "2.0"},
 			},
-			expected: "",
+			omitted: true,
 		},
 		{
 			name:     "response status code - gRPC server span",
@@ -545,6 +548,24 @@ func TestSpanOTELGetters_JSONRPCAttributes(t *testing.T) {
 				Status: 3,
 			},
 			expected: "INVALID_ARGUMENT",
+		},
+		{
+			name:     "response status code - gRPC span with leaked HTTP status is omitted",
+			attrName: attr.RPCResponseStatusCode,
+			span: &Span{
+				Type:   EventTypeGRPC,
+				Status: 200,
+			},
+			omitted: true,
+		},
+		{
+			name:     "response status code - gRPC client span with failed status read is omitted",
+			attrName: attr.RPCResponseStatusCode,
+			span: &Span{
+				Type:   EventTypeGRPCClient,
+				Status: 0xFFFF, // u16(-1) fallback from the eBPF side
+			},
+			omitted: true,
 		},
 		{
 			name:     "response status code - SunRPC success",
@@ -581,6 +602,10 @@ func TestSpanOTELGetters_JSONRPCAttributes(t *testing.T) {
 			require.True(t, ok, "getter should be found for %s", tt.attrName)
 
 			kv := getter(tt.span)
+			if tt.omitted {
+				assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+				return
+			}
 			assert.Equal(t, string(tt.attrName), string(kv.Key))
 			assert.Equal(t, tt.expected, kv.Value.AsString())
 		})
@@ -678,6 +703,107 @@ func TestSpanOTELGetters_MessagingAttributes_NATS(t *testing.T) {
 
 	span.Method = MessagingProcess
 	assert.Equal(t, MessagingProcess, opTypeGetter(span).Value.AsString())
+}
+
+// TestSpanOTELGetters_MessagingOpTypeOmitted ensures messaging.operation.type
+// (a semconv enum) is omitted — not emitted as an empty string — when the
+// operation is unknown or the span is not a messaging span.
+func TestSpanOTELGetters_MessagingOpTypeOmitted(t *testing.T) {
+	opTypeGetter, ok := spanOTELGetters(attr.MessagingOpType)
+	require.True(t, ok, "getter should be found for MessagingOpType")
+
+	// messaging span with an unknown operation
+	kv := opTypeGetter(&Span{Type: EventTypeKafkaClient})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+
+	// SQS span whose operation type was not recognized
+	kv = opTypeGetter(&Span{
+		Type:    EventTypeHTTPClient,
+		SubType: HTTPSubtypeAWSSQS,
+		AWS:     &AWS{},
+	})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+
+	// non-messaging span
+	kv = opTypeGetter(&Span{Type: EventTypeHTTP})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+}
+
+// TestSpanOTELGetters_ErrorTypeOmitted ensures error.type is omitted — not
+// emitted as an empty string — on successful requests, while failed requests
+// keep their error.type value.
+func TestSpanOTELGetters_ErrorTypeOmitted(t *testing.T) {
+	getter, ok := spanOTELGetters(attr.ErrorType)
+	require.True(t, ok, "getter should be found for ErrorType")
+
+	// successful HTTP request: no error.type
+	kv := getter(&Span{Type: EventTypeHTTP, Status: 200})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+
+	// failed HTTP request: generic error.type
+	kv = getter(&Span{Type: EventTypeHTTP, Status: 500})
+	require.True(t, kv.Valid())
+	assert.Equal(t, string(attr.ErrorType), string(kv.Key))
+	assert.Equal(t, "error", kv.Value.AsString())
+
+	// failed Memcached request keeps its specific error code
+	kv = getter(&Span{
+		Type:    EventTypeMemcachedClient,
+		Status:  1,
+		DBError: DBError{ErrorCode: "SERVER_ERROR"},
+	})
+	require.True(t, kv.Valid())
+	assert.Equal(t, "SERVER_ERROR", kv.Value.AsString())
+}
+
+// TestSpanOTELGetters_GenAIOperationNameOmitted ensures gen_ai.operation.name
+// is omitted — not emitted as an empty string — when the operation could not
+// be derived, while classified operations keep it.
+func TestSpanOTELGetters_GenAIOperationNameOmitted(t *testing.T) {
+	getter, ok := spanOTELGetters(attr.GenAIOperationName)
+	require.True(t, ok, "getter should be found for GenAIOperationName")
+
+	// non-GenAI span
+	kv := getter(&Span{Type: EventTypeHTTPClient})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+
+	// GenAI span whose operation was not classified
+	kv = getter(&Span{
+		Type:    EventTypeHTTPClient,
+		SubType: HTTPSubtypeOpenAI,
+		GenAI:   &GenAI{OpenAI: &VendorOpenAI{}},
+	})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+
+	// classified GenAI span keeps its operation name
+	kv = getter(&Span{
+		Type:    EventTypeHTTPClient,
+		SubType: HTTPSubtypeOpenAI,
+		GenAI:   &GenAI{OpenAI: &VendorOpenAI{OperationName: ChatOperationName}},
+	})
+	require.True(t, kv.Valid())
+	assert.Equal(t, ChatOperationName, kv.Value.AsString())
+}
+
+// TestSpanOTELGetters_GenAIProviderNameOmitted ensures gen_ai.provider.name
+// (a semconv enum) is omitted — not emitted as an empty string — on spans
+// with no detected GenAI provider.
+func TestSpanOTELGetters_GenAIProviderNameOmitted(t *testing.T) {
+	getter, ok := spanOTELGetters(attr.GenAIProviderName)
+	require.True(t, ok, "getter should be found for GenAIProviderName")
+
+	// non-GenAI span
+	kv := getter(&Span{Type: EventTypeHTTPClient})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+
+	// GenAI span keeps its provider
+	kv = getter(&Span{
+		Type:    EventTypeHTTPClient,
+		SubType: HTTPSubtypeOpenAI,
+		GenAI:   &GenAI{OpenAI: &VendorOpenAI{}},
+	})
+	require.True(t, kv.Valid())
+	assert.Equal(t, "openai", kv.Value.AsString())
 }
 
 func TestSpanOTELGetters_GenAIInput(t *testing.T) {

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -520,7 +520,24 @@ func ReadBPFTraceAsSpan(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, reco
 		return request.Span{}, true, err
 	}
 
-	return finalizeParsedSpan(parseCtx, HTTPRequestTraceToSpan(event), false, nil)
+	span := HTTPRequestTraceToSpan(event)
+	if isH2CPrefacePseudoRequest(&span) {
+		return span, true, nil
+	}
+
+	return finalizeParsedSpan(parseCtx, span, false, nil)
+}
+
+// isH2CPrefacePseudoRequest reports whether the span is the HTTP/2 client
+// connection preface ("PRI * HTTP/2.0", RFC 9113 section 3.4) surfaced as a
+// literal request. Go's h2c upgrade path lets net/http parse the preface as a
+// request with method "PRI" and target "*" before hijacking the connection,
+// so the Go tracer uprobes observe it as one. It is not an application
+// request — the real HTTP/2 exchanges on the connection are traced separately
+// — and "PRI" is not a registered HTTP method, so such spans are dropped.
+func isH2CPrefacePseudoRequest(span *request.Span) bool {
+	return (span.Type == request.EventTypeHTTP || span.Type == request.EventTypeHTTPClient) &&
+		span.Method == "PRI" && span.Path == "*"
 }
 
 func ReinterpretCast[T any](b []byte) (*T, error) {

--- a/pkg/ebpf/common/common_test.go
+++ b/pkg/ebpf/common/common_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
 
 // GetBuildTags returns a slice of the build tags used to compile the binary.
@@ -87,4 +89,25 @@ func TestLockdownParsing(t *testing.T) {
 	setIntegrity(t, path, "[none] integrity confidentiality\n")
 	setNotReadable(t, path)
 	assert.Equal(t, KernelLockdownIntegrity, KernelLockdownMode())
+}
+
+// TestIsH2CPrefacePseudoRequest pins that the HTTP/2 connection preface
+// ("PRI * HTTP/2.0"), which Go's h2c path surfaces as a literal request, is
+// recognized (and thus dropped by ReadBPFTraceAsSpan) while real requests
+// are not.
+func TestIsH2CPrefacePseudoRequest(t *testing.T) {
+	preface := request.Span{Type: request.EventTypeHTTP, Method: "PRI", Path: "*"}
+	assert.True(t, isH2CPrefacePseudoRequest(&preface))
+
+	clientPreface := request.Span{Type: request.EventTypeHTTPClient, Method: "PRI", Path: "*"}
+	assert.True(t, isH2CPrefacePseudoRequest(&clientPreface))
+
+	for _, span := range []request.Span{
+		{Type: request.EventTypeHTTP, Method: "GET", Path: "*"},
+		{Type: request.EventTypeHTTP, Method: "PRI", Path: "/pri"},
+		{Type: request.EventTypeHTTP, Method: "GET", Path: "/users"},
+		{Type: request.EventTypeKafkaClient, Method: "PRI", Path: "*"},
+	} {
+		assert.False(t, isH2CPrefacePseudoRequest(&span), "span %+v must not be dropped", span)
+	}
 }

--- a/pkg/ebpf/common/http/openai.go
+++ b/pkg/ebpf/common/http/openai.go
@@ -102,7 +102,11 @@ func OpenAISpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 	parsedResponse.Request = parsedRequest
 	parsedResponse.ToolCalls = toolCalls
 
-	// Override operation name and derive API type from URL path.
+	// Override operation name and derive API type from URL path. The path is
+	// authoritative even when the response carries no `object` field (error
+	// responses don't): the operation name feeds required metric attributes
+	// (gen_ai.client.operation.duration / token.usage), so failed calls must
+	// carry it too.
 	if req.URL != nil {
 		path := strings.TrimSuffix(req.URL.Path, "/")
 		switch path {
@@ -113,7 +117,10 @@ func OpenAISpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 			parsedResponse.OperationName = request.EmbeddingOperationName
 			parsedResponse.APIType = "embeddings"
 		case "/v1/responses":
+			parsedResponse.OperationName = request.ResponseOperationName
 			parsedResponse.APIType = "responses"
+		case "/v1/conversations":
+			parsedResponse.OperationName = request.ConversationOperationName
 		}
 	}
 

--- a/pkg/ebpf/common/http/openai_test.go
+++ b/pkg/ebpf/common/http/openai_test.go
@@ -194,6 +194,12 @@ func TestOpenAISpan_ErrorResponse(t *testing.T) {
 	ai := span.GenAI.OpenAI
 	assert.Equal(t, "insufficient_quota", ai.Error.Type)
 	assert.NotEmpty(t, ai.Error.Message)
+
+	// The error body carries no `object` field, so the operation name must be
+	// derived from the request path: gen_ai.operation.name is required on the
+	// gen_ai client metrics, so failed calls must carry it too.
+	assert.Equal(t, request.ResponseOperationName, ai.OperationName)
+	assert.Equal(t, "responses", ai.APIType)
 }
 
 func TestOpenAISpan_NotOpenAI(t *testing.T) {

--- a/pkg/ebpf/common/http/rerank.go
+++ b/pkg/ebpf/common/http/rerank.go
@@ -14,6 +14,13 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
 
+// genericRerankProvider is the declared gen_ai.provider.name fallback used
+// for genuine rerank requests whose vendor could not be identified by
+// hostname. It mirrors RetrievalSpan's genericRetrievalProvider so that
+// gen_ai.provider.name stays a valid semconv enum member (weaver live-check
+// rejects the internal "unknown" sentinel).
+const genericRerankProvider = "generic"
+
 // rerankProviders maps hostname suffixes to GenAI provider names.
 // Provider names are aligned with existing canonical names used elsewhere
 // in the codebase (e.g. embedding uses "voyage" for Voyage AI).
@@ -163,7 +170,12 @@ func RerankSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 	}
 
 	// At this point, we've confirmed this is a genuine rerank request.
-	// Continue with full parsing even if provider is "unknown" (as long as model exists).
+	// Emit the declared "generic" provider rather than the internal
+	// "unknown" sentinel so gen_ai.provider.name remains a valid enum
+	// member (mirrors RetrievalSpan).
+	if provider == "unknown" {
+		provider = genericRerankProvider
+	}
 
 	// Response body parsing is best-effort: truncated responses may fail
 	// to parse but should not prevent provider detection.

--- a/pkg/ebpf/common/http/rerank_test.go
+++ b/pkg/ebpf/common/http/rerank_test.go
@@ -152,7 +152,9 @@ func TestRerankSpan_VoyageAI(t *testing.T) {
 
 func TestRerankSpan_UnknownProvider(t *testing.T) {
 	// Unknown hostname but request body contains "model" field,
-	// so it should still be detected as a rerank request.
+	// so it should still be detected as a rerank request. The vendor
+	// cannot be identified, so it falls back to the declared "generic"
+	// provider rather than the invalid "unknown" enum value.
 	req := makeRequest(t, http.MethodPost, "http://custom-rerank.example.com/v1/rerank", cohereRerankRequestBody)
 	resp := makePlainResponse(http.StatusOK, http.Header{
 		"Content-Type": []string{"application/json"},
@@ -162,7 +164,7 @@ func TestRerankSpan_UnknownProvider(t *testing.T) {
 	span, ok := RerankSpan(base, req, resp)
 
 	require.True(t, ok)
-	assert.Equal(t, "unknown", span.GenAI.Rerank.Provider)
+	assert.Equal(t, genericRerankProvider, span.GenAI.Rerank.Provider)
 }
 
 func TestRerankSpan_ErrorResponse(t *testing.T) {

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -356,26 +356,32 @@ func (r *SvcGraphMetrics) record(span *request.Span, mr *SvcGraphMetricsReporter
 	ctx := trace.ContextWithSpanContext(r.ctx, trace.SpanContext{}.WithTraceID(span.TraceID).WithSpanID(span.SpanID).WithTraceFlags(trace.TraceFlags(span.TraceFlags)))
 
 	if !span.IsSelfReferenceSpan() || mr.cfg.AllowServiceGraphSelfReferences {
-		connType := request.ConnectionTypeMetric(ConnectionTypeForSpan(span, &mr.pidTracker))
+		// connection_type is an enumerated attribute: omit it for direct
+		// HTTP/gRPC requests (empty value) instead of emitting an empty
+		// string, which is not a valid enum member.
+		var connType []attribute.KeyValue
+		if ct := ConnectionTypeForSpan(span, &mr.pidTracker); ct != "" {
+			connType = append(connType, request.ConnectionTypeMetric(ct))
+		}
 
 		if span.IsClientSpan() {
-			sgc, attrs := r.serviceGraphClient.ForRecord(span, connType)
+			sgc, attrs := r.serviceGraphClient.ForRecord(span, connType...)
 			sgc.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 			// If we managed to resolve the remote name only, we check to see
 			// we are not instrumenting the server service, then and only then,
 			// we generate client span count for service graph total
 			if ClientSpanToUninstrumentedService(&mr.pidTracker, span) {
-				sgt, attrs := r.serviceGraphTotal.ForRecord(span, connType)
+				sgt, attrs := r.serviceGraphTotal.ForRecord(span, connType...)
 				sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 			}
 		} else {
-			sgs, attrs := r.serviceGraphServer.ForRecord(span, connType)
+			sgs, attrs := r.serviceGraphServer.ForRecord(span, connType...)
 			sgs.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			sgt, attrs := r.serviceGraphTotal.ForRecord(span, connType)
+			sgt, attrs := r.serviceGraphTotal.ForRecord(span, connType...)
 			sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 		}
 		if request.SpanStatusCode(span) == request.StatusCodeError {
-			sgf, attrs := r.serviceGraphFailed.ForRecord(span, connType)
+			sgf, attrs := r.serviceGraphFailed.ForRecord(span, connType...)
 			sgf.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 		}
 	}

--- a/pkg/export/otel/metrics_svc_graph_test.go
+++ b/pkg/export/otel/metrics_svc_graph_test.go
@@ -68,6 +68,11 @@ func TestServiceGraphMetrics(t *testing.T) {
 	reported := map[string]struct{}{}
 	for _, m := range res {
 		reported[m.Name+":"+m.Attributes["client"]+":"+m.Attributes["server"]] = struct{}{}
+		// connection_type is an enum attribute: for direct HTTP/gRPC requests
+		// it must be omitted, not emitted as an empty string
+		if ct, ok := m.Attributes["connection_type"]; ok {
+			assert.Fail(t, "direct HTTP requests must omit connection_type", "metric %s got connection_type=%q", m.Name, ct)
+		}
 	}
 
 	require.Equal(t, map[string]struct{}{

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -590,6 +590,98 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		ensureTraceIntAttr(t, attrs, semconv.MessagingMessageEnvelopeSizeKey, 42)
 	})
 
+	t.Run("test Kafka trace generation omits unknown operation type", func(t *testing.T) {
+		// messaging.operation.type is a semconv enum: when the operation was
+		// not captured, the attribute must be omitted, not emitted empty
+		span := request.Span{Type: request.EventTypeKafkaClient, Method: "", Path: "important-topic", Statement: "test"}
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
+
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+		attrs := spans.At(0).Attributes()
+		ensureTraceAttrNotExists(t, attrs, attribute.Key(attr.MessagingOpType))
+		ensureTraceStrAttr(t, attrs, semconv.MessagingDestinationNameKey, "important-topic")
+	})
+
+	t.Run("test gRPC trace generation", func(t *testing.T) {
+		span := request.Span{Type: request.EventTypeGRPC, Path: "/routeguide.RouteGuide/GetFeature", Status: 0}
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
+
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+		attrs := spans.At(0).Attributes()
+		ensureTraceStrAttr(t, attrs, semconv.RPCMethodKey, "/routeguide.RouteGuide/GetFeature")
+		ensureTraceStrAttr(t, attrs, semconv.RPCResponseStatusCodeKey, "OK")
+	})
+
+	t.Run("test gRPC trace generation omits leaked HTTP status", func(t *testing.T) {
+		// a span.Status outside the gRPC enum (e.g. an HTTP 200 that leaked
+		// through protocol detection) must not become a made-up status value
+		span := request.Span{Type: request.EventTypeGRPC, Path: "/routeguide.RouteGuide/GetFeature", Status: 200}
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
+
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+		attrs := spans.At(0).Attributes()
+		ensureTraceStrAttr(t, attrs, semconv.RPCMethodKey, "/routeguide.RouteGuide/GetFeature")
+		ensureTraceAttrNotExists(t, attrs, semconv.RPCResponseStatusCodeKey)
+	})
+
+	t.Run("test gRPC client trace generation omits invalid status", func(t *testing.T) {
+		span := request.Span{Type: request.EventTypeGRPCClient, Path: "/routeguide.RouteGuide/GetFeature", Status: 0xFFFF}
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
+
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+		attrs := spans.At(0).Attributes()
+		ensureTraceAttrNotExists(t, attrs, semconv.RPCResponseStatusCodeKey)
+	})
+
+	t.Run("test Elasticsearch trace generation omits empty error.type", func(t *testing.T) {
+		// successful Elasticsearch spans have no error code: error.type must
+		// be omitted, not emitted as an empty string
+		span := request.Span{
+			Type:    request.EventTypeHTTPClient,
+			SubType: request.HTTPSubtypeElasticsearch,
+			Method:  "GET",
+			Path:    "/products/_search",
+			Status:  200,
+			Elasticsearch: &request.Elasticsearch{
+				DBSystemName:     "elasticsearch",
+				DBOperationName:  "search",
+				DBCollectionName: "products",
+			},
+		}
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
+
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+		attrs := spans.At(0).Attributes()
+		ensureTraceStrAttr(t, attrs, attribute.Key(attr.DBSystemName), "elasticsearch")
+		ensureTraceAttrNotExists(t, attrs, attribute.Key(attr.ErrorType))
+	})
+
+	t.Run("test OpenAI trace generation omits empty operation name", func(t *testing.T) {
+		// gen_ai.operation.name must not be emitted as an empty string:
+		// when the operation could not be classified (e.g. an error response
+		// parsed before the request body), the attribute must be omitted
+		span := request.Span{
+			Type:    request.EventTypeHTTPClient,
+			SubType: request.HTTPSubtypeOpenAI,
+			Method:  "POST",
+			Path:    "/v1/responses",
+			Status:  429,
+			GenAI:   &request.GenAI{OpenAI: &request.VendorOpenAI{ID: "chatcmpl-err"}},
+		}
+		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{})
+		traces := tracesgen.GenerateTracesWithAttributes(cache, &span.Service, []attribute.KeyValue{}, hostID, groupFromSpanAndAttributes(&span, tAttrs), reporterName)
+
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+		attrs := spans.At(0).Attributes()
+		ensureTraceStrAttr(t, attrs, semconv.GenAIProviderNameKey, "openai")
+		ensureTraceAttrNotExists(t, attrs, semconv.GenAIOperationNameKey)
+	})
+
 	t.Run("test Mongo trace generation", func(t *testing.T) {
 		span := request.Span{Type: request.EventTypeMongoClient, Method: "insert", Path: "mycollection", DBNamespace: "mydatabase", Status: 0}
 		tAttrs := tracesgen.TraceAttributesSelector(&span, map[attr.Name]struct{}{"db.operation.name": {}})

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -564,10 +564,15 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		attrs = []attribute.KeyValue{
 			semconv.RPCMethod(span.Path),
 			semconv.RPCSystemNameGRPC,
-			semconv.RPCResponseStatusCode(request.GRPCStatusCodeString(span.Status)),
 			request.ClientAddr(request.PeerAsClient(span)),
 			request.ServerAddr(request.SpanHost(span)),
 			request.ServerPort(span.HostPort),
+		}
+		// GRPCStatusCodeString returns "" for statuses outside the gRPC enum
+		// (e.g. an HTTP code that leaked through protocol detection): omit
+		// the attribute instead of inventing a value.
+		if code := request.GRPCStatusCodeString(span.Status); code != "" {
+			attrs = append(attrs, semconv.RPCResponseStatusCode(code))
 		}
 	case request.EventTypeHTTPClient:
 		// SQL++ spans should only have DB attributes, not HTTP attributes
@@ -649,7 +654,11 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			}
 			attrs = append(attrs, request.DBOperationName(span.Elasticsearch.DBOperationName))
 			attrs = append(attrs, request.DBSystemName(span.Elasticsearch.DBSystemName))
-			attrs = append(attrs, request.ErrorType(span.DBError.ErrorCode))
+			// error.type only applies to failed requests: omit it instead of
+			// emitting an empty string on successful spans.
+			if span.DBError.ErrorCode != "" {
+				attrs = append(attrs, request.ErrorType(span.DBError.ErrorCode))
+			}
 		}
 
 		if span.SubType == request.HTTPSubtypeAWSS3 && span.AWS != nil {
@@ -666,7 +675,11 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		if span.SubType == request.HTTPSubtypeAWSSQS && span.AWS != nil {
 			sqs := span.AWS.SQS
 			attrs = append(attrs, request.MessagingOperationName(sqs.OperationName))
-			attrs = append(attrs, request.MessagingOperationType(sqs.OperationType))
+			// messaging.operation.type is a semconv enum: omit it instead of
+			// emitting an empty (invalid) variant when the type is unknown.
+			if sqs.OperationType != "" {
+				attrs = append(attrs, request.MessagingOperationType(sqs.OperationType))
+			}
 			attrs = append(attrs, request.MessagingDestinationName(sqs.Destination))
 			attrs = append(attrs, request.MessagingMessageID(sqs.MessageID))
 			attrs = append(attrs, semconv.CloudRegion(sqs.Meta.Region))
@@ -678,7 +691,11 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		if span.SubType == request.HTTPSubtypeOpenAI && span.GenAI != nil && span.GenAI.OpenAI != nil {
 			ai := span.GenAI.OpenAI
 			attrs = append(attrs, semconv.GenAIProviderNameOpenAI)
-			attrs = append(attrs, semconv.GenAIOperationNameKey.String(ai.OperationName))
+			if ai.OperationName != "" {
+				// Omit gen_ai.operation.name when the operation could not be
+				// derived rather than emitting an empty value.
+				attrs = append(attrs, semconv.GenAIOperationNameKey.String(ai.OperationName))
+			}
 			attrs = append(attrs, semconv.GenAIResponseID(ai.ID))
 			if ai.OperationName == "conversation" || ai.OperationName == "chatkit.session" || ai.OperationName == "chatkit.thread" {
 				attrs = append(attrs, semconv.GenAIConversationID(ai.ID))
@@ -781,7 +798,11 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		if span.SubType == request.HTTPSubtypeAnthropic && span.GenAI != nil && span.GenAI.Anthropic != nil {
 			ai := span.GenAI.Anthropic
 			attrs = append(attrs, semconv.GenAIProviderNameAnthropic)
-			attrs = append(attrs, semconv.GenAIOperationNameKey.String(ai.Output.Type))
+			if ai.Output.Type != "" {
+				// Omit gen_ai.operation.name when the response type was not
+				// captured rather than emitting an empty value.
+				attrs = append(attrs, semconv.GenAIOperationNameKey.String(ai.Output.Type))
+			}
 			if ai.Output.Error != nil && ai.Output.Error.Type != "" {
 				attrs = append(attrs, semconv.GenAIResponseID(ai.Output.RequestID))
 			} else {
@@ -928,7 +949,12 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		if span.SubType == request.HTTPSubtypeQwen && span.GenAI != nil && span.GenAI.Qwen != nil {
 			ai := span.GenAI.Qwen
 			attrs = append(attrs, semconv.GenAIProviderNameKey.String(attr.QwenProviderName))
-			attrs = append(attrs, semconv.GenAIOperationNameKey.String(ai.OperationName))
+			if ai.OperationName != "" {
+				// gen_ai.operation.name must not be emitted as an empty
+				// string: omit it when the operation could not be derived
+				// (re-typed to string in schemas/obi/groups/gen_ai.yaml).
+				attrs = append(attrs, semconv.GenAIOperationNameKey.String(ai.OperationName))
+			}
 			attrs = append(attrs, semconv.GenAIResponseID(ai.ID))
 			attrs = append(attrs, semconv.GenAIRequestModel(ai.Request.Model))
 			if ai.ResponseModel != "" {
@@ -1154,10 +1180,14 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		attrs = []attribute.KeyValue{
 			semconv.RPCMethod(span.Path),
 			semconv.RPCSystemNameGRPC,
-			semconv.RPCResponseStatusCode(request.GRPCStatusCodeString(span.Status)),
 			request.ServerAddr(request.HostAsServer(span)),
 			request.PeerService(request.PeerServiceFromSpan(span)),
 			request.ServerPort(span.HostPort),
+		}
+		// See the EventTypeGRPC case: omit the status code attribute when the
+		// span status is not a valid gRPC code.
+		if code := request.GRPCStatusCodeString(span.Status); code != "" {
+			attrs = append(attrs, semconv.RPCResponseStatusCode(code))
 		}
 	case request.EventTypeSQLClient, request.EventTypeSQLServer:
 		attrs = []attribute.KeyValue{
@@ -1181,7 +1211,11 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		}
 		if span.Status == 1 && span.SQLError != nil {
 			attrs = append(attrs, request.DBResponseStatusCode(strconv.Itoa(int(span.SQLError.Code))))
-			attrs = append(attrs, request.ErrorType(span.SQLError.SQLState))
+			// omit error.type when the SQLSTATE was not captured, instead of
+			// emitting an empty string.
+			if span.SQLError.SQLState != "" {
+				attrs = append(attrs, request.ErrorType(span.SQLError.SQLState))
+			}
 			attrs = append(attrs, attributes.DBResponseErrorAttr(optionalAttrs, span.SQLErrorDescription())...)
 		}
 	case request.EventTypeRedisServer, request.EventTypeRedisClient:
@@ -1211,14 +1245,17 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			attrs = append(attrs, request.DBNamespace(span.DBNamespace))
 		}
 	case request.EventTypeKafkaServer, request.EventTypeKafkaClient:
-		operation := request.MessagingOperationType(span.Method)
 		attrs = []attribute.KeyValue{
 			request.ServerAddr(request.HostAsServer(span)),
 			request.ServerPort(span.HostPort),
 			semconv.MessagingSystemKafka,
 			semconv.MessagingDestinationName(span.Path),
 			semconv.MessagingClientID(span.Statement),
-			operation,
+		}
+		// messaging.operation.type is a semconv enum: omit it instead of
+		// emitting an empty (invalid) variant when the operation is unknown.
+		if span.Method != "" {
+			attrs = append(attrs, request.MessagingOperationType(span.Method))
 		}
 
 		if span.Type == request.EventTypeKafkaClient {
@@ -1232,41 +1269,44 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			}
 		}
 	case request.EventTypeMQTTServer, request.EventTypeMQTTClient:
-		operation := request.MessagingOperationType(span.Method)
 		attrs = []attribute.KeyValue{
 			request.ServerAddr(request.HostAsServer(span)),
 			request.ServerPort(span.HostPort),
 			messagingSystemMQTT,
 			semconv.MessagingDestinationName(span.Path),
 			semconv.MessagingClientID(span.Statement),
-			operation,
+		}
+		if span.Method != "" {
+			attrs = append(attrs, request.MessagingOperationType(span.Method))
 		}
 
 		if span.Type == request.EventTypeMQTTClient {
 			attrs = append(attrs, request.PeerService(request.PeerServiceFromSpan(span)))
 		}
 	case request.EventTypeNATSServer, request.EventTypeNATSClient:
-		operation := request.MessagingOperationType(span.Method)
 		attrs = []attribute.KeyValue{
 			request.ServerAddr(request.HostAsServer(span)),
 			request.ServerPort(span.HostPort),
 			messagingSystemNATS,
 			semconv.MessagingDestinationName(span.Path),
 			semconv.MessagingClientID(span.Statement),
-			operation,
 			semconv.MessagingMessageEnvelopeSize(int(span.ContentLength)),
+		}
+		if span.Method != "" {
+			attrs = append(attrs, request.MessagingOperationType(span.Method))
 		}
 
 		if span.Type == request.EventTypeNATSClient {
 			attrs = append(attrs, request.PeerService(request.PeerServiceFromSpan(span)))
 		}
 	case request.EventTypeAMQPClient:
-		operation := request.MessagingOperationType(span.Method)
 		attrs = []attribute.KeyValue{
 			request.ServerAddr(request.HostAsServer(span)),
 			request.ServerPort(span.HostPort),
 			messagingSystemAMQP,
-			operation,
+		}
+		if span.Method != "" {
+			attrs = append(attrs, request.MessagingOperationType(span.Method))
 		}
 
 		attrs = append(attrs, request.PeerService(request.PeerServiceFromSpan(span)))

--- a/schemas/obi/README.md
+++ b/schemas/obi/README.md
@@ -3,21 +3,18 @@
 This registry (see `manifest.yaml`) extends the upstream OpenTelemetry
 semantic-conventions registry with the signals and attributes OBI emits in
 addition to — or as overrides of — the standard semconv set. Together with the
-upstream dependency it forms the complete contract of what OBI emits, and the
-weaver-validated integration suites enforce it
-(`internal/test/weavercheck`).
+upstream dependency it forms the complete contract of what OBI emits
 
 ## Overriding an upstream definition
 
 Weaver (v0.24.x) has **no precedence or merge semantics** between a local
 group and the groups a dependency contributes to the resolved registry
 (`--include-unreferenced`, which OBI needs). When the same attribute id or
-metric name is declared by more than one group, live-check silently resolves
+signal name is declared by more than one group, live-check silently resolves
 the duplicate in favor of the group whose id sorts **last lexicographically** —
 including the upstream `span.*` / `metric.*` groups that `ref` an attribute
 and therefore carry an embedded copy of its upstream definition. Tracked
-upstream in <https://github.com/open-telemetry/weaver/issues/1578>; verified
-still unfixed on weaver `main` as of 2026-07.
+upstream in <https://github.com/open-telemetry/weaver/issues/1578>.
 
 Until weaver defines local-wins override semantics, every override in
 `groups/` must follow these rules:

--- a/schemas/obi/README.md
+++ b/schemas/obi/README.md
@@ -1,0 +1,70 @@
+# OBI semantic-convention registry
+
+This registry (see `manifest.yaml`) extends the upstream OpenTelemetry
+semantic-conventions registry with the signals and attributes OBI emits in
+addition to — or as overrides of — the standard semconv set. Together with the
+upstream dependency it forms the complete contract of what OBI emits, and the
+weaver-validated integration suites enforce it
+(`internal/test/weavercheck`).
+
+## Overriding an upstream definition
+
+Weaver (v0.24.x) has **no precedence or merge semantics** between a local
+group and the groups a dependency contributes to the resolved registry
+(`--include-unreferenced`, which OBI needs). When the same attribute id or
+metric name is declared by more than one group, live-check silently resolves
+the duplicate in favor of the group whose id sorts **last lexicographically** —
+including the upstream `span.*` / `metric.*` groups that `ref` an attribute
+and therefore carry an embedded copy of its upstream definition. Tracked
+upstream in <https://github.com/open-telemetry/weaver/issues/1578>; verified
+still unfixed on weaver `main` as of 2026-07.
+
+Until weaver defines local-wins override semantics, every override in
+`groups/` must follow these rules:
+
+1. **Group id**: use the `x.obi.<namespace>` prefix so the override sorts
+   after every upstream group id (`registry.*`, `span.*`, `metric.*`, …) and
+   wins the resolution. Do not rename an override to something that sorts
+   earlier, and do not reuse an upstream group id (a same-id redefinition
+   loses the tie to the dependency AND trips `DuplicateGroupId` in
+   `registry check`).
+2. **Replacement, not merge**: an override REPLACES the upstream attribute
+   definition wholesale. An enum override must therefore carry the FULL
+   upstream member list plus OBI's extensions; when bumping the semconv
+   dependency, re-sync the upstream members verbatim from
+   `.deps/upstream-<version>/model/<ns>/registry.yaml`. A missing member
+   resurfaces as an `undefined_enum_variant` failure in the weaver-validated
+   suites, so drift is caught, not silent.
+3. **Expected lint duplicates**: `weaver registry check` flags each override
+   as a `DuplicateAttributeId` (or `DuplicateMetricName`) error even though
+   live-check resolves it. Each expected duplicate is allowlisted — tightly,
+   by attribute id and group pair — in `scripts/lint-schema-filter.jq`
+   (covered by `scripts/lint_schema_filter_test.go`). Anything else still
+   fails `make lint-schema`.
+
+`groups/dns.yaml` is the metric-level variant of the same problem (duplicate
+`metric_name` instead of attribute id) and follows the same group-id rule.
+
+## Two override styles
+
+- **Closed enum, extended**: the upstream value space is enumerable and OBI
+  intentionally emits extra members (e.g. `messaging.system` gains
+  `amqp`/`mqtt`/`nats`, `db.system.name` gains `aerospike`). The override
+  re-declares the enum with upstream members + OBI's, so weaver still flags
+  any value outside the combined list — bug values like an empty string or
+  `unknown` are deliberately NOT declared and keep failing the suites.
+- **Open-ended value space, re-typed as string**: upstream declares an enum,
+  but the real value space is unbounded by design — domain-specific error
+  codes (`error.type`) or provider/MCP operation vocabularies
+  (`gen_ai.operation.name`). Enumerating these is impossible, so the override
+  re-types the attribute as a plain `string` with examples. Weaver then
+  validates presence/type but not membership. For these attributes the
+  emitters must still omit the attribute instead of sending an empty value;
+  that guarantee lives in the emitter unit tests
+  (`pkg/appolly/app/request/span_getters_test.go`,
+  `pkg/export/otel/traces_test.go`), not in weaver.
+
+Values OBI merely passes through from user configuration (e.g.
+`deployment.environment.name` from a workload's `OTEL_RESOURCE_ATTRIBUTES`)
+are NOT overridden: the integration tests must configure values that satisfy
+the upstream conventions instead.

--- a/schemas/obi/groups/db.yaml
+++ b/schemas/obi/groups/db.yaml
@@ -1,0 +1,196 @@
+groups:
+  # Overrides `db.system.name`: extends the upstream enum with `aerospike`.
+  # OBI's Aerospike client instrumentation (pkg/ebpf/common/
+  # aerospike_detect_transform.go, reported via attr.DBSystemName in
+  # pkg/appolly/app/request/span_getters.go) identifies the Aerospike wire
+  # protocol, which upstream semconv v1.41 has no member for. The `unknown`
+  # fallback in the same getter is a bug marker and is deliberately NOT
+  # declared here, so weaver keeps flagging it.
+  #
+  # See ../README.md for the override mechanics (x.obi.* group id, full
+  # upstream member list, lint allowlist).
+  - id: x.obi.db
+    type: attribute_group
+    display_name: OBI Database Attribute Overrides
+    brief: >
+      OBI override of `db.system.name` extending the upstream enum with the
+      database systems OBI detects that upstream semconv has no member for.
+    attributes:
+      - id: db.system.name
+        brief: The database management system (DBMS) product as identified by the client instrumentation.
+        note: >
+          The actual DBMS may differ from the one identified by the client.
+          For example, when using PostgreSQL client libraries to connect to a CockroachDB, the `db.system.name`
+          is set to `postgresql` based on the instrumentation's best knowledge.
+        type:
+          members:
+            - id: other_sql
+              value: "other_sql"
+              brief: "Some other SQL database. Fallback only."
+              stability: development
+            - id: softwareag.adabas
+              value: "softwareag.adabas"
+              brief: "[Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas)"
+              stability: development
+            - id: actian.ingres
+              value: "actian.ingres"
+              brief: "[Actian Ingres](https://www.actian.com/databases/ingres/)"
+              stability: development
+            - id: aws.dynamodb
+              value: "aws.dynamodb"
+              brief: "[Amazon DynamoDB](https://aws.amazon.com/pm/dynamodb/)"
+              stability: development
+            - id: aws.redshift
+              value: "aws.redshift"
+              brief: "[Amazon Redshift](https://aws.amazon.com/redshift/)"
+              stability: development
+            - id: azure.cosmosdb
+              value: "azure.cosmosdb"
+              brief: "[Azure Cosmos DB](https://learn.microsoft.com/azure/cosmos-db)"
+              stability: development
+            - id: intersystems.cache
+              value: "intersystems.cache"
+              brief: "[InterSystems Caché](https://www.intersystems.com/products/cache/)"
+              stability: development
+            - id: cassandra
+              value: "cassandra"
+              brief: "[Apache Cassandra](https://cassandra.apache.org/)"
+              stability: development
+            - id: clickhouse
+              value: "clickhouse"
+              brief: "[ClickHouse](https://clickhouse.com/)"
+              stability: development
+            - id: cockroachdb
+              value: "cockroachdb"
+              brief: "[CockroachDB](https://www.cockroachlabs.com/)"
+              stability: development
+            - id: couchbase
+              value: "couchbase"
+              brief: "[Couchbase](https://www.couchbase.com/)"
+              stability: development
+            - id: couchdb
+              value: "couchdb"
+              brief: "[Apache CouchDB](https://couchdb.apache.org/)"
+              stability: development
+            - id: derby
+              value: "derby"
+              brief: "[Apache Derby](https://db.apache.org/derby/)"
+              stability: development
+            - id: elasticsearch
+              value: "elasticsearch"
+              brief: "[Elasticsearch](https://www.elastic.co/elasticsearch)"
+              stability: development
+            - id: firebirdsql
+              value: "firebirdsql"
+              brief: "[Firebird](https://www.firebirdsql.org/)"
+              stability: development
+            - id: gcp.spanner
+              value: "gcp.spanner"
+              brief: "[Google Cloud Spanner](https://cloud.google.com/spanner)"
+              stability: development
+            - id: geode
+              value: "geode"
+              brief: "[Apache Geode](https://geode.apache.org/)"
+              stability: development
+            - id: h2database
+              value: "h2database"
+              brief: "[H2 Database](https://h2database.com/)"
+              stability: development
+            - id: hbase
+              value: "hbase"
+              brief: "[Apache HBase](https://hbase.apache.org/)"
+              stability: development
+            - id: hive
+              value: "hive"
+              brief: "[Apache Hive](https://hive.apache.org/)"
+              stability: development
+            - id: hsqldb
+              value: "hsqldb"
+              brief: "[HyperSQL Database](https://hsqldb.org/)"
+              stability: development
+            - id: ibm.db2
+              value: "ibm.db2"
+              brief: "[IBM Db2](https://www.ibm.com/db2)"
+              stability: development
+            - id: ibm.informix
+              value: "ibm.informix"
+              brief: "[IBM Informix](https://www.ibm.com/products/informix)"
+              stability: development
+            - id: ibm.netezza
+              value: "ibm.netezza"
+              brief: "[IBM Netezza](https://www.ibm.com/products/netezza)"
+              stability: development
+            - id: influxdb
+              value: "influxdb"
+              brief: "[InfluxDB](https://www.influxdata.com/)"
+              stability: development
+            - id: instantdb
+              value: "instantdb"
+              brief: "[Instant](https://www.instantdb.com/)"
+              stability: development
+            - id: mariadb
+              value: "mariadb"
+              brief: "[MariaDB](https://mariadb.org/)"
+              stability: stable
+            - id: memcached
+              value: "memcached"
+              brief: "[Memcached](https://memcached.org/)"
+              stability: development
+            - id: mongodb
+              value: "mongodb"
+              brief: "[MongoDB](https://www.mongodb.com/)"
+              stability: development
+            - id: microsoft.sql_server
+              value: "microsoft.sql_server"
+              brief: "[Microsoft SQL Server](https://www.microsoft.com/sql-server)"
+              stability: stable
+            - id: mysql
+              value: "mysql"
+              brief: "[MySQL](https://www.mysql.com/)"
+              stability: stable
+            - id: neo4j
+              value: "neo4j"
+              brief: "[Neo4j](https://neo4j.com/)"
+              stability: development
+            - id: opensearch
+              value: "opensearch"
+              brief: "[OpenSearch](https://opensearch.org/)"
+              stability: development
+            - id: oracle.db
+              value: "oracle.db"
+              brief: "[Oracle Database](https://www.oracle.com/database/)"
+              stability: development
+            - id: postgresql
+              value: "postgresql"
+              brief: "[PostgreSQL](https://www.postgresql.org/)"
+              stability: stable
+            - id: redis
+              value: "redis"
+              brief: "[Redis](https://redis.io/)"
+              stability: development
+            - id: sap.hana
+              value: "sap.hana"
+              brief: "[SAP HANA](https://www.sap.com/products/technology-platform/hana/what-is-sap-hana.html)"
+              stability: development
+            - id: sap.maxdb
+              value: "sap.maxdb"
+              brief: "[SAP MaxDB](https://maxdb.sap.com/)"
+              stability: development
+            - id: sqlite
+              value: "sqlite"
+              brief: "[SQLite](https://www.sqlite.org/)"
+              stability: development
+            - id: teradata
+              value: "teradata"
+              brief: "[Teradata](https://www.teradata.com/)"
+              stability: development
+            - id: trino
+              value: "trino"
+              brief: "[Trino](https://trino.io/)"
+              stability: development
+            # --- OBI extensions (not in upstream semconv v1.41) ---
+            - id: aerospike
+              value: "aerospike"
+              brief: "[Aerospike](https://aerospike.com/)"
+              stability: development
+        stability: stable

--- a/schemas/obi/groups/error.yaml
+++ b/schemas/obi/groups/error.yaml
@@ -1,0 +1,36 @@
+groups:
+  # Re-types `error.type` as string (upstream: enum whose only member is
+  # `_OTHER`, with arbitrary domain strings as examples). Every real error
+  # value OBI captures — HTTP status codes, DNS RCODEs ('NXDomain'), database
+  # error codes, GenAI provider error codes ('insufficient_quota') — is
+  # outside the declared enum by construction, and the set is unbounded, so
+  # it cannot be enumerated. Emitters must omit the attribute on success and
+  # never send an empty string; pinned by
+  # pkg/appolly/app/request/span_getters_test.go and
+  # pkg/export/otel/traces_test.go.
+  #
+  # See ../README.md for the override mechanics (x.obi.* group id, string
+  # re-typing of open-ended value spaces, lint allowlist).
+  - id: x.obi.error
+    type: attribute_group
+    display_name: OBI Error Attribute Overrides
+    brief: >
+      OBI override of `error.type` re-typed as an open-ended string: OBI
+      reports domain-specific error identifiers whose value space is
+      unbounded.
+    attributes:
+      - id: error.type
+        type: string
+        stability: stable
+        brief: >
+          Describes a class of error the operation ended with.
+        examples: ['timeout', 'java.net.UnknownHostException', 'server_certificate_invalid', '500']
+        note: |
+          The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+
+          When `error.type` is set to a type (e.g., an exception type), its
+          canonical class name identifying the type within the artifact SHOULD be used.
+
+          Instrumentations SHOULD document the list of errors they report.
+
+          If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.

--- a/schemas/obi/groups/gen_ai.yaml
+++ b/schemas/obi/groups/gen_ai.yaml
@@ -1,0 +1,177 @@
+groups:
+  # Overrides two `gen_ai.*` attributes:
+  #
+  # - `gen_ai.provider.name`: extends the upstream enum with the GenAI,
+  #   embedding, rerank, and vector-retrieval providers OBI detects that
+  #   upstream semconv has no member for. The extension members mirror the
+  #   provider-detection tables in
+  #   pkg/ebpf/common/http/{embedding,rerank,retrieval}.go and the
+  #   Qwen/DashScope parser; adding a provider to those tables requires adding
+  #   its member here (the weaver-validated suites fail otherwise).
+  # - `gen_ai.operation.name`: re-typed as a plain string. Upstream's note
+  #   explicitly recommends system-specific operation names, and OBI emits the
+  #   provider's own vocabulary ('invoke_model' for Bedrock, 'message' for
+  #   Anthropic, 'conversation'/'response' for the OpenAI APIs, 'rerank', ...)
+  #   plus MCP JSON-RPC method names verbatim — custom MCP servers make the
+  #   value space unbounded, so it cannot be enumerated.
+  #
+  # See ../README.md for the override mechanics (x.obi.* group id, full
+  # upstream member list, lint allowlist).
+  - id: x.obi.gen_ai
+    type: attribute_group
+    display_name: OBI GenAI Attribute Overrides
+    brief: >
+      OBI overrides of `gen_ai.provider.name` (upstream enum extended with
+      the providers OBI detects that upstream semconv has no member for) and
+      `gen_ai.operation.name` (re-typed as an open-ended string).
+    attributes:
+      - id: gen_ai.provider.name
+        stability: development
+        type:
+          members:
+            - id: openai
+              stability: development
+              value: "openai"
+              brief: '[OpenAI](https://openai.com/)'
+            - id: gcp.gen_ai
+              stability: development
+              value: "gcp.gen_ai"
+              brief: "Any Google generative AI endpoint"
+              note: >
+                May be used when specific backend is unknown.
+            - id: gcp.vertex_ai
+              stability: development
+              value: "gcp.vertex_ai"
+              brief: "[Vertex AI](https://cloud.google.com/vertex-ai)"
+              note: >
+                Used when accessing the 'aiplatform.googleapis.com' endpoint.
+            - id: gcp.gemini
+              stability: development
+              value: "gcp.gemini"
+              brief: '[Gemini](https://cloud.google.com/products/gemini)'
+              note: >
+                Used when accessing the 'generativelanguage.googleapis.com' endpoint.
+                Also known as the AI Studio API.
+            - id: anthropic
+              stability: development
+              value: "anthropic"
+              brief: '[Anthropic](https://www.anthropic.com/)'
+            - id: cohere
+              stability: development
+              value: "cohere"
+              brief: '[Cohere](https://cohere.com/)'
+            - id: azure.ai.inference
+              stability: development
+              value: "azure.ai.inference"
+              brief: 'Azure AI Inference'
+            - id: azure.ai.openai
+              stability: development
+              value: "azure.ai.openai"
+              brief: '[Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview)'
+            - id: ibm.watsonx.ai
+              stability: development
+              value: "ibm.watsonx.ai"
+              brief: '[IBM Watsonx AI](https://www.ibm.com/products/watsonx-ai)'
+            - id: aws.bedrock
+              stability: development
+              value: "aws.bedrock"
+              brief: '[AWS Bedrock](https://aws.amazon.com/bedrock)'
+            - id: perplexity
+              stability: development
+              value: "perplexity"
+              brief: '[Perplexity](https://www.perplexity.ai/)'
+            - id: x_ai
+              stability: development
+              value: "x_ai"
+              brief: '[xAI](https://x.ai/)'
+            - id: deepseek
+              stability: development
+              value: "deepseek"
+              brief: '[DeepSeek](https://www.deepseek.com/)'
+            - id: groq
+              stability: development
+              value: "groq"
+              brief: '[Groq](https://groq.com/)'
+            - id: mistral_ai
+              stability: development
+              value: "mistral_ai"
+              brief: '[Mistral AI](https://mistral.ai/)'
+            # --- OBI extensions (not in upstream semconv v1.41) ---
+            - id: qwen
+              stability: development
+              value: "qwen"
+              brief: '[Alibaba Qwen / DashScope](https://www.alibabacloud.com/en/product/modelstudio)'
+            - id: voyage
+              stability: development
+              value: "voyage"
+              brief: '[Voyage AI](https://www.voyageai.com/) embedding and rerank APIs'
+            - id: jina
+              stability: development
+              value: "jina"
+              brief: '[Jina AI](https://jina.ai/) embedding and rerank APIs'
+            - id: pinecone
+              stability: development
+              value: "pinecone"
+              brief: '[Pinecone](https://www.pinecone.io/) vector retrieval'
+            - id: qdrant
+              stability: development
+              value: "qdrant"
+              brief: '[Qdrant](https://qdrant.tech/) vector retrieval'
+            - id: milvus
+              stability: development
+              value: "milvus"
+              brief: '[Milvus](https://milvus.io/) vector retrieval'
+            - id: zilliz
+              stability: development
+              value: "zilliz"
+              brief: '[Zilliz Cloud](https://zilliz.com/) vector retrieval'
+            - id: chroma
+              stability: development
+              value: "chroma"
+              brief: '[Chroma](https://www.trychroma.com/) vector retrieval'
+            - id: weaviate
+              stability: development
+              value: "weaviate"
+              brief: '[Weaviate](https://weaviate.io/) vector retrieval'
+            - id: generic
+              stability: development
+              value: "generic"
+              brief: >
+                A vector-retrieval provider OBI identified from the request
+                shape without recognizing the vendor.
+        brief: The Generative AI provider as identified by the client
+          or server instrumentation.
+        note: |
+          The attribute SHOULD be set based on the instrumentation's best
+          knowledge and may differ from the actual model provider.
+
+          Multiple providers, including Azure OpenAI, Gemini, and AI hosting platforms
+          are accessible using the OpenAI REST API and corresponding client libraries,
+          but may proxy or host models from different providers.
+
+          The `gen_ai.request.model`, `gen_ai.response.model`, and `server.address`
+          attributes may help identify the actual system in use.
+
+          The `gen_ai.provider.name` attribute acts as a discriminator that
+          identifies the GenAI telemetry format flavor specific to that provider
+          within GenAI semantic conventions.
+          It SHOULD be set consistently with provider-specific attributes and signals.
+          For example, GenAI spans, metrics, and events related to AWS Bedrock
+          should have the `gen_ai.provider.name` set to `aws.bedrock` and include
+          applicable `aws.bedrock.*` attributes and are not expected to include
+          `openai.*` attributes.
+      # Re-typed as string (upstream: enum): OBI emits provider-specific
+      # operation vocabularies and MCP JSON-RPC method names verbatim, so the
+      # value space is open-ended. Emitters must omit the attribute when no
+      # operation name is available (never send an empty string); pinned by
+      # pkg/appolly/app/request/span_getters_test.go.
+      - id: gen_ai.operation.name
+        stability: development
+        type: string
+        brief: The name of the operation being performed.
+        note: >
+          OBI reports the provider's own operation vocabulary (e.g.
+          'invoke_model' for Bedrock, 'message' for Anthropic, 'generation'
+          for Qwen/DashScope, 'conversation'/'response' for the OpenAI APIs,
+          'rerank') and passes MCP JSON-RPC method names through verbatim.
+        examples: ['chat', 'embeddings', 'response', 'conversation', 'invoke_model', 'rerank', 'tools/call']

--- a/schemas/obi/groups/messaging.yaml
+++ b/schemas/obi/groups/messaging.yaml
@@ -1,0 +1,89 @@
+groups:
+  # Overrides `messaging.system`: extends the upstream enum with `amqp`,
+  # `mqtt` and `nats` — messaging protocols OBI detects that upstream semconv
+  # has no member for. OBI identifies the protocol on the wire, not the broker
+  # product behind it, so `amqp` is reported as-is rather than assuming
+  # `rabbitmq`. Emitters: pkg/appolly/app/request/span_getters.go
+  # (attr.MessagingSystem) and pkg/export/otel/tracesgen/tracesgen.go.
+  #
+  # See ../README.md for the override mechanics (x.obi.* group id, full
+  # upstream member list, lint allowlist).
+  - id: x.obi.messaging
+    type: attribute_group
+    display_name: OBI Messaging Attribute Overrides
+    brief: >
+      OBI override of `messaging.system` extending the upstream enum with the
+      messaging protocols OBI detects that upstream semconv has no member for.
+    attributes:
+      - id: messaging.system
+        brief: The messaging system as identified by the client instrumentation.
+        note: >
+          The actual messaging system may differ from the one known by the client.
+          For example, when using Kafka client libraries to communicate with Azure Event Hubs, the `messaging.system`
+          is set to `kafka` based on the instrumentation's best knowledge.
+        type:
+          members:
+            - id: activemq
+              value: 'activemq'
+              brief: 'Apache ActiveMQ'
+              stability: development
+            - id: aws.sns
+              value: 'aws.sns'
+              brief: 'Amazon Simple Notification Service (SNS)'
+              stability: development
+            - id: aws_sqs
+              value: 'aws_sqs'
+              brief: 'Amazon Simple Queue Service (SQS)'
+              stability: development
+            - id: eventgrid
+              value: 'eventgrid'
+              brief: 'Azure Event Grid'
+              stability: development
+            - id: eventhubs
+              value: 'eventhubs'
+              brief: 'Azure Event Hubs'
+              stability: development
+            - id: servicebus
+              value: 'servicebus'
+              brief: 'Azure Service Bus'
+              stability: development
+            - id: gcp_pubsub
+              value: 'gcp_pubsub'
+              brief: 'Google Cloud Pub/Sub'
+              stability: development
+            - id: jms
+              value: 'jms'
+              brief: 'Java Message Service'
+              stability: development
+            - id: kafka
+              value: 'kafka'
+              brief: 'Apache Kafka'
+              stability: development
+            - id: rabbitmq
+              value: 'rabbitmq'
+              brief: 'RabbitMQ'
+              stability: development
+            - id: rocketmq
+              value: 'rocketmq'
+              brief: 'Apache RocketMQ'
+              stability: development
+            - id: pulsar
+              value: 'pulsar'
+              brief: 'Apache Pulsar'
+              stability: development
+            # --- OBI extensions (not in upstream semconv v1.41) ---
+            - id: amqp
+              value: 'amqp'
+              brief: >
+                An AMQP 0-9-1 broker (e.g. RabbitMQ). OBI detects the wire
+                protocol, not the broker product behind it.
+              stability: development
+            - id: mqtt
+              value: 'mqtt'
+              brief: 'An MQTT broker'
+              stability: development
+            - id: nats
+              value: 'nats'
+              brief: 'NATS'
+              stability: development
+        stability: development

--- a/schemas/obi/groups/openai.yaml
+++ b/schemas/obi/groups/openai.yaml
@@ -1,0 +1,33 @@
+groups:
+  # Overrides `openai.api.type`: extends the upstream enum with `embeddings`.
+  # pkg/ebpf/common/http/openai.go classifies OpenAI calls as
+  # chat_completions / responses / embeddings from the URL path; upstream
+  # v1.41 declares only the first two.
+  #
+  # See ../README.md for the override mechanics (x.obi.* group id, full
+  # upstream member list, lint allowlist).
+  - id: x.obi.openai
+    type: attribute_group
+    display_name: OBI OpenAI Attribute Overrides
+    brief: >
+      OBI override of `openai.api.type` extending the upstream enum with the
+      embeddings API, which OBI detects but upstream semconv has no member for.
+    attributes:
+      - id: openai.api.type
+        stability: development
+        type:
+          members:
+            - id: chat_completions
+              value: "chat_completions"
+              brief: The OpenAI [Chat Completions API](https://developers.openai.com/api/reference/chat-completions/overview).
+              stability: development
+            - id: responses
+              value: "responses"
+              brief: The OpenAI [Responses API](https://developers.openai.com/api/reference/responses/overview).
+              stability: development
+            # --- OBI extensions (not in upstream semconv v1.41) ---
+            - id: embeddings
+              value: "embeddings"
+              brief: The OpenAI [Embeddings API](https://developers.openai.com/api/reference/embeddings/overview).
+              stability: development
+        brief: The type of OpenAI API being used.

--- a/schemas/obi/groups/rpc.yaml
+++ b/schemas/obi/groups/rpc.yaml
@@ -1,0 +1,56 @@
+groups:
+  # Overrides `rpc.system.name`: extends the upstream enum with `aws-api`,
+  # which OBI reports for AWS SDK calls (S3, SQS, ...) detected on the wire —
+  # the value the AWS SDK instrumentation conventions historically used for
+  # `rpc.system`, which upstream v1.41 has no `rpc.system.name` member for.
+  # Emitters: pkg/appolly/app/request/span_getters.go (attr.RPCSystem) and
+  # pkg/export/otel/tracesgen/tracesgen.go.
+  #
+  # See ../README.md for the override mechanics (x.obi.* group id, full
+  # upstream member list, lint allowlist).
+  - id: x.obi.rpc
+    type: attribute_group
+    display_name: OBI RPC Attribute Overrides
+    brief: >
+      OBI override of `rpc.system.name` extending the upstream enum with the
+      RPC systems OBI detects that upstream semconv has no member for.
+    attributes:
+      - id: rpc.system.name
+        brief: 'The Remote Procedure Call (RPC) system.'
+        note: >
+          The client and server RPC systems may differ for the same RPC interaction.
+          For example, a client may use Apache Dubbo or Connect RPC to communicate
+          with a server that uses gRPC since both protocols provide compatibility
+          with gRPC.
+        type:
+          members:
+            - id: grpc
+              value: 'grpc'
+              brief: '[gRPC](https://grpc.io/)'
+              stability: release_candidate
+            - id: dubbo
+              value: 'dubbo'
+              brief: '[Apache Dubbo](https://dubbo.apache.org/)'
+              stability: release_candidate
+            - id: connectrpc
+              value: 'connectrpc'
+              brief: '[Connect RPC](https://connectrpc.com/)'
+              stability: development
+            - id: jsonrpc
+              value: 'jsonrpc'
+              brief: '[JSON-RPC](https://www.jsonrpc.org/)'
+              stability: development
+            # --- OBI extensions (not in upstream semconv v1.41) ---
+            - id: aws-api
+              value: 'aws-api'
+              brief: >
+                An AWS service API call detected on the wire (S3, SQS, ...).
+                Mirrors the `aws-api` value the AWS SDK instrumentation
+                conventions used for the former `rpc.system` attribute.
+              stability: development
+            - id: onc_rpc
+              value: 'onc_rpc'
+              brief: >
+                ONC/Sun RPC, detected by OBI's SunRPC instrumentation.
+              stability: development
+        stability: release_candidate

--- a/schemas/obi/groups/service_graph.yaml
+++ b/schemas/obi/groups/service_graph.yaml
@@ -40,8 +40,8 @@ groups:
         stability: development
         brief: >
           The connection type between the two services (mirroring the
-          servicegraphconnector values). Empty string represents a direct
-          HTTP/gRPC request.
+          servicegraphconnector values). The attribute is omitted for a
+          direct HTTP/gRPC request.
       - id: server_service_namespace
         type: string
         stability: development

--- a/schemas/obi/groups/telemetry.yaml
+++ b/schemas/obi/groups/telemetry.yaml
@@ -1,0 +1,67 @@
+groups:
+  # Overrides `telemetry.sdk.language`: extends the upstream enum with
+  # `generic`, which pkg/appolly/app/svc/svc.go (InstrumentableType.String)
+  # reports for executables with no recognized language runtime — OBI
+  # instruments processes that carry no SDK at all, a case the upstream enum
+  # has no member for. The `unknown` fallback in the same switch is a bug
+  # marker and is deliberately NOT declared here, so weaver keeps flagging it.
+  #
+  # See ../README.md for the override mechanics (x.obi.* group id, full
+  # upstream member list, lint allowlist).
+  - id: x.obi.telemetry
+    type: attribute_group
+    display_name: OBI Telemetry Attribute Overrides
+    brief: >
+      OBI override of `telemetry.sdk.language` extending the upstream enum
+      with the `generic` language OBI reports for processes with no
+      recognized language runtime.
+    attributes:
+      - id: telemetry.sdk.language
+        type:
+          members:
+            - id: cpp
+              value: "cpp"
+              stability: stable
+            - id: dotnet
+              value: "dotnet"
+              stability: stable
+            - id: erlang
+              value: "erlang"
+              stability: stable
+            - id: go
+              value: "go"
+              stability: stable
+            - id: java
+              value: "java"
+              stability: stable
+            - id: nodejs
+              value: "nodejs"
+              stability: stable
+            - id: php
+              value: "php"
+              stability: stable
+            - id: python
+              value: "python"
+              stability: stable
+            - id: ruby
+              value: "ruby"
+              stability: stable
+            - id: rust
+              value: "rust"
+              stability: stable
+            - id: swift
+              value: "swift"
+              stability: stable
+            - id: webjs
+              value: "webjs"
+              stability: stable
+            # --- OBI extensions (not in upstream semconv v1.41) ---
+            - id: generic
+              value: "generic"
+              brief: >
+                A process with no recognized language runtime, instrumented
+                at the eBPF level without any telemetry SDK.
+              stability: development
+        stability: stable
+        brief: >
+          The language of the telemetry SDK.

--- a/scripts/lint-schema-filter.jq
+++ b/scripts/lint-schema-filter.jq
@@ -1,28 +1,50 @@
 # Filters `weaver registry check` JSON diagnostics down to the ones that must
-# fail `make lint-schema`, removing only the single expected finding:
+# fail `make lint-schema`, removing only the expected findings below. Weaver
+# has no first-class override mechanism between a registry and its
+# dependencies yet, nor a CLI flag to suppress the duplicate checks, while
+# `registry live-check` resolves each duplicate in the local group's favor.
+# Tracked in https://github.com/open-telemetry/weaver/issues/1578; when
+# weaver defines override semantics this filter (and the override groups
+# documented in schemas/obi/README.md) can be dropped.
 #
-# DuplicateMetricName for `dns.lookup.duration` between the upstream semconv
-# dependency (under `.deps/`) and `schemas/obi/groups/dns.yaml`. That file
-# deliberately re-declares the upstream metric (via `extends` under a distinct
-# group id) to relax `dns.question.name` from required to opt_in — weaver has
-# no first-class override mechanism between a registry and its dependencies
-# yet, nor a CLI flag to suppress the duplicate check, while `registry
-# live-check` resolves the duplicate in the local group's favor. Tracked in
-# https://github.com/open-telemetry/weaver/issues/1578; when weaver defines
-# override semantics this filter (and the comment in groups/dns.yaml) can be
-# dropped.
+# 1. DuplicateMetricName for `dns.lookup.duration` between the upstream
+#    semconv dependency (under `.deps/`) and `schemas/obi/groups/dns.yaml`.
+#    That file deliberately re-declares the upstream metric (via `extends`
+#    under a distinct group id) to relax `dns.question.name` from required to
+#    opt_in.
 #
-# Any other diagnostic — including a DuplicateMetricName for a different
-# metric, or for dns.lookup.duration with unexpected provenances — is kept and
-# fails the lint. Covered by scripts/lint_schema_filter_test.go.
+# 2. DuplicateAttributeId for the attribute overrides in
+#    `schemas/obi/groups/` (see schemas/obi/README.md): each re-declares an
+#    upstream attribute (from group `registry.<ns>`, under the distinct group
+#    id `x.obi.<ns>`) — either an enum extended with the values OBI
+#    intentionally emits, or an open-ended enum re-typed as string.
+#
+# Any other diagnostic — including duplicates for other metrics/attributes,
+# or the expected ones with unexpected provenances/groups — is kept and fails
+# the lint. Covered by scripts/lint_schema_filter_test.go.
 map(select(
   (
-    (.error.DuplicateMetricName? // null) as $dup
-    | $dup != null
-      and $dup.metric_name == "dns.lookup.duration"
-      and (($dup.provenances // []) | length) == 2
-      and ([$dup.provenances[].path] | sort
-           | (.[0] | startswith(".deps/"))
-             and (.[1] | endswith("groups/dns.yaml")))
+    (
+      (.error.DuplicateMetricName? // null) as $dup
+      | $dup != null
+        and $dup.metric_name == "dns.lookup.duration"
+        and (($dup.provenances // []) | length) == 2
+        and ([$dup.provenances[].path] | sort
+             | (.[0] | startswith(".deps/"))
+               and (.[1] | endswith("groups/dns.yaml")))
+    )
+    or
+    (
+      (.error.DuplicateAttributeId? // null) as $dup
+      | $dup != null
+        and ($dup.attribute_id
+             | IN("messaging.system", "gen_ai.provider.name", "gen_ai.operation.name",
+                  "openai.api.type", "telemetry.sdk.language", "db.system.name",
+                  "rpc.system.name", "error.type"))
+        and ((($dup.group_ids // []) | sort) as $groups
+             | ($groups | length) == 2
+               and ($groups[0] | startswith("registry."))
+               and $groups[1] == ("x.obi." + ($groups[0] | ltrimstr("registry."))))
+    )
   ) | not
 ))

--- a/scripts/lint_schema_filter_test.go
+++ b/scripts/lint_schema_filter_test.go
@@ -51,6 +51,66 @@ func TestLintSchemaFilterAllowsExpectedDNSDuplicate(t *testing.T) {
 	}
 }
 
+// expectedEnumOverrideDuplicates mirrors the DuplicateAttributeId diagnostics
+// weaver emits for the attribute overrides in schemas/obi/groups/ (see
+// schemas/obi/README.md).
+const expectedEnumOverrideDuplicates = `[{
+	"diagnostic": {"severity": "Error"},
+	"error": {"DuplicateAttributeId": {
+		"attribute_id": "messaging.system",
+		"group_ids": ["registry.messaging", "x.obi.messaging"]
+	}}
+}, {
+	"diagnostic": {"severity": "Error"},
+	"error": {"DuplicateAttributeId": {
+		"attribute_id": "gen_ai.provider.name",
+		"group_ids": ["registry.gen_ai", "x.obi.gen_ai"]
+	}}
+}, {
+	"diagnostic": {"severity": "Error"},
+	"error": {"DuplicateAttributeId": {
+		"attribute_id": "gen_ai.operation.name",
+		"group_ids": ["registry.gen_ai", "x.obi.gen_ai"]
+	}}
+}, {
+	"diagnostic": {"severity": "Error"},
+	"error": {"DuplicateAttributeId": {
+		"attribute_id": "openai.api.type",
+		"group_ids": ["registry.openai", "x.obi.openai"]
+	}}
+}, {
+	"diagnostic": {"severity": "Error"},
+	"error": {"DuplicateAttributeId": {
+		"attribute_id": "telemetry.sdk.language",
+		"group_ids": ["registry.telemetry", "x.obi.telemetry"]
+	}}
+}, {
+	"diagnostic": {"severity": "Error"},
+	"error": {"DuplicateAttributeId": {
+		"attribute_id": "db.system.name",
+		"group_ids": ["registry.db", "x.obi.db"]
+	}}
+}, {
+	"diagnostic": {"severity": "Error"},
+	"error": {"DuplicateAttributeId": {
+		"attribute_id": "rpc.system.name",
+		"group_ids": ["registry.rpc", "x.obi.rpc"]
+	}}
+}, {
+	"diagnostic": {"severity": "Error"},
+	"error": {"DuplicateAttributeId": {
+		"attribute_id": "error.type",
+		"group_ids": ["registry.error", "x.obi.error"]
+	}}
+}]`
+
+func TestLintSchemaFilterAllowsExpectedEnumOverrideDuplicates(t *testing.T) {
+	remaining := runLintSchemaFilter(t, expectedEnumOverrideDuplicates)
+	if len(remaining) != 0 {
+		t.Fatalf("expected the documented enum-override attribute duplicates to be filtered, got %d diagnostics", len(remaining))
+	}
+}
+
 func TestLintSchemaFilterKeepsUnrelatedDiagnostics(t *testing.T) {
 	cases := map[string]string{
 		"duplicate of another metric": `[{
@@ -84,6 +144,24 @@ func TestLintSchemaFilterKeepsUnrelatedDiagnostics(t *testing.T) {
 		"different error type": `[{
 			"diagnostic": {"severity": "Error"},
 			"error": {"DuplicateGroupId": {"group_id": "metric.dns.lookup.duration"}}
+		}]`,
+		"attribute duplicate for an undeclared attribute": `[{
+			"error": {"DuplicateAttributeId": {
+				"attribute_id": "http.request.method",
+				"group_ids": ["registry.http", "x.obi.http"]
+			}}
+		}]`,
+		"attribute duplicate with a non-obi group pair": `[{
+			"error": {"DuplicateAttributeId": {
+				"attribute_id": "messaging.system",
+				"group_ids": ["registry.messaging", "x.obi.something"]
+			}}
+		}]`,
+		"attribute duplicate declared a third time": `[{
+			"error": {"DuplicateAttributeId": {
+				"attribute_id": "messaging.system",
+				"group_ids": ["registry.messaging", "x.obi.messaging", "registry.extra"]
+			}}
 		}]`,
 	}
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2572

Weaver `registry live-check` reported `undefined_enum_variant` findings caused by real
emitter bugs: enumerated semconv attributes were emitted with values outside their
declared members — an HTTP status leaking into the gRPC status attribute, and empty
strings for `connection_type`, `error.type`, and `messaging.operation.type`.

This PR fixes each emitter (omitting the attribute when there is no valid value,
never inventing one) and then flips enforcement: `undefined_enum_variant` is now an
actionable advice type in `weavercheck`, so any regression fails the suites.

## Root causes and fixes

### 1. gRPC status code carrying an HTTP status (`rpc.response.status_code`)

Before the semconv v1.41 migration OBI emitted `rpc.grpc.status_code` as a raw
`span.Status` int, so a leaked HTTP status surfaced as `rpc.grpc.status_code=200`.
After the migration the same leak produced fabricated `rpc.response.status_code`
values: `GRPCStatusCodeString` returned `"CODE(200)"` (or `"CODE(65535)"` from the
eBPF client-side `u16(-1)` status-read fallback) for anything outside the gRPC
enum (0–16).

- `pkg/appolly/app/request/grpc_status.go` — `GRPCStatusCodeString` now returns `""`
  for statuses outside 0–16 instead of `"CODE(n)"`.
- `pkg/appolly/app/request/span_getters.go` (`attr.RPCResponseStatusCode` getter) and
  `pkg/export/otel/tracesgen/tracesgen.go` (gRPC server + client span attributes) —
  the attribute is omitted when `GRPCStatusCodeString` returns `""`.

### 2. `connection_type` emitted as an empty string on service-graph metrics

`ConnectionTypeForSpan` returns `""` for direct HTTP/gRPC requests, but the
service-graph recorder attached the attribute unconditionally, emitting an empty
(invalid) enum variant on every direct-request metric.

- `pkg/export/otel/metrics_svc_graph.go` — the attribute is only attached when the
  connection type is non-empty.
- `schemas/obi/groups/service_graph.yaml` — brief updated: the attribute is omitted
  for direct requests (previously documented as "empty string represents a direct
  request").

### 3. `error.type` emitted as an empty string on successful requests

- `pkg/appolly/app/request/span_getters.go` (`attr.ErrorType` getter) — returned
  `error.type=""` for every successful request on metrics; now omits the attribute.
- `pkg/export/otel/tracesgen/tracesgen.go` — Elasticsearch spans attached
  `error.type` unguarded (empty on success), and SQL error spans attached it even
  when the SQLSTATE was not captured; both are now guarded.

### 4. `messaging.operation.type` emitted as an empty string

- `pkg/appolly/app/request/span_getters.go` (`attr.MessagingOpType` getter) —
  defaulted to `""` for non-messaging spans / unknown operations; now omits.
- `pkg/export/otel/tracesgen/tracesgen.go` — Kafka/MQTT/NATS/AMQP spans attached the
  attribute even when `span.Method` was empty, and AWS SQS spans when the operation
  type was unrecognized; all sites now omit instead.

### 5. `gen_ai.operation.name` emitted as an empty string (found by CI after the flip)

The first weaver-enforced CI run flagged `gen_ai.operation.name=""` on OpenAI
error spans (`span:POST /v1/responses`) and on the gen_ai metrics.

- `pkg/appolly/app/request/span_getters.go` (`attr.GenAIOperationName`,
  `attr.GenAIProviderName` getters) — omit when the span carries no value.
- `pkg/export/otel/tracesgen/tracesgen.go` — OpenAI, Anthropic, and Qwen span
  attribute sites now omit `gen_ai.operation.name` when the operation was not
  classified.

### 6. HTTP/2 connection preface reported as a request span (`PRI *`)

Go's h2c upgrade path lets `net/http` parse the HTTP/2 client connection
preface (`PRI * HTTP/2.0`, RFC 9113 §3.4) as a literal request before
hijacking the connection, so the Go tracer uprobes surfaced a bogus
`http.request.method="PRI"` span (`span:PRI *`) on every h2c connection
(flagged by weaver in the gRPC-mux suite).

- `pkg/ebpf/common/common.go` — `isH2CPrefacePseudoRequest` drops these
  pseudo-requests at span-conversion time; the real HTTP/2 exchanges on the
  connection are traced separately by the http2 tracer.

### 7. `gen_ai.operation.name` missing on failed OpenAI calls

The omission fix (5) traded an empty enum value for a missing-required-
attribute violation: OpenAI error responses carry no `object` field, so
spans/metrics for failed `/v1/responses` calls had no operation name at all —
but `gen_ai.operation.name` is `required` on the gen_ai client metrics.

- `pkg/ebpf/common/http/openai.go` — the operation name is now derived from
  the request path (authoritative even on errors): `/v1/responses` →
  `response`, `/v1/conversations` → `conversation` (matching the existing
  `/v1/chat/completions` / `/v1/embeddings` handling). Failed calls now get
  the semconv span name (`response gpt-5-mini`) and fully-attributed metrics.
- `internal/test/oats/ai/yaml/oats_open_ai_test.yaml` — error-span assertion
  updated accordingly.

### Registry overrides (values OBI emits on purpose)

CI flagged values OBI emits intentionally but that upstream semconv v1.41
cannot validate. These are declared as attribute overrides in
`schemas/obi/groups/`, in two styles (documented once in
`schemas/obi/README.md`):

**Closed enums, extended** (upstream members duplicated verbatim + OBI
extensions — weaver has no enum-member merge, a local re-declaration replaces
the upstream definition in live-check's lookup):

- `messaging.yaml` — `messaging.system` + `amqp`, `mqtt`, `nats` (OBI detects
  the wire protocol, not the broker product).
- `gen_ai.yaml` — `gen_ai.provider.name` + `qwen`, `voyage`, `jina`,
  `pinecone`, `qdrant`, `milvus`, `zilliz`, `chroma`, `weaviate`, `generic`
  (mirrors the provider-detection tables in `pkg/ebpf/common/http/`).
- `openai.yaml` — `openai.api.type` + `embeddings`.
- `telemetry.yaml` — `telemetry.sdk.language` + `generic` (processes with no
  recognized language runtime; the `unknown` bug-marker fallback is
  deliberately NOT declared so weaver keeps flagging it).
- `db.yaml` (new) — `db.system.name` + `aerospike` (OBI's Aerospike client
  instrumentation; `unknown` again deliberately not declared).
- `rpc.yaml` (new) — `rpc.system.name` + `aws-api` (AWS SDK calls detected on
  the wire) and `onc_rpc` (SunRPC instrumentation).

**Open-ended value spaces, re-typed as string** (for values which are declared as enums by the otel semconv but are explicitly not enums):

- `error.yaml` (new) — `error.type`: upstream declares only `_OTHER` and its
  examples are arbitrary domain strings; observed CI values include
  `insufficient_quota`, `NXDomain`, `ValidationException`, `error`.
- `gen_ai.yaml` — `gen_ai.operation.name`: OBI emits provider-specific
  operation vocabulary (`invoke_model`, `message`, `conversation`,
  `response`, `rerank`, ...) and passes MCP JSON-RPC method names through
  verbatim.

For these two, the "never emit an empty value" guarantee moves entirely to
the emitter unit tests (weaver cannot flag an empty string on a string-typed
attribute).

**Test-config fix (no override)**: the Rails suites set
`deployment.environment.name=to` in their own `OTEL_RESOURCE_ATTRIBUTES`
(passthrough verification with an arbitrary value), which weaver flagged
against upstream's enum (production/staging/test/development). OBI is a pure
passthrough here — verified `ParseOTELResourceVariable` does not truncate —
so the tests now use the valid member `staging` instead of declaring a
registry override for a user-configured attribute
(`internal/test/integration/docker-compose-ruby*.yml`,
`red_test_ruby.go`).

Group ids use a `x.obi.<ns>` prefix: weaver v0.24.1 resolves duplicate
attribute names last-insert-wins over id-sorted groups, and upstream `span.*`
groups that `ref` these attributes sort after `registry.*` (verified
empirically with `weaver registry live-check`: OBI extensions, re-typed
values, and all upstream members accepted; bogus values and `unknown` still
flagged; also verified the bug is unfixed on weaver `main` as of 2026-07 —
see weaver#1578). The resulting `DuplicateAttributeId` lint findings are
allowlisted (tightly, per attribute + group pair) in
`scripts/lint-schema-filter.jq`, with cases added to
`scripts/lint_schema_filter_test.go`. The full override mechanics are
documented once in `schemas/obi/README.md`; the per-file comments only state
WHAT is overridden and why.

### Omission plumbing

Getters signal omission by returning an invalid (zero) `attribute.KeyValue`, which
the OTLP metrics `Expirer` already skips. `spanPromGetters` now maps omission to
`""` explicitly — Prometheus label sets are fixed, and `Value.Emit()` on an invalid
value would otherwise have produced the string `"unknown"`.

### Enforcement flip

- `internal/test/weavercheck/weavercheck.go` — `undefined_enum_variant` added
  to `actionableAdviceTypes` (as a named const, per review) with a doc comment
  in the existing style. Weaver classifies these findings as
  `information`-level (enums are open), but every occurrence seen so far has
  been an emitter bug. There is no in-code exemption list: values OBI emits on
  purpose are declared in the registry overrides, so anything weaver still
  flags is a bug by definition.

## Testing

- New/updated unit tests:
  - `grpc_status_test.go`: out-of-range statuses (99, 200, 0xFFFF, −1) map to `""`.
  - `span_getters_test.go`: omission cases for the RPC status getter (leaked HTTP
    200, failed status read, non-RPC spans), plus new tests for `error.type` and
    `messaging.operation.type` omission vs. genuine error/operation values.
  - `traces_test.go`: gRPC spans with valid status keep `rpc.response.status_code`;
    leaked/invalid statuses omit it; Kafka spans with unknown operation omit
    `messaging.operation.type`; successful Elasticsearch spans omit `error.type`.
  - `metrics_svc_graph_test.go`: direct-HTTP service-graph metrics must not carry a
    `connection_type` attribute at all.
  - `weavercheck_test.go`: `undefined_enum_variant` counts as actionable
    (including empty enum values); other information-level advice types still
    do not.
  - `common_test.go` (`pkg/ebpf/common`): the h2c preface pseudo-request is
    recognized and dropped; real requests are not.
  - `openai_test.go`: failed `/v1/responses` calls carry the path-derived
    `response` operation name and `responses` API type.
- `CGO_ENABLED=0 GOOS=linux go build ./...` passes.
- `go test` (linux, docker `golang:1.25`) passes for `internal/test/weavercheck`,
  `pkg/appolly/app/request`, `pkg/ebpf/common/http`, `pkg/export/otel`,
  `pkg/export/otel/tracesgen`, `pkg/export/prom`, `pkg/export/attributes`,
  `scripts`; the full `./pkg/...` sweep has only pre-existing
  environment-dependent failures (kernel BTF, lockdown, kubebuilder etcd).
- `make lint-schema` passes with the extended allowlist.
- `go vet -tags=integration ./internal/test/integration/` passes (covers the
  `red_test_ruby.go` assertion change; the Rails suites themselves run in CI).
- `weaver registry live-check` (v0.24.1, file input) against the updated
  registry accepts every intentional value (`nats`, `qwen`, `aerospike`,
  `aws-api`, `onc_rpc`, `deployment.environment.name=staging`,
  `error.type=NXDomain/insufficient_quota`, `gen_ai.operation.name=tools/call`)
  while still flagging `db.system.name=unknown`, `telemetry.sdk.language=unknown`,
  `deployment.environment.name=to`, and bogus enum values.

## Notes / follow-ups for reviewers

- **Detection layer left unchanged**: the kprobes HTTP/2 path still passes through
  `span.Status` values 17–99, and the eBPF gRPC client fallback still records
  `u16(-1)`; these are now omitted at emission rather than clamped at detection.
  Clamping (e.g. to `UNKNOWN`) would be a product decision.
- **`publish` vs `send`**: OBI emits `messaging.operation.type="publish"` for
  producer spans. Verified empirically: semconv v1.41 still declares `publish`
  (and `deliver`) as deprecated enum members and weaver accepts deprecated
  members, so no action is needed. Renaming to `send` remains a
  compat-sensitive decision out of scope here.
- **Semconv bump duty**: the enum-override files under `schemas/obi/groups/`
  duplicate upstream member lists; when bumping the semconv dependency they
  must be re-synced (drift resurfaces as `undefined_enum_variant` failures in
  the weaver-validated suites — caught, not silent). Documented in
  `schemas/obi/README.md`.
- **`error.type="error"` generic fallback**: the metrics `attr.ErrorType`
  getter reports the literal `error` for failed requests with no specific
  code; semconv's designated fallback member is `_OTHER`. Changing the
  emitted value is a compat-sensitive product decision, left as-is (validates
  cleanly now that `error.type` is re-typed as a string in the registry).
- **Prometheus parity**: prom exporters keep the fixed `connection_type` /
  `rpc_response_status_code` labels with `""` when the OTLP attribute is omitted
  (empty label ≡ absent in the Prometheus data model; weaver validates OTLP only).

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->

