### PR TITLE
emit OBI internal metrics in OTel dot-format over OTLP

### DIFF
--- a/devdocs/metrics.md
+++ b/devdocs/metrics.md
@@ -164,7 +164,7 @@ The user can then filter the metrics in userspace using appropriate filters or e
 
 For both `OTEL` and `Prometheus`, there are metrics created in their respective methods that are **not** defined in [pkg/export/attributes/metric.go](../pkg/export/attributes/metric.go) because we are disabling user-provided attribute selection for them. They are very specific metrics with an opinionated format for Span Metrics and Service Graph Metrics functionalities. Examples: `ServiceGraphClient = "traces_service_graph_request_client_seconds"` or `SpanMetricsResponseSizes = "traces_spanmetrics_response_size_total"`.
 
-Resource attributes exported through Prometheus `target_info` / `traces_target_info` and the corresponding OTLP resources can be filtered with `attributes.select.resource`. By default, detected resource attributes are preserved. For example:
+Resource attributes exported through Prometheus `target_info` / `traces_target_info` (named `target.info` / `traces.target.info` on the OTLP path) and the corresponding OTLP resources can be filtered with `attributes.select.resource`. By default, detected resource attributes are preserved. For example:
 
 ```yaml
 attributes:

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -48,9 +48,12 @@ const (
 	SpanMetricsCallsOTel     = "traces_span_metrics_calls_total"
 	SpanMetricsRequestSizes  = "traces_spanmetrics_size_total"
 	SpanMetricsResponseSizes = "traces_spanmetrics_response_size_total"
-	TracesTargetInfo         = "traces_target_info"
-	TargetInfo               = "target_info"
-	TracesHostInfo           = "traces_host_info"
+	// TracesTargetInfo, TargetInfo and TracesHostInfo use OTel dot notation.
+	// The Prometheus exporter keeps the underscore variants of these names
+	// (see pkg/export/prom), following the OpenMetrics convention.
+	TracesTargetInfo = "traces.target.info"
+	TargetInfo       = "target.info"
+	TracesHostInfo   = "traces.host.info"
 )
 
 // CloudHostIDKey is the host ID attribute for cloud provider integrations,
@@ -1078,7 +1081,7 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 }
 
 func (mr *MetricsReporter) createTargetInfo(attrs *attribute.Set) {
-	mlog().Debug("Creating target_info")
+	mlog().Debug("Creating target.info")
 
 	attrOpt := instrument.WithAttributeSet(*attrs)
 
@@ -1090,7 +1093,7 @@ func (mr *MetricsReporter) deleteTargetInfo(attrs *attribute.Set) {
 		return
 	}
 
-	mlog().Debug("Deleting target_info for", "attrs", attrs)
+	mlog().Debug("Deleting target.info for", "attrs", attrs)
 	attrOpt := instrument.WithAttributeSet(*attrs)
 	mr.targetInfo.Remove(mr.ctx, attrOpt)
 }
@@ -1100,7 +1103,7 @@ func (mr *MetricsReporter) createTracesTargetInfo(svc *svc.Attrs, attrs *attribu
 		return
 	}
 
-	mlog().Debug("Creating traces_target_info")
+	mlog().Debug("Creating traces.target.info")
 
 	attrOpt := instrument.WithAttributeSet(*attrs)
 
@@ -1112,7 +1115,7 @@ func (mr *MetricsReporter) deleteTracesTargetInfo(attrs *attribute.Set) {
 		return
 	}
 
-	mlog().Debug("Deleting traces_target_info for", "attrs", attrs)
+	mlog().Debug("Deleting traces.target.info for", "attrs", attrs)
 
 	attrOpt := instrument.WithAttributeSet(*attrs)
 	mr.tracesTargetInfo.Remove(mr.ctx, attrOpt)

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -908,7 +908,7 @@ func TestAppMetrics_TracesHostInfo(t *testing.T) {
 
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		assert.NotEmpty(ct, mr.hostInfo.entries.All(),
-			"traces_host_info metric has not been created yet")
+			"traces.host.info metric has not been created yet")
 	}, timeout, 100*time.Millisecond)
 
 	// Check expiration logic
@@ -926,7 +926,7 @@ func TestAppMetrics_TracesHostInfo(t *testing.T) {
 
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		assert.Empty(ct, mr.hostInfo.entries.All(),
-			"traces_host_info metric has not expired yet") // The entry should be expired
+			"traces.host.info metric has not expired yet") // The entry should be expired
 	}, timeout, 100*time.Millisecond)
 }
 

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -140,7 +140,7 @@ func resourceAttrs(nodeMeta *meta.NodeMeta, service *svc.Attrs) []attribute.KeyV
 	attrs := []attribute.KeyValue{
 		semconv.ServiceName(service.UID.Name),
 		// SpanMetrics requires an extra attribute besides service name
-		// to generate the traces_target_info metric,
+		// to generate the traces.target.info / traces_target_info metric,
 		// so the service is visible in the ServicesList
 		// This attribute also allows that App O11y plugin shows this app as a Go application.
 		semconv.TelemetrySDKLanguageKey.String(service.SDKLanguage.String()),

--- a/schemas/obi/groups/obi_internal.yaml
+++ b/schemas/obi/groups/obi_internal.yaml
@@ -3,8 +3,10 @@ groups:
     type: attribute_group
     display_name: OBI Internal Telemetry
     brief: >
-      OBI's own meta-telemetry: the `target_info` / `host_info` family of
-      Prometheus-style and OBI-invented per-target meta-metrics that
+      OBI's own meta-telemetry: the `target.info` / `host.info` family of
+      per-target meta-metrics (emitted in OTel dot notation over OTLP, and
+      as the Prometheus-style `target_info` / `host_info` underscore
+      variants by the Prometheus exporter) that
       identify the instrumenter and the resource it is running against,
       together with the labels they carry and any deviations from upstream
       semconv that are tracked for removal. Distinct from OBI's emissions
@@ -55,32 +57,37 @@ groups:
   # The instrument and (empty) unit declared here mirror what OBI currently
   # emits over OTLP rather than the OTel-canonical `gauge` / `unit: "1"`
   # Prometheus mapping, so weaver validates against the actual contract.
-  - id: metric.target_info
+  # The OTLP name uses OTel dot notation; OBI's Prometheus exporter emits
+  # the OpenMetrics-convention `target_info` counterpart, which weaver does
+  # not see (only the OTLP tap is validated).
+  - id: metric.target.info
     type: metric
-    metric_name: target_info
+    metric_name: target.info
     instrument: updowncounter
     unit: ""
     stability: development
     brief: >
-      `target_info` meta-metric in the Prometheus / OpenMetrics style.
-      Emitted with value 1 to carry the resource attributes of the
-      originating service.
+      `target.info` meta-metric, modeled after the Prometheus / OpenMetrics
+      `target_info` convention. Emitted with value 1 to carry the resource
+      attributes of the originating service.
     attributes:
       - ref: instance
       - ref: job
 
-  # The trace-pipeline counterpart of `target_info`. Only emitted when any
+  # The trace-pipeline counterpart of `target.info`. Only emitted when any
   # span-metrics feature is enabled — i.e. one of `application_span`,
   # `application_span_otel`, or `application_span_sizes` (the
-  # `application_service_graph` feature does NOT trigger it).
-  - id: metric.traces_target_info
+  # `application_service_graph` feature does NOT trigger it). OBI's
+  # Prometheus exporter emits the underscore `traces_target_info`
+  # counterpart.
+  - id: metric.traces.target.info
     type: metric
-    metric_name: traces_target_info
+    metric_name: traces.target.info
     instrument: updowncounter
     unit: ""
     stability: development
     brief: >
-      OBI counterpart of `target_info` for the traces pipeline. Carries the
+      OBI counterpart of `target.info` for the traces pipeline. Carries the
       resource attribute set of every traced service so dashboards can
       join trace metrics back to service identity.
     attributes:
@@ -88,9 +95,11 @@ groups:
 
   # OBI-invented per-host meta-metric — there is no upstream /
   # collector-contrib analogue. Carries the upstream `host.id` attribute.
-  - id: metric.traces_host_info
+  # OBI's Prometheus exporter emits the underscore `traces_host_info`
+  # counterpart.
+  - id: metric.traces.host.info
     type: metric
-    metric_name: traces_host_info
+    metric_name: traces.host.info
     instrument: gauge
     unit: ""
     stability: development

--- a/schemas/obi/manifest.yaml
+++ b/schemas/obi/manifest.yaml
@@ -6,7 +6,9 @@ description: |
   metrics and attributes that OBI emits in addition to (or as overrides of)
   the standard semconv set:
 
-  - Prometheus / OpenMetrics conventions (`target_info`, `instance`, `job`)
+  - The `target.info` meta-metric family (Prometheus / OpenMetrics
+    `target_info` heritage, emitted in OTel dot notation over OTLP) and the
+    `instance` / `job` scrape-convention attributes
   - Span metrics matching the OTel collector-contrib `spanmetricsconnector`
     output, in both naming schemes: the OTel-canonical
     `traces_span_metrics_*` names (emitted when the `application_span_otel`


### PR DESCRIPTION
## Summary

FIxes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1965

The three OBI meta-metrics were emitted with Prometheus-style underscore
names on the **OTLP** export path, where OTel dot-format is the convention:

| before (OTLP) | after (OTLP) | Prometheus path |
|---|---|---|
| `target_info` | `target.info` | `target_info` (unchanged) |
| `traces_target_info` | `traces.target.info` | `traces_target_info` (unchanged) |
| `traces_host_info` | `traces.host.info` | `traces_host_info` (unchanged) |

The Prometheus exporter keeps the underscore names — `target_info` is an
OpenMetrics convention there and must not change.

## How

These three metrics were intentionally excluded from the general
`Name{Prom, OTEL}` dual-naming mechanism (`pkg/export/attributes/metric.go`)
and instead defined as separate per-package constants in
`pkg/export/otel/metrics.go` and `pkg/export/prom/prom.go`. Renaming only
the otel-package constants cleanly splits the two paths; the prom package is
untouched.

- `pkg/export/otel/metrics.go` — constants renamed to dot format; debug-log
  strings updated.
- `schemas/obi/groups/obi_internal.yaml` — the weaver registry groups
  renamed to `metric.target.info` / `metric.traces.target.info` /
  `metric.traces.host.info` with dot-format `metric_name` (weaver only
  validates the OTLP tap); briefs document the prom-side underscore
  counterparts.
- `schemas/obi/manifest.yaml` — description bullet updated.
- `devdocs/metrics.md` — resource-attribute filtering paragraph names the
  OTLP-path dot variants.
- `pkg/export/otel/metrics_test.go` — assertion messages updated;
  `pkg/export/otel/otelcfg/common.go` — comment mentions both naming
  variants.

## Compatibility

**This is a user-facing rename for direct-OTLP consumers.** Consumers
scraping through a collector's `prometheus` exporter are unaffected — its
default translation maps the dots back to underscores, which is also why no
integration-test expectations needed changes (all of them query through
prometheus).

## Verification

- `go build ./...` and 621 tests across `pkg/export/{otel,otelcfg,prom}` +
  `pkg/export/` — pass.
- `make lint-schema` (weaver registry check) — pass with the renamed groups.
- Integration tests unaffected by design (prometheus-path queries preserve
  the underscore names).

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
