### PR TITLE
fix(ebpf): mark unresolved Go probes as Skip to avoid full ELF symbol parse

### DIFF
--- a/pkg/ebpf/instrumenter.go
+++ b/pkg/ebpf/instrumenter.go
@@ -991,10 +991,16 @@ func (i *instrumenter) gatherGoOffsets(goProbes map[string][]*ebpfcommon.ProbeDe
 			// probes as Skip so instrumentProbes does not attempt to attach
 			// them with Address=0, which would force cilium/ebpf to parse the
 			// full ELF symbol table via lazyLoadSymbols and retain it on
-			// Executable.cachedSymbols for the tracer's lifetime.
+			// Executable.cachedSymbols for the tracer's lifetime. Emit an
+			// InstrumentationError with a symbol_not_found label to preserve
+			// observability of missing symbols where they might've been
+			// expected.
 			log.Debug("ignoring function", "function", symbolName)
 			for _, probe := range descs {
 				probe.Skip = true
+			}
+			if i.metrics != nil {
+				i.metrics.InstrumentationError(i.processName, imetrics.InstrumentationErrorSymbolNotFound)
 			}
 			continue
 		}

--- a/pkg/ebpf/instrumenter.go
+++ b/pkg/ebpf/instrumenter.go
@@ -987,12 +987,20 @@ func (i *instrumenter) gatherGoOffsets(goProbes map[string][]*ebpfcommon.ProbeDe
 		offs, ok := i.offsets.Funcs[symbolName]
 
 		if !ok {
-			// the program function is not in the detected offsets. Ignoring
+			// The program function is not in the detected offsets. Mark the
+			// probes as Skip so instrumentProbes does not attempt to attach
+			// them with Address=0, which would force cilium/ebpf to parse the
+			// full ELF symbol table via lazyLoadSymbols and retain it on
+			// Executable.cachedSymbols for the tracer's lifetime.
 			log.Debug("ignoring function", "function", symbolName)
+			for _, probe := range descs {
+				probe.Skip = true
+			}
 			continue
 		}
 
 		for _, probe := range descs {
+			probe.Skip = false
 			probe.StartOffset = offs.Start
 			probe.ReturnOffsets = offs.Returns
 		}

--- a/pkg/ebpf/instrumenter_test.go
+++ b/pkg/ebpf/instrumenter_test.go
@@ -196,6 +196,54 @@ func TestGatherOffsetsFailsMissingRequiredSymbol(t *testing.T) {
 	assert.Empty(t, desc.ReturnOffsets)
 }
 
+func TestGatherGoOffsetsMarksMissingSymbolAsSkip(t *testing.T) {
+	// Regression for the retention bug fixed alongside this test: when
+	// gatherGoOffsets does not find an offset for a probe symbol it must
+	// mark the probe as Skip. Otherwise instrumentProbes attaches with
+	// probe.StartOffset == 0, which reaches cilium/ebpf as
+	// UprobeOptions{Address: 0} and forces a full ELF symbol table parse
+	// retained on Executable.cachedSymbols for the tracer's lifetime.
+	i := &instrumenter{
+		offsets: &goexec.Offsets{
+			Funcs: map[string]goexec.FuncOffsets{},
+		},
+	}
+	probes := probeDescMap{
+		"net/rpc/jsonrpc.(*serverCodec).ReadRequestHeader": {{}},
+	}
+
+	i.gatherGoOffsets(probes)
+
+	desc := probes["net/rpc/jsonrpc.(*serverCodec).ReadRequestHeader"][0]
+	assert.True(t, desc.Skip)
+	assert.Zero(t, desc.StartOffset)
+	assert.Empty(t, desc.ReturnOffsets)
+}
+
+func TestGatherGoOffsetsAppliesResolvedOffsetsAndClearsSkip(t *testing.T) {
+	i := &instrumenter{
+		offsets: &goexec.Offsets{
+			Funcs: map[string]goexec.FuncOffsets{
+				"net/http.serverHandler.ServeHTTP": {
+					Start:   0x1234,
+					Returns: []uint64{0x1250, 0x1260},
+				},
+			},
+		},
+	}
+	// Seed Skip = true to ensure the resolved branch clears stale state on reuse.
+	probes := probeDescMap{
+		"net/http.serverHandler.ServeHTTP": {{Skip: true}},
+	}
+
+	i.gatherGoOffsets(probes)
+
+	desc := probes["net/http.serverHandler.ServeHTTP"][0]
+	assert.False(t, desc.Skip)
+	assert.Equal(t, uint64(0x1234), desc.StartOffset)
+	assert.Equal(t, []uint64{0x1250, 0x1260}, desc.ReturnOffsets)
+}
+
 func TestInstrumentProbesSkipsMarkedOptionalProbe(t *testing.T) {
 	i := &instrumenter{}
 	probes := probeDescMap{

--- a/pkg/ebpf/instrumenter_test.go
+++ b/pkg/ebpf/instrumenter_test.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/goexec"
 	"go.opentelemetry.io/obi/pkg/internal/procs"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
@@ -203,10 +204,16 @@ func TestGatherGoOffsetsMarksMissingSymbolAsSkip(t *testing.T) {
 	// probe.StartOffset == 0, which reaches cilium/ebpf as
 	// UprobeOptions{Address: 0} and forces a full ELF symbol table parse
 	// retained on Executable.cachedSymbols for the tracer's lifetime.
+	// The skip path must also emit an InstrumentationError with the
+	// symbol_not_found label so operators can observe when expected Go
+	// probe symbols are missing from a binary.
+	reporter := &countingReporter{}
 	i := &instrumenter{
 		offsets: &goexec.Offsets{
 			Funcs: map[string]goexec.FuncOffsets{},
 		},
+		metrics:     reporter,
+		processName: "testproc",
 	}
 	probes := probeDescMap{
 		"net/rpc/jsonrpc.(*serverCodec).ReadRequestHeader": {{}},
@@ -218,9 +225,11 @@ func TestGatherGoOffsetsMarksMissingSymbolAsSkip(t *testing.T) {
 	assert.True(t, desc.Skip)
 	assert.Zero(t, desc.StartOffset)
 	assert.Empty(t, desc.ReturnOffsets)
+	assert.Equal(t, 1, reporter.errors[imetrics.InstrumentationErrorSymbolNotFound])
 }
 
 func TestGatherGoOffsetsAppliesResolvedOffsetsAndClearsSkip(t *testing.T) {
+	reporter := &countingReporter{}
 	i := &instrumenter{
 		offsets: &goexec.Offsets{
 			Funcs: map[string]goexec.FuncOffsets{
@@ -230,6 +239,8 @@ func TestGatherGoOffsetsAppliesResolvedOffsetsAndClearsSkip(t *testing.T) {
 				},
 			},
 		},
+		metrics:     reporter,
+		processName: "testproc",
 	}
 	// Seed Skip = true to ensure the resolved branch clears stale state on reuse.
 	probes := probeDescMap{
@@ -242,6 +253,7 @@ func TestGatherGoOffsetsAppliesResolvedOffsetsAndClearsSkip(t *testing.T) {
 	assert.False(t, desc.Skip)
 	assert.Equal(t, uint64(0x1234), desc.StartOffset)
 	assert.Equal(t, []uint64{0x1250, 0x1260}, desc.ReturnOffsets)
+	assert.Empty(t, reporter.errors, "no InstrumentationError should be emitted when the symbol resolves")
 }
 
 func TestInstrumentProbesSkipsMarkedOptionalProbe(t *testing.T) {
@@ -546,6 +558,21 @@ func makeProcMaps(paths ...string) []*procfs.ProcMap {
 	}
 
 	return maps
+}
+
+// countingReporter is a minimal imetrics.Reporter test double that only
+// records InstrumentationError calls, sufficient for gatherGoOffsets tests.
+// It embeds imetrics.NoopReporter so the rest of the Reporter surface stays a no-op.
+type countingReporter struct {
+	imetrics.NoopReporter
+	errors map[string]int
+}
+
+func (r *countingReporter) InstrumentationError(_ string, errorType string) {
+	if r.errors == nil {
+		r.errors = map[string]int{}
+	}
+	r.errors[errorType]++
 }
 
 type stubTracer struct {

--- a/pkg/export/imetrics/imetrics.go
+++ b/pkg/export/imetrics/imetrics.go
@@ -45,6 +45,7 @@ const (
 	InstrumentationErrorAttachingCgroup                = "attaching_cgroup"
 	InstrumentationErrorAttachingKprobe                = "attaching_kprobe"
 	InstrumentationErrorAttachingUprobe                = "attaching_uprobe"
+	InstrumentationErrorSymbolNotFound                 = "symbol_not_found"
 	InstrumentationErrorAttachingIter                  = "attaching_iter"
 	InstrumentationErrorAttachingTracing               = "attaching_tracing"
 	InstrumentationErrorInvalidTracepoint              = "invalid_tracepoint"


### PR DESCRIPTION
## Summary

Fixes a heap retention where OBI holds 100+ MiB of parsed ELF symbols per instrumented Go binary. Refs #2638.

`gatherGoOffsets` did not set `probe.Skip = true` when a Go probe symbol was missing from the resolved offsets. `instrumentProbes` then attached the probe with `probe.StartOffset == 0`, which reaches cilium/ebpf as `UprobeOptions{Address: 0}`. cilium's `Executable.address()` only short-circuits when `Address > 0`, so `Address == 0` forces `lazyLoadSymbols()` to parse the full ELF symbol table into `Executable.cachedSymbols`. That map is retained for the lifetime of the `*Executable`, which is held by `instrumenter.exe` on the tracer stored in `ProcessTracer.Instrumentables[ino]` — i.e. as long as any process for the binary is alive.

The bug reproduces reliably because gotracer's `GoProbes()` registers ~60 probes across `net/http`, `net/rpc/jsonrpc`, `github.com/lib/pq`, `golang.org/x/net/http2`, `crypto/tls`, `database/sql`, etc. Most Go services don't use every one of these, so at least one symbol lookup fails on every Go binary.

The native uprobe path (`gatherOffsetsImpl` at line 900-916) already sets `probe.Skip = true` on unresolved symbols; this change brings the Go path into symmetry.

**Retention path** (before this fix):

```
attacherLoop
 └─ traceAttacher.getTracer
    └─ ProcessTracer.NewExecutable
       └─ i.goprobes(p)
          └─ i.gatherGoOffsets(goProbes)          // probe.Skip stays false on missed lookup
          └─ i.instrumentProbes(exe, goProbes)
             └─ i.uprobe(exe, probe)               // probe.Skip == false → attach attempted
                └─ exe.Uprobe("", prog, &UprobeOptions{Address: 0})   // ← the bug
                   └─ cilium address() → lazyLoadSymbols()
                      └─ debug/elf (*File).Symbols + DynamicSymbols
                         └─ Executable.cachedSymbols map[string]symbol   // retained
```

**Fix:** mark probes as `Skip` when their offset is not present in `i.offsets.Funcs`, matching the native path's behavior. Also set `Skip = false` on the resolved branch to guard against stale state across reuse (`NewExecutableInstance`).

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed. (N/A — no user-facing feature change)

## Related

- Refs #2638 (detailed root cause analysis in a follow-up comment on the issue)
- The `gatherOffsetsImpl` symmetry it aligns to was introduced at line 900-916 of `pkg/ebpf/instrumenter.go`
