### PR TITLE
Add per rule obfuscation string option

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -242,7 +242,7 @@ HTTPParsingPolicy defines the default action for http enrichment rules.
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
 |---|---|---|---|---|---|---|
 | `ebpf.payload_extraction.http.enrichment.policy.default_action` | [`HTTPParsingDefaultAction`](#httpparsingdefaultaction) |  |  |  |  | Specifies what to do when no rule matches, per type. |
-| `ebpf.payload_extraction.http.enrichment.policy.obfuscation_string` | `string` | `OTEL_EBPF_HTTP_ENRICHMENT_OBFUSCATION_STRING` | `***` |  |  | Is the replacement string used when a rule's action is "obfuscate" |
+| `ebpf.payload_extraction.http.enrichment.policy.obfuscation_string` | `string` | `OTEL_EBPF_HTTP_ENRICHMENT_OBFUSCATION_STRING` | `***` |  |  | Is the replacement string used when a rule's action is "obfuscate" and the rule doesn't define it's own obfuscation_string. |
 
 #### `ebpf.payload_extraction.http.genai`
 
@@ -716,6 +716,7 @@ HTTPParsingRule defines a single include/exclude/obfuscate rule for HTTP header 
 |---|---|---|---|
 | `action` | `string` | `exclude`, `include`, `obfuscate` | Of the rule: "include", "exclude", or "obfuscate" |
 | `match` | [`HTTPParsingMatch`](#httpparsingmatch) |  | Defines the matching criteria for this rule |
+| `obfuscation_string` | `string` |  | Is the replacement string used when a rule's action is "obfuscate" |
 | `scope` | `string` | `all`, `request`, `response` | Of the rule: "request", "response", or "all" |
 | `type` | `string` | `body`, `headers` | Specifies what this rule matches against: "headers" or "body" |
 

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -1254,7 +1254,7 @@
         },
         "obfuscation_string": {
           "type": "string",
-          "description": "Is the replacement string used when a rule's action is \"obfuscate\"",
+          "description": "Is the replacement string used when a rule's action is \"obfuscate\" and the rule doesn't define it's own obfuscation_string.",
           "default": "***",
           "x-env-var": "OTEL_EBPF_HTTP_ENRICHMENT_OBFUSCATION_STRING"
         }
@@ -1271,6 +1271,10 @@
         "match": {
           "$ref": "#/$defs/HTTPParsingMatch",
           "description": "Defines the matching criteria for this rule"
+        },
+        "obfuscation_string": {
+          "type": "string",
+          "description": "Is the replacement string used when a rule's action is \"obfuscate\""
         },
         "scope": {
           "$ref": "#/$defs/HTTPParsingScope",

--- a/internal/config/convert/export_parity.go
+++ b/internal/config/convert/export_parity.go
@@ -127,7 +127,7 @@ func httpEnrichment(cfg *obi.Config) schema.HTTPEnrichment {
 				Headers: enrichment.Policy.DefaultAction.Headers,
 				Body:    enrichment.Policy.DefaultAction.Body,
 			},
-			ObfuscationString: enrichment.Policy.ObfuscationString,
+			DefaultObfuscationString: enrichment.Policy.DefaultObfuscationString,
 		},
 		Rules: enrichment.Rules,
 	}

--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -556,7 +556,7 @@ func TestRuntimeToV2AdvancedCaptureParity(t *testing.T) {
 	cfg.EBPF.PayloadExtraction.HTTP.Enrichment.Enabled = true
 	cfg.EBPF.PayloadExtraction.HTTP.Enrichment.Policy.DefaultAction.Headers = config.HTTPParsingActionInclude
 	cfg.EBPF.PayloadExtraction.HTTP.Enrichment.Policy.DefaultAction.Body = config.HTTPParsingActionObfuscate
-	cfg.EBPF.PayloadExtraction.HTTP.Enrichment.Policy.ObfuscationString = "[redacted]"
+	cfg.EBPF.PayloadExtraction.HTTP.Enrichment.Policy.DefaultObfuscationString = "[redacted]"
 	jsonPath, err := config.NewJSONPathExpr("$.secret")
 	require.NoError(t, err)
 	cfg.EBPF.PayloadExtraction.HTTP.Enrichment.Rules = []config.HTTPParsingRule{

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -946,7 +946,7 @@ func applyV2HTTPPayloadExtractorMembership(http *obiconfig.HTTPConfig, enabled [
 func applyFullV2HTTPEnrichment(http *obiconfig.HTTPConfig, enrichment schema.HTTPEnrichment) {
 	http.Enrichment.Policy.DefaultAction.Headers = enrichment.Policy.DefaultAction.Headers
 	http.Enrichment.Policy.DefaultAction.Body = enrichment.Policy.DefaultAction.Body
-	http.Enrichment.Policy.ObfuscationString = enrichment.Policy.ObfuscationString
+	http.Enrichment.Policy.DefaultObfuscationString = enrichment.Policy.DefaultObfuscationString
 	http.Enrichment.Rules = cloneHTTPParsingRules(enrichment.Rules)
 }
 
@@ -957,8 +957,8 @@ func applyPartialV2HTTPEnrichment(http *obiconfig.HTTPConfig, enrichment schema.
 	if !zeroValue(enrichment.Policy.DefaultAction.Body) {
 		http.Enrichment.Policy.DefaultAction.Body = enrichment.Policy.DefaultAction.Body
 	}
-	if enrichment.Policy.ObfuscationString != "" {
-		http.Enrichment.Policy.ObfuscationString = enrichment.Policy.ObfuscationString
+	if enrichment.Policy.DefaultObfuscationString != "" {
+		http.Enrichment.Policy.DefaultObfuscationString = enrichment.Policy.DefaultObfuscationString
 	}
 	if enrichment.Rules != nil {
 		http.Enrichment.Rules = cloneHTTPParsingRules(enrichment.Rules)

--- a/internal/config/convert/import_http_test.go
+++ b/internal/config/convert/import_http_test.go
@@ -90,7 +90,7 @@ func TestV2ToRuntimeHTTPPayloadExtractionRoundTrip(t *testing.T) {
 	http.Enrichment.Enabled = true
 	http.Enrichment.Policy.DefaultAction.Headers = config.HTTPParsingActionInclude
 	http.Enrichment.Policy.DefaultAction.Body = config.HTTPParsingActionObfuscate
-	http.Enrichment.Policy.ObfuscationString = "[redacted]"
+	http.Enrichment.Policy.DefaultObfuscationString = "[redacted]"
 	jsonPath, err := config.NewJSONPathExpr("$.secret")
 	require.NoError(t, err)
 	http.Enrichment.Rules = []config.HTTPParsingRule{

--- a/internal/config/schema/instrumentation.go
+++ b/internal/config/schema/instrumentation.go
@@ -180,8 +180,8 @@ type HTTPEnrichment struct {
 
 // HTTPEnrichmentPolicy describes default HTTP payload enrichment actions.
 type HTTPEnrichmentPolicy struct {
-	DefaultAction     HTTPEnrichmentDefaultAction `yaml:"default_action"`
-	ObfuscationString string                      `yaml:"obfuscation_string"`
+	DefaultAction            HTTPEnrichmentDefaultAction `yaml:"default_action"`
+	DefaultObfuscationString string                      `yaml:"obfuscation_string"`
 }
 
 // HTTPEnrichmentDefaultAction describes default enrichment actions for headers

--- a/internal/test/integration/configs/obi-config-http-enrichment-body.yml
+++ b/internal/test/integration/configs/obi-config-http-enrichment-body.yml
@@ -44,6 +44,27 @@ ebpf:
               obfuscation_json_paths:
                 - "$.password"
                 - "$.secret"
+          # Obfuscate credit-card with a different obfuscation
+          - action: obfuscate
+            type: body
+            scope: request
+            obfuscation_string: "PCI"
+            match:
+              methods: ["POST"]
+              obfuscation_json_paths:
+                - "$['credit-card']"
+                - "$.creditcard"
+                - "$.cc"
+          # Obfuscate social insurance numbers
+          - action: obfuscate
+            type: body
+            scope: request
+            obfuscation_string: "PII"
+            match:
+              methods: ["POST"]
+              obfuscation_json_paths:
+                - "$.sin"
+                - "$.ssn"
           # Exclude body on /smoke endpoint
           - action: exclude
             type: body

--- a/internal/test/integration/http_enrichment_body_test.go
+++ b/internal/test/integration/http_enrichment_body_test.go
@@ -21,10 +21,11 @@ import (
 // capture the request body with sensitive fields obfuscated.
 func testBodyExtractionObfuscate(t *testing.T) {
 	// Send POST requests with a JSON body containing sensitive fields.
-	// The config obfuscates $.password and $.secret on POST requests.
+	// The config obfuscates $.password and $.secret with "***", credit-card
+	// fields with "PCI", and social/insurance numbers with "PII" on POST requests.
 	for i := 0; i < 4; i++ {
 		doHTTPPost(t, instrumentedServiceStdURL+"/rolldice/50", 200,
-			[]byte(`{"username":"alice","password":"secret123","secret":"my-api-key","email":"alice@test.com"}`))
+			[]byte(`{"username":"alice","password":"secret123","secret":"my-api-key","email":"alice@test.com","credit-card":"4111-1111-1111-1111","creditcard":"5555555555554444","cc":"378282246310005","sin":"046454286","ssn":"123-45-6789"}`))
 	}
 
 	var trace jaeger.Trace
@@ -53,14 +54,21 @@ func testBodyExtractionObfuscate(t *testing.T) {
 	val, valOk := jaeger.TagFirstStringValue(tag)
 	require.True(t, valOk)
 
-	// Verify sensitive fields are obfuscated.
+	// Verify sensitive fields are obfuscated with the default obfuscation string.
 	assert.NotContains(t, val, "secret123", "password should be obfuscated")
 	assert.NotContains(t, val, "my-api-key", "secret should be obfuscated")
-	assert.Contains(t, val, "***", "obfuscation string should be present")
+	assert.Contains(t, val, "***", "default obfuscation string should be present")
 
-	// Verify non-sensitive fields are preserved.
-	assert.Contains(t, val, "alice", "username should be present")
-	assert.Contains(t, val, "alice@test.com", "email should be present")
+	// Verify credit-card fields are obfuscated with the per-rule "PCI" string.
+	assert.NotContains(t, val, "4111-1111-1111-1111", "credit-card should be obfuscated")
+	assert.NotContains(t, val, "5555555555554444", "creditcard should be obfuscated")
+	assert.NotContains(t, val, "378282246310005", "cc should be obfuscated")
+	assert.Contains(t, val, "PCI", "credit-card obfuscation string should be present")
+
+	// Verify social/insurance numbers are obfuscated with the per-rule "PII" string.
+	assert.NotContains(t, val, "046454286", "sin should be obfuscated")
+	assert.NotContains(t, val, "123-45-6789", "ssn should be obfuscated")
+	assert.Contains(t, val, "PII", "sin/ssn obfuscation string should be present")
 }
 
 // testBodyExtractionInclude verifies that body include rules capture the raw body

--- a/pkg/config/payload_extraction.go
+++ b/pkg/config/payload_extraction.go
@@ -171,6 +171,10 @@ type EnrichmentConfig struct {
 // Required fields (action, type, scope) are enforced by validate:"required" tags.
 func (c EnrichmentConfig) Validate() error {
 	for i, rule := range c.Rules {
+		if rule.ObfuscationString != nil && rule.Action != HTTPParsingActionObfuscate {
+			return fmt.Errorf("rule %d: obfuscation_string can only be used with action \"obfuscate\"", i)
+		}
+
 		switch rule.Type {
 		case HTTPParsingRuleTypeHeaders:
 			if err := validateHeaderRule(i, rule); err != nil {
@@ -229,8 +233,9 @@ func validateBodyRule(i int, rule HTTPParsingRule) error {
 type HTTPParsingPolicy struct {
 	// DefaultAction specifies what to do when no rule matches, per type.
 	DefaultAction HTTPParsingDefaultAction `yaml:"default_action"`
-	// ObfuscationString is the replacement string used when a rule's action is "obfuscate"
-	ObfuscationString string `yaml:"obfuscation_string" env:"OTEL_EBPF_HTTP_ENRICHMENT_OBFUSCATION_STRING"`
+	// DefaultObfuscationString is the replacement string used when a rule's action is "obfuscate" and
+	// the rule doesn't define it's own obfuscation_string.
+	DefaultObfuscationString string `yaml:"obfuscation_string" env:"OTEL_EBPF_HTTP_ENRICHMENT_OBFUSCATION_STRING"`
 }
 
 // HTTPParsingDefaultAction specifies the default action per rule type.
@@ -249,6 +254,8 @@ type HTTPParsingRule struct {
 	Scope HTTPParsingScope `yaml:"scope" validate:"required"`
 	// Match defines the matching criteria for this rule
 	Match HTTPParsingMatch `yaml:"match"`
+	// ObfuscationString is the replacement string used when a rule's action is "obfuscate"
+	ObfuscationString *string `yaml:"obfuscation_string"`
 }
 
 // HTTPParsingRuleType specifies the target of a parsing rule.

--- a/pkg/config/payload_extraction_test.go
+++ b/pkg/config/payload_extraction_test.go
@@ -14,6 +14,8 @@ import (
 // intPtr returns a pointer to the given int value
 func intPtr(v int) *int { return &v }
 
+func stringPtr(v string) *string { return &v }
+
 func TestEnrichmentConfig_Validate_HeaderRules(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -60,6 +62,21 @@ func TestEnrichmentConfig_Validate_HeaderRules(t *testing.T) {
 			},
 			wantErr: "rule 0: header rules cannot use obfuscation_json_paths",
 		},
+		{
+			name: "header include rule with obfuscation string",
+			rules: []HTTPParsingRule{
+				{
+					Action:            HTTPParsingActionInclude,
+					Type:              HTTPParsingRuleTypeHeaders,
+					Scope:             HTTPParsingScopeAll,
+					ObfuscationString: stringPtr("[REDACTED]"),
+					Match: HTTPParsingMatch{
+						Patterns: []services.GlobAttr{services.NewGlob("Authorization")},
+					},
+				},
+			},
+			wantErr: "rule 0: obfuscation_string can only be used with action \"obfuscate\"",
+		},
 	}
 
 	for _, tt := range tests {
@@ -98,9 +115,10 @@ func TestEnrichmentConfig_Validate_BodyRules(t *testing.T) {
 			name: "valid body obfuscate rule",
 			rules: []HTTPParsingRule{
 				{
-					Action: HTTPParsingActionObfuscate,
-					Type:   HTTPParsingRuleTypeBody,
-					Scope:  HTTPParsingScopeAll,
+					Action:            HTTPParsingActionObfuscate,
+					Type:              HTTPParsingRuleTypeBody,
+					Scope:             HTTPParsingScopeAll,
+					ObfuscationString: stringPtr("[REDACTED]"),
 					Match: HTTPParsingMatch{
 						ObfuscationJSONPaths: []JSONPathExpr{jsonPath},
 					},
@@ -160,6 +178,19 @@ func TestEnrichmentConfig_Validate_BodyRules(t *testing.T) {
 				},
 			},
 			wantErr: "rule 0: obfuscation_json_paths can only be used with action \"obfuscate\"",
+		},
+		{
+			name: "body exclude rule with obfuscation string",
+			rules: []HTTPParsingRule{
+				{
+					Action:            HTTPParsingActionExclude,
+					Type:              HTTPParsingRuleTypeBody,
+					Scope:             HTTPParsingScopeAll,
+					ObfuscationString: stringPtr("[REDACTED]"),
+					Match:             HTTPParsingMatch{},
+				},
+			},
+			wantErr: "rule 0: obfuscation_string can only be used with action \"obfuscate\"",
 		},
 		{
 			name: "happy status code range",

--- a/pkg/ebpf/common/http/http_enrichment.go
+++ b/pkg/ebpf/common/http/http_enrichment.go
@@ -33,7 +33,7 @@ type HTTPEnricher struct {
 func NewHTTPEnricher(cfg config.EnrichmentConfig) *HTTPEnricher {
 	e := &HTTPEnricher{
 		policy:            cfg.Policy,
-		obfuscationString: cfg.Policy.ObfuscationString,
+		obfuscationString: cfg.Policy.DefaultObfuscationString,
 	}
 	for _, rule := range cfg.Rules {
 		switch rule.Type {
@@ -71,6 +71,16 @@ func statusCodeMatches(m *config.NumericRange, status int) bool {
 		return false
 	}
 	return true
+}
+
+func (e *HTTPEnricher) preferredObfuscationString(rule *config.HTTPParsingRule) string {
+	obfuscationString := e.obfuscationString
+
+	if rule != nil && rule.ObfuscationString != nil {
+		obfuscationString = *rule.ObfuscationString
+	}
+
+	return obfuscationString
 }
 
 // Enrich applies header and body extraction rules to the span.
@@ -115,14 +125,14 @@ func (e *HTTPEnricher) processHeaders(
 ) map[string][]string {
 	var result map[string][]string
 	for name, values := range headers {
-		action := e.resolveHeaderAction(name, scope, span)
+		action, rule := e.resolveHeaderAction(name, scope, span)
 		if action == config.HTTPParsingActionExclude {
 			continue
 		}
 		if result == nil {
 			result = make(map[string][]string)
 		}
-		applyHeaderAction(action, name, values, result, e.obfuscationString)
+		applyHeaderAction(action, name, values, result, e.preferredObfuscationString(rule))
 	}
 	return result
 }
@@ -133,7 +143,7 @@ func (e *HTTPEnricher) resolveHeaderAction(
 	headerName string,
 	scope config.HTTPParsingScope,
 	span *request.Span,
-) config.HTTPParsingAction {
+) (config.HTTPParsingAction, *config.HTTPParsingRule) {
 	var lowerName string
 
 	for _, rule := range e.headerRules {
@@ -149,11 +159,11 @@ func (e *HTTPEnricher) resolveHeaderAction(
 		}
 		for i := range rule.Match.Patterns {
 			if rule.Match.Patterns[i].MatchString(matchName) {
-				return rule.Action
+				return rule.Action, &rule
 			}
 		}
 	}
-	return e.policy.DefaultAction.Headers
+	return e.policy.DefaultAction.Headers, nil
 }
 
 // readRequestBody returns a function that reads and resets the request body.
@@ -182,6 +192,11 @@ func readResponseBody(resp *http.Response) func() ([]byte, error) {
 	}
 }
 
+type bodyObfuscation struct {
+	path              config.JSONPathExpr
+	obfuscationString string
+}
+
 // processBody evaluates body rules and returns the body content string (possibly obfuscated).
 // All matching body rules are merged (unlike headers which use first-match-wins).
 // Rule precedence: exclude > obfuscate > include. If any matching rule excludes, the body is excluded.
@@ -198,9 +213,9 @@ func (e *HTTPEnricher) processBody(
 	// Collect all matching body rules
 	hasInclude := false
 	hasExclude := false
-	var allJSONPaths []config.JSONPathExpr
-
 	matched := false
+	var obfuscations []bodyObfuscation
+
 	for _, rule := range e.bodyRules {
 		if !ruleApplies(rule, scope, span) {
 			continue
@@ -213,7 +228,10 @@ func (e *HTTPEnricher) processBody(
 		case config.HTTPParsingActionInclude:
 			hasInclude = true
 		case config.HTTPParsingActionObfuscate:
-			allJSONPaths = append(allJSONPaths, rule.Match.ObfuscationJSONPaths...)
+			obf := e.preferredObfuscationString(&rule)
+			for _, p := range rule.Match.ObfuscationJSONPaths {
+				obfuscations = append(obfuscations, bodyObfuscation{path: p, obfuscationString: obf})
+			}
 		}
 	}
 
@@ -224,7 +242,7 @@ func (e *HTTPEnricher) processBody(
 		effectiveAction = e.policy.DefaultAction.Body
 	case hasExclude:
 		effectiveAction = config.HTTPParsingActionExclude
-	case len(allJSONPaths) > 0:
+	case len(obfuscations) > 0:
 		effectiveAction = config.HTTPParsingActionObfuscate
 	case hasInclude:
 		effectiveAction = config.HTTPParsingActionInclude
@@ -255,8 +273,8 @@ func (e *HTTPEnricher) processBody(
 		return ""
 	}
 
-	for i := range allJSONPaths {
-		if err := allJSONPaths[i].Expr().Set(parsed, e.obfuscationString); err != nil {
+	for i := range obfuscations {
+		if err := obfuscations[i].path.Expr().Set(parsed, obfuscations[i].obfuscationString); err != nil {
 			// Unmatched paths are silently ignored — Set returns error only for structural issues
 			continue
 		}

--- a/pkg/ebpf/common/http/http_enrichment.go
+++ b/pkg/ebpf/common/http/http_enrichment.go
@@ -146,7 +146,8 @@ func (e *HTTPEnricher) resolveHeaderAction(
 ) (config.HTTPParsingAction, *config.HTTPParsingRule) {
 	var lowerName string
 
-	for _, rule := range e.headerRules {
+	for i := range e.headerRules {
+		rule := &e.headerRules[i]
 		if !ruleApplies(rule, scope, span) {
 			continue
 		}
@@ -159,7 +160,7 @@ func (e *HTTPEnricher) resolveHeaderAction(
 		}
 		for i := range rule.Match.Patterns {
 			if rule.Match.Patterns[i].MatchString(matchName) {
-				return rule.Action, &rule
+				return rule.Action, rule
 			}
 		}
 	}
@@ -216,7 +217,8 @@ func (e *HTTPEnricher) processBody(
 	matched := false
 	var obfuscations []bodyObfuscation
 
-	for _, rule := range e.bodyRules {
+	for i := range e.bodyRules {
+		rule := &e.bodyRules[i]
 		if !ruleApplies(rule, scope, span) {
 			continue
 		}
@@ -228,7 +230,7 @@ func (e *HTTPEnricher) processBody(
 		case config.HTTPParsingActionInclude:
 			hasInclude = true
 		case config.HTTPParsingActionObfuscate:
-			obf := e.preferredObfuscationString(&rule)
+			obf := e.preferredObfuscationString(rule)
 			for _, p := range rule.Match.ObfuscationJSONPaths {
 				obfuscations = append(obfuscations, bodyObfuscation{path: p, obfuscationString: obf})
 			}
@@ -284,7 +286,7 @@ func (e *HTTPEnricher) processBody(
 }
 
 // ruleApplies returns true if the rule matches the given scope, path, and method.
-func ruleApplies(rule config.HTTPParsingRule, scope config.HTTPParsingScope, span *request.Span) bool {
+func ruleApplies(rule *config.HTTPParsingRule, scope config.HTTPParsingScope, span *request.Span) bool {
 	return scopeApplies(rule.Scope, scope) &&
 		urlPathMatches(rule.Match.URLPathPatterns, span.Path) &&
 		methodMatches(rule.Match.Methods, span.Method) &&

--- a/pkg/ebpf/common/http/http_enrichment_test.go
+++ b/pkg/ebpf/common/http/http_enrichment_test.go
@@ -42,7 +42,7 @@ func TestGenericParsingSpan_IncludeByDefault(t *testing.T) {
 				Headers: config.HTTPParsingActionInclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "*",
+			DefaultObfuscationString: "*",
 		},
 	}
 	span := &request.Span{Method: "GET", Path: "/test"}
@@ -66,7 +66,7 @@ func TestGenericParsingSpan_ExcludeByDefault(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "*",
+			DefaultObfuscationString: "*",
 		},
 	}
 	span := &request.Span{Method: "GET", Path: "/test"}
@@ -87,7 +87,7 @@ func TestGenericParsingSpan_IncludeRule(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "*",
+			DefaultObfuscationString: "*",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -122,7 +122,7 @@ func TestGenericParsingSpan_ObfuscateRule(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -156,7 +156,7 @@ func TestGenericParsingSpan_ScopeRequest(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "*",
+			DefaultObfuscationString: "*",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -188,7 +188,7 @@ func TestGenericParsingSpan_ScopeResponse(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "*",
+			DefaultObfuscationString: "*",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -220,7 +220,7 @@ func TestGenericParsingSpan_CaseInsensitiveMatch(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "*",
+			DefaultObfuscationString: "*",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -252,7 +252,7 @@ func TestGenericParsingSpan_FirstMatchWins(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -293,7 +293,7 @@ func TestGenericParsingSpan_MultipleGlobsInRule(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "*",
+			DefaultObfuscationString: "*",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -328,7 +328,7 @@ func TestGenericParsingSpan_RuleOrderExcludeBeforeInclude(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "*",
+			DefaultObfuscationString: "*",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -366,7 +366,7 @@ func TestGenericParsingSpan_RuleOrderIncludeBeforeExclude(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "*",
+			DefaultObfuscationString: "*",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -404,7 +404,7 @@ func TestGenericParsingSpan_RuleOrderObfuscateBeforeInclude(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "[REDACTED]",
+			DefaultObfuscationString: "[REDACTED]",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -446,7 +446,7 @@ func TestGenericParsingSpan_ExplicitExcludeRule(t *testing.T) {
 				Headers: config.HTTPParsingActionInclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "*",
+			DefaultObfuscationString: "*",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -478,7 +478,7 @@ func TestGenericParsingSpan_MixedScopeRuleOrder(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -518,7 +518,7 @@ func TestGenericParsingSpan_MultipleHeaderValues(t *testing.T) {
 				Headers: config.HTTPParsingActionInclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 	}
 	span := &request.Span{Method: "GET", Path: "/test"}
@@ -564,7 +564,7 @@ func TestBodyExtraction_IncludeRawJSON(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -595,7 +595,7 @@ func TestBodyExtraction_ObfuscateJSONPaths(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -631,7 +631,7 @@ func TestBodyExtraction_ExcludeByDefault(t *testing.T) {
 				Headers: config.HTTPParsingActionInclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 	}
 	span := &request.Span{Method: "POST", Path: "/api/data"}
@@ -652,7 +652,7 @@ func TestBodyExtraction_NonJSONSkipped(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -682,7 +682,7 @@ func TestBodyExtraction_InvalidJSONSkipped(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -712,7 +712,7 @@ func TestBodyExtraction_ArrayElementRedaction(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "[REDACTED]",
+			DefaultObfuscationString: "[REDACTED]",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -748,7 +748,7 @@ func TestBodyExtraction_MergeMultipleRules(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -791,7 +791,7 @@ func TestBodyExtraction_RouteFiltering(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -828,7 +828,7 @@ func TestBodyExtraction_MethodFiltering(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -865,7 +865,7 @@ func TestBodyExtraction_ScopeRequestOnly(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -893,7 +893,7 @@ func TestBodyExtraction_UnmatchedPathsIgnored(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -924,7 +924,7 @@ func TestBodyExtraction_ExcludeRuleOnRoute(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionInclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -961,7 +961,7 @@ func TestBodyExtraction_ContentTypeVariants(t *testing.T) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -1123,7 +1123,7 @@ func BenchmarkHTTPEnricher_HeadersOnly(b *testing.B) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -1171,7 +1171,7 @@ func BenchmarkHTTPEnricher_BodyInclude_SmallJSON(b *testing.B) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -1208,7 +1208,7 @@ func BenchmarkHTTPEnricher_BodyObfuscate_SmallJSON(b *testing.B) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -1247,7 +1247,7 @@ func BenchmarkHTTPEnricher_BodyObfuscate_LargeJSON(b *testing.B) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -1291,7 +1291,7 @@ func BenchmarkHTTPEnricher_BodyExcludedByDefault(b *testing.B) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 	}
 
@@ -1320,7 +1320,7 @@ func BenchmarkHTTPEnricher_HeadersAndBody(b *testing.B) {
 				Headers: config.HTTPParsingActionExclude,
 				Body:    config.HTTPParsingActionExclude,
 			},
-			ObfuscationString: "***",
+			DefaultObfuscationString: "***",
 		},
 		Rules: []config.HTTPParsingRule{
 			{
@@ -1367,4 +1367,152 @@ func BenchmarkHTTPEnricher_HeadersAndBody(b *testing.B) {
 		}}
 		enricher.Enrich(span, req, resp)
 	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func TestGenericParsingSpan_ObfuscateRulePerRuleOverride(t *testing.T) {
+	cfg := config.EnrichmentConfig{
+		Enabled: true,
+		Policy: config.HTTPParsingPolicy{
+			DefaultAction: config.HTTPParsingDefaultAction{
+				Headers: config.HTTPParsingActionExclude,
+				Body:    config.HTTPParsingActionExclude,
+			},
+			DefaultObfuscationString: "***",
+		},
+		Rules: []config.HTTPParsingRule{
+			{
+				Action:            config.HTTPParsingActionObfuscate,
+				Type:              config.HTTPParsingRuleTypeHeaders,
+				Scope:             config.HTTPParsingScopeAll,
+				ObfuscationString: ptr("[RULE-REDACTED]"),
+				Match: config.HTTPParsingMatch{
+					Patterns: []services.GlobAttr{gi("Authorization")},
+				},
+			},
+			{
+				Action: config.HTTPParsingActionObfuscate,
+				Type:   config.HTTPParsingRuleTypeHeaders,
+				Scope:  config.HTTPParsingScopeAll,
+				Match: config.HTTPParsingMatch{
+					Patterns: []services.GlobAttr{gi("Cookie")},
+				},
+			},
+		},
+	}
+	span := &request.Span{Method: "GET", Path: "/test"}
+	req, resp := makeReqResp(
+		map[string]string{"Authorization": "Bearer secret-token", "Cookie": "session=abc"},
+		nil,
+	)
+
+	ok := NewHTTPEnricher(cfg).Enrich(span, req, resp)
+	require.True(t, ok)
+	// The Authorization rule overrides the policy obfuscation string.
+	assert.Equal(t, []string{"[RULE-REDACTED]"}, span.RequestHeaders["Authorization"])
+	// The Cookie rule has no override, so it falls back to the policy default.
+	assert.Equal(t, []string{"***"}, span.RequestHeaders["Cookie"])
+}
+
+func TestBodyExtraction_ObfuscatePerRuleOverride(t *testing.T) {
+	cfg := config.EnrichmentConfig{
+		Enabled: true,
+		Policy: config.HTTPParsingPolicy{
+			DefaultAction: config.HTTPParsingDefaultAction{
+				Headers: config.HTTPParsingActionExclude,
+				Body:    config.HTTPParsingActionExclude,
+			},
+			DefaultObfuscationString: "***",
+		},
+		Rules: []config.HTTPParsingRule{
+			{
+				Action:            config.HTTPParsingActionObfuscate,
+				Type:              config.HTTPParsingRuleTypeBody,
+				Scope:             config.HTTPParsingScopeAll,
+				ObfuscationString: ptr("[RULE-REDACTED]"),
+				Match: config.HTTPParsingMatch{
+					ObfuscationJSONPaths: []config.JSONPathExpr{jp("$.password")},
+				},
+			},
+		},
+	}
+	span := &request.Span{Method: "POST", Path: "/api/auth"}
+	req, resp := makeReqRespWithBody(
+		`{"username":"alice","password":"secret123"}`,
+		"",
+	)
+
+	ok := NewHTTPEnricher(cfg).Enrich(span, req, resp)
+	require.True(t, ok)
+	assert.Contains(t, span.RequestBodyContent, `"[RULE-REDACTED]"`)
+	assert.NotContains(t, span.RequestBodyContent, "secret123")
+	assert.NotContains(t, span.RequestBodyContent, "***")
+	assert.Contains(t, span.RequestBodyContent, `"alice"`)
+}
+
+func TestBodyExtraction_MultipleObfuscateRulesDistinctStrings(t *testing.T) {
+	cfg := config.EnrichmentConfig{
+		Enabled: true,
+		Policy: config.HTTPParsingPolicy{
+			DefaultAction: config.HTTPParsingDefaultAction{
+				Headers: config.HTTPParsingActionExclude,
+				Body:    config.HTTPParsingActionExclude,
+			},
+			DefaultObfuscationString: "***",
+		},
+		Rules: []config.HTTPParsingRule{
+			{
+				Action: config.HTTPParsingActionObfuscate,
+				Type:   config.HTTPParsingRuleTypeBody,
+				Scope:  config.HTTPParsingScopeRequest,
+				Match: config.HTTPParsingMatch{
+					ObfuscationJSONPaths: []config.JSONPathExpr{jp("$.password")},
+				},
+			},
+			{
+				Action:            config.HTTPParsingActionObfuscate,
+				Type:              config.HTTPParsingRuleTypeBody,
+				Scope:             config.HTTPParsingScopeRequest,
+				ObfuscationString: ptr("PCI"),
+				Match: config.HTTPParsingMatch{
+					ObfuscationJSONPaths: []config.JSONPathExpr{jp("$.cc")},
+				},
+			},
+			{
+				Action:            config.HTTPParsingActionObfuscate,
+				Type:              config.HTTPParsingRuleTypeBody,
+				Scope:             config.HTTPParsingScopeRequest,
+				ObfuscationString: ptr("PII"),
+				Match: config.HTTPParsingMatch{
+					ObfuscationJSONPaths: []config.JSONPathExpr{jp("$.ssn")},
+				},
+			},
+			// A trailing include rule that also matches — this must not clobber
+			// the obfuscation strings of the earlier obfuscate rules.
+			{
+				Action: config.HTTPParsingActionInclude,
+				Type:   config.HTTPParsingRuleTypeBody,
+				Scope:  config.HTTPParsingScopeRequest,
+				Match:  config.HTTPParsingMatch{},
+			},
+		},
+	}
+	span := &request.Span{Method: "POST", Path: "/api/users"}
+	req, resp := makeReqRespWithBody(
+		`{"password":"secret123","cc":"4111111111111111","ssn":"123-45-6789","name":"alice"}`,
+		"",
+	)
+
+	ok := NewHTTPEnricher(cfg).Enrich(span, req, resp)
+	require.True(t, ok)
+	val := span.RequestBodyContent
+	// Each obfuscate rule applies its own obfuscation string.
+	assert.Contains(t, val, `"password":"***"`)
+	assert.Contains(t, val, `"cc":"PCI"`)
+	assert.Contains(t, val, `"ssn":"PII"`)
+	assert.NotContains(t, val, "secret123")
+	assert.NotContains(t, val, "4111111111111111")
+	assert.NotContains(t, val, "123-45-6789")
+	assert.Contains(t, val, `"alice"`)
 }

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -194,7 +194,7 @@ var DefaultConfig = Config{
 							Headers: config.HTTPParsingActionExclude,
 							Body:    config.HTTPParsingActionExclude,
 						},
-						ObfuscationString: "***",
+						DefaultObfuscationString: "***",
 					},
 					Rules: []config.HTTPParsingRule{},
 				},

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -212,7 +212,7 @@ discovery:
 								Headers: config.HTTPParsingActionExclude,
 								Body:    config.HTTPParsingActionExclude,
 							},
-							ObfuscationString: "***",
+							DefaultObfuscationString: "***",
 						},
 						Rules: []config.HTTPParsingRule{},
 					},


### PR DESCRIPTION
## Summary

In HTTP payload extraction we have the option to obfuscate sensitive information with an obfuscation string. I'm adding an option to define a per rule obfuscation string, such that, traces can be searched with the kind of sensitive information they contained. For example, we can obfuscate PII data with [PII] and PHI data with [PHI]. This information can be used to build sensitive data flow knowledge graph between services.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
