### PR TITLE
fix(kafka): resolve topic names for`librdkafka` multi-chunk responses

### DIFF
--- a/bpf/generictracer/protocol_kafka.h
+++ b/bpf/generictracer/protocol_kafka.h
@@ -458,6 +458,9 @@ static __always_inline int kafka_send_large_buffer(tcp_req_t *req,
     if (!capture_in_progress) {
         remaining = response_total_bytes - (s32)req->lb_res_bytes;
     } else {
+        // If the entry was LRU-evicted mid-capture, correlation_data is NULL and
+        // remaining goes negative -> we finalize below (possibly truncated) rather
+        // than never completing the response.
         remaining = (correlation_data ? correlation_data->response_bytes_remaining : 0) -
                     (s32)consumed_bytes;
     }

--- a/bpf/generictracer/protocol_kafka.h
+++ b/bpf/generictracer/protocol_kafka.h
@@ -54,6 +54,11 @@ struct {
 
 typedef struct kafka_correlation_data {
     s32 correlation_id;
+    // A single Kafka response can span multiple recv() chunks, so we need to keep
+    // the correlation entry alive and append every chunk until the whole response
+    // (message_size + 4) has been captured, instead of finalizing on the first chunk.
+    // 0 means no capture in progress.
+    s32 response_bytes_remaining;
 } kafka_correlation_data_t;
 
 struct {
@@ -343,27 +348,58 @@ static __always_inline int kafka_send_large_buffer(tcp_req_t *req,
         return -1;
     }
 
-    const kafka_correlation_data_t *correlation_data =
+    kafka_correlation_data_t *correlation_data =
         bpf_map_lookup_elem(&kafka_ongoing_requests, &pid_conn->conn);
 
-    if (!correlation_data) {
+    // lb_res_bytes > 0 means we already captured the first chunk of this response
+    // and are mid-capture, so keep appending even if the correlation entry was
+    // evicted from the LRU map in the meantime.
+    const bool capture_in_progress = req->lb_res_bytes > 0;
+
+    if (!correlation_data && !capture_in_progress) {
         bpf_dbg_printk("no ongoing request found for this response");
         return 0;
     }
 
     const kafka_state_key_t state_key = {.conn = pid_conn->conn, .direction = direction};
     const kafka_state_data_t *state_data = bpf_map_lookup_elem(&kafka_state, &state_key);
-    const s32 correlation_id = kafka_read_response_correlation_id(state_data, u_buf, bytes_len);
 
-    if (correlation_id != correlation_data->correlation_id) {
-        bpf_dbg_printk("request correlation_id != response "
-                       "correlation_id, %d != %d. Ignoring...",
-                       correlation_data->correlation_id,
-                       correlation_id);
-        return 0;
+    // message_size arrived split from the rest of the response and was stashed in
+    // kafka_state: u_buf starts at the correlation_id and we synthesize the
+    // message_size prefix below.
+    const bool msg_size_from_state =
+        state_data && state_data->message_size > 0 && (u32)state_data->message_size == bytes_len;
+
+    if (!capture_in_progress) {
+        // First chunk of the response: validate it against the pending request.
+        const s32 correlation_id = kafka_read_response_correlation_id(state_data, u_buf, bytes_len);
+        if (correlation_id != correlation_data->correlation_id) {
+            bpf_dbg_printk("request correlation_id != response "
+                           "correlation_id, %d != %d. Ignoring...",
+                           correlation_data->correlation_id,
+                           correlation_id);
+            return 0;
+        }
     }
 
-    bpf_map_delete_elem(&kafka_ongoing_requests, &pid_conn->conn);
+    // Total wire bytes to capture (message_size field + its value), read once on
+    // the first chunk; later chunks rely on the stored remaining counter.
+    s32 response_total_bytes = 0;
+    if (!capture_in_progress) {
+        s32 message_size = 0;
+        if (msg_size_from_state) {
+            message_size = state_data->message_size;
+        } else if (bytes_len >= k_kafka_hdr_message_size) {
+            bpf_probe_read(&message_size, k_kafka_hdr_message_size, u_buf);
+            message_size = bpf_ntohl(message_size);
+        }
+        if (message_size > 0) {
+            response_total_bytes = message_size + k_kafka_hdr_message_size;
+        }
+        bpf_dbg_printk("kafka response capture start, target=%d bytes_len=%d",
+                       response_total_bytes,
+                       bytes_len);
+    }
 
     tcp_large_buffer_t *lb = (tcp_large_buffer_t *)tcp_large_buffers_mem();
 
@@ -383,7 +419,7 @@ static __always_inline int kafka_send_large_buffer(tcp_req_t *req,
     u32 max_available_bytes = kafka_max_captured_bytes - req->lb_res_bytes;
     u32 consumed_bytes = 0;
 
-    if (state_data && state_data->message_size > 0 && (u32)state_data->message_size == bytes_len) {
+    if (msg_size_from_state) {
         bpf_map_delete_elem(&kafka_state, &state_key);
 
         if (max_available_bytes < k_kafka_hdr_message_size) {
@@ -418,6 +454,30 @@ static __always_inline int kafka_send_large_buffer(tcp_req_t *req,
         req->has_large_buffers = true;
     }
 
+    s32 remaining;
+    if (!capture_in_progress) {
+        remaining = response_total_bytes - (s32)req->lb_res_bytes;
+    } else {
+        remaining = (correlation_data ? correlation_data->response_bytes_remaining : 0) -
+                    (s32)consumed_bytes;
+    }
+
+    if (req->lb_res_bytes >= kafka_max_captured_bytes) {
+        remaining = 0;
+    }
+
+    if (remaining > 0) {
+        if (correlation_data) {
+            correlation_data->response_bytes_remaining = remaining;
+        }
+        bpf_dbg_printk("kafka response incomplete, captured=%d remaining=%d, waiting for more",
+                       req->lb_res_bytes,
+                       remaining);
+        return -1;
+    }
+
+    bpf_dbg_printk("kafka response fully captured, res_bytes=%d", req->lb_res_bytes);
+    bpf_map_delete_elem(&kafka_ongoing_requests, &pid_conn->conn);
     return 0;
 }
 

--- a/bpf/tests/bpf_kafka_large_buffer.c
+++ b/bpf/tests/bpf_kafka_large_buffer.c
@@ -578,16 +578,8 @@ int is_kafka(connection_info_t *conn_info, const unsigned char *data, u32 data_l
 }
 
 // NOTES
-// The following tests aim to test different use cases for the kafka processing:
-// test1: a complete metadata request and a complete metadata response related
-// to the request test2: a metadata request split in two and a complete metadata
-// response relating to the request test3: a split metadata request and a split
-// metadata response related to the request test4: metadata request divided in 2
-// and a metadata NOT related response test5: short metadata requests without a
-// full correlation_id are rejected test6: a complete metadata request and a
-// metadata response split as an 8-byte header (message_size + correlation_id)
-// then a separate body chunk (the librdkafka read pattern) — the capture must
-// span both chunks and only finalize once the body arrives
+// The following tests exercise different use cases for kafka processing; each
+// test's specific scenario is documented in the comment above its function.
 
 // A note on the connection passed to the is_kafka() function: it might seem
 // strange to see the connection used to save the request in the

--- a/bpf/tests/bpf_kafka_large_buffer.c
+++ b/bpf/tests/bpf_kafka_large_buffer.c
@@ -79,6 +79,7 @@ typedef struct kafka_state_key {
 
 typedef struct kafka_correlation_data {
     s32 correlation_id;
+    s32 response_bytes_remaining;
 } kafka_correlation_data_t;
 
 typedef struct kafka_state_entry_t {
@@ -98,6 +99,14 @@ typedef struct kafka_correlation_entry {
 
 // It simulates the kafka_ongoing_requests ebpf map
 static kafka_correlation_entry_t kafka_ongoing_requests[MAX_ENTRIES];
+
+typedef struct res_bytes_entry {
+    connection_info_t key;
+    u32 lb_res_bytes;
+    int used;
+} res_bytes_entry_t;
+
+static res_bytes_entry_t res_bytes_state[MAX_ENTRIES];
 
 enum {
     k_kafka_hdr_message_size = 4,
@@ -187,6 +196,55 @@ static void correlation_delete(const connection_info_t *key) {
             return;
         }
     }
+}
+
+// Returns a pointer to the response-bytes counter for this connection, creating
+// a zero-initialized entry on first use (mirrors the fresh tcp_req_t per request).
+static u32 *res_bytes_get(const connection_info_t *key) {
+    for (int i = 0; i < MAX_ENTRIES; i++) {
+        if (res_bytes_state[i].used && memcmp(&res_bytes_state[i].key, key, sizeof(*key)) == 0) {
+            return &res_bytes_state[i].lb_res_bytes;
+        }
+    }
+    for (int i = 0; i < MAX_ENTRIES; i++) {
+        if (!res_bytes_state[i].used) {
+            res_bytes_state[i].used = 1;
+            res_bytes_state[i].key = *key;
+            res_bytes_state[i].lb_res_bytes = 0;
+            return &res_bytes_state[i].lb_res_bytes;
+        }
+    }
+    return NULL;
+}
+
+static void res_bytes_reset(const connection_info_t *key) {
+    for (int i = 0; i < MAX_ENTRIES; i++) {
+        if (res_bytes_state[i].used && memcmp(&res_bytes_state[i].key, key, sizeof(*key)) == 0) {
+            res_bytes_state[i].used = 0;
+            return;
+        }
+    }
+}
+
+// Mirrors kafka_read_response_correlation_id() from protocol_kafk
+s32 kafka_read_response_correlation_id(const kafka_state_data_t *state_data,
+                                       const void *u_buf,
+                                       u32 bytes_len) {
+    s32 correlation_id = 0;
+    if (state_data && state_data->message_size > 0 && (u32)state_data->message_size == bytes_len) {
+        if (bytes_len < k_kafka_hdr_correlation_id) {
+            return -1;
+        }
+        memcpy(&correlation_id, u_buf, k_kafka_hdr_correlation_id);
+    } else {
+        if (bytes_len < k_kafka_hdr_message_size + k_kafka_hdr_correlation_id) {
+            return -1;
+        }
+        memcpy(&correlation_id,
+               (const unsigned char *)u_buf + k_kafka_hdr_message_size,
+               k_kafka_hdr_correlation_id);
+    }
+    return ntohl(correlation_id);
 }
 
 void assert_equal(int expected, int actual, const char *message) {
@@ -398,9 +456,10 @@ int kafka_parse_fixup_response_header(const connection_info_t *conn_info,
     return -1;
 }
 
-// Emit a large buffer event for Kafka protocol.
-// The return value is used to control the flow for this specific protocol.
-// -1: wait additional data; 0: continue, regardless of errors.
+// Mirrors kafka_send_large_buffer() from protocol_kafka.h (correlation lifecycle
+// only; byte emission elided). Returns -1 while the response is incomplete
+// (correlation kept), 0 if it does not match a request, 1 once fully captured
+// (correlation deleted).
 int kafka_send_large_buffer(connection_info_t *conn,
                             const void *u_buf,
                             u32 bytes_len,
@@ -410,29 +469,70 @@ int kafka_send_large_buffer(connection_info_t *conn,
         return -1;
     }
 
-    // check if this event matches an ongoing request
     kafka_correlation_data_t *correlation_data = kafka_correlation_lookup(conn);
-    if (!correlation_data) {
-        return 0;
-    }
-    struct kafka_response_hdr hdr = {};
-    if (kafka_parse_fixup_response_header(conn, &hdr, u_buf, bytes_len, direction) != 0) {
+    u32 *lb_res_bytes = res_bytes_get(conn);
+
+    // lb_res_bytes > 0 means the first chunk of this response was already captured
+    // and we are mid-capture, so keep appending even if the correlation entry was
+    // evicted meanwhile.
+    const int capture_in_progress = (*lb_res_bytes > 0);
+
+    if (!correlation_data && !capture_in_progress) {
         return 0;
     }
 
-    if (hdr.correlation_id != correlation_data->correlation_id) {
-        return 0;
+    kafka_state_key_t state_key = {.conn = *conn, .direction = direction};
+    kafka_state_data_t *state_data = kafka_state_lookup(&state_key);
+    const int msg_size_from_state =
+        state_data && state_data->message_size > 0 && (u32)state_data->message_size == bytes_len;
+
+    if (!capture_in_progress) {
+        // First chunk of the response: validate it against the pending request.
+        const s32 correlation_id = kafka_read_response_correlation_id(state_data, u_buf, bytes_len);
+        if (correlation_id != correlation_data->correlation_id) {
+            return 0;
+        }
     }
 
-    // remove all the large buffer code because
-    // if we are here it means that the packet is for sure a good response because
-    // we populated the hdr with message_size and correlation_id
-    // we checked also in the map of ongoing requests if there was a related
-    // ongoing request so we can hardcode the packet_type as response
-    // **NOTE**: we only send the response as a large buffer event in userspace
-    // because the topic_id and name are in the response.
+    // Total wire bytes to capture (message_size field + its value), read once on
+    // the first chunk; later chunks rely on the stored remaining counter.
+    s32 response_total_bytes = 0;
+    if (!capture_in_progress) {
+        s32 message_size = 0;
+        if (msg_size_from_state) {
+            message_size = state_data->message_size;
+        } else if (bytes_len >= k_kafka_hdr_message_size) {
+            memcpy(&message_size, u_buf, k_kafka_hdr_message_size);
+            message_size = ntohl(message_size);
+        }
+        if (message_size > 0) {
+            response_total_bytes = message_size + k_kafka_hdr_message_size;
+        }
+    }
+
+    // When the message_size arrived split (kafka_state), the synthesized 4-byte
+    // prefix is captured in addition to this chunk's bytes.
+    const u32 consumed_bytes =
+        msg_size_from_state ? (k_kafka_hdr_message_size + bytes_len) : bytes_len;
+    *lb_res_bytes += consumed_bytes;
+
+    s32 remaining;
+    if (!capture_in_progress) {
+        remaining = response_total_bytes - (s32)*lb_res_bytes;
+    } else {
+        remaining = (correlation_data ? correlation_data->response_bytes_remaining : 0) -
+                    (s32)consumed_bytes;
+    }
+
+    if (remaining > 0) {
+        if (correlation_data) {
+            correlation_data->response_bytes_remaining = remaining;
+        }
+        return -1;
+    }
+
+    res_bytes_reset(conn);
     correlation_delete(conn);
-    // modified version used only here in order to assert the result
     return 1;
 }
 
@@ -483,7 +583,11 @@ int is_kafka(connection_info_t *conn_info, const unsigned char *data, u32 data_l
 // to the request test2: a metadata request split in two and a complete metadata
 // response relating to the request test3: a split metadata request and a split
 // metadata response related to the request test4: metadata request divided in 2
-// and a metadata NOT related response
+// and a metadata NOT related response test5: short metadata requests without a
+// full correlation_id are rejected test6: a complete metadata request and a
+// metadata response split as an 8-byte header (message_size + correlation_id)
+// then a separate body chunk (the librdkafka read pattern) — the capture must
+// span both chunks and only finalize once the body arrives
 
 // A note on the connection passed to the is_kafka() function: it might seem
 // strange to see the connection used to save the request in the
@@ -822,12 +926,85 @@ void test5() {
     assert_equal(0, result, "A short split request without correlation_id must not be Kafka");
 }
 
+// test6
+// a complete metadata request and a metadata response split as an 8-byte header
+// (message_size + correlation_id) followed by a separate body chunk. This is the
+// librdkafka read pattern (header read, then body read). The capture must span
+// both chunks: the first chunk must not finalize (correlation kept, wait), and
+// only the second chunk completes the response and is sent to userspace.
+void test6() {
+    int result = 0;
+    printf("Test 6\n");
+
+    connection_info_t conn = {
+        .src_ip = 0x0a00000b,
+        .dst_ip = 0x0a00000c,
+        .src_port = 12345,
+        .dst_port = 9092,
+    };
+
+    // complete metadata request (sets the ongoing correlation)
+    unsigned char req[DATA_LEN];
+    s32 message_size = htonl(14); // key(2), version(2), correlation id(4), fake_payload(6)
+    s16 request_api_key = htons(k_kafka_api_key_metadata);
+    s16 request_api_version = htons(k_kafka_max_metadata_api_version);
+    s32 correlation_id = htonl(6); // for both request and response
+    char fake_payload[] = "Hello";
+
+    int offset = 0;
+    memcpy(req + offset, &message_size, k_kafka_hdr_message_size);
+    offset += k_kafka_hdr_message_size;
+    memcpy(req + offset, &request_api_key, k_kafka_hdr_request_api_key);
+    offset += k_kafka_hdr_request_api_key;
+    memcpy(req + offset, &request_api_version, k_kafka_hdr_request_api_version);
+    offset += k_kafka_hdr_request_api_version;
+    memcpy(req + offset, &correlation_id, k_kafka_hdr_correlation_id);
+    offset += k_kafka_hdr_correlation_id;
+    memcpy(req + offset, fake_payload, sizeof(fake_payload));
+    offset += sizeof(fake_payload);
+
+    result = is_kafka(&conn, req, offset, TCP_RECV);
+    assert_equal(1, result, "The event should be classified as a Kafka metadata request");
+    result = kafka_send_large_buffer(&conn, req, offset, TCP_RECV);
+    assert_equal(0, result, "The request event should NOT be sent to userspace");
+
+    // first response chunk: 8-byte header only (message_size + correlation_id),
+    // body arrives separately. The connection is already classified as Kafka, so
+    // it goes straight to kafka_send_large_buffer without is_kafka.
+    unsigned char res_hdr[DATA_LEN];
+    message_size = htonl(10); // correlation id(4) + fake_payload(6)
+    offset = 0;
+    memcpy(res_hdr + offset, &message_size, k_kafka_hdr_message_size);
+    offset += k_kafka_hdr_message_size;
+    memcpy(res_hdr + offset, &correlation_id, k_kafka_hdr_correlation_id);
+    offset += k_kafka_hdr_correlation_id;
+
+    result = kafka_send_large_buffer(&conn, res_hdr, offset, TCP_SEND);
+    assert_equal(-1, result, "The header-only chunk must wait for the response body");
+    assert_equal(1,
+                 kafka_correlation_lookup(&conn) != NULL,
+                 "The correlation entry must be kept while the body is pending");
+
+    // second response chunk: the body. This completes the response.
+    unsigned char res_body[DATA_LEN];
+    offset = 0;
+    memcpy(res_body + offset, fake_payload, sizeof(fake_payload));
+    offset += sizeof(fake_payload);
+
+    result = kafka_send_large_buffer(&conn, res_body, offset, TCP_SEND);
+    assert_equal(1, result, "The completed response should be sent to userspace");
+    assert_equal(0,
+                 kafka_correlation_lookup(&conn) != NULL,
+                 "The correlation entry must be deleted once the response is complete");
+}
+
 int main(int argc, char **argv) {
     test1();
     test2();
     test3();
     test4();
     test5();
+    test6();
 
     printf("\nAll tests PASSED!\n");
     return 0;

--- a/internal/test/integration/components/noderdkafka/Dockerfile
+++ b/internal/test/integration/components/noderdkafka/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-slim@sha256:d8a35d586fad3af7abb6fdb9ba972388395405f4d462da9e4a4ddcde67b5e0fb
+
+WORKDIR /
+
+COPY internal/test/integration/components/noderdkafka .
+
+RUN npm ci
+
+EXPOSE 8080
+
+CMD [ "node", "app" ]

--- a/internal/test/integration/components/noderdkafka/app.js
+++ b/internal/test/integration/components/noderdkafka/app.js
@@ -1,0 +1,94 @@
+"use strict";
+
+// Minimal librdkafka (confluent-kafka-javascript) client that speaks
+// Fetch/Produce v13+ (topic-by-UUID). It creates a single topic with many
+// partitions so the broker's Metadata response is large enough to arrive across
+// multiple recv() chunks, exercising OBI's multi-chunk Kafka response capture.
+
+const Kafka = require("@confluentinc/kafka-javascript");
+const http = require("http");
+
+const brokers = process.env.KAFKA_BOOTSTRAP_SERVERS || "localhost:9092";
+const target = process.env.KAFKA_TOPIC || "obi-node-rdkafka-topic";
+// Many partitions inflate the Metadata response so its body is large enough to
+// (a) arrive separately from the 8-byte header and (b) be emitted as several
+// large-buffer append chunks. The capture budget is OTEL_EBPF_BPF_BUFFER_SIZE_KAFKA
+// (64K max); ~200 partitions is roughly 5KB, well within it.
+const numPartitions = 200;
+
+function createTopics() {
+  return new Promise((resolve) => {
+    const admin = Kafka.AdminClient.create({ "bootstrap.servers": brokers });
+    admin.createTopic(
+      { topic: target, num_partitions: numPartitions, replication_factor: 1 },
+      () => {
+        // ignore "already exists"
+        admin.disconnect();
+        resolve();
+      }
+    );
+  });
+}
+
+function startProducer() {
+  const producer = new Kafka.Producer({ "bootstrap.servers": brokers });
+  producer.setPollInterval(1000);
+  producer.on("event.error", (e) => console.error("producer error", e));
+  producer.connect();
+  producer.on("ready", () => {
+    console.log("producer ready");
+    setInterval(() => {
+      try {
+        producer.produce(target, null, Buffer.from("hello"), "key", Date.now());
+      } catch (e) {
+        console.error("produce err", e);
+      }
+    }, 3000);
+  });
+}
+
+function startConsumer() {
+  const consumer = new Kafka.KafkaConsumer(
+    {
+      "group.id": "obi-noderdkafka-group",
+      "bootstrap.servers": brokers,
+      // force periodic metadata refresh so OBI reliably observes a metadata
+      // request/response after it attaches.
+      "topic.metadata.refresh.interval.ms": 10000,
+    },
+    { "auto.offset.reset": "earliest" }
+  );
+  consumer.on("event.error", (e) => console.error("consumer error", e));
+  consumer.connect();
+  consumer.on("ready", () => {
+    console.log("consumer ready, subscribing to", target);
+    consumer.subscribe([target]);
+    consumer.consume();
+  });
+  consumer.on("data", (m) =>
+    console.log("consumed", m.topic, "partition", m.partition, "offset", m.offset)
+  );
+}
+
+async function main() {
+  await createTopics();
+  // brief settle for topic propagation before produce/consume start
+  setTimeout(() => {
+    startProducer();
+    startConsumer();
+  }, 3000);
+
+  // health endpoint so the integration harness has a service to poll
+  http
+    .createServer((_req, res) => {
+      res.writeHead(200);
+      res.end("OK");
+    })
+    .listen(8080);
+  console.log("noderdkafka up: brokers=%s target=%s partitions=%d", brokers, target, numPartitions);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/internal/test/integration/components/noderdkafka/package-lock.json
+++ b/internal/test/integration/components/noderdkafka/package-lock.json
@@ -1,0 +1,316 @@
+{
+  "name": "noderdkafka",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "noderdkafka",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@confluentinc/kafka-javascript": "^1.3.0"
+      }
+    },
+    "node_modules/@confluentinc/kafka-javascript": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@confluentinc/kafka-javascript/-/kafka-javascript-1.10.0.tgz",
+      "integrity": "sha512-6gLgZSxbtlC5kR/VOG1JE2m8Lb2NwXMDJmkEDunyj8yV/VyzjLTqH/SojMJ/SdcmwUxmXVwf7VC4ATK/gQsKxg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "schemaregistry",
+        "schemaregistry-examples"
+      ],
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^2.0.3",
+        "bindings": "^1.3.1",
+        "js-yaml": "^4.2.0",
+        "nan": "^2.22.0",
+        "tar": "^7.5.16"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
+      "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "consola": "^3.2.3",
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^2.6.7",
+        "nopt": "^8.0.0",
+        "semver": "^7.5.3",
+        "tar": "^7.4.0"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nopt": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.20",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/internal/test/integration/components/noderdkafka/package.json
+++ b/internal/test/integration/components/noderdkafka/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "noderdkafka",
+  "version": "1.0.0",
+  "description": "librdkafka (confluent-kafka-javascript) consumer/producer used to reproduce OBI Kafka topic-name (v13+/UUID) resolution",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@confluentinc/kafka-javascript": "^1.3.0"
+  }
+}

--- a/internal/test/integration/docker-compose-node-rdkafka.yml
+++ b/internal/test/integration/docker-compose-node-rdkafka.yml
@@ -1,0 +1,135 @@
+services:
+  kafka:
+    image: docker.io/bitnamilegacy/kafka:4.0.0@sha256:f45d5b813412e1ef7ce67b467309a84e4c6dc03d7626a0b6da867db9b69bd107
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      - KAFKA_ENABLE_KRAFT=yes
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
+
+  # librdkafka (confluent-kafka-javascript) client -> Fetch v13+ (topic-by-UUID).
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/noderdkafka/Dockerfile
+    image: hatest-testserver-noderdkafka
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - KAFKA_TOPIC=obi-node-rdkafka-topic
+    depends_on:
+      otelcol:
+        condition: service_started
+      kafka:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-node-rdkafka:/var/run/obi
+    image: hatest-obi
+    privileged: true
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_TRACES_INSTRUMENTATIONS: "kafka"
+      OTEL_EBPF_METRICS_INSTRUMENTATIONS: "kafka"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+      OTEL_KAFKA_TOPIC_UUID_CACHE_SIZE: "1000"
+      OTEL_EBPF_BPF_BUFFER_SIZE_KAFKA: "65536"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.155.0@sha256:4935caa35e9a4cb387e35732e8fb22b2b5759af8d12e7043357f03837f6e8df5
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317"
+      - "4318:4318"
+      - "9464"
+      - "8888"
+    depends_on:
+      prometheus:
+        condition: service_started
+      jaeger:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
+
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.60@sha256:4fd2d70fa347d6a47e79fcb06b1c177e6079f92cba88b083153d56263082135e
+    ports:
+      - "16686:16686"
+      - "4317"
+      - "4318"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=debug
+    volumes:
+      - ./configs/jaeger-ui-config.json:/etc/jaeger/ui-config.json
+    command: ["--query.ui-config=/etc/jaeger/ui-config.json"]

--- a/internal/test/integration/red_test_kafka.go
+++ b/internal/test/integration/red_test_kafka.go
@@ -221,6 +221,56 @@ func testJavaKafkaLargeBuffer(t *testing.T) {
 	}
 }
 
+// testNodeRdkafka exercises a librdkafka (confluent-kafka-javascript) client,
+// which negotiates Fetch/Produce v13+ (topic-by-UUID). The client uses a single
+// topic with many partitions so the broker's metadata response is large enough
+// to arrive across multiple recv() chunks. Asserts the real topic name resolves
+// (not "*"): fails without the eBPF multi-chunk capture because the response body
+// was dropped, so the topic UUID->name mapping was never learned.
+func testNodeRdkafka(t *testing.T) {
+	commonAttrs := []attribute.KeyValue{
+		attribute.String("messaging.system", "kafka"),
+		attribute.Int("server.port", 9092),
+	}
+
+	testCases := []TestCase{
+		{
+			Route:   "http://localhost:8381",
+			Subpath: "health",
+			Comm:    "node",
+			Spans: []TestCaseSpan{
+				{
+					Name: "publish obi-node-rdkafka-topic",
+					Attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "producer"),
+						attribute.String("messaging.operation.type", "publish"),
+						attribute.String("messaging.destination.name", "obi-node-rdkafka-topic"),
+					},
+				},
+				{
+					Name: "process obi-node-rdkafka-topic",
+					Attributes: []attribute.KeyValue{
+						attribute.String("span.kind", "consumer"),
+						attribute.String("messaging.operation.type", "process"),
+						attribute.String("messaging.destination.name", "obi-node-rdkafka-topic"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		for i := range testCase.Spans {
+			testCase.Spans[i].Attributes = append(testCase.Spans[i].Attributes, commonAttrs...)
+		}
+
+		t.Run(testCase.Route, func(t *testing.T) {
+			waitForKafkaTestComponents(t, testCase.Route, "/"+testCase.Subpath)
+			runKafkaTestCase(t, testCase)
+		})
+	}
+}
+
 func waitForKafkaTestComponents(t *testing.T, url string, subpath string) {
 	t.Helper()
 

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -624,6 +624,16 @@ func TestSuite_JavaKafkaLargeBuffer(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_NodeRdkafka(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-node-rdkafka.yml", path.Join(pathOutput, "test-suite-node-rdkafka.log"))
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+	t.Run("Node librdkafka topic resolution", testNodeRdkafka)
+	runWeaverValidation(t)
+	require.NoError(t, compose.Close())
+}
+
 func TestSuite_PythonAsyncUvloop_3_9(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-async-uvloop-3.9.yml", path.Join(pathOutput, "test-suite-python-async-uvloop-3_9.log"))
 	require.NoError(t, err)

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -626,8 +626,8 @@ func TestSuite_JavaKafkaLargeBuffer(t *testing.T) {
 
 func TestSuite_NodeRdkafka(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-node-rdkafka.yml", path.Join(pathOutput, "test-suite-node-rdkafka.log"))
-	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, err)
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
 	require.NoError(t, compose.Up())
 	t.Run("Node librdkafka topic resolution", testNodeRdkafka)
 	runWeaverValidation(t)


### PR DESCRIPTION
## Summary

Clients on `librdkafka` reference topics by UUID (Fetch/Produce v13+), so obi must learn the UUID->name mapping from the broker's Metadata response. `librdkafka` delivers a response over multiple `recv()` calls (8-byte header, then body); the large-buffer capture finalized and dropped the correlation on the first chunk, so the body was never captured, and every Fetch-by-UUID resolved to "*".  

This PR fixes the ebpf kafka algorithm and update the related unit and integration tests.

Note: `bpftrace` syscall trace on the `rdk:broker` threads confirming the strict recvmsg 8 -> recvmsg <body> -> EAGAIN pattern of one response per read cycle, no pipelining.
```
sudo bpftrace -e '
tracepoint:syscalls:sys_exit_read,
tracepoint:syscalls:sys_exit_recvfrom,
tracepoint:syscalls:sys_exit_recvmsg
/comm=="rdk:broker" || comm=="rdk:broker1" || comm=="rdk:broker2"/
{ printf("%s %s ret=%d\n", comm, probe, args->ret); }'
Attaching 3 probes...
rdk:broker1 tracepoint:syscalls:sys_exit_read ret=1
rdk:broker1 tracepoint:syscalls:sys_exit_read ret=-11
rdk:broker1 tracepoint:syscalls:sys_exit_recvmsg ret=8
rdk:broker1 tracepoint:syscalls:sys_exit_recvmsg ret=64
rdk:broker1 tracepoint:syscalls:sys_exit_recvmsg ret=-11
rdk:broker1 tracepoint:syscalls:sys_exit_read ret=1
rdk:broker1 tracepoint:syscalls:sys_exit_read ret=-11
rdk:broker1 tracepoint:syscalls:sys_exit_recvmsg ret=8
rdk:broker1 tracepoint:syscalls:sys_exit_recvmsg ret=126
...
```

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
