### PR TITLE
TPinjector: do not track sockets from uninstrumented processes

### DIFF
--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -517,6 +517,12 @@ int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
         return 1;
     }
 
+    // if the process is not being monitored, there is no need for tracking this socket
+    const u64 id = bpf_get_current_pid_tgid();
+    if (!valid_pid(id)) {
+        return 1;
+    }
+
     switch (skops->op) {
     case BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB:
         bpf_sock_ops_active_est_cb(skops);


### PR DESCRIPTION
## Summary

Instead of tracking all the outgoing sockets in the system for L7 context propagation, we ignore the sockets from processes that are not being instrumented.

Expected improvements:
- Less impact in the overall system performance.
- Reduce the blast radius of issues like https://github.com/grafana/beyla/issues/2941 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
