### PR TITLE
add some context comments to FIONREAD fix

### DIFF
--- a/bpf/maps/tracked_sock_cookies.h
+++ b/bpf/maps/tracked_sock_cookies.h
@@ -1,6 +1,15 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Context for future maintainers: this code was added to mitigate a bug in the Linux kernel that
+// was fixed a few weeks after being reported (July 2026), but had already reached some users'
+// production environments from version 6.x onwards (via backports). This mitigation code will be
+// kept here for an undetermined, long period of time, until it is safe to assume that no trace of
+// the buggy kernel versions remains.
+// Original report impacting OBI users: https://github.com/grafana/beyla/issues/2941
+// Kernel bug fix and merge notification thread:
+// https://lore.kernel.org/bpf/20260708-fionread-no-verdict-v3-0-b4ee31b3af53@coralogix.com/
+
 #pragma once
 
 #include <bpfcore/vmlinux.h>

--- a/bpf/tpinjector/fionread_fixup.c
+++ b/bpf/tpinjector/fionread_fixup.c
@@ -1,6 +1,15 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Context for future maintainers: this code was added to mitigate a bug in the Linux kernel that
+// was fixed a few weeks after being reported (July 2026), but had already reached some users'
+// production environments from version 6.x onwards (via backports). This mitigation code will be
+// kept here for an undetermined, long period of time, until it is safe to assume that no trace of
+// the buggy kernel versions remains.
+// Original report impacting OBI users: https://github.com/grafana/beyla/issues/2941
+// Kernel bug fix and merge notification thread:
+// https://lore.kernel.org/bpf/20260708-fionread-no-verdict-v3-0-b4ee31b3af53@coralogix.com/
+
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_core_read.h>
 #include <bpfcore/bpf_helpers.h>

--- a/pkg/internal/ebpf/tpinjector/fionread_check.go
+++ b/pkg/internal/ebpf/tpinjector/fionread_check.go
@@ -5,6 +5,15 @@
 
 package tpinjector // import "go.opentelemetry.io/obi/pkg/internal/ebpf/tpinjector"
 
+// Context for future maintainers: this code was added to mitigate a bug in the Linux kernel that
+// was fixed a few weeks after being reported (July 2026), but had already reached some users'
+// production environments from version 6.x onwards (via backports). This mitigation code will be
+// kept here for an undetermined, long period of time, until it is safe to assume that no trace of
+// the buggy kernel versions remains.
+// Original report impacting OBI users: https://github.com/grafana/beyla/issues/2941
+// Kernel bug fix and merge notification thread:
+// https://lore.kernel.org/bpf/20260708-fionread-no-verdict-v3-0-b4ee31b3af53@coralogix.com/
+
 import (
 	"errors"
 	"fmt"


### PR DESCRIPTION
## Summary

The ioctl(FIONREAD) workaround ( https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2580 ) is going to stay in our codebase for long time, [despite the Linux Kernel bug causing it has been fixed](https://lore.kernel.org/bpf/178410720889.3980181.6978995644978494942.git-patchwork-notify@kernel.org/).

This looks as the typical piece of code that after some years there, nobody knows why is there and nobody dares to remove it :-D So I'm adding a bit of context.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
