### PR TITLE
Fix Go process instrumentation ~regression

### DIFF
--- a/pkg/appolly/discover/matcher.go
+++ b/pkg/appolly/discover/matcher.go
@@ -183,7 +183,7 @@ func (m *Matcher) filterCreated(obj ProcessAttrs) (Event[ProcessMatch], bool) {
 	}
 
 	// We didn't match the process, but let's see if the parent PID is tracked, it might be the child hasn't opened the port yet
-	if procMatch, ok := m.ProcessHistory[proc.PPid]; ok {
+	if procMatch, ok := m.ProcessHistory[proc.PPid]; ok && !m.isExcluded(&obj, proc) {
 		m.Log.Debug("found process by matching the process parent id", "pid", proc.Pid, "ppid", proc.PPid, "comm", proc.ExePath, "metadata", obj.metadata)
 
 		procMatch.Process = proc

--- a/pkg/appolly/discover/matcher_test.go
+++ b/pkg/appolly/discover/matcher_test.go
@@ -448,6 +448,49 @@ func TestCriteriaMatcherMissingPort(t *testing.T) {
 	assert.Zero(t, matches[1].Obj.DynamicSelectorPID)
 }
 
+func TestCriteriaMatcherExcludedChildDoesNotInheritParentMatch(t *testing.T) {
+	pipeConfig := obi.Config{}
+	require.NoError(t, yaml.Unmarshal([]byte(`discovery:
+  instrument:
+  - name: port-only
+    open_ports: 80
+  exclude_instrument:
+  - exe_path: /tmp/provjob*
+`), &pipeConfig))
+
+	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+	filteredProcesses := filteredProcessesQu.Subscribe()
+	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
+	require.NoError(t, err)
+	go matcherFunc(t.Context())
+	defer filteredProcessesQu.Close()
+
+	processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
+		proc := map[app.PID]struct {
+			Exe  string
+			PPid app.PID
+		}{
+			1: {Exe: "/bin/parent"},
+			2: {Exe: "/bin/allowed", PPid: 1},
+			3: {Exe: "/tmp/provjob123 (deleted)", PPid: 1},
+		}[pp.pid]
+		return &services.ProcessInfo{Pid: pp.pid, ExePath: proc.Exe, PPid: proc.PPid, OpenPorts: pp.openPorts}, nil
+	}
+
+	discoveredProcesses.Send([]Event[ProcessAttrs]{
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 1, openPorts: []uint32{80}}},
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 2}},
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 3}},
+	})
+
+	matches := testutil.ReadChannel(t, filteredProcesses, testTimeout)
+	require.Len(t, matches, 2)
+	assert.Equal(t, app.PID(1), matches[0].Obj.Process.Pid)
+	assert.Equal(t, app.PID(2), matches[1].Obj.Process.Pid)
+	assert.NotContains(t, matches[1].Obj.Process.ExePath, "provjob")
+}
+
 func TestDynamicMatcher_ChildInheritsDynamicSelectorPID(t *testing.T) {
 	dynamicSelector := NewDynamicPIDSelector()
 	dynamicSelector.AddPIDs(100)

--- a/pkg/internal/goexec/instructions.go
+++ b/pkg/internal/goexec/instructions.go
@@ -303,6 +303,9 @@ func loadModuledataOffsets(elfF *elf.File) (moduledataOffsets, error) {
 	if err != nil {
 		return moduledataOffsets{}, fmt.Errorf("getting Go version: %w", err)
 	}
+	if !supportedGoVersion(goVersion) {
+		return moduledataOffsets{}, fmt.Errorf("unsupported Go version: %v. Minimum supported version is %v", goVersion, minGoVersion)
+	}
 
 	goVersion = strings.ReplaceAll(goVersion, "go", "")
 

--- a/pkg/internal/goexec/moduledata_test.go
+++ b/pkg/internal/goexec/moduledata_test.go
@@ -77,7 +77,7 @@ const (
 //
 // pclntableData is the value written into the runtime.moduledata pclntable.data field.
 // All other moduledata fields are fixed (pcHeader = testGopclntabVMA, text = testTextVMA, …).
-func buildTestELF(t *testing.T, pclntableData uint64) *elf.File {
+func buildTestELF(t *testing.T, pclntableData uint64, goVersions ...string) *elf.File {
 	t.Helper()
 
 	const (
@@ -161,6 +161,17 @@ func buildTestELF(t *testing.T, pclntableData uint64) *elf.File {
 	put64(db+int(testMDText), testTextVMA)               // text
 	put64(db+int(testMDEtext), testTextVMA+testTextSize) // etext
 
+	if len(goVersions) > 0 {
+		buildInfoOffset := db + 0x200
+		copy(buf[buildInfoOffset:], buildInfoMagic)
+		buf[buildInfoOffset+14] = 8
+		buf[buildInfoOffset+15] = 2
+		buildInfo := binary.AppendUvarint(nil, uint64(len(goVersions[0])))
+		buildInfo = append(buildInfo, goVersions[0]...)
+		buildInfo = append(buildInfo, 0)
+		copy(buf[buildInfoOffset+32:], buildInfo)
+	}
+
 	// ── .shstrtab ────────────────────────────────────────────────────────────────
 	shstrtab := "\x00.text\x00.gopclntab\x00.data\x00.shstrtab\x00"
 	copy(buf[shstrtabFileOff:], shstrtab)
@@ -206,6 +217,24 @@ func buildTestELF(t *testing.T, pclntableData uint64) *elf.File {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = f.Close() })
 	return f
+}
+
+func TestLoadModuledataOffsets(t *testing.T) {
+	elfF := buildTestELF(t, testGopclntabVMA, "go1.26.4")
+
+	actual, err := loadModuledataOffsets(elfF)
+	require.NoError(t, err)
+	require.Equal(t, testMDOffsets, actual)
+}
+
+func TestLoadModuledataOffsetsRejectsInvalidGoVersion(t *testing.T) {
+	elfF := buildTestELF(t, testGopclntabVMA, "unknown")
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = loadModuledataOffsets(elfF)
+	})
+	require.ErrorContains(t, err, "unsupported Go version: unknown")
 }
 
 // emptyRelocs returns a zero-populated relocationInfo (no RELA, no RELR).


### PR DESCRIPTION
## Summary

Fix two process-discovery issues that can combine to terminate OBI while inspecting short-lived child processes:

1. A child process that did not directly match discovery criteria could inherit its tracked parent’s match
2. (Actual root cause) One such deleted executable reported `unknown` as its Go build version.

(2) caused OBI to `panic`, and my attempts to exclude the offending executable to avoid that uncovered (1). Hence the two separate safeguards. In my eyes this is regression-like, the panic didn't occur under OBI v0.7.1 - not adding support for any new versions.

Added tests cover:

 - An excluded child of a matched parent is not emitted for instrumentation.
 - Valid Go versions still load module-data offsets.
 - An unknown Go version returns an error without panicking.

Let me know if more tests, splitting this into two PRs, or providing a full repro is desired. 🙏 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
