### PR TITLE
Enable Config v2 in the OBI receiver

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -245,3 +245,7 @@ jobs:
       - name: Validate Config v2 collector configuration
         working-directory: examples/otel-collector
         run: ./otelcol-dev/otelcol-dev validate --config ./config.yaml
+
+      - name: Smoke test Config v2 collector receiver
+        working-directory: examples/otel-collector
+        run: sudo ./smoke-test.sh

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -241,3 +241,7 @@ jobs:
       - name: Build collector distribution
         working-directory: examples/otel-collector
         run: "$(go env GOPATH)/bin/builder --config ./builder-config.yaml"
+
+      - name: Validate Config v2 collector configuration
+        working-directory: examples/otel-collector
+        run: ./otelcol-dev/otelcol-dev validate --config ./config.yaml

--- a/collector/config_linux.go
+++ b/collector/config_linux.go
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && (amd64 || arm64)
+
+package collector // import "go.opentelemetry.io/obi/collector"
+
+import (
+	"errors"
+	"fmt"
+
+	"go.yaml.in/yaml/v3"
+
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+
+	"go.opentelemetry.io/obi/internal/config/convert"
+	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+type receiverConfig struct {
+	runtime *obi.Config
+}
+
+func (c *receiverConfig) Unmarshal(component *confmap.Conf) error {
+	if component == nil {
+		return nil
+	}
+
+	data, err := yaml.Marshal(component.ToStringMap())
+	if err != nil {
+		return fmt.Errorf("marshal OBI receiver config: %w", err)
+	}
+
+	extension, err := schema.ParseReceiverYAML(data)
+	if err != nil {
+		var notV2 *schema.NotV2Error
+		if !errors.As(err, &notV2) {
+			return fmt.Errorf("parse OBI receiver config v2: %w", err)
+		}
+
+		cfg := defaultRuntimeConfig()
+		if err := cfg.Unmarshal(component); err != nil {
+			return fmt.Errorf("parse legacy OBI receiver config: %w", err)
+		}
+		c.runtime = cfg
+		return nil
+	}
+
+	cfg, err := convert.V2ToRuntime(extension)
+	if err != nil {
+		return fmt.Errorf("convert OBI receiver config v2: %w", err)
+	}
+	setReceiverConsumers(cfg)
+	c.runtime = cfg
+	return nil
+}
+
+func (c *receiverConfig) Validate() error {
+	if c == nil || c.runtime == nil {
+		return errInvalidConfig
+	}
+	return c.runtime.Validate()
+}
+
+func defaultRuntimeConfig() *obi.Config {
+	cfg := obi.DefaultConfig
+	setReceiverConsumers(&cfg)
+	return &cfg
+}
+
+func setReceiverConsumers(cfg *obi.Config) {
+	cfg.Traces.TracesConsumer = consumertest.NewNop()
+	cfg.OTELMetrics.MetricsConsumer = consumertest.NewNop()
+}

--- a/collector/config_linux_test.go
+++ b/collector/config_linux_test.go
@@ -1,0 +1,182 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && (amd64 || arm64)
+
+package collector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+
+	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+func TestReceiverConfigStructure(t *testing.T) {
+	require.NoError(t, componenttest.CheckConfigStruct(defaultConfig()))
+}
+
+func TestReceiverConfigUnmarshalV2(t *testing.T) {
+	cfg := newTestReceiverConfig(t)
+	component := confmap.NewFromStringMap(map[string]any{
+		"version": "2.0",
+		"rules": []any{
+			map[string]any{
+				"action": "include",
+				"match": map[string]any{
+					"process": map[string]any{"open_ports": "8080"},
+				},
+			},
+		},
+		"channels": map[string]any{"buffer_len": 123},
+	})
+
+	require.NoError(t, component.Unmarshal(cfg))
+	require.NoError(t, cfg.Validate())
+	require.Equal(t, 123, cfg.runtime.ChannelBufferLen)
+	require.Len(t, cfg.runtime.Discovery.Instrument, 1)
+	require.Equal(t, []int{8080}, cfg.runtime.Discovery.Instrument[0].OpenPorts.AllValues())
+	require.NotNil(t, cfg.runtime.Traces.TracesConsumer)
+	require.NotNil(t, cfg.runtime.OTELMetrics.MetricsConsumer)
+}
+
+func TestReceiverConfigUnmarshalLegacy(t *testing.T) {
+	cfg := newTestReceiverConfig(t)
+	component := confmap.NewFromStringMap(map[string]any{
+		"open_port": "8080",
+	})
+
+	require.NoError(t, component.Unmarshal(cfg))
+	require.NoError(t, cfg.Validate())
+	require.Equal(t, []int{8080}, cfg.runtime.Port.AllValues())
+}
+
+func TestReceiverConfigRejectsStandaloneSections(t *testing.T) {
+	for _, section := range []string{"enrich", "correlation", "daemon"} {
+		t.Run(section, func(t *testing.T) {
+			cfg := newTestReceiverConfig(t)
+			component := confmap.NewFromStringMap(map[string]any{
+				"version": "2.0",
+				section:   map[string]any{},
+			})
+
+			err := component.Unmarshal(cfg)
+
+			var notAllowed *schema.SectionNotAllowedError
+			require.ErrorAs(t, err, &notAllowed)
+			require.Equal(t, section, notAllowed.Section)
+			require.Contains(t, err.Error(), "receiver config")
+			require.Contains(t, err.Error(), "standalone mode")
+		})
+	}
+}
+
+func TestReceiverConfigDoesNotFallbackFromInvalidV2(t *testing.T) {
+	tests := []struct {
+		name      string
+		component map[string]any
+		check     func(*testing.T, error)
+	}{
+		{
+			name: "unsupported version",
+			component: map[string]any{
+				"version":            "3.0",
+				"channel_buffer_len": 123,
+			},
+			check: func(t *testing.T, err error) {
+				var unsupported *schema.UnsupportedVersionError
+				require.ErrorAs(t, err, &unsupported)
+				require.Equal(t, "3.0", unsupported.Version)
+			},
+		},
+		{
+			name: "invalid capture value",
+			component: map[string]any{
+				"version": "2.0",
+				"network": map[string]any{
+					"capture": map[string]any{"source": "invalid"},
+				},
+				"channel_buffer_len": 123,
+			},
+			check: func(t *testing.T, err error) {
+				require.Contains(t, err.Error(), "invalid source")
+				var notV2 *schema.NotV2Error
+				require.NotErrorAs(t, err, &notV2)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := newTestReceiverConfig(t)
+
+			err := confmap.NewFromStringMap(test.component).Unmarshal(cfg)
+
+			require.Error(t, err)
+			test.check(t, err)
+			require.Equal(t, obi.DefaultConfig.ChannelBufferLen, cfg.runtime.ChannelBufferLen)
+		})
+	}
+}
+
+func TestReceiverV2PipelineModes(t *testing.T) {
+	tests := []struct {
+		name    string
+		traces  bool
+		metrics bool
+	}{
+		{name: "traces", traces: true},
+		{name: "metrics", metrics: true},
+		{name: "traces and metrics", traces: true, metrics: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := newTestReceiverConfig(t)
+			require.NoError(t, confmap.NewFromStringMap(map[string]any{
+				"version": "2.0",
+			}).Unmarshal(cfg))
+
+			factory := NewFactory()
+			settings := receivertest.NewNopSettings(typeStr)
+			settings.ID = component.MustNewIDWithName("obi", test.name)
+
+			if test.traces {
+				consumer := consumertest.NewNop()
+				receiver, err := factory.CreateTraces(t.Context(), settings, cfg, consumer)
+				require.NoError(t, err)
+				require.Same(t, consumer, cfg.runtime.Traces.TracesConsumer)
+				t.Cleanup(func() {
+					require.NoError(t, receiver.Shutdown(context.Background()))
+				})
+			}
+
+			if test.metrics {
+				consumer := consumertest.NewNop()
+				receiver, err := factory.CreateMetrics(t.Context(), settings, cfg, consumer)
+				require.NoError(t, err)
+				require.Same(t, consumer, cfg.runtime.OTELMetrics.MetricsConsumer)
+				t.Cleanup(func() {
+					require.NoError(t, receiver.Shutdown(context.Background()))
+				})
+			}
+		})
+	}
+}
+
+func newTestReceiverConfig(t *testing.T) *receiverConfig {
+	t.Helper()
+
+	cfg, ok := NewFactory().CreateDefaultConfig().(*receiverConfig)
+	require.True(t, ok)
+	return cfg
+}

--- a/collector/config_linux_test.go
+++ b/collector/config_linux_test.go
@@ -113,6 +113,26 @@ func TestReceiverConfigDoesNotFallbackFromInvalidV2(t *testing.T) {
 				require.NotErrorAs(t, err, &notV2)
 			},
 		},
+		{
+			name: "standalone v2 layout with legacy selector",
+			component: map[string]any{
+				"file_format": "1.0",
+				"extensions": map[string]any{
+					"obi": map[string]any{
+						"version": "2.0",
+						"capture": map[string]any{},
+					},
+				},
+				"open_port":          "8080",
+				"channel_buffer_len": 123,
+			},
+			check: func(t *testing.T, err error) {
+				var wrongLayout *schema.ReceiverLayoutError
+				require.ErrorAs(t, err, &wrongLayout)
+				var notV2 *schema.NotV2Error
+				require.NotErrorAs(t, err, &notV2)
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/collector/config_linux_test.go
+++ b/collector/config_linux_test.go
@@ -61,21 +61,33 @@ func TestReceiverConfigUnmarshalLegacy(t *testing.T) {
 }
 
 func TestReceiverConfigRejectsStandaloneSections(t *testing.T) {
-	for _, section := range []string{"enrich", "correlation", "daemon"} {
-		t.Run(section, func(t *testing.T) {
-			cfg := newTestReceiverConfig(t)
-			component := confmap.NewFromStringMap(map[string]any{
-				"version": "2.0",
-				section:   map[string]any{},
-			})
+	layouts := []struct {
+		name  string
+		key   string
+		value any
+	}{
+		{name: "v2", key: "version", value: "2.0"},
+		{name: "legacy selector", key: "open_port", value: "8080"},
+	}
+	for _, layout := range layouts {
+		t.Run(layout.name, func(t *testing.T) {
+			for _, section := range []string{"enrich", "correlation", "daemon"} {
+				t.Run(section, func(t *testing.T) {
+					cfg := newTestReceiverConfig(t)
+					component := confmap.NewFromStringMap(map[string]any{
+						layout.key: layout.value,
+						section:    map[string]any{},
+					})
 
-			err := component.Unmarshal(cfg)
+					err := component.Unmarshal(cfg)
 
-			var notAllowed *schema.SectionNotAllowedError
-			require.ErrorAs(t, err, &notAllowed)
-			require.Equal(t, section, notAllowed.Section)
-			require.Contains(t, err.Error(), "receiver config")
-			require.Contains(t, err.Error(), "standalone mode")
+					var notAllowed *schema.SectionNotAllowedError
+					require.ErrorAs(t, err, &notAllowed)
+					require.Equal(t, section, notAllowed.Section)
+					require.Contains(t, err.Error(), "receiver config")
+					require.Contains(t, err.Error(), "standalone mode")
+				})
+			}
 		})
 	}
 }

--- a/collector/factory_linux.go
+++ b/collector/factory_linux.go
@@ -14,7 +14,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
-	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver"
 
 	"go.opentelemetry.io/obi/collector/internal"
@@ -37,7 +36,7 @@ func BuildTracesReceiver() receiver.CreateTracesFunc {
 	) (receiver.Traces, error) {
 		initLogger(rs)
 
-		cfg, ok := baseCfg.(*obi.Config)
+		cfg, ok := runtimeConfig(baseCfg)
 		if !ok {
 			return nil, errInvalidConfig
 		}
@@ -55,7 +54,7 @@ func BuildMetricsReceiver() receiver.CreateMetricsFunc {
 	) (receiver.Metrics, error) {
 		initLogger(rs)
 
-		cfg, ok := baseCfg.(*obi.Config)
+		cfg, ok := runtimeConfig(baseCfg)
 		if !ok {
 			return nil, errInvalidConfig
 		}
@@ -66,10 +65,16 @@ func BuildMetricsReceiver() receiver.CreateMetricsFunc {
 }
 
 func defaultConfig() component.Config {
-	cfg := obi.DefaultConfig
-	// These are placeholders for the consumers; without these obi config will be invalid.
-	// The actual consumers are set when the receiver is created.
-	cfg.Traces.TracesConsumer = consumertest.NewNop()
-	cfg.OTELMetrics.MetricsConsumer = consumertest.NewNop()
-	return &cfg
+	return &receiverConfig{runtime: defaultRuntimeConfig()}
+}
+
+func runtimeConfig(baseCfg component.Config) (*obi.Config, bool) {
+	switch cfg := baseCfg.(type) {
+	case *receiverConfig:
+		return cfg.runtime, cfg.runtime != nil
+	case *obi.Config:
+		return cfg, cfg != nil
+	default:
+		return nil, false
+	}
 }

--- a/examples/otel-collector/README.md
+++ b/examples/otel-collector/README.md
@@ -41,6 +41,17 @@ The collector requires `sudo` to attach eBPF probes to processes.
 
 ## Testing the Collector
 
+After building the collector, run the same end-to-end smoke test used by the
+pull request workflow:
+
+```bash
+sudo ./smoke-test.sh
+```
+
+The smoke test starts an HTTP server and the Collector with `smoke-config.yaml`,
+then verifies that the Config v2 OBI receiver exports the server's trace through
+the debug exporter.
+
 Once the collector is running, you can generate some test traces:
 
 1. In a new terminal, start a simple HTTP server:

--- a/examples/otel-collector/README.md
+++ b/examples/otel-collector/README.md
@@ -130,11 +130,12 @@ Once the collector is running, you can generate some test traces:
 
 The `config.yaml` file defines:
 
-- **OBI receiver**: Listens on port 8000 for HTTP traffic and automatically instruments services
+- **OBI receiver**: Uses Config v2 to capture services listening on port 8000
 - **OTLP receiver**: Accepts spans from manually instrumented applications
 - **Batch processor**: Groups spans for efficient export
 - **Debug exporter**: Prints spans to logs (useful for debugging)
 - **OTLP exporter**: Sends spans to a Jaeger backend (requires Jaeger to be running)
+- **Trace and metric pipelines**: Share one OBI receiver instance
 
 You can modify `config.yaml` to:
 

--- a/examples/otel-collector/config.yaml
+++ b/examples/otel-collector/config.yaml
@@ -1,9 +1,11 @@
 receivers:
   obi:
-    open_port: "8000"
-    # Uncomment to enable service discovery
-    # discovery:
-    #   poll_interval: 30s
+    version: "2.0"
+    rules:
+      - action: include
+        match:
+          process:
+            open_ports: "8000"
   otlp:
     protocols:
       grpc:
@@ -28,6 +30,10 @@ service:
       receivers: [otlp, obi]
       processors: [batch]
       exporters: [otlp/jaeger, debug]
+    metrics:
+      receivers: [obi]
+      processors: [batch]
+      exporters: [debug]
   telemetry:
     logs:
       level: debug

--- a/examples/otel-collector/smoke-config.yaml
+++ b/examples/otel-collector/smoke-config.yaml
@@ -1,0 +1,24 @@
+receivers:
+  obi:
+    version: "2.0"
+    policy:
+      poll_interval: 1s
+      min_process_age: 1s
+    rules:
+      - action: include
+        match:
+          process:
+            open_ports: "18080"
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [obi]
+      exporters: [debug]
+    metrics:
+      receivers: [obi]
+      exporters: [debug]

--- a/examples/otel-collector/smoke-test.sh
+++ b/examples/otel-collector/smoke-test.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 set -Eeuo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"

--- a/examples/otel-collector/smoke-test.sh
+++ b/examples/otel-collector/smoke-test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly SCRIPT_DIR
+readonly COLLECTOR_BINARY="$SCRIPT_DIR/otelcol-dev/otelcol-dev"
+readonly CONFIG_PATH="$SCRIPT_DIR/smoke-config.yaml"
+readonly SMOKE_PORT="18080"
+readonly SMOKE_URL="http://127.0.0.1:${SMOKE_PORT}/"
+readonly TRACE_ATTEMPTS="60"
+
+TMP_DIR=""
+COLLECTOR_LOG=""
+SERVER_LOG=""
+COLLECTOR_PID=""
+SERVER_PID=""
+
+log_info() {
+    printf 'INFO: %s\n' "$*" >&2
+}
+
+log_error() {
+    printf 'ERROR: %s\n' "$*" >&2
+}
+
+on_error() {
+    local -r line="$1"
+    log_error "command failed at line $line"
+}
+
+process_is_running() {
+    local -r pid="$1"
+    kill -0 "$pid" 2>/dev/null
+}
+
+stop_process() {
+    local -r pid="$1"
+    local watchdog_pid=""
+
+    if process_is_running "$pid"; then
+        kill -TERM "$pid" 2>/dev/null || true
+        (
+            sleep 10
+            kill -KILL "$pid" 2>/dev/null || true
+        ) &
+        watchdog_pid="$!"
+    fi
+
+    wait "$pid" 2>/dev/null || true
+
+    if [[ -n "$watchdog_pid" ]]; then
+        kill -TERM "$watchdog_pid" 2>/dev/null || true
+        wait "$watchdog_pid" 2>/dev/null || true
+    fi
+}
+
+print_failure_logs() {
+    if [[ -f "$COLLECTOR_LOG" ]]; then
+        log_error "collector output:"
+        tail -n 200 -- "$COLLECTOR_LOG" >&2
+    fi
+    if [[ -f "$SERVER_LOG" ]]; then
+        log_error "HTTP server output:"
+        tail -n 50 -- "$SERVER_LOG" >&2
+    fi
+}
+
+cleanup() {
+    local -r status="$?"
+    trap - ERR EXIT INT TERM
+
+    if [[ -n "$COLLECTOR_PID" ]]; then
+        stop_process "$COLLECTOR_PID"
+    fi
+    if [[ -n "$SERVER_PID" ]]; then
+        stop_process "$SERVER_PID"
+    fi
+    if (( status != 0 )); then
+        print_failure_logs
+    fi
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+        rm -rf -- "$TMP_DIR"
+    fi
+}
+
+check_dependencies() {
+    local -a required=(curl grep mktemp python3 tail)
+    local -a missing=()
+    local command=""
+
+    for command in "${required[@]}"; do
+        if ! command -v "$command" >/dev/null 2>&1; then
+            missing+=("$command")
+        fi
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_error "missing required commands: ${missing[*]}"
+        return 1
+    fi
+}
+
+check_inputs() {
+    if (( EUID != 0 )); then
+        log_error "run this smoke test with sudo so OBI can attach eBPF probes"
+        return 1
+    fi
+    if [[ ! -x "$COLLECTOR_BINARY" ]]; then
+        log_error "collector binary not found; build it with ocb before running this test"
+        return 1
+    fi
+    if [[ ! -f "$CONFIG_PATH" ]]; then
+        log_error "smoke configuration not found: $CONFIG_PATH"
+        return 1
+    fi
+}
+
+wait_for_http_server() {
+    local -i attempt=0
+
+    for ((attempt = 1; attempt <= 10; attempt += 1)); do
+        if ! process_is_running "$SERVER_PID"; then
+            log_error "HTTP server exited before becoming ready"
+            return 1
+        fi
+        if curl --fail --silent --show-error --max-time 2 "$SMOKE_URL" >/dev/null; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    log_error "HTTP server did not become ready"
+    return 1
+}
+
+wait_for_obi_trace() {
+    local -i attempt=0
+
+    for ((attempt = 1; attempt <= TRACE_ATTEMPTS; attempt += 1)); do
+        if ! process_is_running "$COLLECTOR_PID"; then
+            log_error "collector exited before exporting OBI telemetry"
+            return 1
+        fi
+
+        curl --fail --silent --show-error --max-time 2 "$SMOKE_URL" >/dev/null
+        if grep -Fq "ResourceSpans #0" "$COLLECTOR_LOG" &&
+            grep -Eq "Name[[:space:]]*: GET /" "$COLLECTOR_LOG"; then
+            return 0
+        fi
+        sleep 1
+    done
+
+    log_error "collector did not export an OBI HTTP trace within ${TRACE_ATTEMPTS}s"
+    return 1
+}
+
+main() {
+    if (( $# != 0 )); then
+        log_error "this smoke test does not accept arguments"
+        return 2
+    fi
+
+    check_dependencies
+    check_inputs
+
+    TMP_DIR="$(mktemp -d)"
+    COLLECTOR_LOG="$TMP_DIR/collector.log"
+    SERVER_LOG="$TMP_DIR/http-server.log"
+    printf 'OBI Collector receiver smoke test\n' >"$TMP_DIR/index.html"
+
+    python3 -m http.server "$SMOKE_PORT" --bind 127.0.0.1 \
+        --directory "$TMP_DIR" >"$SERVER_LOG" 2>&1 &
+    SERVER_PID="$!"
+    wait_for_http_server
+
+    "$COLLECTOR_BINARY" --config "$CONFIG_PATH" >"$COLLECTOR_LOG" 2>&1 &
+    COLLECTOR_PID="$!"
+    wait_for_obi_trace
+
+    log_info "Config v2 receiver exported OBI HTTP trace telemetry"
+}
+
+trap 'on_error "$LINENO"' ERR
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+main "$@"

--- a/internal/config/schema/errors.go
+++ b/internal/config/schema/errors.go
@@ -46,6 +46,15 @@ func (e *UnsupportedFileFormatError) Error() string {
 	return fmt.Sprintf("unsupported OpenTelemetry config file_format %q", e.FileFormat)
 }
 
+// ReceiverLayoutError reports a standalone OBI configuration envelope passed
+// to the Collector receiver parser.
+type ReceiverLayoutError struct{}
+
+func (*ReceiverLayoutError) Error() string {
+	return "standalone OBI config v2 layout is not valid in receiver config; " +
+		"move extensions.obi.capture fields to the receiver top level and set version there"
+}
+
 // SectionNotAllowedError reports a standalone-only configuration section in a
 // receiver-embedded OBI config.
 type SectionNotAllowedError struct {

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -205,6 +205,10 @@ func ParseReceiverYAML(data []byte) (*Extension, error) {
 		return nil, err
 	}
 
+	if _, ok := nestedNode(root, "extensions", "obi"); ok {
+		return nil, &ReceiverLayoutError{}
+	}
+
 	if version, ok := nestedScalar(root, "version"); ok {
 		if version != SupportedVersion {
 			return nil, &UnsupportedVersionError{Version: version}

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -209,12 +209,14 @@ func ParseReceiverYAML(data []byte) (*Extension, error) {
 		return nil, &ReceiverLayoutError{}
 	}
 
+	disallowedSection, hasDisallowedSection := disallowedReceiverSection(root)
+
 	if version, ok := nestedScalar(root, "version"); ok {
 		if version != SupportedVersion {
 			return nil, &UnsupportedVersionError{Version: version}
 		}
-		if section, ok := disallowedReceiverSection(root); ok {
-			return nil, &SectionNotAllowedError{Section: section}
+		if hasDisallowedSection {
+			return nil, &SectionNotAllowedError{Section: disallowedSection}
 		}
 		var receiver receiverConfig
 		if err := decode(root, &receiver); err != nil {
@@ -232,6 +234,10 @@ func ParseReceiverYAML(data []byte) (*Extension, error) {
 
 	if version, ok := nestedVersion(root, "version"); ok {
 		return nil, &UnsupportedVersionError{Version: version}
+	}
+
+	if hasDisallowedSection {
+		return nil, &SectionNotAllowedError{Section: disallowedSection}
 	}
 
 	if looksLikeV1(root) {

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -513,14 +513,27 @@ network: {}
 	require.ErrorAs(t, err, &standaloneNotV2)
 	require.Contains(t, err.Error(), "missing extensions.obi.version field")
 
-	_, err = ParseReceiverYAML([]byte(`
+	for _, yaml := range []string{
+		`
 file_format: "1.0"
 extensions:
   obi:
     version: "2.0"
     capture: {}
-`))
-	var receiverNotV2 *NotV2Error
-	require.ErrorAs(t, err, &receiverNotV2)
-	require.Contains(t, err.Error(), "missing top-level OBI v2 version field")
+`,
+		`
+file_format: "1.0"
+extensions:
+  obi:
+    capture: {}
+`,
+	} {
+		_, err = ParseReceiverYAML([]byte(yaml))
+		var wrongLayout *ReceiverLayoutError
+		require.ErrorAs(t, err, &wrongLayout)
+		var receiverNotV2 *NotV2Error
+		require.NotErrorAs(t, err, &receiverNotV2)
+		require.Contains(t, err.Error(), "extensions.obi.capture")
+		require.Contains(t, err.Error(), "receiver top level")
+	}
 }

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -251,6 +251,13 @@ extensions:
 func TestReceiverRejectsStandaloneSections(t *testing.T) {
 	t.Parallel()
 
+	layouts := []struct {
+		name   string
+		prefix string
+	}{
+		{name: "v2", prefix: "version: \"2.0\"\n"},
+		{name: "legacy selector", prefix: "open_port: \"8080\"\n"},
+	}
 	tests := []struct {
 		name  string
 		value string
@@ -264,17 +271,23 @@ func TestReceiverRejectsStandaloneSections(t *testing.T) {
 		t.Run(section, func(t *testing.T) {
 			t.Parallel()
 
-			for _, test := range tests {
-				t.Run(test.name, func(t *testing.T) {
+			for _, layout := range layouts {
+				t.Run(layout.name, func(t *testing.T) {
 					t.Parallel()
 
-					_, err := ParseReceiverYAML([]byte("version: \"2.0\"\n" + section + ": " + test.value + "\n"))
+					for _, test := range tests {
+						t.Run(test.name, func(t *testing.T) {
+							t.Parallel()
 
-					var notAllowed *SectionNotAllowedError
-					require.ErrorAs(t, err, &notAllowed)
-					require.Equal(t, section, notAllowed.Section)
-					require.Contains(t, err.Error(), "receiver config")
-					require.Contains(t, err.Error(), "standalone mode")
+							_, err := ParseReceiverYAML([]byte(layout.prefix + section + ": " + test.value + "\n"))
+
+							var notAllowed *SectionNotAllowedError
+							require.ErrorAs(t, err, &notAllowed)
+							require.Equal(t, section, notAllowed.Section)
+							require.Contains(t, err.Error(), "receiver config")
+							require.Contains(t, err.Error(), "standalone mode")
+						})
+					}
 				})
 			}
 		})


### PR DESCRIPTION
## Summary

- Parse receiver-embedded Config v2 through the shared schema and runtime conversion packages.
- Preserve legacy receiver configuration by falling back to v1 only when the input is conclusively not Config v2.
- Reject standalone Config v2 envelopes and the `enrich`, `correlation`, and `daemon` sections with actionable receiver-mode errors.
- Cover trace-only, metric-only, and combined pipelines, and exercise Config v2 through an OCB-built Collector runtime smoke test.

## Context

This completes the Collector receiver release-gate portion of #2251 using the self-contained receiver contract resolved in #2211. Collector pipelines remain authoritative, and this change does not create or publish a Collector distribution.

Closes #2536

## Testing

- `make docker-generate`
- `go test -v -p 2 -timeout 2m ./collector/...`
- `go test -v -p 2 -timeout 2m ./internal/config/...`
- `go test -short -p 2 ./...`
- `make compile`
- `make license-header-check`
- `make check-config-v2-artifacts`
- `make lint-markdown`
- Linux/arm64 and Darwin/amd64 Collector cross-builds
- OCB v0.151.0 build and validation of `config.yaml` and `smoke-config.yaml`
- Privileged OCB runtime smoke with a live HTTP service and OBI trace assertion