### PR TITLE
Detect sql type in Go SQL spans

### DIFF
--- a/bpf/common/common.h
+++ b/bpf/common/common.h
@@ -93,7 +93,7 @@ typedef struct http_request_trace {
 
 typedef struct sql_request_trace {
     u8 type; // Must be first
-    u8 _pad[1];
+    u8 sub_type;
     u16 status;
     pid_info pid;
     u64 start_monotime_ns;

--- a/bpf/gotracer/go_sql.c
+++ b/bpf/gotracer/go_sql.c
@@ -32,13 +32,13 @@
 
 // Sets the driver type based on the Go enum:
 // const (
-//	DBGeneric SQLKind = iota + 1
+//	DBGeneric SQLKind = iota
 //	DBPostgres
 //	DBMySQL
 //	DBMSSQL
 // )
 
-enum db_sub_type { k_db_generic = 1, k_db_postgres = 2, k_db_mysql = 3, k_db_mssql = 4 };
+enum db_sub_type { k_db_generic = 0, k_db_postgres = 1, k_db_mysql = 2, k_db_mssql = 3 };
 
 // Validates that driverConn.ci points to the expected database/sql driver
 // connection type and returns the concrete connection pointer.
@@ -235,7 +235,7 @@ static __always_inline bool supports_pq_conn_cfg_hostname() {
 // attempts to extract hostname by trying supported database drivers
 // Sets the driver type based on the Go enum:
 // const (
-//	DBGeneric SQLKind = iota + 1
+//	DBGeneric SQLKind = iota
 //	DBPostgres
 //	DBMySQL
 //	DBMSSQL

--- a/bpf/gotracer/go_sql.c
+++ b/bpf/gotracer/go_sql.c
@@ -30,6 +30,16 @@
 
 #include <shared/obi_ctx.h>
 
+// Sets the driver type based on the Go enum:
+// const (
+//	DBGeneric SQLKind = iota + 1
+//	DBPostgres
+//	DBMySQL
+//	DBMSSQL
+// )
+
+enum db_sub_type { k_db_generic = 1, k_db_postgres = 2, k_db_mysql = 3, k_db_mssql = 4 };
+
 // Validates that driverConn.ci points to the expected database/sql driver
 // connection type and returns the concrete connection pointer.
 static __always_inline void *get_database_sql_conn_ptr(u64 driver_conn_ptr,
@@ -223,6 +233,13 @@ static __always_inline bool supports_pq_conn_cfg_hostname() {
 // SQL hostname extraction with driver type routing.
 // Uses conn_type to determine which driver-specific extraction to use or
 // attempts to extract hostname by trying supported database drivers
+// Sets the driver type based on the Go enum:
+// const (
+//	DBGeneric SQLKind = iota + 1
+//	DBPostgres
+//	DBMySQL
+//	DBMSSQL
+// )
 static __always_inline void extract_sql_hostname(sql_request_trace_t *trace,
                                                  u64 driver_conn_ptr,
                                                  void *goroutine_addr,
@@ -238,6 +255,7 @@ static __always_inline void extract_sql_hostname(sql_request_trace_t *trace,
         if (read_pgx_hostname_from_conn(
                 (void *)driver_conn_ptr, (char *)trace->hostname, sizeof(trace->hostname))) {
             bpf_dbg_printk("extracted pgx hostname: %s", trace->hostname);
+            trace->sub_type = k_db_postgres;
         }
         return;
     }
@@ -248,6 +266,7 @@ static __always_inline void extract_sql_hostname(sql_request_trace_t *trace,
             if (read_pq_hostname_from_pqconn(
                     pq_conn_ptr, (char *)trace->hostname, sizeof(trace->hostname))) {
                 bpf_dbg_printk("extracted lib/pq hostname from conn.cfg: %s", trace->hostname);
+                trace->sub_type = k_db_postgres;
                 return;
             }
         }
@@ -261,6 +280,7 @@ static __always_inline void extract_sql_hostname(sql_request_trace_t *trace,
             char *pq_hostname = bpf_map_lookup_elem(&pq_hostnames, &g_key);
             if (pq_hostname) {
                 __builtin_memcpy(trace->hostname, pq_hostname, sizeof(trace->hostname));
+                trace->sub_type = k_db_postgres;
                 bpf_dbg_printk("extracted legacy lib/pq hostname: %s", trace->hostname);
             }
         }
@@ -271,6 +291,7 @@ static __always_inline void extract_sql_hostname(sql_request_trace_t *trace,
     if (mysql_conn_ptr) {
         if (read_mysql_hostname_from_mysqlconn(
                 mysql_conn_ptr, (char *)trace->hostname, sizeof(trace->hostname))) {
+            trace->sub_type = k_db_mysql;
             bpf_dbg_printk("extracted MySQL hostname: %s", trace->hostname);
         }
         return;
@@ -316,6 +337,7 @@ static __always_inline int process_sql_return(void *goroutine_addr, u8 error, u8
     if (trace) {
         task_pid(&trace->pid);
         trace->type = EVENT_SQL_CLIENT;
+        trace->sub_type = k_db_generic;
         trace->start_monotime_ns = invocation->start_monotime_ns;
         trace->end_monotime_ns = bpf_ktime_get_ns();
 

--- a/internal/test/oats/sql/yaml/oats_sql_go_mysql.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_mysql.yaml
@@ -16,31 +16,31 @@ expected:
     attributes:
       db.operation.name: SELECT
       db.collection.name: students
-      db.system.name: other_sql
+      db.system.name: mysql
   - traceql: '{ name = "UPDATE students" && status = unset}'
     equals: UPDATE students
     attributes:
       db.operation.name: UPDATE
       db.collection.name: students
-      db.system.name: other_sql
+      db.system.name: mysql
   - traceql: '{ name = "UPDATE nonexistent_table" && status = error}'
     equals: UPDATE nonexistent_table
     attributes:
       db.operation.name: UPDATE
       db.collection.name: nonexistent_table
-      db.system.name: other_sql
+      db.system.name: mysql
   - traceql: '{ .db.operation.name = "SELECT" && status = error }'
     equals: SELECT nonexistent_table
     attributes:
       db.operation.name: SELECT
       db.collection.name: nonexistent_table
-      db.system.name: other_sql
+      db.system.name: mysql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: == 0
-  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_mysql_otelsql.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_mysql_otelsql.yaml
@@ -8,18 +8,18 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "other_sql" }'
+  - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "mysql" }'
     equals: SELECT students
     attributes:
       db.operation.name: SELECT
       db.collection.name: students
-      db.system.name: other_sql
+      db.system.name: mysql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: == 0
-  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_mysql_tls.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_mysql_tls.yaml
@@ -8,18 +8,18 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "other_sql" }'
+  - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "mysql" }'
     equals: SELECT students
     attributes:
       db.operation.name: SELECT
       db.collection.name: students
-      db.system.name: other_sql
+      db.system.name: mysql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: == 0
-  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="mysqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="mysql", server_address="mysqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_pgx.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_pgx.yaml
@@ -16,33 +16,33 @@ expected:
     attributes:
       db.operation.name: SELECT
       db.collection.name: accounting.contacts
-      db.system.name: other_sql
+      db.system.name: postgresql
   # Successful UPDATE
   - traceql: '{ name = "UPDATE accounting.contacts" }'
     equals: UPDATE accounting.contacts
     attributes:
       db.operation.name: UPDATE
       db.collection.name: accounting.contacts
-      db.system.name: other_sql
+      db.system.name: postgresql
   # Error query
   - traceql: '{ .db.operation.name = "SELECT" && status = error }'
     equals: SELECT nonexistent_table
     attributes:
       db.operation.name: SELECT
       db.collection.name: nonexistent_table
-      db.system.name: other_sql
+      db.system.name: postgresql
   metrics:
   # SELECT metrics
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: == 0
-  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'
   # UPDATE metrics
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="UPDATE", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="UPDATE", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="UPDATE", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="UPDATE", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_pgx_pool.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_pgx_pool.yaml
@@ -13,9 +13,9 @@ expected:
     attributes:
       db.operation.name: SELECT
       db.collection.name: accounting.contacts
-      db.system.name: other_sql
+      db.system.name: postgresql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_pgx_stdlib.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_pgx_stdlib.yaml
@@ -13,9 +13,9 @@ expected:
     attributes:
       db.operation.name: SELECT
       db.collection.name: accounting.contacts
-      db.system.name: other_sql
+      db.system.name: postgresql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'

--- a/internal/test/oats/sql/yaml/oats_sql_go_postgres.yaml
+++ b/internal/test/oats/sql/yaml/oats_sql_go_postgres.yaml
@@ -8,18 +8,18 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "other_sql"}'
+  - traceql: '{ .db.operation.name = "SELECT" && .db.system.name = "postgresql"}'
     equals: SELECT accounting.contacts
     attributes:
       db.operation.name: SELECT
       db.collection.name: accounting.contacts
-      db.system.name: other_sql
+      db.system.name: postgresql
   metrics:
-  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_sum{db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="0",db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: == 0
-  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_bucket{le="10",db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="other_sql", server_address="sqlserver"}
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SELECT", db_system_name="postgresql", server_address="sqlserver"}
     value: '> 0'

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -88,7 +88,7 @@ const (
 type SQLKind uint8
 
 const (
-	DBGeneric SQLKind = iota + 1
+	DBGeneric SQLKind = iota
 	DBPostgres
 	DBMySQL
 	DBMSSQL

--- a/pkg/ebpf/common/spanner.go
+++ b/pkg/ebpf/common/spanner.go
@@ -127,8 +127,23 @@ func SQLRequestTraceToSpan(trace *SQLRequestTrace) request.Span {
 		hostname = hostname[:idx]
 	}
 
+	subType := trace.SubType
+
+	// if we didn't detect the type in Go, try heuristic detect
+	if subType == uint8(request.DBGeneric) {
+		switch hostPort {
+		case 5432:
+			subType = uint8(request.DBPostgres)
+		case 3306:
+			subType = uint8(request.DBMySQL)
+		case 1434:
+			subType = uint8(request.DBMSSQL)
+		}
+	}
+
 	return request.Span{
 		Type:          request.EventType(trace.Type),
+		SubType:       int(subType),
 		Method:        method,
 		Path:          path,
 		Peer:          peer,

--- a/pkg/ebpf/common/spanner_test.go
+++ b/pkg/ebpf/common/spanner_test.go
@@ -143,6 +143,110 @@ func Test_EmptyHostInfo(t *testing.T) {
 	assert.Empty(t, dest)
 }
 
+func makeSQLRequestTrace(sql string, subType uint8, dPort uint16, hostname string) SQLRequestTrace {
+	s := [500]uint8{}
+	copy(s[:], tocstr(sql))
+	h := [96]uint8{}
+	copy(h[:], tocstr(hostname))
+
+	return SQLRequestTrace{
+		Type:     5, // EventTypeSQLClient
+		SubType:  subType,
+		Sql:      s,
+		Hostname: h,
+		Conn: BpfConnectionInfoT{
+			D_port: dPort,
+		},
+	}
+}
+
+func TestSQLRequestTraceToSpan(t *testing.T) {
+	t.Run("returns empty span for wrong event type", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT 1", uint8(request.DBPostgres), 5432, "")
+		tr.Type = 1
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, request.Span{}, span)
+	})
+
+	t.Run("uses trace SubType when already detected", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT id FROM users", uint8(request.DBPostgres), 5432, "db:5432")
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, int(request.DBPostgres), span.SubType)
+	})
+
+	t.Run("trace SubType wins over port heuristic", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT id FROM users", uint8(request.DBMySQL), 5432, "")
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, int(request.DBMySQL), span.SubType)
+	})
+
+	t.Run("falls back to postgres when SubType is generic and port is 5432", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT id FROM users", uint8(request.DBGeneric), 5432, "")
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, int(request.DBPostgres), span.SubType)
+	})
+
+	t.Run("falls back to mysql when SubType is generic and port is 3306", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT id FROM users", uint8(request.DBGeneric), 3306, "")
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, int(request.DBMySQL), span.SubType)
+	})
+
+	t.Run("falls back to mssql when SubType is generic and port is 1434", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT id FROM users", uint8(request.DBGeneric), 1434, "")
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, int(request.DBMSSQL), span.SubType)
+	})
+
+	t.Run("stays generic when SubType is generic and port is unknown", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT id FROM users", uint8(request.DBGeneric), 9999, "")
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, int(request.DBGeneric), span.SubType)
+	})
+
+	t.Run("stays generic when SubType is generic and port is zero", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT id FROM users", uint8(request.DBGeneric), 0, "")
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, int(request.DBGeneric), span.SubType)
+	})
+
+	t.Run("strips port from hostname", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT 1", uint8(request.DBGeneric), 0, "db-host:5432")
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, "db-host", span.HostName)
+	})
+
+	t.Run("hostname without colon is kept", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT 1", uint8(request.DBGeneric), 0, "db-host")
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, "db-host", span.HostName)
+	})
+
+	t.Run("sets timing fields", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT 1", uint8(request.DBGeneric), 0, "")
+		tr.StartMonotimeNs = 100
+		tr.EndMonotimeNs = 200
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, int64(100), span.RequestStart)
+		assert.Equal(t, int64(100), span.Start)
+		assert.Equal(t, int64(200), span.End)
+	})
+
+	t.Run("sets connection peer and host ports", func(t *testing.T) {
+		tr := makeSQLRequestTrace("SELECT 1", uint8(request.DBPostgres), 5432, "")
+		tr.Conn.S_port = 45678
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, 45678, span.PeerPort)
+		assert.Equal(t, 5432, span.HostPort)
+	})
+
+	t.Run("sets statement from sql", func(t *testing.T) {
+		tr := makeSQLRequestTrace("INSERT INTO t VALUES (1)", uint8(request.DBGeneric), 0, "")
+		span := SQLRequestTraceToSpan(&tr)
+		assert.Equal(t, "INSERT INTO t VALUES (1)", span.Statement)
+	})
+}
+
 func TestStripPattern(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/export/otel/metrics_runtime_test.go
+++ b/pkg/export/otel/metrics_runtime_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	metricdata "go.opentelemetry.io/otel/sdk/metric/metricdata"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 


### PR DESCRIPTION
## Summary

Go SQL spans typically use the Go generic package and we always say the DB type is Generic, while in fact we know the type in certain cases. I added the type explicitly when we know we are dealing with Postgres or MySQL, but I also added heuristic code that determines the DB type based on the server port, which are well known for Postgres, MySQL and MSSQL.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
