### PR TITLE
ebpf: read /proc/<pid>/maps once per process instrumentation event

### DIFF
--- a/pkg/ebpf/instrumenter.go
+++ b/pkg/ebpf/instrumenter.go
@@ -373,11 +373,7 @@ func resolveInstrPath(
 	return mappedPath, exeIno, mappedPath, true
 }
 
-func (i *instrumenter) uprobes(pid app.PID, p Tracer) error {
-	maps, err := processMaps(pid)
-	if err != nil {
-		return err
-	}
+func (i *instrumenter) uprobes(pid app.PID, p Tracer, maps []*procfs.ProcMap) error {
 	log := ilog().With("probes", "uprobes")
 	if len(maps) == 0 {
 		log.Info("didn't find any process maps, not instrumenting shared libraries", "pid", pid)
@@ -437,16 +433,12 @@ func (i *instrumenter) uprobes(pid app.PID, p Tracer) error {
 	return nil
 }
 
-func (i *instrumenter) usdtProbes(pid app.PID, ns uint32, p Tracer) error {
+func (i *instrumenter) usdtProbes(pid app.PID, ns uint32, p Tracer, maps []*procfs.ProcMap) error {
 	probesByLib := p.USDTProbes()
 	if len(probesByLib) == 0 {
 		return nil
 	}
 
-	maps, err := processMaps(pid)
-	if err != nil {
-		return err
-	}
 	if len(maps) == 0 {
 		ilog().Debug("didn't find any process maps, not instrumenting USDT probes", "pid", pid)
 		return nil

--- a/pkg/ebpf/tracer_linux.go
+++ b/pkg/ebpf/tracer_linux.go
@@ -314,14 +314,18 @@ func (pt *ProcessTracer) Init(eventContext *common.EBPFEventContext, cfg *obi.Co
 
 func (pt *ProcessTracer) NewExecutableInstance(ie *Instrumentable) error {
 	if i, ok := pt.Instrumentables[ie.FileInfo.Ino()]; ok {
+		maps, err := processMaps(ie.FileInfo.Pid())
+		if err != nil {
+			return err
+		}
 		for _, p := range pt.Programs {
 			p.ProcessBinary(ie.FileInfo)
 			// Uprobes to be used for native module instrumentation points
-			if err := i.uprobes(ie.FileInfo.Pid(), p); err != nil {
+			if err := i.uprobes(ie.FileInfo.Pid(), p, maps); err != nil {
 				printVerifierErrorInfo(err)
 				return err
 			}
-			if err := i.usdtProbes(ie.FileInfo.Pid(), ie.FileInfo.Ns(), p); err != nil {
+			if err := i.usdtProbes(ie.FileInfo.Pid(), ie.FileInfo.Ns(), p, maps); err != nil {
 				printVerifierErrorInfo(err)
 				return err
 			}
@@ -342,6 +346,11 @@ func (pt *ProcessTracer) NewExecutable(exe *link.Executable, ie *Instrumentable)
 		processName: ie.FileInfo.ExecutableName(),
 	}
 
+	maps, err := processMaps(ie.FileInfo.Pid())
+	if err != nil {
+		return err
+	}
+
 	for _, p := range pt.Programs {
 		p.RegisterOffsets(ie.FileInfo, ie.Offsets)
 
@@ -352,12 +361,12 @@ func (pt *ProcessTracer) NewExecutable(exe *link.Executable, ie *Instrumentable)
 		}
 
 		// Uprobes to be used for native module instrumentation points
-		if err := i.uprobes(ie.FileInfo.Pid(), p); err != nil {
+		if err := i.uprobes(ie.FileInfo.Pid(), p, maps); err != nil {
 			printVerifierErrorInfo(err)
 			return err
 		}
 
-		if err := i.usdtProbes(ie.FileInfo.Pid(), ie.FileInfo.Ns(), p); err != nil {
+		if err := i.usdtProbes(ie.FileInfo.Pid(), ie.FileInfo.Ns(), p, maps); err != nil {
 			printVerifierErrorInfo(err)
 			return err
 		}


### PR DESCRIPTION
## Summary

`uprobes()` and `usdtProbes()` each called `processMaps()` independently, causing 2N reads of `/proc/<pid>/maps` per process event (where N is the number of Programs in the tracer). Each read acquires the target process's `mmap_lock`, which blocks under contention with any concurrent mmap/munmap in the target.

Read the maps once in `NewExecutable` and `NewExecutableInstance` before the Programs loop, and pass the result to both functions.


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
