### PR TITLE
Emit one span per topic for multi-topic Kafka `Produce/Fetch`

### DIFF
--- a/internal/test/integration/components/javakafka-multitopic/.mvn/wrapper/maven-wrapper.properties
+++ b/internal/test/integration/components/javakafka-multitopic/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip

--- a/internal/test/integration/components/javakafka-multitopic/Dockerfile_400
+++ b/internal/test/integration/components/javakafka-multitopic/Dockerfile_400
@@ -1,0 +1,38 @@
+FROM ghcr.io/graalvm/native-image:ol8-java17-22@sha256:d55ebb6eec6751b87ce9d34ab1004fa088d227d90d3edb4d9b3a994e54ac285a AS javabuilder
+
+# Install tar and gzip to extract the Maven binaries
+RUN microdnf update \
+ && microdnf install --nodocs \
+    tar \
+    gzip \
+ && microdnf clean all \
+ && rm -rf /var/cache/yum
+
+# Install Maven
+ARG USER_HOME_DIR="/cache"
+
+ENV JAVA_HOME /usr/lib64/graalvm/graalvm22-ce-java17
+
+# Set the working directory to /home/app
+WORKDIR /build
+
+# Copy the source code into the image for building
+COPY internal/test/integration/components/javakafka-multitopic/.mvn .mvn/
+COPY internal/test/integration/components/javakafka-multitopic/mvnw mvnw
+COPY internal/test/integration/components/javakafka-multitopic/src src/
+COPY internal/test/integration/components/javakafka-multitopic/pom400.xml pom.xml
+
+RUN java -version
+RUN ./mvnw -version
+
+# Build
+RUN ./mvnw -Pnative native:compile
+
+# The App Image
+FROM debian:bookworm-slim@sha256:74d56e3931e0d5a1dd51f8c8a2466d21de84a271cd3b5a733b803aa91abf4421
+
+EXPOSE 8080
+
+# Copy the native executable into the containers
+COPY --from=javabuilder /build/target/javakafka-mt ./javakafka-mt
+ENTRYPOINT ["/javakafka-mt"]

--- a/internal/test/integration/components/javakafka-multitopic/mvnw
+++ b/internal/test/integration/components/javakafka-multitopic/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/internal/test/integration/components/javakafka-multitopic/pom400.xml
+++ b/internal/test/integration/components/javakafka-multitopic/pom400.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>de.fstab.demo</groupId>
+	<artifactId>javakafka-mt</artifactId>
+	<version>1.0.0</version>
+
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+
+	<dependencies>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.graalvm.buildtools</groupId>
+				<artifactId>native-maven-plugin</artifactId>
+				<version>0.10.6</version>
+			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>Kafka</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>            
+		</plugins>
+	</build>
+
+</project>

--- a/internal/test/integration/components/javakafka-multitopic/src/main/java/Kafka.java
+++ b/internal/test/integration/components/javakafka-multitopic/src/main/java/Kafka.java
@@ -1,0 +1,101 @@
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+public class Kafka {
+
+    // Several topics so the consumer's Metadata response is MULTI-topic. The
+    // parser must resolve every topic, not just the first one in the response;
+    // subscribing to all of them means at least one topic is not first, so a
+    // parser that only handles the first topic leaves the rest as "*".
+    static final List<String> TOPICS = Arrays.asList(
+            "obi-java-multitopic-1",
+            "obi-java-multitopic-2",
+            "obi-java-multitopic-3");
+
+    public static void main(String[] args) {
+        try {
+            HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+            server.createContext("/message", new HttpHandler() {
+                @Override
+                public void handle(HttpExchange exchange) throws IOException {
+                    String response = "OK";
+                    exchange.sendResponseHeaders(200, response.length());
+                    OutputStream os = exchange.getResponseBody();
+                    os.write(response.getBytes());
+                    os.close();
+                }
+            });
+
+            String bootstrapServers = System.getenv("KAFKA_BOOTSTRAP_SERVERS");
+
+            if (bootstrapServers == null || bootstrapServers.isEmpty()) {
+                bootstrapServers = "localhost:9092";
+            }
+            // Producer
+            Properties producerProps = new Properties();
+            producerProps.put("bootstrap.servers", bootstrapServers);
+            producerProps.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+            producerProps.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+            producerProps.put("partitioner.class", "org.apache.kafka.clients.producer.RoundRobinPartitioner");
+            Thread producerThread = new Thread(() -> {
+                KafkaProducer<String, String> producer = new KafkaProducer<>(producerProps);
+                for (;;) {
+                    for (String topic : TOPICS) {
+                        producer.send(new ProducerRecord<>(topic, "key", "value"));
+                    }
+                    System.out.println("Produced messages");
+                    try {
+                        Thread.sleep(5000);
+                    } catch (Exception ignore) {}
+                }
+            });
+
+            // Consumer
+            Properties consumerProps = new Properties();
+            consumerProps.put("bootstrap.servers", bootstrapServers);
+            consumerProps.put("group.id", "1");
+            consumerProps.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+            consumerProps.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+            consumerProps.put("auto.offset.reset", "earliest");
+            // force to refresh metadata info because it can happen that OBI cannot catch it earlier
+            // otherwise we can just sleep at the beginning
+            consumerProps.put("metadata.max.age.ms", "10000");
+
+            Thread consumerThread = new Thread(() -> {
+                KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps);
+                consumer.subscribe(TOPICS);
+
+                while (true) {
+                    System.out.println("Polling for new messages...");
+                    ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(5000));
+                    for (ConsumerRecord<String, String> record : records) {
+                        System.out.printf("Consumed message: topic = %s, offset = %d, key = %s, value = %s%n",
+                                record.topic(), record.offset(), record.key(), record.value());
+                    }
+                }
+            });
+
+            producerThread.start();
+            consumerThread.start();
+            server.start();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/internal/test/integration/docker-compose-java-kafka-multitopic.yml
+++ b/internal/test/integration/docker-compose-java-kafka-multitopic.yml
@@ -1,0 +1,139 @@
+services:
+  # Single-node plaintext Kafka (KRaft). The multi-topic parsing is protocol-
+  # level, so a single broker is enough.
+  kafka:
+    image: docker.io/bitnamilegacy/kafka:4.0.0@sha256:f45d5b813412e1ef7ce67b467309a84e4c6dc03d7626a0b6da867db9b69bd107
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      - KAFKA_ENABLE_KRAFT=yes
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
+
+  # Apache Java client (Fetch/Produce v13+, topic-by-UUID) subscribing to several
+  # topics -> multi-topic Metadata response. Java delivers the response in the
+  # 4-byte-header-then-body shape, which OBI already captures, so this isolates
+  # the metadata parser (no dependency on the eBPF multi-chunk capture fix).
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/javakafka-multitopic/Dockerfile_400
+    image: hatest-testserver-java-kafka-multitopic
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+    depends_on:
+      otelcol:
+        condition: service_started
+      kafka:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-java-multitopic:/var/run/obi
+    image: hatest-obi
+    privileged: true
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_TRACES_INSTRUMENTATIONS: "kafka"
+      OTEL_EBPF_METRICS_INSTRUMENTATIONS: "kafka"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+      OTEL_KAFKA_TOPIC_UUID_CACHE_SIZE: "1000"
+      OTEL_EBPF_BPF_BUFFER_SIZE_KAFKA: "16384"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.155.0@sha256:4935caa35e9a4cb387e35732e8fb22b2b5759af8d12e7043357f03837f6e8df5
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317"
+      - "4318:4318"
+      - "9464"
+      - "8888"
+    depends_on:
+      prometheus:
+        condition: service_started
+      jaeger:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
+
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.60@sha256:4fd2d70fa347d6a47e79fcb06b1c177e6079f92cba88b083153d56263082135e
+    ports:
+      - "16686:16686"
+      - "4317"
+      - "4318"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=debug
+    volumes:
+      - ./configs/jaeger-ui-config.json:/etc/jaeger/ui-config.json
+    command: ["--query.ui-config=/etc/jaeger/ui-config.json"]

--- a/internal/test/integration/red_test_kafka.go
+++ b/internal/test/integration/red_test_kafka.go
@@ -271,6 +271,70 @@ func testNodeRdkafka(t *testing.T) {
 	}
 }
 
+// testJavaKafkaMultiTopic exercises the Apache Java client (Fetch/Produce v13+,
+// topic-by-UUID) subscribing to several topics, so the broker's Metadata
+// response is multi-topic. OBI must resolve every topic to its real name.
+// A parser that only handles the first topic leaves the others as "*",
+// so asserting all of them resolves guards the multi-topic metadata parsing
+// regardless of the broker's topic ordering.
+//
+// Note the asymmetry: the Apache Java producer sends a separate single-topic
+// Produce per topic, so the `publish <topic>` assertions pass even without the
+// multi-topic changes. The real coverage is the `process <topic>` assertions:
+// the Java consumer issues one multi-topic Fetch (all subscribed topics by UUID),
+// so all three `process` spans appearing is what proves the metadata
+// multi-topic parse + fetch alignment + per-topic span emission are working together.
+func testJavaKafkaMultiTopic(t *testing.T) {
+	commonAttrs := []attribute.KeyValue{
+		attribute.String("messaging.system", "kafka"),
+		attribute.Int("server.port", 9092),
+	}
+
+	topics := []string{
+		"obi-java-multitopic-1",
+		"obi-java-multitopic-2",
+		"obi-java-multitopic-3",
+	}
+
+	var spans []TestCaseSpan
+	for _, topic := range topics {
+		spans = append(spans,
+			TestCaseSpan{
+				Name: "publish " + topic,
+				Attributes: []attribute.KeyValue{
+					attribute.String("span.kind", "producer"),
+					attribute.String("messaging.operation.type", "publish"),
+					attribute.String("messaging.destination.name", topic),
+				},
+			},
+			TestCaseSpan{
+				Name: "process " + topic,
+				Attributes: []attribute.KeyValue{
+					attribute.String("span.kind", "consumer"),
+					attribute.String("messaging.operation.type", "process"),
+					attribute.String("messaging.destination.name", topic),
+				},
+			},
+		)
+	}
+
+	testCase := TestCase{
+		Route:   "http://localhost:8381",
+		Subpath: "message",
+		Comm:    "javakafka-mt",
+		Spans:   spans,
+	}
+
+	for i := range testCase.Spans {
+		testCase.Spans[i].Attributes = append(testCase.Spans[i].Attributes, commonAttrs...)
+	}
+
+	t.Run(testCase.Route, func(t *testing.T) {
+		waitForKafkaTestComponents(t, testCase.Route, "/"+testCase.Subpath)
+		runKafkaTestCase(t, testCase)
+	})
+}
+
 func waitForKafkaTestComponents(t *testing.T, url string, subpath string) {
 	t.Helper()
 

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -634,6 +634,16 @@ func TestSuite_NodeRdkafka(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_JavaKafkaMultiTopic(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-java-kafka-multitopic.yml", path.Join(pathOutput, "test-suite-java-kafka-multitopic.log"))
+	require.NoError(t, err)
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
+	require.NoError(t, compose.Up())
+	t.Run("Java Kafka multi-topic metadata resolution", testJavaKafkaMultiTopic)
+	runWeaverValidation(t)
+	require.NoError(t, compose.Close())
+}
+
 func TestSuite_PythonAsyncUvloop_3_9(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-async-uvloop-3.9.yml", path.Join(pathOutput, "test-suite-python-async-uvloop-3_9.log"))
 	require.NoError(t, err)

--- a/pkg/ebpf/common/go_kafka_transform.go
+++ b/pkg/ebpf/common/go_kafka_transform.go
@@ -26,10 +26,12 @@ func ReadGoSaramaRequestIntoSpan(record *ringbuf.Record) (request.Span, bool, er
 		return request.Span{}, true, err
 	}
 
-	info, ignore, err := ProcessKafkaRequest(largebuf.NewLargeBufferFrom(event.Buf[:]), nil)
+	infos, ignore, err := ProcessKafkaRequest(largebuf.NewLargeBufferFrom(event.Buf[:]), nil)
 
-	if err == nil && !ignore {
-		return GoKafkaSaramaToSpan(event, info), false, nil
+	// The Go Sarama uprobe captures one operation at a time, so a single topic is
+	// expected; use the first parsed topic.
+	if err == nil && !ignore && len(infos) > 0 {
+		return GoKafkaSaramaToSpan(event, infos[0]), false, nil
 	}
 
 	return request.Span{}, true, nil // ignore if we couldn't parse it

--- a/pkg/ebpf/common/kafka_detect_transform.go
+++ b/pkg/ebpf/common/kafka_detect_transform.go
@@ -51,8 +51,9 @@ func (k Operation) String() string {
 }
 
 // ProcessPossibleKafkaEvent processes a TCP packet and returns error if the packet is not a valid Kafka request.
-// Otherwise, return kafka.Info with the processed data.
-func ProcessPossibleKafkaEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer, rpkt *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (*KafkaInfo, bool, error) {
+// Otherwise, it returns one KafkaInfo per topic in the request (a single Produce/Fetch request can
+// reference multiple topics).
+func ProcessPossibleKafkaEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer, rpkt *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) ([]*KafkaInfo, bool, error) {
 	k, ok, err := ProcessKafkaEvent(pkt, rpkt, kafkaTopicUUIDToName)
 	if err != nil {
 		// If we are getting the information in the response buffer, the event
@@ -65,7 +66,7 @@ func ProcessPossibleKafkaEvent(event *TCPRequestInfo, pkt *largebuf.LargeBuffer,
 	return k, ok, err
 }
 
-func ProcessKafkaEvent(pkt *largebuf.LargeBuffer, rpkt *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (*KafkaInfo, bool, error) {
+func ProcessKafkaEvent(pkt *largebuf.LargeBuffer, rpkt *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) ([]*KafkaInfo, bool, error) {
 	hdr, err := kafkaparser.NewKafkaRequestHeader(pkt)
 	if err != nil {
 		return nil, true, err
@@ -82,7 +83,7 @@ func ProcessKafkaEvent(pkt *largebuf.LargeBuffer, rpkt *largebuf.LargeBuffer, ka
 	}
 }
 
-func processProduceRequest(hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (*KafkaInfo, bool, error) {
+func processProduceRequest(hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) ([]*KafkaInfo, bool, error) {
 	r, err := hdr.NewBodyReader()
 	if err != nil {
 		return nil, true, err
@@ -92,35 +93,35 @@ func processProduceRequest(hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToN
 	if err != nil {
 		return nil, true, err
 	}
-	firstTopic := produceReq.Topics[0]
-	topicName := firstTopic.Name
-	if firstTopic.UUID != nil {
-		if kafkaTopicUUIDToName != nil {
-			var found bool
-			topicName, found = kafkaTopicUUIDToName.Get(*firstTopic.UUID)
-			if !found {
-				topicName = "*"
-			}
-		} else {
+	clientID := hdr.ClientID()
+	infos := make([]*KafkaInfo, 0, len(produceReq.Topics))
+	for _, topic := range produceReq.Topics {
+		topicName := topic.Name
+		if topic.UUID != nil {
 			topicName = "*"
+			if kafkaTopicUUIDToName != nil {
+				if name, found := kafkaTopicUUIDToName.Get(*topic.UUID); found {
+					topicName = name
+				}
+			}
 		}
-	}
-	var partitionInfo *PartitionInfo
-	if firstTopic.Partition != nil {
-		partitionInfo = &PartitionInfo{
-			Partition: *firstTopic.Partition,
+		var partitionInfo *PartitionInfo
+		if topic.Partition != nil {
+			partitionInfo = &PartitionInfo{
+				Partition: *topic.Partition,
+			}
 		}
+		infos = append(infos, &KafkaInfo{
+			ClientID:      clientID,
+			Operation:     Produce,
+			Topic:         topicName,
+			PartitionInfo: partitionInfo,
+		})
 	}
-	return &KafkaInfo{
-		ClientID:  hdr.ClientID(),
-		Operation: Produce,
-		// TODO: handle multiple topics
-		Topic:         topicName,
-		PartitionInfo: partitionInfo,
-	}, false, nil
+	return infos, false, nil
 }
 
-func processFetchRequest(hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (*KafkaInfo, bool, error) {
+func processFetchRequest(hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) ([]*KafkaInfo, bool, error) {
 	r, err := hdr.NewBodyReader()
 	if err != nil {
 		return nil, true, err
@@ -130,33 +131,38 @@ func processFetchRequest(hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToNam
 	if err != nil {
 		return nil, true, err
 	}
-	firstTopic := fetchReq.Topics[0]
-	topicName := firstTopic.Name
-	// get topic name from UUID if available
-	if firstTopic.UUID != nil {
-		var found bool
-		topicName, found = kafkaTopicUUIDToName.Get(*firstTopic.UUID)
-		if !found {
+	clientID := hdr.ClientID()
+	infos := make([]*KafkaInfo, 0, len(fetchReq.Topics))
+	for _, topic := range fetchReq.Topics {
+		topicName := topic.Name
+		// Fetch v13+ identifies topics by UUID; resolve it via the cache filled
+		// from Metadata responses.
+		if topic.UUID != nil {
 			topicName = "*"
+			if kafkaTopicUUIDToName != nil {
+				if name, found := kafkaTopicUUIDToName.Get(*topic.UUID); found {
+					topicName = name
+				}
+			}
 		}
-	}
-	var partitionInfo *PartitionInfo
-	if firstTopic.Partition != nil {
-		partitionInfo = &PartitionInfo{
-			Partition: firstTopic.Partition.Partition,
-			Offset:    firstTopic.Partition.FetchOffset,
+		var partitionInfo *PartitionInfo
+		if topic.Partition != nil {
+			partitionInfo = &PartitionInfo{
+				Partition: topic.Partition.Partition,
+				Offset:    topic.Partition.FetchOffset,
+			}
 		}
+		infos = append(infos, &KafkaInfo{
+			ClientID:      clientID,
+			Operation:     Fetch,
+			Topic:         topicName,
+			PartitionInfo: partitionInfo,
+		})
 	}
-	return &KafkaInfo{
-		ClientID:  hdr.ClientID(),
-		Operation: Fetch,
-		// TODO: handle multiple topics
-		Topic:         topicName,
-		PartitionInfo: partitionInfo,
-	}, false, nil
+	return infos, false, nil
 }
 
-func processMetadataResponse(rpkt *largebuf.LargeBuffer, hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (*KafkaInfo, bool, error) {
+func processMetadataResponse(rpkt *largebuf.LargeBuffer, hdr kafkaparser.KafkaRequestHeader, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) ([]*KafkaInfo, bool, error) {
 	if rpkt == nil {
 		return nil, true, errKafkaNoResponseBufferForMetadata
 	}
@@ -176,7 +182,7 @@ func processMetadataResponse(rpkt *largebuf.LargeBuffer, hdr kafkaparser.KafkaRe
 	return nil, true, nil
 }
 
-func ProcessKafkaRequest(pkt *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (*KafkaInfo, bool, error) {
+func ProcessKafkaRequest(pkt *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) ([]*KafkaInfo, bool, error) {
 	hdr, err := kafkaparser.NewKafkaRequestHeader(pkt)
 	if err != nil {
 		return nil, true, err

--- a/pkg/ebpf/common/kafka_detect_transform_test.go
+++ b/pkg/ebpf/common/kafka_detect_transform_test.go
@@ -4,6 +4,7 @@
 package ebpfcommon
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
@@ -207,7 +208,9 @@ func TestProcessKafkaRequest(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.Equal(t, tt.expected, res)
+			require.NoError(t, err)
+			require.Len(t, res, 1)
+			assert.Equal(t, tt.expected, res[0])
 		})
 	}
 }
@@ -222,9 +225,10 @@ func TestProcessKafkaRequestProduceV13WithoutTopicCache(t *testing.T) {
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	}
 
-	info, ignore, err := ProcessKafkaRequest(largebuf.NewLargeBufferFrom(request), nil)
+	infos, ignore, err := ProcessKafkaRequest(largebuf.NewLargeBufferFrom(request), nil)
 	require.NoError(t, err)
 	require.False(t, ignore)
+	require.Len(t, infos, 1)
 	require.Equal(t, &KafkaInfo{
 		ClientID:  "kafka-producer-fights",
 		Operation: Produce,
@@ -232,7 +236,7 @@ func TestProcessKafkaRequestProduceV13WithoutTopicCache(t *testing.T) {
 		PartitionInfo: &PartitionInfo{
 			Partition: 0,
 		},
-	}, info)
+	}, infos[0])
 }
 
 func TestProcessKafkaRequestProduceV13WithTopicCache(t *testing.T) {
@@ -250,9 +254,10 @@ func TestProcessKafkaRequestProduceV13WithTopicCache(t *testing.T) {
 	uuid := kafkaparser.UUID{172, 231, 101, 123, 36, 212, 77, 228, 142, 87, 26, 240, 250, 236, 204, 15}
 	cache.Add(uuid, "my-topic")
 
-	info, ignore, err := ProcessKafkaRequest(largebuf.NewLargeBufferFrom(request), cache)
+	infos, ignore, err := ProcessKafkaRequest(largebuf.NewLargeBufferFrom(request), cache)
 	require.NoError(t, err)
 	require.False(t, ignore)
+	require.Len(t, infos, 1)
 	require.Equal(t, &KafkaInfo{
 		ClientID:  "kafka-producer-fights",
 		Operation: Produce,
@@ -260,5 +265,117 @@ func TestProcessKafkaRequestProduceV13WithTopicCache(t *testing.T) {
 		PartitionInfo: &PartitionInfo{
 			Partition: 0,
 		},
-	}, info)
+	}, infos[0])
+}
+
+// TestProcessKafkaRequestFetchMultiTopic verifies that a single multi-topic Fetch
+// request yields one KafkaInfo per topic (not just the first), each with its own
+// resolved name and partition. This is the transform-side counterpart to the
+// parser-level TestParseFetchRequestMultiTopicWithPartitions.
+func TestProcessKafkaRequestFetchMultiTopic(t *testing.T) {
+	uuid1 := kafkaparser.UUID{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+	}
+	uuid2 := kafkaparser.UUID{
+		0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+		0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30,
+	}
+
+	// Writes one full v12+ fetch partition entry.
+	writePartition := func(pkt []byte, offset int, idx uint32, fetchOffset uint64) int {
+		binary.BigEndian.PutUint32(pkt[offset:], idx) // partition_index
+		offset += 4
+		binary.BigEndian.PutUint32(pkt[offset:], 5) // current_leader_epoch
+		offset += 4
+		binary.BigEndian.PutUint64(pkt[offset:], fetchOffset) // fetch_offset
+		offset += 8
+		binary.BigEndian.PutUint32(pkt[offset:], 0xFFFFFFFF) // last_fetched_epoch
+		offset += 4
+		binary.BigEndian.PutUint64(pkt[offset:], 0) // log_start_offset
+		offset += 8
+		binary.BigEndian.PutUint32(pkt[offset:], 1048576) // partition_max_bytes
+		offset += 4
+		pkt[offset] = 0x00 // partition _tagged_fields
+		offset++
+		return offset
+	}
+
+	pkt := make([]byte, 300)
+	offset := 0
+
+	// Request header v2 (flexible): message_size is written last.
+	offset += 4                                                               // message_size (filled below)
+	binary.BigEndian.PutUint16(pkt[offset:], uint16(kafkaparser.APIKeyFetch)) // api_key
+	offset += 2
+	binary.BigEndian.PutUint16(pkt[offset:], 13) // api_version
+	offset += 2
+	binary.BigEndian.PutUint32(pkt[offset:], 1) // correlation_id
+	offset += 4
+	binary.BigEndian.PutUint16(pkt[offset:], 1) // client_id length
+	offset += 2
+	pkt[offset] = 'c' // client_id
+	offset++
+	pkt[offset] = 0x00 // header _tagged_fields (flexible)
+	offset++
+
+	// Fetch v13 body: replica_id, max_wait_ms, min_bytes, max_bytes, isolation_level, session_id, session_epoch.
+	binary.BigEndian.PutUint32(pkt[offset:], 1)
+	offset += 4
+	binary.BigEndian.PutUint32(pkt[offset:], 1000)
+	offset += 4
+	binary.BigEndian.PutUint32(pkt[offset:], 1)
+	offset += 4
+	binary.BigEndian.PutUint32(pkt[offset:], 1024)
+	offset += 4
+	pkt[offset] = 0 // isolation_level
+	offset++
+	binary.BigEndian.PutUint32(pkt[offset:], 1) // session_id
+	offset += 4
+	binary.BigEndian.PutUint32(pkt[offset:], 1) // session_epoch
+	offset += 4
+
+	pkt[offset] = 0x03 // topics COMPACT_ARRAY: 2 topics (N+1)
+	offset++
+	// topic 1
+	copy(pkt[offset:], uuid1[:])
+	offset += kafkaparser.UUIDLen
+	pkt[offset] = 0x02 // 1 partition
+	offset++
+	offset = writePartition(pkt, offset, 0, 100)
+	pkt[offset] = 0x00 // topic _tagged_fields
+	offset++
+	// topic 2
+	copy(pkt[offset:], uuid2[:])
+	offset += kafkaparser.UUIDLen
+	pkt[offset] = 0x02 // 1 partition
+	offset++
+	offset = writePartition(pkt, offset, 3, 200)
+	pkt[offset] = 0x00 // topic _tagged_fields
+	offset++
+
+	pkt = pkt[:offset]
+	binary.BigEndian.PutUint32(pkt[0:], uint32(offset-4)) // message_size
+
+	cache, _ := simplelru.NewLRU[kafkaparser.UUID, string](1000, nil)
+	cache.Add(uuid1, "topic-one")
+	cache.Add(uuid2, "topic-two")
+
+	infos, ignore, err := ProcessKafkaRequest(largebuf.NewLargeBufferFrom(pkt), cache)
+	require.NoError(t, err)
+	require.False(t, ignore)
+	require.Len(t, infos, 2)
+
+	require.Equal(t, &KafkaInfo{
+		ClientID:      "c",
+		Operation:     Fetch,
+		Topic:         "topic-one",
+		PartitionInfo: &PartitionInfo{Partition: 0, Offset: 100},
+	}, infos[0])
+	require.Equal(t, &KafkaInfo{
+		ClientID:      "c",
+		Operation:     Fetch,
+		Topic:         "topic-two",
+		PartitionInfo: &PartitionInfo{Partition: 3, Offset: 200},
+	}, infos[1])
 }

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -84,7 +84,7 @@ func ReadTCPRequestIntoSpan(parseCtx *EBPFParseContext, cfg *config.EBPFTracer, 
 func dispatchKernelAssignedProtocol(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
 	switch event.ProtocolType {
 	case ProtocolTypeKafka:
-		return dispatchKafka(event, requestBuffer, responseBuffer, parseCtx.kafkaTopicUUIDToName)
+		return dispatchKafka(parseCtx, event, requestBuffer, responseBuffer, parseCtx.kafkaTopicUUIDToName)
 	case ProtocolTypeMQTT:
 		return dispatchMQTT(event, requestBuffer, responseBuffer)
 	case ProtocolTypeMySQL:
@@ -100,18 +100,54 @@ func dispatchKernelAssignedProtocol(parseCtx *EBPFParseContext, event *TCPReques
 	return request.Span{}, false, false, nil
 }
 
-func dispatchKafka(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (request.Span, bool, bool, error) {
-	k, ignore, err := ProcessPossibleKafkaEvent(event, requestBuffer, responseBuffer, kafkaTopicUUIDToName)
+// handleKafkaEvent runs the common Kafka parse-and-emit path shared by dispatchKafka and
+// matchKafkaFallback. On a parse failure it returns the raw error; the caller decides whether
+// to surface it (classified packet) or swallow it as "not Kafka" (fallback path).
+func handleKafkaEvent(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (request.Span, bool, bool, error) {
+	infos, ignore, err := ProcessPossibleKafkaEvent(event, requestBuffer, responseBuffer, kafkaTopicUUIDToName)
 
 	if ignore && err == nil {
 		return request.Span{}, true, true, nil // parsed kafka event, but we don't want to create a span for it
 	}
 
 	if err == nil {
-		return TCPToKafkaToSpan(event, k), false, true, nil
+		if span, ok := kafkaSpanEmittingExtras(parseCtx, event, infos); ok {
+			return span, false, true, nil
+		}
+		return request.Span{}, true, true, nil // no topics to report
 	}
 
-	return request.Span{}, true, true, fmt.Errorf("failed to handle Kafka event: %w", err)
+	return request.Span{}, false, false, err
+}
+
+func dispatchKafka(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (request.Span, bool, bool, error) {
+	span, ignore, matched, err := handleKafkaEvent(parseCtx, event, requestBuffer, responseBuffer, kafkaTopicUUIDToName)
+	if err != nil {
+		return request.Span{}, true, true, fmt.Errorf("failed to handle Kafka event: %w", err)
+	}
+	return span, ignore, matched, nil
+}
+
+// kafkaSpanEmittingExtras turns the per-topic KafkaInfos of one Produce/Fetch request into spans.
+// A request can reference multiple topics; we return the span for the first topic and emit the rest
+// as extra spans (each gets a fresh SpanID downstream, since they share the event's trace context).
+func kafkaSpanEmittingExtras(parseCtx *EBPFParseContext, event *TCPRequestInfo, infos []*KafkaInfo) (request.Span, bool) {
+	if len(infos) == 0 {
+		return request.Span{}, false
+	}
+	primary := TCPToKafkaToSpan(event, infos[0])
+	if len(infos) > 1 {
+		extra := make([]request.Span, 0, len(infos)-1)
+		for _, info := range infos[1:] {
+			s := TCPToKafkaToSpan(event, info)
+			// Zero the SpanID so the pipeline assigns a unique one; otherwise every
+			// topic span from this request would share the event's SpanID.
+			s.SpanID = trace.SpanID{}
+			extra = append(extra, s)
+		}
+		parseCtx.emitExtraSpans(extra...)
+	}
+	return primary, true
 }
 
 func dispatchMQTT(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
@@ -328,7 +364,7 @@ func detectHeuristicProtocol(parseCtx *EBPFParseContext, event *TCPRequestInfo, 
 	}
 
 	// Kafka can arrive here for packets the kernel couldn't classify (e.g. OBI attached mid-connection).
-	if span, ignore, matched, err := matchKafkaFallback(event, requestBuffer, responseBuffer, parseCtx.kafkaTopicUUIDToName); matched {
+	if span, ignore, matched, err := matchKafkaFallback(parseCtx, event, requestBuffer, responseBuffer, parseCtx.kafkaTopicUUIDToName); matched {
 		return span, ignore, matched, err
 	}
 
@@ -548,18 +584,12 @@ func matchMQTT(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.La
 
 // matchKafkaFallback handles Kafka for unclassified packets (e.g. when the kernel missed the
 // connection start). Unlike dispatchKafka, errors here mean "not Kafka" — no error is surfaced.
-func matchKafkaFallback(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (request.Span, bool, bool, error) { //nolint:unparam
-	k, ignore, err := ProcessPossibleKafkaEvent(event, requestBuffer, responseBuffer, kafkaTopicUUIDToName)
-
-	if ignore && err == nil {
-		return request.Span{}, true, true, nil // parsed kafka event, but we don't want to create a span for it
+func matchKafkaFallback(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer, kafkaTopicUUIDToName *simplelru.LRU[kafkaparser.UUID, string]) (request.Span, bool, bool, error) { //nolint:unparam
+	span, ignore, matched, err := handleKafkaEvent(parseCtx, event, requestBuffer, responseBuffer, kafkaTopicUUIDToName)
+	if err != nil {
+		return request.Span{}, false, false, nil // parse failed on an unclassified packet — treat as "not Kafka"
 	}
-
-	if err == nil {
-		return TCPToKafkaToSpan(event, k), false, true, nil
-	}
-
-	return request.Span{}, false, false, nil
+	return span, ignore, matched, nil
 }
 
 func getBuffers(parseCtx *EBPFParseContext, event *TCPRequestInfo) (req *largebuf.LargeBuffer, resp *largebuf.LargeBuffer) {

--- a/pkg/ebpf/common/tcp_detect_transform_test.go
+++ b/pkg/ebpf/common/tcp_detect_transform_test.go
@@ -332,9 +332,10 @@ func TestTCPReqKafkaParsing(t *testing.T) {
 	// kafka message
 	b := []byte{0, 0, 0, 94, 0, 1, 0, 11, 0, 0, 0, 224, 0, 6, 115, 97, 114, 97, 109, 97, 255, 255, 255, 255, 0, 0, 1, 244, 0, 0, 0, 1, 6, 64, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 0, 0, 0, 1, 0, 9, 105, 109, 112, 111, 114, 116, 97, 110, 116, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0}
 	r := makeTCPReq(string(b), 343534)
-	k, _, err := ProcessKafkaRequest(largebuf.NewLargeBufferFrom(b), nil)
+	ks, _, err := ProcessKafkaRequest(largebuf.NewLargeBufferFrom(b), nil)
 	require.NoError(t, err)
-	s := TCPToKafkaToSpan(&r, k)
+	require.Len(t, ks, 1)
+	s := TCPToKafkaToSpan(&r, ks[0])
 	assert.NotNil(t, s)
 	assert.NotEmpty(t, s.Host)
 	assert.NotEmpty(t, s.Peer)

--- a/pkg/internal/ebpf/kafkaparser/fetch.go
+++ b/pkg/internal/ebpf/kafkaparser/fetch.go
@@ -162,20 +162,25 @@ func parseFetchTopic(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (
 		// if we fail to read Partition count, we can still return the topic
 		return &topic, nil
 	}
-	if partitionCount != 1 {
-		// no need to capture multiple partitions for fetch request, if its 1 Partition we can add it to the span
-		if err = skipFetchPartitions(r, header, partitionCount); err != nil {
-			// if we fail to skip partitions, we can still return the topic
+	// Walk every partition so the reader stays aligned for the next topic. We only
+	// keep the first partition for the span, but each entry MUST be fully consumed
+	// (including its trailing fields and per-partition tagged fields); otherwise a
+	// multi-topic Fetch request mis-parses every topic after the first.
+	for i := range partitionCount {
+		partition, fetchOffset, perr := parseFetchPartition(r, header)
+		if perr != nil {
+			// if we fail to parse a Partition, we can still return the topic
 			return &topic, nil
 		}
-	} else {
-		var partition *FetchPartition
-		partition, err = parseFetchPartition(r, header)
-		if err != nil {
-			// if we fail to parse Partition, we can still return the topic
-			return &topic, nil
+		// Only the first partition is kept for the span; the rest are parsed
+		// solely to advance the reader (a topic can have many partitions, e.g. 47),
+		// so allocate a FetchPartition for the first entry only.
+		if i == 0 {
+			topic.Partition = &FetchPartition{
+				Partition:   partition,
+				FetchOffset: fetchOffset,
+			}
 		}
-		topic.Partition = partition
 	}
 	if err = skipTaggedFields(r, header); err != nil {
 		return &topic, nil
@@ -183,93 +188,45 @@ func parseFetchTopic(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (
 	return &topic, nil
 }
 
-func parseFetchPartition(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (*FetchPartition, error) {
-	/*
-	   partitions => Partition fetch_offset log_start_offset partition_max_bytes
-	     Partition => INT32
-	     fetch_offset => INT64
-	*/
-	partition, err := readInt32(r)
+// parseFetchPartition reads one partition entry, advancing the reader past the
+// entire entry (including version-specific fields and flexible tagged fields).
+//
+// partitions => partition current_leader_epoch(9+) fetch_offset last_fetched_epoch(12+) log_start_offset(5+) partition_max_bytes _tagged_fields(12+)
+func parseFetchPartition(r *largebuf.LargeBufferReader, header KafkaRequestHeader) (partition int, fetchOffset int64, err error) {
+	partition, err = readInt32(r)
 	if err != nil {
-		return nil, err
+		return 0, 0, err
 	}
 	if header.APIVersion() >= 9 {
-		/*
-				fetch request version 9 and above include current_leader_epoch between Partition and fetch_offset.
-			    partitions => Partition current_leader_epoch fetch_offset last_fetched_epoch log_start_offset partition_max_bytes _tagged_fields
-			      Partition => INT32
-			      current_leader_epoch => INT32
-			      fetch_offset => INT64
-		*/
 		if err = r.Skip(Int32Len); err != nil { // current_leader_epoch
-			return nil, err
+			return 0, 0, err
 		}
 	}
-	fetchOffset, err := readInt64(r)
+	fetchOffset, err = readInt64(r)
 	if err != nil {
-		return nil, err
+		return 0, 0, err
 	}
-	return &FetchPartition{
-		Partition:   partition,
-		FetchOffset: fetchOffset,
-	}, nil
-}
-
-func skipFetchPartitions(r *largebuf.LargeBufferReader, header KafkaRequestHeader, partitionCount int) error {
-	var fetchPartitionLen int
+	// Skip the remaining fixed fields of this partition; the set is version-dependent.
 	switch {
 	case header.APIVersion() >= 12:
-		/*
-		   partitions => Partition current_leader_epoch fetch_offset last_fetched_epoch log_start_offset partition_max_bytes _tagged_fields
-		     Partition => INT32
-		     current_leader_epoch => INT32
-		     fetch_offset => INT64
-		     last_fetched_epoch => INT32
-		     log_start_offset => INT64
-		     partition_max_bytes => INT32
-		*/
-		fetchPartitionLen = Int32Len + // Partition
-			Int32Len + // current_leader_epoch
-			Int64Len + // fetch_offset
-			Int32Len + // last_fetched_epoch
-			Int64Len + // log_start_offset
-			Int32Len // partition_max_bytes
-	case header.APIVersion() >= 9:
-		/*
-		   partitions => Partition current_leader_epoch fetch_offset log_start_offset partition_max_bytes
-		     Partition => INT32
-		     current_leader_epoch => INT32
-		     fetch_offset => INT64
-		     log_start_offset => INT64
-		     partition_max_bytes => INT32
-		*/
-		fetchPartitionLen = Int32Len + // Partition
-			Int32Len + // current_leader_epoch
-			Int64Len + // fetch_offset
-			Int64Len + // log_start_offset
-			Int32Len // partition_max_bytes
+		// last_fetched_epoch(INT32) log_start_offset(INT64) partition_max_bytes(INT32)
+		if err = r.Skip(Int32Len + Int64Len + Int32Len); err != nil {
+			return 0, 0, err
+		}
 	case header.APIVersion() >= 5:
-		/*
-		   partitions => Partition fetch_offset log_start_offset partition_max_bytes
-		     Partition => INT32
-		     fetch_offset => INT64
-		     log_start_offset => INT64
-		     partition_max_bytes => INT32
-		*/
-		fetchPartitionLen = Int32Len + // Partition
-			Int64Len + // fetch_offset
-			Int64Len + // log_start_offset
-			Int32Len // partition_max_bytes
+		// log_start_offset(INT64) partition_max_bytes(INT32)
+		if err = r.Skip(Int64Len + Int32Len); err != nil {
+			return 0, 0, err
+		}
 	default:
-		/*
-		   partitions => Partition fetch_offset partition_max_bytes
-		     Partition => INT32
-		     fetch_offset => INT64
-		     partition_max_bytes => INT32
-		*/
-		fetchPartitionLen = Int32Len + // Partition
-			Int64Len + // fetch_offset
-			Int32Len // partition_max_bytes
+		// partition_max_bytes(INT32)
+		if err = r.Skip(Int32Len); err != nil {
+			return 0, 0, err
+		}
 	}
-	return r.Skip(fetchPartitionLen * partitionCount)
+	// per-partition tagged fields (flexible versions only; no-op otherwise)
+	if err = skipTaggedFields(r, header); err != nil {
+		return 0, 0, err
+	}
+	return partition, fetchOffset, nil
 }

--- a/pkg/internal/ebpf/kafkaparser/fetch_test.go
+++ b/pkg/internal/ebpf/kafkaparser/fetch_test.go
@@ -355,6 +355,101 @@ func TestParseFetchRequest(t *testing.T) {
 	}
 }
 
+// TestParseFetchRequestMultiTopicWithPartitions parses a v13 (flexible) request
+// with multiple topics, each with a fully-populated partition, and asserts
+// topics[1] (UUID + partition) parses correctly, i.e. the reader stayed aligned
+// across topics.
+func TestParseFetchRequestMultiTopicWithPartitions(t *testing.T) {
+	uuid1 := UUID{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+	}
+	uuid2 := UUID{
+		0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+		0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30,
+	}
+
+	// Writes one full v12+ partition entry: partition_index, current_leader_epoch,
+	// fetch_offset, last_fetched_epoch, log_start_offset, partition_max_bytes,
+	// and the per-partition _tagged_fields.
+	writePartition := func(pkt []byte, offset int, idx int32, fetchOffset int64) int {
+		binary.BigEndian.PutUint32(pkt[offset:], uint32(idx)) // partition_index
+		offset += 4
+		binary.BigEndian.PutUint32(pkt[offset:], 5) // current_leader_epoch
+		offset += 4
+		binary.BigEndian.PutUint64(pkt[offset:], uint64(fetchOffset)) // fetch_offset
+		offset += 8
+		binary.BigEndian.PutUint32(pkt[offset:], 0xFFFFFFFF) // last_fetched_epoch (-1)
+		offset += 4
+		binary.BigEndian.PutUint64(pkt[offset:], 0) // log_start_offset
+		offset += 8
+		binary.BigEndian.PutUint32(pkt[offset:], 1048576) // partition_max_bytes
+		offset += 4
+		pkt[offset] = 0x00 // partition _tagged_fields (empty)
+		offset++
+		return offset
+	}
+
+	pkt := make([]byte, 300)
+	offset := 0
+
+	// v13 header fields (v7-14 branch): replica_id, max_wait_ms, min_bytes,
+	// max_bytes, isolation_level, session_id, session_epoch.
+	binary.BigEndian.PutUint32(pkt[offset:], 1) // replica_id
+	offset += 4
+	binary.BigEndian.PutUint32(pkt[offset:], 1000) // max_wait_ms
+	offset += 4
+	binary.BigEndian.PutUint32(pkt[offset:], 1) // min_bytes
+	offset += 4
+	binary.BigEndian.PutUint32(pkt[offset:], 1024) // max_bytes
+	offset += 4
+	pkt[offset] = 0 // isolation_level
+	offset++
+	binary.BigEndian.PutUint32(pkt[offset:], 1) // session_id
+	offset += 4
+	binary.BigEndian.PutUint32(pkt[offset:], 1) // session_epoch
+	offset += 4
+
+	// Topics COMPACT_ARRAY: 2 topics => varint 3 (N+1).
+	pkt[offset] = 0x03
+	offset++
+
+	// Topic 1: UUID, 1 partition, topic tagged fields.
+	copy(pkt[offset:], uuid1[:])
+	offset += UUIDLen
+	pkt[offset] = 0x02 // partitions COMPACT_ARRAY: 1 => varint 2
+	offset++
+	offset = writePartition(pkt, offset, 0, 100)
+	pkt[offset] = 0x00 // topic _tagged_fields (empty)
+	offset++
+
+	// Topic 2: only parsed correctly if topic 1's partition was fully consumed.
+	copy(pkt[offset:], uuid2[:])
+	offset += UUIDLen
+	pkt[offset] = 0x02 // 1 partition
+	offset++
+	offset = writePartition(pkt, offset, 3, 200)
+	pkt[offset] = 0x00 // topic _tagged_fields (empty)
+	offset++
+
+	r := largebuf.NewLargeBufferFrom(pkt[:offset]).NewReader()
+	req, err := ParseFetchRequest(&r, newTestHeader(APIKeyFetch, 13))
+	require.NoError(t, err)
+	require.Len(t, req.Topics, 2)
+
+	assert.Equal(t, &uuid1, req.Topics[0].UUID)
+	require.NotNil(t, req.Topics[0].Partition)
+	assert.Equal(t, 0, req.Topics[0].Partition.Partition)
+	assert.Equal(t, int64(100), req.Topics[0].Partition.FetchOffset)
+
+	// The regression assertion: without fully consuming topic 1's partition,
+	// this UUID (and partition) would be read from the wrong offset.
+	assert.Equal(t, &uuid2, req.Topics[1].UUID)
+	require.NotNil(t, req.Topics[1].Partition)
+	assert.Equal(t, 3, req.Topics[1].Partition.Partition)
+	assert.Equal(t, int64(200), req.Topics[1].Partition.FetchOffset)
+}
+
 // Comprehensive truncation tests for fetch requests
 func TestParseFetchRequestTruncation(t *testing.T) {
 	// Create a valid fetch request packet for each version

--- a/pkg/internal/ebpf/kafkaparser/metadata.go
+++ b/pkg/internal/ebpf/kafkaparser/metadata.go
@@ -9,15 +9,6 @@ import (
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 )
 
-const partitionLen = // 26
-Int16Len +           // error_code
-	Int32Len + // partition_index
-	Int32Len + // leader_id
-	Int32Len + // leader_epoch
-	Int32Len + // replica_nodes
-	Int32Len + // isr_nodes
-	Int32Len // offline_replicas
-
 type MetadataTopic struct {
 	Name string
 	UUID UUID
@@ -111,6 +102,30 @@ func parseMetadataTopics(r *largebuf.LargeBufferReader, header KafkaRequestHeade
 	return topics, nil
 }
 
+// skipMetadataPartition advances the reader past one partition entry of a
+// Metadata Response topic (v10-13):
+// partitions => { error_code partition_index leader_id leader_epoch (replica_nodes) (isr_nodes) (offline_replicas) }
+// https://kafka.apache.org/43/design/protocol/
+// replica/isr/offline are compact arrays of INT32 node ids, so the entry is
+// variable-length and must be walked field by field.
+func skipMetadataPartition(r *largebuf.LargeBufferReader, header KafkaRequestHeader) error {
+	// error_code + partition_index + leader_id + leader_epoch
+	if err := r.Skip(Int16Len + Int32Len*3); err != nil {
+		return err
+	}
+	// replica_nodes, isr_nodes, offline_replicas
+	for range 3 {
+		n, err := readArrayLength(r, header)
+		if err != nil {
+			return err
+		}
+		if err = r.Skip(n * Int32Len); err != nil {
+			return err
+		}
+	}
+	return skipTaggedFields(r, header)
+}
+
 func parseMetadataTopic(r *largebuf.LargeBufferReader, header KafkaRequestHeader, isLast bool) (*MetadataTopic, error) {
 	var topic MetadataTopic
 	/*
@@ -148,14 +163,27 @@ func parseMetadataTopic(r *largebuf.LargeBufferReader, header KafkaRequestHeader
 	if isLast {
 		return &topic, nil
 	}
+	// is_internal (BOOLEAN) precedes the partitions array in the wire format.
+	// It must be skipped to stay aligned for the next topic; otherwise every
+	// topic after the first is mis-parsed (its name/UUID are read from the
+	// middle of this topic's partition data).
+	if err = r.Skip(Int8Len); err != nil { // is_internal
+		return &topic, nil
+	}
 	partitionsCount, err := readArrayLength(r, header)
 	if err != nil {
-		return nil, err
+		return &topic, nil
 	}
-	skipBytes := partitionsCount*partitionLen + // partitions
-		Int32Len // topic_authorized_operations
-	if err = r.Skip(skipBytes); err != nil {
-		// if we can't read partitions, we can still return the topic
+	// Each partition is variable-length in the flexible (compact) encoding
+	// (replica_nodes/isr_nodes/offline_replicas are compact arrays, plus a
+	// per-partition tagged-fields section), so it cannot be skipped with a
+	// fixed size.
+	for range partitionsCount {
+		if err = skipMetadataPartition(r, header); err != nil {
+			return &topic, nil
+		}
+	}
+	if err = r.Skip(Int32Len); err != nil { // topic_authorized_operations
 		return &topic, nil
 	}
 	if err = skipTaggedFields(r, header); err != nil {

--- a/pkg/internal/ebpf/kafkaparser/metadata_test.go
+++ b/pkg/internal/ebpf/kafkaparser/metadata_test.go
@@ -245,6 +245,9 @@ func TestParseMetadataResponse(t *testing.T) {
 				copy(pkt[offset:], uuid1[:])
 				offset += UUIDLen
 
+				pkt[offset] = 0x00 // is_internal
+				offset++
+
 				pkt[offset] = 0x00 // varint for 0 partitions (0)
 				offset++
 
@@ -347,6 +350,80 @@ func TestParseMetadataResponse(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestParseMetadataResponse_MultiTopicRealistic feeds a realistic v13 (flexible)
+// metadata response with two topics where the first topic carries a real
+// is_internal byte and a non-empty compact partition array. A correct parser
+// must skip past topic[0]'s is_internal + partitions (variable-length compact
+// arrays + tagged fields) to reach topic[1]. This is the shape of a real
+// broker response — unlike the other fixtures, which omit is_internal and use
+// zero partitions and therefore never exercise the skip logic.
+func TestParseMetadataResponse_MultiTopicRealistic(t *testing.T) {
+	uuid1 := UUID{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+	}
+	uuid2 := UUID{
+		0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+		0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30,
+	}
+
+	var buf []byte
+	put16 := func(v uint16) { b := make([]byte, 2); binary.BigEndian.PutUint16(b, v); buf = append(buf, b...) }
+	put32 := func(v uint32) { b := make([]byte, 4); binary.BigEndian.PutUint32(b, v); buf = append(buf, b...) }
+	putByte := func(v byte) { buf = append(buf, v) }
+	putStr := func(s string) { putByte(byte(len(s) + 1)); buf = append(buf, s...) } // compact string
+
+	put32(0)         // throttle_time_ms
+	putByte(0x02)    // brokers array: 1 broker (compact 1+1)
+	put32(1)         // node_id
+	putStr("broker") // host
+	put32(9092)      // port
+	putByte(0x00)    // rack (null)
+	putByte(0x00)    // broker tagged_fields
+	putByte(0x00)    // cluster_id (null)
+	put32(1)         // controller_id
+	putByte(0x03)    // topics array: 2 topics (compact 2+1)
+
+	// --- topic[0]: internal + one partition (must be skipped to reach topic[1]) ---
+	put16(0)                       // error_code
+	putStr("topic1")               // name
+	buf = append(buf, uuid1[:]...) // topic_id
+	putByte(0x00)                  // is_internal (BOOLEAN) -- present in real responses
+	putByte(0x02)                  // partitions array: 1 partition (compact 1+1)
+	put16(0)                       // partition error_code
+	put32(0)                       // partition_index
+	put32(1)                       // leader_id
+	put32(5)                       // leader_epoch
+	putByte(0x03)
+	put32(1)
+	put32(2) // replica_nodes: [1,2] (compact 2+1)
+	putByte(0x03)
+	put32(1)
+	put32(2)      // isr_nodes: [1,2]
+	putByte(0x01) // offline_replicas: [] (compact 0+1)
+	putByte(0x00) // partition tagged_fields
+	put32(0)      // topic_authorized_operations
+	putByte(0x00) // topic tagged_fields
+
+	// --- topic[1]: the target (last topic; parser returns after topic_id) ---
+	put16(0)                       // error_code
+	putStr("topic2")               // name
+	buf = append(buf, uuid2[:]...) // topic_id
+	putByte(0x00)                  // is_internal
+
+	header := newTestHeader(APIKeyMetadata, 13)
+	r := largebuf.NewLargeBufferFrom(buf).NewReader()
+	resp, err := ParseMetadataResponse(&r, header)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.Len(t, resp.Topics, 2, "both topics must be parsed (topic[1] is lost if topic[0]'s is_internal+partitions aren't skipped correctly)")
+	assert.Equal(t, "topic1", resp.Topics[0].Name)
+	assert.Equal(t, uuid1, resp.Topics[0].UUID)
+	assert.Equal(t, "topic2", resp.Topics[1].Name)
+	assert.Equal(t, uuid2, resp.Topics[1].UUID)
 }
 
 // Comprehensive truncation tests for metadata responses


### PR DESCRIPTION
## Summary

This PR allows OBI to emit a distinct span per topic for Kafka `Produce/Fetch` requests that reference multiple topics while previously only `Topics[0]` produced a span and the rest were dropped.

In brief:
- we now parse every topic in the `Metadata response`, not just the first, so the UUID->name cache is complete; before only first topic cached and  others resolved to `*`. (note: cache only matters for v13+, which identify topics by UUID, not name.)
- we now consume each partition entry completely so the reader stays aligned to the next topic; before under-read -> every topic after the first mis-parsed (transform used only `Topics[0]`, so the parser never needed to read past the first topic)
- emit one span per topic where the primary span from `topic[0]` and emit the rest as `extras`: same `TraceID`, unique `SpanID`, name `publish <topic> / process <topic>`.

Note: Go Sarama uprobe path unchanged in behavior because it captures one operation at a time, so it keeps using the first parsed topic.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
