### PR TITLE
Track Go SpanContext field offsets

### DIFF
--- a/bpf/gotracer/go_offsets.h
+++ b/bpf/gotracer/go_offsets.h
@@ -85,6 +85,9 @@ typedef enum {
     _tracer_delegate_pos,
     _tracer_attribute_opt_off,
     _error_string_off,
+    _span_context_trace_id_pos,
+    _span_context_span_id_pos,
+    _span_context_trace_flags_pos,
     // go runtime channels
     _hchan_qcount_pos,
     _hchan_dataqsiz_pos,

--- a/configs/offsets/oteltrace/inspect.go
+++ b/configs/offsets/oteltrace/inspect.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func main() {
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    trace.TraceID{1},
+		SpanID:     trace.SpanID{1},
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	fmt.Println(spanContext)
+}

--- a/configs/offsets/tracker_input.json
+++ b/configs/offsets/tracker_input.json
@@ -131,6 +131,17 @@
       "go.opentelemetry.io/otel/internal/global.tracer": ["delegate"]
     }
   },
+  "go.opentelemetry.io/otel/trace": {
+    "inspect": "./configs/offsets/oteltrace/inspect.go",
+    "versions": ">= v1.0.0",
+    "fields": {
+      "go.opentelemetry.io/otel/trace.SpanContext": [
+        "traceID",
+        "spanID",
+        "traceFlags"
+      ]
+    }
+  },
   "go.mongodb.org/mongo-driver": {
     "inspect": "./configs/offsets/mongo/inspect.go",
     "versions": ">= v1.10.1",

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -341,6 +341,9 @@ func (p *Tracer) RegisterOffsets(fileInfo *exec.FileInfo, offsets *goexec.Offset
 		goexec.GrpcClientStreamStream,
 		// go manual spans
 		goexec.GoTracerDelegatePos,
+		goexec.SpanContextTraceIDPos,
+		goexec.SpanContextSpanIDPos,
+		goexec.SpanContextTraceFlagsPos,
 		// go runtime channels
 		goexec.HchanQcountPos,
 		goexec.HchanDataqsizPos,

--- a/pkg/internal/goexec/offsets.go
+++ b/pkg/internal/goexec/offsets.go
@@ -47,6 +47,26 @@ func (o *Offsets) HasGoChannelOffsets() bool {
 	return true
 }
 
+// HasGoAutoSDKSpanContextOffsets reports whether all trace.SpanContext offsets
+// needed for Go Auto SDK span integration are available for an inspected executable.
+func (o *Offsets) HasGoAutoSDKSpanContextOffsets() bool {
+	if o == nil {
+		return false
+	}
+
+	for _, field := range []GoOffset{
+		SpanContextTraceIDPos,
+		SpanContextSpanIDPos,
+		SpanContextTraceFlagsPos,
+	} {
+		if _, ok := o.Field[field].(uint64); !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
 // InspectOffsets gets the memory addresses/offsets of the instrumenting function, as well as the required
 // parameters fields to be read from the eBPF code
 func InspectOffsets(execElf *exec.FileInfo, funcs []string) (*Offsets, error) {

--- a/pkg/internal/goexec/offsets.json
+++ b/pkg/internal/goexec/offsets.json
@@ -510,6 +510,44 @@
         ]
       }
     },
+    "go.opentelemetry.io/otel/trace.SpanContext": {
+      "spanID": {
+        "versions": {
+          "oldest": "1.0.0",
+          "newest": "1.44.0"
+        },
+        "offsets": [
+          {
+            "offset": 16,
+            "since": "1.0.0"
+          }
+        ]
+      },
+      "traceFlags": {
+        "versions": {
+          "oldest": "1.0.0",
+          "newest": "1.44.0"
+        },
+        "offsets": [
+          {
+            "offset": 24,
+            "since": "1.0.0"
+          }
+        ]
+      },
+      "traceID": {
+        "versions": {
+          "oldest": "1.0.0",
+          "newest": "1.44.0"
+        },
+        "offsets": [
+          {
+            "offset": 0,
+            "since": "1.0.0"
+          }
+        ]
+      }
+    },
     "golang.org/x/net/http2.ClientConn": {
       "fr": {
         "versions": {

--- a/pkg/internal/goexec/offsets_test.go
+++ b/pkg/internal/goexec/offsets_test.go
@@ -51,3 +51,22 @@ func TestOffsets_HasGoChannelOffsets(t *testing.T) {
 		HchanRecvxPos:    uint64(56),
 	}}).HasGoChannelOffsets())
 }
+
+func TestOffsets_HasGoAutoSDKSpanContextOffsets(t *testing.T) {
+	assert.False(t, (*Offsets)(nil).HasGoAutoSDKSpanContextOffsets())
+	assert.False(t, (&Offsets{}).HasGoAutoSDKSpanContextOffsets())
+	assert.False(t, (&Offsets{Field: FieldOffsets{
+		SpanContextTraceIDPos: uint64(0),
+		SpanContextSpanIDPos:  uint64(16),
+	}}).HasGoAutoSDKSpanContextOffsets())
+	assert.False(t, (&Offsets{Field: FieldOffsets{
+		SpanContextTraceIDPos:    uint64(0),
+		SpanContextSpanIDPos:     uint64(16),
+		SpanContextTraceFlagsPos: int64(24),
+	}}).HasGoAutoSDKSpanContextOffsets())
+	assert.True(t, (&Offsets{Field: FieldOffsets{
+		SpanContextTraceIDPos:    uint64(0),
+		SpanContextSpanIDPos:     uint64(16),
+		SpanContextTraceFlagsPos: uint64(24),
+	}}).HasGoAutoSDKSpanContextOffsets())
+}

--- a/pkg/internal/goexec/structmembers.go
+++ b/pkg/internal/goexec/structmembers.go
@@ -107,6 +107,9 @@ const (
 	GoTracerDelegatePos
 	GoTracerAttributeOptOffset
 	GoErrorStringOffset
+	SpanContextTraceIDPos
+	SpanContextSpanIDPos
+	SpanContextTraceFlagsPos
 	// go runtime channels
 	HchanQcountPos
 	HchanDataqsizPos
@@ -437,6 +440,14 @@ var structMembers = map[string]structInfo{
 		lib: "go.opentelemetry.io/otel",
 		fields: map[string]GoOffset{
 			"delegate": GoTracerDelegatePos,
+		},
+	},
+	"go.opentelemetry.io/otel/trace.SpanContext": {
+		lib: "go.opentelemetry.io/otel/trace",
+		fields: map[string]GoOffset{
+			"traceID":    SpanContextTraceIDPos,
+			"spanID":     SpanContextSpanIDPos,
+			"traceFlags": SpanContextTraceFlagsPos,
 		},
 	},
 	"runtime.hchan": {

--- a/pkg/internal/goexec/structmembers_test.go
+++ b/pkg/internal/goexec/structmembers_test.go
@@ -21,10 +21,12 @@ import (
 )
 
 var (
-	debugData    *dwarf.Data
-	grpcElf      *dwarf.Data
-	smallELF     *elf.File
-	smallGRPCElf *elf.File
+	debugData           *dwarf.Data
+	grpcElf             *dwarf.Data
+	spanContextData     *dwarf.Data
+	smallELF            *elf.File
+	smallGRPCElf        *elf.File
+	smallSpanContextELF *elf.File
 )
 
 func compileELF(source string, extraArgs ...string) *elf.File {
@@ -34,7 +36,7 @@ func compileELF(source string, extraArgs ...string) *elf.File {
 	cmdParts = append(cmdParts, extraArgs...)
 	cmdParts = append(cmdParts, "-o", tmpFilePath, source)
 	cmd := exec.Command("go", cmdParts...)
-	cmd.Env = []string{"GOOS=linux", "HOME=" + tempDir}
+	cmd.Env = []string{"GOOS=linux", "HOME=" + tempDir, "TMPDIR=" + tempDir}
 	out := &bytes.Buffer{}
 	cmd.Stdout, cmd.Stderr = out, out
 	if err := cmd.Run(); err != nil {
@@ -62,6 +64,11 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	smallGRPCElf = compileELF(baseDir+"/internal/test/cmd/grpc/server/server.go", "-ldflags", "-s -w")
+	spanContextData, err = compileELF(baseDir + "/configs/offsets/oteltrace/inspect.go").DWARF()
+	if err != nil {
+		panic(err)
+	}
+	smallSpanContextELF = compileELF(baseDir+"/configs/offsets/oteltrace/inspect.go", "-ldflags", "-s -w")
 	m.Run()
 }
 
@@ -131,6 +138,25 @@ func TestGrpcOffsetsWithoutDwarf(t *testing.T) {
 		GrpcStatusCodePtrPos:   uint64(40),
 		ConnFdPos:              uint64(0),
 		FdLaddrPos:             uint64(96),
+	}, offsets)
+}
+
+func TestSpanContextOffsetsFromDwarf(t *testing.T) {
+	offsets, _ := structMemberOffsetsFromDwarf(spanContextData)
+	mustMatch(t, FieldOffsets{
+		SpanContextTraceIDPos:    uint64(0),
+		SpanContextSpanIDPos:     uint64(16),
+		SpanContextTraceFlagsPos: uint64(24),
+	}, offsets)
+}
+
+func TestSpanContextOffsetsWithoutDwarf(t *testing.T) {
+	offsets, err := structMemberOffsets(smallSpanContextELF)
+	require.NoError(t, err)
+	mustMatch(t, FieldOffsets{
+		SpanContextTraceIDPos:    uint64(0),
+		SpanContextSpanIDPos:     uint64(16),
+		SpanContextTraceFlagsPos: uint64(24),
 	}, offsets)
 }
 


### PR DESCRIPTION
## Summary

- discover `trace.SpanContext` trace ID, span ID, and trace flags offsets for every supported OpenTelemetry Go trace release
- register the offsets in the Go tracer table and expose an availability check for later Go Auto SDK integration
- verify offset discovery from both DWARF data and stripped binaries

## Context

This is the first production slice extracted from #2258. The privileged manual-span bridge needs to populate Auto SDK `SpanContext` values without relying on hard-coded Go struct layouts.

A dedicated trace-only fixture keeps OpenTelemetry module versions aligned during offset generation. This change intentionally adds no probes, events, or user-visible telemetry behavior. Follow-up changes can add inert event, parser, and exporter support before activating the privileged probes.

## Validation

- `make update-offsets`
- `make generate`
- `make docker-generate`
- `make compile`
- `make license-header-check`
- `go test -count=1 ./pkg/internal/goexec ./pkg/internal/ebpf/gotracer`
- `make verify`
