### PR TITLE
Strengthen Config v2 conversion boundaries

### DIFF
--- a/devdocs/config/version-2.0/examples/default-configuration.yaml
+++ b/devdocs/config/version-2.0/examples/default-configuration.yaml
@@ -600,28 +600,12 @@ extensions:
             source_labels:
               service_name: ""
               service_namespace: ""
-        # DNS enricher runtime configuration.
-        dns:
-          enabled: true
       # Service identity enrichment policy from configured enrichers.
       service_name:
         # Shared cache for peer/host service-name lookups.
         cache:
           size: 1024
           ttl: 5m0s
-        # Rule-based service identity mapping.
-        # Rule order is the precedence model: earlier rules win when they set the same target field.
-        rules:
-          - id: k8s-default
-            from: kubernetes
-            description: Default Kubernetes label mapping into canonical service identity.
-            map:
-              service.name:
-                - app.kubernetes.io/name
-              service.namespace:
-                - app.kubernetes.io/part-of
-              service.version:
-                - app.kubernetes.io/version
         # Fallback names when peer/host resolution fails.
         unresolved_hosts:
           names:
@@ -630,35 +614,6 @@ extensions:
             incoming: incoming
       # Attribute enrichment/selection controls.
       attributes:
-        # Rule order is the precedence model: earlier rules win when they set the same target attribute.
-        rules:
-          - id: k8s-default-attributes
-            from: kubernetes
-            description: Default Kubernetes-derived attribute enrichment and selection.
-            add:
-              # Explicit attribute mapping policy for Kubernetes metadata.
-              map:
-                k8s.namespace.name:
-                  - kubernetes.namespace
-                k8s.pod.name:
-                  - kubernetes.pod.name
-                k8s.deployment.name:
-                  - kubernetes.workload.deployment
-                k8s.node.name:
-                  - kubernetes.node.name
-          - id: dns-default-attributes
-            from: dns
-            description: Default DNS-based host and instance identity enrichment.
-            add:
-              # Explicit attribute mapping policy for DNS metadata.
-              map:
-                host.name:
-                  - dns.host_name
-                  - dns.ptr_name
-                service.instance.id:
-                  - dns.host_name
-                server.address:
-                  - dns.resolved_ip
 
     # correlation propagates OBI trace context into external streams.
     # Standalone-mode only: not valid in Collector receiver deployments.

--- a/internal/config/convert/export.go
+++ b/internal/config/convert/export.go
@@ -715,12 +715,12 @@ func daemon(cfg *obi.Config) *schema.Daemon {
 }
 
 func logLevel(level obi.LogLevel) otelconfx.SeverityNumber {
-	switch level {
-	case obi.LogLevelDebug:
+	switch strings.ToUpper(string(level)) {
+	case string(obi.LogLevelDebug):
 		return otelconfx.SeverityNumberDebug
-	case obi.LogLevelWarn:
+	case string(obi.LogLevelWarn):
 		return otelconfx.SeverityNumberWarn
-	case obi.LogLevelError:
+	case string(obi.LogLevelError):
 		return otelconfx.SeverityNumberError
 	default:
 		return otelconfx.SeverityNumberInfo

--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -865,6 +865,7 @@ func TestRuntimeToV2DocumentParsesAsStandaloneV2(t *testing.T) {
 	require.NotContains(t, string(data), "rules: null")
 	require.NotContains(t, string(data), "telemetry: null")
 	require.NotContains(t, string(data), "refine: {}")
+	require.NotContains(t, string(data), "additionalproperties")
 
 	parsedDoc, parsedExt, err := schema.ParseStandaloneYAML(data)
 	require.NoError(t, err)

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -38,13 +38,22 @@ func V2ToRuntime(src *schema.Extension) (*obi.Config, error) {
 	if err := schema.ValidateStandalone(src); err != nil {
 		return nil, err
 	}
+	if err := validateV2MatchOrder(src.Capture.Policy.MatchOrder, src.Capture.Rules); err != nil {
+		return nil, err
+	}
 	if err := validateV2RulePatterns(src.Capture.Rules); err != nil {
+		return nil, err
+	}
+	if err := validateV2RuleSelectorFamilies(src.Capture.Rules); err != nil {
 		return nil, err
 	}
 	if err := validateV2HTTPFilters(src.Capture.Instrumentation.HTTP.Filters); err != nil {
 		return nil, err
 	}
 	if err := validateV2HTTPPayloadExtraction(src.Capture.Instrumentation.HTTP.PayloadExtraction); err != nil {
+		return nil, err
+	}
+	if err := validateUnsupportedV2Fields(src); err != nil {
 		return nil, err
 	}
 
@@ -55,6 +64,57 @@ func V2ToRuntime(src *schema.Extension) (*obi.Config, error) {
 	cfg.Attributes.Select.Normalize()
 
 	return &cfg, nil
+}
+
+func validateUnsupportedV2Fields(src *schema.Extension) error {
+	runtimeFilters := []struct {
+		path    string
+		filters schema.AttributeFilters
+	}{
+		{path: "capture.runtimes.go.filter", filters: src.Capture.Runtimes.Go.Filter},
+		{path: "capture.runtimes.nodejs.filter", filters: src.Capture.Runtimes.NodeJS.Filter},
+		{path: "capture.runtimes.java.filter", filters: src.Capture.Runtimes.Java.Filter},
+	}
+	for _, runtimeFilter := range runtimeFilters {
+		if len(runtimeFilter.filters) != 0 {
+			return fmt.Errorf("%s is not supported", runtimeFilter.path)
+		}
+	}
+
+	if src.Enrich != nil {
+		for _, enrichmentProperties := range []struct {
+			path       string
+			properties map[string]any
+		}{
+			{path: "enrich", properties: src.Enrich.AdditionalProperties},
+			{path: "enrich.enrichers", properties: src.Enrich.Enrichers.AdditionalProperties},
+			{path: "enrich.enrichers.kubernetes", properties: src.Enrich.Enrichers.Kubernetes.AdditionalProperties},
+			{path: "enrich.service_name", properties: src.Enrich.ServiceName.AdditionalProperties},
+			{path: "enrich.attributes", properties: src.Enrich.Attributes.AdditionalProperties},
+		} {
+			if err := rejectUnsupportedProperties(enrichmentProperties.path, enrichmentProperties.properties); err != nil {
+				return err
+			}
+		}
+	}
+
+	if src.Correlation != nil && len(src.Correlation.LogTraceAnnotation.Filter) != 0 {
+		return errors.New("correlation.log_trace_annotation.filter is not supported")
+	}
+	return nil
+}
+
+func rejectUnsupportedProperties(path string, properties map[string]any) error {
+	if len(properties) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(properties))
+	for key := range properties {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return fmt.Errorf("%s.%s is not supported", path, keys[0])
 }
 
 func runtimeConfigDefaults() obi.Config {
@@ -72,7 +132,7 @@ func runtimeConfigDefaults() obi.Config {
 
 func applyV2Capture(cfg *obi.Config, src *schema.Extension) {
 	applyV2Policy(cfg, src.Capture.Policy, completePolicy(src.Capture.Policy))
-	applyV2Rules(cfg, src.Capture.Rules)
+	applyV2Rules(cfg, src.Capture.Rules, src.Capture.Policy.DefaultAction)
 	applyV2Limits(cfg, src.Capture.Limits, completeLimits(src.Capture.Limits))
 	applyV2Safety(cfg, src.Capture.Safety, !zeroValue(src.Capture.Safety))
 	applyV2Channels(cfg, src.Capture.Channels, completeChannels(src.Capture.Channels))
@@ -112,12 +172,30 @@ type runtimeDiscoveryRules struct {
 	defaultOTLPGRPCPort             int
 }
 
-func applyV2Rules(cfg *obi.Config, rules []schema.Rule) {
+func applyV2Rules(cfg *obi.Config, rules []schema.Rule, defaultAction schema.CaptureAction) {
+	includeByDefault := defaultAction != schema.CaptureActionExclude
 	if rules == nil {
+		if includeByDefault {
+			cfg.Discovery.Instrument = services.GlobDefinitionCriteria{
+				{Path: services.NewGlob("*")},
+			}
+		}
 		return
 	}
 
-	applyRuntimeDiscoveryRules(cfg, runtimeDiscoveryRulesFromV2(rules))
+	converted := runtimeDiscoveryRulesFromV2(rules)
+	if includeByDefault {
+		if len(converted.includeRegex) > 0 || len(converted.excludeRegex) > 0 {
+			converted.includeRegex = append(converted.includeRegex, services.RegexSelector{
+				Path: services.NewRegexp(".*"),
+			})
+		} else {
+			converted.includeGlobs = append(converted.includeGlobs, services.GlobAttributes{
+				Path: services.NewGlob("*"),
+			})
+		}
+	}
+	applyRuntimeDiscoveryRules(cfg, converted)
 }
 
 func runtimeDiscoveryRulesFromV2(rules []schema.Rule) runtimeDiscoveryRules {
@@ -193,6 +271,69 @@ func validateV2RulePatterns(rules []schema.Rule) error {
 		}
 	}
 	return nil
+}
+
+func validateV2RuleSelectorFamilies(rules []schema.Rule) error {
+	selectorFamily := ""
+	for i, rule := range rules {
+		if rule.Match.Process.ExportsOTLP != nil || ruleMatchEmpty(rule.Match) {
+			continue
+		}
+
+		ruleSelectorFamily := "glob"
+		if ruleUsesRegex(rule.Match) {
+			if ruleUsesGlob(rule.Match) {
+				return fmt.Errorf(
+					"capture.rules[%d].match: mixing glob and regex selectors is not supported",
+					i,
+				)
+			}
+			ruleSelectorFamily = "regex"
+		}
+
+		if selectorFamily != "" && selectorFamily != ruleSelectorFamily {
+			return fmt.Errorf(
+				"capture.rules[%d].match: mixing glob and regex selectors is not supported",
+				i,
+			)
+		}
+		selectorFamily = ruleSelectorFamily
+	}
+	return nil
+}
+
+func validateV2MatchOrder(matchOrder schema.MatchOrder, rules []schema.Rule) error {
+	if matchOrder == schema.MatchOrderLastMatchWins {
+		return errors.New("capture.policy.match_order: last_match_wins is not supported")
+	}
+
+	includeSeen := false
+	for i, rule := range rules {
+		if !ruleAffectsV2Selection(rule) {
+			continue
+		}
+
+		switch rule.Action {
+		case schema.CaptureActionInclude:
+			includeSeen = true
+		case schema.CaptureActionExclude:
+			if includeSeen {
+				return fmt.Errorf(
+					"capture.rules[%d]: exclude rules must precede include rules for first_match_wins",
+					i,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+func ruleAffectsV2Selection(rule schema.Rule) bool {
+	if rule.Match.Process.ExportsOTLP != nil || ruleMatchEmpty(rule.Match) {
+		return false
+	}
+	return !ruleUsesRegex(rule.Match) || !ruleUsesGlob(rule.Match)
 }
 
 func validateV2HTTPFilters(filters schema.SignalFilters) error {

--- a/internal/config/convert/import_document.go
+++ b/internal/config/convert/import_document.go
@@ -25,6 +25,12 @@ func DocumentToRuntime(src *schema.Document) (*obi.Config, error) {
 	if src == nil {
 		return nil, errors.New("missing OBI document")
 	}
+	if fields := src.OpenTelemetryExtensionFields(); len(fields) != 0 {
+		return nil, fmt.Errorf(
+			"OpenTelemetry extension fields are not supported: %s",
+			strings.Join(fields, ", "),
+		)
+	}
 
 	cfg, err := V2ToRuntime(src.Extensions.OBI)
 	if err != nil {

--- a/internal/config/convert/import_document_test.go
+++ b/internal/config/convert/import_document_test.go
@@ -175,6 +175,28 @@ extensions:
 	require.Contains(t, err.Error(), "verbose")
 }
 
+func TestDocumentToRuntimeRejectsOpenTelemetryExtensionFields(t *testing.T) {
+	t.Parallel()
+
+	doc, _, err := schema.ParseStandaloneYAML([]byte(`
+file_format: "1.0"
+tracer_provider:
+  sampler:
+    vendor_sampler: {}
+extensions:
+  obi:
+    version: "2.0"
+`))
+	require.NoError(t, err)
+
+	_, err = DocumentToRuntime(doc)
+	require.ErrorContains(
+		t,
+		err,
+		"OpenTelemetry extension fields are not supported: tracer_provider.sampler.vendor_sampler",
+	)
+}
+
 func TestDocumentToRuntimeSkipsUnsupportedMetricReaderShapes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/convert/import_test.go
+++ b/internal/config/convert/import_test.go
@@ -308,7 +308,19 @@ func TestV2ToRuntimeImportsRules(t *testing.T) {
 	got, err := V2ToRuntime(&schema.Extension{
 		Version: schema.SupportedVersion,
 		Capture: schema.Capture{
+			Policy: schema.CapturePolicy{DefaultAction: schema.CaptureActionExclude},
 			Rules: []schema.Rule{
+				{
+					Action: schema.CaptureActionExclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{
+							ExePathGlob: []string{"/usr/bin/*"},
+						},
+						Kubernetes: schema.RuleKubernetesMatch{
+							NamespaceGlob: []string{"kube-*"},
+						},
+					},
+				},
 				{
 					Action: schema.CaptureActionInclude,
 					Match: schema.RuleMatch{
@@ -345,17 +357,6 @@ func TestV2ToRuntimeImportsRules(t *testing.T) {
 						},
 					},
 				},
-				{
-					Action: schema.CaptureActionExclude,
-					Match: schema.RuleMatch{
-						Process: schema.RuleProcessMatch{
-							ExePathRegex: "^/usr/bin/.*",
-						},
-						Kubernetes: schema.RuleKubernetesMatch{
-							NamespaceRegex: "kube-.*",
-						},
-					},
-				},
 			},
 		},
 	})
@@ -379,10 +380,10 @@ func TestV2ToRuntimeImportsRules(t *testing.T) {
 
 	require.True(t, got.Discovery.ExcludeOTelInstrumentedServices)
 	require.Equal(t, 4317, got.Discovery.DefaultOtlpGRPCPort)
-	require.Len(t, got.Discovery.ExcludeServices, 1)
-	exclude := got.Discovery.ExcludeServices[0]
-	require.Equal(t, "^/usr/bin/.*", regexString(exclude.Path))
-	require.Equal(t, "kube-.*", regexString(*exclude.Metadata[services.AttrNamespace]))
+	require.Len(t, got.Discovery.ExcludeInstrument, 1)
+	exclude := got.Discovery.ExcludeInstrument[0]
+	require.Equal(t, "/usr/bin/*", globString(exclude.Path))
+	require.Equal(t, "kube-*", globString(*exclude.Metadata[services.AttrNamespace]))
 }
 
 func TestV2ToRuntimeSkipsUnsupportedExportsOTLPRules(t *testing.T) {
@@ -391,6 +392,7 @@ func TestV2ToRuntimeSkipsUnsupportedExportsOTLPRules(t *testing.T) {
 	got, err := V2ToRuntime(&schema.Extension{
 		Version: schema.SupportedVersion,
 		Capture: schema.Capture{
+			Policy: schema.CapturePolicy{DefaultAction: schema.CaptureActionExclude},
 			Rules: []schema.Rule{
 				{
 					Action: schema.CaptureActionInclude,
@@ -419,44 +421,57 @@ func TestV2ToRuntimeSkipsUnsupportedExportsOTLPRules(t *testing.T) {
 	require.False(t, got.Discovery.ExcludeOTelInstrumentedServices)
 }
 
-func TestV2ToRuntimeSkipsMixedGlobRegexRules(t *testing.T) {
+func TestV2ToRuntimeRejectsMixedGlobRegexRules(t *testing.T) {
 	t.Parallel()
 
-	got, err := V2ToRuntime(&schema.Extension{
-		Version: schema.SupportedVersion,
-		Capture: schema.Capture{
-			Rules: []schema.Rule{
+	for _, test := range []struct {
+		name  string
+		rules []schema.Rule
+		path  string
+	}{
+		{
+			name: "within rule",
+			rules: []schema.Rule{
 				{
 					Action: schema.CaptureActionInclude,
 					Match: schema.RuleMatch{
-						Process: schema.RuleProcessMatch{
-							ExePathGlob: []string{"/srv/*"},
-						},
-						Kubernetes: schema.RuleKubernetesMatch{
-							NamespaceRegex: "prod-.*",
-						},
-					},
-				},
-				{
-					Action: schema.CaptureActionExclude,
-					Match: schema.RuleMatch{
-						Process: schema.RuleProcessMatch{
-							LanguageRegex: "go|java",
-						},
-						Kubernetes: schema.RuleKubernetesMatch{
-							PodLabels: map[string][]string{"app": {"checkout"}},
-						},
+						Process:    schema.RuleProcessMatch{ExePathGlob: []string{"/srv/*"}},
+						Kubernetes: schema.RuleKubernetesMatch{NamespaceRegex: "prod-.*"},
 					},
 				},
 			},
+			path: "capture.rules[0].match",
 		},
-	})
-	require.NoError(t, err)
-
-	require.Empty(t, got.Discovery.Instrument)
-	require.Empty(t, got.Discovery.Services)
-	require.Empty(t, got.Discovery.ExcludeInstrument)
-	require.Empty(t, got.Discovery.ExcludeServices)
+		{
+			name: "across rules",
+			rules: []schema.Rule{
+				{
+					Action: schema.CaptureActionExclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{ExePathGlob: []string{"/srv/ignored"}},
+					},
+				},
+				{
+					Action: schema.CaptureActionInclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{ExePathRegex: "^/srv/worker$"},
+					},
+				},
+			},
+			path: "capture.rules[1].match",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := V2ToRuntime(&schema.Extension{
+				Version: schema.SupportedVersion,
+				Capture: schema.Capture{
+					Policy: schema.CapturePolicy{DefaultAction: schema.CaptureActionExclude},
+					Rules:  test.rules,
+				},
+			})
+			require.ErrorContains(t, err, test.path+": mixing glob and regex selectors is not supported")
+		})
+	}
 }
 
 func TestV2ToRuntimeRejectsMalformedRulePatterns(t *testing.T) {
@@ -502,35 +517,247 @@ func TestV2ToRuntimeRejectsMalformedRulePatterns(t *testing.T) {
 	}
 }
 
-func TestV2ToRuntimeDefaultIncludeUsesOnlyExclusions(t *testing.T) {
+func TestV2ToRuntimeRejectsLastMatchWins(t *testing.T) {
 	t.Parallel()
 
-	got, err := V2ToRuntime(&schema.Extension{
+	_, err := V2ToRuntime(&schema.Extension{
 		Version: schema.SupportedVersion,
 		Capture: schema.Capture{
 			Policy: schema.CapturePolicy{
-				DefaultAction: schema.CaptureActionInclude,
-				MatchOrder:    schema.MatchOrderFirstMatchWins,
+				MatchOrder: schema.MatchOrderLastMatchWins,
 			},
 			Rules: []schema.Rule{
 				{
 					Action: schema.CaptureActionExclude,
 					Match: schema.RuleMatch{
-						Process: schema.RuleProcessMatch{
-							ExePathGlob: []string{"*/obi", "obi"},
-						},
+						Process: schema.RuleProcessMatch{ExePathGlob: []string{"/srv/*"}},
+					},
+				},
+				{
+					Action: schema.CaptureActionInclude,
+					Match: schema.RuleMatch{
+						Process: schema.RuleProcessMatch{ExePathGlob: []string{"/srv/worker"}},
 					},
 				},
 			},
 		},
 	})
-	require.NoError(t, err)
 
-	require.Empty(t, got.Discovery.Instrument)
-	require.Empty(t, got.Discovery.Services)
-	require.Len(t, got.Discovery.ExcludeInstrument, 1)
-	require.Equal(t, "{*/obi,obi}", globString(got.Discovery.ExcludeInstrument[0].Path))
-	require.Empty(t, got.Discovery.ExcludeServices)
+	require.ErrorContains(t, err, "capture.policy.match_order: last_match_wins is not supported")
+}
+
+func TestV2ToRuntimeRejectsExclusionAfterInclusion(t *testing.T) {
+	t.Parallel()
+
+	for _, matchOrder := range []schema.MatchOrder{"", schema.MatchOrderFirstMatchWins} {
+		_, err := V2ToRuntime(&schema.Extension{
+			Version: schema.SupportedVersion,
+			Capture: schema.Capture{
+				Policy: schema.CapturePolicy{MatchOrder: matchOrder},
+				Rules: []schema.Rule{
+					{
+						Action: schema.CaptureActionInclude,
+						Match: schema.RuleMatch{
+							Process: schema.RuleProcessMatch{ExePathGlob: []string{"/srv/worker"}},
+						},
+					},
+					{
+						Action: schema.CaptureActionExclude,
+						Match: schema.RuleMatch{
+							Process: schema.RuleProcessMatch{ExePathGlob: []string{"/srv/*"}},
+						},
+					},
+				},
+			},
+		})
+
+		require.ErrorContains(t, err, "capture.rules[1]: exclude rules must precede include rules for first_match_wins")
+	}
+}
+
+func TestV2ToRuntimeDefaultIncludeAddsCatchAllSelector(t *testing.T) {
+	t.Parallel()
+
+	for _, defaultAction := range []schema.CaptureAction{"", schema.CaptureActionInclude} {
+		got, err := V2ToRuntime(&schema.Extension{
+			Version: schema.SupportedVersion,
+			Capture: schema.Capture{
+				Policy: schema.CapturePolicy{
+					DefaultAction: defaultAction,
+					MatchOrder:    schema.MatchOrderFirstMatchWins,
+				},
+				Rules: []schema.Rule{
+					{
+						Action: schema.CaptureActionInclude,
+						Match: schema.RuleMatch{
+							Process: schema.RuleProcessMatch{
+								ExePathGlob: []string{"/srv/worker"},
+							},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		require.Len(t, got.Discovery.Instrument, 2)
+		require.Equal(t, "/srv/worker", globString(got.Discovery.Instrument[0].Path))
+		require.Equal(t, "*", globString(got.Discovery.Instrument[1].Path))
+		require.Empty(t, got.Discovery.Services)
+		require.Empty(t, got.Discovery.ExcludeInstrument)
+		require.Empty(t, got.Discovery.ExcludeServices)
+	}
+}
+
+func TestV2ToRuntimeDefaultIncludeAddsRegexCatchAllSelector(t *testing.T) {
+	t.Parallel()
+
+	for _, defaultAction := range []schema.CaptureAction{"", schema.CaptureActionInclude} {
+		got, err := V2ToRuntime(&schema.Extension{
+			Version: schema.SupportedVersion,
+			Capture: schema.Capture{
+				Policy: schema.CapturePolicy{
+					DefaultAction: defaultAction,
+					MatchOrder:    schema.MatchOrderFirstMatchWins,
+				},
+				Rules: []schema.Rule{
+					{
+						Action: schema.CaptureActionExclude,
+						Match: schema.RuleMatch{
+							Process: schema.RuleProcessMatch{ExePathRegex: "^/usr/bin/otelcol$"},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		require.Empty(t, got.Discovery.Instrument)
+		require.Len(t, got.Discovery.Services, 1)
+		require.Equal(t, ".*", regexString(got.Discovery.Services[0].Path))
+		require.Empty(t, got.Discovery.ExcludeInstrument)
+		require.Len(t, got.Discovery.ExcludeServices, 1)
+		require.Equal(t, "^/usr/bin/otelcol$", regexString(got.Discovery.ExcludeServices[0].Path))
+	}
+}
+
+func TestV2ToRuntimeRejectsUnsupportedFields(t *testing.T) {
+	t.Parallel()
+
+	filters := schema.AttributeFilters{
+		"service.name": {Match: "checkout"},
+	}
+	tests := []struct {
+		name   string
+		path   string
+		mutate func(*schema.Extension)
+	}{
+		{
+			name: "Go runtime filter",
+			path: "capture.runtimes.go.filter",
+			mutate: func(ext *schema.Extension) {
+				ext.Capture.Runtimes.Go.Filter = filters
+			},
+		},
+		{
+			name: "Node.js runtime filter",
+			path: "capture.runtimes.nodejs.filter",
+			mutate: func(ext *schema.Extension) {
+				ext.Capture.Runtimes.NodeJS.Filter = filters
+			},
+		},
+		{
+			name: "Java runtime filter",
+			path: "capture.runtimes.java.filter",
+			mutate: func(ext *schema.Extension) {
+				ext.Capture.Runtimes.Java.Filter = filters
+			},
+		},
+		{
+			name: "correlation filter",
+			path: "correlation.log_trace_annotation.filter",
+			mutate: func(ext *schema.Extension) {
+				ext.Correlation = &schema.Correlation{
+					LogTraceAnnotation: schema.LogTraceAnnotation{Enabled: true, Filter: filters},
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ext := &schema.Extension{Version: schema.SupportedVersion}
+			test.mutate(ext)
+			_, err := V2ToRuntime(ext)
+
+			require.ErrorContains(t, err, test.path+" is not supported")
+		})
+	}
+}
+
+func TestV2ToRuntimeRejectsUnsupportedEnrichmentFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		path   string
+		mutate func(*schema.Enrich)
+	}{
+		{
+			name: "enrich root",
+			path: "enrich.custom",
+			mutate: func(enrich *schema.Enrich) {
+				enrich.AdditionalProperties = map[string]any{"custom": true}
+			},
+		},
+		{
+			name: "DNS enricher",
+			path: "enrich.enrichers.dns",
+			mutate: func(enrich *schema.Enrich) {
+				enrich.Enrichers.AdditionalProperties = map[string]any{
+					"dns": map[string]any{"enabled": true},
+				}
+			},
+		},
+		{
+			name: "Kubernetes enricher",
+			path: "enrich.enrichers.kubernetes.custom",
+			mutate: func(enrich *schema.Enrich) {
+				enrich.Enrichers.Kubernetes.AdditionalProperties = map[string]any{"custom": true}
+			},
+		},
+		{
+			name: "service name rules",
+			path: "enrich.service_name.rules",
+			mutate: func(enrich *schema.Enrich) {
+				enrich.ServiceName.AdditionalProperties = map[string]any{"rules": []any{}}
+			},
+		},
+		{
+			name: "attribute rules",
+			path: "enrich.attributes.rules",
+			mutate: func(enrich *schema.Enrich) {
+				enrich.Attributes.AdditionalProperties = map[string]any{"rules": []any{}}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			enrich := &schema.Enrich{}
+			test.mutate(enrich)
+			_, err := V2ToRuntime(&schema.Extension{
+				Version: schema.SupportedVersion,
+				Enrich:  enrich,
+			})
+
+			require.ErrorContains(t, err, test.path+" is not supported")
+		})
+	}
 }
 
 func TestV2ToRuntimeRulesPresenceControlsSelectorReplacement(t *testing.T) {
@@ -548,7 +775,8 @@ func TestV2ToRuntimeRulesPresenceControlsSelectorReplacement(t *testing.T) {
 	empty, err := V2ToRuntime(&schema.Extension{
 		Version: schema.SupportedVersion,
 		Capture: schema.Capture{
-			Rules: []schema.Rule{},
+			Policy: schema.CapturePolicy{DefaultAction: schema.CaptureActionExclude},
+			Rules:  []schema.Rule{},
 		},
 	})
 	require.NoError(t, err)

--- a/internal/config/schema/correlation.go
+++ b/internal/config/schema/correlation.go
@@ -10,9 +10,10 @@ type Correlation struct {
 
 // LogTraceAnnotation describes log trace annotation settings.
 type LogTraceAnnotation struct {
-	Enabled     bool        `yaml:"enabled"`
-	Cache       Cache       `yaml:"cache"`
-	AsyncWriter AsyncWriter `yaml:"async_writer"`
+	Enabled     bool             `yaml:"enabled"`
+	Filter      AttributeFilters `yaml:"filter,omitempty"`
+	Cache       Cache            `yaml:"cache"`
+	AsyncWriter AsyncWriter      `yaml:"async_writer"`
 }
 
 // AsyncWriter describes asynchronous writer worker and channel settings.

--- a/internal/config/schema/enrich.go
+++ b/internal/config/schema/enrich.go
@@ -13,14 +13,16 @@ import (
 
 // Enrich describes standalone metadata enrichment settings.
 type Enrich struct {
-	Enrichers   Enrichers            `yaml:"enrichers"`
-	ServiceName ServiceName          `yaml:"service_name"`
-	Attributes  EnrichmentAttributes `yaml:"attributes"`
+	Enrichers            Enrichers            `yaml:"enrichers"`
+	ServiceName          ServiceName          `yaml:"service_name"`
+	Attributes           EnrichmentAttributes `yaml:"attributes"`
+	AdditionalProperties map[string]any       `yaml:",inline"`
 }
 
 // Enrichers groups metadata enricher settings.
 type Enrichers struct {
-	Kubernetes KubernetesEnricher `yaml:"kubernetes"`
+	Kubernetes           KubernetesEnricher `yaml:"kubernetes"`
+	AdditionalProperties map[string]any     `yaml:",inline"`
 }
 
 // KubernetesMode describes Kubernetes metadata enricher activation.
@@ -42,14 +44,15 @@ func (m *KubernetesMode) UnmarshalYAML(value *yaml.Node) error {
 
 // KubernetesEnricher describes Kubernetes metadata enrichment settings.
 type KubernetesEnricher struct {
-	Mode                KubernetesMode          `yaml:"mode"`
-	ClusterName         string                  `yaml:"cluster_name"`
-	ServiceNameTemplate string                  `yaml:"service_name_template"`
-	Auth                KubernetesAuth          `yaml:"auth"`
-	Informers           KubernetesInformers     `yaml:"informers"`
-	DropExternal        bool                    `yaml:"drop_external"`
-	ResourceLabels      ResourceLabels          `yaml:"resource_labels"`
-	MetadataCache       KubernetesMetadataCache `yaml:"metadata_cache"`
+	Mode                 KubernetesMode          `yaml:"mode"`
+	ClusterName          string                  `yaml:"cluster_name"`
+	ServiceNameTemplate  string                  `yaml:"service_name_template"`
+	Auth                 KubernetesAuth          `yaml:"auth"`
+	Informers            KubernetesInformers     `yaml:"informers"`
+	DropExternal         bool                    `yaml:"drop_external"`
+	ResourceLabels       ResourceLabels          `yaml:"resource_labels"`
+	MetadataCache        KubernetesMetadataCache `yaml:"metadata_cache"`
+	AdditionalProperties map[string]any          `yaml:",inline"`
 }
 
 // KubernetesAuth describes Kubernetes authentication settings.
@@ -86,9 +89,10 @@ type KubernetesSourceLabels struct {
 
 // ServiceName describes service name resolution settings.
 type ServiceName struct {
-	UnresolvedHosts UnresolvedHosts    `yaml:"unresolved_hosts"`
-	Sources         []transform.Source `yaml:"sources"`
-	Cache           Cache              `yaml:"cache"`
+	UnresolvedHosts      UnresolvedHosts    `yaml:"unresolved_hosts"`
+	Sources              []transform.Source `yaml:"sources"`
+	Cache                Cache              `yaml:"cache"`
+	AdditionalProperties map[string]any     `yaml:",inline"`
 }
 
 // UnresolvedHosts describes names assigned to unresolved hosts.
@@ -109,6 +113,7 @@ type EnrichmentAttributes struct {
 	Select               attributes.Selection `yaml:"select"`
 	ExtraGroupAttributes ExtraGroupAttributes `yaml:"extra_group_attributes"`
 	MetadataRetry        MetadataRetry        `yaml:"metadata_retry"`
+	AdditionalProperties map[string]any       `yaml:",inline"`
 }
 
 // ExtraGroupAttributes maps OBI attribute group names to extra attribute names.

--- a/internal/config/schema/runtimes.go
+++ b/internal/config/schema/runtimes.go
@@ -12,14 +12,16 @@ type CaptureRuntimes struct {
 
 // Runtime describes generic language runtime capture settings.
 type Runtime struct {
-	Enabled bool `yaml:"enabled"`
+	Enabled bool             `yaml:"enabled"`
+	Filter  AttributeFilters `yaml:"filter,omitempty"`
 }
 
 // JavaRuntime describes Java runtime capture and debug settings.
 type JavaRuntime struct {
-	Enabled       bool      `yaml:"enabled"`
-	Debug         JavaDebug `yaml:"debug"`
-	AttachTimeout Duration  `yaml:"attach_timeout"`
+	Enabled       bool             `yaml:"enabled"`
+	Filter        AttributeFilters `yaml:"filter,omitempty"`
+	Debug         JavaDebug        `yaml:"debug"`
+	AttachTimeout Duration         `yaml:"attach_timeout"`
 }
 
 // JavaDebug describes Java runtime debug instrumentation settings.

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -19,8 +19,12 @@
 package schema // import "go.opentelemetry.io/obi/internal/config/schema"
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
+	"reflect"
+	"strings"
 
 	"go.yaml.in/yaml/v3"
 
@@ -53,25 +57,149 @@ type Document struct {
 	otelconfx.OpenTelemetryConfiguration `yaml:",inline"`
 	Extensions                           Extensions `yaml:"extensions"`
 	logLevelSet                          bool
+	openTelemetryExtensionFields         []string
 }
 
 // UnmarshalYAML decodes OpenTelemetry-owned fields with otelconf/x and the OBI
 // extension with the local schema model.
 func (d *Document) UnmarshalYAML(node *yaml.Node) error {
-	type extensionDocument struct {
-		Extensions Extensions `yaml:"extensions"`
+	extensionFields, err := validateOpenTelemetryFields(node)
+	if err != nil {
+		return err
 	}
-	var ext extensionDocument
 	_, logLevelSet := mappingValue(node, "log_level")
 	if err := node.Decode(&d.OpenTelemetryConfiguration); err != nil {
 		return err
 	}
-	if err := node.Decode(&ext); err != nil {
+	extensions, ok := mappingValue(node, "extensions")
+	if !ok {
+		return errors.New("missing extensions")
+	}
+	if err := decodeKnownFields(extensions, &d.Extensions); err != nil {
 		return err
 	}
-	d.Extensions = ext.Extensions
 	d.logLevelSet = logLevelSet
+	d.openTelemetryExtensionFields = extensionFields
 	return nil
+}
+
+func validateOpenTelemetryFields(node *yaml.Node) ([]string, error) {
+	configType := reflect.TypeFor[otelconfx.OpenTelemetryConfiguration]()
+	var extensionFields []string
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		field := node.Content[i].Value
+		if field == "extensions" {
+			continue
+		}
+
+		fieldType, ok := yamlFieldType(configType, field)
+		if !ok {
+			if allowsAdditionalYAMLFields(configType) {
+				extensionFields = append(extensionFields, field)
+				continue
+			}
+			return nil, fmt.Errorf("field %s not found in config v2 document", field)
+		}
+		if err := validateYAMLFields(node.Content[i+1], fieldType, field, &extensionFields); err != nil {
+			return nil, err
+		}
+	}
+	return extensionFields, nil
+}
+
+func validateYAMLFields(node *yaml.Node, valueType reflect.Type, path string, extensionFields *[]string) error {
+	for valueType.Kind() == reflect.Pointer {
+		valueType = valueType.Elem()
+	}
+
+	switch valueType.Kind() {
+	case reflect.Struct:
+		if node.Kind != yaml.MappingNode {
+			return nil
+		}
+		for i := 0; i < len(node.Content)-1; i += 2 {
+			field := node.Content[i].Value
+			fieldPath := path + "." + field
+			fieldType, ok := yamlFieldType(valueType, field)
+			if !ok {
+				if allowsAdditionalYAMLFields(valueType) {
+					*extensionFields = append(*extensionFields, fieldPath)
+					continue
+				}
+				return fmt.Errorf("field %s not found in config v2 document", fieldPath)
+			}
+			if err := validateYAMLFields(node.Content[i+1], fieldType, fieldPath, extensionFields); err != nil {
+				return err
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		if node.Kind != yaml.SequenceNode {
+			return nil
+		}
+		for i, item := range node.Content {
+			if err := validateYAMLFields(item, valueType.Elem(), fmt.Sprintf("%s[%d]", path, i), extensionFields); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		if node.Kind != yaml.MappingNode {
+			return nil
+		}
+		for i := 1; i < len(node.Content); i += 2 {
+			if err := validateYAMLFields(node.Content[i], valueType.Elem(), path, extensionFields); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func yamlFieldType(valueType reflect.Type, name string) (reflect.Type, bool) {
+	for valueType.Kind() == reflect.Pointer {
+		valueType = valueType.Elem()
+	}
+	if valueType.Kind() != reflect.Struct {
+		return nil, false
+	}
+
+	for i := 0; i < valueType.NumField(); i++ {
+		field := valueType.Field(i)
+		if !field.IsExported() || field.Name == "AdditionalProperties" {
+			continue
+		}
+		tag, _, _ := strings.Cut(field.Tag.Get("yaml"), ",")
+		if tag == "-" {
+			continue
+		}
+		if tag == "" {
+			tag = strings.ToLower(field.Name)
+		}
+		if tag == name {
+			return field.Type, true
+		}
+	}
+	return nil, false
+}
+
+func allowsAdditionalYAMLFields(valueType reflect.Type) bool {
+	for valueType.Kind() == reflect.Pointer {
+		valueType = valueType.Elem()
+	}
+	if valueType.Kind() != reflect.Struct {
+		return false
+	}
+
+	field, ok := valueType.FieldByName("AdditionalProperties")
+	return ok && field.IsExported()
+}
+
+// OpenTelemetryExtensionFields returns paths handled by upstream declarative
+// configuration extension points rather than the core schema.
+func (d *Document) OpenTelemetryExtensionFields() []string {
+	if d == nil {
+		return nil
+	}
+	return append([]string(nil), d.openTelemetryExtensionFields...)
 }
 
 // HasLogLevel reports whether the document explicitly declared top-level
@@ -91,7 +219,7 @@ func (d *Document) SetLogLevel(level otelconfx.SeverityNumber) {
 // explicit wrapper avoids relying on yaml inline behavior for a type with custom
 // unmarshaling in the upstream otelconf/x package.
 func (d Document) MarshalYAML() (any, error) {
-	return struct {
+	value := struct {
 		AttributeLimits            *otelconfx.AttributeLimits                   `yaml:"attribute_limits,omitempty"`
 		Disabled                   otelconfx.OpenTelemetryConfigurationDisabled `yaml:"disabled,omitempty"`
 		Distribution               otelconfx.Distribution                       `yaml:"distribution,omitempty"`
@@ -117,7 +245,36 @@ func (d Document) MarshalYAML() (any, error) {
 		Resource:                   d.Resource,
 		TracerProvider:             d.TracerProvider,
 		Extensions:                 d.Extensions,
-	}, nil
+	}
+
+	var node yaml.Node
+	if err := node.Encode(value); err != nil {
+		return nil, err
+	}
+	removeNullAdditionalProperties(&node)
+	return &node, nil
+}
+
+// otelconf/x models extensible objects with an untagged AdditionalProperties
+// field. Remove its nil value so the generated Go name is not emitted as a YAML
+// configuration key.
+func removeNullAdditionalProperties(node *yaml.Node) {
+	for _, child := range node.Content {
+		removeNullAdditionalProperties(child)
+	}
+	if node.Kind != yaml.MappingNode {
+		return
+	}
+
+	content := make([]*yaml.Node, 0, len(node.Content))
+	for i := 0; i < len(node.Content); i += 2 {
+		key, value := node.Content[i], node.Content[i+1]
+		if key.Value == "additionalproperties" && value.Tag == "!!null" {
+			continue
+		}
+		content = append(content, key, value)
+	}
+	node.Content = content
 }
 
 // Extensions holds declarative configuration extensions recognized by this
@@ -213,7 +370,7 @@ func ParseReceiverYAML(data []byte) (*Extension, error) {
 			return nil, &SectionNotAllowedError{Section: section}
 		}
 		var receiver receiverConfig
-		if err := decode(root, &receiver); err != nil {
+		if err := decodeKnownFields(root, &receiver); err != nil {
 			return nil, err
 		}
 		cfg := Extension{
@@ -310,9 +467,19 @@ func looksLikeV1(root *yaml.Node) bool {
 }
 
 func parseYAML(data []byte) (*yaml.Node, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	var doc yaml.Node
-	if err := yaml.Unmarshal(data, &doc); err != nil {
+	if err := decoder.Decode(&doc); err != nil {
+		if errors.Is(err, io.EOF) {
+			return &doc, nil
+		}
 		return nil, fmt.Errorf("parsing config v2 YAML: %w", err)
+	}
+	var trailing yaml.Node
+	if err := decoder.Decode(&trailing); err == nil {
+		return nil, errors.New("config v2 YAML must contain exactly one document")
+	} else if !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("parsing trailing config v2 YAML: %w", err)
 	}
 	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
 		return doc.Content[0], nil
@@ -322,6 +489,20 @@ func parseYAML(data []byte) (*yaml.Node, error) {
 
 func decode(node *yaml.Node, dst any) error {
 	if err := node.Decode(dst); err != nil {
+		return fmt.Errorf("decoding config v2 YAML: %w", err)
+	}
+	return nil
+}
+
+func decodeKnownFields(node *yaml.Node, dst any) error {
+	var data bytes.Buffer
+	if err := yaml.NewEncoder(&data).Encode(node); err != nil {
+		return fmt.Errorf("encoding config v2 YAML: %w", err)
+	}
+
+	decoder := yaml.NewDecoder(&data)
+	decoder.KnownFields(true)
+	if err := decoder.Decode(dst); err != nil {
 		return fmt.Errorf("decoding config v2 YAML: %w", err)
 	}
 	return nil

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -8,7 +8,31 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+
+	otelconfx "go.opentelemetry.io/contrib/otelconf/x"
 )
+
+func TestDocumentMarshalYAMLOmitsNullAdditionalProperties(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{
+		OpenTelemetryConfiguration: otelconfx.OpenTelemetryConfiguration{
+			FileFormat: "1.0",
+			MeterProvider: &otelconfx.MeterProvider{
+				Readers: []otelconfx.MetricReader{{
+					Periodic: &otelconfx.PeriodicMetricReader{
+						Exporter: otelconfx.PushMetricExporter{},
+					},
+				}},
+			},
+		},
+	}
+
+	data, err := yaml.Marshal(doc)
+	require.NoError(t, err)
+	require.NotContains(t, string(data), "additionalproperties")
+}
 
 func TestParseStandaloneYAMLDocument(t *testing.T) {
 	t.Parallel()
@@ -39,7 +63,8 @@ meter_provider:
             tls:
               insecure: true
 instrumentation/development:
-  ignored: true
+  go:
+    go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp: {}
 extensions:
   obi:
     version: "2.0"
@@ -105,6 +130,150 @@ extensions:
 	require.Equal(t, AttributeFilter{Match: "5*"}, cfg.Capture.Rules[0].Refine.HTTP.Filters.Traces["status_code"])
 }
 
+func TestParseStandaloneYAMLRejectsUnknownOpenTelemetryFields(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ParseStandaloneYAML([]byte(`
+file_format: "1.0"
+tracer_provider:
+  typoo: true
+extensions:
+  obi:
+    version: "2.0"
+`))
+
+	require.ErrorContains(t, err, "field tracer_provider.typoo not found")
+}
+
+func TestParseStandaloneYAMLAcceptsPublishedExtensionFields(t *testing.T) {
+	t.Parallel()
+
+	_, cfg, err := ParseStandaloneYAML([]byte(`
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      runtimes:
+        go:
+          filter: {}
+        nodejs:
+          filter: {}
+        java:
+          filter: {}
+    enrich:
+      enrichers:
+        dns:
+          enabled: true
+      service_name:
+        rules:
+          - id: k8s-default
+            from: kubernetes
+            description: Default Kubernetes mapping.
+            map:
+              service.name: [app.kubernetes.io/name]
+      attributes:
+        rules:
+          - id: k8s-default-attributes
+            from: kubernetes
+            description: Default Kubernetes attributes.
+            add:
+              map:
+                k8s.pod.name: [kubernetes.pod.name]
+    correlation:
+      log_trace_annotation:
+        filter: {}
+`))
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.NotNil(t, cfg.Capture.Runtimes.Go.Filter)
+	require.NotNil(t, cfg.Capture.Runtimes.NodeJS.Filter)
+	require.NotNil(t, cfg.Capture.Runtimes.Java.Filter)
+	require.Contains(t, cfg.Enrich.Enrichers.AdditionalProperties, "dns")
+	require.Contains(t, cfg.Enrich.ServiceName.AdditionalProperties, "rules")
+	require.Contains(t, cfg.Enrich.Attributes.AdditionalProperties, "rules")
+	require.NotNil(t, cfg.Correlation.LogTraceAnnotation.Filter)
+}
+
+func TestParseStandaloneYAMLRecordsOpenTelemetryExtensionFields(t *testing.T) {
+	t.Parallel()
+
+	doc, _, err := ParseStandaloneYAML([]byte(`
+file_format: "1.0"
+vendor_extension:
+  enabled: true
+tracer_provider:
+  sampler:
+    vendor_sampler: {}
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          console: {}
+        producers:
+          - prometheus: {}
+extensions:
+  obi:
+    version: "2.0"
+`))
+
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"vendor_extension",
+		"tracer_provider.sampler.vendor_sampler",
+		"meter_provider.readers[0].periodic.producers[0].prometheus",
+	}, doc.OpenTelemetryExtensionFields())
+}
+
+func TestParsersRejectMultipleYAMLDocuments(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		yaml  string
+		parse func([]byte) error
+	}{
+		{
+			name: "standalone",
+			yaml: `
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+---
+file_format: "1.0"
+extensions:
+  obi:
+    version: "3.0"
+`,
+			parse: func(data []byte) error {
+				_, _, err := ParseStandaloneYAML(data)
+				return err
+			},
+		},
+		{
+			name: "receiver",
+			yaml: `
+version: "2.0"
+---
+version: "3.0"
+`,
+			parse: func(data []byte) error {
+				_, err := ParseReceiverYAML(data)
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.parse([]byte(test.yaml))
+			require.ErrorContains(t, err, "must contain exactly one document")
+		})
+	}
+}
+
 func TestParseStandaloneYAMLRejectsDaemonLoggingLevel(t *testing.T) {
 	t.Parallel()
 
@@ -153,6 +322,53 @@ channels:
 	require.Equal(t, 123, cfg.Capture.Channels.BufferLen)
 	require.True(t, cfg.Capture.Instrumentation.HTTP.Enabled.Traces)
 	require.False(t, cfg.Capture.Instrumentation.HTTP.Enabled.Metrics)
+}
+
+func TestParsersRejectUnknownOBIFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		yaml  string
+		parse func([]byte) error
+	}{
+		{
+			name: "standalone",
+			yaml: `
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      unknown_field: true
+`,
+			parse: func(data []byte) error {
+				_, _, err := ParseStandaloneYAML(data)
+				return err
+			},
+		},
+		{
+			name: "receiver",
+			yaml: `
+version: "2.0"
+unknown_field: true
+`,
+			parse: func(data []byte) error {
+				_, err := ParseReceiverYAML(data)
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := test.parse([]byte(test.yaml))
+
+			require.ErrorContains(t, err, "field unknown_field not found")
+		})
+	}
 }
 
 func TestParseReceiverRejectsInvalidTypedEnum(t *testing.T) {

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -666,10 +666,41 @@ func (e ConfigError) Error() string {
 	return string(e)
 }
 
-// Validate configuration
-//
-//nolint:cyclop
+// Validate validates a standalone OBI configuration.
 func (c *Config) Validate() error {
+	return c.validate(validationContext{checkCiliumCompatibility: tcmanager.EnsureCiliumCompatibility})
+}
+
+// ValidateStatic validates a standalone OBI configuration without inspecting
+// host state.
+func (c *Config) ValidateStatic() error {
+	return c.validate(validationContext{})
+}
+
+// ValidateForReceiver validates an OBI configuration whose signal consumers
+// are supplied by a Collector receiver.
+func (c *Config) ValidateForReceiver() error {
+	return c.validate(validationContext{
+		hostTracesSink:           true,
+		hostMetricsSink:          true,
+		checkCiliumCompatibility: tcmanager.EnsureCiliumCompatibility,
+	})
+}
+
+// ValidateStaticForReceiver validates a Collector receiver configuration
+// without inspecting host state.
+func (c *Config) ValidateStaticForReceiver() error {
+	return c.validate(validationContext{hostTracesSink: true, hostMetricsSink: true})
+}
+
+type validationContext struct {
+	hostTracesSink           bool
+	hostMetricsSink          bool
+	checkCiliumCompatibility func(config.TCBackend) error
+}
+
+//nolint:cyclop
+func (c *Config) validate(context validationContext) error {
 	validate := validator.New(validator.WithRequiredStructEnabled())
 
 	// for future custom validations
@@ -709,20 +740,26 @@ func (c *Config) Validate() error {
 		return ConfigError(err.Error())
 	}
 
-	if !c.Enabled(FeatureNetO11y) && !c.Enabled(FeatureAppO11y) && !c.Enabled(FeatureStatsO11y) {
+	networkEnabled := c.enabledForValidation(FeatureNetO11y, context)
+	applicationEnabled := c.enabledForValidation(FeatureAppO11y, context)
+	statsEnabled := c.enabledForValidation(FeatureStatsO11y, context)
+	if !networkEnabled && !applicationEnabled && !statsEnabled {
 		return ConfigError("at least one of 'network', 'application' or 'stats' features must be enabled. " +
 			"Enable an OpenTelemetry or Prometheus metrics export, then enable any of the network*, application* or stats*" +
 			"features using the 'OTEL_EBPF_METRICS_FEATURES=network,application,stats' environment variable " +
 			"or 'meter_provider: { features: [network,application,stats] }' in the YAML configuration file. ")
 	}
 
-	if c.willUseTC() {
-		if err := tcmanager.EnsureCiliumCompatibility(c.EBPF.TCBackend); err != nil {
+	if networkEnabled && c.NetworkFlows.Source == EbpfSourceTC && context.checkCiliumCompatibility != nil {
+		if err := context.checkCiliumCompatibility(c.EBPF.TCBackend); err != nil {
 			return ConfigError("Cilium compatibility error: " + err.Error())
 		}
 	}
 
-	if c.Enabled(FeatureNetO11y) && !c.OTELMetrics.EndpointEnabled() &&
+	otelMetricsEnabled := context.hostMetricsSink || c.OTELMetrics.EndpointEnabled()
+	tracesEnabled := context.hostTracesSink || c.Traces.Enabled()
+
+	if networkEnabled && !otelMetricsEnabled &&
 		!c.Prometheus.EndpointEnabled() && !c.NetworkFlows.Print {
 		return ConfigError("enabling network metrics requires to enable at least the OpenTelemetry" +
 			" metrics exporter: otel_metrics_export or prometheus_export sections in the YAML configuration file; or the" +
@@ -730,7 +767,7 @@ func (c *Config) Validate() error {
 			" purposes, you can also set OTEL_EBPF_NETWORK_PRINT_FLOWS=true")
 	}
 
-	if c.Enabled(FeatureStatsO11y) && !c.OTELMetrics.EndpointEnabled() &&
+	if statsEnabled && !otelMetricsEnabled &&
 		!c.Prometheus.EndpointEnabled() && !c.Stats.Print {
 		return ConfigError("enabling stat metrics requires to enable at least the OpenTelemetry" +
 			" metrics exporter: otel_metrics_export or prometheus_export sections in the YAML configuration file; or the" +
@@ -742,14 +779,14 @@ func (c *Config) Validate() error {
 		return ConfigError(fmt.Sprintf("invalid value for trace_printer: '%s'", c.TracePrinter))
 	}
 
-	if c.Enabled(FeatureAppO11y) && !c.TracePrinter.Enabled() &&
-		!c.OTELMetrics.EndpointEnabled() && !c.Traces.Enabled() &&
+	if applicationEnabled && !c.TracePrinter.Enabled() &&
+		!otelMetricsEnabled && !tracesEnabled &&
 		!c.Prometheus.EndpointEnabled() && !c.TracePrinter.Enabled() {
 		return ConfigError("you need to define at least one exporter: trace_printer," +
 			" otel_metrics_export, otel_traces_export or prometheus_export")
 	}
 
-	if c.Enabled(FeatureAppO11y) && (c.Prometheus.EndpointEnabled() || c.OTELMetrics.EndpointEnabled()) {
+	if applicationEnabled && (c.Prometheus.EndpointEnabled() || otelMetricsEnabled) {
 		if c.Metrics.Features.InvalidSpanMetricsConfig() {
 			return ConfigError("you can only enable one format of span metrics," +
 				" application_span or application_span_otel")
@@ -762,11 +799,29 @@ func (c *Config) Validate() error {
 	if c.InternalMetrics.Exporter == imetrics.InternalMetricsExporterOTEL && c.InternalMetrics.Prometheus.Port != 0 {
 		return ConfigError("you can't enable both OTEL and Prometheus internal metrics")
 	}
-	if c.InternalMetrics.Exporter == imetrics.InternalMetricsExporterOTEL && !c.OTELMetrics.EndpointEnabled() {
+	if c.InternalMetrics.Exporter == imetrics.InternalMetricsExporterOTEL && !otelMetricsEnabled {
 		return ConfigError("you can't enable OTEL internal metrics without enabling OTEL metrics")
 	}
 
 	return nil
+}
+
+func (c *Config) enabledForValidation(feature Feature, context validationContext) bool {
+	if c.Enabled(feature) {
+		return true
+	}
+	if !context.hostMetricsSink {
+		return false
+	}
+
+	switch feature {
+	case FeatureNetO11y:
+		return c.Metrics.Features.AnyNetwork()
+	case FeatureStatsO11y:
+		return c.Metrics.Features.StatMetrics()
+	default:
+		return false
+	}
 }
 
 func (c *Config) promNetO11yEnabled() bool {

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -5,6 +5,7 @@ package obi
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -740,6 +741,39 @@ func TestConfigValidate_TracePrinterFallback(t *testing.T) {
 	err := cfg.Validate()
 	require.NoError(t, err)
 	assert.Equal(t, debug.TracePrinterText, cfg.TracePrinter)
+}
+
+func TestConfigValidateForReceiverUsesHostSignalSinks(t *testing.T) {
+	cfg := loadConfig(t, envMap{"OTEL_EBPF_EXECUTABLE_PATH": "foo"})
+
+	require.ErrorContains(t, cfg.Validate(), "you need to define at least one exporter")
+	require.NoError(t, cfg.ValidateForReceiver())
+
+	cfg.TracePrinter = "invalid"
+	require.ErrorContains(t, cfg.ValidateForReceiver(), "invalid value for trace_printer")
+}
+
+func TestConfigValidateForReceiverUsesHostMetricsForStats(t *testing.T) {
+	cfg := loadConfig(t, envMap{})
+	cfg.Metrics.Features = export.FeatureStats
+
+	require.ErrorContains(t, cfg.Validate(), "at least one of 'network', 'application' or 'stats'")
+	require.NoError(t, cfg.ValidateForReceiver())
+}
+
+func TestConfigValidateStaticSkipsHostCompatibility(t *testing.T) {
+	cfg := loadConfig(t, envMap{})
+	cfg.NetworkFlows.Enable = true
+	cfg.NetworkFlows.Source = EbpfSourceTC
+	cfg.NetworkFlows.Print = true
+
+	err := cfg.validate(validationContext{
+		checkCiliumCompatibility: func(config.TCBackend) error {
+			return errors.New("host is incompatible")
+		},
+	})
+	require.ErrorContains(t, err, "host is incompatible")
+	require.NoError(t, cfg.ValidateStatic())
 }
 
 func TestConfigValidateRoutes(t *testing.T) {


### PR DESCRIPTION
## Summary

Internal Config v2 hardening work split from the CLI surface (#2679 and #2682) so the conversion contract can be reviewed independently.

- Reject selectors and declarative fields that the legacy runtime cannot represent.
- Preserve selector semantics while applying Config v2 defaults.
- Separate static configuration validation from host-dependent checks for standalone and receiver callers.
- Harden schema parsing and generated-document handling.

## Verification

- `make generate/all`
- `go test ./internal/config/convert ./internal/config/schema ./pkg/obi`