### PR TITLE
renovate: manage store-demo requirements.txt with the pip-compile manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,8 @@
   "pip-compile": {
     "managerFilePatterns": [
       "/^internal\\/test\\/integration\\/components\\/.*\\/requirements(-[^/]+)?\\.txt$/",
-      "/^\\.github\\/.*-requirements\\.txt$/"
+      "/^\\.github\\/.*-requirements\\.txt$/",
+      "/^examples\\/store-demo\\/app\\/src\\/.*\\/requirements\\.txt$/"
     ]
   },
   "customManagers": [


### PR DESCRIPTION
## Summary

`examples/store-demo/app/src/*/requirements.txt` wasn't matched by the
`pip-compile` manager's `managerFilePatterns`, so Renovate fell back to the
generic `pip_requirements` manager for these files. That manager only bumps
the pinned version/hash on a matching line in `requirements.txt` directly,
without recompiling the full lock from `requirements.in`. This is how
`emailservice`/`recommendationservice`'s lock drifted from
`requirements.in` and ended up missing a hashed `cryptography` pin that
`google-auth` newly required (see #2692), and how `loadgenerator`'s lock
kept a `greenlet` hash that no longer matched what PyPI serves.

Added `examples/store-demo/app/src/*/requirements.txt` to the `pip-compile`
manager's `managerFilePatterns`, so future Renovate updates recompile the
full lock (`requirements.in` to hashed `requirements.txt`) instead of
patching a single pinned line.

Validated with `renovate-config-validator`.