### PR TITLE
Fix OTLP export detection: compare server port (HostPort) not client ephemeral port (PeerPort)

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -2052,9 +2052,9 @@ func (s *Span) isTracesExportURL() bool {
 func (s *Span) sendsOnDefaultGrpcOtelPort(defaultOtlpGRPCPort int) bool {
 	otlpPort, ok := s.portFromEndpointEnvVar(envOTLPEndpoint)
 	if ok {
-		return otlpPort == s.PeerPort
+		return otlpPort == s.HostPort
 	}
-	return s.PeerPort == defaultOtlpGRPCPort
+	return s.HostPort == defaultOtlpGRPCPort
 }
 
 func (s *Span) sendsTracesOnGrpcOtelPort(defaultOtlpGRPCPort int) bool {
@@ -2068,7 +2068,7 @@ func (s *Span) sendsTracesOnGrpcOtelPort(defaultOtlpGRPCPort int) bool {
 	}
 	otlpTracesPort, ok := s.portFromEndpointEnvVar(envOTLPTracesEndpoint)
 	if ok {
-		return otlpTracesPort == s.PeerPort
+		return otlpTracesPort == s.HostPort
 	}
 	return s.sendsOnDefaultGrpcOtelPort(defaultOtlpGRPCPort)
 }
@@ -2102,7 +2102,7 @@ func (s *Span) sendsMetricsOnGrpcOtelPort(defaultOtlpGRPCPort int) bool {
 	}
 	otlpMetricsPort, ok := s.portFromEndpointEnvVar(envOTLPMetricsEndpoint)
 	if ok {
-		return otlpMetricsPort == s.PeerPort
+		return otlpMetricsPort == s.HostPort
 	}
 	return s.sendsOnDefaultGrpcOtelPort(defaultOtlpGRPCPort)
 }

--- a/pkg/appolly/app/request/span_test.go
+++ b/pkg/appolly/app/request/span_test.go
@@ -810,33 +810,33 @@ func TestDetectsOTelExport(t *testing.T) {
 			exports: false,
 		},
 		{
-			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT != span.PeerPort doesn't export",
+			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT != span.HostPort doesn't export",
 			span: Span{
-				Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Type: EventTypeGRPCClient, HostPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
 				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4317"}},
 			},
 			exports: false,
 		},
 		{
-			name: "OTEL_EXPORTER_OTLP_ENDPOINT != span.PeerPort doesn't export",
+			name: "OTEL_EXPORTER_OTLP_ENDPOINT != span.HostPort doesn't export",
 			span: Span{
-				Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Type: EventTypeGRPCClient, HostPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
 				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"}},
 			},
 			exports: false,
 		},
 		{
-			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT == span.PeerPort export",
+			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT == span.HostPort export",
 			span: Span{
-				Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Type: EventTypeGRPCClient, HostPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
 				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:9090"}},
 			},
 			exports: true,
 		},
 		{
-			name: "OTEL_EXPORTER_OTLP_ENDPOINT == span.PeerPort export",
+			name: "OTEL_EXPORTER_OTLP_ENDPOINT == span.HostPort export",
 			span: Span{
-				Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Type: EventTypeGRPCClient, HostPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
 				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:9090", "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"}},
 			},
 			exports: true,
@@ -844,14 +844,14 @@ func TestDetectsOTelExport(t *testing.T) {
 		{
 			name: fmt.Sprintf("no otel metrics environment sends to %x export", defaultOtlpGRPCPort),
 			span: Span{
-				Type: EventTypeGRPCClient, PeerPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Type: EventTypeGRPCClient, HostPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
 				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_PROTOCOL": "http/protobuf"}},
 			},
 			exports: true,
 		},
 		{
 			name:    fmt.Sprintf("no otel environment sends to anything other the %d doesn't export", defaultOtlpGRPCPort),
-			span:    Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0},
+			span:    Span{Type: EventTypeGRPCClient, HostPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0},
 			exports: false,
 		},
 	}
@@ -942,33 +942,33 @@ func TestDetectsOTelExport(t *testing.T) {
 			exports: false,
 		},
 		{
-			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT != span.PeerPort doesn't export",
+			name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT != span.HostPort doesn't export",
 			span: Span{
-				Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Type: EventTypeGRPCClient, HostPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
 				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4317"}},
 			},
 			exports: false,
 		},
 		{
-			name: "OTEL_EXPORTER_OTLP_ENDPOINT != span.PeerPort doesn't export",
+			name: "OTEL_EXPORTER_OTLP_ENDPOINT != span.HostPort doesn't export",
 			span: Span{
-				Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Type: EventTypeGRPCClient, HostPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
 				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317"}},
 			},
 			exports: false,
 		},
 		{
-			name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT == span.PeerPort export",
+			name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT == span.HostPort export",
 			span: Span{
-				Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Type: EventTypeGRPCClient, HostPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
 				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://localhost:9090"}},
 			},
 			exports: true,
 		},
 		{
-			name: "OTEL_EXPORTER_OTLP_ENDPOINT == span.PeerPort export",
+			name: "OTEL_EXPORTER_OTLP_ENDPOINT == span.HostPort export",
 			span: Span{
-				Type: EventTypeGRPCClient, PeerPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Type: EventTypeGRPCClient, HostPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
 				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:9090", "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf"}},
 			},
 			exports: true,
@@ -976,14 +976,14 @@ func TestDetectsOTelExport(t *testing.T) {
 		{
 			name: fmt.Sprintf("no otel traces environment sends to %d export", defaultOtlpGRPCPort),
 			span: Span{
-				Type: EventTypeGRPCClient, PeerPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Type: EventTypeGRPCClient, HostPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
 				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_METRICS_PROTOCOL": "http/protobuf"}},
 			},
 			exports: true,
 		},
 		{
 			name:    fmt.Sprintf("no otel environment sends to anything other the %d doesn't export", defaultOtlpGRPCPort),
-			span:    Span{Type: EventTypeGRPCClient, PeerPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0},
+			span:    Span{Type: EventTypeGRPCClient, HostPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0},
 			exports: false,
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes #2711.

The gRPC port fallback in the OTLP export detection compares the span's `PeerPort` against the process's OTLP endpoint port (from `OTEL_EXPORTER_OTLP_*ENDPOINT`) or `default_otlp_grpc_port`. For a **client** span, `PeerPort` is the client's ephemeral source port; the destination (server) port is `HostPort`. So the fallback could never match in practice, and gRPC export detection effectively relied solely on decoding the `:path` (`.../MetricsService/Export` etc.).

Consequently `exclude_otel_instrumented_services` (default on) silently missed exporters whose `:path` was not decodable — e.g. Python gRPC exporters where `:path` is frequently only seen as an HPACK dynamic-table index reference and OBI reports `Path: "*"`. Those services kept getting OBI RED metrics emitted alongside the app SDK's own metrics (double collection).

### Change

Use `s.HostPort` instead of `s.PeerPort` in `sendsOnDefaultGrpcOtelPort`, `sendsTracesOnGrpcOtelPort`, and `sendsMetricsOnGrpcOtelPort`. Also fix the unit tests in `span_test.go`, which encoded the same inverted assumption (they set `PeerPort` to the destination port); they now set `HostPort`, matching how client spans are actually populated (`PeerPort = S_port`, `HostPort = D_port` in `http2grpc_transform.go`).

Field semantics reference: client spans set `PeerPort: int(info.ConnInfo.S_port)` / `HostPort: int(info.ConnInfo.D_port)`, and the rest of `span.go` already treats `HostPort` as the server port (e.g. the `serverPort` attribute).

### Evidence

On an opentelemetry-demo deployment, `obi_avoided_services` showed gRPC/4317 Python services (`product-reviews`, `load-generator`, `recommendation`) flagged for `traces` but not `metrics`, while gRPC/4317 non-Python services (Go/Node.js/.NET) were flagged for both. With this fix, the port fallback matches on the endpoint port even when `:path` is `"*"`, so the Python services are detected consistently.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] `go test ./pkg/appolly/app/request/` passes.
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed. (n/a — bugfix, no behavior/support-matrix surface change)

---

_AI disclosure (per [AI-POLICY.md](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/AI-POLICY.md)): root-cause analysis and this patch were prepared with the assistance of an AI coding tool. The author has reviewed, tested, and takes full responsibility for the change._