### PR TITLE
build: Resolve metric attribute changes via refinement

### DIFF
--- a/schemas/obi/README.md
+++ b/schemas/obi/README.md
@@ -9,8 +9,8 @@ upstream dependency it forms the complete contract of what OBI emits
 
 Weaver (v0.24.x) has **no precedence or merge semantics** between a local
 group and the groups a dependency contributes to the resolved registry
-(`--include-unreferenced`, which OBI needs). When the same attribute id or
-signal name is declared by more than one group, live-check silently resolves
+(`--include-unreferenced`, which OBI needs). When the same attribute id
+is declared by more than one group, live-check silently resolves
 the duplicate in favor of the group whose id sorts **last lexicographically** —
 including the upstream `span.*` / `metric.*` groups that `ref` an attribute
 and therefore carry an embedded copy of its upstream definition. Tracked
@@ -33,14 +33,11 @@ Until weaver defines local-wins override semantics, every override in
    resurfaces as an `undefined_enum_variant` failure in the weaver-validated
    suites, so drift is caught, not silent.
 3. **Expected lint duplicates**: `weaver registry check` flags each override
-   as a `DuplicateAttributeId` (or `DuplicateMetricName`) error even though
+   as a `DuplicateAttributeId` error even though
    live-check resolves it. Each expected duplicate is allowlisted — tightly,
    by attribute id and group pair — in `scripts/lint-schema-filter.jq`
    (covered by `scripts/lint_schema_filter_test.go`). Anything else still
    fails `make lint-schema`.
-
-`groups/dns.yaml` is the metric-level variant of the same problem (duplicate
-`metric_name` instead of attribute id) and follows the same group-id rule.
 
 ## Two override styles
 

--- a/schemas/obi/groups/dns.yaml
+++ b/schemas/obi/groups/dns.yaml
@@ -1,4 +1,6 @@
-groups:
+file_format: definition/2
+
+metric_refinements:
   # OBI override of the upstream metric.dns.lookup.duration definition.
   #
   # Upstream (semconv v1.41.0) marks dns.question.name as `required`, but OBI
@@ -27,16 +29,12 @@ groups:
   # as a DuplicateMetricName error even though live-check resolves it; this
   # specific expected duplicate is allowlisted in
   # scripts/lint-schema-filter.jq with the same rationale.
-  - id: metric.dns.lookup.duration.obi
-    type: metric
-    extends: metric.dns.lookup.duration
-    metric_name: dns.lookup.duration
+  - id: dns.lookup.duration
+    ref: dns.lookup.duration
     stability: development
     brief: >
       Measures the time taken to perform a DNS lookup. OBI variant of the
       upstream metric with dns.question.name opt-in instead of required.
-    instrument: histogram
-    unit: "s"
     attributes:
       - ref: dns.question.name
         requirement_level: opt_in

--- a/schemas/obi/groups/dns.yaml
+++ b/schemas/obi/groups/dns.yaml
@@ -29,7 +29,7 @@ metric_refinements:
   # as a DuplicateMetricName error even though live-check resolves it; this
   # specific expected duplicate is allowlisted in
   # scripts/lint-schema-filter.jq with the same rationale.
-  - id: dns.lookup.duration
+  - id: metric.dns.lookup.duration.obi
     ref: dns.lookup.duration
     stability: development
     brief: >

--- a/scripts/lint-schema-filter.jq
+++ b/scripts/lint-schema-filter.jq
@@ -7,11 +7,7 @@
 # weaver defines override semantics this filter (and the override groups
 # documented in schemas/obi/README.md) can be dropped.
 #
-# 1. DuplicateMetricName for `dns.lookup.duration` between the upstream
-#    semconv dependency (under `.deps/`) and `schemas/obi/groups/dns.yaml`.
-#    That file deliberately re-declares the upstream metric (via `extends`
-#    under a distinct group id) to relax `dns.question.name` from required to
-#    opt_in.
+# 1. UnstableFileFormat we accept UnstableFileFormat for "definition/2" due to the migration process.
 #
 # 2. DuplicateAttributeId for the attribute overrides in
 #    `schemas/obi/groups/` (see schemas/obi/README.md): each re-declares an
@@ -25,13 +21,11 @@
 map(select(
   (
     (
-      (.error.DuplicateMetricName? // null) as $dup
-      | $dup != null
-        and $dup.metric_name == "dns.lookup.duration"
-        and (($dup.provenances // []) | length) == 2
-        and ([$dup.provenances[].path] | sort
-             | (.[0] | startswith(".deps/"))
-               and (.[1] | endswith("groups/dns.yaml")))
+      (.error.FailToResolveDefinition? // null) as $fail
+      | $fail != null
+        and ($fail.UnstableFileFormat? // null) as $unstable
+        | $unstable != null
+          and $unstable.file_format  == "definition/2"
     )
     or
     (

--- a/scripts/lint-schema-filter.jq
+++ b/scripts/lint-schema-filter.jq
@@ -25,7 +25,7 @@ map(select(
       | $fail != null
         and ($fail.UnstableFileFormat? // null) as $unstable
         | $unstable != null
-          and $unstable.file_format  == "definition/2"
+          and $unstable.file_format == "definition/2"
     )
     or
     (

--- a/scripts/lint-schema.sh
+++ b/scripts/lint-schema.sh
@@ -38,6 +38,7 @@ out=$($OCI_BIN run --rm \
     --registry /obi-registry \
     --include-unreferenced \
     --future \
+    --v2=true \
     --diagnostic-format json \
     --diagnostic-stdout 2>"$stderr") || rc=$?
 

--- a/scripts/lint_schema_filter_test.go
+++ b/scripts/lint_schema_filter_test.go
@@ -33,21 +33,18 @@ func runLintSchemaFilter(t *testing.T, diagnostics string) []json.RawMessage {
 	return remaining
 }
 
-const expectedDNSDuplicate = `[{
+const expectedUnstable = `[{
 	"diagnostic": {"severity": "Error"},
-	"error": {"DuplicateMetricName": {
-		"metric_name": "dns.lookup.duration",
-		"provenances": [
-			{"path": ".deps/upstream-v1.41.0/model/dns/metrics.yaml"},
-			{"path": "/obi-registry/groups/dns.yaml"}
-		]
-	}}
+	"error": {"FailToResolveDefinition": {"UnstableFileFormat" :{
+		"file_format": "definition/2",
+		"provenances": "/obi-registry/groups/dns.yaml"
+	}}}
 }]`
 
-func TestLintSchemaFilterAllowsExpectedDNSDuplicate(t *testing.T) {
-	remaining := runLintSchemaFilter(t, expectedDNSDuplicate)
+func TestLintSchemaFilterAllowsExpectedUnstable(t *testing.T) {
+	remaining := runLintSchemaFilter(t, expectedUnstable)
 	if len(remaining) != 0 {
-		t.Fatalf("expected the documented dns.lookup.duration duplicate to be filtered, got %d diagnostics", len(remaining))
+		t.Fatalf("expected the documented unstable error to be filtered, got %d diagnostics", len(remaining))
 	}
 }
 


### PR DESCRIPTION
## Summary

This switches dns to weaver v2 and resolves metric name collisions.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

<!-- markdownlint-disable-file MD041 -->
