### PR TITLE
Omit empty http method from http metrics

### DIFF
--- a/internal/test/oats/harness/weaver.go
+++ b/internal/test/oats/harness/weaver.go
@@ -38,7 +38,7 @@ const (
 // shared weaver compose fragment), unless the run explicitly opts out via
 // TESTCASE_SKIP_WEAVER=true.
 func validateWeaver() {
-	if os.Getenv(skipWeaverEnv) == "true" || true {
+	if os.Getenv(skipWeaverEnv) == "true" {
 		ginkgo.GinkgoWriter.Printf("%s=true — skipping weaver validation\n", skipWeaverEnv)
 		return
 	}

--- a/internal/test/weavercheck/weavercheck.go
+++ b/internal/test/weavercheck/weavercheck.go
@@ -255,7 +255,7 @@ func Validate(t TestingT, report *Report) {
 		actionableAdvisories += e.Occurrences
 	}
 	if len(actionable) > 0 {
-		t.Logf("  actionable advisories (these fail the check, most frequent first):")
+		t.Logf("  actionable advisories:")
 		for _, e := range actionable {
 			signals := "unknown"
 			if len(e.Signals) > 0 {

--- a/internal/test/weavercheck/weavercheck.go
+++ b/internal/test/weavercheck/weavercheck.go
@@ -247,7 +247,25 @@ func Validate(t TestingT, report *Report) {
 	// Build message → {level, type, signals} lookup from the sample data.
 	adviceByMsg := collectAdviceInfo(report.Samples)
 
-	// Log all advisory messages grouped by level.
+	// Surface the advisories that actually fail the check first, so the cause
+	// of a failure is obvious without scanning the full advisory dump below.
+	actionable := collectActionableAdvisories(stats, adviceByMsg)
+	actionableAdvisories := 0
+	for _, e := range actionable {
+		actionableAdvisories += e.Occurrences
+	}
+	if len(actionable) > 0 {
+		t.Logf("  actionable advisories (these fail the check, most frequent first):")
+		for _, e := range actionable {
+			signals := "unknown"
+			if len(e.Signals) > 0 {
+				signals = strings.Join(e.Signals, ", ")
+			}
+			t.Logf("    [%s/%s] [%dx] %s (signals: %s)", e.Level, e.AdviceType, e.Occurrences, e.Message, signals)
+		}
+	}
+
+	// Log all advisory messages grouped by level for full context.
 	t.Logf("  advisory details:")
 	for _, level := range []string{"violation", "improvement", "information"} {
 		for msg, count := range stats.AdviceMessageCounts {
@@ -277,7 +295,6 @@ func Validate(t TestingT, report *Report) {
 		}
 	}
 
-	actionableAdvisories := countActionableAdvisories(stats, adviceByMsg)
 	t.Logf("  advisories: %d violation(s), %d actionable (violations + actionableAdviceTypes, after ignoring %v)",
 		violations, actionableAdvisories, sortedSignals(IgnoredSignals))
 
@@ -299,26 +316,63 @@ func isActionableAdvice(info *adviceInfo) bool {
 	return actionable
 }
 
-// countActionableAdvisories counts advisories that must fail validation,
+// actionableEntry is a single advisory that fails validation, carrying the
+// attribution needed to print an at-a-glance "this is what broke" summary.
+type actionableEntry struct {
+	Message     string
+	Level       string
+	AdviceType  string
+	Occurrences int
+	Signals     []string
+}
+
+// collectActionableAdvisories returns the advisories that must fail validation,
 // excluding signals listed in IgnoredSignals and messages listed in
 // IgnoredAdviceMessages. Messages present in the statistics but absent from
 // the sample data carry no level/type/signal attribution, so they are
-// conservatively counted as actionable unless message-ignored.
-func countActionableAdvisories(stats *Statistics, adviceByMsg map[string]*adviceInfo) int {
-	var count int
+// conservatively treated as actionable unless message-ignored. Results are
+// sorted by descending occurrence count, then message, for stable output.
+func collectActionableAdvisories(stats *Statistics, adviceByMsg map[string]*adviceInfo) []actionableEntry {
+	var entries []actionableEntry
 	for msg, occurrences := range stats.AdviceMessageCounts {
 		_, messageIgnored := IgnoredAdviceMessages[msg]
 		info := adviceByMsg[msg]
 		if info == nil {
 			if !messageIgnored {
-				count += occurrences
+				entries = append(entries, actionableEntry{
+					Message:     msg,
+					Level:       "unknown",
+					AdviceType:  "unknown",
+					Occurrences: occurrences,
+				})
 			}
 			continue
 		}
 		ignored := messageIgnored || allSignalsIgnored(info.Signals)
 		if isActionableAdvice(info) && !ignored {
-			count += occurrences
+			entries = append(entries, actionableEntry{
+				Message:     msg,
+				Level:       info.Level,
+				AdviceType:  info.AdviceType,
+				Occurrences: occurrences,
+				Signals:     sortedSignals(info.Signals),
+			})
 		}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Occurrences != entries[j].Occurrences {
+			return entries[i].Occurrences > entries[j].Occurrences
+		}
+		return entries[i].Message < entries[j].Message
+	})
+	return entries
+}
+
+// countActionableAdvisories counts advisories that must fail validation.
+func countActionableAdvisories(stats *Statistics, adviceByMsg map[string]*adviceInfo) int {
+	var count int
+	for _, e := range collectActionableAdvisories(stats, adviceByMsg) {
+		count += e.Occurrences
 	}
 	return count
 }

--- a/pkg/appolly/app/request/span_getters.go
+++ b/pkg/appolly/app/request/span_getters.go
@@ -52,7 +52,12 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 			return K8SClientClusterMetric(otherCluster)
 		}
 	case attr.HTTPRequestMethod:
-		getter = func(s *Span) attribute.KeyValue { return HTTPRequestMethod(s.Method) }
+		getter = func(s *Span) attribute.KeyValue {
+			if s.Method == "" {
+				return attribute.KeyValue{}
+			}
+			return HTTPRequestMethod(s.Method)
+		}
 	case attr.HTTPResponseStatusCode:
 		getter = func(s *Span) attribute.KeyValue { return HTTPResponseStatusCode(s.Status) }
 	case attr.HTTPRoute:

--- a/pkg/appolly/app/request/span_getters_test.go
+++ b/pkg/appolly/app/request/span_getters_test.go
@@ -494,6 +494,23 @@ func TestSpanOTELGetters_HTTPURLScheme(t *testing.T) {
 	}
 }
 
+func TestSpanOTELGetters_HTTPRequestMethod(t *testing.T) {
+	getter, ok := spanOTELGetters(attr.HTTPRequestMethod)
+	require.True(t, ok, "getter should be found for HTTPRequestMethod")
+
+	t.Run("present when method is known", func(t *testing.T) {
+		kv := getter(&Span{Method: "GET"})
+		require.True(t, kv.Valid())
+		assert.Equal(t, string(attr.HTTPRequestMethod), string(kv.Key))
+		assert.Equal(t, "GET", kv.Value.AsString())
+	})
+
+	t.Run("omitted when method is empty", func(t *testing.T) {
+		kv := getter(&Span{Method: ""})
+		assert.False(t, kv.Valid(), "empty method must yield an invalid KeyValue so it is dropped")
+	})
+}
+
 func TestSpanOTELGetters_SunRPC(t *testing.T) {
 	span := &Span{
 		Type:    EventTypeSunRPCClient,

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -527,13 +527,15 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 	switch span.Type {
 	case request.EventTypeHTTP:
 		attrs = []attribute.KeyValue{
-			request.HTTPRequestMethod(span.Method),
 			request.HTTPResponseStatusCode(span.Status),
 			request.ClientAddr(request.PeerAsClient(span)),
 			request.ServerAddr(request.SpanHost(span)),
 			request.ServerPort(span.HostPort),
 			request.HTTPRequestBodySize(int(span.RequestBodyLength())),
 			request.HTTPResponseBodySize(span.ResponseBodyLength()),
+		}
+		if span.Method != "" {
+			attrs = append(attrs, request.HTTPRequestMethod(span.Method))
 		}
 		if span.Path != "" {
 			attrs = append(attrs, request.HTTPUrlPath(span.Path))
@@ -630,7 +632,6 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		}
 
 		attrs = []attribute.KeyValue{
-			request.HTTPRequestMethod(span.Method),
 			request.HTTPResponseStatusCode(span.Status),
 			request.HTTPUrlFull(url),
 			semconv.URLScheme(scheme),
@@ -639,6 +640,9 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			request.ServerPort(span.HostPort),
 			request.HTTPRequestBodySize(int(span.RequestBodyLength())),
 			request.HTTPResponseBodySize(span.ResponseBodyLength()),
+		}
+		if span.Method != "" {
+			attrs = append(attrs, request.HTTPRequestMethod(span.Method))
 		}
 
 		if scrubbedQS != "" {

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -266,6 +266,34 @@ func TestHTTPServerSpanURLQuery(t *testing.T) {
 	})
 }
 
+func TestHTTPRequestMethodOmittedWhenEmpty(t *testing.T) {
+	defaultAttrs, err := UserSelectedAttributes(&attributes.SelectorConfig{})
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name      string
+		spanType  request.EventType
+		method    string
+		wantValue string
+		wantOK    bool
+	}{
+		{name: "server span with known method", spanType: request.EventTypeHTTP, method: "GET", wantValue: "GET", wantOK: true},
+		{name: "server span with empty method", spanType: request.EventTypeHTTP, method: "", wantOK: false},
+		{name: "client span with known method", spanType: request.EventTypeHTTPClient, method: "GET", wantValue: "GET", wantOK: true},
+		{name: "client span with empty method", spanType: request.EventTypeHTTPClient, method: "", wantOK: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			span := &request.Span{Type: tt.spanType, Method: tt.method, Path: "/", Host: "example.com", HostPort: 80, Status: 200}
+			selected := AttrsToMap(TraceAttributesSelector(span, defaultAttrs))
+			val, ok := selected.Get("http.request.method")
+			assert.Equal(t, tt.wantOK, ok, "http.request.method presence should match method availability")
+			if tt.wantOK {
+				assert.Equal(t, tt.wantValue, val.Str())
+			}
+		})
+	}
+}
+
 func TestCreateToolCallSpans(t *testing.T) {
 	t.Run("nil tool calls creates no spans", func(t *testing.T) {
 		ss := ptrace.NewScopeSpans()


### PR DESCRIPTION
## Summary

Fixes the OATS weaver semantic-convention check that was failing on
`run-oats_java_tls_sync_async` (the reason the OATS weaver validation was
temporarily disabled in #2727), and re-enables that validation.

OBI was emitting the enumerated attribute `http.request.method` with an empty
value (`""`) on client-side HTTP metrics (`http.client.request.body.size`,
`http.client.request.duration`, `http.client.response.body.size`). Weaver
classifies an empty enum value as `undefined_enum_variant`, and the OATS weaver
gate treats it as actionable — the check reported `4 actionable` advisories and
failed with "Should be zero, but was 4".

### Root cause

For TLS / async client traffic, connection info is often unavailable, so span
construction falls back to `httpRequestToSpan`, which derives the method from a
raw buffer via `httpMethodFromBuf`. When the buffer holds no
`METHOD SP URL SP VERSION` request line, that function returns `""`. Nothing
downstream dropped the attribute: the metrics getter passed the value through,
and the expirer's only omit-gate (`attribute.KeyValue.Valid()`) considers an
empty string valid. Per the weaver-check contract, when OBI has no valid value
for an enumerated attribute it must **omit** the attribute rather than emit an
empty one.

### Changes

- **Omit `http.request.method` when empty (metrics):** the OTEL method getter
  now returns an invalid `attribute.KeyValue{}` for an empty method, so the
  expirer's existing `Valid()` gate drops it — the established skip-idiom in
  `span_getters.go`.
- **Omit `http.request.method` when empty (traces):** the HTTP server and
  client span builders now append the method only when non-empty, matching the
  existing `if span.Method != ""` guard already used for DB / messaging spans.
- **Surface failing advisories first:** the weaver report now prints an
  "actionable advisories (these fail the check, most frequent first)" block
  before the full advisory dump, so the cause of a failure is visible at a
  glance instead of buried among hundreds of ignored/informational lines.
  Ordering is deterministic (by occurrence count, then message).
- **Re-enable the OATS weaver validation** by reverting the temporary
  `|| true` short-circuit added in #2727, now that the root cause is fixed.
- Regression tests: `http.request.method` is present for a known method and
  absent for an empty one, on both client and server spans, and at the
  metrics-getter level.

### Example: new weaver output ordering

```
  actionable advisories:
    [information/undefined_enum_variant] [4x] Enum attribute 'http.request.method' has value '' which is not documented. (signals: metric:http.client.request.body.size, metric:http.client.request.duration, metric:http.client.response.body.size)
  advisory details:
    ... (full per-level list unchanged, for context)
```

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
