### PR TITLE
Fix double-traceparent injection in programs using the Go OTEL SDK

### DIFF
--- a/bpf/gotracer/go_common.h
+++ b/bpf/gotracer/go_common.h
@@ -107,6 +107,37 @@ struct {
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
 } ongoing_grpc_transports SEC(".maps");
 
+// go_sdk_tp_pids tracks the PIDs (host tgid) whose OpenTelemetry Go SDK writes
+// its own traceparent into outgoing HTTP/gRPC headers. For these processes OBI
+// must not inject a second traceparent via its uprobes,
+// otherwise the frame ends up carrying two traceparent headers and downstream
+// traces break. The flag is set from the SDK delegate check in go_sdk.c.
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u32);  // host tgid
+    __type(value, u8); // presence flag
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} go_sdk_tp_pids SEC(".maps");
+
+// Records that the current process drives its own OTel SDK traceparent, so OBI
+// must skip its uprobe-based traceparent injection for it.
+static __always_inline void mark_pid_writes_own_tp() {
+    const u32 tgid = (u32)(bpf_get_current_pid_tgid() >> 32);
+    const u8 one = 1;
+    bpf_map_update_elem(&go_sdk_tp_pids, &tgid, &one, BPF_ANY);
+}
+
+// Returns true when the current process drives its own OTel SDK traceparent
+// injection and OBI should therefore skip its own injection.
+static __always_inline bool pid_writes_own_tp() {
+    if (!g_bpf_traceparent_enabled) {
+        return false;
+    }
+    const u32 tgid = (u32)(bpf_get_current_pid_tgid() >> 32);
+    return bpf_map_lookup_elem(&go_sdk_tp_pids, &tgid) != NULL;
+}
+
 #define SQL_CONN_TYPE_DATABASE_SQL 0 // database/sql (mysql, pq)
 #define SQL_CONN_TYPE_PGX 1          // github.com/jackc/pgx/v5
 

--- a/bpf/gotracer/go_grpc.c
+++ b/bpf/gotracer/go_grpc.c
@@ -828,7 +828,13 @@ int obi_uprobe_grpcFramerWriteHeaders(struct pt_regs *ctx) {
         // The offset will be 0 on first connection through the stream and 9 on subsequent.
         // If we read some very large offset, we don't do anything since it might be a situation
         // we can't handle
-        if (offset < MAX_W_PTR_OFFSET) {
+        if (pid_writes_own_tp()) {
+            // The application drives its own OTel SDK traceparent, so the return
+            // uprobe will skip injection: don't stash the invocation for it. The
+            // connection is already marked above so the sk_msg path also leaves
+            // the app's traceparent intact.
+            bpf_dbg_printk("skipping grpc framer stash, pid writes its own traceparent");
+        } else if (offset < MAX_W_PTR_OFFSET) {
             grpc_framer_func_invocation_t f_info = {
                 .tp = invocation->tp,
                 .framer_ptr = (u64)framer,
@@ -858,6 +864,13 @@ int obi_uprobe_grpcFramerWriteHeaders_returns(struct pt_regs *ctx) {
     }
 
     bpf_dbg_printk("=== uprobe/grpcFramerWriteHeaders_returns ===");
+
+    // The application drives its own OTel SDK traceparent; injecting ours would
+    // append a duplicate traceparent and break downstream traces
+    if (pid_writes_own_tp()) {
+        bpf_dbg_printk("skipping grpc tp injection, pid writes its own traceparent");
+        return 0;
+    }
 
     void *goroutine_addr = GOROUTINE_PTR(ctx);
     off_table_t *ot = get_offsets_table();

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -817,6 +817,13 @@ int obi_uprobe_writeSubset(struct pt_regs *ctx) {
         return 0;
     }
 
+    // The application drives its own OTel SDK traceparent; injecting ours would
+    // append a duplicate traceparent and break downstream traces.
+    if (pid_writes_own_tp()) {
+        bpf_dbg_printk("skipping http tp injection, pid writes its own traceparent");
+        return 0;
+    }
+
     bpf_dbg_printk("=== uprobe/header_writeSubset ===");
 
     void *header_addr = GO_PARAM1(ctx);
@@ -1122,6 +1129,13 @@ on_http2FramerWriteHeaders(struct pt_regs *ctx, off_table_t *ot, u64 stream_id) 
         return;
     }
 
+    // The application drives its own OTel SDK traceparent; the return uprobe
+    // would skip injection anyway, so don't stash the invocation state for it.
+    // Unlike the gRPC path, this uprobe has no other side effects to preserve.
+    if (pid_writes_own_tp()) {
+        return;
+    }
+
     void *framer = GO_PARAM1(ctx);
 
     if (!framer) {
@@ -1231,6 +1245,13 @@ int obi_uprobe_net_http2FramerWriteHeaders(struct pt_regs *ctx) {
 SEC("uprobe/http2FramerWriteHeaders_returns")
 int obi_uprobe_http2FramerWriteHeaders_returns(struct pt_regs *ctx) {
     if (!g_bpf_header_propagation) {
+        return 0;
+    }
+
+    // The application drives its own OTel SDK traceparent; injecting ours would
+    // append a duplicate traceparent and break downstream traces.
+    if (pid_writes_own_tp()) {
+        bpf_dbg_printk("skipping http2 tp injection, pid writes its own traceparent");
         return 0;
     }
 

--- a/bpf/gotracer/go_sdk.c
+++ b/bpf/gotracer/go_sdk.c
@@ -111,6 +111,10 @@ static __always_inline int tracer_start(struct pt_regs *ctx, u8 check_delegate) 
             sizeof(delegate_ptr),
             (void *)(tracer_ptr + go_offset_of(ot, (go_offset){.v = _tracer_delegate_pos})));
         if (delegate_ptr != NULL) {
+            // Delegate is set, so the application drives its own OTel SDK
+            // tracing. Mark the PID so the Go uprobe traceparent injection
+            // skips it and we don't append a duplicate traceparent.
+            mark_pid_writes_own_tp();
             // Delegate is set, so we should not instrument this call
             return 0;
         }

--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -43,6 +43,15 @@ type ServiceFilter interface {
 	CurrentPIDs(PIDType) map[uint32]map[app.PID]svc.Attrs
 }
 
+// OTelPIDMarker receives the host PID (TGID) of a process detected to export
+// its own OpenTelemetry traces, so a tracer can suppress its duplicate
+// traceparent injection for that process. It complements the
+// gotracer's in-kernel SDK-delegate detection, which only fires when the app
+// obtains its tracer before installing the SDK TracerProvider.
+type OTelPIDMarker interface {
+	MarkPIDWritesOwnTP(hostPID uint32)
+}
+
 // PIDsFilter keeps a thread-safe copy of the PIDs whose traces are allowed to
 // be forwarded. Its Filter method filters the request.Span instances whose
 // PIDs are not in the allowed list.
@@ -54,6 +63,7 @@ type PIDsFilter struct {
 	ignoreOtelSpan      bool
 	defaultOtlpGRPCPort int
 	metrics             imetrics.Reporter
+	otelMarker          OTelPIDMarker
 }
 
 func NewPIDsFilter(c *services.DiscoveryConfig, log *slog.Logger, metrics imetrics.Reporter) *PIDsFilter {
@@ -66,6 +76,15 @@ func NewPIDsFilter(c *services.DiscoveryConfig, log *slog.Logger, metrics imetri
 		defaultOtlpGRPCPort: c.DefaultOtlpGRPCPort,
 		metrics:             metrics,
 	}
+}
+
+// SetOTelPIDMarker registers a marker notified whenever a tracked process is
+// detected to export its own OTel traces. It is expected to be set once, at
+// startup, before Filter runs.
+func (pf *PIDsFilter) SetOTelPIDMarker(m OTelPIDMarker) {
+	pf.mux.Lock()
+	defer pf.mux.Unlock()
+	pf.otelMarker = m
 }
 
 func (pf *PIDsFilter) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo, pidType PIDType) {
@@ -227,6 +246,11 @@ func (pf *PIDsFilter) checkIfExportsOTel(fi *exec.FileInfo, span *request.Span, 
 		pf.reportAvoidedService(fi, "metrics")
 	} else if span.IsExportTracesSpan(defaultOtlpGRPCPort) && fi.EnsureExportsOTelTraces() {
 		pf.reportAvoidedService(fi, "traces")
+		// The process exports its own OTel traces, so it writes its own
+		// traceparent: tell the tracer to stop injecting a duplicate.
+		if pf.otelMarker != nil {
+			pf.otelMarker.MarkPIDWritesOwnTP(uint32(span.Pid.HostPID))
+		}
 	}
 }
 

--- a/pkg/ebpf/common/pids_test.go
+++ b/pkg/ebpf/common/pids_test.go
@@ -159,6 +159,36 @@ func TestFilter_ExportsOTelDetection(t *testing.T) {
 	assert.True(t, fi.ExportsOTelTraces())
 }
 
+type recordingOTelMarker struct{ marked []uint32 }
+
+func (m *recordingOTelMarker) MarkPIDWritesOwnTP(hostPID uint32) {
+	m.marked = append(m.marked, hostPID)
+}
+
+// TestFilter_MarksOTelExportingPID verifies the userspace path of the #2732
+// fix: when a process is detected exporting its own OTel traces, its host PID
+// is handed to the registered marker (so the gotracer can suppress duplicate
+// traceparent injection). Metrics-only export must not mark it.
+func TestFilter_MarksOTelExportingPID(t *testing.T) {
+	const defaultOtlpPort = 4317
+	pf := NewPIDsFilter(&services.DiscoveryConfig{ExcludeOTelInstrumentedServices: true}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+	marker := &recordingOTelMarker{}
+	pf.SetOTelPIDMarker(marker)
+
+	// metrics-only export: detected, but no traceparent, so not marked.
+	fi := exec.New(exec.Init{})
+	metricsSpan := request.Span{Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/metrics", Status: 200, Pid: request.PidInfo{HostPID: 4321}}
+	pf.checkIfExportsOTel(fi, &metricsSpan, defaultOtlpPort)
+	assert.Empty(t, marker.marked)
+
+	// traces export: process writes its own traceparent -> must be marked once.
+	fi = exec.New(exec.Init{})
+	tracesSpan := request.Span{Type: request.EventTypeHTTPClient, Method: "GET", Path: "/v1/traces", Status: 200, Pid: request.PidInfo{HostPID: 1234}}
+	pf.checkIfExportsOTel(fi, &tracesSpan, defaultOtlpPort)
+	pf.checkIfExportsOTel(fi, &tracesSpan, defaultOtlpPort) // idempotent: flag already set
+	assert.Equal(t, []uint32{1234}, marker.marked)
+}
+
 func TestFilter_ExportsOTelSpanDetection(t *testing.T) {
 	const defaultOtlpPort = 4317
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})

--- a/pkg/ebpf/tracer_linux.go
+++ b/pkg/ebpf/tracer_linux.go
@@ -138,7 +138,7 @@ func (pt *ProcessTracer) Run(
 					runningTracerNames = append(runningTracerNames, ti.implType)
 				}
 			}
-			pt.log.Warn("some process tracers did not finish", "tracers", runningTracers)
+			pt.log.Warn("some process tracers did not finish", "tracers", runningTracerNames)
 			hasWarned = true
 		case <-tracersEnded:
 			if hasWarned {

--- a/pkg/ebpf/tracer_linux.go
+++ b/pkg/ebpf/tracer_linux.go
@@ -105,18 +105,16 @@ func (pt *ProcessTracer) Run(
 	// Searches for traceable functions
 	trcrs := pt.Programs
 	wg := sync.WaitGroup{}
-	runningTracers := make([]tracerInstance, 0, len(trcrs))
-	for i := range trcrs {
-		idx := i
+	runningTracers := make([]*tracerInstance, 0, len(trcrs))
+	for idx := range trcrs {
 		t := trcrs[idx]
 		wg.Add(1)
-		runningTracers = append(runningTracers, tracerInstance{
-			implType: reflect.TypeOf(t).String(),
-		})
+		ti := &tracerInstance{implType: reflect.TypeOf(t).String()}
+		runningTracers = append(runningTracers, ti)
 		go func() {
 			defer wg.Done()
 			t.Run(ctx, ebpfEventContext, out)
-			runningTracers[idx].done.Store(true)
+			ti.done.Store(true)
 		}()
 	}
 
@@ -134,6 +132,12 @@ func (pt *ProcessTracer) Run(
 		select {
 		// notifying before OBI times out on finish
 		case <-time.After(3 * pt.shutdownTimeout / 4):
+			var runningTracerNames []string
+			for _, ti := range runningTracers {
+				if !ti.done.Load() {
+					runningTracerNames = append(runningTracerNames, ti.implType)
+				}
+			}
 			pt.log.Warn("some process tracers did not finish", "tracers", runningTracers)
 			hasWarned = true
 		case <-tracersEnded:

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -188,11 +188,41 @@ func New(
 func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 	p.pidsFilter.AllowPID(pid, ns, fi, ebpfcommon.PIDTypeGo)
 	p.registerRuntimeMetricTarget(pid, ns, fi)
+	p.registerOTelPIDMarker()
+}
+
+// registerOTelPIDMarker wires this tracer into the shared PIDs filter so that a
+// process detected (in userspace) to export its own OTel traces gets recorded
+// in go_sdk_tp_pids, suppressing OBI's duplicate traceparent injection.
+// This covers the case the in-kernel SDK-delegate detection misses: an app that
+// obtains its tracer after installing the SDK TracerProvider. Idempotent.
+func (p *Tracer) registerOTelPIDMarker() {
+	if pf, ok := p.pidsFilter.(*ebpfcommon.PIDsFilter); ok {
+		pf.SetOTelPIDMarker(p)
+	}
+}
+
+// MarkPIDWritesOwnTP implements ebpfcommon.OTelPIDMarker. The map key is the
+// host TGID, matching mark_pid_writes_own_tp() in bpf/gotracer/go_common.h.
+func (p *Tracer) MarkPIDWritesOwnTP(hostPID uint32) {
+	if p.bpfObjects.GoSdkTpPids != nil {
+		_ = p.bpfObjects.GoSdkTpPids.Put(hostPID, uint8(1))
+	}
 }
 
 func (p *Tracer) BlockPID(pid app.PID, ns uint32) {
 	p.deleteRuntimeMetricTarget(pid, ns)
+	p.deleteSDKTraceparentPID(pid)
 	p.pidsFilter.BlockPID(pid, ns)
+}
+
+// deleteSDKTraceparentPID removes the process from the go_sdk_tp_pids map when
+// it exits, so a reused PID cannot inherit a stale "skip traceparent injection"
+// flag. The map key is the host TGID, matching mark_pid_writes_own_tp().
+func (p *Tracer) deleteSDKTraceparentPID(pid app.PID) {
+	if p.bpfObjects.GoSdkTpPids != nil {
+		_ = p.bpfObjects.GoSdkTpPids.Delete(uint32(pid))
+	}
 }
 
 func (p *Tracer) supportsContextPropagation() bool {

--- a/pkg/internal/ebpf/gotracer/testdata/tpinjecttarget/main.go
+++ b/pkg/internal/ebpf/gotracer/testdata/tpinjecttarget/main.go
@@ -1,0 +1,126 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build ignore
+
+// Command tpinjecttarget is a small helper binary used by the gotracer
+// privileged test (TestGoSDKTraceparentNotDuplicated). On demand it issues an
+// HTTP/1 request that already carries its own `traceparent` to its own loopback
+// server, which reports how many `Traceparent` header values it received. Two
+// modes drive the two test scenarios:
+//
+//   - "SDK": the request is made under an OpenTelemetry Go SDK span (obtained
+//     BEFORE SetTracerProvider, so Start routes through global.(*tracer).Start,
+//     where OBI detects the SDK and marks the process). OBI must NOT add a
+//     second traceparent -> receiver sees 1.
+//   - "PLAIN": the request sets its own traceparent by hand, without ever
+//     touching the global tracer, so OBI does not detect an SDK and injects as
+//     usual -> receiver sees 2. This is the control that proves the injection
+//     path is active and the test can actually observe a duplicate.
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// A valid W3C traceparent used by the PLAIN (non-SDK) control mode.
+const staticTraceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+
+func main() {
+	// Obtain the tracer BEFORE installing the SDK provider so that, in SDK mode,
+	// Start() routes through global.(*tracer).Start (the uprobe where OBI
+	// detects the SDK). Obtaining it here does not create a span, so it does not
+	// mark the process on its own.
+	tracer := otel.Tracer("tpinjecttarget")
+
+	tp := sdktrace.NewTracerProvider()
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	// Loopback server that reports how many Traceparent header values arrived.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "%d", len(r.Header.Values("Traceparent")))
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "listen error: %v\n", err)
+		os.Exit(1)
+	}
+	go func() { _ = http.Serve(ln, mux) }()
+
+	url := "http://" + ln.Addr().String() + "/"
+
+	// Signal readiness only after the listener is up.
+	fmt.Println("READY")
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		switch scanner.Text() {
+		case "SDK":
+			report(doSDKRequest(tracer, url))
+		case "PLAIN":
+			report(doPlainRequest(url))
+		case "EXIT":
+			return
+		}
+	}
+}
+
+func report(count string, err error) {
+	if err != nil {
+		fmt.Printf("ERROR %v\n", err)
+		return
+	}
+	fmt.Printf("TP_COUNT=%s\n", count)
+}
+
+// doSDKRequest starts an SDK span (routing through global.(*tracer).Start ->
+// delegate) and lets the propagator write the span's traceparent.
+func doSDKRequest(tracer trace.Tracer, url string) (string, error) {
+	ctx, span := tracer.Start(context.Background(), "call")
+	defer span.End()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return "", err
+	}
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+	return do(req)
+}
+
+// doPlainRequest writes its own traceparent by hand, without any SDK span, so
+// OBI does not detect a self-instrumented process and injects as usual.
+func doPlainRequest(url string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Traceparent", staticTraceparent)
+	return do(req)
+}
+
+func do(req *http.Request) (string, error) {
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}

--- a/pkg/internal/ebpf/gotracer/tpinject_privileged_test.go
+++ b/pkg/internal/ebpf/gotracer/tpinject_privileged_test.go
@@ -1,0 +1,270 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && privileged_tests
+
+package gotracer
+
+import (
+	"bufio"
+	"context"
+	"debug/elf"
+	"io"
+	"log/slog"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	discexec "go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/config"
+	ebpftracer "go.opentelemetry.io/obi/pkg/ebpf"
+	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	"go.opentelemetry.io/obi/pkg/internal/goexec"
+	"go.opentelemetry.io/obi/pkg/internal/procs"
+	"go.opentelemetry.io/obi/pkg/obi"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+)
+
+// TestGoSDKTraceparentNotDuplicated is the end-to-end regression test for
+// GitHub issue #2732. It attaches the real gotracer to a live Go process that
+// issues an HTTP/1 request already carrying its own `traceparent`, and checks
+// how many `Traceparent` header values reach the loopback receiver:
+//
+//   - SDK mode (the fix): the request runs under an OTel SDK span, so OBI's
+//     in-kernel SDK-delegate detection marks the process and skips its uprobe
+//     injection — exactly ONE traceparent arrives.
+//   - PLAIN mode (control): the process writes its own traceparent without ever
+//     touching the SDK, so OBI does not detect it and injects as usual — TWO
+//     arrive. This proves the injection path is active and the test can observe
+//     a duplicate, so the SDK-mode "1" is meaningful and not a false pass.
+func TestGoSDKTraceparentNotDuplicated(t *testing.T) {
+	require.Equal(t, 0, os.Geteuid(), "privileged eBPF test must run as root")
+	require.NoError(t, rlimit.RemoveMemlock())
+
+	if !ebpfcommon.SupportsContextPropagationWithProbe(slog.Default()) {
+		t.Skip("kernel does not support bpf_probe_write_user context propagation (e.g. lockdown); skipping")
+	}
+
+	targetBin := buildTraceparentTarget(t)
+
+	t.Run("SDK-instrumented: no duplicate traceparent", func(t *testing.T) {
+		got := runTraceparentTarget(t, targetBin, "SDK")
+		assert.Equal(t, "1", got,
+			"with the SDK detected, OBI must not append a second traceparent")
+	})
+
+	t.Run("non-SDK control: OBI injects", func(t *testing.T) {
+		got := runTraceparentTarget(t, targetBin, "PLAIN")
+		assert.Equal(t, "2", got,
+			"a process not detected as SDK-instrumented still gets OBI's traceparent injected")
+	})
+}
+
+// buildTraceparentTarget compiles the self-contained SDK-instrumented helper
+// binary (testdata/tpinjecttarget). Its single source file carries a
+// `//go:build ignore` tag, so it is named explicitly to bypass the constraint.
+func buildTraceparentTarget(t *testing.T) string {
+	t.Helper()
+
+	bin := filepath.Join(t.TempDir(), "tpinjecttarget")
+	cmd := osexec.Command("go", "build", "-o", bin, "testdata/tpinjecttarget/main.go")
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "go build tpinjecttarget:\n%s", string(out))
+	return bin
+}
+
+// runTraceparentTarget starts the target, attaches the gotracer, sends the
+// given mode command ("SDK" or "PLAIN") and returns the number of Traceparent
+// headers the receiver reported.
+func runTraceparentTarget(t *testing.T, bin, mode string) string {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := osexec.CommandContext(ctx, bin)
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	stderr, err := cmd.StderrPipe()
+	require.NoError(t, err)
+
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_, _ = io.WriteString(stdin, "EXIT\n")
+		cancel()
+		_ = cmd.Wait()
+	})
+
+	stdoutLines := collectLines(t, "target stdout", stdout)
+	_ = collectLines(t, "target stderr", stderr)
+	waitForLine(t, stdoutLines, "READY", 30*time.Second)
+
+	attachGoTracer(t, app.PID(cmd.Process.Pid))
+
+	// Give the uprobes a moment to be effective before the first request.
+	time.Sleep(500 * time.Millisecond)
+
+	_, err = io.WriteString(stdin, mode+"\n")
+	require.NoError(t, err)
+
+	line := waitForLine(t, stdoutLines, "TP_COUNT=", 30*time.Second)
+	return strings.TrimPrefix(strings.TrimSpace(line), "TP_COUNT=")
+}
+
+// attachGoTracer wires up the real ProcessTracer with the gotracer against the
+// given PID, mirroring the production discovery/attach path.
+func attachGoTracer(t *testing.T, pid app.PID) {
+	t.Helper()
+
+	cfg := obi.DefaultConfig
+	cfg.LogLevel = obi.LogLevelDebug
+	cfg.EBPF.BpfDebug = true
+	cfg.EBPF.ContextPropagation = config.ContextPropagationAll
+
+	pidsFilter := ebpfcommon.NewPIDsFilter(&cfg.Discovery, slog.With("component", "tpinject-pids"), imetrics.NoopReporter{})
+	goTracer := New(pidsFilter, &cfg, imetrics.NoopReporter{})
+	eventContext := ebpfcommon.NewEBPFEventContext()
+	eventContext.CommonPIDsFilter = pidsFilter
+
+	processTracer := ebpftracer.NewProcessTracer(ebpftracer.Go, []ebpftracer.Tracer{goTracer}, &cfg, imetrics.NoopReporter{})
+	require.NoError(t, processTracer.Init(eventContext, &cfg))
+
+	fileInfo := goProcessFileInfo(t, pid)
+	offsets, err := goexec.InspectOffsets(fileInfo, goFunctionNames(&cfg))
+	require.NoError(t, err)
+
+	processTracer.AllowPID(pid, fileInfo.Ns(), fileInfo)
+
+	executable, err := link.OpenExecutable(fileInfo.ProExeLinkPath())
+	require.NoError(t, err)
+	require.NoError(t, processTracer.NewExecutable(executable, &ebpftracer.Instrumentable{
+		Type:     svc.InstrumentableGolang,
+		FileInfo: fileInfo,
+		Offsets:  offsets,
+	}))
+
+	spans := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(1))
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		processTracer.Run(runCtx, eventContext, spans)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Log("timed out waiting for gotracer ProcessTracer to stop")
+		}
+		spans.Close()
+	})
+}
+
+// goFunctionNames returns the union of Go symbols the gotracer probes, matching
+// the discovery typer's loadAllGoFunctionNames so offset resolution succeeds.
+func goFunctionNames(cfg *obi.Config) []string {
+	uniq := map[string]struct{}{}
+	var funcs []string
+	add := func(sym string) {
+		if _, ok := uniq[sym]; ok {
+			return
+		}
+		uniq[sym] = struct{}{}
+		funcs = append(funcs, sym)
+	}
+
+	tracer := New(nil, cfg, imetrics.NoopReporter{})
+	for sym := range tracer.GoProbes() {
+		add(sym)
+	}
+	for _, sym := range GoChannelLinkProbeSymbols() {
+		add(sym)
+	}
+	for _, sym := range GoRuntimeMetricProbeSymbols() {
+		add(sym)
+	}
+	return funcs
+}
+
+func goProcessFileInfo(t *testing.T, pid app.PID) *discexec.FileInfo {
+	t.Helper()
+
+	procExeLinkPath := "/proc/" + strconv.Itoa(int(pid)) + "/exe"
+	cmdExePath, err := os.Readlink(procExeLinkPath)
+	require.NoError(t, err)
+
+	info, err := os.Stat(procExeLinkPath)
+	require.NoError(t, err)
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+
+	ns, err := procs.FindNamespace(pid)
+	require.NoError(t, err)
+
+	// Go offset resolution (goexec.InspectOffsets) reads the executable's ELF,
+	// so it must be opened and attached to the FileInfo, just like the real
+	// discovery typer does.
+	elfFile, err := elf.Open(procExeLinkPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = elfFile.Close() })
+
+	return discexec.New(discexec.Init{
+		Service: svc.Attrs{
+			UID:         svc.UID{Name: "tpinject", Namespace: "integration-test"},
+			SDKLanguage: svc.InstrumentableGolang,
+		},
+		ELF:            elfFile,
+		CmdExePath:     cmdExePath,
+		ProExeLinkPath: procExeLinkPath,
+		Pid:            pid,
+		Dev:            uint64(stat.Dev),
+		Ino:            stat.Ino,
+		Ns:             ns,
+	})
+}
+
+func collectLines(t *testing.T, name string, r io.Reader) <-chan string {
+	t.Helper()
+	lines := make(chan string, 100)
+	go func() {
+		defer close(lines)
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			line := scanner.Text()
+			t.Logf("%s: %s", name, line)
+			lines <- line
+		}
+	}()
+	return lines
+}
+
+func waitForLine(t *testing.T, lines <-chan string, want string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case line, ok := <-lines:
+			require.Truef(t, ok, "process output closed before %q", want)
+			if strings.Contains(line, want) {
+				return line
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for process line containing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2732 .

For Go services that were already instrumented with the Go OTEL SDK, we were filtering out the metrics/traces at the userspace level. This was not preventing our kernel-side eBPF Go tracers to keep injecting the traceparent. This resulted on duplicate traceparent injection.

This PR maintains a map with the PIDs of these Go processes that should be injecting its own Traceparent, so we early abort any kernel-side operation regarding traceparent injection.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
