### PR TITLE
Fix gotracer_test.go in non-Linux environments

### DIFF
--- a/internal/test/integration/components/gokafka/no-promise/producer.go
+++ b/internal/test/integration/components/gokafka/no-promise/producer.go
@@ -21,9 +21,11 @@ type saramaLogger struct {
 func (l *saramaLogger) Printf(format string, v ...interface{}) {
 	l.logger.Info(fmt.Sprintf(format, v...))
 }
+
 func (l *saramaLogger) Println(v ...interface{}) {
 	l.logger.Info(fmt.Sprint(v...))
 }
+
 func (l *saramaLogger) Print(v ...interface{}) {
 	l.logger.Info(fmt.Sprint(v...))
 }
@@ -54,7 +56,6 @@ func CreateKafkaProducer(brokers []string, logger *slog.Logger) (sarama.AsyncPro
 	go func() {
 		for err := range producer.Errors() {
 			logger.Error(fmt.Sprintf("Failed to write message: %+v", err))
-
 		}
 	}()
 	return producer, nil

--- a/pkg/internal/ebpf/gotracer/gotracer_test.go
+++ b/pkg/internal/ebpf/gotracer/gotracer_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -138,6 +139,9 @@ func TestGoRuntimeMetricsUseHeapSnapshotProbe(t *testing.T) {
 }
 
 func TestGoRuntimeMetricsFallBackWhenHeapProbeIsMissing(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only test")
+	}
 	disableContextPropagationForTest(t)
 
 	var logs bytes.Buffer
@@ -167,6 +171,9 @@ func TestGoRuntimeMetricsFallBackWhenHeapProbeIsMissing(t *testing.T) {
 }
 
 func TestGoRuntimeMetricsUseResolvedHeapProbe(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Linux-only test")
+	}
 	disableContextPropagationForTest(t)
 
 	tracer := &Tracer{log: slog.New(slog.NewTextHandler(io.Discard, nil))}


### PR DESCRIPTION
## Summary

Skips two unit tests that failed on Mac because they assumed that the value that is returned by `os.Executable` were in ELF format.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
