### PR TITLE
bpf: fix verifier error in generictracer/kafka

### DIFF
--- a/bpf/generictracer/protocol_kafka.h
+++ b/bpf/generictracer/protocol_kafka.h
@@ -372,6 +372,9 @@ static __always_inline int kafka_send_large_buffer(tcp_req_t *req,
 
     if (!capture_in_progress) {
         // First chunk of the response: validate it against the pending request.
+        if (!correlation_data) {
+            return 0;
+        }
         const s32 correlation_id = kafka_read_response_correlation_id(state_data, u_buf, bytes_len);
         if (correlation_id != correlation_data->correlation_id) {
             bpf_dbg_printk("request correlation_id != response "

--- a/bpf/tests/bpf_kafka_large_buffer.c
+++ b/bpf/tests/bpf_kafka_large_buffer.c
@@ -488,6 +488,9 @@ int kafka_send_large_buffer(connection_info_t *conn,
 
     if (!capture_in_progress) {
         // First chunk of the response: validate it against the pending request.
+        if (!correlation_data) {
+            return 0;
+        }
         const s32 correlation_id = kafka_read_response_correlation_id(state_data, u_buf, bytes_len);
         if (correlation_id != correlation_data->correlation_id) {
             return 0;


### PR DESCRIPTION
## Summary

Fixes verifier error on AL2023

```
; if (state_data && state_data->message_size > 0 && (u32)state_data->message_size == bytes_len) {
25604: (6d) if r2 s> r1 goto pc+20    ; R1=scalar(umin=1,umax=2147483647,var_off=(0x0; 0x7fffffff)) R2=1
25605: (67) r1 <<= 32                 ; R1_w=scalar(umin=4294967296,umax=9223372032559808512,var_off=(0x0; 0x7fffffff00000000),s32_min=0,s32_max=0,u32_max=0)
25606: (77) r1 >>= 32                 ; R1_w=scalar(umin=1,umax=2147483647,var_off=(0x0; 0x7fffffff),s32_min=0)
25607: (5d) if r1 != r8 goto pc+17    ; R1_w=scalar(umin=1,umax=2147483647,var_off=(0x0; 0x7fffffff),s32_min=0) R8=scalar(id=1621,umin=1,umax=2147483647,var_off=(0x0; 0x7fffffff),s32_min=0)
25608: (18) r6 = 0xffffffff           ; R6_w=4294967295
25610: (b7) r1 = 4                    ; R1_w=4
; if (bytes_len < k_kafka_hdr_correlation_id) {
25611: (2d) if r1 > r8 goto pc+26     ; R1_w=4 R8=scalar(id=1621,umin=4,umax=2147483647,var_off=(0x0; 0x7fffffff))
25612: (bf) r1 = r10                  ; R1_w=fp0 R10=fp0
25613: (07) r1 += -176                ; R1_w=fp-176
; if (bpf_probe_read(&correlation_id, k_kafka_hdr_correlation_id, u_buf) != 0) {
25614: (b7) r2 = 4                    ; R2_w=4
25615: (79) r3 = *(u64 *)(r10 -200)   ; R3_w=scalar() R10=fp0
25616: (85) call bpf_probe_read#4     ; R0=scalar() fp-176=mmmmmmmm
; if (bpf_probe_read(&correlation_id, k_kafka_hdr_correlation_id, u_buf) != 0) {
25617: (15) if r0 == 0x0 goto pc+18   ; R0=scalar()
25618: (05) goto pc+19
; if (correlation_id != correlation_data->correlation_id) {
25638: (79) r1 = *(u64 *)(r10 -264)   ; R1_w=P0 R10=fp0
25639: (61) r3 = *(u32 *)(r1 +0)
R1 invalid mem access 'scalar'
processed 32680 insns (limit 1000000) max_states_per_insn 12 total_states 1852 peak_states 762 mark_read 187
```

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
