### PR TITLE
Go std net HTTP/1 clients: avoid injecting the traceparent twice

### DIFF
--- a/bpf/bpfcore/compiler.h
+++ b/bpf/bpfcore/compiler.h
@@ -33,15 +33,6 @@
 #define barrier_data(ptr) asm volatile("" : : "r"(ptr) : "memory")
 #endif
 
-// barrier_var makes the compiler treat var as an opaque value it can no longer
-// reason about at compile time. Useful before masking a value into a verifier
-// bound: without it the compiler may prove the mask is a no-op (because a prior
-// clamp already bounded the value) and delete the AND, leaving the verifier with
-// only a range fact that is lost across a stack spill/reload.
-#ifndef barrier_var
-#define barrier_var(var) asm volatile("" : "+r"(var))
-#endif
-
 /* The LOAD_CONSTANT macro is used to define a named constant that will be replaced
  * at runtime by the Go code. This replaces usage of a bpf_map for storing values, which
  * eliminates a bpf_map_lookup_elem per kprobe hit. The constants are best accessed with a

--- a/bpf/bpfcore/compiler.h
+++ b/bpf/bpfcore/compiler.h
@@ -33,6 +33,15 @@
 #define barrier_data(ptr) asm volatile("" : : "r"(ptr) : "memory")
 #endif
 
+// barrier_var makes the compiler treat var as an opaque value it can no longer
+// reason about at compile time. Useful before masking a value into a verifier
+// bound: without it the compiler may prove the mask is a no-op (because a prior
+// clamp already bounded the value) and delete the AND, leaving the verifier with
+// only a range fact that is lost across a stack spill/reload.
+#ifndef barrier_var
+#define barrier_var(var) asm volatile("" : "+r"(var))
+#endif
+
 /* The LOAD_CONSTANT macro is used to define a named constant that will be replaced
  * at runtime by the Go code. This replaces usage of a bpf_map for storing values, which
  * eliminates a bpf_map_lookup_elem per kprobe hit. The constants are best accessed with a

--- a/bpf/common/http_buf_size.h
+++ b/bpf/common/http_buf_size.h
@@ -8,3 +8,5 @@ enum { k_kprobes_http2_ret_buf_size = 64 };
 
 // should be enough for most URLs, we may need to extend it if not.
 #define TRACE_BUF_SIZE 1024 // must be power of 2, we do an & to limit the buffer size
+
+_Static_assert((TRACE_BUF_SIZE & (TRACE_BUF_SIZE - 1)) == 0, "TRACE_BUF_SIZE must be a power of 2");

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -930,6 +930,11 @@ client_request_has_traceparent(void *buf_ptr,
         return false;
     }
 
+    unsigned char *scan = (unsigned char *)tp_char_buf_mem();
+    if (!scan) {
+        return false;
+    }
+
     // region = bytes writeSubset wrote; return_n <= size guarantees it stays
     // within the buffer. Clamp to the scratch buffer capacity as well.
     s64 region = return_n - entry_n;
@@ -941,22 +946,7 @@ client_request_has_traceparent(void *buf_ptr,
     if (region > (s64)(TRACE_BUF_SIZE - 1)) {
         region = TRACE_BUF_SIZE - 1;
     }
-    // The masking operation is not necessary,
-    // but prevents BPF verifier errors in Kernels <= 6.6.
-    // barrier_var is essential: without it the compiler sees the clamp above
-    // already proved region <= TRACE_BUF_SIZE-1, folds the mask to a no-op and
-    // deletes it, so the un-masked s64 reaches bpf_probe_read_user and the <= 6.6
-    // verifier rejects it ("R2 unbounded memory access") because the range fact is
-    // lost across the stack spill/reload. The barrier hides the compile-time
-    // bound so the AND survives and gives the verifier a var_off it keeps.
-    barrier_var(region);
     const u32 uregion = (u32)region & (TRACE_BUF_SIZE - 1);
-
-    unsigned char *scan = (unsigned char *)tp_char_buf_mem();
-    if (!scan) {
-        return false;
-    }
-
     if (bpf_probe_read_user(scan, uregion, (void *)(buf_ptr + (u32)entry_n)) != 0) {
         return false;
     }

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -942,7 +942,14 @@ client_request_has_traceparent(void *buf_ptr,
         region = TRACE_BUF_SIZE - 1;
     }
     // The masking operation is not necessary,
-    // but prevents BPF verifier errors in Kernels <= 6.6
+    // but prevents BPF verifier errors in Kernels <= 6.6.
+    // barrier_var is essential: without it the compiler sees the clamp above
+    // already proved region <= TRACE_BUF_SIZE-1, folds the mask to a no-op and
+    // deletes it, so the un-masked s64 reaches bpf_probe_read_user and the <= 6.6
+    // verifier rejects it ("R2 unbounded memory access") because the range fact is
+    // lost across the stack spill/reload. The barrier hides the compile-time
+    // bound so the AND survives and gives the verifier a var_off it keeps.
+    barrier_var(region);
     const u32 uregion = (u32)region & (TRACE_BUF_SIZE - 1);
 
     unsigned char *scan = (unsigned char *)tp_char_buf_mem();

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -941,7 +941,9 @@ client_request_has_traceparent(void *buf_ptr,
     if (region > (s64)(TRACE_BUF_SIZE - 1)) {
         region = TRACE_BUF_SIZE - 1;
     }
-    const u32 uregion = (u32)region;
+    // The masking operation is not necessary,
+    // but prevents BPF verifier errors in Kernels <= 6.6
+    const u32 uregion = (u32)region & (TRACE_BUF_SIZE - 1);
 
     unsigned char *scan = (unsigned char *)tp_char_buf_mem();
     if (!scan) {
@@ -951,7 +953,7 @@ client_request_has_traceparent(void *buf_ptr,
     if (bpf_probe_read_user(scan, uregion, (void *)(buf_ptr + (u32)entry_n)) != 0) {
         return false;
     }
-    scan[uregion & (TRACE_BUF_SIZE - 1)] = '\0';
+    scan[uregion] = '\0';
 
     // Direct (not indirect) calls so the untaken branch is const-folded away per
     // program instantiation, keeping the bpf_loop subprog out of the legacy one.

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -943,10 +943,8 @@ client_request_has_traceparent(void *buf_ptr,
     if (region <= 0) {
         return false;
     }
-    if (region > (s64)(TRACE_BUF_SIZE - 1)) {
-        region = TRACE_BUF_SIZE - 1;
-    }
-    const u32 uregion = (u32)region & (TRACE_BUF_SIZE - 1);
+    bpf_clamp_umax(region, TRACE_BUF_SIZE - 1);
+    const u32 uregion = (u32)region;
     if (bpf_probe_read_user(scan, uregion, (void *)(buf_ptr + (u32)entry_n)) != 0) {
         return false;
     }

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -816,7 +816,29 @@ done:
     return 0;
 }
 
-// Context propagation through HTTP headers
+// Context propagation through HTTP headers.
+//
+// The uprobe pair below implements the HTTP/1 client traceparent injection. The
+// application's own traceparent (e.g. written by the OTel SDK via
+// req.Header.Set) is serialized by writeSubset itself, so it is only present in
+// the io.Writer buffer once writeSubset returns. We therefore stash the writer
+// on entry and, on return, scan the header block writeSubset just wrote for an
+// existing traceparent: if one is present we must not add a second one
+// otherwise we inject ours at the current write position.
+typedef struct write_subset_invocation {
+    u64 io_writer_addr;
+    u64 req_goaddr; // request (parent) goroutine, key into ongoing_client_connections
+    tp_info_t tp;
+    s64 entry_n; // io.Writer write offset at entry (start of this header block)
+} write_subset_invocation_t;
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, go_addr_key_t); // the writeSubset goroutine
+    __type(value, write_subset_invocation_t);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+} ongoing_write_subsets SEC(".maps");
+
 SEC("uprobe/header_writeSubset")
 int obi_uprobe_writeSubset(struct pt_regs *ctx) {
     void *goroutine_addr = GOROUTINE_PTR(ctx);
@@ -835,7 +857,7 @@ int obi_uprobe_writeSubset(struct pt_regs *ctx) {
 
     bpf_dbg_printk("goroutine_addr=%lx, header_addr=%llx", goroutine_addr, header_addr);
 
-    // we don't want to run this code when we header or the buffer is nil
+    // we don't want to run this code when the header or the buffer is nil
     if (!header_addr || !io_writer_addr) {
         goto done;
     }
@@ -860,11 +882,82 @@ int obi_uprobe_writeSubset(struct pt_regs *ctx) {
         goto done;
     }
 
-    unsigned char buf[k_traceparent_len];
+    const u64 io_writer_n_pos = go_offset_of(ot, (go_offset){.v = _io_writer_n_pos});
+    if (!io_writer_n_pos) {
+        goto done;
+    }
 
-    make_tp_string(buf, &func_inv->tp);
+    // Record the write offset at entry: the header block writeSubset is about
+    // to serialize (where the app's own traceparent would land) starts here.
+    // The io.Writer is a *bufio.Writer, whose backing array is allocated once
+    // and never grown (it flushes and resets n when full, never append/realloc),
+    // so this offset stays valid into a stable buffer at return. The only thing
+    // that invalidates it is a Flush() mid-writeSubset (huge header sets), which
+    // resets n to 0; the return probe handles that (return_n <= entry_n) and all
+    // its reads stay bounded within the buffer regardless.
+    s64 entry_n = 0;
+    bpf_probe_read(&entry_n, sizeof(entry_n), (void *)(io_writer_addr + io_writer_n_pos));
 
-    void *buf_ptr = 0;
+    write_subset_invocation_t inv = {
+        .io_writer_addr = (u64)io_writer_addr,
+        .req_goaddr = parent_goaddr,
+        .tp = func_inv->tp,
+        .entry_n = entry_n,
+    };
+    bpf_map_update_elem(&ongoing_write_subsets, &gw_key, &inv, BPF_ANY);
+
+done:
+    bpf_map_delete_elem(&header_req_map, &header_addr);
+    return 0;
+}
+
+// client_request_has_traceparent scans the header block that writeSubset just
+// serialized ([entry_n, return_n)) for an existing traceparent header, reusing
+// the same primitive as the server-side extraction.
+static __always_inline bool
+client_request_has_traceparent(void *buf_ptr, s64 entry_n, s64 return_n) {
+    if (return_n <= entry_n) {
+        return false;
+    }
+
+    u32 region = (u32)(return_n - entry_n);
+    bpf_clamp_umax(region, TRACE_BUF_SIZE - 1);
+
+    unsigned char *scan = (unsigned char *)tp_char_buf_mem();
+    if (!scan) {
+        return false;
+    }
+
+    if (bpf_probe_read_user(scan, region, (void *)(buf_ptr + (entry_n & 0xffff))) != 0) {
+        return false;
+    }
+    scan[region & (TRACE_BUF_SIZE - 1)] = '\0';
+
+    unsigned char *found = g_bpf_loop_enabled ? bpf_strstr_tp_loop(scan, (u16)region)
+                                              : bpf_strstr_tp_loop__legacy(scan, (u16)region);
+    return found != NULL;
+}
+
+SEC("uprobe/header_writeSubset_returns")
+int obi_uprobe_writeSubset_returns(struct pt_regs *ctx) {
+    if (!g_bpf_header_propagation) {
+        return 0;
+    }
+
+    void *goroutine_addr = GOROUTINE_PTR(ctx);
+    go_addr_key_t gw_key = {};
+    go_addr_key_from_id(&gw_key, goroutine_addr);
+
+    write_subset_invocation_t *inv = bpf_map_lookup_elem(&ongoing_write_subsets, &gw_key);
+    if (!inv) {
+        return 0;
+    }
+
+    bpf_dbg_printk("=== uprobe/header_writeSubset_returns ===");
+
+    off_table_t *ot = get_offsets_table();
+    void *io_writer_addr = (void *)inv->io_writer_addr;
+
     const u64 io_writer_buf_ptr_pos = go_offset_of(ot, (go_offset){.v = _io_writer_buf_ptr_pos});
     const u64 io_writer_n_pos = go_offset_of(ot, (go_offset){.v = _io_writer_n_pos});
 
@@ -873,6 +966,7 @@ int obi_uprobe_writeSubset(struct pt_regs *ctx) {
         goto done;
     }
 
+    void *buf_ptr = 0;
     bpf_probe_read(&buf_ptr, sizeof(buf_ptr), (void *)(io_writer_addr + io_writer_buf_ptr_pos));
     if (!buf_ptr) {
         goto done;
@@ -885,13 +979,23 @@ int obi_uprobe_writeSubset(struct pt_regs *ctx) {
         (void *)(io_writer_addr + io_writer_buf_ptr_pos + k_go_slice_len_offset)); // grab size
 
     s64 len = 0;
-    bpf_probe_read(&len, sizeof(s64),
-                   (void *)(io_writer_addr + io_writer_n_pos)); // grab len
+    bpf_probe_read(&len,
+                   sizeof(s64),
+                   (void *)(io_writer_addr + io_writer_n_pos)); // grab len (return offset)
 
-    bpf_dbg_printk("buf_ptr=%llx, len=%d, size=%d", (void *)buf_ptr, len, size);
+    bpf_dbg_printk("buf_ptr=%llx, entry_n=%d, len=%d", (void *)buf_ptr, inv->entry_n, len);
 
-    if (len <
-        (size - TP_MAX_VAL_LENGTH - TP_MAX_KEY_LENGTH - 4)) { // 4 = strlen(":_") + strlen("\r\n")
+    // If the application already wrote its own traceparent, don't add a second.
+    if (client_request_has_traceparent(buf_ptr, inv->entry_n, len)) {
+        bpf_dbg_printk("client request already carries a traceparent, skipping injection");
+        goto done;
+    }
+
+    unsigned char buf[k_traceparent_len];
+    make_tp_string(buf, &inv->tp);
+
+    if (len >= 0 && len < (size - TP_MAX_VAL_LENGTH - TP_MAX_KEY_LENGTH -
+                           4)) { // 4 = strlen(":_") + strlen("\r\n")
         char key[TP_MAX_KEY_LENGTH + 2] = "Traceparent: ";
         char end[2] = "\r\n";
         bpf_probe_write_user(buf_ptr + (len & 0x0ffff), key, sizeof(key));
@@ -908,6 +1012,8 @@ int obi_uprobe_writeSubset(struct pt_regs *ctx) {
         // If this code ran, we should ensure that the second part doesn't run, therefore
         // we remove the metadata setup in uprobe_persistConnRoundTrip(struct pt_regs *ctx), so
         // that approach 2. skips this packet.
+        go_addr_key_t g_key = {};
+        go_addr_key_from_id(&g_key, (void *)inv->req_goaddr);
         connection_info_t *info = bpf_map_lookup_elem(&ongoing_client_connections, &g_key);
         if (info) {
             egress_key_t e_key = {
@@ -926,7 +1032,7 @@ int obi_uprobe_writeSubset(struct pt_regs *ctx) {
     }
 
 done:
-    bpf_map_delete_elem(&header_req_map, &header_addr);
+    bpf_map_delete_elem(&ongoing_write_subsets, &gw_key);
     return 0;
 }
 

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -896,7 +896,10 @@ int obi_uprobe_writeSubset(struct pt_regs *ctx) {
     // resets n to 0; the return probe handles that (return_n <= entry_n) and all
     // its reads stay bounded within the buffer regardless.
     s64 entry_n = 0;
-    bpf_probe_read(&entry_n, sizeof(entry_n), (void *)(io_writer_addr + io_writer_n_pos));
+    if (bpf_probe_read_user(
+            &entry_n, sizeof(entry_n), (void *)(io_writer_addr + io_writer_n_pos)) != 0) {
+        goto done;
+    }
 
     write_subset_invocation_t inv = {
         .io_writer_addr = (u64)io_writer_addr,
@@ -913,33 +916,57 @@ done:
 
 // client_request_has_traceparent scans the header block that writeSubset just
 // serialized ([entry_n, return_n)) for an existing traceparent header, reusing
-// the same primitive as the server-side extraction.
+// the same primitive as the server-side extraction. All offsets are validated
+// and the scan is clamped to both the scratch buffer and the bytes actually
+// present in the writer buffer, so the read can never run past the buffer.
+// tp_loop_fn selects the scan implementation (bpf_loop vs legacy) at load time.
 static __always_inline bool
-client_request_has_traceparent(void *buf_ptr, s64 entry_n, s64 return_n) {
-    if (return_n <= entry_n) {
+client_request_has_traceparent(void *buf_ptr,
+                               s64 entry_n,
+                               s64 return_n,
+                               s64 size,
+                               unsigned char *(*tp_loop_fn)(unsigned char *, const u16)) {
+    if (entry_n < 0 || return_n <= entry_n || return_n > size) {
         return false;
     }
 
-    u32 region = (u32)(return_n - entry_n);
-    bpf_clamp_umax(region, TRACE_BUF_SIZE - 1);
+    // region = bytes writeSubset wrote; return_n <= size guarantees it stays
+    // within the buffer. Clamp to the scratch buffer capacity as well.
+    s64 region = return_n - entry_n;
+
+    // this check is redundant but otherwise the verifier complains
+    if (region <= 0) {
+        return false;
+    }
+    if (region > (s64)(TRACE_BUF_SIZE - 1)) {
+        region = TRACE_BUF_SIZE - 1;
+    }
+    const u32 uregion = (u32)region;
 
     unsigned char *scan = (unsigned char *)tp_char_buf_mem();
     if (!scan) {
         return false;
     }
 
-    if (bpf_probe_read_user(scan, region, (void *)(buf_ptr + (entry_n & 0xffff))) != 0) {
+    if (bpf_probe_read_user(scan, uregion, (void *)(buf_ptr + (u32)entry_n)) != 0) {
         return false;
     }
-    scan[region & (TRACE_BUF_SIZE - 1)] = '\0';
+    scan[uregion & (TRACE_BUF_SIZE - 1)] = '\0';
 
-    unsigned char *found = g_bpf_loop_enabled ? bpf_strstr_tp_loop(scan, (u16)region)
-                                              : bpf_strstr_tp_loop__legacy(scan, (u16)region);
+    // Direct (not indirect) calls so the untaken branch is const-folded away per
+    // program instantiation, keeping the bpf_loop subprog out of the legacy one.
+    unsigned char *found = NULL;
+    if (tp_loop_fn == bpf_strstr_tp_loop) {
+        found = bpf_strstr_tp_loop(scan, (u16)uregion);
+    } else {
+        found = bpf_strstr_tp_loop__legacy(scan, (u16)uregion);
+    }
     return found != NULL;
 }
 
-SEC("uprobe/header_writeSubset_returns")
-int obi_uprobe_writeSubset_returns(struct pt_regs *ctx) {
+static __always_inline int on_writeSubset_returns(struct pt_regs *ctx,
+                                                  unsigned char *(*tp_loop_fn)(unsigned char *,
+                                                                               const u16)) {
     if (!g_bpf_header_propagation) {
         return 0;
     }
@@ -967,26 +994,36 @@ int obi_uprobe_writeSubset_returns(struct pt_regs *ctx) {
     }
 
     void *buf_ptr = 0;
-    bpf_probe_read(&buf_ptr, sizeof(buf_ptr), (void *)(io_writer_addr + io_writer_buf_ptr_pos));
-    if (!buf_ptr) {
+    if (bpf_probe_read_user(
+            &buf_ptr, sizeof(buf_ptr), (void *)(io_writer_addr + io_writer_buf_ptr_pos)) != 0 ||
+        !buf_ptr) {
         goto done;
     }
 
-    s64 size = 0;
-    bpf_probe_read(
-        &size,
-        sizeof(s64),
-        (void *)(io_writer_addr + io_writer_buf_ptr_pos + k_go_slice_len_offset)); // grab size
+    s64 size = 0; // len(buf) of the bufio.Writer; for bufio len == cap == capacity
+    if (bpf_probe_read_user(
+            &size,
+            sizeof(size),
+            (void *)(io_writer_addr + io_writer_buf_ptr_pos + k_go_slice_len_offset)) != 0) {
+        goto done;
+    }
 
-    s64 len = 0;
-    bpf_probe_read(&len,
-                   sizeof(s64),
-                   (void *)(io_writer_addr + io_writer_n_pos)); // grab len (return offset)
+    s64 len = 0; // current write offset (return position)
+    if (bpf_probe_read_user(&len, sizeof(len), (void *)(io_writer_addr + io_writer_n_pos)) != 0) {
+        goto done;
+    }
+
+    // Sanity-check the writer bounds before touching the buffer: a negative or
+    // out-of-range write offset (e.g. after a bufio flush reset) means we can't
+    // reason about the buffer, so skip rather than risk a bad access.
+    if (size <= 0 || len < 0 || len > size) {
+        goto done;
+    }
 
     bpf_dbg_printk("buf_ptr=%llx, entry_n=%d, len=%d", (void *)buf_ptr, inv->entry_n, len);
 
     // If the application already wrote its own traceparent, don't add a second.
-    if (client_request_has_traceparent(buf_ptr, inv->entry_n, len)) {
+    if (client_request_has_traceparent(buf_ptr, inv->entry_n, len, size, tp_loop_fn)) {
         bpf_dbg_printk("client request already carries a traceparent, skipping injection");
         goto done;
     }
@@ -994,8 +1031,8 @@ int obi_uprobe_writeSubset_returns(struct pt_regs *ctx) {
     unsigned char buf[k_traceparent_len];
     make_tp_string(buf, &inv->tp);
 
-    if (len >= 0 && len < (size - TP_MAX_VAL_LENGTH - TP_MAX_KEY_LENGTH -
-                           4)) { // 4 = strlen(":_") + strlen("\r\n")
+    if (len <
+        (size - TP_MAX_VAL_LENGTH - TP_MAX_KEY_LENGTH - 4)) { // 4 = strlen(":_")+strlen("\r\n")
         char key[TP_MAX_KEY_LENGTH + 2] = "Traceparent: ";
         char end[2] = "\r\n";
         bpf_probe_write_user(buf_ptr + (len & 0x0ffff), key, sizeof(key));
@@ -1034,6 +1071,22 @@ int obi_uprobe_writeSubset_returns(struct pt_regs *ctx) {
 done:
     bpf_map_delete_elem(&ongoing_write_subsets, &gw_key);
     return 0;
+}
+
+// Two variants of the return probe: the default uses bpf_loop; the _legacy one
+// uses a bounded scan for kernels without bpf_loop. FixupSpec swaps the default
+// for the legacy on those kernels (and dummies the legacy elsewhere), mirroring
+// obi_uprobe_readMimeHeader / obi_protocol_http. This keeps the bpf_loop subprog
+// out of the program loaded on pre-5.17 kernels, which would otherwise reject it
+// with "number of funcs in func_info doesn't match number of subprogs".
+SEC("uprobe/header_writeSubset_returns")
+int obi_uprobe_writeSubset_returns(struct pt_regs *ctx) {
+    return on_writeSubset_returns(ctx, bpf_strstr_tp_loop);
+}
+
+SEC("uprobe/header_writeSubset_returns_legacy")
+int obi_uprobe_writeSubset_returns_legacy(struct pt_regs *ctx) {
+    return on_writeSubset_returns(ctx, bpf_strstr_tp_loop__legacy);
 }
 
 // HTTP 2.0 server support

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -694,12 +694,25 @@ func FixupSpec(spec *ebpf.CollectionSpec, overrideKernelVersion bool) {
 		if _, ok := spec.Programs["obi_uprobe_readMimeHeader"]; ok {
 			spec.Programs["obi_uprobe_readMimeHeader"] = dummy
 		}
+
+		// gotracer's HTTP/1 client traceparent injection scans the request
+		// headers with a bpf_loop in obi_uprobe_writeSubset_returns. Swap it for
+		// the bounded-scan legacy variant so the bpf_loop subprog isn't part of
+		// the program loaded on kernels without bpf_loop (same func_info issue as
+		// obi_uprobe_readMimeHeader above).
+		if _, ok := spec.Programs["obi_uprobe_writeSubset_returns_legacy"]; ok {
+			spec.Programs["obi_uprobe_writeSubset_returns"] = spec.Programs["obi_uprobe_writeSubset_returns_legacy"]
+			spec.Programs["obi_uprobe_writeSubset_returns"].Name = "obi_uprobe_writeSubset_returns"
+		}
 	}
 
 	// Slot dummies in place of the legacy programs we already moved, so the
 	// bpf2go struct binding still resolves them.
 	spec.Programs["obi_protocol_http_legacy"] = dummy
 	spec.Programs["obi_continue_protocol_http_legacy"] = dummy
+	if _, ok := spec.Programs["obi_uprobe_writeSubset_returns_legacy"]; ok {
+		spec.Programs["obi_uprobe_writeSubset_returns_legacy"] = dummy
+	}
 }
 
 // Injectable for tests

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -1133,7 +1133,8 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 
 	if p.supportsContextPropagation() {
 		m["net/http.Header.writeSubset"] = []*ebpfcommon.ProbeDesc{{
-			Start: p.bpfObjects.ObiUprobeWriteSubset, // http 1.x context propagation
+			Start: p.bpfObjects.ObiUprobeWriteSubset,        // http 1.x context propagation
+			End:   p.bpfObjects.ObiUprobeWriteSubsetReturns, // inject only if no traceparent present
 		}}
 		m["golang.org/x/net/http2.(*Framer).WriteHeaders"] = []*ebpfcommon.ProbeDesc{
 			{ // http2 context propagation

--- a/pkg/internal/ebpf/gotracer/testdata/tphttpclient/main.go
+++ b/pkg/internal/ebpf/gotracer/testdata/tphttpclient/main.go
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build ignore
+
+// Command tphttpclient is a helper binary for the gotracer HTTP/1 traceparent
+// injection privileged test. It issues an HTTP/1 request to its own loopback
+// server, which reports how many `Traceparent` header values it received. Two
+// modes exercise the two scenarios:
+//
+//   - "WITH_TP": the client sets its own Traceparent header (as an SDK or a
+//     hand-rolled propagator would). OBI must NOT add a second one -> the
+//     receiver sees exactly 1.
+//   - "NO_TP": the client sets no Traceparent. OBI injects its own -> the
+//     receiver sees exactly 1 (proving injection still happens when absent).
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+)
+
+// A valid W3C traceparent used by the WITH_TP mode.
+const staticTraceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "%d", len(r.Header.Values("Traceparent")))
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "listen error: %v\n", err)
+		os.Exit(1)
+	}
+	go func() { _ = http.Serve(ln, mux) }()
+
+	// http:// with the default transport keeps this on HTTP/1.1, exercising
+	// OBI's net/http header_writeSubset injection path.
+	url := "http://" + ln.Addr().String() + "/"
+
+	fmt.Println("READY")
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		switch scanner.Text() {
+		case "WITH_TP":
+			report(doRequest(url, true))
+		case "NO_TP":
+			report(doRequest(url, false))
+		case "EXIT":
+			return
+		}
+	}
+}
+
+func report(count string, err error) {
+	if err != nil {
+		fmt.Printf("ERROR %v\n", err)
+		return
+	}
+	fmt.Printf("TP_COUNT=%s\n", count)
+}
+
+func doRequest(url string, withTraceparent bool) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return "", err
+	}
+	if withTraceparent {
+		req.Header.Set("Traceparent", staticTraceparent)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}

--- a/pkg/internal/ebpf/gotracer/tphttp_privileged_test.go
+++ b/pkg/internal/ebpf/gotracer/tphttp_privileged_test.go
@@ -1,0 +1,264 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && privileged_tests
+
+package gotracer
+
+import (
+	"bufio"
+	"context"
+	"debug/elf"
+	"io"
+	"log/slog"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	discexec "go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/config"
+	ebpftracer "go.opentelemetry.io/obi/pkg/ebpf"
+	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	"go.opentelemetry.io/obi/pkg/internal/goexec"
+	"go.opentelemetry.io/obi/pkg/internal/procs"
+	"go.opentelemetry.io/obi/pkg/obi"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+)
+
+// TestHTTP1ClientTraceparentNotDuplicated attaches the eBPF gotracer to a live Go process that
+// issues an HTTP/1 request to its own loopback server, and checks how many
+// `Traceparent` header values reach the receiver:
+//
+//   - WITH_TP: the client already wrote its own traceparent, so OBI must skip
+//     injection -> exactly ONE arrives (before the fix this was TWO).
+//   - NO_TP: no traceparent present, so OBI injects -> exactly ONE arrives,
+//     proving injection still happens when the header is absent.
+func TestHTTP1ClientTraceparentNotDuplicated(t *testing.T) {
+	require.Equal(t, 0, os.Geteuid(), "privileged eBPF test must run as root")
+	require.NoError(t, rlimit.RemoveMemlock())
+
+	if !ebpfcommon.SupportsContextPropagationWithProbe(slog.Default()) {
+		t.Skip("kernel does not support bpf_probe_write_user context propagation (e.g. lockdown); skipping")
+	}
+
+	targetBin := buildHTTPClientTarget(t)
+
+	t.Run("client already has traceparent: no duplicate", func(t *testing.T) {
+		got := runHTTPClientTarget(t, targetBin, "WITH_TP")
+		assert.Equal(t, "1", got,
+			"OBI must not append a second traceparent when the client already wrote one")
+	})
+
+	t.Run("no traceparent present: OBI injects", func(t *testing.T) {
+		got := runHTTPClientTarget(t, targetBin, "NO_TP")
+		assert.Equal(t, "1", got,
+			"OBI must still inject a traceparent when the client didn't write one")
+	})
+}
+
+// buildHTTPClientTarget compiles the self-contained helper binary. Its single
+// source file carries a `//go:build ignore` tag, so it is named explicitly to
+// bypass the constraint.
+func buildHTTPClientTarget(t *testing.T) string {
+	t.Helper()
+
+	bin := filepath.Join(t.TempDir(), "tphttpclient")
+	cmd := osexec.Command("go", "build", "-o", bin, "testdata/tphttpclient/main.go")
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "go build tphttpclient:\n%s", string(out))
+	return bin
+}
+
+// runHTTPClientTarget starts the target, attaches the gotracer, sends the given
+// mode command and returns the number of Traceparent headers the receiver saw.
+func runHTTPClientTarget(t *testing.T, bin, mode string) string {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := osexec.CommandContext(ctx, bin)
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	stderr, err := cmd.StderrPipe()
+	require.NoError(t, err)
+
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_, _ = io.WriteString(stdin, "EXIT\n")
+		cancel()
+		_ = cmd.Wait()
+	})
+
+	stdoutLines := collectClientLines(t, "target stdout", stdout)
+	_ = collectClientLines(t, "target stderr", stderr)
+	waitForClientLine(t, stdoutLines, "READY", 30*time.Second)
+
+	attachGoTracer(t, app.PID(cmd.Process.Pid))
+
+	// Give the uprobes a moment to be effective before the first request.
+	time.Sleep(500 * time.Millisecond)
+
+	_, err = io.WriteString(stdin, mode+"\n")
+	require.NoError(t, err)
+
+	line := waitForClientLine(t, stdoutLines, "TP_COUNT=", 30*time.Second)
+	return strings.TrimPrefix(strings.TrimSpace(line), "TP_COUNT=")
+}
+
+// attachGoTracer wires up the real ProcessTracer with the gotracer against the
+// given PID, mirroring the production discovery/attach path.
+func attachGoTracer(t *testing.T, pid app.PID) {
+	t.Helper()
+
+	cfg := obi.DefaultConfig
+	cfg.LogLevel = obi.LogLevelDebug
+	cfg.EBPF.BpfDebug = true
+	cfg.EBPF.ContextPropagation = config.ContextPropagationAll
+
+	pidsFilter := ebpfcommon.NewPIDsFilter(&cfg.Discovery, slog.With("component", "tphttp-pids"), imetrics.NoopReporter{})
+	goTracer := New(pidsFilter, &cfg, imetrics.NoopReporter{})
+	eventContext := ebpfcommon.NewEBPFEventContext()
+	eventContext.CommonPIDsFilter = pidsFilter
+
+	processTracer := ebpftracer.NewProcessTracer(ebpftracer.Go, []ebpftracer.Tracer{goTracer}, &cfg, imetrics.NoopReporter{})
+	require.NoError(t, processTracer.Init(eventContext, &cfg))
+
+	fileInfo := goProcessFileInfo(t, pid)
+	offsets, err := goexec.InspectOffsets(fileInfo, goFunctionNames(&cfg))
+	require.NoError(t, err)
+
+	processTracer.AllowPID(pid, fileInfo.Ns(), fileInfo)
+
+	executable, err := link.OpenExecutable(fileInfo.ProExeLinkPath())
+	require.NoError(t, err)
+	require.NoError(t, processTracer.NewExecutable(executable, &ebpftracer.Instrumentable{
+		Type:     svc.InstrumentableGolang,
+		FileInfo: fileInfo,
+		Offsets:  offsets,
+	}))
+
+	spans := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(1))
+	runCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		processTracer.Run(runCtx, eventContext, spans)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Log("timed out waiting for gotracer ProcessTracer to stop")
+		}
+		spans.Close()
+	})
+}
+
+// goFunctionNames returns the union of Go symbols the gotracer probes, matching
+// the discovery typer's loadAllGoFunctionNames so offset resolution succeeds.
+func goFunctionNames(cfg *obi.Config) []string {
+	uniq := map[string]struct{}{}
+	var funcs []string
+	add := func(sym string) {
+		if _, ok := uniq[sym]; ok {
+			return
+		}
+		uniq[sym] = struct{}{}
+		funcs = append(funcs, sym)
+	}
+
+	tracer := New(nil, cfg, imetrics.NoopReporter{})
+	for sym := range tracer.GoProbes() {
+		add(sym)
+	}
+	for _, sym := range GoChannelLinkProbeSymbols() {
+		add(sym)
+	}
+	for _, sym := range GoRuntimeMetricProbeSymbols() {
+		add(sym)
+	}
+	return funcs
+}
+
+func goProcessFileInfo(t *testing.T, pid app.PID) *discexec.FileInfo {
+	t.Helper()
+
+	procExeLinkPath := "/proc/" + strconv.Itoa(int(pid)) + "/exe"
+	cmdExePath, err := os.Readlink(procExeLinkPath)
+	require.NoError(t, err)
+
+	info, err := os.Stat(procExeLinkPath)
+	require.NoError(t, err)
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+
+	ns, err := procs.FindNamespace(pid)
+	require.NoError(t, err)
+
+	// Go offset resolution (goexec.InspectOffsets) reads the executable's ELF,
+	// so it must be opened and attached to the FileInfo, like the real typer.
+	elfFile, err := elf.Open(procExeLinkPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = elfFile.Close() })
+
+	return discexec.New(discexec.Init{
+		Service: svc.Attrs{
+			UID:         svc.UID{Name: "tphttp", Namespace: "integration-test"},
+			SDKLanguage: svc.InstrumentableGolang,
+		},
+		ELF:            elfFile,
+		CmdExePath:     cmdExePath,
+		ProExeLinkPath: procExeLinkPath,
+		Pid:            pid,
+		Dev:            uint64(stat.Dev),
+		Ino:            stat.Ino,
+		Ns:             ns,
+	})
+}
+
+func collectClientLines(t *testing.T, name string, r io.Reader) <-chan string {
+	t.Helper()
+	lines := make(chan string, 100)
+	go func() {
+		defer close(lines)
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			line := scanner.Text()
+			t.Logf("%s: %s", name, line)
+			lines <- line
+		}
+	}()
+	return lines
+}
+
+func waitForClientLine(t *testing.T, lines <-chan string, want string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case line, ok := <-lines:
+			require.Truef(t, ok, "process output closed before %q", want)
+			if strings.Contains(line, want) {
+				return line
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for process line containing %q", want)
+		}
+	}
+}

--- a/pkg/internal/ebpf/gotracer/tphttp_privileged_test.go
+++ b/pkg/internal/ebpf/gotracer/tphttp_privileged_test.go
@@ -56,18 +56,21 @@ func TestHTTP1ClientTraceparentNotDuplicated(t *testing.T) {
 	}
 
 	targetBin := buildHTTPClientTarget(t)
+	send := startHTTPClientTarget(t, targetBin)
 
-	t.Run("client already has traceparent: no duplicate", func(t *testing.T) {
-		got := runHTTPClientTarget(t, targetBin, "WITH_TP")
-		assert.Equal(t, "1", got,
-			"OBI must not append a second traceparent when the client already wrote one")
-	})
+	// Readiness: instead of a fixed sleep, poll until OBI's injection is
+	// effective. NO_TP returns "1" only once the uprobe is attached and
+	// injecting, so this doubles as the "OBI still injects" assertion and
+	// guarantees the probe is live before the no-duplicate check below.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, "1", send(t, "NO_TP"),
+			"OBI must inject a traceparent when the client didn't write one")
+	}, 20*time.Second, 200*time.Millisecond)
 
-	t.Run("no traceparent present: OBI injects", func(t *testing.T) {
-		got := runHTTPClientTarget(t, targetBin, "NO_TP")
-		assert.Equal(t, "1", got,
-			"OBI must still inject a traceparent when the client didn't write one")
-	})
+	// With injection confirmed live, a client that already wrote its own
+	// traceparent must not get a second one appended.
+	assert.Equal(t, "1", send(t, "WITH_TP"),
+		"OBI must not append a second traceparent when the client already wrote one")
 }
 
 // buildHTTPClientTarget compiles the self-contained helper binary. Its single
@@ -83,9 +86,11 @@ func buildHTTPClientTarget(t *testing.T) string {
 	return bin
 }
 
-// runHTTPClientTarget starts the target, attaches the gotracer, sends the given
-// mode command and returns the number of Traceparent headers the receiver saw.
-func runHTTPClientTarget(t *testing.T, bin, mode string) string {
+// startHTTPClientTarget starts the target, attaches the gotracer, and returns a
+// send function that issues one request in the given mode ("WITH_TP"/"NO_TP")
+// and returns the number of Traceparent headers the receiver reported. The
+// target loops over stdin, so send can be called repeatedly (e.g. for polling).
+func startHTTPClientTarget(t *testing.T, bin string) func(t *testing.T, mode string) string {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -110,14 +115,13 @@ func runHTTPClientTarget(t *testing.T, bin, mode string) string {
 
 	attachGoTracer(t, app.PID(cmd.Process.Pid))
 
-	// Give the uprobes a moment to be effective before the first request.
-	time.Sleep(500 * time.Millisecond)
-
-	_, err = io.WriteString(stdin, mode+"\n")
-	require.NoError(t, err)
-
-	line := waitForClientLine(t, stdoutLines, "TP_COUNT=", 30*time.Second)
-	return strings.TrimPrefix(strings.TrimSpace(line), "TP_COUNT=")
+	return func(t *testing.T, mode string) string {
+		t.Helper()
+		_, err := io.WriteString(stdin, mode+"\n")
+		require.NoError(t, err)
+		line := waitForClientLine(t, stdoutLines, "TP_COUNT=", 30*time.Second)
+		return strings.TrimPrefix(strings.TrimSpace(line), "TP_COUNT=")
+	}
 }
 
 // attachGoTracer wires up the real ProcessTracer with the gotracer against the
@@ -242,6 +246,11 @@ func collectClientLines(t *testing.T, name string, r io.Reader) <-chan string {
 			line := scanner.Text()
 			t.Logf("%s: %s", name, line)
 			lines <- line
+		}
+		// Surface read errors (broken pipe/truncation) so failures show up as a
+		// diagnosable log line rather than an opaque waitForClientLine timeout.
+		if err := scanner.Err(); err != nil {
+			t.Logf("%s scanner error: %v", name, err)
 		}
 	}()
 	return lines


### PR DESCRIPTION
## Summary

This is the first PR of a series that would fix issue #2732 (duplicate traceparent in SDK instrumented workloads) at different levels/protocol.

This PR fixes the issue for Go standard `net` package (HTTP/1) clients. It adds a uprobe to the return address of header_writeSubset: when headers are written in the request, we check for a header containing `Traceparent:`. If it already exists, we abort the context propagation. Otherwise we inject the `Traceparent:` header.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
