### PR TITLE
Fix bpf verifier rejection of jvm runtime metrics on older arm64 kernels

### DIFF
--- a/bpf/generictracer/jvm.c
+++ b/bpf/generictracer/jvm.c
@@ -7,9 +7,9 @@
 #include <bpfcore/bpf_builtins.h>
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/bpf_tracing.h>
+#include <bpfcore/utils.h>
 
 #include <generictracer/jvm.h>
-#include <common/algorithm.h>
 #include <common/event_defs.h>
 #include <common/ringbuf.h>
 #include <logger/bpf_dbg.h>
@@ -62,7 +62,8 @@ jvm_read_usdt_string(unsigned char *dst, const unsigned char *src, long src_len)
         return -1;
     }
 
-    const u32 max_len = (u32)min((long)(k_jvm_raw_string_len - 1), src_len);
+    u32 max_len = (u32)src_len;
+    bpf_clamp_umax(max_len, k_jvm_raw_string_len - 1);
     if (bpf_probe_read_user(dst, max_len, src) != 0) {
         return -1;
     }


### PR DESCRIPTION
## Summary

This PR fixes the following bpf verifier error found on kernel version 6.8.0-13 (arm64):
```
; if (!src || src_len <= 0) {
9091: (79) r1 = *(u64 *)(r10 -208)    ; R1_w=scalar() R10=fp0 fp-208=mmmmmmmm
9092: (15) if r1 == 0x0 goto pc+13    ; R1_w=scalar(umin=1)
9093: (b7) r1 = 1                     ; R1_w=1
9094: (79) r2 = *(u64 *)(r10 -216)    ; R2=scalar() R10=fp0 fp-216=mmmmmmmm
9095: (6d) if r1 s> r2 goto pc+10     ; R1=1 R2=scalar(smin=umin=1,umax=0x7fffffffffffffff,var_off=(0x0; 0x7fffffffffffffff))
;
9096: (bf) r1 = r10                   ; R1_w=fp0 R10=fp0
9097: (07) r1 += -96                  ; R1_w=fp-96
9098: (b7) r3 = 63                    ; R3_w=63
9099: (79) r4 = *(u64 *)(r10 -216)    ; R4_w=scalar() R10=fp0 fp-216=mmmmmmmm
9100: (bf) r2 = r4                    ; R2_w=scalar(id=199) R4_w=scalar(id=199)
; return a < b ? a : b;
9101: (6d) if r3 s> r4 goto pc+1 9103: R0=0 R1=fp-96 R2=scalar(id=199,smax=62) R3=63 R4=scalar(id=199,smax=62) R6=map_value(map=obi_usdt_specs,ks=4,vs=208,off=112) R7=112 R8=map_value(map=obi_usdt_specs,ks=4,vs=208,off=124) R9=scalar(id=193) R10=fp0 fp-16=mmmmmmmm fp-24=mmmmmmmm fp-32=????mmmm fp-40=0 fp-48=0 fp-56=0 fp-64=0 fp-72=0 fp-80=0 fp-88=0 fp-96=0 fp-104=0mmmmmmm fp-112=mmmmmmmm fp-120=mmmmmmmm fp-128=mmmmmmmm fp-136=mmmmmmmm fp-144=mmmmmmmm fp-152=mmmmmmmm fp-160=mmmmmmmm fp-168=0000mmmm fp-176=ctx() fp-184=0xfffffffc fp-192=mmmmmmmm fp-200=scalar(id=2,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) fp-208=mmmmmmmm fp-216=mmmmmmmm fp-224=scalar(smin=umin=umin32=1,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) fp-232=mmmmmmmm fp-240=mmmmmmmm fp-248=mmmmmmmm fp-256=mmmmmmmm fp-264=mmmmmmmm fp-272=mmmmmmmm fp-280=fp-168
; if (bpf_probe_read_user(dst, max_len, src) != 0) {
9103: (79) r3 = *(u64 *)(r10 -208)    ; R3_w=scalar() R10=fp0 fp-208=mmmmmmmm
9104: (85) call bpf_probe_read_user#112
R2 min value is negative, either use unsigned or 'var &= const'

```

Note: CI is green on main despite the bug because the kernel-matrix verifier jobs are amd64-only and verify the amd64 object, while the only arm64 verifier job runs on the GitHub runner's host kernel which currently is 6.17 (6.17.0-1020-azure) whose verifier accepts this bytecode.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
