### PR TITLE
Limit HTTP request capture to payload length

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -84,7 +84,7 @@ jobs:
         run: make prereqs
 
       - name: Run checks
-        run: make go-mod-tidy license-header-check notices-update check-go-mod check-ebpf-ver-synced check-config-schema check-config-v2-artifacts check-clean-work-tree
+        run: make go-mod-tidy test-bpf license-header-check notices-update check-go-mod check-ebpf-ver-synced check-config-schema check-config-v2-artifacts check-clean-work-tree
 
   clang-format:
     name: Clang format

--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ docker-generate:
 		make generate
 
 .PHONY: verify
-verify: prereqs go-mod-tidy lint test license-header-check
+verify: prereqs go-mod-tidy lint test test-bpf license-header-check
 
 .PHONY: build
 build: docker-generate verify compile
@@ -318,6 +318,11 @@ compile-cache-for-coverage:
 test:
 	@echo "### Testing code"
 	KUBEBUILDER_ASSETS="$(shell go tool $(TOOLS_MODFILE) setup-envtest use $(ENVTEST_K8S_VERSION) -p path)" go test -short -race -a ./... -coverpkg=./... -coverprofile $(TEST_OUTPUT)/cover.all.txt
+
+.PHONY: test-bpf
+test-bpf:
+	@echo "### Testing BPF helpers"
+	$(MAKE) -C bpf/tests test
 
 .PHONY: test-privileged
 test-privileged: $(ENVTEST)

--- a/bpf/generictracer/http_request_buffer.h
+++ b/bpf/generictracer/http_request_buffer.h
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/bpf_helpers.h>
+#include <bpfcore/utils.h>
+
+#include <common/http_types.h>
+
+static __always_inline int capture_http_request_buffer(http_info_t *info,
+                                                       const call_protocol_args_t *args) {
+    u32 capture_len = (u32)args->bytes_len;
+    bpf_clamp_umax(capture_len, sizeof(info->buf));
+
+    const int err = bpf_probe_read(info->buf, capture_len, (void *)args->u_buf);
+    if (err) {
+        __builtin_memcpy(info->buf, args->small_buf, sizeof(args->small_buf));
+    }
+
+    return err;
+}

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -25,6 +25,7 @@
 
 #include <generictracer/maps/http_info_mem.h>
 
+#include <generictracer/http_request_buffer.h>
 #include <generictracer/k_tracer_tailcall.h>
 #include <generictracer/large_buf_tailcall.h>
 #include <generictracer/protocol_common.h>
@@ -402,9 +403,11 @@ static __always_inline int __obi_continue2_protocol_http(struct pt_regs *ctx,
         bpf_dbg_printk("No META!");
     }
 
-    // we copy some small part of the buffer to the info trace event, so that we can process an event even with
+    // We copy part of the buffer to the info trace event so that we can process an event even with
     // incomplete trace info in user space.
-    bpf_probe_read(info->buf, FULL_BUF_SIZE, (void *)args->u_buf);
+    if (capture_http_request_buffer(info, args)) {
+        bpf_dbg_printk("Failed to capture HTTP request buffer, using protocol prefix");
+    }
     process_http_request(
         info, args->bytes_len, meta, args->direction, args->orig_dport, args->lw_thread);
 

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -10,6 +10,10 @@ all: $(targets)
 %: %.c
 	$(CC) $(CFLAGS) -o $@ $< $(LFLAGS)
 
+.PHONY: test
+test: bpf_http_request_buffer
+	@trap '$(RM) bpf_http_request_buffer' EXIT; ./bpf_http_request_buffer
+
 .PHONY: clean
 clean:
 	rm -f $(targets)

--- a/bpf/tests/bpf_http_request_buffer.c
+++ b/bpf/tests/bpf_http_request_buffer.c
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <bpfcore/bpf_helpers.h>
+
+enum { k_short_request_len = 74 };
+
+static long test_probe_read(void *dst, unsigned int size, const void *src);
+
+#define bpf_probe_read test_probe_read
+#include <generictracer/http_request_buffer.h>
+#undef bpf_probe_read
+
+static unsigned int probe_read_size;
+static unsigned int probe_read_source_size;
+static int probe_read_failure;
+
+static void assert_int_eq(int expected, int actual, const char *message) {
+    if (expected != actual) {
+        fprintf(stderr, "FAIL: %s\n  expected %d, got %d\n", message, expected, actual);
+        exit(1);
+    }
+}
+
+static void
+assert_mem_eq(const void *expected, const void *actual, size_t size, const char *message) {
+    if (memcmp(expected, actual, size) != 0) {
+        fprintf(stderr, "FAIL: %s\n", message);
+        exit(1);
+    }
+}
+
+static long test_probe_read(void *dst, unsigned int size, const void *src) {
+    probe_read_size = size;
+    if (probe_read_failure || size > probe_read_source_size) {
+        memset(dst, 0, size);
+        return -1;
+    }
+
+    memcpy(dst, src, size);
+    return 0;
+}
+
+static call_protocol_args_t protocol_args_for(unsigned char *buf, int len) {
+    probe_read_source_size = (unsigned int)len;
+
+    call_protocol_args_t args = {
+        .bytes_len = len,
+        .u_buf = (u64)buf,
+    };
+
+    const size_t prefix_len =
+        len < (int)sizeof(args.small_buf) ? (size_t)len : sizeof(args.small_buf);
+    memcpy(args.small_buf, buf, prefix_len);
+
+    return args;
+}
+
+static void reset(void) {
+    probe_read_size = 0;
+    probe_read_source_size = 0;
+    probe_read_failure = 0;
+}
+
+static void test_short_request_uses_payload_length(void) {
+    reset();
+    unsigned char request[k_short_request_len] = "GET / HTTP/1.1\r\nHost: google.com\r\n";
+    call_protocol_args_t args = protocol_args_for(request, sizeof(request));
+    http_info_t info = {};
+
+    const int err = capture_http_request_buffer(&info, &args);
+
+    assert_int_eq(0, err, "short request capture succeeds");
+    assert_int_eq(sizeof(request), probe_read_size, "short request read is bounded by payload");
+    assert_mem_eq(request, info.buf, sizeof(request), "short request payload is preserved");
+}
+
+static void test_large_request_uses_destination_size(void) {
+    reset();
+    unsigned char request[FULL_BUF_SIZE + 1] = "GET / HTTP/1.1\r\n";
+    call_protocol_args_t args = protocol_args_for(request, sizeof(request));
+    http_info_t info = {};
+
+    const int err = capture_http_request_buffer(&info, &args);
+
+    assert_int_eq(0, err, "large request capture succeeds");
+    assert_int_eq(FULL_BUF_SIZE, probe_read_size, "large request read is capped by destination");
+    assert_mem_eq(request, info.buf, FULL_BUF_SIZE, "large request prefix is preserved");
+}
+
+static void test_failed_read_preserves_protocol_prefix(void) {
+    reset();
+    unsigned char request[k_short_request_len] = "GET / HTTP/1.1\r\nHost: google.com\r\n";
+    call_protocol_args_t args = protocol_args_for(request, sizeof(request));
+    http_info_t info = {};
+    probe_read_failure = 1;
+
+    const int err = capture_http_request_buffer(&info, &args);
+
+    assert_int_eq(-1, err, "failed request capture returns the helper error");
+    assert_int_eq(sizeof(request), probe_read_size, "failed request read remains bounded");
+    assert_mem_eq(args.small_buf,
+                  info.buf,
+                  sizeof(args.small_buf),
+                  "failed request capture preserves the protocol prefix");
+}
+
+int main(void) {
+    test_short_request_uses_payload_length();
+    test_large_request_uses_destination_size();
+    test_failed_read_preserves_protocol_prefix();
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- bound the generic HTTP request-buffer read to the reported payload length
- retain the validated protocol prefix if the bounded helper read still fails
- add a PR-blocking native BPF regression test for short, capped, and failed reads

## Root cause

The Java TLS agent forwards exact-sized plaintext buffers through its ioctl
path. The generic HTTP tail stage nevertheless always asked `bpf_probe_read`
for the full 256-byte trace buffer. For the 74-byte `GET /` and 104-byte
`GET /greeting` requests used by OATS, that read could cross the readable
allocation boundary. A failed probe read zeroed the destination, so user space
received an HTTP record without a method and span metrics failed Weaver's
required `http.request.method` validation.

Whether the fixed-size over-read reached unreadable memory depended on the
adjacent allocation and page layout, which explains why identical main builds
could pass or fail and why retry failure counts varied.

This change reads `min(bytes_len, sizeof(info->buf))`. The 24-byte prefix that
already classified the payload as HTTP is retained as a best-effort fallback
if the bounded read fails for another reason.

## Validation

- generated the complete amd64 and arm64 BPF translations
- passed the native BPF regression test and license-header checks
- passed clang-format and clang-tidy for the changed production translation unit
- passed `run-oats_java_tls_jdk_8` with Weaver validation
- passed `run-oats_java_tls_sync_async` five times with Weaver validation
- confirmed every sync/async run emitted the 74-byte Google request as `GET /`
  with `http.request.method=GET`
- completed independent adversarial reviews focused on eBPF verifier safety,
  test/CI correctness, and root-cause alternatives
