### PR TITLE
fix empty java tls empty method

### DIFF
--- a/bpf/common/http_types.h
+++ b/bpf/common/http_types.h
@@ -5,6 +5,7 @@
 
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_helpers.h>
+#include <bpfcore/utils.h>
 
 #include <common/connection_info.h>
 #include <common/http_buf_size.h>
@@ -59,6 +60,12 @@ typedef struct call_protocol_args {
     u64 self_ref_parent_id;
     lw_thread_t lw_thread;
 } call_protocol_args_t;
+
+static __always_inline void read_request_buf(http_info_t *info, const call_protocol_args_t *args) {
+    u32 info_buf_len = (u32)args->bytes_len;
+    bpf_clamp_umax(info_buf_len, FULL_BUF_SIZE);
+    bpf_probe_read(info->buf, info_buf_len, (void *)args->u_buf);
+}
 
 // Here we keep information on the packets passing through the socket filter
 typedef struct protocol_info {

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -404,7 +404,7 @@ static __always_inline int __obi_continue2_protocol_http(struct pt_regs *ctx,
 
     // we copy some small part of the buffer to the info trace event, so that we can process an event even with
     // incomplete trace info in user space.
-    bpf_probe_read(info->buf, FULL_BUF_SIZE, (void *)args->u_buf);
+    read_request_buf(info, args);
     process_http_request(
         info, args->bytes_len, meta, args->direction, args->orig_dport, args->lw_thread);
 

--- a/bpf/tests/bpf_http_request_buf_read.c
+++ b/bpf/tests/bpf_http_request_buf_read.c
@@ -1,0 +1,103 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <bpfcore/bpf_helpers.h>
+
+static long test_probe_read(void *dst, unsigned int size, const void *src);
+
+#define bpf_probe_read test_probe_read
+#include <common/http_types.h>
+#undef bpf_probe_read
+
+static unsigned int test_last_read_size;
+static const char *test_src_base;
+static unsigned int test_src_len;
+static int test_read_faulted;
+
+static long test_probe_read(void *dst, unsigned int size, const void *src) {
+    test_last_read_size = size;
+    const unsigned int off = (unsigned int)((const char *)src - test_src_base);
+    if (off + size > test_src_len) {
+        test_read_faulted = 1;
+        return -1;
+    }
+    test_read_faulted = 0;
+    memcpy(dst, src, size);
+    return 0;
+}
+
+static void assert_true(int cond, const char *message) {
+    if (!cond) {
+        fprintf(stderr, "FAIL: %s\n", message);
+        exit(1);
+    }
+}
+
+static void assert_uint_eq(unsigned int expected, unsigned int actual, const char *message) {
+    if (expected != actual) {
+        fprintf(stderr, "FAIL: %s\n  expected %u, got %u\n", message, expected, actual);
+        exit(1);
+    }
+}
+
+static call_protocol_args_t args_for(const char *payload, unsigned int readable, int bytes_len) {
+    test_src_base = payload;
+    test_src_len = readable;
+    test_read_faulted = 0;
+    test_last_read_size = 0;
+
+    call_protocol_args_t args = {0};
+    args.bytes_len = bytes_len;
+    args.u_buf = (u64)(uintptr_t)payload;
+    return args;
+}
+
+static void test_short_request_line_is_fully_copied(void) {
+    const char payload[] = "GET /greeting HTTP/1.1\r\n";
+    const unsigned int len = (unsigned int)strlen(payload);
+    http_info_t info = {0};
+    call_protocol_args_t args = args_for(payload, len, (int)len);
+
+    read_request_buf(&info, &args);
+
+    assert_uint_eq(len, test_last_read_size, "read is clamped down to the payload length");
+    assert_true(!test_read_faulted, "clamped read stays within the payload and does not fault");
+    assert_true(memcmp(info.buf, "GET ", 4) == 0, "method survives the copy");
+}
+
+static void test_unclamped_read_would_have_faulted(void) {
+    const char payload[] = "GET /greeting HTTP/1.1\r\n";
+    const unsigned int len = (unsigned int)strlen(payload);
+    unsigned char dst[FULL_BUF_SIZE] = {0};
+    test_src_base = payload;
+    test_src_len = len;
+
+    test_probe_read(dst, FULL_BUF_SIZE, payload);
+
+    assert_true(test_read_faulted, "the pre-fix fixed-size read over-reads and faults");
+}
+
+static void test_oversized_payload_is_clamped_to_capacity(void) {
+    char payload[FULL_BUF_SIZE * 4];
+    memset(payload, 'a', sizeof(payload));
+    http_info_t info = {0};
+    call_protocol_args_t args = args_for(payload, sizeof(payload), (int)sizeof(payload));
+
+    read_request_buf(&info, &args);
+
+    assert_uint_eq(FULL_BUF_SIZE, test_last_read_size, "read never exceeds info->buf capacity");
+    assert_true(!test_read_faulted, "capacity-clamped read does not fault");
+}
+
+int main(void) {
+    test_short_request_line_is_fully_copied();
+    test_unclamped_read_would_have_faulted();
+    test_oversized_payload_is_clamped_to_capacity();
+
+    return 0;
+}

--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -373,6 +373,36 @@ func TestMethodURLParsing(t *testing.T) {
 	assert.Empty(t, httpURLFromBuf(i.Buf[:]))
 }
 
+func TestHTTPRequestToSpanMethodFromSSLBuffer(t *testing.T) {
+	newSSLEvent := func(buf []uint8) *BPFHTTPInfo {
+		event := makeBPFInfoWithBuf(buf)
+		event.Ssl = 1
+		event.Type = uint8(request.EventTypeHTTPClient)
+		event.ConnInfo.S_port = 34567
+		event.ConnInfo.D_port = 443
+		return &event
+	}
+
+	t.Run("short request line is enough to recover the method", func(t *testing.T) {
+		event := newSSLEvent([]uint8("GET /greeting HTTP/1.1\r\n"))
+		span := httpRequestToSpan(event, largebuf.NewLargeBufferFrom(event.Buf[:]))
+		assert.Equal(t, "GET", span.Method)
+		assert.Equal(t, "/greeting", span.Path)
+	})
+
+	t.Run("minimal method token still recovers the method", func(t *testing.T) {
+		event := newSSLEvent([]uint8("GET /"))
+		span := httpRequestToSpan(event, largebuf.NewLargeBufferFrom(event.Buf[:]))
+		assert.Equal(t, "GET", span.Method)
+	})
+
+	t.Run("zeroed buffer yields empty method", func(t *testing.T) {
+		event := newSSLEvent(nil)
+		span := httpRequestToSpan(event, largebuf.NewLargeBufferFrom(event.Buf[:]))
+		assert.Empty(t, span.Method)
+	})
+}
+
 func makeHTTPInfo(method, path, peer, host string, peerPort, hostPort uint32, status uint16, durationMs uint64) HTTPInfo {
 	bpfInfo := BPFHTTPInfo{
 		Type:            1,


### PR DESCRIPTION
## Summary

Fix intermittently missing `http.request.method` on HTTP metrics/spans for Java TLS traffic.

The request-line copy in `__obi_continue2_protocol_http` read a fixed `FULL_BUF_SIZE` (256) bytes from the user buffer:

```c
bpf_probe_read(info->buf, FULL_BUF_SIZE, (void *)args->u_buf);
```

`bpf_probe_read` is all-or-nothing. This is the only `FULL_BUF_SIZE`-sized read in the BPF tree that is not clamped to the actual payload length (every other buffer read clamps first, e.g. the sibling `small_buf` read in `k_tracer_defs.h`). The Java TLS ioctl path (`java_tls.c`) is the one ingress that hands over a tightly sized, flat user buffer with only the first and last byte validated as readable. When a request's first captured chunk is short (a bare request line + a few headers) and sits near the end of a mapped page, reading a fixed 256 bytes straddles an unmapped page, faults, and copies nothing — leaving `info->buf` zeroed. `httpMethodFromBuf` then finds no space in the buffer and returns an empty method, so `Span.Method == ""`.

The generic kprobe path reads kernel skb memory and the OpenSSL uprobe path reads the app's slack-padded heap buffer, so an over-read there lands in mapped memory and the method survives. That is why the loss is Java-TLS-specific and intermittent (depends on the payload's position relative to a page boundary): most spans carry `http.request.method`, some don't, and the empty-method datapoints propagate into the aggregated `http.server.*` / `http.client.*` metrics.

### Change

- Extract the copy into a small `read_request_buf()` helper in `bpf/common/http_types.h` that clamps the read to `args->bytes_len` before `bpf_probe_read`, mirroring the existing `small_buf` idiom. For the Java path `bytes_len == max_len` (already validated readable), so the read can never fault; for every other path reading `min(bytes_len, FULL_BUF_SIZE)` is strictly more correct.
- `protocol_http.h` calls the helper.
- Add a BPF C regression test (`bpf/tests/bpf_http_request_buf_read.c`) that models the kernel all-or-nothing `bpf_probe_read`: a short request line is fully copied under the clamp, the pre-fix fixed-size read faults on that same buffer, and an oversized payload clamps to capacity.
- Add a Go regression test asserting a short SSL request buffer still recovers the method.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
