### PR TITLE
run BPF tests in CI

### DIFF
--- a/.github/workflows/bpf_unit_tests.yml
+++ b/.github/workflows/bpf_unit_tests.yml
@@ -1,0 +1,42 @@
+name: BPF unit tests
+
+on:
+  push:
+    branches: [main, release-*]
+  pull_request:
+    branches: [main, release-*]
+    paths:
+      - ".github/workflows/bpf_unit_tests.yml"
+      - "bpf/**"
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref (commit, branch, or tag) to check out"
+        required: false
+        type: string
+
+concurrency:
+  group: pr-bpf-unit-tests-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  bpf-unit-tests:
+    name: BPF unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Install clang
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+
+      - name: Run BPF unit tests
+        run: make -C bpf/tests test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -118,24 +118,6 @@ jobs:
             exit 1
           fi
 
-  bpf-unit-tests:
-    name: BPF unit tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-          persist-credentials: false
-
-      - name: Install clang
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang
-
-      - name: Run BPF unit tests
-        run: make -C bpf/tests test
-
   clang-tidy:
     name: Clang tidy
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -118,6 +118,24 @@ jobs:
             exit 1
           fi
 
+  bpf-unit-tests:
+    name: BPF unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Install clang
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+
+      - name: Run BPF unit tests
+        run: make -C bpf/tests test
+
   clang-tidy:
     name: Clang tidy
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,16 @@ jobs:
     with:
       ref: ${{ inputs.tag || github.ref_name }}
 
+  bpf-unit-tests:
+    name: BPF unit tests
+    uses: ./.github/workflows/bpf_unit_tests.yml
+    needs: validate-tag
+    permissions:
+      contents: read
+    secrets: inherit # zizmor: ignore[secrets-inherit]
+    with:
+      ref: ${{ inputs.tag || github.ref_name }}
+
   integration-tests:
     name: Integration tests
     uses: ./.github/workflows/pull_request_integration_tests.yml
@@ -274,6 +284,7 @@ jobs:
       - unit-tests
       - unit-tests-privileged
       - bpf-verifier
+      - bpf-unit-tests
       - integration-tests
       - integration-tests-arm
       - k8s-integration-tests

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -10,6 +10,11 @@ all: $(targets)
 %: %.c
 	$(CC) $(CFLAGS) -o $@ $< $(LFLAGS)
 
+.PHONY: test
+test: $(targets)
+	@set -e; for t in $(targets); do echo "### running $$t"; ./$$t; done
+	@echo "All BPF unit tests passed"
+
 .PHONY: clean
 clean:
 	rm -f $(targets)


### PR DESCRIPTION
## Summary

Run the `bpf/tests` C unit tests in CI.

The `bpf/tests` directory holds native C unit tests for BPF-side logic (`bpf_ssl_read_guard`, `bpf_http2_preface_bounds`, `bpf_kafka_large_buffer`, `bpf_postgres_detection`, `bpf_float64`, `test_trace_util`, `test_large_buffer_loop`, `test_failed_connect_event`), compiled natively against the `bpf/tests/bpfcore` stubs. Nothing ran them: no workflow referenced the directory, and its `Makefile` only compiled the binaries (the `all` / `%: %.c` rules never execute them). As a result these tests provided no automated protection.

### Change

- Add a `test` target to `bpf/tests/Makefile` that compiles **and runs** every test binary, failing on the first non-zero exit.
- Add a dedicated `.github/workflows/bpf_unit_tests.yml` workflow (ubuntu, install clang, `make -C bpf/tests test`), mirroring the `bpf_verifier.yml` pattern and scoped via `paths:` to `bpf/**` (and the workflow file), so it only runs when BPF sources change rather than on every code PR.

Newly added C tests (e.g. those introduced alongside BPF fixes) are then covered automatically.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
