### PR TITLE
bpf: restore HTTP server span context on SQL query return

### DIFF
--- a/bpf/gotracer/go_sql.c
+++ b/bpf/gotracer/go_sql.c
@@ -25,6 +25,8 @@
 
 #include <gotracer/go_common.h>
 #include <gotracer/go_str.h>
+#include <gotracer/maps/nethttp.h>
+#include <gotracer/types/nethttp.h>
 
 #include <maps/go_sql.h>
 
@@ -331,7 +333,18 @@ static __always_inline int process_sql_return(void *goroutine_addr, u8 error, u8
         return 0;
     }
     bpf_map_delete_elem(&ongoing_sql_queries, &g_key);
-    obi_ctx__del(bpf_get_current_pid_tgid());
+
+    // Restore the enclosing HTTP server span's context instead of clearing
+    // it: obi_ctx__del alone would wipe it whenever this SQL query ran
+    // inside an HTTP handler, dropping trace_id/span_id from any log line
+    // written after the query returns.
+    server_http_func_invocation_t *http_inv =
+        bpf_map_lookup_elem(&ongoing_http_server_requests, &g_key);
+    if (http_inv) {
+        obi_ctx__set(bpf_get_current_pid_tgid(), &http_inv->tp);
+    } else {
+        obi_ctx__del(bpf_get_current_pid_tgid());
+    }
 
     sql_request_trace_t *trace = bpf_ringbuf_reserve(&events, sizeof(sql_request_trace_t), 0);
     if (trace) {


### PR DESCRIPTION
## Summary

`process_sql_return()` in `go_sql.c` calls `obi_ctx__del()` unconditionally when a SQL query returns, clearing `traces_ctx_v1[pid_tgid]` regardless of whether an outer server span (HTTP) was still active on that goroutine.

`traces_ctx_v1` (`bpf/shared/obi_ctx.h`) is keyed only by `pid_tgid`, with no notion of nesting depth. So when a SQL query runs inside an HTTP handler, a very common shape such as logging the response after the query that built it, this unconditional delete clobbers the outer HTTP server span's context too. Any log line the handler writes after the query returns never gets `trace_id`/`span_id` injected by the log enricher (`ebpf.log_enricher`), even though the HTTP span is still active.

## Fix

Before clearing the context, look up `ongoing_http_server_requests` for the current goroutine. If an HTTP server invocation is still ongoing, restore its context instead of clearing it.

## Testing

Verified against a Go (gin + gorm + Postgres) service with `ebpf.log_enricher` enabled: log lines written after a request that runs a SQL query now get `trace_id`/`span_id` injected.