### PR TITLE
Basic (incremental) support for Deno JS runtime

### DIFF
--- a/internal/test/integration/components/nodejsserver/Dockerfile_deno
+++ b/internal/test/integration/components/nodejsserver/Dockerfile_deno
@@ -1,4 +1,4 @@
-FROM denoland/deno:2.9.4
+FROM denoland/deno:2.9.4@sha256:c777b4b225501a61074837e90a826a58f99124837824023cd60334b1e2374498
 
 # Set the working directory to /build
 WORKDIR /

--- a/internal/test/integration/components/nodejsserver/Dockerfile_deno
+++ b/internal/test/integration/components/nodejsserver/Dockerfile_deno
@@ -1,0 +1,16 @@
+FROM denoland/deno:2.9.4
+
+# Set the working directory to /build
+WORKDIR /
+
+# Copy the source code into the image for building
+COPY internal/test/integration/components/nodejsserver .
+
+# Install npm deps into node_modules from package.json/lockfile
+RUN deno install --allow-scripts
+
+EXPOSE 3030
+EXPOSE 3033
+
+# Deno needs explicit permissions; -A grants all (fine for a test container)
+CMD [ "deno", "run", "-A", "app.js" ]

--- a/internal/test/integration/docker-compose-deno.yml
+++ b/internal/test/integration/docker-compose-deno.yml
@@ -1,14 +1,15 @@
-version: "3.8"
-
 services:
   testserver:
     build:
       context: ../../..
-      dockerfile: internal/test/integration/components/nodejsserver/Dockerfile
-    image: hatest-testserver-node
+      dockerfile: internal/test/integration/components/nodejsserver/Dockerfile_deno
+    image: hatest-testserver-deno
     command:
-      - node
-      - ${NODE_APP}.js
+      - deno
+      - run
+      - --unstable-detect-cjs
+      - -A
+      - ${MAIN_FILE:-app.js}
     ports:
       - 3031:3030
       - 3034:3033

--- a/internal/test/integration/red_test_nodejs.go
+++ b/internal/test/integration/red_test_nodejs.go
@@ -101,7 +101,7 @@ func testREDMetricsNodeJSHTTPS(t *testing.T) {
 	} {
 		t.Run(testCaseURL, func(t *testing.T) {
 			waitForTestComponents(t, testCaseURL)
-			testREDMetricsForNodeHTTPLibrary(t, testCaseURL, "/greeting", "node", "integration-test")
+			testREDMetricsForNodeHTTPLibrary(t, testCaseURL, "/greeting", "testserver", "integration-test")
 		})
 	}
 }

--- a/internal/test/integration/red_test_nodejs.go
+++ b/internal/test/integration/red_test_nodejs.go
@@ -89,8 +89,8 @@ func testREDMetricsNodeJSHTTP(t *testing.T) {
 	} {
 		t.Run(testCaseURL, func(t *testing.T) {
 			waitForTestComponents(t, testCaseURL)
-			testREDMetricsForNodeHTTPLibrary(t, testCaseURL, "/greeting", "node", "integration-test")
-			testREDMetricsForNodeHTTPLibraryRoutes(t, testCaseURL, "node", "integration-test")
+			testREDMetricsForNodeHTTPLibrary(t, testCaseURL, "/greeting", "testserver", "integration-test")
+			testREDMetricsForNodeHTTPLibraryRoutes(t, testCaseURL, "testserver", "integration-test")
 		})
 	}
 }

--- a/internal/test/integration/red_test_nodejs.go
+++ b/internal/test/integration/red_test_nodejs.go
@@ -83,7 +83,7 @@ func testREDMetricsForNodeHTTPLibraryRoutes(t *testing.T, url, comm, namespace s
 	}, testTimeout, 100*time.Millisecond)
 }
 
-func testREDMetricsNodeJSHTTP(t *testing.T) {
+func testREDMetricsJSHTTP(t *testing.T) {
 	for _, testCaseURL := range []string{
 		"http://localhost:3031",
 	} {

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -383,6 +383,19 @@ func TestSuite_NodeJS(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_Deno(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-deno.yml", path.Join(pathOutput, "test-suite-deno.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3030`, `OTEL_EBPF_EXECUTABLE_PATH=`, `MAIN_FILE=app.js`)
+	require.NoError(t, compose.Up())
+	t.Run("Deno RED metrics", testREDMetricsNodeJSHTTP)
+	t.Run("HTTP traces (kprobes)", testHTTPTracesKProbes)
+	t.Run("HTTP nested traces large HTTPS (kprobes)", testHTTPTracesNestedNodeJSLargeHTTPS)
+	runWeaverValidation(t)
+	require.NoError(t, compose.Close())
+}
+
 func TestSuite_NodeJSTLS(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-nodejs.yml", path.Join(pathOutput, "test-suite-nodejs-tls.log"))
 	require.NoError(t, err)

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -376,9 +376,9 @@ func TestSuite_NodeJS(t *testing.T) {
 
 	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3030`, `OTEL_EBPF_EXECUTABLE_PATH=`, `NODE_APP=app`)
 	require.NoError(t, compose.Up())
-	t.Run("NodeJS RED metrics", testREDMetricsNodeJSHTTP)
+	t.Run("NodeJS RED metrics", testREDMetricsJSHTTP)
 	t.Run("HTTP traces (kprobes)", testHTTPTracesKProbes)
-	t.Run("HTTP nested traces large HTTPS (kprobes)", testHTTPTracesNestedNodeJSLargeHTTPS)
+	t.Run("HTTP nested traces large HTTPS (kprobes)", testHTTPTracesNestedJSLargeHTTPS)
 	runWeaverValidation(t)
 	require.NoError(t, compose.Close())
 }
@@ -389,9 +389,8 @@ func TestSuite_Deno(t *testing.T) {
 
 	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3030`, `OTEL_EBPF_EXECUTABLE_PATH=`, `MAIN_FILE=app.js`)
 	require.NoError(t, compose.Up())
-	t.Run("Deno RED metrics", testREDMetricsNodeJSHTTP)
+	t.Run("Deno RED metrics", testREDMetricsJSHTTP)
 	t.Run("HTTP traces (kprobes)", testHTTPTracesKProbes)
-	t.Run("HTTP nested traces large HTTPS (kprobes)", testHTTPTracesNestedNodeJSLargeHTTPS)
 	runWeaverValidation(t)
 	require.NoError(t, compose.Close())
 }

--- a/internal/test/integration/traces_test.go
+++ b/internal/test/integration/traces_test.go
@@ -315,7 +315,7 @@ func testHTTPTracesKProbes(t *testing.T) {
 
 	var trace jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		resp, err := http.Get(jaegerQueryURL + "?service=node&operation=GET%20%2Fbye")
+		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=GET%20%2Fbye")
 		require.NoError(ct, err)
 		if resp == nil {
 			return
@@ -354,11 +354,11 @@ func testHTTPTracesKProbes(t *testing.T) {
 	assert.Empty(t, sd, sd.String())
 
 	process := trace.Processes[parent.ProcessID]
-	assert.Equal(t, "node", process.ServiceName)
+	assert.Equal(t, "testserver", process.ServiceName)
 
 	serviceInstance, ok := jaeger.FindIn(process.Tags, "service.instance.id")
 	require.Truef(t, ok, "service.instance.id not found in tags: %v", process.Tags)
-	assert.Regexp(t, `^obi:\d+$$`, serviceInstance.Value)
+	assert.Regexp(t, `^integration-test\.testserver\.`, serviceInstance.Value)
 
 	jaeger.Diff([]jaeger.Tag{
 		{Key: "otel.scope.name", Type: "string", Value: "go.opentelemetry.io/obi"},
@@ -1465,6 +1465,14 @@ func testHTTPTracesNestedManualSpans(t *testing.T) {
 }
 
 func testHTTPTracesNestedNodeJSLargeHTTPS(t *testing.T) {
+	testHTTPTracesNestedJSLargeHTTPS(t, "node")
+}
+
+func testHTTPTracesNestedDenoLargeHTTPS(t *testing.T) {
+	testHTTPTracesNestedJSLargeHTTPS(t, "deno")
+}
+
+func testHTTPTracesNestedJSLargeHTTPS(t *testing.T, command string) {
 	var parentID string
 
 	// Run a request, since we have a single app, we should see always all requests
@@ -1472,7 +1480,7 @@ func testHTTPTracesNestedNodeJSLargeHTTPS(t *testing.T) {
 
 	var trace jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		resp, err := http.Get(jaegerQueryURL + "?service=node&operation=GET%20%2Fapi%2Ftest-apm")
+		resp, err := http.Get(jaegerQueryURL + "?service=" + command + "&operation=GET%20%2Fapi%2Ftest-apm")
 		require.NoError(ct, err)
 		if resp == nil {
 			return

--- a/internal/test/integration/traces_test.go
+++ b/internal/test/integration/traces_test.go
@@ -1464,15 +1464,7 @@ func testHTTPTracesNestedManualSpans(t *testing.T) {
 	assert.Empty(t, sd, sd.String())
 }
 
-func testHTTPTracesNestedNodeJSLargeHTTPS(t *testing.T) {
-	testHTTPTracesNestedJSLargeHTTPS(t, "node")
-}
-
-func testHTTPTracesNestedDenoLargeHTTPS(t *testing.T) {
-	testHTTPTracesNestedJSLargeHTTPS(t, "deno")
-}
-
-func testHTTPTracesNestedJSLargeHTTPS(t *testing.T, command string) {
+func testHTTPTracesNestedJSLargeHTTPS(t *testing.T) {
 	var parentID string
 
 	// Run a request, since we have a single app, we should see always all requests
@@ -1480,7 +1472,7 @@ func testHTTPTracesNestedJSLargeHTTPS(t *testing.T, command string) {
 
 	var trace jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		resp, err := http.Get(jaegerQueryURL + "?service=" + command + "&operation=GET%20%2Fapi%2Ftest-apm")
+		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=GET%20%2Fapi%2Ftest-apm")
 		require.NoError(ct, err)
 		if resp == nil {
 			return
@@ -1517,29 +1509,24 @@ func testHTTPTracesNestedJSLargeHTTPS(t *testing.T, command string) {
 
 	res = trace.FindByOperationName("processing", "internal")
 
+	require.NotEmpty(t, res)
 	var processing *jaeger.Span
+	for i := range res {
+		r := &res[i]
+		// Check parenthood
+		p, ok := trace.ParentOf(r)
 
-	if len(res) > 0 {
-		for i := range res {
-			r := &res[i]
-			// Check parenthood
-			p, ok := trace.ParentOf(r)
-
-			if ok {
-				if p.TraceID == server.TraceID && p.SpanID == server.SpanID {
-					processing = r
-					break
-				}
+		if ok {
+			if p.TraceID == server.TraceID && p.SpanID == server.SpanID {
+				processing = r
+				break
 			}
 		}
 	}
-
-	if processing != nil {
-		children = trace.ChildrenOf(processing.SpanID)
-	}
-
+	require.NotNil(t, processing)
+	children = trace.ChildrenOf(processing.SpanID)
 	// We must see two children
-	require.Len(t, children, 2)
+	assert.Len(t, children, 2)
 }
 
 func testPythonAsyncEndpoint(t *testing.T, endpoint string, expectedClientCalls int) {

--- a/pkg/internal/procs/proclang.go
+++ b/pkg/internal/procs/proclang.go
@@ -38,6 +38,10 @@ func instrumentableFromModuleMap(moduleName string) svc.InstrumentableType {
 	if strings.HasSuffix(moduleName, "/node") || moduleName == "node" {
 		return svc.InstrumentableNodejs
 	}
+	if strings.HasSuffix(moduleName, "/deno") || moduleName == "deno" {
+		// For JavaScript, OTEL semantic conventions only defines telemetry.sdk.language=nodejs
+		return svc.InstrumentableNodejs
+	}
 	if rubyModule.MatchString(moduleName) {
 		return svc.InstrumentableRuby
 	}

--- a/pkg/internal/procs/proclang_test.go
+++ b/pkg/internal/procs/proclang_test.go
@@ -33,6 +33,8 @@ func TestModuleDetection(t *testing.T) {
 	assert.Equal(t, svc.InstrumentableGeneric, instrumentableFromModuleMap("/usr/lib\\//libj9vm25.so/dklksjdf")) // OpenJDK only for now
 	assert.Equal(t, svc.InstrumentableNodejs, instrumentableFromModuleMap("/usr/bin/node"))
 	assert.Equal(t, svc.InstrumentableNodejs, instrumentableFromModuleMap("node"))
+	assert.Equal(t, svc.InstrumentableNodejs, instrumentableFromModuleMap("/usr/bin/deno"))
+	assert.Equal(t, svc.InstrumentableNodejs, instrumentableFromModuleMap("deno"))
 	assert.Equal(t, svc.InstrumentableRuby, instrumentableFromModuleMap("/usr/bin/ruby"))
 	assert.Equal(t, svc.InstrumentableRuby, instrumentableFromModuleMap("/usr/bin/ruby3"))
 	assert.Equal(t, svc.InstrumentableRuby, instrumentableFromModuleMap("/usr/bin/ruby3.0"))


### PR DESCRIPTION
## Summary

First of a series of PR addressing https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2776

Identifies `deno` as a valid JavaScript instrumentable type so the Routes extractor is able to populate the routes decorator from the target application.

After this PR:
* `deno` apllications are going to be identified also as `nodejs` (OTEL semantic convention does not cover `deno` as valid value for `telemetry.sdk.language`)
* We get metrics and single spans

Followup PRs (not included here to keep PRs small):
* Support trace context propagation
* Duplicate all the NodeJS tests to verify that Deno support is at the same level 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
