### PR TITLE
Add remaining Go runtime metrics

### DIFF
--- a/bpf/gotracer/go_offsets.h
+++ b/bpf/gotracer/go_offsets.h
@@ -144,6 +144,12 @@ typedef enum {
     _runtime_heap_stats_delta_large_alloc_count_pos,
     _runtime_heap_stats_delta_small_alloc_count_pos,
     _runtime_heap_stats_delta_small_free_count_pos,
+    _runtime_sched_ngsys_pos,
+    _runtime_sched_gfree_stack_pos,
+    _runtime_sched_gfree_no_stack_pos,
+    _runtime_p_gfree_pos,
+    _runtime_glist_size_pos,
+    _runtime_gc_controller_heap_goal_pos,
     _last_go_offset,
 } go_offset_const;
 

--- a/bpf/gotracer/go_runtime.c
+++ b/bpf/gotracer/go_runtime.c
@@ -49,6 +49,7 @@ enum : u32 {
     k_go_runtime_heap_stats_slots = 3,
     k_go_runtime_heap_stats_fields_between_size_class_arrays = 2,
     k_go_runtime_max_size_classes = 68,
+    k_go_runtime_max_processors = 256,
 };
 
 static __always_inline bool go_runtime_read(void *dst, u32 size, u64 addr) {
@@ -122,6 +123,39 @@ go_runtime_collect_scheduler_config(const go_runtime_metric_target_t *target,
             &snapshot->gomaxprocs, sizeof(snapshot->gomaxprocs), target->gomaxprocs_addr)) {
         snapshot->valid_mask |= go_runtime_metric_valid_processor_limit;
     }
+}
+
+static __always_inline void go_runtime_collect_gc_goal(go_runtime_metric_target_t *target,
+                                                       off_table_t *ot,
+                                                       go_runtime_metric_snapshot_t *snapshot) {
+    if (!(target->available_mask & go_runtime_metric_valid_memory_gc_goal)) {
+        return;
+    }
+
+    if (target->gc_goal_source == go_runtime_gc_goal_source_heap_goal_field) {
+        const u64 heap_goal_pos =
+            go_offset_of(ot, (go_offset){.v = _runtime_gc_controller_heap_goal_pos});
+        if (go_runtime_read_offset(&snapshot->memory_gc_goal,
+                                   sizeof(snapshot->memory_gc_goal),
+                                   target->gc_controller_addr,
+                                   heap_goal_pos)) {
+            snapshot->valid_mask |= go_runtime_metric_valid_memory_gc_goal;
+        }
+        return;
+    }
+
+    if (target->gc_goal_source != go_runtime_gc_goal_source_pace_scavenger_argument) {
+        return;
+    }
+
+    // Aligned u64 map-value loads JIT to single native accesses, which are tear-free on 64-bit hosts.
+    const u64 goal = *(volatile u64 *)&target->gc_goal;
+    if (!goal) {
+        return;
+    }
+
+    snapshot->memory_gc_goal = goal;
+    snapshot->valid_mask |= go_runtime_metric_valid_memory_gc_goal;
 }
 
 static __always_inline void go_runtime_collect_cpu_time(const go_runtime_metric_target_t *target,
@@ -445,6 +479,82 @@ static __always_inline void go_runtime_collect_heap_stats(const go_runtime_metri
     snapshot->valid_mask |= go_runtime_metric_valid_memory_used;
 }
 
+static __always_inline void
+go_runtime_collect_goroutine_count(const go_runtime_metric_target_t *target,
+                                   off_table_t *ot,
+                                   go_runtime_metric_snapshot_t *snapshot) {
+    if (!(target->available_mask & go_runtime_metric_valid_goroutine_count)) {
+        return;
+    }
+
+    const u64 sched_ngsys_pos = go_offset_of(ot, (go_offset){.v = _runtime_sched_ngsys_pos});
+    const u64 sched_gfree_stack_pos =
+        go_offset_of(ot, (go_offset){.v = _runtime_sched_gfree_stack_pos});
+    const u64 sched_gfree_no_stack_pos =
+        go_offset_of(ot, (go_offset){.v = _runtime_sched_gfree_no_stack_pos});
+    const u64 p_gfree_pos = go_offset_of(ot, (go_offset){.v = _runtime_p_gfree_pos});
+    const u64 glist_size_pos = go_offset_of(ot, (go_offset){.v = _runtime_glist_size_pos});
+
+    u64 allglen = 0;
+    s32 ngsys = 0;
+    s32 sched_gfree_stack = 0;
+    s32 sched_gfree_no_stack = 0;
+    u64 allp_data = 0;
+    u64 allp_len = 0;
+
+    if (!go_runtime_read(&allglen, sizeof(allglen), target->allglen_addr)) {
+        return;
+    }
+    if (!target->goroutine_count_includes_system &&
+        !go_runtime_read_offset(&ngsys, sizeof(ngsys), target->sched_addr, sched_ngsys_pos)) {
+        return;
+    }
+    if (!go_runtime_read_offset(&sched_gfree_stack,
+                                sizeof(sched_gfree_stack),
+                                target->sched_addr,
+                                sched_gfree_stack_pos + glist_size_pos)) {
+        return;
+    }
+    if (!go_runtime_read_offset(&sched_gfree_no_stack,
+                                sizeof(sched_gfree_no_stack),
+                                target->sched_addr,
+                                sched_gfree_no_stack_pos + glist_size_pos)) {
+        return;
+    }
+    if (!go_runtime_read(&allp_data, sizeof(allp_data), target->allp_addr) ||
+        !go_runtime_read(&allp_len, sizeof(allp_len), target->allp_addr + k_go_slice_len_offset) ||
+        !allp_data || !allp_len || allp_len > k_go_runtime_max_processors) {
+        return;
+    }
+
+    s64 goroutines = (s64)allglen - sched_gfree_stack - sched_gfree_no_stack;
+    if (!target->goroutine_count_includes_system) {
+        goroutines -= ngsys;
+    }
+
+    for (u32 i = 0; i < k_go_runtime_max_processors; i++) {
+        if (i >= allp_len) {
+            break;
+        }
+
+        u64 p_addr = 0;
+        s32 p_gfree = 0;
+        if (!go_runtime_read(&p_addr, sizeof(p_addr), allp_data + (i * sizeof(p_addr))) ||
+            !p_addr ||
+            !go_runtime_read_offset(
+                &p_gfree, sizeof(p_gfree), p_addr, p_gfree_pos + glist_size_pos)) {
+            return;
+        }
+        goroutines -= p_gfree;
+    }
+
+    if (goroutines < 1) {
+        return;
+    }
+    snapshot->goroutine_count = goroutines;
+    snapshot->valid_mask |= go_runtime_metric_valid_goroutine_count;
+}
+
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __type(key, go_addr_key_t); // key: pointer to the request goroutine
@@ -461,8 +571,7 @@ int obi_uprobe_go_runtime_metrics(struct pt_regs *ctx) {
 
     bpf_dbg_printk("collecting Go runtime metrics pid=%d ns=%d", key.user_pid, key.ns);
 
-    const go_runtime_metric_target_t *target =
-        bpf_map_lookup_elem(&go_runtime_metric_targets, &key);
+    go_runtime_metric_target_t *target = bpf_map_lookup_elem(&go_runtime_metric_targets, &key);
     if (!target) {
         return 0;
     }
@@ -482,10 +591,27 @@ int obi_uprobe_go_runtime_metrics(struct pt_regs *ctx) {
     go_runtime_collect_gc(target, ot, &event->snapshot);
     go_runtime_collect_memory_config(target, ot, &event->snapshot);
     go_runtime_collect_scheduler_config(target, &event->snapshot);
+    go_runtime_collect_gc_goal(target, ot, &event->snapshot);
     go_runtime_collect_cpu_time(target, ot, &event->snapshot);
     go_runtime_collect_heap_stats(target, ot, &key, &event->snapshot);
+    go_runtime_collect_goroutine_count(target, ot, &event->snapshot);
 
     bpf_ringbuf_submit(event, get_flags());
+    return 0;
+}
+
+SEC("uprobe/go_runtime_gc_goal")
+int obi_uprobe_go_runtime_gc_goal(struct pt_regs *ctx) {
+    pid_info key = {};
+    task_pid(&key);
+
+    go_runtime_metric_target_t *target = bpf_map_lookup_elem(&go_runtime_metric_targets, &key);
+    if (!target || target->gc_goal_source != go_runtime_gc_goal_source_pace_scavenger_argument) {
+        return 0;
+    }
+
+    const u64 goal = (u64)GO_PARAM2(ctx);
+    *(volatile u64 *)&target->gc_goal = goal;
     return 0;
 }
 

--- a/bpf/gotracer/maps/runtime.h
+++ b/bpf/gotracer/maps/runtime.h
@@ -92,7 +92,21 @@ typedef struct go_runtime_metric_target {
     u64 work_addr;
     u64 available_mask;
     u64 size_class_to_sizes_addr;
+    u64 sched_addr;
+    u64 allglen_addr;
+    u64 allp_addr;
+    bool goroutine_count_includes_system;
+    u8 _pad[7];
+    u32 gc_goal_source;
+    u32 _pad2;
+    u64 gc_goal;
 } go_runtime_metric_target_t;
+
+typedef enum go_runtime_gc_goal_source {
+    go_runtime_gc_goal_source_none = 0,
+    go_runtime_gc_goal_source_heap_goal_field = 1,
+    go_runtime_gc_goal_source_pace_scavenger_argument = 2,
+} go_runtime_gc_goal_source_t;
 
 // Metric group bits shared by go_runtime_metric_target.available_mask and
 // go_runtime_metric_snapshot.valid_mask. A snapshot bit is set only when the
@@ -107,6 +121,8 @@ typedef enum go_runtime_metric_valid {
     go_runtime_metric_valid_cpu_time = 1 << 4,
     go_runtime_metric_valid_memory_used = 1 << 5,
     go_runtime_metric_valid_memory_allocations = 1 << 6,
+    go_runtime_metric_valid_goroutine_count = 1 << 9,
+    go_runtime_metric_valid_memory_gc_goal = 1 << 10,
 } go_runtime_metric_valid_t;
 
 typedef struct go_runtime_metric_snapshot {
@@ -129,6 +145,8 @@ typedef struct go_runtime_metric_snapshot {
     s64 memory_used_other;
     u64 memory_allocated;
     u64 memory_allocations;
+    s64 goroutine_count;
+    u64 memory_gc_goal;
 } go_runtime_metric_snapshot_t;
 
 typedef struct go_runtime_metric_event {

--- a/configs/offsets/tracker_input.json
+++ b/configs/offsets/tracker_input.json
@@ -38,7 +38,11 @@
         "[1.23.0]gcMiscSys",
         "[1.23.0]other_sys"
       ],
-      "runtime.gcControllerState": ["[1.19.0]memoryLimit", "gcPercent"],
+      "runtime.gcControllerState": [
+        "[1.17.0,1.18.10]heapGoal",
+        "[1.19.0]memoryLimit",
+        "gcPercent"
+      ],
       "runtime.hchan": ["qcount", "dataqsiz", "sendx", "recvx"],
       "runtime.consistentHeapStats": ["[1.23.0]stats"],
       "runtime.heapStatsDelta": [
@@ -49,6 +53,10 @@
         "[1.23.0]smallAllocCount",
         "[1.23.0]smallFreeCount"
       ],
+      "runtime.schedt": ["ngsys", "gFree"],
+      "runtime.p": ["gFree"],
+      "runtime.gList": ["[1.25.0]size"],
+      "runtime.mutex": ["key"],
       "runtime.workType": ["[1.23.0]cpuStats"],
       "runtime.cpuStats": [
         "[1.23.0]GCAssistTime",

--- a/devdocs/runtimes/go.md
+++ b/devdocs/runtimes/go.md
@@ -11,15 +11,30 @@ builds using `-ldflags=-s`, are not supported.
 | OTel metric | Prometheus metric | Available since | Runtime source | Export behavior |
 | --- | --- | --- | --- | --- |
 | `go.memory.limit` | `go_memory_limit_bytes` | Go 1.19 | `runtime.gcController.memoryLimit` | Emits positive runtime memory limits; treats `math.MaxInt64` as the runtime's unset sentinel. |
+| `go.memory.gc.goal` | `go_memory_gc_goal_bytes` | Go 1.17 | Exact committed heap goal | Reads `runtime.gcController.heapGoal` when its offset is available; otherwise captures the second argument of `runtime.gcPaceScavenger` when that symbol is available. If neither source is available, OBI omits the metric. Emits only positive values that fit in `int64`. |
 | `go.memory.gc.cycles` | `go_memory_gc_cycles_total` | Go 1.17 | `runtime.memstats.numgc` | Emits the total completed GC cycle count. |
 | `go.memory.used` | `go_memory_used_bytes` | Go 1.23 | `runtime.memstats.heapStats` and runtime sys stats | Emits `go.memory.type=stack` and `go.memory.type=other` values. |
 | `go.memory.allocated` | `go_memory_allocated_bytes_total` | Go 1.23 | `runtime.memstats.heapStats` and Go size-class table | Emits cumulative allocated heap bytes. |
 | `go.memory.allocations` | `go_memory_allocations_total` | Go 1.23 | `runtime.memstats.heapStats` | Emits the cumulative heap allocation count. |
 | `go.cpu.time` | `go_cpu_time_seconds_total` | Go 1.23 | `runtime.work.cpuStats` | Emits cumulative CPU seconds with `go.cpu.state` and, where applicable, `go.cpu.detailed_state`. |
+| `go.goroutine.count` | `go_goroutine_count` | Capability-based | `runtime.allglen`, `runtime.sched`, and `runtime.allp` | Emits the current goroutine count using the same free-list subtraction as `/sched/goroutines:goroutines`. |
 | `go.processor.limit` | `go_processor_limit` | Go 1.17 | `runtime.gomaxprocs` | Emits the current `GOMAXPROCS` value. |
 | `go.config.gogc` | `go_config_gogc_percent` | Go 1.17 | `runtime.gcController.gcPercent` | Emits non-negative `GOGC` percentages; a negative runtime value represents `GOGC=off`. |
 
 OBI reads absolute runtime values from the target process.
+
+Goroutine counting starts with `runtime.allglen`, subtracts both scheduler
+`gFree` list sizes and every `runtime.allp` processor's `gFree` list size, then
+clamps the result to at least one. Before Go 1.26 it also subtracts
+`runtime.sched.ngsys`, matching the target runtime's exclusion of system
+goroutines; from Go 1.26 onward, system goroutines are included.
+The metric is capability-based because OBI enables it only when the target Go
+version, runtime symbols, and all required scheduler/free-list offsets resolve.
+The supported per-list size layout first appears in Go 1.25, so older targets
+omit this metric without affecting other runtime metrics.
+OBI scans at most 256 processors to keep the BPF verifier bound fixed. When
+`runtime.allp` exceeds that bound, or any pointer or memory read fails, the
+snapshot omits `go.goroutine.count` instead of exporting a partial count.
 
 ## Collection path
 
@@ -30,23 +45,33 @@ ring buffer, and the runtime metrics export queue:
    by the BPF probe.
 2. Userspace writes process-scoped addresses and executable-scoped field offsets
    to BPF maps.
-3. For Go 1.23 and newer, a BPF entry probe on
+3. If the `runtime.gcController.heapGoal` field offset is available, OBI reads
+   that field at snapshot time. Otherwise, when `runtime.gcPaceScavenger`
+   resolves, an entry probe caches its second argument, which is the exact heap
+   goal passed by `runtime.gcControllerCommit`. This fallback assumes the Go
+   1.19+ signature (`memoryLimit`, `heapGoal`, `lastHeapGoal`); Go 1.17–1.18
+   resolve the `heapGoal` field instead. If neither source is available, OBI
+   omits only `go.memory.gc.goal`; it never estimates the goal from other runtime
+   fields.
+4. For Go 1.23 and newer, a BPF entry probe on
    `runtime.(*scavengeIndex).nextGen` runs during GC mark termination after
    accounting is updated and while the Go world is stopped. This prevents Go's
    heap-stat ring from rotating during a memory snapshot. Older Go versions use
    the `runtime.gcMarkDone` return probe for the legacy metric set. The probe
    reads scalar runtime values with `bpf_probe_read_user` and submits a runtime
    snapshot through the shared BPF event ring buffer.
-4. The Go tracer converts runtime snapshot events into userspace
+5. The Go tracer converts runtime snapshot events into userspace
    `RuntimeMetricSnapshot` values and forwards them through the runtime metrics
    queue.
-5. OTEL and Prometheus exporters consume queued snapshots at their export
+6. OTEL and Prometheus exporters consume queued snapshots at their export
    cadence, join them to current Go service metadata, apply metric export
    semantics, and emit the metrics.
 
 ## Snapshot cadence
 
 Snapshots update when the version-appropriate GC probe fires. A newly started
-process emits runtime metrics after it completes a GC cycle. Changes to `GOGC`,
-`GOMEMLIMIT`, `GOMAXPROCS`, CPU counters, and memory counters appear in exported
-metrics after the next completed GC.
+process emits runtime metrics after it completes a GC cycle. A GC goal captured
+from `runtime.gcPaceScavenger` is exported by the next GC-cadence snapshot; a
+goal backed by `runtime.gcController.heapGoal` is read during that snapshot.
+Changes to `GOGC`, `GOMEMLIMIT`, `GOMAXPROCS`, CPU counters, goroutine count,
+and memory counters appear in exported metrics after the next completed GC.

--- a/internal/test/integration/components/go-runtime-metrics-server/Dockerfile
+++ b/internal/test/integration/components/go-runtime-metrics-server/Dockerfile
@@ -1,6 +1,7 @@
 # Build the testserver binary
 # Docker command must be invoked from the project root directory
-FROM golang:1.26.3@sha256:efaccb5b497e90df3ebe5216cc25cd9f98e73874e2d638b56e38d4a3f098c41c AS builder
+ARG RUNTIME_METRICS_TESTSERVER_GO_IMAGE=golang:1.26.3@sha256:efaccb5b497e90df3ebe5216cc25cd9f98e73874e2d638b56e38d4a3f098c41c
+FROM ${RUNTIME_METRICS_TESTSERVER_GO_IMAGE} AS builder
 
 ARG TARGETARCH
 

--- a/internal/test/integration/components/go-runtime-metrics-server/main.go
+++ b/internal/test/integration/components/go-runtime-metrics-server/main.go
@@ -17,6 +17,8 @@ import (
 
 var runtimeMetricsReadLoopActive uint32
 
+const runtimeMetricMaxProcessors = 256
+
 func main() {
 	go serve(":8081")
 	serve(":8080")
@@ -50,6 +52,9 @@ func handleConnection(conn net.Conn) {
 
 	switch strings.TrimSpace(message) {
 	case "FORCE_GC":
+		runtime.GC()
+	case "SET_GOMAXPROCS_ABOVE_RUNTIME_METRIC_LIMIT":
+		runtime.GOMAXPROCS(runtimeMetricMaxProcessors + 1)
 		runtime.GC()
 	case "RUNTIME_METRICS":
 		if err := json.NewEncoder(conn).Encode(runtimeMetricValues()); err != nil {
@@ -85,6 +90,7 @@ func runtimeMetricValues() map[string]float64 {
 		"/gc/cycles/automatic:gc-cycles",
 		"/gc/cycles/forced:gc-cycles",
 		"/gc/cycles/total:gc-cycles",
+		"/gc/heap/goal:bytes",
 		"/gc/heap/allocs:bytes",
 		"/gc/heap/allocs:objects",
 		"/cpu/classes/gc/mark/assist:cpu-seconds",
@@ -95,6 +101,7 @@ func runtimeMetricValues() map[string]float64 {
 		"/cpu/classes/scavenge/assist:cpu-seconds",
 		"/cpu/classes/scavenge/background:cpu-seconds",
 		"/cpu/classes/user:cpu-seconds",
+		"/sched/goroutines:goroutines",
 		"/memory/classes/heap/released:bytes",
 		"/memory/classes/heap/stacks:bytes",
 		"/memory/classes/total:bytes",

--- a/internal/test/integration/docker-compose-go-runtime-metrics.yml
+++ b/internal/test/integration/docker-compose-go-runtime-metrics.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: ../../..
       dockerfile: ${RUNTIME_METRICS_TESTSERVER_DOCKERFILE:-./internal/test/integration/components/go-runtime-metrics-server/Dockerfile}
+      args:
+        - RUNTIME_METRICS_TESTSERVER_GO_IMAGE
     image: ${RUNTIME_METRICS_TESTSERVER_IMAGE:-hatest-testserver-go-runtime-metrics}
     ports:
       - "${TEST_SERVICE_PORTS}"

--- a/internal/test/integration/runtime_metrics_test.go
+++ b/internal/test/integration/runtime_metrics_test.go
@@ -22,7 +22,9 @@ const (
 	prometheusInstantVectorValueLen = 2
 	runtimeMetricsHostPort          = "8392"
 	runtimeMetricsGo117HostPort     = "8393"
+	runtimeMetricsGo125HostPort     = "8394"
 	runtimeMemoryGaugeTolerance     = 16 * 1024 * 1024
+	runtimeGoroutineGaugeTolerance  = 4
 	runtimeMetricsReadIterations    = 12
 )
 
@@ -81,14 +83,26 @@ func testRuntimeMetricsGo(t *testing.T) {
 	gaugeMetrics := []struct {
 		runtimeName string
 		obiQuery    string
+		tolerance   float64
 	}{
+		{
+			runtimeName: "/gc/heap/goal:bytes",
+			obiQuery:    "go_memory_gc_goal_bytes",
+		},
 		{
 			runtimeName: "go.memory.used/stack",
 			obiQuery:    `go_memory_used_bytes{go_memory_type="stack"}`,
+			tolerance:   runtimeMemoryGaugeTolerance,
 		},
 		{
 			runtimeName: "go.memory.used/other",
 			obiQuery:    `go_memory_used_bytes{go_memory_type="other"}`,
+			tolerance:   runtimeMemoryGaugeTolerance,
+		},
+		{
+			runtimeName: "/sched/goroutines:goroutines",
+			obiQuery:    "go_goroutine_count",
+			tolerance:   runtimeGoroutineGaugeTolerance,
 		},
 	}
 
@@ -122,12 +136,43 @@ func testRuntimeMetricsGo(t *testing.T) {
 				metric.runtimeName,
 				obiValue,
 				metric.obiQuery,
-				runtimeMemoryGaugeTolerance,
+				metric.tolerance,
 			)
 		}
 	}, testTimeout, 250*time.Millisecond)
 
 	assertRuntimeMemoryMetricsDuringConcurrentReads(t, pq)
+}
+
+func testRuntimeGoroutineCountSuppressedAboveProcessorLimit(t *testing.T) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	assert.Positive(t, runtimeMetricValue(t, pq, "go_goroutine_count"))
+
+	setGOMAXPROCSAboveRuntimeMetricLimit(t)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		forceRuntimeGC(ct)
+		results, err := pq.Query("go_goroutine_count")
+		require.NoError(ct, err)
+		assert.Empty(ct, results, "go_goroutine_count should be removed after collection is suppressed")
+	}, testTimeout, 250*time.Millisecond)
+}
+
+func testRuntimeGoroutineCountGo125(t *testing.T) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+
+	forceRuntimeGCAtPort(t, runtimeMetricsGo125HostPort)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		forceRuntimeGCAtPort(ct, runtimeMetricsGo125HostPort)
+		current := readRuntimeMetricsAtPort(ct, runtimeMetricsGo125HostPort)
+		assertRuntimeMetricGaugeObserved(
+			ct,
+			current,
+			"/sched/goroutines:goroutines",
+			runtimeMetricValue(ct, pq, "go_goroutine_count"),
+			"go_goroutine_count",
+			runtimeGoroutineGaugeTolerance,
+		)
+	}, testTimeout, 250*time.Millisecond)
 }
 
 func testRuntimeMetricsGo117(t *testing.T) {
@@ -136,6 +181,7 @@ func testRuntimeMetricsGo117(t *testing.T) {
 		"go_memory_gc_cycles_total",
 		"go_processor_limit",
 		"go_config_gogc_percent",
+		"go_memory_gc_goal_bytes",
 	}
 	unavailableMetrics := []string{
 		"go_memory_limit_bytes",
@@ -143,11 +189,13 @@ func testRuntimeMetricsGo117(t *testing.T) {
 		"go_memory_used_bytes",
 		"go_memory_allocated_bytes_total",
 		"go_memory_allocations_total",
+		"go_goroutine_count",
 	}
 
 	forceRuntimeGCAtPort(t, runtimeMetricsGo117HostPort)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		forceRuntimeGCAtPort(ct, runtimeMetricsGo117HostPort)
+		current := readRuntimeMetricsAtPort(ct, runtimeMetricsGo117HostPort)
 		for _, metric := range availableMetrics {
 			assert.Positivef(ct, runtimeMetricValue(ct, pq, metric), "OBI %s should be positive", metric)
 		}
@@ -156,6 +204,14 @@ func testRuntimeMetricsGo117(t *testing.T) {
 			require.NoError(ct, err)
 			assert.Emptyf(ct, results, "OBI %s should not be exported", metric)
 		}
+		assertRuntimeMetricGaugeObserved(
+			ct,
+			current,
+			"/gc/heap/goal:bytes",
+			runtimeMetricValue(ct, pq, "go_memory_gc_goal_bytes"),
+			"go_memory_gc_goal_bytes",
+			0,
+		)
 	}, testTimeout, 250*time.Millisecond)
 }
 
@@ -281,6 +337,17 @@ func forceRuntimeGCAtPort(t require.TestingT, port string) {
 	require.NoError(t, err)
 }
 
+func setGOMAXPROCSAboveRuntimeMetricLimit(t require.TestingT) {
+	conn := runtimeMetricsConnAtPort(t, runtimeMetricsHostPort)
+	defer conn.Close()
+
+	_, err := conn.Write([]byte("SET_GOMAXPROCS_ABOVE_RUNTIME_METRIC_LIMIT\n"))
+	require.NoError(t, err)
+
+	_, err = bufio.NewReader(conn).ReadString('\n')
+	require.NoError(t, err)
+}
+
 func setRuntimeMetricsReadLoop(t require.TestingT, enabled bool) {
 	conn := runtimeMetricsConnAtPort(t, runtimeMetricsHostPort)
 	defer conn.Close()
@@ -297,7 +364,11 @@ func setRuntimeMetricsReadLoop(t require.TestingT, enabled bool) {
 }
 
 func readRuntimeMetrics(t require.TestingT) map[string]float64 {
-	conn := runtimeMetricsConnAtPort(t, runtimeMetricsHostPort)
+	return readRuntimeMetricsAtPort(t, runtimeMetricsHostPort)
+}
+
+func readRuntimeMetricsAtPort(t require.TestingT, port string) map[string]float64 {
+	conn := runtimeMetricsConnAtPort(t, port)
 	defer conn.Close()
 
 	_, err := conn.Write([]byte("RUNTIME_METRICS\n"))

--- a/internal/test/integration/suites_runtime_test.go
+++ b/internal/test/integration/suites_runtime_test.go
@@ -5,12 +5,23 @@ package integration
 
 import (
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
 )
+
+const runtimeMetricsGo125BuilderImage = "golang:1.25.11@sha256:f188e8c16ea47a8b22d2bdcf6d9bcd07b63ea7876c199749c07bf31e0ab33bad"
+
+type runtimeMetricsPromCompatibilityConfig struct {
+	goVersion    string
+	hostPort     string
+	builderImage string
+	dockerfile   string
+	test         func(*testing.T)
+}
 
 func TestRuntimeMetricsProm(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-go-runtime-metrics.yml", path.Join(pathOutput, "test-suite-runtime-metrics-prom.log"))
@@ -23,6 +34,7 @@ func TestRuntimeMetricsProm(t *testing.T) {
 	require.NoError(t, compose.Up())
 	t.Run("Go runtime metrics with Prometheus export", testRuntimeMetricsGo)
 	runWeaverValidation(t)
+	t.Run("Go goroutine count suppression above processor limit", testRuntimeGoroutineCountSuppressedAboveProcessorLimit)
 	require.NoError(t, compose.Close())
 }
 
@@ -41,17 +53,51 @@ func TestRuntimeMetricsOTel(t *testing.T) {
 }
 
 func TestRuntimeMetricsPromGo117(t *testing.T) {
-	compose, err := docker.ComposeSuite("docker-compose-go-runtime-metrics.yml", path.Join(pathOutput, "test-suite-runtime-metrics-prom-go-1-17.log"))
+	runRuntimeMetricsPromCompatibility(t, runtimeMetricsPromCompatibilityConfig{
+		goVersion:  "1.17",
+		hostPort:   runtimeMetricsGo117HostPort,
+		dockerfile: "./internal/test/integration/components/go-runtime-metrics-server/Dockerfile_1.17",
+		test:       testRuntimeMetricsGo117,
+	})
+}
+
+func TestRuntimeMetricsPromGo125(t *testing.T) {
+	runRuntimeMetricsPromCompatibility(t, runtimeMetricsPromCompatibilityConfig{
+		goVersion:    "1.25",
+		hostPort:     runtimeMetricsGo125HostPort,
+		builderImage: runtimeMetricsGo125BuilderImage,
+		test:         testRuntimeGoroutineCountGo125,
+	})
+}
+
+func runRuntimeMetricsPromCompatibility(t *testing.T, cfg runtimeMetricsPromCompatibilityConfig) {
+	versionSlug := strings.ReplaceAll(cfg.goVersion, ".", "-")
+	compose, err := docker.ComposeSuite(
+		"docker-compose-go-runtime-metrics.yml",
+		path.Join(pathOutput, "test-suite-runtime-metrics-prom-go-"+versionSlug+".log"),
+	)
 	require.NoError(t, err)
 	compose.Env = append(compose.Env,
-		`TEST_SERVICE_PORTS=`+runtimeMetricsGo117HostPort+`:8080`,
+		`TEST_SERVICE_PORTS=`+cfg.hostPort+`:8080`,
 		`INSTRUMENTER_CONFIG_SUFFIX=-prom`,
 		`PROM_CONFIG_SUFFIX=`,
-		`RUNTIME_METRICS_TESTSERVER_DOCKERFILE=./internal/test/integration/components/go-runtime-metrics-server/Dockerfile_1.17`,
-		`RUNTIME_METRICS_TESTSERVER_IMAGE=hatest-testserver-go-runtime-metrics-1-17`,
+		`RUNTIME_METRICS_TESTSERVER_IMAGE=hatest-testserver-go-runtime-metrics-`+versionSlug,
 	)
+	if cfg.builderImage != "" {
+		compose.Env = append(
+			compose.Env,
+			`RUNTIME_METRICS_TESTSERVER_GO_IMAGE=`+cfg.builderImage,
+		)
+	}
+	if cfg.dockerfile != "" {
+		compose.Env = append(
+			compose.Env,
+			`RUNTIME_METRICS_TESTSERVER_DOCKERFILE=`+cfg.dockerfile,
+		)
+	}
+
 	require.NoError(t, compose.Up())
-	t.Run("Go 1.17 runtime metrics with Prometheus export", testRuntimeMetricsGo117)
+	t.Run("Go "+cfg.goVersion+" runtime metrics with Prometheus export", cfg.test)
 	runWeaverValidation(t)
 	require.NoError(t, compose.Close())
 }

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -480,6 +480,14 @@ func getDefinitions(
 				attr.ServerAddr:         true,
 			},
 		},
+		GoRuntimeMemoryGCGoal.Section: {
+			SubGroups:  []*AttrReportGroup{&appAttributes},
+			Attributes: map[attr.Name]Default{},
+		},
+		GoRuntimeGoroutineCount.Section: {
+			SubGroups:  []*AttrReportGroup{&appAttributes},
+			Attributes: map[attr.Name]Default{},
+		},
 		JVMMemoryUsed.Section: {
 			SubGroups:  []*AttrReportGroup{&jvmMemoryAttributes},
 			Attributes: map[attr.Name]Default{},

--- a/pkg/export/attributes/attr_defs_test.go
+++ b/pkg/export/attributes/attr_defs_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 )
 
 func TestEnabledGroups(t *testing.T) {
@@ -27,4 +30,40 @@ func TestEnabledGroups(t *testing.T) {
 	assert.True(t, group.Has(GroupPrometheus))
 	assert.True(t, group.Has(GroupKubernetes))
 	assert.False(t, group.Has(GroupNetCIDR))
+}
+
+func TestGoRuntimeDefinitions(t *testing.T) {
+	tests := []struct {
+		name Name
+		want Name
+	}{
+		{
+			name: GoRuntimeMemoryGCGoal,
+			want: Name{
+				Section: "go.memory.gc.goal",
+				Prom:    "go_memory_gc_goal_bytes",
+				OTEL:    "go.memory.gc.goal",
+			},
+		},
+		{
+			name: GoRuntimeGoroutineCount,
+			want: Name{
+				Section: "go.goroutine.count",
+				Prom:    "go_goroutine_count",
+				OTEL:    "go.goroutine.count",
+			},
+		},
+	}
+
+	definitions := getDefinitions(0, NewGroupAttributes(nil))
+	for _, test := range tests {
+		t.Run(test.want.OTEL, func(t *testing.T) {
+			assert.Equal(t, test.want, test.name)
+
+			definition, ok := definitions[test.name.Section]
+			require.True(t, ok)
+			assert.Contains(t, definition.All(), attr.ServiceName)
+			assert.Contains(t, definition.All(), attr.ServiceNamespace)
+		})
+	}
 }

--- a/pkg/export/attributes/metric.go
+++ b/pkg/export/attributes/metric.go
@@ -149,6 +149,11 @@ var (
 		Prom:    "go_memory_limit_bytes",
 		OTEL:    "go.memory.limit",
 	}
+	GoRuntimeMemoryGCGoal = Name{
+		Section: "go.memory.gc.goal",
+		Prom:    "go_memory_gc_goal_bytes",
+		OTEL:    "go.memory.gc.goal",
+	}
 	GoRuntimeMemoryGCCycles = Name{
 		Section: "go.memory.gc.cycles",
 		Prom:    "go_memory_gc_cycles_total",
@@ -173,6 +178,11 @@ var (
 		Section: "go.cpu.time",
 		Prom:    "go_cpu_time_seconds_total",
 		OTEL:    "go.cpu.time",
+	}
+	GoRuntimeGoroutineCount = Name{
+		Section: "go.goroutine.count",
+		Prom:    "go_goroutine_count",
+		OTEL:    "go.goroutine.count",
 	}
 	GoRuntimeProcessorLimit = Name{
 		Section: "go.processor.limit",

--- a/pkg/export/otel/metrics_runtime.go
+++ b/pkg/export/otel/metrics_runtime.go
@@ -54,20 +54,24 @@ type RuntimeMetrics struct {
 
 type goRuntimeMetrics struct {
 	memoryLimit       instrument.Int64UpDownCounter
+	memoryGCGoal      instrument.Int64UpDownCounter
 	memoryGCCycles    instrument.Int64Counter
 	memoryUsed        instrument.Int64UpDownCounter
 	memoryAllocated   instrument.Int64Counter
 	memoryAllocations instrument.Int64Counter
 	cpuTime           instrument.Float64Counter
+	goroutineCount    instrument.Int64UpDownCounter
 	processorLimit    instrument.Int64UpDownCounter
 	configGOGC        instrument.Int64UpDownCounter
 
 	memoryLimitValue       *int64
+	memoryGCGoalValue      *int64
 	memoryGCCyclesValue    *uint64
 	memoryUsedValues       map[string]int64
 	memoryAllocatedValue   *uint64
 	memoryAllocationsValue *uint64
 	cpuTimeValues          map[string]int64
+	goroutineCountValue    *int64
 	processorLimitValue    *int64
 	configGOGCValue        *int64
 }
@@ -198,6 +202,10 @@ func setupGoRuntimeMeters(metrics *goRuntimeMetrics, meter instrument.Meter) err
 	if err != nil {
 		return fmt.Errorf("creating go memory limit: %w", err)
 	}
+	metrics.memoryGCGoal, err = meter.Int64UpDownCounter(attributes.GoRuntimeMemoryGCGoal.OTEL, instrument.WithUnit("By"))
+	if err != nil {
+		return fmt.Errorf("creating go memory gc goal: %w", err)
+	}
 	metrics.memoryGCCycles, err = meter.Int64Counter(attributes.GoRuntimeMemoryGCCycles.OTEL, instrument.WithUnit("{gc_cycle}"))
 	if err != nil {
 		return fmt.Errorf("creating go memory gc cycles: %w", err)
@@ -217,6 +225,13 @@ func setupGoRuntimeMeters(metrics *goRuntimeMetrics, meter instrument.Meter) err
 	metrics.cpuTime, err = meter.Float64Counter(attributes.GoRuntimeCPUTime.OTEL, instrument.WithUnit("s"))
 	if err != nil {
 		return fmt.Errorf("creating go cpu time: %w", err)
+	}
+	metrics.goroutineCount, err = meter.Int64UpDownCounter(
+		attributes.GoRuntimeGoroutineCount.OTEL,
+		instrument.WithUnit("{goroutine}"),
+	)
+	if err != nil {
+		return fmt.Errorf("creating go goroutine count: %w", err)
 	}
 	metrics.processorLimit, err = meter.Int64UpDownCounter(attributes.GoRuntimeProcessorLimit.OTEL, instrument.WithUnit("{thread}"))
 	if err != nil {
@@ -291,6 +306,7 @@ func recordGoRuntimeMetrics(ctx context.Context, metrics *goRuntimeMetrics, snap
 	}
 
 	recordCurrentRuntimeMetric(ctx, metrics.memoryLimit, &metrics.memoryLimitValue, snapshot.Go.MemoryLimit)
+	recordCurrentRuntimeMetric(ctx, metrics.memoryGCGoal, &metrics.memoryGCGoalValue, snapshot.Go.MemoryGCGoal)
 	recordRuntimeCounter(ctx, metrics.memoryGCCycles, &metrics.memoryGCCyclesValue, snapshot.Go.GCCycles)
 	recordCurrentRuntimeMetricWithAttributes(
 		ctx,
@@ -311,6 +327,7 @@ func recordGoRuntimeMetrics(ctx context.Context, metrics *goRuntimeMetrics, snap
 	recordRuntimeCounter(ctx, metrics.memoryAllocated, &metrics.memoryAllocatedValue, snapshot.Go.MemoryAllocated)
 	recordRuntimeCounter(ctx, metrics.memoryAllocations, &metrics.memoryAllocationsValue, snapshot.Go.MemoryAllocations)
 	recordGoRuntimeCPUTime(ctx, metrics, snapshot.Go.CPUTime)
+	recordCurrentRuntimeMetric(ctx, metrics.goroutineCount, &metrics.goroutineCountValue, snapshot.Go.GoroutineCount)
 	recordCurrentRuntimeMetric(ctx, metrics.processorLimit, &metrics.processorLimitValue, snapshot.Go.ProcessorLimit)
 	recordCurrentRuntimeMetric(ctx, metrics.configGOGC, &metrics.configGOGCValue, snapshot.Go.GOGC)
 }

--- a/pkg/export/otel/metrics_runtime_test.go
+++ b/pkg/export/otel/metrics_runtime_test.go
@@ -201,6 +201,62 @@ func TestGoRuntimeMemoryMetricsDeltaResetAndRemoval(t *testing.T) {
 	assert.Empty(t, collectGoRuntimeInt64Points(t, reader, attributes.GoRuntimeMemoryAllocations.OTEL))
 }
 
+func TestGoRuntimeGoroutineCountCurrentValueAndRemoval(t *testing.T) {
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	t.Cleanup(func() {
+		require.NoError(t, provider.Shutdown(t.Context()))
+	})
+
+	var metrics goRuntimeMetrics
+	require.NoError(t, setupGoRuntimeMeters(&metrics, provider.Meter(reporterName)))
+	require.NotNil(t, metrics.goroutineCount)
+
+	for _, value := range []int64{10, 15, 3} {
+		recordGoRuntimeMetrics(t.Context(), &metrics, runtimemetrics.RuntimeMetricSnapshot{
+			Go: &runtimemetrics.GoRuntimeMetricSnapshot{GoroutineCount: &value},
+		})
+		assert.Equal(t, "{goroutine}", collectGoRuntimeInt64Metric(
+			t, reader, attributes.GoRuntimeGoroutineCount.OTEL,
+		).Unit)
+		assert.Equal(t, value, collectSingleGoRuntimeInt64Value(
+			t, reader, attributes.GoRuntimeGoroutineCount.OTEL,
+		))
+	}
+
+	recordGoRuntimeMetrics(t.Context(), &metrics, runtimemetrics.RuntimeMetricSnapshot{
+		Go: &runtimemetrics.GoRuntimeMetricSnapshot{},
+	})
+	assert.Empty(t, collectGoRuntimeInt64Points(t, reader, attributes.GoRuntimeGoroutineCount.OTEL))
+}
+
+func TestGoRuntimeMemoryGCGoalCurrentValueAndRemoval(t *testing.T) {
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(t.Context())) })
+
+	var metrics goRuntimeMetrics
+	require.NoError(t, setupGoRuntimeMeters(&metrics, provider.Meter(reporterName)))
+	require.NotNil(t, metrics.memoryGCGoal)
+
+	for _, value := range []int64{1024, 4096, 2048} {
+		recordGoRuntimeMetrics(t.Context(), &metrics, runtimemetrics.RuntimeMetricSnapshot{
+			Go: &runtimemetrics.GoRuntimeMetricSnapshot{MemoryGCGoal: &value},
+		})
+		assert.Equal(t, "By", collectGoRuntimeInt64Metric(
+			t, reader, attributes.GoRuntimeMemoryGCGoal.OTEL,
+		).Unit)
+		assert.Equal(t, value, collectSingleGoRuntimeInt64Value(
+			t, reader, attributes.GoRuntimeMemoryGCGoal.OTEL,
+		))
+	}
+
+	recordGoRuntimeMetrics(t.Context(), &metrics, runtimemetrics.RuntimeMetricSnapshot{
+		Go: &runtimemetrics.GoRuntimeMetricSnapshot{},
+	})
+	assert.Empty(t, collectGoRuntimeInt64Points(t, reader, attributes.GoRuntimeMemoryGCGoal.OTEL))
+}
+
 type goCPUTimePointKey struct {
 	state         string
 	detailedState string
@@ -254,6 +310,22 @@ func collectGoRuntimeInt64Points(
 ) []metricdata.DataPoint[int64] {
 	t.Helper()
 
+	metric := collectGoRuntimeInt64Metric(t, reader, name)
+	if metric.Name == "" {
+		return nil
+	}
+	sum, ok := metric.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	return sum.DataPoints
+}
+
+func collectGoRuntimeInt64Metric(
+	t *testing.T,
+	reader *metric.ManualReader,
+	name string,
+) metricdata.Metrics {
+	t.Helper()
+
 	var resourceMetrics metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(t.Context(), &resourceMetrics))
 
@@ -262,12 +334,9 @@ func collectGoRuntimeInt64Points(
 			if collected.Name != name {
 				continue
 			}
-
-			sum, ok := collected.Data.(metricdata.Sum[int64])
-			require.True(t, ok)
-			return sum.DataPoints
+			return collected
 		}
 	}
 
-	return nil
+	return metricdata.Metrics{}
 }

--- a/pkg/export/prom/prom_runtime.go
+++ b/pkg/export/prom/prom_runtime.go
@@ -19,11 +19,13 @@ import (
 
 type goRuntimeMetricsCollector struct {
 	memoryLimit       *prometheus.GaugeVec
+	memoryGCGoal      *prometheus.GaugeVec
 	memoryGCCycles    *prometheus.CounterVec
 	memoryUsed        *prometheus.GaugeVec
 	memoryAllocated   *prometheus.CounterVec
 	memoryAllocations *prometheus.CounterVec
 	cpuTime           *prometheus.CounterVec
+	goroutineCount    *prometheus.GaugeVec
 	processorLimit    *prometheus.GaugeVec
 	configGOGC        *prometheus.GaugeVec
 	counterValuesMu   sync.Mutex
@@ -38,6 +40,10 @@ func newGoRuntimeMetricsCollector(runtimeLabelNames []string) goRuntimeMetricsCo
 		memoryLimit: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: attributes.GoRuntimeMemoryLimit.Prom,
 			Help: "Runtime memory limit configured by the user, if a limit exists.",
+		}, runtimeLabelNames),
+		memoryGCGoal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: attributes.GoRuntimeMemoryGCGoal.Prom,
+			Help: "Heap size target for the next Go garbage collection cycle.",
 		}, runtimeLabelNames),
 		memoryGCCycles: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: attributes.GoRuntimeMemoryGCCycles.Prom,
@@ -59,6 +65,10 @@ func newGoRuntimeMetricsCollector(runtimeLabelNames []string) goRuntimeMetricsCo
 			Name: attributes.GoRuntimeCPUTime.Prom,
 			Help: "Estimated CPU time spent by the Go runtime.",
 		}, cpuTimeLabels),
+		goroutineCount: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: attributes.GoRuntimeGoroutineCount.Prom,
+			Help: "Number of goroutines that currently exist.",
+		}, runtimeLabelNames),
 		processorLimit: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: attributes.GoRuntimeProcessorLimit.Prom,
 			Help: "The number of OS threads that can execute user-level Go code simultaneously.",
@@ -77,11 +87,13 @@ func (c *goRuntimeMetricsCollector) collectors() []prometheus.Collector {
 	}
 	return []prometheus.Collector{
 		c.memoryLimit,
+		c.memoryGCGoal,
 		c.memoryGCCycles,
 		c.memoryUsed,
 		c.memoryAllocated,
 		c.memoryAllocations,
 		c.cpuTime,
+		c.goroutineCount,
 		c.processorLimit,
 		c.configGOGC,
 	}
@@ -123,6 +135,11 @@ func (r *metricsReporter) collectGoRuntimeMetrics(snapshot runtimemetrics.Runtim
 		r.goRuntimeMetrics.memoryLimit.WithLabelValues(labels...).Set(float64(*snapshot.Go.MemoryLimit))
 	} else {
 		r.goRuntimeMetrics.memoryLimit.DeleteLabelValues(labels...)
+	}
+	if snapshot.Go.MemoryGCGoal != nil {
+		r.goRuntimeMetrics.memoryGCGoal.WithLabelValues(labels...).Set(float64(*snapshot.Go.MemoryGCGoal))
+	} else {
+		r.goRuntimeMetrics.memoryGCGoal.DeleteLabelValues(labels...)
 	}
 	if snapshot.Go.GCCycles != nil {
 		r.goRuntimeMetrics.addGCCycles(labels, *snapshot.Go.GCCycles)
@@ -172,6 +189,11 @@ func (r *metricsReporter) collectGoRuntimeMetrics(snapshot runtimemetrics.Runtim
 		)
 	}
 	r.goRuntimeMetrics.collectCPUTime(labels, snapshot.Go.CPUTime)
+	if snapshot.Go.GoroutineCount != nil {
+		r.goRuntimeMetrics.goroutineCount.WithLabelValues(labels...).Set(float64(*snapshot.Go.GoroutineCount))
+	} else {
+		r.goRuntimeMetrics.goroutineCount.DeleteLabelValues(labels...)
+	}
 	if snapshot.Go.ProcessorLimit != nil {
 		r.goRuntimeMetrics.processorLimit.WithLabelValues(labels...).Set(float64(*snapshot.Go.ProcessorLimit))
 	} else {
@@ -274,6 +296,7 @@ func (r *metricsReporter) deleteRuntimeMetrics(service *svc.Attrs) {
 
 	labels := r.labelValuesTargetInfo(service)
 	r.goRuntimeMetrics.memoryLimit.DeleteLabelValues(labels...)
+	r.goRuntimeMetrics.memoryGCGoal.DeleteLabelValues(labels...)
 	r.goRuntimeMetrics.deleteGCCycles(labels)
 	r.goRuntimeMetrics.memoryUsed.DeleteLabelValues(append(append([]string{}, labels...), "stack")...)
 	r.goRuntimeMetrics.memoryUsed.DeleteLabelValues(append(append([]string{}, labels...), "other")...)
@@ -288,6 +311,7 @@ func (r *metricsReporter) deleteRuntimeMetrics(service *svc.Attrs) {
 		labels,
 	)
 	r.goRuntimeMetrics.deleteCPUTime(labels)
+	r.goRuntimeMetrics.goroutineCount.DeleteLabelValues(labels...)
 	r.goRuntimeMetrics.processorLimit.DeleteLabelValues(labels...)
 	r.goRuntimeMetrics.configGOGC.DeleteLabelValues(labels...)
 }

--- a/pkg/export/prom/prom_runtime_test.go
+++ b/pkg/export/prom/prom_runtime_test.go
@@ -56,6 +56,73 @@ func TestGoRuntimeGCCyclesCounterDeltaResetAndRemoval(t *testing.T) {
 	assert.Nil(t, gatheredMetric(t, registry, attributes.GoRuntimeMemoryGCCycles.Prom, nil))
 }
 
+func TestGoRuntimeGoroutineCountGaugeAndRemoval(t *testing.T) {
+	selection := attributes.Selection{
+		attributes.Resource.Section: attributes.InclusionLists{Include: []string{"service.name"}},
+	}
+	reporter := &metricsReporter{userAttribSelection: selection}
+	reporter.goRuntimeMetrics = newGoRuntimeMetricsCollector(
+		labelNamesTargetInfo(false, false, &reporter.nodeMeta, nil, selection),
+	)
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(reporter.goRuntimeMetrics.goroutineCount)
+
+	count := int64(12)
+	snapshot := runtimemetrics.RuntimeMetricSnapshot{
+		Service: svc.Attrs{UID: svc.UID{Name: "orders"}},
+		Go:      &runtimemetrics.GoRuntimeMetricSnapshot{GoroutineCount: &count},
+	}
+	reporter.collectGoRuntimeMetrics(snapshot)
+	labels := map[string]string{"service_name": "orders"}
+	metric := gatheredMetric(t, registry, attributes.GoRuntimeGoroutineCount.Prom, labels)
+	require.NotNil(t, metric)
+	assert.InDelta(t, float64(count), metric.GetGauge().GetValue(), 0)
+
+	snapshot.Go.GoroutineCount = nil
+	reporter.collectGoRuntimeMetrics(snapshot)
+	assert.Nil(t, gatheredMetric(t, registry, attributes.GoRuntimeGoroutineCount.Prom, labels))
+
+	snapshot.Go.GoroutineCount = &count
+	reporter.collectGoRuntimeMetrics(snapshot)
+	reporter.deleteRuntimeMetrics(&snapshot.Service)
+	assert.Nil(t, gatheredMetric(t, registry, attributes.GoRuntimeGoroutineCount.Prom, labels))
+
+	reporter.collectGoRuntimeMetrics(snapshot)
+	require.NotNil(t, gatheredMetric(t, registry, attributes.GoRuntimeGoroutineCount.Prom, labels))
+}
+
+func TestGoRuntimeMemoryGCGoalGaugeAndRemoval(t *testing.T) {
+	selection := attributes.Selection{
+		attributes.Resource.Section: attributes.InclusionLists{Include: []string{"service.name"}},
+	}
+	reporter := &metricsReporter{userAttribSelection: selection}
+	reporter.goRuntimeMetrics = newGoRuntimeMetricsCollector(
+		labelNamesTargetInfo(false, false, &reporter.nodeMeta, nil, selection),
+	)
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(reporter.goRuntimeMetrics.memoryGCGoal)
+
+	goal := int64(4096)
+	snapshot := runtimemetrics.RuntimeMetricSnapshot{
+		Service: svc.Attrs{UID: svc.UID{Name: "orders"}},
+		Go:      &runtimemetrics.GoRuntimeMetricSnapshot{MemoryGCGoal: &goal},
+	}
+	reporter.collectGoRuntimeMetrics(snapshot)
+	labels := map[string]string{"service_name": "orders"}
+	metric := gatheredMetric(t, registry, attributes.GoRuntimeMemoryGCGoal.Prom, labels)
+	require.NotNil(t, metric)
+	assert.InDelta(t, float64(goal), metric.GetGauge().GetValue(), 0)
+
+	snapshot.Go.MemoryGCGoal = nil
+	reporter.collectGoRuntimeMetrics(snapshot)
+	assert.Nil(t, gatheredMetric(t, registry, attributes.GoRuntimeMemoryGCGoal.Prom, labels))
+
+	snapshot.Go.MemoryGCGoal = &goal
+	reporter.collectGoRuntimeMetrics(snapshot)
+	reporter.deleteRuntimeMetrics(&snapshot.Service)
+	assert.Nil(t, gatheredMetric(t, registry, attributes.GoRuntimeMemoryGCGoal.Prom, labels))
+}
+
 func TestGoRuntimeMemoryCountersDeltaResetAndRemoval(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	collector := newGoRuntimeMetricsCollector(nil)

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -58,6 +58,16 @@ const (
 	goRuntimeMetricCPUTimeMask        uint64 = 1 << 4
 	goRuntimeMetricMemoryUsedMask     uint64 = 1 << 5
 	goRuntimeMetricMemoryAllocsMask   uint64 = 1 << 6
+	goRuntimeMetricGoroutineCountMask uint64 = 1 << 9
+	goRuntimeMetricMemoryGCGoalMask   uint64 = 1 << 10
+)
+
+type goRuntimeGCGoalSource uint32
+
+const (
+	goRuntimeGCGoalSourceNone goRuntimeGCGoalSource = iota
+	goRuntimeGCGoalSourceHeapGoalField
+	goRuntimeGCGoalSourcePaceScavengerArgument
 )
 
 const goRuntimeMetricBaseMask = goRuntimeMetricGCCyclesMask | goRuntimeMetricGOGCMask
@@ -99,6 +109,12 @@ var goRuntimeMetricOffsetFields = [...]goexec.GoOffset{
 	goexec.RuntimeHeapStatsDeltaLargeAllocCountPos,
 	goexec.RuntimeHeapStatsDeltaSmallAllocCountPos,
 	goexec.RuntimeHeapStatsDeltaSmallFreeCountPos,
+	goexec.RuntimeSchedNgSysPos,
+	goexec.RuntimeSchedGFreeStackPos,
+	goexec.RuntimeSchedGFreeNoStackPos,
+	goexec.RuntimePFreeGPos,
+	goexec.RuntimeGListSizePos,
+	goexec.RuntimeGCControllerHeapGoalPos,
 }
 
 var goRuntimeCPUTimeOffsetFields = [...]goexec.GoOffset{
@@ -130,6 +146,13 @@ var goRuntimeMemoryOffsetFields = [...]goexec.GoOffset{
 	goexec.RuntimeHeapStatsDeltaSmallFreeCountPos,
 }
 
+var goRuntimeGoroutineCountCommonOffsetFields = [...]goexec.GoOffset{
+	goexec.RuntimeSchedGFreeStackPos,
+	goexec.RuntimeSchedGFreeNoStackPos,
+	goexec.RuntimePFreeGPos,
+	goexec.RuntimeGListSizePos,
+}
+
 var goRuntimeMetricOffsetGroups = [...]struct {
 	mask   uint64
 	fields []goexec.GoOffset
@@ -142,18 +165,19 @@ var goRuntimeMetricOffsetGroups = [...]struct {
 }
 
 type Tracer struct {
-	log                      *slog.Logger
-	pidsFilter               ebpfcommon.ServiceFilter
-	cfg                      *config.EBPFTracer
-	metrics                  imetrics.Reporter
-	bpfObjects               BpfObjects
-	closers                  []io.Closer
-	disabledRouteHarvesting  bool
-	supportsBPFLoop          bool
-	runtimeMetricTargetKeys  map[runtimeMetricTargetKey]BpfPidInfo
-	goChannelOffsetsByIno    map[uint64]bool
-	goRuntimeMetricMaskByIno map[uint64]uint64
-	currentBinaryIno         uint64
+	log                        *slog.Logger
+	pidsFilter                 ebpfcommon.ServiceFilter
+	cfg                        *config.EBPFTracer
+	metrics                    imetrics.Reporter
+	bpfObjects                 BpfObjects
+	closers                    []io.Closer
+	disabledRouteHarvesting    bool
+	supportsBPFLoop            bool
+	runtimeMetricTargetKeys    map[runtimeMetricTargetKey]BpfPidInfo
+	goChannelOffsetsByIno      map[uint64]bool
+	goRuntimeMetricMaskByIno   map[uint64]uint64
+	goRuntimeGCGoalSourceByIno map[uint64]goRuntimeGCGoalSource
+	currentBinaryIno           uint64
 }
 
 func New(
@@ -173,15 +197,16 @@ func New(
 	}
 
 	return &Tracer{
-		log:                      log,
-		pidsFilter:               pidFilter,
-		cfg:                      &cfg.EBPF,
-		metrics:                  metrics,
-		disabledRouteHarvesting:  disabledRouteHarvesting,
-		supportsBPFLoop:          ebpfcommon.SupportsEBPFLoops(log, cfg.EBPF.OverrideBPFLoopEnabled),
-		runtimeMetricTargetKeys:  map[runtimeMetricTargetKey]BpfPidInfo{},
-		goChannelOffsetsByIno:    map[uint64]bool{},
-		goRuntimeMetricMaskByIno: map[uint64]uint64{},
+		log:                        log,
+		pidsFilter:                 pidFilter,
+		cfg:                        &cfg.EBPF,
+		metrics:                    metrics,
+		disabledRouteHarvesting:    disabledRouteHarvesting,
+		supportsBPFLoop:            ebpfcommon.SupportsEBPFLoops(log, cfg.EBPF.OverrideBPFLoopEnabled),
+		runtimeMetricTargetKeys:    map[runtimeMetricTargetKey]BpfPidInfo{},
+		goChannelOffsetsByIno:      map[uint64]bool{},
+		goRuntimeMetricMaskByIno:   map[uint64]uint64{},
+		goRuntimeGCGoalSourceByIno: map[uint64]goRuntimeGCGoalSource{},
 	}
 }
 
@@ -498,9 +523,24 @@ func (p *Tracer) recordGoRuntimeMetricAvailability(fileInfo *exec.FileInfo, offs
 	if p.goRuntimeMetricMaskByIno == nil {
 		p.goRuntimeMetricMaskByIno = map[uint64]uint64{}
 	}
+	if p.goRuntimeGCGoalSourceByIno == nil {
+		p.goRuntimeGCGoalSourceByIno = map[uint64]goRuntimeGCGoalSource{}
+	}
 
 	ino := fileInfo.Ino()
 	mask := goRuntimeMetricMask(offsets)
+	gcGoalSource := selectGoRuntimeGCGoalSource(
+		offsets,
+		goexec.RuntimeMetricGCGoalArgumentSupported(fileInfo.ELF()),
+	)
+	if gcGoalSource != goRuntimeGCGoalSourceNone {
+		mask |= goRuntimeMetricMemoryGCGoalMask
+	}
+	p.goRuntimeGCGoalSourceByIno[ino] = gcGoalSource
+	includesSystem, modeKnown := goexec.RuntimeMetricGoroutineCountMode(fileInfo.ELF())
+	if hasGoRuntimeGoroutineCountOffsets(offsets, includesSystem, modeKnown) {
+		mask |= goRuntimeMetricGoroutineCountMask
+	}
 	supportsStableHeapSnapshotVersion, err := goexec.SupportsGoRuntimeMemoryMetrics(fileInfo.ELF())
 	if err != nil && p.log != nil {
 		p.log.Debug("Go runtime memory metric version detection failed",
@@ -513,7 +553,7 @@ func (p *Tracer) recordGoRuntimeMetricAvailability(fileInfo *exec.FileInfo, offs
 	heapMetricsEnabled := mask&goRuntimeMetricHeapSnapshotMask != 0
 	nextGenResolved := false
 	if offsets != nil {
-		_, nextGenResolved = offsets.Funcs[goRuntimeMetricProbeSymbols[1]]
+		_, nextGenResolved = offsets.Funcs[goRuntimeMetricHeapSnapshotSymbol]
 	}
 
 	if !supportsStableHeapSnapshotVersion {
@@ -525,8 +565,8 @@ func (p *Tracer) recordGoRuntimeMetricAvailability(fileInfo *exec.FileInfo, offs
 				"pid", fileInfo.Pid(),
 				"ino", ino,
 				"cmd", fileInfo.CmdExePath(),
-				"missing_probe", goRuntimeMetricProbeSymbols[1],
-				"fallback_probe", goRuntimeMetricProbeSymbols[0])
+				"missing_probe", goRuntimeMetricHeapSnapshotSymbol,
+				"fallback_probe", goRuntimeMetricGCMarkDoneSymbol)
 		}
 	}
 	p.goRuntimeMetricMaskByIno[ino] = mask
@@ -539,8 +579,27 @@ func (p *Tracer) recordGoRuntimeMetricAvailability(fileInfo *exec.FileInfo, offs
 			"available_mask", mask,
 			"base_available", hasBaseGoRuntimeMetrics(mask),
 			"cpu_time_available", mask&goRuntimeMetricCPUTimeMask != 0,
-			"memory_available", mask&goRuntimeMetricMemoryUsedMask != 0)
+			"memory_available", mask&goRuntimeMetricMemoryUsedMask != 0,
+			"goroutine_count_available", mask&goRuntimeMetricGoroutineCountMask != 0,
+			"memory_gc_goal_available", mask&goRuntimeMetricMemoryGCGoalMask != 0,
+			"memory_gc_goal_source", gcGoalSource)
 	}
+}
+
+func selectGoRuntimeGCGoalSource(
+	offsets *goexec.Offsets,
+	goalArgumentSupported bool,
+) goRuntimeGCGoalSource {
+	if offsets == nil {
+		return goRuntimeGCGoalSourceNone
+	}
+	if hasGoRuntimeMetricOffsets(offsets, goexec.RuntimeGCControllerHeapGoalPos) {
+		return goRuntimeGCGoalSourceHeapGoalField
+	}
+	if _, ok := offsets.Funcs[goRuntimeMetricGCGoalSymbol]; ok && goalArgumentSupported {
+		return goRuntimeGCGoalSourcePaceScavengerArgument
+	}
+	return goRuntimeGCGoalSourceNone
 }
 
 func goRuntimeMetricMask(offsets *goexec.Offsets) uint64 {
@@ -568,6 +627,17 @@ func hasGoRuntimeMetricOffsets(offsets *goexec.Offsets, fields ...goexec.GoOffse
 		}
 	}
 	return true
+}
+
+func hasGoRuntimeGoroutineCountOffsets(
+	offsets *goexec.Offsets,
+	includesSystem bool,
+	modeKnown bool,
+) bool {
+	if !modeKnown || !hasGoRuntimeMetricOffsets(offsets, goRuntimeGoroutineCountCommonOffsetFields[:]...) {
+		return false
+	}
+	return includesSystem || hasGoRuntimeMetricOffsets(offsets, goexec.RuntimeSchedNgSysPos)
 }
 
 func hasBaseGoRuntimeMetrics(mask uint64) bool {
@@ -601,12 +671,17 @@ func (p *Tracer) registerRuntimeMetricTarget(pid app.PID, ns uint32, fileInfo *e
 	p.goRuntimeMetricMaskByIno[fileInfo.Ino()] = availableMask
 
 	value := BpfGoRuntimeMetricTargetT{
-		MemstatsAddr:         symbols.MemstatsAddr,
-		GcControllerAddr:     symbols.GCControllerAddr,
-		GomaxprocsAddr:       symbols.GOMAXPROCSAddr,
-		WorkAddr:             symbols.WorkAddr,
-		AvailableMask:        availableMask,
-		SizeClassToSizesAddr: symbols.SizeClassToSizesAddr,
+		MemstatsAddr:                 symbols.MemstatsAddr,
+		GcControllerAddr:             symbols.GCControllerAddr,
+		GomaxprocsAddr:               symbols.GOMAXPROCSAddr,
+		WorkAddr:                     symbols.WorkAddr,
+		AvailableMask:                availableMask,
+		SizeClassToSizesAddr:         symbols.SizeClassToSizesAddr,
+		SchedAddr:                    symbols.SchedAddr,
+		AllglenAddr:                  symbols.AllgLenAddr,
+		AllpAddr:                     symbols.AllpAddr,
+		GoroutineCountIncludesSystem: symbols.GoroutineCountIncludesSystem,
+		GcGoalSource:                 uint32(p.goRuntimeGCGoalSourceByIno[fileInfo.Ino()]),
 	}
 
 	if err := p.bpfObjects.GoRuntimeMetricTargets.Put(pidInfo, value); err != nil {
@@ -625,16 +700,26 @@ func (p *Tracer) goRuntimeMetricMaskForSymbols(
 	mask uint64,
 	symbols goexec.RuntimeMetricSymbols,
 ) uint64 {
-	if mask&goRuntimeMetricMemoryAllocsMask == 0 || symbols.SizeClassToSizesAddr != 0 {
-		return mask
+	if mask&goRuntimeMetricMemoryAllocsMask != 0 && symbols.SizeClassToSizesAddr == 0 {
+		mask &^= goRuntimeMetricMemoryAllocsMask
+		if p.log != nil {
+			p.log.Warn("Go runtime size-class table symbol unresolved; disabling allocation metrics",
+				"pid", fileInfo.Pid(),
+				"ino", fileInfo.Ino(),
+				"cmd", fileInfo.CmdExePath())
+		}
 	}
 
-	mask &^= goRuntimeMetricMemoryAllocsMask
-	if p.log != nil {
-		p.log.Warn("Go runtime size-class table symbol unresolved; disabling allocation metrics",
-			"pid", fileInfo.Pid(),
-			"ino", fileInfo.Ino(),
-			"cmd", fileInfo.CmdExePath())
+	if mask&goRuntimeMetricGoroutineCountMask != 0 &&
+		(symbols.SchedAddr == 0 || symbols.AllgLenAddr == 0 || symbols.AllpAddr == 0 ||
+			!symbols.GoroutineCountModeKnown) {
+		mask &^= goRuntimeMetricGoroutineCountMask
+		if p.log != nil {
+			p.log.Warn("Go runtime goroutine count metadata unresolved; disabling goroutine metric",
+				"pid", fileInfo.Pid(),
+				"ino", fileInfo.Ino(),
+				"cmd", fileInfo.CmdExePath())
+		}
 	}
 	return mask
 }
@@ -700,9 +785,16 @@ var goChannelLinkProbeSymbols = []string{
 	"runtime.chanrecv2",
 }
 
+const (
+	goRuntimeMetricGCMarkDoneSymbol   = "runtime.gcMarkDone"
+	goRuntimeMetricHeapSnapshotSymbol = "runtime.(*scavengeIndex).nextGen"
+	goRuntimeMetricGCGoalSymbol       = "runtime.gcPaceScavenger"
+)
+
 var goRuntimeMetricProbeSymbols = []string{
-	"runtime.gcMarkDone",
-	"runtime.(*scavengeIndex).nextGen",
+	goRuntimeMetricGCMarkDoneSymbol,
+	goRuntimeMetricHeapSnapshotSymbol,
+	goRuntimeMetricGCGoalSymbol,
 }
 
 // GoChannelLinkProbeSymbols returns the Go runtime symbols used to correlate direct channel handoffs.
@@ -1069,14 +1161,20 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 	if p.goRuntimeHeapSnapshotProbeEnabled() {
 		// Go 1.23+ heap statistics use a rotating ring. Collect at nextGen after GC
 		// accounting and before the world restarts so the ring cannot rotate mid-read.
-		m[goRuntimeMetricProbeSymbols[1]] = []*ebpfcommon.ProbeDesc{{
+		m[goRuntimeMetricHeapSnapshotSymbol] = []*ebpfcommon.ProbeDesc{{
 			Start: p.bpfObjects.ObiUprobeGoRuntimeMetrics,
 		}}
 	} else {
 		// Older Go versions expose only the scalar metric set and may not contain
 		// nextGen. Keep the gcMarkDone return probe for backward compatibility.
-		m[goRuntimeMetricProbeSymbols[0]] = []*ebpfcommon.ProbeDesc{{
+		m[goRuntimeMetricGCMarkDoneSymbol] = []*ebpfcommon.ProbeDesc{{
 			End: p.bpfObjects.ObiUprobeGoRuntimeMetrics,
+		}}
+	}
+
+	if p.goRuntimeGCGoalSourceEnabled() {
+		m[goRuntimeMetricGCGoalSymbol] = []*ebpfcommon.ProbeDesc{{
+			Start: p.bpfObjects.ObiUprobeGoRuntimeGcGoal,
 		}}
 	}
 
@@ -1168,6 +1266,14 @@ func (p *Tracer) goRuntimeHeapSnapshotProbeEnabled() bool {
 	}
 
 	return p.goRuntimeMetricMaskByIno[p.currentBinaryIno]&goRuntimeMetricHeapSnapshotMask != 0
+}
+
+func (p *Tracer) goRuntimeGCGoalSourceEnabled() bool {
+	if p == nil || p.currentBinaryIno == 0 {
+		return false
+	}
+	return p.goRuntimeGCGoalSourceByIno[p.currentBinaryIno] ==
+		goRuntimeGCGoalSourcePaceScavengerArgument
 }
 
 func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {

--- a/pkg/internal/ebpf/gotracer/gotracer_test.go
+++ b/pkg/internal/ebpf/gotracer/gotracer_test.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"unsafe"
 
+	"github.com/cilium/ebpf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -109,6 +111,101 @@ func TestGoRuntimeMetricMaskABI(t *testing.T) {
 	assert.Equal(t, goRuntimeMetricCPUTimeMask, uint64(1<<4))
 	assert.Equal(t, goRuntimeMetricMemoryUsedMask, uint64(1<<5))
 	assert.Equal(t, goRuntimeMetricMemoryAllocsMask, uint64(1<<6))
+	assert.Equal(t, goRuntimeMetricGoroutineCountMask, uint64(1<<9))
+	assert.Equal(t, goRuntimeMetricMemoryGCGoalMask, uint64(1<<10))
+}
+
+func TestGoRuntimeMetricTargetABIAppendsGoroutineMetadata(t *testing.T) {
+	var target BpfGoRuntimeMetricTargetT
+
+	assert.Equal(t, uintptr(96), unsafe.Sizeof(target))
+	assert.Equal(t, uintptr(40), unsafe.Offsetof(target.SizeClassToSizesAddr))
+	assert.Equal(t, uintptr(48), unsafe.Offsetof(target.SchedAddr))
+	assert.Equal(t, uintptr(56), unsafe.Offsetof(target.AllglenAddr))
+	assert.Equal(t, uintptr(64), unsafe.Offsetof(target.AllpAddr))
+	assert.Equal(t, uintptr(72), unsafe.Offsetof(target.GoroutineCountIncludesSystem))
+}
+
+func TestGoRuntimeMetricTargetABIAppendsGCGoalCache(t *testing.T) {
+	var target BpfGoRuntimeMetricTargetT
+
+	assert.Equal(t, uintptr(96), unsafe.Sizeof(target))
+	assert.Equal(t, uintptr(80), unsafe.Offsetof(target.GcGoalSource))
+	assert.Equal(t, uintptr(88), unsafe.Offsetof(target.GcGoal))
+}
+
+func TestGoRuntimeGCGoalSourceSelection(t *testing.T) {
+	tests := []struct {
+		name                  string
+		offsets               *goexec.Offsets
+		goalArgumentSupported bool
+		want                  goRuntimeGCGoalSource
+	}{
+		{name: "missing metadata", offsets: nil, want: goRuntimeGCGoalSourceNone},
+		{name: "probe symbol with compatible signature", offsets: &goexec.Offsets{Funcs: map[string]goexec.FuncOffsets{
+			goRuntimeMetricGCGoalSymbol: {},
+		}}, goalArgumentSupported: true, want: goRuntimeGCGoalSourcePaceScavengerArgument},
+		{name: "probe symbol with incompatible signature", offsets: &goexec.Offsets{Funcs: map[string]goexec.FuncOffsets{
+			goRuntimeMetricGCGoalSymbol: {},
+		}}, want: goRuntimeGCGoalSourceNone},
+		{name: "heap goal field preferred when both sources are present", offsets: &goexec.Offsets{
+			Funcs: map[string]goexec.FuncOffsets{goRuntimeMetricGCGoalSymbol: {}},
+			Field: goexec.FieldOffsets{goexec.RuntimeGCControllerHeapGoalPos: uint64(112)},
+		}, want: goRuntimeGCGoalSourceHeapGoalField},
+		{name: "sources missing", offsets: &goexec.Offsets{}, want: goRuntimeGCGoalSourceNone},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, selectGoRuntimeGCGoalSource(tt.offsets, tt.goalArgumentSupported))
+		})
+	}
+}
+
+func TestGoRuntimeGCGoalProbeAttachedOnlyForPaceScavengerSource(t *testing.T) {
+	disableContextPropagationForTest(t)
+	tracer := &Tracer{
+		currentBinaryIno:         1,
+		goRuntimeMetricMaskByIno: map[uint64]uint64{1: goRuntimeMetricBaseMask | goRuntimeMetricMemoryGCGoalMask},
+		goRuntimeGCGoalSourceByIno: map[uint64]goRuntimeGCGoalSource{
+			1: goRuntimeGCGoalSourcePaceScavengerArgument,
+			2: goRuntimeGCGoalSourceHeapGoalField,
+			3: goRuntimeGCGoalSourceNone,
+		},
+	}
+	tracer.bpfObjects.ObiUprobeGoRuntimeGcGoal = &ebpf.Program{}
+
+	probes := tracer.GoProbes()
+	require.Contains(t, probes, goRuntimeMetricGCGoalSymbol)
+	require.NotNil(t, probes[goRuntimeMetricGCGoalSymbol][0].Start)
+	assert.Contains(t, probes, goRuntimeMetricGCMarkDoneSymbol)
+
+	for _, ino := range []uint64{2, 3} {
+		tracer.currentBinaryIno = ino
+		probes = tracer.GoProbes()
+		assert.NotContains(t, probes, goRuntimeMetricGCGoalSymbol)
+		assert.Contains(t, probes, goRuntimeMetricGCMarkDoneSymbol)
+	}
+}
+
+func TestGoRuntimeGoroutineCountAvailabilityRequiresAllOffsets(t *testing.T) {
+	offsets := goRuntimeMetricOffsets()
+	delete(offsets.Field, goexec.RuntimeGListSizePos)
+
+	assert.False(t, hasGoRuntimeGoroutineCountOffsets(offsets, false, true))
+	assert.False(t, hasGoRuntimeGoroutineCountOffsets(offsets, true, true))
+}
+
+func TestGoRuntimeGoroutineCountAvailabilityRequiresNgsysOnlyBeforeGo126(t *testing.T) {
+	offsets := goRuntimeMetricOffsets()
+	delete(offsets.Field, goexec.RuntimeSchedNgSysPos)
+
+	assert.False(t, hasGoRuntimeGoroutineCountOffsets(offsets, false, false), "unknown mode must fail closed")
+	assert.False(t, hasGoRuntimeGoroutineCountOffsets(offsets, false, true), "Go 1.25 requires sched.ngsys")
+	assert.True(t, hasGoRuntimeGoroutineCountOffsets(offsets, true, true), "Go 1.26 does not read sched.ngsys")
+
+	offsets.Field[goexec.RuntimeSchedNgSysPos] = uint64(0)
+	assert.True(t, hasGoRuntimeGoroutineCountOffsets(offsets, false, true))
 }
 
 func TestGoRuntimeMetricsUseHeapSnapshotProbe(t *testing.T) {
@@ -176,7 +273,11 @@ func TestGoRuntimeMetricsUseResolvedHeapProbe(t *testing.T) {
 	}
 	disableContextPropagationForTest(t)
 
-	tracer := &Tracer{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	var logs bytes.Buffer
+	tracer := &Tracer{log: slog.New(slog.NewTextHandler(
+		&logs,
+		&slog.HandlerOptions{Level: slog.LevelDebug},
+	))}
 	fileInfo := exec.New(exec.Init{ELF: currentExecutableELF(t), Ino: 1})
 	offsets := goRuntimeMetricOffsets()
 	offsets.Funcs[goRuntimeMetricProbeSymbols[1]] = goexec.FuncOffsets{}
@@ -187,6 +288,9 @@ func TestGoRuntimeMetricsUseResolvedHeapProbe(t *testing.T) {
 	mask := tracer.goRuntimeMetricMaskByIno[fileInfo.Ino()]
 	assert.NotZero(t, mask&goRuntimeMetricCPUTimeMask)
 	assert.Equal(t, goRuntimeMetricHeapSnapshotMask, mask&goRuntimeMetricHeapSnapshotMask)
+	assert.NotZero(t, mask&goRuntimeMetricGoroutineCountMask)
+	assert.NotZero(t, mask&goRuntimeMetricMemoryGCGoalMask)
+	assert.Contains(t, logs.String(), "goroutine_count_available=true")
 
 	probes := tracer.GoProbes()
 	require.Contains(t, probes, goRuntimeMetricProbeSymbols[1])
@@ -224,6 +328,31 @@ func TestGoRuntimeMetricMaskKeepsAllocationsWithSizeClassTable(t *testing.T) {
 
 	assert.Equal(t, mask, got)
 	assert.Empty(t, logs.String())
+}
+
+func TestGoRuntimeMetricMaskRequiresGoroutineSymbolsAndModeOnlyForCount(t *testing.T) {
+	tracer := &Tracer{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	fileInfo := exec.New(exec.Init{Ino: 1})
+	mask := goRuntimeMetricBaseMask | goRuntimeMetricCPUTimeMask | goRuntimeMetricGoroutineCountMask
+	symbols := goexec.RuntimeMetricSymbols{
+		SchedAddr:               0x1000,
+		AllgLenAddr:             0x2000,
+		AllpAddr:                0x3000,
+		GoroutineCountModeKnown: true,
+	}
+
+	assert.Equal(t, mask, tracer.goRuntimeMetricMaskForSymbols(fileInfo, mask, symbols))
+
+	symbols.AllgLenAddr = 0
+	got := tracer.goRuntimeMetricMaskForSymbols(fileInfo, mask, symbols)
+	assert.Zero(t, got&goRuntimeMetricGoroutineCountMask)
+	assert.NotZero(t, got&goRuntimeMetricCPUTimeMask)
+
+	symbols.AllgLenAddr = 0x2000
+	symbols.GoroutineCountModeKnown = false
+	got = tracer.goRuntimeMetricMaskForSymbols(fileInfo, mask, symbols)
+	assert.Zero(t, got&goRuntimeMetricGoroutineCountMask)
+	assert.NotZero(t, got&goRuntimeMetricCPUTimeMask)
 }
 
 func TestProcessBinarySelectsRecordedChannelOffsetState(t *testing.T) {

--- a/pkg/internal/goexec/gofile.go
+++ b/pkg/internal/goexec/gofile.go
@@ -19,8 +19,10 @@ import (
 const (
 	// minGoVersion defines the minimum instrumentable Go version. If the target binary was
 	// compiled using an older Go version, it will be treated as a non-Go program.
-	minGoVersion                    = "1.17"
-	minGoRuntimeMemoryMetricVersion = "1.23"
+	minGoVersion                                    = "1.17"
+	minGoRuntimeMemoryMetricVersion                 = "1.23"
+	minGoRuntimeGCGoalArgumentVersion               = "1.19"
+	minGoRuntimeGoroutineCountIncludesSystemVersion = "1.26"
 )
 
 var goVersionPattern = regexp.MustCompile(`\d+\.\d+(?:\.\d+)?`)
@@ -54,6 +56,17 @@ func goVersionAtLeast(version, minimum string) bool {
 
 	// 'semver' package requires version strings to begin with a leading "v".
 	return semver.Compare("v"+match, "v"+minimum) >= 0
+}
+
+func runtimeMetricGoroutineCountModeVersion(version string) (includesSystem, known bool) {
+	if goVersionPattern.FindString(version) == "" {
+		return false, false
+	}
+	return goVersionAtLeast(version, minGoRuntimeGoroutineCountIncludesSystemVersion), true
+}
+
+func runtimeMetricGCGoalArgumentSupportedVersion(version string) bool {
+	return goVersionAtLeast(version, minGoRuntimeGCGoalArgumentVersion)
 }
 
 // findLibraryVersions looks for all the libraries and versions inside the elf file.

--- a/pkg/internal/goexec/gofile_test.go
+++ b/pkg/internal/goexec/gofile_test.go
@@ -73,6 +73,51 @@ func TestGoRuntimeMemoryMetricVersion(t *testing.T) {
 	}
 }
 
+func TestRuntimeMetricGoroutineCountModeVersion(t *testing.T) {
+	tests := []struct {
+		version        string
+		includesSystem bool
+		known          bool
+	}{
+		{version: "go1.25.11", known: true},
+		{version: "go1.26.0", includesSystem: true, known: true},
+		{version: "unknown"},
+	}
+
+	for _, tt := range tests {
+		includesSystem, known := runtimeMetricGoroutineCountModeVersion(tt.version)
+		assert.Equal(t, tt.includesSystem, includesSystem, "version: %s", tt.version)
+		assert.Equal(t, tt.known, known, "version: %s", tt.version)
+	}
+}
+
+func TestRuntimeMetricGoroutineCountModeFailsClosedWithoutELF(t *testing.T) {
+	includesSystem, known := RuntimeMetricGoroutineCountMode(nil)
+	assert.False(t, includesSystem)
+	assert.False(t, known)
+}
+
+func TestRuntimeMetricGCGoalArgumentSupportedVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{version: "go1.17.13"},
+		{version: "go1.18.10"},
+		{version: "go1.19", want: true},
+		{version: "go1.26.3", want: true},
+		{version: "unknown"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, runtimeMetricGCGoalArgumentSupportedVersion(tt.version))
+	}
+}
+
+func TestRuntimeMetricGCGoalArgumentFailsClosedWithoutELF(t *testing.T) {
+	assert.False(t, RuntimeMetricGCGoalArgumentSupported(nil))
+}
+
 func TestRuntimeMetricSymbolAddrFallsBackToInternalSizeClassTable(t *testing.T) {
 	symbols := map[string]procs.Sym{
 		runtimeMetricInternalSizeClassToSizesSymbol: {Off: 0x20},
@@ -81,4 +126,22 @@ func TestRuntimeMetricSymbolAddrFallsBackToInternalSizeClassTable(t *testing.T) 
 	got := runtimeMetricSymbolAddr(symbols, runtimeMetricSizeClassToSizesSymbol, 0x1000)
 
 	assert.Equal(t, uint64(0x1020), got)
+}
+
+func TestRuntimeMetricSymbolAddrResolvesOptionalGoroutineSymbols(t *testing.T) {
+	symbols := map[string]procs.Sym{
+		runtimeMetricSchedSymbol:   {Off: 0x40},
+		runtimeMetricAllgLenSymbol: {Off: 0x50},
+		runtimeMetricAllpSymbol:    {Off: 0x60},
+	}
+
+	assert.Equal(t, uint64(0x1040),
+		runtimeMetricSymbolAddr(symbols, runtimeMetricSchedSymbol, 0x1000))
+	assert.Equal(t, uint64(0x1050),
+		runtimeMetricSymbolAddr(symbols, runtimeMetricAllgLenSymbol, 0x1000))
+	assert.Equal(t, uint64(0x1060),
+		runtimeMetricSymbolAddr(symbols, runtimeMetricAllpSymbol, 0x1000))
+	assert.Zero(t, runtimeMetricSymbolAddr(nil, runtimeMetricSchedSymbol, 0x1000))
+	assert.Zero(t, runtimeMetricSymbolAddr(nil, runtimeMetricAllgLenSymbol, 0x1000))
+	assert.Zero(t, runtimeMetricSymbolAddr(nil, runtimeMetricAllpSymbol, 0x1000))
 }

--- a/pkg/internal/goexec/offsets.json
+++ b/pkg/internal/goexec/offsets.json
@@ -1344,6 +1344,20 @@
         ]
       }
     },
+    "runtime.gList": {
+      "size": {
+        "versions": {
+          "oldest": "1.25.0",
+          "newest": "1.26.5"
+        },
+        "offsets": [
+          {
+            "offset": 8,
+            "since": "1.25.0"
+          }
+        ]
+      }
+    },
     "runtime.consistentHeapStats": {
       "stats": {
         "versions": {
@@ -1466,6 +1480,22 @@
           {
             "offset": 0,
             "since": "1.17.0"
+          }
+        ]
+      },
+      "heapGoal": {
+        "versions": {
+          "oldest": "1.17.0",
+          "newest": "1.18.10"
+        },
+        "offsets": [
+          {
+            "offset": 32,
+            "since": "1.17.0"
+          },
+          {
+            "offset": 104,
+            "since": "1.18.0"
           }
         ]
       },
@@ -1830,6 +1860,92 @@
           {
             "offset": 3520,
             "since": "1.25.0"
+          }
+        ]
+      }
+    },
+    "runtime.mutex": {
+      "key": {
+        "versions": {
+          "oldest": "1.17.0",
+          "newest": "1.26.5"
+        },
+        "offsets": [
+          {
+            "offset": 0,
+            "since": "1.17.0"
+          }
+        ]
+      }
+    },
+    "runtime.p": {
+      "gFree": {
+        "versions": {
+          "oldest": "1.17.0",
+          "newest": "1.26.5"
+        },
+        "offsets": [
+          {
+            "offset": 3584,
+            "since": "1.17.0"
+          },
+          {
+            "offset": 2464,
+            "since": "1.18.0"
+          },
+          {
+            "offset": 2456,
+            "since": "1.23.0"
+          },
+          {
+            "offset": 2464,
+            "since": "1.26.0"
+          }
+        ]
+      }
+    },
+    "runtime.schedt": {
+      "gFree": {
+        "versions": {
+          "oldest": "1.17.0",
+          "newest": "1.26.5"
+        },
+        "offsets": [
+          {
+            "offset": 152,
+            "since": "1.17.0"
+          },
+          {
+            "offset": 160,
+            "since": "1.20.0"
+          },
+          {
+            "offset": 168,
+            "since": "1.25.0"
+          },
+          {
+            "offset": 184,
+            "since": "1.26.0"
+          }
+        ]
+      },
+      "ngsys": {
+        "versions": {
+          "oldest": "1.17.0",
+          "newest": "1.26.5"
+        },
+        "offsets": [
+          {
+            "offset": 72,
+            "since": "1.17.0"
+          },
+          {
+            "offset": 80,
+            "since": "1.25.0"
+          },
+          {
+            "offset": 96,
+            "since": "1.26.0"
           }
         ]
       }

--- a/pkg/internal/goexec/runtime_metrics.go
+++ b/pkg/internal/goexec/runtime_metrics.go
@@ -14,16 +14,24 @@ import (
 )
 
 type RuntimeMetricSymbols struct {
-	MemstatsAddr         uint64
-	GCControllerAddr     uint64
-	GOMAXPROCSAddr       uint64
-	WorkAddr             uint64
-	SizeClassToSizesAddr uint64
+	MemstatsAddr                 uint64
+	GCControllerAddr             uint64
+	GOMAXPROCSAddr               uint64
+	WorkAddr                     uint64
+	SizeClassToSizesAddr         uint64
+	SchedAddr                    uint64
+	AllgLenAddr                  uint64
+	AllpAddr                     uint64
+	GoroutineCountIncludesSystem bool
+	GoroutineCountModeKnown      bool
 }
 
 const (
 	runtimeMetricSizeClassToSizesSymbol         = "runtime.class_to_size"
 	runtimeMetricInternalSizeClassToSizesSymbol = "internal/runtime/gc.SizeClassToSize"
+	runtimeMetricSchedSymbol                    = "runtime.sched"
+	runtimeMetricAllgLenSymbol                  = "runtime.allglen"
+	runtimeMetricAllpSymbol                     = "runtime.allp"
 )
 
 // ResolveRuntimeMetricSymbols resolves Go runtime global variables to absolute
@@ -39,7 +47,12 @@ func ResolveRuntimeMetricSymbols(file *exec.FileInfo, pid app.PID) (RuntimeMetri
 		return RuntimeMetricSymbols{}, fmt.Errorf("reading executable load bias: %w", err)
 	}
 
-	return resolveRuntimeMetricSymbols(file.ELF(), loadBias)
+	symbols, err := resolveRuntimeMetricSymbols(file.ELF(), loadBias)
+	if err != nil {
+		return RuntimeMetricSymbols{}, err
+	}
+	symbols.GoroutineCountIncludesSystem, symbols.GoroutineCountModeKnown = RuntimeMetricGoroutineCountMode(file.ELF())
+	return symbols, nil
 }
 
 func resolveRuntimeMetricSymbols(f *elf.File, loadBias uint64) (RuntimeMetricSymbols, error) {
@@ -57,6 +70,9 @@ func resolveRuntimeMetricSymbols(f *elf.File, loadBias uint64) (RuntimeMetricSym
 		workSymbol,
 		runtimeMetricSizeClassToSizesSymbol,
 		runtimeMetricInternalSizeClassToSizesSymbol,
+		runtimeMetricSchedSymbol,
+		runtimeMetricAllgLenSymbol,
+		runtimeMetricAllpSymbol,
 	}, elf.STT_OBJECT)
 	if err != nil {
 		return RuntimeMetricSymbols{}, err
@@ -81,7 +97,36 @@ func resolveRuntimeMetricSymbols(f *elf.File, loadBias uint64) (RuntimeMetricSym
 		GOMAXPROCSAddr:       loadBias + gomaxprocs.Off,
 		WorkAddr:             runtimeMetricSymbolAddr(symbols, workSymbol, loadBias),
 		SizeClassToSizesAddr: runtimeMetricSymbolAddr(symbols, runtimeMetricSizeClassToSizesSymbol, loadBias),
+		SchedAddr:            runtimeMetricSymbolAddr(symbols, runtimeMetricSchedSymbol, loadBias),
+		AllgLenAddr:          runtimeMetricSymbolAddr(symbols, runtimeMetricAllgLenSymbol, loadBias),
+		AllpAddr:             runtimeMetricSymbolAddr(symbols, runtimeMetricAllpSymbol, loadBias),
 	}, nil
+}
+
+// RuntimeMetricGoroutineCountMode reports whether the target Go runtime's
+// goroutine metric includes system goroutines and whether that mode is known.
+func RuntimeMetricGoroutineCountMode(f *elf.File) (includesSystem, known bool) {
+	if f == nil {
+		return false, false
+	}
+	goVersion, _, err := getGoDetails(f)
+	if err != nil {
+		return false, false
+	}
+	return runtimeMetricGoroutineCountModeVersion(goVersion)
+}
+
+// RuntimeMetricGCGoalArgumentSupported reports whether runtime.gcPaceScavenger
+// has the Go 1.19+ argument layout used by the GC goal probe.
+func RuntimeMetricGCGoalArgumentSupported(f *elf.File) bool {
+	if f == nil {
+		return false
+	}
+	goVersion, _, err := getGoDetails(f)
+	if err != nil {
+		return false
+	}
+	return runtimeMetricGCGoalArgumentSupportedVersion(goVersion)
 }
 
 func runtimeMetricSymbolAddr(symbols map[string]procs.Sym, name string, loadBias uint64) uint64 {

--- a/pkg/internal/goexec/structmembers.go
+++ b/pkg/internal/goexec/structmembers.go
@@ -166,6 +166,12 @@ const (
 	RuntimeHeapStatsDeltaLargeAllocCountPos
 	RuntimeHeapStatsDeltaSmallAllocCountPos
 	RuntimeHeapStatsDeltaSmallFreeCountPos
+	RuntimeSchedNgSysPos
+	RuntimeSchedGFreeStackPos
+	RuntimeSchedGFreeNoStackPos
+	RuntimePFreeGPos
+	RuntimeGListSizePos
+	RuntimeGCControllerHeapGoalPos
 )
 
 //go:embed offsets.json
@@ -177,6 +183,33 @@ type structInfo struct {
 	lib string
 	// fields of the struct as key, and the name of the constant defined in the eBPF code as value
 	fields map[string]GoOffset
+}
+
+type nestedStructField struct {
+	parentType  string
+	parentField string
+	childField  string
+	offset      GoOffset
+}
+
+const (
+	runtimePointerSize = 8
+	runtimeInt32Size   = 4
+)
+
+var nestedRuntimeFields = []nestedStructField{
+	{
+		parentType:  "runtime.schedt",
+		parentField: "gFree",
+		childField:  "stack",
+		offset:      RuntimeSchedGFreeStackPos,
+	},
+	{
+		parentType:  "runtime.schedt",
+		parentField: "gFree",
+		childField:  "noStack",
+		offset:      RuntimeSchedGFreeNoStackPos,
+	},
 }
 
 // level-1 key = Struct type name and its containing library
@@ -571,6 +604,7 @@ var structMembers = map[string]structInfo{
 		fields: map[string]GoOffset{
 			"memoryLimit": RuntimeGCControllerMemoryLimitPos,
 			"gcPercent":   RuntimeGCControllerGCPercentPos,
+			"heapGoal":    RuntimeGCControllerHeapGoalPos,
 		},
 	},
 	"runtime.workType": {
@@ -607,6 +641,24 @@ var structMembers = map[string]structInfo{
 			"largeAllocCount": RuntimeHeapStatsDeltaLargeAllocCountPos,
 			"smallAllocCount": RuntimeHeapStatsDeltaSmallAllocCountPos,
 			"smallFreeCount":  RuntimeHeapStatsDeltaSmallFreeCountPos,
+		},
+	},
+	"runtime.schedt": {
+		lib: "go",
+		fields: map[string]GoOffset{
+			"ngsys": RuntimeSchedNgSysPos,
+		},
+	},
+	"runtime.p": {
+		lib: "go",
+		fields: map[string]GoOffset{
+			"gFree": RuntimePFreeGPos,
+		},
+	},
+	"runtime.gList": {
+		lib: "go",
+		fields: map[string]GoOffset{
+			"size": RuntimeGListSizePos,
 		},
 	},
 }
@@ -736,8 +788,15 @@ func structMemberPreFetchedOffsets(elfFile *elf.File, fieldOffsets FieldOffsets)
 		version, ok := libVersions[strInfo.lib]
 		version = cleanLibVersion(version, ok, strInfo.lib, log)
 		for fieldName, constantName := range strInfo.fields {
+			if _, found := fieldOffsets[constantName]; found {
+				continue
+			}
+
 			// look the version of the required field in the offsets.json memory copy
 			offset, ok := offs.Find(strName, fieldName, version)
+			if constantName == RuntimeGCControllerHeapGoalPos {
+				offset, ok = prefetchedGoRuntimeGCGoalOffset(offs, version)
+			}
 			if !ok {
 				log.Debug("can't find offsets for field",
 					"lib", strInfo.lib, "name", strName, "field", fieldName, "version", version)
@@ -747,7 +806,81 @@ func structMemberPreFetchedOffsets(elfFile *elf.File, fieldOffsets FieldOffsets)
 			fieldOffsets[constantName] = offset
 		}
 	}
+	version, ok := libVersions["go"]
+	resolveNestedStructPreFetchedOffsets(
+		offs, fieldOffsets, cleanLibVersion(version, ok, "go", log), log,
+	)
 	return fieldOffsets, nil
+}
+
+func prefetchedGoRuntimeGCGoalOffset(offs *offsets.Track, goVersion string) (uint64, bool) {
+	field, ok := offs.Data["runtime.gcControllerState"]["heapGoal"]
+	if !ok {
+		return 0, false
+	}
+
+	target, err := version.NewVersion(goVersion)
+	if err != nil {
+		return 0, false
+	}
+	newest, err := version.NewVersion(field.Versions.Newest)
+	if err != nil || target.GreaterThan(newest) {
+		return 0, false
+	}
+
+	return field.GetOffset(goVersion)
+}
+
+func resolveNestedStructPreFetchedOffsets(
+	offs *offsets.Track,
+	fieldOffsets FieldOffsets,
+	goVersion string,
+	log *slog.Logger,
+) {
+	if _, stackOK := fieldOffsets[RuntimeSchedGFreeStackPos]; stackOK {
+		if _, noStackOK := fieldOffsets[RuntimeSchedGFreeNoStackPos]; noStackOK {
+			return
+		}
+	}
+
+	gFreeOff, ok := offs.Find("runtime.schedt", "gFree", goVersion)
+	if !ok {
+		log.Debug("can't derive nested runtime offsets",
+			"missing_field", "runtime.schedt.gFree", "go_version", goVersion)
+		return
+	}
+	mutexKeyOff, ok := offs.Find("runtime.mutex", "key", goVersion)
+	if !ok {
+		log.Debug("can't derive nested runtime offsets",
+			"missing_field", "runtime.mutex.key", "go_version", goVersion)
+		return
+	}
+	gListSizeOff, ok := offs.Find("runtime.gList", "size", goVersion)
+	if !ok {
+		log.Debug("can't derive nested runtime offsets",
+			"missing_field", "runtime.gList.size", "go_version", goVersion)
+		return
+	}
+
+	mutexSize := alignRuntimeOffset(mutexKeyOff+runtimePointerSize, runtimePointerSize)
+	gListSize := alignRuntimeOffset(gListSizeOff+runtimeInt32Size, runtimePointerSize)
+	stackOff := gFreeOff + mutexSize
+	noStackOff := stackOff + gListSize
+	if _, ok := fieldOffsets[RuntimeSchedGFreeStackPos]; !ok {
+		log.Debug("found nested offset", "fieldName", "gFree.stack", "offset", stackOff)
+		fieldOffsets[RuntimeSchedGFreeStackPos] = stackOff
+	}
+	if _, ok := fieldOffsets[RuntimeSchedGFreeNoStackPos]; !ok {
+		log.Debug("found nested offset", "fieldName", "gFree.noStack", "offset", noStackOff)
+		fieldOffsets[RuntimeSchedGFreeNoStackPos] = noStackOff
+	}
+}
+
+func alignRuntimeOffset(offset, alignment uint64) uint64 {
+	if alignment == 0 || offset%alignment == 0 {
+		return offset
+	}
+	return offset + alignment - offset%alignment
 }
 
 // structMemberOffsetsFromDwarf reads the executable dwarf information to get
@@ -759,6 +892,9 @@ func structMemberOffsetsFromDwarf(data *dwarf.Data) (FieldOffsets, map[GoOffset]
 		for _, ctName := range str.fields {
 			expectedReturns[ctName] = struct{}{}
 		}
+	}
+	for _, field := range nestedRuntimeFields {
+		expectedReturns[field.offset] = struct{}{}
 	}
 	log.Debug("searching offests for field constants", "constants", expectedReturns)
 
@@ -777,22 +913,75 @@ func structMemberOffsetsFromDwarf(data *dwarf.Data) (FieldOffsets, map[GoOffset]
 			continue
 		}
 		attrs := getAttrs(entry)
-		typeName, ok := attrs[dwarf.AttrName]
+		typeName, ok := attrs[dwarf.AttrName].(string)
 		if !ok {
 			reader.SkipChildren()
 			continue
 		}
-		structMember, ok := structMembers[typeName.(string)]
+		structMember, ok := structMembers[typeName]
 		if !ok {
 			reader.SkipChildren()
 			continue
 		}
 		log.Debug("inspecting fields for struct type", "type", typeName)
+		resolveNestedStructOffsets(data, entry.Offset, typeName, expectedReturns, fieldOffsets)
 		if err := readMembers(reader, structMember.fields, expectedReturns, fieldOffsets); err != nil {
 			log.Debug("error reading DWARF info", "type", typeName, "error", err)
 			return fieldOffsets, expectedReturns
 		}
 	}
+}
+
+func resolveNestedStructOffsets(
+	data *dwarf.Data,
+	typeOffset dwarf.Offset,
+	typeName string,
+	expectedReturns map[GoOffset]struct{},
+	offsets FieldOffsets,
+) {
+	var fields []nestedStructField
+	for _, field := range nestedRuntimeFields {
+		if field.parentType == typeName {
+			fields = append(fields, field)
+		}
+	}
+	if len(fields) == 0 {
+		return
+	}
+
+	typeInfo, err := data.Type(typeOffset)
+	if err != nil {
+		return
+	}
+	parent, ok := typeInfo.(*dwarf.StructType)
+	if !ok {
+		return
+	}
+	for _, field := range fields {
+		parentField := dwarfStructFieldByName(parent, field.parentField)
+		if parentField == nil {
+			continue
+		}
+		child, ok := parentField.Type.(*dwarf.StructType)
+		if !ok {
+			continue
+		}
+		childField := dwarfStructFieldByName(child, field.childField)
+		if childField == nil {
+			continue
+		}
+		offsets[field.offset] = uint64(parentField.ByteOffset + childField.ByteOffset)
+		delete(expectedReturns, field.offset)
+	}
+}
+
+func dwarfStructFieldByName(structType *dwarf.StructType, name string) *dwarf.StructField {
+	for _, field := range structType.Field {
+		if field.Name == name {
+			return field
+		}
+	}
+	return nil
 }
 
 type dwarfReader interface {

--- a/pkg/internal/goexec/structmembers_test.go
+++ b/pkg/internal/goexec/structmembers_test.go
@@ -79,6 +79,38 @@ func mustMatch(t *testing.T, expected, actual FieldOffsets) {
 	}
 }
 
+func dwarfStruct(t *testing.T, data *dwarf.Data, name string) *dwarf.StructType {
+	t.Helper()
+
+	reader := data.Reader()
+	for {
+		entry, err := reader.Next()
+		require.NoError(t, err)
+		if entry == nil {
+			t.Fatalf("DWARF struct %s not found", name)
+		}
+		if entry.Tag != dwarf.TagStructType || entry.Val(dwarf.AttrName) != name {
+			continue
+		}
+		typeData, err := data.Type(entry.Offset)
+		require.NoError(t, err)
+		if structType, ok := typeData.(*dwarf.StructType); ok && len(structType.Field) > 0 {
+			return structType
+		}
+	}
+}
+
+func dwarfStructField(t *testing.T, structType *dwarf.StructType, name string) *dwarf.StructField {
+	t.Helper()
+	for _, field := range structType.Field {
+		if field.Name == name {
+			return field
+		}
+	}
+	t.Fatalf("DWARF field %s.%s not found", structType.StructName, name)
+	return nil
+}
+
 func TestGoOffsetsFromDwarf(t *testing.T) {
 	offsets, _ := structMemberOffsetsFromDwarf(debugData)
 	// this test might fail if a future Go version updates the internal structure of the used structs.
@@ -95,6 +127,21 @@ func TestGoOffsetsFromDwarf(t *testing.T) {
 		HchanSendxPos:     uint64(48),
 		HchanRecvxPos:     uint64(56),
 	}, offsets)
+}
+
+func TestNestedRuntimeOffsetsFromDwarf(t *testing.T) {
+	offsets, missing := structMemberOffsetsFromDwarf(debugData)
+	schedType := dwarfStruct(t, debugData, "runtime.schedt")
+	gFreeField := dwarfStructField(t, schedType, "gFree")
+	gFreeType, ok := gFreeField.Type.(*dwarf.StructType)
+	require.True(t, ok)
+
+	stack := uint64(gFreeField.ByteOffset + dwarfStructField(t, gFreeType, "stack").ByteOffset)
+	noStack := uint64(gFreeField.ByteOffset + dwarfStructField(t, gFreeType, "noStack").ByteOffset)
+	require.NotContains(t, missing, RuntimeSchedGFreeStackPos)
+	require.NotContains(t, missing, RuntimeSchedGFreeNoStackPos)
+	assert.Equal(t, stack, offsets[RuntimeSchedGFreeStackPos])
+	assert.Equal(t, noStack, offsets[RuntimeSchedGFreeNoStackPos])
 }
 
 func TestGrpcOffsetsFromDwarf(t *testing.T) {
@@ -127,6 +174,47 @@ func TestGoOffsetsWithoutDwarf(t *testing.T) {
 		RuntimeGCControllerMemoryLimitPos: uint64(8),
 		RuntimeGCControllerGCPercentPos:   uint64(0),
 	}, offsets)
+}
+
+func TestGoRuntimeGCGoalFieldUnavailableAfterTrackedRange(t *testing.T) {
+	offsets, err := structMemberOffsets(smallELF)
+	require.NoError(t, err)
+
+	assert.NotContains(t, offsets, RuntimeGCControllerHeapGoalPos)
+}
+
+func TestPrefetchedOffsetsPreserveResolvedOffsets(t *testing.T) {
+	const resolvedOffset = uint64(999)
+	resolved := FieldOffsets{
+		RuntimeGCControllerGCPercentPos: resolvedOffset,
+	}
+
+	got, err := structMemberPreFetchedOffsets(smallELF, resolved)
+	require.NoError(t, err)
+	assert.Equal(t, resolvedOffset, got[RuntimeGCControllerGCPercentPos])
+}
+
+func TestGoroutineRuntimeOffsetsWithoutDwarf(t *testing.T) {
+	offsets, err := structMemberOffsets(smallELF)
+	require.NoError(t, err)
+	schedType := dwarfStruct(t, debugData, "runtime.schedt")
+	gFreeField := dwarfStructField(t, schedType, "gFree")
+	gFreeType, ok := gFreeField.Type.(*dwarf.StructType)
+	require.True(t, ok)
+
+	assert.Equal(t,
+		uint64(gFreeField.ByteOffset+dwarfStructField(t, gFreeType, "stack").ByteOffset),
+		offsets[RuntimeSchedGFreeStackPos])
+	assert.Equal(t,
+		uint64(gFreeField.ByteOffset+dwarfStructField(t, gFreeType, "noStack").ByteOffset),
+		offsets[RuntimeSchedGFreeNoStackPos])
+	for _, field := range []GoOffset{
+		RuntimeSchedNgSysPos,
+		RuntimePFreeGPos,
+		RuntimeGListSizePos,
+	} {
+		assert.IsType(t, uint64(0), offsets[field], "offset %d", field)
+	}
 }
 
 func TestGrpcOffsetsWithoutDwarf(t *testing.T) {
@@ -277,6 +365,108 @@ func TestPrefetchedGoRuntimeMemoryOffsets(t *testing.T) {
 		require.True(t, found, "%s.%s missing for Go 1.25", tt.structName, tt.fieldName)
 		assert.Equal(t, tt.go125, offset, "%s.%s Go 1.25 offset", tt.structName, tt.fieldName)
 	}
+}
+
+func TestPrefetchedGoRuntimeGoroutineOffsets(t *testing.T) {
+	track, err := offsets.Read(bytes.NewBufferString(prefetchedOffsets))
+	require.NoError(t, err)
+
+	tests := []struct {
+		structName string
+		fieldName  string
+		goVersion  string
+		want       uint64
+	}{
+		{structName: "runtime.gList", fieldName: "size", goVersion: "1.25.0", want: 8},
+		{structName: "runtime.mutex", fieldName: "key", goVersion: "1.17.0", want: 0},
+		{structName: "runtime.p", fieldName: "gFree", goVersion: "1.17.0", want: 3584},
+		{structName: "runtime.p", fieldName: "gFree", goVersion: "1.18.0", want: 2464},
+		{structName: "runtime.p", fieldName: "gFree", goVersion: "1.23.0", want: 2456},
+		{structName: "runtime.p", fieldName: "gFree", goVersion: "1.26.0", want: 2464},
+		{structName: "runtime.schedt", fieldName: "gFree", goVersion: "1.17.0", want: 152},
+		{structName: "runtime.schedt", fieldName: "gFree", goVersion: "1.20.0", want: 160},
+		{structName: "runtime.schedt", fieldName: "gFree", goVersion: "1.25.0", want: 168},
+		{structName: "runtime.schedt", fieldName: "gFree", goVersion: "1.26.0", want: 184},
+		{structName: "runtime.schedt", fieldName: "ngsys", goVersion: "1.17.0", want: 72},
+		{structName: "runtime.schedt", fieldName: "ngsys", goVersion: "1.25.0", want: 80},
+		{structName: "runtime.schedt", fieldName: "ngsys", goVersion: "1.26.0", want: 96},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.structName+"."+tt.fieldName+"/"+tt.goVersion, func(t *testing.T) {
+			assertPrefetchedOffset(t, track, tt.structName, tt.fieldName, tt.goVersion, tt.want)
+		})
+	}
+
+	_, found := track.Find("runtime.gList", "size", "1.24.0")
+	assert.False(t, found, "runtime.gList.size should be unavailable before Go 1.25")
+}
+
+func TestPrefetchedGoRuntimeGCGoalFieldOffsets(t *testing.T) {
+	track, err := offsets.Read(bytes.NewBufferString(prefetchedOffsets))
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		goVersion string
+		want      uint64
+	}{
+		{goVersion: "1.17.0", want: 32},
+		{goVersion: "1.17.13", want: 32},
+		{goVersion: "1.18.0", want: 104},
+		{goVersion: "1.18.10", want: 104},
+	} {
+		offset, found := prefetchedGoRuntimeGCGoalOffset(track, tt.goVersion)
+		require.True(t, found, "heapGoal missing for Go %s", tt.goVersion)
+		assert.Equal(t, tt.want, offset)
+	}
+	_, found := prefetchedGoRuntimeGCGoalOffset(track, "1.19.0")
+	assert.False(t, found)
+
+	heapGoal := track.Data["runtime.gcControllerState"]["heapGoal"]
+	assert.Equal(t, "1.17.0", heapGoal.Versions.Oldest)
+	assert.Equal(t, "1.18.10", heapGoal.Versions.Newest)
+}
+
+func TestResolveNestedStructPrefetchedOffsetsLogsMissingFields(t *testing.T) {
+	const goVersion = "1.25.0"
+	for _, missing := range []struct {
+		structName string
+		fieldName  string
+	}{
+		{structName: "runtime.schedt", fieldName: "gFree"},
+		{structName: "runtime.mutex", fieldName: "key"},
+		{structName: "runtime.gList", fieldName: "size"},
+	} {
+		t.Run(missing.structName+"."+missing.fieldName, func(t *testing.T) {
+			track, err := offsets.Read(bytes.NewBufferString(prefetchedOffsets))
+			require.NoError(t, err)
+			delete(track.Data[missing.structName], missing.fieldName)
+
+			var logs bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(
+				&logs,
+				&slog.HandlerOptions{Level: slog.LevelDebug},
+			))
+			resolveNestedStructPreFetchedOffsets(track, FieldOffsets{}, goVersion, logger)
+
+			assert.Contains(t, logs.String(), "missing_field="+missing.structName+"."+missing.fieldName)
+			assert.Contains(t, logs.String(), "go_version="+goVersion)
+		})
+	}
+}
+
+func assertPrefetchedOffset(
+	t *testing.T,
+	track *offsets.Track,
+	structName string,
+	fieldName string,
+	goVersion string,
+	want uint64,
+) {
+	t.Helper()
+	offset, found := track.Find(structName, fieldName, goVersion)
+	require.True(t, found, "%s.%s missing for Go %s", structName, fieldName, goVersion)
+	assert.Equal(t, want, offset, "%s.%s Go %s offset", structName, fieldName, goVersion)
 }
 
 type fakeDwarfReader struct {

--- a/pkg/runtimemetrics/reader.go
+++ b/pkg/runtimemetrics/reader.go
@@ -42,6 +42,8 @@ type GoRuntimeMetricSnapshot struct {
 	MemoryUsedOther   *int64
 	MemoryAllocated   *uint64
 	MemoryAllocations *uint64
+	GoroutineCount    *int64
+	MemoryGCGoal      *int64
 }
 
 type GoRuntimeCPUTimeSnapshot struct {
@@ -160,6 +162,8 @@ type goRuntimeMetricRawSnapshot struct {
 	MemoryUsedOther       int64
 	MemoryAllocated       uint64
 	MemoryAllocations     uint64
+	GoroutineCount        int64
+	MemoryGCGoal          uint64
 }
 
 // Mirrors go_runtime_metric_valid_t in bpf/gotracer/maps/runtime.h.
@@ -172,6 +176,8 @@ const (
 	goRuntimeMetricValidCPUTime        uint64 = 1 << 4
 	goRuntimeMetricValidMemoryUsed     uint64 = 1 << 5
 	goRuntimeMetricValidMemoryAllocs   uint64 = 1 << 6
+	goRuntimeMetricValidGoroutineCount uint64 = 1 << 9
+	goRuntimeMetricValidMemoryGCGoal   uint64 = 1 << 10
 )
 
 func SnapshotFromRingbuf(
@@ -277,6 +283,16 @@ func convertGoRuntimeMetricSnapshot(
 		memoryAllocated = &raw.MemoryAllocated
 		memoryAllocations = &raw.MemoryAllocations
 	}
+	var goroutineCount *int64
+	if raw.ValidMask&goRuntimeMetricValidGoroutineCount != 0 && raw.GoroutineCount > 0 {
+		goroutineCount = &raw.GoroutineCount
+	}
+	var memoryGCGoal *int64
+	if raw.ValidMask&goRuntimeMetricValidMemoryGCGoal != 0 &&
+		raw.MemoryGCGoal > 0 && raw.MemoryGCGoal <= math.MaxInt64 {
+		value := int64(raw.MemoryGCGoal)
+		memoryGCGoal = &value
+	}
 
 	return RuntimeMetricSnapshot{
 		Service: service,
@@ -292,6 +308,8 @@ func convertGoRuntimeMetricSnapshot(
 			MemoryUsedOther:   memoryUsedOther,
 			MemoryAllocated:   memoryAllocated,
 			MemoryAllocations: memoryAllocations,
+			GoroutineCount:    goroutineCount,
+			MemoryGCGoal:      memoryGCGoal,
 		},
 	}
 }

--- a/pkg/runtimemetrics/reader_test.go
+++ b/pkg/runtimemetrics/reader_test.go
@@ -28,9 +28,9 @@ func TestGoRuntimeMetricRawABI(t *testing.T) {
 	var event goRuntimeMetricRawEvent
 	var snapshot goRuntimeMetricRawSnapshot
 
-	require.Equal(t, uintptr(144), unsafe.Sizeof(event))
+	require.Equal(t, uintptr(160), unsafe.Sizeof(event))
 	require.Equal(t, uintptr(16), unsafe.Offsetof(event.Snapshot))
-	require.Equal(t, uintptr(128), unsafe.Sizeof(snapshot))
+	require.Equal(t, uintptr(144), unsafe.Sizeof(snapshot))
 	require.Equal(t, uintptr(0), unsafe.Offsetof(snapshot.ValidMask))
 	require.Equal(t, uintptr(8), unsafe.Offsetof(snapshot.NumGC))
 	require.Equal(t, uintptr(12), unsafe.Offsetof(snapshot.Pad))
@@ -49,6 +49,8 @@ func TestGoRuntimeMetricRawABI(t *testing.T) {
 	require.Equal(t, uintptr(104), unsafe.Offsetof(snapshot.MemoryUsedOther))
 	require.Equal(t, uintptr(112), unsafe.Offsetof(snapshot.MemoryAllocated))
 	require.Equal(t, uintptr(120), unsafe.Offsetof(snapshot.MemoryAllocations))
+	require.Equal(t, uintptr(128), unsafe.Offsetof(snapshot.GoroutineCount))
+	require.Equal(t, uintptr(136), unsafe.Offsetof(snapshot.MemoryGCGoal))
 }
 
 func TestGoRuntimeMetricValidMaskABI(t *testing.T) {
@@ -59,6 +61,8 @@ func TestGoRuntimeMetricValidMaskABI(t *testing.T) {
 	require.Equal(t, goRuntimeMetricValidCPUTime, uint64(1<<4))
 	require.Equal(t, goRuntimeMetricValidMemoryUsed, uint64(1<<5))
 	require.Equal(t, goRuntimeMetricValidMemoryAllocs, uint64(1<<6))
+	require.Equal(t, goRuntimeMetricValidGoroutineCount, uint64(1<<9))
+	require.Equal(t, goRuntimeMetricValidMemoryGCGoal, uint64(1<<10))
 }
 
 func TestConvertGoRuntimeMetricSnapshot(t *testing.T) {
@@ -169,6 +173,50 @@ func TestConvertGoRuntimeMetricSnapshotSuppressesNegativeCPUTime(t *testing.T) {
 
 	require.NotNil(t, snapshot.Go)
 	require.Nil(t, snapshot.Go.CPUTime)
+}
+
+func TestConvertGoRuntimeMetricSnapshotIncludesPositiveGoroutineCount(t *testing.T) {
+	snapshot := convertGoRuntimeMetricSnapshot(svc.Attrs{}, app.PID(123), goRuntimeMetricRawSnapshot{
+		ValidMask:      goRuntimeMetricValidGoroutineCount,
+		GoroutineCount: 17,
+	})
+
+	require.NotNil(t, snapshot.Go)
+	require.NotNil(t, snapshot.Go.GoroutineCount)
+	require.Equal(t, int64(17), *snapshot.Go.GoroutineCount)
+}
+
+func TestConvertGoRuntimeMetricSnapshotSuppressesInvalidGoroutineCount(t *testing.T) {
+	for _, raw := range []goRuntimeMetricRawSnapshot{
+		{GoroutineCount: 17},
+		{ValidMask: goRuntimeMetricValidGoroutineCount},
+		{ValidMask: goRuntimeMetricValidGoroutineCount, GoroutineCount: -1},
+	} {
+		snapshot := convertGoRuntimeMetricSnapshot(svc.Attrs{}, app.PID(123), raw)
+		require.NotNil(t, snapshot.Go)
+		require.Nil(t, snapshot.Go.GoroutineCount)
+	}
+}
+
+func TestConvertGoRuntimeMetricSnapshotIncludesExactGCGoal(t *testing.T) {
+	snapshot := convertGoRuntimeMetricSnapshot(svc.Attrs{}, app.PID(123), goRuntimeMetricRawSnapshot{
+		ValidMask:    goRuntimeMetricValidMemoryGCGoal,
+		MemoryGCGoal: 123456789,
+	})
+
+	require.NotNil(t, snapshot.Go.MemoryGCGoal)
+	require.Equal(t, int64(123456789), *snapshot.Go.MemoryGCGoal)
+}
+
+func TestConvertGoRuntimeMetricSnapshotSuppressesInvalidGCGoal(t *testing.T) {
+	for _, raw := range []goRuntimeMetricRawSnapshot{
+		{MemoryGCGoal: 1024},
+		{ValidMask: goRuntimeMetricValidMemoryGCGoal},
+		{ValidMask: goRuntimeMetricValidMemoryGCGoal, MemoryGCGoal: uint64(math.MaxInt64) + 1},
+	} {
+		snapshot := convertGoRuntimeMetricSnapshot(svc.Attrs{}, app.PID(123), raw)
+		require.Nil(t, snapshot.Go.MemoryGCGoal)
+	}
 }
 
 func TestRuntimeMetricServiceRequiresRuntimeMetricsFeature(t *testing.T) {


### PR DESCRIPTION
## Summary

Add eBPF collection and export for the remaining Go runtime metrics:

  - `go.memory.gc.goal`
  - `go.goroutine.count`

This is the final PR in the Go runtime metrics saga.

The GC goal is read from the exact committed heap goal when available, with a runtime probe fallback for supported Go versions. Goroutine count is collected directly from runtime scheduler data and omitted when the required symbols or offsets cannot be resolved safely.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
