### PR TITLE
Node.js injector: don't write to the instrumented process's stdout

### DIFF
--- a/pkg/internal/nodejs/fdextractor.js
+++ b/pkg/internal/nodejs/fdextractor.js
@@ -20,8 +20,10 @@ const { AsyncLocalStorage, createHook } = require('async_hooks');
 
 const debug_enabled = false;
 
-console.log('OpenTelemetry eBPF Instrumentation has injected instrumentation via the NodeJS debugger');
-console.log('The debugger will be deactivated again and closed');
+if (debug_enabled) {
+  console.log('OpenTelemetry eBPF Instrumentation has injected instrumentation via the NodeJS debugger');
+  console.log('The debugger will be deactivated again and closed');
+}
 
 // ALS store holds only incomingFd
 const als = new AsyncLocalStorage();


### PR DESCRIPTION
## Summary

`fdextractor.js` is evaluated inside the application being instrumented, so anything it logs lands on **that process's** stdout rather than the agent's. Two lines were printed unconditionally on every injection:

```
OpenTelemetry eBPF Instrumentation has injected instrumentation via the NodeJS debugger
The debugger will be deactivated again and closed
```

This corrupts any consumer that treats a Node process's stdout as a data channel. Two cases observed in practice, both with Playwright 1.49.1:

- **`playwright test --reporter=json` stops being parseable.** The injector fires for `npx`, the test CLI and every worker, so several banner pairs land in the middle of the report:

  ```
  JSON.parse: Unexpected token 'O', "OpenTeleme"... is not valid JSON
  ```

- **`playwright run-driver` desynchronises permanently.** Its stdout is a length-prefixed protocol transport, so the banner text was consumed as a frame length of 1.85 GB. This is the transport the Python, Java and .NET clients use, making the failure a hang rather than a bad report.

In both cases the tests themselves passed and the runner exited 0 — only the output stream was corrupted, which is what made this hard to attribute.

Both lines now sit behind the existing `debug_enabled` flag, alongside the other diagnostics in this file, so nothing is lost when debugging the injector.

Note that Node itself still writes `Debugger listening on ws://...`, `For help, see: ...` and `Debugger attached.` to **stderr** when the inspector is activated by signal. Those come from Node core before the injected script runs and cannot be suppressed from here; they only affect consumers that merge stderr into a stdout data channel.

## Validation

Built an agent from this change and ran `npx playwright test` with the JSON reporter on stdout, against the real agent instrumenting the container's Node processes:

| | before | after |
|---|---|---|
| runner exit code | 0 | 0 |
| tests | 6/6 passed | 6/6 passed |
| `JSON.parse` of stdout | **fails** | **OK** |
| injected lines in stdout | 6 | **0** |
| injections performed | 3 | 3 |

The agent still injects into all three Node processes of the run, so instrumentation is unaffected — only the stray output is gone.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
