### PR TITLE
Add opt-in GenAI error status messages

### DIFF
--- a/devdocs/features.md
+++ b/devdocs/features.md
@@ -51,6 +51,34 @@ chunk.
 | Vector retrieval | `usage.prompt_tokens` or `usage.total_tokens` | Not reported | Most vector stores do not return token usage; it is exported when present. |
 | MCP | Not reported | Not reported | MCP spans do not currently expose token usage. |
 
+## GenAI provider error messages
+
+OBI does not export raw GenAI provider error messages by default. To copy them
+verbatim into the OTLP span `status.message`, explicitly select the
+`gen_ai.response.error` control:
+
+```yaml
+attributes:
+  select:
+    traces:
+      include:
+        - gen_ai.response.error
+```
+
+The control applies to OpenAI, OpenAI-compatible APIs, Anthropic, Google AI
+Studio (Gemini), Qwen, AWS Bedrock, and Rerank responses. It only affects spans
+whose resulting status is `Error`; it does not change status classification or
+the `error.type` attribute. `gen_ai.response.error` is not exported as a span
+attribute, and OBI does not use the deprecated `error.message` attribute.
+
+This sensitive control requires an exact include. Wildcards such as
+`gen_ai.*` and `*` do not enable it. OBI does not additionally redact or
+truncate selected messages. Provider error text can contain credentials,
+account or request identifiers, prompts or completions, tenant metadata,
+request details, customer usage data, account or billing details, and other
+sensitive data. Review backend access, retention, and downstream processing
+before enabling it.
+
 ## Go Instrumentation
 
 Specifically for Go applications, OBI chooses to instrument libraries directly using Uprobes, instead of instrumenting

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -408,6 +408,7 @@ func getDefinitions(
 				attr.GenAITools:             false,
 				attr.GenAIToolCallArguments: false,
 				attr.GenAIToolCallResult:    false,
+				attr.GenAIResponseError:     false,
 				attr.DBResponseError:        false,
 			},
 		},

--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -144,6 +144,7 @@ type AttrSelector struct {
 var exactIncludeOnlyAttrs = map[attr.Name]struct{}{
 	attr.GenAIToolCallArguments: {},
 	attr.GenAIToolCallResult:    {},
+	attr.GenAIResponseError:     {},
 }
 
 // NewAttrSelector returns an AttrSelector instance based on the user-provided attributes Selection

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -253,6 +253,7 @@ const (
 	GenAIToolCallArguments = Name(semconv.GenAIToolCallArgumentsKey)
 	GenAIToolCallResult    = Name(semconv.GenAIToolCallResultKey)
 	GenAIPromptName        = Name(semconv.GenAIPromptNameKey)
+	GenAIResponseError     = Name("gen_ai.response.error")
 )
 
 // OBI specific GPU events

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,7 @@ var (
 	genAIUsageReasoningOutputTokens    = attribute.Key("gen_ai.usage.reasoning.output_tokens")
 	openAIAPITypeKey                   = attribute.Key("openai.api.type")
 	awsBedrockGuardrailIDKey           = attribute.Key("aws.bedrock.guardrail.id")
+	genAIResponseErrorControlKey       = attribute.Key("obi.internal.gen_ai.response.error")
 )
 
 type TraceSpanAndAttributes struct {
@@ -89,7 +91,8 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 			continue
 		}
 
-		finalAttrs := traceAttributesSelectorInternal(span, traceAttrs, redactSet)
+		selectedAttrs := traceAttributesSelectorInternal(span, traceAttrs, redactSet)
+		samplerAttrs, responseErrorSelected := removeGenAIResponseErrorControl(selectedAttrs)
 
 		spanSampler := func() trace.Sampler {
 			if span.Service.Sampler != nil {
@@ -104,7 +107,7 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 			Name:          span.TraceName(),
 			TraceID:       span.TraceID,
 			Kind:          spanKind(span),
-			Attributes:    finalAttrs,
+			Attributes:    samplerAttrs,
 		})
 
 		if sr.Decision == trace.Drop {
@@ -115,7 +118,11 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 		if !ok {
 			group = []TraceSpanAndAttributes{}
 		}
-		group = append(group, TraceSpanAndAttributes{Span: span, Attributes: finalAttrs})
+		exportAttrs := samplerAttrs
+		if responseErrorSelected {
+			exportAttrs = append(slices.Clone(samplerAttrs), genAIResponseErrorControlKey.Bool(true))
+		}
+		group = append(group, TraceSpanAndAttributes{Span: span, Attributes: exportAttrs})
 		spanGroups[span.Service.UID] = group
 	}
 
@@ -222,6 +229,11 @@ func generateTracesWithAttributes(
 			dbResponseError = request.SpanDBStatusMessage(span, dbErr.AsString())
 		}
 		m.Remove(string(attr.DBResponseError.OTEL()))
+		var genAIResponseErrorSelected bool
+		if control, ok := m.Get(string(genAIResponseErrorControlKey)); ok {
+			genAIResponseErrorSelected = control.Type() == pcommon.ValueTypeBool && control.Bool()
+		}
+		m.Remove(string(genAIResponseErrorControlKey))
 		m.MoveTo(s.Attributes())
 
 		// Set status code
@@ -232,6 +244,11 @@ func generateTracesWithAttributes(
 			statusMessage = dbResponseError
 		} else {
 			statusMessage = request.SpanStatusMessage(span)
+			if statusMessage == "" &&
+				statusCode == ptrace.StatusCodeError &&
+				genAIResponseErrorSelected {
+				statusMessage = genAIResponseErrorMessage(span)
+			}
 		}
 		if statusMessage != "" {
 			s.Status().SetMessage(statusMessage)
@@ -1366,6 +1383,11 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			}
 		}
 
+		if _, selected := optionalAttrs[attr.GenAIResponseError]; selected {
+			if message := genAIResponseErrorMessage(span); message != "" {
+				attrs = append(attrs, genAIResponseErrorControlKey.Bool(true))
+			}
+		}
 		attrs = append(attrs, jsonRPCAttributes(span)...)
 		attrs = append(attrs, httpEnrichmentAttributes(span)...)
 	case request.EventTypeGRPCClient:
@@ -1660,6 +1682,62 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 // TraceAttributesSelector returns the []attribute.KeyValue for a single span.
 func TraceAttributesSelector(span *request.Span, optionalAttrs map[attr.Name]struct{}, redactKeys ...string) []attribute.KeyValue {
 	return traceAttributesSelectorInternal(span, optionalAttrs, buildRedactSet(redactKeys))
+}
+
+func removeGenAIResponseErrorControl(attrs []attribute.KeyValue) ([]attribute.KeyValue, bool) {
+	for i := range attrs {
+		if attrs[i].Key != genAIResponseErrorControlKey ||
+			attrs[i].Value.Type() != attribute.BOOL ||
+			!attrs[i].Value.AsBool() {
+			continue
+		}
+
+		copy(attrs[i:], attrs[i+1:])
+		attrs[len(attrs)-1] = attribute.KeyValue{}
+		attrs = attrs[:len(attrs)-1]
+		return attrs, true
+	}
+
+	return attrs, false
+}
+
+func genAIResponseErrorMessage(span *request.Span) string {
+	if span.Type != request.EventTypeHTTPClient || span.GenAI == nil {
+		return ""
+	}
+
+	switch span.SubType {
+	case request.HTTPSubtypeOpenAI:
+		if span.GenAI.OpenAI != nil {
+			return span.GenAI.OpenAI.Error.Message
+		}
+	case request.HTTPSubtypeOpenAICompatible:
+		if span.GenAI.OpenAICompatible != nil {
+			return span.GenAI.OpenAICompatible.Error.Message
+		}
+	case request.HTTPSubtypeAnthropic:
+		if span.GenAI.Anthropic != nil && span.GenAI.Anthropic.Output.Error != nil {
+			return span.GenAI.Anthropic.Output.Error.Message
+		}
+	case request.HTTPSubtypeGemini:
+		if span.GenAI.Gemini != nil && span.GenAI.Gemini.Output.Error != nil {
+			return span.GenAI.Gemini.Output.Error.Message
+		}
+	case request.HTTPSubtypeQwen:
+		if span.GenAI.Qwen != nil {
+			return span.GenAI.Qwen.Error.Message
+		}
+	case request.HTTPSubtypeAWSBedrock:
+		if span.GenAI.Bedrock != nil {
+			return span.GenAI.Bedrock.Output.ErrorMessage
+		}
+	case request.HTTPSubtypeRerank:
+		if span.GenAI.Rerank != nil && span.GenAI.Rerank.Output.Error != nil {
+			return span.GenAI.Rerank.Output.Error.Message
+		}
+	}
+
+	return ""
 }
 
 func spanKind(span *request.Span) trace2.SpanKind {

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -16,6 +16,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	trace2 "go.opentelemetry.io/otel/trace"
 
@@ -24,6 +26,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 )
 
 func TestTraceAttributesSelector_DNSQuestionName(t *testing.T) {
@@ -539,6 +542,435 @@ func TestTraceAttributesSelector_OpenAICompatible(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, request.CompletionOperationName, opName.Str())
 	})
+}
+
+func TestGenAIResponseErrorStatusMessage(t *testing.T) {
+	const rawMessage = "  api_key=sk-secret\nprompt=\"private input\" account=acct_123 🧪  "
+
+	tests := []struct {
+		name      string
+		subType   int
+		genAI     *request.GenAI
+		errorType string
+	}{
+		{
+			name:    "OpenAI",
+			subType: request.HTTPSubtypeOpenAI,
+			genAI: &request.GenAI{OpenAI: &request.VendorOpenAI{
+				Error: request.OpenAIError{Type: "rate_limit_error", Message: rawMessage},
+			}},
+			errorType: "rate_limit_error",
+		},
+		{
+			name:    "OpenAI compatible",
+			subType: request.HTTPSubtypeOpenAICompatible,
+			genAI: &request.GenAI{OpenAICompatible: &request.VendorOpenAI{
+				Error: request.OpenAIError{Type: "gateway_error", Message: rawMessage},
+			}},
+			errorType: "gateway_error",
+		},
+		{
+			name:    "Anthropic",
+			subType: request.HTTPSubtypeAnthropic,
+			genAI: &request.GenAI{Anthropic: &request.VendorAnthropic{
+				Output: request.AnthropicResponse{
+					Error: &request.AnthropicError{Type: "authentication_error", Message: rawMessage},
+				},
+			}},
+			errorType: "authentication_error",
+		},
+		{
+			name:    "Gemini",
+			subType: request.HTTPSubtypeGemini,
+			genAI: &request.GenAI{Gemini: &request.VendorGemini{
+				Output: request.GeminiResponse{
+					Error: &request.GeminiError{Status: "PERMISSION_DENIED", Message: rawMessage},
+				},
+			}},
+			errorType: "PERMISSION_DENIED",
+		},
+		{
+			name:    "Qwen",
+			subType: request.HTTPSubtypeQwen,
+			genAI: &request.GenAI{Qwen: &request.VendorOpenAI{
+				Error: request.OpenAIError{Type: "invalid_request_error", Message: rawMessage},
+			}},
+			errorType: "invalid_request_error",
+		},
+		{
+			name:    "AWS Bedrock",
+			subType: request.HTTPSubtypeAWSBedrock,
+			genAI: &request.GenAI{Bedrock: &request.VendorBedrock{
+				Output: request.BedrockResponse{
+					ErrorType:    "ValidationException",
+					ErrorMessage: rawMessage,
+				},
+			}},
+			errorType: "ValidationException",
+		},
+		{
+			name:    "Rerank",
+			subType: request.HTTPSubtypeRerank,
+			genAI: &request.GenAI{Rerank: &request.VendorRerank{
+				Output: request.RerankResponse{
+					Error: &request.RerankError{Type: "invalid_request", Message: rawMessage},
+				},
+			}},
+			errorType: "invalid_request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := &request.Span{
+				Type:    request.EventTypeHTTPClient,
+				SubType: tt.subType,
+				Method:  "POST",
+				Status:  429,
+				GenAI:   tt.genAI,
+			}
+
+			defaultSpan := generateSingleTraceSpan(t, span, nil)
+			assert.Equal(t, ptrace.StatusCodeError, defaultSpan.Status().Code())
+			assert.Empty(t, defaultSpan.Status().Message())
+			assertSpanStringAttribute(t, defaultSpan, semconv.ErrorTypeKey, tt.errorType)
+			assertSpanAttributeAbsent(t, defaultSpan, string(attr.GenAIResponseError))
+			assertSpanAttributeAbsent(t, defaultSpan, "error.message")
+
+			selectedSpan := generateSingleTraceSpan(t, span, map[attr.Name]struct{}{
+				attr.GenAIResponseError: {},
+			})
+			assert.Equal(t, ptrace.StatusCodeError, selectedSpan.Status().Code())
+			assert.Equal(t, rawMessage, selectedSpan.Status().Message())
+			assertSpanStringAttribute(t, selectedSpan, semconv.ErrorTypeKey, tt.errorType)
+			assertSpanAttributeAbsent(t, selectedSpan, string(attr.GenAIResponseError))
+			assertSpanAttributeAbsent(t, selectedSpan, "error.message")
+		})
+	}
+}
+
+func TestGenAIResponseErrorSelectionToStatusMessage(t *testing.T) {
+	const rawMessage = "provider request failed"
+
+	tests := []struct {
+		name     string
+		include  []string
+		expected string
+	}{
+		{
+			name: "default",
+		},
+		{
+			name:    "all attributes wildcard",
+			include: []string{"*"},
+		},
+		{
+			name:    "GenAI wildcard",
+			include: []string{"gen_ai.*"},
+		},
+		{
+			name:     "exact name",
+			include:  []string{"gen_ai.response.error"},
+			expected: rawMessage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &attributes.SelectorConfig{}
+			if tt.include != nil {
+				cfg.SelectionCfg = attributes.Selection{
+					attributes.Traces.Section: attributes.InclusionLists{
+						Include: tt.include,
+					},
+				}
+			}
+			selectedAttrs, err := UserSelectedAttributes(cfg)
+			require.NoError(t, err)
+
+			span := request.Span{
+				Type:    request.EventTypeHTTPClient,
+				SubType: request.HTTPSubtypeOpenAI,
+				Method:  "POST",
+				Status:  429,
+				GenAI: &request.GenAI{OpenAI: &request.VendorOpenAI{
+					Error: request.OpenAIError{
+						Type:    "rate_limit_error",
+						Message: rawMessage,
+					},
+				}},
+			}
+			sampler := &recordingSampler{}
+			groups := GroupSpans(
+				t.Context(),
+				[]request.Span{span},
+				selectedAttrs,
+				sampler,
+				instrumentations.NewInstrumentationSelection(
+					[]instrumentations.Instrumentation{instrumentations.InstrumentationALL},
+				),
+			)
+			group := groups[span.Service.UID]
+			require.Len(t, group, 1)
+			assertAttributeKeyAbsent(t, sampler.attributes, string(attr.GenAIResponseError))
+			assertAttributeKeyAbsent(t, sampler.attributes, string(genAIResponseErrorControlKey))
+			assertAttributeKeyAbsent(t, group[0].Attributes, string(attr.GenAIResponseError))
+
+			exported := generateTraceSpan(t, group[0])
+			assert.Equal(t, ptrace.StatusCodeError, exported.Status().Code())
+			assert.Equal(t, tt.expected, exported.Status().Message())
+			assertSpanAttributeAbsent(t, exported, string(attr.GenAIResponseError))
+			assertSpanAttributeAbsent(t, exported, string(genAIResponseErrorControlKey))
+		})
+	}
+}
+
+func TestGenAIResponseErrorStatusMessageEdgeCases(t *testing.T) {
+	t.Run("empty provider message", func(t *testing.T) {
+		span := &request.Span{
+			Type:    request.EventTypeHTTPClient,
+			SubType: request.HTTPSubtypeOpenAI,
+			Method:  "POST",
+			Status:  429,
+			GenAI: &request.GenAI{OpenAI: &request.VendorOpenAI{
+				Error: request.OpenAIError{Type: "rate_limit_error"},
+			}},
+		}
+
+		exported := generateSingleTraceSpan(t, span, map[attr.Name]struct{}{
+			attr.GenAIResponseError: {},
+		})
+		assert.Equal(t, ptrace.StatusCodeError, exported.Status().Code())
+		assert.Empty(t, exported.Status().Message())
+		assertSpanAttributeAbsent(t, exported, string(attr.GenAIResponseError))
+	})
+
+	t.Run("non-error status", func(t *testing.T) {
+		span := &request.Span{
+			Type:    request.EventTypeHTTPClient,
+			SubType: request.HTTPSubtypeOpenAI,
+			Method:  "POST",
+			Status:  200,
+			GenAI: &request.GenAI{OpenAI: &request.VendorOpenAI{
+				Error: request.OpenAIError{Message: "message without an error"},
+			}},
+		}
+
+		exported := generateSingleTraceSpan(t, span, map[attr.Name]struct{}{
+			attr.GenAIResponseError: {},
+		})
+		assert.Equal(t, ptrace.StatusCodeUnset, exported.Status().Code())
+		assert.Empty(t, exported.Status().Message())
+		assertSpanAttributeAbsent(t, exported, string(attr.GenAIResponseError))
+	})
+}
+
+func TestGenAIResponseErrorPreservesProtocolStatusMessages(t *testing.T) {
+	tests := []struct {
+		name    string
+		span    *request.Span
+		message string
+	}{
+		{
+			name: "JSON-RPC",
+			span: &request.Span{
+				Type:    request.EventTypeHTTPClient,
+				SubType: request.HTTPSubtypeJSONRPC,
+				Method:  "POST",
+				Status:  200,
+				JSONRPC: &request.JSONRPC{
+					ErrorCode:    -32600,
+					ErrorMessage: "Invalid Request",
+				},
+			},
+			message: "Invalid Request",
+		},
+		{
+			name: "MCP",
+			span: &request.Span{
+				Type:    request.EventTypeHTTPClient,
+				SubType: request.HTTPSubtypeMCP,
+				Method:  "POST",
+				Status:  200,
+				GenAI: &request.GenAI{MCP: &request.MCPCall{
+					ErrorCode:    -32602,
+					ErrorMessage: "Unknown tool",
+				}},
+			},
+			message: "Unknown tool",
+		},
+		{
+			name: "JSON-RPC without native message",
+			span: &request.Span{
+				Type:    request.EventTypeHTTPClient,
+				SubType: request.HTTPSubtypeJSONRPC,
+				Method:  "POST",
+				Status:  200,
+				JSONRPC: &request.JSONRPC{
+					ErrorCode: -32600,
+				},
+			},
+		},
+		{
+			name: "MCP without native message",
+			span: &request.Span{
+				Type:    request.EventTypeHTTPClient,
+				SubType: request.HTTPSubtypeMCP,
+				Method:  "POST",
+				Status:  200,
+				GenAI: &request.GenAI{MCP: &request.MCPCall{
+					ErrorCode: -32602,
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exported := generateSingleTraceSpan(t, tt.span, map[attr.Name]struct{}{
+				attr.GenAIResponseError: {},
+			})
+			assert.Equal(t, ptrace.StatusCodeError, exported.Status().Code())
+			assert.Equal(t, tt.message, exported.Status().Message())
+			assertSpanAttributeAbsent(t, exported, string(attr.GenAIResponseError))
+		})
+	}
+}
+
+func TestGenAIResponseErrorAttributeCollision(t *testing.T) {
+	const ordinaryValue = "ordinary application attribute"
+
+	tests := []struct {
+		name string
+		span *request.Span
+	}{
+		{
+			name: "manual span",
+			span: &request.Span{
+				Type:   request.EventTypeManualSpan,
+				Method: "manual",
+				Status: int(codes.Error),
+			},
+		},
+		{
+			name: "MCP without native message",
+			span: &request.Span{
+				Type:    request.EventTypeHTTPClient,
+				SubType: request.HTTPSubtypeMCP,
+				Method:  "POST",
+				Status:  200,
+				GenAI: &request.GenAI{MCP: &request.MCPCall{
+					ErrorCode: -32602,
+				}},
+			},
+		},
+		{
+			name: "supported provider without selection metadata",
+			span: &request.Span{
+				Type:    request.EventTypeHTTPClient,
+				SubType: request.HTTPSubtypeOpenAI,
+				Method:  "POST",
+				Status:  429,
+				GenAI: &request.GenAI{OpenAI: &request.VendorOpenAI{
+					Error: request.OpenAIError{Message: ordinaryValue},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exported := generateTraceSpan(t, TraceSpanAndAttributes{
+				Span: tt.span,
+				Attributes: []attribute.KeyValue{
+					attribute.String(string(attr.GenAIResponseError), ordinaryValue),
+				},
+			})
+			assert.Equal(t, ptrace.StatusCodeError, exported.Status().Code())
+			assert.Empty(t, exported.Status().Message())
+			assertSpanStringAttribute(
+				t,
+				exported,
+				attribute.Key(attr.GenAIResponseError),
+				ordinaryValue,
+			)
+		})
+	}
+}
+
+type recordingSampler struct {
+	attributes []attribute.KeyValue
+}
+
+func (s *recordingSampler) ShouldSample(parameters sdktrace.SamplingParameters) sdktrace.SamplingResult {
+	s.attributes = append([]attribute.KeyValue(nil), parameters.Attributes...)
+	return sdktrace.SamplingResult{Decision: sdktrace.RecordAndSample}
+}
+
+func (*recordingSampler) Description() string {
+	return "recording sampler"
+}
+
+func generateSingleTraceSpan(
+	t *testing.T,
+	span *request.Span,
+	optionalAttrs map[attr.Name]struct{},
+) ptrace.Span {
+	t.Helper()
+
+	return generateTraceSpan(t, TraceSpanAndAttributes{
+		Span:       span,
+		Attributes: TraceAttributesSelector(span, optionalAttrs),
+	})
+}
+
+func generateTraceSpan(t *testing.T, spanWithAttributes TraceSpanAndAttributes) ptrace.Span {
+	t.Helper()
+
+	span := spanWithAttributes.Span
+	cache := expirable2.NewLRU[svc.UID, []attribute.KeyValue](10, nil, 0)
+	traces := GenerateTracesWithAttributes(
+		cache,
+		&span.Service,
+		nil,
+		&meta.NodeMeta{},
+		[]TraceSpanAndAttributes{spanWithAttributes},
+		"obi",
+	)
+
+	require.Equal(t, 1, traces.ResourceSpans().Len())
+	require.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
+	spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	require.Equal(t, 1, spans.Len())
+	return spans.At(0)
+}
+
+func assertAttributeKeyAbsent(t *testing.T, attrs []attribute.KeyValue, key string) {
+	t.Helper()
+
+	for i := range attrs {
+		assert.NotEqual(t, key, string(attrs[i].Key))
+	}
+}
+
+func assertSpanStringAttribute(
+	t *testing.T,
+	span ptrace.Span,
+	key attribute.Key,
+	expected string,
+) {
+	t.Helper()
+
+	value, ok := span.Attributes().Get(string(key))
+	require.True(t, ok)
+	assert.Equal(t, expected, value.Str())
+}
+
+func assertSpanAttributeAbsent(t *testing.T, span ptrace.Span, key string) {
+	t.Helper()
+
+	_, ok := span.Attributes().Get(key)
+	assert.False(t, ok)
 }
 
 func TestGenerateTracesWithAttributesManualOTelJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `gen_ai.response.error` as an exact-selection-only trace control
- copy supported provider error text verbatim to `status.message` only when the resulting span status is `Error`
- keep raw provider text disabled by default and out of sampler and exported span attributes
- preserve existing status classification, `error.type`, database, MCP, and JSON-RPC behavior
- document the privacy implications of enabling provider-supplied error text

## Rationale

Raw provider messages can be valuable for diagnosing quota, authentication, and request failures, but they are unstructured provider-supplied text. They can contain credentials, identifiers, prompts or completions, tenant metadata, request details, customer usage data, billing details, and other sensitive information.

The new control is therefore disabled by default. Operators must explicitly include `gen_ai.response.error`; `*` and `gen_ai.*` do not enable it. Selected messages are copied without additional redaction or truncation, and only for OpenAI, OpenAI-compatible, Anthropic, Gemini, Qwen, AWS Bedrock, and Rerank error responses. The control itself is never exported, and the deprecated `error.message` attribute is not used.

## Validation

- `go test -race ./pkg/export/attributes ./pkg/export/otel/tracesgen ./pkg/appolly/app/request`
- scoped `golangci-lint` for `./pkg/export/attributes` and `./pkg/export/otel/tracesgen`
- Markdown lint

Closes #2507
