### PR TITLE
Document Config v2 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ the [internal/test/integration](./internal/test/integration) and [internal/test/
 
 Below are quick reference instructions for getting OBI up and running with binary downloads or container images. For comprehensive setup, configuration, and troubleshooting guidance, refer to the [OpenTelemetry zero-code instrumentation documentation](https://opentelemetry.io/docs/zero-code/), which is the authoritative source of truth.
 
+When upgrading an existing configuration, follow the
+[Config v1 to v2 migration guide](devdocs/config/version-2.0/migration.md).
+Use Config v2 only with a release whose notes explicitly enable it for your
+standalone or Collector deployment mode.
+
 For release artifact verification and installation details, see:
 
 - [Run OBI as a standalone process](https://opentelemetry.io/docs/zero-code/obi/setup/standalone/)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -179,6 +179,18 @@ Once the workflow completes successfully, a draft release is automatically creat
    - Verify the matching GHCR image as well:
      `cosign verify --certificate-identity 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/.github/workflows/publish_dockerhub_main.yml@refs/tags/<tag>' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:<tag>`
    - Review auto-generated release notes for accuracy
+   - When the supported configuration contract changes, link the
+     [Config v1 to v2 migration guide](devdocs/config/version-2.0/migration.md)
+     and state:
+     - the first release that can load the new version in standalone and
+       Collector receiver modes;
+     - whether the previous configuration version remains supported;
+     - any migration limitations that affect compatibility.
+   - Link those release notes back from the
+     [Config v2 release gate](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2251)
+     and the
+     [stable v1.0 release epic](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1133)
+     before publishing the release.
 4. Edit release notes if necessary to add context, highlight important changes, or improve clarity
 5. Once satisfied with artifacts and release notes, click "Publish release" to make it immutable and publicly available
 
@@ -191,6 +203,7 @@ When release artifact names, verification commands, or installation steps change
 update the user-facing docs in both places before or alongside the release:
 
 - Repository quick-start guide: [README.md](README.md)
+- Repository [Config v1 to v2 migration guide](devdocs/config/version-2.0/migration.md)
 - OpenTelemetry [docs for standalone installs](https://opentelemetry.io/docs/zero-code/obi/setup/standalone/)
 - OpenTelemetry [docs for container installs](https://opentelemetry.io/docs/zero-code/obi/setup/docker/)
 

--- a/devdocs/README.md
+++ b/devdocs/README.md
@@ -1,10 +1,16 @@
 # Documentation for developers
 
-This directory contains documentation that is not useful for our users but might be useful for developers.
+This directory contains developer documentation and repository-hosted design
+references. It also contains the operator-facing Config migration guide linked
+from the repository README. General setup documentation lives on the
+OpenTelemetry website.
 
 ## Table Of Contents
 
 - [Pipeline Map](pipeline-map.md): explanation of pipeline map.
+- [Config v1 to v2 migration](config/version-2.0/migration.md): operator guide
+  for migrating and validating standalone and Collector receiver
+  configurations.
 - [Profiling](profiling.md): how to profile OBI.
 - [Features](features.md): features supported by OBI.
 - [Context Propagation Architecture](context-propagation.md): how OpenTelemetry context propagation works in the eBPF instrumentation.

--- a/devdocs/config/version-2.0/config-v2.md
+++ b/devdocs/config/version-2.0/config-v2.md
@@ -42,7 +42,7 @@ To ensure that the redesign is guided by consistent values and priorities, we de
 - **Deployment-aware structure**
   - OBI runs in two modes: standalone daemon and Collector receiver.
   - Configuration structure should reflect which parts are valid in each mode.
-  - The receiver-valid sub-config should be embeddable directly, without requiring users to manually extract a subset.
+  - The receiver-valid sub-config should have an unambiguous derivation from the standalone shape.
   - Standalone-only concerns (daemon process management, enrichment, log annotation) must not leak into receiver deployments.
 
 - **Protocol-local ownership over global toggles**
@@ -143,21 +143,28 @@ OBI adopts the standard declarative fields incrementally. For the first stable v
 | Declarative section | Stable v2 behavior |
 | --- | --- |
 | `file_format` | Required and restricted to `"1.0"`. |
-| `resource` | Partial: string `host.name` overrides OBI hostname and string `host.id` overrides OBI host ID. Other attributes are currently ignored. |
+| `resource` | Partial: string `host.name`, `host.id`, `service.name`, and `service.namespace` attributes are imported. Other attributes, detection configuration, and schema URLs are rejected by the target adapter in #2682. |
 | `tracer_provider.sampler` | Partial: `always_on`, `always_off`, `trace_id_ratio_based`, and simple `parent_based` roots that use those samplers. |
-| `tracer_provider.processors` | Partial: one batch processor with one OTLP/gRPC exporter. |
-| `meter_provider.readers` | Partial: at most one periodic OTLP/gRPC reader and one Prometheus development pull reader. |
+| `tracer_provider.processors` | Partial: one batch processor with one OTLP exporter. Automatic migration emits gRPC; the gated standalone importer in [#2682](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2682) also accepts HTTP/protobuf, HTTP/JSON, and declarative exporter headers. |
+| `meter_provider.readers` | Partial: at most one periodic OTLP reader and one Prometheus development pull reader. Automatic migration emits OTLP/gRPC; the gated standalone importer in [#2682](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2682) also accepts OTLP/HTTP and declarative exporter headers. |
 | `log_level` | Supported for OBI daemon logging. OTel `trace*` and `debug*` severities map to `DEBUG`; `info*` to `INFO`; `warn*` to `WARN`; `error*` and `fatal*` to `ERROR`. `extensions.obi.daemon.logging.level` is not part of v2; use the top-level field. |
-| `propagator`, `attribute_limits`, `disabled`, `distribution`, `instrumentation/development`, `logger_provider` | Parsed by the declarative model but not applied to OBI runtime behavior in the stable milestone. |
+| `attribute_limits` | Rejected whenever present by the target adapter in #2682. |
+| `disabled`, `distribution`, `propagator` | `disabled: true`, non-empty `distribution`, and non-empty propagator configuration are rejected. Empty/default placeholders do not enable runtime behavior. |
+| `instrumentation/development`, `logger_provider` | Rejected when present by the target adapter in #2682. |
 
-Environment-variable substitution depends on the loader. The upstream `otelconf/x.ParseYAML` path expands `${VAR}`, `${env:VAR}`, and `${VAR:-fallback}` before decoding. OBI's internal `schema.ParseStandaloneYAML` parser decodes the supplied bytes directly, so callers using that parser must perform any desired substitution before calling it.
+Environment-variable substitution depends on the loader. The upstream `otelconf/x.ParseYAML` path expands `${VAR}`, `${env:VAR}`, `${VAR:-fallback}`, and `${env:VAR:-fallback}` before decoding. OBI's internal `schema.ParseStandaloneYAML` parser decodes the supplied bytes directly, so callers using that parser must perform any desired substitution before calling it.
 
 The `extensions.obi` block is divided by deployment scope:
 
-- `capture`: valid in **all** deployment modes. Contains everything OBI needs to select workloads and capture telemetry. When running OBI as a Collector receiver, this block is embedded directly in the receiver configuration — no manual extraction required.
+- `capture`: valid in **all** deployment modes. Contains everything OBI needs to select workloads and capture telemetry. A receiver component places the children of this block beside its own `version`; it does not retain the `capture` wrapper.
 - `enrich`, `correlation`, `daemon`: **standalone-mode only**. These sections are not valid in Collector receiver deployments. The Collector pipeline handles enrichment (via processors) and process lifecycle (logging, profiling, shutdown) in receiver mode.
 
-```yaml
+The following is a non-runnable structural sketch. It omits exporter settings
+and many values deliberately. Use the tested
+[generated standalone fixture](examples/migration-v2.yaml) or
+[receiver component body](examples/migration-receiver-v2.yaml) for validation.
+
+```text
 file_format: '1.0'
 log_level: info
 
@@ -176,6 +183,7 @@ extensions:
         default_action: include
         match_order: first_match_wins
       rules: []
+      # ...
       instrumentation:
         http:
           enabled: { traces: true, metrics: true }
@@ -246,6 +254,7 @@ extensions:
           multiline: first_line
 
     daemon:
+      # ...
       logging: {}
       profiling: {}
       shutdown: {}
@@ -256,22 +265,23 @@ extensions:
 ### `version` property
 
 The `extensions.obi.version` field defines the version of the OBI extension schema being used.
-This allows the parsing and validation logic to apply the correct schema rules and migration logic based on the declared version.
+It selects the supported extension schema; the only supported value is currently `"2.0"`.
 
 ### `capture` Section
 
 The `extensions.obi.capture` section is the receiver-embeddable core of the OBI configuration.
 It defines what OBI instruments and how it captures telemetry.
-This is the **only** section valid in Collector receiver deployments.
+Its children are the **only** OBI extension fields valid in Collector receiver deployments.
+Receiver configuration flattens those children beside its own `version` field rather than retaining the `capture` wrapper.
 
 #### Why `capture` is a named grouping
 
 Early design iterations kept all top-level OBI sections flat: `selection`, `instrumentation`, `runtimes`, `network`, `operations`, `enrich`, `correlation`.
 The `capture` grouping was introduced for two reasons:
 
-1. **Receiver embedding**: OBI runs in two deployment modes — standalone daemon and Collector receiver. In receiver mode, OBI is a telemetry source only. Side-effect features (k8s enrichment, log annotation) and process management (logging, profiling, shutdown) are not the receiver's responsibility — the Collector pipeline handles those. Having a single named block (`capture`) that represents exactly what the receiver embeds makes the boundary unambiguous and avoids requiring users or tools to manually enumerate which fields are valid.
+1. **Receiver embedding**: OBI runs in two deployment modes — standalone daemon and Collector receiver. In receiver mode, OBI is a telemetry source only. Side-effect features (k8s enrichment, log annotation) and process management (logging, profiling, shutdown) are not the receiver's responsibility — the Collector pipeline handles those. Having a single named block (`capture`) that represents exactly what the receiver shape flattens makes the boundary unambiguous and avoids requiring users or tools to manually enumerate which fields are valid.
 
-2. **Correctness over documentation**: An alternative was a flat structure with a `deployment: standalone | receiver` flag, where the parser would reject standalone-only fields in receiver mode. This was rejected because it makes the boundary a runtime enforcement concern rather than a structural schema concern. With `capture` as an explicit block, the schema itself communicates the boundary, and a schema-only view of the Collector receiver config is the `capture` block — no validation flags needed.
+2. **Correctness over documentation**: An alternative was a flat standalone structure with a `deployment: standalone | receiver` flag, where one parser would reject standalone-only fields in receiver mode. This was rejected because it makes the boundary a runtime enforcement concern rather than a structural schema concern. The named `capture` block communicates the boundary in standalone configuration, while the receiver uses its distinct flattened shape. Select the matching parser when validating: standalone is the default, and receiver configuration requires `--mode=receiver`.
 
 `capture` contains:
 
@@ -292,6 +302,24 @@ The `capture` grouping was introduced for two reasons:
 Rules are based on process identity, network identity, language, Kubernetes metadata, and already-instrumented status.
 These are the primary user controls for defining which services get instrumented by OBI.
 
+The target adapter in
+[#2682](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2682)
+accepts `first_match_wins` and `last_match_wins`. Runtime selection always
+gives matching exclusions precedence. To preserve that behavior,
+`first_match_wins` requires exclusions before includes, while
+`last_match_wins` requires includes before exclusions. With
+`first_match_wins`, the first matching YAML include refinement wins. The
+migrator reverses effective v1 include-selector order because the v1 runtime
+applies the later matching selector's refinement. Preserve generated rule
+order during migration. When multiple include rules use an export or HTTP-route
+refinement, omitting that refinement on another include rule resets it instead
+of inheriting a prior rule's value. The migrator therefore rejects v1 selector
+lists that mix explicit and omitted `exports`, or mix explicit and omitted
+`routes`; make each field explicit on every selector and test overlapping and
+selector-only matches, or keep v1 when behavior depends on conditional
+inheritance. Writing `rules: []` explicitly also removes the generated
+built-in workload exclusions.
+
 **Why `policy` and `rules` are direct children of `capture`, not nested under `capture.selection`**
 
 An earlier draft had a `selection` sub-section under `capture` (i.e., `capture.selection.policy` and `capture.selection.rules`).
@@ -309,8 +337,13 @@ It does not only copy `discovery.instrument` literally. It uses the same effecti
 
 - `target_pids` becomes a single include rule that matches `process.target_pids`.
 - Modern glob selectors from `discovery.instrument`, `discovery.exclude_instrument`, and environment auto-target fields become include/exclude rules with `*_glob` match fields.
-- Legacy regex selectors from `discovery.services`, `discovery.exclude_services`, `executable_path`, and `open_port` become include/exclude rules with `*_regex` match fields.
-- Default excludes and already-instrumented-service detection become explicit exclude rules.
+- Legacy regex selectors from `discovery.services`, `discovery.exclude_services`, and `executable_path` become include/exclude rules with `*_regex` match fields. The `open_port` fallback becomes `open_ports`.
+- Default workload excludes and already-instrumented-service detection become explicit exclude rules.
+
+`discovery.excluded_linux_system_paths` is not a workload exclusion. It skips
+an early language-detection pass while an explicitly selected process still
+reaches later type detection. Its built-in default remains internal runtime
+behavior; custom values have no v2 field and migration rejects them.
 
 Known `match.process` fields exported today:
 
@@ -388,7 +421,11 @@ Current overridable fields in `refine`:
 
 - `exports`: override which signals (`traces`, `metrics`) are emitted for this workload.
 - `http.routes`: refine the direction-scoped HTTP route policy for this workload.
-- `http.filters`: replace HTTP trace/metric filters for this workload.
+
+The schema reserves refinement `http.filters`, but the target runtime adapter
+rejects a non-empty value. Do not use it to narrow a migrated configuration;
+filter semantics remain tracked in
+[#1282](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1282).
 
 New fields can be added to the `refine` vocabulary deliberately as use cases emerge.
 
@@ -437,40 +474,14 @@ For a matched workload, an omitted direction or field inherits the corresponding
 An explicitly configured scalar replaces the global scalar, and an explicitly configured array replaces the global array; use an empty array to clear inherited patterns.
 
 Sampling overrides are **not** part of the `refine` block.
-Per-workload sampling is handled via `tracer_provider.sampler` using the `obi_rule_based` custom sampler, which matches on resource attributes.
 See the [Sampling model](#sampling-model) section below.
 
 ### Sampling model
 
-Sampling remains owned by top-level OTel declarative configuration under `tracer_provider.sampler`.
-OBI does not define a parallel sampling section under `extensions.obi`, and selection rules do not override sampler behavior.
-
-**Why sampling is not in `capture.rules[].refine`**
-
-The `tracer_provider.sampler` is already the standard, extensible place for sampling policy in OTel declarative config.
-Adding a parallel `sampler` field inside `capture.rules[].refine` would violate the "compatible with OTel declarative configuration" principle by introducing a competing pipeline model.
-Instead, the `obi_rule_based` custom sampler plugin (a planned v2 deliverable) allows workload-matching sampling behavior to be expressed inside `tracer_provider.sampler`, keeping the concern in its canonical location while still meeting the per-workload use case.
-
-For v2 scope, OBI will provide and ship an OBI sampler plugin implementation in this project,
-so users can reference it directly from `tracer_provider.sampler`.
-
-When workload-specific sampling behavior is needed, users should configure it through the sampler itself:
-
-- Use built-in OTel samplers when global behavior is sufficient.
-- Use the `obi_rule_based` custom sampler plugin when rule/pattern-based workload sampling is required.
-
-The plugin implementation will include:
-
-- sampler component implementation in OBI,
-- registration/wiring in OBI runtime initialization,
-- validation/documentation for supported sampler rule semantics.
-
-This keeps concerns separated and explicit:
-
-- `extensions.obi.capture`: workload discovery and capture configuration.
-- `tracer_provider.sampler`: trace sampling policy.
-
-Example (global built-in sampler):
+Sampling is owned by top-level OTel declarative configuration under
+`tracer_provider.sampler`. The current runtime adapter supports the built-in
+always-on, always-off, trace-ID-ratio, and corresponding parent-based shapes.
+For example, this provider fragment uses parent-based ratio sampling:
 
 ```yaml
 tracer_provider:
@@ -481,37 +492,28 @@ tracer_provider:
           ratio: 0.10
 ```
 
-Example (custom sampler plugin with workload-matching semantics):
-
-```yaml
-tracer_provider:
-  sampler:
-    obi_rule_based:
-      fallback:
-        always_on: {}
-      rules:
-        - match:
-            attributes:
-              service.namespace:
-                - low-priority
-          sample:
-            trace_id_ratio_based:
-              ratio: 0.01
-        - match:
-            attributes:
-              service.name:
-                - checkout
-          sample:
-            always_on: {}
-```
+Per-workload v1 samplers have no current v2 migration target. Vendor sampler
+shapes such as `obi_rule_based` are not imported by the runtime. Keep v1 when
+workload-specific sampling is required; broader per-workload pipeline work is
+tracked in
+[#923](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/923).
 
 ### `capture.instrumentation` Section
 
 The `capture.instrumentation` section defines protocol-specific instrumentation controls, including enablement and filtering for traces and metrics.
 
-All protocols (HTTP, gRPC, SQL, Redis, Kafka, MongoDB, Couchbase, DNS, GPU, Aerospike) have a consistent base structure for defining whether traces and metrics are enabled and what filters apply to each signal.
-Each protocol can also have its own specific configuration subsections.
-For example, SQL has `mysql` and `postgres` for driver-specific controls, HTTP has `routes.discovery` for route harvesting controls, etc.
+All protocols (HTTP, gRPC, SQL, Redis, Kafka, MongoDB, Couchbase, DNS, GPU,
+Aerospike) have a consistent base structure for trace and metric enablement.
+Each protocol can also have specific subsections; for example, SQL has `mysql`
+and `postgres`, while HTTP has `routes.discovery`.
+
+Filter fields are schema-modelled but only a compatibility subset is imported.
+The target adapter compares every application protocol's trace and metric maps
+with `http.filters.traces` and rejects any difference because the runtime uses
+one application filter. It likewise requires identical trace and metric maps
+within network flow capture and within TCP stats. Migrated v1 filters remain
+fanned out and equal pending
+[#1282](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1282).
 
 HTTP route normalization is directional. `http.routes.incoming` applies to requests handled by an instrumented workload and `http.routes.outgoing` applies to requests made by it.
 Each direction has the same route-policy fields: `patterns`, `ignored_patterns`, `ignore_mode`, `unmatched`, `wildcard_char`, and `max_path_segment_cardinality`.
@@ -521,7 +523,7 @@ Global route discovery remains under `http.routes.discovery` because harvesting 
 HTTP `payload_extraction` uses the same list-based enablement model as other instrumentation selectors:
 
 - `payload_extraction.enabled` is the only enablement surface.
-- Concrete values currently supported are `graphql`, `elasticsearch`, `aws`, `sqlpp`, `openai`, `anthropic`, `gemini`, `qwen`, `bedrock`, `mcp`, `embedding`, `rerank`, `retrieval`, `jsonrpc`, and `enrichment`.
+- Concrete values currently supported are `graphql`, `elasticsearch`, `aws`, `sqlpp`, `openai`, `anthropic`, `gemini`, `qwen`, `bedrock`, `mcp`, `embedding`, `rerank`, `retrieval`, `ollama`, `openai_compatible`, `jsonrpc`, and `enrichment`.
 - Nested extractor blocks are for tuning, not duplicate enablement. For example, `payload_extraction.sqlpp.endpoint_patterns` refines SQL++ matching after `sqlpp` is enabled in the list.
 - If future aliases or families are needed, they should be added as values in the same `enabled` list rather than introducing parallel knobs.
 
@@ -531,8 +533,10 @@ The `capture.runtimes` section defines how language-specific runtime instrumenta
 These include Go probes, Node.js SIGUSR1 signal injection, and Java agent attachment.
 
 Unlike protocol instrumentation, runtimes are not about capturing specific telemetry signals — they are about *how* to instrument a service once it's selected.
-Each runtime has a simple structure: `enabled` (boolean) controls whether to attempt injection, and `filter` provides optional per-runtime refinement for which selected services receive the injection.
+Each runtime has a simple structure: `enabled` (boolean) controls whether to attempt injection.
 Java also includes additional runtime-specific configuration such as debug controls and attachment timeout.
+Runtime `filter` fields are reserved by the schema but non-empty values are not
+supported by the current adapter; use capture rules for workload selection.
 
 ### `capture.network` Section
 
@@ -573,16 +577,9 @@ This was raised directly by reviewers (dmitryax) who noted the overlap with exis
 
 In standalone mode, `enrich` remains essential — there is no Collector pipeline to delegate enrichment to.
 
-For Kubernetes environments using OBI as a receiver, use `k8sattributesprocessor` and set `enrich.enrichers.kubernetes.mode: disabled` if the `enrich` section is present (or omit `enrich` entirely):
-
-```yaml
-extensions:
-  obi:
-    enrich:
-      enrichers:
-        kubernetes:
-          mode: disabled   # use k8sattributesprocessor in the Collector pipeline instead
-```
+For Kubernetes environments using OBI as a receiver, omit `enrich` entirely
+and use `k8sattributesprocessor` in the Collector pipeline. Receiver validation
+rejects the standalone-only `enrich` section.
 
 The `mode` field supports: `autodetect` (default — enable if k8s environment is detected), `enabled`, and `disabled`.
 
@@ -630,14 +627,19 @@ The name `daemon` was chosen over `process` (too generic), `agent` (overloaded i
 ### Compatibility and mapping from v1
 
 v2 is a structural redesign of v1, with deterministic compatibility mapping.
-Use the table below to find any v1 field and its v2 canonical location.
+The table lists fields whose canonical location or behavior changes, including
+explicit no-target rows for removed settings.
+The migration command combines round-trip comparison with guards for
+non-1:1 mappings and rejects detected values that cannot be preserved. See the
+[migration guide](migration.md#handle-fields-that-need-manual-intervention)
+for unsupported and manual cases.
 
 Important mapping notes:
 
 - OTel pipeline structure ownership moved to top-level declarative sections:
-  - `otel_metrics_export` pipeline structure and transport settings → `meter_provider.*`
-  - `prometheus_export.path` → `meter_provider.*`
-  - `otel_traces_export` pipeline structure and transport/sampler settings → `tracer_provider.*`
+  - the automatically migrated `otel_metrics_export` OTLP/gRPC subset → `meter_provider.*`; gated OTLP/HTTP uses the manual provider mapping in the migration guide
+  - `prometheus_export.port` → `meter_provider.*`
+  - the automatically migrated `otel_traces_export` OTLP/gRPC and global sampler subset → `tracer_provider.*`; gated OTLP/HTTP uses the manual provider mapping in the migration guide
 - The old flat `operations` section is split by deployment scope:
   - Capture-valid fields move into `extensions.obi.capture.*` (valid in all deployment modes).
   - Daemon-only fields move into `extensions.obi.daemon.*` (standalone mode only).
@@ -645,45 +647,82 @@ Important mapping notes:
   - `filter.application` fans out to `capture.instrumentation.<protocol>.filters.{traces,metrics}`.
   - `filter.network` fans out to `capture.network.capture.filters.{traces,metrics}`.
   - `filter.stats` fans out to `capture.network.stats.filters.{traces,metrics}`.
-  - `metrics.features` maps to `capture.instrumentation.<protocol>.enabled.metrics`, `capture.network.capture.enabled`, and `capture.network.stats.{enabled,features}`.
+  - Supported `metrics.features` values map to `capture.instrumentation.<protocol>.enabled.metrics`, `capture.network.capture.enabled`, and `capture.network.stats.{enabled,features}`. These are application RED, basic network flow, and individual network-stat features.
   - Discovery selectors are exported as effective `capture.rules` after legacy/new selector precedence is resolved.
   - `discovery.skip_go_specific_tracers` maps to `capture.runtimes.go.enabled` with inverted semantics.
 
 | v1 field | v2 canonical location | Notes |
 |---|---|---|
+| `attributes.extra_group_attributes` | `extensions.obi.enrich.attributes.extra_group_attributes` | Move |
+| `attributes.host_id.override` | String `resource.attributes[]` entry named `host.id` | Move to standard resource metadata |
+| `attributes.instance_id.override_hostname` | String `resource.attributes[]` entry named `host.name` | Move to standard resource metadata |
+| `attributes.kubernetes.cluster_name` | `extensions.obi.enrich.enrichers.kubernetes.cluster_name` | Move |
+| `attributes.kubernetes.disable_informers` | `extensions.obi.enrich.enrichers.kubernetes.informers.disabled` | Move + rename |
+| `attributes.kubernetes.drop_external` | `extensions.obi.enrich.enrichers.kubernetes.drop_external` | Move |
+| `attributes.kubernetes.enable` | `extensions.obi.enrich.enrichers.kubernetes.mode` | Reshape `true`, `false`, and `autodetect` to `enabled`, `disabled`, and `autodetect` |
 | `attributes.kubernetes.informers_sync_timeout` | `extensions.obi.enrich.enrichers.kubernetes.informers.initial_sync_timeout` | Move |
 | `attributes.kubernetes.informers_resync_period` | `extensions.obi.enrich.enrichers.kubernetes.informers.resync_period` | Move |
+| `attributes.kubernetes.kubeconfig_path` | `extensions.obi.enrich.enrichers.kubernetes.auth.kubeconfig_path` | Move |
+| `attributes.kubernetes.meta_cache_address` | `extensions.obi.enrich.enrichers.kubernetes.metadata_cache.address` | Move + rename |
+| `attributes.kubernetes.meta_restrict_local_node` | `extensions.obi.enrich.enrichers.kubernetes.metadata_cache.restrict_local_node` | Move + rename |
+| `attributes.kubernetes.meta_source_labels.service_name` | `extensions.obi.enrich.enrichers.kubernetes.metadata_cache.source_labels.service_name` | Move |
+| `attributes.kubernetes.meta_source_labels.service_namespace` | `extensions.obi.enrich.enrichers.kubernetes.metadata_cache.source_labels.service_namespace` | Move |
+| `attributes.kubernetes.reconnect_initial_interval` | `extensions.obi.enrich.enrichers.kubernetes.informers.reconnect_initial_interval` | Move |
+| `attributes.kubernetes.resource_labels` | `extensions.obi.enrich.enrichers.kubernetes.resource_labels` | Move |
+| `attributes.kubernetes.service_name_template` | `extensions.obi.enrich.enrichers.kubernetes.service_name_template` | Move |
+| `attributes.metadata_retry.max_interval` | `extensions.obi.enrich.attributes.metadata_retry.max_interval` | Move |
+| `attributes.metadata_retry.start_interval` | `extensions.obi.enrich.attributes.metadata_retry.start_interval` | Move |
+| `attributes.metadata_retry.timeout` | `extensions.obi.enrich.attributes.metadata_retry.timeout` | Move |
 | `attributes.metric_span_names_limit` | `extensions.obi.capture.limits.metric_span_names` | Move + rename |
 | `attributes.rename_unresolved_hosts` | `extensions.obi.enrich.service_name.unresolved_hosts.names.default` | Move |
+| `attributes.rename_unresolved_hosts_incoming` | `extensions.obi.enrich.service_name.unresolved_hosts.names.incoming` | Move |
+| `attributes.rename_unresolved_hosts_outgoing` | `extensions.obi.enrich.service_name.unresolved_hosts.names.outgoing` | Move |
+| `attributes.select` | `extensions.obi.enrich.attributes.select` | Move |
 | `channel_buffer_len` | `extensions.obi.capture.channels.buffer_len` | Move |
 | `channel_send_timeout` | `extensions.obi.capture.channels.send_timeout` | Move |
 | `channel_send_timeout_panic` | `extensions.obi.capture.channels.panic_on_send_timeout` | Move + rename |
 | `discovery.bpf_pid_filter_off` | `extensions.obi.capture.engine.pid_filter.disabled` | Move + rename |
-| `discovery.default_otlp_grpc_port` | `extensions.obi.capture.rules[].match.process.exports_otlp.port` | Move + reshape |
+| `discovery.default_otlp_grpc_port` | `extensions.obi.capture.rules[].match.process.exports_otlp.port` | Emitted only when `exclude_otel_instrumented_services` is enabled |
 | `discovery.default_exclude_instrument` | `extensions.obi.capture.rules[]` (exclude rules with glob selectors) | Move + reshape |
 | `discovery.default_exclude_services` | `extensions.obi.capture.rules[]` (exclude rules with legacy regex selectors) | Legacy move + reshape |
 | `discovery.disabled_route_harvesters` | `extensions.obi.capture.instrumentation.http.routes.discovery.disabled_languages` | Move + rename |
 | `discovery.exclude_instrument` | `extensions.obi.capture.rules[]` (exclude rules with glob selectors) | Move + reshape |
 | `discovery.exclude_otel_instrumented_services` | `extensions.obi.capture.rules[].match.process.exports_otlp` (exclude rule) | Move + reshape |
 | `discovery.exclude_services` | `extensions.obi.capture.rules[]` (exclude rules with legacy regex selectors) | Legacy move + reshape |
-| `discovery.excluded_linux_system_paths` | *No v2 field* | Internal language-detection optimization; built-in defaults remain active and custom v1 values cannot be migrated |
-| `discovery.instrument` | `extensions.obi.capture.rules[]` (include rules with glob selectors) | Move + reshape |
+| `discovery.excluded_linux_system_paths` | *No v2 field* | The built-in default remains an internal language-detection optimization. Migration rejects custom or explicitly empty values; an exclude rule is not equivalent. |
+| `discovery.instrument` | `extensions.obi.capture.rules[]` (include rules with glob selectors) | Effective match fields only; see selector limitations in the migration guide |
+| `discovery.instrument[].exports` | `extensions.obi.capture.rules[].refine.exports.{traces,metrics}` | Logs cannot be represented |
+| `discovery.instrument[].routes.incoming` | `extensions.obi.capture.rules[].refine.http.routes.incoming.patterns` | Supported only when global `routes.patterns` is empty |
+| `discovery.instrument[].routes.outgoing` | `extensions.obi.capture.rules[].refine.http.routes.outgoing.patterns` | Supported only when global `routes.patterns` is empty |
 | `discovery.min_process_age` | `extensions.obi.capture.policy.min_process_age` | Move |
+| `discovery.poll_interval` | `extensions.obi.capture.policy.poll_interval` | Move |
 | `discovery.route_harvester_advanced.java_harvest_delay` | `extensions.obi.capture.instrumentation.http.routes.discovery.java.delay` | Move + rename |
 | `discovery.route_harvester_timeout` | `extensions.obi.capture.instrumentation.http.routes.discovery.timeout` | Move + rename |
-| `discovery.services` | `extensions.obi.capture.rules[]` (include rules with legacy regex selectors) | Legacy move + reshape |
+| `discovery.services` | `extensions.obi.capture.rules[]` (include rules with legacy regex selectors) | Effective match fields only; see selector limitations in the migration guide |
+| `discovery.services[].exports` | `extensions.obi.capture.rules[].refine.exports.{traces,metrics}` | Logs cannot be represented |
+| `discovery.services[].routes.incoming` | `extensions.obi.capture.rules[].refine.http.routes.incoming.patterns` | Supported only when global `routes.patterns` is empty |
+| `discovery.services[].routes.outgoing` | `extensions.obi.capture.rules[].refine.http.routes.outgoing.patterns` | Supported only when global `routes.patterns` is empty |
 | `discovery.skip_go_specific_tracers` | `extensions.obi.capture.runtimes.go.enabled` | Inverted boolean mapping |
 | `ebpf.batch_length` | `extensions.obi.capture.engine.batching.batch_length` | Move |
 | `ebpf.batch_timeout` | `extensions.obi.capture.engine.batching.batch_timeout` | Move |
+| `ebpf.bpf_debug` | `extensions.obi.capture.engine.debug.bpf` | Move |
 | `ebpf.bpf_fs_path` | `extensions.obi.capture.engine.bpf_filesystem.path` | Move + rename |
+| `ebpf.buffer_sizes.tcp` | `extensions.obi.capture.network.capture.buffer_size` | Move |
 | `ebpf.buffer_sizes.http` | `extensions.obi.capture.instrumentation.http.buffer_size` | Move |
 | `ebpf.buffer_sizes.kafka` | `extensions.obi.capture.instrumentation.kafka.buffer_size` | Move |
 | `ebpf.buffer_sizes.mssql` | `extensions.obi.capture.instrumentation.sql.mssql.buffer_size` | Move |
 | `ebpf.buffer_sizes.mysql` | `extensions.obi.capture.instrumentation.sql.mysql.buffer_size` | Move |
 | `ebpf.buffer_sizes.postgres` | `extensions.obi.capture.instrumentation.sql.postgres.buffer_size` | Move |
+| `ebpf.context_propagation` | `extensions.obi.capture.engine.propagation.context_propagation` | Move |
+| `ebpf.couchbase_db_cache_size` | `extensions.obi.capture.instrumentation.couchbase.db_cache_size` | Move |
+| `ebpf.disable_black_box_cp` | `extensions.obi.capture.engine.propagation.disable_black_box_cp` | Move |
 | `ebpf.dns_request_timeout` | `extensions.obi.capture.instrumentation.dns.request_timeout` | Move |
 | `ebpf.force_bpf_map_reader` | `extensions.obi.capture.engine.traffic.force_map_reader` | Move + rename |
+| `ebpf.go_http_client_buffer_timeout` | `extensions.obi.capture.instrumentation.http.go_http_client_buffer_timeout` | Move |
+| `ebpf.high_request_volume` | `extensions.obi.capture.engine.traffic.high_request_volume` | Move |
 | `ebpf.heuristic_sql_detect` | `extensions.obi.capture.instrumentation.sql.heuristic_detect` | Move + rename |
+| `ebpf.http_request_timeout` | `extensions.obi.capture.instrumentation.http.request_timeout` | Move |
+| `ebpf.instrument_cuda` | `extensions.obi.capture.instrumentation.gpu.enabled_mode` | Move + reshape |
 | `ebpf.kafka_topic_uuid_cache_size` | `extensions.obi.capture.instrumentation.kafka.topic_uuid_cache_size` | Move |
 | `ebpf.log_enricher.cache_size` | `extensions.obi.correlation.log_trace_annotation.cache.size` | Move + rename |
 | `ebpf.log_enricher.cache_ttl` | `extensions.obi.correlation.log_trace_annotation.cache.ttl` | Move + rename |
@@ -696,6 +735,7 @@ Important mapping notes:
 | `ebpf.log_enricher.plain_text.multiline` | `extensions.obi.correlation.log_trace_annotation.plain_text.multiline` | Move |
 | `ebpf.maps_config.global_scale_factor` | `extensions.obi.capture.engine.maps.global_scale_factor` | Move + rename |
 | `ebpf.max_transaction_time` | `extensions.obi.capture.engine.transactions.max_duration` | Move + rename |
+| `ebpf.mongo_requests_cache_size` | `extensions.obi.capture.instrumentation.mongo.requests_cache_size` | Move |
 | `ebpf.mssql_prepared_statements_cache_size` | `extensions.obi.capture.instrumentation.sql.mssql.prepared_statements_cache_size` | Move |
 | `ebpf.mysql_prepared_statements_cache_size` | `extensions.obi.capture.instrumentation.sql.mysql.prepared_statements_cache_size` | Move |
 | `ebpf.payload_extraction.http.graphql.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `graphql` | Move + normalize |
@@ -709,6 +749,9 @@ Important mapping notes:
 | `ebpf.payload_extraction.http.genai.qwen.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `qwen` | Move + normalize |
 | `ebpf.payload_extraction.http.genai.bedrock.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `bedrock` | Move + normalize |
 | `ebpf.payload_extraction.http.genai.mcp.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `mcp` | Move + normalize |
+| `ebpf.payload_extraction.http.genai.ollama.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `ollama` | Move + normalize |
+| `ebpf.payload_extraction.http.genai.openai_compatible.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `openai_compatible` | Move + normalize |
+| `ebpf.payload_extraction.http.genai.openai_compatible.gateways` | `extensions.obi.capture.instrumentation.http.payload_extraction.openai_compatible.gateways` | Move |
 | `ebpf.payload_extraction.http.genai.embedding.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `embedding` | Move + normalize |
 | `ebpf.payload_extraction.http.genai.rerank.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `rerank` | Move + normalize |
 | `ebpf.payload_extraction.http.genai.retrieval.enabled` | `extensions.obi.capture.instrumentation.http.payload_extraction.enabled[]` contains `retrieval` | Move + normalize |
@@ -719,8 +762,12 @@ Important mapping notes:
 | `ebpf.payload_extraction.http.enrichment.policy.obfuscation_string` | `extensions.obi.capture.instrumentation.http.payload_extraction.enrichment.policy.obfuscation_string` | Move |
 | `ebpf.payload_extraction.http.enrichment.rules` | `extensions.obi.capture.instrumentation.http.payload_extraction.enrichment.rules` | Move |
 | `ebpf.postgres_prepared_statements_cache_size` | `extensions.obi.capture.instrumentation.sql.postgres.prepared_statements_cache_size` | Move |
+| `ebpf.protocol_debug_print` | `extensions.obi.capture.engine.debug.protocol_print` | Move |
 | `ebpf.redis_db_cache.enabled` | `extensions.obi.capture.instrumentation.redis.db_cache.enabled` | Move |
+| `ebpf.redis_db_cache.max_size` | `extensions.obi.capture.instrumentation.redis.db_cache.max_size` | Move |
+| `ebpf.track_request_headers` | `extensions.obi.capture.instrumentation.http.track_request_headers` | Move |
 | `ebpf.traffic_control_backend` | `extensions.obi.capture.engine.traffic.control_backend` | Move + rename |
+| `ebpf.override_bpfloop_enabled` | `extensions.obi.capture.engine.propagation.override_bpfloop_enabled` | Move |
 | `ebpf.wakeup_len` | `extensions.obi.capture.engine.batching.wakeup_len` | Move |
 | `enforce_sys_caps` | `extensions.obi.capture.safety.enforce_system_capabilities` | Move + rename |
 | `executable_path` | `extensions.obi.capture.rules[].match.process.exe_path_regex` (include rule) | Legacy fallback selector |
@@ -732,21 +779,23 @@ Important mapping notes:
 | `internal_metrics.bpf_metric_scrape_interval` | `extensions.obi.daemon.internal_metrics.bpf.scrape_interval` | Move + rename |
 | `internal_metrics.exporter` | `extensions.obi.daemon.internal_metrics.exporter` | Move |
 | `internal_metrics.prometheus.path` | `extensions.obi.daemon.internal_metrics.prometheus.path` | Move |
+| `internal_metrics.prometheus.port` | `extensions.obi.daemon.internal_metrics.prometheus.port` | Move |
 | `javaagent.attach_timeout` | `extensions.obi.capture.runtimes.java.attach_timeout` | Move |
 | `javaagent.debug` | `extensions.obi.capture.runtimes.java.debug.enabled` | Move + rename |
 | `javaagent.debug_instrumentation` | `extensions.obi.capture.runtimes.java.debug.bytecode_instrumentation` | Move + rename |
-| `javaagent.enabled` | `extensions.obi.capture.runtimes.java.enabled` | Simplified to boolean |
+| `javaagent.enabled` | `extensions.obi.capture.runtimes.java.enabled` | Move |
 | `log_config` | `extensions.obi.daemon.logging.config_format` | Move + rename |
 | `log_format` | `extensions.obi.daemon.logging.format` | Move + rename |
 | `log_level` | Top-level `log_level` | Move to standard field |
-| `metrics.features` | `extensions.obi.capture.instrumentation.<protocol>.enabled.metrics` + `extensions.obi.capture.network.capture.enabled` + `extensions.obi.capture.network.stats.{enabled,features}` | Split mapping |
+| `metrics.features` | `extensions.obi.capture.instrumentation.<protocol>.enabled.metrics` + `extensions.obi.capture.network.capture.enabled` + `extensions.obi.capture.network.stats.{enabled,features}` | Split mapping for application RED, basic network flow, and individual network-stat features only |
 | `name_resolver.cache_expiry` | `extensions.obi.enrich.service_name.cache.ttl` | Move + rename |
 | `name_resolver.cache_len` | `extensions.obi.enrich.service_name.cache.size` | Move + rename |
+| `name_resolver.sources` | `extensions.obi.enrich.service_name.sources` | Move |
 | `network.agent_ip` | `extensions.obi.capture.network.capture.endpoint_identity.agent_ip` | Move |
 | `network.agent_ip_iface` | `extensions.obi.capture.network.capture.endpoint_identity.agent_ip_interface` | Move + rename |
 | `network.agent_ip_type` | `extensions.obi.capture.network.capture.endpoint_identity.agent_ip_family` | Move + rename |
 | `network.cache_active_timeout` | `extensions.obi.capture.network.capture.flow_lifecycle.active_timeout` | Move + rename |
-| `network.cache_max_flows` | `extensions.obi.capture.network.capture.flow_lifecycle.max_tracked_flows` | Move + rename |
+| `network.cache_max_flows` | `extensions.obi.capture.network.capture.flow_lifecycle.max_tracked_flows` and `extensions.obi.capture.limits.network_packets` | Split mapping |
 | `network.cidrs` | `extensions.obi.capture.network.capture.selection.cidrs` | Move |
 | `network.deduper` | `extensions.obi.capture.network.capture.flow_lifecycle.deduplication.strategy` | Move + rename |
 | `network.deduper_fc_ttl` | `extensions.obi.capture.network.capture.flow_lifecycle.deduplication.first_come_ttl` | Move + rename |
@@ -760,29 +809,42 @@ Important mapping notes:
 | `network.guess_ports` | `extensions.obi.capture.network.capture.flow_lifecycle.guess_ports` | Move |
 | `network.listen_interfaces` | `extensions.obi.capture.network.capture.interface_discovery.mode` | Move + reshape |
 | `network.listen_poll_period` | `extensions.obi.capture.network.capture.interface_discovery.poll_interval` | Move + rename |
+| `network.exclude_interfaces` | `extensions.obi.capture.network.capture.selection.interfaces.exclude` | Move + reshape |
+| `network.exclude_protocols` | `extensions.obi.capture.network.capture.selection.protocols.exclude` | Move + reshape |
+| `network.interfaces` | `extensions.obi.capture.network.capture.selection.interfaces.include` | Move + reshape |
+| `network.protocols` | `extensions.obi.capture.network.capture.selection.protocols.include` | Move + reshape |
 | `network.print_flows` | `extensions.obi.capture.network.capture.diagnostics.print_flows` | Move |
 | `network.reverse_dns.cache_expiry` | `extensions.obi.capture.network.capture.enrichment.reverse_dns.cache.ttl` | Move + rename |
 | `network.reverse_dns.cache_len` | `extensions.obi.capture.network.capture.enrichment.reverse_dns.cache.size` | Move + rename |
 | `network.reverse_dns.type` | `extensions.obi.capture.network.capture.enrichment.reverse_dns.mode` | Move + rename |
 | `network.sampling` | `extensions.obi.capture.network.capture.flow_lifecycle.sampling` | Move |
 | `network.source` | `extensions.obi.capture.network.capture.source` | Move |
-| `nodejs.enabled` | `extensions.obi.capture.runtimes.nodejs.enabled` | Simplified to boolean |
+| `nodejs.enabled` | `extensions.obi.capture.runtimes.nodejs.enabled` | Move |
+| `otel_metrics_export.endpoint` | `meter_provider.readers[0].periodic.exporter.otlp_grpc.endpoint` or, with gated HTTP support, `.otlp_http.endpoint` | OTel ownership move; automatic migration emits gRPC, while HTTP requires the documented manual mapping |
+| `otel_metrics_export.features` | Split through the effective `metrics.features` mapping | Deprecated; an enabled OTLP exporter whose deprecated `features` field is present (including `[]`) takes precedence, otherwise enabled Prometheus features may supply it |
 | `otel_metrics_export.histogram_aggregation` | `meter_provider.readers[0].periodic.exporter.otlp_grpc.default_histogram_aggregation` | OTel ownership move + declarative reader/exporter shape |
+| `otel_metrics_export.instrumentations` | `extensions.obi.capture.instrumentation.<protocol>.enabled.metrics` | Only protocols modeled by v2; migration rejects differing active OTLP and Prometheus lists |
+| `otel_metrics_export.interval` | `meter_provider.readers[0].periodic.interval` | Converted to milliseconds |
+| `otel_metrics_export.protocol` | Selects `meter_provider.readers[0].periodic.exporter.otlp_grpc` or, with gated HTTP support, `.otlp_http` plus its `encoding` | The exporter shape encodes the protocol; automatic migration currently supports gRPC |
 | `otel_metrics_export.reporters_cache_len` | `extensions.obi.capture.telemetry.metrics.reporters_cache_len` | Move to capture telemetry tuning |
 | `otel_metrics_export.ttl` | `extensions.obi.capture.telemetry.metrics.ttl` | Move to capture telemetry tuning |
-| `otel_metrics_export.extra_span_resource_attributes` | `extensions.obi.daemon.telemetry.metrics.prometheus.extra_span_resource_attributes` | Move to daemon telemetry tuning |
+| `otel_traces_export.endpoint` | `tracer_provider.processors[0].batch.exporter.otlp_grpc.endpoint` or, with gated HTTP support, `.otlp_http.endpoint` | OTel ownership move; automatic migration emits gRPC, while HTTP requires the documented manual mapping |
+| `otel_traces_export.instrumentations` | `extensions.obi.capture.instrumentation.<protocol>.enabled.traces` | Only protocols modeled by v2 |
+| `otel_traces_export.protocol` | Selects `tracer_provider.processors[0].batch.exporter.otlp_grpc` or, with gated HTTP support, `.otlp_http` plus its `encoding` | The exporter shape encodes the protocol; automatic migration currently supports gRPC |
 | `otel_traces_export.batch_timeout` | `tracer_provider.processors[0].batch.schedule_delay` | OTel ownership move + rename + duration(ms) representation |
 | `otel_traces_export.queue_size` | `tracer_provider.processors[0].batch.max_queue_size` | OTel ownership move + declarative processor list shape |
 | `otel_traces_export.batch_max_size` | `tracer_provider.processors[0].batch.max_export_batch_size` | OTel ownership move + declarative processor list shape |
 | `otel_traces_export.reporters_cache_len` | `extensions.obi.capture.telemetry.traces.reporters_cache_len` | Move to capture telemetry tuning |
-| `otel_traces_export.sampler.arg` | `tracer_provider.sampler` | OTel ownership move. Map to built-in sampler arguments when possible; per-workload semantics require the `obi_rule_based` sampler plugin. |
-| `otel_traces_export.sampler.name` | `tracer_provider.sampler` | OTel ownership move. Map to built-in sampler names when possible; per-workload semantics require the `obi_rule_based` sampler plugin. |
+| `otel_traces_export.sampler.arg` | `tracer_provider.sampler` | OTel ownership move for supported global built-in samplers; per-workload sampler arguments are unsupported |
+| `otel_traces_export.sampler.name` | `tracer_provider.sampler` | OTel ownership move for supported global built-in samplers; per-workload samplers are unsupported |
 | `profile_port` | `extensions.obi.daemon.profiling.port` | Move |
 | `prometheus_export.allow_service_graph_self_references` | `extensions.obi.daemon.telemetry.metrics.prometheus.allow_service_graph_self_references` | Move to daemon telemetry tuning |
 | `prometheus_export.extra_resource_attributes` | `extensions.obi.daemon.telemetry.metrics.prometheus.extra_resource_attributes` | Move to daemon telemetry tuning |
 | `prometheus_export.extra_span_resource_attributes` | `extensions.obi.daemon.telemetry.metrics.prometheus.extra_span_resource_attributes` | Move to daemon telemetry tuning |
 | `prometheus_export.port` | `meter_provider.readers[1].pull.exporter.prometheus/development.port` | OTel ownership move + declarative reader/exporter shape |
 | `prometheus_export.path` | *No canonical OTel core path in current declarative schema* | Distribution-specific/unsupported in current target shape |
+| `prometheus_export.features` | Split through the effective `metrics.features` mapping | Deprecated; used only when the OTLP metric exporter does not provide features |
+| `prometheus_export.instrumentations` | `extensions.obi.capture.instrumentation.<protocol>.enabled.metrics` | Only protocols modeled by v2; migration rejects differing active Prometheus and OTLP lists |
 | `prometheus_export.service_cache_size` | `extensions.obi.daemon.telemetry.metrics.prometheus.span_metrics_service_cache_size` | Move to daemon telemetry tuning + rename |
 | `routes.ignore_mode` | `extensions.obi.capture.instrumentation.http.routes.{incoming,outgoing}.ignore_mode` | Move + duplicate v1 global value into both directions |
 | `routes.ignored_patterns` | `extensions.obi.capture.instrumentation.http.routes.{incoming,outgoing}.ignored_patterns` | Move + duplicate v1 global value into both directions |
@@ -790,6 +852,8 @@ Important mapping notes:
 | `routes.patterns` | `extensions.obi.capture.instrumentation.http.routes.{incoming,outgoing}.patterns` | Move + duplicate v1 global value into both directions |
 | `routes.unmatched` | `extensions.obi.capture.instrumentation.http.routes.{incoming,outgoing}.unmatched` | Move + duplicate v1 global value into both directions |
 | `routes.wildcard_char` | `extensions.obi.capture.instrumentation.http.routes.{incoming,outgoing}.wildcard_char` | Move + duplicate v1 global value into both directions |
+| `service_name` | String `resource.attributes[]` entry named `service.name` | Manual standalone mapping; automatic migration rejects the deprecated OBI-wide override |
+| `service_namespace` | String `resource.attributes[]` entry named `service.namespace` | Manual standalone mapping; automatic migration rejects the deprecated OBI-wide override |
 | `shutdown_timeout` | `extensions.obi.daemon.shutdown.timeout` | Move |
 | `stats.agent_ip` | `extensions.obi.capture.network.stats.endpoint_identity.agent_ip` | Move |
 | `stats.agent_ip_iface` | `extensions.obi.capture.network.stats.endpoint_identity.agent_ip_interface` | Move + rename |
@@ -806,14 +870,28 @@ Important mapping notes:
 | `stats.reverse_dns.type` | `extensions.obi.capture.network.stats.enrichment.reverse_dns.mode` | Move + rename |
 | `trace_printer` | `extensions.obi.daemon.logging.debug_trace_output` | Move + rename |
 
+Both v2 paths for `network.cache_max_flows` configure the same runtime value.
+Migration writes them identically. If an authored document sets both
+`capture.limits.network_packets` and
+`capture.network.capture.flow_lifecycle.max_tracked_flows`, they must be equal;
+each explicitly authored value must also be greater than zero. Validation
+rejects zero or divergent values instead of silently choosing one.
+
 ## Related docs
 
-- Migration, validation, and tooling plan: [migration.md](migration.md)
+- Config v1 to v2 migration guide: [migration.md](migration.md)
 - OBI extension schema: [obi-extension.schema.json](obi-extension.schema.json)
 - Runnable standalone configuration:
   [examples/default-configuration.yaml](examples/default-configuration.yaml)
 - Authored default-values reference fragment (not a standalone document):
   [examples/default-values-reference.fragment.yaml](examples/default-values-reference.fragment.yaml)
+- Tested migration input and generated result:
+  [examples/migration-v1.yaml](examples/migration-v1.yaml) and
+  [examples/migration-v2.yaml](examples/migration-v2.yaml)
+- Tested receiver migration input and generated component body:
+  [examples/migration-receiver-v1.yaml](examples/migration-receiver-v1.yaml)
+  and
+  [examples/migration-receiver-v2.yaml](examples/migration-receiver-v2.yaml)
 
 ## Appendix: upstream alignment status (2026-02-24)
 

--- a/devdocs/config/version-2.0/examples/migration-receiver-v1.yaml
+++ b/devdocs/config/version-2.0/examples/migration-receiver-v1.yaml
@@ -1,0 +1,18 @@
+discovery:
+  instrument:
+    - exe_path: "${CART_ROOT:-/srv}/cart-*"
+      open_ports: "8080"
+filter:
+  application:
+    http.request.method:
+      not_match: OPTIONS
+routes:
+  unmatched: heuristic
+  patterns:
+    - "/cart/{id}"
+  ignored_patterns:
+    - "/health"
+  ignore_mode: all
+metrics:
+  features:
+    - application

--- a/devdocs/config/version-2.0/examples/migration-receiver-v2.yaml
+++ b/devdocs/config/version-2.0/examples/migration-receiver-v2.yaml
@@ -1,0 +1,351 @@
+version: "2.0"
+policy:
+    default_action: exclude
+    match_order: first_match_wins
+    poll_interval: 0s
+    min_process_age: 5s
+rules:
+    - action: exclude
+      name: exclude-obi-and-collectors
+      description: Exclude OBI and collector binaries to avoid self-instrumentation and collector recursion.
+      match:
+        process:
+            exe_path_glob:
+                - '{*/obi,obi,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*}'
+    - action: exclude
+      name: exclude-system-namespaces
+      description: Exclude common platform/system Kubernetes namespaces from instrumentation by default.
+      match:
+        kubernetes:
+            namespace_glob:
+                - kube-system
+                - kube-node-lease
+                - local-path-storage
+                - cert-manager
+                - monitoring
+                - gke-connect
+                - gke-gmp-system
+                - gke-managed-cim
+                - gke-managed-filestorecsi
+                - gke-managed-metrics-server
+                - gke-managed-system
+                - gke-system
+                - gke-managed-volumepopulator
+                - gatekeeper-system
+    - action: exclude
+      name: exclude-otlp-exporters
+      description: Exclude services that already export OTLP to prevent duplicate telemetry pipelines.
+      match:
+        process:
+            exports_otlp:
+                port: 4317
+                protocol: protobuf
+    - action: include
+      name: ""
+      description: ""
+      match:
+        process:
+            open_ports: "8080"
+            exe_path_glob:
+                - /srv/cart-*
+instrumentation:
+    http:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        track_request_headers: false
+        request_timeout: 0s
+        go_http_client_buffer_timeout: 1s
+        buffer_size: 0
+        routes:
+            incoming:
+                unmatched: heuristic
+                patterns:
+                    - /cart/{id}
+                ignored_patterns:
+                    - /health
+                ignore_mode: all
+                wildcard_char: '*'
+                max_path_segment_cardinality: 10
+            outgoing:
+                unmatched: heuristic
+                patterns:
+                    - /cart/{id}
+                ignored_patterns:
+                    - /health
+                ignore_mode: all
+                wildcard_char: '*'
+                max_path_segment_cardinality: 10
+            discovery:
+                timeout: 10s
+                disabled_languages: []
+                java:
+                    delay: 5s
+        payload_extraction:
+            enabled: []
+            sqlpp:
+                endpoint_patterns:
+                    - /query/service
+            enrichment:
+                policy:
+                    default_action:
+                        headers: exclude
+                        body: exclude
+                    obfuscation_string: '***'
+                rules: []
+            openai_compatible:
+                gateways: []
+    grpc:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+    sql:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        heuristic_detect: false
+        mysql:
+            buffer_size: 0
+            prepared_statements_cache_size: 1024
+        postgres:
+            buffer_size: 0
+            prepared_statements_cache_size: 1024
+        mssql:
+            buffer_size: 0
+            prepared_statements_cache_size: 1024
+    redis:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        db_cache:
+            enabled: false
+            max_size: 1000
+    kafka:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        buffer_size: 0
+        topic_uuid_cache_size: 1024
+    mongo:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        requests_cache_size: 1024
+    couchbase:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        db_cache_size: 1024
+    dns:
+        enabled:
+            traces: false
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        request_timeout: 5s
+    gpu:
+        enabled:
+            traces: false
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        enabled_mode: auto
+    aerospike:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+runtimes:
+    go:
+        enabled: true
+    nodejs:
+        enabled: true
+    java:
+        enabled: true
+        debug:
+            enabled: false
+            bytecode_instrumentation: false
+        attach_timeout: 10s
+network:
+    capture:
+        enabled: false
+        source: socket_filter
+        buffer_size: 0
+        endpoint_identity:
+            agent_ip: ""
+            agent_ip_interface: external
+            agent_ip_family: any
+        selection:
+            interfaces:
+                include: []
+                exclude:
+                    - lo
+            protocols:
+                include: []
+                exclude: []
+            direction: both
+            cidrs: []
+        filters:
+            traces: {}
+            metrics: {}
+        flow_lifecycle:
+            max_tracked_flows: 5000
+            active_timeout: 5s
+            deduplication:
+                strategy: first_come
+                first_come_ttl: 0s
+            sampling: 0
+            guess_ports: disable
+        interface_discovery:
+            mode: watch
+            poll_interval: 10s
+        enrichment:
+            geo_ip:
+                ipinfo:
+                    path: ""
+                maxmind:
+                    country_path: ""
+                    asn_path: ""
+                cache:
+                    size: 512
+                    ttl: 1h0m0s
+            reverse_dns:
+                mode: none
+                cache:
+                    size: 256
+                    ttl: 1h0m0s
+        diagnostics:
+            print_flows: false
+    stats:
+        enabled: false
+        features: []
+        endpoint_identity:
+            agent_ip: ""
+            agent_ip_interface: external
+            agent_ip_family: any
+        selection:
+            cidrs: []
+        filters:
+            traces: {}
+            metrics: {}
+        enrichment:
+            geo_ip:
+                ipinfo:
+                    path: ""
+                maxmind:
+                    country_path: ""
+                    asn_path: ""
+                cache:
+                    size: 512
+                    ttl: 1h0m0s
+            reverse_dns:
+                mode: none
+                cache:
+                    size: 256
+                    ttl: 1h0m0s
+        diagnostics:
+            print_stats: false
+limits:
+    network_packets: 5000
+    metric_span_names: 100
+engine:
+    debug:
+        bpf: false
+        protocol_print: false
+    pid_filter:
+        disabled: false
+    batching:
+        wakeup_len: 500
+        batch_length: 100
+        batch_timeout: 1s
+    propagation:
+        context_propagation: disabled
+        override_bpfloop_enabled: false
+        disable_black_box_cp: false
+    traffic:
+        control_backend: auto
+        high_request_volume: false
+        force_map_reader: auto
+    transactions:
+        max_duration: 5m0s
+    maps:
+        global_scale_factor: 0
+    bpf_filesystem:
+        path: /sys/fs/bpf/
+safety:
+    enforce_system_capabilities: false
+channels:
+    buffer_len: 50
+    send_timeout: 1m0s
+    panic_on_send_timeout: false
+telemetry:
+    traces:
+        reporters_cache_len: 256
+    metrics:
+        reporters_cache_len: 256
+        ttl: 5m0s

--- a/devdocs/config/version-2.0/examples/migration-v1.yaml
+++ b/devdocs/config/version-2.0/examples/migration-v1.yaml
@@ -1,0 +1,23 @@
+discovery:
+  instrument:
+    - exe_path: "${CART_ROOT:-/srv}/cart-*"
+      open_ports: "8080"
+filter:
+  application:
+    http.request.method:
+      not_match: OPTIONS
+routes:
+  unmatched: heuristic
+  patterns:
+    - "/cart/{id}"
+  ignored_patterns:
+    - "/health"
+  ignore_mode: all
+metrics:
+  features:
+    - application
+otel_traces_export:
+  endpoint: "http://${OTLP_HOST:-collector}:4317"
+otel_metrics_export:
+  endpoint: "http://${OTLP_HOST:-collector}:4317"
+log_level: DEBUG

--- a/devdocs/config/version-2.0/examples/migration-v2.yaml
+++ b/devdocs/config/version-2.0/examples/migration-v2.yaml
@@ -1,0 +1,468 @@
+file_format: "1.0"
+log_level: debug
+meter_provider:
+    readers:
+        - periodic:
+            exporter:
+                otlp_grpc:
+                    default_histogram_aggregation: explicit_bucket_histogram
+                    endpoint: http://collector:4317
+                    tls:
+                        insecure: true
+            interval: 60000
+        - pull:
+            exporter:
+                prometheus/development:
+                    port: 0
+propagator: {}
+resource: {}
+tracer_provider:
+    processors:
+        - batch:
+            exporter:
+                otlp_grpc:
+                    endpoint: http://collector:4317
+                    tls:
+                        insecure: true
+            max_export_batch_size: 4096
+            max_queue_size: 16384
+            schedule_delay: 15000
+extensions:
+    obi:
+        version: "2.0"
+        capture:
+            policy:
+                default_action: exclude
+                match_order: first_match_wins
+                poll_interval: 0s
+                min_process_age: 5s
+            rules:
+                - action: exclude
+                  name: exclude-obi-and-collectors
+                  description: Exclude OBI and collector binaries to avoid self-instrumentation and collector recursion.
+                  match:
+                    process:
+                        exe_path_glob:
+                            - '{*/obi,obi,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*}'
+                - action: exclude
+                  name: exclude-system-namespaces
+                  description: Exclude common platform/system Kubernetes namespaces from instrumentation by default.
+                  match:
+                    kubernetes:
+                        namespace_glob:
+                            - kube-system
+                            - kube-node-lease
+                            - local-path-storage
+                            - cert-manager
+                            - monitoring
+                            - gke-connect
+                            - gke-gmp-system
+                            - gke-managed-cim
+                            - gke-managed-filestorecsi
+                            - gke-managed-metrics-server
+                            - gke-managed-system
+                            - gke-system
+                            - gke-managed-volumepopulator
+                            - gatekeeper-system
+                - action: exclude
+                  name: exclude-otlp-exporters
+                  description: Exclude services that already export OTLP to prevent duplicate telemetry pipelines.
+                  match:
+                    process:
+                        exports_otlp:
+                            port: 4317
+                            protocol: protobuf
+                - action: include
+                  name: ""
+                  description: ""
+                  match:
+                    process:
+                        open_ports: "8080"
+                        exe_path_glob:
+                            - /srv/cart-*
+            instrumentation:
+                http:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    track_request_headers: false
+                    request_timeout: 0s
+                    go_http_client_buffer_timeout: 1s
+                    buffer_size: 0
+                    routes:
+                        incoming:
+                            unmatched: heuristic
+                            patterns:
+                                - /cart/{id}
+                            ignored_patterns:
+                                - /health
+                            ignore_mode: all
+                            wildcard_char: '*'
+                            max_path_segment_cardinality: 10
+                        outgoing:
+                            unmatched: heuristic
+                            patterns:
+                                - /cart/{id}
+                            ignored_patterns:
+                                - /health
+                            ignore_mode: all
+                            wildcard_char: '*'
+                            max_path_segment_cardinality: 10
+                        discovery:
+                            timeout: 10s
+                            disabled_languages: []
+                            java:
+                                delay: 5s
+                    payload_extraction:
+                        enabled: []
+                        sqlpp:
+                            endpoint_patterns:
+                                - /query/service
+                        enrichment:
+                            policy:
+                                default_action:
+                                    headers: exclude
+                                    body: exclude
+                                obfuscation_string: '***'
+                            rules: []
+                        openai_compatible:
+                            gateways: []
+                grpc:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                sql:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    heuristic_detect: false
+                    mysql:
+                        buffer_size: 0
+                        prepared_statements_cache_size: 1024
+                    postgres:
+                        buffer_size: 0
+                        prepared_statements_cache_size: 1024
+                    mssql:
+                        buffer_size: 0
+                        prepared_statements_cache_size: 1024
+                redis:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    db_cache:
+                        enabled: false
+                        max_size: 1000
+                kafka:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    buffer_size: 0
+                    topic_uuid_cache_size: 1024
+                mongo:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    requests_cache_size: 1024
+                couchbase:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    db_cache_size: 1024
+                dns:
+                    enabled:
+                        traces: false
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    request_timeout: 5s
+                gpu:
+                    enabled:
+                        traces: false
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    enabled_mode: auto
+                aerospike:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+            runtimes:
+                go:
+                    enabled: true
+                nodejs:
+                    enabled: true
+                java:
+                    enabled: true
+                    debug:
+                        enabled: false
+                        bytecode_instrumentation: false
+                    attach_timeout: 10s
+            network:
+                capture:
+                    enabled: false
+                    source: socket_filter
+                    buffer_size: 0
+                    endpoint_identity:
+                        agent_ip: ""
+                        agent_ip_interface: external
+                        agent_ip_family: any
+                    selection:
+                        interfaces:
+                            include: []
+                            exclude:
+                                - lo
+                        protocols:
+                            include: []
+                            exclude: []
+                        direction: both
+                        cidrs: []
+                    filters:
+                        traces: {}
+                        metrics: {}
+                    flow_lifecycle:
+                        max_tracked_flows: 5000
+                        active_timeout: 5s
+                        deduplication:
+                            strategy: first_come
+                            first_come_ttl: 0s
+                        sampling: 0
+                        guess_ports: disable
+                    interface_discovery:
+                        mode: watch
+                        poll_interval: 10s
+                    enrichment:
+                        geo_ip:
+                            ipinfo:
+                                path: ""
+                            maxmind:
+                                country_path: ""
+                                asn_path: ""
+                            cache:
+                                size: 512
+                                ttl: 1h0m0s
+                        reverse_dns:
+                            mode: none
+                            cache:
+                                size: 256
+                                ttl: 1h0m0s
+                    diagnostics:
+                        print_flows: false
+                stats:
+                    enabled: false
+                    features: []
+                    endpoint_identity:
+                        agent_ip: ""
+                        agent_ip_interface: external
+                        agent_ip_family: any
+                    selection:
+                        cidrs: []
+                    filters:
+                        traces: {}
+                        metrics: {}
+                    enrichment:
+                        geo_ip:
+                            ipinfo:
+                                path: ""
+                            maxmind:
+                                country_path: ""
+                                asn_path: ""
+                            cache:
+                                size: 512
+                                ttl: 1h0m0s
+                        reverse_dns:
+                            mode: none
+                            cache:
+                                size: 256
+                                ttl: 1h0m0s
+                    diagnostics:
+                        print_stats: false
+            limits:
+                network_packets: 5000
+                metric_span_names: 100
+            engine:
+                debug:
+                    bpf: false
+                    protocol_print: false
+                pid_filter:
+                    disabled: false
+                batching:
+                    wakeup_len: 500
+                    batch_length: 100
+                    batch_timeout: 1s
+                propagation:
+                    context_propagation: disabled
+                    override_bpfloop_enabled: false
+                    disable_black_box_cp: false
+                traffic:
+                    control_backend: auto
+                    high_request_volume: false
+                    force_map_reader: auto
+                transactions:
+                    max_duration: 5m0s
+                maps:
+                    global_scale_factor: 0
+                bpf_filesystem:
+                    path: /sys/fs/bpf/
+            safety:
+                enforce_system_capabilities: false
+            channels:
+                buffer_len: 50
+                send_timeout: 1m0s
+                panic_on_send_timeout: false
+            telemetry:
+                traces:
+                    reporters_cache_len: 256
+                metrics:
+                    reporters_cache_len: 256
+                    ttl: 5m0s
+        enrich:
+            enrichers:
+                kubernetes:
+                    mode: autodetect
+                    cluster_name: ""
+                    service_name_template: ""
+                    auth:
+                        kubeconfig_path: ""
+                    informers:
+                        initial_sync_timeout: 30s
+                        reconnect_initial_interval: 5s
+                        resync_period: 30m0s
+                        disabled: []
+                    drop_external: false
+                    resource_labels:
+                        service.name:
+                            - app.kubernetes.io/instance
+                            - app.kubernetes.io/name
+                        service.namespace:
+                            - app.kubernetes.io/part-of
+                        service.version:
+                            - app.kubernetes.io/version
+                    metadata_cache:
+                        address: ""
+                        restrict_local_node: false
+                        source_labels:
+                            service_name: ""
+                            service_namespace: ""
+            service_name:
+                unresolved_hosts:
+                    names:
+                        default: unresolved
+                        outgoing: outgoing
+                        incoming: incoming
+                sources:
+                    - k8s
+                cache:
+                    size: 1024
+                    ttl: 5m0s
+            attributes:
+                select: {}
+                extra_group_attributes: {}
+                metadata_retry:
+                    timeout: 30s
+                    start_interval: 500ms
+                    max_interval: 5s
+        correlation:
+            log_trace_annotation:
+                enabled: false
+                field_names:
+                    trace_id: trace_id
+                    span_id: span_id
+                plain_text:
+                    enabled: true
+                    placement: suffix
+                    multiline: first_line
+                cache:
+                    size: 128
+                    ttl: 30m0s
+                async_writer:
+                    workers: 8
+                    channel_len: 500
+        daemon:
+            logging:
+                format: text
+                config_format: ""
+                debug_trace_output: disabled
+            profiling:
+                port: 0
+            shutdown:
+                timeout: 10s
+            internal_metrics:
+                exporter: disabled
+                prometheus:
+                    port: 0
+                    path: /internal/metrics
+                bpf:
+                    scrape_interval: 15s
+            telemetry:
+                metrics:
+                    prometheus:
+                        allow_service_graph_self_references: false
+                        span_metrics_service_cache_size: 10000
+                        extra_resource_attributes: []
+                        extra_span_resource_attributes: []

--- a/devdocs/config/version-2.0/migration.md
+++ b/devdocs/config/version-2.0/migration.md
@@ -1,195 +1,785 @@
-# OBI Configuration Migration Plan
+# Migrate OBI configuration from v1 to v2
 
-Status: Draft for discussion  
-Audience: OBI maintainers and contributors  
-Scope: migration behavior, validation policy, rollout strategy, and tooling expectations
+This guide explains how to move an existing OBI configuration to Config v2
+with a workflow designed to preserve effective behavior. It covers the
+standalone OBI binary and the OBI Collector receiver.
 
-This document defines how the project and users will migrate configuration from the v1 to v2 model safely and predictably.
+> [!IMPORTANT]
+> Use Config v2 for standalone OBI only with a release whose notes explicitly
+> say that standalone Config v2 loading is enabled. Config v2 in OBI v0.10.0
+> is internal groundwork, not a public runtime configuration interface. The
+> complete public release is tracked by the
+> [Config v2 release gate](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2251),
+> including
+> [standalone loading](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2535)
+> and its
+> [implementation PR](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2682).
+> A successful `obi config validate` checks the document; it does not prove
+> that the installed OBI runtime can load v2.
 
-Goals:
+The migration command is designed to preserve effective behavior. It combines
+a v2 round-trip comparison with checks for structural mappings that cannot be
+compared field-for-field, and rejects detected values that cannot be
+preserved. Static checks cannot cover external environment overlays or runtime
+dependencies, so the canary comparison in this guide remains required.
 
-- Deterministic parsing and validation for v2 inputs.
-- Consistent behavior across standalone host and collector receiver host.
-- Actionable diagnostics for operators before rollout.
+## Before you migrate
 
-## v2 Configuration Parsing
+1. Keep the old OBI binary or container image, its exact version or digest,
+   and an unchanged copy of the v1 file.
+2. Inventory configuration supplied outside the file: environment variables,
+   command-line arguments, Kubernetes manifests, Helm values, and injected
+   secrets.
+3. Obtain an OBI binary from the release that will run v2. Do not replace the
+   running binary yet.
+4. Confirm that the release notes say both standalone loading and the
+   migration CLI are supported.
+5. Choose one representative instance for a canary. Keep the rest on v1 until
+   telemetry from the canary has been compared.
 
-A new configuration package will be added. Its purpose will be to provide:
+The command migrates one YAML file. Runtime environment overrides such as
+`OTEL_EBPF_*`, `OTEL_EXPORTER_OTLP_*`, and `OTEL_SERVICE_NAME` are not read as
+additional v1 configuration. Merely carrying a legacy variable into the v2
+deployment does not preserve its override. Materialize its reviewed value or
+reference that variable explicitly from the canonical v2 field, as shown in
+[Rewire v1 environment overrides](#rewire-v1-environment-overrides).
 
-- Parsing functionality of the `extension.obi` portion of the `v2` configuration
-- Export types representing the OBI configuration
+Do not put credentials into a temporary migration file merely to make them
+visible to the command. Keep secret-backed values external, but wire their
+variables explicitly into the supported v2 field that consumes them.
 
-Using this new package, both the OBI command and the collector receiver will parse user provided configuration.
-It will be up to these callers to determine:
+Substitution happens before output is written. A secret referenced inside the
+source file can therefore be materialized into the generated file. Keep the
+migration directory private and inspect its handling as secret material.
 
-- how to fallback to v1 support when the parser informs it that the input format is v1
-- how to setup the SDK which is outside the scope of the v2 configuration package
+## Run the migration
 
-### Integration with `otelconf`
+The exact command shape is:
 
-The OBI v2 configuration package models top-level OpenTelemetry declarative sections with `go.opentelemetry.io/contrib/otelconf/x` and imports the narrow subset OBI supports directly:
-
-- `file_format` is validated and currently restricted to `"1.0"`.
-- `resource` imports string `host.name` and `host.id`.
-- `tracer_provider` imports the supported sampler subset and one batch OTLP/gRPC span exporter.
-- `meter_provider` imports one periodic OTLP/gRPC reader and one Prometheus development pull reader.
-- Top-level `log_level` configures OBI daemon logging.
-
-The v2 extension does not define `extensions.obi.daemon.logging.level`; OBI log
-verbosity is sourced only from the standard top-level `log_level` field.
-
-SDK object construction is outside the v2 configuration package scope. Unsupported declarative sections and fields are parsed when `otelconf/x` models them, but they are not merged into OBI-owned runtime settings. OBI also does not merge or translate `instrumentation/development` into OBI-owned settings.
-
-Environment-variable substitution is loader-specific. `otelconf/x.ParseYAML` expands `${VAR}`, `${env:VAR}`, and `${VAR:-fallback}` before decoding. The internal OBI `schema.ParseStandaloneYAML` parser decodes the bytes it is given directly, so callers using that parser must perform any desired substitution first.
-
-### Deployment-mode validation
-
-`extensions.obi` has a two-tier structure:
-
-- `capture`: receiver-embeddable — valid in **all** deployment modes.
-- `enrich`, `correlation`, `daemon`: **standalone-mode only** — not valid in Collector receiver deployments.
-
-When parsing configuration for a Collector receiver context, the v2 parser will reject any configuration that includes standalone-only sections (`enrich`, `correlation`, `daemon`) and surface a structured error with remediation guidance.
-This validation is structural: the parser does not rely on a `deployment:` flag in the config — the section presence itself is the indicator.
-
-When parsing for a standalone context, all sections are valid.
-The presence of `enrich`, `correlation`, and `daemon` is not required — these sections have defaults when omitted.
-
-### Backward compatibility behavior
-
-Based on the structure of the configuration, the version of that configuration can be determined from:
-
-- Root `file_format` identifies the OTel declarative document contract.
-- `extensions.obi.version` identifies OBI extension contract.
-
-From this, the v2 configuration package will behave as follows:
-
-- The v2 parser only accepts supported v2 configuration contracts.
-- If config is not v2 (including detectable v1 shape), return a structured version error with actionable guidance.
-- Caller decides fallback behavior (for example, route to legacy v1 parsing/setup path).
-- The v2 parser does not perform legacy setup or implicit v1→v2 translation.
-- If both `extensions.obi` and `instrumentation/development` are present, OBI behavior is sourced from `extensions.obi` only.
-
-Going forward, the configuration package may need to add support for future versions (i.e. v3).
-It will be structured in a way to seamlessly support these new configuration files.
-
-### Why these responsibilities belong to the caller
-
-The v2 configuration package is deliberately a parsing and validation layer — not a setup or migration layer.
-This separation was a conscious design choice:
-
-- Version detection and fallback routing are host-specific concerns. The standalone `obi` command and the Collector receiver have different error surfaces, logging facilities, and user communication channels. Centralizing routing logic in the package would force one error-handling strategy onto both hosts.
-- A parser that silently attempts v1→v2 translation would hide version mismatches from operators. Explicit versioning with a structured error gives the caller — and ultimately the operator — full visibility into what version was provided and what was expected.
-- Keeping the package scope narrow (parse + validate `extensions.obi`) makes it testable in isolation, without requiring a full OBI host context.
-
-## Migration CLI
-
-Migrate a v1 file to a standalone v2 document with:
-
-```shell
-obi config migrate ./obi-v1.yaml > ./obi-v2.yaml
+```text
+obi config migrate [--mode=standalone|receiver] <path>
 ```
 
-The command performs v1-to-v2 migration. The migrated YAML is written to standard output so it can be reviewed or redirected to a file. A deterministic mapping report for non-1:1 rewrites is written to standard error.
+It accepts one file path. Standalone is the default; use `--mode=receiver` for
+a legacy `receivers.obi` component body. It does not accept standard input, an
+output option, or source and target version flags.
 
-Migration uses the v1 runtime configuration type and the same internal v1-to-v2 converter used by OBI. It rejects malformed input, unknown v1 fields, and fields whose effective value cannot survive a v2 round trip. The command also validates the generated document before writing it.
+Migration uses the v1 runtime configuration type and the same internal
+v1-to-v2 converter as OBI. It rejects malformed input, unknown v1 fields, and
+values that cannot survive a v2 round trip, then validates the generated
+document before writing it.
 
-The command migrates the file-based configuration surface. It resolves `${VAR}`, `${VAR:-default}`, and `$(VAR)` references embedded in the file, but it does not apply unrelated runtime environment-variable overrides. Given the same file and substitution values, output is stable across runs.
-
-### What non-deterministic means
-
-Most v1→v2 mappings are 1:1 moves and renames (see the [v1→v2 mapping table](./config-v2.md#compatibility-and-mapping-from-v1)).
-A small set of mappings are structurally non-trivial:
-
-- **Fan-out**: `filter.application` fans out to per-protocol `capture.instrumentation.<protocol>.filters.{traces,metrics}`. The migration tool applies the v1 value as the default for all protocols and emits a mapping report explaining the fan-out.
-- **Directional fan-out**: each flat v1 global `routes` field is copied into both `capture.instrumentation.http.routes.incoming` and `.outgoing`. Existing per-service `routes.incoming` and `routes.outgoing` patterns retain their direction under `capture.rules[].refine.http.routes`. Omitted per-service fields inherit their matching global direction; explicit arrays replace inherited arrays.
-- **Shape change**: `discovery.exclude_otel_instrumented_services` is rewritten into a structured rule entry under `capture.rules`. The migration tool generates the entry and flags it for operator review.
-- **Removed implementation tuning**: `discovery.excluded_linux_system_paths` controls preliminary language-detection cost rather than workload selection. Config v2 retains the built-in runtime defaults without exposing a field. A custom or empty v1 value cannot round-trip and causes migration to fail; use explicit `capture.rules` when the intent is to exclude workloads.
-- **Inverted boolean**: `discovery.skip_go_specific_tracers: true` maps to `capture.runtimes.go.enabled: false`. The migration tool applies the inversion and emits a note.
-- **Sampler**: `otel_traces_export.sampler.name` and `.arg` migrate to `tracer_provider.sampler`. Simple cases (e.g., `always_on`, `trace_id_ratio_based`) map directly to built-in OTel declarative sampler types. Custom or workload-specific sampler configs may require operator intervention and use of the `obi_rule_based` sampler plugin.
-
-Mappings that cannot be resolved without operator input fail with an error that identifies the affected v1 field. For example, a non-default `prometheus_export.path` cannot currently be represented by the supported OpenTelemetry declarative Prometheus exporter shape and must be migrated manually.
-
-## Validation CLI
-
-Validate a standalone v2 document with:
+Create new files in a private temporary directory so neither the source file
+nor an earlier result can be overwritten accidentally:
 
 ```shell
-obi config validate ./path/to/config
+umask 077
+migration_dir="$(mktemp -d)"
+
+obi config migrate ./obi-v1.yaml \
+  > "${migration_dir}/obi-v2.yaml" \
+  2> "${migration_dir}/migration-report.txt"
 ```
 
-Validate a Collector receiver v2 configuration with:
+On success, standard output is either a complete standalone v2 document or,
+with `--mode=receiver`, a complete v2 receiver component body. Standard error
+is a deterministic summary report. The report starts with:
+
+```text
+migrated v1 config to OBI config v2
+```
+
+It may then list broad non-1:1 transformation categories present in the source:
+filter fan-out, discovery-rule reshaping, inverted Go tracer enablement,
+directional route expansion, and exporter ownership changes. It is not a
+field-by-field mapping report. Save both streams and review the generated YAML.
+The CLI has no separate warning class: report bullets are informational, while
+unsupported values make the command fail.
+
+Migration, parsing, and validation failures detected before output writing
+leave standard output empty, and standard error starts with `migration failed:`.
+An output write failure such as a full filesystem can leave a partial target
+file; accept the file only when the command exits `0`. Unsupported or lossy
+values are reported with relevant v1 paths, for example:
+
+```text
+migration failed: fields are outside the supported v1-to-v2 migration contract: prometheus_export.path
+```
+
+Given the same file and substitution environment, repeated runs produce the
+same YAML and report. Confirm that before editing the result:
 
 ```shell
-obi config validate --mode=receiver ./path/to/receiver-config
+obi config migrate ./obi-v1.yaml \
+  > "${migration_dir}/obi-v2-second.yaml" \
+  2> "${migration_dir}/migration-report-second.txt"
+
+diff -u "${migration_dir}/obi-v2.yaml" \
+  "${migration_dir}/obi-v2-second.yaml"
+diff -u "${migration_dir}/migration-report.txt" \
+  "${migration_dir}/migration-report-second.txt"
 ```
 
-The default mode is `standalone`. Validation performs environment substitution, parses the selected v2 layout, converts it through the shared runtime adapter, and applies runtime configuration validation without starting OBI. Receiver mode rejects standalone-only sections (`enrich`, `correlation`, and `daemon`) and reports the section that must be removed or moved to a standalone document.
+## Follow the tested example
 
-Validation accepts Config v2 only. A malformed or unsupported Config v2 document is never reinterpreted as v1. Use `obi config migrate` for v1 input.
+The checked-in
+[v1 migration input](examples/migration-v1.yaml) includes a discovery selector,
+an application filter, global HTTP route settings, OTLP traces and metrics,
+and environment substitution. Its
+[generated standalone v2 result](examples/migration-v2.yaml) is the unedited
+output of the real migration command.
 
-Both commands use stable exit codes:
+Reproduce it with:
 
-| Exit code | Meaning |
+```shell
+CART_ROOT=/srv OTLP_HOST=collector \
+  obi config migrate \
+  ./devdocs/config/version-2.0/examples/migration-v1.yaml \
+  > ./migration-v2.yaml \
+  2> ./migration-report.txt
+
+diff -u \
+  ./devdocs/config/version-2.0/examples/migration-v2.yaml \
+  ./migration-v2.yaml
+
+obi config validate ./migration-v2.yaml
+```
+
+The generated file is intentionally verbose. It materializes the v1 values and
+defaults represented by the current v2 model. Unmodelled runtime behavior can
+still vary by release, which is why the target version must be pinned and
+canary-tested. Do not remove apparently redundant `false`, zero, empty, or
+default-valued fields before that test. Presence and omission are not
+interchangeable for every v2 field.
+
+The most visible rewrites in this example are:
+
+| v1 | v2 |
 |---|---|
-| `0` | Validation or migration succeeded, or command help was requested. |
-| `1` | The file could not be read, the configuration was invalid, or migration could not preserve a field. |
-| `2` | Command usage, a flag, or a mode was unsupported. |
+| `discovery.instrument` | Ordered `extensions.obi.capture.rules` |
+| `filter.application` | Every protocol's trace and metric filters |
+| Flat global `routes` | HTTP `routes.incoming` and `routes.outgoing` |
+| `otel_traces_export` | Top-level `tracer_provider` |
+| `otel_metrics_export` | Top-level `meter_provider` |
+| `log_level` | Top-level standard `log_level` |
 
-## Rollout strategy
+## Review behavior changes
 
-### Phase 0 — Build contract and tooling
+The migration output is intended to preserve the represented effective v1
+configuration, but native v2 authoring has different defaults and structure.
+Review these points before deployment.
 
-- Finalize v2 configuration artifacts: schema, example, migration doc, parity check.
-- Implement the new `extensions.obi` v2 configuration package (parse + validate `capture`, `enrich`, `correlation`, `daemon`).
-- Implement and ship the `obi_rule_based` sampler plugin (referenced via `tracer_provider.sampler`) with documented rule semantics.
-  - This is required before v2 GA: per-workload sampling is a first-class use case and must be addressable without requiring workarounds.
-  - Integrate sampler plugin registration/wiring in OBI startup paths (standalone and receiver embedding paths where applicable).
-- Implement migration CLI.
-- Implement validation CLI.
+### Capture policy and ordered rules
 
-### Phase 1 — Freeze and identify
+Config v2 uses a default-on policy: omitting
+`capture.policy.default_action`, or setting it to `include`, captures processes
+that no rule excludes. This differs from a v1 file with no target selector,
+where application capture is disabled.
 
-- Freeze v1 key surface except critical fixes.
-- Lock version-detection and compatibility behavior.
-- Communicate v1 freeze to users and direct them to migration tooling.
+The migrator writes `default_action: exclude` when needed to preserve v1
+selection. It emits `first_match_wins` with exclusion rules before inclusion
+rules. The target adapter in
+[#2682](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2682)
+also accepts `last_match_wins`; preserving runtime exclusion precedence
+requires includes before excludes in that mode. The migrator does not emit
+that alternative. It also resolves the precedence between
+deprecated regex selectors, current glob selectors, and the top-level
+`executable_path`, `open_port`, and `target_pids` fallbacks. The output is the
+effective ordered policy, not a syntactic copy of every selector.
 
-### Phase 2 — Dual-read period
+Do not reorder generated rules without retesting:
 
-- Attempt v2 parser first; on explicit not-v2 result, invoke legacy parser path.
-- Both parsers active simultaneously; no user-visible behavior change for v1 configs.
-- Use this phase to gather feedback on v2 ergonomics and migration tooling.
+- any matching exclusion takes precedence over inclusion;
+- with generated `first_match_wins`, the first matching YAML include rule's
+  refinement wins;
+- generated include rules reverse the effective v1 selector order because v1
+  applies the later matching selector's refinement;
+- when multiple v1 include selectors are effective, `exports` must be present
+  on every selector or absent from every selector, and the same rule applies
+  independently to `routes`; the command rejects mixed explicit and inherited
+  refinements because a single winning v2 rule cannot preserve v1's
+  field-by-field layering safely;
+- explicitly setting `rules: []` removes the generated built-in workload
+  exclusions;
+- an empty rule list with `default_action: include` is default-on;
+- an empty rule list with `default_action: exclude` captures nothing.
 
-### Phase 3 — v2-first default
+### Protocol and signal filters
 
-- Default docs/examples/CI to v2.
-- Deprecate the v1 configuration. Warn users in logs and validation output, and tell them how to migrate with tooling.
-- v1 parsing remains available but is no longer the recommended path.
+The v1 `filter.application` value is global. Migration copies it to trace and
+metric filters for every application protocol. It similarly copies
+`filter.network` and `filter.stats` into their supported signal locations.
 
-### Phase 4 — v1 retirement
+Keep every migrated application protocol's trace and metric maps identical to
+`capture.instrumentation.http.filters.traces`. Keep each network flow trace
+and metric map identical, and do the same for network stats. The target loader
+rejects any difference because each family still has one runtime filter.
+Protocol- and signal-specific narrowing is modeled in the v2 document but is
+not yet a supported runtime behavior. Its final semantics remain tracked in
+[#1282](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1282).
+Do not invent different SQL, HTTP, trace, or metric filters during migration.
 
-- Remove v1 parsing. Error on v1 input, and tell users how to migrate with tooling.
+### HTTP routes
 
-### Why this phased approach
+Each v1 global route field is copied to both
+`capture.instrumentation.http.routes.incoming` and `.outgoing`:
 
-The dual-read period (Phase 2) is the key risk mitigation:
+- `unmatched`
+- `patterns`
+- `ignored_patterns`
+- `ignore_mode`
+- `wildcard_char`
+- `max_path_segment_cardinality`
 
-- Users on v1 configs continue working without changes during v2 stabilization.
-- The version-detection boundary is exercised in production before v1 parsing is removed.
-- Feedback on v2 ergonomics and migration tooling can be incorporated before the v2-first default.
+Per-service v1 incoming and outgoing routes retain their direction under the
+matching capture rule when global `routes.patterns` is empty. When a v1 file
+combines non-empty global patterns with a non-empty per-service direction,
+migration rejects that selector route path. V1 tries global patterns first and
+then service patterns, while a v2 refinement replaces the inherited array;
+neither direct replacement nor concatenation preserves matcher precedence.
 
-A hard cutover (skip Phase 2) was considered and rejected because it places migration burden on operators with no fallback path if the v2 parser has edge cases. The phased approach lets operators validate at their own pace before the v1 path is gone.
+In native v2, an omitted per-service route field inherits the global value. An
+explicit array replaces the inherited array, and `[]` clears it.
 
-## Operator-facing quality bar
+### Exporters and OpenTelemetry ownership
 
-Before rollout, migration UX should ensure:
+Standalone v2 uses top-level OpenTelemetry declarative providers:
 
-- Every failure has clear remediation text.
-- Every warning identifies exact source key and target key.
-- Resolved/effective config is inspectable.
-- Same input produces same output across environments.
-- Receiver-context validation clearly identifies which standalone-only sections are invalid and why.
+- trace batching, sampling, and OTLP export are under `tracer_provider`;
+- metric intervals and OTLP or Prometheus readers are under `meter_provider`;
+- `resource` owns the supported host resource attributes;
+- top-level `log_level` owns OBI log verbosity.
 
-## Open decisions
+The migrator in the current CLI baseline emits only one batch OTLP/gRPC span
+exporter, one periodic OTLP/gRPC metric exporter, and one Prometheus
+development pull reader. Do not add other declarative SDK settings only
+because the upstream schema accepts them. Some schema-modeled provider fields
+are not yet applied by the OBI runtime.
 
-- Timeline for final v1 removal after v2 GA.
+V1 infers an omitted OTLP protocol from the endpoint. An endpoint using port
+4318, or another endpoint that does not imply gRPC, is effectively
+HTTP/protobuf. The current migration command rejects its `endpoint` path
+because its round-trip target still emits only gRPC. Add `protocol: grpc` only
+when the actual collector endpoint already speaks gRPC. This explicit setting
+also allows a non-standard gRPC port to migrate.
+
+HTTP export does have a manual declarative representation in a release that
+includes the gated
+[standalone HTTP importer](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2682).
+Use `encoding: protobuf` for v1 `http/protobuf` or an inferred HTTP endpoint,
+and `encoding: json` for v1 `http/json`:
+
+```yaml
+tracer_provider:
+  processors:
+    - batch:
+        exporter:
+          otlp_http:
+            endpoint: http://collector:4318
+            encoding: protobuf
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          otlp_http:
+            endpoint: http://collector:4318
+            encoding: protobuf
+```
+
+These are provider fragments, not a complete configuration. Preserve an
+explicit v1 signal endpoint exactly, including any path. A v1 common
+`OTEL_EXPORTER_OTLP_ENDPOINT` appends `/v1/traces` and `/v1/metrics`; when
+rewiring that environment overlay, use those signal-specific URLs in the two
+v2 exporters. Validate the edited complete document with the target release.
+If its release notes do not include HTTP importer support, remain on v1 rather
+than adding a provider shape that its runtime cannot apply.
+
+The target importer in #2682 accepts declarative `headers` and `headers_list`
+on supported OTLP/gRPC and OTLP/HTTP exporters. The migration command cannot
+inspect runtime header variables and does not copy them into YAML. Keep
+`OTEL_EXPORTER_OTLP_HEADERS`,
+`OTEL_EXPORTER_OTLP_TRACES_HEADERS`, and
+`OTEL_EXPORTER_OTLP_METRICS_HEADERS` as secret-backed runtime inputs, or map a
+reviewed secret provider into the corresponding declarative exporter header.
+Signal-specific environment headers override a duplicate common header.
+Validate with the target release and verify authentication at the exporter;
+static validation does not contact it.
+
+In Collector receiver mode, the Collector's service pipelines, processors,
+exporters, exporter headers, resource processing, and telemetry settings own
+these concerns. Do not put exporter headers in `receivers.obi`.
+
+### Strict input and full defaults
+
+Migration rejects unknown v1 fields, multiple YAML documents, invalid v1
+runtime combinations, already-v2 input, and detected source values outside the
+supported migration contract. Validation rejects unknown OBI extension fields
+and invalid supported shapes. In the target adapter delivered by #2682,
+`attribute_limits` is rejected whenever present; `disabled: true`, non-empty
+`distribution`, non-empty `propagator`, `instrumentation/development`, and
+`logger_provider` are also rejected. Empty schema placeholders such as
+`propagator: {}`, `distribution: {}`, and `disabled: false` do not enable
+runtime behavior. Unsupported resource detection, resource schema URLs, and
+resource attributes are rejected rather than ignored. A recognized broken v2
+document is never retried as v1.
+
+The generated document contains defaults represented by the current v2 model.
+There is no promise that a hand-minimized document will have the same behavior,
+even when both documents validate.
+
+### Native v2 defaults differ from migrated v1 defaults
+
+The
+[authored v2 default-values reference](examples/default-values-reference.fragment.yaml)
+is a YAML fragment, not a standalone document and not the result of migrating
+an empty or minimal v1 file. The migrator writes different values where parity
+requires them:
+
+| Behavior | Native v2 reference | Migrated v1 behavior |
+|---|---|---|
+| Workload selection | `default_action: include` with built-in workload exclusions | Writes `exclude` when v1 application capture has no effective include selector |
+| Explicit `rules: []` | Removes the built-in workload exclusions and captures by the default action | Generated rules materialize applicable v1 selectors and exclusions |
+| DNS metrics | Disabled | Enabled when an active v1 metric exporter uses the `*` instrumentation default |
+
+Do not replace generated values with the native reference defaults during an
+upgrade.
+
+## Find renamed and restructured fields
+
+The [Config v1 to v2 compatibility table](config-v2.md#compatibility-and-mapping-from-v1)
+lists canonical locations for fields supported by the migrator. The major
+group moves are:
+
+| v1 group | v2 owner |
+|---|---|
+| Discovery and top-level selectors | `extensions.obi.capture.policy` and `.rules` |
+| Application protocol settings | `extensions.obi.capture.instrumentation` |
+| Network flows and network statistics | `extensions.obi.capture.network` |
+| eBPF engine, batching, propagation, and buffers | `extensions.obi.capture.engine` and protocol sections |
+| Kubernetes and name resolution | `extensions.obi.enrich` |
+| Log trace annotation | `extensions.obi.correlation` |
+| OBI logging, profiling, shutdown, and internal metrics | `extensions.obi.daemon` |
+| Trace and metric exporters | Top-level `tracer_provider` and `meter_provider` |
+
+Supported match criteria from deprecated selectors are removed as v2 keys and
+reshaped:
+
+- `executable_path`, `open_port`, and `target_pids` become an include rule;
+- `discovery.services` and related regex selectors become regex rules;
+- `discovery.instrument` and related glob selectors become glob rules;
+- deprecated exporter `features` values are normalized through
+  `metrics.features` and then split across protocol and network enablement.
+
+Selector naming, per-selector metric features and samplers, and exclusion-rule
+refinements are not part of that reshape; the command rejects them as described
+below.
+
+## Handle fields that need manual intervention
+
+The command is the executable authority for a particular file. It reports
+detected paths whose effective values cannot be represented. The canary remains
+the authority for external overrides and runtime behavior. Settings that
+require removal, a supported replacement, or a separate deployment decision
+include:
+
+| v1 setting | Migration action |
+|---|---|
+| `prometheus_export.path` | The supported declarative pull exporter has no path field. Use its supported endpoint or keep v1 until the required shape exists. |
+| `service_name`, `service_namespace` | Automatic migration rejects these deprecated OBI-wide overrides. Prefer identity on each instrumented target through `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, or Kubernetes metadata. When the same OBI-wide override is intentionally required, map it manually to string `service.name` and `service.namespace` attributes in the standalone top-level `resource`, then validate with a release containing #2682. In receiver mode, use a Collector resource processor instead. |
+| `discovery.excluded_linux_system_paths` | This v1 field skips an early language-detection pass; it does not exclude workloads selected by path or port. The default remains an internal runtime behavior, but v2 has no field for custom values. Migration rejects a non-default or explicitly empty list. Do not translate it into an exclude rule, which would suppress telemetry. |
+| `health_check.*` | No v2 daemon health-check section exists. Move the health check to the host/orchestrator or keep v1. |
+| `jvm_runtime_metrics.sampling_interval` | No v2 field exists. Keep the default or remain on v1 if the override is required. |
+| `attributes.instance_id.dns` | V2 can represent explicit `host.name` and `host.id` overrides, but not this DNS lookup control. |
+| `ebpf.stats_wakeup_data_bytes` | No v2 field exists. Keep v1 when non-default stats wakeup behavior is required. |
+| Selector `name` or `namespace`, any per-selector `metrics.features` or `sampler`, and refinements on exclusion selectors | The current v2 rules cannot preserve these fields. Express supported identity criteria as rule matches; otherwise keep v1. |
+| Selector `exports` containing `logs` | V2 rule export refinements represent traces and metrics only. Remove the log-specific override only after verifying equivalent behavior, or keep v1. |
+| Multiple include selectors that mix explicit and omitted `exports`, or mix explicit and omitted `routes` | V1 layers each refinement field across every matching selector, while v2 applies one winning rule and resets its omitted refinements. Refactor the selectors so each effective selector states its intended refinement, then test both overlapping and selector-only matches. If behavior depends on conditional inheritance from another selector, keep v1. The command rejects the mixed shape rather than broadening telemetry or changing routes. |
+| Non-empty global `routes.patterns` combined with non-empty selector `routes.incoming` or `.outgoing` | V1 uses global-first additive matching while v2 arrays replace inherited patterns. The command rejects the selector route path; keep v1 or redesign and canary-test the policy. |
+| A network feature in `metrics.features` with no active metric exporter and `network.enable` omitted or `false` | V1 leaves network capture disabled, while the current v2 enablement shape would turn it on. Migration rejects the relevant `network.enable` or feature path. Keep v1 or explicitly redesign and canary-test network capture; do not enable it only to make migration pass. |
+| `ebpf.log_enricher.services` | Correlation filtering is not supported in v2. Do not broaden annotation silently; keep v1 or redesign the deployment. |
+| `attributes.sensitive_query_params` | No v2 field exists. Do not remove a redaction setting without an equivalent privacy review. |
+| `discovery.exclude_otel_instrumented_services_span_metrics` | No independent v2 selector exists for this legacy span-metrics exception. |
+| `metrics.features` values other than application RED, basic network flow, and the individual network-stat features | Span metrics, service graphs, application host/runtime metrics, inter-zone/network-packet variants, and eBPF metrics are not represented by current v2 enablement. |
+| Non-default `otel_traces_export.instrumentations`, `otel_metrics_export.instrumentations`, or `prometheus_export.instrumentations` selections involving protocols not modeled by v2 | The v2 protocol enablement section cannot represent every v1 instrumentation. Keep v1 when the command reports a changed instrumentation list. |
+| OTLP HTTP protocol or an implicitly HTTP endpoint | Automatic migration supports the emitted OTLP/gRPC provider subset only. In a release that includes [#2682](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2682), map it manually to the signal's `otlp_http` exporter and preserve the effective endpoint and encoding as described above; otherwise keep v1. |
+| `otel_traces_export.protocol: debug` | The v1 debug exporter has no supported declarative provider mapping. `daemon.logging.debug_trace_output` maps `trace_printer`, which is a different output path. Keep v1 when the debug exporter behavior is required. |
+| OTLP retry/backoff, custom TLS verification, or SDK log-level overrides | These controls are outside the supported provider subset. Keep v1 when the command reports them unless the target release documents an equivalent declarative field. |
+| Custom metric buckets, exponential histogram tuning, native histogram options, or exemplars | These v1 exporter-specific controls are not all represented by the supported v2 provider subset. |
+| `otel_metrics_export.extra_span_resource_attributes` | The current importer does not restore this OTLP span-metric setting. The similarly named Prometheus field is a separate setting. |
+| `otel_metrics_export.allow_service_graph_self_references` | This OTLP span-metric setting has no current v2 provider mapping. |
+| `prometheus_export.disable_build_info`, `ttl`, custom `buckets`, `exemplar_filter`, or `native_histogram.*` | These Prometheus-specific controls are not represented by the supported declarative pull exporter subset. |
+| `internal_metrics.avoided_services.disabled` or `.limit` | Avoided-service controls have no v2 daemon mapping. |
+| Global samplers outside the documented always-on, always-off, trace-ID-ratio, and parent-based variants | The current importer supports only that built-in subset. Ratio arguments must parse as numbers; other names and per-workload samplers require v1. |
+| Non-standard `log_format`, `log_config`, or log-level values outside the documented severity families | V2 normalizes only `text`/`json`, empty/`yaml`/`json`, and DEBUG/INFO/WARN/ERROR severity families. |
+| Unknown or non-string metric feature entries | V1 parsing can collapse these entries silently; migration rejects the containing `features` path. Replace them with a documented feature or remove them after review. |
+
+A field explicitly set to its v1 default may pass because the same effective
+default is present after round trip even when no dedicated v2 key exists. Do
+not interpret that as support for non-default values.
+
+For a deliberate standalone OBI-wide service identity mapping, use:
+
+```yaml
+resource:
+  attributes:
+    - name: service.name
+      value: checkout
+    - name: service.namespace
+      value: shop
+```
+
+This is a standalone top-level fragment. It is not valid inside
+`receivers.obi`.
+
+If migration fails:
+
+1. keep the original v1 file unchanged;
+2. inspect every reported path in the
+   [v1 reference](../CONFIG.md) and the compatibility table;
+3. decide whether to use a documented v2 replacement, remove an obsolete
+   value, or postpone migration;
+4. rerun migration from the original file plus only the reviewed adjustment.
+
+## Environment-variable behavior
+
+Migration and validation perform one substitution pass over the file before
+decoding. Supported forms are:
+
+```text
+${VAR}
+${env:VAR}
+${VAR:-fallback}
+${env:VAR:-fallback}
+$(VAR)
+$(env:VAR)
+$(VAR:-fallback)
+$(env:VAR:-fallback)
+```
+
+An unset reference without a fallback becomes an empty string. The fallback
+form is used when the variable is unset or empty, and it can be combined with
+the `env:` prefix with either delimiter. Prefix a substitution token with an
+extra dollar sign when it must remain literal through this pass, for example
+`$${LATER}` or `$$(LATER)`.
+
+Migration resolves substitutions embedded in the v1 file and then preserves
+escaped literal tokens in its output. It does not apply the broader v1 runtime
+environment overlay. This matters because normal v1 loading applies defaults,
+then file values, then environment variables.
+
+### Rewire v1 environment overrides
+
+Suppose the v1 file omits `ebpf.wakeup_len` and the deployment supplies:
+
+```shell
+OTEL_EBPF_BPF_WAKEUP_LEN=999
+```
+
+Setting that variable while migrating does not apply the v1 overlay. The
+checked-in example proves the behavior:
+
+```shell
+CART_ROOT=/srv OTLP_HOST=collector \
+OTEL_EBPF_BPF_WAKEUP_LEN=999 \
+  obi config migrate \
+  ./devdocs/config/version-2.0/examples/migration-v1.yaml \
+  > ./migration-v2.yaml \
+  2> ./migration-report.txt
+
+grep 'wakeup_len:' ./migration-v2.yaml
+```
+
+The result is the v1 file/default value, not the external override:
+
+```text
+                    wakeup_len: 500
+```
+
+To retain the deployment-controlled value, edit that canonical v2 field to
+reference the variable explicitly:
+
+```yaml
+extensions:
+  obi:
+    capture:
+      engine:
+        batching:
+          wakeup_len: ${OTEL_EBPF_BPF_WAKEUP_LEN:-500}
+```
+
+Then validate with the canary environment:
+
+```shell
+OTEL_EBPF_BPF_WAKEUP_LEN=999 \
+  obi config validate ./migration-v2.yaml
+```
+
+Apply the same process to every inventoried v1 overlay: find its mapping in the
+compatibility table, put a substitution token at that canonical v2 path, and
+validate the resulting document. A variable that is not referenced by the v2
+document has no migration effect unless the target release explicitly
+documents it as a separate runtime input.
+
+Two v1 target selectors exist only as environment fields. If a deployment has:
+
+```shell
+OTEL_EBPF_AUTO_TARGET_EXE='/srv/*'
+OTEL_EBPF_AUTO_TARGET_LANGUAGE='{go,java}'
+```
+
+materialize their effective values as one include rule:
+
+```yaml
+extensions:
+  obi:
+    capture:
+      policy:
+        default_action: exclude
+        match_order: first_match_wins
+      rules:
+        - action: include
+          match:
+            process:
+              exe_path_glob: ["/srv/*"]
+              language_glob: [go, java]
+```
+
+`OTEL_GO_AUTO_TARGET_EXE` is a compatibility alias used only when
+`OTEL_EBPF_AUTO_TARGET_EXE` is unset; the newer variable wins when both are
+set. Preserve the combined executable-and-language match, and place the rule
+at the reviewed precedence among any other generated include rules.
+
+Exporter authentication is the exception to the general overlay rule:
+supported OTLP exporters continue to read
+`OTEL_EXPORTER_OTLP_HEADERS`,
+`OTEL_EXPORTER_OTLP_TRACES_HEADERS`, and
+`OTEL_EXPORTER_OTLP_METRICS_HEADERS` directly at runtime. Keep these values
+secret-backed rather than materializing them during migration. The migration
+command and static validation do not prove that a remote exporter accepts
+them.
+
+The generated standalone file can contain resolved secret values if the source
+referenced them. Treat it as sensitive. In receiver deployments, the
+Collector's configuration provider owns substitution during normal Collector
+startup; CLI receiver validation performs only the OBI command's substitution
+pass and does not prove every Collector provider expression.
+
+For every runtime override, choose one of these approaches:
+
+- materialize its non-secret value in a reviewed v1 copy before migration;
+- map it to the documented v2 field with an explicit substitution token;
+- keep it as a separate runtime input only when the target release documents
+  that variable independently of the v1 overlay.
+
+Run both migration and validation with the same substitution environment that
+the canary will use.
+
+## Validate the standalone document
+
+The exact command shape is:
+
+```text
+obi config validate [--mode=standalone|receiver] <path>
+```
+
+Standalone is the default:
+
+```shell
+obi config validate "${migration_dir}/obi-v2.yaml"
+```
+
+Success writes:
+
+```text
+configuration is valid
+```
+
+Validation performs substitution, strict v2 parsing, conversion through the
+runtime adapter, and host-independent static validation. It does not start
+OBI, connect to an exporter, attach eBPF programs, inspect kernel support, or
+prove that the installed runtime dispatches normal startup to the v2 loader.
+
+The commands use these exit codes:
+
+| Exit | Meaning |
+|---|---|
+| `0` | Migration or validation succeeded, or help was requested. |
+| `1` | Reading, parsing, validation, or supported-contract migration failed. |
+| `2` | The command, flag, mode, or argument count was invalid. |
+
+Help and usage text are written to standard error. Automation should check the
+exit code instead of parsing success text.
+
+The [default configuration example](examples/default-configuration.yaml) is a
+complete standalone document that writes debug traces as text for local
+verification. Validate it directly:
+
+```shell
+obi config validate ./devdocs/config/version-2.0/examples/default-configuration.yaml
+```
+
+Replace the debug output with a production exporter before deployment, and
+replace its placeholder process selector with the application you intend to
+instrument. Use the
+[default-values reference fragment](examples/default-values-reference.fragment.yaml)
+only to inspect authored defaults; it is intentionally not a configuration
+document and must not be passed to `obi config validate`.
+
+## Migrate a Collector receiver
+
+Migrate the legacy receiver component body directly:
+
+```shell
+CART_ROOT=/srv \
+  obi config migrate --mode=receiver \
+  ./devdocs/config/version-2.0/examples/migration-receiver-v1.yaml \
+  > ./migration-receiver-v2.yaml \
+  2> ./migration-receiver-report.txt
+
+diff -u \
+  ./devdocs/config/version-2.0/examples/migration-receiver-v2.yaml \
+  ./migration-receiver-v2.yaml
+
+obi config validate --mode=receiver ./migration-receiver-v2.yaml
+```
+
+Receiver migration models the trace and metric sinks supplied by the
+Collector. It therefore accepts a valid legacy component body such as
+`open_port: "8080"` without inventing a standalone exporter. It emits every
+capture child flattened beside `version`. Explicit v1
+`otel_traces_export`, `otel_metrics_export`, and `prometheus_export` sections
+are rejected because the Collector pipeline must own those exporters:
+
+```text
+receivers:
+  obi:
+    version: "2.0"
+    policy:
+      default_action: exclude
+    rules:
+      - action: include
+        match:
+          process:
+            open_ports: "8080"
+    # ...every other migrated capture child...
+```
+
+Before reporting success, the command round trips the exact flattened capture
+body it will emit. Legacy receiver fields whose v2 destinations are
+standalone-only—such as Kubernetes/attribute enrichment, name resolution, log
+correlation, daemon logging, and internal metrics—are rejected with their v1
+paths. Move those responsibilities to Collector processors or service
+telemetry; do not discard them merely to make migration pass.
+
+There is no `capture:` wrapper in the receiver component. Do not copy
+standalone `enrich`, `correlation`, or `daemon`; receiver validation rejects
+them. Do not copy top-level standalone providers into the receiver component.
+Configure exporters and resource processing in the Collector service
+pipelines.
+
+The
+[legacy receiver input](examples/migration-receiver-v1.yaml) and its
+[generated v2 result](examples/migration-receiver-v2.yaml) form the tested
+receiver pair. The result is a complete receiver component body, not a whole
+Collector document. Embed it under `receivers.obi` after validation.
+
+For a full Collector document, see the
+[OBI Collector example](../../../examples/otel-collector/config.yaml). The
+Collector receiver retains v1 fallback when its release documents that
+compatibility, but a malformed recognized v2 receiver configuration is not
+reinterpreted as v1.
+
+## Canary and verify
+
+Do not deploy the generated standalone file until the target release advertises
+runtime v2 loading.
+
+For a canary:
+
+1. deploy the new OBI release and v2 file to one representative instance;
+2. preserve the same permissions, kernel, exporter destinations, resource
+   metadata, and secret environment;
+3. confirm OBI starts without configuration warnings and exporters connect;
+4. exercise known HTTP, gRPC, database, messaging, and network paths;
+5. compare v1 and v2 over the same traffic window.
+
+At minimum compare:
+
+- discovered and excluded processes;
+- trace and metric export rates and error/drop counters;
+- `service.name`, `service.namespace`, Kubernetes, and host attributes;
+- span names, normalized routes, and route-cardinality bounds;
+- filtered methods, paths, addresses, and other sensitive attributes;
+- enabled protocols, span metrics, service graphs, network flows, and network
+  statistics;
+- OBI self-instrumentation and already-instrumented-service exclusions;
+- shutdown, profiling, internal metrics, and log format where configured.
+
+Validation cannot perform these runtime checks.
+
+## Roll back
+
+Keep the old binary or image, v1 file, external environment, and deployment
+manifest until the canary and production observation window have completed.
+
+If startup or telemetry differs:
+
+1. stop the v2 canary;
+2. restore both the old OBI version and its v1 file;
+3. restore the original environment and manifest;
+4. verify telemetry returns to the recorded v1 baseline;
+5. retain the generated YAML and migration report for diagnosis.
+
+Do not use a v2 file with a release that only supports the v1 runtime loader.
+Do not convert the generated v2 file back into v1 by hand; the saved source is
+the rollback artifact.
+
+## Publication and release linkage
+
+This operator guide is published from the repository and linked from the root
+[README](../../../README.md), the [developer documentation index](../../README.md),
+and the [Config v2 reference](config-v2.md). Config v2 remains behind the
+atomic release gate until its runtime, CLI, receiver, artifacts, and
+documentation ship together.
+
+The release process requires the first enabling release's notes to link this
+guide and identify its supported deployment modes, v1 compatibility, and
+migration limitations. It also requires those notes to be linked from the
+[Config v2 release gate](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2251)
+and the
+[stable v1.0 release epic](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1133).
+Do not infer an enabling version from this guide; use only an explicit release
+note.
+
+## Known limitations and deferred work
+
+- Public standalone loading is part of the atomic
+  [Config v2 release gate](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2251);
+  track [#2535](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2535)
+  and [#2682](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2682)
+  before choosing a release.
+- Protocol- and signal-specific filter narrowing remains unresolved in
+  [#1282](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1282).
+  Migrated filters must remain fanned out and equal.
+- Per-workload pipelines, exporters, metric views, and sampling are outside
+  the current v2 migration contract and remain tracked in
+  [#923](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/923).
+- The supported top-level OpenTelemetry declarative subset is intentionally
+  narrow. Schema acceptance alone does not imply runtime application of every
+  upstream field.
+- The v1 removal date is not decided. Follow the release notes rather than
+  assuming that v1 fallback has ended.
+
+Do not resolve these open contracts by inventing configuration fields. Keep
+the generated parity configuration or postpone migration when a required
+behavior is not supported.
+
+## References
+
+- [Config v1 reference](../CONFIG.md)
+- [Config v2 design and field mapping](config-v2.md)
+- [OBI Config v2 extension schema](obi-extension.schema.json)
+- [Runnable standalone Config v2 example](examples/default-configuration.yaml)
+- [Authored Config v2 default-values reference fragment](examples/default-values-reference.fragment.yaml)
+- [Config v2 release gate](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2251)
+- [Migration documentation issue](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1758)


### PR DESCRIPTION
## Summary

- document the Config v1-to-v2 migration workflow for standalone and Collector
  receiver deployments
- provide deterministic input and expected-output fixtures for both deployment
  modes
- document validation, canary, rollback, and release-gate procedures and link
  them from the relevant operator entry points

Closes #1758.

## Motivation

Operators need a reviewable migration path that distinguishes standalone and
Collector receiver configuration shapes, identifies settings that cannot be
preserved safely, and provides a rollback plan before Config v2 is enabled in
production. The committed fixtures make the documented transformation concrete
and reproducible for both deployment modes.

## Validation

- Markdown lint across the repository: 0 issues
- parsed all four migration fixtures as YAML

## Release considerations

This guide documents the migration path without declaring Config v2 released.

- Schema acceptance does not imply runtime support outside the documented
  declarative-provider subset.
- The v1 removal date is not decided.
- The first enabling release notes must link this guide, state supported
  deployment modes and v1 compatibility, and be linked from #2251 and #1133.
