### PR TITLE
fix(ebpf): never scale array maps in SetupMapSizes

### DIFF
--- a/pkg/internal/ebpf/convenience/convenience.go
+++ b/pkg/internal/ebpf/convenience/convenience.go
@@ -112,10 +112,13 @@ const (
 
 // isResizableMapType returns true for map types where scaling MaxEntries
 // is meaningful. Excludes special map types whose MaxEntries has fixed
-// semantics (e.g. ProgramArray entries are tail-call slots, not data).
+// semantics (e.g. ProgramArray entries are tail-call slots, not data), and
+// array types, whose MaxEntries is a valid index space rather than a capacity
+// (e.g. valid_pids is indexed using a constant shared with userspace).
 func isResizableMapType(t ebpf.MapType) bool {
 	switch t {
-	case ebpf.ProgramArray, ebpf.PerfEventArray, ebpf.CGroupArray,
+	case ebpf.Array, ebpf.PerCPUArray,
+		ebpf.ProgramArray, ebpf.PerfEventArray, ebpf.CGroupArray,
 		ebpf.ArrayOfMaps, ebpf.HashOfMaps,
 		ebpf.DevMap, ebpf.SockMap, ebpf.CPUMap, ebpf.XSKMap, ebpf.SockHash,
 		ebpf.DevMapHash, ebpf.ReusePortSockArray:

--- a/pkg/internal/ebpf/convenience/convenience_test.go
+++ b/pkg/internal/ebpf/convenience/convenience_test.go
@@ -128,6 +128,32 @@ func TestSetupMapSizes_SkipsNonResizableTypes(t *testing.T) {
 	}
 }
 
+func TestSetupMapSizes_SkipsArrayTypes(t *testing.T) {
+	spec := makeSpec(map[string]*ebpf.MapSpec{
+		"valid_pids":   {Type: ebpf.Array, MaxEntries: 3001},
+		"percpu_array": {Type: ebpf.PerCPUArray, MaxEntries: 1024},
+		"normal":       {Type: ebpf.Hash, MaxEntries: 1024},
+	})
+
+	for _, factor := range []int{-1, 2} {
+		spec.Maps["valid_pids"].MaxEntries = 3001
+		spec.Maps["percpu_array"].MaxEntries = 1024
+
+		SetupMapSizes(spec, factor)
+
+		if got := spec.Maps["valid_pids"].MaxEntries; got != 3001 {
+			t.Errorf("Array must not be resized (factor %d): got %d, want 3001", factor, got)
+		}
+		if got := spec.Maps["percpu_array"].MaxEntries; got != 1024 {
+			t.Errorf("PerCPUArray must not be resized (factor %d): got %d, want 1024", factor, got)
+		}
+	}
+
+	if spec.Maps["normal"].MaxEntries == 1024 {
+		t.Error("Hash map should still have been resized")
+	}
+}
+
 func TestSetupMapSizes_SkipsBelowMinResizableMapSize(t *testing.T) {
 	spec := makeSpec(map[string]*ebpf.MapSpec{
 		"tiny": {Type: ebpf.Hash, MaxEntries: 32},
@@ -172,6 +198,7 @@ func TestSetupMapSizes_OverflowClampsToMax(t *testing.T) {
 
 func TestIsResizableMapType(t *testing.T) {
 	nonResizable := []ebpf.MapType{
+		ebpf.Array, ebpf.PerCPUArray,
 		ebpf.ProgramArray, ebpf.PerfEventArray, ebpf.CGroupArray,
 		ebpf.ArrayOfMaps, ebpf.HashOfMaps,
 		ebpf.DevMap, ebpf.SockMap, ebpf.CPUMap, ebpf.XSKMap, ebpf.SockHash,
@@ -183,7 +210,7 @@ func TestIsResizableMapType(t *testing.T) {
 		}
 	}
 
-	resizable := []ebpf.MapType{ebpf.Hash, ebpf.Array, ebpf.LRUHash, ebpf.RingBuf}
+	resizable := []ebpf.MapType{ebpf.Hash, ebpf.LRUHash, ebpf.PerCPUHash, ebpf.RingBuf}
 	for _, mt := range resizable {
 		if !isResizableMapType(mt) {
 			t.Errorf("expected %v to be resizable", mt)

--- a/pkg/internal/ebpf/convenience/convenience_test.go
+++ b/pkg/internal/ebpf/convenience/convenience_test.go
@@ -129,28 +129,33 @@ func TestSetupMapSizes_SkipsNonResizableTypes(t *testing.T) {
 }
 
 func TestSetupMapSizes_SkipsArrayTypes(t *testing.T) {
-	spec := makeSpec(map[string]*ebpf.MapSpec{
-		"valid_pids":   {Type: ebpf.Array, MaxEntries: 3001},
-		"percpu_array": {Type: ebpf.PerCPUArray, MaxEntries: 1024},
-		"normal":       {Type: ebpf.Hash, MaxEntries: 1024},
-	})
+	// Each case builds a fresh spec so the control map's expected size is an
+	// exact number per factor, instead of depending on the factors not
+	// canceling each other out across iterations.
+	for _, tc := range []struct {
+		factor     int
+		wantNormal uint32
+	}{
+		{-1, 512},
+		{2, 4096},
+	} {
+		spec := makeSpec(map[string]*ebpf.MapSpec{
+			"valid_pids":   {Type: ebpf.Array, MaxEntries: 3001},
+			"percpu_array": {Type: ebpf.PerCPUArray, MaxEntries: 1024},
+			"normal":       {Type: ebpf.Hash, MaxEntries: 1024},
+		})
 
-	for _, factor := range []int{-1, 2} {
-		spec.Maps["valid_pids"].MaxEntries = 3001
-		spec.Maps["percpu_array"].MaxEntries = 1024
-
-		SetupMapSizes(spec, factor)
+		SetupMapSizes(spec, tc.factor)
 
 		if got := spec.Maps["valid_pids"].MaxEntries; got != 3001 {
-			t.Errorf("Array must not be resized (factor %d): got %d, want 3001", factor, got)
+			t.Errorf("Array must not be resized (factor %d): got %d, want 3001", tc.factor, got)
 		}
 		if got := spec.Maps["percpu_array"].MaxEntries; got != 1024 {
-			t.Errorf("PerCPUArray must not be resized (factor %d): got %d, want 1024", factor, got)
+			t.Errorf("PerCPUArray must not be resized (factor %d): got %d, want 1024", tc.factor, got)
 		}
-	}
-
-	if spec.Maps["normal"].MaxEntries == 1024 {
-		t.Error("Hash map should still have been resized")
+		if got := spec.Maps["normal"].MaxEntries; got != tc.wantNormal {
+			t.Errorf("Hash must be resized (factor %d): got %d, want %d", tc.factor, got, tc.wantNormal)
+		}
 	}
 }
 
@@ -210,7 +215,7 @@ func TestIsResizableMapType(t *testing.T) {
 		}
 	}
 
-	resizable := []ebpf.MapType{ebpf.Hash, ebpf.LRUHash, ebpf.PerCPUHash, ebpf.RingBuf}
+	resizable := []ebpf.MapType{ebpf.Hash, ebpf.LRUHash, ebpf.LRUCPUHash, ebpf.PerCPUHash, ebpf.RingBuf}
 	for _, mt := range resizable {
 		if !isResizableMapType(mt) {
 			t.Errorf("expected %v to be resizable", mt)


### PR DESCRIPTION
## Summary

`SetupMapSizes` scales array maps, but for arrays `max_entries` is the valid index
space, not a capacity with headroom. `valid_pids` is an array bitmap sized by
`k_max_concurrent_pids` (3001) and indexed by generictracer through the mirrored Go
constant, so with `global_scale_factor: -1` it halves to 1500 and every update at or
above that index fails:

```
Error setting up pid in BPF space, sizes of Go and BPF maps don't match
  error="update: key too big for map: argument list too long" i=2995
```

Worse than the log suggests: `pid_matches()` returns 1 (match) on a failed lookup, so
the upper half of the PID hash space silently bypasses the discovery filter.

Fix is to exclude `Array` and `PerCPUArray` in `isResizableMapType`. Type-based rather
than a name denylist, since the invariant holds for every array. No change at the
default `global_scale_factor: 0`. These two types were 0.6 MiB of 294.6 MiB of map
memlock on a test node, so nothing meaningful is lost. `pid_cache` uses the same
constant but stays scalable — it is an LRU hash, so shrinking it only costs hit rate.

Verified with a new test covering shrink and grow (a sibling `Hash` map still resizes),
and on a cluster: 6 of 7 DaemonSet pods logged the error with `global_scale_factor: -1`
and none after removing it. `TestIsResizableMapType` previously asserted `Array` was
resizable; that assertion is updated.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] N/A — map-sizing bug fix, no feature support status change, so [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and the [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) are unchanged.

---

AI policy: I used Claude Code to help analyse the failure and locate the interacting
constants. I reviewed every line, ran the tests, and reproduced both the failure and
the fix on my own cluster.
