### PR TITLE
Add section of GitHub Communication in AI policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,14 @@ Do not assume boundaries can be changed without explicit instruction.
 
 If the task is unclear or underspecified, ask for clarification before making changes.
 
+## GitHub Communication
+
+Write issue and pull request descriptions, reviews, and comments for human
+readers. Keep them concise, specific, and easy to scan. Lead with the relevant
+point, use short paragraphs or lists when helpful, and include only the context
+needed to understand or act on the message. Do not post generated wall-of-text
+reports, exhaustive restatements of the code, or a play-by-play of the work.
+
 ## Validation
 
 Before proposing changes, ensure the repository generates required artifacts, passes validation, and compiles successfully.

--- a/AI-POLICY.md
+++ b/AI-POLICY.md
@@ -57,6 +57,14 @@ These uses are acceptable provided you:
 6. Report the use of Generative AI tools for non-trivial preparation of
   submissions (that is, at level 2 or higher on the [AI Influence Level]).
 
+### GitHub Communication
+
+Issue and pull request descriptions, reviews, and comments must be written for
+human readers. Keep them concise, specific, and easy to scan. Do not submit raw
+or lightly edited Generative AI output, generated wall-of-text reports,
+exhaustive restatements of the code, or a play-by-play of the work. Include only
+the context needed for another contributor to understand or act on the message.
+
 ## 3. Unacceptable Use
 
 It is not acceptable to use Generative AI tools to:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# Claude Code Instructions
+
+@AGENTS.md
+@AI-POLICY.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,12 @@ All relevant build, lint, and test steps must pass locally before opening a PR.
 
 PRs must be ready for review when submitted, not ready for validation. The contributor is responsible for verifying correctness before asking for a reviewer's time.
 
+GitHub communication must be written for human readers. Keep issue and PR
+descriptions, reviews, and comments concise, specific, and easy to scan. Lead
+with the relevant point, use short paragraphs or lists when helpful, and include
+only the context needed to understand or act on the message. Avoid wall-of-text
+reports, exhaustive restatements of the code, and a play-by-play of the work.
+
 For detailed code and eBPF/C guidelines, see [AGENTS.md](AGENTS.md).
 
 ### Code Ownership


### PR DESCRIPTION
## Summary

Added section in our guidelines to avoid unnecessary text in our issues/PR description and avoid
maintenance burden for OBI reviewers.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
