### PR TITLE
fix(embedding): complete embeddings semconv attributes across all providers

### DIFF
--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -819,13 +819,46 @@ func (e *VendorEmbedding) OperationName() string {
 	return EmbeddingOperationName
 }
 
+// Dimensions returns the output vector dimension count. It prefers an explicit
+// request dimension ("dimensions" or "output_dimension"), falling back to the
+// length derived from the response payload. Returns 0 when not determinable.
+func (e *VendorEmbedding) Dimensions() int {
+	if e.Input.Dimensions > 0 {
+		return e.Input.Dimensions
+	}
+	if e.Input.OutputDimension > 0 {
+		return e.Input.OutputDimension
+	}
+	return e.Output.Dimensions
+}
+
 // EmbeddingRequest captures the common fields from embedding API requests.
 type EmbeddingRequest struct {
 	Model      string          `json:"model"`
 	Input      json.RawMessage `json:"input"`
 	Dimensions int             `json:"dimensions,omitempty"`
+	// Voyage AI and Cohere use "output_dimension" for the requested vector size.
+	OutputDimension int `json:"output_dimension,omitempty"`
 	// Cohere uses "texts" instead of "input"
 	Texts json.RawMessage `json:"texts,omitempty"`
+	// EncodingFormat is the OpenAI/Voyage/Jina style single-value output format.
+	EncodingFormat string `json:"encoding_format,omitempty"`
+	// EmbeddingTypes is the Cohere v2 style list of output formats.
+	EmbeddingTypes []string `json:"embedding_types,omitempty"`
+}
+
+// EncodingFormats returns the requested output encoding formats, normalizing
+// across providers: OpenAI/Voyage/Jina expose a single "encoding_format"
+// string, while Cohere v2 uses an "embedding_types" array. Returns nil when
+// no format was specified.
+func (r *EmbeddingRequest) EncodingFormats() []string {
+	if len(r.EmbeddingTypes) > 0 {
+		return r.EmbeddingTypes
+	}
+	if r.EncodingFormat != "" {
+		return []string{r.EncodingFormat}
+	}
+	return nil
 }
 
 // InputCount returns the number of input texts in the request.
@@ -853,6 +886,9 @@ type EmbeddingResponse struct {
 	Usage EmbeddingUsage `json:"usage"`
 	// Cohere uses meta.billed_units for token counts
 	Meta *CohereResponseMeta `json:"meta,omitempty"`
+	// Dimensions is the length of a single output vector, derived from the
+	// response payload. Populated by the embedding parser; zero when unknown.
+	Dimensions int `json:"-"`
 }
 
 // EmbeddingUsage captures token usage in embedding responses.

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -336,6 +336,12 @@ type OpenAIError struct {
 type ToolCall struct {
 	ID   string `json:"id,omitempty"`
 	Name string `json:"name"`
+	// Arguments holds the tool-call input as a JSON string. OpenAI-family
+	// function.arguments is already a JSON string; Anthropic input / Gemini
+	// args / Ollama arguments are JSON objects stored as their raw encoding.
+	Arguments string `json:"arguments,omitempty"`
+	// Type is the tool type, e.g. "function".
+	Type string `json:"type,omitempty"`
 }
 
 type VendorOpenAI struct {
@@ -383,20 +389,70 @@ func (ai *VendorOpenAI) GetOutput() string {
 	return normalizeOpenAIOutput(ai)
 }
 
+// InputTokenCount returns the input token count and whether it was reported.
+// For embeddings, where the output token count is always zero, it falls back to
+// total_tokens when the provider reports only a total (e.g. native DashScope,
+// whose usage carries total_tokens but no input_tokens/prompt_tokens).
+func (ai *VendorOpenAI) InputTokenCount() (int, bool) {
+	if tokens, reported := ai.Usage.InputTokenCount(); reported {
+		return tokens, true
+	}
+	if ai.OperationName == EmbeddingOperationName {
+		if total, reported := ai.Usage.TotalTokens.Get(); reported {
+			return total, true
+		}
+	}
+	return 0, false
+}
+
 func (ai *VendorOpenAI) GetEmbeddingDimensions() int {
+	// Explicit request dimension: OpenAI/compatible top-level "dimensions"...
 	if ai.Request.Dimensions > 0 {
 		return ai.Request.Dimensions
 	}
-	if len(ai.Data) == 0 {
+	// ...or native DashScope "parameters.dimension".
+	if d := ai.Request.ParameterDimension(); d > 0 {
+		return d
+	}
+	// OpenAI-style response: data[].embedding length.
+	if n := embeddingLenFromData(ai.Data); n > 0 {
+		return n
+	}
+	// Native DashScope response: output.embeddings[].embedding length.
+	return embeddingDimsFromOutput(ai.Output)
+}
+
+// embeddingLenFromData returns the vector length from an OpenAI-style embedding
+// response body: {"data":[{"embedding":[...]}]}. Returns 0 when not present.
+func embeddingLenFromData(raw json.RawMessage) int {
+	if len(raw) == 0 {
 		return 0
 	}
 	var data []struct {
 		Embedding []json.Number `json:"embedding"`
 	}
-	if err := json.Unmarshal(ai.Data, &data); err != nil || len(data) == 0 {
+	if err := json.Unmarshal(raw, &data); err != nil || len(data) == 0 {
 		return 0
 	}
 	return len(data[0].Embedding)
+}
+
+// embeddingDimsFromOutput returns the vector length from a native DashScope
+// embedding response `output` object: {"embeddings":[{"embedding":[...]}]}.
+// Returns 0 when not present.
+func embeddingDimsFromOutput(raw json.RawMessage) int {
+	if len(raw) == 0 {
+		return 0
+	}
+	var out struct {
+		Embeddings []struct {
+			Embedding []json.Number `json:"embedding"`
+		} `json:"embeddings"`
+	}
+	if err := json.Unmarshal(raw, &out); err != nil || len(out.Embeddings) == 0 {
+		return 0
+	}
+	return len(out.Embeddings[0].Embedding)
 }
 
 type OpenAIInput struct {
@@ -418,6 +474,25 @@ type OpenAIInput struct {
 	Seed             *int            `json:"seed,omitempty"`
 	Tools            json.RawMessage `json:"tools,omitempty"`
 	ServiceTier      string          `json:"service_tier,omitempty"`
+	// Parameters carries provider-specific request options. Native Alibaba
+	// DashScope embedding requests nest the vector size under
+	// parameters.dimension instead of a top-level "dimensions" field.
+	Parameters json.RawMessage `json:"parameters,omitempty"`
+}
+
+// ParameterDimension extracts the requested embedding dimension from the
+// native DashScope "parameters.dimension" field. Returns 0 when absent.
+func (air *OpenAIInput) ParameterDimension() int {
+	if len(air.Parameters) == 0 {
+		return 0
+	}
+	var p struct {
+		Dimension int `json:"dimension"`
+	}
+	if err := json.Unmarshal(air.Parameters, &p); err != nil {
+		return 0
+	}
+	return p.Dimension
 }
 
 func (air *OpenAIInput) GetStopSequences() []string {
@@ -2195,7 +2270,7 @@ func (s *Span) GenAIInputTokenCount() (int, bool) {
 	}
 
 	if s.GenAI.OpenAI != nil {
-		return s.GenAI.OpenAI.Usage.InputTokenCount()
+		return s.GenAI.OpenAI.InputTokenCount()
 	}
 
 	if s.GenAI.Anthropic != nil {
@@ -2207,7 +2282,7 @@ func (s *Span) GenAIInputTokenCount() (int, bool) {
 	}
 
 	if s.GenAI.Qwen != nil {
-		return s.GenAI.Qwen.Usage.InputTokenCount()
+		return s.GenAI.Qwen.InputTokenCount()
 	}
 
 	if s.GenAI.Ollama != nil {
@@ -2215,7 +2290,7 @@ func (s *Span) GenAIInputTokenCount() (int, bool) {
 	}
 
 	if s.GenAI.OpenAICompatible != nil {
-		return s.GenAI.OpenAICompatible.Usage.InputTokenCount()
+		return s.GenAI.OpenAICompatible.InputTokenCount()
 	}
 
 	if s.GenAI.Bedrock != nil {

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -337,12 +337,10 @@ type OpenAIError struct {
 type ToolCall struct {
 	ID   string `json:"id,omitempty"`
 	Name string `json:"name"`
-	// Arguments holds the tool-call input as a JSON string. OpenAI-family
-	// function.arguments is already a JSON string; Anthropic input / Gemini
-	// args / Ollama arguments are JSON objects stored as their raw encoding.
+	// Arguments is the tool-call input as raw JSON: a string for OpenAI-family
+	// providers, an object for Anthropic, Gemini and Ollama.
 	Arguments string `json:"arguments,omitempty"`
-	// Type is the tool type, e.g. "function".
-	Type string `json:"type,omitempty"`
+	Type      string `json:"type,omitempty"`
 }
 
 type VendorOpenAI struct {
@@ -390,10 +388,8 @@ func (ai *VendorOpenAI) GetOutput() string {
 	return normalizeOpenAIOutput(ai)
 }
 
-// InputTokenCount returns the input token count and whether it was reported.
-// For embeddings, where the output token count is always zero, it falls back to
-// total_tokens when the provider reports only a total (e.g. native DashScope,
-// whose usage carries total_tokens but no input_tokens/prompt_tokens).
+// InputTokenCount returns the input token count, falling back to total_tokens
+// for embeddings since some providers (e.g. native DashScope) report only a total.
 func (ai *VendorOpenAI) InputTokenCount() (int, bool) {
 	if tokens, reported := ai.Usage.InputTokenCount(); reported {
 		return tokens, true
@@ -407,19 +403,15 @@ func (ai *VendorOpenAI) InputTokenCount() (int, bool) {
 }
 
 func (ai *VendorOpenAI) GetEmbeddingDimensions() int {
-	// Explicit request dimension: OpenAI/compatible top-level "dimensions"...
 	if ai.Request.Dimensions > 0 {
 		return ai.Request.Dimensions
 	}
-	// ...or native DashScope "parameters.dimension".
 	if d := ai.Request.ParameterDimension(); d > 0 {
 		return d
 	}
-	// OpenAI-style response: data[].embedding length.
 	if n := embeddingLenFromData(ai.Data); n > 0 {
 		return n
 	}
-	// Native DashScope response: output.embeddings[].embedding length.
 	return embeddingDimsFromOutput(ai.Output)
 }
 
@@ -439,8 +431,7 @@ func embeddingLenFromData(raw json.RawMessage) int {
 }
 
 // embeddingDimsFromOutput returns the vector length from a native DashScope
-// embedding response `output` object: {"embeddings":[{"embedding":<vector>}]}.
-// Returns 0 when not present.
+// response `output` object: {"embeddings":[{"embedding":<vector>}]}.
 func embeddingDimsFromOutput(raw json.RawMessage) int {
 	if len(raw) == 0 {
 		return 0
@@ -456,17 +447,13 @@ func embeddingDimsFromOutput(raw json.RawMessage) int {
 	return embeddingVectorLen(out.Embeddings[0].Embedding)
 }
 
-// embeddingVectorLen returns the dimension count of a single embedding vector.
-// The vector may be encoded either as a JSON array of numbers (encoding_format
-// "float", the default) or as a base64 string of packed float32 values
-// (encoding_format "base64", which the OpenAI SDKs use by default). Returns 0
-// when the encoding is not recognized.
+// embeddingVectorLen returns the dimension count of a vector encoded either as
+// a JSON array of numbers or as a base64 string of packed float32 values.
 func embeddingVectorLen(embedding json.RawMessage) int {
 	trimmed := bytesTrimSpace(embedding)
 	if len(trimmed) == 0 {
 		return 0
 	}
-	// Array of numbers: count the elements.
 	if trimmed[0] == '[' {
 		var arr []json.Number
 		if err := json.Unmarshal(trimmed, &arr); err != nil {
@@ -474,7 +461,6 @@ func embeddingVectorLen(embedding json.RawMessage) int {
 		}
 		return len(arr)
 	}
-	// Base64 string of packed float32 values.
 	if trimmed[0] == '"' {
 		var s string
 		if err := json.Unmarshal(trimmed, &s); err != nil || s == "" {
@@ -489,7 +475,6 @@ func embeddingVectorLen(embedding json.RawMessage) int {
 	return 0
 }
 
-// bytesTrimSpace trims leading/trailing JSON whitespace from a raw value.
 func bytesTrimSpace(b []byte) []byte {
 	start := 0
 	for start < len(b) {
@@ -531,10 +516,7 @@ type OpenAIInput struct {
 	Seed             *int            `json:"seed,omitempty"`
 	Tools            json.RawMessage `json:"tools,omitempty"`
 	ServiceTier      string          `json:"service_tier,omitempty"`
-	// Parameters carries provider-specific request options. Native Alibaba
-	// DashScope embedding requests nest the vector size under
-	// parameters.dimension instead of a top-level "dimensions" field.
-	Parameters json.RawMessage `json:"parameters,omitempty"`
+	Parameters       json.RawMessage `json:"parameters,omitempty"`
 }
 
 // ParameterDimension extracts the requested embedding dimension from the
@@ -951,9 +933,8 @@ func (e *VendorEmbedding) OperationName() string {
 	return EmbeddingOperationName
 }
 
-// Dimensions returns the output vector dimension count. It prefers an explicit
-// request dimension ("dimensions" or "output_dimension"), falling back to the
-// length derived from the response payload. Returns 0 when not determinable.
+// Dimensions returns the output vector dimension count, preferring an explicit
+// request dimension over the length derived from the response payload.
 func (e *VendorEmbedding) Dimensions() int {
 	if e.Input.Dimensions > 0 {
 		return e.Input.Dimensions
@@ -973,23 +954,18 @@ type EmbeddingRequest struct {
 	OutputDimension int `json:"output_dimension,omitempty"`
 	// Cohere uses "texts" instead of "input"
 	Texts json.RawMessage `json:"texts,omitempty"`
-	// EncodingFormat is the OpenAI/Voyage style single-value output format.
+	// OpenAI and Voyage use a single-value "encoding_format"
 	EncodingFormat string `json:"encoding_format,omitempty"`
-	// EmbeddingTypes is the Cohere v2 style list of output formats.
+	// Cohere v2 uses an "embedding_types" list
 	EmbeddingTypes []string `json:"embedding_types,omitempty"`
-	// EmbeddingType is the Jina style output format: a string or an array of
-	// strings.
+	// Jina uses "embedding_type": a string or an array of strings
 	EmbeddingType json.RawMessage `json:"embedding_type,omitempty"`
-	// OutputDtype is the Voyage style element representation of the output
-	// vectors (float, int8, uint8, binary, ubinary).
+	// Voyage uses "output_dtype" for the output element representation
 	OutputDtype string `json:"output_dtype,omitempty"`
 }
 
-// EncodingFormats returns the requested output encoding formats, normalizing
-// across providers: Cohere v2 uses an "embedding_types" array, Jina an
-// "embedding_type" string or array, Voyage an "output_dtype" string, and
-// OpenAI-compatible APIs a single "encoding_format" string. Returns nil when
-// no format was specified.
+// EncodingFormats returns the requested output encoding formats, normalized
+// across the provider-specific request fields. Returns nil when unspecified.
 func (r *EmbeddingRequest) EncodingFormats() []string {
 	if len(r.EmbeddingTypes) > 0 {
 		return r.EmbeddingTypes
@@ -1009,8 +985,6 @@ func (r *EmbeddingRequest) EncodingFormats() []string {
 	return nil
 }
 
-// embeddingTypeValues parses the Jina "embedding_type" field, which may be a
-// single string or an array of strings.
 func (r *EmbeddingRequest) embeddingTypeValues() []string {
 	if len(r.EmbeddingType) == 0 {
 		return nil
@@ -1027,9 +1001,7 @@ func (r *EmbeddingRequest) embeddingTypeValues() []string {
 }
 
 // RequestedDtype returns the element representation requested for the output
-// vectors, normalizing provider-specific fields: Voyage "output_dtype", Jina
-// "embedding_type", and the OpenAI-style "encoding_format". Returns empty
-// string when unspecified (providers default to float).
+// vectors, or empty when unspecified (providers default to float).
 func (r *EmbeddingRequest) RequestedDtype() string {
 	if r.OutputDtype != "" {
 		return r.OutputDtype
@@ -1065,8 +1037,7 @@ type EmbeddingResponse struct {
 	Usage EmbeddingUsage `json:"usage"`
 	// Cohere uses meta.billed_units for token counts
 	Meta *CohereResponseMeta `json:"meta,omitempty"`
-	// Dimensions is the length of a single output vector, derived from the
-	// response payload. Populated by the embedding parser; zero when unknown.
+	// Dimensions is derived from the response payload; zero when unknown
 	Dimensions int `json:"-"`
 }
 

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -4,6 +4,7 @@
 package request // import "go.opentelemetry.io/obi/pkg/appolly/app/request"
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -423,22 +424,22 @@ func (ai *VendorOpenAI) GetEmbeddingDimensions() int {
 }
 
 // embeddingLenFromData returns the vector length from an OpenAI-style embedding
-// response body: {"data":[{"embedding":[...]}]}. Returns 0 when not present.
+// response body: {"data":[{"embedding":<vector>}]}. Returns 0 when not present.
 func embeddingLenFromData(raw json.RawMessage) int {
 	if len(raw) == 0 {
 		return 0
 	}
 	var data []struct {
-		Embedding []json.Number `json:"embedding"`
+		Embedding json.RawMessage `json:"embedding"`
 	}
 	if err := json.Unmarshal(raw, &data); err != nil || len(data) == 0 {
 		return 0
 	}
-	return len(data[0].Embedding)
+	return embeddingVectorLen(data[0].Embedding)
 }
 
 // embeddingDimsFromOutput returns the vector length from a native DashScope
-// embedding response `output` object: {"embeddings":[{"embedding":[...]}]}.
+// embedding response `output` object: {"embeddings":[{"embedding":<vector>}]}.
 // Returns 0 when not present.
 func embeddingDimsFromOutput(raw json.RawMessage) int {
 	if len(raw) == 0 {
@@ -446,13 +447,69 @@ func embeddingDimsFromOutput(raw json.RawMessage) int {
 	}
 	var out struct {
 		Embeddings []struct {
-			Embedding []json.Number `json:"embedding"`
+			Embedding json.RawMessage `json:"embedding"`
 		} `json:"embeddings"`
 	}
 	if err := json.Unmarshal(raw, &out); err != nil || len(out.Embeddings) == 0 {
 		return 0
 	}
-	return len(out.Embeddings[0].Embedding)
+	return embeddingVectorLen(out.Embeddings[0].Embedding)
+}
+
+// embeddingVectorLen returns the dimension count of a single embedding vector.
+// The vector may be encoded either as a JSON array of numbers (encoding_format
+// "float", the default) or as a base64 string of packed float32 values
+// (encoding_format "base64", which the OpenAI SDKs use by default). Returns 0
+// when the encoding is not recognized.
+func embeddingVectorLen(embedding json.RawMessage) int {
+	trimmed := bytesTrimSpace(embedding)
+	if len(trimmed) == 0 {
+		return 0
+	}
+	// Array of numbers: count the elements.
+	if trimmed[0] == '[' {
+		var arr []json.Number
+		if err := json.Unmarshal(trimmed, &arr); err != nil {
+			return 0
+		}
+		return len(arr)
+	}
+	// Base64 string of packed float32 values.
+	if trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil || s == "" {
+			return 0
+		}
+		decoded, err := base64.StdEncoding.DecodeString(s)
+		if err != nil || len(decoded)%4 != 0 {
+			return 0
+		}
+		return len(decoded) / 4 // float32 = 4 bytes
+	}
+	return 0
+}
+
+// bytesTrimSpace trims leading/trailing JSON whitespace from a raw value.
+func bytesTrimSpace(b []byte) []byte {
+	start := 0
+	for start < len(b) {
+		switch b[start] {
+		case ' ', '\t', '\n', '\r':
+			start++
+			continue
+		}
+		break
+	}
+	end := len(b)
+	for end > start {
+		switch b[end-1] {
+		case ' ', '\t', '\n', '\r':
+			end--
+			continue
+		}
+		break
+	}
+	return b[start:end]
 }
 
 type OpenAIInput struct {

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -973,24 +973,71 @@ type EmbeddingRequest struct {
 	OutputDimension int `json:"output_dimension,omitempty"`
 	// Cohere uses "texts" instead of "input"
 	Texts json.RawMessage `json:"texts,omitempty"`
-	// EncodingFormat is the OpenAI/Voyage/Jina style single-value output format.
+	// EncodingFormat is the OpenAI/Voyage style single-value output format.
 	EncodingFormat string `json:"encoding_format,omitempty"`
 	// EmbeddingTypes is the Cohere v2 style list of output formats.
 	EmbeddingTypes []string `json:"embedding_types,omitempty"`
+	// EmbeddingType is the Jina style output format: a string or an array of
+	// strings.
+	EmbeddingType json.RawMessage `json:"embedding_type,omitempty"`
+	// OutputDtype is the Voyage style element representation of the output
+	// vectors (float, int8, uint8, binary, ubinary).
+	OutputDtype string `json:"output_dtype,omitempty"`
 }
 
 // EncodingFormats returns the requested output encoding formats, normalizing
-// across providers: OpenAI/Voyage/Jina expose a single "encoding_format"
-// string, while Cohere v2 uses an "embedding_types" array. Returns nil when
+// across providers: Cohere v2 uses an "embedding_types" array, Jina an
+// "embedding_type" string or array, Voyage an "output_dtype" string, and
+// OpenAI-compatible APIs a single "encoding_format" string. Returns nil when
 // no format was specified.
 func (r *EmbeddingRequest) EncodingFormats() []string {
 	if len(r.EmbeddingTypes) > 0 {
 		return r.EmbeddingTypes
 	}
+	if types := r.embeddingTypeValues(); len(types) > 0 {
+		return types
+	}
+	if r.OutputDtype != "" {
+		if r.EncodingFormat != "" && r.EncodingFormat != r.OutputDtype {
+			return []string{r.OutputDtype, r.EncodingFormat}
+		}
+		return []string{r.OutputDtype}
+	}
 	if r.EncodingFormat != "" {
 		return []string{r.EncodingFormat}
 	}
 	return nil
+}
+
+// embeddingTypeValues parses the Jina "embedding_type" field, which may be a
+// single string or an array of strings.
+func (r *EmbeddingRequest) embeddingTypeValues() []string {
+	if len(r.EmbeddingType) == 0 {
+		return nil
+	}
+	var arr []string
+	if json.Unmarshal(r.EmbeddingType, &arr) == nil {
+		return arr
+	}
+	var s string
+	if json.Unmarshal(r.EmbeddingType, &s) == nil && s != "" {
+		return []string{s}
+	}
+	return nil
+}
+
+// RequestedDtype returns the element representation requested for the output
+// vectors, normalizing provider-specific fields: Voyage "output_dtype", Jina
+// "embedding_type", and the OpenAI-style "encoding_format". Returns empty
+// string when unspecified (providers default to float).
+func (r *EmbeddingRequest) RequestedDtype() string {
+	if r.OutputDtype != "" {
+		return r.OutputDtype
+	}
+	if types := r.embeddingTypeValues(); len(types) > 0 {
+		return types[0]
+	}
+	return r.EncodingFormat
 }
 
 // InputCount returns the number of input texts in the request.

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -104,15 +104,10 @@ func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 	return *baseSpan, true
 }
 
-// parseEmbeddingDimensions inspects a raw embedding response body and returns
-// the model dimension count of a single output vector. It supports the
-// OpenAI-style data[].embedding layout (Voyage, Jina) and the Cohere v2
-// embeddings.{float,int8,...}[][] layout. Vectors are decoded according to the
-// representation requested in req: binary/ubinary entries pack eight
-// dimensions per byte, and base64 strings carry packed element bytes. Bodies
-// are decoded best-effort so a batch truncated by the capture limit still
-// yields the dimension of its first complete vector. Returns 0 when not
-// determinable.
+// parseEmbeddingDimensions returns the dimension count of the first output
+// vector in a raw embedding response body, decoded according to the
+// representation requested in req. Bodies are parsed best-effort so a batch
+// truncated by the capture limit still yields its first complete vector.
 func parseEmbeddingDimensions(req *request.EmbeddingRequest, body []byte) int {
 	if len(body) == 0 {
 		return 0
@@ -146,15 +141,12 @@ func parseEmbeddingDimensions(req *request.EmbeddingRequest, body []byte) int {
 // entry of a binary/ubinary embedding vector.
 const binaryPackedDims = 8
 
-// float32Bytes is the byte width of one float32 embedding element, the
-// representation providers default to for base64-encoded vectors.
+// float32Bytes is the byte width of one float32 embedding element.
 const float32Bytes = 4
 
-// cohereEmbeddingDimensions derives the model dimension count from Cohere v2
-// embeddings, keyed by embedding type. Non-packed types are preferred because
-// their entry count equals the dimension count; binary/ubinary vectors pack
-// eight dimensions into each byte entry, and base64 vectors are strings of
-// packed float32 bytes.
+// cohereEmbeddingDimensions derives the dimension count from Cohere v2
+// embeddings keyed by type, preferring non-packed types whose entry count
+// equals the dimension count.
 func cohereEmbeddingDimensions(embeddings map[string]json.RawMessage) int {
 	for _, key := range []string{"float", "int8", "uint8"} {
 		if n := cohereVectorDims(embeddings, key); n > 0 {
@@ -172,8 +164,7 @@ func cohereEmbeddingDimensions(embeddings map[string]json.RawMessage) int {
 }
 
 // cohereVectorDims returns the dimension count derived from the first vector
-// under the given embedding type key, or 0 when the key is absent or its
-// first vector is incomplete.
+// under the given embedding type key.
 func cohereVectorDims(embeddings map[string]json.RawMessage, key string) int {
 	raw, ok := embeddings[key]
 	if !ok {
@@ -188,11 +179,9 @@ func cohereVectorDims(embeddings map[string]json.RawMessage, key string) int {
 	return embeddingVectorDims(vectors[0], key)
 }
 
-// embeddingVectorDims returns the model dimension count of a single embedding
-// vector, honoring the requested element representation: numeric arrays count
-// entries (expanded for bit-packed binary/ubinary), and base64 strings are
-// decoded to bytes sized by the underlying dtype. A partially captured vector
-// fails strict decoding and yields 0.
+// embeddingVectorDims returns the dimension count of a single vector, honoring
+// the requested element representation. A partially captured vector fails
+// strict decoding and yields 0.
 func embeddingVectorDims(vec json.RawMessage, dtype string) int {
 	trimmed := bytes.TrimSpace(vec)
 	if len(trimmed) == 0 {
@@ -229,9 +218,7 @@ func isPackedDtype(dtype string) bool {
 }
 
 // dimsFromPackedBytes converts a decoded base64 byte count into a dimension
-// count based on the element representation: int8/uint8 use one byte per
-// dimension, binary/ubinary pack eight dimensions per byte, and everything
-// else defaults to float32 elements.
+// count based on the element representation.
 func dimsFromPackedBytes(n int, dtype string) int {
 	switch {
 	case dtype == "int8" || dtype == "uint8":

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -103,7 +103,7 @@ func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 }
 
 // parseEmbeddingDimensions inspects a raw embedding response body and returns
-// the length of a single output vector. It supports the OpenAI-style
+// the model dimension count of a single output vector. It supports the OpenAI-style
 // data[].embedding layout (Voyage, Jina) and the Cohere v2
 // embeddings.{float,int8,...}[][] layout. Returns 0 when not determinable.
 func parseEmbeddingDimensions(body []byte) int {
@@ -123,19 +123,56 @@ func parseEmbeddingDimensions(body []byte) int {
 		}
 	}
 
-	// Cohere v2 layout: {"embeddings":{"float":[[...]]}}
+	// Cohere v2 layout: {"embeddings":{"float":[[...]],"binary":[[...]]}}
 	var cohereStyle struct {
-		Embeddings map[string][][]json.Number `json:"embeddings"`
+		Embeddings map[string]json.RawMessage `json:"embeddings"`
 	}
 	if unmarshalJSON(body, &cohereStyle) {
-		for _, vectors := range cohereStyle.Embeddings {
-			if len(vectors) > 0 {
-				if n := len(vectors[0]); n > 0 {
-					return n
-				}
-			}
+		if n := cohereEmbeddingDimensions(cohereStyle.Embeddings); n > 0 {
+			return n
 		}
 	}
 
 	return 0
+}
+
+// cohereBinaryPackedDims is the number of model dimensions packed into each
+// byte entry of a Cohere v2 binary/ubinary embedding vector.
+const cohereBinaryPackedDims = 8
+
+// cohereEmbeddingDimensions derives the model dimension count from Cohere v2
+// embeddings, keyed by embedding type. Non-packed types are preferred because
+// their entry count equals the dimension count; binary/ubinary vectors pack
+// eight dimensions into each byte entry, so their length is expanded.
+func cohereEmbeddingDimensions(embeddings map[string]json.RawMessage) int {
+	for _, key := range []string{"float", "int8", "uint8"} {
+		if n := cohereVectorLength(embeddings, key); n > 0 {
+			return n
+		}
+	}
+
+	for _, key := range []string{"binary", "ubinary"} {
+		if n := cohereVectorLength(embeddings, key); n > 0 {
+			return n * cohereBinaryPackedDims
+		}
+	}
+
+	return 0
+}
+
+// cohereVectorLength returns the entry count of the first vector under the
+// given embedding type key, or 0 when the key is absent or its value is not
+// a numeric matrix.
+func cohereVectorLength(embeddings map[string]json.RawMessage, key string) int {
+	raw, ok := embeddings[key]
+	if !ok {
+		return 0
+	}
+
+	var vectors [][]json.Number
+	if !unmarshalJSON(raw, &vectors) || len(vectors) == 0 {
+		return 0
+	}
+
+	return len(vectors[0])
 }

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -4,6 +4,8 @@
 package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -86,7 +88,7 @@ func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 		parsedResponse.Meta.BilledUnits.InputTokens.Merge(billedUnits.InputTokens)
 	}
 	if parsedResponse.Dimensions == 0 {
-		parsedResponse.Dimensions = parseEmbeddingDimensions(respB)
+		parsedResponse.Dimensions = parseEmbeddingDimensions(&parsedRequest, respB)
 	}
 
 	baseSpan.SubType = request.HTTPSubtypeEmbedding
@@ -103,22 +105,30 @@ func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 }
 
 // parseEmbeddingDimensions inspects a raw embedding response body and returns
-// the model dimension count of a single output vector. It supports the OpenAI-style
-// data[].embedding layout (Voyage, Jina) and the Cohere v2
-// embeddings.{float,int8,...}[][] layout. Returns 0 when not determinable.
-func parseEmbeddingDimensions(body []byte) int {
+// the model dimension count of a single output vector. It supports the
+// OpenAI-style data[].embedding layout (Voyage, Jina) and the Cohere v2
+// embeddings.{float,int8,...}[][] layout. Vectors are decoded according to the
+// representation requested in req: binary/ubinary entries pack eight
+// dimensions per byte, and base64 strings carry packed element bytes. Bodies
+// are decoded best-effort so a batch truncated by the capture limit still
+// yields the dimension of its first complete vector. Returns 0 when not
+// determinable.
+func parseEmbeddingDimensions(req *request.EmbeddingRequest, body []byte) int {
 	if len(body) == 0 {
 		return 0
 	}
 
-	// OpenAI-style layout: {"data":[{"embedding":[...]}]}
+	dtype := req.RequestedDtype()
+
+	// OpenAI-style layout: {"data":[{"embedding":<vector>}]}
 	var openAIStyle struct {
 		Data []struct {
-			Embedding []json.Number `json:"embedding"`
+			Embedding json.RawMessage `json:"embedding"`
 		} `json:"data"`
 	}
-	if unmarshalJSON(body, &openAIStyle) && len(openAIStyle.Data) > 0 {
-		if n := len(openAIStyle.Data[0].Embedding); n > 0 {
+	unmarshalJSONBestEffort(body, &openAIStyle)
+	if len(openAIStyle.Data) > 0 {
+		if n := embeddingVectorDims(openAIStyle.Data[0].Embedding, dtype); n > 0 {
 			return n
 		}
 	}
@@ -127,52 +137,111 @@ func parseEmbeddingDimensions(body []byte) int {
 	var cohereStyle struct {
 		Embeddings map[string]json.RawMessage `json:"embeddings"`
 	}
-	if unmarshalJSON(body, &cohereStyle) {
-		if n := cohereEmbeddingDimensions(cohereStyle.Embeddings); n > 0 {
-			return n
-		}
-	}
+	unmarshalJSONBestEffort(body, &cohereStyle)
 
-	return 0
+	return cohereEmbeddingDimensions(cohereStyle.Embeddings)
 }
 
-// cohereBinaryPackedDims is the number of model dimensions packed into each
-// byte entry of a Cohere v2 binary/ubinary embedding vector.
-const cohereBinaryPackedDims = 8
+// binaryPackedDims is the number of model dimensions packed into each byte
+// entry of a binary/ubinary embedding vector.
+const binaryPackedDims = 8
+
+// float32Bytes is the byte width of one float32 embedding element, the
+// representation providers default to for base64-encoded vectors.
+const float32Bytes = 4
 
 // cohereEmbeddingDimensions derives the model dimension count from Cohere v2
 // embeddings, keyed by embedding type. Non-packed types are preferred because
 // their entry count equals the dimension count; binary/ubinary vectors pack
-// eight dimensions into each byte entry, so their length is expanded.
+// eight dimensions into each byte entry, and base64 vectors are strings of
+// packed float32 bytes.
 func cohereEmbeddingDimensions(embeddings map[string]json.RawMessage) int {
 	for _, key := range []string{"float", "int8", "uint8"} {
-		if n := cohereVectorLength(embeddings, key); n > 0 {
+		if n := cohereVectorDims(embeddings, key); n > 0 {
 			return n
 		}
 	}
 
 	for _, key := range []string{"binary", "ubinary"} {
-		if n := cohereVectorLength(embeddings, key); n > 0 {
-			return n * cohereBinaryPackedDims
+		if n := cohereVectorDims(embeddings, key); n > 0 {
+			return n
 		}
 	}
 
-	return 0
+	return cohereVectorDims(embeddings, "base64")
 }
 
-// cohereVectorLength returns the entry count of the first vector under the
-// given embedding type key, or 0 when the key is absent or its value is not
-// a numeric matrix.
-func cohereVectorLength(embeddings map[string]json.RawMessage, key string) int {
+// cohereVectorDims returns the dimension count derived from the first vector
+// under the given embedding type key, or 0 when the key is absent or its
+// first vector is incomplete.
+func cohereVectorDims(embeddings map[string]json.RawMessage, key string) int {
 	raw, ok := embeddings[key]
 	if !ok {
 		return 0
 	}
 
-	var vectors [][]json.Number
+	var vectors []json.RawMessage
 	if !unmarshalJSON(raw, &vectors) || len(vectors) == 0 {
 		return 0
 	}
 
-	return len(vectors[0])
+	return embeddingVectorDims(vectors[0], key)
+}
+
+// embeddingVectorDims returns the model dimension count of a single embedding
+// vector, honoring the requested element representation: numeric arrays count
+// entries (expanded for bit-packed binary/ubinary), and base64 strings are
+// decoded to bytes sized by the underlying dtype. A partially captured vector
+// fails strict decoding and yields 0.
+func embeddingVectorDims(vec json.RawMessage, dtype string) int {
+	trimmed := bytes.TrimSpace(vec)
+	if len(trimmed) == 0 {
+		return 0
+	}
+
+	switch trimmed[0] {
+	case '[':
+		var arr []json.Number
+		if json.Unmarshal(trimmed, &arr) != nil || len(arr) == 0 {
+			return 0
+		}
+		if isPackedDtype(dtype) {
+			return len(arr) * binaryPackedDims
+		}
+		return len(arr)
+	case '"':
+		var s string
+		if json.Unmarshal(trimmed, &s) != nil || s == "" {
+			return 0
+		}
+		decoded, err := base64.StdEncoding.DecodeString(s)
+		if err != nil || len(decoded) == 0 {
+			return 0
+		}
+		return dimsFromPackedBytes(len(decoded), dtype)
+	}
+
+	return 0
+}
+
+func isPackedDtype(dtype string) bool {
+	return dtype == "binary" || dtype == "ubinary"
+}
+
+// dimsFromPackedBytes converts a decoded base64 byte count into a dimension
+// count based on the element representation: int8/uint8 use one byte per
+// dimension, binary/ubinary pack eight dimensions per byte, and everything
+// else defaults to float32 elements.
+func dimsFromPackedBytes(n int, dtype string) int {
+	switch {
+	case dtype == "int8" || dtype == "uint8":
+		return n
+	case isPackedDtype(dtype):
+		return n * binaryPackedDims
+	default:
+		if n%float32Bytes != 0 {
+			return 0
+		}
+		return n / float32Bytes
+	}
 }

--- a/pkg/ebpf/common/http/embedding.go
+++ b/pkg/ebpf/common/http/embedding.go
@@ -4,6 +4,7 @@
 package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common/http"
 
 import (
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -84,6 +85,9 @@ func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 		}
 		parsedResponse.Meta.BilledUnits.InputTokens.Merge(billedUnits.InputTokens)
 	}
+	if parsedResponse.Dimensions == 0 {
+		parsedResponse.Dimensions = parseEmbeddingDimensions(respB)
+	}
 
 	baseSpan.SubType = request.HTTPSubtypeEmbedding
 	baseSpan.GenAI = &request.GenAI{
@@ -96,4 +100,42 @@ func EmbeddingSpan(baseSpan *request.Span, req *http.Request, resp *http.Respons
 	}
 
 	return *baseSpan, true
+}
+
+// parseEmbeddingDimensions inspects a raw embedding response body and returns
+// the length of a single output vector. It supports the OpenAI-style
+// data[].embedding layout (Voyage, Jina) and the Cohere v2
+// embeddings.{float,int8,...}[][] layout. Returns 0 when not determinable.
+func parseEmbeddingDimensions(body []byte) int {
+	if len(body) == 0 {
+		return 0
+	}
+
+	// OpenAI-style layout: {"data":[{"embedding":[...]}]}
+	var openAIStyle struct {
+		Data []struct {
+			Embedding []json.Number `json:"embedding"`
+		} `json:"data"`
+	}
+	if unmarshalJSON(body, &openAIStyle) && len(openAIStyle.Data) > 0 {
+		if n := len(openAIStyle.Data[0].Embedding); n > 0 {
+			return n
+		}
+	}
+
+	// Cohere v2 layout: {"embeddings":{"float":[[...]]}}
+	var cohereStyle struct {
+		Embeddings map[string][][]json.Number `json:"embeddings"`
+	}
+	if unmarshalJSON(body, &cohereStyle) {
+		for _, vectors := range cohereStyle.Embeddings {
+			if len(vectors) > 0 {
+				if n := len(vectors[0]); n > 0 {
+					return n
+				}
+			}
+		}
+	}
+
+	return 0
 }

--- a/pkg/ebpf/common/http/embedding_test.go
+++ b/pkg/ebpf/common/http/embedding_test.go
@@ -64,6 +64,8 @@ func TestEmbeddingSpan_VoyageAI(t *testing.T) {
 	assert.Equal(t, "embeddings", ai.OperationName())
 	assert.Equal(t, 8, reportedValue(ai.InputTokenCount()))
 	assert.Equal(t, 2, ai.Input.InputCount())
+	// No request dimension: derived from the response vector length.
+	assert.Equal(t, 2, ai.Dimensions())
 }
 
 func TestEmbeddingSpan_Cohere(t *testing.T) {
@@ -108,7 +110,48 @@ func TestEmbeddingSpan_JinaAI(t *testing.T) {
 	assert.Equal(t, "embeddings", ai.OperationName())
 	assert.Equal(t, 6, reportedValue(ai.InputTokenCount()))
 	assert.Equal(t, 512, ai.Input.Dimensions)
+	// Explicit request dimension takes precedence over the response vector length.
+	assert.Equal(t, 512, ai.Dimensions())
 	assert.Equal(t, 1, ai.Input.InputCount())
+}
+
+func TestEmbeddingSpan_EncodingFormats(t *testing.T) {
+	t.Run("openai_style_single", func(t *testing.T) {
+		req := makeRequest(t, http.MethodPost, "https://api.voyageai.com/v1/embeddings",
+			`{"model":"voyage-3","input":["hi"],"encoding_format":"base64"}`)
+		resp := makePlainResponse(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}},
+			voyageResponseBody)
+
+		span, ok := EmbeddingSpan(&request.Span{}, req, resp)
+		require.True(t, ok)
+		assert.Equal(t, []string{"base64"}, span.GenAI.Embedding.Input.EncodingFormats())
+	})
+
+	t.Run("cohere_style_list", func(t *testing.T) {
+		req := makeRequest(t, http.MethodPost, "https://api.cohere.com/v2/embed",
+			`{"model":"embed-english-v3.0","texts":["hi"],"embedding_types":["float","int8"]}`)
+		resp := makePlainResponse(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}},
+			cohereResponseBody)
+
+		span, ok := EmbeddingSpan(&request.Span{}, req, resp)
+		require.True(t, ok)
+		ai := span.GenAI.Embedding
+		assert.Equal(t, []string{"float", "int8"}, ai.Input.EncodingFormats())
+		// Cohere embeddings.float[][] vectors yield the dimension count.
+		assert.Equal(t, 2, ai.Dimensions())
+	})
+
+	t.Run("output_dimension_request", func(t *testing.T) {
+		req := makeRequest(t, http.MethodPost, "https://api.voyageai.com/v1/embeddings",
+			`{"model":"voyage-3","input":["hi"],"output_dimension":1024}`)
+		resp := makePlainResponse(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}},
+			voyageResponseBody)
+
+		span, ok := EmbeddingSpan(&request.Span{}, req, resp)
+		require.True(t, ok)
+		assert.Equal(t, 1024, span.GenAI.Embedding.Dimensions())
+		assert.Nil(t, span.GenAI.Embedding.Input.EncodingFormats())
+	})
 }
 
 func TestEmbeddingSpan_ExplicitZeroUsage(t *testing.T) {

--- a/pkg/ebpf/common/http/embedding_test.go
+++ b/pkg/ebpf/common/http/embedding_test.go
@@ -154,6 +154,37 @@ func TestEmbeddingSpan_EncodingFormats(t *testing.T) {
 	})
 }
 
+func TestEmbeddingSpan_CohereBinaryDimensions(t *testing.T) {
+	post := func(t *testing.T, respBody string) request.Span {
+		t.Helper()
+		req := makeRequest(t, http.MethodPost, "https://api.cohere.com/v2/embed",
+			`{"model":"embed-english-v3.0","texts":["hi"],"embedding_types":["binary"]}`)
+		resp := makePlainResponse(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}},
+			respBody)
+
+		span, ok := EmbeddingSpan(&request.Span{}, req, resp)
+		require.True(t, ok)
+		return span
+	}
+
+	t.Run("binary_expands_packed_entries", func(t *testing.T) {
+		span := post(t, `{"embeddings":{"binary":[[1,2,3,4]]}}`)
+		// Each binary entry packs eight model dimensions: 4 entries -> 32 dims.
+		assert.Equal(t, 32, span.GenAI.Embedding.Dimensions())
+	})
+
+	t.Run("ubinary_expands_packed_entries", func(t *testing.T) {
+		span := post(t, `{"embeddings":{"ubinary":[[255,0]]}}`)
+		assert.Equal(t, 16, span.GenAI.Embedding.Dimensions())
+	})
+
+	t.Run("float_preferred_over_binary", func(t *testing.T) {
+		span := post(t, `{"embeddings":{"binary":[[1,2]],"float":[[0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.6]]}}`)
+		// Non-packed vectors are preferred regardless of map iteration order.
+		assert.Equal(t, 16, span.GenAI.Embedding.Dimensions())
+	})
+}
+
 func TestEmbeddingSpan_ExplicitZeroUsage(t *testing.T) {
 	req := makeRequest(t, http.MethodPost, "https://api.voyageai.com/v1/embeddings", voyageRequestBody)
 	resp := makePlainResponse(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}},

--- a/pkg/ebpf/common/http/embedding_test.go
+++ b/pkg/ebpf/common/http/embedding_test.go
@@ -295,7 +295,7 @@ func TestEmbeddingRequest_NativeFormatFields(t *testing.T) {
 	t.Run("cohere_embedding_types_take_precedence", func(t *testing.T) {
 		r := &request.EmbeddingRequest{EmbeddingTypes: []string{"float", "binary"}}
 		assert.Equal(t, []string{"float", "binary"}, r.EncodingFormats())
-		assert.Equal(t, "", r.RequestedDtype())
+		assert.Empty(t, r.RequestedDtype())
 	})
 }
 

--- a/pkg/ebpf/common/http/embedding_test.go
+++ b/pkg/ebpf/common/http/embedding_test.go
@@ -4,6 +4,7 @@
 package ebpfcommon
 
 import (
+	"encoding/base64"
 	"net/http"
 	"testing"
 
@@ -182,6 +183,119 @@ func TestEmbeddingSpan_CohereBinaryDimensions(t *testing.T) {
 		span := post(t, `{"embeddings":{"binary":[[1,2]],"float":[[0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.6]]}}`)
 		// Non-packed vectors are preferred regardless of map iteration order.
 		assert.Equal(t, 16, span.GenAI.Embedding.Dimensions())
+	})
+}
+
+func TestEmbeddingSpan_RepresentationAwareDimensions(t *testing.T) {
+	embed := func(t *testing.T, url, reqBody, respBody string) request.Span {
+		t.Helper()
+		req := makeRequest(t, http.MethodPost, url, reqBody)
+		resp := makePlainResponse(http.StatusOK, http.Header{"Content-Type": []string{"application/json"}},
+			respBody)
+
+		span, ok := EmbeddingSpan(&request.Span{}, req, resp)
+		require.True(t, ok)
+		return span
+	}
+
+	b64Floats := func(dims int) string {
+		return base64.StdEncoding.EncodeToString(make([]byte, dims*4))
+	}
+
+	t.Run("voyage_binary_dtype_expands_packed_vector", func(t *testing.T) {
+		span := embed(t, "https://api.voyageai.com/v1/embeddings",
+			`{"model":"voyage-3","input":["hi"],"output_dtype":"binary"}`,
+			`{"data":[{"embedding":[1,2,3,4]}],"model":"voyage-3"}`)
+		// 4 bit-packed byte entries carry 32 model dimensions.
+		assert.Equal(t, 32, span.GenAI.Embedding.Dimensions())
+	})
+
+	t.Run("voyage_base64_float_vector", func(t *testing.T) {
+		span := embed(t, "https://api.voyageai.com/v1/embeddings",
+			`{"model":"voyage-3","input":["hi"],"encoding_format":"base64"}`,
+			`{"data":[{"embedding":"`+b64Floats(1024)+`"}],"model":"voyage-3"}`)
+		assert.Equal(t, 1024, span.GenAI.Embedding.Dimensions())
+	})
+
+	t.Run("voyage_base64_int8_vector", func(t *testing.T) {
+		vec := base64.StdEncoding.EncodeToString(make([]byte, 256))
+		span := embed(t, "https://api.voyageai.com/v1/embeddings",
+			`{"model":"voyage-3","input":["hi"],"output_dtype":"int8","encoding_format":"base64"}`,
+			`{"data":[{"embedding":"`+vec+`"}],"model":"voyage-3"}`)
+		// int8 elements are one byte per dimension.
+		assert.Equal(t, 256, span.GenAI.Embedding.Dimensions())
+	})
+
+	t.Run("jina_base64_embedding_type", func(t *testing.T) {
+		span := embed(t, "https://api.jina.ai/v1/embeddings",
+			`{"model":"jina-embeddings-v3","input":["hi"],"embedding_type":"base64"}`,
+			`{"data":[{"embedding":"`+b64Floats(512)+`"}],"model":"jina-embeddings-v3"}`)
+		assert.Equal(t, 512, span.GenAI.Embedding.Dimensions())
+	})
+
+	t.Run("jina_binary_embedding_type", func(t *testing.T) {
+		span := embed(t, "https://api.jina.ai/v1/embeddings",
+			`{"model":"jina-embeddings-v3","input":["hi"],"embedding_type":"binary"}`,
+			`{"data":[{"embedding":[7,7]}],"model":"jina-embeddings-v3"}`)
+		assert.Equal(t, 16, span.GenAI.Embedding.Dimensions())
+	})
+
+	t.Run("cohere_base64_vectors", func(t *testing.T) {
+		span := embed(t, "https://api.cohere.com/v2/embed",
+			`{"model":"embed-english-v3.0","texts":["hi"],"embedding_types":["base64"]}`,
+			`{"embeddings":{"base64":["`+b64Floats(1024)+`"]}}`)
+		assert.Equal(t, 1024, span.GenAI.Embedding.Dimensions())
+	})
+}
+
+func TestParseEmbeddingDimensions_TruncatedBatch(t *testing.T) {
+	noFormat := &request.EmbeddingRequest{}
+
+	t.Run("first_vector_complete_later_vector_truncated", func(t *testing.T) {
+		body := []byte(`{"data":[{"embedding":[0.1,0.2,0.3]},{"embedding":[0.4,0.`)
+		assert.Equal(t, 3, parseEmbeddingDimensions(noFormat, body))
+	})
+
+	t.Run("first_vector_truncated_returns_zero", func(t *testing.T) {
+		body := []byte(`{"data":[{"embedding":[0.1,0.2`)
+		assert.Equal(t, 0, parseEmbeddingDimensions(noFormat, body))
+	})
+
+	t.Run("truncated_after_complete_envelope_field", func(t *testing.T) {
+		body := []byte(`{"model":"voyage-3","data":[{"embedding":[0.1,0.2]}],"usage":{"total_to`)
+		assert.Equal(t, 2, parseEmbeddingDimensions(noFormat, body))
+	})
+}
+
+func TestEmbeddingRequest_NativeFormatFields(t *testing.T) {
+	t.Run("jina_embedding_type_string", func(t *testing.T) {
+		r := &request.EmbeddingRequest{EmbeddingType: []byte(`"binary"`)}
+		assert.Equal(t, []string{"binary"}, r.EncodingFormats())
+		assert.Equal(t, "binary", r.RequestedDtype())
+	})
+
+	t.Run("jina_embedding_type_array", func(t *testing.T) {
+		r := &request.EmbeddingRequest{EmbeddingType: []byte(`["float","base64"]`)}
+		assert.Equal(t, []string{"float", "base64"}, r.EncodingFormats())
+		assert.Equal(t, "float", r.RequestedDtype())
+	})
+
+	t.Run("voyage_output_dtype", func(t *testing.T) {
+		r := &request.EmbeddingRequest{OutputDtype: "ubinary"}
+		assert.Equal(t, []string{"ubinary"}, r.EncodingFormats())
+		assert.Equal(t, "ubinary", r.RequestedDtype())
+	})
+
+	t.Run("voyage_output_dtype_with_base64_encoding", func(t *testing.T) {
+		r := &request.EmbeddingRequest{OutputDtype: "int8", EncodingFormat: "base64"}
+		assert.Equal(t, []string{"int8", "base64"}, r.EncodingFormats())
+		assert.Equal(t, "int8", r.RequestedDtype())
+	})
+
+	t.Run("cohere_embedding_types_take_precedence", func(t *testing.T) {
+		r := &request.EmbeddingRequest{EmbeddingTypes: []string{"float", "binary"}}
+		assert.Equal(t, []string{"float", "binary"}, r.EncodingFormats())
+		assert.Equal(t, "", r.RequestedDtype())
 	})
 }
 

--- a/pkg/ebpf/common/http/genai_http2_fallback_test.go
+++ b/pkg/ebpf/common/http/genai_http2_fallback_test.go
@@ -20,6 +20,9 @@ func TestGenAIHTTP2BodyHeuristics(t *testing.T) {
 	openAIChatResp := []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"gpt-4o-mini","choices":[{"index":0}],"usage":{"prompt_tokens":1}}`)
 	openAIRespReq := []byte(`{"model":"gpt-5-mini","input":"hi","instructions":"be terse"}`)
 	openAIEmbedReq := []byte(`{"model":"text-embedding-3-small","input":"Your text string goes here","encoding_format":"float"}`)
+	// DashScope compatible-mode embedding: OpenAI-shaped, but the model naming
+	// scheme belongs to Qwen.
+	dashScopeEmbedReq := []byte(`{"model":"text-embedding-v3","input":["hello"],"encoding_format":"float"}`)
 	openAIEmbedResp := []byte(`{"object":"list","model":"text-embedding-3-small","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2]}],"usage":{"prompt_tokens":5,"total_tokens":5}}`)
 	// OpenAI-compatible shape but a non-"gpt" model: OpenAI is no longer a
 	// catch-all, so these must not be claimed.
@@ -51,11 +54,13 @@ func TestGenAIHTTP2BodyHeuristics(t *testing.T) {
 		assert.False(t, looksLikeOpenAIBody(unknownModelReq, unknownModelResp, "/v1/responses"), "unknown model is not a catch-all match")
 		assert.False(t, looksLikeOpenAIBody(nil, nil, "/v1/responses"))
 		assert.False(t, looksLikeOpenAIBody(openAIEmbedReq, nil, "/v1/responses"), "text-embedding model in request but not embeddings call")
+		assert.False(t, looksLikeOpenAIBody(dashScopeEmbedReq, nil, "/v1/embeddings"), "DashScope text-embedding-v* model must be left for qwen")
 	})
 
 	t.Run("qwen", func(t *testing.T) {
 		assert.True(t, looksLikeQwenBody(qwenReq, nil), "qwen model in request")
 		assert.True(t, looksLikeQwenBody(nil, qwenReqIDResp), "DashScope request_id in response")
+		assert.True(t, looksLikeQwenBody(dashScopeEmbedReq, nil), "DashScope text-embedding-v* model in request")
 		assert.False(t, looksLikeQwenBody(openAIChatReq, openAIChatResp))
 	})
 
@@ -113,4 +118,42 @@ func TestGenAIHTTP2Gate(t *testing.T) {
 	span, ok := OpenAISpan(baseSpan(), newReq(2), newResp())
 	assert.True(t, ok, "HTTP/2 OpenAI gpt-model body should be detected")
 	assert.Equal(t, request.HTTPSubtypeOpenAI, span.SubType)
+}
+
+// TestGenAIHTTP2DashScopeEmbeddingDetectorOrder replays the postProcessHTTPSpan
+// GenAI detector order for a headerless HTTP/2 request to DashScope's
+// compatible-mode /v1/embeddings endpoint: OpenAI must yield the DashScope
+// "text-embedding-v<N>" model so the later Qwen detector claims it.
+func TestGenAIHTTP2DashScopeEmbeddingDetectorOrder(t *testing.T) {
+	reqBody := []byte(`{"model":"text-embedding-v3","input":["hello"],"encoding_format":"float"}`)
+	respBody := []byte(`{"data":[{"embedding":[0.1,0.2],"index":0,"object":"embedding"}],"model":"text-embedding-v3","usage":{"prompt_tokens":6,"total_tokens":6},"id":"eb4ea05e"}`)
+
+	newReq := func() *http.Request {
+		return &http.Request{
+			Method:     http.MethodPost,
+			ProtoMajor: 2,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewReader(reqBody)),
+			URL:        &url.URL{Path: "/v1/embeddings"},
+		}
+	}
+	newResp := func() *http.Response {
+		return &http.Response{Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(respBody))}
+	}
+	baseSpan := func() *request.Span {
+		return &request.Span{Type: request.EventTypeHTTPClient, Path: "/v1/embeddings"}
+	}
+
+	// Detectors that run before Qwen in postProcessHTTPSpan must not claim it.
+	_, ok := EmbeddingSpan(baseSpan(), newReq(), newResp())
+	assert.False(t, ok, "embedding-only providers must not claim DashScope")
+
+	_, ok = OpenAISpan(baseSpan(), newReq(), newResp())
+	assert.False(t, ok, "openai must yield DashScope text-embedding-v* models")
+
+	span, ok := QwenSpan(baseSpan(), newReq(), newResp())
+	assert.True(t, ok, "qwen must claim the DashScope embedding model")
+	assert.Equal(t, request.HTTPSubtypeQwen, span.SubType)
+	assert.Equal(t, "embeddings", span.GenAI.Qwen.OperationName)
+	assert.Equal(t, "text-embedding-v3", span.GenAI.Qwen.Request.Model)
 }

--- a/pkg/ebpf/common/http/genai_http2_fallback_test.go
+++ b/pkg/ebpf/common/http/genai_http2_fallback_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
@@ -121,39 +122,56 @@ func TestGenAIHTTP2Gate(t *testing.T) {
 }
 
 // TestGenAIHTTP2DashScopeEmbeddingDetectorOrder replays the postProcessHTTPSpan
-// GenAI detector order for a headerless HTTP/2 request to DashScope's
-// compatible-mode /v1/embeddings endpoint: OpenAI must yield the DashScope
+// GenAI detector order for an HTTP/2 request to DashScope's compatible-mode
+// /v1/embeddings endpoint: OpenAI must yield the DashScope
 // "text-embedding-v<N>" model so the later Qwen detector claims it.
+// parseHTTP2Request always populates both Host and URL.Host from the captured
+// span, so the production shape carries the host; the hostless variant covers
+// degraded captures where the :authority header was not recovered.
 func TestGenAIHTTP2DashScopeEmbeddingDetectorOrder(t *testing.T) {
 	reqBody := []byte(`{"model":"text-embedding-v3","input":["hello"],"encoding_format":"float"}`)
 	respBody := []byte(`{"data":[{"embedding":[0.1,0.2],"index":0,"object":"embedding"}],"model":"text-embedding-v3","usage":{"prompt_tokens":6,"total_tokens":6},"id":"eb4ea05e"}`)
 
-	newReq := func() *http.Request {
-		return &http.Request{
-			Method:     http.MethodPost,
-			ProtoMajor: 2,
-			Header:     http.Header{},
-			Body:       io.NopCloser(bytes.NewReader(reqBody)),
-			URL:        &url.URL{Path: "/v1/embeddings"},
-		}
-	}
-	newResp := func() *http.Response {
-		return &http.Response{Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(respBody))}
-	}
-	baseSpan := func() *request.Span {
-		return &request.Span{Type: request.EventTypeHTTPClient, Path: "/v1/embeddings"}
-	}
+	for _, tc := range []struct {
+		name string
+		host string
+	}{
+		{name: "production_shape_with_host", host: "dashscope.aliyuncs.com"},
+		{name: "degraded_capture_without_host", host: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mirror parseHTTP2Request, which always sets both Host and
+			// URL.Host from the captured span.
+			newReq := func() *http.Request {
+				return &http.Request{
+					Method:     http.MethodPost,
+					ProtoMajor: 2,
+					Header:     http.Header{},
+					Host:       tc.host,
+					Body:       io.NopCloser(bytes.NewReader(reqBody)),
+					URL:        &url.URL{Path: "/v1/embeddings", Host: tc.host},
+				}
+			}
+			newResp := func() *http.Response {
+				return &http.Response{Header: http.Header{}, Body: io.NopCloser(bytes.NewReader(respBody))}
+			}
+			baseSpan := func() *request.Span {
+				return &request.Span{Type: request.EventTypeHTTPClient, Path: "/v1/embeddings"}
+			}
 
-	// Detectors that run before Qwen in postProcessHTTPSpan must not claim it.
-	_, ok := EmbeddingSpan(baseSpan(), newReq(), newResp())
-	assert.False(t, ok, "embedding-only providers must not claim DashScope")
+			// Detectors that run before Qwen in postProcessHTTPSpan must not
+			// claim it.
+			_, ok := EmbeddingSpan(baseSpan(), newReq(), newResp())
+			assert.False(t, ok, "embedding-only providers must not claim DashScope")
 
-	_, ok = OpenAISpan(baseSpan(), newReq(), newResp())
-	assert.False(t, ok, "openai must yield DashScope text-embedding-v* models")
+			_, ok = OpenAISpan(baseSpan(), newReq(), newResp())
+			assert.False(t, ok, "openai must yield DashScope text-embedding-v* models")
 
-	span, ok := QwenSpan(baseSpan(), newReq(), newResp())
-	assert.True(t, ok, "qwen must claim the DashScope embedding model")
-	assert.Equal(t, request.HTTPSubtypeQwen, span.SubType)
-	assert.Equal(t, "embeddings", span.GenAI.Qwen.OperationName)
-	assert.Equal(t, "text-embedding-v3", span.GenAI.Qwen.Request.Model)
+			span, ok := QwenSpan(baseSpan(), newReq(), newResp())
+			require.True(t, ok, "qwen must claim the DashScope embedding model")
+			assert.Equal(t, request.HTTPSubtypeQwen, span.SubType)
+			assert.Equal(t, "embeddings", span.GenAI.Qwen.OperationName)
+			assert.Equal(t, "text-embedding-v3", span.GenAI.Qwen.Request.Model)
+		})
+	}
 }

--- a/pkg/ebpf/common/http/genai_http2_fallback_test.go
+++ b/pkg/ebpf/common/http/genai_http2_fallback_test.go
@@ -21,8 +21,7 @@ func TestGenAIHTTP2BodyHeuristics(t *testing.T) {
 	openAIChatResp := []byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"gpt-4o-mini","choices":[{"index":0}],"usage":{"prompt_tokens":1}}`)
 	openAIRespReq := []byte(`{"model":"gpt-5-mini","input":"hi","instructions":"be terse"}`)
 	openAIEmbedReq := []byte(`{"model":"text-embedding-3-small","input":"Your text string goes here","encoding_format":"float"}`)
-	// DashScope compatible-mode embedding: OpenAI-shaped, but the model naming
-	// scheme belongs to Qwen.
+	// DashScope compatible-mode embedding: OpenAI-shaped, but a Qwen model name.
 	dashScopeEmbedReq := []byte(`{"model":"text-embedding-v3","input":["hello"],"encoding_format":"float"}`)
 	openAIEmbedResp := []byte(`{"object":"list","model":"text-embedding-3-small","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2]}],"usage":{"prompt_tokens":5,"total_tokens":5}}`)
 	// OpenAI-compatible shape but a non-"gpt" model: OpenAI is no longer a
@@ -123,11 +122,8 @@ func TestGenAIHTTP2Gate(t *testing.T) {
 
 // TestGenAIHTTP2DashScopeEmbeddingDetectorOrder replays the postProcessHTTPSpan
 // GenAI detector order for an HTTP/2 request to DashScope's compatible-mode
-// /v1/embeddings endpoint: OpenAI must yield the DashScope
-// "text-embedding-v<N>" model so the later Qwen detector claims it.
-// parseHTTP2Request always populates both Host and URL.Host from the captured
-// span, so the production shape carries the host; the hostless variant covers
-// degraded captures where the :authority header was not recovered.
+// /v1/embeddings endpoint: OpenAI must yield the "text-embedding-v<N>" model so
+// the later Qwen detector claims it.
 func TestGenAIHTTP2DashScopeEmbeddingDetectorOrder(t *testing.T) {
 	reqBody := []byte(`{"model":"text-embedding-v3","input":["hello"],"encoding_format":"float"}`)
 	respBody := []byte(`{"data":[{"embedding":[0.1,0.2],"index":0,"object":"embedding"}],"model":"text-embedding-v3","usage":{"prompt_tokens":6,"total_tokens":6},"id":"eb4ea05e"}`)

--- a/pkg/ebpf/common/http/openai.go
+++ b/pkg/ebpf/common/http/openai.go
@@ -66,8 +66,7 @@ func parseOpenAICompatibleResponse(respB []byte) (*request.VendorOpenAI, []reque
 func looksLikeOpenAIBody(reqB, respB []byte, path string) bool {
 	model := strings.ToLower(genaiModel(reqB, respB))
 
-	// DashScope names its embedding models "text-embedding-v<N>" while OpenAI
-	// uses "text-embedding-3-*" and "text-embedding-ada-*": leave the former
+	// DashScope embedding models are named "text-embedding-v<N>": leave them
 	// for the Qwen detector.
 	if isDashScopeEmbeddingModel(model) {
 		return false

--- a/pkg/ebpf/common/http/openai.go
+++ b/pkg/ebpf/common/http/openai.go
@@ -66,6 +66,13 @@ func parseOpenAICompatibleResponse(respB []byte) (*request.VendorOpenAI, []reque
 func looksLikeOpenAIBody(reqB, respB []byte, path string) bool {
 	model := strings.ToLower(genaiModel(reqB, respB))
 
+	// DashScope names its embedding models "text-embedding-v<N>" while OpenAI
+	// uses "text-embedding-3-*" and "text-embedding-ada-*": leave the former
+	// for the Qwen detector.
+	if isDashScopeEmbeddingModel(model) {
+		return false
+	}
+
 	// "gpt" covers chat/completions and responses; "text-embedding" covers the
 	// embeddings.
 	return strings.HasPrefix(model, "gpt") || (strings.HasPrefix(model, "text-embedding") && strings.Contains(path, "/v1/embeddings"))

--- a/pkg/ebpf/common/http/partial_json.go
+++ b/pkg/ebpf/common/http/partial_json.go
@@ -263,6 +263,12 @@ func parseOpenAIInput(body []byte) request.OpenAIInput {
 	if len(parsed.Parameters) == 0 && len(body) > 0 {
 		parsed.Parameters = extractJSONRawField(body, "parameters")
 	}
+	// An array-typed "input" (batch embeddings) similarly aborts the decode
+	// before "encoding_format"; backfill it so gen_ai.request.encoding_formats
+	// is captured regardless of input shape.
+	if parsed.EncodingFormat == "" && len(body) > 0 {
+		parsed.EncodingFormat = extractJSONStringField(body, "encoding_format", 0)
+	}
 	return parsed
 }
 

--- a/pkg/ebpf/common/http/partial_json.go
+++ b/pkg/ebpf/common/http/partial_json.go
@@ -257,6 +257,12 @@ func parseOpenAIInput(body []byte) request.OpenAIInput {
 	if len(parsed.Messages) == 0 && len(body) > 0 {
 		parsed.Messages = extractJSONRawField(body, "messages")
 	}
+	// Native DashScope nests options under "parameters" and uses an object-typed
+	// "input"; the latter aborts jsoniter's struct decode before it reaches
+	// "parameters", so backfill it directly from the raw body.
+	if len(parsed.Parameters) == 0 && len(body) > 0 {
+		parsed.Parameters = extractJSONRawField(body, "parameters")
+	}
 	return parsed
 }
 

--- a/pkg/ebpf/common/http/partial_json.go
+++ b/pkg/ebpf/common/http/partial_json.go
@@ -257,15 +257,9 @@ func parseOpenAIInput(body []byte) request.OpenAIInput {
 	if len(parsed.Messages) == 0 && len(body) > 0 {
 		parsed.Messages = extractJSONRawField(body, "messages")
 	}
-	// Native DashScope nests options under "parameters" and uses an object-typed
-	// "input"; the latter aborts jsoniter's struct decode before it reaches
-	// "parameters", so backfill it directly from the raw body.
 	if len(parsed.Parameters) == 0 && len(body) > 0 {
 		parsed.Parameters = extractJSONRawField(body, "parameters")
 	}
-	// An array-typed "input" (batch embeddings) similarly aborts the decode
-	// before "encoding_format"; backfill it so gen_ai.request.encoding_formats
-	// is captured regardless of input shape.
 	if parsed.EncodingFormat == "" && len(body) > 0 {
 		parsed.EncodingFormat = extractJSONStringField(body, "encoding_format", 0)
 	}

--- a/pkg/ebpf/common/http/qwen.go
+++ b/pkg/ebpf/common/http/qwen.go
@@ -55,11 +55,12 @@ func QwenSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (r
 		return *baseSpan, false
 	}
 
-	// If detected only by URL, verify model name starts with "qwen". The header
-	// and HTTP/2-body paths have already confirmed the provider.
+	// If detected only by URL, verify the model belongs to Qwen: either a
+	// "qwen*" model or a DashScope "text-embedding-v<N>" embedding model. The
+	// header and HTTP/2-body paths have already confirmed the provider.
 	if !headerDetected && !maybeQwen {
-		model := extractModelField(reqB)
-		if !strings.HasPrefix(strings.ToLower(model), "qwen") {
+		model := strings.ToLower(extractModelField(reqB))
+		if !strings.HasPrefix(model, "qwen") && !isDashScopeEmbeddingModel(model) {
 			return *baseSpan, false
 		}
 	}

--- a/pkg/ebpf/common/http/qwen.go
+++ b/pkg/ebpf/common/http/qwen.go
@@ -21,10 +21,19 @@ func isQwen(respHeader http.Header) bool {
 }
 
 func looksLikeQwenBody(reqB, respB []byte) bool {
-	if strings.HasPrefix(strings.ToLower(genaiModel(reqB, respB)), "qwen") {
+	model := strings.ToLower(genaiModel(reqB, respB))
+	if strings.HasPrefix(model, "qwen") || isDashScopeEmbeddingModel(model) {
 		return true
 	}
 	return extractJSONRawField(respB, "request_id") != nil
+}
+
+// isDashScopeEmbeddingModel reports whether the model follows the DashScope
+// embedding naming scheme "text-embedding-v<N>", which distinguishes Qwen
+// embeddings from OpenAI's "text-embedding-3-*" and "text-embedding-ada-*"
+// models on headerless HTTP/2 requests.
+func isDashScopeEmbeddingModel(model string) bool {
+	return strings.HasPrefix(model, "text-embedding-v")
 }
 
 func QwenSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (request.Span, bool) {

--- a/pkg/ebpf/common/http/qwen.go
+++ b/pkg/ebpf/common/http/qwen.go
@@ -29,9 +29,8 @@ func looksLikeQwenBody(reqB, respB []byte) bool {
 }
 
 // isDashScopeEmbeddingModel reports whether the model follows the DashScope
-// embedding naming scheme "text-embedding-v<N>", which distinguishes Qwen
-// embeddings from OpenAI's "text-embedding-3-*" and "text-embedding-ada-*"
-// models on headerless HTTP/2 requests.
+// embedding naming scheme "text-embedding-v<N>", distinct from OpenAI's
+// "text-embedding-3-*" and "text-embedding-ada-*" models.
 func isDashScopeEmbeddingModel(model string) bool {
 	return strings.HasPrefix(model, "text-embedding-v")
 }
@@ -55,9 +54,8 @@ func QwenSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (r
 		return *baseSpan, false
 	}
 
-	// If detected only by URL, verify the model belongs to Qwen: either a
-	// "qwen*" model or a DashScope "text-embedding-v<N>" embedding model. The
-	// header and HTTP/2-body paths have already confirmed the provider.
+	// If detected only by URL, verify the model belongs to Qwen. The header
+	// and HTTP/2-body paths have already confirmed the provider.
 	if !headerDetected && !maybeQwen {
 		model := strings.ToLower(extractModelField(reqB))
 		if !strings.HasPrefix(model, "qwen") && !isDashScopeEmbeddingModel(model) {

--- a/pkg/ebpf/common/http/qwen_test.go
+++ b/pkg/ebpf/common/http/qwen_test.go
@@ -116,10 +116,8 @@ func TestQwenSpan_DashScopeGeneration(t *testing.T) {
 	assert.JSONEq(t, `{"text":"eBPF is a kernel programmability technology.","finish_reason":"stop"}`, ai.GetOutput())
 }
 
-// Native DashScope text-embedding request/response: input is nested under
-// input.texts, the requested dimension under parameters.dimension, and the
-// output vectors under output.embeddings[].embedding. Usage carries only
-// total_tokens (no input_tokens/prompt_tokens).
+// Native DashScope text-embedding bodies: input under input.texts, dimension
+// under parameters.dimension, vectors under output.embeddings[].embedding.
 const dashScopeEmbeddingRequestBody = `{
   "model":"text-embedding-v2",
   "input":{"texts":["Hello world","Goodbye world"]},
@@ -176,9 +174,8 @@ func TestQwenSpan_DashScopeNativeEmbedding_DimensionFromResponse(t *testing.T) {
 }
 
 func TestQwenSpan_CompatibleModeBase64Embedding(t *testing.T) {
-	// OpenAI SDKs default to encoding_format=base64 for embeddings: the response
-	// data[].embedding is a base64 string of packed float32 values, not a JSON
-	// array. A 1024-dim vector is 1024*4=4096 bytes.
+	// OpenAI SDKs default to encoding_format=base64: data[].embedding is a
+	// base64 string of packed float32 values (1024 dims = 4096 bytes).
 	vec := base64.StdEncoding.EncodeToString(make([]byte, 1024*4))
 	respBody := fmt.Sprintf(
 		`{"data":[{"embedding":"%s","index":0,"object":"embedding"}],"model":"text-embedding-v3","usage":{"prompt_tokens":6,"total_tokens":6},"id":"eb4ea05e-18c5-9554-9234-78a1528e7be3"}`,

--- a/pkg/ebpf/common/http/qwen_test.go
+++ b/pkg/ebpf/common/http/qwen_test.go
@@ -5,6 +5,8 @@ package ebpfcommon
 
 import (
 	"bufio"
+	"encoding/base64"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -171,6 +173,32 @@ func TestQwenSpan_DashScopeNativeEmbedding_DimensionFromResponse(t *testing.T) {
 	require.True(t, ok)
 	require.NotNil(t, span.GenAI.Qwen)
 	assert.Equal(t, 3, span.GenAI.Qwen.GetEmbeddingDimensions())
+}
+
+func TestQwenSpan_CompatibleModeBase64Embedding(t *testing.T) {
+	// OpenAI SDKs default to encoding_format=base64 for embeddings: the response
+	// data[].embedding is a base64 string of packed float32 values, not a JSON
+	// array. A 1024-dim vector is 1024*4=4096 bytes.
+	vec := base64.StdEncoding.EncodeToString(make([]byte, 1024*4))
+	respBody := fmt.Sprintf(
+		`{"data":[{"embedding":"%s","index":0,"object":"embedding"}],"model":"text-embedding-v3","usage":{"prompt_tokens":6,"total_tokens":6},"id":"eb4ea05e-18c5-9554-9234-78a1528e7be3"}`,
+		vec)
+	reqBody := `{"model":"text-embedding-v3","input":["hello"],"encoding_format":"base64"}`
+
+	req := makeRequest(t, http.MethodPost, "https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings", reqBody)
+	resp := makePlainResponse(http.StatusOK, qwenHeaders(), respBody)
+
+	base := &request.Span{}
+	span, ok := QwenSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI.Qwen)
+	ai := span.GenAI.Qwen
+	assert.Equal(t, "embeddings", ai.OperationName)
+	// Dimension resolved from the base64-decoded vector: 4096 bytes / 4 = 1024.
+	assert.Equal(t, 1024, ai.GetEmbeddingDimensions())
+	assert.Equal(t, "base64", ai.Request.EncodingFormat)
+	assert.Equal(t, 6, reportedValue(span.GenAIInputTokenCount()))
 }
 
 func TestQwenSpan_IDFallbackFromHeadersWhenBodyMissingID(t *testing.T) {

--- a/pkg/ebpf/common/http/qwen_test.go
+++ b/pkg/ebpf/common/http/qwen_test.go
@@ -114,6 +114,65 @@ func TestQwenSpan_DashScopeGeneration(t *testing.T) {
 	assert.JSONEq(t, `{"text":"eBPF is a kernel programmability technology.","finish_reason":"stop"}`, ai.GetOutput())
 }
 
+// Native DashScope text-embedding request/response: input is nested under
+// input.texts, the requested dimension under parameters.dimension, and the
+// output vectors under output.embeddings[].embedding. Usage carries only
+// total_tokens (no input_tokens/prompt_tokens).
+const dashScopeEmbeddingRequestBody = `{
+  "model":"text-embedding-v2",
+  "input":{"texts":["Hello world","Goodbye world"]},
+  "parameters":{"dimension":1024,"output_type":"dense","text_type":"query"}
+}`
+
+const dashScopeEmbeddingResponseBody = `{
+  "output":{"embeddings":[
+    {"embedding":[0.1,0.2,0.3],"text_index":0},
+    {"embedding":[0.4,0.5,0.6],"text_index":1}
+  ]},
+  "usage":{"total_tokens":8},
+  "request_id":"req-emb-1"
+}`
+
+func TestQwenSpan_DashScopeNativeEmbedding(t *testing.T) {
+	req := makeRequest(t, http.MethodPost,
+		"https://dashscope.aliyuncs.com/api/v1/services/embeddings/text-embedding/text-embedding",
+		dashScopeEmbeddingRequestBody)
+	resp := makePlainResponse(http.StatusOK, qwenHeaders(), dashScopeEmbeddingResponseBody)
+
+	base := &request.Span{}
+	span, ok := QwenSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI)
+	require.NotNil(t, span.GenAI.Qwen)
+
+	ai := span.GenAI.Qwen
+	assert.Equal(t, "embeddings", ai.OperationName)
+	assert.Equal(t, "text-embedding-v2", ai.Request.Model)
+	// Requested dimension comes from parameters.dimension (takes precedence).
+	assert.Equal(t, 1024, ai.GetEmbeddingDimensions())
+	// input_tokens falls back to total_tokens for embeddings.
+	assert.Equal(t, 8, reportedValue(span.GenAIInputTokenCount()))
+	assert.True(t, isReported(span.GenAIInputTokenCount()))
+}
+
+func TestQwenSpan_DashScopeNativeEmbedding_DimensionFromResponse(t *testing.T) {
+	// No parameters.dimension in the request: dimension is derived from the
+	// response output.embeddings[0].embedding vector length.
+	reqBody := `{"model":"text-embedding-v2","input":{"texts":["hi"]}}`
+	req := makeRequest(t, http.MethodPost,
+		"https://dashscope.aliyuncs.com/api/v1/services/embeddings/text-embedding/text-embedding",
+		reqBody)
+	resp := makePlainResponse(http.StatusOK, qwenHeaders(), dashScopeEmbeddingResponseBody)
+
+	base := &request.Span{}
+	span, ok := QwenSpan(base, req, resp)
+
+	require.True(t, ok)
+	require.NotNil(t, span.GenAI.Qwen)
+	assert.Equal(t, 3, span.GenAI.Qwen.GetEmbeddingDimensions())
+}
+
 func TestQwenSpan_IDFallbackFromHeadersWhenBodyMissingID(t *testing.T) {
 	req := makeRequest(t, http.MethodPost, "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions", qwenCompatibleRequestBody)
 	h := http.Header{}

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -1334,8 +1334,11 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 				attrs = append(attrs, semconv.GenAIResponseModel(model))
 			}
 			attrs = append(attrs, genAIUsageAttributes(span)...)
-			if ai.Input.Dimensions > 0 {
-				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.dimensions", ai.Input.Dimensions))
+			if dims := ai.Dimensions(); dims > 0 {
+				attrs = append(attrs, semconv.GenAIEmbeddingsDimensionCount(dims))
+			}
+			if formats := ai.Input.EncodingFormats(); len(formats) > 0 {
+				attrs = append(attrs, semconv.GenAIRequestEncodingFormats(formats...))
 			}
 			if count := ai.Input.InputCount(); count > 0 {
 				attrs = append(attrs, attribute.Int("gen_ai.request.embedding.input_count", count))


### PR DESCRIPTION
## Summary

Aligns GenAI embeddings spans with the OTel GenAI semantic conventions across all embedding paths, and fixes two cases where the dimension count / encoding format were dropped.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
