### PR TITLE
Fix v2 routes conversion

### DIFF
--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -1052,12 +1052,31 @@ func applyFullV2HTTPRoutes(cfg *obi.Config, routes schema.HTTPRoutes) {
 
 	policies := services.DirectionalRoutePolicies{}
 	applyV2HTTPRouteConfig(&policies, routes)
+	// A v1 global routes block exports identical incoming/outgoing policies.
+	// Collapse them back into a single global RoutesConfig so migrations round-trip
+	// to the representation the user authored instead of a directional one.
+	if routes.Incoming != nil && routes.Outgoing != nil &&
+		reflect.DeepEqual(policies.Incoming, policies.Outgoing) {
+		cfg.Routes = globalRoutesConfig(policies.Incoming)
+		return
+	}
 	cfg.Routes = &transform.RoutesConfig{
 		Directional: &policies,
 		DirectionalPolicyPresence: &transform.DirectionalRoutePolicyPresence{
 			Incoming: routes.Incoming != nil,
 			Outgoing: routes.Outgoing != nil,
 		},
+	}
+}
+
+func globalRoutesConfig(policy services.RoutePolicy) *transform.RoutesConfig {
+	return &transform.RoutesConfig{
+		Unmatch:                   transform.UnmatchType(policy.Unmatch),
+		Patterns:                  cloneStrings(policy.Patterns),
+		IgnorePatterns:            cloneStrings(policy.IgnorePatterns),
+		IgnoredEvents:             transform.IgnoreMode(policy.IgnoredEvents),
+		WildcardChar:              policy.WildcardChar,
+		MaxPathSegmentCardinality: policy.MaxPathSegmentCardinality,
 	}
 }
 

--- a/internal/config/convert/import_http_test.go
+++ b/internal/config/convert/import_http_test.go
@@ -39,7 +39,15 @@ func TestV2ToRuntimeHTTPRoutesRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, got.Routes)
-	require.NotNil(t, got.Routes.Directional)
+	// A symmetric global routes config round-trips back to the global
+	// representation the user authored, not a directional one.
+	require.Nil(t, got.Routes.Directional)
+	require.Equal(t, cfg.Routes.Unmatch, got.Routes.Unmatch)
+	require.Equal(t, cfg.Routes.Patterns, got.Routes.Patterns)
+	require.Equal(t, cfg.Routes.IgnorePatterns, got.Routes.IgnorePatterns)
+	require.Equal(t, cfg.Routes.IgnoredEvents, got.Routes.IgnoredEvents)
+	require.Equal(t, cfg.Routes.WildcardChar, got.Routes.WildcardChar)
+	require.Equal(t, cfg.Routes.MaxPathSegmentCardinality, got.Routes.MaxPathSegmentCardinality)
 	require.Equal(t, cfg.Routes.DirectionalPolicies(), got.Routes.DirectionalPolicies())
 	require.Equal(t, cfg.Discovery.RouteHarvesterTimeout, got.Discovery.RouteHarvesterTimeout)
 	require.Equal(t, cfg.Discovery.DisabledRouteHarvesters, got.Discovery.DisabledRouteHarvesters)


### PR DESCRIPTION
## Summary

Fix V1→V2 config migration losing global `routes` settings. When a V1 config sets a global `routes` block (`unmatched`, `patterns`, `ignored_patterns`, `ignore_mode`), it exports to symmetric `incoming`/`outgoing` V2 policies, but the importer always rebuilt a `Directional` config and left the global `RoutesConfig` fields empty — so the round-trip dropped those fields and the migration contract check rejected them as unsupported. `applyFullV2HTTPRoutes` now collapses identical incoming/outgoing policies back into a single global `RoutesConfig`, which is semantically equivalent but preserves the representation the user authored, making the round-trip lossless. Also updates `TestV2ToRuntimeHTTPRoutesRoundTrip`, which had asserted the old always-directional behavior, to expect the preserved global form while still verifying directional-policy equivalence.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
