### PR TITLE
fix(nodejs): never fragment inspector websocket messages

### DIFF
--- a/pkg/internal/nodejs/injector.go
+++ b/pkg/internal/nodejs/injector.go
@@ -167,11 +167,11 @@ func (i *NodeInjector) requestDebuggerURL(conn net.Conn) (string, error) {
 	return targets[0].WebSocketDebuggerURL, nil
 }
 
-func upgradeConn(conn net.Conn, wsURL string) (*websocket.Conn, *http.Response, error) {
-	return upgradeConnWithTimeout(conn, wsURL, inspectorRequestTimeout)
+func upgradeConn(conn net.Conn, wsURL string, writeBufferSize int) (*websocket.Conn, *http.Response, error) {
+	return upgradeConnWithTimeout(conn, wsURL, writeBufferSize, inspectorRequestTimeout)
 }
 
-func upgradeConnWithTimeout(conn net.Conn, wsURL string, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
+func upgradeConnWithTimeout(conn net.Conn, wsURL string, writeBufferSize int, timeout time.Duration) (*websocket.Conn, *http.Response, error) {
 	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
 		return nil, nil, fmt.Errorf("connection deadline error: %w", err)
 	}
@@ -181,6 +181,7 @@ func upgradeConnWithTimeout(conn net.Conn, wsURL string, timeout time.Duration) 
 
 	dialer := websocket.Dialer{
 		HandshakeTimeout: timeout,
+		WriteBufferSize:  writeBufferSize,
 		NetDial: func(_, _ string) (net.Conn, error) {
 			return conn, nil
 		},
@@ -190,11 +191,7 @@ func upgradeConnWithTimeout(conn net.Conn, wsURL string, timeout time.Duration) 
 	return wsConn, resp, err
 }
 
-func sendEvaluate(wsConn *websocket.Conn, exp string, id int) error {
-	return sendEvaluateWithTimeout(wsConn, exp, id, inspectorRequestTimeout)
-}
-
-func sendEvaluateWithTimeout(wsConn *websocket.Conn, exp string, id int, timeout time.Duration) error {
+func evaluateRequest(exp string, id int) ([]byte, error) {
 	req := cdpRequest{
 		ID:     id,
 		Method: "Runtime.evaluate",
@@ -206,9 +203,24 @@ func sendEvaluateWithTimeout(wsConn *websocket.Conn, exp string, id int, timeout
 
 	data, err := json.Marshal(req)
 	if err != nil {
-		return fmt.Errorf("failed to serialize request: %w", err)
+		return nil, fmt.Errorf("failed to serialize request: %w", err)
 	}
+	return data, nil
+}
 
+func sendEvaluate(wsConn *websocket.Conn, exp string, id int) error {
+	return sendEvaluateWithTimeout(wsConn, exp, id, inspectorRequestTimeout)
+}
+
+func sendEvaluateWithTimeout(wsConn *websocket.Conn, exp string, id int, timeout time.Duration) error {
+	data, err := evaluateRequest(exp, id)
+	if err != nil {
+		return err
+	}
+	return sendMessageWithTimeout(wsConn, data, timeout)
+}
+
+func sendMessageWithTimeout(wsConn *websocket.Conn, data []byte, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 
 	if err := wsConn.SetWriteDeadline(deadline); err != nil {
@@ -227,6 +239,9 @@ func sendEvaluateWithTimeout(wsConn *websocket.Conn, exp string, id int, timeout
 		return fmt.Errorf("websocket write error: %w", err)
 	}
 
+	// NOTE: the next message is assumed to be the response to `data`: valid as
+	// long as no CDP event domain is enabled on this session (e.g.
+	// Runtime.enable), since events would interleave before the response
 	_, msg, err := wsConn.ReadMessage()
 	if err != nil {
 		return fmt.Errorf("websocket read error: %w", err)
@@ -257,16 +272,12 @@ func sendEvaluateWithTimeout(wsConn *websocket.Conn, exp string, id int, timeout
 	return nil
 }
 
-func (i *NodeInjector) injectFileWS(wsConn *websocket.Conn) error {
+func (i *NodeInjector) injectFileWS(wsConn *websocket.Conn, payload []byte) error {
 	defer func() {
 		_ = sendEvaluate(wsConn, "process._debugEnd();", 2)
 	}()
 
-	script := string(_extractorBytes)
-
-	wrapped := fmt.Sprintf("(()=>{\n%s\n})()", script)
-
-	if err := sendEvaluate(wsConn, wrapped, 1); err != nil {
+	if err := sendMessageWithTimeout(wsConn, payload, inspectorRequestTimeout); err != nil {
 		return err
 	}
 
@@ -284,11 +295,19 @@ func (i *NodeInjector) injectViaConn(conn net.Conn) error {
 
 	i.log.Debug("found debugger url", "url", wsURL)
 
-	wsConn, _, err := upgradeConn(conn, wsURL)
+	wrapped := fmt.Sprintf("(()=>{\n%s\n})()", string(_extractorBytes))
+	payload, err := evaluateRequest(wrapped, 1)
+	if err != nil {
+		conn.Close()
+		return err
+	}
+
+	// buffer sized to the payload: the inspector rejects fragmented messages
+	wsConn, _, err := upgradeConn(conn, wsURL, len(payload))
 	if err != nil {
 		conn.Close()
 		return fmt.Errorf("failed to connect to inspector WebSocket: %w", err)
 	}
 
-	return i.injectFileWS(wsConn)
+	return i.injectFileWS(wsConn, payload)
 }

--- a/pkg/internal/nodejs/injector_test.go
+++ b/pkg/internal/nodejs/injector_test.go
@@ -5,7 +5,12 @@ package nodejs
 
 import (
 	"bufio"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/binary"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -143,7 +148,7 @@ func TestUpgradeConnTimesOutWhenInspectorDoesNotRespond(t *testing.T) {
 	})
 
 	err := runWithOperationTimeout(t, "upgradeConnWithTimeout", func() error {
-		wsConn, _, err := upgradeConnWithTimeout(conn, "ws://127.0.0.1/json", testInspectorTimeout)
+		wsConn, _, err := upgradeConnWithTimeout(conn, "ws://127.0.0.1/json", 0, testInspectorTimeout)
 		if wsConn != nil {
 			_ = wsConn.Close()
 		}
@@ -164,7 +169,7 @@ func TestUpgradeConnClearsDeadline(t *testing.T) {
 	}
 
 	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
-	wsConn, _, err := upgradeConnWithTimeout(conn, wsURL, testInspectorTimeout)
+	wsConn, _, err := upgradeConnWithTimeout(conn, wsURL, 0, testInspectorTimeout)
 	if err != nil {
 		_ = conn.Close()
 		t.Fatalf("upgrade websocket: %v", err)
@@ -340,4 +345,129 @@ func assertTimeoutError(t *testing.T, err error) {
 	}
 
 	t.Fatalf("expected timeout error, got %v", err)
+}
+
+// gorilla's read API only exposes reassembled messages, so detecting
+// fragmentation requires parsing frames off the raw TCP stream.
+type frameHeader struct {
+	fin        bool
+	opcode     byte
+	payloadLen uint64
+}
+
+type frameResult struct {
+	header frameHeader
+	err    error
+}
+
+func readFrameHeader(br *bufio.Reader) (frameHeader, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(br, hdr[:]); err != nil {
+		return frameHeader{}, fmt.Errorf("reading frame header: %w", err)
+	}
+
+	h := frameHeader{fin: hdr[0]&0x80 != 0, opcode: hdr[0] & 0x0f, payloadLen: uint64(hdr[1] & 0x7f)}
+	switch h.payloadLen {
+	case 126:
+		var ext [2]byte
+		if _, err := io.ReadFull(br, ext[:]); err != nil {
+			return frameHeader{}, fmt.Errorf("reading extended length: %w", err)
+		}
+		h.payloadLen = uint64(binary.BigEndian.Uint16(ext[:]))
+	case 127:
+		var ext [8]byte
+		if _, err := io.ReadFull(br, ext[:]); err != nil {
+			return frameHeader{}, fmt.Errorf("reading extended length: %w", err)
+		}
+		h.payloadLen = binary.BigEndian.Uint64(ext[:])
+	}
+	return h, nil
+}
+
+func newFrameInspectingServer(results chan<- frameResult) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, brw, err := http.NewResponseController(w).Hijack()
+		if err != nil {
+			results <- frameResult{err: fmt.Errorf("hijacking connection: %w", err)}
+			return
+		}
+		defer conn.Close()
+
+		key := r.Header.Get("Sec-WebSocket-Key")
+		sum := sha1.Sum([]byte(key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+		_, err = brw.WriteString("HTTP/1.1 101 Switching Protocols\r\n" +
+			"Upgrade: websocket\r\nConnection: Upgrade\r\n" +
+			"Sec-WebSocket-Accept: " + base64.StdEncoding.EncodeToString(sum[:]) + "\r\n\r\n")
+		if err == nil {
+			err = brw.Flush()
+		}
+		if err != nil {
+			results <- frameResult{err: fmt.Errorf("writing upgrade response: %w", err)}
+			return
+		}
+
+		header, err := readFrameHeader(brw.Reader)
+		results <- frameResult{header: header, err: err}
+
+		// drain until the client disconnects: closing while it still has
+		// frames in flight resets its write
+		_, _ = io.Copy(io.Discard, brw)
+	}))
+}
+
+// The Node.js inspector closes the connection on fragmented messages, so the
+// injection payload must always leave as one final frame.
+func TestInjectionPayloadIsNeverFragmented(t *testing.T) {
+	// larger than gorilla's 4096-byte default write buffer
+	payload, err := evaluateRequest("(()=>{"+strings.Repeat("x();", 4096)+"})()", 1)
+	if err != nil {
+		t.Fatalf("marshaling evaluate request: %v", err)
+	}
+
+	sendPayload := func(writeBufferSize int) frameHeader {
+		results := make(chan frameResult, 1)
+		srv := newFrameInspectingServer(results)
+		defer srv.Close()
+
+		conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+		if err != nil {
+			t.Fatalf("dial test inspector: %v", err)
+		}
+		defer conn.Close()
+
+		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+		wsConn, _, err := upgradeConnWithTimeout(conn, wsURL, writeBufferSize, testInspectorOperationTimeout)
+		if err != nil {
+			t.Fatalf("upgrade websocket: %v", err)
+		}
+		defer wsConn.Close()
+
+		if err := wsConn.WriteMessage(websocket.TextMessage, payload); err != nil {
+			t.Fatalf("writing payload: %v", err)
+		}
+
+		select {
+		case result := <-results:
+			if result.err != nil {
+				t.Fatalf("reading first frame: %v", result.err)
+			}
+			return result.header
+		case <-time.After(testInspectorOperationTimeout):
+			t.Fatal("timeout waiting for the first frame")
+			return frameHeader{}
+		}
+	}
+
+	sized := sendPayload(len(payload))
+	if !sized.fin || sized.opcode != 1 || sized.payloadLen != uint64(len(payload)) {
+		t.Fatalf("expected a single final text frame with %d bytes, got fin=%v opcode=%d len=%d",
+			len(payload), sized.fin, sized.opcode, sized.payloadLen)
+	}
+
+	// control: prove the default buffer still fragments this payload
+	unsized := sendPayload(0)
+	if unsized.fin {
+		t.Fatal("expected the default write buffer to fragment the payload; " +
+			"if gorilla no longer fragments, this test and the sizing rationale should be revisited")
+	}
 }


### PR DESCRIPTION
## Summary

This is a preparatory PR for the upcoming Node.js runtime metrics feature I'm working on, which grows the agent past the 4096-byte threshold and was how the bug was found.

Basically, nodejs inspector doesn't support fragmented WebSocket messages. Meanwhile, gorilla/websocket automatically fragments messages larger than its 4096-byte write buffer. The CDP payload is now built before the WebSocket upgrade, and the write buffer is sized to fit the exact message, preventing fragmentation regardless of agent size.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
