### PR TITLE
Reject unsupported Config v2 document fields

### DIFF
--- a/internal/config/convert/import_document.go
+++ b/internal/config/convert/import_document.go
@@ -25,11 +25,8 @@ func DocumentToRuntime(src *schema.Document) (*obi.Config, error) {
 	if src == nil {
 		return nil, errors.New("missing OBI document")
 	}
-	if fields := src.OpenTelemetryExtensionFields(); len(fields) != 0 {
-		return nil, fmt.Errorf(
-			"OpenTelemetry extension fields are not supported: %s",
-			strings.Join(fields, ", "),
-		)
+	if err := validateV2Document(src); err != nil {
+		return nil, err
 	}
 
 	cfg, err := V2ToRuntime(src.Extensions.OBI)
@@ -45,6 +42,41 @@ func DocumentToRuntime(src *schema.Document) (*obi.Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func validateV2Document(src *schema.Document) error {
+	if fields := src.OpenTelemetryExtensionFields(); len(fields) != 0 {
+		return fmt.Errorf(
+			"OpenTelemetry extension fields are not supported: %s",
+			strings.Join(fields, ", "),
+		)
+	}
+
+	switch {
+	case src.AttributeLimits != nil:
+		return unsupportedV2Field("attribute_limits")
+	case src.Disabled != nil && *src.Disabled:
+		return unsupportedV2Field("disabled")
+	case len(src.Distribution) != 0:
+		return unsupportedV2Field("distribution")
+	case src.InstrumentationDevelopment != nil:
+		return unsupportedV2Field("instrumentation/development")
+	case src.LoggerProvider != nil:
+		return unsupportedV2Field("logger_provider")
+	case !zeroValue(src.AdditionalProperties):
+		return unsupportedV2Field("additional declarative properties")
+	}
+
+	if src.Propagator != nil &&
+		(len(src.Propagator.Composite) != 0 || src.Propagator.CompositeList != nil) {
+		return unsupportedV2Field("propagator")
+	}
+
+	return nil
+}
+
+func unsupportedV2Field(path string) error {
+	return fmt.Errorf("%s is not supported by the OBI runtime converter", path)
 }
 
 func applyV2LogLevel(cfg *obi.Config, src *schema.Document) error {

--- a/internal/config/convert/import_document_test.go
+++ b/internal/config/convert/import_document_test.go
@@ -197,6 +197,81 @@ extensions:
 	)
 }
 
+func TestDocumentToRuntimeRejectsUnsupportedDocumentFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "attribute limits",
+			yaml: "attribute_limits: {}\n",
+			want: "attribute_limits is not supported by the OBI runtime converter",
+		},
+		{
+			name: "disabled",
+			yaml: "disabled: true\n",
+			want: "disabled is not supported by the OBI runtime converter",
+		},
+		{
+			name: "distribution",
+			yaml: "distribution:\n  vendor:\n    option: true\n",
+			want: "distribution is not supported by the OBI runtime converter",
+		},
+		{
+			name: "instrumentation development",
+			yaml: "instrumentation/development: {}\n",
+			want: "instrumentation/development is not supported by the OBI runtime converter",
+		},
+		{
+			name: "logger provider",
+			yaml: "logger_provider: {}\n",
+			want: "logger_provider is not supported by the OBI runtime converter",
+		},
+		{
+			name: "propagator",
+			yaml: "propagator:\n  composite_list: \"\"\n",
+			want: "propagator is not supported by the OBI runtime converter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			doc, _, err := schema.ParseStandaloneYAML([]byte(
+				"file_format: \"1.0\"\n" +
+					tt.yaml +
+					"extensions:\n  obi:\n    version: \"2.0\"\n",
+			))
+			require.NoError(t, err)
+
+			_, err = DocumentToRuntime(doc)
+			require.EqualError(t, err, tt.want)
+		})
+	}
+}
+
+func TestDocumentToRuntimeAcceptsEmptySupportedDocumentFields(t *testing.T) {
+	t.Parallel()
+
+	doc, _, err := schema.ParseStandaloneYAML([]byte(`
+file_format: "1.0"
+disabled: false
+distribution: {}
+propagator: {}
+extensions:
+  obi:
+    version: "2.0"
+`))
+	require.NoError(t, err)
+
+	_, err = DocumentToRuntime(doc)
+	require.NoError(t, err)
+}
+
 func TestDocumentToRuntimeSkipsUnsupportedMetricReaderShapes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/schema/schema.go
+++ b/internal/config/schema/schema.go
@@ -71,6 +71,11 @@ func (d *Document) UnmarshalYAML(node *yaml.Node) error {
 	if err := node.Decode(&d.OpenTelemetryConfiguration); err != nil {
 		return err
 	}
+	if distribution, ok := mappingValue(node, "distribution"); ok {
+		if err := distribution.Decode(&d.Distribution); err != nil {
+			return err
+		}
+	}
 	extensions, ok := mappingValue(node, "extensions")
 	if !ok {
 		return errors.New("missing extensions")

--- a/internal/config/schema/schema_test.go
+++ b/internal/config/schema/schema_test.go
@@ -40,6 +40,9 @@ func TestParseStandaloneYAMLDocument(t *testing.T) {
 	doc, cfg, err := ParseStandaloneYAML([]byte(`
 file_format: "1.0"
 log_level: debug
+distribution:
+  vendor:
+    option: true
 resource:
   attributes:
     - name: service.namespace
@@ -101,6 +104,7 @@ extensions:
 	require.True(t, doc.HasLogLevel())
 	require.NotNil(t, doc.LogLevel)
 	require.Equal(t, "debug", string(*doc.LogLevel))
+	require.Equal(t, true, doc.Distribution["vendor"]["option"])
 	require.Equal(t, SupportedVersion, cfg.Version)
 	require.NotNil(t, doc.InstrumentationDevelopment)
 	require.Len(t, doc.Resource.Attributes, 1)


### PR DESCRIPTION
## Summary

- reject non-empty Config v2 document fields that the runtime converter cannot preserve instead of silently ignoring them
- keep empty optional document sections accepted
- decode `distribution` explicitly so its presence is available to validation
- add focused coverage for accepted and rejected top-level document shapes

## Why

The Config v2 runtime converter supports only a bounded subset of the OpenTelemetry declarative document. Accepting unsupported fields makes a configuration appear valid even though conversion drops user intent and changes runtime behavior.

This is the first internal, review-sized extraction from #2799. It does not expose a new public surface or publish migration guidance; later stacked changes will cover the remaining conversion, CLI, artifact, and documentation work.

## Validation

- `go test ./internal/config/schema ./internal/config/convert`
- `go test -race ./internal/config/schema ./internal/config/convert`
- `make -o prereqs verify`
- `git diff --check`