### PR TITLE
JS Route harvester: support standard URLPattern API

### DIFF
--- a/pkg/internal/transform/route/harvest/js.go
+++ b/pkg/internal/transform/route/harvest/js.go
@@ -217,13 +217,14 @@ func newFrameworkPatterns() *FrameworkPatterns {
 		// Supports both string literals and regex literals
 		HTTPDispatcher: regexp.MustCompile(`\.on(Get|Post|Put|Patch|Delete|Head|Options|All)\s*\(\s*(?:['"\x60]([^'"\x60]+)['"\x60]|/((?:[^\\,]|\\.)+))`),
 
-		// URLPattern WEB API. The constructor takes the pattern either as a
-		// string or as an init object, optionally through a namespace object:
+		// URLPattern WEB API: matches the opening of the constructor call, whose
+		// arguments are then read until the call closes. The pattern is given
+		// either as a string or as an init object, and either of them may be
+		// spread over several lines:
 		//   new URLPattern("https://example.com/books/:id")
 		//   new URLPattern({ pathname: "/books/:id" })
 		//   new urlpattern.URLPattern("/books/:id", base)
-		// \s covers the line breaks of a call spread over several lines.
-		URLPattern: regexp.MustCompile(`URLPattern\s*\(\s*(?:['"\x60]([^'"\x60]*)['"\x60])?`),
+		URLPattern: regexp.MustCompile(`URLPattern\s*\(`),
 
 		// Matches the 'pathname' member of a URLPattern init object in every
 		// legal property key form: pathname, 'pathname', ["pathname"]
@@ -271,9 +272,9 @@ type RouteExtractor struct {
 	// enableVersioningTypeSeen tracks whether the current enableVersioning call
 	// named an explicit VersioningType (URI is NestJS's default when it didn't)
 	enableVersioningTypeSeen bool
-	// inURLPattern tracks a new URLPattern({...}) call whose init object spans
-	// several lines, until its closing parenthesis
-	inURLPattern bool
+	// urlPatternCall buffers the arguments of the URLPattern call currently
+	// being scanned, nil when no call is open
+	urlPatternCall *urlPatternCall
 
 	// application-level NestJS settings, harvested from any scanned file
 	// (typically main.ts) and applied to Nest routes after the scan
@@ -719,43 +720,140 @@ func urlPatternPathname(pattern string) string {
 	return ensureLeadingSlash(pattern)
 }
 
-// handleURLPattern harvests routes declared through the URL Pattern API. The
-// pattern comes either as a string argument or as an init object holding a
-// 'pathname' member. The init object may be spread over several lines, so the
-// call is tracked until its closing parenthesis. No method is declared, so the
-// route applies to all of them.
+// urlPatternCall buffers the arguments of a URLPattern call while it is being
+// scanned. The scanner reads one physical line at a time and the call may span
+// several of them, so its arguments are parsed only once the call closes.
+type urlPatternCall struct {
+	args  strings.Builder
+	depth int
+	file  string
+	line  int
+}
+
+// consume appends the part of text that belongs to the call and returns the
+// offset just past its closing parenthesis, or -1 when the call is still open.
+// Parentheses inside a string literal belong to a component pattern
+// (protocol: "(https?)"), not to the call, so they are skipped.
+func (c *urlPatternCall) consume(text string) int {
+	for i := 0; i < len(text); i++ {
+		switch text[i] {
+		case '\'', '"', '`':
+			i = endOfJSString(text, i)
+		case '(':
+			c.depth++
+		case ')':
+			c.depth--
+			if c.depth == 0 {
+				c.args.WriteString(text[:i])
+				return i + 1
+			}
+		}
+	}
+
+	c.args.WriteString(text)
+	return -1
+}
+
+// endOfJSString returns the offset of the closing quote of the string literal
+// that starts at open, or len(s) when the literal does not close in s.
+func endOfJSString(s string, open int) int {
+	quote := s[open]
+	for i := open + 1; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			i++
+		case quote:
+			return i
+		}
+	}
+	return len(s)
+}
+
+func isJSQuote(c byte) bool {
+	return c == '\'' || c == '"' || c == '`'
+}
+
+// handleURLPattern harvests routes declared through the URL Pattern API. A call
+// may open, span, and close any number of lines, so each line is fed to the
+// buffered call and the route is emitted when the call closes.
 func (e *RouteExtractor) handleURLPattern(filePath, line string, lineNum int) bool {
-	constructors := e.patterns.URLPattern.FindAllStringSubmatch(line, -1)
-	if constructors == nil && !e.inURLPattern {
+	if e.urlPatternCall != nil {
+		e.urlPatternCall.args.WriteString("\n")
+	} else if !e.patterns.URLPattern.MatchString(line) {
 		return false
 	}
 
-	addRoute := func(path string) {
-		if path == "" {
-			return
+	rest := line
+	for {
+		if e.urlPatternCall == nil {
+			opening := e.patterns.URLPattern.FindStringIndex(rest)
+			if opening == nil {
+				return true
+			}
+			e.urlPatternCall = &urlPatternCall{depth: 1, file: filePath, line: lineNum}
+			rest = rest[opening[1]:]
 		}
-		e.routes = append(e.routes, RoutePattern{
-			Method: "ALL",
-			Path:   path,
-			File:   filePath,
-			Line:   lineNum,
-		})
+
+		end := e.urlPatternCall.consume(rest)
+		if end < 0 {
+			return true
+		}
+
+		e.flushURLPattern()
+		rest = rest[end:]
+	}
+}
+
+// flushURLPattern emits the route declared by the buffered URLPattern call. It
+// is also called at the end of a file, which may end (or be truncated at
+// MaxJSFileScanBytes) while a call is still open.
+func (e *RouteExtractor) flushURLPattern() {
+	call := e.urlPatternCall
+	if call == nil {
+		return
+	}
+	e.urlPatternCall = nil
+
+	path := e.urlPatternPath(call.args.String())
+	if path == "" {
+		return
 	}
 
-	for _, constructor := range constructors {
-		e.inURLPattern = true
-		addRoute(urlPatternPathname(constructor[1]))
+	// URLPattern declares no method, so the route applies to all of them
+	e.routes = append(e.routes, RoutePattern{
+		Method: "ALL",
+		Path:   path,
+		File:   call.file,
+		Line:   call.line,
+	})
+}
+
+// urlPatternPath returns the route declared by the arguments of a URLPattern
+// call. Only the first argument holds the pattern, either as an init object
+// with a pathname member or as a pattern string; the second one is a base URL
+// or an options object. Any other argument shape (a variable, a spread) is not
+// statically resolvable.
+func (e *RouteExtractor) urlPatternPath(args string) string {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return ""
 	}
 
-	for _, pathname := range e.patterns.URLPatternPathname.FindAllStringSubmatch(line, -1) {
-		addRoute(ensureLeadingSlash(pathname[1]))
+	if args[0] == '{' {
+		pathname := e.patterns.URLPatternPathname.FindStringSubmatch(args)
+		if pathname == nil || pathname[1] == "" {
+			return ""
+		}
+		return ensureLeadingSlash(pathname[1])
 	}
 
-	if strings.Contains(line, ")") {
-		e.inURLPattern = false
+	if isJSQuote(args[0]) {
+		if pattern := e.patterns.QuotedString.FindStringSubmatch(args); pattern != nil {
+			return urlPatternPathname(pattern[1])
+		}
 	}
 
-	return true
+	return ""
 }
 
 func (e *RouteExtractor) handleHTTPDispatcher(filePath, line string, lineNum int) bool {
@@ -936,7 +1034,7 @@ func (e *RouteExtractor) scanFile(filePath string) error {
 	e.pendingNestVersions = nil
 	e.pendingNestMethod = nil
 	e.inEnableVersioning = false
-	e.inURLPattern = false
+	e.urlPatternCall = nil
 
 	for scanner.Scan() {
 		lineNum++
@@ -1050,8 +1148,10 @@ func (e *RouteExtractor) scanFile(filePath string) error {
 		save = line
 	}
 
-	// the file may end while a method decorator stack is still buffered
+	// the file may end while a method decorator stack or a URLPattern call is
+	// still buffered
 	e.flushNestMethod()
+	e.flushURLPattern()
 
 	if err := scanner.Err(); err != nil {
 		return err

--- a/pkg/internal/transform/route/harvest/js.go
+++ b/pkg/internal/transform/route/harvest/js.go
@@ -224,7 +224,10 @@ func newFrameworkPatterns() *FrameworkPatterns {
 		//   new URLPattern("https://example.com/books/:id")
 		//   new URLPattern({ pathname: "/books/:id" })
 		//   new urlpattern.URLPattern("/books/:id", base)
-		URLPattern: regexp.MustCompile(`URLPattern\s*\(`),
+		// The 'new' operator and the optional namespace are required, so that a
+		// helper whose name ends in URLPattern (createURLPattern(...)) is not
+		// taken for the standard constructor.
+		URLPattern: regexp.MustCompile(`\bnew\s+(?:[\w$]+\s*\.\s*)*URLPattern\s*\(`),
 
 		// Matches the 'pathname' member of a URLPattern init object in every
 		// legal property key form: pathname, 'pathname', ["pathname"]
@@ -703,13 +706,16 @@ func sortRouteFragments(fragments []string) {
 	})
 }
 
-// urlPatternPathname returns the pathname part of the string form of a
+// urlPatternPathname returns the pathname component of the string form of a
 // URLPattern, which may be a full URL pattern or a path relative to the
 // constructor's baseURL argument.
-func urlPatternPathname(pattern string) string {
+func urlPatternPathname(pattern, base string) string {
 	if pattern == "" {
 		return ""
 	}
+
+	pattern = pattern[:urlPatternPathnameEnd(pattern)]
+
 	if _, authority, hasScheme := strings.Cut(pattern, "://"); hasScheme {
 		_, path, hasPath := strings.Cut(authority, "/")
 		if !hasPath {
@@ -717,7 +723,110 @@ func urlPatternPathname(pattern string) string {
 		}
 		return "/" + path
 	}
-	return ensureLeadingSlash(pattern)
+
+	return resolveURLPatternPathname(pattern, base)
+}
+
+// urlPatternPathnameEnd returns the offset at which the pathname of a
+// URLPattern string ends: the first '?' or '#' that opens the search or hash
+// component. A bare '?' following a named group, a group or a wildcard is the
+// optional modifier of that token and belongs to the pathname, which is why an
+// escaped '\?' is the way to open a search component after one of them.
+func urlPatternPathnameEnd(pattern string) int {
+	// whether a '?' at the current offset would be the optional modifier of
+	// the token just read instead of the start of the search component
+	modifier := false
+
+	for i := 0; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '\\':
+			if i+1 < len(pattern) && (pattern[i+1] == '?' || pattern[i+1] == '#') {
+				return i
+			}
+			i++
+			modifier = false
+		case '?':
+			if !modifier {
+				return i
+			}
+			modifier = false
+		case '#':
+			return i
+		case ':':
+			end := endOfURLPatternName(pattern, i)
+			modifier = end > i
+			i = end
+		case '(':
+			i = endOfURLPatternGroup(pattern, i)
+			modifier = true
+		case '}', '*':
+			modifier = true
+		default:
+			modifier = false
+		}
+	}
+
+	return len(pattern)
+}
+
+// endOfURLPatternName returns the offset of the last character of the named
+// group that starts at colon, or colon itself when no name follows it.
+func endOfURLPatternName(pattern string, colon int) int {
+	end := colon
+	for end+1 < len(pattern) && isURLPatternNameChar(pattern[end+1]) {
+		end++
+	}
+	return end
+}
+
+func isURLPatternNameChar(c byte) bool {
+	return c == '_' || c == '$' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// endOfURLPatternGroup returns the offset of the parenthesis closing the group
+// that starts at open, or the last offset of pattern when it does not close.
+func endOfURLPatternGroup(pattern string, open int) int {
+	depth := 0
+	for i := open; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '\\':
+			i++
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return len(pattern) - 1
+}
+
+// resolveURLPatternPathname resolves a relative pathname against the pathname
+// of the constructor's baseURL argument, as the URL Pattern API does.
+func resolveURLPatternPathname(pathname, base string) string {
+	if strings.HasPrefix(pathname, "/") {
+		return pathname
+	}
+
+	// a baseURL must be absolute, so a value without a scheme is not one
+	_, authority, hasScheme := strings.Cut(base, "://")
+	if !hasScheme {
+		return ensureLeadingSlash(pathname)
+	}
+
+	basePath := "/"
+	if _, path, hasPath := strings.Cut(authority, "/"); hasPath {
+		basePath = "/" + path
+	}
+	if end := strings.IndexAny(basePath, "?#"); end >= 0 {
+		basePath = basePath[:end]
+	}
+
+	// a relative pathname replaces the last segment of the base pathname
+	return basePath[:strings.LastIndex(basePath, "/")+1] + pathname
 }
 
 // urlPatternCall buffers the arguments of a URLPattern call while it is being
@@ -834,26 +943,69 @@ func (e *RouteExtractor) flushURLPattern() {
 // or an options object. Any other argument shape (a variable, a spread) is not
 // statically resolvable.
 func (e *RouteExtractor) urlPatternPath(args string) string {
-	args = strings.TrimSpace(args)
-	if args == "" {
+	parsed := splitJSArguments(args)
+	if len(parsed) == 0 || parsed[0] == "" {
 		return ""
 	}
 
-	if args[0] == '{' {
-		pathname := e.patterns.URLPatternPathname.FindStringSubmatch(args)
+	pattern := parsed[0]
+
+	var base string
+	if len(parsed) > 1 {
+		base = jsStringLiteral(parsed[1])
+	}
+
+	if pattern[0] == '{' {
+		pathname := e.patterns.URLPatternPathname.FindStringSubmatch(pattern)
 		if pathname == nil || pathname[1] == "" {
 			return ""
 		}
-		return ensureLeadingSlash(pathname[1])
+		return resolveURLPatternPathname(pathname[1], base)
 	}
 
-	if isJSQuote(args[0]) {
-		if pattern := e.patterns.QuotedString.FindStringSubmatch(args); pattern != nil {
-			return urlPatternPathname(pattern[1])
-		}
+	if isJSQuote(pattern[0]) {
+		return urlPatternPathname(jsStringLiteral(pattern), base)
 	}
 
 	return ""
+}
+
+// splitJSArguments splits an argument list into its top-level arguments.
+// Commas inside a string literal or a nested object, array or call do not
+// separate arguments.
+func splitJSArguments(args string) []string {
+	var (
+		arguments []string
+		depth     int
+		start     int
+	)
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case '\'', '"', '`':
+			i = endOfJSString(args, i)
+		case '{', '[', '(':
+			depth++
+		case '}', ']', ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				arguments = append(arguments, strings.TrimSpace(args[start:i]))
+				start = i + 1
+			}
+		}
+	}
+
+	return append(arguments, strings.TrimSpace(args[start:]))
+}
+
+// jsStringLiteral returns the contents of the string literal that s starts
+// with, or an empty string when s does not start with one.
+func jsStringLiteral(s string) string {
+	if s == "" || !isJSQuote(s[0]) {
+		return ""
+	}
+	return s[1:endOfJSString(s, 0)]
 }
 
 func (e *RouteExtractor) handleHTTPDispatcher(filePath, line string, lineNum int) bool {

--- a/pkg/internal/transform/route/harvest/js.go
+++ b/pkg/internal/transform/route/harvest/js.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -129,8 +130,10 @@ type FrameworkPatterns struct {
 	HTTPDispatcher *regexp.Regexp
 	// URLPattern: new URLPattern({ pathname: "/users/:id" });
 	URLPattern *regexp.Regexp
-	// 'pathname' member of a URLPattern init object
+	// key of the 'pathname' member of a URLPattern init object
 	URLPatternPathname *regexp.Regexp
+	// key of the 'baseURL' member of a URLPattern init object
+	URLPatternBaseURL *regexp.Regexp
 	// Fallback
 	Fallback *regexp.Regexp
 
@@ -229,10 +232,10 @@ func newFrameworkPatterns() *FrameworkPatterns {
 		// taken for the standard constructor.
 		URLPattern: regexp.MustCompile(`\bnew\s+(?:[\w$]+\s*\.\s*)*URLPattern\s*\(`),
 
-		// Matches the 'pathname' member of a URLPattern init object in every
-		// legal property key form: pathname, 'pathname', ["pathname"]
-		URLPatternPathname: regexp.MustCompile(
-			`(?:pathname|['"]pathname['"]|\[\s*['"\x60]pathname['"\x60]\s*\])\s*:\s*['"\x60]([^'"\x60]*)['"\x60]`),
+		// Match the key of a URLPattern init object member, so that its value
+		// can be read from the source that follows
+		URLPatternPathname: jsObjectKeyPattern("pathname"),
+		URLPatternBaseURL:  jsObjectKeyPattern("baseURL"),
 
 		// Fallback (e.g. NextJS)
 		Fallback: regexp.MustCompile(`['"\x60](/[^'"\x60]+)['"\x60]`),
@@ -709,7 +712,7 @@ func sortRouteFragments(fragments []string) {
 // urlPatternPathname returns the pathname component of the string form of a
 // URLPattern, which may be a full URL pattern or a path relative to the
 // constructor's baseURL argument.
-func urlPatternPathname(pattern, base string) string {
+func urlPatternPathname(pattern string, base urlPatternBase) string {
 	if pattern == "" {
 		return ""
 	}
@@ -804,29 +807,36 @@ func endOfURLPatternGroup(pattern string, open int) int {
 	return len(pattern) - 1
 }
 
+// urlPatternBase is the base URL a relative pathname is resolved against. A
+// base that is declared by the call but is not a string literal leaves the
+// resulting pathname unknown, which a zero url with declared set represents.
+type urlPatternBase struct {
+	url      string
+	declared bool
+}
+
 // resolveURLPatternPathname resolves a relative pathname against the pathname
-// of the constructor's baseURL argument, as the URL Pattern API does.
-func resolveURLPatternPathname(pathname, base string) string {
+// of the base URL, as the URL Pattern API does. It returns an empty string when
+// the base is declared but is not statically resolvable, as the pathname the
+// call ends up with is then unknown.
+func resolveURLPatternPathname(pathname string, base urlPatternBase) string {
 	if strings.HasPrefix(pathname, "/") {
 		return pathname
 	}
 
-	// a baseURL must be absolute, so a value without a scheme is not one
-	_, authority, hasScheme := strings.Cut(base, "://")
-	if !hasScheme {
+	if !base.declared {
 		return ensureLeadingSlash(pathname)
 	}
 
-	basePath := "/"
-	if _, path, hasPath := strings.Cut(authority, "/"); hasPath {
-		basePath = "/" + path
-	}
-	if end := strings.IndexAny(basePath, "?#"); end >= 0 {
-		basePath = basePath[:end]
+	// a base URL must be absolute, so anything else is not statically resolvable
+	baseURL, err := url.Parse(base.url)
+	if err != nil || !baseURL.IsAbs() {
+		return ""
 	}
 
-	// a relative pathname replaces the last segment of the base pathname
-	return basePath[:strings.LastIndex(basePath, "/")+1] + pathname
+	// the pathname is escaped and unescaped back by the resolution, so the
+	// pattern syntax it holds survives it unchanged
+	return baseURL.ResolveReference(&url.URL{Path: pathname}).Path
 }
 
 // urlPatternCall buffers the arguments of a URLPattern call while it is being
@@ -939,9 +949,8 @@ func (e *RouteExtractor) flushURLPattern() {
 
 // urlPatternPath returns the route declared by the arguments of a URLPattern
 // call. Only the first argument holds the pattern, either as an init object
-// with a pathname member or as a pattern string; the second one is a base URL
-// or an options object. Any other argument shape (a variable, a spread) is not
-// statically resolvable.
+// with a pathname member or as a pattern string. Any other argument shape (a
+// variable, a spread) is not statically resolvable.
 func (e *RouteExtractor) urlPatternPath(args string) string {
 	parsed := splitJSArguments(args)
 	if len(parsed) == 0 || parsed[0] == "" {
@@ -950,24 +959,42 @@ func (e *RouteExtractor) urlPatternPath(args string) string {
 
 	pattern := parsed[0]
 
-	var base string
-	if len(parsed) > 1 {
-		base = jsStringLiteral(parsed[1])
-	}
-
 	if pattern[0] == '{' {
-		pathname := e.patterns.URLPatternPathname.FindStringSubmatch(pattern)
-		if pathname == nil || pathname[1] == "" {
-			return ""
-		}
-		return resolveURLPatternPathname(pathname[1], base)
+		return e.urlPatternInitPath(pattern)
 	}
 
 	if isJSQuote(pattern[0]) {
-		return urlPatternPathname(jsStringLiteral(pattern), base)
+		return urlPatternPathname(jsStringLiteral(pattern), stringURLPatternBase(parsed))
 	}
 
 	return ""
+}
+
+// urlPatternInitPath returns the route declared by the init object form of a
+// URLPattern call. This overload takes its base URL as the baseURL member of
+// the init object, its second argument being the options of the call.
+func (e *RouteExtractor) urlPatternInitPath(init string) string {
+	pathname := jsStringLiteral(jsObjectMemberValue(init, e.patterns.URLPatternPathname))
+	if pathname == "" {
+		return ""
+	}
+
+	var base urlPatternBase
+	if baseURL := jsObjectMemberValue(init, e.patterns.URLPatternBaseURL); baseURL != "" {
+		base = urlPatternBase{url: jsStringLiteral(baseURL), declared: true}
+	}
+
+	return resolveURLPatternPathname(pathname, base)
+}
+
+// stringURLPatternBase returns the base URL of the string form of a URLPattern
+// call, whose second argument is either a base URL or the options of the call.
+func stringURLPatternBase(args []string) urlPatternBase {
+	if len(args) < 2 || args[1] == "" || args[1][0] == '{' {
+		return urlPatternBase{}
+	}
+
+	return urlPatternBase{url: jsStringLiteral(args[1]), declared: true}
 }
 
 // splitJSArguments splits an argument list into its top-level arguments.
@@ -999,13 +1026,87 @@ func splitJSArguments(args string) []string {
 	return append(arguments, strings.TrimSpace(args[start:]))
 }
 
-// jsStringLiteral returns the contents of the string literal that s starts
-// with, or an empty string when s does not start with one.
+// jsStringLiteral returns the contents of s when the whole of it is a single
+// string literal, and an empty string otherwise. A literal that only prefixes a
+// larger expression ("/books/" + segment) or a template with an interpolation
+// is not statically resolvable, as the value it ends up with is unknown.
 func jsStringLiteral(s string) string {
 	if s == "" || !isJSQuote(s[0]) {
 		return ""
 	}
-	return s[1:endOfJSString(s, 0)]
+
+	end := endOfJSString(s, 0)
+	if end != len(s)-1 {
+		return ""
+	}
+
+	contents := s[1:end]
+	if s[0] == '`' && hasJSInterpolation(contents) {
+		return ""
+	}
+
+	return contents
+}
+
+// hasJSInterpolation reports whether the contents of a template literal hold a
+// substitution.
+func hasJSInterpolation(contents string) bool {
+	for i := 0; i+1 < len(contents); i++ {
+		switch contents[i] {
+		case '\\':
+			i++
+		case '$':
+			if contents[i+1] == '{' {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// jsObjectKeyPattern matches the key of the named member of an object literal
+// in every legal property key form: name, 'name', ["name"]. The value of the
+// member is the source that follows the match.
+func jsObjectKeyPattern(name string) *regexp.Regexp {
+	return regexp.MustCompile(
+		`(?:\b` + name + `|['"]` + name + `['"]|\[\s*['"\x60]` + name + `['"\x60]\s*\])\s*:\s*`)
+}
+
+// jsObjectMemberValue returns the source of the value of the object literal
+// member whose key matches key, or an empty string when there is no such
+// member. The value ends at the comma separating it from the next member or at
+// the closing brace of the object.
+func jsObjectMemberValue(object string, key *regexp.Regexp) string {
+	loc := key.FindStringIndex(object)
+	if loc == nil {
+		return ""
+	}
+
+	value := object[loc[1]:]
+
+	depth := 0
+	for i := 0; i < len(value); i++ {
+		switch value[i] {
+		case '\'', '"', '`':
+			i = endOfJSString(value, i)
+		case '{', '[', '(':
+			depth++
+		case ']', ')':
+			depth--
+		case '}':
+			if depth == 0 {
+				return strings.TrimSpace(value[:i])
+			}
+			depth--
+		case ',':
+			if depth == 0 {
+				return strings.TrimSpace(value[:i])
+			}
+		}
+	}
+
+	return strings.TrimSpace(value)
 }
 
 func (e *RouteExtractor) handleHTTPDispatcher(filePath, line string, lineNum int) bool {

--- a/pkg/internal/transform/route/harvest/js.go
+++ b/pkg/internal/transform/route/harvest/js.go
@@ -127,6 +127,10 @@ type FrameworkPatterns struct {
 	QuotedString *regexp.Regexp
 	// HTTPDispatcher: dispatcher.onGet('/path', ...), dispatcher.onPost(/^\/ratings\/[0-9]*/, ...)
 	HTTPDispatcher *regexp.Regexp
+	// URLPattern: new URLPattern({ pathname: "/users/:id" });
+	URLPattern *regexp.Regexp
+	// 'pathname' member of a URLPattern init object
+	URLPatternPathname *regexp.Regexp
 	// Fallback
 	Fallback *regexp.Regexp
 
@@ -213,6 +217,19 @@ func newFrameworkPatterns() *FrameworkPatterns {
 		// Supports both string literals and regex literals
 		HTTPDispatcher: regexp.MustCompile(`\.on(Get|Post|Put|Patch|Delete|Head|Options|All)\s*\(\s*(?:['"\x60]([^'"\x60]+)['"\x60]|/((?:[^\\,]|\\.)+))`),
 
+		// URLPattern WEB API. The constructor takes the pattern either as a
+		// string or as an init object, optionally through a namespace object:
+		//   new URLPattern("https://example.com/books/:id")
+		//   new URLPattern({ pathname: "/books/:id" })
+		//   new urlpattern.URLPattern("/books/:id", base)
+		// \s covers the line breaks of a call spread over several lines.
+		URLPattern: regexp.MustCompile(`URLPattern\s*\(\s*(?:['"\x60]([^'"\x60]*)['"\x60])?`),
+
+		// Matches the 'pathname' member of a URLPattern init object in every
+		// legal property key form: pathname, 'pathname', ["pathname"]
+		URLPatternPathname: regexp.MustCompile(
+			`(?:pathname|['"]pathname['"]|\[\s*['"\x60]pathname['"\x60]\s*\])\s*:\s*['"\x60]([^'"\x60]*)['"\x60]`),
+
 		// Fallback (e.g. NextJS)
 		Fallback: regexp.MustCompile(`['"\x60](/[^'"\x60]+)['"\x60]`),
 
@@ -254,6 +271,9 @@ type RouteExtractor struct {
 	// enableVersioningTypeSeen tracks whether the current enableVersioning call
 	// named an explicit VersioningType (URI is NestJS's default when it didn't)
 	enableVersioningTypeSeen bool
+	// inURLPattern tracks a new URLPattern({...}) call whose init object spans
+	// several lines, until its closing parenthesis
+	inURLPattern bool
 
 	// application-level NestJS settings, harvested from any scanned file
 	// (typically main.ts) and applied to Nest routes after the scan
@@ -682,6 +702,62 @@ func sortRouteFragments(fragments []string) {
 	})
 }
 
+// urlPatternPathname returns the pathname part of the string form of a
+// URLPattern, which may be a full URL pattern or a path relative to the
+// constructor's baseURL argument.
+func urlPatternPathname(pattern string) string {
+	if pattern == "" {
+		return ""
+	}
+	if _, authority, hasScheme := strings.Cut(pattern, "://"); hasScheme {
+		_, path, hasPath := strings.Cut(authority, "/")
+		if !hasPath {
+			return ""
+		}
+		return "/" + path
+	}
+	return ensureLeadingSlash(pattern)
+}
+
+// handleURLPattern harvests routes declared through the URL Pattern API. The
+// pattern comes either as a string argument or as an init object holding a
+// 'pathname' member. The init object may be spread over several lines, so the
+// call is tracked until its closing parenthesis. No method is declared, so the
+// route applies to all of them.
+func (e *RouteExtractor) handleURLPattern(filePath, line string, lineNum int) bool {
+	constructors := e.patterns.URLPattern.FindAllStringSubmatch(line, -1)
+	if constructors == nil && !e.inURLPattern {
+		return false
+	}
+
+	addRoute := func(path string) {
+		if path == "" {
+			return
+		}
+		e.routes = append(e.routes, RoutePattern{
+			Method: "ALL",
+			Path:   path,
+			File:   filePath,
+			Line:   lineNum,
+		})
+	}
+
+	for _, constructor := range constructors {
+		e.inURLPattern = true
+		addRoute(urlPatternPathname(constructor[1]))
+	}
+
+	for _, pathname := range e.patterns.URLPatternPathname.FindAllStringSubmatch(line, -1) {
+		addRoute(ensureLeadingSlash(pathname[1]))
+	}
+
+	if strings.Contains(line, ")") {
+		e.inURLPattern = false
+	}
+
+	return true
+}
+
 func (e *RouteExtractor) handleHTTPDispatcher(filePath, line string, lineNum int) bool {
 	if matches := e.patterns.HTTPDispatcher.FindStringSubmatch(line); len(matches) > 2 {
 		method := strings.ToUpper(matches[1])
@@ -860,6 +936,7 @@ func (e *RouteExtractor) scanFile(filePath string) error {
 	e.pendingNestVersions = nil
 	e.pendingNestMethod = nil
 	e.inEnableVersioning = false
+	e.inURLPattern = false
 
 	for scanner.Scan() {
 		lineNum++
@@ -952,6 +1029,11 @@ func (e *RouteExtractor) scanFile(filePath string) error {
 			if e.handleNestJS(filePath, line, lineNum) {
 				continue
 			}
+		}
+
+		// URL Pattern web API
+		if e.handleURLPattern(filePath, line, lineNum) {
+			continue
 		}
 
 		// HttpDispatcher

--- a/pkg/internal/transform/route/harvest/js_test.go
+++ b/pkg/internal/transform/route/harvest/js_test.go
@@ -957,6 +957,41 @@ func TestHandleURLPattern(t *testing.T) {
 			paths: []string{"/books/:id"},
 		},
 		{
+			name:  "string pattern with search and hash components",
+			lines: []string{`  new URLPattern("https://example.com/books/:id\?view=:view#details")`},
+			paths: []string{"/books/:id"},
+		},
+		{
+			name:  "string pattern with a hash component",
+			lines: []string{`  new URLPattern("https://example.com/books/:id#details")`},
+			paths: []string{"/books/:id"},
+		},
+		{
+			name:  "optional modifier is not a search component",
+			lines: []string{`  new URLPattern("https://(sub.)?example.com/books/:id?")`},
+			paths: []string{"/books/:id?"},
+		},
+		{
+			name:  "relative string pattern resolved against the base URL path",
+			lines: []string{`  new URLPattern("books/:id", "https://example.com/api/")`},
+			paths: []string{"/api/books/:id"},
+		},
+		{
+			name:  "relative string pattern replaces the last base URL segment",
+			lines: []string{`  new URLPattern("books/:id", "https://example.com/api")`},
+			paths: []string{"/books/:id"},
+		},
+		{
+			name:  "relative init pathname resolved against the base URL path",
+			lines: []string{`  new URLPattern({ pathname: "books/:id" }, "https://example.com/api/")`},
+			paths: []string{"/api/books/:id"},
+		},
+		{
+			name:  "relative string pattern with no base URL",
+			lines: []string{`  new URLPattern("books/:id")`},
+			paths: []string{"/books/:id"},
+		},
+		{
 			name: "string pattern spread over several lines",
 			lines: []string{
 				`const pattern = new URLPattern(`,
@@ -1025,6 +1060,14 @@ func TestHandleURLPattern(t *testing.T) {
 		{
 			name:  "not a URLPattern",
 			lines: []string{`  const url = new URL("/users/1", base);`},
+		},
+		{
+			name:  "helper whose name ends in URLPattern",
+			lines: []string{`  const pattern = createURLPattern("/not-a-route");`},
+		},
+		{
+			name:  "constructor of a type whose name ends in URLPattern",
+			lines: []string{`  const pattern = new MyURLPattern("/not-a-route");`},
 		},
 	}
 

--- a/pkg/internal/transform/route/harvest/js_test.go
+++ b/pkg/internal/transform/route/harvest/js_test.go
@@ -894,6 +894,105 @@ func TestHandleHTTPDispatcher(t *testing.T) {
 	}
 }
 
+func TestHandleURLPattern(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		paths []string
+	}{
+		{
+			name:  "init object with double quotes",
+			lines: []string{`  const userURL = new URLPattern({ pathname: "/users/:id" });`},
+			paths: []string{"/users/:id"},
+		},
+		{
+			name:  "init object with single quotes",
+			lines: []string{`  new URLPattern({pathname: '/books/:id'})`},
+			paths: []string{"/books/:id"},
+		},
+		{
+			name:  "init object with backticks",
+			lines: []string{"  new URLPattern({ pathname: `/books/:id/pages` })"},
+			paths: []string{"/books/:id/pages"},
+		},
+		{
+			name:  "quoted property key",
+			lines: []string{`  new URLPattern({ "pathname": "/users/:id" })`},
+			paths: []string{"/users/:id"},
+		},
+		{
+			name:  "computed property key",
+			lines: []string{`  new URLPattern({ ["pathname"]: "/users/:id" })`},
+			paths: []string{"/users/:id"},
+		},
+		{
+			name: "init object spread over several lines",
+			lines: []string{
+				`const pattern = new URLPattern({`,
+				`  protocol: "https",`,
+				`  hostname: "example.com",`,
+				`  pathname: "/books/:id",`,
+				`});`,
+			},
+			paths: []string{"/books/:id"},
+		},
+		{
+			name:  "spaces around the constructor call",
+			lines: []string{`  new   URLPattern (  { pathname : "/users/:id" } )`},
+			paths: []string{"/users/:id"},
+		},
+		{
+			name:  "namespaced constructor",
+			lines: []string{`  new urlpattern.URLPattern({ pathname: "/users/:id" })`},
+			paths: []string{"/users/:id"},
+		},
+		{
+			name:  "string pattern with origin",
+			lines: []string{`  new URLPattern("https://example.com/books/:id")`},
+			paths: []string{"/books/:id"},
+		},
+		{
+			name:  "string pattern relative to a base URL",
+			lines: []string{`  new URLPattern("/books/:id", "https://example.com")`},
+			paths: []string{"/books/:id"},
+		},
+		{
+			name:  "string pattern with origin and no path",
+			lines: []string{`  new URLPattern("https://example.com")`},
+		},
+		{
+			name:  "two patterns in the same line",
+			lines: []string{`  [new URLPattern({pathname: "/a/:id"}), new URLPattern({pathname: "/b/:id"})]`},
+			paths: []string{"/a/:id", "/b/:id"},
+		},
+		{
+			name:  "pathname outside a URLPattern call",
+			lines: []string{`  const { pathname: "/users/:id" } = parsed;`},
+		},
+		{
+			name:  "not a URLPattern",
+			lines: []string{`  const url = new URL("/users/1", base);`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extractor := NewRouteExtractor()
+			for i, line := range tt.lines {
+				extractor.handleURLPattern("test.js", line, i+1)
+			}
+
+			var paths []string
+			for _, r := range extractor.routes {
+				assert.Equal(t, "ALL", r.Method)
+				assert.Equal(t, "test.js", r.File)
+				paths = append(paths, r.Path)
+			}
+			assert.Equal(t, tt.paths, paths)
+		})
+	}
+}
+
 func TestCleanupRegexPath(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/internal/transform/route/harvest/js_test.go
+++ b/pkg/internal/transform/route/harvest/js_test.go
@@ -982,14 +982,52 @@ func TestHandleURLPattern(t *testing.T) {
 			paths: []string{"/books/:id"},
 		},
 		{
-			name:  "relative init pathname resolved against the base URL path",
-			lines: []string{`  new URLPattern({ pathname: "books/:id" }, "https://example.com/api/")`},
+			name:  "relative string pattern with dot segments",
+			lines: []string{`  new URLPattern("../books/:id", "https://example.com/api/v1/")`},
 			paths: []string{"/api/books/:id"},
+		},
+		{
+			// the base is only known at runtime, so neither is the pathname
+			name:  "relative string pattern with a non-literal base URL",
+			lines: []string{`  new URLPattern("books/:id", base)`},
+		},
+		{
+			name:  "absolute string pattern with a non-literal base URL",
+			lines: []string{`  new URLPattern("/books/:id", base)`},
+			paths: []string{"/books/:id"},
+		},
+		{
+			name:  "relative init pathname resolved against the baseURL member",
+			lines: []string{`  new URLPattern({ pathname: "books/:id", baseURL: "https://example.com/api/" })`},
+			paths: []string{"/api/books/:id"},
+		},
+		{
+			name:  "relative init pathname with a non-literal baseURL member",
+			lines: []string{`  new URLPattern({ pathname: "books/:id", baseURL: base })`},
+		},
+		{
+			// the second argument of the object overload holds the options of
+			// the call, not its base URL
+			name:  "second argument of the object form is not a base URL",
+			lines: []string{`  new URLPattern({ pathname: "books/:id" }, { ignoreCase: true })`},
+			paths: []string{"/books/:id"},
 		},
 		{
 			name:  "relative string pattern with no base URL",
 			lines: []string{`  new URLPattern("books/:id")`},
 			paths: []string{"/books/:id"},
+		},
+		{
+			name:  "string pattern concatenated with an expression",
+			lines: []string{`  new URLPattern("/books/" + segment, "https://example.com")`},
+		},
+		{
+			name:  "init pathname concatenated with an expression",
+			lines: []string{`  new URLPattern({ pathname: "/books/" + segment })`},
+		},
+		{
+			name:  "template pattern with an interpolation",
+			lines: []string{"  new URLPattern(`/books/${segment}`)"},
 		},
 		{
 			name: "string pattern spread over several lines",

--- a/pkg/internal/transform/route/harvest/js_test.go
+++ b/pkg/internal/transform/route/harvest/js_test.go
@@ -957,6 +957,59 @@ func TestHandleURLPattern(t *testing.T) {
 			paths: []string{"/books/:id"},
 		},
 		{
+			name: "string pattern spread over several lines",
+			lines: []string{
+				`const pattern = new URLPattern(`,
+				`  "/books/:id",`,
+				`  base,`,
+				`)`,
+			},
+			paths: []string{"/books/:id"},
+		},
+		{
+			name: "parentheses of a component pattern do not close the call",
+			lines: []string{
+				`const pattern = new URLPattern({`,
+				`  protocol: "(https?)",`,
+				`  hostname: "(sub.)?example.com",`,
+				`  pathname: "/books/:id",`,
+				`});`,
+			},
+			paths: []string{"/books/:id"},
+		},
+		{
+			name: "unbalanced parenthesis inside a string does not swallow the call",
+			lines: []string{
+				`const pattern = new URLPattern({`,
+				`  search: "?q=\\(",`,
+				`  pathname: "/books/:id",`,
+				`});`,
+				`router.use(middleware);`,
+			},
+			paths: []string{"/books/:id"},
+		},
+		{
+			name:  "regexp group in the pathname",
+			lines: []string{`  new URLPattern({ pathname: "/books/:id(\\d+)" })`},
+			paths: []string{`/books/:id(\\d+)`},
+		},
+		{
+			name:  "base URL is not the pattern",
+			lines: []string{`  new URLPattern(init, "https://example.com/base/")`},
+		},
+		{
+			name:  "options object is not the pattern",
+			lines: []string{`  new URLPattern(init, { ignoreCase: true })`},
+		},
+		{
+			name: "file ends before the call closes",
+			lines: []string{
+				`const pattern = new URLPattern({`,
+				`  pathname: "/books/:id",`,
+			},
+			paths: []string{"/books/:id"},
+		},
+		{
 			name:  "string pattern with origin and no path",
 			lines: []string{`  new URLPattern("https://example.com")`},
 		},
@@ -981,16 +1034,46 @@ func TestHandleURLPattern(t *testing.T) {
 			for i, line := range tt.lines {
 				extractor.handleURLPattern("test.js", line, i+1)
 			}
+			// a file may end while a call is still open, as scanFile does
+			extractor.flushURLPattern()
 
 			var paths []string
 			for _, r := range extractor.routes {
 				assert.Equal(t, "ALL", r.Method)
 				assert.Equal(t, "test.js", r.File)
+				// the route is anchored at the line the call opens on
+				assert.Equal(t, 1, r.Line)
 				paths = append(paths, r.Path)
 			}
 			assert.Equal(t, tt.paths, paths)
 		})
 	}
+}
+
+// URLPattern calls spread over several lines must be harvested as framework
+// routes: as fallback guesses they would be discarded in favor of the partial
+// fragments of any compiled output.
+func TestRouteExtractorURLPatternMultiLineCall(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "urlpattern.js")
+	content := `const books = new URLPattern(
+  "/books/:id",
+  base,
+);
+
+const users = new URLPattern({
+  protocol: "(https?)",
+  pathname: "/users/:id",
+});
+
+export default { books, users };
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	extractor := NewRouteExtractor()
+	require.NoError(t, extractor.scanFile(path))
+
+	assert.ElementsMatch(t, []string{"/books/:id", "/users/:id"}, extractor.GetHarvestedRoutes())
+	assert.Equal(t, 2, extractor.FrameworkRoutes())
 }
 
 func TestCleanupRegexPath(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds support for the standard URL Pattern API in the JS Route harvester: https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
