### PR TITLE
Limit NestJS route harvesting expansion

### DIFF
--- a/pkg/internal/transform/route/harvest/js.go
+++ b/pkg/internal/transform/route/harvest/js.go
@@ -252,8 +252,9 @@ type RouteExtractor struct {
 	// (@Version() may appear above or below @Get()), so the route is emitted
 	// only when the stack ends: at the first non-decorator line, the next
 	// method or controller decorator, or the end of the file.
-	pendingNestMethod *RoutePattern
-	nestRouteVariants int
+	pendingNestMethod    *RoutePattern
+	nestRouteVariants    int
+	nestRouteLimitLogged bool
 	// inEnableVersioning tracks a multi-line app.enableVersioning({...}) call
 	// until its closing parenthesis
 	inEnableVersioning bool
@@ -435,6 +436,12 @@ func (e *RouteExtractor) flushNestMethod() {
 
 func (e *RouteExtractor) appendNestRoute(route RoutePattern) bool {
 	if e.nestRouteVariants >= maxNestRouteVariants {
+		if !e.nestRouteLimitLogged {
+			e.log.Debug("nestjs route variant limit reached",
+				"file", route.File,
+				"limit", maxNestRouteVariants)
+			e.nestRouteLimitLogged = true
+		}
 		return false
 	}
 

--- a/pkg/internal/transform/route/harvest/js.go
+++ b/pkg/internal/transform/route/harvest/js.go
@@ -24,6 +24,11 @@ import (
 // unbounded work on large application files.
 const MaxJSFileScanBytes int64 = 10 * 1024 * 1024
 
+const (
+	maxNestDecoratorValues = 64
+	maxNestRouteVariants   = 256
+)
+
 // /root is purposefully missing, since we need it to star the file walk
 // we skip later any root directories we find that don't match our original
 // path
@@ -248,6 +253,7 @@ type RouteExtractor struct {
 	// only when the stack ends: at the first non-decorator line, the next
 	// method or controller decorator, or the end of the file.
 	pendingNestMethod *RoutePattern
+	nestRouteVariants int
 	// inEnableVersioning tracks a multi-line app.enableVersioning({...}) call
 	// until its closing parenthesis
 	inEnableVersioning bool
@@ -366,7 +372,7 @@ func (e *RouteExtractor) handleRestify(filePath, line string, lineNum int) bool 
 // quotedStrings returns the contents of every quoted string in s: the single
 // value of 'x' as well as every element of ['x', 'y'].
 func (e *RouteExtractor) quotedStrings(s string) []string {
-	matches := e.patterns.QuotedString.FindAllStringSubmatch(s, -1)
+	matches := e.patterns.QuotedString.FindAllStringSubmatch(s, maxNestDecoratorValues)
 	result := make([]string, 0, len(matches))
 	for _, m := range matches {
 		result = append(result, m[1])
@@ -413,16 +419,28 @@ func (e *RouteExtractor) flushNestMethod() {
 
 	for _, prefix := range prefixes {
 		for _, version := range versions {
-			e.routes = append(e.routes, RoutePattern{
+			if !e.appendNestRoute(RoutePattern{
 				Method:  m.Method,
 				Path:    joinNestPaths(prefix, m.Path),
 				File:    m.File,
 				Line:    m.Line,
 				Nest:    true,
 				Version: version,
-			})
+			}) {
+				return
+			}
 		}
 	}
+}
+
+func (e *RouteExtractor) appendNestRoute(route RoutePattern) bool {
+	if e.nestRouteVariants >= maxNestRouteVariants {
+		return false
+	}
+
+	e.routes = append(e.routes, route)
+	e.nestRouteVariants++
+	return true
 }
 
 func (e *RouteExtractor) handleNestJSController(line string) bool {
@@ -573,7 +591,7 @@ func (e *RouteExtractor) handleNestJS(filePath, line string, lineNum int) bool {
 // declared versions become fragments too (/v2).
 func (e *RouteExtractor) handleCompiledNestController(filePath, line string, lineNum int) bool {
 	addFragment := func(path string) {
-		e.routes = append(e.routes, RoutePattern{
+		e.appendNestRoute(RoutePattern{
 			Method: "ALL",
 			Path:   ensureLeadingSlash(path),
 			File:   filePath,
@@ -617,12 +635,14 @@ func (e *RouteExtractor) handleCompiledNestVersion(filePath, line string, lineNu
 		return false
 	}
 	for _, version := range e.quotedStrings(matches[1]) {
-		e.routes = append(e.routes, RoutePattern{
+		if !e.appendNestRoute(RoutePattern{
 			Method: "ALL",
 			Path:   "/v" + version,
 			File:   filePath,
 			Line:   lineNum,
-		})
+		}) {
+			break
+		}
 	}
 	return true
 }
@@ -637,7 +657,7 @@ func (e *RouteExtractor) handleCompiledNestMethod(filePath, line string, lineNum
 		return false
 	}
 	if matches[2] != "" {
-		e.routes = append(e.routes, RoutePattern{
+		e.appendNestRoute(RoutePattern{
 			Method: strings.ToUpper(matches[1]),
 			Path:   ensureLeadingSlash(matches[2]),
 			File:   filePath,
@@ -859,6 +879,7 @@ func (e *RouteExtractor) scanFile(filePath string) error {
 	e.nestCtrlVersions = nil
 	e.pendingNestVersions = nil
 	e.pendingNestMethod = nil
+	e.nestRouteVariants = 0
 	e.inEnableVersioning = false
 
 	for scanner.Scan() {

--- a/pkg/internal/transform/route/harvest/js_test.go
+++ b/pkg/internal/transform/route/harvest/js_test.go
@@ -4,6 +4,7 @@
 package harvest
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -785,6 +786,69 @@ func TestHandleNestJS(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNestJSQuotedStringsAreBounded(t *testing.T) {
+	extractor := NewRouteExtractor()
+	values := make([]string, maxNestDecoratorValues+1)
+	for i := range values {
+		values[i] = fmt.Sprintf("'route-%d'", i)
+	}
+
+	quoted := extractor.quotedStrings(strings.Join(values, ","))
+
+	require.Len(t, quoted, maxNestDecoratorValues)
+	assert.Equal(t, "route-0", quoted[0])
+	assert.Equal(t, fmt.Sprintf("route-%d", maxNestDecoratorValues-1), quoted[len(quoted)-1])
+}
+
+func TestFlushNestMethodCapsRouteVariants(t *testing.T) {
+	extractor := NewRouteExtractor()
+	extractor.nestPrefixes = make([]string, maxNestRouteVariants)
+	extractor.nestCtrlVersions = []string{"1", "2"}
+	for i := range extractor.nestPrefixes {
+		extractor.nestPrefixes[i] = fmt.Sprintf("prefix-%d", i)
+	}
+	extractor.pendingNestMethod = &RoutePattern{Method: "GET", Path: "item", File: "test.ts", Line: 1}
+
+	extractor.flushNestMethod()
+
+	require.Len(t, extractor.routes, maxNestRouteVariants)
+	assert.Equal(t, "/prefix-0/item", extractor.routes[0].Path)
+	assert.Equal(t, "1", extractor.routes[0].Version)
+	assert.Equal(t, "/prefix-127/item", extractor.routes[len(extractor.routes)-1].Path)
+	assert.Equal(t, "2", extractor.routes[len(extractor.routes)-1].Version)
+
+	extractor.pendingNestMethod = &RoutePattern{Method: "POST", Path: "other", File: "test.ts", Line: 2}
+	extractor.flushNestMethod()
+	require.Len(t, extractor.routes, maxNestRouteVariants)
+}
+
+func TestCompiledNestJSFragmentsAreCappedPerFile(t *testing.T) {
+	values := make([]string, maxNestDecoratorValues)
+	for i := range values {
+		values[i] = fmt.Sprintf("'route-%d'", i)
+	}
+	joinedValues := strings.Join(values, ",")
+
+	controller := NewCompiledRouteExtractor()
+	controllerLine := fmt.Sprintf("(0, common_1.Controller)([%s])", joinedValues)
+	for i := 0; i <= maxNestRouteVariants/maxNestDecoratorValues; i++ {
+		require.True(t, controller.handleCompiledNestController("test.js", controllerLine, i+1))
+	}
+	require.Len(t, controller.routes, maxNestRouteVariants)
+	assert.Equal(t, maxNestRouteVariants, controller.nestRouteVariants)
+
+	version := NewCompiledRouteExtractor()
+	versionLine := fmt.Sprintf("(0, common_1.Version)([%s])", joinedValues)
+	for i := 0; i <= maxNestRouteVariants/maxNestDecoratorValues; i++ {
+		require.True(t, version.handleCompiledNestVersion("test.js", versionLine, i+1))
+	}
+	require.Len(t, version.routes, maxNestRouteVariants)
+	assert.Equal(t, maxNestRouteVariants, version.nestRouteVariants)
+
+	require.True(t, version.handleCompiledNestMethod("test.js", "(0, common_1.Get)('item')", 10))
+	require.Len(t, version.routes, maxNestRouteVariants)
 }
 
 func TestHandleHTTPDispatcher(t *testing.T) {

--- a/pkg/internal/transform/route/harvest/js_test.go
+++ b/pkg/internal/transform/route/harvest/js_test.go
@@ -4,7 +4,9 @@
 package harvest
 
 import (
+	"bytes"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -804,6 +806,8 @@ func TestNestJSQuotedStringsAreBounded(t *testing.T) {
 
 func TestFlushNestMethodCapsRouteVariants(t *testing.T) {
 	extractor := NewRouteExtractor()
+	var logs bytes.Buffer
+	extractor.log = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	extractor.nestPrefixes = make([]string, maxNestRouteVariants)
 	extractor.nestCtrlVersions = []string{"1", "2"}
 	for i := range extractor.nestPrefixes {
@@ -822,6 +826,9 @@ func TestFlushNestMethodCapsRouteVariants(t *testing.T) {
 	extractor.pendingNestMethod = &RoutePattern{Method: "POST", Path: "other", File: "test.ts", Line: 2}
 	extractor.flushNestMethod()
 	require.Len(t, extractor.routes, maxNestRouteVariants)
+	assert.Equal(t, 1, strings.Count(logs.String(), "nestjs route variant limit reached"))
+	assert.Contains(t, logs.String(), "file=test.ts")
+	assert.Contains(t, logs.String(), fmt.Sprintf("limit=%d", maxNestRouteVariants))
 }
 
 func TestCompiledNestJSFragmentsAreCappedPerFile(t *testing.T) {


### PR DESCRIPTION
### Motivation

- Prevent untrusted Node.js source from forcing unbounded work in the route harvester by bounding decorator-array extraction and the controller-prefix/version Cartesian expansion.
- The previous logic could extract unlimited quoted strings and emit an unbounded number of `RoutePattern` entries, enabling a resource exhaustion.

### Description

- Add two constants: `maxNestDecoratorValues = 64` and `maxNestRouteVariants = 256` to bound NestJS decorator processing.
- Limit `quotedStrings` to at most `maxNestDecoratorValues` matches instead of using `-1` for unlimited extraction.
- Cap the number of emitted route variants in `flushNestMethod` to `maxNestRouteVariants` and stop emitting further pairs once the cap is reached.
- Add two unit tests (`TestNestJSQuotedStringsAreBounded`, `TestFlushNestMethodCapsRouteVariants`) that exercise the new bounds.

### Testing
- `go test ./pkg/internal/transform/route/harvest`
