### PR TITLE
Stop caching negative PID filter results

### DIFF
--- a/bpf/pid/pid.h
+++ b/bpf/pid/pid.h
@@ -78,10 +78,6 @@ static __always_inline u32 valid_pid(u64 id) {
                 return a_pid;
             }
         }
-
-        // Cache negative result: PID not in tracked set
-        u32 neg = 0;
-        bpf_map_update_elem(&pid_cache, &a_pid, &neg, BPF_NOEXIST);
     }
 
     return 0;

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -127,7 +127,7 @@ func (p *Tracer) rebuildValidPids() {
 func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 	p.pidsFilter.AllowPID(pid, ns, fi, ebpfcommon.PIDTypeKProbes)
 	p.rebuildValidPids()
-	// Override potential negative cache entry for this PID
+	// Keep the cache consistent with the updated filter.
 	if p.bpfObjects.PidCache != nil {
 		pidU32 := uint32(pid)
 		_ = p.bpfObjects.PidCache.Put(pidU32, pidU32)
@@ -137,7 +137,7 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 func (p *Tracer) BlockPID(pid app.PID, ns uint32) {
 	p.pidsFilter.BlockPID(pid, ns)
 	p.rebuildValidPids()
-	// Remove from cache so next access re-evaluates
+	// Remove from cache so next access re-evaluates.
 	if p.bpfObjects.PidCache != nil {
 		pidU32 := uint32(pid)
 		_ = p.bpfObjects.PidCache.Delete(pidU32)


### PR DESCRIPTION
### Motivation

- Fix a logic bug where negative `pid_cache` entries (value `0`) keyed only by PID could stale-deny processes across PID namespaces or after parent-authorized matches, causing telemetry to be suppressed.
- Ensure PIDs are re-evaluated after filter changes so newly-authorized namespace aliases or parent-authorized children are not incorrectly blocked by a stale negative cache entry.

### Description

- Remove the negative cache write from `valid_pid` in `bpf/pid/pid.h` so only positive matches are stored in `pid_cache` and untracked PIDs are re-evaluated on subsequent calls.
- Keep existing positive `bpf_map_update_elem(&pid_cache, &a_pid, &a_pid, BPF_ANY)` behavior for direct and parent-authorized matches.
- Update comments in `pkg/internal/ebpf/generictracer/generictracer.go` to clarify the tracer-side cache synchronization behavior with the BPF `pid_cache`.

### Testing

- `git diff --check`
- `make clang-format`
- `make compile`
