### PR TITLE
Reject divergent Config v2 signal filters

### DIFF
--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -48,7 +48,7 @@ func V2ToRuntime(src *schema.Extension) (*obi.Config, error) {
 	if err := validateV2RuleSelectorFamilies(src.Capture.Rules); err != nil {
 		return nil, err
 	}
-	if err := validateV2HTTPFilters(src.Capture.Instrumentation.HTTP.Filters); err != nil {
+	if err := validateV2SignalFilters(src); err != nil {
 		return nil, err
 	}
 	if err := validateV2HTTPRoutes(src.Capture.Instrumentation.HTTP.Routes, src.Capture.Rules); err != nil {
@@ -417,14 +417,79 @@ func ruleAffectsV2Selection(rule schema.Rule) bool {
 	return !ruleUsesRegex(rule.Match) || !ruleUsesGlob(rule.Match)
 }
 
-func validateV2HTTPFilters(filters schema.SignalFilters) error {
-	if len(filters.Traces) == 0 || len(filters.Metrics) == 0 {
+func validateV2SignalFilters(src *schema.Extension) error {
+	canonicalPath := "capture.instrumentation.http.filters.traces"
+	canonical := src.Capture.Instrumentation.HTTP.Filters.Traces
+	for _, mapping := range protocolMappings {
+		path := fmt.Sprintf("capture.instrumentation.%s.filters", mapping.name)
+		filters := protocolFilters(src.Capture.Instrumentation, mapping.name)
+		if err := validateSharedAttributeFilters(
+			path+".traces",
+			canonicalPath,
+			"application",
+			filters.Traces,
+			canonical,
+		); err != nil {
+			return err
+		}
+		if err := validateSharedAttributeFilters(
+			path+".metrics",
+			canonicalPath,
+			"application",
+			filters.Metrics,
+			canonical,
+		); err != nil {
+			return err
+		}
+	}
+
+	if err := validateSharedSignalFilters(
+		"capture.network.capture.filters",
+		"network",
+		src.Capture.Network.Capture.Filters,
+	); err != nil {
+		return err
+	}
+	return validateSharedSignalFilters(
+		"capture.network.stats.filters",
+		"network stats",
+		src.Capture.Network.Stats.Filters,
+	)
+}
+
+func validateSharedSignalFilters(path, runtimeFilter string, filters schema.SignalFilters) error {
+	return validateSharedAttributeFilters(
+		path+".metrics",
+		path+".traces",
+		runtimeFilter,
+		filters.Metrics,
+		filters.Traces,
+	)
+}
+
+func validateSharedAttributeFilters(
+	path string,
+	canonicalPath string,
+	runtimeFilter string,
+	filters schema.AttributeFilters,
+	canonical schema.AttributeFilters,
+) error {
+	if attributeFiltersEqual(filters, canonical) {
 		return nil
 	}
-	if reflect.DeepEqual(filters.Traces, filters.Metrics) {
-		return nil
+	return fmt.Errorf(
+		"%s cannot differ from %s because the runtime uses one %s filter",
+		path,
+		canonicalPath,
+		runtimeFilter,
+	)
+}
+
+func attributeFiltersEqual(left, right schema.AttributeFilters) bool {
+	if len(left) == 0 && len(right) == 0 {
+		return true
 	}
-	return errors.New("capture.instrumentation.http.filters: trace and metric filters cannot differ")
+	return reflect.DeepEqual(left, right)
 }
 
 func validateV2HTTPPayloadExtraction(payload schema.PayloadExtraction) error {
@@ -2128,6 +2193,31 @@ func protocolEnablement(instrumentation schema.Instrumentation, name protocolNam
 		return instrumentation.GPU.Enabled
 	default:
 		return schema.ProtocolEnablement{}
+	}
+}
+
+func protocolFilters(instrumentation schema.Instrumentation, name protocolName) schema.SignalFilters {
+	switch name {
+	case protocolHTTP:
+		return instrumentation.HTTP.Filters
+	case protocolGRPC:
+		return instrumentation.GRPC.Filters
+	case protocolSQL:
+		return instrumentation.SQL.Filters
+	case protocolRedis:
+		return instrumentation.Redis.Filters
+	case protocolKafka:
+		return instrumentation.Kafka.Filters
+	case protocolMongo:
+		return instrumentation.Mongo.Filters
+	case protocolCouchbase:
+		return instrumentation.Couchbase.Filters
+	case protocolDNS:
+		return instrumentation.DNS.Filters
+	case protocolGPU:
+		return instrumentation.GPU.Filters
+	default:
+		return schema.SignalFilters{}
 	}
 }
 

--- a/internal/config/convert/import_http_test.go
+++ b/internal/config/convert/import_http_test.go
@@ -398,7 +398,7 @@ func TestV2ToRuntimeHTTPApplicationFiltersRoundTrip(t *testing.T) {
 	require.Equal(t, cfg.Filters.Application, got.Filters.Application)
 }
 
-func TestV2ToRuntimeHTTPApplicationFiltersImportsOneSignal(t *testing.T) {
+func TestV2ToRuntimeHTTPApplicationFiltersRejectsOneSignal(t *testing.T) {
 	t.Parallel()
 
 	statusCode := 500
@@ -407,7 +407,7 @@ func TestV2ToRuntimeHTTPApplicationFiltersImportsOneSignal(t *testing.T) {
 		"service.name":     {Match: "checkout-*"},
 	}
 
-	got, err := V2ToRuntime(&schema.Extension{
+	_, err := V2ToRuntime(&schema.Extension{
 		Version: schema.SupportedVersion,
 		Capture: schema.Capture{
 			Instrumentation: schema.Instrumentation{
@@ -419,12 +419,12 @@ func TestV2ToRuntimeHTTPApplicationFiltersImportsOneSignal(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
-
-	require.Equal(t, filter.AttributeFamilyConfig{
-		"http.status_code": {Equals: &statusCode},
-		"service.name":     {Match: "checkout-*"},
-	}, got.Filters.Application)
+	require.ErrorContains(
+		t,
+		err,
+		"capture.instrumentation.http.filters.metrics cannot differ from "+
+			"capture.instrumentation.http.filters.traces",
+	)
 }
 
 func TestV2ToRuntimeHTTPApplicationFiltersRejectsConflictingSignals(t *testing.T) {
@@ -450,6 +450,28 @@ func TestV2ToRuntimeHTTPApplicationFiltersRejectsConflictingSignals(t *testing.T
 	})
 
 	require.ErrorContains(t, err, "capture.instrumentation.http.filters")
+}
+
+func TestV2ToRuntimeRejectsDivergentProtocolFilters(t *testing.T) {
+	t.Parallel()
+
+	statusCode := 500
+	cfg := defaultRuntimeConfig()
+	cfg.Filters.Application = filter.AttributeFamilyConfig{
+		"http.status_code": {Equals: &statusCode},
+	}
+	_, ext := RuntimeToV2(&cfg)
+	ext.Capture.Instrumentation.GRPC.Filters.Traces = schema.AttributeFilters{
+		"service.name": {Match: "checkout-*"},
+	}
+
+	_, err := V2ToRuntime(ext)
+	require.ErrorContains(
+		t,
+		err,
+		"capture.instrumentation.grpc.filters.traces cannot differ from "+
+			"capture.instrumentation.http.filters.traces",
+	)
 }
 
 func TestV2ToRuntimeHTTPPayloadExtractionRejectsUnknownEnabled(t *testing.T) {

--- a/internal/config/convert/import_network_test.go
+++ b/internal/config/convert/import_network_test.go
@@ -156,10 +156,10 @@ func TestV2ToRuntimePartialNetworkCapturePreservesMissingMetadataDefaults(t *tes
 	require.Equal(t, obi.DefaultConfig.NetworkFlows.ReverseDNS.CacheTTL, got.NetworkFlows.ReverseDNS.CacheTTL)
 }
 
-func TestV2ToRuntimeNetworkCaptureSkipsDivergentSignalFilters(t *testing.T) {
+func TestV2ToRuntimeNetworkCaptureRejectsDivergentSignalFilters(t *testing.T) {
 	t.Parallel()
 
-	got, err := V2ToRuntime(&schema.Extension{
+	_, err := V2ToRuntime(&schema.Extension{
 		Version: schema.SupportedVersion,
 		Capture: schema.Capture{
 			Network: schema.CaptureNetwork{
@@ -176,7 +176,38 @@ func TestV2ToRuntimeNetworkCaptureSkipsDivergentSignalFilters(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
+	require.ErrorContains(
+		t,
+		err,
+		"capture.network.capture.filters.metrics cannot differ from "+
+			"capture.network.capture.filters.traces",
+	)
+}
 
-	require.Equal(t, obi.DefaultConfig.Filters.Network, got.Filters.Network)
+func TestV2ToRuntimeNetworkStatsRejectsDivergentSignalFilters(t *testing.T) {
+	t.Parallel()
+
+	_, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Network: schema.CaptureNetwork{
+				Stats: schema.NetworkStats{
+					Filters: schema.SignalFilters{
+						Traces: schema.AttributeFilters{
+							"src.address": {Match: "10.*"},
+						},
+						Metrics: schema.AttributeFilters{
+							"dst.address": {Match: "10.*"},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.ErrorContains(
+		t,
+		err,
+		"capture.network.stats.filters.metrics cannot differ from "+
+			"capture.network.stats.filters.traces",
+	)
 }


### PR DESCRIPTION
## Summary

- reject Config v2 application filters when protocol or signal definitions differ from the canonical HTTP trace filter
- reject metric and trace filter differences for network capture and network stats
- add focused coverage for divergent protocol, single-signal, and network filter configurations

## Why

Config v2 can express filters per protocol and signal, while the runtime stores one shared application filter, one network filter, and one network-stats filter. Conversion previously compared only non-empty HTTP trace and metric filters. A filter defined for one signal, another protocol, or a network path could therefore be accepted and silently collapse into different runtime behavior.

Failing closed preserves user intent until the runtime can represent these distinctions. This is a focused internal extraction from #2799 and is independently mergeable from `main`.

## Validation

- `go test ./internal/config/convert`
- `go test -race ./internal/config/convert`
- `make -o prereqs verify`
- `git diff --check`