### PR TITLE
Stabilize YAML export mode ordering

### DIFF
--- a/pkg/appolly/services/export.go
+++ b/pkg/appolly/services/export.go
@@ -27,6 +27,7 @@ var modeForText = map[string]maps.Bits{
 	"logs":    blockLogs,
 }
 
+// YAML serialization must use a fixed order to keep generated configuration reproducible.
 var orderedExportModes = []string{"metrics", "traces", "logs"}
 
 const (

--- a/pkg/appolly/services/export.go
+++ b/pkg/appolly/services/export.go
@@ -27,6 +27,8 @@ var modeForText = map[string]maps.Bits{
 	"logs":    blockLogs,
 }
 
+var orderedExportModes = []string{"metrics", "traces", "logs"}
+
 const (
 	// the zero-value of ExportModes (blockSignal == 0) means that the value is unset.
 	// This is, all the signals are allowed.
@@ -164,7 +166,8 @@ func (modes ExportModes) MarshalYAML() (any, error) {
 	if modes.blockSignal == blockAll {
 		return node, nil
 	}
-	for text, mode := range modeForText {
+	for _, text := range orderedExportModes {
+		mode := modeForText[text]
 		// the given signal is not explicitly blocked, so we can list it as allowed
 		if !modes.blockSignal.Has(mode) {
 			node.Content = append(node.Content, &yaml.Node{

--- a/pkg/appolly/services/export_test.go
+++ b/pkg/appolly/services/export_test.go
@@ -46,7 +46,7 @@ func TestYAMLMarshal_Exports(t *testing.T) {
 			Exports []string `yaml:"exports"`
 		}
 		require.NoError(t, yaml.Unmarshal(yamlOut, &exports))
-		assert.ElementsMatch(t, []string{"metrics", "traces", "logs"}, exports.Exports)
+		assert.Equal(t, []string{"metrics", "traces", "logs"}, exports.Exports)
 	})
 }
 


### PR DESCRIPTION
## Summary

- serialize export modes in the fixed order `metrics`, `traces`, `logs`
- strengthen YAML marshal coverage to assert the emitted sequence order

## Why

`ExportModes.MarshalYAML` iterated over a Go map, so otherwise identical configuration and migration output could list signals in a different order between runs. That nondeterminism creates noisy diffs and prevents generated YAML from being reproducible.

Using an explicit sequence makes output stable without changing which signals are enabled. This focused change is extracted from #2799 and is independently mergeable from `main`.

## Validation

- `go test ./pkg/appolly/services`
- `go test -race ./pkg/appolly/services`
- `git diff --check`