### PR TITLE
Bound Gemini partialArgs array expansion

### DIFF
--- a/pkg/ebpf/common/http/gemini_stream.go
+++ b/pkg/ebpf/common/http/gemini_stream.go
@@ -23,6 +23,13 @@ const maxGeminiStreamCandidates = 256
 // partialArgs to prevent unbounded memory allocation from malformed paths.
 const maxPartialArgArrayIndex = 1024
 
+// maxPartialArgArraySlots bounds the cumulative number of array slots that
+// can be allocated while reconstructing Vertex AI partialArgs. The per-index
+// guard above prevents a single huge index from allocating an enormous slice;
+// this cumulative guard prevents many distinct bounded high-index paths from
+// expanding a small captured stream into excessive heap usage and span output.
+const maxPartialArgArraySlots = 4096
+
 type geminiStreamChunk struct {
 	Candidates   []geminiStreamCandidate `json:"candidates"`
 	ModelVersion string                  `json:"modelVersion"`
@@ -97,9 +104,17 @@ type fcAggregator struct {
 	// splits a single string argument across multiple PartialArg elements that
 	// share a jsonPath and set willContinue=true until the final fragment, so
 	// the fragments must be concatenated rather than overwritten.
-	strFrags   map[string]string
-	hasFullArg bool            // true if args came as a complete JSON object
-	fullArg    json.RawMessage // stored when args is a complete JSON object
+	strFrags map[string]string
+	// rejectedStrFrags marks incomplete sequences whose prefix could not be
+	// assigned, so later fragments are skipped until the sequence terminates.
+	rejectedStrFrags map[string]struct{}
+	hasFullArg       bool            // true if args came as a complete JSON object
+	fullArg          json.RawMessage // stored when args is a complete JSON object
+}
+
+type partialArgBudget struct {
+	arraySlots       int
+	arrayAllocations int
 }
 
 // geminiPartialArg mirrors a single Vertex AI PartialArg element from the
@@ -121,10 +136,10 @@ type geminiPartialArg struct {
 // addPartialArgs interprets a raw partialArgs value, supporting both the
 // Vertex AI array-of-objects shape ([{jsonPath, <typed value>}, ...]) and the
 // plain string-fragment shape. Unknown shapes are ignored rather than fatal.
-func (fc *fcAggregator) addPartialArgs(raw json.RawMessage) {
+func (fc *fcAggregator) addPartialArgs(raw json.RawMessage, budget partialArgBudget) partialArgBudget {
 	trimmed := strings.TrimSpace(string(raw))
 	if trimmed == "" {
-		return
+		return budget
 	}
 	switch trimmed[0] {
 	case '"':
@@ -138,12 +153,13 @@ func (fc *fcAggregator) addPartialArgs(raw json.RawMessage) {
 		// one typed value from the value union.
 		var elems []geminiPartialArg
 		if err := json.Unmarshal(raw, &elems); err != nil {
-			return
+			return budget
 		}
 		for i := range elems {
-			fc.applyPartialArg(&elems[i])
+			budget = fc.applyPartialArg(&elems[i], budget)
 		}
 	}
+	return budget
 }
 
 // applyPartialArg decodes one PartialArg's typed value and assigns it at the
@@ -151,34 +167,51 @@ func (fc *fcAggregator) addPartialArgs(raw json.RawMessage) {
 // (Vertex AI streams them with willContinue=true until the final fragment) so
 // that a trailing empty terminator does not clobber the accumulated text; other
 // typed values are assigned directly.
-func (fc *fcAggregator) applyPartialArg(arg *geminiPartialArg) {
+func (fc *fcAggregator) applyPartialArg(arg *geminiPartialArg, budget partialArgBudget) partialArgBudget {
 	if arg.JSONPath == "" {
-		return
+		return budget
 	}
 	if fc.argsObj == nil {
 		fc.argsObj = map[string]any{}
 	}
 	switch {
 	case arg.StringValue != nil:
+		continuing := arg.WillContinue != nil && *arg.WillContinue
+		if _, rejected := fc.rejectedStrFrags[arg.JSONPath]; rejected {
+			if !continuing {
+				delete(fc.rejectedStrFrags, arg.JSONPath)
+			}
+			return budget
+		}
 		if fc.strFrags == nil {
 			fc.strFrags = map[string]string{}
 		}
 		acc := fc.strFrags[arg.JSONPath] + *arg.StringValue
-		fc.strFrags[arg.JSONPath] = acc
-		setByJSONPath(fc.argsObj, arg.JSONPath, acc)
+		var ok bool
+		budget, ok = setByJSONPathWithBudget(fc.argsObj, arg.JSONPath, acc, budget)
+		if ok {
+			fc.strFrags[arg.JSONPath] = acc
+		} else if continuing {
+			if fc.rejectedStrFrags == nil {
+				fc.rejectedStrFrags = map[string]struct{}{}
+			}
+			fc.rejectedStrFrags[arg.JSONPath] = struct{}{}
+			delete(fc.strFrags, arg.JSONPath)
+		}
 		// Once the provider signals the fragment sequence is complete, drop
 		// the per-path accumulator so a later argument at the same path starts
 		// fresh.
-		if arg.WillContinue == nil || !*arg.WillContinue {
+		if !continuing {
 			delete(fc.strFrags, arg.JSONPath)
 		}
 	case arg.NumberValue != nil:
-		setByJSONPath(fc.argsObj, arg.JSONPath, *arg.NumberValue)
+		budget, _ = setByJSONPathWithBudget(fc.argsObj, arg.JSONPath, *arg.NumberValue, budget)
 	case arg.BoolValue != nil:
-		setByJSONPath(fc.argsObj, arg.JSONPath, *arg.BoolValue)
+		budget, _ = setByJSONPathWithBudget(fc.argsObj, arg.JSONPath, *arg.BoolValue, budget)
 	case arg.NullValue != nil:
-		setByJSONPath(fc.argsObj, arg.JSONPath, nil)
+		budget, _ = setByJSONPathWithBudget(fc.argsObj, arg.JSONPath, nil, budget)
 	}
+	return budget
 }
 
 // setByJSONPath assigns value at the given JSONPath within the target map,
@@ -186,16 +219,38 @@ func (fc *fcAggregator) applyPartialArg(arg *geminiPartialArg) {
 // github.com/ohler55/ojg/jp parser so array segments (e.g. "$.items[0].id")
 // are handled per the Vertex AI contract instead of a hand-rolled dotted-key
 // parser. Invalid paths are skipped rather than fatal.
-func setByJSONPath(m map[string]any, path string, value any) {
+func setByJSONPath(m map[string]any, path string, value any, arraySlots int) (int, bool) {
+	budget, ok := setByJSONPathWithBudget(m, path, value, partialArgBudget{arraySlots: arraySlots})
+	return budget.arraySlots, ok
+}
+
+func setByJSONPathWithBudget(
+	m map[string]any,
+	path string,
+	value any,
+	budget partialArgBudget,
+) (partialArgBudget, bool) {
 	expr, err := jsonpath.ParseString(path)
 	if err != nil {
-		return
+		return budget, false
 	}
 	frags := stripRootFrags([]jsonpath.Frag(expr))
 	if len(frags) == 0 {
-		return
+		return budget, false
 	}
-	setAtFrags(m, frags, value)
+	if _, ok := frags[0].(jsonpath.Child); !ok {
+		return budget, false
+	}
+	freshArrayAllocations, ok := validateJSONPathFrags(frags)
+	if !ok {
+		return budget, false
+	}
+	previousArraySlots := budget.arraySlots
+	_, budget, ok = setAtFrags(m, frags, value, budget, freshArrayAllocations)
+	if !ok {
+		budget.arraySlots = previousArraySlots
+	}
+	return budget, ok
 }
 
 // stripRootFrags drops the leading root ("$") or current-node ("@") markers
@@ -213,37 +268,133 @@ func stripRootFrags(frags []jsonpath.Frag) []jsonpath.Frag {
 	return frags
 }
 
+func validateJSONPathFrags(frags []jsonpath.Frag) (int, bool) {
+	freshArrayAllocations := 0
+	for _, frag := range frags {
+		switch frag := frag.(type) {
+		case jsonpath.Child:
+		case jsonpath.Nth:
+			idx := int(frag)
+			if idx < 0 || idx >= maxPartialArgArrayIndex {
+				return 0, false
+			}
+			freshArrayAllocations += idx + 1
+		default:
+			return 0, false
+		}
+	}
+	return freshArrayAllocations, true
+}
+
 // setAtFrags recursively assigns value at the location described by frags
 // within container, creating intermediate maps and arrays (including nested
 // array elements) as needed. It returns the possibly reallocated container so
 // callers can reattach a grown slice. Only plain object-key (Child) and array
 // index (Nth) fragments are supported; other fragment kinds stop the descent.
-func setAtFrags(container any, frags []jsonpath.Frag, value any) any {
+// freshArrayAllocations is the precomputed allocation required by Nth fragments
+// in frags.
+func setAtFrags(
+	container any,
+	frags []jsonpath.Frag,
+	value any,
+	budget partialArgBudget,
+	freshArrayAllocations int,
+) (any, partialArgBudget, bool) {
 	if len(frags) == 0 {
-		return value
+		updatedArraySlots := budget.arraySlots -
+			min(countArraySlots(container), budget.arraySlots) +
+			countArraySlots(value)
+		if updatedArraySlots > maxPartialArgArraySlots {
+			return container, budget, false
+		}
+		budget.arraySlots = updatedArraySlots
+		return value, budget, true
+	}
+	remainingFreshArrayAllocations := freshArrayAllocations
+	if idx, ok := frags[0].(jsonpath.Nth); ok {
+		remainingFreshArrayAllocations -= int(idx) + 1
 	}
 	switch f := frags[0].(type) {
 	case jsonpath.Child:
 		m, ok := container.(map[string]any)
 		if !ok || m == nil {
+			if remainingFreshArrayAllocations >
+				maxPartialArgArraySlots-budget.arrayAllocations {
+				return container, budget, false
+			}
+			budget.arraySlots -= min(countArraySlots(container), budget.arraySlots)
 			m = map[string]any{}
 		}
 		key := string(f)
-		m[key] = setAtFrags(m[key], frags[1:], value)
-		return m
+		child, budget, ok := setAtFrags(
+			m[key],
+			frags[1:],
+			value,
+			budget,
+			remainingFreshArrayAllocations,
+		)
+		if !ok {
+			return m, budget, false
+		}
+		m[key] = child
+		return m, budget, true
 	case jsonpath.Nth:
 		idx := int(f)
 		if idx < 0 || idx >= maxPartialArgArrayIndex {
-			return container
+			return container, budget, false
 		}
-		s, _ := container.([]any)
-		for len(s) <= idx {
-			s = append(s, nil)
+		s, ok := container.([]any)
+		if !ok {
+			if budget.arrayAllocations+idx+1 > maxPartialArgArraySlots {
+				return container, budget, false
+			}
+			budget.arraySlots -= min(countArraySlots(container), budget.arraySlots)
 		}
-		s[idx] = setAtFrags(s[idx], frags[1:], value)
-		return s
+		if idx >= len(s) {
+			additionalSlots := idx + 1 - len(s)
+			if budget.arraySlots+additionalSlots > maxPartialArgArraySlots ||
+				budget.arrayAllocations+additionalSlots > maxPartialArgArraySlots {
+				return container, budget, false
+			}
+			budget.arraySlots += additionalSlots
+			budget.arrayAllocations += additionalSlots
+			for len(s) <= idx {
+				s = append(s, nil)
+			}
+		}
+		child, budget, ok := setAtFrags(
+			s[idx],
+			frags[1:],
+			value,
+			budget,
+			remainingFreshArrayAllocations,
+		)
+		if !ok {
+			return s, budget, false
+		}
+		s[idx] = child
+		return s, budget, true
 	default:
-		return container
+		return container, budget, false
+	}
+}
+
+func countArraySlots(value any) int {
+	switch value := value.(type) {
+	case []any:
+		slots := len(value)
+		for _, element := range value {
+			slots += countArraySlots(element)
+		}
+		return slots
+	case map[string]any:
+		slots := 0
+		for _, element := range value {
+			slots += countArraySlots(element)
+		}
+		return slots
+	default:
+		return 0
 	}
 }
 
@@ -333,6 +484,7 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 	scanner.Buffer(make([]byte, 0, 256*1024), 256*1024)
 
 	candidates := make(map[int]*candidateAggregator)
+	partialArgsBudget := partialArgBudget{}
 	var toolCalls []request.ToolCall
 	var modelVersion string
 	var responseID string
@@ -403,7 +555,10 @@ func parseGeminiStream(reader io.Reader) (*request.GeminiResponse, []request.Too
 				}
 
 				if part.FunctionCall != nil {
-					processFunctionCallPart(agg, part.FunctionCall, part.ThoughtSignature, &toolCalls)
+					partialArgsBudget, toolCalls = processFunctionCallPart(
+						agg, part.FunctionCall, part.ThoughtSignature,
+						partialArgsBudget, toolCalls,
+					)
 					continue
 				}
 
@@ -473,11 +628,17 @@ func appendTextPart(agg *candidateAggregator, tp geminiStreamPart) {
 // complete single-chunk calls and Vertex AI's streaming function call
 // arguments where the name arrives first and args follow in subsequent chunks.
 // signature is the part's outer thoughtSignature (if any).
-func processFunctionCallPart(agg *candidateAggregator, fc *geminiFunctionCallData, signature string, toolCalls *[]request.ToolCall) {
+func processFunctionCallPart(
+	agg *candidateAggregator,
+	fc *geminiFunctionCallData,
+	signature string,
+	budget partialArgBudget,
+	toolCalls []request.ToolCall,
+) (partialArgBudget, []request.ToolCall) {
 	if fc.Name != "" {
 		// New named function call: flush any previous active FC.
 		if name := agg.flushActiveFC(); name != "" {
-			*toolCalls = append(*toolCalls, request.ToolCall{Name: name})
+			toolCalls = append(toolCalls, request.ToolCall{Name: name})
 		}
 
 		// If the call has complete args and no continuation, store directly.
@@ -491,31 +652,31 @@ func processFunctionCallPart(agg *candidateAggregator, fc *geminiFunctionCallDat
 			// If willContinue is nil or false, this is a complete call.
 			if fc.WillContinue == nil || !*fc.WillContinue {
 				if name := agg.flushActiveFC(); name != "" {
-					*toolCalls = append(*toolCalls, request.ToolCall{Name: name})
+					toolCalls = append(toolCalls, request.ToolCall{Name: name})
 				}
 			}
-			return
+			return budget, toolCalls
 		}
 
 		// Start aggregation (name only, or name with partial args).
 		agg.activeFC = &fcAggregator{name: fc.Name, signature: signature}
-		agg.activeFC.addPartialArgs(fc.PartialArgs)
+		budget = agg.activeFC.addPartialArgs(fc.PartialArgs, budget)
 
 		// If no continuation expected and no partial args, flush immediately.
 		if fc.WillContinue == nil && len(fc.PartialArgs) == 0 && len(fc.Args) == 0 {
 			if name := agg.flushActiveFC(); name != "" {
-				*toolCalls = append(*toolCalls, request.ToolCall{Name: name})
+				toolCalls = append(toolCalls, request.ToolCall{Name: name})
 			}
 		}
-		return
+		return budget, toolCalls
 	}
 
 	// Continuation fragment (no name): append to active function call.
 	if agg.activeFC == nil {
-		return
+		return budget, toolCalls
 	}
 	if len(fc.PartialArgs) > 0 {
-		agg.activeFC.addPartialArgs(fc.PartialArgs)
+		budget = agg.activeFC.addPartialArgs(fc.PartialArgs, budget)
 	} else if len(fc.Args) > 0 {
 		// Args as JSON in continuation.
 		agg.activeFC.argsAccum.Write(fc.Args)
@@ -524,9 +685,10 @@ func processFunctionCallPart(agg *candidateAggregator, fc *geminiFunctionCallDat
 	// If willContinue is explicitly false or absent, the call is complete.
 	if fc.WillContinue == nil || !*fc.WillContinue {
 		if name := agg.flushActiveFC(); name != "" {
-			*toolCalls = append(*toolCalls, request.ToolCall{Name: name})
+			toolCalls = append(toolCalls, request.ToolCall{Name: name})
 		}
 	}
+	return budget, toolCalls
 }
 
 // tryParseErrorLine attempts to parse a line as a bare Gemini error envelope.

--- a/pkg/ebpf/common/http/gemini_stream.go
+++ b/pkg/ebpf/common/http/gemini_stream.go
@@ -214,16 +214,11 @@ func (fc *fcAggregator) applyPartialArg(arg *geminiPartialArg, budget partialArg
 	return budget
 }
 
-// setByJSONPath assigns value at the given JSONPath within the target map,
-// creating intermediate objects and arrays as needed. It reuses the shared
+// setByJSONPathWithBudget assigns value at the given JSONPath within the target
+// map, creating intermediate objects and arrays as needed. It reuses the shared
 // github.com/ohler55/ojg/jp parser so array segments (e.g. "$.items[0].id")
 // are handled per the Vertex AI contract instead of a hand-rolled dotted-key
 // parser. Invalid paths are skipped rather than fatal.
-func setByJSONPath(m map[string]any, path string, value any, arraySlots int) (int, bool) {
-	budget, ok := setByJSONPathWithBudget(m, path, value, partialArgBudget{arraySlots: arraySlots})
-	return budget.arraySlots, ok
-}
-
 func setByJSONPathWithBudget(
 	m map[string]any,
 	path string,

--- a/pkg/ebpf/common/http/gemini_stream_test.go
+++ b/pkg/ebpf/common/http/gemini_stream_test.go
@@ -621,3 +621,264 @@ func TestParseGeminiStream_OversizedArrayIndex(t *testing.T) {
 	// "items" should not be present (oversized index was skipped).
 	assert.Nil(t, args["items"])
 }
+
+func TestParseGeminiStream_PartialArgsArraySlotBudget(t *testing.T) {
+	// Each accepted path can allocate up to maxPartialArgArrayIndex array slots.
+	// The cumulative budget must stop many distinct bounded high-index paths
+	// from expanding a small stream into excessive heap usage and span output.
+	var partialArgs strings.Builder
+	for i := range maxPartialArgArraySlots/maxPartialArgArrayIndex + 2 {
+		if i > 0 {
+			partialArgs.WriteByte(',')
+		}
+		partialArgs.WriteString(`{"jsonPath":"$.k`)
+		partialArgs.WriteString(string(rune('0' + i)))
+		partialArgs.WriteString(`[1023]","numberValue":1}`)
+	}
+
+	stream := `data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"bounded","partialArgs":[` + partialArgs.String() + `]}}],"role":"model"},"finishReason":"STOP"}],"modelVersion":"gemini-2.0-flash"}` + "\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	require.Len(t, toolCalls, 1)
+	require.Len(t, resp.Candidates, 1)
+
+	var parts []struct {
+		FunctionCall *struct {
+			Args json.RawMessage `json:"args"`
+		} `json:"functionCall"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].FunctionCall)
+
+	var args map[string]any
+	require.NoError(t, json.Unmarshal(parts[0].FunctionCall.Args, &args))
+	assert.Len(t, args, maxPartialArgArraySlots/maxPartialArgArrayIndex)
+	assert.NotContains(t, args, "k4")
+	assert.NotContains(t, args, "k5")
+}
+
+func TestParseGeminiStream_PartialArgsArraySlotBudgetAcrossFunctionCalls(t *testing.T) {
+	var functionCalls strings.Builder
+	for i := range maxPartialArgArraySlots/maxPartialArgArrayIndex + 2 {
+		if i > 0 {
+			functionCalls.WriteByte(',')
+		}
+		functionCalls.WriteString("{\"functionCall\":{\"name\":\"call")
+		functionCalls.WriteString(string(rune('0' + i)))
+		functionCalls.WriteString("\",\"partialArgs\":[{\"jsonPath\":\"$.items[1023]\",\"numberValue\":1}]}}")
+	}
+
+	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[" + functionCalls.String() + "],\"role\":\"model\"},\"finishReason\":\"STOP\"}],\"modelVersion\":\"gemini-2.0-flash\"}" + "\n\n"
+
+	resp, toolCalls := parseGeminiStream(strings.NewReader(stream))
+
+	require.NotNil(t, resp)
+	require.Len(t, toolCalls, maxPartialArgArraySlots/maxPartialArgArrayIndex+2)
+	require.Len(t, resp.Candidates, 1)
+
+	var parts []geminiStreamPart
+	require.NoError(t, json.Unmarshal(resp.Candidates[0].Content.Parts, &parts))
+	require.Len(t, parts, maxPartialArgArraySlots/maxPartialArgArrayIndex+2)
+
+	retainedSlots := 0
+	for i := range maxPartialArgArraySlots / maxPartialArgArrayIndex {
+		var args map[string]any
+		require.NoError(t, json.Unmarshal(parts[i].FunctionCall.Args, &args))
+		retainedSlots += countArraySlots(args)
+	}
+	assert.Equal(t, maxPartialArgArraySlots, retainedSlots)
+	assert.Empty(t, parts[len(parts)-2].FunctionCall.Args)
+	assert.Empty(t, parts[len(parts)-1].FunctionCall.Args)
+}
+
+func TestPartialArgRejectedStringFragmentsAreSkipped(t *testing.T) {
+	args := map[string]any{}
+	arraySlots := 0
+	var ok bool
+	for _, path := range []string{
+		"$.fill0[1023]",
+		"$.fill1[1023]",
+		"$.fill2[1023]",
+		"$.fill3[1023]",
+	} {
+		arraySlots, ok = setByJSONPath(args, path, 1, arraySlots)
+		require.True(t, ok)
+	}
+
+	continuing := true
+	prefix := "he"
+	fc := fcAggregator{argsObj: args}
+	budget := fc.applyPartialArg(&geminiPartialArg{
+		JSONPath:     "$.value[0]",
+		StringValue:  &prefix,
+		WillContinue: &continuing,
+	}, partialArgBudget{arraySlots: arraySlots})
+
+	budget.arraySlots, ok = setByJSONPath(args, "$.fill0", 1, budget.arraySlots)
+	require.True(t, ok)
+	suffix := "llo"
+	fc.applyPartialArg(&geminiPartialArg{JSONPath: "$.value[0]", StringValue: &suffix}, budget)
+
+	assert.NotContains(t, args, "value")
+	assert.Empty(t, fc.strFrags)
+	assert.Empty(t, fc.rejectedStrFrags)
+}
+
+func TestSetByJSONPathRejectedPathDoesNotConsumeArraySlotBudget(t *testing.T) {
+	args := map[string]any{}
+	arraySlots := 0
+
+	for _, path := range []string{
+		"$.bad0[1023][1000000000]",
+		"$.bad1[1023][1000000000]",
+		"$.bad2[1023][1000000000]",
+		"$.bad3[1023][1000000000]",
+	} {
+		updatedArraySlots, ok := setByJSONPath(args, path, 1, arraySlots)
+		assert.False(t, ok)
+		arraySlots = updatedArraySlots
+	}
+
+	assert.Zero(t, arraySlots)
+	assert.Empty(t, args)
+	var ok bool
+	arraySlots, ok = setByJSONPath(args, "$.items[0]", 1, arraySlots)
+	require.True(t, ok)
+	assert.Equal(t, 1, arraySlots)
+	assert.Equal(t, []any{1}, args["items"])
+}
+
+func TestSetByJSONPathRootArrayDoesNotConsumeArraySlotBudget(t *testing.T) {
+	args := map[string]any{}
+	arraySlots := 0
+
+	for range maxPartialArgArraySlots / maxPartialArgArrayIndex {
+		updatedArraySlots, ok := setByJSONPath(args, "$[1023]", 1, arraySlots)
+		assert.False(t, ok)
+		arraySlots = updatedArraySlots
+	}
+
+	assert.Zero(t, arraySlots)
+	assert.Empty(t, args)
+	var ok bool
+	arraySlots, ok = setByJSONPath(args, "$.items[0]", 1, arraySlots)
+	require.True(t, ok)
+	assert.Equal(t, 1, arraySlots)
+	assert.Equal(t, []any{1}, args["items"])
+}
+
+func TestSetByJSONPathOverwriteReclaimsArraySlotBudget(t *testing.T) {
+	args := map[string]any{}
+	arraySlots := 0
+	var ok bool
+
+	for _, path := range []string{"$.tmp0", "$.tmp1", "$.tmp2", "$.tmp3"} {
+		arraySlots, ok = setByJSONPath(args, path+"[1023]", 1, arraySlots)
+		require.True(t, ok)
+		arraySlots, ok = setByJSONPath(args, path, 1, arraySlots)
+		require.True(t, ok)
+	}
+
+	assert.Zero(t, arraySlots)
+	arraySlots, ok = setByJSONPath(args, "$.items[0]", 1, arraySlots)
+	require.True(t, ok)
+	assert.Equal(t, 1, arraySlots)
+	assert.Equal(t, []any{1}, args["items"])
+}
+
+func TestSetByJSONPathIntermediateTypeChangesReclaimArraySlotBudget(t *testing.T) {
+	args := map[string]any{}
+	arraySlots := 0
+	var ok bool
+
+	for _, path := range []string{"$.tmp0", "$.tmp1", "$.tmp2", "$.tmp3"} {
+		arraySlots, ok = setByJSONPath(args, path+"[1023]", 1, arraySlots)
+		require.True(t, ok)
+		arraySlots, ok = setByJSONPath(args, path+".child[0]", 1, arraySlots)
+		require.True(t, ok)
+	}
+
+	assert.Equal(t, 4, arraySlots)
+	arraySlots, ok = setByJSONPath(args, "$.items[1023]", 1, arraySlots)
+	require.True(t, ok)
+	assert.Equal(t, maxPartialArgArrayIndex+4, arraySlots)
+
+	arraySlots, ok = setByJSONPath(args, "$.nested.child[1023]", 1, arraySlots)
+	require.True(t, ok)
+	arraySlots, ok = setByJSONPath(args, "$.nested[0]", 1, arraySlots)
+	require.True(t, ok)
+	assert.Equal(t, maxPartialArgArrayIndex+5, arraySlots)
+}
+
+func TestSetByJSONPathAllocationBudgetIsMonotonic(t *testing.T) {
+	args := map[string]any{}
+	budget := partialArgBudget{}
+
+	budget, ok := setByJSONPathWithBudget(args, "$.x[1023][1023][1023][1023]", 1, budget)
+	require.True(t, ok)
+	budget, ok = setByJSONPathWithBudget(args, "$.x", 1, budget)
+	require.True(t, ok)
+	assert.Zero(t, budget.arraySlots)
+	assert.Equal(t, maxPartialArgArraySlots, budget.arrayAllocations)
+	budget, ok = setByJSONPathWithBudget(args, "$.x[1023][1023][1023][1023]", 1, budget)
+	assert.False(t, ok)
+	assert.Equal(t, 1, args["x"])
+}
+
+func TestSetByJSONPathExhaustedAllocationBudgetRejectsObjectToArray(t *testing.T) {
+	args := map[string]any{}
+	budget := partialArgBudget{}
+
+	for _, path := range []string{
+		"$.large.k0[1023]",
+		"$.large.k1[1023]",
+		"$.large.k2[1023]",
+		"$.large.k3[1023]",
+	} {
+		var ok bool
+		budget, ok = setByJSONPathWithBudget(args, path, 1, budget)
+		require.True(t, ok)
+	}
+	require.Equal(t, maxPartialArgArraySlots, budget.arrayAllocations)
+
+	for range 3 {
+		updatedBudget, ok := setByJSONPathWithBudget(args, "$.large[0]", 1, budget)
+		assert.False(t, ok)
+		assert.Equal(t, budget, updatedBudget)
+	}
+	assert.Len(t, args["large"], maxPartialArgArraySlots/maxPartialArgArrayIndex)
+}
+
+func TestSetByJSONPathExhaustedAllocationBudgetRejectsArrayToObject(t *testing.T) {
+	args := map[string]any{}
+	budget := partialArgBudget{}
+
+	budget, ok := setByJSONPathWithBudget(
+		args,
+		"$.large[1023][1023][1023][1023]",
+		1,
+		budget,
+	)
+	require.True(t, ok)
+	require.Equal(t, maxPartialArgArraySlots, budget.arrayAllocations)
+
+	for range 3 {
+		updatedBudget, ok := setByJSONPathWithBudget(args, "$.large.child[0]", 1, budget)
+		assert.False(t, ok)
+		assert.Equal(t, budget, updatedBudget)
+	}
+	assert.IsType(t, []any{}, args["large"])
+}
+
+func TestSetByJSONPathDeepFreshPath(t *testing.T) {
+	const childFragments = 32 * 1024
+
+	args := map[string]any{}
+	path := "$" + strings.Repeat(".a", childFragments) + "[0]"
+	budget, ok := setByJSONPathWithBudget(args, path, 1, partialArgBudget{})
+	require.True(t, ok)
+	assert.Equal(t, partialArgBudget{arraySlots: 1, arrayAllocations: 1}, budget)
+}

--- a/pkg/ebpf/common/http/gemini_stream_test.go
+++ b/pkg/ebpf/common/http/gemini_stream_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func setOneByJSONPath(m map[string]any, path string, arraySlots int) (int, bool) {
+	budget, ok := setByJSONPathWithBudget(m, path, 1, partialArgBudget{arraySlots: arraySlots})
+	return budget.arraySlots, ok
+}
+
 func TestParseGeminiStream_CompleteResponse(t *testing.T) {
 	stream := "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"AI \"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_abc\"}\n\n" +
 		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"uses \"}],\"role\":\"model\"}}],\"modelVersion\":\"gemini-2.0-flash\",\"responseId\":\"resp_abc\"}\n\n" +
@@ -704,7 +709,7 @@ func TestPartialArgRejectedStringFragmentsAreSkipped(t *testing.T) {
 		"$.fill2[1023]",
 		"$.fill3[1023]",
 	} {
-		arraySlots, ok = setByJSONPath(args, path, 1, arraySlots)
+		arraySlots, ok = setOneByJSONPath(args, path, arraySlots)
 		require.True(t, ok)
 	}
 
@@ -717,7 +722,7 @@ func TestPartialArgRejectedStringFragmentsAreSkipped(t *testing.T) {
 		WillContinue: &continuing,
 	}, partialArgBudget{arraySlots: arraySlots})
 
-	budget.arraySlots, ok = setByJSONPath(args, "$.fill0", 1, budget.arraySlots)
+	budget.arraySlots, ok = setOneByJSONPath(args, "$.fill0", budget.arraySlots)
 	require.True(t, ok)
 	suffix := "llo"
 	fc.applyPartialArg(&geminiPartialArg{JSONPath: "$.value[0]", StringValue: &suffix}, budget)
@@ -737,7 +742,7 @@ func TestSetByJSONPathRejectedPathDoesNotConsumeArraySlotBudget(t *testing.T) {
 		"$.bad2[1023][1000000000]",
 		"$.bad3[1023][1000000000]",
 	} {
-		updatedArraySlots, ok := setByJSONPath(args, path, 1, arraySlots)
+		updatedArraySlots, ok := setOneByJSONPath(args, path, arraySlots)
 		assert.False(t, ok)
 		arraySlots = updatedArraySlots
 	}
@@ -745,7 +750,7 @@ func TestSetByJSONPathRejectedPathDoesNotConsumeArraySlotBudget(t *testing.T) {
 	assert.Zero(t, arraySlots)
 	assert.Empty(t, args)
 	var ok bool
-	arraySlots, ok = setByJSONPath(args, "$.items[0]", 1, arraySlots)
+	arraySlots, ok = setOneByJSONPath(args, "$.items[0]", arraySlots)
 	require.True(t, ok)
 	assert.Equal(t, 1, arraySlots)
 	assert.Equal(t, []any{1}, args["items"])
@@ -756,7 +761,7 @@ func TestSetByJSONPathRootArrayDoesNotConsumeArraySlotBudget(t *testing.T) {
 	arraySlots := 0
 
 	for range maxPartialArgArraySlots / maxPartialArgArrayIndex {
-		updatedArraySlots, ok := setByJSONPath(args, "$[1023]", 1, arraySlots)
+		updatedArraySlots, ok := setOneByJSONPath(args, "$[1023]", arraySlots)
 		assert.False(t, ok)
 		arraySlots = updatedArraySlots
 	}
@@ -764,7 +769,7 @@ func TestSetByJSONPathRootArrayDoesNotConsumeArraySlotBudget(t *testing.T) {
 	assert.Zero(t, arraySlots)
 	assert.Empty(t, args)
 	var ok bool
-	arraySlots, ok = setByJSONPath(args, "$.items[0]", 1, arraySlots)
+	arraySlots, ok = setOneByJSONPath(args, "$.items[0]", arraySlots)
 	require.True(t, ok)
 	assert.Equal(t, 1, arraySlots)
 	assert.Equal(t, []any{1}, args["items"])
@@ -776,14 +781,14 @@ func TestSetByJSONPathOverwriteReclaimsArraySlotBudget(t *testing.T) {
 	var ok bool
 
 	for _, path := range []string{"$.tmp0", "$.tmp1", "$.tmp2", "$.tmp3"} {
-		arraySlots, ok = setByJSONPath(args, path+"[1023]", 1, arraySlots)
+		arraySlots, ok = setOneByJSONPath(args, path+"[1023]", arraySlots)
 		require.True(t, ok)
-		arraySlots, ok = setByJSONPath(args, path, 1, arraySlots)
+		arraySlots, ok = setOneByJSONPath(args, path, arraySlots)
 		require.True(t, ok)
 	}
 
 	assert.Zero(t, arraySlots)
-	arraySlots, ok = setByJSONPath(args, "$.items[0]", 1, arraySlots)
+	arraySlots, ok = setOneByJSONPath(args, "$.items[0]", arraySlots)
 	require.True(t, ok)
 	assert.Equal(t, 1, arraySlots)
 	assert.Equal(t, []any{1}, args["items"])
@@ -795,20 +800,20 @@ func TestSetByJSONPathIntermediateTypeChangesReclaimArraySlotBudget(t *testing.T
 	var ok bool
 
 	for _, path := range []string{"$.tmp0", "$.tmp1", "$.tmp2", "$.tmp3"} {
-		arraySlots, ok = setByJSONPath(args, path+"[1023]", 1, arraySlots)
+		arraySlots, ok = setOneByJSONPath(args, path+"[1023]", arraySlots)
 		require.True(t, ok)
-		arraySlots, ok = setByJSONPath(args, path+".child[0]", 1, arraySlots)
+		arraySlots, ok = setOneByJSONPath(args, path+".child[0]", arraySlots)
 		require.True(t, ok)
 	}
 
 	assert.Equal(t, 4, arraySlots)
-	arraySlots, ok = setByJSONPath(args, "$.items[1023]", 1, arraySlots)
+	arraySlots, ok = setOneByJSONPath(args, "$.items[1023]", arraySlots)
 	require.True(t, ok)
 	assert.Equal(t, maxPartialArgArrayIndex+4, arraySlots)
 
-	arraySlots, ok = setByJSONPath(args, "$.nested.child[1023]", 1, arraySlots)
+	arraySlots, ok = setOneByJSONPath(args, "$.nested.child[1023]", arraySlots)
 	require.True(t, ok)
-	arraySlots, ok = setByJSONPath(args, "$.nested[0]", 1, arraySlots)
+	arraySlots, ok = setOneByJSONPath(args, "$.nested[0]", arraySlots)
 	require.True(t, ok)
 	assert.Equal(t, maxPartialArgArrayIndex+5, arraySlots)
 }


### PR DESCRIPTION
### Motivation

- Gemini SSE reconstruction expands Vertex AI `partialArgs` JSONPaths into nested objects and arrays. A per-index limit alone still allowed many bounded paths, multiple function calls, or repeated allocation and replacement to amplify a small captured response into excessive heap work and span output.
- Bound both retained array slots and cumulative allocation work across the captured response while preserving valid streaming function-call arguments.

### Description

- Add response-scoped retained-slot and monotonic allocation-work counters shared by all function-call aggregators.
- Prevalidate every JSONPath fragment before allocation, accepting only object-rooted child and bounded array-index fragments.
- Thread both budgets through `setByJSONPath` and `setAtFrags`, reject assignments that exceed either limit, restore retained-slot accounting after rejected assignments, and reclaim retained slots when arrays are overwritten or replaced by another container type.
- Suppress the remainder of a fragmented string sequence when its prefix cannot be assigned, preventing rejected fragments from being accumulated or attached later.
- Add regression coverage for distinct high-index paths, multiple function calls, rejected and root-array paths, overwritten and replaced arrays, rejected string fragments, and repeated allocation churn.

### Testing

- `go test -count=1 ./pkg/ebpf/common/http`
- `gofmt` on the changed Go files
- `git diff --check`