### PR TITLE
Restrict and harden the TCP health endpoint

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -369,6 +369,7 @@ AttributesConfig stores the user-provided section for filtering either Applicati
 
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
 |---|---|---|---|---|---|---|
+| `health_check.listen_address` | `ip` | `OTEL_EBPF_HEALTH_CHECK_LISTEN_ADDRESS` | `127.0.0.1` |  |  | IP address the TCP health endpoint binds to. Defaults to 127.0.0.1. Set to 0.0.0.0 or :: only when external probes require access. |
 | `health_check.port` | `integer` | `OTEL_EBPF_HEALTH_CHECK_PORT` | `0` |  |  | 0 (default) means disabled |
 | `health_check.unix_socket_path` | `string` | `OTEL_EBPF_HEALTH_CHECK_UNIX_SOCKET_PATH` |  |  |  | when set, the health endpoint binds this unix socket (a filesystem path or a leading-'@' abstract name) instead of the TCP port |
 

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -1325,6 +1325,13 @@
     },
     "HealthCheckConfig": {
       "properties": {
+        "listen_address": {
+          "type": "string",
+          "format": "ip",
+          "description": "IP address the TCP health endpoint binds to. Defaults to 127.0.0.1. Set to 0.0.0.0 or :: only when external probes require access.",
+          "default": "127.0.0.1",
+          "x-env-var": "OTEL_EBPF_HEALTH_CHECK_LISTEN_ADDRESS"
+        },
         "port": {
           "type": "integer",
           "description": "0 (default) means disabled",

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -9,17 +9,28 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
+
+	"golang.org/x/net/netutil"
 )
 
 const (
 	path          = "/healthz"
 	schemaVersion = 1
+
+	maxOpenConns      = 100
+	readHeaderTimeout = 5 * time.Second
+	readTimeout       = 5 * time.Second
+	writeTimeout      = 5 * time.Second
+	idleTimeout       = 5 * time.Second
 )
+
+// DefaultListenAddress keeps the TCP health endpoint local unless configured otherwise.
+const DefaultListenAddress = "127.0.0.1"
 
 func log() *slog.Logger {
 	return slog.With("component", "health")
@@ -45,10 +56,23 @@ func (e *endpoint) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	_ = json.NewEncoder(w).Encode(&resp)
 }
 
+func tcpListenAddr(address string, port int) string {
+	if address == "" {
+		address = DefaultListenAddress
+	}
+
+	return net.JoinHostPort(address, strconv.Itoa(port))
+}
+
 func ListenAndServe(ctx context.Context, port int) error {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	return ListenAndServeTCP(ctx, DefaultListenAddress, port)
+}
+
+func ListenAndServeTCP(ctx context.Context, address string, port int) error {
+	listenAddr := tcpListenAddr(address, port)
+	lis, err := net.Listen("tcp", listenAddr)
 	if err != nil {
-		log().With("port", port).Error("can't bind health endpoint", "err", err)
+		log().With("address", listenAddr).Error("can't bind health endpoint", "err", err)
 		return nil
 	}
 
@@ -65,14 +89,22 @@ func ListenAndServeUDS(ctx context.Context, addr string) error {
 	return Serve(ctx, lis)
 }
 
-func Serve(ctx context.Context, lis net.Listener) error {
+func newServer() *http.Server {
 	mux := http.NewServeMux()
 	mux.Handle(path, &endpoint{start: time.Now()})
 
-	server := &http.Server{
+	return &http.Server{
 		Handler:           mux,
-		ReadHeaderTimeout: 5 * time.Second,
+		ReadHeaderTimeout: readHeaderTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
 	}
+}
+
+func Serve(ctx context.Context, lis net.Listener) error {
+	server := newServer()
+	lis = netutil.LimitListener(lis, maxOpenConns)
 
 	l := log().With("addr", lis.Addr().String(), "path", path)
 	l.Info("starting health endpoint")

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -4,8 +4,10 @@
 package health
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -42,6 +44,75 @@ func TestServeHTTPAdvancesTime(t *testing.T) {
 
 	assert.Greater(t, r2.NowUnixNs, r1.NowUnixNs)
 	assert.GreaterOrEqual(t, r2.ProcessUptimeNs, r1.ProcessUptimeNs)
+}
+
+func TestTCPListenAddr(t *testing.T) {
+	tests := map[string]struct {
+		address string
+		want    string
+	}{
+		"default":       {want: "127.0.0.1:8080"},
+		"loopback":      {address: "127.0.0.1", want: "127.0.0.1:8080"},
+		"wildcard IPv4": {address: "0.0.0.0", want: "0.0.0.0:8080"},
+		"wildcard IPv6": {address: "::", want: "[::]:8080"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, tcpListenAddr(test.address, 8080))
+		})
+	}
+}
+
+func TestNewServerHardening(t *testing.T) {
+	server := newServer()
+
+	assert.Equal(t, readHeaderTimeout, server.ReadHeaderTimeout)
+	assert.Equal(t, readTimeout, server.ReadTimeout)
+	assert.Equal(t, writeTimeout, server.WriteTimeout)
+	assert.Equal(t, idleTimeout, server.IdleTimeout)
+}
+
+func TestIdleConnectionsExpire(t *testing.T) {
+	server := newServer()
+	server.IdleTimeout = 25 * time.Millisecond
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- server.Serve(lis)
+	}()
+
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+		assert.ErrorIs(t, <-serverErr, http.ErrServerClosed)
+	})
+
+	conn, err := net.Dial("tcp", lis.Addr().String())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+
+	const request = "GET /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n"
+	_, err = io.WriteString(conn, request)
+	require.NoError(t, err)
+
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, &http.Request{Method: http.MethodGet})
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+
+	time.Sleep(2 * server.IdleTimeout)
+	require.NoError(t, conn.SetDeadline(time.Now().Add(time.Second)))
+
+	_, _ = io.WriteString(conn, request)
+	_, err = http.ReadResponse(reader, &http.Request{Method: http.MethodGet})
+	require.Error(t, err)
 }
 
 func TestServeEndToEnd(t *testing.T) {

--- a/pkg/instrumenter/instrumenter.go
+++ b/pkg/instrumenter/instrumenter.go
@@ -50,7 +50,7 @@ func startHealthCheck(ctx context.Context, g *errgroup.Group, cfg obi.HealthChec
 		})
 	case cfg.Port != 0:
 		g.Go(func() error {
-			return health.ListenAndServe(ctx, cfg.Port)
+			return health.ListenAndServeTCP(ctx, cfg.ListenAddress, cfg.Port)
 		})
 	}
 }

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -35,6 +35,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 	"go.opentelemetry.io/obi/pkg/export/prom"
 	"go.opentelemetry.io/obi/pkg/filter"
+	"go.opentelemetry.io/obi/pkg/health"
 	"go.opentelemetry.io/obi/pkg/internal/avoidedsvc"
 	"go.opentelemetry.io/obi/pkg/kube"
 	"go.opentelemetry.io/obi/pkg/kube/kubeflags"
@@ -353,7 +354,8 @@ var DefaultConfig = Config{
 		SamplingInterval: time.Second,
 	},
 	HealthCheck: HealthCheckConfig{
-		Port: 0,
+		Port:          0,
+		ListenAddress: health.DefaultListenAddress,
 	},
 }
 
@@ -472,6 +474,9 @@ func (c *Config) JoinMetricsConfig() *perapp.MetricsConfig {
 type HealthCheckConfig struct {
 	// 0 (default) means disabled
 	Port int `yaml:"port" env:"OTEL_EBPF_HEALTH_CHECK_PORT" validate:"gte=0,lte=65535"`
+	// IP address the TCP health endpoint binds to. Defaults to 127.0.0.1. Set to 0.0.0.0
+	// or :: only when external probes require access.
+	ListenAddress string `yaml:"listen_address" env:"OTEL_EBPF_HEALTH_CHECK_LISTEN_ADDRESS" validate:"omitempty,ip" jsonschema:"type=string,format=ip"`
 	// when set, the health endpoint binds this unix socket (a filesystem path or a leading-'@'
 	// abstract name) instead of the TCP port
 	UnixSocketPath string `yaml:"unix_socket_path" env:"OTEL_EBPF_HEALTH_CHECK_UNIX_SOCKET_PATH"`

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 	"go.opentelemetry.io/obi/pkg/export/prom"
+	"go.opentelemetry.io/obi/pkg/health"
 	"go.opentelemetry.io/obi/pkg/internal/avoidedsvc"
 	"go.opentelemetry.io/obi/pkg/internal/pipe/cidr"
 	"go.opentelemetry.io/obi/pkg/kube"
@@ -400,7 +401,8 @@ discovery:
 			SamplingInterval: time.Second,
 		},
 		HealthCheck: HealthCheckConfig{
-			Port: 0,
+			Port:          0,
+			ListenAddress: health.DefaultListenAddress,
 		},
 	}, cfg)
 }
@@ -879,6 +881,42 @@ health_check:
 `)
 		cfg, err := LoadConfig(userConfig)
 		require.NoError(t, err)
+		require.Error(t, cfg.Validate())
+	})
+}
+
+func TestHealthCheckListenAddress(t *testing.T) {
+	t.Run("defaults to loopback", func(t *testing.T) {
+		unsetEnv(t, "OTEL_EBPF_HEALTH_CHECK_LISTEN_ADDRESS")
+
+		cfg, err := LoadConfig(nil)
+		require.NoError(t, err)
+		assert.Equal(t, health.DefaultListenAddress, cfg.HealthCheck.ListenAddress)
+	})
+
+	t.Run("loads external address from YAML", func(t *testing.T) {
+		unsetEnv(t, "OTEL_EBPF_HEALTH_CHECK_LISTEN_ADDRESS")
+		userConfig := bytes.NewBufferString(`health_check:
+  listen_address: 0.0.0.0
+  port: 8080
+`)
+
+		cfg, err := LoadConfig(userConfig)
+		require.NoError(t, err)
+		assert.Equal(t, "0.0.0.0", cfg.HealthCheck.ListenAddress)
+	})
+
+	t.Run("loads external address from environment", func(t *testing.T) {
+		t.Setenv("OTEL_EBPF_HEALTH_CHECK_LISTEN_ADDRESS", "::")
+
+		cfg, err := LoadConfig(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "::", cfg.HealthCheck.ListenAddress)
+	})
+
+	t.Run("rejects non-IP address", func(t *testing.T) {
+		cfg := DefaultConfig
+		cfg.HealthCheck.ListenAddress = "localhost"
 		require.Error(t, cfg.Validate())
 	})
 }


### PR DESCRIPTION
The optional TCP health endpoint previously exposed an unauthenticated listener on every network interface. Clients could retain idle HTTP/1.1 connections indefinitely, consuming file descriptors and goroutines in the privileged OBI process. The response also exposes process timing information to every network peer that can reach the configured port.

### Description

- Bind `health_check.port` to `127.0.0.1` so the unauthenticated endpoint and its timing response are not reachable outside OBI's network namespace.
- Limit the health listener to 100 concurrent accepted connections.
- Configure 5-second read-header, read, write, and idle timeouts.
- Preserve Unix-domain-socket health checks as the alternative for local integrations.
- Document the loopback-only TCP behavior in the configuration schema and generated reference.
- Add coverage for the loopback address, timeout configuration, and actual idle keep-alive expiration.

### Compatibility

Kubernetes HTTP probes that connect to the pod IP can no longer reach the TCP endpoint. Deployments that need a Kubernetes probe should use an exec probe targeting `127.0.0.1` or the configured Unix-domain socket.

### Testing

- `go test -count=20 ./pkg/health`
- `go test -race -count=1 ./pkg/health ./pkg/obi ./pkg/instrumenter`
- `make check-config-schema`
- Markdown lint for `devdocs/config/CONFIG.md`
