### PR TITLE
fix(ebpf): enforce the valid_pids index space invariant

### DIFF
--- a/bpf/pid/pid.h
+++ b/bpf/pid/pid.h
@@ -19,6 +19,10 @@ volatile const s32 filter_pids = 0;
 
 enum { k_prime_hash = 192053 }; // closest prime to k_max_concurrent_pids * 64
 
+// out of range makes the lookup in pid_matches() miss, which fails open
+_Static_assert((k_prime_hash - 1) / 64 < k_max_concurrent_pids,
+               "k_prime_hash exceeds the valid_pids index space");
+
 static __always_inline u8 pid_matches(pid_data_t *p) {
     // combine the namespace id and the pid into one single u64
     const u64 k = (((u64)p->ns) << 32) | p->pid;

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -133,10 +133,6 @@ func (p *Tracer) rebuildValidPids() error {
 		return nil
 	}
 
-	if err := p.validateValidPidsMap(); err != nil {
-		return err
-	}
-
 	v := p.buildPidFilter()
 
 	p.log.Debug("number of segments in pid filter cache", "len", len(v))
@@ -667,8 +663,11 @@ func (p *Tracer) Run(
 	// At this point we now have loaded the bpf objects, which means we should insert any
 	// pids that are allowed into the bpf map
 	if p.bpfObjects.ValidPids != nil {
+		if err := p.validateValidPidsMap(); err != nil {
+			p.log.Error("BPF PID filter map sizing is invalid, discovery filtering may not be enforced", "error", err)
+		}
 		if err := p.rebuildValidPids(); err != nil {
-			p.log.Error("Error setting up the BPF PID filter, discovery filtering may not be enforced", "error", err)
+			p.log.Error("setting up the BPF PID filter, discovery filtering may not be enforced", "error", err)
 		}
 	} else {
 		p.log.Error("BPF Pids map is not created yet, this is a bug.")

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -74,9 +74,8 @@ func New(pidFilter ebpfcommon.ServiceFilter, cfg *obi.Config, metrics imetrics.R
 	}
 }
 
-// Updating these requires updating the constants below in pid.h
-// #define MAX_CONCURRENT_PIDS 3001 // estimate: 1000 concurrent processes (including children) * 3 namespaces per pid
-// #define PRIME_HASH 192053 // closest prime to 3001 * 64
+// Keep in sync with k_max_concurrent_pids (bpf/pid/maps/map_sizing.h) and
+// k_prime_hash (bpf/pid/pid.h), which assert they agree at compile time.
 const (
 	maxConcurrentPids = 3001
 	primeHash         = 192053
@@ -110,24 +109,45 @@ func (p *Tracer) buildPidFilter() []uint64 {
 	return result
 }
 
-func (p *Tracer) rebuildValidPids() {
-	if p.bpfObjects.ValidPids != nil {
-		v := p.buildPidFilter()
+// validateValidPidsMap rejects a map too small to hold every segment index, which
+// would make pid_matches() miss and fail open.
+func (p *Tracer) validateValidPidsMap() error {
+	if got := p.bpfObjects.ValidPids.MaxEntries(); got != maxConcurrentPids {
+		return fmt.Errorf(
+			"valid_pids BPF map holds %d entries, expected %d: the PID filter would fail open",
+			got, maxConcurrentPids)
+	}
 
-		p.log.Debug("number of segments in pid filter cache", "len", len(v))
+	return nil
+}
 
-		for i, segment := range v {
-			err := p.bpfObjects.ValidPids.Put(uint32(i), segment)
-			if err != nil {
-				p.log.Error("Error setting up pid in BPF space, sizes of Go and BPF maps don't match", "error", err, "i", i)
-			}
+func (p *Tracer) rebuildValidPids() error {
+	if p.bpfObjects.ValidPids == nil {
+		return nil
+	}
+
+	if err := p.validateValidPidsMap(); err != nil {
+		return err
+	}
+
+	v := p.buildPidFilter()
+
+	p.log.Debug("number of segments in pid filter cache", "len", len(v))
+
+	for i, segment := range v {
+		if err := p.bpfObjects.ValidPids.Put(uint32(i), segment); err != nil {
+			return fmt.Errorf("setting up pid segment %d in BPF space: %w", i, err)
 		}
 	}
+
+	return nil
 }
 
 func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 	p.pidsFilter.AllowPID(pid, ns, fi, ebpfcommon.PIDTypeKProbes)
-	p.rebuildValidPids()
+	if err := p.rebuildValidPids(); err != nil {
+		p.log.Error("Error rebuilding the BPF PID filter", "error", err)
+	}
 	// Keep the cache consistent with the updated filter.
 	if p.bpfObjects.PidCache != nil {
 		pidU32 := uint32(pid)
@@ -137,7 +157,9 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 
 func (p *Tracer) BlockPID(pid app.PID, ns uint32) {
 	p.pidsFilter.BlockPID(pid, ns)
-	p.rebuildValidPids()
+	if err := p.rebuildValidPids(); err != nil {
+		p.log.Error("Error rebuilding the BPF PID filter", "error", err)
+	}
 	// Remove from cache so next access re-evaluates.
 	if p.bpfObjects.PidCache != nil {
 		pidU32 := uint32(pid)
@@ -632,7 +654,9 @@ func (p *Tracer) Run(
 	// At this point we now have loaded the bpf objects, which means we should insert any
 	// pids that are allowed into the bpf map
 	if p.bpfObjects.ValidPids != nil {
-		p.rebuildValidPids()
+		if err := p.rebuildValidPids(); err != nil {
+			p.log.Error("Error setting up the BPF PID filter, discovery filtering may not be enforced", "error", err)
+		}
 	} else {
 		p.log.Error("BPF Pids map is not created yet, this is a bug.")
 	}

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -74,11 +74,16 @@ func New(pidFilter ebpfcommon.ServiceFilter, cfg *obi.Config, metrics imetrics.R
 	}
 }
 
-// Keep in sync with k_max_concurrent_pids (bpf/pid/maps/map_sizing.h) and
-// k_prime_hash (bpf/pid/pid.h), which assert they agree at compile time.
+// Keep in sync with the BPF side, which asserts the relation between both
+// constants at compile time (bpf/pid/pid.h).
 const (
+	// mirrors k_max_concurrent_pids (bpf/pid/maps/map_sizing.h): estimate of
+	// 1000 concurrent processes (including children) * 3 namespaces per pid
 	maxConcurrentPids = 3001
-	primeHash         = 192053
+	// mirrors k_prime_hash (bpf/pid/pid.h): closest prime below
+	// maxConcurrentPids * 64; modulo by a prime distributes the hash evenly
+	// across the segment bit array
+	primeHash = 192053
 )
 
 func pidSegmentBit(k uint64) (uint32, uint32) {
@@ -109,12 +114,14 @@ func (p *Tracer) buildPidFilter() []uint64 {
 	return result
 }
 
-// validateValidPidsMap rejects a map too small to hold every segment index, which
-// would make pid_matches() miss and fail open.
+// validateValidPidsMap ensures the loaded map matches the index space written
+// by rebuildValidPids: a smaller map makes pid_matches() lookups miss and fail
+// open, while a larger one leaves segments unset, silently filtering out
+// matching PIDs.
 func (p *Tracer) validateValidPidsMap() error {
 	if got := p.bpfObjects.ValidPids.MaxEntries(); got != maxConcurrentPids {
 		return fmt.Errorf(
-			"valid_pids BPF map holds %d entries, expected %d: the PID filter would fail open",
+			"valid_pids BPF map holds %d entries, expected %d: BPF and userspace PID filter constants have diverged",
 			got, maxConcurrentPids)
 	}
 
@@ -145,9 +152,12 @@ func (p *Tracer) rebuildValidPids() error {
 
 func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 	p.pidsFilter.AllowPID(pid, ns, fi, ebpfcommon.PIDTypeKProbes)
+
 	if err := p.rebuildValidPids(); err != nil {
-		p.log.Error("Error rebuilding the BPF PID filter", "error", err)
+		p.log.Error("rebuilding the BPF PID filter", "error", err)
+		return
 	}
+
 	// Keep the cache consistent with the updated filter.
 	if p.bpfObjects.PidCache != nil {
 		pidU32 := uint32(pid)
@@ -157,9 +167,12 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 
 func (p *Tracer) BlockPID(pid app.PID, ns uint32) {
 	p.pidsFilter.BlockPID(pid, ns)
+
 	if err := p.rebuildValidPids(); err != nil {
-		p.log.Error("Error rebuilding the BPF PID filter", "error", err)
+		p.log.Error("rebuilding the BPF PID filter", "error", err)
+		return
 	}
+
 	// Remove from cache so next access re-evaluates.
 	if p.bpfObjects.PidCache != nil {
 		pidU32 := uint32(pid)

--- a/pkg/internal/ebpf/generictracer/generictracer_test.go
+++ b/pkg/internal/ebpf/generictracer/generictracer_test.go
@@ -51,6 +51,18 @@ func makeKey(first, second uint32) uint64 {
 	return (uint64(first) << 32) | uint64(second)
 }
 
+// Mirrors the _Static_assert in bpf/pid/pid.h.
+func TestPidFilterIndexSpaceFitsMap(t *testing.T) {
+	highestSegment := (primeHash - 1) / 64
+
+	assert.Less(t, highestSegment, maxConcurrentPids,
+		"primeHash %d needs %d segments but valid_pids holds %d",
+		primeHash, highestSegment+1, maxConcurrentPids)
+
+	// buildPidFilter must allocate a slot for every reachable segment.
+	assert.Len(t, (&Tracer{pidsFilter: fakeServiceFilter{}}).buildPidFilter(), maxConcurrentPids)
+}
+
 func TestParseJVMMemoryPoolRecordDecoratesServiceByPIDNamespace(t *testing.T) {
 	service := svc.Attrs{UID: svc.UID{Name: "orders", Namespace: "prod"}}
 	currentPIDsCalls := 0


### PR DESCRIPTION
## Summary

`pid_matches()` treats a failed `valid_pids` lookup as a match, so a map too small for the segment index space would disable discovery filtering across all probes at once. The sizing currently works out with zero headroom — `(k_prime_hash - 1) / 64` is exactly `k_max_concurrent_pids - 1` — but nothing enforced it on either side.

- `bpf/pid/pid.h`: `_Static_assert` on the invariant
- `generictracer.go`: validate the loaded map's `MaxEntries` before writing to it
- `rebuildValidPids` returns an error and fails fast, instead of logging once per segment

Refs #2801.

This hardens against regressions rather than fixing a live fail-open: the lookup cannot currently miss (segment tops out at 3000, the array holds 3001), and #2800 already removed the known trigger. The stale comment on the Go constants pointed at `#define`s that no longer exist, which is how the invariant could drift unnoticed.

## AI usage

Per AI-POLICY §5: Claude Code was used to analyze issue #2801, write these changes, and run the verification below. I reviewed the resulting diff before submitting.

Verification run:
- BPF compile (`-Werror`) for amd64 + arm64
- assert confirmed to fire at `k_prime_hash=192065`, pass at `192064`
- `go vet` clean; `./pkg/internal/ebpf/...` tests pass

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
