### PR TITLE
ci: run unit tests on arm

### DIFF
--- a/.github/workflows/bpf_verifier.yml
+++ b/.github/workflows/bpf_verifier.yml
@@ -107,20 +107,6 @@ jobs:
             TARGET_TEST=run-bpf-verifier-vm \
             && [ -f testoutput/success ]
 
-  generate-bpf-arm:
-    name: Generate BPF (arm64)
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-          persist-credentials: false
-
-      - uses: ./.github/actions/generate-bpf
-        with:
-          artifact-name: bpf-generated-arm-${{ github.run_id }}
-
   al2023:
     name: Kernel al2023-${{ matrix.nvr }}
     needs: generate-bpf
@@ -167,7 +153,7 @@ jobs:
     name: Host kernel (arm64)
     # Runs verifier suite directly on the runner's own kernel — no VM, no
     # kernel matrix. Cheapest way to keep arm64 in the PR-blocking set.
-    needs: generate-bpf-arm
+    needs: generate-bpf
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     steps:
@@ -193,7 +179,7 @@ jobs:
       - name: Download generated BPF files
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: bpf-generated-arm-${{ github.run_id }}
+          name: bpf-generated-${{ github.run_id }}
 
       - name: Run BPF verifier tests (host kernel)
         run: go test -exec=sudo -count=1 -timeout=20m -parallel=8 -tags=bpf_verifier_tests ./pkg/internal/ebpf/verifier/...

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   generate-bpf:
     name: Generate BPF
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -47,7 +47,6 @@ jobs:
 
       - uses: ./.github/actions/generate-bpf
         with:
-          artifact-name: bpf-generated-arm-${{ github.run_id }}
           cache-key-prefix: go-build-integration
 
   test-matrix:
@@ -168,7 +167,7 @@ jobs:
       - name: Download generated BPF files
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: bpf-generated-arm-${{ github.run_id }}
+          name: bpf-generated-${{ github.run_id }}
 
       - name: Build test tools
         run: make prereqs

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -66,16 +66,22 @@ jobs:
           make unit-test-matrix-json >> "$GITHUB_OUTPUT"
 
   test:
-    name: "Unit tests #${{ matrix.id }}"
+    name: "Unit tests #${{ matrix.shard.id }} (${{ matrix.platform.arch }})"
     needs: [matrix, generate-bpf]
     permissions:
       checks: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.matrix.outputs.matrix) }}
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+        shard: ${{ fromJson(needs.matrix.outputs.matrix).include }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -106,15 +112,15 @@ jobs:
 
       - name: Run unit tests
         env:
-          MATRIX_ID: ${{ matrix.id }}
-          MATRIX_PACKAGES: ${{ matrix.packages }}
+          MATRIX_ID: ${{ matrix.shard.id }}
+          MATRIX_PACKAGES: ${{ matrix.shard.packages }}
         run: make run-unit-test-shard cov-exclude-generated SHARD_ID="${MATRIX_ID}" UNIT_TEST_PACKAGES="${MATRIX_PACKAGES}"
 
       - name: Upload unit test report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: unit-reports-${{ matrix.id }}-${{ github.run_number }}
+          name: unit-reports-${{ matrix.shard.id }}-${{ matrix.platform.arch }}-${{ github.run_number }}
           path: testoutput/unit-test-shard-*.log
           retention-days: 5
 
@@ -125,4 +131,4 @@ jobs:
         with:
           files: ./testoutput/cover.txt
           flags: unittests
-          name: unit-coverage-${{ matrix.id }}-${{ github.run_number }}
+          name: unit-coverage-${{ matrix.shard.id }}-${{ matrix.platform.arch }}-${{ github.run_number }}


### PR DESCRIPTION
## Summary

Part of:

- #2849 

This PR adds ARM to the list of platforms that the unit tests run on, so that they will now run on both x86 and ARM.

Also remove redundant `generate-bpf-arm` step as the existing `generate-bpf` creates both x86 and ARM artifacts already.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

Unit tests running on both x86 and arm:

https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/30557663403?pr=2853

<img width="679" height="405" alt="Screenshot 2026-07-30 at 16 45 25" src="https://github.com/user-attachments/assets/696b1707-00a0-4265-8a3f-8b54c10e8fdd" />
