### PR TITLE
fix(ebpf): page-align UserRingbuf max_entries like RingBuf

### DIFF
--- a/pkg/internal/ebpf/convenience/convenience.go
+++ b/pkg/internal/ebpf/convenience/convenience.go
@@ -32,9 +32,9 @@ func roundToNearestMultiple(x, n uint32) uint32 {
 	return (x + n/2) / n * n
 }
 
-// RingBuf map types must be a multiple of os.Getpagesize()
+// RingBuf and UserRingbuf max_entries must be page-aligned: both go through the kernel's ringbuf_map_alloc
 func alignMaxEntriesIfRingBuf(m *ebpf.MapSpec) {
-	if m.Type == ebpf.RingBuf {
+	if m.Type == ebpf.RingBuf || m.Type == ebpf.UserRingbuf {
 		m.MaxEntries = roundToNearestMultiple(m.MaxEntries, uint32(os.Getpagesize()))
 	}
 }

--- a/pkg/internal/ebpf/convenience/convenience_test.go
+++ b/pkg/internal/ebpf/convenience/convenience_test.go
@@ -5,6 +5,7 @@ package ebpfconvenience
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/cilium/ebpf"
@@ -220,5 +221,27 @@ func TestIsResizableMapType(t *testing.T) {
 		if !isResizableMapType(mt) {
 			t.Errorf("expected %v to be resizable", mt)
 		}
+	}
+}
+
+func TestAlignMaxEntriesIfRingBuf(t *testing.T) {
+	pageSize := uint32(os.Getpagesize())
+
+	for _, mt := range []ebpf.MapType{ebpf.RingBuf, ebpf.UserRingbuf} {
+		m := &ebpf.MapSpec{Type: mt, MaxEntries: pageSize + 1}
+
+		alignMaxEntriesIfRingBuf(m)
+
+		if m.MaxEntries%pageSize != 0 {
+			t.Errorf("%v: MaxEntries %d is not page-aligned", mt, m.MaxEntries)
+		}
+	}
+
+	hash := &ebpf.MapSpec{Type: ebpf.Hash, MaxEntries: pageSize + 1}
+
+	alignMaxEntriesIfRingBuf(hash)
+
+	if hash.MaxEntries != pageSize+1 {
+		t.Errorf("non-ringbuf map should not be realigned: got %d", hash.MaxEntries)
 	}
 }


### PR DESCRIPTION
## Summary

`alignMaxEntriesIfRingBuf` only covers `ebpf.RingBuf`, but `UserRingbuf` is allocated
through the same kernel path (`ringbuf_map_alloc`), which requires `max_entries` to be
page-aligned. A `UserRingbuf` map scaled down with a negative `global_scale_factor`
would skip the fixup and fail at load.

Not reachable today — OBI defines no `UserRingbuf` maps — so this is a preventive fix
so the case isn't missed if one is added later. Extends the condition to both types and
adds a test covering the alignment for both, plus that other map types are left untouched.

Fixes #2808

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] N/A — internal map-sizing fix with no feature support status change, so the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) are unchanged.

---

AI policy: I used Claude Code to draft the change and this description. I reviewed
the code and ran the tests myself.