### PR TITLE
Improve performance of BPF metrics

### DIFF
--- a/devdocs/README.md
+++ b/devdocs/README.md
@@ -19,4 +19,5 @@ This directory contains documentation that is not useful for our users but might
 - [Trace-Profile Correlation](trace-profile-correlation.md): standard communication channel for correlating profiles to OBI traces.
 - [Kubernetes Metadata Cache Service (`k8s-cache`)](k8s-cache.md): what the standalone metadata cache service is, why it exists, and how to deploy it alongside OBI.
 - [Metrics](./metrics.md): how the NetO11y, AppO11y, and StatsO11y pipelines turn eBPF events into exported metrics, and where to edit when adding a new one.
+- [BPF Metrics Collection](bpf-metrics-collection.md): how OBI discovers all existing supported probes and LRU hash maps on the host and reports their metrics.
 - [Runtime Metrics](runtimes/README.md): developer notes for the `application_runtime` feature and per-runtime coverage.

--- a/devdocs/bpf-metrics-collection.md
+++ b/devdocs/bpf-metrics-collection.md
@@ -56,15 +56,16 @@ labels. Map metrics use the map ID, type, and name.
 
 ## Program discovery and statistics
 
-Each collection enables kernel BPF runtime statistics, walks every program ID,
-and reads `Stats()` from every supported program. Metadata is cached when a
-program is first observed. Supported program handles are retained, while
-unsupported program handles are closed immediately.
+The collector enables kernel BPF runtime statistics for its lifetime so that
+accounting continues between collections. Each collection walks every program
+ID and reads `Stats()` from every supported program. Metadata is cached when a
+program is first observed. Each supported program is opened temporarily to read
+its statistics and closed before collection continues. Unsupported program
+types are cached without retaining their handles.
 
-Runtime statistics are enabled only during the collection window. The
-collector reports execution-count and runtime changes between collections and
-derives probe latency by dividing the runtime change by the execution-count
-change.
+The collector reports execution-count and runtime changes between collections
+and derives probe latency by dividing the runtime change by the execution-count
+change. Runtime statistics are disabled when the collector shuts down.
 
 ## Map discovery and entry counting
 

--- a/devdocs/bpf-metrics-collection.md
+++ b/devdocs/bpf-metrics-collection.md
@@ -1,0 +1,74 @@
+# BPF metrics collection
+
+The BPF metrics collector reports execution statistics for eBPF programs and
+entry counts for eBPF LRU hash maps loaded on the host.
+
+The collector is host-wide. Every collection walks the kernel's complete
+program ID namespace from the beginning, so it captures all existing probes of
+the supported program types, including probes that were not loaded by OBI. A
+later collection also discovers probes loaded after the collector started.
+
+## Supported kernel objects
+
+The collector reports programs with these eBPF program types:
+
+- `Kprobe`
+- `SocketFilter`
+- `SchedCLS`
+- `SkMsg`
+- `SockOps`
+
+It reports entry counts only for `LRUHash` maps. Other program and map types are
+still encountered during the host-wide walks, but they are not emitted as
+metrics.
+
+## Collection paths
+
+BPF metrics can be collected through either of these paths:
+
+- The Prometheus BPF collector is active when a Prometheus endpoint is enabled
+  and the `ebpf` metrics feature is selected.
+- The internal metrics collector is active when
+  `internal_metrics.bpf_metric_scrape_interval` is greater than zero. The
+  configured internal reporter exports the collected values through
+  Prometheus or OpenTelemetry.
+
+If both paths are active, each path owns a separate collector.
+
+### Prometheus collector metrics
+
+| Metric | Type | Labels |
+| --- | --- | --- |
+| `bpf_probe_latency_seconds` | Histogram | `probe_id`, `probe_type`, `probe_name` |
+| `bpf_map_entries_total` | Counter | `map_id`, `map_name`, `map_type`, `max_entries` |
+
+### Internal metrics
+
+| Prometheus metric | OpenTelemetry metric | Value |
+| --- | --- | --- |
+| `obi_bpf_probe_executions_total` | `obi.bpf.probe.executions` | Probe executions |
+| `obi_bpf_probe_latency_seconds_total` | `obi.bpf.probe.latency_seconds_total` | Total probe runtime in seconds |
+| `obi_bpf_map_entries_total` | `obi.bpf.map.entries_total` | Current map entry count |
+| `obi_bpf_map_max_entries_total` | `obi.bpf.map.max_entries_total` | Configured maximum map entries |
+
+Probe metrics use the program ID, type, and function name as attributes or
+labels. Map metrics use the map ID, type, and name.
+
+## Program discovery and statistics
+
+Each collection enables kernel BPF runtime statistics, walks every program ID,
+and reads `Stats()` from every supported program. Metadata is cached when a
+program is first observed. Supported program handles are retained, while
+unsupported program handles are closed immediately.
+
+Runtime statistics are enabled only during the collection window. The
+collector reports execution-count and runtime changes between collections and
+derives probe latency by dividing the runtime change by the execution-count
+change.
+
+## Map discovery and entry counting
+
+Each collection walks every map ID and caches metadata for newly observed maps.
+For each `LRUHash` map, it opens a temporary handle, iterates the entries to
+count them, and closes the handle. Missing metadata entries are removed after a
+complete ID walk.

--- a/pkg/export/prom/prom_bpf.go
+++ b/pkg/export/prom/prom_bpf.go
@@ -39,12 +39,13 @@ type BPFCollector struct {
 	mapCache         map[ebpf.MapID]*cachedMap
 	probeMetrics     func() []ProbeMetrics
 	mapMetrics       func() []BpfMapMetrics
+	closeBPFStats    func()
 	mu               sync.Mutex
 	closed           bool
 }
 
 type cachedProgram struct {
-	program   *ebpf.Program
+	supported bool
 	probeType string
 	probeName string
 	probeID   string
@@ -88,7 +89,7 @@ func BPFMetrics(
 	cfg *PrometheusConfig,
 	mpCfg *perapp.MetricsConfig,
 ) swarm.InstanceFunc {
-	return func(_ context.Context) (swarm.RunFunc, error) {
+	return func(ctx context.Context) (swarm.RunFunc, error) {
 		promEnabled := promMetricsEnabled(cfg, mpCfg)
 		internalEnabled := internalMetricsEnabled(ctxInfo.Metrics)
 		if !promEnabled && !internalEnabled {
@@ -98,10 +99,12 @@ func BPFMetrics(
 		runFns := make([]swarm.RunFunc, 0, 2)
 		if promEnabled {
 			collector := newBPFCollectorFn(ctxInfo, cfg, mpCfg)
+			collector.cleanupOnContext(ctx)
 			runFns = append(runFns, collector.startPrometheus)
 		}
 		if internalEnabled {
 			collector := newInternalBPFCollectorFn(ctxInfo, cfg, mpCfg)
+			collector.cleanupOnContext(ctx)
 			runFns = append(runFns, collector.startInternalMetrics)
 		}
 
@@ -168,6 +171,7 @@ func newCollector(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *per
 	}
 	c.probeMetrics = c.getProbeMetrics
 	c.mapMetrics = c.getMapMetrics
+	c.closeBPFStats = c.enableBPFStatsRuntime()
 	if registerProm && promMetricsEnabled(cfg, mpCfg) {
 		// Register the collector
 		c.promConnect.Register(cfg.Port, cfg.Path, c)
@@ -204,13 +208,13 @@ func (bc *BPFCollector) close() {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
+	if bc.closed {
+		return
+	}
 	bc.closed = true
-	for id, cached := range bc.programCache {
-		if cached.program != nil {
-			if err := cached.program.Close(); err != nil {
-				bc.log.Debug("failed to close cached program", "ID", id, "error", err)
-			}
-		}
+	if bc.closeBPFStats != nil {
+		bc.closeBPFStats()
+		bc.closeBPFStats = nil
 	}
 	clear(bc.programCache)
 	clear(bc.mapCache)
@@ -307,9 +311,6 @@ func (bc *BPFCollector) collectMetrics() ([]ProbeMetrics, []BpfMapMetrics) {
 }
 
 func (bc *BPFCollector) getProbeMetrics() []ProbeMetrics {
-	cleanup := bc.enableBPFStatsRuntime()
-	defer cleanup()
-
 	probeMetrics := make([]ProbeMetrics, 0, len(bc.programCache))
 	seen := make(map[ebpf.ProgramID]struct{}, len(bc.programCache))
 	completeWalk := false
@@ -324,14 +325,26 @@ func (bc *BPFCollector) getProbeMetrics() []ProbeMetrics {
 		seen[id] = struct{}{}
 
 		cached, ok := bc.programCache[id]
-		if !ok {
-			cached = bc.cacheProgram(id)
-		}
-		if cached == nil || cached.program == nil {
+		if ok && !cached.supported {
 			continue
 		}
 
-		stats, err := cached.program.Stats()
+		program, err := ebpf.NewProgramFromID(id)
+		if err != nil {
+			bc.log.Debug("failed to load program", "ID", id, "error", err)
+			continue
+		}
+
+		if !ok {
+			cached = bc.cacheProgram(id, program)
+		}
+		if cached == nil || !cached.supported {
+			bc.closeProgram(id, program)
+			continue
+		}
+
+		stats, err := program.Stats()
+		bc.closeProgram(id, program)
 		if err != nil {
 			bc.log.Debug("failed to get program stats", "ID", id, "error", err)
 			continue
@@ -370,29 +383,21 @@ func (bc *BPFCollector) getProbeMetrics() []ProbeMetrics {
 	return probeMetrics
 }
 
-func (bc *BPFCollector) cacheProgram(id ebpf.ProgramID) *cachedProgram {
-	program, err := ebpf.NewProgramFromID(id)
-	if err != nil {
-		bc.log.Debug("failed to load program", "ID", id, "error", err)
-		return nil
-	}
-
+func (bc *BPFCollector) cacheProgram(id ebpf.ProgramID, program *ebpf.Program) *cachedProgram {
 	info, err := program.Info()
 	if err != nil {
 		bc.log.Debug("failed to get program info", "ID", id, "error", err)
-		bc.closeProgram(id, program)
 		return nil
 	}
 
 	if !supportedProgramType(info.Type) {
-		bc.closeProgram(id, program)
 		cached := &cachedProgram{}
 		bc.programCache[id] = cached
 		return cached
 	}
 
 	cached := &cachedProgram{
-		program:   program,
+		supported: true,
 		probeType: info.Type.String(),
 		probeName: getFuncName(info, id, bc.log),
 		probeID:   strconv.FormatUint(uint64(id), 10),
@@ -411,12 +416,9 @@ func supportedProgramType(programType ebpf.ProgramType) bool {
 }
 
 func (bc *BPFCollector) evictMissingPrograms(seen map[ebpf.ProgramID]struct{}) {
-	for id, cached := range bc.programCache {
+	for id := range bc.programCache {
 		if _, ok := seen[id]; ok {
 			continue
-		}
-		if cached.program != nil {
-			bc.closeProgram(id, cached.program)
 		}
 		delete(bc.programCache, id)
 		delete(bc.progs, id)

--- a/pkg/export/prom/prom_bpf.go
+++ b/pkg/export/prom/prom_bpf.go
@@ -6,7 +6,9 @@ package prom // import "go.opentelemetry.io/obi/pkg/export/prom"
 import (
 	"context"
 	"encoding"
+	"errors"
 	"log/slog"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -33,9 +35,27 @@ type BPFCollector struct {
 	probeLatencyDesc *prometheus.Desc
 	mapSizeDesc      *prometheus.Desc
 	progs            map[ebpf.ProgramID]*BPFProgram
+	programCache     map[ebpf.ProgramID]*cachedProgram
+	mapCache         map[ebpf.MapID]*cachedMap
 	probeMetrics     func() []ProbeMetrics
 	mapMetrics       func() []BpfMapMetrics
 	mu               sync.Mutex
+	closed           bool
+}
+
+type cachedProgram struct {
+	program   *ebpf.Program
+	probeType string
+	probeName string
+	probeID   string
+}
+
+type cachedMap struct {
+	supported  bool
+	mapType    string
+	mapName    string
+	mapID      string
+	maxEntries int
 }
 
 type BPFProgram struct {
@@ -131,6 +151,8 @@ func newCollector(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *per
 		ctxInfo:         ctxInfo,
 		promConnect:     ctxInfo.Prometheus,
 		progs:           make(map[ebpf.ProgramID]*BPFProgram),
+		programCache:    make(map[ebpf.ProgramID]*cachedProgram),
+		mapCache:        make(map[ebpf.MapID]*cachedMap),
 		probeLatencyDesc: prometheus.NewDesc(
 			prometheus.BuildFQName("bpf", "probe", "latency_seconds"),
 			"Latency of the probe in seconds",
@@ -154,6 +176,7 @@ func newCollector(ctxInfo *global.ContextInfo, cfg *PrometheusConfig, mpCfg *per
 }
 
 func (bc *BPFCollector) startPrometheus(ctx context.Context) {
+	bc.cleanupOnContext(ctx)
 	bc.reportMetrics(ctx)
 }
 
@@ -161,7 +184,37 @@ func (bc *BPFCollector) startInternalMetrics(ctx context.Context) {
 	if !internalMetricsEnabled(bc.internalMetrics) {
 		return
 	}
+	bc.cleanupOnContext(ctx)
 	go bc.collectInternalMetrics(ctx)
+}
+
+func (bc *BPFCollector) cleanupOnContext(ctx context.Context) {
+	done := ctx.Done()
+	if done == nil {
+		return
+	}
+
+	go func() {
+		<-done
+		bc.close()
+	}()
+}
+
+func (bc *BPFCollector) close() {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+
+	bc.closed = true
+	for id, cached := range bc.programCache {
+		if cached.program != nil {
+			if err := cached.program.Close(); err != nil {
+				bc.log.Debug("failed to close cached program", "ID", id, "error", err)
+			}
+		}
+	}
+	clear(bc.programCache)
+	clear(bc.mapCache)
+	clear(bc.progs)
 }
 
 func (bc *BPFCollector) reportMetrics(ctx context.Context) {
@@ -209,6 +262,10 @@ func (bc *BPFCollector) Collect(ch chan<- prometheus.Metric) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
+	if bc.closed {
+		return
+	}
+
 	probeMetrics := bc.probeMetrics()
 	for _, metric := range probeMetrics {
 		metric.program.updateBuckets(metric.latency, metric.count)
@@ -242,52 +299,44 @@ func (bc *BPFCollector) collectMetrics() ([]ProbeMetrics, []BpfMapMetrics) {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
 
+	if bc.closed {
+		return nil, nil
+	}
+
 	return bc.probeMetrics(), bc.mapMetrics()
 }
 
 func (bc *BPFCollector) getProbeMetrics() []ProbeMetrics {
-	bc.enableBPFStatsRuntime()
+	cleanup := bc.enableBPFStatsRuntime()
+	defer cleanup()
 
-	probeMetrics := make([]ProbeMetrics, 0)
+	probeMetrics := make([]ProbeMetrics, 0, len(bc.programCache))
+	seen := make(map[ebpf.ProgramID]struct{}, len(bc.programCache))
+	completeWalk := false
 
 	for id := ebpf.ProgramID(0); ; {
 		nextID, err := ebpf.ProgramGetNextID(id)
 		if err != nil {
+			completeWalk = errors.Is(err, os.ErrNotExist)
 			break
 		}
 		id = nextID
+		seen[id] = struct{}{}
 
-		program, err := ebpf.NewProgramFromID(id)
-		if err != nil {
-			bc.log.Debug("failed to load program", "ID", id, "error", err)
-			continue
+		cached, ok := bc.programCache[id]
+		if !ok {
+			cached = bc.cacheProgram(id)
 		}
-		defer program.Close()
-
-		info, err := program.Info()
-		if err != nil {
-			bc.log.Debug("failed to get program info", "ID", id, "error", err)
+		if cached == nil || cached.program == nil {
 			continue
 		}
 
-		switch info.Type {
-		case ebpf.Kprobe, ebpf.SocketFilter, ebpf.SchedCLS, ebpf.SkMsg, ebpf.SockOps:
-		// Supported program types
-		default:
-			continue // Skip unsupported program types
-		}
-
-		name := getFuncName(info, id, bc.log)
-
-		stats, err := program.Stats()
+		stats, err := cached.program.Stats()
 		if err != nil {
 			bc.log.Debug("failed to get program stats", "ID", id, "error", err)
 			continue
 		}
 
-		idStr := strconv.FormatUint(uint64(id), 10)
-
-		// Get the previous stats
 		probe, ok := bc.progs[id]
 		if !ok {
 			probe = &BPFProgram{
@@ -305,15 +354,79 @@ func (bc *BPFCollector) getProbeMetrics() []ProbeMetrics {
 		}
 		latency, count := probe.calculateStats()
 		probeMetrics = append(probeMetrics, ProbeMetrics{
-			probeID:   idStr,
-			probeType: info.Type.String(),
-			probeName: name,
+			probeID:   cached.probeID,
+			probeType: cached.probeType,
+			probeName: cached.probeName,
 			latency:   latency,
 			count:     count,
 			program:   probe,
 		})
 	}
+
+	if completeWalk {
+		bc.evictMissingPrograms(seen)
+	}
+
 	return probeMetrics
+}
+
+func (bc *BPFCollector) cacheProgram(id ebpf.ProgramID) *cachedProgram {
+	program, err := ebpf.NewProgramFromID(id)
+	if err != nil {
+		bc.log.Debug("failed to load program", "ID", id, "error", err)
+		return nil
+	}
+
+	info, err := program.Info()
+	if err != nil {
+		bc.log.Debug("failed to get program info", "ID", id, "error", err)
+		bc.closeProgram(id, program)
+		return nil
+	}
+
+	if !supportedProgramType(info.Type) {
+		bc.closeProgram(id, program)
+		cached := &cachedProgram{}
+		bc.programCache[id] = cached
+		return cached
+	}
+
+	cached := &cachedProgram{
+		program:   program,
+		probeType: info.Type.String(),
+		probeName: getFuncName(info, id, bc.log),
+		probeID:   strconv.FormatUint(uint64(id), 10),
+	}
+	bc.programCache[id] = cached
+	return cached
+}
+
+func supportedProgramType(programType ebpf.ProgramType) bool {
+	switch programType {
+	case ebpf.Kprobe, ebpf.SocketFilter, ebpf.SchedCLS, ebpf.SkMsg, ebpf.SockOps:
+		return true
+	default:
+		return false
+	}
+}
+
+func (bc *BPFCollector) evictMissingPrograms(seen map[ebpf.ProgramID]struct{}) {
+	for id, cached := range bc.programCache {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		if cached.program != nil {
+			bc.closeProgram(id, cached.program)
+		}
+		delete(bc.programCache, id)
+		delete(bc.progs, id)
+	}
+}
+
+func (bc *BPFCollector) closeProgram(id ebpf.ProgramID, program *ebpf.Program) {
+	if err := program.Close(); err != nil {
+		bc.log.Debug("failed to close program", "ID", id, "error", err)
+	}
 }
 
 func getFuncName(info *ebpf.ProgramInfo, id ebpf.ProgramID, log *slog.Logger) string {
@@ -332,52 +445,96 @@ func getFuncName(info *ebpf.ProgramInfo, id ebpf.ProgramID, log *slog.Logger) st
 }
 
 func (bc *BPFCollector) getMapMetrics() []BpfMapMetrics {
-	mapMetrics := make([]BpfMapMetrics, 0)
+	mapMetrics := make([]BpfMapMetrics, 0, len(bc.mapCache))
+	seen := make(map[ebpf.MapID]struct{}, len(bc.mapCache))
+	completeWalk := false
+
 	for id := ebpf.MapID(0); ; {
 		nextID, err := ebpf.MapGetNextID(id)
 		if err != nil {
+			completeWalk = errors.Is(err, os.ErrNotExist)
 			break
 		}
 		id = nextID
+		seen[id] = struct{}{}
+
+		cached, ok := bc.mapCache[id]
+		if !ok {
+			cached = bc.cacheMap(id)
+		}
+		if cached == nil || !cached.supported {
+			continue
+		}
 
 		m, err := ebpf.NewMapFromID(id)
 		if err != nil {
-			bc.log.Debug("failed to load map", "ID", id, "error", err)
+			bc.log.Debug("failed to load map for entry iteration", "ID", id, "error", err)
 			continue
 		}
-		defer m.Close()
-
-		info, err := m.Info()
+		count, err := countMapEntries(m)
+		if closeErr := m.Close(); closeErr != nil {
+			bc.log.Debug("failed to close map", "ID", id, "error", closeErr)
+		}
 		if err != nil {
-			bc.log.Debug("failed to get map info", "ID", id, "error", err)
 			continue
 		}
 
-		// Only collect maps that are LRUHash
-		if info.Type != ebpf.LRUHash {
-			continue
-		}
+		mapMetrics = append(mapMetrics, BpfMapMetrics{
+			mapType:    cached.mapType,
+			mapName:    cached.mapName,
+			mapID:      cached.mapID,
+			maxEntries: cached.maxEntries,
+			entries:    count,
+		})
+	}
 
-		var count uint64
-		throwawayKey := discardEncoding{}
-		throwawayValues := make(sliceDiscardEncoding, 0)
-		iter := m.Iterate()
-		for iter.Next(&throwawayKey, &throwawayValues) {
-			count++
-		}
-		if err := iter.Err(); err == nil {
-			mapID := strconv.FormatUint(uint64(id), 10)
-			mapType := info.Type.String()
-			mapMetrics = append(mapMetrics, BpfMapMetrics{
-				mapType:    mapType,
-				mapName:    info.Name,
-				mapID:      mapID,
-				maxEntries: int(info.MaxEntries),
-				entries:    count,
-			})
+	if completeWalk {
+		for id := range bc.mapCache {
+			if _, ok := seen[id]; !ok {
+				delete(bc.mapCache, id)
+			}
 		}
 	}
+
 	return mapMetrics
+}
+
+func (bc *BPFCollector) cacheMap(id ebpf.MapID) *cachedMap {
+	m, err := ebpf.NewMapFromID(id)
+	if err != nil {
+		bc.log.Debug("failed to load map", "ID", id, "error", err)
+		return nil
+	}
+
+	info, infoErr := m.Info()
+	if closeErr := m.Close(); closeErr != nil {
+		bc.log.Debug("failed to close map", "ID", id, "error", closeErr)
+	}
+	if infoErr != nil {
+		bc.log.Debug("failed to get map info", "ID", id, "error", infoErr)
+		return nil
+	}
+
+	cached := &cachedMap{
+		supported:  info.Type == ebpf.LRUHash,
+		mapType:    info.Type.String(),
+		mapName:    info.Name,
+		mapID:      strconv.FormatUint(uint64(id), 10),
+		maxEntries: int(info.MaxEntries),
+	}
+	bc.mapCache[id] = cached
+	return cached
+}
+
+func countMapEntries(m *ebpf.Map) (uint64, error) {
+	var count uint64
+	throwawayKey := discardEncoding{}
+	throwawayValues := make(sliceDiscardEncoding, 0)
+	iter := m.Iterate()
+	for iter.Next(&throwawayKey, &throwawayValues) {
+		count++
+	}
+	return count, iter.Err()
 }
 
 func (bp *BPFProgram) calculateStats() (float64, uint64) {

--- a/pkg/export/prom/prom_bpf_linux.go
+++ b/pkg/export/prom/prom_bpf_linux.go
@@ -8,9 +8,18 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func (bc *BPFCollector) enableBPFStatsRuntime() {
-	_, err := ebpf.EnableStats(unix.BPF_STATS_RUN_TIME)
+var enableStats = ebpf.EnableStats
+
+func (bc *BPFCollector) enableBPFStatsRuntime() func() {
+	stats, err := enableStats(unix.BPF_STATS_RUN_TIME)
 	if err != nil {
 		bc.log.Error("failed to enable runtime stats", "error", err)
+		return func() {}
+	}
+
+	return func() {
+		if err := stats.Close(); err != nil {
+			bc.log.Error("failed to close runtime stats", "error", err)
+		}
 	}
 }

--- a/pkg/export/prom/prom_bpf_linux_test.go
+++ b/pkg/export/prom/prom_bpf_linux_test.go
@@ -1,0 +1,73 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package prom
+
+import (
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
+	"go.opentelemetry.io/obi/pkg/pipe/global"
+)
+
+func TestGetProbeMetricsClosesStatsExactlyOnce(t *testing.T) {
+	originalEnableStats := enableStats
+	t.Cleanup(func() {
+		enableStats = originalEnableStats
+	})
+
+	var closeCalls atomic.Int32
+	enableStats = func(uint32) (io.Closer, error) {
+		return closeFunc(func() error {
+			closeCalls.Add(1)
+			return nil
+		}), nil
+	}
+
+	collector := newCollector(
+		&global.ContextInfo{},
+		&PrometheusConfig{},
+		&perapp.MetricsConfig{},
+		false,
+	)
+	t.Cleanup(collector.close)
+	collector.getProbeMetrics()
+
+	require.Equal(t, int32(1), closeCalls.Load())
+}
+
+func TestEnableBPFStatsRuntimeReturnsCleanupOnError(t *testing.T) {
+	originalEnableStats := enableStats
+	t.Cleanup(func() {
+		enableStats = originalEnableStats
+	})
+
+	enableStats = func(uint32) (io.Closer, error) {
+		return nil, errors.New("enable stats")
+	}
+
+	collector := newCollector(
+		&global.ContextInfo{},
+		&PrometheusConfig{},
+		&perapp.MetricsConfig{},
+		false,
+	)
+	t.Cleanup(collector.close)
+	cleanup := collector.enableBPFStatsRuntime()
+
+	require.NotNil(t, cleanup)
+	require.NotPanics(t, cleanup)
+}
+
+type closeFunc func() error
+
+func (fn closeFunc) Close() error {
+	return fn()
+}

--- a/pkg/export/prom/prom_bpf_linux_test.go
+++ b/pkg/export/prom/prom_bpf_linux_test.go
@@ -6,25 +6,31 @@
 package prom
 
 import (
+	"context"
 	"errors"
 	"io"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 )
 
-func TestGetProbeMetricsClosesStatsExactlyOnce(t *testing.T) {
+func TestBPFStatsRuntimeClosesWithCollector(t *testing.T) {
 	originalEnableStats := enableStats
 	t.Cleanup(func() {
 		enableStats = originalEnableStats
 	})
 
 	var closeCalls atomic.Int32
+	var enableCalls atomic.Int32
 	enableStats = func(uint32) (io.Closer, error) {
+		enableCalls.Add(1)
 		return closeFunc(func() error {
 			closeCalls.Add(1)
 			return nil
@@ -37,19 +43,26 @@ func TestGetProbeMetricsClosesStatsExactlyOnce(t *testing.T) {
 		&perapp.MetricsConfig{},
 		false,
 	)
-	t.Cleanup(collector.close)
+	collector.getProbeMetrics()
 	collector.getProbeMetrics()
 
+	require.Equal(t, int32(1), enableCalls.Load())
+	require.Zero(t, closeCalls.Load())
+	collector.close()
+	require.Equal(t, int32(1), closeCalls.Load())
+	collector.close()
 	require.Equal(t, int32(1), closeCalls.Load())
 }
 
-func TestEnableBPFStatsRuntimeReturnsCleanupOnError(t *testing.T) {
+func TestBPFStatsRuntimeEnableErrorDoesNotBreakCollectorClose(t *testing.T) {
 	originalEnableStats := enableStats
 	t.Cleanup(func() {
 		enableStats = originalEnableStats
 	})
 
+	var enableCalls atomic.Int32
 	enableStats = func(uint32) (io.Closer, error) {
+		enableCalls.Add(1)
 		return nil, errors.New("enable stats")
 	}
 
@@ -59,11 +72,46 @@ func TestEnableBPFStatsRuntimeReturnsCleanupOnError(t *testing.T) {
 		&perapp.MetricsConfig{},
 		false,
 	)
-	t.Cleanup(collector.close)
-	cleanup := collector.enableBPFStatsRuntime()
+	collector.getProbeMetrics()
 
-	require.NotNil(t, cleanup)
-	require.NotPanics(t, cleanup)
+	require.Equal(t, int32(1), enableCalls.Load())
+	require.NotPanics(t, collector.close)
+}
+
+func TestBPFStatsRuntimeClosesWhenInstanceEndsBeforeCollectorStarts(t *testing.T) {
+	originalEnableStats := enableStats
+	t.Cleanup(func() {
+		enableStats = originalEnableStats
+	})
+
+	var enableCalls atomic.Int32
+	var closeCalls atomic.Int32
+	enableStats = func(uint32) (io.Closer, error) {
+		enableCalls.Add(1)
+		return closeFunc(func() error {
+			closeCalls.Add(1)
+			return nil
+		}), nil
+	}
+
+	internalMetrics := imetrics.NewPrometheusReporter(
+		&imetrics.InternalMetricsConfig{BpfMetricScrapeInterval: time.Hour},
+		nil,
+		prometheus.NewRegistry(),
+	)
+	ctx, cancel := context.WithCancel(t.Context())
+	_, err := BPFMetrics(
+		&global.ContextInfo{Metrics: internalMetrics},
+		&PrometheusConfig{},
+		&perapp.MetricsConfig{},
+	)(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), enableCalls.Load())
+
+	cancel()
+	require.Eventually(t, func() bool {
+		return closeCalls.Load() == 1
+	}, time.Second, 10*time.Millisecond)
 }
 
 type closeFunc func() error

--- a/pkg/export/prom/prom_bpf_nonlinux.go
+++ b/pkg/export/prom/prom_bpf_nonlinux.go
@@ -5,4 +5,6 @@
 
 package prom // import "go.opentelemetry.io/obi/pkg/export/prom"
 
-func (bc *BPFCollector) enableBPFStatsRuntime() {}
+func (bc *BPFCollector) enableBPFStatsRuntime() func() {
+	return func() {}
+}

--- a/pkg/export/prom/prom_bpf_privileged_test.go
+++ b/pkg/export/prom/prom_bpf_privileged_test.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 )
 
-func TestGetProbeMetricsClosesStatsFD(t *testing.T) {
+func TestBPFStatsRuntimeDoesNotLeakFDsAcrossScrapes(t *testing.T) {
 	collector := newPrivilegedTestCollector(t)
 	loadTestPrograms(t, 1, ebpf.SocketFilter)
 
@@ -33,7 +33,6 @@ func TestGetProbeMetricsClosesStatsFD(t *testing.T) {
 		debug.SetGCPercent(previousGCPercent)
 	})
 
-	collector.getProbeMetrics()
 	before := openFDCount(t)
 
 	for range 10 {
@@ -43,7 +42,7 @@ func TestGetProbeMetricsClosesStatsFD(t *testing.T) {
 	require.Equal(t, before, openFDCount(t))
 }
 
-func TestGetProbeMetricsCachesProgramsAndDiscoversNewIDs(t *testing.T) {
+func TestGetProbeMetricsCachesProgramMetadataAndDiscoversNewIDs(t *testing.T) {
 	collector := newPrivilegedTestCollector(t)
 	firstProgram := loadTestPrograms(t, 1, ebpf.SocketFilter)[0]
 	firstID := programID(t, firstProgram)
@@ -52,12 +51,18 @@ func TestGetProbeMetricsCachesProgramsAndDiscoversNewIDs(t *testing.T) {
 
 	firstCached, ok := collector.programCache[firstID]
 	require.True(t, ok)
-	require.NotNil(t, firstCached.program)
-	require.Equal(t, firstCached.program.FD(), cachedProgramFD(t, collector, firstID))
 	requireProbeMetric(t, metrics, firstID, ebpf.SocketFilter, "metric_0")
 
+	collector.getProbeMetrics()
+	require.Same(t, firstCached, collector.programCache[firstID])
+
 	require.NoError(t, firstProgram.Close())
-	requireProbeMetric(t, collector.getProbeMetrics(), firstID, ebpf.SocketFilter, "metric_0")
+	metrics = collector.getProbeMetrics()
+	requireNoProbeMetric(t, metrics, firstID)
+	_, ok = collector.programCache[firstID]
+	require.False(t, ok)
+	_, ok = collector.progs[firstID]
+	require.False(t, ok)
 
 	secondProgram := loadTestPrograms(t, 1, ebpf.SocketFilter)[0]
 	secondID := programID(t, secondProgram)
@@ -65,8 +70,7 @@ func TestGetProbeMetricsCachesProgramsAndDiscoversNewIDs(t *testing.T) {
 
 	metrics = collector.getProbeMetrics()
 
-	require.Same(t, firstCached, collector.programCache[firstID])
-	require.NotNil(t, collector.programCache[secondID].program)
+	require.True(t, collector.programCache[secondID].supported)
 	requireProbeMetric(t, metrics, secondID, ebpf.SocketFilter, "metric_0")
 }
 
@@ -79,10 +83,10 @@ func TestGetProbeMetricsNegativelyCachesUnsupportedPrograms(t *testing.T) {
 
 	cached, ok := collector.programCache[id]
 	require.True(t, ok)
-	require.Nil(t, cached.program)
+	require.False(t, cached.supported)
 }
 
-func TestCollectorShutdownClosesProgramsAndClearsState(t *testing.T) {
+func TestCollectorShutdownClearsState(t *testing.T) {
 	internalMetrics := imetrics.NewPrometheusReporter(
 		&imetrics.InternalMetricsConfig{BpfMetricScrapeInterval: time.Hour},
 		nil,
@@ -99,8 +103,7 @@ func TestCollectorShutdownClosesProgramsAndClearsState(t *testing.T) {
 
 	collector.getProbeMetrics()
 	collector.getMapMetrics()
-	cachedProgram := collector.programCache[id].program
-	require.NotNil(t, cachedProgram)
+	require.True(t, collector.programCache[id].supported)
 	require.NotEmpty(t, collector.progs)
 	require.NotEmpty(t, collector.mapCache)
 
@@ -115,8 +118,8 @@ func TestCollectorShutdownClosesProgramsAndClearsState(t *testing.T) {
 			len(collector.mapCache) == 0 &&
 			len(collector.progs) == 0
 	}, time.Second, 10*time.Millisecond)
-	_, err := cachedProgram.Info()
-	require.Error(t, err)
+	_, err := program.Info()
+	require.NoError(t, err)
 }
 
 func TestGetMapMetricsCachesMetadataAndEvictsMissingMaps(t *testing.T) {
@@ -279,16 +282,6 @@ func mapID(tb testing.TB, bpfMap *ebpf.Map) ebpf.MapID {
 	return id
 }
 
-func cachedProgramFD(t *testing.T, collector *BPFCollector, id ebpf.ProgramID) int {
-	t.Helper()
-
-	collector.getProbeMetrics()
-	cached, ok := collector.programCache[id]
-	require.True(t, ok)
-	require.NotNil(t, cached.program)
-	return cached.program.FD()
-}
-
 func requireProbeMetric(
 	t *testing.T,
 	metrics []ProbeMetrics,
@@ -307,6 +300,17 @@ func requireProbeMetric(
 		}
 	}
 	require.Failf(t, "probe metric not found", "program ID %d", id)
+}
+
+func requireNoProbeMetric(t *testing.T, metrics []ProbeMetrics, id ebpf.ProgramID) {
+	t.Helper()
+
+	idString := fmt.Sprintf("%d", id)
+	for _, metric := range metrics {
+		if metric.probeID == idString {
+			require.Failf(t, "unexpected probe metric", "program ID %d", id)
+		}
+	}
 }
 
 func requireMapMetric(

--- a/pkg/export/prom/prom_bpf_privileged_test.go
+++ b/pkg/export/prom/prom_bpf_privileged_test.go
@@ -1,0 +1,334 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && privileged_tests
+
+package prom
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	"go.opentelemetry.io/obi/pkg/export/otel/perapp"
+	"go.opentelemetry.io/obi/pkg/pipe/global"
+)
+
+func TestGetProbeMetricsClosesStatsFD(t *testing.T) {
+	collector := newPrivilegedTestCollector(t)
+	loadTestPrograms(t, 1, ebpf.SocketFilter)
+
+	previousGCPercent := debug.SetGCPercent(-1)
+	t.Cleanup(func() {
+		debug.SetGCPercent(previousGCPercent)
+	})
+
+	collector.getProbeMetrics()
+	before := openFDCount(t)
+
+	for range 10 {
+		collector.getProbeMetrics()
+	}
+
+	require.Equal(t, before, openFDCount(t))
+}
+
+func TestGetProbeMetricsCachesProgramsAndDiscoversNewIDs(t *testing.T) {
+	collector := newPrivilegedTestCollector(t)
+	firstProgram := loadTestPrograms(t, 1, ebpf.SocketFilter)[0]
+	firstID := programID(t, firstProgram)
+
+	metrics := collector.getProbeMetrics()
+
+	firstCached, ok := collector.programCache[firstID]
+	require.True(t, ok)
+	require.NotNil(t, firstCached.program)
+	require.Equal(t, firstCached.program.FD(), cachedProgramFD(t, collector, firstID))
+	requireProbeMetric(t, metrics, firstID, ebpf.SocketFilter, "metric_0")
+
+	require.NoError(t, firstProgram.Close())
+	requireProbeMetric(t, collector.getProbeMetrics(), firstID, ebpf.SocketFilter, "metric_0")
+
+	secondProgram := loadTestPrograms(t, 1, ebpf.SocketFilter)[0]
+	secondID := programID(t, secondProgram)
+	require.Greater(t, secondID, firstID)
+
+	metrics = collector.getProbeMetrics()
+
+	require.Same(t, firstCached, collector.programCache[firstID])
+	require.NotNil(t, collector.programCache[secondID].program)
+	requireProbeMetric(t, metrics, secondID, ebpf.SocketFilter, "metric_0")
+}
+
+func TestGetProbeMetricsNegativelyCachesUnsupportedPrograms(t *testing.T) {
+	collector := newPrivilegedTestCollector(t)
+	program := loadTestPrograms(t, 1, ebpf.XDP)[0]
+	id := programID(t, program)
+
+	collector.getProbeMetrics()
+
+	cached, ok := collector.programCache[id]
+	require.True(t, ok)
+	require.Nil(t, cached.program)
+}
+
+func TestCollectorShutdownClosesProgramsAndClearsState(t *testing.T) {
+	internalMetrics := imetrics.NewPrometheusReporter(
+		&imetrics.InternalMetricsConfig{BpfMetricScrapeInterval: time.Hour},
+		nil,
+		prometheus.NewRegistry(),
+	)
+	collector := newInternalBPFCollector(
+		&global.ContextInfo{Metrics: internalMetrics},
+		&PrometheusConfig{},
+		&perapp.MetricsConfig{},
+	)
+	program := loadTestPrograms(t, 1, ebpf.SocketFilter)[0]
+	id := programID(t, program)
+	loadTestMaps(t, 1, ebpf.LRUHash, 1)
+
+	collector.getProbeMetrics()
+	collector.getMapMetrics()
+	cachedProgram := collector.programCache[id].program
+	require.NotNil(t, cachedProgram)
+	require.NotEmpty(t, collector.progs)
+	require.NotEmpty(t, collector.mapCache)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	collector.startInternalMetrics(ctx)
+	cancel()
+
+	require.Eventually(t, func() bool {
+		collector.mu.Lock()
+		defer collector.mu.Unlock()
+		return len(collector.programCache) == 0 &&
+			len(collector.mapCache) == 0 &&
+			len(collector.progs) == 0
+	}, time.Second, 10*time.Millisecond)
+	_, err := cachedProgram.Info()
+	require.Error(t, err)
+}
+
+func TestGetMapMetricsCachesMetadataAndEvictsMissingMaps(t *testing.T) {
+	collector := newPrivilegedTestCollector(t)
+	supportedMap := loadTestMaps(t, 1, ebpf.LRUHash, 3)[0]
+	unsupportedMap := loadTestMaps(t, 1, ebpf.Hash, 1)[0]
+	supportedID := mapID(t, supportedMap)
+	unsupportedID := mapID(t, unsupportedMap)
+
+	metrics := collector.getMapMetrics()
+
+	supportedCached, ok := collector.mapCache[supportedID]
+	require.True(t, ok)
+	require.True(t, supportedCached.supported)
+	unsupportedCached, ok := collector.mapCache[unsupportedID]
+	require.True(t, ok)
+	require.False(t, unsupportedCached.supported)
+	require.Equal(t, ebpf.Hash.String(), unsupportedCached.mapType)
+	require.Equal(t, "metric_0", unsupportedCached.mapName)
+	require.Equal(t, fmt.Sprintf("%d", unsupportedID), unsupportedCached.mapID)
+	require.Equal(t, 2, unsupportedCached.maxEntries)
+	requireMapMetric(t, metrics, supportedID, "metric_0", ebpf.LRUHash, 6, 3)
+
+	collector.getMapMetrics()
+	require.Same(t, supportedCached, collector.mapCache[supportedID])
+	require.Same(t, unsupportedCached, collector.mapCache[unsupportedID])
+
+	require.NoError(t, supportedMap.Close())
+	require.NoError(t, unsupportedMap.Close())
+	collector.getMapMetrics()
+
+	_, ok = collector.mapCache[supportedID]
+	require.False(t, ok)
+	_, ok = collector.mapCache[unsupportedID]
+	require.False(t, ok)
+}
+
+func BenchmarkGetProbeMetrics(b *testing.B) {
+	for _, count := range []int{50, 500} {
+		b.Run(fmt.Sprintf("programs=%d", count), func(b *testing.B) {
+			loadTestPrograms(b, count, ebpf.SocketFilter)
+			collector := newPrivilegedTestCollector(b)
+			collector.getProbeMetrics()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				collector.getProbeMetrics()
+			}
+		})
+		runtime.GC()
+	}
+}
+
+func BenchmarkGetMapMetrics(b *testing.B) {
+	for _, count := range []int{50, 500} {
+		b.Run(fmt.Sprintf("maps=%d", count), func(b *testing.B) {
+			loadTestMaps(b, count, ebpf.LRUHash, 16)
+			collector := newPrivilegedTestCollector(b)
+			collector.getMapMetrics()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				collector.getMapMetrics()
+			}
+		})
+	}
+}
+
+func newPrivilegedTestCollector(tb testing.TB) *BPFCollector {
+	tb.Helper()
+
+	collector := newCollector(
+		&global.ContextInfo{},
+		&PrometheusConfig{},
+		&perapp.MetricsConfig{},
+		false,
+	)
+	tb.Cleanup(collector.close)
+	return collector
+}
+
+func loadTestPrograms(tb testing.TB, count int, programType ebpf.ProgramType) []*ebpf.Program {
+	tb.Helper()
+
+	programs := make([]*ebpf.Program, 0, count)
+	for index := range count {
+		program, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+			Name:         fmt.Sprintf("metric_%d", index),
+			Type:         programType,
+			License:      "Dual MIT/GPL",
+			Instructions: asm.Instructions{asm.Mov.Imm(asm.R0, 0), asm.Return()},
+		})
+		require.NoError(tb, err)
+		programs = append(programs, program)
+	}
+	tb.Cleanup(func() {
+		for _, program := range programs {
+			_ = program.Close()
+		}
+	})
+
+	return programs
+}
+
+func loadTestMaps(tb testing.TB, count int, mapType ebpf.MapType, entries int) []*ebpf.Map {
+	tb.Helper()
+
+	maps := make([]*ebpf.Map, 0, count)
+	for index := range count {
+		bpfMap, err := ebpf.NewMap(&ebpf.MapSpec{
+			Name:       fmt.Sprintf("metric_%d", index),
+			Type:       mapType,
+			KeySize:    4,
+			ValueSize:  4,
+			MaxEntries: uint32(entries * 2),
+		})
+		require.NoError(tb, err)
+		maps = append(maps, bpfMap)
+
+		for entry := range entries {
+			require.NoError(tb, bpfMap.Put(uint32(entry), uint32(entry)))
+		}
+	}
+	tb.Cleanup(func() {
+		for _, bpfMap := range maps {
+			_ = bpfMap.Close()
+		}
+	})
+
+	return maps
+}
+
+func openFDCount(t *testing.T) int {
+	t.Helper()
+
+	entries, err := os.ReadDir("/proc/self/fd")
+	require.NoError(t, err)
+	return len(entries)
+}
+
+func programID(tb testing.TB, program *ebpf.Program) ebpf.ProgramID {
+	tb.Helper()
+
+	info, err := program.Info()
+	require.NoError(tb, err)
+	id, ok := info.ID()
+	require.True(tb, ok)
+	return id
+}
+
+func mapID(tb testing.TB, bpfMap *ebpf.Map) ebpf.MapID {
+	tb.Helper()
+
+	info, err := bpfMap.Info()
+	require.NoError(tb, err)
+	id, ok := info.ID()
+	require.True(tb, ok)
+	return id
+}
+
+func cachedProgramFD(t *testing.T, collector *BPFCollector, id ebpf.ProgramID) int {
+	t.Helper()
+
+	collector.getProbeMetrics()
+	cached, ok := collector.programCache[id]
+	require.True(t, ok)
+	require.NotNil(t, cached.program)
+	return cached.program.FD()
+}
+
+func requireProbeMetric(
+	t *testing.T,
+	metrics []ProbeMetrics,
+	id ebpf.ProgramID,
+	programType ebpf.ProgramType,
+	name string,
+) {
+	t.Helper()
+
+	idString := fmt.Sprintf("%d", id)
+	for _, metric := range metrics {
+		if metric.probeID == idString {
+			require.Equal(t, programType.String(), metric.probeType)
+			require.Equal(t, name, metric.probeName)
+			return
+		}
+	}
+	require.Failf(t, "probe metric not found", "program ID %d", id)
+}
+
+func requireMapMetric(
+	t *testing.T,
+	metrics []BpfMapMetrics,
+	id ebpf.MapID,
+	name string,
+	mapType ebpf.MapType,
+	maxEntries int,
+	entries uint64,
+) {
+	t.Helper()
+
+	idString := fmt.Sprintf("%d", id)
+	for _, metric := range metrics {
+		if metric.mapID == idString {
+			require.Equal(t, name, metric.mapName)
+			require.Equal(t, mapType.String(), metric.mapType)
+			require.Equal(t, maxEntries, metric.maxEntries)
+			require.Equal(t, entries, metric.entries)
+			return
+		}
+	}
+	require.Failf(t, "map metric not found", "map ID %d", id)
+}

--- a/pkg/export/prom/prom_bpf_test.go
+++ b/pkg/export/prom/prom_bpf_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/ebpf"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
@@ -375,6 +376,40 @@ func TestBPFMetricsDoesNotStartInternalCollectorForZeroIntervalReporter(t *testi
 
 	time.Sleep(10 * time.Millisecond)
 	assert.False(t, internalCollectorStarted.Load())
+}
+
+func TestBPFCollectorDoesNotCollectAfterContextCleanup(t *testing.T) {
+	collector := newCollector(
+		&global.ContextInfo{},
+		&PrometheusConfig{},
+		&perapp.MetricsConfig{},
+		false,
+	)
+	collector.progs[ebpf.ProgramID(1)] = &BPFProgram{}
+
+	var collectionCalls atomic.Int32
+	collector.probeMetrics = func() []ProbeMetrics {
+		collectionCalls.Add(1)
+		return nil
+	}
+	collector.mapMetrics = func() []BpfMapMetrics {
+		collectionCalls.Add(1)
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	collector.cleanupOnContext(ctx)
+	cancel()
+
+	require.Eventually(t, func() bool {
+		collector.mu.Lock()
+		defer collector.mu.Unlock()
+		return len(collector.progs) == 0
+	}, time.Second, 10*time.Millisecond)
+
+	collector.collectMetrics()
+
+	require.Zero(t, collectionCalls.Load())
 }
 
 func gatheredMetric(t *testing.T, registry *prometheus.Registry, name string, labels map[string]string) *dto.Metric {


### PR DESCRIPTION
## Summary

Describe the change briefly.

Cache eBPF program and map metadata across metric collections while continuing to discover all existing supported probes and maps on every collection.

| Benchmark | Time/op | Memory/op | Allocations/op |
| --- | ---: | ---: | ---: |
| Probe metrics | 8.1497 ms → 0.9832 ms (**87.94% lower**) | 3,492.9 KiB → 178.3 KiB (**94.90% lower**) | 17,523 → 1,008 (**94.25% lower**) |
| Map metrics | 12.944 ms → 7.586 ms (**41.40% lower**) | 2,908.1 KiB → 295.5 KiB (**89.84% lower**) | 23,900 → 14,010 (**41.40% lower**) |

  Results are benchstat medians from 10 runs with 10 iterations per run on Linux/amd64. All changes were statistically significant (p < 0.001).

Fixes #727 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
