### PR TITLE
NodeJS: simplify script injection

### DIFF
--- a/pkg/internal/nodejs/fdextractor.js
+++ b/pkg/internal/nodejs/fdextractor.js
@@ -1,120 +1,122 @@
-const STORE = Symbol.for('otel-ebpf-instrumentation.fdextractor');
+(()=>{
+  const STORE = Symbol.for('otel-ebpf-instrumentation.fdextractor');
 
-const net = require('net');
-const fs = require('fs');
+  const net = require('net');
+  const fs = require('fs');
 
-if (!global[STORE]) {
-  global[STORE] = {
-    serverEmit: net.Server.prototype.emit,
-    socketConnect: net.Socket.prototype.connect,
-    socketWrite: net.Socket.prototype.write,
+  if (!global[STORE]) {
+    global[STORE] = {
+      serverEmit: net.Server.prototype.emit,
+      socketConnect: net.Socket.prototype.connect,
+      socketWrite: net.Socket.prototype.write,
+    };
+  }
+
+  const orig = global[STORE];
+  net.Server.prototype.emit = orig.serverEmit;
+  net.Socket.prototype.connect = orig.socketConnect;
+  net.Socket.prototype.write = orig.socketWrite;
+
+  const { AsyncLocalStorage, createHook } = require('async_hooks');
+
+  const debug_enabled = false;
+
+  if (debug_enabled) {
+    console.log('OpenTelemetry eBPF Instrumentation has injected instrumentation via the NodeJS debugger');
+    console.log('The debugger will be deactivated again and closed');
+  }
+
+  // ALS store holds only incomingFd
+  const als = new AsyncLocalStorage();
+
+  net.Server.prototype.emit = function (event, ...args) {
+    if (event === 'connection') {
+      const socket = args[0];
+      const incomingFd = socket._handle && socket._handle.fd;
+
+      if (debug_enabled) {
+        console.log(
+          `[incoming TCP] fd:${incomingFd}, remote=${socket.remoteAddress}:${socket.remotePort}`,
+        );
+      }
+
+      return als.run({ incomingFd }, () =>
+        orig.serverEmit.call(this, event, ...args),
+      );
+    }
+    return orig.serverEmit.call(this, event, ...args);
   };
-}
 
-const orig = global[STORE];
-net.Server.prototype.emit = orig.serverEmit;
-net.Socket.prototype.connect = orig.socketConnect;
-net.Socket.prototype.write = orig.socketWrite;
+  const pad4 = n => String(n).padStart(4, '0');
 
-const { AsyncLocalStorage, createHook } = require('async_hooks');
-
-const debug_enabled = false;
-
-if (debug_enabled) {
-  console.log('OpenTelemetry eBPF Instrumentation has injected instrumentation via the NodeJS debugger');
-  console.log('The debugger will be deactivated again and closed');
-}
-
-// ALS store holds only incomingFd
-const als = new AsyncLocalStorage();
-
-net.Server.prototype.emit = function (event, ...args) {
-  if (event === 'connection') {
-    const socket = args[0];
-    const incomingFd = socket._handle && socket._handle.fd;
+  function correlate(incomingFd, outFd, socket) {
+    if (incomingFd < 0 || outFd < 0 || incomingFd === outFd) {
+      return Promise.resolve();
+    }
 
     if (debug_enabled) {
+      const addr = socket.remoteAddress || 'unknown';
+      const port = socket.remotePort || 'unknown';
+
       console.log(
-        `[incoming TCP] fd:${incomingFd}, remote=${socket.remoteAddress}:${socket.remotePort}`,
+        `[outgoing TCP] inFd:${incomingFd}, outFd:${outFd}, to=${addr}:${port}`,
       );
     }
 
-    return als.run({ incomingFd }, () =>
-      orig.serverEmit.call(this, event, ...args),
-    );
-  }
-  return orig.serverEmit.call(this, event, ...args);
-};
-
-const pad4 = n => String(n).padStart(4, '0');
-
-function correlate(incomingFd, outFd, socket) {
-  if (incomingFd < 0 || outFd < 0 || incomingFd === outFd) {
-    return Promise.resolve();
-  }
-
-  if (debug_enabled) {
-    const addr = socket.remoteAddress || 'unknown';
-    const port = socket.remotePort || 'unknown';
-
-    console.log(
-      `[outgoing TCP] inFd:${incomingFd}, outFd:${outFd}, to=${addr}:${port}`,
-    );
-  }
-
-  try {
-    fs.accessSync(`/dev/null/obi/${pad4(incomingFd)}${pad4(outFd)}`)
-  } catch (err) {
-  }
-}
-
-net.Socket.prototype.connect = function (...args) {
-  const store = als.getStore();
-  const sock = this;
-  const result = orig.socketConnect.apply(this, args);
-
-  if (store) {
-    sock.once('connect', () => {
-      const outFd = sock._handle && sock._handle.fd;
-      correlate(store.incomingFd, outFd, sock);
-    });
-  }
-
-  return result;
-};
-
-net.Socket.prototype.write = function (data, ...rest) {
-  const doWrite = () => orig.socketWrite.apply(this, [data, ...rest]);
-
-  // skip ipc writes
-  if (
-    this === process.stdout ||
-    this === process.stderr
-  ) {
-    return doWrite();
-  }
-
-  const store = als.getStore();
-
-  if (store) {
-    const outFd = this._handle && this._handle.fd;
-    correlate(store.incomingFd, outFd, this);
-  }
-
-  return doWrite();
-};
-
-// Signal the BPF layer before each async callback so it can restore the correct
-// trace context for this request into traces_ctx_v1.
-// fs.accessSync is safe inside async_hooks callbacks: synchronous fs operations
-// do not create AsyncWrap objects and therefore do not re-trigger this hook.
-createHook({
-  before() {
-    const store = als.getStore();
-    if (store && store.incomingFd != null && store.incomingFd >= 0) {
-      try {
-        fs.accessSync(`/dev/null/obi-ctx/${pad4(store.incomingFd)}`);
-      } catch (_) {}
+    try {
+      fs.accessSync(`/dev/null/obi/${pad4(incomingFd)}${pad4(outFd)}`)
+    } catch (err) {
     }
-  },
-}).enable();
+  }
+
+  net.Socket.prototype.connect = function (...args) {
+    const store = als.getStore();
+    const sock = this;
+    const result = orig.socketConnect.apply(this, args);
+
+    if (store) {
+      sock.once('connect', () => {
+        const outFd = sock._handle && sock._handle.fd;
+        correlate(store.incomingFd, outFd, sock);
+      });
+    }
+
+    return result;
+  };
+
+  net.Socket.prototype.write = function (data, ...rest) {
+    const doWrite = () => orig.socketWrite.apply(this, [data, ...rest]);
+
+    // skip ipc writes
+    if (
+      this === process.stdout ||
+      this === process.stderr
+    ) {
+      return doWrite();
+    }
+
+    const store = als.getStore();
+
+    if (store) {
+      const outFd = this._handle && this._handle.fd;
+      correlate(store.incomingFd, outFd, this);
+    }
+
+    return doWrite();
+  };
+
+  // Signal the BPF layer before each async callback so it can restore the correct
+  // trace context for this request into traces_ctx_v1.
+  // fs.accessSync is safe inside async_hooks callbacks: synchronous fs operations
+  // do not create AsyncWrap objects and therefore do not re-trigger this hook.
+  createHook({
+    before() {
+      const store = als.getStore();
+      if (store && store.incomingFd != null && store.incomingFd >= 0) {
+        try {
+          fs.accessSync(`/dev/null/obi-ctx/${pad4(store.incomingFd)}`);
+        } catch (_) {}
+      }
+    },
+  }).enable();
+})()

--- a/pkg/internal/nodejs/injector.go
+++ b/pkg/internal/nodejs/injector.go
@@ -295,8 +295,7 @@ func (i *NodeInjector) injectViaConn(conn net.Conn) error {
 
 	i.log.Debug("found debugger url", "url", wsURL)
 
-	wrapped := fmt.Sprintf("(()=>{\n%s\n})()", string(_extractorBytes))
-	payload, err := evaluateRequest(wrapped, 1)
+	payload, err := evaluateRequest(_extractorCode, 1)
 	if err != nil {
 		conn.Close()
 		return err

--- a/pkg/internal/nodejs/nodejs.go
+++ b/pkg/internal/nodejs/nodejs.go
@@ -122,4 +122,4 @@ func (i *NodeInjector) isNodeInspector(conn net.Conn) bool {
 }
 
 //go:embed fdextractor.js
-var _extractorBytes []byte
+var _extractorCode string


### PR DESCRIPTION
## Summary

Before: converting `_extractorBytes []byte` into a string and then wrap it inside a `((() => { ... })()` clause, before injecting it via `Runtime.eval`.

Now: `_extractorCode string` is a self-contained string and we don't need to prepend/append any string before injecting it.

Reason: A followup Deno extractor code needs to be wrapped differently (into an `async` lambda), so it's simpler keeping the `fdextractor.js` code self-contained so the Go code just injects it without prior processing (and doesn't need to make any difference when we later add a future, async `fdextractor_deno.js`).

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
