### PR TITLE
Dynamic Client: Support isolated netns non-k8s processes for network+stats metrics

### DIFF
--- a/pkg/internal/helpers/container/ips.go
+++ b/pkg/internal/helpers/container/ips.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package container // import "go.opentelemetry.io/obi/pkg/internal/helpers/container"
+
+import (
+	"fmt"
+	"net"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/internal/netns"
+)
+
+// injectable for testing
+var (
+	withNetNS      = netns.WithNetNS
+	interfaceAddrs = net.InterfaceAddrs
+)
+
+// IPsForPID returns the non-loopback IPv4/IPv6 addresses visible in pid's network
+// namespace. This covers Docker/containerd bridge networking and host-network /
+// bare-metal processes (where the process shares the agent's netns) without
+// requiring a Kubernetes metadata store.
+func IPsForPID(pid app.PID) ([]string, error) {
+	var ips []string
+	err := withNetNS(int(pid), func() error {
+		addrs, err := interfaceAddrs()
+		if err != nil {
+			return fmt.Errorf("listing interface addresses: %w", err)
+		}
+		ips = uniqueNonLoopbackIPs(addrs)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ips, nil
+}
+
+func uniqueNonLoopbackIPs(addrs []net.Addr) []string {
+	seen := make(map[string]struct{}, len(addrs))
+	var out []string
+	for _, addr := range addrs {
+		ipnet, ok := addr.(*net.IPNet)
+		if !ok || ipnet == nil || ipnet.IP == nil || ipnet.IP.IsLoopback() {
+			continue
+		}
+		// Prefer the canonical string form (IPv4 as dotted quad, not :ffff:).
+		ip := ipnet.IP
+		if v4 := ip.To4(); v4 != nil {
+			ip = v4
+		}
+		s := ip.String()
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/pkg/internal/helpers/container/ips.go
+++ b/pkg/internal/helpers/container/ips.go
@@ -13,17 +13,27 @@ import (
 
 // injectable for testing
 var (
-	withNetNS      = netns.WithNetNS
-	interfaceAddrs = net.InterfaceAddrs
+	withNetNS       = netns.WithNetNS
+	interfaceAddrs  = net.InterfaceAddrs
+	isIsolatedNetNS = netns.IsIsolated
 )
 
-// IPsForPID returns the non-loopback IPv4/IPv6 addresses visible in pid's network
-// namespace. This covers Docker/containerd bridge networking and host-network /
-// bare-metal processes (where the process shares the agent's netns) without
-// requiring a Kubernetes metadata store.
+// IPsForPID returns the non-loopback IPv4/IPv6 addresses visible in pid's
+// network namespace when that namespace is isolated from the agent and host
+// (PID 1). This covers Docker/containerd bridge networking. Host-network and
+// bare-host processes share those namespaces; their interface addresses are
+// not process identity, so this returns no IPs.
 func IPsForPID(pid app.PID) ([]string, error) {
+	isolated, err := isIsolatedNetNS(int(pid))
+	if err != nil {
+		return nil, fmt.Errorf("checking netns isolation: %w", err)
+	}
+	if !isolated {
+		return nil, nil
+	}
+
 	var ips []string
-	err := withNetNS(int(pid), func() error {
+	err = withNetNS(int(pid), func() error {
 		addrs, err := interfaceAddrs()
 		if err != nil {
 			return fmt.Errorf("listing interface addresses: %w", err)

--- a/pkg/internal/helpers/container/ips_test.go
+++ b/pkg/internal/helpers/container/ips_test.go
@@ -27,14 +27,20 @@ func TestUniqueNonLoopbackIPs(t *testing.T) {
 }
 
 func TestIPsForPID_usesNetNS(t *testing.T) {
+	origIso := isIsolatedNetNS
 	origWith := withNetNS
 	origAddrs := interfaceAddrs
 	t.Cleanup(func() {
+		isIsolatedNetNS = origIso
 		withNetNS = origWith
 		interfaceAddrs = origAddrs
 	})
 
 	var sawPID int
+	isIsolatedNetNS = func(pid int) (bool, error) {
+		assert.Equal(t, 4242, pid)
+		return true, nil
+	}
 	withNetNS = func(pid int, fn func() error) error {
 		sawPID = pid
 		return fn()
@@ -52,10 +58,47 @@ func TestIPsForPID_usesNetNS(t *testing.T) {
 	assert.Equal(t, []string{"10.88.0.5"}, ips)
 }
 
-func TestIPsForPID_propagatesNetNSError(t *testing.T) {
+func TestIPsForPID_sharedNetNSReturnsNoIPs(t *testing.T) {
+	origIso := isIsolatedNetNS
 	origWith := withNetNS
-	t.Cleanup(func() { withNetNS = origWith })
+	t.Cleanup(func() {
+		isIsolatedNetNS = origIso
+		withNetNS = origWith
+	})
 
+	listed := false
+	isIsolatedNetNS = func(int) (bool, error) { return false, nil }
+	withNetNS = func(int, func() error) error {
+		listed = true
+		return nil
+	}
+
+	ips, err := IPsForPID(app.PID(1))
+	require.NoError(t, err)
+	assert.Empty(t, ips)
+	assert.False(t, listed)
+}
+
+func TestIPsForPID_propagatesIsolationError(t *testing.T) {
+	origIso := isIsolatedNetNS
+	t.Cleanup(func() { isIsolatedNetNS = origIso })
+
+	sentinel := errors.New("stat netns")
+	isIsolatedNetNS = func(int) (bool, error) { return false, sentinel }
+
+	_, err := IPsForPID(app.PID(1))
+	assert.ErrorIs(t, err, sentinel)
+}
+
+func TestIPsForPID_propagatesNetNSError(t *testing.T) {
+	origIso := isIsolatedNetNS
+	origWith := withNetNS
+	t.Cleanup(func() {
+		isIsolatedNetNS = origIso
+		withNetNS = origWith
+	})
+
+	isIsolatedNetNS = func(int) (bool, error) { return true, nil }
 	sentinel := errors.New("setns denied")
 	withNetNS = func(int, func() error) error { return sentinel }
 

--- a/pkg/internal/helpers/container/ips_test.go
+++ b/pkg/internal/helpers/container/ips_test.go
@@ -1,0 +1,64 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+)
+
+func TestUniqueNonLoopbackIPs(t *testing.T) {
+	addrs := []net.Addr{
+		&net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)},
+		&net.IPNet{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)},
+		&net.IPNet{IP: net.ParseIP("172.17.0.2"), Mask: net.CIDRMask(16, 32)},
+		&net.IPNet{IP: net.ParseIP("172.17.0.2"), Mask: net.CIDRMask(16, 32)}, // dup
+		&net.IPNet{IP: net.ParseIP("fd00::1"), Mask: net.CIDRMask(64, 128)},
+		&net.IPAddr{IP: net.ParseIP("10.0.0.1")}, // wrong type, ignored
+	}
+	assert.Equal(t, []string{"172.17.0.2", "fd00::1"}, uniqueNonLoopbackIPs(addrs))
+}
+
+func TestIPsForPID_usesNetNS(t *testing.T) {
+	origWith := withNetNS
+	origAddrs := interfaceAddrs
+	t.Cleanup(func() {
+		withNetNS = origWith
+		interfaceAddrs = origAddrs
+	})
+
+	var sawPID int
+	withNetNS = func(pid int, fn func() error) error {
+		sawPID = pid
+		return fn()
+	}
+	interfaceAddrs = func() ([]net.Addr, error) {
+		return []net.Addr{
+			&net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)},
+			&net.IPNet{IP: net.ParseIP("10.88.0.5"), Mask: net.CIDRMask(16, 32)},
+		}, nil
+	}
+
+	ips, err := IPsForPID(app.PID(4242))
+	require.NoError(t, err)
+	assert.Equal(t, 4242, sawPID)
+	assert.Equal(t, []string{"10.88.0.5"}, ips)
+}
+
+func TestIPsForPID_propagatesNetNSError(t *testing.T) {
+	origWith := withNetNS
+	t.Cleanup(func() { withNetNS = origWith })
+
+	sentinel := errors.New("setns denied")
+	withNetNS = func(int, func() error) error { return sentinel }
+
+	_, err := IPsForPID(app.PID(1))
+	assert.ErrorIs(t, err, sentinel)
+}

--- a/pkg/internal/netns/netns.go
+++ b/pkg/internal/netns/netns.go
@@ -21,6 +21,41 @@ func netNSPath(hostPid int) string {
 	return fmt.Sprintf("/proc/%d/ns/net", hostPid)
 }
 
+// IsIsolated reports whether pid's network namespace is distinct from both the
+// calling process and PID 1. Isolated namespaces are Docker/containerd bridge
+// nets; host-network and bare-host processes share the agent or host netns.
+func IsIsolated(pid int) (bool, error) {
+	pidIno, err := netNSInode(netNSPath(pid))
+	if err != nil {
+		return false, fmt.Errorf("stat pid netns: %w", err)
+	}
+
+	selfIno, err := netNSInode(netNSPath(os.Getpid()))
+	if err != nil {
+		return false, fmt.Errorf("stat self netns: %w", err)
+	}
+
+	if pidIno == selfIno {
+		return false, nil
+	}
+
+	hostIno, err := netNSInode(netNSPath(1))
+	if err != nil {
+		// Host PID 1 is not visible; agent vs pid is the only check.
+		return true, nil
+	}
+
+	return pidIno != hostIno, nil
+}
+
+func netNSInode(path string) (uint64, error) {
+	var st unix.Stat_t
+	if err := unix.Stat(path, &st); err != nil {
+		return 0, err
+	}
+	return st.Ino, nil
+}
+
 // WithNetNS runs fn in the network namespace of hostPid.
 //
 // The switch runs on a goroutine of its own, and that goroutine returns while still locked

--- a/pkg/internal/netns/netns.go
+++ b/pkg/internal/netns/netns.go
@@ -21,16 +21,19 @@ func netNSPath(hostPid int) string {
 	return fmt.Sprintf("/proc/%d/ns/net", hostPid)
 }
 
+// statNetNSInode is injectable for tests.
+var statNetNSInode = netNSInode
+
 // IsIsolated reports whether pid's network namespace is distinct from both the
 // calling process and PID 1. Isolated namespaces are Docker/containerd bridge
 // nets; host-network and bare-host processes share the agent or host netns.
 func IsIsolated(pid int) (bool, error) {
-	pidIno, err := netNSInode(netNSPath(pid))
+	pidIno, err := statNetNSInode(netNSPath(pid))
 	if err != nil {
 		return false, fmt.Errorf("stat pid netns: %w", err)
 	}
 
-	selfIno, err := netNSInode(netNSPath(os.Getpid()))
+	selfIno, err := statNetNSInode(netNSPath(os.Getpid()))
 	if err != nil {
 		return false, fmt.Errorf("stat self netns: %w", err)
 	}
@@ -39,10 +42,9 @@ func IsIsolated(pid int) (bool, error) {
 		return false, nil
 	}
 
-	hostIno, err := netNSInode(netNSPath(1))
+	hostIno, err := statNetNSInode(netNSPath(1))
 	if err != nil {
-		// Host PID 1 is not visible; agent vs pid is the only check.
-		return true, nil
+		return false, fmt.Errorf("stat host netns: %w", err)
 	}
 
 	return pidIno != hostIno, nil

--- a/pkg/internal/netns/netns_other.go
+++ b/pkg/internal/netns/netns_other.go
@@ -8,3 +8,7 @@ package netns // import "go.opentelemetry.io/obi/pkg/internal/netns"
 func WithNetNS(_ int, fn func() error) error {
 	return fn()
 }
+
+func IsIsolated(_ int) (bool, error) {
+	return false, nil
+}

--- a/pkg/internal/netns/netns_test.go
+++ b/pkg/internal/netns/netns_test.go
@@ -97,3 +97,9 @@ func TestSameNetNSReportsMissingTarget(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, os.ErrNotExist)
 }
+
+func TestIsIsolated_selfIsNotIsolated(t *testing.T) {
+	isolated, err := IsIsolated(os.Getpid())
+	require.NoError(t, err)
+	assert.False(t, isolated)
+}

--- a/pkg/internal/netns/netns_test.go
+++ b/pkg/internal/netns/netns_test.go
@@ -103,3 +103,28 @@ func TestIsIsolated_selfIsNotIsolated(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, isolated)
 }
+
+func TestIsIsolated_failsClosedWhenHostNetNSUnavailable(t *testing.T) {
+	orig := statNetNSInode
+	t.Cleanup(func() { statNetNSInode = orig })
+
+	const targetPID = 9999
+	statNetNSInode = func(path string) (uint64, error) {
+		switch path {
+		case netNSPath(targetPID):
+			return 100, nil
+		case netNSPath(os.Getpid()):
+			return 200, nil
+		case netNSPath(1):
+			return 0, os.ErrNotExist
+		default:
+			t.Fatalf("unexpected netns path %q", path)
+			return 0, nil
+		}
+	}
+
+	isolated, err := IsIsolated(targetPID)
+	require.Error(t, err)
+	assert.False(t, isolated)
+	assert.ErrorContains(t, err, "stat host netns")
+}

--- a/pkg/selection/dynamic_app_ips.go
+++ b/pkg/selection/dynamic_app_ips.go
@@ -123,24 +123,36 @@ func (d *DynamicAppIPs) decrementIPsLocked(ips []string) {
 	}
 }
 
-// ResolveContainerIPs returns pod IPs for a PID when a Kubernetes store is available.
-// It registers the PID in store via AddProcess; callers that invoke it outside
-// DynamicAppIPs must call store.DeleteProcess when the PID is no longer needed.
-func ResolveContainerIPs(store *kube.Store, pid app.PID) []string {
-	if store == nil {
-		return nil
-	}
-	store.AddProcess(pid)
-	info, err := container.InfoForPID(pid)
+// processIPs resolves non-loopback addresses from pid's network namespace (Docker /
+// containerd / host-network / bare processes). Injectable for tests.
+var processIPs = func(pid app.PID) []string {
+	ips, err := container.IPsForPID(pid)
 	if err != nil {
-		selLog().Debug("can't read container info for PID", "pid", pid, "error", err)
+		selLog().Debug("can't list netns IPs for PID", "pid", pid, "error", err)
 		return nil
 	}
-	meta, _ := store.PodContainerByPIDNs(info.PIDNamespace, pid)
-	if meta == nil {
-		return nil
+	return ips
+}
+
+// ResolveContainerIPs returns the IPs associated with a dynamically selected PID.
+// Prefer Kubernetes pod IPs when a kube store is available; otherwise (and when the
+// store has no entry for the PID) fall back to addresses visible in the process's
+// network namespace so NetO11y/StatsO11y work on VMs and plain Docker hosts.
+//
+// When store is non-nil the PID is registered via AddProcess; callers that invoke
+// this outside DynamicAppIPs must call store.DeleteProcess when the PID is no
+// longer needed.
+func ResolveContainerIPs(store *kube.Store, pid app.PID) []string {
+	if store != nil {
+		store.AddProcess(pid)
+		info, err := container.InfoForPID(pid)
+		if err != nil {
+			selLog().Debug("can't read container info for PID", "pid", pid, "error", err)
+		} else if meta, _ := store.PodContainerByPIDNs(info.PIDNamespace, pid); meta != nil && len(meta.Meta.Ips) > 0 {
+			return append([]string(nil), meta.Meta.Ips...)
+		}
 	}
-	return append([]string(nil), meta.Meta.Ips...)
+	return processIPs(pid)
 }
 
 // Allows returns whether a flow/stat record should be exported for the current dynamic selection.

--- a/pkg/selection/dynamic_app_ips.go
+++ b/pkg/selection/dynamic_app_ips.go
@@ -10,7 +10,6 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/internal/helpers/container"
-	"go.opentelemetry.io/obi/pkg/internal/netns"
 	"go.opentelemetry.io/obi/pkg/internal/pipe"
 	"go.opentelemetry.io/obi/pkg/kube"
 )
@@ -134,39 +133,32 @@ var processIPs = func(pid app.PID) []string {
 	return ips
 }
 
-// injectable for tests
-var isIsolatedNetNS = netns.IsIsolated
-
 // ResolveContainerIPs returns the IPs associated with a dynamically selected PID.
-// Prefer Kubernetes pod IPs when a kube store is available; otherwise (and when
-// the store has no entry for the PID) fall back to addresses in an isolated
-// container network namespace (Docker/containerd bridge). Processes that share
-// the host or agent netns are not identified by interface address: those IPs
-// are shared with unselected traffic and CommonAttrs has no PID to recover
-// ownership.
+//
+// The two sources are mutually exclusive. With a Kubernetes store, pod IPs are the only
+// source of identity and a PID without pod metadata resolves to nothing. Without a store,
+// identity comes from the addresses of an isolated container network namespace
+// (Docker/containerd bridge); container.IPsForPID yields nothing for a process sharing
+// the host or agent namespace, whose addresses belong to the node rather than to it.
 //
 // When store is non-nil the PID is registered via AddProcess; callers that invoke
 // this outside DynamicAppIPs must call store.DeleteProcess when the PID is no
 // longer needed.
 func ResolveContainerIPs(store *kube.Store, pid app.PID) []string {
-	if store != nil {
-		store.AddProcess(pid)
-		info, err := container.InfoForPID(pid)
-		if err != nil {
-			selLog().Debug("can't read container info for PID", "pid", pid, "error", err)
-		} else if meta, _ := store.PodContainerByPIDNs(info.PIDNamespace, pid); meta != nil && len(meta.Meta.Ips) > 0 {
-			return append([]string(nil), meta.Meta.Ips...)
-		}
+	if store == nil {
+		return processIPs(pid)
 	}
-	isolated, err := isIsolatedNetNS(int(pid))
+	store.AddProcess(pid)
+	info, err := container.InfoForPID(pid)
 	if err != nil {
-		selLog().Debug("can't determine netns isolation for PID", "pid", pid, "error", err)
+		selLog().Debug("can't read container info for PID", "pid", pid, "error", err)
 		return nil
 	}
-	if !isolated {
+	meta, _ := store.PodContainerByPIDNs(info.PIDNamespace, pid)
+	if meta == nil {
 		return nil
 	}
-	return processIPs(pid)
+	return append([]string(nil), meta.Meta.Ips...)
 }
 
 // Allows returns whether a flow/stat record should be exported for the current dynamic selection.

--- a/pkg/selection/dynamic_app_ips.go
+++ b/pkg/selection/dynamic_app_ips.go
@@ -10,6 +10,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/internal/helpers/container"
+	"go.opentelemetry.io/obi/pkg/internal/netns"
 	"go.opentelemetry.io/obi/pkg/internal/pipe"
 	"go.opentelemetry.io/obi/pkg/kube"
 )
@@ -123,8 +124,7 @@ func (d *DynamicAppIPs) decrementIPsLocked(ips []string) {
 	}
 }
 
-// processIPs resolves non-loopback addresses from pid's network namespace (Docker /
-// containerd / host-network / bare processes). Injectable for tests.
+// processIPs lists addresses in pid's netns. Injectable for tests.
 var processIPs = func(pid app.PID) []string {
 	ips, err := container.IPsForPID(pid)
 	if err != nil {
@@ -134,10 +134,16 @@ var processIPs = func(pid app.PID) []string {
 	return ips
 }
 
+// injectable for tests
+var isIsolatedNetNS = netns.IsIsolated
+
 // ResolveContainerIPs returns the IPs associated with a dynamically selected PID.
-// Prefer Kubernetes pod IPs when a kube store is available; otherwise (and when the
-// store has no entry for the PID) fall back to addresses visible in the process's
-// network namespace so NetO11y/StatsO11y work on VMs and plain Docker hosts.
+// Prefer Kubernetes pod IPs when a kube store is available; otherwise (and when
+// the store has no entry for the PID) fall back to addresses in an isolated
+// container network namespace (Docker/containerd bridge). Processes that share
+// the host or agent netns are not identified by interface address: those IPs
+// are shared with unselected traffic and CommonAttrs has no PID to recover
+// ownership.
 //
 // When store is non-nil the PID is registered via AddProcess; callers that invoke
 // this outside DynamicAppIPs must call store.DeleteProcess when the PID is no
@@ -151,6 +157,14 @@ func ResolveContainerIPs(store *kube.Store, pid app.PID) []string {
 		} else if meta, _ := store.PodContainerByPIDNs(info.PIDNamespace, pid); meta != nil && len(meta.Meta.Ips) > 0 {
 			return append([]string(nil), meta.Meta.Ips...)
 		}
+	}
+	isolated, err := isIsolatedNetNS(int(pid))
+	if err != nil {
+		selLog().Debug("can't determine netns isolation for PID", "pid", pid, "error", err)
+		return nil
+	}
+	if !isolated {
+		return nil
 	}
 	return processIPs(pid)
 }

--- a/pkg/selection/dynamic_app_ips_test.go
+++ b/pkg/selection/dynamic_app_ips_test.go
@@ -37,6 +37,36 @@ func (s *stubPIDSelector) IncludesPID(pid app.PID) bool {
 func (s *stubPIDSelector) AddedPIDsNotify() <-chan []app.PID { return s.addedCh }
 func (s *stubPIDSelector) RemovedNotify() <-chan []app.PID   { return s.removed }
 
+func TestResolveContainerIPs_netnsFallbackWithoutStore(t *testing.T) {
+	orig := processIPs
+	t.Cleanup(func() { processIPs = orig })
+	processIPs = func(pid app.PID) []string {
+		assert.Equal(t, app.PID(7), pid)
+		return []string{"172.17.0.3", "fd00::a"}
+	}
+
+	assert.Equal(t, []string{"172.17.0.3", "fd00::a"}, ResolveContainerIPs(nil, 7))
+}
+
+func TestDynamicAppIPs_addBatch_usesResolvedIPs(t *testing.T) {
+	orig := processIPs
+	t.Cleanup(func() { processIPs = orig })
+	processIPs = func(pid app.PID) []string {
+		if pid == 99 {
+			return []string{"10.1.1.5"}
+		}
+		return nil
+	}
+
+	sel := &stubPIDSelector{pids: []app.PID{99}}
+	tracker := NewDynamicAppIPs(sel, nil)
+	tracker.addBatch([]app.PID{99})
+
+	src := pipe.IPAddr(net.ParseIP("10.1.1.5"))
+	dst := pipe.IPAddr(net.ParseIP("10.2.2.2"))
+	assert.True(t, tracker.Allows(&pipe.CommonAttrs{SrcAddr: src, DstAddr: dst}))
+}
+
 func TestDynamicAppIPs_Allows_emptySelectorBlocks(t *testing.T) {
 	sel := &stubPIDSelector{}
 	tracker := NewDynamicAppIPs(sel, nil)

--- a/pkg/selection/dynamic_app_ips_test.go
+++ b/pkg/selection/dynamic_app_ips_test.go
@@ -4,8 +4,8 @@
 package selection
 
 import (
-	"errors"
 	"net"
+	"os"
 	"slices"
 	"testing"
 
@@ -13,7 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/pipe"
+	"go.opentelemetry.io/obi/pkg/kube"
+	"go.opentelemetry.io/obi/pkg/kube/kubecache/informer"
+	"go.opentelemetry.io/obi/pkg/kube/kubecache/meta"
 )
 
 type stubPIDSelector struct {
@@ -40,29 +44,45 @@ func (s *stubPIDSelector) RemovedNotify() <-chan []app.PID   { return s.removed 
 
 func stubIsolatedProcessIPs(t *testing.T, ipsFor func(app.PID) []string) {
 	t.Helper()
-	origIso := isIsolatedNetNS
-	origIPs := processIPs
-	t.Cleanup(func() {
-		isIsolatedNetNS = origIso
-		processIPs = origIPs
-	})
-	isIsolatedNetNS = func(int) (bool, error) { return true, nil }
+	orig := processIPs
+	t.Cleanup(func() { processIPs = orig })
 	processIPs = ipsFor
 }
 
+// container.IPsForPID yields no addresses for a process sharing the host or agent
+// network namespace, whether because the namespace is not isolated or because the
+// isolation check itself failed.
 func stubSharedHostNetNS(t *testing.T) {
 	t.Helper()
-	origIso := isIsolatedNetNS
-	origIPs := processIPs
-	t.Cleanup(func() {
-		isIsolatedNetNS = origIso
-		processIPs = origIPs
-	})
-	isIsolatedNetNS = func(int) (bool, error) { return false, nil }
-	processIPs = func(app.PID) []string {
-		t.Error("processIPs must not run for a shared host netns")
-		return []string{"192.168.1.10"}
+	stubIsolatedProcessIPs(t, func(app.PID) []string { return nil })
+}
+
+// fakeInformer is a meta.Notifier that never publishes anything, so a store built on it
+// knows no pods.
+type fakeInformer struct {
+	observers map[string]meta.Observer
+}
+
+func (f *fakeInformer) Subscribe(observer meta.Observer) {
+	if f.observers == nil {
+		f.observers = map[string]meta.Observer{}
 	}
+	f.observers[observer.ID()] = observer
+}
+
+func (f *fakeInformer) Unsubscribe(observer meta.Observer) {
+	delete(f.observers, observer.ID())
+}
+
+func (f *fakeInformer) Notify(event *informer.Event) {
+	for _, observer := range f.observers {
+		_ = observer.On(event)
+	}
+}
+
+func newTestKubeStore(t *testing.T) *kube.Store {
+	t.Helper()
+	return kube.NewStore(&fakeInformer{}, kube.ResourceLabels{}, nil, imetrics.NoopReporter{})
 }
 
 func TestResolveContainerIPs_netnsFallbackWithoutStore(t *testing.T) {
@@ -79,19 +99,32 @@ func TestResolveContainerIPs_sharedHostNetNSReturnsNoIPs(t *testing.T) {
 	assert.Empty(t, ResolveContainerIPs(nil, 7))
 }
 
-func TestResolveContainerIPs_isolationErrorReturnsNoIPs(t *testing.T) {
-	origIso := isIsolatedNetNS
-	origIPs := processIPs
-	t.Cleanup(func() {
-		isIsolatedNetNS = origIso
-		processIPs = origIPs
+// Host addresses are only usable as identity off Kubernetes. A Kubernetes deployment must
+// resolve identity from pod metadata alone, so a PID the store knows nothing about resolves
+// to no IPs rather than to whatever its namespace happens to expose.
+func TestResolveContainerIPs_withStoreNeverUsesNetNS(t *testing.T) {
+	stubIsolatedProcessIPs(t, func(app.PID) []string {
+		t.Error("processIPs must not run when a Kubernetes store is configured")
+		return []string{"192.168.1.10"}
 	})
-	isIsolatedNetNS = func(int) (bool, error) { return false, errors.New("stat netns") }
-	processIPs = func(app.PID) []string {
-		t.Error("processIPs must not run when isolation cannot be determined")
-		return []string{"172.17.0.2"}
-	}
-	assert.Empty(t, ResolveContainerIPs(nil, 7))
+
+	assert.Empty(t, ResolveContainerIPs(newTestKubeStore(t), app.PID(os.Getpid())))
+}
+
+func TestDynamicAppIPs_withStore_doesNotAdmitTrafficForUnknownPID(t *testing.T) {
+	stubIsolatedProcessIPs(t, func(app.PID) []string {
+		t.Error("processIPs must not run when a Kubernetes store is configured")
+		return []string{"192.168.1.10"}
+	})
+
+	pid := app.PID(os.Getpid())
+	sel := &stubPIDSelector{pids: []app.PID{pid}}
+	tracker := NewDynamicAppIPs(sel, newTestKubeStore(t))
+	tracker.addBatch([]app.PID{pid})
+
+	host := pipe.IPAddr(net.ParseIP("192.168.1.10"))
+	other := pipe.IPAddr(net.ParseIP("8.8.8.8"))
+	assert.False(t, tracker.Allows(&pipe.CommonAttrs{SrcAddr: host, DstAddr: other}))
 }
 
 func TestDynamicAppIPs_addBatch_usesResolvedIPs(t *testing.T) {

--- a/pkg/selection/dynamic_app_ips_test.go
+++ b/pkg/selection/dynamic_app_ips_test.go
@@ -4,6 +4,7 @@
 package selection
 
 import (
+	"errors"
 	"net"
 	"slices"
 	"testing"
@@ -37,26 +38,69 @@ func (s *stubPIDSelector) IncludesPID(pid app.PID) bool {
 func (s *stubPIDSelector) AddedPIDsNotify() <-chan []app.PID { return s.addedCh }
 func (s *stubPIDSelector) RemovedNotify() <-chan []app.PID   { return s.removed }
 
+func stubIsolatedProcessIPs(t *testing.T, ipsFor func(app.PID) []string) {
+	t.Helper()
+	origIso := isIsolatedNetNS
+	origIPs := processIPs
+	t.Cleanup(func() {
+		isIsolatedNetNS = origIso
+		processIPs = origIPs
+	})
+	isIsolatedNetNS = func(int) (bool, error) { return true, nil }
+	processIPs = ipsFor
+}
+
+func stubSharedHostNetNS(t *testing.T) {
+	t.Helper()
+	origIso := isIsolatedNetNS
+	origIPs := processIPs
+	t.Cleanup(func() {
+		isIsolatedNetNS = origIso
+		processIPs = origIPs
+	})
+	isIsolatedNetNS = func(int) (bool, error) { return false, nil }
+	processIPs = func(app.PID) []string {
+		t.Error("processIPs must not run for a shared host netns")
+		return []string{"192.168.1.10"}
+	}
+}
+
 func TestResolveContainerIPs_netnsFallbackWithoutStore(t *testing.T) {
-	orig := processIPs
-	t.Cleanup(func() { processIPs = orig })
-	processIPs = func(pid app.PID) []string {
+	stubIsolatedProcessIPs(t, func(pid app.PID) []string {
 		assert.Equal(t, app.PID(7), pid)
 		return []string{"172.17.0.3", "fd00::a"}
-	}
+	})
 
 	assert.Equal(t, []string{"172.17.0.3", "fd00::a"}, ResolveContainerIPs(nil, 7))
 }
 
+func TestResolveContainerIPs_sharedHostNetNSReturnsNoIPs(t *testing.T) {
+	stubSharedHostNetNS(t)
+	assert.Empty(t, ResolveContainerIPs(nil, 7))
+}
+
+func TestResolveContainerIPs_isolationErrorReturnsNoIPs(t *testing.T) {
+	origIso := isIsolatedNetNS
+	origIPs := processIPs
+	t.Cleanup(func() {
+		isIsolatedNetNS = origIso
+		processIPs = origIPs
+	})
+	isIsolatedNetNS = func(int) (bool, error) { return false, errors.New("stat netns") }
+	processIPs = func(app.PID) []string {
+		t.Error("processIPs must not run when isolation cannot be determined")
+		return []string{"172.17.0.2"}
+	}
+	assert.Empty(t, ResolveContainerIPs(nil, 7))
+}
+
 func TestDynamicAppIPs_addBatch_usesResolvedIPs(t *testing.T) {
-	orig := processIPs
-	t.Cleanup(func() { processIPs = orig })
-	processIPs = func(pid app.PID) []string {
+	stubIsolatedProcessIPs(t, func(pid app.PID) []string {
 		if pid == 99 {
 			return []string{"10.1.1.5"}
 		}
 		return nil
-	}
+	})
 
 	sel := &stubPIDSelector{pids: []app.PID{99}}
 	tracker := NewDynamicAppIPs(sel, nil)
@@ -65,6 +109,60 @@ func TestDynamicAppIPs_addBatch_usesResolvedIPs(t *testing.T) {
 	src := pipe.IPAddr(net.ParseIP("10.1.1.5"))
 	dst := pipe.IPAddr(net.ParseIP("10.2.2.2"))
 	assert.True(t, tracker.Allows(&pipe.CommonAttrs{SrcAddr: src, DstAddr: dst}))
+}
+
+func TestDynamicAppIPs_sharedHostNetNS_doesNotAdmitUnselectedHostTraffic(t *testing.T) {
+	stubSharedHostNetNS(t)
+
+	sel := &stubPIDSelector{pids: []app.PID{100}}
+	tracker := NewDynamicAppIPs(sel, nil)
+	tracker.addBatch([]app.PID{100})
+
+	host := pipe.IPAddr(net.ParseIP("192.168.1.10"))
+	other := pipe.IPAddr(net.ParseIP("8.8.8.8"))
+	assert.False(t, tracker.Allows(&pipe.CommonAttrs{SrcAddr: host, DstAddr: other}))
+}
+
+func TestDynamicAppIPs_twoSelectedInSharedNetNS_neitherGetsHostIPs(t *testing.T) {
+	stubSharedHostNetNS(t)
+
+	sel := &stubPIDSelector{pids: []app.PID{10, 20}}
+	tracker := NewDynamicAppIPs(sel, nil)
+	tracker.addBatch([]app.PID{10, 20})
+
+	host := pipe.IPAddr(net.ParseIP("192.168.1.10"))
+	other := pipe.IPAddr(net.ParseIP("8.8.8.8"))
+	assert.False(t, tracker.Allows(&pipe.CommonAttrs{SrcAddr: host, DstAddr: other}))
+}
+
+func TestDynamicAppIPs_twoIsolatedNetNS_eachKeepsOwnIP(t *testing.T) {
+	stubIsolatedProcessIPs(t, func(pid app.PID) []string {
+		switch pid {
+		case 10:
+			return []string{"172.17.0.2"}
+		case 20:
+			return []string{"172.17.0.3"}
+		}
+		return nil
+	})
+
+	sel := &stubPIDSelector{pids: []app.PID{10, 20}}
+	tracker := NewDynamicAppIPs(sel, nil)
+	tracker.addBatch([]app.PID{10, 20})
+
+	dst := pipe.IPAddr(net.ParseIP("8.8.8.8"))
+	assert.True(t, tracker.Allows(&pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("172.17.0.2")),
+		DstAddr: dst,
+	}))
+	assert.True(t, tracker.Allows(&pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("172.17.0.3")),
+		DstAddr: dst,
+	}))
+	assert.False(t, tracker.Allows(&pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("192.168.1.10")),
+		DstAddr: dst,
+	}))
 }
 
 func TestDynamicAppIPs_Allows_emptySelectorBlocks(t *testing.T) {

--- a/pkg/selection/dynamic_flow_attrs.go
+++ b/pkg/selection/dynamic_flow_attrs.go
@@ -87,7 +87,7 @@ func (d *DynamicFlowAttrs) rebuild() {
 
 	next := map[string]flowIPDecoration{}
 	storeRegisteredPIDs := map[app.PID]struct{}{}
-	if ok && d.store != nil {
+	if ok {
 		for _, pid := range pids {
 			entry, found := d.multiSel.GetPID(uint32(pid))
 			if !found {
@@ -100,7 +100,10 @@ func (d *DynamicFlowAttrs) rebuild() {
 			for _, ip := range ResolveContainerIPs(d.store, pid) {
 				next[ip] = dec
 			}
-			storeRegisteredPIDs[pid] = struct{}{}
+			// Only kube-store registrations need DeleteProcess cleanup.
+			if d.store != nil {
+				storeRegisteredPIDs[pid] = struct{}{}
+			}
 		}
 	}
 

--- a/pkg/selection/dynamic_flow_attrs_test.go
+++ b/pkg/selection/dynamic_flow_attrs_test.go
@@ -132,14 +132,12 @@ func TestDynamicFlowAttrs_rebuild_doesNotTrackPIDWithoutDecoration(t *testing.T)
 }
 
 func TestDynamicFlowAttrs_rebuild_netnsFallbackWithoutStore(t *testing.T) {
-	orig := processIPs
-	t.Cleanup(func() { processIPs = orig })
-	processIPs = func(pid app.PID) []string {
+	stubIsolatedProcessIPs(t, func(pid app.PID) []string {
 		if pid == 42 {
 			return []string{"10.0.0.5"}
 		}
 		return nil
-	}
+	})
 
 	sel := &stubMultiPIDSelector{
 		stubPIDSelector: stubPIDSelector{pids: []app.PID{42}},
@@ -158,4 +156,87 @@ func TestDynamicFlowAttrs_rebuild_netnsFallbackWithoutStore(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "coupon", dec.serviceName)
 	assert.Equal(t, "demo", dec.serviceNamespace)
+}
+
+func TestDynamicFlowAttrs_rebuild_sharedHostNetNS_doesNotDecorate(t *testing.T) {
+	stubSharedHostNetNS(t)
+
+	sel := &stubMultiPIDSelector{
+		stubPIDSelector: stubPIDSelector{pids: []app.PID{100}},
+		entries: map[app.PID]DynamicPIDEntry{
+			100: {PID: 100, ServiceName: "sshd"},
+		},
+	}
+	tracker := NewDynamicFlowAttrs(sel, sel, nil)
+	tracker.rebuild()
+
+	flow := &pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("192.168.1.10")),
+		DstAddr: pipe.IPAddr(net.ParseIP("8.8.8.8")),
+	}
+	tracker.Apply(flow)
+	assert.Nil(t, flow.Metadata)
+}
+
+func TestDynamicFlowAttrs_rebuild_twoSelectedSharedNetNS_noLastWriterWins(t *testing.T) {
+	stubSharedHostNetNS(t)
+
+	sel := &stubMultiPIDSelector{
+		stubPIDSelector: stubPIDSelector{pids: []app.PID{10, 20}},
+		entries: map[app.PID]DynamicPIDEntry{
+			10: {PID: 10, ServiceName: "sshd"},
+			20: {PID: 20, ServiceName: "nginx"},
+		},
+	}
+	tracker := NewDynamicFlowAttrs(sel, sel, nil)
+	tracker.rebuild()
+
+	tracker.mu.RLock()
+	assert.Empty(t, tracker.ipDecor)
+	tracker.mu.RUnlock()
+
+	flow := &pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("192.168.1.10")),
+		DstAddr: pipe.IPAddr(net.ParseIP("8.8.8.8")),
+	}
+	tracker.Apply(flow)
+	assert.Nil(t, flow.Metadata)
+}
+
+func TestDynamicFlowAttrs_rebuild_twoIsolatedNetNS_eachKeepsOwnAttrs(t *testing.T) {
+	stubIsolatedProcessIPs(t, func(pid app.PID) []string {
+		switch pid {
+		case 1:
+			return []string{"172.17.0.2"}
+		case 2:
+			return []string{"172.17.0.3"}
+		}
+		return nil
+	})
+
+	sel := &stubMultiPIDSelector{
+		stubPIDSelector: stubPIDSelector{pids: []app.PID{1, 2}},
+		entries: map[app.PID]DynamicPIDEntry{
+			1: {PID: 1, ServiceName: "payments"},
+			2: {PID: 2, ServiceName: "checkout"},
+		},
+	}
+	tracker := NewDynamicFlowAttrs(sel, sel, nil)
+	tracker.rebuild()
+
+	payments := &pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("172.17.0.2")),
+		DstAddr: pipe.IPAddr(net.ParseIP("8.8.8.8")),
+	}
+	tracker.Apply(payments)
+	require.NotNil(t, payments.Metadata)
+	assert.Equal(t, "payments", payments.Metadata[attr.ServiceName])
+
+	checkout := &pipe.CommonAttrs{
+		SrcAddr: pipe.IPAddr(net.ParseIP("172.17.0.3")),
+		DstAddr: pipe.IPAddr(net.ParseIP("8.8.8.8")),
+	}
+	tracker.Apply(checkout)
+	require.NotNil(t, checkout.Metadata)
+	assert.Equal(t, "checkout", checkout.Metadata[attr.ServiceName])
 }

--- a/pkg/selection/dynamic_flow_attrs_test.go
+++ b/pkg/selection/dynamic_flow_attrs_test.go
@@ -130,3 +130,32 @@ func TestDynamicFlowAttrs_rebuild_doesNotTrackPIDWithoutDecoration(t *testing.T)
 	assert.Empty(t, tracker.registeredPIDs)
 	tracker.mu.RUnlock()
 }
+
+func TestDynamicFlowAttrs_rebuild_netnsFallbackWithoutStore(t *testing.T) {
+	orig := processIPs
+	t.Cleanup(func() { processIPs = orig })
+	processIPs = func(pid app.PID) []string {
+		if pid == 42 {
+			return []string{"10.0.0.5"}
+		}
+		return nil
+	}
+
+	sel := &stubMultiPIDSelector{
+		stubPIDSelector: stubPIDSelector{pids: []app.PID{42}},
+		entries: map[app.PID]DynamicPIDEntry{
+			42: {PID: 42, ServiceName: "coupon", ServiceNamespace: "demo"},
+		},
+	}
+	tracker := NewDynamicFlowAttrs(sel, sel, nil)
+	tracker.rebuild()
+
+	tracker.mu.RLock()
+	dec, ok := tracker.ipDecor["10.0.0.5"]
+	assert.Empty(t, tracker.registeredPIDs) // no kube store → no DeleteProcess tracking
+	tracker.mu.RUnlock()
+
+	require.True(t, ok)
+	assert.Equal(t, "coupon", dec.serviceName)
+	assert.Equal(t, "demo", dec.serviceNamespace)
+}


### PR DESCRIPTION
## Summary

This adds support for non-k8s network and stats metrics via the DynamicSelector. The DynamicSelector currently uses a lookup to map selected PIDs to a matching IP to decide which apps to "include" (export). Today this relies on a k8s store lookup, which won't work in VM/Docker-standalone apps.

This adds an additional fallback into the mapping to look up host network addresses that map to the selected PIDs and uses that if the k8s store is nil.

Based on feedback from the original attempts, this PR limits the scope to host processes that exist in isolated network namespaces, such as docker containers. Bare host PID support will come in a follow up which requires pid-level association for the host network namespace (meaning this PR also doesn't support containers running with host network)

Something else I noticed which may be a follow up is it doesn't look like we export attributes like `service.name` in non-k8s metrics? This would be good to update if possible

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.