### PR TITLE
feat(logs): replace queue/processing spans with a combined log record (opt-in)

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -22,6 +22,7 @@ Generated from [`config-schema.json`](config-schema.json).
 - [`name_resolver`](#name-resolver)
 - [`network`](#network)
 - [`nodejs`](#nodejs)
+- [`otel_logs_export`](#otel-logs-export)
 - [`otel_metrics_export`](#otel-metrics-export)
 - [`otel_traces_export`](#otel-traces-export)
 - [`prometheus_export`](#prometheus-export)
@@ -533,6 +534,23 @@ ReverseDNS is currently experimental. It is kept disabled by default and will be
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
 |---|---|---|---|---|---|---|
 | `nodejs.enabled` | `boolean` | `OTEL_EBPF_NODEJS_ENABLED` | `true` |  |  |  |
+
+## `otel_logs_export`
+
+| YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
+|---|---|---|---|---|---|---|
+| `otel_logs_export.backoff_initial_interval` | `duration` | `OTEL_EBPF_LOGS_BACKOFF_INITIAL_INTERVAL` | `0s` | `30s`, `5m`, `1ms`, etc |  | Configuration options for BackOffConfig of the logs exporter. See <https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configretry/backoff.go> Namespaced per-signal (unlike TracesConfig's generically-named equivalents) since this is a new signal and there's no existing precedent of these being intentionally shared across signals. |
+| `otel_logs_export.backoff_max_elapsed_time` | `duration` | `OTEL_EBPF_LOGS_BACKOFF_MAX_ELAPSED_TIME` | `0s` | `30s`, `5m`, `1ms`, etc |  |  |
+| `otel_logs_export.backoff_max_interval` | `duration` | `OTEL_EBPF_LOGS_BACKOFF_MAX_INTERVAL` | `0s` | `30s`, `5m`, `1ms`, etc |  |  |
+| `otel_logs_export.batch_max_size` | `integer` | `OTEL_EBPF_OTLP_LOGS_BATCH_MAX_SIZE` | `0` |  |  | Is the maximum number of log records that the batcher will accumulate before flushing a batch to the sending queue. |
+| `otel_logs_export.batch_timeout` | `duration` | `OTEL_EBPF_OTLP_LOGS_BATCH_TIMEOUT` | `0s` | `30s`, `5m`, `1ms`, etc |  | Is the time after which a batch will be sent regardless of its size. |
+| `otel_logs_export.endpoint` | `uri` | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` |  |  |  |  |
+| `otel_logs_export.insecure_skip_verify` | `boolean` | `OTEL_EBPF_INSECURE_SKIP_VERIFY` | `false` |  |  | Enables skipping TLS certificate verification (not standard, so we don't follow the same naming convention) |
+| `otel_logs_export.otel_sdk_log_level` | `string` | `OTEL_EBPF_SDK_LOG_LEVEL` |  |  |  | Is intentionally the SAME env var as TracesConfig/MetricsConfig's field of the same name — this is an existing shared, not per-signal, knob. |
+| `otel_logs_export.protocol` | `string` | `OTEL_EXPORTER_OTLP_PROTOCOL` |  | ``, `debug`, `grpc`, `http/json`, `http/protobuf` |  |  |
+| `otel_logs_export.queue_processing_logs` | `boolean` | `OTEL_EBPF_QUEUE_PROCESSING_LOGS` | `false` |  |  | Replaces the "in queue"/"processing" sub-spans in the traces pipeline with a single combined log record per request (only emitted when there was an observable queue gap), correlated to the parent span via the log record's trace_id/span_id. Takes effect only when the logs exporter is also enabled — see Config.QueueProcessingAsLogsEnabled. |
+| `otel_logs_export.queue_size` | `integer` | `OTEL_EBPF_OTLP_LOGS_QUEUE_SIZE` | `0` |  |  | Is the maximum number of log records that the sending queue will hold before applying back-pressure. It must be >= `2 * BatchMaxSize`, otherwise the memory queue rejects every batch with "element size too large" and drops log records permanently. If left at 0 it defaults to `4 * BatchMaxSize`. |
+| `otel_logs_export.reporters_cache_len` | `integer` | `OTEL_EBPF_LOGS_REPORT_CACHE_LEN` | `0` |  |  |  |
 
 ## `otel_metrics_export`
 

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -1732,6 +1732,107 @@
       },
       "type": "object"
     },
+    "LogsConfig": {
+      "properties": {
+        "backoff_initial_interval": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s|m)$",
+          "description": "Configuration options for BackOffConfig of the logs exporter. See https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configretry/backoff.go Namespaced per-signal (unlike TracesConfig's generically-named equivalents) since this is a new signal and there's no existing precedent of these being intentionally shared across signals.",
+          "default": "0s",
+          "examples": [
+            "30s",
+            "5m",
+            "1ms"
+          ],
+          "x-env-var": "OTEL_EBPF_LOGS_BACKOFF_INITIAL_INTERVAL"
+        },
+        "backoff_max_elapsed_time": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s|m)$",
+          "default": "0s",
+          "examples": [
+            "30s",
+            "5m",
+            "1ms"
+          ],
+          "x-env-var": "OTEL_EBPF_LOGS_BACKOFF_MAX_ELAPSED_TIME"
+        },
+        "backoff_max_interval": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s|m)$",
+          "default": "0s",
+          "examples": [
+            "30s",
+            "5m",
+            "1ms"
+          ],
+          "x-env-var": "OTEL_EBPF_LOGS_BACKOFF_MAX_INTERVAL"
+        },
+        "batch_max_size": {
+          "type": "integer",
+          "description": "Is the maximum number of log records that the batcher will accumulate before flushing a batch to the sending queue.",
+          "default": 0,
+          "x-env-var": "OTEL_EBPF_OTLP_LOGS_BATCH_MAX_SIZE"
+        },
+        "batch_timeout": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s|m)$",
+          "description": "Is the time after which a batch will be sent regardless of its size.",
+          "default": "0s",
+          "examples": [
+            "30s",
+            "5m",
+            "1ms"
+          ],
+          "x-env-var": "OTEL_EBPF_OTLP_LOGS_BATCH_TIMEOUT"
+        },
+        "endpoint": {
+          "type": "string",
+          "format": "uri",
+          "x-env-var": "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"
+        },
+        "insecure_skip_verify": {
+          "type": "boolean",
+          "description": "Enables skipping TLS certificate verification (not standard, so we don't follow the same naming convention)",
+          "default": false,
+          "x-env-var": "OTEL_EBPF_INSECURE_SKIP_VERIFY"
+        },
+        "otel_sdk_log_level": {
+          "type": "string",
+          "description": "Is intentionally the SAME env var as TracesConfig/MetricsConfig's field of the same name — this is an existing shared, not per-signal, knob.",
+          "x-env-var": "OTEL_EBPF_SDK_LOG_LEVEL"
+        },
+        "protocol": {
+          "type": "string",
+          "enum": [
+            "",
+            "debug",
+            "grpc",
+            "http/json",
+            "http/protobuf"
+          ],
+          "x-env-var": "OTEL_EXPORTER_OTLP_PROTOCOL"
+        },
+        "queue_processing_logs": {
+          "type": "boolean",
+          "description": "Replaces the \"in queue\"/\"processing\" sub-spans in the traces pipeline with a single combined log record per request (only emitted when there was an observable queue gap), correlated to the parent span via the log record's trace_id/span_id. Takes effect only when the logs exporter is also enabled — see Config.QueueProcessingAsLogsEnabled.",
+          "default": false,
+          "x-env-var": "OTEL_EBPF_QUEUE_PROCESSING_LOGS"
+        },
+        "queue_size": {
+          "type": "integer",
+          "description": "Is the maximum number of log records that the sending queue will hold before applying back-pressure. It must be >= `2 * BatchMaxSize`, otherwise the memory queue rejects every batch with \"element size too large\" and drops log records permanently. If left at 0 it defaults to `4 * BatchMaxSize`.",
+          "default": 0,
+          "x-env-var": "OTEL_EBPF_OTLP_LOGS_QUEUE_SIZE"
+        },
+        "reporters_cache_len": {
+          "type": "integer",
+          "default": 0,
+          "x-env-var": "OTEL_EBPF_LOGS_REPORT_CACHE_LEN"
+        }
+      },
+      "type": "object"
+    },
     "MCPConfig": {
       "properties": {
         "enabled": {
@@ -3130,6 +3231,9 @@
       "$ref": "#/$defs/IntEnum",
       "description": "Allows selecting the instrumented executable that owns the Port value. If this value is set (and different to zero), the value of the Exec property won't take effect. It's important to emphasize that if your process opens multiple HTTP/GRPC ports, the auto-instrumenter will instrument all the service calls in all the ports, not only the port specified here.",
       "x-env-var": "OTEL_EBPF_OPEN_PORT"
+    },
+    "otel_logs_export": {
+      "$ref": "#/$defs/LogsConfig"
     },
     "otel_metrics_export": {
       "$ref": "#/$defs/MetricsConfig"

--- a/internal/test/integration/configs/obi-config-logs.yml
+++ b/internal/test/integration/configs/obi-config-logs.yml
@@ -1,0 +1,24 @@
+routes:
+  patterns:
+    - /basic/:rnd
+  unmatched: path
+  ignored_patterns:
+    - /metrics
+  ignore_mode: traces
+otel_metrics_export:
+  endpoint: http://otelcol:4318
+otel_traces_export:
+  endpoint: http://jaeger:4318
+  otel_sdk_log_level: debug
+otel_logs_export:
+  protocol: debug
+  otel_sdk_log_level: debug
+  queue_processing_logs: true
+attributes:
+  kubernetes:
+    cluster_name: obi-k8s-test-cluster
+    resource_labels:
+      deployment.environment: ["deployment.environment"]
+  select:
+    "*":
+      include: ["*"]

--- a/internal/test/integration/logs_test.go
+++ b/internal/test/integration/logs_test.go
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
+)
+
+func TestSuite_QueueProcessingLogs(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose.yml", path.Join(pathOutput, "test-suite-queue-processing-logs.log"))
+	require.NoError(t, err)
+	compose.Env = append(compose.Env,
+		`OTEL_EBPF_EXECUTABLE_PATH=(pingclient|testserver)`,
+		`INSTRUMENTER_CONFIG_SUFFIX=-logs`,
+	)
+	require.NoError(t, compose.Up())
+	t.Cleanup(func() {
+		require.NoError(t, compose.Close())
+	})
+
+	// Warm-up requests, same pattern as testHTTPTracesCommon: the first requests
+	// after the containers come up may race with eBPF probe attachment/symbol
+	// resolution, so we don't want to rely on the very first request below.
+	ti.DoHTTPGet(t, instrumentedServiceStdURL+"/metrics", 200)
+	ti.DoHTTPGet(t, instrumentedServiceStdURL+"/metrics", 200)
+
+	ti.DoHTTPGet(t, instrumentedServiceStdURL+"/create-trace?delay=10ms&status=200", 200)
+
+	// The span -> log-record pipeline is asynchronous (BPF ring buffer batching,
+	// span processing, logs exporter batching), so the queue/processing log
+	// record won't necessarily be in `docker compose logs obi`'s output the
+	// instant the HTTP request completes. Poll until it shows up.
+	//
+	// The debugexporter (protocol: debug) renders logs with its "detailed"
+	// verbosity as a human-readable field dump, not as JSON, e.g.:
+	//   EventName: request.queue_processing
+	//   Attributes:
+	//        -> queue.duration: Double(0.000006625)
+	//        -> processing.duration: Double(0.010251008)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		logLines, err := compose.LogsOutput("obi")
+		require.NoError(ct, err)
+		require.Contains(ct, logLines, "EventName: request.queue_processing",
+			"expected the debug-protocol logs exporter to print the queue/processing log record to OBI's own stdout")
+		assert.Contains(ct, logLines, "queue.duration: Double(")
+		assert.Contains(ct, logLines, "processing.duration: Double(")
+	}, testTimeout, 500*time.Millisecond)
+}

--- a/pkg/appolly/instrumenter.go
+++ b/pkg/appolly/instrumenter.go
@@ -128,7 +128,7 @@ func newGraphBuilder(
 		swarm.WithID("DynamicSignalSpanGate"))
 
 	swi.Add(otel.TracesReceiver(
-		ctxInfo, config.Traces, config.SpanMetricsEnabledForTraces(), selectorCfg, exportableSpans,
+		ctxInfo, config.Traces, config.SpanMetricsEnabledForTraces(), false, selectorCfg, exportableSpans,
 	), swarm.WithID("OTELTracesReceiver"))
 	swi.Add(debug.PrinterNode(config.TracePrinter, exportableSpans),
 		swarm.WithID("PrinterNode"))

--- a/pkg/appolly/instrumenter.go
+++ b/pkg/appolly/instrumenter.go
@@ -128,8 +128,11 @@ func newGraphBuilder(
 		swarm.WithID("DynamicSignalSpanGate"))
 
 	swi.Add(otel.TracesReceiver(
-		ctxInfo, config.Traces, config.SpanMetricsEnabledForTraces(), false, selectorCfg, exportableSpans,
+		ctxInfo, config.Traces, config.SpanMetricsEnabledForTraces(), config.QueueProcessingAsLogsEnabled(), selectorCfg, exportableSpans,
 	), swarm.WithID("OTELTracesReceiver"))
+	swi.Add(otel.LogsReceiver(
+		ctxInfo, config.Logs, config.Traces, selectorCfg, exportableSpans,
+	), swarm.WithID("OTELLogsReceiver"))
 	swi.Add(debug.PrinterNode(config.TracePrinter, exportableSpans),
 		swarm.WithID("PrinterNode"))
 

--- a/pkg/export/otel/logs.go
+++ b/pkg/export/otel/logs.go
@@ -187,30 +187,11 @@ func getLogsExporter(ctx context.Context, cfg otelcfg.LogsConfig) (exporter.Logs
 	switch proto := cfg.GetProtocol(); proto {
 	case otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf, "":
 		slog.Debug("instantiating HTTP LogsReporter", "protocol", proto)
-		opts, err := otelcfg.HTTPLogsEndpointOptions(&cfg)
+		factory := otlphttpexporter.NewFactory()
+		config, host, queueCfg, retryCfg, err := buildHTTPLogsExporterConfig(cfg, factory)
 		if err != nil {
 			slog.Error("can't get HTTP logs endpoint options", "error", err)
 			return nil, nil, err
-		}
-		factory := otlphttpexporter.NewFactory()
-		config := factory.CreateDefaultConfig().(*otlphttpexporter.Config)
-		config.QueueConfig = getLogsQueueConfig(cfg)
-		config.RetryConfig = getLogsRetrySettings(cfg)
-		config.ClientConfig = confighttp.ClientConfig{
-			Endpoint: opts.Scheme + "://" + opts.Endpoint + opts.BaseURLPath,
-			TLS: configtls.ClientConfig{
-				Insecure:           opts.Insecure,
-				InsecureSkipVerify: cfg.InsecureSkipVerify,
-			},
-			Headers: convertHeaders(opts.Headers),
-		}
-		host := component.Host(emptyHost{})
-		if opts.UnixSocketAddr != "" {
-			mwID := component.MustNewID("obi_uds")
-			config.ClientConfig.Middlewares = []configmiddleware.Config{{ID: mwID}}
-			host = udsHost{extensions: map[component.ID]component.Component{
-				mwID: udsMiddleware{addr: opts.UnixSocketAddr},
-			}}
 		}
 		set := getTraceSettings(factory.Type(), cfg.SDKLogLevel)
 		exp, err := factory.CreateLogs(ctx, set, config)
@@ -218,13 +199,16 @@ func getLogsExporter(ctx context.Context, cfg otelcfg.LogsConfig) (exporter.Logs
 			slog.Error("can't create OTLP HTTP logs exporter", "error", err)
 			return nil, nil, err
 		}
+		// The inner exporter's own queue/retry are disabled by
+		// buildHTTPLogsExporterConfig; queueCfg/retryCfg are applied here so
+		// there is exactly one buffering/retry layer, matching getTracesExporter.
 		wrapped, err := exporterhelper.NewLogs(ctx, set, cfg,
 			exp.ConsumeLogs,
 			exporterhelper.WithStart(exp.Start),
 			exporterhelper.WithShutdown(exp.Shutdown),
 			exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-			exporterhelper.WithQueue(config.QueueConfig),
-			exporterhelper.WithRetry(config.RetryConfig))
+			exporterhelper.WithQueue(queueCfg),
+			exporterhelper.WithRetry(retryCfg))
 		return wrapped, host, err
 	case otelcfg.ProtocolGRPC:
 		slog.Debug("instantiating GRPC LogsReporter", "protocol", proto)
@@ -277,6 +261,53 @@ func getLogsExporter(ctx context.Context, cfg otelcfg.LogsConfig) (exporter.Logs
 			proto, otelcfg.ProtocolGRPC, otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf))
 		return nil, nil, fmt.Errorf("invalid protocol value: %q", proto)
 	}
+}
+
+// buildHTTPLogsExporterConfig builds the otlphttpexporter.Config for the HTTP logs
+// exporter, with its own queue and retry disabled, and separately returns the real
+// queue/retry settings for the caller to apply exactly once via the outer
+// exporterhelper.NewLogs wrap — mirroring getTracesExporter's HTTP branch, so a log
+// record is buffered and retried by a single layer instead of the inner exporter and
+// the outer wrap each doing it independently. Split out from getLogsExporter so this
+// disable-then-wrap-once behavior is directly testable.
+func buildHTTPLogsExporterConfig(cfg otelcfg.LogsConfig, factory exporter.Factory) (
+	*otlphttpexporter.Config,
+	component.Host,
+	configoptional.Optional[exporterhelper.QueueBatchConfig],
+	configretry.BackOffConfig,
+	error,
+) {
+	opts, err := otelcfg.HTTPLogsEndpointOptions(&cfg)
+	if err != nil {
+		return nil, nil, configoptional.None[exporterhelper.QueueBatchConfig](), configretry.BackOffConfig{}, err
+	}
+
+	config := factory.CreateDefaultConfig().(*otlphttpexporter.Config)
+	queueCfg := getLogsQueueConfig(cfg)
+	retryCfg := getLogsRetrySettings(cfg)
+	disabledRetry := configretry.NewDefaultBackOffConfig()
+	disabledRetry.Enabled = false
+	config.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+	config.RetryConfig = disabledRetry
+	config.ClientConfig = confighttp.ClientConfig{
+		Endpoint: opts.Scheme + "://" + opts.Endpoint + opts.BaseURLPath,
+		TLS: configtls.ClientConfig{
+			Insecure:           opts.Insecure,
+			InsecureSkipVerify: cfg.InsecureSkipVerify,
+		},
+		Headers: convertHeaders(opts.Headers),
+	}
+
+	host := component.Host(emptyHost{})
+	if opts.UnixSocketAddr != "" {
+		mwID := component.MustNewID("obi_uds")
+		config.ClientConfig.Middlewares = []configmiddleware.Config{{ID: mwID}}
+		host = udsHost{extensions: map[component.ID]component.Component{
+			mwID: udsMiddleware{addr: opts.UnixSocketAddr},
+		}}
+	}
+
+	return config, host, queueCfg, retryCfg, nil
 }
 
 func getLogsQueueConfig(cfg otelcfg.LogsConfig) configoptional.Optional[exporterhelper.QueueBatchConfig] {

--- a/pkg/export/otel/logs.go
+++ b/pkg/export/otel/logs.go
@@ -1,0 +1,322 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel // import "go.opentelemetry.io/obi/pkg/export/otel"
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configmiddleware"
+	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/debugexporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
+	"go.opentelemetry.io/obi/pkg/export/otel/logsgen"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
+	"go.opentelemetry.io/obi/pkg/pipe/global"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm/swarms"
+)
+
+func ologslog() *slog.Logger {
+	return slog.With("component", "otel.LogsReceiver")
+}
+
+func makeLogsReceiver(
+	cfg otelcfg.LogsConfig,
+	tracesCfg otelcfg.TracesConfig,
+	ctxInfo *global.ContextInfo,
+	selectorCfg *attributes.SelectorConfig,
+	input *msg.Queue[[]request.Span],
+) *logsOTELReceiver {
+	return &logsOTELReceiver{
+		cfg:            cfg,
+		tracesCfg:      tracesCfg,
+		ctxInfo:        ctxInfo,
+		selectorCfg:    selectorCfg,
+		is:             instrumentations.NewInstrumentationSelection(tracesCfg.Instrumentations),
+		input:          input.Subscribe(msg.SubscriberName("otel.LogsReceiver")),
+		attributeCache: expirable2.NewLRU[svc.UID, []attribute.KeyValue](1024, nil, 5*time.Minute),
+	}
+}
+
+// LogsReceiver creates a terminal node that consumes request.Spans and sends
+// queue/processing log records to the configured logs consumer. It shares
+// the InstrumentationSelection and Sampler with the traces pipeline
+// (tracesCfg), so a request's log record is subject to the exact same
+// accept/sample decision as its trace.
+func LogsReceiver(
+	ctxInfo *global.ContextInfo,
+	cfg otelcfg.LogsConfig,
+	tracesCfg otelcfg.TracesConfig,
+	selectorCfg *attributes.SelectorConfig,
+	input *msg.Queue[[]request.Span],
+) swarm.InstanceFunc {
+	return func(_ context.Context) (swarm.RunFunc, error) {
+		if !cfg.Enabled() || !cfg.QueueProcessingLogs {
+			return swarm.EmptyRunFunc()
+		}
+		lr := makeLogsReceiver(cfg, tracesCfg, ctxInfo, selectorCfg, input)
+		return lr.provideLoop, nil
+	}
+}
+
+type logsOTELReceiver struct {
+	cfg            otelcfg.LogsConfig
+	tracesCfg      otelcfg.TracesConfig
+	ctxInfo        *global.ContextInfo
+	selectorCfg    *attributes.SelectorConfig
+	is             instrumentations.InstrumentationSelection
+	attributeCache *expirable2.LRU[svc.UID, []attribute.KeyValue]
+	input          <-chan []request.Span
+}
+
+func (lr *logsOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, error) {
+	return tracesgen.UserSelectedAttributes(lr.selectorCfg)
+}
+
+func (lr *logsOTELReceiver) processSpans(ctx context.Context, exp exporter.Logs, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler) {
+	spanGroups := tracesgen.GroupSpans(ctx, spans, traceAttrs, sampler, lr.is, lr.selectorCfg.SensitiveQueryParamsCfg.Effective()...)
+
+	for _, spanGroup := range spanGroups {
+		if len(spanGroup) == 0 {
+			continue
+		}
+		sample := spanGroup[0]
+		if !sample.Span.Service.ExportModes.CanExportLogs() {
+			continue
+		}
+
+		envResourceAttrs := otelcfg.ResourceAttrsFromEnv(&sample.Span.Service)
+		logs := logsgen.GenerateLogs(
+			lr.attributeCache,
+			&sample.Span.Service,
+			envResourceAttrs,
+			&lr.ctxInfo.NodeMeta,
+			spanGroup,
+			reporterName,
+		)
+		if logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().Len() == 0 {
+			continue
+		}
+		err := exp.ConsumeLogs(ctx, logs)
+		if err != nil {
+			if err.Error() == "sending queue is full" {
+				slog.Debug("error sending log record to consumer", "error", err)
+			} else {
+				slog.Warn("error sending log record to consumer", "error", err)
+			}
+		}
+	}
+}
+
+func (lr *logsOTELReceiver) provideLoop(ctx context.Context) {
+	exp, host, err := getLogsExporter(ctx, lr.cfg)
+	if err != nil {
+		slog.Error("error creating logs exporter", "error", err)
+		return
+	}
+	defer func() {
+		if err := exp.Shutdown(ctx); err != nil {
+			slog.Error("error shutting down logs exporter", "error", err)
+		}
+	}()
+	if err := exp.Start(ctx, host); err != nil {
+		slog.Error("error starting logs exporter", "error", err)
+		return
+	}
+
+	traceAttrs, err := lr.getConstantAttributes()
+	if err != nil {
+		slog.Error("error selecting user trace attributes", "error", err)
+		return
+	}
+
+	sampler := lr.tracesCfg.SamplerConfig.Implementation()
+	swarms.ForEachInput(ctx, lr.input, ologslog().Debug, func(spans []request.Span) {
+		lr.processSpans(ctx, exp, spans, traceAttrs, sampler)
+	})
+}
+
+// emptyHost, udsHost, udsMiddleware, createZapLoggerDev, and getTraceSettings
+// are defined in traces.go (same package) and reused here unchanged.
+
+//nolint:cyclop
+func getLogsExporter(ctx context.Context, cfg otelcfg.LogsConfig) (exporter.Logs, component.Host, error) {
+	if cfg.LogsConsumer != nil {
+		newType, err := component.NewType("logs")
+		if err != nil {
+			return nil, nil, err
+		}
+		set := getTraceSettings(newType, cfg.SDKLogLevel)
+		exp, err := exporterhelper.NewLogs(ctx, set, cfg,
+			cfg.LogsConsumer.ConsumeLogs,
+			exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		return exp, emptyHost{}, nil
+	}
+	switch proto := cfg.GetProtocol(); proto {
+	case otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf, "":
+		slog.Debug("instantiating HTTP LogsReporter", "protocol", proto)
+		opts, err := otelcfg.HTTPLogsEndpointOptions(&cfg)
+		if err != nil {
+			slog.Error("can't get HTTP logs endpoint options", "error", err)
+			return nil, nil, err
+		}
+		factory := otlphttpexporter.NewFactory()
+		config := factory.CreateDefaultConfig().(*otlphttpexporter.Config)
+		config.QueueConfig = getLogsQueueConfig(cfg)
+		config.RetryConfig = getLogsRetrySettings(cfg)
+		config.ClientConfig = confighttp.ClientConfig{
+			Endpoint: opts.Scheme + "://" + opts.Endpoint + opts.BaseURLPath,
+			TLS: configtls.ClientConfig{
+				Insecure:           opts.Insecure,
+				InsecureSkipVerify: cfg.InsecureSkipVerify,
+			},
+			Headers: convertHeaders(opts.Headers),
+		}
+		host := component.Host(emptyHost{})
+		if opts.UnixSocketAddr != "" {
+			mwID := component.MustNewID("obi_uds")
+			config.ClientConfig.Middlewares = []configmiddleware.Config{{ID: mwID}}
+			host = udsHost{extensions: map[component.ID]component.Component{
+				mwID: udsMiddleware{addr: opts.UnixSocketAddr},
+			}}
+		}
+		set := getTraceSettings(factory.Type(), cfg.SDKLogLevel)
+		exp, err := factory.CreateLogs(ctx, set, config)
+		if err != nil {
+			slog.Error("can't create OTLP HTTP logs exporter", "error", err)
+			return nil, nil, err
+		}
+		wrapped, err := exporterhelper.NewLogs(ctx, set, cfg,
+			exp.ConsumeLogs,
+			exporterhelper.WithStart(exp.Start),
+			exporterhelper.WithShutdown(exp.Shutdown),
+			exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+			exporterhelper.WithQueue(config.QueueConfig),
+			exporterhelper.WithRetry(config.RetryConfig))
+		return wrapped, host, err
+	case otelcfg.ProtocolGRPC:
+		slog.Debug("instantiating GRPC LogsReporter", "protocol", proto)
+		opts, err := otelcfg.GRPCLogsEndpointOptions(&cfg)
+		if err != nil {
+			slog.Error("can't get GRPC logs endpoint options", "error", err)
+			return nil, nil, err
+		}
+		grpcEndpoint := opts.Endpoint
+		if opts.UnixSocketAddr == "" {
+			endpoint, _, perr := otelcfg.ParseLogsEndpoint(&cfg)
+			if perr != nil {
+				slog.Error("can't parse GRPC logs endpoint", "error", perr)
+				return nil, nil, perr
+			}
+			grpcEndpoint = endpoint.String()
+		}
+		factory := otlpexporter.NewFactory()
+		config := factory.CreateDefaultConfig().(*otlpexporter.Config)
+		config.QueueConfig = getLogsQueueConfig(cfg)
+		config.RetryConfig = getLogsRetrySettings(cfg)
+		config.ClientConfig = configgrpc.ClientConfig{
+			Endpoint: grpcEndpoint,
+			TLS: configtls.ClientConfig{
+				Insecure:           opts.Insecure,
+				InsecureSkipVerify: cfg.InsecureSkipVerify,
+			},
+			Headers: convertHeaders(opts.Headers),
+		}
+		set := getTraceSettings(factory.Type(), cfg.SDKLogLevel)
+		exp, err := factory.CreateLogs(ctx, set, config)
+		if err != nil {
+			return nil, nil, err
+		}
+		return exp, emptyHost{}, nil
+	case otelcfg.ProtocolDebug:
+		slog.Debug("instantiating Debug LogsReporter", "protocol", proto)
+		factory := debugexporter.NewFactory()
+		config := factory.CreateDefaultConfig().(*debugexporter.Config)
+		config.UseInternalLogger = false
+		config.Verbosity = configtelemetry.LevelDetailed
+		set := getTraceSettings(factory.Type(), cfg.SDKLogLevel)
+		exp, err := factory.CreateLogs(ctx, set, config)
+		if err != nil {
+			return nil, nil, err
+		}
+		return exp, emptyHost{}, nil
+	default:
+		slog.Error(fmt.Sprintf("invalid protocol value: %q. Accepted values are: %s, %s, %s",
+			proto, otelcfg.ProtocolGRPC, otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf))
+		return nil, nil, fmt.Errorf("invalid protocol value: %q", proto)
+	}
+}
+
+func getLogsQueueConfig(cfg otelcfg.LogsConfig) configoptional.Optional[exporterhelper.QueueBatchConfig] {
+	if cfg.BatchMaxSize <= 0 && cfg.BatchTimeout <= 0 && cfg.QueueSize <= 0 {
+		return configoptional.None[exporterhelper.QueueBatchConfig]()
+	}
+
+	queueConfig := exporterhelper.NewDefaultQueueConfig()
+	queueConfig.Sizer = exporterhelper.RequestSizerTypeItems
+	queueConfig.BlockOnOverflow = true
+	if cfg.QueueSize > 0 {
+		queueConfig.QueueSize = int64(cfg.QueueSize)
+	}
+	batchCfg := exporterhelper.BatchConfig{
+		Sizer: queueConfig.Sizer,
+	}
+	batchSet := false
+	if cfg.BatchMaxSize > 0 {
+		batchSet = true
+		batchCfg.MaxSize = int64(cfg.BatchMaxSize)
+	}
+	if cfg.BatchTimeout > 0 {
+		batchSet = true
+		batchCfg.FlushTimeout = cfg.BatchTimeout
+		batchCfg.MinSize = int64(cfg.BatchMaxSize)
+	}
+	if batchSet {
+		queueConfig.Batch = configoptional.Some(batchCfg)
+	}
+	return configoptional.Some(queueConfig)
+}
+
+func getLogsRetrySettings(cfg otelcfg.LogsConfig) configretry.BackOffConfig {
+	backOffCfg := configretry.NewDefaultBackOffConfig()
+	if cfg.BackOffInitialInterval > 0 {
+		backOffCfg.InitialInterval = cfg.BackOffInitialInterval
+	}
+	if cfg.BackOffMaxInterval > 0 {
+		backOffCfg.MaxInterval = cfg.BackOffMaxInterval
+	}
+	if cfg.BackOffMaxElapsedTime > 0 {
+		backOffCfg.MaxElapsedTime = cfg.BackOffMaxElapsedTime
+	}
+	return backOffCfg
+}

--- a/pkg/export/otel/logs.go
+++ b/pkg/export/otel/logs.go
@@ -119,6 +119,8 @@ func (lr *logsOTELReceiver) processSpans(ctx context.Context, exp exporter.Logs,
 			&lr.ctxInfo.NodeMeta,
 			spanGroup,
 			reporterName,
+			lr.selectorCfg.SelectionCfg,
+			lr.ctxInfo.ExtraResourceAttributes...,
 		)
 		if logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().Len() == 0 {
 			continue

--- a/pkg/export/otel/logs_test.go
+++ b/pkg/export/otel/logs_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
@@ -20,6 +22,52 @@ import (
 
 func TestGetLogsExporter_Debug(t *testing.T) {
 	cfg := otelcfg.LogsConfig{LogsProtocol: otelcfg.ProtocolDebug}
+	exp, host, err := getLogsExporter(t.Context(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+	require.NotNil(t, host)
+
+	require.NoError(t, exp.Start(context.Background(), host))
+	defer func() { assert.NoError(t, exp.Shutdown(context.Background())) }()
+}
+
+// TestBuildHTTPLogsExporterConfig_SingleBufferingLayer is a regression test for the
+// HTTP logs exporter double-buffering bug: buildHTTPLogsExporterConfig must disable the
+// inner otlphttpexporter's own queue/retry, and hand back the real queue/retry settings
+// separately for the caller to apply exactly once via the outer exporterhelper.NewLogs
+// wrap — matching getTracesExporter's HTTP branch.
+func TestBuildHTTPLogsExporterConfig_SingleBufferingLayer(t *testing.T) {
+	cfg := otelcfg.LogsConfig{
+		LogsEndpoint:           "http://localhost:4318",
+		QueueSize:              7,
+		BatchMaxSize:           10,
+		BackOffInitialInterval: 2 * time.Second,
+	}
+
+	factory := otlphttpexporter.NewFactory()
+	config, host, queueCfg, retryCfg, err := buildHTTPLogsExporterConfig(cfg, factory)
+	require.NoError(t, err)
+	require.NotNil(t, host)
+
+	assert.False(t, config.QueueConfig.HasValue(), "the inner otlphttpexporter must not buffer on its own")
+	assert.False(t, config.RetryConfig.Enabled, "the inner otlphttpexporter must not retry on its own")
+
+	require.True(t, queueCfg.HasValue(), "the outer wrap must receive the real queue settings")
+	assert.EqualValues(t, 7, queueCfg.Get().QueueSize)
+
+	assert.True(t, retryCfg.Enabled, "the outer wrap must receive the real, enabled retry settings")
+	assert.Equal(t, 2*time.Second, retryCfg.InitialInterval)
+}
+
+// TestGetLogsExporter_HTTP exercises getLogsExporter's HTTP branch end to end with a
+// real queue/batch/retry configuration, which previously had no test coverage at all.
+func TestGetLogsExporter_HTTP(t *testing.T) {
+	cfg := otelcfg.LogsConfig{
+		LogsEndpoint:           "http://localhost:4318",
+		QueueSize:              5,
+		BatchMaxSize:           5,
+		BackOffInitialInterval: time.Second,
+	}
 	exp, host, err := getLogsExporter(t.Context(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, exp)

--- a/pkg/export/otel/logs_test.go
+++ b/pkg/export/otel/logs_test.go
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/pipe/global"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+)
+
+func TestGetLogsExporter_Debug(t *testing.T) {
+	cfg := otelcfg.LogsConfig{LogsProtocol: otelcfg.ProtocolDebug}
+	exp, host, err := getLogsExporter(t.Context(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+	require.NotNil(t, host)
+
+	require.NoError(t, exp.Start(context.Background(), host))
+	defer func() { assert.NoError(t, exp.Shutdown(context.Background())) }()
+}
+
+func TestGetLogsExporter_InvalidProtocol(t *testing.T) {
+	cfg := otelcfg.LogsConfig{LogsEndpoint: "http://localhost:4318", LogsProtocol: otelcfg.Protocol("bogus")}
+	_, _, err := getLogsExporter(t.Context(), cfg)
+	require.Error(t, err)
+}
+
+// TestLogsReceiver_QueueProcessingLogsDisabled is a regression test for the
+// LogsReceiver enable-gate: a user with a common OTEL_EXPORTER_OTLP_ENDPOINT
+// set (so cfg.Enabled() is true) but the queue_processing_logs toggle left
+// off (QueueProcessingLogs is false) must not get a running logs receiver —
+// mirroring Config.QueueProcessingAsLogsEnabled(), which checks both halves
+// of the gate together.
+func TestLogsReceiver_QueueProcessingLogsDisabled(t *testing.T) {
+	cfg := otelcfg.LogsConfig{LogsEndpoint: "http://localhost:4318"}
+	require.True(t, cfg.Enabled(), "test setup: endpoint must make Enabled() true")
+	require.False(t, cfg.QueueProcessingLogs, "test setup: toggle must be left off")
+
+	input := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(1))
+	instanceFn := LogsReceiver(&global.ContextInfo{}, cfg, otelcfg.TracesConfig{}, &attributes.SelectorConfig{}, input)
+
+	runFunc, err := instanceFn(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, runFunc)
+
+	// A real provideLoop would block reading from the (unclosed, empty)
+	// subscribed input channel. The expected no-op RunFunc (from
+	// swarm.EmptyRunFunc) returns immediately regardless of context.
+	done := make(chan struct{})
+	go func() {
+		runFunc(t.Context())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// OK: no-op RunFunc, as expected when the toggle is off.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("LogsReceiver started a live receiver even though QueueProcessingLogs was disabled")
+	}
+}

--- a/pkg/export/otel/logsgen/logsgen.go
+++ b/pkg/export/otel/logsgen/logsgen.go
@@ -1,0 +1,72 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package logsgen // import "go.opentelemetry.io/obi/pkg/export/otel/logsgen"
+
+import (
+	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/appolly/meta"
+	"go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
+)
+
+// EventNameQueueProcessing is the fixed EventName used on every log record
+// this package emits.
+const EventNameQueueProcessing = "request.queue_processing"
+
+// GenerateLogs builds a plog.Logs payload containing, for each span in spans
+// that had an observable queue gap (RequestStart < Start), a single combined
+// log record describing queue and processing duration in seconds,
+// correlated to the parent trace span via trace_id/span_id.
+//
+// Spans without an observable gap produce no log record — the resulting
+// plog.Logs may have zero LogRecords; callers should check for that before
+// sending an otherwise-empty batch.
+func GenerateLogs(
+	cache *expirable2.LRU[svc.UID, []attribute.KeyValue],
+	svcAttrs *svc.Attrs,
+	envResourceAttrs []attribute.KeyValue,
+	nodeMeta *meta.NodeMeta,
+	spans []tracesgen.TraceSpanAndAttributes,
+	reporterName string,
+) plog.Logs {
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+
+	resourceAttrs := tracesgen.TraceAppResourceAttrs(cache, nodeMeta, svcAttrs)
+	resourceAttrs = append(resourceAttrs, envResourceAttrs...)
+	resourceAttrsMap := tracesgen.AttrsToMap(resourceAttrs)
+	resourceAttrsMap.PutStr(string(semconv.OTelScopeNameKey), reporterName)
+	resourceAttrsMap.MoveTo(rl.Resource().Attributes())
+
+	sl := rl.ScopeLogs().AppendEmpty()
+
+	for _, spanWithAttributes := range spans {
+		span := spanWithAttributes.Span
+		t := span.Timings()
+		start := tracesgen.SpanStartTime(t)
+		if !t.Start.After(start) || !span.SpanID.IsValid() {
+			continue // no observable queue gap, or no valid SpanID to correlate against
+		}
+
+		lr := sl.LogRecords().AppendEmpty()
+		lr.SetTimestamp(pcommon.NewTimestampFromTime(t.End))
+		lr.SetTraceID(pcommon.TraceID(span.TraceID))
+		lr.SetSpanID(pcommon.SpanID(span.SpanID))
+		lr.SetEventName(EventNameQueueProcessing)
+		lr.SetSeverityNumber(plog.SeverityNumberInfo)
+		lr.SetSeverityText("INFO")
+
+		attrs := lr.Attributes()
+		attrs.PutDouble("queue.duration", t.Start.Sub(t.RequestStart).Seconds())
+		attrs.PutDouble("processing.duration", t.End.Sub(t.Start).Seconds())
+	}
+
+	return logs
+}

--- a/pkg/export/otel/logsgen/logsgen.go
+++ b/pkg/export/otel/logsgen/logsgen.go
@@ -46,10 +46,10 @@ func GenerateLogs(
 	resourceAttrs := tracesgen.TraceAppResourceAttrs(cache, nodeMeta, svcAttrs)
 	resourceAttrs = append(resourceAttrs, envResourceAttrs...)
 	resourceAttrs = otelcfg.FilterResourceAttrs(resourceAttrs, attrSelector)
-	extraResAttrs = otelcfg.FilterResourceAttrs(extraResAttrs, attrSelector)
-	resourceAttrs = append(resourceAttrs, extraResAttrs...)
 	resourceAttrsMap := tracesgen.AttrsToMap(resourceAttrs)
 	resourceAttrsMap.PutStr(string(semconv.OTelScopeNameKey), reporterName)
+	extraResAttrs = otelcfg.FilterResourceAttrs(extraResAttrs, attrSelector)
+	tracesgen.AddAttrsToMap(extraResAttrs, resourceAttrsMap)
 	resourceAttrsMap.MoveTo(rl.Resource().Attributes())
 
 	sl := rl.ScopeLogs().AppendEmpty()

--- a/pkg/export/otel/logsgen/logsgen.go
+++ b/pkg/export/otel/logsgen/logsgen.go
@@ -13,6 +13,8 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
 )
 
@@ -35,12 +37,17 @@ func GenerateLogs(
 	nodeMeta *meta.NodeMeta,
 	spans []tracesgen.TraceSpanAndAttributes,
 	reporterName string,
+	attrSelector attributes.Selection,
+	extraResAttrs ...attribute.KeyValue,
 ) plog.Logs {
 	logs := plog.NewLogs()
 	rl := logs.ResourceLogs().AppendEmpty()
 
 	resourceAttrs := tracesgen.TraceAppResourceAttrs(cache, nodeMeta, svcAttrs)
 	resourceAttrs = append(resourceAttrs, envResourceAttrs...)
+	resourceAttrs = otelcfg.FilterResourceAttrs(resourceAttrs, attrSelector)
+	extraResAttrs = otelcfg.FilterResourceAttrs(extraResAttrs, attrSelector)
+	resourceAttrs = append(resourceAttrs, extraResAttrs...)
 	resourceAttrsMap := tracesgen.AttrsToMap(resourceAttrs)
 	resourceAttrsMap.PutStr(string(semconv.OTelScopeNameKey), reporterName)
 	resourceAttrsMap.MoveTo(rl.Resource().Attributes())

--- a/pkg/export/otel/logsgen/logsgen_test.go
+++ b/pkg/export/otel/logsgen/logsgen_test.go
@@ -145,3 +145,28 @@ func TestGenerateLogs_ResourceAttrsFiltering(t *testing.T) {
 	require.True(t, ok, "embedding-supplied extra resource attributes must be present")
 	assert.Equal(t, "value", v.AsString())
 }
+
+// TestGenerateLogs_ExtraResAttrsOverrideScopeName locks in the write order shared with
+// generateTracesWithAttributes: extraResAttrs is written to the resource map last, so on
+// key collision it wins over both the base resource attrs and the otel.scope.name entry.
+func TestGenerateLogs_ExtraResAttrsOverrideScopeName(t *testing.T) {
+	start := time.Now()
+	traceID, _ := trace.TraceIDFromHex("eae56fbbec9505c102e8aabfc6b5c481")
+	spanID, _ := trace.SpanIDFromHex("89cbc1f60aab3b01")
+	span := &request.Span{
+		Type:         request.EventTypeHTTP,
+		RequestStart: start.UnixNano(),
+		Start:        start.Add(time.Second).UnixNano(),
+		End:          start.Add(3 * time.Second).UnixNano(),
+		TraceID:      traceID,
+		SpanID:       spanID,
+	}
+
+	overrideAttr := attribute.String("otel.scope.name", "embedder-override")
+
+	logs := logsgen.GenerateLogs(cache, &span.Service, nil, hostID, group(span), "go.opentelemetry.io/obi", nil, overrideAttr)
+
+	v, ok := logs.ResourceLogs().At(0).Resource().Attributes().Get("otel.scope.name")
+	require.True(t, ok)
+	assert.Equal(t, "embedder-override", v.AsString(), "extraResAttrs must be able to override the reporter-supplied scope name, same as generateTracesWithAttributes")
+}

--- a/pkg/export/otel/logsgen/logsgen_test.go
+++ b/pkg/export/otel/logsgen/logsgen_test.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/otel/logsgen"
 	"go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
 )
@@ -43,7 +44,7 @@ func TestGenerateLogs_ObservableGap(t *testing.T) {
 		SpanID:       spanID,
 	}
 
-	logs := logsgen.GenerateLogs(cache, &span.Service, nil, hostID, group(span), "go.opentelemetry.io/obi")
+	logs := logsgen.GenerateLogs(cache, &span.Service, nil, hostID, group(span), "go.opentelemetry.io/obi", nil)
 
 	require.Equal(t, 1, logs.ResourceLogs().Len())
 	require.Equal(t, 1, logs.ResourceLogs().At(0).ScopeLogs().Len())
@@ -75,7 +76,7 @@ func TestGenerateLogs_NoObservableGap(t *testing.T) {
 		TraceID:      traceID,
 	}
 
-	logs := logsgen.GenerateLogs(cache, &span.Service, nil, hostID, group(span), "go.opentelemetry.io/obi")
+	logs := logsgen.GenerateLogs(cache, &span.Service, nil, hostID, group(span), "go.opentelemetry.io/obi", nil)
 
 	records := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
 	assert.Equal(t, 0, records.Len(), "no log record should be emitted when there's no observable queue gap")
@@ -99,8 +100,48 @@ func TestGenerateLogs_ObservableGapButInvalidSpanID(t *testing.T) {
 	}
 	require.False(t, span.SpanID.IsValid())
 
-	logs := logsgen.GenerateLogs(cache, &span.Service, nil, hostID, group(span), "go.opentelemetry.io/obi")
+	logs := logsgen.GenerateLogs(cache, &span.Service, nil, hostID, group(span), "go.opentelemetry.io/obi", nil)
 
 	records := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
 	assert.Equal(t, 0, records.Len(), "no log record should be emitted when the span has no valid SpanID to correlate against")
+}
+
+// TestGenerateLogs_ResourceAttrsFiltering verifies GenerateLogs applies the same
+// resource-attribute selection and embedding-supplied extra resource attributes as
+// the trace pipeline's generateTracesWithAttributes, so a log record's resource is
+// not a superset (excluded attrs leaking through) or subset (missing embedder attrs)
+// of what the correlated trace's resource carries.
+func TestGenerateLogs_ResourceAttrsFiltering(t *testing.T) {
+	start := time.Now()
+	traceID, _ := trace.TraceIDFromHex("eae56fbbec9505c102e8aabfc6b5c481")
+	spanID, _ := trace.SpanIDFromHex("89cbc1f60aab3b01")
+	span := &request.Span{
+		Type:         request.EventTypeHTTP,
+		RequestStart: start.UnixNano(),
+		Start:        start.Add(time.Second).UnixNano(),
+		End:          start.Add(3 * time.Second).UnixNano(),
+		TraceID:      traceID,
+		SpanID:       spanID,
+	}
+
+	attrSelector := attributes.Selection{
+		attributes.Resource.Section: attributes.InclusionLists{
+			Exclude: []string{"host.name"},
+		},
+	}
+	extraAttr := attribute.String("embedder.custom", "value")
+
+	logs := logsgen.GenerateLogs(cache, &span.Service, nil, hostID, group(span), "go.opentelemetry.io/obi", attrSelector, extraAttr)
+
+	resAttrs := logs.ResourceLogs().At(0).Resource().Attributes()
+
+	_, ok := resAttrs.Get("host.name")
+	assert.False(t, ok, "resource attribute excluded via attributes.select must not be present on the log record's resource")
+
+	_, ok = resAttrs.Get("host.id")
+	assert.True(t, ok, "non-excluded resource attributes must still be present")
+
+	v, ok := resAttrs.Get("embedder.custom")
+	require.True(t, ok, "embedding-supplied extra resource attributes must be present")
+	assert.Equal(t, "value", v.AsString())
 }

--- a/pkg/export/otel/logsgen/logsgen_test.go
+++ b/pkg/export/otel/logsgen/logsgen_test.go
@@ -1,0 +1,106 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package logsgen_test
+
+import (
+	"testing"
+	"time"
+
+	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/appolly/meta"
+	"go.opentelemetry.io/obi/pkg/export/otel/logsgen"
+	"go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
+)
+
+var (
+	cache  = expirable2.NewLRU[svc.UID, []attribute.KeyValue](1024, nil, 5*time.Minute)
+	hostID = &meta.NodeMeta{HostID: "host-id"}
+)
+
+func group(span *request.Span) []tracesgen.TraceSpanAndAttributes {
+	return []tracesgen.TraceSpanAndAttributes{{Span: span, Attributes: nil}}
+}
+
+func TestGenerateLogs_ObservableGap(t *testing.T) {
+	start := time.Now()
+	traceID, _ := trace.TraceIDFromHex("eae56fbbec9505c102e8aabfc6b5c481")
+	spanID, _ := trace.SpanIDFromHex("89cbc1f60aab3b01")
+	span := &request.Span{
+		Type:         request.EventTypeHTTP,
+		RequestStart: start.UnixNano(),
+		Start:        start.Add(time.Second).UnixNano(),
+		End:          start.Add(3 * time.Second).UnixNano(),
+		TraceID:      traceID,
+		SpanID:       spanID,
+	}
+
+	logs := logsgen.GenerateLogs(cache, &span.Service, nil, hostID, group(span), "go.opentelemetry.io/obi")
+
+	require.Equal(t, 1, logs.ResourceLogs().Len())
+	require.Equal(t, 1, logs.ResourceLogs().At(0).ScopeLogs().Len())
+	records := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	require.Equal(t, 1, records.Len())
+
+	lr := records.At(0)
+	assert.Equal(t, "request.queue_processing", lr.EventName())
+	assert.Equal(t, traceID.String(), lr.TraceID().String())
+	assert.Equal(t, spanID.String(), lr.SpanID().String())
+
+	queueDuration, ok := lr.Attributes().Get("queue.duration")
+	require.True(t, ok)
+	assert.InDelta(t, 1.0, queueDuration.Double(), 0.01)
+
+	processingDuration, ok := lr.Attributes().Get("processing.duration")
+	require.True(t, ok)
+	assert.InDelta(t, 2.0, processingDuration.Double(), 0.01)
+}
+
+func TestGenerateLogs_NoObservableGap(t *testing.T) {
+	start := time.Now()
+	traceID, _ := trace.TraceIDFromHex("eae56fbbec9505c102e8aabfc6b5c481")
+	span := &request.Span{
+		Type:         request.EventTypeHTTP,
+		RequestStart: start.UnixNano(),
+		Start:        start.UnixNano(), // no gap
+		End:          start.Add(time.Second).UnixNano(),
+		TraceID:      traceID,
+	}
+
+	logs := logsgen.GenerateLogs(cache, &span.Service, nil, hostID, group(span), "go.opentelemetry.io/obi")
+
+	records := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	assert.Equal(t, 0, records.Len(), "no log record should be emitted when there's no observable queue gap")
+}
+
+func TestGenerateLogs_ObservableGapButInvalidSpanID(t *testing.T) {
+	// span.SpanID is invalid (e.g. eBPF failed to assign one). tracesgen.go's
+	// suppressed-span path would generate a fresh random SpanID for the
+	// parent in this case, so reusing span.SpanID verbatim here would
+	// correlate the log record with the wrong (mismatched) span_id.
+	// Instead, no log record should be emitted at all.
+	start := time.Now()
+	traceID, _ := trace.TraceIDFromHex("eae56fbbec9505c102e8aabfc6b5c481")
+	span := &request.Span{
+		Type:         request.EventTypeHTTP,
+		RequestStart: start.UnixNano(),
+		Start:        start.Add(time.Second).UnixNano(), // observable gap
+		End:          start.Add(3 * time.Second).UnixNano(),
+		TraceID:      traceID,
+		// SpanID intentionally left as the zero value (invalid)
+	}
+	require.False(t, span.SpanID.IsValid())
+
+	logs := logsgen.GenerateLogs(cache, &span.Service, nil, hostID, group(span), "go.opentelemetry.io/obi")
+
+	records := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords()
+	assert.Equal(t, 0, records.Len(), "no log record should be emitted when the span has no valid SpanID to correlate against")
+}

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -51,10 +51,12 @@ const (
 const (
 	envTracesProtocol  = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
 	envMetricsProtocol = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
+	envLogsProtocol    = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"
 	envProtocol        = "OTEL_EXPORTER_OTLP_PROTOCOL"
 	envHeaders         = "OTEL_EXPORTER_OTLP_HEADERS"
 	envTracesHeaders   = "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
 	envMetricsHeaders  = "OTEL_EXPORTER_OTLP_METRICS_HEADERS"
+	envLogsHeaders     = "OTEL_EXPORTER_OTLP_LOGS_HEADERS"
 	envResourceAttrs   = "OTEL_RESOURCE_ATTRIBUTES"
 )
 

--- a/pkg/export/otel/otelcfg/config_logs.go
+++ b/pkg/export/otel/otelcfg/config_logs.go
@@ -1,0 +1,292 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg // import "go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
+import (
+	"fmt"
+	"log/slog"
+	"maps"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/collector/consumer"
+)
+
+func llog() *slog.Logger {
+	return slog.With("component", "otelcfg.LogsConfig")
+}
+
+type LogsConfig struct {
+	LogsConsumer   consumer.Logs `yaml:"-"`
+	CommonEndpoint string        `yaml:"-" env:"OTEL_EXPORTER_OTLP_ENDPOINT" jsonschema:"format=uri"`
+	LogsEndpoint   string        `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT" jsonschema:"format=uri"`
+
+	Protocol     Protocol `yaml:"protocol" env:"OTEL_EXPORTER_OTLP_PROTOCOL"`
+	LogsProtocol Protocol `yaml:"-" env:"OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"`
+
+	// InsecureSkipVerify enables skipping TLS certificate verification (not standard, so we don't follow the same naming convention)
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"OTEL_EBPF_INSECURE_SKIP_VERIFY"`
+
+	// QueueProcessingLogs replaces the "in queue"/"processing" sub-spans in the
+	// traces pipeline with a single combined log record per request (only
+	// emitted when there was an observable queue gap), correlated to the
+	// parent span via the log record's trace_id/span_id. Takes effect only
+	// when the logs exporter is also enabled — see Config.QueueProcessingAsLogsEnabled.
+	QueueProcessingLogs bool `yaml:"queue_processing_logs" env:"OTEL_EBPF_QUEUE_PROCESSING_LOGS"`
+
+	// BatchMaxSize is the maximum number of log records that the batcher will accumulate
+	// before flushing a batch to the sending queue.
+	BatchMaxSize int `yaml:"batch_max_size" env:"OTEL_EBPF_OTLP_LOGS_BATCH_MAX_SIZE" validate:"omitempty,gt=0"`
+
+	// QueueSize is the maximum number of log records that the sending queue will hold
+	// before applying back-pressure. It must be >= `2 * BatchMaxSize`, otherwise the
+	// memory queue rejects every batch with "element size too large" and drops
+	// log records permanently. If left at 0 it defaults to `4 * BatchMaxSize`.
+	QueueSize int `yaml:"queue_size" env:"OTEL_EBPF_OTLP_LOGS_QUEUE_SIZE"`
+
+	// BatchTimeout is the time after which a batch will be sent regardless of its size.
+	BatchTimeout time.Duration `yaml:"batch_timeout" env:"OTEL_EBPF_OTLP_LOGS_BATCH_TIMEOUT"`
+
+	// Configuration options for BackOffConfig of the logs exporter.
+	// See https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configretry/backoff.go
+	// Namespaced per-signal (unlike TracesConfig's generically-named
+	// equivalents) since this is a new signal and there's no existing
+	// precedent of these being intentionally shared across signals.
+	BackOffInitialInterval time.Duration `yaml:"backoff_initial_interval" env:"OTEL_EBPF_LOGS_BACKOFF_INITIAL_INTERVAL" validate:"omitempty,gt=0"`
+	BackOffMaxInterval     time.Duration `yaml:"backoff_max_interval" env:"OTEL_EBPF_LOGS_BACKOFF_MAX_INTERVAL" validate:"omitempty,gt=0"`
+	BackOffMaxElapsedTime  time.Duration `yaml:"backoff_max_elapsed_time" env:"OTEL_EBPF_LOGS_BACKOFF_MAX_ELAPSED_TIME" validate:"omitempty,gt=0"`
+	ReportersCacheLen      int           `yaml:"reporters_cache_len" env:"OTEL_EBPF_LOGS_REPORT_CACHE_LEN" validate:"omitempty,gt=0"`
+
+	// SDKLogLevel is intentionally the SAME env var as TracesConfig/MetricsConfig's
+	// field of the same name — this is an existing shared, not per-signal, knob.
+	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL" validate:"omitempty,oneofci=debug info warn error"`
+
+	// OTLPEndpointProvider allows overriding the OTLP Endpoint. It needs to return an endpoint and
+	// a boolean indicating if the endpoint is common for both traces and metrics
+	OTLPEndpointProvider func() (string, bool) `yaml:"-" env:"-"`
+
+	// InjectHeaders allows injecting custom headers to the HTTP OTLP exporter
+	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
+}
+
+func (m *LogsConfig) NormalizeQueueConfig() error {
+	if m.QueueSize == 0 && m.BatchMaxSize > 0 {
+		m.QueueSize = 4 * m.BatchMaxSize
+		llog().Info("logs.queue_size not set, defaulting to 4 * batch_max_size",
+			"queue_size", m.QueueSize, "batch_max_size", m.BatchMaxSize)
+	}
+	if m.BatchMaxSize > 0 && m.QueueSize < 2*m.BatchMaxSize {
+		return fmt.Errorf("logs.queue_size (%d) must be >= 2 * logs.batch_max_size (%d): "+
+			"otherwise the sending queue rejects every batch with \"element size too large\"",
+			m.QueueSize, m.BatchMaxSize)
+	}
+	return nil
+}
+
+func (m LogsConfig) MarshalYAML() (any, error) {
+	omit := map[string]struct{}{
+		"endpoint": {},
+	}
+	return omitFieldsForYAML(m, omit), nil
+}
+
+// Enabled specifies that the OTEL logs node is enabled if and only if
+// either the OTEL endpoint and OTEL logs endpoint is defined.
+// If not enabled, this node won't be instantiated
+func (m *LogsConfig) Enabled() bool {
+	if m.LogsConsumer != nil {
+		return true
+	}
+
+	if m.LogsProtocol == ProtocolDebug || (m.LogsProtocol == "" && m.Protocol == ProtocolDebug) {
+		return true
+	}
+
+	ep, _ := m.OTLPLogsEndpoint()
+	return ep != ""
+}
+
+func (m *LogsConfig) GetProtocol() Protocol {
+	if m.LogsConsumer != nil {
+		return ProtocolUnset
+	}
+	if m.LogsProtocol != "" {
+		return m.LogsProtocol
+	}
+	if m.Protocol != "" {
+		return m.Protocol
+	}
+	return m.guessProtocol()
+}
+
+func (m *LogsConfig) OTLPLogsEndpoint() (string, bool) {
+	if m.OTLPEndpointProvider != nil {
+		return m.OTLPEndpointProvider()
+	}
+	return ResolveOTLPEndpoint(m.LogsEndpoint, m.CommonEndpoint)
+}
+
+func (m *LogsConfig) guessProtocol() Protocol {
+	ep, _, err := ParseLogsEndpoint(m)
+	if err == nil {
+		if strings.HasSuffix(ep.Port(), UsualPortGRPC) {
+			return ProtocolGRPC
+		} else if strings.HasSuffix(ep.Port(), UsualPortHTTP) {
+			return ProtocolHTTPProtobuf
+		}
+	}
+	return ProtocolHTTPProtobuf
+}
+
+// ParseLogsEndpoint defines the HTTP path of the logs collector.
+func ParseLogsEndpoint(cfg *LogsConfig) (*url.URL, bool, error) {
+	endpoint, isCommon := cfg.OTLPLogsEndpoint()
+
+	murl, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, isCommon, fmt.Errorf("parsing endpoint URL %s: %w", endpoint, err)
+	}
+	if murl.Scheme == "" || murl.Host == "" {
+		return nil, isCommon, fmt.Errorf("URL %q must have a scheme and a host", endpoint)
+	}
+	return murl, isCommon, nil
+}
+
+func unixLogsHTTPOptions(cfg *LogsConfig, addr string) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	if err := validateUnixSocketAddr(addr); err != nil {
+		return opts, err
+	}
+
+	setLogsProtocol(cfg)
+	opts.UnixSocketAddr = addr
+	opts.Scheme = "http"
+	opts.Endpoint = "localhost"
+	opts.Insecure = true
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envLogsHeaders))
+
+	return opts, nil
+}
+
+func unixLogsGRPCOptions(cfg *LogsConfig, addr string) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	if err := validateUnixSocketAddr(addr); err != nil {
+		return opts, err
+	}
+
+	opts.UnixSocketAddr = addr
+	opts.Endpoint = grpcUnixTarget(addr)
+	opts.Insecure = true
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envLogsHeaders))
+
+	return opts, nil
+}
+
+func HTTPLogsEndpointOptions(cfg *LogsConfig) (OTLPOptions, error) {
+	rawEndpoint, _ := cfg.OTLPLogsEndpoint()
+	if addr, ok := unixSocketEndpoint(rawEndpoint); ok {
+		return unixLogsHTTPOptions(cfg, addr)
+	}
+
+	opts := OTLPOptions{Headers: map[string]string{}}
+	log := llog().With("transport", "http")
+
+	murl, isCommon, err := ParseLogsEndpoint(cfg)
+	if err != nil {
+		return opts, err
+	}
+
+	log.Debug("Configuring exporter", "protocol",
+		cfg.Protocol, "logsProtocol", cfg.LogsProtocol, "endpoint", murl.Host)
+	setLogsProtocol(cfg)
+	opts.Scheme = murl.Scheme
+	opts.Endpoint = murl.Host
+	if murl.Scheme == "http" {
+		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
+		opts.Insecure = true
+	}
+	opts.URLPath = strings.TrimSuffix(murl.Path, "/")
+	opts.BaseURLPath = strings.TrimSuffix(opts.URLPath, "/v1/logs")
+	if isCommon {
+		opts.URLPath += "/v1/logs"
+		log.Debug("Specifying path", "path", opts.URLPath)
+	}
+
+	if cfg.InsecureSkipVerify {
+		log.Debug("Setting InsecureSkipVerify")
+		opts.SkipTLSVerify = true
+	}
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envLogsHeaders))
+
+	return opts, nil
+}
+
+func GRPCLogsEndpointOptions(cfg *LogsConfig) (OTLPOptions, error) {
+	rawEndpoint, _ := cfg.OTLPLogsEndpoint()
+	if addr, ok := unixSocketEndpoint(rawEndpoint); ok {
+		return unixLogsGRPCOptions(cfg, addr)
+	}
+
+	opts := OTLPOptions{Headers: map[string]string{}}
+	log := llog().With("transport", "grpc")
+	murl, _, err := ParseLogsEndpoint(cfg)
+	if err != nil {
+		return opts, err
+	}
+
+	log.Debug("Configuring exporter", "protocol",
+		cfg.Protocol, "logsProtocol", cfg.LogsProtocol, "endpoint", murl.Host)
+	opts.Endpoint = murl.Host
+	if murl.Scheme == "http" {
+		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
+		opts.Insecure = true
+	}
+
+	if cfg.InsecureSkipVerify {
+		log.Debug("Setting InsecureSkipVerify")
+		opts.SkipTLSVerify = true
+	}
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envLogsHeaders))
+	return opts, nil
+}
+
+func setLogsProtocol(cfg *LogsConfig) {
+	if _, ok := os.LookupEnv(envLogsProtocol); ok {
+		return
+	}
+	if _, ok := os.LookupEnv(envProtocol); ok {
+		return
+	}
+	if cfg.LogsProtocol != "" {
+		os.Setenv(envLogsProtocol, string(cfg.LogsProtocol))
+		return
+	}
+	if cfg.Protocol != "" {
+		os.Setenv(envProtocol, string(cfg.Protocol))
+		return
+	}
+	os.Setenv(envLogsProtocol, string(cfg.guessProtocol()))
+}

--- a/pkg/export/otel/otelcfg/config_logs_test.go
+++ b/pkg/export/otel/otelcfg/config_logs_test.go
@@ -1,0 +1,84 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestLogsConfig_Enabled(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		cfg := LogsConfig{}
+		assert.False(t, cfg.Enabled())
+	})
+
+	t.Run("enabled with an endpoint", func(t *testing.T) {
+		cfg := LogsConfig{LogsEndpoint: "http://localhost:4318"}
+		assert.True(t, cfg.Enabled())
+	})
+
+	t.Run("enabled via debug protocol", func(t *testing.T) {
+		cfg := LogsConfig{LogsProtocol: ProtocolDebug}
+		assert.True(t, cfg.Enabled())
+	})
+
+	t.Run("enabled via injected consumer", func(t *testing.T) {
+		cfg := LogsConfig{LogsConsumer: fakeLogsConsumer{}}
+		assert.True(t, cfg.Enabled())
+	})
+}
+
+func TestHTTPLogsEndpoint(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	cfg := LogsConfig{
+		CommonEndpoint: "https://localhost:3131",
+		LogsEndpoint:   "https://localhost:3232/v1/logs",
+	}
+	opts, err := HTTPLogsEndpointOptions(&cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "https", opts.Scheme)
+	assert.Equal(t, "localhost:3232", opts.Endpoint)
+	assert.Equal(t, "/v1/logs", opts.URLPath)
+}
+
+func TestHTTPLogsEndpoint_CommonOnly(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	cfg := LogsConfig{
+		CommonEndpoint: "https://localhost:3131/otlp",
+	}
+	opts, err := HTTPLogsEndpointOptions(&cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "https", opts.Scheme)
+	assert.Equal(t, "localhost:3131", opts.Endpoint)
+	assert.Equal(t, "/otlp", opts.BaseURLPath)
+	assert.Equal(t, "/otlp/v1/logs", opts.URLPath)
+}
+
+func TestLogsConfig_NormalizeQueueConfig(t *testing.T) {
+	t.Run("defaults queue size to 4x batch size", func(t *testing.T) {
+		cfg := LogsConfig{BatchMaxSize: 100}
+		require.NoError(t, cfg.NormalizeQueueConfig())
+		assert.Equal(t, 400, cfg.QueueSize)
+	})
+
+	t.Run("rejects queue size smaller than 2x batch size", func(t *testing.T) {
+		cfg := LogsConfig{BatchMaxSize: 100, QueueSize: 50}
+		require.Error(t, cfg.NormalizeQueueConfig())
+	})
+}
+
+type fakeLogsConsumer struct{}
+
+func (fakeLogsConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (fakeLogsConsumer) ConsumeLogs(_ context.Context, _ plog.Logs) error { return nil }

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -132,6 +132,11 @@ func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Tra
 			if tr.spanMetricsEnabled {
 				envResourceAttrs = append(envResourceAttrs, attribute.Bool(string(attr.SkipSpanMetrics.OTEL()), true))
 			}
+			// Only suppress the queue/processing sub-spans if this service's
+			// export config actually receives the replacement log record
+			// (logsOTELReceiver.processSpans gates on the same CanExportLogs()
+			// check) — otherwise the timing data would be silently dropped.
+			suppressQueueProcessingSpans := tr.suppressQueueProcessingSpans && sample.Span.Service.ExportModes.CanExportLogs()
 			traces := tracesgen.GenerateTracesWithSelectedResourceAttributes(
 				tr.attributeCache,
 				&sample.Span.Service,
@@ -140,7 +145,7 @@ func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Tra
 				spanGroup,
 				reporterName,
 				tr.selectorCfg.SelectionCfg,
-				tr.suppressQueueProcessingSpans,
+				suppressQueueProcessingSpans,
 				tr.ctxInfo.ExtraResourceAttributes...)
 			err := exp.ConsumeTraces(ctx, traces)
 			if err != nil {

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -59,18 +59,20 @@ func otlog() *slog.Logger {
 func makeTracesReceiver(
 	cfg otelcfg.TracesConfig,
 	spanMetricsEnabled bool,
+	suppressQueueProcessingSpans bool,
 	ctxInfo *global.ContextInfo,
 	selectorCfg *attributes.SelectorConfig,
 	input *msg.Queue[[]request.Span],
 ) *tracesOTELReceiver {
 	return &tracesOTELReceiver{
-		cfg:                cfg,
-		ctxInfo:            ctxInfo,
-		selectorCfg:        selectorCfg,
-		is:                 instrumentations.NewInstrumentationSelection(cfg.Instrumentations),
-		spanMetricsEnabled: spanMetricsEnabled,
-		input:              input.Subscribe(msg.SubscriberName("otel.TracesReceiver")),
-		attributeCache:     expirable2.NewLRU[svc.UID, []attribute.KeyValue](1024, nil, 5*time.Minute),
+		cfg:                          cfg,
+		ctxInfo:                      ctxInfo,
+		selectorCfg:                  selectorCfg,
+		is:                           instrumentations.NewInstrumentationSelection(cfg.Instrumentations),
+		spanMetricsEnabled:           spanMetricsEnabled,
+		suppressQueueProcessingSpans: suppressQueueProcessingSpans,
+		input:                        input.Subscribe(msg.SubscriberName("otel.TracesReceiver")),
+		attributeCache:               expirable2.NewLRU[svc.UID, []attribute.KeyValue](1024, nil, 5*time.Minute),
 	}
 }
 
@@ -79,6 +81,7 @@ func TracesReceiver(
 	ctxInfo *global.ContextInfo,
 	cfg otelcfg.TracesConfig,
 	spanMetricsEnabled bool,
+	suppressQueueProcessingSpans bool,
 	selectorCfg *attributes.SelectorConfig,
 	input *msg.Queue[[]request.Span],
 ) swarm.InstanceFunc {
@@ -86,19 +89,20 @@ func TracesReceiver(
 		if !cfg.Enabled() {
 			return swarm.EmptyRunFunc()
 		}
-		tr := makeTracesReceiver(cfg, spanMetricsEnabled, ctxInfo, selectorCfg, input)
+		tr := makeTracesReceiver(cfg, spanMetricsEnabled, suppressQueueProcessingSpans, ctxInfo, selectorCfg, input)
 		return tr.provideLoop, nil
 	}
 }
 
 type tracesOTELReceiver struct {
-	cfg                otelcfg.TracesConfig
-	ctxInfo            *global.ContextInfo
-	selectorCfg        *attributes.SelectorConfig
-	is                 instrumentations.InstrumentationSelection
-	spanMetricsEnabled bool
-	attributeCache     *expirable2.LRU[svc.UID, []attribute.KeyValue]
-	input              <-chan []request.Span
+	cfg                          otelcfg.TracesConfig
+	ctxInfo                      *global.ContextInfo
+	selectorCfg                  *attributes.SelectorConfig
+	is                           instrumentations.InstrumentationSelection
+	spanMetricsEnabled           bool
+	suppressQueueProcessingSpans bool
+	attributeCache               *expirable2.LRU[svc.UID, []attribute.KeyValue]
+	input                        <-chan []request.Span
 }
 
 func (tr *tracesOTELReceiver) getConstantAttributes() (map[attr.Name]struct{}, error) {
@@ -136,6 +140,7 @@ func (tr *tracesOTELReceiver) processSpans(ctx context.Context, exp exporter.Tra
 				spanGroup,
 				reporterName,
 				tr.selectorCfg.SelectionCfg,
+				tr.suppressQueueProcessingSpans,
 				tr.ctxInfo.ExtraResourceAttributes...)
 			err := exp.ConsumeTraces(ctx, traces)
 			if err != nil {

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -237,6 +237,40 @@ func TestGenerateTraces(t *testing.T) {
 		assert.NotEqual(t, spans.At(1).SpanID().String(), spans.At(2).SpanID().String())
 	})
 
+	t.Run("test with subtraces - queue processing suppressed", func(t *testing.T) {
+		start := time.Now()
+		parentSpanID, _ := trace.SpanIDFromHex("89cbc1f60aab3b04")
+		spanID, _ := trace.SpanIDFromHex("89cbc1f60aab3b01")
+		traceID, _ := trace.TraceIDFromHex("eae56fbbec9505c102e8aabfc6b5c481")
+		span := &request.Span{
+			Type:         request.EventTypeHTTP,
+			RequestStart: start.UnixNano(),
+			Start:        start.Add(time.Second).UnixNano(),
+			End:          start.Add(3 * time.Second).UnixNano(),
+			Method:       "GET",
+			Route:        "/test",
+			Status:       200,
+			ParentSpanID: parentSpanID,
+			TraceID:      traceID,
+			SpanID:       spanID,
+			Service:      svc.Attrs{UID: svc.UID{Name: "1"}},
+		}
+
+		traces := tracesgen.GenerateTracesWithSelectedResourceAttributes(
+			cache, &span.Service, []attribute.KeyValue{}, hostID,
+			groupFromSpanAndAttributes(span, []attribute.KeyValue{}), reporterName,
+			nil, true, // suppressQueueProcessingSpans = true
+		)
+
+		assert.Equal(t, 1, traces.ResourceSpans().Len())
+		assert.Equal(t, 1, traces.ResourceSpans().At(0).ScopeSpans().Len())
+		spans := traces.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+		require.Equal(t, 1, spans.Len(), "expected only the parent span, no 'in queue'/'processing' sub-spans")
+		assert.Equal(t, "GET /test", spans.At(0).Name())
+		assert.Equal(t, spanID.String(), spans.At(0).SpanID().String(), "parent should take the real eBPF-assigned SpanID directly")
+		assert.Equal(t, parentSpanID.String(), spans.At(0).ParentSpanID().String())
+	})
+
 	t.Run("test with subtraces - ids set bpf layer", func(t *testing.T) {
 		start := time.Now()
 		spanID, _ := trace.SpanIDFromHex("89cbc1f60aab3b04")
@@ -3254,6 +3288,7 @@ func makeTracesTestReceiver(instr []instrumentations.Instrumentation) *tracesOTE
 			Instrumentations:  instr,
 		},
 		false,
+		false,
 		&global.ContextInfo{},
 		&attributes.SelectorConfig{},
 		msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10)),
@@ -3269,6 +3304,7 @@ func makeTracesTestReceiverWithSpanMetrics(enabled bool, instr []instrumentation
 			Instrumentations:  instr,
 		},
 		enabled,
+		false,
 		&global.ContextInfo{},
 		&attributes.SelectorConfig{},
 		msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10)),

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
+	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/instrumentations"
@@ -2486,6 +2487,74 @@ func TestTraceSkipSpanMetrics(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestTraceSuppressQueueProcessingSpansPerService verifies that the queue/processing
+// sub-spans are only suppressed for services whose export config actually receives the
+// replacement log record. A service restricted to `exports: [traces]` must keep the
+// sub-spans even when the logs receiver is globally enabled, or its queue/processing
+// timing would disappear entirely (neither sub-spans nor a log record).
+func TestTraceSuppressQueueProcessingSpansPerService(t *testing.T) {
+	start := time.Now()
+
+	tracesOnly := services.NewExportModes()
+	tracesOnly.AllowTraces()
+
+	newSpan := func(uid, route string, modes services.ExportModes) request.Span {
+		return request.Span{
+			Type:         request.EventTypeHTTP,
+			RequestStart: start.UnixNano(),
+			Start:        start.Add(time.Second).UnixNano(),
+			End:          start.Add(3 * time.Second).UnixNano(),
+			Method:       "GET",
+			Route:        route,
+			Status:       200,
+			TraceID:      idgen.RandomTraceID(),
+			Service:      svc.Attrs{UID: svc.UID{Name: uid}, ExportModes: modes},
+		}
+	}
+
+	spans := []request.Span{
+		newSpan("traces-only", "/traces-only", tracesOnly),
+		newSpan("traces-and-logs", "/traces-and-logs", services.ExportModeUnset),
+	}
+
+	receiver := makeTracesReceiver(
+		otelcfg.TracesConfig{
+			CommonEndpoint:    "http://something",
+			BatchTimeout:      10 * time.Millisecond,
+			ReportersCacheLen: 16,
+			Instrumentations:  []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP},
+		},
+		false,
+		true, // suppressQueueProcessingSpans = true, globally
+		&global.ContextInfo{},
+		&attributes.SelectorConfig{},
+		msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10)),
+	)
+
+	sampler := sdktrace.AlwaysSample()
+	attrs, err := receiver.getConstantAttributes()
+	require.NoError(t, err)
+
+	byRoute := map[string]ptrace.Traces{}
+	exporter := TestExporter{
+		collector: func(td ptrace.Traces) {
+			spans := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+			byRoute[spans.At(spans.Len()-1).Name()] = td
+		},
+	}
+
+	receiver.processSpans(t.Context(), exporter, spans, attrs, sampler)
+	require.Len(t, byRoute, 2)
+
+	tracesOnlySpans := byRoute["GET /traces-only"].ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	require.Equal(t, 3, tracesOnlySpans.Len(), "traces-only service must keep 'in queue'/'processing' sub-spans")
+	assert.Equal(t, "in queue", tracesOnlySpans.At(0).Name())
+	assert.Equal(t, "processing", tracesOnlySpans.At(1).Name())
+
+	tracesAndLogsSpans := byRoute["GET /traces-and-logs"].ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	require.Equal(t, 1, tracesAndLogsSpans.Len(), "service that also exports logs must have sub-spans suppressed")
 }
 
 func TestAttrsToMap(t *testing.T) {

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -175,7 +175,7 @@ func generateTracesWithAttributes(
 	resourceAttrsMap := AttrsToMap(resourceAttrs)
 	resourceAttrsMap.PutStr(string(semconv.OTelScopeNameKey), reporterName)
 	extraResAttrs = otelcfg.FilterResourceAttrs(extraResAttrs, attrSelector)
-	addAttrsToMap(extraResAttrs, resourceAttrsMap)
+	AddAttrsToMap(extraResAttrs, resourceAttrsMap)
 	resourceAttrsMap.MoveTo(rs.Resource().Attributes())
 
 	for _, spanWithAttributes := range spans {
@@ -377,11 +377,12 @@ func TraceAppResourceAttrs(cache *expirable2.LRU[svc.UID, []attribute.KeyValue],
 // AttrsToMap converts a slice of attribute.KeyValue to a pcommon.Map
 func AttrsToMap(attrs []attribute.KeyValue) pcommon.Map {
 	m := pcommon.NewMap()
-	addAttrsToMap(attrs, m)
+	AddAttrsToMap(attrs, m)
 	return m
 }
 
-func addAttrsToMap(attrs []attribute.KeyValue, dst pcommon.Map) {
+// AddAttrsToMap writes attrs into dst, overwriting any existing key on collision.
+func AddAttrsToMap(attrs []attribute.KeyValue, dst pcommon.Map) {
 	dst.EnsureCapacity(dst.Len() + len(attrs))
 	for _, attr := range attrs {
 		switch v := attr.Value.AsInterface().(type) {

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -139,7 +139,7 @@ func GenerateTracesWithAttributes(
 	reporterName string,
 	extraResAttrs ...attribute.KeyValue,
 ) ptrace.Traces {
-	return generateTracesWithAttributes(cache, svc, envResourceAttrs, nodeMeta, spans, reporterName, nil, extraResAttrs...)
+	return generateTracesWithAttributes(cache, svc, envResourceAttrs, nodeMeta, spans, reporterName, nil, false, extraResAttrs...)
 }
 
 func GenerateTracesWithSelectedResourceAttributes(
@@ -150,9 +150,10 @@ func GenerateTracesWithSelectedResourceAttributes(
 	spans []TraceSpanAndAttributes,
 	reporterName string,
 	attrSelector attributes.Selection,
+	suppressQueueProcessingSpans bool,
 	extraResAttrs ...attribute.KeyValue,
 ) ptrace.Traces {
-	return generateTracesWithAttributes(cache, svc, envResourceAttrs, nodeMeta, spans, reporterName, attrSelector, extraResAttrs...)
+	return generateTracesWithAttributes(cache, svc, envResourceAttrs, nodeMeta, spans, reporterName, attrSelector, suppressQueueProcessingSpans, extraResAttrs...)
 }
 
 func generateTracesWithAttributes(
@@ -163,6 +164,7 @@ func generateTracesWithAttributes(
 	spans []TraceSpanAndAttributes,
 	reporterName string,
 	attrSelector attributes.Selection,
+	suppressQueueProcessingSpans bool,
 	extraResAttrs ...attribute.KeyValue,
 ) ptrace.Traces {
 	traces := ptrace.NewTraces()
@@ -190,8 +192,9 @@ func generateTracesWithAttributes(
 		ss := rs.ScopeSpans().AppendEmpty()
 
 		t := span.Timings()
-		start := spanStartTime(t)
-		hasSubSpans := t.Start.After(start)
+		start := SpanStartTime(t)
+		hasQueueGap := t.Start.After(start)
+		emitSubSpans := hasQueueGap && !suppressQueueProcessingSpans
 
 		traceID := pcommon.TraceID(span.TraceID)
 		spanID := pcommon.SpanID(idgen.RandomSpanID())
@@ -200,7 +203,7 @@ func generateTracesWithAttributes(
 			traceID = pcommon.TraceID(idgen.RandomTraceID())
 		}
 
-		if hasSubSpans {
+		if emitSubSpans {
 			createSubSpans(span, spanID, traceID, &ss, t)
 		} else if span.SpanID.IsValid() {
 			spanID = pcommon.SpanID(span.SpanID)
@@ -253,7 +256,7 @@ func generateTracesWithAttributes(
 		if statusMessage != "" {
 			s.Status().SetMessage(statusMessage)
 		}
-		if !hasSubSpans {
+		if !emitSubSpans {
 			appendSpanLinks(s, span.Links)
 		}
 		s.SetEndTimestamp(pcommon.NewTimestampFromTime(t.End))
@@ -1764,7 +1767,7 @@ func spanKind(span *request.Span) trace2.SpanKind {
 	return trace2.SpanKindInternal
 }
 
-func spanStartTime(t request.Timings) time.Time {
+func SpanStartTime(t request.Timings) time.Time {
 	realStart := t.RequestStart
 	if t.Start.Before(realStart) {
 		realStart = t.Start

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -374,6 +374,7 @@ type Config struct {
 	NameResolver *transform.NameResolverConfig `yaml:"name_resolver"`
 	OTELMetrics  otelcfg.MetricsConfig         `yaml:"otel_metrics_export"`
 	Traces       otelcfg.TracesConfig          `yaml:"otel_traces_export"`
+	Logs         otelcfg.LogsConfig            `yaml:"otel_logs_export"`
 	Prometheus   prom.PrometheusConfig         `yaml:"prometheus_export"`
 	TracePrinter debug.TracePrinter            `yaml:"trace_printer" env:"OTEL_EBPF_TRACE_PRINTER"`
 
@@ -759,9 +760,14 @@ func (c *Config) validate(context validationContext) error {
 		return ConfigError(err.Error())
 	}
 
+	if err := c.Logs.NormalizeQueueConfig(); err != nil {
+		return ConfigError(err.Error())
+	}
+
 	networkEnabled := c.enabledForValidation(FeatureNetO11y, context)
 	applicationEnabled := c.enabledForValidation(FeatureAppO11y, context)
 	statsEnabled := c.enabledForValidation(FeatureStatsO11y, context)
+
 	if !networkEnabled && !applicationEnabled && !statsEnabled {
 		return ConfigError("at least one of 'network', 'application' or 'stats' features must be enabled. " +
 			"Enable an OpenTelemetry or Prometheus metrics export, then enable any of the network*, application* or stats*" +
@@ -880,6 +886,16 @@ func (c *Config) Enabled(feature Feature) bool {
 func (c *Config) SpanMetricsEnabledForTraces() bool {
 	return c.Metrics.Features.AnySpanMetrics() &&
 		(c.OTELMetrics.EndpointEnabled() || c.Prometheus.EndpointEnabled())
+}
+
+// QueueProcessingAsLogsEnabled reports whether the "in queue"/"processing"
+// sub-spans should be suppressed in favor of a single combined log record.
+// Gating on c.Logs.Enabled() first means a user who sets the toggle without
+// configuring a logs endpoint never silently loses the queue/processing
+// timing data — the spans keep flowing until there's somewhere for the
+// replacement log record to go.
+func (c *Config) QueueProcessingAsLogsEnabled() bool {
+	return c.Logs.Enabled() && c.Logs.QueueProcessingLogs
 }
 
 // ExternalLogger sets the logging capabilities of OBI.

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -295,6 +295,9 @@ discovery:
 				// no traces for DNS and GPU by default
 			},
 		},
+		Logs: otelcfg.LogsConfig{
+			CommonEndpoint: "localhost:3131",
+		},
 		Prometheus: prom.PrometheusConfig{
 			Path: "/metrics",
 			Instrumentations: []instrumentations.Instrumentation{
@@ -489,6 +492,28 @@ func TestConfig_JVMRuntimeMetricsDefaults(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, time.Second, cfg.JVMRuntimeMetrics.SamplingInterval)
+}
+
+func TestConfig_QueueProcessingAsLogsEnabled(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		cfg := &Config{}
+		assert.False(t, cfg.QueueProcessingAsLogsEnabled())
+	})
+
+	t.Run("toggle set but no logs endpoint configured", func(t *testing.T) {
+		cfg := &Config{Logs: otelcfg.LogsConfig{QueueProcessingLogs: true}}
+		assert.False(t, cfg.QueueProcessingAsLogsEnabled(), "must not suppress spans without a place to send the replacement log")
+	})
+
+	t.Run("toggle set and logs endpoint configured", func(t *testing.T) {
+		cfg := &Config{Logs: otelcfg.LogsConfig{QueueProcessingLogs: true, LogsEndpoint: "http://localhost:4318"}}
+		assert.True(t, cfg.QueueProcessingAsLogsEnabled())
+	})
+
+	t.Run("logs endpoint configured but toggle off", func(t *testing.T) {
+		cfg := &Config{Logs: otelcfg.LogsConfig{LogsEndpoint: "http://localhost:4318"}}
+		assert.False(t, cfg.QueueProcessingAsLogsEnabled())
+	})
 }
 
 func TestConfig_JVMRuntimeMetricsFromEnv(t *testing.T) {

--- a/schemas/obi/groups/traces.yaml
+++ b/schemas/obi/groups/traces.yaml
@@ -45,6 +45,30 @@ groups:
           semconv adds an official ONC RPC auth flavor attribute, at which
           point this key will be migrated to the semconv name.
         examples: ["AUTH_NONE", "AUTH_SYS"]
+      - id: queue.duration
+        type: double
+        stability: development
+        brief: >
+          Time (in seconds) a request spent queued before its handler began
+          processing, as observed by OBI's eBPF instrumentation.
+        note: >
+          Emitted as a log record attribute (event.name
+          "request.queue_processing") instead of the deprecated "in queue"
+          span, when otel_logs_export.queue_processing_logs is enabled. See
+          https://opentelemetry.io/blog/2026/deprecating-span-events/.
+        examples: [0.012]
+      - id: processing.duration
+        type: double
+        stability: development
+        brief: >
+          Time (in seconds) a request's handler spent actually processing
+          it, as observed by OBI's eBPF instrumentation.
+        note: >
+          Emitted as a log record attribute (event.name
+          "request.queue_processing") instead of the deprecated "processing"
+          span, when otel_logs_export.queue_processing_logs is enabled. See
+          https://opentelemetry.io/blog/2026/deprecating-span-events/.
+        examples: [0.231]
       - id: gen_ai.metadata
         type: string
         stability: development


### PR DESCRIPTION
## Summary

Every request with an observable queue gap produces two extra full sibling spans, `"in queue"` and `"processing"`, alongside the parent — tripling OTLP span volume for that request. The originating issue proposed span events as a lighter-weight fix, but that API has since been deprecated in favor of the Logs API, so this replaces the sub-spans with a single combined log record instead.

- `pkg/export/otel/tracesgen/tracesgen.go`, `traces.go`: thread a `suppressQueueProcessingSpans` toggle through span generation
- `pkg/export/otel/otelcfg/config_logs.go`, `logsgen/`, `logs.go`: new `otel_logs_export` signal, mirroring the existing `TracesConfig` pattern
- `pkg/obi/config.go`, `pkg/appolly/instrumenter.go`: wire in `Config.QueueProcessingAsLogsEnabled()` and the `OTELLogsReceiver` node
- `internal/test/integration/logs_test.go`: end-to-end toggle-on verification

The toggle defaults off (no behavior change for existing users), and gates on both the `queue_processing_logs` flag _and_ a configured logs endpoint (`Config.QueueProcessingAsLogsEnabled`) — a half-configured toggle keeps the old sub-spans flowing instead of silently dropping the queue/processing timing data. The log record correlates to its parent span via the record's native `trace_id/span_id`, carrying `queue.duration/processing.duration` as attributes.

Refs #1193 

## AI usage

Per AI-Policy §5: Claude Code was used to implement this feature end-to-end (new logs export signal, span-suppression toggle, wiring, and tests) and to run the verification below. Review caught and fixed three correctness issues before this was opened: a logs-receiver enable gate that only checked the common endpoint and ignored the `queue_processing_logs` toggle, a per-service export check using the traces permission instead of the logs one, and a log record that could carry an unmatchable `span_id` on the suppressed-span fallback path. I reviewed the resulting diff before submitting.

Verification run:
- `go test ./pkg/export/otel/... ./pkg/obi/... ./pkg/appolly/...` clean
- Integration suite: toggle-on (`TestSuite_QueueProcessingLogs`) confirms 0 sub-spans + 1 log record; toggle-off regression re-run confirms the existing 3-span behavior is unchanged
- `make lint / make build` clean

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] features doc / support matrix - not applicable: both documents cover protocol/library instrumentation matrices, not OTLP export signal config. The new `otel_logs_export` config is documented in the autogenerated `devdocs/config/CONFIG.md`.
