### PR TITLE
Route integration workflows by build inputs

### DIFF
--- a/.github/workflows/java-agent.yml
+++ b/.github/workflows/java-agent.yml
@@ -7,6 +7,7 @@ on:
     branches: ["main", "release-*"]
     paths:
       - "pkg/internal/java/**"
+      - "dependencies.Dockerfile"
       - ".github/workflows/java-agent.yml"
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -9,11 +9,31 @@ on:
     branches: [main, release-*]
     paths:
       - ".github/workflows/workflow_integration_tests_vm.yml"
+      - ".github/actions/free-disk/**"
+      - ".github/actions/setup-lvh-kernel/**"
+      - ".dockerignore"
+      - "go.mod"
+      - "go.sum"
       - "bpf/**"
+      - "cmd/**"
+      - "configs/**"
+      - "internal/config/**"
       - "internal/test/integration/**"
+      - "internal/test/tools/**"
       - "internal/test/vm/**"
+      - "internal/test/weavercheck/**"
+      - "internal/tools/go.mod"
+      - "internal/tools/go.sum"
+      - "pkg/**"
+      - "schemas/obi/**"
+      - "scripts/discover-integration-images.sh"
+      - "scripts/fetch-upstream-semconv.sh"
       - "scripts/generate-integration-matrix.sh"
+      - "scripts/integration-test-weights.generated.json"
       - "scripts/kernel-matrix-json.sh"
+      - "scripts/pull-base-images.sh"
+      - "Makefile"
+      - "!**/*.md"
   workflow_call:
     inputs:
       ref:
@@ -151,8 +171,8 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] keyed on hash of compose+Dockerfile+source inputs
         with:
           path: compiled-tests/docker-images.tar
-          # OBI binary bakes bpf/cmd/pkg sources; hash them too or source changes reuse stale images.
-          key: vm-docker-images-${{ hashFiles('internal/test/integration/docker-compose-multiexec*.yml', 'internal/test/integration/**/Dockerfile*', 'bpf/**', 'cmd/**', 'pkg/**', 'go.mod', 'go.sum') }}
+          # Hash every discovered build input so source changes cannot reuse stale images.
+          key: vm-docker-images-${{ hashFiles('internal/test/integration/**', 'internal/config/**', 'Makefile', '.dockerignore', 'scripts/discover-integration-images.sh', 'bpf/**', 'cmd/**', 'pkg/**', 'go.mod', 'go.sum') }}
 
       - name: Pre-build Docker images
         if: steps.docker-images-cache.outputs.cache-hit != 'true'
@@ -190,7 +210,8 @@ jobs:
           fi
 
           IMAGE_SCOPE="$(bash scripts/discover-integration-images.sh --base-images | sha256sum | cut -d' ' -f1)"
-          echo "key=base-images-${ARCH}-${REF_SCOPE}-${IMAGE_SCOPE}" >> "$GITHUB_OUTPUT"
+          PULL_SCRIPT_SCOPE="$(sha256sum scripts/pull-base-images.sh | cut -d' ' -f1)"
+          echo "key=base-images-${ARCH}-${REF_SCOPE}-${IMAGE_SCOPE}-${PULL_SCRIPT_SCOPE}" >> "$GITHUB_OUTPUT"
 
       - name: Cache base images
         id: base-images-cache


### PR DESCRIPTION
## Summary

- Route VM integration checks for the Go, configuration, test, schema, action, script, and Docker build inputs they consume.
- Route Java Agent CI when the root dependency image definition changes.
- Keep Markdown-only pull requests out of the VM matrix.
- Invalidate prebuilt Docker artifacts when their source or producer scripts change.

## Why

Several checked-in build inputs could change without scheduling the integration workflow that consumes them. Some newly routed inputs could also reuse cached artifacts produced from older source, allowing CI to pass without exercising the pull request's change.

## Testing

- Ordered path and cache contract assertions — passed
- YAML parsing for both edited workflows — passed
- Focused `actionlint` validation — passed
- `make lint` — passed
- `git diff --check` — passed
