### PR TITLE
Harden integration shard generation

### DIFF
--- a/scripts/generate-integration-matrix.sh
+++ b/scripts/generate-integration-matrix.sh
@@ -5,58 +5,112 @@
 # Generate standard test matrix with configurable partitions
 # Usage: ./scripts/generate-integration-matrix.sh [search_dir] [partitions] [test_pattern]
 
-set -e
+set -euo pipefail
+shopt -s lastpipe
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd -- "${BASH_SOURCE[0]%/*}" && pwd -P)"
 SEARCH_DIR="${1:-internal/test/integration}"
 PARTITIONS="${2:-5}"
 TEST_PATTERN="${3:-Test}"
-WEIGHTS_FILE="$SCRIPT_DIR/integration-test-weights.generated.json"
+WEIGHTS_FILE="${OBI_INTEGRATION_TEST_WEIGHTS_FILE:-$SCRIPT_DIR/integration-test-weights.generated.json}"
 
-FILES=$(find "$SEARCH_DIR" -maxdepth 1 -type f -name "*_test.go")
-if [ -z "$FILES" ]; then
-    echo "No test files found" >&2
+required_commands=(awk find grep sed sort tr)
+missing_commands=()
+for command_name in "${required_commands[@]}"; do
+    if ! command -v "$command_name" >/dev/null 2>&1; then
+        missing_commands+=("$command_name")
+    fi
+done
+if (( ${#missing_commands[@]} > 0 )); then
+    printf 'ERROR: missing required commands: %s\n' "${missing_commands[*]}" >&2
     exit 1
 fi
 
-# Extract test function names from the files and sort
-TEST_NAMES=$(grep -hE "^func $TEST_PATTERN" $FILES | sed 's/^func \([^(]*\).*/\1/' | sort -u)
-
-if [ -z "$TEST_NAMES" ]; then
-    echo "ERROR: No tests found in '$SEARCH_DIR'" >&2
+if [[ ! "$PARTITIONS" =~ ^[1-9][0-9]*$ ]]; then
+    printf "ERROR: partitions must be a positive integer, got '%s'\n" "$PARTITIONS" >&2
+    exit 1
+fi
+if [[ ! -d "$SEARCH_DIR" ]]; then
+    printf "ERROR: search directory not found: '%s'\n" "$SEARCH_DIR" >&2
+    exit 1
+fi
+if [[ "$TEST_PATTERN" == *$'\n'* || "$TEST_PATTERN" == *$'\r'* ]]; then
+    echo "ERROR: test pattern must not contain newline or carriage return" >&2
     exit 1
 fi
 
-TOTAL_TESTS=$(echo "$TEST_NAMES" | wc -l | tr -d " ")
+declare -a test_files=()
+if ! find "$SEARCH_DIR" -maxdepth 1 -type f -name "*_test.go" -print0 | LC_ALL=C sort -z | mapfile -d '' -t test_files; then
+    echo "ERROR: failed to discover test files" >&2
+    exit 1
+fi
+
+if (( ${#test_files[@]} == 0 )); then
+    echo "ERROR: No test files found" >&2
+    exit 1
+fi
+
+declare -a test_names=()
+if grep -hE "^func $TEST_PATTERN" "${test_files[@]}" \
+    | sed 's/^func \([^(]*\).*/\1/' \
+    | LC_ALL=C sort -u \
+    | mapfile -t test_names; then
+    :
+else
+    extraction_status=("${PIPESTATUS[@]}")
+    if (( extraction_status[0] == 1 && extraction_status[1] == 0 && extraction_status[2] == 0 && extraction_status[3] == 0 )); then
+        printf "ERROR: No tests matching '%s' found in '%s'\n" "$TEST_PATTERN" "$SEARCH_DIR" >&2
+    else
+        printf 'ERROR: failed to extract test names (grep=%d sed=%d sort=%d read=%d)\n' "${extraction_status[@]}" >&2
+    fi
+    exit 1
+fi
 
 # Look up weights and assign tests to shards using LPT (Longest Processing Time)
 # bin packing: sort tests by weight descending, assign each to the lightest shard.
-if [ -f "$WEIGHTS_FILE" ] && command -v jq >/dev/null 2>&1; then
-    DEFAULT_WEIGHT=$(jq -r '._default // 20' "$WEIGHTS_FILE")
+if [[ -f "$WEIGHTS_FILE" ]] && command -v jq >/dev/null 2>&1; then
+    if ! jq -e -s '
+        length == 1 and (.[0]
+        | type == "object"
+        and ((if has("_default") then ._default else 20 end) | type == "number" and . >= 0)
+        and ([to_entries[] | select(.key != "_default") | .value
+              | type == "number" and . >= 0] | all)
+        )
+    ' "$WEIGHTS_FILE" >/dev/null; then
+        printf "ERROR: invalid weights file '%s'; weights must be non-negative numbers\n" "$WEIGHTS_FILE" >&2
+        exit 1
+    fi
 
-    # Build "weight testname" pairs, sorted by weight descending then name
-    WEIGHTED_TESTS=$(echo "$TEST_NAMES" | while read -r name; do
-        w=$(jq -r --arg n "$name" '.[$n] // empty' "$WEIGHTS_FILE")
-        if [ -z "$w" ]; then
-            w=$DEFAULT_WEIGHT
+    default_weight="$(jq -r 'if has("_default") then ._default else 20 end' "$WEIGHTS_FILE")"
+    weighted_tests=""
+    for name in "${test_names[@]}"; do
+        weight="$(jq -r --arg name "$name" '.[$name] // empty' "$WEIGHTS_FILE")"
+        if [[ -z "$weight" ]]; then
+            weight="$default_weight"
         fi
-        echo "$w $name"
-    done | sort -k1,1 -rn -k2,2)
+        weighted_tests+="$weight $name"$'\n'
+    done
+    weighted_tests="$(printf '%s' "$weighted_tests" | LC_ALL=C sort -k1,1 -rg -k2,2)"
 
-    echo "Using weighted bin packing (weights from $WEIGHTS_FILE)" >&2
+    printf 'Using weighted bin packing (weights from %s)\n' "$WEIGHTS_FILE" >&2
 else
-    # Fallback: equal weights, alphabetical order
-    DEFAULT_WEIGHT=20
-    WEIGHTED_TESTS=$(echo "$TEST_NAMES" | while read -r name; do
-        echo "$DEFAULT_WEIGHT $name"
-    done)
+    default_weight=20
+    weighted_tests=""
+    for name in "${test_names[@]}"; do
+        weighted_tests+="$default_weight $name"$'\n'
+    done
+    weighted_tests="${weighted_tests%$'\n'}"
 
     echo "Warning: weights file not found or jq not available, using equal weights" >&2
 fi
 
-# LPT bin packing via awk: assign each test (sorted heaviest first) to the
-# shard with the smallest accumulated weight.
-SHARD_ASSIGNMENTS=$(echo "$WEIGHTED_TESTS" | awk -v partitions="$PARTITIONS" '
+# Assign each test to the shard with the smallest accumulated weight.
+shard_count="$PARTITIONS"
+test_count="${#test_names[@]}"
+if [[ ${#PARTITIONS} -gt ${#test_count} || (${#PARTITIONS} -eq ${#test_count} && "$PARTITIONS" > "$test_count") ]]; then
+    shard_count="${#test_names[@]}"
+fi
+shard_assignments="$(awk -v partitions="$shard_count" '
 BEGIN {
     for (i = 0; i < partitions; i++) {
         shard_weight[i] = 0
@@ -65,8 +119,6 @@ BEGIN {
 {
     weight = $1
     name = $2
-
-    # Find the shard with the smallest total weight
     min_shard = 0
     min_weight = shard_weight[0]
     for (i = 1; i < partitions; i++) {
@@ -75,7 +127,6 @@ BEGIN {
             min_shard = i
         }
     }
-
     shard_weight[min_shard] += weight
     print min_shard, weight, name
 }
@@ -83,29 +134,27 @@ END {
     for (i = 0; i < partitions; i++) {
         printf "Shard %d estimated weight: %ds\n", i, shard_weight[i] > "/dev/stderr"
     }
-}')
+}' <<< "$weighted_tests")"
 
-echo "Total tests matching '$TEST_PATTERN': $TOTAL_TESTS, Partitions: $PARTITIONS" >&2
+printf "Total tests matching '%s': %d, Partitions: %s\n" "$TEST_PATTERN" "${#test_names[@]}" "$PARTITIONS" >&2
 
-# Generate matrix JSON from shard assignments
-MATRIX_JSON='{"include":['
-FIRST_SHARD=true
-
-for SHARD in $(seq 0 $((PARTITIONS - 1))); do
-    SHARD_TESTS=$(echo "$SHARD_ASSIGNMENTS" | awk -v s="$SHARD" '$1 == s { print $3 }' | tr "\n" "|" | sed "s/|$//")
-
-    if [ -n "$SHARD_TESTS" ]; then
-        if [ "$FIRST_SHARD" = "false" ]; then
-            MATRIX_JSON+=","
-        fi
-        FIRST_SHARD=false
-
-        TEST_COUNT=$(echo "$SHARD_TESTS" | tr "|" "\n" | wc -l | tr -d " ")
-        MATRIX_JSON+="{\"id\":$SHARD,\"description\":\"shard-$SHARD ($TEST_COUNT tests)\",\"test_pattern\":\"$SHARD_TESTS\"}"
-
-        echo "Shard $SHARD: $TEST_COUNT tests: $SHARD_TESTS" >&2
+matrix_json='{"include":['
+first_shard=true
+for (( shard = 0; shard < shard_count; shard++ )); do
+    shard_tests="$(awk -v shard="$shard" '$1 == shard { print $3 }' <<< "$shard_assignments" | tr "\n" "|" | sed "s/|$//")"
+    if [[ -z "$shard_tests" ]]; then
+        continue
     fi
+
+    if [[ "$first_shard" == "false" ]]; then
+        matrix_json+=","
+    fi
+    first_shard=false
+
+    test_count="$(tr "|" "\n" <<< "$shard_tests" | awk 'END { print NR }')"
+    matrix_json+="{\"id\":$shard,\"description\":\"shard-$shard ($test_count tests)\",\"test_pattern\":\"$shard_tests\"}"
+    printf 'Shard %d: %d tests: %s\n' "$shard" "$test_count" "$shard_tests" >&2
 done
 
-MATRIX_JSON+=']}'
-echo "$MATRIX_JSON"
+matrix_json+=']}'
+printf '%s\n' "$matrix_json"

--- a/scripts/generate-integration-matrix_test.go
+++ b/scripts/generate-integration-matrix_test.go
@@ -1,0 +1,243 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package scripts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+type integrationMatrix struct {
+	Include []struct {
+		TestPattern string `json:"test_pattern"`
+	} `json:"include"`
+}
+
+func TestGenerateIntegrationMatrixIsCompleteUniqueAndDeterministic(t *testing.T) {
+	searchDir := t.TempDir()
+	mustWriteIntegrationTestFile(t, searchDir, "z [*]_test.go", "TestZulu", "TestAlpha")
+	mustWriteIntegrationTestFile(t, searchDir, "a_test.go", "TestCharlie", "TestBravo")
+	weightsFile := mustWriteWeightsFile(t, `{"_default": 1}`)
+	var first string
+	for run := 0; run < 5; run++ {
+		stdout, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "3", "", weightsFile, "")
+		if err != nil {
+			t.Fatalf("run %d failed: %v\nstderr:\n%s", run, err, stderr)
+		}
+		if run == 0 {
+			first = stdout
+		} else if stdout != first {
+			t.Fatalf("run %d was not byte-stable:\nfirst: %s\ncurrent: %s", run, first, stdout)
+		}
+	}
+	got := matrixTestNames(t, first)
+	want := []string{"TestAlpha", "TestBravo", "TestCharlie", "TestZulu"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("matrix union differs: got %v, want %v", got, want)
+	}
+}
+
+func TestGenerateIntegrationMatrixUsesLongestProcessingTimeWeights(t *testing.T) {
+	searchDir := t.TempDir()
+	mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestDelta", "TestCharlie", "TestBravo", "TestAlpha")
+	weightsFile := mustWriteWeightsFile(t, `{"_default":1,"TestAlpha":1e100,"TestBravo":20,"TestCharlie":19,"TestDelta":1}`)
+	stdout, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", "", weightsFile, "")
+	if err != nil {
+		t.Fatalf("generator failed: %v\nstderr:\n%s", err, stderr)
+	}
+	matrix := parseIntegrationMatrix(t, stdout)
+	want := []string{"TestAlpha", "TestBravo|TestCharlie|TestDelta"}
+	got := []string{matrix.Include[0].TestPattern, matrix.Include[1].TestPattern}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected weighted allocation: got %v, want %v", got, want)
+	}
+}
+
+func TestGenerateIntegrationMatrixRejectsInvalidWeights(t *testing.T) {
+	for _, contents := range []string{"", " \n", `{} {}`, `not-json`, `{"_default":false}`, `{"_default":-1}`, `{"TestAlpha":"heavy"}`} {
+		searchDir := t.TempDir()
+		mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha")
+		_, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", "", mustWriteWeightsFile(t, contents), "")
+		if err == nil || !strings.Contains(stderr, "invalid weights file") {
+			t.Fatalf("weights %q: got err=%v stderr=%q", contents, err, stderr)
+		}
+	}
+}
+
+func TestGenerateIntegrationMatrixHandlesInputBoundaries(t *testing.T) {
+	t.Run("empty directory", func(t *testing.T) {
+		_, stderr, err := runGenerateIntegrationMatrix(t, t.TempDir(), "2", "", "", "")
+		if err == nil || !strings.Contains(stderr, "No test files found") {
+			t.Fatalf("expected empty input error, got err=%v stderr=%q", err, stderr)
+		}
+	})
+	t.Run("custom pattern", func(t *testing.T) {
+		searchDir := t.TempDir()
+		mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha", "TestBeta", "TestGamma")
+		stdout, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", "(TestAlpha|TestGamma)", "", "")
+		if err != nil {
+			t.Fatalf("generator failed: %v\nstderr:\n%s", err, stderr)
+		}
+		if got, want := matrixTestNames(t, stdout), []string{"TestAlpha", "TestGamma"}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("custom pattern selected %v, want %v", got, want)
+		}
+	})
+	t.Run("custom pattern without matches", func(t *testing.T) {
+		searchDir := t.TempDir()
+		mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha")
+		_, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", "TestMissing", "", "")
+		if err == nil || !strings.Contains(stderr, "No tests matching 'TestMissing'") {
+			t.Fatalf("expected no matches error, got err=%v stderr=%q", err, stderr)
+		}
+	})
+	t.Run("more partitions than tests", func(t *testing.T) {
+		searchDir := t.TempDir()
+		mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha", "TestBeta")
+		for _, partitions := range []string{"100000", "18446744073709551616"} {
+			stdout, stderr, err := runGenerateIntegrationMatrix(t, searchDir, partitions, "", "", "")
+			if err != nil {
+				t.Fatalf("partitions %s failed: %v\nstderr:\n%s", partitions, err, stderr)
+			}
+			matrix := parseIntegrationMatrix(t, stdout)
+			if len(matrix.Include) != 2 || !reflect.DeepEqual(matrixTestNames(t, stdout), []string{"TestAlpha", "TestBeta"}) {
+				t.Fatalf("partitions %s produced %+v", partitions, matrix.Include)
+			}
+		}
+	})
+}
+
+func TestGenerateIntegrationMatrixRejectsInvalidArguments(t *testing.T) {
+	searchDir := t.TempDir()
+	mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha")
+	for _, partitions := range []string{"0", "-1", "many"} {
+		_, stderr, err := runGenerateIntegrationMatrix(t, searchDir, partitions, "", "", "")
+		if err == nil || !strings.Contains(stderr, "partitions must be a positive integer") {
+			t.Fatalf("partitions %q: expected validation error, got err=%v stderr=%q", partitions, err, stderr)
+		}
+	}
+	for _, pattern := range []string{"TestAlpha\n.*", "TestAlpha\r.*"} {
+		_, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", pattern, "", "")
+		if err == nil || !strings.Contains(stderr, "test pattern must not contain") {
+			t.Fatalf("pattern %q: got err=%v stderr=%q", pattern, err, stderr)
+		}
+	}
+}
+
+func TestGenerateIntegrationMatrixFailsClosedOnToolErrors(t *testing.T) {
+	tests := []struct{ command, script, want string }{
+		{"awk", "", "missing required commands: awk"},
+		{"sort", "#!/bin/bash\n/usr/bin/head -c 1\nexit 17\n", "failed to discover test files"},
+		{"grep", "#!/bin/bash\nprintf '%s\\n' 'func TestPartial(t *testing.T) {}'\nexit 2\n", "failed to extract test names"},
+	}
+	for _, tc := range tests {
+		searchDir, binDir := t.TempDir(), t.TempDir()
+		mustWriteIntegrationTestFile(t, searchDir, "sample_test.go", "TestAlpha")
+		for _, name := range []string{"awk", "find", "grep", "sed", "sort", "tr"} {
+			path := filepath.Join(binDir, name)
+			if name == tc.command {
+				if tc.script != "" {
+					if err := os.WriteFile(path, []byte(tc.script), 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				continue
+			}
+			target, err := exec.LookPath(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, path); err != nil {
+				t.Fatal(err)
+			}
+		}
+		stdout, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "2", "", "", binDir)
+		if err == nil || stdout != "" || !strings.Contains(stderr, tc.want) {
+			t.Fatalf("%s: stdout=%q err=%v stderr=%q", tc.command, stdout, err, stderr)
+		}
+	}
+}
+
+func runGenerateIntegrationMatrix(t *testing.T, searchDir, partitions, pattern, weightsFile, path string) (string, string, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/bin/bash", "./generate-integration-matrix.sh", searchDir, partitions, pattern)
+	cmd.Dir = "."
+	for _, variable := range os.Environ() {
+		if strings.HasPrefix(variable, "OBI_INTEGRATION_TEST_WEIGHTS_FILE=") || path != "" && strings.HasPrefix(variable, "PATH=") {
+			continue
+		}
+		cmd.Env = append(cmd.Env, variable)
+	}
+	if weightsFile == "" {
+		weightsFile = filepath.Join(searchDir, "missing-weights.json")
+	}
+	cmd.Env = append(cmd.Env, "OBI_INTEGRATION_TEST_WEIGHTS_FILE="+weightsFile)
+	if path != "" {
+		cmd.Env = append(cmd.Env, "PATH="+path)
+	}
+	stdout, err := cmd.Output()
+	if err == nil {
+		return string(stdout), "", nil
+	}
+	var stderr string
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		stderr = string(exitErr.Stderr)
+	}
+	return string(stdout), stderr, err
+}
+
+func parseIntegrationMatrix(t *testing.T, stdout string) integrationMatrix {
+	t.Helper()
+	var matrix integrationMatrix
+	if err := json.Unmarshal([]byte(stdout), &matrix); err != nil {
+		t.Fatalf("failed to parse matrix JSON %q: %v", stdout, err)
+	}
+	return matrix
+}
+
+func matrixTestNames(t *testing.T, stdout string) []string {
+	t.Helper()
+	matrix := parseIntegrationMatrix(t, stdout)
+	seen := map[string]bool{}
+	var names []string
+	for _, shard := range matrix.Include {
+		for _, name := range strings.Split(shard.TestPattern, "|") {
+			if seen[name] {
+				t.Fatalf("test %s appears more than once", name)
+			}
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func mustWriteIntegrationTestFile(t *testing.T, rootDir, name string, testNames ...string) {
+	t.Helper()
+	contents := "package fixture\n\nfunc " + strings.Join(testNames, "(t *testing.T) {}\n\nfunc ") + "(t *testing.T) {}\n"
+	if err := os.WriteFile(filepath.Join(rootDir, name), []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWriteWeightsFile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "weights.json")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary

- generate deterministic, complete integration shards with strict input and dependency validation
- reject malformed weights, invalid or excessive partition values, multiline patterns, and partial tool output
- add hermetic contract tests for exact union, uniqueness, weighted allocation, failure handling, and hostile filenames

## Testing

- go test -race ./scripts -run TestGenerate -count=1
- make integration-test-matrix-json
- Bash syntax and ShellCheck validation
- targeted golangci-lint for the scripts package