### PR TITLE
Harden watcher event decoding and shutdown

### DIFF
--- a/pkg/internal/ebpf/watcher/watcher.go
+++ b/pkg/internal/ebpf/watcher/watcher.go
@@ -26,7 +26,10 @@ type Watcher struct {
 	closers    []io.Closer
 	log        *slog.Logger
 	events     chan<- Event
+	forward    func(context.Context, watchEventParser)
 }
+
+type watchEventParser func(*ringbuf.Record) (request.Span, bool, error)
 
 type EventType int
 
@@ -34,6 +37,8 @@ const (
 	Ready = EventType(iota)
 	NewPort
 )
+
+const watchBind uint64 = 1
 
 type Event struct {
 	Type    EventType
@@ -87,11 +92,18 @@ func (p *Watcher) Tracepoints() map[string]ebpfcommon.ProbeDesc {
 func (p *Watcher) SetupTailCalls() {}
 
 func (p *Watcher) Run(ctx context.Context) {
-	p.events <- Event{Type: Ready}
+	parse := func(record *ringbuf.Record) (request.Span, bool, error) {
+		return p.processWatchEvent(ctx, record)
+	}
+	_ = p.sendEvent(ctx, Event{Type: Ready})
+	if p.forward != nil {
+		p.forward(ctx, parse)
+		return
+	}
 	ebpfcommon.ForwardRingbuf(
 		&p.cfg.EBPF,
 		p.bpfObjects.WatchEvents,
-		p.processWatchEvent,
+		parse,
 		nil,
 		p.log,
 		nil,
@@ -99,7 +111,19 @@ func (p *Watcher) Run(ctx context.Context) {
 	)(ctx, nil)
 }
 
-func (p *Watcher) processWatchEvent(record *ringbuf.Record) (request.Span, bool, error) {
+func (p *Watcher) sendEvent(ctx context.Context, event Event) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	select {
+	case p.events <- event:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *Watcher) processWatchEvent(ctx context.Context, record *ringbuf.Record) (request.Span, bool, error) {
 	var flags uint64
 	var event BPFWatchInfo
 
@@ -108,12 +132,15 @@ func (p *Watcher) processWatchEvent(record *ringbuf.Record) (request.Span, bool,
 		return request.Span{}, true, err
 	}
 
-	if flags == 1 { // socket bind
+	if flags == watchBind { // socket bind
 		err = binary.Read(bytes.NewBuffer(record.RawSample), binary.LittleEndian, &event)
+		if err != nil {
+			return request.Span{}, true, err
+		}
 
-		if err == nil {
-			p.log.Debug("New port bind event", "port", event.Payload)
-			p.events <- Event{Type: NewPort, Payload: uint32(event.Payload)}
+		p.log.Debug("New port bind event", "port", event.Payload)
+		if err := p.sendEvent(ctx, Event{Type: NewPort, Payload: uint32(event.Payload)}); err != nil {
+			return request.Span{}, true, err
 		}
 	}
 

--- a/pkg/internal/ebpf/watcher/watcher_test.go
+++ b/pkg/internal/ebpf/watcher/watcher_test.go
@@ -1,0 +1,139 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package watcher
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/obi/pkg/ebpf/ringbuf"
+	"go.opentelemetry.io/obi/pkg/internal/testutil"
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+func TestProcessWatchEventRejectsTruncatedRecords(t *testing.T) {
+	events := make(chan Event, 1)
+	w := New(&obi.Config{}, events)
+	sample := watchSample(1, 8080)
+	for length := 0; length < 8; length++ {
+		_, _, err := w.processWatchEvent(t.Context(), &ringbuf.Record{RawSample: sample[:length]})
+		if err == nil {
+			t.Errorf("flags length %d: expected error", length)
+		}
+	}
+	for length := 8; length < len(sample); length++ {
+		_, _, err := w.processWatchEvent(t.Context(), &ringbuf.Record{RawSample: sample[:length]})
+		if err == nil {
+			t.Errorf("bind length %d: expected error", length)
+		}
+	}
+	assertNoEvent(t, events)
+}
+
+func TestProcessWatchEventEmitsDecodedBind(t *testing.T) {
+	events := make(chan Event, 2)
+	_, ignore, err := New(&obi.Config{}, events).processWatchEvent(t.Context(), &ringbuf.Record{RawSample: watchSample(1, 8080)})
+	if err != nil || !ignore {
+		t.Fatalf("process bind event: ignore=%t, error=%v", ignore, err)
+	}
+	if event := testutil.ReadChannel(t, events, time.Second); event != (Event{Type: NewPort, Payload: 8080}) {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+	assertNoEvent(t, events)
+}
+
+func TestProcessWatchEventIgnoresUnknownFlags(t *testing.T) {
+	events := make(chan Event, 1)
+	_, ignore, err := New(&obi.Config{}, events).processWatchEvent(t.Context(), &ringbuf.Record{RawSample: watchSample(2, 8080)[:8]})
+	if err != nil {
+		t.Fatalf("process unknown event: %v", err)
+	}
+	if !ignore {
+		t.Fatal("unknown watcher event must not be forwarded as a span")
+	}
+	assertNoEvent(t, events)
+}
+
+func TestRunReturnsWhenBufferedReadySendIsCanceled(t *testing.T) {
+	events := make(chan Event, 100)
+	w := New(&obi.Config{}, events)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	forwarded := false
+	w.forward = func(context.Context, watchEventParser) { forwarded = true }
+	w.Run(ctx)
+	if !forwarded {
+		t.Fatal("canceled Run did not reach the forwarder")
+	}
+	assertNoEvent(t, events)
+}
+
+func TestBlockedReadySendStopsOnCancellation(t *testing.T) {
+	events := make(chan Event)
+	base, cancel := context.WithCancel(t.Context())
+	ctx := checkedContext{Context: base, checked: make(chan struct{})}
+	done := make(chan error, 1)
+	go func() { done <- New(&obi.Config{}, events).sendEvent(ctx, Event{Type: Ready}) }()
+	testutil.ReadChannel(t, ctx.checked, time.Second)
+	cancel()
+	if err := testutil.ReadChannel(t, done, time.Second); !errors.Is(err, context.Canceled) {
+		t.Fatalf("send ready event: %v", err)
+	}
+	assertNoEvent(t, events)
+}
+
+func TestRunEmitsOneReadyAndStopsOnCancellation(t *testing.T) {
+	events := make(chan Event, 100)
+	w := New(&obi.Config{}, events)
+	ctx, cancel := context.WithCancel(t.Context())
+	parseErr := make(chan error, 1)
+	w.forward = func(ctx context.Context, parse watchEventParser) {
+		<-ctx.Done()
+		_, _, err := parse(&ringbuf.Record{RawSample: watchSample(1, 8080)})
+		parseErr <- err
+	}
+	done := make(chan struct{})
+	go func() { w.Run(ctx); close(done) }()
+	if event := testutil.ReadChannel(t, events, time.Second); event != (Event{Type: Ready}) {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+	cancel()
+	if err := testutil.ReadChannel(t, parseErr, time.Second); !errors.Is(err, context.Canceled) {
+		t.Fatalf("process bind event: %v", err)
+	}
+	testutil.ReadChannel(t, done, time.Second)
+	assertNoEvent(t, events)
+}
+
+func watchSample(flags, payload uint64) []byte {
+	sample := make([]byte, 16)
+	binary.LittleEndian.PutUint64(sample, flags)
+	binary.LittleEndian.PutUint64(sample[8:], payload)
+	return sample
+}
+
+func assertNoEvent(t *testing.T, events <-chan Event) {
+	t.Helper()
+	select {
+	case event := <-events:
+		t.Fatalf("unexpected event: %+v", event)
+	default:
+	}
+}
+
+type checkedContext struct {
+	context.Context
+	checked chan struct{}
+}
+
+func (c checkedContext) Err() error {
+	err := c.Context.Err()
+	if err == nil {
+		close(c.checked)
+	}
+	return err
+}

--- a/pkg/internal/ebpf/watcher/watcher_test.go
+++ b/pkg/internal/ebpf/watcher/watcher_test.go
@@ -18,7 +18,7 @@ import (
 func TestProcessWatchEventRejectsTruncatedRecords(t *testing.T) {
 	events := make(chan Event, 1)
 	w := New(&obi.Config{}, events)
-	sample := watchSample(1, 8080)
+	sample := watchSample(1)
 	for length := 0; length < 8; length++ {
 		_, _, err := w.processWatchEvent(t.Context(), &ringbuf.Record{RawSample: sample[:length]})
 		if err == nil {
@@ -36,7 +36,7 @@ func TestProcessWatchEventRejectsTruncatedRecords(t *testing.T) {
 
 func TestProcessWatchEventEmitsDecodedBind(t *testing.T) {
 	events := make(chan Event, 2)
-	_, ignore, err := New(&obi.Config{}, events).processWatchEvent(t.Context(), &ringbuf.Record{RawSample: watchSample(1, 8080)})
+	_, ignore, err := New(&obi.Config{}, events).processWatchEvent(t.Context(), &ringbuf.Record{RawSample: watchSample(1)})
 	if err != nil || !ignore {
 		t.Fatalf("process bind event: ignore=%t, error=%v", ignore, err)
 	}
@@ -48,7 +48,7 @@ func TestProcessWatchEventEmitsDecodedBind(t *testing.T) {
 
 func TestProcessWatchEventIgnoresUnknownFlags(t *testing.T) {
 	events := make(chan Event, 1)
-	_, ignore, err := New(&obi.Config{}, events).processWatchEvent(t.Context(), &ringbuf.Record{RawSample: watchSample(2, 8080)[:8]})
+	_, ignore, err := New(&obi.Config{}, events).processWatchEvent(t.Context(), &ringbuf.Record{RawSample: watchSample(2)[:8]})
 	if err != nil {
 		t.Fatalf("process unknown event: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestRunEmitsOneReadyAndStopsOnCancellation(t *testing.T) {
 	parseErr := make(chan error, 1)
 	w.forward = func(ctx context.Context, parse watchEventParser) {
 		<-ctx.Done()
-		_, _, err := parse(&ringbuf.Record{RawSample: watchSample(1, 8080)})
+		_, _, err := parse(&ringbuf.Record{RawSample: watchSample(1)})
 		parseErr <- err
 	}
 	done := make(chan struct{})
@@ -109,10 +109,10 @@ func TestRunEmitsOneReadyAndStopsOnCancellation(t *testing.T) {
 	assertNoEvent(t, events)
 }
 
-func watchSample(flags, payload uint64) []byte {
+func watchSample(flags uint64) []byte {
 	sample := make([]byte, 16)
 	binary.LittleEndian.PutUint64(sample, flags)
-	binary.LittleEndian.PutUint64(sample[8:], payload)
+	binary.LittleEndian.PutUint64(sample[8:], 8080)
 	return sample
 }
 


### PR DESCRIPTION
## Summary

- reject truncated watcher bind records instead of accepting partial payloads
- make Ready and NewPort delivery cancellation-aware while preserving ring-buffer cleanup ownership
- add deterministic fixed-wire, cancellation, callback, and startup lifecycle coverage

## Testing

- `go test -race -count=1 -timeout=3m ./pkg/internal/ebpf/watcher`
- `go test -race -shuffle=on -count=100 -timeout=3m ./pkg/internal/ebpf/watcher`
- `go vet ./pkg/internal/ebpf/watcher`