### PR TITLE
Harden TC manager lifecycle handling

### DIFF
--- a/pkg/internal/ebpf/tcmanager/error_reporter.go
+++ b/pkg/internal/ebpf/tcmanager/error_reporter.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tcmanager // import "go.opentelemetry.io/obi/pkg/internal/ebpf/tcmanager"
+
+import "sync"
+
+const errorBufferLen = 16
+
+type errorReporter struct {
+	mutex  sync.RWMutex
+	errors chan error
+	closed bool
+}
+
+func newErrorReporter() errorReporter {
+	return errorReporter{errors: make(chan error, errorBufferLen)}
+}
+
+func (r *errorReporter) channel() chan error {
+	return r.errors
+}
+
+func (r *errorReporter) emit(err error) {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	if r.closed {
+		return
+	}
+
+	select {
+	case r.errors <- err:
+	default:
+	}
+}
+
+func (r *errorReporter) close() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.closed {
+		return
+	}
+
+	r.closed = true
+	close(r.errors)
+}

--- a/pkg/internal/ebpf/tcmanager/error_reporter.go
+++ b/pkg/internal/ebpf/tcmanager/error_reporter.go
@@ -10,20 +10,17 @@ import "sync"
 const errorBufferLen = 16
 
 type errorReporter struct {
+	// mutex prevents close from racing with a send to ch.
 	mutex  sync.RWMutex
-	errors chan error
+	ch     chan error
 	closed bool
 }
 
 func newErrorReporter() errorReporter {
-	return errorReporter{errors: make(chan error, errorBufferLen)}
+	return errorReporter{ch: make(chan error, errorBufferLen)}
 }
 
-func (r *errorReporter) channel() chan error {
-	return r.errors
-}
-
-func (r *errorReporter) emit(err error) {
+func (r *errorReporter) enqueue(err error) {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
 
@@ -32,7 +29,7 @@ func (r *errorReporter) emit(err error) {
 	}
 
 	select {
-	case r.errors <- err:
+	case r.ch <- err:
 	default:
 	}
 }
@@ -46,5 +43,5 @@ func (r *errorReporter) close() {
 	}
 
 	r.closed = true
-	close(r.errors)
+	close(r.ch)
 }

--- a/pkg/internal/ebpf/tcmanager/error_reporter.go
+++ b/pkg/internal/ebpf/tcmanager/error_reporter.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build linux
+
 package tcmanager // import "go.opentelemetry.io/obi/pkg/internal/ebpf/tcmanager"
 
 import "sync"

--- a/pkg/internal/ebpf/tcmanager/error_reporter.go
+++ b/pkg/internal/ebpf/tcmanager/error_reporter.go
@@ -20,6 +20,8 @@ func newErrorReporter() errorReporter {
 	return errorReporter{ch: make(chan error, errorBufferLen)}
 }
 
+// enqueue does not block because callers may hold a manager mutex. If the
+// buffer is full, emitError has already logged the dropped error.
 func (r *errorReporter) enqueue(err error) {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()

--- a/pkg/internal/ebpf/tcmanager/lifecycle_test.go
+++ b/pkg/internal/ebpf/tcmanager/lifecycle_test.go
@@ -1,0 +1,453 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package tcmanager
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	"go.opentelemetry.io/obi/pkg/internal/netolly/ifaces"
+)
+
+const lifecycleTestTimeout = time.Second
+
+func TestManagersDeliverUnconsumedCallbackErrors(t *testing.T) {
+	for name, newManager := range managerFactories() {
+		t.Run(name, func(t *testing.T) {
+			manager := newManager()
+			interfaces := NewInterfaceManager()
+			manager.SetInterfaceManager(interfaces)
+
+			callbackErr := errors.New("callback failed")
+			requireCompletes(t, func() { interfaces.emitError(callbackErr) })
+
+			select {
+			case err := <-manager.Errors():
+				require.ErrorContains(t, err, callbackErr.Error())
+			case <-time.After(lifecycleTestTimeout):
+				t.Fatal("callback error was not delivered")
+			}
+
+			manager.Shutdown()
+		})
+	}
+}
+
+func TestManagerAddRemoveDoesNotWaitForErrorConsumer(t *testing.T) {
+	for name, newManager := range managerFactories() {
+		t.Run(name, func(t *testing.T) {
+			manager := newManager()
+			interfaces := prepareInvalidAttachment(manager)
+
+			requireCompletes(t, func() {
+				manager.AddProgram("invalid", nil, AttachmentType(255))
+			})
+			assertNextErrorContains(t, manager.Errors(), "invalid attachment type")
+			requireCompletes(t, func() { manager.RemoveProgram("invalid") })
+
+			manager.Shutdown()
+			assertCallbacksEmpty(t, interfaces)
+		})
+	}
+}
+
+func TestManagersReportProgramCloseFailures(t *testing.T) {
+	for name, newManager := range managerFactories() {
+		t.Run(name, func(t *testing.T) {
+			manager := newManager()
+			manager.AddProgram("close-fails", nil, AttachmentIngress)
+
+			closeErr := errors.New("closing program failed")
+			switch typedManager := manager.(type) {
+			case *netlinkManager:
+				typedManager.programs[0].closeFn = func() error { return closeErr }
+			case *tcxManager:
+				typedManager.programs[0].closeFn = func() error { return closeErr }
+			}
+
+			requireCompletes(t, func() { manager.RemoveProgram("close-fails") })
+			assertNextErrorContains(t, manager.Errors(), closeErr.Error())
+			assertProgramsEmpty(t, manager)
+			manager.Shutdown()
+		})
+	}
+}
+
+func TestInterfaceRemovalReleasesResources(t *testing.T) {
+	for name, newManager := range managerFactories() {
+		t.Run(name, func(t *testing.T) {
+			manager := newManager()
+			interfaces := NewInterfaceManager()
+			manager.SetInterfaceManager(interfaces)
+			iface := &ifaces.Interface{Index: 42, Name: "test"}
+
+			var linkCloses atomic.Int32
+			switch typedManager := manager.(type) {
+			case *netlinkManager:
+				typedManager.interfaces[iface.Index] = &netlinkIface{Interface: iface}
+			case *tcxManager:
+				typedManager.links = append(typedManager.links, &ifaceLink{
+					progName: "test",
+					iface:    iface.Index,
+					closeFn: func() error {
+						linkCloses.Add(1)
+						return nil
+					},
+				})
+			}
+
+			requireCompletes(t, func() { interfaces.onInterfaceRemoved(iface) })
+			switch typedManager := manager.(type) {
+			case *netlinkManager:
+				assert.NotContains(t, typedManager.interfaces, iface.Index)
+			case *tcxManager:
+				assert.Empty(t, typedManager.links)
+				assert.EqualValues(t, 1, linkCloses.Load())
+			}
+
+			manager.Shutdown()
+		})
+	}
+}
+
+func TestTCXInterfaceRemovalReportsLinkCloseFailure(t *testing.T) {
+	manager := NewTCXManager().(*tcxManager)
+	interfaces := NewInterfaceManager()
+	manager.SetInterfaceManager(interfaces)
+	iface := &ifaces.Interface{Index: 42, Name: "test"}
+	closeErr := errors.New("closing link failed")
+	manager.links = append(manager.links, &ifaceLink{
+		progName: "test",
+		iface:    iface.Index,
+		closeFn:  func() error { return closeErr },
+	})
+
+	requireCompletes(t, func() { interfaces.onInterfaceRemoved(iface) })
+	assertNextErrorContains(t, manager.Errors(), closeErr.Error())
+	assert.Empty(t, manager.links)
+	manager.Shutdown()
+}
+
+func TestShutdownUnregistersCallbacksBeforeCleanup(t *testing.T) {
+	for name, newManager := range managerFactories() {
+		t.Run(name, func(t *testing.T) {
+			manager := newManager()
+			interfaces := NewInterfaceManager()
+			manager.SetInterfaceManager(interfaces)
+			callbacks := snapshotCallbacks(t, manager, interfaces)
+
+			checkedOrder := false
+			checkOrder := func() error {
+				assertCallbacksEmpty(t, interfaces)
+				checkedOrder = true
+				return nil
+			}
+			switch typedManager := manager.(type) {
+			case *netlinkManager:
+				typedManager.programs = append(typedManager.programs, &netlinkProg{
+					name: "test", closeFn: checkOrder,
+				})
+			case *tcxManager:
+				typedManager.links = append(typedManager.links, &ifaceLink{
+					progName: "test", iface: 42, closeFn: checkOrder,
+				})
+			}
+
+			requireCompletes(t, manager.Shutdown)
+			assert.True(t, checkedOrder)
+			assertCallbacksEmpty(t, interfaces)
+
+			lateIface := &ifaces.Interface{Index: 43, Name: "late"}
+			assertLateStateCallbacksAreNoOps(t, manager, callbacks, lateIface)
+			requireCompletes(t, func() { callbacks.failed(errors.New("late callback")) })
+			assertErrorChannelClosed(t, manager.Errors())
+		})
+	}
+}
+
+func assertLateStateCallbacksAreNoOps(
+	t *testing.T, manager TCManager, callbacks savedCallbacks, lateIface *ifaces.Interface,
+) {
+	t.Helper()
+
+	var addedCalls atomic.Int32
+	var linkCloses atomic.Int32
+
+	switch typedManager := manager.(type) {
+	case *netlinkManager:
+		sentinel := &netlinkIface{Interface: lateIface}
+		typedManager.interfaces[lateIface.Index] = sentinel
+		typedManager.installQdiscFn = func(*ifaces.Interface) *netlink.GenericQdisc {
+			addedCalls.Add(1)
+			return &netlink.GenericQdisc{}
+		}
+
+		requireCompletes(t, func() { callbacks.added(lateIface) })
+		assert.Zero(t, addedCalls.Load())
+		assert.Same(t, sentinel, typedManager.interfaces[lateIface.Index])
+
+		requireCompletes(t, func() { callbacks.removed(lateIface) })
+		assert.Same(t, sentinel, typedManager.interfaces[lateIface.Index])
+	case *tcxManager:
+		typedManager.programs = append(typedManager.programs, &attachedProg{name: "late"})
+		typedManager.attachProgramFn = func(*attachedProg, int) { addedCalls.Add(1) }
+		sentinel := &ifaceLink{
+			progName: "late",
+			iface:    lateIface.Index,
+			closeFn:  func() error { linkCloses.Add(1); return nil },
+		}
+		typedManager.links = append(typedManager.links, sentinel)
+
+		requireCompletes(t, func() { callbacks.added(lateIface) })
+		assert.Zero(t, addedCalls.Load())
+		assert.Equal(t, []*ifaceLink{sentinel}, typedManager.links)
+
+		requireCompletes(t, func() { callbacks.removed(lateIface) })
+		assert.Zero(t, linkCloses.Load())
+		assert.Equal(t, []*ifaceLink{sentinel}, typedManager.links)
+	}
+}
+
+func TestConcurrentShutdownIsSafe(t *testing.T) {
+	for name, newManager := range managerFactories() {
+		t.Run(name, func(t *testing.T) {
+			manager := newManager()
+			interfaces := NewInterfaceManager()
+			manager.SetInterfaceManager(interfaces)
+
+			operations := make([]func(), 32)
+			for i := range operations {
+				operations[i] = manager.Shutdown
+			}
+			requireConcurrentOperations(t, operations...)
+			requireCompletes(t, manager.Shutdown)
+
+			assertCallbacksEmpty(t, interfaces)
+			assertErrorChannelClosed(t, manager.Errors())
+		})
+	}
+}
+
+func TestConcurrentLifecycleOperationsAreSafe(t *testing.T) {
+	for name, newManager := range managerFactories() {
+		t.Run(name, func(t *testing.T) {
+			manager := newManager()
+			interfaces := prepareInvalidAttachment(manager)
+			iface := &ifaces.Interface{Index: 42, Name: "test"}
+
+			operations := make([]func(), 0, 64)
+			for i := 0; i < 16; i++ {
+				programName := fmt.Sprintf("program-%d", i)
+				operations = append(operations,
+					func() { manager.AddProgram(programName, nil, AttachmentType(255)) },
+					func() { manager.RemoveProgram(programName) },
+					func() { interfaces.emitError(errors.New("callback failed")) },
+					func() { interfaces.onInterfaceRemoved(iface) },
+				)
+			}
+			operations = append(operations, manager.Shutdown, manager.Shutdown)
+
+			requireConcurrentOperations(t, operations...)
+			manager.Shutdown()
+			assertCallbacksEmpty(t, interfaces)
+			assertErrorChannelClosed(t, manager.Errors())
+		})
+	}
+}
+
+func TestManagersLogCleanupErrorsWhenErrorChannelIsFull(t *testing.T) {
+	for name, newManager := range managerFactories() {
+		t.Run(name, func(t *testing.T) {
+			manager := newManager()
+			var logs bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logs, nil))
+			closeErr := errors.New("cleanup close failed")
+
+			switch typedManager := manager.(type) {
+			case *netlinkManager:
+				typedManager.log = logger
+				typedManager.programs = append(typedManager.programs, &netlinkProg{
+					name: "test", closeFn: func() error { return closeErr },
+				})
+			case *tcxManager:
+				typedManager.log = logger
+				typedManager.links = append(typedManager.links, &ifaceLink{
+					progName: "test", iface: 42, closeFn: func() error { return closeErr },
+				})
+			}
+
+			for i := 0; i < cap(manager.Errors()); i++ {
+				manager.Errors() <- fmt.Errorf("queued error %d", i)
+			}
+			requireCompletes(t, manager.Shutdown)
+
+			assert.Contains(t, logs.String(), closeErr.Error())
+			assertErrorChannelClosed(t, manager.Errors())
+		})
+	}
+}
+
+type savedCallbacks struct {
+	added   InterfaceManagerCB
+	removed InterfaceManagerCB
+	failed  InterfaceManagerErrorCB
+}
+
+func managerFactories() map[string]func() TCManager {
+	return map[string]func() TCManager{
+		"netlink": NewNetlinkManager,
+		"tcx":     NewTCXManager,
+	}
+}
+
+func prepareInvalidAttachment(manager TCManager) *InterfaceManager {
+	interfaces := NewInterfaceManager()
+	iface := &ifaces.Interface{Index: 42, Name: "test"}
+	interfaces.interfaces[iface.Index] = iface
+	manager.SetInterfaceManager(interfaces)
+
+	if typedManager, ok := manager.(*netlinkManager); ok {
+		typedManager.interfaces[iface.Index] = &netlinkIface{Interface: iface}
+	}
+
+	return interfaces
+}
+
+func snapshotCallbacks(t *testing.T, manager TCManager, interfaces *InterfaceManager) savedCallbacks {
+	t.Helper()
+
+	interfaces.mutex.Lock()
+	defer interfaces.mutex.Unlock()
+
+	var addedID, removedID, errorID uint64
+	switch typedManager := manager.(type) {
+	case *netlinkManager:
+		addedID = typedManager.addedCallbackID
+		removedID = typedManager.removedCallbackID
+		errorID = typedManager.errorCallbackID
+	case *tcxManager:
+		addedID = typedManager.addedCallbackID
+		removedID = typedManager.removedCallbackID
+		errorID = typedManager.errorCallbackID
+	}
+
+	return savedCallbacks{
+		added:   requireCallback(t, interfaces.ifaceAddedCallbacks, addedID),
+		removed: requireCallback(t, interfaces.ifaceRemovedCallbacks, removedID),
+		failed:  requireCallback(t, interfaces.ifaceErrorCallbacks, errorID),
+	}
+}
+
+func requireCallback[T any](t *testing.T, callbacks map[uint64]T, id uint64) T {
+	t.Helper()
+	callback, ok := callbacks[id]
+	require.True(t, ok)
+	return callback
+}
+
+func assertCallbacksEmpty(t *testing.T, interfaces *InterfaceManager) {
+	t.Helper()
+
+	interfaces.mutex.Lock()
+	defer interfaces.mutex.Unlock()
+	assert.Empty(t, interfaces.ifaceAddedCallbacks)
+	assert.Empty(t, interfaces.ifaceRemovedCallbacks)
+	assert.Empty(t, interfaces.ifaceErrorCallbacks)
+}
+
+func assertProgramsEmpty(t *testing.T, manager TCManager) {
+	t.Helper()
+	switch typedManager := manager.(type) {
+	case *netlinkManager:
+		assert.Empty(t, typedManager.programs)
+	case *tcxManager:
+		assert.Empty(t, typedManager.programs)
+	}
+}
+
+func assertNextErrorContains(t *testing.T, errors <-chan error, substring string) {
+	t.Helper()
+	select {
+	case err := <-errors:
+		require.ErrorContains(t, err, substring)
+	case <-time.After(lifecycleTestTimeout):
+		t.Fatalf("error containing %q was not delivered", substring)
+	}
+}
+
+func assertErrorChannelClosed(t *testing.T, errors <-chan error) {
+	t.Helper()
+	timer := time.NewTimer(lifecycleTestTimeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case _, ok := <-errors:
+			if !ok {
+				return
+			}
+		case <-timer.C:
+			t.Fatal("error channel did not close")
+		}
+	}
+}
+
+func requireConcurrentOperations(t *testing.T, operations ...func()) {
+	t.Helper()
+
+	start := make(chan struct{})
+	results := make(chan any, len(operations))
+	var ready sync.WaitGroup
+	ready.Add(len(operations))
+	for _, operation := range operations {
+		go func() {
+			ready.Done()
+			<-start
+			defer func() { results <- recover() }()
+			operation()
+		}()
+	}
+	ready.Wait()
+	close(start)
+
+	timer := time.NewTimer(lifecycleTestTimeout)
+	defer timer.Stop()
+	for range operations {
+		select {
+		case panicValue := <-results:
+			require.Nil(t, panicValue, "operation panicked: %v", panicValue)
+		case <-timer.C:
+			t.Fatalf("operations did not complete within %s", lifecycleTestTimeout)
+		}
+	}
+}
+
+func requireCompletes(t *testing.T, operation func()) {
+	t.Helper()
+
+	result := make(chan any, 1)
+	go func() {
+		defer func() { result <- recover() }()
+		operation()
+	}()
+
+	select {
+	case panicValue := <-result:
+		require.Nil(t, panicValue, "operation panicked: %v", panicValue)
+	case <-time.After(lifecycleTestTimeout):
+		t.Fatalf("operation did not complete within %s", lifecycleTestTimeout)
+	}
+}

--- a/pkg/internal/ebpf/tcmanager/lifecycle_test.go
+++ b/pkg/internal/ebpf/tcmanager/lifecycle_test.go
@@ -86,6 +86,27 @@ func TestManagersReportProgramCloseFailures(t *testing.T) {
 	}
 }
 
+func TestShutdownClosesPrograms(t *testing.T) {
+	for name, newManager := range managerFactories() {
+		t.Run(name, func(t *testing.T) {
+			manager := newManager()
+			manager.AddProgram("test", nil, AttachmentIngress)
+
+			var closes atomic.Int32
+			switch typedManager := manager.(type) {
+			case *netlinkManager:
+				typedManager.programs[0].closeFn = func() error { closes.Add(1); return nil }
+			case *tcxManager:
+				typedManager.programs[0].closeFn = func() error { closes.Add(1); return nil }
+			}
+
+			requireCompletes(t, manager.Shutdown)
+			assert.EqualValues(t, 1, closes.Load())
+			assertProgramsEmpty(t, manager)
+		})
+	}
+}
+
 func TestInterfaceRemovalReleasesResources(t *testing.T) {
 	for name, newManager := range managerFactories() {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/internal/ebpf/tcmanager/netlinkmanager.go
+++ b/pkg/internal/ebpf/tcmanager/netlinkmanager.go
@@ -36,11 +36,7 @@ type netlinkProg struct {
 }
 
 func (p *netlinkProg) Close() error {
-	if p.closeFn != nil {
-		return p.closeFn()
-	}
-
-	return p.Program.Close()
+	return closeWith(p.closeFn, p.Program)
 }
 
 type netlinkIface struct {

--- a/pkg/internal/ebpf/tcmanager/netlinkmanager.go
+++ b/pkg/internal/ebpf/tcmanager/netlinkmanager.go
@@ -168,7 +168,7 @@ func (tc *netlinkManager) RemoveProgram(name string) {
 }
 
 func (tc *netlinkManager) Errors() chan error {
-	return tc.errors.channel()
+	return tc.errors.ch
 }
 
 func (tc *netlinkManager) attachProgramLocked(prog *netlinkProg) {
@@ -411,7 +411,7 @@ func (tc *netlinkManager) emitError(msg string, args ...any) {
 	formattedArgs := fmt.Sprint(args...)
 	compositeError := fmt.Errorf("%s: %s", msg, formattedArgs)
 
-	tc.errors.emit(compositeError)
+	tc.errors.enqueue(compositeError)
 }
 
 // doIgnoreNoDev runs the provided syscall over the provided device and ignores the error

--- a/pkg/internal/ebpf/tcmanager/netlinkmanager.go
+++ b/pkg/internal/ebpf/tcmanager/netlinkmanager.go
@@ -32,6 +32,15 @@ type netlinkProg struct {
 	*ebpf.Program
 	name       string
 	attachType AttachmentType
+	closeFn    func() error
+}
+
+func (p *netlinkProg) Close() error {
+	if p.closeFn != nil {
+		return p.closeFn()
+	}
+
+	return p.Program.Close()
 }
 
 type netlinkIface struct {
@@ -51,7 +60,9 @@ type netlinkManager struct {
 	addedCallbackID   uint64
 	removedCallbackID uint64
 	errorCallbackID   uint64
-	errorCh           chan error
+	errors            errorReporter
+	installQdiscFn    func(*ifaces.Interface) *netlink.GenericQdisc
+	shutdown          bool
 }
 
 func netlinkAttachType(attachment AttachmentType) (uint32, error) {
@@ -66,24 +77,26 @@ func netlinkAttachType(attachment AttachmentType) (uint32, error) {
 }
 
 func NewNetlinkManager() TCManager {
-	return &netlinkManager{
+	tc := &netlinkManager{
 		ifaceManager: nil,
 		interfaces:   netlinkIfaceMap{},
 		programs:     []*netlinkProg{},
 		log:          slog.With("component", "tc_manager_netlink"),
 		mutex:        sync.Mutex{},
-		errorCh:      make(chan error),
+		errors:       newErrorReporter(),
 	}
+	tc.installQdiscFn = tc.installQdisc
+	return tc
 }
 
 func (tc *netlinkManager) SetInterfaceManager(im *InterfaceManager) {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
 
-	if tc.ifaceManager != nil {
-		tc.ifaceManager.RemoveCallback(tc.addedCallbackID)
-		tc.ifaceManager.RemoveCallback(tc.removedCallbackID)
-		tc.ifaceManager.RemoveCallback(tc.errorCallbackID)
+	tc.unregisterCallbacksLocked()
+
+	if tc.shutdown {
+		return
 	}
 
 	if im != nil {
@@ -95,16 +108,33 @@ func (tc *netlinkManager) SetInterfaceManager(im *InterfaceManager) {
 	tc.ifaceManager = im
 }
 
+func (tc *netlinkManager) unregisterCallbacksLocked() {
+	if tc.ifaceManager == nil {
+		return
+	}
+
+	tc.ifaceManager.RemoveCallback(tc.addedCallbackID)
+	tc.ifaceManager.RemoveCallback(tc.removedCallbackID)
+	tc.ifaceManager.RemoveCallback(tc.errorCallbackID)
+	tc.ifaceManager = nil
+}
+
 func (tc *netlinkManager) Shutdown() {
 	tc.log.Debug("TC initiated shutdown")
 
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
 
+	if tc.shutdown {
+		return
+	}
+	tc.shutdown = true
+
+	tc.unregisterCallbacksLocked()
 	tc.cleanupInterfacesLocked()
 	tc.cleanupProgsLocked()
 
-	close(tc.errorCh)
+	tc.errors.close()
 
 	tc.log.Debug("TC completed shutdown")
 }
@@ -112,6 +142,9 @@ func (tc *netlinkManager) Shutdown() {
 func (tc *netlinkManager) AddProgram(name string, prog *ebpf.Program, attachment AttachmentType) {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
+	if tc.shutdown {
+		return
+	}
 
 	p := &netlinkProg{
 		Program:    prog,
@@ -126,13 +159,16 @@ func (tc *netlinkManager) AddProgram(name string, prog *ebpf.Program, attachment
 func (tc *netlinkManager) RemoveProgram(name string) {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
+	if tc.shutdown {
+		return
+	}
 
 	tc.detachProgramLocked(name)
 	tc.removeProgramLocked(name)
 }
 
 func (tc *netlinkManager) Errors() chan error {
-	return tc.errorCh
+	return tc.errors.channel()
 }
 
 func (tc *netlinkManager) attachProgramLocked(prog *netlinkProg) {
@@ -225,8 +261,11 @@ func (tc *netlinkManager) removeProgramLocked(name string) {
 func (tc *netlinkManager) onInterfaceAdded(i *ifaces.Interface) {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
+	if tc.shutdown {
+		return
+	}
 
-	qdisc := tc.installQdisc(i)
+	qdisc := tc.installQdiscFn(i)
 
 	if qdisc == nil {
 		tc.log.Debug("Unable to install qdisc, ignoring interface", "interface", i.Name)
@@ -244,6 +283,9 @@ func (tc *netlinkManager) onInterfaceAdded(i *ifaces.Interface) {
 func (tc *netlinkManager) onInterfaceRemoved(iface *ifaces.Interface) {
 	tc.mutex.Lock()
 	defer tc.mutex.Unlock()
+	if tc.shutdown {
+		return
+	}
 
 	// links, qdiscs and other associated resources are automatically removed
 	// when an interface is removed, there's no need to explicitly remove them
@@ -355,7 +397,9 @@ func ifaceHasFilters(iface *netlinkIface, parent uint32) bool {
 func (tc *netlinkManager) cleanupProgsLocked() {
 	for _, prog := range tc.programs {
 		tc.log.Debug("closing tc program", "name", prog.name)
-		prog.Close()
+		if err := prog.Close(); err != nil {
+			tc.emitError("Failed to close program", "program", prog.name, "error", err)
+		}
 	}
 
 	tc.programs = []*netlinkProg{}
@@ -367,7 +411,7 @@ func (tc *netlinkManager) emitError(msg string, args ...any) {
 	formattedArgs := fmt.Sprint(args...)
 	compositeError := fmt.Errorf("%s: %s", msg, formattedArgs)
 
-	tc.errorCh <- compositeError
+	tc.errors.emit(compositeError)
 }
 
 // doIgnoreNoDev runs the provided syscall over the provided device and ignores the error

--- a/pkg/internal/ebpf/tcmanager/tcmanager_privileged_test.go
+++ b/pkg/internal/ebpf/tcmanager/tcmanager_privileged_test.go
@@ -116,7 +116,6 @@ func TestTCXManagerNoErrOnMissingIface(t *testing.T) {
 	defer progs.Egress.Close()
 
 	tcx := NewTCXManager().(*tcxManager)
-	tcx.errorCh = make(chan error, 1)
 
 	tcx.attachProgramToIfaceLocked(&attachedProg{
 		Program:    progs.Ingress,
@@ -125,12 +124,11 @@ func TestTCXManagerNoErrOnMissingIface(t *testing.T) {
 	}, missingIfaceIndex)
 
 	assert.Empty(t, tcx.links)
-	assert.Empty(t, tcx.errorCh)
+	assert.Empty(t, tcx.Errors())
 }
 
 func TestNetlinkManagerNoErrOnMissingIfaceQdisc(t *testing.T) {
 	tc := NewNetlinkManager().(*netlinkManager)
-	tc.errorCh = make(chan error, 1)
 
 	qdisc := tc.installQdisc(&ifaces.Interface{
 		Index: missingIfaceIndex,
@@ -138,7 +136,7 @@ func TestNetlinkManagerNoErrOnMissingIfaceQdisc(t *testing.T) {
 	})
 
 	assert.Nil(t, qdisc)
-	assert.Empty(t, tc.errorCh)
+	assert.Empty(t, tc.Errors())
 }
 
 func TestNetlinkManagerNoErrOnMissingIface(t *testing.T) {
@@ -147,7 +145,6 @@ func TestNetlinkManagerNoErrOnMissingIface(t *testing.T) {
 	defer progs.Egress.Close()
 
 	tc := NewNetlinkManager().(*netlinkManager)
-	tc.errorCh = make(chan error, 1)
 
 	iface := &netlinkIface{
 		Interface: &ifaces.Interface{
@@ -163,7 +160,7 @@ func TestNetlinkManagerNoErrOnMissingIface(t *testing.T) {
 	}, iface)
 
 	assert.Empty(t, iface.filters)
-	assert.Empty(t, tc.errorCh)
+	assert.Empty(t, tc.Errors())
 }
 
 func isBpfProgLoaded(name string) (bool, error) {

--- a/pkg/internal/ebpf/tcmanager/tcxmanager.go
+++ b/pkg/internal/ebpf/tcmanager/tcxmanager.go
@@ -26,11 +26,7 @@ type attachedProg struct {
 }
 
 func (p *attachedProg) Close() error {
-	if p.closeFn != nil {
-		return p.closeFn()
-	}
-
-	return p.Program.Close()
+	return closeWith(p.closeFn, p.Program)
 }
 
 type ifaceLink struct {
@@ -41,11 +37,7 @@ type ifaceLink struct {
 }
 
 func (l *ifaceLink) Close() error {
-	if l.closeFn != nil {
-		return l.closeFn()
-	}
-
-	return l.Link.Close()
+	return closeWith(l.closeFn, l.Link)
 }
 
 type tcxManager struct {
@@ -142,8 +134,7 @@ func (tcx *tcxManager) Shutdown() {
 
 	tcx.unregisterCallbacksLocked()
 	tcx.cleanupLinksLocked()
-
-	tcx.programs = []*attachedProg{}
+	tcx.cleanupProgsLocked()
 	tcx.errors.close()
 
 	tcx.log.Debug("TCX completed shutdown")
@@ -292,6 +283,17 @@ func (tcx *tcxManager) cleanupLinksLocked() {
 	}
 
 	tcx.links = []*ifaceLink{}
+}
+
+func (tcx *tcxManager) cleanupProgsLocked() {
+	for _, prog := range tcx.programs {
+		tcx.log.Debug("closing tcx program", "name", prog.name)
+		if err := prog.Close(); err != nil {
+			tcx.emitError("Failed to close program", "program", prog.name, "error", err)
+		}
+	}
+
+	tcx.programs = []*attachedProg{}
 }
 
 func (tcx *tcxManager) onIfaceManagerError(err error) {

--- a/pkg/internal/ebpf/tcmanager/tcxmanager.go
+++ b/pkg/internal/ebpf/tcmanager/tcxmanager.go
@@ -22,12 +22,30 @@ type attachedProg struct {
 	*ebpf.Program
 	attachType AttachmentType
 	name       string
+	closeFn    func() error
+}
+
+func (p *attachedProg) Close() error {
+	if p.closeFn != nil {
+		return p.closeFn()
+	}
+
+	return p.Program.Close()
 }
 
 type ifaceLink struct {
 	link.Link
 	progName string
 	iface    int
+	closeFn  func() error
+}
+
+func (l *ifaceLink) Close() error {
+	if l.closeFn != nil {
+		return l.closeFn()
+	}
+
+	return l.Link.Close()
 }
 
 type tcxManager struct {
@@ -39,22 +57,26 @@ type tcxManager struct {
 	addedCallbackID   uint64
 	removedCallbackID uint64
 	errorCallbackID   uint64
-	errorCh           chan error
+	errors            errorReporter
+	attachProgramFn   func(*attachedProg, int)
+	shutdown          bool
 }
 
 func NewTCXManager() TCManager {
-	return &tcxManager{
+	tcx := &tcxManager{
 		ifaceManager: nil,
 		programs:     []*attachedProg{},
 		links:        []*ifaceLink{},
 		log:          slog.With("component", "tcx_manager"),
 		mutex:        sync.Mutex{},
-		errorCh:      make(chan error),
+		errors:       newErrorReporter(),
 	}
+	tcx.attachProgramFn = tcx.attachProgramToIfaceLocked
+	return tcx
 }
 
 func (tcx *tcxManager) Errors() chan error {
-	return tcx.errorCh
+	return tcx.errors.channel()
 }
 
 func (tcx *tcxManager) emitError(msg string, args ...any) {
@@ -63,17 +85,17 @@ func (tcx *tcxManager) emitError(msg string, args ...any) {
 	formattedArgs := fmt.Sprint(args...)
 	compositeError := fmt.Errorf("%s: %s", msg, formattedArgs)
 
-	tcx.errorCh <- compositeError
+	tcx.errors.emit(compositeError)
 }
 
 func (tcx *tcxManager) SetInterfaceManager(im *InterfaceManager) {
 	tcx.mutex.Lock()
 	defer tcx.mutex.Unlock()
 
-	if tcx.ifaceManager != nil {
-		tcx.ifaceManager.RemoveCallback(tcx.addedCallbackID)
-		tcx.ifaceManager.RemoveCallback(tcx.removedCallbackID)
-		tcx.ifaceManager.RemoveCallback(tcx.errorCallbackID)
+	tcx.unregisterCallbacksLocked()
+
+	if tcx.shutdown {
+		return
 	}
 
 	if im != nil {
@@ -83,6 +105,17 @@ func (tcx *tcxManager) SetInterfaceManager(im *InterfaceManager) {
 	}
 
 	tcx.ifaceManager = im
+}
+
+func (tcx *tcxManager) unregisterCallbacksLocked() {
+	if tcx.ifaceManager == nil {
+		return
+	}
+
+	tcx.ifaceManager.RemoveCallback(tcx.addedCallbackID)
+	tcx.ifaceManager.RemoveCallback(tcx.removedCallbackID)
+	tcx.ifaceManager.RemoveCallback(tcx.errorCallbackID)
+	tcx.ifaceManager = nil
 }
 
 func tcxAttachType(attachment AttachmentType) (ebpf.AttachType, error) {
@@ -102,16 +135,16 @@ func (tcx *tcxManager) Shutdown() {
 	tcx.mutex.Lock()
 	defer tcx.mutex.Unlock()
 
-	if tcx.ifaceManager != nil {
-		for _, iface := range tcx.ifaceManager.Interfaces() {
-			tcx.closeLinksLocked(iface)
-		}
+	if tcx.shutdown {
+		return
 	}
+	tcx.shutdown = true
+
+	tcx.unregisterCallbacksLocked()
+	tcx.cleanupLinksLocked()
 
 	tcx.programs = []*attachedProg{}
-	tcx.links = []*ifaceLink{}
-
-	close(tcx.errorCh)
+	tcx.errors.close()
 
 	tcx.log.Debug("TCX completed shutdown")
 }
@@ -119,6 +152,9 @@ func (tcx *tcxManager) Shutdown() {
 func (tcx *tcxManager) AddProgram(name string, prog *ebpf.Program, attachment AttachmentType) {
 	tcx.mutex.Lock()
 	defer tcx.mutex.Unlock()
+	if tcx.shutdown {
+		return
+	}
 
 	p := &attachedProg{
 		Program:    prog,
@@ -143,6 +179,9 @@ func (tcx *tcxManager) attachProgramLocked(prog *attachedProg) {
 func (tcx *tcxManager) RemoveProgram(name string) {
 	tcx.mutex.Lock()
 	defer tcx.mutex.Unlock()
+	if tcx.shutdown {
+		return
+	}
 
 	tcx.unlinkProgramLocked(name)
 	tcx.removeProgramLocked(name)
@@ -211,15 +250,21 @@ func (tcx *tcxManager) attachProgramToIfaceLocked(prog *attachedProg, iface int)
 func (tcx *tcxManager) onInterfaceAdded(iface *ifaces.Interface) {
 	tcx.mutex.Lock()
 	defer tcx.mutex.Unlock()
+	if tcx.shutdown {
+		return
+	}
 
 	for _, prog := range tcx.programs {
-		tcx.attachProgramToIfaceLocked(prog, iface.Index)
+		tcx.attachProgramFn(prog, iface.Index)
 	}
 }
 
 func (tcx *tcxManager) onInterfaceRemoved(iface *ifaces.Interface) {
 	tcx.mutex.Lock()
 	defer tcx.mutex.Unlock()
+	if tcx.shutdown {
+		return
+	}
 
 	tcx.closeLinksLocked(iface)
 }
@@ -227,12 +272,26 @@ func (tcx *tcxManager) onInterfaceRemoved(iface *ifaces.Interface) {
 func (tcx *tcxManager) closeLinksLocked(iface *ifaces.Interface) {
 	closeLinks := func(link *ifaceLink) {
 		if link.iface == iface.Index {
-			link.Close()
+			if err := link.Close(); err != nil {
+				tcx.emitError("Failed to unlink program", "program", link.progName,
+					"iface", iface.Index, "error", err)
+			}
 		}
 	}
 
 	apply(tcx.links, closeLinks)
 	tcx.links = removeIf(tcx.links, func(l *ifaceLink) bool { return l.iface == iface.Index })
+}
+
+func (tcx *tcxManager) cleanupLinksLocked() {
+	for _, ifaceLink := range tcx.links {
+		if err := ifaceLink.Close(); err != nil {
+			tcx.emitError("Failed to unlink program", "program", ifaceLink.progName,
+				"iface", ifaceLink.iface, "error", err)
+		}
+	}
+
+	tcx.links = []*ifaceLink{}
 }
 
 func (tcx *tcxManager) onIfaceManagerError(err error) {

--- a/pkg/internal/ebpf/tcmanager/tcxmanager.go
+++ b/pkg/internal/ebpf/tcmanager/tcxmanager.go
@@ -76,7 +76,7 @@ func NewTCXManager() TCManager {
 }
 
 func (tcx *tcxManager) Errors() chan error {
-	return tcx.errors.channel()
+	return tcx.errors.ch
 }
 
 func (tcx *tcxManager) emitError(msg string, args ...any) {
@@ -85,7 +85,7 @@ func (tcx *tcxManager) emitError(msg string, args ...any) {
 	formattedArgs := fmt.Sprint(args...)
 	compositeError := fmt.Errorf("%s: %s", msg, formattedArgs)
 
-	tcx.errors.emit(compositeError)
+	tcx.errors.enqueue(compositeError)
 }
 
 func (tcx *tcxManager) SetInterfaceManager(im *InterfaceManager) {

--- a/pkg/internal/ebpf/tcmanager/util.go
+++ b/pkg/internal/ebpf/tcmanager/util.go
@@ -5,7 +5,17 @@
 
 package tcmanager // import "go.opentelemetry.io/obi/pkg/internal/ebpf/tcmanager"
 
+import "io"
+
 const eNoDevMsg = "Interface no longer exists"
+
+func closeWith(override func() error, fallback io.Closer) error {
+	if override != nil {
+		return override()
+	}
+
+	return fallback.Close()
+}
 
 func removeIf[T any](s []T, pred func(T) bool) []T {
 	i := 0


### PR DESCRIPTION
## Summary

- serialize TC and TCX shutdown with interface callbacks
- make repeated shutdown and late lifecycle callbacks safe
- surface link and program cleanup failures through a bounded error reporter
- add lifecycle, concurrency, and privileged cleanup coverage

## Validation

- `make lint` with Go 1.25.11
- package race tests
- privileged race tests
- focused lifecycle stress tests (100 repetitions)
- targeted `go vet`
- independent testing, architecture, and security reviews