### PR TITLE
feat(config): remove the deprecated `application_jvm` feature alias

### DIFF
--- a/internal/test/integration/docker-compose-go-kafka-traceparent.yml
+++ b/internal/test/integration/docker-compose-go-kafka-traceparent.yml
@@ -80,8 +80,8 @@ services:
       OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
       OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
       OTEL_EBPF_BPF_TRACK_REQUEST_HEADERS: "true"
-      OTEL_EBPF_METRICS_FEATURES: "application,application_process"
-      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_process"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+      OTEL_EBPF_PROMETHEUS_FEATURES: "application"
     depends_on:
       testserver:
         condition: service_started

--- a/internal/test/integration/docker-compose-large-http-req.yml
+++ b/internal/test/integration/docker-compose-large-http-req.yml
@@ -34,8 +34,8 @@ services:
       GOCOVERDIR: "/coverage"
       OTEL_EBPF_TRACE_PRINTER: "text"
       OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
-      OTEL_EBPF_METRICS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf,application_host"
-      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf,application_host"
+      OTEL_EBPF_METRICS_FEATURES: "application,application_span_otel,application_service_graph,ebpf,application_host"
+      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_service_graph,ebpf,application_host"
       OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
       OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
       OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"

--- a/internal/test/integration/docker-compose-log-enricher.yml
+++ b/internal/test/integration/docker-compose-log-enricher.yml
@@ -149,8 +149,8 @@ services:
       OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
       OTEL_EBPF_BPF_TRACK_REQUEST_HEADERS: "true"
       OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
-      OTEL_EBPF_METRICS_FEATURES: "application,application_process,application_span_otel,application_service_graph"
-      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_process,application_service_graph"
+      OTEL_EBPF_METRICS_FEATURES: "application,application_span_otel,application_service_graph"
+      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_service_graph"
     depends_on:
       testserverhttp:
         condition: service_started

--- a/internal/test/integration/docker-compose-python-async-uvloop-3.14.yml
+++ b/internal/test/integration/docker-compose-python-async-uvloop-3.14.yml
@@ -43,8 +43,8 @@ services:
       GOCOVERDIR: "/coverage"
       OTEL_EBPF_TRACE_PRINTER: "text"
       OTEL_EBPF_OPEN_PORT: "8391,8080"
-      OTEL_EBPF_METRICS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf,application_host"
-      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf,application_host"
+      OTEL_EBPF_METRICS_FEATURES: "application,application_span_otel,application_service_graph,ebpf,application_host"
+      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_service_graph,ebpf,application_host"
       OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
       OTEL_EBPF_EXECUTABLE_NAME: ""
       OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"

--- a/internal/test/integration/docker-compose-python-async-uvloop-3.9.yml
+++ b/internal/test/integration/docker-compose-python-async-uvloop-3.9.yml
@@ -43,8 +43,8 @@ services:
       GOCOVERDIR: "/coverage"
       OTEL_EBPF_TRACE_PRINTER: "text"
       OTEL_EBPF_OPEN_PORT: "8391,8080"
-      OTEL_EBPF_METRICS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf,application_host"
-      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_process,application_service_graph,ebpf,application_host"
+      OTEL_EBPF_METRICS_FEATURES: "application,application_span_otel,application_service_graph,ebpf,application_host"
+      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span_otel,application_service_graph,ebpf,application_host"
       OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
       OTEL_EBPF_EXECUTABLE_NAME: ""
       OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"

--- a/pkg/export/feature.go
+++ b/pkg/export/feature.go
@@ -5,6 +5,7 @@ package export // import "go.opentelemetry.io/obi/pkg/export"
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/invopop/jsonschema"
@@ -64,23 +65,18 @@ var FeatureMapper = map[string]Features{
 	"application_service_graph":    FeatureGraph,
 	"application_host":             FeatureApplicationHost,
 	"application_runtime":          FeatureApplicationRuntime,
-	// Deprecated alias kept for v0.10 config compatibility.
-	"application_jvm": FeatureApplicationRuntime,
-	"ebpf":            FeatureEBPF,
-	"all":             FeatureAll,
-	"*":               FeatureAll,
+	"ebpf":                         FeatureEBPF,
+	"all":                          FeatureAll,
+	"*":                            FeatureAll,
 }
 
 func (Features) JSONSchema() *jsonschema.Schema {
-	features := make([]any, 0, len(FeatureMapper))
-
-	for k := range FeatureMapper {
-		// Keep application_jvm accepted for v0.10 config compatibility, but do not advertise it in generated docs.
-		if k == "application_jvm" {
-			continue
-		}
-		features = append(features, k)
+	names := validFeatureNames()
+	features := make([]any, 0, len(names)+1)
+	for _, name := range names {
+		features = append(features, name)
 	}
+	features = append(features, "*")
 	return &jsonschema.Schema{
 		Type: "array",
 		Items: &jsonschema.Schema{
@@ -100,16 +96,37 @@ var AppO11yFeatures = FeatureApplicationRED |
 	FeatureGraph |
 	FeatureApplicationHost
 
-func LoadFeatures(features []string) Features {
+func validFeatureNames() []string {
+	names := make([]string, 0, len(FeatureMapper))
+	for name := range FeatureMapper {
+		if name == "*" {
+			continue
+		}
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func LoadFeatures(features []string) (Features, error) {
 	if len(features) == 0 {
-		return FeatureEmpty
+		return FeatureEmpty, nil
 	}
 	// convert the public data type to the internal representation
 	feats := Features(0)
 	for _, f := range features {
-		feats |= FeatureMapper[f]
+		name := strings.TrimSpace(f)
+		if name == "" {
+			continue
+		}
+		feature, ok := FeatureMapper[name]
+		if !ok {
+			return Features(0), fmt.Errorf("unknown metrics feature %q (valid features: %s)",
+				name, strings.Join(validFeatureNames(), ", "))
+		}
+		feats |= feature
 	}
-	return feats
+	return feats, nil
 }
 
 func (f Features) has(feature Features) bool {
@@ -132,12 +149,20 @@ func (f *Features) UnmarshalYAML(value *yaml.Node) error {
 		}
 		features = append(features, item.Value)
 	}
-	*f = LoadFeatures(features)
+	feats, err := LoadFeatures(features)
+	if err != nil {
+		return err
+	}
+	*f = feats
 	return nil
 }
 
 func (f *Features) UnmarshalText(text []byte) error {
-	*f = LoadFeatures(strings.Split(string(text), ","))
+	feats, err := LoadFeatures(strings.Split(string(text), ","))
+	if err != nil {
+		return err
+	}
+	*f = feats
 	return nil
 }
 

--- a/pkg/export/feature_test.go
+++ b/pkg/export/feature_test.go
@@ -70,20 +70,49 @@ func TestFeatureEnv_Separator(t *testing.T) {
 }
 
 func TestFeatureApplicationAliasDoesNotIncludeRuntime(t *testing.T) {
-	features := LoadFeatures([]string{"application"})
+	features := mustLoadFeatures(t, "application")
 
 	assert.True(t, features.has(FeatureApplicationRED))
 	assert.False(t, features.has(FeatureApplicationRuntime))
 	assert.False(t, AppO11yFeatures.has(FeatureApplicationRuntime))
-	assert.True(t, LoadFeatures([]string{"application_runtime"}).AnyAppO11yMetric())
-	assert.True(t, LoadFeatures([]string{"application_runtime"}).AppOrSpan())
+	assert.True(t, mustLoadFeatures(t, "application_runtime").AnyAppO11yMetric())
+	assert.True(t, mustLoadFeatures(t, "application_runtime").AppOrSpan())
 }
 
-func TestFeatureApplicationJVMAliasMapsToRuntime(t *testing.T) {
-	features := LoadFeatures([]string{"application_jvm"})
+func mustLoadFeatures(t *testing.T, names ...string) Features {
+	t.Helper()
+	features, err := LoadFeatures(names)
+	require.NoError(t, err)
+	return features
+}
 
-	assert.True(t, features.AppRuntime())
-	assert.True(t, features.AnyAppO11yMetric())
+func TestLoadFeaturesRejectsUnknownNames(t *testing.T) {
+	_, err := LoadFeatures([]string{"application_jvm"})
+	require.ErrorContains(t, err, `unknown metrics feature "application_jvm"`)
+
+	_, err = LoadFeatures([]string{"application", "application_runtme"})
+	require.ErrorContains(t, err, "application_runtme")
+
+	// empty entries (trailing commas in env values) are not an error
+	features, err := LoadFeatures([]string{"application", ""})
+	require.NoError(t, err)
+	assert.True(t, features.has(FeatureApplicationRED))
+
+	// the error names the valid features so a typo is self-diagnosing
+	_, err = LoadFeatures([]string{"no_such_feature"})
+	require.ErrorContains(t, err, "application_runtime")
+}
+
+// An unset OTEL_EBPF_METRICS_FEATURES resolves to an empty envDefault string
+// (perapp.MetricsConfig), so UnmarshalText("") runs on every default
+// deployment and must keep yielding Undefined rather than an error.
+func TestFeatureUnmarshalTextEmpty(t *testing.T) {
+	var features Features
+	require.NoError(t, features.UnmarshalText(nil))
+	assert.True(t, features.Undefined())
+
+	require.NoError(t, features.UnmarshalText([]byte("")))
+	assert.True(t, features.Undefined())
 }
 
 func TestFeatureEnv_All(t *testing.T) {

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -510,19 +510,15 @@ jvm_runtime_metrics:
 	assert.Equal(t, 2*time.Second, cfg.JVMRuntimeMetrics.SamplingInterval)
 }
 
-func TestConfig_JVMRuntimeMetricsV010ConfigCompatibility(t *testing.T) {
-	cfg, err := LoadConfig(bytes.NewBufferString(`
+// An unknown feature name must abort config loading, not be silently ignored.
+// application_jvm is an unknown name most likely to appear in real configs.
+func TestConfig_UnknownMetricsFeatureFailsStartup(t *testing.T) {
+	_, err := LoadConfig(bytes.NewBufferString(`
 metrics:
   features:
     - application_jvm
-jvm_runtime_metrics:
-  enabled: true
-  sampling_interval: 2s
 `))
-	require.NoError(t, err)
-
-	assert.True(t, cfg.Metrics.Features.AppRuntime())
-	assert.Equal(t, 2*time.Second, cfg.JVMRuntimeMetrics.SamplingInterval)
+	require.ErrorContains(t, err, `unknown metrics feature "application_jvm"`)
 }
 
 func TestConfigValidate_JVMRuntimeMetricsSamplingInterval(t *testing.T) {


### PR DESCRIPTION
## Summary

`application_jvm` was kept as a `v0.10` compatibility alias of `application_runtime`, meaning a jvm-named flag enables runtime metrics for every language (including the upcoming nodejs runtime metrics).

This PR removes the deprecated `application_jvm` feature alias and uses `application_runtime` instead.

Also, feature parsing is now strict: an unknown name in `metrics.features` fails at startup with an error listing the valid features, instead of being silently ignored. Without strict parsing, removing the `application_jvm`  alias would have silently disabled metrics for configs still using it.


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
