### PR TITLE
netolly: emit optional network attributes in the direction suite

### DIFF
--- a/internal/test/integration/configs/obi-config-netolly-direction.yml
+++ b/internal/test/integration/configs/obi-config-netolly-direction.yml
@@ -1,5 +1,7 @@
 network:
   guess_ports: ordinal
+  cidrs:
+  - 0.0.0.0/0
 attributes:
   select:
     obi_network_flow_bytes:
@@ -15,6 +17,8 @@ attributes:
       - dst.namespace
       - src.cidr
       - dst.cidr
+      - transport
+      - network.type
       - iface
       - iface_direction
       - direction

--- a/internal/test/integration/docker-compose-netolly-direction.yml
+++ b/internal/test/integration/docker-compose-netolly-direction.yml
@@ -41,7 +41,7 @@ services:
       OTEL_EBPF_CONFIG_PATH: /configs/obi-config-netolly${OTEL_EBPF_CONFIG_SUFFIX}.yml
       GOCOVERDIR: "/coverage"
       OTEL_EBPF_NETWORK_SOURCE: ${OTEL_EBPF_NETWORK_SOURCE}
-      OTEL_EBPF_METRICS_FEATURES: "network" # implicitly enabling network metrics without a global enable
+      OTEL_EBPF_METRICS_FEATURES: "network,network_flow_packets,network_inter_zone" # implicitly enabling network metrics without a global enable
       OTEL_EBPF_NETWORK_PRINT_FLOWS: "true"
       OTEL_EBPF_METRICS_INTERVAL: "1s"
       OTEL_EBPF_BPF_BATCH_TIMEOUT: "1s"

--- a/pkg/internal/netolly/flow/transport/networktype.go
+++ b/pkg/internal/netolly/flow/transport/networktype.go
@@ -3,10 +3,6 @@
 
 package transport // import "go.opentelemetry.io/obi/pkg/internal/netolly/flow/transport"
 
-import (
-	"strconv"
-)
-
 // NetworkType value stores the L3 network protocol (IPv4, IPV6....)
 // Values are defined in IEEE 802: https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml
 type NetworkType uint16
@@ -14,6 +10,7 @@ type NetworkType uint16
 const (
 	IPv4 = NetworkType(0x800)
 	IPv6 = NetworkType(0x86DD)
+	ARP  = NetworkType(0x806)
 )
 
 // String representation of the Protocol enum
@@ -23,6 +20,8 @@ func (p NetworkType) String() string {
 		return "ipv4"
 	case IPv6:
 		return "ipv6"
+	case ARP:
+		return "arp"
 	}
-	return strconv.Itoa(int(p))
+	return "unknown"
 }

--- a/schemas/obi/groups/network.yaml
+++ b/schemas/obi/groups/network.yaml
@@ -182,3 +182,40 @@ groups:
       - ref: dst.zone
       - ref: src.name
       - ref: dst.name
+
+  # Overrides `network.type`: extends the upstream `ipv4`/`ipv6` enum with
+  # `arp`, which OBI reports for ARP frames — OBI observes raw L2 frames, a
+  # case the upstream network-layer enum has no member for. Other non-IP
+  # EtherTypes fall back to `unknown` (pkg/internal/netolly/flow/transport,
+  # NetworkType.String); that bug-marker value is deliberately NOT declared
+  # here, so weaver keeps flagging it if it ever appears.
+  #
+  # See ../README.md for the override mechanics (x.obi.* group id, full
+  # upstream member list, lint allowlist).
+  - id: x.obi.network
+    type: attribute_group
+    display_name: OBI Network Attribute Overrides
+    brief: >
+      OBI override of `network.type` extending the upstream enum with `arp`
+      for the ARP frames OBI observes at L2.
+    attributes:
+      - id: network.type
+        stability: stable
+        type:
+          members:
+            - id: ipv4
+              value: 'ipv4'
+              brief: "IPv4"
+              stability: stable
+            - id: ipv6
+              value: 'ipv6'
+              brief: "IPv6"
+              stability: stable
+            # --- OBI extension (not in upstream semconv v1.41) ---
+            - id: arp
+              value: 'arp'
+              brief: "ARP (Address Resolution Protocol) frame observed at L2."
+              stability: development
+        brief: '[OSI network layer](https://wikipedia.org/wiki/Network_layer) or non-OSI equivalent.'
+        note: The value SHOULD be normalized to lowercase.
+        examples: ['ipv4', 'ipv6']

--- a/scripts/lint-schema-filter.jq
+++ b/scripts/lint-schema-filter.jq
@@ -40,7 +40,7 @@ map(select(
         and ($dup.attribute_id
              | IN("messaging.system", "gen_ai.provider.name", "gen_ai.operation.name",
                   "openai.api.type", "telemetry.sdk.language", "db.system.name",
-                  "rpc.system.name", "error.type"))
+                  "rpc.system.name", "error.type", "network.type"))
         and ((($dup.group_ids // []) | sort) as $groups
              | ($groups | length) == 2
                and ($groups[0] | startswith("registry."))

--- a/scripts/lint_schema_filter_test.go
+++ b/scripts/lint_schema_filter_test.go
@@ -99,6 +99,12 @@ const expectedEnumOverrideDuplicates = `[{
 		"attribute_id": "error.type",
 		"group_ids": ["registry.error", "x.obi.error"]
 	}}
+}, {
+	"diagnostic": {"severity": "Error"},
+	"error": {"DuplicateAttributeId": {
+		"attribute_id": "network.type",
+		"group_ids": ["registry.network", "x.obi.network"]
+	}}
 }]`
 
 func TestLintSchemaFilterAllowsExpectedEnumOverrideDuplicates(t *testing.T) {


### PR DESCRIPTION
## Summary

The network (netolly) flow telemetry declares several optional attributes and metrics that no weaver-wired suite enabled, so weaver's live-check never observed them. This enables them on the `netolly-direction` suite (already weaver-wired, exercised by `TestNetwork_Direction` / `TestNetwork_IfaceDirection_Use_Socket_Filter`), which is scoped to its own config via `OTEL_EBPF_CONFIG_SUFFIX=-direction` so no other suite is affected.

Covers: `obi.network.flow.packets`, `src.cidr`, `dst.cidr`, `network.type`, `transport`.

### Notes
- `obi.network.inter.zone.bytes` is **not** covered by this PR: it only emits when `SrcZone != DstZone`, and zones are populated exclusively from Kubernetes node labels — a docker-compose run has no k8s metadata, so it stays suppressed. Covering it needs a weaver-wired k8s suite with cross-zone traffic (part of https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2785).

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
