### PR TITLE
http: cover request/response body content in the body-extraction suite

### DIFF
--- a/internal/test/integration/components/testserver/std/std.go
+++ b/internal/test/integration/components/testserver/std/std.go
@@ -309,12 +309,28 @@ func rolldice(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "%v", n)
 }
 
+// rolldicePost handles POST /rolldice/{id} and returns a JSON response body so
+// that HTTP response-body extraction has non-empty JSON content to capture.
+func rolldicePost(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	n := rd.IntN(6) + 1
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Dice-Roll", strconv.Itoa(n))
+
+	slog.Info("rolldice POST called", "id", id, "dice", n)
+
+	fmt.Fprintf(w, `{"result":%d}`, n)
+}
+
 func Setup(port int) {
 	log := slog.With("component", "std.Server")
 	address := fmt.Sprintf(":%d", port)
 	log.Info("starting HTTP server", "address", address)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /rolldice/{id}", rolldice)
+	mux.HandleFunc("POST /rolldice/{id}", rolldicePost)
 	mux.HandleFunc("/", HTTPHandler(log, port))
 
 	err := http.ListenAndServe(address, mux)
@@ -328,6 +344,7 @@ func SetupTLS(port int) {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /rolldice/{id}", rolldice)
+	mux.HandleFunc("POST /rolldice/{id}", rolldicePost)
 	mux.HandleFunc("/", HTTPHandler(log, port))
 
 	err := http.ListenAndServeTLS(address, "x509/server_test_cert.pem", "x509/server_test_key.pem", mux)

--- a/internal/test/integration/configs/obi-config-http-enrichment-body.yml
+++ b/internal/test/integration/configs/obi-config-http-enrichment-body.yml
@@ -9,7 +9,7 @@ routes:
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4318
 attributes:
   select:
     "*":
@@ -72,10 +72,10 @@ ebpf:
             match:
               url_path_patterns:
                 - "/smoke"
-          # Include body on specific route without obfuscation
+          # Include request + response body on specific route without obfuscation
           - action: include
             type: body
-            scope: request
+            scope: all
             match:
               methods: ["POST"]
               url_path_patterns:

--- a/internal/test/integration/http_enrichment_body_test.go
+++ b/internal/test/integration/http_enrichment_body_test.go
@@ -20,7 +20,7 @@ import (
 
 // bodyExtractionObfuscate verifies that the body extraction rules correctly
 // capture the request body with sensitive fields obfuscated.
-func bodyExtractionObfuscate(t *testing.T) {
+func bodyExtractionObfuscate(t *testing.T, postOperation string) {
 	// Send POST requests with a JSON body containing sensitive fields.
 	// The config obfuscates $.password and $.secret with "***", credit-card
 	// fields with "PCI", and social/insurance numbers with "PII" on POST requests.
@@ -31,7 +31,7 @@ func bodyExtractionObfuscate(t *testing.T) {
 
 	var trace jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=POST%20%2Frolldice%2F%3Aid")
+		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=" + url.QueryEscape(postOperation))
 		require.NoError(ct, err)
 		if resp == nil {
 			return
@@ -45,7 +45,7 @@ func bodyExtractionObfuscate(t *testing.T) {
 		trace = traces[0]
 	}, testTimeout, 100*time.Millisecond)
 
-	res := trace.FindByOperationName("POST /rolldice/:id", "server")
+	res := trace.FindByOperationName(postOperation, "server")
 	require.NotEmpty(t, res)
 	span := res[0]
 
@@ -74,7 +74,7 @@ func bodyExtractionObfuscate(t *testing.T) {
 
 // bodyExtractionInclude verifies that body include rules capture the raw body
 // without obfuscation when only an include rule matches.
-func bodyExtractionInclude(t *testing.T) {
+func bodyExtractionInclude(t *testing.T, postOperation string) {
 	// The config has an include rule for POST /rolldice/* which also matches,
 	// but the obfuscate rule also matches POST requests.
 	// Since body rules merge, both rules apply: obfuscate paths are applied
@@ -88,7 +88,7 @@ func bodyExtractionInclude(t *testing.T) {
 
 	var trace jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=POST%20%2Frolldice%2F%3Aid")
+		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=" + url.QueryEscape(postOperation))
 		require.NoError(ct, err)
 		if resp == nil {
 			return
@@ -102,7 +102,7 @@ func bodyExtractionInclude(t *testing.T) {
 		trace = traces[0]
 	}, testTimeout, 100*time.Millisecond)
 
-	res := trace.FindByOperationName("POST /rolldice/:id", "server")
+	res := trace.FindByOperationName(postOperation, "server")
 	require.NotEmpty(t, res)
 	span := res[0]
 
@@ -158,7 +158,7 @@ func bodyExtractionExcludedByDefault(t *testing.T, getOperation string) {
 
 // bodyExtractionContentTypeHeader verifies that the Content-Type header
 // is also included on the span (configured via a header include rule).
-func bodyExtractionContentTypeHeader(t *testing.T) {
+func bodyExtractionContentTypeHeader(t *testing.T, postOperation string) {
 	for i := 0; i < 4; i++ {
 		doHTTPPost(t, instrumentedServiceStdURL+"/rolldice/53", 200,
 			[]byte(`{"test":"header-check"}`))
@@ -166,7 +166,7 @@ func bodyExtractionContentTypeHeader(t *testing.T) {
 
 	var trace jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=POST%20%2Frolldice%2F%3Aid")
+		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=" + url.QueryEscape(postOperation))
 		require.NoError(ct, err)
 		if resp == nil {
 			return
@@ -180,7 +180,7 @@ func bodyExtractionContentTypeHeader(t *testing.T) {
 		trace = traces[0]
 	}, testTimeout, 100*time.Millisecond)
 
-	res := trace.FindByOperationName("POST /rolldice/:id", "server")
+	res := trace.FindByOperationName(postOperation, "server")
 	require.NotEmpty(t, res)
 	span := res[0]
 
@@ -208,10 +208,10 @@ func TestSuiteBodyExtraction(t *testing.T) {
 
 	t.Run("Body extraction obfuscate", func(t *testing.T) {
 		waitForTestComponents(t, instrumentedServiceStdURL)
-		bodyExtractionObfuscate(t)
+		bodyExtractionObfuscate(t, "POST /rolldice/:id")
 	})
 	t.Run("Body extraction include", func(t *testing.T) {
-		bodyExtractionInclude(t)
+		bodyExtractionInclude(t, "POST /rolldice/:id")
 	})
 	t.Run("Body excluded by default", func(t *testing.T) {
 		// The socket tracer doesn't capture the Go mux pattern, so OBI resolves
@@ -219,7 +219,7 @@ func TestSuiteBodyExtraction(t *testing.T) {
 		bodyExtractionExcludedByDefault(t, "GET /rolldice/:id")
 	})
 	t.Run("Body with Content-Type header", func(t *testing.T) {
-		bodyExtractionContentTypeHeader(t)
+		bodyExtractionContentTypeHeader(t, "POST /rolldice/:id")
 	})
 
 	runWeaverValidation(t)

--- a/internal/test/integration/http_enrichment_body_test.go
+++ b/internal/test/integration/http_enrichment_body_test.go
@@ -113,6 +113,13 @@ func bodyExtractionInclude(t *testing.T) {
 	require.True(t, valOk)
 	assert.Contains(t, val, "roll", "action field should be present")
 	assert.Contains(t, val, "6", "sides field should be present")
+
+	// Verify the JSON response body content is captured (response-scope include rule).
+	respTag, respOk := jaeger.FindIn(span.Tags, "http.response.body.content")
+	require.True(t, respOk, "expected http.response.body.content on span")
+	respVal, respValOk := jaeger.TagFirstStringValue(respTag)
+	require.True(t, respValOk)
+	assert.Contains(t, respVal, "result", "response body result field should be present")
 }
 
 // bodyExtractionExcludedByDefault verifies that GET requests (which don't match

--- a/internal/test/integration/http_go_enrichment_body_test.go
+++ b/internal/test/integration/http_go_enrichment_body_test.go
@@ -23,10 +23,10 @@ func TestSuiteGoBodyExtraction(t *testing.T) {
 
 	t.Run("Body extraction obfuscate", func(t *testing.T) {
 		waitForTestComponents(t, instrumentedServiceStdURL)
-		bodyExtractionObfuscate(t)
+		bodyExtractionObfuscate(t, "POST /rolldice/{id}")
 	})
 	t.Run("Body extraction include", func(t *testing.T) {
-		bodyExtractionInclude(t)
+		bodyExtractionInclude(t, "POST /rolldice/{id}")
 	})
 	t.Run("Body excluded by default", func(t *testing.T) {
 		// The Go uprobe tracer captures the native std-mux pattern, reported
@@ -34,7 +34,7 @@ func TestSuiteGoBodyExtraction(t *testing.T) {
 		bodyExtractionExcludedByDefault(t, "GET /rolldice/{id}")
 	})
 	t.Run("Body with Content-Type header", func(t *testing.T) {
-		bodyExtractionContentTypeHeader(t)
+		bodyExtractionContentTypeHeader(t, "POST /rolldice/{id}")
 	})
 
 	require.NoError(t, compose.Close())


### PR DESCRIPTION
## Summary

`http.request.body.content` / `http.response.body.content` were never observed even though `TestSuiteBodyExtraction` enables body capture and calls weaver validation. Root cause: the suite exported traces **directly to jaeger**, bypassing the weaver-tapping collector, so weaver only ever saw its metrics — never the body-carrying spans. Additionally no rule used `scope: response` and the app returned no JSON body. This routes the suite's traces through the collector (which still forwards to jaeger) and adds a JSON response so both attributes populate and reach weaver.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
