### PR TITLE
gpu: hardware-free CUDA instrumentation test (stub libcudart)

### DIFF
--- a/internal/test/integration/components/gpu-cuda-tester/Dockerfile
+++ b/internal/test/integration/components/gpu-cuda-tester/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Builds a self-contained target that exercises OBI's CUDA instrumentation with
+# NO GPU and NO NVIDIA driver: a stub libcudart.so exporting the CUDA Runtime
+# API symbols OBI's gpuevent uprobes attach to, plus a caller that invokes them
+# in a loop with realistic arguments. OBI attaches its uprobes by symbol name to
+# any mapped library whose path contains "/libcudart.so", so each call fires the
+# probe and emits gpu.cuda.* metrics exactly as a real CUDA app would.
+#
+# Docker command must be invoked from the project root directory.
+FROM gcc:14.4.0-trixie@sha256:df8990c2f53aa9ef57808e755aa8f580dd86b9b34c6233715de23e89f7e06b65 AS builder
+
+WORKDIR /src
+COPY internal/test/integration/components/gpu-cuda-tester/ .
+
+# Build the stub shared library (unversioned SONAME so its mapped path is
+# exactly ".../libcudart.so") and the caller linked against it. -O0 keeps every
+# CUDA call going through the PLT so OBI's uprobes have a symbol to attach to.
+RUN gcc -O0 -fPIC -shared -Wl,-soname,libcudart.so -o libcudart.so libcudart-stub.c && \
+    gcc -O0 -o gpu-cuda-tester main.c -L. -lcudart -Wl,-rpath,/app
+
+FROM debian:bookworm-slim@sha256:74d56e3931e0d5a1dd51f8c8a2466d21de84a271cd3b5a733b803aa91abf4421
+
+WORKDIR /app
+COPY --from=builder /src/libcudart.so /app/libcudart.so
+COPY --from=builder /src/gpu-cuda-tester /app/gpu-cuda-tester
+ENV LD_LIBRARY_PATH=/app
+USER 0:0
+
+CMD ["/app/gpu-cuda-tester"]

--- a/internal/test/integration/components/gpu-cuda-tester/cuda_stub.h
+++ b/internal/test/integration/components/gpu-cuda-tester/cuda_stub.h
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal subset of the CUDA Runtime API surface that OBI's gpuevent uprobes
+// attach to. The types and signatures mirror <cuda_runtime_api.h> closely
+// enough that the SysV x86-64 / AArch64 calling convention places each argument
+// in the register OBI's BPF programs read (see bpf/gpuevent/cuda.c):
+//
+//   cudaLaunchKernel(func, gridDim, blockDim, ...)  BPF reads gridDim/blockDim
+//   cudaMalloc(devPtr, size)                         BPF reads size
+//   cudaMemcpy(dst, src, count, kind)                BPF reads size + kind
+//   cudaMemcpyAsync(dst, src, count, kind, stream)   BPF reads size + kind
+//   cudaGraphLaunch(graphExec, stream)               BPF reads nothing
+//
+// dim3 is a 12-byte struct passed by value: the {x,y} pair occupies one
+// eightbyte register and {z} the next, which is exactly how OBI decodes
+// grid_xy/grid_z and block_xy/block_z.
+#ifndef CUDA_STUB_H
+#define CUDA_STUB_H
+
+#include <stddef.h>
+
+typedef int cudaError_t;
+typedef void *cudaStream_t;
+typedef void *cudaGraphExec_t;
+
+typedef struct dim3 {
+  unsigned int x;
+  unsigned int y;
+  unsigned int z;
+} dim3;
+
+enum cudaMemcpyKind {
+  cudaMemcpyHostToHost = 0,
+  cudaMemcpyHostToDevice = 1,
+  cudaMemcpyDeviceToHost = 2,
+  cudaMemcpyDeviceToDevice = 3,
+  cudaMemcpyDefault = 4
+};
+
+cudaError_t cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim,
+                             void **args, size_t sharedMem, cudaStream_t stream);
+cudaError_t cudaMalloc(void **devPtr, size_t size);
+cudaError_t cudaMemcpy(void *dst, const void *src, size_t count,
+                       enum cudaMemcpyKind kind);
+cudaError_t cudaMemcpyAsync(void *dst, const void *src, size_t count,
+                            enum cudaMemcpyKind kind, cudaStream_t stream);
+cudaError_t cudaGraphLaunch(cudaGraphExec_t graphExec, cudaStream_t stream);
+
+#endif // CUDA_STUB_H

--- a/internal/test/integration/components/gpu-cuda-tester/cuda_stub.h
+++ b/internal/test/integration/components/gpu-cuda-tester/cuda_stub.h
@@ -39,7 +39,8 @@ enum cudaMemcpyKind {
 };
 
 cudaError_t cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim,
-                             void **args, size_t sharedMem, cudaStream_t stream);
+                             void **args, size_t sharedMem,
+                             cudaStream_t stream);
 cudaError_t cudaMalloc(void **devPtr, size_t size);
 cudaError_t cudaMemcpy(void *dst, const void *src, size_t count,
                        enum cudaMemcpyKind kind);

--- a/internal/test/integration/components/gpu-cuda-tester/libcudart-stub.c
+++ b/internal/test/integration/components/gpu-cuda-tester/libcudart-stub.c
@@ -1,0 +1,64 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Stub implementation of libcudart.so. It performs no GPU work and needs no
+// NVIDIA driver: each function has a trivial body and returns success. Its only
+// purpose is to export the CUDA Runtime API symbols by name so that, when the
+// caller invokes them, OBI's uprobes (attached by symbol name to any mapped
+// library whose path contains "/libcudart.so") fire with realistic register
+// arguments and emit gpu.cuda.* metrics.
+//
+// Built into a shared object so the symbols land in .dynsym (where OBI's ELF
+// symbol resolution finds them) and every call goes through the PLT (so the
+// compiler cannot inline the calls away). Compiled with -O0 and a volatile sink
+// for the same reason.
+
+#include "cuda_stub.h"
+
+static volatile unsigned long g_sink;
+
+cudaError_t cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim,
+                             void **args, size_t sharedMem,
+                             cudaStream_t stream) {
+  (void)func;
+  (void)args;
+  (void)sharedMem;
+  (void)stream;
+  g_sink += (unsigned long)gridDim.x * gridDim.y * gridDim.z;
+  g_sink += (unsigned long)blockDim.x * blockDim.y * blockDim.z;
+  return 0;
+}
+
+cudaError_t cudaMalloc(void **devPtr, size_t size) {
+  if (devPtr != NULL) {
+    // Hand back a non-NULL fake device pointer so the caller can pass it to
+    // cudaMemcpy without tripping any of its own NULL checks.
+    *devPtr = (void *)0x1000;
+  }
+  g_sink += size;
+  return 0;
+}
+
+cudaError_t cudaMemcpy(void *dst, const void *src, size_t count,
+                       enum cudaMemcpyKind kind) {
+  (void)dst;
+  (void)src;
+  g_sink += count + (unsigned long)kind;
+  return 0;
+}
+
+cudaError_t cudaMemcpyAsync(void *dst, const void *src, size_t count,
+                            enum cudaMemcpyKind kind, cudaStream_t stream) {
+  (void)dst;
+  (void)src;
+  (void)stream;
+  g_sink += count + (unsigned long)kind;
+  return 0;
+}
+
+cudaError_t cudaGraphLaunch(cudaGraphExec_t graphExec, cudaStream_t stream) {
+  (void)graphExec;
+  (void)stream;
+  g_sink += 1;
+  return 0;
+}

--- a/internal/test/integration/components/gpu-cuda-tester/main.c
+++ b/internal/test/integration/components/gpu-cuda-tester/main.c
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Caller that drives the stub libcudart.so in an endless loop, exercising every
+// CUDA Runtime API entry point OBI instruments. It runs continuously so OBI has
+// time to discover the process and attach its uprobes before (and while) the
+// calls fire. Each iteration:
+//
+//   - cudaMalloc      -> gpu.cuda.memory.allocations
+//   - cudaLaunchKernel-> gpu.cuda.kernel.launch.calls + grid/block size
+//   - cudaMemcpy      -> gpu.cuda.memory.copies (+ cuda.memcpy.kind)
+//   - cudaMemcpyAsync -> gpu.cuda.memory.copies (+ cuda.memcpy.kind)
+//   - cudaGraphLaunch -> gpu.cuda.graph.launch.calls
+//
+// The memcpy kind is cycled through all four directions so cuda.memcpy.kind is
+// emitted with varied, semantically valid values.
+
+#include <stddef.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "cuda_stub.h"
+
+int main(void) {
+  setvbuf(stdout, NULL, _IONBF, 0);
+  printf("gpu-cuda-tester started\n");
+
+  const enum cudaMemcpyKind kinds[] = {
+      cudaMemcpyHostToDevice,
+      cudaMemcpyDeviceToHost,
+      cudaMemcpyDeviceToDevice,
+      cudaMemcpyHostToHost,
+  };
+
+  char hostbuf[256];
+  void *devptr = NULL;
+  unsigned long i = 0;
+
+  for (;;) {
+    cudaMalloc(&devptr, sizeof(hostbuf));
+
+    dim3 grid = {4, 2, 1};
+    dim3 block = {32, 4, 1};
+    cudaLaunchKernel((const void *)0xdeadbeef, grid, block, NULL, 0, NULL);
+
+    cudaMemcpy(devptr, hostbuf, sizeof(hostbuf), kinds[i % 4]);
+    cudaMemcpyAsync(hostbuf, devptr, sizeof(hostbuf), kinds[(i + 1) % 4], NULL);
+
+    cudaGraphLaunch((cudaGraphExec_t)0xcafe, NULL);
+
+    i++;
+    usleep(50 * 1000); // 50ms
+  }
+
+  return 0;
+}

--- a/internal/test/integration/configs/obi-config-gpu.yml
+++ b/internal/test/integration/configs/obi-config-gpu.yml
@@ -6,7 +6,7 @@ otel_metrics_export:
   endpoint: http://otelcol:4318
 discovery:
   instrument:
-    - exe_path: gpu-cuda-tester
+    - exe_path: "*gpu-cuda-tester"
       namespace: integration-test
 attributes:
   select:

--- a/internal/test/integration/configs/obi-config-gpu.yml
+++ b/internal/test/integration/configs/obi-config-gpu.yml
@@ -1,0 +1,14 @@
+# OBI configuration for the GPU/CUDA weaver suite. CUDA instrumentation is
+# forced on (compose sets OTEL_EBPF_INSTRUMENT_CUDA=on) so the gpuevent tracer
+# loads without needing nvidia-smi / a real GPU. The target has no listening
+# ports, so it is discovered by executable path rather than open_ports.
+otel_metrics_export:
+  endpoint: http://otelcol:4318
+discovery:
+  instrument:
+    - exe_path: gpu-cuda-tester
+      namespace: integration-test
+attributes:
+  select:
+    "*":
+      include: ["*"]

--- a/internal/test/integration/configs/prometheus-config-gpu.yml
+++ b/internal/test/integration/configs/prometheus-config-gpu.yml
@@ -1,0 +1,11 @@
+# Scrapes the collector's Prometheus exporter (fed by OBI's OTLP metrics) so the
+# test can assert the gpu.cuda.* surface is present alongside weaver validation.
+global:
+  evaluation_interval: 250ms
+  scrape_interval: 250ms
+scrape_configs:
+  - job_name: obi-gpu-metrics
+    honor_labels: true
+    static_configs:
+      - targets:
+          - 'otelcol:9464'

--- a/internal/test/integration/docker-compose-gpu.yml
+++ b/internal/test/integration/docker-compose-gpu.yml
@@ -1,0 +1,86 @@
+services:
+  # Self-contained CUDA target: a stub libcudart.so + a caller that invokes the
+  # CUDA Runtime API in a loop. No GPU or NVIDIA driver required.
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/gpu-cuda-tester/Dockerfile
+    image: hatest-testserver-gpu-cuda-tester
+    depends_on:
+      otelcol:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-gpu:/var/run/obi
+      - /sys/kernel/tracing:/sys/kernel/tracing:rw
+    image: hatest-obi
+    privileged: true
+    pid: "host"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: /configs/obi-config-gpu.yml
+      GOCOVERDIR: "/coverage"
+      # Force CUDA instrumentation on so the gpuevent tracer loads without a GPU
+      # (nvidia-smi auto-detect is bypassed).
+      OTEL_EBPF_INSTRUMENT_CUDA: "on"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "10ms"
+      OTEL_EBPF_BPF_METRIC_SCRAPE_INTERVAL: "1s"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config-gpu.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  # OpenTelemetry Collector: single OTLP receiver fans out to the Prometheus
+  # exporter (scraped by the test) and to weaver (semconv live-check).
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.157.0@sha256:f2f01157055a9b2aab9df7118e1f1c9abf345e99b23bc7a2bc791db374a7d0f6
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver-no-jaeger.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318:4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro

--- a/internal/test/integration/gpu_metrics_test.go
+++ b/internal/test/integration/gpu_metrics_test.go
@@ -1,0 +1,105 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration // import "go.opentelemetry.io/obi/internal/test/integration"
+
+import (
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
+	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
+)
+
+// gpuCounterMetricsExpected are the CUDA counter series OBI emits, in the
+// Prometheus form the collector exports (OTLP dots -> underscores; monotonic
+// sums get a _total suffix; the memory allocations counter carries a "By" unit
+// so the collector appends _bytes). Each is driven by a distinct CUDA Runtime
+// API call the target makes every loop iteration.
+var gpuCounterMetricsExpected = []string{
+	"gpu_cuda_kernel_launch_calls_total",      // cudaLaunchKernel
+	"gpu_cuda_graph_launch_calls_total",       // cudaGraphLaunch
+	"gpu_cuda_memory_allocations_bytes_total", // cudaMalloc (unit "By")
+}
+
+// gpuHistogramFamilyPrefixes are the CUDA histogram families. The collector
+// explodes each OTLP histogram into _bucket/_sum/_count and, for the unit-"1"
+// histograms, may insert a unit suffix (e.g. _ratio) before those — so we match
+// the _count series with an optional-suffix regex rather than a fixed name.
+var gpuHistogramFamilyPrefixes = []string{
+	"gpu_cuda_kernel_grid_size",  // grid dims from cudaLaunchKernel
+	"gpu_cuda_kernel_block_size", // block dims from cudaLaunchKernel
+	"gpu_cuda_memory_copies",     // cudaMemcpy / cudaMemcpyAsync
+}
+
+// TestGPUCudaMetrics brings up a target that dynamically links a stub
+// libcudart.so and calls the CUDA Runtime API in a loop. OBI (with CUDA
+// instrumentation forced on) attaches its gpuevent uprobes to those symbols by
+// name — needing no GPU or NVIDIA driver — so every call emits a gpu.cuda.*
+// metric. The collector fans the OTLP stream out to a Prometheus exporter
+// (asserted here) and to weaver, which live-checks the surface against the
+// semantic-convention registry in enforce mode.
+func TestGPUCudaMetrics(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-gpu.yml", path.Join(pathOutput, "test-suite-gpu.log"))
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+
+	// Cleanups run LIFO: register compose.Close() first so it runs LAST, after
+	// runWeaverValidation has /stopped the still-running weaver container.
+	t.Cleanup(func() { require.NoError(t, compose.Close()) })
+	t.Cleanup(func() { runWeaverValidation(t) })
+
+	t.Run("gpu.cuda.* metrics exported over OTLP", func(t *testing.T) {
+		pq := promtest.Client{HostPort: prometheusHostPort}
+
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			for _, name := range gpuCounterMetricsExpected {
+				results, err := pq.Query(name)
+				if !assert.NoError(ct, err, "querying %s", name) {
+					continue
+				}
+				assert.NotEmptyf(ct, results, "gpu metric %s should be present", name)
+			}
+			for _, prefix := range gpuHistogramFamilyPrefixes {
+				q := `{__name__=~"` + prefix + `.*_count"}`
+				results, err := pq.Query(q)
+				if !assert.NoError(ct, err, "querying %s", q) {
+					continue
+				}
+				assert.NotEmptyf(ct, results, "gpu histogram family %s should be present", prefix)
+			}
+		}, testTimeout, 500*time.Millisecond)
+
+		// The cuda.memcpy.kind attribute is default-on for gpu.cuda.memory.copies
+		// and the target cycles through every copy direction, so the label must be
+		// populated with at least one recognized value.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			results, err := pq.Query(`{__name__=~"gpu_cuda_memory_copies.*_count"}`)
+			if !assert.NoError(ct, err) {
+				return
+			}
+			kinds := map[string]bool{}
+			for _, r := range results {
+				if k := r.Metric["cuda_memcpy_kind"]; k != "" {
+					kinds[k] = true
+				}
+			}
+			assert.NotEmpty(ct, kinds, "cuda_memcpy_kind label should be present on gpu_cuda_memory_copies")
+		}, testTimeout, 500*time.Millisecond)
+
+		// Diagnostic: log the full gpu_cuda_* surface actually observed, so the
+		// exact collector-exported series names can be reconciled against what the
+		// emitter really emits.
+		if observed, err := pq.Query(`group by (__name__) ({__name__=~"gpu_cuda_.*"})`); err == nil {
+			names := make([]string, 0, len(observed))
+			for _, r := range observed {
+				names = append(names, r.Metric["__name__"])
+			}
+			t.Logf("observed gpu_cuda_* metric series: %v", names)
+		}
+	})
+}

--- a/schemas/obi/groups/gpu.yaml
+++ b/schemas/obi/groups/gpu.yaml
@@ -1,0 +1,93 @@
+groups:
+  # CUDA GPU telemetry OBI emits from its gpuevent uprobes (enabled via
+  # `instrument_cuda`). The metric names, units and instruments mirror the
+  # emitters in `pkg/export/otel/metrics.go` / `pkg/export/prom/prom.go`; the
+  # `cuda.memcpy.kind` attribute mirrors `CudaMemcpyName` in
+  # `pkg/appolly/app/request/metric_attributes.go`.
+  - id: registry.obi.gpu
+    type: attribute_group
+    display_name: OBI CUDA GPU
+    brief: >
+      Attributes carried on OBI's CUDA GPU metrics.
+    attributes:
+      - id: cuda.memcpy.kind
+        type:
+          allow_custom_values: true
+          members:
+            - id: host_to_host
+              value: MemcpyHostToHost
+              stability: development
+            - id: host_to_device
+              value: MemcpyHostToDevice
+              stability: development
+            - id: device_to_host
+              value: MemcpyDeviceToHost
+              stability: development
+            - id: device_to_device
+              value: MemcpyDeviceToDevice
+              stability: development
+            - id: default
+              value: MemcpyDefault
+              stability: development
+        stability: development
+        brief: >
+          Direction of a CUDA memory copy, mirroring the `cudaMemcpyKind` enum
+          of the CUDA Runtime API.
+
+  - id: metric.gpu_cuda_kernel_launch_calls
+    type: metric
+    metric_name: gpu.cuda.kernel.launch.calls
+    instrument: counter
+    unit: ""
+    stability: development
+    brief: >
+      Count of CUDA kernel launches observed (cudaLaunchKernel).
+
+  - id: metric.gpu_cuda_graph_launch_calls
+    type: metric
+    metric_name: gpu.cuda.graph.launch.calls
+    instrument: counter
+    unit: ""
+    stability: development
+    brief: >
+      Count of CUDA graph launches observed (cudaGraphLaunch).
+
+  - id: metric.gpu_cuda_memory_allocations
+    type: metric
+    metric_name: gpu.cuda.memory.allocations
+    instrument: counter
+    unit: "By"
+    stability: development
+    brief: >
+      Bytes requested through CUDA device memory allocations (cudaMalloc).
+
+  - id: metric.gpu_cuda_kernel_grid_size
+    type: metric
+    metric_name: gpu.cuda.kernel.grid.size
+    instrument: histogram
+    unit: "1"
+    stability: development
+    brief: >
+      Distribution of CUDA kernel launch grid sizes (grid.x * grid.y * grid.z).
+
+  - id: metric.gpu_cuda_kernel_block_size
+    type: metric
+    metric_name: gpu.cuda.kernel.block.size
+    instrument: histogram
+    unit: "1"
+    stability: development
+    brief: >
+      Distribution of CUDA kernel launch block sizes
+      (block.x * block.y * block.z).
+
+  - id: metric.gpu_cuda_memory_copies
+    type: metric
+    metric_name: gpu.cuda.memory.copies
+    instrument: histogram
+    unit: "1"
+    stability: development
+    brief: >
+      Distribution of CUDA memory copy sizes (cudaMemcpy / cudaMemcpyAsync),
+      broken down by `cuda.memcpy.kind`.
+    attributes:
+      - ref: cuda.memcpy.kind


### PR DESCRIPTION
## Summary

There was no GPU integration test at all, so the `gpu.cuda.*` metrics and `cuda.memcpy.kind` were never observed. OBI's CUDA instrumentation attaches uprobes to `libcudart.so` **by symbol name** and reads entry-register args — it never talks to the GPU or driver. So a target that links a **stub `libcudart.so`** (the five hooked symbols, called with realistic args) exercises OBI's full instrumentation path on ordinary CI runners, no GPU hardware required. This adds that suite.

### Notes
- The new `schemas/obi/groups/gpu.yaml` will **overlap** the `gpu.cuda.*` declarations added by the coverage-tooling branch (`emitted_metrics.yaml`). Reconcile at merge — pick one home for the GPU metric declarations to avoid a duplicate-metric-name lint finding.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
