### PR TITLE
sunrpc: route traces through the weaver collector

### DIFF
--- a/internal/test/integration/configs/obi-config-sunrpc.yml
+++ b/internal/test/integration/configs/obi-config-sunrpc.yml
@@ -8,7 +8,7 @@ routes:
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4318
   otel_sdk_log_level: debug
 prometheus_export:
   port: 8999


### PR DESCRIPTION
## Summary

`onc_rpc.auth.flavor` was reported as never observed, but it is in fact already emitted: `AuthFlavorName(0)` returns `"auth_null"` (non-empty), it is set unconditionally on every call span, and the parser accepts `AUTH_NONE`. The real reason weaver never saw it is that the sunrpc suite exported its **traces straight to jaeger**, bypassing the weaver-tapping collector — so weaver only received the suite's metrics (its report carried resource attributes but zero rpc/span attributes). This routes traces through the collector (which still forwards to jaeger), so the sunrpc spans — and `onc_rpc.auth.flavor` with them — reach weaver. No test or app change.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
