### PR TITLE
Distinguish reused PIDs in runtime metrics

### DIFF
--- a/bpf/gotracer/go_runtime.c
+++ b/bpf/gotracer/go_runtime.c
@@ -72,7 +72,8 @@ static __always_inline void go_runtime_collect_histogram(u64 histogram_addr,
                                                          u64 underflow_offset,
                                                          u64 overflow_offset,
                                                          go_runtime_histogram_kind_t kind,
-                                                         const pid_info *pid) {
+                                                         const pid_info *pid,
+                                                         u64 generation) {
     if (!histogram_addr || underflow_offset % sizeof(u64)) {
         return;
     }
@@ -94,6 +95,7 @@ static __always_inline void go_runtime_collect_histogram(u64 histogram_addr,
     event->kind = kind;
     event->pid = *pid;
     event->bucket_count = bucket_count;
+    event->generation = generation;
 
     const u32 counts_size = bucket_count * sizeof(u64);
     if (bpf_probe_read_user(event->counts, counts_size, (void *)histogram_addr) ||
@@ -624,6 +626,7 @@ int obi_uprobe_go_runtime_metrics(struct pt_regs *ctx) {
 
     event->type = EVENT_GO_RUNTIME_METRICS;
     event->pid = key;
+    event->generation = target->generation;
     // Collectors set valid_mask bits for metric groups populated in this snapshot.
     __builtin_memset(&event->snapshot, 0, sizeof(event->snapshot));
 
@@ -648,8 +651,12 @@ int obi_uprobe_go_runtime_metrics(struct pt_regs *ctx) {
         const u64 histogram_addr =
             target->sched_addr +
             go_offset_of(ot, (go_offset){.v = _runtime_sched_stw_total_time_gc_pos});
-        go_runtime_collect_histogram(
-            histogram_addr, underflow_pos, overflow_pos, go_runtime_histogram_kind_gc_pause, &key);
+        go_runtime_collect_histogram(histogram_addr,
+                                     underflow_pos,
+                                     overflow_pos,
+                                     go_runtime_histogram_kind_gc_pause,
+                                     &key,
+                                     target->generation);
     }
 
     if (target->sched_addr &&
@@ -660,7 +667,8 @@ int obi_uprobe_go_runtime_metrics(struct pt_regs *ctx) {
                                      underflow_pos,
                                      overflow_pos,
                                      go_runtime_histogram_kind_scheduler_latency,
-                                     &key);
+                                     &key,
+                                     target->generation);
     }
     return 0;
 }

--- a/bpf/gotracer/maps/runtime.h
+++ b/bpf/gotracer/maps/runtime.h
@@ -100,6 +100,7 @@ typedef struct go_runtime_metric_target {
     u32 gc_goal_source;
     u32 _pad2;
     u64 gc_goal;
+    u64 generation;
 } go_runtime_metric_target_t;
 
 typedef enum go_runtime_gc_goal_source {
@@ -145,6 +146,7 @@ typedef struct go_runtime_histogram_event {
     u32 _pad2;
     u64 underflow;
     u64 overflow;
+    u64 generation;
     u64 counts[k_hist_max_buckets];
 } go_runtime_histogram_event_t;
 
@@ -176,6 +178,7 @@ typedef struct go_runtime_metric_event {
     u8 type;
     u8 _pad[3];
     pid_info pid;
+    u64 generation;
     go_runtime_metric_snapshot_t snapshot;
 } go_runtime_metric_event_t;
 

--- a/pkg/appolly/discover/exec/file.go
+++ b/pkg/appolly/discover/exec/file.go
@@ -39,6 +39,7 @@ type Init struct {
 type FileInfo struct {
 	mu             sync.RWMutex
 	service        svc.Attrs
+	runtimeGen     map[app.PID]uint64
 	cmdExePath     string
 	proExeLinkPath string
 	elfFile        *elf.File
@@ -52,6 +53,7 @@ type FileInfo struct {
 func New(init Init) *FileInfo {
 	return &FileInfo{
 		service:        init.Service,
+		runtimeGen:     map[app.PID]uint64{},
 		cmdExePath:     init.CmdExePath,
 		proExeLinkPath: init.ProExeLinkPath,
 		elfFile:        init.ELF,
@@ -61,6 +63,23 @@ func New(init Init) *FileInfo {
 		ino:            init.Ino,
 		ns:             init.Ns,
 	}
+}
+
+func (fi *FileInfo) RuntimeMetricGeneration(pid app.PID) uint64 {
+	fi.mu.RLock()
+	defer fi.mu.RUnlock()
+
+	return fi.runtimeGen[pid]
+}
+
+func (fi *FileInfo) SetRuntimeMetricGeneration(pid app.PID, generation uint64) {
+	fi.mu.Lock()
+	defer fi.mu.Unlock()
+
+	if fi.runtimeGen == nil {
+		fi.runtimeGen = map[app.PID]uint64{}
+	}
+	fi.runtimeGen[pid] = generation
 }
 
 // Identity getters. Fields are set at construction and never mutated, so

--- a/pkg/export/otel/metrics_runtime.go
+++ b/pkg/export/otel/metrics_runtime.go
@@ -295,7 +295,7 @@ func (r *RuntimeMetricsReporter) onProcessEvent(pe *exec.ProcessEvent) {
 			r.reporters.Remove(staleUID)
 			return
 		}
-		r.pidTracker.AddPID(pid, service.UID)
+		r.pidTracker.AddPIDWithGeneration(pid, service.UID, pe.File.RuntimeMetricGeneration(pid))
 		return
 	}
 
@@ -339,7 +339,7 @@ func (r *RuntimeMetricsReporter) snapshotProcessLive(snapshot runtimemetrics.Run
 	if pid == 0 {
 		return true
 	}
-	return r.pidTracker.PIDLiveOrUnknown(pid, snapshot.Service.UID)
+	return r.pidTracker.PIDLiveOrUnknown(pid, snapshot.Service.UID, snapshot.Generation)
 }
 
 func (r *RuntimeMetricsReporter) shouldReportSnapshot(snapshot runtimemetrics.RuntimeMetricSnapshot) bool {

--- a/pkg/export/otel/metrics_runtime_test.go
+++ b/pkg/export/otel/metrics_runtime_test.go
@@ -188,29 +188,38 @@ func TestRuntimeMetricsReporterAcceptsSnapshotsBeforeCreationAndSkipsAfterTermin
 		log:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 		runtimeEnabled: runtimemetrics.Enabled{Runtime: true},
 	}
-	processEvent := func(eventType exec.ProcessEventType) *exec.ProcessEvent {
+	processEvent := func(eventType exec.ProcessEventType, generation uint64) *exec.ProcessEvent {
+		file := exec.New(exec.Init{Pid: 101, Service: service})
+		file.SetRuntimeMetricGeneration(101, generation)
 		return &exec.ProcessEvent{
 			Type: eventType,
-			File: exec.New(exec.Init{Pid: 101, Service: service}),
+			File: file,
 		}
 	}
 	snapshots := []runtimemetrics.RuntimeMetricSnapshot{{
-		PID:     101,
-		Service: service,
-		Go:      &runtimemetrics.GoRuntimeMetricSnapshot{},
+		PID:        101,
+		Service:    service,
+		Generation: 1,
+		Go:         &runtimemetrics.GoRuntimeMetricSnapshot{},
 	}}
 
 	reporter.reportRuntimeMetrics(snapshots)
 	assert.Equal(t, 1, constructed)
 
-	reporter.onProcessEvent(processEvent(exec.ProcessEventCreated))
+	reporter.onProcessEvent(processEvent(exec.ProcessEventCreated, 1))
 	reporter.reportRuntimeMetrics(snapshots)
 	assert.Equal(t, 1, constructed)
 
-	reporter.onProcessEvent(processEvent(exec.ProcessEventTerminated))
+	reporter.onProcessEvent(processEvent(exec.ProcessEventTerminated, 1))
 	reporter.reportRuntimeMetrics(snapshots)
 	assert.Equal(t, 1, constructed,
 		"in-flight snapshot must not resurrect the removed reporter")
+
+	reusedPIDSnapshot := snapshots[0]
+	reusedPIDSnapshot.Generation = 2
+	reporter.reportRuntimeMetrics([]runtimemetrics.RuntimeMetricSnapshot{reusedPIDSnapshot})
+	assert.Equal(t, 2, constructed,
+		"a reused PID generation must be accepted before its creation event")
 }
 
 func TestRuntimeMetricsReporterShouldReportSnapshot(t *testing.T) {

--- a/pkg/export/otel/pid_tracker.go
+++ b/pkg/export/otel/pid_tracker.go
@@ -12,28 +12,40 @@ import (
 
 type PidServiceTracker struct {
 	pidToService   map[app.PID]svc.UID
+	pidGenerations map[app.PID]uint64
 	servicePIDs    map[svc.UID]map[app.PID]struct{}
-	terminatedPIDs map[app.PID]svc.UID
+	terminatedPIDs map[app.PID]pidServiceGeneration
 	lock           sync.Mutex
 	names          map[svc.ServiceNameNamespace]svc.UID
+}
+
+type pidServiceGeneration struct {
+	uid        svc.UID
+	generation uint64
 }
 
 func NewPidServiceTracker() PidServiceTracker {
 	return PidServiceTracker{
 		pidToService:   map[app.PID]svc.UID{},
+		pidGenerations: map[app.PID]uint64{},
 		servicePIDs:    map[svc.UID]map[app.PID]struct{}{},
-		terminatedPIDs: map[app.PID]svc.UID{},
+		terminatedPIDs: map[app.PID]pidServiceGeneration{},
 		lock:           sync.Mutex{},
 		names:          map[svc.ServiceNameNamespace]svc.UID{},
 	}
 }
 
 func (p *PidServiceTracker) AddPID(pid app.PID, uid svc.UID) {
+	p.AddPIDWithGeneration(pid, uid, 0)
+}
+
+func (p *PidServiceTracker) AddPIDWithGeneration(pid app.PID, uid svc.UID, generation uint64) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	delete(p.terminatedPIDs, pid)
 	p.pidToService[pid] = uid
+	p.pidGenerations[pid] = generation
 
 	pids, ok := p.servicePIDs[uid]
 	if !ok {
@@ -52,7 +64,8 @@ func (p *PidServiceTracker) RemovePID(pid app.PID) (bool, svc.UID) {
 	uid, ok := p.pidToService[pid]
 	if ok {
 		delete(p.pidToService, pid)
-		p.terminatedPIDs[pid] = uid
+		p.terminatedPIDs[pid] = pidServiceGeneration{uid: uid, generation: p.pidGenerations[pid]}
+		delete(p.pidGenerations, pid)
 
 		if pids, exists := p.servicePIDs[uid]; exists {
 			delete(pids, pid)
@@ -78,15 +91,23 @@ func (p *PidServiceTracker) TracksPID(pid app.PID) (svc.UID, bool) {
 	return u, ok
 }
 
-func (p *PidServiceTracker) PIDLiveOrUnknown(pid app.PID, uid svc.UID) bool {
+func (p *PidServiceTracker) PIDLiveOrUnknown(pid app.PID, uid svc.UID, generation uint64) bool {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	if trackedUID, ok := p.pidToService[pid]; ok {
-		return trackedUID.Equals(&uid)
+		if !trackedUID.Equals(&uid) {
+			return false
+		}
+		trackedGeneration := p.pidGenerations[pid]
+		return trackedGeneration == 0 || generation == 0 || trackedGeneration == generation
 	}
-	terminatedUID, terminated := p.terminatedPIDs[pid]
-	return !terminated || !terminatedUID.Equals(&uid)
+	terminatedProcess, terminated := p.terminatedPIDs[pid]
+	if !terminated || !terminatedProcess.uid.Equals(&uid) {
+		return true
+	}
+	return terminatedProcess.generation != 0 && generation != 0 &&
+		terminatedProcess.generation != generation
 }
 
 func (p *PidServiceTracker) ReplaceUID(staleUID, newUID svc.UID) {

--- a/pkg/export/otel/pid_tracker.go
+++ b/pkg/export/otel/pid_tracker.go
@@ -106,8 +106,7 @@ func (p *PidServiceTracker) PIDLiveOrUnknown(pid app.PID, uid svc.UID, generatio
 	if !terminated || !terminatedProcess.uid.Equals(&uid) {
 		return true
 	}
-	return terminatedProcess.generation != 0 && generation != 0 &&
-		terminatedProcess.generation != generation
+	return generation != 0 && terminatedProcess.generation != generation
 }
 
 func (p *PidServiceTracker) ReplaceUID(staleUID, newUID svc.UID) {

--- a/pkg/export/otel/pid_tracker_test.go
+++ b/pkg/export/otel/pid_tracker_test.go
@@ -209,6 +209,24 @@ func TestPidServiceTracker_TracksPID(t *testing.T) {
 	assert.Equal(t, uid2, gotUID, "TracksPID should return correct UID for remaining PID")
 }
 
+func TestPidServiceTracker_PIDLiveOrUnknownUsesProcessGeneration(t *testing.T) {
+	tracker := NewPidServiceTracker()
+	uid := makeUID("orders", "production")
+	pid := app.PID(101)
+
+	tracker.AddPIDWithGeneration(pid, uid, 1)
+	assert.True(t, tracker.PIDLiveOrUnknown(pid, uid, 1))
+	assert.False(t, tracker.PIDLiveOrUnknown(pid, uid, 2))
+
+	tracker.RemovePID(pid)
+	assert.False(t, tracker.PIDLiveOrUnknown(pid, uid, 1))
+	assert.True(t, tracker.PIDLiveOrUnknown(pid, uid, 2))
+
+	tracker.AddPIDWithGeneration(pid, uid, 2)
+	assert.False(t, tracker.PIDLiveOrUnknown(pid, uid, 1))
+	assert.True(t, tracker.PIDLiveOrUnknown(pid, uid, 2))
+}
+
 func TestPidServiceTracker_UpdateUID(t *testing.T) {
 	t.Run("update existing service UID", func(t *testing.T) {
 		tracker := NewPidServiceTracker()

--- a/pkg/export/otel/pid_tracker_test.go
+++ b/pkg/export/otel/pid_tracker_test.go
@@ -225,6 +225,12 @@ func TestPidServiceTracker_PIDLiveOrUnknownUsesProcessGeneration(t *testing.T) {
 	tracker.AddPIDWithGeneration(pid, uid, 2)
 	assert.False(t, tracker.PIDLiveOrUnknown(pid, uid, 1))
 	assert.True(t, tracker.PIDLiveOrUnknown(pid, uid, 2))
+
+	tracker = NewPidServiceTracker()
+	tracker.AddPID(pid, uid)
+	tracker.RemovePID(pid)
+	assert.False(t, tracker.PIDLiveOrUnknown(pid, uid, 0))
+	assert.True(t, tracker.PIDLiveOrUnknown(pid, uid, 2))
 }
 
 func TestPidServiceTracker_UpdateUID(t *testing.T) {

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -1533,7 +1533,7 @@ func (r *metricsReporter) handleProcessEvent(pe exec.ProcessEvent, log *slog.Log
 
 		r.createEventMetrics(&snap)
 		r.serviceMap[uid] = snap
-		r.setupPIDToServiceRelationship(pid, uid)
+		r.pidsTracker.AddPIDWithGeneration(pid, uid, pe.File.RuntimeMetricGeneration(pid))
 	} else {
 		if r.goRuntimeHistograms != nil {
 			r.goRuntimeHistograms.DeletePID(pid)

--- a/pkg/export/prom/prom_runtime.go
+++ b/pkg/export/prom/prom_runtime.go
@@ -127,7 +127,7 @@ func (r *metricsReporter) runtimeSnapshotProcessLive(
 	if snapshot.PID == 0 {
 		return true
 	}
-	return r.pidsTracker.PIDLiveOrUnknown(snapshot.PID, snapshot.Service.UID)
+	return r.pidsTracker.PIDLiveOrUnknown(snapshot.PID, snapshot.Service.UID, snapshot.Generation)
 }
 
 func (r *metricsReporter) runtimeMetricsEnabled() runtimemetrics.Enabled {

--- a/pkg/export/prom/prom_runtime_histograms_test.go
+++ b/pkg/export/prom/prom_runtime_histograms_test.go
@@ -465,18 +465,21 @@ func TestRuntimeReporterAcceptsHistogramsBeforeCreationAndSkipsAfterTermination(
 	trackedService := untrackedService
 	trackedService.UID.Name = "tracked"
 	trackedService.ProcPID = 101
-	processEvent := func(eventType exec.ProcessEventType) exec.ProcessEvent {
+	processEvent := func(eventType exec.ProcessEventType, generation uint64) exec.ProcessEvent {
+		file := exec.New(exec.Init{Pid: trackedService.ProcPID, Service: trackedService})
+		file.SetRuntimeMetricGeneration(trackedService.ProcPID, generation)
 		return exec.ProcessEvent{
 			Type: eventType,
-			File: exec.New(exec.Init{Pid: trackedService.ProcPID, Service: trackedService}),
+			File: file,
 		}
 	}
-	reporter.handleProcessEvent(processEvent(exec.ProcessEventCreated), slog.Default())
+	reporter.handleProcessEvent(processEvent(exec.ProcessEventCreated, 1), slog.Default())
 	trackedSnapshot := testPromRuntimeHistogramMetricSnapshot(
 		trackedService,
 		runtimemetrics.GoHistogramKindGCPause,
 		3,
 	)
+	trackedSnapshot.Generation = 1
 	reporter.collectRuntimeMetrics([]runtimemetrics.RuntimeMetricSnapshot{trackedSnapshot})
 	require.NotNil(t, gatheredMetric(t, registry, attributes.GoRuntimeMemoryGCPauseDuration.Prom,
 		map[string]string{"service_name": "tracked", "service_namespace": "production"}))
@@ -487,7 +490,7 @@ func TestRuntimeReporterAcceptsHistogramsBeforeCreationAndSkipsAfterTermination(
 	go func() {
 		defer waitGroup.Done()
 		<-start
-		reporter.handleProcessEvent(processEvent(exec.ProcessEventTerminated), slog.Default())
+		reporter.handleProcessEvent(processEvent(exec.ProcessEventTerminated, 1), slog.Default())
 	}()
 	go func() {
 		defer waitGroup.Done()
@@ -499,6 +502,26 @@ func TestRuntimeReporterAcceptsHistogramsBeforeCreationAndSkipsAfterTermination(
 
 	assert.Nil(t, gatheredMetric(t, registry, attributes.GoRuntimeMemoryGCPauseDuration.Prom,
 		map[string]string{"service_name": "tracked", "service_namespace": "production"}))
+
+	reusedPIDSnapshot := testPromRuntimeHistogramMetricSnapshot(
+		trackedService,
+		runtimemetrics.GoHistogramKindGCPause,
+		4,
+	)
+	reusedPIDSnapshot.Generation = 2
+	reporter.collectRuntimeMetrics([]runtimemetrics.RuntimeMetricSnapshot{reusedPIDSnapshot})
+	histogram = gatheredMetric(t, registry, attributes.GoRuntimeMemoryGCPauseDuration.Prom,
+		map[string]string{"service_name": "tracked", "service_namespace": "production"})
+	require.NotNil(t, histogram, "a reused PID must be accepted before its creation event")
+	assert.Equal(t, uint64(4), histogram.GetHistogram().GetSampleCount())
+
+	reporter.handleProcessEvent(processEvent(exec.ProcessEventCreated, 2), slog.Default())
+	reporter.collectRuntimeMetrics([]runtimemetrics.RuntimeMetricSnapshot{trackedSnapshot})
+	histogram = gatheredMetric(t, registry, attributes.GoRuntimeMemoryGCPauseDuration.Prom,
+		map[string]string{"service_name": "tracked", "service_namespace": "production"})
+	require.NotNil(t, histogram)
+	assert.Equal(t, uint64(4), histogram.GetHistogram().GetSampleCount(),
+		"an old in-flight generation must be rejected after PID reuse")
 }
 
 func TestGoRuntimeHistogramCollectorSupportsConcurrentUpdateCollectAndDelete(_ *testing.T) {

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -47,6 +48,16 @@ type runtimeMetricTargetKey struct {
 }
 
 const missingGoOffset = ^uint64(0)
+
+var nextRuntimeMetricGeneration atomic.Uint64
+
+func newRuntimeMetricGeneration() uint64 {
+	for {
+		if generation := nextRuntimeMetricGeneration.Add(1); generation != 0 {
+			return generation
+		}
+	}
+}
 
 // Mirrors go_runtime_metric_valid_t in bpf/gotracer/maps/runtime.h. Scalar
 // bits also mirror the raw snapshot masks in pkg/runtimemetrics/reader.go.
@@ -711,6 +722,10 @@ func (p *Tracer) registerRuntimeMetricTarget(pid app.PID, ns uint32, fileInfo *e
 	}
 	availableMask = p.goRuntimeMetricMaskForSymbols(fileInfo, availableMask, symbols)
 	p.goRuntimeMetricMaskByIno[fileInfo.Ino()] = availableMask
+	generation := fileInfo.RuntimeMetricGeneration(pid)
+	if generation == 0 {
+		generation = newRuntimeMetricGeneration()
+	}
 
 	value := BpfGoRuntimeMetricTargetT{
 		MemstatsAddr:                 symbols.MemstatsAddr,
@@ -724,12 +739,14 @@ func (p *Tracer) registerRuntimeMetricTarget(pid app.PID, ns uint32, fileInfo *e
 		AllpAddr:                     symbols.AllpAddr,
 		GoroutineCountIncludesSystem: symbols.GoroutineCountIncludesSystem,
 		GcGoalSource:                 uint32(p.goRuntimeGCGoalSourceByIno[fileInfo.Ino()]),
+		Generation:                   generation,
 	}
 
 	if err := p.bpfObjects.GoRuntimeMetricTargets.Put(pidInfo, value); err != nil {
 		p.log.Debug("setting runtime metric target failed", "pid", pid, "ino", fileInfo.Ino(), "error", err)
 		return
 	}
+	fileInfo.SetRuntimeMetricGeneration(pid, generation)
 
 	if p.runtimeMetricTargetKeys == nil {
 		p.runtimeMetricTargetKeys = map[runtimeMetricTargetKey]BpfPidInfo{}

--- a/pkg/internal/ebpf/gotracer/gotracer_test.go
+++ b/pkg/internal/ebpf/gotracer/gotracer_test.go
@@ -175,7 +175,7 @@ func TestGoRuntimeMetricMaskABI(t *testing.T) {
 func TestGoRuntimeMetricTargetABIAppendsGoroutineMetadata(t *testing.T) {
 	var target BpfGoRuntimeMetricTargetT
 
-	assert.Equal(t, uintptr(96), unsafe.Sizeof(target))
+	assert.Equal(t, uintptr(104), unsafe.Sizeof(target))
 	assert.Equal(t, uintptr(40), unsafe.Offsetof(target.SizeClassToSizesAddr))
 	assert.Equal(t, uintptr(48), unsafe.Offsetof(target.SchedAddr))
 	assert.Equal(t, uintptr(56), unsafe.Offsetof(target.AllglenAddr))
@@ -186,9 +186,10 @@ func TestGoRuntimeMetricTargetABIAppendsGoroutineMetadata(t *testing.T) {
 func TestGoRuntimeMetricTargetABIAppendsGCGoalCache(t *testing.T) {
 	var target BpfGoRuntimeMetricTargetT
 
-	assert.Equal(t, uintptr(96), unsafe.Sizeof(target))
+	assert.Equal(t, uintptr(104), unsafe.Sizeof(target))
 	assert.Equal(t, uintptr(80), unsafe.Offsetof(target.GcGoalSource))
 	assert.Equal(t, uintptr(88), unsafe.Offsetof(target.GcGoal))
+	assert.Equal(t, uintptr(96), unsafe.Offsetof(target.Generation))
 }
 
 func TestGoRuntimeGCGoalSourceSelection(t *testing.T) {

--- a/pkg/runtimemetrics/reader.go
+++ b/pkg/runtimemetrics/reader.go
@@ -28,9 +28,10 @@ func IsGoRuntimeMetricRecord(record *ringbuf.Record) bool {
 }
 
 type RuntimeMetricSnapshot struct {
-	Service svc.Attrs
-	PID     app.PID
-	Time    time.Time
+	Service    svc.Attrs
+	PID        app.PID
+	Generation uint64
+	Time       time.Time
 
 	Go  *GoRuntimeMetricSnapshot
 	JVM *JVMRuntimeMetricSnapshot
@@ -161,10 +162,11 @@ type goRuntimeMetricRawKey struct {
 }
 
 type goRuntimeMetricRawEvent struct {
-	Type     uint8
-	Pad      [3]uint8
-	PID      goRuntimeMetricRawKey
-	Snapshot goRuntimeMetricRawSnapshot
+	Type       uint8
+	Pad        [3]uint8
+	PID        goRuntimeMetricRawKey
+	Generation uint64
+	Snapshot   goRuntimeMetricRawSnapshot
 }
 
 type goRuntimeMetricRawSnapshot struct {
@@ -201,6 +203,7 @@ type goRuntimeHistogramRawEvent struct {
 	Pad2        uint32
 	Underflow   uint64
 	Overflow    uint64
+	Generation  uint64
 	Counts      [goRuntimeHistogramMaxBuckets]uint64
 }
 
@@ -254,6 +257,7 @@ func scalarSnapshotFromRingbuf(
 	}
 
 	snapshot := convertGoRuntimeMetricSnapshot(service, app.PID(event.PID.HostPID), event.Snapshot)
+	snapshot.Generation = event.Generation
 	return snapshot, false, nil
 }
 
@@ -287,9 +291,10 @@ func histogramSnapshotFromRingbuf(
 	counts := make([]uint64, int(event.BucketCount))
 	copy(counts, event.Counts[:event.BucketCount])
 	return RuntimeMetricSnapshot{
-		Service: service,
-		PID:     app.PID(event.PID.HostPID),
-		Time:    time.Now(),
+		Service:    service,
+		PID:        app.PID(event.PID.HostPID),
+		Generation: event.Generation,
+		Time:       time.Now(),
 		Histogram: &GoRuntimeHistogramSnapshot{
 			Kind:      event.Kind,
 			Counts:    counts,

--- a/pkg/runtimemetrics/reader_test.go
+++ b/pkg/runtimemetrics/reader_test.go
@@ -28,8 +28,9 @@ func TestGoRuntimeMetricRawABI(t *testing.T) {
 	var event goRuntimeMetricRawEvent
 	var snapshot goRuntimeMetricRawSnapshot
 
-	require.Equal(t, uintptr(160), unsafe.Sizeof(event))
-	require.Equal(t, uintptr(16), unsafe.Offsetof(event.Snapshot))
+	require.Equal(t, uintptr(168), unsafe.Sizeof(event))
+	require.Equal(t, uintptr(16), unsafe.Offsetof(event.Generation))
+	require.Equal(t, uintptr(24), unsafe.Offsetof(event.Snapshot))
 	require.Equal(t, uintptr(144), unsafe.Sizeof(snapshot))
 	require.Equal(t, uintptr(0), unsafe.Offsetof(snapshot.ValidMask))
 	require.Equal(t, uintptr(8), unsafe.Offsetof(snapshot.NumGC))
@@ -59,7 +60,7 @@ func TestGoRuntimeHistogramRawABI(t *testing.T) {
 	require.Equal(t, byte(21), byte(EventTypeGoRuntimeHistogram))
 	require.Equal(t, GoHistogramKindGCPause, GoHistogramKind(0))
 	require.Equal(t, GoHistogramKindSchedLatency, GoHistogramKind(1))
-	require.Equal(t, uintptr(1320), unsafe.Sizeof(event))
+	require.Equal(t, uintptr(1328), unsafe.Sizeof(event))
 	require.Equal(t, uintptr(0), unsafe.Offsetof(event.Type))
 	require.Equal(t, uintptr(1), unsafe.Offsetof(event.Kind))
 	require.Equal(t, uintptr(2), unsafe.Offsetof(event.Pad))
@@ -68,7 +69,8 @@ func TestGoRuntimeHistogramRawABI(t *testing.T) {
 	require.Equal(t, uintptr(20), unsafe.Offsetof(event.Pad2))
 	require.Equal(t, uintptr(24), unsafe.Offsetof(event.Underflow))
 	require.Equal(t, uintptr(32), unsafe.Offsetof(event.Overflow))
-	require.Equal(t, uintptr(40), unsafe.Offsetof(event.Counts))
+	require.Equal(t, uintptr(40), unsafe.Offsetof(event.Generation))
+	require.Equal(t, uintptr(48), unsafe.Offsetof(event.Counts))
 }
 
 func TestGoRuntimeMetricValidMaskABI(t *testing.T) {
@@ -266,7 +268,8 @@ func TestSnapshotFromRingbuf(t *testing.T) {
 	}
 	var record bytes.Buffer
 	require.NoError(t, binary.Write(&record, binary.LittleEndian, goRuntimeMetricRawEvent{
-		Type: EventTypeGoRuntimeMetric,
+		Type:       EventTypeGoRuntimeMetric,
+		Generation: 17,
 		PID: goRuntimeMetricRawKey{
 			HostPID: 1000,
 			UserPID: 123,
@@ -298,6 +301,7 @@ func TestSnapshotFromRingbuf(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ignore)
 	require.Equal(t, app.PID(1000), snapshot.PID)
+	require.Equal(t, uint64(17), snapshot.Generation)
 	require.Equal(t, service, snapshot.Service)
 	require.NotNil(t, snapshot.Go)
 	require.Equal(t, int64(1024), *snapshot.Go.MemoryLimit)
@@ -314,8 +318,9 @@ func TestSnapshotFromRingbufDecodesHistogramAndCopiesCounts(t *testing.T) {
 		Features:    export.FeatureApplicationRuntime,
 	}
 	event := goRuntimeHistogramRawEvent{
-		Type: EventTypeGoRuntimeHistogram,
-		Kind: GoHistogramKindSchedLatency,
+		Type:       EventTypeGoRuntimeHistogram,
+		Kind:       GoHistogramKindSchedLatency,
+		Generation: 23,
 		PID: goRuntimeMetricRawKey{
 			HostPID: 1000,
 			UserPID: 123,
@@ -338,6 +343,7 @@ func TestSnapshotFromRingbufDecodesHistogramAndCopiesCounts(t *testing.T) {
 	require.False(t, ignore)
 	require.Equal(t, service, snapshot.Service)
 	require.Equal(t, app.PID(1000), snapshot.PID)
+	require.Equal(t, uint64(23), snapshot.Generation)
 	require.False(t, snapshot.Time.Before(before))
 	require.False(t, snapshot.Time.After(after))
 	require.Nil(t, snapshot.Go)


### PR DESCRIPTION
## Summary

- Version each process-scoped Go runtime metric target and propagate that generation through scalar and histogram ring buffer events.
- Make the OTLP and Prometheus exporters reject late snapshots from a terminated generation while accepting a reused PID's new generation before its process-created event arrives.
- Cover the runtime event ABI and the termination → PID reuse → snapshot-before-create lifecycle.

## Context

PR #2740 guarded runtime metric exporters against snapshots that arrive after process termination by retaining `(PID, service UID)` tombstones. Both identifiers can be reused, so a new process's first snapshot could match the old tombstone and be dropped when it arrived before the new process-created event.

This change assigns a generation when each per-process Go runtime metric target is installed. The eBPF events carry that generation through decoding to the exporters, allowing lifecycle filtering to distinguish old in-flight data from a newly reused PID without weakening the late-snapshot guard.

Follow-up to https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2740#discussion_r3707534412.

## Validation

- `make generate`
- `make clang-format`
- `make clang-tidy`
- `make verify`
- `make compile`
