### PR TITLE
fix(otel-detection): don't attribute an ambiguous OTLP export to both signals

### DIFF
--- a/devdocs/exclude-otel-instrumented-services.md
+++ b/devdocs/exclude-otel-instrumented-services.md
@@ -71,6 +71,11 @@ as follows:
   `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`,
   falling back to `OTEL_EXPORTER_OTLP_ENDPOINT`, falling back to
   `default_otlp_grpc_port` (4317).
+- Accept the match only if it fits **one** signal. A single OTLP endpoint carries
+  every signal, so a port that matches traces and metrics equally well identifies
+  neither, and OBI leaves both flags unset. The heuristic still resolves a signal
+  whenever the per-signal `..._ENDPOINT` ports differ or a per-signal
+  `..._PROTOCOL` rules one of them out.
 
 Detection is per-telemetry-type and per-service: a service may be flagged for
 metrics but not traces, or vice versa. Once flagged, the flag is sticky for the
@@ -150,7 +155,24 @@ In practice this means:
   always produce duplicates.
 - The first few requests of a long-lived process are duplicated.
 
-### 2. Suppression is all-or-nothing per service
+### 2. Undecoded gRPC paths on a shared endpoint are never suppressed
+
+OBI cannot always recover a gRPC method: an OTLP exporter holds one long-lived
+HTTP/2 connection and sends an identical `:path` on every export, so HPACK
+compresses it to a dynamic-table index after the first request. OBI attaching
+mid-stream has no dynamic-table state to resolve that index. This is what the
+port fallback exists for, and it is common with Python `grpcio` exporters.
+
+When such a service also sends every signal to one endpoint — the usual
+`OTEL_EXPORTER_OTLP_ENDPOINT` setup — nothing distinguishes a traces export from
+a metrics export, so OBI suppresses neither and duplicates that service's
+telemetry for as long as it runs. This is deliberate: attributing the export to
+both signals would suppress the one the SDK never sends, and no other producer
+would replace it, so an ambiguous signal fails open. Configuring
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
+on different ports restores suppression.
+
+### 3. Suppression is all-or-nothing per service
 
 Once a service is flagged, OBI suppresses **every** span / metric it would
 produce for that service, regardless of category. There is no way to say "the

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -2264,6 +2264,17 @@ func (s *Span) sendsTracesOnOtelPort(defaultOtlpGRPCPort int) bool {
 	}
 }
 
+// A single OTLP endpoint carries every signal, so a port match alone cannot tell
+// which signal a span exports. Attributing an ambiguous export to both would
+// suppress the one the SDK never sends, and nothing else would produce it.
+func (s *Span) sendsOnlyMetricsOnOtelPort(defaultOtlpGRPCPort int) bool {
+	return s.sendsMetricsOnOtelPort(defaultOtlpGRPCPort) && !s.sendsTracesOnOtelPort(defaultOtlpGRPCPort)
+}
+
+func (s *Span) sendsOnlyTracesOnOtelPort(defaultOtlpGRPCPort int) bool {
+	return s.sendsTracesOnOtelPort(defaultOtlpGRPCPort) && !s.sendsMetricsOnOtelPort(defaultOtlpGRPCPort)
+}
+
 func (s *Span) sendsMetricsOnGrpcOtelPort(defaultOtlpGRPCPort int) bool {
 	otlpMetricsProtocol, ok := s.Service.EnvVars[envOTLPMetricsProtocol]
 	if ok && otlpMetricsProtocol != otlpGrpcProtocol {
@@ -2302,7 +2313,7 @@ func (s *Span) IsExportMetricsSpan(defaultOtlpGRPCPort int) bool {
 		return false
 	}
 
-	return s.isMetricsExportURL() || s.sendsMetricsOnOtelPort(defaultOtlpGRPCPort)
+	return s.isMetricsExportURL() || s.sendsOnlyMetricsOnOtelPort(defaultOtlpGRPCPort)
 }
 
 func (s *Span) IsExportTracesSpan(defaultOtlpGRPCPort int) bool {
@@ -2311,7 +2322,7 @@ func (s *Span) IsExportTracesSpan(defaultOtlpGRPCPort int) bool {
 		return false
 	}
 
-	return s.isTracesExportURL() || s.sendsTracesOnOtelPort(defaultOtlpGRPCPort)
+	return s.isTracesExportURL() || s.sendsOnlyTracesOnOtelPort(defaultOtlpGRPCPort)
 }
 
 func (s *Span) IsSelfReferenceSpan() bool {

--- a/pkg/appolly/app/request/span_test.go
+++ b/pkg/appolly/app/request/span_test.go
@@ -854,6 +854,32 @@ func TestDetectsOTelExport(t *testing.T) {
 			span:    Span{Type: EventTypeGRPCClient, HostPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0},
 			exports: false,
 		},
+		{
+			name: fmt.Sprintf("undecoded path on the default %d port doesn't identify the signal", defaultOtlpGRPCPort),
+			span: Span{
+				Type: EventTypeGRPCClient, HostPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+			},
+			exports: false,
+		},
+		{
+			name: "undecoded path on a generic OTEL_EXPORTER_OTLP_ENDPOINT doesn't identify the signal",
+			span: Span{
+				Type: EventTypeGRPCClient, HostPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:9090"}},
+			},
+			exports: false,
+		},
+		{
+			name: "signal endpoints on distinct ports export",
+			span: Span{
+				Type: EventTypeGRPCClient, HostPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{
+					"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4317",
+					"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":  "http://localhost:4318",
+				}},
+			},
+			exports: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -985,6 +1011,32 @@ func TestDetectsOTelExport(t *testing.T) {
 			name:    fmt.Sprintf("no otel environment sends to anything other the %d doesn't export", defaultOtlpGRPCPort),
 			span:    Span{Type: EventTypeGRPCClient, HostPort: 8080, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0},
 			exports: false,
+		},
+		{
+			name: fmt.Sprintf("undecoded path on the default %d port doesn't identify the signal", defaultOtlpGRPCPort),
+			span: Span{
+				Type: EventTypeGRPCClient, HostPort: 4317, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+			},
+			exports: false,
+		},
+		{
+			name: "undecoded path on a generic OTEL_EXPORTER_OTLP_ENDPOINT doesn't identify the signal",
+			span: Span{
+				Type: EventTypeGRPCClient, HostPort: 9090, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{"OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:9090"}},
+			},
+			exports: false,
+		},
+		{
+			name: "signal endpoints on distinct ports export",
+			span: Span{
+				Type: EventTypeGRPCClient, HostPort: 4318, Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+				Service: svc.Attrs{EnvVars: map[string]string{
+					"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "http://localhost:4317",
+					"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":  "http://localhost:4318",
+				}},
+			},
+			exports: true,
 		},
 	}
 

--- a/pkg/ebpf/common/pids_test.go
+++ b/pkg/ebpf/common/pids_test.go
@@ -159,6 +159,28 @@ func TestFilter_ExportsOTelDetection(t *testing.T) {
 	assert.True(t, fi.ExportsOTelTraces())
 }
 
+func TestFilter_ExportsOTelDetectionUndecodedPath(t *testing.T) {
+	const defaultOtlpPort = 4317
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+
+	fi := exec.New(exec.Init{})
+	// Undecoded :path on the shared OTLP gRPC port identifies no signal, so repeated
+	// exports must not accumulate both flags.
+	span := request.Span{
+		Type: request.EventTypeGRPCClient, HostPort: defaultOtlpPort,
+		Method: "GET", Path: "*", RequestStart: 100, End: 200, Status: 0,
+	}
+
+	pf.checkIfExportsOTel(fi, &span, defaultOtlpPort)
+	pf.checkIfExportsOTel(fi, &span, defaultOtlpPort)
+
+	assert.False(t, fi.ExportsOTelMetrics())
+	assert.False(t, fi.ExportsOTelTraces())
+
+	pf.checkIfExportsOTelSpanMetrics(fi, &span, defaultOtlpPort)
+	assert.False(t, fi.ExportsOTelMetricsSpan())
+}
+
 func TestFilter_ExportsOTelSpanDetection(t *testing.T) {
 	const defaultOtlpPort = 4317
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})


### PR DESCRIPTION
## Summary

Fixes #2765.

When OBI can't decode a gRPC `:path` it falls back to matching the peer port against the process's OTLP endpoint. Traces and metrics share that endpoint, so the fallback made `IsExportMetricsSpan` and `IsExportTracesSpan` both accept the same span. With the sticky per-signal flags, two exports were enough to flag a service for both signals — a service exporting only traces through its SDK had OBI suppress its own RED metrics, which nothing else produced.

The port now counts as evidence only when it identifies one signal: the per-signal `..._ENDPOINT` ports differ, or a per-signal `..._PROTOCOL` rules one out. An ambiguous export sets no flag, so the worst case becomes duplicate telemetry rather than a signal disappearing. Path-based detection is unaffected.

The existing `TestDetectsOTelExport` cases already assert that the two predicates are mutually exclusive (`assert.False` on the opposite predicate), and each port-based case sets the other signal's protocol to `http/protobuf` to keep it unambiguous — so the invariant was intended; only the ambiguous case was uncovered. New cases cover it, plus a `pids.go`-level test that two ambiguous exports set neither flag.

`devdocs/exclude-otel-instrumented-services.md` documents the new fail-open behavior and how to restore suppression (distinct per-signal endpoint ports).

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

`make lint`, `make compile`, and the affected unit tests pass. I also confirmed the new tests fail without the fix.

Per the [Generative AI policy](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/AI-POLICY.md): I used Claude Code to draft the change, tests, and docs; I reviewed and edited all of it, verified the behavior against the code paths described in #2765, and take responsibility for the result.
