### PR TITLE
fix(genai): normalize OpenAI Responses content

### DIFF
--- a/pkg/appolly/app/request/genai_normalize_openai.go
+++ b/pkg/appolly/app/request/genai_normalize_openai.go
@@ -8,6 +8,23 @@ import (
 	"strings"
 )
 
+type openAIInputAudio struct {
+	Data   string `json:"data"`
+	Format string `json:"format,omitempty"`
+}
+
+type openAIResponsesContentBlock struct {
+	Type       string            `json:"type"`
+	Text       string            `json:"text,omitempty"`
+	Refusal    string            `json:"refusal,omitempty"`
+	ImageURL   string            `json:"image_url,omitempty"`
+	FileID     string            `json:"file_id,omitempty"`
+	FileData   string            `json:"file_data,omitempty"`
+	FileURL    string            `json:"file_url,omitempty"`
+	Filename   string            `json:"filename,omitempty"`
+	InputAudio *openAIInputAudio `json:"input_audio,omitempty"`
+}
+
 // normalizeOpenAIMessages converts OpenAI-style messages (flat "content")
 // to the semconv parts schema.
 func normalizeOpenAIMessages(raw json.RawMessage) string {
@@ -74,11 +91,8 @@ func openAIContentToParts(content json.RawMessage) []normalizedPart {
 			URL    string `json:"url"`
 			Detail string `json:"detail,omitempty"`
 		} `json:"image_url,omitempty"`
-		InputAudio *struct {
-			Data   string `json:"data"`
-			Format string `json:"format,omitempty"`
-		} `json:"input_audio,omitempty"`
-		File *struct {
+		InputAudio *openAIInputAudio `json:"input_audio,omitempty"`
+		File       *struct {
 			FileID   string `json:"file_id,omitempty"`
 			Filename string `json:"filename,omitempty"`
 			FileData string `json:"file_data,omitempty"`
@@ -95,23 +109,13 @@ func openAIContentToParts(content json.RawMessage) []normalizedPart {
 			parts = append(parts, normalizedPart{Type: "text", Content: b.Text})
 		case "image_url":
 			if b.ImageURL != nil {
-				parts = append(parts, normalizedPart{
-					Type:     "uri",
-					URI:      b.ImageURL.URL,
-					Modality: "image",
-				})
+				if part, ok := openAIImageURLPart(b.ImageURL.URL); ok {
+					parts = append(parts, part)
+				}
 			}
 		case "input_audio":
 			if b.InputAudio != nil {
-				p := normalizedPart{
-					Type:     "blob",
-					Content:  b.InputAudio.Data,
-					Modality: "audio",
-				}
-				if b.InputAudio.Format != "" {
-					p.MimeType = "audio/" + b.InputAudio.Format
-				}
-				parts = append(parts, p)
+				parts = append(parts, openAIAudioPart(b.InputAudio))
 			}
 		case "file":
 			if b.File != nil {
@@ -137,6 +141,110 @@ func openAIContentToParts(content json.RawMessage) []normalizedPart {
 		}
 	}
 	return parts
+}
+
+func openAIResponsesContentToParts(content json.RawMessage) []normalizedPart {
+	if len(content) == 0 {
+		return nil
+	}
+
+	var text string
+	if err := json.Unmarshal(content, &text); err == nil {
+		return []normalizedPart{{Type: "text", Content: text}}
+	}
+
+	var blocks []openAIResponsesContentBlock
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return []normalizedPart{{Type: "text", Content: string(content)}}
+	}
+
+	parts := make([]normalizedPart, 0, len(blocks))
+	for _, block := range blocks {
+		if part, ok := openAIResponsesContentBlockToPart(block); ok {
+			parts = append(parts, part)
+		}
+	}
+	return parts
+}
+
+func openAIResponsesContentBlockToPart(block openAIResponsesContentBlock) (normalizedPart, bool) {
+	switch block.Type {
+	case "text", "input_text", "output_text":
+		return normalizedPart{Type: "text", Content: block.Text}, true
+	case "refusal":
+		return normalizedPart{Type: "text", Content: block.Refusal}, true
+	case "input_image":
+		if block.FileID != "" {
+			return normalizedPart{
+				Type:     "file",
+				FileID:   block.FileID,
+				Modality: "image",
+			}, true
+		}
+		return openAIImageURLPart(block.ImageURL)
+	case "input_file":
+		return openAIResponsesFilePart(block)
+	case "input_audio":
+		if block.InputAudio == nil {
+			return normalizedPart{}, false
+		}
+		return openAIAudioPart(block.InputAudio), true
+	default:
+		return normalizedPart{Type: block.Type, Content: block.Text}, true
+	}
+}
+
+func openAIResponsesFilePart(block openAIResponsesContentBlock) (normalizedPart, bool) {
+	modalitySource := block.Filename
+	if modalitySource == "" {
+		modalitySource = block.FileURL
+	}
+	modality := modalityFromFilename(modalitySource)
+
+	switch {
+	case block.FileID != "":
+		return normalizedPart{Type: "file", FileID: block.FileID, Modality: modality}, true
+	case block.FileURL != "":
+		return normalizedPart{Type: "uri", URI: block.FileURL, Modality: modality}, true
+	case block.FileData != "":
+		return normalizedPart{Type: "blob", Content: block.FileData, Modality: modality}, true
+	default:
+		return normalizedPart{}, false
+	}
+}
+
+func openAIAudioPart(audio *openAIInputAudio) normalizedPart {
+	part := normalizedPart{
+		Type:     "blob",
+		Content:  audio.Data,
+		Modality: "audio",
+	}
+	if audio.Format != "" {
+		part.MimeType = "audio/" + audio.Format
+	}
+	return part
+}
+
+func openAIImageURLPart(imageURL string) (normalizedPart, bool) {
+	if imageURL == "" {
+		return normalizedPart{}, false
+	}
+
+	if metadata, data, ok := strings.Cut(imageURL, ","); ok &&
+		strings.HasPrefix(metadata, "data:") && strings.HasSuffix(metadata, ";base64") {
+		return normalizedPart{
+			Type:     "blob",
+			Content:  data,
+			Modality: "image",
+			MimeType: strings.TrimSuffix(strings.TrimPrefix(metadata, "data:"), ";base64"),
+		}, true
+	}
+
+	return normalizedPart{
+		Type:     "uri",
+		URI:      imageURL,
+		Modality: "image",
+	}, true
 }
 
 // modalityFromFilename returns a semconv modality string derived from a
@@ -212,13 +320,10 @@ func normalizeOpenAIOutput(ai *VendorOpenAI) string {
 // items have semconv mappings; unknown item types are dropped.
 func normalizeOpenAIResponsesOutput(raw json.RawMessage) string {
 	var items []struct {
-		Type    string `json:"type"`
-		Role    string `json:"role"`
-		Status  string `json:"status"`
-		Content []struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		} `json:"content"`
+		Type    string          `json:"type"`
+		Role    string          `json:"role"`
+		Status  string          `json:"status"`
+		Content json.RawMessage `json:"content"`
 		// function_call items
 		ID        string          `json:"id"`
 		CallID    string          `json:"call_id"`
@@ -247,10 +352,7 @@ func normalizeOpenAIResponsesOutput(raw json.RawMessage) string {
 				}},
 			})
 		case "", "message":
-			parts := make([]normalizedPart, 0, len(item.Content))
-			for _, c := range item.Content {
-				parts = append(parts, normalizedPart{Type: "text", Content: c.Text})
-			}
+			parts := openAIResponsesContentToParts(item.Content)
 			if len(parts) == 0 {
 				continue
 			}
@@ -318,7 +420,7 @@ func normalizeOpenAIResponsesInput(raw json.RawMessage) string {
 				}},
 			})
 		case "", "message":
-			parts := openAIContentToParts(item.Content)
+			parts := openAIResponsesContentToParts(item.Content)
 			if len(parts) == 0 {
 				continue
 			}

--- a/pkg/appolly/app/request/genai_normalize_openai.go
+++ b/pkg/appolly/app/request/genai_normalize_openai.go
@@ -127,11 +127,7 @@ func openAIContentToParts(content json.RawMessage) []normalizedPart {
 						Modality: modality,
 					})
 				} else if b.File.FileData != "" {
-					parts = append(parts, normalizedPart{
-						Type:     "blob",
-						Content:  b.File.FileData,
-						Modality: modality,
-					})
+					parts = append(parts, openAIFileDataPart(b.File.FileData, modality))
 				}
 			}
 		case "refusal":
@@ -207,10 +203,23 @@ func openAIResponsesFilePart(block openAIResponsesContentBlock) (normalizedPart,
 	case block.FileURL != "":
 		return normalizedPart{Type: "uri", URI: block.FileURL, Modality: modality}, true
 	case block.FileData != "":
-		return normalizedPart{Type: "blob", Content: block.FileData, Modality: modality}, true
+		return openAIFileDataPart(block.FileData, modality), true
 	default:
 		return normalizedPart{}, false
 	}
+}
+
+func openAIFileDataPart(fileData, modality string) normalizedPart {
+	part := normalizedPart{
+		Type:     "blob",
+		Content:  fileData,
+		Modality: modality,
+	}
+	if data, mimeType, ok := openAIBase64DataURL(fileData); ok {
+		part.Content = data
+		part.MimeType = mimeType
+	}
+	return part
 }
 
 func openAIAudioPart(audio *openAIInputAudio) normalizedPart {
@@ -230,13 +239,12 @@ func openAIImageURLPart(imageURL string) (normalizedPart, bool) {
 		return normalizedPart{}, false
 	}
 
-	if metadata, data, ok := strings.Cut(imageURL, ","); ok &&
-		strings.HasPrefix(metadata, "data:") && strings.HasSuffix(metadata, ";base64") {
+	if data, mimeType, ok := openAIBase64DataURL(imageURL); ok {
 		return normalizedPart{
 			Type:     "blob",
 			Content:  data,
 			Modality: "image",
-			MimeType: strings.TrimSuffix(strings.TrimPrefix(metadata, "data:"), ";base64"),
+			MimeType: mimeType,
 		}, true
 	}
 
@@ -247,16 +255,25 @@ func openAIImageURLPart(imageURL string) (normalizedPart, bool) {
 	}, true
 }
 
+func openAIBase64DataURL(value string) (data, mimeType string, ok bool) {
+	metadata, data, ok := strings.Cut(value, ",")
+	if !ok || !strings.HasPrefix(metadata, "data:") || !strings.HasSuffix(metadata, ";base64") {
+		return "", "", false
+	}
+
+	mimeType = strings.TrimSuffix(strings.TrimPrefix(metadata, "data:"), ";base64")
+	return data, mimeType, true
+}
+
 // modalityFromFilename returns a semconv modality string derived from a
-// filename's extension, or "file" when the modality cannot be determined.
-// The semconv schema accepts the enum image|video|audio or any string.
+// filename's extension. Non-media files use the standard document modality.
 func modalityFromFilename(filename string) string {
 	if filename == "" {
-		return "file"
+		return "document"
 	}
 	dot := strings.LastIndex(filename, ".")
 	if dot < 0 || dot == len(filename)-1 {
-		return "file"
+		return "document"
 	}
 	switch strings.ToLower(filename[dot+1:]) {
 	case "png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "tiff":
@@ -266,7 +283,7 @@ func modalityFromFilename(filename string) string {
 	case "mp4", "webm", "mov", "mkv", "avi":
 		return "video"
 	}
-	return "file"
+	return "document"
 }
 
 func openAIToolCallsToParts(raw json.RawMessage) []normalizedPart {

--- a/pkg/appolly/app/request/genai_normalize_openai_test.go
+++ b/pkg/appolly/app/request/genai_normalize_openai_test.go
@@ -219,7 +219,7 @@ func TestOpenAIContentToParts_FileByID(t *testing.T) {
 	require.Len(t, parts, 1)
 	assert.Equal(t, "file", parts[0].Type)
 	assert.Equal(t, "file_abc123", parts[0].FileID)
-	assert.Equal(t, "file", parts[0].Modality)
+	assert.Equal(t, "document", parts[0].Modality)
 }
 
 func TestOpenAIContentToParts_FileByID_ImageFilename(t *testing.T) {
@@ -231,11 +231,12 @@ func TestOpenAIContentToParts_FileByID_ImageFilename(t *testing.T) {
 }
 
 func TestOpenAIContentToParts_FileByData(t *testing.T) {
-	parts := openAIContentToParts(json.RawMessage(`[{"type":"file","file":{"file_data":"base64pdf","filename":"doc.pdf"}}]`))
+	parts := openAIContentToParts(json.RawMessage(`[{"type":"file","file":{"file_data":"data:application/pdf;base64,base64pdf","filename":"doc.pdf"}}]`))
 	require.Len(t, parts, 1)
 	assert.Equal(t, "blob", parts[0].Type)
 	assert.Equal(t, "base64pdf", parts[0].Content)
-	assert.Equal(t, "file", parts[0].Modality)
+	assert.Equal(t, "document", parts[0].Modality)
+	assert.Equal(t, "application/pdf", parts[0].MimeType)
 }
 
 func TestOpenAIContentToParts_FileByData_AudioFilename(t *testing.T) {
@@ -424,7 +425,7 @@ func TestGetInput_ResponsesAPI_StructuredContent(t *testing.T) {
 			`{"type":"input_image","image_url":"https://example.com/image.png"},` +
 			`{"type":"input_image","file_id":"file_image"},` +
 			`{"type":"input_file","file_url":"https://example.com/report.pdf","filename":"report.pdf"},` +
-			`{"type":"input_file","file_data":"base64audio","filename":"clip.mp3"}` +
+			`{"type":"input_file","file_data":"data:application/pdf;base64,base64pdf","filename":"report.pdf"}` +
 			`]}]`),
 	}
 	result := air.GetInput()
@@ -433,8 +434,8 @@ func TestGetInput_ResponsesAPI_StructuredContent(t *testing.T) {
 		`{"type":"text","content":"describe these inputs"},`+
 		`{"type":"uri","uri":"https://example.com/image.png","modality":"image"},`+
 		`{"type":"file","file_id":"file_image","modality":"image"},`+
-		`{"type":"uri","uri":"https://example.com/report.pdf","modality":"file"},`+
-		`{"type":"blob","content":"base64audio","modality":"audio"}`+
+		`{"type":"uri","uri":"https://example.com/report.pdf","modality":"document"},`+
+		`{"type":"blob","content":"base64pdf","modality":"document","mime_type":"application/pdf"}`+
 		`]}]`, result)
 }
 

--- a/pkg/appolly/app/request/genai_normalize_openai_test.go
+++ b/pkg/appolly/app/request/genai_normalize_openai_test.go
@@ -101,7 +101,7 @@ func TestNormalizeOpenAIOutput_Choices(t *testing.T) {
 
 func TestNormalizeOpenAIOutput_ResponsesAPI(t *testing.T) {
 	ai := &VendorOpenAI{
-		Output: json.RawMessage(`[{"role":"assistant","status":"completed","content":[{"type":"text","text":"response text"}]}]`),
+		Output: json.RawMessage(`[{"role":"assistant","status":"completed","content":[{"type":"output_text","text":"response text"}]}]`),
 	}
 	result := normalizeOpenAIOutput(ai)
 
@@ -185,6 +185,15 @@ func TestOpenAIContentToParts_ImageURL(t *testing.T) {
 	assert.Equal(t, "https://example.com/img.png", parts[0].URI)
 	assert.Equal(t, "image", parts[0].Modality)
 	assert.Empty(t, parts[0].Content)
+}
+
+func TestOpenAIContentToParts_ImageDataURL(t *testing.T) {
+	parts := openAIContentToParts(json.RawMessage(`[{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgo="}}]`))
+	require.Len(t, parts, 1)
+	assert.Equal(t, "blob", parts[0].Type)
+	assert.Equal(t, "iVBORw0KGgo=", parts[0].Content)
+	assert.Equal(t, "image", parts[0].Modality)
+	assert.Equal(t, "image/png", parts[0].MimeType)
 }
 
 func TestOpenAIContentToParts_InputAudio(t *testing.T) {
@@ -315,7 +324,7 @@ func TestNormalizeOpenAIOutput_ResponsesAPI_FunctionCall(t *testing.T) {
 func TestNormalizeOpenAIOutput_ResponsesAPI_MixedItems(t *testing.T) {
 	ai := &VendorOpenAI{
 		Output: json.RawMessage(`[` +
-			`{"type":"message","role":"assistant","status":"completed","content":[{"type":"text","text":"hello"}]},` +
+			`{"type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hello"}]},` +
 			`{"type":"function_call","call_id":"call_1","name":"do_thing","arguments":"{}"}` +
 			`]`),
 	}
@@ -359,6 +368,20 @@ func TestNormalizeOpenAIOutput_ResponsesAPI_FunctionCallFallbackID(t *testing.T)
 	assert.Equal(t, "fc_only", msgs[0].Parts[0].ID)
 }
 
+func TestNormalizeOpenAIOutput_ResponsesAPI_Refusal(t *testing.T) {
+	ai := &VendorOpenAI{
+		Output: json.RawMessage(`[{"type":"message","role":"assistant","status":"completed","content":[{"type":"refusal","refusal":"I cannot help with that."}]}]`),
+	}
+	result := normalizeOpenAIOutput(ai)
+
+	var msgs []normalizedMessage
+	require.NoError(t, json.Unmarshal([]byte(result), &msgs))
+	require.Len(t, msgs, 1)
+	require.Len(t, msgs[0].Parts, 1)
+	assert.Equal(t, "text", msgs[0].Parts[0].Type)
+	assert.Equal(t, "I cannot help with that.", msgs[0].Parts[0].Content)
+}
+
 func TestGetInput_ResponsesAPI_InputItems(t *testing.T) {
 	// The Responses API input array carries the conversation as message,
 	// function_call and function_call_output items. GetInput must surface all
@@ -392,6 +415,27 @@ func TestGetInput_ResponsesAPI_InputItems(t *testing.T) {
 	assert.Equal(t, "tool_call_response", msgs[2].Parts[0].Type)
 	assert.Equal(t, "call_1", msgs[2].Parts[0].ID)
 	assert.Equal(t, "sunny, 72F", msgs[2].Parts[0].Response)
+}
+
+func TestGetInput_ResponsesAPI_StructuredContent(t *testing.T) {
+	air := OpenAIInput{
+		InputItems: json.RawMessage(`[{"type":"message","role":"user","content":[` +
+			`{"type":"input_text","text":"describe these inputs"},` +
+			`{"type":"input_image","image_url":"https://example.com/image.png"},` +
+			`{"type":"input_image","file_id":"file_image"},` +
+			`{"type":"input_file","file_url":"https://example.com/report.pdf","filename":"report.pdf"},` +
+			`{"type":"input_file","file_data":"base64audio","filename":"clip.mp3"}` +
+			`]}]`),
+	}
+	result := air.GetInput()
+
+	assert.JSONEq(t, `[{"role":"user","parts":[`+
+		`{"type":"text","content":"describe these inputs"},`+
+		`{"type":"uri","uri":"https://example.com/image.png","modality":"image"},`+
+		`{"type":"file","file_id":"file_image","modality":"image"},`+
+		`{"type":"uri","uri":"https://example.com/report.pdf","modality":"file"},`+
+		`{"type":"blob","content":"base64audio","modality":"audio"}`+
+		`]}]`, result)
 }
 
 func TestNormalizeOpenAIResponsesInput_ParseFailure(t *testing.T) {

--- a/pkg/ebpf/common/http/openai.go
+++ b/pkg/ebpf/common/http/openai.go
@@ -117,7 +117,7 @@ func OpenAISpan(baseSpan *request.Span, req *http.Request, resp *http.Response) 
 
 	slog.Debug("OpenAI", "request", string(reqB), "response", string(respB))
 
-	parsedRequest := parseOpenAIInput(reqB)
+	parsedRequest := parseOpenAIInput(reqB, isOpenAIResponsesRequest(req))
 	parsedResponse, toolCalls := parseOpenAICompatibleResponse(respB)
 
 	if parsedResponse.ResponseModel == "" {

--- a/pkg/ebpf/common/http/openai_compatible.go
+++ b/pkg/ebpf/common/http/openai_compatible.go
@@ -58,7 +58,7 @@ func OpenAICompatibleSpan(baseSpan *request.Span, req *http.Request, resp *http.
 		return *baseSpan, false
 	}
 
-	parsedRequest := parseOpenAIInput(reqB)
+	parsedRequest := parseOpenAIInput(reqB, isOpenAIResponsesRequest(req))
 	parsedResponse, toolCalls := parseOpenAICompatibleResponse(respB)
 
 	if parsedResponse.ResponseModel == "" && len(parsedResponse.Choices) == 0 &&

--- a/pkg/ebpf/common/http/partial_json.go
+++ b/pkg/ebpf/common/http/partial_json.go
@@ -248,7 +248,11 @@ func logTruncatedResponseBody(component string, err error, got int, resp *http.R
 	)
 }
 
-func parseOpenAIInput(body []byte) request.OpenAIInput {
+func isOpenAIResponsesRequest(req *http.Request) bool {
+	return strings.HasSuffix(strings.TrimSuffix(requestPath(req), "/"), "/v1/responses")
+}
+
+func parseOpenAIInput(body []byte, captureInputItems bool) request.OpenAIInput {
 	var parsed request.OpenAIInput
 	unmarshalJSONBestEffort(body, &parsed)
 	if parsed.Model == "" {
@@ -259,11 +263,14 @@ func parseOpenAIInput(body []byte) request.OpenAIInput {
 	}
 	// The `input` field is a plain string for Chat/text Completions, but an
 	// array of items for the Responses API and an object wrapping `messages`
-	// for native DashScope generation. Retain the array and unwrap the nested
-	// messages so tool-call pairing can reach both schemas.
+	// for native DashScope generation. Retain Responses items and unwrap the
+	// nested messages so content normalization can reach both schemas.
 	if len(body) > 0 {
 		switch raw := extractJSONRawField(body, "input"); firstJSONByte(raw) {
 		case '[':
+			if !captureInputItems {
+				break
+			}
 			parsed.InputItems = raw
 		case '{':
 			if len(parsed.Messages) == 0 {

--- a/pkg/ebpf/common/http/partial_json_test.go
+++ b/pkg/ebpf/common/http/partial_json_test.go
@@ -4,12 +4,24 @@
 package ebpfcommon
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsOpenAIResponsesRequest(t *testing.T) {
+	for _, path := range []string{"/v1/responses", "/gateway/v1/responses/"} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		assert.True(t, isOpenAIResponsesRequest(req), path)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/embeddings", nil)
+	assert.False(t, isOpenAIResponsesRequest(req))
+}
 
 func TestExtractModelField(t *testing.T) {
 	full := `{"messages":[{"role":"user","content":"hi"}],"model":"gpt-4o-mini","temperature":1.0}`
@@ -44,23 +56,29 @@ func TestExtractModelField_ignoresNestedModelAfterSearchWindow(t *testing.T) {
 
 func TestParseOpenAIInput_truncated(t *testing.T) {
 	body := []byte(`{"model":"gpt-5-mini","input":"hello`)
-	parsed := parseOpenAIInput(body)
+	parsed := parseOpenAIInput(body, false)
 	assert.Equal(t, "gpt-5-mini", parsed.Model)
 }
 
 func TestParseOpenAIInput_ResponsesInputArray(t *testing.T) {
 	// The Responses API `input` array is retained in InputItems.
 	body := []byte(`{"model":"gpt-5-mini","input":[{"type":"function_call","call_id":"c1","name":"f"}]}`)
-	parsed := parseOpenAIInput(body)
+	parsed := parseOpenAIInput(body, true)
 	assert.Empty(t, parsed.Messages)
 	assert.JSONEq(t, `[{"type":"function_call","call_id":"c1","name":"f"}]`, string(parsed.InputItems))
+}
+
+func TestParseOpenAIInput_EmbeddingInputArray(t *testing.T) {
+	body := []byte(`{"model":"text-embedding-3-small","input":["first","second"]}`)
+	parsed := parseOpenAIInput(body, false)
+	assert.Empty(t, parsed.InputItems)
 }
 
 func TestParseOpenAIInput_NativeDashScopeInputMessages(t *testing.T) {
 	// Native DashScope generation nests conversation history under
 	// input.messages instead of a top-level messages field.
 	body := []byte(`{"model":"qwen-max","input":{"messages":[{"role":"user","content":"hi"}]}}`)
-	parsed := parseOpenAIInput(body)
+	parsed := parseOpenAIInput(body, false)
 	assert.Empty(t, parsed.InputItems)
 	assert.JSONEq(t, `[{"role":"user","content":"hi"}]`, string(parsed.Messages))
 }
@@ -206,7 +224,7 @@ func TestExtractJSONRawField(t *testing.T) {
 
 func TestParseOpenAIInput_messagesFromTruncatedBody(t *testing.T) {
 	body := []byte(`{"model":"qwen-plus","messages":[{"role":"user","content":"你好"}],"stre`)
-	parsed := parseOpenAIInput(body)
+	parsed := parseOpenAIInput(body, false)
 	assert.Equal(t, "qwen-plus", parsed.Model)
 	assert.NotNil(t, parsed.Messages)
 	assert.JSONEq(t, `[{"role":"user","content":"你好"}]`, string(parsed.Messages))

--- a/pkg/ebpf/common/http/qwen.go
+++ b/pkg/ebpf/common/http/qwen.go
@@ -74,7 +74,7 @@ func QwenSpan(baseSpan *request.Span, req *http.Request, resp *http.Response) (r
 		}
 	}
 
-	parsedRequest := parseOpenAIInput(reqB)
+	parsedRequest := parseOpenAIInput(reqB, false)
 	parsedResponse, toolCalls := parseOpenAICompatibleResponse(respB)
 
 	// Qwen-specific: try to extract request_id from response body


### PR DESCRIPTION
## Summary

- normalize Responses text, image, file, audio, and refusal content
- restrict Responses input-item capture to `/v1/responses` endpoints
- encode base64 image data URLs as blob parts instead of remote URIs

## Why

#2845 added Responses input-array capture so tool calls and outputs remain visible in `gen_ai.input.messages`. The shared parser treated every array-valued `input` as Responses items, including embedding batches, and reused Chat Completions decoding for Responses-specific content shapes. This could export embedding arrays outside the message schema and collapse valid multimodal Responses content into raw text.

Responses refusals were also decoded through the `text` field, which emitted an empty content part. Chat Completions image data URLs were represented as remote URIs even though their payload is embedded in the request.

This change keeps endpoint routing and provider-specific content decoding explicit while preserving the existing opt-in content behavior.

## Validation

- `go test ./pkg/appolly/app/request ./pkg/ebpf/common/http`
