### PR TITLE
Capture `Request.URL.RawQuery` for Go HTTP spans

### DIFF
--- a/bpf/common/common.h
+++ b/bpf/common/common.h
@@ -29,6 +29,7 @@ enum : u32 {
     k_tcp_max_len = 256,
     k_tcp_res_len = 128,
     k_path_max_len = 100,
+    k_query_max_len = 100,
     k_pattern_max_len = 96,
     k_method_max_len = 7, // Longest method: OPTIONS
     k_remote_addr_max_len =
@@ -85,8 +86,10 @@ typedef struct http_request_trace {
     s64 content_length;
     s64 response_length;
     unsigned char path[k_path_max_len];
+    unsigned char raw_query[k_query_max_len];
     unsigned char pattern[k_pattern_max_len];
     unsigned char host[k_host_max_len];
+    u8 _pad1[4];
     tp_info_t tp;
     connection_info_t conn;
     pid_info pid;

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -26,6 +26,7 @@
 #include <common/http_types.h>
 #include <common/protocol_defs.h>
 #include <common/ringbuf.h>
+#include <common/scratch_mem.h>
 #include <common/strings.h>
 #include <common/tracing.h>
 #include <common/trace_helpers.h>
@@ -56,6 +57,9 @@ static __always_inline unsigned char *temp_header_mem() {
     return bpf_map_lookup_elem(&temp_header_mem_store, &zero);
 }
 
+SCRATCH_MEM_TYPED(serve_http_inv, server_http_func_invocation_t)
+SCRATCH_MEM_TYPED(round_trip_client_data, http_client_data_t)
+
 /* HTTP Server */
 
 // This instrumentation attaches uprobe to the following function:
@@ -81,20 +85,16 @@ int obi_uprobe_ServeHTTP(struct pt_regs *ctx) {
         decoded_tp = &header_inv->tp;
     }
 
-    server_http_func_invocation_t invocation = {
-        .start_monotime_ns = bpf_ktime_get_ns(),
-        .tp = {0},
-        .status = 0,
-        .content_length = 0,
-        .response_length = 0,
-    };
+    server_http_func_invocation_t *invocation = serve_http_inv_mem();
+    if (!invocation) {
+        goto done;
+    }
 
-    invocation.method[0] = 0;
-    invocation.path[0] = 0;
-    invocation.pattern[0] = 0;
+    bpf_memset(invocation, 0, sizeof(*invocation));
+    invocation->start_monotime_ns = bpf_ktime_get_ns();
 
     if (req) {
-        server_trace_parent(goroutine_addr, &invocation.tp, decoded_tp);
+        server_trace_parent(goroutine_addr, &invocation->tp, decoded_tp);
         // TODO: if context propagation is supported, overwrite the header value in the map with the
         // new span context and the same thread id.
 
@@ -102,8 +102,8 @@ int obi_uprobe_ServeHTTP(struct pt_regs *ctx) {
         if (!read_go_str("method",
                          req,
                          go_offset_of(ot, (go_offset){.v = _method_ptr_pos}),
-                         invocation.method,
-                         sizeof(invocation.method))) {
+                         invocation->method,
+                         sizeof(invocation->method))) {
             bpf_dbg_printk("can't read http Request.Method");
             goto done;
         }
@@ -118,17 +118,26 @@ int obi_uprobe_ServeHTTP(struct pt_regs *ctx) {
             !read_go_str("path",
                          url_ptr,
                          go_offset_of(ot, (go_offset){.v = _path_ptr_pos}),
-                         invocation.path,
-                         sizeof(invocation.path))) {
+                         invocation->path,
+                         sizeof(invocation->path))) {
             bpf_dbg_printk("can't read http Request.URL.Path");
             goto done;
         }
 
-        bpf_dbg_printk("path=%s", invocation.path);
+        // best-effort: the query string is optional, so a failed read must not
+        // drop the event; the buffer stays zeroed and the span has no query
+        read_go_str("raw_query",
+                    url_ptr,
+                    go_offset_of(ot, (go_offset){.v = _raw_query_ptr_pos}),
+                    invocation->raw_query,
+                    sizeof(invocation->raw_query));
+
+        bpf_dbg_printk("path=%s", invocation->path);
+        bpf_dbg_printk("raw_query=%s", invocation->raw_query);
 
         res = bpf_probe_read(
-            &invocation.content_length,
-            sizeof(invocation.content_length),
+            &invocation->content_length,
+            sizeof(invocation->content_length),
             (void *)(req + go_offset_of(ot, (go_offset){.v = _content_length_ptr_pos})));
         if (res) {
             bpf_dbg_printk("can't read http Request.ContentLength");
@@ -139,11 +148,11 @@ int obi_uprobe_ServeHTTP(struct pt_regs *ctx) {
     }
 
     // Write event
-    if (bpf_map_update_elem(&ongoing_http_server_requests, &g_key, &invocation, BPF_ANY)) {
+    if (bpf_map_update_elem(&ongoing_http_server_requests, &g_key, invocation, BPF_ANY)) {
         bpf_dbg_printk("can't update map element");
     }
 
-    obi_ctx__set(bpf_get_current_pid_tgid(), &invocation.tp);
+    obi_ctx__set(bpf_get_current_pid_tgid(), &invocation->tp);
 
 done:
     return 0;
@@ -373,10 +382,14 @@ static __always_inline void handle_traceparent_header(server_http_func_invocatio
             update_traceparent(inv, traceparent_start);
         }
     } else {
-        server_http_func_invocation_t minimal_inv = {0};
-        update_traceparent(&minimal_inv, traceparent_start);
-        bpf_map_update_elem(&ongoing_http_server_requests, g_key, &minimal_inv, BPF_ANY);
-        obi_ctx__set(bpf_get_current_pid_tgid(), &minimal_inv.tp);
+        server_http_func_invocation_t *minimal_inv = serve_http_inv_mem();
+        if (!minimal_inv) {
+            return;
+        }
+        bpf_memset(minimal_inv, 0, sizeof(*minimal_inv));
+        update_traceparent(minimal_inv, traceparent_start);
+        bpf_map_update_elem(&ongoing_http_server_requests, g_key, minimal_inv, BPF_ANY);
+        obi_ctx__set(bpf_get_current_pid_tgid(), &minimal_inv->tp);
     }
 }
 
@@ -586,6 +599,7 @@ static __always_inline int serve_http_returns(struct pt_regs *ctx) {
     trace->content_length = invocation->content_length;
     __builtin_memcpy(trace->method, invocation->method, sizeof(trace->method));
     __builtin_memcpy(trace->path, invocation->path, sizeof(trace->path));
+    __builtin_memcpy(trace->raw_query, invocation->raw_query, sizeof(trace->raw_query));
     __builtin_memcpy(trace->pattern, invocation->pattern, sizeof(trace->pattern));
     trace->status = (u16)invocation->status;
     trace->response_length = invocation->response_length;
@@ -630,20 +644,25 @@ static __always_inline void roundTripStartHelper(struct pt_regs *ctx) {
 
     client_trace_parent(goroutine_addr, &invocation.tp);
 
-    http_client_data_t trace = {0};
+    http_client_data_t *trace = round_trip_client_data_mem();
+    if (!trace) {
+        return;
+    }
+
+    bpf_memset(trace, 0, sizeof(*trace));
 
     // Get method from Request.Method
     if (!read_go_str("method",
                      req,
                      go_offset_of(ot, (go_offset){.v = _method_ptr_pos}),
-                     trace.method,
-                     sizeof(trace.method))) {
+                     trace->method,
+                     sizeof(trace->method))) {
         bpf_dbg_printk("can't read http Request.Method");
         return;
     }
 
-    bpf_probe_read(&trace.content_length,
-                   sizeof(trace.content_length),
+    bpf_probe_read(&trace->content_length,
+                   sizeof(trace->content_length),
                    (void *)(req + go_offset_of(ot, (go_offset){.v = _content_length_ptr_pos})));
 
     // Get path from Request.URL
@@ -656,17 +675,25 @@ static __always_inline void roundTripStartHelper(struct pt_regs *ctx) {
         if (!read_go_str("path",
                          url_ptr,
                          go_offset_of(ot, (go_offset){.v = _path_ptr_pos}),
-                         trace.path,
-                         sizeof(trace.path))) {
+                         trace->path,
+                         sizeof(trace->path))) {
             bpf_dbg_printk("can't read http Request.URL.Path");
             return;
         }
 
+        // best-effort: the query string is optional, so a failed read must not
+        // drop the event; the buffer stays zeroed and the span has no query
+        read_go_str("raw_query",
+                    url_ptr,
+                    go_offset_of(ot, (go_offset){.v = _raw_query_ptr_pos}),
+                    trace->raw_query,
+                    sizeof(trace->raw_query));
+
         if (!read_go_str("host",
                          url_ptr,
                          go_offset_of(ot, (go_offset){.v = _host_ptr_pos}),
-                         trace.host,
-                         sizeof(trace.host))) {
+                         trace->host,
+                         sizeof(trace->host))) {
             bpf_dbg_printk("can't read http Request.URL.Host");
             return;
         }
@@ -674,23 +701,24 @@ static __always_inline void roundTripStartHelper(struct pt_regs *ctx) {
         if (!read_go_str("scheme",
                          url_ptr,
                          go_offset_of(ot, (go_offset){.v = _scheme_ptr_pos}),
-                         trace.scheme,
-                         sizeof(trace.scheme))) {
+                         trace->scheme,
+                         sizeof(trace->scheme))) {
             bpf_dbg_printk("can't read http Request.URL.Scheme");
             return;
         }
     }
 
-    bpf_dbg_printk("path=%s", trace.path);
-    bpf_dbg_printk("host=%s", trace.host);
-    bpf_dbg_printk("scheme=%s", trace.scheme);
+    bpf_dbg_printk("path=%s", trace->path);
+    bpf_dbg_printk("raw_query=%s", trace->raw_query);
+    bpf_dbg_printk("host=%s", trace->host);
+    bpf_dbg_printk("scheme=%s", trace->scheme);
 
     // Write event
     if (bpf_map_update_elem(&go_ongoing_http_client_requests, &g_key, &invocation, BPF_ANY)) {
         bpf_dbg_printk("can't update http client map element");
     }
 
-    bpf_map_update_elem(&ongoing_http_client_requests_data, &g_key, &trace, BPF_ANY);
+    bpf_map_update_elem(&ongoing_http_client_requests_data, &g_key, trace, BPF_ANY);
 
     if (g_bpf_header_propagation) {
         void *headers_ptr = 0;
@@ -754,6 +782,7 @@ int obi_uprobe_roundTripReturn(struct pt_regs *ctx) {
     // Copy the values read on request start
     __builtin_memcpy(trace->method, data->method, sizeof(trace->method));
     __builtin_memcpy(trace->path, data->path, sizeof(trace->path));
+    __builtin_memcpy(trace->raw_query, data->raw_query, sizeof(trace->raw_query));
     __builtin_memcpy(trace->host, data->host, sizeof(trace->host));
     __builtin_memcpy(trace->scheme, data->scheme, sizeof(trace->scheme));
     trace->content_length = data->content_length;
@@ -1162,12 +1191,15 @@ int obi_uprobe_http2serverConn_runHandler(struct pt_regs *ctx) {
         bpf_dbg_printk("looked up tp: %llx", tp);
 
         if (tp) {
-            server_http_func_invocation_t inv = {0};
-            __builtin_memcpy(&inv.tp, tp, sizeof(tp_info_t));
-            bpf_dbg_printk("Found traceparent in HTTP2 headers");
-            bpf_map_update_elem(&ongoing_http_server_requests, &g_key, &inv, BPF_ANY);
-            obi_ctx__set(bpf_get_current_pid_tgid(), &inv.tp);
-            bpf_map_delete_elem(&http2_server_requests_tp, &sc_key);
+            server_http_func_invocation_t *inv = serve_http_inv_mem();
+            if (inv) {
+                bpf_memset(inv, 0, sizeof(*inv));
+                __builtin_memcpy(&inv->tp, tp, sizeof(tp_info_t));
+                bpf_dbg_printk("Found traceparent in HTTP2 headers");
+                bpf_map_update_elem(&ongoing_http_server_requests, &g_key, inv, BPF_ANY);
+                obi_ctx__set(bpf_get_current_pid_tgid(), &inv->tp);
+                bpf_map_delete_elem(&http2_server_requests_tp, &sc_key);
+            }
         }
     }
 

--- a/bpf/gotracer/go_offsets.h
+++ b/bpf/gotracer/go_offsets.h
@@ -20,6 +20,7 @@ typedef enum {
     // http
     _url_ptr_pos,
     _path_ptr_pos,
+    _raw_query_ptr_pos,
     _host_ptr_pos,
     _scheme_ptr_pos,
     _method_ptr_pos,

--- a/bpf/gotracer/types/nethttp.h
+++ b/bpf/gotracer/types/nethttp.h
@@ -19,10 +19,11 @@ typedef struct http_client_data {
     s64 content_length;
     pid_info pid;
     unsigned char path[k_path_max_len];
+    unsigned char raw_query[k_query_max_len];
     unsigned char host[k_host_max_len];
     unsigned char scheme[k_scheme_max_len];
     unsigned char method[k_method_max_len];
-    u8 _pad[3];
+    u8 _pad[7];
 } http_client_data_t;
 
 typedef struct server_http_func_invocation {
@@ -34,10 +35,11 @@ typedef struct server_http_func_invocation {
     tp_info_t tp;
     u8 method[k_method_max_len];
     u8 path[k_path_max_len];
+    u8 raw_query[k_query_max_len];
     u8 pattern[k_pattern_max_len];
     u8 is_tls;
     bool is_jsonrpc;
-    u8 _pad[3];
+    u8 _pad[7];
 } server_http_func_invocation_t;
 
 typedef struct framer_func_invocation {

--- a/configs/offsets/tracker_input.json
+++ b/configs/offsets/tracker_input.json
@@ -9,7 +9,7 @@
         "ContentLength",
         "Header"
       ],
-      "net/url.URL": ["Path", "Host", "Scheme"],
+      "net/url.URL": ["Path", "RawQuery", "Host", "Scheme"],
       "net/http.Response": ["StatusCode", "ContentLength"],
       "net.TCPAddr": ["IP", "Port"],
       "context.valueCtx": ["val"],

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -63,6 +63,7 @@ func TestSuite_Go(t *testing.T) {
 			t.Run("RED JSON RPC metrics", testREDMetricsJSONRPCHTTP)
 			t.Run("HTTP traces", testHTTPTraces)
 			t.Run("HTTP traces (no traceID)", testHTTPTracesNoTraceID)
+			t.Run("HTTP traces (url.query redaction)", testHTTPTracesURLQuery)
 			t.Run("HTTP traces (manual spans)", testHTTPTracesNestedManualSpans)
 			t.Run("GRPC traces", testGRPCTraces)
 			t.Run("GRPC RED metrics", testREDMetricsGRPC)
@@ -161,6 +162,7 @@ func TestSuite_NoDebugInfo(t *testing.T) {
 
 	t.Run("RED metrics", testREDMetricsHTTP)
 	t.Run("HTTP traces", testHTTPTraces)
+	t.Run("HTTP traces (url.query redaction)", testHTTPTracesURLQuery)
 	t.Run("GRPC traces", testGRPCTraces)
 	t.Run("GRPC RED metrics", testREDMetricsGRPC)
 	t.Run("Internal Prometheus metrics", func(t *testing.T) { ti.InternalPrometheusExport(t, config) })

--- a/internal/test/integration/traces_test.go
+++ b/internal/test/integration/traces_test.go
@@ -170,6 +170,37 @@ func testHTTPTracesCommon(t *testing.T, doTraceID bool, httpCode int) {
 	require.Empty(t, traces)
 }
 
+func testHTTPTracesURLQuery(t *testing.T) {
+	// Ensure OBI is attached before sending the single marker request; this
+	// subtest may run first (e.g. filtered runs), without prior warm-up.
+	waitForTestComponents(t, instrumentedServiceStdURL)
+
+	// Use a unique marker value to avoid matching stale traces from earlier requests.
+	// "sig" is in the default redact list, so its value must appear as REDACTED.
+	ti.DoHTTPGet(t, instrumentedServiceStdURL+"/query-trace?obi_urlquery_test=1&sig=secret123", 200)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=testserver&operation=GET%20%2Fquery-trace")
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		defer resp.Body.Close()
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+
+		traces := tq.FindBySpan(jaeger.Tag{Key: "url.query", Type: "string", Value: "obi_urlquery_test=1&sig=REDACTED"})
+		require.GreaterOrEqual(ct, len(traces), 1)
+
+		spans := traces[0].FindByOperationName("GET /query-trace", "server")
+		require.GreaterOrEqual(ct, len(spans), 1)
+		tag, ok := jaeger.FindIn(spans[0].Tags, "url.query")
+		require.True(ct, ok, "url.query tag missing from Go server span")
+		assert.Equal(ct, "obi_urlquery_test=1&sig=REDACTED", tag.Value)
+	}, testTimeout, 100*time.Millisecond)
+}
+
 func testGRPCTraces(t *testing.T) {
 	testGRPCTracesForServiceName(t, "testserver")
 }
@@ -486,7 +517,7 @@ func testHTTPTracesNestedCalls(t *testing.T) {
 	sd = client.Diff(
 		jaeger.Tag{Key: "http.request.method", Type: "string", Value: "GET"},
 		jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(203)},
-		jaeger.Tag{Key: "url.full", Type: "string", Value: "http://localhost:8080/echoBack"},
+		jaeger.Tag{Key: "url.full", Type: "string", Value: "http://localhost:8080/echoBack?delay=20ms&status=203"},
 		jaeger.Tag{Key: "server.port", Type: "int64", Value: float64(8080)}, // client call is to 8080
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "client"},
 	)

--- a/pkg/ebpf/common/spanner.go
+++ b/pkg/ebpf/common/spanner.go
@@ -23,6 +23,7 @@ func HTTPRequestTraceToSpan(parseCtx *EBPFParseContext, trace *HTTPRequestTrace)
 	// From C, assuming 0-ended strings
 	method := cstr(trace.Method[:])
 	path := cstr(trace.Path[:])
+	rawQuery := cstr(trace.RawQuery[:])
 	pattern := cstr(trace.Pattern[:])
 	scheme := cstr(trace.Scheme[:])
 	origHost := cstr(trace.Host[:])
@@ -60,11 +61,16 @@ func HTTPRequestTraceToSpan(parseCtx *EBPFParseContext, trace *HTTPRequestTrace)
 		schemeHost = strings.Join([]string{scheme, origHost}, request.SchemeHostSeparator)
 	}
 
+	fullPath := path
+	if rawQuery != "" {
+		fullPath = path + "?" + rawQuery
+	}
+
 	span := request.Span{
 		Type:           request.EventType(trace.Type),
 		Method:         method,
 		Path:           path,
-		FullPath:       path,
+		FullPath:       fullPath,
 		Route:          pattern,
 		Peer:           peer,
 		PeerPort:       int(trace.Conn.S_port),

--- a/pkg/ebpf/common/spanner_test.go
+++ b/pkg/ebpf/common/spanner_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
+	"go.opentelemetry.io/obi/pkg/export/otel/tracesgen"
 )
 
 func tocstr(s string) []byte {
@@ -70,6 +73,50 @@ func assertMatches(
 	assert.Equal(t, responseLength, span.ResponseLength)
 	assert.Equal(t, int64(durationMs*1000000), span.End-span.Start)
 	assert.Equal(t, int64(durationMs*1000000), span.Start-span.RequestStart)
+}
+
+func TestHTTPRequestTraceToSpan_FullPath(t *testing.T) {
+	t.Run("RawQuery appended to FullPath with separator", func(t *testing.T) {
+		p := [100]uint8{}
+		copy(p[:], tocstr("/search"))
+		q := [100]uint8{}
+		copy(q[:], tocstr("q=hello&sig=secret"))
+
+		tr := HTTPRequestTrace{Type: 1, Path: p, RawQuery: q, Status: 200}
+		s := HTTPRequestTraceToSpan(nil, &tr)
+
+		assert.Equal(t, "/search", s.Path)
+		assert.Equal(t, "/search?q=hello&sig=secret", s.FullPath)
+	})
+
+	t.Run("empty RawQuery leaves FullPath equal to Path", func(t *testing.T) {
+		p := [100]uint8{}
+		copy(p[:], tocstr("/health"))
+
+		tr := HTTPRequestTrace{Type: 1, Path: p, Status: 200}
+		s := HTTPRequestTraceToSpan(nil, &tr)
+
+		assert.Equal(t, "/health", s.Path)
+		assert.Equal(t, "/health", s.FullPath)
+	})
+
+	t.Run("sensitive query params redacted at trace export", func(t *testing.T) {
+		p := [100]uint8{}
+		copy(p[:], tocstr("/search"))
+		q := [100]uint8{}
+		copy(q[:], tocstr("q=hello&sig=secret"))
+
+		tr := HTTPRequestTrace{Type: 1, Path: p, RawQuery: q, Status: 200}
+		s := HTTPRequestTraceToSpan(nil, &tr)
+
+		defaultAttrs, err := tracesgen.UserSelectedAttributes(&attributes.SelectorConfig{})
+		require.NoError(t, err)
+
+		selected := tracesgen.AttrsToMap(tracesgen.TraceAttributesSelector(&s, defaultAttrs, "sig"))
+		val, ok := selected.Get("url.query")
+		require.True(t, ok)
+		assert.Equal(t, "q=hello&sig=REDACTED", val.Str())
+	})
 }
 
 func TestRequestTraceParsing(t *testing.T) {

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -376,6 +376,7 @@ func (p *Tracer) RegisterOffsets(fileInfo *exec.FileInfo, offsets *goexec.Offset
 		// http
 		goexec.URLPtrPos,
 		goexec.PathPtrPos,
+		goexec.RawQueryPtrPos,
 		goexec.HostPtrPos,
 		goexec.SchemePtrPos,
 		goexec.MethodPtrPos,

--- a/pkg/internal/goexec/offsets.json
+++ b/pkg/internal/goexec/offsets.json
@@ -1345,6 +1345,22 @@
           }
         ]
       },
+      "RawQuery": {
+        "versions": {
+          "oldest": "1.17.0",
+          "newest": "1.26.4"
+        },
+        "offsets": [
+          {
+            "offset": 96,
+            "since": "1.17.0"
+          },
+          {
+            "offset": 88,
+            "since": "1.26.0"
+          }
+        ]
+      },
       "Scheme": {
         "versions": {
           "oldest": "1.17.0",

--- a/pkg/internal/goexec/structmembers.go
+++ b/pkg/internal/goexec/structmembers.go
@@ -93,6 +93,7 @@ const (
 	// http
 	URLPtrPos
 	PathPtrPos
+	RawQueryPtrPos
 	HostPtrPos
 	SchemePtrPos
 	MethodPtrPos
@@ -285,9 +286,10 @@ var structMembers = map[string]structInfo{
 	"net/url.URL": {
 		lib: "go",
 		fields: map[string]GoOffset{
-			"Path":   PathPtrPos,
-			"Host":   HostPtrPos,
-			"Scheme": SchemePtrPos,
+			"Path":     PathPtrPos,
+			"RawQuery": RawQueryPtrPos,
+			"Host":     HostPtrPos,
+			"Scheme":   SchemePtrPos,
 		},
 	},
 	"net/http.Response": {


### PR DESCRIPTION
## Summary

This PR adds to the Go net/http server and client spans the request query string. resolves #2475 

Note (minor overlap): the redaction mechanism already has its own tests from #2415. These don't duplicate that, they pin the `Go capture -> span ->  export`, which is exactly what this PR adds and what the earlier review found broken. 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
