### PR TITLE
Harden Config v2 migration

### DIFF
--- a/cmd/obi/internal/configcmd/configcmd.go
+++ b/cmd/obi/internal/configcmd/configcmd.go
@@ -9,20 +9,29 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
 
 	"go.yaml.in/yaml/v3"
 	legacyyaml "gopkg.in/yaml.v3"
 
+	"go.opentelemetry.io/collector/consumer/consumertest"
+
 	"go.opentelemetry.io/obi/internal/config/convert"
 	"go.opentelemetry.io/obi/internal/config/schema"
+	"go.opentelemetry.io/obi/pkg/appolly/discover"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	obiconfig "go.opentelemetry.io/obi/pkg/config"
 	featureexport "go.opentelemetry.io/obi/pkg/export"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/obi"
+	"go.opentelemetry.io/obi/pkg/transform"
 )
 
 const (
@@ -107,6 +116,8 @@ func runValidate(args []string, stdout, stderr io.Writer) int {
 
 var errInvalidMode = errors.New("invalid validation mode")
 
+var runtimeValidationMu sync.Mutex
+
 func validateConfig(data []byte, mode validationMode) error {
 	data = obiconfig.ReplaceEnv(data)
 
@@ -131,24 +142,39 @@ func validateConfig(data []byte, mode validationMode) error {
 	if err != nil {
 		return err
 	}
-	if mode == validationModeReceiver {
-		err = cfg.ValidateStaticForReceiver()
-	} else {
-		err = cfg.ValidateStatic()
-	}
+	err = validateRuntimeConfig(cfg, mode)
 	if err != nil {
 		return fmt.Errorf("runtime configuration: %w", err)
 	}
 	return nil
 }
 
+func validateRuntimeConfig(cfg *obi.Config, mode validationMode) error {
+	runtimeValidationMu.Lock()
+	defer runtimeValidationMu.Unlock()
+
+	logger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	defer slog.SetDefault(logger)
+
+	switch mode {
+	case validationModeStandalone:
+		return cfg.ValidateStatic()
+	case validationModeReceiver:
+		return cfg.ValidateStaticForReceiver()
+	default:
+		return fmt.Errorf("%w %q; expected standalone or receiver", errInvalidMode, mode)
+	}
+}
+
 func runMigrate(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("obi config migrate", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	flags.Usage = func() {
-		fmt.Fprintln(flags.Output(), "usage: obi config migrate <path>")
+		fmt.Fprintln(flags.Output(), "usage: obi config migrate [--mode=standalone|receiver] <path>")
 		flags.PrintDefaults()
 	}
+	mode := flags.String("mode", string(validationModeStandalone), "migration mode: standalone or receiver")
 	if err := flags.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return ExitSuccess
@@ -159,13 +185,18 @@ func runMigrate(args []string, stdout, stderr io.Writer) int {
 		flags.Usage()
 		return ExitUsage
 	}
+	selectedMode := validationMode(*mode)
+	if selectedMode != validationModeStandalone && selectedMode != validationModeReceiver {
+		fmt.Fprintf(stderr, "invalid migration mode %q; expected standalone or receiver\n", *mode)
+		return ExitUsage
+	}
 
 	data, err := os.ReadFile(flags.Arg(0))
 	if err != nil {
 		fmt.Fprintf(stderr, "migration failed: read %s: %v\n", flags.Arg(0), err)
 		return ExitError
 	}
-	output, report, err := migrateConfig(data)
+	output, report, err := migrateConfigForMode(data, selectedMode)
 	if err != nil {
 		fmt.Fprintf(stderr, "migration failed: %v\n", err)
 		return ExitError
@@ -181,43 +212,72 @@ func runMigrate(args []string, stdout, stderr io.Writer) int {
 }
 
 func migrateConfig(data []byte) ([]byte, string, error) {
+	return migrateConfigForMode(data, validationModeStandalone)
+}
+
+func migrateConfigForMode(
+	data []byte,
+	mode validationMode,
+) ([]byte, string, error) {
 	replaced := obiconfig.ReplaceEnv(data)
-	if _, _, err := schema.ParseStandaloneYAML(replaced); err == nil {
-		return nil, "", errors.New("input is already a standalone OBI config v2 document")
+	var v2Err error
+	switch mode {
+	case validationModeStandalone:
+		_, _, v2Err = schema.ParseStandaloneYAML(replaced)
+	case validationModeReceiver:
+		_, v2Err = schema.ParseReceiverYAML(replaced)
+	default:
+		return nil, "", fmt.Errorf("%w %q; expected standalone or receiver", errInvalidMode, mode)
+	}
+	if v2Err == nil {
+		return nil, "", fmt.Errorf("input is already a %s OBI config v2 document", mode)
 	} else {
 		var notV2 *schema.NotV2Error
-		if !errors.As(err, &notV2) {
-			return nil, "", fmt.Errorf("source is not supported v1 YAML: %w", err)
+		if !errors.As(v2Err, &notV2) {
+			return nil, "", fmt.Errorf("source is not supported v1 YAML: %w", v2Err)
 		}
 	}
-	cfg, err := loadV1Config(replaced)
+	cfg, err := loadV1ConfigForMode(replaced, mode)
 	if err != nil {
 		return nil, "", err
 	}
-	if err := cfg.ValidateStatic(); err != nil {
+	if err := validateRuntimeConfig(cfg, mode); err != nil {
 		return nil, "", fmt.Errorf("v1 runtime configuration: %w", err)
+	}
+	if err := validateMigratableSelectorRefinements(cfg); err != nil {
+		return nil, "", err
 	}
 
 	doc, ext := convert.RuntimeToV2(cfg)
 	if !cfg.Enabled(obi.FeatureAppO11y) {
 		ext.Capture.Policy.DefaultAction = schema.CaptureActionExclude
 	}
-	output, err := yaml.Marshal(doc)
-	if err != nil {
-		return nil, "", fmt.Errorf("encode config v2 YAML: %w", err)
-	}
-	output = obiconfig.EscapeEnv(output)
-	if err := validateConfig(output, validationModeStandalone); err != nil {
-		return nil, "", fmt.Errorf("migrated config v2 did not validate: %w", err)
-	}
+	preserveV1DNSMetrics(cfg, ext)
 
-	roundTripped, err := convert.DocumentToRuntime(doc)
+	var roundTripped *obi.Config
+	switch mode {
+	case validationModeStandalone:
+		roundTripped, err = convert.DocumentToRuntime(doc)
+	case validationModeReceiver:
+		roundTripped, err = convert.V2ToRuntime(&schema.Extension{
+			Version: ext.Version,
+			Capture: ext.Capture,
+		})
+		if err == nil {
+			setReceiverConsumers(roundTripped)
+		}
+	}
 	if err != nil {
 		return nil, "", fmt.Errorf("verify migrated config v2: %w", err)
 	}
 	unsupported, err := changedInputFields(replaced, cfg, roundTripped)
 	if err != nil {
 		return nil, "", fmt.Errorf("verify migrated fields: %w", err)
+	}
+	if mode == validationModeReceiver {
+		unsupported = append(unsupported, receiverExporterPaths(replaced)...)
+		sort.Strings(unsupported)
+		unsupported = slices.Compact(unsupported)
 	}
 	if len(unsupported) != 0 {
 		return nil, "", fmt.Errorf(
@@ -226,10 +286,106 @@ func migrateConfig(data []byte) ([]byte, string, error) {
 		)
 	}
 
+	var output []byte
+	switch mode {
+	case validationModeStandalone:
+		output, err = yaml.Marshal(doc)
+	case validationModeReceiver:
+		output, err = yaml.Marshal(struct {
+			Version        string `yaml:"version"`
+			schema.Capture `yaml:",inline"`
+		}{
+			Version: ext.Version,
+			Capture: ext.Capture,
+		})
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("encode config v2 YAML: %w", err)
+	}
+	output = obiconfig.EscapeEnv(output)
+	if err := validateConfig(output, mode); err != nil {
+		return nil, "", fmt.Errorf("migrated config v2 did not validate: %w", err)
+	}
+
 	return output, migrationReport(replaced), nil
 }
 
-func loadV1Config(data []byte) (*obi.Config, error) {
+func validateMigratableSelectorRefinements(cfg *obi.Config) error {
+	selectors := discover.FindingCriteria(cfg)
+	if len(selectors) < 2 {
+		return nil
+	}
+
+	var exportsSet, exportsOmitted bool
+	var routesSet, routesOmitted bool
+	for _, selector := range selectors {
+		if selector.GetExportModes() == services.ExportModeUnset {
+			exportsOmitted = true
+		} else {
+			exportsSet = true
+		}
+		if selector.GetRoutesConfig() == nil {
+			routesOmitted = true
+		} else {
+			routesSet = true
+		}
+	}
+
+	var mixed []string
+	if exportsSet && exportsOmitted {
+		mixed = append(mixed, "exports")
+	}
+	if routesSet && routesOmitted {
+		mixed = append(mixed, "routes")
+	}
+	if len(mixed) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"v1 selector refinements cannot be migrated safely: multiple effective discovery selectors mix explicit and omitted fields: %s; each field must be set on every effective selector or omitted from every effective selector",
+		strings.Join(mixed, ", "),
+	)
+}
+
+func receiverExporterPaths(data []byte) []string {
+	var source map[string]any
+	if err := yaml.Unmarshal(data, &source); err != nil {
+		return nil
+	}
+
+	var paths []string
+	for _, section := range []string{
+		"otel_traces_export",
+		"otel_metrics_export",
+		"prometheus_export",
+	} {
+		value, ok := source[section]
+		if !ok {
+			continue
+		}
+		for _, path := range leafPaths(value, yamlPath{section}) {
+			paths = append(paths, formatPath(path))
+		}
+	}
+	return paths
+}
+
+func preserveV1DNSMetrics(cfg *obi.Config, ext *schema.Extension) {
+	otelDNS := cfg.OTELMetrics.EndpointEnabled() &&
+		instrumentations.NewInstrumentationSelection(
+			cfg.OTELMetrics.Instrumentations,
+		).DNSEnabled()
+	prometheusDNS := cfg.Prometheus.EndpointEnabled() &&
+		instrumentations.NewInstrumentationSelection(
+			cfg.Prometheus.Instrumentations,
+		).DNSEnabled()
+	if otelDNS || prometheusDNS {
+		ext.Capture.Instrumentation.DNS.Enabled.Metrics = true
+	}
+}
+
+func loadV1ConfigForMode(data []byte, mode validationMode) (*obi.Config, error) {
 	cfg := obi.DefaultConfig
 	if cfg.Routes != nil {
 		routes := *cfg.Routes
@@ -239,6 +395,13 @@ func loadV1Config(data []byte) (*obi.Config, error) {
 		nameResolver := *cfg.NameResolver
 		cfg.NameResolver = &nameResolver
 	}
+	switch mode {
+	case validationModeStandalone:
+	case validationModeReceiver:
+		setReceiverConsumers(&cfg)
+	default:
+		return nil, fmt.Errorf("%w %q; expected standalone or receiver", errInvalidMode, mode)
+	}
 	if len(bytes.TrimSpace(data)) == 0 {
 		return &cfg, nil
 	}
@@ -247,6 +410,13 @@ func loadV1Config(data []byte) (*obi.Config, error) {
 	decoder := legacyyaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&cfg); err != nil {
+		if paths := unsupportedFeaturePathsFromYAML(data); len(paths) != 0 {
+			return nil, fmt.Errorf(
+				"decode v1 YAML fields at %s: %w",
+				strings.Join(paths, ", "),
+				err,
+			)
+		}
 		return nil, fmt.Errorf("decode v1 YAML fields: %w", err)
 	}
 	var extra any
@@ -268,6 +438,11 @@ func loadV1Config(data []byte) (*obi.Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+func setReceiverConsumers(cfg *obi.Config) {
+	cfg.Traces.TracesConsumer = consumertest.NewNop()
+	cfg.OTELMetrics.MetricsConsumer = consumertest.NewNop()
 }
 
 type yamlPath []any
@@ -313,8 +488,146 @@ func changedInputFields(data []byte, before, after *obi.Config) ([]string, error
 			changed = append(changed, name)
 		}
 	}
+	for _, path := range sequencePaths(source, nil) {
+		name := formatPath(path)
+		if migrationAlias(name) || migrationSequenceAlias(name) {
+			continue
+		}
+		beforeValue, beforeOK := valueAtPath(beforeMap, path)
+		afterValue, afterOK := valueAtPath(afterMap, path)
+		if beforeOK != afterOK || !reflect.DeepEqual(beforeValue, afterValue) {
+			changed = append(changed, name)
+		}
+	}
+	root, _ := source.(map[string]any)
+	changed = append(changed, unsupportedLayeredRoutePaths(root, before.Routes)...)
+	changed = append(changed, unsupportedFeaturePaths(root)...)
+	if hasAnyPath(root, "otel_traces_export.sampler") {
+		if path := changedMigrationSamplerPath(
+			before.Traces.SamplerConfig,
+			after.Traces.SamplerConfig,
+		); path != "" {
+			changed = append(changed, path)
+		}
+	}
+	if hasAnyPath(root, "otel_metrics_export.interval") &&
+		before.OTELMetrics.GetInterval() != after.OTELMetrics.GetInterval() {
+		changed = append(changed, "otel_metrics_export.interval")
+	}
+	if (before.Traces.Enabled() ||
+		hasNonEmptyStringPath(root, "otel_traces_export.protocol")) &&
+		before.Traces.GetProtocol() != after.Traces.GetProtocol() {
+		changed = append(changed, migrationOTLPProtocolPath(root, "otel_traces_export"))
+	}
+	if (before.OTELMetrics.EndpointEnabled() ||
+		hasNonEmptyStringPath(root, "otel_metrics_export.protocol")) &&
+		before.OTELMetrics.GetProtocol() != after.OTELMetrics.GetProtocol() {
+		changed = append(changed, migrationOTLPProtocolPath(root, "otel_metrics_export"))
+	}
+	if !equalMigrationFeatures(before.Metrics.Features, after.Metrics.Features) {
+		for _, path := range []string{
+			"metrics.features",
+			"otel_metrics_export.features",
+			"prometheus_export.features",
+		} {
+			if hasAnyPath(root, path) {
+				changed = append(changed, path)
+			}
+		}
+	}
+	if before.Enabled(obi.FeatureNetO11y) != after.Enabled(obi.FeatureNetO11y) {
+		changed = append(changed, migrationNetworkEnablePath(root))
+	}
+	for _, comparison := range []struct {
+		path    string
+		enabled bool
+		before  []instrumentations.Instrumentation
+		after   []instrumentations.Instrumentation
+	}{
+		{
+			path:    "otel_traces_export.instrumentations",
+			enabled: before.Traces.Enabled(),
+			before:  before.Traces.Instrumentations,
+			after:   after.Traces.Instrumentations,
+		},
+		{
+			path:    "otel_metrics_export.instrumentations",
+			enabled: before.OTELMetrics.EndpointEnabled(),
+			before:  before.OTELMetrics.Instrumentations,
+			after:   after.OTELMetrics.Instrumentations,
+		},
+		{
+			path:    "prometheus_export.instrumentations",
+			enabled: before.Prometheus.EndpointEnabled(),
+			before:  before.Prometheus.Instrumentations,
+			after:   after.Prometheus.Instrumentations,
+		},
+	} {
+		if (comparison.enabled || hasAnyPath(root, comparison.path)) &&
+			!equalMigrationInstrumentations(comparison.before, comparison.after) {
+			changed = append(changed, comparison.path)
+		}
+	}
 	sort.Strings(changed)
-	return changed, nil
+	return slices.Compact(changed), nil
+}
+
+func equalMigrationFeatures(before, after featureexport.Features) bool {
+	return before&^featureexport.FeatureEmpty == after&^featureexport.FeatureEmpty
+}
+
+func equalMigrationInstrumentations(
+	before, after []instrumentations.Instrumentation,
+) bool {
+	if len(before) != len(after) {
+		return false
+	}
+	counts := make(map[instrumentations.Instrumentation]int, len(before))
+	for _, instrumentation := range before {
+		counts[instrumentation]++
+	}
+	for _, instrumentation := range after {
+		counts[instrumentation]--
+	}
+	for _, count := range counts {
+		if count != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func changedMigrationSamplerPath(
+	before, after services.SamplerConfig,
+) string {
+	beforeName := normalizedMigrationSamplerName(before.Name)
+	afterName := normalizedMigrationSamplerName(after.Name)
+	beforeRatio, beforeErr := strconv.ParseFloat(before.Arg, 64)
+	if (beforeName == services.SamplerTraceIDRatio ||
+		beforeName == services.SamplerParentBasedTraceIDRatio) &&
+		beforeErr != nil {
+		return "otel_traces_export.sampler.arg"
+	}
+	if beforeName != afterName {
+		return "otel_traces_export.sampler.name"
+	}
+	if beforeName != services.SamplerTraceIDRatio &&
+		beforeName != services.SamplerParentBasedTraceIDRatio {
+		return ""
+	}
+
+	afterRatio, afterErr := strconv.ParseFloat(after.Arg, 64)
+	if afterErr != nil || beforeRatio != afterRatio {
+		return "otel_traces_export.sampler.arg"
+	}
+	return ""
+}
+
+func normalizedMigrationSamplerName(name services.SamplerName) services.SamplerName {
+	if name == "" {
+		return services.SamplerParentBasedAlwaysOn
+	}
+	return name
 }
 
 func equalMigrationValues(path string, before, after any) bool {
@@ -358,6 +671,25 @@ func leafPaths(value any, prefix yamlPath) []yamlPath {
 		return paths
 	default:
 		return []yamlPath{prefix}
+	}
+}
+
+func sequencePaths(value any, prefix yamlPath) []yamlPath {
+	switch value := value.(type) {
+	case map[string]any:
+		var paths []yamlPath
+		for key, child := range value {
+			paths = append(paths, sequencePaths(child, appendPath(prefix, key))...)
+		}
+		return paths
+	case []any:
+		paths := []yamlPath{prefix}
+		for index, child := range value {
+			paths = append(paths, sequencePaths(child, appendPath(prefix, index))...)
+		}
+		return paths
+	default:
+		return nil
 	}
 }
 
@@ -407,7 +739,9 @@ func formatPath(path yamlPath) string {
 }
 
 func migrationAlias(path string) bool {
-	if migrationDiscoveryLegacyPathRegexpAlias(path) || migrationDiscoveryExclusionAlias(path) {
+	if migrationDiscoveryLegacyPathRegexpAlias(path) ||
+		migrationDiscoveryExclusionAlias(path) ||
+		migrationDiscoveryRouteAlias(path) {
 		return true
 	}
 	for _, prefix := range []string{
@@ -416,13 +750,216 @@ func migrationAlias(path string) bool {
 		"target_pids",
 		"network.enable",
 		"otel_metrics_export.features",
+		"otel_metrics_export.interval",
+		"otel_metrics_export.protocol",
 		"prometheus_export.features",
+		"routes",
+		"otel_traces_export.protocol",
+		"otel_traces_export.sampler",
+		"otel_traces_export.instrumentations",
+		"otel_metrics_export.instrumentations",
+		"prometheus_export.instrumentations",
 	} {
 		if path == prefix || strings.HasPrefix(path, prefix+".") || strings.HasPrefix(path, prefix+"[") {
 			return true
 		}
 	}
 	return false
+}
+
+func migrationOTLPProtocolPath(root map[string]any, exporter string) string {
+	if hasNonEmptyStringPath(root, exporter+".protocol") {
+		return exporter + ".protocol"
+	}
+	return exporter + ".endpoint"
+}
+
+func migrationNetworkEnablePath(root map[string]any) string {
+	for _, path := range []string{
+		"network.enable",
+		"metrics.features",
+		"otel_metrics_export.features",
+		"prometheus_export.features",
+	} {
+		if hasAnyPath(root, path) {
+			return path
+		}
+	}
+	return "network.enable"
+}
+
+func hasNonEmptyStringPath(root map[string]any, path string) bool {
+	value, ok := rawValueAtPath(root, path)
+	if !ok {
+		return false
+	}
+	text, ok := value.(string)
+	return ok && text != ""
+}
+
+func unsupportedFeaturePaths(root map[string]any) []string {
+	var paths []string
+	for _, path := range []string{
+		"metrics.features",
+		"otel_metrics_export.features",
+		"prometheus_export.features",
+	} {
+		value, ok := rawValueAtPath(root, path)
+		if ok && containsUnknownFeature(value) {
+			paths = append(paths, path)
+		}
+	}
+
+	discovery, ok := root["discovery"].(map[string]any)
+	if !ok {
+		return paths
+	}
+	for _, field := range []string{
+		"instrument",
+		"services",
+		"exclude_instrument",
+		"exclude_services",
+		"default_exclude_instrument",
+		"default_exclude_services",
+	} {
+		selectors, ok := discovery[field].([]any)
+		if !ok {
+			continue
+		}
+		for index, rawSelector := range selectors {
+			selector, ok := rawSelector.(map[string]any)
+			if !ok {
+				continue
+			}
+			metrics, ok := selector["metrics"].(map[string]any)
+			if !ok {
+				continue
+			}
+			if _, ok := metrics["features"]; ok {
+				paths = append(paths, fmt.Sprintf(
+					"discovery.%s[%d].metrics.features",
+					field,
+					index,
+				))
+			}
+		}
+	}
+	return paths
+}
+
+func unsupportedFeaturePathsFromYAML(data []byte) []string {
+	var root map[string]any
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return nil
+	}
+	return unsupportedFeaturePaths(root)
+}
+
+func rawValueAtPath(root map[string]any, path string) (any, bool) {
+	var current any = root
+	for _, part := range strings.Split(path, ".") {
+		mapping, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = mapping[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func containsUnknownFeature(value any) bool {
+	features, ok := value.([]any)
+	if !ok {
+		return false
+	}
+	for _, value := range features {
+		feature, ok := value.(string)
+		if !ok {
+			return true
+		}
+		if _, ok := featureexport.FeatureMapper[feature]; !ok {
+			return true
+		}
+	}
+	return false
+}
+
+func migrationSequenceAlias(path string) bool {
+	switch path {
+	case "metrics.features",
+		"otel_metrics_export.features",
+		"prometheus_export.features",
+		"otel_traces_export.instrumentations",
+		"otel_metrics_export.instrumentations",
+		"prometheus_export.instrumentations",
+		"discovery.instrument",
+		"discovery.services",
+		"discovery.exclude_services":
+		return true
+	default:
+		return false
+	}
+}
+
+func migrationDiscoveryRouteAlias(path string) bool {
+	for _, prefix := range []string{
+		"discovery.instrument",
+		"discovery.services",
+	} {
+		field, ok := migrationDiscoverySelectorField(path, prefix)
+		if ok && field == "routes" {
+			return true
+		}
+	}
+	return false
+}
+
+func unsupportedLayeredRoutePaths(
+	root map[string]any,
+	routes *transform.RoutesConfig,
+) []string {
+	policies := routes.DirectionalPolicies()
+	directions := map[string]bool{
+		"incoming": len(policies.Incoming.Patterns) > 0,
+		"outgoing": len(policies.Outgoing.Patterns) > 0,
+	}
+
+	discovery, ok := root["discovery"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	var paths []string
+	for _, field := range []string{"instrument", "services"} {
+		selectors, ok := discovery[field].([]any)
+		if !ok {
+			continue
+		}
+		for index, rawSelector := range selectors {
+			selector, ok := rawSelector.(map[string]any)
+			if !ok {
+				continue
+			}
+			customRoutes, ok := selector["routes"].(map[string]any)
+			if !ok {
+				continue
+			}
+			for direction, globalPatterns := range directions {
+				values, ok := customRoutes[direction].([]any)
+				if globalPatterns && ok && len(values) > 0 {
+					paths = append(paths, fmt.Sprintf(
+						"discovery.%s[%d].routes.%s",
+						field,
+						index,
+						direction,
+					))
+				}
+			}
+		}
+	}
+	return paths
 }
 
 func migrationDiscoveryLegacyPathRegexpAlias(path string) bool {
@@ -499,10 +1036,35 @@ func migrationReport(data []byte) string {
 	if hasAnyPath(root, "discovery.skip_go_specific_tracers") {
 		lines = append(lines, "- inverted discovery.skip_go_specific_tracers into capture.runtimes.go.enabled")
 	}
+	if hasAnyPath(root, "routes") || hasDiscoveryRoutes(root) {
+		lines = append(lines, "- expanded v1 route settings into incoming and outgoing HTTP route policies")
+	}
 	if hasAnyPath(root, "otel_traces_export", "otel_metrics_export", "prometheus_export") {
 		lines = append(lines, "- moved exporter configuration into top-level OpenTelemetry providers")
 	}
 	return strings.Join(lines, "\n") + "\n"
+}
+
+func hasDiscoveryRoutes(root map[string]any) bool {
+	discovery, ok := root["discovery"].(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, field := range []string{"instrument", "services"} {
+		selectors, ok := discovery[field].([]any)
+		if !ok {
+			continue
+		}
+		for _, selector := range selectors {
+			selector, ok := selector.(map[string]any)
+			if ok {
+				if _, ok := selector["routes"]; ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func hasAnyPath(root map[string]any, paths ...string) bool {

--- a/cmd/obi/internal/configcmd/configcmd_test.go
+++ b/cmd/obi/internal/configcmd/configcmd_test.go
@@ -136,6 +136,31 @@ network:
 	require.Equal(t, "configuration is valid\n", stdout.String())
 }
 
+func TestValidateConfigAcceptsLastMatchWins(t *testing.T) {
+	require.NoError(t, validateConfig([]byte(`
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      policy:
+        default_action: exclude
+        match_order: last_match_wins
+      rules:
+        - action: include
+          match:
+            process:
+              exe_path_glob: ["/srv/*"]
+        - action: exclude
+          match:
+            process:
+              exe_path_glob: ["/srv/private/*"]
+    daemon:
+      logging:
+        debug_trace_output: text
+`), validationModeStandalone))
+}
+
 func TestValidateConfigDefaultIncludeWithoutSelector(t *testing.T) {
 	tests := []struct {
 		name string
@@ -186,6 +211,204 @@ rules:
 	}
 }
 
+func TestValidateConfigRejectsDivergentFlowLimitAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		mode validationMode
+		yaml string
+	}{
+		{
+			name: "standalone",
+			mode: validationModeStandalone,
+			yaml: `
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      limits:
+        network_packets: 74
+      network:
+        capture:
+          flow_lifecycle:
+            max_tracked_flows: 75
+    daemon:
+      logging:
+        debug_trace_output: text
+`,
+		},
+		{
+			name: "receiver",
+			mode: validationModeReceiver,
+			yaml: `
+version: "2.0"
+limits:
+  network_packets: 74
+network:
+  capture:
+    flow_lifecycle:
+      max_tracked_flows: 75
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateConfig([]byte(test.yaml), test.mode)
+			require.EqualError(
+				t,
+				err,
+				"capture.limits.network_packets (74) must equal "+
+					"capture.network.capture.flow_lifecycle.max_tracked_flows (75): "+
+					"both configure network.cache_max_flows",
+			)
+		})
+	}
+}
+
+func TestValidateConfigAcceptsSingleFlowLimitAlias(t *testing.T) {
+	tests := []struct {
+		name string
+		mode validationMode
+		yaml string
+	}{
+		{
+			name: "standalone limits",
+			mode: validationModeStandalone,
+			yaml: `
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      limits:
+        network_packets: 74
+    daemon:
+      logging:
+        debug_trace_output: text
+`,
+		},
+		{
+			name: "standalone lifecycle",
+			mode: validationModeStandalone,
+			yaml: `
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      network:
+        capture:
+          flow_lifecycle:
+            max_tracked_flows: 75
+    daemon:
+      logging:
+        debug_trace_output: text
+`,
+		},
+		{
+			name: "receiver limits",
+			mode: validationModeReceiver,
+			yaml: `
+version: "2.0"
+limits:
+  network_packets: 74
+`,
+		},
+		{
+			name: "receiver lifecycle",
+			mode: validationModeReceiver,
+			yaml: `
+version: "2.0"
+network:
+  capture:
+    flow_lifecycle:
+      max_tracked_flows: 75
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, validateConfig([]byte(test.yaml), test.mode))
+		})
+	}
+}
+
+func TestValidateConfigRejectsZeroFlowLimitAlias(t *testing.T) {
+	tests := []struct {
+		name string
+		mode validationMode
+		yaml string
+		want string
+	}{
+		{
+			name: "standalone limits",
+			mode: validationModeStandalone,
+			yaml: `
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      limits:
+        network_packets: 0
+    daemon:
+      logging:
+        debug_trace_output: text
+`,
+			want: "capture.limits.network_packets must be greater than zero",
+		},
+		{
+			name: "standalone lifecycle",
+			mode: validationModeStandalone,
+			yaml: `
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      network:
+        capture:
+          flow_lifecycle:
+            max_tracked_flows: 0
+    daemon:
+      logging:
+        debug_trace_output: text
+`,
+			want: "capture.network.capture.flow_lifecycle.max_tracked_flows must be greater than zero",
+		},
+		{
+			name: "receiver limits",
+			mode: validationModeReceiver,
+			yaml: `
+version: "2.0"
+limits:
+  network_packets: 0
+`,
+			want: "capture.limits.network_packets must be greater than zero",
+		},
+		{
+			name: "receiver lifecycle",
+			mode: validationModeReceiver,
+			yaml: `
+version: "2.0"
+network:
+  capture:
+    flow_lifecycle:
+      max_tracked_flows: 0
+`,
+			want: "capture.network.capture.flow_lifecycle.max_tracked_flows must be greater than zero",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.EqualError(t, validateConfig([]byte(test.yaml), test.mode), test.want)
+		})
+	}
+}
+
 func TestRunValidateRejectsInvalidInput(t *testing.T) {
 	tests := []struct {
 		name string
@@ -207,6 +430,36 @@ func TestRunValidateRejectsInvalidInput(t *testing.T) {
 			name: "unknown v2 field",
 			yaml: strings.Replace(validStandaloneV2, "      policy:\n", "      unknown_field: true\n      policy:\n", 1),
 			want: "field unknown_field not found",
+		},
+		{
+			name: "unsupported attribute limits",
+			yaml: strings.Replace(
+				validStandaloneV2,
+				"file_format: \"1.0\"\n",
+				"file_format: \"1.0\"\nattribute_limits: {}\n",
+				1,
+			),
+			want: "attribute_limits is not supported by the OBI runtime converter",
+		},
+		{
+			name: "unsupported disabled document",
+			yaml: strings.Replace(
+				validStandaloneV2,
+				"file_format: \"1.0\"\n",
+				"file_format: \"1.0\"\ndisabled: true\n",
+				1,
+			),
+			want: "disabled is not supported by the OBI runtime converter",
+		},
+		{
+			name: "capture rule missing action",
+			yaml: strings.Replace(
+				validStandaloneV2,
+				"        - action: include\n",
+				"        - name: missing-action\n",
+				1,
+			),
+			want: "capture.rules[0].action",
 		},
 		{
 			name: "v1 is not reinterpreted",
@@ -237,6 +490,225 @@ func TestRunValidateRejectsInvalidInput(t *testing.T) {
 	}
 }
 
+func TestMigrationGoldenFiles(t *testing.T) {
+	t.Setenv("CART_ROOT", "/srv")
+	t.Setenv("OTLP_HOST", "collector")
+	t.Setenv("OTEL_EBPF_BPF_WAKEUP_LEN", "999")
+
+	defaultConfig := integrationConfig(
+		t,
+		"devdocs/config/version-2.0/examples/default-configuration.yaml",
+	)
+	require.NoError(t, validateConfig(defaultConfig, validationModeStandalone))
+
+	input := integrationConfig(
+		t,
+		"cmd/obi/internal/configcmd/testdata/migration-v1.yaml",
+	)
+	wantStandalone := integrationConfig(
+		t,
+		"cmd/obi/internal/configcmd/testdata/migration-v2.yaml",
+	)
+	output, report, err := migrateConfig(input)
+	require.NoError(t, err)
+	require.Equal(t, wantStandalone, output)
+	require.Contains(t, string(output), "wakeup_len: 500")
+	require.Equal(t, `migrated v1 config to OBI config v2
+- fanned out v1 attribute filters to signal-scoped v2 filters
+- reshaped effective discovery selectors into capture.rules
+- expanded v1 route settings into incoming and outgoing HTTP route policies
+- moved exporter configuration into top-level OpenTelemetry providers
+`, report)
+
+	_, standalone, err := schema.ParseStandaloneYAML(output)
+	require.NoError(t, err)
+
+	receiverData := integrationConfig(
+		t,
+		"cmd/obi/internal/configcmd/testdata/migration-receiver-v2.yaml",
+	)
+	receiverInput := integrationConfig(
+		t,
+		"cmd/obi/internal/configcmd/testdata/migration-receiver-v1.yaml",
+	)
+	receiverOutput, receiverReport, err := migrateConfigForMode(
+		receiverInput,
+		validationModeReceiver,
+	)
+	require.NoError(t, err)
+	require.Equal(t, receiverData, receiverOutput)
+	require.Contains(t, receiverReport, "capture.rules")
+	receiverOutputAgain, receiverReportAgain, err := migrateConfigForMode(
+		receiverInput,
+		validationModeReceiver,
+	)
+	require.NoError(t, err)
+	require.Equal(t, receiverOutput, receiverOutputAgain)
+	require.Equal(t, receiverReport, receiverReportAgain)
+
+	receiver, err := schema.ParseReceiverYAML(receiverData)
+	require.NoError(t, err)
+	require.Equal(t, standalone.Version, receiver.Version)
+	require.Equal(t, standalone.Capture, receiver.Capture)
+	require.NoError(t, validateConfig(receiverData, validationModeReceiver))
+
+	rewired := bytes.Replace(
+		output,
+		[]byte("wakeup_len: 500"),
+		[]byte("wakeup_len: ${OTEL_EBPF_BPF_WAKEUP_LEN:-500}"),
+		1,
+	)
+	require.NotEqual(t, output, rewired)
+	require.NoError(t, validateConfig(rewired, validationModeStandalone))
+
+	rewiredDoc, _, err := schema.ParseStandaloneYAML(obiconfig.ReplaceEnv(rewired))
+	require.NoError(t, err)
+	rewiredRuntime, err := convert.DocumentToRuntime(rewiredDoc)
+	require.NoError(t, err)
+	require.Equal(t, 999, rewiredRuntime.EBPF.WakeupLen)
+}
+
+func TestRunMigrateReceiver(t *testing.T) {
+	path := writeConfig(t, "receiver-v1.yaml", `open_port: "8080"`)
+	var stdout, stderr bytes.Buffer
+
+	exitCode := run(
+		[]string{"migrate", "--mode=receiver", path},
+		&stdout,
+		&stderr,
+	)
+
+	require.Equal(t, ExitSuccess, exitCode, stderr.String())
+	require.Contains(t, stdout.String(), `version: "2.0"`)
+	require.NotContains(t, stdout.String(), "file_format:")
+	require.NotContains(t, stdout.String(), "extensions:")
+	require.Contains(t, stderr.String(), "capture.rules")
+	receiver, err := schema.ParseReceiverYAML(stdout.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, validateConfig(stdout.Bytes(), validationModeReceiver))
+	require.Equal(
+		t,
+		[]int{8080},
+		receiver.Capture.Rules[len(receiver.Capture.Rules)-1].
+			Match.Process.OpenPorts.AllValues(),
+	)
+}
+
+func TestMigrateConfigReceiverRejectsWrongInputShape(t *testing.T) {
+	_, _, err := migrateConfigForMode(
+		[]byte("version: \"2.0\"\npolicy: {}\n"),
+		validationModeReceiver,
+	)
+	require.ErrorContains(t, err, "already a receiver OBI config v2 document")
+
+	_, _, err = migrateConfigForMode([]byte(`
+open_port: "8080"
+otel_traces_export:
+  endpoint: http://collector:4317
+`), validationModeReceiver)
+	require.ErrorContains(t, err, "otel_traces_export.endpoint")
+}
+
+func TestMigrateConfigReceiverRejectsStandaloneOnlyV1Fields(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "Kubernetes enrichment",
+			yaml: `
+attributes:
+  kubernetes:
+    cluster_name: production
+`,
+			want: "attributes.kubernetes.cluster_name",
+		},
+		{
+			name: "name resolution",
+			yaml: `
+name_resolver:
+  sources: [dns]
+`,
+			want: "name_resolver.sources",
+		},
+		{
+			name: "log correlation",
+			yaml: `
+ebpf:
+  log_enricher:
+    cache_size: 256
+`,
+			want: "ebpf.log_enricher.cache_size",
+		},
+		{
+			name: "daemon telemetry",
+			yaml: `
+internal_metrics:
+  exporter: prometheus
+  prometheus:
+    port: 9090
+`,
+			want: "internal_metrics.exporter",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := migrateConfigForMode(
+				[]byte("open_port: \"8080\"\n"+test.yaml),
+				validationModeReceiver,
+			)
+
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestMigrationEnvironmentSelectorExample(t *testing.T) {
+	example := []byte(`
+file_format: "1.0"
+extensions:
+  obi:
+    version: "2.0"
+    capture:
+      policy:
+        default_action: exclude
+        match_order: first_match_wins
+      rules:
+        - action: include
+          match:
+            process:
+              exe_path_glob: ["/srv/*"]
+              language_glob: [go, java]
+    daemon:
+      logging:
+        debug_trace_output: text
+`)
+
+	require.NoError(t, validateConfig(example, validationModeStandalone))
+	doc, ext, err := schema.ParseStandaloneYAML(example)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		[]string{"/srv/*"},
+		ext.Capture.Rules[0].Match.Process.ExePathGlob,
+	)
+	require.Equal(
+		t,
+		[]string{"go", "java"},
+		ext.Capture.Rules[0].Match.Process.LanguageGlob,
+	)
+
+	cfg, err := convert.DocumentToRuntime(doc)
+	require.NoError(t, err)
+	require.Len(t, cfg.Discovery.Instrument, 1)
+	require.True(t, cfg.Discovery.Instrument[0].Path.MatchString("/srv/api"))
+	require.True(t, cfg.Discovery.Instrument[0].Languages.MatchString("go"))
+	require.True(t, cfg.Discovery.Instrument[0].Languages.MatchString("java"))
+	require.False(t, cfg.Discovery.Instrument[0].Languages.MatchString("python"))
+}
+
 func TestRunMigrateRepresentativeV1(t *testing.T) {
 	t.Setenv("OTEL_EBPF_BPF_WAKEUP_LEN", "999")
 	t.Setenv("MIGRATION_WAKEUP_LEN", "64")
@@ -260,6 +732,92 @@ func TestRunMigrateRepresentativeV1(t *testing.T) {
 	require.Contains(t, firstReport.String(), "inverted")
 	require.Contains(t, firstReport.String(), "OpenTelemetry providers")
 	require.NoError(t, validateConfig(first.Bytes(), validationModeStandalone))
+}
+
+func TestMigrateConfigAcceptsSemanticNormalization(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "trace ID ratio sampler",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_traces_export:
+  endpoint: http://collector:4317
+  sampler:
+    name: traceidratio
+    arg: "0.10"
+`,
+			want: "ratio: 0.1",
+		},
+		{
+			name: "parent-based trace ID ratio sampler",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_traces_export:
+  endpoint: http://collector:4317
+  sampler:
+    name: parentbased_traceidratio
+    arg: "0.10"
+`,
+			want: "ratio: 0.1",
+		},
+		{
+			name: "effective metric interval",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_metrics_export:
+  endpoint: http://collector:4317
+  interval: 0s
+`,
+			want: "interval: 60000",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output, _, err := migrateConfig([]byte(test.yaml))
+			require.NoError(t, err)
+			require.Contains(t, string(output), test.want)
+		})
+	}
+}
+
+func TestConfigCommandsSuppressRuntimeValidationLogs(t *testing.T) {
+	originalLogger := slog.Default()
+	var logs bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+
+	path := writeConfig(t, "v1.yaml", `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_traces_export:
+  endpoint: http://collector:4317
+  batch_max_size: 10
+  queue_size: 0
+`)
+	var stdout, stderr bytes.Buffer
+
+	exitCode := run([]string{"migrate", path}, &stdout, &stderr)
+
+	require.Equal(t, ExitSuccess, exitCode, stderr.String())
+	require.Empty(t, logs.String())
+	require.Equal(t, `migrated v1 config to OBI config v2
+- reshaped effective discovery selectors into capture.rules
+- moved exporter configuration into top-level OpenTelemetry providers
+`, stderr.String())
 }
 
 func TestMigrateConfigPreservesEscapedEnvironmentVariable(t *testing.T) {
@@ -302,6 +860,466 @@ metrics:
 	require.True(t, runtimeConfig.Enabled(obi.FeatureNetO11y))
 }
 
+func TestMigrateConfigExpandsGlobalRoutes(t *testing.T) {
+	output, report, err := migrateConfig([]byte(`
+routes:
+  unmatched: path
+  patterns: ["/users/{id}"]
+  ignored_patterns: ["/health"]
+  ignore_mode: metrics
+  wildcard_char: "#"
+  max_path_segment_cardinality: 25
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+metrics:
+  features: [application]
+prometheus_export:
+  port: 9090
+`))
+	require.NoError(t, err)
+	require.Contains(t, report, "incoming and outgoing HTTP route policies")
+
+	_, ext, err := schema.ParseStandaloneYAML(output)
+	require.NoError(t, err)
+
+	for _, policy := range []*schema.HTTPRoutePolicy{
+		ext.Capture.Instrumentation.HTTP.Routes.Incoming,
+		ext.Capture.Instrumentation.HTTP.Routes.Outgoing,
+	} {
+		require.NotNil(t, policy)
+		require.Equal(t, "path", string(*policy.Unmatched))
+		require.Equal(t, []string{"/users/{id}"}, *policy.Patterns)
+		require.Equal(t, []string{"/health"}, *policy.IgnoredPatterns)
+		require.Equal(t, "metrics", string(*policy.IgnoreMode))
+		require.Equal(t, "#", *policy.WildcardChar)
+		require.Equal(t, 25, *policy.MaxPathSegmentCardinality)
+	}
+}
+
+func TestMigrateConfigPreservesPerServiceRoutes(t *testing.T) {
+	output, report, err := migrateConfig([]byte(`
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+      routes:
+        incoming: ["/users/{id}"]
+        outgoing: ["/inventory/{id}"]
+metrics:
+  features: [application]
+prometheus_export:
+  port: 9090
+`))
+	require.NoError(t, err)
+	require.Contains(t, report, "incoming and outgoing HTTP route policies")
+
+	_, ext, err := schema.ParseStandaloneYAML(output)
+	require.NoError(t, err)
+	require.NotEmpty(t, ext.Capture.Rules)
+
+	rule := ext.Capture.Rules[len(ext.Capture.Rules)-1]
+	require.NotNil(t, rule.Refine.HTTP)
+	require.Equal(t, []string{"/users/{id}"}, *rule.Refine.HTTP.Routes.Incoming.Patterns)
+	require.Equal(t, []string{"/inventory/{id}"}, *rule.Refine.HTTP.Routes.Outgoing.Patterns)
+}
+
+func TestMigrateConfigDeterministicSelectorExports(t *testing.T) {
+	input := []byte(`
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+      exports: [metrics, traces]
+metrics:
+  features: [application]
+prometheus_export:
+  port: 9090
+`)
+	wantOutput, wantReport, err := migrateConfig(input)
+	require.NoError(t, err)
+
+	for range 100 {
+		output, report, err := migrateConfig(input)
+		require.NoError(t, err)
+		require.Equal(t, wantOutput, output)
+		require.Equal(t, wantReport, report)
+	}
+}
+
+func TestMigrateConfigOrdersOverlappingRefinementsForFirstMatch(t *testing.T) {
+	output, _, err := migrateConfig([]byte(`
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+      exports: [metrics]
+    - exe_path: "/srv/payments/*"
+      exports: [traces]
+metrics:
+  features: [application]
+otel_traces_export:
+  endpoint: http://collector:4317
+prometheus_export:
+  port: 9090
+`))
+	require.NoError(t, err)
+
+	_, ext, err := schema.ParseStandaloneYAML(output)
+	require.NoError(t, err)
+	var includes []schema.Rule
+	for _, rule := range ext.Capture.Rules {
+		if rule.Action == schema.CaptureActionInclude {
+			includes = append(includes, rule)
+		}
+	}
+	require.Len(t, includes, 2)
+	require.Equal(
+		t,
+		[]string{"/srv/payments/*"},
+		includes[0].Match.Process.ExePathGlob,
+	)
+	require.Equal(t, []string{"/srv/*"}, includes[1].Match.Process.ExePathGlob)
+}
+
+func TestMigrateConfigRejectsMixedSelectorRefinementInheritance(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "exports",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+      exports: [metrics]
+    - exe_path: "/srv/payments/*"
+metrics:
+  features: [application]
+otel_traces_export:
+  endpoint: http://collector:4317
+prometheus_export:
+  port: 9090
+`,
+			want: "mix explicit and omitted fields: exports",
+		},
+		{
+			name: "routes",
+			yaml: `
+discovery:
+  services:
+    - exe_path: "^/srv/.*"
+      routes:
+        incoming: ["/api/{id}"]
+    - exe_path: "^/srv/payments/.*"
+trace_printer: text
+`,
+			want: "mix explicit and omitted fields: routes",
+		},
+		{
+			name: "exports and routes",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+      exports: [metrics]
+      routes:
+        incoming: ["/api/{id}"]
+    - exe_path: "/srv/payments/*"
+metrics:
+  features: [application]
+prometheus_export:
+  port: 9090
+`,
+			want: "mix explicit and omitted fields: exports, routes",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := migrateConfig([]byte(test.yaml))
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestMigrateConfigRejectsMixedSelectorRefinementsInReceiverMode(t *testing.T) {
+	_, _, err := migrateConfigForMode([]byte(`
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+      exports: [metrics]
+    - exe_path: "/srv/payments/*"
+metrics:
+  features: [application]
+`), validationModeReceiver)
+
+	require.ErrorContains(t, err, "mix explicit and omitted fields: exports")
+}
+
+func TestMigrateConfigRejectsMixedRefinementWithSyntheticSelector(t *testing.T) {
+	_, _, err := migrateConfig([]byte(`
+open_port: "8080"
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+      exports: [metrics]
+metrics:
+  features: [application]
+prometheus_export:
+  port: 9090
+`))
+
+	require.ErrorContains(t, err, "mix explicit and omitted fields: exports")
+}
+
+func TestMigrateConfigAllowsExplicitRoutesOnEverySelector(t *testing.T) {
+	output, _, err := migrateConfig([]byte(`
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+      routes:
+        incoming: ["/api/{id}"]
+    - exe_path: "/srv/payments/*"
+      routes: {}
+trace_printer: text
+`))
+	require.NoError(t, err)
+
+	_, ext, err := schema.ParseStandaloneYAML(output)
+	require.NoError(t, err)
+	var includes []schema.Rule
+	for _, rule := range ext.Capture.Rules {
+		if rule.Action == schema.CaptureActionInclude {
+			includes = append(includes, rule)
+		}
+	}
+	require.Len(t, includes, 2)
+	require.Equal(
+		t,
+		[]string{"/srv/payments/*"},
+		includes[0].Match.Process.ExePathGlob,
+	)
+	require.Nil(t, includes[0].Refine.HTTP)
+	require.NotNil(t, includes[1].Refine.HTTP)
+}
+
+func TestMigrateConfigPreservesReorderedInstrumentations(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "traces",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_traces_export:
+  endpoint: http://collector:4317
+  instrumentations: [grpc, http, sql, redis, kafka, mqtt, nats, amqp, mongo, couchbase, memcached, sunrpc, aerospike]
+`,
+		},
+		{
+			name: "OTLP metrics",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+metrics:
+  features: [application]
+otel_metrics_export:
+  endpoint: http://collector:4317
+  instrumentations: [http, nats, mqtt, amqp, genai, memcached, sunrpc, aerospike]
+`,
+		},
+		{
+			name: "Prometheus metrics",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+metrics:
+  features: [application]
+prometheus_export:
+  port: 9090
+  instrumentations: [http, nats, mqtt, amqp, genai, memcached, sunrpc, aerospike]
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := migrateConfig([]byte(test.yaml))
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestMigrateConfigRejectsNetworkEnablementChange(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "omitted enable",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+network:
+  print_flows: true
+metrics:
+  features: [application, network]
+otel_traces_export:
+  endpoint: http://collector:4317
+`,
+			want: "metrics.features",
+		},
+		{
+			name: "explicit false",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+network:
+  enable: false
+  print_flows: true
+metrics:
+  features: [application, network]
+otel_traces_export:
+  endpoint: http://collector:4317
+`,
+			want: "network.enable",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := migrateConfig([]byte(test.yaml))
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestMigrateConfigRejectsLayeredRoutePatterns(t *testing.T) {
+	_, _, err := migrateConfig([]byte(`
+routes:
+  patterns: ["/global/{id}"]
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+      routes:
+        incoming: ["/users/{id}"]
+metrics:
+  features: [application]
+prometheus_export:
+  port: 9090
+`))
+	require.ErrorContains(t, err, "discovery.instrument[0].routes.incoming")
+}
+
+func TestMigrateConfigPreservesExplicitGRPCProtocol(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "traces",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_traces_export:
+  endpoint: http://collector:4318
+  protocol: grpc
+`,
+		},
+		{
+			name: "metrics",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+metrics:
+  features: [application]
+otel_metrics_export:
+  endpoint: http://collector:4318
+  protocol: grpc
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output, _, err := migrateConfig([]byte(test.yaml))
+			require.NoError(t, err)
+			require.Contains(t, string(output), "otlp_grpc:")
+		})
+	}
+}
+
+func TestMigrateConfigPreservesDefaultDNSMetrics(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "OTLP",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+metrics:
+  features: [application]
+otel_metrics_export:
+  endpoint: http://collector:4317
+`,
+		},
+		{
+			name: "Prometheus",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+metrics:
+  features: [application]
+prometheus_export:
+  port: 9090
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			output, _, err := migrateConfig([]byte(test.yaml))
+			require.NoError(t, err)
+
+			_, ext, err := schema.ParseStandaloneYAML(output)
+			require.NoError(t, err)
+			require.True(t, ext.Capture.Instrumentation.DNS.Enabled.Metrics)
+		})
+	}
+}
+
+func TestMigrateConfigAllowsDisabledEmptyExporterEndpoints(t *testing.T) {
+	for _, exporter := range []string{"otel_traces_export", "otel_metrics_export"} {
+		t.Run(exporter, func(t *testing.T) {
+			_, _, err := migrateConfig([]byte(fmt.Sprintf(`
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+prometheus_export:
+  port: 9090
+%s:
+  endpoint: ""
+  protocol: ""
+`, exporter)))
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestMigrateConfigSupportsDeprecatedServiceSelectors(t *testing.T) {
 	originalLogger := slog.Default()
 	var logs bytes.Buffer
@@ -316,7 +1334,7 @@ discovery:
     - exe_path: "^/srv/api$"
     - open_ports: 5000
 otel_traces_export:
-  endpoint: http://collector:4318
+  endpoint: http://collector:4317
 `))
 	require.NoError(t, err)
 	require.Empty(t, logs.String())
@@ -346,7 +1364,7 @@ discovery:
     - exe_path: "{[a,b],c}"
   default_exclude_instrument: []
 otel_traces_export:
-  endpoint: http://collector:4318
+  endpoint: http://collector:4317
 `))
 	require.NoError(t, err)
 	require.Contains(t, report, "capture.rules")
@@ -380,7 +1398,7 @@ discovery:
   default_exclude_services:
     - exe_path_regexp: "^/usr/bin/obi$"
 otel_traces_export:
-  endpoint: http://collector:4318
+  endpoint: http://collector:4317
 `))
 	require.NoError(t, err)
 
@@ -411,7 +1429,7 @@ open_port: "8080"
 discovery:
   excluded_linux_system_paths: %s
 otel_traces_export:
-  endpoint: http://collector:4318
+  endpoint: http://collector:4317
 `, value)))
 
 		require.ErrorContains(t, err, "discovery.excluded_linux_system_paths")
@@ -429,7 +1447,7 @@ discovery:
     - /sbin/
     - /usr/sbin/
 otel_traces_export:
-  endpoint: http://collector:4318
+  endpoint: http://collector:4317
 `))
 	require.NoError(t, err)
 
@@ -455,10 +1473,10 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 		{
 			name: "Docker Go OTEL gRPC",
 			input: func(t *testing.T) []byte {
-				return withV1OpenPort(
+				return withV1GRPCProtocol(withV1OpenPort(
 					integrationConfig(t, "internal/test/integration/configs/obi-config-go-otel-grpc.yml"),
 					8080,
-				)
+				), "http://jaeger:4318")
 			},
 			verify: func(t *testing.T, cfg *obi.Config) {
 				require.True(t, cfg.Enabled(obi.FeatureAppO11y))
@@ -467,16 +1485,18 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 				require.Equal(t, 8999, cfg.Prometheus.Port)
 				require.Equal(t, "http://jaeger:4318", cfg.Traces.TracesEndpoint)
 				require.NotNil(t, cfg.Routes)
-				require.Equal(t, "path", string(cfg.Routes.Unmatch))
+				routes := cfg.Routes.DirectionalPolicies()
+				require.Equal(t, "path", string(routes.Incoming.Unmatch))
+				require.Equal(t, "path", string(routes.Outgoing.Unmatch))
 			},
 		},
 		{
 			name: "Docker Java",
 			input: func(t *testing.T) []byte {
-				return withV1OpenPort(
+				return withV1GRPCProtocol(withV1OpenPort(
 					integrationConfig(t, "internal/test/integration/configs/obi-config-java.yml"),
 					8085,
-				)
+				), "http://otelcol:4318")
 			},
 			verify: func(t *testing.T, cfg *obi.Config) {
 				require.True(t, cfg.Enabled(obi.FeatureAppO11y))
@@ -484,13 +1504,17 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 				require.True(t, cfg.Discovery.Instrument[0].OpenPorts.Matches(8085))
 				require.Equal(t, "http://otelcol:4318", cfg.OTELMetrics.MetricsEndpoint)
 				require.NotNil(t, cfg.Routes)
-				require.Equal(t, []string{"/greeting"}, cfg.Routes.Patterns)
+				routes := cfg.Routes.DirectionalPolicies()
+				require.Equal(t, []string{"/greeting"}, routes.Incoming.Patterns)
+				require.Equal(t, []string{"/greeting"}, routes.Outgoing.Patterns)
 			},
 		},
 		{
 			name: "Kubernetes daemonset",
 			input: func(t *testing.T) []byte {
-				return kubernetesConfig(t, "internal/test/integration/k8s/manifests/06-obi-daemonset.yml")
+				config := kubernetesConfig(t, "internal/test/integration/k8s/manifests/06-obi-daemonset.yml")
+				config = withV1GRPCProtocol(config, "http://otelcol:4318")
+				return withV1GRPCProtocol(config, "http://jaeger:4318")
 			},
 			verify: func(t *testing.T, cfg *obi.Config) {
 				require.True(t, cfg.Enabled(obi.FeatureAppO11y))
@@ -501,13 +1525,16 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 				require.True(t, cfg.Discovery.Instrument[0].Metadata["k8s_deployment_name"].MatchString("testserver"))
 				require.True(t, cfg.Discovery.ExcludeInstrument[0].Metadata["k8s_deployment_name"].MatchString("testserver"))
 				require.NotNil(t, cfg.Routes)
-				require.Equal(t, []string{"/metrics"}, cfg.Routes.IgnorePatterns)
+				routes := cfg.Routes.DirectionalPolicies()
+				require.Equal(t, []string{"/metrics"}, routes.Incoming.IgnorePatterns)
+				require.Equal(t, []string{"/metrics"}, routes.Outgoing.IgnorePatterns)
 			},
 		},
 		{
 			name: "Kubernetes shared PID namespace daemonset",
 			input: func(t *testing.T) []byte {
-				return kubernetesConfig(t, "internal/test/integration/k8s/manifests/06-obi-daemonset-sharedpidns.yml")
+				config := kubernetesConfig(t, "internal/test/integration/k8s/manifests/06-obi-daemonset-sharedpidns.yml")
+				return withV1GRPCProtocol(config, "http://otelcol:4318")
 			},
 			verify: func(t *testing.T, cfg *obi.Config) {
 				require.True(t, cfg.Enabled(obi.FeatureAppO11y))
@@ -517,7 +1544,9 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 				require.True(t, cfg.Discovery.Instrument[0].Metadata["k8s_deployment_name"].MatchString("testserver"))
 				require.True(t, cfg.Discovery.Instrument[1].Metadata["k8s_daemonset_name"].MatchString("hostpid-httpserver"))
 				require.NotNil(t, cfg.Routes)
-				require.Equal(t, []string{"/pingpong"}, cfg.Routes.Patterns)
+				routes := cfg.Routes.DirectionalPolicies()
+				require.Equal(t, []string{"/pingpong"}, routes.Incoming.Patterns)
+				require.Equal(t, []string{"/pingpong"}, routes.Outgoing.Patterns)
 			},
 		},
 	}
@@ -547,6 +1576,12 @@ func integrationConfig(t *testing.T, relativePath string) []byte {
 
 func withV1OpenPort(config []byte, port int) []byte {
 	return append(config, fmt.Sprintf("\nopen_port: %d\n", port)...)
+}
+
+func withV1GRPCProtocol(config []byte, endpoint string) []byte {
+	oldEndpoint := []byte("  endpoint: " + endpoint)
+	newEndpoint := append(append([]byte{}, oldEndpoint...), []byte("\n  protocol: grpc")...)
+	return bytes.Replace(config, oldEndpoint, newEndpoint, 1)
 }
 
 func kubernetesConfig(t *testing.T, relativePath string) []byte {
@@ -605,6 +1640,146 @@ func TestRunMigrateRejectsUnsupportedInput(t *testing.T) {
 			want: "prometheus_export.path",
 		},
 		{
+			name: "unsupported metric feature",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+metrics:
+  features: [application, application_span]
+prometheus_export:
+  port: 9090
+`,
+			want: "metrics.features",
+		},
+		{
+			name: "unknown metric feature",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+metrics:
+  features: [application, totally_unknown]
+prometheus_export:
+  port: 9090
+`,
+			want: "metrics.features",
+		},
+		{
+			name: "non-string metric feature",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+metrics:
+  features: [application, 123]
+prometheus_export:
+  port: 9090
+`,
+			want: "metrics.features",
+		},
+		{
+			name: "unknown deprecated metric feature",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_metrics_export:
+  endpoint: http://collector:4317
+  features: [application, totally_unknown]
+`,
+			want: "otel_metrics_export.features",
+		},
+		{
+			name: "per-service metric features",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+      metrics:
+        features: [application]
+prometheus_export:
+  port: 9090
+`,
+			want: "discovery.instrument[0].metrics.features",
+		},
+		{
+			name: "unsupported instrumentation selection",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_traces_export:
+  endpoint: http://collector:4317
+  instrumentations: [http]
+`,
+			want: "otel_traces_export.instrumentations",
+		},
+		{
+			name: "invalid trace ID ratio sampler argument",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_traces_export:
+  endpoint: http://collector:4317
+  sampler:
+    name: traceidratio
+    arg: invalid
+`,
+			want: "otel_traces_export.sampler.arg",
+		},
+		{
+			name: "implicit HTTP trace protocol",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_traces_export:
+  endpoint: http://collector:4318
+`,
+			want: "otel_traces_export.endpoint",
+		},
+		{
+			name: "implicit HTTP metric protocol",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+metrics:
+  features: [application]
+otel_metrics_export:
+  endpoint: http://collector:4318
+`,
+			want: "otel_metrics_export.endpoint",
+		},
+		{
+			name: "implicit HTTP trace protocol explicitly empty",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_traces_export:
+  endpoint: http://collector:4318
+  protocol: ""
+`,
+			want: "otel_traces_export.endpoint",
+		},
+		{
+			name: "implicit HTTP metric protocol explicitly empty",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+metrics:
+  features: [application]
+otel_metrics_export:
+  endpoint: http://collector:4318
+  protocol: ""
+`,
+			want: "otel_metrics_export.endpoint",
+		},
+		{
 			name: "unsupported exclusion selector field",
 			yaml: `
 discovery:
@@ -628,7 +1803,7 @@ discovery:
     - name: ignored
       exe_path_regexp: "^/srv/.*$"
 otel_traces_export:
-  endpoint: http://collector:4318
+  endpoint: http://collector:4317
 `,
 			want: "discovery.services[0].name",
 		},
@@ -636,6 +1811,17 @@ otel_traces_export:
 			name: "already v2",
 			yaml: validStandaloneV2,
 			want: "already a standalone OBI config v2",
+		},
+		{
+			name: "debug trace exporter",
+			yaml: `
+discovery:
+  instrument:
+    - exe_path: "/srv/*"
+otel_traces_export:
+  protocol: debug
+`,
+			want: "otel_traces_export.protocol",
 		},
 	}
 
@@ -662,6 +1848,7 @@ func TestRunExitCodes(t *testing.T) {
 		{name: "missing subcommand", want: ExitUsage},
 		{name: "unknown subcommand", args: []string{"unknown"}, want: ExitUsage},
 		{name: "invalid mode", args: []string{"validate", "--mode=other", "missing"}, want: ExitUsage},
+		{name: "invalid migrate mode", args: []string{"migrate", "--mode=other", "missing"}, want: ExitUsage},
 		{name: "unsupported migrate flag", args: []string{"migrate", "--from=v1", "missing"}, want: ExitUsage},
 		{name: "validate read error", args: []string{"validate", "missing"}, want: ExitError},
 		{name: "migrate read error", args: []string{"migrate", "missing"}, want: ExitError},

--- a/cmd/obi/internal/configcmd/testdata/migration-receiver-v1.yaml
+++ b/cmd/obi/internal/configcmd/testdata/migration-receiver-v1.yaml
@@ -1,0 +1,18 @@
+discovery:
+  instrument:
+    - exe_path: "${CART_ROOT:-/srv}/cart-*"
+      open_ports: "8080"
+filter:
+  application:
+    http.request.method:
+      not_match: OPTIONS
+routes:
+  unmatched: heuristic
+  patterns:
+    - "/cart/{id}"
+  ignored_patterns:
+    - "/health"
+  ignore_mode: all
+metrics:
+  features:
+    - application

--- a/cmd/obi/internal/configcmd/testdata/migration-receiver-v2.yaml
+++ b/cmd/obi/internal/configcmd/testdata/migration-receiver-v2.yaml
@@ -1,0 +1,351 @@
+version: "2.0"
+policy:
+    default_action: exclude
+    match_order: first_match_wins
+    poll_interval: 0s
+    min_process_age: 5s
+rules:
+    - action: exclude
+      name: exclude-obi-and-collectors
+      description: Exclude OBI and collector binaries to avoid self-instrumentation and collector recursion.
+      match:
+        process:
+            exe_path_glob:
+                - '{*/obi,obi,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*}'
+    - action: exclude
+      name: exclude-system-namespaces
+      description: Exclude common platform/system Kubernetes namespaces from instrumentation by default.
+      match:
+        kubernetes:
+            namespace_glob:
+                - kube-system
+                - kube-node-lease
+                - local-path-storage
+                - cert-manager
+                - monitoring
+                - gke-connect
+                - gke-gmp-system
+                - gke-managed-cim
+                - gke-managed-filestorecsi
+                - gke-managed-metrics-server
+                - gke-managed-system
+                - gke-system
+                - gke-managed-volumepopulator
+                - gatekeeper-system
+    - action: exclude
+      name: exclude-otlp-exporters
+      description: Exclude services that already export OTLP to prevent duplicate telemetry pipelines.
+      match:
+        process:
+            exports_otlp:
+                port: 4317
+                protocol: protobuf
+    - action: include
+      name: ""
+      description: ""
+      match:
+        process:
+            open_ports: "8080"
+            exe_path_glob:
+                - /srv/cart-*
+instrumentation:
+    http:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        track_request_headers: false
+        request_timeout: 0s
+        go_http_client_buffer_timeout: 1s
+        buffer_size: 0
+        routes:
+            incoming:
+                unmatched: heuristic
+                patterns:
+                    - /cart/{id}
+                ignored_patterns:
+                    - /health
+                ignore_mode: all
+                wildcard_char: '*'
+                max_path_segment_cardinality: 10
+            outgoing:
+                unmatched: heuristic
+                patterns:
+                    - /cart/{id}
+                ignored_patterns:
+                    - /health
+                ignore_mode: all
+                wildcard_char: '*'
+                max_path_segment_cardinality: 10
+            discovery:
+                timeout: 10s
+                disabled_languages: []
+                java:
+                    delay: 5s
+        payload_extraction:
+            enabled: []
+            sqlpp:
+                endpoint_patterns:
+                    - /query/service
+            enrichment:
+                policy:
+                    default_action:
+                        headers: exclude
+                        body: exclude
+                    obfuscation_string: '***'
+                rules: []
+            openai_compatible:
+                gateways: []
+    grpc:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+    sql:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        heuristic_detect: false
+        mysql:
+            buffer_size: 0
+            prepared_statements_cache_size: 1024
+        postgres:
+            buffer_size: 0
+            prepared_statements_cache_size: 1024
+        mssql:
+            buffer_size: 0
+            prepared_statements_cache_size: 1024
+    redis:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        db_cache:
+            enabled: false
+            max_size: 1000
+    kafka:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        buffer_size: 0
+        topic_uuid_cache_size: 1024
+    mongo:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        requests_cache_size: 1024
+    couchbase:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        db_cache_size: 1024
+    dns:
+        enabled:
+            traces: false
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        request_timeout: 5s
+    gpu:
+        enabled:
+            traces: false
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+        enabled_mode: auto
+    aerospike:
+        enabled:
+            traces: true
+            metrics: true
+        filters:
+            traces:
+                http.request.method:
+                    not_match: OPTIONS
+            metrics:
+                http.request.method:
+                    not_match: OPTIONS
+runtimes:
+    go:
+        enabled: true
+    nodejs:
+        enabled: true
+    java:
+        enabled: true
+        debug:
+            enabled: false
+            bytecode_instrumentation: false
+        attach_timeout: 10s
+network:
+    capture:
+        enabled: false
+        source: socket_filter
+        buffer_size: 0
+        endpoint_identity:
+            agent_ip: ""
+            agent_ip_interface: external
+            agent_ip_family: any
+        selection:
+            interfaces:
+                include: []
+                exclude:
+                    - lo
+            protocols:
+                include: []
+                exclude: []
+            direction: both
+            cidrs: []
+        filters:
+            traces: {}
+            metrics: {}
+        flow_lifecycle:
+            max_tracked_flows: 5000
+            active_timeout: 5s
+            deduplication:
+                strategy: first_come
+                first_come_ttl: 0s
+            sampling: 0
+            guess_ports: disable
+        interface_discovery:
+            mode: watch
+            poll_interval: 10s
+        enrichment:
+            geo_ip:
+                ipinfo:
+                    path: ""
+                maxmind:
+                    country_path: ""
+                    asn_path: ""
+                cache:
+                    size: 512
+                    ttl: 1h0m0s
+            reverse_dns:
+                mode: none
+                cache:
+                    size: 256
+                    ttl: 1h0m0s
+        diagnostics:
+            print_flows: false
+    stats:
+        enabled: false
+        features: []
+        endpoint_identity:
+            agent_ip: ""
+            agent_ip_interface: external
+            agent_ip_family: any
+        selection:
+            cidrs: []
+        filters:
+            traces: {}
+            metrics: {}
+        enrichment:
+            geo_ip:
+                ipinfo:
+                    path: ""
+                maxmind:
+                    country_path: ""
+                    asn_path: ""
+                cache:
+                    size: 512
+                    ttl: 1h0m0s
+            reverse_dns:
+                mode: none
+                cache:
+                    size: 256
+                    ttl: 1h0m0s
+        diagnostics:
+            print_stats: false
+limits:
+    network_packets: 5000
+    metric_span_names: 100
+engine:
+    debug:
+        bpf: false
+        protocol_print: false
+    pid_filter:
+        disabled: false
+    batching:
+        wakeup_len: 500
+        batch_length: 100
+        batch_timeout: 1s
+    propagation:
+        context_propagation: disabled
+        override_bpfloop_enabled: false
+        disable_black_box_cp: false
+    traffic:
+        control_backend: auto
+        high_request_volume: false
+        force_map_reader: auto
+    transactions:
+        max_duration: 5m0s
+    maps:
+        global_scale_factor: 0
+    bpf_filesystem:
+        path: /sys/fs/bpf/
+safety:
+    enforce_system_capabilities: false
+channels:
+    buffer_len: 50
+    send_timeout: 1m0s
+    panic_on_send_timeout: false
+telemetry:
+    traces:
+        reporters_cache_len: 256
+    metrics:
+        reporters_cache_len: 256
+        ttl: 5m0s

--- a/cmd/obi/internal/configcmd/testdata/migration-v1.yaml
+++ b/cmd/obi/internal/configcmd/testdata/migration-v1.yaml
@@ -1,0 +1,23 @@
+discovery:
+  instrument:
+    - exe_path: "${CART_ROOT:-/srv}/cart-*"
+      open_ports: "8080"
+filter:
+  application:
+    http.request.method:
+      not_match: OPTIONS
+routes:
+  unmatched: heuristic
+  patterns:
+    - "/cart/{id}"
+  ignored_patterns:
+    - "/health"
+  ignore_mode: all
+metrics:
+  features:
+    - application
+otel_traces_export:
+  endpoint: "http://${OTLP_HOST:-collector}:4317"
+otel_metrics_export:
+  endpoint: "http://${OTLP_HOST:-collector}:4317"
+log_level: DEBUG

--- a/cmd/obi/internal/configcmd/testdata/migration-v2.yaml
+++ b/cmd/obi/internal/configcmd/testdata/migration-v2.yaml
@@ -1,0 +1,468 @@
+file_format: "1.0"
+log_level: debug
+meter_provider:
+    readers:
+        - periodic:
+            exporter:
+                otlp_grpc:
+                    default_histogram_aggregation: explicit_bucket_histogram
+                    endpoint: http://collector:4317
+                    tls:
+                        insecure: true
+            interval: 60000
+        - pull:
+            exporter:
+                prometheus/development:
+                    port: 0
+propagator: {}
+resource: {}
+tracer_provider:
+    processors:
+        - batch:
+            exporter:
+                otlp_grpc:
+                    endpoint: http://collector:4317
+                    tls:
+                        insecure: true
+            max_export_batch_size: 4096
+            max_queue_size: 16384
+            schedule_delay: 15000
+extensions:
+    obi:
+        version: "2.0"
+        capture:
+            policy:
+                default_action: exclude
+                match_order: first_match_wins
+                poll_interval: 0s
+                min_process_age: 5s
+            rules:
+                - action: exclude
+                  name: exclude-obi-and-collectors
+                  description: Exclude OBI and collector binaries to avoid self-instrumentation and collector recursion.
+                  match:
+                    process:
+                        exe_path_glob:
+                            - '{*/obi,obi,*otelcol,*otelcol-contrib,*otelcol-contrib[!/]*}'
+                - action: exclude
+                  name: exclude-system-namespaces
+                  description: Exclude common platform/system Kubernetes namespaces from instrumentation by default.
+                  match:
+                    kubernetes:
+                        namespace_glob:
+                            - kube-system
+                            - kube-node-lease
+                            - local-path-storage
+                            - cert-manager
+                            - monitoring
+                            - gke-connect
+                            - gke-gmp-system
+                            - gke-managed-cim
+                            - gke-managed-filestorecsi
+                            - gke-managed-metrics-server
+                            - gke-managed-system
+                            - gke-system
+                            - gke-managed-volumepopulator
+                            - gatekeeper-system
+                - action: exclude
+                  name: exclude-otlp-exporters
+                  description: Exclude services that already export OTLP to prevent duplicate telemetry pipelines.
+                  match:
+                    process:
+                        exports_otlp:
+                            port: 4317
+                            protocol: protobuf
+                - action: include
+                  name: ""
+                  description: ""
+                  match:
+                    process:
+                        open_ports: "8080"
+                        exe_path_glob:
+                            - /srv/cart-*
+            instrumentation:
+                http:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    track_request_headers: false
+                    request_timeout: 0s
+                    go_http_client_buffer_timeout: 1s
+                    buffer_size: 0
+                    routes:
+                        incoming:
+                            unmatched: heuristic
+                            patterns:
+                                - /cart/{id}
+                            ignored_patterns:
+                                - /health
+                            ignore_mode: all
+                            wildcard_char: '*'
+                            max_path_segment_cardinality: 10
+                        outgoing:
+                            unmatched: heuristic
+                            patterns:
+                                - /cart/{id}
+                            ignored_patterns:
+                                - /health
+                            ignore_mode: all
+                            wildcard_char: '*'
+                            max_path_segment_cardinality: 10
+                        discovery:
+                            timeout: 10s
+                            disabled_languages: []
+                            java:
+                                delay: 5s
+                    payload_extraction:
+                        enabled: []
+                        sqlpp:
+                            endpoint_patterns:
+                                - /query/service
+                        enrichment:
+                            policy:
+                                default_action:
+                                    headers: exclude
+                                    body: exclude
+                                obfuscation_string: '***'
+                            rules: []
+                        openai_compatible:
+                            gateways: []
+                grpc:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                sql:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    heuristic_detect: false
+                    mysql:
+                        buffer_size: 0
+                        prepared_statements_cache_size: 1024
+                    postgres:
+                        buffer_size: 0
+                        prepared_statements_cache_size: 1024
+                    mssql:
+                        buffer_size: 0
+                        prepared_statements_cache_size: 1024
+                redis:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    db_cache:
+                        enabled: false
+                        max_size: 1000
+                kafka:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    buffer_size: 0
+                    topic_uuid_cache_size: 1024
+                mongo:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    requests_cache_size: 1024
+                couchbase:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    db_cache_size: 1024
+                dns:
+                    enabled:
+                        traces: false
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    request_timeout: 5s
+                gpu:
+                    enabled:
+                        traces: false
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+                    enabled_mode: auto
+                aerospike:
+                    enabled:
+                        traces: true
+                        metrics: true
+                    filters:
+                        traces:
+                            http.request.method:
+                                not_match: OPTIONS
+                        metrics:
+                            http.request.method:
+                                not_match: OPTIONS
+            runtimes:
+                go:
+                    enabled: true
+                nodejs:
+                    enabled: true
+                java:
+                    enabled: true
+                    debug:
+                        enabled: false
+                        bytecode_instrumentation: false
+                    attach_timeout: 10s
+            network:
+                capture:
+                    enabled: false
+                    source: socket_filter
+                    buffer_size: 0
+                    endpoint_identity:
+                        agent_ip: ""
+                        agent_ip_interface: external
+                        agent_ip_family: any
+                    selection:
+                        interfaces:
+                            include: []
+                            exclude:
+                                - lo
+                        protocols:
+                            include: []
+                            exclude: []
+                        direction: both
+                        cidrs: []
+                    filters:
+                        traces: {}
+                        metrics: {}
+                    flow_lifecycle:
+                        max_tracked_flows: 5000
+                        active_timeout: 5s
+                        deduplication:
+                            strategy: first_come
+                            first_come_ttl: 0s
+                        sampling: 0
+                        guess_ports: disable
+                    interface_discovery:
+                        mode: watch
+                        poll_interval: 10s
+                    enrichment:
+                        geo_ip:
+                            ipinfo:
+                                path: ""
+                            maxmind:
+                                country_path: ""
+                                asn_path: ""
+                            cache:
+                                size: 512
+                                ttl: 1h0m0s
+                        reverse_dns:
+                            mode: none
+                            cache:
+                                size: 256
+                                ttl: 1h0m0s
+                    diagnostics:
+                        print_flows: false
+                stats:
+                    enabled: false
+                    features: []
+                    endpoint_identity:
+                        agent_ip: ""
+                        agent_ip_interface: external
+                        agent_ip_family: any
+                    selection:
+                        cidrs: []
+                    filters:
+                        traces: {}
+                        metrics: {}
+                    enrichment:
+                        geo_ip:
+                            ipinfo:
+                                path: ""
+                            maxmind:
+                                country_path: ""
+                                asn_path: ""
+                            cache:
+                                size: 512
+                                ttl: 1h0m0s
+                        reverse_dns:
+                            mode: none
+                            cache:
+                                size: 256
+                                ttl: 1h0m0s
+                    diagnostics:
+                        print_stats: false
+            limits:
+                network_packets: 5000
+                metric_span_names: 100
+            engine:
+                debug:
+                    bpf: false
+                    protocol_print: false
+                pid_filter:
+                    disabled: false
+                batching:
+                    wakeup_len: 500
+                    batch_length: 100
+                    batch_timeout: 1s
+                propagation:
+                    context_propagation: disabled
+                    override_bpfloop_enabled: false
+                    disable_black_box_cp: false
+                traffic:
+                    control_backend: auto
+                    high_request_volume: false
+                    force_map_reader: auto
+                transactions:
+                    max_duration: 5m0s
+                maps:
+                    global_scale_factor: 0
+                bpf_filesystem:
+                    path: /sys/fs/bpf/
+            safety:
+                enforce_system_capabilities: false
+            channels:
+                buffer_len: 50
+                send_timeout: 1m0s
+                panic_on_send_timeout: false
+            telemetry:
+                traces:
+                    reporters_cache_len: 256
+                metrics:
+                    reporters_cache_len: 256
+                    ttl: 5m0s
+        enrich:
+            enrichers:
+                kubernetes:
+                    mode: autodetect
+                    cluster_name: ""
+                    service_name_template: ""
+                    auth:
+                        kubeconfig_path: ""
+                    informers:
+                        initial_sync_timeout: 30s
+                        reconnect_initial_interval: 5s
+                        resync_period: 30m0s
+                        disabled: []
+                    drop_external: false
+                    resource_labels:
+                        service.name:
+                            - app.kubernetes.io/instance
+                            - app.kubernetes.io/name
+                        service.namespace:
+                            - app.kubernetes.io/part-of
+                        service.version:
+                            - app.kubernetes.io/version
+                    metadata_cache:
+                        address: ""
+                        restrict_local_node: false
+                        source_labels:
+                            service_name: ""
+                            service_namespace: ""
+            service_name:
+                unresolved_hosts:
+                    names:
+                        default: unresolved
+                        outgoing: outgoing
+                        incoming: incoming
+                sources:
+                    - k8s
+                cache:
+                    size: 1024
+                    ttl: 5m0s
+            attributes:
+                select: {}
+                extra_group_attributes: {}
+                metadata_retry:
+                    timeout: 30s
+                    start_interval: 500ms
+                    max_interval: 5s
+        correlation:
+            log_trace_annotation:
+                enabled: false
+                field_names:
+                    trace_id: trace_id
+                    span_id: span_id
+                plain_text:
+                    enabled: true
+                    placement: suffix
+                    multiline: first_line
+                cache:
+                    size: 128
+                    ttl: 30m0s
+                async_writer:
+                    workers: 8
+                    channel_len: 500
+        daemon:
+            logging:
+                format: text
+                config_format: ""
+                debug_trace_output: disabled
+            profiling:
+                port: 0
+            shutdown:
+                timeout: 10s
+            internal_metrics:
+                exporter: disabled
+                prometheus:
+                    port: 0
+                    path: /internal/metrics
+                bpf:
+                    scrape_interval: 15s
+            telemetry:
+                metrics:
+                    prometheus:
+                        allow_service_graph_self_references: false
+                        span_metrics_service_cache_size: 10000
+                        extra_resource_attributes: []
+                        extra_span_resource_attributes: []


### PR DESCRIPTION
## Summary

- validate Config v1 migration in the selected standalone or Collector receiver deployment mode
- reject unsupported or lossy settings when Config v2 cannot preserve runtime behavior
- validate generated Config v2 documents and keep deterministic migration golden files with the command tests

## Why

`obi config migrate` should fail closed instead of emitting a document that appears valid but changes runtime behavior. This implementation was split from #2799 so the operator documentation can be reviewed independently.

## Validation

- `go test ./cmd/obi/internal/configcmd`
