### PR TITLE
Extend Config v2 parity checks

### DIFF
--- a/cmd/check-config-v2-parity/main.go
+++ b/cmd/check-config-v2-parity/main.go
@@ -531,6 +531,7 @@ func parityChecks() []parityCheck {
 		{[]string{"network", "agent_ip_iface"}, []string{"obi", "capture", "network", "capture", "endpoint_identity", "agent_ip_interface"}},
 		{[]string{"network", "agent_ip_type"}, []string{"obi", "capture", "network", "capture", "endpoint_identity", "agent_ip_family"}},
 		{[]string{"network", "cache_max_flows"}, []string{"obi", "capture", "network", "capture", "flow_lifecycle", "max_tracked_flows"}},
+		{[]string{"network", "cache_max_flows"}, []string{"obi", "capture", "limits", "network_packets"}},
 		{[]string{"network", "cache_active_timeout"}, []string{"obi", "capture", "network", "capture", "flow_lifecycle", "active_timeout"}},
 		{[]string{"network", "deduper"}, []string{"obi", "capture", "network", "capture", "flow_lifecycle", "deduplication", "strategy"}},
 		{[]string{"network", "deduper_fc_ttl"}, []string{"obi", "capture", "network", "capture", "flow_lifecycle", "deduplication", "first_come_ttl"}},

--- a/cmd/check-config-v2-parity/main_test.go
+++ b/cmd/check-config-v2-parity/main_test.go
@@ -141,6 +141,42 @@ func TestVerifyDefaultsDetectsMappedDefaultMismatch(t *testing.T) {
 	t.Fatalf("expected batch_length failure, got: %v", failures)
 }
 
+func TestVerifyDefaultsRejectsLanguageSkipAsCaptureExclusion(t *testing.T) {
+	cur, ex := loadCurrentAndExample(t)
+	rules, ok := get(ex, "obi", "capture", "rules")
+	if !ok {
+		t.Fatal("missing capture rules")
+	}
+	existing, ok := rules.([]any)
+	if !ok {
+		t.Fatal("capture rules are not a list")
+	}
+	capture, ok := get(ex, "obi", "capture")
+	if !ok {
+		t.Fatal("missing capture")
+	}
+	captureMap, ok := capture.(map[string]any)
+	if !ok {
+		t.Fatal("capture is not a map")
+	}
+	captureMap["rules"] = append(existing, map[string]any{
+		"action": "exclude",
+		"match": map[string]any{
+			"process": map[string]any{
+				"exe_path_glob": []any{"/usr/sbin/*"},
+			},
+		},
+	})
+
+	failures, _ := verifyDefaults(cur, ex)
+	for _, failure := range failures {
+		if strings.Contains(failure.Error(), "language-detection skip") {
+			return
+		}
+	}
+	t.Fatalf("expected language-detection skip failure, got: %v", failures)
+}
+
 func loadCurrentAndExample(t *testing.T) (map[string]any, map[string]any) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- map the v1 network flow cache limit to both Config v2 runtime consumers
- exercise the language-detection skip guard through the full parity verification path

## Why

The Config v2 reference should remain aligned with v1 defaults without turning internal language-detection skips into capture exclusions. This checker update was split from #2799 so it can be reviewed as an independent validation change.

## Validation

- `go test ./cmd/check-config-v2-parity`
