### PR TITLE
Make Collector capture policy explicit

### DIFF
--- a/cmd/obi/internal/configcmd/configcmd_test.go
+++ b/cmd/obi/internal/configcmd/configcmd_test.go
@@ -537,6 +537,35 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 	}
 }
 
+func TestCollectorReceiverExamples(t *testing.T) {
+	for _, path := range []string{
+		"examples/otel-collector/config.yaml",
+		"examples/otel-collector/smoke-config.yaml",
+	} {
+		t.Run(path, func(t *testing.T) {
+			data := integrationConfig(t, path)
+			var collector struct {
+				Receivers struct {
+					OBI map[string]any `yaml:"obi"`
+				} `yaml:"receivers"`
+			}
+			require.NoError(t, yaml.Unmarshal(data, &collector))
+			require.NotEmpty(t, collector.Receivers.OBI)
+
+			receiverData, err := yaml.Marshal(collector.Receivers.OBI)
+			require.NoError(t, err)
+			receiver, err := schema.ParseReceiverYAML(receiverData)
+			require.NoError(t, err)
+			require.Equal(
+				t,
+				schema.CaptureActionExclude,
+				receiver.Capture.Policy.DefaultAction,
+			)
+			require.NoError(t, validateConfig(receiverData, validationModeReceiver))
+		})
+	}
+}
+
 func integrationConfig(t *testing.T, relativePath string) []byte {
 	t.Helper()
 

--- a/examples/otel-collector/config.yaml
+++ b/examples/otel-collector/config.yaml
@@ -1,6 +1,8 @@
 receivers:
   obi:
     version: "2.0"
+    policy:
+      default_action: exclude
     rules:
       - action: include
         match:

--- a/examples/otel-collector/smoke-config.yaml
+++ b/examples/otel-collector/smoke-config.yaml
@@ -2,6 +2,7 @@ receivers:
   obi:
     version: "2.0"
     policy:
+      default_action: exclude
       poll_interval: 1s
       min_process_age: 1s
     rules:


### PR DESCRIPTION
## Summary

- set `default_action: exclude` in both Config v2 Collector receiver examples
- verify the examples parse as receiver configuration and preserve the intended capture policy

## Why

The examples use include rules to opt matching processes into capture. Making the default exclusion explicit prevents unmatched discovered processes from being captured implicitly. This cleanup was split from #2799 because it is independent of the migration guide.

## Validation

- `go test ./cmd/obi/internal/configcmd`
- parsed both modified files as YAML
