### PR TITLE
Fix DNS capture so peer endpoints get named correctly

### DIFF
--- a/bpf/generictracer/dns.h
+++ b/bpf/generictracer/dns.h
@@ -217,8 +217,12 @@ static __always_inline u8 handle_dns_buf(const unsigned char *buf,
         return 0;
     }
 
+    // buf is scratch memory from iovec_memory(), so this is a kernel read; a
+    // user read silently zeroes hdr, yielding id 0 and a bogus qr
     struct dnshdr hdr;
-    bpf_probe_read_user(&hdr, sizeof(struct dnshdr), buf);
+    if (bpf_probe_read_kernel(&hdr, sizeof(struct dnshdr), buf) != 0) {
+        return 0;
+    }
 
     const u16 flags = bpf_ntohs(hdr.flags);
     const u8 qr = dns_qr(flags);
@@ -236,7 +240,7 @@ static __always_inline u8 handle_dns_buf(const unsigned char *buf,
         if (req) {
             populate_dns_record(req, p_conn, orig_dport, size, qr, hdr.id, conn_pid);
 
-            bpf_probe_read(req->buf, sizeof(req->buf), buf);
+            bpf_probe_read_kernel(req->buf, sizeof(req->buf), buf);
             bpf_d_printk("sending dns trace [%s]", __FUNCTION__);
             bpf_ringbuf_submit(req, get_flags());
         }

--- a/bpf/generictracer/dns.h
+++ b/bpf/generictracer/dns.h
@@ -84,8 +84,19 @@ static __always_inline u8 dns_ra(u16 f) {
     return (f >> 7) & 0x1;
 }
 
+// RFC 1035 reserved three bits here, but RFC 2535 reassigned the lower two to
+// AD and CD, which DNSSEC-aware resolvers set on ordinary traffic. Only bit 6
+// is still required to be zero, so only bit 6 may be used to reject a message.
 static __always_inline u8 dns_z(u16 f) {
-    return (f >> 4) & 0x7;
+    return (f >> 6) & 0x1;
+}
+
+static __always_inline u8 dns_ad(u16 f) {
+    return (f >> 5) & 0x1;
+}
+
+static __always_inline u8 dns_cd(u16 f) {
+    return (f >> 4) & 0x1;
 }
 
 static __always_inline u8 dns_rcode(u16 f) {
@@ -122,6 +133,62 @@ static __always_inline u16 obi_msg_name_port(struct msghdr *msg) {
         return 0; // IPv6 DNS transport not handled by this fallback
     }
     return bpf_ntohs(sa.sin_port);
+}
+
+// Smallest encodings of a question and of a resource record: the root name
+// (a single zero length octet), then the fixed fields of each.
+enum : u32 {
+    k_dns_min_question_bytes = 1 + 2 + 2,   // name, qtype, qclass
+    k_dns_min_rr_bytes = 1 + 2 + 2 + 4 + 2, // name, type, class, ttl, rdlength
+};
+
+// Whether a datagram is structurally a DNS message. qr alone is one bit, so it
+// says nothing: every payload of at least sizeof(struct dnshdr) has a valid qr,
+// and the socket-identity tier hands this function payloads whose only other
+// evidence is the socket they arrived on. These checks are what separates a DNS
+// message from arbitrary bytes.
+//
+// Deliberately not checked: rcode, because NXDOMAIN and SERVFAIL are lookups
+// worth reporting, and the AD and CD bits, which ordinary DNSSEC-aware
+// resolvers set.
+static __always_inline u8 dns_header_is_plausible(const struct dnshdr *hdr,
+                                                  const u16 flags,
+                                                  const u32 size) {
+    if (dns_opcode(flags) != 0) {
+        return 0; // a lookup is a standard query; IQUERY, STATUS, NOTIFY and UPDATE are not
+    }
+
+    if (dns_z(flags) != 0) {
+        return 0; // still reserved, so a set bit means this is not a DNS header
+    }
+
+    const u16 qdcount = bpf_ntohs(hdr->qdcount);
+    const u16 ancount = bpf_ntohs(hdr->ancount);
+    const u16 nscount = bpf_ntohs(hdr->nscount);
+    const u16 arcount = bpf_ntohs(hdr->arcount);
+
+    if (dns_qr(flags) == k_dns_qr_query) {
+        // a query asks at least one question and answers none of them
+        if (qdcount == 0 || ancount != 0) {
+            return 0;
+        }
+    } else if (qdcount + ancount + nscount + arcount == 0) {
+        // an empty response carries no lookup; an mDNS response may omit the
+        // question, so the sections are counted together rather than separately
+        return 0;
+    }
+
+    // A truncated message describes records that were never sent, so its counts
+    // cannot be held against the bytes on hand.
+    if (dns_tc(flags)) {
+        return 1;
+    }
+
+    const u32 payload = size - sizeof(struct dnshdr);
+    const u32 needed = ((u32)qdcount * k_dns_min_question_bytes) +
+                       (((u32)ancount + nscount + arcount) * k_dns_min_rr_bytes);
+
+    return needed <= payload;
 }
 
 // k_dns_msg_no is a positive answer, not an absence of evidence: the peer is
@@ -362,7 +429,7 @@ static __always_inline u8 handle_dns_buf(const unsigned char *buf,
 
     bpf_d_printk("QR type: %d [%s]", qr, __FUNCTION__);
 
-    if (qr == k_dns_qr_query || qr == k_dns_qr_resp) {
+    if (dns_header_is_plausible(&hdr, flags, size)) {
         conn_pid_t *conn_pid = bpf_map_lookup_elem(&sock_pids, &p_conn->conn);
         if (!conn_pid) {
             bpf_d_printk("can't find connection info for dns call [%s]", __FUNCTION__);

--- a/bpf/generictracer/dns.h
+++ b/bpf/generictracer/dns.h
@@ -20,6 +20,7 @@
 #include <generictracer/k_tracer_defs.h>
 
 #include <maps/sock_pids.h>
+#include <maps/unconn_dns_socks.h>
 
 #include <pid/types/pid_info.h>
 
@@ -136,13 +137,6 @@ static __always_inline u8 is_dns_msg(connection_info_t *conn, struct msghdr *msg
     }
     return 0;
 }
-
-struct {
-    __uint(type, BPF_MAP_TYPE_LRU_HASH);
-    __type(key, u64); // (u64)struct sock *
-    __type(value, u8);
-    __uint(max_entries, 1024);
-} unconn_dns_socks SEC(".maps");
 
 static __always_inline void obi_note_unconn_dns_sock(void *sk) {
     u64 k = (u64)sk;

--- a/bpf/generictracer/dns.h
+++ b/bpf/generictracer/dns.h
@@ -247,10 +247,7 @@ static __always_inline void obi_forget_unconn_dns_sock(void *sk) {
     bpf_map_delete_elem(&unconn_dns_socks, &k);
 }
 
-// Records that sk just sent a DNS query, opening the window in which a nameless
-// answer on this socket may be classified as DNS. Call this only once the sent
-// payload has been parsed as a DNS message, so that a send which never carried
-// DNS — or never left the host — does not open the window.
+// Opens the window in which a nameless answer on sk may be classified as DNS.
 //
 // conn must be the unsorted tuple, so that s_addr/s_port name the local endpoint.
 // The whole record is rewritten unconditionally: one map store, no
@@ -265,6 +262,43 @@ static __always_inline void obi_note_unconn_dns_query(void *sk, const connection
     __builtin_memcpy(fresh.s_addr, conn->s_addr, sizeof(fresh.s_addr));
 
     bpf_map_update_elem(&unconn_dns_socks, &k, &fresh, BPF_ANY);
+}
+
+// Holds a parsed DNS query until udp_sendmsg returns. The payload has been
+// recognised as DNS by this point, but the send may still fail, and a query
+// that never left the host is owed no answer.
+//
+// conn must be the unsorted tuple.
+static __always_inline void
+obi_stage_unconn_dns_query(u64 pid_tid, void *sk, const connection_info_t *conn) {
+    unconn_dns_pending_t pending = {
+        .sk = (u64)sk,
+        .s_port = conn->s_port,
+    };
+    __builtin_memcpy(pending.s_addr, conn->s_addr, sizeof(pending.s_addr));
+
+    bpf_map_update_elem(&unconn_dns_pending, &pid_tid, &pending, BPF_ANY);
+}
+
+static __always_inline void obi_discard_unconn_dns_query(u64 pid_tid) {
+    bpf_map_delete_elem(&unconn_dns_pending, &pid_tid);
+}
+
+// Opens the answer window for a query that was staged and has now been sent.
+// The window is timed from here rather than from the entry probe, so it starts
+// when the datagram actually went out.
+static __always_inline void obi_commit_unconn_dns_query(u64 pid_tid) {
+    const unconn_dns_pending_t *pending = bpf_map_lookup_elem(&unconn_dns_pending, &pid_tid);
+
+    if (!pending) {
+        return;
+    }
+
+    connection_info_t local_conn = {.s_port = pending->s_port};
+    __builtin_memcpy(local_conn.s_addr, pending->s_addr, sizeof(local_conn.s_addr));
+
+    obi_note_unconn_dns_query((void *)pending->sk, &local_conn);
+    obi_discard_unconn_dns_query(pid_tid);
 }
 
 // Reports whether a nameless answer on sk may be attributed to DNS: the socket

--- a/bpf/generictracer/dns.h
+++ b/bpf/generictracer/dns.h
@@ -162,12 +162,11 @@ static __always_inline u8 is_dns_msg(const connection_info_t *conn, struct msghd
     return classify_dns_msg(conn, msg) == k_dns_msg_yes;
 }
 
-// An answer is only expected for as long as a query is outstanding; a resolver
-// that never sees its answer must not leave the socket classified forever.
-enum : u64 { k_unconn_dns_answer_timeout_ns = 10ULL * 1000000000ULL };
-
-// Bounds the state a single socket can accumulate when answers never arrive
-enum : u16 { k_unconn_dns_max_pending = 8 };
+// An answer is only expected for a short while after a query; a resolver that
+// never sees its answer must not leave the socket classified forever. Answers
+// arrive in milliseconds, so this is far longer than needed and still well
+// inside the usual 5s resolver timeout.
+enum : u64 { k_unconn_dns_answer_timeout_ns = 2ULL * 1000000000ULL };
 
 static __always_inline u8 obi_same_local_addr(const unconn_dns_sock_t *state,
                                               const connection_info_t *conn) {
@@ -181,23 +180,19 @@ static __always_inline void obi_forget_unconn_dns_sock(void *sk) {
     bpf_map_delete_elem(&unconn_dns_socks, &k);
 }
 
-// conn must be the unsorted tuple, so that s_addr/s_port name the local endpoint
+// Records that sk just sent a DNS query, opening the window in which a nameless
+// answer on this socket may be classified as DNS. Call this only once the sent
+// payload has been parsed as a DNS message, so that a send which never carried
+// DNS — or never left the host — does not open the window.
+//
+// conn must be the unsorted tuple, so that s_addr/s_port name the local endpoint.
+// The whole record is rewritten unconditionally: one map store, no
+// read-modify-write, so concurrent sends on the same socket cannot lose state.
 static __always_inline void obi_note_unconn_dns_query(void *sk, const connection_info_t *conn) {
     const u64 k = (u64)sk;
 
-    unconn_dns_sock_t *state = bpf_map_lookup_elem(&unconn_dns_socks, &k);
-
-    if (state && obi_same_local_addr(state, conn)) {
-        if (state->pending < k_unconn_dns_max_pending) {
-            state->pending++;
-        }
-        state->last_query_ns = bpf_ktime_get_ns();
-        return;
-    }
-
     unconn_dns_sock_t fresh = {
         .s_port = conn->s_port,
-        .pending = 1,
         .last_query_ns = bpf_ktime_get_ns(),
     };
     __builtin_memcpy(fresh.s_addr, conn->s_addr, sizeof(fresh.s_addr));
@@ -205,12 +200,17 @@ static __always_inline void obi_note_unconn_dns_query(void *sk, const connection
     bpf_map_update_elem(&unconn_dns_socks, &k, &fresh, BPF_ANY);
 }
 
-// Consumes one outstanding query on sk, if this socket is still the one that
-// sent it and the answer is not stale. conn must be the unsorted tuple.
-static __always_inline u8 obi_claim_unconn_dns_answer(void *sk, const connection_info_t *conn) {
+// Reports whether a nameless answer on sk may be attributed to DNS: the socket
+// must still be the one that sent the query, and the query must be recent. This
+// only decides eligibility; nothing is consumed, so several answers to queries
+// issued in parallel are all classified. A stale or mismatched record is
+// retired here so it cannot accumulate.
+//
+// conn must be the unsorted tuple.
+static __always_inline u8 obi_unconn_dns_answer_expected(void *sk, const connection_info_t *conn) {
     const u64 k = (u64)sk;
 
-    unconn_dns_sock_t *state = bpf_map_lookup_elem(&unconn_dns_socks, &k);
+    const unconn_dns_sock_t *state = bpf_map_lookup_elem(&unconn_dns_socks, &k);
 
     if (!state) {
         return 0;
@@ -222,16 +222,9 @@ static __always_inline u8 obi_claim_unconn_dns_answer(void *sk, const connection
         return 0;
     }
 
-    if (state->pending == 0 ||
-        bpf_ktime_get_ns() - state->last_query_ns > k_unconn_dns_answer_timeout_ns) {
+    if (bpf_ktime_get_ns() - state->last_query_ns > k_unconn_dns_answer_timeout_ns) {
         obi_forget_unconn_dns_sock(sk);
         return 0;
-    }
-
-    state->pending--;
-
-    if (state->pending == 0) {
-        obi_forget_unconn_dns_sock(sk);
     }
 
     return 1;

--- a/bpf/generictracer/dns.h
+++ b/bpf/generictracer/dns.h
@@ -117,15 +117,6 @@ static __always_inline u8 is_dns(const connection_info_t *conn) {
     return is_dns_port(conn->s_port) || is_dns_port(conn->d_port);
 }
 
-// A compliant multicast DNS querier sends from source port 5353 (RFC 6762
-// §5.2), and a responder is bound to it, so either endpoint naming that port
-// identifies the message as multicast DNS. A one-shot querier uses an ephemeral
-// source port and is explicitly not a compliant querier (§5.1), so it does not
-// emit the forms this distinction exists to admit.
-static __always_inline u8 is_mdns(const connection_info_t *conn) {
-    return is_mdns_port(conn->s_port) || is_mdns_port(conn->d_port);
-}
-
 // Recovers the peer port from a kernel-resident msghdr->msg_name. An unconnected
 // UDP socket has no peer in its 4-tuple (skc_dport==0), so the destination
 // (sendmsg) or source (recvmsg) port lives only in msg_name.
@@ -148,6 +139,33 @@ static __always_inline u16 obi_msg_name_port(struct msghdr *msg) {
         return 0; // IPv6 DNS transport not handled by this fallback
     }
     return bpf_ntohs(sa.sin_port);
+}
+
+// Whether the exchange is multicast DNS, which runs 5353 to 5353: a compliant
+// querier sends from source port 5353 (RFC 6762 §5.2) to 224.0.0.251:5353, and
+// a responder is bound to the same port. A one-shot querier uses an ephemeral
+// source port and is explicitly not a compliant querier (§5.1), so it does not
+// emit the forms this distinction exists to admit.
+//
+// Both ends are required because holding 5353 locally proves nothing: the port
+// is unprivileged, so any process may bind it, and a site that widens
+// ip_local_port_range down to 1024 lets the kernel hand it to an arbitrary
+// client as an ephemeral source port.
+static __always_inline u8 is_mdns_exchange(const connection_info_t *conn, struct msghdr *msg) {
+    if (is_mdns_port(conn->s_port) && is_mdns_port(conn->d_port)) {
+        return 1;
+    }
+
+    if (!is_mdns_port(conn->s_port) && !is_mdns_port(conn->d_port)) {
+        return 0;
+    }
+
+    if (conn->d_port != 0) {
+        return 0; // the tuple names the peer, and it is not the mDNS port
+    }
+
+    // an unconnected socket, so the peer lives only in msg_name
+    return is_mdns_port(obi_msg_name_port(msg));
 }
 
 // Smallest encodings of a question and of a resource record: the root name
@@ -468,7 +486,8 @@ static __always_inline u8 handle_dns(struct __sk_buff *skb,
 static __always_inline u8 handle_dns_buf(const unsigned char *buf,
                                          const int size,
                                          pid_connection_info_t *p_conn,
-                                         u16 orig_dport) {
+                                         u16 orig_dport,
+                                         struct msghdr *msg) {
 
     if (size < sizeof(struct dnshdr)) {
         bpf_d_printk("dns packet too small [%s]", __FUNCTION__);
@@ -487,7 +506,7 @@ static __always_inline u8 handle_dns_buf(const unsigned char *buf,
 
     bpf_d_printk("QR type: %d [%s]", qr, __FUNCTION__);
 
-    if (dns_header_is_plausible(&hdr, flags, size, is_mdns(&p_conn->conn))) {
+    if (dns_header_is_plausible(&hdr, flags, size, is_mdns_exchange(&p_conn->conn, msg))) {
         conn_pid_t *conn_pid = bpf_map_lookup_elem(&sock_pids, &p_conn->conn);
         if (!conn_pid) {
             bpf_d_printk("can't find connection info for dns call [%s]", __FUNCTION__);

--- a/bpf/generictracer/dns.h
+++ b/bpf/generictracer/dns.h
@@ -13,6 +13,7 @@
 #include <common/lw_thread.h>
 #include <common/protocol_defs.h>
 #include <common/ringbuf.h>
+#include <common/strings.h>
 #include <common/trace_helpers.h>
 #include <common/trace_parent.h>
 #include <common/trace_util.h>
@@ -95,7 +96,7 @@ static __always_inline u8 is_dns_port(u16 port) {
     return port == 53 || port == 5353;
 }
 
-static __always_inline u8 is_dns(connection_info_t *conn) {
+static __always_inline u8 is_dns(const connection_info_t *conn) {
     return is_dns_port(conn->s_port) || is_dns_port(conn->d_port);
 }
 
@@ -123,30 +124,117 @@ static __always_inline u16 obi_msg_name_port(struct msghdr *msg) {
     return bpf_ntohs(sa.sin_port);
 }
 
-static __always_inline u8 is_dns_msg(connection_info_t *conn, struct msghdr *msg) {
+// k_dns_msg_no is a positive answer, not an absence of evidence: the peer is
+// known and it is not a DNS endpoint. Only k_dns_msg_unknown may fall through
+// to the socket-identity tier.
+enum dns_msg_class : u8 {
+    k_dns_msg_unknown = 0,
+    k_dns_msg_yes = 1,
+    k_dns_msg_no = 2,
+};
+
+static __always_inline enum dns_msg_class classify_dns_msg(const connection_info_t *conn,
+                                                           struct msghdr *msg) {
     if (is_dns(conn)) {
-        return 1;
+        return k_dns_msg_yes;
     }
-    if (conn->d_port == 0) {
-        u16 p = obi_msg_name_port(msg);
-        if (is_dns_port(p)) {
-            bpf_dbg_printk(
-                "UNCONN_DNS_MSGNAME: classified unconnected UDP DNS via msg_name port=%d", p);
-            return 1;
+
+    if (conn->d_port != 0) {
+        return k_dns_msg_no; // the tuple names a non-DNS peer
+    }
+
+    const u16 peer_port = obi_msg_name_port(msg);
+
+    if (peer_port == 0) {
+        return k_dns_msg_unknown;
+    }
+
+    if (is_dns_port(peer_port)) {
+        bpf_dbg_printk("UNCONN_DNS_MSGNAME: classified unconnected UDP DNS via msg_name port=%d",
+                       peer_port);
+        return k_dns_msg_yes;
+    }
+
+    return k_dns_msg_no;
+}
+
+static __always_inline u8 is_dns_msg(const connection_info_t *conn, struct msghdr *msg) {
+    return classify_dns_msg(conn, msg) == k_dns_msg_yes;
+}
+
+// An answer is only expected for as long as a query is outstanding; a resolver
+// that never sees its answer must not leave the socket classified forever.
+enum : u64 { k_unconn_dns_answer_timeout_ns = 10ULL * 1000000000ULL };
+
+// Bounds the state a single socket can accumulate when answers never arrive
+enum : u16 { k_unconn_dns_max_pending = 8 };
+
+static __always_inline u8 obi_same_local_addr(const unconn_dns_sock_t *state,
+                                              const connection_info_t *conn) {
+    return state->s_port == conn->s_port && obi_bpf_memcmp((const char *)state->s_addr,
+                                                           (const char *)conn->s_addr,
+                                                           sizeof(state->s_addr)) == 0;
+}
+
+static __always_inline void obi_forget_unconn_dns_sock(void *sk) {
+    const u64 k = (u64)sk;
+    bpf_map_delete_elem(&unconn_dns_socks, &k);
+}
+
+// conn must be the unsorted tuple, so that s_addr/s_port name the local endpoint
+static __always_inline void obi_note_unconn_dns_query(void *sk, const connection_info_t *conn) {
+    const u64 k = (u64)sk;
+
+    unconn_dns_sock_t *state = bpf_map_lookup_elem(&unconn_dns_socks, &k);
+
+    if (state && obi_same_local_addr(state, conn)) {
+        if (state->pending < k_unconn_dns_max_pending) {
+            state->pending++;
         }
+        state->last_query_ns = bpf_ktime_get_ns();
+        return;
     }
-    return 0;
+
+    unconn_dns_sock_t fresh = {
+        .s_port = conn->s_port,
+        .pending = 1,
+        .last_query_ns = bpf_ktime_get_ns(),
+    };
+    __builtin_memcpy(fresh.s_addr, conn->s_addr, sizeof(fresh.s_addr));
+
+    bpf_map_update_elem(&unconn_dns_socks, &k, &fresh, BPF_ANY);
 }
 
-static __always_inline void obi_note_unconn_dns_sock(void *sk) {
-    u64 k = (u64)sk;
-    u8 one = 1;
-    bpf_map_update_elem(&unconn_dns_socks, &k, &one, BPF_ANY);
-}
+// Consumes one outstanding query on sk, if this socket is still the one that
+// sent it and the answer is not stale. conn must be the unsorted tuple.
+static __always_inline u8 obi_claim_unconn_dns_answer(void *sk, const connection_info_t *conn) {
+    const u64 k = (u64)sk;
 
-static __always_inline u8 obi_is_unconn_dns_sock(void *sk) {
-    u64 k = (u64)sk;
-    return bpf_map_lookup_elem(&unconn_dns_socks, &k) != NULL;
+    unconn_dns_sock_t *state = bpf_map_lookup_elem(&unconn_dns_socks, &k);
+
+    if (!state) {
+        return 0;
+    }
+
+    // the struct sock * address has been recycled by an unrelated socket
+    if (!obi_same_local_addr(state, conn)) {
+        obi_forget_unconn_dns_sock(sk);
+        return 0;
+    }
+
+    if (state->pending == 0 ||
+        bpf_ktime_get_ns() - state->last_query_ns > k_unconn_dns_answer_timeout_ns) {
+        obi_forget_unconn_dns_sock(sk);
+        return 0;
+    }
+
+    state->pending--;
+
+    if (state->pending == 0) {
+        obi_forget_unconn_dns_sock(sk);
+    }
+
+    return 1;
 }
 
 static __always_inline void populate_dns_record(dns_req_t *req,

--- a/bpf/generictracer/dns.h
+++ b/bpf/generictracer/dns.h
@@ -11,6 +11,7 @@
 #include <common/connection_info.h>
 #include <common/http_types.h>
 #include <common/lw_thread.h>
+#include <common/protocol_defs.h>
 #include <common/ringbuf.h>
 #include <common/trace_helpers.h>
 #include <common/trace_parent.h>
@@ -95,6 +96,63 @@ static __always_inline u8 is_dns_port(u16 port) {
 
 static __always_inline u8 is_dns(connection_info_t *conn) {
     return is_dns_port(conn->s_port) || is_dns_port(conn->d_port);
+}
+
+// Recovers the peer port from a kernel-resident msghdr->msg_name. An unconnected
+// UDP socket has no peer in its 4-tuple (skc_dport==0), so the destination
+// (sendmsg) or source (recvmsg) port lives only in msg_name.
+static __always_inline u16 obi_msg_name_port(struct msghdr *msg) {
+    if (!msg) {
+        return 0;
+    }
+    void *name = NULL;
+    int namelen = 0;
+    BPF_CORE_READ_INTO(&name, msg, msg_name);
+    BPF_CORE_READ_INTO(&namelen, msg, msg_namelen);
+    if (!name || namelen < (int)sizeof(struct sockaddr_in)) {
+        return 0;
+    }
+    struct sockaddr_in sa = {0};
+    if (bpf_probe_read_kernel(&sa, sizeof(sa), name) != 0) {
+        return 0;
+    }
+    if (sa.sin_family != AF_INET) {
+        return 0; // IPv6 DNS transport not handled by this fallback
+    }
+    return bpf_ntohs(sa.sin_port);
+}
+
+static __always_inline u8 is_dns_msg(connection_info_t *conn, struct msghdr *msg) {
+    if (is_dns(conn)) {
+        return 1;
+    }
+    if (conn->d_port == 0) {
+        u16 p = obi_msg_name_port(msg);
+        if (is_dns_port(p)) {
+            bpf_dbg_printk(
+                "UNCONN_DNS_MSGNAME: classified unconnected UDP DNS via msg_name port=%d", p);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u64); // (u64)struct sock *
+    __type(value, u8);
+    __uint(max_entries, 1024);
+} unconn_dns_socks SEC(".maps");
+
+static __always_inline void obi_note_unconn_dns_sock(void *sk) {
+    u64 k = (u64)sk;
+    u8 one = 1;
+    bpf_map_update_elem(&unconn_dns_socks, &k, &one, BPF_ANY);
+}
+
+static __always_inline u8 obi_is_unconn_dns_sock(void *sk) {
+    u64 k = (u64)sk;
+    return bpf_map_lookup_elem(&unconn_dns_socks, &k) != NULL;
 }
 
 static __always_inline void populate_dns_record(dns_req_t *req,

--- a/bpf/generictracer/dns.h
+++ b/bpf/generictracer/dns.h
@@ -103,12 +103,27 @@ static __always_inline u8 dns_rcode(u16 f) {
     return f & 0xF;
 }
 
+enum : u16 { k_dns_port = 53, k_mdns_port = 5353 };
+
+static __always_inline u8 is_mdns_port(u16 port) {
+    return port == k_mdns_port;
+}
+
 static __always_inline u8 is_dns_port(u16 port) {
-    return port == 53 || port == 5353;
+    return port == k_dns_port || is_mdns_port(port);
 }
 
 static __always_inline u8 is_dns(const connection_info_t *conn) {
     return is_dns_port(conn->s_port) || is_dns_port(conn->d_port);
+}
+
+// A compliant multicast DNS querier sends from source port 5353 (RFC 6762
+// §5.2), and a responder is bound to it, so either endpoint naming that port
+// identifies the message as multicast DNS. A one-shot querier uses an ephemeral
+// source port and is explicitly not a compliant querier (§5.1), so it does not
+// emit the forms this distinction exists to admit.
+static __always_inline u8 is_mdns(const connection_info_t *conn) {
+    return is_mdns_port(conn->s_port) || is_mdns_port(conn->d_port);
 }
 
 // Recovers the peer port from a kernel-resident msghdr->msg_name. An unconnected
@@ -151,9 +166,13 @@ enum : u32 {
 // Deliberately not checked: rcode, because NXDOMAIN and SERVFAIL are lookups
 // worth reporting, and the AD and CD bits, which ordinary DNSSEC-aware
 // resolvers set.
+//
+// mdns relaxes the counts a query may carry, because multicast DNS puts records
+// in sections a unicast query leaves empty.
 static __always_inline u8 dns_header_is_plausible(const struct dnshdr *hdr,
                                                   const u16 flags,
-                                                  const u32 size) {
+                                                  const u32 size,
+                                                  const u8 mdns) {
     if (dns_opcode(flags) != 0) {
         return 0; // a lookup is a standard query; IQUERY, STATUS, NOTIFY and UPDATE are not
     }
@@ -167,14 +186,19 @@ static __always_inline u8 dns_header_is_plausible(const struct dnshdr *hdr,
     const u16 nscount = bpf_ntohs(hdr->nscount);
     const u16 arcount = bpf_ntohs(hdr->arcount);
 
-    if (dns_qr(flags) == k_dns_qr_query) {
-        // a query asks at least one question and answers none of them
-        if (qdcount == 0 || ancount != 0) {
-            return 0;
-        }
-    } else if (qdcount + ancount + nscount + arcount == 0) {
-        // an empty response carries no lookup; an mDNS response may omit the
-        // question, so the sections are counted together rather than separately
+    // A message describing no records at all carries no lookup, whichever
+    // direction it travels in. An mDNS response may omit the question, so the
+    // sections are counted together rather than separately.
+    if (qdcount + ancount + nscount + arcount == 0) {
+        return 0;
+    }
+
+    // A unicast query asks at least one question and answers none of them.
+    // Multicast DNS is exempt on both halves: a query carries the answers it
+    // already knows so that responders suppress them (RFC 6762 §7.1), and the
+    // continuation packets holding the rest of that list have no question at
+    // all (§7.2).
+    if (dns_qr(flags) == k_dns_qr_query && !mdns && (qdcount == 0 || ancount != 0)) {
         return 0;
     }
 
@@ -463,7 +487,7 @@ static __always_inline u8 handle_dns_buf(const unsigned char *buf,
 
     bpf_d_printk("QR type: %d [%s]", qr, __FUNCTION__);
 
-    if (dns_header_is_plausible(&hdr, flags, size)) {
+    if (dns_header_is_plausible(&hdr, flags, size, is_mdns(&p_conn->conn))) {
         conn_pid_t *conn_pid = bpf_map_lookup_elem(&sock_pids, &p_conn->conn);
         if (!conn_pid) {
             bpf_d_printk("can't find connection info for dns call [%s]", __FUNCTION__);

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -257,15 +257,10 @@ int BPF_KPROBE_GUARDED(obi_kprobe_udp_sendmsg, struct sock *sk, struct msghdr *m
     if (parse_sock_info(sk, &s_args.p_conn.conn)) {
         const u16 orig_dport = s_args.p_conn.conn.d_port;
         dbg_print_http_connection_info(&s_args.p_conn.conn);
-        const enum dns_msg_class dns = classify_dns_msg(&s_args.p_conn.conn, msg);
-
-        // this socket is being used for something else, so it must not stay
-        // classified by an earlier DNS query
-        if (dns == k_dns_msg_no) {
-            obi_forget_unconn_dns_sock(sk);
-        }
-
-        if (dns == k_dns_msg_yes) {
+        // an unrelated send does not retire the window: a query already sent on
+        // this socket is still owed an answer, and the window is bounded by
+        // k_unconn_dns_answer_timeout_ns and the socket's lifetime
+        if (is_dns_msg(&s_args.p_conn.conn, msg)) {
             const connection_info_t local_conn = s_args.p_conn.conn;
 
             sort_connection_info(&s_args.p_conn.conn);
@@ -990,11 +985,9 @@ int BPF_KRETPROBE_GUARDED(obi_kretprobe_sock_recvmsg, int copied_len) {
             const enum dns_msg_class dns_class =
                 classify_dns_msg(&info.conn, (struct msghdr *)args->msg_ptr);
 
-            // an explicit non-DNS peer retires the socket's classification
-            if (dns_class == k_dns_msg_no) {
-                obi_forget_unconn_dns_sock(sock_ptr);
-            }
-
+            // an explicit non-DNS peer is not reported, and it does not retire
+            // the window either: a query already sent on this socket is still
+            // owed its own nameless answer
             u8 dns = dns_class == k_dns_msg_yes;
 
             // msg_name did not classify it, but the answer arrived on a socket

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -252,6 +252,10 @@ int BPF_KPROBE_GUARDED(obi_kprobe_udp_sendmsg, struct sock *sk, struct msghdr *m
 
     store_sock_pid(sk);
 
+    // any query staged by an earlier send on this thread has lost its return
+    // probe, so it must not be committed by this send's return
+    obi_discard_unconn_dns_query(id);
+
     send_args_t s_args = {.size = len};
 
     if (parse_sock_info(sk, &s_args.p_conn.conn)) {
@@ -273,11 +277,36 @@ int BPF_KPROBE_GUARDED(obi_kprobe_udp_sendmsg, struct sock *sk, struct msghdr *m
                 if (len && handle_dns_buf(buf, len, &s_args.p_conn, orig_dport) &&
                     orig_dport == 0) {
                     // the answer to this query will carry no peer, so the only
-                    // thing left to recognise it by is the socket it arrives on
-                    obi_note_unconn_dns_query(sk, &local_conn);
+                    // thing left to recognise it by is the socket it arrives on.
+                    // Held until the return probe confirms the send.
+                    obi_stage_unconn_dns_query(id, sk, &local_conn);
                 }
             }
         }
+    }
+
+    return 0;
+}
+
+// Opens the answer window only for a query that actually left the host. A
+// resolver whose send fails asked nothing, so a later nameless datagram on that
+// socket must not be reported as its answer.
+SEC("kretprobe/udp_sendmsg")
+int BPF_KRETPROBE_GUARDED(obi_kretprobe_udp_sendmsg, int ret) {
+    (void)ctx;
+
+    const u64 id = bpf_get_current_pid_tgid();
+
+    if (!valid_pid(id)) {
+        return 0;
+    }
+
+    // a partial send still carries the query; only an error means it never went
+    if (ret > 0) {
+        obi_commit_unconn_dns_query(id);
+    } else {
+        bpf_dbg_printk("=== kretprobe/udp_sendmsg id=%llx failed ret=%d ===", id, ret);
+        obi_discard_unconn_dns_query(id);
     }
 
     return 0;

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -274,7 +274,7 @@ int BPF_KPROBE_GUARDED(obi_kprobe_udp_sendmsg, struct sock *sk, struct msghdr *m
             unsigned char *buf = iovec_memory();
             if (buf) {
                 len = read_msghdr_buf(msg, buf, len);
-                if (len && handle_dns_buf(buf, len, &s_args.p_conn, orig_dport) &&
+                if (len && handle_dns_buf(buf, len, &s_args.p_conn, orig_dport, msg) &&
                     orig_dport == 0) {
                     // the answer to this query will carry no peer, so the only
                     // thing left to recognise it by is the socket it arrives on.
@@ -1048,7 +1048,8 @@ int BPF_KRETPROBE_GUARDED(obi_kretprobe_sock_recvmsg, int copied_len) {
                     } else {
                         bpf_d_printk(
                             "Got potential dns buffer with len: %d [%s]", copied_len, __FUNCTION__);
-                        handle_dns_buf(buf, copied_len, &info, orig_dport);
+                        handle_dns_buf(
+                            buf, copied_len, &info, orig_dport, (struct msghdr *)args->msg_ptr);
                     }
                 }
             }

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -257,7 +257,11 @@ int BPF_KPROBE_GUARDED(obi_kprobe_udp_sendmsg, struct sock *sk, struct msghdr *m
     if (parse_sock_info(sk, &s_args.p_conn.conn)) {
         const u16 orig_dport = s_args.p_conn.conn.d_port;
         dbg_print_http_connection_info(&s_args.p_conn.conn);
-        if (is_dns(&s_args.p_conn.conn)) {
+        if (is_dns_msg(&s_args.p_conn.conn, msg)) {
+            // the answer is not classifiable from msg_name, so key on the socket
+            if (orig_dport == 0) {
+                obi_note_unconn_dns_sock(sk);
+            }
             sort_connection_info(&s_args.p_conn.conn);
             s_args.p_conn.pid = pid_from_pid_tgid(id);
             s_args.orig_dport = orig_dport;
@@ -856,6 +860,7 @@ static __always_inline void setup_recvmsg(u64 id, struct sock *sk, struct msghdr
 
     recv_args_t args = {
         .sock_ptr = (u64)sk,
+        .msg_ptr = (u64)msg,
     };
 
     struct iov_iter___dummy *iov_iter = (struct iov_iter___dummy *)&msg->msg_iter;
@@ -956,7 +961,16 @@ int BPF_KRETPROBE_GUARDED(obi_kretprobe_sock_recvmsg, int copied_len) {
             setup_cp_support_conn_info(&info, false);
             setup_connection_to_pid_mapping(id, &info, orig_dport);
 
-            if (is_dns(&info.conn)) {
+            u8 dns = is_dns_msg(&info.conn, (struct msghdr *)args->msg_ptr);
+            // msg_name did not classify it, but the answer arrived on a socket
+            // seen sending an unconnected UDP DNS query
+            if (!dns && orig_dport == 0 && obi_is_unconn_dns_sock(sock_ptr)) {
+                bpf_dbg_printk("UNCONN_DNS_RECVFROM: classified unconnected UDP DNS answer on "
+                               "known DNS sock=%llx",
+                               (u64)sock_ptr);
+                dns = 1;
+            }
+            if (dns) {
                 sort_connection_info(&info.conn);
 
                 iovec_iter_ctx *iov_ctx = (iovec_iter_ctx *)&args->iovec_ctx;

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -257,10 +257,18 @@ int BPF_KPROBE_GUARDED(obi_kprobe_udp_sendmsg, struct sock *sk, struct msghdr *m
     if (parse_sock_info(sk, &s_args.p_conn.conn)) {
         const u16 orig_dport = s_args.p_conn.conn.d_port;
         dbg_print_http_connection_info(&s_args.p_conn.conn);
-        if (is_dns_msg(&s_args.p_conn.conn, msg)) {
+        const enum dns_msg_class dns = classify_dns_msg(&s_args.p_conn.conn, msg);
+
+        // this socket is being used for something else, so it must not stay
+        // classified by an earlier DNS query
+        if (dns == k_dns_msg_no) {
+            obi_forget_unconn_dns_sock(sk);
+        }
+
+        if (dns == k_dns_msg_yes) {
             // the answer is not classifiable from msg_name, so key on the socket
             if (orig_dport == 0) {
-                obi_note_unconn_dns_sock(sk);
+                obi_note_unconn_dns_query(sk, &s_args.p_conn.conn);
             }
             sort_connection_info(&s_args.p_conn.conn);
             s_args.p_conn.pid = pid_from_pid_tgid(id);
@@ -956,20 +964,36 @@ int BPF_KRETPROBE_GUARDED(obi_kretprobe_sock_recvmsg, int copied_len) {
     if (sock_ptr) {
         if (parse_sock_info((struct sock *)sock_ptr, &info.conn)) {
             const u16 orig_dport = info.conn.d_port;
+
+            // the socket-identity tier matches on the local endpoint, which
+            // sorting may move into the destination fields
+            const connection_info_t local_conn = info.conn;
+
             sort_connection_info(&info.conn);
             info.pid = pid_from_pid_tgid(id);
             setup_cp_support_conn_info(&info, false);
             setup_connection_to_pid_mapping(id, &info, orig_dport);
 
-            u8 dns = is_dns_msg(&info.conn, (struct msghdr *)args->msg_ptr);
+            const enum dns_msg_class dns_class =
+                classify_dns_msg(&info.conn, (struct msghdr *)args->msg_ptr);
+
+            // an explicit non-DNS peer retires the socket's classification
+            if (dns_class == k_dns_msg_no) {
+                obi_forget_unconn_dns_sock(sock_ptr);
+            }
+
+            u8 dns = dns_class == k_dns_msg_yes;
+
             // msg_name did not classify it, but the answer arrived on a socket
-            // seen sending an unconnected UDP DNS query
-            if (!dns && orig_dport == 0 && obi_is_unconn_dns_sock(sock_ptr)) {
-                bpf_dbg_printk("UNCONN_DNS_RECVFROM: classified unconnected UDP DNS answer on "
+            // with an outstanding unconnected UDP DNS query
+            if (dns_class == k_dns_msg_unknown && orig_dport == 0 &&
+                obi_claim_unconn_dns_answer(sock_ptr, &local_conn)) {
+                bpf_dbg_printk("UNCONN_DNS_RECVFROM: claimed unconnected UDP DNS answer on "
                                "known DNS sock=%llx",
                                (u64)sock_ptr);
                 dns = 1;
             }
+
             if (dns) {
                 sort_connection_info(&info.conn);
 

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -288,6 +288,19 @@ int BPF_KPROBE_GUARDED(obi_kprobe_udp_sendmsg, struct sock *sk, struct msghdr *m
     return 0;
 }
 
+// unconn_dns_socks is keyed by the struct sock * address, which the kernel may
+// hand to a new socket once this one is gone. Retiring the entry here bounds the
+// key's meaning to the socket's lifetime, so a later socket at the same address
+// cannot inherit its DNS classification.
+SEC("kprobe/udp_destroy_sock")
+int BPF_KPROBE(obi_kprobe_udp_destroy_sock, struct sock *sk) {
+    (void)ctx;
+
+    obi_forget_unconn_dns_sock(sk);
+
+    return 0;
+}
+
 static __always_inline void cp_support_established(pid_connection_info_t *p_conn) {
     cp_support_data_t *cp_support = bpf_map_lookup_elem(&cp_support_connect_info, p_conn);
     if (cp_support) {

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -317,7 +317,7 @@ int BPF_KRETPROBE_GUARDED(obi_kretprobe_udp_sendmsg, int ret) {
 // key's meaning to the socket's lifetime, so a later socket at the same address
 // cannot inherit its DNS classification.
 SEC("kprobe/udp_destroy_sock")
-int BPF_KPROBE(obi_kprobe_udp_destroy_sock, struct sock *sk) {
+int BPF_KPROBE_GUARDED(obi_kprobe_udp_destroy_sock, struct sock *sk) {
     (void)ctx;
 
     obi_forget_unconn_dns_sock(sk);

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -266,10 +266,8 @@ int BPF_KPROBE_GUARDED(obi_kprobe_udp_sendmsg, struct sock *sk, struct msghdr *m
         }
 
         if (dns == k_dns_msg_yes) {
-            // the answer is not classifiable from msg_name, so key on the socket
-            if (orig_dport == 0) {
-                obi_note_unconn_dns_query(sk, &s_args.p_conn.conn);
-            }
+            const connection_info_t local_conn = s_args.p_conn.conn;
+
             sort_connection_info(&s_args.p_conn.conn);
             s_args.p_conn.pid = pid_from_pid_tgid(id);
             s_args.orig_dport = orig_dport;
@@ -277,9 +275,11 @@ int BPF_KPROBE_GUARDED(obi_kprobe_udp_sendmsg, struct sock *sk, struct msghdr *m
             unsigned char *buf = iovec_memory();
             if (buf) {
                 len = read_msghdr_buf(msg, buf, len);
-                if (len) {
-                    bpf_dbg_printk("Got buffer with len: %d", len);
-                    handle_dns_buf(buf, len, &s_args.p_conn, orig_dport);
+                if (len && handle_dns_buf(buf, len, &s_args.p_conn, orig_dport) &&
+                    orig_dport == 0) {
+                    // the answer to this query will carry no peer, so the only
+                    // thing left to recognise it by is the socket it arrives on
+                    obi_note_unconn_dns_query(sk, &local_conn);
                 }
             }
         }
@@ -985,10 +985,10 @@ int BPF_KRETPROBE_GUARDED(obi_kretprobe_sock_recvmsg, int copied_len) {
             u8 dns = dns_class == k_dns_msg_yes;
 
             // msg_name did not classify it, but the answer arrived on a socket
-            // with an outstanding unconnected UDP DNS query
+            // that recently sent an unconnected UDP DNS query
             if (dns_class == k_dns_msg_unknown && orig_dport == 0 &&
-                obi_claim_unconn_dns_answer(sock_ptr, &local_conn)) {
-                bpf_dbg_printk("UNCONN_DNS_RECVFROM: claimed unconnected UDP DNS answer on "
+                obi_unconn_dns_answer_expected(sock_ptr, &local_conn)) {
+                bpf_dbg_printk("UNCONN_DNS_RECVFROM: expecting an unconnected UDP DNS answer on "
                                "known DNS sock=%llx",
                                (u64)sock_ptr);
                 dns = 1;

--- a/bpf/generictracer/k_tracer_defs.h
+++ b/bpf/generictracer/k_tracer_defs.h
@@ -20,6 +20,9 @@
 // Temporary tracking of tcp_recvmsg arguments
 typedef struct recv_args {
     u64 sock_ptr; // linux sock or socket address
+    // stashed at recv entry so the kretprobe can read msg_name, which the kernel
+    // fills with the source address on return, to classify unconnected UDP DNS
+    u64 msg_ptr;
     // this is done because bpf2go cannot generate the go bindings of this
     // struct containing a 'iovec_iter_ctx iovec_ctx' member
     unsigned char iovec_ctx[sizeof(iovec_iter_ctx)];

--- a/bpf/maps/unconn_dns_socks.h
+++ b/bpf/maps/unconn_dns_socks.h
@@ -6,15 +6,26 @@
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_helpers.h>
 
+#include <common/connection_info.h>
 #include <common/map_sizing.h>
 #include <common/pin_internal.h>
 
-// Sockets classified as carrying DNS over an unconnected UDP socket, keyed by
-// (u64)struct sock *.
+// Outstanding DNS queries sent over an unconnected UDP socket, keyed by
+// (u64)struct sock *. The local endpoint is recorded alongside the outstanding
+// query count so that a recycled struct sock * address cannot inherit the
+// classification of the socket that previously occupied it.
+typedef struct unconn_dns_sock {
+    u64 last_query_ns;
+    u8 s_addr[IP_V6_ADDR_LEN];
+    u16 s_port;
+    u16 pending;
+    u8 _pad[4];
+} unconn_dns_sock_t;
+
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __type(key, u64);
-    __type(value, u8);
+    __type(value, unconn_dns_sock_t);
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
     __uint(pinning, OBI_PIN_INTERNAL);
 } unconn_dns_socks SEC(".maps");

--- a/bpf/maps/unconn_dns_socks.h
+++ b/bpf/maps/unconn_dns_socks.h
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/map_sizing.h>
+#include <common/pin_internal.h>
+
+// Sockets classified as carrying DNS over an unconnected UDP socket, keyed by
+// (u64)struct sock *.
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u64);
+    __type(value, u8);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} unconn_dns_socks SEC(".maps");

--- a/bpf/maps/unconn_dns_socks.h
+++ b/bpf/maps/unconn_dns_socks.h
@@ -10,16 +10,21 @@
 #include <common/map_sizing.h>
 #include <common/pin_internal.h>
 
-// Outstanding DNS queries sent over an unconnected UDP socket, keyed by
-// (u64)struct sock *. The local endpoint is recorded alongside the outstanding
-// query count so that a recycled struct sock * address cannot inherit the
-// classification of the socket that previously occupied it.
+// The most recent DNS query sent over an unconnected UDP socket, keyed by
+// (u64)struct sock *. The local endpoint is recorded alongside the timestamp so
+// that a recycled struct sock * address cannot inherit the classification of
+// the socket that previously occupied it.
+//
+// There is deliberately no outstanding-query counter. A resolver may have
+// several queries in flight on one socket (musl sends A and AAAA in parallel),
+// and a counter decremented per answer would leave the later answers
+// unclassified. The timestamp bounds how long the socket stays eligible, and it
+// is a single aligned store, so concurrent sends cannot corrupt it.
 typedef struct unconn_dns_sock {
     u64 last_query_ns;
     u8 s_addr[IP_V6_ADDR_LEN];
     u16 s_port;
-    u16 pending;
-    u8 _pad[4];
+    u8 _pad[6];
 } unconn_dns_sock_t;
 
 struct {

--- a/bpf/maps/unconn_dns_socks.h
+++ b/bpf/maps/unconn_dns_socks.h
@@ -34,3 +34,22 @@ struct {
     __uint(max_entries, MAX_CONCURRENT_REQUESTS);
     __uint(pinning, OBI_PIN_INTERNAL);
 } unconn_dns_socks SEC(".maps");
+
+// A DNS query parsed on the way into udp_sendmsg, held until the return probe
+// says whether it left the host, and keyed by pid_tid because that is what
+// joins the entry probe to its return. A send that fails must not open an
+// answer window: nothing was asked, so nothing is owed an answer.
+typedef struct unconn_dns_pending {
+    u64 sk;
+    u8 s_addr[IP_V6_ADDR_LEN];
+    u16 s_port;
+    u8 _pad[6];
+} unconn_dns_pending_t;
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u64); // pid_tid
+    __type(value, unconn_dns_pending_t);
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} unconn_dns_pending SEC(".maps");

--- a/bpf/tests/bpf_dns_header.c
+++ b/bpf/tests/bpf_dns_header.c
@@ -160,7 +160,7 @@ static dns_req_t *run_handle_dns_buf(u16 id, u16 flags) {
     p_conn.conn.d_port = 53;
 
     test_record_submitted = false;
-    handle_dns_buf(buf, len, &p_conn, 53);
+    handle_dns_buf(buf, len, &p_conn, 53, NULL);
 
     return test_record_submitted ? (dns_req_t *)test_record : NULL;
 }

--- a/bpf/tests/bpf_dns_header.c
+++ b/bpf/tests/bpf_dns_header.c
@@ -16,13 +16,11 @@
 
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_helpers.h>
+// included ahead of the override below, so the include chain does not redefine it
+#include <bpfcore/bpf_core_read.h>
 
 // Called by the dns.h include chain, omitted by the shared stub
 #define BPF_ANY 0
-
-static inline u64 bpf_ktime_get_ns(void) {
-    return 0;
-}
 
 static inline u32 bpf_get_prandom_u32(void) {
     return 0;
@@ -39,7 +37,9 @@ static inline long bpf_skb_load_bytes(const void *skb, u32 offset, void *to, u32
 // The shared stubs no-op every read and map lookup, so live mocks are supplied
 // below and macro-shadowed over the include.
 
-// Host-resident structs, so a direct field access stands in for the CO-RE read
+// Host-resident structs, so a direct field access stands in for the CO-RE read.
+// The shared stub copies a zero value instead.
+#undef BPF_CORE_READ_INTO
 #define BPF_CORE_READ_INTO(dst, src, field) (*(dst) = (src)->field)
 
 static long test_probe_read_kernel(void *dst, u32 size, const void *src) {

--- a/bpf/tests/bpf_dns_header.c
+++ b/bpf/tests/bpf_dns_header.c
@@ -39,6 +39,9 @@ static inline long bpf_skb_load_bytes(const void *skb, u32 offset, void *to, u32
 // The shared stubs no-op every read and map lookup, so live mocks are supplied
 // below and macro-shadowed over the include.
 
+// Host-resident structs, so a direct field access stands in for the CO-RE read
+#define BPF_CORE_READ_INTO(dst, src, field) (*(dst) = (src)->field)
+
 static long test_probe_read_kernel(void *dst, u32 size, const void *src) {
     if (!src) {
         return -1;

--- a/bpf/tests/bpf_dns_header.c
+++ b/bpf/tests/bpf_dns_header.c
@@ -1,0 +1,208 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// DNS header extraction in handle_dns_buf (generictracer/dns.h). The buffer it
+// parses is scratch memory from iovec_memory(), which is a BPF map, so reading
+// it needs the kernel probe helper: a user read fails, silently zeroing the
+// header, which loses the transaction id and makes every record look like a
+// query.
+//
+// Run from repo root:
+//   make -C bpf/tests bpf_dns_header && bpf/tests/bpf_dns_header
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+// Called by the dns.h include chain, omitted by the shared stub
+#define BPF_ANY 0
+
+static inline u64 bpf_ktime_get_ns(void) {
+    return 0;
+}
+
+static inline u32 bpf_get_prandom_u32(void) {
+    return 0;
+}
+
+static inline long bpf_loop(u32 nr_loops, void *cb, void *ctx, u64 flags) {
+    return 0;
+}
+
+static inline long bpf_skb_load_bytes(const void *skb, u32 offset, void *to, u32 len) {
+    return 0;
+}
+
+// The shared stubs no-op every read and map lookup, so live mocks are supplied
+// below and macro-shadowed over the include.
+
+static long test_probe_read_kernel(void *dst, u32 size, const void *src) {
+    if (!src) {
+        return -1;
+    }
+    memcpy(dst, src, size);
+    return 0;
+}
+
+// Mirrors a user read of kernel memory: it fails and zeroes the destination.
+// Unused while the code reads correctly; kept so a regression to
+// bpf_probe_read_user fails deterministically rather than on uninitialized stack.
+__attribute__((unused)) static long test_probe_read_user(void *dst, u32 size, const void *src) {
+    (void)src;
+    memset(dst, 0, size);
+    return -1;
+}
+
+// handle_dns_buf bails unless sock_pids resolves the connection
+static void *test_sock_pids_map;
+static unsigned char test_conn_pid[128];
+
+static void *test_map_lookup(void *map, const void *key) {
+    (void)key;
+    if (test_sock_pids_map != NULL && map == test_sock_pids_map) {
+        return test_conn_pid;
+    }
+    return NULL;
+}
+
+// Captures the record handle_dns_buf reserves, so the test can inspect it
+static unsigned char test_record[4096];
+static bool test_record_submitted;
+
+static void *test_ringbuf_reserve(void *rb, u64 size, u64 flags) {
+    (void)rb;
+    (void)flags;
+    if (size > sizeof(test_record)) {
+        return NULL;
+    }
+    memset(test_record, 0, sizeof(test_record));
+    return test_record;
+}
+
+static void test_ringbuf_submit(void *data, u64 flags) {
+    (void)data;
+    (void)flags;
+    test_record_submitted = true;
+}
+
+#define bpf_probe_read_kernel test_probe_read_kernel
+#define bpf_probe_read_user test_probe_read_user
+#define bpf_map_lookup_elem test_map_lookup
+#define bpf_ringbuf_reserve test_ringbuf_reserve
+#define bpf_ringbuf_submit test_ringbuf_submit
+
+#include <generictracer/dns.h>
+
+#undef bpf_probe_read_kernel
+#undef bpf_probe_read_user
+#undef bpf_map_lookup_elem
+#undef bpf_ringbuf_reserve
+#undef bpf_ringbuf_submit
+
+// Test harness
+
+static int failures = 0;
+
+static void check_u16(const char *name, u16 expected, u16 actual) {
+    if (expected != actual) {
+        fprintf(stderr, "FAIL: %s\n  expected %u, got %u\n", name, expected, actual);
+        failures++;
+        return;
+    }
+    printf("ok: %s\n", name);
+}
+
+static void check_u8(const char *name, u8 expected, u8 actual) {
+    if (expected != actual) {
+        fprintf(stderr, "FAIL: %s\n  expected %u, got %u\n", name, expected, actual);
+        failures++;
+        return;
+    }
+    printf("ok: %s\n", name);
+}
+
+// Header plus one question for "a.example.com"
+static int build_dns_message(unsigned char *buf, u16 id, u16 flags) {
+    static const unsigned char question[] = "\x01"
+                                            "a"
+                                            "\x07"
+                                            "example"
+                                            "\x03"
+                                            "com"
+                                            "\x00"
+                                            "\x00\x01"
+                                            "\x00\x01";
+    int off = 0;
+    buf[off++] = (unsigned char)(id >> 8);
+    buf[off++] = (unsigned char)(id & 0xff);
+    buf[off++] = (unsigned char)(flags >> 8);
+    buf[off++] = (unsigned char)(flags & 0xff);
+    buf[off++] = 0;
+    buf[off++] = 1;          // qdcount
+    memset(buf + off, 0, 6); // ancount, nscount, arcount
+    off += 6;
+    memcpy(buf + off, question, sizeof(question) - 1);
+    return off + (int)(sizeof(question) - 1);
+}
+
+static dns_req_t *run_handle_dns_buf(u16 id, u16 flags) {
+    unsigned char buf[512] = {0};
+    const int len = build_dns_message(buf, id, flags);
+
+    pid_connection_info_t p_conn = {0};
+    p_conn.conn.s_port = 40100;
+    p_conn.conn.d_port = 53;
+
+    test_record_submitted = false;
+    handle_dns_buf(buf, len, &p_conn, 53);
+
+    return test_record_submitted ? (dns_req_t *)test_record : NULL;
+}
+
+static void test_query_id_is_extracted(void) {
+    dns_req_t *req = run_handle_dns_buf(3178, 0x0100);
+
+    check_u8("a query is recorded", 1, req != NULL);
+    if (req) {
+        check_u16("the wire transaction id survives extraction", 3178, req->id);
+        check_u8("a query is recorded as a query", k_dns_qr_query, req->dns_q);
+    }
+}
+
+static void test_answer_id_is_extracted(void) {
+    dns_req_t *req = run_handle_dns_buf(3178, 0x8180);
+
+    check_u8("an answer is recorded", 1, req != NULL);
+    if (req) {
+        check_u16("the answer carries the same transaction id", 3178, req->id);
+        check_u8("an answer is recorded as an answer", k_dns_qr_resp, req->dns_q);
+    }
+}
+
+// Pairing keys on the id, so distinct transactions must not collapse onto one
+static void test_ids_are_distinct(void) {
+    dns_req_t *first = run_handle_dns_buf(3178, 0x0100);
+    u16 first_id = first ? first->id : 0;
+    dns_req_t *second = run_handle_dns_buf(4242, 0x0100);
+    u16 second_id = second ? second->id : 0;
+
+    check_u8("two transactions yield different ids", 1, first_id != second_id);
+}
+
+int main(void) {
+    test_sock_pids_map = &sock_pids;
+
+    test_query_id_is_extracted();
+    test_answer_id_is_extracted();
+    test_ids_are_distinct();
+
+    if (failures > 0) {
+        fprintf(stderr, "%d test(s) failed\n", failures);
+        return 1;
+    }
+    printf("all DNS header extraction tests passed\n");
+    return 0;
+}

--- a/bpf/tests/bpf_dns_unconnected.c
+++ b/bpf/tests/bpf_dns_unconnected.c
@@ -14,16 +14,15 @@
 
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_helpers.h>
+// included ahead of the override below, so the include chain does not redefine it
+#include <bpfcore/bpf_core_read.h>
 
 // Called by the dns.h include chain, omitted by the shared stub
 #define BPF_ANY 0
 
-// Mutable so the answer-timeout boundary can be pinned
-static u64 test_now_ns;
-
-static inline u64 bpf_ktime_get_ns(void) {
-    return test_now_ns;
-}
+// The shared stub's clock, which this test drives so the answer-timeout
+// boundary can be pinned
+#define test_now_ns bpf_ktime_ns_value
 
 static inline u32 bpf_get_prandom_u32(void) {
     return 0;
@@ -40,7 +39,9 @@ static inline long bpf_skb_load_bytes(const void *skb, u32 offset, void *to, u32
 // The shared stubs no-op every read and map lookup, so the classifier is given
 // live mocks below and they are macro-shadowed over the include.
 
-// Host-resident structs, so a direct field access stands in for the CO-RE read
+// Host-resident structs, so a direct field access stands in for the CO-RE read.
+// The shared stub copies a zero value instead, which would leave msg_name unread.
+#undef BPF_CORE_READ_INTO
 #define BPF_CORE_READ_INTO(dst, src, field) (*(dst) = (src)->field)
 
 // Returns an error on a NULL source rather than faulting the test process
@@ -312,9 +313,14 @@ static void test_classify_reports_no_for_connected_non_dns_peer(void) {
 // between arbitrary bytes on a resolver socket and a reported lookup.
 
 enum : u16 {
-    k_flags_query = 0x0100,    // qr=0, opcode=0, rd=1
-    k_flags_response = 0x8180, // qr=1, opcode=0, rd=1, ra=1, rcode=0
+    k_flags_query = 0x0100,      // qr=0, opcode=0, rd=1
+    k_flags_response = 0x8180,   // qr=1, opcode=0, rd=1, ra=1, rcode=0
+    k_flags_mdns_query = 0x0000, // qr=0, opcode=0; a multicast query sets no rd
+    k_flag_tc = 1 << 9,
 };
+
+// whether the message is multicast DNS, which decides how much a query may carry
+enum : u8 { k_unicast = 0, k_mdns = 1 };
 
 // counts as they sit in a real header, in network byte order
 static struct dnshdr dns_header(u16 flags, u16 qd, u16 an, u16 ns, u16 ar) {
@@ -339,7 +345,7 @@ static void test_header_accepts_a_real_query(void) {
 
     check_u8("an ordinary query is plausible",
              1,
-             dns_header_is_plausible(&hdr, k_flags_query, roomy_size()));
+             dns_header_is_plausible(&hdr, k_flags_query, roomy_size(), k_unicast));
 }
 
 static void test_header_accepts_a_real_response(void) {
@@ -347,7 +353,7 @@ static void test_header_accepts_a_real_response(void) {
 
     check_u8("an ordinary response is plausible",
              1,
-             dns_header_is_plausible(&hdr, k_flags_response, roomy_size()));
+             dns_header_is_plausible(&hdr, k_flags_response, roomy_size(), k_unicast));
 }
 
 // NXDOMAIN and SERVFAIL are lookups worth reporting, so rcode is not a filter
@@ -355,8 +361,9 @@ static void test_header_accepts_an_nxdomain_response(void) {
     const u16 flags = k_flags_response | 3;
     struct dnshdr hdr = dns_header(flags, 1, 0, 1, 0);
 
-    check_u8(
-        "an NXDOMAIN response is plausible", 1, dns_header_is_plausible(&hdr, flags, roomy_size()));
+    check_u8("an NXDOMAIN response is plausible",
+             1,
+             dns_header_is_plausible(&hdr, flags, roomy_size(), k_unicast));
 }
 
 // A DNSSEC-aware resolver sets AD and CD on ordinary traffic. RFC 1035 called
@@ -367,7 +374,7 @@ static void test_header_accepts_dnssec_ad_and_cd(void) {
 
     check_u8("AD and CD do not make a response implausible",
              1,
-             dns_header_is_plausible(&hdr, flags, roomy_size()));
+             dns_header_is_plausible(&hdr, flags, roomy_size(), k_unicast));
 }
 
 // mDNS responses may omit the question section
@@ -376,7 +383,7 @@ static void test_header_accepts_a_response_without_a_question(void) {
 
     check_u8("a response with answers but no question is plausible",
              1,
-             dns_header_is_plausible(&hdr, k_flags_response, roomy_size()));
+             dns_header_is_plausible(&hdr, k_flags_response, roomy_size(), k_unicast));
 }
 
 static void test_header_rejects_a_non_query_opcode(void) {
@@ -385,15 +392,16 @@ static void test_header_rejects_a_non_query_opcode(void) {
 
     check_u8("a non-standard opcode is not a lookup",
              0,
-             dns_header_is_plausible(&hdr, flags, roomy_size()));
+             dns_header_is_plausible(&hdr, flags, roomy_size(), k_unicast));
 }
 
 static void test_header_rejects_a_set_reserved_bit(void) {
     const u16 flags = k_flags_response | (1 << 6);
     struct dnshdr hdr = dns_header(flags, 1, 1, 0, 0);
 
-    check_u8(
-        "the reserved bit must be zero", 0, dns_header_is_plausible(&hdr, flags, roomy_size()));
+    check_u8("the reserved bit must be zero",
+             0,
+             dns_header_is_plausible(&hdr, flags, roomy_size(), k_unicast));
 }
 
 static void test_header_rejects_a_query_that_asks_nothing(void) {
@@ -401,7 +409,7 @@ static void test_header_rejects_a_query_that_asks_nothing(void) {
 
     check_u8("a query with no question is implausible",
              0,
-             dns_header_is_plausible(&hdr, k_flags_query, roomy_size()));
+             dns_header_is_plausible(&hdr, k_flags_query, roomy_size(), k_unicast));
 }
 
 static void test_header_rejects_a_query_carrying_answers(void) {
@@ -409,7 +417,7 @@ static void test_header_rejects_a_query_carrying_answers(void) {
 
     check_u8("a query does not answer itself",
              0,
-             dns_header_is_plausible(&hdr, k_flags_query, roomy_size()));
+             dns_header_is_plausible(&hdr, k_flags_query, roomy_size(), k_unicast));
 }
 
 static void test_header_rejects_an_empty_response(void) {
@@ -417,7 +425,7 @@ static void test_header_rejects_an_empty_response(void) {
 
     check_u8("a response with no sections carries no lookup",
              0,
-             dns_header_is_plausible(&hdr, k_flags_response, roomy_size()));
+             dns_header_is_plausible(&hdr, k_flags_response, roomy_size(), k_unicast));
 }
 
 // The check that does most of the work against arbitrary bytes: random counts
@@ -425,9 +433,10 @@ static void test_header_rejects_an_empty_response(void) {
 static void test_header_rejects_counts_that_cannot_fit(void) {
     struct dnshdr hdr = dns_header(k_flags_response, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF);
 
-    check_u8("counts larger than the datagram are implausible",
-             0,
-             dns_header_is_plausible(&hdr, k_flags_response, sizeof(struct dnshdr) + 32));
+    check_u8(
+        "counts larger than the datagram are implausible",
+        0,
+        dns_header_is_plausible(&hdr, k_flags_response, sizeof(struct dnshdr) + 32, k_unicast));
 }
 
 static void test_header_accepts_counts_that_exactly_fit(void) {
@@ -437,7 +446,7 @@ static void test_header_accepts_counts_that_exactly_fit(void) {
 
     check_u8("sections that exactly fit are plausible",
              1,
-             dns_header_is_plausible(&hdr, k_flags_response, size));
+             dns_header_is_plausible(&hdr, k_flags_response, size, k_unicast));
 }
 
 // A truncated response describes records it never sent, so its counts cannot be
@@ -448,7 +457,78 @@ static void test_header_accepts_a_truncated_response(void) {
 
     check_u8("a truncated response is not judged on its counts",
              1,
-             dns_header_is_plausible(&hdr, flags, sizeof(struct dnshdr) + 16));
+             dns_header_is_plausible(&hdr, flags, sizeof(struct dnshdr) + 16, k_unicast));
+}
+
+// Multicast DNS, which puts records in sections a unicast query leaves empty.
+// The port is recognized as DNS, so rejecting these forms would drop lookups
+// this code claims to report.
+
+// RFC 6762 §7.1: a querier that already knows some answers populates the Answer
+// Section with them, so that responders holding the same records stay quiet
+static void test_header_accepts_an_mdns_known_answer_query(void) {
+    struct dnshdr hdr = dns_header(k_flags_mdns_query, 1, 2, 0, 0);
+
+    check_u8("a known-answer suppression query is plausible over mDNS",
+             1,
+             dns_header_is_plausible(&hdr, k_flags_mdns_query, roomy_size(), k_mdns));
+
+    check_u8("the same query is implausible over unicast DNS",
+             0,
+             dns_header_is_plausible(&hdr, k_flags_mdns_query, roomy_size(), k_unicast));
+}
+
+// RFC 6762 §7.2: a known-answer list too large for one packet is continued in
+// further query packets, which carry no question at all. Every packet but the
+// last sets TC.
+static void test_header_accepts_an_mdns_continuation_packet(void) {
+    const u16 flags = k_flags_mdns_query | k_flag_tc;
+    struct dnshdr hdr = dns_header(flags, 0, 2, 0, 0);
+
+    check_u8("a continuation packet with more to follow is plausible over mDNS",
+             1,
+             dns_header_is_plausible(&hdr, flags, roomy_size(), k_mdns));
+}
+
+static void test_header_accepts_a_final_mdns_continuation_packet(void) {
+    struct dnshdr hdr = dns_header(k_flags_mdns_query, 0, 2, 0, 0);
+
+    check_u8("the last continuation packet, which clears TC, is plausible over mDNS",
+             1,
+             dns_header_is_plausible(&hdr, k_flags_mdns_query, roomy_size(), k_mdns));
+
+    check_u8("a question-less query is implausible over unicast DNS",
+             0,
+             dns_header_is_plausible(&hdr, k_flags_mdns_query, roomy_size(), k_unicast));
+}
+
+// RFC 6762 §8.1: a probe proposes its records in the Authority Section
+static void test_header_accepts_an_mdns_probe(void) {
+    struct dnshdr hdr = dns_header(k_flags_mdns_query, 1, 0, 1, 0);
+
+    check_u8("a probe query is plausible over mDNS",
+             1,
+             dns_header_is_plausible(&hdr, k_flags_mdns_query, roomy_size(), k_mdns));
+}
+
+// The relaxation is about which sections may be occupied, not about whether the
+// message has to describe anything at all
+static void test_header_rejects_an_empty_mdns_query(void) {
+    struct dnshdr hdr = dns_header(k_flags_mdns_query, 0, 0, 0, 0);
+
+    check_u8("an mDNS query describing no records is implausible",
+             0,
+             dns_header_is_plausible(&hdr, k_flags_mdns_query, roomy_size(), k_mdns));
+}
+
+// The size check is what stands between arbitrary bytes and a reported lookup,
+// and admitting answers into a query must not exempt a query from it
+static void test_header_rejects_an_mdns_query_that_cannot_fit(void) {
+    struct dnshdr hdr = dns_header(k_flags_mdns_query, 0, 0xFFFF, 0, 0);
+
+    check_u8("an mDNS query claiming more answers than it can hold is implausible",
+             0,
+             dns_header_is_plausible(&hdr, k_flags_mdns_query, sizeof(struct dnshdr) + 32, k_mdns));
 }
 
 // unconn_dns_socks
@@ -788,6 +868,12 @@ int main(void) {
     test_header_rejects_counts_that_cannot_fit();
     test_header_accepts_counts_that_exactly_fit();
     test_header_accepts_a_truncated_response();
+    test_header_accepts_an_mdns_known_answer_query();
+    test_header_accepts_an_mdns_continuation_packet();
+    test_header_accepts_a_final_mdns_continuation_packet();
+    test_header_accepts_an_mdns_probe();
+    test_header_rejects_an_empty_mdns_query();
+    test_header_rejects_an_mdns_query_that_cannot_fit();
 
     test_unconn_sock_has_no_expected_answer_by_default();
     test_unconn_sock_answer_is_expected_after_a_query();

--- a/bpf/tests/bpf_dns_unconnected.c
+++ b/bpf/tests/bpf_dns_unconnected.c
@@ -510,6 +510,100 @@ static void test_unconn_sock_unparsed_receive_does_not_spend_the_window(void) {
              obi_unconn_dns_answer_expected((void *)0x1000, &conn));
 }
 
+// A staged query is one that parsed as DNS on the way into udp_sendmsg. Until
+// the return probe says it left the host, it opens no window.
+
+enum : u64 { k_test_pid_tid = 0x2a2a };
+
+static void test_unconn_staged_query_opens_no_window(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+
+    obi_stage_unconn_dns_query(k_test_pid_tid, (void *)0x1000, &conn);
+
+    check_u8("a staged query alone expects no answer",
+             0,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
+}
+
+static void test_unconn_committed_query_opens_the_window(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+
+    obi_stage_unconn_dns_query(k_test_pid_tid, (void *)0x1000, &conn);
+    obi_commit_unconn_dns_query(k_test_pid_tid);
+
+    check_u8("a committed query expects an answer",
+             1,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
+}
+
+// The case the return probe exists for: sendto() returned an error, so the
+// resolver asked nothing and is owed nothing.
+static void test_unconn_failed_send_opens_no_window(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+
+    obi_stage_unconn_dns_query(k_test_pid_tid, (void *)0x1000, &conn);
+    obi_discard_unconn_dns_query(k_test_pid_tid);
+
+    check_u8("a failed DNS send expects no answer",
+             0,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
+}
+
+// The commit consumes the staged query, so a later send whose return probe
+// fires without staging anything cannot reopen the window
+static void test_unconn_commit_does_not_repeat(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+
+    obi_stage_unconn_dns_query(k_test_pid_tid, (void *)0x1000, &conn);
+    obi_commit_unconn_dns_query(k_test_pid_tid);
+    obi_forget_unconn_dns_sock((void *)0x1000);
+
+    // the socket was destroyed and its window retired; a second return probe
+    // for the same thread has nothing left to commit
+    obi_commit_unconn_dns_query(k_test_pid_tid);
+
+    check_u8("a second commit reopens nothing",
+             0,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
+}
+
+// The window is timed from the commit, not from the entry probe, so a send that
+// blocks in the kernel does not spend part of its own answer window
+static void test_unconn_window_is_timed_from_the_commit(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+
+    obi_stage_unconn_dns_query(k_test_pid_tid, (void *)0x1000, &conn);
+
+    // the send blocks for longer than the whole answer window before returning
+    test_now_ns = k_unconn_dns_answer_timeout_ns * 2;
+    obi_commit_unconn_dns_query(k_test_pid_tid);
+
+    check_u8("the window starts when the datagram went out",
+             1,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
+}
+
+// The staged record carries the socket, so a commit reaching the map applies to
+// the socket that sent the query rather than to whatever sent last
+static void test_unconn_commit_applies_to_the_staged_socket(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+
+    obi_stage_unconn_dns_query(k_test_pid_tid, (void *)0x1000, &conn);
+    obi_commit_unconn_dns_query(k_test_pid_tid);
+
+    check_u8("the staged socket got the window",
+             1,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
+    check_u8(
+        "an unrelated socket did not", 0, obi_unconn_dns_answer_expected((void *)0x2000, &conn));
+}
+
 static void test_unconn_sock_does_not_match_other_sockets(void) {
     mock_map_reset();
     connection_info_t conn = local_endpoint(40100, 10);
@@ -699,6 +793,13 @@ int main(void) {
     test_unconn_sock_answer_is_expected_after_a_query();
     test_unconn_sock_expects_every_parallel_answer();
     test_unconn_sock_unparsed_receive_does_not_spend_the_window();
+    test_unconn_staged_query_opens_no_window();
+    test_unconn_committed_query_opens_the_window();
+    test_unconn_failed_send_opens_no_window();
+    test_unconn_commit_does_not_repeat();
+    test_unconn_window_is_timed_from_the_commit();
+    test_unconn_commit_applies_to_the_staged_socket();
+
     test_unconn_sock_does_not_match_other_sockets();
     test_unconn_sock_non_dns_send_preserves_the_window();
     test_unconn_sock_non_dns_receive_preserves_the_window();

--- a/bpf/tests/bpf_dns_unconnected.c
+++ b/bpf/tests/bpf_dns_unconnected.c
@@ -18,8 +18,11 @@
 // Called by the dns.h include chain, omitted by the shared stub
 #define BPF_ANY 0
 
+// Mutable so the answer-timeout boundary can be pinned
+static u64 test_now_ns;
+
 static inline u64 bpf_ktime_get_ns(void) {
-    return 0;
+    return test_now_ns;
 }
 
 static inline u32 bpf_get_prandom_u32(void) {
@@ -49,17 +52,35 @@ static long test_probe_read_kernel(void *dst, u32 size, const void *src) {
     return 0;
 }
 
-// Stands in for the unconn_dns_socks LRU map; membership only, no eviction
+// Stands in for the unconn_dns_socks LRU map; no eviction. Defined after the
+// include, where the map's value type is visible.
+static void *test_map_lookup(void *map, const void *key);
+static long test_map_update(void *map, const void *key, const void *value, u64 flags);
+static long test_map_delete(void *map, const void *key);
+
+#define bpf_probe_read_kernel test_probe_read_kernel
+#define bpf_map_lookup_elem test_map_lookup
+#define bpf_map_update_elem test_map_update
+#define bpf_map_delete_elem test_map_delete
+
+#include <generictracer/dns.h>
+
+#undef bpf_probe_read_kernel
+#undef bpf_map_lookup_elem
+#undef bpf_map_update_elem
+#undef bpf_map_delete_elem
+
 enum { k_mock_map_capacity = 8 };
 
 static struct {
     u64 keys[k_mock_map_capacity];
-    u8 values[k_mock_map_capacity];
+    unconn_dns_sock_t values[k_mock_map_capacity];
     bool used[k_mock_map_capacity];
 } test_map;
 
 static void mock_map_reset(void) {
     memset(&test_map, 0, sizeof(test_map));
+    test_now_ns = 0;
 }
 
 static void *test_map_lookup(void *map, const void *key) {
@@ -82,7 +103,7 @@ static long test_map_update(void *map, const void *key, const void *value, u64 f
 
     for (int i = 0; i < k_mock_map_capacity; i++) {
         if (test_map.used[i] && test_map.keys[i] == k) {
-            test_map.values[i] = *(const u8 *)value;
+            test_map.values[i] = *(const unconn_dns_sock_t *)value;
             return 0;
         }
     }
@@ -91,7 +112,7 @@ static long test_map_update(void *map, const void *key, const void *value, u64 f
         if (!test_map.used[i]) {
             test_map.used[i] = true;
             test_map.keys[i] = k;
-            test_map.values[i] = *(const u8 *)value;
+            test_map.values[i] = *(const unconn_dns_sock_t *)value;
             return 0;
         }
     }
@@ -99,15 +120,20 @@ static long test_map_update(void *map, const void *key, const void *value, u64 f
     return -1;
 }
 
-#define bpf_probe_read_kernel test_probe_read_kernel
-#define bpf_map_lookup_elem test_map_lookup
-#define bpf_map_update_elem test_map_update
+static long test_map_delete(void *map, const void *key) {
+    (void)map;
+    const u64 k = *(const u64 *)key;
 
-#include <generictracer/dns.h>
+    for (int i = 0; i < k_mock_map_capacity; i++) {
+        if (test_map.used[i] && test_map.keys[i] == k) {
+            test_map.used[i] = false;
+            memset(&test_map.values[i], 0, sizeof(test_map.values[i]));
+            return 0;
+        }
+    }
 
-#undef bpf_probe_read_kernel
-#undef bpf_map_lookup_elem
-#undef bpf_map_update_elem
+    return -1;
+}
 
 // obi_msg_name_port rejects a shorter msg_namelen, so a stub disagreeing with
 // the kernel layout would move the boundary the msg_namelen cases pin
@@ -251,36 +277,174 @@ static void test_is_dns_msg_rejects_unconnected_without_msg_name(void) {
     check_u8("an unclassifiable answer falls through", 0, is_dns_msg(&conn, NULL));
 }
 
-// unconn_dns_socks
+// classify_dns_msg tri-state
 
-static void test_unconn_sock_is_not_recorded_by_default(void) {
-    mock_map_reset();
+static void test_classify_reports_unknown_without_msg_name(void) {
+    connection_info_t conn = {.s_port = 40100, .d_port = 0};
 
-    check_u8("an unseen socket is not a DNS socket", 0, obi_is_unconn_dns_sock((void *)0x1000));
+    check_u8("an unclassifiable unconnected receive is unknown",
+             k_dns_msg_unknown,
+             classify_dns_msg(&conn, NULL));
 }
 
-static void test_unconn_sock_round_trips(void) {
-    mock_map_reset();
-    obi_note_unconn_dns_sock((void *)0x1000);
+static void test_classify_reports_no_for_explicit_non_dns_peer(void) {
+    // a positive non-DNS answer, which must veto the socket tier
+    connection_info_t conn = {.s_port = 40100, .d_port = 0};
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 8125);
+    struct msghdr msg = msg_with_addr(&sa, sizeof(sa));
 
-    check_u8("a noted socket is recognized", 1, obi_is_unconn_dns_sock((void *)0x1000));
+    check_u8("an explicit non-DNS msg_name port is a positive no",
+             k_dns_msg_no,
+             classify_dns_msg(&conn, &msg));
+}
+
+static void test_classify_reports_no_for_connected_non_dns_peer(void) {
+    connection_info_t conn = {.s_port = 40100, .d_port = 8080};
+
+    check_u8(
+        "a connected non-DNS peer is a positive no", k_dns_msg_no, classify_dns_msg(&conn, NULL));
+}
+
+// unconn_dns_socks
+
+// the local endpoint of an unconnected resolver socket, as parse_sock_info
+// reports it before the tuple is sorted
+static connection_info_t local_endpoint(u16 port, u8 last_octet) {
+    connection_info_t conn = {.s_port = port, .d_port = 0};
+    conn.s_addr[15] = last_octet;
+    return conn;
+}
+
+static void test_unconn_sock_has_no_outstanding_query_by_default(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+
+    check_u8("an unseen socket has no answer to claim",
+             0,
+             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+}
+
+static void test_unconn_sock_answer_is_claimed_once(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &conn);
+
+    check_u8("the answer to an outstanding query is claimed",
+             1,
+             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+
+    // the query is no longer outstanding, so later traffic is not DNS by default
+    check_u8(
+        "a second receive claims nothing", 0, obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+}
+
+static void test_unconn_sock_claims_match_outstanding_queries(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &conn);
+    obi_note_unconn_dns_query((void *)0x1000, &conn);
+
+    check_u8("the first of two answers is claimed",
+             1,
+             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+    check_u8("the second of two answers is claimed",
+             1,
+             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+    check_u8(
+        "a third receive claims nothing", 0, obi_claim_unconn_dns_answer((void *)0x1000, &conn));
 }
 
 static void test_unconn_sock_does_not_match_other_sockets(void) {
-    // the recv-side tier keys on socket identity, so a second resolver socket
-    // must not inherit the first one's classification
     mock_map_reset();
-    obi_note_unconn_dns_sock((void *)0x1000);
+    connection_info_t conn = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &conn);
 
-    check_u8("a different socket is unaffected", 0, obi_is_unconn_dns_sock((void *)0x2000));
+    check_u8(
+        "a different socket is unaffected", 0, obi_claim_unconn_dns_answer((void *)0x2000, &conn));
 }
 
-static void test_unconn_sock_note_is_idempotent(void) {
+static void test_unconn_sock_rejects_a_recycled_pointer(void) {
+    // the kernel freed the resolver socket and handed the same address to an
+    // unrelated socket, which binds a different local endpoint
     mock_map_reset();
-    obi_note_unconn_dns_sock((void *)0x1000);
-    obi_note_unconn_dns_sock((void *)0x1000);
+    connection_info_t resolver = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &resolver);
 
-    check_u8("re-noting a socket keeps it recognized", 1, obi_is_unconn_dns_sock((void *)0x1000));
+    connection_info_t recycled = local_endpoint(51000, 10);
+
+    check_u8("a recycled sock pointer does not inherit the classification",
+             0,
+             obi_claim_unconn_dns_answer((void *)0x1000, &recycled));
+
+    // the stale entry is dropped, so the original endpoint cannot claim either
+    check_u8("the stale entry is retired on the mismatch",
+             0,
+             obi_claim_unconn_dns_answer((void *)0x1000, &resolver));
+}
+
+static void test_unconn_sock_rejects_a_different_local_address(void) {
+    mock_map_reset();
+    connection_info_t resolver = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &resolver);
+
+    connection_info_t other_addr = local_endpoint(40100, 11);
+
+    check_u8("a matching port on a different local address does not claim",
+             0,
+             obi_claim_unconn_dns_answer((void *)0x1000, &other_addr));
+}
+
+static void test_unconn_sock_answer_expires(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &conn);
+
+    test_now_ns = k_unconn_dns_answer_timeout_ns + 1;
+
+    check_u8("an answer arriving after the timeout is not claimed",
+             0,
+             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+}
+
+static void test_unconn_sock_answer_within_timeout_is_claimed(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &conn);
+
+    test_now_ns = k_unconn_dns_answer_timeout_ns;
+
+    check_u8("an answer arriving on the timeout boundary is claimed",
+             1,
+             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+}
+
+static void test_unconn_sock_pending_is_bounded(void) {
+    // answers that never arrive must not let one socket accumulate credit
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+
+    for (int i = 0; i < k_unconn_dns_max_pending * 4; i++) {
+        obi_note_unconn_dns_query((void *)0x1000, &conn);
+    }
+
+    for (int i = 0; i < k_unconn_dns_max_pending; i++) {
+        check_u8("a bounded outstanding query is claimed",
+                 1,
+                 obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+    }
+
+    check_u8(
+        "outstanding queries are capped", 0, obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+}
+
+static void test_unconn_sock_is_forgotten_on_demand(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &conn);
+    obi_forget_unconn_dns_sock((void *)0x1000);
+
+    check_u8(
+        "a forgotten socket claims nothing", 0, obi_claim_unconn_dns_answer((void *)0x1000, &conn));
 }
 
 int main(void) {
@@ -299,10 +463,20 @@ int main(void) {
     test_is_dns_msg_ignores_msg_name_when_peer_is_known();
     test_is_dns_msg_rejects_unconnected_without_msg_name();
 
-    test_unconn_sock_is_not_recorded_by_default();
-    test_unconn_sock_round_trips();
+    test_classify_reports_unknown_without_msg_name();
+    test_classify_reports_no_for_explicit_non_dns_peer();
+    test_classify_reports_no_for_connected_non_dns_peer();
+
+    test_unconn_sock_has_no_outstanding_query_by_default();
+    test_unconn_sock_answer_is_claimed_once();
+    test_unconn_sock_claims_match_outstanding_queries();
     test_unconn_sock_does_not_match_other_sockets();
-    test_unconn_sock_note_is_idempotent();
+    test_unconn_sock_rejects_a_recycled_pointer();
+    test_unconn_sock_rejects_a_different_local_address();
+    test_unconn_sock_answer_expires();
+    test_unconn_sock_answer_within_timeout_is_claimed();
+    test_unconn_sock_pending_is_bounded();
+    test_unconn_sock_is_forgotten_on_demand();
 
     if (failures > 0) {
         fprintf(stderr, "%d test(s) failed\n", failures);

--- a/bpf/tests/bpf_dns_unconnected.c
+++ b/bpf/tests/bpf_dns_unconnected.c
@@ -306,6 +306,75 @@ static void test_classify_reports_no_for_connected_non_dns_peer(void) {
         "a connected non-DNS peer is a positive no", k_dns_msg_no, classify_dns_msg(&conn, NULL));
 }
 
+// is_mdns_exchange
+//
+// Multicast DNS runs 5353 to 5353, and only that relaxes what a query may
+// carry. Holding 5353 at one end proves nothing: the port is unprivileged, and
+// a site that widens ip_local_port_range down to 1024 lets the kernel hand it
+// to an arbitrary client as an ephemeral source port.
+
+static void test_mdns_exchange_accepts_both_ends_on_the_mdns_port(void) {
+    connection_info_t conn = {.s_port = 5353, .d_port = 5353};
+
+    check_u8("5353 at both ends is multicast DNS", 1, is_mdns_exchange(&conn, NULL));
+}
+
+// a compliant querier's sendto(), where the socket carries no peer
+static void test_mdns_exchange_accepts_an_unconnected_peer_on_the_mdns_port(void) {
+    connection_info_t conn = {.s_port = 5353, .d_port = 0};
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 5353);
+    struct msghdr msg = msg_with_addr(&sa, sizeof(sa));
+
+    check_u8("an unconnected socket whose msg_name names 5353 is multicast DNS",
+             1,
+             is_mdns_exchange(&conn, &msg));
+}
+
+// the case the tightening exists for: 5353 held locally, peer somewhere else
+static void test_mdns_exchange_rejects_a_local_port_with_an_unrelated_peer(void) {
+    connection_info_t conn = {.s_port = 5353, .d_port = 0};
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 9999);
+    struct msghdr msg = msg_with_addr(&sa, sizeof(sa));
+
+    check_u8("holding 5353 locally while talking to another port is not multicast DNS",
+             0,
+             is_mdns_exchange(&conn, &msg));
+}
+
+static void test_mdns_exchange_rejects_a_connected_non_mdns_peer(void) {
+    connection_info_t conn = {.s_port = 5353, .d_port = 9999};
+
+    check_u8(
+        "a tuple naming a non-mDNS peer is not multicast DNS", 0, is_mdns_exchange(&conn, NULL));
+}
+
+// RFC 6762 §5.1: a one-shot querier must not send from 5353, and is explicitly
+// not a compliant querier, so it does not emit the forms the relaxation admits
+static void test_mdns_exchange_rejects_a_one_shot_querier(void) {
+    connection_info_t conn = {.s_port = 40100, .d_port = 0};
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 5353);
+    struct msghdr msg = msg_with_addr(&sa, sizeof(sa));
+
+    check_u8("an ephemeral source port querying 5353 is not multicast DNS",
+             0,
+             is_mdns_exchange(&conn, &msg));
+}
+
+// a receive that gave the kernel no address buffer, so the peer is unknowable
+static void test_mdns_exchange_rejects_an_unnamed_peer(void) {
+    connection_info_t conn = {.s_port = 5353, .d_port = 0};
+
+    check_u8("an unnamed peer leaves the exchange unproven, so it is not multicast DNS",
+             0,
+             is_mdns_exchange(&conn, NULL));
+}
+
+static void test_mdns_exchange_rejects_ordinary_unicast_dns(void) {
+    connection_info_t conn = {.s_port = 40100, .d_port = 53};
+
+    check_u8("a unicast resolver exchange is not multicast DNS", 0, is_mdns_exchange(&conn, NULL));
+}
+
 // dns_header_is_plausible
 //
 // The socket-identity tier admits payloads whose only evidence is the socket
@@ -854,6 +923,14 @@ int main(void) {
     test_classify_reports_unknown_without_msg_name();
     test_classify_reports_no_for_explicit_non_dns_peer();
     test_classify_reports_no_for_connected_non_dns_peer();
+
+    test_mdns_exchange_accepts_both_ends_on_the_mdns_port();
+    test_mdns_exchange_accepts_an_unconnected_peer_on_the_mdns_port();
+    test_mdns_exchange_rejects_a_local_port_with_an_unrelated_peer();
+    test_mdns_exchange_rejects_a_connected_non_mdns_peer();
+    test_mdns_exchange_rejects_a_one_shot_querier();
+    test_mdns_exchange_rejects_an_unnamed_peer();
+    test_mdns_exchange_rejects_ordinary_unicast_dns();
 
     test_header_accepts_a_real_query();
     test_header_accepts_a_real_response();

--- a/bpf/tests/bpf_dns_unconnected.c
+++ b/bpf/tests/bpf_dns_unconnected.c
@@ -374,24 +374,44 @@ static void test_unconn_sock_does_not_match_other_sockets(void) {
              obi_unconn_dns_answer_expected((void *)0x2000, &conn));
 }
 
-// The socket is reused for unrelated traffic while a DNS answer could still
-// arrive. The non-DNS send retires the window, so a later nameless datagram is
-// not reported as DNS.
-static void test_unconn_sock_non_dns_send_retires_the_window(void) {
+// A resolver socket carries unrelated traffic while a query is still
+// outstanding: DNS query -> non-DNS send -> nameless DNS answer. The
+// intervening send says nothing about the query already in flight, so the
+// window has to survive it or the answer is lost.
+static void test_unconn_sock_non_dns_send_preserves_the_window(void) {
     mock_map_reset();
     connection_info_t conn = local_endpoint(40100, 10);
     obi_note_unconn_dns_query((void *)0x1000, &conn);
 
-    // classify_dns_msg returned k_dns_msg_no for the next datagram on this socket
+    // classify_dns_msg returns k_dns_msg_no for the intervening send, and the
+    // send path acts on that by declining to report it, nothing more
     struct sockaddr_in statsd = inet_addr_port(AF_INET, 8125);
     struct msghdr non_dns = msg_with_addr(&statsd, sizeof(statsd));
     check_u8("the intervening send is a positive non-DNS",
              k_dns_msg_no,
              classify_dns_msg(&conn, &non_dns));
-    obi_forget_unconn_dns_sock((void *)0x1000);
 
-    check_u8("a nameless datagram after a non-DNS send is not expected as DNS",
-             0,
+    check_u8("the answer is still expected after an unrelated send",
+             1,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
+}
+
+// The symmetric loss on the receive path: DNS query -> non-DNS receive that
+// names its peer -> nameless DNS answer. The named receive is classified and
+// discarded on its own merits, and must not take the outstanding query with it.
+static void test_unconn_sock_non_dns_receive_preserves_the_window(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &conn);
+
+    struct sockaddr_in statsd = inet_addr_port(AF_INET, 8125);
+    struct msghdr non_dns = msg_with_addr(&statsd, sizeof(statsd));
+    check_u8("the intervening receive is a positive non-DNS",
+             k_dns_msg_no,
+             classify_dns_msg(&conn, &non_dns));
+
+    check_u8("the answer is still expected after an unrelated receive",
+             1,
              obi_unconn_dns_answer_expected((void *)0x1000, &conn));
 }
 
@@ -520,7 +540,8 @@ int main(void) {
     test_unconn_sock_expects_every_parallel_answer();
     test_unconn_sock_unparsed_receive_does_not_spend_the_window();
     test_unconn_sock_does_not_match_other_sockets();
-    test_unconn_sock_non_dns_send_retires_the_window();
+    test_unconn_sock_non_dns_send_preserves_the_window();
+    test_unconn_sock_non_dns_receive_preserves_the_window();
     test_unconn_sock_query_refreshes_the_window();
     test_unconn_sock_rejects_a_recycled_pointer();
     test_unconn_sock_rejects_a_recycled_pointer_at_the_same_endpoint();

--- a/bpf/tests/bpf_dns_unconnected.c
+++ b/bpf/tests/bpf_dns_unconnected.c
@@ -315,43 +315,53 @@ static connection_info_t local_endpoint(u16 port, u8 last_octet) {
     return conn;
 }
 
-static void test_unconn_sock_has_no_outstanding_query_by_default(void) {
+static void test_unconn_sock_has_no_expected_answer_by_default(void) {
     mock_map_reset();
     connection_info_t conn = local_endpoint(40100, 10);
 
-    check_u8("an unseen socket has no answer to claim",
+    check_u8("no answer is expected on an unseen socket",
              0,
-             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
 }
 
-static void test_unconn_sock_answer_is_claimed_once(void) {
+static void test_unconn_sock_answer_is_expected_after_a_query(void) {
     mock_map_reset();
     connection_info_t conn = local_endpoint(40100, 10);
     obi_note_unconn_dns_query((void *)0x1000, &conn);
 
-    check_u8("the answer to an outstanding query is claimed",
+    check_u8("an answer is expected after a query",
              1,
-             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
-
-    // the query is no longer outstanding, so later traffic is not DNS by default
-    check_u8(
-        "a second receive claims nothing", 0, obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
 }
 
-static void test_unconn_sock_claims_match_outstanding_queries(void) {
+// musl resolves A and AAAA in parallel on one socket, so consuming the window on
+// the first answer would leave the second unclassified
+static void test_unconn_sock_expects_every_parallel_answer(void) {
     mock_map_reset();
     connection_info_t conn = local_endpoint(40100, 10);
     obi_note_unconn_dns_query((void *)0x1000, &conn);
+
+    check_u8("the first parallel answer is expected",
+             1,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
+    check_u8("the second parallel answer is still expected",
+             1,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
+}
+
+// A datagram too short to parse, or one whose iovec could not be read, must not
+// spend the window that the real answer still needs
+static void test_unconn_sock_unparsed_receive_does_not_spend_the_window(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
     obi_note_unconn_dns_query((void *)0x1000, &conn);
 
-    check_u8("the first of two answers is claimed",
+    // the caller looked, then failed to read or parse the payload
+    obi_unconn_dns_answer_expected((void *)0x1000, &conn);
+
+    check_u8("the window survives a receive that never parsed",
              1,
-             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
-    check_u8("the second of two answers is claimed",
-             1,
-             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
-    check_u8(
-        "a third receive claims nothing", 0, obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
 }
 
 static void test_unconn_sock_does_not_match_other_sockets(void) {
@@ -359,8 +369,46 @@ static void test_unconn_sock_does_not_match_other_sockets(void) {
     connection_info_t conn = local_endpoint(40100, 10);
     obi_note_unconn_dns_query((void *)0x1000, &conn);
 
-    check_u8(
-        "a different socket is unaffected", 0, obi_claim_unconn_dns_answer((void *)0x2000, &conn));
+    check_u8("a different socket is unaffected",
+             0,
+             obi_unconn_dns_answer_expected((void *)0x2000, &conn));
+}
+
+// The socket is reused for unrelated traffic while a DNS answer could still
+// arrive. The non-DNS send retires the window, so a later nameless datagram is
+// not reported as DNS.
+static void test_unconn_sock_non_dns_send_retires_the_window(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &conn);
+
+    // classify_dns_msg returned k_dns_msg_no for the next datagram on this socket
+    struct sockaddr_in statsd = inet_addr_port(AF_INET, 8125);
+    struct msghdr non_dns = msg_with_addr(&statsd, sizeof(statsd));
+    check_u8("the intervening send is a positive non-DNS",
+             k_dns_msg_no,
+             classify_dns_msg(&conn, &non_dns));
+    obi_forget_unconn_dns_sock((void *)0x1000);
+
+    check_u8("a nameless datagram after a non-DNS send is not expected as DNS",
+             0,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
+}
+
+static void test_unconn_sock_query_refreshes_the_window(void) {
+    mock_map_reset();
+    connection_info_t conn = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &conn);
+
+    // a second lookup, issued just before the first window would lapse
+    test_now_ns = k_unconn_dns_answer_timeout_ns;
+    obi_note_unconn_dns_query((void *)0x1000, &conn);
+
+    test_now_ns += k_unconn_dns_answer_timeout_ns;
+
+    check_u8("a later query extends the window",
+             1,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
 }
 
 static void test_unconn_sock_rejects_a_recycled_pointer(void) {
@@ -374,12 +422,12 @@ static void test_unconn_sock_rejects_a_recycled_pointer(void) {
 
     check_u8("a recycled sock pointer does not inherit the classification",
              0,
-             obi_claim_unconn_dns_answer((void *)0x1000, &recycled));
+             obi_unconn_dns_answer_expected((void *)0x1000, &recycled));
 
-    // the stale entry is dropped, so the original endpoint cannot claim either
+    // the stale entry is dropped, so the original endpoint expects nothing either
     check_u8("the stale entry is retired on the mismatch",
              0,
-             obi_claim_unconn_dns_answer((void *)0x1000, &resolver));
+             obi_unconn_dns_answer_expected((void *)0x1000, &resolver));
 }
 
 static void test_unconn_sock_rejects_a_different_local_address(void) {
@@ -389,9 +437,9 @@ static void test_unconn_sock_rejects_a_different_local_address(void) {
 
     connection_info_t other_addr = local_endpoint(40100, 11);
 
-    check_u8("a matching port on a different local address does not claim",
+    check_u8("a matching port on a different local address expects nothing",
              0,
-             obi_claim_unconn_dns_answer((void *)0x1000, &other_addr));
+             obi_unconn_dns_answer_expected((void *)0x1000, &other_addr));
 }
 
 static void test_unconn_sock_answer_expires(void) {
@@ -401,40 +449,21 @@ static void test_unconn_sock_answer_expires(void) {
 
     test_now_ns = k_unconn_dns_answer_timeout_ns + 1;
 
-    check_u8("an answer arriving after the timeout is not claimed",
+    check_u8("an answer arriving after the timeout is not expected",
              0,
-             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
 }
 
-static void test_unconn_sock_answer_within_timeout_is_claimed(void) {
+static void test_unconn_sock_answer_within_timeout_is_expected(void) {
     mock_map_reset();
     connection_info_t conn = local_endpoint(40100, 10);
     obi_note_unconn_dns_query((void *)0x1000, &conn);
 
     test_now_ns = k_unconn_dns_answer_timeout_ns;
 
-    check_u8("an answer arriving on the timeout boundary is claimed",
+    check_u8("an answer arriving on the timeout boundary is expected",
              1,
-             obi_claim_unconn_dns_answer((void *)0x1000, &conn));
-}
-
-static void test_unconn_sock_pending_is_bounded(void) {
-    // answers that never arrive must not let one socket accumulate credit
-    mock_map_reset();
-    connection_info_t conn = local_endpoint(40100, 10);
-
-    for (int i = 0; i < k_unconn_dns_max_pending * 4; i++) {
-        obi_note_unconn_dns_query((void *)0x1000, &conn);
-    }
-
-    for (int i = 0; i < k_unconn_dns_max_pending; i++) {
-        check_u8("a bounded outstanding query is claimed",
-                 1,
-                 obi_claim_unconn_dns_answer((void *)0x1000, &conn));
-    }
-
-    check_u8(
-        "outstanding queries are capped", 0, obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
 }
 
 static void test_unconn_sock_is_forgotten_on_demand(void) {
@@ -443,8 +472,9 @@ static void test_unconn_sock_is_forgotten_on_demand(void) {
     obi_note_unconn_dns_query((void *)0x1000, &conn);
     obi_forget_unconn_dns_sock((void *)0x1000);
 
-    check_u8(
-        "a forgotten socket claims nothing", 0, obi_claim_unconn_dns_answer((void *)0x1000, &conn));
+    check_u8("a forgotten socket expects nothing",
+             0,
+             obi_unconn_dns_answer_expected((void *)0x1000, &conn));
 }
 
 int main(void) {
@@ -467,15 +497,17 @@ int main(void) {
     test_classify_reports_no_for_explicit_non_dns_peer();
     test_classify_reports_no_for_connected_non_dns_peer();
 
-    test_unconn_sock_has_no_outstanding_query_by_default();
-    test_unconn_sock_answer_is_claimed_once();
-    test_unconn_sock_claims_match_outstanding_queries();
+    test_unconn_sock_has_no_expected_answer_by_default();
+    test_unconn_sock_answer_is_expected_after_a_query();
+    test_unconn_sock_expects_every_parallel_answer();
+    test_unconn_sock_unparsed_receive_does_not_spend_the_window();
     test_unconn_sock_does_not_match_other_sockets();
+    test_unconn_sock_non_dns_send_retires_the_window();
+    test_unconn_sock_query_refreshes_the_window();
     test_unconn_sock_rejects_a_recycled_pointer();
     test_unconn_sock_rejects_a_different_local_address();
     test_unconn_sock_answer_expires();
-    test_unconn_sock_answer_within_timeout_is_claimed();
-    test_unconn_sock_pending_is_bounded();
+    test_unconn_sock_answer_within_timeout_is_expected();
     test_unconn_sock_is_forgotten_on_demand();
 
     if (failures > 0) {

--- a/bpf/tests/bpf_dns_unconnected.c
+++ b/bpf/tests/bpf_dns_unconnected.c
@@ -430,6 +430,24 @@ static void test_unconn_sock_rejects_a_recycled_pointer(void) {
              obi_unconn_dns_answer_expected((void *)0x1000, &resolver));
 }
 
+// The endpoint check cannot see this one: the replacement socket binds exactly
+// what the resolver had, so only retiring the entry when the socket is destroyed
+// keeps the new socket from inheriting the classification. obi_kprobe_udp_destroy_sock
+// is what calls obi_forget_unconn_dns_sock in the tracer.
+static void test_unconn_sock_rejects_a_recycled_pointer_at_the_same_endpoint(void) {
+    mock_map_reset();
+    connection_info_t resolver = local_endpoint(40100, 10);
+    obi_note_unconn_dns_query((void *)0x1000, &resolver);
+
+    // the resolver socket is destroyed, and a new socket lands on the same
+    // address and rebinds the identical local endpoint inside the window
+    obi_forget_unconn_dns_sock((void *)0x1000);
+
+    check_u8("a socket recycled at the identical endpoint expects nothing",
+             0,
+             obi_unconn_dns_answer_expected((void *)0x1000, &resolver));
+}
+
 static void test_unconn_sock_rejects_a_different_local_address(void) {
     mock_map_reset();
     connection_info_t resolver = local_endpoint(40100, 10);
@@ -505,6 +523,7 @@ int main(void) {
     test_unconn_sock_non_dns_send_retires_the_window();
     test_unconn_sock_query_refreshes_the_window();
     test_unconn_sock_rejects_a_recycled_pointer();
+    test_unconn_sock_rejects_a_recycled_pointer_at_the_same_endpoint();
     test_unconn_sock_rejects_a_different_local_address();
     test_unconn_sock_answer_expires();
     test_unconn_sock_answer_within_timeout_is_expected();

--- a/bpf/tests/bpf_dns_unconnected.c
+++ b/bpf/tests/bpf_dns_unconnected.c
@@ -1,0 +1,313 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Unconnected-UDP DNS classification in generictracer/dns.h: obi_msg_name_port,
+// is_dns_msg and the unconn_dns_socks helpers. An unconnected resolver socket
+// carries no peer in its tuple (d_port == 0), so :53 is only in msg_name.
+//
+// Run from repo root:
+//   make -C bpf/tests bpf_dns_unconnected && bpf/tests/bpf_dns_unconnected
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+// Called by the dns.h include chain, omitted by the shared stub
+#define BPF_ANY 0
+
+static inline u64 bpf_ktime_get_ns(void) {
+    return 0;
+}
+
+static inline u32 bpf_get_prandom_u32(void) {
+    return 0;
+}
+
+static inline long bpf_loop(u32 nr_loops, void *cb, void *ctx, u64 flags) {
+    return 0;
+}
+
+static inline long bpf_skb_load_bytes(const void *skb, u32 offset, void *to, u32 len) {
+    return 0;
+}
+
+// The shared stubs no-op every read and map lookup, so the classifier is given
+// live mocks below and they are macro-shadowed over the include.
+
+// Host-resident structs, so a direct field access stands in for the CO-RE read
+#define BPF_CORE_READ_INTO(dst, src, field) (*(dst) = (src)->field)
+
+// Returns an error on a NULL source rather than faulting the test process
+static long test_probe_read_kernel(void *dst, u32 size, const void *src) {
+    if (!src) {
+        return -1;
+    }
+    memcpy(dst, src, size);
+    return 0;
+}
+
+// Stands in for the unconn_dns_socks LRU map; membership only, no eviction
+enum { k_mock_map_capacity = 8 };
+
+static struct {
+    u64 keys[k_mock_map_capacity];
+    u8 values[k_mock_map_capacity];
+    bool used[k_mock_map_capacity];
+} test_map;
+
+static void mock_map_reset(void) {
+    memset(&test_map, 0, sizeof(test_map));
+}
+
+static void *test_map_lookup(void *map, const void *key) {
+    (void)map;
+    const u64 k = *(const u64 *)key;
+
+    for (int i = 0; i < k_mock_map_capacity; i++) {
+        if (test_map.used[i] && test_map.keys[i] == k) {
+            return &test_map.values[i];
+        }
+    }
+
+    return NULL;
+}
+
+static long test_map_update(void *map, const void *key, const void *value, u64 flags) {
+    (void)map;
+    (void)flags;
+    const u64 k = *(const u64 *)key;
+
+    for (int i = 0; i < k_mock_map_capacity; i++) {
+        if (test_map.used[i] && test_map.keys[i] == k) {
+            test_map.values[i] = *(const u8 *)value;
+            return 0;
+        }
+    }
+
+    for (int i = 0; i < k_mock_map_capacity; i++) {
+        if (!test_map.used[i]) {
+            test_map.used[i] = true;
+            test_map.keys[i] = k;
+            test_map.values[i] = *(const u8 *)value;
+            return 0;
+        }
+    }
+
+    return -1;
+}
+
+#define bpf_probe_read_kernel test_probe_read_kernel
+#define bpf_map_lookup_elem test_map_lookup
+#define bpf_map_update_elem test_map_update
+
+#include <generictracer/dns.h>
+
+#undef bpf_probe_read_kernel
+#undef bpf_map_lookup_elem
+#undef bpf_map_update_elem
+
+// obi_msg_name_port rejects a shorter msg_namelen, so a stub disagreeing with
+// the kernel layout would move the boundary the msg_namelen cases pin
+_Static_assert(sizeof(struct sockaddr_in) == 16, "sockaddr_in must match the kernel layout");
+
+// Test harness
+
+static int failures = 0;
+
+static void check_u16(const char *name, u16 expected, u16 actual) {
+    if (expected != actual) {
+        fprintf(stderr, "FAIL: %s\n  expected %u, got %u\n", name, expected, actual);
+        failures++;
+        return;
+    }
+    printf("ok: %s\n", name);
+}
+
+static void check_u8(const char *name, u8 expected, u8 actual) {
+    if (expected != actual) {
+        fprintf(stderr, "FAIL: %s\n  expected %u, got %u\n", name, expected, actual);
+        failures++;
+        return;
+    }
+    printf("ok: %s\n", name);
+}
+
+// msg_name as the kernel presents it: the sockaddr passed to sendto(), or the
+// source address filled in on recvmsg() return
+static struct msghdr msg_with_addr(struct sockaddr_in *sa, int namelen) {
+    struct msghdr msg = {
+        .msg_name = sa,
+        .msg_namelen = namelen,
+    };
+    return msg;
+}
+
+static struct sockaddr_in inet_addr_port(u16 family, u16 port) {
+    struct sockaddr_in sa = {0};
+    sa.sin_family = family;
+    sa.sin_port = bpf_htons(port);
+    return sa;
+}
+
+// obi_msg_name_port
+
+static void test_msg_name_port_reads_ipv4_peer_port(void) {
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 53);
+    struct msghdr msg = msg_with_addr(&sa, sizeof(sa));
+
+    check_u16("msg_name port is read in host order", 53, obi_msg_name_port(&msg));
+}
+
+static void test_msg_name_port_reads_non_dns_port_unchanged(void) {
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 8080);
+    struct msghdr msg = msg_with_addr(&sa, sizeof(sa));
+
+    check_u16("a non-DNS peer port is reported as-is", 8080, obi_msg_name_port(&msg));
+}
+
+static void test_msg_name_port_rejects_null_msghdr(void) {
+    check_u16("a NULL msghdr yields no port", 0, obi_msg_name_port(NULL));
+}
+
+static void test_msg_name_port_rejects_absent_name(void) {
+    // empty recv-side msg_name, as Netty leaves it; the socket-identity tier
+    // covers this case
+    struct msghdr msg = msg_with_addr(NULL, sizeof(struct sockaddr_in));
+
+    check_u16("an absent msg_name yields no port", 0, obi_msg_name_port(&msg));
+}
+
+static void test_msg_name_port_rejects_short_namelen(void) {
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 53);
+    struct msghdr msg = msg_with_addr(&sa, (int)sizeof(sa) - 1);
+
+    check_u16("a short msg_namelen yields no port", 0, obi_msg_name_port(&msg));
+}
+
+static void test_msg_name_port_rejects_negative_namelen(void) {
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 53);
+    struct msghdr msg = msg_with_addr(&sa, -1);
+
+    check_u16("a negative msg_namelen yields no port", 0, obi_msg_name_port(&msg));
+}
+
+static void test_msg_name_port_rejects_non_ipv4_family(void) {
+    // stated scope limit: IPv6 DNS transport is not handled
+    struct sockaddr_in sa = inet_addr_port(AF_INET6, 53);
+    struct msghdr msg = msg_with_addr(&sa, sizeof(sa));
+
+    check_u16("a non-AF_INET msg_name yields no port", 0, obi_msg_name_port(&msg));
+}
+
+// is_dns_msg
+
+static void test_is_dns_msg_uses_tuple_fast_path(void) {
+    connection_info_t conn = {.s_port = 40100, .d_port = 53};
+
+    // tuple already names :53, so msg_name is never consulted
+    check_u8("a connected socket is classified from the tuple", 1, is_dns_msg(&conn, NULL));
+}
+
+static void test_is_dns_msg_classifies_unconnected_query(void) {
+    // musl's resolver: bind() + sendto(), so :53 is only in msg_name
+    connection_info_t conn = {.s_port = 40100, .d_port = 0};
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 53);
+    struct msghdr msg = msg_with_addr(&sa, sizeof(sa));
+
+    check_u8("an unconnected DNS query is classified via msg_name", 1, is_dns_msg(&conn, &msg));
+}
+
+static void test_is_dns_msg_classifies_mdns_port(void) {
+    connection_info_t conn = {.s_port = 40100, .d_port = 0};
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 5353);
+    struct msghdr msg = msg_with_addr(&sa, sizeof(sa));
+
+    check_u8("port 5353 is classified as DNS", 1, is_dns_msg(&conn, &msg));
+}
+
+static void test_is_dns_msg_rejects_unconnected_non_dns(void) {
+    connection_info_t conn = {.s_port = 40100, .d_port = 0};
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 8125);
+    struct msghdr msg = msg_with_addr(&sa, sizeof(sa));
+
+    check_u8("unconnected non-DNS UDP is not classified", 0, is_dns_msg(&conn, &msg));
+}
+
+static void test_is_dns_msg_ignores_msg_name_when_peer_is_known(void) {
+    // a connected socket, so :53 in msg_name must not override the tuple
+    connection_info_t conn = {.s_port = 40100, .d_port = 8080};
+    struct sockaddr_in sa = inet_addr_port(AF_INET, 53);
+    struct msghdr msg = msg_with_addr(&sa, sizeof(sa));
+
+    check_u8("msg_name is not consulted for a connected socket", 0, is_dns_msg(&conn, &msg));
+}
+
+static void test_is_dns_msg_rejects_unconnected_without_msg_name(void) {
+    connection_info_t conn = {.s_port = 40100, .d_port = 0};
+
+    check_u8("an unclassifiable answer falls through", 0, is_dns_msg(&conn, NULL));
+}
+
+// unconn_dns_socks
+
+static void test_unconn_sock_is_not_recorded_by_default(void) {
+    mock_map_reset();
+
+    check_u8("an unseen socket is not a DNS socket", 0, obi_is_unconn_dns_sock((void *)0x1000));
+}
+
+static void test_unconn_sock_round_trips(void) {
+    mock_map_reset();
+    obi_note_unconn_dns_sock((void *)0x1000);
+
+    check_u8("a noted socket is recognized", 1, obi_is_unconn_dns_sock((void *)0x1000));
+}
+
+static void test_unconn_sock_does_not_match_other_sockets(void) {
+    // the recv-side tier keys on socket identity, so a second resolver socket
+    // must not inherit the first one's classification
+    mock_map_reset();
+    obi_note_unconn_dns_sock((void *)0x1000);
+
+    check_u8("a different socket is unaffected", 0, obi_is_unconn_dns_sock((void *)0x2000));
+}
+
+static void test_unconn_sock_note_is_idempotent(void) {
+    mock_map_reset();
+    obi_note_unconn_dns_sock((void *)0x1000);
+    obi_note_unconn_dns_sock((void *)0x1000);
+
+    check_u8("re-noting a socket keeps it recognized", 1, obi_is_unconn_dns_sock((void *)0x1000));
+}
+
+int main(void) {
+    test_msg_name_port_reads_ipv4_peer_port();
+    test_msg_name_port_reads_non_dns_port_unchanged();
+    test_msg_name_port_rejects_null_msghdr();
+    test_msg_name_port_rejects_absent_name();
+    test_msg_name_port_rejects_short_namelen();
+    test_msg_name_port_rejects_negative_namelen();
+    test_msg_name_port_rejects_non_ipv4_family();
+
+    test_is_dns_msg_uses_tuple_fast_path();
+    test_is_dns_msg_classifies_unconnected_query();
+    test_is_dns_msg_classifies_mdns_port();
+    test_is_dns_msg_rejects_unconnected_non_dns();
+    test_is_dns_msg_ignores_msg_name_when_peer_is_known();
+    test_is_dns_msg_rejects_unconnected_without_msg_name();
+
+    test_unconn_sock_is_not_recorded_by_default();
+    test_unconn_sock_round_trips();
+    test_unconn_sock_does_not_match_other_sockets();
+    test_unconn_sock_note_is_idempotent();
+
+    if (failures > 0) {
+        fprintf(stderr, "%d test(s) failed\n", failures);
+        return 1;
+    }
+    printf("all unconnected DNS classification tests passed\n");
+    return 0;
+}

--- a/bpf/tests/bpf_dns_unconnected.c
+++ b/bpf/tests/bpf_dns_unconnected.c
@@ -305,6 +305,152 @@ static void test_classify_reports_no_for_connected_non_dns_peer(void) {
         "a connected non-DNS peer is a positive no", k_dns_msg_no, classify_dns_msg(&conn, NULL));
 }
 
+// dns_header_is_plausible
+//
+// The socket-identity tier admits payloads whose only evidence is the socket
+// they arrived on, and qr is a single bit, so this is the only thing standing
+// between arbitrary bytes on a resolver socket and a reported lookup.
+
+enum : u16 {
+    k_flags_query = 0x0100,    // qr=0, opcode=0, rd=1
+    k_flags_response = 0x8180, // qr=1, opcode=0, rd=1, ra=1, rcode=0
+};
+
+// counts as they sit in a real header, in network byte order
+static struct dnshdr dns_header(u16 flags, u16 qd, u16 an, u16 ns, u16 ar) {
+    struct dnshdr hdr = {
+        .id = bpf_htons(0x4242),
+        .flags = bpf_htons(flags),
+        .qdcount = bpf_htons(qd),
+        .ancount = bpf_htons(an),
+        .nscount = bpf_htons(ns),
+        .arcount = bpf_htons(ar),
+    };
+    return hdr;
+}
+
+// a datagram whose sections comfortably fit whatever the counts claim
+static u32 roomy_size(void) {
+    return sizeof(struct dnshdr) + 512;
+}
+
+static void test_header_accepts_a_real_query(void) {
+    struct dnshdr hdr = dns_header(k_flags_query, 1, 0, 0, 0);
+
+    check_u8("an ordinary query is plausible",
+             1,
+             dns_header_is_plausible(&hdr, k_flags_query, roomy_size()));
+}
+
+static void test_header_accepts_a_real_response(void) {
+    struct dnshdr hdr = dns_header(k_flags_response, 1, 1, 0, 0);
+
+    check_u8("an ordinary response is plausible",
+             1,
+             dns_header_is_plausible(&hdr, k_flags_response, roomy_size()));
+}
+
+// NXDOMAIN and SERVFAIL are lookups worth reporting, so rcode is not a filter
+static void test_header_accepts_an_nxdomain_response(void) {
+    const u16 flags = k_flags_response | 3;
+    struct dnshdr hdr = dns_header(flags, 1, 0, 1, 0);
+
+    check_u8(
+        "an NXDOMAIN response is plausible", 1, dns_header_is_plausible(&hdr, flags, roomy_size()));
+}
+
+// A DNSSEC-aware resolver sets AD and CD on ordinary traffic. RFC 1035 called
+// these part of Z, so treating Z as three bits would drop this answer.
+static void test_header_accepts_dnssec_ad_and_cd(void) {
+    const u16 flags = k_flags_response | (1 << 5) | (1 << 4);
+    struct dnshdr hdr = dns_header(flags, 1, 1, 0, 0);
+
+    check_u8("AD and CD do not make a response implausible",
+             1,
+             dns_header_is_plausible(&hdr, flags, roomy_size()));
+}
+
+// mDNS responses may omit the question section
+static void test_header_accepts_a_response_without_a_question(void) {
+    struct dnshdr hdr = dns_header(k_flags_response, 0, 1, 0, 0);
+
+    check_u8("a response with answers but no question is plausible",
+             1,
+             dns_header_is_plausible(&hdr, k_flags_response, roomy_size()));
+}
+
+static void test_header_rejects_a_non_query_opcode(void) {
+    const u16 flags = k_flags_query | (5 << 11); // UPDATE
+    struct dnshdr hdr = dns_header(flags, 1, 0, 0, 0);
+
+    check_u8("a non-standard opcode is not a lookup",
+             0,
+             dns_header_is_plausible(&hdr, flags, roomy_size()));
+}
+
+static void test_header_rejects_a_set_reserved_bit(void) {
+    const u16 flags = k_flags_response | (1 << 6);
+    struct dnshdr hdr = dns_header(flags, 1, 1, 0, 0);
+
+    check_u8(
+        "the reserved bit must be zero", 0, dns_header_is_plausible(&hdr, flags, roomy_size()));
+}
+
+static void test_header_rejects_a_query_that_asks_nothing(void) {
+    struct dnshdr hdr = dns_header(k_flags_query, 0, 0, 0, 0);
+
+    check_u8("a query with no question is implausible",
+             0,
+             dns_header_is_plausible(&hdr, k_flags_query, roomy_size()));
+}
+
+static void test_header_rejects_a_query_carrying_answers(void) {
+    struct dnshdr hdr = dns_header(k_flags_query, 1, 1, 0, 0);
+
+    check_u8("a query does not answer itself",
+             0,
+             dns_header_is_plausible(&hdr, k_flags_query, roomy_size()));
+}
+
+static void test_header_rejects_an_empty_response(void) {
+    struct dnshdr hdr = dns_header(k_flags_response, 0, 0, 0, 0);
+
+    check_u8("a response with no sections carries no lookup",
+             0,
+             dns_header_is_plausible(&hdr, k_flags_response, roomy_size()));
+}
+
+// The check that does most of the work against arbitrary bytes: random counts
+// describe far more records than the datagram could hold.
+static void test_header_rejects_counts_that_cannot_fit(void) {
+    struct dnshdr hdr = dns_header(k_flags_response, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF);
+
+    check_u8("counts larger than the datagram are implausible",
+             0,
+             dns_header_is_plausible(&hdr, k_flags_response, sizeof(struct dnshdr) + 32));
+}
+
+static void test_header_accepts_counts_that_exactly_fit(void) {
+    // two questions and one answer, and not a byte to spare
+    const u32 size = sizeof(struct dnshdr) + (2 * k_dns_min_question_bytes) + k_dns_min_rr_bytes;
+    struct dnshdr hdr = dns_header(k_flags_response, 2, 1, 0, 0);
+
+    check_u8("sections that exactly fit are plausible",
+             1,
+             dns_header_is_plausible(&hdr, k_flags_response, size));
+}
+
+// A truncated response describes records it never sent, so its counts cannot be
+// held against the bytes on hand
+static void test_header_accepts_a_truncated_response(void) {
+    const u16 flags = k_flags_response | (1 << 9); // TC
+    struct dnshdr hdr = dns_header(flags, 1, 0xFFFF, 0, 0);
+
+    check_u8("a truncated response is not judged on its counts",
+             1,
+             dns_header_is_plausible(&hdr, flags, sizeof(struct dnshdr) + 16));
+}
+
 // unconn_dns_socks
 
 // the local endpoint of an unconnected resolver socket, as parse_sock_info
@@ -534,6 +680,20 @@ int main(void) {
     test_classify_reports_unknown_without_msg_name();
     test_classify_reports_no_for_explicit_non_dns_peer();
     test_classify_reports_no_for_connected_non_dns_peer();
+
+    test_header_accepts_a_real_query();
+    test_header_accepts_a_real_response();
+    test_header_accepts_an_nxdomain_response();
+    test_header_accepts_dnssec_ad_and_cd();
+    test_header_accepts_a_response_without_a_question();
+    test_header_rejects_a_non_query_opcode();
+    test_header_rejects_a_set_reserved_bit();
+    test_header_rejects_a_query_that_asks_nothing();
+    test_header_rejects_a_query_carrying_answers();
+    test_header_rejects_an_empty_response();
+    test_header_rejects_counts_that_cannot_fit();
+    test_header_accepts_counts_that_exactly_fit();
+    test_header_accepts_a_truncated_response();
 
     test_unconn_sock_has_no_expected_answer_by_default();
     test_unconn_sock_answer_is_expected_after_a_query();

--- a/bpf/tests/bpfcore/vmlinux.h
+++ b/bpf/tests/bpfcore/vmlinux.h
@@ -131,6 +131,14 @@ struct iovec {
     void *iov_base;
     size_t iov_len;
 };
+struct msghdr {
+    void *msg_name;
+    int msg_namelen;
+    struct iov_iter msg_iter;
+};
+struct in_addr {
+    u32 s_addr;
+};
 struct udphdr {
     u16 source;
     u16 dest;
@@ -160,6 +168,11 @@ struct __sk_buff {
     u32 len;
     u32 protocol;
 };
-struct msghdr {
-    struct iov_iter msg_iter;
+// 16 bytes, as in bpfcore/vmlinux_*.h; obi_msg_name_port length-checks
+// msg_namelen against sizeof(struct sockaddr_in)
+struct sockaddr_in {
+    u16 sin_family;
+    u16 sin_port;
+    struct in_addr sin_addr;
+    unsigned char __pad[8];
 };

--- a/bpf/tests/bpfcore/vmlinux.h
+++ b/bpf/tests/bpfcore/vmlinux.h
@@ -131,6 +131,35 @@ struct iovec {
     void *iov_base;
     size_t iov_len;
 };
+struct udphdr {
+    u16 source;
+    u16 dest;
+    u16 len;
+    u16 check;
+};
+struct tcphdr {
+    u16 source;
+    u16 dest;
+    u32 seq;
+    u32 ack_seq;
+    u16 res1 : 4;
+    u16 doff : 4;
+    u16 fin : 1;
+    u16 syn : 1;
+    u16 rst : 1;
+    u16 psh : 1;
+    u16 ack : 1;
+    u16 urg : 1;
+    u16 ece : 1;
+    u16 cwr : 1;
+    u16 window;
+    u16 check;
+    u16 urg_ptr;
+};
+struct __sk_buff {
+    u32 len;
+    u32 protocol;
+};
 struct msghdr {
     struct iov_iter msg_iter;
 };

--- a/bpf/tests/bpfcore/vmlinux.h
+++ b/bpf/tests/bpfcore/vmlinux.h
@@ -88,12 +88,6 @@ struct sockaddr {
     u16 sa_family;
 };
 
-struct sockaddr_in {
-    u16 sin_family;
-    u16 sin_port;
-    u32 sin_addr;
-};
-
 struct sockaddr_in6 {
     u16 sin6_family;
     u16 sin6_port;

--- a/bpf/tests/common/trace_parent.h
+++ b/bpf/tests/common/trace_parent.h
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Shadows common/trace_parent.h, whose real include chain pulls in the Go
+// tracer and fourteen map definitions. Parent-trace resolution is not
+// exercised by the host tests, so find_trace_* always reports no match.
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/trace_helpers.h>
+#include <common/trace_key.h>
+
+static __always_inline void
+trace_key_from_pid_tid_with_p_key(trace_key_t *t_key, const pid_key_t *p_key, u64 id) {
+    t_key->p_key = *p_key;
+    t_key->extra_id = id;
+}
+
+static __always_inline u8 find_trace_for_client_request_with_t_key(
+    const void *p_conn, u16 orig_dport, const void *t_key, u64 id, u8 lw_thread, void *tp) {
+    return 0;
+}

--- a/bpf/tests/generictracer/k_tracer_defs.h
+++ b/bpf/tests/generictracer/k_tracer_defs.h
@@ -7,6 +7,15 @@
 
 #include <common/connection_info.h>
 
+// The skb path is not exercised; dependents only need the symbol
+static __always_inline void
+read_skb_bytes(const void *skb, u32 offset, unsigned char *buf, const u32 len) {
+    (void)skb;
+    (void)offset;
+    (void)buf;
+    (void)len;
+}
+
 extern int test_parser_call_count;
 extern int test_last_parser_bytes_len;
 extern u8 test_last_ssl;

--- a/internal/test/integration/components/dnsclient/Dockerfile
+++ b/internal/test/integration/components/dnsclient/Dockerfile
@@ -1,0 +1,12 @@
+# Dockerfile that will build a container resolving names in a loop over musl's
+# unconnected UDP resolver socket. Alpine is required for musl.
+# Docker command must be invoked from the project root directory
+FROM python:3.14-alpine@sha256:a1321512d6a287428c50dcdf2ab3857761127e03a23b1f648e9c1c0de59288f8
+
+WORKDIR /
+
+COPY internal/test/integration/components/dnsclient/dnsclient.py .
+
+USER 0:0
+
+CMD [ "python3", "/dnsclient.py" ]

--- a/internal/test/integration/components/dnsclient/dnsclient.py
+++ b/internal/test/integration/components/dnsclient/dnsclient.py
@@ -100,19 +100,164 @@ def exchange_non_dns(probe):
         print(f"decoy exchange failed error={err}", flush=True)
 
 
+# Interleaving: a resolver socket that carries unrelated traffic while a query
+# is still outstanding. The query goes out, something unrelated happens on the
+# same socket, and only then does the nameless answer arrive. Both sequences
+# have to leave the lookup reportable.
+#
+# The answers come from the delayed responder rather than from the compose
+# resolver, because the interleaved step and the answer would otherwise race:
+# whichever datagram lands first is the one the next receive returns, and the
+# receive-side sequence needs the unrelated datagram to be the one it reads. The
+# responder holds its answer back long enough that the ordering is not a matter
+# of timing.
+#
+# The responder runs in its own container, so its own DNS traffic is outside the
+# instrumented PID namespace and does not appear in the telemetry under test.
+RESPONDER_HOST = "dnsresponder"
+RESPONDER_PORT = 5353
+
+# Long enough that the interleaved step is ordered ahead of the answer by
+# construction: the unrelated datagram travels over loopback and lands in
+# microseconds, so nothing about the ordering rests on timing.
+RESPONDER_DELAY_SECONDS = 0.5
+
+# Answered by the delayed responder, so neither name has to exist in the compose
+# network. A lookup reported under one of these names, with no error, means the
+# answer was paired with its query across the interleaved step.
+INTERLEAVED_SEND_NAME = "interleaved-send.test"
+INTERLEAVED_RECV_NAME = "interleaved-recv.test"
+
+# Discards whatever it is sent, so the send-side sequence gets an unrelated send
+# on the socket without also putting a datagram in its receive queue
+BLACKHOLE_PORT = 8126
+
+
+def encode_labels(name):
+    return (
+        b"".join(bytes([len(label)]) + label.encode() for label in name.split("."))
+        + b"\x00"
+    )
+
+
+def dns_query(name, txid):
+    header = struct.pack("!HHHHHH", txid, 0x0100, 1, 0, 0, 0)  # rd=1, qdcount=1
+    return header + encode_labels(name) + struct.pack("!HH", 1, 1)  # type A, class IN
+
+
+def dns_answer_for(query):
+    """A NOERROR response echoing the question, with one A record."""
+    header = query[:2] + struct.pack("!HHHHH", 0x8180, 1, 1, 0, 0)
+    question = query[12:]
+    # name as a pointer back to the question, then type A, class IN, ttl, rdlength
+    answer = b"\xc0\x0c" + struct.pack("!HHIH", 1, 1, 60, 4) + bytes([127, 0, 0, 1])
+    return header + question + answer
+
+
+def run_responder():
+    """Answers every query after a delay, so callers can order what follows."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("", RESPONDER_PORT))
+    print(f"dnsresponder listening: port={RESPONDER_PORT}", flush=True)
+
+    while True:
+        query, peer = sock.recvfrom(512)
+        if len(query) < 12:
+            continue
+        time.sleep(RESPONDER_DELAY_SECONDS)
+        sock.sendto(dns_answer_for(query), peer)
+
+
+def start_blackhole_sink():
+    sink = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sink.bind((NON_DNS_HOST, BLACKHOLE_PORT))
+
+    def serve():
+        while True:
+            sink.recvfrom(512)
+
+    threading.Thread(target=serve, daemon=True).start()
+
+
+def interleave_non_dns_send(sock):
+    """An unrelated send, which says nothing about the query already in flight."""
+    sock.sendto(dns_shaped_response(), (NON_DNS_HOST, BLACKHOLE_PORT))
+
+
+def interleave_non_dns_receive(sock):
+    """An unrelated receive that names its non-DNS peer explicitly."""
+    sock.sendto(dns_shaped_response(), (NON_DNS_HOST, NON_DNS_PORT))
+
+    _, peer = sock.recvfrom(512)
+    if peer[1] != NON_DNS_PORT:
+        # the delayed answer overtook the echo, so this iteration did not
+        # exercise the interleaving; say so rather than reporting a lookup that
+        # proves nothing
+        raise OSError(f"expected the echo reply first, got a datagram from {peer}")
+
+
+def interleaved_lookup(name, txid, interleave, responder_ip):
+    """One lookup with an unrelated step between the query and its answer.
+
+    The answer is taken with recv() rather than recvfrom(), so the kernel fills
+    in no address and the answer carries no peer. Classifying it therefore rests
+    entirely on the window the query opened, which the interleaved step must not
+    have closed.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("", 0))  # bound but never connected, so its tuple has no peer
+    sock.settimeout(RECV_TIMEOUT_SECONDS)
+
+    try:
+        sock.sendto(dns_query(name, txid), (responder_ip, RESPONDER_PORT))
+        interleave(sock)
+        sock.recv(512)
+        print(f"interleaved lookup answered name={name}", flush=True)
+    except OSError as err:
+        print(f"interleaved lookup failed name={name} error={err}", flush=True)
+    finally:
+        sock.close()
+
+
 def main():
+    if os.getenv("DNS_RESPONDER"):
+        return run_responder()
+
     print(f"dnsclient running: pid={os.getpid()} host={HOST}", flush=True)
 
     start_echo_sink()
+    start_blackhole_sink()
+
+    # resolved once, so the responder's own name does not add a lookup per
+    # iteration; it still shows up once, at startup
+    responder_ip = socket.gethostbyname(RESPONDER_HOST)
+    print(f"responder resolved: {RESPONDER_HOST}={responder_ip}", flush=True)
 
     # never connected, so its tuple has no peer, exactly like musl's resolver socket
     probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     probe.bind((NON_DNS_HOST, 0))
     probe.settimeout(RECV_TIMEOUT_SECONDS)
 
+    # Every lookup needs its own transaction id. Lookups are paired with their
+    # answers on (pid, transaction id), so two outstanding queries sharing an id
+    # collide: the second displaces the first, and the displaced one is reported
+    # as an unanswered lookup even though its answer did arrive.
+    txid = 0
+
+    def next_txid():
+        nonlocal txid
+        txid = (txid + 1) & 0xFFFF
+        return txid
+
     while True:
         resolve_and_ping()
         exchange_non_dns(probe)
+        interleaved_lookup(
+            INTERLEAVED_SEND_NAME, next_txid(), interleave_non_dns_send, responder_ip
+        )
+        interleaved_lookup(
+            INTERLEAVED_RECV_NAME, next_txid(), interleave_non_dns_receive, responder_ip
+        )
         time.sleep(INTERVAL_SECONDS)
 
 

--- a/internal/test/integration/components/dnsclient/dnsclient.py
+++ b/internal/test/integration/components/dnsclient/dnsclient.py
@@ -7,10 +7,19 @@
 #
 # The name is served by the compose network's embedded DNS, so the lookup does
 # not depend on an upstream resolver.
+#
+# Alongside each lookup, the workload runs an unrelated UDP exchange that looks
+# as much like DNS as a non-DNS flow can: an unconnected socket, a peer that the
+# receive never names, and a payload that parses as a DNS response. Only the port
+# distinguishes it from the real resolver traffic, so it exercises the tier that
+# classifies an answer by the socket it arrives on. None of it may be reported as
+# a DNS lookup.
 
 import os
 import socket
+import struct
 import sys
+import threading
 import time
 
 HOST = "valkey"
@@ -20,6 +29,16 @@ INTERVAL_SECONDS = float(os.getenv("DNS_LOOKUP_INTERVAL_SECONDS", "1"))
 CONNECT_TIMEOUT_SECONDS = 2
 
 PING = b"*1\r\n$4\r\nPING\r\n"
+
+# A real non-DNS port, so the send is positively classified as something other
+# than DNS rather than being merely unrecognized
+NON_DNS_PORT = 8125
+NON_DNS_HOST = "127.0.0.1"
+
+# The name encoded in the decoy payload. If any of this traffic is reported as
+# DNS, it surfaces as a lookup for this name.
+FALSE_POSITIVE_LABELS = ("falsepositive", "test")
+RECV_TIMEOUT_SECONDS = 2
 
 
 def resolve_and_ping():
@@ -39,11 +58,61 @@ def resolve_and_ping():
         print(f"ping failed host={HOST} error={err}", flush=True)
 
 
+def dns_shaped_response():
+    """A well-formed DNS response, so nothing but the port marks it as non-DNS."""
+    # id, flags (QR=1, RD=1, RA=1), qdcount=1, ancount/nscount/arcount=0
+    header = struct.pack("!HHHHHH", 0x4242, 0x8180, 1, 0, 0, 0)
+
+    question = b"".join(
+        bytes([len(label)]) + label.encode() for label in FALSE_POSITIVE_LABELS
+    )
+    question += b"\x00"
+    question += struct.pack("!HH", 1, 1)  # type A, class IN
+
+    return header + question
+
+
+def start_echo_sink():
+    """Returns the decoy peer, which echoes whatever it is sent."""
+    sink = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sink.bind((NON_DNS_HOST, NON_DNS_PORT))
+
+    def serve():
+        while True:
+            payload, peer = sink.recvfrom(512)
+            sink.sendto(payload, peer)
+
+    threading.Thread(target=serve, daemon=True).start()
+
+
+def exchange_non_dns(probe):
+    """One decoy round trip on an unconnected socket.
+
+    The reply is taken with recv() rather than recvfrom(), so the kernel is given
+    no address buffer to fill and the receive carries no peer. That leaves the
+    socket as the only thing the answer could be classified by.
+    """
+    probe.sendto(dns_shaped_response(), (NON_DNS_HOST, NON_DNS_PORT))
+
+    try:
+        probe.recv(512)
+    except OSError as err:
+        print(f"decoy exchange failed error={err}", flush=True)
+
+
 def main():
     print(f"dnsclient running: pid={os.getpid()} host={HOST}", flush=True)
 
+    start_echo_sink()
+
+    # never connected, so its tuple has no peer, exactly like musl's resolver socket
+    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    probe.bind((NON_DNS_HOST, 0))
+    probe.settimeout(RECV_TIMEOUT_SECONDS)
+
     while True:
         resolve_and_ping()
+        exchange_non_dns(probe)
         time.sleep(INTERVAL_SECONDS)
 
 

--- a/internal/test/integration/components/dnsclient/dnsclient.py
+++ b/internal/test/integration/components/dnsclient/dnsclient.py
@@ -1,0 +1,51 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Resolves the valkey service name in a loop, then speaks the Redis protocol to
+# it. On Alpine, musl resolves over an unconnected UDP socket (bind + sendto, no
+# connect), so the socket tuple has no peer associated with it.
+#
+# The name is served by the compose network's embedded DNS, so the lookup does
+# not depend on an upstream resolver.
+
+import os
+import socket
+import sys
+import time
+
+HOST = "valkey"
+PORT = 6379
+
+INTERVAL_SECONDS = float(os.getenv("DNS_LOOKUP_INTERVAL_SECONDS", "1"))
+CONNECT_TIMEOUT_SECONDS = 2
+
+PING = b"*1\r\n$4\r\nPING\r\n"
+
+
+def resolve_and_ping():
+    try:
+        addrs = socket.getaddrinfo(HOST, PORT, socket.AF_INET, socket.SOCK_STREAM)
+    except socket.gaierror as err:
+        print(f"lookup failed name={HOST} error={err}", flush=True)
+        return
+
+    sockaddr = addrs[0][4]
+    try:
+        with socket.create_connection(sockaddr, CONNECT_TIMEOUT_SECONDS) as conn:
+            conn.sendall(PING)
+            reply = conn.recv(64)
+            print(f"resolved {HOST}={sockaddr[0]} ping={reply.decode().strip()}", flush=True)
+    except OSError as err:
+        print(f"ping failed host={HOST} error={err}", flush=True)
+
+
+def main():
+    print(f"dnsclient running: pid={os.getpid()} host={HOST}", flush=True)
+
+    while True:
+        resolve_and_ping()
+        time.sleep(INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/internal/test/integration/docker-compose-dns-unconnected.yml
+++ b/internal/test/integration/docker-compose-dns-unconnected.yml
@@ -1,0 +1,97 @@
+version: "3.8"
+
+services:
+  # Resolved by the workload through the compose network's embedded DNS, so the
+  # lookup under test needs no upstream resolver.
+  valkey:
+    image: valkey/valkey:8-alpine@sha256:a038175878d66b9d274fbf8be73c0305e93798b83917647f167e18cef3c71eec
+    container_name: valkey
+
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/dnsclient/Dockerfile
+    image: hatest-dnsclient
+    environment:
+      DNS_LOOKUP_INTERVAL_SECONDS: "1"
+    depends_on:
+      otelcol:
+        condition: service_started
+      valkey:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-dns-unconnected:/var/run/obi
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config${INSTRUMENTER_CONFIG_SUFFIX}.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_METRICS_FEATURES: "application,application_span_otel,application_service_graph"
+      OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span,application_service_graph"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.157.0@sha256:f2f01157055a9b2aab9df7118e1f1c9abf345e99b23bc7a2bc791db374a7d0f6
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver-no-jaeger.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318:4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
+
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"

--- a/internal/test/integration/docker-compose-dns-unconnected.yml
+++ b/internal/test/integration/docker-compose-dns-unconnected.yml
@@ -7,6 +7,19 @@ services:
     image: valkey/valkey:8-alpine@sha256:a038175878d66b9d274fbf8be73c0305e93798b83917647f167e18cef3c71eec
     container_name: valkey
 
+  # Answers the workload's hand-built queries after a delay, so that an
+  # interleaved step on the resolver socket is ordered ahead of the answer
+  # rather than racing it. Runs outside the instrumented PID namespace, so its
+  # own DNS traffic does not appear in the telemetry under test.
+  dnsresponder:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/dnsclient/Dockerfile
+    image: hatest-dnsclient
+    container_name: dnsresponder
+    environment:
+      DNS_RESPONDER: "1"
+
   testserver:
     build:
       context: ../../..
@@ -18,6 +31,8 @@ services:
       otelcol:
         condition: service_started
       valkey:
+        condition: service_started
+      dnsresponder:
         condition: service_started
 
   obi:

--- a/internal/test/integration/red_test_dns_unconnected.go
+++ b/internal/test/integration/red_test_dns_unconnected.go
@@ -21,6 +21,19 @@ const unconnectedDNSName = "valkey."
 // traffic was classified as DNS.
 const falsePositiveDNSName = "falsepositive.test."
 
+// Names the workload looks up with an unrelated step between the query and its
+// nameless answer: an unrelated send on the resolver socket for the first, an
+// unrelated receive that names its non-DNS peer for the second. Neither step
+// says anything about the query already in flight, so both lookups must still
+// pair.
+const (
+	interleavedSendDNSName = "interleaved-send.test."
+	interleavedRecvDNSName = "interleaved-recv.test."
+)
+
+// The workload resolves the delayed responder's own name once, at startup
+const responderDNSName = "dnsresponder."
+
 // The Redis traffic that follows each lookup. Instrumenting it confirms the
 // workload is being watched, so a missing DNS metric means the lookup was not
 // captured rather than that the process was never instrumented.
@@ -81,6 +94,42 @@ func testDNSMetricsCountEveryLookup(t *testing.T, namespace string) {
 	}, testTimeout, time.Second)
 }
 
+// Counts only lookups that were answered. An unanswered query is reported too,
+// with error_type "Refused", once the pipeline gives up waiting for its answer.
+// That is exactly what a lost answer looks like, so the interleaving assertions
+// have to exclude it or they pass whether or not the answer was classified.
+func answeredLookupCount(ct *assert.CollectT, pq promtest.Client, name, namespace string) int {
+	results, err := pq.Query(`dns_lookup_duration_seconds_count{` +
+		`dns_question_name="` + name + `",` +
+		`error_type="",` +
+		`service_namespace="` + namespace + `"}`)
+	require.NoError(ct, err)
+	enoughPromResults(ct, results)
+	return totalPromCount(ct, results)
+}
+
+// A query goes out on an unconnected socket, an unrelated datagram is sent on
+// that same socket, and only then does the nameless answer arrive. Retiring the
+// socket's window on that intervening send loses the answer.
+func testDNSInterleavedSendKeepsTheLookup(t *testing.T, namespace string) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.LessOrEqual(ct, 1, answeredLookupCount(ct, pq, interleavedSendDNSName, namespace))
+	}, testTimeout, 100*time.Millisecond)
+}
+
+// The same sequence with an unrelated receive in the middle, one that names its
+// non-DNS peer. It is classified and discarded on its own merits, and must not
+// take the outstanding query with it.
+func testDNSInterleavedReceiveKeepsTheLookup(t *testing.T, namespace string) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.LessOrEqual(ct, 1, answeredLookupCount(ct, pq, interleavedRecvDNSName, namespace))
+	}, testTimeout, 100*time.Millisecond)
+}
+
 // The workload pairs every lookup with a decoy UDP exchange on an unconnected
 // socket: a DNS-shaped payload, a receive that names no peer, and a non-DNS peer
 // port. Classifying an answer by the socket it arrived on has to stop short of
@@ -104,8 +153,16 @@ func testDNSNoFalsePositiveFromNonDNSUDP(t *testing.T, namespace string) {
 	require.NoError(t, err)
 	require.NotEmpty(t, results, "no DNS lookups at all, so this proves nothing")
 
+	// everything the workload legitimately looks up
+	expected := []string{
+		unconnectedDNSName,
+		interleavedSendDNSName,
+		interleavedRecvDNSName,
+		responderDNSName,
+	}
+
 	for _, result := range results {
-		assert.Equal(t, unconnectedDNSName, result.Metric["dns_question_name"],
+		assert.Contains(t, expected, result.Metric["dns_question_name"],
 			"non-DNS UDP on an unconnected socket was reported as a DNS lookup; "+
 				"the decoy payload carries the name %q", falsePositiveDNSName)
 	}
@@ -118,6 +175,11 @@ func testDNSUnconnectedResolver(t *testing.T) {
 
 func testDNSNoFalsePositive(t *testing.T) {
 	testDNSNoFalsePositiveFromNonDNSUDP(t, "integration-test")
+}
+
+func testDNSInterleavedTraffic(t *testing.T) {
+	testDNSInterleavedSendKeepsTheLookup(t, "integration-test")
+	testDNSInterleavedReceiveKeepsTheLookup(t, "integration-test")
 }
 
 func testDNSEveryLookupCounted(t *testing.T) {

--- a/internal/test/integration/red_test_dns_unconnected.go
+++ b/internal/test/integration/red_test_dns_unconnected.go
@@ -16,6 +16,11 @@ import (
 // Served by the compose network's embedded DNS, so no upstream resolver is involved
 const unconnectedDNSName = "valkey."
 
+// The question name carried by the workload's decoy UDP payload. It is only ever
+// sent to a non-DNS port, so a lookup reported for this name means unrelated
+// traffic was classified as DNS.
+const falsePositiveDNSName = "falsepositive.test."
+
 // The Redis traffic that follows each lookup. Instrumenting it confirms the
 // workload is being watched, so a missing DNS metric means the lookup was not
 // captured rather than that the process was never instrumented.
@@ -76,9 +81,43 @@ func testDNSMetricsCountEveryLookup(t *testing.T, namespace string) {
 	}, testTimeout, time.Second)
 }
 
+// The workload pairs every lookup with a decoy UDP exchange on an unconnected
+// socket: a DNS-shaped payload, a receive that names no peer, and a non-DNS peer
+// port. Classifying an answer by the socket it arrived on has to stop short of
+// this, or unrelated UDP shows up as DNS telemetry.
+func testDNSNoFalsePositiveFromNonDNSUDP(t *testing.T, namespace string) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+
+	// The decoy exchange follows each lookup in the same iteration, so several
+	// reported lookups mean several decoy exchanges have been seen and had every
+	// chance to be misreported.
+	const lookupsBeforeChecking = 5
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.LessOrEqual(ct, lookupsBeforeChecking, dnsLookupCount(ct, pq, namespace))
+	}, testTimeout, 100*time.Millisecond)
+
+	// Every name, rather than just the decoy's own: a false positive reported
+	// under any other name still means unrelated UDP became DNS telemetry.
+	results, err := pq.Query(`dns_lookup_duration_seconds_count{` +
+		`service_namespace="` + namespace + `"}`)
+	require.NoError(t, err)
+	require.NotEmpty(t, results, "no DNS lookups at all, so this proves nothing")
+
+	for _, result := range results {
+		assert.Equal(t, unconnectedDNSName, result.Metric["dns_question_name"],
+			"non-DNS UDP on an unconnected socket was reported as a DNS lookup; "+
+				"the decoy payload carries the name %q", falsePositiveDNSName)
+	}
+}
+
 func testDNSUnconnectedResolver(t *testing.T) {
 	testDNSUnconnectedResolverControl(t, "integration-test")
 	testDNSMetricsForUnconnectedResolver(t, "integration-test")
+}
+
+func testDNSNoFalsePositive(t *testing.T) {
+	testDNSNoFalsePositiveFromNonDNSUDP(t, "integration-test")
 }
 
 func testDNSEveryLookupCounted(t *testing.T) {

--- a/internal/test/integration/red_test_dns_unconnected.go
+++ b/internal/test/integration/red_test_dns_unconnected.go
@@ -1,0 +1,86 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration // import "go.opentelemetry.io/obi/internal/test/integration"
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
+)
+
+// Served by the compose network's embedded DNS, so no upstream resolver is involved
+const unconnectedDNSName = "valkey."
+
+// The Redis traffic that follows each lookup. Instrumenting it confirms the
+// workload is being watched, so a missing DNS metric means the lookup was not
+// captured rather than that the process was never instrumented.
+func testDNSUnconnectedResolverControl(t *testing.T, namespace string) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		results, err := pq.Query(`db_client_operation_duration_seconds_count{` +
+			`db_system_name="redis",` +
+			`service_namespace="` + namespace + `"}`)
+		require.NoError(ct, err)
+		enoughPromResults(ct, results)
+		assert.LessOrEqual(ct, 1, totalPromCount(ct, results))
+	}, testTimeout, 100*time.Millisecond)
+}
+
+func dnsLookupCount(ct *assert.CollectT, pq promtest.Client, namespace string) int {
+	results, err := pq.Query(`dns_lookup_duration_seconds_count{` +
+		`dns_question_name="` + unconnectedDNSName + `",` +
+		`service_namespace="` + namespace + `"}`)
+	require.NoError(ct, err)
+	enoughPromResults(ct, results)
+	return totalPromCount(ct, results)
+}
+
+// The Alpine workload resolves over an unconnected UDP socket, so the lookup is
+// only recognizable as DNS through msg_name. Unclassified, no span is produced
+// and the metric never appears for this name.
+func testDNSMetricsForUnconnectedResolver(t *testing.T, namespace string) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+
+	// Eventually, Prometheus would make this query visible
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.LessOrEqual(ct, 1, dnsLookupCount(ct, pq, namespace))
+	}, testTimeout, 100*time.Millisecond)
+}
+
+// Every iteration resolves the same name, so consecutive lookups are separated
+// only by their transaction ids: reported as 0 they share a pairing key, and
+// each lookup is discarded as a duplicate of the one still cached. Counting has
+// to keep pace with the workload, which it cannot do while they collide.
+func testDNSMetricsCountEveryLookup(t *testing.T, namespace string) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+
+	var start int
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		start = dnsLookupCount(ct, pq, namespace)
+		assert.Positive(ct, start)
+	}, testTimeout, 100*time.Millisecond)
+
+	// The workload resolves once a second, so a healthy pairing counts roughly
+	// one lookup per second; colliding keys cap it at one per DNS request
+	// timeout, which is 5s by default.
+	const minLookups = 20
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.GreaterOrEqual(ct, dnsLookupCount(ct, pq, namespace)-start, minLookups)
+	}, testTimeout, time.Second)
+}
+
+func testDNSUnconnectedResolver(t *testing.T) {
+	testDNSUnconnectedResolverControl(t, "integration-test")
+	testDNSMetricsForUnconnectedResolver(t, "integration-test")
+}
+
+func testDNSEveryLookupCounted(t *testing.T) {
+	testDNSMetricsCountEveryLookup(t, "integration-test")
+}

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -149,6 +149,7 @@ func TestSuite_DNSUnconnectedResolver(t *testing.T) {
 	t.Run("DNS RED metrics over an unconnected resolver socket", testDNSUnconnectedResolver)
 	t.Run("every DNS lookup is counted", testDNSEveryLookupCounted)
 	t.Run("non-DNS UDP is not reported as DNS", testDNSNoFalsePositive)
+	t.Run("unrelated traffic does not lose an outstanding lookup", testDNSInterleavedTraffic)
 	runWeaverValidation(t)
 	require.NoError(t, compose.Close())
 }

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -148,6 +148,7 @@ func TestSuite_DNSUnconnectedResolver(t *testing.T) {
 	require.NoError(t, compose.Up())
 	t.Run("DNS RED metrics over an unconnected resolver socket", testDNSUnconnectedResolver)
 	t.Run("every DNS lookup is counted", testDNSEveryLookupCounted)
+	t.Run("non-DNS UDP is not reported as DNS", testDNSNoFalsePositive)
 	runWeaverValidation(t)
 	require.NoError(t, compose.Close())
 }

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -134,6 +134,24 @@ func TestSuiteGoGeneric(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+// Alpine workload, so name resolution goes through musl's unconnected UDP socket
+func TestSuite_DNSUnconnectedResolver(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-dns-unconnected.yml", path.Join(pathOutput, "test-suite-dns-unconnected.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(
+		compose.Env,
+		`OTEL_EBPF_EXECUTABLE_PATH=python`,
+		`OTEL_EBPF_OPEN_PORT=`,
+		`INSTRUMENTER_CONFIG_SUFFIX=-java`,
+	)
+	require.NoError(t, compose.Up())
+	t.Run("DNS RED metrics over an unconnected resolver socket", testDNSUnconnectedResolver)
+	t.Run("every DNS lookup is counted", testDNSEveryLookupCounted)
+	runWeaverValidation(t)
+	require.NoError(t, compose.Close())
+}
+
 func TestSuiteClientPromScrape(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-client.yml", path.Join(pathOutput, "test-suite-client-promscrape.log"))
 	require.NoError(t, err)

--- a/pkg/ebpf/common/dns_request_transform.go
+++ b/pkg/ebpf/common/dns_request_transform.go
@@ -51,7 +51,21 @@ func readDNSEventIntoSpan(parseCtx *EBPFParseContext, record *ringbuf.Record) (r
 
 	dnsID := dnsparser.DNSId{HostPID: event.Pid.HostPid, ID: event.Id}
 
+	curName := ""
+	if len(msg.Questions) > 0 {
+		curName = msg.Questions[0].Name.String()
+	}
+
 	span, ok := parseCtx.dnsEvents.Get(dnsID)
+
+	// The transaction ID is 0 in the unconnected resolver case, so the pairing key
+	// degenerates to (HostPID, 0) and collides across a process's concurrent DNS
+	// transactions. A different question name means a collision rather than a
+	// retransmit, so start a fresh span: otherwise the stale occupant suppresses
+	// this answer at the duplicate guard below.
+	if ok && span.Path != "" && curName != "" && span.Path != curName {
+		ok = false
+	}
 
 	if !ok {
 		span = &request.Span{
@@ -81,9 +95,8 @@ func readDNSEventIntoSpan(parseCtx *EBPFParseContext, record *ringbuf.Record) (r
 	}
 
 	if len(msg.Questions) > 0 {
-		question := msg.Questions[0]
-		span.Method = dnsparser.Type(question.Type).String()
-		span.Path = question.Name.String()
+		span.Method = dnsparser.Type(msg.Questions[0].Type).String()
+		span.Path = curName
 	}
 
 	var addresses []string

--- a/pkg/ebpf/common/dns_request_transform_test.go
+++ b/pkg/ebpf/common/dns_request_transform_test.go
@@ -1,0 +1,189 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon
+
+import (
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/dns/dnsmessage"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/ebpf/common/dnsparser"
+	"go.opentelemetry.io/obi/pkg/ebpf/ringbuf"
+)
+
+const testDNSPid = uint32(1234)
+
+func newDNSParseContext() *EBPFParseContext {
+	return &EBPFParseContext{
+		dnsEvents: expirable.NewLRU[dnsparser.DNSId, *request.Span](1024, nil, time.Minute),
+	}
+}
+
+func dnsQueryRecord(t *testing.T, id uint16, name string) *ringbuf.Record {
+	t.Helper()
+	return dnsRecord(t, id, dnsmessage.Message{
+		Header:    dnsmessage.Header{ID: id},
+		Questions: []dnsmessage.Question{dnsQuestion(t, name)},
+	})
+}
+
+func dnsAnswerRecord(t *testing.T, id uint16, name string, addr [4]byte) *ringbuf.Record {
+	t.Helper()
+	qname := dnsQuestion(t, name).Name
+	return dnsRecord(t, id, dnsmessage.Message{
+		Header:    dnsmessage.Header{ID: id, Response: true, RCode: dnsmessage.RCodeSuccess},
+		Questions: []dnsmessage.Question{dnsQuestion(t, name)},
+		Answers: []dnsmessage.Resource{{
+			Header: dnsmessage.ResourceHeader{Name: qname, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET},
+			Body:   &dnsmessage.AResource{A: addr},
+		}},
+	})
+}
+
+func dnsQuestion(t *testing.T, name string) dnsmessage.Question {
+	t.Helper()
+	qname, err := dnsmessage.NewName(name)
+	require.NoError(t, err)
+	return dnsmessage.Question{Name: qname, Type: dnsmessage.TypeA, Class: dnsmessage.ClassINET}
+}
+
+func dnsRecord(t *testing.T, id uint16, msg dnsmessage.Message) *ringbuf.Record {
+	t.Helper()
+
+	packed, err := msg.Pack()
+	require.NoError(t, err)
+
+	event := BpfDnsReqT{Id: id}
+	event.Pid.HostPid = testDNSPid
+	event.Len = uint32(copy(event.Buf[:], packed))
+
+	raw := unsafe.Slice((*byte)(unsafe.Pointer(&event)), int(unsafe.Sizeof(event)))
+	return &ringbuf.Record{RawSample: append([]byte(nil), raw...)}
+}
+
+// Ensure a stale (HostPID, 0) occupant with a different question name does not
+// suppress this answer
+func TestReadDNSEventIntoSpan_ZeroIDCollisionDoesNotSuppressAnswer(t *testing.T) {
+	parseCtx := newDNSParseContext()
+
+	_, _, err := readDNSEventIntoSpan(parseCtx, dnsQueryRecord(t, 0, "a.example.com."))
+	require.NoError(t, err)
+
+	_, _, err = readDNSEventIntoSpan(parseCtx, dnsAnswerRecord(t, 0, "a.example.com.", [4]byte{10, 0, 0, 1}))
+	require.NoError(t, err)
+
+	// a concurrent transaction for a different name, same key
+	span, ignore, err := readDNSEventIntoSpan(parseCtx, dnsAnswerRecord(t, 0, "b.example.com.", [4]byte{10, 0, 0, 2}))
+	require.NoError(t, err)
+
+	assert.False(t, ignore, "answer for a different name must not be treated as a duplicate")
+	assert.Equal(t, "b.example.com.", span.Path)
+	assert.Equal(t, "10.0.0.2", span.Statement)
+	assert.Equal(t, int(dnsparser.RCodeSuccess), span.Status)
+}
+
+func TestReadDNSEventIntoSpan_DuplicateSameNameAnswerIgnored(t *testing.T) {
+	parseCtx := newDNSParseContext()
+
+	_, _, err := readDNSEventIntoSpan(parseCtx, dnsQueryRecord(t, 42, "a.example.com."))
+	require.NoError(t, err)
+
+	span, ignore, err := readDNSEventIntoSpan(parseCtx, dnsAnswerRecord(t, 42, "a.example.com.", [4]byte{10, 0, 0, 1}))
+	require.NoError(t, err)
+	require.False(t, ignore)
+	require.Equal(t, "10.0.0.1", span.Statement)
+
+	dup, ignore, err := readDNSEventIntoSpan(parseCtx, dnsAnswerRecord(t, 42, "a.example.com.", [4]byte{10, 0, 0, 1}))
+	require.NoError(t, err)
+
+	assert.True(t, ignore, "a retransmitted answer for the same name is a duplicate")
+	assert.Equal(t, "10.0.0.1", dup.Statement, "duplicate must not append addresses again")
+}
+
+// Concurrent A and AAAA lookups share a question name, so the name-based
+// collision guard cannot separate them. They stay distinct only while the eBPF
+// layer reports the real transaction id.
+func TestReadDNSEventIntoSpan_SameNameDistinctIDsStayDistinct(t *testing.T) {
+	parseCtx := newDNSParseContext()
+
+	_, _, err := readDNSEventIntoSpan(parseCtx, dnsQueryRecord(t, 1, "a.example.com."))
+	require.NoError(t, err)
+	_, _, err = readDNSEventIntoSpan(parseCtx, dnsQueryRecord(t, 2, "a.example.com."))
+	require.NoError(t, err)
+
+	first, ignore, err := readDNSEventIntoSpan(parseCtx, dnsAnswerRecord(t, 1, "a.example.com.", [4]byte{10, 0, 0, 1}))
+	require.NoError(t, err)
+	require.False(t, ignore)
+	assert.Equal(t, "10.0.0.1", first.Statement)
+
+	second, ignore, err := readDNSEventIntoSpan(parseCtx, dnsAnswerRecord(t, 2, "a.example.com.", [4]byte{10, 0, 0, 2}))
+	require.NoError(t, err)
+
+	assert.False(t, ignore, "a second transaction for the same name must not be a duplicate")
+	assert.Equal(t, "10.0.0.2", second.Statement)
+}
+
+// Documents the collision the eBPF id extraction removes: with every id at 0 the
+// two transactions share a key, and the name guard cannot tell them apart
+// because the name matches, so the second answer is dropped.
+func TestReadDNSEventIntoSpan_SameNameZeroIDsCollide(t *testing.T) {
+	parseCtx := newDNSParseContext()
+
+	_, _, err := readDNSEventIntoSpan(parseCtx, dnsQueryRecord(t, 0, "a.example.com."))
+	require.NoError(t, err)
+
+	_, ignore, err := readDNSEventIntoSpan(parseCtx, dnsAnswerRecord(t, 0, "a.example.com.", [4]byte{10, 0, 0, 1}))
+	require.NoError(t, err)
+	require.False(t, ignore)
+
+	_, ignore, err = readDNSEventIntoSpan(parseCtx, dnsAnswerRecord(t, 0, "a.example.com.", [4]byte{10, 0, 0, 2}))
+	require.NoError(t, err)
+
+	assert.True(t, ignore, "the second same-name transaction is lost when both ids are 0")
+}
+
+// A colliding key whose occupant holds a different name is a collision rather
+// than a retransmit, so the incoming transaction starts a fresh span.
+func TestReadDNSEventIntoSpan_ZeroIDCollisionAcrossNames(t *testing.T) {
+	parseCtx := newDNSParseContext()
+
+	_, _, err := readDNSEventIntoSpan(parseCtx, dnsQueryRecord(t, 0, "a.example.com."))
+	require.NoError(t, err)
+	_, _, err = readDNSEventIntoSpan(parseCtx, dnsAnswerRecord(t, 0, "a.example.com.", [4]byte{10, 0, 0, 1}))
+	require.NoError(t, err)
+
+	_, _, err = readDNSEventIntoSpan(parseCtx, dnsQueryRecord(t, 0, "b.example.com."))
+	require.NoError(t, err)
+
+	span, ignore, err := readDNSEventIntoSpan(parseCtx, dnsAnswerRecord(t, 0, "b.example.com.", [4]byte{10, 0, 0, 2}))
+	require.NoError(t, err)
+
+	assert.False(t, ignore, "an answer for a different name must not be a duplicate")
+	assert.Equal(t, "b.example.com.", span.Path)
+	assert.Equal(t, "10.0.0.2", span.Statement)
+}
+
+func TestReadDNSEventIntoSpan_QueryThenAnswerPairs(t *testing.T) {
+	parseCtx := newDNSParseContext()
+
+	query, ignore, err := readDNSEventIntoSpan(parseCtx, dnsQueryRecord(t, 7, "a.example.com."))
+	require.NoError(t, err)
+	assert.True(t, ignore, "a query without a response is not emitted")
+	assert.Equal(t, -1, query.Status)
+	assert.Equal(t, "A", query.Method)
+	assert.Equal(t, "a.example.com.", query.Path)
+
+	answer, ignore, err := readDNSEventIntoSpan(parseCtx, dnsAnswerRecord(t, 7, "a.example.com.", [4]byte{10, 0, 0, 1}))
+	require.NoError(t, err)
+	assert.False(t, ignore)
+	assert.Equal(t, int(dnsparser.RCodeSuccess), answer.Status)
+	assert.Equal(t, "10.0.0.1", answer.Statement)
+	assert.Equal(t, request.EventTypeDNS, answer.Type)
+}

--- a/pkg/ebpf/common/ringbuf.go
+++ b/pkg/ebpf/common/ringbuf.go
@@ -23,6 +23,14 @@ import (
 // Max interval before reading stale available bytes from the ring buffer
 const flushInterval = 3 * time.Second
 
+// How long the reader must have gone without consuming a record before a flush
+// is issued on its behalf. This has to stay strictly below flushInterval: a
+// flush wakes the reader, so the reads it causes are timestamped just after the
+// tick that issued it. Measuring idleness over the whole interval therefore
+// lets every flush suppress the tick that should follow it, halving the flush
+// rate and leaving records pending for two intervals instead of one.
+const readerStalledAfter = flushInterval / 2
+
 // ringBufReader interface extracts the used methods from ringbuf.Reader for proper
 // dependency injection during tests
 type ringBufReader interface {
@@ -174,7 +182,7 @@ func (rbf *ringBufForwarder[T]) flushOnAvailableBytes(ctx context.Context, event
 		select {
 		case <-ticker.C:
 			available := eventsReader.AvailableBytes()
-			if available > 0 && rbf.hasPendingReadIdleSince(time.Now(), flushInterval) {
+			if available > 0 && rbf.hasPendingReadIdleSince(time.Now(), readerStalledAfter) {
 				err := eventsReader.Flush()
 				rbf.logger.Debug("flushing ringbuf", "available_bytes", available, "flush_err", err)
 			}

--- a/pkg/ebpf/common/ringbuf_test.go
+++ b/pkg/ebpf/common/ringbuf_test.go
@@ -264,6 +264,97 @@ func TestRingbufLastReadAtRace(t *testing.T) {
 	<-readDone
 }
 
+// A producer that submitted with BPF_RB_NO_WAKEUP leaves bytes pending without
+// waking the reader, so the reader only makes progress when it is flushed on its
+// own behalf. Each flush therefore has to be issued on the tick that follows the
+// previous one: while the idle window matched the tick period, the reads caused
+// by one flush suppressed the next tick, so records waited two intervals and a
+// DNS answer could reach the pairing stage past its request timeout.
+func TestRingbufStalledReaderIsFlushedOnConsecutiveTicks(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	rbf := &ringBufForwarder[HTTPRequestTrace]{
+		cfg:    &config.EBPFTracer{BatchLength: 1},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		parse: func(*ringbuf.Record) (HTTPRequestTrace, bool, error) {
+			return HTTPRequestTrace{}, true, nil
+		},
+	}
+
+	eventsReader := newStalledReader()
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		rbf.readAndForwardInner(ctx, eventsReader, msg.NewQueue[[]HTTPRequestTrace](msg.ChannelBufferLen(1)))
+	}()
+
+	// Two flushes land within two ticks once each one is issued on the tick
+	// following the last. Skipping every other tick needs four.
+	require.Eventually(t, func() bool {
+		return eventsReader.FlushCount() >= 2
+	}, 2*flushInterval+time.Second, 50*time.Millisecond)
+
+	cancel()
+	eventsReader.Close()
+	<-readDone
+}
+
+// stalledReader always reports pending bytes and only lets a read through once
+// it has been flushed, so that every flush advances lastReadAt exactly the way a
+// woken reader does.
+type stalledReader struct {
+	flushCount atomic.Int64
+	readTokens chan struct{}
+	closed     chan struct{}
+}
+
+func newStalledReader() *stalledReader {
+	return &stalledReader{
+		readTokens: make(chan struct{}, 1),
+		closed:     make(chan struct{}),
+	}
+}
+
+func (r *stalledReader) FlushCount() int { return int(r.flushCount.Load()) }
+
+func (r *stalledReader) Close() error {
+	select {
+	case <-r.closed:
+	default:
+		close(r.closed)
+	}
+	return nil
+}
+
+func (r *stalledReader) Read() (ringbuf.Record, error) {
+	record := ringbuf.Record{}
+	err := r.ReadInto(&record)
+	return record, err
+}
+
+func (r *stalledReader) ReadInto(record *ringbuf.Record) error {
+	select {
+	case <-r.readTokens:
+		record.RawSample = nil
+		return nil
+	case <-r.closed:
+		return ringbuf.ErrClosed
+	}
+}
+
+func (r *stalledReader) AvailableBytes() int { return 1 }
+
+func (r *stalledReader) Flush() error {
+	r.flushCount.Add(1)
+	// the woken reader drains one record, which is what moves lastReadAt
+	select {
+	case r.readTokens <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
 // replaces the original ring buffer factory by a fake ring buffer creator and returns it
 func replaceTestRingBuf() *fakeRingBufReader {
 	rb := fakeRingBufReader{events: make(chan HTTPRequestTrace, 100), closeCh: make(chan struct{})}

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -337,6 +337,13 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {
 			Required: true,
 			Start:    p.bpfObjects.ObiKprobeUdpSendmsg,
 		},
+		// Not required: without it the unconnected DNS state still expires on its
+		// own, so a kernel where this symbol is unavailable loses the lifetime
+		// bound rather than the whole tracer.
+		"udp_destroy_sock": {
+			Required: false,
+			Start:    p.bpfObjects.ObiKprobeUdpDestroySock,
+		},
 		"tcp_close": {
 			Required: true,
 			Start:    p.bpfObjects.ObiKprobeTcpClose,

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -336,6 +336,7 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {
 		"udp_sendmsg": {
 			Required: true,
 			Start:    p.bpfObjects.ObiKprobeUdpSendmsg,
+			End:      p.bpfObjects.ObiKretprobeUdpSendmsg,
 		},
 		// Not required: without it the unconnected DNS state still expires on its
 		// own, so a kernel where this symbol is unavailable loses the lifetime


### PR DESCRIPTION
## Summary

OBI names the peers an application talks to by watching its DNS lookups. When a
lookup is missed, the peer shows up as a bare IP address instead of a hostname.
These peer names are then reported as "outgoing" instead of the actual name.

I found two separate bugs that make OBI miss a number of DNS lookups. This PR fixes
both, plus a smaller related issue.

## Bug 1: the DNS header was read with the wrong helper

`handle_dns_buf()` parses a buffer that comes from `iovec_memory()`. That
function returns a pointer into a BPF map, which is kernel memory. But the code
read the DNS header out of it with `bpf_probe_read_user()`, the helper for user
memory.

That read always fails. When it fails, the helper zeroes the destination, and
the return value was never checked. So the header came back as all zeroes. The
message body was then copied with a different helper that *does* work, which is
why the captured packet held the real data while the parsed header did not.

Two things break as a result:

1. The transaction ID is always 0. OBI matches a DNS answer to its question
   using the key `(process ID, transaction ID)`. With the ID stuck at 0, every
   lookup from the same process collides on the same key. A lookup that lands
   while a previous one is still cached is thrown away as a duplicate.
2. Every answer is recorded as a question. The flags field is zeroed too, so
   the query/response bit always reads as "query".

Consequently, an app that looks up one name every second had 8 of about
60 lookups reported over a minute. The rest were dropped. After the fix, all
of them are successfully reported.

## Bug 2: unconnected resolver sockets were skipped entirely

musl libc (so every Alpine-based container) and some Java stacks never call
`connect()` on their resolver socket. They use `bind()` plus `sendto()` instead.
These are known as *unconnected sockets*. This [CloudFlare blog post](https://blog.cloudflare.com/everything-you-ever-wanted-to-know-about-udp-sockets-but-were-afraid-to-ask-part-1/)
discusses the subject in detail.

For unconnected sockets, the socket's address pair has no peer in it. `is_dns()`
only looks at that pair to decide whether traffic is DNS, so it never matched,
and OBI missed these lookups completely. For an affected app, no DNS was
captured at all, so no peer could ever be named.

## Bug 3: pairing key collision

Transaction IDs are random, so two lookups from one process can collide by
chance. When that happened, the older entry could suppress the newer answer.
Now a different question name starts a fresh record instead.

## Scope

IPv4 (AF_INET) UDP DNS only. IPv6 DNS transport is still not handled.

## Testing

### Unit tests

`bpf/tests/bpf_dns_header.c` runs the real `dns.h` against a mocked BPF runtime.
Against the old code it fails with `expected 3178, got 0`, and it also catches
answers being mislabelled as questions. `bpf/tests/bpf_dns_unconnected.c` covers
the unconnected-socket classification.

Including `dns.h` in a host test needs a stub for `common/trace_parent.h`, which
otherwise pulls in the Go tracer and fourteen map definitions. That stub and a
few kernel types are added to the existing `bpf/tests` scaffolding.

`dns_request_transform_test.go` covers the collision guard and the case it
cannot help with, where two lookups share a question name.

### Integration test

`TestSuite_DNSUnconnectedResolver` runs an Alpine workload that resolves a
`valkey` service name and then sends it Redis traffic. The name is served by the
compose network's own DNS, so the test needs no internet access. The Redis
metric acts as a control: if the process was never instrumented, that check
fails first, which separates "DNS capture broke" from "nothing was
instrumented".

The test counts lookups over time rather than just checking one exists. Without
the header fix it sees 8 lookups where it needs 20, and fails.

I ran the full BPF test suite, the Go unit tests, `make lint`, and this
integration suite against `main`, and confirmed the failure direction by
reverting each fix and rebuilding.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

## AI assistance

Generative AI was used to assist with identifying the bugs and proposing this
change and the accompanying test suite. I personally reviewed every line before
submitting, verified each claim above against captured output, and confirmed the
tests fail without the fixes.
