### PR TITLE
Enable the eBPF PID filter before injecting the Java agent

### DIFF
--- a/internal/test/integration/components/javadiscovery/Dockerfile
+++ b/internal/test/integration/components/javadiscovery/Dockerfile
@@ -1,0 +1,13 @@
+# Dockerfile that will build a container sending Redis traffic from a JVM whose
+# attach mechanism is disabled, so agent injection cannot complete.
+# Docker command must be invoked from the project root directory
+FROM eclipse-temurin:21@sha256:efd34b940f2d5a621605c8531c2afb7759c936b6c2ef637a69aa3bf3e1e789d1 AS builder
+WORKDIR /app
+COPY internal/test/integration/components/javadiscovery/JavaRedisClient.java .
+RUN javac -d /app/classes JavaRedisClient.java
+
+FROM eclipse-temurin:21@sha256:efd34b940f2d5a621605c8531c2afb7759c936b6c2ef637a69aa3bf3e1e789d1
+WORKDIR /app
+COPY --from=builder /app/classes /app/classes
+USER 0:0
+CMD ["java", "-XX:+DisableAttachMechanism", "-cp", "/app/classes", "JavaRedisClient"]

--- a/internal/test/integration/components/javadiscovery/JavaRedisClient.java
+++ b/internal/test/integration/components/javadiscovery/JavaRedisClient.java
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+// Sends Redis traffic from the moment it starts. The JVM runs with the attach
+// mechanism disabled, so the agent injection OBI attempts against it can never
+// complete and blocks for the whole attach timeout. Traffic from this process
+// is only captured if the eBPF PID filter is enabled without waiting for that.
+public class JavaRedisClient {
+    private static final String HOST = "redis";
+    private static final int PORT = 6379;
+    private static final byte[] PING = "*1\r\n$4\r\nPING\r\n".getBytes();
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("javaredisclient running: pid=" + ProcessHandle.current().pid());
+
+        while (true) {
+            try (Socket s = new Socket()) {
+                s.connect(new InetSocketAddress(HOST, PORT), 2000);
+                OutputStream out = s.getOutputStream();
+                out.write(PING);
+                out.flush();
+                InputStream in = s.getInputStream();
+                byte[] buf = new byte[64];
+                int n = in.read(buf);
+                System.out.println("ping=" + new String(buf, 0, Math.max(n, 0)).trim());
+            } catch (Exception e) {
+                System.out.println("ping failed: " + e);
+            }
+            Thread.sleep(500);
+        }
+    }
+}

--- a/internal/test/integration/docker-compose-java-discovery.yml
+++ b/internal/test/integration/docker-compose-java-discovery.yml
@@ -1,0 +1,114 @@
+version: "3.8"
+
+services:
+  redis:
+    build:
+      context: ../../../internal/test/integration/components/redis/
+      dockerfile: Dockerfile
+    image: redis
+
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/javadiscovery/Dockerfile
+    image: hatest-javadiscovery
+    depends_on:
+      otelcol:
+        condition: service_started
+      redis:
+        condition: service_started
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-java-discovery:/var/run/obi
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config-redis.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_TRACES_INSTRUMENTATIONS: "redis"
+      OTEL_EBPF_METRICS_INSTRUMENTATIONS: "redis"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+      OTEL_EBPF_JAVAAGENT_ENABLED: "true"
+      # Much longer than the assertion window. This JVM disables the attach
+      # mechanism, so the injection can never succeed and blocks for the whole
+      # timeout; capture must not wait on it.
+      OTEL_EBPF_JAVAAGENT_ATTACH_TIMEOUT: "90s"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.158.0@sha256:c5918f78992ee73b0d6f0e599423ac5ec52dd5d9726733114d6eca53d5a32ed5
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318:4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+      jaeger:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.60@sha256:4fd2d70fa347d6a47e79fcb06b1c177e6079f92cba88b083153d56263082135e
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - LOG_LEVEL=debug

--- a/internal/test/integration/red_test_java_discovery.go
+++ b/internal/test/integration/red_test_java_discovery.go
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration // import "go.opentelemetry.io/obi/internal/test/integration"
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
+)
+
+// The workload is a JVM started with the attach mechanism disabled, so the
+// agent injection OBI attempts against it never completes and runs for the full
+// OTEL_EBPF_JAVAAGENT_ATTACH_TIMEOUT, which the compose file sets well beyond
+// this assertion window. Its Redis traffic is only visible if the eBPF PID
+// filter is enabled without waiting for that injection.
+func testJavaDiscoveryCapturesEarlyTraffic(t *testing.T, namespace string) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		results, err := pq.Query(`db_client_operation_duration_seconds_count{` +
+			`db_system_name="redis",` +
+			`service_namespace="` + namespace + `"}`)
+		require.NoError(ct, err)
+		enoughPromResults(ct, results)
+		assert.LessOrEqual(ct, 1, totalPromCount(ct, results))
+	}, testTimeout, 100*time.Millisecond)
+}
+
+func testJavaDiscoveryEarlyTraffic(t *testing.T) {
+	testJavaDiscoveryCapturesEarlyTraffic(t, "integration-test")
+}

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -154,6 +154,21 @@ func TestSuite_DNSUnconnectedResolver(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+// A JVM that cannot be attached to must not delay capture of its own traffic
+func TestSuite_JavaDiscoveryEarlyTraffic(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-java-discovery.yml", path.Join(pathOutput, "test-suite-java-discovery.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(
+		compose.Env,
+		`OTEL_EBPF_EXECUTABLE_PATH=java`,
+		`OTEL_EBPF_OPEN_PORT=`,
+	)
+	require.NoError(t, compose.Up())
+	t.Run("early JVM traffic is captured", testJavaDiscoveryEarlyTraffic)
+	require.NoError(t, compose.Close())
+}
+
 func TestSuiteClientPromScrape(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-client.yml", path.Join(pathOutput, "test-suite-client-promscrape.log"))
 	require.NoError(t, err)

--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/cilium/ebpf/link"
@@ -126,6 +127,15 @@ func (ta *traceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 	in := ta.InputInstrumentables.Subscribe(msg.SubscriberName("traceAttacher"))
 	return func(ctx context.Context) {
 		defer ta.OutputTracerEvents.Close()
+		// TODO: cancel an in-flight injection on shutdown (ctx cancellation) or
+		// when a concurrent EventDeleted arrives for the same PID, rather than
+		// only waiting for its internal timeout to elapse. That requires
+		// threading a context.Context through JavaInjector.NewExecutable
+		// (currently it takes only *ebpf.Instrumentable and derives its own
+		// context.Background()-rooted timeout), plus a per-PID cancel-func
+		// registry keyed on the executable key.
+		var javaInjections sync.WaitGroup
+		defer javaInjections.Wait()
 		swarms.ForEachInput(ctx, in, ta.log.Debug, func(instrumentables []Event[ebpf.Instrumentable]) {
 			for _, instr := range instrumentables {
 				ta.log.Debug("Instrumentable", "created", instr.Type, "type", instr.Obj.Type,
@@ -134,15 +144,24 @@ func (ta *traceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 				case EventCreated:
 					ta.resolveServiceMetadata(&instr.Obj)
 					ta.nodeInjector.NewExecutable(&instr.Obj)
-					if ta.javaInjector != nil {
-						if err := ta.javaInjector.NewExecutable(&instr.Obj); err != nil {
-							ta.log.Warn("unable to attach java agent to process, Java TLS telemetry will not work", "pid", instr.Obj.FileInfo.Pid(), "error", err)
-						}
-					}
 
 					ta.processInstances.Inc(executableKey(instr.Obj.FileInfo))
 					if ok := ta.getTracer(&instr.Obj); ok {
 						ta.OutputTracerEvents.Send(Event[*ebpf.Instrumentable]{Type: EventCreated, Obj: &instr.Obj})
+					}
+
+					// Injection blocks for up to the Java attach timeout, so it runs
+					// after the PID is allowed through the eBPF filter, and off the
+					// discovery loop.
+					if ta.javaInjector != nil {
+						javaObj := &instr.Obj
+						javaInjections.Add(1)
+						go func() {
+							defer javaInjections.Done()
+							if err := ta.javaInjector.NewExecutable(javaObj); err != nil {
+								ta.log.Warn("unable to attach java agent to process, Java TLS telemetry will not work", "pid", javaObj.FileInfo.Pid(), "error", err)
+							}
+						}()
 					}
 
 					if instr.Obj.FileInfo.ELF() != nil {

--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
-	"sync"
 	"time"
 
 	"github.com/cilium/ebpf/link"
@@ -127,14 +126,14 @@ func (ta *traceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 	in := ta.InputInstrumentables.Subscribe(msg.SubscriberName("traceAttacher"))
 	return func(ctx context.Context) {
 		defer ta.OutputTracerEvents.Close()
-		// TODO: cancel an in-flight injection on shutdown (ctx cancellation) or
-		// when a concurrent EventDeleted arrives for the same PID, rather than
-		// only waiting for its internal timeout to elapse. That requires
-		// threading a context.Context through JavaInjector.NewExecutable
-		// (which currently derives its own context.Background()-rooted
-		// timeout), plus a per-PID cancel-func registry.
-		var javaInjections sync.WaitGroup
-		defer javaInjections.Wait()
+
+		var javaInjections *javaInjectionQueue
+		if ta.javaInjector != nil {
+			javaInjections = newJavaInjectionQueue(ta.log, ta.javaInjector.NewExecutable)
+			javaInjections.start(ctx)
+			defer javaInjections.wait()
+		}
+
 		swarms.ForEachInput(ctx, in, ta.log.Debug, func(instrumentables []Event[ebpf.Instrumentable]) {
 			for _, instr := range instrumentables {
 				ta.log.Debug("Instrumentable", "created", instr.Type, "type", instr.Obj.Type,
@@ -149,19 +148,13 @@ func (ta *traceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 						ta.OutputTracerEvents.Send(Event[*ebpf.Instrumentable]{Type: EventCreated, Obj: &instr.Obj})
 					}
 
-					// Injection blocks for up to the Java attach timeout, so it runs
-					// after the PID is allowed through the eBPF filter, and off the
-					// discovery loop. The target is copied out here so the goroutine
-					// does not share instr.Obj with the consumers it was just sent to.
-					if ta.javaInjector != nil {
-						target := javaagent.InjectionTargetFrom(&instr.Obj)
-						javaInjections.Add(1)
-						go func() {
-							defer javaInjections.Done()
-							if err := ta.javaInjector.NewExecutable(target); err != nil {
-								ta.log.Warn("unable to attach java agent to process, Java TLS telemetry will not work", "pid", target.Pid, "error", err)
-							}
-						}()
+					// Injection blocks for up to the Java attach timeout, so it is
+					// queued after the PID is allowed through the eBPF filter, and
+					// runs off the discovery loop. The target is copied out here so
+					// the injection does not share instr.Obj with the consumers it
+					// was just sent to.
+					if javaInjections != nil {
+						javaInjections.enqueue(javaagent.InjectionTargetFrom(&instr.Obj))
 					}
 
 					if instr.Obj.FileInfo.ELF() != nil {

--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -131,9 +131,8 @@ func (ta *traceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 		// when a concurrent EventDeleted arrives for the same PID, rather than
 		// only waiting for its internal timeout to elapse. That requires
 		// threading a context.Context through JavaInjector.NewExecutable
-		// (currently it takes only *ebpf.Instrumentable and derives its own
-		// context.Background()-rooted timeout), plus a per-PID cancel-func
-		// registry keyed on the executable key.
+		// (which currently derives its own context.Background()-rooted
+		// timeout), plus a per-PID cancel-func registry.
 		var javaInjections sync.WaitGroup
 		defer javaInjections.Wait()
 		swarms.ForEachInput(ctx, in, ta.log.Debug, func(instrumentables []Event[ebpf.Instrumentable]) {
@@ -152,14 +151,15 @@ func (ta *traceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 
 					// Injection blocks for up to the Java attach timeout, so it runs
 					// after the PID is allowed through the eBPF filter, and off the
-					// discovery loop.
+					// discovery loop. The target is copied out here so the goroutine
+					// does not share instr.Obj with the consumers it was just sent to.
 					if ta.javaInjector != nil {
-						javaObj := &instr.Obj
+						target := javaagent.TargetFrom(&instr.Obj)
 						javaInjections.Add(1)
 						go func() {
 							defer javaInjections.Done()
-							if err := ta.javaInjector.NewExecutable(javaObj); err != nil {
-								ta.log.Warn("unable to attach java agent to process, Java TLS telemetry will not work", "pid", javaObj.FileInfo.Pid(), "error", err)
+							if err := ta.javaInjector.NewExecutable(target); err != nil {
+								ta.log.Warn("unable to attach java agent to process, Java TLS telemetry will not work", "pid", target.Pid, "error", err)
 							}
 						}()
 					}

--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -154,7 +154,7 @@ func (ta *traceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 					// discovery loop. The target is copied out here so the goroutine
 					// does not share instr.Obj with the consumers it was just sent to.
 					if ta.javaInjector != nil {
-						target := javaagent.TargetFrom(&instr.Obj)
+						target := javaagent.InjectionTargetFrom(&instr.Obj)
 						javaInjections.Add(1)
 						go func() {
 							defer javaInjections.Done()

--- a/pkg/appolly/discover/java_injection_queue.go
+++ b/pkg/appolly/discover/java_injection_queue.go
@@ -1,0 +1,88 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package discover // import "go.opentelemetry.io/obi/pkg/appolly/discover"
+
+import (
+	"context"
+	"log/slog"
+
+	javaagent "go.opentelemetry.io/obi/pkg/internal/java"
+)
+
+// javaInjectionQueueLen bounds how many discovered JVMs can wait for injection.
+// The queue only fills while an attach is stuck, and a dropped target loses Java
+// TLS telemetry for that process, nothing else.
+const javaInjectionQueueLen = 100
+
+// javaInjectionQueue performs Java agent injections on a single worker
+// goroutine, off the discovery loop.
+//
+// Injection must not run concurrently with another injection: attaching to a
+// HotSpot JVM switches the euid/egid of the whole OBI process to the target's
+// owner, so two overlapping attaches on processes with different owners would
+// run under, and restore, each other's credentials.
+type javaInjectionQueue struct {
+	log     *slog.Logger
+	inject  func(context.Context, javaagent.InjectionTarget) error
+	targets chan javaagent.InjectionTarget
+	done    chan struct{}
+}
+
+func newJavaInjectionQueue(
+	log *slog.Logger,
+	inject func(context.Context, javaagent.InjectionTarget) error,
+) *javaInjectionQueue {
+	return &javaInjectionQueue{
+		log:     log,
+		inject:  inject,
+		targets: make(chan javaagent.InjectionTarget, javaInjectionQueueLen),
+		done:    make(chan struct{}),
+	}
+}
+
+// start launches the worker. Targets are injected one at a time, in the order
+// they were discovered.
+func (q *javaInjectionQueue) start(ctx context.Context) {
+	go func() {
+		defer close(q.done)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case target := <-q.targets:
+				// A ready target and a cancelled context make both cases above
+				// eligible, and select would pick either. No new attach may
+				// start once shutdown has begun.
+				if ctx.Err() != nil {
+					return
+				}
+
+				if err := q.inject(ctx, target); err != nil {
+					q.log.Warn("unable to attach java agent to process, Java TLS telemetry will not work",
+						"pid", target.Pid, "error", err)
+				}
+			}
+		}
+	}()
+}
+
+// enqueue never blocks. A stuck attach holds the worker for up to the Java
+// attach timeout, and process discovery must keep running meanwhile.
+func (q *javaInjectionQueue) enqueue(target javaagent.InjectionTarget) {
+	select {
+	case q.targets <- target:
+	case <-q.done:
+		q.log.Debug("java injection queue stopped, skipping java agent injection", "pid", target.Pid)
+	default:
+		q.log.Warn("java injection queue is full, skipping java agent injection", "pid", target.Pid)
+	}
+}
+
+// wait joins the worker. The injection in flight observes the cancelled context
+// through its own attach deadline, so this returns without waiting for that
+// deadline to elapse.
+func (q *javaInjectionQueue) wait() {
+	<-q.done
+}

--- a/pkg/appolly/discover/java_injection_queue.go
+++ b/pkg/appolly/discover/java_injection_queue.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log/slog"
 
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	javaagent "go.opentelemetry.io/obi/pkg/internal/java"
 )
 
@@ -70,7 +71,15 @@ func (q *javaInjectionQueue) start(ctx context.Context) {
 
 // enqueue never blocks. A stuck attach holds the worker for up to the Java
 // attach timeout, and process discovery must keep running meanwhile.
+//
+// Only JVMs are admitted: the queue is bounded, and letting processes the
+// injector would ignore consume slots would let unrelated discovery churn
+// evict a real JVM while an attach is stuck.
 func (q *javaInjectionQueue) enqueue(target javaagent.InjectionTarget) {
+	if target.Type != svc.InstrumentableJava {
+		return
+	}
+
 	select {
 	case q.targets <- target:
 	case <-q.done:

--- a/pkg/appolly/discover/java_injection_queue_test.go
+++ b/pkg/appolly/discover/java_injection_queue_test.go
@@ -1,0 +1,234 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package discover
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	javaagent "go.opentelemetry.io/obi/pkg/internal/java"
+)
+
+func javaTarget(pid app.PID) javaagent.InjectionTarget {
+	return javaagent.InjectionTarget{Pid: pid}
+}
+
+// Attaching to a HotSpot JVM switches the euid/egid of the whole OBI process,
+// so two injections must never be in flight at the same time.
+func TestJavaInjectionQueue_InjectsOneAtATimeInOrder(t *testing.T) {
+	const targets = 20
+
+	var (
+		mt       sync.Mutex
+		order    []app.PID
+		inFlight atomic.Int32
+		maxSeen  atomic.Int32
+	)
+	done := make(chan struct{})
+
+	queue := newJavaInjectionQueue(slog.Default(), func(_ context.Context, target javaagent.InjectionTarget) error {
+		if current := inFlight.Add(1); current > maxSeen.Load() {
+			maxSeen.Store(current)
+		}
+		// Widen the window in which an overlapping injection would be visible.
+		time.Sleep(time.Millisecond)
+
+		mt.Lock()
+		order = append(order, target.Pid)
+		last := len(order) == targets
+		mt.Unlock()
+
+		inFlight.Add(-1)
+		if last {
+			close(done)
+		}
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	queue.start(ctx)
+
+	var want []app.PID
+	for pid := app.PID(1); pid <= targets; pid++ {
+		queue.enqueue(javaTarget(pid))
+		want = append(want, pid)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(testTimeout):
+		t.Fatal("timed out waiting for all injections")
+	}
+
+	assert.Equal(t, int32(1), maxSeen.Load(), "injections must not overlap")
+	mt.Lock()
+	defer mt.Unlock()
+	assert.Equal(t, want, order)
+}
+
+// Models what jvm.JAttacher does: it switches the euid/egid of the whole OBI
+// process to the target's owner and restores the previous values when the attach
+// ends. JVMs owned by different users must never see each other's identity.
+func TestJavaInjectionQueue_NoTwoJVMsShareProcessCredentials(t *testing.T) {
+	const (
+		obiUID  = 0
+		targets = 20
+	)
+
+	var (
+		processEUID atomic.Int32
+		violations  atomic.Int32
+		injected    atomic.Int32
+	)
+	processEUID.Store(obiUID)
+	done := make(chan struct{})
+
+	queue := newJavaInjectionQueue(slog.Default(), func(_ context.Context, target javaagent.InjectionTarget) error {
+		targetUID := int32(target.Pid)
+
+		if !processEUID.CompareAndSwap(obiUID, targetUID) {
+			violations.Add(1)
+		}
+		time.Sleep(time.Millisecond)
+
+		// Restoring is only correct if nothing else moved the credentials in
+		// the meantime.
+		if !processEUID.CompareAndSwap(targetUID, obiUID) {
+			violations.Add(1)
+		}
+
+		if injected.Add(1) == targets {
+			close(done)
+		}
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	queue.start(ctx)
+
+	for pid := app.PID(1); pid <= targets; pid++ {
+		queue.enqueue(javaTarget(pid))
+	}
+
+	select {
+	case <-done:
+	case <-time.After(testTimeout):
+		t.Fatal("timed out waiting for all injections")
+	}
+
+	assert.Equal(t, int32(0), violations.Load(), "an injection ran under or restored another target's credentials")
+	assert.Equal(t, int32(obiUID), processEUID.Load())
+}
+
+// A stuck attach holds the worker for up to the attach timeout. Discovery must
+// keep making progress meanwhile, so enqueue never blocks.
+func TestJavaInjectionQueue_EnqueueDoesNotBlockOnStuckInjection(t *testing.T) {
+	injecting := make(chan struct{})
+	release := make(chan struct{})
+	var firstInjection sync.Once
+
+	queue := newJavaInjectionQueue(slog.Default(), func(ctx context.Context, _ javaagent.InjectionTarget) error {
+		firstInjection.Do(func() { close(injecting) })
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	queue.start(ctx)
+
+	queue.enqueue(javaTarget(1))
+	<-injecting
+
+	enqueued := make(chan struct{})
+	go func() {
+		defer close(enqueued)
+		// One more than the buffer, to also cover the full-queue drop path.
+		for pid := app.PID(2); pid <= javaInjectionQueueLen+2; pid++ {
+			queue.enqueue(javaTarget(pid))
+		}
+	}()
+
+	select {
+	case <-enqueued:
+	case <-time.After(testTimeout):
+		t.Fatal("enqueue blocked behind a stuck injection")
+	}
+
+	close(release)
+}
+
+// javaInjections.wait() runs inside the attacher loop's shutdown path, which the
+// pipeline bounds with its own cancel timeout. The in-flight injection sees the
+// cancelled context, so the drain must not wait out the attach timeout.
+func TestJavaInjectionQueue_ShutdownCancelsInFlightAndSkipsPending(t *testing.T) {
+	injecting := make(chan struct{})
+	var started atomic.Int32
+	cancelled := make(chan struct{}, 1)
+
+	queue := newJavaInjectionQueue(slog.Default(), func(ctx context.Context, _ javaagent.InjectionTarget) error {
+		if started.Add(1) == 1 {
+			close(injecting)
+		}
+		<-ctx.Done()
+		cancelled <- struct{}{}
+		return ctx.Err()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	queue.start(ctx)
+
+	queue.enqueue(javaTarget(1))
+	<-injecting
+	queue.enqueue(javaTarget(2))
+	queue.enqueue(javaTarget(3))
+
+	cancel()
+
+	waited := make(chan struct{})
+	go func() {
+		queue.wait()
+		close(waited)
+	}()
+
+	select {
+	case <-waited:
+	case <-time.After(testTimeout):
+		t.Fatal("shutdown did not return after context cancellation")
+	}
+
+	require.Len(t, cancelled, 1)
+	assert.Equal(t, int32(1), started.Load(), "queued targets must not be injected during shutdown")
+}
+
+func TestJavaInjectionQueue_EnqueueAfterShutdownIsDropped(t *testing.T) {
+	var injections atomic.Int32
+
+	queue := newJavaInjectionQueue(slog.Default(), func(context.Context, javaagent.InjectionTarget) error {
+		injections.Add(1)
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	queue.start(ctx)
+	cancel()
+	queue.wait()
+
+	queue.enqueue(javaTarget(1))
+
+	assert.Equal(t, int32(0), injections.Load())
+}

--- a/pkg/appolly/discover/java_injection_queue_test.go
+++ b/pkg/appolly/discover/java_injection_queue_test.go
@@ -15,11 +15,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	javaagent "go.opentelemetry.io/obi/pkg/internal/java"
 )
 
 func javaTarget(pid app.PID) javaagent.InjectionTarget {
-	return javaagent.InjectionTarget{Pid: pid}
+	return javaagent.InjectionTarget{Type: svc.InstrumentableJava, Pid: pid}
 }
 
 // Attaching to a HotSpot JVM switches the euid/egid of the whole OBI process,
@@ -213,6 +214,57 @@ func TestJavaInjectionQueue_ShutdownCancelsInFlightAndSkipsPending(t *testing.T)
 
 	require.Len(t, cancelled, 1)
 	assert.Equal(t, int32(1), started.Load(), "queued targets must not be injected during shutdown")
+}
+
+// The queue is bounded and only JVMs are ever injected. If processes of other
+// languages took slots, discovery churn during a stuck attach would evict a JVM
+// discovered later, losing its Java TLS telemetry for the life of the process.
+func TestJavaInjectionQueue_OnlyJVMsAreAdmitted(t *testing.T) {
+	injecting := make(chan struct{})
+	release := make(chan struct{})
+	injected := make(chan app.PID, javaInjectionQueueLen+2)
+	var firstInjection sync.Once
+
+	queue := newJavaInjectionQueue(slog.Default(), func(ctx context.Context, target javaagent.InjectionTarget) error {
+		injected <- target.Pid
+		firstInjection.Do(func() {
+			close(injecting)
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+		})
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	queue.start(ctx)
+
+	// Hold the worker, then flood the queue with processes the injector would
+	// ignore, well past its capacity.
+	queue.enqueue(javaTarget(1))
+	<-injecting
+	require.Equal(t, app.PID(1), <-injected)
+
+	for pid := app.PID(2); pid <= javaInjectionQueueLen+2; pid++ {
+		queue.enqueue(javaagent.InjectionTarget{Type: svc.InstrumentableGeneric, Pid: pid})
+	}
+
+	const lateJVM = app.PID(javaInjectionQueueLen + 3)
+	queue.enqueue(javaTarget(lateJVM))
+	close(release)
+
+	select {
+	case pid := <-injected:
+		assert.Equal(t, lateJVM, pid, "a JVM discovered after non-Java processes must still be injected")
+	case <-time.After(testTimeout):
+		t.Fatal("timed out waiting for the second injection")
+	}
+
+	cancel()
+	queue.wait()
+	assert.Empty(t, injected, "only JVMs may be injected")
 }
 
 func TestJavaInjectionQueue_EnqueueAfterShutdownIsDropped(t *testing.T) {

--- a/pkg/internal/java/injection_target.go
+++ b/pkg/internal/java/injection_target.go
@@ -7,7 +7,11 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/ebpf"
+	"go.opentelemetry.io/obi/pkg/internal/procs"
 )
+
+// to be changed in tests
+var processStartTime = procs.StartTime
 
 // InjectionTarget is everything the injector reads about a process. Callers
 // copy these values out of the Instrumentable up front, so injection can run
@@ -18,12 +22,26 @@ type InjectionTarget struct {
 	Pid  app.PID
 	// TempDirEnv is the process' TMPDIR, empty when it does not set one.
 	TempDirEnv string
+	// StartTime pins the target to one incarnation of Pid. Injection is queued
+	// by numeric PID and can run long after discovery saw the process, so the
+	// kernel may have recycled that PID for an unrelated program in the
+	// meantime. Zero when the start time could not be read, in which case the
+	// target cannot be identified and injection refuses it.
+	StartTime uint64
 }
 
 func InjectionTargetFrom(ie *ebpf.Instrumentable) InjectionTarget {
+	pid := ie.FileInfo.Pid()
+
+	// A failure here means the process is already gone or /proc is unreadable.
+	// StartTime stays zero, which the injector treats as an unidentifiable
+	// target and refuses.
+	startTime, _ := processStartTime(pid)
+
 	return InjectionTarget{
 		Type:       ie.Type,
-		Pid:        ie.FileInfo.Pid(),
+		Pid:        pid,
 		TempDirEnv: ie.FileInfo.ServiceAttrs().EnvVars["TMPDIR"],
+		StartTime:  startTime,
 	}
 }

--- a/pkg/internal/java/injection_target.go
+++ b/pkg/internal/java/injection_target.go
@@ -9,18 +9,19 @@ import (
 	"go.opentelemetry.io/obi/pkg/ebpf"
 )
 
-// Target is everything the injector reads about a process. Callers copy these
-// values out of the Instrumentable up front, so injection can run concurrently
-// with the rest of the discovery pipeline without sharing that object.
-type Target struct {
+// InjectionTarget is everything the injector reads about a process. Callers
+// copy these values out of the Instrumentable up front, so injection can run
+// concurrently with the rest of the discovery pipeline without sharing that
+// object.
+type InjectionTarget struct {
 	Type svc.InstrumentableType
 	Pid  app.PID
 	// TempDirEnv is the process' TMPDIR, empty when it does not set one.
 	TempDirEnv string
 }
 
-func TargetFrom(ie *ebpf.Instrumentable) Target {
-	return Target{
+func InjectionTargetFrom(ie *ebpf.Instrumentable) InjectionTarget {
+	return InjectionTarget{
 		Type:       ie.Type,
 		Pid:        ie.FileInfo.Pid(),
 		TempDirEnv: ie.FileInfo.ServiceAttrs().EnvVars["TMPDIR"],

--- a/pkg/internal/java/injection_target_test.go
+++ b/pkg/internal/java/injection_target_test.go
@@ -1,0 +1,189 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package javaagent
+
+import (
+	"errors"
+	"log/slog"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	execdiscover "go.opentelemetry.io/obi/pkg/appolly/discover/exec"
+	"go.opentelemetry.io/obi/pkg/ebpf"
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+func stubProcessStartTime(t *testing.T, fn func(app.PID) (uint64, error)) {
+	original := processStartTime
+	t.Cleanup(func() { processStartTime = original })
+	processStartTime = fn
+}
+
+func TestInjectionTargetFrom_CapturesStartTime(t *testing.T) {
+	stubProcessStartTime(t, func(pid app.PID) (uint64, error) {
+		require.Equal(t, app.PID(1000), pid)
+		return 4242, nil
+	})
+
+	target := InjectionTargetFrom(&ebpf.Instrumentable{
+		FileInfo: execdiscover.New(execdiscover.Init{Pid: 1000}),
+		Type:     svc.InstrumentableJava,
+	})
+
+	assert.Equal(t, uint64(4242), target.StartTime)
+}
+
+func TestInjectionTargetFrom_UnreadableStartTime(t *testing.T) {
+	stubProcessStartTime(t, func(app.PID) (uint64, error) {
+		return 0, errors.New("no such process")
+	})
+
+	target := InjectionTargetFrom(&ebpf.Instrumentable{
+		FileInfo: execdiscover.New(execdiscover.Init{Pid: 1000}),
+		Type:     svc.InstrumentableJava,
+	})
+
+	assert.Zero(t, target.StartTime)
+}
+
+func TestVerifyTargetIdentity(t *testing.T) {
+	tests := []struct {
+		name          string
+		startTime     uint64
+		current       func(app.PID) (uint64, error)
+		errorContains string
+	}{
+		{
+			name:      "same process",
+			startTime: 4242,
+			current:   func(app.PID) (uint64, error) { return 4242, nil },
+		},
+		{
+			name:      "start time unknown, target is refused",
+			startTime: 0,
+			current: func(app.PID) (uint64, error) {
+				t.Error("start time must not be read when none was captured")
+				return 0, nil
+			},
+			errorContains: "identity of process 1000 was not captured",
+		},
+		{
+			name:          "pid reused by another process",
+			startTime:     4242,
+			current:       func(app.PID) (uint64, error) { return 5353, nil },
+			errorContains: "was replaced before injection",
+		},
+		{
+			name:          "process is gone",
+			startTime:     4242,
+			current:       func(app.PID) (uint64, error) { return 0, errors.New("no such process") },
+			errorContains: "cannot confirm identity",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubProcessStartTime(t, tt.current)
+
+			err := verifyTargetIdentity(InjectionTarget{
+				Type:      svc.InstrumentableJava,
+				Pid:       1000,
+				StartTime: tt.startTime,
+			})
+
+			if tt.errorContains == "" {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errorContains)
+		})
+	}
+}
+
+// A target queued before its PID was recycled must be left alone: the attach
+// sequence signals the process with SIGQUIT and writes into its root
+// filesystem, which would terminate or corrupt an unrelated program.
+func TestJavaInjector_NewExecutableLeavesReusedPIDAlone(t *testing.T) {
+	victim := exec.Command("sleep", "60")
+	require.NoError(t, victim.Start())
+	t.Cleanup(func() {
+		_ = victim.Process.Kill()
+		_ = victim.Wait()
+	})
+
+	pid := app.PID(victim.Process.Pid)
+
+	startTime, err := processStartTime(pid)
+	require.NoError(t, err)
+
+	injector := &JavaInjector{
+		cfg: &obi.DefaultConfig,
+		log: slog.With("component", "javaagent.Injector"),
+	}
+
+	// The captured start time belongs to the process that has since exited, so
+	// it never matches the one now holding this PID.
+	err = injector.NewExecutable(InjectionTarget{
+		Type:      svc.InstrumentableJava,
+		Pid:       pid,
+		StartTime: startTime + 1,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "was replaced before injection")
+
+	// SIGQUIT would have terminated the replacement process.
+	time.Sleep(100 * time.Millisecond)
+	assert.NoError(t, victim.Process.Signal(syscall.Signal(0)), "the process holding the reused PID was disturbed")
+}
+
+// A start time that could not be read at discovery leaves the target with no
+// identity to check later, so the whole path from InjectionTargetFrom to the
+// attach must fail closed. Injecting anyway would signal whichever process
+// holds the PID by the time the queue reaches it.
+func TestJavaInjector_NewExecutableRefusesUnidentifiedTarget(t *testing.T) {
+	victim := exec.Command("sleep", "60")
+	require.NoError(t, victim.Start())
+	t.Cleanup(func() {
+		_ = victim.Process.Kill()
+		_ = victim.Wait()
+	})
+
+	pid := app.PID(victim.Process.Pid)
+
+	stubProcessStartTime(t, func(app.PID) (uint64, error) {
+		return 0, errors.New("no such process")
+	})
+
+	target := InjectionTargetFrom(&ebpf.Instrumentable{
+		FileInfo: execdiscover.New(execdiscover.Init{Pid: pid}),
+		Type:     svc.InstrumentableJava,
+	})
+	require.Zero(t, target.StartTime)
+
+	injector := &JavaInjector{
+		cfg: &obi.DefaultConfig,
+		log: slog.With("component", "javaagent.Injector"),
+	}
+
+	err := injector.NewExecutable(target)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "was not captured")
+
+	// SIGQUIT would have terminated the process holding the PID.
+	time.Sleep(100 * time.Millisecond)
+	assert.NoError(t, victim.Process.Signal(syscall.Signal(0)), "an unidentifiable target was disturbed")
+}

--- a/pkg/internal/java/injection_target_test.go
+++ b/pkg/internal/java/injection_target_test.go
@@ -135,7 +135,7 @@ func TestJavaInjector_NewExecutableLeavesReusedPIDAlone(t *testing.T) {
 
 	// The captured start time belongs to the process that has since exited, so
 	// it never matches the one now holding this PID.
-	err = injector.NewExecutable(InjectionTarget{
+	err = injector.NewExecutable(t.Context(), InjectionTarget{
 		Type:      svc.InstrumentableJava,
 		Pid:       pid,
 		StartTime: startTime + 1,
@@ -178,7 +178,7 @@ func TestJavaInjector_NewExecutableRefusesUnidentifiedTarget(t *testing.T) {
 		log: slog.With("component", "javaagent.Injector"),
 	}
 
-	err := injector.NewExecutable(target)
+	err := injector.NewExecutable(t.Context(), target)
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "was not captured")

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -160,9 +160,17 @@ func verifyTargetIdentity(target InjectionTarget) error {
 	return nil
 }
 
-func (i *JavaInjector) NewExecutable(target InjectionTarget) error {
+// NewExecutable injects the Java agent into target. The attach deadline is
+// derived from ctx, so canceling ctx abandons an in-flight attach instead of
+// waiting out the configured timeout.
+func (i *JavaInjector) NewExecutable(ctx context.Context, target InjectionTarget) error {
 	if target.Type != svc.InstrumentableJava {
 		return nil
+	}
+
+	// Nothing should signal a JVM once the caller has given up.
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	// Injection is queued by PID and can start long after discovery, so the
@@ -173,7 +181,7 @@ func (i *JavaInjector) NewExecutable(target InjectionTarget) error {
 
 	attachID := i.nextAttachID()
 
-	ctx, cancel := context.WithTimeout(context.Background(), i.cfg.Java.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, i.cfg.Java.Timeout)
 	defer cancel()
 
 	// Channel to receive the result
@@ -262,8 +270,12 @@ func (i *JavaInjector) NewExecutable(target InjectionTarget) error {
 	case result := <-resultChan:
 		return result.err
 	case <-ctx.Done():
-		i.log.Warn("java attach timed out", "timeout", i.cfg.Java.Timeout, "pid", target.Pid)
-		return &JavaInjectError{Message: "java attach timed out"}
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			i.log.Warn("java attach timed out", "timeout", i.cfg.Java.Timeout, "pid", target.Pid)
+			return &JavaInjectError{Message: "java attach timed out"}
+		}
+		i.log.Debug("java attach abandoned", "pid", target.Pid, "error", ctx.Err())
+		return &JavaInjectError{Message: "java attach canceled"}
 	}
 }
 

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -134,9 +134,41 @@ func (i *JavaInjector) runIfCurrentAttach(
 	return fn()
 }
 
+// verifyTargetIdentity fails when Pid no longer refers to the process that was
+// queued for injection. Every attach-side operation (entering the target's
+// namespaces, dropping to its credentials, writing the agent into its root
+// filesystem, and signaling it with SIGQUIT) is destructive to an unrelated
+// process, so it must be preceded by this check.
+//
+// A target whose start time was never captured cannot be checked at all, so it
+// is refused rather than injected on the assumption that its PID still holds
+// the process discovery saw.
+func verifyTargetIdentity(target InjectionTarget) error {
+	if target.StartTime == 0 {
+		return &JavaInjectError{Message: fmt.Sprintf("identity of process %d was not captured, refusing to inject", target.Pid)}
+	}
+
+	startTime, err := processStartTime(target.Pid)
+	if err != nil {
+		return &JavaInjectError{Message: fmt.Sprintf("cannot confirm identity of process %d: %s", target.Pid, err)}
+	}
+
+	if startTime != target.StartTime {
+		return &JavaInjectError{Message: fmt.Sprintf("process %d was replaced before injection", target.Pid)}
+	}
+
+	return nil
+}
+
 func (i *JavaInjector) NewExecutable(target InjectionTarget) error {
 	if target.Type != svc.InstrumentableJava {
 		return nil
+	}
+
+	// Injection is queued by PID and can start long after discovery, so the
+	// process must be proven to be the one we discovered before we touch it.
+	if err := verifyTargetIdentity(target); err != nil {
+		return err
 	}
 
 	attachID := i.nextAttachID()
@@ -200,6 +232,14 @@ func (i *JavaInjector) NewExecutable(target InjectionTarget) error {
 		}
 
 		i.log.Info("injecting OpenTelemetry eBPF instrumentation for Java process", "pid", target.Pid)
+
+		// The handshake above can block for the whole attach timeout, which is
+		// long enough for the PID to be recycled before we write into the
+		// target's root filesystem and load the agent.
+		if err := verifyTargetIdentity(target); err != nil {
+			resultChan <- result{err: err}
+			return
+		}
 
 		agentPath, err := i.copyAgent(target.Pid, target.TempDirEnv)
 		if err != nil {

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -22,7 +22,6 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
-	"go.opentelemetry.io/obi/pkg/ebpf"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/internal/jvmtools/jvm"
 	"go.opentelemetry.io/obi/pkg/obi"
@@ -95,11 +94,9 @@ func dirOK(root, dir string) bool {
 	return err == nil && info.IsDir()
 }
 
-func (i *JavaInjector) findTempDir(root string, ie *ebpf.Instrumentable) (string, error) {
-	if tmpDir, ok := ie.FileInfo.ServiceAttrs().EnvVars["TMPDIR"]; ok {
-		if dirOK(root, tmpDir) {
-			return tmpDir, nil
-		}
+func (i *JavaInjector) findTempDir(root, tempDirEnv string) (string, error) {
+	if tempDirEnv != "" && dirOK(root, tempDirEnv) {
+		return tempDirEnv, nil
 	}
 
 	tmpDir := "/tmp"
@@ -137,8 +134,8 @@ func (i *JavaInjector) runIfCurrentAttach(
 	return fn()
 }
 
-func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
-	if ie.Type != svc.InstrumentableJava {
+func (i *JavaInjector) NewExecutable(target Target) error {
+	if target.Type != svc.InstrumentableJava {
 		return nil
 	}
 
@@ -177,7 +174,7 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 			}
 		}()
 
-		ok, jdk8 := i.verifyJVMVersion(ctx, attacher, ie.FileInfo.Pid())
+		ok, jdk8 := i.verifyJVMVersion(ctx, attacher, target.Pid)
 		if !ok {
 			resultChan <- result{err: &JavaInjectError{Message: "unsupported Java version for OpenTelemetry eBPF instrumentation"}}
 			return
@@ -186,9 +183,9 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 		var loaded bool
 		var err error
 		if jdk8 {
-			loaded, err = i.jdkAgentAlreadyLoadedHotspot8(ctx, attacher, ie.FileInfo.Pid())
+			loaded, err = i.jdkAgentAlreadyLoadedHotspot8(ctx, attacher, target.Pid)
 		} else {
-			loaded, err = i.jdkAgentAlreadyLoaded(ctx, attacher, ie.FileInfo.Pid())
+			loaded, err = i.jdkAgentAlreadyLoaded(ctx, attacher, target.Pid)
 		}
 
 		if err != nil {
@@ -202,17 +199,17 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 			return
 		}
 
-		i.log.Info("injecting OpenTelemetry eBPF instrumentation for Java process", "pid", ie.FileInfo.Pid())
+		i.log.Info("injecting OpenTelemetry eBPF instrumentation for Java process", "pid", target.Pid)
 
-		agentPath, err := i.copyAgent(ie)
+		agentPath, err := i.copyAgent(target.Pid, target.TempDirEnv)
 		if err != nil {
-			i.log.Error("failed to extract java agent", "pid", ie.FileInfo.Pid(), "error", err)
+			i.log.Error("failed to extract java agent", "pid", target.Pid, "error", err)
 			resultChan <- result{err: err}
 			return
 		}
 
-		if err = i.attachJDKAgent(ctx, attacher, ie.FileInfo.Pid(), agentPath); err != nil {
-			i.log.Error("couldn't attach OpenTelemetry eBPF Java Agent", "pid", ie.FileInfo.Pid(), "path", agentPath, "error", err)
+		if err = i.attachJDKAgent(ctx, attacher, target.Pid, agentPath); err != nil {
+			i.log.Error("couldn't attach OpenTelemetry eBPF Java Agent", "pid", target.Pid, "path", agentPath, "error", err)
 			resultChan <- result{err: err}
 			return
 		}
@@ -225,7 +222,7 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 	case result := <-resultChan:
 		return result.err
 	case <-ctx.Done():
-		i.log.Warn("java attach timed out", "timeout", i.cfg.Java.Timeout, "pid", ie.FileInfo.Pid())
+		i.log.Warn("java attach timed out", "timeout", i.cfg.Java.Timeout, "pid", target.Pid)
 		return &JavaInjectError{Message: "java attach timed out"}
 	}
 }
@@ -241,9 +238,9 @@ func ensureEmbeddedAgent() error {
 // to be changed in tests
 var rootDirForPID func(app.PID) string = ebpfcommon.RootDirectoryForPID
 
-func (i *JavaInjector) copyAgent(ie *ebpf.Instrumentable) (string, error) {
-	root := rootDirForPID(ie.FileInfo.Pid())
-	tempDir, err := i.findTempDir(root, ie)
+func (i *JavaInjector) copyAgent(pid app.PID, tempDirEnv string) (string, error) {
+	root := rootDirForPID(pid)
+	tempDir, err := i.findTempDir(root, tempDirEnv)
 	if err != nil {
 		return "", fmt.Errorf("error accessing temp directory: %w", err)
 	}
@@ -253,7 +250,7 @@ func (i *JavaInjector) copyAgent(ie *ebpf.Instrumentable) (string, error) {
 		return "", fmt.Errorf("invalid temp directory for injection: %q", tempDir)
 	}
 
-	i.log.Info("found injection directory for process", "pid", ie.FileInfo.Pid(), "path", fullTempDir)
+	i.log.Info("found injection directory for process", "pid", pid, "path", fullTempDir)
 
 	agentPathHost := filepath.Join(fullTempDir, ObiJavaAgentFileName)
 

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -134,7 +134,7 @@ func (i *JavaInjector) runIfCurrentAttach(
 	return fn()
 }
 
-func (i *JavaInjector) NewExecutable(target Target) error {
+func (i *JavaInjector) NewExecutable(target InjectionTarget) error {
 	if target.Type != svc.InstrumentableJava {
 		return nil
 	}

--- a/pkg/internal/java/java_inject_notlinux.go
+++ b/pkg/internal/java/java_inject_notlinux.go
@@ -10,4 +10,4 @@ package javaagent // import "go.opentelemetry.io/obi/pkg/internal/java"
 type JavaInjector struct{}
 
 func NewJavaInjector(_ any) (*JavaInjector, error) { return nil, nil }
-func (*JavaInjector) NewExecutable(_ Target) error { return nil }
+func (*JavaInjector) NewExecutable(_ InjectionTarget) error { return nil }

--- a/pkg/internal/java/java_inject_notlinux.go
+++ b/pkg/internal/java/java_inject_notlinux.go
@@ -5,9 +5,13 @@
 
 package javaagent // import "go.opentelemetry.io/obi/pkg/internal/java"
 
+import "context"
+
 // placeholder to avoid compilation errors in non-linux platforms
 
 type JavaInjector struct{}
 
-func NewJavaInjector(_ any) (*JavaInjector, error)          { return nil, nil }
-func (*JavaInjector) NewExecutable(_ InjectionTarget) error { return nil }
+func NewJavaInjector(_ any) (*JavaInjector, error) { return nil, nil }
+func (*JavaInjector) NewExecutable(_ context.Context, _ InjectionTarget) error {
+	return nil
+}

--- a/pkg/internal/java/java_inject_notlinux.go
+++ b/pkg/internal/java/java_inject_notlinux.go
@@ -10,4 +10,4 @@ package javaagent // import "go.opentelemetry.io/obi/pkg/internal/java"
 type JavaInjector struct{}
 
 func NewJavaInjector(_ any) (*JavaInjector, error) { return nil, nil }
-func (*JavaInjector) NewExecutable(_ any) error    { return nil }
+func (*JavaInjector) NewExecutable(_ Target) error { return nil }

--- a/pkg/internal/java/java_inject_notlinux.go
+++ b/pkg/internal/java/java_inject_notlinux.go
@@ -9,5 +9,5 @@ package javaagent // import "go.opentelemetry.io/obi/pkg/internal/java"
 
 type JavaInjector struct{}
 
-func NewJavaInjector(_ any) (*JavaInjector, error) { return nil, nil }
+func NewJavaInjector(_ any) (*JavaInjector, error)          { return nil, nil }
 func (*JavaInjector) NewExecutable(_ InjectionTarget) error { return nil }

--- a/pkg/internal/java/java_inject_test.go
+++ b/pkg/internal/java/java_inject_test.go
@@ -228,7 +228,7 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 				log: slog.With("component", "javaagent.Injector"),
 			}
 
-			ie := &ebpf.Instrumentable{
+			target := TargetFrom(&ebpf.Instrumentable{
 				FileInfo: exec.New(exec.Init{
 					Pid: tt.pid,
 					Service: svc.Attrs{
@@ -236,9 +236,9 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 					},
 				}),
 				Type: svc.InstrumentableJava,
-			}
+			})
 
-			resultPath, err := injector.copyAgent(ie)
+			resultPath, err := injector.copyAgent(target.Pid, target.TempDirEnv)
 
 			if tt.expectError {
 				require.Error(t, err)
@@ -367,15 +367,15 @@ func TestJavaInjector_FindTempDir(t *testing.T) {
 				cfg: &obi.Config{},
 			}
 
-			ie := &ebpf.Instrumentable{
+			target := TargetFrom(&ebpf.Instrumentable{
 				FileInfo: exec.New(exec.Init{
 					Service: svc.Attrs{
 						EnvVars: tt.envVars,
 					},
 				}),
-			}
+			})
 
-			tmpDir, err := injector.findTempDir(root, ie)
+			tmpDir, err := injector.findTempDir(root, target.TempDirEnv)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/pkg/internal/java/java_inject_test.go
+++ b/pkg/internal/java/java_inject_test.go
@@ -6,11 +6,13 @@
 package javaagent
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -543,6 +545,41 @@ func TestJavaInjector_AttachOpts(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+// The attach deadline must be derived from the caller's context, so a shutdown
+// abandons the attach instead of signaling a JVM and waiting out the timeout.
+func TestJavaInjector_NewExecutable_CanceledContextStartsNoAttach(t *testing.T) {
+	injector := &JavaInjector{
+		log: slog.Default(),
+		cfg: &obi.Config{Java: obi.JavaConfig{Enabled: true, Timeout: time.Hour}},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	err := injector.NewExecutable(ctx, InjectionTarget{
+		Type: svc.InstrumentableJava,
+		Pid:  app.PID(os.Getpid()),
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, time.Since(start), time.Second)
+	assert.Equal(t, int64(0), injector.currentAttachID, "no attach should have been started")
+}
+
+func TestJavaInjector_NewExecutable_IgnoresNonJavaTarget(t *testing.T) {
+	injector := &JavaInjector{
+		log: slog.Default(),
+		cfg: &obi.Config{Java: obi.JavaConfig{Enabled: true, Timeout: time.Hour}},
+	}
+
+	require.NoError(t, injector.NewExecutable(context.Background(), InjectionTarget{
+		Type: svc.InstrumentableGolang,
+		Pid:  app.PID(os.Getpid()),
+	}))
+	assert.Equal(t, int64(0), injector.currentAttachID)
 }
 
 func TestNewJavaInjector_Disabled(t *testing.T) {

--- a/pkg/internal/java/java_inject_test.go
+++ b/pkg/internal/java/java_inject_test.go
@@ -228,7 +228,7 @@ func TestJavaInjector_CopyAgent(t *testing.T) {
 				log: slog.With("component", "javaagent.Injector"),
 			}
 
-			target := TargetFrom(&ebpf.Instrumentable{
+			target := InjectionTargetFrom(&ebpf.Instrumentable{
 				FileInfo: exec.New(exec.Init{
 					Pid: tt.pid,
 					Service: svc.Attrs{
@@ -367,7 +367,7 @@ func TestJavaInjector_FindTempDir(t *testing.T) {
 				cfg: &obi.Config{},
 			}
 
-			target := TargetFrom(&ebpf.Instrumentable{
+			target := InjectionTargetFrom(&ebpf.Instrumentable{
 				FileInfo: exec.New(exec.Init{
 					Service: svc.Attrs{
 						EnvVars: tt.envVars,

--- a/pkg/internal/java/target.go
+++ b/pkg/internal/java/target.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package javaagent // import "go.opentelemetry.io/obi/pkg/internal/java"
+
+import (
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
+	"go.opentelemetry.io/obi/pkg/ebpf"
+)
+
+// Target is everything the injector reads about a process. Callers copy these
+// values out of the Instrumentable up front, so injection can run concurrently
+// with the rest of the discovery pipeline without sharing that object.
+type Target struct {
+	Type svc.InstrumentableType
+	Pid  app.PID
+	// TempDirEnv is the process' TMPDIR, empty when it does not set one.
+	TempDirEnv string
+}
+
+func TargetFrom(ie *ebpf.Instrumentable) Target {
+	return Target{
+		Type:       ie.Type,
+		Pid:        ie.FileInfo.Pid(),
+		TempDirEnv: ie.FileInfo.ServiceAttrs().EnvVars["TMPDIR"],
+	}
+}

--- a/pkg/internal/procs/procstat.go
+++ b/pkg/internal/procs/procstat.go
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package procs // import "go.opentelemetry.io/obi/pkg/internal/procs"
+
+import (
+	"fmt"
+
+	"github.com/prometheus/procfs"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app"
+)
+
+// StartTime returns the process start time in clock ticks since boot, as
+// reported by /proc/<pid>/stat. Together with the PID it identifies a process
+// unambiguously, so callers can detect PID reuse.
+func StartTime(pid app.PID) (uint64, error) {
+	proc, err := procfs.NewProc(int(pid))
+	if err != nil {
+		return 0, fmt.Errorf("opening process %d: %w", pid, err)
+	}
+
+	stat, err := proc.Stat()
+	if err != nil {
+		return 0, fmt.Errorf("reading stat of process %d: %w", pid, err)
+	}
+
+	return stat.Starttime, nil
+}


### PR DESCRIPTION
## Summary

When OBI discovers a new JVM, it tries to inject the Java agent into it. That
injection currently runs before OBI enables the eBPF PID filter for the process.
Until that filter is enabled, none of the process's traffic is captured.

Attaching to a JVM is slow. HotSpot dynamic attach can take up to
`OTEL_EBPF_JAVAAGENT_ATTACH_TIMEOUT` (10s by default) on a JVM that is busy
starting up. During that entire period, a freshly-discovered JVM's own startup
traffic is dropped. If the attach never succeeds, nothing from that process is
captured until the timeout expires.

Capturing events as quickly as possible during startup is important,
because applications often make connections to dependencies immediately at
launch.

This PR enables the PID first and moves the injection after it, into a
goroutine, so discovery no longer waits on the attach.

## Related changes

Moving the injection into a goroutine left `*ebpf.Instrumentable` shared without
synchronization between the injector and the downstream consumers it had just
been sent to. Nothing mutates the fields the injector reads today, so there
would have been no race now, but nothing would have stopped a future change
from introducing one.

The injector only ever needed three values: the instrumentable type, the pid,
and the process's `TMPDIR`. Those are now copied into a `Target` at the call
site and passed by value, avoiding a future possible race.

## Impact on shutdown behavior

In-flight injections are drained with a `WaitGroup` at shutdown. Because
`JavaInjector.NewExecutable` builds its own timeout internally and cannot be
cancelled, shutdown can wait for an injection to time out. There is a `TODO` in
the code describing what threading a context through the injector would take.
I did not do that here to keep the change small, but I am happy to if reviewers
would rather it be fixed now.

## Testing

`TestSuite_JavaDiscoveryEarlyTraffic` runs a JVM started with
`-XX:+DisableAttachMechanism` that sends Redis traffic from the moment it
starts. That flag makes the slow attach deterministic instead of depending on
machine load: the JVM never creates the attach socket, so the injection runs
until the timeout. The compose file sets that timeout to 90s, well past the
60s assertion window.

The suite asserts the workload's Redis operations are recorded:

- with this change: captured in about 7 seconds
- with only the reordering reverted: nothing captured, the assertion fails
  after the full 60 seconds

I also ran `go build`, `go vet`, `make lint`, and `go test -race` on the
discovery package.

The disabled attach mechanism is a stand-in for a busy-starting JVM, which
cannot be reproduced reliably in CI; it drives the same code path for the same
reason, but it is not the literal production case. Separately,
`TestJavaInjector_CopyAgent/error_when_target_directory_not_writable` fails when
the test runs as root, because root ignores directory permissions. That is
pre-existing and not related to this change.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

## AI assistance

Generative AI was used to identify the issue and assist with this change and its
test suite. I reviewed every line before submitting, verified each claim above
against captured output, and confirmed the test fails without the fix.
