### PR TITLE
test: cover obi.kube.cache.forward.lag in the weaver-wired k8s daemonset suite

### DIFF
--- a/internal/test/integration/k8s/daemonset/k8s_daemonset_internal_metrics_test.go
+++ b/internal/test/integration/k8s/daemonset/k8s_daemonset_internal_metrics_test.go
@@ -1,0 +1,46 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
+)
+
+// prometheusHostPort is the host-mapped port of the suite's Prometheus
+// (02-prometheus-otelscrape.yml), which scrapes the otelcol's exporter.
+const prometheusHostPort = "localhost:39090"
+
+// The OBI daemonset runs with internal_metrics.exporter=otel
+// (06-obi-daemonset.yml), so its internal metrics reach the suite otelcol,
+// which fans them out to both the weaver tap and its Prometheus exporter
+// (03-otelcol-weaver.yml). obi.kube.cache.forward.lag — the in-process kube
+// informer forward lag, a Float64Histogram in seconds — is therefore validated
+// by the weaver live-check; this asserts the same metric also lands in
+// Prometheus (as obi_kube_cache_forward_lag_seconds_*), giving it deterministic
+// coverage on both paths.
+func TestInternalMetrics_ForwardLag(t *testing.T) {
+	feat := features.New("OBI exports the kube informer forward-lag internal metric").
+		Assess("obi.kube.cache.forward.lag reaches Prometheus via the otelcol",
+			func(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+				pq := promtest.Client{HostPort: prometheusHostPort}
+				require.EventuallyWithT(t, func(ct *assert.CollectT) {
+					results, err := pq.Query(`{__name__=~"obi_kube_cache_forward_lag.*"}`)
+					require.NoError(ct, err)
+					require.NotEmpty(ct, results,
+						"obi.kube.cache.forward.lag was not exported to Prometheus by the otelcol")
+				}, testTimeout, time.Second)
+				return ctx
+			},
+		).Feature()
+	cluster.TestEnv().Test(t, feat)
+}

--- a/internal/test/integration/k8s/daemonset/k8s_daemonset_internal_metrics_test.go
+++ b/internal/test/integration/k8s/daemonset/k8s_daemonset_internal_metrics_test.go
@@ -20,14 +20,11 @@ import (
 // (02-prometheus-otelscrape.yml), which scrapes the otelcol's exporter.
 const prometheusHostPort = "localhost:39090"
 
-// The OBI daemonset runs with internal_metrics.exporter=otel
-// (06-obi-daemonset.yml), so its internal metrics reach the suite otelcol,
-// which fans them out to both the weaver tap and its Prometheus exporter
-// (03-otelcol-weaver.yml). obi.kube.cache.forward.lag — the in-process kube
-// informer forward lag, a Float64Histogram in seconds — is therefore validated
-// by the weaver live-check; this asserts the same metric also lands in
-// Prometheus (as obi_kube_cache_forward_lag_seconds_*), giving it deterministic
-// coverage on both paths.
+// The OBI daemonset exports its internal metrics via the otel exporter
+// (06-obi-daemonset.yml), which the suite otelcol re-exports to Prometheus
+// (03-otelcol-weaver.yml). This asserts obi.kube.cache.forward.lag — the
+// in-process kube informer forward lag — reaches Prometheus, matched by name so
+// the histogram suffix is not load-bearing.
 func TestInternalMetrics_ForwardLag(t *testing.T) {
 	feat := features.New("OBI exports the kube informer forward-lag internal metric").
 		Assess("obi.kube.cache.forward.lag reaches Prometheus via the otelcol",

--- a/internal/test/integration/k8s/manifests/06-obi-daemonset.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-daemonset.yml
@@ -34,6 +34,8 @@ data:
       endpoint: http://otelcol:4318
     otel_traces_export:
       endpoint: http://jaeger:4318
+    internal_metrics:
+      exporter: otel
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
## Summary

Currently weaver does not validate the internal metric of `obi.kube.cache.forward.lag` since no integration test emits it
changing the k8s test to emit internal metrics makes sure we export it

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
