### PR TITLE
Fix Go Auto SDK scope assertions for Jaeger v2

### DIFF
--- a/internal/test/integration/go_auto_sdk_test.go
+++ b/internal/test/integration/go_auto_sdk_test.go
@@ -201,8 +201,8 @@ func testGoAutoSDKRichSpans(t *testing.T, version, service string) {
 	assert.Empty(t, root.Diff(
 		jaeger.Tag{Key: "activation.version", Type: "string", Value: version},
 		jaeger.Tag{Key: "activation.root", Type: "bool", Value: true},
-		jaeger.Tag{Key: "otel.library.name", Type: "string", Value: "go-auto-sdk-activation-test"},
-		jaeger.Tag{Key: "otel.library.version", Type: "string", Value: "v1.0.0"},
+		jaeger.Tag{Key: "otel.scope.name", Type: "string", Value: "go-auto-sdk-activation-test"},
+		jaeger.Tag{Key: "otel.scope.version", Type: "string", Value: "v1.0.0"},
 	))
 	require.Len(t, root.Logs, 1)
 	assert.Empty(t, jaeger.Diff([]jaeger.Tag{


### PR DESCRIPTION
## Summary

- assert the Go Auto SDK instrumentation scope with the stable `otel.scope.name` and `otel.scope.version` tags
- keep exact coverage for the emitted scope name and version while using Jaeger v2's query representation

## Root cause

#2702 replaced the EOL Jaeger 1.60 all-in-one backend with Jaeger v2. #2810 was based on the earlier backend and asserted the `otel.library.name` and `otel.library.version` aliases returned by Jaeger 1.x.

Jaeger v2's query API returns the Go Auto SDK root and child spans with:

```text
otel.scope.name=go-auto-sdk-activation-test
otel.scope.version=v1.0.0
```

The OpenTelemetry [non-OTLP mapping](https://opentelemetry.io/docs/specs/otel/common/mapping-to-non-otlp/#instrumentationscope) defines these tags for `InstrumentationScope.Name` and `InstrumentationScope.Version`, and the [semantic-convention registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/otel/#deprecated-otel-library-attributes) marks the `otel.library.*` names as deprecated aliases. The old assertion was therefore coupled to Jaeger 1.x's legacy representation rather than the stable scope fields.

This change updates only the expected tag keys. It still verifies that OBI preserves and exports the exact scope name and version emitted by the Go Auto SDK fixture.

## Reproduction

On current `main` after `make docker-generate`:

```console
$ go test -v -run '^TestGoAutoSDKActivation$' -count=1 -timeout 10m ./internal/test/integration/
```

Both `otel-1.33.0` and `otel-latest` failed only because the two legacy `otel.library.*` tags were absent. The root/child relationships, page-boundary payload handling, and oversized-payload cleanup assertions passed.

As an A/B check, changing only the backend from `jaegertracing/jaeger:2.19.0@sha256:ede486...` to `jaegertracing/all-in-one:1.60@sha256:4fd2d70...` made the exact suite pass for both SDK versions in about 75 seconds.

## Validation

- `make docker-generate`
- `go test -v -run '^TestGoAutoSDKActivation$' -count=1 -timeout 10m ./internal/test/integration/` — passed both SDK variants and all subtests in 57.461s
- `go test ./pkg/export/otel/tracesgen`
- `go tool -modfile=internal/tools/go.mod golangci-lint run ./internal/test/integration --timeout=6m`
- `gofmt -d internal/test/integration/go_auto_sdk_test.go`
- `git diff --check`
