### PR TITLE
Emit span metrics with OTel dot-notation names over OTLP

### DIFF
--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -42,10 +42,14 @@ const (
 	// pkg/export/attributes/metric.go file as we are disabling user-provided attribute
 	// selection for them. They are very specific metrics with an opinionated format
 	// for Span Metrics and Service Graph Metrics functionalities
-	SpanMetricsLatency       = "traces_spanmetrics_latency"
-	SpanMetricsLatencyOTel   = "traces_span_metrics_duration"
-	SpanMetricsCalls         = "traces_spanmetrics_calls_total"
-	SpanMetricsCallsOTel     = "traces_span_metrics_calls_total"
+	SpanMetricsLatency = "traces_spanmetrics_latency"
+	SpanMetricsCalls   = "traces_spanmetrics_calls_total"
+	// SpanMetricsLatencyOTel and SpanMetricsCallsOTel use OTel dot notation,
+	// matching the default `traces.span.metrics` namespace of the
+	// collector-contrib spanmetricsconnector. The Prometheus exporter emits the
+	// underscore counterparts (see pkg/export/prom).
+	SpanMetricsLatencyOTel   = "traces.span.metrics.duration"
+	SpanMetricsCallsOTel     = "traces.span.metrics.calls"
 	SpanMetricsRequestSizes  = "traces_spanmetrics_size_total"
 	SpanMetricsResponseSizes = "traces_spanmetrics_response_size_total"
 	// TracesTargetInfo, TargetInfo and TracesHostInfo use OTel dot notation.

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -695,6 +695,34 @@ func TestSpanMetrics_ExtraResourceAttributes(t *testing.T) {
 	assert.Empty(t, expected)
 }
 
+func TestSpanMetricsNames(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		features        export.Features
+		expectedLatency string
+		expectedCalls   string
+	}{
+		{
+			name:            "otel naming",
+			features:        export.FeatureSpanOTel,
+			expectedLatency: "traces.span.metrics.duration",
+			expectedCalls:   "traces.span.metrics.calls",
+		},
+		{
+			name:            "legacy naming",
+			features:        export.FeatureSpanLegacy,
+			expectedLatency: "traces_spanmetrics_latency",
+			expectedCalls:   "traces_spanmetrics_calls_total",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := &MetricsReporter{jointMetricsCfg: &perapp.MetricsConfig{Features: tc.features}}
+			assert.Equal(t, tc.expectedLatency, mr.spanMetricsLatencyName())
+			assert.Equal(t, tc.expectedCalls, mr.spanMetricsCallsName())
+		})
+	}
+}
+
 func TestSpanSizeMetrics_ExtraResourceAttributes(t *testing.T) {
 	defer otelcfg.RestoreEnvAfterExecution()()
 

--- a/schemas/obi/groups/spanmetrics.yaml
+++ b/schemas/obi/groups/spanmetrics.yaml
@@ -69,9 +69,9 @@ groups:
 
   # Counter has no explicit OTLP unit set; mirror that here so live-check
   # doesn't complain "Unit should be '1', but found ''".
-  - id: metric.traces_span_metrics_calls_total
+  - id: metric.traces.span.metrics.calls
     type: metric
-    metric_name: traces_span_metrics_calls_total
+    metric_name: traces.span.metrics.calls
     instrument: counter
     unit: ""
     stability: development
@@ -83,9 +83,9 @@ groups:
       - ref: status.code
       - ref: source
 
-  - id: metric.traces_span_metrics_duration
+  - id: metric.traces.span.metrics.duration
     type: metric
-    metric_name: traces_span_metrics_duration
+    metric_name: traces.span.metrics.duration
     instrument: histogram
     unit: "s"
     stability: development
@@ -100,7 +100,7 @@ groups:
 
   # Legacy Grafana-style names for the same two metrics, matching the older
   # spanmetrics processor output. This is what OBI emits by DEFAULT — the
-  # `traces_span_metrics_*` names above are the opt-in OTel naming
+  # `traces.span.metrics.*` names above are the opt-in OTel naming
   # (`OTEL_EBPF_OTEL_METRICS_FEATURES=application_span_otel`).
   - id: metric.traces_spanmetrics_calls_total
     type: metric

--- a/schemas/obi/manifest.yaml
+++ b/schemas/obi/manifest.yaml
@@ -11,7 +11,7 @@ description: |
     `instance` / `job` scrape-convention attributes
   - Span metrics matching the OTel collector-contrib `spanmetricsconnector`
     output, in both naming schemes: the OTel-canonical
-    `traces_span_metrics_*` names (emitted when the `application_span_otel`
+    `traces.span.metrics.*` names (emitted when the `application_span_otel`
     metrics feature is enabled) and the legacy Grafana-style
     `traces_spanmetrics_*` names (OBI's default `application_span` feature)
   - Service-graph metrics matching the OTel collector-contrib


### PR DESCRIPTION
## Summary
Resolves https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1964

OBI's span metrics mirror the collector-contrib `spanmetricsconnector`, but their OTLP
names were written in Prometheus style (underscores) instead of OTel dot notation. This
renames the two `application_span_otel` metrics on the OTLP path:

| before | after |
| --- | --- |
| `traces_span_metrics_calls_total` | `traces.span.metrics.calls` |
| `traces_span_metrics_duration` | `traces.span.metrics.duration` |

Both now match the connector's default `traces.span.metrics` namespace, so the same
dashboards and processors consume OBI-emitted and connector-emitted data unchanged.

This is a breaking change for OTLP-native consumers, but Prometheus scrapers are
unaffected: the collector's Prometheus exporter normalizes dots to underscores and
re-derives suffixes, so the scraped names remain `traces_span_metrics_calls_total` and
`traces_span_metrics_duration_seconds`. The integration tests assert against Prometheus
and needed no changes.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
