### PR TITLE
Drop unknown enum fallbacks

### DIFF
--- a/pkg/appolly/app/request/span_getters.go
+++ b/pkg/appolly/app/request/span_getters.go
@@ -209,7 +209,7 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 					return DBSystemName(span.DBSystem)
 				}
 			}
-			return DBSystemName("unknown")
+			return attribute.KeyValue{}
 		}
 	case attr.DBNamespace:
 		getter = func(span *Span) attribute.KeyValue { return DBNamespace(span.DBNamespace) }
@@ -245,7 +245,7 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 			if span.Type == EventTypeHTTPClient && span.SubType == HTTPSubtypeAWSSQS && span.AWS != nil {
 				return semconv.MessagingSystemAWSSQS
 			}
-			return semconv.MessagingSystemKey.String("unknown")
+			return attribute.KeyValue{}
 		}
 	case attr.MessagingDestination:
 		getter = func(span *Span) attribute.KeyValue {

--- a/pkg/appolly/app/request/span_getters_test.go
+++ b/pkg/appolly/app/request/span_getters_test.go
@@ -890,6 +890,47 @@ func TestSpanOTELGetters_GenAIProviderNameOmitted(t *testing.T) {
 	assert.Equal(t, "openai", kv.Value.AsString())
 }
 
+func TestSpanOTELGetters_DBSystemNameOmitted(t *testing.T) {
+	getter, ok := spanOTELGetters(attr.DBSystemName)
+	require.True(t, ok, "getter should be found for DBSystemName")
+
+	kv := getter(&Span{Type: EventTypeHTTP})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+
+	kv = getter(&Span{Type: EventTypeHTTPClient, SubType: HTTPSubtypeElasticsearch})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+
+	kv = getter(&Span{Type: EventTypeHTTPClient, SubType: HTTPSubtypeSQLPP})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+
+	kv = getter(&Span{
+		Type:          EventTypeHTTPClient,
+		SubType:       HTTPSubtypeElasticsearch,
+		Elasticsearch: &Elasticsearch{DBSystemName: "elasticsearch"},
+	})
+	require.True(t, kv.Valid())
+	assert.Equal(t, "elasticsearch", kv.Value.AsString())
+
+	kv = getter(&Span{Type: EventTypeRedisClient})
+	require.True(t, kv.Valid())
+	assert.Equal(t, "redis", kv.Value.AsString())
+}
+
+func TestSpanOTELGetters_MessagingSystemOmitted(t *testing.T) {
+	getter, ok := spanOTELGetters(attr.MessagingSystem)
+	require.True(t, ok, "getter should be found for MessagingSystem")
+
+	kv := getter(&Span{Type: EventTypeHTTP})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+
+	kv = getter(&Span{Type: EventTypeHTTPClient, SubType: HTTPSubtypeAWSSQS})
+	assert.False(t, kv.Valid(), "attribute should be omitted, got %v", kv)
+
+	kv = getter(&Span{Type: EventTypeKafkaClient})
+	require.True(t, kv.Valid())
+	assert.Equal(t, "kafka", kv.Value.AsString())
+}
+
 func TestSpanOTELGetters_GenAIInput(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/appolly/discover/typer.go
+++ b/pkg/appolly/discover/typer.go
@@ -155,6 +155,7 @@ func (t *typer) makeServiceAttrs(processMatch *ProcessMatch) svc.Attrs {
 		Sampler:            samplerFromConfig(samplerConfig),
 		Features:           svcFeatures,
 		LogEnricherEnabled: processMatch.LogEnricherEnabled(),
+		SDKLanguage:        svc.InstrumentableGeneric,
 	}
 
 	routesCfg := t.cfg.Routes

--- a/pkg/appolly/discover/typer_test.go
+++ b/pkg/appolly/discover/typer_test.go
@@ -100,6 +100,20 @@ func TestMakeServiceAttrs(t *testing.T) {
 	assert.NotNil(t, attrs2.CustomOutRouteMatcher)
 }
 
+func TestMakeServiceAttrsDefaultsSDKLanguageToGeneric(t *testing.T) {
+	pi := services.ProcessInfo{Pid: 1234}
+	proc := &ProcessMatch{
+		Process:  &pi,
+		Criteria: []services.Selector{dummyCriterion{name: "svc1"}},
+	}
+	ty := typer{cfg: &obi.Config{Routes: &transform.RoutesConfig{}}}
+
+	attrs := ty.makeServiceAttrs(proc)
+
+	assert.Equal(t, svc.InstrumentableGeneric, attrs.SDKLanguage)
+	assert.Equal(t, "generic", attrs.SDKLanguage.String())
+}
+
 func TestMakeServiceAttrs_DynamicPIDOptions(t *testing.T) {
 	d := NewDynamicPIDSelector()
 	d.Traces().AddPID(42, selection.DynamicPIDOptions{

--- a/schemas/obi/groups/db.yaml
+++ b/schemas/obi/groups/db.yaml
@@ -3,9 +3,7 @@ groups:
   # OBI's Aerospike client instrumentation (pkg/ebpf/common/
   # aerospike_detect_transform.go, reported via attr.DBSystemName in
   # pkg/appolly/app/request/span_getters.go) identifies the Aerospike wire
-  # protocol, which upstream semconv v1.41 has no member for. When the getter
-  # recognizes no database system it omits the attribute, so every value that
-  # reaches the wire is one of the members below.
+  # protocol, which upstream semconv v1.41 has no member for.
   #
   # See ../README.md for the override mechanics (x.obi.* group id, full
   # upstream member list, lint allowlist).

--- a/schemas/obi/groups/db.yaml
+++ b/schemas/obi/groups/db.yaml
@@ -3,9 +3,9 @@ groups:
   # OBI's Aerospike client instrumentation (pkg/ebpf/common/
   # aerospike_detect_transform.go, reported via attr.DBSystemName in
   # pkg/appolly/app/request/span_getters.go) identifies the Aerospike wire
-  # protocol, which upstream semconv v1.41 has no member for. The `unknown`
-  # fallback in the same getter is a bug marker and is deliberately NOT
-  # declared here, so weaver keeps flagging it.
+  # protocol, which upstream semconv v1.41 has no member for. When the getter
+  # recognizes no database system it omits the attribute, so every value that
+  # reaches the wire is one of the members below.
   #
   # See ../README.md for the override mechanics (x.obi.* group id, full
   # upstream member list, lint allowlist).

--- a/schemas/obi/groups/messaging.yaml
+++ b/schemas/obi/groups/messaging.yaml
@@ -3,9 +3,7 @@ groups:
   # `mqtt` and `nats` — messaging protocols OBI detects that upstream semconv
   # has no member for. OBI identifies the protocol on the wire, not the broker
   # product behind it, so `amqp` is reported as-is rather than assuming
-  # `rabbitmq`. When the getter recognizes no messaging protocol it omits the
-  # attribute, so every value that reaches the wire is one of the members
-  # below. Emitters: pkg/appolly/app/request/span_getters.go
+  # `rabbitmq`. Emitters: pkg/appolly/app/request/span_getters.go
   # (attr.MessagingSystem) and pkg/export/otel/tracesgen/tracesgen.go.
   #
   # See ../README.md for the override mechanics (x.obi.* group id, full

--- a/schemas/obi/groups/messaging.yaml
+++ b/schemas/obi/groups/messaging.yaml
@@ -3,7 +3,9 @@ groups:
   # `mqtt` and `nats` — messaging protocols OBI detects that upstream semconv
   # has no member for. OBI identifies the protocol on the wire, not the broker
   # product behind it, so `amqp` is reported as-is rather than assuming
-  # `rabbitmq`. Emitters: pkg/appolly/app/request/span_getters.go
+  # `rabbitmq`. When the getter recognizes no messaging protocol it omits the
+  # attribute, so every value that reaches the wire is one of the members
+  # below. Emitters: pkg/appolly/app/request/span_getters.go
   # (attr.MessagingSystem) and pkg/export/otel/tracesgen/tracesgen.go.
   #
   # See ../README.md for the override mechanics (x.obi.* group id, full

--- a/schemas/obi/groups/telemetry.yaml
+++ b/schemas/obi/groups/telemetry.yaml
@@ -3,8 +3,8 @@ groups:
   # `generic`, which pkg/appolly/app/svc/svc.go (InstrumentableType.String)
   # reports for executables with no recognized language runtime — OBI
   # instruments processes that carry no SDK at all, a case the upstream enum
-  # has no member for. The `unknown` fallback in the same switch is a bug
-  # marker and is deliberately NOT declared here, so weaver keeps flagging it.
+  # has no member for. `generic` is also the value a service carries until
+  # language detection replaces it, so no un-detected state reaches the wire.
   #
   # See ../README.md for the override mechanics (x.obi.* group id, full
   # upstream member list, lint allowlist).

--- a/schemas/obi/groups/telemetry.yaml
+++ b/schemas/obi/groups/telemetry.yaml
@@ -3,8 +3,7 @@ groups:
   # `generic`, which pkg/appolly/app/svc/svc.go (InstrumentableType.String)
   # reports for executables with no recognized language runtime — OBI
   # instruments processes that carry no SDK at all, a case the upstream enum
-  # has no member for. `generic` is also the value a service carries until
-  # language detection replaces it, so no un-detected state reaches the wire.
+  # has no member for.
   #
   # See ../README.md for the override mechanics (x.obi.* group id, full
   # upstream member list, lint allowlist).


### PR DESCRIPTION
## Summary

Three semconv enum attributes had an `unknown` fallback that is not a member of the enum they
belong to. OBI's registry deliberately leaves `unknown` undeclared, so any signal carrying it
fails live-check with `undefined_enum_variant`.

None of the three fallbacks is reachable. Rather than declare a value OBI cannot legitimately
send, this removes the fallbacks so the code matches the contract the schema already states.

## What changes

**`db.system.name` and `messaging.system` now omit the attribute.** The metrics recorder routes
only database span types to `db.client.operation.duration`, and only Kafka/MQTT/NATS/AMQP to the
messaging metrics, so a span the getter cannot classify never reaches them. The two HTTP-client
sub-cases satisfy the getter's guards by construction: the Elasticsearch path sets `SubType` and
the `Elasticsearch` payload together, and the SQL++ path always resolves `DBSystem` to either
`couchbase` or `other_sql`. Both getters now return an invalid `KeyValue` — the same omit idiom
already used a few lines up for `error.type`, `gen_ai.operation.name` and `gen_ai.provider.name`,
dropped by the expirer and mapped to an empty label by the Prometheus getter.

**`telemetry.sdk.language` gets a real default instead.** Here `"unknown"` is load-bearing, just
not for telemetry: `InstrumentableUnknown` is the zero value of `ProcessAttrs.detectedType`, and
the selection-criteria matcher compares `languages:` against `String()`, so a process on an
ignored system path correctly matches nothing. Telemetry reads a different field —
`svc.Attrs.SDKLanguage`, only ever assigned from `FindProcLanguage`, which returns `generic`
rather than `unknown` when it recognizes no runtime. Its single construction site in the typer
just left the field at its zero value. It now initializes to `InstrumentableGeneric`, so the
export path cannot observe the un-classified state. `String()` is untouched, and discovery
behaves exactly as before.

`generic` stays exported. It is a classification — "this process carries no SDK" — not the absence
of one, and it is the extra resource attribute `traces_target_info` needs for the service to
appear in the services list.

**Schema.** The `db` and `telemetry` override groups described `unknown` as a bug marker left
undeclared so weaver keeps flagging it. That sentence no longer holds and is dropped. No members
change.

## Not covered

Two other enum attributes emit `unknown` on paths that *are* reachable, and each needs a contract
decision rather than a deletion:

- `jvm.memory.type` — `InferJVMMemoryType` falls back to `"unknown"` for pool names outside its
  substring lists (OpenJ9's `nursery-allocate`, `class storage`, `JIT code cache`; legacy
  `Perm Gen`), while semconv declares only `heap` and `non_heap`.
- `network.type` — any EtherType other than IPv4/IPv6/ARP stringifies to `"unknown"`, and the
  registry declares exactly those three.

Both want either a better classifier, an omitted attribute, or a declared member.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
