### PR TITLE
feat(otel): add generic OTLP logs export pipeline

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -22,6 +22,7 @@ Generated from [`config-schema.json`](config-schema.json).
 - [`name_resolver`](#name-resolver)
 - [`network`](#network)
 - [`nodejs`](#nodejs)
+- [`otel_logs_export`](#otel-logs-export)
 - [`otel_metrics_export`](#otel-metrics-export)
 - [`otel_traces_export`](#otel-traces-export)
 - [`prometheus_export`](#prometheus-export)
@@ -533,6 +534,22 @@ ReverseDNS is currently experimental. It is kept disabled by default and will be
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
 |---|---|---|---|---|---|---|
 | `nodejs.enabled` | `boolean` | `OTEL_EBPF_NODEJS_ENABLED` | `true` |  |  |  |
+
+## `otel_logs_export`
+
+| YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
+|---|---|---|---|---|---|---|
+| `otel_logs_export.backoff_initial_interval` | `duration` | `OTEL_EBPF_LOGS_BACKOFF_INITIAL_INTERVAL` | `0s` | `30s`, `5m`, `1ms`, etc |  | Configuration options for BackOffConfig of the logs exporter. See <https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configretry/backoff.go> Namespaced per-signal (unlike TracesConfig's generically-named equivalents) since this is a new signal and there's no existing precedent of these being intentionally shared across signals. |
+| `otel_logs_export.backoff_max_elapsed_time` | `duration` | `OTEL_EBPF_LOGS_BACKOFF_MAX_ELAPSED_TIME` | `0s` | `30s`, `5m`, `1ms`, etc |  |  |
+| `otel_logs_export.backoff_max_interval` | `duration` | `OTEL_EBPF_LOGS_BACKOFF_MAX_INTERVAL` | `0s` | `30s`, `5m`, `1ms`, etc |  |  |
+| `otel_logs_export.batch_max_size` | `integer` | `OTEL_EBPF_OTLP_LOGS_BATCH_MAX_SIZE` | `0` |  |  | Is the maximum number of log records that the batcher will accumulate before flushing a batch to the sending queue. |
+| `otel_logs_export.batch_timeout` | `duration` | `OTEL_EBPF_OTLP_LOGS_BATCH_TIMEOUT` | `0s` | `30s`, `5m`, `1ms`, etc |  | Is the time after which a batch will be sent regardless of its size. |
+| `otel_logs_export.endpoint` | `uri` | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` |  |  |  |  |
+| `otel_logs_export.insecure_skip_verify` | `boolean` | `OTEL_EBPF_INSECURE_SKIP_VERIFY` | `false` |  |  | Enables skipping TLS certificate verification (not standard, so we don't follow the same naming convention) |
+| `otel_logs_export.otel_sdk_log_level` | `string` | `OTEL_EBPF_SDK_LOG_LEVEL` |  |  |  | Is intentionally the SAME env var as TracesConfig/MetricsConfig's field of the same name — this is an existing shared, not per-signal, knob. |
+| `otel_logs_export.protocol` | `string` | `OTEL_EXPORTER_OTLP_PROTOCOL` |  | ``, `debug`, `grpc`, `http/json`, `http/protobuf` |  |  |
+| `otel_logs_export.queue_size` | `integer` | `OTEL_EBPF_OTLP_LOGS_QUEUE_SIZE` | `0` |  |  | Is the maximum number of log records that the sending queue will hold before applying back-pressure. It must be >= `2 * BatchMaxSize`, otherwise the memory queue rejects every batch with "element size too large" and drops log records permanently. If left at 0 it defaults to `4 * BatchMaxSize`. |
+| `otel_logs_export.reporters_cache_len` | `integer` | `OTEL_EBPF_LOGS_REPORT_CACHE_LEN` | `0` |  |  |  |
 
 ## `otel_metrics_export`
 

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -1732,6 +1732,101 @@
       },
       "type": "object"
     },
+    "LogsConfig": {
+      "properties": {
+        "backoff_initial_interval": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s|m)$",
+          "description": "Configuration options for BackOffConfig of the logs exporter. See https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configretry/backoff.go Namespaced per-signal (unlike TracesConfig's generically-named equivalents) since this is a new signal and there's no existing precedent of these being intentionally shared across signals.",
+          "default": "0s",
+          "examples": [
+            "30s",
+            "5m",
+            "1ms"
+          ],
+          "x-env-var": "OTEL_EBPF_LOGS_BACKOFF_INITIAL_INTERVAL"
+        },
+        "backoff_max_elapsed_time": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s|m)$",
+          "default": "0s",
+          "examples": [
+            "30s",
+            "5m",
+            "1ms"
+          ],
+          "x-env-var": "OTEL_EBPF_LOGS_BACKOFF_MAX_ELAPSED_TIME"
+        },
+        "backoff_max_interval": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s|m)$",
+          "default": "0s",
+          "examples": [
+            "30s",
+            "5m",
+            "1ms"
+          ],
+          "x-env-var": "OTEL_EBPF_LOGS_BACKOFF_MAX_INTERVAL"
+        },
+        "batch_max_size": {
+          "type": "integer",
+          "description": "Is the maximum number of log records that the batcher will accumulate before flushing a batch to the sending queue.",
+          "default": 0,
+          "x-env-var": "OTEL_EBPF_OTLP_LOGS_BATCH_MAX_SIZE"
+        },
+        "batch_timeout": {
+          "type": "string",
+          "pattern": "^[0-9]+(ms|s|m)$",
+          "description": "Is the time after which a batch will be sent regardless of its size.",
+          "default": "0s",
+          "examples": [
+            "30s",
+            "5m",
+            "1ms"
+          ],
+          "x-env-var": "OTEL_EBPF_OTLP_LOGS_BATCH_TIMEOUT"
+        },
+        "endpoint": {
+          "type": "string",
+          "format": "uri",
+          "x-env-var": "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"
+        },
+        "insecure_skip_verify": {
+          "type": "boolean",
+          "description": "Enables skipping TLS certificate verification (not standard, so we don't follow the same naming convention)",
+          "default": false,
+          "x-env-var": "OTEL_EBPF_INSECURE_SKIP_VERIFY"
+        },
+        "otel_sdk_log_level": {
+          "type": "string",
+          "description": "Is intentionally the SAME env var as TracesConfig/MetricsConfig's field of the same name — this is an existing shared, not per-signal, knob.",
+          "x-env-var": "OTEL_EBPF_SDK_LOG_LEVEL"
+        },
+        "protocol": {
+          "type": "string",
+          "enum": [
+            "",
+            "debug",
+            "grpc",
+            "http/json",
+            "http/protobuf"
+          ],
+          "x-env-var": "OTEL_EXPORTER_OTLP_PROTOCOL"
+        },
+        "queue_size": {
+          "type": "integer",
+          "description": "Is the maximum number of log records that the sending queue will hold before applying back-pressure. It must be >= `2 * BatchMaxSize`, otherwise the memory queue rejects every batch with \"element size too large\" and drops log records permanently. If left at 0 it defaults to `4 * BatchMaxSize`.",
+          "default": 0,
+          "x-env-var": "OTEL_EBPF_OTLP_LOGS_QUEUE_SIZE"
+        },
+        "reporters_cache_len": {
+          "type": "integer",
+          "default": 0,
+          "x-env-var": "OTEL_EBPF_LOGS_REPORT_CACHE_LEN"
+        }
+      },
+      "type": "object"
+    },
     "MCPConfig": {
       "properties": {
         "enabled": {
@@ -3130,6 +3225,9 @@
       "$ref": "#/$defs/IntEnum",
       "description": "Allows selecting the instrumented executable that owns the Port value. If this value is set (and different to zero), the value of the Exec property won't take effect. It's important to emphasize that if your process opens multiple HTTP/GRPC ports, the auto-instrumenter will instrument all the service calls in all the ports, not only the port specified here.",
       "x-env-var": "OTEL_EBPF_OPEN_PORT"
+    },
+    "otel_logs_export": {
+      "$ref": "#/$defs/LogsConfig"
     },
     "otel_metrics_export": {
       "$ref": "#/$defs/MetricsConfig"

--- a/pkg/export/otel/logs.go
+++ b/pkg/export/otel/logs.go
@@ -1,0 +1,217 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel // import "go.opentelemetry.io/obi/pkg/export/otel"
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configgrpc"
+	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configmiddleware"
+	"go.opentelemetry.io/collector/config/configoptional"
+	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/debugexporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+)
+
+// emptyHost, udsHost, udsMiddleware, createZapLoggerDev, and getTraceSettings
+// are defined in traces.go (same package) and reused here unchanged.
+
+//nolint:cyclop
+func getLogsExporter(ctx context.Context, cfg otelcfg.LogsConfig) (exporter.Logs, component.Host, error) {
+	if cfg.LogsConsumer != nil {
+		newType, err := component.NewType("logs")
+		if err != nil {
+			return nil, nil, err
+		}
+		set := getTraceSettings(newType, cfg.SDKLogLevel)
+		exp, err := exporterhelper.NewLogs(ctx, set, cfg,
+			cfg.LogsConsumer.ConsumeLogs,
+			exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		return exp, emptyHost{}, nil
+	}
+	switch proto := cfg.GetProtocol(); proto {
+	case otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf, "":
+		slog.Debug("instantiating HTTP LogsReporter", "protocol", proto)
+		factory := otlphttpexporter.NewFactory()
+		config, host, queueCfg, retryCfg, err := buildHTTPLogsExporterConfig(cfg, factory)
+		if err != nil {
+			slog.Error("can't get HTTP logs endpoint options", "error", err)
+			return nil, nil, err
+		}
+		set := getTraceSettings(factory.Type(), cfg.SDKLogLevel)
+		exp, err := factory.CreateLogs(ctx, set, config)
+		if err != nil {
+			slog.Error("can't create OTLP HTTP logs exporter", "error", err)
+			return nil, nil, err
+		}
+		// The inner exporter's own queue/retry are disabled by
+		// buildHTTPLogsExporterConfig; queueCfg/retryCfg are applied here so
+		// there is exactly one buffering/retry layer, matching getTracesExporter.
+		wrapped, err := exporterhelper.NewLogs(ctx, set, cfg,
+			exp.ConsumeLogs,
+			exporterhelper.WithStart(exp.Start),
+			exporterhelper.WithShutdown(exp.Shutdown),
+			exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+			exporterhelper.WithQueue(queueCfg),
+			exporterhelper.WithRetry(retryCfg))
+		return wrapped, host, err
+	case otelcfg.ProtocolGRPC:
+		slog.Debug("instantiating GRPC LogsReporter", "protocol", proto)
+		opts, err := otelcfg.GRPCLogsEndpointOptions(&cfg)
+		if err != nil {
+			slog.Error("can't get GRPC logs endpoint options", "error", err)
+			return nil, nil, err
+		}
+		grpcEndpoint := opts.Endpoint
+		if opts.UnixSocketAddr == "" {
+			endpoint, _, perr := otelcfg.ParseLogsEndpoint(&cfg)
+			if perr != nil {
+				slog.Error("can't parse GRPC logs endpoint", "error", perr)
+				return nil, nil, perr
+			}
+			grpcEndpoint = endpoint.String()
+		}
+		factory := otlpexporter.NewFactory()
+		config := factory.CreateDefaultConfig().(*otlpexporter.Config)
+		config.QueueConfig = getLogsQueueConfig(cfg)
+		config.RetryConfig = getLogsRetrySettings(cfg)
+		config.ClientConfig = configgrpc.ClientConfig{
+			Endpoint: grpcEndpoint,
+			TLS: configtls.ClientConfig{
+				Insecure:           opts.Insecure,
+				InsecureSkipVerify: cfg.InsecureSkipVerify,
+			},
+			Headers: convertHeaders(opts.Headers),
+		}
+		set := getTraceSettings(factory.Type(), cfg.SDKLogLevel)
+		exp, err := factory.CreateLogs(ctx, set, config)
+		if err != nil {
+			return nil, nil, err
+		}
+		return exp, emptyHost{}, nil
+	case otelcfg.ProtocolDebug:
+		slog.Debug("instantiating Debug LogsReporter", "protocol", proto)
+		factory := debugexporter.NewFactory()
+		config := factory.CreateDefaultConfig().(*debugexporter.Config)
+		config.UseInternalLogger = false
+		config.Verbosity = configtelemetry.LevelDetailed
+		set := getTraceSettings(factory.Type(), cfg.SDKLogLevel)
+		exp, err := factory.CreateLogs(ctx, set, config)
+		if err != nil {
+			return nil, nil, err
+		}
+		return exp, emptyHost{}, nil
+	default:
+		slog.Error(fmt.Sprintf("invalid protocol value: %q. Accepted values are: %s, %s, %s",
+			proto, otelcfg.ProtocolGRPC, otelcfg.ProtocolHTTPJSON, otelcfg.ProtocolHTTPProtobuf))
+		return nil, nil, fmt.Errorf("invalid protocol value: %q", proto)
+	}
+}
+
+// buildHTTPLogsExporterConfig builds the otlphttpexporter.Config for the HTTP logs
+// exporter, with its own queue and retry disabled, and separately returns the real
+// queue/retry settings for the caller to apply exactly once via the outer
+// exporterhelper.NewLogs wrap — mirroring getTracesExporter's HTTP branch, so a log
+// record is buffered and retried by a single layer instead of the inner exporter and
+// the outer wrap each doing it independently. Split out from getLogsExporter so this
+// disable-then-wrap-once behavior is directly testable.
+func buildHTTPLogsExporterConfig(cfg otelcfg.LogsConfig, factory exporter.Factory) (
+	*otlphttpexporter.Config,
+	component.Host,
+	configoptional.Optional[exporterhelper.QueueBatchConfig],
+	configretry.BackOffConfig,
+	error,
+) {
+	opts, err := otelcfg.HTTPLogsEndpointOptions(&cfg)
+	if err != nil {
+		return nil, nil, configoptional.None[exporterhelper.QueueBatchConfig](), configretry.BackOffConfig{}, err
+	}
+
+	config := factory.CreateDefaultConfig().(*otlphttpexporter.Config)
+	queueCfg := getLogsQueueConfig(cfg)
+	retryCfg := getLogsRetrySettings(cfg)
+	disabledRetry := configretry.NewDefaultBackOffConfig()
+	disabledRetry.Enabled = false
+	config.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+	config.RetryConfig = disabledRetry
+	config.ClientConfig = confighttp.ClientConfig{
+		Endpoint: opts.Scheme + "://" + opts.Endpoint + opts.BaseURLPath,
+		TLS: configtls.ClientConfig{
+			Insecure:           opts.Insecure,
+			InsecureSkipVerify: cfg.InsecureSkipVerify,
+		},
+		Headers: convertHeaders(opts.Headers),
+	}
+
+	host := component.Host(emptyHost{})
+	if opts.UnixSocketAddr != "" {
+		mwID := component.MustNewID("obi_uds")
+		config.ClientConfig.Middlewares = []configmiddleware.Config{{ID: mwID}}
+		host = udsHost{extensions: map[component.ID]component.Component{
+			mwID: udsMiddleware{addr: opts.UnixSocketAddr},
+		}}
+	}
+
+	return config, host, queueCfg, retryCfg, nil
+}
+
+func getLogsQueueConfig(cfg otelcfg.LogsConfig) configoptional.Optional[exporterhelper.QueueBatchConfig] {
+	if cfg.BatchMaxSize <= 0 && cfg.BatchTimeout <= 0 && cfg.QueueSize <= 0 {
+		return configoptional.None[exporterhelper.QueueBatchConfig]()
+	}
+
+	queueConfig := exporterhelper.NewDefaultQueueConfig()
+	queueConfig.Sizer = exporterhelper.RequestSizerTypeItems
+	queueConfig.BlockOnOverflow = true
+	if cfg.QueueSize > 0 {
+		queueConfig.QueueSize = int64(cfg.QueueSize)
+	}
+	batchCfg := exporterhelper.BatchConfig{
+		Sizer: queueConfig.Sizer,
+	}
+	batchSet := false
+	if cfg.BatchMaxSize > 0 {
+		batchSet = true
+		batchCfg.MaxSize = int64(cfg.BatchMaxSize)
+	}
+	if cfg.BatchTimeout > 0 {
+		batchSet = true
+		batchCfg.FlushTimeout = cfg.BatchTimeout
+		batchCfg.MinSize = int64(cfg.BatchMaxSize)
+	}
+	if batchSet {
+		queueConfig.Batch = configoptional.Some(batchCfg)
+	}
+	return configoptional.Some(queueConfig)
+}
+
+func getLogsRetrySettings(cfg otelcfg.LogsConfig) configretry.BackOffConfig {
+	backOffCfg := configretry.NewDefaultBackOffConfig()
+	if cfg.BackOffInitialInterval > 0 {
+		backOffCfg.InitialInterval = cfg.BackOffInitialInterval
+	}
+	if cfg.BackOffMaxInterval > 0 {
+		backOffCfg.MaxInterval = cfg.BackOffMaxInterval
+	}
+	if cfg.BackOffMaxElapsedTime > 0 {
+		backOffCfg.MaxElapsedTime = cfg.BackOffMaxElapsedTime
+	}
+	return backOffCfg
+}

--- a/pkg/export/otel/logs_export_delivery_test.go
+++ b/pkg/export/otel/logs_export_delivery_test.go
@@ -1,0 +1,140 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	collectorplog "go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
+
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+)
+
+const testLogsEventName = "obi.otlp.delivery.test"
+
+func oneLogRecord() collectorplog.Logs {
+	logs := collectorplog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("service.name", "otlp-delivery-test")
+	lr := rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	lr.SetEventName(testLogsEventName)
+	lr.Body().SetStr("hello")
+	return logs
+}
+
+type otlpLogsGRPCServer struct {
+	plogotlp.UnimplementedGRPCServer
+	mu       sync.Mutex
+	received []collectorplog.Logs
+}
+
+func (s *otlpLogsGRPCServer) Export(_ context.Context, req plogotlp.ExportRequest) (plogotlp.ExportResponse, error) {
+	s.mu.Lock()
+	s.received = append(s.received, req.Logs())
+	s.mu.Unlock()
+	return plogotlp.NewExportResponse(), nil
+}
+
+func (s *otlpLogsGRPCServer) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.received)
+}
+
+func (s *otlpLogsGRPCServer) first() collectorplog.Logs {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.received[0]
+}
+
+// startOTLPLogsGRPCServer starts an in-process OTLP/gRPC logs receiver that
+// accepts every export, returning its "http://host:port" endpoint.
+func startOTLPLogsGRPCServer(t *testing.T) (string, *otlpLogsGRPCServer) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	logsSrv := &otlpLogsGRPCServer{}
+	plogotlp.RegisterGRPCServer(srv, logsSrv)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+	return "http://" + lis.Addr().String(), logsSrv
+}
+
+// TestLogsExportDelivery proves a log record pushed through getLogsExporter
+// actually crosses the real OTLP wire (HTTP and gRPC) and is decodable by a
+// real OTLP logs receiver on the other end, unlike the internal
+// TestSuite_QueueProcessingLogs integration test, which only exercises the
+// in-process debug exporter and never puts a byte on the wire.
+func TestLogsExportDelivery(t *testing.T) {
+	t.Run("HTTP", func(t *testing.T) {
+		var mu sync.Mutex
+		var received []collectorplog.Logs
+		coll := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			req := plogotlp.NewExportRequest()
+			if err := req.UnmarshalProto(body); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			received = append(received, req.Logs())
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer coll.Close()
+
+		cfg := otelcfg.LogsConfig{CommonEndpoint: coll.URL}
+		exp, host, err := getLogsExporter(context.Background(), cfg)
+		require.NoError(t, err)
+		require.NoError(t, exp.Start(context.Background(), host))
+		t.Cleanup(func() { _ = exp.Shutdown(context.Background()) })
+
+		require.NoError(t, exp.ConsumeLogs(context.Background(), oneLogRecord()))
+
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return len(received) > 0
+		}, 5*time.Second, 20*time.Millisecond, "log record must be delivered to the OTLP HTTP receiver")
+
+		mu.Lock()
+		lr := received[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+		mu.Unlock()
+		assert.Equal(t, testLogsEventName, lr.EventName(), "the exact log record content must survive the real OTLP HTTP round trip")
+	})
+
+	t.Run("gRPC", func(t *testing.T) {
+		endpoint, srv := startOTLPLogsGRPCServer(t)
+		cfg := otelcfg.LogsConfig{CommonEndpoint: endpoint, Protocol: otelcfg.ProtocolGRPC}
+		exp, host, err := getLogsExporter(context.Background(), cfg)
+		require.NoError(t, err)
+		require.NoError(t, exp.Start(context.Background(), host))
+		t.Cleanup(func() { _ = exp.Shutdown(context.Background()) })
+
+		require.NoError(t, exp.ConsumeLogs(context.Background(), oneLogRecord()))
+
+		require.Eventually(t, func() bool { return srv.count() > 0 }, 5*time.Second, 20*time.Millisecond,
+			"log record must be delivered to the OTLP gRPC receiver")
+
+		lr := srv.first().ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+		assert.Equal(t, testLogsEventName, lr.EventName(), "the exact log record content must survive the real OTLP gRPC round trip")
+	})
+}

--- a/pkg/export/otel/logs_test.go
+++ b/pkg/export/otel/logs_test.go
@@ -1,0 +1,80 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
+
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+)
+
+func TestGetLogsExporter_Debug(t *testing.T) {
+	cfg := otelcfg.LogsConfig{LogsProtocol: otelcfg.ProtocolDebug}
+	exp, host, err := getLogsExporter(t.Context(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+	require.NotNil(t, host)
+
+	require.NoError(t, exp.Start(context.Background(), host))
+	defer func() { assert.NoError(t, exp.Shutdown(context.Background())) }()
+}
+
+// TestBuildHTTPLogsExporterConfig_SingleBufferingLayer is a regression test for the
+// HTTP logs exporter double-buffering bug: buildHTTPLogsExporterConfig must disable the
+// inner otlphttpexporter's own queue/retry, and hand back the real queue/retry settings
+// separately for the caller to apply exactly once via the outer exporterhelper.NewLogs
+// wrap — matching getTracesExporter's HTTP branch.
+func TestBuildHTTPLogsExporterConfig_SingleBufferingLayer(t *testing.T) {
+	cfg := otelcfg.LogsConfig{
+		LogsEndpoint:           "http://localhost:4318",
+		QueueSize:              7,
+		BatchMaxSize:           10,
+		BackOffInitialInterval: 2 * time.Second,
+	}
+
+	factory := otlphttpexporter.NewFactory()
+	config, host, queueCfg, retryCfg, err := buildHTTPLogsExporterConfig(cfg, factory)
+	require.NoError(t, err)
+	require.NotNil(t, host)
+
+	assert.False(t, config.QueueConfig.HasValue(), "the inner otlphttpexporter must not buffer on its own")
+	assert.False(t, config.RetryConfig.Enabled, "the inner otlphttpexporter must not retry on its own")
+
+	require.True(t, queueCfg.HasValue(), "the outer wrap must receive the real queue settings")
+	assert.EqualValues(t, 7, queueCfg.Get().QueueSize)
+
+	assert.True(t, retryCfg.Enabled, "the outer wrap must receive the real, enabled retry settings")
+	assert.Equal(t, 2*time.Second, retryCfg.InitialInterval)
+}
+
+// TestGetLogsExporter_HTTP exercises getLogsExporter's HTTP branch end to end with a
+// real queue/batch/retry configuration, which previously had no test coverage at all.
+func TestGetLogsExporter_HTTP(t *testing.T) {
+	cfg := otelcfg.LogsConfig{
+		LogsEndpoint:           "http://localhost:4318",
+		QueueSize:              5,
+		BatchMaxSize:           5,
+		BackOffInitialInterval: time.Second,
+	}
+	exp, host, err := getLogsExporter(t.Context(), cfg)
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+	require.NotNil(t, host)
+
+	require.NoError(t, exp.Start(context.Background(), host))
+	defer func() { assert.NoError(t, exp.Shutdown(context.Background())) }()
+}
+
+func TestGetLogsExporter_InvalidProtocol(t *testing.T) {
+	cfg := otelcfg.LogsConfig{LogsEndpoint: "http://localhost:4318", LogsProtocol: otelcfg.Protocol("bogus")}
+	_, _, err := getLogsExporter(t.Context(), cfg)
+	require.Error(t, err)
+}

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -51,10 +51,12 @@ const (
 const (
 	envTracesProtocol  = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
 	envMetricsProtocol = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL"
+	envLogsProtocol    = "OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"
 	envProtocol        = "OTEL_EXPORTER_OTLP_PROTOCOL"
 	envHeaders         = "OTEL_EXPORTER_OTLP_HEADERS"
 	envTracesHeaders   = "OTEL_EXPORTER_OTLP_TRACES_HEADERS"
 	envMetricsHeaders  = "OTEL_EXPORTER_OTLP_METRICS_HEADERS"
+	envLogsHeaders     = "OTEL_EXPORTER_OTLP_LOGS_HEADERS"
 	envResourceAttrs   = "OTEL_RESOURCE_ATTRIBUTES"
 )
 

--- a/pkg/export/otel/otelcfg/config_logs.go
+++ b/pkg/export/otel/otelcfg/config_logs.go
@@ -1,0 +1,285 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg // import "go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+
+import (
+	"fmt"
+	"log/slog"
+	"maps"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/collector/consumer"
+)
+
+func llog() *slog.Logger {
+	return slog.With("component", "otelcfg.LogsConfig")
+}
+
+type LogsConfig struct {
+	LogsConsumer   consumer.Logs `yaml:"-"`
+	CommonEndpoint string        `yaml:"-" env:"OTEL_EXPORTER_OTLP_ENDPOINT" jsonschema:"format=uri"`
+	LogsEndpoint   string        `yaml:"endpoint" env:"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT" jsonschema:"format=uri"`
+
+	Protocol     Protocol `yaml:"protocol" env:"OTEL_EXPORTER_OTLP_PROTOCOL"`
+	LogsProtocol Protocol `yaml:"-" env:"OTEL_EXPORTER_OTLP_LOGS_PROTOCOL"`
+
+	// InsecureSkipVerify enables skipping TLS certificate verification (not standard, so we don't follow the same naming convention)
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify" env:"OTEL_EBPF_INSECURE_SKIP_VERIFY"`
+
+	// BatchMaxSize is the maximum number of log records that the batcher will accumulate
+	// before flushing a batch to the sending queue.
+	BatchMaxSize int `yaml:"batch_max_size" env:"OTEL_EBPF_OTLP_LOGS_BATCH_MAX_SIZE" validate:"omitempty,gt=0"`
+
+	// QueueSize is the maximum number of log records that the sending queue will hold
+	// before applying back-pressure. It must be >= `2 * BatchMaxSize`, otherwise the
+	// memory queue rejects every batch with "element size too large" and drops
+	// log records permanently. If left at 0 it defaults to `4 * BatchMaxSize`.
+	QueueSize int `yaml:"queue_size" env:"OTEL_EBPF_OTLP_LOGS_QUEUE_SIZE"`
+
+	// BatchTimeout is the time after which a batch will be sent regardless of its size.
+	BatchTimeout time.Duration `yaml:"batch_timeout" env:"OTEL_EBPF_OTLP_LOGS_BATCH_TIMEOUT"`
+
+	// Configuration options for BackOffConfig of the logs exporter.
+	// See https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configretry/backoff.go
+	// Namespaced per-signal (unlike TracesConfig's generically-named
+	// equivalents) since this is a new signal and there's no existing
+	// precedent of these being intentionally shared across signals.
+	BackOffInitialInterval time.Duration `yaml:"backoff_initial_interval" env:"OTEL_EBPF_LOGS_BACKOFF_INITIAL_INTERVAL" validate:"omitempty,gt=0"`
+	BackOffMaxInterval     time.Duration `yaml:"backoff_max_interval" env:"OTEL_EBPF_LOGS_BACKOFF_MAX_INTERVAL" validate:"omitempty,gt=0"`
+	BackOffMaxElapsedTime  time.Duration `yaml:"backoff_max_elapsed_time" env:"OTEL_EBPF_LOGS_BACKOFF_MAX_ELAPSED_TIME" validate:"omitempty,gt=0"`
+	ReportersCacheLen      int           `yaml:"reporters_cache_len" env:"OTEL_EBPF_LOGS_REPORT_CACHE_LEN" validate:"omitempty,gt=0"`
+
+	// SDKLogLevel is intentionally the SAME env var as TracesConfig/MetricsConfig's
+	// field of the same name — this is an existing shared, not per-signal, knob.
+	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL" validate:"omitempty,oneofci=debug info warn error"`
+
+	// OTLPEndpointProvider allows overriding the OTLP Endpoint. It needs to return an endpoint and
+	// a boolean indicating if the endpoint is common for both traces and metrics
+	OTLPEndpointProvider func() (string, bool) `yaml:"-" env:"-"`
+
+	// InjectHeaders allows injecting custom headers to the HTTP OTLP exporter
+	InjectHeaders func(dst map[string]string) `yaml:"-" env:"-"`
+}
+
+func (m *LogsConfig) NormalizeQueueConfig() error {
+	if m.QueueSize == 0 && m.BatchMaxSize > 0 {
+		m.QueueSize = 4 * m.BatchMaxSize
+		llog().Info("logs.queue_size not set, defaulting to 4 * batch_max_size",
+			"queue_size", m.QueueSize, "batch_max_size", m.BatchMaxSize)
+	}
+	if m.BatchMaxSize > 0 && m.QueueSize < 2*m.BatchMaxSize {
+		return fmt.Errorf("logs.queue_size (%d) must be >= 2 * logs.batch_max_size (%d): "+
+			"otherwise the sending queue rejects every batch with \"element size too large\"",
+			m.QueueSize, m.BatchMaxSize)
+	}
+	return nil
+}
+
+func (m LogsConfig) MarshalYAML() (any, error) {
+	omit := map[string]struct{}{
+		"endpoint": {},
+	}
+	return omitFieldsForYAML(m, omit), nil
+}
+
+// Enabled specifies that the OTEL logs node is enabled if and only if
+// either the OTEL endpoint and OTEL logs endpoint is defined.
+// If not enabled, this node won't be instantiated
+func (m *LogsConfig) Enabled() bool {
+	if m.LogsConsumer != nil {
+		return true
+	}
+
+	if m.LogsProtocol == ProtocolDebug || (m.LogsProtocol == "" && m.Protocol == ProtocolDebug) {
+		return true
+	}
+
+	ep, _ := m.OTLPLogsEndpoint()
+	return ep != ""
+}
+
+func (m *LogsConfig) GetProtocol() Protocol {
+	if m.LogsConsumer != nil {
+		return ProtocolUnset
+	}
+	if m.LogsProtocol != "" {
+		return m.LogsProtocol
+	}
+	if m.Protocol != "" {
+		return m.Protocol
+	}
+	return m.guessProtocol()
+}
+
+func (m *LogsConfig) OTLPLogsEndpoint() (string, bool) {
+	if m.OTLPEndpointProvider != nil {
+		return m.OTLPEndpointProvider()
+	}
+	return ResolveOTLPEndpoint(m.LogsEndpoint, m.CommonEndpoint)
+}
+
+func (m *LogsConfig) guessProtocol() Protocol {
+	ep, _, err := ParseLogsEndpoint(m)
+	if err == nil {
+		if strings.HasSuffix(ep.Port(), UsualPortGRPC) {
+			return ProtocolGRPC
+		} else if strings.HasSuffix(ep.Port(), UsualPortHTTP) {
+			return ProtocolHTTPProtobuf
+		}
+	}
+	return ProtocolHTTPProtobuf
+}
+
+// ParseLogsEndpoint defines the HTTP path of the logs collector.
+func ParseLogsEndpoint(cfg *LogsConfig) (*url.URL, bool, error) {
+	endpoint, isCommon := cfg.OTLPLogsEndpoint()
+
+	murl, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, isCommon, fmt.Errorf("parsing endpoint URL %s: %w", endpoint, err)
+	}
+	if murl.Scheme == "" || murl.Host == "" {
+		return nil, isCommon, fmt.Errorf("URL %q must have a scheme and a host", endpoint)
+	}
+	return murl, isCommon, nil
+}
+
+func unixLogsHTTPOptions(cfg *LogsConfig, addr string) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	if err := validateUnixSocketAddr(addr); err != nil {
+		return opts, err
+	}
+
+	setLogsProtocol(cfg)
+	opts.UnixSocketAddr = addr
+	opts.Scheme = "http"
+	opts.Endpoint = "localhost"
+	opts.Insecure = true
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envLogsHeaders))
+
+	return opts, nil
+}
+
+func unixLogsGRPCOptions(cfg *LogsConfig, addr string) (OTLPOptions, error) {
+	opts := OTLPOptions{Headers: map[string]string{}}
+	if err := validateUnixSocketAddr(addr); err != nil {
+		return opts, err
+	}
+
+	opts.UnixSocketAddr = addr
+	opts.Endpoint = grpcUnixTarget(addr)
+	opts.Insecure = true
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envLogsHeaders))
+
+	return opts, nil
+}
+
+func HTTPLogsEndpointOptions(cfg *LogsConfig) (OTLPOptions, error) {
+	rawEndpoint, _ := cfg.OTLPLogsEndpoint()
+	if addr, ok := unixSocketEndpoint(rawEndpoint); ok {
+		return unixLogsHTTPOptions(cfg, addr)
+	}
+
+	opts := OTLPOptions{Headers: map[string]string{}}
+	log := llog().With("transport", "http")
+
+	murl, isCommon, err := ParseLogsEndpoint(cfg)
+	if err != nil {
+		return opts, err
+	}
+
+	log.Debug("Configuring exporter", "protocol",
+		cfg.Protocol, "logsProtocol", cfg.LogsProtocol, "endpoint", murl.Host)
+	setLogsProtocol(cfg)
+	opts.Scheme = murl.Scheme
+	opts.Endpoint = murl.Host
+	if murl.Scheme == "http" {
+		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
+		opts.Insecure = true
+	}
+	opts.URLPath = strings.TrimSuffix(murl.Path, "/")
+	opts.BaseURLPath = strings.TrimSuffix(opts.URLPath, "/v1/logs")
+	if isCommon {
+		opts.URLPath += "/v1/logs"
+		log.Debug("Specifying path", "path", opts.URLPath)
+	}
+
+	if cfg.InsecureSkipVerify {
+		log.Debug("Setting InsecureSkipVerify")
+		opts.SkipTLSVerify = true
+	}
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envLogsHeaders))
+
+	return opts, nil
+}
+
+func GRPCLogsEndpointOptions(cfg *LogsConfig) (OTLPOptions, error) {
+	rawEndpoint, _ := cfg.OTLPLogsEndpoint()
+	if addr, ok := unixSocketEndpoint(rawEndpoint); ok {
+		return unixLogsGRPCOptions(cfg, addr)
+	}
+
+	opts := OTLPOptions{Headers: map[string]string{}}
+	log := llog().With("transport", "grpc")
+	murl, _, err := ParseLogsEndpoint(cfg)
+	if err != nil {
+		return opts, err
+	}
+
+	log.Debug("Configuring exporter", "protocol",
+		cfg.Protocol, "logsProtocol", cfg.LogsProtocol, "endpoint", murl.Host)
+	opts.Endpoint = murl.Host
+	if murl.Scheme == "http" {
+		log.Debug("Specifying insecure connection", "scheme", murl.Scheme)
+		opts.Insecure = true
+	}
+
+	if cfg.InsecureSkipVerify {
+		log.Debug("Setting InsecureSkipVerify")
+		opts.SkipTLSVerify = true
+	}
+
+	if cfg.InjectHeaders != nil {
+		cfg.InjectHeaders(opts.Headers)
+	}
+	maps.Copy(opts.Headers, HeadersFromEnv(envHeaders))
+	maps.Copy(opts.Headers, HeadersFromEnv(envLogsHeaders))
+	return opts, nil
+}
+
+func setLogsProtocol(cfg *LogsConfig) {
+	if _, ok := os.LookupEnv(envLogsProtocol); ok {
+		return
+	}
+	if _, ok := os.LookupEnv(envProtocol); ok {
+		return
+	}
+	if cfg.LogsProtocol != "" {
+		os.Setenv(envLogsProtocol, string(cfg.LogsProtocol))
+		return
+	}
+	if cfg.Protocol != "" {
+		os.Setenv(envProtocol, string(cfg.Protocol))
+		return
+	}
+	os.Setenv(envLogsProtocol, string(cfg.guessProtocol()))
+}

--- a/pkg/export/otel/otelcfg/config_logs_test.go
+++ b/pkg/export/otel/otelcfg/config_logs_test.go
@@ -1,0 +1,84 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelcfg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestLogsConfig_Enabled(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		cfg := LogsConfig{}
+		assert.False(t, cfg.Enabled())
+	})
+
+	t.Run("enabled with an endpoint", func(t *testing.T) {
+		cfg := LogsConfig{LogsEndpoint: "http://localhost:4318"}
+		assert.True(t, cfg.Enabled())
+	})
+
+	t.Run("enabled via debug protocol", func(t *testing.T) {
+		cfg := LogsConfig{LogsProtocol: ProtocolDebug}
+		assert.True(t, cfg.Enabled())
+	})
+
+	t.Run("enabled via injected consumer", func(t *testing.T) {
+		cfg := LogsConfig{LogsConsumer: fakeLogsConsumer{}}
+		assert.True(t, cfg.Enabled())
+	})
+}
+
+func TestHTTPLogsEndpoint(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	cfg := LogsConfig{
+		CommonEndpoint: "https://localhost:3131",
+		LogsEndpoint:   "https://localhost:3232/v1/logs",
+	}
+	opts, err := HTTPLogsEndpointOptions(&cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "https", opts.Scheme)
+	assert.Equal(t, "localhost:3232", opts.Endpoint)
+	assert.Equal(t, "/v1/logs", opts.URLPath)
+}
+
+func TestHTTPLogsEndpoint_CommonOnly(t *testing.T) {
+	defer RestoreEnvAfterExecution()()
+	cfg := LogsConfig{
+		CommonEndpoint: "https://localhost:3131/otlp",
+	}
+	opts, err := HTTPLogsEndpointOptions(&cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "https", opts.Scheme)
+	assert.Equal(t, "localhost:3131", opts.Endpoint)
+	assert.Equal(t, "/otlp", opts.BaseURLPath)
+	assert.Equal(t, "/otlp/v1/logs", opts.URLPath)
+}
+
+func TestLogsConfig_NormalizeQueueConfig(t *testing.T) {
+	t.Run("defaults queue size to 4x batch size", func(t *testing.T) {
+		cfg := LogsConfig{BatchMaxSize: 100}
+		require.NoError(t, cfg.NormalizeQueueConfig())
+		assert.Equal(t, 400, cfg.QueueSize)
+	})
+
+	t.Run("rejects queue size smaller than 2x batch size", func(t *testing.T) {
+		cfg := LogsConfig{BatchMaxSize: 100, QueueSize: 50}
+		require.Error(t, cfg.NormalizeQueueConfig())
+	})
+}
+
+type fakeLogsConsumer struct{}
+
+func (fakeLogsConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+func (fakeLogsConsumer) ConsumeLogs(_ context.Context, _ plog.Logs) error { return nil }

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -374,6 +374,7 @@ type Config struct {
 	NameResolver *transform.NameResolverConfig `yaml:"name_resolver"`
 	OTELMetrics  otelcfg.MetricsConfig         `yaml:"otel_metrics_export"`
 	Traces       otelcfg.TracesConfig          `yaml:"otel_traces_export"`
+	Logs         otelcfg.LogsConfig            `yaml:"otel_logs_export"`
 	Prometheus   prom.PrometheusConfig         `yaml:"prometheus_export"`
 	TracePrinter debug.TracePrinter            `yaml:"trace_printer" env:"OTEL_EBPF_TRACE_PRINTER"`
 
@@ -756,6 +757,10 @@ func (c *Config) validate(context validationContext) error {
 	}
 
 	if err := c.Traces.NormalizeQueueConfig(); err != nil {
+		return ConfigError(err.Error())
+	}
+
+	if err := c.Logs.NormalizeQueueConfig(); err != nil {
 		return ConfigError(err.Error())
 	}
 

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -295,6 +295,9 @@ discovery:
 				// no traces for DNS and GPU by default
 			},
 		},
+		Logs: otelcfg.LogsConfig{
+			CommonEndpoint: "localhost:3131",
+		},
 		Prometheus: prom.PrometheusConfig{
 			Path: "/metrics",
 			Instrumentations: []instrumentations.Instrumentation{


### PR DESCRIPTION
## Summary

Adds generic OTLP logs export capability to OBI: `otelcfg.LogsConfig`, `getLogsExporter` (HTTP/gRPC/debug), and `LogsConsumer` embedding hook, mirroring existing `TracesConfig`/`TracesConsumer` pattern. Wires new `otel_logs_export` config surface into `Config`.

Split out of #2863 per review (see thread for context). Original PR was too much to review together.

## Notes
- HTTP exporter mirrors `getTracesExporter`'s pattern of disabling inner `otlphttpexporter`'s own queue/retry and applying real settings exactly once per outer wrap, avoiding double-buffering.
- `TestLogsExportDelivery` proves real OTLP delivery over both HTTP and gRPC to an in-process receiver, decoding the actual wire payload (end-to-end test)

## AI Usage

Per AI-Policy §5: Claude Code was used to split the PR out of #2863, extracting plumbing subset. I reviewed the resulting diff, and confirmed no queue/processing-specific code leaked into this split, and ran the verification below.

Verification run:

- `go build ./... clean` (eBPF bindings regenerated against current `main`)
- `go test ./pkg/export/otel/... ./pkg/obi/... clean`
- `TestLogsExportDelivery` (new): proves OTLP delivery over both HTTP and gRPC to in-process receiver, decoding actual wire payload
- `make lint` clean
- `make check-config-schema` clean (`devdocs/config/CONFIG.md/config-schema.json` regenerated from code

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
