### PR TITLE
tpinjector: attach a no-op SK_SKB verdict on FIONREAD-regression kernels

### DIFF
--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -1160,6 +1160,21 @@ int obi_packet_extender(struct sk_msg_md *msg) {
     return SK_PASS;
 }
 
+// A no-op stream verdict attached to sock_dir. Kernels carrying commit
+// 929e30f93125 (present in 6.6.128+, 6.12.75+, 6.18.14+ and 6.19+) can lose the
+// receive-side readiness wakeup for a socket enrolled in a sockhash that has no
+// verdict program: bytes sit in the receive queue but the epoll/poll edge is
+// never delivered. fionread_fixup.c handles the ioctl(FIONREAD) half of the
+// same regression (nginx, Java NIO, .NET); it cannot help readers that block on
+// epoll/poll (Node.js/libuv, the Go netpoller, Python asyncio). Attaching a
+// verdict program moves enrolled sockets onto the receive path that kernel fix
+// 04af4efde58a targets, which restores the readiness notification. The program
+// passes every skb through unchanged — the attachment is the fix, not the body.
+SEC("sk_skb/verdict")
+int obi_sk_skb_verdict(struct __sk_buff *skb __maybe_unused) {
+    return SK_PASS;
+}
+
 //k_tail_write_msg_traceparent
 SEC("sk_msg")
 int obi_packet_extender_write_msg_tp(struct sk_msg_md *msg) {

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -257,13 +257,30 @@ func (p *Tracer) SocketFilters() []*ebpf.Program {
 }
 
 func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg {
-	return []ebpfcommon.SockMsg{
+	msgs := []ebpfcommon.SockMsg{
 		{
 			Program:  p.bpfObjects.ObiPacketExtender,
 			MapFD:    p.bpfObjects.SockDir.FD(),
 			AttachAs: ebpf.AttachSkMsgVerdict,
 		},
 	}
+
+	// On kernels carrying commit 929e30f93125, sockets enrolled in sock_dir
+	// without a verdict program can lose the receive-side readiness wakeup.
+	// The FIONREAD fixup only repairs ioctl-based readers; a no-op SK_SKB
+	// verdict moves enrolled sockets onto the receive path kernel fix
+	// 04af4efde58a targets, restoring epoll/poll readiness for runtimes that
+	// never call ioctl(FIONREAD) (Node.js, the Go netpoller, Python asyncio).
+	// Same detection as the FIONREAD fixup, so the two travel together.
+	if p.kernelBreaksFIONREAD() {
+		msgs = append(msgs, ebpfcommon.SockMsg{
+			Program:  p.bpfObjects.ObiSkSkbVerdict,
+			MapFD:    p.bpfObjects.SockDir.FD(),
+			AttachAs: ebpf.AttachSkSKBVerdict,
+		})
+	}
+
+	return msgs
 }
 
 func (p *Tracer) SockOps() []ebpfcommon.SockOps {


### PR DESCRIPTION
### Problem

Kernels carrying commit `929e30f93125` (6.6.128+, 6.12.75+, 6.18.14+, 6.19+) can drop the receive-side readiness wakeup for a socket enrolled in `sock_dir` that has no verdict program: bytes sit in the receive queue but the epoll/poll edge is never delivered.

#2580 (the FIONREAD fixup) addresses the `ioctl(FIONREAD)` half of the same regression, but only helps readers that size their reads via that ioctl (nginx, Java NIO, .NET). Runtimes that block on epoll/poll — Node.js/libuv, the Go netpoller, Python asyncio — get no wakeup and stall. This is the sibling of grafana/beyla#3025 (and #2941).

### Fix

Attach a no-op `SK_SKB` verdict (`SK_PASS`) to `sock_dir`. The kernel then routes enrolled sockets onto the verdict-present receive branch — the path kernel fix `04af4efde58a` repairs — which restores readiness. The program does nothing; the *attachment* is the fix.

It reuses the existing `kernelBreaksFIONREAD()` probe, so it attaches only where the FIONREAD fixup already does and unaffected kernels are untouched. No new config surface, and the generated bindings pick up the program through the normal `make generate` path.

### Validation

Running in production as an equivalent patch (the verdict built at runtime rather than via bpf2go) on affected-kernel nodes across two clusters. On 6.12.85 the HTTP failure rate under context propagation dropped from ~1.8% back to baseline, and the epoll-based stalls disappeared. I have not compiled this exact C form locally (no bpf/clang toolchain on my machine) — CI's `make generate` + build covers that.

### AI disclosure

Prepared with AI assistance (Claude Code). I reviewed every line, validated the approach in production, and take full responsibility for the change per the OBI AI policy.

Refs grafana/beyla#3025
