### PR TITLE
k8s weaver: retry transient first-hop tap exports to stop intermittent suite failures

### DIFF
--- a/internal/test/integration/configs/otelcol-config-k8s-weaver.yml
+++ b/internal/test/integration/configs/otelcol-config-k8s-weaver.yml
@@ -50,7 +50,10 @@ exporters:
       enabled: true
       queue_size: 500
     retry_on_failure:
-      enabled: false
+      enabled: true
+      initial_interval: 1s
+      max_interval: 5s
+      max_elapsed_time: 15s
 service:
   # own telemetry exposed for validateWeaver's first-hop drop check (00-kind*.yml)
   telemetry:


### PR DESCRIPTION
## Summary

Enable a bounded `retry_on_failure` on the first hop of the Kubernetes Weaver tap (the suite `otelcol` → `weavercol` exporter), so a transient export blip retries instead of being dropped.

## Background

The k8s Weaver suites fail the whole suite if the tap drops any export, on the principle that a dropped batch may carry Weaver's only copy of a metric or span shape and leave it unvalidated.

In practice the suite `otelcol` occasionally drops a handful of exports to `weavercol` on a transient blip (observed: 2 of ~7000 in the `otel` suite). With retries disabled those drops are counted and fail the run, which shows up as an intermittent `otel` (and other trace-suite) failure on unrelated PRs.

A bounded retry lets those transient blips recover:

- The retry budget (`max_elapsed_time: 15s`) is shorter than `validateWeaver`'s drain window (25s), so a genuinely unresolved export still increments `otelcol_exporter_send_failed_*` and is counted before the report is stopped — real loss still fails the suite.
- The exporter keeps dropping on queue overflow (no `block_on_overflow`), so OBI's export path is never back-pressured.

Both the single- and multi-node otelcol manifests mount this config, so the change covers every Weaver-tapped suite.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
