### PR TITLE
integration: netolly GeoIP suite covering src/dst asn+country flow attributes

### DIFF
--- a/internal/test/integration/configs/obi-config-netolly-geoip.yml
+++ b/internal/test/integration/configs/obi-config-netolly-geoip.yml
@@ -1,0 +1,25 @@
+log_format: json
+network:
+  guess_ports: ordinal
+  geo_ip:
+    maxmind:
+      country_path: /geoip/GeoIP2-Country-Test.mmdb
+      asn_path: /geoip/GeoLite2-ASN-Test.mmdb
+internal_metrics:
+  exporter: otel
+attributes:
+  select:
+    obi_network_flow_bytes:
+      include:
+      - obi.ip
+      - src.address
+      - dst.address
+      - src.name
+      - dst.name
+      - src.asn
+      - dst.asn
+      - src.country
+      - dst.country
+      - iface
+      - iface_direction
+      - direction

--- a/internal/test/integration/docker-compose-netolly-geoip.yml
+++ b/internal/test/integration/docker-compose-netolly-geoip.yml
@@ -1,0 +1,105 @@
+version: "3.8"
+
+networks:
+  geoip:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 216.160.83.0/24
+
+services:
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/testserver/Dockerfile
+    image: hatest-testserver
+    networks:
+      default: {}
+      geoip:
+        ipv4_address: 216.160.83.57
+    ports:
+      - "8080:8080"
+    environment:
+      LOG_LEVEL: DEBUG
+
+  netclient:
+    image: alpine/curl@sha256:e62df00da54d9b51ae83ecdf4ad84a4fc4bca3a91189f1d6eae84d5f46d3a9cc
+    networks:
+      geoip:
+        ipv4_address: 216.160.83.100
+    command:
+      - sh
+      - -c
+      - "while true; do curl -s --max-time 2 http://216.160.83.57:8080/ || true; sleep 1; done"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-netolly:/var/run/obi
+      - ../geoip:/geoip:ro
+    image: hatest-obi
+    privileged: true
+    network_mode: service:testserver
+    environment:
+      OTEL_EBPF_CONFIG_PATH: /configs/obi-config-netolly-geoip.yml
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_NETWORK_METRICS: "true" # explicitly enabling network metrics
+      OTEL_EBPF_NETWORK_PRINT_FLOWS: "true"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "1s"
+      OTEL_EBPF_NETWORK_CACHE_ACTIVE_TIMEOUT: "1s"
+      OTEL_EBPF_NETWORK_DEDUPER: "none"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4318
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.158.0@sha256:c5918f78992ee73b0d6f0e599423ac5ec52dd5d9726733114d6eca53d5a32ed5
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver-no-jaeger.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
+
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config${PROM_CONFIG_SUFFIX}.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"

--- a/internal/test/integration/suites_network_geoip_test.go
+++ b/internal/test/integration/suites_network_geoip_test.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
+	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
+)
+
+func TestNetwork_GeoIP(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-netolly-geoip.yml", path.Join(pathOutput, "test-suite-netolly-geoip.log"))
+	require.NoError(t, err)
+	compose.Env = append(compose.Env, `PROM_CONFIG_SUFFIX=`)
+	require.NoError(t, compose.Up())
+
+	checkGeoIPFlows := func(query string) {
+		pq := promtest.Client{HostPort: prometheusHostPort}
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			results, err := pq.Query(`obi_network_flow_bytes_total` + query)
+			require.NoError(ct, err)
+			require.NotEmpty(ct, results)
+		}, 4*testTimeout, 100*time.Millisecond)
+	}
+
+	checkGeoIPFlows(`{dst_asn="AS209",dst_country="US"}`)
+	checkGeoIPFlows(`{src_asn="AS209",src_country="US"}`)
+
+	runWeaverValidation(t)
+
+	require.NoError(t, compose.Close())
+}

--- a/schemas/obi/groups/network.yaml
+++ b/schemas/obi/groups/network.yaml
@@ -111,12 +111,12 @@ groups:
         type: string
         stability: development
         brief: Autonomous System Number of the source endpoint, from GeoIP lookup.
-        examples: ["15169"]
+        examples: ["AS15169"]
       - id: dst.asn
         type: string
         stability: development
         brief: Autonomous System Number of the destination endpoint, from GeoIP lookup.
-        examples: ["15169"]
+        examples: ["AS15169"]
       - id: src.country
         type: string
         stability: development
@@ -319,6 +319,10 @@ groups:
       - ref: dst.zone
       - ref: src.name
       - ref: dst.name
+      - ref: src.asn
+      - ref: dst.asn
+      - ref: src.country
+      - ref: dst.country
 
   # Overrides `network.type`: extends the upstream `ipv4`/`ipv6` enum with
   # `arp`, which OBI reports for ARP frames — OBI observes raw L2 frames, a

--- a/schemas/obi/groups/network.yaml
+++ b/schemas/obi/groups/network.yaml
@@ -104,6 +104,30 @@ groups:
         brief: CIDR block matched against the destination IP.
         examples: ["10.0.0.0/8"]
 
+      # GeoIP decoration of the flow endpoints, attached by the geoip pipeline
+      # stage when GeoIP is enabled. Stored as strings (netolly Metadata is
+      # string-valued). OBI/netolly convention, no upstream equivalent.
+      - id: src.asn
+        type: string
+        stability: development
+        brief: Autonomous System Number of the source endpoint, from GeoIP lookup.
+        examples: ["15169"]
+      - id: dst.asn
+        type: string
+        stability: development
+        brief: Autonomous System Number of the destination endpoint, from GeoIP lookup.
+        examples: ["15169"]
+      - id: src.country
+        type: string
+        stability: development
+        brief: ISO country code of the source endpoint, from GeoIP lookup.
+        examples: ["US"]
+      - id: dst.country
+        type: string
+        stability: development
+        brief: ISO country code of the destination endpoint, from GeoIP lookup.
+        examples: ["US"]
+
       # Kubernetes decoration of the source / destination flow endpoints,
       # attached by netolly (pkg/internal/netolly/transform/k8s) when
       # Kubernetes metadata is available and the corresponding keys are
@@ -224,6 +248,10 @@ groups:
       - ref: k8s.dst.type
       - ref: k8s.dst.node.ip
       - ref: k8s.dst.node.name
+      - ref: src.asn
+      - ref: dst.asn
+      - ref: src.country
+      - ref: dst.country
 
   - id: metric.obi_network_flow_packets
     type: metric
@@ -269,6 +297,10 @@ groups:
       - ref: k8s.dst.type
       - ref: k8s.dst.node.ip
       - ref: k8s.dst.node.name
+      - ref: src.asn
+      - ref: dst.asn
+      - ref: src.country
+      - ref: dst.country
 
   - id: metric.obi_network_inter_zone_bytes
     type: metric


### PR DESCRIPTION
## Summary

Adds an integration suite that exercises OBI's GeoIP network-flow attributes
end to end, and declares those attributes in the semantic-convention registry.

When GeoIP is enabled, netolly decorates flows with `src.asn`, `dst.asn`,
`src.country`, and `dst.country`. No suite emitted them before, so they were
never observed by weaver or checked against the schema.

**The suite.** `docker-compose-netolly-geoip.yml` + `TestNetwork_GeoIP` stand up
a server pinned to the MaxMind test address `216.160.83.57` on a dedicated
`216.160.83.0/24` network, plus a client that connects to it. A single
connection produces both a request flow (`dst=…57`) and a response flow
(`src=…57`), so all four attributes get decorated. It uses the MaxMind test
databases already vendored under `internal/test/geoip/`, so it needs no external
data or internet access. The test asserts
`obi_network_flow_bytes_total{dst_asn="AS209",dst_country="US"}` and the `src_*`
equivalents, then weaver live-check validates the emitted shape.

**The schema change.** `schemas/obi/groups/network.yaml` gains the four
attribute declarations and refs them on the flow-bytes / flow-packets metrics.
Without this, weaver flags them as undeclared attributes under the existing
`src`/`dst` namespaces (an `extends_namespace` violation).

No behavioral change to OBI runtime — integration test, config, and schema only.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
