### PR TITLE
cp: avoid creating multiple root spans in case of foreign traceparents

### DIFF
--- a/bpf/common/connection_info.h
+++ b/bpf/common/connection_info.h
@@ -221,13 +221,20 @@ static __always_inline u8 is_empty_connection_info(const connection_info_t *conn
     return conn->s_port == 0 && conn->d_port == 0;
 }
 
-static __always_inline egress_key_t make_egress_key(const connection_info_t *conn) {
+// Sorts internally so either direction of a connection yields one key
+static __always_inline egress_key_t make_egress_key_stream(const connection_info_t *conn,
+                                                           u32 stream_id) {
     egress_key_t e_key = {
-        .d_port = conn->d_port,
         .s_port = conn->s_port,
+        .d_port = conn->d_port,
+        .stream_id = stream_id,
     };
 
     sort_egress_key(&e_key);
 
     return e_key;
+}
+
+static __always_inline egress_key_t make_egress_key(const connection_info_t *conn) {
+    return make_egress_key_stream(conn, 0);
 }

--- a/bpf/common/egress_key.h
+++ b/bpf/common/egress_key.h
@@ -5,6 +5,7 @@
 
 #include <bpfcore/vmlinux.h>
 
+// Ports collide across namespaces; readers must validate pid and freshness
 typedef struct egress_key {
     u16 s_port;
     u16 d_port;

--- a/bpf/common/trace_helpers.h
+++ b/bpf/common/trace_helpers.h
@@ -37,6 +37,11 @@ static __always_inline u8 valid_trace(const unsigned char *trace_id) {
     return *((u64 *)trace_id) != 0 || *((u64 *)(trace_id + 8)) != 0;
 }
 
+// Cached tps only die under LRU pressure, so stale ones must not be adopted
+static __always_inline u8 tp_within_transaction(const tp_info_t *tp, u64 now) {
+    return now >= tp->ts && (now - tp->ts) < max_transaction_time;
+}
+
 static __always_inline u8 should_be_in_same_transaction(const tp_info_t *parent_tp,
                                                         const tp_info_t *child_tp) {
     if (child_tp->ts < parent_tp->ts) {

--- a/bpf/common/trace_lifecycle.h
+++ b/bpf/common/trace_lifecycle.h
@@ -8,6 +8,7 @@
 
 #include <common/event_defs.h>
 #include <common/runtime.h>
+#include <common/trace_helpers.h>
 #include <common/trace_key.h>
 #include <common/tracing.h>
 
@@ -41,11 +42,7 @@ static __always_inline void delete_client_trace_info(pid_connection_info_t *pid_
 
     delete_trace_info_for_connection(&pid_conn->conn, TRACE_TYPE_CLIENT);
 
-    egress_key_t e_key = {
-        .d_port = pid_conn->conn.d_port,
-        .s_port = pid_conn->conn.s_port,
-    };
-    sort_egress_key(&e_key);
+    const egress_key_t e_key = make_egress_key(&pid_conn->conn);
     bpf_map_delete_elem(&outgoing_trace_map, &e_key);
     bpf_map_delete_elem(&cp_support_connect_info, pid_conn);
 }
@@ -57,6 +54,12 @@ static __always_inline u8 find_trace_for_server_request(connection_info_t *conn,
     connection_info_t sorted_conn = *conn;
     sort_connection_info(&sorted_conn);
     tp_info_pid_t *existing_tp = bpf_map_lookup_elem(&incoming_trace_map, &sorted_conn);
+    if (existing_tp && !tp_within_transaction(&existing_tp->tp, bpf_ktime_get_ns())) {
+        bpf_dbg_printk("incoming (TCP/IP) tp outlived its transaction, dropping");
+        bpf_map_delete_elem(&incoming_trace_map, &sorted_conn);
+        existing_tp = NULL;
+    }
+
     if (existing_tp) {
         found_tp = 1;
         bpf_dbg_printk("Found incoming (TCP/IP) tp for server request");
@@ -166,12 +169,7 @@ static __always_inline void server_or_client_trace(const u8 type,
         // We need the PID id to be able to query ongoing_http and update
         // the span id with the SEQ/ACK pair.
         tp_p->pid = host_pid;
-        egress_key_t e_key = {
-            .d_port = conn->d_port,
-            .s_port = conn->s_port,
-            .stream_id = stream_id,
-        };
-        sort_egress_key(&e_key);
+        const egress_key_t e_key = make_egress_key_stream(conn, stream_id);
 
         if (ssl) {
             // Clone and mark it invalid for the purpose of storing it in the

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -437,8 +437,7 @@ int BPF_KPROBE(obi_kprobe_tcp_sendmsg, struct sock *sk, struct msghdr *msg, size
         const u16 orig_dport = s_args.p_conn.conn.d_port;
         dbg_print_http_connection_info(
             &s_args.p_conn.conn); // commented out since GitHub CI doesn't like this call
-        // Create the egress key before we sort the connection info.
-        egress_key_t e_key = make_egress_key(&s_args.p_conn.conn);
+        const egress_key_t e_key = make_egress_key(&s_args.p_conn.conn);
         sort_connection_info(&s_args.p_conn.conn);
         s_args.p_conn.pid = pid_from_pid_tgid(id);
         s_args.orig_dport = orig_dport;

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -40,8 +40,6 @@
 
 volatile const u32 high_request_volume;
 
-SCRATCH_MEM_SIZED(http_previous_trace_id, TRACE_ID_SIZE_BYTES);
-
 // empty_http_info zeroes and return the unique percpu copy in the map
 // this function assumes that a given thread is not trying to use many
 // instances at the same time
@@ -552,36 +550,23 @@ __obi_continue_protocol_http_tp(struct pt_regs *ctx,
             buf[buf_len] = '\0';
 
             unsigned char *res = tp_loop_fn(buf, buf_len);
-            if (res) {
+            const bool is_client = meta && meta->type == EVENT_HTTP_CLIENT;
+
+            if (res && !is_client) {
                 bpf_dbg_printk("Found traceparent in headers [%s] overriding what was before", res);
-                unsigned char *t_id = extract_trace_id(res);
-                unsigned char *s_id = extract_span_id(res);
-                unsigned char *f_id = extract_flags(res);
-                const bool is_client = meta && meta->type == EVENT_HTTP_CLIENT;
-                unsigned char *previous_trace_id = NULL;
 
-                if (is_client && valid_trace(tp_p->tp.trace_id)) {
-                    previous_trace_id = (unsigned char *)http_previous_trace_id_mem();
-                    if (previous_trace_id) {
-                        __builtin_memcpy(previous_trace_id, tp_p->tp.trace_id, TRACE_ID_SIZE_BYTES);
-                    }
-                }
-
-                decode_hex(tp_p->tp.trace_id, t_id, TRACE_ID_CHAR_LEN);
-                decode_hex((unsigned char *)&tp_p->tp.flags, f_id, FLAGS_CHAR_LEN);
-                if (meta && meta->type != EVENT_HTTP_CLIENT) {
-                    decode_hex(tp_p->tp.parent_id, s_id, SPAN_ID_CHAR_LEN);
-                } else if (previous_trace_id &&
-                           bpf_memcmp(previous_trace_id, tp_p->tp.trace_id, TRACE_ID_SIZE_BYTES) !=
-                               0) {
-                    __builtin_memset(tp_p->tp.parent_id, 0, sizeof(tp_p->tp.parent_id));
-                }
+                decode_hex(tp_p->tp.trace_id, extract_trace_id(res), TRACE_ID_CHAR_LEN);
+                decode_hex((unsigned char *)&tp_p->tp.flags, extract_flags(res), FLAGS_CHAR_LEN);
+                decode_hex(tp_p->tp.parent_id, extract_span_id(res), SPAN_ID_CHAR_LEN);
 
                 if (g_bpf_debug) {
                     unsigned char tp_buf[TP_MAX_VAL_LENGTH];
                     make_tp_string(tp_buf, &tp_p->tp);
                     bpf_dbg_printk("new tp: %s", tp_buf);
                 }
+            } else if (res) {
+                // the app's own header is unverifiable, so it never moves our span
+                bpf_dbg_printk("Found app traceparent on egress, keeping our own context");
             } else {
                 bpf_dbg_printk("No additional traceparent in headers, using what was made before");
             }
@@ -644,17 +629,12 @@ __obi_continue_protocol_http(struct pt_regs *ctx,
     http_connection_metadata_t *meta =
         connection_meta_by_direction(args->direction, PACKET_TYPE_REQUEST);
 
-    egress_key_t e_key = {
-        .d_port = args->pid_conn.conn.d_port,
-        .s_port = args->pid_conn.conn.s_port,
-    };
-
-    sort_egress_key(&e_key);
+    const egress_key_t e_key = make_egress_key(&args->pid_conn.conn);
 
     tp_info_pid_t *tp_p = bpf_map_lookup_elem(&outgoing_trace_map, &e_key);
 
     if (tp_p && tp_p->req_type == EVENT_HTTP_CLIENT && tp_p->written &&
-        tp_p->pid == args->pid_conn.pid) {
+        tp_p->pid == args->pid_conn.pid && tp_within_transaction(&tp_p->tp, bpf_ktime_get_ns())) {
         bpf_dbg_printk("found tp info previously set by sock msg");
         // we've already got a tp_info_pid_t setup by the sockmsg program, use
         // that instead

--- a/bpf/generictracer/protocol_http2.h
+++ b/bpf/generictracer/protocol_http2.h
@@ -62,15 +62,12 @@ static __always_inline u64 uniqueHTTP2ConnId(pid_connection_info_t *p_conn) {
 
 // Use the trace the Go uprobe wrote to outgoing_trace_map (replaces what find_trace_for_client_request returned).
 static __always_inline void adopt_injected_trace(http2_conn_stream_t *s_key, tp_info_t *tp) {
-    egress_key_t sorted_e = {
-        .d_port = s_key->pid_conn.conn.d_port,
-        .s_port = s_key->pid_conn.conn.s_port,
-        .stream_id = s_key->stream_id,
-    };
-    sort_egress_key(&sorted_e);
+    const egress_key_t sorted_e = make_egress_key_stream(&s_key->pid_conn.conn, s_key->stream_id);
     tp_info_pid_t *injected = bpf_map_lookup_elem(&outgoing_trace_map, &sorted_e);
     // written=1 means a uprobe wrote the entry (not a kprobe's random one).
-    if (injected && injected->valid && injected->written && valid_trace(injected->tp.trace_id)) {
+    if (injected && injected->valid && injected->written && valid_trace(injected->tp.trace_id) &&
+        injected->pid == s_key->pid_conn.pid &&
+        tp_within_transaction(&injected->tp, bpf_ktime_get_ns())) {
         bpf_memcpy(tp->trace_id, injected->tp.trace_id, TRACE_ID_SIZE_BYTES);
         bpf_memcpy(tp->span_id, injected->tp.span_id, SPAN_ID_SIZE_BYTES);
         bpf_memcpy(tp->parent_id, injected->tp.parent_id, SPAN_ID_SIZE_BYTES);
@@ -255,12 +252,7 @@ http2_grpc_end(http2_conn_stream_t *stream, http2_grpc_request_t *prev_info, voi
 
     // delete_client_trace_info only clears stream_id=0 — without this the
     // per-stream entries would leak until the LRU evicts them
-    egress_key_t e_key = {
-        .d_port = stream->pid_conn.conn.d_port,
-        .s_port = stream->pid_conn.conn.s_port,
-        .stream_id = stream->stream_id,
-    };
-    sort_egress_key(&e_key);
+    const egress_key_t e_key = make_egress_key_stream(&stream->pid_conn.conn, stream->stream_id);
     bpf_map_delete_elem(&outgoing_trace_map, &e_key);
 }
 

--- a/bpf/gotracer/go_common.h
+++ b/bpf/gotracer/go_common.h
@@ -255,6 +255,12 @@ server_trace_parent(void *goroutine_addr, tp_info_t *tp, tp_info_t *found_tp) {
             // First we look-up if we have information passed down to us from
             // TCP/IP context propagation.
             tp_info_pid_t *existing_tp = bpf_map_lookup_elem(&incoming_trace_map, &conn);
+            if (existing_tp && !tp_within_transaction(&existing_tp->tp, bpf_ktime_get_ns())) {
+                bpf_dbg_printk("incoming (TCP) tp outlived its transaction, dropping");
+                bpf_map_delete_elem(&incoming_trace_map, &conn);
+                existing_tp = NULL;
+            }
+
             if (existing_tp) {
                 bpf_dbg_printk("Found incoming (TCP) tp for server request");
                 found_info = 1;

--- a/bpf/gotracer/go_grpc.c
+++ b/bpf/gotracer/go_grpc.c
@@ -798,12 +798,7 @@ int obi_uprobe_grpcFramerWriteHeaders(struct pt_regs *ctx) {
             tp_p.pid = pid_from_pid_tgid(bpf_get_current_pid_tgid());
             tp_p.req_type = EVENT_HTTP_CLIENT;
 
-            egress_key_t e_key = {
-                .d_port = conn_info->d_port,
-                .s_port = conn_info->s_port,
-                .stream_id = (u32)stream_id,
-            };
-            sort_egress_key(&e_key);
+            const egress_key_t e_key = make_egress_key_stream(conn_info, (u32)stream_id);
             bpf_map_update_elem(&outgoing_trace_map, &e_key, &tp_p, BPF_ANY);
 
             pid_connection_info_t p_conn = {.conn = *conn_info, .pid = tp_p.pid};
@@ -1080,12 +1075,7 @@ int obi_uprobe_grpc_loopyWriter_originateStream(struct pt_regs *ctx) {
         tp_p.pid = pid_from_pid_tgid(bpf_get_current_pid_tgid());
         tp_p.req_type = EVENT_HTTP_CLIENT;
 
-        egress_key_t e_key = {
-            .d_port = conn_info->d_port,
-            .s_port = conn_info->s_port,
-            .stream_id = stream_id,
-        };
-        sort_egress_key(&e_key);
+        const egress_key_t e_key = make_egress_key_stream(conn_info, stream_id);
         bpf_map_update_elem(&outgoing_trace_map, &e_key, &tp_p, BPF_ANY);
 
         pid_connection_info_t p_conn = {.conn = *conn_info, .pid = tp_p.pid};

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -795,10 +795,7 @@ int obi_uprobe_roundTripReturn(struct pt_regs *ctx) {
     if (info) {
         __builtin_memcpy(&trace->conn, info, sizeof(connection_info_t));
 
-        egress_key_t e_key = {
-            .d_port = info->d_port,
-            .s_port = info->s_port,
-        };
+        const egress_key_t e_key = make_egress_key(info);
         bpf_map_delete_elem(&outgoing_trace_map, &e_key);
         bpf_map_delete_elem(&go_ongoing_http, &e_key);
     } else {
@@ -1076,10 +1073,7 @@ static __always_inline int on_writeSubset_returns(struct pt_regs *ctx,
         go_addr_key_from_id(&g_key, (void *)inv->req_goaddr);
         connection_info_t *info = bpf_map_lookup_elem(&ongoing_client_connections, &g_key);
         if (info) {
-            egress_key_t e_key = {
-                .d_port = info->d_port,
-                .s_port = info->s_port,
-            };
+            const egress_key_t e_key = make_egress_key(info);
             //dbg_print_http_connection_info(info);
             bpf_map_delete_elem(&outgoing_trace_map, &e_key);
             bpf_dbg_printk(
@@ -1715,10 +1709,7 @@ int obi_uprobe_persistConnRoundTrip(struct pt_regs *ctx) {
                 // We need the PID id to be able to query ongoing_http and update
                 // the span id with the SEQ/ACK pair.
 
-                egress_key_t e_key = {
-                    .d_port = conn.d_port,
-                    .s_port = conn.s_port,
-                };
+                const egress_key_t e_key = make_egress_key(&conn);
 
                 if (tls_state) {
                     // Clone and mark it invalid for the purpose of storing it in the

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -473,6 +473,8 @@ static __always_inline bool create_trace_info(const tailcall_ctx *t_ctx, tp_info
     // earlier in  k_tail_find_existing_tp - sorry!
     urand_bytes(tp_p->tp.span_id, sizeof(tp_p->tp.span_id));
     tp_p->tp.flags = 1;
+    // scratch is per-CPU: without this we inherit an older request's ts
+    tp_p->tp.ts = bpf_ktime_get_ns();
     tp_p->valid = 1;
     tp_p->pid = t_ctx->p_conn.pid;
     tp_p->req_type = EVENT_HTTP_CLIENT;
@@ -602,6 +604,8 @@ static __always_inline void bpf_sock_ops_parse_hdr_cb(struct bpf_sock_ops *skops
 
     tp_info_pid_t tp = {};
     tp.valid = 1;
+    // lets the server side reject a handover the connection has sat on
+    tp.tp.ts = bpf_ktime_get_ns();
 
     __builtin_memcpy(tp.tp.trace_id, opt.trace_id, sizeof(tp.tp.trace_id));
     __builtin_memcpy(tp.tp.span_id, opt.span_id, sizeof(tp.tp.span_id));
@@ -1114,6 +1118,13 @@ int obi_packet_extender(struct sk_msg_md *msg) {
 
     // skip H2 here — it uses HPACK for per-stream traceparents
     tp_info_pid_t *tp_pid = get_tp_info_pid(&e_key);
+    if (tp_pid && !tp_within_transaction(&tp_pid->tp, bpf_ktime_get_ns())) {
+        // a recycled port pair must not inherit the previous connection's trace
+        bpf_dbg_printk("stale tp for this connection, dropping");
+        clear_tp_info_pid(&e_key);
+        tp_pid = NULL;
+    }
+
     if (tp_pid && !is_h2_socket(msg) &&
         handle_existing_tp_pid(msg, id, &t_ctx->p_conn, &e_key, tp_pid)) {
         return SK_PASS;
@@ -1184,28 +1195,46 @@ int obi_packet_extender_write_msg_tp(struct sk_msg_md *msg) {
     return SK_PASS;
 }
 
-// Stitches the parsed wire tp into the in-process trace context. Returns true
-// when a proxy was just forwarding our own header — caller must overwrite the
-// span_id on the wire to keep the child distinct from the parent
-static __always_inline bool apply_parent_tp(const tailcall_ctx *t_ctx, tp_info_t *tp) {
+enum wire_tp_kind {
+    // header carries a trace the in-process context knows nothing about
+    k_wire_tp_foreign = 0,
+    // header belongs to the in-process trace; parent assigned
+    k_wire_tp_known = 1,
+    // a proxy was just forwarding our own header — caller must overwrite the
+    // span_id on the wire to keep the child distinct from the parent
+    k_wire_tp_forwarded = 2,
+};
+
+// Stitches the parsed wire tp into the in-process trace context
+static __always_inline enum wire_tp_kind apply_parent_tp(const tailcall_ctx *t_ctx, tp_info_t *tp) {
     if (!t_ctx->has_parent_tp ||
         bpf_memcmp(tp->trace_id, t_ctx->parent_tp.trace_id, TRACE_ID_SIZE_BYTES) != 0) {
-        return false;
+        return k_wire_tp_foreign;
     }
     bpf_memcpy(tp->parent_id, t_ctx->parent_tp.span_id, SPAN_ID_SIZE_BYTES);
     if (bpf_memcmp(tp->span_id, t_ctx->parent_tp.parent_id, SPAN_ID_SIZE_BYTES) != 0) {
-        return false;
+        return k_wire_tp_known;
     }
     urand_bytes(tp->span_id, SPAN_ID_SIZE_BYTES);
-    return true;
+    return k_wire_tp_forwarded;
 }
 
-static __always_inline void
+// false: wire trace unverifiable, caller must build its own
+static __always_inline bool
 assign_parent_tp(const tailcall_ctx *t_ctx, tp_info_t *tp, unsigned char *span_id) {
-    if (apply_parent_tp(t_ctx, tp)) {
+    switch (apply_parent_tp(t_ctx, tp)) {
+    case k_wire_tp_forwarded:
         bpf_dbg_printk("detected forwarded TP header, overriding span id");
         encode_hex(span_id, tp->span_id, SPAN_ID_SIZE_BYTES);
+        return true;
+    case k_wire_tp_known:
+        return true;
+    case k_wire_tp_foreign:
+        bpf_dbg_printk("foreign TP header, keeping our own trace");
+        return false;
     }
+
+    return false;
 }
 
 //k_tail_find_existing_tp
@@ -1287,7 +1316,11 @@ int obi_packet_extender_find_existing_tp(struct sk_msg_md *msg) {
             // 'Traceparent: ...' header that we can utilise
 
             bpf_memset(tp_p->tp.parent_id, 0, sizeof(tp_p->tp.parent_id));
-            assign_parent_tp(t_ctx, &tp_p->tp, span_id);
+            const bool adopted = assign_parent_tp(t_ctx, &tp_p->tp, span_id);
+
+            if (!adopted && !create_trace_info(t_ctx, tp_p)) {
+                return SK_PASS;
+            }
 
             tp_p->tp.ts = bpf_ktime_get_ns();
             tp_p->tp.flags = 1;
@@ -1300,7 +1333,8 @@ int obi_packet_extender_find_existing_tp(struct sk_msg_md *msg) {
 
             set_tp_info_pid(&t_ctx->e_key, tp_p);
 
-            if (inject_flags & k_inject_tcp_options) {
+            // ours differs from the wire: an option would split the app's trace
+            if (adopted && (inject_flags & k_inject_tcp_options)) {
                 schedule_write_tcp_option(msg, tp_p);
             }
 
@@ -1473,7 +1507,8 @@ int obi_packet_extender_detect_h2(struct sk_msg_md *msg) {
             t_ctx->opener = facts.opener;
 
             tp_info_pid_t *go_tp = get_tp_info_pid(&t_ctx->e_key);
-            if (go_tp && go_tp->valid && go_tp->written) {
+            if (go_tp && go_tp->valid && go_tp->written &&
+                tp_within_transaction(&go_tp->tp, bpf_ktime_get_ns())) {
                 h2_resume_after(msg, t_ctx, pos + k_h2_frame_header_len + f.payload_len);
                 return SK_PASS;
             }
@@ -1686,7 +1721,8 @@ int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg) {
         init_tp_ctx_parent_tp(t_ctx);
         bpf_memset(tp_p->tp.parent_id, 0, sizeof(tp_p->tp.parent_id));
         const u32 span_id_offset = hpack_start + target + off;
-        if (apply_parent_tp(t_ctx, &tp_p->tp)) {
+        switch (apply_parent_tp(t_ctx, &tp_p->tp)) {
+        case k_wire_tp_forwarded:
             if (bpf_msg_pull_data(msg, span_id_offset, span_id_offset + SPAN_ID_CHAR_LEN, 0) == 0) {
                 unsigned char *d = msg->data;
                 const unsigned char *e = msg->data_end;
@@ -1694,6 +1730,14 @@ int obi_packet_extender_validate_h2_tp(struct sk_msg_md *msg) {
                     encode_hex(d, tp_p->tp.span_id, SPAN_ID_SIZE_BYTES);
                 }
             }
+            break;
+        case k_wire_tp_foreign:
+            if (!create_trace_info(t_ctx, tp_p)) {
+                return SK_PASS;
+            }
+            break;
+        case k_wire_tp_known:
+            break;
         }
         tp_p->tp.ts = bpf_ktime_get_ns();
         tp_p->valid = 1;
@@ -1739,7 +1783,8 @@ int obi_packet_extender_create_h2_tp(struct sk_msg_md *msg) {
     bpf_memset(tp_p, 0, sizeof(*tp_p));
 
     tp_info_pid_t *existing = get_tp_info_pid(&t_ctx->e_key);
-    const bool have_existing = existing && existing->valid && valid_trace(existing->tp.trace_id);
+    const bool have_existing = existing && existing->valid && valid_trace(existing->tp.trace_id) &&
+                               tp_within_transaction(&existing->tp, bpf_ktime_get_ns());
 
     h2_inject_facts_t facts = {0};
     facts.opener = t_ctx->opener;

--- a/devdocs/context-propagation.md
+++ b/devdocs/context-propagation.md
@@ -11,6 +11,7 @@ This document explains how OpenTelemetry context propagation works in the eBPF i
     - [Scenario A: Go HTTP or SSL/TLS (uprobes involved)](#scenario-a-go-http-or-ssltls-uprobes-involved)
     - [Scenario B: Plain HTTP (no uprobes, kprobes only)](#scenario-b-plain-http-no-uprobes-kprobes-only)
     - [Scenario C: Non-HTTP TCP (no uprobes, socket not in sockmap)](#scenario-c-non-http-tcp-no-uprobes-socket-not-in-sockmap)
+  - [Pre-existing Traceparent Handling](#pre-existing-traceparent-handling)
   - [Mutual Exclusion Mechanism](#mutual-exclusion-mechanism)
     - [Case 1: Traffic in sockmap with Go/SSL uprobes](#case-1-traffic-in-sockmap-with-gossl-uprobes)
     - [Case 2: Traffic in sockmap without uprobes (plain HTTP via kprobes)](#case-2-traffic-in-sockmap-without-uprobes-plain-http-via-kprobes)
@@ -93,6 +94,76 @@ The order in which BPF programs execute varies depending on whether Go uprobes o
    - Sets `valid=1, written=0`
 
 Note: tpinjector does not run for this traffic because the socket was not in `sock_dir`. The `iter/tcp` iterator pre-populates `sock_dir` at startup for existing connections; new connections are added via `BPF_SOCK_OPS`.
+
+### Pre-existing Traceparent Handling
+
+When the extender (`sk_msg`) or the kprobe parser finds a `traceparent` already
+present in an outgoing request, `apply_parent_tp` (`bpf/tpinjector/tpinjector.c`)
+classifies it against the in-process trace context:
+
+```text
+wire header trace == in-process trace?
+│
+├─ no  → FOREIGN: a context the application injected itself, or one that a
+│        metrics scraper or proxy sidecar reuses across many requests.
+│        Not adopted: the span keeps the in-process trace and parent, and the
+│        wire is left untouched so the callee still follows the app's header.
+│
+├─ yes, wire span ≠ our parent's parent → KNOWN: a normal downstream hop
+│        inside a trace OBI adopted earlier.
+│        parent ← in-process server span. The wire is left untouched.
+│
+└─ yes, wire span == our parent's parent → FORWARDED: a proxy re-sent our
+         own header. span ← fresh and rewritten on the wire, so the child
+         stays distinct from its parent.
+```
+
+On egress the in-process context always wins. A wire header we cannot tie to a
+request we observed tells us nothing we can verify: the span id in it may be the
+app's own span, or — behind a header-copying proxy such as an Istio sidecar or an
+nginx without OTel instrumentation — the *caller's* span, which is not our parent
+at all. Both look identical from BPF, so neither clearing the parent nor adopting
+the wire span is safe:
+
+- clearing it exports one parentless client span per request into the app's
+  trace, and a scraper reusing one context turns that into thousands of roots;
+- adopting it parents our egress to whatever the header names, which for a
+  copying proxy puts our ingress and egress spans side by side under the caller
+  instead of in a chain, and merges every request that reuses the header into one
+  unbounded trace.
+
+Keeping our own context costs the link to the app's trace — the callee still
+joins it, so the chain has a gap rather than a wrong shape. A missing edge is
+recoverable; a fabricated one is not. When the hop *is* observable in-process,
+KNOWN and FORWARDED cover it and the full chain is preserved.
+
+Backing this up: **adopted contexts expire**. A `tp` cached in a map is only
+evicted under LRU pressure, so any read of one is gated on
+`tp_within_transaction()`, and every writer stamps `ts`. Without this a single
+stale entry keeps adopting new requests for as long as it is hit, which is how one
+trace grew to span nearly a day.
+
+Readers also check `pid` wherever they have one, which keeps one process from
+adopting another's context.
+
+### Known limitation: egress key collisions
+
+`egress_key_t` is `{s_port, d_port, stream_id}`, and the maps keyed by it
+(`outgoing_trace_map`, `msg_buffers`) are shared by every process on the node. Two
+connections in different network namespaces can therefore hold the same key at the
+same time, and nothing in the key distinguishes them.
+
+Reads are validated as far as the available information allows — `pid` plus
+`tp_within_transaction()` — which covers every kprobe and uprobe reader, since a
+colliding peer is a different process. The gap is the `sk_msg` readers: those run
+without a trustworthy current pid (deferred sends are not in the sending task's
+context, which is why `tpinjector.c` compares no pids), so a collision there can
+still be adopted or can evict the rightful owner's entry.
+
+Closing it needs the connection identity stored somewhere — the key or the value —
+since ports alone do not identify a connection. Per-socket storage
+(`bpf_sk_storage`) would be the natural fit but is unavailable to the Go uprobe
+writers, which hold no `struct sock *`.
 
 ### Mutual Exclusion Mechanism
 

--- a/internal/test/integration/components/tpclient/service.js
+++ b/internal/test/integration/components/tpclient/service.js
@@ -22,6 +22,12 @@ const STATIC_TRACEPARENT = '00-12345678901234567890123456789012-0000000000000001
 // This traceparent is forwarded unchanged through the chain to trigger eBPF proxy detection
 const FORWARDED_TRACEPARENT = '00-12345678901234567890123456789012-1111111111111111-01';
 
+// Scraper-style traceparent: reused unchanged across MANY independent client
+// calls, like a metrics scraper or a proxy sidecar reusing one context
+const SCRAPER_TRACEPARENT = '00-abcdefabcdefabcdefabcdefabcdef12-2222222222222222-01';
+const http = require('http');
+const keepAliveAgent = new http.Agent({ keepAlive: true });
+
 // Endpoint: Request WITHOUT traceparent (eBPF should generate)
 app.get('/no-tp', async (req, res) => {
   if (upstream) {
@@ -71,6 +77,35 @@ app.get('/with-tp', async (req, res) => {
   } else {
     res.send(`End of chain (${route})`);
   }
+});
+
+// Endpoint: scraper burst — N sequential client calls over one keep-alive
+// connection, every one carrying the SAME traceparent. None of the resulting
+// client spans may become a root of that trace.
+app.get('/scrape-burst', async (req, res) => {
+  const n = parseInt(req.query.n || '15', 10);
+  if (!upstream) {
+    res.send(`End of chain (${route})`);
+    return;
+  }
+  try {
+    for (let i = 0; i < n; i++) {
+      await axios.get(`${upstream}/scraped`, {
+        headers: { 'traceparent': SCRAPER_TRACEPARENT },
+        httpAgent: keepAliveAgent,
+      });
+    }
+    console.log(`[${route}/scrape-burst] completed ${n} scrapes`);
+    res.send(`${route}/scrape-burst completed ${n}`);
+  } catch (err) {
+    console.error(`[${route}/scrape-burst] Error:`, err.message);
+    res.status(500).send(`Error: ${err.message}`);
+  }
+});
+
+// Endpoint: scrape target — terminates without forwarding
+app.get('/scraped', (req, res) => {
+  res.send(`scraped (${route})`);
 });
 
 // Endpoint: Request WITH forwarded traceparent (eBPF should detect proxy and override span ID)

--- a/internal/test/integration/traceparent_extraction_test.go
+++ b/internal/test/integration/traceparent_extraction_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"fmt"
 	"net/http"
 	"path"
 	"testing"
@@ -19,8 +20,14 @@ import (
 )
 
 const (
-	staticTraceID   = "12345678901234567890123456789012" // Easy to spot
-	forwardedSpanID = "1111111111111111"                 // Span ID used in forwarded traceparent
+	staticTraceID = "12345678901234567890123456789012" // Easy to spot
+	staticSpanID  = "0000000000000001"                 // Span ID in the static traceparent
+	// the test client increments the span ID by 0x10 before injecting
+	staticSpanIDSentByA = "0000000000000011"
+	forwardedSpanID     = "1111111111111111"                 // Span ID used in forwarded traceparent
+	scraperTraceID      = "abcdefabcdefabcdefabcdefabcdef12" // Trace reused across every scrape
+	scraperSpanID       = "2222222222222222"                 // Span ID reused across every scrape
+	scrapeBurstLen      = 15
 )
 
 // TestTraceparentExtraction validates that the eBPF tpinjector correctly:
@@ -57,6 +64,7 @@ func TestTraceparentExtraction(t *testing.T) {
 	t.Run("without_traceparent", testWithoutTraceparent)
 	t.Run("with_traceparent", testWithTraceparent)
 	t.Run("with_forwarded_traceparent", testWithForwardedTraceparent)
+	t.Run("scraper_burst_never_joins_reused_trace", testScraperBurstNeverJoinsReusedTrace)
 
 	runWeaverValidation(t)
 
@@ -135,17 +143,31 @@ func testWithTraceparent(t *testing.T) {
 	require.GreaterOrEqual(t, len(trace.Spans), 3,
 		"Should have spans from all services in the chain (a, b, c)")
 
-	serviceAClientSpans := trace.FindByOperationNameServiceAndKind("GET /with-tp", "tpclient-a", "client")
-	require.GreaterOrEqual(t, len(serviceAClientSpans), 1, "should find tpclient-a client span")
-	requireNoChildOfReference(t, serviceAClientSpans[0],
-		"tpclient-a client span should not inherit a parent from the generated server trace")
-
+	// wire left untouched, so the callee still parents to the app's span
 	serviceBServerSpans := trace.FindByOperationNameServiceAndKind("GET /with-tp", "tpclient-b", "server")
 	require.GreaterOrEqual(t, len(serviceBServerSpans), 1, "should find tpclient-b server span")
+	requireChildOfSpanID(t, serviceBServerSpans[0], staticSpanIDSentByA,
+		"tpclient-b server span should parent to the span tpclient-a put on the wire")
+
 	serviceBClientSpans := trace.FindByOperationNameServiceAndKind("GET /with-tp", "tpclient-b", "client")
 	require.GreaterOrEqual(t, len(serviceBClientSpans), 1, "should find tpclient-b client span")
 	requireChildOfReference(t, serviceBClientSpans[0], serviceBServerSpans[0],
 		"tpclient-b client span should keep the matching in-process parent")
+
+	// unverifiable on egress: the client span stays in the inbound trace
+	require.Empty(t, trace.FindByOperationNameServiceAndKind("GET /with-tp", "tpclient-a", "client"),
+		"tpclient-a client span must not join a trace the app injected on egress")
+
+	ownTrace := findTraceExcluding(t, "GET%20%2Fwith-tp", staticTraceID)
+	logTraceShape(t, "tpclient-a own trace", ownTrace)
+
+	serviceAServerSpans := ownTrace.FindByOperationNameServiceAndKind("GET /with-tp", "tpclient-a", "server")
+	require.GreaterOrEqual(t, len(serviceAServerSpans), 1, "should find tpclient-a server span")
+	serviceAClientSpans := ownTrace.FindByOperationNameServiceAndKind("GET /with-tp", "tpclient-a", "client")
+	require.GreaterOrEqual(t, len(serviceAClientSpans), 1, "should find tpclient-a client span")
+
+	requireDescendantOf(t, ownTrace, serviceAClientSpans[0], serviceAServerSpans[0],
+		"tpclient-a client span should stay under its own server span")
 }
 
 // testWithForwardedTraceparent validates that when the SAME Traceparent is forwarded
@@ -196,12 +218,133 @@ func testWithForwardedTraceparent(t *testing.T) {
 		"Should have spans from all services in the chain (a, b, c)")
 }
 
-func requireNoChildOfReference(t *testing.T, span jaeger.Span, msgAndArgs ...any) {
+// a scraper reusing one traceparent must never pull our spans into its trace
+func testScraperBurstNeverJoinsReusedTrace(t *testing.T) {
+	ti.DoHTTPGet(t, fmt.Sprintf("http://localhost:6000/scrape-burst?n=%d", scrapeBurstLen), 200)
+
+	var trace jaeger.Trace
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=tpclient-b&traceID=" + scraperTraceID)
+		require.NoError(ct, err)
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+		require.GreaterOrEqual(ct, len(tq.Data), 1, "should find the scraper trace")
+		trace = tq.Data[0]
+
+		serverSpans := trace.FindByOperationNameServiceAndKind("GET /scraped", "tpclient-b", "server")
+		require.GreaterOrEqual(ct, len(serverSpans), scrapeBurstLen, "every scrape must reach the callee")
+	}, testTimeout, 100*time.Millisecond)
+
+	// the app's own propagation: none of it may be a root we introduced
+	spanIDs := map[string]struct{}{}
+	for _, span := range trace.Spans {
+		require.Equal(t, scraperTraceID, span.TraceID)
+
+		requireChildOfSpanID(t, span, scraperSpanID,
+			"span %q must parent to the reused header span, never become a root of the app's trace",
+			span.OperationName)
+
+		_, dup := spanIDs[span.SpanID]
+		require.False(t, dup, "span IDs within the scraper trace must be unique")
+		spanIDs[span.SpanID] = struct{}{}
+	}
+
+	require.Empty(t, trace.FindByOperationNameServiceAndKind("GET /scraped", "tpclient-a", "client"),
+		"the scraper's own client spans must not join the trace it keeps reusing")
+
+	// every scrape stays under the request that triggered the burst
+	ownTrace := findTraceExcluding(t, "GET%20%2Fscrape-burst", scraperTraceID)
+	burstServerSpans := ownTrace.FindByOperationNameServiceAndKind("GET /scrape-burst", "tpclient-a", "server")
+	require.GreaterOrEqual(t, len(burstServerSpans), 1, "should find the tpclient-a server span for the burst")
+	scrapeClientSpans := ownTrace.FindByOperationNameServiceAndKind("GET /scraped", "tpclient-a", "client")
+	require.GreaterOrEqual(t, len(scrapeClientSpans), scrapeBurstLen, "all scrapes must be captured")
+
+	for _, span := range scrapeClientSpans {
+		requireDescendantOf(t, ownTrace, span, burstServerSpans[0],
+			"each scrape must stay under the request that made it")
+	}
+}
+
+// server spans export "in queue"/"processing" children, so calls hang off "processing"
+func requireDescendantOf(t *testing.T, trace jaeger.Trace, child, ancestor jaeger.Span, msgAndArgs ...any) {
 	t.Helper()
 
-	for _, ref := range span.References {
-		require.NotEqual(t, "CHILD_OF", ref.RefType, msgAndArgs...)
+	current := child
+
+	for range len(trace.Spans) {
+		parent, ok := trace.ParentOf(&current)
+		if !ok {
+			break
+		}
+
+		if parent.SpanID == ancestor.SpanID {
+			return
+		}
+
+		current = parent
 	}
+
+	require.Fail(t, "span does not descend from the expected ancestor", msgAndArgs...)
+}
+
+func logTraceShape(t *testing.T, label string, trace jaeger.Trace) {
+	t.Helper()
+
+	t.Logf("%s: traceID=%s spans=%d", label, trace.TraceID, len(trace.Spans))
+
+	for _, span := range trace.Spans {
+		parent := "<root>"
+		for _, ref := range span.References {
+			if ref.RefType == "CHILD_OF" {
+				parent = ref.SpanID
+			}
+		}
+		kind, _ := jaeger.FindIn(span.Tags, "span.kind")
+		t.Logf("  span=%s parent=%s kind=%v op=%q svc=%s",
+			span.SpanID, parent, kind.Value, span.OperationName,
+			trace.Processes[span.ProcessID].ServiceName)
+	}
+}
+
+// the trace OBI resolved itself, not the one the app injected
+func findTraceExcluding(t *testing.T, operation, excludedTraceID string) jaeger.Trace {
+	t.Helper()
+
+	var found jaeger.Trace
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=tpclient-a&operation=" + operation)
+		require.NoError(ct, err)
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+
+		for _, tr := range tq.Data {
+			if tr.TraceID != excludedTraceID && len(tr.Spans) > 0 {
+				found = tr
+				return
+			}
+		}
+
+		require.Fail(ct, "no trace of OBI's own making found", "operation=%s", operation)
+	}, testTimeout, 100*time.Millisecond)
+
+	return found
+}
+
+func requireChildOfSpanID(t *testing.T, child jaeger.Span, parentSpanID string, msgAndArgs ...any) {
+	t.Helper()
+
+	for _, ref := range child.References {
+		if ref.RefType == "CHILD_OF" {
+			require.Equal(t, parentSpanID, ref.SpanID, msgAndArgs...)
+			return
+		}
+	}
+	require.Fail(t, "no CHILD_OF reference found", msgAndArgs...)
 }
 
 func requireChildOfReference(t *testing.T, child, parent jaeger.Span, msgAndArgs ...any) {


### PR DESCRIPTION
## Summary

When an outgoing request already carries a traceparent that OBI's in-process
context doesn't know (the app injected it itself, an SDK, a metrics scraper,
or a proxy sidecar reusing one context), the client span was emitted with an
empty parent. Every request added one more root span to that trace;
high-volume reusers turned this into thousands of extra roots per trace.
Introduced in #2232.

The client span now adopts the header's span id as its parent, joining the
trace as a child instead of a second root.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
