### PR TITLE
Add kernel-side Aerospike protocol detection

### DIFF
--- a/bpf/common/connection_info.h
+++ b/bpf/common/connection_info.h
@@ -23,6 +23,8 @@ enum protocol_type : u8 {
     k_protocol_type_mqtt = 5,
     k_protocol_type_mssql = 6,
     k_protocol_type_sunrpc = 7,
+    // NOTE: 8 and 9 are reserved for NATS and AMQP (userspace placeholders).
+    k_protocol_type_aerospike = 10,
 };
 
 // Struct to keep information on the connections in flight

--- a/bpf/common/connection_info.h
+++ b/bpf/common/connection_info.h
@@ -12,6 +12,7 @@
 
 #include <logger/bpf_dbg.h>
 
+// Keep these values aligned with consts in pkg/ebpf/common/common.go
 enum protocol_type : u8 {
     // Default value, used when the protocol is not known or will be determined/classified
     // in userspace.
@@ -23,7 +24,8 @@ enum protocol_type : u8 {
     k_protocol_type_mqtt = 5,
     k_protocol_type_mssql = 6,
     k_protocol_type_sunrpc = 7,
-    // NOTE: 8 and 9 are reserved for NATS and AMQP (userspace placeholders).
+    k_protocol_type_nats = 8,
+    k_protocol_type_amqp = 9,
     k_protocol_type_aerospike = 10,
 };
 

--- a/bpf/generictracer/protocol_aerospike.h
+++ b/bpf/generictracer/protocol_aerospike.h
@@ -53,7 +53,7 @@ static __always_inline u8 is_aerospike(connection_info_t *conn_info,
         return 0;
     }
 
-    unsigned char hdr[k_aerospike_proto_header_len + 1];
+    unsigned char hdr[k_aerospike_proto_header_len + 1] = {};
     if (bpf_probe_read(hdr, sizeof(hdr), data) != 0) {
         return 0;
     }

--- a/bpf/generictracer/protocol_aerospike.h
+++ b/bpf/generictracer/protocol_aerospike.h
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/connection_info.h>
+
+#include <generictracer/maps/protocol_cache.h>
+
+#include <logger/bpf_dbg.h>
+
+// Aerospike native client protocol ("proto" version 2).
+//
+// Every message starts with an 8-byte proto header:
+//   version(1) = 2, type(1), size(6, big-endian) = body length
+// Only type-3 AS_MSG data frames produce spans. Their body begins with a fixed
+// 22-byte as_msg header whose first byte is its own size (22), which makes the
+// (version, type, header_sz) triple a strong classification signature for both
+// requests and responses. Parsing happens in userspace:
+// pkg/ebpf/common/aerospike_detect_transform.go.
+
+enum {
+    k_aerospike_proto_header_len = 8,
+    k_aerospike_proto_version = 2,
+    k_aerospike_msg_type_as_msg = 3,
+    k_aerospike_as_msg_header_len = 22,
+    // largest declared proto body we treat as plausibly Aerospike;
+    // matches asMaxBodyLen in the userspace parser
+    k_aerospike_max_body_len = 128 * 1024 * 1024,
+};
+
+static __always_inline u64 aerospike_body_len(const unsigned char *hdr) {
+    return ((u64)hdr[2] << 40) | ((u64)hdr[3] << 32) | ((u64)hdr[4] << 24) | ((u64)hdr[5] << 16) |
+           ((u64)hdr[6] << 8) | (u64)hdr[7];
+}
+
+static __always_inline u8 is_aerospike(connection_info_t *conn_info,
+                                       const unsigned char *data,
+                                       u32 data_len,
+                                       enum protocol_type *protocol_type) {
+    if (*protocol_type == k_protocol_type_aerospike) {
+        return 1;
+    }
+    if (*protocol_type != k_protocol_type_unknown) {
+        return 0;
+    }
+
+    // require the full proto + as_msg headers so the signature check below is meaningful
+    if (data_len < k_aerospike_proto_header_len + k_aerospike_as_msg_header_len) {
+        return 0;
+    }
+
+    unsigned char hdr[k_aerospike_proto_header_len + 1];
+    if (bpf_probe_read(hdr, sizeof(hdr), data) != 0) {
+        return 0;
+    }
+
+    if (hdr[0] != k_aerospike_proto_version || hdr[1] != k_aerospike_msg_type_as_msg ||
+        hdr[8] != k_aerospike_as_msg_header_len) {
+        return 0;
+    }
+
+    const u64 body_len = aerospike_body_len(hdr);
+    if (body_len < k_aerospike_as_msg_header_len || body_len > k_aerospike_max_body_len) {
+        return 0;
+    }
+
+    *protocol_type = k_protocol_type_aerospike;
+    bpf_map_update_elem(&protocol_cache, conn_info, protocol_type, BPF_ANY);
+    return 1;
+}

--- a/bpf/generictracer/protocol_handler.c
+++ b/bpf/generictracer/protocol_handler.c
@@ -10,6 +10,7 @@
 #include <common/protocol_http2_helpers.h>
 #include <common/tc_common.h>
 
+#include <generictracer/protocol_aerospike.h>
 #include <generictracer/protocol_http.h>
 #include <generictracer/protocol_http2.h>
 #include <generictracer/protocol_kafka.h>
@@ -93,6 +94,12 @@ int obi_handle_buf_with_args(void *ctx) {
                                                 args->bytes_len,
                                                 &args->protocol_type)) {
         bpf_dbg_printk("Found SunRPC connection");
+        bpf_tail_call(ctx, &jump_table, k_tail_protocol_tcp);
+    } else if (args->protocols.tcp && is_aerospike(&args->pid_conn.conn,
+                                                   (const unsigned char *)args->u_buf,
+                                                   args->bytes_len,
+                                                   &args->protocol_type)) {
+        bpf_dbg_printk("Found Aerospike connection");
         bpf_tail_call(ctx, &jump_table, k_tail_protocol_tcp);
     } else { // large request tracking and generic TCP
         http_info_t *info = bpf_map_lookup_elem(&ongoing_http, &args->pid_conn);

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -224,6 +224,11 @@ static __always_inline int tcp_send_large_buffer(tcp_req_t *req,
     case k_protocol_type_sunrpc:
         unknown_send_large_buffer(req, pid_conn, u_buf, bytes_len, packet_type, direction, action);
         break;
+    case k_protocol_type_aerospike:
+        // No protocol-specific large buffers yet: keep the generic wire-layer
+        // capture so classification doesn't reduce what userspace sees.
+        unknown_send_large_buffer(req, pid_conn, u_buf, bytes_len, packet_type, direction, action);
+        break;
     case k_protocol_type_unknown:
         unknown_send_large_buffer(req, pid_conn, u_buf, bytes_len, packet_type, direction, action);
         break;

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -229,6 +229,8 @@ static __always_inline int tcp_send_large_buffer(tcp_req_t *req,
         // capture so classification doesn't reduce what userspace sees.
         unknown_send_large_buffer(req, pid_conn, u_buf, bytes_len, packet_type, direction, action);
         break;
+    case k_protocol_type_nats:
+    case k_protocol_type_amqp:
     case k_protocol_type_unknown:
         unknown_send_large_buffer(req, pid_conn, u_buf, bytes_len, packet_type, direction, action);
         break;

--- a/bpf/tests/bpf_aerospike_detection.c
+++ b/bpf/tests/bpf_aerospike_detection.c
@@ -1,0 +1,300 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The following code is copied from bpf/generictracer/protocol_aerospike.h and
+ * adapted to run as a host unit test. The functions under test are:
+ *
+ *   static __always_inline u64 aerospike_body_len(const unsigned char *hdr);
+ *   static __always_inline u8 is_aerospike(connection_info_t *conn_info,
+ *                                          const unsigned char *data,
+ *                                          u32 data_len,
+ *                                          enum protocol_type *protocol_type);
+ *
+ * The BPF-only helpers (bpf_probe_read, bpf_map_update_elem and the
+ * protocol_cache map) are mocked below. The real header cannot be #included
+ * directly on a non-BPF target because its map definitions use SEC(".maps").
+ *
+ * These tests pin down the classification signature: only type-3 AS_MSG frames
+ * with the proto version, the fixed as_msg header size, and a sane body length
+ * may classify a connection, while info/security/compressed frames and split
+ * header-only reads must be left unclassified.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+
+// Mocks for the BPF runtime helpers used by is_aerospike.
+typedef struct connection_info {
+    u32 src_ip;
+    u32 dst_ip;
+    u16 src_port;
+    u16 dst_port;
+} connection_info_t;
+
+enum protocol_type {
+    k_protocol_type_unknown = 0,
+    k_protocol_type_mysql = 1,
+    k_protocol_type_aerospike = 10,
+};
+
+#define BPF_ANY 0
+
+#ifndef __always_inline
+#define __always_inline inline
+#endif
+
+static int bpf_probe_read(void *dst, u32 size, const void *src) {
+    memcpy(dst, src, size);
+    return 0;
+}
+
+// Discard the formatted debug output, mirroring bpf_dbg_printk when BPF debug
+// is disabled.
+#define bpf_dbg_printk(...) ((void)0)
+
+// The protocol_cache map is reduced to a single slot that records the last
+// written protocol so the tests can assert the classification side effect.
+static int protocol_cache;
+static enum protocol_type cached_protocol = k_protocol_type_unknown;
+
+static long bpf_map_update_elem(void *map, const void *key, const void *value, u64 flags) {
+    (void)map;
+    (void)key;
+    (void)flags;
+    cached_protocol = *(const enum protocol_type *)value;
+    return 0;
+}
+
+// Code under test (copied verbatim from protocol_aerospike.h).
+
+enum {
+    k_aerospike_proto_header_len = 8,
+    k_aerospike_proto_version = 2,
+    k_aerospike_msg_type_as_msg = 3,
+    k_aerospike_as_msg_header_len = 22,
+    // largest declared proto body we treat as plausibly Aerospike;
+    // matches asMaxBodyLen in the userspace parser
+    k_aerospike_max_body_len = 128 * 1024 * 1024,
+};
+
+static __always_inline u64 aerospike_body_len(const unsigned char *hdr) {
+    return ((u64)hdr[2] << 40) | ((u64)hdr[3] << 32) | ((u64)hdr[4] << 24) | ((u64)hdr[5] << 16) |
+           ((u64)hdr[6] << 8) | (u64)hdr[7];
+}
+
+static __always_inline u8 is_aerospike(connection_info_t *conn_info,
+                                       const unsigned char *data,
+                                       u32 data_len,
+                                       enum protocol_type *protocol_type) {
+    if (*protocol_type == k_protocol_type_aerospike) {
+        return 1;
+    }
+    if (*protocol_type != k_protocol_type_unknown) {
+        return 0;
+    }
+
+    // require the full proto + as_msg headers so the signature check below is meaningful
+    if (data_len < k_aerospike_proto_header_len + k_aerospike_as_msg_header_len) {
+        return 0;
+    }
+
+    unsigned char hdr[k_aerospike_proto_header_len + 1];
+    if (bpf_probe_read(hdr, sizeof(hdr), data) != 0) {
+        return 0;
+    }
+
+    if (hdr[0] != k_aerospike_proto_version || hdr[1] != k_aerospike_msg_type_as_msg ||
+        hdr[8] != k_aerospike_as_msg_header_len) {
+        return 0;
+    }
+
+    const u64 body_len = aerospike_body_len(hdr);
+    if (body_len < k_aerospike_as_msg_header_len || body_len > k_aerospike_max_body_len) {
+        return 0;
+    }
+
+    *protocol_type = k_protocol_type_aerospike;
+    bpf_map_update_elem(&protocol_cache, conn_info, protocol_type, BPF_ANY);
+    return 1;
+}
+
+// Test harness
+
+static int failures = 0;
+
+static void check(const char *name, u8 expected, u8 actual) {
+    if (expected != actual) {
+        fprintf(stderr, "FAIL: %s\n  expected is_aerospike=%u, got %u\n", name, expected, actual);
+        failures++;
+    } else {
+        printf("ok: %s\n", name);
+    }
+}
+
+static void check_u64(const char *name, u64 expected, u64 actual) {
+    if (expected != actual) {
+        fprintf(stderr,
+                "FAIL: %s\n  expected %llu, got %llu\n",
+                name,
+                (unsigned long long)expected,
+                (unsigned long long)actual);
+        failures++;
+    } else {
+        printf("ok: %s\n", name);
+    }
+}
+
+// Writes an 8-byte proto header (version, type, 48-bit big-endian body length)
+// followed by the first as_msg header byte (header_sz). The rest of the buffer
+// is left as-is; is_aerospike never reads past byte 8.
+static void put_frame(unsigned char *buf, u8 version, u8 type, u64 body_len, u8 header_sz) {
+    buf[0] = version;
+    buf[1] = type;
+    for (int i = 0; i < 6; i++) {
+        buf[2 + i] = (unsigned char)(body_len >> (8 * (5 - i)));
+    }
+    buf[8] = header_sz;
+}
+
+static u8 classify(const unsigned char *data, u32 len) {
+    connection_info_t conn = {0};
+    enum protocol_type pt = k_protocol_type_unknown;
+    cached_protocol = k_protocol_type_unknown;
+    return is_aerospike(&conn, data, len, &pt);
+}
+
+static void test_valid_as_msg_frame(void) {
+    unsigned char buf[64] = {0};
+    put_frame(buf, 2, 3, 56, 22); // 56-byte body: as_msg header + a namespace field
+
+    connection_info_t conn = {0};
+    enum protocol_type pt = k_protocol_type_unknown;
+    cached_protocol = k_protocol_type_unknown;
+
+    check("valid type-3 AS_MSG frame", 1, is_aerospike(&conn, buf, sizeof(buf), &pt));
+    check("classification sets protocol_type", k_protocol_type_aerospike, (u8)pt);
+    check("classification updates protocol_cache", k_protocol_type_aerospike, (u8)cached_protocol);
+}
+
+static void test_minimum_length_frame(void) {
+    unsigned char buf[30] = {0}; // exactly proto header + as_msg header
+    put_frame(buf, 2, 3, 22, 22);
+    check("30-byte frame (headers only)", 1, classify(buf, sizeof(buf)));
+}
+
+static void test_already_classified_aerospike(void) {
+    // Garbage bytes: an already classified connection short-circuits before parsing.
+    unsigned char buf[8] = {0xde, 0xad, 0xbe, 0xef, 0, 0, 0, 0};
+    connection_info_t conn = {0};
+    enum protocol_type pt = k_protocol_type_aerospike;
+    check(
+        "already classified aerospike, any buffer", 1, is_aerospike(&conn, buf, sizeof(buf), &pt));
+}
+
+static void test_classified_as_other_protocol(void) {
+    unsigned char buf[64] = {0};
+    put_frame(buf, 2, 3, 56, 22); // valid aerospike bytes
+
+    connection_info_t conn = {0};
+    enum protocol_type pt = k_protocol_type_mysql;
+    check(
+        "connection classified as another protocol", 0, is_aerospike(&conn, buf, sizeof(buf), &pt));
+}
+
+static void test_info_frame_rejected(void) {
+    // Type-1 info (tend) frame as captured on the wire: "node\t..." ASCII body.
+    unsigned char buf[71] = {0};
+    put_frame(buf, 2, 1, 63, 'n'); // byte 8 is the first body byte 'n' of "node"
+    memcpy(buf + 9, "ode\tBB9146B478C3844\n", 20);
+    check("type-1 info (tend) frame", 0, classify(buf, sizeof(buf)));
+}
+
+static void test_security_frame_rejected(void) {
+    unsigned char buf[64] = {0};
+    put_frame(buf, 2, 2, 56, 22);
+    check("type-2 security frame", 0, classify(buf, sizeof(buf)));
+}
+
+static void test_compressed_frame_rejected(void) {
+    unsigned char buf[64] = {0};
+    put_frame(buf, 2, 4, 56, 22);
+    check("type-4 compressed frame", 0, classify(buf, sizeof(buf)));
+}
+
+static void test_wrong_version_rejected(void) {
+    unsigned char buf[64] = {0};
+    put_frame(buf, 3, 3, 56, 22);
+    check("proto version other than 2", 0, classify(buf, sizeof(buf)));
+}
+
+static void test_wrong_as_msg_header_size_rejected(void) {
+    unsigned char buf[64] = {0};
+    put_frame(buf, 2, 3, 56, 30);
+    check("as_msg header_sz other than 22", 0, classify(buf, sizeof(buf)));
+}
+
+static void test_body_shorter_than_as_msg_header_rejected(void) {
+    unsigned char buf[64] = {0};
+    put_frame(buf, 2, 3, 8, 22); // declared body cannot hold the 22-byte as_msg header
+    check("declared body shorter than as_msg header", 0, classify(buf, sizeof(buf)));
+}
+
+static void test_body_over_max_rejected(void) {
+    unsigned char buf[64] = {0};
+    put_frame(buf, 2, 3, (u64)k_aerospike_max_body_len + 1, 22);
+    check("declared body over 128MB cap", 0, classify(buf, sizeof(buf)));
+}
+
+static void test_split_header_only_read_rejected(void) {
+    // A client reading the 8-byte proto header separately (split read) must not
+    // be classified from the header alone.
+    unsigned char buf[9] = {0}; // room for put_frame's header_sz byte; only 8 bytes are passed
+    put_frame(buf, 2, 3, 56, 22);
+    check("8-byte header-only read", 0, classify(buf, 8));
+}
+
+static void test_one_byte_short_of_minimum_rejected(void) {
+    unsigned char buf[29] = {0};
+    put_frame(buf, 2, 3, 22, 22);
+    check("29-byte frame (one short of headers)", 0, classify(buf, sizeof(buf)));
+}
+
+static void test_body_len_decoding(void) {
+    unsigned char buf[9] = {0};
+    put_frame(buf, 2, 3, 0x0000AABBCCDDEEFF & 0xFFFFFFFFFFFF, 22);
+    check_u64("48-bit big-endian body length decoding",
+              0x0000AABBCCDDEEFF & 0xFFFFFFFFFFFF,
+              aerospike_body_len(buf));
+}
+
+int main(void) {
+    test_valid_as_msg_frame();
+    test_minimum_length_frame();
+    test_already_classified_aerospike();
+    test_classified_as_other_protocol();
+    test_info_frame_rejected();
+    test_security_frame_rejected();
+    test_compressed_frame_rejected();
+    test_wrong_version_rejected();
+    test_wrong_as_msg_header_size_rejected();
+    test_body_shorter_than_as_msg_header_rejected();
+    test_body_over_max_rejected();
+    test_split_header_only_read_rejected();
+    test_one_byte_short_of_minimum_rejected();
+    test_body_len_decoding();
+
+    if (failures) {
+        fprintf(stderr, "%d test(s) failed\n", failures);
+        return 1;
+    }
+
+    printf("all aerospike detection tests passed\n");
+    return 0;
+}

--- a/devdocs/protocols/tcp/aerospike.md
+++ b/devdocs/protocols/tcp/aerospike.md
@@ -7,10 +7,11 @@ This document describes the Aerospike protocol parser that OBI provides.
 Aerospike clients talk to the server over a custom binary protocol (the native
 "proto version 2" protocol) on the service port (default **3000**). It is a
 length-prefixed binary protocol — not HTTP, gRPC, or Protocol Buffers despite
-the unfortunate "proto" name. OBI parses this wire format in userspace: the
-request and response payloads of an unclassified TCP connection are handed to
-the Aerospike parser. The protocol is **one-request-one-response per connection
-(FIFO)**, so the generic per-connection direction-flip correlation is exact.
+the unfortunate "proto" name. Connections are classified as Aerospike in kernel
+space (eBPF) from the frame signature; the request and response payloads are
+then parsed in userspace. The protocol is **one-request-one-response per
+connection (FIFO)**, so the generic per-connection direction-flip correlation
+is exact.
 
 ### proto header (8 bytes, every message)
 
@@ -112,10 +113,17 @@ plus, for writes, the per-op type bytes:
 
 ## Protocol Parsing
 
-1. TCP packets arrive at `ReadTCPRequestIntoSpan`
+1. `is_aerospike` in
+   [protocol_aerospike.h](../../../bpf/generictracer/protocol_aerospike.h)
+   classifies the connection in kernel space from the frame signature
+   (proto version 2, type-3 AS_MSG, `header_sz` 22, sane body length) and
+   caches it in `protocol_cache`, so classification runs once per connection.
+2. TCP events arrive at `ReadTCPRequestIntoSpan`
    in [tcp_detect_transform.go](../../../pkg/ebpf/common/tcp_detect_transform.go).
-2. `matchAerospike` (in the heuristic detection stage) recognizes the proto
-   header and parses the request.
+   Kernel-classified events dispatch directly to the Aerospike parser
+   (`dispatchAerospike`); for connections the kernel missed (e.g. OBI attached
+   mid-connection) `matchAerospike` in the heuristic detection stage recognizes
+   the proto header as a fallback.
 3. Parsing logic lives in
    [aerospike_detect_transform.go](../../../pkg/ebpf/common/aerospike_detect_transform.go):
    `parseAerospikeRequest` (op classification + field extraction),
@@ -182,8 +190,9 @@ the decrypted payloads, so the AS_MSG frames are parsed the same as cleartext.
     in the captured buffer, so the `result_code` is read and error status is
     emitted.
 
-  Capturing the body regardless of the client's read pattern would require
-  kernel-side response reassembly (an eBPF change outside this parser's scope).
+  Capturing the body regardless of the client's read pattern requires
+  kernel-side response reassembly, a planned follow-up now that connections are
+  classified as Aerospike in kernel space.
 
 ## Configuration
 

--- a/pkg/ebpf/common/aerospike_detect_transform_test.go
+++ b/pkg/ebpf/common/aerospike_detect_transform_test.go
@@ -169,6 +169,63 @@ func TestMatchAerospikeNonAerospike(t *testing.T) {
 	assert.False(t, matched, "HTTP must not be misclassified as Aerospike")
 }
 
+// TestDispatchAerospikeSpan covers the kernel-classified path: an event the
+// kernel marked as Aerospike goes straight to the parser and yields a span.
+func TestDispatchAerospikeSpan(t *testing.T) {
+	req := largebuf.NewLargeBufferFrom(mustHex(t, fixtureHex(t, "put")))
+	resp := largebuf.NewLargeBufferFrom(mustHex(t, aerospikeWriteOKResp))
+
+	event := &TCPRequestInfo{ProtocolType: ProtocolTypeAerospike}
+	span, ignore, matched, err := dispatchKernelAssignedProtocol(nil, event, req, resp)
+	require.NoError(t, err)
+	require.True(t, matched, "kernel-classified aerospike event must be handled")
+	assert.False(t, ignore)
+	assert.Equal(t, request.EventTypeAerospikeClient, span.Type)
+	assert.Equal(t, "PUT", span.Method)
+	assert.Equal(t, "PUT test.s_put", span.TraceName())
+}
+
+// TestDispatchAerospikeIgnoresNoise ensures non-data frames on a classified
+// connection (info/tend traffic, junk) are consumed as ignored events instead of
+// falling through to the generic protocol detectors.
+func TestDispatchAerospikeIgnoresNoise(t *testing.T) {
+	// A type-1 info (tend) frame: "node\n" request, ASCII response.
+	infoFrame := append([]byte{2, 1, 0, 0, 0, 0, 0, 5}, []byte("node\n")...)
+
+	event := &TCPRequestInfo{ProtocolType: ProtocolTypeAerospike}
+	_, ignore, matched, err := dispatchKernelAssignedProtocol(nil, event,
+		largebuf.NewLargeBufferFrom(infoFrame),
+		largebuf.NewLargeBufferFrom([]byte("node\tBB9146B478C3844\n")))
+	require.NoError(t, err)
+	assert.True(t, matched, "classified-connection noise must not leak to generic detectors")
+	assert.True(t, ignore, "noise frames must not produce a span")
+}
+
+// TestDispatchAerospikeServerSideIgnored mirrors the matchAerospike server-side
+// guard on the kernel-classified path.
+func TestDispatchAerospikeServerSideIgnored(t *testing.T) {
+	req := largebuf.NewLargeBufferFrom(mustHex(t, fixtureHex(t, "put")))
+	resp := largebuf.NewLargeBufferFrom(mustHex(t, aerospikeWriteOKResp))
+
+	event := &TCPRequestInfo{ProtocolType: ProtocolTypeAerospike, IsServer: true}
+	_, ignore, matched, err := dispatchKernelAssignedProtocol(nil, event, req, resp)
+	require.NoError(t, err)
+	assert.True(t, matched)
+	assert.True(t, ignore, "server-side exchange must not produce a client span")
+}
+
+// TestDispatchAerospikeUnknownFallsThrough ensures unclassified events are left
+// for the generic/heuristic detection stages.
+func TestDispatchAerospikeUnknownFallsThrough(t *testing.T) {
+	req := largebuf.NewLargeBufferFrom(mustHex(t, fixtureHex(t, "put")))
+	resp := largebuf.NewLargeBufferFrom(mustHex(t, aerospikeWriteOKResp))
+
+	event := &TCPRequestInfo{ProtocolType: ProtocolTypeUnknown}
+	_, _, matched, err := dispatchKernelAssignedProtocol(nil, event, req, resp)
+	require.NoError(t, err)
+	assert.False(t, matched, "unknown protocol must fall through to the detection stages")
+}
+
 // TestMatchAerospikeServerSideSkipped ensures a valid Aerospike exchange observed
 // from the server process (IsServer) does not produce a span, so an operation
 // instrumented on both peers is reported only once (client-side).

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -102,6 +102,7 @@ const (
 	ProtocolTypeSunRPC
 	ProtocolTypeNATS // placeholder for future kernel-space detection
 	ProtocolTypeAMQP // placeholder for future kernel-space detection
+	ProtocolTypeAerospike
 )
 
 const (

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -91,6 +91,7 @@ const (
 )
 
 // Kernel-side classification
+// Keep these values aligned with protocol_type in bpf/common/connection_info.h
 const (
 	ProtocolTypeUnknown uint8 = iota
 	ProtocolTypeMySQL

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -95,6 +95,8 @@ func dispatchKernelAssignedProtocol(parseCtx *EBPFParseContext, event *TCPReques
 		return dispatchMSSQL(parseCtx, event, requestBuffer, responseBuffer)
 	case ProtocolTypeSunRPC:
 		return dispatchSunRPC(event, requestBuffer, responseBuffer)
+	case ProtocolTypeAerospike:
+		return dispatchAerospike(event, requestBuffer, responseBuffer)
 	}
 
 	return request.Span{}, false, false, nil
@@ -378,6 +380,14 @@ func detectHeuristicProtocol(parseCtx *EBPFParseContext, event *TCPRequestInfo, 
 	}
 
 	return request.Span{}, false, false, nil
+}
+
+func dispatchAerospike(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) {
+	span, ignore, matched, err := matchAerospike(event, requestBuffer, responseBuffer)
+	if !matched {
+		return request.Span{}, true, true, nil
+	}
+	return span, ignore, matched, err
 }
 
 // matchAerospike detects the Aerospike native client protocol (proto v2) from the

--- a/pkg/ebpf/common/tcp_large_buffer_test.go
+++ b/pkg/ebpf/common/tcp_large_buffer_test.go
@@ -29,6 +29,8 @@ func TestProtocolToLargeBufferKind(t *testing.T) {
 		{ProtocolTypeHTTP, KindLayerApp},
 		{ProtocolTypeMQTT, KindLayerWire},
 		{ProtocolTypeUnknown, KindLayerWire},
+		{ProtocolTypeSunRPC, KindLayerWire},
+		{ProtocolTypeAerospike, KindLayerWire},
 	}
 	for _, tt := range tests {
 		require.Equal(t, tt.expected, protocolToLargeBufferKind(tt.protocolType))


### PR DESCRIPTION
## Summary

This PR adds the kernel-side for Aerospike and it continues the work done in #2545 

The kernel-classified events dispatch directly to the existing Aerospike parser and the userspace heuristic stays as a fallback for connections attached mid-flight, mirroring the Kafka setup.

Notes: 
- Classified connections keep the generic wire-layer large buffers, so captured data is unchanged and protocol-specific response reassembly (fixing the split-read status limitation) is the planned follow-up.
- Two known trade-offs, both shared with the other kernel-classified protocols: request-only events are no longer flushed on connection close (an operation whose response is never captured no longer produces a span), and a classification sticks for the connection's cache lifetime so a misclassified connection would have its events ignored rather than re-detected.

Limitations/Follow-ups
- Split-read responses (the Java client reads the 8-byte proto header separately from the body) still miss `result_code`: kernel-side response reassembly is the next PR, building on the dispatch hook this PR adds.
- Type-4 compressed frames classify the connection but their bodies remain unparsed (unchanged).

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
