### PR TITLE
Fix `perapp.MetricsConfig` references missed by rename

### DIFF
--- a/pkg/export/feature_test.go
+++ b/pkg/export/feature_test.go
@@ -104,7 +104,7 @@ func TestLoadFeaturesRejectsUnknownNames(t *testing.T) {
 }
 
 // An unset OTEL_EBPF_METRICS_FEATURES resolves to an empty envDefault string
-// (perapp.MetricsConfig), so UnmarshalText("") runs on every default
+// (perapp.GlobalMetricsConfig), so UnmarshalText("") runs on every default
 // deployment and must keep yielding Undefined rather than an error.
 func TestFeatureUnmarshalTextEmpty(t *testing.T) {
 	var features Features

--- a/pkg/export/prom/prom_bpf_linux_test.go
+++ b/pkg/export/prom/prom_bpf_linux_test.go
@@ -40,7 +40,7 @@ func TestBPFStatsRuntimeClosesWithCollector(t *testing.T) {
 	collector := newCollector(
 		&global.ContextInfo{},
 		&PrometheusConfig{},
-		&perapp.MetricsConfig{},
+		&perapp.GlobalMetricsConfig{},
 		false,
 	)
 	collector.getProbeMetrics()
@@ -69,7 +69,7 @@ func TestBPFStatsRuntimeEnableErrorDoesNotBreakCollectorClose(t *testing.T) {
 	collector := newCollector(
 		&global.ContextInfo{},
 		&PrometheusConfig{},
-		&perapp.MetricsConfig{},
+		&perapp.GlobalMetricsConfig{},
 		false,
 	)
 	collector.getProbeMetrics()
@@ -103,7 +103,7 @@ func TestBPFStatsRuntimeClosesWhenInstanceEndsBeforeCollectorStarts(t *testing.T
 	_, err := BPFMetrics(
 		&global.ContextInfo{Metrics: internalMetrics},
 		&PrometheusConfig{},
-		&perapp.MetricsConfig{},
+		&perapp.GlobalMetricsConfig{},
 	)(ctx)
 	require.NoError(t, err)
 	require.Equal(t, int32(1), enableCalls.Load())

--- a/pkg/export/prom/prom_bpf_privileged_test.go
+++ b/pkg/export/prom/prom_bpf_privileged_test.go
@@ -95,7 +95,7 @@ func TestCollectorShutdownClearsState(t *testing.T) {
 	collector := newInternalBPFCollector(
 		&global.ContextInfo{Metrics: internalMetrics},
 		&PrometheusConfig{},
-		&perapp.MetricsConfig{},
+		&perapp.GlobalMetricsConfig{},
 	)
 	program := loadTestPrograms(t, 1, ebpf.SocketFilter)[0]
 	id := programID(t, program)
@@ -196,7 +196,7 @@ func newPrivilegedTestCollector(tb testing.TB) *BPFCollector {
 	collector := newCollector(
 		&global.ContextInfo{},
 		&PrometheusConfig{},
-		&perapp.MetricsConfig{},
+		&perapp.GlobalMetricsConfig{},
 		false,
 	)
 	tb.Cleanup(collector.close)

--- a/pkg/export/prom/prom_bpf_test.go
+++ b/pkg/export/prom/prom_bpf_test.go
@@ -382,7 +382,7 @@ func TestBPFCollectorDoesNotCollectAfterContextCleanup(t *testing.T) {
 	collector := newCollector(
 		&global.ContextInfo{},
 		&PrometheusConfig{},
-		&perapp.MetricsConfig{},
+		&perapp.GlobalMetricsConfig{},
 		false,
 	)
 	collector.progs[ebpf.ProgramID(1)] = &BPFProgram{}

--- a/pkg/export/prom/prom_runtime_histograms_test.go
+++ b/pkg/export/prom/prom_runtime_histograms_test.go
@@ -577,7 +577,7 @@ func newGoRuntimeHistogramTestReporter(t *testing.T) (*metricsReporter, *prometh
 		t.Context(),
 		&global.ContextInfo{Prometheus: &connector.PrometheusManager{}},
 		&PrometheusConfig{Registry: registry, TTL: time.Minute},
-		&perapp.MetricsConfig{Features: export.FeatureApplicationRuntime},
+		&perapp.GlobalMetricsConfig{Features: export.FeatureApplicationRuntime},
 		&attributes.SelectorConfig{SelectionCfg: attributes.Selection{
 			attributes.Resource.Section: attributes.InclusionLists{
 				Include: []string{"service.name", "service.namespace"},


### PR DESCRIPTION
## Summary

This PR fixes failing tests I found in #2982 (but it affects every PR).

PR #2899 renamed `perapp.MetricsConfig` to `GlobalMetricsConfig` but missed five test references, breaking compilation of the prom and export test packages.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
