### PR TITLE
Fail schema generation on duplicate config type names

### DIFF
--- a/cmd/obi-schema/main.go
+++ b/cmd/obi-schema/main.go
@@ -399,6 +399,8 @@ func main() {
 
 	schema := reflector.Reflect(&obi.Config{})
 
+	inlineTypeSchemas := g.buildInlineTypeSchemas(reflect.TypeFor[obi.Config]())
+
 	// A collision makes every later step operate on a schema that already
 	// merged two unrelated types, so stop before post-processing it.
 	if err := g.checkTypeNameCollisions(); err != nil {
@@ -410,7 +412,7 @@ func main() {
 	schema.Description = "JSON Schema for OpenTelemetry eBPF Instrumentation (OBI) configuration"
 
 	// Process inline fields first (merge properties from inline types)
-	g.processInlineFields(schema)
+	g.processInlineFields(schema, inlineTypeSchemas)
 
 	// Process deprecated annotations from comments
 	processDeprecated(schema)
@@ -465,7 +467,9 @@ type jsonSchemaer interface {
 
 // buildInlineTypeSchemas uses reflection to find inline fields that implement JSONSchema().
 // It walks the type hierarchy starting from rootType and returns a map of type name to schema function.
-func buildInlineTypeSchemas(rootType reflect.Type) map[string]func() *jsonschema.Schema {
+// Walking also records the package of every named inline field type, which is
+// what makes those types visible to checkTypeNameCollisions.
+func (g *SchemaGenerator) buildInlineTypeSchemas(rootType reflect.Type) map[string]func() *jsonschema.Schema {
 	result := make(map[string]func() *jsonschema.Schema)
 	visited := make(map[reflect.Type]bool)
 
@@ -510,6 +514,9 @@ func buildInlineTypeSchemas(rootType reflect.Type) map[string]func() *jsonschema
 				for fieldType.Kind() == reflect.Pointer {
 					fieldType = fieldType.Elem()
 				}
+
+				// The reflector never names inline types, so the collision check only sees them from here.
+				g.recordTypeName(fieldType)
 
 				// Check if it implements JSONSchema()
 				if hasJSONSchemaMethod(fieldType) {
@@ -566,13 +573,10 @@ func callJSONSchemaMethod(t reflect.Type) *jsonschema.Schema {
 }
 
 // processInlineFields merges properties from inline field types into their parent schemas.
-func (g *SchemaGenerator) processInlineFields(schema *jsonschema.Schema) {
+func (g *SchemaGenerator) processInlineFields(schema *jsonschema.Schema, inlineTypeSchemas map[string]func() *jsonschema.Schema) {
 	if schema == nil {
 		return
 	}
-
-	// Build inline type schemas dynamically using reflection
-	inlineTypeSchemas := buildInlineTypeSchemas(reflect.TypeFor[obi.Config]())
 
 	// Process each definition that has inline fields
 	for typeName, inlineTypes := range g.inlineFields {

--- a/cmd/obi-schema/main.go
+++ b/cmd/obi-schema/main.go
@@ -465,6 +465,26 @@ type jsonSchemaer interface {
 	JSONSchema() *jsonschema.Schema
 }
 
+// reflectsField reports whether the schema reflector would follow f. It mirrors
+// the eligibility rules the library applies in reflectFieldName, so that walking
+// the type graph here does not reach types the schema can never contain.
+func reflectsField(f reflect.StructField) bool {
+	for _, key := range []string{"yaml", "jsonschema"} {
+		if strings.Split(f.Tag.Get(key), ",")[0] == "-" {
+			return false
+		}
+	}
+
+	// An unexported field is only followed when it is embedded.
+	return f.Anonymous || f.PkgPath == ""
+}
+
+// isInlineField reports whether f carries the yaml inline option.
+func isInlineField(f reflect.StructField) bool {
+	options := strings.Split(f.Tag.Get("yaml"), ",")
+	return slices.Contains(options[1:], "inline")
+}
+
 // buildInlineTypeSchemas uses reflection to find inline fields that implement JSONSchema().
 // It walks the type hierarchy starting from rootType and returns a map of type name to schema function.
 // Walking also records the package of every named inline field type, which is
@@ -505,10 +525,11 @@ func (g *SchemaGenerator) buildInlineTypeSchemas(rootType reflect.Type) map[stri
 
 		for i := 0; i < t.NumField(); i++ {
 			field := t.Field(i)
-			yamlTag := field.Tag.Get("yaml")
+			if !reflectsField(field) {
+				continue
+			}
 
-			// Check if this is an inline field
-			if strings.Contains(yamlTag, "inline") {
+			if isInlineField(field) {
 				fieldType := field.Type
 				// Handle pointer types
 				for fieldType.Kind() == reflect.Pointer {

--- a/cmd/obi-schema/main.go
+++ b/cmd/obi-schema/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -43,17 +44,79 @@ type SchemaGenerator struct {
 	// goFieldNames maps (typeName, propertyKey) to the Go field name,
 	// so we can strip it from descriptions.
 	goFieldNames map[string]map[string]string
+	// reflectedTypeNames maps a type name to the packages declaring a type with
+	// that name, for the types the reflector walks. Unlike the registries above
+	// it is filled during reflection, not by scanning source files.
+	reflectedTypeNames map[string]map[string]bool
 }
 
 // NewSchemaGenerator creates a new SchemaGenerator with initialized registries.
 func NewSchemaGenerator() *SchemaGenerator {
 	return &SchemaGenerator{
-		enums:        make(map[string][]any),
-		envVars:      make(map[string]map[string]string),
-		inlineFields: make(map[string][]string),
-		noYaml:       make(map[string]map[string]bool),
-		goFieldNames: make(map[string]map[string]string),
+		enums:              make(map[string][]any),
+		envVars:            make(map[string]map[string]string),
+		inlineFields:       make(map[string][]string),
+		noYaml:             make(map[string]map[string]bool),
+		goFieldNames:       make(map[string]map[string]string),
+		reflectedTypeNames: make(map[string]map[string]bool),
 	}
+}
+
+// newReflector builds the reflector used to generate the schema.
+func (g *SchemaGenerator) newReflector() *jsonschema.Reflector {
+	return &jsonschema.Reflector{
+		RequiredFromJSONSchemaTags: true,
+		AllowAdditionalProperties:  true,
+		ExpandedStruct:             true,
+		FieldNameTag:               "yaml",
+		Mapper:                     g.customMapper(),
+		Namer:                      g.recordTypeName,
+	}
+}
+
+// recordTypeName records the package that declares t and returns an empty name
+// so the reflector falls back to its default naming. It is installed as the
+// reflector's Namer because that is the single point where every type that
+// needs a definition name passes through.
+func (g *SchemaGenerator) recordTypeName(t reflect.Type) string {
+	name := t.Name()
+	pkgPath := t.PkgPath()
+	if name == "" || pkgPath == "" {
+		return ""
+	}
+
+	if g.reflectedTypeNames[name] == nil {
+		g.reflectedTypeNames[name] = make(map[string]bool)
+	}
+	g.reflectedTypeNames[name][pkgPath] = true
+
+	return ""
+}
+
+// checkTypeNameCollisions reports type names declared by more than one package.
+// Definitions are keyed by the bare type name, so the second type to be walked
+// silently reuses the first one's definition instead of getting its own.
+//
+// This covers the types the reflector walks. Collisions among source-scanned
+// types that the configuration does not reach are not detected here.
+func (g *SchemaGenerator) checkTypeNameCollisions() error {
+	var collisions []string
+	for name, pkgPaths := range g.reflectedTypeNames {
+		if len(pkgPaths) < 2 {
+			continue
+		}
+		collisions = append(collisions,
+			name+"\n    "+strings.Join(slices.Sorted(maps.Keys(pkgPaths)), "\n    "))
+	}
+
+	if len(collisions) == 0 {
+		return nil
+	}
+	sort.Strings(collisions)
+
+	return fmt.Errorf("type name declared in more than one package; "+
+		"rename one type per group so that every configuration type has a unique name:\n  %s",
+		strings.Join(collisions, "\n  "))
 }
 
 // packagesToScan lists packages that contain types used in the config
@@ -329,18 +392,20 @@ func main() {
 	// Scan source files to populate registries
 	g.scanSourceFiles()
 
-	reflector := &jsonschema.Reflector{
-		RequiredFromJSONSchemaTags: true,
-		AllowAdditionalProperties:  true,
-		ExpandedStruct:             true,
-		FieldNameTag:               "yaml",
-		Mapper:                     g.customMapper(),
-	}
+	reflector := g.newReflector()
 	if err := reflector.AddGoComments("go.opentelemetry.io/obi", "./", jsonschema.WithFullComment()); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not add Go comments: %v\n", err)
 	}
 
 	schema := reflector.Reflect(&obi.Config{})
+
+	// A collision makes every later step operate on a schema that already
+	// merged two unrelated types, so stop before post-processing it.
+	if err := g.checkTypeNameCollisions(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
 	schema.Title = "OBI Configuration Schema"
 	schema.Description = "JSON Schema for OpenTelemetry eBPF Instrumentation (OBI) configuration"
 

--- a/cmd/obi-schema/main_test.go
+++ b/cmd/obi-schema/main_test.go
@@ -4,10 +4,12 @@
 package main
 
 import (
+	"archive/tar"
 	"encoding/json"
 	"encoding/xml"
 	"go/parser"
 	"go/token"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
@@ -480,7 +482,7 @@ func TestProcessInlineFields(t *testing.T) {
 	// Add a property to parent that should not be overwritten
 	schema.Definitions["ParentType"].Properties.Set("parent_field", &jsonschema.Schema{Type: "string"})
 
-	g.processInlineFields(schema)
+	g.processInlineFields(schema, nil)
 
 	// Check that inline_field was merged into ParentType
 	parentSchema := schema.Definitions["ParentType"]
@@ -529,7 +531,7 @@ func TestSortSchemaProperties(t *testing.T) {
 
 func TestBuildInlineTypeSchemas(t *testing.T) {
 	t.Run("finds MetadataGlobMap and MetadataRegexMap from obi.Config", func(t *testing.T) {
-		result := buildInlineTypeSchemas(reflect.TypeOf(obi.Config{}))
+		result := NewSchemaGenerator().buildInlineTypeSchemas(reflect.TypeOf(obi.Config{}))
 
 		// Should find MetadataGlobMap
 		schemaFunc, found := result["MetadataGlobMap"]
@@ -554,12 +556,12 @@ func TestBuildInlineTypeSchemas(t *testing.T) {
 		type SimpleStruct struct {
 			Name string `yaml:"name"`
 		}
-		result := buildInlineTypeSchemas(reflect.TypeOf(SimpleStruct{}))
+		result := NewSchemaGenerator().buildInlineTypeSchemas(reflect.TypeOf(SimpleStruct{}))
 		assert.Empty(t, result)
 	})
 
 	t.Run("handles pointer types", func(t *testing.T) {
-		result := buildInlineTypeSchemas(reflect.TypeOf(&obi.Config{}))
+		result := NewSchemaGenerator().buildInlineTypeSchemas(reflect.TypeOf(&obi.Config{}))
 
 		// Should still find inline types
 		_, found := result["MetadataGlobMap"]
@@ -762,16 +764,47 @@ func TestCheckTypeNameCollisions(t *testing.T) {
 	})
 }
 
+// inlineHeaderRoot reproduces the shape that the reflector never names: an
+// inline field whose type is a named map. http.Header is such a map, and
+// tar.Header is an unrelated struct with the same bare name.
+type inlineHeaderRoot struct {
+	Inline http.Header `yaml:",inline"`
+	Other  tar.Header  `yaml:"other"`
+}
+
+// TestInlineTypeNameCollisionIsDetected covers a collision where both types are
+// reachable but only one of them is reflected into a definition. The inline type
+// is selected by bare name in processInlineFields, so the other type taking that
+// name would merge an unrelated schema into the parent.
+func TestInlineTypeNameCollisionIsDetected(t *testing.T) {
+	g := NewSchemaGenerator()
+	schema := g.newReflector().Reflect(&inlineHeaderRoot{})
+
+	// The reflector names the struct but not the inline map, which is why the
+	// inline walk has to record it too.
+	require.Contains(t, schema.Definitions, "Header")
+	require.NotContains(t, g.reflectedTypeNames["Header"], "net/http")
+
+	g.buildInlineTypeSchemas(reflect.TypeFor[inlineHeaderRoot]())
+
+	err := g.checkTypeNameCollisions()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "net/http")
+	assert.Contains(t, err.Error(), "archive/tar")
+}
+
 // TestConfigTypeNamesAreUnique guards the whole configuration graph: the schema
 // keys definitions by bare type name, so two config types sharing a name would
 // silently share one definition.
 func TestConfigTypeNamesAreUnique(t *testing.T) {
 	g := NewSchemaGenerator()
 	g.newReflector().Reflect(&obi.Config{})
+	g.buildInlineTypeSchemas(reflect.TypeFor[obi.Config]())
 
-	// Without this the test would pass vacuously if the reflector ever stopped
-	// recording type names.
+	// Without these the test would pass vacuously if either path ever stopped
+	// recording type names. MetadataGlobMap is only seen by the inline walk.
 	require.Contains(t, g.reflectedTypeNames, "Config")
+	require.Contains(t, g.reflectedTypeNames, "MetadataGlobMap")
 
 	require.NoError(t, g.checkTypeNameCollisions())
 }

--- a/cmd/obi-schema/main_test.go
+++ b/cmd/obi-schema/main_test.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"go/parser"
 	"go/token"
 	"reflect"
@@ -726,4 +728,50 @@ func TestIsZeroDefault(t *testing.T) {
 	assert.False(t, isZeroDefault(int64(0)))
 	assert.False(t, isZeroDefault("hello"))
 	assert.False(t, isZeroDefault([]any{"a"}))
+}
+
+func TestCheckTypeNameCollisions(t *testing.T) {
+	t.Run("no collision", func(t *testing.T) {
+		g := NewSchemaGenerator()
+		g.recordTypeName(reflect.TypeFor[json.Decoder]())
+		g.recordTypeName(reflect.TypeFor[json.Decoder]())
+		g.recordTypeName(reflect.TypeFor[xml.Encoder]())
+
+		require.NoError(t, g.checkTypeNameCollisions())
+	})
+
+	t.Run("same name in two packages", func(t *testing.T) {
+		g := NewSchemaGenerator()
+		g.recordTypeName(reflect.TypeFor[json.Decoder]())
+		g.recordTypeName(reflect.TypeFor[xml.Decoder]())
+
+		err := g.checkTypeNameCollisions()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Decoder")
+		assert.Contains(t, err.Error(), "encoding/json")
+		assert.Contains(t, err.Error(), "encoding/xml")
+	})
+
+	t.Run("types with no name or no package are ignored", func(t *testing.T) {
+		g := NewSchemaGenerator()
+		g.recordTypeName(reflect.TypeFor[struct{ A int }]())
+		g.recordTypeName(reflect.TypeFor[int]())
+
+		require.NoError(t, g.checkTypeNameCollisions())
+		assert.Empty(t, g.reflectedTypeNames)
+	})
+}
+
+// TestConfigTypeNamesAreUnique guards the whole configuration graph: the schema
+// keys definitions by bare type name, so two config types sharing a name would
+// silently share one definition.
+func TestConfigTypeNamesAreUnique(t *testing.T) {
+	g := NewSchemaGenerator()
+	g.newReflector().Reflect(&obi.Config{})
+
+	// Without this the test would pass vacuously if the reflector ever stopped
+	// recording type names.
+	require.Contains(t, g.reflectedTypeNames, "Config")
+
+	require.NoError(t, g.checkTypeNameCollisions())
 }

--- a/cmd/obi-schema/main_test.go
+++ b/cmd/obi-schema/main_test.go
@@ -793,6 +793,48 @@ func TestInlineTypeNameCollisionIsDetected(t *testing.T) {
 	assert.Contains(t, err.Error(), "archive/tar")
 }
 
+// propertyKeys lists the property names of a schema in order.
+func propertyKeys(schema *jsonschema.Schema) []string {
+	var keys []string
+	for pair := schema.Properties.Oldest(); pair != nil; pair = pair.Next() {
+		keys = append(keys, pair.Key)
+	}
+	return keys
+}
+
+// hiddenInlineHeader carries an inline net/http.Header, and is only ever
+// reached through fields the reflector drops.
+type hiddenInlineHeader struct {
+	Header http.Header `yaml:",inline"`
+}
+
+// ignoredInlineRoot reaches hiddenInlineHeader only through fields excluded by
+// tag and an unexported one, while archive/tar.Header is genuinely reflected.
+type ignoredInlineRoot struct {
+	Ignored    hiddenInlineHeader `yaml:"-"`
+	SchemaSkip hiddenInlineHeader `jsonschema:"-"`
+	unexported hiddenInlineHeader //nolint:unused // Present so the walk meets an unexported field.
+	Other      tar.Header         `yaml:"other"`
+}
+
+// TestUnreachableInlineTypeNameDoesNotCollide keeps the inline walk from
+// aborting generation over a name the schema can never contain: only
+// archive/tar.Header reaches the schema here, so there is no collision.
+func TestUnreachableInlineTypeNameDoesNotCollide(t *testing.T) {
+	g := NewSchemaGenerator()
+	schema := g.newReflector().Reflect(&ignoredInlineRoot{})
+	g.buildInlineTypeSchemas(reflect.TypeFor[ignoredInlineRoot]())
+
+	// Pin the behavior reflectsField mirrors: the reflector keeps only the
+	// eligible field, so the inline type behind the dropped ones is unreachable.
+	require.Equal(t, []string{"other"}, propertyKeys(schema))
+
+	require.Contains(t, schema.Definitions, "Header")
+	assert.NotContains(t, g.reflectedTypeNames["Header"], "net/http")
+
+	require.NoError(t, g.checkTypeNameCollisions())
+}
+
 // TestConfigTypeNamesAreUnique guards the whole configuration graph: the schema
 // keys definitions by bare type name, so two config types sharing a name would
 // silently share one definition.


### PR DESCRIPTION
## Summary

The remaining half of #2898. #2899 fixed the symptom by renaming the colliding types; this PR adds the guard.

The generator now records the declaring package of every type the reflector names, and fails generation when one name is claimed by more than one package.
`check-config-schema` already runs the generator on every PR, so no workflow change is needed.

## Implementation

The `Namer` hook is used purely for observation. It renames nothing — it returns an empty name so the reflector keeps its default naming, and only records the types passing through. The check itself runs after reflection completes.

I picked this hook because every type that needs a definition name has to pass through it, so there is no need to recompute which types end up in `$defs`. I tried a hand-written `reflect` walk first, but it followed unexported fields and produced false positives on things like `sync.Mutex`.

As a side effect this also covers collisions in the enum registry. The reflector asks for names on more types than end up in `$defs`; the difference is enum types such as `LogLevel`, `Protocol` and `Source`. They produce no definition, but the `enums` registry is keyed by bare name too, so a collision concatenates their values via `append`.

## Limitations

Name collisions among types that are scanned from `packagesToScan` but are not reachable from `obi.Config` are not detected. The reflector never meets those types while the AST scan still collects them, so the env and enum registries can be polluted.

For that to cause actual damage, all of the following must hold:
- the name matches exactly a type that the schema actually uses
- that type carries `env` tags or enum constants, so there is something to pollute
- it is scanned later, since being scanned earlier makes the overwrite harmless

Today the only names declared more than once across the scanned packages are `goRuntimeHistogramKey` and `goRuntimeHistogramState`, both unexported runtime types that never reach the schema. The two collisions that actually broke in #2898 were reachable from both sides, and this guard catches those.

Covering the rest would mean recording the declaring package along the AST scan path as well, which is a larger change than the failure conditions justify, so it is out of scope here.

## What I verified

The generated `config-schema.json` is byte-for-byte identical to the committed file — the guard only observes, so the output does not change.

Temporarily reverting the two renames from #2899 to reproduce a real collision makes generation fail like this:

```
Error: type name declared in more than one package; rename one type per group so that every configuration type has a unique name:
  MetricsConfig
    go.opentelemetry.io/obi/pkg/export/otel/otelcfg
    go.opentelemetry.io/obi/pkg/export/otel/perapp
  PrometheusConfig
    go.opentelemetry.io/obi/pkg/export/imetrics
    go.opentelemetry.io/obi/pkg/export/prom
```

## Generative AI disclosure

Claude Code was used for the design and the implementation. I reviewed the approach and the alternatives, the code and the tests myself, and verified them locally.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.