### PR TITLE
fix(ebpf): prevent latching incorrect TLS connection socket attribution (#2998)

### DIFF
--- a/bpf/common/connection_info.h
+++ b/bpf/common/connection_info.h
@@ -61,7 +61,8 @@ typedef struct http_pid_connection_info {
 typedef struct ssl_pid_connection_info {
     pid_connection_info_t p_conn;
     u16 orig_dport;
-    u8 _pad[6];
+    u8 tentative;
+    u8 _pad[5];
 } ssl_pid_connection_info_t;
 
 typedef struct connection_info_part {

--- a/bpf/common/ssl_helpers.h
+++ b/bpf/common/ssl_helpers.h
@@ -22,6 +22,7 @@ static __always_inline void set_active_ssl_connection(ssl_pid_connection_info_t 
     bpf_dbg_printk("Correlating SSL %llx to connection", ssl);
     dbg_print_http_connection_info(&ssl_conn->p_conn.conn);
 
+    ssl_conn->tentative = 0;
     bpf_map_update_elem(&active_ssl_connections, &ssl_conn->p_conn, &ssl, BPF_ANY);
     bpf_map_update_elem(&ssl_to_conn, &ssl, ssl_conn, BPF_ANY);
 }

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -407,6 +407,7 @@ setup_connection_to_pid_mapping(u64 id, pid_connection_info_t *p_conn, u16 orig_
         ssl_pid_connection_info_t ssl_conn = {0};
         ssl_conn.orig_dport = orig_dport;
         ssl_conn.p_conn = *p_conn;
+        ssl_conn.tentative = 1;
 
         bpf_map_update_elem(&pid_tid_to_conn, &id, &ssl_conn, BPF_ANY);
     }

--- a/bpf/generictracer/ssl_defs.h
+++ b/bpf/generictracer/ssl_defs.h
@@ -34,12 +34,19 @@ handle_ssl_buf(void *ctx, u64 id, ssl_args_t *args, int bytes_len, u8 direction)
         void *ssl = ((void *)args->ssl);
         const u64 ssl_ptr = (u64)ssl;
         bpf_dbg_printk("SSL_buf id=%d ssl=%llx", id, ssl);
+
+        bpf_map_delete_elem(&ssl_to_pid_tid, &ssl_ptr);
+
+        if (bytes_len <= 0) {
+            return;
+        }
+
         ssl_pid_connection_info_t *conn = bpf_map_lookup_elem(&ssl_to_conn, &ssl);
 
-        if (!conn) {
-            conn = bpf_map_lookup_elem(&pid_tid_to_conn, &id);
+        if (!conn || conn->tentative) {
+            ssl_pid_connection_info_t *fallback_conn = bpf_map_lookup_elem(&pid_tid_to_conn, &id);
 
-            if (!conn) {
+            if (!fallback_conn) {
                 // We try even harder, we might have an SSL pointer mapped on another
                 // thread, since tcp_rcv_established was handled on another thread pool.
                 // First we look up a pid_tid by the ssl pointer, which might've been established
@@ -50,9 +57,9 @@ handle_ssl_buf(void *ctx, u64 id, ssl_args_t *args, int bytes_len, u8 direction)
                 if (pid_tid_ptr) {
                     const u64 pid_tid = *pid_tid_ptr;
 
-                    conn = bpf_map_lookup_elem(&pid_tid_to_conn, &pid_tid);
+                    fallback_conn = bpf_map_lookup_elem(&pid_tid_to_conn, &pid_tid);
                     bpf_dbg_printk(
-                        "Separate pool lookup ssl=%llx, pid=%d, conn=%llx", ssl_ptr, pid_tid, conn);
+                        "Separate pool lookup ssl=%llx, pid=%d, conn=%llx", ssl_ptr, pid_tid, fallback_conn);
                 } else {
                     bpf_dbg_printk("Other thread lookup failed for ssl=%llx", ssl_ptr);
                 }
@@ -62,18 +69,14 @@ handle_ssl_buf(void *ctx, u64 id, ssl_args_t *args, int bytes_len, u8 direction)
             // we missed a SSL_do_handshake, update our ssl to connection map to be
             // used by the rest of the SSL lifecycle. We shouldn't rely on the SSL_write
             // being on the same thread as the SSL_read.
-            if (conn) {
+            if (fallback_conn) {
                 bpf_map_delete_elem(&pid_tid_to_conn, &id);
                 ssl_pid_connection_info_t c;
-                bpf_probe_read(&c, sizeof(ssl_pid_connection_info_t), conn);
+                bpf_probe_read(&c, sizeof(ssl_pid_connection_info_t), fallback_conn);
+                c.tentative = 1;
                 bpf_map_update_elem(&ssl_to_conn, &ssl, &c, BPF_ANY);
+                conn = bpf_map_lookup_elem(&ssl_to_conn, &ssl);
             }
-        }
-
-        bpf_map_delete_elem(&ssl_to_pid_tid, &ssl_ptr);
-
-        if (bytes_len <= 0) {
-            return;
         }
 
         if (!conn) {
@@ -85,6 +88,7 @@ handle_ssl_buf(void *ctx, u64 id, ssl_args_t *args, int bytes_len, u8 direction)
             __builtin_memcpy(&p_c.p_conn.conn.s_addr, &ssl, sizeof(void *));
             p_c.p_conn.conn.d_port = p_c.p_conn.conn.s_port = p_c.orig_dport = 0;
             p_c.p_conn.pid = pid_from_pid_tgid(id);
+            p_c.tentative = 1;
 
             bpf_map_update_elem(&ssl_to_conn, &ssl, &p_c, BPF_ANY);
             conn = bpf_map_lookup_elem(&ssl_to_conn, &ssl);

--- a/bpf/tests/bpf_ssl_read_guard.c
+++ b/bpf/tests/bpf_ssl_read_guard.c
@@ -6,9 +6,40 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <bpfcore/bpf_helpers.h>
+#include <stdbool.h>
 
-enum { BPF_ANY = 0, BPF_NOEXIST = 1 };
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+typedef int8_t s8;
+typedef int16_t s16;
+typedef int32_t s32;
+typedef int64_t s64;
+typedef uint8_t __u8;
+typedef uint16_t __u16;
+typedef uint32_t __u32;
+typedef uint64_t __u64;
+
+#ifndef __always_inline
+#define __always_inline inline
+#endif
+#ifndef SEC
+#define SEC(name)
+#endif
+#ifndef __uint
+#define __uint(name, val) int name
+#endif
+#ifndef __type
+#define __type(name, val) typeof(val) *name
+#endif
+
+#ifndef valid_pid
+#define valid_pid(id) (1)
+#endif
+#ifndef pid_from_pid_tgid
+#define pid_from_pid_tgid(id) ((u32)((id) >> 32))
+#endif
 
 struct bpf_test_map {
     int id;
@@ -18,6 +49,11 @@ static void *test_map_lookup(void *map, const void *key);
 static long test_map_update(void *map, const void *key, const void *val, unsigned long long flags);
 static long test_map_delete(void *map, const void *key);
 static long test_probe_read(void *dst, unsigned int size, const void *src);
+
+#define __BPF_HELPERS__
+#define __BPF_HELPER_DEFS__
+#define IP_V6_ADDR_LEN 16
+#define IP_V6_ADDR_LEN_WORDS 4
 
 #define bpf_map_lookup_elem test_map_lookup
 #define bpf_map_update_elem test_map_update
@@ -254,6 +290,36 @@ static void test_successful_read_can_reuse_mapped_pid_tid_connection(void) {
     assert_u16_eq(8443, test_last_orig_dport, "mapped pid_tid connection preserves original dport");
 }
 
+static void test_tentative_connection_is_reevaluated(void) {
+    reset();
+    seed_existing_ssl_connection(8080);
+    test_ssl_conn.tentative = 1; // Mark existing as tentative guess
+
+    test_mapped_pid_tid = 0x2a00000001ULL;
+    test_mapped_pid_tid_available = 1;
+
+    ssl_args_t args = ssl_args();
+    handle_ssl_buf(NULL, 0x2a00000001ULL, &args, 64, TCP_RECV);
+
+    assert_int_eq(1, ssl_to_conn_update_count, "tentative connection is re-evaluated and updated");
+    assert_int_eq(1, (int)test_ssl_conn.tentative, "updated fallback connection remains marked tentative");
+}
+
+static void test_confirmed_connection_is_not_overwritten(void) {
+    reset();
+    seed_existing_ssl_connection(6379);
+    test_ssl_conn.tentative = 0; // Mark existing as confirmed socket connection
+
+    test_mapped_pid_tid = 0x2a00000001ULL;
+    test_mapped_pid_tid_available = 1;
+
+    ssl_args_t args = ssl_args();
+    handle_ssl_buf(NULL, 0x2a00000001ULL, &args, 64, TCP_RECV);
+
+    assert_int_eq(0, ssl_to_conn_update_count, "confirmed connection is preserved and not overwritten");
+    assert_u16_eq(6379, test_last_orig_dport, "confirmed connection dport is preserved");
+}
+
 static void test_missing_args_noops(void) {
     reset();
 
@@ -272,6 +338,8 @@ int main(void) {
     test_successful_write_still_parses();
     test_successful_read_can_create_fake_connection();
     test_successful_read_can_reuse_mapped_pid_tid_connection();
+    test_tentative_connection_is_reevaluated();
+    test_confirmed_connection_is_not_overwritten();
     test_missing_args_noops();
 
     return 0;


### PR DESCRIPTION
Fixes #2998

### Root Cause
TLS client spans in event-loop applications (e.g. `asyncio`, `Node.js`) were mis-attributed to inbound server sockets because:
1. Zero-byte reads (`WANT_READ`) looked up thread fallback connections (`pid_tid_to_conn`) before checking `bytes_len <= 0`.
2. Once saved into `ssl_to_conn`, fallback guesses were never re-evaluated and remained latched permanently.

### Fix
- Added a `tentative` provenance bit to `ssl_pid_connection_info_t` to differentiate fallback guesses (`tentative = 1`) from confirmed socket bindings (`tentative = 0`).
- Returned early on `bytes_len <= 0` in `handle_ssl_buf` to prevent zero-byte reads from creating or updating `ssl_to_conn`.
- Allowed re-evaluating `ssl_to_conn` when `conn->tentative == 1` so tentative guesses update when confirmed socket info becomes available.
