### PR TITLE
Adds OBI's emitted-telemetry schema

### DIFF
--- a/internal/schemacheck/upstream_consistency_test.go
+++ b/internal/schemacheck/upstream_consistency_test.go
@@ -1,0 +1,120 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package schemacheck holds tests that validate the OBI semantic-convention
+// registry against the pinned upstream OpenTelemetry semantic conventions it
+// depends on.
+package schemacheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	obiGroupsDir = "../../schemas/obi/groups"
+	upstreamDeps = "../../schemas/obi/.deps"
+)
+
+type metricGroupsFile struct {
+	Groups []struct {
+		Type       string `yaml:"type"`
+		MetricName string `yaml:"metric_name"`
+		Unit       string `yaml:"unit"`
+		Instrument string `yaml:"instrument"`
+		Stability  string `yaml:"stability"`
+	} `yaml:"groups"`
+}
+
+type metricDef struct {
+	unit       string
+	instrument string
+	stability  string
+	source     string
+}
+
+func metricsFromFile(t *testing.T, path string, out map[string]metricDef) {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var f metricGroupsFile
+	require.NoErrorf(t, yaml.Unmarshal(body, &f), "parsing %s", path)
+	for _, g := range f.Groups {
+		if g.Type != "metric" || g.MetricName == "" {
+			continue
+		}
+		out[g.MetricName] = metricDef{unit: g.Unit, instrument: g.Instrument, stability: g.Stability, source: path}
+	}
+}
+
+func obiMetrics(t *testing.T) map[string]metricDef {
+	t.Helper()
+	entries, err := os.ReadDir(obiGroupsDir)
+	require.NoError(t, err)
+	out := map[string]metricDef{}
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".yaml" {
+			continue
+		}
+		metricsFromFile(t, filepath.Join(obiGroupsDir, e.Name()), out)
+	}
+	return out
+}
+
+func upstreamMetrics(t *testing.T) map[string]metricDef {
+	t.Helper()
+	out := map[string]metricDef{}
+	err := filepath.WalkDir(upstreamDeps, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".yaml" {
+			return nil
+		}
+		metricsFromFile(t, path, out)
+		return nil
+	})
+	require.NoError(t, err)
+	return out
+}
+
+// TestOBIMetricOverridesMatchUpstream asserts that every OBI metric reusing an
+// upstream semconv metric name declares the same unit, instrument, and stability
+// as the pinned upstream definition.
+//
+// OBI redeclares these metrics instead of importing them because weaver cannot
+// narrow an imported metric's attributes down to the subset OBI emits
+// (open-telemetry/weaver#1667). Redeclaring copies the metric wrapper — unit,
+// instrument, stability — which can then drift from upstream, so this test pins
+// it to the upstream definition. Attributes are not compared: OBI refs them, so
+// they resolve against this same upstream registry and cannot drift.
+func TestOBIMetricOverridesMatchUpstream(t *testing.T) {
+	obi := obiMetrics(t)
+	upstream := upstreamMetrics(t)
+	require.NotEmpty(t, obi)
+	require.NotEmpty(t, upstream)
+
+	overrides := 0
+	for name, m := range obi {
+		up, ok := upstream[name]
+		if !ok {
+			continue // OBI-custom metric with no upstream definition to match
+		}
+		overrides++
+		assert.Equalf(t, up.unit, m.unit,
+			"metric %q unit %q differs from upstream %q (%s vs %s)",
+			name, m.unit, up.unit, m.source, up.source)
+		assert.Equalf(t, up.instrument, m.instrument,
+			"metric %q instrument %q differs from upstream %q (%s vs %s)",
+			name, m.instrument, up.instrument, m.source, up.source)
+		assert.Equalf(t, up.stability, m.stability,
+			"metric %q stability %q differs from upstream %q (%s vs %s)",
+			name, m.stability, up.stability, m.source, up.source)
+	}
+	require.Positive(t, overrides, "expected OBI to override at least one upstream metric")
+}

--- a/schemas/obi/README.md
+++ b/schemas/obi/README.md
@@ -8,8 +8,9 @@ upstream dependency it forms the complete contract of what OBI emits
 ## Overriding an upstream definition
 
 Weaver has **no precedence or merge semantics** between a local group and the
-groups a dependency contributes to the resolved registry
-(`groups/dns.yaml` imports all upstream groups). When the same attribute id is
+groups a dependency contributes to the resolved registry (OBI's group files
+`import` the definitions they refine and `ref` the attributes they emit, both
+of which pull the upstream groups in). When the same attribute id is
 declared by more than one group, live-check silently resolves
 the duplicate in favor of the group whose id sorts **last lexicographically** —
 including the upstream `span.*` / `metric.*` groups that `ref` an attribute

--- a/schemas/obi/groups/dns.yaml
+++ b/schemas/obi/groups/dns.yaml
@@ -1,11 +1,8 @@
 file_format: definition/2
 
 imports:
-  entities: ["*"]
-  events: ["*"]
-  metrics: ["*"]
-  spans: ["*"]
-  attribute_groups: ["*"]
+  metrics:
+    - dns.lookup.duration
 
 metric_refinements:
   # OBI override of the upstream metric.dns.lookup.duration definition.

--- a/schemas/obi/groups/emitted_metrics.yaml
+++ b/schemas/obi/groups/emitted_metrics.yaml
@@ -1,0 +1,446 @@
+# OBI-emitted semconv metrics, narrowed to exactly the attributes OBI sets.
+# Each metric ref-s only what OBI emits so the registry resolves (without
+# --include-unreferenced) to OBI's true OTLP contract. Kubernetes attributes
+# are added once their upstream declarations land; per-suite validation keeps
+# --include-unreferenced so forwarded pass-through attributes are tolerated.
+groups:
+  - id: metric.obi.db.client.operation.duration
+    type: metric
+    metric_name: db.client.operation.duration
+    brief: OBI-emitted db.client.operation.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: db.collection.name
+      - ref: db.operation.name
+      - ref: db.system.name
+      - ref: error.type
+      - ref: server.address
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.gen_ai.client.operation.duration
+    type: metric
+    metric_name: gen_ai.client.operation.duration
+    brief: OBI-emitted gen_ai.client.operation.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: error.type
+      - ref: gen_ai.operation.name
+      - ref: gen_ai.provider.name
+      - ref: gen_ai.request.model
+      - ref: gen_ai.response.model
+      - ref: server.address
+      - ref: server.port
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.gen_ai.client.token.usage
+    type: metric
+    metric_name: gen_ai.client.token.usage
+    brief: OBI-emitted gen_ai.client.token.usage
+    instrument: histogram
+    unit: "{token}"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: gen_ai.operation.name
+      - ref: gen_ai.provider.name
+      - ref: gen_ai.request.model
+      - ref: gen_ai.response.model
+      - ref: gen_ai.token.type
+      - ref: server.address
+      - ref: server.port
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.config.gogc
+    type: metric
+    metric_name: go.config.gogc
+    brief: OBI-emitted go.config.gogc
+    instrument: updowncounter
+    unit: "%"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.cpu.time
+    type: metric
+    metric_name: go.cpu.time
+    brief: OBI-emitted go.cpu.time
+    instrument: counter
+    unit: "s"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: go.cpu.state
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.goroutine.count
+    type: metric
+    metric_name: go.goroutine.count
+    brief: OBI-emitted go.goroutine.count
+    instrument: updowncounter
+    unit: "{goroutine}"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.memory.allocated
+    type: metric
+    metric_name: go.memory.allocated
+    brief: OBI-emitted go.memory.allocated
+    instrument: counter
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.memory.allocations
+    type: metric
+    metric_name: go.memory.allocations
+    brief: OBI-emitted go.memory.allocations
+    instrument: counter
+    unit: "{allocation}"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.memory.gc.cycles
+    type: metric
+    metric_name: go.memory.gc.cycles
+    brief: OBI-emitted go.memory.gc.cycles
+    instrument: counter
+    unit: "{gc_cycle}"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.memory.gc.goal
+    type: metric
+    metric_name: go.memory.gc.goal
+    brief: OBI-emitted go.memory.gc.goal
+    instrument: updowncounter
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.memory.gc.pause.duration
+    type: metric
+    metric_name: go.memory.gc.pause.duration
+    brief: OBI-emitted go.memory.gc.pause.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.memory.limit
+    type: metric
+    metric_name: go.memory.limit
+    brief: OBI-emitted go.memory.limit
+    instrument: updowncounter
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.memory.used
+    type: metric
+    metric_name: go.memory.used
+    brief: OBI-emitted go.memory.used
+    instrument: updowncounter
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: go.memory.type
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.processor.limit
+    type: metric
+    metric_name: go.processor.limit
+    brief: OBI-emitted go.processor.limit
+    instrument: updowncounter
+    unit: "{thread}"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.go.schedule.duration
+    type: metric
+    metric_name: go.schedule.duration
+    brief: OBI-emitted go.schedule.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.http.client.request.body.size
+    type: metric
+    metric_name: http.client.request.body.size
+    brief: OBI-emitted http.client.request.body.size
+    instrument: histogram
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: http.request.method
+      - ref: http.response.status_code
+      - ref: http.route
+      - ref: server.address
+      - ref: server.port
+      - ref: service.name
+      - ref: service.namespace
+      - ref: url.path
+      - ref: url.scheme
+  - id: metric.obi.http.client.request.duration
+    type: metric
+    metric_name: http.client.request.duration
+    brief: OBI-emitted http.client.request.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: http.request.method
+      - ref: http.response.status_code
+      - ref: http.route
+      - ref: server.address
+      - ref: server.port
+      - ref: service.name
+      - ref: service.namespace
+      - ref: url.path
+      - ref: url.scheme
+  - id: metric.obi.http.client.response.body.size
+    type: metric
+    metric_name: http.client.response.body.size
+    brief: OBI-emitted http.client.response.body.size
+    instrument: histogram
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: http.request.method
+      - ref: http.response.status_code
+      - ref: http.route
+      - ref: server.address
+      - ref: server.port
+      - ref: service.name
+      - ref: service.namespace
+      - ref: url.path
+      - ref: url.scheme
+  - id: metric.obi.http.server.request.body.size
+    type: metric
+    metric_name: http.server.request.body.size
+    brief: OBI-emitted http.server.request.body.size
+    instrument: histogram
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: client.address
+      - ref: container.id
+      - ref: container.name
+      - ref: http.request.method
+      - ref: http.response.status_code
+      - ref: http.route
+      - ref: server.address
+      - ref: server.port
+      - ref: service.name
+      - ref: service.namespace
+      - ref: url.path
+      - ref: url.scheme
+  - id: metric.obi.http.server.request.duration
+    type: metric
+    metric_name: http.server.request.duration
+    brief: OBI-emitted http.server.request.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    attributes:
+      - ref: client.address
+      - ref: container.id
+      - ref: container.name
+      - ref: http.request.method
+      - ref: http.response.status_code
+      - ref: http.route
+      - ref: server.address
+      - ref: server.port
+      - ref: service.name
+      - ref: service.namespace
+      - ref: url.path
+      - ref: url.scheme
+  - id: metric.obi.http.server.response.body.size
+    type: metric
+    metric_name: http.server.response.body.size
+    brief: OBI-emitted http.server.response.body.size
+    instrument: histogram
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: client.address
+      - ref: container.id
+      - ref: container.name
+      - ref: http.request.method
+      - ref: http.response.status_code
+      - ref: http.route
+      - ref: server.address
+      - ref: server.port
+      - ref: service.name
+      - ref: service.namespace
+      - ref: url.path
+      - ref: url.scheme
+  - id: metric.obi.jvm.memory.committed
+    type: metric
+    metric_name: jvm.memory.committed
+    brief: OBI-emitted jvm.memory.committed
+    instrument: updowncounter
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: jvm.memory.pool.name
+      - ref: jvm.memory.type
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.jvm.memory.limit
+    type: metric
+    metric_name: jvm.memory.limit
+    brief: OBI-emitted jvm.memory.limit
+    instrument: updowncounter
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: jvm.memory.pool.name
+      - ref: jvm.memory.type
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.jvm.memory.used
+    type: metric
+    metric_name: jvm.memory.used
+    brief: OBI-emitted jvm.memory.used
+    instrument: updowncounter
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: jvm.memory.pool.name
+      - ref: jvm.memory.type
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.jvm.memory.used.after.last.gc
+    type: metric
+    metric_name: jvm.memory.used_after_last_gc
+    brief: OBI-emitted jvm.memory.used_after_last_gc
+    instrument: updowncounter
+    unit: "By"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: jvm.memory.pool.name
+      - ref: jvm.memory.type
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.messaging.client.operation.duration
+    type: metric
+    metric_name: messaging.client.operation.duration
+    brief: OBI-emitted messaging.client.operation.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: messaging.destination.name
+      - ref: messaging.operation.name
+      - ref: messaging.system
+      - ref: server.address
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.messaging.process.duration
+    type: metric
+    metric_name: messaging.process.duration
+    brief: OBI-emitted messaging.process.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: messaging.destination.name
+      - ref: messaging.operation.name
+      - ref: messaging.system
+      - ref: server.address
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.rpc.client.call.duration
+    type: metric
+    metric_name: rpc.client.call.duration
+    brief: OBI-emitted rpc.client.call.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    attributes:
+      - ref: container.id
+      - ref: container.name
+      - ref: rpc.method
+      - ref: rpc.response.status_code
+      - ref: rpc.system.name
+      - ref: server.address
+      - ref: service.name
+      - ref: service.namespace
+  - id: metric.obi.rpc.server.call.duration
+    type: metric
+    metric_name: rpc.server.call.duration
+    brief: OBI-emitted rpc.server.call.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    attributes:
+      - ref: client.address
+      - ref: container.id
+      - ref: container.name
+      - ref: rpc.method
+      - ref: rpc.response.status_code
+      - ref: rpc.system.name
+      - ref: server.address
+      - ref: server.port
+      - ref: service.name
+      - ref: service.namespace

--- a/schemas/obi/groups/emitted_metrics.yaml
+++ b/schemas/obi/groups/emitted_metrics.yaml
@@ -10,7 +10,7 @@ groups:
     brief: OBI-emitted db.client.operation.duration
     instrument: histogram
     unit: "s"
-    stability: development
+    stability: stable
     attributes:
       - ref: container.id
       - ref: container.name
@@ -230,7 +230,7 @@ groups:
     brief: OBI-emitted http.client.request.duration
     instrument: histogram
     unit: "s"
-    stability: development
+    stability: stable
     attributes:
       - ref: container.id
       - ref: container.name
@@ -288,7 +288,7 @@ groups:
     brief: OBI-emitted http.server.request.duration
     instrument: histogram
     unit: "s"
-    stability: development
+    stability: stable
     attributes:
       - ref: client.address
       - ref: container.id
@@ -328,7 +328,7 @@ groups:
     brief: OBI-emitted jvm.memory.committed
     instrument: updowncounter
     unit: "By"
-    stability: development
+    stability: stable
     attributes:
       - ref: container.id
       - ref: container.name
@@ -342,7 +342,7 @@ groups:
     brief: OBI-emitted jvm.memory.limit
     instrument: updowncounter
     unit: "By"
-    stability: development
+    stability: stable
     attributes:
       - ref: container.id
       - ref: container.name
@@ -356,7 +356,7 @@ groups:
     brief: OBI-emitted jvm.memory.used
     instrument: updowncounter
     unit: "By"
-    stability: development
+    stability: stable
     attributes:
       - ref: container.id
       - ref: container.name
@@ -370,7 +370,7 @@ groups:
     brief: OBI-emitted jvm.memory.used_after_last_gc
     instrument: updowncounter
     unit: "By"
-    stability: development
+    stability: stable
     attributes:
       - ref: container.id
       - ref: container.name
@@ -416,7 +416,7 @@ groups:
     brief: OBI-emitted rpc.client.call.duration
     instrument: histogram
     unit: "s"
-    stability: development
+    stability: release_candidate
     attributes:
       - ref: container.id
       - ref: container.name
@@ -432,7 +432,7 @@ groups:
     brief: OBI-emitted rpc.server.call.duration
     instrument: histogram
     unit: "s"
-    stability: development
+    stability: release_candidate
     attributes:
       - ref: client.address
       - ref: container.id

--- a/schemas/obi/groups/obi_internal.yaml
+++ b/schemas/obi/groups/obi_internal.yaml
@@ -73,6 +73,20 @@ groups:
     attributes:
       - ref: instance
       - ref: job
+      - ref: service.instance.id
+      - ref: k8s.cluster.name
+      - ref: k8s.container.name
+      - ref: k8s.cronjob.name
+      - ref: k8s.daemonset.name
+      - ref: k8s.deployment.name
+      - ref: k8s.job.name
+      - ref: k8s.namespace.name
+      - ref: k8s.node.name
+      - ref: k8s.pod.name
+      - ref: k8s.pod.start_time
+      - ref: k8s.pod.uid
+      - ref: k8s.replicaset.name
+      - ref: k8s.statefulset.name
 
   # The trace-pipeline counterpart of `target.info`. Only emitted when any
   # span-metrics feature is enabled — i.e. one of `application_span`,


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1759

## Summary

Adds OBI's emitted-telemetry schema: a semantic-convention registry that declares exactly the metrics and attributes OBI produces over OTLP.

This is a prerequisite to full telemetry schema coverage validation. It is **schema only** — nothing consumes it yet. Reviewing this one is purely "is this the correct description of what OBI emits?"

**What's here**

- `emitted_metrics.yaml` (new): every OBI-emitted OTLP metric and the attributes  it carries, 
narrowed to what OBI actually sets. 
This lets the registry resolve to OBI's true OTLP contract instead of the full upstream surface.
- `obi_internal.yaml`: `target.info` now references the resource attributes OBI attaches to it (`service.instance.id` and the `k8s.*` set), so the  resource-attribute carrier is described rather than empty.
- `dns.yaml`: imports only `dns.lookup.duration` instead of the whole upstream DNS group.
- `README.md`: corrects a stale note on how the group files import and reference upstream definitions.

**Why the metrics are fully re-declared**

`emitted_metrics.yaml` restates each upstream metric with its full attribute list rather than importing it and refining the attributes down to OBI's subset.
That looks like duplication, but it is currently the only option. This is tracked in [open-telemetry/weaver#1667](https://github.com/open-telemetry/weaver/issues/1667)
Until then we redeclare the otel metric defenitions and ref only the attributes we emit
we validate that our schema does not drift from the upstream otel one with `TestOBIMetricOverridesMatchUpstream`

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
