### PR TITLE
gotracer: fix duplicate spans on wrapped net.Conn

### DIFF
--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -42,6 +42,7 @@
 #include <gotracer/types/net_args.h>
 #include <gotracer/types/nethttp.h>
 
+#include <gotracer/maps/go_persist_conn.h>
 #include <gotracer/maps/nethttp.h>
 #include <gotracer/maps/ongoing_fd_reads.h>
 #include <gotracer/maps/ongoing_large_buffers.h>
@@ -218,6 +219,10 @@ int obi_uprobe_netFdWrite(struct pt_regs *ctx) {
         }
 
         p_conn.pid = pid_from_pid_tgid(id);
+
+        // an http client request being written: hand the connection to the request
+        // goroutine and claim it, so this write is not reported a second time
+        persist_conn_publish(&g_key, &p_conn.conn);
 
         u16 orig_dport = p_conn.conn.d_port;
         sort_connection_info(&p_conn.conn);

--- a/bpf/gotracer/go_nethttp.c
+++ b/bpf/gotracer/go_nethttp.c
@@ -36,6 +36,7 @@
 #include <gotracer/go_offsets.h>
 #include <gotracer/go_str.h>
 
+#include <gotracer/maps/go_persist_conn.h>
 #include <gotracer/maps/nethttp.h>
 
 #include <gotracer/types/nethttp.h>
@@ -802,7 +803,14 @@ int obi_uprobe_roundTripReturn(struct pt_regs *ctx) {
         bpf_map_delete_elem(&outgoing_trace_map, &e_key);
         bpf_map_delete_elem(&go_ongoing_http, &e_key);
     } else {
-        __builtin_memset(&trace->conn, 0, sizeof(connection_info_t));
+        // persistConn.conn was unreadable, so take the connection the write side read
+        // from the netFD instead of reporting this call without a peer.
+        connection_info_t *published = persist_conn_lookup(&g_key);
+        if (published) {
+            bpf_memcpy(&trace->conn, published, sizeof(connection_info_t));
+        } else {
+            bpf_memset(&trace->conn, 0, sizeof(connection_info_t));
+        }
     }
 
     trace->tp = invocation->tp;
@@ -839,6 +847,7 @@ done:
     bpf_map_delete_elem(&go_ongoing_http_client_requests, &g_key);
     bpf_map_delete_elem(&ongoing_http_client_requests_data, &g_key);
     bpf_map_delete_elem(&ongoing_client_connections, &g_key);
+    bpf_map_delete_elem(&go_persist_conn_request, &g_key);
     return 0;
 }
 
@@ -1644,6 +1653,28 @@ int obi_uprobe_connServeRet(struct pt_regs *ctx) {
     return 0;
 }
 
+// net/http writes the request through this io.Writer on persistConn.writeLoop.
+// Its receiver is the persistConn, which the netFD write that follows on this same
+// goroutine cannot see.
+SEC("uprobe/persistConnWriterWrite")
+int obi_uprobe_persistConnWriterWrite(struct pt_regs *ctx) {
+    void *goroutine_addr = GOROUTINE_PTR(ctx);
+    const u64 pc = (u64)GO_PARAM1(ctx);
+
+    bpf_dbg_printk(
+        "=== uprobe/persistConnWriter.Write goroutine=%lx, pc=%llx ===", goroutine_addr, pc);
+
+    if (!pc) {
+        return 0;
+    }
+
+    go_addr_key_t g_key = {};
+    go_addr_key_from_id(&g_key, goroutine_addr);
+    store_persist_conn_writer(&g_key, pc);
+
+    return 0;
+}
+
 SEC("uprobe/persistConnRoundTrip")
 int obi_uprobe_persistConnRoundTrip(struct pt_regs *ctx) {
     bpf_dbg_printk("=== uprobe/persistConnRoundTrip ===");
@@ -1662,6 +1693,10 @@ int obi_uprobe_persistConnRoundTrip(struct pt_regs *ctx) {
     }
 
     void *pc_ptr = GO_PARAM1(ctx);
+
+    // the write side resolves this persistConn's connection from its netFD
+    store_persist_conn_request(&g_key, (u64)pc_ptr);
+
     if (pc_ptr) {
         void *conn_conn_ptr = pc_ptr + k_go_iface_data_offset +
                               go_offset_of(ot, (go_offset){.v = _pc_conn_pos}); // embedded struct
@@ -1684,9 +1719,14 @@ int obi_uprobe_persistConnRoundTrip(struct pt_regs *ctx) {
             bpf_dbg_printk("conn_ptr=%llx", conn_ptr);
             if (conn_ptr) {
                 connection_info_t conn = {0};
-                get_conn_info(
-                    conn_ptr,
-                    &conn); // initialized to 0, no need to check the result if we succeeded
+                if (!get_conn_info(conn_ptr, &conn)) {
+                    // an app wrapping net.Conn leaves this unreadable; storing the zero
+                    // connection would claim it as the Go-handled one and set it as this
+                    // request's peer, neither of which is true
+                    bpf_dbg_printk("can't read client connection, leaving it unassociated");
+                    return 0;
+                }
+
                 const u64 pid_tid = bpf_get_current_pid_tgid();
                 const u32 pid = pid_from_pid_tgid(pid_tid);
                 tp_info_pid_t tp_p = {

--- a/bpf/gotracer/maps/go_persist_conn.h
+++ b/bpf/gotracer/maps/go_persist_conn.h
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/connection_info.h>
+#include <common/go_addr_key.h>
+#include <common/map_sizing.h>
+#include <common/pin_internal.h>
+
+#include <gotracer/maps/handled_by_go.h>
+
+// net/http writes a client request from persistConn.writeLoop, a different
+// goroutine than the one running the request, so the connection can only be read
+// from the netFD there. These three maps carry it back to the request:
+//
+//   writeLoop goroutine --> persistConn   (go_persist_conn_writer)
+//   persistConn         --> connection    (go_persist_conn_info)
+//   request goroutine   --> persistConn   (go_persist_conn_request)
+//
+// Reading it off persistConn.conn instead only works while the application does
+// not wrap net.Conn.
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, go_addr_key_t); // the goroutine writing the request
+    __type(value, u64);         // the persistConn it writes for
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} go_persist_conn_writer SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, u64);                 // the persistConn
+    __type(value, connection_info_t); // its connection, as read from the netFD
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} go_persist_conn_info SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_LRU_HASH);
+    __type(key, go_addr_key_t); // the goroutine running the request
+    __type(value, u64);         // the persistConn serving it
+    __uint(max_entries, MAX_CONCURRENT_REQUESTS);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} go_persist_conn_request SEC(".maps");
+
+static __always_inline void store_persist_conn_writer(const go_addr_key_t *g_key, u64 pc) {
+    bpf_map_update_elem(&go_persist_conn_writer, g_key, &pc, BPF_ANY);
+}
+
+static __always_inline void store_persist_conn_request(const go_addr_key_t *g_key, u64 pc) {
+    bpf_map_update_elem(&go_persist_conn_request, g_key, &pc, BPF_ANY);
+}
+
+// Called where the connection is known: publishes it for the request goroutine and
+// claims it, since the roundTrip probes report this request.
+static __always_inline void persist_conn_publish(const go_addr_key_t *g_key,
+                                                 const connection_info_t *conn) {
+    const u64 *pc = bpf_map_lookup_elem(&go_persist_conn_writer, g_key);
+    if (!pc) {
+        return;
+    }
+
+    bpf_map_update_elem(&go_persist_conn_info, pc, conn, BPF_ANY);
+    bpf_map_delete_elem(&go_persist_conn_writer, g_key);
+    store_go_handled_connection_info(conn);
+}
+
+static __always_inline connection_info_t *persist_conn_lookup(const go_addr_key_t *g_key) {
+    const u64 *pc = bpf_map_lookup_elem(&go_persist_conn_request, g_key);
+    if (!pc) {
+        return NULL;
+    }
+
+    return bpf_map_lookup_elem(&go_persist_conn_info, pc);
+}

--- a/internal/test/integration/configs/obi-config-wrapped-conn.yml
+++ b/internal/test/integration/configs/obi-config-wrapped-conn.yml
@@ -1,0 +1,16 @@
+routes:
+  unmatched: path
+otel_traces_export:
+  endpoint: http://jaeger:4318
+attributes:
+  select:
+    "*":
+      include: ["*"]
+discovery:
+  instrument:
+    - exe_path: "*vmagent*"
+# context propagation makes the sock_msg program hand the outgoing payload to the
+# tcp_sendmsg kprobe, so the generic pipeline can report requests the Go uprobes
+# already report
+ebpf:
+  context_propagation: all

--- a/internal/test/integration/configs/vmagent-scrape.yml
+++ b/internal/test/integration/configs/vmagent-scrape.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 1s
+scrape_configs:
+  - job_name: targets
+    static_configs:
+      - targets:
+          - "target-a:8000"
+          - "target-b:8000"
+          - "target-c:8000"
+          - "target-d:8000"
+          - "target-e:8000"
+          - "target-f:8000"
+  - job_name: self
+    static_configs:
+      - targets: ["127.0.0.1:8429"]

--- a/internal/test/integration/docker-compose-wrapped-conn.yml
+++ b/internal/test/integration/docker-compose-wrapped-conn.yml
@@ -1,0 +1,66 @@
+version: "3.8"
+
+# vmagent is the driver because its statConn wraps net.Conn without holding it as the
+# first field, and it scrapes several targets at once over pooled keep-alive
+# connections: the workload where a client request ends up reported by both the Go
+# uprobes and the generic kprobe pipeline.
+
+x-target: &target
+  image: python:3.14.3-slim@sha256:6a27522252aef8432841f224d9baaa6e9fce07b07584154fa0b9a96603af7456
+  command: ["python", "-m", "http.server", "8000"]
+
+services:
+  target-a: *target
+  target-b: *target
+  target-c: *target
+  target-d: *target
+  target-e: *target
+  target-f: *target
+
+  vmagent:
+    image: victoriametrics/vmagent:v1.111.0
+    command:
+      - -promscrape.config=/etc/vmagent/scrape.yml
+      - -remoteWrite.url=http://target-a:8000/
+      - -remoteWrite.tmpDataPath=/tmp/vmagent
+      - -httpListenAddr=:8429
+    volumes:
+      - ./configs/vmagent-scrape.yml:/etc/vmagent/scrape.yml:ro
+    depends_on:
+      target-a:
+        condition: service_started
+      jaeger:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    command:
+      - --config=/configs/obi-config-wrapped-conn.yml
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+    image: hatest-obi
+    privileged: true
+    pid: "host"
+    environment:
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+    depends_on:
+      vmagent:
+        condition: service_started
+
+  jaeger:
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    command:
+      - "--set=service.telemetry.logs.level=debug"

--- a/internal/test/integration/wrapped_conn_client_test.go
+++ b/internal/test/integration/wrapped_conn_client_test.go
@@ -1,0 +1,97 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
+	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+)
+
+// enough scrapes that a per-request failure rate of a few percent shows up every run
+const minWrappedConnTraces = 200
+
+// OBI names the service after the executable, there being no k8s metadata here
+const wrappedConnService = "vmagent-prod"
+
+// TestWrappedConnClientSpans covers a Go client whose net.Conn is wrapped by a struct
+// that does not hold the connection as its first field, so it cannot be read off the
+// request goroutine. With context propagation on, the generic kprobe pipeline then
+// reports a request the Go uprobes already reported, leaving two parentless client
+// spans for the same call.
+func TestWrappedConnClientSpans(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-wrapped-conn.yml", path.Join(pathOutput, "test-suite-wrapped-conn.log"))
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+
+	var traces []jaeger.Trace
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=" + wrappedConnService + "&limit=1500")
+		require.NoError(ct, err)
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+		require.GreaterOrEqualf(ct, len(tq.Data), minWrappedConnTraces,
+			"need at least %d scrape traces before judging duplication", minWrappedConnTraces)
+		traces = tq.Data
+	}, 3*time.Minute, time.Second)
+
+	// Every scrape yields two client spans: one carrying the socket 4-tuple and one
+	// with no connection info at all (server.port 0). They pair up 1:1, and land in
+	// separate traces, so counting parentless spans within a trace misses them.
+	unattributed := map[string]int{}
+	attributed := map[string]int{}
+
+	for _, trace := range traces {
+		for _, span := range trace.Spans {
+			if spanKind(span) != "client" {
+				continue
+			}
+
+			target, _ := jaeger.FindIn(span.Tags, "server.address")
+			port, _ := jaeger.FindIn(span.Tags, "server.port")
+
+			key := fmt.Sprintf("%v", target.Value)
+			if fmt.Sprintf("%v", port.Value) == "0" {
+				unattributed[key]++
+			} else {
+				attributed[key]++
+			}
+		}
+	}
+
+	assert.Emptyf(t, unattributed, "client spans reported without connection info, one per "+
+		"properly reported call, so every outgoing request was reported twice: "+
+		"unattributed=%v attributed=%v", unattributed, attributed)
+
+	// the other half of the check: dropping the duplicate must not drop the call
+	assert.NotEmptyf(t, attributed, "no client span carries connection info, so the calls "+
+		"stopped being reported at all: unattributed=%v", unattributed)
+
+	for target, count := range attributed {
+		assert.GreaterOrEqualf(t, count, 5,
+			"only %d fully attributed client spans for %s, so calls went missing", count, target)
+	}
+
+	require.NoError(t, compose.Close())
+}
+
+func spanKind(s jaeger.Span) string {
+	if tag, ok := jaeger.FindIn(s.Tags, "span.kind"); ok {
+		if v, ok := tag.Value.(string); ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -1663,6 +1663,11 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 		"net/http.(*persistConn).roundTrip": {{ // http client
 			Start: p.bpfObjects.ObiUprobePersistConnRoundTrip,
 		}},
+		// runs on persistConn.writeLoop, the only place the request's connection can be
+		// read when the application wraps net.Conn
+		"net/http.persistConnWriter.Write": {{
+			Start: p.bpfObjects.ObiUprobePersistConnWriterWrite,
+		}},
 		// sql
 		"database/sql.(*DB).queryDC": {{
 			Start: p.bpfObjects.ObiUprobeQueryDC,


### PR DESCRIPTION
## Summary

A Go client whose net.Conn is wrapped by a struct that doesn't hold the
connection first can't be read from the request goroutine, so we reported the
same call twice — once with no peer, once with the real address.

Test: a new suite drives vmagent scraping six targets once a second over
pooled keep-alive connections. It asserts both directions — no client span
with server.port 0, and at least five properly attributed spans per target —
so a "fix" that removes the duplicate by dropping the span fails too. Without
the fix it's a clean 1:1, every scrape yielding one span of each kind.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
