### PR TITLE
Release v0.11.0

### DIFF
--- a/internal/test/integration/components/gokafka/no-promise/go.mod
+++ b/internal/test/integration/components/gokafka/no-promise/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-telemetry/opentelemetry-demo/src/checkout
+module go.opentelemetry.io/obi/internal/test/integration/components/gokafka/no-promise
 
 go 1.25.0
 

--- a/internal/test/oats/ai/go.mod
+++ b/internal/test/oats/ai/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/obi v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/amqp/go.mod
+++ b/internal/test/oats/amqp/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/obi v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/harness/go.mod
+++ b/internal/test/oats/harness/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/grafana/oats v0.7.0
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.41.0
-	go.opentelemetry.io/obi v0.0.0-00010101000000-000000000000
+	go.opentelemetry.io/obi v0.11.0
 )
 
 // The oats harness reuses the shared weaver-validation logic

--- a/internal/test/oats/http/go.mod
+++ b/internal/test/oats/http/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/obi v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/kafka/go.mod
+++ b/internal/test/oats/kafka/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/obi v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/memcached/go.mod
+++ b/internal/test/oats/memcached/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/obi v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/mongo/go.mod
+++ b/internal/test/oats/mongo/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/obi v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/nats/go.mod
+++ b/internal/test/oats/nats/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/obi v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/redis/go.mod
+++ b/internal/test/oats/redis/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/obi v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/sql/go.mod
+++ b/internal/test/oats/sql/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.0.0-00010101000000-000000000000 // indirect
+	go.opentelemetry.io/obi v0.11.0 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/versions.yaml
+++ b/versions.yaml
@@ -13,7 +13,6 @@ excluded-modules:
   - github.com/GoogleCloudPlatform/microservices-demo/src/shippingservice
   - github.com/hashicorp/go-version
   - github.com/hashicorp/golang-lru/v2
-  - github.com/open-telemetry/opentelemetry-demo/src/checkout
   - go.opentelemetry.io/collector/cmd/builder
   - go.opentelemetry.io/obi/configs/offsets/gin
   - go.opentelemetry.io/obi/configs/offsets/kafkago
@@ -43,6 +42,7 @@ excluded-modules:
   - go.opentelemetry.io/obi/internal/test/integration/components/goautosdk
   - go.opentelemetry.io/obi/internal/test/integration/components/gogeneric/fiber-example
   - go.opentelemetry.io/obi/internal/test/integration/components/gokafka
+  - go.opentelemetry.io/obi/internal/test/integration/components/gokafka/no-promise
   - go.opentelemetry.io/obi/internal/test/integration/components/gokafka-seg
   - go.opentelemetry.io/obi/internal/test/integration/components/gomongo
   - go.opentelemetry.io/obi/internal/test/integration/components/gomongov2

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   obi:
-    version: v0.10.0
+    version: v0.11.0
     modules:
       - go.opentelemetry.io/obi
 excluded-modules:
@@ -13,6 +13,7 @@ excluded-modules:
   - github.com/GoogleCloudPlatform/microservices-demo/src/shippingservice
   - github.com/hashicorp/go-version
   - github.com/hashicorp/golang-lru/v2
+  - github.com/open-telemetry/opentelemetry-demo/src/checkout
   - go.opentelemetry.io/collector/cmd/builder
   - go.opentelemetry.io/obi/configs/offsets/gin
   - go.opentelemetry.io/obi/configs/offsets/kafkago
@@ -29,6 +30,7 @@ excluded-modules:
   - go.opentelemetry.io/obi/examples/go-trace-api/app
   - go.opentelemetry.io/obi/internal/test/benchmarks/goshorturl
   - go.opentelemetry.io/obi/internal/test/benchmarks/goshorturl/memsql
+  - go.opentelemetry.io/obi/internal/test/integration/components/ai/openai/go
   - go.opentelemetry.io/obi/internal/test/integration/components/go-runtime-metrics-server
   - go.opentelemetry.io/obi/internal/test/integration/components/go-stat-metrics-client
   - go.opentelemetry.io/obi/internal/test/integration/components/go-stat-metrics-server
@@ -38,6 +40,7 @@ excluded-modules:
   - go.opentelemetry.io/obi/internal/test/integration/components/go_otel
   - go.opentelemetry.io/obi/internal/test/integration/components/go_otel_grpc
   - go.opentelemetry.io/obi/internal/test/integration/components/go_simple_grpc
+  - go.opentelemetry.io/obi/internal/test/integration/components/goautosdk
   - go.opentelemetry.io/obi/internal/test/integration/components/gogeneric/fiber-example
   - go.opentelemetry.io/obi/internal/test/integration/components/gokafka
   - go.opentelemetry.io/obi/internal/test/integration/components/gokafka-seg


### PR DESCRIPTION
`v0.11.0` is a minor release that activates OpenTelemetry Go Trace API auto-instrumentation, enables Configuration v2 for standalone OBI and the OBI Collector receiver, adds plain-text trace-log correlation, expands runtime and protocol coverage, and strengthens parser, lifecycle, and telemetry reliability.

### Go instrumentation and runtime metrics

- Activated automatic instrumentation for applications that use the OpenTelemetry Go Trace API without registering an SDK, including eligibility checks, optional probe orchestration, SpanContext offset discovery, and span payload export. ([#2698](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2698), [#2724](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2724), [#2810](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2810), [#2819](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2819), [#2820](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2820), [#2962](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2962))
- Expanded Go runtime telemetry with CPU, memory, scheduler, GC, and histogram metrics, and distinguished reused PIDs when attributing runtime metrics. ([#2665](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2665), [#2694](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2694), [#2740](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2740), [#2781](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2781), [#2915](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2915))
- Added Go HTTP server request-body extraction and Go HTTP/2 client payload extraction, and retained raw query strings for Go HTTP spans. ([#1941](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1941), [#2760](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2760), [#2938](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2938))

### Configuration v2

- Enabled Configuration v2 in `v0.11.0` for both standalone OBI and the OBI Collector receiver, while retaining Configuration v1 compatibility. ([#2681](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2681), [#2682](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2682))
- Added `obi config validate` and `obi config migrate` for standalone and receiver configurations, including fail-closed checks for unsupported or lossy migrations. ([#2679](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2679), [#2799](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2799), [#2943](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2943))
- Added stable declarative fields, per-rule obfuscation, unified HTTP route policies, stricter document validation, deterministic YAML export, and stronger conversion and migration parity checks. ([#2629](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2629), [#2647](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2647), [#2680](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2680), [#2700](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2700), [#2811](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2811), [#2815](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2815), [#2816](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2816), [#2817](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2817), [#2944](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2944))

> [!IMPORTANT]
> Configuration v1 remains supported. Before migrating, follow the [Config v1 to v2 migration guide](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/config/version-2.0/migration.md) and canary the generated configuration. The migrator does not automatically consume configuration supplied through environment overlays and rejects settings it cannot preserve. In receiver mode, standalone-only enrichment, correlation, daemon, and exporter settings must move to the appropriate Collector processors, service telemetry, and pipelines.

### Protocol and Generative AI coverage

- Added Aerospike client and kernel-side protocol instrumentation, together with Configuration v2 schema and protocol mappings. ([#2545](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2545), [#2839](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2839), [#2982](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2982))
- Added incremental Deno support while preventing Node.js agent injection into Deno processes. ([#2777](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2777), [#2957](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2957))
- Added OpenAI-compatible gateway support, native Ollama chat and generation instrumentation, Gemini streaming responses, and normalized OpenAI Responses content. ([#2530](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2530), [#2672](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2672), [#2710](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2710), [#2927](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2927))
- Improved GenAI semantic-convention coverage for token availability, embeddings, individual tool-call spans, tool arguments and results, and opt-in provider error status messages. ([#2588](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2588), [#2749](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2749), [#2759](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2759), [#2795](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2795), [#2804](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2804), [#2845](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2845))
- Improved SQL span names and type detection, database collection metrics, PostgreSQL namespace caching, Redis pipelines and existing connections, and multi-topic Kafka extraction and span generation. ([#2623](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2623), [#2652](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2652), [#2656](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2656), [#2663](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2663), [#2677](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2677), [#2683](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2683), [#2686](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2686), [#2693](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2693), [#2722](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2722))

### Context propagation, log correlation, and telemetry

- Added trace context to plain-text application logs with configurable field names, prefix or suffix placement, and multiline selection. JSON objects and newline-delimited JSON continue to receive structured enrichment. ([#2697](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2697))
- Improved HTTP/2 and gRPC propagation for pre-existing connections, preserved HTTP server context through response bodies, and avoided duplicate HTTP/1 `traceparent` injection. ([#2752](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2752), [#2772](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2772), [#2809](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2809))
- Reported real OTLP trace export outcomes, attached host metadata to OBI internal metrics, and expanded Weaver semantic-convention validation across integration suites. ([#2716](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2716), [#2721](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2721), [#2723](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2723), [#2785](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2785), [#2946](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2946))

### Runtime, tracing, and protocol fixes

- Fixed never-ending Go transactions, restored reliable Go process instrumentation when probes cannot be resolved, and read Go HTTP/2 stream IDs correctly on arm64. ([#2676](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2676), [#2726](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2726), [#2825](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2825))
- Fixed buffered Go channel handoff matching and shared Puma correlation maps across BPF collections. ([#2575](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2575), [#2608](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2608))
- Fixed ambiguous OTLP export detection, restored metric-provider contracts, and omitted empty HTTP methods from metrics. ([#2735](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2735), [#2879](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2879), [#2921](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2921))
- Improved Node.js script injection, inspector WebSocket handling, standard `URLPattern` route harvesting, and NestJS route expansion bounds. ([#2806](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2806), [#2812](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2812), [#2813](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2813), [#2858](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2858))

### Reliability and security hardening

- Bounded and validated malformed ELF offsets, MQTT packets, HPACK state, Mongo responses, reverse DNS messages, raw trace records, ring-buffer records, watcher events, and large-buffer integer arithmetic. ([#2569](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2569), [#2881](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2881), [#2882](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2882), [#2885](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2885), [#2887](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2887), [#2892](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2892), [#2897](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2897), [#2900](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2900), [#2901](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2901))
- Hardened tracer, PID-cache, map sizing, TC manager, and socket lifecycle behavior, including shutdown and verifier edge cases. ([#2594](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2594), [#2607](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2607), [#2613](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2613), [#2620](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2620), [#2800](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2800), [#2846](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2846), [#2854](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2854), [#2895](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2895))
- Restricted the TCP health endpoint, stopped logging process environments and attributes, and updated security-affected gRPC and `klauspost/compress` dependencies. ([#2621](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2621), [#2625](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2625), [#2841](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2841), [#2907](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2907), [#2908](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2908))

### Behavior changes and compatibility notes

> [!WARNING]
> Plain-text log enrichment is enabled by default for every service selected by the log enricher. After upgrading, non-JSON writes that were previously re-emitted unchanged receive space-separated `trace_id=... span_id=...` fields. This can break downstream parsers for structured non-JSON formats. Set `ebpf.log_enricher.plain_text.enabled: false` before upgrading to preserve the previous behavior, or set `extensions.obi.correlation.log_trace_annotation.plain_text.enabled: false` in Configuration v2. ([#2697](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2697))

- Direct OTLP consumers now receive OpenTelemetry dot-notation metric names: `target_info` is now `target.info`, `traces_target_info` is now `traces.target.info`, `traces_host_info` is now `traces.host.info`, `traces_span_metrics_calls_total` is now `traces.span.metrics.calls`, and `traces_span_metrics_duration` is now `traces.span.metrics.duration`. Prometheus metric names are unchanged. ([#2634](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2634), [#2963](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2963))
- The deprecated `application_jvm` feature alias was removed; use the shared `application_runtime` feature. ([#2909](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2909))
- Native Configuration v2 authoring uses a default-on capture policy. Omitting `capture.policy.default_action`, or using `include`, captures processes that no rule excludes; the migration command writes an explicit policy when needed to preserve Configuration v1 selection behavior. ([#2945](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2945))

### Build, validation, and release infrastructure

- Updated the project to Go 1.26.5 and `cilium/ebpf` v0.22.0. ([#2584](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2584), [#2635](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2635))
- Added BPF tests to CI, unit tests on arm64, and broader Weaver validation of OBI telemetry. ([#2770](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2770), [#2853](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2853), [#2937](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2937), [#2951](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2951))
- Added nightly releases and SHA-based image tags for `main`, and tightened Cosign verification of release artifacts. ([#2548](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2548), [#2574](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2574), [#2609](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2609))

**Full Changelog**: [v0.10.0...v0.11.0](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/compare/v0.10.0...v0.11.0)
