### PR TITLE
Stop process metadata observer on shutdown

### DIFF
--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -34,6 +34,8 @@ var containerInfoForPID = container.InfoForPID
 
 var errProcEventDecoratorStopped = errors.New("process event metadata decorator stopped")
 
+const procEventDecoratorMaxPendingProcessEvents = 1024
+
 func klog() *slog.Logger {
 	return slog.With("component", "transform.KubernetesDecorator")
 }
@@ -317,9 +319,6 @@ func (md *procEventMetadataDecorator) On(event *informer.Event) error {
 }
 
 func (md *procEventMetadataDecorator) k8sLoop(ctx context.Context) {
-	// output channel must be closed so later stages in the pipeline can finish in cascade
-	defer md.output.Close()
-
 	md.log.Debug("starting kubernetes process event decoration loop")
 	subscriptionDone := make(chan struct{})
 	go func() {
@@ -331,8 +330,11 @@ func (md *procEventMetadataDecorator) k8sLoop(ctx context.Context) {
 		md.waitForSubscription(subscriptionDone)
 		md.unsubscribeObserver(md)
 	}()
+	// output channel must be closed so later stages in the pipeline can finish in cascade
+	defer md.output.Close()
 	subscribing := (<-chan struct{})(subscriptionDone)
 	var pending []procEventDecoratorInput
+	pendingProcessEvents := 0
 
 mainLoop:
 	for {
@@ -349,6 +351,7 @@ mainLoop:
 				pending = nil
 			}
 			if event.processEvent != nil {
+				pendingProcessEvents--
 				md.handleProcessEvent(*event.processEvent)
 			} else {
 				md.handlePodEvent(*event.podEvent)
@@ -356,17 +359,23 @@ mainLoop:
 			continue
 		}
 
+		input := md.input
+		if subscribing != nil && pendingProcessEvents >= procEventDecoratorMaxPendingProcessEvents {
+			input = nil
+		}
+
 		select {
 		case <-ctx.Done():
 			break mainLoop
 		case <-subscribing:
 			subscribing = nil
-		case pe, ok := <-md.input:
+		case pe, ok := <-input:
 			if !ok {
 				break mainLoop
 			}
 			if subscribing != nil {
 				pending = append(pending, procEventDecoratorInput{processEvent: &pe})
+				pendingProcessEvents++
 			} else {
 				md.handleProcessEvent(pe)
 			}

--- a/pkg/transform/k8s.go
+++ b/pkg/transform/k8s.go
@@ -5,6 +5,7 @@ package transform // import "go.opentelemetry.io/obi/pkg/transform"
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -21,6 +22,7 @@ import (
 	ikube "go.opentelemetry.io/obi/pkg/internal/kube"
 	"go.opentelemetry.io/obi/pkg/kube"
 	"go.opentelemetry.io/obi/pkg/kube/kubecache/informer"
+	"go.opentelemetry.io/obi/pkg/kube/kubecache/meta"
 	"go.opentelemetry.io/obi/pkg/kube/kubeflags"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
@@ -29,6 +31,8 @@ import (
 )
 
 var containerInfoForPID = container.InfoForPID
+
+var errProcEventDecoratorStopped = errors.New("process event metadata decorator stopped")
 
 func klog() *slog.Logger {
 	return slog.With("component", "transform.KubernetesDecorator")
@@ -129,13 +133,17 @@ func KubeProcessEventDecoratorProvider(
 		}
 
 		decorator := &procEventMetadataDecorator{
-			log:         slog.With("component", "transform.KubeProcessEventDecoratorProvider"),
-			store:       store,
-			clusterName: KubeClusterName(ctx, cfg, ctxInfo.K8sInformer),
-			input:       input.Subscribe(msg.SubscriberName("transform.KubeProcessEventDecorator")),
-			output:      output,
-			podsInfoCh:  make(chan Event[*informer.ObjectMeta]),
-			tracker:     newPidContainerTracker(),
+			log:                 slog.With("component", "transform.KubeProcessEventDecoratorProvider"),
+			store:               store,
+			clusterName:         KubeClusterName(ctx, cfg, ctxInfo.K8sInformer),
+			input:               input.Subscribe(msg.SubscriberName("transform.KubeProcessEventDecorator")),
+			output:              output,
+			podsInfoCh:          make(chan Event[*informer.ObjectMeta]),
+			observerDone:        make(chan struct{}),
+			subscribeObserver:   store.Subscribe,
+			waitForSubscription: waitForSubscription,
+			unsubscribeObserver: store.Unsubscribe,
+			tracker:             newPidContainerTracker(),
 		}
 
 		decorator.log.Debug("starting KubeDecoratorProvider")
@@ -196,13 +204,23 @@ type Event[T any] struct {
 }
 
 type procEventMetadataDecorator struct {
-	log         *slog.Logger
-	store       *kube.Store
-	clusterName string
-	input       <-chan exec.ProcessEvent
-	output      *msg.Queue[exec.ProcessEvent]
-	podsInfoCh  chan Event[*informer.ObjectMeta]
-	tracker     *pidContainerTracker
+	log                 *slog.Logger
+	store               *kube.Store
+	clusterName         string
+	input               <-chan exec.ProcessEvent
+	output              *msg.Queue[exec.ProcessEvent]
+	podsInfoCh          chan Event[*informer.ObjectMeta]
+	observerDone        chan struct{}
+	deliveryReady       chan<- struct{}
+	subscribeObserver   func(meta.Observer)
+	waitForSubscription func(<-chan struct{})
+	unsubscribeObserver func(meta.Observer)
+	tracker             *pidContainerTracker
+}
+
+type procEventDecoratorInput struct {
+	processEvent *exec.ProcessEvent
+	podEvent     *Event[*informer.ObjectMeta]
 }
 
 type pidContainerTracker struct {
@@ -264,17 +282,38 @@ func (t *pidContainerTracker) info(containerID string) (map[app.PID]*exec.Proces
 func (md *procEventMetadataDecorator) ID() string { return "unique-proc-event-metadata-decorator-id" }
 
 func (md *procEventMetadataDecorator) On(event *informer.Event) error {
+	select {
+	case <-md.observerDone:
+		return errProcEventDecoratorStopped
+	default:
+	}
+
 	// ignoring updates on non-pod resources
 	if event.Resource == nil || event.GetResource().GetPod() == nil {
 		return nil
 	}
+	var podEvent Event[*informer.ObjectMeta]
 	switch event.Type {
 	case informer.EventType_CREATED, informer.EventType_UPDATED:
-		md.podsInfoCh <- Event[*informer.ObjectMeta]{Type: EventCreated, Obj: event.Resource}
+		podEvent = Event[*informer.ObjectMeta]{Type: EventCreated, Obj: event.Resource}
 	case informer.EventType_DELETED:
-		md.podsInfoCh <- Event[*informer.ObjectMeta]{Type: EventDeleted, Obj: event.Resource}
+		podEvent = Event[*informer.ObjectMeta]{Type: EventDeleted, Obj: event.Resource}
+	default:
+		return nil
 	}
-	return nil
+
+	if md.deliveryReady != nil {
+		select {
+		case md.deliveryReady <- struct{}{}:
+		default:
+		}
+	}
+	select {
+	case md.podsInfoCh <- podEvent:
+		return nil
+	case <-md.observerDone:
+		return errProcEventDecoratorStopped
+	}
 }
 
 func (md *procEventMetadataDecorator) k8sLoop(ctx context.Context) {
@@ -282,52 +321,105 @@ func (md *procEventMetadataDecorator) k8sLoop(ctx context.Context) {
 	defer md.output.Close()
 
 	md.log.Debug("starting kubernetes process event decoration loop")
-	go md.store.Subscribe(md)
+	subscriptionDone := make(chan struct{})
+	go func() {
+		defer close(subscriptionDone)
+		md.subscribeObserver(md)
+	}()
+	defer func() {
+		close(md.observerDone)
+		md.waitForSubscription(subscriptionDone)
+		md.unsubscribeObserver(md)
+	}()
+	subscribing := (<-chan struct{})(subscriptionDone)
+	var pending []procEventDecoratorInput
 
 mainLoop:
 	for {
+		if subscribing == nil && len(pending) > 0 {
+			select {
+			case <-ctx.Done():
+				break mainLoop
+			default:
+			}
+			event := pending[0]
+			pending[0] = procEventDecoratorInput{}
+			pending = pending[1:]
+			if len(pending) == 0 {
+				pending = nil
+			}
+			if event.processEvent != nil {
+				md.handleProcessEvent(*event.processEvent)
+			} else {
+				md.handlePodEvent(*event.podEvent)
+			}
+			continue
+		}
+
 		select {
 		case <-ctx.Done():
 			break mainLoop
+		case <-subscribing:
+			subscribing = nil
 		case pe, ok := <-md.input:
 			if !ok {
 				break mainLoop
 			}
-			md.log.Debug("annotating process event", "event", pe)
-
-			if podMeta, containerName := md.store.PodContainerByPIDNs(pe.File.Ns(), pe.File.Pid()); podMeta != nil {
-				AppendKubeMetadata(md.store, pe.File, podMeta, md.clusterName, containerName)
+			if subscribing != nil {
+				pending = append(pending, procEventDecoratorInput{processEvent: &pe})
 			} else {
-				// do not leave the service attributes map as nil
-				pe.File.SetMetadata(map[attr.Name]string{})
-
-				md.log.Debug("no metadata for event", "event", pe)
-
-				if pe.Type == exec.ProcessEventCreated {
-					if containerInfo, err := md.getContainerInfo(pe.File.Pid()); err == nil {
-						md.log.Debug("storing pid info", "pid", pe.File.Pid(), "containerId", containerInfo.ContainerID)
-						md.tracker.track(containerInfo.ContainerID, &pe)
-					}
-				} else {
-					md.tracker.remove(pe.File.Pid())
-				}
+				md.handleProcessEvent(pe)
 			}
-
-			// in-place decoration and forwarding
-			md.output.Send(pe)
 		case podEvent := <-md.podsInfoCh:
-			switch podEvent.Type {
-			case EventCreated:
-				md.log.Debug("created pod event", "pod", podEvent.Obj.Name, "namespace", podEvent.Obj.Namespace)
-				md.handlePodUpdateEvent(podEvent.Obj)
-			case EventDeleted:
-				md.cleanupPodData(podEvent.Obj)
-				md.log.Debug("deleted pod event", "pod", podEvent.Obj.Name, "namespace", podEvent.Obj.Namespace)
+			if subscribing != nil {
+				pending = append(pending, procEventDecoratorInput{podEvent: &podEvent})
+			} else {
+				md.handlePodEvent(podEvent)
 			}
 		}
 	}
 
 	md.log.Debug("stopping kubernetes process event decoration loop")
+}
+
+func waitForSubscription(done <-chan struct{}) {
+	<-done
+}
+
+func (md *procEventMetadataDecorator) handleProcessEvent(pe exec.ProcessEvent) {
+	md.log.Debug("annotating process event", "event", pe)
+
+	if podMeta, containerName := md.store.PodContainerByPIDNs(pe.File.Ns(), pe.File.Pid()); podMeta != nil {
+		AppendKubeMetadata(md.store, pe.File, podMeta, md.clusterName, containerName)
+	} else {
+		// do not leave the service attributes map as nil
+		pe.File.SetMetadata(map[attr.Name]string{})
+
+		md.log.Debug("no metadata for event", "event", pe)
+
+		if pe.Type == exec.ProcessEventCreated {
+			if containerInfo, err := md.getContainerInfo(pe.File.Pid()); err == nil {
+				md.log.Debug("storing pid info", "pid", pe.File.Pid(), "containerId", containerInfo.ContainerID)
+				md.tracker.track(containerInfo.ContainerID, &pe)
+			}
+		} else {
+			md.tracker.remove(pe.File.Pid())
+		}
+	}
+
+	// in-place decoration and forwarding
+	md.output.Send(pe)
+}
+
+func (md *procEventMetadataDecorator) handlePodEvent(podEvent Event[*informer.ObjectMeta]) {
+	switch podEvent.Type {
+	case EventCreated:
+		md.log.Debug("created pod event", "pod", podEvent.Obj.Name, "namespace", podEvent.Obj.Namespace)
+		md.handlePodUpdateEvent(podEvent.Obj)
+	case EventDeleted:
+		md.cleanupPodData(podEvent.Obj)
+		md.log.Debug("deleted pod event", "pod", podEvent.Obj.Name, "namespace", podEvent.Obj.Namespace)
+	}
 }
 
 func (md *procEventMetadataDecorator) getContainerInfo(pid app.PID) (container.Info, error) {

--- a/pkg/transform/k8s_test.go
+++ b/pkg/transform/k8s_test.go
@@ -933,6 +933,57 @@ func TestProcEventMetadataDecoratorDefersCachedReplayHandling(t *testing.T) {
 	requireOutputClosed(t, h.output)
 }
 
+func TestProcEventMetadataDecoratorBoundsPendingProcessEvents(t *testing.T) {
+	h := newProcEventDecoratorHarness(t)
+
+	subscribeStarted := make(chan struct{})
+	allowSubscribe := make(chan struct{})
+	h.decorator.subscribeObserver = func(meta.Observer) {
+		close(subscribeStarted)
+		<-allowSubscribe
+	}
+
+	cancel, done := h.start(t)
+	select {
+	case <-subscribeStarted:
+	case <-time.After(timeout):
+		t.Fatal("decorator subscription did not start")
+	}
+
+	inputAccepted := make(chan struct{})
+	senderDone := make(chan struct{})
+	go func() {
+		defer close(senderDone)
+		for i := 0; i <= procEventDecoratorMaxPendingProcessEvents; i++ {
+			h.input <- procEventDecoratorProcessEvent(app.PID(i + 1))
+			inputAccepted <- struct{}{}
+		}
+	}()
+	for range procEventDecoratorMaxPendingProcessEvents {
+		testutil.ReadChannel(t, inputAccepted, timeout)
+	}
+	select {
+	case <-inputAccepted:
+		t.Fatal("decorator accepted process input beyond the pending limit")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	podDelivered := make(chan error, 1)
+	go func() {
+		podDelivered <- h.decorator.On(procEventDecoratorPodEvent("cached-pod", 1))
+	}()
+	require.NoError(t, testutil.ReadChannel(t, podDelivered, timeout))
+
+	cancel()
+	close(allowSubscribe)
+	waitForLoop(t, done)
+	requireOutputClosed(t, h.output)
+
+	testutil.ReadChannel(t, h.input, timeout)
+	testutil.ReadChannel(t, inputAccepted, timeout)
+	testutil.ReadChannel(t, senderDone, timeout)
+}
+
 func TestProcEventMetadataDecoratorShutdown(t *testing.T) {
 	tests := map[string]func(context.CancelFunc, chan exec.ProcessEvent){
 		"context cancellation": func(cancel context.CancelFunc, _ chan exec.ProcessEvent) {
@@ -1021,6 +1072,7 @@ func TestProcEventMetadataDecoratorWaitsForLateSubscription(t *testing.T) {
 	case <-time.After(timeout):
 		t.Fatal("decorator did not wait for its pending subscription")
 	}
+	requireOutputClosed(t, h.output)
 	select {
 	case <-unsubscribed:
 		t.Fatal("decorator unsubscribed before its pending subscription completed")

--- a/pkg/transform/k8s_test.go
+++ b/pkg/transform/k8s_test.go
@@ -4,8 +4,10 @@
 package transform
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,6 +31,11 @@ import (
 const timeout = 5 * time.Second
 
 func TestDecoration(t *testing.T) {
+	originalInfoForPID := kube.InfoForPID
+	t.Cleanup(func() {
+		kube.InfoForPID = originalInfoForPID
+	})
+
 	inf := &fakeInformer{}
 	store := kube.NewStore(inf, kube.ResourceLabels{
 		"service.name":      []string{"app.kubernetes.io/name"},
@@ -346,6 +353,13 @@ func TestDecoration(t *testing.T) {
 }
 
 func TestDecorationProcessEvents(t *testing.T) {
+	originalInfoForPID := kube.InfoForPID
+	originalContainerInfoForPID := containerInfoForPID
+	t.Cleanup(func() {
+		kube.InfoForPID = originalInfoForPID
+		containerInfoForPID = originalContainerInfoForPID
+	})
+
 	inf := &fakeInformer{}
 	store := kube.NewStore(inf, kube.ResourceLabels{
 		"service.name":      []string{"app.kubernetes.io/name"},
@@ -390,18 +404,31 @@ func TestDecorationProcessEvents(t *testing.T) {
 	podInfoCh := make(chan Event[*informer.ObjectMeta])
 
 	dec := &procEventMetadataDecorator{
-		log:         slog.With("component", "transform.KubeProcessEventDecoratorProvider"),
-		store:       store,
-		clusterName: "the-cluster",
-		input:       inputQueue.Subscribe(msg.SubscriberName("transform.KubeProcessEventDecorator")),
-		output:      msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(10)),
-		podsInfoCh:  podInfoCh,
-		tracker:     newPidContainerTracker(),
+		log:                 slog.With("component", "transform.KubeProcessEventDecoratorProvider"),
+		store:               store,
+		clusterName:         "the-cluster",
+		input:               inputQueue.Subscribe(msg.SubscriberName("transform.KubeProcessEventDecorator")),
+		output:              msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(10)),
+		podsInfoCh:          podInfoCh,
+		observerDone:        make(chan struct{}),
+		subscribeObserver:   store.Subscribe,
+		waitForSubscription: waitForSubscription,
+		unsubscribeObserver: store.Unsubscribe,
+		tracker:             newPidContainerTracker(),
 	}
 
 	outputCh := dec.output.Subscribe()
-	defer inputQueue.Close()
-	go dec.k8sLoop(t.Context())
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		dec.k8sLoop(ctx)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		inputQueue.Close()
+		waitForLoop(t, done)
+	})
 
 	autoNameSvc := svc.Attrs{}
 	autoNameSvc.SetAutoName()
@@ -565,6 +592,452 @@ func TestDecorationProcessEvents(t *testing.T) {
 
 	// no more events
 	testutil.ChannelEmpty(t, outputCh, 100*time.Millisecond)
+}
+
+type procEventDecoratorHarness struct {
+	decorator   *procEventMetadataDecorator
+	store       *kube.Store
+	input       chan exec.ProcessEvent
+	output      <-chan exec.ProcessEvent
+	outputQueue *msg.Queue[exec.ProcessEvent]
+	cancel      context.CancelFunc
+	loopDone    <-chan struct{}
+}
+
+func newProcEventDecoratorHarness(t *testing.T) *procEventDecoratorHarness {
+	t.Helper()
+
+	originalInfoForPID := kube.InfoForPID
+	kube.InfoForPID = func(pid app.PID) (container.Info, error) {
+		return container.Info{
+			ContainerID:  fmt.Sprintf("container-%d", pid),
+			PIDNamespace: 1000 + uint32(pid),
+		}, nil
+	}
+	t.Cleanup(func() {
+		kube.InfoForPID = originalInfoForPID
+	})
+
+	notifier := meta.NewBaseNotifier(slog.Default())
+	store := kube.NewStore(&notifier, nil, nil, imetrics.NoopReporter{})
+	input := make(chan exec.ProcessEvent)
+	output := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(10))
+	decorator := &procEventMetadataDecorator{
+		log:                 slog.With("component", "transform.KubeProcessEventDecoratorProvider"),
+		store:               store,
+		clusterName:         "the-cluster",
+		input:               input,
+		output:              output,
+		podsInfoCh:          make(chan Event[*informer.ObjectMeta]),
+		observerDone:        make(chan struct{}),
+		subscribeObserver:   store.Subscribe,
+		waitForSubscription: waitForSubscription,
+		unsubscribeObserver: store.Unsubscribe,
+		tracker:             newPidContainerTracker(),
+	}
+	harness := &procEventDecoratorHarness{
+		decorator:   decorator,
+		store:       store,
+		input:       input,
+		output:      output.Subscribe(),
+		outputQueue: output,
+	}
+	t.Cleanup(func() {
+		if harness.cancel != nil {
+			harness.cancel()
+		}
+		if harness.loopDone != nil {
+			select {
+			case <-harness.loopDone:
+			case <-time.After(timeout):
+				t.Errorf("kubernetes process event decoration loop leaked")
+			}
+		}
+		harness.outputQueue.Close()
+		store.Unsubscribe(decorator)
+	})
+
+	return harness
+}
+
+func (h *procEventDecoratorHarness) addTrackedPod(t *testing.T, pid app.PID, name string) {
+	t.Helper()
+
+	h.store.AddProcess(pid)
+	processEvent := procEventDecoratorProcessEvent(pid)
+	h.decorator.tracker.track(fmt.Sprintf("container-%d", pid), &processEvent)
+	require.NoError(t, h.store.On(procEventDecoratorPodEvent(name, pid)))
+}
+
+func (h *procEventDecoratorHarness) start(t *testing.T) (context.CancelFunc, <-chan struct{}) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	h.cancel = cancel
+	h.loopDone = done
+	go func() {
+		h.decorator.k8sLoop(ctx)
+		close(done)
+	}()
+	return cancel, done
+}
+
+func procEventDecoratorPodEvent(name string, pid app.PID) *informer.Event {
+	return &informer.Event{
+		Type: informer.EventType_CREATED,
+		Resource: &informer.ObjectMeta{
+			Name:      name,
+			Namespace: "the-ns",
+			Kind:      "Pod",
+			Pod: &informer.PodInfo{
+				Uid:        "uid-" + name,
+				Containers: []*informer.ContainerInfo{{Name: "app", Id: fmt.Sprintf("container-%d", pid)}},
+			},
+		},
+	}
+}
+
+func procEventDecoratorProcessEvent(pid app.PID) exec.ProcessEvent {
+	service := svc.Attrs{}
+	service.SetAutoName()
+	return exec.ProcessEvent{
+		File: exec.New(exec.Init{Pid: pid, Ns: 1000 + uint32(pid), Service: service}),
+		Type: exec.ProcessEventCreated,
+	}
+}
+
+func waitForLoop(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("kubernetes process event decoration loop did not stop")
+	}
+}
+
+func requireOutputClosed(t *testing.T, output <-chan exec.ProcessEvent) {
+	t.Helper()
+	select {
+	case _, ok := <-output:
+		require.False(t, ok, "decorator output remained open after loop exit")
+	case <-time.After(timeout):
+		t.Fatal("decorator output remained open after loop exit")
+	}
+}
+
+func requirePodNotifyReturns(t *testing.T, h *procEventDecoratorHarness) {
+	t.Helper()
+	notifyDone := make(chan struct{})
+	go func() {
+		h.store.Notify(procEventDecoratorPodEvent("after-shutdown", 99))
+		close(notifyDone)
+	}()
+
+	select {
+	case <-notifyDone:
+		return
+	case <-time.After(timeout):
+	}
+
+	// Release the callback before failing so the regression test cannot leak a
+	// goroutine when run against the broken implementation.
+	select {
+	case <-h.decorator.podsInfoCh:
+	case <-time.After(timeout):
+		t.Fatal("failed to release blocked pod notification")
+	}
+	select {
+	case <-notifyDone:
+	case <-time.After(timeout):
+		t.Fatal("pod notification remained blocked after the callback was released")
+	}
+	t.Fatal("pod notification blocked after decorator shutdown")
+}
+
+func TestProcEventMetadataDecoratorStopsInFlightDelivery(t *testing.T) {
+	h := newProcEventDecoratorHarness(t)
+	deliveryReady := make(chan struct{}, 1)
+	h.decorator.deliveryReady = deliveryReady
+	deliveryResult := make(chan error, 1)
+	deliveryDone := make(chan struct{})
+	go func() {
+		defer close(deliveryDone)
+		deliveryResult <- h.decorator.On(procEventDecoratorPodEvent("in-flight", 1))
+	}()
+	var stopOnce sync.Once
+	stopObserver := func() {
+		stopOnce.Do(func() {
+			close(h.decorator.observerDone)
+		})
+	}
+	t.Cleanup(func() {
+		stopObserver()
+		select {
+		case <-deliveryDone:
+			return
+		case <-h.decorator.podsInfoCh:
+		case <-time.After(timeout):
+			t.Errorf("in-flight pod callback could not be released")
+			return
+		}
+		select {
+		case <-deliveryDone:
+		case <-time.After(timeout):
+			t.Errorf("in-flight pod callback leaked")
+		}
+	})
+
+	select {
+	case <-deliveryReady:
+	case <-time.After(timeout):
+		t.Fatal("pod callback did not reach the delivery handoff")
+	}
+	stopObserver()
+	select {
+	case err := <-deliveryResult:
+		require.ErrorIs(t, err, errProcEventDecoratorStopped)
+	case <-time.After(timeout):
+		t.Fatal("in-flight pod delivery did not observe observer shutdown")
+	}
+}
+
+func TestProcEventMetadataDecoratorCachedAndLiveDelivery(t *testing.T) {
+	h := newProcEventDecoratorHarness(t)
+	h.addTrackedPod(t, 1, "cached-pod")
+	h.addTrackedPod(t, 2, "second-cached-pod")
+
+	cancel, done := h.start(t)
+
+	cached := []string{
+		testutil.ReadChannel(t, h.output, timeout).File.ServiceAttrs().UID.Instance,
+		testutil.ReadChannel(t, h.output, timeout).File.ServiceAttrs().UID.Instance,
+	}
+	require.ElementsMatch(t, []string{"the-ns.cached-pod.app", "the-ns.second-cached-pod.app"}, cached)
+
+	h.addTrackedPod(t, 3, "live-pod")
+	live := testutil.ReadChannel(t, h.output, timeout)
+	require.Equal(t, "the-ns.live-pod.app", live.File.ServiceAttrs().UID.Instance)
+
+	cancel()
+	waitForLoop(t, done)
+	requireOutputClosed(t, h.output)
+}
+
+type gatedReplayObserver struct {
+	meta.Observer
+	delivered chan<- struct{}
+	release   <-chan struct{}
+	once      sync.Once
+}
+
+func (g *gatedReplayObserver) On(event *informer.Event) error {
+	err := g.Observer.On(event)
+	g.once.Do(func() {
+		g.delivered <- struct{}{}
+		<-g.release
+	})
+	return err
+}
+
+func TestProcEventMetadataDecoratorDefersCachedReplayHandling(t *testing.T) {
+	h := newProcEventDecoratorHarness(t)
+	h.addTrackedPod(t, 1, "cached-pod")
+
+	replayDelivered := make(chan struct{}, 1)
+	releaseReplay := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseReplay)
+		})
+	}
+	t.Cleanup(release)
+	h.decorator.subscribeObserver = func(observer meta.Observer) {
+		h.store.Subscribe(&gatedReplayObserver{
+			Observer:  observer,
+			delivered: replayDelivered,
+			release:   releaseReplay,
+		})
+	}
+
+	cancel, done := h.start(t)
+	select {
+	case <-replayDelivered:
+	case <-time.After(timeout):
+		t.Fatal("cached replay did not reach the decorator")
+	}
+
+	writerDone := make(chan struct{})
+	go func() {
+		h.store.AddProcess(2)
+		close(writerDone)
+	}()
+	t.Cleanup(func() {
+		release()
+		select {
+		case <-writerDone:
+		case <-time.After(timeout):
+			t.Errorf("store writer leaked")
+		}
+	})
+
+	inputAccepted := make(chan struct{})
+	go func() {
+		h.input <- procEventDecoratorProcessEvent(2)
+		close(inputAccepted)
+	}()
+	t.Cleanup(func() {
+		select {
+		case <-inputAccepted:
+			return
+		default:
+		}
+		select {
+		case <-h.input:
+		case <-inputAccepted:
+		case <-time.After(timeout):
+			t.Errorf("staged process event could not be released")
+			return
+		}
+		select {
+		case <-inputAccepted:
+		case <-time.After(timeout):
+			t.Errorf("staged process event sender leaked")
+		}
+	})
+	select {
+	case <-inputAccepted:
+	case <-time.After(timeout):
+		t.Fatal("process event was not staged during cached replay")
+	}
+	select {
+	case <-h.output:
+		t.Fatal("decorator handled cached replay before subscription completed")
+	default:
+	}
+
+	release()
+	select {
+	case <-writerDone:
+	case <-time.After(timeout):
+		t.Fatal("store writer remained blocked after cached replay")
+	}
+
+	cached := testutil.ReadChannel(t, h.output, timeout)
+	require.Equal(t, "the-ns.cached-pod.app", cached.File.ServiceAttrs().UID.Instance)
+	testutil.ReadChannel(t, h.output, timeout)
+
+	cancel()
+	waitForLoop(t, done)
+	requireOutputClosed(t, h.output)
+}
+
+func TestProcEventMetadataDecoratorShutdown(t *testing.T) {
+	tests := map[string]func(context.CancelFunc, chan exec.ProcessEvent){
+		"context cancellation": func(cancel context.CancelFunc, _ chan exec.ProcessEvent) {
+			cancel()
+		},
+		"input closure": func(_ context.CancelFunc, input chan exec.ProcessEvent) {
+			close(input)
+		},
+	}
+
+	for name, shutdown := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := newProcEventDecoratorHarness(t)
+			h.addTrackedPod(t, 1, "cached-pod")
+
+			cancel, done := h.start(t)
+			decorated := testutil.ReadChannel(t, h.output, timeout)
+			require.Equal(t, "the-ns.cached-pod.app", decorated.File.ServiceAttrs().UID.Instance)
+
+			shutdown(cancel, h.input)
+			waitForLoop(t, done)
+			requireOutputClosed(t, h.output)
+			h.decorator.observerDone = make(chan struct{})
+			requirePodNotifyReturns(t, h)
+		})
+	}
+}
+
+func TestProcEventMetadataDecoratorWaitsForLateSubscription(t *testing.T) {
+	h := newProcEventDecoratorHarness(t)
+
+	subscribeStarted := make(chan struct{})
+	allowSubscribe := make(chan struct{})
+	var allowSubscribeOnce sync.Once
+	releaseSubscribe := func() {
+		allowSubscribeOnce.Do(func() {
+			close(allowSubscribe)
+		})
+	}
+	t.Cleanup(releaseSubscribe)
+	subscribeObserver := h.decorator.subscribeObserver
+	h.decorator.subscribeObserver = func(observer meta.Observer) {
+		close(subscribeStarted)
+		<-allowSubscribe
+		subscribeObserver(observer)
+	}
+
+	waitStarted := make(chan struct{})
+	allowWait := make(chan struct{})
+	var allowWaitOnce sync.Once
+	releaseWait := func() {
+		allowWaitOnce.Do(func() {
+			close(allowWait)
+		})
+	}
+	t.Cleanup(releaseWait)
+	waitForSubscription := h.decorator.waitForSubscription
+	h.decorator.waitForSubscription = func(done <-chan struct{}) {
+		close(waitStarted)
+		<-allowWait
+		waitForSubscription(done)
+	}
+
+	unsubscribed := make(chan struct{})
+	unsubscribeObserver := h.decorator.unsubscribeObserver
+	h.decorator.unsubscribeObserver = func(observer meta.Observer) {
+		unsubscribeObserver(observer)
+		close(unsubscribed)
+	}
+
+	_, done := h.start(t)
+	select {
+	case <-subscribeStarted:
+	case <-time.After(timeout):
+		t.Fatal("decorator subscription did not start")
+	}
+
+	close(h.input)
+	select {
+	case <-h.decorator.observerDone:
+	case <-time.After(timeout):
+		t.Fatal("decorator did not begin observer shutdown")
+	}
+	select {
+	case <-waitStarted:
+	case <-time.After(timeout):
+		t.Fatal("decorator did not wait for its pending subscription")
+	}
+	select {
+	case <-unsubscribed:
+		t.Fatal("decorator unsubscribed before its pending subscription completed")
+	default:
+	}
+
+	releaseSubscribe()
+	releaseWait()
+	waitForLoop(t, done)
+	select {
+	case <-unsubscribed:
+	default:
+		t.Fatal("decorator did not unsubscribe after its pending subscription completed")
+	}
+	requireOutputClosed(t, h.output)
+	h.decorator.observerDone = make(chan struct{})
+	requirePodNotifyReturns(t, h)
 }
 
 type fakeInformer struct {


### PR DESCRIPTION
## Summary

Stop the process-event Kubernetes metadata observer when its decoration loop exits.

The observer previously remained registered after context cancellation or input closure. A later pod notification could block forever on the decorator's unbuffered channel while `BaseNotifier` held its read lock, stalling metadata fanout.

## Lifecycle guarantees

- Pod callbacks select on an observer stop signal, so an in-flight delivery can return during shutdown.
- Shutdown closes that signal, waits for the asynchronous subscription to finish, and then unsubscribes. This prevents a late subscription from registering after cleanup.
- Inputs received during synchronous cached replay are staged in receive order and handled only after replay releases the store read lock. This preserves cached replay while avoiding a queued-writer/reentrant-read deadlock.
- Context cancellation and input-channel closure follow the same teardown path, and output closure remains unchanged.
- Generic notifier ordering and backpressure semantics are unchanged; the broader fanout work remains scoped to #1831.

## Validation

Passed:

- Focused lifecycle tests, 100 repetitions
- Focused race-detector tests, 50 repetitions
- `go test -race -timeout 5m ./pkg/transform`
- Shuffled affected tests under the race detector
- `make test license-header-check` (including `go test -short -race -a ./...`)
- Diff-aware `golangci-lint` for `pkg/transform`
- `gofumpt`, `goimports`, and `git diff --check`
- `make generate` with no generated-file changes

`make verify` completes prerequisite, module-tidy, vanity-import, dependency-policy, and analyzer checks, then stops on three unchanged formatting failures already present in the base:

- `pkg/transform/name_resolver.go:216`
- `pkg/transform/routes.go:322`
- `pkg/transform/routes_test.go:333`

## Tests

Regression coverage includes cached and live pod delivery, context cancellation, input closure, post-shutdown notification, in-flight delivery cancellation, output closure, store-writer progress during cached replay, and a subscription completing after shutdown starts.

Residual follow-up: #1831 still tracks generic synchronous notifier fanout behavior.

Fixes #1830