### PR TITLE
Stabilize Java nested trace assertions

### DIFF
--- a/internal/test/integration/java_dist_test.go
+++ b/internal/test/integration/java_dist_test.go
@@ -29,7 +29,6 @@ func testJavaNestedTraces(t *testing.T, slug string) {
 	// give enough time for the Java injector to finish and to
 	// harvest the routes
 	t.Log("checking proper server to client nesting for [/api/" + slug + "]")
-	var trace jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		ti.DoHTTPGet(ct, "http://localhost:8081/api/"+slug+"?url=https://httpbin.org/get", 200)
 
@@ -43,11 +42,17 @@ func testJavaNestedTraces(t *testing.T, slug string) {
 		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
 		traces := tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/api/" + slug})
 		require.GreaterOrEqual(ct, len(traces), 1)
-		trace = traces[0]
-		res := trace.FindByOperationName("GET /get", "client")
-		require.Len(ct, res, 1)
-		child := res[0]
-		require.NotEmpty(ct, child.TraceID)
+		// Client spans can arrive after their server span, leaving the newest trace incomplete.
+		for _, trace := range traces {
+			res := trace.FindByOperationName("GET /get", "client")
+			if len(res) == 0 {
+				continue
+			}
+			require.Len(ct, res, 1)
+			require.NotEmpty(ct, res[0].TraceID)
+			return
+		}
+		require.Fail(ct, "client span not found in matching traces")
 	}, 2*time.Minute, 5*time.Second)
 }
 


### PR DESCRIPTION
## Summary

- search all matching Java server traces for a completed nested client span
- retain the assertion that the selected trace contains exactly one client span

## Root cause

`testJavaNestedTraces` creates a request on every polling attempt and previously inspected only the first trace returned by Jaeger. Java client spans can be exported after their server span, so the newest trace can remain incomplete while an earlier request becomes complete. Replacing the newest request on each poll can therefore keep the test chasing an incomplete trace until it times out.

## Validation

- `git diff --check`
- `go test -c -o /tmp/obi-integration.test ./internal/test/integration`
- `go vet ./internal/test/integration`
- `golangci-lint run ./internal/test/integration --timeout=6m`
