### PR TITLE
feat(metrics): export eBPF probe latency as a pre-aggregated OTLP histogram

### DIFF
--- a/devdocs/bpf-metrics-collection.md
+++ b/devdocs/bpf-metrics-collection.md
@@ -46,8 +46,8 @@ If both paths are active, each path owns a separate collector.
 
 | Prometheus metric | OpenTelemetry metric | Value |
 | --- | --- | --- |
-| `obi_bpf_probe_executions_total` | `obi.bpf.probe.executions` | Probe executions |
-| `obi_bpf_probe_latency_seconds_total` | `obi.bpf.probe.latency_seconds_total` | Total probe runtime in seconds |
+| `obi_bpf_probe_executions_total` | *(none: see `obi.bpf.probe.latency` count)* | Probe executions |
+| `obi_bpf_probe_latency_seconds_total` | `obi.bpf.probe.latency` | Probe latency distribution in seconds |
 | `obi_bpf_map_entries_total` | `obi.bpf.map.entries_total` | Current map entry count |
 | `obi_bpf_map_max_entries_total` | `obi.bpf.map.max_entries_total` | Configured maximum map entries |
 

--- a/internal/test/integration/internal_metrics_otel_test.go
+++ b/internal/test/integration/internal_metrics_otel_test.go
@@ -31,8 +31,7 @@ var internalMetricsExpected = []string{
 	"obi_otel_metric_exports_total",       // counter, every metric export
 	"obi_bpf_map_entries_total",           // gauge, per eBPF map
 	"obi_bpf_map_max_entries_total",       // gauge, per eBPF map
-	"obi_bpf_probe_executions_total",      // counter, needs BPF run-stats + traffic
-	"obi_bpf_probe_latency_seconds_total", // counter, needs BPF run-stats + traffic
+	"obi_bpf_probe_latency_seconds_count", // histogram, needs BPF run-stats + traffic
 }
 
 // TestInternalOTelMetrics brings up OBI with internal_metrics.exporter=otel so

--- a/pkg/export/imetrics/imetrics.go
+++ b/pkg/export/imetrics/imetrics.go
@@ -87,8 +87,11 @@ type Reporter interface {
 	AvoidInstrumentationMetrics(serviceName, serviceNamespace, serviceInstanceID string)
 	// AvoidInstrumentationTraces is invoked every time a service is avoided due to OTLP traces detection
 	AvoidInstrumentationTraces(serviceName, serviceNamespace, serviceInstanceID string)
-	// BpfProbeStats is invoked every time aggregate BPF probe stats are recorded for a scrape interval
-	BpfProbeStats(probeID, probeType, probeName string, count uint64, latencySumSeconds float64)
+	// BpfProbeStats is invoked every time aggregate BPF probe stats are recorded for a scrape
+	// interval. latencyBuckets holds the cumulative observation count per upper bound in
+	// BpfLatenciesBuckets; the caller retains ownership, so implementations must copy it to
+	// retain it. It is nil when the caller does not track a distribution.
+	BpfProbeStats(probeID, probeType, probeName string, count uint64, latencySumSeconds float64, latencyBuckets map[float64]uint64)
 	// BpfMapEntries is invoked every time a BPF map size is recorded
 	BpfMapEntries(mapID, mapName, mapType string, entriesTotal int)
 	// BpfMapMaxEntries is invoked every time a BPF map max size is recorded
@@ -121,22 +124,22 @@ func IsBuiltinNoopReporter(reporter Reporter) bool {
 // NoopReporter is a metrics Reporter that just does nothing
 type NoopReporter struct{}
 
-func (n NoopReporter) Start(_ context.Context)                           {}
-func (n NoopReporter) TracerFlush(_ int)                                 {}
-func (n NoopReporter) OTELMetricExport(_ int)                            {}
-func (n NoopReporter) OTELMetricExportError(_ error)                     {}
-func (n NoopReporter) OTELTraceExport(_ int)                             {}
-func (n NoopReporter) OTELTraceExportError(_ error)                      {}
-func (n NoopReporter) PrometheusRequest(_, _ string)                     {}
-func (n NoopReporter) InstrumentProcess(_ string)                        {}
-func (n NoopReporter) UninstrumentProcess(_ string)                      {}
-func (n NoopReporter) InstrumentationError(_, _ string)                  {}
-func (n NoopReporter) AvoidInstrumentationMetrics(_, _, _ string)        {}
-func (n NoopReporter) AvoidInstrumentationTraces(_, _, _ string)         {}
-func (n NoopReporter) BpfProbeStats(_, _, _ string, _ uint64, _ float64) {}
-func (n NoopReporter) BpfMapEntries(_, _, _ string, _ int)               {}
-func (n NoopReporter) BpfMapMaxEntries(_, _, _ string, _ int)            {}
-func (n NoopReporter) BpfInternalMetricsScrapeInterval() time.Duration   { return 0 }
-func (n NoopReporter) InformerLag(_ float64)                             {}
-func (n NoopReporter) BPFPacketStats(_, _ uint64)                        {}
-func (n NoopReporter) QueueBufferUtilization(_ string, _ float64)        {}
+func (n NoopReporter) Start(_ context.Context)                                                 {}
+func (n NoopReporter) TracerFlush(_ int)                                                       {}
+func (n NoopReporter) OTELMetricExport(_ int)                                                  {}
+func (n NoopReporter) OTELMetricExportError(_ error)                                           {}
+func (n NoopReporter) OTELTraceExport(_ int)                                                   {}
+func (n NoopReporter) OTELTraceExportError(_ error)                                            {}
+func (n NoopReporter) PrometheusRequest(_, _ string)                                           {}
+func (n NoopReporter) InstrumentProcess(_ string)                                              {}
+func (n NoopReporter) UninstrumentProcess(_ string)                                            {}
+func (n NoopReporter) InstrumentationError(_, _ string)                                        {}
+func (n NoopReporter) AvoidInstrumentationMetrics(_, _, _ string)                              {}
+func (n NoopReporter) AvoidInstrumentationTraces(_, _, _ string)                               {}
+func (n NoopReporter) BpfProbeStats(_, _, _ string, _ uint64, _ float64, _ map[float64]uint64) {}
+func (n NoopReporter) BpfMapEntries(_, _, _ string, _ int)                                     {}
+func (n NoopReporter) BpfMapMaxEntries(_, _, _ string, _ int)                                  {}
+func (n NoopReporter) BpfInternalMetricsScrapeInterval() time.Duration                         { return 0 }
+func (n NoopReporter) InformerLag(_ float64)                                                   {}
+func (n NoopReporter) BPFPacketStats(_, _ uint64)                                              {}
+func (n NoopReporter) QueueBufferUtilization(_ string, _ float64)                              {}

--- a/pkg/export/imetrics/imetrics_test.go
+++ b/pkg/export/imetrics/imetrics_test.go
@@ -63,7 +63,8 @@ type noopEmbeddingReporter struct {
 	NoopReporter
 }
 
-func (n *noopEmbeddingReporter) BpfProbeStats(_, _, _ string, _ uint64, _ float64) {}
+func (n *noopEmbeddingReporter) BpfProbeStats(_, _, _ string, _ uint64, _ float64, _ map[float64]uint64) {
+}
 
 func TestPrometheusReporterAvoidedServicesBounded(t *testing.T) {
 	registry := prometheus.NewRegistry()

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -250,7 +250,7 @@ func (p *PrometheusReporter) AvoidInstrumentationTraces(serviceName, serviceName
 	p.recordAvoidedService(serviceName, serviceNamespace, serviceInstanceID, "traces")
 }
 
-func (p *PrometheusReporter) BpfProbeStats(probeID, probeType, probeName string, count uint64, latencySumSeconds float64) {
+func (p *PrometheusReporter) BpfProbeStats(probeID, probeType, probeName string, count uint64, latencySumSeconds float64, _ map[float64]uint64) {
 	p.bpfProbeExecutions.WithLabelValues(probeID, probeType, probeName).Add(float64(count))
 	p.bpfProbeLatencySum.WithLabelValues(probeID, probeType, probeName).Add(latencySumSeconds)
 }

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -26,6 +26,8 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/global"
 )
 
+const internalMetricsMeterName = "obi_internal"
+
 // InternalMetricsReporter is an internal metrics Reporter that exports to OTEL
 type InternalMetricsReporter struct {
 	ctx                              context.Context
@@ -39,8 +41,7 @@ type InternalMetricsReporter struct {
 	avoidedServices                  instrument.Int64Gauge
 	avoidedServicesLimiter           *avoidedsvc.Limiter
 	buildInfo                        instrument.Int64Gauge
-	bpfProbeExecutions               instrument.Int64Counter
-	bpfProbeLatencySum               instrument.Float64Counter
+	bpfProbeLatency                  *bpfProbeLatencyProducer
 	bpfMapEntries                    instrument.Int64Gauge
 	bpfMapMaxEntries                 instrument.Int64Gauge
 	bpfInternalMetricsScrapeInterval time.Duration
@@ -68,8 +69,9 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	res := newResourceInternal(&ctxInfo.NodeMeta)
-	provider := newInternalMeterProvider(res, &exporter, metrics.Interval)
-	meter := provider.Meter("obi_internal")
+	bpfProbeLatency := newBpfProbeLatencyProducer(exporter.Temporality(metric.InstrumentKindHistogram))
+	provider := newInternalMeterProvider(res, &exporter, metrics.Interval, bpfProbeLatency)
+	meter := provider.Meter(internalMetricsMeterName)
 	tracerFlushes, err := meter.Float64Histogram(
 		attr.VendorPrefix+".ebpf.tracer.flushes",
 		instrument.WithDescription("Length of the groups of traces flushed from the eBPF tracer to the next pipeline stage"),
@@ -148,23 +150,6 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		return nil, err
 	}
 
-	bpfProbeExecutions, err := meter.Int64Counter(
-		attr.VendorPrefix+".bpf.probe.executions",
-		instrument.WithDescription("Total number of eBPF probe executions"),
-		instrument.WithUnit("{call}"),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	bpfProbeLatencySum, err := meter.Float64Counter(
-		attr.VendorPrefix+".bpf.probe.latency_seconds_total",
-		instrument.WithDescription("Total latency of the eBPF probe in seconds"),
-		instrument.WithUnit("s"),
-	)
-	if err != nil {
-		return nil, err
-	}
 	bpfMapEntries, err := meter.Int64Gauge(
 		attr.VendorPrefix+".bpf.map.entries_total",
 		instrument.WithDescription("Number of entries in the eBPF map"),
@@ -229,8 +214,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		avoidedServices:                  avoidedServices,
 		avoidedServicesLimiter:           avoidedServicesLimiter,
 		buildInfo:                        buildInfo,
-		bpfProbeExecutions:               bpfProbeExecutions,
-		bpfProbeLatencySum:               bpfProbeLatencySum,
+		bpfProbeLatency:                  bpfProbeLatency,
 		bpfMapEntries:                    bpfMapEntries,
 		bpfMapMaxEntries:                 bpfMapMaxEntries,
 		bpfInternalMetricsScrapeInterval: internalMetrics.BpfMetricScrapeInterval,
@@ -241,10 +225,17 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}, nil
 }
 
-func newInternalMeterProvider(res *resource.Resource, exporter *metric.Exporter, interval time.Duration) *metric.MeterProvider {
+func newInternalMeterProvider(
+	res *resource.Resource,
+	exporter *metric.Exporter,
+	interval time.Duration,
+	bpfProbeLatency *bpfProbeLatencyProducer,
+) *metric.MeterProvider {
 	return metric.NewMeterProvider(
 		metric.WithResource(res),
-		metric.WithReader(metric.NewPeriodicReader(*exporter, metric.WithInterval(interval))),
+		metric.WithReader(metric.NewPeriodicReader(*exporter,
+			metric.WithInterval(interval),
+			metric.WithProducer(bpfProbeLatency))),
 	)
 }
 
@@ -339,15 +330,8 @@ func (p *InternalMetricsReporter) AvoidInstrumentationTraces(serviceName, servic
 	p.recordAvoidedService(serviceName, serviceNamespace, serviceInstanceID, "traces")
 }
 
-func (p *InternalMetricsReporter) BpfProbeStats(probeID, probeType, probeName string, count uint64, latencySumSeconds float64) {
-	attrs := []attribute.KeyValue{
-		attribute.String("bpf.probe.id", probeID),
-		attribute.String("bpf.probe.type", probeType),
-		attribute.String("bpf.probe.name", probeName),
-	}
-
-	p.bpfProbeExecutions.Add(p.ctx, int64(count), instrument.WithAttributes(attrs...))
-	p.bpfProbeLatencySum.Add(p.ctx, latencySumSeconds, instrument.WithAttributes(attrs...))
+func (p *InternalMetricsReporter) BpfProbeStats(probeID, probeType, probeName string, count uint64, latencySumSeconds float64, latencyBuckets map[float64]uint64) {
+	p.bpfProbeLatency.Update(probeID, probeType, probeName, count, latencySumSeconds, latencyBuckets)
 }
 
 func (p *InternalMetricsReporter) BpfMapEntries(mapID, mapName, mapType string, entriesTotal int) {

--- a/pkg/export/otel/metrics_internal_bpf_histogram.go
+++ b/pkg/export/otel/metrics_internal_bpf_histogram.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package otel
+package otel // import "go.opentelemetry.io/obi/pkg/export/otel"
 
 import (
 	"context"

--- a/pkg/export/otel/metrics_internal_bpf_histogram.go
+++ b/pkg/export/otel/metrics_internal_bpf_histogram.go
@@ -1,0 +1,195 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otel
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	metricdata "go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
+)
+
+// bpfProbeLatencyMetricName is the OTLP counterpart of the Prometheus
+// bpf_probe_latency_seconds const histogram.
+var bpfProbeLatencyMetricName = attr.VendorPrefix + ".bpf.probe.latency"
+
+type bpfProbeKey struct {
+	probeID   string
+	probeType string
+	probeName string
+}
+
+// bpfProbeLatencyState accumulates the cumulative distribution of a single probe.
+// BpfProbeStats reports per-interval deltas for count and sum, while the bucket map it
+// receives is already cumulative, so only the former are accumulated here.
+type bpfProbeLatencyState struct {
+	time    time.Time
+	count   uint64
+	sum     float64
+	buckets map[float64]uint64
+}
+
+// subtractBpfProbeLatency returns the delta between two cumulative snapshots. A snapshot that
+// went backwards, which happens when the kernel reuses a program ID, is treated as a fresh
+// series rather than producing negative counts.
+func subtractBpfProbeLatency(current, previous bpfProbeLatencyState) bpfProbeLatencyState {
+	if current.count < previous.count || current.sum < previous.sum {
+		return current
+	}
+
+	delta := bpfProbeLatencyState{
+		count:   current.count - previous.count,
+		sum:     current.sum - previous.sum,
+		buckets: make(map[float64]uint64, len(current.buckets)),
+	}
+	for bound, count := range current.buckets {
+		if previousCount := previous.buckets[bound]; count >= previousCount {
+			delta.buckets[bound] = count - previousCount
+		}
+	}
+
+	return delta
+}
+
+// bpfProbeLatencyProducer emits the eBPF probe latency distribution as a pre-aggregated
+// histogram. An SDK Float64Histogram cannot express "add N observations to this bucket",
+// which is the only form the kernel exposes, so this implements the SDK Producer interface
+// instead and emits explicit bounds and bucket counts.
+type bpfProbeLatencyProducer struct {
+	mu           sync.Mutex
+	temporality  metricdata.Temporality
+	startTime    time.Time
+	probes       map[bpfProbeKey]*bpfProbeLatencyState
+	lastProduced map[bpfProbeKey]bpfProbeLatencyState
+}
+
+func newBpfProbeLatencyProducer(temporality metricdata.Temporality) *bpfProbeLatencyProducer {
+	return &bpfProbeLatencyProducer{
+		temporality:  temporality,
+		startTime:    timeNow(),
+		probes:       make(map[bpfProbeKey]*bpfProbeLatencyState),
+		lastProduced: make(map[bpfProbeKey]bpfProbeLatencyState),
+	}
+}
+
+func (p *bpfProbeLatencyProducer) Update(
+	probeID, probeType, probeName string,
+	count uint64,
+	latencySumSeconds float64,
+	latencyBuckets map[float64]uint64,
+) {
+	key := bpfProbeKey{probeID: probeID, probeType: probeType, probeName: probeName}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	state, ok := p.probes[key]
+	if !ok {
+		state = &bpfProbeLatencyState{}
+		p.probes[key] = state
+	}
+
+	state.count += count
+	state.sum += latencySumSeconds
+	// the caller keeps mutating its map between intervals
+	state.buckets = maps.Clone(latencyBuckets)
+}
+
+func (p *bpfProbeLatencyProducer) Produce(ctx context.Context) ([]metricdata.ScopeMetrics, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if len(p.probes) == 0 {
+		return nil, nil
+	}
+
+	now := timeNow()
+	delta := p.temporality == metricdata.DeltaTemporality
+	dataPoints := make([]metricdata.HistogramDataPoint[float64], 0, len(p.probes))
+	for key, state := range p.probes {
+		emitted := *state
+		startTime := p.startTime
+		if delta {
+			previous := p.lastProduced[key]
+			emitted = subtractBpfProbeLatency(*state, previous)
+			startTime = previous.time
+			if startTime.IsZero() {
+				startTime = p.startTime
+			}
+		}
+
+		dataPoints = append(dataPoints, metricdata.HistogramDataPoint[float64]{
+			Attributes: attribute.NewSet(
+				attribute.String("bpf.probe.id", key.probeID),
+				attribute.String("bpf.probe.type", key.probeType),
+				attribute.String("bpf.probe.name", key.probeName),
+			),
+			StartTime:    startTime,
+			Time:         now,
+			Count:        emitted.count,
+			Sum:          emitted.sum,
+			Bounds:       slices.Clone(imetrics.BpfLatenciesBuckets),
+			BucketCounts: bucketCounts(&emitted),
+		})
+
+		if delta {
+			produced := *state
+			produced.buckets = maps.Clone(state.buckets)
+			produced.time = now
+			p.lastProduced[key] = produced
+		}
+	}
+
+	return []metricdata.ScopeMetrics{{
+		Scope: instrumentation.Scope{Name: internalMetricsMeterName},
+		Metrics: []metricdata.Metrics{{
+			Name:        bpfProbeLatencyMetricName,
+			Description: "Latency distribution of the eBPF probe in seconds",
+			Unit:        "s",
+			Data: metricdata.Histogram[float64]{
+				Temporality: metricdata.CumulativeTemporality,
+				DataPoints:  dataPoints,
+			},
+		}},
+	}}, nil
+}
+
+// bucketCounts converts the per-bound counts the kernel-side accounting produces into the
+// BucketCounts layout the SDK expects: one entry per bound plus a trailing overflow bucket
+// for observations above the largest bound, which the accounting does not record.
+func bucketCounts(state *bpfProbeLatencyState) []uint64 {
+	counts := make([]uint64, len(imetrics.BpfLatenciesBuckets)+1)
+
+	var bounded uint64
+	for i, bound := range imetrics.BpfLatenciesBuckets {
+		counts[i] = state.buckets[bound]
+		bounded += counts[i]
+	}
+
+	// The bucket map must hold per-bucket counts, not the cumulative "le" counts Prometheus
+	// uses; otherwise the totals below would exceed the observation count and the datapoint
+	// would be invalid. Fall back to attributing everything to the overflow bucket, which is
+	// wrong but stays self-consistent.
+	if bounded > state.count {
+		clear(counts)
+		counts[len(counts)-1] = state.count
+		return counts
+	}
+
+	counts[len(counts)-1] = state.count - bounded
+
+	return counts
+}

--- a/pkg/export/otel/metrics_internal_test.go
+++ b/pkg/export/otel/metrics_internal_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metricdata "go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"go.opentelemetry.io/obi/internal/test/collector"
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
@@ -38,39 +39,77 @@ func TestInternalMetricsReporterBpfProbeStats(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	reporter.BpfProbeStats("7", "kprobe", "tcp_connect", 3, 0.75)
+	// 3 executions averaging 0.0001s, which the accounting attributes to the 0.0001 bucket
+	reporter.BpfProbeStats("7", "kprobe", "tcp_connect", 3, 0.0003, map[float64]uint64{0.0001: 3})
 
 	records := readMetricsByName(t, metricRecords, time.Second,
-		attr.VendorPrefix+".bpf.probe.executions",
-		attr.VendorPrefix+".bpf.probe.latency_seconds_total",
+		attr.VendorPrefix+".bpf.probe.latency",
 	)
-	assert.Len(t, records, 2)
+	require.Len(t, records, 1)
 
-	expected := map[string]collector.MetricRecord{
-		attr.VendorPrefix + ".bpf.probe.executions": {
-			IntVal: 3,
-		},
-		attr.VendorPrefix + ".bpf.probe.latency_seconds_total": {
-			FloatVal: 0.75,
-		},
+	record := records[0]
+	assert.Equal(t, "7", record.Attributes["bpf.probe.id"])
+	assert.Equal(t, "kprobe", record.Attributes["bpf.probe.type"])
+	assert.Equal(t, "tcp_connect", record.Attributes["bpf.probe.name"])
+	assert.Equal(t, 3, record.Count)
+	assert.InDelta(t, 0.0003, record.FloatVal, 0.00001)
+}
+
+func TestBpfProbeLatencyProducerDeltaTemporality(t *testing.T) {
+	bound := imetrics.BpfLatenciesBuckets[0]
+	producer := newBpfProbeLatencyProducer(metricdata.DeltaTemporality)
+
+	producer.Update("7", "kprobe", "tcp_connect", 2, 0.5, map[float64]uint64{bound: 2})
+	first := produceHistogramPoint(t, producer)
+	assert.Equal(t, uint64(2), first.Count)
+	assert.InDelta(t, 0.5, first.Sum, 0.0001)
+
+	// the source snapshots are cumulative, so a second interval of 3 more observations
+	// arrives as a total of 5 and must be emitted as the delta
+	producer.Update("7", "kprobe", "tcp_connect", 3, 0.75, map[float64]uint64{bound: 5})
+	second := produceHistogramPoint(t, producer)
+	assert.Equal(t, uint64(3), second.Count)
+	assert.InDelta(t, 0.75, second.Sum, 0.0001)
+	assert.Equal(t, uint64(3), second.BucketCounts[0])
+	assert.Equal(t, first.Time, second.StartTime, "delta points must start where the previous one ended")
+}
+
+func produceHistogramPoint(t *testing.T, producer *bpfProbeLatencyProducer) metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+
+	scopeMetrics, err := producer.Produce(t.Context())
+	require.NoError(t, err)
+	require.Len(t, scopeMetrics, 1)
+	require.Len(t, scopeMetrics[0].Metrics, 1)
+
+	histogram, ok := scopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+	require.True(t, ok, "expected a float64 histogram")
+	require.Len(t, histogram.DataPoints, 1)
+
+	return histogram.DataPoints[0]
+}
+
+func TestBpfProbeLatencyProducerBucketCounts(t *testing.T) {
+	bounds := imetrics.BpfLatenciesBuckets
+	largest := bounds[len(bounds)-1]
+
+	// two observations land in a real bucket, a third exceeds every bound and so was
+	// never recorded by the accounting: it must surface in the overflow bucket
+	counts := bucketCounts(&bpfProbeLatencyState{
+		count:   3,
+		sum:     1.5,
+		buckets: map[float64]uint64{bounds[0]: 2},
+	})
+
+	require.Len(t, counts, len(bounds)+1)
+	assert.Equal(t, uint64(2), counts[0])
+	assert.Equal(t, uint64(1), counts[len(counts)-1], "observation above %v must land in the overflow bucket", largest)
+
+	var total uint64
+	for _, c := range counts {
+		total += c
 	}
-
-	for _, record := range records {
-		assert.Equal(t, "7", record.Attributes["bpf.probe.id"])
-		assert.Equal(t, "kprobe", record.Attributes["bpf.probe.type"])
-		assert.Equal(t, "tcp_connect", record.Attributes["bpf.probe.name"])
-
-		want, ok := expected[record.Name]
-		require.True(t, ok, "unexpected metric %q", record.Name)
-		if record.Name == attr.VendorPrefix+".bpf.probe.executions" {
-			assert.Equal(t, want.IntVal, record.IntVal)
-		} else {
-			assert.Equal(t, want.FloatVal, record.FloatVal)
-		}
-		delete(expected, record.Name)
-	}
-
-	assert.Empty(t, expected)
+	assert.Equal(t, uint64(3), total, "bucket counts must sum to the observation count")
 }
 
 func TestInternalMetricsReporterQueueBufferUtilization(t *testing.T) {

--- a/pkg/export/prom/prom_bpf.go
+++ b/pkg/export/prom/prom_bpf.go
@@ -240,12 +240,15 @@ func (bc *BPFCollector) collectInternalMetrics(ctx context.Context) {
 					continue
 				}
 
+				metric.program.updateBuckets(metric.latency, metric.count)
+
 				bc.ctxInfo.Metrics.BpfProbeStats(
 					metric.probeID,
 					metric.probeType,
 					metric.probeName,
 					metric.count,
 					metric.latency*float64(metric.count),
+					metric.program.buckets,
 				)
 			}
 

--- a/pkg/export/prom/prom_bpf_test.go
+++ b/pkg/export/prom/prom_bpf_test.go
@@ -105,6 +105,7 @@ func TestBPFMetricsCollectsInternalMetricsForPrometheusReporter(t *testing.T) {
 					probeID:   "7",
 					latency:   0.25,
 					count:     count,
+					program:   &BPFProgram{},
 				}}
 			},
 			mapMetrics: func() []BpfMapMetrics {
@@ -249,6 +250,7 @@ func TestBPFMetricsCollectsInternalMetricsWhenPrometheusEndpointEnabled(t *testi
 					probeID:   "7",
 					latency:   0.25,
 					count:     count,
+					program:   &BPFProgram{},
 				}}
 			},
 			mapMetrics: func() []BpfMapMetrics {

--- a/schemas/obi/groups/obi_internal.yaml
+++ b/schemas/obi/groups/obi_internal.yaml
@@ -306,25 +306,19 @@ groups:
       Length of the groups of traces flushed from the eBPF tracer to the next
       pipeline stage.
 
-  - id: metric.obi.bpf.probe.executions
+  # Pre-aggregated: emitted through the SDK Producer interface rather than a
+  # Float64Histogram, because the kernel exposes only cumulative run_time_ns /
+  # run_cnt and bucket counts are derived from those rather than observed
+  # individually. Supersedes the former obi.bpf.probe.executions and
+  # obi.bpf.probe.latency_seconds_total, whose values are this histogram's
+  # count and sum.
+  - id: metric.obi.bpf.probe.latency
     type: metric
-    metric_name: obi.bpf.probe.executions
-    instrument: counter
-    unit: "{call}"
-    stability: development
-    brief: Total number of eBPF probe executions.
-    attributes:
-      - ref: bpf.probe.id
-      - ref: bpf.probe.type
-      - ref: bpf.probe.name
-
-  - id: metric.obi.bpf.probe.latency_seconds_total
-    type: metric
-    metric_name: obi.bpf.probe.latency_seconds_total
-    instrument: counter
+    metric_name: obi.bpf.probe.latency
+    instrument: histogram
     unit: "s"
     stability: development
-    brief: Total latency of the eBPF probe in seconds.
+    brief: Latency distribution of the eBPF probe in seconds.
     attributes:
       - ref: bpf.probe.id
       - ref: bpf.probe.type


### PR DESCRIPTION
## Summary

`bpf_probe_latency_seconds` was the only metric on the BPF collector's surface that OBI could emit
over Prometheus but not OTLP. This adds `obi.bpf.probe.latency` (histogram, `s`) and removes
`obi.bpf.probe.executions` and `obi.bpf.probe.latency_seconds_total`, whose values are that
histogram's count and sum.

It uses the SDK `Producer` interface, like the existing `goRuntimeHistogramProducer`: the kernel
exposes only cumulative `run_time_ns` / `run_cnt`, so there are no individual observations to
`Record()`. Bounds come from the already-shared `imetrics.BpfLatenciesBuckets`, and temporality
follows the exporter's preference, with cumulative snapshots differenced when it asks for delta.

The distribution is an approximation: each interval contributes its whole execution count to the
single bucket matching that interval's *average* latency. The kernel only gives totals, but the
attribution to one bucket is OBI's own choice in `updateBuckets`, not a kernel constraint.

## Worth a reviewer's attention

- **`updateBuckets` was only called from the Prometheus `Collect()` path**, so an OTLP-only
  deployment accumulated no buckets at all. `collectInternalMetrics` now calls it. This cannot
  double-count: `BPFMetrics` builds separate `BPFCollector` instances for the two paths, each
  with its own `progs` map.
- **Observations above the largest bound are never recorded** by `updateBuckets`, so
  `bucketCounts` derives the trailing overflow bucket as `count - sum(recorded)`. Without it a
  histogram's buckets would not sum to its own count.

`imetrics.Reporter.BpfProbeStats` gained a `latencyBuckets` parameter; the producer clones it
because the caller keeps mutating it between intervals.

## Breaking changes

Two OTLP metrics removed, both internal meta-metrics about OBI itself:

- `obi.bpf.probe.executions` → the histogram's count (`obi_bpf_probe_latency_seconds_count`)
- `obi.bpf.probe.latency_seconds_total` → its sum (`obi_bpf_probe_latency_seconds_sum`)

Note the sum's Prometheus name changes too (`_sum`, not `_total`), so dashboards reading the total
latency need updating even though the value is preserved.

OBI's own Prometheus internal endpoint is unchanged; aligning `iprom.go` belongs to the
internal-metric reconciliation step. Known limitation, at parity with the counters it replaces:
per-probe state is never pruned, so a program ID that disappears keeps being exported with a
frozen count.

## Validation

- [x] I have read and followed the contributing guidelines
- [ ] If this enhances / fixes / changes a core feature, I have updated the features
      documentation and support matrix as needed.