### PR TITLE
Prefer exact Go symbols over vendor aliases

### DIFF
--- a/pkg/internal/goexec/instructions.go
+++ b/pkg/internal/goexec/instructions.go
@@ -83,12 +83,15 @@ func instrumentationPoints(elfF *elf.File, funcNames []string) (map[string]FuncO
 		allSyms, _ = procs.FindExeSymbols(elfF, funcNames)
 	}
 
+	// Prefer usable offsets from exact requested names over vendor aliases,
+	// regardless of symbol-table traversal order. At the same priority, keep the
+	// first usable offset found.
 	allOffsets := map[string]FuncOffsets{}
-	exactOffsets := map[string]bool{}
+	selectedIsExact := map[string]bool{}
 	for _, f := range symTab.Funcs {
-		fName, exact, ok := requestedFunctionName(f.Name, functions)
+		fName, isExact, ok := requestedFunctionName(f.Name, functions)
 		if ok {
-			if exactOffsets[fName] && !exact {
+			if selectedIsExact[fName] && !isExact {
 				continue
 			}
 
@@ -98,7 +101,7 @@ func instrumentationPoints(elfF *elf.File, funcNames []string) (map[string]FuncO
 			if gosyms == nil && len(allSyms) > 0 {
 				offs, found := staticSymbolOffsets(fName, allSyms, ilog)
 				if found {
-					storeFunctionOffset(allOffsets, exactOffsets, fName, offs, exact)
+					storeFunctionOffset(allOffsets, selectedIsExact, fName, offs, isExact)
 				}
 				continue
 			}
@@ -109,7 +112,7 @@ func instrumentationPoints(elfF *elf.File, funcNames []string) (map[string]FuncO
 			}
 			if ok {
 				ilog.Debug("found relevant function for instrumentation", "function", fName, "offsets", offs)
-				storeFunctionOffset(allOffsets, exactOffsets, fName, offs, exact)
+				storeFunctionOffset(allOffsets, selectedIsExact, fName, offs, isExact)
 			}
 		}
 	}
@@ -133,17 +136,17 @@ func requestedFunctionName(rawName string, functions map[string]struct{}) (strin
 
 func storeFunctionOffset(
 	allOffsets map[string]FuncOffsets,
-	exactOffsets map[string]bool,
+	selectedIsExact map[string]bool,
 	fName string,
 	offs FuncOffsets,
-	exact bool,
+	isExact bool,
 ) {
-	if previousExact, found := exactOffsets[fName]; found && (previousExact || !exact) {
+	if previousIsExact, found := selectedIsExact[fName]; found && (previousIsExact || !isExact) {
 		return
 	}
 
 	allOffsets[fName] = offs
-	exactOffsets[fName] = exact
+	selectedIsExact[fName] = isExact
 }
 
 func staticSymbolOffsets(fName string, allSyms map[string]procs.Sym, ilog *slog.Logger) (FuncOffsets, bool) {

--- a/pkg/internal/goexec/instructions.go
+++ b/pkg/internal/goexec/instructions.go
@@ -84,19 +84,22 @@ func instrumentationPoints(elfF *elf.File, funcNames []string) (map[string]FuncO
 	}
 
 	allOffsets := map[string]FuncOffsets{}
+	exactOffsets := map[string]bool{}
 	for _, f := range symTab.Funcs {
-		fName := f.Name
-		// fetch short path of function for vendor scene
-		if paths := strings.Split(fName, "/vendor/"); len(paths) > 1 {
-			fName = paths[1]
-		}
+		fName, exact, ok := requestedFunctionName(f.Name, functions)
+		if ok {
+			if exactOffsets[fName] && !exact {
+				continue
+			}
 
-		if _, ok := functions[fName]; ok {
 			// when we don't have a Go symbol table, the executable is statically linked, we don't look for offsets
 			// using the gosym tab, we lookup offsets just like a regular elf file.
 			// we still need to find the return statements, since go linkage is non-standard we can't use uretprobe
 			if gosyms == nil && len(allSyms) > 0 {
-				handleStaticSymbol(fName, allOffsets, allSyms, ilog)
+				offs, found := staticSymbolOffsets(fName, allSyms, ilog)
+				if found {
+					storeFunctionOffset(allOffsets, exactOffsets, fName, offs, exact)
+				}
 				continue
 			}
 
@@ -106,7 +109,7 @@ func instrumentationPoints(elfF *elf.File, funcNames []string) (map[string]FuncO
 			}
 			if ok {
 				ilog.Debug("found relevant function for instrumentation", "function", fName, "offsets", offs)
-				allOffsets[fName] = offs
+				storeFunctionOffset(allOffsets, exactOffsets, fName, offs, exact)
 			}
 		}
 	}
@@ -114,7 +117,36 @@ func instrumentationPoints(elfF *elf.File, funcNames []string) (map[string]FuncO
 	return allOffsets, nil
 }
 
-func handleStaticSymbol(fName string, allOffsets map[string]FuncOffsets, allSyms map[string]procs.Sym, ilog *slog.Logger) {
+func requestedFunctionName(rawName string, functions map[string]struct{}) (string, bool, bool) {
+	if _, ok := functions[rawName]; ok {
+		return rawName, true, true
+	}
+
+	if paths := strings.Split(rawName, "/vendor/"); len(paths) > 1 {
+		if _, ok := functions[paths[1]]; ok {
+			return paths[1], false, true
+		}
+	}
+
+	return "", false, false
+}
+
+func storeFunctionOffset(
+	allOffsets map[string]FuncOffsets,
+	exactOffsets map[string]bool,
+	fName string,
+	offs FuncOffsets,
+	exact bool,
+) {
+	if previousExact, found := exactOffsets[fName]; found && (previousExact || !exact) {
+		return
+	}
+
+	allOffsets[fName] = offs
+	exactOffsets[fName] = exact
+}
+
+func staticSymbolOffsets(fName string, allSyms map[string]procs.Sym, ilog *slog.Logger) (FuncOffsets, bool) {
 	s, ok := allSyms[fName]
 
 	if ok && s.Prog != nil {
@@ -122,18 +154,20 @@ func handleStaticSymbol(fName string, allOffsets map[string]FuncOffsets, allSyms
 		_, err := s.Prog.ReadAt(data, int64(s.Off-s.Prog.Off))
 		if err != nil {
 			ilog.Error("error reading instructions for symbol", "symbol", fName, "error", err)
-			return
+			return FuncOffsets{}, false
 		}
 
 		returns, err := FindReturnOffsets(s.Off, data)
 		if err != nil {
 			ilog.Error("error finding returns for symbol", "symbol", fName, "offset", s.Off-s.Prog.Off, "size", s.Len, "error", err)
-			return
+			return FuncOffsets{}, false
 		}
-		allOffsets[fName] = FuncOffsets{Start: s.Off, Returns: returns}
+		return FuncOffsets{Start: s.Off, Returns: returns}, true
 	} else {
 		ilog.Debug("can't find in elf symbol table", "symbol", fName, "ok", ok, "prog", s.Prog)
 	}
+
+	return FuncOffsets{}, false
 }
 
 // findFuncOffset gets the start address and end addresses of the function whose symbol is passed

--- a/pkg/internal/goexec/instructions_priority_test.go
+++ b/pkg/internal/goexec/instructions_priority_test.go
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package goexec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestedFunctionNamePrefersExactName(t *testing.T) {
+	functions := map[string]struct{}{
+		"golang.org/x/net/http2/hpack.(*Encoder).WriteField": {},
+	}
+
+	name, exact, ok := requestedFunctionName(
+		"golang.org/x/net/http2/hpack.(*Encoder).WriteField", functions)
+	require.True(t, ok)
+	assert.True(t, exact)
+	assert.Equal(t, "golang.org/x/net/http2/hpack.(*Encoder).WriteField", name)
+}
+
+func TestRequestedFunctionNameFallsBackToVendorAlias(t *testing.T) {
+	functions := map[string]struct{}{
+		"golang.org/x/net/http2/hpack.(*Encoder).WriteField": {},
+	}
+
+	name, exact, ok := requestedFunctionName(
+		"example.com/module/vendor/golang.org/x/net/http2/hpack.(*Encoder).WriteField", functions)
+	require.True(t, ok)
+	assert.False(t, exact)
+	assert.Equal(t, "golang.org/x/net/http2/hpack.(*Encoder).WriteField", name)
+}
+
+func TestStoreFunctionOffsetExactNameWinsInEitherOrder(t *testing.T) {
+	const name = "golang.org/x/net/http2/hpack.(*Encoder).WriteField"
+	alias := FuncOffsets{Start: 1}
+	exact := FuncOffsets{Start: 2}
+
+	for _, order := range []struct {
+		name       string
+		candidates []struct {
+			offsets FuncOffsets
+			exact   bool
+		}
+	}{
+		{
+			name: "alias before exact",
+			candidates: []struct {
+				offsets FuncOffsets
+				exact   bool
+			}{{alias, false}, {exact, true}},
+		},
+		{
+			name: "exact before alias",
+			candidates: []struct {
+				offsets FuncOffsets
+				exact   bool
+			}{{exact, true}, {alias, false}},
+		},
+	} {
+		t.Run(order.name, func(t *testing.T) {
+			allOffsets := map[string]FuncOffsets{}
+			exactOffsets := map[string]bool{}
+			for _, candidate := range order.candidates {
+				storeFunctionOffset(allOffsets, exactOffsets, name, candidate.offsets, candidate.exact)
+			}
+
+			assert.Equal(t, exact, allOffsets[name])
+			assert.True(t, exactOffsets[name])
+		})
+	}
+}
+
+func TestStoreFunctionOffsetKeepsFirstAliasFallback(t *testing.T) {
+	const name = "golang.org/x/net/http2/hpack.(*Encoder).WriteField"
+	allOffsets := map[string]FuncOffsets{}
+	exactOffsets := map[string]bool{}
+
+	storeFunctionOffset(allOffsets, exactOffsets, name, FuncOffsets{Start: 1}, false)
+	storeFunctionOffset(allOffsets, exactOffsets, name, FuncOffsets{Start: 2}, false)
+
+	assert.Equal(t, uint64(1), allOffsets[name].Start)
+	assert.False(t, exactOffsets[name])
+}

--- a/pkg/internal/goexec/instructions_priority_test.go
+++ b/pkg/internal/goexec/instructions_priority_test.go
@@ -43,33 +43,33 @@ func TestStoreFunctionOffsetExactNameWinsInEitherOrder(t *testing.T) {
 		name       string
 		candidates []struct {
 			offsets FuncOffsets
-			exact   bool
+			isExact bool
 		}
 	}{
 		{
 			name: "alias before exact",
 			candidates: []struct {
 				offsets FuncOffsets
-				exact   bool
+				isExact bool
 			}{{alias, false}, {exact, true}},
 		},
 		{
 			name: "exact before alias",
 			candidates: []struct {
 				offsets FuncOffsets
-				exact   bool
+				isExact bool
 			}{{exact, true}, {alias, false}},
 		},
 	} {
 		t.Run(order.name, func(t *testing.T) {
 			allOffsets := map[string]FuncOffsets{}
-			exactOffsets := map[string]bool{}
+			selectedIsExact := map[string]bool{}
 			for _, candidate := range order.candidates {
-				storeFunctionOffset(allOffsets, exactOffsets, name, candidate.offsets, candidate.exact)
+				storeFunctionOffset(allOffsets, selectedIsExact, name, candidate.offsets, candidate.isExact)
 			}
 
 			assert.Equal(t, exact, allOffsets[name])
-			assert.True(t, exactOffsets[name])
+			assert.True(t, selectedIsExact[name])
 		})
 	}
 }
@@ -77,11 +77,11 @@ func TestStoreFunctionOffsetExactNameWinsInEitherOrder(t *testing.T) {
 func TestStoreFunctionOffsetKeepsFirstAliasFallback(t *testing.T) {
 	const name = "golang.org/x/net/http2/hpack.(*Encoder).WriteField"
 	allOffsets := map[string]FuncOffsets{}
-	exactOffsets := map[string]bool{}
+	selectedIsExact := map[string]bool{}
 
-	storeFunctionOffset(allOffsets, exactOffsets, name, FuncOffsets{Start: 1}, false)
-	storeFunctionOffset(allOffsets, exactOffsets, name, FuncOffsets{Start: 2}, false)
+	storeFunctionOffset(allOffsets, selectedIsExact, name, FuncOffsets{Start: 1}, false)
+	storeFunctionOffset(allOffsets, selectedIsExact, name, FuncOffsets{Start: 2}, false)
 
 	assert.Equal(t, uint64(1), allOffsets[name].Start)
-	assert.False(t, exactOffsets[name])
+	assert.False(t, selectedIsExact[name])
 }


### PR DESCRIPTION
## Summary

- prefer the exact requested Go symbol over `/vendor/` aliases regardless of ELF traversal order
- retain a deterministic vendor alias fallback when the exact symbol is absent
- cover exact-only, alias-only, both discovery orders, and repeated aliases

## Why

Go binaries can contain both canonical `golang.org/x/net/http2` symbols and vendored aliases. Probe resolution previously kept whichever matching symbol happened to be discovered first, which could attach a probe to the wrong HTTP/2 implementation.

This establishes the symbol-selection invariant needed by the per-library HTTP/2 ownership probes in the follow-up draft while remaining independently useful to other Go probes.

## Validation

- `go test ./pkg/internal/goexec`
- `make compile`

Relates to #2769.

Stack: 1 of 2. Follow-up #3021 depends on this draft and contains the complete Go HTTP/2 and grpc-go ownership fix. Merge this draft first.
