### PR TITLE
Fix java attach setting OBI uid/gid as 0s

### DIFF
--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
@@ -44,8 +45,9 @@ func (e *JavaInjectError) Error() string {
 }
 
 type JavaInjector struct {
-	log *slog.Logger
-	cfg *obi.Config
+	log             *slog.Logger
+	cfg             *obi.Config
+	currentAttachID atomic.Int64
 }
 
 func NewJavaInjector(cfg *obi.Config) (*JavaInjector, error) {
@@ -57,8 +59,9 @@ func NewJavaInjector(cfg *obi.Config) (*JavaInjector, error) {
 	}
 
 	return &JavaInjector{
-		cfg: cfg,
-		log: slog.With("component", "javaagent.Injector"),
+		cfg:             cfg,
+		log:             slog.With("component", "javaagent.Injector"),
+		currentAttachID: atomic.Int64{},
 	}, nil
 }
 
@@ -116,6 +119,8 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 		return nil
 	}
 
+	attachID := i.currentAttachID.Add(1)
+
 	ctx, cancel := context.WithTimeout(context.Background(), i.cfg.Java.Timeout)
 	defer cancel()
 
@@ -127,7 +132,10 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 
 	resultChan := make(chan result, 1)
 
-	attacher := jvm.NewJAttacher(i.log)
+	attacher := jvm.NewJAttacher(i.log, attachID, func() int64 {
+		return i.currentAttachID.Load()
+	})
+
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -131,6 +131,15 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
+	// We need to call cleanup here even though init may not have
+	// happened, to ensure the case when the JVM never responds and
+	// we've terminated with a timeout. Cleanup() is idempotent.
+	defer func() {
+		if err := attacher.Cleanup(); err != nil {
+			i.log.Warn("error on JVM attach cleanup", "error", err)
+		}
+	}()
+
 	// Run the attach procedure in a goroutine, so that we can terminate on stuck attach
 	go func() {
 		defer func() {

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -148,7 +148,7 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 			}
 		}()
 
-		ok, jdk8 := i.verifyJVMVersion(attacher, ie.FileInfo.Pid())
+		ok, jdk8 := i.verifyJVMVersion(ctx, attacher, ie.FileInfo.Pid())
 		if !ok {
 			resultChan <- result{err: &JavaInjectError{Message: "unsupported Java version for OpenTelemetry eBPF instrumentation"}}
 			return
@@ -157,9 +157,9 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 		var loaded bool
 		var err error
 		if jdk8 {
-			loaded, err = i.jdkAgentAlreadyLoadedHotspot8(attacher, ie.FileInfo.Pid())
+			loaded, err = i.jdkAgentAlreadyLoadedHotspot8(ctx, attacher, ie.FileInfo.Pid())
 		} else {
-			loaded, err = i.jdkAgentAlreadyLoaded(attacher, ie.FileInfo.Pid())
+			loaded, err = i.jdkAgentAlreadyLoaded(ctx, attacher, ie.FileInfo.Pid())
 		}
 
 		if err != nil {
@@ -182,7 +182,7 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 			return
 		}
 
-		if err = i.attachJDKAgent(attacher, ie.FileInfo.Pid(), agentPath); err != nil {
+		if err = i.attachJDKAgent(ctx, attacher, ie.FileInfo.Pid(), agentPath); err != nil {
 			i.log.Error("couldn't attach OpenTelemetry eBPF Java Agent", "pid", ie.FileInfo.Pid(), "path", agentPath, "error", err)
 			resultChan <- result{err: err}
 			return
@@ -289,7 +289,7 @@ func (i *JavaInjector) attachOpts() string {
 	return "=" + strings.Join(opts, ",")
 }
 
-func (i *JavaInjector) attachJDKAgent(attacher *jvm.JAttacher, pid app.PID, path string) error {
+func (i *JavaInjector) attachJDKAgent(ctx context.Context, attacher *jvm.JAttacher, pid app.PID, path string) error {
 	attacher.Init()
 
 	defer func() {
@@ -297,7 +297,7 @@ func (i *JavaInjector) attachJDKAgent(attacher *jvm.JAttacher, pid app.PID, path
 			slog.Warn("error on JVM attach cleanup", "error", err)
 		}
 	}()
-	out, err := attacher.Attach(int(pid), []string{"load", "instrument", "false", path + i.attachOpts()}, false)
+	out, err := attacher.Attach(ctx, int(pid), []string{"load", "instrument", "false", path + i.attachOpts()}, false)
 	if err != nil {
 		i.log.Error("error executing command for the JVM", "pid", pid, "error", err)
 		return err
@@ -338,7 +338,7 @@ func (i *JavaInjector) attachJDKAgent(attacher *jvm.JAttacher, pid app.PID, path
 	return nil
 }
 
-func (i *JavaInjector) jdkAgentAlreadyLoaded(attacher *jvm.JAttacher, pid app.PID) (bool, error) {
+func (i *JavaInjector) jdkAgentAlreadyLoaded(ctx context.Context, attacher *jvm.JAttacher, pid app.PID) (bool, error) {
 	attacher.Init()
 
 	defer func() {
@@ -347,7 +347,7 @@ func (i *JavaInjector) jdkAgentAlreadyLoaded(attacher *jvm.JAttacher, pid app.PI
 		}
 	}()
 	// OpenJ9 doesn't support listing loaded classes
-	out, err := attacher.Attach(int(pid), []string{"jcmd", "VM.class_hierarchy"}, true)
+	out, err := attacher.Attach(ctx, int(pid), []string{"jcmd", "VM.class_hierarchy"}, true)
 	if err != nil {
 		i.log.Error("error executing command for the JVM", "pid", pid, "error", err)
 		return false, err
@@ -376,7 +376,7 @@ func (i *JavaInjector) jdkAgentAlreadyLoaded(attacher *jvm.JAttacher, pid app.PI
 
 // Hotspot version 8 doesn't support VM.class_hierarchy, we use GC.class_histogram and look for the class itself
 // without the address
-func (i *JavaInjector) jdkAgentAlreadyLoadedHotspot8(attacher *jvm.JAttacher, pid app.PID) (bool, error) {
+func (i *JavaInjector) jdkAgentAlreadyLoadedHotspot8(ctx context.Context, attacher *jvm.JAttacher, pid app.PID) (bool, error) {
 	attacher.Init()
 
 	defer func() {
@@ -385,7 +385,7 @@ func (i *JavaInjector) jdkAgentAlreadyLoadedHotspot8(attacher *jvm.JAttacher, pi
 		}
 	}()
 	// OpenJ9 doesn't support listing loaded classes
-	out, err := attacher.Attach(int(pid), []string{"jcmd", "GC.class_histogram"}, true)
+	out, err := attacher.Attach(ctx, int(pid), []string{"jcmd", "GC.class_histogram"}, true)
 	if err != nil {
 		i.log.Error("error executing command for the JVM", "pid", pid, "error", err)
 		return false, err
@@ -412,7 +412,7 @@ func (i *JavaInjector) jdkAgentAlreadyLoadedHotspot8(attacher *jvm.JAttacher, pi
 	return false, nil
 }
 
-func (i *JavaInjector) verifyJVMVersion(attacher *jvm.JAttacher, pid app.PID) (bool, bool) {
+func (i *JavaInjector) verifyJVMVersion(ctx context.Context, attacher *jvm.JAttacher, pid app.PID) (bool, bool) {
 	attacher.Init()
 
 	defer func() {
@@ -421,7 +421,7 @@ func (i *JavaInjector) verifyJVMVersion(attacher *jvm.JAttacher, pid app.PID) (b
 		}
 	}()
 	// OpenJ9 doesn't support VM.version command
-	out, err := attacher.Attach(int(pid), []string{"jcmd", "VM.version"}, true)
+	out, err := attacher.Attach(ctx, int(pid), []string{"jcmd", "VM.version"}, true)
 	if err != nil {
 		i.log.Error("error executing command for the JVM", "pid", pid, "error", err)
 		return false, false

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -135,7 +135,7 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 	// happened, to ensure the case when the JVM never responds and
 	// we've terminated with a timeout. Cleanup() is idempotent.
 	defer func() {
-		if err := attacher.Cleanup(); err != nil {
+		if err := attacher.Cleanup(true); err != nil {
 			i.log.Warn("error on JVM attach cleanup", "error", err)
 		}
 	}()
@@ -293,7 +293,7 @@ func (i *JavaInjector) attachJDKAgent(ctx context.Context, attacher *jvm.JAttach
 	attacher.Init()
 
 	defer func() {
-		if err := attacher.Cleanup(); err != nil {
+		if err := attacher.Cleanup(false); err != nil {
 			slog.Warn("error on JVM attach cleanup", "error", err)
 		}
 	}()
@@ -342,7 +342,7 @@ func (i *JavaInjector) jdkAgentAlreadyLoaded(ctx context.Context, attacher *jvm.
 	attacher.Init()
 
 	defer func() {
-		if err := attacher.Cleanup(); err != nil {
+		if err := attacher.Cleanup(false); err != nil {
 			slog.Warn("error on JVM attach cleanup", "error", err)
 		}
 	}()
@@ -380,7 +380,7 @@ func (i *JavaInjector) jdkAgentAlreadyLoadedHotspot8(ctx context.Context, attach
 	attacher.Init()
 
 	defer func() {
-		if err := attacher.Cleanup(); err != nil {
+		if err := attacher.Cleanup(false); err != nil {
 			slog.Warn("error on JVM attach cleanup", "error", err)
 		}
 	}()
@@ -416,7 +416,7 @@ func (i *JavaInjector) verifyJVMVersion(ctx context.Context, attacher *jvm.JAtta
 	attacher.Init()
 
 	defer func() {
-		if err := attacher.Cleanup(); err != nil {
+		if err := attacher.Cleanup(false); err != nil {
 			slog.Warn("error on JVM attach cleanup", "error", err)
 		}
 	}()

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -357,6 +357,11 @@ func (i *JavaInjector) jdkAgentAlreadyLoaded(attacher *jvm.JAttacher, pid app.PI
 		}
 	}
 
+	if err := scanner.Err(); err != nil {
+		i.log.Error("error reading JVM command output", "pid", pid, "error", err)
+		return false, err
+	}
+
 	return false, nil
 }
 
@@ -388,6 +393,11 @@ func (i *JavaInjector) jdkAgentAlreadyLoadedHotspot8(attacher *jvm.JAttacher, pi
 		if strings.Contains(s, "io.opentelemetry.obi.java.Agent") {
 			return true, nil
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		i.log.Error("error reading JVM command output", "pid", pid, "error", err)
+		return false, err
 	}
 
 	return false, nil

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -112,6 +112,10 @@ func (i *JavaInjector) findTempDir(root string, ie *ebpf.Instrumentable) (string
 }
 
 func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
+	if ie.Type != svc.InstrumentableJava {
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), i.cfg.Java.Timeout)
 	defer cancel()
 
@@ -127,75 +131,65 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	defer func() {
-		if err := attacher.Cleanup(); err != nil {
-			slog.Warn("error on JVM attach cleanup", "error", err)
-		}
-	}()
-
-	if ie.Type == svc.InstrumentableJava {
-		// Run the attach procedure in a goroutine, so that we can terminate on stuck attach
-		go func() {
-			defer func() {
-				if r := recover(); r != nil {
-					resultChan <- result{err: &JavaInjectError{Message: "attach failed"}}
-				}
-			}()
-
-			ok, jdk8 := i.verifyJVMVersion(attacher, ie.FileInfo.Pid())
-			if !ok {
-				resultChan <- result{err: &JavaInjectError{Message: "unsupported Java version for OpenTelemetry eBPF instrumentation"}}
-				return
+	// Run the attach procedure in a goroutine, so that we can terminate on stuck attach
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				resultChan <- result{err: &JavaInjectError{Message: "attach failed"}}
 			}
-
-			var loaded bool
-			var err error
-			if jdk8 {
-				loaded, err = i.jdkAgentAlreadyLoadedHotspot8(attacher, ie.FileInfo.Pid())
-			} else {
-				loaded, err = i.jdkAgentAlreadyLoaded(attacher, ie.FileInfo.Pid())
-			}
-
-			if err != nil {
-				resultChan <- result{err: err}
-				return
-			}
-
-			if loaded {
-				i.log.Info("OpenTelemetry eBPF Java Agent already loaded, not reloading")
-				resultChan <- result{attached: false}
-				return
-			}
-
-			i.log.Info("injecting OpenTelemetry eBPF instrumentation for Java process", "pid", ie.FileInfo.Pid())
-
-			agentPath, err := i.copyAgent(ie)
-			if err != nil {
-				i.log.Error("failed to extract java agent", "pid", ie.FileInfo.Pid(), "error", err)
-				resultChan <- result{err: err}
-				return
-			}
-
-			if err = i.attachJDKAgent(attacher, ie.FileInfo.Pid(), agentPath); err != nil {
-				i.log.Error("couldn't attach OpenTelemetry eBPF Java Agent", "pid", ie.FileInfo.Pid(), "path", agentPath, "error", err)
-				resultChan <- result{err: err}
-				return
-			}
-
-			resultChan <- result{attached: true}
 		}()
 
-		// Wait for either completion or timeout
-		select {
-		case result := <-resultChan:
-			return result.err
-		case <-ctx.Done():
-			i.log.Warn("java attach timed out", "timeout", i.cfg.Java.Timeout, "pid", ie.FileInfo.Pid())
-			return &JavaInjectError{Message: "java attach timed out"}
+		ok, jdk8 := i.verifyJVMVersion(attacher, ie.FileInfo.Pid())
+		if !ok {
+			resultChan <- result{err: &JavaInjectError{Message: "unsupported Java version for OpenTelemetry eBPF instrumentation"}}
+			return
 		}
-	}
 
-	return nil
+		var loaded bool
+		var err error
+		if jdk8 {
+			loaded, err = i.jdkAgentAlreadyLoadedHotspot8(attacher, ie.FileInfo.Pid())
+		} else {
+			loaded, err = i.jdkAgentAlreadyLoaded(attacher, ie.FileInfo.Pid())
+		}
+
+		if err != nil {
+			resultChan <- result{err: err}
+			return
+		}
+
+		if loaded {
+			i.log.Info("OpenTelemetry eBPF Java Agent already loaded, not reloading")
+			resultChan <- result{attached: false}
+			return
+		}
+
+		i.log.Info("injecting OpenTelemetry eBPF instrumentation for Java process", "pid", ie.FileInfo.Pid())
+
+		agentPath, err := i.copyAgent(ie)
+		if err != nil {
+			i.log.Error("failed to extract java agent", "pid", ie.FileInfo.Pid(), "error", err)
+			resultChan <- result{err: err}
+			return
+		}
+
+		if err = i.attachJDKAgent(attacher, ie.FileInfo.Pid(), agentPath); err != nil {
+			i.log.Error("couldn't attach OpenTelemetry eBPF Java Agent", "pid", ie.FileInfo.Pid(), "path", agentPath, "error", err)
+			resultChan <- result{err: err}
+			return
+		}
+
+		resultChan <- result{attached: true}
+	}()
+
+	// Wait for either completion or timeout
+	select {
+	case result := <-resultChan:
+		return result.err
+	case <-ctx.Done():
+		i.log.Warn("java attach timed out", "timeout", i.cfg.Java.Timeout, "pid", ie.FileInfo.Pid())
+		return &JavaInjectError{Message: "java attach timed out"}
+	}
 }
 
 func ensureEmbeddedAgent() error {

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -135,7 +135,7 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 	// happened, to ensure the case when the JVM never responds and
 	// we've terminated with a timeout. Cleanup() is idempotent.
 	defer func() {
-		if err := attacher.Cleanup(true); err != nil {
+		if err := attacher.Terminate(); err != nil {
 			i.log.Warn("error on JVM attach cleanup", "error", err)
 		}
 	}()
@@ -293,7 +293,7 @@ func (i *JavaInjector) attachJDKAgent(ctx context.Context, attacher *jvm.JAttach
 	attacher.Init()
 
 	defer func() {
-		if err := attacher.Cleanup(false); err != nil {
+		if err := attacher.Cleanup(); err != nil {
 			slog.Warn("error on JVM attach cleanup", "error", err)
 		}
 	}()
@@ -342,7 +342,7 @@ func (i *JavaInjector) jdkAgentAlreadyLoaded(ctx context.Context, attacher *jvm.
 	attacher.Init()
 
 	defer func() {
-		if err := attacher.Cleanup(false); err != nil {
+		if err := attacher.Cleanup(); err != nil {
 			slog.Warn("error on JVM attach cleanup", "error", err)
 		}
 	}()
@@ -380,7 +380,7 @@ func (i *JavaInjector) jdkAgentAlreadyLoadedHotspot8(ctx context.Context, attach
 	attacher.Init()
 
 	defer func() {
-		if err := attacher.Cleanup(false); err != nil {
+		if err := attacher.Cleanup(); err != nil {
 			slog.Warn("error on JVM attach cleanup", "error", err)
 		}
 	}()
@@ -416,7 +416,7 @@ func (i *JavaInjector) verifyJVMVersion(ctx context.Context, attacher *jvm.JAtta
 	attacher.Init()
 
 	defer func() {
-		if err := attacher.Cleanup(false); err != nil {
+		if err := attacher.Cleanup(); err != nil {
 			slog.Warn("error on JVM attach cleanup", "error", err)
 		}
 	}()

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -18,7 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"sync/atomic"
+	"sync"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
@@ -47,7 +47,8 @@ func (e *JavaInjectError) Error() string {
 type JavaInjector struct {
 	log             *slog.Logger
 	cfg             *obi.Config
-	currentAttachID atomic.Int64
+	currentAttachID int64
+	mu              sync.Mutex
 }
 
 func NewJavaInjector(cfg *obi.Config) (*JavaInjector, error) {
@@ -61,7 +62,7 @@ func NewJavaInjector(cfg *obi.Config) (*JavaInjector, error) {
 	return &JavaInjector{
 		cfg:             cfg,
 		log:             slog.With("component", "javaagent.Injector"),
-		currentAttachID: atomic.Int64{},
+		currentAttachID: 0,
 	}, nil
 }
 
@@ -114,12 +115,34 @@ func (i *JavaInjector) findTempDir(root string, ie *ebpf.Instrumentable) (string
 	return "", errors.New("couldn't find suitable temp directory for injection")
 }
 
+func (i *JavaInjector) nextAttachID() int64 {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	i.currentAttachID++
+	return i.currentAttachID
+}
+
+func (i *JavaInjector) runIfCurrentAttach(
+	attachID int64,
+	fn func() error,
+) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.currentAttachID != attachID {
+		return nil
+	}
+
+	return fn()
+}
+
 func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 	if ie.Type != svc.InstrumentableJava {
 		return nil
 	}
 
-	attachID := i.currentAttachID.Add(1)
+	attachID := i.nextAttachID()
 
 	ctx, cancel := context.WithTimeout(context.Background(), i.cfg.Java.Timeout)
 	defer cancel()
@@ -132,9 +155,7 @@ func (i *JavaInjector) NewExecutable(ie *ebpf.Instrumentable) error {
 
 	resultChan := make(chan result, 1)
 
-	attacher := jvm.NewJAttacher(i.log, attachID, func() int64 {
-		return i.currentAttachID.Load()
-	})
+	attacher := jvm.NewJAttacher(i.log, attachID, i.runIfCurrentAttach)
 
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()

--- a/pkg/internal/java/java_inject_test.go
+++ b/pkg/internal/java/java_inject_test.go
@@ -22,6 +22,45 @@ import (
 	"go.opentelemetry.io/obi/pkg/obi"
 )
 
+func TestRunIfCurrentAttachHoldsLockWhileRunningAction(t *testing.T) {
+	injector := &JavaInjector{}
+	attachID := injector.nextAttachID()
+
+	actionStarted := make(chan struct{})
+	finishAction := make(chan struct{})
+	actionDone := make(chan error, 1)
+	go func() {
+		actionDone <- injector.runIfCurrentAttach(attachID, func() error {
+			close(actionStarted)
+			<-finishAction
+			return nil
+		})
+	}()
+
+	<-actionStarted
+	lockWasAvailable := injector.mu.TryLock()
+	if lockWasAvailable {
+		injector.mu.Unlock()
+	}
+
+	nextAttachID := make(chan int64, 1)
+	go func() {
+		nextAttachID <- injector.nextAttachID()
+	}()
+
+	close(finishAction)
+	require.NoError(t, <-actionDone)
+	require.Equal(t, int64(2), <-nextAttachID)
+	require.False(t, lockWasAvailable)
+
+	actionRan := false
+	require.NoError(t, injector.runIfCurrentAttach(attachID, func() error {
+		actionRan = true
+		return nil
+	}))
+	require.False(t, actionRan)
+}
+
 func TestJavaInjector_CopyAgent(t *testing.T) {
 	oldJavaAgentBytes := embeddedJavaAgentBytes
 	embeddedJavaAgentBytes = []byte("test agent content")

--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -31,23 +31,27 @@ var (
 var errTerminated = errors.New("attach terminated")
 
 type JAttacher struct {
-	logger      *slog.Logger
-	j9attacher  *j9Attacher
-	myUID       int
-	myGID       int
-	mu          sync.Mutex
-	initialized bool
-	terminated  bool
+	logger         *slog.Logger
+	j9attacher     *j9Attacher
+	myUID          int
+	myGID          int
+	mu             sync.Mutex
+	initialized    bool
+	terminated     bool
+	attachID       int64
+	activeAttachID func() int64
 }
 
-func NewJAttacher(logger *slog.Logger) *JAttacher {
+func NewJAttacher(logger *slog.Logger, attachID int64, activeAttachID func() int64) *JAttacher {
 	if logger == nil {
 		logger = slog.Default()
 	}
 
 	return &JAttacher{
-		logger:     logger,
-		j9attacher: nil,
+		logger:         logger,
+		j9attacher:     nil,
+		attachID:       attachID,
+		activeAttachID: activeAttachID,
 	}
 }
 
@@ -130,7 +134,14 @@ func (j *JAttacher) Cleanup() error {
 		cleanupErr = errors.Join(cleanupErr, j.j9attacher.detach())
 	}
 
-	cleanupErr = errors.Join(cleanupErr, j.restoreCredentialsLocked())
+	activeAttachID := j.activeAttachID()
+
+	// Restore credentials if we are the active attach happening on the pipeline.
+	// If we were delayed and the main loop abandoned us, they would reset the
+	// credentials in Terminate and they might be in process of other JVM attach.
+	if activeAttachID == j.attachID {
+		cleanupErr = errors.Join(cleanupErr, j.restoreCredentialsLocked())
+	}
 
 	return cleanupErr
 }

--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -87,11 +87,7 @@ func (j *JAttacher) Cleanup() error {
 	return cleanupErr
 }
 
-func (j *JAttacher) Attach(pid int, argv []string, ignoreOnJ9 bool) (io.ReadCloser, error) {
-	return j.AttachContext(context.Background(), pid, argv, ignoreOnJ9)
-}
-
-func (j *JAttacher) AttachContext(ctx context.Context, pid int, argv []string, ignoreOnJ9 bool) (io.ReadCloser, error) {
+func (j *JAttacher) Attach(ctx context.Context, pid int, argv []string, ignoreOnJ9 bool) (io.ReadCloser, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -82,13 +82,43 @@ func (j *JAttacher) Init() {
 	j.initialized = true
 }
 
-func (j *JAttacher) Cleanup(terminate bool) error {
+func (j *JAttacher) restoreCredentialsLocked() error {
+	var restoreErr error
+	// Credentials (euid/egid) are switched process-wide during Attach, so they
+	// must be restored here. Namespaces are NOT restored: the namespace switch
+	// happens only on the dedicated sacrificial thread spawned by Attach, which
+	// is destroyed once attach completes — the runtime's pool threads never
+	// leave their original namespaces, so there is nothing to roll back.
+	if err := setEUID(j.myUID); err != nil {
+		restoreErr = errors.Join(restoreErr, err)
+	}
+	if err := setEGID(j.myGID); err != nil {
+		restoreErr = errors.Join(restoreErr, err)
+	}
+
+	// No need to restore the pid namespace, since we do this on a
+	// locked thread that's never unlocked, which means the Go runtime
+	// will destroy it when the goroutine ends.
+
+	return restoreErr
+}
+
+func (j *JAttacher) Terminate() error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	if terminate {
-		j.terminated = true
+	j.terminated = true
+
+	if !j.initialized {
+		return nil
 	}
+
+	return j.restoreCredentialsLocked()
+}
+
+func (j *JAttacher) Cleanup() error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
 
 	if !j.initialized {
 		return nil
@@ -100,21 +130,7 @@ func (j *JAttacher) Cleanup(terminate bool) error {
 		cleanupErr = errors.Join(cleanupErr, j.j9attacher.detach())
 	}
 
-	// Credentials (euid/egid) are switched process-wide during Attach, so they
-	// must be restored here. Namespaces are NOT restored: the namespace switch
-	// happens only on the dedicated sacrificial thread spawned by Attach, which
-	// is destroyed once attach completes — the runtime's pool threads never
-	// leave their original namespaces, so there is nothing to roll back.
-	if err := setEUID(j.myUID); err != nil {
-		cleanupErr = errors.Join(cleanupErr, err)
-	}
-	if err := setEGID(j.myGID); err != nil {
-		cleanupErr = errors.Join(cleanupErr, err)
-	}
-
-	// No need to restore the pid namespace, since we do this on a
-	// locked thread that's never unlocked, which means the Go runtime
-	// will destroy it when the goroutine ends.
+	cleanupErr = errors.Join(cleanupErr, j.restoreCredentialsLocked())
 
 	return cleanupErr
 }

--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -20,6 +20,14 @@ import (
 	"go.opentelemetry.io/obi/pkg/internal/jvmtools/util"
 )
 
+// extracted for testing
+var (
+	getEUID = syscall.Geteuid
+	getEGID = syscall.Getegid
+	setEUID = syscall.Seteuid
+	setEGID = syscall.Setegid
+)
+
 type JAttacher struct {
 	logger      *slog.Logger
 	j9attacher  *j9Attacher
@@ -48,8 +56,8 @@ func (j *JAttacher) Init() {
 		return
 	}
 
-	j.myUID = syscall.Geteuid()
-	j.myGID = syscall.Getegid()
+	j.myUID = getEUID()
+	j.myGID = getEGID()
 	j.initialized = true
 }
 
@@ -73,10 +81,10 @@ func (j *JAttacher) Cleanup() error {
 	// happens only on the dedicated sacrificial thread spawned by Attach, which
 	// is destroyed once attach completes — the runtime's pool threads never
 	// leave their original namespaces, so there is nothing to roll back.
-	if err := syscall.Seteuid(j.myUID); err != nil {
+	if err := setEUID(j.myUID); err != nil {
 		cleanupErr = errors.Join(cleanupErr, err)
 	}
-	if err := syscall.Setegid(j.myGID); err != nil {
+	if err := setEGID(j.myGID); err != nil {
 		cleanupErr = errors.Join(cleanupErr, err)
 	}
 
@@ -164,8 +172,8 @@ func (j *JAttacher) attachInNamespace(ctx context.Context, pid, nspid, targetUID
 
 	// In HotSpot, dynamic attach is allowed only for the clients with the same euid/egid.
 	// If we are running under root, switch to the required euid/egid automatically.
-	if (j.myGID != targetGID && syscall.Setegid(targetGID) != nil) ||
-		(j.myUID != targetUID && syscall.Seteuid(targetUID) != nil) {
+	if (j.myGID != targetGID && setEGID(targetGID) != nil) ||
+		(j.myUID != targetUID && setEUID(targetUID) != nil) {
 		return nil, errors.New("failed to change credentials to match the target process")
 	}
 

--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -31,27 +31,27 @@ var (
 var errTerminated = errors.New("attach terminated")
 
 type JAttacher struct {
-	logger         *slog.Logger
-	j9attacher     *j9Attacher
-	myUID          int
-	myGID          int
-	mu             sync.Mutex
-	initialized    bool
-	terminated     bool
-	attachID       int64
-	activeAttachID func() int64
+	logger             *slog.Logger
+	j9attacher         *j9Attacher
+	myUID              int
+	myGID              int
+	mu                 sync.Mutex
+	initialized        bool
+	terminated         bool
+	attachID           int64
+	runIfCurrentAttach func(int64, func() error) error
 }
 
-func NewJAttacher(logger *slog.Logger, attachID int64, activeAttachID func() int64) *JAttacher {
+func NewJAttacher(logger *slog.Logger, attachID int64, runIfCurrentAttach func(int64, func() error) error) *JAttacher {
 	if logger == nil {
 		logger = slog.Default()
 	}
 
 	return &JAttacher{
-		logger:         logger,
-		j9attacher:     nil,
-		attachID:       attachID,
-		activeAttachID: activeAttachID,
+		logger:             logger,
+		j9attacher:         nil,
+		attachID:           attachID,
+		runIfCurrentAttach: runIfCurrentAttach,
 	}
 }
 
@@ -134,14 +134,16 @@ func (j *JAttacher) Cleanup() error {
 		cleanupErr = errors.Join(cleanupErr, j.j9attacher.detach())
 	}
 
-	activeAttachID := j.activeAttachID()
-
 	// Restore credentials if we are the active attach happening on the pipeline.
 	// If we were delayed and the main loop abandoned us, they would reset the
 	// credentials in Terminate and they might be in process of other JVM attach.
-	if activeAttachID == j.attachID {
-		cleanupErr = errors.Join(cleanupErr, j.restoreCredentialsLocked())
-	}
+	cleanupErr = errors.Join(
+		cleanupErr,
+		j.runIfCurrentAttach(
+			j.attachID,
+			j.restoreCredentialsLocked,
+		),
+	)
 
 	return cleanupErr
 }

--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -14,16 +14,19 @@ import (
 	"os/signal"
 	"runtime"
 	"runtime/debug"
+	"sync"
 	"syscall"
 
 	"go.opentelemetry.io/obi/pkg/internal/jvmtools/util"
 )
 
 type JAttacher struct {
-	logger     *slog.Logger
-	j9attacher *j9Attacher
-	myUID      int
-	myGID      int
+	logger      *slog.Logger
+	j9attacher  *j9Attacher
+	myUID       int
+	myGID       int
+	mu          sync.Mutex
+	initialized bool
 }
 
 func NewJAttacher(logger *slog.Logger) *JAttacher {
@@ -38,11 +41,27 @@ func NewJAttacher(logger *slog.Logger) *JAttacher {
 }
 
 func (j *JAttacher) Init() {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if j.initialized {
+		return
+	}
+
 	j.myUID = syscall.Geteuid()
 	j.myGID = syscall.Getegid()
+	j.initialized = true
 }
 
 func (j *JAttacher) Cleanup() error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if !j.initialized {
+		return nil
+	}
+	j.initialized = false
+
 	var cleanupErr error
 
 	if j.j9attacher != nil {

--- a/pkg/internal/jvmtools/jvm/cmd.go
+++ b/pkg/internal/jvmtools/jvm/cmd.go
@@ -28,6 +28,8 @@ var (
 	setEGID = syscall.Setegid
 )
 
+var errTerminated = errors.New("attach terminated")
+
 type JAttacher struct {
 	logger      *slog.Logger
 	j9attacher  *j9Attacher
@@ -35,6 +37,7 @@ type JAttacher struct {
 	myGID       int
 	mu          sync.Mutex
 	initialized bool
+	terminated  bool
 }
 
 func NewJAttacher(logger *slog.Logger) *JAttacher {
@@ -46,6 +49,24 @@ func NewJAttacher(logger *slog.Logger) *JAttacher {
 		logger:     logger,
 		j9attacher: nil,
 	}
+}
+
+func (j *JAttacher) setEUID(euid int) (err error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.terminated && euid != j.myUID {
+		return errTerminated
+	}
+	return setEUID(euid)
+}
+
+func (j *JAttacher) setEGID(egid int) (err error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.terminated && egid != j.myGID {
+		return errTerminated
+	}
+	return setEGID(egid)
 }
 
 func (j *JAttacher) Init() {
@@ -61,14 +82,17 @@ func (j *JAttacher) Init() {
 	j.initialized = true
 }
 
-func (j *JAttacher) Cleanup() error {
+func (j *JAttacher) Cleanup(terminate bool) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
+
+	if terminate {
+		j.terminated = true
+	}
 
 	if !j.initialized {
 		return nil
 	}
-	j.initialized = false
 
 	var cleanupErr error
 
@@ -172,8 +196,11 @@ func (j *JAttacher) attachInNamespace(ctx context.Context, pid, nspid, targetUID
 
 	// In HotSpot, dynamic attach is allowed only for the clients with the same euid/egid.
 	// If we are running under root, switch to the required euid/egid automatically.
-	if (j.myGID != targetGID && setEGID(targetGID) != nil) ||
-		(j.myUID != targetUID && setEUID(targetUID) != nil) {
+	// We must use j.setEGID and j.setEUID instead of setEUID and setEGID to ensure OBI
+	// is still waiting on the attach, rather than changing the user credentials after OBI
+	// has abandoned this attach in the pipeline.
+	if (j.myGID != targetGID && j.setEGID(targetGID) != nil) ||
+		(j.myUID != targetUID && j.setEUID(targetUID) != nil) {
 		return nil, errors.New("failed to change credentials to match the target process")
 	}
 

--- a/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
+++ b/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
@@ -54,7 +54,7 @@ func TestCleanupWithoutInitDoesNotSetCredentials(t *testing.T) {
 
 	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	require.NoError(t, attacher.Cleanup())
+	require.NoError(t, attacher.Cleanup(true))
 	require.Empty(t, euidCalls)
 	require.Empty(t, egidCalls)
 }
@@ -62,9 +62,13 @@ func TestCleanupWithoutInitDoesNotSetCredentials(t *testing.T) {
 func TestInitIsIdempotent(t *testing.T) {
 	originalGetEUID := getEUID
 	originalGetEGID := getEGID
+	originalSetEUID := setEUID
+	originalSetEGID := setEGID
 	t.Cleanup(func() {
 		getEUID = originalGetEUID
 		getEGID = originalGetEGID
+		setEUID = originalSetEUID
+		setEGID = originalSetEGID
 	})
 
 	euidCalls := 0
@@ -77,18 +81,26 @@ func TestInitIsIdempotent(t *testing.T) {
 		egidCalls++
 		return 456
 	}
+	setEUID = func(int) error {
+		return nil
+	}
+	setEGID = func(int) error {
+		return nil
+	}
 
 	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	attacher.Init()
+	require.NoError(t, attacher.Cleanup(false))
 	attacher.Init()
 
 	require.Equal(t, 1, euidCalls)
 	require.Equal(t, 1, egidCalls)
 	require.Equal(t, 123, attacher.myUID)
 	require.Equal(t, 456, attacher.myGID)
+	require.True(t, attacher.initialized)
 }
 
-func TestCleanupIsIdempotent(t *testing.T) {
+func TestCleanupCanRunRepeatedly(t *testing.T) {
 	originalGetEUID := getEUID
 	originalGetEGID := getEGID
 	originalSetEUID := setEUID
@@ -119,10 +131,134 @@ func TestCleanupIsIdempotent(t *testing.T) {
 
 	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	attacher.Init()
-	require.NoError(t, attacher.Cleanup())
-	require.NoError(t, attacher.Cleanup())
+	require.NoError(t, attacher.Cleanup(false))
+	require.NoError(t, attacher.Cleanup(false))
+	require.Equal(t, []int{123, 123}, euidCalls)
+	require.Equal(t, []int{456, 456}, egidCalls)
+	require.True(t, attacher.initialized)
+}
+
+func TestTerminalCleanupPreventsLaterCredentialChanges(t *testing.T) {
+	originalGetEUID := getEUID
+	originalGetEGID := getEGID
+	originalSetEUID := setEUID
+	originalSetEGID := setEGID
+	t.Cleanup(func() {
+		getEUID = originalGetEUID
+		getEGID = originalGetEGID
+		setEUID = originalSetEUID
+		setEGID = originalSetEGID
+	})
+
+	var euidCalls []int
+	var egidCalls []int
+	getEUID = func() int {
+		return 123
+	}
+	getEGID = func() int {
+		return 456
+	}
+	setEUID = func(id int) error {
+		euidCalls = append(euidCalls, id)
+		return nil
+	}
+	setEGID = func(id int) error {
+		egidCalls = append(egidCalls, id)
+		return nil
+	}
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	attacher.Init()
+	require.NoError(t, attacher.Cleanup(true))
+
+	require.ErrorIs(t, attacher.setEUID(789), errTerminated)
+	require.ErrorIs(t, attacher.setEGID(987), errTerminated)
+	require.NoError(t, attacher.setEUID(123))
+	require.NoError(t, attacher.setEGID(456))
+	require.Equal(t, []int{123, 123}, euidCalls)
+	require.Equal(t, []int{456, 456}, egidCalls)
+	require.True(t, attacher.initialized)
+	require.True(t, attacher.terminated)
+}
+
+func TestTerminalCleanupCanRunRepeatedly(t *testing.T) {
+	originalGetEUID := getEUID
+	originalGetEGID := getEGID
+	originalSetEUID := setEUID
+	originalSetEGID := setEGID
+	t.Cleanup(func() {
+		getEUID = originalGetEUID
+		getEGID = originalGetEGID
+		setEUID = originalSetEUID
+		setEGID = originalSetEGID
+	})
+
+	var euidCalls []int
+	var egidCalls []int
+	getEUID = func() int {
+		return 123
+	}
+	getEGID = func() int {
+		return 456
+	}
+	setEUID = func(id int) error {
+		euidCalls = append(euidCalls, id)
+		return nil
+	}
+	setEGID = func(id int) error {
+		egidCalls = append(egidCalls, id)
+		return nil
+	}
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	attacher.Init()
+	require.NoError(t, attacher.Cleanup(true))
+	require.NoError(t, attacher.Cleanup(false))
+
+	require.Equal(t, []int{123, 123}, euidCalls)
+	require.Equal(t, []int{456, 456}, egidCalls)
+	require.True(t, attacher.initialized)
+	require.True(t, attacher.terminated)
+}
+
+func TestTerminalCleanupWinsBetweenCredentialChanges(t *testing.T) {
+	originalGetEUID := getEUID
+	originalGetEGID := getEGID
+	originalSetEUID := setEUID
+	originalSetEGID := setEGID
+	t.Cleanup(func() {
+		getEUID = originalGetEUID
+		getEGID = originalGetEGID
+		setEUID = originalSetEUID
+		setEGID = originalSetEGID
+	})
+
+	var euidCalls []int
+	var egidCalls []int
+	getEUID = func() int {
+		return 123
+	}
+	getEGID = func() int {
+		return 456
+	}
+	setEUID = func(id int) error {
+		euidCalls = append(euidCalls, id)
+		return nil
+	}
+	setEGID = func(id int) error {
+		egidCalls = append(egidCalls, id)
+		return nil
+	}
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	attacher.Init()
+	require.NoError(t, attacher.setEGID(987))
+	require.NoError(t, attacher.Cleanup(true))
+	require.ErrorIs(t, attacher.setEUID(789), errTerminated)
+
 	require.Equal(t, []int{123}, euidCalls)
-	require.Equal(t, []int{456}, egidCalls)
+	require.Equal(t, []int{987, 456}, egidCalls)
+	require.True(t, attacher.terminated)
 }
 
 func TestStartAttachMechanismStopsOnContextCancellationAndRemovesAttachFile(t *testing.T) {

--- a/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
+++ b/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
@@ -26,7 +26,11 @@ func TestAttachReturnsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	const attachID int64 = 1
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
+		return attachID
+	})
 
 	out, err := attacher.Attach(ctx, os.Getpid(), []string{"jcmd"}, true)
 	require.Nil(t, out)
@@ -52,7 +56,11 @@ func TestCleanupWithoutInitDoesNotSetCredentials(t *testing.T) {
 		return nil
 	}
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	const attachID int64 = 1
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
+		return attachID
+	})
 
 	require.NoError(t, attacher.Terminate())
 	require.Empty(t, euidCalls)
@@ -88,7 +96,12 @@ func TestInitIsIdempotent(t *testing.T) {
 		return nil
 	}
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	const attachID int64 = 1
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
+		return attachID
+	})
+
 	attacher.Init()
 	require.NoError(t, attacher.Cleanup())
 	attacher.Init()
@@ -129,13 +142,74 @@ func TestCleanupCanRunRepeatedly(t *testing.T) {
 		return nil
 	}
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	const attachID int64 = 1
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
+		return attachID
+	})
+
 	attacher.Init()
 	require.NoError(t, attacher.Cleanup())
 	require.NoError(t, attacher.Cleanup())
 	require.Equal(t, []int{123, 123}, euidCalls)
 	require.Equal(t, []int{456, 456}, egidCalls)
 	require.True(t, attacher.initialized)
+}
+
+func TestDelayedCleanupDoesNotRestoreCredentialsDuringNewAttachAttemptForSamePID(t *testing.T) {
+	originalGetEUID := getEUID
+	originalGetEGID := getEGID
+	originalSetEUID := setEUID
+	originalSetEGID := setEGID
+	t.Cleanup(func() {
+		getEUID = originalGetEUID
+		getEGID = originalGetEGID
+		setEUID = originalSetEUID
+		setEGID = originalSetEGID
+	})
+
+	var euidCalls []int
+	var egidCalls []int
+	getEUID = func() int {
+		return 123
+	}
+	getEGID = func() int {
+		return 456
+	}
+	setEUID = func(id int) error {
+		euidCalls = append(euidCalls, id)
+		return nil
+	}
+	setEGID = func(id int) error {
+		egidCalls = append(egidCalls, id)
+		return nil
+	}
+
+	activeAttachID := int64(1)
+	getActiveAttachID := func() int64 {
+		return activeAttachID
+	}
+
+	oldAttacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), activeAttachID, getActiveAttachID)
+	oldAttacher.Init()
+	require.NoError(t, oldAttacher.Terminate())
+
+	euidCalls = nil
+	egidCalls = nil
+	activeAttachID = 2
+
+	newAttacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), activeAttachID, getActiveAttachID)
+	newAttacher.Init()
+	require.NoError(t, newAttacher.setEGID(987))
+	require.NoError(t, newAttacher.setEUID(789))
+
+	require.NoError(t, oldAttacher.Cleanup())
+	require.Equal(t, []int{789}, euidCalls)
+	require.Equal(t, []int{987}, egidCalls)
+
+	require.NoError(t, newAttacher.Cleanup())
+	require.Equal(t, []int{789, 123}, euidCalls)
+	require.Equal(t, []int{987, 456}, egidCalls)
 }
 
 func TestTerminalCleanupPreventsLaterCredentialChanges(t *testing.T) {
@@ -167,7 +241,11 @@ func TestTerminalCleanupPreventsLaterCredentialChanges(t *testing.T) {
 		return nil
 	}
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	const attachID int64 = 1
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
+		return attachID
+	})
 	attacher.Init()
 	require.NoError(t, attacher.Terminate())
 
@@ -210,7 +288,11 @@ func TestTerminalCleanupCanRunRepeatedly(t *testing.T) {
 		return nil
 	}
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	const attachID int64 = 1
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
+		return attachID
+	})
 	attacher.Init()
 	require.NoError(t, attacher.Terminate())
 	require.NoError(t, attacher.Cleanup())
@@ -250,7 +332,11 @@ func TestTerminalCleanupWinsBetweenCredentialChanges(t *testing.T) {
 		return nil
 	}
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	const attachID int64 = 1
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
+		return attachID
+	})
 	attacher.Init()
 	require.NoError(t, attacher.setEGID(987))
 	require.NoError(t, attacher.Terminate())

--- a/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
+++ b/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
@@ -22,28 +22,107 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAttachContextReturnsCanceledContext(t *testing.T) {
+func TestAttachReturnsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	out, err := attacher.AttachContext(ctx, os.Getpid(), []string{"jcmd"}, true)
+	out, err := attacher.Attach(ctx, os.Getpid(), []string{"jcmd"}, true)
 	require.Nil(t, out)
 	require.ErrorIs(t, err, context.Canceled)
 }
 
-func TestCleanupIsIdempotent(t *testing.T) {
+func TestCleanupWithoutInitDoesNotSetCredentials(t *testing.T) {
+	originalSetEUID := setEUID
+	originalSetEGID := setEGID
+	t.Cleanup(func() {
+		setEUID = originalSetEUID
+		setEGID = originalSetEGID
+	})
+
+	var euidCalls []int
+	var egidCalls []int
+	setEUID = func(id int) error {
+		euidCalls = append(euidCalls, id)
+		return nil
+	}
+	setEGID = func(id int) error {
+		egidCalls = append(egidCalls, id)
+		return nil
+	}
+
 	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	require.NoError(t, attacher.Cleanup())
-	require.False(t, attacher.initialized)
+	require.Empty(t, euidCalls)
+	require.Empty(t, egidCalls)
+}
 
+func TestInitIsIdempotent(t *testing.T) {
+	originalGetEUID := getEUID
+	originalGetEGID := getEGID
+	t.Cleanup(func() {
+		getEUID = originalGetEUID
+		getEGID = originalGetEGID
+	})
+
+	euidCalls := 0
+	egidCalls := 0
+	getEUID = func() int {
+		euidCalls++
+		return 123
+	}
+	getEGID = func() int {
+		egidCalls++
+		return 456
+	}
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	attacher.Init()
-	require.True(t, attacher.initialized)
+	attacher.Init()
+
+	require.Equal(t, 1, euidCalls)
+	require.Equal(t, 1, egidCalls)
+	require.Equal(t, 123, attacher.myUID)
+	require.Equal(t, 456, attacher.myGID)
+}
+
+func TestCleanupIsIdempotent(t *testing.T) {
+	originalGetEUID := getEUID
+	originalGetEGID := getEGID
+	originalSetEUID := setEUID
+	originalSetEGID := setEGID
+	t.Cleanup(func() {
+		getEUID = originalGetEUID
+		getEGID = originalGetEGID
+		setEUID = originalSetEUID
+		setEGID = originalSetEGID
+	})
+
+	var euidCalls []int
+	var egidCalls []int
+	getEUID = func() int {
+		return 123
+	}
+	getEGID = func() int {
+		return 456
+	}
+	setEUID = func(id int) error {
+		euidCalls = append(euidCalls, id)
+		return nil
+	}
+	setEGID = func(id int) error {
+		egidCalls = append(egidCalls, id)
+		return nil
+	}
+
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	attacher.Init()
 	require.NoError(t, attacher.Cleanup())
-	require.False(t, attacher.initialized)
 	require.NoError(t, attacher.Cleanup())
+	require.Equal(t, []int{123}, euidCalls)
+	require.Equal(t, []int{456}, egidCalls)
 }
 
 func TestStartAttachMechanismStopsOnContextCancellationAndRemovesAttachFile(t *testing.T) {

--- a/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
+++ b/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
@@ -54,7 +54,7 @@ func TestCleanupWithoutInitDoesNotSetCredentials(t *testing.T) {
 
 	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	require.NoError(t, attacher.Cleanup(true))
+	require.NoError(t, attacher.Terminate())
 	require.Empty(t, euidCalls)
 	require.Empty(t, egidCalls)
 }
@@ -90,7 +90,7 @@ func TestInitIsIdempotent(t *testing.T) {
 
 	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	attacher.Init()
-	require.NoError(t, attacher.Cleanup(false))
+	require.NoError(t, attacher.Cleanup())
 	attacher.Init()
 
 	require.Equal(t, 1, euidCalls)
@@ -131,8 +131,8 @@ func TestCleanupCanRunRepeatedly(t *testing.T) {
 
 	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	attacher.Init()
-	require.NoError(t, attacher.Cleanup(false))
-	require.NoError(t, attacher.Cleanup(false))
+	require.NoError(t, attacher.Cleanup())
+	require.NoError(t, attacher.Cleanup())
 	require.Equal(t, []int{123, 123}, euidCalls)
 	require.Equal(t, []int{456, 456}, egidCalls)
 	require.True(t, attacher.initialized)
@@ -169,7 +169,7 @@ func TestTerminalCleanupPreventsLaterCredentialChanges(t *testing.T) {
 
 	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	attacher.Init()
-	require.NoError(t, attacher.Cleanup(true))
+	require.NoError(t, attacher.Terminate())
 
 	require.ErrorIs(t, attacher.setEUID(789), errTerminated)
 	require.ErrorIs(t, attacher.setEGID(987), errTerminated)
@@ -212,8 +212,8 @@ func TestTerminalCleanupCanRunRepeatedly(t *testing.T) {
 
 	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	attacher.Init()
-	require.NoError(t, attacher.Cleanup(true))
-	require.NoError(t, attacher.Cleanup(false))
+	require.NoError(t, attacher.Terminate())
+	require.NoError(t, attacher.Cleanup())
 
 	require.Equal(t, []int{123, 123}, euidCalls)
 	require.Equal(t, []int{456, 456}, egidCalls)
@@ -253,7 +253,7 @@ func TestTerminalCleanupWinsBetweenCredentialChanges(t *testing.T) {
 	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
 	attacher.Init()
 	require.NoError(t, attacher.setEGID(987))
-	require.NoError(t, attacher.Cleanup(true))
+	require.NoError(t, attacher.Terminate())
 	require.ErrorIs(t, attacher.setEUID(789), errTerminated)
 
 	require.Equal(t, []int{123}, euidCalls)

--- a/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
+++ b/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
@@ -33,6 +33,19 @@ func TestAttachContextReturnsCanceledContext(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestCleanupIsIdempotent(t *testing.T) {
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	require.NoError(t, attacher.Cleanup())
+	require.False(t, attacher.initialized)
+
+	attacher.Init()
+	require.True(t, attacher.initialized)
+	require.NoError(t, attacher.Cleanup())
+	require.False(t, attacher.initialized)
+	require.NoError(t, attacher.Cleanup())
+}
+
 func TestStartAttachMechanismStopsOnContextCancellationAndRemovesAttachFile(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
+++ b/pkg/internal/jvmtools/jvm/cmd_hotspot_test.go
@@ -22,15 +22,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func alwaysRunForCurrentAttach(_ int64, fn func() error) error {
+	return fn()
+}
+
 func TestAttachReturnsCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	const attachID int64 = 1
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
-		return attachID
-	})
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, alwaysRunForCurrentAttach)
 
 	out, err := attacher.Attach(ctx, os.Getpid(), []string{"jcmd"}, true)
 	require.Nil(t, out)
@@ -58,9 +60,7 @@ func TestCleanupWithoutInitDoesNotSetCredentials(t *testing.T) {
 
 	const attachID int64 = 1
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
-		return attachID
-	})
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, alwaysRunForCurrentAttach)
 
 	require.NoError(t, attacher.Terminate())
 	require.Empty(t, euidCalls)
@@ -98,9 +98,7 @@ func TestInitIsIdempotent(t *testing.T) {
 
 	const attachID int64 = 1
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
-		return attachID
-	})
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, alwaysRunForCurrentAttach)
 
 	attacher.Init()
 	require.NoError(t, attacher.Cleanup())
@@ -144,9 +142,7 @@ func TestCleanupCanRunRepeatedly(t *testing.T) {
 
 	const attachID int64 = 1
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
-		return attachID
-	})
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, alwaysRunForCurrentAttach)
 
 	attacher.Init()
 	require.NoError(t, attacher.Cleanup())
@@ -186,11 +182,19 @@ func TestDelayedCleanupDoesNotRestoreCredentialsDuringNewAttachAttemptForSamePID
 	}
 
 	activeAttachID := int64(1)
-	getActiveAttachID := func() int64 {
-		return activeAttachID
+	var attachMu sync.Mutex
+	runIfCurrentAttach := func(attachID int64, fn func() error) error {
+		attachMu.Lock()
+		defer attachMu.Unlock()
+
+		if activeAttachID != attachID {
+			return nil
+		}
+
+		return fn()
 	}
 
-	oldAttacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), activeAttachID, getActiveAttachID)
+	oldAttacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), activeAttachID, runIfCurrentAttach)
 	oldAttacher.Init()
 	require.NoError(t, oldAttacher.Terminate())
 
@@ -198,7 +202,7 @@ func TestDelayedCleanupDoesNotRestoreCredentialsDuringNewAttachAttemptForSamePID
 	egidCalls = nil
 	activeAttachID = 2
 
-	newAttacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), activeAttachID, getActiveAttachID)
+	newAttacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), activeAttachID, runIfCurrentAttach)
 	newAttacher.Init()
 	require.NoError(t, newAttacher.setEGID(987))
 	require.NoError(t, newAttacher.setEUID(789))
@@ -243,9 +247,7 @@ func TestTerminalCleanupPreventsLaterCredentialChanges(t *testing.T) {
 
 	const attachID int64 = 1
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
-		return attachID
-	})
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, alwaysRunForCurrentAttach)
 	attacher.Init()
 	require.NoError(t, attacher.Terminate())
 
@@ -290,9 +292,7 @@ func TestTerminalCleanupCanRunRepeatedly(t *testing.T) {
 
 	const attachID int64 = 1
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
-		return attachID
-	})
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, alwaysRunForCurrentAttach)
 	attacher.Init()
 	require.NoError(t, attacher.Terminate())
 	require.NoError(t, attacher.Cleanup())
@@ -334,9 +334,7 @@ func TestTerminalCleanupWinsBetweenCredentialChanges(t *testing.T) {
 
 	const attachID int64 = 1
 
-	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, func() int64 {
-		return attachID
-	})
+	attacher := NewJAttacher(slog.New(slog.NewTextHandler(io.Discard, nil)), attachID, alwaysRunForCurrentAttach)
 	attacher.Init()
 	require.NoError(t, attacher.setEGID(987))
 	require.NoError(t, attacher.Terminate())


### PR DESCRIPTION
## Summary

OBI java attach could set the uid/gid on the OBI process itself to 0 is undesirable. This PR fixes the flow with the following approach:

- We now pass the cancellation context to the attach helpers, so they would get cancelled if the timeout expired.
- We make the init() and cleanup() idempotent and only run if there was successful save of credentials. This makes the outer cleanup on timeout termination safe to be called when no init happened.
- We skip the whole logic if the process is not Java.

Fixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/3018

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
