### PR TITLE
fix(metrics)!: derive internal metric names and drop Prometheus-isms from the OTLP ones

### DIFF
--- a/devdocs/bpf-metrics-collection.md
+++ b/devdocs/bpf-metrics-collection.md
@@ -48,8 +48,8 @@ If both paths are active, each path owns a separate collector.
 | --- | --- | --- |
 | `obi_bpf_probe_executions_total` | *(none: see `obi.bpf.probe.latency` count)* | Probe executions |
 | `obi_bpf_probe_latency_seconds_total` | `obi.bpf.probe.latency` | Probe latency distribution in seconds |
-| `obi_bpf_map_entries_total` | `obi.bpf.map.entries_total` | Current map entry count |
-| `obi_bpf_map_max_entries_total` | `obi.bpf.map.max_entries_total` | Configured maximum map entries |
+| `obi_bpf_map_entries` | `obi.bpf.map.entries` | Current map entry count |
+| `obi_bpf_map_max_entries` | `obi.bpf.map.max_entries` | Configured maximum map entries |
 
 Probe metrics use the program ID, type, and function name as attributes or
 labels. Map metrics use the map ID, type, and name.

--- a/internal/test/integration/configs/obi-config-netolly.yml
+++ b/internal/test/integration/configs/obi-config-netolly.yml
@@ -2,7 +2,7 @@ log_format: json
 network:
   guess_ports: ordinal
 # OTLP internal metrics so the network packet counters
-# (obi.bpf.network.packets.total, obi.bpf.network.ignored.packets.total) are
+# (obi.bpf.network.packets, obi.bpf.network.ignored.packets) are
 # weaver-validated on this netolly suite. Metrics endpoint is enabled via the
 # OTEL_EXPORTER_OTLP_ENDPOINT env in the compose file.
 internal_metrics:

--- a/internal/test/integration/internal_metrics_otel_test.go
+++ b/internal/test/integration/internal_metrics_otel_test.go
@@ -29,8 +29,8 @@ var internalMetricsExpected = []string{
 	"obi_internal_build_info",             // gauge, emitted once at startup
 	"obi_instrumented_processes",          // updowncounter, +1 per instrumented process
 	"obi_otel_metric_exports_total",       // counter, every metric export
-	"obi_bpf_map_entries_total",           // gauge, per eBPF map
-	"obi_bpf_map_max_entries_total",       // gauge, per eBPF map
+	"obi_bpf_map_entries",                 // gauge, per eBPF map
+	"obi_bpf_map_max_entries",             // gauge, per eBPF map
 	"obi_bpf_probe_latency_seconds_count", // histogram, needs BPF run-stats + traffic
 }
 

--- a/pkg/export/attributes/metric_internal.go
+++ b/pkg/export/attributes/metric_internal.go
@@ -1,0 +1,83 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package attributes // import "go.opentelemetry.io/obi/pkg/export/attributes"
+
+// OBI's own internal ("meta") metrics, which describe OBI rather than the instrumented
+// application. Declared here so their Prometheus name is derived from the OTLP definition
+// instead of being hand-written a second time in the internal Prometheus exporter.
+//
+// Unlike the metrics above these are not user-selectable, so they carry no Section: nothing
+// refers to them from an attributes.select group.
+var (
+	InternalTracerFlushes = metric(Name{
+		OTEL: "obi.ebpf.tracer.flushes",
+		Unit: "1",
+		Type: InstrumentHistogram,
+	})
+	InternalOTELMetricExports = metric(Name{
+		OTEL: "obi.otel.metric.exports",
+		Type: InstrumentCounter,
+	})
+	InternalOTELMetricExportErrors = metric(Name{
+		OTEL: "obi.otel.metric.export.errors",
+		Type: InstrumentCounter,
+	})
+	InternalOTELTraceExports = metric(Name{
+		OTEL: "obi.otel.trace.exports",
+		Type: InstrumentCounter,
+	})
+	InternalOTELTraceExportErrors = metric(Name{
+		OTEL: "obi.otel.trace.export.errors",
+		Type: InstrumentCounter,
+	})
+	InternalInstrumentedProcesses = metric(Name{
+		OTEL: "obi.instrumented.processes",
+		Type: InstrumentUpDownCounter,
+	})
+	InternalInstrumentationErrors = metric(Name{
+		OTEL: "obi.instrumentation.errors",
+		Type: InstrumentCounter,
+	})
+	InternalAvoidedServices = metric(Name{
+		OTEL: "obi.avoided.services",
+		Type: InstrumentGauge,
+	})
+	InternalBuildInfo = metric(Name{
+		OTEL: "obi.internal.build.info",
+		Type: InstrumentGauge,
+	})
+	InternalBpfProbeLatency = metric(Name{
+		OTEL: "obi.bpf.probe.latency",
+		Unit: "s",
+		Type: InstrumentHistogram,
+	})
+	InternalBpfMapEntries = metric(Name{
+		OTEL: "obi.bpf.map.entries",
+		Type: InstrumentGauge,
+	})
+	InternalBpfMapMaxEntries = metric(Name{
+		OTEL: "obi.bpf.map.max_entries",
+		Type: InstrumentGauge,
+	})
+	InternalKubeCacheForwardLag = metric(Name{
+		OTEL: "obi.kube.cache.forward.lag",
+		Unit: "s",
+		Type: InstrumentHistogram,
+	})
+	InternalBpfNetworkIgnoredPackets = metric(Name{
+		OTEL: "obi.bpf.network.ignored.packets",
+		Unit: "{packet}",
+		Type: InstrumentCounter,
+	})
+	InternalBpfNetworkPackets = metric(Name{
+		OTEL: "obi.bpf.network.packets",
+		Unit: "{packet}",
+		Type: InstrumentCounter,
+	})
+	InternalQueueCapacityRatio = metric(Name{
+		OTEL: "obi.queue.capacity.ratio",
+		Unit: "1",
+		Type: InstrumentGauge,
+	})
+)

--- a/pkg/export/attributes/metric_internal.go
+++ b/pkg/export/attributes/metric_internal.go
@@ -3,81 +3,107 @@
 
 package attributes // import "go.opentelemetry.io/obi/pkg/export/attributes"
 
-// OBI's own internal ("meta") metrics, which describe OBI rather than the instrumented
-// application. Declared here so their Prometheus name is derived from the OTLP definition
-// instead of being hand-written a second time in the internal Prometheus exporter.
+// InternalMetrics declares OBI's own internal ("meta") metrics, which describe OBI rather than
+// the instrumented application. Declaring them here lets the Prometheus name be derived from the
+// OTLP definition instead of being hand-written a second time in the internal Prometheus
+// exporter.
 //
-// Unlike the metrics above these are not user-selectable, so they carry no Section: nothing
-// refers to them from an attributes.select group.
-var (
-	InternalTracerFlushes = metric(Name{
-		OTEL: "obi.ebpf.tracer.flushes",
-		Unit: "1",
-		Type: InstrumentHistogram,
-	})
-	InternalOTELMetricExports = metric(Name{
-		OTEL: "obi.otel.metric.exports",
-		Type: InstrumentCounter,
-	})
-	InternalOTELMetricExportErrors = metric(Name{
-		OTEL: "obi.otel.metric.export.errors",
-		Type: InstrumentCounter,
-	})
-	InternalOTELTraceExports = metric(Name{
-		OTEL: "obi.otel.trace.exports",
-		Type: InstrumentCounter,
-	})
-	InternalOTELTraceExportErrors = metric(Name{
-		OTEL: "obi.otel.trace.export.errors",
-		Type: InstrumentCounter,
-	})
-	InternalInstrumentedProcesses = metric(Name{
-		OTEL: "obi.instrumented.processes",
-		Type: InstrumentUpDownCounter,
-	})
-	InternalInstrumentationErrors = metric(Name{
-		OTEL: "obi.instrumentation.errors",
-		Type: InstrumentCounter,
-	})
-	InternalAvoidedServices = metric(Name{
-		OTEL: "obi.avoided.services",
-		Type: InstrumentGauge,
-	})
-	InternalBuildInfo = metric(Name{
-		OTEL: "obi.internal.build.info",
-		Type: InstrumentGauge,
-	})
-	InternalBpfProbeLatency = metric(Name{
-		OTEL: "obi.bpf.probe.latency",
-		Unit: "s",
-		Type: InstrumentHistogram,
-	})
-	InternalBpfMapEntries = metric(Name{
-		OTEL: "obi.bpf.map.entries",
-		Type: InstrumentGauge,
-	})
-	InternalBpfMapMaxEntries = metric(Name{
-		OTEL: "obi.bpf.map.max_entries",
-		Type: InstrumentGauge,
-	})
-	InternalKubeCacheForwardLag = metric(Name{
-		OTEL: "obi.kube.cache.forward.lag",
-		Unit: "s",
-		Type: InstrumentHistogram,
-	})
-	InternalBpfNetworkIgnoredPackets = metric(Name{
-		OTEL: "obi.bpf.network.ignored.packets",
-		Unit: "{packet}",
-		Type: InstrumentCounter,
-	})
-	InternalBpfNetworkPackets = metric(Name{
-		OTEL: "obi.bpf.network.packets",
-		Unit: "{packet}",
-		Type: InstrumentCounter,
-	})
-	InternalQueueCapacityRatio = metric(Name{
-		OTEL: "obi.queue.capacity.ratio",
-		Unit: "1",
-		Type: InstrumentGauge,
-	})
-)
+// They are built from a prefix at call time rather than declared as package variables, because a
+// component that vendors OBI can override attr.VendorPrefix, and package-variable initialization
+// would run before it had the chance.
+//
+// Unlike the metrics in metric.go these are not user-selectable, so they carry no Section:
+// nothing refers to them from an attributes.select group.
+type InternalMetrics struct {
+	TracerFlushes            Name
+	OTELMetricExports        Name
+	OTELMetricExportErrors   Name
+	OTELTraceExports         Name
+	OTELTraceExportErrors    Name
+	InstrumentedProcesses    Name
+	InstrumentationErrors    Name
+	AvoidedServices          Name
+	BuildInfo                Name
+	BpfProbeLatency          Name
+	BpfMapEntries            Name
+	BpfMapMaxEntries         Name
+	KubeCacheForwardLag      Name
+	BpfNetworkIgnoredPackets Name
+	BpfNetworkPackets        Name
+	QueueCapacityRatio       Name
+}
+
+func NewInternalMetrics(prefix string) InternalMetrics {
+	return InternalMetrics{
+		TracerFlushes: metric(Name{
+			OTEL: prefix + ".ebpf.tracer.flushes",
+			Unit: "1",
+			Type: InstrumentHistogram,
+		}),
+		OTELMetricExports: metric(Name{
+			OTEL: prefix + ".otel.metric.exports",
+			Type: InstrumentCounter,
+		}),
+		OTELMetricExportErrors: metric(Name{
+			OTEL: prefix + ".otel.metric.export.errors",
+			Type: InstrumentCounter,
+		}),
+		OTELTraceExports: metric(Name{
+			OTEL: prefix + ".otel.trace.exports",
+			Type: InstrumentCounter,
+		}),
+		OTELTraceExportErrors: metric(Name{
+			OTEL: prefix + ".otel.trace.export.errors",
+			Type: InstrumentCounter,
+		}),
+		InstrumentedProcesses: metric(Name{
+			OTEL: prefix + ".instrumented.processes",
+			Type: InstrumentUpDownCounter,
+		}),
+		InstrumentationErrors: metric(Name{
+			OTEL: prefix + ".instrumentation.errors",
+			Type: InstrumentCounter,
+		}),
+		AvoidedServices: metric(Name{
+			OTEL: prefix + ".avoided.services",
+			Type: InstrumentGauge,
+		}),
+		BuildInfo: metric(Name{
+			OTEL: prefix + ".internal.build.info",
+			Type: InstrumentGauge,
+		}),
+		BpfProbeLatency: metric(Name{
+			OTEL: prefix + ".bpf.probe.latency",
+			Unit: "s",
+			Type: InstrumentHistogram,
+		}),
+		BpfMapEntries: metric(Name{
+			OTEL: prefix + ".bpf.map.entries",
+			Type: InstrumentGauge,
+		}),
+		BpfMapMaxEntries: metric(Name{
+			OTEL: prefix + ".bpf.map.max_entries",
+			Type: InstrumentGauge,
+		}),
+		KubeCacheForwardLag: metric(Name{
+			OTEL: prefix + ".kube.cache.forward.lag",
+			Unit: "s",
+			Type: InstrumentHistogram,
+		}),
+		BpfNetworkIgnoredPackets: metric(Name{
+			OTEL: prefix + ".bpf.network.ignored.packets",
+			Unit: "{packet}",
+			Type: InstrumentCounter,
+		}),
+		BpfNetworkPackets: metric(Name{
+			OTEL: prefix + ".bpf.network.packets",
+			Unit: "{packet}",
+			Type: InstrumentCounter,
+		}),
+		QueueCapacityRatio: metric(Name{
+			OTEL: prefix + ".queue.capacity.ratio",
+			Unit: "1",
+			Type: InstrumentGauge,
+		}),
+	}
+}

--- a/pkg/export/attributes/metric_internal_test.go
+++ b/pkg/export/attributes/metric_internal_test.go
@@ -4,6 +4,7 @@
 package attributes
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,32 +14,74 @@ import (
 // The expectations are the names OBI's internal Prometheus exporter emitted before these metrics
 // were declared here, so this pins the move as a refactor rather than a rename.
 func TestInternalPrometheusNames(t *testing.T) {
+	internal := NewInternalMetrics("obi")
+
 	tests := []struct {
 		metric Name
 		prom   string
 	}{
-		{InternalTracerFlushes, "obi_ebpf_tracer_flushes"},
-		{InternalOTELMetricExports, "obi_otel_metric_exports_total"},
-		{InternalOTELMetricExportErrors, "obi_otel_metric_export_errors_total"},
-		{InternalOTELTraceExports, "obi_otel_trace_exports_total"},
-		{InternalOTELTraceExportErrors, "obi_otel_trace_export_errors_total"},
-		{InternalInstrumentedProcesses, "obi_instrumented_processes"},
-		{InternalInstrumentationErrors, "obi_instrumentation_errors_total"},
-		{InternalAvoidedServices, "obi_avoided_services"},
-		{InternalBuildInfo, "obi_internal_build_info"},
-		{InternalBpfProbeLatency, "obi_bpf_probe_latency_seconds"},
-		{InternalBpfMapEntries, "obi_bpf_map_entries"},
-		{InternalBpfMapMaxEntries, "obi_bpf_map_max_entries"},
-		{InternalKubeCacheForwardLag, "obi_kube_cache_forward_lag_seconds"},
-		{InternalBpfNetworkIgnoredPackets, "obi_bpf_network_ignored_packets_total"},
-		{InternalBpfNetworkPackets, "obi_bpf_network_packets_total"},
-		{InternalQueueCapacityRatio, "obi_queue_capacity_ratio"},
+		{internal.TracerFlushes, "obi_ebpf_tracer_flushes"},
+		{internal.OTELMetricExports, "obi_otel_metric_exports_total"},
+		{internal.OTELMetricExportErrors, "obi_otel_metric_export_errors_total"},
+		{internal.OTELTraceExports, "obi_otel_trace_exports_total"},
+		{internal.OTELTraceExportErrors, "obi_otel_trace_export_errors_total"},
+		{internal.InstrumentedProcesses, "obi_instrumented_processes"},
+		{internal.InstrumentationErrors, "obi_instrumentation_errors_total"},
+		{internal.AvoidedServices, "obi_avoided_services"},
+		{internal.BuildInfo, "obi_internal_build_info"},
+		{internal.BpfProbeLatency, "obi_bpf_probe_latency_seconds"},
+		{internal.BpfMapEntries, "obi_bpf_map_entries"},
+		{internal.BpfMapMaxEntries, "obi_bpf_map_max_entries"},
+		{internal.KubeCacheForwardLag, "obi_kube_cache_forward_lag_seconds"},
+		{internal.BpfNetworkIgnoredPackets, "obi_bpf_network_ignored_packets_total"},
+		{internal.BpfNetworkPackets, "obi_bpf_network_packets_total"},
+		{internal.QueueCapacityRatio, "obi_queue_capacity_ratio"},
 	}
 
 	for _, test := range tests {
 		t.Run(test.metric.OTEL, func(t *testing.T) {
 			require.NotEmpty(t, test.metric.Prom)
 			assert.Equal(t, test.prom, test.metric.Prom)
+		})
+	}
+}
+
+// A component that vendors OBI can override attr.VendorPrefix, so the names must be built from
+// the prefix rather than baked in.
+func TestInternalMetricsHonourVendorPrefix(t *testing.T) {
+	vendored := NewInternalMetrics("beyla")
+
+	assert.Equal(t, "beyla.ebpf.tracer.flushes", vendored.TracerFlushes.OTEL)
+	assert.Equal(t, "beyla_ebpf_tracer_flushes", vendored.TracerFlushes.Prom)
+	assert.Equal(t, "beyla_bpf_network_packets_total", vendored.BpfNetworkPackets.Prom)
+	assert.Equal(t, "beyla_bpf_probe_latency_seconds", vendored.BpfProbeLatency.Prom)
+}
+
+func TestInternalMetricsAllDeclared(t *testing.T) {
+	internal := NewInternalMetrics("obi")
+
+	for name, m := range map[string]Name{
+		"TracerFlushes":            internal.TracerFlushes,
+		"OTELMetricExports":        internal.OTELMetricExports,
+		"OTELMetricExportErrors":   internal.OTELMetricExportErrors,
+		"OTELTraceExports":         internal.OTELTraceExports,
+		"OTELTraceExportErrors":    internal.OTELTraceExportErrors,
+		"InstrumentedProcesses":    internal.InstrumentedProcesses,
+		"InstrumentationErrors":    internal.InstrumentationErrors,
+		"AvoidedServices":          internal.AvoidedServices,
+		"BuildInfo":                internal.BuildInfo,
+		"BpfProbeLatency":          internal.BpfProbeLatency,
+		"BpfMapEntries":            internal.BpfMapEntries,
+		"BpfMapMaxEntries":         internal.BpfMapMaxEntries,
+		"KubeCacheForwardLag":      internal.KubeCacheForwardLag,
+		"BpfNetworkIgnoredPackets": internal.BpfNetworkIgnoredPackets,
+		"BpfNetworkPackets":        internal.BpfNetworkPackets,
+		"QueueCapacityRatio":       internal.QueueCapacityRatio,
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.NotEmpty(t, m.OTEL, "OTEL name must be set")
+			require.NotEmpty(t, m.Prom, "Prom name must be derived")
+			assert.True(t, strings.HasPrefix(m.OTEL, "obi."), "must carry the vendor prefix")
 		})
 	}
 }

--- a/pkg/export/attributes/metric_internal_test.go
+++ b/pkg/export/attributes/metric_internal_test.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package attributes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The expectations are the names OBI's internal Prometheus exporter emitted before these metrics
+// were declared here, so this pins the move as a refactor rather than a rename.
+func TestInternalPrometheusNames(t *testing.T) {
+	tests := []struct {
+		metric Name
+		prom   string
+	}{
+		{InternalTracerFlushes, "obi_ebpf_tracer_flushes"},
+		{InternalOTELMetricExports, "obi_otel_metric_exports_total"},
+		{InternalOTELMetricExportErrors, "obi_otel_metric_export_errors_total"},
+		{InternalOTELTraceExports, "obi_otel_trace_exports_total"},
+		{InternalOTELTraceExportErrors, "obi_otel_trace_export_errors_total"},
+		{InternalInstrumentedProcesses, "obi_instrumented_processes"},
+		{InternalInstrumentationErrors, "obi_instrumentation_errors_total"},
+		{InternalAvoidedServices, "obi_avoided_services"},
+		{InternalBuildInfo, "obi_internal_build_info"},
+		{InternalBpfProbeLatency, "obi_bpf_probe_latency_seconds"},
+		{InternalBpfMapEntries, "obi_bpf_map_entries"},
+		{InternalBpfMapMaxEntries, "obi_bpf_map_max_entries"},
+		{InternalKubeCacheForwardLag, "obi_kube_cache_forward_lag_seconds"},
+		{InternalBpfNetworkIgnoredPackets, "obi_bpf_network_ignored_packets_total"},
+		{InternalBpfNetworkPackets, "obi_bpf_network_packets_total"},
+		{InternalQueueCapacityRatio, "obi_queue_capacity_ratio"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.metric.OTEL, func(t *testing.T) {
+			require.NotEmpty(t, test.metric.Prom)
+			assert.Equal(t, test.prom, test.metric.Prom)
+		})
+	}
+}

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -59,10 +59,12 @@ type PrometheusReporter struct {
 }
 
 func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.PrometheusManager, registry *prometheus.Registry) *PrometheusReporter {
+	internalNames := attributes.NewInternalMetrics(attr.VendorPrefix)
+
 	pr := &PrometheusReporter{
 		connector: manager,
 		tracerFlushes: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:                            attributes.InternalTracerFlushes.Prom,
+			Name:                            internalNames.TracerFlushes.Prom,
 			Help:                            "Length of the groups of traces flushed from the eBPF tracer to the next pipeline stage",
 			Buckets:                         pipelineBufferLengths,
 			NativeHistogramBucketFactor:     1.1,
@@ -70,19 +72,19 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}),
 		otelMetricExports: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: attributes.InternalOTELMetricExports.Prom,
+			Name: internalNames.OTELMetricExports.Prom,
 			Help: "Length of the metric batches submitted to the remote OTEL collector",
 		}),
 		otelMetricExportErrs: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: attributes.InternalOTELMetricExportErrors.Prom,
+			Name: internalNames.OTELMetricExportErrors.Prom,
 			Help: "Error count on each failed OTEL metric export",
 		}, []string{"error"}),
 		otelTraceExports: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: attributes.InternalOTELTraceExports.Prom,
+			Name: internalNames.OTELTraceExports.Prom,
 			Help: "Length of the trace batches submitted to the remote OTEL collector",
 		}),
 		otelTraceExportErrs: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: attributes.InternalOTELTraceExportErrors.Prom,
+			Name: internalNames.OTELTraceExportErrors.Prom,
 			Help: "Error count on each failed OTEL trace export",
 		}, []string{"error"}),
 		prometheusRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -90,15 +92,15 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			Help: "Requests towards the Prometheus Scrape endpoint",
 		}, []string{"port", "path"}),
 		instrumentedProcesses: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: attributes.InternalInstrumentedProcesses.Prom,
+			Name: internalNames.InstrumentedProcesses.Prom,
 			Help: "Total number of instrumented processes by process name",
 		}, []string{"process_name"}),
 		instrumentationErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: attributes.InternalInstrumentationErrors.Prom,
+			Name: internalNames.InstrumentationErrors.Prom,
 			Help: "Total number of instrumentation errors by process name and error type",
 		}, []string{"process_name", "error_type"}),
 		buildInfo: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: attributes.InternalBuildInfo.Prom,
+			Name: internalNames.BuildInfo.Prom,
 			Help: "A metric with a constant '1' value labeled by version, revision, branch, " +
 				"goversion, goos and goarch during build.",
 			ConstLabels: map[string]string{
@@ -120,16 +122,16 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			Help: "Total latency of the BPF probes in seconds",
 		}, []string{"probe_id", "probe_type", "probe_name"}),
 		bpfMapEntries: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: attributes.InternalBpfMapEntries.Prom,
+			Name: internalNames.BpfMapEntries.Prom,
 			Help: "Total number of entries in the BPF maps",
 		}, []string{"map_id", "map_name", "map_type"}),
 		bpfMapMaxEntries: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: attributes.InternalBpfMapMaxEntries.Prom,
+			Name: internalNames.BpfMapMaxEntries.Prom,
 			Help: "Maximum number of entries in the BPF maps",
 		}, []string{"map_id", "map_name", "map_type"}),
 		bpfInternalMetricsScrapeInterval: cfg.BpfMetricScrapeInterval,
 		informerLag: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: attributes.InternalKubeCacheForwardLag.Prom,
+			Name: internalNames.KubeCacheForwardLag.Prom,
 			Help: "How long, in seconds, it takes since a Kubernetes event happens until it is forwarded to the subscribers",
 			// Since K8s stores the timestamps with second precision, we initially provide buckets larger than 0.5s
 			Buckets:                         InformerLagBuckets,
@@ -138,22 +140,22 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			NativeHistogramMinResetDuration: 10 * time.Minute,
 		}),
 		bpfIgnoredPacketCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: attributes.InternalBpfNetworkIgnoredPackets.Prom,
+			Name: internalNames.BpfNetworkIgnoredPackets.Prom,
 			Help: "How many network packets have been internally ignored due to collisions in the internal eBPF cache",
 		}),
 		bpfPacketCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: attributes.InternalBpfNetworkPackets.Prom,
+			Name: internalNames.BpfNetworkPackets.Prom,
 			Help: "How many network packets have been internally accounted",
 		}),
 		queueCapacityRatio: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: attributes.InternalQueueCapacityRatio.Prom,
+			Name: internalNames.QueueCapacityRatio.Prom,
 			Help: "Ratio [0-1] between the unread messages of an internal Go channel and its total capacity",
 		}, []string{"subscriber"}),
 	}
 	if !cfg.AvoidedServices.Disabled {
 		pr.avoidedServicesLimiter = avoidedsvc.NewLimiter(cfg.AvoidedServices.Limit)
 		pr.avoidedServices = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: attributes.InternalAvoidedServices.Prom,
+			Name: internalNames.AvoidedServices.Prom,
 			Help: "Services avoided due to existing OpenTelemetry instrumentation",
 		}, []string{
 			"service_name",

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"go.opentelemetry.io/obi/pkg/buildinfo"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/connector"
 	"go.opentelemetry.io/obi/pkg/internal/avoidedsvc"
@@ -61,7 +62,7 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 	pr := &PrometheusReporter{
 		connector: manager,
 		tracerFlushes: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:                            attr.VendorPrefix + "_ebpf_tracer_flushes",
+			Name:                            attributes.InternalTracerFlushes.Prom,
 			Help:                            "Length of the groups of traces flushed from the eBPF tracer to the next pipeline stage",
 			Buckets:                         pipelineBufferLengths,
 			NativeHistogramBucketFactor:     1.1,
@@ -69,19 +70,19 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			NativeHistogramMinResetDuration: 1 * time.Hour,
 		}),
 		otelMetricExports: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: attr.VendorPrefix + "_otel_metric_exports_total",
+			Name: attributes.InternalOTELMetricExports.Prom,
 			Help: "Length of the metric batches submitted to the remote OTEL collector",
 		}),
 		otelMetricExportErrs: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: attr.VendorPrefix + "_otel_metric_export_errors_total",
+			Name: attributes.InternalOTELMetricExportErrors.Prom,
 			Help: "Error count on each failed OTEL metric export",
 		}, []string{"error"}),
 		otelTraceExports: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: attr.VendorPrefix + "_otel_trace_exports_total",
+			Name: attributes.InternalOTELTraceExports.Prom,
 			Help: "Length of the trace batches submitted to the remote OTEL collector",
 		}),
 		otelTraceExportErrs: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: attr.VendorPrefix + "_otel_trace_export_errors_total",
+			Name: attributes.InternalOTELTraceExportErrors.Prom,
 			Help: "Error count on each failed OTEL trace export",
 		}, []string{"error"}),
 		prometheusRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -89,15 +90,15 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			Help: "Requests towards the Prometheus Scrape endpoint",
 		}, []string{"port", "path"}),
 		instrumentedProcesses: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: attr.VendorPrefix + "_instrumented_processes",
+			Name: attributes.InternalInstrumentedProcesses.Prom,
 			Help: "Total number of instrumented processes by process name",
 		}, []string{"process_name"}),
 		instrumentationErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: attr.VendorPrefix + "_instrumentation_errors_total",
+			Name: attributes.InternalInstrumentationErrors.Prom,
 			Help: "Total number of instrumentation errors by process name and error type",
 		}, []string{"process_name", "error_type"}),
 		buildInfo: prometheus.NewGauge(prometheus.GaugeOpts{
-			Name: attr.VendorPrefix + "_internal_build_info",
+			Name: attributes.InternalBuildInfo.Prom,
 			Help: "A metric with a constant '1' value labeled by version, revision, branch, " +
 				"goversion, goos and goarch during build.",
 			ConstLabels: map[string]string{
@@ -108,6 +109,8 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 				"revision":  buildinfo.Revision,
 			},
 		}),
+		// These two have no OTLP counterpart to derive from: the OTLP path exports the
+		// obi.bpf.probe.latency histogram instead, whose count and sum carry the same values.
 		bpfProbeExecutions: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: attr.VendorPrefix + "_bpf_probe_executions_total",
 			Help: "Total number of BPF probe executions",
@@ -117,16 +120,16 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			Help: "Total latency of the BPF probes in seconds",
 		}, []string{"probe_id", "probe_type", "probe_name"}),
 		bpfMapEntries: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: attr.VendorPrefix + "_bpf_map_entries_total",
+			Name: attributes.InternalBpfMapEntries.Prom,
 			Help: "Total number of entries in the BPF maps",
 		}, []string{"map_id", "map_name", "map_type"}),
 		bpfMapMaxEntries: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: attr.VendorPrefix + "_bpf_map_max_entries_total",
+			Name: attributes.InternalBpfMapMaxEntries.Prom,
 			Help: "Maximum number of entries in the BPF maps",
 		}, []string{"map_id", "map_name", "map_type"}),
 		bpfInternalMetricsScrapeInterval: cfg.BpfMetricScrapeInterval,
 		informerLag: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name: attr.VendorPrefix + "_kube_cache_forward_lag_seconds",
+			Name: attributes.InternalKubeCacheForwardLag.Prom,
 			Help: "How long, in seconds, it takes since a Kubernetes event happens until it is forwarded to the subscribers",
 			// Since K8s stores the timestamps with second precision, we initially provide buckets larger than 0.5s
 			Buckets:                         InformerLagBuckets,
@@ -135,22 +138,22 @@ func NewPrometheusReporter(cfg *InternalMetricsConfig, manager *connector.Promet
 			NativeHistogramMinResetDuration: 10 * time.Minute,
 		}),
 		bpfIgnoredPacketCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: attr.VendorPrefix + "_bpf_network_ignored_packets_total",
+			Name: attributes.InternalBpfNetworkIgnoredPackets.Prom,
 			Help: "How many network packets have been internally ignored due to collisions in the internal eBPF cache",
 		}),
 		bpfPacketCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Name: attr.VendorPrefix + "_bpf_network_packets_total",
+			Name: attributes.InternalBpfNetworkPackets.Prom,
 			Help: "How many network packets have been internally accounted",
 		}),
 		queueCapacityRatio: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: attr.VendorPrefix + "_queue_capacity_ratio",
+			Name: attributes.InternalQueueCapacityRatio.Prom,
 			Help: "Ratio [0-1] between the unread messages of an internal Go channel and its total capacity",
 		}, []string{"subscriber"}),
 	}
 	if !cfg.AvoidedServices.Disabled {
 		pr.avoidedServicesLimiter = avoidedsvc.NewLimiter(cfg.AvoidedServices.Limit)
 		pr.avoidedServices = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Name: attr.VendorPrefix + "_avoided_services",
+			Name: attributes.InternalAvoidedServices.Prom,
 			Help: "Services avoided due to existing OpenTelemetry instrumentation",
 		}, []string{
 			"service_name",

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -69,21 +69,26 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 		return nil, err
 	}
 
+	internalNames := attributes.NewInternalMetrics(attr.VendorPrefix)
+
 	res := newResourceInternal(&ctxInfo.NodeMeta)
-	bpfProbeLatency := newBpfProbeLatencyProducer(exporter.Temporality(metric.InstrumentKindHistogram))
+	bpfProbeLatency := newBpfProbeLatencyProducer(
+		internalNames.BpfProbeLatency,
+		exporter.Temporality(metric.InstrumentKindHistogram),
+	)
 	provider := newInternalMeterProvider(res, &exporter, metrics.Interval, bpfProbeLatency)
 	meter := provider.Meter(internalMetricsMeterName)
 	tracerFlushes, err := meter.Float64Histogram(
-		attributes.InternalTracerFlushes.OTEL,
+		internalNames.TracerFlushes.OTEL,
 		instrument.WithDescription("Length of the groups of traces flushed from the eBPF tracer to the next pipeline stage"),
-		instrument.WithUnit(attributes.InternalTracerFlushes.Unit),
+		instrument.WithUnit(internalNames.TracerFlushes.Unit),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	otelMetricExports, err := meter.Float64Counter(
-		attributes.InternalOTELMetricExports.OTEL,
+		internalNames.OTELMetricExports.OTEL,
 		instrument.WithDescription("Length of the metric batches submitted to the remote OTEL collector"),
 	)
 	if err != nil {
@@ -91,7 +96,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	otelMetricExportErrs, err := meter.Float64Counter(
-		attributes.InternalOTELMetricExportErrors.OTEL,
+		internalNames.OTELMetricExportErrors.OTEL,
 		instrument.WithDescription("Error count on each failed OTEL metric export"),
 	)
 	if err != nil {
@@ -99,7 +104,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	otelTraceExports, err := meter.Float64Counter(
-		attributes.InternalOTELTraceExports.OTEL,
+		internalNames.OTELTraceExports.OTEL,
 		instrument.WithDescription("Length of the trace batches submitted to the remote OTEL collector"),
 	)
 	if err != nil {
@@ -107,7 +112,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	otelTraceExportErrs, err := meter.Float64Counter(
-		attributes.InternalOTELTraceExportErrors.OTEL,
+		internalNames.OTELTraceExportErrors.OTEL,
 		instrument.WithDescription("Error count on each failed OTEL trace export"),
 	)
 	if err != nil {
@@ -115,7 +120,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	instrumentedProcesses, err := meter.Int64UpDownCounter(
-		attributes.InternalInstrumentedProcesses.OTEL,
+		internalNames.InstrumentedProcesses.OTEL,
 		instrument.WithDescription("Total number of instrumented processes by process name"),
 	)
 	if err != nil {
@@ -123,7 +128,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	instrumentationErrors, err := meter.Int64Counter(
-		attributes.InternalInstrumentationErrors.OTEL,
+		internalNames.InstrumentationErrors.OTEL,
 		instrument.WithDescription("Total number of instrumentation errors by process name and error type"),
 	)
 	if err != nil {
@@ -134,7 +139,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	var avoidedServicesLimiter *avoidedsvc.Limiter
 	if !internalMetrics.AvoidedServices.Disabled {
 		avoidedServices, err = meter.Int64Gauge(
-			attributes.InternalAvoidedServices.OTEL,
+			internalNames.AvoidedServices.OTEL,
 			instrument.WithDescription("Services avoided due to existing OpenTelemetry instrumentation"),
 		)
 		if err != nil {
@@ -144,7 +149,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	buildInfo, err := meter.Int64Gauge(
-		attributes.InternalBuildInfo.OTEL,
+		internalNames.BuildInfo.OTEL,
 		instrument.WithDescription("A metric with a constant '1' value labeled by version, revision, branch, goversion, goos and goarch during build."),
 	)
 	if err != nil {
@@ -152,14 +157,14 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	bpfMapEntries, err := meter.Int64Gauge(
-		attributes.InternalBpfMapEntries.OTEL,
+		internalNames.BpfMapEntries.OTEL,
 		instrument.WithDescription("Number of entries in the eBPF map"),
 	)
 	if err != nil {
 		return nil, err
 	}
 	bpfMapMaxEntries, err := meter.Int64Gauge(
-		attributes.InternalBpfMapMaxEntries.OTEL,
+		internalNames.BpfMapMaxEntries.OTEL,
 		instrument.WithDescription("Max number of entries in the eBPF map"),
 	)
 	if err != nil {
@@ -167,9 +172,9 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	informerLag, err := meter.Float64Histogram(
-		attributes.InternalKubeCacheForwardLag.OTEL,
+		internalNames.KubeCacheForwardLag.OTEL,
 		instrument.WithDescription("How long, in seconds, it takes since a Kubernetes event happens until it is forwarded to the subscribers"),
-		instrument.WithUnit(attributes.InternalKubeCacheForwardLag.Unit),
+		instrument.WithUnit(internalNames.KubeCacheForwardLag.Unit),
 		instrument.WithExplicitBucketBoundaries(
 			imetrics.InformerLagBuckets...,
 		),
@@ -179,27 +184,27 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	bpfIgnoredPacketCount, err := meter.Int64Counter(
-		attributes.InternalBpfNetworkIgnoredPackets.OTEL,
+		internalNames.BpfNetworkIgnoredPackets.OTEL,
 		instrument.WithDescription("How many network packets have been internally ignored due to collisions in the internal eBPF cache"),
-		instrument.WithUnit(attributes.InternalBpfNetworkIgnoredPackets.Unit),
+		instrument.WithUnit(internalNames.BpfNetworkIgnoredPackets.Unit),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	bpfPacketCount, err := meter.Int64Counter(
-		attributes.InternalBpfNetworkPackets.OTEL,
+		internalNames.BpfNetworkPackets.OTEL,
 		instrument.WithDescription("How many network packets have been internally accounted"),
-		instrument.WithUnit(attributes.InternalBpfNetworkPackets.Unit),
+		instrument.WithUnit(internalNames.BpfNetworkPackets.Unit),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	queueCapacityRatio, err := meter.Float64Gauge(
-		attributes.InternalQueueCapacityRatio.OTEL,
+		internalNames.QueueCapacityRatio.OTEL,
 		instrument.WithDescription("Ratio [0-1] between the unread messages of an internal Go channel and its total capacity"),
-		instrument.WithUnit(attributes.InternalQueueCapacityRatio.Unit))
+		instrument.WithUnit(internalNames.QueueCapacityRatio.Unit))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -19,6 +19,7 @@ import (
 
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
 	"go.opentelemetry.io/obi/pkg/buildinfo"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
@@ -73,16 +74,16 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	provider := newInternalMeterProvider(res, &exporter, metrics.Interval, bpfProbeLatency)
 	meter := provider.Meter(internalMetricsMeterName)
 	tracerFlushes, err := meter.Float64Histogram(
-		attr.VendorPrefix+".ebpf.tracer.flushes",
+		attributes.InternalTracerFlushes.OTEL,
 		instrument.WithDescription("Length of the groups of traces flushed from the eBPF tracer to the next pipeline stage"),
-		instrument.WithUnit("1"),
+		instrument.WithUnit(attributes.InternalTracerFlushes.Unit),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	otelMetricExports, err := meter.Float64Counter(
-		attr.VendorPrefix+".otel.metric.exports",
+		attributes.InternalOTELMetricExports.OTEL,
 		instrument.WithDescription("Length of the metric batches submitted to the remote OTEL collector"),
 	)
 	if err != nil {
@@ -90,7 +91,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	otelMetricExportErrs, err := meter.Float64Counter(
-		attr.VendorPrefix+".otel.metric.export.errors",
+		attributes.InternalOTELMetricExportErrors.OTEL,
 		instrument.WithDescription("Error count on each failed OTEL metric export"),
 	)
 	if err != nil {
@@ -98,7 +99,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	otelTraceExports, err := meter.Float64Counter(
-		attr.VendorPrefix+".otel.trace.exports",
+		attributes.InternalOTELTraceExports.OTEL,
 		instrument.WithDescription("Length of the trace batches submitted to the remote OTEL collector"),
 	)
 	if err != nil {
@@ -106,7 +107,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	otelTraceExportErrs, err := meter.Float64Counter(
-		attr.VendorPrefix+".otel.trace.export.errors",
+		attributes.InternalOTELTraceExportErrors.OTEL,
 		instrument.WithDescription("Error count on each failed OTEL trace export"),
 	)
 	if err != nil {
@@ -114,7 +115,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	instrumentedProcesses, err := meter.Int64UpDownCounter(
-		attr.VendorPrefix+".instrumented.processes",
+		attributes.InternalInstrumentedProcesses.OTEL,
 		instrument.WithDescription("Total number of instrumented processes by process name"),
 	)
 	if err != nil {
@@ -122,7 +123,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	instrumentationErrors, err := meter.Int64Counter(
-		attr.VendorPrefix+".instrumentation.errors",
+		attributes.InternalInstrumentationErrors.OTEL,
 		instrument.WithDescription("Total number of instrumentation errors by process name and error type"),
 	)
 	if err != nil {
@@ -133,7 +134,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	var avoidedServicesLimiter *avoidedsvc.Limiter
 	if !internalMetrics.AvoidedServices.Disabled {
 		avoidedServices, err = meter.Int64Gauge(
-			attr.VendorPrefix+".avoided.services",
+			attributes.InternalAvoidedServices.OTEL,
 			instrument.WithDescription("Services avoided due to existing OpenTelemetry instrumentation"),
 		)
 		if err != nil {
@@ -143,7 +144,7 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	buildInfo, err := meter.Int64Gauge(
-		attr.VendorPrefix+".internal.build.info",
+		attributes.InternalBuildInfo.OTEL,
 		instrument.WithDescription("A metric with a constant '1' value labeled by version, revision, branch, goversion, goos and goarch during build."),
 	)
 	if err != nil {
@@ -151,14 +152,14 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	bpfMapEntries, err := meter.Int64Gauge(
-		attr.VendorPrefix+".bpf.map.entries_total",
+		attributes.InternalBpfMapEntries.OTEL,
 		instrument.WithDescription("Number of entries in the eBPF map"),
 	)
 	if err != nil {
 		return nil, err
 	}
 	bpfMapMaxEntries, err := meter.Int64Gauge(
-		attr.VendorPrefix+".bpf.map.max_entries_total",
+		attributes.InternalBpfMapMaxEntries.OTEL,
 		instrument.WithDescription("Max number of entries in the eBPF map"),
 	)
 	if err != nil {
@@ -166,9 +167,9 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	informerLag, err := meter.Float64Histogram(
-		attr.VendorPrefix+".kube.cache.forward.lag",
+		attributes.InternalKubeCacheForwardLag.OTEL,
 		instrument.WithDescription("How long, in seconds, it takes since a Kubernetes event happens until it is forwarded to the subscribers"),
-		instrument.WithUnit("s"),
+		instrument.WithUnit(attributes.InternalKubeCacheForwardLag.Unit),
 		instrument.WithExplicitBucketBoundaries(
 			imetrics.InformerLagBuckets...,
 		),
@@ -178,27 +179,27 @@ func NewInternalMetricsReporter(ctx context.Context, ctxInfo *global.ContextInfo
 	}
 
 	bpfIgnoredPacketCount, err := meter.Int64Counter(
-		attr.VendorPrefix+".bpf.network.ignored.packets.total",
+		attributes.InternalBpfNetworkIgnoredPackets.OTEL,
 		instrument.WithDescription("How many network packets have been internally ignored due to collisions in the internal eBPF cache"),
-		instrument.WithUnit("{packet}"),
+		instrument.WithUnit(attributes.InternalBpfNetworkIgnoredPackets.Unit),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	bpfPacketCount, err := meter.Int64Counter(
-		attr.VendorPrefix+".bpf.network.packets.total",
+		attributes.InternalBpfNetworkPackets.OTEL,
 		instrument.WithDescription("How many network packets have been internally accounted"),
-		instrument.WithUnit("{packet}"),
+		instrument.WithUnit(attributes.InternalBpfNetworkPackets.Unit),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	queueCapacityRatio, err := meter.Float64Gauge(
-		attr.VendorPrefix+".queue.capacity.ratio",
+		attributes.InternalQueueCapacityRatio.OTEL,
 		instrument.WithDescription("Ratio [0-1] between the unread messages of an internal Go channel and its total capacity"),
-		instrument.WithUnit("1"))
+		instrument.WithUnit(attributes.InternalQueueCapacityRatio.Unit))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/export/otel/metrics_internal_bpf_histogram.go
+++ b/pkg/export/otel/metrics_internal_bpf_histogram.go
@@ -14,13 +14,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/instrumentation"
 	metricdata "go.opentelemetry.io/otel/sdk/metric/metricdata"
 
-	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 )
-
-// bpfProbeLatencyMetricName is the OTLP counterpart of the Prometheus
-// bpf_probe_latency_seconds const histogram.
-var bpfProbeLatencyMetricName = attr.VendorPrefix + ".bpf.probe.latency"
 
 type bpfProbeKey struct {
 	probeID   string
@@ -156,9 +152,9 @@ func (p *bpfProbeLatencyProducer) Produce(ctx context.Context) ([]metricdata.Sco
 	return []metricdata.ScopeMetrics{{
 		Scope: instrumentation.Scope{Name: internalMetricsMeterName},
 		Metrics: []metricdata.Metrics{{
-			Name:        bpfProbeLatencyMetricName,
+			Name:        attributes.InternalBpfProbeLatency.OTEL,
 			Description: "Latency distribution of the eBPF probe in seconds",
-			Unit:        "s",
+			Unit:        attributes.InternalBpfProbeLatency.Unit,
 			Data: metricdata.Histogram[float64]{
 				Temporality: metricdata.CumulativeTemporality,
 				DataPoints:  dataPoints,

--- a/pkg/export/otel/metrics_internal_bpf_histogram.go
+++ b/pkg/export/otel/metrics_internal_bpf_histogram.go
@@ -62,14 +62,16 @@ func subtractBpfProbeLatency(current, previous bpfProbeLatencyState) bpfProbeLat
 // instead and emits explicit bounds and bucket counts.
 type bpfProbeLatencyProducer struct {
 	mu           sync.Mutex
+	name         attributes.Name
 	temporality  metricdata.Temporality
 	startTime    time.Time
 	probes       map[bpfProbeKey]*bpfProbeLatencyState
 	lastProduced map[bpfProbeKey]bpfProbeLatencyState
 }
 
-func newBpfProbeLatencyProducer(temporality metricdata.Temporality) *bpfProbeLatencyProducer {
+func newBpfProbeLatencyProducer(name attributes.Name, temporality metricdata.Temporality) *bpfProbeLatencyProducer {
 	return &bpfProbeLatencyProducer{
+		name:         name,
 		temporality:  temporality,
 		startTime:    timeNow(),
 		probes:       make(map[bpfProbeKey]*bpfProbeLatencyState),
@@ -152,9 +154,9 @@ func (p *bpfProbeLatencyProducer) Produce(ctx context.Context) ([]metricdata.Sco
 	return []metricdata.ScopeMetrics{{
 		Scope: instrumentation.Scope{Name: internalMetricsMeterName},
 		Metrics: []metricdata.Metrics{{
-			Name:        attributes.InternalBpfProbeLatency.OTEL,
+			Name:        p.name.OTEL,
 			Description: "Latency distribution of the eBPF probe in seconds",
-			Unit:        attributes.InternalBpfProbeLatency.Unit,
+			Unit:        p.name.Unit,
 			Data: metricdata.Histogram[float64]{
 				Temporality: metricdata.CumulativeTemporality,
 				DataPoints:  dataPoints,

--- a/pkg/export/otel/metrics_internal_test.go
+++ b/pkg/export/otel/metrics_internal_test.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/obi/internal/test/collector"
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
+	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
@@ -57,7 +58,10 @@ func TestInternalMetricsReporterBpfProbeStats(t *testing.T) {
 
 func TestBpfProbeLatencyProducerDeltaTemporality(t *testing.T) {
 	bound := imetrics.BpfLatenciesBuckets[0]
-	producer := newBpfProbeLatencyProducer(metricdata.DeltaTemporality)
+	producer := newBpfProbeLatencyProducer(
+		attributes.NewInternalMetrics(attr.VendorPrefix).BpfProbeLatency,
+		metricdata.DeltaTemporality,
+	)
 
 	producer.Update("7", "kprobe", "tcp_connect", 2, 0.5, map[float64]uint64{bound: 2})
 	first := produceHistogramPoint(t, producer)

--- a/pkg/export/prom/prom_bpf_test.go
+++ b/pkg/export/prom/prom_bpf_test.go
@@ -138,12 +138,12 @@ func TestBPFMetricsCollectsInternalMetricsForPrometheusReporter(t *testing.T) {
 			"probe_type": "kprobe",
 			"probe_name": "tcp_connect",
 		})
-		mapEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_entries_total", map[string]string{
+		mapEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_entries", map[string]string{
 			"map_id":   "3",
 			"map_name": "connections",
 			"map_type": "hash",
 		})
-		mapMaxEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_max_entries_total", map[string]string{
+		mapMaxEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_max_entries", map[string]string{
 			"map_id":   "3",
 			"map_name": "connections",
 			"map_type": "hash",
@@ -299,12 +299,12 @@ func TestBPFMetricsCollectsInternalMetricsWhenPrometheusEndpointEnabled(t *testi
 			"probe_type": "kprobe",
 			"probe_name": "tcp_connect",
 		})
-		mapEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_entries_total", map[string]string{
+		mapEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_entries", map[string]string{
 			"map_id":   "3",
 			"map_name": "connections",
 			"map_type": "hash",
 		})
-		mapMaxEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_max_entries_total", map[string]string{
+		mapMaxEntriesMetric := gatheredMetric(t, registry, "obi_bpf_map_max_entries", map[string]string{
 			"map_id":   "3",
 			"map_name": "connections",
 			"map_type": "hash",

--- a/schemas/obi/groups/obi_internal.yaml
+++ b/schemas/obi/groups/obi_internal.yaml
@@ -324,9 +324,9 @@ groups:
       - ref: bpf.probe.type
       - ref: bpf.probe.name
 
-  - id: metric.obi.bpf.map.entries_total
+  - id: metric.obi.bpf.map.entries
     type: metric
-    metric_name: obi.bpf.map.entries_total
+    metric_name: obi.bpf.map.entries
     instrument: gauge
     unit: ""
     stability: development
@@ -336,9 +336,9 @@ groups:
       - ref: bpf.map.type
       - ref: bpf.map.name
 
-  - id: metric.obi.bpf.map.max_entries_total
+  - id: metric.obi.bpf.map.max_entries
     type: metric
-    metric_name: obi.bpf.map.max_entries_total
+    metric_name: obi.bpf.map.max_entries
     instrument: gauge
     unit: ""
     stability: development
@@ -349,17 +349,17 @@ groups:
       - ref: bpf.map.name
 
   # --- Network packet accounting (netolly) -------------------------------
-  - id: metric.obi.bpf.network.packets.total
+  - id: metric.obi.bpf.network.packets
     type: metric
-    metric_name: obi.bpf.network.packets.total
+    metric_name: obi.bpf.network.packets
     instrument: counter
     unit: "{packet}"
     stability: development
     brief: How many network packets have been internally accounted.
 
-  - id: metric.obi.bpf.network.ignored.packets.total
+  - id: metric.obi.bpf.network.ignored.packets
     type: metric
-    metric_name: obi.bpf.network.ignored.packets.total
+    metric_name: obi.bpf.network.ignored.packets
     instrument: counter
     unit: "{packet}"
     stability: development


### PR DESCRIPTION
## Summary

Two related changes to OBI's internal (`obi.*`) metrics.

**1. Four OTLP names end in `_total`**, which denotes a monotonic counter — two of them are gauges.
That suffix belongs to the Prometheus rendering, where it is derived from the instrument type and
unit.

| OTLP name | after | instrument |
|---|---|---|
| `obi.bpf.map.entries_total` | `obi.bpf.map.entries` | gauge |
| `obi.bpf.map.max_entries_total` | `obi.bpf.map.max_entries` | gauge |
| `obi.bpf.network.packets.total` | `obi.bpf.network.packets` | counter |
| `obi.bpf.network.ignored.packets.total` | `obi.bpf.network.ignored.packets` | counter |

**2. Internal metrics now declare their name once**, extending the derive-don't-hand-write approach
to the last place it was missing. They were written twice — the OTLP name in
`pkg/export/otel/metrics_internal.go`, the Prometheus name in `pkg/export/imetrics/iprom.go` — with
nothing keeping them consistent. They are now declared in
`pkg/export/attributes/metric_internal.go` and both exporters read `OTEL` / `Unit` / `Prom` from
there, including the `obi.bpf.probe.latency` histogram, whose name was still a local `var`.

This is a refactor, not a rename: `TestInternalPrometheusNames` pins every derived Prometheus name
against what the exporters emitted before, and they match exactly. It also makes the rename above
self-consistent — previously the two map gauges had to be edited by hand in both files to stay
aligned.

Three metrics stay hand-written in `iprom.go` because they have no OTLP counterpart to derive from:
`obi_prometheus_http_requests_total` (`PrometheusRequest` is a no-op on the OTLP side), and
`obi_bpf_probe_executions_total` / `obi_bpf_probe_latency_seconds_total`, whose OTLP equivalents
were replaced by the latency histogram's count and sum.

## Breaking changes

**All four OTLP names change**, so a backend consuming OBI's OTLP directly sees four renames. On the
Prometheus side it depends on the translation:

- Default (`add_metric_suffixes: true`): only the two map gauges move —
  `obi_bpf_map_entries_total` → `obi_bpf_map_entries`, `obi_bpf_map_max_entries_total` →
  `obi_bpf_map_max_entries`. The counters are unchanged, because `_total` is de-duplicated and
  re-appended.
- With `add_metric_suffixes: false` or a no-suffix / `NoTranslation` strategy, the counters move too.

Both are internal meta-metrics about OBI itself, not application telemetry.

```yaml
metric_relabel_configs:
  - source_labels: [__name__]
    regex: 'obi_bpf_map_entries'
    target_label: __name__
    replacement: 'obi_bpf_map_entries_total'
  - source_labels: [__name__]
    regex: 'obi_bpf_map_max_entries'
    target_label: __name__
    replacement: 'obi_bpf_map_max_entries_total'
```

`metric_relabel_configs` only helps scrape-time consumers. On an OTLP → collector → remote-write
path, use a collector `transform` rule instead.

The un-prefixed `bpf_map_entries_total` on the application endpoint (`prom_bpf.go`) has the same
defect — a point-in-time entry count typed and named as a counter — but it is a different metric
with a different label set, so it is left for a focused fix.

## Not included

Internal metric *label* names (`map_*` → `bpf_map_*`, `process_name` →
`process_executable_name`, `error` → `obi_error`) still differ between the two exporters. That is a
separate, wider breaking change and the last remaining step for internal metrics.

## Testing

`GOOS=linux go build ./...`, `go vet`, `gofmt` and `make lint-schema` clean; `./pkg/export/...`
passes. `TestInternalPrometheusNames` covers all 16 declarations. Assertions updated in
`prom_bpf_test.go` and `internal_metrics_otel_test.go`, the latter now expecting the histogram's
`_count` series rather than the two removed counters; the integration suite was not run locally.

`TestTerminatesOnBadPromPort` is a pre-existing flake — it binds a random port and intermittently
hits `bind: address already in use`, reproducible on repeat runs — so budget a retry rather than
reading it as a regression.

## Validation

- [x] I have read and followed the contributing guidelines
- [ ] If this enhances / fixes / changes a core feature, I have updated the features
      documentation and support matrix as needed.
