### PR TITLE
Fix stale go trace map data

### DIFF
--- a/bpf/gotracer/go_runtime.c
+++ b/bpf/gotracer/go_runtime.c
@@ -703,6 +703,9 @@ int obi_uprobe_runtime_newproc1(struct pt_regs *ctx) {
         bpf_dbg_printk("can't update map element");
     }
 
+    // Delete any stale info on go_trace_map
+    bpf_map_delete_elem(&go_trace_map, &g_key);
+
     return 0;
 }
 
@@ -757,26 +760,6 @@ int obi_uprobe_runtime_newproc1_return(struct pt_regs *ctx) {
 
 done:
     bpf_map_delete_elem(&newproc1, &c_key);
-
-    return 0;
-}
-
-SEC("uprobe/runtime_goexit1")
-int beyla_uprobe_proc_goexit1(struct pt_regs *ctx) {
-    bpf_dbg_printk("=== uprobe/proc goexit1 === ");
-
-    void *goroutine_addr = GOROUTINE_PTR(ctx);
-    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
-
-    u64 pid_tid = bpf_get_current_pid_tgid();
-    u32 pid = pid_from_pid_tgid(pid_tid);
-
-    go_addr_key_t g_key = {.addr = (u64)goroutine_addr, .pid = pid};
-
-    //bpf_map_delete_elem(&ongoing_goroutines, &g_key);
-    // We also clean-up the go routine based trace map, it's an LRU
-    // but at this point we are sure we don't need the data.
-    bpf_map_delete_elem(&go_trace_map, &g_key);
 
     return 0;
 }

--- a/bpf/gotracer/go_runtime.c
+++ b/bpf/gotracer/go_runtime.c
@@ -703,9 +703,6 @@ int obi_uprobe_runtime_newproc1(struct pt_regs *ctx) {
         bpf_dbg_printk("can't update map element");
     }
 
-    // Delete any stale info on go_trace_map
-    bpf_map_delete_elem(&go_trace_map, &g_key);
-
     return 0;
 }
 
@@ -759,6 +756,8 @@ int obi_uprobe_runtime_newproc1_return(struct pt_regs *ctx) {
     }
 
 done:
+    // Delete any stale info on go_trace_map
+    bpf_map_delete_elem(&go_trace_map, &g_key);
     bpf_map_delete_elem(&newproc1, &c_key);
 
     return 0;

--- a/bpf/gotracer/go_runtime.c
+++ b/bpf/gotracer/go_runtime.c
@@ -716,6 +716,10 @@ int obi_uprobe_runtime_newproc1_return(struct pt_regs *ctx) {
 
     bpf_dbg_printk("creator_goroutine_addr=%lx", creator_goroutine_addr);
 
+    // The result of newproc1 is the new goroutine
+    void *goroutine_addr = (void *)GO_PARAM1(ctx);
+    go_addr_key_t g_key = {.addr = (u64)goroutine_addr, .pid = pid};
+
     // Lookup the newproc1 invocation metadata
     new_func_invocation_t *invocation = bpf_map_lookup_elem(&newproc1, &c_key);
     if (invocation == NULL) {
@@ -727,8 +731,6 @@ int obi_uprobe_runtime_newproc1_return(struct pt_regs *ctx) {
     void *parent_goroutine = (void *)invocation->parent;
     bpf_dbg_printk("parent_goroutine=%lx", parent_goroutine);
 
-    // The result of newproc1 is the new goroutine
-    void *goroutine_addr = (void *)GO_PARAM1(ctx);
     bpf_dbg_printk("goroutine_addr=%lx", goroutine_addr);
 
     go_addr_key_t p_key = {.addr = (u64)parent_goroutine, .pid = pid};
@@ -743,8 +745,6 @@ int obi_uprobe_runtime_newproc1_return(struct pt_regs *ctx) {
             goto done;
         }
     }
-
-    go_addr_key_t g_key = {.addr = (u64)goroutine_addr, .pid = pid};
 
     goroutine_metadata metadata = {
         .timestamp = bpf_ktime_get_ns(),

--- a/bpf/gotracer/go_runtime.c
+++ b/bpf/gotracer/go_runtime.c
@@ -761,6 +761,26 @@ done:
     return 0;
 }
 
+SEC("uprobe/runtime_goexit1")
+int beyla_uprobe_proc_goexit1(struct pt_regs *ctx) {
+    bpf_dbg_printk("=== uprobe/proc goexit1 === ");
+
+    void *goroutine_addr = GOROUTINE_PTR(ctx);
+    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);
+
+    u64 pid_tid = bpf_get_current_pid_tgid();
+    u32 pid = pid_from_pid_tgid(pid_tid);
+
+    go_addr_key_t g_key = {.addr = (u64)goroutine_addr, .pid = pid};
+
+    //bpf_map_delete_elem(&ongoing_goroutines, &g_key);
+    // We also clean-up the go routine based trace map, it's an LRU
+    // but at this point we are sure we don't need the data.
+    bpf_map_delete_elem(&go_trace_map, &g_key);
+
+    return 0;
+}
+
 static __always_inline bool valid_tp_info(const tp_info_t *tp) {
     return tp && valid_trace(tp->trace_id) && valid_span(tp->span_id);
 }

--- a/internal/test/integration/components/gomemcached/Dockerfile
+++ b/internal/test/integration/components/gomemcached/Dockerfile
@@ -1,0 +1,24 @@
+# Build the testserver binary
+# Docker command must be invoked from the projec root directory
+FROM golang:1.26.3@sha256:efaccb5b497e90df3ebe5216cc25cd9f98e73874e2d638b56e38d4a3f098c41c AS builder
+
+ARG TARGETARCH
+
+ENV GOARCH=$TARGETARCH
+
+WORKDIR /src
+
+# Copy the go manifests and source
+COPY . .
+
+# Build
+RUN go build -o testserver main.go
+
+# Create final image from minimal + built binary
+FROM debian:bookworm-slim@sha256:74d56e3931e0d5a1dd51f8c8a2466d21de84a271cd3b5a733b803aa91abf4421
+
+WORKDIR /
+COPY --from=builder /src/testserver .
+USER 0:0
+
+CMD [ "/testserver" ]

--- a/internal/test/integration/components/gomemcached/go.mod
+++ b/internal/test/integration/components/gomemcached/go.mod
@@ -1,0 +1,5 @@
+module go.opentelemetry.io/obi/internal/test/integration/components/gomemcached
+
+go 1.25.11
+
+require github.com/grafana/gomemcache v0.0.0-20260728143316-9448343bd654

--- a/internal/test/integration/components/gomemcached/go.sum
+++ b/internal/test/integration/components/gomemcached/go.sum
@@ -1,0 +1,2 @@
+github.com/grafana/gomemcache v0.0.0-20260728143316-9448343bd654 h1:d04mpP3+tVfBec0NkKKASCnzps5xfd8UY5gBoVFOba0=
+github.com/grafana/gomemcache v0.0.0-20260728143316-9448343bd654/go.mod h1:j/s0jkda4UXTemDs7Pgw/vMT06alWc42CHisvYac0qw=

--- a/internal/test/integration/components/gomemcached/main.go
+++ b/internal/test/integration/components/gomemcached/main.go
@@ -1,0 +1,110 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/grafana/gomemcache/memcache"
+)
+
+const memcachedAddr = "memcached:11211"
+
+func newClient() *memcache.Client {
+	client := memcache.New(memcachedAddr)
+	client.Timeout = 5 * time.Second
+	client.ConnectTimeout = 5 * time.Second
+	return client
+}
+
+func memcachedPath() ([]byte, error) {
+	client := newClient()
+	defer client.Close()
+
+	if err := client.Set(&memcache.Item{Key: "session-key", Value: []byte("value"), Expiration: 300}); err != nil {
+		return nil, err
+	}
+
+	item, err := client.Get("session-key")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := client.Delete("session-key"); err != nil {
+		return nil, err
+	}
+
+	return item.Value, nil
+}
+
+func memcachedErrorPath() {
+	client := newClient()
+	defer client.Close()
+
+	// Trigger a CLIENT_ERROR by trying to increment a non-numeric value.
+	// memcached responds: CLIENT_ERROR cannot increment or decrement non-numeric value
+	if err := client.Set(&memcache.Item{Key: "error-key", Value: []byte("not-a-number"), Expiration: 300}); err != nil {
+		return
+	}
+
+	_, _ = client.Increment("error-key", 1)
+}
+
+func memcachedNoreplyPath() error {
+	conn, err := net.DialTimeout("tcp", memcachedAddr, 5*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_, err = conn.Write([]byte("set touch-key 0 300 5 noreply\r\nvalue\r\ntouch touch-key 60 noreply\r\n"))
+	return err
+}
+
+func writeResponse(rw http.ResponseWriter, body []byte) {
+	rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	rw.WriteHeader(http.StatusOK)
+	_, _ = rw.Write(body)
+}
+
+func HTTPHandler(log *slog.Logger) http.HandlerFunc {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		log.Debug("received request", "url", req.RequestURI)
+
+		switch req.URL.Path {
+		case "/memcached":
+			value, err := memcachedPath()
+			if err != nil {
+				log.Debug("memcached path failed", "error", err)
+				rw.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			writeResponse(rw, value)
+		case "/memcached-error":
+			memcachedErrorPath()
+			writeResponse(rw, []byte("error triggered"))
+		case "/memcached-noreply":
+			if err := memcachedNoreplyPath(); err != nil {
+				log.Debug("memcached noreply path failed", "error", err)
+				rw.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			writeResponse(rw, []byte("noreply triggered"))
+		default:
+			rw.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func main() {
+	log := slog.With("component", "gomemcached")
+	address := ":8080"
+	log.Info("starting HTTP server", "address", address, "process_id", os.Getpid())
+	err := http.ListenAndServe(address, HTTPHandler(log)) //nolint:gosec // test component, no timeouts needed
+	log.Error("HTTP server has unexpectedly stopped", "error", err)
+}

--- a/internal/test/oats/memcached/docker-compose-obi-go-memcached.yml
+++ b/internal/test/oats/memcached/docker-compose-obi-go-memcached.yml
@@ -38,7 +38,6 @@ services:
       OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
       OTEL_EBPF_LOG_LEVEL: "DEBUG"
       OTEL_EBPF_BPF_DEBUG: "true"
-      OTEL_EBPF_SKIP_GO_SPECIFIC_TRACERS: "true"
       # Export through the weaver-tapping collector instead of straight to lgtm,
       # so weaver validates the emitted telemetry (collector + weaver come from
       # the shared ../weaver/docker-compose-weaver.yml fragment).

--- a/internal/test/oats/memcached/docker-compose-obi-go-memcached.yml
+++ b/internal/test/oats/memcached/docker-compose-obi-go-memcached.yml
@@ -1,0 +1,48 @@
+services:
+  memcached:
+    image: memcached:1.6.39-alpine@sha256:c8503d4491edd3110cc07d0465089d3a41cf1daf8645e71149e39a51835e92cd
+    ports:
+      - "11211:11211"
+
+  testserver:
+    build:
+      context: ../../integration/components/gomemcached
+      dockerfile: Dockerfile
+    image: gomemcachedclient
+    ports:
+      - "8080:8080"
+    depends_on:
+      memcached:
+        condition: service_started
+
+  autoinstrumenter:
+    build:
+      context: ../../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    command:
+      - --config=/configs/instrumenter-config-traces.yml
+    volumes:
+      - ./configs:/configs
+      - ./testoutput/run:/var/run/obi
+      - ../../../../testoutput:/coverage
+    privileged: true
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "8080"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "true"
+      OTEL_EBPF_SKIP_GO_SPECIFIC_TRACERS: "true"
+      # Export through the weaver-tapping collector instead of straight to lgtm,
+      # so weaver validates the emitted telemetry (collector + weaver come from
+      # the shared ../weaver/docker-compose-weaver.yml fragment).
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector:4318"
+    depends_on:
+      testserver:
+        condition: service_started

--- a/internal/test/oats/memcached/yaml/oats_go_memcached.yaml
+++ b/internal/test/oats/memcached/yaml/oats_go_memcached.yaml
@@ -1,0 +1,58 @@
+oats-schema-version: 2
+docker-compose:
+  files:
+  - ../docker-compose-obi-python-memcached.yml
+  - ../../weaver/docker-compose-weaver.yml
+input:
+- path: /memcached
+- path: /memcached-error
+- path: /memcached-noreply
+interval: 500ms
+expected:
+  traces:
+  - traceql: '{ .db.operation.name = "SET" && .db.system.name = "memcached" }'
+    equals: SET
+    attributes:
+      db.operation.name: SET
+      db.system.name: memcached
+      db.query.text: session-key
+      server.port: '11211'
+  - traceql: '{ .db.operation.name = "GET" && .db.system.name = "memcached" }'
+    equals: GET
+    attributes:
+      db.operation.name: GET
+      db.system.name: memcached
+      db.query.text: session-key
+      server.port: '11211'
+  - traceql: '{ .db.operation.name = "DELETE" && .db.system.name = "memcached" }'
+    equals: DELETE
+    attributes:
+      db.operation.name: DELETE
+      db.system.name: memcached
+      db.query.text: session-key
+      server.port: '11211'
+  - traceql: '{ .db.system.name = "memcached" && status = error }'
+    equals: INCR
+    attributes:
+      db.operation.name: INCR
+      db.system.name: memcached
+      db.query.text: error-key
+      db.response.status_code: CLIENT_ERROR
+  - traceql: '{ .db.operation.name = "TOUCH" && .db.system.name = "memcached" }'
+    equals: TOUCH
+    attributes:
+      db.operation.name: TOUCH
+      db.system.name: memcached
+      db.query.text: touch-key
+      server.port: '11211'
+  metrics:
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="SET", db_system_name="memcached"}
+    value: '> 0'
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="GET", db_system_name="memcached"}
+    value: '> 0'
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="DELETE", db_system_name="memcached"}
+    value: '> 0'
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="INCR", error_type="CLIENT_ERROR", db_system_name="memcached"}
+    value: '> 0'
+  - promql: db_client_operation_duration_seconds_count{db_operation_name="TOUCH", db_system_name="memcached"}
+    value: '> 0'

--- a/internal/test/oats/memcached/yaml/oats_go_memcached.yaml
+++ b/internal/test/oats/memcached/yaml/oats_go_memcached.yaml
@@ -10,41 +10,34 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .db.operation.name = "SET" && .db.system.name = "memcached" }'
+  - traceql: '{ .db.operation.name = "SET" && .db.system.name = "memcached" } | count() = 1'
     equals: SET
     attributes:
       db.operation.name: SET
       db.system.name: memcached
       db.query.text: session-key
       server.port: '11211'
-  - traceql: '{ .db.operation.name = "GET" && .db.system.name = "memcached" }'
+  - traceql: '{ .db.operation.name = "GET" && .db.system.name = "memcached" } | count() = 1'
     equals: GET
     attributes:
       db.operation.name: GET
       db.system.name: memcached
       db.query.text: session-key
       server.port: '11211'
-  - traceql: '{ .db.operation.name = "DELETE" && .db.system.name = "memcached" }'
+  - traceql: '{ .db.operation.name = "DELETE" && .db.system.name = "memcached" } | count() = 1'
     equals: DELETE
     attributes:
       db.operation.name: DELETE
       db.system.name: memcached
       db.query.text: session-key
       server.port: '11211'
-  - traceql: '{ .db.system.name = "memcached" && status = error }'
+  - traceql: '{ .db.system.name = "memcached" && status = error } | count() = 1'
     equals: INCR
     attributes:
       db.operation.name: INCR
       db.system.name: memcached
       db.query.text: error-key
       db.response.status_code: CLIENT_ERROR
-  - traceql: '{ .db.operation.name = "TOUCH" && .db.system.name = "memcached" }'
-    equals: TOUCH
-    attributes:
-      db.operation.name: TOUCH
-      db.system.name: memcached
-      db.query.text: touch-key
-      server.port: '11211'
   metrics:
   - promql: db_client_operation_duration_seconds_count{db_operation_name="SET", db_system_name="memcached"}
     value: '> 0'
@@ -53,6 +46,4 @@ expected:
   - promql: db_client_operation_duration_seconds_count{db_operation_name="DELETE", db_system_name="memcached"}
     value: '> 0'
   - promql: db_client_operation_duration_seconds_count{db_operation_name="INCR", error_type="CLIENT_ERROR", db_system_name="memcached"}
-    value: '> 0'
-  - promql: db_client_operation_duration_seconds_count{db_operation_name="TOUCH", db_system_name="memcached"}
     value: '> 0'

--- a/internal/test/oats/memcached/yaml/oats_go_memcached.yaml
+++ b/internal/test/oats/memcached/yaml/oats_go_memcached.yaml
@@ -1,7 +1,7 @@
 oats-schema-version: 2
 docker-compose:
   files:
-  - ../docker-compose-obi-python-memcached.yml
+  - ../docker-compose-obi-go-memcached.yml
   - ../../weaver/docker-compose-weaver.yml
 input:
 - path: /memcached

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -1563,6 +1563,9 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 			Start: p.bpfObjects.ObiUprobeRuntimeNewproc1,
 			End:   p.bpfObjects.ObiUprobeRuntimeNewproc1Return,
 		}},
+		"runtime.goexit1": {{
+			Start: p.bpfObjects.BeylaUprobeProcGoexit1,
+		}},
 		"runtime.casgstatus": {{
 			Start: p.bpfObjects.ObiUprobeRuntimeCasgstatus,
 		}},

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -1563,9 +1563,6 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 			Start: p.bpfObjects.ObiUprobeRuntimeNewproc1,
 			End:   p.bpfObjects.ObiUprobeRuntimeNewproc1Return,
 		}},
-		"runtime.goexit1": {{
-			Start: p.bpfObjects.BeylaUprobeProcGoexit1,
-		}},
 		"runtime.casgstatus": {{
 			Start: p.bpfObjects.ObiUprobeRuntimeCasgstatus,
 		}},


### PR DESCRIPTION
## Summary

For the new generic Go tracer path, we had to remove our old probe on the `Runtime.goexit1`. The reason is that this probe typically removes the correlation too quickly and we'd not find correctly any goroutine information for the final send/receive message. There's no downside of leaving tombstones for the goroutines, except when the goroutine is reused. The go routine mapping is fine, but we used to clear also the go_trace_map where the trace context information is stored, and this wasn't happening anymore.

Here's how the goexit1 probe looked like:
```go
SEC("uprobe/runtime_goexit1")
int beyla_uprobe_proc_goexit1(struct pt_regs *ctx) {
    bpf_dbg_printk("=== uprobe/proc goexit1 === ");

    void *goroutine_addr = GOROUTINE_PTR(ctx);
    bpf_dbg_printk("goroutine_addr %lx", goroutine_addr);

    u64 pid_tid = bpf_get_current_pid_tgid();
    u32 pid = pid_from_pid_tgid(pid_tid);

    go_addr_key_t g_key = {.addr = (u64)goroutine_addr, .pid = pid};

    bpf_map_delete_elem(&ongoing_goroutines, &g_key);
    // We also clean-up the go routine based trace map, it's an LRU
    // but at this point we are sure we don't need the data.
    bpf_map_delete_elem(&go_trace_map, &g_key); // <-- IMPORTANT BIT FOR THIS BUG

    return 0;
}
```

So while we benefited from keeping the `ongoing_goroutines` tombstone, we now are not clearing the go_trace_map when we are done with the goroutine.

I re-enabled the `goexit1` probe and saw what was happening with the memcached client:
```
      testserver-87025   [008] ...11 62242.170633: bpf_trace_printk: === uprobe/proc goexit1 === 
      testserver-87025   [008] ...11 62242.170636: bpf_trace_printk: goroutine_addr 2b37366b10e0
      testserver-87025   [008] ...11 62242.170651: bpf_trace_printk: === uprobe/proc goexit1 === 
      testserver-87025   [008] ...11 62242.170654: bpf_trace_printk: goroutine_addr 2b37366b1680
      testserver-87025   [008] ...11 62242.170665: bpf_trace_printk: === uprobe/runtime_newproc1 ===
      testserver-87025   [008] ...11 62242.170668: bpf_trace_printk: creator_goroutine_addr=2b37365e10e0
      testserver-87025   [008] ...11 62242.170675: bpf_trace_printk: === uprobe/runtime_newproc1_return ===
      testserver-87025   [008] ...11 62242.170679: bpf_trace_printk: creator_goroutine_addr=2b37365e10e0
      testserver-87025   [008] ...11 62242.170681: bpf_trace_printk: parent_goroutine=2b37366b0780
      testserver-87025   [008] ...11 62242.170682: bpf_trace_printk: goroutine_addr=2b37366b1680

```
We can see that as soon as `goexit1` happens we create a new goroutine and it has the same exact address, inheriting accidentally now the go trace information.

The fix is to clear the go_trace_map when we create the goroutine, at that point we know we are starting a fresh and we can delete the stale info, without removing it too soon for correlation.

Fixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2948

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
