### PR TITLE
Strengthen memcached trace-merging coverage

### DIFF
--- a/internal/test/oats/memcached/yaml/oats_go_memcached.yaml
+++ b/internal/test/oats/memcached/yaml/oats_go_memcached.yaml
@@ -10,13 +10,17 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .db.operation.name = "SET" && .db.system.name = "memcached" } | count() = 1'
+  - traceql: '{ .db.operation.name = "SET" && .db.system.name = "memcached" }'
     equals: SET
     attributes:
       db.operation.name: SET
       db.system.name: memcached
       db.query.text: session-key
       server.port: '11211'
+  - traceql: '{ .db.operation.name = "SET" && .db.system.name = "memcached" } | count() > 1'
+    count:
+      min: 0
+      max: 0
   - traceql: '{ .db.operation.name = "GET" && .db.system.name = "memcached" } | count() = 1'
     equals: GET
     attributes:


### PR DESCRIPTION
## Summary

- keep the positive assertion that a memcached SET span is emitted
- reject traces containing more than one matching SET span

This is a test-only follow-up to #3027 for #2948. The previous `count() = 1` TraceQL filter selected healthy traces but did not reject a different merged trace containing multiple SET spans. The separate absence assertion now verifies that no trace contains multiple matching SET spans.

No runtime behavior changes.

## Validation

- `git diff --check`
- `make oats-test-memcached`
