### PR TITLE
gotracer: publish wrapped TLS client connections

### DIFF
--- a/bpf/gotracer/go_net_tls.c
+++ b/bpf/gotracer/go_net_tls.c
@@ -23,6 +23,7 @@
 
 #include <gotracer/go_common.h>
 #include <gotracer/go_large_buffer.h>
+#include <gotracer/maps/go_persist_conn.h>
 #include <gotracer/maps/ongoing_ssl_ops.h>
 
 #include <gotracer/types/net_args.h>
@@ -214,6 +215,8 @@ int obi_uprobe_cryptoTlsWrite(struct pt_regs *ctx) {
         const u64 id = bpf_get_current_pid_tgid();
         args.p_conn.pid = pid_from_pid_tgid(id);
         args.byte_ptr = (u64)buf;
+
+        persist_conn_publish(&g_key, &args.p_conn.conn);
 
         if (args.skip) {
             send_http_large_buffers_if_needed(&g_key, &args.p_conn.conn, buf, len, TCP_SEND);

--- a/internal/test/integration/components/httppinger/httppinger.go
+++ b/internal/test/integration/components/httppinger/httppinger.go
@@ -16,7 +16,7 @@ import (
 )
 
 type wrappedTLSConn struct {
-	unused int
+	_ int
 	*tls.Conn
 }
 
@@ -48,7 +48,7 @@ func httpClient() *http.Client {
 	}
 
 	dialer := tls.Dialer{
-		Config: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		Config: &tls.Config{InsecureSkipVerify: true},
 	}
 	transport := &http.Transport{
 		DialTLSContext: func(ctx context.Context, network, address string) (net.Conn, error) {

--- a/internal/test/integration/components/httppinger/httppinger.go
+++ b/internal/test/integration/components/httppinger/httppinger.go
@@ -5,7 +5,9 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -13,11 +15,17 @@ import (
 	"time"
 )
 
+type wrappedTLSConn struct {
+	unused int
+	*tls.Conn
+}
+
 func main() {
 	// Adding shutdown hook for graceful stop.
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	client := httpClient()
 	for {
-		r, err := http.Get(os.Getenv("TARGET_URL"))
+		r, err := client.Get(os.Getenv("TARGET_URL"))
 		if err != nil {
 			fmt.Println("error!", err)
 		}
@@ -32,4 +40,26 @@ func main() {
 			os.Exit(0)
 		}
 	}
+}
+
+func httpClient() *http.Client {
+	if os.Getenv("WRAP_TLS_CONN") != "true" {
+		return http.DefaultClient
+	}
+
+	dialer := tls.Dialer{
+		Config: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+	}
+	transport := &http.Transport{
+		DialTLSContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			conn, err := dialer.DialContext(ctx, network, address)
+			if err != nil {
+				return nil, err
+			}
+
+			return &wrappedTLSConn{Conn: conn.(*tls.Conn)}, nil
+		},
+	}
+
+	return &http.Client{Transport: transport}
 }

--- a/internal/test/integration/configs/obi-config-wrapped-conn.yml
+++ b/internal/test/integration/configs/obi-config-wrapped-conn.yml
@@ -9,6 +9,7 @@ attributes:
 discovery:
   instrument:
     - exe_path: "*vmagent*"
+    - exe_path: "*httppinger*"
 # context propagation makes the sock_msg program hand the outgoing payload to the
 # tcp_sendmsg kprobe, so the generic pipeline can report requests the Go uprobes
 # already report

--- a/internal/test/integration/docker-compose-wrapped-tls-conn.yml
+++ b/internal/test/integration/docker-compose-wrapped-tls-conn.yml
@@ -1,0 +1,53 @@
+version: "3.8"
+
+services:
+  tls-target:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/pythonserver/Dockerfile_tls
+    image: hatest-pythonserver-tls
+
+  wrapped-tls-client:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/httppinger/Dockerfile
+    image: hatest-httppinger
+    environment:
+      TARGET_URL: "https://tls-target:8380/greeting"
+      WRAP_TLS_CONN: "true"
+    depends_on:
+      tls-target:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    command:
+      - --config=/configs/obi-config-wrapped-conn.yml
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+    image: hatest-obi
+    privileged: true
+    pid: "host"
+    environment:
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+    depends_on:
+      wrapped-tls-client:
+        condition: service_started
+
+  jaeger:
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    command:
+      - "--set=service.telemetry.logs.level=debug"

--- a/internal/test/integration/wrapped_conn_client_test.go
+++ b/internal/test/integration/wrapped_conn_client_test.go
@@ -21,8 +21,12 @@ import (
 // enough scrapes that a per-request failure rate of a few percent shows up every run
 const minWrappedConnTraces = 200
 
+const minWrappedTLSConnTraces = 5
+
 // OBI names the service after the executable, there being no k8s metadata here
 const wrappedConnService = "vmagent-prod"
+
+const wrappedTLSConnService = "httppinger"
 
 // TestWrappedConnClientSpans covers a Go client whose net.Conn is wrapped by a struct
 // that does not hold the connection as its first field, so it cannot be read off the
@@ -30,20 +34,28 @@ const wrappedConnService = "vmagent-prod"
 // reports a request the Go uprobes already reported, leaving two parentless client
 // spans for the same call.
 func TestWrappedConnClientSpans(t *testing.T) {
-	compose, err := docker.ComposeSuite("docker-compose-wrapped-conn.yml", path.Join(pathOutput, "test-suite-wrapped-conn.log"))
+	assertWrappedClientSpans(t, "docker-compose-wrapped-conn.yml", wrappedConnService, minWrappedConnTraces)
+}
+
+func TestWrappedTLSConnClientSpans(t *testing.T) {
+	assertWrappedClientSpans(t, "docker-compose-wrapped-tls-conn.yml", wrappedTLSConnService, minWrappedTLSConnTraces)
+}
+
+func assertWrappedClientSpans(t *testing.T, composeFile, service string, minTraces int) {
+	compose, err := docker.ComposeSuite(composeFile, path.Join(pathOutput, "test-suite-"+service+".log"))
 	require.NoError(t, err)
 	require.NoError(t, compose.Up())
 
 	var traces []jaeger.Trace
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		resp, err := http.Get(jaegerQueryURL + "?service=" + wrappedConnService + "&limit=1500")
+		resp, err := http.Get(jaegerQueryURL + "?service=" + service + "&limit=1500")
 		require.NoError(ct, err)
 		require.Equal(ct, http.StatusOK, resp.StatusCode)
 
 		var tq jaeger.TracesQuery
 		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
-		require.GreaterOrEqualf(ct, len(tq.Data), minWrappedConnTraces,
-			"need at least %d scrape traces before judging duplication", minWrappedConnTraces)
+		require.GreaterOrEqualf(ct, len(tq.Data), minTraces,
+			"need at least %d request traces before judging duplication", minTraces)
 		traces = tq.Data
 	}, 3*time.Minute, time.Second)
 


### PR DESCRIPTION
## Summary

- publish the HTTP persistConn socket tuple from the TLS write probe
- add an opt-in custom TLS dialer wrapper to the HTTP test client
- verify wrapped HTTPS requests produce attributed, non-duplicate spans

## Motivation

Follow-up to #3006. A custom `DialTLSContext` can return a wrapper around `*tls.Conn`, which prevents the round-trip probe from reading the connection directly. The TLS write probe can still resolve the underlying socket, but its `ongoing_ssl_ops` entry suppresses the nested `netFD.Write` probe before that probe publishes the connection.

Publishing from the TLS write path gives the round-trip probe the same connection handoff used for cleartext requests and prevents the attributed TLS event from being accompanied by a zero-peer client span.

## Validation

- `make generate`
- `make clang-format`
- `go test ./internal/test/integration/components/httppinger`
- `docker compose -f internal/test/integration/docker-compose-wrapped-tls-conn.yml config --quiet`
- `go test -v -run '^TestWrappedTLSConnClientSpans$' -timeout 10m ./internal/test/integration/`
