### PR TITLE
generictracer: stop reporting established idle connections as failed connects

### DIFF
--- a/bpf/common/sockaddr.h
+++ b/bpf/common/sockaddr.h
@@ -137,24 +137,42 @@ parse_sockaddr_info(const u32 pid, struct sockaddr *addr, connection_info_part_t
     return false;
 }
 
-static __always_inline bool is_tcp_socket_never_connected(struct sock *sk) {
-    if (!sk) {
-        return true;
-    }
-
-    // Read the socket state
-    const u8 sk_state = BPF_CORE_READ(sk, __sk_common.skc_state);
-
-    // Socket was never connected if it's in these states:
+// Decides whether a socket's handshake ever completed, from the two values the
+// kernel keeps for its whole lifetime.
+//
+// A socket that completed its handshake never returns to TCP_SYN_SENT or
+// TCP_SYN_RECV, so either state answers the question on its own. Every other
+// state except TCP_CLOSE is only reachable after the handshake completed.
+//
+// TCP_CLOSE is reached both ways: tcp_done() puts a connect that was refused,
+// reset or timed out there, and so does a close that ran to completion after a
+// normal exchange. bytes_acked separates them, because tcp_snd_una_update()
+// counts the SYN's own sequence byte when the peer acknowledges it. It is
+// therefore at least 1 for every socket whose handshake completed, whatever the
+// connection carried afterwards, and 0 for one whose handshake did not. A
+// socket the process never connected also reads 0 here; the callers gate on a
+// connect-time entry, so it never reaches this predicate.
+static __always_inline bool tcp_never_connected(u8 sk_state, u64 bytes_acked) {
     if (sk_state == TCP_SYN_SENT || // Connection attempt in progress
         sk_state == TCP_SYN_RECV    // SYN received but not established
     ) {
         return true;
     }
 
-    struct tcp_sock *tp = (struct tcp_sock *)sk;
-    const u64 bytes_sent = BPF_CORE_READ(tp, bytes_sent);
-    const u64 bytes_received = BPF_CORE_READ(tp, bytes_received);
+    if (sk_state != TCP_CLOSE) {
+        return false;
+    }
 
-    return (bytes_sent == 0 && bytes_received == 0);
+    return bytes_acked == 0;
+}
+
+static __always_inline bool is_tcp_socket_never_connected(struct sock *sk) {
+    if (!sk) {
+        return true;
+    }
+
+    const u8 sk_state = BPF_CORE_READ(sk, __sk_common.skc_state);
+    const struct tcp_sock *tp = (const struct tcp_sock *)sk;
+
+    return tcp_never_connected(sk_state, BPF_CORE_READ(tp, bytes_acked));
 }

--- a/bpf/common/trace_helpers.h
+++ b/bpf/common/trace_helpers.h
@@ -49,6 +49,16 @@ static __always_inline u8 should_be_in_same_transaction(const tp_info_t *parent_
     return diff < max_transaction_time;
 }
 
+// Tells apart the two reasons should_be_in_same_transaction() rejects a
+// candidate parent. A parent left behind by a transaction that ended long ago
+// is stale and the caller retires it. A parent that started after the child
+// did is simply not this child's parent: it belongs to a transaction still in
+// flight, and retiring it would drop the trace of the requests it is serving.
+static __always_inline u8 parent_trace_is_stale(const tp_info_t *parent_tp,
+                                                const tp_info_t *child_tp) {
+    return child_tp->ts >= parent_tp->ts;
+}
+
 static __always_inline void init_new_trace(tp_info_t *tp) {
     bpf_d_printk("Generating new traceparent id [%s]", __FUNCTION__);
     new_trace_id(tp);

--- a/bpf/common/trace_parent.h
+++ b/bpf/common/trace_parent.h
@@ -363,10 +363,12 @@ find_trace_for_client_request_with_t_key(const pid_connection_info_t *p_conn,
         bpf_dbg_printk("Found existing server tp for client call");
 
         if (!should_be_in_same_transaction(&server_tp->tp, tp)) {
-            bpf_dbg_printk("Parent and child are too far apart, marking server trace as invalid");
+            bpf_dbg_printk("Parent and child are too far apart, discarding the parent trace");
             bpf_dbg_printk(
                 "%lld >>> %lld (max: %lld)", tp->ts, server_tp->tp.ts, max_transaction_time);
-            server_tp->valid = 0;
+            if (parent_trace_is_stale(&server_tp->tp, tp)) {
+                server_tp->valid = 0;
+            }
             return 0;
         }
 
@@ -404,10 +406,12 @@ find_parent_trace_for_client_request_with_t_key(const pid_connection_info_t *p_c
         bpf_dbg_printk("Found existing server tp for client call");
 
         if (!should_be_in_same_transaction(&server_tp->tp, tp)) {
-            bpf_dbg_printk("Parent and child are too far apart, marking server trace as invalid");
+            bpf_dbg_printk("Parent and child are too far apart, discarding the parent trace");
             bpf_dbg_printk(
                 "%lld >>> %lld (max: %lld)", tp->ts, server_tp->tp.ts, max_transaction_time);
-            server_tp->valid = 0;
+            if (parent_trace_is_stale(&server_tp->tp, tp)) {
+                server_tp->valid = 0;
+            }
             return 0;
         }
 

--- a/bpf/generictracer/failed_connect.h
+++ b/bpf/generictracer/failed_connect.h
@@ -15,7 +15,6 @@ static __always_inline void init_failed_connect_tcp_req(tcp_req_t *req,
                                                         u16 orig_dport,
                                                         u64 connect_ts,
                                                         u64 end_ts,
-                                                        u64 trace_ts,
                                                         u64 extra_id,
                                                         const pid_info *pid) {
     __builtin_memset(req, 0, sizeof(*req));
@@ -35,5 +34,10 @@ static __always_inline void init_failed_connect_tcp_req(tcp_req_t *req,
     req->pid = *pid;
     req->buf[0] = '\0';
 
-    req->tp.ts = trace_ts;
+    // The event is built at close time, but the span starts at the connect.
+    // tp.ts is what should_be_in_same_transaction() compares against a
+    // candidate parent's start, so it has to be the same instant the span
+    // reports, or a connect made before the parent request existed passes a
+    // check meant to reject exactly that.
+    req->tp.ts = connect_ts;
 }

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -362,6 +362,15 @@ int BPF_KRETPROBE_GUARDED(obi_kretprobe_sys_connect, int res) {
 
         setup_cp_support_conn_info(&info.p_conn, true);
 
+        // connect() returning 0 means the handshake completed, so the socket
+        // cannot be a failed connect from here on, whether or not it ever
+        // carries data. The non-blocking path returns -EINPROGRESS and
+        // completes in softirq, where no probe of ours observes it, so for
+        // those the socket's own state at close time remains the only answer.
+        if (res == 0) {
+            cp_support_established(&info.p_conn);
+        }
+
         tracked_connection_t t_conn = {
             .time = bpf_ktime_get_ns(),
             .direction = TCP_SEND,

--- a/bpf/generictracer/protocol_tcp.h
+++ b/bpf/generictracer/protocol_tcp.h
@@ -230,7 +230,7 @@ static __always_inline void failed_to_connect_event(pid_connection_info_t *pid_c
         const u64 event_ts = bpf_ktime_get_ns();
         const u64 extra_id = extra_runtime_id();
         init_failed_connect_tcp_req(
-            req, pid_conn, orig_dport, connect_ts, event_ts, event_ts, extra_id, &pid);
+            req, pid_conn, orig_dport, connect_ts, event_ts, extra_id, &pid);
 
         bpf_dbg_printk("TCP connect failed event");
 

--- a/bpf/tests/bpfcore/bpf_core_read.h
+++ b/bpf/tests/bpfcore/bpf_core_read.h
@@ -26,6 +26,16 @@
         __r;                                                                                       \
     })
 
+// Copies a zero value of the field's type, so an array field lands in an array
+// destination the way the real macro's bpf_probe_read() does.
+#define BPF_CORE_READ_INTO(dst, src, ...)                                                          \
+    do {                                                                                           \
+        __typeof__(___bpf_apply(___bpf_arrow, ___bpf_narg(__VA_ARGS__))(src,                       \
+                                                                        ##__VA_ARGS__)) __v = {};  \
+        (void)(src);                                                                               \
+        __builtin_memcpy((dst), &__v, sizeof(__v));                                                \
+    } while (0)
+
 #define BPF_CORE_READ_STR_INTO(dst, src, ...) ((void)(src), 0)
 #define bpf_core_field_exists(field) (0)
 #define bpf_core_enum_value_exists(t, v) (0)

--- a/bpf/tests/bpfcore/bpf_endian.h
+++ b/bpf/tests/bpfcore/bpf_endian.h
@@ -1,0 +1,11 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Host tests run on little-endian targets, matching the byte order the real
+// header selects for x86_64 and arm64.
+#define bpf_ntohs(x) __builtin_bswap16(x)
+#define bpf_htons(x) __builtin_bswap16(x)
+#define bpf_ntohl(x) __builtin_bswap32(x)
+#define bpf_htonl(x) __builtin_bswap32(x)

--- a/bpf/tests/bpfcore/vmlinux.h
+++ b/bpf/tests/bpfcore/vmlinux.h
@@ -64,13 +64,68 @@ struct task_struct {
     struct pid *thread_pid;
 };
 
+enum {
+    TCP_ESTABLISHED = 1,
+    TCP_SYN_SENT = 2,
+    TCP_SYN_RECV = 3,
+    TCP_FIN_WAIT1 = 4,
+    TCP_FIN_WAIT2 = 5,
+    TCP_TIME_WAIT = 6,
+    TCP_CLOSE = 7,
+    TCP_CLOSE_WAIT = 8,
+    TCP_LAST_ACK = 9,
+    TCP_LISTEN = 10,
+    TCP_CLOSING = 11,
+};
+
+struct in6_addr {
+    union {
+        u8 u6_addr8[16];
+    } in6_u;
+};
+
+struct sockaddr {
+    u16 sa_family;
+};
+
+struct sockaddr_in {
+    u16 sin_family;
+    u16 sin_port;
+    u32 sin_addr;
+};
+
+struct sockaddr_in6 {
+    u16 sin6_family;
+    u16 sin6_port;
+    struct in6_addr sin6_addr;
+};
+
 struct sock_common {
+    u32 skc_daddr;
+    u32 skc_rcv_saddr;
     u16 skc_num;
+    u16 skc_dport;
+    u16 skc_family;
+    u8 skc_state;
+    struct in6_addr skc_v6_daddr;
+    struct in6_addr skc_v6_rcv_saddr;
     possible_net_t skc_net;
 };
 struct sock {
     struct sock_common __sk_common;
 };
+
+// Only the fields the failed-connect classification reads, in the order the
+// kernel declares them.
+struct tcp_sock {
+    u64 bytes_received;
+    u64 bytes_sent;
+    u64 bytes_acked;
+};
+struct socket {
+    struct sock *sk;
+};
+
 struct iov_iter {};
 struct iovec {
     void *iov_base;

--- a/bpf/tests/test_failed_connect_classify.c
+++ b/bpf/tests/test_failed_connect_classify.c
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Run from repo root:
+//   make -C bpf/tests test_failed_connect_classify && bpf/tests/test_failed_connect_classify
+// Run from bpf/tests:
+//   make test_failed_connect_classify && ./test_failed_connect_classify
+
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <common/sockaddr.h>
+
+static unsigned int failed_assertions;
+
+static void assert_true(bool condition, const char *message) {
+    if (condition) {
+        printf("PASS: %s\n", message);
+        return;
+    }
+
+    failed_assertions++;
+    printf("FAIL: %s\n", message);
+}
+
+// An established socket that carried no application bytes is what a client
+// connection pool leaves behind when it reaps an idle connection, and what a
+// racing pool checkout leaves behind when the connection it started arrives
+// after the request it was started for has been served elsewhere.
+static void test_established_socket_without_traffic_is_connected(void) {
+    assert_true(!tcp_never_connected(TCP_ESTABLISHED, 1),
+                "an established socket that carried no bytes is connected");
+    assert_true(!tcp_never_connected(TCP_CLOSE_WAIT, 1),
+                "a socket whose peer closed first is connected");
+    assert_true(!tcp_never_connected(TCP_FIN_WAIT1, 1),
+                "a socket closing after a completed handshake is connected");
+}
+
+static void test_socket_dying_in_the_handshake_never_connected(void) {
+    assert_true(tcp_never_connected(TCP_SYN_SENT, 0), "a socket still in SYN_SENT never connected");
+    assert_true(tcp_never_connected(TCP_SYN_RECV, 0), "a socket still in SYN_RECV never connected");
+}
+
+// tcp_done() moves a refused, reset or timed out connect to TCP_CLOSE, the same
+// state a socket reaches once a normal close completes.
+static void test_closed_socket_is_told_apart_by_the_acknowledged_syn(void) {
+    assert_true(tcp_never_connected(TCP_CLOSE, 0),
+                "a closed socket whose SYN was never acknowledged never connected");
+    assert_true(!tcp_never_connected(TCP_CLOSE, 1),
+                "a closed socket whose SYN was acknowledged is connected");
+}
+
+static void test_listening_socket_is_not_a_failed_connect(void) {
+    assert_true(!tcp_never_connected(TCP_LISTEN, 0),
+                "a listening socket never attempted a connect");
+}
+
+int main(void) {
+    test_established_socket_without_traffic_is_connected();
+    test_socket_dying_in_the_handshake_never_connected();
+    test_closed_socket_is_told_apart_by_the_acknowledged_syn();
+    test_listening_socket_is_not_a_failed_connect();
+
+    if (failed_assertions != 0) {
+        printf("%u failed assertions\n", failed_assertions);
+        return 1;
+    }
+
+    return 0;
+}

--- a/bpf/tests/test_failed_connect_event.c
+++ b/bpf/tests/test_failed_connect_event.c
@@ -63,7 +63,6 @@ static void test_failed_connect_record_is_fully_initialized(void) {
     const u16 orig_dport = 443;
     const u64 connect_ts = 123456789;
     const u64 end_ts = 123456999;
-    const u64 trace_ts = 123457111;
     const u64 extra_id = 0xaabbccddeeff0011;
 
     const pid_info pid = {
@@ -78,8 +77,7 @@ static void test_failed_connect_record_is_fully_initialized(void) {
 
     tcp_req_t actual;
     __builtin_memset(&actual, 0xff, sizeof(actual));
-    init_failed_connect_tcp_req(
-        &actual, &pid_conn, orig_dport, connect_ts, end_ts, trace_ts, extra_id, &pid);
+    init_failed_connect_tcp_req(&actual, &pid_conn, orig_dport, connect_ts, end_ts, extra_id, &pid);
 
     tcp_req_t expected = {};
     expected.flags = EVENT_FAILED_CONNECT;
@@ -90,12 +88,17 @@ static void test_failed_connect_record_is_fully_initialized(void) {
     expected.end_monotime_ns = end_ts;
     expected.extra_id = extra_id;
     expected.pid = pid;
-    expected.tp.ts = trace_ts;
+    expected.tp.ts = connect_ts;
 
     assert_tcp_req_equal(&actual, &expected);
     assert_true(actual.buf[0] == '\0', "request buffer is empty");
     assert_true(actual.rbuf[0] == '\0', "response buffer is empty");
     assert_true(actual.tp.flags == 0, "trace flags do not retain stale bytes");
+    // should_be_in_same_transaction() compares this against a candidate
+    // parent's start, so it has to be the instant the span starts rather than
+    // the close that produced the event.
+    assert_true(actual.tp.ts == actual.start_monotime_ns,
+                "trace timestamp is the connect, not the close");
 }
 
 int main(void) {

--- a/internal/test/integration/components/failedconnectclient/Dockerfile
+++ b/internal/test/integration/components/failedconnectclient/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.26.3@sha256:efaccb5b497e90df3ebe5216cc25cd9f98e73874e2d638b56e38d4a3f098c41c AS builder
+
+ARG TARGETARCH
+
+ENV GOARCH=$TARGETARCH
+
+WORKDIR /src
+
+COPY internal/test/ internal/test/
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN go build -o failedconnectclient ./internal/test/integration/components/failedconnectclient/
+
+FROM debian:bookworm-slim@sha256:74d56e3931e0d5a1dd51f8c8a2466d21de84a271cd3b5a733b803aa91abf4421
+
+WORKDIR /
+
+COPY --from=builder /src/failedconnectclient .
+USER 0:0
+
+CMD [ "/failedconnectclient" ]

--- a/internal/test/integration/components/failedconnectclient/main.go
+++ b/internal/test/integration/components/failedconnectclient/main.go
@@ -1,0 +1,154 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Workload for the failed-connect suite. It produces the two kinds of socket
+// that have to be told apart: a pooled connection that completed its handshake,
+// carried nothing and was closed by this process, and a connect to a port
+// nobody listens on.
+//
+// ROLE=peer runs the other end: it accepts connections and leaves them alone,
+// so the pooled sockets stay established and idle until this process closes
+// them.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type pooledConn struct {
+	conn   net.Conn
+	opened time.Time
+}
+
+type pool struct {
+	mu    sync.Mutex
+	conns []pooledConn
+}
+
+// Closes every connection that has been idle for at least minIdle. The caller
+// is serving an inbound request, which is what puts a span misattributed to the
+// close into that request's trace.
+func (p *pool) closeIdle(minIdle time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	kept := p.conns[:0]
+
+	for _, pc := range p.conns {
+		if time.Since(pc.opened) < minIdle {
+			kept = append(kept, pc)
+			continue
+		}
+		if err := pc.conn.Close(); err != nil {
+			log.Printf("closing idle connection: %v", err)
+		}
+	}
+
+	p.conns = kept
+}
+
+func (p *pool) add(addr string) error {
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.conns = append(p.conns, pooledConn{conn: conn, opened: time.Now()})
+
+	return nil
+}
+
+// Every attempt is refused, so each one is a connect that genuinely failed and
+// has to keep being reported.
+func dialUnreachable(addr string, every time.Duration) {
+	for {
+		conn, err := net.Dial("tcp", addr)
+		if err == nil {
+			log.Printf("unexpected connection to %s", addr)
+			conn.Close()
+		}
+		time.Sleep(every)
+	}
+}
+
+func runPeer(port string) {
+	listener, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		log.Fatalf("listening on %s: %v", port, err)
+	}
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Fatalf("accepting: %v", err)
+		}
+		// Held open and never read from, so the connection stays established
+		// and carries no bytes until the client closes it.
+		go func() {
+			var buf [1]byte
+			//nolint:errcheck // the read returns when the client closes
+			conn.Read(buf[:])
+			conn.Close()
+		}()
+	}
+}
+
+func envOr(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+
+	return fallback
+}
+
+func envSeconds(name string, fallback time.Duration) time.Duration {
+	value := os.Getenv(name)
+	if value == "" {
+		return fallback
+	}
+
+	seconds, err := strconv.Atoi(value)
+	if err != nil {
+		log.Fatalf("%s=%q is not a number of seconds: %v", name, value, err)
+	}
+
+	return time.Duration(seconds) * time.Second
+}
+
+func main() {
+	if os.Getenv("ROLE") == "peer" {
+		runPeer(envOr("PEER_PORT", "7000"))
+		return
+	}
+
+	idlePeer := envOr("IDLE_PEER", "idlepeer:7000")
+	unreachablePeer := envOr("UNREACHABLE_PEER", "idlepeer:7001")
+	idleFor := envSeconds("IDLE_FOR_SECONDS", 3*time.Second)
+
+	go dialUnreachable(unreachablePeer, 2*time.Second)
+
+	p := &pool{}
+
+	http.HandleFunc("/work", func(w http.ResponseWriter, _ *http.Request) {
+		p.closeIdle(idleFor)
+
+		if err := p.add(idlePeer); err != nil {
+			log.Printf("connecting to %s: %v", idlePeer, err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		fmt.Fprintln(w, "ok")
+	})
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/internal/test/integration/configs/obi-config-failed-connect.yml
+++ b/internal/test/integration/configs/obi-config-failed-connect.yml
@@ -1,0 +1,13 @@
+trace_printer: text
+log_level: debug
+routes:
+  unmatched: path
+otel_traces_export:
+  endpoint: http://jaeger:4318
+discovery:
+  # The workload is a Go binary, and the code under test is in the generic
+  # tracer, which is where every non-Go workload lands.
+  skip_go_specific_tracers: true
+  services:
+    - name: failedconnectclient
+      exe_path: failedconnectclient

--- a/internal/test/integration/docker-compose-failed-connect.yml
+++ b/internal/test/integration/docker-compose-failed-connect.yml
@@ -1,0 +1,64 @@
+version: "3.8"
+
+services:
+  idlepeer:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/failedconnectclient/Dockerfile
+    image: hatest-failedconnectclient
+    environment:
+      ROLE: "peer"
+      PEER_PORT: "7000"
+
+  failedconnectclient:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/failedconnectclient/Dockerfile
+    image: hatest-failedconnectclient
+    ports:
+      - "8080:8080"
+    environment:
+      IDLE_PEER: "idlepeer:7000"
+      # Nothing listens here, so every attempt is refused
+      UNREACHABLE_PEER: "idlepeer:7001"
+      IDLE_FOR_SECONDS: "3"
+    depends_on:
+      idlepeer:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    command:
+      - --config=/configs/obi-config-failed-connect.yml
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-failed-connect:/var/run/obi
+    image: hatest-obi
+    privileged: true
+    network_mode: "service:failedconnectclient"
+    pid: "service:failedconnectclient"
+    environment:
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+    depends_on:
+      failedconnectclient:
+        condition: service_started
+
+  jaeger:
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    command:
+      - "--set=service.telemetry.logs.level=debug"

--- a/internal/test/integration/failed_connect_test.go
+++ b/internal/test/integration/failed_connect_test.go
@@ -1,0 +1,125 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
+	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
+)
+
+const (
+	// The port the workload's pooled connections go to. They complete their
+	// handshake, carry no bytes and are closed by the workload.
+	idlePeerPort = 7000
+	// The port nothing listens on, so every connect to it is refused.
+	unreachablePeerPort = 7001
+)
+
+func failedConnectTraces(t require.TestingT) []jaeger.Trace {
+	resp, err := http.Get(jaegerQueryURL + "?service=failedconnectclient")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tq jaeger.TracesQuery
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tq))
+
+	return tq.Data
+}
+
+func connectSpansToPort(traces []jaeger.Trace, port int) []jaeger.Span {
+	var matches []jaeger.Span
+
+	for i := range traces {
+		for _, span := range traces[i].Spans {
+			if span.OperationName != "CONNECT" {
+				continue
+			}
+			if len(span.Diff(jaeger.Tag{Key: "server.port", Type: "int64", Value: float64(port)})) == 0 {
+				matches = append(matches, span)
+			}
+		}
+	}
+
+	return matches
+}
+
+// Drives the workload for long enough that each request closes connections
+// opened by an earlier one, and that several connects to the unreachable port
+// have been attempted.
+func driveFailedConnectWorkload(t *testing.T) {
+	for range 15 {
+		ti.DoHTTPGet(t, "http://localhost:8080/work", 200)
+		time.Sleep(time.Second)
+	}
+}
+
+// Confirms the workload is instrumented, so a missing CONNECT span below means
+// the connect was not reported rather than that nothing was watched at all.
+func testFailedConnectInstrumented(t *testing.T) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		var served int
+		for _, trace := range failedConnectTraces(ct) {
+			served += len(trace.FindByOperationName("GET /work", "server"))
+		}
+		assert.Positive(ct, served)
+	}, testTimeout, 100*time.Millisecond)
+}
+
+// A connect that is refused is a genuine failure and stays reported.
+func testRefusedConnectIsReported(t *testing.T) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.NotEmpty(ct, connectSpansToPort(failedConnectTraces(ct), unreachablePeerPort))
+	}, testTimeout, 100*time.Millisecond)
+}
+
+// The pooled connections completed their handshake and were closed by the
+// workload without carrying a byte, which is what a client connection pool does
+// to an idle connection. None of them is a failed connect.
+func testIdlePooledConnectionIsNotAFailedConnect(t *testing.T) {
+	spans := connectSpansToPort(failedConnectTraces(t), idlePeerPort)
+	assert.Empty(t, spans, "established idle connections reported as failed connects: %d", len(spans))
+}
+
+// A connect reported as failed belongs to the transaction that made it, if any.
+// The workload closes its pooled connections from inside a request handler, so
+// a span attributed to that close joins the request being served, dated at a
+// connect that happened before the request existed.
+func testNoSpanStartsBeforeItsParent(t *testing.T) {
+	for _, trace := range failedConnectTraces(t) {
+		for _, span := range trace.Spans {
+			parent, ok := trace.ParentOf(&span)
+			if !ok {
+				continue
+			}
+			assert.GreaterOrEqual(t, span.StartTime, parent.StartTime,
+				"span %s starts before its parent %s", span.OperationName, parent.OperationName)
+		}
+	}
+}
+
+func TestSuite_FailedConnect(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-failed-connect.yml", path.Join(pathOutput, "test-suite-failed-connect.log"))
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+
+	driveFailedConnectWorkload(t)
+
+	t.Run("the workload is instrumented", testFailedConnectInstrumented)
+	t.Run("a refused connect is reported", testRefusedConnectIsReported)
+	t.Run("an idle pooled connection is not a failed connect", testIdlePooledConnectionIsNotAFailedConnect)
+	t.Run("no span starts before its parent", testNoSpanStartsBeforeItsParent)
+
+	require.NoError(t, compose.Close())
+}


### PR DESCRIPTION

Fixes #3040.

## Symptom

A TCP connection that completed its handshake, transferred no data, and
was closed by the local process was incorrectly classified as a failed connect. 
OBI emitted a `CONNECT` client span with `status = error` spanning the socket's 
whole lifetime, attached to whatever request the closing thread was serving. Client
connection pools produce these sockets routinely, so healthy services emitted
error spans and healthy traces acquired multi-second durations; the reporting
case measured a 242ms HTTP 200 arriving in Tempo as a 33.9s error trace.

## Changes

**Classification** (`bpf/common/sockaddr.h`). `is_tcp_socket_never_connected()`
treated `bytes_sent == 0 && bytes_received == 0` as a failed handshake, but
those counters are application payload only — a connection that established and
never carried a request reads 0 on both.

The predicate now uses two values the kernel maintains for the socket's
lifetime: its state and `bytes_acked`. `TCP_SYN_SENT` and `TCP_SYN_RECV` mean
the handshake never finished. `TCP_CLOSE` is ambiguous; a socket reaches it 
both when a connect fails and when a working connection is closed normally. 
`bytes_acked` distinguishes the two. A SYN consumes one byte of sequence space, 
and the kernel adds that byte once the peer acknowledges it, so any socket whose 
handshake completed reads at least 1 even if it never carried data, and one whose 
handshake did not reads 0. Thus, refused, reset and timed-out connects stay 
correctly reported.

This also removes an asymmetry the byte counters introduced: a FIN advances
`bytes_received` to 1 for its own sequence byte, so of two identical idle
sockets, the one closed by this process fired and the one whose peer hung up
first did not.

**Establishment** (`bpf/generictracer/k_tracer.c`). `cp_support_data_t.established`
was set only from the four data-transfer paths, so the `tcp_close` gate that
reads it repeated the byte test rather than checking it independently.
`kretprobe/sys_connect` now sets it when `connect()` returns 0. The
`-EINPROGRESS` path completes in softirq, where no probe of ours observes it, so
those sockets are still decided by their state at close time.

**Span timestamp** (`bpf/generictracer/failed_connect.h`). `tp.ts` was the close
time while the span's `start_monotime_ns` was the connect, so
`should_be_in_same_transaction()` validated the parent against a timestamp taken
microseconds earlier and admitted any request in flight. `tp.ts` is now the
connect, the instant the span reports, so the existing guard rejects a parent
that did not exist when the connect was made. This applies to failed connects as
well as the false positives.

**Parent retirement** (`bpf/common/trace_parent.h`). Correcting the timestamp
makes the guard reject more parents, and a rejected parent was always marked
invalid. That's correct for a parent left behind by a transaction that ended long
ago, and incorrect for one that started after its candidate child: it is serving a
live transaction, and retiring it would drop the traces of the requests it is
still handling. Only the first case now retires the parent.

## Tests

`bpf/tests/test_failed_connect_classify.c` covers the predicate; the
established-idle case fails against the previous code.
`test_failed_connect_event.c` gains an assertion that the trace timestamp equals
the span start. The test stubs gain `struct tcp_sock`, the TCP state enum, the
`sock_common` fields the predicate reads, `BPF_CORE_READ_INTO` and a
`bpf_endian.h`.

`TestSuite_FailedConnect` drives a Go workload (`skip_go_specific_tracers`, so
it lands in the generic tracer) that closes idle pooled connections from inside
a request handler while a second goroutine connects to a port nobody listens on.
It asserts the workload is instrumented, a refused connect is still reported, no
`CONNECT` span names the idle peer's port, and no span starts before its parent.

Without this fix, the suite reports idle sockets as `CONNECT` errors, each
`CHILD_OF` a `processing` span starting 3s after it, and both new assertions
fail. With the fix, all four now pass, as do `TestSuiteGoGeneric`,
`TestSuiteNestedTracesMaxTransactionTime` and `TestExistingSocketsDetection`,
which cover the propagation and transaction-window paths the `trace_parent.h`
change touches. Verified on kernel 7.0.0-1010-aws, aarch64.

## AI assistance disclosure

Per the project's Generative AI Policy: this change was developed with AI
assistance. The fix, the unit tests, and the integration suite were written
against a local checkout, the test runs recorded above were executed on a
dedicated host, and all of it was reviewed by a human before submission.
