### PR TITLE
Closes 1192  - Add mongo connection hostname logging

### DIFF
--- a/bpf/common/common.h
+++ b/bpf/common/common.h
@@ -40,6 +40,7 @@ enum : u32 {
     k_kafka_max_len = 256,
     k_redis_max_len = 256,
     k_mongo_max_len = 256,
+    k_mongo_hostname_max_len = 96,
     k_max_topic_name_len = 64,
     k_host_max_len = 100,
     k_scheme_max_len = 10,
@@ -284,6 +285,7 @@ typedef struct mongo_go_client_req {
     unsigned char coll[32];
     connection_info_t conn;
     tp_info_t tp;
+    unsigned char hostname[k_mongo_hostname_max_len];
 } mongo_go_client_req_t;
 
 typedef struct dns_req {

--- a/bpf/gotracer/go_offsets.h
+++ b/bpf/gotracer/go_offsets.h
@@ -156,6 +156,9 @@ typedef enum {
     _runtime_sched_stw_total_time_gc_pos,
     _runtime_time_histogram_underflow_pos,
     _runtime_time_histogram_overflow_pos,
+    _mongo_deployment_pos,
+    _mongo_topology_cfg_pos,
+    _mongo_config_seedlist_pos,
     _last_go_offset,
 } go_offset_const;
 

--- a/configs/offsets/tracker_input.json
+++ b/configs/offsets/tracker_input.json
@@ -191,8 +191,11 @@
       "go.mongodb.org/mongo-driver/mongo.Collection": ["name"],
       "go.mongodb.org/mongo-driver/x/mongo/driver.Operation": [
         "Name",
-        "Database"
-      ]
+        "Database",
+        "Deployment"
+      ],
+      "go.mongodb.org/mongo-driver/x/mongo/driver/topology.Topology": ["cfg"],
+      "go.mongodb.org/mongo-driver/x/mongo/driver/topology.Config": ["[1.11.0]SeedList"]
     }
   },
   "go.mongodb.org/mongo-driver/v2": {
@@ -202,8 +205,11 @@
       "go.mongodb.org/mongo-driver/v2/mongo.Collection": ["name"],
       "go.mongodb.org/mongo-driver/v2/x/mongo/driver.Operation": [
         "Name",
-        "Database"
-      ]
+        "Database",
+        "Deployment"
+      ],
+      "go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology.Topology": ["cfg"],
+      "go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology.Config": ["SeedList"]
     }
   },
   "github.com/gorilla/mux": {

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -827,6 +827,18 @@ func cstr(chars []uint8) string {
 	return string(chars[:addrLen])
 }
 
+// hostWithoutPort drops the trailing ":port" from a server address read from a
+// client library's configuration, e.g. "mongo:27017" or "sqlserver:5432".
+// Addresses without a port are returned unchanged. IPv6 literals are bracketed
+// in the configurations we read, so trimming at the last colon is safe.
+func hostWithoutPort(addr string) string {
+	if idx := strings.LastIndex(addr, ":"); idx != -1 {
+		return addr[:idx]
+	}
+
+	return addr
+}
+
 func (connInfo *BPFConnInfo) reqHostInfo() (source, target string) {
 	src := make(net.IP, net.IPv6len)
 	dst := make(net.IP, net.IPv6len)

--- a/pkg/ebpf/common/common_test.go
+++ b/pkg/ebpf/common/common_test.go
@@ -111,3 +111,18 @@ func TestIsH2CPrefacePseudoRequest(t *testing.T) {
 		assert.False(t, isH2CPrefacePseudoRequest(&span), "span %+v must not be dropped", span)
 	}
 }
+
+func TestHostWithoutPort(t *testing.T) {
+	for _, tc := range []struct {
+		addr string
+		want string
+	}{
+		{"mongo:27017", "mongo"},
+		{"sqlserver:5432", "sqlserver"},
+		{"mongo", "mongo"},
+		{"[::1]:27017", "[::1]"},
+		{"", ""},
+	} {
+		assert.Equal(t, tc.want, hostWithoutPort(tc.addr), "addr %q", tc.addr)
+	}
+}

--- a/pkg/ebpf/common/mongo_detect_transform.go
+++ b/pkg/ebpf/common/mongo_detect_transform.go
@@ -654,13 +654,16 @@ func ReadGoMongoRequestIntoSpan(record *ringbuf.Record) (request.Span, bool, err
 	}
 
 	peer := ""
-	hostname := ""
+	host := ""
 	hostPort := 0
 
 	if event.Conn.S_port != 0 || event.Conn.D_port != 0 {
-		peer, hostname = (*BPFConnInfo)(unsafe.Pointer(&event.Conn)).reqHostInfo()
+		peer, host = (*BPFConnInfo)(unsafe.Pointer(&event.Conn)).reqHostInfo()
 		hostPort = int(event.Conn.D_port)
 	}
+
+	// the seed address configured in the client, when the tracer managed to read it
+	hostName := hostWithoutPort(cstr(event.Hostname[:]))
 
 	op, coll := opAndCollectionFromEvent(event)
 
@@ -674,7 +677,8 @@ func ReadGoMongoRequestIntoSpan(record *ringbuf.Record) (request.Span, bool, err
 		Method:        op,
 		Path:          coll,
 		Peer:          peer,
-		Host:          hostname,
+		Host:          host,
+		HostName:      hostName,
 		HostPort:      hostPort,
 		ContentLength: 0,
 		RequestStart:  int64(event.StartMonotimeNs),

--- a/pkg/ebpf/common/mongo_detect_transform_test.go
+++ b/pkg/ebpf/common/mongo_detect_transform_test.go
@@ -6,12 +6,16 @@ package ebpfcommon
 import (
 	"bytes"
 	"encoding/binary"
+	"net"
 	"testing"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/ebpf/ringbuf"
 )
 
 var requests = expirable.NewLRU[MongoRequestKey, *MongoRequestValue](1000, nil, 0)
@@ -665,4 +669,58 @@ func TestOpAndCollectionFromEvent(t *testing.T) {
 			assert.Equal(t, tt.wantColl, gotColl)
 		})
 	}
+}
+
+func goMongoRecord(t *testing.T, event GoMongoClientInfo) *ringbuf.Record {
+	t.Helper()
+
+	var raw bytes.Buffer
+	require.NoError(t, binary.Write(&raw, binary.LittleEndian, event))
+
+	return &ringbuf.Record{RawSample: raw.Bytes()}
+}
+
+func TestReadGoMongoRequestIntoSpanHostName(t *testing.T) {
+	tests := []struct {
+		name     string
+		hostname string
+		want     string
+	}{
+		{"host and port", "mongo:27017", "mongo"},
+		{"host without port", "mongo", "mongo"},
+		{"bracketed ipv6 and port", "[::1]:27017", "[::1]"},
+		{"tracer could not read it", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := GoMongoClientInfo{Op: [32]uint8{'f', 'i', 'n', 'd'}}
+			copy(event.Hostname[:], tt.hostname)
+
+			span, ignore, err := ReadGoMongoRequestIntoSpan(goMongoRecord(t, event))
+			require.NoError(t, err)
+			require.False(t, ignore)
+
+			assert.Equal(t, tt.want, span.HostName)
+		})
+	}
+}
+
+// The exported server.address attribute is derived from the span through
+// request.SpanHost, which prefers HostName over the address of the socket.
+func TestGoMongoSpanReportsHostNameAsServer(t *testing.T) {
+	event := GoMongoClientInfo{Op: [32]uint8{'f', 'i', 'n', 'd'}}
+	copy(event.Hostname[:], "mongo:27017")
+	copy(event.Conn.D_addr[:], net.ParseIP("10.0.0.4").To16())
+	event.Conn.S_port = 40000
+	event.Conn.D_port = 27017
+
+	span, ignore, err := ReadGoMongoRequestIntoSpan(goMongoRecord(t, event))
+	require.NoError(t, err)
+	require.False(t, ignore)
+
+	assert.Equal(t, "10.0.0.4", span.Host)
+	assert.Equal(t, 27017, span.HostPort)
+	assert.Equal(t, "mongo", request.SpanHost(&span))
+	assert.Equal(t, "mongo", request.HostAsServer(&span))
 }

--- a/pkg/ebpf/common/spanner.go
+++ b/pkg/ebpf/common/spanner.go
@@ -324,10 +324,7 @@ func SQLRequestTraceToSpan(trace *SQLRequestTrace) request.Span {
 		hostPort = int(trace.Conn.D_port)
 	}
 
-	hostname := cstr(trace.Hostname[:])
-	if idx := strings.LastIndex(hostname, ":"); idx != -1 {
-		hostname = hostname[:idx]
-	}
+	hostname := hostWithoutPort(cstr(trace.Hostname[:]))
 
 	subType := trace.SubType
 

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -594,6 +594,9 @@ func (p *Tracer) RegisterOffsets(fileInfo *exec.FileInfo, offsets *goexec.Offset
 		goexec.MongoOpNamePos,
 		goexec.MongoOpDBPos,
 		goexec.MongoOneThirteenOne,
+		goexec.MongoDeploymentPos,
+		goexec.MongoTopologyCfgPos,
+		goexec.MongoConfigSeedListPos,
 		// database/sql stdlib
 		goexec.DriverConnCiPos,
 		// lib/pq driver

--- a/pkg/internal/goexec/offsets.json
+++ b/pkg/internal/goexec/offsets.json
@@ -418,7 +418,7 @@
       "name": {
         "versions": {
           "oldest": "2.0.1",
-          "newest": "2.7.0"
+          "newest": "2.8.0"
         },
         "offsets": [
           {
@@ -432,7 +432,7 @@
       "Database": {
         "versions": {
           "oldest": "2.0.1",
-          "newest": "2.7.0"
+          "newest": "2.8.0"
         },
         "offsets": [
           {
@@ -441,10 +441,22 @@
           }
         ]
       },
+      "Deployment": {
+        "versions": {
+          "oldest": "2.0.1",
+          "newest": "2.8.0"
+        },
+        "offsets": [
+          {
+            "offset": 24,
+            "since": "2.0.1"
+          }
+        ]
+      },
       "Name": {
         "versions": {
           "oldest": "2.0.1",
-          "newest": "2.7.0"
+          "newest": "2.8.0"
         },
         "offsets": [
           {
@@ -462,6 +474,34 @@
         ]
       }
     },
+    "go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology.Config": {
+      "SeedList": {
+        "versions": {
+          "oldest": "2.0.1",
+          "newest": "2.8.0"
+        },
+        "offsets": [
+          {
+            "offset": 24,
+            "since": "2.0.1"
+          }
+        ]
+      }
+    },
+    "go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology.Topology": {
+      "cfg": {
+        "versions": {
+          "oldest": "2.0.1",
+          "newest": "2.8.0"
+        },
+        "offsets": [
+          {
+            "offset": 8,
+            "since": "2.0.1"
+          }
+        ]
+      }
+    },
     "go.mongodb.org/mongo-driver/x/mongo/driver.Operation": {
       "Database": {
         "versions": {
@@ -471,6 +511,18 @@
         "offsets": [
           {
             "offset": 8,
+            "since": "1.10.1"
+          }
+        ]
+      },
+      "Deployment": {
+        "versions": {
+          "oldest": "1.10.1",
+          "newest": "1.17.9"
+        },
+        "offsets": [
+          {
+            "offset": 24,
             "since": "1.10.1"
           }
         ]
@@ -492,20 +544,30 @@
         ]
       }
     },
-    "go.opentelemetry.io/otel/internal/global.tracer": {
-      "delegate": {
+    "go.mongodb.org/mongo-driver/x/mongo/driver/topology.Config": {
+      "SeedList": {
         "versions": {
-          "oldest": "1.10.0",
-          "newest": "1.44.0"
+          "oldest": "1.11.3",
+          "newest": "1.17.9"
         },
         "offsets": [
           {
-            "offset": 48,
-            "since": "1.10.0"
-          },
+            "offset": 24,
+            "since": "1.11.3"
+          }
+        ]
+      }
+    },
+    "go.mongodb.org/mongo-driver/x/mongo/driver/topology.Topology": {
+      "cfg": {
+        "versions": {
+          "oldest": "1.10.1",
+          "newest": "1.17.9"
+        },
+        "offsets": [
           {
-            "offset": 64,
-            "since": "1.20.0"
+            "offset": 8,
+            "since": "1.10.1"
           }
         ]
       }
@@ -520,6 +582,24 @@
           {
             "offset": 80,
             "since": "1.1.0"
+          }
+        ]
+      }
+    },
+    "go.opentelemetry.io/otel/internal/global.tracer": {
+      "delegate": {
+        "versions": {
+          "oldest": "1.10.0",
+          "newest": "1.44.0"
+        },
+        "offsets": [
+          {
+            "offset": 48,
+            "since": "1.10.0"
+          },
+          {
+            "offset": 64,
+            "since": "1.20.0"
           }
         ]
       }
@@ -1358,20 +1438,6 @@
         ]
       }
     },
-    "runtime.gList": {
-      "size": {
-        "versions": {
-          "oldest": "1.25.0",
-          "newest": "1.26.5"
-        },
-        "offsets": [
-          {
-            "offset": 8,
-            "since": "1.25.0"
-          }
-        ]
-      }
-    },
     "runtime.consistentHeapStats": {
       "stats": {
         "versions": {
@@ -1480,6 +1546,20 @@
           {
             "offset": 72,
             "since": "1.23.0"
+          }
+        ]
+      }
+    },
+    "runtime.gList": {
+      "size": {
+        "versions": {
+          "oldest": "1.25.0",
+          "newest": "1.26.5"
+        },
+        "offsets": [
+          {
+            "offset": 8,
+            "since": "1.25.0"
           }
         ]
       }

--- a/pkg/internal/goexec/structmembers.go
+++ b/pkg/internal/goexec/structmembers.go
@@ -1123,19 +1123,29 @@ func readMembers(
 			return nil
 		}
 		attrs := getAttrs(entry)
-		if constName, ok := fields[attrs[dwarf.AttrName].(string)]; ok {
-			value := attrs[dwarf.AttrDataMemberLoc]
-			if constLocation, ok := value.(int64); ok {
-				delete(expectedReturns, constName)
-				log.Debug("found struct member offset",
-					"const", constName, "offset", attrs[dwarf.AttrDataMemberLoc])
-				offsets[constName] = uint64(constLocation)
-			} else {
-				// Temporary workaround
-				return fmt.Errorf("at the moment, OBI only supports constant values for DW_AT_data_member_location;"+
-					"got %s. OBI will read the offsets from a pre-fetched database", attrs[dwarf.AttrDataMemberLoc])
-			}
+		name, ok := attrs[dwarf.AttrName].(string)
+		if !ok {
+			// anonymous members (e.g. embedded fields) carry no DW_AT_name
+			continue
 		}
+		constName, ok := fields[name]
+		if !ok {
+			continue
+		}
+		value := attrs[dwarf.AttrDataMemberLoc]
+		constLocation, ok := value.(int64)
+		if !ok {
+			// Only constant locations are supported. Leaving the field in
+			// expectedReturns makes the caller fall back to the pre-fetched
+			// offsets database for it, while the remaining members of this and
+			// any later struct are still read from DWARF.
+			log.Debug("skipping member with non-constant DW_AT_data_member_location",
+				"field", name, "value", value)
+			continue
+		}
+		delete(expectedReturns, constName)
+		log.Debug("found struct member offset", "const", constName, "offset", constLocation)
+		offsets[constName] = uint64(constLocation)
 	}
 }
 

--- a/pkg/internal/goexec/structmembers.go
+++ b/pkg/internal/goexec/structmembers.go
@@ -229,6 +229,12 @@ const (
 	RuntimeSchedSTWTotalTimeGCPos
 	RuntimeTimeHistogramUnderflowPos
 	RuntimeTimeHistogramOverflowPos
+	// go mongodb topology. Appended here, and not next to the other mongodb
+	// offsets, because the values are positional and must keep matching
+	// go_offset_const in go_offsets.h
+	MongoDeploymentPos
+	MongoTopologyCfgPos
+	MongoConfigSeedListPos
 )
 
 //go:embed offsets.json
@@ -578,8 +584,29 @@ var structMembers = map[string]structInfo{
 	"go.mongodb.org/mongo-driver/x/mongo/driver.Operation": {
 		lib: "go.mongodb.org/mongo-driver",
 		fields: map[string]GoOffset{
-			"Name":     MongoOpNamePos,
-			"Database": MongoOpDBPos,
+			"Name":       MongoOpNamePos,
+			"Database":   MongoOpDBPos,
+			"Deployment": MongoDeploymentPos,
+		},
+	},
+	"go.mongodb.org/mongo-driver/x/mongo/driver/topology.Topology": {
+		lib: "go.mongodb.org/mongo-driver",
+		fields: map[string]GoOffset{
+			"cfg": MongoTopologyCfgPos,
+		},
+	},
+	"go.mongodb.org/mongo-driver/x/mongo/driver/topology.Config": {
+		lib: "go.mongodb.org/mongo-driver",
+		fields: map[string]GoOffset{
+			"SeedList": MongoConfigSeedListPos,
+		},
+	},
+	// the topology configuration was unexported up to driver v1.10.6, and is
+	// only reachable through DWARF: offsets.json tracks the exported spelling
+	"go.mongodb.org/mongo-driver/x/mongo/driver/topology.config": {
+		lib: "go.mongodb.org/mongo-driver",
+		fields: map[string]GoOffset{
+			"seedList": MongoConfigSeedListPos,
 		},
 	},
 	"go.mongodb.org/mongo-driver/v2/mongo.Collection": {
@@ -591,8 +618,21 @@ var structMembers = map[string]structInfo{
 	"go.mongodb.org/mongo-driver/v2/x/mongo/driver.Operation": {
 		lib: "go.mongodb.org/mongo-driver",
 		fields: map[string]GoOffset{
-			"Name":     MongoOpNamePos,
-			"Database": MongoOpDBPos,
+			"Name":       MongoOpNamePos,
+			"Database":   MongoOpDBPos,
+			"Deployment": MongoDeploymentPos,
+		},
+	},
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology.Topology": {
+		lib: "go.mongodb.org/mongo-driver",
+		fields: map[string]GoOffset{
+			"cfg": MongoTopologyCfgPos,
+		},
+	},
+	"go.mongodb.org/mongo-driver/v2/x/mongo/driver/topology.Config": {
+		lib: "go.mongodb.org/mongo-driver",
+		fields: map[string]GoOffset{
+			"SeedList": MongoConfigSeedListPos,
 		},
 	},
 	"database/sql.driverConn": {

--- a/pkg/internal/goexec/structmembers_test.go
+++ b/pkg/internal/goexec/structmembers_test.go
@@ -348,17 +348,46 @@ func TestReadMembers_UnsupportedLocationType(t *testing.T) {
 		123456: {},
 		234567: {},
 	}
-	// Must return an error if there is a field with unsupported location type
-	require.Error(t, readMembers(fdr, map[string]GoOffset{
+	offsets := FieldOffsets{}
+	// A field with an unsupported location type must not abort the scan, so
+	// that the members after it are still read
+	require.NoError(t, readMembers(fdr, map[string]GoOffset{
 		"supported_loc":   123456,
 		"unsupported_loc": 234567,
-	}, notFoundFields, FieldOffsets{}))
-	// And this field will be kept in the "expectedFields" map, so OBI will
+	}, notFoundFields, offsets))
+	assert.Equal(t, FieldOffsets{GoOffset(123456): uint64(33)}, offsets)
+	// And the skipped field will be kept in the "expectedFields" map, so OBI will
 	// later know that it didn't manage to get that information from dwarf
 	// and will try to look for it in the precompiled offsets DB
 	assert.Equal(t, map[GoOffset]struct{}{
 		234567: {},
 	}, notFoundFields)
+}
+
+func TestReadMembers_UnnamedMember(t *testing.T) {
+	fdr := &fakeDwarfReader{
+		entries: []*dwarf.Entry{
+			{
+				Tag:   dwarf.TagStructType,
+				Field: []dwarf.Field{{Attr: dwarf.AttrDataMemberLoc, Val: int64(0)}},
+			}, {
+				Tag: dwarf.TagStructType,
+				Field: []dwarf.Field{
+					{Attr: dwarf.AttrName, Val: "named"},
+					{Attr: dwarf.AttrDataMemberLoc, Val: int64(8)},
+				},
+			},
+		},
+	}
+	notFoundFields := map[GoOffset]struct{}{123456: {}}
+	offsets := FieldOffsets{}
+	// A member without DW_AT_name must be skipped rather than panic, and the
+	// members after it must still be read
+	require.NoError(t, readMembers(fdr, map[string]GoOffset{
+		"named": 123456,
+	}, notFoundFields, offsets))
+	assert.Equal(t, FieldOffsets{GoOffset(123456): uint64(8)}, offsets)
+	assert.Empty(t, notFoundFields)
 }
 
 func TestOffsetsForLibVersions(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR fixes MongoDB `server.address` for the Go tracer so spans report the configured hostname instead of falling back to the raw socket IP when that hostname is available.

The change follows the same overall pattern used by the SQL instrumentation:

- harden DWARF member scanning so unnamed or non-constant members do not abort offset discovery
- add hostname plumbing to the MongoDB event path
- register the MongoDB driver offsets needed to walk `driver.Operation -> Deployment -> topology.Topology -> cfg -> SeedList`
- extract `SeedList[0]` in the eBPF path and carry it into the userspace span transform
- assert `server.address: mongo` in the Go MongoDB OATS coverage

One caveat is that `SeedList[0]` is the configured seed address, not necessarily the exact server selected for a replica set or `mongodb+srv://` deployment. That matches the existing SQL behavior in this repository and still improves the current MongoDB output from IP-only to hostname-aware for the supported test cases.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

Validation plan from the implementation notes:

- `go test -run 'TestReadMembers|TestGoOffsetsFromDwarf' ./pkg/internal/goexec/`
- `go test -run Mongo ./pkg/ebpf/common/`
- `go test -run TestRawTraceDispatcher ./pkg/ebpf/common/`
- `make compile`
- `make oats-test-mongo`
- `make verify`
- `make build`
- `make lint`
- `make test`

The current planning document records implementation work as complete and final validation as still in progress.

## Generative AI Disclosure

Generative AI was used to compare the MongoDB path against the existing MySQL hostname-logging path and help identify the changes needed for MongoDB to behave the same way. Claude Code was also used to design the full planning document and implementation plan for this issue.

When the work hit roadblocks such as stack-size overlap concerns and unexpected errors during debugging, Generative AI was used as a troubleshooting aid to narrow down likely causes and next checks. The resulting plan, affected files, caveats, and validation steps were then reviewed against the repository code and local findings before submission.
