### PR TITLE
Update release documentation for v0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ below matches the release workflow at the release tag.
 
 ```bash
 # Set your desired version (find latest at https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases)
-export VERSION=1.0.0
+export VERSION=0.11.0
 
 # Determine your architecture
 # For Intel/AMD 64-bit: amd64
@@ -231,7 +231,7 @@ OBI is also available as container images:
 
 ```bash
 # Set your desired version.
-export VERSION=v0.7.0
+export VERSION=v0.11.0
 export CERTIFICATE_IDENTITY="https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/.github/workflows/publish_dockerhub_main.yml@refs/tags/${VERSION}"
 
 # (Optional) Verify the signature of the container image

--- a/devdocs/config/version-2.0/migration.md
+++ b/devdocs/config/version-2.0/migration.md
@@ -5,17 +5,11 @@ with a workflow designed to preserve effective behavior. It covers the
 standalone OBI binary and the OBI Collector receiver.
 
 > [!IMPORTANT]
-> Use Config v2 for standalone OBI only with a release whose notes explicitly
-> say that standalone Config v2 loading is enabled. Config v2 in OBI v0.10.0
-> is internal groundwork, not a public runtime configuration interface. The
-> complete public release is tracked by the
-> [Config v2 release gate](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2251),
-> including
-> [standalone loading](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2535)
-> and its
-> [implementation PR](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2682).
-> A successful `obi config validate` checks the document; it does not prove
-> that the installed OBI runtime can load v2.
+> Config v2 is supported for standalone OBI and the OBI Collector receiver
+> starting with OBI v0.11.0. Config v1 remains supported. Before migrating,
+> confirm that every deployed OBI binary or container image is v0.11.0 or
+> later. A successful `obi config validate` checks the document but does not
+> prove that an older installed OBI runtime can load v2.
 
 The migration command is designed to preserve effective behavior. It combines
 a v2 round-trip comparison with checks for structural mappings that cannot be

--- a/examples/apache/docker-compose.yml
+++ b/examples/apache/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - edge-apache
 
   obi:
-    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.10.0@sha256:9c66cdb920202b9502e6f1b8e9b238757848eded40a0aad262976d6ebea23b02}
+    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.11.0@sha256:ad0c8d7b362500a5fb9dec19c00e07f1cc0c80c27d3e85862c43585207ff7c6d}
     container_name: obi-apache-example
     command:
       - --config=/config/obi-config.yaml

--- a/examples/http-header-enrichment-demo/docker-compose.yaml
+++ b/examples/http-header-enrichment-demo/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
       - "4317:4317"
 
   obi:
-    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.10.0@sha256:9c66cdb920202b9502e6f1b8e9b238757848eded40a0aad262976d6ebea23b02}
+    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.11.0@sha256:ad0c8d7b362500a5fb9dec19c00e07f1cc0c80c27d3e85862c43585207ff7c6d}
     privileged: true
     pid: "host"
     environment:

--- a/examples/nginx/docker-compose.yml
+++ b/examples/nginx/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - edge-nginx
 
   obi:
-    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.10.0@sha256:9c66cdb920202b9502e6f1b8e9b238757848eded40a0aad262976d6ebea23b02}
+    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.11.0@sha256:ad0c8d7b362500a5fb9dec19c00e07f1cc0c80c27d3e85862c43585207ff7c6d}
     container_name: obi-nginx-example
     command:
       - --config=/config/obi-config.yaml


### PR DESCRIPTION
## Summary

- update binary and container installation examples for v0.11.0
- document Config v2 support for standalone OBI and the Collector receiver
- refresh example Compose files to use the signed v0.11.0 multi-architecture image digest

## Why

The v0.11.0 release is published, but user-facing examples still referenced older releases and the migration guide described Config v2 as internal groundwork. These updates align the repository documentation with the released behavior and artifacts.

## User impact

Users following the README and example deployments now install v0.11.0. Config v2 adopters are told that standalone and receiver support begins with v0.11.0 while Config v1 remains supported.

## Validation

- `make lint-markdown`
- `git diff --check`
- confirmed the Docker Hub v0.11.0 image index digest