### PR TITLE
Attach Go probes to all matching symbol copies

### DIFF
--- a/pkg/appolly/discover/typer_test.go
+++ b/pkg/appolly/discover/typer_test.go
@@ -71,11 +71,11 @@ func TestLoadAllGoFunctionNamesIncludesConditionalGoTracerSymbols(t *testing.T) 
 }
 
 func TestContextWithValueDoesNotQualifyGoProxy(t *testing.T) {
-	assert.True(t, isGoProxy(&goexec.Offsets{Funcs: map[string]goexec.FuncOffsets{
+	assert.True(t, isGoProxy(&goexec.Offsets{Funcs: map[string][]goexec.FuncOffsets{
 		"runtime.chansend1": {},
 		"context.WithValue": {},
 	}}))
-	assert.False(t, isGoProxy(&goexec.Offsets{Funcs: map[string]goexec.FuncOffsets{
+	assert.False(t, isGoProxy(&goexec.Offsets{Funcs: map[string][]goexec.FuncOffsets{
 		"runtime.chansend1":                {},
 		"context.WithValue":                {},
 		"net/http.serverHandler.ServeHTTP": {},

--- a/pkg/ebpf/instrumenter.go
+++ b/pkg/ebpf/instrumenter.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -151,25 +152,26 @@ func (i *instrumenter) goprobes(p Tracer) error {
 			if goProbeGroupHasProcessScopedProbe(group) && !hasProcessScopedTracer {
 				continue
 			}
-			i.gatherGoProbeGroupOffsets(group)
-			groupClosers := i.instrumentOptionalGoProbeGroup(i.exe, group)
-			if len(groupClosers) == 0 {
-				continue
-			}
-			closer := &reverseCloser{closers: groupClosers}
-			i.closables = append(i.closables, closer)
-			i.optionalGoProbeGroupClosers = append(i.optionalGoProbeGroupClosers, closer)
-			p.AddCloser(closer)
-			if hasProcessScopedTracer {
-				for _, candidate := range group.Probes {
-					if candidate.ProcessScoped {
-						i.processScopedGoProbes = append(
-							i.processScopedGoProbes,
-							processScopedGoProbeRegistration{
-								tracer: processScopedTracer,
-								probe:  candidate,
-							},
-						)
+			for _, resolvedGroup := range i.gatherGoProbeGroupOffsets(group) {
+				groupClosers := i.instrumentOptionalGoProbeGroup(i.exe, resolvedGroup)
+				if len(groupClosers) == 0 {
+					continue
+				}
+				closer := &reverseCloser{closers: groupClosers}
+				i.closables = append(i.closables, closer)
+				i.optionalGoProbeGroupClosers = append(i.optionalGoProbeGroupClosers, closer)
+				p.AddCloser(closer)
+				if hasProcessScopedTracer {
+					for _, candidate := range resolvedGroup.Probes {
+						if candidate.ProcessScoped {
+							i.processScopedGoProbes = append(
+								i.processScopedGoProbes,
+								processScopedGoProbeRegistration{
+									tracer: processScopedTracer,
+									probe:  candidate,
+								},
+							)
+						}
 					}
 				}
 			}
@@ -1160,9 +1162,9 @@ func (i *instrumenter) gatherGoOffsets(goProbes map[string][]*ebpfcommon.ProbeDe
 	log := ilog().With("probes", "gatherGoOffsets")
 
 	for symbolName, descs := range goProbes {
-		offs, ok := i.offsets.Funcs[symbolName]
+		offsets, ok := i.offsets.Funcs[symbolName]
 
-		if !ok {
+		if !ok || len(offsets) == 0 {
 			// The program function is not in the detected offsets. Mark the
 			// probes as Skip so instrumentProbes does not attempt to attach
 			// them with Address=0, which would force cilium/ebpf to parse the
@@ -1181,30 +1183,97 @@ func (i *instrumenter) gatherGoOffsets(goProbes map[string][]*ebpfcommon.ProbeDe
 			continue
 		}
 
+		resolved := make([]*ebpfcommon.ProbeDesc, 0, len(descs)*len(offsets))
 		for _, probe := range descs {
-			probe.Skip = false
-			probe.StartOffset = offs.Start
-			probe.ReturnOffsets = offs.Returns
+			resolvedForProbe := 0
+			for _, offs := range offsets {
+				if probe.End != nil && len(offs.Returns) == 0 {
+					continue
+				}
+				probeCopy := *probe
+				probeCopy.Skip = false
+				probeCopy.StartOffset = offs.Start
+				probeCopy.ReturnOffsets = append([]uint64(nil), offs.Returns...)
+				resolved = append(resolved, &probeCopy)
+				resolvedForProbe++
+			}
+			if resolvedForProbe == 0 {
+				probeCopy := *probe
+				probeCopy.Skip = false
+				probeCopy.StartOffset = offsets[0].Start
+				probeCopy.ReturnOffsets = append([]uint64(nil), offsets[0].Returns...)
+				resolved = append(resolved, &probeCopy)
+			}
 		}
+		goProbes[symbolName] = resolved
 	}
 }
 
-func (i *instrumenter) gatherGoProbeGroupOffsets(group ebpfcommon.GoProbeGroup) {
+func (i *instrumenter) gatherGoProbeGroupOffsets(group ebpfcommon.GoProbeGroup) []ebpfcommon.GoProbeGroup {
+	copyIDs := map[string]struct{}{}
+	resolvedBySymbol := make(map[string]map[string][]goexec.FuncOffsets, len(group.Probes))
 	for _, candidate := range group.Probes {
-		if candidate.Probe == nil {
-			continue
+		byCopy := map[string][]goexec.FuncOffsets{}
+		for _, offs := range i.offsets.Funcs[candidate.Symbol] {
+			copyID, ok := goFunctionCopyID(candidate.Symbol, offs.Symbol)
+			if !ok {
+				continue
+			}
+			byCopy[copyID] = append(byCopy[copyID], offs)
+			copyIDs[copyID] = struct{}{}
 		}
-
-		offs, ok := i.offsets.Funcs[candidate.Symbol]
-		if !ok {
-			candidate.Probe.Skip = true
-			continue
-		}
-
-		candidate.Probe.Skip = false
-		candidate.Probe.StartOffset = offs.Start
-		candidate.Probe.ReturnOffsets = offs.Returns
+		resolvedBySymbol[candidate.Symbol] = byCopy
 	}
+
+	orderedCopyIDs := make([]string, 0, len(copyIDs))
+	for copyID := range copyIDs {
+		orderedCopyIDs = append(orderedCopyIDs, copyID)
+	}
+	slices.Sort(orderedCopyIDs)
+
+	resolvedGroups := make([]ebpfcommon.GoProbeGroup, 0, len(orderedCopyIDs))
+	for _, copyID := range orderedCopyIDs {
+		resolved := ebpfcommon.GoProbeGroup{
+			Name:          group.Name,
+			Prerequisites: append([]string(nil), group.Prerequisites...),
+		}
+		complete := true
+		for _, candidate := range group.Probes {
+			offsets := resolvedBySymbol[candidate.Symbol][copyID]
+			if candidate.Probe == nil || len(offsets) == 0 {
+				complete = false
+				break
+			}
+			for _, offs := range offsets {
+				probeCopy := *candidate.Probe
+				probeCopy.Skip = false
+				probeCopy.StartOffset = offs.Start
+				probeCopy.ReturnOffsets = append([]uint64(nil), offs.Returns...)
+				resolved.Probes = append(resolved.Probes, ebpfcommon.GoProbe{
+					Symbol:        candidate.Symbol,
+					Probe:         &probeCopy,
+					ProcessScoped: candidate.ProcessScoped,
+				})
+			}
+		}
+		if complete {
+			resolvedGroups = append(resolvedGroups, resolved)
+		}
+	}
+
+	return resolvedGroups
+}
+
+func goFunctionCopyID(requestedName, resolvedName string) (string, bool) {
+	if resolvedName == requestedName {
+		return "", true
+	}
+
+	prefix, found := strings.CutSuffix(resolvedName, requestedName)
+	if !found || !strings.HasSuffix(prefix, "/vendor/") {
+		return "", false
+	}
+	return prefix, true
 }
 
 func readSymbolData(sym *procs.Sym) []byte {

--- a/pkg/ebpf/instrumenter_test.go
+++ b/pkg/ebpf/instrumenter_test.go
@@ -210,7 +210,7 @@ func TestGatherGoOffsetsMarksMissingSymbolAsSkip(t *testing.T) {
 	reporter := &countingReporter{}
 	i := &instrumenter{
 		offsets: &goexec.Offsets{
-			Funcs: map[string]goexec.FuncOffsets{},
+			Funcs: map[string][]goexec.FuncOffsets{},
 		},
 		metrics:     reporter,
 		processName: "testproc",
@@ -232,11 +232,12 @@ func TestGatherGoOffsetsAppliesResolvedOffsetsAndClearsSkip(t *testing.T) {
 	reporter := &countingReporter{}
 	i := &instrumenter{
 		offsets: &goexec.Offsets{
-			Funcs: map[string]goexec.FuncOffsets{
-				"net/http.serverHandler.ServeHTTP": {
+			Funcs: map[string][]goexec.FuncOffsets{
+				"net/http.serverHandler.ServeHTTP": {{
+					Symbol:  "net/http.serverHandler.ServeHTTP",
 					Start:   0x1234,
 					Returns: []uint64{0x1250, 0x1260},
-				},
+				}},
 			},
 		},
 		metrics:     reporter,
@@ -254,6 +255,45 @@ func TestGatherGoOffsetsAppliesResolvedOffsetsAndClearsSkip(t *testing.T) {
 	assert.Equal(t, uint64(0x1234), desc.StartOffset)
 	assert.Equal(t, []uint64{0x1250, 0x1260}, desc.ReturnOffsets)
 	assert.Empty(t, reporter.errors, "no InstrumentationError should be emitted when the symbol resolves")
+}
+
+func TestGatherGoOffsetsExpandsEveryResolvedCopy(t *testing.T) {
+	const symbol = "example.com/library.Function"
+	original := &ebpfcommon.ProbeDesc{Skip: true}
+	probes := probeDescMap{symbol: {original}}
+	i := &instrumenter{offsets: &goexec.Offsets{Funcs: map[string][]goexec.FuncOffsets{
+		symbol: {
+			{Symbol: symbol, Start: 0x10, Returns: []uint64{0x11}},
+			{Symbol: "one/vendor/" + symbol, Start: 0x20, Returns: []uint64{0x21}},
+		},
+	}}}
+
+	i.gatherGoOffsets(probes)
+
+	require.Len(t, probes[symbol], 2)
+	assert.Equal(t, uint64(0x10), probes[symbol][0].StartOffset)
+	assert.Equal(t, []uint64{0x11}, probes[symbol][0].ReturnOffsets)
+	assert.Equal(t, uint64(0x20), probes[symbol][1].StartOffset)
+	assert.Equal(t, []uint64{0x21}, probes[symbol][1].ReturnOffsets)
+	assert.True(t, original.Skip)
+	assert.Zero(t, original.StartOffset)
+}
+
+func TestGatherGoOffsetsKeepsCompatibleCopy(t *testing.T) {
+	const symbol = "example.com/library.Function"
+	probes := probeDescMap{symbol: {{End: &ebpf.Program{}}}}
+	i := &instrumenter{offsets: &goexec.Offsets{Funcs: map[string][]goexec.FuncOffsets{
+		symbol: {
+			{Symbol: symbol, Start: 0x10},
+			{Symbol: "one/vendor/" + symbol, Start: 0x20, Returns: []uint64{0x21}},
+		},
+	}}}
+
+	i.gatherGoOffsets(probes)
+
+	require.Len(t, probes[symbol], 1)
+	assert.Equal(t, uint64(0x20), probes[symbol][0].StartOffset)
+	assert.Equal(t, []uint64{0x21}, probes[symbol][0].ReturnOffsets)
 }
 
 func TestInstrumentProbesSkipsMarkedOptionalProbe(t *testing.T) {
@@ -446,7 +486,7 @@ func TestInstrumentOptionalGoProbeGroupRollsBackOnFailure(t *testing.T) {
 	assert.Equal(t, int32(1), partialCloser.closes.Load())
 }
 
-func TestGatherGoProbeGroupOffsetsMarksMissingSymbolAsSkip(t *testing.T) {
+func TestGatherGoProbeGroupOffsetsSkipsIncompleteCopy(t *testing.T) {
 	group := ebpfcommon.GoProbeGroup{
 		Name: "activation",
 		Probes: []ebpfcommon.GoProbe{
@@ -456,19 +496,75 @@ func TestGatherGoProbeGroupOffsetsMarksMissingSymbolAsSkip(t *testing.T) {
 		},
 	}
 	i := &instrumenter{
-		offsets: &goexec.Offsets{Funcs: map[string]goexec.FuncOffsets{
-			"start":   {Start: 0x10},
-			"newSpan": {Start: 0x30},
+		offsets: &goexec.Offsets{Funcs: map[string][]goexec.FuncOffsets{
+			"start":   {{Symbol: "start", Start: 0x10}},
+			"newSpan": {{Symbol: "newSpan", Start: 0x30}},
 		}},
 	}
 
-	i.gatherGoProbeGroupOffsets(group)
+	assert.Empty(t, i.gatherGoProbeGroupOffsets(group))
+}
 
-	assert.False(t, group.Probes[0].Probe.Skip)
-	assert.Equal(t, uint64(0x10), group.Probes[0].Probe.StartOffset)
-	assert.True(t, group.Probes[1].Probe.Skip)
-	assert.False(t, group.Probes[2].Probe.Skip)
-	assert.Equal(t, uint64(0x30), group.Probes[2].Probe.StartOffset)
+func TestGoProbeGroupCompatibilityIsAppliedPerCopy(t *testing.T) {
+	const symbol = "example.com/library.Function"
+	group := ebpfcommon.GoProbeGroup{
+		Name: "compatible-copy",
+		Probes: []ebpfcommon.GoProbe{{
+			Symbol: symbol,
+			Probe:  &ebpfcommon.ProbeDesc{End: &ebpf.Program{}},
+		}},
+	}
+	i := &instrumenter{offsets: &goexec.Offsets{Funcs: map[string][]goexec.FuncOffsets{
+		symbol: {
+			{Symbol: symbol, Start: 0x10},
+			{Symbol: "one/vendor/" + symbol, Start: 0x20, Returns: []uint64{0x21}},
+		},
+	}}}
+
+	resolved := i.gatherGoProbeGroupOffsets(group)
+	require.Len(t, resolved, 2)
+	assert.Empty(t, instrumentOptionalGoProbeGroup(resolved[0], func(string, *ebpfcommon.ProbeDesc) ([]io.Closer, error) {
+		return []io.Closer{&countingCloser{}}, nil
+	}))
+
+	var attached []uint64
+	closers := instrumentOptionalGoProbeGroup(resolved[1], func(_ string, probe *ebpfcommon.ProbeDesc) ([]io.Closer, error) {
+		attached = append(attached, probe.StartOffset)
+		return []io.Closer{&countingCloser{}}, nil
+	})
+	require.Len(t, closers, 1)
+	assert.Equal(t, []uint64{0x20}, attached)
+}
+
+func TestGatherGoProbeGroupOffsetsDoesNotMixCopies(t *testing.T) {
+	group := ebpfcommon.GoProbeGroup{
+		Name: "separate-copies",
+		Probes: []ebpfcommon.GoProbe{
+			{Symbol: "library.Start", Probe: &ebpfcommon.ProbeDesc{}},
+			{Symbol: "library.End", Probe: &ebpfcommon.ProbeDesc{}},
+		},
+	}
+	i := &instrumenter{offsets: &goexec.Offsets{Funcs: map[string][]goexec.FuncOffsets{
+		"library.Start": {{Symbol: "library.Start", Start: 0x10}},
+		"library.End":   {{Symbol: "one/vendor/library.End", Start: 0x20}},
+	}}}
+
+	assert.Empty(t, i.gatherGoProbeGroupOffsets(group))
+}
+
+func TestGoFunctionCopyID(t *testing.T) {
+	const symbol = "example.com/library.Function"
+
+	copyID, ok := goFunctionCopyID(symbol, symbol)
+	require.True(t, ok)
+	assert.Empty(t, copyID)
+
+	copyID, ok = goFunctionCopyID(symbol, "one/vendor/"+symbol)
+	require.True(t, ok)
+	assert.Equal(t, "one/vendor/", copyID)
+
+	_, ok = goFunctionCopyID(symbol, "unrelated."+symbol)
+	assert.False(t, ok)
 }
 
 func TestMatchVersionedUprobeLibrary(t *testing.T) {

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -1246,7 +1246,7 @@ func (p *Tracer) recordGoRuntimeMetricAvailability(fileInfo *exec.FileInfo, offs
 	heapMetricsEnabled := mask&goRuntimeMetricHeapSnapshotMask != 0
 	nextGenResolved := false
 	if offsets != nil {
-		_, nextGenResolved = offsets.Funcs[goRuntimeMetricHeapSnapshotSymbol]
+		nextGenResolved = len(offsets.Funcs[goRuntimeMetricHeapSnapshotSymbol]) > 0
 	}
 
 	if !supportsStableHeapSnapshotVersion {
@@ -1303,7 +1303,7 @@ func selectGoRuntimeGCGoalSource(
 	if hasGoRuntimeMetricOffsets(offsets, goexec.RuntimeGCControllerHeapGoalPos) {
 		return goRuntimeGCGoalSourceHeapGoalField
 	}
-	if _, ok := offsets.Funcs[goRuntimeMetricGCGoalSymbol]; ok && goalArgumentSupported {
+	if len(offsets.Funcs[goRuntimeMetricGCGoalSymbol]) > 0 && goalArgumentSupported {
 		return goRuntimeGCGoalSourcePaceScavengerArgument
 	}
 	return goRuntimeGCGoalSourceNone

--- a/pkg/internal/ebpf/gotracer/gotracer_test.go
+++ b/pkg/internal/ebpf/gotracer/gotracer_test.go
@@ -230,14 +230,14 @@ func TestGoRuntimeGCGoalSourceSelection(t *testing.T) {
 		want                  goRuntimeGCGoalSource
 	}{
 		{name: "missing metadata", offsets: nil, want: goRuntimeGCGoalSourceNone},
-		{name: "probe symbol with compatible signature", offsets: &goexec.Offsets{Funcs: map[string]goexec.FuncOffsets{
-			goRuntimeMetricGCGoalSymbol: {},
+		{name: "probe symbol with compatible signature", offsets: &goexec.Offsets{Funcs: map[string][]goexec.FuncOffsets{
+			goRuntimeMetricGCGoalSymbol: {{}},
 		}}, goalArgumentSupported: true, want: goRuntimeGCGoalSourcePaceScavengerArgument},
-		{name: "probe symbol with incompatible signature", offsets: &goexec.Offsets{Funcs: map[string]goexec.FuncOffsets{
-			goRuntimeMetricGCGoalSymbol: {},
+		{name: "probe symbol with incompatible signature", offsets: &goexec.Offsets{Funcs: map[string][]goexec.FuncOffsets{
+			goRuntimeMetricGCGoalSymbol: {{}},
 		}}, want: goRuntimeGCGoalSourceNone},
 		{name: "heap goal field preferred when both sources are present", offsets: &goexec.Offsets{
-			Funcs: map[string]goexec.FuncOffsets{goRuntimeMetricGCGoalSymbol: {}},
+			Funcs: map[string][]goexec.FuncOffsets{goRuntimeMetricGCGoalSymbol: {{}}},
 			Field: goexec.FieldOffsets{goexec.RuntimeGCControllerHeapGoalPos: uint64(112)},
 		}, want: goRuntimeGCGoalSourceHeapGoalField},
 		{name: "sources missing", offsets: &goexec.Offsets{}, want: goRuntimeGCGoalSourceNone},
@@ -368,7 +368,7 @@ func TestGoRuntimeMetricsUseResolvedHeapProbe(t *testing.T) {
 	))}
 	fileInfo := exec.New(exec.Init{ELF: currentExecutableELF(t), Ino: 1})
 	offsets := goRuntimeMetricOffsets()
-	offsets.Funcs[goRuntimeMetricProbeSymbols[1]] = goexec.FuncOffsets{}
+	offsets.Funcs[goRuntimeMetricProbeSymbols[1]] = []goexec.FuncOffsets{{}}
 
 	tracer.recordGoRuntimeMetricAvailability(fileInfo, offsets)
 	tracer.ProcessBinary(fileInfo)
@@ -1461,8 +1461,8 @@ func goAutoSDKSpanContextOffsets() *goexec.Offsets {
 
 func goRuntimeMetricOffsets() *goexec.Offsets {
 	offsets := &goexec.Offsets{
-		Funcs: map[string]goexec.FuncOffsets{
-			goRuntimeMetricProbeSymbols[0]: {},
+		Funcs: map[string][]goexec.FuncOffsets{
+			goRuntimeMetricProbeSymbols[0]: {{}},
 		},
 		Field: goexec.FieldOffsets{},
 	}

--- a/pkg/internal/goexec/instructions.go
+++ b/pkg/internal/goexec/instructions.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/grafana/go-offsets-tracker/pkg/offsets"
@@ -56,7 +57,7 @@ func isSupportedGoBinary(elfF *elf.File) error {
 
 // instrumentationPoints loads the provided executable and looks for the addresses
 // where the start and return probes must be inserted.
-func instrumentationPoints(elfF *elf.File, funcNames []string) (map[string]FuncOffsets, error) {
+func instrumentationPoints(elfF *elf.File, funcNames []string) (map[string][]FuncOffsets, error) {
 	ilog := slog.With("component", "goexec.instructions")
 	ilog.Debug("searching for instrumentation points", "functions", funcNames)
 	functions := map[string]struct{}{}
@@ -75,45 +76,53 @@ func instrumentationPoints(elfF *elf.File, funcNames []string) (map[string]FuncO
 
 	gosyms := elfF.Section(".gosymtab")
 
-	var allSyms map[string]procs.Sym
+	type functionCandidate struct {
+		requestedName string
+		function      gosym.Func
+	}
+	candidates := make([]functionCandidate, 0)
+	for _, f := range symTab.Funcs {
+		requestedName, _, ok := requestedFunctionName(f.Name, functions)
+		if ok {
+			candidates = append(candidates, functionCandidate{requestedName: requestedName, function: f})
+		}
+	}
 
 	// no go symbols in the executable, maybe it's statically linked
 	// find regular elf symbols
+	var allSyms map[string]procs.Sym
 	if gosyms == nil {
-		allSyms, _ = procs.FindExeSymbols(elfF, funcNames)
+		symbolNames := make([]string, 0, len(candidates))
+		for _, candidate := range candidates {
+			symbolNames = append(symbolNames, candidate.function.Name)
+		}
+		allSyms, _ = procs.FindExeSymbols(elfF, symbolNames)
 	}
 
-	// Prefer usable offsets from exact requested names over vendor aliases,
-	// regardless of symbol-table traversal order. At the same priority, keep the
-	// first usable offset found.
-	allOffsets := map[string]FuncOffsets{}
-	selectedIsExact := map[string]bool{}
-	for _, f := range symTab.Funcs {
-		fName, isExact, ok := requestedFunctionName(f.Name, functions)
-		if ok {
-			if selectedIsExact[fName] && !isExact {
-				continue
-			}
+	allOffsets := map[string][]FuncOffsets{}
+	for _, candidate := range candidates {
+		f := candidate.function
+		var offs FuncOffsets
+		var found bool
 
-			// when we don't have a Go symbol table, the executable is statically linked, we don't look for offsets
-			// using the gosym tab, we lookup offsets just like a regular elf file.
-			// we still need to find the return statements, since go linkage is non-standard we can't use uretprobe
-			if gosyms == nil && len(allSyms) > 0 {
-				offs, found := staticSymbolOffsets(fName, allSyms, ilog)
-				if found {
-					storeFunctionOffset(allOffsets, selectedIsExact, fName, offs, isExact)
-				}
-				continue
-			}
-
-			offs, ok, err := findFuncOffset(&f, elfF)
+		// when we don't have a Go symbol table, the executable is statically linked, we don't look for offsets
+		// using the gosym tab, we lookup offsets just like a regular elf file.
+		// we still need to find the return statements, since go linkage is non-standard we can't use uretprobe
+		if gosyms == nil && len(allSyms) > 0 {
+			offs, found = staticSymbolOffsets(f.Name, allSyms, ilog)
+		}
+		if !found {
+			var err error
+			offs, found, err = findFuncOffset(&f, elfF)
 			if err != nil {
 				return nil, err
 			}
-			if ok {
-				ilog.Debug("found relevant function for instrumentation", "function", fName, "offsets", offs)
-				storeFunctionOffset(allOffsets, selectedIsExact, fName, offs, isExact)
-			}
+		}
+		if found {
+			offs.Symbol = f.Name
+			ilog.Debug("found relevant function for instrumentation", "function", candidate.requestedName,
+				"matched_symbol", f.Name, "offsets", offs)
+			storeFunctionOffset(allOffsets, candidate.requestedName, offs)
 		}
 	}
 
@@ -135,18 +144,45 @@ func requestedFunctionName(rawName string, functions map[string]struct{}) (strin
 }
 
 func storeFunctionOffset(
-	allOffsets map[string]FuncOffsets,
-	selectedIsExact map[string]bool,
+	allOffsets map[string][]FuncOffsets,
 	fName string,
 	offs FuncOffsets,
-	isExact bool,
 ) {
-	if previousIsExact, found := selectedIsExact[fName]; found && (previousIsExact || !isExact) {
+	offs.Returns = sortedUniqueOffsets(offs.Returns)
+	for index, existing := range allOffsets[fName] {
+		if existing.Start != offs.Start {
+			continue
+		}
+
+		existing.Returns = sortedUniqueOffsets(append(existing.Returns, offs.Returns...))
+		if offs.Symbol == fName || (existing.Symbol != fName && offs.Symbol < existing.Symbol) {
+			existing.Symbol = offs.Symbol
+		}
+		allOffsets[fName][index] = existing
+		sortFunctionOffsets(allOffsets[fName])
 		return
 	}
 
-	allOffsets[fName] = offs
-	selectedIsExact[fName] = isExact
+	allOffsets[fName] = append(allOffsets[fName], offs)
+	sortFunctionOffsets(allOffsets[fName])
+}
+
+func sortedUniqueOffsets(offsets []uint64) []uint64 {
+	offsets = append([]uint64(nil), offsets...)
+	slices.Sort(offsets)
+	return slices.Compact(offsets)
+}
+
+func sortFunctionOffsets(offsets []FuncOffsets) {
+	slices.SortFunc(offsets, func(a, b FuncOffsets) int {
+		if a.Start < b.Start {
+			return -1
+		}
+		if a.Start > b.Start {
+			return 1
+		}
+		return strings.Compare(a.Symbol, b.Symbol)
+	})
 }
 
 func staticSymbolOffsets(fName string, allSyms map[string]procs.Sym, ilog *slog.Logger) (FuncOffsets, bool) {

--- a/pkg/internal/goexec/instructions_priority_test.go
+++ b/pkg/internal/goexec/instructions_priority_test.go
@@ -34,10 +34,10 @@ func TestRequestedFunctionNameFallsBackToVendorAlias(t *testing.T) {
 	assert.Equal(t, "golang.org/x/net/http2/hpack.(*Encoder).WriteField", name)
 }
 
-func TestStoreFunctionOffsetExactNameWinsInEitherOrder(t *testing.T) {
+func TestStoreFunctionOffsetRetainsEveryCopyInTraversalIndependentOrder(t *testing.T) {
 	const name = "golang.org/x/net/http2/hpack.(*Encoder).WriteField"
-	alias := FuncOffsets{Start: 1}
-	exact := FuncOffsets{Start: 2}
+	alias := FuncOffsets{Symbol: "example.com/module/vendor/" + name, Start: 1}
+	exact := FuncOffsets{Symbol: name, Start: 2}
 
 	for _, order := range []struct {
 		name       string
@@ -62,26 +62,47 @@ func TestStoreFunctionOffsetExactNameWinsInEitherOrder(t *testing.T) {
 		},
 	} {
 		t.Run(order.name, func(t *testing.T) {
-			allOffsets := map[string]FuncOffsets{}
-			selectedIsExact := map[string]bool{}
+			allOffsets := map[string][]FuncOffsets{}
 			for _, candidate := range order.candidates {
-				storeFunctionOffset(allOffsets, selectedIsExact, name, candidate.offsets, candidate.isExact)
+				storeFunctionOffset(allOffsets, name, candidate.offsets)
 			}
 
-			assert.Equal(t, exact, allOffsets[name])
-			assert.True(t, selectedIsExact[name])
+			assert.Equal(t, []FuncOffsets{alias, exact}, allOffsets[name])
 		})
 	}
 }
 
-func TestStoreFunctionOffsetKeepsFirstAliasFallback(t *testing.T) {
+func TestStoreFunctionOffsetRetainsMultipleAliases(t *testing.T) {
 	const name = "golang.org/x/net/http2/hpack.(*Encoder).WriteField"
-	allOffsets := map[string]FuncOffsets{}
-	selectedIsExact := map[string]bool{}
+	allOffsets := map[string][]FuncOffsets{}
+	first := FuncOffsets{Symbol: "one/vendor/" + name, Start: 1}
+	second := FuncOffsets{Symbol: "two/vendor/" + name, Start: 2}
 
-	storeFunctionOffset(allOffsets, selectedIsExact, name, FuncOffsets{Start: 1}, false)
-	storeFunctionOffset(allOffsets, selectedIsExact, name, FuncOffsets{Start: 2}, false)
+	storeFunctionOffset(allOffsets, name, second)
+	storeFunctionOffset(allOffsets, name, first)
 
-	assert.Equal(t, uint64(1), allOffsets[name].Start)
-	assert.False(t, selectedIsExact[name])
+	assert.Equal(t, []FuncOffsets{first, second}, allOffsets[name])
+}
+
+func TestStoreFunctionOffsetDeduplicatesAttachmentOffsets(t *testing.T) {
+	const name = "golang.org/x/net/http2/hpack.(*Encoder).WriteField"
+	allOffsets := map[string][]FuncOffsets{}
+
+	storeFunctionOffset(allOffsets, name, FuncOffsets{Symbol: "z/vendor/" + name, Start: 1, Returns: []uint64{4, 3}})
+	storeFunctionOffset(allOffsets, name, FuncOffsets{Symbol: "a/vendor/" + name, Start: 1, Returns: []uint64{3, 5}})
+
+	require.Len(t, allOffsets[name], 1)
+	assert.Equal(t, "a/vendor/"+name, allOffsets[name][0].Symbol)
+	assert.Equal(t, []uint64{3, 4, 5}, allOffsets[name][0].Returns)
+}
+
+func TestStoreFunctionOffsetKeepsCanonicalIdentityWhenOffsetsMatch(t *testing.T) {
+	const name = "golang.org/x/net/http2/hpack.(*Encoder).WriteField"
+	allOffsets := map[string][]FuncOffsets{}
+
+	storeFunctionOffset(allOffsets, name, FuncOffsets{Symbol: "a/vendor/" + name, Start: 1})
+	storeFunctionOffset(allOffsets, name, FuncOffsets{Symbol: name, Start: 1})
+
+	require.Len(t, allOffsets[name], 1)
+	assert.Equal(t, name, allOffsets[name][0].Symbol)
 }

--- a/pkg/internal/goexec/offsets.go
+++ b/pkg/internal/goexec/offsets.go
@@ -13,13 +13,15 @@ import (
 )
 
 type Offsets struct {
-	// Funcs key: function name
-	Funcs  map[string]FuncOffsets
+	// Funcs key: requested function name. Each value contains every resolved
+	// canonical or vendored copy of that function.
+	Funcs  map[string][]FuncOffsets
 	Field  FieldOffsets
 	ITypes map[string]uint64
 }
 
 type FuncOffsets struct {
+	Symbol  string
 	Start   uint64
 	Returns []uint64
 }


### PR DESCRIPTION
## Summary

- retain every usable canonical or `/vendor/` match for each requested Go function
- attach ordinary probes to every compatible resolved copy
- partition atomic probe groups by canonical or vendor namespace
- sort and deduplicate attachment offsets independently of symbol-table traversal order

Fixes #3063.

## Why

Go binaries can contain active canonical and vendored copies of the same requested function. The existing contract established in #3020 selected one deterministic match, so other executable copies remained uninstrumented.

This changes the offset contract from one result per requested name to an ordered list that preserves the actual resolved symbol identity. Probe descriptors are cloned per copy, keeping per-copy start and return offsets independent.

## Invariants and compatibility

- Binaries with one usable match retain the existing attachment behavior.
- Canonical and vendored copies are all retained when they have distinct attachment addresses.
- Matches sharing a start address are merged so they cannot create duplicate entry or return attachments.
- Return-probe compatibility is evaluated per copy; a copy without usable return offsets does not suppress another compatible copy.
- Atomic groups are formed only from symbols in the same canonical or vendor namespace. An incomplete group in one namespace does not suppress a complete group in another, and symbols from different copies are never combined.

## Validation

- `go test ./pkg/internal/goexec ./pkg/ebpf ./pkg/appolly/discover ./pkg/internal/ebpf/gotracer`
- `make compile`
- targeted `golangci-lint` for the four affected packages
- `git diff --check`

## Scope

This PR completes the general multi-copy resolution and attachment contract. It intentionally does not include the HTTP/2 traceparent ownership state machine or generated eBPF changes from #3021; those remain separate from this symbol-resolution work.