### PR TITLE
Support protocol-scoped filters in Config V2

### DIFF
--- a/cmd/obi/internal/configcmd/configcmd.go
+++ b/cmd/obi/internal/configcmd/configcmd.go
@@ -746,6 +746,7 @@ func migrationAlias(path string) bool {
 	}
 	for _, prefix := range []string{
 		"executable_path",
+		"filter.application",
 		"open_port",
 		"target_pids",
 		"network.enable",

--- a/internal/config/convert/export.go
+++ b/internal/config/convert/export.go
@@ -195,7 +195,7 @@ func protocolInstrumentation(
 ) schema.ProtocolInstrumentation {
 	return schema.ProtocolInstrumentation{
 		Enabled: protocolEnabled(tracesInstrumentations, metricsInstrumentations, appMetricsEnabled, mapping),
-		Filters: signalFilters(cfg.Filters.Application),
+		Filters: applicationSignalFilters(cfg.Filters, mapping.instr),
 	}
 }
 

--- a/internal/config/convert/export_parity.go
+++ b/internal/config/convert/export_parity.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/obi/internal/config/schema"
 	"go.opentelemetry.io/obi/pkg/appolly/discover"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/filter"
 	"go.opentelemetry.io/obi/pkg/obi"
 )
@@ -174,6 +175,20 @@ func signalFilters(in filter.AttributeFamilyConfig) schema.SignalFilters {
 	return schema.SignalFilters{
 		Traces:  filterMap(in),
 		Metrics: filterMap(in),
+	}
+}
+
+func applicationSignalFilters(
+	filters filter.AttributesConfig,
+	instrumentation instrumentations.Instrumentation,
+) schema.SignalFilters {
+	scoped, ok := filters.ApplicationByInstrumentation[instrumentation]
+	if !ok {
+		return signalFilters(filters.Application)
+	}
+	return schema.SignalFilters{
+		Traces:  filterMap(scoped.Traces),
+		Metrics: filterMap(scoped.Metrics),
 	}
 }
 

--- a/internal/config/convert/export_test.go
+++ b/internal/config/convert/export_test.go
@@ -481,6 +481,45 @@ func TestRuntimeToV2FallsBackOnUnsupportedLogFormats(t *testing.T) {
 	require.Equal(t, schema.ConfigFormatUnset, value(t, ext.Daemon, "logging", "config_format"))
 }
 
+func TestRuntimeToV2ApplicationFiltersByInstrumentation(t *testing.T) {
+	t.Parallel()
+
+	statusCode := 500
+	cfg := defaultRuntimeConfig()
+	cfg.Filters.Application = nil
+	cfg.Filters.ApplicationByInstrumentation = filter.InstrumentationAttributeFamilyConfig{
+		instrumentations.InstrumentationHTTP: {
+			Traces: filter.AttributeFamilyConfig{
+				"http.status_code": {Equals: &statusCode},
+			},
+		},
+		instrumentations.InstrumentationSQL: {
+			Metrics: filter.AttributeFamilyConfig{
+				"service.name": {Match: "checkout-*"},
+			},
+		},
+	}
+
+	_, ext := RuntimeToV2(&cfg)
+
+	require.Equal(t, schema.SignalFilters{
+		Traces: schema.AttributeFilters{
+			"http.status_code": {Equals: &statusCode},
+		},
+		Metrics: schema.AttributeFilters{},
+	}, ext.Capture.Instrumentation.HTTP.Filters)
+	require.Equal(t, schema.SignalFilters{
+		Traces: schema.AttributeFilters{},
+		Metrics: schema.AttributeFilters{
+			"service.name": {Match: "checkout-*"},
+		},
+	}, ext.Capture.Instrumentation.SQL.Filters)
+	require.Equal(t, schema.SignalFilters{
+		Traces:  schema.AttributeFilters{},
+		Metrics: schema.AttributeFilters{},
+	}, ext.Capture.Instrumentation.GRPC.Filters)
+}
+
 func TestRuntimeToV2AdvancedCaptureParity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -545,19 +545,6 @@ func validateV2RulePatterns(rules []schema.Rule) error {
 }
 
 func validateV2SignalFilters(src *schema.Extension) error {
-	canonicalPath := "capture.instrumentation.http.filters.traces"
-	canonical := src.Capture.Instrumentation.HTTP.Filters.Traces
-	for _, mapping := range protocolMappings {
-		path := fmt.Sprintf("capture.instrumentation.%s.filters", mapping.name)
-		filters := protocolFilters(src.Capture.Instrumentation, mapping.name)
-		if err := validateSharedAttributeFilters(path+".traces", canonicalPath, "application", filters.Traces, canonical); err != nil {
-			return err
-		}
-		if err := validateSharedAttributeFilters(path+".metrics", canonicalPath, "application", filters.Metrics, canonical); err != nil {
-			return err
-		}
-	}
-
 	if err := validateSharedSignalFilters(
 		"capture.network.capture.filters",
 		"network",
@@ -1178,6 +1165,8 @@ func applyV2Instrumentation(cfg *obi.Config, instrumentation schema.Instrumentat
 		return
 	}
 
+	applyV2InstrumentationFilters(cfg, instrumentation)
+
 	complete = complete || completeInstrumentation(instrumentation)
 	if !complete {
 		applyPartialV2Instrumentation(cfg, instrumentation)
@@ -1276,7 +1265,6 @@ func applyFullV2HTTPInstrumentation(cfg *obi.Config, http schema.HTTPInstrumenta
 	cfg.EBPF.GoHTTPClientBufferTimeout = http.GoHTTPClientBufferTimeout.TimeDuration()
 	cfg.EBPF.BufferSizes.HTTP = http.BufferSize
 
-	applyV2HTTPFilters(cfg, http.Filters, true)
 	applyFullV2HTTPRoutes(cfg, http.Routes)
 	applyFullV2HTTPPayloadExtraction(cfg, http.PayloadExtraction)
 }
@@ -1294,16 +1282,25 @@ func applyPartialV2HTTPInstrumentation(cfg *obi.Config, http schema.HTTPInstrume
 	if http.BufferSize != 0 {
 		cfg.EBPF.BufferSizes.HTTP = http.BufferSize
 	}
-	applyV2HTTPFilters(cfg, http.Filters, false)
 	applyPartialV2HTTPRoutes(cfg, http.Routes)
 	applyPartialV2HTTPPayloadExtraction(cfg, http.PayloadExtraction)
 }
 
-func applyV2HTTPFilters(cfg *obi.Config, filters schema.SignalFilters, complete bool) {
-	if zeroValue(filters) && !complete {
-		return
+func applyV2InstrumentationFilters(cfg *obi.Config, instrumentation schema.Instrumentation) {
+	for _, mapping := range protocolMappings {
+		filters := protocolFilters(instrumentation, mapping.name)
+		runtimeFilters := filter.SignalAttributeFamilyConfig{
+			Traces:  attributeFilterMap(filters.Traces),
+			Metrics: attributeFilterMap(filters.Metrics),
+		}
+		if len(runtimeFilters.Traces) == 0 && len(runtimeFilters.Metrics) == 0 {
+			continue
+		}
+		if cfg.Filters.ApplicationByInstrumentation == nil {
+			cfg.Filters.ApplicationByInstrumentation = filter.InstrumentationAttributeFamilyConfig{}
+		}
+		cfg.Filters.ApplicationByInstrumentation[mapping.instr] = runtimeFilters
 	}
-	cfg.Filters.Application = attributeFilterMap(filters.Traces)
 }
 
 func applyFullV2HTTPRoutes(cfg *obi.Config, routes schema.HTTPRoutes) {

--- a/internal/config/convert/import_http_test.go
+++ b/internal/config/convert/import_http_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/obi/internal/config/schema"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/export/instrumentations"
 	"go.opentelemetry.io/obi/pkg/filter"
 	"go.opentelemetry.io/obi/pkg/transform"
 )
@@ -380,7 +381,7 @@ func TestV2ToRuntimeHTTPPayloadExtractionRoundTrip(t *testing.T) {
 	require.Equal(t, http.Enrichment.Rules, gotHTTP.Enrichment.Rules)
 }
 
-func TestV2ToRuntimeHTTPApplicationFiltersRoundTrip(t *testing.T) {
+func TestV2ToRuntimeApplicationFiltersMigratesLegacyRuntimeConfig(t *testing.T) {
 	t.Parallel()
 
 	statusCode := 500
@@ -401,17 +402,24 @@ func TestV2ToRuntimeHTTPApplicationFiltersRoundTrip(t *testing.T) {
 	got, err := V2ToRuntime(ext)
 	require.NoError(t, err)
 
-	require.Equal(t, cfg.Filters.Application, got.Filters.Application)
+	require.Empty(t, got.Filters.Application)
+	require.Len(t, got.Filters.ApplicationByInstrumentation, len(protocolMappings))
+	for _, mapping := range protocolMappings {
+		require.Equal(t, filter.SignalAttributeFamilyConfig{
+			Traces:  cfg.Filters.Application,
+			Metrics: cfg.Filters.Application,
+		}, got.Filters.ApplicationByInstrumentation[mapping.instr])
+	}
 }
 
-func TestV2ToRuntimeHTTPApplicationFiltersRejectsOneSignal(t *testing.T) {
+func TestV2ToRuntimeApplicationFiltersAcceptOneSignal(t *testing.T) {
 	t.Parallel()
 
 	filters := schema.AttributeFilters{
 		"service.name": {Match: "checkout-*"},
 	}
 
-	_, err := V2ToRuntime(&schema.Extension{
+	got, err := V2ToRuntime(&schema.Extension{
 		Version: schema.SupportedVersion,
 		Capture: schema.Capture{
 			Instrumentation: schema.Instrumentation{
@@ -423,19 +431,22 @@ func TestV2ToRuntimeHTTPApplicationFiltersRejectsOneSignal(t *testing.T) {
 			},
 		},
 	})
-	require.ErrorContains(
-		t,
-		err,
-		"capture.instrumentation.http.filters.metrics cannot differ from "+
-			"capture.instrumentation.http.filters.traces",
-	)
+	require.NoError(t, err)
+	require.Empty(t, got.Filters.Application)
+	require.Equal(t, filter.InstrumentationAttributeFamilyConfig{
+		instrumentations.InstrumentationHTTP: {
+			Traces: filter.AttributeFamilyConfig{
+				"service.name": {Match: "checkout-*"},
+			},
+		},
+	}, got.Filters.ApplicationByInstrumentation)
 }
 
-func TestV2ToRuntimeHTTPApplicationFiltersRejectsConflictingSignals(t *testing.T) {
+func TestV2ToRuntimeApplicationFiltersAcceptDifferentSignals(t *testing.T) {
 	t.Parallel()
 
 	statusCode := 500
-	_, err := V2ToRuntime(&schema.Extension{
+	got, err := V2ToRuntime(&schema.Extension{
 		Version: schema.SupportedVersion,
 		Capture: schema.Capture{
 			Instrumentation: schema.Instrumentation{
@@ -453,13 +464,21 @@ func TestV2ToRuntimeHTTPApplicationFiltersRejectsConflictingSignals(t *testing.T
 		},
 	})
 
-	require.ErrorContains(t, err, "capture.instrumentation.http.filters")
+	require.NoError(t, err)
+	require.Equal(t, filter.SignalAttributeFamilyConfig{
+		Traces: filter.AttributeFamilyConfig{
+			"service.name": {Match: "checkout-*"},
+		},
+		Metrics: filter.AttributeFamilyConfig{
+			"http.status_code": {Equals: &statusCode},
+		},
+	}, got.Filters.ApplicationByInstrumentation[instrumentations.InstrumentationHTTP])
 }
 
-func TestV2ToRuntimeApplicationFiltersRejectsProtocolScope(t *testing.T) {
+func TestV2ToRuntimeApplicationFiltersAcceptProtocolScope(t *testing.T) {
 	t.Parallel()
 
-	_, err := V2ToRuntime(&schema.Extension{
+	got, err := V2ToRuntime(&schema.Extension{
 		Version: schema.SupportedVersion,
 		Capture: schema.Capture{
 			Instrumentation: schema.Instrumentation{
@@ -473,32 +492,55 @@ func TestV2ToRuntimeApplicationFiltersRejectsProtocolScope(t *testing.T) {
 			},
 		},
 	})
-	require.ErrorContains(t, err, "capture.instrumentation.grpc.filters.traces")
+	require.NoError(t, err)
+	require.Equal(t, filter.InstrumentationAttributeFamilyConfig{
+		instrumentations.InstrumentationGRPC: {
+			Traces: filter.AttributeFamilyConfig{
+				"service.name": {Match: "checkout-*"},
+			},
+		},
+	}, got.Filters.ApplicationByInstrumentation)
 }
 
-func TestV2ToRuntimeRejectsDivergentProtocolFilters(t *testing.T) {
+func TestV2ToRuntimeApplicationFiltersAcceptDifferentProtocols(t *testing.T) {
 	t.Parallel()
 
 	statusCode := 500
-	cfg := defaultRuntimeConfig()
-	cfg.Filters.Application = filter.AttributeFamilyConfig{
-		"http.status_code": {Equals: &statusCode},
-	}
-	_, ext := RuntimeToV2(&cfg)
-	ext.Capture.Instrumentation.GRPC.Filters.Traces = schema.AttributeFilters{
-		"service.name": {Match: "checkout-*"},
-	}
-
-	_, err := V2ToRuntime(ext)
-	require.ErrorContains(
-		t,
-		err,
-		"capture.instrumentation.grpc.filters.traces cannot differ from "+
-			"capture.instrumentation.http.filters.traces",
-	)
+	got, err := V2ToRuntime(&schema.Extension{
+		Version: schema.SupportedVersion,
+		Capture: schema.Capture{
+			Instrumentation: schema.Instrumentation{
+				HTTP: schema.HTTPInstrumentation{
+					Filters: schema.SignalFilters{
+						Traces: schema.AttributeFilters{
+							"http.status_code": {Equals: &statusCode},
+						},
+					},
+				},
+				GRPC: schema.ProtocolInstrumentation{
+					Filters: schema.SignalFilters{
+						Traces: schema.AttributeFilters{
+							"service.name": {Match: "checkout-*"},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, filter.SignalAttributeFamilyConfig{
+		Traces: filter.AttributeFamilyConfig{
+			"http.status_code": {Equals: &statusCode},
+		},
+	}, got.Filters.ApplicationByInstrumentation[instrumentations.InstrumentationHTTP])
+	require.Equal(t, filter.SignalAttributeFamilyConfig{
+		Traces: filter.AttributeFamilyConfig{
+			"service.name": {Match: "checkout-*"},
+		},
+	}, got.Filters.ApplicationByInstrumentation[instrumentations.InstrumentationGRPC])
 }
 
-func TestV2ToRuntimeRejectsDivergentAerospikeFilters(t *testing.T) {
+func TestV2ToRuntimeApplicationFiltersAcceptAerospikeSignals(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -528,22 +570,28 @@ func TestV2ToRuntimeRejectsDivergentAerospikeFilters(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			statusCode := 500
-			cfg := defaultRuntimeConfig()
-			cfg.Filters.Application = filter.AttributeFamilyConfig{
-				"http.status_code": {Equals: &statusCode},
-			}
-			_, ext := RuntimeToV2(&cfg)
-			require.NotNil(t, ext.Capture.Instrumentation.Aerospike)
-			test.mutate(ext.Capture.Instrumentation.Aerospike)
+			aerospike := &schema.AerospikeInstrumentation{}
+			test.mutate(aerospike)
+			got, err := V2ToRuntime(&schema.Extension{
+				Version: schema.SupportedVersion,
+				Capture: schema.Capture{
+					Instrumentation: schema.Instrumentation{Aerospike: aerospike},
+				},
+			})
+			require.NoError(t, err)
 
-			_, err := V2ToRuntime(ext)
-			require.ErrorContains(
-				t,
-				err,
-				"capture.instrumentation.aerospike.filters."+test.signal+" cannot differ from "+
-					"capture.instrumentation.http.filters.traces because the runtime uses one application filter",
-			)
+			gotFilters := got.Filters.ApplicationByInstrumentation[instrumentations.InstrumentationAerospike]
+			if test.signal == "traces" {
+				require.Equal(t, filter.AttributeFamilyConfig{
+					"service.name": {Match: "checkout-*"},
+				}, gotFilters.Traces)
+				require.Empty(t, gotFilters.Metrics)
+			} else {
+				require.Equal(t, filter.AttributeFamilyConfig{
+					"service.name": {Match: "checkout-*"},
+				}, gotFilters.Metrics)
+				require.Empty(t, gotFilters.Traces)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Translate each Config V2 instrumentation filter into the runtime's protocol- and signal-scoped filter representation added by #2996.
- Export scoped runtime filters back to their matching Config V2 protocol and signal sections.
- Preserve V1 migration coverage for legacy application filters that are fanned out across Config V2.

## Motivation

Config V2 already models application filters independently for each protocol and telemetry signal. The runtime converter nevertheless required every protocol's trace and metric filters to match the HTTP trace filter because the runtime previously had only one global application filter.

That restriction prevented Config V2 from using the scoped filtering behavior now available in the runtime.

## Behavior

An HTTP trace filter now affects only HTTP trace spans. HTTP metrics and spans produced by unconfigured protocols continue through the pipeline unchanged. Different protocols and signals can use different filter definitions.

Legacy Config V1 `filter.application` behavior remains global. Network capture and network stats filters remain shared between their trace and metric representations because their runtime filters are still global.

## Testing

- Config V2 import coverage for single-signal, cross-signal, cross-protocol, Aerospike, and legacy migration cases.
- Runtime-to-V2 export coverage for scoped filters.
- V1 migration command coverage.
- `make verify`.

Closes #1282
