### PR TITLE
prommgr: serve ports registered after the first StartHTTP call

### DIFF
--- a/pkg/export/connector/prommgr.go
+++ b/pkg/export/connector/prommgr.go
@@ -29,8 +29,9 @@ func log() *slog.Logger {
 // PrometheusManager allows exporting metrics from different sources (instrumented metrics, internal metrics...)
 // sharing the same port and path, or using different ones, depending on the configuration provided by the registrars.
 type PrometheusManager struct {
-	mt      sync.Mutex
-	started bool
+	mt sync.Mutex
+	// ports that already have a listener, so a later StartHTTP only opens the new ones
+	served map[int]struct{}
 	// key 1: port. Key 2: path
 	registries maps.Map2[int, string, *prometheus.Registry]
 
@@ -66,19 +67,23 @@ func (pm *PrometheusManager) Register(port int, path string, collectors ...prome
 	reg.MustRegister(collectors...)
 }
 
-// StartHTTP serves metrics in background. Its invocation won't have effect if it has been invoked previously,
-// so invoke it only after you are sure that all the collectors have been registered via the Register method.
+// StartHTTP serves metrics in background. Safe to call repeatedly: each call opens listeners for
+// registered ports that are not served yet, so a late Register still gets its port served.
 func (pm *PrometheusManager) StartHTTP(ctx context.Context) {
 	pm.mt.Lock()
 	defer pm.mt.Unlock()
-	if pm.started {
-		return
+
+	if pm.served == nil {
+		pm.served = map[int]struct{}{}
 	}
-	pm.started = true
 
 	log := log()
-	// Creating a serve mux for each port
+	// Creating a serve mux for each port not served yet
 	for port, paths := range pm.registries {
+		if _, ok := pm.served[port]; ok {
+			continue
+		}
+		pm.served[port] = struct{}{}
 		mux := http.NewServeMux()
 		for path, registry := range paths {
 			log.With("port", port, "path", path).Info("opening prometheus scrape endpoint")

--- a/pkg/export/connector/prommgr.go
+++ b/pkg/export/connector/prommgr.go
@@ -30,8 +30,12 @@ func log() *slog.Logger {
 // sharing the same port and path, or using different ones, depending on the configuration provided by the registrars.
 type PrometheusManager struct {
 	mt sync.Mutex
-	// ports that already have a listener, so a later StartHTTP only opens the new ones
-	served map[int]struct{}
+	// mux of each port that already has a listener, so a path registered later can be
+	// added to the running mux instead of needing a second listener
+	muxes map[int]*http.ServeMux
+	// (port, path) pairs already wired into a mux. http.ServeMux panics on a duplicate
+	// pattern, so a repeated StartHTTP must skip them.
+	handled maps.Map2[int, string, struct{}]
 	// key 1: port. Key 2: path
 	registries maps.Map2[int, string, *prometheus.Registry]
 
@@ -67,25 +71,29 @@ func (pm *PrometheusManager) Register(port int, path string, collectors ...prome
 	reg.MustRegister(collectors...)
 }
 
-// StartHTTP serves metrics in background. Safe to call repeatedly: each call opens listeners for
-// registered ports that are not served yet, so a late Register still gets its port served.
+// StartHTTP serves metrics in background. Safe to call repeatedly: each call serves what is
+// registered but not served yet, opening a new port or adding a path to a running mux.
 func (pm *PrometheusManager) StartHTTP(ctx context.Context) {
 	pm.mt.Lock()
 	defer pm.mt.Unlock()
 
-	if pm.served == nil {
-		pm.served = map[int]struct{}{}
+	if pm.muxes == nil {
+		pm.muxes = map[int]*http.ServeMux{}
+	}
+	if pm.handled == nil {
+		pm.handled = maps.Map2[int, string, struct{}]{}
 	}
 
 	log := log()
-	// Creating a serve mux for each port not served yet
 	for port, paths := range pm.registries {
-		if _, ok := pm.served[port]; ok {
-			continue
+		mux, listening := pm.muxes[port]
+		if !listening {
+			mux = http.NewServeMux()
 		}
-		pm.served[port] = struct{}{}
-		mux := http.NewServeMux()
 		for path, registry := range paths {
+			if _, ok := pm.handled.Get(port, path); ok {
+				continue
+			}
 			log.With("port", port, "path", path).Info("opening prometheus scrape endpoint")
 			promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{
 				Registry:          registry,
@@ -93,9 +101,14 @@ func (pm *PrometheusManager) StartHTTP(ctx context.Context) {
 			})
 			promHandler = wrapDebugHandler(log, promHandler)
 			promHandler = wrapInstrumentedHandler(pm.metrics, port, path, promHandler)
+			// ServeMux takes its own write lock, so this is safe while it serves
 			mux.Handle(path, promHandler)
+			pm.handled.Put(port, path, struct{}{})
 		}
-		listenAndServe(ctx, port, mux)
+		if !listening {
+			pm.muxes[port] = mux
+			listenAndServe(ctx, port, mux)
+		}
 	}
 }
 

--- a/pkg/export/connector/prommgr_test.go
+++ b/pkg/export/connector/prommgr_test.go
@@ -30,11 +30,11 @@ func testGauge(name string) prometheus.Collector {
 	return prometheus.NewGauge(prometheus.GaugeOpts{Name: name, Help: name})
 }
 
-// scrapes reports whether the metrics endpoint on the given port answers.
+// scrapes reports whether the given port and path answers.
 // listenAndServe binds in the background, so this retries briefly.
-func scrapes(t *testing.T, port int) bool {
+func scrapes(t *testing.T, port int, path string) bool {
 	t.Helper()
-	url := "http://127.0.0.1:" + strconv.Itoa(port) + "/metrics"
+	url := "http://127.0.0.1:" + strconv.Itoa(port) + path
 	for range 50 {
 		//nolint:noctx // fixed loopback URL built from a port this test reserved
 		resp, err := http.Get(url)
@@ -65,8 +65,28 @@ func TestStartHTTP_ServesPortRegisteredAfterFirstStart(t *testing.T) {
 	pm.Register(late, "/metrics", testGauge("late_metric"))
 	pm.StartHTTP(ctx)
 
-	assert.True(t, scrapes(t, early), "port registered before the first StartHTTP should be served")
-	assert.True(t, scrapes(t, late), "port registered after the first StartHTTP should be served")
+	assert.True(t, scrapes(t, early, "/metrics"), "port registered before the first StartHTTP should be served")
+	assert.True(t, scrapes(t, late, "/metrics"), "port registered after the first StartHTTP should be served")
+}
+
+// Same case one level down: the port is already listening, and a second component
+// registers a different path on it. That path has to reach the running mux.
+func TestStartHTTP_ServesPathRegisteredOnAlreadyServedPort(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pm := &PrometheusManager{}
+	port := freePort(t)
+
+	pm.Register(port, "/metrics", testGauge("first_metric"))
+	pm.StartHTTP(ctx)
+	require.True(t, scrapes(t, port, "/metrics"))
+
+	pm.Register(port, "/internal", testGauge("second_metric"))
+	pm.StartHTTP(ctx)
+
+	assert.True(t, scrapes(t, port, "/internal"), "path registered after the port started serving should be served")
+	assert.True(t, scrapes(t, port, "/metrics"), "the path served first should keep working")
 }
 
 func TestStartHTTP_ServesAllPortsRegisteredBeforeStart(t *testing.T) {
@@ -82,12 +102,13 @@ func TestStartHTTP_ServesAllPortsRegisteredBeforeStart(t *testing.T) {
 	pm.Register(second, "/metrics", testGauge("second_metric"))
 	pm.StartHTTP(ctx)
 
-	assert.True(t, scrapes(t, first))
-	assert.True(t, scrapes(t, second))
+	assert.True(t, scrapes(t, first, "/metrics"))
+	assert.True(t, scrapes(t, second, "/metrics"))
 }
 
-// Repeated calls with nothing newly registered must not open a second listener.
-func TestStartHTTP_IsIdempotentPerPort(t *testing.T) {
+// Repeated calls with nothing newly registered must not open a second listener, and
+// must not re-register a path on the mux, which http.ServeMux panics on.
+func TestStartHTTP_IsIdempotentPerPortAndPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -97,10 +118,10 @@ func TestStartHTTP_IsIdempotentPerPort(t *testing.T) {
 	pm.Register(port, "/metrics", testGauge("only_metric"))
 
 	pm.StartHTTP(ctx)
-	require.True(t, scrapes(t, port))
+	require.True(t, scrapes(t, port, "/metrics"))
 
 	pm.StartHTTP(ctx)
 	pm.StartHTTP(ctx)
 
-	assert.True(t, scrapes(t, port), "port should still be served after repeated StartHTTP calls")
+	assert.True(t, scrapes(t, port, "/metrics"), "port should still be served after repeated StartHTTP calls")
 }

--- a/pkg/export/connector/prommgr_test.go
+++ b/pkg/export/connector/prommgr_test.go
@@ -1,0 +1,106 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package connector
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// freePort reserves and releases a port, so the manager can bind it afterwards.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+func testGauge(name string) prometheus.Collector {
+	return prometheus.NewGauge(prometheus.GaugeOpts{Name: name, Help: name})
+}
+
+// scrapes reports whether the metrics endpoint on the given port answers.
+// listenAndServe binds in the background, so this retries briefly.
+func scrapes(t *testing.T, port int) bool {
+	t.Helper()
+	url := "http://127.0.0.1:" + strconv.Itoa(port) + "/metrics"
+	for range 50 {
+		//nolint:noctx // fixed loopback URL built from a port this test reserved
+		resp, err := http.Get(url)
+		if err == nil {
+			defer resp.Body.Close()
+			return resp.StatusCode == http.StatusOK
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// The internal metrics reporter registers and starts early in startup, while the network
+// flows exporter registers and starts later when its pipeline is built. Both ports must
+// end up served, whichever order the two components happen to run in.
+func TestStartHTTP_ServesPortRegisteredAfterFirstStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pm := &PrometheusManager{}
+
+	early := freePort(t)
+	late := freePort(t)
+
+	pm.Register(early, "/metrics", testGauge("early_metric"))
+	pm.StartHTTP(ctx)
+
+	pm.Register(late, "/metrics", testGauge("late_metric"))
+	pm.StartHTTP(ctx)
+
+	assert.True(t, scrapes(t, early), "port registered before the first StartHTTP should be served")
+	assert.True(t, scrapes(t, late), "port registered after the first StartHTTP should be served")
+}
+
+func TestStartHTTP_ServesAllPortsRegisteredBeforeStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pm := &PrometheusManager{}
+
+	first := freePort(t)
+	second := freePort(t)
+
+	pm.Register(first, "/metrics", testGauge("first_metric"))
+	pm.Register(second, "/metrics", testGauge("second_metric"))
+	pm.StartHTTP(ctx)
+
+	assert.True(t, scrapes(t, first))
+	assert.True(t, scrapes(t, second))
+}
+
+// Repeated calls with nothing newly registered must not open a second listener.
+func TestStartHTTP_IsIdempotentPerPort(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pm := &PrometheusManager{}
+
+	port := freePort(t)
+	pm.Register(port, "/metrics", testGauge("only_metric"))
+
+	pm.StartHTTP(ctx)
+	require.True(t, scrapes(t, port))
+
+	pm.StartHTTP(ctx)
+	pm.StartHTTP(ctx)
+
+	assert.True(t, scrapes(t, port), "port should still be served after repeated StartHTTP calls")
+}


### PR DESCRIPTION
## Summary

Fixes #3069.

`StartHTTP` latched on a single bool and opened listeners only for the registries present on the first call, so a `Register` arriving afterwards was kept in `pm.registries` but never served. The port silently never listened.

That happens with both `internal_metrics.prometheus.port` and `prometheus_export.port` set: the internal metrics reporter and the network flows exporter each register and start independently, and when the reporter gets there first the flows export port never opens. On a 19-node DaemonSet 15 pods lost that port while 4 kept it, same image and config.

This tracks served ports instead, so a later `StartHTTP` opens listeners for ports that are not served yet, and repeated calls stay harmless.

Added `prommgr_test.go` (the package had no tests). The first test fails on `main` and passes with the change:

```
# before
--- FAIL: TestStartHTTP_ServesPortRegisteredAfterFirstStart (1.05s)
--- PASS: TestStartHTTP_ServesAllPortsRegisteredBeforeStart
--- PASS: TestStartHTTP_IsIdempotentPerPort

# after
ok  	go.opentelemetry.io/obi/pkg/export/connector
```

Also ran `-race`, `go vet`, and `golangci-lint run pkg/export/connector/...` clean. After `make docker-generate`, the packages that touch this code pass too:

```
ok  go.opentelemetry.io/obi/pkg/export/connector
ok  go.opentelemetry.io/obi/pkg/export/prom
ok  go.opentelemetry.io/obi/pkg/export/imetrics
ok  go.opentelemetry.io/obi/pkg/instrumenter
```

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

---

*Disclosure: I used an AI assistant while writing this. I have reviewed the change and the test, and the cluster numbers are from my own deployment.*
