### PR TITLE
fionread: disable CP on failed fixup attachment

### DIFF
--- a/internal/test/integration/docker-compose-discovery.yml
+++ b/internal/test/integration/docker-compose-discovery.yml
@@ -28,6 +28,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-multi:/var/run/obi
     image: hatest-obi

--- a/internal/test/integration/docker-compose-error-test.yml
+++ b/internal/test/integration/docker-compose-error-test.yml
@@ -25,6 +25,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-error:/var/run/obi
     image: hatest-obi

--- a/internal/test/integration/docker-compose-http2.yml
+++ b/internal/test/integration/docker-compose-http2.yml
@@ -35,6 +35,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security${SECURITY_CONFIG_SUFFIX}:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-http2:/var/run/obi
     image: hatest-obi

--- a/internal/test/integration/docker-compose-instrumentation-errors.yml
+++ b/internal/test/integration/docker-compose-instrumentation-errors.yml
@@ -21,6 +21,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-instrumentation-errors:/var/run/obi
     image: hatest-obi

--- a/internal/test/integration/docker-compose-java-dist-malicious-ioctl.yml
+++ b/internal/test/integration/docker-compose-java-dist-malicious-ioctl.yml
@@ -19,6 +19,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - /sys/fs/cgroup:/sys/fs/cgroup
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-nodejsdist:/var/run/obi

--- a/internal/test/integration/docker-compose-java-dist.yml
+++ b/internal/test/integration/docker-compose-java-dist.yml
@@ -25,6 +25,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - /sys/fs/cgroup:/sys/fs/cgroup
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-nodejsdist:/var/run/obi

--- a/internal/test/integration/docker-compose-java-vthreads.yml
+++ b/internal/test/integration/docker-compose-java-vthreads.yml
@@ -30,6 +30,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - /sys/fs/cgroup:/sys/fs/cgroup
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-java-vthreads:/var/run/obi

--- a/internal/test/integration/docker-compose-keepalive.yml
+++ b/internal/test/integration/docker-compose-keepalive.yml
@@ -33,6 +33,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-keepalive:/var/run/obi
     image: hatest-obi

--- a/internal/test/integration/docker-compose-large-http-req.yml
+++ b/internal/test/integration/docker-compose-large-http-req.yml
@@ -23,6 +23,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security${SECURITY_CONFIG_SUFFIX}:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - /sys/fs/cgroup:/sys/fs/cgroup
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-large-http-req:/var/run/obi

--- a/internal/test/integration/docker-compose-multiexec-host.yml
+++ b/internal/test/integration/docker-compose-multiexec-host.yml
@@ -128,6 +128,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - /sys/fs/cgroup:/sys/fs/cgroup
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-multi:/var/run/obi

--- a/internal/test/integration/docker-compose-multiexec.yml
+++ b/internal/test/integration/docker-compose-multiexec.yml
@@ -124,6 +124,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-multi:/var/run/obi
     image: hatest-obi

--- a/internal/test/integration/docker-compose-nodejs-dist.yml
+++ b/internal/test/integration/docker-compose-nodejs-dist.yml
@@ -34,6 +34,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - /sys/fs/cgroup:/sys/fs/cgroup
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-nodejsdist:/var/run/obi

--- a/internal/test/integration/docker-compose-nodemultiproc.yml
+++ b/internal/test/integration/docker-compose-nodemultiproc.yml
@@ -28,6 +28,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-multi:/var/run/obi
     image: hatest-obi

--- a/internal/test/integration/docker-compose-perapp.yml
+++ b/internal/test/integration/docker-compose-perapp.yml
@@ -58,6 +58,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-multi:/var/run/obi
     image: hatest-obi

--- a/internal/test/integration/docker-compose-python-self.yml
+++ b/internal/test/integration/docker-compose-python-self.yml
@@ -25,6 +25,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-python:/var/run/obi
     image: hatest-obi

--- a/internal/test/integration/docker-compose-tpclient.yml
+++ b/internal/test/integration/docker-compose-tpclient.yml
@@ -27,6 +27,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-tpclient:/var/run/obi
     image: hatest-obi

--- a/internal/test/integration/docker-compose-wrapped-conn.yml
+++ b/internal/test/integration/docker-compose-wrapped-conn.yml
@@ -41,6 +41,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
     image: hatest-obi
     privileged: true

--- a/internal/test/integration/docker-compose-wrapped-tls-conn.yml
+++ b/internal/test/integration/docker-compose-wrapped-tls-conn.yml
@@ -28,6 +28,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
     image: hatest-obi
     privileged: true

--- a/internal/test/integration/docker-compose-yamux-grpc.yml
+++ b/internal/test/integration/docker-compose-yamux-grpc.yml
@@ -39,6 +39,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security${SECURITY_CONFIG_SUFFIX}:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - /sys/fs/bpf:/sys/fs/bpf
       - /sys/fs/cgroup:/sys/fs/cgroup
       - ../../../testoutput:/coverage

--- a/internal/test/integration/docker-compose.yml
+++ b/internal/test/integration/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     volumes:
       - ./configs/:/configs
       - ./system/sys/kernel/security${SECURITY_CONFIG_SUFFIX}:/sys/kernel/security
+      - /sys/kernel/tracing:/sys/kernel/tracing:ro
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-base${TESTSERVER_DOCKERFILE_SUFFIX}:/var/run/obi
     image: hatest-obi

--- a/internal/test/vm/Dockerfile
+++ b/internal/test/vm/Dockerfile
@@ -118,6 +118,12 @@ start() {
     if ! mountpoint -q /sys/fs/bpf 2>/dev/null; then
         mount -t bpf bpffs /sys/fs/bpf || ewarn "bpffs mount failed"
     fi
+    # tracefs at /sys/kernel/tracing: the obi container bind-mounts it to attach
+    # the FIONREAD compensation tracepoints. Alpine OpenRC doesn't auto-mount it.
+    mkdir -p /sys/kernel/tracing
+    if ! mountpoint -q /sys/kernel/tracing 2>/dev/null; then
+        mount -t tracefs tracefs /sys/kernel/tracing || ewarn "tracefs mount failed"
+    fi
     eend 0
 }
 EOF

--- a/pkg/internal/ebpf/tpinjector/fionread_check.go
+++ b/pkg/internal/ebpf/tpinjector/fionread_check.go
@@ -115,7 +115,7 @@ func sockhashFIONREADProbe(cookies *ebpf.Map) (bool, error) {
 
 func (p *Tracer) kernelBreaksFIONREAD() bool {
 	p.fionreadOnce.Do(func() {
-		broken, err := sockhashFIONREADProbe(nil)
+		broken, err := p.fionreadProbe(nil)
 		if err != nil {
 			// an inconclusive probe must not enable propagation on its own; the
 			// end-to-end check in sockhashSafe makes the final call
@@ -157,9 +157,9 @@ func loadableFIONREADFixup() (*ebpf.CollectionSpec, error) {
 // every bail-out has the same consequence, so each reason is reported with a common explanation
 func (p *Tracer) reportPropagationDisabled(reason string, args ...any) {
 	p.log.Error("context propagation is disabled: "+reason+". This kernel misreports "+
-		"ioctl(FIONREAD) for sockets in a sockhash (kernel commit 929e30f93125), so keeping "+
-		"propagation enabled would make applications sizing reads via FIONREAD stall or "+
-		"truncate transfers", args...)
+		"ioctl(FIONREAD) for sockets in a sockhash (kernel commit 929e30f93125), or could not "+
+		"be verified to report it correctly, so keeping propagation enabled would risk making "+
+		"applications sizing reads via FIONREAD stall or truncate transfers", args...)
 }
 
 // Inserting sockets into a sockhash is what triggers the kernel bug, so on an affected
@@ -177,7 +177,7 @@ func (p *Tracer) sockhashSafe() bool {
 			return
 		}
 
-		stillBroken, err := sockhashFIONREADProbe(p.bpfObjects.TrackedSockCookies)
+		stillBroken, err := p.fionreadProbe(p.bpfObjects.TrackedSockCookies)
 		if err != nil {
 			p.reportPropagationDisabled("the BPF compensation cannot be verified", "error", err)
 			return

--- a/pkg/internal/ebpf/tpinjector/fionread_check.go
+++ b/pkg/internal/ebpf/tpinjector/fionread_check.go
@@ -117,7 +117,10 @@ func (p *Tracer) kernelBreaksFIONREAD() bool {
 	p.fionreadOnce.Do(func() {
 		broken, err := sockhashFIONREADProbe(nil)
 		if err != nil {
-			p.log.Warn("FIONREAD sockhash probe failed", "error", err)
+			// an inconclusive probe must not enable propagation on its own; the
+			// end-to-end check in sockhashSafe makes the final call
+			p.log.Warn("FIONREAD sockhash probe failed, assuming an affected kernel", "error", err)
+			p.fionreadBroken = true
 			return
 		}
 		p.fionreadBroken = broken
@@ -151,19 +154,43 @@ func loadableFIONREADFixup() (*ebpf.CollectionSpec, error) {
 	return spec, nil
 }
 
-// end-to-end check that the attached fixup actually corrects FIONREAD
-func (p *Tracer) verifyFIONREADFix() {
-	stillBroken, err := sockhashFIONREADProbe(p.bpfObjects.TrackedSockCookies)
-	if err != nil {
-		p.log.Warn("cannot verify FIONREAD compensation", "error", err)
-		return
-	}
-	if stillBroken {
-		p.log.Error("FIONREAD compensation is ineffective (attach failed or blocked?); " +
-			"applications sizing reads via FIONREAD (nginx, Java, .NET) may stall or " +
-			"truncate transfers; set context_propagation: disabled " +
-			"(OTEL_EBPF_BPF_CONTEXT_PROPAGATION=disabled) to avoid impact")
-		return
-	}
-	p.log.Info("FIONREAD compensation verified")
+// every bail-out has the same consequence, so each reason is reported with a common explanation
+func (p *Tracer) reportPropagationDisabled(reason string, args ...any) {
+	p.log.Error("context propagation is disabled: "+reason+". This kernel misreports "+
+		"ioctl(FIONREAD) for sockets in a sockhash (kernel commit 929e30f93125), so keeping "+
+		"propagation enabled would make applications sizing reads via FIONREAD stall or "+
+		"truncate transfers", args...)
+}
+
+// Inserting sockets into a sockhash is what triggers the kernel bug, so on an affected
+// kernel propagation stays off unless the compensation is verified end to end: losing
+// propagation is preferable to breaking the instrumented applications
+func (p *Tracer) sockhashSafe() bool {
+	p.sockhashOnce.Do(func() {
+		if !p.kernelBreaksFIONREAD() {
+			p.sockhashOK = true
+			return
+		}
+
+		if !p.fionreadFixupEnabled {
+			p.reportPropagationDisabled("the BPF compensation could not be loaded")
+			return
+		}
+
+		stillBroken, err := sockhashFIONREADProbe(p.bpfObjects.TrackedSockCookies)
+		if err != nil {
+			p.reportPropagationDisabled("the BPF compensation cannot be verified", "error", err)
+			return
+		}
+
+		if stillBroken {
+			p.reportPropagationDisabled("the BPF compensation is ineffective (attach failed or blocked?)")
+			return
+		}
+
+		p.sockhashOK = true
+		p.log.Info("FIONREAD compensation verified")
+	})
+
+	return p.sockhashOK
 }

--- a/pkg/internal/ebpf/tpinjector/fionread_check_test.go
+++ b/pkg/internal/ebpf/tpinjector/fionread_check_test.go
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package tpinjector
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// one entry per expected p.fionreadProbe call: the detection probe runs first, the
+// end-to-end verification of the loaded fixup second
+type probeOutcome struct {
+	broken bool
+	err    error
+}
+
+func TestSockhashSafe(t *testing.T) {
+	probeErr := errors.New("probe failed")
+
+	tests := []struct {
+		name         string
+		outcomes     []probeOutcome
+		fixupEnabled bool
+		wantSafe     bool
+		wantCalls    int
+	}{
+		{
+			name:      "unaffected kernel skips verification",
+			outcomes:  []probeOutcome{{broken: false}},
+			wantSafe:  true,
+			wantCalls: 1,
+		},
+		{
+			name:      "affected kernel without a loaded fixup",
+			outcomes:  []probeOutcome{{broken: true}},
+			wantSafe:  false,
+			wantCalls: 1,
+		},
+		{
+			name:      "detection probe error is treated as affected",
+			outcomes:  []probeOutcome{{err: probeErr}},
+			wantSafe:  false,
+			wantCalls: 1,
+		},
+		{
+			name:         "verification probe error keeps propagation off",
+			outcomes:     []probeOutcome{{broken: true}, {err: probeErr}},
+			fixupEnabled: true,
+			wantSafe:     false,
+			wantCalls:    2,
+		},
+		{
+			name:         "ineffective fixup keeps propagation off",
+			outcomes:     []probeOutcome{{broken: true}, {broken: true}},
+			fixupEnabled: true,
+			wantSafe:     false,
+			wantCalls:    2,
+		},
+		{
+			name:         "verified fixup enables propagation",
+			outcomes:     []probeOutcome{{broken: true}, {broken: false}},
+			fixupEnabled: true,
+			wantSafe:     true,
+			wantCalls:    2,
+		},
+		{
+			name:         "detection probe error recovers when the fixup verifies",
+			outcomes:     []probeOutcome{{err: probeErr}, {broken: false}},
+			fixupEnabled: true,
+			wantSafe:     true,
+			wantCalls:    2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			p := &Tracer{
+				log:                  slog.Default(),
+				fionreadFixupEnabled: tt.fixupEnabled,
+				fionreadProbe: func(*ebpf.Map) (bool, error) {
+					require.Less(t, calls, len(tt.outcomes), "unexpected extra probe call")
+					o := tt.outcomes[calls]
+					calls++
+					return o.broken, o.err
+				},
+			}
+
+			assert.Equal(t, tt.wantSafe, p.sockhashSafe())
+			assert.Equal(t, tt.wantCalls, calls)
+
+			// the decision is cached: repeated calls must not re-probe
+			assert.Equal(t, tt.wantSafe, p.sockhashSafe())
+			assert.Equal(t, tt.wantCalls, calls)
+		})
+	}
+}
+
+func TestSockhashSafeGatesAttachments(t *testing.T) {
+	p := &Tracer{
+		log:           slog.Default(),
+		fionreadProbe: func(*ebpf.Map) (bool, error) { return true, nil },
+	}
+
+	assert.False(t, p.sockhashSafe())
+	assert.Nil(t, p.SockMsgs())
+	assert.Nil(t, p.SockOps())
+	assert.Nil(t, p.Iters())
+}

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -45,6 +45,8 @@ type Tracer struct {
 	fionreadOnce            sync.Once
 	fionreadBroken          bool
 	fionreadFixupEnabled    bool
+	sockhashOnce            sync.Once
+	sockhashOK              bool
 	iterMu                  sync.Mutex
 	itersOnce               sync.Once
 	seenNetns               *expirable.LRU[uint64, struct{}]
@@ -162,11 +164,7 @@ func (p *Tracer) LoadSpecs() ([]*ebpfcommon.SpecBundle, error) {
 	if p.kernelBreaksFIONREAD() {
 		fixupSpec, err := loadableFIONREADFixup()
 		if err != nil {
-			p.log.Error("kernel misreports FIONREAD for sockets in a sockhash and the BPF "+
-				"compensation cannot be loaded (kernel lockdown?); applications sizing reads "+
-				"via FIONREAD (nginx, Java, .NET) may stall or truncate transfers; "+
-				"set context_propagation: disabled (OTEL_EBPF_BPF_CONTEXT_PROPAGATION=disabled) "+
-				"to avoid impact", "error", err)
+			p.log.Warn("cannot load the FIONREAD compensation (kernel lockdown?)", "error", err)
 		} else {
 			bundles = append(bundles, &ebpfcommon.SpecBundle{
 				Spec:      fixupSpec,
@@ -251,6 +249,10 @@ func (p *Tracer) SocketFilters() []*ebpf.Program {
 }
 
 func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg {
+	if !p.sockhashSafe() {
+		return nil
+	}
+
 	return []ebpfcommon.SockMsg{
 		{
 			Program:  p.bpfObjects.ObiPacketExtender,
@@ -261,6 +263,10 @@ func (p *Tracer) SockMsgs() []ebpfcommon.SockMsg {
 }
 
 func (p *Tracer) SockOps() []ebpfcommon.SockOps {
+	if !p.sockhashSafe() {
+		return nil
+	}
+
 	return []ebpfcommon.SockOps{
 		{
 			Program:  p.bpfObjects.ObiSockmapTracker,
@@ -271,6 +277,10 @@ func (p *Tracer) SockOps() []ebpfcommon.SockOps {
 
 // Iters is called from both AllowPID (discovery) and Run (pipeline) goroutines
 func (p *Tracer) Iters() []*ebpfcommon.Iter {
+	if !p.sockhashSafe() {
+		return nil
+	}
+
 	p.itersOnce.Do(func() {
 		major, minor := ebpfcommon.KernelVersion()
 
@@ -315,10 +325,6 @@ func (p *Tracer) AlreadyInstrumentedLib(uint64) bool {
 
 func (p *Tracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg.Queue[[]request.Span]) {
 	p.log.Debug("tpinjector started")
-
-	if p.fionreadFixupEnabled {
-		p.verifyFIONREADFix()
-	}
 
 	for _, it := range p.Iters() {
 		if err := it.Run(p.log); err != nil {

--- a/pkg/internal/ebpf/tpinjector/tpinjector.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector.go
@@ -43,6 +43,7 @@ type Tracer struct {
 	log                     *slog.Logger
 	iters                   []*ebpfcommon.Iter
 	fionreadOnce            sync.Once
+	fionreadProbe           func(cookies *ebpf.Map) (bool, error)
 	fionreadBroken          bool
 	fionreadFixupEnabled    bool
 	sockhashOnce            sync.Once
@@ -69,6 +70,7 @@ func New(cfg *obi.Config) *Tracer {
 	return &Tracer{
 		log:           log,
 		cfg:           cfg,
+		fionreadProbe: sockhashFIONREADProbe,
 		seenNetns:     expirable.NewLRU[uint64, struct{}](seenNetnsCacheLen, nil, seenNetnsTTL),
 		netnsAttempts: expirable.NewLRU[uint64, int](seenNetnsCacheLen, nil, seenNetnsTTL),
 	}


### PR DESCRIPTION
## Summary

Currently, on failed fixup attachment for ioctl(FIONREAD), we just log an error and proceed. This PR disables context propagation as a safety measure in order to not break external apps

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
