### PR TITLE
ci: run bpf unit tests on arm

### DIFF
--- a/.github/workflows/bpf_unit_tests.yml
+++ b/.github/workflows/bpf_unit_tests.yml
@@ -24,9 +24,17 @@ permissions:
 
 jobs:
   bpf-unit-tests:
-    name: BPF unit tests
-    runs-on: ubuntu-latest
+    name: BPF unit tests (${{ matrix.platform.arch }})
+    runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:


### PR DESCRIPTION
## Summary

Part of #2849, this PR adds ARM as a platform to run the existing bpf unit tests.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
