### PR TITLE
Fix versions.yaml

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -25,8 +25,8 @@ excluded-modules:
   - go.opentelemetry.io/obi/configs/offsets/redis
   - go.opentelemetry.io/obi/configs/offsets/sarama
   - go.opentelemetry.io/obi/configs/offsets/shopify
-  - go.opentelemetry.io/obi/examples/http-header-enrichment-demo/app
   - go.opentelemetry.io/obi/examples/go-trace-api/app
+  - go.opentelemetry.io/obi/examples/http-header-enrichment-demo/app
   - go.opentelemetry.io/obi/internal/test/benchmarks/goshorturl
   - go.opentelemetry.io/obi/internal/test/benchmarks/goshorturl/memsql
   - go.opentelemetry.io/obi/internal/test/integration/components/ai/openai/go
@@ -42,8 +42,9 @@ excluded-modules:
   - go.opentelemetry.io/obi/internal/test/integration/components/goautosdk
   - go.opentelemetry.io/obi/internal/test/integration/components/gogeneric/fiber-example
   - go.opentelemetry.io/obi/internal/test/integration/components/gokafka
-  - go.opentelemetry.io/obi/internal/test/integration/components/gokafka/no-promise
   - go.opentelemetry.io/obi/internal/test/integration/components/gokafka-seg
+  - go.opentelemetry.io/obi/internal/test/integration/components/gokafka/no-promise
+  - go.opentelemetry.io/obi/internal/test/integration/components/gomemcached
   - go.opentelemetry.io/obi/internal/test/integration/components/gomongo
   - go.opentelemetry.io/obi/internal/test/integration/components/gomongov2
   - go.opentelemetry.io/obi/internal/test/integration/components/gomqtt


### PR DESCRIPTION
Ignore the missing gomemcached module.

Sort the module listings.

## Validation

- `go tool -modfile=[...].tools/go.mod multimod verify`