### PR TITLE
generictracer: report an unobserved response as unknown, not as a 499 error

### DIFF
--- a/bpf/common/http_info.h
+++ b/bpf/common/http_info.h
@@ -11,6 +11,34 @@
 
 #define FULL_BUF_SIZE 256
 
+// How much of the response instrumentation saw, on a request finished at socket
+// teardown. The value decides whether the record's duration is a measurement.
+enum http_response_observation : u8 {
+    // Response parsed, or request still in flight.
+    http_response_parsed = 0,
+    // Bytes arrived, no probe parsed them.
+    http_response_received = 1,
+    // Nothing arrived, the local process closed.
+    http_response_silent = 2,
+};
+
+// A FIN advances bytes_received by one, so ignore that byte.
+#define HTTP_RESPONSE_BYTES_FIN_TOLERANCE 1
+
+// Reports whether the peer sent payload since the request was recorded.
+static __always_inline bool http_response_bytes_advanced(u64 at_request, u64 at_close) {
+    if (at_close <= at_request) {
+        return false;
+    }
+
+    return (at_close - at_request) > HTTP_RESPONSE_BYTES_FIN_TOLERANCE;
+}
+
+static __always_inline u8 http_response_observation_at_close(u64 at_request, u64 at_close) {
+    return http_response_bytes_advanced(at_request, at_close) ? http_response_received
+                                                              : http_response_silent;
+}
+
 // Here we keep the information that is sent on the ring buffer
 typedef struct http_info {
     u8 flags; // Must be first, we use it to tell what kind of packet we have on the ring buffer
@@ -22,6 +50,10 @@ typedef struct http_info {
     u64 end_monotime_ns;
     u64 req_monotime_ns;
     u64 extra_id;
+    // The byte counter when the request was recorded: received bytes for a
+    // client, sent bytes for a server. Zero when the recording path held no
+    // socket (TLS uprobes, unix sockets).
+    u64 response_bytes_at_request;
     tp_info_t tp;
     pid_info pid;
     u32 len;
@@ -36,5 +68,27 @@ typedef struct http_info {
     u8 submitted;
     enum parent_status parent_status;
     enum event_source_type event_source;
-    u8 _pad[1];
+    u8 response_observation;
 } http_info_t;
+
+static __always_inline bool still_responding(const http_info_t *info) {
+    return info->status != 0;
+}
+
+static __always_inline bool still_reading(const http_info_t *info) {
+    return info->status == 0 && info->response_observation == http_response_parsed &&
+           info->start_monotime_ns != 0;
+}
+
+static __always_inline u8 http_info_complete(const http_info_t *info) {
+    return (info->start_monotime_ns != 0 && info->status != 0 && info->pid.host_pid != 0);
+}
+
+static __always_inline u8 http_info_emittable(const http_info_t *info) {
+    if (http_info_complete(info)) {
+        return 1;
+    }
+
+    return (info->response_observation != http_response_parsed && info->start_monotime_ns != 0 &&
+            info->pid.host_pid != 0);
+}

--- a/bpf/common/http_info.h
+++ b/bpf/common/http_info.h
@@ -6,20 +6,29 @@
 #include <bpfcore/vmlinux.h>
 
 #include <common/connection_info.h>
+#include <common/event_defs.h>
 #include <common/event_source.h>
+#include <common/protocol_defs.h>
 #include <common/tp_info.h>
 
 #define FULL_BUF_SIZE 256
 
-// How much of the response instrumentation saw, on a request finished at socket
-// teardown. The value decides whether the record's duration is a measurement.
+// How much of the response instrumentation saw. The value decides whether the record
+// carries a status and whether its duration is a measurement.
 enum http_response_observation : u8 {
     // Response parsed, or request still in flight.
     http_response_parsed = 0,
-    // Bytes arrived, no probe parsed them.
+    // No probe parsed the response, and the record was ended by something other than
+    // the response itself: the socket tearing down, or the next request taking over the
+    // connection. Its duration overstates the request.
     http_response_received = 1,
-    // Nothing arrived, the local process closed.
+    // Nothing arrived, the local process closed. The close ended the request, so the
+    // duration is a measurement.
     http_response_silent = 2,
+    // Bytes arrived in the response direction while the request was in flight and no
+    // probe could parse them. The record ends when the last of them arrived, so the
+    // duration is a measurement.
+    http_response_unread = 3,
 };
 
 // A FIN advances bytes_received by one, so ignore that byte.
@@ -78,6 +87,57 @@ static __always_inline bool still_responding(const http_info_t *info) {
 static __always_inline bool still_reading(const http_info_t *info) {
     return info->status == 0 && info->response_observation == http_response_parsed &&
            info->start_monotime_ns != 0;
+}
+
+// Reports whether the request's response arrived without being parsed. The record is
+// finished, and only the status is missing from it.
+static __always_inline bool response_unread(const http_info_t *info) {
+    return info->status == 0 && info->response_observation == http_response_unread;
+}
+
+// Reports whether a buffer traveling in this direction carries the response to this
+// record's request: inbound for a call this process made, outbound for one it served.
+static __always_inline bool http_response_direction(const http_info_t *info, u8 direction) {
+    if (info->type == k_event_type_http_client) {
+        return direction == TCP_RECV;
+    }
+
+    return direction == TCP_SEND;
+}
+
+// Reports whether a buffer that no parser recognized carries this record's response: it
+// travels in the response direction, and the record is one whose status is still missing.
+static __always_inline bool unparsed_response_buffer(const http_info_t *info, u8 direction) {
+    if (still_responding(info)) {
+        return false;
+    }
+
+    if (!still_reading(info) && !response_unread(info)) {
+        return false;
+    }
+
+    return http_response_direction(info, direction);
+}
+
+// Records a response that arrived unparsed, ending the record when the bytes arrived.
+// Called for every such buffer, so the end advances to the last one seen.
+static __always_inline void note_unread_response(http_info_t *info, u64 at) {
+    info->response_observation = http_response_unread;
+    info->end_monotime_ns = at;
+}
+
+// Records that the next request took over the connection while this one was still in
+// flight. The response cannot be observed after this point, so the record is reported
+// for what it is: a call that was made, with no status, ended at a time it cannot vouch
+// for. Reporting nothing loses one call for every request a connection carries.
+static __always_inline void note_displaced_by_next_request(http_info_t *info, u64 at) {
+    if (!still_reading(info)) {
+        return;
+    }
+
+    info->resp_len = 0;
+    info->end_monotime_ns = at;
+    info->response_observation = http_response_received;
 }
 
 static __always_inline u8 http_info_complete(const http_info_t *info) {

--- a/bpf/common/http_types.h
+++ b/bpf/common/http_types.h
@@ -58,6 +58,7 @@ typedef struct call_protocol_args {
     u16 _pad2;
     u64 u_buf;
     u64 self_ref_parent_id;
+    u64 sock_ptr;
     lw_thread_t lw_thread;
 } call_protocol_args_t;
 

--- a/bpf/generictracer/java_tls.c
+++ b/bpf/generictracer/java_tls.c
@@ -269,7 +269,7 @@ int BPF_KPROBE_GUARDED(obi_kprobe_sys_ioctl) {
 
         const u64 zero = 0;
         bpf_map_update_elem(&active_ssl_connections, &p_conn, &zero, BPF_ANY);
-        handle_buf_with_connection(ctx, &p_conn, buf, max_len, WITH_SSL, op, orig_dport);
+        handle_buf_with_connection(ctx, &p_conn, buf, max_len, WITH_SSL, op, orig_dport, 0);
     }
 
     return 0;

--- a/bpf/generictracer/k_send_receive.h
+++ b/bpf/generictracer/k_send_receive.h
@@ -68,7 +68,8 @@ static __always_inline void force_sent_event(u64 id,
                                              u64 *sock_p,
                                              pid_connection_info_t *p_conn,
                                              const bool unreadable,
-                                             const trace_key_t *current_key) {
+                                             const trace_key_t *current_key,
+                                             struct sock *sk) {
     send_args_t *s_args = (send_args_t *)bpf_map_lookup_elem(&active_send_args, &id);
     if (s_args) {
         if (should_ignore_unreadable(&s_args->p_conn, unreadable)) {
@@ -76,7 +77,7 @@ static __always_inline void force_sent_event(u64 id,
             return;
         }
         bpf_dbg_printk("Checking if we need to finish the request per thread id");
-        force_finish_possible_delayed_http_request(&s_args->p_conn, current_key);
+        force_finish_possible_delayed_http_request(&s_args->p_conn, current_key, sk);
     } // see if we match on another thread, but same sock *
     s_args = (send_args_t *)bpf_map_lookup_elem(&active_send_sock_args, sock_p);
     if (s_args) {
@@ -85,7 +86,7 @@ static __always_inline void force_sent_event(u64 id,
             return;
         }
         bpf_dbg_printk("Checking if we need to finish the request per socket");
-        force_finish_possible_delayed_http_request(&s_args->p_conn, current_key);
+        force_finish_possible_delayed_http_request(&s_args->p_conn, current_key, sk);
     }
 
     if (!is_empty_connection_info(&p_conn->conn)) {
@@ -94,6 +95,6 @@ static __always_inline void force_sent_event(u64 id,
             return;
         }
         bpf_dbg_printk("Checking if we need to finish the request per connection info");
-        force_finish_possible_delayed_http_request(p_conn, current_key);
+        force_finish_possible_delayed_http_request(p_conn, current_key, sk);
     }
 }

--- a/bpf/generictracer/k_tracer.c
+++ b/bpf/generictracer/k_tracer.c
@@ -26,6 +26,7 @@
 
 #include <generictracer/dns.h>
 #include <generictracer/k_send_receive.h>
+#include <generictracer/send_buffer.h>
 #include <generictracer/k_tracer_defs.h>
 #include <generictracer/k_unix_sock.h>
 #include <generictracer/maps/active_accept_args.h>
@@ -493,7 +494,7 @@ int BPF_KPROBE_GUARDED(obi_kprobe_tcp_sendmsg, struct sock *sk, struct msghdr *m
 
     bpf_dbg_printk("=== kprobe/tcp_sendmsg id=%d, sock=%llx, size=%d ===", id, sk, size);
 
-    send_args_t s_args = {.size = size, .buffer_read = 0};
+    send_args_t s_args = {.size = size, .buffer_read = 0, .sock_ptr = (u64)sk};
 
     if (parse_sock_info(sk, &s_args.p_conn.conn)) {
         const u16 orig_dport = s_args.p_conn.conn.d_port;
@@ -610,7 +611,7 @@ int BPF_KPROBE_GUARDED(obi_kprobe_tcp_sendmsg, struct sock *sk, struct msghdr *m
                         bpf_map_delete_elem(&msg_buffers, &e_key);
                         // Logically last for !ssl.
                         handle_buf_with_connection(
-                            ctx, &s_args.p_conn, buf, size, NO_SSL, TCP_SEND, orig_dport);
+                            ctx, &s_args.p_conn, buf, size, NO_SSL, TCP_SEND, orig_dport, sk);
                     }
                 }
                 bpf_map_delete_elem(&msg_buffers, &e_key);
@@ -644,6 +645,7 @@ int BPF_KPROBE_GUARDED(obi_kprobe_tcp_rate_check_app_limited, struct sock *sk) {
 
     send_args_t s_args = {
         .buffer_read = 0,
+        .sock_ptr = (u64)sk,
     };
 
     if (parse_sock_info(sk, &s_args.p_conn.conn)) {
@@ -709,7 +711,7 @@ int BPF_KPROBE_GUARDED(obi_kprobe_tcp_rate_check_app_limited, struct sock *sk) {
                         bpf_map_delete_elem(&msg_buffers, &e_key);
                         // Logically last for !ssl.
                         handle_buf_with_connection(
-                            ctx, &s_args.p_conn, buf, size, NO_SSL, TCP_SEND, orig_dport);
+                            ctx, &s_args.p_conn, buf, size, NO_SSL, TCP_SEND, orig_dport, sk);
                     }
                 }
                 bpf_map_delete_elem(&msg_buffers, &e_key);
@@ -748,24 +750,7 @@ int BPF_KRETPROBE_GUARDED(obi_kretprobe_tcp_sendmsg, int sent_len) {
             finish_possible_delayed_http_request(&s_args->p_conn);
         }
 
-        if (!s_args->buffer_read) {
-            backup_buffer_t *backup =
-                bpf_map_lookup_elem(&sock_filter_buffers, &s_args->p_conn.conn);
-            if (backup) {
-                bpf_map_delete_elem(&active_send_args, &id);
-                // Don't delete the sock filter buffer, there might be a receive message that will
-                // need it.
-
-                // Logically last, doesn't return it tail calls
-                handle_buf_with_connection(ctx,
-                                           &s_args->p_conn,
-                                           backup->buf,
-                                           s_args->size,
-                                           NO_SSL,
-                                           TCP_SEND,
-                                           s_args->orig_dport);
-            }
-        }
+        flush_backup_send_buffer(ctx, id, s_args);
     }
 
     bpf_map_delete_elem(&active_send_args, &id);
@@ -835,7 +820,7 @@ int BPF_KPROBE_GUARDED(obi_kprobe_tcp_close, struct sock *sk, long timeout) {
         unreadable = is_conn_unreadable(&info.conn);
     }
 
-    force_sent_event(id, &sock_p, &info, unreadable, &current_key);
+    force_sent_event(id, &sock_p, &info, unreadable, &current_key, sk);
 
     if (success) {
         //dbg_print_http_connection_info(&info.conn);
@@ -1173,8 +1158,14 @@ static __always_inline int return_recvmsg(void *ctx, struct sock *in_sock, u64 i
             if (buf && copied_len) {
                 bpf_map_delete_elem(&active_recv_args, &id);
                 // doesn't return must be logically last statement
-                handle_buf_with_connection(
-                    ctx, &info, buf, copied_len, NO_SSL, TCP_RECV, orig_dport);
+                handle_buf_with_connection(ctx,
+                                           &info,
+                                           buf,
+                                           copied_len,
+                                           NO_SSL,
+                                           TCP_RECV,
+                                           orig_dport,
+                                           (struct sock *)sock_ptr);
             }
         } else {
             bpf_dbg_printk("identified SSL connection, ignoring: [%llx]...", *ssl);

--- a/bpf/generictracer/k_tracer_defs.h
+++ b/bpf/generictracer/k_tracer_defs.h
@@ -47,7 +47,8 @@ static __always_inline call_protocol_args_t *make_protocol_args(const pid_connec
                                                                 int bytes_len,
                                                                 u8 ssl,
                                                                 u8 direction,
-                                                                u16 orig_dport) {
+                                                                u16 orig_dport,
+                                                                struct sock *sk) {
     if (bytes_len <= 0) {
         return 0;
     }
@@ -61,6 +62,7 @@ static __always_inline call_protocol_args_t *make_protocol_args(const pid_connec
     args->bytes_len = bytes_len;
     args->direction = direction;
     args->orig_dport = orig_dport;
+    args->sock_ptr = (u64)sk;
     args->u_buf = (u64)u_buf;
     args->lw_thread = lw_thread;
     args->protocols = protocols;
@@ -81,7 +83,8 @@ static __always_inline void handle_buf_with_connection(void *ctx,
                                                        int bytes_len,
                                                        u8 ssl,
                                                        u8 direction,
-                                                       u16 orig_dport) {
+                                                       u16 orig_dport,
+                                                       struct sock *sk) {
     call_protocol_args_t *args = make_protocol_args(pid_conn,
                                                     k_lw_thread_none,
                                                     k_protocol_selector_all,
@@ -89,7 +92,8 @@ static __always_inline void handle_buf_with_connection(void *ctx,
                                                     bytes_len,
                                                     ssl,
                                                     direction,
-                                                    orig_dport);
+                                                    orig_dport,
+                                                    sk);
     if (!args) {
         return;
     }
@@ -107,7 +111,7 @@ static __always_inline void handle_light_weight_thread_buf(void *ctx,
                                                            u8 direction,
                                                            u16 orig_dport) {
     call_protocol_args_t *args = make_protocol_args(
-        pid_conn, lw_thread, protocols, u_buf, bytes_len, ssl, direction, orig_dport);
+        pid_conn, lw_thread, protocols, u_buf, bytes_len, ssl, direction, orig_dport, 0);
     if (!args) {
         return;
     }

--- a/bpf/generictracer/k_unix_sock.h
+++ b/bpf/generictracer/k_unix_sock.h
@@ -204,7 +204,7 @@ static __always_inline int return_unix_recvmsg(void *ctx, u64 id, int copied_len
         int read_len = read_iovec_ctx(iov_ctx, buf, copied_len);
         if (read_len) {
             // doesn't return must be logically last statement
-            handle_buf_with_connection(ctx, &p_conn, buf, read_len, NO_SSL, TCP_RECV, 0);
+            handle_buf_with_connection(ctx, &p_conn, buf, read_len, NO_SSL, TCP_RECV, 0, 0);
         } else {
             bpf_dbg_printk("Not copied anything");
         }
@@ -268,7 +268,7 @@ int BPF_KPROBE_GUARDED(obi_kprobe_unix_stream_sendmsg,
                 bpf_map_update_elem(&active_send_sock_args, &sock_p, &s_args, BPF_ANY);
             }
 
-            handle_buf_with_connection(ctx, &s_args.p_conn, buf, size, NO_SSL, TCP_SEND, 0);
+            handle_buf_with_connection(ctx, &s_args.p_conn, buf, size, NO_SSL, TCP_SEND, 0, 0);
         } else {
             bpf_dbg_printk("can't find iovec ptr in msghdr, not tracking sendmsg");
         }

--- a/bpf/generictracer/protocol_handler.c
+++ b/bpf/generictracer/protocol_handler.c
@@ -117,9 +117,10 @@ int GUARDED_PROG(obi_handle_buf_with_args, void *, ctx) {
 
             const u8 reading = still_reading(info);
             const u8 responding = still_responding(info);
+            const u8 unread = response_unread(info);
             // Still reading checks if we are processing buffers of a HTTP request
             // that has started, but we haven't seen a response yet.
-            if (reading || responding) {
+            if (reading || responding || unread) {
                 // Packets are split into chunks if OBI injected the Traceparent
                 // Make sure you look for split packets containing the real Traceparent.
                 // Essentially, when a packet is extended by our sock_msg program and
@@ -156,12 +157,21 @@ int GUARDED_PROG(obi_handle_buf_with_args, void *, ctx) {
                     }
                 }
 
+                // A buffer arriving in the response direction with no status line in it
+                // is the response, unparsed. Counting it as more of the request would
+                // leave the record indistinguishable from one still waiting, and the
+                // next request on the connection would then destroy it unreported.
+                const bool unparsed_response = unparsed_response_buffer(info, args->direction);
+
                 u8 packet_type = PACKET_TYPE_REQUEST;
-                if (responding) {
+                if (responding || unparsed_response) {
                     packet_type = PACKET_TYPE_RESPONSE;
                 }
 
-                if (reading) {
+                if (unparsed_response) {
+                    note_unread_response(info, bpf_ktime_get_ns());
+                    info->resp_len += args->bytes_len;
+                } else if (reading) {
                     info->len += args->bytes_len;
                 } else if (responding) {
                     info->end_monotime_ns = bpf_ktime_get_ns();

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -5,6 +5,7 @@
 
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_builtins.h>
+#include <bpfcore/bpf_core_read.h>
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/utils.h>
 
@@ -79,18 +80,6 @@ static __always_inline u8 is_http(const unsigned char *p, u32 len, u8 *packet_ty
     return 0;
 }
 
-static __always_inline bool still_responding(http_info_t *info) {
-    return info->status != 0;
-}
-
-static __always_inline bool still_reading(http_info_t *info) {
-    return info->status == 0 && info->start_monotime_ns != 0;
-}
-
-static __always_inline u8 http_info_complete(http_info_t *info) {
-    return (info->start_monotime_ns != 0 && info->status != 0 && info->pid.host_pid != 0);
-}
-
 static __always_inline u8 http_will_complete(http_info_t *info, unsigned char *buf, u32 len) {
     if (info->start_monotime_ns != 0) {
         u8 packet_type;
@@ -159,7 +148,7 @@ static __always_inline void mark_http_server_thread_trace_response_sent(http_inf
 }
 
 static __always_inline void submit_http_event(http_info_t *info, pid_connection_info_t *pid_conn) {
-    if (!http_info_complete(info) || info->submitted) {
+    if (!http_info_emittable(info) || info->submitted) {
         return;
     }
 
@@ -179,7 +168,7 @@ static __always_inline void submit_http_event(http_info_t *info, pid_connection_
 
 static __always_inline void
 finish_http(http_info_t *info, pid_connection_info_t *pid_conn, const trace_key_t *current_key) {
-    if (!http_info_complete(info)) {
+    if (!http_info_emittable(info)) {
         return;
     }
 
@@ -197,18 +186,33 @@ finish_http(http_info_t *info, pid_connection_info_t *pid_conn, const trace_key_
     bpf_map_delete_elem(&active_ssl_connections, pid_conn);
 }
 
+static __always_inline u64 http_response_bytes_from_sock(struct sock *sk, u8 type) {
+    if (!sk) {
+        return 0;
+    }
+
+    if (type == k_event_type_http_request) {
+        return BPF_CORE_READ((struct tcp_sock *)sk, bytes_sent);
+    }
+
+    return BPF_CORE_READ((struct tcp_sock *)sk, bytes_received);
+}
+
 static __always_inline void force_finish_http(http_info_t *info,
                                               pid_connection_info_t *pid_conn,
-                                              const trace_key_t *current_key) {
+                                              const trace_key_t *current_key,
+                                              u64 response_bytes) {
     if (info->submitted) {
         return;
     }
 
     if (!high_request_volume) {
         if (!http_info_complete(info)) {
+            // status stays 0: nothing was parsed, so there is no status to report.
             info->resp_len = 0;
             info->end_monotime_ns = bpf_ktime_get_ns();
-            info->status = 499;
+            info->response_observation =
+                http_response_observation_at_close(info->response_bytes_at_request, response_bytes);
         }
     }
 
@@ -272,9 +276,8 @@ static __always_inline void finish_possible_delayed_http_request(pid_connection_
     }
 }
 
-static __always_inline void
-force_finish_possible_delayed_http_request(pid_connection_info_t *pid_conn,
-                                           const trace_key_t *current_key) {
+static __always_inline void force_finish_possible_delayed_http_request(
+    pid_connection_info_t *pid_conn, const trace_key_t *current_key, struct sock *sk) {
     http_info_t *info = bpf_map_lookup_elem(&ongoing_http, pid_conn);
     if (info) {
         cleanup_incomplete_http_server_thread_trace(info, current_key);
@@ -282,7 +285,8 @@ force_finish_possible_delayed_http_request(pid_connection_info_t *pid_conn,
             finish_http(info, pid_conn, current_key);
         } else {
             bpf_dbg_printk("forcing HTTP event finish");
-            force_finish_http(info, pid_conn, current_key);
+            force_finish_http(
+                info, pid_conn, current_key, http_response_bytes_from_sock(sk, info->type));
         }
     }
     cleanup_http_info(pid_conn);
@@ -307,7 +311,8 @@ static __always_inline void process_http_request(http_info_t *info,
                                                  http_connection_metadata_t *meta,
                                                  int direction,
                                                  u16 orig_dport,
-                                                 lw_thread_t lw_thread) {
+                                                 lw_thread_t lw_thread,
+                                                 struct sock *sk) {
     // Set pid and type early as best effort in case the request times out or dies.
     if (meta) {
         info->pid = meta->pid;
@@ -351,6 +356,8 @@ static __always_inline void process_http_request(http_info_t *info,
     info->req_monotime_ns = req_time;
     info->status = 0;
     info->submitted = 0;
+    info->response_observation = http_response_parsed;
+    info->response_bytes_at_request = http_response_bytes_from_sock(sk, info->type);
     info->len = len;
     info->event_source = event_source(lw_thread); // generic events generated from Go
     info->extra_id = extra_runtime_id();          // required for deleting the trace information
@@ -477,8 +484,13 @@ static __always_inline int __obi_continue2_protocol_http(struct pt_regs *ctx,
     // we copy some small part of the buffer to the info trace event, so that we can process an event even with
     // incomplete trace info in user space.
     read_request_buf(info, args);
-    process_http_request(
-        info, args->bytes_len, meta, args->direction, args->orig_dport, args->lw_thread);
+    process_http_request(info,
+                         args->bytes_len,
+                         meta,
+                         args->direction,
+                         args->orig_dport,
+                         args->lw_thread,
+                         (struct sock *)args->sock_ptr);
 
     // Emit large buffer last: may tail call for continuation batches, so all
     // critical state updates must precede this call.

--- a/bpf/generictracer/protocol_http.h
+++ b/bpf/generictracer/protocol_http.h
@@ -207,7 +207,9 @@ static __always_inline void force_finish_http(http_info_t *info,
     }
 
     if (!high_request_volume) {
-        if (!http_info_complete(info)) {
+        // A record that already saw its response unparsed is timed from those bytes, so
+        // the teardown neither ends it nor tells us anything new about it.
+        if (!http_info_complete(info) && info->response_observation == http_response_parsed) {
             // status stays 0: nothing was parsed, so there is no status to report.
             info->resp_len = 0;
             info->end_monotime_ns = bpf_ktime_get_ns();
@@ -240,10 +242,15 @@ static __always_inline http_info_t *get_or_set_http_info(http_info_t *info,
         if (old_info && !old_info->submitted) {
             const u8 req_type = request_type_by_direction(direction, packet_type);
             if (!http_info_complete(old_info)) {
-                if (old_info->type == req_type && is_duplicate_info(old_info)) {
+                // A record whose response already arrived is finished, whatever came of
+                // the parse, so a request in the same epoch is the next call on a reused
+                // connection rather than a second sighting of this one.
+                if (old_info->type == req_type && !response_unread(old_info) &&
+                    is_duplicate_info(old_info)) {
                     return 0;
                 }
                 cleanup_incomplete_http_server_thread_trace(old_info, NULL);
+                note_displaced_by_next_request(old_info, bpf_ktime_get_ns());
             }
             // this will delete ongoing_http for this connection info if there's full stale request
             finish_http(old_info, pid_conn, NULL);
@@ -372,6 +379,9 @@ static __always_inline void process_http_request(http_info_t *info,
 static __always_inline void process_http_response(http_info_t *info, const unsigned char *buf) {
     info->resp_len = 0;
     info->end_monotime_ns = bpf_ktime_get_ns();
+    // An earlier buffer on this connection may have been marked as the response arriving
+    // unparsed. This one parsed, so the record carries a status after all.
+    info->response_observation = http_response_parsed;
 
     u16 status = 0;
 

--- a/bpf/generictracer/send_buffer.h
+++ b/bpf/generictracer/send_buffer.h
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/backup_buffer.h>
+#include <common/protocol_defs.h>
+#include <common/send_args.h>
+
+#include <generictracer/k_tracer_defs.h>
+
+#include <generictracer/maps/active_send_args.h>
+#include <generictracer/maps/sock_filter_buffers.h>
+
+// Hands the socket filter's captured buffer to the protocol parser when a send
+// completed without one having been read inline. The socket comes from send_args_t,
+// recorded by the entry kprobe: a kretprobe sees only the return value, so it has none
+// of its own to pass.
+static __always_inline void flush_backup_send_buffer(void *ctx, u64 id, send_args_t *s_args) {
+    if (s_args->buffer_read) {
+        return;
+    }
+
+    backup_buffer_t *backup = bpf_map_lookup_elem(&sock_filter_buffers, &s_args->p_conn.conn);
+    if (!backup) {
+        return;
+    }
+
+    bpf_map_delete_elem(&active_send_args, &id);
+    // Don't delete the sock filter buffer, there might be a receive message that will
+    // need it.
+
+    // Logically last, doesn't return it tail calls
+    handle_buf_with_connection(ctx,
+                               &s_args->p_conn,
+                               backup->buf,
+                               s_args->size,
+                               NO_SSL,
+                               TCP_SEND,
+                               s_args->orig_dport,
+                               (struct sock *)s_args->sock_ptr);
+}

--- a/bpf/generictracer/ssl_defs.h
+++ b/bpf/generictracer/ssl_defs.h
@@ -130,7 +130,9 @@ handle_ssl_buf(void *ctx, u64 id, ssl_args_t *args, int bytes_len, u8 direction)
                                        bytes_len,
                                        WITH_SSL,
                                        direction,
-                                       conn->orig_dport);
+                                       conn->orig_dport,
+                                       // A TLS uprobe holds no socket.
+                                       0);
         } else {
             bpf_dbg_printk("No connection info! This is a bug.");
         }

--- a/bpf/tests/bpf_ssl_read_guard.c
+++ b/bpf/tests/bpf_ssl_read_guard.c
@@ -43,6 +43,7 @@ int test_parser_call_count;
 int test_last_parser_bytes_len;
 u8 test_last_ssl;
 u8 test_last_direction;
+void *test_last_sock;
 u16 test_last_orig_dport;
 int test_finish_http_count;
 u8 test_http_will_complete;
@@ -59,6 +60,13 @@ static int test_mapped_pid_tid_available;
 static void assert_int_eq(int expected, int actual, const char *message) {
     if (expected != actual) {
         fprintf(stderr, "FAIL: %s\n  expected %d, got %d\n", message, expected, actual);
+        exit(1);
+    }
+}
+
+static void assert_null(const void *actual, const char *message) {
+    if (actual != NULL) {
+        fprintf(stderr, "FAIL: %s\n  expected NULL, got %p\n", message, actual);
         exit(1);
     }
 }
@@ -135,6 +143,7 @@ static void reset(void) {
     test_last_parser_bytes_len = 0;
     test_last_ssl = 0;
     test_last_direction = 0;
+    test_last_sock = (void *)1;
     test_last_orig_dport = 0;
     test_finish_http_count = 0;
     test_http_will_complete = 0;
@@ -195,6 +204,8 @@ static void test_successful_read_still_parses(void) {
     assert_int_eq(1, test_last_parser_bytes_len, "successful read forwards the read length");
     assert_int_eq(WITH_SSL, test_last_ssl, "successful read is marked as SSL");
     assert_int_eq(TCP_RECV, test_last_direction, "successful read preserves direction");
+    // A TLS uprobe sees the decrypted buffer and holds no struct sock.
+    assert_null(test_last_sock, "a TLS read passes no socket to the parser");
     assert_u16_eq(443, test_last_orig_dport, "successful read preserves original dport");
 }
 
@@ -223,6 +234,7 @@ static void test_successful_write_still_parses(void) {
     assert_int_eq(32, test_last_parser_bytes_len, "successful write forwards the written length");
     assert_int_eq(WITH_SSL, test_last_ssl, "successful write is marked as SSL");
     assert_int_eq(TCP_SEND, test_last_direction, "successful write preserves direction");
+    assert_null(test_last_sock, "a TLS write passes no socket to the parser");
     assert_u16_eq(443, test_last_orig_dport, "successful write preserves original dport");
 }
 

--- a/bpf/tests/bpf_tls_prefix_bind.c
+++ b/bpf/tests/bpf_tls_prefix_bind.c
@@ -87,6 +87,7 @@ int test_last_parser_bytes_len;
 u8 test_last_ssl;
 u8 test_last_direction;
 u16 test_last_orig_dport;
+void *test_last_sock;
 int test_finish_http_count;
 u8 test_http_will_complete;
 

--- a/bpf/tests/generictracer/k_tracer_defs.h
+++ b/bpf/tests/generictracer/k_tracer_defs.h
@@ -21,14 +21,18 @@ extern int test_last_parser_bytes_len;
 extern u8 test_last_ssl;
 extern u8 test_last_direction;
 extern u16 test_last_orig_dport;
+extern void *test_last_sock;
 
+// bpf/tests shadows generictracer/k_tracer_defs.h, so this signature has to track the
+// real one.
 static __always_inline void handle_buf_with_connection(void *ctx,
                                                        pid_connection_info_t *pid_conn,
                                                        void *u_buf,
                                                        int bytes_len,
                                                        u8 ssl,
                                                        u8 direction,
-                                                       u16 orig_dport) {
+                                                       u16 orig_dport,
+                                                       struct sock *sk) {
     (void)ctx;
     (void)pid_conn;
     (void)u_buf;
@@ -38,4 +42,5 @@ static __always_inline void handle_buf_with_connection(void *ctx,
     test_last_ssl = ssl;
     test_last_direction = direction;
     test_last_orig_dport = orig_dport;
+    test_last_sock = sk;
 }

--- a/bpf/tests/generictracer/maps/active_send_args.h
+++ b/bpf/tests/generictracer/maps/active_send_args.h
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/bpf_helpers.h>
+
+extern struct bpf_test_map active_send_args;

--- a/bpf/tests/generictracer/maps/sock_filter_buffers.h
+++ b/bpf/tests/generictracer/maps/sock_filter_buffers.h
@@ -1,0 +1,8 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/bpf_helpers.h>
+
+extern struct bpf_test_map sock_filter_buffers;

--- a/bpf/tests/test_http_connection_reuse.c
+++ b/bpf/tests/test_http_connection_reuse.c
@@ -1,0 +1,159 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Run from repo root:
+//   make -C bpf/tests test_http_connection_reuse && bpf/tests/test_http_connection_reuse
+// Run from bpf/tests:
+//   make test_http_connection_reuse && ./test_http_connection_reuse
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include <common/http_info.h>
+
+static unsigned int failed_assertions;
+
+static void assert_true(bool condition, const char *message) {
+    if (condition) {
+        printf("PASS: %s\n", message);
+        return;
+    }
+
+    failed_assertions++;
+    printf("FAIL: %s\n", message);
+}
+
+static http_info_t in_flight_client_request(void) {
+    http_info_t info = {};
+    info.type = k_event_type_http_client;
+    info.start_monotime_ns = 1000;
+    info.pid.host_pid = 4242;
+
+    return info;
+}
+
+static http_info_t in_flight_server_request(void) {
+    http_info_t info = in_flight_client_request();
+    info.type = k_event_type_http_request;
+
+    return info;
+}
+
+// The response travels opposite the request: inbound for a call this process made,
+// outbound for one it served.
+static void test_response_direction_follows_the_record_type(void) {
+    const http_info_t client = in_flight_client_request();
+    const http_info_t server = in_flight_server_request();
+
+    assert_true(http_response_direction(&client, TCP_RECV),
+                "a client's response arrives on a read");
+    assert_true(!http_response_direction(&client, TCP_SEND),
+                "a client's own request going out is not its response");
+    assert_true(http_response_direction(&server, TCP_SEND), "a server's response goes out");
+    assert_true(!http_response_direction(&server, TCP_RECV),
+                "a request arriving at a server is not its response");
+}
+
+// The unparsed remainder of a response used to be added to the request's length, which
+// left the record indistinguishable from one still waiting to be answered.
+static void test_unparsed_response_is_recognized_not_counted_as_request(void) {
+    const http_info_t client = in_flight_client_request();
+    const http_info_t server = in_flight_server_request();
+
+    assert_true(unparsed_response_buffer(&client, TCP_RECV),
+                "an unrecognized read is the client's response");
+    assert_true(!unparsed_response_buffer(&client, TCP_SEND),
+                "an unrecognized write is more of the client's request");
+    assert_true(unparsed_response_buffer(&server, TCP_SEND),
+                "an unrecognized write is the server's response");
+    assert_true(!unparsed_response_buffer(&server, TCP_RECV),
+                "an unrecognized read is more of the server's request");
+}
+
+// A response split across several unparsed buffers ends the record at the last of them.
+static void test_marking_advances_the_end_with_each_buffer(void) {
+    http_info_t info = in_flight_client_request();
+
+    note_unread_response(&info, 3000);
+    assert_true(response_unread(&info), "a marked record is holding an unread response");
+    assert_true(info.status == 0, "an unread response reports no status");
+    assert_true(info.end_monotime_ns == 3000, "the record ends when the response arrived");
+    assert_true(!still_reading(&info), "a marked record is no longer waiting on a response");
+
+    assert_true(unparsed_response_buffer(&info, TCP_RECV),
+                "a further unrecognized read is still this response");
+
+    note_unread_response(&info, 4000);
+    assert_true(info.end_monotime_ns == 4000, "the end advances to the last buffer seen");
+}
+
+// The whole point of the marker: the record survives the next request on the connection.
+// Before it, only status != 0 got a record out, so every reused connection lost the call
+// that came before.
+static void test_marked_record_is_emitted_where_an_unmarked_one_was_dropped(void) {
+    http_info_t waiting = in_flight_client_request();
+    assert_true(!http_info_emittable(&waiting),
+                "a request still waiting on its response is not emitted");
+
+    http_info_t answered_unparsed = in_flight_client_request();
+    note_unread_response(&answered_unparsed, 3000);
+    assert_true(http_info_emittable(&answered_unparsed),
+                "a request whose response went unparsed is emitted");
+    assert_true(!http_info_complete(&answered_unparsed),
+                "an unread response is not mistaken for an observed one");
+}
+
+// A record still waiting when the next request takes the connection is reported too,
+// without a duration it cannot vouch for.
+static void test_displaced_record_is_reported(void) {
+    http_info_t waiting = in_flight_client_request();
+    waiting.resp_len = 17;
+
+    note_displaced_by_next_request(&waiting, 5000);
+
+    assert_true(waiting.response_observation == http_response_received,
+                "a displaced request reports that its response was never read");
+    assert_true(waiting.status == 0, "a displaced request reports no status");
+    assert_true(waiting.end_monotime_ns != 0, "a displaced request is ended");
+    assert_true(waiting.resp_len == 0, "a displaced request claims no response body");
+    assert_true(http_info_emittable(&waiting), "a displaced request is emitted");
+}
+
+// Displacement must not overwrite a record that already timed its own response, nor
+// disturb one that parsed a status.
+static void test_displacement_leaves_finished_records_alone(void) {
+    http_info_t unread = in_flight_client_request();
+    note_unread_response(&unread, 3000);
+
+    note_displaced_by_next_request(&unread, 5000);
+    assert_true(unread.response_observation == http_response_unread,
+                "a record that saw its response keeps that observation");
+    assert_true(unread.end_monotime_ns == 3000, "a record that saw its response keeps its end");
+
+    http_info_t answered = in_flight_client_request();
+    answered.status = 200;
+    answered.end_monotime_ns = 2000;
+
+    note_displaced_by_next_request(&answered, 5000);
+    assert_true(answered.status == 200, "an answered request keeps its status");
+    assert_true(answered.end_monotime_ns == 2000, "an answered request keeps its end");
+    assert_true(answered.response_observation == http_response_parsed,
+                "an answered request stays parsed");
+}
+
+int main(void) {
+    test_response_direction_follows_the_record_type();
+    test_unparsed_response_is_recognized_not_counted_as_request();
+    test_marking_advances_the_end_with_each_buffer();
+    test_marked_record_is_emitted_where_an_unmarked_one_was_dropped();
+    test_displaced_record_is_reported();
+    test_displacement_leaves_finished_records_alone();
+
+    if (failed_assertions != 0) {
+        printf("%u failed assertions\n", failed_assertions);
+        return 1;
+    }
+
+    return 0;
+}

--- a/bpf/tests/test_http_response_observation.c
+++ b/bpf/tests/test_http_response_observation.c
@@ -117,19 +117,15 @@ static void test_observation_at_close_names_both_cases(void) {
                 "an unsnapshotted record with no traffic at all is still absent");
 }
 
-// The marker takes a former padding byte; the snapshot is the word past it. The struct
-// was already a full 416 bytes, so it grew by one word. Assert it so a later field is
-// not added in the belief the tail has room.
+// The marker takes a former padding byte at the tail, and the snapshot sits with the
+// other u64s where it costs no padding of its own. Assert both, so a later field is not
+// added in the belief the tail has room.
 static void test_struct_grew_by_exactly_the_snapshot(void) {
     assert_true(sizeof(http_info_t) % 8 == 0, "http_info_t stays 8-byte aligned in size");
-    assert_true(offsetof(http_info_t, response_observation) <
-                    offsetof(http_info_t, response_bytes_at_request),
-                "the snapshot follows the marker");
-    assert_true(offsetof(http_info_t, response_bytes_at_request) + sizeof(u64) ==
-                    sizeof(http_info_t),
-                "the snapshot is the struct's last field and its last word");
-    assert_true(sizeof(http_info_t) == offsetof(http_info_t, response_observation) + 2 + 8,
-                "the record grew by exactly the 8 bytes the snapshot needs, and no more");
+    assert_true(offsetof(http_info_t, response_bytes_at_request) % sizeof(u64) == 0,
+                "the snapshot is aligned, so it added no padding beyond its own word");
+    assert_true(offsetof(http_info_t, response_observation) + sizeof(u8) == sizeof(http_info_t),
+                "the marker is the record's last byte, in padding that already existed");
 }
 
 // Both outcomes travel the identical path out. Userspace decides what to do with the

--- a/bpf/tests/test_http_response_observation.c
+++ b/bpf/tests/test_http_response_observation.c
@@ -1,0 +1,168 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Run from repo root:
+//   make -C bpf/tests test_http_response_observation && bpf/tests/test_http_response_observation
+// Run from bpf/tests:
+//   make test_http_response_observation && ./test_http_response_observation
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include <common/http_info.h>
+
+static unsigned int failed_assertions;
+
+static void assert_true(bool condition, const char *message) {
+    if (condition) {
+        printf("PASS: %s\n", message);
+        return;
+    }
+
+    failed_assertions++;
+    printf("FAIL: %s\n", message);
+}
+
+static http_info_t in_flight_request(void) {
+    http_info_t info = {};
+    info.start_monotime_ns = 1000;
+    info.pid.host_pid = 4242;
+
+    return info;
+}
+
+static void test_in_flight_request_is_not_emitted(void) {
+    http_info_t info = in_flight_request();
+
+    assert_true(!http_info_complete(&info), "an unanswered request is not complete");
+    assert_true(!http_info_emittable(&info), "an unanswered request is not emitted");
+    assert_true(still_reading(&info), "an unanswered request is still reading");
+}
+
+static void test_answered_request_is_emitted(void) {
+    http_info_t info = in_flight_request();
+    info.status = 200;
+    info.end_monotime_ns = 2000;
+
+    assert_true(http_info_complete(&info), "an answered request is complete");
+    assert_true(http_info_emittable(&info), "an answered request is emitted");
+    assert_true(!still_reading(&info), "an answered request is no longer reading");
+}
+
+static void test_unobserved_response_is_emitted_without_a_status(void) {
+    http_info_t info = in_flight_request();
+    info.response_observation = http_response_silent;
+    info.end_monotime_ns = 2000;
+
+    assert_true(info.status == 0, "an unobserved response reports no status");
+    assert_true(http_info_emittable(&info), "an unobserved response is still emitted");
+    assert_true(!http_info_complete(&info),
+                "an unobserved response is not mistaken for an observed one");
+    assert_true(!still_reading(&info), "an unobserved response is no longer reading");
+}
+
+static void test_marker_alone_is_not_enough(void) {
+    http_info_t info = {};
+    info.response_observation = http_response_silent;
+
+    assert_true(!http_info_emittable(&info), "a marked record with no start time is not emitted");
+
+    info.start_monotime_ns = 1000;
+    assert_true(!http_info_emittable(&info), "a marked record with no pid is not emitted");
+
+    info.pid.host_pid = 4242;
+    assert_true(http_info_emittable(&info), "a marked record with start time and pid is emitted");
+}
+
+// Measured against a peer that closes without answering: a bare FIN advanced
+// bytes_received by exactly 1, a reset by 0, and a real response by its length plus the
+// FIN's byte.
+static void test_response_bytes_tolerate_the_fin_byte(void) {
+    assert_true(!http_response_bytes_advanced(0, 0), "an untouched connection saw no response");
+    assert_true(!http_response_bytes_advanced(0, 1),
+                "a bare FIN on a fresh connection is not a response");
+    assert_true(http_response_bytes_advanced(0, 2),
+                "one payload byte plus the FIN byte is a response");
+
+    // The case #3040 came from: a connection that has already carried an exchange is
+    // nowhere near zero when the request that goes unanswered is written to it.
+    assert_true(!http_response_bytes_advanced(4096, 4097),
+                "a bare FIN on a reused connection is not a response");
+    assert_true(!http_response_bytes_advanced(4096, 4096),
+                "a reused connection with no further bytes saw no response");
+    assert_true(http_response_bytes_advanced(4096, 4098),
+                "payload past the snapshot on a reused connection is a response");
+    assert_true(http_response_bytes_advanced(4096, 9000),
+                "a full response past the snapshot is a response");
+
+    assert_true(!http_response_bytes_advanced(4096, 1),
+                "a counter below its snapshot is no advance");
+    assert_true(!http_response_bytes_advanced(1, 0), "a one-byte regression is no advance");
+}
+
+static void test_observation_at_close_names_both_cases(void) {
+    assert_true(http_response_observation_at_close(100, 5000) == http_response_received,
+                "bytes past the snapshot mean the peer answered and OBI did not parse it");
+    assert_true(http_response_observation_at_close(100, 101) == http_response_silent,
+                "a FIN alone means nothing came back");
+    assert_true(http_response_observation_at_close(100, 100) == http_response_silent,
+                "no movement at all means nothing came back");
+
+    // A TLS uprobe holds no socket, so the baseline stays zero and the connection's
+    // whole history reads as an advance.
+    assert_true(http_response_observation_at_close(0, 5000) == http_response_received,
+                "an unsnapshotted record with traffic degrades to unparsed, not to absent");
+    assert_true(http_response_observation_at_close(0, 0) == http_response_silent,
+                "an unsnapshotted record with no traffic at all is still absent");
+}
+
+// The marker takes a former padding byte; the snapshot is the word past it. The struct
+// was already a full 416 bytes, so it grew by one word. Assert it so a later field is
+// not added in the belief the tail has room.
+static void test_struct_grew_by_exactly_the_snapshot(void) {
+    assert_true(sizeof(http_info_t) % 8 == 0, "http_info_t stays 8-byte aligned in size");
+    assert_true(offsetof(http_info_t, response_observation) <
+                    offsetof(http_info_t, response_bytes_at_request),
+                "the snapshot follows the marker");
+    assert_true(offsetof(http_info_t, response_bytes_at_request) + sizeof(u64) ==
+                    sizeof(http_info_t),
+                "the snapshot is the struct's last field and its last word");
+    assert_true(sizeof(http_info_t) == offsetof(http_info_t, response_observation) + 2 + 8,
+                "the record grew by exactly the 8 bytes the snapshot needs, and no more");
+}
+
+// Both outcomes travel the identical path out. Userspace decides what to do with the
+// difference.
+static void test_predicates_do_not_notice_which_unobserved_case(void) {
+    http_info_t unparsed = in_flight_request();
+    unparsed.response_observation = http_response_received;
+
+    http_info_t absent = in_flight_request();
+    absent.response_observation = http_response_silent;
+
+    assert_true(http_info_emittable(&unparsed) && http_info_emittable(&absent),
+                "both unobserved outcomes are emittable");
+    assert_true(!http_info_complete(&unparsed) && !http_info_complete(&absent),
+                "neither unobserved outcome is mistaken for an observed one");
+    assert_true(!still_reading(&unparsed) && !still_reading(&absent),
+                "neither unobserved outcome is still reading");
+}
+
+int main(void) {
+    test_in_flight_request_is_not_emitted();
+    test_answered_request_is_emitted();
+    test_unobserved_response_is_emitted_without_a_status();
+    test_marker_alone_is_not_enough();
+    test_response_bytes_tolerate_the_fin_byte();
+    test_observation_at_close_names_both_cases();
+    test_predicates_do_not_notice_which_unobserved_case();
+    test_struct_grew_by_exactly_the_snapshot();
+
+    if (failed_assertions != 0) {
+        printf("%u failed assertions\n", failed_assertions);
+        return 1;
+    }
+
+    return 0;
+}

--- a/bpf/tests/test_send_buffer_socket.c
+++ b/bpf/tests/test_send_buffer_socket.c
@@ -1,0 +1,144 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Run from repo root:
+//   make -C bpf/tests test_send_buffer_socket && bpf/tests/test_send_buffer_socket
+// Run from bpf/tests:
+//   make test_send_buffer_socket && ./test_send_buffer_socket
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <bpfcore/bpf_helpers.h>
+
+enum { BPF_ANY = 0, BPF_NOEXIST = 1 };
+
+struct bpf_test_map {
+    int id;
+};
+
+static void *test_map_lookup(void *map, const void *key);
+static long test_map_delete(void *map, const void *key);
+
+#define bpf_map_lookup_elem test_map_lookup
+#define bpf_map_delete_elem test_map_delete
+
+#include <generictracer/send_buffer.h>
+
+#undef bpf_map_lookup_elem
+#undef bpf_map_delete_elem
+
+struct bpf_test_map active_send_args = {.id = 1};
+struct bpf_test_map sock_filter_buffers = {.id = 2};
+
+int test_parser_call_count;
+int test_last_parser_bytes_len;
+u8 test_last_ssl;
+u8 test_last_direction;
+u16 test_last_orig_dport;
+void *test_last_sock;
+
+static backup_buffer_t test_backup;
+static int test_backup_present;
+static int test_send_args_deleted;
+
+static void *test_map_lookup(void *map, const void *key) {
+    (void)key;
+    if (map == &sock_filter_buffers) {
+        return test_backup_present ? &test_backup : NULL;
+    }
+    return NULL;
+}
+
+static long test_map_delete(void *map, const void *key) {
+    (void)key;
+    if (map == &active_send_args) {
+        test_send_args_deleted++;
+    }
+    return 0;
+}
+
+static int failures;
+
+static void assert_true(int cond, const char *what) {
+    if (cond) {
+        printf("PASS: %s\n", what);
+        return;
+    }
+    printf("FAIL: %s\n", what);
+    failures++;
+}
+
+static void reset(void) {
+    test_backup_present = 1;
+    test_send_args_deleted = 0;
+    // Seed non-null so an assertion of null is a claim rather than an artefact of
+    // the stub never having been called.
+    test_last_sock = (void *)0xdeadbeef;
+    test_parser_call_count = 0;
+}
+
+// The kretprobe has no socket of its own, so the one recorded by the entry kprobe is
+// what reaches the parser. Without it every record finished on this path keeps a zero
+// baseline, reads the connection's whole history as an advance, and never reports that
+// nothing came back.
+static void test_recorded_socket_reaches_the_parser(void) {
+    reset();
+
+    struct sock *const recorded = (struct sock *)0x1234;
+    send_args_t s_args = {
+        .size = 64,
+        .orig_dport = 8080,
+        .buffer_read = 0,
+        .sock_ptr = (u64)recorded,
+    };
+
+    flush_backup_send_buffer(NULL, 42, &s_args);
+
+    assert_true(test_parser_call_count == 1, "a captured buffer is handed to the parser");
+    assert_true(test_last_sock == (void *)recorded,
+                "the parser gets the socket the kprobe recorded");
+    assert_true(test_send_args_deleted == 1, "the send args are consumed");
+}
+
+// A send whose buffer was already read inline needs no flush, and must not consume the
+// send args a later probe still depends on.
+static void test_buffer_already_read_is_not_flushed(void) {
+    reset();
+
+    send_args_t s_args = {.size = 64, .buffer_read = 1, .sock_ptr = 0x1234};
+
+    flush_backup_send_buffer(NULL, 42, &s_args);
+
+    assert_true(test_parser_call_count == 0, "an already-read buffer is not flushed again");
+    assert_true(test_send_args_deleted == 0, "the send args survive");
+}
+
+// Nothing was captured for this connection, so there is nothing to hand over.
+static void test_absent_backup_is_not_flushed(void) {
+    reset();
+    test_backup_present = 0;
+
+    send_args_t s_args = {.size = 64, .buffer_read = 0, .sock_ptr = 0x1234};
+
+    flush_backup_send_buffer(NULL, 42, &s_args);
+
+    assert_true(test_parser_call_count == 0, "no captured buffer means no parser call");
+    assert_true(test_send_args_deleted == 0, "the send args survive");
+}
+
+int main(void) {
+    test_recorded_socket_reaches_the_parser();
+    test_buffer_already_read_is_not_flushed();
+    test_absent_backup_is_not_flushed();
+
+    if (failures) {
+        printf("%d failure(s)\n", failures);
+        return 1;
+    }
+
+    printf("all assertions passed\n");
+    return 0;
+}

--- a/bpf/tests/test_send_buffer_socket.c
+++ b/bpf/tests/test_send_buffer_socket.c
@@ -13,8 +13,6 @@
 
 #include <bpfcore/bpf_helpers.h>
 
-enum { BPF_ANY = 0, BPF_NOEXIST = 1 };
-
 struct bpf_test_map {
     int id;
 };

--- a/internal/test/integration/components/responseobservationclient/Dockerfile
+++ b/internal/test/integration/components/responseobservationclient/Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.26.3@sha256:efaccb5b497e90df3ebe5216cc25cd9f98e73874e2d638b56e38d4a3f098c41c AS builder
+
+ARG TARGETARCH
+
+ENV GOARCH=$TARGETARCH
+
+WORKDIR /src
+
+COPY internal/test/ internal/test/
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+RUN go build -o responseobservationclient ./internal/test/integration/components/responseobservationclient/
+
+FROM debian:bookworm-slim@sha256:74d56e3931e0d5a1dd51f8c8a2466d21de84a271cd3b5a733b803aa91abf4421
+
+WORKDIR /
+
+COPY --from=builder /src/responseobservationclient .
+USER 0:0
+
+CMD [ "/responseobservationclient" ]

--- a/internal/test/integration/components/responseobservationclient/main.go
+++ b/internal/test/integration/components/responseobservationclient/main.go
@@ -1,0 +1,244 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Workload for the response-observation suite. Every inbound request makes three
+// outbound calls. They differ in what instrumentation gets to see of the response.
+//
+// ROLE=peer is the origin. It answers 200 and is the authority on what happened.
+//
+// ROLE=relay is a transparent TCP relay in front of the peer. It forwards both
+// directions byte for byte and changes only how the response is segmented on the
+// wire: the first byte goes out in its own TCP segment and the rest follows
+// RESEGMENT_DELAY_MS later. OBI's tcp_cleanup_rbuf probe returns early on any read
+// of one byte or fewer, and the remainder does not begin with a status line, so no
+// probe parses the 200. The bytes the caller receives are the same either way.
+//
+// ROLE=resetter accepts a connection, reads the request, and resets it without
+// answering. Nothing comes back, which is the case the byte counter tells apart from
+// a response that arrived and went unparsed.
+//
+// The default role calls the relay (received), the peer directly (parsed), and the
+// resetter (silent) on every request, so one run carries all three. Keep-alives are
+// off, so each call's socket closes right after it completes. That close is what makes
+// the kernel finish the incomplete record.
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+// resegmentAt is the size of the first segment, in bytes. One byte is what puts the
+// read under OBI's copied_len <= 1 early return in return_recvmsg.
+const resegmentAt = 1
+
+// noKeepAlive closes a call's socket as soon as the response has been read.
+func noKeepAlive() *http.Client {
+	return &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}
+}
+
+// call performs a GET and drains the response, so the exchange completes from the
+// application's point of view whether or not it was observed.
+func call(client *http.Client, url string) error {
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s answered %d", url, resp.StatusCode)
+	}
+
+	log.Printf("call to %s completed: status=%d bytes=%d", url, resp.StatusCode, len(body))
+
+	return nil
+}
+
+// runResetter answers nothing. It reads what the caller sent so the request is
+// genuinely delivered, then sets SO_LINGER to zero and closes, which makes the kernel
+// send an RST.
+func runResetter(port string) {
+	listener, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		log.Fatalf("listening on %s: %v", port, err)
+	}
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Fatalf("accepting: %v", err)
+		}
+
+		go func() {
+			tcp, ok := conn.(*net.TCPConn)
+			if !ok {
+				conn.Close()
+				return
+			}
+
+			// Read first, so this is an exchange that got no answer. A reset before
+			// the connection carried anything is a different case.
+			buf := make([]byte, 4096)
+			//nolint:errcheck // a caller that vanished first is still a reset case
+			tcp.SetReadDeadline(time.Now().Add(2 * time.Second))
+			//nolint:errcheck // the request's content is irrelevant, only its arrival
+			tcp.Read(buf)
+
+			// Zero linger turns the close into an RST.
+			//nolint:errcheck // if this fails the close below is merely a FIN
+			tcp.SetLinger(0)
+			tcp.Close()
+		}()
+	}
+}
+
+func runPeer(port string) {
+	http.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		// Long enough that the first byte is not the whole response.
+		fmt.Fprintln(w, "answered by the peer, which is the authority on this call")
+	})
+	log.Fatal(http.ListenAndServe(":"+port, nil))
+}
+
+// relayResponse copies peer to caller, splitting the first segment of every
+// chunk it forwards.
+func relayResponse(dst, src net.Conn, delay time.Duration) {
+	buf := make([]byte, 32*1024)
+
+	for {
+		n, err := src.Read(buf)
+		if n > resegmentAt {
+			if _, werr := dst.Write(buf[:resegmentAt]); werr != nil {
+				return
+			}
+			time.Sleep(delay)
+			if _, werr := dst.Write(buf[resegmentAt:n]); werr != nil {
+				return
+			}
+		} else if n > 0 {
+			if _, werr := dst.Write(buf[:n]); werr != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func runRelay(port, peer string, delay time.Duration) {
+	listener, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		log.Fatalf("listening on %s: %v", port, err)
+	}
+
+	for {
+		down, err := listener.Accept()
+		if err != nil {
+			log.Fatalf("accepting: %v", err)
+		}
+
+		go func() {
+			defer down.Close()
+
+			up, err := net.Dial("tcp", peer)
+			if err != nil {
+				log.Printf("connecting to %s: %v", peer, err)
+				return
+			}
+			defer up.Close()
+
+			// Caller to peer, untouched.
+			//nolint:errcheck // the copy ends when either side closes
+			go io.Copy(up, down)
+
+			relayResponse(down, up, delay)
+		}()
+	}
+}
+
+func envOr(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+
+	return fallback
+}
+
+func envMillis(name string, fallback time.Duration) time.Duration {
+	value := os.Getenv(name)
+	if value == "" {
+		return fallback
+	}
+
+	millis, err := strconv.Atoi(value)
+	if err != nil {
+		log.Fatalf("%s=%q is not a number of milliseconds: %v", name, value, err)
+	}
+
+	return time.Duration(millis) * time.Millisecond
+}
+
+func main() {
+	switch os.Getenv("ROLE") {
+	case "peer":
+		runPeer(envOr("PEER_PORT", "9000"))
+		return
+	case "resetter":
+		runResetter(envOr("RESETTER_PORT", "9200"))
+		return
+	case "relay":
+		runRelay(envOr("RELAY_PORT", "9100"), envOr("PEER", "peer:9000"),
+			envMillis("RESEGMENT_DELAY_MS", 5*time.Millisecond))
+		return
+	}
+
+	unobservedURL := "http://" + envOr("RELAY", "relay:9100") + "/unobserved"
+	observedURL := "http://" + envOr("PEER", "peer:9000") + "/observed"
+	resetURL := "http://" + envOr("RESETTER", "resetter:9200") + "/reset"
+	client := noKeepAlive()
+
+	http.HandleFunc("/work", func(w http.ResponseWriter, _ *http.Request) {
+		// Through the relay: the call succeeds and instrumentation never sees a
+		// status line.
+		if err := call(client, unobservedURL); err != nil {
+			log.Printf("unobserved call: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// Straight to the peer: the control, observed in full.
+		if err := call(client, observedURL); err != nil {
+			log.Printf("observed call: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// To the resetter: no response arrives. The error is expected, so it is
+		// logged and the handler still succeeds.
+		if err := call(client, resetURL); err != nil {
+			log.Printf("reset call failed as expected: %v", err)
+		} else {
+			log.Printf("reset call unexpectedly succeeded")
+		}
+
+		fmt.Fprintln(w, "ok")
+	})
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/internal/test/integration/components/responseobservationclient/main.go
+++ b/internal/test/integration/components/responseobservationclient/main.go
@@ -17,10 +17,17 @@
 // answering. Nothing comes back, which is the case the byte counter tells apart from
 // a response that arrived and went unparsed.
 //
-// The default role calls the relay (received), the peer directly (parsed), and the
-// resetter (silent) on every request, so one run carries all three. Keep-alives are
-// off, so each call's socket closes right after it completes. That close is what makes
-// the kernel finish the incomplete record.
+// The default role calls the relay (unread), the peer directly (parsed), the resetter
+// (silent), and a second peer it abandons (received) on every request, so one run
+// carries all four. Keep-alives are off, so each call's socket closes right after it
+// completes. That close is what makes the kernel finish the incomplete record.
+//
+// The abandoned call is the one whose response arrives but is never read: the request
+// goes out on a raw socket, the answer lands in the receive queue, and the socket closes
+// without a read ever being issued. No probe sees those bytes, so the record is finished
+// by the close rather than by the response, and only the socket's byte counter says an
+// answer came at all. That is the case whose duration overstates the request, so it is
+// the one whose duration is withheld from the metrics.
 //
 // It also drives REUSE_CALLS calls per request through a second relay over a pool
 // holding a single connection, with keep-alives on. Nothing closes that socket, so the
@@ -186,6 +193,34 @@ func call(client *http.Client, url string) error {
 	return nil
 }
 
+// abandonCall sends a request on a raw socket and closes without ever reading the
+// answer. The bytes still arrive, so the socket's counter advances, but no read is
+// issued and no probe sees them: the record is finished by the close, holding a
+// duration that runs to the close rather than to the response.
+func abandonCall(addr, path string, settle time.Duration) error {
+	conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return err
+	}
+
+	request := "GET " + path + " HTTP/1.1\r\nHost: " + host + "\r\nConnection: close\r\n\r\n"
+	if _, err := conn.Write([]byte(request)); err != nil {
+		return err
+	}
+
+	// Long enough for the answer to reach the receive queue, so this is a response
+	// that arrived unseen rather than one that never came.
+	time.Sleep(settle)
+
+	return nil
+}
+
 // runResetter answers nothing. It reads what the caller sent so the request is
 // genuinely delivered, then sets SO_LINGER to zero and closes, which makes the kernel
 // send an RST.
@@ -342,6 +377,8 @@ func main() {
 	unobservedURL := "http://" + envOr("RELAY", "relay:9100") + "/unobserved"
 	observedURL := "http://" + envOr("PEER", "peer:9000") + "/observed"
 	resetURL := "http://" + envOr("RESETTER", "resetter:9200") + "/reset"
+	abandonAddr := envOr("ABANDON_PEER", "abandonpeer:9500")
+	abandonSettle := envMillis("ABANDON_SETTLE_MS", 100*time.Millisecond)
 	reusedURL := "http://" + envOr("REUSE_RELAY", "reuserelay:9300") + "/reused"
 	client := noKeepAlive()
 
@@ -419,6 +456,11 @@ func main() {
 			log.Printf("reset call failed as expected: %v", err)
 		} else {
 			log.Printf("reset call unexpectedly succeeded")
+		}
+
+		// To the abandoned peer: the response arrives and is never read.
+		if err := abandonCall(abandonAddr, "/abandoned", abandonSettle); err != nil {
+			log.Printf("abandoned call: %v", err)
 		}
 
 		fmt.Fprintln(w, "ok")

--- a/internal/test/integration/components/responseobservationclient/main.go
+++ b/internal/test/integration/components/responseobservationclient/main.go
@@ -21,16 +21,26 @@
 // resetter (silent) on every request, so one run carries all three. Keep-alives are
 // off, so each call's socket closes right after it completes. That close is what makes
 // the kernel finish the incomplete record.
+//
+// It also drives REUSE_CALLS calls per request through a second relay over a pool
+// holding a single connection, with keep-alives on. Nothing closes that socket, so the
+// close no longer finishes anything: each record is finished by the next request taking
+// the connection. That is the reuse case, where a record used to be discarded outright
+// and the call went unreported. /stats reports what the application itself measured, so
+// the assertions compare against the workload rather than a hardcoded count.
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 )
 
@@ -44,6 +54,113 @@ func noKeepAlive() *http.Client {
 		Timeout:   5 * time.Second,
 		Transport: &http.Transport{DisableKeepAlives: true},
 	}
+}
+
+// keepAlive holds one connection per host and keeps it, so consecutive calls travel the
+// same socket and no close ever finishes a record.
+func keepAlive() *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			MaxConnsPerHost:     1,
+			MaxIdleConnsPerHost: 1,
+			IdleConnTimeout:     time.Minute,
+		},
+	}
+}
+
+// reuseStats is what the application knows about its own keep-alive traffic. The test
+// compares OBI's spans against it: the defect reported one span per connection, so the
+// connection count is what separates a fix from a coincidence.
+type reuseStats struct {
+	Calls         int   `json:"calls"`
+	Done          bool  `json:"done"`
+	Connections   int   `json:"connections"`
+	Aborts        int   `json:"aborts"`
+	MaxCallMicros int64 `json:"maxCallMicros"`
+	mutex         sync.Mutex
+}
+
+func (s *reuseStats) recordCall(elapsed time.Duration, err error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.Calls++
+	if err != nil {
+		s.Aborts++
+	}
+	if micros := elapsed.Microseconds(); micros > s.MaxCallMicros {
+		s.MaxCallMicros = micros
+	}
+}
+
+func (s *reuseStats) recordConnection() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.Connections++
+}
+
+func (s *reuseStats) finish() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.Done = true
+}
+
+func (s *reuseStats) snapshot() reuseStats {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return reuseStats{
+		Done:          s.Done,
+		Calls:         s.Calls,
+		Connections:   s.Connections,
+		Aborts:        s.Aborts,
+		MaxCallMicros: s.MaxCallMicros,
+	}
+}
+
+// callReusing times one call and counts the connections it had to open, so a run that
+// silently stopped reusing the socket cannot pass as a fix.
+func callReusing(client *http.Client, url string, stats *reuseStats) {
+	trace := &httptrace.ClientTrace{
+		ConnectStart: func(_, _ string) { stats.recordConnection() },
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Fatalf("building a request for %s: %v", url, err)
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+
+	started := time.Now()
+	err = performRequest(client, req)
+	stats.recordCall(time.Since(started), err)
+
+	if err != nil {
+		log.Printf("reused-connection call: %v", err)
+	}
+}
+
+// performRequest drains the body so the connection returns to the pool for the next
+// call. A body left unread makes the transport open a new connection instead.
+func performRequest(client *http.Client, req *http.Request) error {
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s answered %d", req.URL, resp.StatusCode)
+	}
+
+	return nil
 }
 
 // call performs a GET and drains the response, so the exchange completes from the
@@ -180,6 +297,20 @@ func envOr(name, fallback string) string {
 	return fallback
 }
 
+func envCount(name string, fallback int) int {
+	value := os.Getenv(name)
+	if value == "" {
+		return fallback
+	}
+
+	count, err := strconv.Atoi(value)
+	if err != nil {
+		log.Fatalf("%s=%q is not a number: %v", name, value, err)
+	}
+
+	return count
+}
+
 func envMillis(name string, fallback time.Duration) time.Duration {
 	value := os.Getenv(name)
 	if value == "" {
@@ -211,7 +342,60 @@ func main() {
 	unobservedURL := "http://" + envOr("RELAY", "relay:9100") + "/unobserved"
 	observedURL := "http://" + envOr("PEER", "peer:9000") + "/observed"
 	resetURL := "http://" + envOr("RESETTER", "resetter:9200") + "/reset"
+	reusedURL := "http://" + envOr("REUSE_RELAY", "reuserelay:9300") + "/reused"
 	client := noKeepAlive()
+
+	// Two pooled connections carrying the same number of calls. They differ only in
+	// whether the responses can be parsed, which is what separates a loss caused by the
+	// unparsed response from one caused by reuse itself.
+	reusedControlURL := "http://" + envOr("REUSE_PEER", "reusepeer:9400") + "/reused-control"
+	reuseClient := keepAlive()
+	reuseControlClient := keepAlive()
+	reuseCalls := envCount("REUSE_CALLS", 60)
+	// Long enough that the handler that started the run has returned and instrumentation
+	// is attached before the first call.
+	reuseStartDelay := envMillis("REUSE_START_DELAY_MS", time.Second)
+	stats := &reuseStats{}
+	controlStats := &reuseStats{}
+
+	http.HandleFunc("/stats", func(w http.ResponseWriter, _ *http.Request) {
+		snapshot := map[string]reuseStats{
+			"unparsed": stats.snapshot(),
+			"parsed":   controlStats.snapshot(),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(snapshot); err != nil {
+			log.Printf("encoding stats: %v", err)
+		}
+	})
+
+	// The pooled calls run in their own goroutine, after the handler that started them
+	// has returned. A client call made while an inbound request is being served is held
+	// downstream until that request's end timestamp is known, which is a separate
+	// mechanism from the reuse this suite covers.
+	var startOnce sync.Once
+	http.HandleFunc("/start-reuse", func(w http.ResponseWriter, _ *http.Request) {
+		startOnce.Do(func() {
+			go func() {
+				time.Sleep(reuseStartDelay)
+				for range reuseCalls {
+					callReusing(reuseClient, reusedURL, stats)
+				}
+				// The last call on a pooled connection is finished by whatever comes
+				// next. Closing the socket is what a client eventually does, and it
+				// keeps the run's tail from waiting on a sweep.
+				reuseClient.CloseIdleConnections()
+				stats.finish()
+
+				for range reuseCalls {
+					callReusing(reuseControlClient, reusedControlURL, controlStats)
+				}
+				reuseControlClient.CloseIdleConnections()
+				controlStats.finish()
+			}()
+		})
+		fmt.Fprintln(w, "started")
+	})
 
 	http.HandleFunc("/work", func(w http.ResponseWriter, _ *http.Request) {
 		// Through the relay: the call succeeds and instrumentation never sees a

--- a/internal/test/integration/configs/obi-config-response-observation.yml
+++ b/internal/test/integration/configs/obi-config-response-observation.yml
@@ -10,6 +10,16 @@ routes:
   unmatched: path
 otel_traces_export:
   endpoint: http://jaeger:4318
+prometheus_export:
+  port: 8999
+metrics:
+  features:
+    - application
+    # The service graph is emitted from inside the span-metrics path, so that
+    # feature has to be on for the graph series to exist at all.
+    - application_span_otel
+    - application_service_graph
+    - application_host
 discovery:
   # The workload is a Go binary, and the code under test is in the generic
   # tracer, which is where every non-Go workload lands.

--- a/internal/test/integration/configs/obi-config-response-observation.yml
+++ b/internal/test/integration/configs/obi-config-response-observation.yml
@@ -1,0 +1,19 @@
+trace_printer: text
+log_level: debug
+ebpf:
+  # The pooled calls are made after the request that triggered them has already
+  # answered, so they arrive conditionally parented and are held until their parent
+  # settles or this bound elapses. The default of five minutes outlives the suite,
+  # which would leave the spans unexported rather than late.
+  max_transaction_time: 15s
+routes:
+  unmatched: path
+otel_traces_export:
+  endpoint: http://jaeger:4318
+discovery:
+  # The workload is a Go binary, and the code under test is in the generic
+  # tracer, which is where every non-Go workload lands.
+  skip_go_specific_tracers: true
+  services:
+    - name: responseobservationclient
+      exe_path: responseobservationclient

--- a/internal/test/integration/configs/prometheus-config-response-observation.yml
+++ b/internal/test/integration/configs/prometheus-config-response-observation.yml
@@ -1,0 +1,11 @@
+global:
+  evaluation_interval: 250ms
+  scrape_interval: 250ms
+scrape_configs:
+  # OBI runs in the workload's network namespace, so its metrics endpoint answers on
+  # the workload's name.
+  - job_name: obi
+    honor_labels: true
+    static_configs:
+      - targets:
+          - 'responseobservationclient:8999'

--- a/internal/test/integration/docker-compose-response-observation.yml
+++ b/internal/test/integration/docker-compose-response-observation.yml
@@ -1,0 +1,91 @@
+version: "3.8"
+
+services:
+  peer:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/responseobservationclient/Dockerfile
+    image: hatest-responseobservationclient
+    environment:
+      ROLE: "peer"
+      PEER_PORT: "9000"
+
+  relay:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/responseobservationclient/Dockerfile
+    image: hatest-responseobservationclient
+    environment:
+      ROLE: "relay"
+      RELAY_PORT: "9100"
+      PEER: "peer:9000"
+      RESEGMENT_DELAY_MS: "5"
+    depends_on:
+      peer:
+        condition: service_started
+
+  resetter:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/responseobservationclient/Dockerfile
+    image: hatest-responseobservationclient
+    environment:
+      ROLE: "resetter"
+      RESETTER_PORT: "9200"
+
+  responseobservationclient:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/responseobservationclient/Dockerfile
+    image: hatest-responseobservationclient
+    ports:
+      - "8080:8080"
+    environment:
+      # The response comes back re-segmented, so instrumentation never sees it.
+      RELAY: "relay:9100"
+      # The same peer, called directly: the control.
+      PEER: "peer:9000"
+      # A peer that never answers and resets instead: the failure path.
+      RESETTER: "resetter:9200"
+    depends_on:
+      relay:
+        condition: service_started
+      resetter:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    command:
+      - --config=/configs/obi-config-response-observation.yml
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-unobserved-response:/var/run/obi
+    image: hatest-obi
+    privileged: true
+    network_mode: "service:responseobservationclient"
+    pid: "service:responseobservationclient"
+    environment:
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+    depends_on:
+      responseobservationclient:
+        condition: service_started
+
+  jaeger:
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    command:
+      - "--set=service.telemetry.logs.level=debug"

--- a/internal/test/integration/docker-compose-response-observation.yml
+++ b/internal/test/integration/docker-compose-response-observation.yml
@@ -62,6 +62,17 @@ services:
       ROLE: "resetter"
       RESETTER_PORT: "9200"
 
+  # Answers normally. It is a separate peer only so the calls the workload abandons
+  # are told apart from the ones it reads, which is the port the spans carry.
+  abandonpeer:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/responseobservationclient/Dockerfile
+    image: hatest-ro-abandonpeer
+    environment:
+      ROLE: "peer"
+      PEER_PORT: "9500"
+
   responseobservationclient:
     build:
       context: ../../..
@@ -69,6 +80,9 @@ services:
     image: hatest-responseobservationclient
     ports:
       - "8080:8080"
+      # OBI shares this container's network namespace, so its metrics endpoint is
+      # reachable here and Prometheus scrapes it by this service's name.
+      - "8999:8999"
     environment:
       # The response comes back re-segmented, so instrumentation never sees it.
       RELAY: "relay:9100"
@@ -76,6 +90,8 @@ services:
       PEER: "peer:9000"
       # A peer that never answers and resets instead: the failure path.
       RESETTER: "resetter:9200"
+      # A peer that answers into a socket the workload never reads.
+      ABANDON_PEER: "abandonpeer:9500"
       # The same unparsed responses, over one connection that is never closed.
       REUSE_RELAY: "reuserelay:9300"
       REUSE_PEER: "reusepeer:9400"
@@ -88,6 +104,8 @@ services:
       reusepeer:
         condition: service_started
       resetter:
+        condition: service_started
+      abandonpeer:
         condition: service_started
 
   obi:
@@ -114,6 +132,22 @@ services:
       OTEL_EBPF_LOG_LEVEL: "DEBUG"
       OTEL_EBPF_BPF_DEBUG: "TRUE"
       OTEL_EBPF_HOSTNAME: "obi"
+    depends_on:
+      responseobservationclient:
+        condition: service_started
+
+  # The metrics side of the same calls. What a span reports and what a metric reports
+  # are decided in different code, so the suite has to read both.
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.14.0@sha256:5ce7540c3c00ef4ab0c9d2c995c6a5b9c421f44b4a115d97a2c7af3b1c21cbb0
+    command:
+      - --config.file=/etc/prometheus/prometheus-config-response-observation.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
     depends_on:
       responseobservationclient:
         condition: service_started

--- a/internal/test/integration/docker-compose-response-observation.yml
+++ b/internal/test/integration/docker-compose-response-observation.yml
@@ -1,11 +1,14 @@
 version: "3.8"
 
 services:
+  # Every role runs the same binary, chosen by ROLE. Each service builds the same context
+  # under its own tag: sharing one tag makes concurrent builds race for it, and a service
+  # that only references the tag tries to pull it.
   peer:
     build:
       context: ../../..
       dockerfile: internal/test/integration/components/responseobservationclient/Dockerfile
-    image: hatest-responseobservationclient
+    image: hatest-ro-peer
     environment:
       ROLE: "peer"
       PEER_PORT: "9000"
@@ -14,7 +17,7 @@ services:
     build:
       context: ../../..
       dockerfile: internal/test/integration/components/responseobservationclient/Dockerfile
-    image: hatest-responseobservationclient
+    image: hatest-ro-relay
     environment:
       ROLE: "relay"
       RELAY_PORT: "9100"
@@ -24,11 +27,37 @@ services:
       peer:
         condition: service_started
 
+  # A second relay, for the calls that share one connection. It is separate only so the
+  # spans of the two cases are told apart by the port they went to.
+  reuserelay:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/responseobservationclient/Dockerfile
+    image: hatest-ro-reuserelay
+    environment:
+      ROLE: "relay"
+      RELAY_PORT: "9300"
+      PEER: "peer:9000"
+      RESEGMENT_DELAY_MS: "5"
+    depends_on:
+      peer:
+        condition: service_started
+
+  # The control for the reuse case: the same pooled traffic, responses parsed normally.
+  reusepeer:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/responseobservationclient/Dockerfile
+    image: hatest-ro-reusepeer
+    environment:
+      ROLE: "peer"
+      PEER_PORT: "9400"
+
   resetter:
     build:
       context: ../../..
       dockerfile: internal/test/integration/components/responseobservationclient/Dockerfile
-    image: hatest-responseobservationclient
+    image: hatest-ro-resetter
     environment:
       ROLE: "resetter"
       RESETTER_PORT: "9200"
@@ -47,8 +76,16 @@ services:
       PEER: "peer:9000"
       # A peer that never answers and resets instead: the failure path.
       RESETTER: "resetter:9200"
+      # The same unparsed responses, over one connection that is never closed.
+      REUSE_RELAY: "reuserelay:9300"
+      REUSE_PEER: "reusepeer:9400"
+      REUSE_CALLS: "60"
     depends_on:
       relay:
+        condition: service_started
+      reuserelay:
+        condition: service_started
+      reusepeer:
         condition: service_started
       resetter:
         condition: service_started

--- a/internal/test/integration/response_observation_test.go
+++ b/internal/test/integration/response_observation_test.go
@@ -28,10 +28,42 @@ const (
 	// The port of a peer that answers nothing and resets. Calls to it are the
 	// absent case: no response exists at all.
 	resettingPeerPort = 9200
+	// The port of the second relay. Calls to it carry unparsed responses over one
+	// connection that is never closed, which is the reuse case.
+	reusedConnectionPort = 9300
+	// The port of the second peer. The same pooled traffic with parsed responses: the
+	// control that separates a loss caused by the unparsed response from one caused by
+	// reuse itself.
+	reusedControlPort = 9400
 )
 
+// reuseStats mirrors what the workload reports at /stats.
+type reuseStats struct {
+	Calls         int   `json:"calls"`
+	Done          bool  `json:"done"`
+	Connections   int   `json:"connections"`
+	Aborts        int   `json:"aborts"`
+	MaxCallMicros int64 `json:"maxCallMicros"`
+}
+
+// workloadReuseStats returns the workload's counts for the unparsed case and for the
+// parsed control, keyed as the workload reports them.
+func workloadReuseStats(t require.TestingT) map[string]reuseStats {
+	resp, err := http.Get("http://localhost:8080/stats")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	stats := map[string]reuseStats{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&stats))
+
+	return stats
+}
+
+// The limit is explicit because the reuse case produces a trace per call: Jaeger returns
+// 20 traces by default, which silently caps the count the assertions are built on.
 func unobservedResponseTraces(t require.TestingT) []jaeger.Trace {
-	resp, err := http.Get(jaegerQueryURL + "?service=responseobservationclient")
+	resp, err := http.Get(jaegerQueryURL + "?service=responseobservationclient&limit=1000")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -66,6 +98,24 @@ func driveResponseObservationWorkload(t *testing.T) {
 		ti.DoHTTPGet(t, "http://localhost:8080/work", 200)
 		time.Sleep(500 * time.Millisecond)
 	}
+
+	// The pooled runs go last: the spans of the requests above are what prove
+	// instrumentation is attached, and traffic before that proves nothing.
+	ti.DoHTTPGet(t, "http://localhost:8080/start-reuse", 200)
+}
+
+// finishedReuseStats waits for both pooled runs to complete, so the counts the
+// assertions compare against are final.
+func finishedReuseStats(t *testing.T) map[string]reuseStats {
+	var stats map[string]reuseStats
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		stats = workloadReuseStats(ct)
+		assert.True(ct, stats["unparsed"].Done && stats["parsed"].Done,
+			"the workload is still making pooled calls")
+	}, testTimeout, 200*time.Millisecond)
+
+	return stats
 }
 
 // The control. The same peer answered 200 on a socket whose response was read
@@ -179,6 +229,80 @@ func testObservedResponseIsNotMarked(t *testing.T) {
 	}
 }
 
+// The reuse case. The socket carries call after call and never closes, so no close
+// finishes a record: the next request does. Each call must still produce a span.
+//
+// The defect emitted one span per connection instead of one per request, so the
+// workload's own connection count is the discriminator. Asserting only "some spans
+// exist" would have passed against the defect.
+func testReusedConnectionReportsEveryCall(t *testing.T) {
+	stats := finishedReuseStats(t)["unparsed"]
+	require.Positive(t, stats.Calls, "the workload made no calls over a reused connection")
+	require.Zero(t, stats.Aborts, "the calls themselves failed, so there is nothing to observe")
+	require.Less(t, stats.Connections, stats.Calls,
+		"the connection was not reused, so this run does not exercise the case")
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		spans := clientSpansToPort(unobservedResponseTraces(ct), reusedConnectionPort)
+		assert.GreaterOrEqual(ct, len(spans), stats.Calls,
+			"%d calls over %d connections produced %d spans",
+			stats.Calls, stats.Connections, len(spans))
+	}, testTimeout, 100*time.Millisecond)
+}
+
+// The control: the same pooled traffic with responses OBI parses normally. It separates
+// a call lost to the unparsed response from one lost to reuse itself, and it is what
+// makes the count above meaningful.
+func testReuseControlReportsEveryCall(t *testing.T) {
+	stats := finishedReuseStats(t)["parsed"]
+	require.Positive(t, stats.Calls)
+	require.Less(t, stats.Connections, stats.Calls, "the control connection was not reused")
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		spans := clientSpansToPort(unobservedResponseTraces(ct), reusedControlPort)
+		assert.GreaterOrEqual(ct, len(spans), stats.Calls,
+			"%d parsed calls over %d connections produced %d spans",
+			stats.Calls, stats.Connections, len(spans))
+	}, testTimeout, 100*time.Millisecond)
+}
+
+// The reuse case reports no status either, for the same reason as the relay case: no
+// response was parsed. A fabricated status here would be the #3067 defect on a new path.
+func testReusedConnectionCarriesNoStatusCode(t *testing.T) {
+	spans := clientSpansToPort(unobservedResponseTraces(t), reusedConnectionPort)
+	require.NotEmpty(t, spans, "there is nothing to assert the absence of a status on")
+
+	for _, span := range spans {
+		status, ok := jaeger.FindIn(span.Tags, "http.response.status_code")
+		assert.False(t, ok, "a call whose response was not observed reports a status: %v", status.Value)
+
+		assert.Empty(t, span.Diff(
+			jaeger.Tag{Key: "obi.http.response.observed", Type: "bool", Value: false}))
+	}
+}
+
+// A record could be emitted by dating it at the next request's arrival, which reports a
+// call that took milliseconds as one that took as long as the caller's think time. The
+// duration comes from the response's own bytes instead, so it stays within reach of what
+// the application measured.
+func testReusedConnectionDurationsAreBounded(t *testing.T) {
+	stats := finishedReuseStats(t)["unparsed"]
+	require.Positive(t, stats.MaxCallMicros, "the workload timed no calls")
+
+	spans := clientSpansToPort(unobservedResponseTraces(t), reusedConnectionPort)
+	require.NotEmpty(t, spans, "there is nothing to bound")
+
+	// Five times the slowest call the application itself timed. Wide enough to absorb
+	// probe overhead, far below the think time a next-request timestamp would produce.
+	const slack = 5
+
+	for _, span := range spans {
+		assert.LessOrEqual(t, span.Duration, stats.MaxCallMicros*slack,
+			"a span lasts %dus where the slowest call the application timed took %dus",
+			span.Duration, stats.MaxCallMicros)
+	}
+}
+
 func TestSuite_ResponseObservation(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-response-observation.yml", path.Join(pathOutput, "test-suite-unobserved-response.log"))
 	require.NoError(t, err)
@@ -194,6 +318,10 @@ func TestSuite_ResponseObservation(t *testing.T) {
 	t.Run("an observed response is not marked", testObservedResponseIsNotMarked)
 	t.Run("a reset peer reports no fabricated status", testResetPeerReportsNoFabricatedStatus)
 	t.Run("a reset peer is marked unobserved", testResetPeerIsMarkedUnobserved)
+	t.Run("a reused connection with parsed responses reports every call", testReuseControlReportsEveryCall)
+	t.Run("a reused connection reports every call", testReusedConnectionReportsEveryCall)
+	t.Run("a reused connection carries no status code", testReusedConnectionCarriesNoStatusCode)
+	t.Run("a reused connection's durations are bounded", testReusedConnectionDurationsAreBounded)
 
 	require.NoError(t, compose.Close())
 }

--- a/internal/test/integration/response_observation_test.go
+++ b/internal/test/integration/response_observation_test.go
@@ -393,6 +393,22 @@ func testUnmeasuredCallPublishesNoDuration(t *testing.T) {
 		"a duration that runs past the request it describes was published as the call's duration")
 }
 
+// A withheld duration says nothing about the request that was sent. Its size is known
+// and is reported. The response size is not known: the record carries a zeroed length,
+// and publishing it would report an empty response for a call whose response was never
+// seen.
+func testUnmeasuredCallStillPublishesItsRequestSize(t *testing.T) {
+	promSeries(t, `http_client_request_body_size_bytes_count{server_port="`+
+		strconv.Itoa(abandonedPeerPort)+`"}`)
+
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	withheld, err := pq.Query(`http_client_response_body_size_bytes_count{server_port="` +
+		strconv.Itoa(abandonedPeerPort) + `"}`)
+	require.NoError(t, err)
+	assert.Empty(t, withheld,
+		"a response nobody saw was reported as having a size")
+}
+
 func TestSuite_ResponseObservation(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-response-observation.yml", path.Join(pathOutput, "test-suite-unobserved-response.log"))
 	require.NoError(t, err)
@@ -419,6 +435,7 @@ func TestSuite_ResponseObservation(t *testing.T) {
 	t.Run("the host info gauge is exported", testHostInfoIsExported)
 	t.Run("an unmeasured call counts on its edge without a latency", testUnmeasuredCallCountsOnItsEdgeWithoutLatency)
 	t.Run("an unmeasured call publishes no duration", testUnmeasuredCallPublishesNoDuration)
+	t.Run("an unmeasured call still publishes its request size", testUnmeasuredCallStillPublishesItsRequestSize)
 
 	require.NoError(t, compose.Close())
 }

--- a/internal/test/integration/response_observation_test.go
+++ b/internal/test/integration/response_observation_test.go
@@ -1,0 +1,199 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	json "github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
+	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
+)
+
+const (
+	// The port of the relay, which re-segments the response so instrumentation
+	// never reads a status line. Calls through it are the unparsed case.
+	unobservedPeerPort = 9100
+	// The port of the peer itself. Calls straight to it are the control: the
+	// same origin, the same 200, observed in full.
+	observedPeerPort = 9000
+	// The port of a peer that answers nothing and resets. Calls to it are the
+	// absent case: no response exists at all.
+	resettingPeerPort = 9200
+)
+
+func unobservedResponseTraces(t require.TestingT) []jaeger.Trace {
+	resp, err := http.Get(jaegerQueryURL + "?service=responseobservationclient")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tq jaeger.TracesQuery
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tq))
+
+	return tq.Data
+}
+
+// The outbound calls are told apart by the port they went to, which is the only
+// thing that differs between them.
+func clientSpansToPort(traces []jaeger.Trace, port int) []jaeger.Span {
+	var matches []jaeger.Span
+
+	for i := range traces {
+		for _, span := range traces[i].Spans {
+			if kind, ok := jaeger.FindIn(span.Tags, "span.kind"); !ok || kind.Value != "client" {
+				continue
+			}
+			if len(span.Diff(jaeger.Tag{Key: "server.port", Type: "int64", Value: float64(port)})) == 0 {
+				matches = append(matches, span)
+			}
+		}
+	}
+
+	return matches
+}
+
+func driveResponseObservationWorkload(t *testing.T) {
+	for range 15 {
+		ti.DoHTTPGet(t, "http://localhost:8080/work", 200)
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// The control. The same peer answered 200 on a socket whose response was read
+// normally. It also confirms the workload is instrumented at all.
+func testObservedResponseReportsItsStatus(t *testing.T) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		spans := clientSpansToPort(unobservedResponseTraces(ct), observedPeerPort)
+		if !assert.NotEmpty(ct, spans) {
+			return
+		}
+		for _, span := range spans {
+			assert.Empty(ct, span.Diff(
+				jaeger.Tag{Key: "http.response.status_code", Type: "int64", Value: float64(200)}))
+		}
+	}, testTimeout, 100*time.Millisecond)
+}
+
+// The call happened, so it is still reported. The cheapest way to stop publishing a
+// fabricated status is to stop publishing the span.
+func testUnparsedResponseIsStillReported(t *testing.T) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.NotEmpty(ct, clientSpansToPort(unobservedResponseTraces(ct), unobservedPeerPort))
+	}, testTimeout, 100*time.Millisecond)
+}
+
+// Nothing was observed to fail, so the span is not an error.
+//
+// The non-empty guard is this subtest's own. An absence assertion over an empty set
+// passes having asserted nothing, and -failfast is a property of how the suite is
+// invoked.
+func testUnparsedResponseIsNotAnError(t *testing.T) {
+	spans := clientSpansToPort(unobservedResponseTraces(t), unobservedPeerPort)
+	require.NotEmpty(t, spans, "there is nothing to assert the absence of an error on")
+
+	for _, span := range spans {
+		status, ok := jaeger.FindIn(span.Tags, "otel.status_code")
+		assert.False(t, ok && status.Value == "ERROR",
+			"a call whose response was not observed is reported as failed: %v", status.Value)
+
+		errored, ok := jaeger.FindIn(span.Tags, "error")
+		assert.False(t, ok && errored.Value == true,
+			"a call whose response was not observed is flagged as an error")
+	}
+}
+
+// Semconv requires http.response.status_code "if and only if one was received/sent".
+// Nothing was received, so there is no status, least of all 499.
+func testUnparsedResponseCarriesNoStatusCode(t *testing.T) {
+	spans := clientSpansToPort(unobservedResponseTraces(t), unobservedPeerPort)
+	require.NotEmpty(t, spans, "there is nothing to assert the absence of a status on")
+
+	for _, span := range spans {
+		status, ok := jaeger.FindIn(span.Tags, "http.response.status_code")
+		assert.False(t, ok, "a call whose response was not observed reports a status: %v", status.Value)
+	}
+}
+
+// An absent status attribute reads the same as an exporter that dropped one.
+func testUnparsedResponseIsMarked(t *testing.T) {
+	spans := clientSpansToPort(unobservedResponseTraces(t), unobservedPeerPort)
+	require.NotEmpty(t, spans)
+
+	for _, span := range spans {
+		assert.Empty(t, span.Diff(
+			jaeger.Tag{Key: "obi.http.response.observed", Type: "bool", Value: false}))
+	}
+}
+
+// Nothing comes back from this peer, and the record is finished at teardown.
+//
+// The span exists and reports no status. It is also not an error: OBI cannot tell this
+// reset apart from a client that stopped waiting, because sk_err is consumed by the
+// application's read before the close.
+func testResetPeerReportsNoFabricatedStatus(t *testing.T) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		spans := clientSpansToPort(unobservedResponseTraces(ct), resettingPeerPort)
+		if !assert.NotEmpty(ct, spans, "a call that was reset produced no span at all") {
+			return
+		}
+		for _, span := range spans {
+			status, ok := jaeger.FindIn(span.Tags, "http.response.status_code")
+			assert.False(ct, ok,
+				"a call nothing answered reports a status: %v", status.Value)
+
+			otelStatus, ok := jaeger.FindIn(span.Tags, "otel.status_code")
+			assert.False(ct, ok && otelStatus.Value == "ERROR",
+				"a reset is reported as failed, which OBI cannot actually tell from a client giving up")
+		}
+	}, testTimeout, 100*time.Millisecond)
+}
+
+// The same marker the relay case carries, for the same reason.
+func testResetPeerIsMarkedUnobserved(t *testing.T) {
+	spans := clientSpansToPort(unobservedResponseTraces(t), resettingPeerPort)
+	require.NotEmpty(t, spans, "there is nothing to assert the marker on")
+
+	for _, span := range spans {
+		assert.Empty(t, span.Diff(
+			jaeger.Tag{Key: "obi.http.response.observed", Type: "bool", Value: false}))
+	}
+}
+
+// The control must not pick the marker up.
+func testObservedResponseIsNotMarked(t *testing.T) {
+	spans := clientSpansToPort(unobservedResponseTraces(t), observedPeerPort)
+	require.NotEmpty(t, spans, "there is nothing to assert the absence of the marker on")
+
+	for _, span := range spans {
+		_, ok := jaeger.FindIn(span.Tags, "obi.http.response.observed")
+		assert.False(t, ok, "an observed call is marked as unobserved")
+	}
+}
+
+func TestSuite_ResponseObservation(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-response-observation.yml", path.Join(pathOutput, "test-suite-unobserved-response.log"))
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+
+	driveResponseObservationWorkload(t)
+
+	t.Run("an observed response reports its status", testObservedResponseReportsItsStatus)
+	t.Run("an unobserved response is still reported", testUnparsedResponseIsStillReported)
+	t.Run("an unobserved response is not an error", testUnparsedResponseIsNotAnError)
+	t.Run("an unobserved response carries no status code", testUnparsedResponseCarriesNoStatusCode)
+	t.Run("an unobserved response is marked as such", testUnparsedResponseIsMarked)
+	t.Run("an observed response is not marked", testObservedResponseIsNotMarked)
+	t.Run("a reset peer reports no fabricated status", testResetPeerReportsNoFabricatedStatus)
+	t.Run("a reset peer is marked unobserved", testResetPeerIsMarkedUnobserved)
+
+	require.NoError(t, compose.Close())
+}

--- a/internal/test/integration/response_observation_test.go
+++ b/internal/test/integration/response_observation_test.go
@@ -6,6 +6,7 @@ package integration
 import (
 	"net/http"
 	"path"
+	"strconv"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 
 	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
 	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
 	ti "go.opentelemetry.io/obi/pkg/test/integration"
 )
 
@@ -35,7 +37,15 @@ const (
 	// control that separates a loss caused by the unparsed response from one caused by
 	// reuse itself.
 	reusedControlPort = 9400
+	// The port of the peer whose answer the workload never reads. The response arrives
+	// and no probe sees it, so the record is finished by the close instead: the one case
+	// whose duration runs past the request it describes.
+	abandonedPeerPort = 9500
 )
+
+// The service graph names the far side of a call by the host it was made to, which is
+// the compose service name.
+const abandonedPeerService = "abandonpeer"
 
 // reuseStats mirrors what the workload reports at /stats.
 type reuseStats struct {
@@ -303,6 +313,86 @@ func testReusedConnectionDurationsAreBounded(t *testing.T) {
 	}
 }
 
+// The call whose answer arrives into a socket nobody reads. Only the socket's byte
+// counter says a response came, so the record is finished by the close and its duration
+// runs to the close rather than to the answer. The call still happened, so it is still
+// reported, and it carries no status because none was read.
+func testAbandonedResponseIsReportedWithoutStatus(t *testing.T) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		spans := clientSpansToPort(unobservedResponseTraces(ct), abandonedPeerPort)
+		if !assert.NotEmpty(ct, spans, "a call whose response went unread produced no span") {
+			return
+		}
+
+		for _, span := range spans {
+			status, ok := jaeger.FindIn(span.Tags, "http.response.status_code")
+			assert.False(ct, ok,
+				"a call whose response was never read reports a status: %v", status.Value)
+
+			assert.Empty(ct, span.Diff(
+				jaeger.Tag{Key: "obi.http.response.observed", Type: "bool", Value: false}))
+		}
+	}, testTimeout, 100*time.Millisecond)
+}
+
+// promSeries returns the series a query holds once it has any, so the assertions do
+// not race the scrape interval.
+func promSeries(t *testing.T, query string) []promtest.Result {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+
+	var results []promtest.Result
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		var err error
+		results, err = pq.Query(query)
+		require.NoError(ct, err)
+		require.NotEmpty(ct, results)
+	}, testTimeout, 100*time.Millisecond)
+
+	return results
+}
+
+// A withheld duration must not take unrelated metrics down with it. This gauge reports
+// that the host is running, which no call's duration has a say in.
+//
+// The workload also makes calls that are measured, so this only proves the gauge is
+// exported at all. What proves it survives a service whose every call is unmeasured is
+// TestAppMetrics_TracesHostInfoUnmeasuredSpans, which drives that service directly.
+func testHostInfoIsExported(t *testing.T) {
+	promSeries(t, `traces_host_info{}`)
+}
+
+// The service graph edge to the abandoned peer exists and is counted, because the call
+// was made. Its latency is withheld, because the record's duration runs to the close.
+// Dropping the span whole would erase an edge that a service really does talk to.
+func testUnmeasuredCallCountsOnItsEdgeWithoutLatency(t *testing.T) {
+	counted := promSeries(t,
+		`traces_service_graph_request_total{server="`+abandonedPeerService+`"}`)
+	require.NotEmpty(t, counted, "the edge a call traveled is missing from the service graph")
+
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	latencies, err := pq.Query(
+		`traces_service_graph_request_client_seconds_count{server="` + abandonedPeerService + `"}`)
+	require.NoError(t, err)
+	assert.Empty(t, latencies,
+		"a duration that runs to the close of the socket was published as the call's latency")
+}
+
+// The RED series separates the two ways a response goes unobserved. The relay's answer
+// arrives and is read, so the record ends at those bytes and the duration is a
+// measurement worth publishing. The abandoned answer is never read, so the record ends
+// at the close and the duration is withheld.
+func testUnmeasuredCallPublishesNoDuration(t *testing.T) {
+	promSeries(t, `http_client_request_duration_seconds_count{server_port="`+
+		strconv.Itoa(unobservedPeerPort)+`"}`)
+
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	withheld, err := pq.Query(`http_client_request_duration_seconds_count{server_port="` +
+		strconv.Itoa(abandonedPeerPort) + `"}`)
+	require.NoError(t, err)
+	assert.Empty(t, withheld,
+		"a duration that runs past the request it describes was published as the call's duration")
+}
+
 func TestSuite_ResponseObservation(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-response-observation.yml", path.Join(pathOutput, "test-suite-unobserved-response.log"))
 	require.NoError(t, err)
@@ -322,6 +412,13 @@ func TestSuite_ResponseObservation(t *testing.T) {
 	t.Run("a reused connection reports every call", testReusedConnectionReportsEveryCall)
 	t.Run("a reused connection carries no status code", testReusedConnectionCarriesNoStatusCode)
 	t.Run("a reused connection's durations are bounded", testReusedConnectionDurationsAreBounded)
+	t.Run("an abandoned response is reported without a status", testAbandonedResponseIsReportedWithoutStatus)
+
+	// What a span reports and what a metric reports are decided in separate code, so
+	// the same calls are checked on both sides.
+	t.Run("the host info gauge is exported", testHostInfoIsExported)
+	t.Run("an unmeasured call counts on its edge without a latency", testUnmeasuredCallCountsOnItsEdgeWithoutLatency)
+	t.Run("an unmeasured call publishes no duration", testUnmeasuredCallPublishesNoDuration)
 
 	require.NoError(t, compose.Close())
 }

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -1369,6 +1369,22 @@ type SpanLink struct {
 	TraceFlags uint8         `json:"traceFlags,string"`
 }
 
+// ResponseObservation mirrors the kernel's enum http_response_observation: how much of
+// the response instrumentation saw.
+type ResponseObservation uint8
+
+const (
+	// ResponseParsed is the ordinary case: a response was read and Status carries it.
+	// It is the zero value, so spans built outside the eBPF path need not set it.
+	ResponseParsed ResponseObservation = iota
+	// ResponseReceived means the peer answered and no probe parsed the response. The
+	// end timestamp is when watching stopped, so the duration overstates the request.
+	ResponseReceived
+	// ResponseSilent means nothing came back and the local process closed the socket.
+	// The close ended the request, so the duration is a measurement.
+	ResponseSilent
+)
+
 // Span contains the information being submitted by the following nodes in the graph.
 // It enables comfortable handling of data from Go.
 // REMINDER: any attribute here must be also added to the functions SpanOTELGetters
@@ -1423,6 +1439,10 @@ type Span struct {
 	AWS               *AWS           `json:"-"`
 	GenAI             *GenAI         `json:"-"`
 	JSONRPC           *JSONRPC       `json:"-"`
+
+	// Anything but ResponseParsed means Status holds no observation. Whether the
+	// duration is a measurement is recorded separately, by ignoreDurations.
+	ResponseObservation ResponseObservation `json:"-"`
 
 	// RequestHeaders stores extracted HTTP request headers based on enrichment rules.
 	// Keys are canonical header names, values are all header values (possibly obfuscated).
@@ -1855,6 +1875,13 @@ func SpanStatusMessage(span *Span) string {
 
 // HTTPSpanStatusCode https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/http/#status
 func HTTPSpanStatusCode(span *Span) string {
+	// No response was read, so there is nothing to judge. Not even a reset: sock_error()
+	// clears sk_err on the application's read, which precedes the close, so a peer that
+	// failed and a client that gave up are indistinguishable by then.
+	if span.ResponseObservation != ResponseParsed {
+		return StatusCodeUnset
+	}
+
 	if span.Status == 0 {
 		return StatusCodeError
 	}

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -1383,6 +1383,9 @@ const (
 	// ResponseSilent means nothing came back and the local process closed the socket.
 	// The close ended the request, so the duration is a measurement.
 	ResponseSilent
+	// ResponseUnread means the response arrived and no probe could parse it. The end
+	// timestamp came from the response's own bytes, so the duration is a measurement.
+	ResponseUnread
 )
 
 // Span contains the information being submitted by the following nodes in the graph.

--- a/pkg/appolly/app/request/span_ignores.go
+++ b/pkg/appolly/app/request/span_ignores.go
@@ -6,8 +6,9 @@ package request // import "go.opentelemetry.io/obi/pkg/appolly/app/request"
 type ignoreMode uint8
 
 const (
-	ignoreMetrics ignoreMode = 0x1
-	ignoreTraces  ignoreMode = 0x2
+	ignoreMetrics   ignoreMode = 0x1
+	ignoreTraces    ignoreMode = 0x2
+	ignoreDurations ignoreMode = 0x4
 )
 
 func setIgnoreFlag(s *Span, flag ignoreMode) {
@@ -32,4 +33,14 @@ func IgnoreMetrics(s *Span) bool {
 
 func IgnoreTraces(s *Span) bool {
 	return isIgnored(s, ignoreTraces)
+}
+
+func SetIgnoreDurations(s *Span) {
+	setIgnoreFlag(s, ignoreDurations)
+}
+
+// IgnoreDurations reports whether this span's duration is unusable. An OTel histogram
+// publishes its own count, so admitting a span to that count also puts it in a bucket.
+func IgnoreDurations(s *Span) bool {
+	return isIgnored(s, ignoreDurations)
 }

--- a/pkg/appolly/app/request/span_response_observation_test.go
+++ b/pkg/appolly/app/request/span_response_observation_test.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package request
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A client span with no observed response used to report an error twice over: through
+// the fabricated 499, and through HTTPSpanStatusCode's zero-status branch. OBI saw
+// nothing, so the status is Unset.
+func TestSpanStatusCode_UnknownOutcomeIsUnset(t *testing.T) {
+	for _, eventType := range []EventType{EventTypeHTTPClient, EventTypeHTTP} {
+		span := &Span{Type: eventType, ResponseObservation: ResponseReceived}
+
+		assert.Equal(t, StatusCodeUnset, SpanStatusCode(span), eventType)
+	}
+}
+
+// The guard fires on the marker, not on the zero status, so a request that genuinely
+// failed without a response keeps reporting an error.
+func TestSpanStatusCode_UnsetStatusWithoutMarkerStaysError(t *testing.T) {
+	for _, eventType := range []EventType{EventTypeHTTPClient, EventTypeHTTP} {
+		span := &Span{Type: eventType}
+
+		assert.Equal(t, StatusCodeError, SpanStatusCode(span), eventType)
+	}
+}
+
+// The control: ordinary outcomes are unchanged.
+func TestSpanStatusCode_ObservedResponsesAreUnchanged(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType EventType
+		status    int
+		expected  string
+	}{
+		{"client 200", EventTypeHTTPClient, 200, StatusCodeUnset},
+		{"client 404", EventTypeHTTPClient, 404, StatusCodeError},
+		{"client 500", EventTypeHTTPClient, 500, StatusCodeError},
+		{"server 200", EventTypeHTTP, 200, StatusCodeUnset},
+		{"server 404", EventTypeHTTP, 404, StatusCodeUnset},
+		{"server 500", EventTypeHTTP, 500, StatusCodeError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := &Span{Type: tt.eventType, Status: tt.status}
+
+			assert.Equal(t, tt.expected, SpanStatusCode(span))
+		})
+	}
+}

--- a/pkg/ebpf/common/http_response_observation_test.go
+++ b/pkg/ebpf/common/http_response_observation_test.go
@@ -87,9 +87,29 @@ func TestHTTPInfoEventToSpan_AbsentResponseIsMeasuredButNotJudged(t *testing.T) 
 	assert.False(t, request.IgnoreMetrics(&span))
 }
 
+// The response arrived and no probe could parse it. The end time came from those bytes,
+// so the duration is a measurement even though the status is missing. This is the case a
+// reused connection produces: the request is finished by its response, not by a close.
+func TestHTTPInfoEventToSpan_UnreadResponseKeepsItsDuration(t *testing.T) {
+	event := clientRequestEvent()
+	event.ResponseObservation = bpfResponseUnread
+
+	span, ignore, err := HTTPInfoEventToSpan(nil, event)
+	require.NoError(t, err)
+	require.False(t, ignore, "the span is emitted, not dropped")
+
+	assert.Equal(t, request.ResponseUnread, span.ResponseObservation)
+	assert.Equal(t, 0, span.Status, "no status is invented for a response nobody parsed")
+	assert.Equal(t, request.StatusCodeUnset, request.SpanStatusCode(&span))
+	assert.False(t, request.IgnoreDurations(&span),
+		"the response's own bytes ended the request, so the duration is a measurement")
+	assert.False(t, request.IgnoreMetrics(&span))
+	assert.False(t, request.IgnoreTraces(&span))
+}
+
 // No span on this path names an error type.
 func TestErrorType_NoUnobservedCaseNamesAFailure(t *testing.T) {
-	for _, observation := range []uint8{bpfResponseReceived, bpfResponseSilent} {
+	for _, observation := range []uint8{bpfResponseReceived, bpfResponseSilent, bpfResponseUnread} {
 		event := clientRequestEvent()
 		event.ResponseObservation = observation
 

--- a/pkg/ebpf/common/http_response_observation_test.go
+++ b/pkg/ebpf/common/http_response_observation_test.go
@@ -1,0 +1,183 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon
+
+import (
+	"bufio"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+)
+
+func clientRequestEvent() *BPFHTTPInfo {
+	event := &BPFHTTPInfo{
+		Type:            uint8(request.EventTypeHTTPClient),
+		StartMonotimeNs: 1000,
+		EndMonotimeNs:   2000,
+		Len:             64,
+	}
+	event.Pid.HostPid = 4242
+	copy(event.Buf[:], "GET /r HTTP/1.1\r\nHost: relay:9100\r\n\r\n")
+
+	return event
+}
+
+// The span must survive. Dropping the record would reintroduce the silently-missing
+// spans #767 fixed.
+func TestHTTPInfoEventToSpan_UnparsedResponseIsStillReported(t *testing.T) {
+	event := clientRequestEvent()
+	event.ResponseObservation = bpfResponseReceived
+
+	span, ignore, err := HTTPInfoEventToSpan(nil, event)
+	require.NoError(t, err)
+	require.False(t, ignore, "the span is emitted, not dropped")
+
+	assert.NotEqual(t, request.ResponseParsed, span.ResponseObservation)
+	assert.Equal(t, 0, span.Status, "no status is invented for a response nobody saw")
+	assert.Equal(t, request.StatusCodeUnset, request.SpanStatusCode(&span))
+	assert.Equal(t, "GET", span.Method)
+	assert.Equal(t, "/r", span.Path)
+}
+
+// The recorded end time is when the socket went away, not when the request finished, so
+// the duration overstates the request and stays out of every duration instrument. It
+// still counts in the service graph, whose request counter stands on its own.
+func TestHTTPInfoEventToSpan_UnknownOutcomeHasNoMeasuredDuration(t *testing.T) {
+	event := clientRequestEvent()
+	event.ResponseObservation = bpfResponseReceived
+
+	span, _, err := HTTPInfoEventToSpan(nil, event)
+	require.NoError(t, err)
+
+	assert.True(t, request.IgnoreDurations(&span))
+	assert.False(t, request.IgnoreMetrics(&span),
+		"the span is withheld from durations, not from every metric")
+	assert.False(t, request.IgnoreTraces(&span), "the trace still carries the call")
+}
+
+// Nothing came back, so the close is the end of the request and its duration is a
+// measurement. The status stays Unset: a peer that reset the connection and a client
+// that stopped waiting look alike here.
+//
+// Measured against a peer that resets mid-response, sk_err reached tcp_close set in 0 of
+// 200 loopback failures and 0 of 9,936 containerized ones. sock_error() consumes it with
+// an xchg on the application's read. A control that never reads before closing kept it
+// in 200 of 200.
+func TestHTTPInfoEventToSpan_AbsentResponseIsMeasuredButNotJudged(t *testing.T) {
+	event := clientRequestEvent()
+	event.ResponseObservation = bpfResponseSilent
+
+	span, ignore, err := HTTPInfoEventToSpan(nil, event)
+	require.NoError(t, err)
+	require.False(t, ignore, "the span is emitted, not dropped")
+
+	assert.NotEqual(t, request.ResponseParsed, span.ResponseObservation, "no response was read, so there is no status")
+	assert.Equal(t, 0, span.Status)
+	assert.Equal(t, request.StatusCodeUnset, request.SpanStatusCode(&span),
+		"OBI cannot tell a reset from a client that gave up, so it asserts neither")
+	assert.False(t, request.IgnoreDurations(&span),
+		"the close is a real event at a real time, so the duration is a measurement")
+	assert.False(t, request.IgnoreMetrics(&span))
+}
+
+// No span on this path names an error type.
+func TestErrorType_NoUnobservedCaseNamesAFailure(t *testing.T) {
+	for _, observation := range []uint8{bpfResponseReceived, bpfResponseSilent} {
+		event := clientRequestEvent()
+		event.ResponseObservation = observation
+
+		span, _, err := HTTPInfoEventToSpan(nil, event)
+		require.NoError(t, err)
+
+		require.Equal(t, request.StatusCodeUnset, request.SpanStatusCode(&span))
+
+		getter, ok := request.SpanOTELGetters(request.UnresolvedNames{})(attr.ErrorType)
+		require.True(t, ok)
+		assert.False(t, getter(&span).Valid(),
+			"observation %d names an error type", observation)
+	}
+}
+
+// The control. An observed response is untouched on every axis the fix moves.
+func TestHTTPInfoEventToSpan_ObservedResponseIsUnchanged(t *testing.T) {
+	event := clientRequestEvent()
+	event.Status = 200
+	event.RespLen = 227
+
+	span, _, err := HTTPInfoEventToSpan(nil, event)
+	require.NoError(t, err)
+
+	assert.Equal(t, request.ResponseParsed, span.ResponseObservation)
+	assert.Equal(t, 200, span.Status)
+	assert.False(t, request.IgnoreMetrics(&span))
+	assert.False(t, request.IgnoreDurations(&span))
+	assert.Equal(t, request.StatusCodeUnset, request.SpanStatusCode(&span))
+}
+
+// The same marker on the response-parsing path, which a large-buffer capture takes.
+func TestHTTPRequestResponseToSpan_CarriesResponseObservation(t *testing.T) {
+	event := clientRequestEvent()
+	event.ResponseObservation = bpfResponseReceived
+
+	req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(
+		"GET /r HTTP/1.1\r\nHost: relay:9100\r\n\r\n")))
+	require.NoError(t, err)
+	resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(
+		"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")), req)
+	require.NoError(t, err)
+
+	span := httpRequestResponseToSpan(nil, event, req, resp)
+
+	assert.NotEqual(t, request.ResponseParsed, span.ResponseObservation)
+	assert.Equal(t, 0, span.Status)
+	assert.True(t, request.IgnoreDurations(&span))
+}
+
+// The two cases differ in one axis, whether the duration is a measurement, and agree on
+// every other. Asserted together, so a regression that collapsed them cannot leave a
+// passing assertion behind.
+func TestHTTPInfoEventToSpan_ReceivedAndSilentDifferOnlyInTheirDuration(t *testing.T) {
+	receivedEvent := clientRequestEvent()
+	receivedEvent.ResponseObservation = bpfResponseReceived
+
+	silentEvent := clientRequestEvent()
+	silentEvent.ResponseObservation = bpfResponseSilent
+
+	received, _, err := HTTPInfoEventToSpan(nil, receivedEvent)
+	require.NoError(t, err)
+	silent, _, err := HTTPInfoEventToSpan(nil, silentEvent)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, request.ResponseParsed, received.ResponseObservation)
+	assert.NotEqual(t, request.ResponseParsed, silent.ResponseObservation)
+	assert.Equal(t, request.SpanStatusCode(&received), request.SpanStatusCode(&silent),
+		"neither is judged, because neither was observed to succeed or to fail")
+	assert.Equal(t, 0, received.Status)
+	assert.Equal(t, 0, silent.Status)
+
+	assert.True(t, request.IgnoreDurations(&received),
+		"the peer answered and OBI lost the response, so the end time is not the request's")
+	assert.False(t, request.IgnoreDurations(&silent),
+		"nothing came back, so the close is the end of the request itself")
+}
+
+// The control on the encoding. Zero is a response that was read.
+func TestHTTPInfoEventToSpan_ObservedEncodingIsUntouched(t *testing.T) {
+	event := clientRequestEvent()
+	event.ResponseObservation = bpfResponseParsed
+	event.Status = 200
+
+	span, _, err := HTTPInfoEventToSpan(nil, event)
+	require.NoError(t, err)
+
+	assert.Equal(t, request.ResponseParsed, span.ResponseObservation)
+	assert.Equal(t, 200, span.Status)
+	assert.False(t, request.IgnoreDurations(&span))
+}

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -103,28 +103,31 @@ func httpInfoToSpanLegacy(info *HTTPInfo) request.Span {
 	return span
 }
 
-// The kernel's enum http_response_observation. Nonzero means the record was
-// force-finished at socket teardown with no response read, so it carries no status.
+// The kernel's enum http_response_observation. Nonzero means no probe read the
+// response, so the record carries no status.
 const (
 	bpfResponseParsed   = 0
 	bpfResponseReceived = 1
 	bpfResponseSilent   = 2
+	bpfResponseUnread   = 3
 )
 
-// markResponseObservation copies the kernel's observation onto the span. Both
-// nonzero values mean no response was read, so Status is cleared in either
-// case.
+// markResponseObservation copies the kernel's observation onto the span. Every
+// nonzero value means no response was read, so Status is cleared in each case.
 //
-// They differ in whether the end timestamp is usable. ResponseReceived took it
-// when instrumentation stopped watching, which can be long after the response
-// arrived, so the duration is discarded. ResponseSilent took it from the close
-// that ended the request, so the duration is preserved.
+// They differ in whether the end timestamp is usable. ResponseReceived took it when
+// instrumentation stopped watching, which can be long after the response arrived, so
+// the duration is discarded. ResponseSilent took it from the close that ended the
+// request and ResponseUnread from the response's own bytes, so both durations are
+// preserved.
 func markResponseObservation(span *request.Span, event *BPFHTTPInfo) {
 	switch event.ResponseObservation {
 	case bpfResponseParsed:
 		return
 	case bpfResponseSilent:
 		span.ResponseObservation = request.ResponseSilent
+	case bpfResponseUnread:
+		span.ResponseObservation = request.ResponseUnread
 	// An unrecognized value withholds the duration, which asserts less than publishing
 	// one.
 	case bpfResponseReceived:

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -69,7 +69,7 @@ func httpInfoToSpanLegacy(info *HTTPInfo) request.Span {
 		scheme = "https"
 	}
 
-	return request.Span{
+	span := request.Span{
 		Type:              request.EventType(info.Type),
 		Method:            info.Method,
 		Path:              removeQuery(info.URL),
@@ -97,6 +97,44 @@ func httpInfoToSpanLegacy(info *HTTPInfo) request.Span {
 		Statement:    scheme + request.SchemeHostSeparator + info.HeaderHost,
 		ProtoVersion: info.ProtoVersion,
 	}
+
+	markResponseObservation(&span, &info.BPFHTTPInfo)
+
+	return span
+}
+
+// The kernel's enum http_response_observation. Nonzero means the record was
+// force-finished at socket teardown with no response read, so it carries no status.
+const (
+	bpfResponseParsed   = 0
+	bpfResponseReceived = 1
+	bpfResponseSilent   = 2
+)
+
+// markResponseObservation copies the kernel's observation onto the span. Both
+// nonzero values mean no response was read, so Status is cleared in either
+// case.
+//
+// They differ in whether the end timestamp is usable. ResponseReceived took it
+// when instrumentation stopped watching, which can be long after the response
+// arrived, so the duration is discarded. ResponseSilent took it from the close
+// that ended the request, so the duration is preserved.
+func markResponseObservation(span *request.Span, event *BPFHTTPInfo) {
+	switch event.ResponseObservation {
+	case bpfResponseParsed:
+		return
+	case bpfResponseSilent:
+		span.ResponseObservation = request.ResponseSilent
+	// An unrecognized value withholds the duration, which asserts less than publishing
+	// one.
+	case bpfResponseReceived:
+		fallthrough
+	default:
+		span.ResponseObservation = request.ResponseReceived
+		request.SetIgnoreDurations(span)
+	}
+
+	span.Status = 0
 }
 
 func httpRequestResponseToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo, req *http.Request, resp *http.Response) request.Span {
@@ -162,6 +200,8 @@ func httpRequestResponseToSpan(parseCtx *EBPFParseContext, event *BPFHTTPInfo, r
 		},
 		Statement: scheme + request.SchemeHostSeparator + headerHost,
 	}
+
+	markResponseObservation(&httpSpan, event)
 
 	return postProcessHTTPSpan(parseCtx, &httpSpan, req, resp)
 }

--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -138,6 +138,10 @@ func init() {
 
 var OBIIP = Name("obi.ip")
 
+// OBIHTTPResponseObserved is false on a span whose response was never seen, and absent
+// otherwise.
+var OBIHTTPResponseObserved = Name("obi.http.response.observed")
+
 const (
 	Transport       = Name("transport")
 	NetworkType     = Name(semconv.NetworkTypeKey)

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -939,225 +939,296 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 
 	ctx := trace.ContextWithSpanContext(r.ctx, trace.SpanContext{}.WithTraceID(span.TraceID).WithSpanID(span.SpanID).WithTraceFlags(trace.TraceFlags(span.TraceFlags)))
 
-	// Data point timestamps are the collection time, not the span end time: the OTel
-	// metrics API takes no per-measurement timestamp. Span-accurate timing lives in
-	// traces and in the exemplars attached through ctx.
+	// A record finished without its response ends when something other than the
+	// response ended it, so its duration describes more than the request it names.
+	// Every instrument reached through recordDuration stands on that duration; the
+	// body sizes do not, and are recorded on their own terms.
+	measured := !request.IgnoreDurations(span)
+
 	if otelMetricsAccepted(span) {
-		switch span.Type {
-		case request.EventTypeHTTP:
-			// JSON-RPC over HTTP gets recorded as RPC server metrics
-			if span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled() {
-				grpcDuration, attrs := r.grpcDuration.ForRecord(span)
-				grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			} else if mr.is.HTTPEnabled() {
-				httpDuration, attrs := r.httpDuration.ForRecord(span)
-				httpDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		if measured {
+			r.recordDuration(span, mr, ctx, duration)
+		}
 
-				httpRequestSize, attrs := r.httpRequestSize.ForRecord(span)
-				httpRequestSize.Record(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
+		r.recordBodySizes(span, mr, ctx)
+	}
 
-				httpResponseSize, attrs := r.httpResponseSize.ForRecord(span)
-				httpResponseSize.Record(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeGRPC:
-			if mr.is.GRPCEnabled() {
-				grpcDuration, attrs := r.grpcDuration.ForRecord(span)
-				grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeGRPCClient:
-			if mr.is.GRPCEnabled() {
-				grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
-				grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeSunRPCClient:
-			if mr.is.SunRPCEnabled() {
-				grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
-				grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeSunRPCServer:
-			if mr.is.SunRPCEnabled() {
-				grpcDuration, attrs := r.grpcDuration.ForRecord(span)
-				grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeHTTPClient:
-			// HTTP client subtypes that are database calls get recorded as db client metrics
-			if mr.is.DBEnabled() && (span.SubType == request.HTTPSubtypeSQLPP || span.SubType == request.HTTPSubtypeElasticsearch) {
-				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			} else if span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled() {
-				grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
-				grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			} else if span.SubType == request.HTTPSubtypeAWSS3 && mr.rpcClientRecorded() {
-				grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
-				grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			} else if span.SubType == request.HTTPSubtypeAWSSQS && request.IsSQSMessagingClientOperation(span) && mr.msgPublishRecorded() {
-				msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
-				msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			} else if mr.is.GenAIEnabled() && request.IsGenAISubtype(span.SubType) {
-				genAIClientDuration, attrs := r.genAIClientDuration.ForRecord(span)
-				genAIClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				if tokens, reported := span.GenAIInputTokenCount(); reported {
-					genAIInputTokenUsage, attrs := r.genAIInputTokenUsage.ForRecord(span)
-					genAIInputTokenUsage.Record(ctx, float64(tokens), instrument.WithAttributeSet(attrs))
-				}
-				if tokens, reported := span.GenAIOutputTokenCount(); reported {
-					genAIOutputTokenUsage, attrs := r.genAIOutputTokenUsage.ForRecord(span)
-					genAIOutputTokenUsage.Record(ctx, float64(tokens), instrument.WithAttributeSet(attrs))
-				}
-			} else if mr.is.HTTPEnabled() {
-				httpClientDuration, attrs := r.httpClientDuration.ForRecord(span)
-				httpClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				httpClientRequestSize, attrs := r.httpClientRequestSize.ForRecord(span)
-				httpClientRequestSize.Record(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
-				httpClientResponseSize, attrs := r.httpClientResponseSize.ForRecord(span)
-				httpClientResponseSize.Record(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeRedisClient:
-			if mr.is.RedisEnabled() {
-				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeRedisServer:
-			if mr.is.RedisEnabled() {
-				dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
-				dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeSQLClient:
-			if mr.is.SQLEnabled() {
-				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeSQLServer:
-			if mr.is.SQLEnabled() {
-				dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
-				dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeMongoClient:
-			if mr.is.MongoEnabled() {
-				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeCouchbaseClient:
-			if mr.is.CouchbaseEnabled() {
-				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeMemcachedClient:
-			if mr.is.MemcachedEnabled() {
-				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeMemcachedServer:
-			if mr.is.MemcachedEnabled() {
-				dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
-				dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeAerospikeClient:
-			if mr.is.AerospikeEnabled() {
-				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeKafkaClient, request.EventTypeKafkaServer:
-			if mr.is.KafkaEnabled() {
-				switch request.MessagingOperationTypeOf(span.Method) {
-				case request.MessagingSend:
-					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
-					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				case request.MessagingProcess:
-					msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
-					msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				}
-			}
-		case request.EventTypeMQTTClient, request.EventTypeMQTTServer:
-			if mr.is.MQTTEnabled() {
-				switch request.MessagingOperationTypeOf(span.Method) {
-				case request.MessagingSend:
-					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
-					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				case request.MessagingProcess:
-					msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
-					msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				}
-			}
-		case request.EventTypeNATSClient, request.EventTypeNATSServer:
-			if mr.is.NATSEnabled() {
-				switch request.MessagingOperationTypeOf(span.Method) {
-				case request.MessagingSend:
-					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
-					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				case request.MessagingProcess:
-					msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
-					msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				}
-			}
-		case request.EventTypeAMQPClient:
-			if mr.is.AMQPEnabled() {
-				switch request.MessagingOperationTypeOf(span.Method) {
-				case request.MessagingSend:
-					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
-					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				case request.MessagingProcess:
-					msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
-					msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-				}
-			}
-		case request.EventTypeGPUCudaKernelLaunch:
-			if mr.is.GPUEnabled() {
-				gcalls, attrs := r.gpuKernelCallsTotal.ForRecord(span)
-				gcalls.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+	if measured {
+		r.recordSpanMetrics(span, mr, ctx, duration)
+	}
+}
 
-				ggrid, attrs := r.gpuKernelGridSize.ForRecord(span)
-				ggrid.Record(ctx, float64(span.ContentLength), instrument.WithAttributeSet(attrs))
+// recordSpanMetrics publishes the span-metrics family. The calls counter is separable
+// from the latency histogram, but the two are read together, so feeding one alone makes
+// the pair disagree. Both stay out when the duration is withheld.
+func (r *Metrics) recordSpanMetrics(span *request.Span, mr *MetricsReporter, ctx context.Context, duration float64) {
+	if !otelSpanMetricsAccepted(span) {
+		return
+	}
 
-				gblock, attrs := r.gpuKernelBlockSize.ForRecord(span)
-				gblock.Record(ctx, float64(span.SubType), instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeGPUCudaMalloc:
-			if mr.is.GPUEnabled() {
-				gmem, attrs := r.gpuMemoryAllocsTotal.ForRecord(span)
-				gmem.Add(ctx, span.ContentLength, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeGPUCudaGraphLaunch:
-			if mr.is.GPUEnabled() {
-				ggraph, attrs := r.gpuGraphCallsTotal.ForRecord(span)
-				ggraph.Add(ctx, 1, instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeGPUCudaMemcpy:
-			if mr.is.GPUEnabled() {
-				gmem, attrs := r.gpuMemoryCopySize.ForRecord(span)
-				gmem.Record(r.ctx, float64(span.ContentLength), instrument.WithAttributeSet(attrs))
-			}
-		case request.EventTypeDNS:
-			if mr.is.DNSEnabled() {
-				dnsDuration, attrs := r.dnsLookupDuration.ForRecord(span)
-				dnsDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
+	var extraAttrs []attribute.KeyValue
+
+	for _, l := range mr.spanExtraAttrs {
+		if v, ok := span.Service.Metadata[l]; ok {
+			extraAttrs = append(extraAttrs, l.OTEL().String(v))
 		}
 	}
 
-	if otelSpanMetricsAccepted(span) {
-		var extraAttrs []attribute.KeyValue
+	if span.Service.Features.SpanMetrics() {
+		sml, attrs := r.spanMetricsLatency.ForRecord(span, extraAttrs...)
+		sml.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 
-		for _, l := range mr.spanExtraAttrs {
-			if v, ok := span.Service.Metadata[l]; ok {
-				extraAttrs = append(extraAttrs, l.OTEL().String(v))
+		smct, attrs := r.spanMetricsCallsTotal.ForRecord(span, extraAttrs...)
+		smct.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+	}
+
+	if span.Service.Features.SpanSizes() {
+		smst, attrs := r.spanMetricsRequestSizeTotal.ForRecord(span, extraAttrs...)
+		smst.Add(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
+
+		smst, attr := r.spanMetricsResponseSizeTotal.ForRecord(span, extraAttrs...)
+		smst.Add(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attr))
+	}
+}
+
+// recordedAsNonHTTPClient reports whether an HTTP client span is published under the
+// database, RPC, or GenAI instruments rather than the HTTP ones. Those families carry no
+// body-size instrument, so such a span has no size to publish. It mirrors the dispatch
+// in recordDuration.
+func recordedAsNonHTTPClient(span *request.Span, mr *MetricsReporter) bool {
+	switch {
+	case mr.is.DBEnabled() &&
+		(span.SubType == request.HTTPSubtypeSQLPP || span.SubType == request.HTTPSubtypeElasticsearch):
+		return true
+	case span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled():
+		return true
+	case mr.is.GenAIEnabled() && request.IsGenAISubtype(span.SubType):
+		return true
+	default:
+		return false
+	}
+}
+
+// recordBodySizes publishes what the exchange carried. The request size is known
+// whatever came of the response, so it is published even when the duration is not. The
+// response size is not known: a record finished without its response carries a zeroed
+// length, and publishing that would report an empty response for a call whose response
+// was never seen.
+func (r *Metrics) recordBodySizes(span *request.Span, mr *MetricsReporter, ctx context.Context) {
+	if !mr.is.HTTPEnabled() {
+		return
+	}
+
+	var requestSize, responseSize *Expirer[*request.Span, instrument.Float64Histogram, float64]
+
+	switch span.Type {
+	case request.EventTypeHTTP:
+		// JSON-RPC over HTTP is recorded as an RPC call, which has no size instrument.
+		if span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled() {
+			return
+		}
+		requestSize, responseSize = r.httpRequestSize, r.httpResponseSize
+	case request.EventTypeHTTPClient:
+		if recordedAsNonHTTPClient(span, mr) {
+			return
+		}
+		requestSize, responseSize = r.httpClientRequestSize, r.httpClientResponseSize
+	default:
+		return
+	}
+
+	size, attrs := requestSize.ForRecord(span)
+	size.Record(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
+
+	if request.IgnoreDurations(span) {
+		return
+	}
+
+	size, attrs = responseSize.ForRecord(span)
+	size.Record(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attrs))
+}
+
+//nolint:cyclop
+func (r *Metrics) recordDuration(span *request.Span, mr *MetricsReporter, ctx context.Context, duration float64) {
+	switch span.Type {
+	case request.EventTypeHTTP:
+		// JSON-RPC over HTTP gets recorded as RPC server metrics
+		if span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled() {
+			grpcDuration, attrs := r.grpcDuration.ForRecord(span)
+			grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		} else if mr.is.HTTPEnabled() {
+			httpDuration, attrs := r.httpDuration.ForRecord(span)
+			httpDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeGRPC:
+		if mr.is.GRPCEnabled() {
+			grpcDuration, attrs := r.grpcDuration.ForRecord(span)
+			grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeGRPCClient:
+		if mr.is.GRPCEnabled() {
+			grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
+			grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeSunRPCClient:
+		if mr.is.SunRPCEnabled() {
+			grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
+			grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeSunRPCServer:
+		if mr.is.SunRPCEnabled() {
+			grpcDuration, attrs := r.grpcDuration.ForRecord(span)
+			grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeHTTPClient:
+		// HTTP client subtypes that are database calls get recorded as db client metrics
+		if mr.is.DBEnabled() && (span.SubType == request.HTTPSubtypeSQLPP || span.SubType == request.HTTPSubtypeElasticsearch) {
+			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		} else if span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled() {
+			// JSON-RPC client calls over HTTP get recorded as RPC client metrics
+			grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
+			grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		} else if span.SubType == request.HTTPSubtypeAWSS3 && mr.rpcClientRecorded() {
+			grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
+			grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		} else if span.SubType == request.HTTPSubtypeAWSSQS && request.IsSQSMessagingClientOperation(span) && mr.msgPublishRecorded() {
+			msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
+			msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		} else if mr.is.GenAIEnabled() && request.IsGenAISubtype(span.SubType) {
+			genAIClientDuration, attrs := r.genAIClientDuration.ForRecord(span)
+			genAIClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			if tokens, reported := span.GenAIInputTokenCount(); reported {
+				genAIInputTokenUsage, attrs := r.genAIInputTokenUsage.ForRecord(span)
+				genAIInputTokenUsage.Record(ctx, float64(tokens), instrument.WithAttributeSet(attrs))
+			}
+			if tokens, reported := span.GenAIOutputTokenCount(); reported {
+				genAIOutputTokenUsage, attrs := r.genAIOutputTokenUsage.ForRecord(span)
+				genAIOutputTokenUsage.Record(ctx, float64(tokens), instrument.WithAttributeSet(attrs))
+			}
+		} else if mr.is.HTTPEnabled() {
+			httpClientDuration, attrs := r.httpClientDuration.ForRecord(span)
+			httpClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeRedisClient:
+		if mr.is.RedisEnabled() {
+			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeRedisServer:
+		if mr.is.RedisEnabled() {
+			dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
+			dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeSQLClient:
+		if mr.is.SQLEnabled() {
+			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeSQLServer:
+		if mr.is.SQLEnabled() {
+			dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
+			dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeMongoClient:
+		if mr.is.MongoEnabled() {
+			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeCouchbaseClient:
+		if mr.is.CouchbaseEnabled() {
+			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeMemcachedClient:
+		if mr.is.MemcachedEnabled() {
+			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeMemcachedServer:
+		if mr.is.MemcachedEnabled() {
+			dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
+			dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeAerospikeClient:
+		if mr.is.AerospikeEnabled() {
+			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeKafkaClient, request.EventTypeKafkaServer:
+		if mr.is.KafkaEnabled() {
+			switch request.MessagingOperationTypeOf(span.Method) {
+			case request.MessagingSend:
+				msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
+				msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			case request.MessagingProcess:
+				msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
+				msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 			}
 		}
-
-		if span.Service.Features.SpanMetrics() {
-			sml, attrs := r.spanMetricsLatency.ForRecord(span, extraAttrs...)
-			sml.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-
-			smct, attrs := r.spanMetricsCallsTotal.ForRecord(span, extraAttrs...)
-			smct.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+	case request.EventTypeMQTTClient, request.EventTypeMQTTServer:
+		if mr.is.MQTTEnabled() {
+			switch request.MessagingOperationTypeOf(span.Method) {
+			case request.MessagingSend:
+				msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
+				msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			case request.MessagingProcess:
+				msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
+				msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
 		}
+	case request.EventTypeNATSClient, request.EventTypeNATSServer:
+		if mr.is.NATSEnabled() {
+			switch request.MessagingOperationTypeOf(span.Method) {
+			case request.MessagingSend:
+				msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
+				msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			case request.MessagingProcess:
+				msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
+				msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		}
+	case request.EventTypeAMQPClient:
+		if mr.is.AMQPEnabled() {
+			switch request.MessagingOperationTypeOf(span.Method) {
+			case request.MessagingSend:
+				msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
+				msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			case request.MessagingProcess:
+				msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
+				msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		}
+	case request.EventTypeGPUCudaKernelLaunch:
+		if mr.is.GPUEnabled() {
+			gcalls, attrs := r.gpuKernelCallsTotal.ForRecord(span)
+			gcalls.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 
-		if span.Service.Features.SpanSizes() {
-			smst, attrs := r.spanMetricsRequestSizeTotal.ForRecord(span, extraAttrs...)
-			smst.Add(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
+			ggrid, attrs := r.gpuKernelGridSize.ForRecord(span)
+			ggrid.Record(ctx, float64(span.ContentLength), instrument.WithAttributeSet(attrs))
 
-			smst, attr := r.spanMetricsResponseSizeTotal.ForRecord(span, extraAttrs...)
-			smst.Add(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attr))
+			gblock, attrs := r.gpuKernelBlockSize.ForRecord(span)
+			gblock.Record(ctx, float64(span.SubType), instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeGPUCudaMalloc:
+		if mr.is.GPUEnabled() {
+			gmem, attrs := r.gpuMemoryAllocsTotal.ForRecord(span)
+			gmem.Add(ctx, span.ContentLength, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeGPUCudaGraphLaunch:
+		if mr.is.GPUEnabled() {
+			ggraph, attrs := r.gpuGraphCallsTotal.ForRecord(span)
+			ggraph.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeGPUCudaMemcpy:
+		if mr.is.GPUEnabled() {
+			gmem, attrs := r.gpuMemoryCopySize.ForRecord(span)
+			gmem.Record(r.ctx, float64(span.ContentLength), instrument.WithAttributeSet(attrs))
+		}
+	case request.EventTypeDNS:
+		if mr.is.DNSEnabled() {
+			dnsDuration, attrs := r.dnsLookupDuration.ForRecord(span)
+			dnsDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 		}
 	}
 }
@@ -1378,12 +1449,6 @@ func (mr *MetricsReporter) onSpan(spans []request.Span) {
 			hostInfo.Record(mr.ctx, 1, instrument.WithAttributeSet(attrs))
 		}
 
-		// The span's duration feeds every instrument reporter.record reaches for
-		// these spans, so it is dropped whole. The service graph counts it instead;
-		// its request counter stands on its own.
-		if request.IgnoreDurations(s) {
-			continue
-		}
 		reporter, err := mr.reporters.For(&s.Service)
 		if err != nil {
 			mlog().Error("unexpected error creating OTEL resource. Ignoring metric",

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -1371,6 +1371,19 @@ func (mr *MetricsReporter) onSpan(spans []request.Span) {
 		if !s.Service.Features.AppOrSpan() || request.IgnoreMetrics(s) {
 			continue
 		}
+		// This gauge reports that the host is running, which the span's duration
+		// says nothing about, so it is recorded whatever came of the response.
+		if s.Service.Features.AppHost() {
+			hostInfo, attrs := mr.hostInfo.ForRecord(s)
+			hostInfo.Record(mr.ctx, 1, instrument.WithAttributeSet(attrs))
+		}
+
+		// The span's duration feeds every instrument reporter.record reaches for
+		// these spans, so it is dropped whole. The service graph counts it instead;
+		// its request counter stands on its own.
+		if request.IgnoreDurations(s) {
+			continue
+		}
 		reporter, err := mr.reporters.For(&s.Service)
 		if err != nil {
 			mlog().Error("unexpected error creating OTEL resource. Ignoring metric",
@@ -1378,11 +1391,6 @@ func (mr *MetricsReporter) onSpan(spans []request.Span) {
 			continue
 		}
 		reporter.record(s, mr)
-
-		if s.Service.Features.AppHost() {
-			hostInfo, attrs := mr.hostInfo.ForRecord(s)
-			hostInfo.Record(mr.ctx, 1, instrument.WithAttributeSet(attrs))
-		}
 	}
 }
 

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -939,296 +939,260 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 
 	ctx := trace.ContextWithSpanContext(r.ctx, trace.SpanContext{}.WithTraceID(span.TraceID).WithSpanID(span.SpanID).WithTraceFlags(trace.TraceFlags(span.TraceFlags)))
 
-	// A record finished without its response ends when something other than the
-	// response ended it, so its duration describes more than the request it names.
-	// Every instrument reached through recordDuration stands on that duration; the
-	// body sizes do not, and are recorded on their own terms.
+	// A record finished without its response ends when something other than the response
+	// ended it, so its duration and response size describe more than the request they
+	// name. Only HTTP marks a span this way; every instrument below still gets the
+	// duration and body sizes it always did for every other event type.
 	measured := !request.IgnoreDurations(span)
 
+	// Data point timestamps are the collection time, not the span end time: the OTel
+	// metrics API takes no per-measurement timestamp. Span-accurate timing lives in
+	// traces and in the exemplars attached through ctx.
 	if otelMetricsAccepted(span) {
-		if measured {
-			r.recordDuration(span, mr, ctx, duration)
-		}
+		switch span.Type {
+		case request.EventTypeHTTP:
+			// JSON-RPC over HTTP gets recorded as RPC server metrics
+			if span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled() {
+				if measured {
+					grpcDuration, attrs := r.grpcDuration.ForRecord(span)
+					grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
+			} else if mr.is.HTTPEnabled() {
+				if measured {
+					httpDuration, attrs := r.httpDuration.ForRecord(span)
+					httpDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
 
-		r.recordBodySizes(span, mr, ctx)
-	}
+				httpRequestSize, attrs := r.httpRequestSize.ForRecord(span)
+				httpRequestSize.Record(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
 
-	if measured {
-		r.recordSpanMetrics(span, mr, ctx, duration)
-	}
-}
-
-// recordSpanMetrics publishes the span-metrics family. The calls counter is separable
-// from the latency histogram, but the two are read together, so feeding one alone makes
-// the pair disagree. Both stay out when the duration is withheld.
-func (r *Metrics) recordSpanMetrics(span *request.Span, mr *MetricsReporter, ctx context.Context, duration float64) {
-	if !otelSpanMetricsAccepted(span) {
-		return
-	}
-
-	var extraAttrs []attribute.KeyValue
-
-	for _, l := range mr.spanExtraAttrs {
-		if v, ok := span.Service.Metadata[l]; ok {
-			extraAttrs = append(extraAttrs, l.OTEL().String(v))
-		}
-	}
-
-	if span.Service.Features.SpanMetrics() {
-		sml, attrs := r.spanMetricsLatency.ForRecord(span, extraAttrs...)
-		sml.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-
-		smct, attrs := r.spanMetricsCallsTotal.ForRecord(span, extraAttrs...)
-		smct.Add(ctx, 1, instrument.WithAttributeSet(attrs))
-	}
-
-	if span.Service.Features.SpanSizes() {
-		smst, attrs := r.spanMetricsRequestSizeTotal.ForRecord(span, extraAttrs...)
-		smst.Add(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
-
-		smst, attr := r.spanMetricsResponseSizeTotal.ForRecord(span, extraAttrs...)
-		smst.Add(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attr))
-	}
-}
-
-// recordedAsNonHTTPClient reports whether an HTTP client span is published under the
-// database, RPC, or GenAI instruments rather than the HTTP ones. Those families carry no
-// body-size instrument, so such a span has no size to publish. It mirrors the dispatch
-// in recordDuration.
-func recordedAsNonHTTPClient(span *request.Span, mr *MetricsReporter) bool {
-	switch {
-	case mr.is.DBEnabled() &&
-		(span.SubType == request.HTTPSubtypeSQLPP || span.SubType == request.HTTPSubtypeElasticsearch):
-		return true
-	case span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled():
-		return true
-	case mr.is.GenAIEnabled() && request.IsGenAISubtype(span.SubType):
-		return true
-	default:
-		return false
-	}
-}
-
-// recordBodySizes publishes what the exchange carried. The request size is known
-// whatever came of the response, so it is published even when the duration is not. The
-// response size is not known: a record finished without its response carries a zeroed
-// length, and publishing that would report an empty response for a call whose response
-// was never seen.
-func (r *Metrics) recordBodySizes(span *request.Span, mr *MetricsReporter, ctx context.Context) {
-	if !mr.is.HTTPEnabled() {
-		return
-	}
-
-	var requestSize, responseSize *Expirer[*request.Span, instrument.Float64Histogram, float64]
-
-	switch span.Type {
-	case request.EventTypeHTTP:
-		// JSON-RPC over HTTP is recorded as an RPC call, which has no size instrument.
-		if span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled() {
-			return
-		}
-		requestSize, responseSize = r.httpRequestSize, r.httpResponseSize
-	case request.EventTypeHTTPClient:
-		if recordedAsNonHTTPClient(span, mr) {
-			return
-		}
-		requestSize, responseSize = r.httpClientRequestSize, r.httpClientResponseSize
-	default:
-		return
-	}
-
-	size, attrs := requestSize.ForRecord(span)
-	size.Record(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
-
-	if request.IgnoreDurations(span) {
-		return
-	}
-
-	size, attrs = responseSize.ForRecord(span)
-	size.Record(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attrs))
-}
-
-//nolint:cyclop
-func (r *Metrics) recordDuration(span *request.Span, mr *MetricsReporter, ctx context.Context, duration float64) {
-	switch span.Type {
-	case request.EventTypeHTTP:
-		// JSON-RPC over HTTP gets recorded as RPC server metrics
-		if span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled() {
-			grpcDuration, attrs := r.grpcDuration.ForRecord(span)
-			grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		} else if mr.is.HTTPEnabled() {
-			httpDuration, attrs := r.httpDuration.ForRecord(span)
-			httpDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeGRPC:
-		if mr.is.GRPCEnabled() {
-			grpcDuration, attrs := r.grpcDuration.ForRecord(span)
-			grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeGRPCClient:
-		if mr.is.GRPCEnabled() {
-			grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
-			grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeSunRPCClient:
-		if mr.is.SunRPCEnabled() {
-			grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
-			grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeSunRPCServer:
-		if mr.is.SunRPCEnabled() {
-			grpcDuration, attrs := r.grpcDuration.ForRecord(span)
-			grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeHTTPClient:
-		// HTTP client subtypes that are database calls get recorded as db client metrics
-		if mr.is.DBEnabled() && (span.SubType == request.HTTPSubtypeSQLPP || span.SubType == request.HTTPSubtypeElasticsearch) {
-			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		} else if span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled() {
-			// JSON-RPC client calls over HTTP get recorded as RPC client metrics
-			grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
-			grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		} else if span.SubType == request.HTTPSubtypeAWSS3 && mr.rpcClientRecorded() {
-			grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
-			grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		} else if span.SubType == request.HTTPSubtypeAWSSQS && request.IsSQSMessagingClientOperation(span) && mr.msgPublishRecorded() {
-			msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
-			msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		} else if mr.is.GenAIEnabled() && request.IsGenAISubtype(span.SubType) {
-			genAIClientDuration, attrs := r.genAIClientDuration.ForRecord(span)
-			genAIClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			if tokens, reported := span.GenAIInputTokenCount(); reported {
-				genAIInputTokenUsage, attrs := r.genAIInputTokenUsage.ForRecord(span)
-				genAIInputTokenUsage.Record(ctx, float64(tokens), instrument.WithAttributeSet(attrs))
+				// The response size is not known: a record finished without its
+				// response carries a zeroed length, and publishing that would
+				// report an empty response for a call whose response was never
+				// seen.
+				if measured {
+					httpResponseSize, attrs := r.httpResponseSize.ForRecord(span)
+					httpResponseSize.Record(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attrs))
+				}
 			}
-			if tokens, reported := span.GenAIOutputTokenCount(); reported {
-				genAIOutputTokenUsage, attrs := r.genAIOutputTokenUsage.ForRecord(span)
-				genAIOutputTokenUsage.Record(ctx, float64(tokens), instrument.WithAttributeSet(attrs))
+		case request.EventTypeGRPC:
+			if mr.is.GRPCEnabled() {
+				grpcDuration, attrs := r.grpcDuration.ForRecord(span)
+				grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 			}
-		} else if mr.is.HTTPEnabled() {
-			httpClientDuration, attrs := r.httpClientDuration.ForRecord(span)
-			httpClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeRedisClient:
-		if mr.is.RedisEnabled() {
-			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeRedisServer:
-		if mr.is.RedisEnabled() {
-			dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
-			dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeSQLClient:
-		if mr.is.SQLEnabled() {
-			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeSQLServer:
-		if mr.is.SQLEnabled() {
-			dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
-			dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeMongoClient:
-		if mr.is.MongoEnabled() {
-			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeCouchbaseClient:
-		if mr.is.CouchbaseEnabled() {
-			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeMemcachedClient:
-		if mr.is.MemcachedEnabled() {
-			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeMemcachedServer:
-		if mr.is.MemcachedEnabled() {
-			dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
-			dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeAerospikeClient:
-		if mr.is.AerospikeEnabled() {
-			dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
-			dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeKafkaClient, request.EventTypeKafkaServer:
-		if mr.is.KafkaEnabled() {
-			switch request.MessagingOperationTypeOf(span.Method) {
-			case request.MessagingSend:
-				msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
-				msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			case request.MessagingProcess:
-				msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
-				msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+		case request.EventTypeGRPCClient:
+			if mr.is.GRPCEnabled() {
+				grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
+				grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeSunRPCClient:
+			if mr.is.SunRPCEnabled() {
+				grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
+				grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeSunRPCServer:
+			if mr.is.SunRPCEnabled() {
+				grpcDuration, attrs := r.grpcDuration.ForRecord(span)
+				grpcDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeHTTPClient:
+			// HTTP client subtypes that are database calls get recorded as db client metrics
+			if mr.is.DBEnabled() && (span.SubType == request.HTTPSubtypeSQLPP || span.SubType == request.HTTPSubtypeElasticsearch) {
+				if measured {
+					dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+					dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
+			} else if span.SubType == request.HTTPSubtypeJSONRPC && mr.is.GRPCEnabled() {
+				if measured {
+					grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
+					grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
+			} else if span.SubType == request.HTTPSubtypeAWSS3 && mr.rpcClientRecorded() {
+				if measured {
+					grpcClientDuration, attrs := r.grpcClientDuration.ForRecord(span)
+					grpcClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
+			} else if span.SubType == request.HTTPSubtypeAWSSQS && request.IsSQSMessagingClientOperation(span) && mr.msgPublishRecorded() {
+				if measured {
+					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
+					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
+			} else if mr.is.GenAIEnabled() && request.IsGenAISubtype(span.SubType) {
+				if measured {
+					genAIClientDuration, attrs := r.genAIClientDuration.ForRecord(span)
+					genAIClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+					if tokens, reported := span.GenAIInputTokenCount(); reported {
+						genAIInputTokenUsage, attrs := r.genAIInputTokenUsage.ForRecord(span)
+						genAIInputTokenUsage.Record(ctx, float64(tokens), instrument.WithAttributeSet(attrs))
+					}
+					if tokens, reported := span.GenAIOutputTokenCount(); reported {
+						genAIOutputTokenUsage, attrs := r.genAIOutputTokenUsage.ForRecord(span)
+						genAIOutputTokenUsage.Record(ctx, float64(tokens), instrument.WithAttributeSet(attrs))
+					}
+				}
+			} else if mr.is.HTTPEnabled() {
+				if measured {
+					httpClientDuration, attrs := r.httpClientDuration.ForRecord(span)
+					httpClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
+
+				httpClientRequestSize, attrs := r.httpClientRequestSize.ForRecord(span)
+				httpClientRequestSize.Record(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
+
+				if measured {
+					httpClientResponseSize, attrs := r.httpClientResponseSize.ForRecord(span)
+					httpClientResponseSize.Record(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attrs))
+				}
+			}
+		case request.EventTypeRedisClient:
+			if mr.is.RedisEnabled() {
+				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeRedisServer:
+			if mr.is.RedisEnabled() {
+				dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
+				dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeSQLClient:
+			if mr.is.SQLEnabled() {
+				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeSQLServer:
+			if mr.is.SQLEnabled() {
+				dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
+				dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeMongoClient:
+			if mr.is.MongoEnabled() {
+				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeCouchbaseClient:
+			if mr.is.CouchbaseEnabled() {
+				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeMemcachedClient:
+			if mr.is.MemcachedEnabled() {
+				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeMemcachedServer:
+			if mr.is.MemcachedEnabled() {
+				dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
+				dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeAerospikeClient:
+			if mr.is.AerospikeEnabled() {
+				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
+				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeKafkaClient, request.EventTypeKafkaServer:
+			if mr.is.KafkaEnabled() {
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
+					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
+					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				case request.MessagingProcess:
+					msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
+					msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
+			}
+		case request.EventTypeMQTTClient, request.EventTypeMQTTServer:
+			if mr.is.MQTTEnabled() {
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
+					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
+					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				case request.MessagingProcess:
+					msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
+					msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
+			}
+		case request.EventTypeNATSClient, request.EventTypeNATSServer:
+			if mr.is.NATSEnabled() {
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
+					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
+					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				case request.MessagingProcess:
+					msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
+					msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
+			}
+		case request.EventTypeAMQPClient:
+			if mr.is.AMQPEnabled() {
+				switch request.MessagingOperationTypeOf(span.Method) {
+				case request.MessagingSend:
+					msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
+					msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				case request.MessagingProcess:
+					msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
+					msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+				}
+			}
+		case request.EventTypeGPUCudaKernelLaunch:
+			if mr.is.GPUEnabled() {
+				gcalls, attrs := r.gpuKernelCallsTotal.ForRecord(span)
+				gcalls.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+
+				ggrid, attrs := r.gpuKernelGridSize.ForRecord(span)
+				ggrid.Record(ctx, float64(span.ContentLength), instrument.WithAttributeSet(attrs))
+
+				gblock, attrs := r.gpuKernelBlockSize.ForRecord(span)
+				gblock.Record(ctx, float64(span.SubType), instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeGPUCudaMalloc:
+			if mr.is.GPUEnabled() {
+				gmem, attrs := r.gpuMemoryAllocsTotal.ForRecord(span)
+				gmem.Add(ctx, span.ContentLength, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeGPUCudaGraphLaunch:
+			if mr.is.GPUEnabled() {
+				ggraph, attrs := r.gpuGraphCallsTotal.ForRecord(span)
+				ggraph.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeGPUCudaMemcpy:
+			if mr.is.GPUEnabled() {
+				gmem, attrs := r.gpuMemoryCopySize.ForRecord(span)
+				gmem.Record(r.ctx, float64(span.ContentLength), instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeDNS:
+			if mr.is.DNSEnabled() {
+				dnsDuration, attrs := r.dnsLookupDuration.ForRecord(span)
+				dnsDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 			}
 		}
-	case request.EventTypeMQTTClient, request.EventTypeMQTTServer:
-		if mr.is.MQTTEnabled() {
-			switch request.MessagingOperationTypeOf(span.Method) {
-			case request.MessagingSend:
-				msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
-				msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			case request.MessagingProcess:
-				msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
-				msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		}
-	case request.EventTypeNATSClient, request.EventTypeNATSServer:
-		if mr.is.NATSEnabled() {
-			switch request.MessagingOperationTypeOf(span.Method) {
-			case request.MessagingSend:
-				msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
-				msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			case request.MessagingProcess:
-				msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
-				msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		}
-	case request.EventTypeAMQPClient:
-		if mr.is.AMQPEnabled() {
-			switch request.MessagingOperationTypeOf(span.Method) {
-			case request.MessagingSend:
-				msgPublishDuration, attrs := r.msgPublishDuration.ForRecord(span)
-				msgPublishDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			case request.MessagingProcess:
-				msgProcessDuration, attrs := r.msgProcessDuration.ForRecord(span)
-				msgProcessDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
-			}
-		}
-	case request.EventTypeGPUCudaKernelLaunch:
-		if mr.is.GPUEnabled() {
-			gcalls, attrs := r.gpuKernelCallsTotal.ForRecord(span)
-			gcalls.Add(ctx, 1, instrument.WithAttributeSet(attrs))
+	}
 
-			ggrid, attrs := r.gpuKernelGridSize.ForRecord(span)
-			ggrid.Record(ctx, float64(span.ContentLength), instrument.WithAttributeSet(attrs))
+	// The calls counter is separable from the latency histogram, but the two are read
+	// together, so feeding one alone makes the pair disagree. Both stay out when the
+	// duration is withheld.
+	if measured && otelSpanMetricsAccepted(span) {
+		var extraAttrs []attribute.KeyValue
 
-			gblock, attrs := r.gpuKernelBlockSize.ForRecord(span)
-			gblock.Record(ctx, float64(span.SubType), instrument.WithAttributeSet(attrs))
+		for _, l := range mr.spanExtraAttrs {
+			if v, ok := span.Service.Metadata[l]; ok {
+				extraAttrs = append(extraAttrs, l.OTEL().String(v))
+			}
 		}
-	case request.EventTypeGPUCudaMalloc:
-		if mr.is.GPUEnabled() {
-			gmem, attrs := r.gpuMemoryAllocsTotal.ForRecord(span)
-			gmem.Add(ctx, span.ContentLength, instrument.WithAttributeSet(attrs))
+
+		if span.Service.Features.SpanMetrics() {
+			sml, attrs := r.spanMetricsLatency.ForRecord(span, extraAttrs...)
+			sml.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+
+			smct, attrs := r.spanMetricsCallsTotal.ForRecord(span, extraAttrs...)
+			smct.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 		}
-	case request.EventTypeGPUCudaGraphLaunch:
-		if mr.is.GPUEnabled() {
-			ggraph, attrs := r.gpuGraphCallsTotal.ForRecord(span)
-			ggraph.Add(ctx, 1, instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeGPUCudaMemcpy:
-		if mr.is.GPUEnabled() {
-			gmem, attrs := r.gpuMemoryCopySize.ForRecord(span)
-			gmem.Record(r.ctx, float64(span.ContentLength), instrument.WithAttributeSet(attrs))
-		}
-	case request.EventTypeDNS:
-		if mr.is.DNSEnabled() {
-			dnsDuration, attrs := r.dnsLookupDuration.ForRecord(span)
-			dnsDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+
+		if span.Service.Features.SpanSizes() {
+			smst, attrs := r.spanMetricsRequestSizeTotal.ForRecord(span, extraAttrs...)
+			smst.Add(ctx, float64(span.RequestBodyLength()), instrument.WithAttributeSet(attrs))
+
+			smst, attr := r.spanMetricsResponseSizeTotal.ForRecord(span, extraAttrs...)
+			smst.Add(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attr))
 		}
 	}
 }

--- a/pkg/export/otel/metrics_svc_graph.go
+++ b/pkg/export/otel/metrics_svc_graph.go
@@ -353,6 +353,11 @@ func (r *SvcGraphMetrics) record(span *request.Span, mr *SvcGraphMetricsReporter
 	t := span.Timings()
 	duration := t.End.Sub(t.RequestStart).Seconds()
 
+	// The request counter is its own instrument, so a span whose duration was never
+	// measured still counts on the edge it traveled. Dropping it would erase an edge
+	// where every call goes unobserved. Only the two histograms are withheld.
+	durationMeasured := !request.IgnoreDurations(span)
+
 	ctx := trace.ContextWithSpanContext(r.ctx, trace.SpanContext{}.WithTraceID(span.TraceID).WithSpanID(span.SpanID).WithTraceFlags(trace.TraceFlags(span.TraceFlags)))
 
 	if !span.IsSelfReferenceSpan() || mr.cfg.AllowServiceGraphSelfReferences {
@@ -365,8 +370,10 @@ func (r *SvcGraphMetrics) record(span *request.Span, mr *SvcGraphMetricsReporter
 		}
 
 		if span.IsClientSpan() {
-			sgc, attrs := r.serviceGraphClient.ForRecord(span, connType...)
-			sgc.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			if durationMeasured {
+				sgc, attrs := r.serviceGraphClient.ForRecord(span, connType...)
+				sgc.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
 			// If we managed to resolve the remote name only, we check to see
 			// we are not instrumenting the server service, then and only then,
 			// we generate client span count for service graph total
@@ -375,11 +382,14 @@ func (r *SvcGraphMetrics) record(span *request.Span, mr *SvcGraphMetricsReporter
 				sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 			}
 		} else {
-			sgs, attrs := r.serviceGraphServer.ForRecord(span, connType...)
-			sgs.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			if durationMeasured {
+				sgs, attrs := r.serviceGraphServer.ForRecord(span, connType...)
+				sgs.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
 			sgt, attrs := r.serviceGraphTotal.ForRecord(span, connType...)
 			sgt.Add(ctx, 1, instrument.WithAttributeSet(attrs))
 		}
+		// An unmeasured span has status Unset, so it never counts against the edge.
 		if request.SpanStatusCode(span) == request.StatusCodeError {
 			sgf, attrs := r.serviceGraphFailed.ForRecord(span, connType...)
 			sgf.Add(ctx, 1, instrument.WithAttributeSet(attrs))

--- a/pkg/export/otel/metrics_svc_graph_test.go
+++ b/pkg/export/otel/metrics_svc_graph_test.go
@@ -157,3 +157,81 @@ func makeSvcGraphExporter(
 
 	return otelExporter
 }
+
+// The exclusion this replaces dropped the span entirely, which erases an edge where
+// every call goes unobserved.
+func TestServiceGraphMetrics_UnknownOutcomeIsCountedWithoutADuration(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer otelcfg.RestoreEnvAfterExecution()()
+
+	ctx := t.Context()
+
+	otlp, err := collector.Start(ctx)
+	require.NoError(t, err)
+
+	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+
+	otelExporter := makeSvcGraphExporter(ctx, t, otlp, metrics, processEvents)
+	go func() {
+		otelExporter(ctx)
+	}()
+
+	clientID := svc.Attrs{Features: export.FeatureAll, ProcPID: 33, UID: svc.UID{Name: "client", Instance: "the-client"}}
+
+	processEvents.Send(exec.ProcessEvent{
+		Type: exec.ProcessEventCreated,
+		File: exec.New(exec.Init{Service: clientID, Pid: clientID.ProcPID}),
+	})
+
+	// The peer is not instrumented, which is the case the client-side request
+	// counter exists for.
+	unobserved := request.Span{
+		Service: clientID, Type: request.EventTypeHTTPClient,
+		Peer: "client-host", Host: "unobserved-peer", HostName: "unobserved-peer",
+		Path: "/r", RequestStart: 100, End: 6_000_000_000,
+		ResponseObservation: request.ResponseReceived,
+	}
+	request.SetIgnoreDurations(&unobserved)
+
+	// The control travels the identical path and differs only in having been observed.
+	observed := request.Span{
+		Service: clientID, Type: request.EventTypeHTTPClient,
+		Peer: "client-host", Host: "observed-peer", HostName: "observed-peer",
+		Path: "/r", RequestStart: 100, End: 200, Status: 200,
+	}
+
+	metrics.Send([]request.Span{unobserved, observed})
+
+	res := readNChan(t, otlp.Records(), 3, timeout)
+	// readNChan stops at three and leaves anything further on the channel, so keep
+	// reading: a fourth record is the regression the absence assertions below are
+	// looking for. The reader re-exports on an interval, so this collects for a fixed
+	// window rather than waiting for the channel to fall quiet, which it never does.
+	collect := time.After(500 * time.Millisecond)
+drain:
+	for {
+		select {
+		case m := <-otlp.Records():
+			res = append(res, m)
+		case <-collect:
+			break drain
+		}
+	}
+	reported := map[string]struct{}{}
+	for _, m := range res {
+		reported[m.Name+":"+m.Attributes["server"]] = struct{}{}
+	}
+
+	// The control proves the edge is drawn at all, so an absent histogram below means
+	// the latency was withheld.
+	assert.Contains(t, reported, "traces_service_graph_request_client:observed-peer")
+	assert.Contains(t, reported, "traces_service_graph_request_total:observed-peer")
+
+	assert.Contains(t, reported, "traces_service_graph_request_total:unobserved-peer",
+		"the call happened, so the edge it traveled is counted")
+	assert.NotContains(t, reported, "traces_service_graph_request_client:unobserved-peer",
+		"its duration is not a measurement, so it lands in no latency histogram")
+	assert.NotContains(t, reported, "traces_service_graph_request_failed_total:unobserved-peer",
+		"nothing was observed to fail, so it is never counted against the edge")
+}

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -2033,3 +2033,57 @@ func resourcesMatch(t *testing.T, one *TargetMetrics, two *TargetMetrics) {
 		assert.Equal(t, a.Value.AsString(), other.AsString())
 	}
 }
+
+// The OTel counterpart of the Prometheus case: a call whose response was never observed
+// publishes the size of the request it sent, and neither a duration nor a response size,
+// which it does not know.
+func TestAppMetrics_UnmeasuredSpanPublishesRequestSizeOnly(t *testing.T) {
+	ctx := t.Context()
+
+	otlp, err := collector.Start(ctx)
+	require.NoError(t, err)
+
+	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	feats := export.FeatureApplicationRED
+	go makeMetricsReporter(ctx, t,
+		[]instrumentations.Instrumentation{instrumentations.InstrumentationALL},
+		feats, otlp, metrics, processEvents).reportMetrics(ctx)
+
+	unmeasured := request.Span{
+		Service:             svc.Attrs{Features: feats, UID: svc.UID{Instance: "foo"}},
+		Type:                request.EventTypeHTTPClient,
+		Method:              "GET",
+		Route:               "/unmeasured",
+		RequestStart:        100,
+		End:                 6 * time.Second.Nanoseconds(),
+		ContentLength:       512,
+		ResponseObservation: request.ResponseReceived,
+	}
+	request.SetIgnoreDurations(&unmeasured)
+
+	metrics.Send([]request.Span{unmeasured})
+
+	// One record is expected. Drain briefly afterwards so an instrument that should
+	// have stayed out has a chance to show up and fail the assertion.
+	published := map[string]struct{}{}
+	for _, r := range readNChan(t, otlp.Records(), 1, timeout) {
+		published[r.Name] = struct{}{}
+	}
+	drain := time.After(500 * time.Millisecond)
+	for draining := true; draining; {
+		select {
+		case r := <-otlp.Records():
+			published[r.Name] = struct{}{}
+		case <-drain:
+			draining = false
+		}
+	}
+
+	assert.Contains(t, published, "http.client.request.body.size",
+		"the size of the request that was sent is known and must be reported")
+	assert.NotContains(t, published, "http.client.request.duration",
+		"a duration that runs past the request it describes was published")
+	assert.NotContains(t, published, "http.client.response.body.size",
+		"a response nobody saw was reported as having a size")
+}

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -1219,6 +1219,52 @@ func TestAppMetrics_TracesHostInfo(t *testing.T) {
 	}, timeout, 100*time.Millisecond)
 }
 
+// The gauge reports that the host is running. A service whose every call ended
+// without a usable duration still runs, so the only traffic being unmeasured must
+// not withhold it.
+func TestAppMetrics_TracesHostInfoUnmeasuredSpans(t *testing.T) {
+	ctx := t.Context()
+
+	otlp, err := collector.Start(ctx)
+	require.NoError(t, err)
+
+	now := syncedClock{now: time.Now()}
+	timeNow = now.Now
+
+	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(20))
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	feats := export.FeatureApplicationRED | export.FeatureApplicationHost
+	mr := makeMetricsReporter(ctx, t, []instrumentations.Instrumentation{instrumentations.InstrumentationHTTP}, feats, otlp, metrics, processEvents)
+	go mr.reportMetrics(ctx)
+
+	processEvents.Send(exec.ProcessEvent{
+		Type: exec.ProcessEventCreated,
+		File: exec.New(exec.Init{
+			Service: svc.Attrs{
+				Features: feats,
+				UID:      svc.UID{Instance: "foo"},
+			},
+		}),
+	})
+
+	unmeasured := request.Span{
+		Service:             svc.Attrs{Features: feats, UID: svc.UID{Instance: "foo"}},
+		Type:                request.EventTypeHTTPClient,
+		Path:                "/foo",
+		RequestStart:        100,
+		End:                 200,
+		ResponseObservation: request.ResponseReceived,
+	}
+	request.SetIgnoreDurations(&unmeasured)
+
+	metrics.Send([]request.Span{unmeasured})
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.NotEmpty(ct, mr.hostInfo.entries.All(),
+			"traces.host.info metric has not been created for a service whose only calls were unmeasured")
+	}, timeout, 100*time.Millisecond)
+}
+
 func TestMetricResourceAttributes(t *testing.T) {
 	// Test different filtering scenarios
 	testCases := []struct {

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -571,6 +571,16 @@ func httpClientTransportScope(subType int) httpTransportScope {
 	}
 }
 
+// appendHTTPResponseStatus reports the status only when one was seen: semconv requires
+// http.response.status_code "if and only if one was received/sent".
+func appendHTTPResponseStatus(attrs []attribute.KeyValue, span *request.Span) []attribute.KeyValue {
+	if span.ResponseObservation == request.ResponseParsed {
+		return append(attrs, request.HTTPResponseStatusCode(span.Status))
+	}
+
+	return append(attrs, attribute.Bool(string(attr.OBIHTTPResponseObserved), false))
+}
+
 //nolint:cyclop
 func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.Name]struct{}, redactSet map[string]struct{}) []attribute.KeyValue {
 	var attrs []attribute.KeyValue
@@ -578,13 +588,13 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 	switch span.Type {
 	case request.EventTypeHTTP:
 		attrs = []attribute.KeyValue{
-			request.HTTPResponseStatusCode(span.Status),
 			request.ClientAddr(request.PeerAsClient(span)),
 			request.ServerAddr(request.SpanHost(span)),
 			request.ServerPort(span.HostPort),
 			request.HTTPRequestBodySize(int(span.RequestBodyLength())),
 			request.HTTPResponseBodySize(span.ResponseBodyLength()),
 		}
+		attrs = appendHTTPResponseStatus(attrs, span)
 		if span.Method != "" {
 			attrs = append(attrs, request.HTTPRequestMethod(span.Method))
 		}
@@ -697,8 +707,8 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		}
 
 		if transport == httpTransportAll {
+			attrs = appendHTTPResponseStatus(attrs, span)
 			attrs = append(attrs,
-				request.HTTPResponseStatusCode(span.Status),
 				semconv.URLScheme(scheme),
 				request.HTTPRequestBodySize(int(span.RequestBodyLength())),
 				request.HTTPResponseBodySize(span.ResponseBodyLength()),

--- a/pkg/export/otel/tracesgen/tracesgen_response_observation_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_response_observation_test.go
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tracesgen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
+)
+
+func hasAttributeKey(attrs []attribute.KeyValue, key attribute.Key) bool {
+	for _, kv := range attrs {
+		if kv.Key == key {
+			return true
+		}
+	}
+
+	return false
+}
+
+// A response that was never observed was never received, so semconv forbids the
+// attribute.
+func TestTraceAttributesSelector_UnparsedResponseOmitsStatusCode(t *testing.T) {
+	statusCode := attribute.Key(attr.HTTPResponseStatusCode)
+	observed := attribute.Key(attr.OBIHTTPResponseObserved)
+
+	for _, eventType := range []request.EventType{request.EventTypeHTTPClient, request.EventTypeHTTP} {
+		span := &request.Span{
+			Type:                eventType,
+			Method:              "GET",
+			Path:                "/r",
+			Host:                "relay",
+			HostPort:            9100,
+			ResponseObservation: request.ResponseReceived,
+		}
+
+		attrs := TraceAttributesSelector(span, map[attr.Name]struct{}{})
+
+		assert.False(t, hasAttributeKey(attrs, statusCode),
+			"%s: no status code is reported when none was observed", eventType)
+		assert.Contains(t, attrs, attribute.Bool(string(observed), false),
+			"%s: the span says the response was not observed", eventType)
+	}
+}
+
+// No span on this path names an error type.
+func TestTraceAttributesSelector_UnknownOutcomeNamesNoError(t *testing.T) {
+	errorType := attribute.Key(attr.ErrorType)
+
+	for _, eventType := range []request.EventType{request.EventTypeHTTPClient, request.EventTypeHTTP} {
+		span := &request.Span{
+			Type:                eventType,
+			Method:              "GET",
+			Path:                "/r",
+			Host:                "relay",
+			HostPort:            9100,
+			ResponseObservation: request.ResponseReceived,
+		}
+
+		attrs := TraceAttributesSelector(span, map[attr.Name]struct{}{})
+
+		assert.False(t, hasAttributeKey(attrs, errorType),
+			"%s: a span nobody judged names no error", eventType)
+	}
+}
+
+// The control. An ordinary request reports its status and says nothing about
+// observation.
+func TestTraceAttributesSelector_ObservedResponseKeepsStatusCode(t *testing.T) {
+	observed := attribute.Key(attr.OBIHTTPResponseObserved)
+
+	for _, eventType := range []request.EventType{request.EventTypeHTTPClient, request.EventTypeHTTP} {
+		span := &request.Span{
+			Type:     eventType,
+			Method:   "GET",
+			Path:     "/r",
+			Host:     "relay",
+			HostPort: 9100,
+			Status:   200,
+		}
+
+		attrs := TraceAttributesSelector(span, map[attr.Name]struct{}{})
+
+		assert.Contains(t, attrs, request.HTTPResponseStatusCode(200), eventType)
+		assert.False(t, hasAttributeKey(attrs, observed),
+			"%s: the observation marker is additive and absent on a normal span", eventType)
+	}
+}

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -972,8 +972,11 @@ func (r *metricsReporter) collectMetrics(ctx context.Context) {
 	})
 }
 
+// otelMetricsObserved gates the RED series. A span with no measured duration stays out,
+// body-size histograms included: those buckets are only meaningful next to a duration.
 func (r *metricsReporter) otelMetricsObserved(span *request.Span) bool {
-	return span.Service.Features.AppRED() && !span.Service.ExportsOTelMetrics()
+	return span.Service.Features.AppRED() && !span.Service.ExportsOTelMetrics() &&
+		!request.IgnoreDurations(span)
 }
 
 func (r *metricsReporter) otelSpanMetricsObserved(span *request.Span) bool {
@@ -1218,13 +1221,17 @@ func (r *metricsReporter) observe(span *request.Span) {
 	}
 
 	if r.otelSpanMetricsObserved(span) {
-		if span.Service.Features.SpanMetrics() {
+		// The calls counter is separable from the latency histogram, but the two are
+		// read together, so feeding one alone makes the pair disagree.
+		durationMeasured := !request.IgnoreDurations(span)
+
+		if span.Service.Features.SpanMetrics() && durationMeasured {
 			lv := r.labelValuesSpans(span)
 			r.observeHistogram(r.spanMetricsLatency.WithLabelValues(lv...).Metric, duration, span)
 			r.addCounter(r.spanMetricsCallsTotal.WithLabelValues(lv...).Metric, 1, span)
 		}
 
-		if span.Service.Features.SpanSizes() {
+		if span.Service.Features.SpanSizes() && durationMeasured {
 			lv := r.labelValuesSpans(span)
 			r.addCounter(r.spanMetricsRequestSizeTotal.WithLabelValues(lv...).Metric, float64(span.RequestBodyLength()), span)
 			r.addCounter(r.spanMetricsResponseSizeTotal.WithLabelValues(lv...).Metric, float64(span.ResponseBodyLength()), span)
@@ -1234,8 +1241,12 @@ func (r *metricsReporter) observe(span *request.Span) {
 			if !span.IsSelfReferenceSpan() || r.cfg.AllowServiceGraphSelfReferences {
 				lvg := labelValuesSvcGraph(span, r.attrSvcGraph, &r.pidsTracker)
 
+				// The request counter is its own instrument, so an unmeasured span
+				// still counts on its edge. Only the latency is withheld.
 				if span.IsClientSpan() {
-					r.observeHistogram(r.serviceGraphClient.WithLabelValues(lvg...).Metric, duration, span)
+					if durationMeasured {
+						r.observeHistogram(r.serviceGraphClient.WithLabelValues(lvg...).Metric, duration, span)
+					}
 					// If we managed to resolve the remote name only, we check to see
 					// we are not instrumenting the server service, then and only then,
 					// we generate client span count for service graph total
@@ -1243,9 +1254,13 @@ func (r *metricsReporter) observe(span *request.Span) {
 						r.addCounter(r.serviceGraphTotal.WithLabelValues(lvg...).Metric, 1, span)
 					}
 				} else {
-					r.observeHistogram(r.serviceGraphServer.WithLabelValues(lvg...).Metric, duration, span)
+					if durationMeasured {
+						r.observeHistogram(r.serviceGraphServer.WithLabelValues(lvg...).Metric, duration, span)
+					}
 					r.addCounter(r.serviceGraphTotal.WithLabelValues(lvg...).Metric, 1, span)
 				}
+				// An unmeasured span has status Unset, so it never counts against
+				// the edge.
 				if request.SpanStatusCode(span) == request.StatusCodeError {
 					r.addCounter(r.serviceGraphFailed.WithLabelValues(lvg...).Metric, 1, span)
 				}

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -972,11 +972,68 @@ func (r *metricsReporter) collectMetrics(ctx context.Context) {
 	})
 }
 
-// otelMetricsObserved gates the RED series. A span with no measured duration stays out,
-// body-size histograms included: those buckets are only meaningful next to a duration.
+// recordedAsNonHTTPClient reports whether an HTTP client span is published under the
+// database, RPC, or GenAI instruments rather than the HTTP ones. Those families carry no
+// body-size instrument, so such a span has no size to publish. It mirrors the dispatch in
+// the duration switch.
+func (r *metricsReporter) recordedAsNonHTTPClient(span *request.Span) bool {
+	switch {
+	case r.is.DBEnabled() &&
+		(span.SubType == request.HTTPSubtypeSQLPP || span.SubType == request.HTTPSubtypeElasticsearch):
+		return true
+	case span.SubType == request.HTTPSubtypeJSONRPC && r.is.GRPCEnabled():
+		return true
+	case r.is.GenAIEnabled() && request.IsGenAISubtype(span.SubType):
+		return true
+	default:
+		return false
+	}
+}
+
+// observeBodySizes publishes what the exchange carried. The request size is known
+// whatever came of the response, so it is published even when the duration is not. The
+// response size is not known: a record finished without its response carries a zeroed
+// length, and publishing that would report an empty response for a call whose response
+// was never seen.
+func (r *metricsReporter) observeBodySizes(span *request.Span) {
+	if !r.is.HTTPEnabled() {
+		return
+	}
+
+	var requestSize, responseSize *Expirer[prometheus.Histogram]
+	var requestAttrs, responseAttrs []attributes.Field[*request.Span, string]
+
+	switch span.Type {
+	case request.EventTypeHTTP:
+		// JSON-RPC over HTTP is recorded as an RPC call, which has no size instrument.
+		if span.SubType == request.HTTPSubtypeJSONRPC && r.is.GRPCEnabled() {
+			return
+		}
+		requestSize, responseSize = r.httpRequestSize, r.httpResponseSize
+		requestAttrs, responseAttrs = r.attrHTTPRequestSize, r.attrHTTPResponseSize
+	case request.EventTypeHTTPClient:
+		if r.recordedAsNonHTTPClient(span) {
+			return
+		}
+		requestSize, responseSize = r.httpClientRequestSize, r.httpClientResponseSize
+		requestAttrs, responseAttrs = r.attrHTTPClientRequestSize, r.attrHTTPClientResponseSize
+	default:
+		return
+	}
+
+	r.observeHistogram(requestSize.WithLabelValues(labelValues(span, requestAttrs)...).Metric,
+		float64(span.RequestBodyLength()), span)
+
+	if request.IgnoreDurations(span) {
+		return
+	}
+
+	r.observeHistogram(responseSize.WithLabelValues(labelValues(span, responseAttrs)...).Metric,
+		float64(span.ResponseBodyLength()), span)
+}
+
 func (r *metricsReporter) otelMetricsObserved(span *request.Span) bool {
-	return span.Service.Features.AppRED() && !span.Service.ExportsOTelMetrics() &&
-		!request.IgnoreDurations(span)
+	return span.Service.Features.AppRED() && !span.Service.ExportsOTelMetrics()
 }
 
 func (r *metricsReporter) otelSpanMetricsObserved(span *request.Span) bool {
@@ -1067,6 +1124,14 @@ func (r *metricsReporter) observe(span *request.Span) {
 	duration := t.End.Sub(t.RequestStart).Seconds()
 
 	if r.otelMetricsObserved(span) {
+		// A record finished without its response ends when something other than the
+		// response ended it, so its duration describes more than the request it names.
+		// Every instrument in the switch stands on that duration; the body sizes do
+		// not, and are recorded on their own terms.
+		r.observeBodySizes(span)
+	}
+
+	if r.otelMetricsObserved(span) && !request.IgnoreDurations(span) {
 		switch span.Type {
 		case request.EventTypeHTTP:
 			// JSON-RPC over HTTP gets recorded as RPC server metrics
@@ -1074,8 +1139,6 @@ func (r *metricsReporter) observe(span *request.Span) {
 				r.observeHistogram(r.grpcDuration.WithLabelValues(labelValues(span, r.attrGRPCDuration)...).Metric, duration, span)
 			} else if r.is.HTTPEnabled() {
 				r.observeHistogram(r.httpDuration.WithLabelValues(labelValues(span, r.attrHTTPDuration)...).Metric, duration, span)
-				r.observeHistogram(r.httpRequestSize.WithLabelValues(labelValues(span, r.attrHTTPRequestSize)...).Metric, float64(span.RequestBodyLength()), span)
-				r.observeHistogram(r.httpResponseSize.WithLabelValues(labelValues(span, r.attrHTTPResponseSize)...).Metric, float64(span.ResponseBodyLength()), span)
 			}
 		case request.EventTypeHTTPClient:
 			// HTTP client subtypes that are database calls get recorded as db client metrics
@@ -1099,8 +1162,6 @@ func (r *metricsReporter) observe(span *request.Span) {
 			default:
 				if r.is.HTTPEnabled() {
 					r.observeHistogram(r.httpClientDuration.WithLabelValues(labelValues(span, r.attrHTTPClientDuration)...).Metric, duration, span)
-					r.observeHistogram(r.httpClientRequestSize.WithLabelValues(labelValues(span, r.attrHTTPClientRequestSize)...).Metric, float64(span.RequestBodyLength()), span)
-					r.observeHistogram(r.httpClientResponseSize.WithLabelValues(labelValues(span, r.attrHTTPClientResponseSize)...).Metric, float64(span.ResponseBodyLength()), span)
 				}
 			}
 		case request.EventTypeGRPC:

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -1526,7 +1526,7 @@ func TestOverridingCloudHostIDKey(t *testing.T) {
 // A span with no measured duration stays out of the RED series, whose buckets are only
 // meaningful next to a duration. otelSpanFiltered still passes it, so the service graph
 // can count the call.
-func TestREDMetricsExcludeSpansWithNoMeasuredDuration(t *testing.T) {
+func TestREDMetricsWithholdDurationsFromUnmeasuredSpans(t *testing.T) {
 	mr := metricsReporter{cfg: &PrometheusConfig{}}
 
 	svcRED := svc.Attrs{Features: export.FeatureApplicationRED}
@@ -1545,8 +1545,71 @@ func TestREDMetricsExcludeSpansWithNoMeasuredDuration(t *testing.T) {
 
 	assert.True(t, mr.otelMetricsObserved(&measured),
 		"an observed call is in the RED series")
-	assert.False(t, mr.otelMetricsObserved(&unmeasured),
-		"a call with no measured duration is not in the RED series")
+	assert.True(t, mr.otelMetricsObserved(&unmeasured),
+		"a call with no measured duration is still in the RED family: the request it sent "+
+			"has a known size even though its duration says more than the request")
 	assert.False(t, mr.otelSpanFiltered(&unmeasured),
 		"it is withheld from durations, not filtered out of every metric")
+}
+
+// A call whose response was never observed still sent a request, and the size of that
+// request is known. Withholding the duration must not withhold what the request itself
+// carried. The response size stays out: an unmeasured record carries a zeroed response
+// length, and publishing it would report an empty response for a call whose response was
+// never seen.
+func TestREDMetricsUnmeasuredSpanPublishesRequestSizeOnly(t *testing.T) {
+	ctx := t.Context()
+	openPort := testutil.FreeTCPPort(t)
+	promURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", openPort)
+
+	promInput := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(20))
+	exporter, err := PrometheusEndpoint(
+		&global.ContextInfo{Prometheus: &connector.PrometheusManager{}},
+		&PrometheusConfig{
+			Port:                        openPort,
+			Path:                        "/metrics",
+			TTL:                         3 * time.Minute,
+			SpanMetricsServiceCacheSize: 10,
+			Instrumentations:            []instrumentations.Instrumentation{instrumentations.InstrumentationALL},
+		},
+		&perapp.GlobalMetricsConfig{Features: export.FeatureApplicationRED},
+		&attributes.SelectorConfig{SelectionCfg: attributes.Selection{}},
+		request.UnresolvedNames{},
+		promInput,
+		processEvents,
+		nil,
+	)(ctx)
+	require.NoError(t, err)
+
+	go exporter(ctx)
+
+	svcAttrs := svc.Attrs{
+		Features: export.FeatureApplicationRED,
+		UID:      svc.UID{Name: "test-app", Namespace: "default", Instance: "test-app-1"},
+	}
+
+	unmeasured := request.Span{
+		Service:             svcAttrs,
+		Type:                request.EventTypeHTTPClient,
+		Method:              "GET",
+		Route:               "/unmeasured",
+		RequestStart:        100,
+		End:                 6 * time.Second.Nanoseconds(),
+		ContentLength:       512,
+		ResponseObservation: request.ResponseReceived,
+	}
+	request.SetIgnoreDurations(&unmeasured)
+
+	promInput.Send([]request.Span{unmeasured})
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		exported := getMetrics(ct, promURL)
+		assert.Contains(ct, exported, "http_client_request_body_size_bytes_count",
+			"the size of the request that was sent is known and must be reported")
+		assert.NotContains(ct, exported, "http_client_request_duration_seconds_count",
+			"a duration that runs past the request it describes was published")
+		assert.NotContains(ct, exported, "http_client_response_body_size_bytes_count",
+			"a response nobody saw was reported as having a size")
+	}, timeout, 100*time.Millisecond)
 }

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -1522,3 +1522,31 @@ func TestOverridingCloudHostIDKey(t *testing.T) {
 		assert.Regexp(ct, containsTracesHostInfo, exported)
 	}, timeout, 10*time.Millisecond)
 }
+
+// A span with no measured duration stays out of the RED series, whose buckets are only
+// meaningful next to a duration. otelSpanFiltered still passes it, so the service graph
+// can count the call.
+func TestREDMetricsExcludeSpansWithNoMeasuredDuration(t *testing.T) {
+	mr := metricsReporter{cfg: &PrometheusConfig{}}
+
+	svcRED := svc.Attrs{Features: export.FeatureApplicationRED}
+
+	unmeasured := request.Span{
+		Service: svcRED, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/r",
+		RequestStart: 100, End: 6_000_000_000, ResponseObservation: request.ResponseReceived,
+	}
+	request.SetIgnoreDurations(&unmeasured)
+
+	// The control differs only in having been observed.
+	measured := request.Span{
+		Service: svcRED, Type: request.EventTypeHTTPClient, Method: "GET", Route: "/r",
+		RequestStart: 100, End: 200, Status: 200,
+	}
+
+	assert.True(t, mr.otelMetricsObserved(&measured),
+		"an observed call is in the RED series")
+	assert.False(t, mr.otelMetricsObserved(&unmeasured),
+		"a call with no measured duration is not in the RED series")
+	assert.False(t, mr.otelSpanFiltered(&unmeasured),
+		"it is withheld from durations, not filtered out of every metric")
+}

--- a/schemas/obi/groups/traces.yaml
+++ b/schemas/obi/groups/traces.yaml
@@ -57,3 +57,11 @@ groups:
           `gen_ai.input.messages` / `gen_ai.output.messages` capture
           attributes.
         examples: ['{"conversation_id":"conv_abc123"}']
+      - id: obi.http.response.observed
+        type: boolean
+        stability: development
+        brief: >
+          Present and false on an HTTP span whose response was never seen;
+          absent otherwise. `http.response.status_code` is emitted instead
+          once a response is observed.
+        examples: [false]


### PR DESCRIPTION
Fixes #3067.

`force_finish_http()` sets `status = 499` when `tcp_close` arrives with a
request still in `ongoing_http` and where no response was read. Userspace
publishes that as `http.response.status_code` on a CLIENT span, and per OTel
HTTP semconv, a 4xx on a CLIENT span should map to `Error`. This bug causes
calls that actually returned 200 to be reported as failures. 499 is nginx's
logging convention indicating that the client closed the connection prematurely.
It's not returned to a client (the client is no longer a client!), so OBI
must not synthesize one as though it actually happened.

The underlying issue is that `status` carries two meanings at once: `0` means
"no response yet", and anything else is the observed HTTP status code. There is
no value for "finished, but nothing was received", so `force_finish_http()`
substituted 499 — which is then published as `http.response.status_code`, an
attribute semconv reserves for a status that was actually received or sent. It
had no better option: `finish_http()` emits only when `status != 0`, so a record
with no observed response would otherwise be dropped in silence.

## Changes

**BPF.** `http_info_t` gains `unobserved_response`, consuming one of the two
bytes of the struct padding. `force_finish_http()` sets it and leaves `status`
at 0. Emit paths now gate on `http_info_emittable()` to avoid dropping the spans
silently, which is the regression #767 added `force_finish_http()` to fix. The
span status is decided from the marker rather than from `status == 0`, since
`HTTPSpanStatusCode()` maps a zero status to `Error` and would otherwise
relocate the same false error from the status code onto the span.
`http_info_complete()` keeps its prior meaning, because
`should_ignore_unreadable()` and the incomplete-server-trace cleanup use it to
ask whether the response arrived, not whether the record can be published.

To determine whether the peer sent anything back, it now saves the kernel's byte
counter when the request starts and reads it again at force-finish. Client
records use `bytes_received`; server records use `bytes_sent`, because a
server's response goes out rather than in. The comparison is `> snapshot + 1`,
not `> snapshot`, since a FIN consumes a sequence number.

**Trace export.** That counter splits a force-finished request into two cases: the
peer sent something back and OBI failed to parse it, or nothing came back at all.
Neither reports a status code, since nothing was received; and neither reports an
error, since OBI has no evidence of failure. They differ in whether the duration is
a measurement:

- If the peer sent bytes OBI did not parse, the outcome is unknown: status `Unset`,
  `obi.http.response.observed=false`. The response arrived at an unknown moment,
  so the span contributes no duration. The call is still counted in
  `traces_service_graph_request_total`, and never in `..._failed_total`.
- If nothing came back, the request ended when the local process closed the
  socket. In this case, the duration is valid, and the span participates in
  metrics normally. The status is still `Unset`, though, because OBI cannot
  distinguish a peer that failed from a client that stopped waiting.

## Resource impact

Adding 8 bytes to `http_info_t` consumes some extra ring buffer space and
memory allocated for the `ongoing_http` map:

| | before | after |
|---|---|---|
| `sizeof(http_info_t)` | 416 B | **424 B** |
| ring-buffer per record (incl. header) | 424 B | 432 B (**+1.89%**) |
| `ongoing_http` (LRU hash, 30 000 preallocated) | — | **+234 KiB** |
| at 1k / 10k requests per second | — | +7.8 / +78 KiB/s |

## Test measurements

Reproduction: https://github.com/mifisignal/obi-phantom-499-repro — `DURATION_S=40
CONCURRENCY=2`, stock and patched images both built on the host from base
`4a6614e6`, measured at branch HEAD `a5a048eb`. Cells read `stock → fix`.

| scenario | app calls returning 200 | CLIENT spans | spans with `499` |
|---|---|---|---|
| C0 (control, response observed) | 10555 → 10659 | 10555 → 10659 | 0 → 0 |
| S1 (connection per request) | 8160 → 8237 | 8160 → 8237 | 8159 → **0** |
| S2 (keep-alive, 250 ms reaping) | 9356 → 9365 | 233 → 227 | 232 → **0** |
| S3 (keep-alive, never reaped) | 9359 → 9393 | 3 → 3 | 2 → **0** |

Every call in every scenario returned 200 at the application. The spans that
carried `499`/`STATUS_CODE_ERROR` on the stock build carry no
`http.response.status_code` at all on the fix build, with span status unset, in
exactly the counts stock reported as 499 — and the control's spans still carry
`http.response.status_code=200` on both builds. Client spans survive at the same
rate per call (C0 1.000 on both; S1 99.99% stock vs 99.98% fix).

Note that S2 and S3 emit a CLIENT span for only a small fraction of calls on
both builds. That is a separate pre-existing defect: when a new request arrives on
a reused connection, `get_or_set_http_info()` hands the previous request's
still-open record to `finish_http()` — which drops it for the same `status != 0`
reason — then overwrites it. This change does not address that; it is
characterized separately at
https://github.com/mifisignal/obi-connection-reuse-span-loss-repro.

## Testing

`bpf/tests/test_http_unobserved_response.c` covers the states the predicates
distinguish, the FIN tolerance, reused connections, and that the marker alone
does not rescue a record missing the fields a span needs. `bpf_ssl_read_guard`
asserts the TLS read and write paths pass no socket, pinning the limitation
described under "What this does not settle" below. Go tests cover the transform, the
status mapping, the trace attributes and both metrics paths, each paired with a
control asserting an ordinary request is unchanged on the same axis. The
transform test asserts the span is emitted.

`TestServiceGraphMetrics_UnknownOutcomeIsCountedWithoutADuration` tests that an
unknown-outcome span increments the service-graph request counter and does not
add a latency sample.

`TestSuite_UnobservedResponse` tests that a call whose response OBI never parses
is still reported, but has no `http.response.status_code`, is not an error,
and carries the observation marker, while ensuring that an ordinary observed
call is unaffected.

## Considerations

A span with no observed response still carries `http.response.status_code` in
the RED series, because `span_getters.go` derives that label from `Span.Status`
unconditionally — so a call in the second case above is counted with a status of
`0`. Traces omit the attribute and metrics label it zero. That is less misleading
than a 499, but it is new behavior.

On TLS uprobe and unix-socket paths there is no `struct sock *`, so the snapshot
stays zero and a request reads as "nothing came back". On a reused keep-alive
connection whose earlier request was answered, that misreads as the peer having
answered. It withholds a duration rather than inventing one, which is the safer
direction, but it argues for plumbing the socket through those paths too.

## AI assistance disclosure

Per the project's Generative AI Policy: this change was developed with AI
assistance. The reproduction, the measurements above and the source analysis were
produced against a running system on a dedicated host, and reviewed by a human
before submission.
