### PR TITLE
Emit `db.server.operation.duration` for server-side DB spans

### DIFF
--- a/internal/test/integration/docker-compose-python-redis-server.yml
+++ b/internal/test/integration/docker-compose-python-redis-server.yml
@@ -1,0 +1,113 @@
+version: "3.8"
+
+services:
+  redis:
+    build:
+      context: ../../../internal/test/integration/components/redis/
+      dockerfile: Dockerfile
+    image: redis
+
+  testserver:
+    build:
+      context: ../../../internal/test/integration/components/pythonredis/
+      dockerfile: Dockerfile
+    image: hatest-testserver-python-redis
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    depends_on:
+      otelcol:
+        condition: service_started
+      redis:
+        condition: service_started
+
+  # OBI instruments the redis server process (not the python client), so the
+  # emitted metrics are the server-side db.server.operation.duration family.
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-python-redis-server:/var/run/obi
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:redis"
+    pid: "service:redis"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config-redis.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_TRACES_INSTRUMENTATIONS: "redis"
+      OTEL_EBPF_METRICS_INSTRUMENTATIONS: "redis"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+    depends_on:
+      redis:
+        condition: service_started
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.159.0@sha256:1f2c54a30e713fac6b3ae77a1ec84010c2007e29ced8ec666214fc2f6739c1cc
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318:4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+      jaeger:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    command:
+      - "--set=service.telemetry.logs.level=debug"

--- a/internal/test/integration/red_test_redis_server.go
+++ b/internal/test/integration/red_test_redis_server.go
@@ -1,0 +1,89 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration // import "go.opentelemetry.io/obi/internal/test/integration"
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
+)
+
+// testREDMetricsRedisServerSide verifies the server-side view: OBI instruments
+// the redis-server process (not the python client), so operations must be
+// reported as db.server.operation.duration and never as the client metric.
+func testREDMetricsRedisServerSide(t *testing.T) {
+	url := "http://localhost:8381"
+	urlPath := "redis"
+	namespace := "integration-test"
+
+	for i := 0; i < 4; i++ {
+		ti.DoHTTPGet(t, url+"/"+urlPath, 200)
+	}
+
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	for _, operation := range []string{"HSET", "HGETALL", "SET", "GET"} {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			results, err := pq.Query(`db_server_operation_duration_seconds_count{` +
+				`db_operation_name="` + operation + `",` +
+				`db_system_name="redis",` +
+				`service_namespace="` + namespace + `"}`)
+			require.NoError(ct, err, "failed to query prometheus for %s", operation)
+			enoughPromResults(ct, results)
+			val := totalPromCount(ct, results)
+			assert.LessOrEqual(ct, 3, val, "expected at least 3 %s operations, got %d", operation, val)
+		}, testTimeout, 100*time.Millisecond)
+	}
+
+	// The python client is not instrumented, so the client-side metric must
+	// not exist: server-side spans must not leak into it.
+	results, err := pq.Query(`db_client_operation_duration_seconds_count{}`)
+	require.NoError(t, err, "failed to query prometheus for db_client_operation_duration_seconds_count")
+	require.Empty(t, results, "expected no client-side db operations, got %d", len(results))
+
+	// Traces: the same operations must be visible as server spans of the
+	// redis-server service.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=redis-server&operation=GET")
+		require.NoError(ct, err, "failed to query jaeger for GET")
+		if resp == nil {
+			return
+		}
+		require.Equal(ct, http.StatusOK, resp.StatusCode, "unexpected status code: %d", resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq), "failed to decode jaeger response")
+		tags := []jaeger.Tag{
+			otelAttributeToJaegerTag(attribute.String("db.system.name", "redis")),
+			otelAttributeToJaegerTag(attribute.String("span.kind", "server")),
+		}
+		traces := tq.FindBySpan(tags...)
+		assert.LessOrEqual(ct, 1, len(traces), "server GET span with tags %v not found in %v", tags, tq.Data)
+	}, testTimeout, 100*time.Millisecond)
+}
+
+func waitForRedisServerTestComponents(t *testing.T, url string, subpath string) {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		// first, verify that the test service endpoint is healthy
+		req, err := http.NewRequest(http.MethodGet, url+subpath, nil)
+		require.NoError(ct, err)
+		r, err := testHTTPClient.Do(req)
+		require.NoError(ct, err)
+		require.Equal(ct, http.StatusOK, r.StatusCode)
+
+		// now, verify that the server-side metric has been reported
+		results, err := pq.Query(`db_server_operation_duration_seconds_count{db_system_name="redis"}`)
+		require.NoError(ct, err)
+		require.NotEmpty(ct, results)
+	}, 1*time.Minute, time.Second)
+}

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -769,6 +769,20 @@ func TestSuite_PythonRedis(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_PythonRedisServerSide(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-python-redis-server.yml", path.Join(pathOutput, "test-suite-python-redis-server.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=6379`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
+	require.NoError(t, compose.Up())
+	t.Run("Redis server-side metrics", func(t *testing.T) {
+		waitForRedisServerTestComponents(t, "http://localhost:8381", "/redis")
+		testREDMetricsRedisServerSide(t)
+	})
+	runWeaverValidation(t)
+	require.NoError(t, compose.Close())
+}
+
 func TestSuite_NodeBullMQ(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-nodejs-bullmq.yml", path.Join(pathOutput, "test-suite-nodejs-bullmq.log"))
 	require.NoError(t, err)

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -396,6 +396,15 @@ func getDefinitions(
 				attr.DBCollectionName: false,
 			},
 		},
+		DBServerDuration.Section: {
+			SubGroups: []*AttrReportGroup{&appAttributes, &serverInfo},
+			Attributes: map[attr.Name]Default{
+				attr.DBOperation:      true,
+				attr.DBSystemName:     true,
+				attr.ErrorType:        true,
+				attr.DBCollectionName: false,
+			},
+		},
 		MessagingPublishDuration.Section: {
 			SubGroups: []*AttrReportGroup{&messagingAttributes},
 		},

--- a/pkg/export/attributes/metric.go
+++ b/pkg/export/attributes/metric.go
@@ -148,6 +148,12 @@ var (
 		Unit:    "s",
 		Type:    InstrumentHistogram,
 	})
+	DBServerDuration = metric(Name{
+		Section: "db.server.operation.duration",
+		OTEL:    "db.server.operation.duration",
+		Unit:    "s",
+		Type:    InstrumentHistogram,
+	})
 	MessagingPublishDuration = metric(Name{
 		Section: "messaging.client.operation.duration",
 		OTEL:    "messaging.client.operation.duration",

--- a/pkg/export/attributes/metric_test.go
+++ b/pkg/export/attributes/metric_test.go
@@ -30,6 +30,7 @@ func TestPrometheusNames(t *testing.T) {
 		{RPCServerDuration, "rpc_server_call_duration_seconds"},
 		{RPCClientDuration, "rpc_client_call_duration_seconds"},
 		{DBClientDuration, "db_client_operation_duration_seconds"},
+		{DBServerDuration, "db_server_operation_duration_seconds"},
 		{MessagingPublishDuration, "messaging_client_operation_duration_seconds"},
 		{MessagingProcessDuration, "messaging_process_duration_seconds"},
 		{GPUCudaKernelLaunchCalls, "gpu_cuda_kernel_launch_calls_total"},

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -97,6 +97,7 @@ type MetricsReporter struct {
 	attrGRPCServer             []attributes.Field[*request.Span, attribute.KeyValue]
 	attrGRPCClient             []attributes.Field[*request.Span, attribute.KeyValue]
 	attrDBClient               []attributes.Field[*request.Span, attribute.KeyValue]
+	attrDBServer               []attributes.Field[*request.Span, attribute.KeyValue]
 	attrMessagingPublish       []attributes.Field[*request.Span, attribute.KeyValue]
 	attrMessagingProcess       []attributes.Field[*request.Span, attribute.KeyValue]
 	attrHTTPRequestSize        []attributes.Field[*request.Span, attribute.KeyValue]
@@ -138,6 +139,7 @@ type Metrics struct {
 	grpcDuration           *Expirer[*request.Span, instrument.Float64Histogram, float64]
 	grpcClientDuration     *Expirer[*request.Span, instrument.Float64Histogram, float64]
 	dbClientDuration       *Expirer[*request.Span, instrument.Float64Histogram, float64]
+	dbServerDuration       *Expirer[*request.Span, instrument.Float64Histogram, float64]
 	msgPublishDuration     *Expirer[*request.Span, instrument.Float64Histogram, float64]
 	msgProcessDuration     *Expirer[*request.Span, instrument.Float64Histogram, float64]
 	httpRequestSize        *Expirer[*request.Span, instrument.Float64Histogram, float64]
@@ -270,6 +272,8 @@ func newMetricsReporter(
 	if is.DBEnabled() {
 		mr.attrDBClient = attributes.OpenTelemetryGetters(
 			mr.attrGetters, mr.attributes.For(attributes.DBClientDuration))
+		mr.attrDBServer = attributes.OpenTelemetryGetters(
+			mr.attrGetters, mr.attributes.For(attributes.DBServerDuration))
 	}
 
 	if is.MQEnabled() {
@@ -380,6 +384,7 @@ func (mr *MetricsReporter) otelMetricOptions() []metric.Option {
 	if mr.is.DBEnabled() {
 		opts = append(opts,
 			metric.WithView(mr.otelHistogramConfig(attributes.DBClientDuration.OTEL, mr.cfg.Buckets.DurationHistogram)),
+			metric.WithView(mr.otelHistogramConfig(attributes.DBServerDuration.OTEL, mr.cfg.Buckets.DurationHistogram)),
 		)
 	}
 
@@ -505,6 +510,13 @@ func (mr *MetricsReporter) setupOtelMeters(m *Metrics, meter instrument.Meter) e
 		}
 		m.dbClientDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
 			m.ctx, dbClientDuration, mr.attrDBClient, timeNow, mr.cfg.TTL)
+
+		dbServerDuration, err := meter.Float64Histogram(attributes.DBServerDuration.OTEL, instrument.WithUnit(attributes.DBServerDuration.Unit))
+		if err != nil {
+			return fmt.Errorf("creating db server duration histogram metric: %w", err)
+		}
+		m.dbServerDuration = NewExpirer[*request.Span, instrument.Float64Histogram, float64](
+			m.ctx, dbServerDuration, mr.attrDBServer, timeNow, mr.cfg.TTL)
 	}
 
 	if mr.is.MQEnabled() {
@@ -978,15 +990,25 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 				httpClientResponseSize, attrs := r.httpClientResponseSize.ForRecord(span)
 				httpClientResponseSize.Record(ctx, float64(span.ResponseBodyLength()), instrument.WithAttributeSet(attrs))
 			}
-		case request.EventTypeRedisServer, request.EventTypeRedisClient:
+		case request.EventTypeRedisClient:
 			if mr.is.RedisEnabled() {
 				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
 				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeRedisServer:
+			if mr.is.RedisEnabled() {
+				dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
+				dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 			}
 		case request.EventTypeSQLClient:
 			if mr.is.SQLEnabled() {
 				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
 				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeSQLServer:
+			if mr.is.SQLEnabled() {
+				dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
+				dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 			}
 		case request.EventTypeMongoClient:
 			if mr.is.MongoEnabled() {
@@ -998,10 +1020,15 @@ func (r *Metrics) record(span *request.Span, mr *MetricsReporter) {
 				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
 				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 			}
-		case request.EventTypeMemcachedClient, request.EventTypeMemcachedServer:
+		case request.EventTypeMemcachedClient:
 			if mr.is.MemcachedEnabled() {
 				dbClientDuration, attrs := r.dbClientDuration.ForRecord(span)
 				dbClientDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
+			}
+		case request.EventTypeMemcachedServer:
+			if mr.is.MemcachedEnabled() {
+				dbServerDuration, attrs := r.dbServerDuration.ForRecord(span)
+				dbServerDuration.Record(ctx, duration, instrument.WithAttributeSet(attrs))
 			}
 		case request.EventTypeAerospikeClient:
 			if mr.is.AerospikeEnabled() {
@@ -1361,6 +1388,7 @@ func (r *Metrics) cleanupAllMetricsInstances() {
 	cleanupMetrics(r.ctx, r.grpcDuration)
 	cleanupMetrics(r.ctx, r.grpcClientDuration)
 	cleanupMetrics(r.ctx, r.dbClientDuration)
+	cleanupMetrics(r.ctx, r.dbServerDuration)
 	cleanupMetrics(r.ctx, r.msgPublishDuration)
 	cleanupMetrics(r.ctx, r.msgProcessDuration)
 	cleanupMetrics(r.ctx, r.httpRequestSize)

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -223,6 +223,8 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				"db.server.operation.duration",        // SQL server SELECT
 				"db.client.operation.duration",        // REDIS client SET
 				"db.server.operation.duration",        // Redis server GET
+				"db.client.operation.duration",        // Memcached client SET
+				"db.server.operation.duration",        // Memcached server GET
 				"db.client.operation.duration",        // MongoDB client find
 				"db.client.operation.duration",        // Aerospike client get
 				"messaging.client.operation.duration", // Kafka client
@@ -270,6 +272,15 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 		{
 			name:      "redis only",
 			instr:     []instrumentations.Instrumentation{instrumentations.InstrumentationRedis},
+			extraColl: 0,
+			expected: []string{
+				"db.client.operation.duration",
+				"db.server.operation.duration",
+			},
+		},
+		{
+			name:      "memcached only",
+			instr:     []instrumentations.Instrumentation{instrumentations.InstrumentationMemcached},
 			extraColl: 0,
 			expected: []string{
 				"db.client.operation.duration",
@@ -408,6 +419,8 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeSQLServer, Method: "SELECT", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeRedisClient, Method: "SET", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeRedisServer, Method: "GET", RequestStart: 150, End: 175},
+				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMemcachedClient, Method: "SET", RequestStart: 150, End: 175},
+				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMemcachedServer, Method: "GET", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMongoClient, Method: "find", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeAerospikeClient, Method: "aerospike_get", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeKafkaClient, Method: "publish", RequestStart: 150, End: 175},

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -220,8 +220,9 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				"rpc.server.call.duration",
 				"rpc.client.call.duration",
 				"db.client.operation.duration",        // SQL client SELECT
+				"db.server.operation.duration",        // SQL server SELECT
 				"db.client.operation.duration",        // REDIS client SET
-				"db.client.operation.duration",        // Redis server GET (TODO is this a bug?)
+				"db.server.operation.duration",        // Redis server GET
 				"db.client.operation.duration",        // MongoDB client find
 				"db.client.operation.duration",        // Aerospike client get
 				"messaging.client.operation.duration", // Kafka client
@@ -272,7 +273,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			extraColl: 0,
 			expected: []string{
 				"db.client.operation.duration",
-				"db.client.operation.duration",
+				"db.server.operation.duration",
 			},
 		},
 		{
@@ -281,6 +282,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			extraColl: 0,
 			expected: []string{
 				"db.client.operation.duration",
+				"db.server.operation.duration",
 			},
 		},
 		{
@@ -351,7 +353,8 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			expected: []string{
 				"db.client.operation.duration",
 				"db.client.operation.duration",
-				"db.client.operation.duration",
+				"db.server.operation.duration",
+				"db.server.operation.duration",
 			},
 			unexpectedOperations: []string{"aerospike_get"},
 		},
@@ -401,7 +404,8 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeHTTPClient, Path: "/bar", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeGRPC, Path: "/foo", RequestStart: 100, End: 200},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeGRPCClient, Path: "/bar", RequestStart: 150, End: 175},
-				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeSQLClient, Path: "SELECT", RequestStart: 150, End: 175},
+				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeSQLClient, Method: "SELECT", RequestStart: 150, End: 175},
+				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeSQLServer, Method: "SELECT", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeRedisClient, Method: "SET", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeRedisServer, Method: "GET", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMongoClient, Method: "find", RequestStart: 150, End: 175},

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -175,6 +175,7 @@ type metricsReporter struct {
 	grpcDuration           *Expirer[prometheus.Histogram]
 	grpcClientDuration     *Expirer[prometheus.Histogram]
 	dbClientDuration       *Expirer[prometheus.Histogram]
+	dbServerDuration       *Expirer[prometheus.Histogram]
 	msgPublishDuration     *Expirer[prometheus.Histogram]
 	msgProcessDuration     *Expirer[prometheus.Histogram]
 	httpRequestSize        *Expirer[prometheus.Histogram]
@@ -189,6 +190,7 @@ type metricsReporter struct {
 	attrGRPCDuration           []attributes.Field[*request.Span, string]
 	attrGRPCClientDuration     []attributes.Field[*request.Span, string]
 	attrDBClientDuration       []attributes.Field[*request.Span, string]
+	attrDBServerDuration       []attributes.Field[*request.Span, string]
 	attrMsgPublishDuration     []attributes.Field[*request.Span, string]
 	attrMsgProcessDuration     []attributes.Field[*request.Span, string]
 	attrHTTPRequestSize        []attributes.Field[*request.Span, string]
@@ -364,10 +366,13 @@ func newReporter(
 	}
 
 	var attrDBClientDuration []attributes.Field[*request.Span, string]
+	var attrDBServerDuration []attributes.Field[*request.Span, string]
 
 	if is.DBEnabled() {
 		attrDBClientDuration = attributes.PrometheusGetters(attributeGetters,
 			attrsProvider.For(attributes.DBClientDuration))
+		attrDBServerDuration = attributes.PrometheusGetters(attributeGetters,
+			attrsProvider.For(attributes.DBServerDuration))
 	}
 
 	var attrMessagingProcessDuration, attrMessagingPublishDuration []attributes.Field[*request.Span, string]
@@ -468,6 +473,7 @@ func newReporter(
 		attrGRPCDuration:           attrGRPCDuration,
 		attrGRPCClientDuration:     attrGRPCClientDuration,
 		attrDBClientDuration:       attrDBClientDuration,
+		attrDBServerDuration:       attrDBServerDuration,
 		attrMsgPublishDuration:     attrMessagingPublishDuration,
 		attrMsgProcessDuration:     attrMessagingProcessDuration,
 		attrHTTPRequestSize:        attrHTTPRequestSize,
@@ -547,6 +553,16 @@ func newReporter(
 				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
 				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
 			}, labelNames(attrDBClientDuration)).MetricVec, timeNow, cfg.TTL)
+		}),
+		dbServerDuration: optionalHistogramProvider(is.DBEnabled(), func() *Expirer[prometheus.Histogram] {
+			return NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Name:                            attributes.DBServerDuration.Prom,
+				Help:                            "duration of db server operations, in seconds",
+				Buckets:                         cfg.Buckets.DurationHistogram,
+				NativeHistogramBucketFactor:     cfg.NativeHistogram.BucketFactor,
+				NativeHistogramMaxBucketNumber:  cfg.NativeHistogram.MaxBucketNumber,
+				NativeHistogramMinResetDuration: cfg.NativeHistogram.MinResetDuration,
+			}, labelNames(attrDBServerDuration)).MetricVec, timeNow, cfg.TTL)
 		}),
 		msgPublishDuration: optionalHistogramProvider(is.MQEnabled(), func() *Expirer[prometheus.Histogram] {
 			return NewExpirer[prometheus.Histogram](prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -812,6 +828,7 @@ func newReporter(
 		if is.DBEnabled() {
 			registeredMetrics = append(registeredMetrics,
 				mr.dbClientDuration,
+				mr.dbServerDuration,
 			)
 		}
 
@@ -1078,13 +1095,21 @@ func (r *metricsReporter) observe(span *request.Span) {
 			if r.is.SunRPCEnabled() {
 				r.observeHistogram(r.grpcDuration.WithLabelValues(labelValues(span, r.attrGRPCDuration)...).Metric, duration, span)
 			}
-		case request.EventTypeRedisClient, request.EventTypeRedisServer:
+		case request.EventTypeRedisClient:
 			if r.is.RedisEnabled() {
 				r.observeHistogram(r.dbClientDuration.WithLabelValues(labelValues(span, r.attrDBClientDuration)...).Metric, duration, span)
+			}
+		case request.EventTypeRedisServer:
+			if r.is.RedisEnabled() {
+				r.observeHistogram(r.dbServerDuration.WithLabelValues(labelValues(span, r.attrDBServerDuration)...).Metric, duration, span)
 			}
 		case request.EventTypeSQLClient:
 			if r.is.SQLEnabled() {
 				r.observeHistogram(r.dbClientDuration.WithLabelValues(labelValues(span, r.attrDBClientDuration)...).Metric, duration, span)
+			}
+		case request.EventTypeSQLServer:
+			if r.is.SQLEnabled() {
+				r.observeHistogram(r.dbServerDuration.WithLabelValues(labelValues(span, r.attrDBServerDuration)...).Metric, duration, span)
 			}
 		case request.EventTypeMongoClient:
 			if r.is.MongoEnabled() {
@@ -1094,9 +1119,13 @@ func (r *metricsReporter) observe(span *request.Span) {
 			if r.is.CouchbaseEnabled() {
 				r.observeHistogram(r.dbClientDuration.WithLabelValues(labelValues(span, r.attrDBClientDuration)...).Metric, duration, span)
 			}
-		case request.EventTypeMemcachedClient, request.EventTypeMemcachedServer:
+		case request.EventTypeMemcachedClient:
 			if r.is.MemcachedEnabled() {
 				r.observeHistogram(r.dbClientDuration.WithLabelValues(labelValues(span, r.attrDBClientDuration)...).Metric, duration, span)
+			}
+		case request.EventTypeMemcachedServer:
+			if r.is.MemcachedEnabled() {
+				r.observeHistogram(r.dbServerDuration.WithLabelValues(labelValues(span, r.attrDBServerDuration)...).Metric, duration, span)
 			}
 		case request.EventTypeAerospikeClient:
 			if r.is.AerospikeEnabled() {

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -228,6 +228,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				"rpc_server_call_duration_seconds",
 				"rpc_client_call_duration_seconds",
 				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
 				"messaging_client_operation_duration_seconds",
 				"messaging_process_duration_seconds",
 				"gpu_cuda_kernel_launch_calls_total",
@@ -256,6 +257,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				"rpc_server_call_duration_seconds",
 				"rpc_client_call_duration_seconds",
 				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
 				"messaging_client_operation_duration_seconds",
 				"messaging_process_duration_seconds",
 				"gpu_cuda_kernel_launch_calls_total",
@@ -273,6 +275,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				"http_server_request_duration_seconds",
 				"http_client_request_duration_seconds",
 				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
 				"messaging_client_operation_duration_seconds",
 				"messaging_process_duration_seconds",
 			},
@@ -282,7 +285,8 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			instr: []instrumentations.Instrumentation{instrumentations.InstrumentationRedis},
 			expected: []string{
 				"db_client_operation_duration_seconds",
-				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
+				`db_system_name="redis"`,
 			},
 			unexpected: []string{
 				"http_server_request_duration_seconds",
@@ -298,6 +302,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			instr: []instrumentations.Instrumentation{instrumentations.InstrumentationSQL},
 			expected: []string{
 				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
 			},
 			unexpected: []string{
 				"http_server_request_duration_seconds",
@@ -321,6 +326,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				"rpc_server_call_duration_seconds",
 				"rpc_client_call_duration_seconds",
 				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
 			},
 		},
 		{
@@ -336,6 +342,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				"rpc_server_call_duration_seconds",
 				"rpc_client_call_duration_seconds",
 				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
 			},
 		},
 		{
@@ -351,6 +358,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				"rpc_server_call_duration_seconds",
 				"rpc_client_call_duration_seconds",
 				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
 			},
 		},
 		{
@@ -366,6 +374,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				"rpc_server_call_duration_seconds",
 				"rpc_client_call_duration_seconds",
 				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
 			},
 		},
 		{
@@ -380,6 +389,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				"http_client_request_duration_seconds",
 				"messaging_client_operation_duration_seconds",
 				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
 			},
 		},
 		{
@@ -394,6 +404,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				`db_operation_name="SET"`,
 				`db_operation_name="GET"`,
 				`db_operation_name="find"`,
+				"db_server_operation_duration_seconds",
 			},
 		},
 
@@ -407,6 +418,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				"rpc_server_call_duration_seconds",
 				"rpc_client_call_duration_seconds",
 				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
 				"messaging_client_operation_duration_seconds",
 				"messaging_process_duration_seconds",
 			},
@@ -416,6 +428,7 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			instr: []instrumentations.Instrumentation{instrumentations.InstrumentationSQL, instrumentations.InstrumentationRedis},
 			expected: []string{
 				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
 			},
 			unexpected: []string{
 				"http_server_request_duration_seconds",
@@ -478,7 +491,8 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeHTTPClient, Path: "/bar", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeGRPC, Path: "/foo", RequestStart: 100, End: 200},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeGRPCClient, Path: "/bar", RequestStart: 150, End: 175},
-				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeSQLClient, Path: "SELECT", RequestStart: 150, End: 175},
+				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeSQLClient, Method: "SELECT", RequestStart: 150, End: 175},
+				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeSQLServer, Method: "SELECT", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeRedisClient, Method: "SET", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeRedisServer, Method: "GET", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeKafkaClient, Method: "publish", RequestStart: 150, End: 175},

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -298,6 +298,22 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 			},
 		},
 		{
+			name:  "memcached only",
+			instr: []instrumentations.Instrumentation{instrumentations.InstrumentationMemcached},
+			expected: []string{
+				"db_client_operation_duration_seconds",
+				"db_server_operation_duration_seconds",
+			},
+			unexpected: []string{
+				"http_server_request_duration_seconds",
+				"http_client_request_duration_seconds",
+				"rpc_server_call_duration_seconds",
+				"rpc_client_call_duration_seconds",
+				"messaging_client_operation_duration_seconds",
+				"messaging_process_duration_seconds",
+			},
+		},
+		{
 			name:  "sql only",
 			instr: []instrumentations.Instrumentation{instrumentations.InstrumentationSQL},
 			expected: []string{
@@ -495,6 +511,8 @@ func TestAppMetrics_ByInstrumentation(t *testing.T) {
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeSQLServer, Method: "SELECT", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeRedisClient, Method: "SET", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeRedisServer, Method: "GET", RequestStart: 150, End: 175},
+				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMemcachedClient, Method: "SET", RequestStart: 150, End: 175},
+				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMemcachedServer, Method: "GET", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeKafkaClient, Method: "publish", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeKafkaServer, Method: "process", RequestStart: 150, End: 175},
 				{Service: svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}}, Type: request.EventTypeMQTTClient, Method: "publish", RequestStart: 150, End: 175},

--- a/schemas/obi/groups/db.yaml
+++ b/schemas/obi/groups/db.yaml
@@ -192,3 +192,28 @@ groups:
               brief: "[Aerospike](https://aerospike.com/)"
               stability: development
         stability: stable
+
+  # OBI-custom metric: upstream semconv defines only the client-side
+  # db.client.operation.duration. OBI's eBPF instrumentation also observes
+  # operations from the database server's perspective (the instrumented
+  # process IS the server), reported here so server-side measurements don't
+  # pollute the client metric or double-count against it.
+  - id: metric.db_server_operation_duration
+    type: metric
+    metric_name: db.server.operation.duration
+    instrument: histogram
+    unit: "s"
+    stability: development
+    brief: >
+      Duration of database operations observed from the server side.
+    attributes:
+      - ref: db.system.name
+        requirement_level: required
+      - ref: db.operation.name
+      - ref: error.type
+      - ref: db.collection.name
+        requirement_level: opt_in
+      - ref: server.address
+      - ref: server.port
+      - ref: client.address
+        requirement_level: opt_in


### PR DESCRIPTION
## Summary

resolves #3031 

This PR adds a new `db.server.operation.duration` histogram and it also moves Redis/Memcached server spans to it. SQL server spans now emit it too. 


Notes:
- Breaking change: dashboards reading server-side Redis/Memcached measurements from `db.client.operation` must switch to this new metric. 
- Integration test: added `TestSuite_PythonRedisServerSide` that asserts per-operation `db_server_operation_duration_seconds` counts and the client-metric is absent. Memcached/SQL server-side integration variants are omitted becayse they share the same one-case switch path redis covers; can be added on request.
- Follow-up: the `db.server.operation.duration` metric is OBI-custom, indeed upstream semconv only defines the client one. A semconv proposal will follow, and the registry entry documents the contract in the meantime.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
