### PR TITLE
chore(examples): pin go-trace-api to a released OBI image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -463,6 +463,39 @@
       "enabled": false
     },
     {
+      // OBI's own image publishes a mostly-disposable tag namespace: every merge
+      // pushes a short-SHA tag and moves `main`, a nightly job pushes `nightly`
+      // and `nightly-<date>`, and only 13 of its 319 tags are releases. Renovate
+      // must follow releases and nothing else, so updates are off by default
+      // here and re-enabled below for release refs only. A denylist does not
+      // work: chasing `main` produced one digest PR per commit, and `nightly`
+      // would do the same daily.
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "otel/ebpf-instrument",
+        "ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument"
+      ],
+      "enabled": false
+    },
+    {
+      // Re-enable refs already on a release tag, and keep their target on one
+      // too: matchCurrentValue gates which refs are tracked, allowedVersions
+      // gates what they may move to, so no ref can slide onto a nightly or
+      // short-SHA tag. Every OBI release to date matches this shape. The
+      // examples/ Compose files all document the same release, so they move
+      // together in one PR — a partial bump leaves them on different versions.
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "otel/ebpf-instrument",
+        "ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument"
+      ],
+      "matchCurrentValue": "/^v\\d+\\.\\d+\\.\\d+$/",
+      "allowedVersions": "/^v\\d+\\.\\d+\\.\\d+$/",
+      "groupName": "OBI example images",
+      "enabled": true,
+      "schedule": ["before 6am on Tuesday"]
+    },
+    {
       // Pin every otel/weaver reference to one version in a single PR. The refs
       // live across four managers: dependencies.Dockerfile (dockerfile — the
       // image `make lint-schema` reads), the OATS/integration compose fragments

--- a/examples/go-trace-api/docker-compose.yml
+++ b/examples/go-trace-api/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "4317:4317"
 
   obi:
-    image: ${OBI_IMAGE:-otel/ebpf-instrument:main@sha256:31c014dff9843488a2b278e9a19644a5beee7c339b36514611952015462bf953}
+    image: ${OBI_IMAGE:-otel/ebpf-instrument:v0.11.0@sha256:ad0c8d7b362500a5fb9dec19c00e07f1cc0c80c27d3e85862c43585207ff7c6d}
     privileged: true
     pid: host
     environment:


### PR DESCRIPTION
## Summary

`examples/go-trace-api/docker-compose.yml` was the only OBI image reference on
a floating tag. `otel/ebpf-instrument:main` is rebuilt on every merge, so
Renovate opened one digest PR per commit - 18 in the eight days after the
example landed, each superseding the last.

- pin the example to `v0.11.0`, the version its README already documents, and
the same tag and digest the apache, nginx and http-header-enrichment
examples use
- group the four example image refs into one scheduled Renovate PR so they
never document different releases
- force Renovate to track only release tags, not `main`/`latest`/`nightly`/`nightly-*`


## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
