### PR TITLE
nodejs: preserve getTracer(name, version, options) through the SDK handoff

### DIFF
--- a/pkg/internal/nodejs/spanbridge.js
+++ b/pkg/internal/nodejs/spanbridge.js
@@ -373,20 +373,22 @@
   // to the app's current tracer instead of producing dead bridge spans. The
   // registry-appearance check also hands off for apps that registered through
   // a copy we could not wrap.
-  const activeAppTracer = (scope, version) => {
+  const activeAppTracer = (scope, version, options) => {
     if (!yielded && !detectRegistryHandoff()) return null;
     const reg = g[API_KEY];
     const prov = reg && reg.trace;
-    if (prov && typeof prov.getTracer === 'function') return prov.getTracer(scope, version);
+    if (prov && typeof prov.getTracer === 'function') return prov.getTracer(scope, version, options);
     return null;
   };
 
   class Tracer {
-    constructor(scopeName) {
+    constructor(scopeName, version, options) {
       this._scope = scopeName;
+      this._version = version;
+      this._options = options;
     }
     startSpan(name, options, context) {
-      const at = activeAppTracer(this._scope);
+      const at = activeAppTracer(this._scope, this._version, this._options);
       if (at) return at.startSpan(name, options, context);
       const ctx = context ?? contextManager.active();
       const opts = options ?? {};
@@ -408,7 +410,7 @@
       return span;
     }
     startActiveSpan(name, arg2, arg3, arg4) {
-      const at = activeAppTracer(this._scope);
+      const at = activeAppTracer(this._scope, this._version, this._options);
       if (at) return at.startActiveSpan(name, arg2, arg3, arg4);
       let options, context, fn;
       if (typeof arg2 === 'function') {
@@ -430,8 +432,8 @@
   }
 
   const tracerProvider = {
-    getTracer(name, _version, _options) {
-      return new Tracer(name || 'unknown');
+    getTracer(name, version, options) {
+      return new Tracer(name, version, options);
     },
   };
 

--- a/pkg/internal/nodejs/spanbridge_test/scenario_ext_parent.js
+++ b/pkg/internal/nodejs/spanbridge_test/scenario_ext_parent.js
@@ -1,5 +1,5 @@
 'use strict';
-// External-parent flagging (Tyler / MrAlias): when the app supplies a parent
+// External-parent flagging: when the app supplies a parent
 // context the bridge does NOT own (a remote/app SpanContext set via
 // trace.setSpan / setSpanContext), the emitted record must carry
 // `extParent: true` so user space can flatten the span under the OBI request

--- a/pkg/internal/nodejs/spanbridge_test/scenario_late_load.js
+++ b/pkg/internal/nodejs/spanbridge_test/scenario_late_load.js
@@ -1,5 +1,5 @@
 'use strict';
-// Regression for the late-loaded-@opentelemetry/api handoff (Tyler / MrAlias):
+// Regression for the late-loaded-@opentelemetry/api handoff:
 // the bridge is injected BEFORE @opentelemetry/api is ever require()d, so the
 // api copy is NOT in require.cache when the bridge wires up. A copy loaded
 // afterwards must still get its global setters wrapped (via the module-load

--- a/pkg/internal/nodejs/spanbridge_test/scenario_mixed_copy.js
+++ b/pkg/internal/nodejs/spanbridge_test/scenario_mixed_copy.js
@@ -1,5 +1,5 @@
 'use strict';
-// Mixed reachable + unreachable @opentelemetry/api copies (Tyler / MrAlias):
+// Mixed reachable + unreachable @opentelemetry/api copies:
 // the bridge wires and captures through a REACHABLE copy, while the app
 // registers its SDK through a SECOND, bundled/unreachable copy whose
 // setGlobalTracerProvider the bridge never wrapped. That registration writes

--- a/pkg/internal/nodejs/spanbridge_test/scenario_multibyte.js
+++ b/pkg/internal/nodejs/spanbridge_test/scenario_multibyte.js
@@ -1,5 +1,5 @@
 'use strict';
-// Multibyte truncation boundary (Tyler / MrAlias): attribute keys/values (and
+// Multibyte truncation boundary: attribute keys/values (and
 // name/status message) are truncated to UTF-8 BYTE budgets because the Go side
 // copies them into fixed byte arrays (key[32], value[128], NUL-terminated).
 // A UTF-16 code-unit budget would let e.g. sixteen 'é' (16 units, 32 bytes)

--- a/pkg/internal/nodejs/spanbridge_test/scenario_versioned_tracer.js
+++ b/pkg/internal/nodejs/spanbridge_test/scenario_versioned_tracer.js
@@ -1,0 +1,85 @@
+'use strict';
+// A tracer acquired with getTracer(name, version, options) before SDK
+// registration caches the bridge Tracer; after handoff the app provider must
+// receive all three original arguments, not just the name.
+
+const fs = require('fs');
+const path = require('path');
+
+const bridgeCaptured = [];
+const origAccess = fs.accessSync;
+fs.accessSync = (p, ...rest) => {
+  if (typeof p === 'string' && p.startsWith('/dev/null/obi-span/')) {
+    bridgeCaptured.push(JSON.parse(p.slice('/dev/null/obi-span/'.length)).name);
+    const err = new Error('ENOTDIR');
+    err.code = 'ENOTDIR';
+    throw err;
+  }
+  return origAccess(p, ...rest);
+};
+
+// Inject the bridge, then load the api (wired via the module-load hook).
+const src = fs.readFileSync(path.join(__dirname, '..', 'spanbridge.js'), 'utf8');
+// eslint-disable-next-line no-eval
+eval(src);
+
+const api = require('@opentelemetry/api');
+const SCHEMA_URL = 'https://example.com/1.2.3';
+
+// Acquired BEFORE any SDK registration: caches the bridge tracer. Acquired
+// through the provider, not api.trace.getTracer — the api's TraceAPI.getTracer
+// itself drops the options argument (api 1.9 forwards only name+version), so
+// the provider path is the only one that can carry options at all.
+const tracer = api.trace.getTracerProvider().getTracer('app', '1.2.3', { schemaUrl: SCHEMA_URL });
+tracer.startSpan('before').end(); // -> bridge
+
+const appCaptured = [];
+const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
+const provider = new NodeTracerProvider({
+  spanProcessors: [
+    {
+      onStart() {},
+      onEnd(span) {
+        appCaptured.push({
+          name: span.name,
+          scope: span.instrumentationScope && {
+            name: span.instrumentationScope.name,
+            version: span.instrumentationScope.version,
+            schemaUrl: span.instrumentationScope.schemaUrl,
+          },
+        });
+      },
+      shutdown() {
+        return Promise.resolve();
+      },
+      forceFlush() {
+        return Promise.resolve();
+      },
+    },
+  ],
+});
+
+// Spy on the provider's getTracer to capture the arguments the bridge
+// forwards at handoff (the registry proxy delegates here on every call).
+const forwardedArgs = [];
+const origGetTracer = provider.getTracer.bind(provider);
+provider.getTracer = (name, version, options) => {
+  forwardedArgs.push({ name, version, options });
+  return origGetTracer(name, version, options);
+};
+
+provider.register(); // -> bridge yields
+
+// The SAME pre-acquired tracer must now route to the app provider with its
+// full original identity.
+tracer.startSpan('after').end();
+
+fs.accessSync = origAccess;
+
+process.stdout.write(
+  JSON.stringify({
+    bridge: bridgeCaptured,
+    app: appCaptured,
+    forwarded: forwardedArgs,
+  })
+);

--- a/pkg/internal/nodejs/spanbridge_test/spanbridge.test.js
+++ b/pkg/internal/nodejs/spanbridge_test/spanbridge.test.js
@@ -124,6 +124,29 @@ test('multibyte strings truncate on a valid UTF-8 byte boundary', () => {
   assert.ok(r.nameOK, 'name must be whole characters (42 x €), no split sequence');
 });
 
+test('versioned pre-acquired tracer keeps name/version/options through the handoff', () => {
+  const r = runScript('scenario_versioned_tracer.js');
+  assert.deepStrictEqual(r.bridge, ['before'], 'bridge captures only the pre-registration span');
+  assert.deepStrictEqual(
+    r.app.map((s) => s.name),
+    ['after'],
+    'the app SDK captures the post-registration span'
+  );
+  assert.deepStrictEqual(
+    r.app[0].scope,
+    { name: 'app', version: '1.2.3', schemaUrl: 'https://example.com/1.2.3' },
+    'the app-exported span keeps the declared scope identity'
+  );
+  const fwd = r.forwarded.find((f) => f.name === 'app');
+  assert.ok(fwd, 'the bridge forwards getTracer to the app provider');
+  assert.strictEqual(fwd.version, '1.2.3', 'original version is forwarded');
+  assert.deepStrictEqual(
+    fwd.options,
+    { schemaUrl: 'https://example.com/1.2.3' },
+    'original options (schemaUrl) are forwarded'
+  );
+});
+
 test('SDK registers after injection: bridge yields and the app SDK takes over', () => {
   const r = runScenario('late-sdk');
   assert.deepStrictEqual(r.bridge, ['before'], 'bridge captures only the pre-handover span');


### PR DESCRIPTION
## Summary

Follow-up to #2661, requested in
[this review comment](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2661#discussion_r3807325929).

A tracer acquired through the span bridge before a late SDK registration cached only the scope *name*. 
After the handoff, the application's providerreceived neither the original `version` nor `options`, so spans from
pre-acquired tracers carried a degraded instrumentation scope.

The bridge `Tracer` now stores all three `getTracer` arguments and forwards them to the application provider on every post-handoff call (`startSpan` and `startActiveSpan`).

Includes a regression: a tracer acquired as `getTracer('app', '1.2.3', {schemaUrl})` before injection emits through the bridge, an SDK registers late, and the same tracer's next span must land in the app SDK with scope name and version intact (options asserted via a provider spy).

Note: `@opentelemetry/api` (1.9.x) itself forwards only `(name, version)` from `trace.getTracer(...)` to the provider, so the `options` case is only reachable via `getTracerProvider().getTracer(...)` — the regression covers both paths.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
