### PR TITLE
Add `server.port` attribute to `db.client.operation.duration`

### DIFF
--- a/internal/test/integration/red_test_python_redis.go
+++ b/internal/test/integration/red_test_python_redis.go
@@ -38,6 +38,8 @@ func testREDMetricsForPythonRedisLibrary(t *testing.T, testCase TestCase) {
 	for _, span := range testCase.Spans {
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			var err error
+			// server_port is present despite being the redis default port because
+			// the suite config explicitly includes all attributes (include: ["*"])
 			results, err = pq.Query(`db_client_operation_duration_seconds_count{` +
 				`db_operation_name="` + span.Name + `",` +
 				`server_port="6379",` +

--- a/internal/test/integration/red_test_python_redis.go
+++ b/internal/test/integration/red_test_python_redis.go
@@ -40,6 +40,7 @@ func testREDMetricsForPythonRedisLibrary(t *testing.T, testCase TestCase) {
 			var err error
 			results, err = pq.Query(`db_client_operation_duration_seconds_count{` +
 				`db_operation_name="` + span.Name + `",` +
+				`server_port="6379",` +
 				`service_namespace="` + namespace + `"}`)
 			require.NoError(ct, err, "failed to query prometheus for %s", span.Name)
 			enoughPromResults(ct, results)

--- a/pkg/appolly/app/request/span_getters.go
+++ b/pkg/appolly/app/request/span_getters.go
@@ -188,26 +188,8 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 		getter = func(span *Span) attribute.KeyValue { return DBOperationName(span.Method) }
 	case attr.DBSystemName:
 		getter = func(span *Span) attribute.KeyValue {
-			switch span.Type {
-			case EventTypeSQLClient, EventTypeSQLServer:
-				return DBSystemName(span.DBSystemName().Value.AsString())
-			case EventTypeRedisClient, EventTypeRedisServer:
-				return semconv.DBSystemNameRedis
-			case EventTypeMemcachedClient, EventTypeMemcachedServer:
-				return semconv.DBSystemNameMemcached
-			case EventTypeMongoClient:
-				return semconv.DBSystemNameMongoDB
-			case EventTypeCouchbaseClient:
-				return semconv.DBSystemNameCouchbase
-			case EventTypeAerospikeClient:
-				return DBSystemName("aerospike")
-			case EventTypeHTTPClient:
-				if span.SubType == HTTPSubtypeElasticsearch && span.Elasticsearch != nil {
-					return DBSystemName(span.Elasticsearch.DBSystemName)
-				}
-				if span.SubType == HTTPSubtypeSQLPP && span.DBSystem != "" {
-					return DBSystemName(span.DBSystem)
-				}
+			if name := dbSystemNameForSpan(span); name != "" {
+				return DBSystemName(name)
 			}
 			return attribute.KeyValue{}
 		}
@@ -615,4 +597,29 @@ func spanPromGetters(attrName attr.Name) attributes.Getter[*Span, string] {
 	// unlike the OTEL getters, when the attribute is not found, we need to look for it
 	// in the metadata section
 	return func(s *Span) string { return s.Service.Metadata[attrName] }
+}
+
+func dbSystemNameForSpan(span *Span) string {
+	switch span.Type {
+	case EventTypeSQLClient, EventTypeSQLServer:
+		return span.DBSystemName().Value.AsString()
+	case EventTypeRedisClient, EventTypeRedisServer:
+		return semconv.DBSystemNameRedis.Value.AsString()
+	case EventTypeMemcachedClient, EventTypeMemcachedServer:
+		return semconv.DBSystemNameMemcached.Value.AsString()
+	case EventTypeMongoClient:
+		return semconv.DBSystemNameMongoDB.Value.AsString()
+	case EventTypeCouchbaseClient:
+		return semconv.DBSystemNameCouchbase.Value.AsString()
+	case EventTypeAerospikeClient:
+		return "aerospike"
+	case EventTypeHTTPClient:
+		if span.SubType == HTTPSubtypeElasticsearch && span.Elasticsearch != nil {
+			return span.Elasticsearch.DBSystemName
+		}
+		if span.SubType == HTTPSubtypeSQLPP && span.DBSystem != "" {
+			return span.DBSystem
+		}
+	}
+	return ""
 }

--- a/pkg/appolly/app/request/span_getters_providers.go
+++ b/pkg/appolly/app/request/span_getters_providers.go
@@ -5,8 +5,10 @@ package request // import "go.opentelemetry.io/obi/pkg/appolly/app/request"
 
 import (
 	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 
 	"go.opentelemetry.io/obi/pkg/export/attributes"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 )
 
 type UnresolvedNames struct {
@@ -25,4 +27,65 @@ func SpanOTELGetters(unresolved UnresolvedNames) attributes.NamedGetters[*Span, 
 // user-provided configuration.
 func SpanPromGetters(unresolved UnresolvedNames) attributes.NamedGetters[*Span, string] {
 	return promUnresolvedHostGetters(unresolved)
+}
+
+var dbClientDefaultPorts = map[string]int{
+	semconv.DBSystemNamePostgreSQL.Value.AsString():         5432,
+	semconv.DBSystemNameMySQL.Value.AsString():              3306,
+	semconv.DBSystemNameMicrosoftSQLServer.Value.AsString(): 1433,
+	semconv.DBSystemNameRedis.Value.AsString():              6379,
+	semconv.DBSystemNameMemcached.Value.AsString():          11211,
+	semconv.DBSystemNameMongoDB.Value.AsString():            27017,
+	semconv.DBSystemNameCouchbase.Value.AsString():          11210,
+	"aerospike": 3000,
+	semconv.DBSystemNameElasticsearch.Value.AsString(): 9200,
+	semconv.DBSystemNameOpenSearch.Value.AsString():    9200,
+}
+
+// dbClientServerPortGetter implements the db.client.operation.duration semconv
+// condition for server.port: report it by default only for a known port other
+// than the DBMS default and only when the server address is set. When the user
+// explicitly includes the attribute, any known port is reported. An unknown
+// port (0) is always omitted.
+func dbClientServerPortGetter(explicitlyIncluded bool) attributes.Getter[*Span, attribute.KeyValue] {
+	return func(span *Span) attribute.KeyValue {
+		if span.HostPort == 0 {
+			return attribute.KeyValue{}
+		}
+		if explicitlyIncluded {
+			return ServerPort(span.HostPort)
+		}
+		if span.HostPort == dbClientDefaultPorts[dbSystemNameForSpan(span)] || HostAsServer(span) == "" {
+			return attribute.KeyValue{}
+		}
+		return ServerPort(span.HostPort)
+	}
+}
+
+func SpanOTELGettersForDBClient(unresolved UnresolvedNames, explicitPort bool) attributes.NamedGetters[*Span, attribute.KeyValue] {
+	base := SpanOTELGetters(unresolved)
+	portGetter := dbClientServerPortGetter(explicitPort)
+	return func(name attr.Name) (attributes.Getter[*Span, attribute.KeyValue], bool) {
+		if name == attr.ServerPort {
+			return portGetter, true
+		}
+		return base(name)
+	}
+}
+
+func SpanPromGettersForDBClient(unresolved UnresolvedNames, explicitPort bool) attributes.NamedGetters[*Span, string] {
+	base := SpanPromGetters(unresolved)
+	portGetter := dbClientServerPortGetter(explicitPort)
+	return func(name attr.Name) (attributes.Getter[*Span, string], bool) {
+		if name == attr.ServerPort {
+			return func(span *Span) string {
+				// fixed prometheus label sets map omission to an empty label
+				if kv := portGetter(span); kv.Valid() {
+					return kv.Value.String()
+				}
+				return ""
+			}, true
+		}
+		return base(name)
+	}
 }

--- a/pkg/appolly/app/request/span_getters_test.go
+++ b/pkg/appolly/app/request/span_getters_test.go
@@ -1239,3 +1239,78 @@ func TestSpanOTELGetters_Instance(t *testing.T) {
 	assert.Equal(t, string(attr.Instance), string(kv.Key))
 	assert.Equal(t, "instance-42", kv.Value.AsString())
 }
+
+func TestDBClientServerPortGetter(t *testing.T) {
+	postgres := func(port int, host string) *Span {
+		return &Span{Type: EventTypeSQLClient, SubType: int(DBPostgres), HostPort: port, Host: host}
+	}
+	tests := []struct {
+		name     string
+		explicit bool
+		span     *Span
+		expected int
+		omitted  bool
+	}{
+		{
+			name:     "default selection, non-default port with address",
+			span:     postgres(5433, "dbhost"),
+			expected: 5433,
+		},
+		{
+			name:    "default selection, DBMS default port",
+			span:    postgres(5432, "dbhost"),
+			omitted: true,
+		},
+		{
+			name:    "default selection, known port without address",
+			span:    postgres(5433, ""),
+			omitted: true,
+		},
+		{
+			name:    "default selection, unknown port",
+			span:    postgres(0, "dbhost"),
+			omitted: true,
+		},
+		{
+			name:    "default selection, redis default port",
+			span:    &Span{Type: EventTypeRedisClient, HostPort: 6379, Host: "cache"},
+			omitted: true,
+		},
+		{
+			name:     "default selection, no known default for the DBMS",
+			span:     &Span{Type: EventTypeSQLClient, HostPort: 5432, Host: "dbhost"},
+			expected: 5432,
+		},
+		{
+			name:     "explicit inclusion, DBMS default port",
+			explicit: true,
+			span:     postgres(5432, "dbhost"),
+			expected: 5432,
+		},
+		{
+			name:     "explicit inclusion, known port without address",
+			explicit: true,
+			span:     postgres(5433, ""),
+			expected: 5433,
+		},
+		{
+			name:     "explicit inclusion, unknown port",
+			explicit: true,
+			span:     postgres(0, "dbhost"),
+			omitted:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kv := dbClientServerPortGetter(tt.explicit)(tt.span)
+			if tt.omitted {
+				assert.False(t, kv.Valid(), "expected server.port to be omitted, got %v", kv)
+				return
+			}
+			require.True(t, kv.Valid(), "expected server.port to be reported")
+			assert.Equal(t, string(attr.ServerPort), string(kv.Key))
+			assert.Equal(t, int64(tt.expected), kv.Value.AsInt64())
+		})
+	}
+}

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -390,6 +390,7 @@ func getDefinitions(
 			SubGroups: []*AttrReportGroup{&appAttributes},
 			Attributes: map[attr.Name]Default{
 				attr.ServerAddr:       true,
+				attr.ServerPort:       true,
 				attr.DBOperation:      true,
 				attr.DBSystemName:     true,
 				attr.ErrorType:        true,

--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -209,6 +209,15 @@ func (p *AttrSelector) For(metricName Name) []attr.Name {
 	return sas
 }
 
+func (p *AttrSelector) ExplicitlyIncluded(metricName Name, attrName attr.Name) bool {
+	for _, il := range p.selector.Matching(metricName) {
+		if il.includes(attrName) {
+			return true
+		}
+	}
+	return false
+}
+
 // returns if the inclusion list have contents or not
 // this will be useful to decide whether to use the default
 // attribute set or not

--- a/pkg/export/attributes/attr_selector_test.go
+++ b/pkg/export/attributes/attr_selector_test.go
@@ -210,6 +210,41 @@ func TestDefault_DBClientDuration(t *testing.T) {
 	}, p.For(DBClientDuration))
 }
 
+func TestExplicitlyIncluded(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		selection Selection
+		expected  bool
+	}{
+		{name: "no user selection", selection: nil, expected: false},
+		{name: "selection for another metric", selection: Selection{
+			"http.client.request.duration": InclusionLists{Include: []string{"server.port"}},
+		}, expected: false},
+		{name: "exact name", selection: Selection{
+			"db.client.operation.duration": InclusionLists{Include: []string{"server.port"}},
+		}, expected: true},
+		{name: "prom-style name", selection: Selection{
+			"db_client_operation_duration": InclusionLists{Include: []string{"server_port"}},
+		}, expected: true},
+		{name: "attribute glob", selection: Selection{
+			"db.client.operation.duration": InclusionLists{Include: []string{"server.*"}},
+		}, expected: true},
+		{name: "metric and attribute globs", selection: Selection{
+			"*": InclusionLists{Include: []string{"*"}},
+		}, expected: true},
+		{name: "unrelated include", selection: Selection{
+			"db.client.operation.duration": InclusionLists{Include: []string{"db.collection.name"}},
+		}, expected: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.selection.Normalize()
+			p, err := NewAttrSelector(0, &SelectorConfig{SelectionCfg: tc.selection})
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, p.ExplicitlyIncluded(DBClientDuration, attr.ServerPort))
+		})
+	}
+}
+
 func TestDefaultSensitiveQueryParamsIncludesLegacyAWSSignedURLKeys(t *testing.T) {
 	assert.Contains(t, DefaultSensitiveQueryParams, "AWSAccessKeyId")
 	assert.Contains(t, DefaultSensitiveQueryParams, "Signature")

--- a/pkg/export/attributes/attr_selector_test.go
+++ b/pkg/export/attributes/attr_selector_test.go
@@ -196,6 +196,20 @@ func TestDefault(t *testing.T) {
 	assert.Equal(t, p.For(NetworkFlow), p.For(NetworkFlowPackets))
 }
 
+func TestDefault_DBClientDuration(t *testing.T) {
+	p, err := NewAttrSelector(0, &SelectorConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, []attr.Name{
+		attr.DBOperation,
+		attr.DBSystemName,
+		attr.ErrorType,
+		attr.ServerAddr,
+		attr.ServerPort,
+		attr.ServiceName,
+		attr.ServiceNamespace,
+	}, p.For(DBClientDuration))
+}
+
 func TestDefaultSensitiveQueryParamsIncludesLegacyAWSSignedURLKeys(t *testing.T) {
 	assert.Contains(t, DefaultSensitiveQueryParams, "AWSAccessKeyId")
 	assert.Contains(t, DefaultSensitiveQueryParams, "Signature")

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -270,8 +270,12 @@ func newMetricsReporter(
 	}
 
 	if is.DBEnabled() {
+		// server.port on db.client metrics is reported conditionally per the
+		// DB semconv, unless the user explicitly includes it
+		explicitPort := mr.attributes.ExplicitlyIncluded(attributes.DBClientDuration, attr.ServerPort)
 		mr.attrDBClient = attributes.OpenTelemetryGetters(
-			mr.attrGetters, mr.attributes.For(attributes.DBClientDuration))
+			request.SpanOTELGettersForDBClient(unresolved, explicitPort),
+			mr.attributes.For(attributes.DBClientDuration))
 		mr.attrDBServer = attributes.OpenTelemetryGetters(
 			mr.attrGetters, mr.attributes.For(attributes.DBServerDuration))
 	}

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -593,7 +593,7 @@ func TestAppMetrics_GenAITokenAvailability(t *testing.T) {
 	}
 }
 
-func TestAppMetrics_DBCollectionName(t *testing.T) {
+func TestAppMetrics_DBClientAttributes(t *testing.T) {
 	ctx := t.Context()
 	metricRecords := make(chan collector.MetricRecord, 10)
 	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
@@ -614,7 +614,7 @@ func TestAppMetrics_DBCollectionName(t *testing.T) {
 		&attributes.SelectorConfig{
 			SelectionCfg: attributes.Selection{
 				attributes.DBClientDuration.Section: attributes.InclusionLists{
-					Include: []string{string(attr.DBCollectionName)},
+					Include: []string{string(attr.DBCollectionName), string(attr.ServerPort)},
 				},
 			},
 		},
@@ -630,6 +630,7 @@ func TestAppMetrics_DBCollectionName(t *testing.T) {
 		Type:         request.EventTypeSQLClient,
 		Path:         "customers",
 		Method:       "SELECT",
+		HostPort:     5432,
 		RequestStart: 100,
 		End:          200,
 	}})
@@ -637,6 +638,7 @@ func TestAppMetrics_DBCollectionName(t *testing.T) {
 	records := readMetricsByName(t, metricRecords, timeout, attributes.DBClientDuration.OTEL)
 	require.Len(t, records, 1)
 	assert.Equal(t, "customers", records[0].Attributes[string(attr.DBCollectionName)])
+	assert.Equal(t, "5432", records[0].Attributes[string(attr.ServerPort)])
 }
 
 func TestSpanMetrics_ExtraResourceAttributes(t *testing.T) {

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -628,6 +628,7 @@ func TestAppMetrics_DBClientAttributes(t *testing.T) {
 	metrics.Send([]request.Span{{
 		Service:      svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}},
 		Type:         request.EventTypeSQLClient,
+		SubType:      int(request.DBPostgres),
 		Path:         "customers",
 		Method:       "SELECT",
 		HostPort:     5432,
@@ -638,7 +639,74 @@ func TestAppMetrics_DBClientAttributes(t *testing.T) {
 	records := readMetricsByName(t, metricRecords, timeout, attributes.DBClientDuration.OTEL)
 	require.Len(t, records, 1)
 	assert.Equal(t, "customers", records[0].Attributes[string(attr.DBCollectionName)])
+	// the DBMS default port is still reported because the user explicitly
+	// included server.port in the selection
 	assert.Equal(t, "5432", records[0].Attributes[string(attr.ServerPort)])
+}
+
+func TestAppMetrics_DBClientServerPortDefaultSelection(t *testing.T) {
+	ctx := t.Context()
+	metricRecords := make(chan collector.MetricRecord, 10)
+	metrics := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
+	processEvents := msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(10))
+	mcfg := &otelcfg.MetricsConfig{
+		Interval:          50 * time.Millisecond,
+		TTL:               30 * time.Minute,
+		ReportersCacheLen: 10,
+		Instrumentations:  []instrumentations.Instrumentation{instrumentations.InstrumentationSQL},
+		MetricsConsumer:   testMetricsConsumer(metricRecords),
+	}
+
+	reporter, err := newMetricsReporter(
+		ctx,
+		&global.ContextInfo{OTELMetricsExporter: &otelcfg.MetricsExporterInstancer{Cfg: mcfg}},
+		mcfg,
+		&perapp.GlobalMetricsConfig{Features: export.FeatureApplicationRED},
+		&attributes.SelectorConfig{},
+		request.UnresolvedNames{},
+		metrics,
+		processEvents,
+	)
+	require.NoError(t, err)
+	go reporter.reportMetrics(ctx)
+
+	postgresSpan := func(operation string, port int, host string) request.Span {
+		return request.Span{
+			Service:      svc.Attrs{Features: export.FeatureApplicationRED, UID: svc.UID{Instance: "foo"}},
+			Type:         request.EventTypeSQLClient,
+			SubType:      int(request.DBPostgres),
+			Method:       operation,
+			Host:         host,
+			HostPort:     port,
+			RequestStart: 100,
+			End:          200,
+		}
+	}
+	metrics.Send([]request.Span{
+		postgresSpan("NONDEFAULT", 5433, "dbhost"),
+		postgresSpan("DEFAULTPORT", 5432, "dbhost"),
+		postgresSpan("NOADDRESS", 5433, ""),
+		postgresSpan("UNKNOWNPORT", 0, "dbhost"),
+	})
+
+	records := map[string]collector.MetricRecord{}
+	deadline := time.After(timeout)
+	for len(records) < 4 {
+		select {
+		case item := <-metricRecords:
+			if item.Name != attributes.DBClientDuration.OTEL {
+				continue
+			}
+			records[item.Attributes[string(attr.DBOperation)]] = item
+		case <-deadline:
+			t.Fatalf("timeout waiting for db.client datapoints, got %v", records)
+		}
+	}
+
+	assert.Equal(t, "5433", records["NONDEFAULT"].Attributes[string(attr.ServerPort)])
+	assert.NotContains(t, records["DEFAULTPORT"].Attributes, string(attr.ServerPort))
+	assert.NotContains(t, records["NOADDRESS"].Attributes, string(attr.ServerPort))
+	assert.NotContains(t, records["UNKNOWNPORT"].Attributes, string(attr.ServerPort))
 }
 
 func TestSpanMetrics_ExtraResourceAttributes(t *testing.T) {

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -368,7 +368,11 @@ func newReporter(
 	var attrDBServerDuration []attributes.Field[*request.Span, string]
 
 	if is.DBEnabled() {
-		attrDBClientDuration = attributes.PrometheusGetters(attributeGetters,
+		// server.port on db.client metrics is reported conditionally per the
+		// DB semconv, unless the user explicitly includes it
+		explicitPort := attrsProvider.ExplicitlyIncluded(attributes.DBClientDuration, attr.ServerPort)
+		attrDBClientDuration = attributes.PrometheusGetters(
+			request.SpanPromGettersForDBClient(unresolved, explicitPort),
 			attrsProvider.For(attributes.DBClientDuration))
 		attrDBServerDuration = attributes.PrometheusGetters(attributeGetters,
 			attrsProvider.For(attributes.DBServerDuration))


### PR DESCRIPTION
## Summary

This PR simply adds `server.port` as a default attribute on the `db.client.operation.duration` metric.
[Otel secomv](https://opentelemetry.io/docs/specs/semconv/db/database-metrics/) recommends both `server.address` and `server.port` on this metric.

We are following the semconv conditional requirement: reported by default only for a known port other than the DBMS default and only when server.address is set. A user selection that explicitly includes `server.port` (exact name or glob, e.g. include: ["*"]) reports any known port, including the DBMS default; an unknown port is always omitted, never emitted as 0.


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
