### PR TITLE
logenricher: only consume pipes registered as tracked stdout/stderr

### DIFF
--- a/bpf/logenricher/logenricher.c
+++ b/bpf/logenricher/logenricher.c
@@ -18,6 +18,7 @@
 
 #include <logenricher/maps/log_enricher_pids.h>
 #include <logenricher/maps/log_events.h>
+#include <logenricher/maps/log_pipes.h>
 #include <logenricher/maps/pid_fd.h>
 #include <logenricher/maps/zeros.h>
 
@@ -105,8 +106,11 @@ static __always_inline u32 consume_iovec(log_event_t *e,
     return tot;
 }
 
-static __always_inline int
-__write(struct kiocb *iocb, struct iov_iter *from, const int fd, const struct task_struct *task) {
+static __always_inline int __write(struct kiocb *iocb,
+                                   struct iov_iter *from,
+                                   const int fd,
+                                   const u64 ino,
+                                   const struct task_struct *task) {
     iovec_iter_ctx ictx;
     get_iovec_ctx(&ictx, (struct iov_iter___dummy *)from);
 
@@ -126,6 +130,7 @@ __write(struct kiocb *iocb, struct iov_iter *from, const int fd, const struct ta
     e->tgid = pid_tgid >> 32;
     e->ctx = obi_ctx ? *obi_ctx : (obi_ctx_info_t){0};
     e->fd = fd;
+    e->ino = ino;
 
     u32 tot = 0;
 
@@ -199,7 +204,7 @@ int BPF_KPROBE(obi_kprobe_tty_write, struct kiocb *iocb, struct iov_iter *from) 
         return 0;
     }
 
-    return __write(iocb, from, 0, task);
+    return __write(iocb, from, 0, 0, task);
 }
 
 SEC("kprobe/pipe_write")
@@ -211,12 +216,18 @@ int BPF_KPROBE(obi_kprobe_pipe_write, struct kiocb *iocb, struct iov_iter *from)
         return 0;
     }
 
+    // only touch registered stdout/stderr pipes, anything else is app data
+    const u64 ino = BPF_CORE_READ(iocb, ki_filp, f_inode, i_ino);
+    if (!bpf_map_lookup_elem(&log_pipes, &ino)) {
+        return 0;
+    }
+
     int *fdp = bpf_map_lookup_elem(&pid_fd, &(u64){bpf_get_current_pid_tgid()});
     if (!fdp) {
         return 0;
     }
 
-    return __write(iocb, from, *fdp, task);
+    return __write(iocb, from, *fdp, ino, task);
 }
 
 static __always_inline int __record_fd(unsigned int fd) {

--- a/bpf/logenricher/logenricher.c
+++ b/bpf/logenricher/logenricher.c
@@ -109,7 +109,7 @@ static __always_inline u32 consume_iovec(log_event_t *e,
 static __always_inline int __write(struct kiocb *iocb,
                                    struct iov_iter *from,
                                    const int fd,
-                                   const u64 ino,
+                                   const log_pipe_key_t *pipe,
                                    const struct task_struct *task) {
     iovec_iter_ctx ictx;
     get_iovec_ctx(&ictx, (struct iov_iter___dummy *)from);
@@ -130,7 +130,8 @@ static __always_inline int __write(struct kiocb *iocb,
     e->tgid = pid_tgid >> 32;
     e->ctx = obi_ctx ? *obi_ctx : (obi_ctx_info_t){0};
     e->fd = fd;
-    e->ino = ino;
+    e->ino = pipe ? pipe->ino : 0;
+    e->dev = pipe ? (u32)pipe->dev : 0;
 
     u32 tot = 0;
 
@@ -204,7 +205,7 @@ int BPF_KPROBE(obi_kprobe_tty_write, struct kiocb *iocb, struct iov_iter *from) 
         return 0;
     }
 
-    return __write(iocb, from, 0, 0, task);
+    return __write(iocb, from, 0, NULL, task);
 }
 
 SEC("kprobe/pipe_write")
@@ -217,8 +218,12 @@ int BPF_KPROBE(obi_kprobe_pipe_write, struct kiocb *iocb, struct iov_iter *from)
     }
 
     // only touch registered stdout/stderr pipes, anything else is app data
-    const u64 ino = BPF_CORE_READ(iocb, ki_filp, f_inode, i_ino);
-    if (!bpf_map_lookup_elem(&log_pipes, &ino)) {
+    const struct inode *f_inode = BPF_CORE_READ(iocb, ki_filp, f_inode);
+    const log_pipe_key_t key = {
+        .ino = BPF_CORE_READ(f_inode, i_ino),
+        .dev = BPF_CORE_READ(f_inode, i_sb, s_dev),
+    };
+    if (!bpf_map_lookup_elem(&log_pipes, &key)) {
         return 0;
     }
 
@@ -227,7 +232,7 @@ int BPF_KPROBE(obi_kprobe_pipe_write, struct kiocb *iocb, struct iov_iter *from)
         return 0;
     }
 
-    return __write(iocb, from, *fdp, ino, task);
+    return __write(iocb, from, *fdp, &key, task);
 }
 
 static __always_inline int __record_fd(unsigned int fd) {

--- a/bpf/logenricher/maps/log_pipes.h
+++ b/bpf/logenricher/maps/log_pipes.h
@@ -8,12 +8,14 @@
 
 #include <common/pin_internal.h>
 
-// stdout/stderr pipe inodes of tracked processes, registered from userspace;
+#include <logenricher/types.h>
+
+// stdout/stderr pipes of tracked processes, registered from userspace;
 // not an LRU (silent eviction would stop capture for live pipes), sized for
 // two pipes per log_enricher_pids entry
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
-    __type(key, u64); // pipe inode
+    __type(key, log_pipe_key_t);
     __type(value, u8);
     __uint(max_entries, 1 << 13);
     __uint(pinning, OBI_PIN_INTERNAL);

--- a/bpf/logenricher/maps/log_pipes.h
+++ b/bpf/logenricher/maps/log_pipes.h
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/pin_internal.h>
+
+// stdout/stderr pipe inodes of tracked processes, registered from userspace;
+// not an LRU (silent eviction would stop capture for live pipes), sized for
+// two pipes per log_enricher_pids entry
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u64); // pipe inode
+    __type(value, u8);
+    __uint(max_entries, 1 << 13);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} log_pipes SEC(".maps");

--- a/bpf/logenricher/types.h
+++ b/bpf/logenricher/types.h
@@ -46,11 +46,14 @@ typedef struct log_event {
 const log_event_t *log_event__unused __attribute__((unused));
 
 // bare inode numbers collide across filesystems (pipefs vs on-disk FIFOs,
-// and get_next_ino() wraps at 32 bits), so pipes are keyed by (ino, dev)
+// and get_next_ino() wraps at 32 bits), so pipes are keyed by (ino, dev).
+// dev holds a 32-bit kernel dev_t; u64 keeps the key free of implicit padding
 typedef struct log_pipe_key {
     u64 ino;
     u64 dev;
 } log_pipe_key_t;
+
+const log_pipe_key_t *log_pipe_key__unused __attribute__((unused));
 
 enum tty_driver_type___new {
     TTY_DRIVER_TYPE_SYSTEM,

--- a/bpf/logenricher/types.h
+++ b/bpf/logenricher/types.h
@@ -33,9 +33,11 @@ enum {
 static const char k_newline = '\n';
 
 typedef struct log_event {
+    u64 ino;
     u32 tgid;
     u32 len;
     u32 fd;
+    u32 _pad;
     obi_ctx_info_t ctx;
     u8 file_path[k_pts_file_path_len_max];
     u8 log[];

--- a/bpf/logenricher/types.h
+++ b/bpf/logenricher/types.h
@@ -37,13 +37,20 @@ typedef struct log_event {
     u32 tgid;
     u32 len;
     u32 fd;
-    u32 _pad;
+    u32 dev; // kernel dev_t of the pipe's superblock, disambiguates ino across filesystems
     obi_ctx_info_t ctx;
     u8 file_path[k_pts_file_path_len_max];
     u8 log[];
 } log_event_t;
 
 const log_event_t *log_event__unused __attribute__((unused));
+
+// bare inode numbers collide across filesystems (pipefs vs on-disk FIFOs,
+// and get_next_ino() wraps at 32 bits), so pipes are keyed by (ino, dev)
+typedef struct log_pipe_key {
+    u64 ino;
+    u64 dev;
+} log_pipe_key_t;
 
 enum tty_driver_type___new {
     TTY_DRIVER_TYPE_SYSTEM,

--- a/devdocs/trace-log-correlation.md
+++ b/devdocs/trace-log-correlation.md
@@ -22,7 +22,7 @@ OBI can enrich JSON and plain-text log lines with trace and span fields, linking
 
 ## Overview
 
-The logenricher hooks into write paths (`tty_write`, `pipe_write`, `ksys_write`, `do_writev`) to intercept log output. When a write occurs it:
+The logenricher hooks into write paths (`tty_write`, `pipe_write`, `ksys_write`, `do_writev`) to intercept log output. Pipe writes are only intercepted for pipes registered as a tracked process's stdout or stderr (keyed by inode and device in the `log_pipes` BPF map): any other pipe — shell command substitutions, application IPC, a pipe on a non-stdio fd — is application data and passes through untouched and un-enriched. When a write to a log destination occurs it:
 
 1. Looks up `traces_ctx_v1[pid_tgid]` to get the active trace/span context for the calling thread.
 2. Reads the user buffer via `bpf_probe_read_user`, packages the log line together with the trace context into a `log_event_t`, and submits it to the `log_events` ring buffer.

--- a/internal/test/integration/components/shellsubst/Dockerfile
+++ b/internal/test/integration/components/shellsubst/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
+
+# a uniquely-named shell binary so OBI can target it via executable-path discovery
+RUN cp /bin/dash /substsh
+
+COPY internal/test/integration/components/shellsubst/subst_loop.sh /subst_loop.sh
+
+ENTRYPOINT ["/substsh", "/subst_loop.sh"]

--- a/internal/test/integration/components/shellsubst/subst_loop.sh
+++ b/internal/test/integration/components/shellsubst/subst_loop.sh
@@ -1,0 +1,13 @@
+#!/substsh
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# V crosses a $() pipe held open 400ms after writing: a buggy enricher grabs
+# it, and V comes back empty or the loop hangs
+i=0
+while true; do
+    i=$((i + 1))
+    V=$(echo "v$i"; sleep 0.4)
+    echo "subst i=$i V=$V"
+    sleep 0.1
+done

--- a/internal/test/integration/configs/obi-config-log-enricher.yml
+++ b/internal/test/integration/configs/obi-config-log-enricher.yml
@@ -17,6 +17,7 @@ ebpf:
     services:
       - service:
         - open_ports: "8380,50051,3030,8085,3040,8388"
+        - exe_path: "*substsh*"
 discovery:
   min_process_age: "0s"
 log_config: "yaml"

--- a/internal/test/integration/docker-compose-log-enricher.yml
+++ b/internal/test/integration/docker-compose-log-enricher.yml
@@ -90,6 +90,14 @@ services:
     environment:
       PORT: "8388"
 
+  testservershellsubst:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/shellsubst/Dockerfile
+    image: hatest-testserver-logenricher-shellsubst
+    networks:
+      - shared
+
   multisegwritev_otelcol:
     image: otel/opentelemetry-collector-contrib:0.159.0@sha256:1f2c54a30e713fac6b3ae77a1ec84010c2007e29ced8ec666214fc2f6739c1cc
     user: "0:0"
@@ -167,6 +175,8 @@ services:
       testserverpythonasync:
         condition: service_started
       testservermultisegwritev:
+        condition: service_started
+      testservershellsubst:
         condition: service_started
 
 networks:

--- a/internal/test/integration/log_enricher_test.go
+++ b/internal/test/integration/log_enricher_test.go
@@ -109,6 +109,14 @@ var (
 const logEnricherGoWritevRegressionLeakMarker = "writev-leak-marker-should-never-appear"
 
 const (
+	logEnricherShellSubstImage  = "hatest-testserver-logenricher-shellsubst"
+	logEnricherShellSubstMarker = "subst i="
+)
+
+// a missing or mismatched V means the enricher corrupted the $() substitution
+var logEnricherShellSubstLineRE = regexp.MustCompile(`^subst i=(\d+) V=v(\d+)$`)
+
+const (
 	logEnricherPlainTextFirstMessage  = "plain-text first line"
 	logEnricherPlainTextSecondMessage = "plain-text second line"
 	logEnricherNDJSONFirstMessage     = "ndjson first record"
@@ -758,6 +766,74 @@ func testLogEnricherMultiSegWritev(t *testing.T) {
 			}
 		}
 	}, testTimeout, 500*time.Millisecond)
+}
+
+// $() pipe content is application data, not a log: it must arrive intact and
+// the shell must never hang waiting for EOF on a pipe the enricher held open
+func testLogEnricherShellSubstitution(t *testing.T) {
+	cl, err := client.New(client.FromEnv)
+	require.NoError(t, err)
+	defer cl.Close()
+
+	countSubstLines := func(logs []string) int {
+		n := 0
+		for _, line := range logs {
+			if strings.Contains(line, logEnricherShellSubstMarker) {
+				n++
+			}
+		}
+		return n
+	}
+
+	// wait until OBI instruments the substitution shell
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		obiID := testContainerID(ct, cl, "hatest-obi")
+		if !assert.NotEmpty(ct, obiID, "could not find OBI container ID") {
+			return
+		}
+		instrumented := false
+		for _, line := range containerLogs(ct, cl, obiID) {
+			if strings.Contains(line, "instrumenting process") && strings.Contains(line, "substsh") {
+				instrumented = true
+				break
+			}
+		}
+		assert.True(ct, instrumented, "OBI has not instrumented the substitution shell yet")
+	}, testTimeout, time.Second)
+
+	containerID := testContainerID(t, cl, logEnricherShellSubstImage)
+	require.NotEmpty(t, containerID, "could not find test container ID")
+
+	baseline := countSubstLines(containerLogs(t, cl, containerID))
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		logs := containerLogs(ct, cl, containerID)
+
+		// NUL ghost lines prove enrichment is active, so the test can't pass vacuously
+		ghostSeen := false
+		for _, line := range logs {
+			if strings.ContainsRune(line, 0) {
+				ghostSeen = true
+				break
+			}
+		}
+		assert.True(ct, ghostSeen, "no NUL ghost lines: log enrichment is not active on this container")
+
+		// the loop must keep producing lines
+		assert.GreaterOrEqual(ct, countSubstLines(logs), baseline+20,
+			"substitution loop is not advancing: shell likely blocked on a held $() pipe")
+
+		// no corruption: every substitution came through intact
+		for _, line := range logs {
+			if !strings.Contains(line, logEnricherShellSubstMarker) {
+				continue
+			}
+			m := logEnricherShellSubstLineRE.FindStringSubmatch(line)
+			if assert.NotNil(ct, m, "corrupted substitution line: %q", line) {
+				assert.Equal(ct, m[1], m[2], "substitution returned a stale value: %q", line)
+			}
+		}
+	}, testTimeout, time.Second)
 }
 
 // testLogEnricherShipperFilters validates the otelcol and fluent-bit filter

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -1228,6 +1228,19 @@ func TestSuite_LogEnricherPythonAsync(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_LogEnricherShellSubstitution(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-log-enricher.yml", path.Join(pathOutput, "test-suite-log-enricher-shellsubst.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=`, `OTEL_EBPF_EXECUTABLE_PATH=substsh`)
+	require.NoError(t, compose.Up())
+
+	t.Run("Log Enricher shell command substitution", func(t *testing.T) {
+		testLogEnricherShellSubstitution(t)
+	})
+	require.NoError(t, compose.Close())
+}
+
 func TestSuite_LogEnricherMultiSegWritev(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-log-enricher.yml", path.Join(pathOutput, "test-suite-log-enricher-multiseg-writev.log"))
 	require.NoError(t, err)

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"sync"
 	"unsafe"
@@ -40,6 +41,7 @@ import (
 type LogEvent struct {
 	orig    BpfLogEventT
 	logLine string
+	dest    string
 }
 
 type Tracer struct {
@@ -51,8 +53,10 @@ type Tracer struct {
 	fdCache     *expirable.LRU[string, *os.File]
 	asyncWriter *shardedqueue.ShardedQueue[LogEvent]
 	formatter   logFormatter
-	pids        map[uint64][]uint64       // pid:[]nsPids
-	pidServices map[uint32]*exec.FileInfo // host pid -> file info, for run-time OTel-export check in handle()
+	pids        map[uint64][]uint64         // pid:[]nsPids
+	pidServices map[uint32]*exec.FileInfo   // host pid -> file info, for run-time OTel-export check in handle()
+	logPipes    map[uint64]map[uint32][]int // log pipe inode -> host pid -> fds (1 and/or 2)
+	pidPipes    map[uint32][]uint64         // host pid -> registered log pipe inodes
 	pidsMU      sync.Mutex
 }
 
@@ -73,12 +77,14 @@ func New(cfg *obi.Config) *Tracer {
 		formatter:   newLogFormatter(cfg.EBPF.LogEnricher),
 		pids:        make(map[uint64][]uint64),
 		pidServices: make(map[uint32]*exec.FileInfo),
+		logPipes:    make(map[uint64]map[uint32][]int),
+		pidPipes:    make(map[uint32][]uint64),
 	}
 
 	asyncWriter := shardedqueue.NewShardedQueue[LogEvent](
 		cfg.EBPF.LogEnricher.AsyncWriterWorkers,
 		cfg.EBPF.LogEnricher.AsyncWriterChannelLen,
-		func(e LogEvent) string { return e.filePath() },
+		func(e LogEvent) string { return e.dest },
 		func(_ int, ch <-chan LogEvent) {
 			for e := range ch {
 				tr.handle(e)
@@ -270,6 +276,8 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 		p.log.Error(err.Error())
 	}
 
+	p.registerLogPipes(uint32(pid))
+
 	nsPids, err := procs.FindNamespacedPids(pid)
 	if err != nil {
 		p.log.Error("allow pid: error finding namespaced pids", "error", err)
@@ -289,11 +297,118 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 	}
 }
 
+// callers must hold pidsMU
+func (p *Tracer) registerLogPipes(pid uint32) {
+	for _, fd := range []int{1, 2} {
+		path := procFdPath(pid, fd)
+
+		var st unix.Stat_t
+		if err := unix.Stat(path, &st); err != nil {
+			p.log.Debug("cannot stat process fd", "path", path, "error", err)
+			continue
+		}
+		if st.Mode&unix.S_IFMT != unix.S_IFIFO {
+			continue
+		}
+
+		owners := p.logPipes[st.Ino]
+		if owners == nil {
+			owners = make(map[uint32][]int)
+			p.logPipes[st.Ino] = owners
+
+			if p.bpfObjects.LogPipes == nil {
+				p.log.Error("BPF objects not loaded, cannot register log pipe", "ino", st.Ino)
+			} else if err := p.bpfObjects.LogPipes.Put(st.Ino, uint8(1)); err != nil {
+				p.log.Error("error registering log pipe in bpf map", "ino", st.Ino, "error", err)
+			}
+		}
+
+		owners[pid] = append(owners[pid], fd)
+		p.pidPipes[pid] = append(p.pidPipes[pid], st.Ino)
+	}
+}
+
+// callers must hold pidsMU
+func (p *Tracer) unregisterLogPipes(pid uint32) {
+	for _, ino := range p.pidPipes[pid] {
+		owners := p.logPipes[ino]
+
+		if fds, ok := owners[pid]; ok {
+			delete(owners, pid)
+			// a held write end would rob readers of EOF once the owner exits
+			for _, fd := range fds {
+				p.fdCache.Remove(procFdPath(pid, fd))
+			}
+		}
+
+		if len(owners) > 0 {
+			continue
+		}
+
+		delete(p.logPipes, ino)
+
+		if p.bpfObjects.LogPipes == nil {
+			continue
+		}
+		if err := p.bpfObjects.LogPipes.Delete(ino); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+			p.log.Error("error removing log pipe from bpf map", "ino", ino, "error", err)
+		}
+	}
+
+	delete(p.pidPipes, pid)
+}
+
+// deterministic order: the chosen path is the shard key, keeping lines ordered
+func (p *Tracer) pipeDestCandidates(ino uint64) []string {
+	p.pidsMU.Lock()
+	defer p.pidsMU.Unlock()
+
+	owners := p.logPipes[ino]
+
+	pids := make([]uint32, 0, len(owners))
+	for pid := range owners {
+		pids = append(pids, pid)
+	}
+	slices.Sort(pids)
+
+	var paths []string
+	for _, pid := range pids {
+		for _, fd := range owners[pid] {
+			paths = append(paths, procFdPath(pid, fd))
+		}
+	}
+
+	return paths
+}
+
+func (p *Tracer) pipeRegistered(ino uint64) bool {
+	p.pidsMU.Lock()
+	defer p.pidsMU.Unlock()
+
+	_, ok := p.logPipes[ino]
+	return ok
+}
+
+// reject the stdout fallback when it points at an unregistered pipe (app IPC)
+func (p *Tracer) fallbackDestSafe(path string) bool {
+	var st unix.Stat_t
+	if err := unix.Stat(path, &st); err != nil {
+		return false
+	}
+
+	if st.Mode&unix.S_IFMT != unix.S_IFIFO {
+		return true
+	}
+
+	return p.pipeRegistered(st.Ino)
+}
+
 func (p *Tracer) BlockPID(pid app.PID, ns uint32) {
 	p.pidsMU.Lock()
 	defer p.pidsMU.Unlock()
 
 	delete(p.pidServices, uint32(pid))
+	p.unregisterLogPipes(uint32(pid))
 
 	pk := p.pidKey(ns, uint32(pid))
 	if err := p.removePID(pk); err != nil {
@@ -357,23 +472,62 @@ func (p *Tracer) handleLogEvent(record *ringbuf.Record) (request.Span, bool, err
 	// Open the destination now, while the writing process is still alive: the
 	// open file description keeps the log pipe writable even if the process is
 	// gone by the time the async writer gets to this line.
-	if _, err := p.openLogDestination(e.filePath()); err != nil {
-		p.logOpenError(e.filePath(), err)
-		return request.Span{}, true, nil
+	if event.Fd != 0 {
+		// address the pipe through a live owner, the writer may already be gone
+		for _, candidate := range p.pipeDestCandidates(event.Ino) {
+			if _, err := p.openLogDestination(candidate, event.Ino); err == nil {
+				e.dest = candidate
+				break
+			}
+		}
+		if e.dest == "" {
+			p.log.Debug("no live destination for log pipe, dropping line", "ino", event.Ino)
+			return request.Span{}, true, nil
+		}
+	} else {
+		e.dest = e.ttyPath()
+		if unix.ByteSliceToString(event.FilePath[:]) == "" && !p.fallbackDestSafe(e.dest) {
+			p.log.Debug("unsafe tty fallback destination, dropping line", "path", e.dest)
+			return request.Span{}, true, nil
+		}
+		if _, err := p.openLogDestination(e.dest, 0); err != nil {
+			p.logOpenError(e.dest, err)
+			return request.Span{}, true, nil
+		}
 	}
 
 	err = p.asyncWriter.Enqueue(p.ctx, e)
 	return request.Span{}, true, err
 }
 
-func (p *Tracer) openLogDestination(path string) (*os.File, error) {
+var errStaleDestination = errors.New("destination no longer points at the captured pipe")
+
+func fileIno(f *os.File) uint64 {
+	var st unix.Stat_t
+	if err := unix.Fstat(int(f.Fd()), &st); err != nil {
+		return 0
+	}
+
+	return st.Ino
+}
+
+// a non-zero ino pins the destination: /proc fd paths re-point when the owner
+// redirects its stdio, and writing there would leak lines into the wrong file
+func (p *Tracer) openLogDestination(path string, ino uint64) (*os.File, error) {
 	if f, ok := p.fdCache.Get(path); ok {
-		return f, nil
+		if ino == 0 || fileIno(f) == ino {
+			return f, nil
+		}
+		p.fdCache.Remove(path)
 	}
 
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
 	if err != nil {
 		return nil, err
+	}
+	if ino != 0 && fileIno(f) != ino {
+		f.Close()
+		return nil, errStaleDestination
 	}
 	p.fdCache.Add(path, f)
 
@@ -391,23 +545,15 @@ func (p *Tracer) logOpenError(path string, err error) {
 	p.log.Error("failed to open log file for writing", "path", path, "error", err)
 }
 
-func (e LogEvent) filePath() string {
-	var fp string
+func procFdPath(pid uint32, fd int) string {
+	return filepath.Join("/proc", strconv.FormatUint(uint64(pid), 10), "fd", strconv.Itoa(fd))
+}
 
-	procFdPath := func(fd int) string {
-		return filepath.Join("/proc", strconv.FormatUint(uint64(e.orig.Tgid), 10), "fd", strconv.Itoa(fd))
-	}
-
-	if e.orig.Fd != 0 {
-		// This is a pipe write, use the target process pipe fd
-		fp = procFdPath(int(e.orig.Fd))
-	} else {
-		// TTY write
-		fp = unix.ByteSliceToString(e.orig.FilePath[:])
-		if fp == "" {
-			// Fallback to process stdout in the case path resolver failed
-			fp = procFdPath(1)
-		}
+func (e LogEvent) ttyPath() string {
+	fp := unix.ByteSliceToString(e.orig.FilePath[:])
+	if fp == "" {
+		// Fallback to process stdout in the case path resolver failed
+		fp = procFdPath(e.orig.Tgid, 1)
 	}
 
 	return fp
@@ -415,9 +561,9 @@ func (e LogEvent) filePath() string {
 
 func (p *Tracer) handle(e LogEvent) {
 	// normally warmed at capture time; reopened only if the cache evicted it
-	f, err := p.openLogDestination(e.filePath())
+	f, err := p.openLogDestination(e.dest, e.orig.Ino)
 	if err != nil {
-		p.logOpenError(e.filePath(), err)
+		p.logOpenError(e.dest, err)
 		return
 	}
 

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -37,7 +37,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 
-//go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -type log_event_t -target amd64,arm64 Bpf ../../../../bpf/logenricher/logenricher.c -- -I../../../../bpf -I../../../../bpf
+//go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -type log_event_t -type log_pipe_key_t -target amd64,arm64 Bpf ../../../../bpf/logenricher/logenricher.c -- -I../../../../bpf -I../../../../bpf
 
 type LogEvent struct {
 	orig    BpfLogEventT
@@ -48,10 +48,7 @@ type LogEvent struct {
 
 // pipe identity as the BPF map sees it: inode number plus the kernel dev_t of
 // its superblock, since bare inode numbers collide across filesystems
-type pipeKey struct {
-	Ino uint64
-	Dev uint64
-}
+type pipeKey = BpfLogPipeKeyT
 
 type Tracer struct {
 	ctx         context.Context
@@ -295,7 +292,12 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 
 	nsPids, err := procs.FindNamespacedPids(pid)
 	if err != nil {
-		p.log.Error("allow pid: error finding namespaced pids", "error", err)
+		// short-lived processes routinely exit before discovery allows them
+		if errors.Is(err, os.ErrNotExist) {
+			p.log.Debug("allow pid: process gone before namespaced pid lookup", "pid", pid, "error", err)
+		} else {
+			p.log.Error("allow pid: error finding namespaced pids", "error", err)
+		}
 		return
 	}
 

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -43,6 +43,14 @@ type LogEvent struct {
 	orig    BpfLogEventT
 	logLine string
 	dest    string
+	pin     pipeKey // destination identity the write must land on; zero when unpinned
+}
+
+// pipe identity as the BPF map sees it: inode number plus the kernel dev_t of
+// its superblock, since bare inode numbers collide across filesystems
+type pipeKey struct {
+	Ino uint64
+	Dev uint64
 }
 
 type Tracer struct {
@@ -54,12 +62,13 @@ type Tracer struct {
 	fdCache     *expirable.LRU[string, *os.File]
 	asyncWriter *shardedqueue.ShardedQueue[LogEvent]
 	formatter   logFormatter
-	pids        map[uint64][]uint64         // pid:[]nsPids
-	pidServices map[uint32]*exec.FileInfo   // host pid -> file info, for run-time OTel-export check in handle()
-	trackedPids map[uint32]struct{}         // host pids currently allowed
-	logPipes    map[uint64]map[uint32][]int // log pipe inode -> host pid -> fds (1 and/or 2)
-	pidPipes    map[uint32]map[int]uint64   // host pid -> fd -> registered log pipe inode
+	pids        map[uint64][]uint64       // pid:[]nsPids
+	pidServices map[uint32]*exec.FileInfo // host pid -> file info, for run-time OTel-export check in handle()
 	pidsMU      sync.Mutex
+	trackedPids map[uint32]struct{}          // host pids currently allowed
+	logPipes    map[pipeKey]map[uint32][]int // log pipe -> host pid -> fds (1 and/or 2)
+	pidPipes    map[uint32]map[int]pipeKey   // host pid -> fd -> registered log pipe
+	pipesMU     sync.RWMutex                 // guards trackedPids, logPipes, pidPipes; hot-path readers vs reconcile
 }
 
 func New(cfg *obi.Config) *Tracer {
@@ -80,14 +89,14 @@ func New(cfg *obi.Config) *Tracer {
 		pids:        make(map[uint64][]uint64),
 		pidServices: make(map[uint32]*exec.FileInfo),
 		trackedPids: make(map[uint32]struct{}),
-		logPipes:    make(map[uint64]map[uint32][]int),
-		pidPipes:    make(map[uint32]map[int]uint64),
+		logPipes:    make(map[pipeKey]map[uint32][]int),
+		pidPipes:    make(map[uint32]map[int]pipeKey),
 	}
 
 	asyncWriter := shardedqueue.NewShardedQueue[LogEvent](
 		cfg.EBPF.LogEnricher.AsyncWriterWorkers,
 		cfg.EBPF.LogEnricher.AsyncWriterChannelLen,
-		func(e LogEvent) string { return e.dest },
+		func(e LogEvent) string { return e.shardKey() },
 		func(_ int, ch <-chan LogEvent) {
 			for e := range ch {
 				tr.handle(e)
@@ -267,6 +276,11 @@ func (p *Tracer) removePID(key uint64) error {
 }
 
 func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
+	p.pipesMU.Lock()
+	p.trackedPids[uint32(pid)] = struct{}{}
+	p.pipesMU.Unlock()
+	p.registerLogPipes(uint32(pid))
+
 	p.pidsMU.Lock()
 	defer p.pidsMU.Unlock()
 
@@ -278,9 +292,6 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 	if err := p.addPID(pk); err != nil {
 		p.log.Error(err.Error())
 	}
-
-	p.trackedPids[uint32(pid)] = struct{}{}
-	p.registerLogPipes(uint32(pid))
 
 	nsPids, err := procs.FindNamespacedPids(pid)
 	if err != nil {
@@ -301,67 +312,89 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 	}
 }
 
-// pipe inode behind /proc/<pid>/fd/<fd>, 0 when gone or not a pipe
-func statPipeIno(pid uint32, fd int) uint64 {
-	var st unix.Stat_t
-	if err := unix.Stat(procFdPath(pid, fd), &st); err != nil {
-		return 0
-	}
-	if st.Mode&unix.S_IFMT != unix.S_IFIFO {
-		return 0
-	}
-
-	return st.Ino
+// userspace stat encodes dev_t differently from the kernel s_dev the BPF
+// program reads; undo the stat encoding so both sides agree on the key
+func kernelDev(dev uint64) uint64 {
+	return uint64(unix.Major(dev))<<20 | uint64(unix.Minor(dev))
 }
 
-// registerLogPipes records the current pipe inodes behind stdout/stderr,
-// retiring registrations the process redirected away from. Callers must
-// hold pidsMU
+// pipe identity behind /proc/<pid>/fd/<fd>, zero when gone or not a pipe
+func statPipeKey(pid uint32, fd int) pipeKey {
+	var st unix.Stat_t
+	if err := unix.Stat(procFdPath(pid, fd), &st); err != nil {
+		return pipeKey{}
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFIFO {
+		return pipeKey{}
+	}
+
+	return pipeKey{Ino: st.Ino, Dev: kernelDev(st.Dev)}
+}
+
+// registerLogPipes records the pipes currently behind stdout/stderr, retiring
+// registrations the process redirected away from. The stats run unlocked so
+// slow /proc access never stalls the event hot path
 func (p *Tracer) registerLogPipes(pid uint32) {
-	for _, fd := range []int{1, 2} {
-		ino := statPipeIno(pid, fd)
+	var desired [2]pipeKey
+	for i, fd := range []int{1, 2} {
+		desired[i] = statPipeKey(pid, fd)
+	}
+
+	p.pipesMU.Lock()
+	defer p.pipesMU.Unlock()
+
+	// the pid may have been blocked while stating; registering would leak
+	if _, ok := p.trackedPids[pid]; !ok {
+		return
+	}
+
+	for i, fd := range []int{1, 2} {
+		key := desired[i]
 		current := p.pidPipes[pid][fd]
-		if current == ino {
+		if current == key {
 			continue
 		}
 
-		if current != 0 {
+		if current != (pipeKey{}) {
 			p.removePipeFD(pid, fd, current)
 		}
-		if ino != 0 {
-			p.addPipeFD(pid, fd, ino)
+		if key != (pipeKey{}) {
+			p.addPipeFD(pid, fd, key)
 		}
 	}
 }
 
-// callers must hold pidsMU
-func (p *Tracer) addPipeFD(pid uint32, fd int, ino uint64) {
-	owners := p.logPipes[ino]
+// callers must hold pipesMU. On BPF update failure nothing is recorded, so
+// the next reconcile retries instead of leaving the pipe silently unenriched
+func (p *Tracer) addPipeFD(pid uint32, fd int, key pipeKey) {
+	owners := p.logPipes[key]
 	if owners == nil {
-		owners = make(map[uint32][]int)
-		p.logPipes[ino] = owners
-
 		if p.bpfObjects.LogPipes == nil {
-			p.log.Error("BPF objects not loaded, cannot register log pipe", "ino", ino)
-		} else if err := p.bpfObjects.LogPipes.Put(ino, uint8(1)); err != nil {
-			p.log.Error("error registering log pipe in bpf map", "ino", ino, "error", err)
+			p.log.Error("BPF objects not loaded, cannot register log pipe", "ino", key.Ino, "dev", key.Dev)
+			return
 		}
+		if err := p.bpfObjects.LogPipes.Put(key, uint8(1)); err != nil {
+			p.log.Error("error registering log pipe in bpf map", "ino", key.Ino, "dev", key.Dev, "error", err)
+			return
+		}
+		owners = make(map[uint32][]int)
+		p.logPipes[key] = owners
 	}
 	owners[pid] = append(owners[pid], fd)
 
 	if p.pidPipes[pid] == nil {
-		p.pidPipes[pid] = make(map[int]uint64)
+		p.pidPipes[pid] = make(map[int]pipeKey)
 	}
-	p.pidPipes[pid][fd] = ino
+	p.pidPipes[pid][fd] = key
 }
 
-// callers must hold pidsMU
-func (p *Tracer) removePipeFD(pid uint32, fd int, ino uint64) {
+// callers must hold pipesMU
+func (p *Tracer) removePipeFD(pid uint32, fd int, key pipeKey) {
 	delete(p.pidPipes[pid], fd)
 	// a held write end would rob readers of EOF once the fd is gone
 	p.fdCache.Remove(procFdPath(pid, fd))
 
-	owners := p.logPipes[ino]
+	owners := p.logPipes[key]
 	if fds, ok := owners[pid]; ok {
 		fds = slices.DeleteFunc(fds, func(f int) bool { return f == fd })
 		if len(fds) > 0 {
@@ -374,42 +407,46 @@ func (p *Tracer) removePipeFD(pid uint32, fd int, ino uint64) {
 		return
 	}
 
-	delete(p.logPipes, ino)
+	delete(p.logPipes, key)
 
 	if p.bpfObjects.LogPipes == nil {
 		return
 	}
-	if err := p.bpfObjects.LogPipes.Delete(ino); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
-		p.log.Error("error removing log pipe from bpf map", "ino", ino, "error", err)
+	if err := p.bpfObjects.LogPipes.Delete(key); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+		p.log.Error("error removing log pipe from bpf map", "ino", key.Ino, "dev", key.Dev, "error", err)
 	}
 }
 
-// callers must hold pidsMU
+// callers must hold pipesMU
 func (p *Tracer) unregisterLogPipes(pid uint32) {
-	for fd, ino := range p.pidPipes[pid] {
-		p.removePipeFD(pid, fd, ino)
+	for fd, key := range p.pidPipes[pid] {
+		p.removePipeFD(pid, fd, key)
 	}
 
 	delete(p.pidPipes, pid)
 }
 
 // processes may redirect their stdio after discovery; re-stat and diff so new
-// pipes get enriched and stale registrations and fd handles are retired
+// pipes get enriched, stale registrations and fd handles are retired, and
+// failed BPF registrations are retried
 func (p *Tracer) reconcileLogPipes() {
-	p.pidsMU.Lock()
-	defer p.pidsMU.Unlock()
-
+	p.pipesMU.RLock()
+	pids := make([]uint32, 0, len(p.trackedPids))
 	for pid := range p.trackedPids {
+		pids = append(pids, pid)
+	}
+	p.pipesMU.RUnlock()
+
+	for _, pid := range pids {
 		p.registerLogPipes(pid)
 	}
 }
 
-// deterministic order: the chosen path is the shard key, keeping lines ordered
-func (p *Tracer) pipeDestCandidates(ino uint64) []string {
-	p.pidsMU.Lock()
-	defer p.pidsMU.Unlock()
+func (p *Tracer) pipeDestCandidates(key pipeKey) []string {
+	p.pipesMU.RLock()
+	defer p.pipesMU.RUnlock()
 
-	owners := p.logPipes[ino]
+	owners := p.logPipes[key]
 
 	pids := make([]uint32, 0, len(owners))
 	for pid := range owners {
@@ -427,35 +464,40 @@ func (p *Tracer) pipeDestCandidates(ino uint64) []string {
 	return paths
 }
 
-func (p *Tracer) pipeRegistered(ino uint64) bool {
-	p.pidsMU.Lock()
-	defer p.pidsMU.Unlock()
+func (p *Tracer) pipeRegistered(key pipeKey) bool {
+	p.pipesMU.RLock()
+	defer p.pipesMU.RUnlock()
 
-	_, ok := p.logPipes[ino]
+	_, ok := p.logPipes[key]
 	return ok
 }
 
-// reject the stdout fallback when it points at an unregistered pipe (app IPC)
-func (p *Tracer) fallbackDestSafe(path string) bool {
+// identity to pin the tty fallback destination with; rejects an unregistered
+// pipe (app IPC)
+func (p *Tracer) fallbackDest(path string) (pipeKey, bool) {
 	var st unix.Stat_t
 	if err := unix.Stat(path, &st); err != nil {
-		return false
+		return pipeKey{}, false
 	}
 
-	if st.Mode&unix.S_IFMT != unix.S_IFIFO {
-		return true
+	key := pipeKey{Ino: st.Ino, Dev: kernelDev(st.Dev)}
+	if st.Mode&unix.S_IFMT == unix.S_IFIFO && !p.pipeRegistered(key) {
+		return pipeKey{}, false
 	}
 
-	return p.pipeRegistered(st.Ino)
+	return key, true
 }
 
 func (p *Tracer) BlockPID(pid app.PID, ns uint32) {
+	p.pipesMU.Lock()
+	delete(p.trackedPids, uint32(pid))
+	p.unregisterLogPipes(uint32(pid))
+	p.pipesMU.Unlock()
+
 	p.pidsMU.Lock()
 	defer p.pidsMU.Unlock()
 
 	delete(p.pidServices, uint32(pid))
-	delete(p.trackedPids, uint32(pid))
-	p.unregisterLogPipes(uint32(pid))
 
 	pk := p.pidKey(ns, uint32(pid))
 	if err := p.removePID(pk); err != nil {
@@ -535,24 +577,30 @@ func (p *Tracer) handleLogEvent(record *ringbuf.Record) (request.Span, bool, err
 	// open file description keeps the log pipe writable even if the process is
 	// gone by the time the async writer gets to this line.
 	if event.Fd != 0 {
+		key := pipeKey{Ino: event.Ino, Dev: uint64(event.Dev)}
 		// address the pipe through a live owner, the writer may already be gone
-		for _, candidate := range p.pipeDestCandidates(event.Ino) {
-			if _, err := p.openLogDestination(candidate, event.Ino); err == nil {
+		for _, candidate := range p.pipeDestCandidates(key) {
+			if _, err := p.openLogDestination(candidate, key); err == nil {
 				e.dest = candidate
+				e.pin = key
 				break
 			}
 		}
 		if e.dest == "" {
-			p.log.Debug("no live destination for log pipe, dropping line", "ino", event.Ino)
+			p.log.Debug("no live destination for log pipe, dropping line", "ino", event.Ino, "dev", event.Dev)
 			return request.Span{}, true, nil
 		}
 	} else {
 		e.dest = e.ttyPath()
-		if unix.ByteSliceToString(event.FilePath[:]) == "" && !p.fallbackDestSafe(e.dest) {
-			p.log.Debug("unsafe tty fallback destination, dropping line", "path", e.dest)
-			return request.Span{}, true, nil
+		if unix.ByteSliceToString(event.FilePath[:]) == "" {
+			pin, ok := p.fallbackDest(e.dest)
+			if !ok {
+				p.log.Debug("unsafe tty fallback destination, dropping line", "path", e.dest)
+				return request.Span{}, true, nil
+			}
+			e.pin = pin
 		}
-		if _, err := p.openLogDestination(e.dest, 0); err != nil {
+		if _, err := p.openLogDestination(e.dest, e.pin); err != nil {
 			p.logOpenError(e.dest, err)
 			return request.Span{}, true, nil
 		}
@@ -564,30 +612,52 @@ func (p *Tracer) handleLogEvent(record *ringbuf.Record) (request.Span, bool, err
 
 var errStaleDestination = errors.New("destination no longer points at the captured pipe")
 
-func fileIno(f *os.File) uint64 {
+func fileKey(f *os.File) pipeKey {
 	var st unix.Stat_t
 	if err := unix.Fstat(int(f.Fd()), &st); err != nil {
-		return 0
+		return pipeKey{}
 	}
 
-	return st.Ino
+	return pipeKey{Ino: st.Ino, Dev: kernelDev(st.Dev)}
 }
 
-// a non-zero ino pins the destination: /proc fd paths re-point when the owner
-// redirects its stdio, and writing there would leak lines into the wrong file
-func (p *Tracer) openLogDestination(path string, ino uint64) (*os.File, error) {
+// O_NONBLOCK so a reader-less pipe fails the open with ENXIO instead of
+// blocking the event handler forever; writes revert to blocking so a full
+// pipe backpressures its shard instead of dropping lines
+func openDestFile(path string) (*os.File, error) {
+	fd, err := unix.Open(path, unix.O_WRONLY|unix.O_APPEND|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+
+	flags, err := unix.FcntlInt(uintptr(fd), unix.F_GETFL, 0)
+	if err == nil {
+		_, err = unix.FcntlInt(uintptr(fd), unix.F_SETFL, flags&^unix.O_NONBLOCK)
+	}
+	if err != nil {
+		unix.Close(fd)
+		return nil, &os.PathError{Op: "fcntl", Path: path, Err: err}
+	}
+
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+// a non-zero pin fixes the destination identity: /proc fd paths re-point when
+// the owner redirects its stdio, and writing there would leak lines into the
+// wrong file
+func (p *Tracer) openLogDestination(path string, pin pipeKey) (*os.File, error) {
 	if f, ok := p.fdCache.Get(path); ok {
-		if ino == 0 || fileIno(f) == ino {
+		if pin == (pipeKey{}) || fileKey(f) == pin {
 			return f, nil
 		}
 		p.fdCache.Remove(path)
 	}
 
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+	f, err := openDestFile(path)
 	if err != nil {
 		return nil, err
 	}
-	if ino != 0 && fileIno(f) != ino {
+	if pin != (pipeKey{}) && fileKey(f) != pin {
 		f.Close()
 		return nil, errStaleDestination
 	}
@@ -596,10 +666,11 @@ func (p *Tracer) openLogDestination(path string, ino uint64) (*os.File, error) {
 	return f, nil
 }
 
-// a gone or re-pointed destination means its process died or redirected
-// between writing the line and us getting to it: expected, drop quietly
+// a gone, re-pointed, or reader-less destination means its process died or
+// redirected between writing the line and us getting to it: expected, drop
+// quietly
 func (p *Tracer) logOpenError(path string, err error) {
-	if errors.Is(err, os.ErrNotExist) || errors.Is(err, errStaleDestination) {
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, errStaleDestination) || errors.Is(err, unix.ENXIO) {
 		p.log.Debug("log destination is gone, dropping line", "path", path, "error", err)
 		return
 	}
@@ -621,9 +692,19 @@ func (e LogEvent) ttyPath() string {
 	return fp
 }
 
+// pipe lines shard by pipe identity so a changing candidate path cannot move
+// a pipe's lines across shards and reorder them; tty lines shard by path
+func (e LogEvent) shardKey() string {
+	if e.orig.Fd != 0 {
+		return "pipe:" + strconv.FormatUint(uint64(e.orig.Dev), 10) + ":" + strconv.FormatUint(e.orig.Ino, 10)
+	}
+
+	return e.dest
+}
+
 func (p *Tracer) handle(e LogEvent) {
 	// normally warmed at capture time; reopened only if the cache evicted it
-	f, err := p.openLogDestination(e.dest, e.orig.Ino)
+	f, err := p.openLogDestination(e.dest, e.pin)
 	if err != nil {
 		p.logOpenError(e.dest, err)
 		return

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -641,7 +641,13 @@ func openDestFile(path string) (*os.File, error) {
 		return nil, &os.PathError{Op: "fcntl", Path: path, Err: err}
 	}
 
-	return os.NewFile(uintptr(fd), path), nil
+	f := os.NewFile(uintptr(fd), path)
+	if f == nil {
+		unix.Close(fd)
+		return nil, &os.PathError{Op: "open", Path: path, Err: unix.EBADF}
+	}
+
+	return f, nil
 }
 
 // a non-zero pin fixes the destination identity: /proc fd paths re-point when
@@ -704,9 +710,33 @@ func (e LogEvent) shardKey() string {
 	return e.dest
 }
 
+// the owner warmed at capture time may exit or redirect while the line sits
+// in the queue; re-resolve the pipe through any remaining live owner before
+// giving the line up
+func (p *Tracer) reopenLogDestination(e LogEvent) (*os.File, error) {
+	f, err := p.openLogDestination(e.dest, e.pin)
+	if err == nil {
+		return f, nil
+	}
+	if e.pin == (pipeKey{}) {
+		return nil, err
+	}
+
+	for _, candidate := range p.pipeDestCandidates(e.pin) {
+		if candidate == e.dest {
+			continue
+		}
+		if f, cErr := p.openLogDestination(candidate, e.pin); cErr == nil {
+			return f, nil
+		}
+	}
+
+	return nil, err
+}
+
 func (p *Tracer) handle(e LogEvent) {
 	// normally warmed at capture time; reopened only if the cache evicted it
-	f, err := p.openLogDestination(e.dest, e.pin)
+	f, err := p.reopenLogDestination(e)
 	if err != nil {
 		p.logOpenError(e.dest, err)
 		return

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -43,7 +44,35 @@ type LogEvent struct {
 	orig    BpfLogEventT
 	logLine string
 	dest    string
-	pin     pipeKey // destination identity the write must land on; zero when unpinned
+	out     *destFile // reference owned by this event until its write completes
+}
+
+// destFile is a refcounted open log destination: the fd cache holds one
+// reference and every in-flight event holds another, so retiring a pipe or
+// evicting the cache entry cannot close a descriptor a queued write still
+// needs
+type destFile struct {
+	f    *os.File
+	refs atomic.Int64
+}
+
+// tryAcquire takes a reference unless the descriptor already closed
+func (d *destFile) tryAcquire() bool {
+	for {
+		n := d.refs.Load()
+		if n <= 0 {
+			return false
+		}
+		if d.refs.CompareAndSwap(n, n+1) {
+			return true
+		}
+	}
+}
+
+func (d *destFile) release() {
+	if d.refs.Add(-1) == 0 {
+		d.f.Close()
+	}
 }
 
 // pipe identity as the BPF map sees it: inode number plus the kernel dev_t of
@@ -56,7 +85,7 @@ type Tracer struct {
 	bpfObjects  BpfObjects
 	closers     []io.Closer
 	log         *slog.Logger
-	fdCache     *expirable.LRU[string, *os.File]
+	fdCache     *expirable.LRU[string, *destFile]
 	asyncWriter *shardedqueue.ShardedQueue[LogEvent]
 	formatter   logFormatter
 	pids        map[uint64][]uint64       // pid:[]nsPids
@@ -79,8 +108,8 @@ func New(cfg *obi.Config) *Tracer {
 	tr := &Tracer{
 		log: logger,
 		cfg: cfg,
-		fdCache: expirable.NewLRU[string, *os.File](cfg.EBPF.LogEnricher.CacheSize, func(_ string, f *os.File) {
-			f.Close()
+		fdCache: expirable.NewLRU[string, *destFile](cfg.EBPF.LogEnricher.CacheSize, func(_ string, d *destFile) {
+			d.release()
 		}, cfg.EBPF.LogEnricher.CacheTTL),
 		formatter:   newLogFormatter(cfg.EBPF.LogEnricher),
 		pids:        make(map[uint64][]uint64),
@@ -576,40 +605,46 @@ func (p *Tracer) handleLogEvent(record *ringbuf.Record) (request.Span, bool, err
 	}
 
 	// Open the destination now, while the writing process is still alive: the
-	// open file description keeps the log pipe writable even if the process is
-	// gone by the time the async writer gets to this line.
+	// event's reference keeps the descriptor open even if the process exits
+	// and its registration is retired before the async writer gets to this
+	// line.
 	if event.Fd != 0 {
 		key := pipeKey{Ino: event.Ino, Dev: uint64(event.Dev)}
 		// address the pipe through a live owner, the writer may already be gone
 		for _, candidate := range p.pipeDestCandidates(key) {
-			if _, err := p.openLogDestination(candidate, key); err == nil {
+			if d, err := p.openLogDestination(candidate, key); err == nil {
 				e.dest = candidate
-				e.pin = key
+				e.out = d
 				break
 			}
 		}
-		if e.dest == "" {
+		if e.out == nil {
 			p.log.Debug("no live destination for log pipe, dropping line", "ino", event.Ino, "dev", event.Dev)
 			return request.Span{}, true, nil
 		}
 	} else {
 		e.dest = e.ttyPath()
+		var pin pipeKey
 		if unix.ByteSliceToString(event.FilePath[:]) == "" {
-			pin, ok := p.fallbackDest(e.dest)
-			if !ok {
+			var ok bool
+			if pin, ok = p.fallbackDest(e.dest); !ok {
 				p.log.Debug("unsafe tty fallback destination, dropping line", "path", e.dest)
 				return request.Span{}, true, nil
 			}
-			e.pin = pin
 		}
-		if _, err := p.openLogDestination(e.dest, e.pin); err != nil {
+		d, err := p.openLogDestination(e.dest, pin)
+		if err != nil {
 			p.logOpenError(e.dest, err)
 			return request.Span{}, true, nil
 		}
+		e.out = d
 	}
 
-	err = p.asyncWriter.Enqueue(p.ctx, e)
-	return request.Span{}, true, err
+	if err := p.asyncWriter.Enqueue(p.ctx, e); err != nil {
+		e.out.release()
+		return request.Span{}, true, err
+	}
+	return request.Span{}, true, nil
 }
 
 var errStaleDestination = errors.New("destination no longer points at the captured pipe")
@@ -652,11 +687,12 @@ func openDestFile(path string) (*os.File, error) {
 
 // a non-zero pin fixes the destination identity: /proc fd paths re-point when
 // the owner redirects its stdio, and writing there would leak lines into the
-// wrong file
-func (p *Tracer) openLogDestination(path string, pin pipeKey) (*os.File, error) {
-	if f, ok := p.fdCache.Get(path); ok {
-		if pin == (pipeKey{}) || fileKey(f) == pin {
-			return f, nil
+// wrong file. The returned reference is owned by the caller and must be
+// released once the write completes
+func (p *Tracer) openLogDestination(path string, pin pipeKey) (*destFile, error) {
+	if d, ok := p.fdCache.Get(path); ok {
+		if (pin == (pipeKey{}) || fileKey(d.f) == pin) && d.tryAcquire() {
+			return d, nil
 		}
 		p.fdCache.Remove(path)
 	}
@@ -669,9 +705,15 @@ func (p *Tracer) openLogDestination(path string, pin pipeKey) (*os.File, error) 
 		f.Close()
 		return nil, errStaleDestination
 	}
-	p.fdCache.Add(path, f)
 
-	return f, nil
+	d := &destFile{f: f}
+	d.refs.Store(2) // one reference for the cache, one for the caller
+	// Add on a lingering expired entry replaces it without the evict
+	// callback, which would leak its cache reference; Remove fires it
+	p.fdCache.Remove(path)
+	p.fdCache.Add(path, d)
+
+	return d, nil
 }
 
 // a gone, re-pointed, or reader-less destination means its process died or
@@ -710,37 +752,11 @@ func (e LogEvent) shardKey() string {
 	return e.dest
 }
 
-// the owner warmed at capture time may exit or redirect while the line sits
-// in the queue; re-resolve the pipe through any remaining live owner before
-// giving the line up
-func (p *Tracer) reopenLogDestination(e LogEvent) (*os.File, error) {
-	f, err := p.openLogDestination(e.dest, e.pin)
-	if err == nil {
-		return f, nil
-	}
-	if e.pin == (pipeKey{}) {
-		return nil, err
-	}
-
-	for _, candidate := range p.pipeDestCandidates(e.pin) {
-		if candidate == e.dest {
-			continue
-		}
-		if f, cErr := p.openLogDestination(candidate, e.pin); cErr == nil {
-			return f, nil
-		}
-	}
-
-	return nil, err
-}
-
 func (p *Tracer) handle(e LogEvent) {
-	// normally warmed at capture time; reopened only if the cache evicted it
-	f, err := p.reopenLogDestination(e)
-	if err != nil {
-		p.logOpenError(e.dest, err)
-		return
-	}
+	// the event owns a reference taken at capture time, so the destination is
+	// alive here even if its owner exited or the cache evicted it meanwhile
+	defer e.out.release()
+	f := e.out.f
 
 	var (
 		zeroTraceID [16]uint8

--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"time"
 	"unsafe"
 
 	"github.com/cilium/ebpf"
@@ -55,8 +56,9 @@ type Tracer struct {
 	formatter   logFormatter
 	pids        map[uint64][]uint64         // pid:[]nsPids
 	pidServices map[uint32]*exec.FileInfo   // host pid -> file info, for run-time OTel-export check in handle()
+	trackedPids map[uint32]struct{}         // host pids currently allowed
 	logPipes    map[uint64]map[uint32][]int // log pipe inode -> host pid -> fds (1 and/or 2)
-	pidPipes    map[uint32][]uint64         // host pid -> registered log pipe inodes
+	pidPipes    map[uint32]map[int]uint64   // host pid -> fd -> registered log pipe inode
 	pidsMU      sync.Mutex
 }
 
@@ -77,8 +79,9 @@ func New(cfg *obi.Config) *Tracer {
 		formatter:   newLogFormatter(cfg.EBPF.LogEnricher),
 		pids:        make(map[uint64][]uint64),
 		pidServices: make(map[uint32]*exec.FileInfo),
+		trackedPids: make(map[uint32]struct{}),
 		logPipes:    make(map[uint64]map[uint32][]int),
-		pidPipes:    make(map[uint32][]uint64),
+		pidPipes:    make(map[uint32]map[int]uint64),
 	}
 
 	asyncWriter := shardedqueue.NewShardedQueue[LogEvent](
@@ -276,6 +279,7 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 		p.log.Error(err.Error())
 	}
 
+	p.trackedPids[uint32(pid)] = struct{}{}
 	p.registerLogPipes(uint32(pid))
 
 	nsPids, err := procs.FindNamespacedPids(pid)
@@ -297,65 +301,107 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 	}
 }
 
-// callers must hold pidsMU
+// pipe inode behind /proc/<pid>/fd/<fd>, 0 when gone or not a pipe
+func statPipeIno(pid uint32, fd int) uint64 {
+	var st unix.Stat_t
+	if err := unix.Stat(procFdPath(pid, fd), &st); err != nil {
+		return 0
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFIFO {
+		return 0
+	}
+
+	return st.Ino
+}
+
+// registerLogPipes records the current pipe inodes behind stdout/stderr,
+// retiring registrations the process redirected away from. Callers must
+// hold pidsMU
 func (p *Tracer) registerLogPipes(pid uint32) {
 	for _, fd := range []int{1, 2} {
-		path := procFdPath(pid, fd)
-
-		var st unix.Stat_t
-		if err := unix.Stat(path, &st); err != nil {
-			p.log.Debug("cannot stat process fd", "path", path, "error", err)
-			continue
-		}
-		if st.Mode&unix.S_IFMT != unix.S_IFIFO {
+		ino := statPipeIno(pid, fd)
+		current := p.pidPipes[pid][fd]
+		if current == ino {
 			continue
 		}
 
-		owners := p.logPipes[st.Ino]
-		if owners == nil {
-			owners = make(map[uint32][]int)
-			p.logPipes[st.Ino] = owners
-
-			if p.bpfObjects.LogPipes == nil {
-				p.log.Error("BPF objects not loaded, cannot register log pipe", "ino", st.Ino)
-			} else if err := p.bpfObjects.LogPipes.Put(st.Ino, uint8(1)); err != nil {
-				p.log.Error("error registering log pipe in bpf map", "ino", st.Ino, "error", err)
-			}
+		if current != 0 {
+			p.removePipeFD(pid, fd, current)
 		}
+		if ino != 0 {
+			p.addPipeFD(pid, fd, ino)
+		}
+	}
+}
 
-		owners[pid] = append(owners[pid], fd)
-		p.pidPipes[pid] = append(p.pidPipes[pid], st.Ino)
+// callers must hold pidsMU
+func (p *Tracer) addPipeFD(pid uint32, fd int, ino uint64) {
+	owners := p.logPipes[ino]
+	if owners == nil {
+		owners = make(map[uint32][]int)
+		p.logPipes[ino] = owners
+
+		if p.bpfObjects.LogPipes == nil {
+			p.log.Error("BPF objects not loaded, cannot register log pipe", "ino", ino)
+		} else if err := p.bpfObjects.LogPipes.Put(ino, uint8(1)); err != nil {
+			p.log.Error("error registering log pipe in bpf map", "ino", ino, "error", err)
+		}
+	}
+	owners[pid] = append(owners[pid], fd)
+
+	if p.pidPipes[pid] == nil {
+		p.pidPipes[pid] = make(map[int]uint64)
+	}
+	p.pidPipes[pid][fd] = ino
+}
+
+// callers must hold pidsMU
+func (p *Tracer) removePipeFD(pid uint32, fd int, ino uint64) {
+	delete(p.pidPipes[pid], fd)
+	// a held write end would rob readers of EOF once the fd is gone
+	p.fdCache.Remove(procFdPath(pid, fd))
+
+	owners := p.logPipes[ino]
+	if fds, ok := owners[pid]; ok {
+		fds = slices.DeleteFunc(fds, func(f int) bool { return f == fd })
+		if len(fds) > 0 {
+			owners[pid] = fds
+		} else {
+			delete(owners, pid)
+		}
+	}
+	if len(owners) > 0 {
+		return
+	}
+
+	delete(p.logPipes, ino)
+
+	if p.bpfObjects.LogPipes == nil {
+		return
+	}
+	if err := p.bpfObjects.LogPipes.Delete(ino); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+		p.log.Error("error removing log pipe from bpf map", "ino", ino, "error", err)
 	}
 }
 
 // callers must hold pidsMU
 func (p *Tracer) unregisterLogPipes(pid uint32) {
-	for _, ino := range p.pidPipes[pid] {
-		owners := p.logPipes[ino]
-
-		if fds, ok := owners[pid]; ok {
-			delete(owners, pid)
-			// a held write end would rob readers of EOF once the owner exits
-			for _, fd := range fds {
-				p.fdCache.Remove(procFdPath(pid, fd))
-			}
-		}
-
-		if len(owners) > 0 {
-			continue
-		}
-
-		delete(p.logPipes, ino)
-
-		if p.bpfObjects.LogPipes == nil {
-			continue
-		}
-		if err := p.bpfObjects.LogPipes.Delete(ino); err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
-			p.log.Error("error removing log pipe from bpf map", "ino", ino, "error", err)
-		}
+	for fd, ino := range p.pidPipes[pid] {
+		p.removePipeFD(pid, fd, ino)
 	}
 
 	delete(p.pidPipes, pid)
+}
+
+// processes may redirect their stdio after discovery; re-stat and diff so new
+// pipes get enriched and stale registrations and fd handles are retired
+func (p *Tracer) reconcileLogPipes() {
+	p.pidsMU.Lock()
+	defer p.pidsMU.Unlock()
+
+	for pid := range p.trackedPids {
+		p.registerLogPipes(pid)
+	}
 }
 
 // deterministic order: the chosen path is the shard key, keeping lines ordered
@@ -408,6 +454,7 @@ func (p *Tracer) BlockPID(pid app.PID, ns uint32) {
 	defer p.pidsMU.Unlock()
 
 	delete(p.pidServices, uint32(pid))
+	delete(p.trackedPids, uint32(pid))
 	p.unregisterLogPipes(uint32(pid))
 
 	pk := p.pidKey(ns, uint32(pid))
@@ -428,10 +475,25 @@ func (p *Tracer) BlockPID(pid app.PID, ns uint32) {
 	p.log.Debug("block pid: namespaced pids not found in internal cache, removing only the given pid", "pid", pid, "ns", ns)
 }
 
+const logPipeReconcileInterval = 15 * time.Second
+
 func (p *Tracer) Run(ctx context.Context, _ *ebpfcommon.EBPFEventContext, _ *msg.Queue[[]request.Span]) {
 	p.log.Debug("starting")
 
 	p.ctx = ctx
+
+	go func() {
+		t := time.NewTicker(logPipeReconcileInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				p.reconcileLogPipes()
+			}
+		}
+	}()
 
 	ebpfcommon.ForwardRingbuf(
 		&p.cfg.EBPF,
@@ -534,10 +596,10 @@ func (p *Tracer) openLogDestination(path string, ino uint64) (*os.File, error) {
 	return f, nil
 }
 
-// a destination that is already gone means its process died between writing
-// the line and us getting to it: expected for short-lived processes
+// a gone or re-pointed destination means its process died or redirected
+// between writing the line and us getting to it: expected, drop quietly
 func (p *Tracer) logOpenError(path string, err error) {
-	if errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, os.ErrNotExist) || errors.Is(err, errStaleDestination) {
 		p.log.Debug("log destination is gone, dropping line", "path", path, "error", err)
 		return
 	}

--- a/pkg/internal/ebpf/logenricher/logenricher_test.go
+++ b/pkg/internal/ebpf/logenricher/logenricher_test.go
@@ -124,6 +124,7 @@ func TestHandleWithoutTraceContextPreservesPlainText(t *testing.T) {
 
 	event := LogEvent{logLine: "request failed\n"}
 	copy(event.orig.FilePath[:], path)
+	event.dest = event.ttyPath()
 
 	tr.handle(event)
 

--- a/pkg/internal/ebpf/logenricher/logenricher_test.go
+++ b/pkg/internal/ebpf/logenricher/logenricher_test.go
@@ -117,14 +117,17 @@ func TestHandleWithoutTraceContextPreservesPlainText(t *testing.T) {
 	tr := newTestTracer(t, false)
 	tr.cfg = &cfg
 	tr.formatter = newLogFormatter(cfg.EBPF.LogEnricher)
-	tr.fdCache = expirable.NewLRU[string, *os.File](1, func(_ string, file *os.File) {
-		_ = file.Close()
+	tr.fdCache = expirable.NewLRU[string, *destFile](1, func(_ string, d *destFile) {
+		d.release()
 	}, time.Minute)
 	t.Cleanup(tr.fdCache.Purge)
 
 	event := LogEvent{logLine: "request failed\n"}
 	copy(event.orig.FilePath[:], path)
 	event.dest = event.ttyPath()
+	out, err := tr.openLogDestination(event.dest, pipeKey{})
+	require.NoError(t, err)
+	event.out = out
 
 	tr.handle(event)
 

--- a/pkg/internal/ebpf/logenricher/logpipes_test.go
+++ b/pkg/internal/ebpf/logenricher/logpipes_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	osexec "os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,12 +27,20 @@ func newPipeTestTracer(t *testing.T) *Tracer {
 
 	tr := newTestTracer(t, false)
 	tr.trackedPids = map[uint32]struct{}{}
-	tr.logPipes = map[uint64]map[uint32][]int{}
-	tr.pidPipes = map[uint32]map[int]uint64{}
+	tr.logPipes = map[pipeKey]map[uint32][]int{}
+	tr.pidPipes = map[uint32]map[int]pipeKey{}
 	tr.fdCache = expirable.NewLRU[string, *os.File](128, func(_ string, f *os.File) {
 		_ = f.Close()
 	}, time.Minute)
 	t.Cleanup(tr.fdCache.Purge)
+
+	tr.bpfObjects.LogPipes = newLogPipesMap(t, 16)
+
+	return tr
+}
+
+func newLogPipesMap(t *testing.T, maxEntries uint32) *ebpf.Map {
+	t.Helper()
 
 	if err := rlimit.RemoveMemlock(); err != nil {
 		t.Skipf("removing memlock failed: %v", err)
@@ -39,25 +48,23 @@ func newPipeTestTracer(t *testing.T) *Tracer {
 	m, err := ebpf.NewMap(&ebpf.MapSpec{
 		Name:       "log_pipes_test",
 		Type:       ebpf.Hash,
-		KeySize:    8,
+		KeySize:    16,
 		ValueSize:  1,
-		MaxEntries: 16,
+		MaxEntries: maxEntries,
 	})
 	if err != nil {
 		t.Skipf("ebpf map create failed: %v", err)
 	}
 	t.Cleanup(func() { _ = m.Close() })
-	tr.bpfObjects.LogPipes = m
-
-	return tr
+	return m
 }
 
-func fdIno(t *testing.T, f *os.File) uint64 {
+func fdKey(t *testing.T, f *os.File) pipeKey {
 	t.Helper()
 
 	var st unix.Stat_t
 	require.NoError(t, unix.Fstat(int(f.Fd()), &st))
-	return st.Ino
+	return pipeKey{Ino: st.Ino, Dev: kernelDev(st.Dev)}
 }
 
 // child process whose stdout/stderr are the given files
@@ -76,11 +83,11 @@ func startChild(t *testing.T, stdout, stderr *os.File, args ...string) *osexec.C
 	return cmd
 }
 
-func bpfHasIno(t *testing.T, tr *Tracer, ino uint64) bool {
+func bpfHasKey(t *testing.T, tr *Tracer, key pipeKey) bool {
 	t.Helper()
 
 	var v uint8
-	err := tr.bpfObjects.LogPipes.Lookup(ino, &v)
+	err := tr.bpfObjects.LogPipes.Lookup(key, &v)
 	if err == nil {
 		return true
 	}
@@ -88,19 +95,27 @@ func bpfHasIno(t *testing.T, tr *Tracer, ino uint64) bool {
 	return false
 }
 
-func registeredIno(tr *Tracer, pid uint32, fd int) uint64 {
-	tr.pidsMU.Lock()
-	defer tr.pidsMU.Unlock()
+func registeredKey(tr *Tracer, pid uint32, fd int) pipeKey {
+	tr.pipesMU.RLock()
+	defer tr.pipesMU.RUnlock()
 
 	return tr.pidPipes[pid][fd]
 }
 
 func trackAndRegister(tr *Tracer, pid uint32) {
-	tr.pidsMU.Lock()
-	defer tr.pidsMU.Unlock()
-
+	tr.pipesMU.Lock()
 	tr.trackedPids[pid] = struct{}{}
+	tr.pipesMU.Unlock()
+
 	tr.registerLogPipes(pid)
+}
+
+func untrack(tr *Tracer, pid uint32) {
+	tr.pipesMU.Lock()
+	defer tr.pipesMU.Unlock()
+
+	delete(tr.trackedPids, pid)
+	tr.unregisterLogPipes(pid)
 }
 
 func TestLogPipeRegistration(t *testing.T) {
@@ -120,13 +135,76 @@ func TestLogPipeRegistration(t *testing.T) {
 
 	trackAndRegister(tr, pid)
 
-	outIno := fdIno(t, outW)
-	errIno := fdIno(t, errW)
-	assert.Equal(t, outIno, registeredIno(tr, pid, 1))
-	assert.Equal(t, errIno, registeredIno(tr, pid, 2))
-	assert.True(t, bpfHasIno(t, tr, outIno))
-	assert.True(t, bpfHasIno(t, tr, errIno))
-	assert.NotEmpty(t, tr.pipeDestCandidates(outIno))
+	outKey := fdKey(t, outW)
+	errKey := fdKey(t, errW)
+	assert.Equal(t, outKey, registeredKey(tr, pid, 1))
+	assert.Equal(t, errKey, registeredKey(tr, pid, 2))
+	assert.True(t, bpfHasKey(t, tr, outKey))
+	assert.True(t, bpfHasKey(t, tr, errKey))
+	assert.NotEmpty(t, tr.pipeDestCandidates(outKey))
+}
+
+// same inode number on a different filesystem must not match the registration
+func TestLogPipeKeyIncludesDevice(t *testing.T) {
+	tr := newPipeTestTracer(t)
+
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	defer outR.Close()
+	defer outW.Close()
+
+	cmd := startChild(t, outW, outW, "sleep", "30")
+	pid := uint32(cmd.Process.Pid)
+
+	trackAndRegister(tr, pid)
+
+	key := fdKey(t, outW)
+	require.NotZero(t, key.Dev, "pipefs device must be part of the key")
+	assert.True(t, bpfHasKey(t, tr, key))
+
+	collided := pipeKey{Ino: key.Ino, Dev: key.Dev + 1}
+	assert.False(t, bpfHasKey(t, tr, collided), "same ino on another device must not match")
+	assert.Empty(t, tr.pipeDestCandidates(collided))
+	assert.False(t, tr.pipeRegistered(collided))
+}
+
+// a failed BPF map update must not be recorded as registered: the next
+// reconcile retries it once there is room again
+func TestFailedPipeRegistrationIsRetried(t *testing.T) {
+	tr := newPipeTestTracer(t)
+	tr.bpfObjects.LogPipes = newLogPipesMap(t, 1)
+
+	aR, aW, err := os.Pipe()
+	require.NoError(t, err)
+	defer aR.Close()
+	defer aW.Close()
+	bR, bW, err := os.Pipe()
+	require.NoError(t, err)
+	defer bR.Close()
+	defer bW.Close()
+
+	cmdA := startChild(t, aW, aW, "sleep", "30")
+	cmdB := startChild(t, bW, bW, "sleep", "30")
+	pidA := uint32(cmdA.Process.Pid)
+	pidB := uint32(cmdB.Process.Pid)
+
+	trackAndRegister(tr, pidA)
+	keyA := fdKey(t, aW)
+	require.True(t, bpfHasKey(t, tr, keyA))
+
+	// the map is full: B's registration must fail and leave no state behind
+	trackAndRegister(tr, pidB)
+	keyB := fdKey(t, bW)
+	assert.Equal(t, pipeKey{}, registeredKey(tr, pidB, 1), "failed registration must not be recorded")
+	assert.False(t, bpfHasKey(t, tr, keyB))
+
+	untrack(tr, pidA)
+	require.False(t, bpfHasKey(t, tr, keyA))
+
+	tr.reconcileLogPipes()
+
+	assert.Equal(t, keyB, registeredKey(tr, pidB, 1), "reconcile must retry the failed registration")
+	assert.True(t, bpfHasKey(t, tr, keyB))
 }
 
 // controllableChild runs a shell that redirects its stdout to redirectTo when
@@ -148,8 +226,8 @@ func controllableChild(t *testing.T, stdout *os.File, redirectTo string) (*osexe
 	return cmd, stdin
 }
 
-// wait until /proc/<pid>/fd/1 no longer points at ino (the redirect happened)
-func waitRedirected(t *testing.T, pid uint32, ino uint64) {
+// wait until /proc/<pid>/fd/1 no longer points at key (the redirect happened)
+func waitRedirected(t *testing.T, pid uint32, key pipeKey) {
 	t.Helper()
 
 	require.Eventually(t, func() bool {
@@ -157,7 +235,7 @@ func waitRedirected(t *testing.T, pid uint32, ino uint64) {
 		if err := unix.Stat(procFdPath(pid, 1), &st); err != nil {
 			return false
 		}
-		return st.Ino != ino
+		return (pipeKey{Ino: st.Ino, Dev: kernelDev(st.Dev)}) != key
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
@@ -174,10 +252,10 @@ func TestReconcileDetectsRedirect(t *testing.T) {
 
 	cmd, stdin := controllableChild(t, oldW, fifo)
 	pid := uint32(cmd.Process.Pid)
-	oldIno := fdIno(t, oldW)
+	oldKey := fdKey(t, oldW)
 
 	trackAndRegister(tr, pid)
-	require.Equal(t, oldIno, registeredIno(tr, pid, 1))
+	require.Equal(t, oldKey, registeredKey(tr, pid, 1))
 
 	// open the fifo's read end so the child's redirect can complete
 	fifoOpened := make(chan *os.File, 1)
@@ -188,7 +266,7 @@ func TestReconcileDetectsRedirect(t *testing.T) {
 
 	_, err = stdin.Write([]byte("\n"))
 	require.NoError(t, err)
-	waitRedirected(t, pid, oldIno)
+	waitRedirected(t, pid, oldKey)
 
 	tr.reconcileLogPipes()
 
@@ -198,11 +276,12 @@ func TestReconcileDetectsRedirect(t *testing.T) {
 
 	var st unix.Stat_t
 	require.NoError(t, unix.Stat(procFdPath(pid, 1), &st))
-	assert.Equal(t, st.Ino, registeredIno(tr, pid, 1), "new pipe must be registered")
-	assert.True(t, bpfHasIno(t, tr, st.Ino))
+	newKey := pipeKey{Ino: st.Ino, Dev: kernelDev(st.Dev)}
+	assert.Equal(t, newKey, registeredKey(tr, pid, 1), "new pipe must be registered")
+	assert.True(t, bpfHasKey(t, tr, newKey))
 
-	assert.Empty(t, tr.pipeDestCandidates(oldIno), "old pipe must have no owners left")
-	assert.False(t, bpfHasIno(t, tr, oldIno), "old pipe must be retired from the BPF map")
+	assert.Empty(t, tr.pipeDestCandidates(oldKey), "old pipe must have no owners left")
+	assert.False(t, bpfHasKey(t, tr, oldKey), "old pipe must be retired from the BPF map")
 }
 
 func TestReconcileReleasesCachedHandle(t *testing.T) {
@@ -217,13 +296,13 @@ func TestReconcileReleasesCachedHandle(t *testing.T) {
 
 	cmd, stdin := controllableChild(t, oldW, fifo)
 	pid := uint32(cmd.Process.Pid)
-	oldIno := fdIno(t, oldW)
+	oldKey := fdKey(t, oldW)
 
 	trackAndRegister(tr, pid)
 
 	// warm the cache like event capture does, then drop our own write end so
 	// the cached handle is the only writer left besides the child
-	_, err = tr.openLogDestination(procFdPath(pid, 1), oldIno)
+	_, err = tr.openLogDestination(procFdPath(pid, 1), oldKey)
 	require.NoError(t, err)
 	require.NoError(t, oldW.Close())
 
@@ -235,7 +314,7 @@ func TestReconcileReleasesCachedHandle(t *testing.T) {
 
 	_, err = stdin.Write([]byte("\n"))
 	require.NoError(t, err)
-	waitRedirected(t, pid, oldIno)
+	waitRedirected(t, pid, oldKey)
 
 	tr.reconcileLogPipes()
 
@@ -269,14 +348,14 @@ func TestReconcileKeepsUnchangedRegistration(t *testing.T) {
 
 	trackAndRegister(tr, pid)
 
-	ino := fdIno(t, outW)
-	f, err := tr.openLogDestination(procFdPath(pid, 1), ino)
+	key := fdKey(t, outW)
+	f, err := tr.openLogDestination(procFdPath(pid, 1), key)
 	require.NoError(t, err)
 
 	tr.reconcileLogPipes()
 	tr.reconcileLogPipes()
 
-	assert.True(t, bpfHasIno(t, tr, ino), "unchanged pipe must stay registered")
+	assert.True(t, bpfHasKey(t, tr, key), "unchanged pipe must stay registered")
 	cached, ok := tr.fdCache.Get(procFdPath(pid, 1))
 	require.True(t, ok, "unchanged pipe must keep its cached handle")
 	assert.Same(t, f, cached)
@@ -298,14 +377,188 @@ func TestReconcileRetiresExitedPidSharedPipe(t *testing.T) {
 	trackAndRegister(tr, pidA)
 	trackAndRegister(tr, pidB)
 
-	ino := fdIno(t, outW)
+	key := fdKey(t, outW)
 	require.NoError(t, cmdA.Process.Kill())
 	_, err = cmdA.Process.Wait()
 	require.NoError(t, err)
 
 	tr.reconcileLogPipes()
 
-	assert.Zero(t, registeredIno(tr, pidA, 1), "exited pid must be retired")
-	assert.Equal(t, ino, registeredIno(tr, pidB, 1), "surviving pid must keep the pipe")
-	assert.True(t, bpfHasIno(t, tr, ino), "shared pipe must survive one owner's exit")
+	assert.Equal(t, pipeKey{}, registeredKey(tr, pidA, 1), "exited pid must be retired")
+	assert.Equal(t, key, registeredKey(tr, pidB, 1), "surviving pid must keep the pipe")
+	assert.True(t, bpfHasKey(t, tr, key), "shared pipe must survive one owner's exit")
+}
+
+// the tty fallback pin must reject a /proc fd path that re-pointed at another
+// file after the identity was taken
+func TestFallbackPinRejectsRepointedFd(t *testing.T) {
+	tr := newPipeTestTracer(t)
+
+	dir := t.TempDir()
+	fileA, err := os.Create(filepath.Join(dir, "a.log"))
+	require.NoError(t, err)
+	defer fileA.Close()
+
+	cmd, stdin := controllableChild(t, fileA, filepath.Join(dir, "b.log"))
+	pid := uint32(cmd.Process.Pid)
+	path := procFdPath(pid, 1)
+
+	pin, ok := tr.fallbackDest(path)
+	require.True(t, ok, "regular file fallback must be accepted")
+	require.Equal(t, fdKey(t, fileA), pin)
+
+	_, err = tr.openLogDestination(path, pin)
+	require.NoError(t, err)
+
+	_, err = stdin.Write([]byte("\n"))
+	require.NoError(t, err)
+	waitRedirected(t, pid, pin)
+
+	// with the cache evicted, reopening through the re-pointed path must be
+	// detected instead of leaking lines into b.log
+	tr.fdCache.Purge()
+	_, err = tr.openLogDestination(path, pin)
+	require.ErrorIs(t, err, errStaleDestination)
+}
+
+func TestFallbackDestPipeRegistration(t *testing.T) {
+	tr := newPipeTestTracer(t)
+
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	defer outR.Close()
+	defer outW.Close()
+
+	cmd := startChild(t, outW, outW, "sleep", "30")
+	pid := uint32(cmd.Process.Pid)
+	path := procFdPath(pid, 1)
+
+	_, ok := tr.fallbackDest(path)
+	assert.False(t, ok, "unregistered pipe fallback must be rejected")
+
+	trackAndRegister(tr, pid)
+
+	pin, ok := tr.fallbackDest(path)
+	assert.True(t, ok, "registered pipe fallback must be accepted")
+	assert.Equal(t, fdKey(t, outW), pin)
+}
+
+// candidate churn must not move a pipe's lines to another shard
+func TestShardKeyStableAcrossOwnerChange(t *testing.T) {
+	viaOwnerA := LogEvent{dest: "/proc/100/fd/1"}
+	viaOwnerA.orig.Fd = 1
+	viaOwnerA.orig.Ino = 42
+	viaOwnerA.orig.Dev = 7
+
+	viaOwnerB := LogEvent{dest: "/proc/200/fd/2"}
+	viaOwnerB.orig.Fd = 2
+	viaOwnerB.orig.Ino = 42
+	viaOwnerB.orig.Dev = 7
+
+	assert.Equal(t, viaOwnerA.shardKey(), viaOwnerB.shardKey())
+
+	otherPipe := viaOwnerA
+	otherPipe.orig.Dev = 8
+	assert.NotEqual(t, viaOwnerA.shardKey(), otherPipe.shardKey())
+
+	tty := LogEvent{dest: "/dev/pts/0"}
+	assert.Equal(t, "/dev/pts/0", tty.shardKey())
+}
+
+// opening a reader-less fifo must fail fast instead of blocking the caller
+func TestOpenDestinationReaderlessFifoFailsFast(t *testing.T) {
+	tr := newPipeTestTracer(t)
+
+	fifo := filepath.Join(t.TempDir(), "noreader")
+	require.NoError(t, unix.Mkfifo(fifo, 0o600))
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := tr.openLogDestination(fifo, pipeKey{})
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, unix.ENXIO)
+	case <-time.After(2 * time.Second):
+		t.Fatal("open blocked on a reader-less fifo")
+	}
+
+	// with a reader present the open succeeds and the write path is blocking
+	reader, err := os.OpenFile(fifo, os.O_RDONLY|unix.O_NONBLOCK, 0)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	f, err := tr.openLogDestination(fifo, pipeKey{})
+	require.NoError(t, err)
+
+	flags, err := unix.FcntlInt(f.Fd(), unix.F_GETFL, 0)
+	require.NoError(t, err)
+	assert.Zero(t, flags&unix.O_NONBLOCK, "write path must be blocking for backpressure")
+}
+
+// exercised under -race: registration, reconcile, and the event hot path
+// must be safe to run concurrently
+func TestConcurrentPipeAccess(t *testing.T) {
+	tr := newPipeTestTracer(t)
+
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	defer outR.Close()
+	defer outW.Close()
+
+	cmdA := startChild(t, outW, outW, "sleep", "30")
+	cmdB := startChild(t, outW, outW, "sleep", "30")
+	pidA := uint32(cmdA.Process.Pid)
+	pidB := uint32(cmdB.Process.Pid)
+
+	trackAndRegister(tr, pidA)
+	key := fdKey(t, outW)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				tr.reconcileLogPipes()
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				tr.pipeDestCandidates(key)
+				tr.pipeRegistered(key)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				trackAndRegister(tr, pidB)
+				untrack(tr, pidB)
+			}
+		}
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	assert.NotEmpty(t, tr.pipeDestCandidates(key), "pid A must remain registered")
 }

--- a/pkg/internal/ebpf/logenricher/logpipes_test.go
+++ b/pkg/internal/ebpf/logenricher/logpipes_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/rlimit"
@@ -48,7 +49,7 @@ func newLogPipesMap(t *testing.T, maxEntries uint32) *ebpf.Map {
 	m, err := ebpf.NewMap(&ebpf.MapSpec{
 		Name:       "log_pipes_test",
 		Type:       ebpf.Hash,
-		KeySize:    16,
+		KeySize:    uint32(unsafe.Sizeof(pipeKey{})),
 		ValueSize:  1,
 		MaxEntries: maxEntries,
 	})

--- a/pkg/internal/ebpf/logenricher/logpipes_test.go
+++ b/pkg/internal/ebpf/logenricher/logpipes_test.go
@@ -1,0 +1,311 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package logenricher
+
+import (
+	"io"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func newPipeTestTracer(t *testing.T) *Tracer {
+	t.Helper()
+
+	tr := newTestTracer(t, false)
+	tr.trackedPids = map[uint32]struct{}{}
+	tr.logPipes = map[uint64]map[uint32][]int{}
+	tr.pidPipes = map[uint32]map[int]uint64{}
+	tr.fdCache = expirable.NewLRU[string, *os.File](128, func(_ string, f *os.File) {
+		_ = f.Close()
+	}, time.Minute)
+	t.Cleanup(tr.fdCache.Purge)
+
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Skipf("removing memlock failed: %v", err)
+	}
+	m, err := ebpf.NewMap(&ebpf.MapSpec{
+		Name:       "log_pipes_test",
+		Type:       ebpf.Hash,
+		KeySize:    8,
+		ValueSize:  1,
+		MaxEntries: 16,
+	})
+	if err != nil {
+		t.Skipf("ebpf map create failed: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+	tr.bpfObjects.LogPipes = m
+
+	return tr
+}
+
+func fdIno(t *testing.T, f *os.File) uint64 {
+	t.Helper()
+
+	var st unix.Stat_t
+	require.NoError(t, unix.Fstat(int(f.Fd()), &st))
+	return st.Ino
+}
+
+// child process whose stdout/stderr are the given files
+func startChild(t *testing.T, stdout, stderr *os.File, args ...string) *osexec.Cmd {
+	t.Helper()
+
+	cmd := osexec.Command(args[0], args[1:]...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	return cmd
+}
+
+func bpfHasIno(t *testing.T, tr *Tracer, ino uint64) bool {
+	t.Helper()
+
+	var v uint8
+	err := tr.bpfObjects.LogPipes.Lookup(ino, &v)
+	if err == nil {
+		return true
+	}
+	require.ErrorIs(t, err, ebpf.ErrKeyNotExist)
+	return false
+}
+
+func registeredIno(tr *Tracer, pid uint32, fd int) uint64 {
+	tr.pidsMU.Lock()
+	defer tr.pidsMU.Unlock()
+
+	return tr.pidPipes[pid][fd]
+}
+
+func trackAndRegister(tr *Tracer, pid uint32) {
+	tr.pidsMU.Lock()
+	defer tr.pidsMU.Unlock()
+
+	tr.trackedPids[pid] = struct{}{}
+	tr.registerLogPipes(pid)
+}
+
+func TestLogPipeRegistration(t *testing.T) {
+	tr := newPipeTestTracer(t)
+
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	defer outR.Close()
+	defer outW.Close()
+	errR, errW, err := os.Pipe()
+	require.NoError(t, err)
+	defer errR.Close()
+	defer errW.Close()
+
+	cmd := startChild(t, outW, errW, "sleep", "30")
+	pid := uint32(cmd.Process.Pid)
+
+	trackAndRegister(tr, pid)
+
+	outIno := fdIno(t, outW)
+	errIno := fdIno(t, errW)
+	assert.Equal(t, outIno, registeredIno(tr, pid, 1))
+	assert.Equal(t, errIno, registeredIno(tr, pid, 2))
+	assert.True(t, bpfHasIno(t, tr, outIno))
+	assert.True(t, bpfHasIno(t, tr, errIno))
+	assert.NotEmpty(t, tr.pipeDestCandidates(outIno))
+}
+
+// controllableChild runs a shell that redirects its stdout to redirectTo when
+// one byte arrives on stdin, then keeps running
+func controllableChild(t *testing.T, stdout *os.File, redirectTo string) (*osexec.Cmd, io.WriteCloser) {
+	t.Helper()
+
+	cmd := osexec.Command("/bin/sh", "-c", `read a; exec > "$0"; read b`, redirectTo)
+	cmd.Stdout = stdout
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	return cmd, stdin
+}
+
+// wait until /proc/<pid>/fd/1 no longer points at ino (the redirect happened)
+func waitRedirected(t *testing.T, pid uint32, ino uint64) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		var st unix.Stat_t
+		if err := unix.Stat(procFdPath(pid, 1), &st); err != nil {
+			return false
+		}
+		return st.Ino != ino
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestReconcileDetectsRedirect(t *testing.T) {
+	tr := newPipeTestTracer(t)
+
+	oldR, oldW, err := os.Pipe()
+	require.NoError(t, err)
+	defer oldR.Close()
+	defer oldW.Close()
+
+	fifo := filepath.Join(t.TempDir(), "redir")
+	require.NoError(t, unix.Mkfifo(fifo, 0o600))
+
+	cmd, stdin := controllableChild(t, oldW, fifo)
+	pid := uint32(cmd.Process.Pid)
+	oldIno := fdIno(t, oldW)
+
+	trackAndRegister(tr, pid)
+	require.Equal(t, oldIno, registeredIno(tr, pid, 1))
+
+	// open the fifo's read end so the child's redirect can complete
+	fifoOpened := make(chan *os.File, 1)
+	go func() {
+		f, _ := os.Open(fifo)
+		fifoOpened <- f
+	}()
+
+	_, err = stdin.Write([]byte("\n"))
+	require.NoError(t, err)
+	waitRedirected(t, pid, oldIno)
+
+	tr.reconcileLogPipes()
+
+	fifoFile := <-fifoOpened
+	require.NotNil(t, fifoFile)
+	defer fifoFile.Close()
+
+	var st unix.Stat_t
+	require.NoError(t, unix.Stat(procFdPath(pid, 1), &st))
+	assert.Equal(t, st.Ino, registeredIno(tr, pid, 1), "new pipe must be registered")
+	assert.True(t, bpfHasIno(t, tr, st.Ino))
+
+	assert.Empty(t, tr.pipeDestCandidates(oldIno), "old pipe must have no owners left")
+	assert.False(t, bpfHasIno(t, tr, oldIno), "old pipe must be retired from the BPF map")
+}
+
+func TestReconcileReleasesCachedHandle(t *testing.T) {
+	tr := newPipeTestTracer(t)
+
+	oldR, oldW, err := os.Pipe()
+	require.NoError(t, err)
+	defer oldR.Close()
+
+	fifo := filepath.Join(t.TempDir(), "redir")
+	require.NoError(t, unix.Mkfifo(fifo, 0o600))
+
+	cmd, stdin := controllableChild(t, oldW, fifo)
+	pid := uint32(cmd.Process.Pid)
+	oldIno := fdIno(t, oldW)
+
+	trackAndRegister(tr, pid)
+
+	// warm the cache like event capture does, then drop our own write end so
+	// the cached handle is the only writer left besides the child
+	_, err = tr.openLogDestination(procFdPath(pid, 1), oldIno)
+	require.NoError(t, err)
+	require.NoError(t, oldW.Close())
+
+	fifoOpened := make(chan *os.File, 1)
+	go func() {
+		f, _ := os.Open(fifo)
+		fifoOpened <- f
+	}()
+
+	_, err = stdin.Write([]byte("\n"))
+	require.NoError(t, err)
+	waitRedirected(t, pid, oldIno)
+
+	tr.reconcileLogPipes()
+
+	if f := <-fifoOpened; f != nil {
+		defer f.Close()
+	}
+
+	// child redirected away and the cache handle is closed: EOF must arrive
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.ReadAll(oldR)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reader did not see EOF: a stale write end is still held")
+	}
+}
+
+func TestReconcileKeepsUnchangedRegistration(t *testing.T) {
+	tr := newPipeTestTracer(t)
+
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	defer outR.Close()
+	defer outW.Close()
+
+	cmd := startChild(t, outW, outW, "sleep", "30")
+	pid := uint32(cmd.Process.Pid)
+
+	trackAndRegister(tr, pid)
+
+	ino := fdIno(t, outW)
+	f, err := tr.openLogDestination(procFdPath(pid, 1), ino)
+	require.NoError(t, err)
+
+	tr.reconcileLogPipes()
+	tr.reconcileLogPipes()
+
+	assert.True(t, bpfHasIno(t, tr, ino), "unchanged pipe must stay registered")
+	cached, ok := tr.fdCache.Get(procFdPath(pid, 1))
+	require.True(t, ok, "unchanged pipe must keep its cached handle")
+	assert.Same(t, f, cached)
+}
+
+func TestReconcileRetiresExitedPidSharedPipe(t *testing.T) {
+	tr := newPipeTestTracer(t)
+
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	defer outR.Close()
+	defer outW.Close()
+
+	cmdA := startChild(t, outW, outW, "sleep", "30")
+	cmdB := startChild(t, outW, outW, "sleep", "30")
+	pidA := uint32(cmdA.Process.Pid)
+	pidB := uint32(cmdB.Process.Pid)
+
+	trackAndRegister(tr, pidA)
+	trackAndRegister(tr, pidB)
+
+	ino := fdIno(t, outW)
+	require.NoError(t, cmdA.Process.Kill())
+	_, err = cmdA.Process.Wait()
+	require.NoError(t, err)
+
+	tr.reconcileLogPipes()
+
+	assert.Zero(t, registeredIno(tr, pidA, 1), "exited pid must be retired")
+	assert.Equal(t, ino, registeredIno(tr, pidB, 1), "surviving pid must keep the pipe")
+	assert.True(t, bpfHasIno(t, tr, ino), "shared pipe must survive one owner's exit")
+}

--- a/pkg/internal/ebpf/logenricher/logpipes_test.go
+++ b/pkg/internal/ebpf/logenricher/logpipes_test.go
@@ -30,8 +30,8 @@ func newPipeTestTracer(t *testing.T) *Tracer {
 	tr.trackedPids = map[uint32]struct{}{}
 	tr.logPipes = map[pipeKey]map[uint32][]int{}
 	tr.pidPipes = map[uint32]map[int]pipeKey{}
-	tr.fdCache = expirable.NewLRU[string, *os.File](128, func(_ string, f *os.File) {
-		_ = f.Close()
+	tr.fdCache = expirable.NewLRU[string, *destFile](128, func(_ string, d *destFile) {
+		d.release()
 	}, time.Minute)
 	t.Cleanup(tr.fdCache.Purge)
 
@@ -301,10 +301,12 @@ func TestReconcileReleasesCachedHandle(t *testing.T) {
 
 	trackAndRegister(tr, pid)
 
-	// warm the cache like event capture does, then drop our own write end so
-	// the cached handle is the only writer left besides the child
-	_, err = tr.openLogDestination(procFdPath(pid, 1), oldKey)
+	// warm the cache like event capture does and complete the write, then
+	// drop our own write end so the cached handle is the only writer left
+	// besides the child
+	warmed, err := tr.openLogDestination(procFdPath(pid, 1), oldKey)
 	require.NoError(t, err)
+	warmed.release()
 	require.NoError(t, oldW.Close())
 
 	fifoOpened := make(chan *os.File, 1)
@@ -350,8 +352,9 @@ func TestReconcileKeepsUnchangedRegistration(t *testing.T) {
 	trackAndRegister(tr, pid)
 
 	key := fdKey(t, outW)
-	f, err := tr.openLogDestination(procFdPath(pid, 1), key)
+	d, err := tr.openLogDestination(procFdPath(pid, 1), key)
 	require.NoError(t, err)
+	defer d.release()
 
 	tr.reconcileLogPipes()
 	tr.reconcileLogPipes()
@@ -359,7 +362,7 @@ func TestReconcileKeepsUnchangedRegistration(t *testing.T) {
 	assert.True(t, bpfHasKey(t, tr, key), "unchanged pipe must stay registered")
 	cached, ok := tr.fdCache.Get(procFdPath(pid, 1))
 	require.True(t, ok, "unchanged pipe must keep its cached handle")
-	assert.Same(t, f, cached)
+	assert.Same(t, d, cached)
 }
 
 func TestReconcileRetiresExitedPidSharedPipe(t *testing.T) {
@@ -408,8 +411,9 @@ func TestFallbackPinRejectsRepointedFd(t *testing.T) {
 	require.True(t, ok, "regular file fallback must be accepted")
 	require.Equal(t, fdKey(t, fileA), pin)
 
-	_, err = tr.openLogDestination(path, pin)
+	warmed, err := tr.openLogDestination(path, pin)
 	require.NoError(t, err)
+	warmed.release()
 
 	_, err = stdin.Write([]byte("\n"))
 	require.NoError(t, err)
@@ -491,60 +495,60 @@ func TestOpenDestinationReaderlessFifoFailsFast(t *testing.T) {
 	require.NoError(t, err)
 	defer reader.Close()
 
-	f, err := tr.openLogDestination(fifo, pipeKey{})
+	d, err := tr.openLogDestination(fifo, pipeKey{})
 	require.NoError(t, err)
+	defer d.release()
 
-	flags, err := unix.FcntlInt(f.Fd(), unix.F_GETFL, 0)
+	flags, err := unix.FcntlInt(d.f.Fd(), unix.F_GETFL, 0)
 	require.NoError(t, err)
 	assert.Zero(t, flags&unix.O_NONBLOCK, "write path must be blocking for backpressure")
 }
 
-// a line warmed through one owner must still land when that owner retires
-// while the line is queued and another registered owner remains
-func TestQueuedLineSurvivesWarmedOwnerExit(t *testing.T) {
+// a queued line owns its destination reference: even when its sole owner
+// exits and is fully retired before the async writer runs, the line must
+// land, and the pipe's reader must see EOF right after the write completes
+func TestQueuedLineSurvivesSoleOwnerExit(t *testing.T) {
 	tr := newPipeTestTracer(t)
 
 	outR, outW, err := os.Pipe()
 	require.NoError(t, err)
 	defer outR.Close()
-	defer outW.Close()
 
-	cmdA := startChild(t, outW, outW, "sleep", "30")
-	cmdB := startChild(t, outW, outW, "sleep", "30")
-	pidA := uint32(cmdA.Process.Pid)
-	pidB := uint32(cmdB.Process.Pid)
+	cmd := startChild(t, outW, outW, "sleep", "30")
+	pid := uint32(cmd.Process.Pid)
 
-	trackAndRegister(tr, pidA)
-	trackAndRegister(tr, pidB)
+	trackAndRegister(tr, pid)
 	key := fdKey(t, outW)
 
-	// capture-time warm open through owner A, like handleLogEvent does
-	e := LogEvent{dest: procFdPath(pidA, 1), pin: key, logLine: "queued line\n"}
+	// capture-time warm open through the sole owner, like handleLogEvent does
+	e := LogEvent{dest: procFdPath(pid, 1), logLine: "queued line\n"}
 	e.orig.Fd = 1
-	_, err = tr.openLogDestination(e.dest, e.pin)
+	e.out, err = tr.openLogDestination(e.dest, key)
 	require.NoError(t, err)
 
-	// owner A exits and is retired before the async writer gets to the line:
-	// its cached handle is closed and its /proc path is gone
-	require.NoError(t, cmdA.Process.Kill())
-	_, err = cmdA.Process.Wait()
+	// the sole owner exits and BlockPID retires it before the async writer
+	// gets to the line: its registration, cached handle, and /proc path are
+	// all gone; only the event's reference keeps the pipe writable
+	require.NoError(t, cmd.Process.Kill())
+	_, err = cmd.Process.Wait()
 	require.NoError(t, err)
-	untrack(tr, pidA)
+	untrack(tr, pid)
+	require.NoError(t, outW.Close())
+	assert.Empty(t, tr.pipeDestCandidates(key), "no candidates must remain")
 
 	done := make(chan []byte, 1)
 	go func() {
-		buf := make([]byte, 64)
-		n, _ := outR.Read(buf)
-		done <- buf[:n]
+		got, _ := io.ReadAll(outR)
+		done <- got
 	}()
 
 	tr.handle(e)
 
 	select {
 	case got := <-done:
-		assert.Equal(t, "queued line\n", string(got), "line must be delivered through the surviving owner")
+		assert.Equal(t, "queued line\n", string(got), "final line must land and be followed by EOF")
 	case <-time.After(5 * time.Second):
-		t.Fatal("queued line was dropped after the warmed owner exited")
+		t.Fatal("line dropped or EOF withheld after sole-owner teardown")
 	}
 }
 

--- a/pkg/internal/ebpf/logenricher/logpipes_test.go
+++ b/pkg/internal/ebpf/logenricher/logpipes_test.go
@@ -499,6 +499,55 @@ func TestOpenDestinationReaderlessFifoFailsFast(t *testing.T) {
 	assert.Zero(t, flags&unix.O_NONBLOCK, "write path must be blocking for backpressure")
 }
 
+// a line warmed through one owner must still land when that owner retires
+// while the line is queued and another registered owner remains
+func TestQueuedLineSurvivesWarmedOwnerExit(t *testing.T) {
+	tr := newPipeTestTracer(t)
+
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	defer outR.Close()
+	defer outW.Close()
+
+	cmdA := startChild(t, outW, outW, "sleep", "30")
+	cmdB := startChild(t, outW, outW, "sleep", "30")
+	pidA := uint32(cmdA.Process.Pid)
+	pidB := uint32(cmdB.Process.Pid)
+
+	trackAndRegister(tr, pidA)
+	trackAndRegister(tr, pidB)
+	key := fdKey(t, outW)
+
+	// capture-time warm open through owner A, like handleLogEvent does
+	e := LogEvent{dest: procFdPath(pidA, 1), pin: key, logLine: "queued line\n"}
+	e.orig.Fd = 1
+	_, err = tr.openLogDestination(e.dest, e.pin)
+	require.NoError(t, err)
+
+	// owner A exits and is retired before the async writer gets to the line:
+	// its cached handle is closed and its /proc path is gone
+	require.NoError(t, cmdA.Process.Kill())
+	_, err = cmdA.Process.Wait()
+	require.NoError(t, err)
+	untrack(tr, pidA)
+
+	done := make(chan []byte, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, _ := outR.Read(buf)
+		done <- buf[:n]
+	}()
+
+	tr.handle(e)
+
+	select {
+	case got := <-done:
+		assert.Equal(t, "queued line\n", string(got), "line must be delivered through the surviving owner")
+	case <-time.After(5 * time.Second):
+		t.Fatal("queued line was dropped after the warmed owner exited")
+	}
+}
+
 // exercised under -race: registration, reconcile, and the event hot path
 // must be safe to run concurrently
 func TestConcurrentPipeAccess(t *testing.T) {


### PR DESCRIPTION
## Summary

Since https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3055, the log enricher opens `/proc/<pid>/fd/<fd>` at event-capture time and caches the open file for 30 minutes. For a shell command-substitution pipe, that cached fd is the pipe's write end: the child exits, the shell never sees EOF, and every `$(...)` in an enriched process tree hangs until cache eviction — then reads the enriched log line as the command's output. Found on a live cluster: an instrumented shell script froze mid-$() for 10+ minutes and resumed only when the OBI pod exited.

Only touch pipes that are actually log destinations. When a PID is allowed, userspace registers the pipe inodes behind its stdout/stderr in a new log_pipes BPF map; pipe_write skips any pipe whose inode is not registered — non-log pipes are no longer NULed, captured, opened, or written to. Pipe events carry the inode, and userspace writes through a live tracked owner's `/proc` fd rather than the possibly-dead writer's — which also delivers short-lived writers' log lines more reliably, the original goal of #3055.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
