### PR TITLE
Release v0.12.1

### DIFF
--- a/internal/test/oats/ai/go.mod
+++ b/internal/test/oats/ai/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.0 // indirect
+	go.opentelemetry.io/obi v0.12.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/amqp/go.mod
+++ b/internal/test/oats/amqp/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.0 // indirect
+	go.opentelemetry.io/obi v0.12.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/harness/go.mod
+++ b/internal/test/oats/harness/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/grafana/oats v0.7.0
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.41.0
-	go.opentelemetry.io/obi v0.12.0
+	go.opentelemetry.io/obi v0.12.1
 )
 
 // The oats harness reuses the shared weaver-validation logic

--- a/internal/test/oats/http/go.mod
+++ b/internal/test/oats/http/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.0 // indirect
+	go.opentelemetry.io/obi v0.12.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/kafka/go.mod
+++ b/internal/test/oats/kafka/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.0 // indirect
+	go.opentelemetry.io/obi v0.12.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/memcached/go.mod
+++ b/internal/test/oats/memcached/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.0 // indirect
+	go.opentelemetry.io/obi v0.12.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/mongo/go.mod
+++ b/internal/test/oats/mongo/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.0 // indirect
+	go.opentelemetry.io/obi v0.12.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/nats/go.mod
+++ b/internal/test/oats/nats/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.0 // indirect
+	go.opentelemetry.io/obi v0.12.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/redis/go.mod
+++ b/internal/test/oats/redis/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.0 // indirect
+	go.opentelemetry.io/obi v0.12.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/sql/go.mod
+++ b/internal/test/oats/sql/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.0 // indirect
+	go.opentelemetry.io/obi v0.12.1 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   obi:
-    version: v0.12.0
+    version: v0.12.1
     modules:
       - go.opentelemetry.io/obi
 excluded-modules:


### PR DESCRIPTION
`v0.12.1` supersedes the unpublished `v0.12.0` release. The `v0.12.0` tag was created, but release validation failed because generation left the tagged commit dirty, so no GitHub Release was published. This patch release restores a clean release build and carries forward the expedited reliability fixes and other changes intended for `v0.12.0`.

Users should install `v0.12.1`; no `v0.12.0` release artifacts are available.

### Release correction

- Fixed an unguarded BPF program introduced by a merge race on `main`, restoring clean generation and release validation. ([#3101](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3101))

### Critical reliability fixes

- Prevented uprobe programs from being preempted on private-stack kernels, avoiding a kernel panic observed under moderate TLS load on Ubuntu 26.04. ([#3059](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3059), [#3056](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/3056))
- Disabled context propagation when the `FIONREAD` fixup cannot be attached, preventing OBI from risking disruption to instrumented applications. ([#3076](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3076))
- Attached Go probes to every usable canonical and vendored symbol copy, fixing missing instrumentation in binaries that execute multiple embedded copies of a library. ([#3020](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3020), [#3065](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3065))
- Stopped completed server requests from incorrectly parenting later client calls, restored connection attribution for wrapped Go TLS clients, and preserved enriched log lines from short-lived processes. ([#3001](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3001), [#3037](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3037), [#3055](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3055))
- Ensured Prometheus ports and paths registered after the first server start are served, and sanitized invalid UTF-8 metric attributes so one malformed value cannot drop an entire OTLP export batch. ([#3072](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3072), [#3003](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3003))

### Instrumentation and configuration

- Added Java service-name discovery consistent with OpenTelemetry Java, preferring the Spring Boot application name, JAR manifest title, and JAR basename before falling back to `java`. ([#3089](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3089))
- Added opt-in capture of manual spans created through `@opentelemetry/api` when a Node.js application has no SDK registered. ([#2661](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2661))
- Added Node.js event-loop utilization and delay runtime metrics through the existing inspector-injected agent. ([#2939](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2939))
- Added experimental OTEP 4719 process-context enrichment for resource attributes and metadata shared through the `OTEL_CTX` mapping. ([#1914](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1914))
- Added protocol- and signal-scoped application filters and enabled their end-to-end use in Configuration v2 while preserving Configuration v1's global filtering behavior. ([#2996](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2996), [#3066](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3066))

### Metrics

- Added `db.server.operation.duration` for server-side database spans, including Redis, Memcached, and SQL. ([#3091](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3091))
- Centralized internal metric declarations and corrected four OTLP metric names that incorrectly encoded Prometheus counter suffixes. Prometheus names remain unchanged except for the two map-entry gauges described below. ([#3026](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3026))

### Behavior changes and compatibility notes

> [!WARNING]
> Four internal OTLP metric names changed: `obi.bpf.map.entries_total` to `obi.bpf.map.entries`, `obi.bpf.map.max_entries_total` to `obi.bpf.map.max_entries`, `obi.bpf.network.packets.total` to `obi.bpf.network.packets`, and `obi.bpf.network.ignored.packets.total` to `obi.bpf.network.ignored.packets`. With default Prometheus translation, the two map gauges also lose the `_total` suffix. ([#3026](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3026))

- Server-side Redis and Memcached measurements now use `db.server.operation.duration` instead of `db.client.operation.duration`; update dashboards and alerts that read server-side measurements from the client metric. ([#3091](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3091))
- Node.js manual span capture is opt-in through `nodejs.manual_spans: true` or `OTEL_EBPF_NODEJS_MANUAL_SPANS`; it remains inactive when an SDK is already registered. ([#2661](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2661))

**Full Changelog**: [v0.11.0...v0.12.1](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/compare/v0.11.0...v0.12.1)
