### PR TITLE
refactor(otel): generalize the JVM up-down counter for shared runtime use

### DIFF
--- a/pkg/export/otel/metrics_jvm.go
+++ b/pkg/export/otel/metrics_jvm.go
@@ -6,7 +6,6 @@ package otel // import "go.opentelemetry.io/obi/pkg/export/otel"
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -14,35 +13,16 @@ import (
 	jvmruntime "go.opentelemetry.io/obi/pkg/appolly/app/runtime"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
 	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
-	"go.opentelemetry.io/obi/pkg/export/expire"
 	instrument "go.opentelemetry.io/obi/pkg/export/otel/metric/api/metric"
 	"go.opentelemetry.io/obi/pkg/runtimemetrics"
 )
 
 type jvmRuntimeMetrics struct {
 	ctx                   context.Context
-	memoryUsed            *jvmCurrentUpDownCounter
-	memoryCommitted       *jvmCurrentUpDownCounter
-	memoryLimit           *jvmCurrentUpDownCounter
-	memoryUsedAfterLastGC *jvmCurrentUpDownCounter
-}
-
-type jvmCurrentUpDownCounter struct {
-	ctx     context.Context
-	metric  instrument.Int64UpDownCounter
-	attrs   []attributes.Field[runtimemetrics.RuntimeMetricSnapshot, attribute.KeyValue]
-	entries *expire.ExpiryMap[*jvmCurrentUpDownCounterEntry]
-	log     *slog.Logger
-
-	clock          expire.Clock
-	lastExpiration time.Time
-	ttl            time.Duration
-}
-
-type jvmCurrentUpDownCounterEntry struct {
-	attrs       attribute.Set
-	value       int64
-	initialized bool
+	memoryUsed            *runtimeCurrentUpDownCounter
+	memoryCommitted       *runtimeCurrentUpDownCounter
+	memoryLimit           *runtimeCurrentUpDownCounter
+	memoryUsedAfterLastGC *runtimeCurrentUpDownCounter
 }
 
 func setupJVMRuntimeMeters(ctx context.Context, m *jvmRuntimeMetrics, meter instrument.Meter, ttl time.Duration) error {
@@ -54,25 +34,25 @@ func setupJVMRuntimeMeters(ctx context.Context, m *jvmRuntimeMetrics, meter inst
 	if err != nil {
 		return fmt.Errorf("creating JVM memory used up-down counter: %w", err)
 	}
-	m.memoryUsed = newJVMCurrentUpDownCounter(ctx, memoryUsed, memoryAttrs, timeNow, ttl)
+	m.memoryUsed = newRuntimeCurrentUpDownCounter(ctx, memoryUsed, memoryAttrs, timeNow, ttl)
 
 	memoryCommitted, err := meter.Int64UpDownCounter(attributes.JVMMemoryCommitted.OTEL, instrument.WithUnit(attributes.JVMMemoryCommitted.Unit))
 	if err != nil {
 		return fmt.Errorf("creating JVM memory committed up-down counter: %w", err)
 	}
-	m.memoryCommitted = newJVMCurrentUpDownCounter(ctx, memoryCommitted, memoryAttrs, timeNow, ttl)
+	m.memoryCommitted = newRuntimeCurrentUpDownCounter(ctx, memoryCommitted, memoryAttrs, timeNow, ttl)
 
 	memoryLimit, err := meter.Int64UpDownCounter(attributes.JVMMemoryLimit.OTEL, instrument.WithUnit(attributes.JVMMemoryLimit.Unit))
 	if err != nil {
 		return fmt.Errorf("creating JVM memory limit up-down counter: %w", err)
 	}
-	m.memoryLimit = newJVMCurrentUpDownCounter(ctx, memoryLimit, memoryAttrs, timeNow, ttl)
+	m.memoryLimit = newRuntimeCurrentUpDownCounter(ctx, memoryLimit, memoryAttrs, timeNow, ttl)
 
 	memoryUsedAfterLastGC, err := meter.Int64UpDownCounter(attributes.JVMMemoryUsedAfterLastGC.OTEL, instrument.WithUnit(attributes.JVMMemoryUsedAfterLastGC.Unit))
 	if err != nil {
 		return fmt.Errorf("creating JVM memory used after last GC up-down counter: %w", err)
 	}
-	m.memoryUsedAfterLastGC = newJVMCurrentUpDownCounter(ctx, memoryUsedAfterLastGC, memoryAttrs, timeNow, ttl)
+	m.memoryUsedAfterLastGC = newRuntimeCurrentUpDownCounter(ctx, memoryUsedAfterLastGC, memoryAttrs, timeNow, ttl)
 
 	return nil
 }
@@ -93,69 +73,6 @@ func (m *jvmRuntimeMetrics) record(snapshot runtimemetrics.RuntimeMetricSnapshot
 	case jvmruntime.JVMMetricMemoryUsedAfterLastGC:
 		m.memoryUsedAfterLastGC.Record(snapshot, value)
 	}
-}
-
-func newJVMCurrentUpDownCounter(
-	ctx context.Context,
-	metric instrument.Int64UpDownCounter,
-	attrs []attributes.Field[runtimemetrics.RuntimeMetricSnapshot, attribute.KeyValue],
-	clock expire.Clock,
-	ttl time.Duration,
-) *jvmCurrentUpDownCounter {
-	return &jvmCurrentUpDownCounter{
-		ctx:            ctx,
-		metric:         metric,
-		attrs:          attrs,
-		entries:        expire.NewExpiryMap[*jvmCurrentUpDownCounterEntry](clock, ttl),
-		log:            plog().With("type", fmt.Sprintf("%T", metric)),
-		clock:          clock,
-		lastExpiration: clock(),
-		ttl:            ttl,
-	}
-}
-
-func (c *jvmCurrentUpDownCounter) Record(snapshot runtimemetrics.RuntimeMetricSnapshot, value int64) {
-	now := c.clock()
-	if now.Sub(c.lastExpiration) >= c.ttl {
-		c.removeOutdated(c.ctx)
-		c.lastExpiration = now
-	}
-
-	recordAttrs, attrValues := jvmRuntimeAttributeSet(c.attrs, snapshot)
-	entry := c.entries.GetOrCreate(attrValues, func() *jvmCurrentUpDownCounterEntry {
-		c.log.Debug("storing new metric label set", "labelValues", attrValues)
-		return &jvmCurrentUpDownCounterEntry{attrs: recordAttrs}
-	})
-
-	delta := value - entry.value
-	if !entry.initialized || delta != 0 {
-		c.metric.Add(c.ctx, delta, instrument.WithAttributeSet(entry.attrs))
-	}
-	entry.value = value
-	entry.initialized = true
-}
-
-func (c *jvmCurrentUpDownCounter) removeOutdated(ctx context.Context) {
-	for _, entry := range c.entries.DeleteExpired() {
-		c.metric.Add(ctx, -entry.value, instrument.WithAttributeSet(entry.attrs))
-		c.metric.Remove(ctx, instrument.WithAttributeSet(entry.attrs))
-	}
-}
-
-func jvmRuntimeAttributeSet(
-	fields []attributes.Field[runtimemetrics.RuntimeMetricSnapshot, attribute.KeyValue],
-	snapshot runtimemetrics.RuntimeMetricSnapshot,
-) (attribute.Set, []string) {
-	keyVals := make([]attribute.KeyValue, 0, len(fields))
-	vals := make([]string, 0, len(fields))
-
-	for _, field := range fields {
-		kv := sanitizeKeyValue(field.Get(snapshot))
-		keyVals = append(keyVals, kv)
-		vals = append(vals, kv.Value.Emit())
-	}
-
-	return attribute.NewSet(keyVals...), vals
 }
 
 func jvmMemoryOTELAttributes() []attributes.Field[runtimemetrics.RuntimeMetricSnapshot, attribute.KeyValue] {

--- a/pkg/export/otel/metrics_runtime.go
+++ b/pkg/export/otel/metrics_runtime.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
 	"go.opentelemetry.io/obi/pkg/export/attributes"
+	"go.opentelemetry.io/obi/pkg/export/expire"
 	"go.opentelemetry.io/obi/pkg/export/otel/metric"
 	instrument "go.opentelemetry.io/obi/pkg/export/otel/metric/api/metric"
 	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
@@ -557,4 +558,85 @@ func (r *RuntimeMetricsReporter) close() {
 		}
 		rmlog().Debug("runtime metrics reporter closed")
 	}()
+}
+
+type runtimeCurrentUpDownCounter struct {
+	ctx     context.Context
+	metric  instrument.Int64UpDownCounter
+	attrs   []attributes.Field[runtimemetrics.RuntimeMetricSnapshot, attribute.KeyValue]
+	entries *expire.ExpiryMap[*runtimeCurrentUpDownCounterEntry]
+	log     *slog.Logger
+
+	clock          expire.Clock
+	lastExpiration time.Time
+	ttl            time.Duration
+}
+
+type runtimeCurrentUpDownCounterEntry struct {
+	attrs       attribute.Set
+	value       int64
+	initialized bool
+}
+
+func newRuntimeCurrentUpDownCounter(
+	ctx context.Context,
+	metric instrument.Int64UpDownCounter,
+	attrs []attributes.Field[runtimemetrics.RuntimeMetricSnapshot, attribute.KeyValue],
+	clock expire.Clock,
+	ttl time.Duration,
+) *runtimeCurrentUpDownCounter {
+	return &runtimeCurrentUpDownCounter{
+		ctx:            ctx,
+		metric:         metric,
+		attrs:          attrs,
+		entries:        expire.NewExpiryMap[*runtimeCurrentUpDownCounterEntry](clock, ttl),
+		log:            plog().With("type", fmt.Sprintf("%T", metric)),
+		clock:          clock,
+		lastExpiration: clock(),
+		ttl:            ttl,
+	}
+}
+
+func (c *runtimeCurrentUpDownCounter) Record(snapshot runtimemetrics.RuntimeMetricSnapshot, value int64) {
+	now := c.clock()
+	if now.Sub(c.lastExpiration) >= c.ttl {
+		c.removeOutdated(c.ctx)
+		c.lastExpiration = now
+	}
+
+	recordAttrs, attrValues := runtimeAttributeSet(c.attrs, snapshot)
+	entry := c.entries.GetOrCreate(attrValues, func() *runtimeCurrentUpDownCounterEntry {
+		c.log.Debug("storing new metric label set", "labelValues", attrValues)
+		return &runtimeCurrentUpDownCounterEntry{attrs: recordAttrs}
+	})
+
+	delta := value - entry.value
+	if !entry.initialized || delta != 0 {
+		c.metric.Add(c.ctx, delta, instrument.WithAttributeSet(entry.attrs))
+	}
+	entry.value = value
+	entry.initialized = true
+}
+
+func (c *runtimeCurrentUpDownCounter) removeOutdated(ctx context.Context) {
+	for _, entry := range c.entries.DeleteExpired() {
+		c.metric.Add(ctx, -entry.value, instrument.WithAttributeSet(entry.attrs))
+		c.metric.Remove(ctx, instrument.WithAttributeSet(entry.attrs))
+	}
+}
+
+func runtimeAttributeSet(
+	fields []attributes.Field[runtimemetrics.RuntimeMetricSnapshot, attribute.KeyValue],
+	snapshot runtimemetrics.RuntimeMetricSnapshot,
+) (attribute.Set, []string) {
+	keyVals := make([]attribute.KeyValue, 0, len(fields))
+	vals := make([]string, 0, len(fields))
+
+	for _, field := range fields {
+		kv := sanitizeKeyValue(field.Get(snapshot))
+		keyVals = append(keyVals, kv)
+		vals = append(vals, kv.Value.Emit())
+	}
+
+	return attribute.NewSet(keyVals...), vals
 }


### PR DESCRIPTION
## Summary

This PR renames the jvm prefixed up-down-counter helpers to runtime-agnostic names and moves them in to `metrics_runtime.go`.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
