### PR TITLE
Fix generic MongoDB detection and service attribution for mongosh

### DIFF
--- a/pkg/ebpf/common/mongo_detect_transform.go
+++ b/pkg/ebpf/common/mongo_detect_transform.go
@@ -412,18 +412,40 @@ func validateFlagBits(flagBits int32) error {
 }
 
 func mongoInfoFromEvent(event *TCPRequestInfo, requestBuffer *largebuf.LargeBuffer, responseBuffer *largebuf.LargeBuffer, mongoRequestCache PendingMongoDBRequests) *mongoSpanInfo {
-	if event.Direction == 0 {
-		return nil
+	if mongoInfo := mongoInfoFromEventBuffers(event, requestBuffer, responseBuffer, mongoRequestCache); mongoInfo != nil {
+		return mongoInfo
 	}
-	reqRaw := requestBuffer.UnsafeView()
-	respRaw := responseBuffer.UnsafeView()
+	return mongoInfoFromEventBuffers(event, responseBuffer, requestBuffer, mongoRequestCache)
+}
+
+func mongoInfoFromEventBuffers(event *TCPRequestInfo, requestBuffer *largebuf.LargeBuffer, responseBuffer *largebuf.LargeBuffer, mongoRequestCache PendingMongoDBRequests) *mongoSpanInfo {
 	var mongoRequest *MongoRequestValue
 	var moreToCome bool
-	_, _, err := ProcessMongoEvent(reqRaw, int64(event.StartMonotimeNs), int64(event.EndMonotimeNs), event.ConnInfo, mongoRequestCache)
-	if err != nil {
+	respRaw := responseBuffer.UnsafeView()
+	if len(respRaw) > 0 {
+		if hdr, err := parseMongoHeader(respRaw); err == nil {
+			if _, ok := mongoRequestCache.Peek(makeRequestKey(true, hdr, event.ConnInfo)); ok {
+				mongoRequest, moreToCome, err = ProcessMongoEvent(respRaw, int64(event.StartMonotimeNs), int64(event.EndMonotimeNs), event.ConnInfo, mongoRequestCache)
+				if err != nil || mongoRequest == nil || moreToCome {
+					return nil
+				}
+				if mongoInfo, err := getMongoInfo(mongoRequest); err == nil {
+					return mongoInfo
+				}
+				return nil
+			}
+		}
+	}
+	if reqRaw := requestBuffer.UnsafeView(); len(reqRaw) > 0 {
+		_, _, err := ProcessMongoEvent(reqRaw, int64(event.StartMonotimeNs), int64(event.EndMonotimeNs), event.ConnInfo, mongoRequestCache)
+		if err != nil {
+			return nil
+		}
+	}
+	if len(respRaw) == 0 {
 		return nil
 	}
-	mongoRequest, moreToCome, err = ProcessMongoEvent(respRaw, int64(event.StartMonotimeNs), int64(event.EndMonotimeNs), event.ConnInfo, mongoRequestCache)
+	mongoRequest, moreToCome, err := ProcessMongoEvent(respRaw, int64(event.StartMonotimeNs), int64(event.EndMonotimeNs), event.ConnInfo, mongoRequestCache)
 	if err != nil || mongoRequest == nil || moreToCome {
 		return nil
 	}

--- a/pkg/ebpf/common/mongo_shell_regression_test.go
+++ b/pkg/ebpf/common/mongo_shell_regression_test.go
@@ -1,0 +1,96 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func buildMongoShellFindWire(t *testing.T) []byte {
+	t.Helper()
+
+	const (
+		wantLength = 300
+		requestID  = 23
+	)
+
+	for commentLen := 0; commentLen < 512; commentLen++ {
+		body := bson.D{
+			{Key: commFind, Value: "obi_shell_test"},
+			{Key: "filter", Value: bson.D{{Key: "source", Value: "strace-test"}}},
+			{Key: "$db", Value: "obi_mongosh_test"},
+			{Key: "comment", Value: strings.Repeat("x", commentLen)},
+		}
+		bodyBytes, err := bson.Marshal(body)
+		require.NoError(t, err)
+
+		if len(bodyBytes)+msgHeaderSize+int32Size+1 != wantLength {
+			continue
+		}
+
+		buf := new(bytes.Buffer)
+		require.NoError(t, binary.Write(buf, binary.LittleEndian, msgHeader{
+			MessageLength: wantLength,
+			RequestID:     requestID,
+			ResponseTo:    0,
+			OpCode:        opMsg,
+		}))
+		require.NoError(t, binary.Write(buf, binary.LittleEndian, uint32(0)))
+		require.NoError(t, binary.Write(buf, binary.LittleEndian, sectionTypeBody))
+		require.NoError(t, binary.Write(buf, binary.LittleEndian, bodyBytes))
+		require.Len(t, buf.Bytes(), wantLength)
+		return buf.Bytes()
+	}
+
+	t.Fatal("could not construct a 300-byte MongoDB OP_MSG request body")
+	return nil
+}
+
+func buildMongoShellFindResponse(t *testing.T, requestID int32) []byte {
+	t.Helper()
+
+	bodyBytes, err := bson.Marshal(bson.D{{Key: "ok", Value: 1.0}})
+	require.NoError(t, err)
+
+	buf := new(bytes.Buffer)
+	require.NoError(t, binary.Write(buf, binary.LittleEndian, msgHeader{
+		MessageLength: msgHeaderSize + int32Size + 1 + int32(len(bodyBytes)),
+		RequestID:     requestID + 1,
+		ResponseTo:    requestID,
+		OpCode:        opMsg,
+	}))
+	require.NoError(t, binary.Write(buf, binary.LittleEndian, uint32(0)))
+	require.NoError(t, binary.Write(buf, binary.LittleEndian, sectionTypeBody))
+	require.NoError(t, binary.Write(buf, binary.LittleEndian, bodyBytes))
+	return buf.Bytes()
+}
+
+func TestProcessMongoEventMongoShellFindExactWire(t *testing.T) {
+	defer requests.Purge()
+
+	connInfo := getConnInfo()
+	requestWire := buildMongoShellFindWire(t)
+	responseWire := buildMongoShellFindResponse(t, 23)
+
+	mongoRequest, moreToCome, err := ProcessMongoEvent(requestWire, StartTime, EndTime, connInfo, requests)
+	require.NoError(t, err)
+	require.True(t, moreToCome)
+
+	mongoRequest, moreToCome, err = ProcessMongoEvent(responseWire, StartTime, EndTime, connInfo, requests)
+	require.NoError(t, err)
+	require.False(t, moreToCome)
+	require.NotNil(t, mongoRequest)
+
+	info, err := getMongoInfo(mongoRequest)
+	require.NoError(t, err)
+	require.Equal(t, "find", info.OpName)
+	require.Equal(t, "obi_shell_test", info.Collection)
+	require.Equal(t, "obi_mongosh_test", info.DB)
+}

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -619,10 +619,15 @@ func getBuffers(parseCtx *EBPFParseContext, event *TCPRequestInfo) (req *largebu
 	resp = largebuf.NewLargeBufferFrom(event.Rbuf[:l])
 
 	if event.HasLargeBuffers == 1 {
-		if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeRequest, directionByPacketType(packetTypeRequest, !event.IsServer), event.ConnInfo, event.ProtocolType); ok {
+		isClient := !event.IsServer
+		if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeRequest, directionByPacketType(packetTypeRequest, isClient), event.ConnInfo, event.ProtocolType); ok {
+			req = b
+		} else if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeRequest, directionByPacketType(packetTypeRequest, !isClient), event.ConnInfo, event.ProtocolType); ok {
 			req = b
 		}
-		if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeResponse, directionByPacketType(packetTypeResponse, !event.IsServer), event.ConnInfo, event.ProtocolType); ok {
+		if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeResponse, directionByPacketType(packetTypeResponse, isClient), event.ConnInfo, event.ProtocolType); ok {
+			resp = b
+		} else if b, ok := extractTCPLargeBuffer(parseCtx, event.Tp.TraceId, packetTypeResponse, directionByPacketType(packetTypeResponse, !isClient), event.ConnInfo, event.ProtocolType); ok {
 			resp = b
 		}
 	}

--- a/pkg/ebpf/common/tcp_detect_transform_test.go
+++ b/pkg/ebpf/common/tcp_detect_transform_test.go
@@ -29,6 +29,453 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 
+func TestReadTCPRequestIntoSpan_MongoShellFindUsesLargeBuffers(t *testing.T) {
+	defer requests.Purge()
+
+	cfg := config.EBPFTracer{
+		MongoRequestsCacheSize: 16,
+		ProtocolDebug:          false,
+	}
+	ctx := NewEBPFParseContext(&cfg, nil, nil)
+	fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+
+	traceID := [16]uint8{95, 133, 126, 235, 9, 61, 211, 78, 63, 27, 202, 54, 186, 104, 47, 109}
+	connInfo := getConnInfo()
+
+	requestWire := buildMongoShellFindWire(t)
+	responseWire := buildMongoShellFindResponse(t, 23)
+
+	reqHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeRequest,
+		Action:     largeBufferActionInit,
+		Direction:  directionSend,
+		Len:        uint32(len(requestWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	reqHdr.Tp.TraceId = traceID
+	reqHdr.ConnInfo = connInfo
+	_, _, err := appendTCPLargeBuffer(ctx, toRingbufRecord(t, reqHdr, string(requestWire)))
+	require.NoError(t, err)
+
+	respHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeResponse,
+		Action:     largeBufferActionInit,
+		Direction:  directionRecv,
+		Len:        uint32(len(responseWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	respHdr.Tp.TraceId = traceID
+	respHdr.ConnInfo = connInfo
+	_, _, err = appendTCPLargeBuffer(ctx, toRingbufRecord(t, respHdr, string(responseWire)))
+	require.NoError(t, err)
+
+	var event TCPRequestInfo
+	event.Direction = directionSend
+	event.IsServer = false
+	event.HasLargeBuffers = 1
+	event.ProtocolType = ProtocolTypeUnknown
+	event.ConnInfo = connInfo
+	event.Tp.TraceId = traceID
+	event.Len = 0
+	event.RespLen = 0
+	event.StartMonotimeNs = StartTime
+	event.EndMonotimeNs = EndTime
+
+	recordBuf := bytes.Buffer{}
+	require.NoError(t, binary.Write(&recordBuf, binary.LittleEndian, event))
+
+	span, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &ringbuf.Record{RawSample: recordBuf.Bytes()}, &fltr)
+	require.NoError(t, err)
+	require.False(t, ignore)
+	require.Equal(t, request.EventTypeMongoClient, span.Type)
+	require.Equal(t, "find", span.Method)
+	require.Equal(t, "obi_shell_test", span.Path)
+	require.Equal(t, "obi_mongosh_test", span.DBNamespace)
+}
+
+func TestReadTCPRequestIntoSpan_MongoShellFindIsParsedOnReceiveSide(t *testing.T) {
+	defer requests.Purge()
+
+	cfg := config.EBPFTracer{
+		MongoRequestsCacheSize: 16,
+		ProtocolDebug:          false,
+	}
+	ctx := NewEBPFParseContext(&cfg, nil, nil)
+	fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+
+	traceID := [16]uint8{95, 133, 126, 235, 9, 61, 211, 78, 63, 27, 202, 54, 186, 104, 47, 109}
+	connInfo := getConnInfo()
+
+	requestWire := buildMongoShellFindWire(t)
+	responseWire := buildMongoShellFindResponse(t, 23)
+
+	reqHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeRequest,
+		Action:     largeBufferActionInit,
+		Direction:  directionSend,
+		Len:        uint32(len(requestWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	reqHdr.Tp.TraceId = traceID
+	reqHdr.ConnInfo = connInfo
+	_, _, err := appendTCPLargeBuffer(ctx, toRingbufRecord(t, reqHdr, string(requestWire)))
+	require.NoError(t, err)
+
+	respHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeResponse,
+		Action:     largeBufferActionInit,
+		Direction:  directionRecv,
+		Len:        uint32(len(responseWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	respHdr.Tp.TraceId = traceID
+	respHdr.ConnInfo = connInfo
+	_, _, err = appendTCPLargeBuffer(ctx, toRingbufRecord(t, respHdr, string(responseWire)))
+	require.NoError(t, err)
+
+	var event TCPRequestInfo
+	event.Direction = directionRecv
+	event.IsServer = false
+	event.HasLargeBuffers = 1
+	event.ProtocolType = ProtocolTypeUnknown
+	event.ConnInfo = connInfo
+	event.Tp.TraceId = traceID
+	event.Len = 0
+	event.RespLen = 0
+	event.StartMonotimeNs = StartTime
+	event.EndMonotimeNs = EndTime
+
+	recordBuf := bytes.Buffer{}
+	require.NoError(t, binary.Write(&recordBuf, binary.LittleEndian, event))
+
+	span, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &ringbuf.Record{RawSample: recordBuf.Bytes()}, &fltr)
+	require.NoError(t, err)
+	require.False(t, ignore)
+	require.Equal(t, request.EventTypeMongoClient, span.Type)
+	require.Equal(t, "find", span.Method)
+	require.Equal(t, "obi_shell_test", span.Path)
+	require.Equal(t, "obi_mongosh_test", span.DBNamespace)
+}
+
+func TestReadTCPRequestIntoSpan_MongoShellFindCanFinalizeOnResponseOnly(t *testing.T) {
+	defer requests.Purge()
+
+	cfg := config.EBPFTracer{
+		MongoRequestsCacheSize: 16,
+		ProtocolDebug:          false,
+	}
+	ctx := NewEBPFParseContext(&cfg, nil, nil)
+	fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+
+	traceID := [16]uint8{95, 133, 126, 235, 9, 61, 211, 78, 63, 27, 202, 54, 186, 104, 47, 109}
+	connInfo := getConnInfo()
+
+	requestWire := buildMongoShellFindWire(t)
+	responseWire := buildMongoShellFindResponse(t, 23)
+
+	reqHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeRequest,
+		Action:     largeBufferActionInit,
+		Direction:  directionSend,
+		Len:        uint32(len(requestWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	reqHdr.Tp.TraceId = traceID
+	reqHdr.ConnInfo = connInfo
+	_, _, err := appendTCPLargeBuffer(ctx, toRingbufRecord(t, reqHdr, string(requestWire)))
+	require.NoError(t, err)
+
+	var requestEvent TCPRequestInfo
+	requestEvent.Direction = directionSend
+	requestEvent.IsServer = false
+	requestEvent.HasLargeBuffers = 1
+	requestEvent.ProtocolType = ProtocolTypeUnknown
+	requestEvent.ConnInfo = connInfo
+	requestEvent.Tp.TraceId = traceID
+	requestEvent.StartMonotimeNs = StartTime
+	requestEvent.EndMonotimeNs = EndTime
+
+	requestBuf := bytes.Buffer{}
+	require.NoError(t, binary.Write(&requestBuf, binary.LittleEndian, requestEvent))
+	_, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &ringbuf.Record{RawSample: requestBuf.Bytes()}, &fltr)
+	require.NoError(t, err)
+	require.True(t, ignore)
+
+	respHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeResponse,
+		Action:     largeBufferActionInit,
+		Direction:  directionRecv,
+		Len:        uint32(len(responseWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	respHdr.Tp.TraceId = traceID
+	respHdr.ConnInfo = connInfo
+	_, _, err = appendTCPLargeBuffer(ctx, toRingbufRecord(t, respHdr, string(responseWire)))
+	require.NoError(t, err)
+
+	var responseEvent TCPRequestInfo
+	responseEvent.Direction = directionRecv
+	responseEvent.IsServer = false
+	responseEvent.HasLargeBuffers = 1
+	responseEvent.ProtocolType = ProtocolTypeUnknown
+	responseEvent.ConnInfo = connInfo
+	responseEvent.Tp.TraceId = traceID
+	responseEvent.StartMonotimeNs = StartTime
+	responseEvent.EndMonotimeNs = EndTime
+
+	responseBuf := bytes.Buffer{}
+	require.NoError(t, binary.Write(&responseBuf, binary.LittleEndian, responseEvent))
+
+	span, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &ringbuf.Record{RawSample: responseBuf.Bytes()}, &fltr)
+	require.NoError(t, err)
+	require.False(t, ignore)
+	require.Equal(t, request.EventTypeMongoClient, span.Type)
+	require.Equal(t, "find", span.Method)
+	require.Equal(t, "obi_shell_test", span.Path)
+	require.Equal(t, "obi_mongosh_test", span.DBNamespace)
+}
+
+func TestReadTCPRequestIntoSpan_MongoShellFindResponseTraceCarriesRequestBytes(t *testing.T) {
+	defer requests.Purge()
+
+	cfg := config.EBPFTracer{
+		MongoRequestsCacheSize: 16,
+		ProtocolDebug:          false,
+	}
+	ctx := NewEBPFParseContext(&cfg, nil, nil)
+	fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+
+	traceID := [16]uint8{95, 133, 126, 235, 9, 61, 211, 78, 63, 27, 202, 54, 186, 104, 47, 109}
+	connInfo := getConnInfo()
+
+	requestWire := buildMongoShellFindWire(t)
+	responseWire := buildMongoShellFindResponse(t, 23)
+
+	reqHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeRequest,
+		Action:     largeBufferActionInit,
+		Direction:  directionSend,
+		Len:        uint32(len(requestWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	reqHdr.Tp.TraceId = traceID
+	reqHdr.ConnInfo = connInfo
+	_, _, err := appendTCPLargeBuffer(ctx, toRingbufRecord(t, reqHdr, string(requestWire)))
+	require.NoError(t, err)
+
+	var requestEvent TCPRequestInfo
+	requestEvent.Direction = directionSend
+	requestEvent.IsServer = false
+	requestEvent.HasLargeBuffers = 1
+	requestEvent.ProtocolType = ProtocolTypeUnknown
+	requestEvent.ConnInfo = connInfo
+	requestEvent.Tp.TraceId = traceID
+	requestEvent.Len = uint32(len(requestWire))
+	requestEvent.StartMonotimeNs = StartTime
+	requestEvent.EndMonotimeNs = EndTime
+
+	requestBuf := bytes.Buffer{}
+	require.NoError(t, binary.Write(&requestBuf, binary.LittleEndian, requestEvent))
+	_, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &ringbuf.Record{RawSample: requestBuf.Bytes()}, &fltr)
+	require.NoError(t, err)
+	require.True(t, ignore)
+
+	respHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeResponse,
+		Action:     largeBufferActionInit,
+		Direction:  directionRecv,
+		Len:        uint32(len(responseWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	respHdr.Tp.TraceId = traceID
+	respHdr.ConnInfo = connInfo
+	_, _, err = appendTCPLargeBuffer(ctx, toRingbufRecord(t, respHdr, string(responseWire)))
+	require.NoError(t, err)
+
+	// The response-side TCP trace still carries the original request bytes in Buf
+	// plus the response bytes in Rbuf. We should finalize from the response instead
+	// of re-parsing the request and dropping the event.
+	var responseEvent TCPRequestInfo
+	responseEvent.Direction = directionSend
+	responseEvent.IsServer = false
+	responseEvent.HasLargeBuffers = 1
+	responseEvent.ProtocolType = ProtocolTypeUnknown
+	responseEvent.ConnInfo = connInfo
+	responseEvent.Tp.TraceId = traceID
+	responseEvent.Len = uint32(len(requestWire))
+	responseEvent.RespLen = uint32(len(responseWire))
+	responseEvent.StartMonotimeNs = StartTime
+	responseEvent.EndMonotimeNs = EndTime
+
+	responseBuf := bytes.Buffer{}
+	require.NoError(t, binary.Write(&responseBuf, binary.LittleEndian, responseEvent))
+
+	span, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &ringbuf.Record{RawSample: responseBuf.Bytes()}, &fltr)
+	require.NoError(t, err)
+	require.False(t, ignore)
+	require.Equal(t, request.EventTypeMongoClient, span.Type)
+	require.Equal(t, "find", span.Method)
+	require.Equal(t, "obi_shell_test", span.Path)
+	require.Equal(t, "obi_mongosh_test", span.DBNamespace)
+}
+
+func TestReadTCPRequestIntoSpan_MongoShellFindUsesLargeBufferFallbackWhenIsServerIsWrong(t *testing.T) {
+	defer requests.Purge()
+
+	cfg := config.EBPFTracer{
+		MongoRequestsCacheSize: 16,
+		ProtocolDebug:          false,
+	}
+	ctx := NewEBPFParseContext(&cfg, nil, nil)
+	fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+
+	traceID := [16]uint8{95, 133, 126, 235, 9, 61, 211, 78, 63, 27, 202, 54, 186, 104, 47, 109}
+	connInfo := getConnInfo()
+
+	requestWire := buildMongoShellFindWire(t)
+	responseWire := buildMongoShellFindResponse(t, 23)
+
+	reqHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeRequest,
+		Action:     largeBufferActionInit,
+		Direction:  directionSend,
+		Len:        uint32(len(requestWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	reqHdr.Tp.TraceId = traceID
+	reqHdr.ConnInfo = connInfo
+	_, _, err := appendTCPLargeBuffer(ctx, toRingbufRecord(t, reqHdr, string(requestWire)))
+	require.NoError(t, err)
+
+	var requestEvent TCPRequestInfo
+	requestEvent.Direction = directionSend
+	requestEvent.IsServer = true
+	requestEvent.HasLargeBuffers = 1
+	requestEvent.ProtocolType = ProtocolTypeUnknown
+	requestEvent.ConnInfo = connInfo
+	requestEvent.Tp.TraceId = traceID
+	requestEvent.Len = 256
+	requestEvent.StartMonotimeNs = StartTime
+	requestEvent.EndMonotimeNs = EndTime
+
+	requestBuf := bytes.Buffer{}
+	require.NoError(t, binary.Write(&requestBuf, binary.LittleEndian, requestEvent))
+	_, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &ringbuf.Record{RawSample: requestBuf.Bytes()}, &fltr)
+	require.NoError(t, err)
+	require.True(t, ignore)
+
+	respHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeResponse,
+		Action:     largeBufferActionInit,
+		Direction:  directionRecv,
+		Len:        uint32(len(responseWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	respHdr.Tp.TraceId = traceID
+	respHdr.ConnInfo = connInfo
+	_, _, err = appendTCPLargeBuffer(ctx, toRingbufRecord(t, respHdr, string(responseWire)))
+	require.NoError(t, err)
+
+	var responseEvent TCPRequestInfo
+	responseEvent.Direction = directionSend
+	responseEvent.IsServer = true
+	responseEvent.HasLargeBuffers = 1
+	responseEvent.ProtocolType = ProtocolTypeUnknown
+	responseEvent.ConnInfo = connInfo
+	responseEvent.Tp.TraceId = traceID
+	responseEvent.Len = 256
+	responseEvent.RespLen = uint32(len(responseWire))
+	responseEvent.StartMonotimeNs = StartTime
+	responseEvent.EndMonotimeNs = EndTime
+
+	responseBuf := bytes.Buffer{}
+	require.NoError(t, binary.Write(&responseBuf, binary.LittleEndian, responseEvent))
+
+	span, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &ringbuf.Record{RawSample: responseBuf.Bytes()}, &fltr)
+	require.NoError(t, err)
+	require.False(t, ignore)
+	require.Equal(t, request.EventTypeMongoClient, span.Type)
+	require.Equal(t, "find", span.Method)
+	require.Equal(t, "obi_shell_test", span.Path)
+	require.Equal(t, "obi_mongosh_test", span.DBNamespace)
+}
+
+func TestReadTCPRequestIntoSpan_MongoShellFindParsesSwappedRequestResponseBuffers(t *testing.T) {
+	defer requests.Purge()
+
+	cfg := config.EBPFTracer{
+		MongoRequestsCacheSize: 16,
+		ProtocolDebug:          false,
+	}
+	ctx := NewEBPFParseContext(&cfg, nil, nil)
+	fltr := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+
+	traceID := [16]uint8{95, 133, 126, 235, 9, 61, 211, 78, 63, 27, 202, 54, 186, 104, 47, 109}
+	connInfo := getConnInfo()
+
+	requestWire := buildMongoShellFindWire(t)
+	responseWire := buildMongoShellFindResponse(t, 23)
+
+	respHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeRequest,
+		Action:     largeBufferActionInit,
+		Direction:  directionSend,
+		Len:        uint32(len(responseWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	respHdr.Tp.TraceId = traceID
+	respHdr.ConnInfo = connInfo
+	_, _, err := appendTCPLargeBuffer(ctx, toRingbufRecord(t, respHdr, string(responseWire)))
+	require.NoError(t, err)
+
+	reqHdr := TCPLargeBufferHeader{
+		Type:       EventTypeTCPLargeBuffer,
+		PacketType: packetTypeResponse,
+		Action:     largeBufferActionInit,
+		Direction:  directionRecv,
+		Len:        uint32(len(requestWire)),
+		Kind:       uint8(KindLayerWire),
+	}
+	reqHdr.Tp.TraceId = traceID
+	reqHdr.ConnInfo = connInfo
+	_, _, err = appendTCPLargeBuffer(ctx, toRingbufRecord(t, reqHdr, string(requestWire)))
+	require.NoError(t, err)
+
+	var event TCPRequestInfo
+	event.Direction = directionSend
+	event.IsServer = false
+	event.HasLargeBuffers = 1
+	event.ProtocolType = ProtocolTypeUnknown
+	event.ConnInfo = connInfo
+	event.Tp.TraceId = traceID
+	event.Len = uint32(len(responseWire))
+	event.RespLen = 256
+	event.StartMonotimeNs = StartTime
+	event.EndMonotimeNs = EndTime
+
+	recordBuf := bytes.Buffer{}
+	require.NoError(t, binary.Write(&recordBuf, binary.LittleEndian, event))
+
+	span, ignore, err := ReadTCPRequestIntoSpan(ctx, &cfg, &ringbuf.Record{RawSample: recordBuf.Bytes()}, &fltr)
+	require.NoError(t, err)
+	require.False(t, ignore)
+	require.Equal(t, request.EventTypeMongoClient, span.Type)
+	require.Equal(t, "find", span.Method)
+	require.Equal(t, "obi_shell_test", span.Path)
+	require.Equal(t, "obi_mongosh_test", span.DBNamespace)
+}
+
 func TestTCPReqSQLParsing(t *testing.T) {
 	sql := randomStringWithSub("SELECT * FROM accounts ")
 	r := makeTCPReq(sql, 343534)


### PR DESCRIPTION
## Summary

This PR fixes MongoDB generic TCP detection/parsing for mongosh traffic where the captured request/response large-buffer orientation can be reversed before reaching the MongoDB parser.

The fix keeps the Mongo parser behavior focused on MongoDB protocol detection/parsing only.

## What changed

- Adds a mongosh OP_MSG regression test using a realistic MongoDB wire message.
- Verifies MongoDB detection succeeds for the synthetic mongosh request.
- Verifies parsing extracts:
  - operation: find
  - collection: obi_shell_test
- Updates generic TCP large-buffer request/response selection to tolerate the observed mongosh capture orientation.
- Updates Mongo parsing to retry with swapped request/response buffers when the first orientation does not produce MongoDB metadata.

## Validation

Tested with focused MongoDB parser/generic TCP regression coverage.

Additional lab validation showed MongoDB client metrics for mongosh after the default transaction settling window, including insert, find, update, and delete operations attributed to service_name="mongosh".

## Note

The short-lived child-process service attribution improvement has been split into a separate PR per maintainer feedback.
