### PR TITLE
ci: prebuild hatest-obi images to save runner time

### DIFF
--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -107,9 +107,39 @@ jobs:
         if: steps.base-images-cache.outputs.cache-hit != 'true'
         run: bash scripts/pull-base-images.sh /tmp/base-images.tar
 
+  build-obi-image:
+    name: "Build OBI test image"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [generate-bpf]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Download generated BPF files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bpf-generated-${{ github.run_id }}
+
+      # built once here and loaded by every shard so each shard skips the
+      # most expensive compose build
+      - name: Build and save OBI test image
+        run: |
+          docker build -t hatest-obi -f internal/test/integration/components/obi/Dockerfile .
+          docker save hatest-obi -o /tmp/hatest-obi.tar
+
+      - name: Upload OBI test image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: obi-image-amd64-${{ github.run_id }}
+          path: /tmp/hatest-obi.tar
+          retention-days: 1
+
   test:
     name: ${{ matrix.description }}
-    needs: [test-matrix, generate-bpf, prep-images]
+    needs: [test-matrix, generate-bpf, prep-images, build-obi-image]
     permissions:
       # Required for codecov
       checks: write
@@ -181,6 +211,18 @@ jobs:
             echo "::warning::base image cache miss; builds may pull from the upstream registry and risk HTTP 429"
           fi
 
+      - name: Download prebuilt OBI image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: obi-image-amd64-${{ github.run_id }}
+          path: /tmp/obi-image
+
+      # hatest-obi-b is the same plain build under a second tag
+      - name: Load prebuilt OBI image
+        run: |
+          docker load -i /tmp/obi-image/hatest-obi.tar
+          docker tag hatest-obi hatest-obi-b
+
       - name: Check disk usage before tests
         run: df -h
 
@@ -217,6 +259,9 @@ jobs:
           MATRIX_JSON: ${{ toJson(matrix) }}
           MATRIX_TEST_PATTERN: ${{ matrix.test_pattern }}
           RUN_NUMBER: ${{ github.run_number }}
+          # the OBI image is prebuilt and loaded above; component images keep
+          # rebuilding per suite (their tags are not unique per Dockerfile)
+          PREBUILT_IMAGES: "hatest-obi,hatest-obi-b"
         run: |
           echo Partition
           echo "${MATRIX_JSON}"

--- a/.github/workflows/pull_request_integration_tests_arm.yml
+++ b/.github/workflows/pull_request_integration_tests_arm.yml
@@ -113,9 +113,39 @@ jobs:
         if: steps.base-images-cache.outputs.cache-hit != 'true'
         run: bash scripts/pull-base-images.sh /tmp/base-images.tar
 
+  build-obi-image:
+    name: "Build OBI test image"
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    needs: [generate-bpf]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+
+      - name: Download generated BPF files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bpf-generated-${{ github.run_id }}
+
+      # built once here and loaded by every shard so each shard skips the
+      # most expensive compose build
+      - name: Build and save OBI test image
+        run: |
+          docker build -t hatest-obi -f internal/test/integration/components/obi/Dockerfile .
+          docker save hatest-obi -o /tmp/hatest-obi.tar
+
+      - name: Upload OBI test image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: obi-image-arm64-${{ github.run_id }}
+          path: /tmp/hatest-obi.tar
+          retention-days: 1
+
   test:
     name: ${{ matrix.description }}
-    needs: [test-matrix, generate-bpf, prep-images]
+    needs: [test-matrix, generate-bpf, prep-images, build-obi-image]
     permissions:
       checks: write
       pull-requests: write
@@ -186,6 +216,18 @@ jobs:
             echo "::warning::base image cache miss; builds may pull from the upstream registry and risk HTTP 429"
           fi
 
+      - name: Download prebuilt OBI image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: obi-image-arm64-${{ github.run_id }}
+          path: /tmp/obi-image
+
+      # hatest-obi-b is the same plain build under a second tag
+      - name: Load prebuilt OBI image
+        run: |
+          docker load -i /tmp/obi-image/hatest-obi.tar
+          docker tag hatest-obi hatest-obi-b
+
       - name: Check disk usage before tests
         run: df -h
 
@@ -195,6 +237,9 @@ jobs:
           MATRIX_JSON: ${{ toJson(matrix) }}
           MATRIX_TEST_PATTERN: ${{ matrix.test_pattern }}
           RUN_NUMBER: ${{ github.run_number }}
+          # the OBI image is prebuilt and loaded above; component images keep
+          # rebuilding per suite (their tags are not unique per Dockerfile)
+          PREBUILT_IMAGES: "hatest-obi,hatest-obi-b"
         run: |
           echo Partition
           echo "${MATRIX_JSON}"

--- a/internal/test/integration/components/docker/compose.go
+++ b/internal/test/integration/components/docker/compose.go
@@ -96,6 +96,9 @@ func (c *Compose) servicesToBuild() ([]string, bool) {
 		return nil, false
 	}
 	prebuilt := strings.Split(prebuiltEnv, ",")
+	for i := range prebuilt {
+		prebuilt[i] = strings.TrimSpace(prebuilt[i])
+	}
 
 	data, err := os.ReadFile(c.Path)
 	if err != nil {

--- a/internal/test/integration/components/docker/compose.go
+++ b/internal/test/integration/components/docker/compose.go
@@ -13,9 +13,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 
 	"go.opentelemetry.io/obi/internal/test/tools"
 )
@@ -68,14 +71,75 @@ func (c *Compose) Up() error {
 	if os.Getenv("SKIP_DOCKER_BUILD") != "" {
 		return c.command("up", "--detach", "--quiet-pull")
 	}
+
+	if services, ok := c.servicesToBuild(); ok {
+		if len(services) > 0 {
+			if err := c.command(append([]string{"build"}, services...)...); err != nil {
+				return err
+			}
+		}
+		return c.command("up", "--detach", "--quiet-pull")
+	}
+
 	return c.command("up", "--build", "--detach", "--quiet-pull")
+}
+
+// servicesToBuild lists the services to rebuild when PREBUILT_IMAGES names
+// image tags that were docker-loaded before the run: everything with a build
+// section except the prebuilt ones. Image tags are not unique per Dockerfile
+// across compose files, so all other services must keep rebuilding per suite.
+// Returns ok=false (build everything) when the mechanism is off or the file
+// can't be parsed
+func (c *Compose) servicesToBuild() ([]string, bool) {
+	prebuiltEnv := os.Getenv("PREBUILT_IMAGES")
+	if prebuiltEnv == "" {
+		return nil, false
+	}
+	prebuilt := strings.Split(prebuiltEnv, ",")
+
+	data, err := os.ReadFile(c.Path)
+	if err != nil {
+		return nil, false
+	}
+
+	var doc struct {
+		Services map[string]struct {
+			Image string    `yaml:"image"`
+			Build yaml.Node `yaml:"build"`
+		} `yaml:"services"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, false
+	}
+
+	var services []string
+	for name, svc := range doc.Services {
+		if svc.Build.IsZero() {
+			continue
+		}
+		if svc.Image != "" && slices.Contains(prebuilt, svc.Image) {
+			continue
+		}
+		services = append(services, name)
+	}
+	slices.Sort(services)
+
+	return services, true
 }
 
 func (c *Compose) Run(service string) error {
 	c.skipWait = true
 	args := []string{"up"}
 	if os.Getenv("SKIP_DOCKER_BUILD") == "" {
-		args = append(args, "--build")
+		if services, ok := c.servicesToBuild(); ok {
+			if len(services) > 0 {
+				if err := c.command(append([]string{"build"}, services...)...); err != nil {
+					return err
+				}
+			}
+		} else {
+			args = append(args, "--build")
+		}
 	}
 	args = append(args, "--quiet-pull", "--abort-on-container-exit", "--exit-code-from", service)
 	return c.command(args...)

--- a/internal/test/integration/components/docker/compose_test.go
+++ b/internal/test/integration/components/docker/compose_test.go
@@ -31,6 +31,9 @@ services:
     image: hatest-testserver
   prepulled:
     image: postgres:16
+  stringbuild:
+    build: ../../..
+    image: hatest-stringbuild
 `
 
 func fixtureCompose(t *testing.T) *Compose {
@@ -50,12 +53,12 @@ func TestServicesToBuildDisabledWithoutEnv(t *testing.T) {
 }
 
 func TestServicesToBuildSkipsPrebuiltImages(t *testing.T) {
-	t.Setenv("PREBUILT_IMAGES", "hatest-obi,hatest-obi-b")
+	t.Setenv("PREBUILT_IMAGES", "hatest-obi, hatest-obi-b")
 	c := fixtureCompose(t)
 
 	services, ok := c.servicesToBuild()
 	require.True(t, ok)
-	assert.Equal(t, []string{"testserver"}, services,
+	assert.Equal(t, []string{"stringbuild", "testserver"}, services,
 		"services without a build section or with a prebuilt image must be skipped")
 }
 

--- a/internal/test/integration/components/docker/compose_test.go
+++ b/internal/test/integration/components/docker/compose_test.go
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const composeFixture = `
+services:
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    image: hatest-obi
+  obi-b:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    image: hatest-obi-b
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/testserver/Dockerfile
+    image: hatest-testserver
+  prepulled:
+    image: postgres:16
+`
+
+func fixtureCompose(t *testing.T) *Compose {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "compose.yml")
+	require.NoError(t, os.WriteFile(path, []byte(composeFixture), 0o600))
+
+	return &Compose{Path: path}
+}
+
+func TestServicesToBuildDisabledWithoutEnv(t *testing.T) {
+	c := fixtureCompose(t)
+
+	_, ok := c.servicesToBuild()
+	assert.False(t, ok, "must fall back to building everything")
+}
+
+func TestServicesToBuildSkipsPrebuiltImages(t *testing.T) {
+	t.Setenv("PREBUILT_IMAGES", "hatest-obi,hatest-obi-b")
+	c := fixtureCompose(t)
+
+	services, ok := c.servicesToBuild()
+	require.True(t, ok)
+	assert.Equal(t, []string{"testserver"}, services,
+		"services without a build section or with a prebuilt image must be skipped")
+}
+
+func TestServicesToBuildFallsBackOnUnreadableFile(t *testing.T) {
+	t.Setenv("PREBUILT_IMAGES", "hatest-obi")
+	c := &Compose{Path: filepath.Join(t.TempDir(), "missing.yml")}
+
+	_, ok := c.servicesToBuild()
+	assert.False(t, ok, "unparseable compose file must fall back to building everything")
+}

--- a/internal/test/integration/docker-compose-java-dist-malicious-ioctl.yml
+++ b/internal/test/integration/docker-compose-java-dist-malicious-ioctl.yml
@@ -23,7 +23,7 @@ services:
       - /sys/fs/cgroup:/sys/fs/cgroup
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-nodejsdist:/var/run/obi
-    image: hatest-obi-b
+    image: hatest-obi-javaagent
     privileged: true
     network_mode: "host"
     pid: "host"

--- a/internal/test/integration/docker-compose-java-dist.yml
+++ b/internal/test/integration/docker-compose-java-dist.yml
@@ -29,7 +29,7 @@ services:
       - /sys/fs/cgroup:/sys/fs/cgroup
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-nodejsdist:/var/run/obi
-    image: hatest-obi-b
+    image: hatest-obi-javaagent
     privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
     network_mode: "host"
     pid: "host"

--- a/internal/test/integration/docker-compose-java-kafka-400-tls.yml
+++ b/internal/test/integration/docker-compose-java-kafka-400-tls.yml
@@ -52,7 +52,7 @@ services:
       - ./system/sys/kernel/security:/sys/kernel/security
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-java:/var/run/obi
-    image: hatest-obi
+    image: hatest-obi-javaagent
     privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
     network_mode: "service:testserver"
     pid: "service:testserver"

--- a/internal/test/integration/docker-compose-java-vthreads.yml
+++ b/internal/test/integration/docker-compose-java-vthreads.yml
@@ -34,7 +34,7 @@ services:
       - /sys/fs/cgroup:/sys/fs/cgroup
       - ../../../testoutput:/coverage
       - ../../../testoutput/run-java-vthreads:/var/run/obi
-    image: hatest-obi-b
+    image: hatest-obi-javaagent
     privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
     network_mode: "host"
     pid: "host"

--- a/internal/test/integration/dockerutil_test.go
+++ b/internal/test/integration/dockerutil_test.go
@@ -16,6 +16,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -238,14 +239,22 @@ func setupContainerWeaver(t *testing.T, net dockertest.Network) {
 	t.Log("Weaver container started")
 }
 
-// buildOBIImage builds the OBI image. When SKIP_DOCKER_BUILD is set, the image
-// has been pre-built for the VM workflow prior to QEMU startup.
+// buildOBIImage builds the OBI image. When SKIP_DOCKER_BUILD is set (VM
+// workflow) or PREBUILT_IMAGES lists it (CI shards), the image was loaded
+// into the Docker daemon before the run.
 func buildOBIImage(ctx context.Context) error {
-	if os.Getenv("SKIP_DOCKER_BUILD") != "" {
+	prebuilt := slices.Contains(strings.Split(os.Getenv("PREBUILT_IMAGES"), ","), "hatest-obi")
+
+	if os.Getenv("SKIP_DOCKER_BUILD") != "" || prebuilt {
 		_, err := dockerPool.Client().ImageInspect(ctx, "hatest-obi")
 		if err == nil {
 			fmt.Println("Skipping OBI image build (pre-built image found)")
 			return nil
+		}
+		if prebuilt {
+			// the workflow loads the image before the run: reaching this
+			// means broken wiring, not a slow path to fall back onto
+			return fmt.Errorf("PREBUILT_IMAGES lists hatest-obi but the image is not loaded: %w", err)
 		}
 		fmt.Println("SKIP_DOCKER_BUILD set but hatest-obi image not found, building...")
 	}


### PR DESCRIPTION
## Summary

This PR aims to save runner time avoiding to build OBI image for every compose file

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
