### PR TITLE
Limit Kafka Produce topic fan-out

### DIFF
--- a/pkg/internal/ebpf/kafkaparser/produce.go
+++ b/pkg/internal/ebpf/kafkaparser/produce.go
@@ -19,6 +19,8 @@ type ProduceRequest struct {
 	Topics []*ProduceTopic
 }
 
+const maxProduceTopics = 100
+
 var (
 	errInvalidProduceRecordsLength = errors.New("invalid produce records length")
 	errNoTopicsInProduce           = errors.New("no Topics found in produce request")
@@ -66,6 +68,9 @@ func parseProduceTopics(r *largebuf.LargeBufferReader, header KafkaRequestHeader
 	}
 	if topicsLen <= 0 {
 		return nil, nil
+	}
+	if topicsLen > maxProduceTopics {
+		topicsLen = maxProduceTopics
 	}
 
 	var topics []*ProduceTopic

--- a/pkg/internal/ebpf/kafkaparser/produce_test.go
+++ b/pkg/internal/ebpf/kafkaparser/produce_test.go
@@ -432,6 +432,33 @@ func TestParseProduceRequestTruncatedLargeTopicCount(t *testing.T) {
 	require.ErrorIs(t, err, errNoTopicsInProduce)
 }
 
+func TestParseProduceRequestLimitsTopics(t *testing.T) {
+	const declaredTopicCount = 1_000_000
+
+	pkt := make([]byte, Int8Len+Int16Len+Int32Len+binary.MaxVarintLen32+(maxProduceTopics+1)*3)
+	offset := 0
+	pkt[offset] = 0 // null transactional ID
+	offset++
+	binary.BigEndian.PutUint16(pkt[offset:], 1)
+	offset += Int16Len
+	binary.BigEndian.PutUint32(pkt[offset:], 30000)
+	offset += Int32Len
+	offset += binary.PutUvarint(pkt[offset:], declaredTopicCount+1)
+	for range maxProduceTopics + 1 {
+		pkt[offset] = 1 // empty compact topic name
+		offset++
+		pkt[offset] = 1 // empty compact partitions array
+		offset++
+		pkt[offset] = 0 // empty tagged fields
+		offset++
+	}
+
+	r := largebuf.NewLargeBufferFrom(pkt[:offset]).NewReader()
+	req, err := ParseProduceRequest(&r, newTestHeader(APIKeyProduce, 9))
+	require.NoError(t, err)
+	require.Len(t, req.Topics, maxProduceTopics)
+}
+
 func TestProduceRequestSkipUntilTopics(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
### Motivation

- The Produce request parser previously trusted the untrusted declared topic count and appended every parsed topic, enabling attacker-controlled per-request fan-out that can exhaust memory and CPU.
- A small per-topic encoding can encode millions of topics in a single Kafka packet, so the parser must bound work and downstream allocations to preserve availability.

### Description

- Add a `const maxProduceTopics = 100` and enforce it in `pkg/internal/ebpf/kafkaparser/produce.go` by capping the parsed `topicsLen` before the parsing loop. 
- Keep existing parsing semantics for each topic; only the number of topics parsed per request is limited. 
- Add `TestParseProduceRequestLimitsTopics` in `pkg/internal/ebpf/kafkaparser/produce_test.go` to exercise an attacker-controlled large declared topic count and assert that only `maxProduceTopics` topics are returned.

### Testing

- `go test ./pkg/internal/ebpf/kafkaparser`
- `git diff --check`
- `make verify`
