### PR TITLE
Reject split span metric format conflicts

### DIFF
--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -858,6 +858,8 @@ func (c *Config) spanMetricsFeatureMasks() []*export.Features {
 // span-metrics service back on the legacy names.
 func (c *Config) resolveSpanMetricsFormats() error {
 	resolved := false
+	legacyEnabled := false
+	otelEnabled := false
 	for _, features := range c.spanMetricsFeatureMasks() {
 		if features.InvalidSpanMetricsConfig() {
 			return ConfigError("you can only enable one format of span metrics," +
@@ -866,12 +868,18 @@ func (c *Config) resolveSpanMetricsFormats() error {
 		if features.ResolveSpanMetricsConflict() {
 			resolved = true
 		}
+		if features.LegacySpanMetrics() {
+			legacyEnabled = true
+		} else if features.SpanMetrics() {
+			otelEnabled = true
+		}
 	}
 
 	// The exporters choose the metric names from the OR of all masks, so a legacy format in
 	// one list and OTel in another would silently select legacy names for every service.
-	// Each mask is already conflict-free here, so a joined conflict is always cross-mask.
-	if c.JoinMetricsConfig().Features.InvalidSpanMetricsConfig() {
+	// Track each format separately because joining an "all" mask with an explicit legacy
+	// mask reconstructs FeatureAll and makes InvalidSpanMetricsConfig exempt the conflict.
+	if legacyEnabled && otelEnabled {
 		return ConfigError("you can only enable one format of span metrics across the" +
 			" top-level and per-service metrics features, application_span or" +
 			" application_span_otel")

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -729,6 +729,38 @@ discovery:
 			"across the top-level and per-service metrics features")
 	})
 
+	t.Run("all top-level with legacy per-service is rejected", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "localhost:1234")
+		cfg, err := LoadConfig(bytes.NewBufferString(`
+metrics:
+  features: ["all"]
+discovery:
+  instrument:
+    - exe_path: foo
+      metrics:
+        features: ["application_span"]
+`))
+		require.NoError(t, err)
+		require.ErrorContains(t, cfg.Validate(),
+			"across the top-level and per-service metrics features")
+	})
+
+	t.Run("legacy top-level with all per-service is rejected", func(t *testing.T) {
+		t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "localhost:1234")
+		cfg, err := LoadConfig(bytes.NewBufferString(`
+metrics:
+  features: ["application", "application_span"]
+discovery:
+  instrument:
+    - exe_path: foo
+      metrics:
+        features: ["*"]
+`))
+		require.NoError(t, err)
+		require.ErrorContains(t, cfg.Validate(),
+			"across the top-level and per-service metrics features")
+	})
+
 	// Per-service sections feed the exporters through JoinMetricsConfig, so a feature
 	// enabled only there must still be reported.
 	t.Run("warns for a feature enabled only per-service", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Track legacy and OTel span metric formats across configuration scopes after resolving `all` and `*`
- Reject split legacy/OTel selections even when their joined mask reconstructs `FeatureAll`
- Cover both top-level and per-service orderings

Follow-up to the non-blocking review note on #2979.

## Testing

- make generate
- make verify
- make compile