### PR TITLE
Fix Go netFD read map cleanup

### DIFF
--- a/bpf/gotracer/go_net.c
+++ b/bpf/gotracer/go_net.c
@@ -149,13 +149,12 @@ int GUARDED_PROG(obi_uprobe_netFdReadRet, struct pt_regs *, ctx) {
     net_args_t *net_ptr = bpf_map_lookup_elem(&ongoing_fd_reads, &g_key);
 
     if (!net_ptr || !net_ptr->byte_ptr || net_ptr->skip) {
-        if (http_large_buffer_skip(len)) {
-            return 0;
-        } else if (net_ptr && net_ptr->byte_ptr) {
+        if (!http_large_buffer_skip(len) && net_ptr && net_ptr->byte_ptr) {
             send_http_large_buffers_if_needed(
                 &g_key, &net_ptr->p_conn.conn, (void *)net_ptr->byte_ptr, len, TCP_RECV);
         }
 
+        bpf_map_delete_elem(&ongoing_fd_reads, &g_key);
         return 0;
     }
 


### PR DESCRIPTION
### Motivation

- Prevent a resource-exhaustion bug where skipped Go `netFD` reads inserted into the fixed-size `ongoing_fd_reads` BPF hash map were not deleted by the read-return probe, allowing an attacker to fill the map and disrupt tracing. 

### Description

- In `obi_uprobe_netFdReadRet`, emit optional HTTP large-buffer data as before but then delete the `ongoing_fd_reads` entry for the goroutine so skipped reads do not leak. 
- Adjusted the large-buffer emission condition to only call `send_http_large_buffers_if_needed` when `http_large_buffer_skip(len)` is false and a valid `net_ptr->byte_ptr` exists. 
- This preserves large-buffer capture behavior while ensuring the pinned `BPF_MAP_TYPE_HASH` does not accumulate stale skip entries. 

### Testing

- `make generate`
- `make clang-format`
- `git diff --check`
- `make clang-tidy`