### PR TITLE
Fix log enricher buffer suppression order

### DIFF
--- a/bpf/logenricher/logenricher.c
+++ b/bpf/logenricher/logenricher.c
@@ -47,10 +47,7 @@ static __always_inline bool pid_tracked(const struct task_struct *task) {
     return tracked != NULL;
 }
 
-static __always_inline u32 consume_ubuf(log_event_t *e,
-                                        struct iov_iter *from,
-                                        void *ubuf,
-                                        const char *fill) {
+static __always_inline u32 copy_ubuf(log_event_t *e, struct iov_iter *from, void *ubuf) {
     const size_t count = BPF_CORE_READ(from, count);
     u32 to_copy = (u32)count;
 
@@ -60,19 +57,22 @@ static __always_inline u32 consume_ubuf(log_event_t *e,
     }
 
     bpf_probe_read_user(e->log, to_copy, ubuf);
-    bpf_clamp_umin(to_copy, 1);
-    bpf_probe_write_user(ubuf, fill, to_copy);
-    bpf_probe_write_user((char *)ubuf + to_copy - 1, &k_newline, 1);
-
     return to_copy;
 }
 
-static __always_inline u32 consume_iovec(log_event_t *e,
-                                         const struct iovec *iov,
-                                         unsigned long nr_segs,
-                                         const char *fill) {
+static __always_inline void suppress_ubuf(void *ubuf, const char *fill, u32 len) {
+    if (len == 0) {
+        return;
+    }
+
+    bpf_probe_write_user(ubuf, fill, len);
+    bpf_probe_write_user((char *)ubuf + len - 1, &k_newline, 1);
+}
+
+static __always_inline u32 copy_iovec(log_event_t *e,
+                                      const struct iovec *iov,
+                                      unsigned long nr_segs) {
     u32 tot = 0;
-    void *last_end = NULL;
 
     bpf_clamp_umax(nr_segs, k_iov_max_segs);
 
@@ -93,7 +93,38 @@ static __always_inline u32 consume_iovec(log_event_t *e,
         }
 
         bpf_probe_read_user(&e->log[tot], to_copy, vec.iov_base);
-        bpf_clamp_umin(to_copy, 1);
+        tot += to_copy;
+    }
+
+    return tot;
+}
+
+static __always_inline void
+suppress_iovec(const struct iovec *iov, unsigned long nr_segs, const char *fill) {
+    u32 tot = 0;
+    void *last_end = NULL;
+
+    bpf_clamp_umax(nr_segs, k_iov_max_segs);
+
+    for (unsigned long i = 0; i < k_iov_max_segs && i < nr_segs; i++) {
+        struct iovec vec;
+        if (bpf_probe_read_kernel(&vec, sizeof(vec), &iov[i]) != 0) {
+            break;
+        }
+        if (!vec.iov_base || !vec.iov_len) {
+            continue;
+        }
+
+        u32 to_copy = (u32)vec.iov_len;
+        if (to_copy == 0) {
+            continue;
+        }
+        bpf_clamp_umax(to_copy, k_iov_seg_max_len);
+        bpf_clamp_umax(tot, k_log_event_max_log_len);
+        if (tot + to_copy > k_log_event_max_log_len) {
+            break;
+        }
+
         bpf_probe_write_user(vec.iov_base, fill, to_copy);
         last_end = (char *)vec.iov_base + to_copy - 1;
         tot += to_copy;
@@ -102,7 +133,6 @@ static __always_inline u32 consume_iovec(log_event_t *e,
     if (last_end) {
         bpf_probe_write_user(last_end, &k_newline, 1);
     }
-    return tot;
 }
 
 static __always_inline int
@@ -131,9 +161,9 @@ __write(struct kiocb *iocb, struct iov_iter *from, const int fd, const struct ta
 
     if (bpf_core_enum_value_exists(enum iter_type___dummy, ITER_UBUF) &&
         ictx.iter_type == bpf_core_enum_value(enum iter_type___dummy, ITER_UBUF) && ictx.ubuf) {
-        tot = consume_ubuf(e, from, ictx.ubuf, fill);
+        tot = copy_ubuf(e, from, ictx.ubuf);
     } else if (ictx.iter_type == bpf_core_enum_value(enum iter_type, ITER_IOVEC) && ictx.iov) {
-        tot = consume_iovec(e, ictx.iov, ictx.nr_segs, fill);
+        tot = copy_iovec(e, ictx.iov, ictx.nr_segs);
     } else {
         bpf_dbg_printk("logenricher: unsupported iter_type %d", ictx.iter_type);
         return 0;
@@ -162,6 +192,14 @@ __write(struct kiocb *iocb, struct iov_iter *from, const int fd, const struct ta
     const long err = bpf_ringbuf_output(&log_events, e, out_size, log_events_flags());
     if (err < 0) {
         bpf_dbg_printk("logenricher: failed to write log event to ringbuf: %d", err);
+        return 0;
+    }
+
+    if (bpf_core_enum_value_exists(enum iter_type___dummy, ITER_UBUF) &&
+        ictx.iter_type == bpf_core_enum_value(enum iter_type___dummy, ITER_UBUF) && ictx.ubuf) {
+        suppress_ubuf(ictx.ubuf, fill, tot);
+    } else if (ictx.iter_type == bpf_core_enum_value(enum iter_type, ITER_IOVEC) && ictx.iov) {
+        suppress_iovec(ictx.iov, ictx.nr_segs, fill);
     }
 
     return 0;

--- a/bpf/logenricher/logenricher.c
+++ b/bpf/logenricher/logenricher.c
@@ -65,6 +65,8 @@ static __always_inline void suppress_ubuf(void *ubuf, const char *fill, u32 len)
         return;
     }
 
+    bpf_clamp_umax(len, k_log_event_max_log_len);
+    bpf_clamp_umin(len, 1);
     bpf_probe_write_user(ubuf, fill, len);
     bpf_probe_write_user((char *)ubuf + len - 1, &k_newline, 1);
 }
@@ -120,6 +122,7 @@ suppress_iovec(const struct iovec *iov, unsigned long nr_segs, const char *fill)
             continue;
         }
         bpf_clamp_umax(to_copy, k_iov_seg_max_len);
+        bpf_clamp_umin(to_copy, 1);
         bpf_clamp_umax(tot, k_log_event_max_log_len);
         if (tot + to_copy > k_log_event_max_log_len) {
             break;


### PR DESCRIPTION
### Motivation

- The BPF log enricher previously overwrote application write buffers before confirming the enriched event was accepted by the ring buffer, which could silently drop application logs on `bpf_ringbuf_output` failure.
- The change restores a fail-open fallback by only mutating user memory after the ring-buffer enqueue succeeds.

### Description

- Split read vs suppression logic by introducing `copy_ubuf`/`copy_iovec` to copy user bytes into the event payload without touching user memory, and `suppress_ubuf`/`suppress_iovec` to perform `bpf_probe_write_user` only when appropriate.
- Update `__write` to call the copy helpers, call `bpf_ringbuf_output`, return immediately on error, and only call the suppress helpers after a successful ring-buffer submission.
- Preserve existing limits and safety checks (`bpf_clamp_umax`, segment/length caps, newline termination) and keep original enrichment payload layout and sizing logic.

### Testing

- `clang-format -i bpf/logenricher/logenricher.c`
- `cd bpf && clang-tidy logenricher/logenricher.c`
- `make generate`
- `make compile`
- `go test ./pkg/internal/ebpf/logenricher`
- `go test -tags=bpf_verifier_tests -run 'TestBPFVerifierWithConstants/logenricher' ./pkg/internal/ebpf/verifier`