### PR TITLE
Limit Java TLS buffer allocation to payload size

### DIFF
--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractor.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractor.java
@@ -58,7 +58,23 @@ public class ByteBufferExtractor {
   // This deals with buffers that are about to be read, they are freshly made for
   // the Java program to consume. We want to read from their pos to the limit.
   public static ByteBuffer flattenFreshByteBufferArray(ByteBuffer[] srcs) {
-    ByteBuffer dstBuffer = ByteBuffer.allocate(MAX_SIZE);
+    int bufSize = 0;
+    if (srcs != null) {
+      for (ByteBuffer src : srcs) {
+        if (src == null) {
+          continue;
+        }
+
+        int remaining = b(src).remaining();
+        if (remaining >= MAX_SIZE - bufSize) {
+          bufSize = MAX_SIZE;
+          break;
+        }
+        bufSize += remaining;
+      }
+    }
+
+    ByteBuffer dstBuffer = ByteBuffer.allocate(bufSize);
     if (srcs == null) {
       return dstBuffer;
     }

--- a/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractorTest.java
+++ b/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/instrumentations/util/ByteBufferExtractorTest.java
@@ -221,7 +221,7 @@ class ByteBufferExtractorTest {
   void testFlattenFreshByteBufferArray_NullInput() {
     ByteBuffer result = ByteBufferExtractor.flattenFreshByteBufferArray(null);
     assertEquals(0, result.position());
-    assertEquals(ByteBufferExtractor.MAX_SIZE, result.capacity());
+    assertEquals(0, result.capacity());
   }
 
   @Test
@@ -229,7 +229,7 @@ class ByteBufferExtractorTest {
     ByteBuffer[] srcs = new ByteBuffer[0];
     ByteBuffer result = ByteBufferExtractor.flattenFreshByteBufferArray(srcs);
     assertEquals(0, result.position());
-    assertEquals(ByteBufferExtractor.MAX_SIZE, result.capacity());
+    assertEquals(0, result.capacity());
   }
 
   @Test
@@ -242,6 +242,7 @@ class ByteBufferExtractorTest {
     ByteBuffer result = ByteBufferExtractor.flattenFreshByteBufferArray(srcs);
     assertEquals(5, buf.limit());
     assertEquals(1, buf.position());
+    assertEquals(4, result.capacity());
 
     result.flip();
     byte[] out = new byte[result.limit()];
@@ -284,6 +285,7 @@ class ByteBufferExtractorTest {
     assertEquals(3, buf1.limit());
     assertEquals(1, buf2.position());
     assertEquals(3, buf2.limit());
+    assertEquals(5, result.capacity());
 
     result.flip();
     byte[] out = new byte[5];
@@ -456,7 +458,7 @@ class ByteBufferExtractorTest {
 
     ByteBuffer result = ByteBufferExtractor.flattenFreshByteBufferArray(srcs);
     assertEquals(0, result.position());
-    assertEquals(ByteBufferExtractor.MAX_SIZE, result.capacity());
+    assertEquals(0, result.capacity());
   }
 
   @Test


### PR DESCRIPTION
### Motivation

- The Java TLS extraction path previously always allocated a `MAX_SIZE` (16 KiB) backing array for flattened fresh `ByteBuffer[]` inputs, which increased worst-case retained plaintext when buffers were stored in `SSLStorage` and introduced a memory exhaustion risk. 
- The goal is to avoid allocating large arrays when the actual payload is much smaller while preserving the existing `MAX_SIZE` cap for legitimately large payloads.

### Description

- Compute the required `bufSize` by summing the `remaining()` bytes from the source buffers up to `MAX_SIZE` and allocate the destination `ByteBuffer` to that size instead of always allocating `MAX_SIZE` in `flattenFreshByteBufferArray`. 
- Keep the existing `MAX_SIZE` cap so large payloads still truncate to the current maximum. 
- Update unit tests in `ByteBufferExtractorTest` to assert zero-capacity for null/empty/all-null fresh-array cases and to assert capacity equals the actual copied payload size for small inputs. 

### Testing

- `make java-spotless-apply`
- `cd pkg/internal/java && gradle :agent:test --tests io.opentelemetry.obi.java.instrumentations.util.ByteBufferExtractorTest -PnativeOnly=true`
- `make java-test`