### PR TITLE
Release v0.12.2

### DIFF
--- a/internal/test/oats/ai/go.mod
+++ b/internal/test/oats/ai/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.1 // indirect
+	go.opentelemetry.io/obi v0.12.2 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/amqp/go.mod
+++ b/internal/test/oats/amqp/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.1 // indirect
+	go.opentelemetry.io/obi v0.12.2 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/harness/go.mod
+++ b/internal/test/oats/harness/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/grafana/oats v0.7.0
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.41.0
-	go.opentelemetry.io/obi v0.12.1
+	go.opentelemetry.io/obi v0.12.2
 )
 
 // The oats harness reuses the shared weaver-validation logic

--- a/internal/test/oats/http/go.mod
+++ b/internal/test/oats/http/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.1 // indirect
+	go.opentelemetry.io/obi v0.12.2 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/kafka/go.mod
+++ b/internal/test/oats/kafka/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.1 // indirect
+	go.opentelemetry.io/obi v0.12.2 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/memcached/go.mod
+++ b/internal/test/oats/memcached/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.1 // indirect
+	go.opentelemetry.io/obi v0.12.2 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/mongo/go.mod
+++ b/internal/test/oats/mongo/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.1 // indirect
+	go.opentelemetry.io/obi v0.12.2 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/nats/go.mod
+++ b/internal/test/oats/nats/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.1 // indirect
+	go.opentelemetry.io/obi v0.12.2 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/redis/go.mod
+++ b/internal/test/oats/redis/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.1 // indirect
+	go.opentelemetry.io/obi v0.12.2 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/internal/test/oats/sql/go.mod
+++ b/internal/test/oats/sql/go.mod
@@ -30,7 +30,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.1 // indirect
+	go.opentelemetry.io/obi v0.12.2 // indirect
 	go.opentelemetry.io/otel v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.45.0 // indirect

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   obi:
-    version: v0.12.1
+    version: v0.12.2
     modules:
       - go.opentelemetry.io/obi
 excluded-modules:


### PR DESCRIPTION
v0.12.2 is an expedited patch release following v0.12.1 that fixes a log-enricher defect capable of deadlocking instrumented shell workloads. It also includes protocol reliability fixes merged since the previous release.

### Critical reliability fixes

- The log enricher now only consumes pipes registered as a tracked process's stdout or stderr, keyed by inode and device. Previously it intercepted every pipe write of a tracked process: shell command substitutions (`$(...)`) came back empty in any enriched namespace, and since v0.12.0 the capture-time warm-open could hold a substitution pipe's write end for up to 30 minutes, deadlocking the shell and then feeding it the enricher's own output. Non-log pipes are no longer zeroed, captured, or held; enriched lines are delivered through a live owner's descriptor with per-event references, so short-lived writers' final lines still land without holding pipes open. ([#3107](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3107))
- Serialized descriptor-cache publication with pipe retirement, closing a race where a destination opened concurrently with its owner's teardown could leave an unretirable cached write end held until cache expiry. ([#3130](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3130))

### Protocol fixes

- Correlated TLS connections that OpenSSL manages through memory BIOs by matching ciphertext prefixes, restoring traces for applications that do their own socket I/O. ([#3023](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3023))
- Decoded HTTP/2 headers in capture order, preventing HPACK dynamic-table drift from misattributing header values. ([#3039](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3039))
- Reassembled Aerospike responses split across TCP reads in kernel, fixing missed or truncated Aerospike spans. ([#3082](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3082))

### Behavior changes and compatibility notes

- The `application_span` and `application_span_sizes` features (Grafana-convention `traces_spanmetrics_*` names) are deprecated in favor of `application_span_otel`. Nothing is removed and no metric stops being emitted; existing configurations keep working and log a deprecation warning. ([#2979](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2979))
- Log enrichment no longer touches pipes that are not a tracked process's stdout/stderr: application data on other pipes now passes through untouched and un-enriched, including pipelines where a process writes logs to a pipe on a non-stdio descriptor. ([#3107](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3107))

**Full Changelog**: [v0.12.1...v0.12.2](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/compare/v0.12.1...v0.12.2)