### PR TITLE
logenricher: serialize cache publication with retirement

### DIFF
--- a/pkg/internal/ebpf/logenricher/logenricher.go
+++ b/pkg/internal/ebpf/logenricher/logenricher.go
@@ -505,18 +505,19 @@ func (p *Tracer) pipeRegistered(key pipeKey) bool {
 
 // identity to pin the tty fallback destination with; rejects an unregistered
 // pipe (app IPC)
-func (p *Tracer) fallbackDest(path string) (pipeKey, bool) {
+func (p *Tracer) fallbackDest(path string) (pipeKey, bool, bool) {
 	var st unix.Stat_t
 	if err := unix.Stat(path, &st); err != nil {
-		return pipeKey{}, false
+		return pipeKey{}, false, false
 	}
 
 	key := pipeKey{Ino: st.Ino, Dev: kernelDev(st.Dev)}
-	if st.Mode&unix.S_IFMT == unix.S_IFIFO && !p.pipeRegistered(key) {
-		return pipeKey{}, false
+	isPipe := st.Mode&unix.S_IFMT == unix.S_IFIFO
+	if isPipe && !p.pipeRegistered(key) {
+		return pipeKey{}, false, false
 	}
 
-	return key, true
+	return key, isPipe, true
 }
 
 func (p *Tracer) BlockPID(pid app.PID, ns uint32) {
@@ -612,7 +613,7 @@ func (p *Tracer) handleLogEvent(record *ringbuf.Record) (request.Span, bool, err
 		key := pipeKey{Ino: event.Ino, Dev: uint64(event.Dev)}
 		// address the pipe through a live owner, the writer may already be gone
 		for _, candidate := range p.pipeDestCandidates(key) {
-			if d, err := p.openLogDestination(candidate, key); err == nil {
+			if d, err := p.openPipeDestination(candidate, key); err == nil {
 				e.dest = candidate
 				e.out = d
 				break
@@ -624,15 +625,23 @@ func (p *Tracer) handleLogEvent(record *ringbuf.Record) (request.Span, bool, err
 		}
 	} else {
 		e.dest = e.ttyPath()
-		var pin pipeKey
+		var (
+			pin      pipeKey
+			pipeDest bool
+		)
 		if unix.ByteSliceToString(event.FilePath[:]) == "" {
 			var ok bool
-			if pin, ok = p.fallbackDest(e.dest); !ok {
+			if pin, pipeDest, ok = p.fallbackDest(e.dest); !ok {
 				p.log.Debug("unsafe tty fallback destination, dropping line", "path", e.dest)
 				return request.Span{}, true, nil
 			}
 		}
-		d, err := p.openLogDestination(e.dest, pin)
+		var d *destFile
+		if pipeDest {
+			d, err = p.openPipeDestination(e.dest, pin)
+		} else {
+			d, err = p.openLogDestination(e.dest, pin)
+		}
 		if err != nil {
 			p.logOpenError(e.dest, err)
 			return request.Span{}, true, nil
@@ -685,11 +694,42 @@ func openDestFile(path string) (*os.File, error) {
 	return f, nil
 }
 
+// callers must hold pipesMU
+func (p *Tracer) pipeDestinationRegisteredLocked(path string, key pipeKey) bool {
+	owners := p.logPipes[key]
+	for pid, fds := range owners {
+		for _, fd := range fds {
+			if procFdPath(pid, fd) == path {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (p *Tracer) cacheDestination(path string, d *destFile) {
+	d.refs.Add(1)
+	// Add on a lingering expired entry replaces it without the evict
+	// callback, which would leak its cache reference; Remove fires it
+	p.fdCache.Remove(path)
+	p.fdCache.Add(path, d)
+}
+
+func (p *Tracer) cachePipeDestination(path string, key pipeKey, d *destFile) {
+	p.pipesMU.RLock()
+	defer p.pipesMU.RUnlock()
+
+	if p.pipeDestinationRegisteredLocked(path, key) {
+		p.cacheDestination(path, d)
+	}
+}
+
 // a non-zero pin fixes the destination identity: /proc fd paths re-point when
 // the owner redirects its stdio, and writing there would leak lines into the
 // wrong file. The returned reference is owned by the caller and must be
 // released once the write completes
-func (p *Tracer) openLogDestination(path string, pin pipeKey) (*destFile, error) {
+func (p *Tracer) openDestination(path string, pin pipeKey, pipeDest bool) (*destFile, error) {
 	if d, ok := p.fdCache.Get(path); ok {
 		if (pin == (pipeKey{}) || fileKey(d.f) == pin) && d.tryAcquire() {
 			return d, nil
@@ -707,13 +747,25 @@ func (p *Tracer) openLogDestination(path string, pin pipeKey) (*destFile, error)
 	}
 
 	d := &destFile{f: f}
-	d.refs.Store(2) // one reference for the cache, one for the caller
-	// Add on a lingering expired entry replaces it without the evict
-	// callback, which would leak its cache reference; Remove fires it
-	p.fdCache.Remove(path)
-	p.fdCache.Add(path, d)
+	d.refs.Store(1) // caller reference
+	if pipeDest {
+		// Serialize publication with pipe retirement. If the owner retired while
+		// the destination was opening, the event reference still delivers the
+		// captured line without resurrecting a stale cache writer.
+		p.cachePipeDestination(path, pin, d)
+	} else {
+		p.cacheDestination(path, d)
+	}
 
 	return d, nil
+}
+
+func (p *Tracer) openLogDestination(path string, pin pipeKey) (*destFile, error) {
+	return p.openDestination(path, pin, false)
+}
+
+func (p *Tracer) openPipeDestination(path string, pin pipeKey) (*destFile, error) {
+	return p.openDestination(path, pin, true)
 }
 
 // a gone, re-pointed, or reader-less destination means its process died or

--- a/pkg/internal/ebpf/logenricher/logpipes_test.go
+++ b/pkg/internal/ebpf/logenricher/logpipes_test.go
@@ -304,7 +304,7 @@ func TestReconcileReleasesCachedHandle(t *testing.T) {
 	// warm the cache like event capture does and complete the write, then
 	// drop our own write end so the cached handle is the only writer left
 	// besides the child
-	warmed, err := tr.openLogDestination(procFdPath(pid, 1), oldKey)
+	warmed, err := tr.openPipeDestination(procFdPath(pid, 1), oldKey)
 	require.NoError(t, err)
 	warmed.release()
 	require.NoError(t, oldW.Close())
@@ -352,7 +352,7 @@ func TestReconcileKeepsUnchangedRegistration(t *testing.T) {
 	trackAndRegister(tr, pid)
 
 	key := fdKey(t, outW)
-	d, err := tr.openLogDestination(procFdPath(pid, 1), key)
+	d, err := tr.openPipeDestination(procFdPath(pid, 1), key)
 	require.NoError(t, err)
 	defer d.release()
 
@@ -407,8 +407,9 @@ func TestFallbackPinRejectsRepointedFd(t *testing.T) {
 	pid := uint32(cmd.Process.Pid)
 	path := procFdPath(pid, 1)
 
-	pin, ok := tr.fallbackDest(path)
+	pin, pipeDest, ok := tr.fallbackDest(path)
 	require.True(t, ok, "regular file fallback must be accepted")
+	assert.False(t, pipeDest)
 	require.Equal(t, fdKey(t, fileA), pin)
 
 	warmed, err := tr.openLogDestination(path, pin)
@@ -438,13 +439,14 @@ func TestFallbackDestPipeRegistration(t *testing.T) {
 	pid := uint32(cmd.Process.Pid)
 	path := procFdPath(pid, 1)
 
-	_, ok := tr.fallbackDest(path)
+	_, _, ok := tr.fallbackDest(path)
 	assert.False(t, ok, "unregistered pipe fallback must be rejected")
 
 	trackAndRegister(tr, pid)
 
-	pin, ok := tr.fallbackDest(path)
+	pin, pipeDest, ok := tr.fallbackDest(path)
 	assert.True(t, ok, "registered pipe fallback must be accepted")
+	assert.True(t, pipeDest)
 	assert.Equal(t, fdKey(t, outW), pin)
 }
 
@@ -523,7 +525,7 @@ func TestQueuedLineSurvivesSoleOwnerExit(t *testing.T) {
 	// capture-time warm open through the sole owner, like handleLogEvent does
 	e := LogEvent{dest: procFdPath(pid, 1), logLine: "queued line\n"}
 	e.orig.Fd = 1
-	e.out, err = tr.openLogDestination(e.dest, key)
+	e.out, err = tr.openPipeDestination(e.dest, key)
 	require.NoError(t, err)
 
 	// the sole owner exits and BlockPID retires it before the async writer
@@ -549,6 +551,53 @@ func TestQueuedLineSurvivesSoleOwnerExit(t *testing.T) {
 		assert.Equal(t, "queued line\n", string(got), "final line must land and be followed by EOF")
 	case <-time.After(5 * time.Second):
 		t.Fatal("line dropped or EOF withheld after sole-owner teardown")
+	}
+}
+
+func TestRetiredPipeDestinationIsNotCached(t *testing.T) {
+	tr := newTestTracer(t, false)
+	tr.logPipes = map[pipeKey]map[uint32][]int{}
+	tr.fdCache = expirable.NewLRU[string, *destFile](1, func(_ string, d *destFile) {
+		d.release()
+	}, time.Minute)
+	t.Cleanup(tr.fdCache.Purge)
+
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	defer outR.Close()
+
+	pid := uint32(os.Getpid())
+	fd := int(outW.Fd())
+	path := procFdPath(pid, fd)
+	key := fdKey(t, outW)
+	tr.logPipes[key] = map[uint32][]int{pid: {fd}}
+
+	f, err := openDestFile(path)
+	require.NoError(t, err)
+	d := &destFile{f: f}
+	d.refs.Store(1) // event reference
+
+	tr.pipesMU.Lock()
+	delete(tr.logPipes, key)
+	tr.pipesMU.Unlock()
+	require.NoError(t, outW.Close())
+
+	// Simulate publication finishing after teardown removed the cache path.
+	tr.cachePipeDestination(path, key, d)
+	_, cached := tr.fdCache.Get(path)
+	assert.False(t, cached, "retired destination must not regain a cache reference")
+	d.release()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.ReadAll(outR)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("reader did not see EOF: retired destination was cached after teardown")
 	}
 }
 


### PR DESCRIPTION
## Summary

- serialize registered pipe cache publication with pipe retirement
- retain event ownership without restoring a cache reference after teardown
- add unprivileged regression coverage for post-retirement publication and EOF

## Context

#3107 made queued events own their destination descriptors until the write completes. A cache miss could still race with owner retirement: teardown could remove an absent cache key immediately before the capture path published its newly opened descriptor. The event reference would be released after the write, but the late cache reference would keep the pipe writer open until eviction or the 30-minute TTL.

This change publishes registered pipe destinations while holding the same lifecycle lock used by retirement. If the destination was retired while it was opening, the event reference remains valid for the captured write, but no cache reference is created.

## Validation

- `make generate`
- `go test -race ./pkg/internal/ebpf/logenricher`
- `go test -race -run TestRetiredPipeDestinationIsNotCached -count=20 -v ./pkg/internal/ebpf/logenricher`