### PR TITLE
release: add draft release verification script

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -133,66 +133,23 @@ When you push a tag matching the pattern `vX.Y.Z` (e.g., `v1.2.3`) or `vX.Y.Z-su
 
 Once the workflow completes successfully, a draft release is automatically created with auto-generated release notes from GitHub, which includes a list of changes since the previous release.
 
-1. Navigate to the [GitHub Releases page](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases)
-2. Locate the draft release for your version
-3. Review the artifacts:
-   - Download and verify checksums for the release artifacts you fetched: `sha256sum -c --ignore-missing SHA256SUMS`
-   - Confirm checksum verification reports `OK` for every downloaded asset that was checked before publication
-   - Verify the Cosign signatures for every release archive, SBOM, and the checksum file. Replace `vX.Y.Z` with the release tag:
+1. Locate the draft release on the [GitHub Releases page](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/releases)
+2. Verify the artifacts, signatures, and container images (requires `gh` and `cosign`); the script must end with `ALL CHECKS PASSED`:
 
-     ```console
-     set -e
+   ```console
+   ./scripts/verify-draft-release.sh vX.Y.Z
+   ```
 
-     release_tag=vX.Y.Z
-     repository=open-telemetry/opentelemetry-ebpf-instrumentation
-     certificate_identity="https://github.com/${repository}/.github/workflows/release.yml"
-     certificate_identity="${certificate_identity}@refs/tags/${release_tag}"
-     release_dir="$(mktemp -d)"
-
-     gh release download "${release_tag}" \
-       --repo "${repository}" \
-       --dir "${release_dir}" \
-       --pattern '*.tar.gz' \
-       --pattern '*.cyclonedx.json' \
-       --pattern SHA256SUMS \
-       --pattern '*.bundle.json'
-
-     for artifact in \
-       "${release_dir}"/*.tar.gz \
-       "${release_dir}"/*.cyclonedx.json \
-       "${release_dir}"/SHA256SUMS; do
-       cosign verify-blob "${artifact}" \
-         --bundle "${artifact}.bundle.json" \
-         --certificate-identity "${certificate_identity}" \
-         --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
-     done
-
-     rm -rf "${release_dir}"
-     ```
-
-     Every `cosign verify-blob` command must report `Verified OK`.
-   - Extract archives and test binaries if needed
-   - Open the published CycloneDX SBOMs with your preferred SBOM tooling if you want to inspect release dependencies
-   - Use the dedicated Java agent SBOM when you need the full Java dependency graph for the JAR embedded inside `obi`
-   - Verify signed container images from both registries before publication:
-     `cosign verify --certificate-identity 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/.github/workflows/publish_dockerhub_main.yml@refs/tags/<tag>' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' otel/ebpf-instrument:<tag>`
-   - Verify the matching GHCR image as well:
-     `cosign verify --certificate-identity 'https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/.github/workflows/publish_dockerhub_main.yml@refs/tags/<tag>' --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:<tag>`
-   - Review auto-generated release notes for accuracy
-   - When the supported configuration contract changes, link the
-     [Config v1 to v2 migration guide](devdocs/config/version-2.0/migration.md)
-     and state:
-     - the first release that can load the new version in standalone and
-       Collector receiver modes;
-     - whether the previous configuration version remains supported;
-     - any migration limitations that affect compatibility.
-   - Link those release notes back from the
-     [Config v2 release gate](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2251)
-     and the
-     [stable v1.0 release epic](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1133)
-     before publishing the release.
-4. Edit release notes if necessary to add context, highlight important changes, or improve clarity
-5. Once satisfied with artifacts and release notes, click "Publish release" to make it immutable and publicly available
+3. Review and edit the auto-generated release notes for accuracy and clarity.
+   When the supported configuration contract changes, link the
+   [Config v1 to v2 migration guide](devdocs/config/version-2.0/migration.md),
+   state the first release that can load the new version in standalone and
+   Collector receiver modes, whether the previous configuration version remains
+   supported, and any migration limitations; link the notes back from the
+   [Config v2 release gate](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/2251)
+   and the
+   [stable v1.0 release epic](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/1133).
+4. Click "Publish release" to make it immutable and publicly available
 
 > [!IMPORTANT]
 > Once published, GitHub releases are immutable. Artifacts and checksums cannot be modified or replaced. Review carefully before publishing.

--- a/scripts/verify-draft-release.sh
+++ b/scripts/verify-draft-release.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Verifies a (draft) release's artifacts as described in RELEASING.md:
+# checksums, Cosign signatures for every archive/SBOM/checksum file, archive
+# contents, and the container image signatures on Docker Hub and GHCR.
+set -o errexit
+set -o nounset
+set -o pipefail
+IFS=$'\n\t'
+
+PROGNAME="$(basename "$0")"
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    green=$'\033[32m'
+    red=$'\033[31m'
+    reset=$'\033[0m'
+else
+    green=""
+    red=""
+    reset=""
+fi
+
+step() {
+    echo
+    echo "=== $* ==="
+}
+
+ok() { echo "${green}$*${reset}"; }
+err() { echo "${red}$*${reset}" >&2; }
+
+# highlight per-line verification verdicts from external tools
+colorize_status() {
+    sed -e "s/Verified OK/${green}Verified OK${reset}/" \
+        -e "s/OK\$/${green}OK${reset}/" \
+        -e "s/FAILED/${red}FAILED${reset}/"
+}
+
+usage() {
+    echo "usage: ${PROGNAME} <tag>" >&2
+    echo "  e.g. ${PROGNAME} v0.12.2" >&2
+    exit 2
+}
+
+[ $# -eq 1 ] || usage
+release_tag="$1"
+case "${release_tag}" in
+v[0-9]*.[0-9]*.[0-9]*) ;;
+*)
+    err "FATAL: tag must look like vX.Y.Z or vX.Y.Z-suffix, got '${release_tag}'"
+    exit 2
+    ;;
+esac
+
+repository=open-telemetry/opentelemetry-ebpf-instrumentation
+release_identity="https://github.com/${repository}/.github/workflows/release.yml@refs/tags/${release_tag}"
+image_identity="https://github.com/${repository}/.github/workflows/publish_dockerhub_main.yml@refs/tags/${release_tag}"
+oidc_issuer='https://token.actions.githubusercontent.com'
+
+for tool in gh cosign tar; do
+    command -v "${tool}" >/dev/null || {
+        err "FATAL: missing required tool: ${tool}"
+        exit 1
+    }
+done
+
+# GNU coreutils (Linux) ships sha256sum; macOS and the BSDs ship shasum
+if command -v sha256sum >/dev/null; then
+    sha_check() { sha256sum -c --ignore-missing SHA256SUMS; }
+elif command -v shasum >/dev/null; then
+    sha_check() { shasum -a 256 -c --ignore-missing SHA256SUMS; }
+else
+    err "FATAL: neither sha256sum nor shasum is available"
+    exit 1
+fi
+
+release_dir="$(mktemp -d)"
+
+# keep the artifacts for inspection when verification fails, clean up on success
+keep_artifacts=1
+cleanup() {
+    if [ "${keep_artifacts}" -eq 1 ]; then
+        echo
+        echo "artifacts left in ${release_dir} for inspection (remove when done)"
+    else
+        rm -rf "${release_dir}"
+    fi
+}
+trap cleanup EXIT
+
+step "1/5 download release assets for ${release_tag}"
+gh release download "${release_tag}" \
+    --repo "${repository}" \
+    --dir "${release_dir}" \
+    --pattern '*.tar.gz' \
+    --pattern '*.cyclonedx.json' \
+    --pattern SHA256SUMS \
+    --pattern '*.bundle.json'
+ls -1 "${release_dir}"
+
+# every expected asset must exist: globs and --ignore-missing silently skip
+# absent files, so a partially-populated release would otherwise pass
+expected_assets="obi-${release_tag}-linux-amd64.tar.gz
+obi-${release_tag}-linux-arm64.tar.gz
+obi-${release_tag}-source-generated.tar.gz
+obi-${release_tag}-linux-amd64.cyclonedx.json
+obi-${release_tag}-linux-arm64.cyclonedx.json
+obi-${release_tag}-source-generated.cyclonedx.json
+obi-java-agent-${release_tag}.cyclonedx.json
+SHA256SUMS"
+missing=0
+for asset in ${expected_assets}; do
+    [ -s "${release_dir}/${asset}" ] || {
+        err "MISSING asset: ${asset}"
+        missing=1
+    }
+    [ -s "${release_dir}/${asset}.bundle.json" ] || {
+        err "MISSING signature bundle: ${asset}.bundle.json"
+        missing=1
+    }
+done
+[ "${missing}" -eq 0 ] || {
+    err "FATAL: release is missing assets"
+    exit 1
+}
+ok "all $(echo "${expected_assets}" | wc -l | tr -d ' ') expected assets present, each with a signature bundle"
+
+step "2/5 checksums (every line must report OK)"
+(
+    cd "${release_dir}"
+    sha_check
+) | colorize_status
+
+step "3/5 Cosign signatures (every artifact must report Verified OK)"
+for artifact in "${release_dir}"/*.tar.gz "${release_dir}"/*.cyclonedx.json "${release_dir}"/SHA256SUMS; do
+    echo "--- $(basename "${artifact}")"
+    cosign verify-blob "${artifact}" \
+        --bundle "${artifact}.bundle.json" \
+        --certificate-identity "${release_identity}" \
+        --certificate-oidc-issuer "${oidc_issuer}" 2>&1 | colorize_status
+done
+
+step "4/5 archive contents"
+for arch in amd64 arm64; do
+    archive="${release_dir}/obi-${release_tag}-linux-${arch}.tar.gz"
+    echo "--- $(basename "${archive}")"
+    listing="$(tar -tzf "${archive}")"
+    for entry in '^obi$' '^LICENSE$' '^NOTICE$' '^NOTICES/'; do
+        echo "${listing}" | grep -q "${entry}" || {
+            err "FATAL: archive is missing an entry matching ${entry}"
+            exit 1
+        }
+    done
+    ok "contains obi, LICENSE, NOTICE, and $(echo "${listing}" | grep -c '^NOTICES/') NOTICES/ entries"
+    extract_dir="${release_dir}/extract-${arch}"
+    mkdir -p "${extract_dir}"
+    tar -xzf "${archive}" -C "${extract_dir}"
+    [ -s "${extract_dir}/obi" ] || {
+        err "FATAL: extracted obi binary is missing or empty"
+        exit 1
+    }
+    if command -v file >/dev/null; then
+        file "${extract_dir}/obi"
+    fi
+done
+tar -tzf "${release_dir}/obi-${release_tag}-source-generated.tar.gz" >/dev/null
+ok "source-generated archive: readable"
+
+step "5/5 container image signatures (Docker Hub + GHCR)"
+for image in \
+    "otel/ebpf-instrument:${release_tag}" \
+    "ghcr.io/${repository}/ebpf-instrument:${release_tag}"; do
+    cosign verify \
+        --certificate-identity "${image_identity}" \
+        --certificate-oidc-issuer "${oidc_issuer}" \
+        "${image}" >/dev/null
+    ok "${image}: Verified OK"
+done
+
+keep_artifacts=0
+echo
+ok "ALL CHECKS PASSED for ${release_tag}"

--- a/scripts/verify-draft-release.sh
+++ b/scripts/verify-draft-release.sh
@@ -138,6 +138,13 @@ done
 ok "all $(echo "${expected_assets}" | wc -l | tr -d ' ') expected assets present, each with a signature bundle"
 
 step "2/5 checksums (every line must report OK)"
+while read -r asset; do
+    case "${asset}" in SHA256SUMS) continue ;; esac
+    grep -q "[[:space:]]${asset}\$" "${release_dir}/SHA256SUMS" || {
+        err "FATAL: SHA256SUMS has no entry for ${asset}"
+        exit 1
+    }
+done <<< "${expected_assets}"
 (
     cd "${release_dir}"
     sha_check
@@ -158,7 +165,7 @@ for arch in amd64 arm64; do
     echo "--- $(basename "${archive}")"
     listing="$(tar -tzf "${archive}")"
     for entry in '^obi$' '^LICENSE$' '^NOTICE$' '^NOTICES/'; do
-        echo "${listing}" | grep -q "${entry}" || {
+        grep -q "${entry}" <<< "${listing}" || {
             err "FATAL: archive is missing an entry matching ${entry}"
             exit 1
         }
@@ -179,9 +186,12 @@ tar -tzf "${release_dir}/obi-${release_tag}-source-generated.tar.gz" >/dev/null
 ok "source-generated archive: readable"
 
 step "5/5 container image signatures (Docker Hub + GHCR)"
+# docker/metadata-action publishes the semver {{version}} tag, which drops any
+# +build metadata the git tag carries (see publish_dockerhub_main.yml)
+image_tag="${release_tag%%+*}"
 for image in \
-    "otel/ebpf-instrument:${release_tag}" \
-    "ghcr.io/${repository}/ebpf-instrument:${release_tag}"; do
+    "otel/ebpf-instrument:${image_tag}" \
+    "ghcr.io/${repository}/ebpf-instrument:${image_tag}"; do
     cosign verify \
         --certificate-identity "${image_identity}" \
         --certificate-oidc-issuer "${oidc_issuer}" \


### PR DESCRIPTION
## Summary

replace manual verification steps in RELEASING.md with a single script:

```console
./scripts/verify-draft-release.sh v0.12.2

=== 1/5 download release assets for v0.12.2 ===
obi-java-agent-v0.12.2.cyclonedx.json
obi-java-agent-v0.12.2.cyclonedx.json.bundle.json
obi-v0.12.2-linux-amd64.cyclonedx.json
obi-v0.12.2-linux-amd64.cyclonedx.json.bundle.json
obi-v0.12.2-linux-amd64.tar.gz
obi-v0.12.2-linux-amd64.tar.gz.bundle.json
obi-v0.12.2-linux-arm64.cyclonedx.json
obi-v0.12.2-linux-arm64.cyclonedx.json.bundle.json
obi-v0.12.2-linux-arm64.tar.gz
obi-v0.12.2-linux-arm64.tar.gz.bundle.json
obi-v0.12.2-source-generated.cyclonedx.json
obi-v0.12.2-source-generated.cyclonedx.json.bundle.json
obi-v0.12.2-source-generated.tar.gz
obi-v0.12.2-source-generated.tar.gz.bundle.json
SHA256SUMS
SHA256SUMS.bundle.json
all 8 expected assets present, each with a signature bundle

=== 2/5 checksums (every line must report OK) ===
obi-java-agent-v0.12.2.cyclonedx.json: OK
obi-v0.12.2-linux-amd64.cyclonedx.json: OK
obi-v0.12.2-linux-amd64.tar.gz: OK
obi-v0.12.2-linux-arm64.cyclonedx.json: OK
obi-v0.12.2-linux-arm64.tar.gz: OK
obi-v0.12.2-source-generated.cyclonedx.json: OK
obi-v0.12.2-source-generated.tar.gz: OK

=== 3/5 Cosign signatures (every artifact must report Verified OK) ===
--- obi-v0.12.2-linux-amd64.tar.gz
Verified OK
--- obi-v0.12.2-linux-arm64.tar.gz
Verified OK
--- obi-v0.12.2-source-generated.tar.gz
Verified OK
--- obi-java-agent-v0.12.2.cyclonedx.json
Verified OK
--- obi-v0.12.2-linux-amd64.cyclonedx.json
Verified OK
--- obi-v0.12.2-linux-arm64.cyclonedx.json
Verified OK
--- obi-v0.12.2-source-generated.cyclonedx.json
Verified OK
--- SHA256SUMS
Verified OK

=== 4/5 archive contents ===
--- obi-v0.12.2-linux-amd64.tar.gz
contains obi, LICENSE, NOTICE, and 771 NOTICES/ entries
/var/folders/nr/8shtpr_90vb76329w5mjkngm0000gp/T/tmp.qSloPFBkBy/extract-amd64/obi: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, BuildID[sha1]=84e65cb79c43935e0a4bfa5898a7511ee49e9482, with debug_info, not stripped
--- obi-v0.12.2-linux-arm64.tar.gz
contains obi, LICENSE, NOTICE, and 771 NOTICES/ entries
/var/folders/nr/8shtpr_90vb76329w5mjkngm0000gp/T/tmp.qSloPFBkBy/extract-arm64/obi: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, BuildID[sha1]=42cb2b27b3d01a2b37e22a208bc663d128e80679, with debug_info, not stripped
source-generated archive: readable

=== 5/5 container image signatures (Docker Hub + GHCR) ===

Verification for index.docker.io/otel/ebpf-instrument:v0.12.2 --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
otel/ebpf-instrument:v0.12.2: Verified OK

Verification for ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.12.2 --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.12.2: Verified OK

ALL CHECKS PASSED for v0.12.2
```

it downloads the release artifacts and then verifies:

- all 8 expected assets are present, each with its signature bundle (globs and `--ignore-missing` would otherwise skip missing files silently)
- `SHA256SUMS` for every downloaded asset
- Cosign signatures of every archive, SBOM, and the checksum file against the `refs/tags/vX.Y.Z` workflow identity
- archive contents (`obi`, LICENSE, NOTICE, NOTICES/) and that the binaries are non-empty
- the signed container images on both Docker Hub and GHCR

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
