### PR TITLE
fix: validate Prometheus scrape paths

### DIFF
--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -25,7 +25,7 @@ var pipelineBufferLengths = []float64{0, 10, 20, 40, 80, 160, 320}
 type PrometheusEndpointConfig struct {
 	// 0 (default) means disabled
 	Port int    `yaml:"port,omitempty" env:"OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT" validate:"gte=0,lte=65535"`
-	Path string `yaml:"path,omitempty" env:"OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PATH"`
+	Path string `yaml:"path,omitempty" env:"OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PATH" validate:"startswith=/"`
 }
 
 // PrometheusReporter is an internal metrics Reporter that exports to Prometheus

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -104,7 +104,7 @@ var DefaultNativeHistogramConfig = NativeHistogramConfig{
 type PrometheusConfig struct {
 	// 0 means disabled
 	Port int    `yaml:"port" env:"OTEL_EBPF_PROMETHEUS_PORT" validate:"gte=0,lte=65535"`
-	Path string `yaml:"path" env:"OTEL_EBPF_PROMETHEUS_PATH"`
+	Path string `yaml:"path" env:"OTEL_EBPF_PROMETHEUS_PATH" validate:"startswith=/"`
 
 	DisableBuildInfo bool `yaml:"disable_build_info" env:"OTEL_EBPF_PROMETHEUS_DISABLE_BUILD_INFO"`
 

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -938,6 +938,44 @@ func TestConfigValidateStaticSkipsHostCompatibility(t *testing.T) {
 	require.NoError(t, cfg.ValidateStatic())
 }
 
+func TestConfigValidatePrometheusPaths(t *testing.T) {
+	testCases := map[string]struct {
+		yamlConfig string
+		field      string
+	}{
+		"application metrics": {
+			yamlConfig: `open_port: 8080
+trace_printer: text
+prometheus_export:
+  port: 9090
+  path: metrics
+`,
+			field: "Config.Prometheus.Path",
+		},
+		"internal metrics": {
+			yamlConfig: `open_port: 8080
+trace_printer: text
+internal_metrics:
+  prometheus:
+    port: 9090
+    path: internal/metrics
+`,
+			field: "Config.InternalMetrics.Prometheus.Path",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := LoadConfig(strings.NewReader(tc.yamlConfig))
+			require.NoError(t, err)
+
+			err = cfg.ValidateStatic()
+			require.ErrorContains(t, err, tc.field)
+			require.ErrorContains(t, err, "'startswith'")
+		})
+	}
+}
+
 func TestConfigValidateRoutes(t *testing.T) {
 	userConfig := bytes.NewBufferString(`executable_path: foo
 trace_printer: text


### PR DESCRIPTION
## Summary

A Prometheus path without a leading slash passes config validation, then OBI panics when `http.ServeMux` registers it.

This validates both application and internal metrics paths up front. 
after the fix bad input now returns a normal validation error

Repro before the fix:

1. Set `open_port: 8080`
2. Set `prometheus_export.port: 9090`
3. Set `prometheus_export.path: metrics`
4. Start OBI. It panics with `host/path missing /`

The same crash happens with `internal_metrics.prometheus.path: internal/metrics`

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed. No docs update was needed.
- `make verify`
- `make compile`