### PR TITLE
feat(java): report incompatible preloaded agents

### DIFF
--- a/pkg/internal/java/README.md
+++ b/pkg/internal/java/README.md
@@ -135,6 +135,20 @@ p.getInt(1 + 36)       → 1    (Buffer length at offset 37)
 p.getByte(1 + 36 + 4)  → 42   (Data byte at offset 41)
 ```
 
+### 4. Java agent compatibility
+
+A JVM cannot unload or replace a Java agent. The agent therefore publishes its version in the
+`otel.obi.java.agent.version` system property. OBI reads this property with
+`jcmd VM.system_properties` and compares it with the version in the embedded agent JAR.
+
+If the versions do not match, OBI reports an error and does not instrument the process. Restart
+the process to load the agent included with the current OBI version.
+
+The version is stored in
+`agent/src/main/resources/obi-java-agent-version.properties`. Increment it when a change breaks
+compatibility between OBI and the Java agent. Do not increment it for compatible changes, such
+as new instrumentation or bug fixes.
+
 ## 🔨 Building
 
 ### Prerequisites

--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/Agent.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/Agent.java
@@ -73,6 +73,16 @@ public class Agent {
     return builder;
   }
 
+  // OBI reads this property from JVMs that already have an agent attached, to tell whether the
+  // attached agent is the one it would inject.
+  private static void publishVersion() {
+    try {
+      System.setProperty(AgentVersion.PROPERTY, AgentVersion.read());
+    } catch (Exception x) {
+      logger.log(Level.WARNING, "Failed to publish the agent version", x);
+    }
+  }
+
   private static Map<String, String> parseArgs(String agentArgs) {
     Map<String, String> opts = new HashMap<>();
     if (agentArgs != null && !agentArgs.isEmpty()) {
@@ -109,6 +119,8 @@ public class Agent {
       }
       agentLoaded = true;
     }
+
+    publishVersion();
 
     Map<String, String> opts = parseArgs(agentArgs);
 

--- a/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/AgentVersion.java
+++ b/pkg/internal/java/agent/src/main/java/io/opentelemetry/obi/java/AgentVersion.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.obi.java;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Version of the contract between this agent and OBI.
+ *
+ * <p>A Java agent cannot be unloaded or replaced in a running JVM. When OBI finds one of its agents
+ * already attached to a process, it compares {@link #PROPERTY} with the version of the agent it
+ * would inject and reports an error when the two differ, rather than reporting telemetry through an
+ * agent it no longer understands.
+ */
+public final class AgentVersion {
+
+  /** JVM system property the agent publishes when it loads. */
+  public static final String PROPERTY = "otel.obi.java.agent.version";
+
+  private static final String RESOURCE = "/obi-java-agent-version.properties";
+
+  private AgentVersion() {}
+
+  /** Reads the version from the JAR resource that OBI also reads before injecting the agent. */
+  public static String read() throws IOException {
+    try (InputStream in = AgentVersion.class.getResourceAsStream(RESOURCE)) {
+      if (in == null) {
+        throw new IOException("missing " + RESOURCE + " in the agent jar");
+      }
+
+      Properties properties = new Properties();
+      properties.load(in);
+
+      String version = properties.getProperty(PROPERTY, "").trim();
+      if (version.isEmpty()) {
+        throw new IOException("missing " + PROPERTY + " in " + RESOURCE);
+      }
+
+      return version;
+    }
+  }
+}

--- a/pkg/internal/java/agent/src/main/resources/obi-java-agent-version.properties
+++ b/pkg/internal/java/agent/src/main/resources/obi-java-agent-version.properties
@@ -1,0 +1,9 @@
+# Version of the contract between the OBI Java agent and OBI.
+#
+# The agent publishes this value as a JVM system property when it loads. Before instrumenting
+# a JVM that already has an OBI agent attached, OBI compares the published value with the
+# version of the agent it would inject, and reports an error when they differ.
+#
+# Bump it whenever a change makes this agent incompatible with the OBI releases that shipped
+# the previous value.
+otel.obi.java.agent.version=1

--- a/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/AgentVersionTest.java
+++ b/pkg/internal/java/agent/src/test/java/io/opentelemetry/obi/java/AgentVersionTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.obi.java;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the version marker OBI relies on to detect agents it cannot talk to. Losing the resource,
+ * or renaming the property inside it, would silently disable that detection.
+ */
+class AgentVersionTest {
+
+  @Test
+  void readsTheVersionShippedWithTheAgent() throws IOException {
+    String version = AgentVersion.read();
+
+    assertFalse(version.isEmpty());
+    assertEquals(version.trim(), version);
+  }
+}

--- a/pkg/internal/java/agent_version.go
+++ b/pkg/internal/java/agent_version.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package javaagent // import "go.opentelemetry.io/obi/pkg/internal/java"
+
+import (
+	"archive/zip"
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	// agentVersionProperty is the JVM system property the OBI Java agent publishes when it
+	// loads, so that OBI can tell which agent an already instrumented JVM is running.
+	agentVersionProperty = "otel.obi.java.agent.version"
+
+	// agentVersionResource is the agent JAR entry holding agentVersionProperty. The agent reads
+	// it at load time and OBI reads it from the JAR it injects, so both sides of the comparison
+	// come from the same artifact.
+	agentVersionResource = "obi-java-agent-version.properties"
+)
+
+var errNoAgentVersion = errors.New("the OBI java agent jar carries no version marker")
+
+// agentVersionFromJar returns the version of the Java agent packaged in jar.
+func agentVersionFromJar(jar []byte) (string, error) {
+	archive, err := zip.NewReader(bytes.NewReader(jar), int64(len(jar)))
+	if err != nil {
+		return "", fmt.Errorf("unable to read the embedded OBI java agent: %w", err)
+	}
+
+	entry, err := archive.Open(agentVersionResource)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", errNoAgentVersion, err)
+	}
+	defer entry.Close()
+
+	version, err := javaProperty(entry, agentVersionProperty)
+	if err != nil {
+		return "", fmt.Errorf("unable to read %s: %w", agentVersionResource, err)
+	}
+
+	if version == "" {
+		return "", errNoAgentVersion
+	}
+
+	return version, nil
+}
+
+// javaProperty returns the value of key in a java.util.Properties formatted stream, or an empty
+// string when the key is absent. It understands the plain "key=value" form only, which is what
+// both the agent version resource and the jcmd VM.system_properties output use.
+func javaProperty(r io.Reader, key string) (string, error) {
+	prefix := key + "="
+	reader := bufio.NewReader(r)
+
+	for {
+		line, err := reader.ReadString('\n')
+
+		if value, found := strings.CutPrefix(strings.TrimLeft(line, " \t"), prefix); found {
+			return strings.TrimSpace(value), nil
+		}
+
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return "", nil
+			}
+			return "", err
+		}
+	}
+}

--- a/pkg/internal/java/agent_version_test.go
+++ b/pkg/internal/java/agent_version_test.go
@@ -1,0 +1,122 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package javaagent
+
+import (
+	"archive/zip"
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJavaProperty(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		expected string
+	}{
+		{
+			name:     "property among other properties",
+			contents: "#Thu Nov 27 10:00:00 UTC 2025\njava.version=21.0.5\notel.obi.java.agent.version=3\nuser.dir=/app\n",
+			expected: "3",
+		},
+		{
+			name:     "last line without a line break",
+			contents: "java.version=21.0.5\notel.obi.java.agent.version=3",
+			expected: "3",
+		},
+		{
+			name:     "carriage return line endings",
+			contents: "java.version=21.0.5\r\notel.obi.java.agent.version=3\r\n",
+			expected: "3",
+		},
+		{
+			name:     "indented property",
+			contents: "  otel.obi.java.agent.version=3\n",
+			expected: "3",
+		},
+		{
+			name:     "absent property",
+			contents: "java.version=21.0.5\nuser.dir=/app\n",
+			expected: "",
+		},
+		{
+			name:     "property name is only a prefix of another one",
+			contents: "otel.obi.java.agent.version.extra=3\n",
+			expected: "",
+		},
+		{
+			name:     "empty stream",
+			contents: "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, err := javaProperty(strings.NewReader(tt.contents), agentVersionProperty)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, value)
+		})
+	}
+}
+
+func TestAgentVersionFromJar(t *testing.T) {
+	t.Run("version marker in the agent jar", func(t *testing.T) {
+		version, err := agentVersionFromJar(agentJar(t, agentVersionResource, "#a comment\n"+agentVersionProperty+"=3\n"))
+		require.NoError(t, err)
+		assert.Equal(t, "3", version)
+	})
+
+	t.Run("agent jar without a version marker", func(t *testing.T) {
+		_, err := agentVersionFromJar(agentJar(t, "unrelated.properties", "some.key=3\n"))
+		require.ErrorIs(t, err, errNoAgentVersion)
+	})
+
+	t.Run("version marker without the version property", func(t *testing.T) {
+		_, err := agentVersionFromJar(agentJar(t, agentVersionResource, "some.key=3\n"))
+		require.ErrorIs(t, err, errNoAgentVersion)
+	})
+
+	t.Run("agent jar that is not a jar", func(t *testing.T) {
+		_, err := agentVersionFromJar([]byte("not a jar"))
+		require.Error(t, err)
+		require.NotErrorIs(t, err, errNoAgentVersion)
+	})
+}
+
+func TestJavaInjector_VerifyAgentVersion(t *testing.T) {
+	injector := &JavaInjector{log: slog.Default(), agentVersion: "3"}
+
+	require.NoError(t, injector.verifyAgentVersion(1000, "3"))
+
+	err := injector.verifyAgentVersion(1000, "2")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version 2, expected 3")
+
+	err = injector.verifyAgentVersion(1000, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version unknown, expected 3")
+}
+
+func agentJar(t *testing.T, name, contents string) []byte {
+	t.Helper()
+
+	buf := bytes.Buffer{}
+	archive := zip.NewWriter(&buf)
+
+	entry, err := archive.Create(name)
+	require.NoError(t, err)
+	_, err = entry.Write([]byte(contents))
+	require.NoError(t, err)
+	require.NoError(t, archive.Close())
+
+	return buf.Bytes()
+}

--- a/pkg/internal/java/java_inject.go
+++ b/pkg/internal/java/java_inject.go
@@ -46,6 +46,7 @@ func (e *JavaInjectError) Error() string {
 type JavaInjector struct {
 	log             *slog.Logger
 	cfg             *obi.Config
+	agentVersion    string
 	currentAttachID int64
 	mu              sync.Mutex
 }
@@ -58,9 +59,20 @@ func NewJavaInjector(cfg *obi.Config) (*JavaInjector, error) {
 		return nil, err
 	}
 
+	log := slog.With("component", "javaagent.Injector")
+
+	// A locally built or outdated agent JAR may carry no version marker. Injection still
+	// works, we just cannot tell whether an agent already attached to a JVM is the one we
+	// would inject.
+	agentVersion, err := agentVersionFromJar(embeddedJavaAgentBytes)
+	if err != nil {
+		log.Debug("cannot read the embedded java agent version, compatibility checks are disabled", "error", err)
+	}
+
 	return &JavaInjector{
 		cfg:             cfg,
-		log:             slog.With("component", "javaagent.Injector"),
+		log:             log,
+		agentVersion:    agentVersion,
 		currentAttachID: 0,
 	}, nil
 }
@@ -234,6 +246,11 @@ func (i *JavaInjector) NewExecutable(ctx context.Context, target InjectionTarget
 		}
 
 		if loaded {
+			if err := i.verifyLoadedAgentVersion(ctx, attacher, target.Pid); err != nil {
+				resultChan <- result{err: err}
+				return
+			}
+
 			i.log.Info("OpenTelemetry eBPF Java Agent already loaded, not reloading")
 			resultChan <- result{attached: false}
 			return
@@ -488,6 +505,64 @@ func (i *JavaInjector) jdkAgentAlreadyLoadedHotspot8(ctx context.Context, attach
 	}
 
 	return false, nil
+}
+
+// verifyLoadedAgentVersion checks the agent a JVM already runs against the agent OBI would
+// inject. A Java agent cannot be unloaded or upgraded in place, so on a mismatch the process
+// keeps reporting through an agent this OBI build does not understand until it is restarted.
+func (i *JavaInjector) verifyLoadedAgentVersion(ctx context.Context, attacher *jvm.JAttacher, pid app.PID) error {
+	// nothing to compare against when the embedded agent carries no version marker
+	if i.agentVersion == "" {
+		return nil
+	}
+
+	loadedVersion, err := i.loadedAgentVersion(ctx, attacher, pid)
+	if err != nil {
+		return err
+	}
+
+	return i.verifyAgentVersion(pid, loadedVersion)
+}
+
+func (i *JavaInjector) verifyAgentVersion(pid app.PID, loadedVersion string) error {
+	if loadedVersion == i.agentVersion {
+		return nil
+	}
+
+	// Agents older than the version marker publish no version at all.
+	if loadedVersion == "" {
+		loadedVersion = "unknown"
+	}
+
+	i.log.Error("the JVM already runs an incompatible OpenTelemetry eBPF Java Agent, restart the process to instrument it with this OBI version",
+		"pid", pid, "loadedVersion", loadedVersion, "expectedVersion", i.agentVersion)
+
+	return &JavaInjectError{
+		Message: fmt.Sprintf("incompatible OpenTelemetry eBPF Java Agent already loaded: version %s, expected %s", loadedVersion, i.agentVersion),
+	}
+}
+
+func (i *JavaInjector) loadedAgentVersion(ctx context.Context, attacher *jvm.JAttacher, pid app.PID) (string, error) {
+	attacher.Init()
+
+	defer func() {
+		if err := attacher.Cleanup(); err != nil {
+			slog.Warn("error on JVM attach cleanup", "error", err)
+		}
+	}()
+	// OpenJ9 doesn't answer jcmd queries, but we only get here after a probe that uses them
+	out, err := attacher.Attach(ctx, int(pid), []string{"jcmd", "VM.system_properties"}, true)
+	if err != nil {
+		i.log.Error("error executing command for the JVM", "pid", pid, "error", err)
+		return "", err
+	}
+
+	if out == nil {
+		return "", nil
+	}
+	defer out.Close()
+
+	return javaProperty(out, agentVersionProperty)
 }
 
 func (i *JavaInjector) verifyJVMVersion(ctx context.Context, attacher *jvm.JAttacher, pid app.PID) (bool, bool) {


### PR DESCRIPTION
## Summary

A JVM cannot replace a Java agent while the process is running. OBI currently
skips injection when it finds its agent already loaded, even if that agent came
from an incompatible OBI release.

This change adds a compatibility version to the Java agent. The agent publishes
the version through the `otel.obi.java.agent.version` system property. When OBI
finds an existing agent, it reads the property with `jcmd VM.system_properties`
and compares it with the version in its embedded agent JAR.

A matching version keeps the existing behavior and skips reinjection. A missing
or different version returns a `JavaInjectError` and logs both the loaded and
expected versions so the operator can restart the process.

Both OBI and the Java agent read the version from
`obi-java-agent-version.properties`. The Java agent README documents when this
compatibility version must change.

The committed `embedded/obi-java-agent.jar` is unchanged. The build and release
targets rebuild it from source, while committing it here would add a 5 MB binary
diff.

Fixes #913.

## Validation

- `go build ./...`
- `go test ./pkg/internal/java/... ./pkg/appolly/discover/...`
- `go tool -modfile=internal/tools/go.mod golangci-lint run ./pkg/internal/java/... --timeout=6m`
- `gradle build`
- `make lint-markdown`
- Manual end-to-end testing with HotSpot JDK 8 and JDK 21:
  - inject an agent into a clean JVM
  - skip reinjection when the versions match
  - report an error when the versions differ
  - report an old agent without a version as `unknown`

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
