### PR TITLE
Use userspace PID

### DIFF
--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -174,6 +174,15 @@ this limit are not exported, and v0.11.0 does not report this condition with a m
 The general Go `1.17+` library-instrumentation baseline elsewhere in this matrix does not widen this v0.11.0 Auto SDK
 allowlist.
 
+### Uprobe Collision Avoidance
+
+OBI currently documents the following embedding hook for skipping a tracer group on a per-PID basis, used when
+another eBPF observability tool already attaches uprobes to the same symbols:
+
+| Hook | Scope | Limitations | Status |
+|:-----|:------|:------------|:-------|
+| `EBPFTracer.ShouldSkipTracerForPID` | Go embedding API only; no YAML key or environment variable | Only the `"libssl"` tracer group (`libssl.so`, `libcrypto.so`, `.NET OpenSsl`) is currently gated | Experimental |
+
 ### Statistical Metrics
 
 OBI currently documents the following statistical instrumentation support:

--- a/bpf/pid/pid.h
+++ b/bpf/pid/pid.h
@@ -71,17 +71,15 @@ static __always_inline u32 valid_pid(u64 id) {
         if (found_ns_pid) {
             bpf_map_update_elem(&pid_cache, &a_pid, &a_pid, BPF_ANY);
             return a_pid;
-        } else if (ns_ppid != 0) {
-            pid_data_t pp_key = {.pid = ns_ppid, .ns = pid_ns_id};
-
-            const u8 found_ns_ppid = pid_matches(&pp_key);
-
-            if (found_ns_ppid) {
-                bpf_map_update_elem(&pid_cache, &a_pid, &a_pid, BPF_ANY);
-
-                return a_pid;
-            }
         }
+        // The userspace matcher is the
+        // single source of truth for which PIDs to instrument. Falling back
+        // to the parent's match here caused excluded children of matched
+        // parents (e.g. /usr/bin/rancher under tini) to be traced anyway,
+        // even when the ExcludeInstrument check correctly rejected them.
+        // The matcher will call AllowPID for the child when it should be
+        // tracked; BPF should not second-guess that decision.
+        (void)ns_ppid;
     }
 
     return 0;

--- a/devdocs/features.md
+++ b/devdocs/features.md
@@ -141,6 +141,18 @@ Large payloads are streamed to userspace across multiple ring-buffer events and 
 
 Equivalent YAML keys live under `ebpf.buffer_sizes.{http,mysql,kafka,postgres,mssql}`.
 
+## Avoiding Uprobe Collisions With Other eBPF Tools
+
+When another eBPF observability tool (for example Datadog system-probe or Grafana Beyla) already attaches uprobes to
+the same TLS symbols on a process, OBI can skip attaching its own copy for that process to avoid doubling the
+BPF-program chain on hot paths.
+
+This is exposed as a Go API hook, not a YAML key or environment variable:
+`EBPFTracer.ShouldSkipTracerForPID(pid int32, tracerName string) bool`, set by code that embeds OBI as a library.
+Returning `true` omits the named uprobe group for that PID only; all other tracers, and the same tracer group on
+other PIDs, are unaffected. The only tracer group currently recognized is `"libssl"`, which covers the `libssl.so`,
+`libcrypto.so`, and `.NET OpenSsl` uprobes.
+
 ## GPU Instrumentation
 
 Specifically for instrumenting GPU execution primitives, like NVIDIA CUDA kernel launches and memory copies. This

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.11
 
 require (
 	github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/andybalholm/brotli v1.2.2
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cilium/ebpf v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396 h1
 github.com/AlessandroPomponio/go-gibberish v0.0.0-20191004143433-a2d4156f0396/go.mod h1:2VCDG9kHYQ5vfYUqeoB7foVlcvIvB7rp9LxTELLD1qU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.35.0 h1:bN1gA3of5bXtbnLsRPrwfmbbe7A5UWFlcTHseujLnpc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.35.0/go.mod h1:Yj5vHEz/aAepZGliRJsA6uvHAVAQyEwajq9ORCHPxzM=
-github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
-github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/andybalholm/brotli v1.2.2 h1:HzTuoo2ErYQqf5qvcJInB8uvqSVxRttzkFexPWtnceM=

--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -179,7 +179,7 @@ func (ta *traceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 
 		// allowing the tracer to forward traces from the new PID and its children processes
 		ta.monitorPIDs(tracer, ie)
-		ta.Metrics.InstrumentProcess(ie.FileInfo.ExecutableName())
+		ta.Metrics.InstrumentProcess(ie.FileInfo.ExecutableName(), uint32(ie.FileInfo.Pid()), int(ie.Type))
 		if tracer.Type == ebpf.Generic {
 			// We need to do this because generic tracers have shared libraries. For example,
 			// a python executable can run an SSL and non-SSL application, so it's not enough
@@ -299,7 +299,7 @@ func (ta *traceAttacher) getTracer(ie *ebpf.Instrumentable) bool {
 	} else {
 		ta.reusableGoTracer = tracer
 	}
-	ta.Metrics.InstrumentProcess(ie.FileInfo.ExecutableName())
+	ta.Metrics.InstrumentProcess(ie.FileInfo.ExecutableName(), uint32(ie.FileInfo.Pid()), int(ie.Type))
 	ta.log.Debug(".done")
 	return true
 }
@@ -389,7 +389,7 @@ func (ta *traceAttacher) reuseTracer(tracer *ebpf.ProcessTracer, ie *ebpf.Instru
 		tracer:     tracer,
 		generation: ie.ExecutableGeneration,
 	}
-	ta.Metrics.InstrumentProcess(ie.FileInfo.ExecutableName())
+	ta.Metrics.InstrumentProcess(ie.FileInfo.ExecutableName(), uint32(ie.FileInfo.Pid()), int(ie.Type))
 
 	return true
 }

--- a/pkg/appolly/discover/matcher_test.go
+++ b/pkg/appolly/discover/matcher_test.go
@@ -531,6 +531,50 @@ func TestDynamicMatcher_ChildInheritsDynamicSelectorPID(t *testing.T) {
 	testutil.DrainUntilClosed(filteredProcesses)
 }
 
+// TestCriteriaMatcher_ExcludeRespectsParentPIDFallback reproduces the scenario where
+// /usr/bin/rancher (a child of tini) was being instrumented despite ExcludeInstrument
+// matching its ExePath, because the parent-PID fallback in filterCreated adopted the
+// parent's match without re-checking exclusion. See ScaleOps RD-15620 / CUST-3212.
+func TestCriteriaMatcher_ExcludeRespectsParentPIDFallback(t *testing.T) {
+	pipeConfig := obi.Config{}
+	require.NoError(t, yaml.Unmarshal([]byte(`discovery:
+  instrument:
+  - open_ports: 80
+  exclude_instrument:
+  - exe_path: /usr/bin/rancher
+`), &pipeConfig))
+
+	discoveredProcesses := msg.NewQueue[[]Event[ProcessAttrs]](msg.ChannelBufferLen(10))
+	filteredProcessesQu := msg.NewQueue[[]Event[ProcessMatch]](msg.ChannelBufferLen(10))
+	filteredProcesses := filteredProcessesQu.Subscribe()
+	matcherFunc, err := criteriaMatcherProvider(&pipeConfig, discoveredProcesses, filteredProcessesQu, FindingCriteria(&pipeConfig), nil)(t.Context())
+	require.NoError(t, err)
+	go matcherFunc(t.Context())
+	defer filteredProcessesQu.Close()
+
+	processInfo = func(pp ProcessAttrs) (*services.ProcessInfo, error) {
+		proc := map[app.PID]struct {
+			Exe  string
+			PPid app.PID
+		}{
+			1: {Exe: "/usr/sbin/tini", PPid: 0},   // parent — matches by port
+			2: {Exe: "/usr/bin/rancher", PPid: 1}, // child — own match fails (no port); parent in history; BUT ExePath matches exclude
+		}[pp.pid]
+		return &services.ProcessInfo{Pid: pp.pid, ExePath: proc.Exe, PPid: proc.PPid, OpenPorts: pp.openPorts}, nil
+	}
+	discoveredProcesses.Send([]Event[ProcessAttrs]{
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 1, openPorts: []uint32{80}}}, // tini matches by port
+		{Type: EventCreated, Obj: ProcessAttrs{pid: 2, openPorts: []uint32{}}},   // rancher: must NOT be adopted via tini's PID
+	})
+
+	matches := testutil.ReadChannel(t, filteredProcesses, testTimeout)
+	// Pre-fix this would be 2 matches (tini + rancher inherited via parent-PID).
+	// After the fix the child is rejected by the exclude check before parent adoption.
+	require.Len(t, matches, 1)
+	assert.Equal(t, app.PID(1), matches[0].Obj.Process.Pid)
+	assert.Equal(t, "/usr/sbin/tini", matches[0].Obj.Process.ExePath)
+}
+
 func TestCriteriaMatcherContainersOnly(t *testing.T) {
 	pipeConfig := obi.Config{}
 	require.NoError(t, yaml.Unmarshal([]byte(`discovery:

--- a/pkg/config/ebpf_tracer.go
+++ b/pkg/config/ebpf_tracer.go
@@ -154,6 +154,22 @@ type EBPFTracer struct {
 
 	// eBPF map configurations
 	MapsConfig MapsConfig `yaml:"maps_config"`
+
+	// ShouldSkipTracerForPID, if non-nil, is consulted before attaching a
+	// specific tracer group to a process. Returning true causes the tracer's
+	// uprobe set for that named group to be omitted for this PID only — all
+	// other tracers still attach normally.
+	//
+	// When another eBPF observability
+	// tool (e.g. Datadog system-probe, Grafana Beyla) is already attaching
+	// uprobes for the same symbols, the consumer can skip our copy to avoid
+	// doubling the BPF-program chain on hot paths.
+	//
+	// The tracerName argument identifies the uprobe group; the initial set is
+	// "libssl" (covers both libssl.so and the .NET OpenSsl wrapper). Future
+	// names may include "go_http", "java_agent", etc. as other collision sets
+	// emerge from customer reports.
+	ShouldSkipTracerForPID func(pid int32, tracerName string) bool `yaml:"-"`
 }
 
 var nvidiaSMIExistsFunc = nvidiaSMIExists

--- a/pkg/export/imetrics/imetrics.go
+++ b/pkg/export/imetrics/imetrics.go
@@ -77,8 +77,10 @@ type Reporter interface {
 	OTELTraceExportError(err error)
 	// PrometheusRequest is invoked every time the Prometheus exporter is invoked, for a given port and path
 	PrometheusRequest(port, path string)
-	// InstrumentProcess is invoked every time a new process is successfully instrumented
-	InstrumentProcess(processName string)
+	// InstrumentProcess is invoked every time a new process is successfully instrumented.
+	// pid is the host-namespace PID; language is the detected InstrumentableType (as int
+	// to avoid an import cycle with the svc package).
+	InstrumentProcess(processName string, pid uint32, language int)
 	// UninstrumentProcess is invoked every time a process is removed from the instrumented processes
 	UninstrumentProcess(processName string)
 	// InstrumentationError is invoked every time an instrumentation attempt fails
@@ -131,7 +133,7 @@ func (n NoopReporter) OTELMetricExportError(_ error)                            
 func (n NoopReporter) OTELTraceExport(_ int)                                                   {}
 func (n NoopReporter) OTELTraceExportError(_ error)                                            {}
 func (n NoopReporter) PrometheusRequest(_, _ string)                                           {}
-func (n NoopReporter) InstrumentProcess(_ string)                                              {}
+func (n NoopReporter) InstrumentProcess(_ string, _ uint32, _ int)                             {}
 func (n NoopReporter) UninstrumentProcess(_ string)                                            {}
 func (n NoopReporter) InstrumentationError(_, _ string)                                        {}
 func (n NoopReporter) AvoidInstrumentationMetrics(_, _, _ string)                              {}

--- a/pkg/export/imetrics/iprom.go
+++ b/pkg/export/imetrics/iprom.go
@@ -226,7 +226,7 @@ func (p *PrometheusReporter) PrometheusRequest(port, path string) {
 	p.prometheusRequests.WithLabelValues(port, path).Inc()
 }
 
-func (p *PrometheusReporter) InstrumentProcess(processName string) {
+func (p *PrometheusReporter) InstrumentProcess(processName string, _ uint32, _ int) {
 	p.instrumentedProcesses.WithLabelValues(processName).Inc()
 }
 

--- a/pkg/export/otel/metrics_internal.go
+++ b/pkg/export/otel/metrics_internal.go
@@ -286,7 +286,7 @@ func (p *InternalMetricsReporter) OTELTraceExportError(err error) {
 func (p *InternalMetricsReporter) PrometheusRequest(_, _ string) {
 }
 
-func (p *InternalMetricsReporter) InstrumentProcess(processName string) {
+func (p *InternalMetricsReporter) InstrumentProcess(processName string, _ uint32, _ int) {
 	p.instrumentedProcesses.Add(p.ctx, 1, sanitizedAttributes(attribute.String("process.executable.name", processName)))
 }
 

--- a/pkg/export/otel/metrics_internal_test.go
+++ b/pkg/export/otel/metrics_internal_test.go
@@ -168,7 +168,7 @@ func TestInternalMetricsReporterInvalidUTF8ProcessName(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	reporter.InstrumentProcess("my-service\xff\xfe")
+	reporter.InstrumentProcess("my-service\xff\xfe", 1234, 0)
 
 	records := readMetricsByName(t, metricRecords, time.Second,
 		attr.VendorPrefix+".instrumented.processes",

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -53,6 +53,10 @@ type Tracer struct {
 	iters            []*ebpfcommon.Iter
 	eventCtx         *ebpfcommon.EBPFEventContext
 	jvmUSDTManager   ebpfcommon.USDTSpecManager
+	// attachPID is the host PID of the process currently being instrumented.
+	// It is set by ProcessBinary before UProbes() is called, so the skip
+	// callback in cfg.EBPF.ShouldSkipTracerForPID receives the right PID.
+	attachPID int32
 }
 
 func tlog() *slog.Logger {
@@ -291,7 +295,13 @@ func (p *Tracer) constants() map[string]any {
 
 func (p *Tracer) RegisterOffsets(_ *exec.FileInfo, _ *goexec.Offsets) {}
 
-func (p *Tracer) ProcessBinary(_ *exec.FileInfo) {}
+// ProcessBinary records the host PID of the binary about to be instrumented
+// so that UProbes() can forward it to ShouldSkipTracerForPID.
+func (p *Tracer) ProcessBinary(info *exec.FileInfo) {
+	if info != nil {
+		p.attachPID = int32(info.Pid())
+	}
+}
 
 func (p *Tracer) AddCloser(c ...io.Closer) {
 	p.closers = append(p.closers, c...)
@@ -385,10 +395,13 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {
 			Required: true,
 			Start:    p.bpfObjects.ObiKprobeInetCskListenStop,
 		},
-		"sys_ioctl": {
+	}
+
+	if p.cfg.Java.Enabled {
+		kp["sys_ioctl"] = ebpfcommon.ProbeDesc{
 			Required: true,
 			Start:    p.bpfObjects.ObiKprobeSysIoctl,
-		},
+		}
 	}
 
 	if p.cfg.EBPF.ContextPropagation.IsEnabled() {
@@ -414,72 +427,6 @@ func (p *Tracer) Tracepoints() map[string]ebpfcommon.ProbeDesc {
 
 func (p *Tracer) UProbes() map[string]map[string][]*ebpfcommon.ProbeDesc {
 	m := map[string]map[string][]*ebpfcommon.ProbeDesc{
-		"libssl.so": {
-			"SSL_read": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeSslRead,
-				End:      p.bpfObjects.ObiUretprobeSslRead,
-			}},
-			"SSL_write": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeSslWrite,
-				End:      p.bpfObjects.ObiUretprobeSslWrite,
-			}},
-			"SSL_read_ex": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeSslReadEx,
-				End:      p.bpfObjects.ObiUretprobeSslReadEx,
-			}},
-			"SSL_write_ex2": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeSslWriteEx2,
-				End:      p.bpfObjects.ObiUretprobeSslWriteEx2,
-			}},
-			"SSL_write_ex": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeSslWriteEx,
-				End:      p.bpfObjects.ObiUretprobeSslWriteEx,
-			}},
-			"SSL_shutdown": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeSslShutdown,
-			}},
-			"SSL_set_bio": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeSslSetBio,
-			}},
-			"SSL_free": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeSslFree,
-			}},
-		},
-		// BIO_write is a libcrypto symbol. A process that links libssl and
-		// libcrypto separately, as CPython does, resolves it from its own
-		// object, so it gets its own key here. Statically linked runtimes such
-		// as node resolve both keys to the executable and are grouped into a
-		// single attachment by inode.
-		"libcrypto.so": {
-			"BIO_write": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeBioWrite,
-			}},
-		},
-		"libSystem.Security.Cryptography.Native.OpenSsl.so": {
-			"CryptoNative_SslRead": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeSslRead,
-				End:      p.bpfObjects.ObiUretprobeSslRead,
-			}},
-			"CryptoNative_SslWrite": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeSslWrite,
-				End:      p.bpfObjects.ObiUretprobeSslWrite,
-			}},
-			"CryptoNative_SslShutdown": {{
-				Required: false,
-				Start:    p.bpfObjects.ObiUprobeSslShutdown,
-			}},
-		},
 		"nginx": {
 			"ngx_http_upstream_init": {{ // on upstream dispatch
 				Required: false,
@@ -553,6 +500,74 @@ func (p *Tracer) UProbes() map[string]map[string][]*ebpfcommon.ProbeDesc {
 				End:      p.bpfObjects.ObiUprobeTaskStepRet,
 			}},
 		},
+	}
+	if p.cfg.EBPF.ShouldSkipTracerForPID == nil || !p.cfg.EBPF.ShouldSkipTracerForPID(p.attachPID, "libssl") {
+		m["libssl.so"] = map[string][]*ebpfcommon.ProbeDesc{
+			"SSL_read": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeSslRead,
+				End:      p.bpfObjects.ObiUretprobeSslRead,
+			}},
+			"SSL_write": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeSslWrite,
+				End:      p.bpfObjects.ObiUretprobeSslWrite,
+			}},
+			"SSL_read_ex": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeSslReadEx,
+				End:      p.bpfObjects.ObiUretprobeSslReadEx,
+			}},
+			"SSL_write_ex2": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeSslWriteEx2,
+				End:      p.bpfObjects.ObiUretprobeSslWriteEx2,
+			}},
+			"SSL_write_ex": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeSslWriteEx,
+				End:      p.bpfObjects.ObiUretprobeSslWriteEx,
+			}},
+			"SSL_shutdown": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeSslShutdown,
+			}},
+			"SSL_set_bio": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeSslSetBio,
+			}},
+			"SSL_free": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeSslFree,
+			}},
+		}
+		// BIO_write is a libcrypto symbol. A process that links libssl and
+		// libcrypto separately, as CPython does, resolves it from its own
+		// object, so it gets its own key here. Statically linked runtimes such
+		// as node resolve both keys to the executable and are grouped into a
+		// single attachment by inode.
+		m["libcrypto.so"] = map[string][]*ebpfcommon.ProbeDesc{
+			"BIO_write": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeBioWrite,
+			}},
+		}
+		m["libSystem.Security.Cryptography.Native.OpenSsl.so"] = map[string][]*ebpfcommon.ProbeDesc{
+			"CryptoNative_SslRead": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeSslRead,
+				End:      p.bpfObjects.ObiUretprobeSslRead,
+			}},
+			"CryptoNative_SslWrite": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeSslWrite,
+				End:      p.bpfObjects.ObiUretprobeSslWrite,
+			}},
+			"CryptoNative_SslShutdown": {{
+				Required: false,
+				Start:    p.bpfObjects.ObiUprobeSslShutdown,
+			}},
+		}
 	}
 	return m
 }

--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -395,13 +395,10 @@ func (p *Tracer) KProbes() map[string]ebpfcommon.ProbeDesc {
 			Required: true,
 			Start:    p.bpfObjects.ObiKprobeInetCskListenStop,
 		},
-	}
-
-	if p.cfg.Java.Enabled {
-		kp["sys_ioctl"] = ebpfcommon.ProbeDesc{
+		"sys_ioctl": {
 			Required: true,
 			Start:    p.bpfObjects.ObiKprobeSysIoctl,
-		}
+		},
 	}
 
 	if p.cfg.EBPF.ContextPropagation.IsEnabled() {

--- a/pkg/internal/ebpf/generictracer/generictracer_test.go
+++ b/pkg/internal/ebpf/generictracer/generictracer_test.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
+	"go.opentelemetry.io/obi/pkg/config"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/ebpf/ringbuf"
 	"go.opentelemetry.io/obi/pkg/export"
@@ -371,4 +372,96 @@ func (f fakeServiceFilter) CurrentPIDs(ebpfcommon.PIDType) map[uint32]map[app.PI
 		(*f.currentPIDsCalls)++
 	}
 	return f.current
+}
+
+// newTestTracer returns a minimal Tracer suitable for UProbes() unit tests.
+// bpfObjects are left zero-valued; UProbes() only reads the cfg field and the
+// attachPID field so this is safe for the coexistence-callback tests.
+func newTestTracer(cfg *obi.Config) *Tracer {
+	return &Tracer{cfg: cfg}
+}
+
+// TestUProbes_ShouldSkipTracerForPID_LibsslOmitted verifies that when
+// ShouldSkipTracerForPID returns true for "libssl", UProbes() omits both the
+// "libssl.so" and "libSystem.Security.Cryptography.Native.OpenSsl.so" entries
+// while leaving all other uprobe groups intact.
+func TestUProbes_ShouldSkipTracerForPID_LibsslOmitted(t *testing.T) {
+	tracer := newTestTracer(&obi.Config{
+		EBPF: config.EBPFTracer{
+			ShouldSkipTracerForPID: func(_ int32, tracerName string) bool {
+				return tracerName == "libssl"
+			},
+		},
+	})
+	tracer.attachPID = 1234
+
+	probes := tracer.UProbes()
+
+	assert.NotContains(t, probes, "libssl.so",
+		"libssl.so must be absent when ShouldSkipTracerForPID returns true for 'libssl'")
+	assert.NotContains(t, probes, "libSystem.Security.Cryptography.Native.OpenSsl.so",
+		"libSystem.Security.Cryptography.Native.OpenSsl.so must be absent when callback returns true")
+
+	// Other uprobe groups must not be affected.
+	assert.Contains(t, probes, "nginx",
+		"nginx uprobes must be present regardless of libssl skip decision")
+}
+
+// TestUProbes_ShouldSkipTracerForPID_NilCallback verifies that a nil callback
+// preserves all uprobe entries including libssl.
+func TestUProbes_ShouldSkipTracerForPID_NilCallback(t *testing.T) {
+	tracer := newTestTracer(&obi.Config{
+		EBPF: config.EBPFTracer{
+			ShouldSkipTracerForPID: nil,
+		},
+	})
+	tracer.attachPID = 1234
+
+	probes := tracer.UProbes()
+
+	assert.Contains(t, probes, "libssl.so",
+		"libssl.so must be present when ShouldSkipTracerForPID is nil")
+	assert.Contains(t, probes, "libSystem.Security.Cryptography.Native.OpenSsl.so",
+		"libSystem.Security.Cryptography.Native.OpenSsl.so must be present when callback is nil")
+}
+
+// TestUProbes_ShouldSkipTracerForPID_FalseDoesNotSkip verifies that a callback
+// returning false preserves all libssl entries.
+func TestUProbes_ShouldSkipTracerForPID_FalseDoesNotSkip(t *testing.T) {
+	tracer := newTestTracer(&obi.Config{
+		EBPF: config.EBPFTracer{
+			ShouldSkipTracerForPID: func(_ int32, _ string) bool {
+				return false
+			},
+		},
+	})
+	tracer.attachPID = 5678
+
+	probes := tracer.UProbes()
+
+	assert.Contains(t, probes, "libssl.so",
+		"libssl.so must be present when ShouldSkipTracerForPID returns false")
+	assert.Contains(t, probes, "libSystem.Security.Cryptography.Native.OpenSsl.so",
+		"libSystem.Security.Cryptography.Native.OpenSsl.so must be present when callback returns false")
+}
+
+// TestUProbes_ShouldSkipTracerForPID_PIDPassedThrough verifies that the PID
+// stored by ProcessBinary is forwarded to the callback unchanged.
+func TestUProbes_ShouldSkipTracerForPID_PIDPassedThrough(t *testing.T) {
+	const wantPID = int32(9999)
+	var gotPID int32
+
+	tracer := newTestTracer(&obi.Config{
+		EBPF: config.EBPFTracer{
+			ShouldSkipTracerForPID: func(pid int32, _ string) bool {
+				gotPID = pid
+				return false
+			},
+		},
+	})
+	tracer.ProcessBinary(&exec.FileInfo{Pid: app.PID(wantPID)})
+	tracer.UProbes()
+
+	assert.Equal(t, wantPID, gotPID,
+		"callback must receive exactly the PID set by ProcessBinary")
 }

--- a/pkg/internal/goexec/structmembers.go
+++ b/pkg/internal/goexec/structmembers.go
@@ -12,8 +12,8 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/grafana/go-offsets-tracker/pkg/offsets"
-	"github.com/hashicorp/go-version"
 )
 
 func log() *slog.Logger {
@@ -24,12 +24,12 @@ func log() *slog.Logger {
 type GoOffset uint32
 
 var (
-	grpcOneSixZero      = version.Must(version.NewVersion("1.60.0"))
-	grpcOneSixNine      = version.Must(version.NewVersion("1.69.0"))
-	grpcOneSevenSeven   = version.Must(version.NewVersion("1.77.0"))
-	http2ZeroFortyFive  = version.Must(version.NewVersion("0.45.0"))
-	mongoOneThirteenOne = version.Must(version.NewVersion("1.13.1"))
-	pqOneElevenZero     = version.Must(version.NewVersion("1.11.0"))
+	grpcOneSixZero      = semver.MustParse("1.60.0")
+	grpcOneSixNine      = semver.MustParse("1.69.0")
+	grpcOneSevenSeven   = semver.MustParse("1.77.0")
+	http2ZeroFortyFive  = semver.MustParse("0.45.0")
+	mongoOneThirteenOne = semver.MustParse("1.13.1")
+	pqOneElevenZero     = semver.MustParse("1.11.0")
 )
 
 type activationModule struct {
@@ -774,18 +774,18 @@ func offsetsForLibVersions(fieldOffsets FieldOffsets, libVersions map[string]str
 		case "google.golang.org/grpc":
 			ver = cleanLibVersion(ver, true, lib, log)
 
-			if v, err := version.NewVersion(ver); err == nil {
-				if v.GreaterThanOrEqual(grpcOneSixZero) {
+			if v, err := semver.NewVersion(ver); err == nil {
+				if !v.LessThan(grpcOneSixZero) {
 					fieldOffsets[GrpcOneSixZero] = uint64(1)
 				} else {
 					fieldOffsets[GrpcOneSixZero] = uint64(0)
 				}
-				if v.GreaterThanOrEqual(grpcOneSixNine) {
+				if !v.LessThan(grpcOneSixNine) {
 					fieldOffsets[GrpcOneSixNine] = uint64(1)
 				} else {
 					fieldOffsets[GrpcOneSixNine] = uint64(0)
 				}
-				if v.GreaterThanOrEqual(grpcOneSevenSeven) {
+				if !v.LessThan(grpcOneSevenSeven) {
 					fieldOffsets[GrpcOneSevenSeven] = uint64(1)
 				} else {
 					fieldOffsets[GrpcOneSevenSeven] = uint64(0)
@@ -796,8 +796,8 @@ func offsetsForLibVersions(fieldOffsets FieldOffsets, libVersions map[string]str
 		case "go.mongodb.org/mongo-driver":
 			ver = cleanLibVersion(ver, true, lib, log)
 
-			if v, err := version.NewVersion(ver); err == nil {
-				if v.GreaterThanOrEqual(mongoOneThirteenOne) {
+			if v, err := semver.NewVersion(ver); err == nil {
+				if !v.LessThan(mongoOneThirteenOne) {
 					fieldOffsets[MongoOneThirteenOne] = uint64(1)
 				} else {
 					fieldOffsets[MongoOneThirteenOne] = uint64(0)
@@ -806,8 +806,8 @@ func offsetsForLibVersions(fieldOffsets FieldOffsets, libVersions map[string]str
 		case "golang.org/x/net":
 			ver = cleanLibVersion(ver, true, lib, log)
 
-			if v, err := version.NewVersion(ver); err == nil {
-				if v.GreaterThanOrEqual(http2ZeroFortyFive) {
+			if v, err := semver.NewVersion(ver); err == nil {
+				if !v.LessThan(http2ZeroFortyFive) {
 					fieldOffsets[HTTP2ZeroFortyFive] = uint64(1)
 				} else {
 					fieldOffsets[HTTP2ZeroFortyFive] = uint64(0)
@@ -818,8 +818,8 @@ func offsetsForLibVersions(fieldOffsets FieldOffsets, libVersions map[string]str
 		case "github.com/lib/pq":
 			ver = cleanLibVersion(ver, true, lib, log)
 
-			if v, err := version.NewVersion(ver); err == nil {
-				if v.GreaterThanOrEqual(pqOneElevenZero) {
+			if v, err := semver.NewVersion(ver); err == nil {
+				if !v.LessThan(pqOneElevenZero) {
 					fieldOffsets[PqOneElevenZero] = uint64(1)
 				} else {
 					fieldOffsets[PqOneElevenZero] = uint64(0)
@@ -938,11 +938,11 @@ func prefetchedGoRuntimeGCGoalOffset(offs *offsets.Track, goVersion string) (uin
 		return 0, false
 	}
 
-	target, err := version.NewVersion(goVersion)
+	target, err := semver.NewVersion(goVersion)
 	if err != nil {
 		return 0, false
 	}
-	newest, err := version.NewVersion(field.Versions.Newest)
+	newest, err := semver.NewVersion(field.Versions.Newest)
 	if err != nil || target.GreaterThan(newest) {
 		return 0, false
 	}


### PR DESCRIPTION
## Summary

The userspace matcher is the single source of truth for which PIDs to instrument. 
Falling back to the parent's match here caused excluded children of matched parents (e.g. /usr/bin/rancher under tini) to be traced anyway, even when the ExcludeInstrument check correctly rejected them.
The matcher will call AllowPID for the child when it should be tracked; BPF should not second-guess that decision.

Allow to skip attaching probes for specific PIDs if specified.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [X] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
