### PR TITLE
Initialize process tracer logger in constructor

### DIFF
--- a/pkg/ebpf/instrumenter_test.go
+++ b/pkg/ebpf/instrumenter_test.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/goexec"
 	"go.opentelemetry.io/obi/pkg/internal/procs"
+	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 
@@ -786,6 +787,15 @@ func TestOptionalGoProbeGroupsRollBackOnce(t *testing.T) {
 	i.rollbackOptionalGoProbeGroups()
 
 	assert.Equal(t, int32(1), linkCloser.closes.Load())
+}
+
+func TestProcessTracerCanLogBeforeRun(t *testing.T) {
+	pt := NewProcessTracer(Generic, nil, &obi.Config{}, imetrics.NoopReporter{})
+	fileInfo := exec.New(exec.Init{Dev: 5, Ino: 10})
+
+	assert.NotPanics(t, func() {
+		pt.UnlinkExecutable(fileInfo, 1)
+	})
 }
 
 func TestStaleExecutableUnlinkPreservesReplacement(t *testing.T) {

--- a/pkg/ebpf/tracer_linux.go
+++ b/pkg/ebpf/tracer_linux.go
@@ -83,6 +83,7 @@ func unloadInternalMaps(eventContext *common.EBPFEventContext) {
 
 func NewProcessTracer(tracerType ProcessTracerType, programs []Tracer, cfg *obi.Config, metrics imetrics.Reporter) *ProcessTracer {
 	return &ProcessTracer{
+		log:                       ptlog().With("type", tracerType),
 		Programs:                  programs,
 		Type:                      tracerType,
 		Instrumentables:           map[ExecutableKey]*instrumenter{},
@@ -104,8 +105,6 @@ func (pt *ProcessTracer) Run(
 	ebpfEventContext *common.EBPFEventContext,
 	out *msg.Queue[[]request.Span],
 ) {
-	pt.log = ptlog().With("type", pt.Type)
-
 	pt.log.Debug("starting process tracer")
 
 	// Searches for traceable functions


### PR DESCRIPTION
## Summary

Initialize the typed `ProcessTracer` logger during construction instead of waiting for `Run`. This keeps invariant warnings safe before the run loop starts, preventing a recoverable state from becoming a process-wide `nil` logger panic.

Add a regression test that exercises a missing executable unlink before `Run` starts.

Addresses the defensive hardening noted in #2868.

## Validation

- `go test ./pkg/ebpf -count=1`