### PR TITLE
Make Config v1 integration fixtures migratable

### DIFF
--- a/cmd/obi/internal/configcmd/configcmd_test.go
+++ b/cmd/obi/internal/configcmd/configcmd_test.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/obi/internal/config/convert"
 	"go.opentelemetry.io/obi/internal/config/schema"
 	obiconfig "go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
 	"go.opentelemetry.io/obi/pkg/obi"
 )
 
@@ -1463,8 +1464,6 @@ otel_traces_export:
 }
 
 func TestMigrateIntegrationConfigurations(t *testing.T) {
-	// Docker suites select their target through OTEL_EBPF_OPEN_PORT. Materialize
-	// that setting in the input because config migrate operates on YAML files.
 	tests := []struct {
 		name   string
 		input  func(t *testing.T) []byte
@@ -1473,17 +1472,15 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 		{
 			name: "Docker Go OTEL gRPC",
 			input: func(t *testing.T) []byte {
-				return withV1GRPCProtocol(withV1OpenPort(
-					integrationConfig(t, "internal/test/integration/configs/obi-config-go-otel-grpc.yml"),
-					8080,
-				), "http://jaeger:4318")
+				return integrationConfig(t, "internal/test/integration/configs/obi-config-go-otel-grpc.yml")
 			},
 			verify: func(t *testing.T, cfg *obi.Config) {
 				require.True(t, cfg.Enabled(obi.FeatureAppO11y))
 				require.Len(t, cfg.Discovery.Instrument, 1)
 				require.True(t, cfg.Discovery.Instrument[0].OpenPorts.Matches(8080))
 				require.Equal(t, 8999, cfg.Prometheus.Port)
-				require.Equal(t, "http://jaeger:4318", cfg.Traces.TracesEndpoint)
+				require.Equal(t, "http://jaeger:4317", cfg.Traces.TracesEndpoint)
+				require.Equal(t, otelcfg.ProtocolGRPC, cfg.Traces.TracesProtocol)
 				require.NotNil(t, cfg.Routes)
 				routes := cfg.Routes.DirectionalPolicies()
 				require.Equal(t, "path", string(routes.Incoming.Unmatch))
@@ -1493,16 +1490,14 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 		{
 			name: "Docker Java",
 			input: func(t *testing.T) []byte {
-				return withV1GRPCProtocol(withV1OpenPort(
-					integrationConfig(t, "internal/test/integration/configs/obi-config-java.yml"),
-					8085,
-				), "http://otelcol:4318")
+				return integrationConfig(t, "internal/test/integration/configs/obi-config-java.yml")
 			},
 			verify: func(t *testing.T, cfg *obi.Config) {
 				require.True(t, cfg.Enabled(obi.FeatureAppO11y))
 				require.Len(t, cfg.Discovery.Instrument, 1)
 				require.True(t, cfg.Discovery.Instrument[0].OpenPorts.Matches(8085))
-				require.Equal(t, "http://otelcol:4318", cfg.OTELMetrics.MetricsEndpoint)
+				require.Equal(t, "http://otelcol:4317", cfg.OTELMetrics.MetricsEndpoint)
+				require.Equal(t, otelcfg.ProtocolGRPC, cfg.OTELMetrics.MetricsProtocol)
 				require.NotNil(t, cfg.Routes)
 				routes := cfg.Routes.DirectionalPolicies()
 				require.Equal(t, []string{"/greeting"}, routes.Incoming.Patterns)
@@ -1512,18 +1507,21 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 		{
 			name: "Kubernetes daemonset",
 			input: func(t *testing.T) []byte {
-				config := kubernetesConfig(t, "internal/test/integration/k8s/manifests/06-obi-daemonset.yml")
-				config = withV1GRPCProtocol(config, "http://otelcol:4318")
-				return withV1GRPCProtocol(config, "http://jaeger:4318")
+				return kubernetesConfig(t, "internal/test/integration/k8s/manifests/06-obi-daemonset.yml")
 			},
 			verify: func(t *testing.T, cfg *obi.Config) {
 				require.True(t, cfg.Enabled(obi.FeatureAppO11y))
 				require.Equal(t, obi.LogLevelDebug, cfg.LogLevel)
 				require.Equal(t, "true", string(cfg.Attributes.Kubernetes.Enable))
+				require.Equal(t, []string{"deployment.environment.name"}, cfg.Attributes.Kubernetes.ResourceLabels["deployment.environment.name"])
 				require.Len(t, cfg.Discovery.Instrument, 5)
 				require.GreaterOrEqual(t, len(cfg.Discovery.ExcludeInstrument), 1)
 				require.True(t, cfg.Discovery.Instrument[0].Metadata["k8s_deployment_name"].MatchString("testserver"))
 				require.True(t, cfg.Discovery.ExcludeInstrument[0].Metadata["k8s_deployment_name"].MatchString("testserver"))
+				require.Equal(t, "http://otelcol:4317", cfg.OTELMetrics.MetricsEndpoint)
+				require.Equal(t, otelcfg.ProtocolGRPC, cfg.OTELMetrics.MetricsProtocol)
+				require.Equal(t, "http://jaeger:4317", cfg.Traces.TracesEndpoint)
+				require.Equal(t, otelcfg.ProtocolGRPC, cfg.Traces.TracesProtocol)
 				require.NotNil(t, cfg.Routes)
 				routes := cfg.Routes.DirectionalPolicies()
 				require.Equal(t, []string{"/metrics"}, routes.Incoming.IgnorePatterns)
@@ -1533,8 +1531,7 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 		{
 			name: "Kubernetes shared PID namespace daemonset",
 			input: func(t *testing.T) []byte {
-				config := kubernetesConfig(t, "internal/test/integration/k8s/manifests/06-obi-daemonset-sharedpidns.yml")
-				return withV1GRPCProtocol(config, "http://otelcol:4318")
+				return kubernetesConfig(t, "internal/test/integration/k8s/manifests/06-obi-daemonset-sharedpidns.yml")
 			},
 			verify: func(t *testing.T, cfg *obi.Config) {
 				require.True(t, cfg.Enabled(obi.FeatureAppO11y))
@@ -1543,6 +1540,8 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 				require.Len(t, cfg.Discovery.Instrument, 2)
 				require.True(t, cfg.Discovery.Instrument[0].Metadata["k8s_deployment_name"].MatchString("testserver"))
 				require.True(t, cfg.Discovery.Instrument[1].Metadata["k8s_daemonset_name"].MatchString("hostpid-httpserver"))
+				require.Equal(t, "http://otelcol:4317", cfg.Traces.TracesEndpoint)
+				require.Equal(t, otelcfg.ProtocolGRPC, cfg.Traces.TracesProtocol)
 				require.NotNil(t, cfg.Routes)
 				routes := cfg.Routes.DirectionalPolicies()
 				require.Equal(t, []string{"/pingpong"}, routes.Incoming.Patterns)
@@ -1601,16 +1600,6 @@ func integrationConfig(t *testing.T, relativePath string) []byte {
 	contents, err := os.ReadFile(filepath.Join(repositoryRoot(t), relativePath))
 	require.NoError(t, err)
 	return contents
-}
-
-func withV1OpenPort(config []byte, port int) []byte {
-	return append(config, fmt.Sprintf("\nopen_port: %d\n", port)...)
-}
-
-func withV1GRPCProtocol(config []byte, endpoint string) []byte {
-	oldEndpoint := []byte("  endpoint: " + endpoint)
-	newEndpoint := append(append([]byte{}, oldEndpoint...), []byte("\n  protocol: grpc")...)
-	return bytes.Replace(config, oldEndpoint, newEndpoint, 1)
 }
 
 func kubernetesConfig(t *testing.T, relativePath string) []byte {

--- a/internal/test/integration/configs/obi-config-go-otel-grpc.yml
+++ b/internal/test/integration/configs/obi-config-go-otel-grpc.yml
@@ -1,9 +1,11 @@
 routes:
   unmatched: path
+open_port: 8080
 prometheus_export:
   port: 8999
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://jaeger:4317
+  protocol: grpc
 metrics:
   features:
     - application

--- a/internal/test/integration/configs/obi-config-java.yml
+++ b/internal/test/integration/configs/obi-config-java.yml
@@ -2,8 +2,10 @@ routes:
   patterns:
     - /greeting
   unmatched: path
+open_port: 8085
 otel_metrics_export:
-  endpoint: http://otelcol:4318
+  endpoint: http://otelcol:4317
+  protocol: grpc
 attributes:
   select:
     "*":

--- a/internal/test/integration/docker-compose-go-otel-grpc.yml
+++ b/internal/test/integration/docker-compose-go-otel-grpc.yml
@@ -30,7 +30,6 @@ services:
     environment:
       GOCOVERDIR: "/coverage"
       OTEL_EBPF_TRACE_PRINTER: "text"
-      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
       OTEL_EBPF_METRICS_FEATURES: "application,application_span_otel"
       OTEL_EBPF_PROMETHEUS_FEATURES: "application,application_span"
       OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms

--- a/internal/test/integration/docker-compose-java.yml
+++ b/internal/test/integration/docker-compose-java.yml
@@ -29,7 +29,6 @@ services:
     environment:
       GOCOVERDIR: "/coverage"
       OTEL_EBPF_TRACE_PRINTER: "text"
-      OTEL_EBPF_OPEN_PORT: "${JAVA_OPEN_PORT}"
       OTEL_EBPF_EXECUTABLE_PATH: "${JAVA_EXECUTABLE_PATH}"
       OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
       OTEL_EBPF_METRICS_INTERVAL: "1s"

--- a/internal/test/integration/http_go_otel_test.go
+++ b/internal/test/integration/http_go_otel_test.go
@@ -322,7 +322,7 @@ func TestHTTPGoOTelInstrumentedAppGRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	// we are going to setup discovery directly in the configuration file
-	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=8080`)
+	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`)
 	lockdown := KernelLockdownMode()
 
 	if !lockdown {
@@ -366,7 +366,7 @@ func TestHTTPGoOTelAvoidsInstrumentedAppGRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	// we are going to setup discovery directly in the configuration file
-	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=8080`, `APP_OTEL_METRICS_ENDPOINT=http://otelcol:4317`, `APP_OTEL_TRACES_ENDPOINT=http://jaeger:4317`)
+	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `APP_OTEL_METRICS_ENDPOINT=http://otelcol:4317`, `APP_OTEL_TRACES_ENDPOINT=http://jaeger:4317`)
 	lockdown := KernelLockdownMode()
 
 	if !lockdown {

--- a/internal/test/integration/k8s/manifests/06-obi-daemonset-sharedpidns.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-daemonset-sharedpidns.yml
@@ -20,7 +20,8 @@ data:
     # jaeger, keeping the jaeger-based assertions working) so weaver can
     # validate them — OBI exports nothing else in this suite.
     otel_traces_export:
-      endpoint: http://otelcol:4318
+      endpoint: http://otelcol:4317
+      protocol: grpc
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/internal/test/integration/k8s/manifests/06-obi-daemonset.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-daemonset.yml
@@ -31,9 +31,11 @@ data:
         - /metrics
       ignore_mode: traces
     otel_metrics_export:
-      endpoint: http://otelcol:4318
+      endpoint: http://otelcol:4317
+      protocol: grpc
     otel_traces_export:
-      endpoint: http://jaeger:4318
+      endpoint: http://jaeger:4317
+      protocol: grpc
     internal_metrics:
       exporter: otel
 ---
@@ -83,7 +85,7 @@ spec:
             - name: OTEL_EBPF_METRICS_INTERVAL
               value: "1s"
             - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-              value: "http://otelcol:4318"
+              value: "http://otelcol:4317"
             - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
               value: "10ms"
             - name: OTEL_EBPF_METRICS_TTL

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -316,7 +316,7 @@ func TestSuite_Java_OpenPort(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-java.yml", path.Join(pathOutput, "test-suite-java-openport.log"))
 	require.NoError(t, err)
 
-	compose.Env = append(compose.Env, `JAVA_OPEN_PORT=8085`, `JAVA_EXECUTABLE_PATH=`, `TESTSERVER_IMAGE=`+obiTestImgJavaJar)
+	compose.Env = append(compose.Env, `JAVA_EXECUTABLE_PATH=`, `TESTSERVER_IMAGE=`+obiTestImgJavaJar)
 	require.NoError(t, compose.Up())
 	t.Run("Java RED metrics", func(t *testing.T) { testREDMetricsJavaHTTP(t, "greeting-service") })
 


### PR DESCRIPTION
## Summary

- materialize the Go port 8080 and Java port 8085 selectors in their v1 integration YAML fixtures
- use explicit OTLP/gRPC exporters on port 4317 while preserving the existing collector and Jaeger destinations
- migrate the checked-in Docker and Kubernetes fixture content unchanged and assert selector, exporter, enrichment, and directional route parity

This is prerequisite 1/3 for #2699.

## Testing

- `go test ./cmd/obi/internal/configcmd -count=1`
- `go test ./internal/test/integration`
- targeted `golangci-lint` for the config command and integration packages
- `docker compose config --quiet` for both changed Docker suites
- `git diff --check origin/main...HEAD`