### PR TITLE
nodejs: fix config file entrypoint parsing

### DIFF
--- a/pkg/internal/nodejstools/launch.go
+++ b/pkg/internal/nodejstools/launch.go
@@ -35,6 +35,7 @@ var optionsWithValues = map[string]struct{}{
 	"--dns-result-order":                  {},
 	"--env-file":                          {},
 	"--env-file-if-exists":                {},
+	"--experimental-config-file":          {},
 	"--experimental-default-type":         {},
 	"--experimental-loader":               {},
 	"--experimental-package-map":          {},

--- a/pkg/internal/nodejstools/launch_test.go
+++ b/pkg/internal/nodejstools/launch_test.go
@@ -52,6 +52,7 @@ func TestParseNodeLaunch(t *testing.T) {
 		{name: "V8 option with attached value", args: []string{"--stack-trace-limit=20", "app"}, entryPoint: "app"},
 		{name: "attached config file", args: []string{"--experimental-config-file=node.config.json", "app"}, entryPoint: "app"},
 		{name: "separate config file", args: []string{"--experimental-config-file", "config", "server.js"}, entryPoint: "server.js"},
+		{name: "default config file", args: []string{"--experimental-default-config-file", "app"}, entryPoint: "app"},
 		{name: "removed Node 16 option", args: []string{"--experimental-fetch", "app"}, entryPoint: "app"},
 		{name: "current compatibility option", args: []string{"--experimental-detect-module", "app"}, entryPoint: "app"},
 		{name: "removed option with value", args: []string{"--experimental-policy", "policy.json", "app"}, entryPoint: "app"},

--- a/pkg/internal/nodejstools/launch_test.go
+++ b/pkg/internal/nodejstools/launch_test.go
@@ -51,7 +51,7 @@ func TestParseNodeLaunch(t *testing.T) {
 		{name: "underscore option", args: []string{"--inspect_port", "9230", "app.js"}, entryPoint: "app.js"},
 		{name: "V8 option with attached value", args: []string{"--stack-trace-limit=20", "app"}, entryPoint: "app"},
 		{name: "attached config file", args: []string{"--experimental-config-file=node.config.json", "app"}, entryPoint: "app"},
-		{name: "default config file", args: []string{"--experimental-config-file", "app"}, entryPoint: "app"},
+		{name: "separate config file", args: []string{"--experimental-config-file", "config", "server.js"}, entryPoint: "server.js"},
 		{name: "removed Node 16 option", args: []string{"--experimental-fetch", "app"}, entryPoint: "app"},
 		{name: "current compatibility option", args: []string{"--experimental-detect-module", "app"}, entryPoint: "app"},
 		{name: "removed option with value", args: []string{"--experimental-policy", "policy.json", "app"}, entryPoint: "app"},


### PR DESCRIPTION
## Summary

- classify `--experimental-config-file` as an option that consumes its following value
- preserve the application script for automatic service identity and route harvesting
- cover the separated config-file syntax with a focused regression test

## Validation

- `go test ./pkg/internal/nodejstools`
- `make verify`