### PR TITLE
Add Aerospike server spans

### DIFF
--- a/devdocs/protocols/tcp/aerospike.md
+++ b/devdocs/protocols/tcp/aerospike.md
@@ -148,6 +148,20 @@ plus, for writes, the per-op type bytes:
 The span name follows the OTel database convention `{operation} {target}`, e.g.
 `GET test.users` (`{db.operation.name} {db.namespace}.{db.collection.name}`).
 
+### Client- and server-side spans
+
+The span type follows the observed role: instrumenting an application that uses
+an Aerospike client produces `client` spans, while instrumenting the Aerospike
+server process (`asd`) produces `server` spans. Both roles share the span name
+convention and the attribute set above. When both peers are instrumented, one
+operation yields one client span and one server span with distinct kinds — the
+server span nests under the client span in the same trace.
+
+Server-side error status does not require the capture buffer size: the server
+writes each response in a single send, so the `result_code` is always captured
+on that side. (The client-side split-read consideration below does not apply
+to the server role.)
+
 ### User key (opt-in)
 
 Capturing `db.query.text` **requires the client to enable the send-key write
@@ -252,7 +266,7 @@ observability tooling is metrics-only:
   latency histograms per command type, but emit no spans and have no out-of-the-box
   OTel exporter.
 
-So OBI's client-side span generation here is novel — it is the only source that
+So OBI's client- and server-side span generation here is novel — it is the only source that
 produces per-operation traces for Aerospike.
 
 ## References

--- a/internal/test/integration/docker-compose-aerospike-server.yml
+++ b/internal/test/integration/docker-compose-aerospike-server.yml
@@ -1,0 +1,116 @@
+version: "3.8"
+
+services:
+  aerospike:
+    image: aerospike/aerospike-server:8.1.2.3@sha256:73c78ec8c2010dbc83ffb4b1249abbdfad3a66173492f46fa54996d0608f122d
+    ulimits:
+      nofile:
+        soft: 20000
+        hard: 20000
+    ports:
+      - "3000"
+
+  testserver:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/javaaerospike/Dockerfile
+    image: hatest-testserver-aerospike
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    depends_on:
+      otelcol:
+        condition: service_started
+      aerospike:
+        condition: service_started
+
+  # OBI instruments the aerospike server process (asd), not the java client, so
+  # the emitted spans are the server-side view. No capture buffer size is set:
+  # the server writes each response in a single send, so the result_code is
+  # captured without response reassembly.
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-aerospike-server:/var/run/obi
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:aerospike"
+    pid: "service:aerospike"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config-aerospike.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_TRACES_INSTRUMENTATIONS: "aerospike"
+      OTEL_EBPF_METRICS_INSTRUMENTATIONS: "aerospike"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+    depends_on:
+      aerospike:
+        condition: service_started
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.159.0@sha256:1f2c54a30e713fac6b3ae77a1ec84010c2007e29ced8ec666214fc2f6739c1cc
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318:4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+      jaeger:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.14.0@sha256:5ce7540c3c00ef4ab0c9d2c995c6a5b9c421f44b4a115d97a2c7af3b1c21cbb0
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    command:
+      - "--set=service.telemetry.logs.level=debug"

--- a/internal/test/integration/red_test_aerospike_server.go
+++ b/internal/test/integration/red_test_aerospike_server.go
@@ -1,0 +1,116 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration // import "go.opentelemetry.io/obi/internal/test/integration"
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
+)
+
+// The Jaeger service name is the instrumented executable: the aerospike
+// server daemon.
+const aerospikeServerService = "asd"
+
+// testREDTracesAerospikeServerSide verifies the server-side view: OBI
+// instruments the aerospike server process (asd), not the java client, so
+// every operation must be reported as a server span. The error operation must
+// carry the response result_code even though no capture buffer size is
+// configured: the server writes each response in a single send.
+// Server-side metrics (db.server.operation.duration) are wired in a follow-up;
+// this test asserts traces only and pins the metric absence meanwhile.
+func testREDTracesAerospikeServerSide(t *testing.T) {
+	baseURL := "http://localhost:8392"
+
+	for i := 0; i < 4; i++ {
+		ti.DoHTTPGet(t, baseURL+"/aerospike", 200)
+	}
+
+	spans := []TestCaseSpan{
+		{Name: "PUT test.demo", Attributes: []attribute.KeyValue{
+			attribute.String("db.operation.name", "PUT"),
+		}},
+		// The create-only PUT on an existing record: the server-side span must
+		// report the result_code without any capture buffer configured.
+		{Name: "PUT test.demo", Attributes: []attribute.KeyValue{
+			attribute.String("db.operation.name", "PUT"),
+			attribute.String("db.response.status_code", "KEY_EXISTS_ERROR"),
+		}},
+		{Name: "GET test.demo", Attributes: []attribute.KeyValue{attribute.String("db.operation.name", "GET")}},
+		{Name: "DELETE test.demo", Attributes: []attribute.KeyValue{attribute.String("db.operation.name", "DELETE")}},
+		{Name: "SCAN test.demo", Attributes: []attribute.KeyValue{attribute.String("db.operation.name", "SCAN")}},
+	}
+	commonAttributes := []attribute.KeyValue{
+		attribute.String("db.system.name", "aerospike"),
+		attribute.String("span.kind", "server"),
+		attribute.String("db.namespace", "test"),
+		attribute.String("db.collection.name", "demo"),
+	}
+	for i := range spans {
+		spans[i].Attributes = append(spans[i].Attributes, commonAttributes...)
+	}
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		for _, span := range spans {
+			resp, err := http.Get(jaegerQueryURL + "?service=" + aerospikeServerService + "&operation=" + url.QueryEscape(span.Name))
+			require.NoError(ct, err, "failed to query jaeger for %s", span.Name)
+			if resp == nil {
+				return
+			}
+			require.Equal(ct, http.StatusOK, resp.StatusCode, "unexpected status code for %s: %d", span.Name, resp.StatusCode)
+			var tq jaeger.TracesQuery
+			require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq), "failed to decode jaeger response for %s", span.Name)
+			var tags []jaeger.Tag
+			for _, attr := range span.Attributes {
+				tags = append(tags, otelAttributeToJaegerTag(attr))
+			}
+			traces := tq.FindBySpan(tags...)
+			assert.LessOrEqual(ct, 1, len(traces), "server span %s with tags %v not found in traces %v", span.Name, tags, tq.Data)
+		}
+	}, testTimeout, 100*time.Millisecond)
+
+	// The java client is not instrumented, so no client-side metric may exist.
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	results, err := pq.Query(`db_client_operation_duration_seconds_count{}`)
+	require.NoError(t, err, "failed to query prometheus for db_client_operation_duration_seconds_count")
+	require.Empty(t, results, "expected no client-side db operations, got %d", len(results))
+
+	// Server-side metric routing lands in a follow-up PR; this assertion is
+	// meant to flip to a positive check there.
+	results, err = pq.Query(`db_server_operation_duration_seconds_count{db_system_name="aerospike"}`)
+	require.NoError(t, err, "failed to query prometheus for db_server_operation_duration_seconds_count")
+	require.Empty(t, results, "server-side metric not wired yet, expected no series, got %d", len(results))
+}
+
+// waitForAerospikeServerTestComponents cannot wait on a db metric (none is
+// emitted server-side yet), so it waits for the first server span instead.
+func waitForAerospikeServerTestComponents(t *testing.T, baseURL string) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		// the test service endpoint is healthy (each hit drives the aerospike ops)
+		req, err := http.NewRequest(http.MethodGet, baseURL+"/aerospike", nil)
+		require.NoError(ct, err)
+		r, err := testHTTPClient.Do(req)
+		require.NoError(ct, err)
+		require.Equal(ct, http.StatusOK, r.StatusCode)
+
+		// a server span reached Jaeger (OBI + collector are healthy)
+		resp, err := http.Get(jaegerQueryURL + "?service=" + aerospikeServerService + "&operation=" + url.QueryEscape("PUT test.demo"))
+		require.NoError(ct, err)
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+		require.NotEmpty(ct, tq.Data)
+	}, 1*time.Minute, time.Second)
+}

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -830,6 +830,20 @@ func TestSuite_Aerospike(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_AerospikeServerSide(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-aerospike-server.yml", path.Join(pathOutput, "test-suite-aerospike-server.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=3000`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8392:8080`)
+	require.NoError(t, compose.Up())
+	t.Run("Aerospike server-side traces", func(t *testing.T) {
+		waitForAerospikeServerTestComponents(t, "http://localhost:8392")
+		testREDTracesAerospikeServerSide(t)
+	})
+	runWeaverValidation(t)
+	require.NoError(t, compose.Close())
+}
+
 func TestSuite_PythonMongo(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-mongo.yml", path.Join(pathOutput, "test-suite-python-mongo.log"))
 	require.NoError(t, err)

--- a/pkg/appolly/app/request/instrumentation.go
+++ b/pkg/appolly/app/request/instrumentation.go
@@ -36,7 +36,7 @@ func (t EventType) Instrumentation() (instrumentations.Instrumentation, bool) {
 		return instrumentations.InstrumentationMemcached, true
 	case EventTypeSunRPCClient, EventTypeSunRPCServer:
 		return instrumentations.InstrumentationSunRPC, true
-	case EventTypeAerospikeClient:
+	case EventTypeAerospikeClient, EventTypeAerospikeServer:
 		return instrumentations.InstrumentationAerospike, true
 	default:
 		return "", false

--- a/pkg/appolly/app/request/instrumentation_test.go
+++ b/pkg/appolly/app/request/instrumentation_test.go
@@ -27,7 +27,7 @@ func TestEventTypeInstrumentation(t *testing.T) {
 		instrumentations.InstrumentationCouchbase: {EventTypeCouchbaseClient},
 		instrumentations.InstrumentationMemcached: {EventTypeMemcachedClient, EventTypeMemcachedServer},
 		instrumentations.InstrumentationSunRPC:    {EventTypeSunRPCClient, EventTypeSunRPCServer},
-		instrumentations.InstrumentationAerospike: {EventTypeAerospikeClient},
+		instrumentations.InstrumentationAerospike: {EventTypeAerospikeClient, EventTypeAerospikeServer},
 	}
 
 	for want, eventTypes := range tests {

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -63,6 +63,7 @@ const (
 	EventTypeSunRPCClient
 	EventTypeSunRPCServer
 	EventTypeAerospikeClient
+	EventTypeAerospikeServer
 )
 
 const (
@@ -193,6 +194,8 @@ func (t EventType) String() string {
 		return "MemcachedServer"
 	case EventTypeAerospikeClient:
 		return "AerospikeClient"
+	case EventTypeAerospikeServer:
+		return "AerospikeServer"
 	default:
 		return fmt.Sprintf("UNKNOWN (%d)", t)
 	}
@@ -1577,7 +1580,7 @@ func spanAttributes(s *Span) SpanAttributes {
 			"operation":  s.Method,
 			"table":      s.Path,
 		}
-	case EventTypeAerospikeClient:
+	case EventTypeAerospikeClient, EventTypeAerospikeServer:
 		attrs := SpanAttributes{
 			"serverAddr":      SpanHost(s),
 			"serverPort":      strconv.Itoa(s.HostPort),
@@ -1730,7 +1733,7 @@ func SpanStatusCode(span *Span) string {
 		return HTTPSpanStatusCode(span)
 	case EventTypeGRPC, EventTypeGRPCClient:
 		return GrpcSpanStatusCode(span)
-	case EventTypeSQLClient, EventTypeSQLServer, EventTypeRedisClient, EventTypeRedisServer, EventTypeMongoClient, EventTypeDNS, EventTypeCouchbaseClient, EventTypeMemcachedClient, EventTypeMemcachedServer, EventTypeSunRPCClient, EventTypeSunRPCServer, EventTypeAerospikeClient:
+	case EventTypeSQLClient, EventTypeSQLServer, EventTypeRedisClient, EventTypeRedisServer, EventTypeMongoClient, EventTypeDNS, EventTypeCouchbaseClient, EventTypeMemcachedClient, EventTypeMemcachedServer, EventTypeSunRPCClient, EventTypeSunRPCServer, EventTypeAerospikeClient, EventTypeAerospikeServer:
 		if span.Status != 0 {
 			return StatusCodeError
 		}
@@ -1758,7 +1761,7 @@ func SpanDBStatusMessage(span *Span, dbError string) string {
 
 func (s *Span) IsDBSpan() bool {
 	switch s.Type {
-	case EventTypeRedisClient, EventTypeRedisServer, EventTypeMongoClient, EventTypeCouchbaseClient, EventTypeMemcachedClient, EventTypeMemcachedServer, EventTypeSQLClient, EventTypeSQLServer, EventTypeAerospikeClient:
+	case EventTypeRedisClient, EventTypeRedisServer, EventTypeMongoClient, EventTypeCouchbaseClient, EventTypeMemcachedClient, EventTypeMemcachedServer, EventTypeSQLClient, EventTypeSQLServer, EventTypeAerospikeClient, EventTypeAerospikeServer:
 		return true
 	case EventTypeHTTPClient:
 		if s.SubType == HTTPSubtypeSQLPP {
@@ -1899,9 +1902,9 @@ func (s *Span) ServiceGraphKind() string {
 	}
 
 	switch s.Type {
-	case EventTypeHTTP, EventTypeGRPC, EventTypeKafkaServer, EventTypeMQTTServer, EventTypeNATSServer, EventTypeSunRPCServer, EventTypeRedisServer, EventTypeMemcachedServer, EventTypeSQLServer:
+	case EventTypeHTTP, EventTypeGRPC, EventTypeKafkaServer, EventTypeMQTTServer, EventTypeNATSServer, EventTypeSunRPCServer, EventTypeRedisServer, EventTypeMemcachedServer, EventTypeSQLServer, EventTypeAerospikeServer:
 		return "SPAN_KIND_SERVER"
-	case EventTypeHTTPClient, EventTypeGRPCClient, EventTypeSQLClient, EventTypeRedisClient, EventTypeMongoClient, EventTypeFailedConnect, EventTypeCouchbaseClient, EventTypeMemcachedClient, EventTypeSunRPCClient:
+	case EventTypeHTTPClient, EventTypeGRPCClient, EventTypeSQLClient, EventTypeRedisClient, EventTypeMongoClient, EventTypeFailedConnect, EventTypeCouchbaseClient, EventTypeMemcachedClient, EventTypeSunRPCClient, EventTypeAerospikeClient:
 		return "SPAN_KIND_CLIENT"
 	case EventTypeKafkaClient, EventTypeMQTTClient, EventTypeNATSClient, EventTypeAMQPClient:
 		switch MessagingOperationTypeOf(s.Method) {
@@ -2192,7 +2195,7 @@ func (s *Span) TraceName() string {
 			return s.Method + " " + s.Path
 		}
 		return s.Method
-	case EventTypeAerospikeClient:
+	case EventTypeAerospikeClient, EventTypeAerospikeServer:
 		if s.Method == "" {
 			return "AEROSPIKE"
 		}

--- a/pkg/appolly/app/request/span_getters.go
+++ b/pkg/appolly/app/request/span_getters.go
@@ -329,7 +329,7 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 				} else if s.SubType == HTTPSubtypeSQLPP {
 					return DBCollectionName(s.Route)
 				}
-			case EventTypeSQLClient, EventTypeSQLServer, EventTypeMongoClient, EventTypeCouchbaseClient, EventTypeAerospikeClient:
+			case EventTypeSQLClient, EventTypeSQLServer, EventTypeMongoClient, EventTypeCouchbaseClient, EventTypeAerospikeClient, EventTypeAerospikeServer:
 				return DBCollectionName(s.Path)
 			}
 			return DBCollectionName("")
@@ -611,7 +611,7 @@ func dbSystemNameForSpan(span *Span) string {
 		return semconv.DBSystemNameMongoDB.Value.AsString()
 	case EventTypeCouchbaseClient:
 		return semconv.DBSystemNameCouchbase.Value.AsString()
-	case EventTypeAerospikeClient:
+	case EventTypeAerospikeClient, EventTypeAerospikeServer:
 		return "aerospike"
 	case EventTypeHTTPClient:
 		if span.SubType == HTTPSubtypeElasticsearch && span.Elasticsearch != nil {

--- a/pkg/appolly/app/request/span_getters_test.go
+++ b/pkg/appolly/app/request/span_getters_test.go
@@ -117,8 +117,13 @@ func TestSpanOTELGetters_DBCollectionName(t *testing.T) {
 			expected: "orders",
 		},
 		{
-			name:     "Aerospike collection",
+			name:     "Aerospike client collection",
 			span:     &Span{Type: EventTypeAerospikeClient, Path: "sessions"},
+			expected: "sessions",
+		},
+		{
+			name:     "Aerospike server collection",
+			span:     &Span{Type: EventTypeAerospikeServer, Path: "sessions"},
 			expected: "sessions",
 		},
 		{

--- a/pkg/ebpf/common/aerospike_detect_transform.go
+++ b/pkg/ebpf/common/aerospike_detect_transform.go
@@ -346,13 +346,18 @@ func TCPToAerospikeToSpan(trace *TCPRequestInfo, info *aerospikeInfo, status int
 	peer := ""
 	hostname := ""
 	hostPort := 0
+
+	spanType := request.EventTypeAerospikeClient
+	if trace.IsServer {
+		spanType = request.EventTypeAerospikeServer
+	}
+
 	if trace.ConnInfo.S_port != 0 || trace.ConnInfo.D_port != 0 {
 		peer, hostname = (*BPFConnInfo)(unsafe.Pointer(&trace.ConnInfo)).reqHostInfo()
 		hostPort = int(trace.ConnInfo.D_port)
 	}
-
 	return request.Span{
-		Type:         request.EventTypeAerospikeClient,
+		Type:         spanType,
 		Method:       info.op,
 		Path:         info.set,
 		Peer:         peer,

--- a/pkg/ebpf/common/aerospike_detect_transform_test.go
+++ b/pkg/ebpf/common/aerospike_detect_transform_test.go
@@ -263,17 +263,20 @@ func TestDispatchAerospikeIgnoresNoise(t *testing.T) {
 	assert.True(t, ignore, "noise frames must not produce a span")
 }
 
-// TestDispatchAerospikeServerSideIgnored mirrors the matchAerospike server-side
-// guard on the kernel-classified path.
-func TestDispatchAerospikeServerSideIgnored(t *testing.T) {
+// TestDispatchAerospikeServerSpan covers the kernel-classified path for an
+// exchange observed from the server process: it must produce a server span.
+func TestDispatchAerospikeServerSpan(t *testing.T) {
 	req := largebuf.NewLargeBufferFrom(mustHex(t, fixtureHex(t, "put")))
 	resp := largebuf.NewLargeBufferFrom(mustHex(t, aerospikeWriteOKResp))
 
 	event := &TCPRequestInfo{ProtocolType: ProtocolTypeAerospike, IsServer: true}
-	_, ignore, matched, err := dispatchKernelAssignedProtocol(nil, event, req, resp)
+	span, ignore, matched, err := dispatchKernelAssignedProtocol(nil, event, req, resp)
 	require.NoError(t, err)
-	assert.True(t, matched)
-	assert.True(t, ignore, "server-side exchange must not produce a client span")
+	require.True(t, matched)
+	assert.False(t, ignore)
+	assert.Equal(t, request.EventTypeAerospikeServer, span.Type)
+	assert.Equal(t, "PUT", span.Method)
+	assert.Equal(t, "PUT test.s_put", span.TraceName())
 }
 
 // TestDispatchAerospikeUnknownFallsThrough ensures unclassified events are left
@@ -288,19 +291,43 @@ func TestDispatchAerospikeUnknownFallsThrough(t *testing.T) {
 	assert.False(t, matched, "unknown protocol must fall through to the detection stages")
 }
 
-// TestMatchAerospikeServerSideSkipped ensures a valid Aerospike exchange observed
-// from the server process (IsServer) does not produce a span, so an operation
-// instrumented on both peers is reported only once (client-side).
-func TestMatchAerospikeServerSideSkipped(t *testing.T) {
+// TestMatchAerospikeSpanTypeByRole ensures the same exchange produces a client
+// span on the client process and a server span on the server process, so an
+// operation instrumented on both peers is reported once per role, never twice
+// with the same type (redis/SQL precedent).
+func TestMatchAerospikeSpanTypeByRole(t *testing.T) {
 	req := largebuf.NewLargeBufferFrom(mustHex(t, fixtureHex(t, "put")))
 	resp := largebuf.NewLargeBufferFrom(mustHex(t, aerospikeWriteOKResp))
 
-	_, _, matched, err := matchAerospike(&TCPRequestInfo{IsServer: true}, req, resp)
+	span, _, matched, err := matchAerospike(&TCPRequestInfo{IsServer: false}, req, resp)
 	require.NoError(t, err)
-	assert.False(t, matched, "server-side Aerospike exchange must not produce a client span")
+	require.True(t, matched)
+	assert.Equal(t, request.EventTypeAerospikeClient, span.Type)
+	assert.Equal(t, "SPAN_KIND_CLIENT", span.ServiceGraphKind())
 
-	// the same exchange on the client side still matches
-	_, _, matched, err = matchAerospike(&TCPRequestInfo{IsServer: false}, req, resp)
+	span, _, matched, err = matchAerospike(&TCPRequestInfo{IsServer: true}, req, resp)
 	require.NoError(t, err)
-	assert.True(t, matched, "client-side Aerospike exchange must still match")
+	require.True(t, matched)
+	assert.Equal(t, request.EventTypeAerospikeServer, span.Type)
+	assert.Equal(t, "SPAN_KIND_SERVER", span.ServiceGraphKind())
+	assert.Equal(t, "PUT test.s_put", span.TraceName(), "server span keeps the same name convention")
+}
+
+// TestMatchAerospikeServerErrorStatus ensures the server role reports the
+// response result_code like the client role does.
+func TestMatchAerospikeServerErrorStatus(t *testing.T) {
+	req := largebuf.NewLargeBufferFrom(mustHex(t, fixtureHex(t, "put")))
+
+	// KEY_EXISTS_ERROR response: as_msg header with result_code 5 at body offset 5.
+	body := make([]byte, 22)
+	body[0] = 22
+	body[5] = 5
+	resp := largebuf.NewLargeBufferFrom(append([]byte{2, 3, 0, 0, 0, 0, 0, 22}, body...))
+
+	span, _, matched, err := matchAerospike(&TCPRequestInfo{IsServer: true}, req, resp)
+	require.NoError(t, err)
+	require.True(t, matched)
+	assert.Equal(t, request.EventTypeAerospikeServer, span.Type)
+	assert.Equal(t, 1, span.Status)
+	assert.Equal(t, "KEY_EXISTS_ERROR", span.DBError.ErrorCode)
 }

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -393,17 +393,13 @@ func dispatchAerospike(event *TCPRequestInfo, requestBuffer, responseBuffer *lar
 	return span, ignore, matched, err
 }
 
-// matchAerospike detects the Aerospike native client protocol (proto v2) from the
-// captured request/response buffers and builds a client span. Only type-3 AS_MSG
-// data requests produce a span; info/auth/compressed frames are left for the
-// generic ignore path. Correlation is the generic per-connection direction flip.
+// matchAerospike detects the Aerospike native protocol (proto v2) from the
+// captured request/response buffers and builds a span typed by the observed
+// role: client on the application side, server on the aerospike server (asd)
+// side. Only type-3 AS_MSG data requests produce a span; info/auth/compressed
+// frames are left for the generic ignore path. Correlation is the generic
+// per-connection direction flip.
 func matchAerospike(event *TCPRequestInfo, requestBuffer, responseBuffer *largebuf.LargeBuffer) (request.Span, bool, bool, error) { //nolint:unparam
-	// Aerospike instrumentation is client-side only. When OBI also instruments the
-	// Aerospike server process it sees the same exchange from the server side; skip
-	// it so a single operation isn't reported twice (once per peer).
-	if event.IsServer {
-		return request.Span{}, false, false, nil
-	}
 
 	// parseAerospikeRequest validates the proto/as_msg header itself and returns
 	// nil for non-Aerospike or response frames, so it doubles as the detector.

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -1530,7 +1530,7 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 		if span.DBNamespace != "" {
 			attrs = append(attrs, request.DBNamespace(span.DBNamespace))
 		}
-	case request.EventTypeAerospikeClient:
+	case request.EventTypeAerospikeClient, request.EventTypeAerospikeServer:
 		attrs = []attribute.KeyValue{
 			request.ServerAddr(request.HostAsServer(span)),
 			request.ServerPort(span.HostPort),
@@ -1675,7 +1675,7 @@ func spanKind(span *request.Span) trace2.SpanKind {
 	}
 
 	switch span.Type {
-	case request.EventTypeHTTP, request.EventTypeGRPC, request.EventTypeRedisServer, request.EventTypeKafkaServer, request.EventTypeMQTTServer, request.EventTypeNATSServer, request.EventTypeSunRPCServer, request.EventTypeMemcachedServer, request.EventTypeSQLServer:
+	case request.EventTypeHTTP, request.EventTypeGRPC, request.EventTypeRedisServer, request.EventTypeKafkaServer, request.EventTypeMQTTServer, request.EventTypeNATSServer, request.EventTypeSunRPCServer, request.EventTypeMemcachedServer, request.EventTypeSQLServer, request.EventTypeAerospikeServer:
 		return trace2.SpanKindServer
 	case request.EventTypeHTTPClient, request.EventTypeGRPCClient, request.EventTypeSQLClient, request.EventTypeRedisClient, request.EventTypeMongoClient, request.EventTypeCouchbaseClient, request.EventTypeMemcachedClient, request.EventTypeSunRPCClient, request.EventTypeAerospikeClient, request.EventTypeFailedConnect:
 		return trace2.SpanKindClient


### PR DESCRIPTION
## Summary

This PR allows produce Aerospike server spans (it follows the redis/sql logic).

Notes:
- server spans report the response `result_code` without any capture buffer configuration (the server writes responses in a single send).
- also fixes a pre-existing gap: `EventTypeAerospikeClient` was missing from the service-graph kind mapping, so aerospike client spans have had the wrong service-graph kind since the parser landed.
- a new integration suite instruments the asd container and asserts the five server spans end to end, including a `KEY_EXISTS_ERROR` one.

Follow-up:
- metric routing is not included: server events don't yet observe `db.server.operation.duration`. That lands in a follow-up PR.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
