### PR TITLE
remove service.name and service.namespace from default metric labels

### DIFF
--- a/devdocs/config/CONFIG.md
+++ b/devdocs/config/CONFIG.md
@@ -59,7 +59,7 @@ Attributes configures the decoration of some extra attributes that will be added
 
 | YAML Path | Type | Env Var | Default | Values | Deprecated | Description |
 |---|---|---|---|---|---|---|
-| `attributes.extra_group_attributes` | [`ExtraGroupAttributesMap`](#extragroupattributesmap) |  |  |  |  | Map of attribute group names to arrays of attribute names. Only 'k8s_app_meta' is currently supported as a key. |
+| `attributes.extra_group_attributes` | [`ExtraGroupAttributesMap`](#extragroupattributesmap) |  |  |  |  | Map of attribute group names to arrays of attribute names. Supported keys are 'app' and 'k8s_app_meta'. |
 | `attributes.metric_span_names_limit` | `integer` | `OTEL_EBPF_METRIC_SPAN_NAMES_LIMIT` | `100` |  |  | Works PER SERVICE and only relates to span_metrics. When the span_name cardinality surpasses this limit, the span_name will be reported as AGGREGATED. If the value <= 0, it is disabled. |
 | `attributes.rename_unresolved_hosts` | `string` | `OTEL_EBPF_RENAME_UNRESOLVED_HOSTS` | `unresolved` |  |  | Will replace HostName and PeerName attributes when they are empty or contain unresolved IP addresses to reduce cardinality. Set this value to the empty string to disable this feature. |
 | `attributes.rename_unresolved_hosts_incoming` | `string` | `OTEL_EBPF_RENAME_UNRESOLVED_HOSTS_INCOMING` | `incoming` |  |  |  |
@@ -654,9 +654,9 @@ Buckets defines the histograms bucket boundaries, and allows users to redefine t
 
 ### ExtraGroupAttributesMap
 
-Map of attribute group names to arrays of attribute names. Only 'k8s_app_meta' is currently supported as a key.
+Map of attribute group names to arrays of attribute names. Supported keys are 'app' and 'k8s_app_meta'.
 
-**Known keys:** `k8s_app_meta`
+**Known keys:** `app`, `k8s_app_meta`
 
 **Value type:** `string[]`
 

--- a/devdocs/config/config-schema.json
+++ b/devdocs/config/config-schema.json
@@ -918,11 +918,12 @@
       },
       "propertyNames": {
         "enum": [
+          "app",
           "k8s_app_meta"
         ]
       },
       "type": "object",
-      "description": "Map of attribute group names to arrays of attribute names. Only 'k8s_app_meta' is currently supported as a key."
+      "description": "Map of attribute group names to arrays of attribute names. Supported keys are 'app' and 'k8s_app_meta'."
     },
     "Features": {
       "items": {

--- a/internal/test/integration/configs/obi-config-perapp.yml
+++ b/internal/test/integration/configs/obi-config-perapp.yml
@@ -26,3 +26,6 @@ discovery:
       metrics: { features: [ "application", "application_span_otel" ] }
     - name: rtestserver
       open_ports: 8090
+attributes:
+  extra_group_attributes:
+    app: [service.name, service.namespace]

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -68,7 +68,7 @@ func getDefinitions(
 		map[attr.Name]Default{
 			attr.Instance:         true,
 			attr.Job:              true,
-			attr.ServiceNamespace: true,
+			attr.ServiceNamespace: false,
 		},
 		extraGroupAttributes[GroupPrometheus],
 	)

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -243,9 +243,10 @@ func getDefinitions(
 		extraGroupAttributes[GroupAppKube],
 	)
 
-	// ServiceName and ServiceNamespace are reported both as resource and metric attributes, as
-	// the OTEL definition requires that it is reported as resource attribute,
-	// but Cloud providers may extract this from the metric
+	// The semantic conventions define service.name and service.namespace as
+	// resource attributes, and OBI reports them there. They are also available
+	// as metric-level attributes for backends that read service identity off
+	// the series instead of joining through target_info.
 	appAttributes := NewAttrReportGroup(
 		false,
 		[]*AttrReportGroup{
@@ -254,8 +255,8 @@ func getDefinitions(
 			&appContainerAttributes,
 		},
 		map[attr.Name]Default{
-			attr.ServiceName:      true,
-			attr.ServiceNamespace: true,
+			attr.ServiceName:      false,
+			attr.ServiceNamespace: false,
 		},
 		extraGroupAttributes[GroupApp],
 	)

--- a/pkg/export/attributes/attr_defs_test.go
+++ b/pkg/export/attributes/attr_defs_test.go
@@ -95,3 +95,35 @@ func TestGoRuntimeDefinitions(t *testing.T) {
 		})
 	}
 }
+
+// service.name and service.namespace are resource attributes per the semantic
+// conventions, so they are not reported as metric attributes by default. The
+// `app` extra-attribute group restores them for backends that read service
+// identity off the series rather than joining through target_info.
+func TestServiceAttributesAreNotMetricDefaults(t *testing.T) {
+	section := HTTPServerDuration.Section
+
+	t.Run("off by default", func(t *testing.T) {
+		definitions := getDefinitions(0, NewGroupAttributes(nil))
+		definition, ok := definitions[section]
+		require.True(t, ok)
+
+		// still selectable, just not part of the default set
+		assert.Contains(t, definition.All(), attr.ServiceName)
+		assert.Contains(t, definition.All(), attr.ServiceNamespace)
+
+		assert.NotContains(t, definition.Default(), attr.ServiceName)
+		assert.NotContains(t, definition.Default(), attr.ServiceNamespace)
+	})
+
+	t.Run("restored by the app extra-attribute group", func(t *testing.T) {
+		definitions := getDefinitions(0, NewGroupAttributes(map[string][]attr.Name{
+			"app": {attr.ServiceName, attr.ServiceNamespace},
+		}))
+		definition, ok := definitions[section]
+		require.True(t, ok)
+
+		assert.Contains(t, definition.Default(), attr.ServiceName)
+		assert.Contains(t, definition.Default(), attr.ServiceNamespace)
+	})
+}

--- a/pkg/export/attributes/attr_defs_test.go
+++ b/pkg/export/attributes/attr_defs_test.go
@@ -103,18 +103,29 @@ func TestGoRuntimeDefinitions(t *testing.T) {
 func TestServiceAttributesAreNotMetricDefaults(t *testing.T) {
 	section := HTTPServerDuration.Section
 
-	t.Run("off by default", func(t *testing.T) {
-		definitions := getDefinitions(0, NewGroupAttributes(nil))
-		definition, ok := definitions[section]
-		require.True(t, ok)
+	// GroupPrometheus pulls in the prometheusAttributes subgroup, which used to
+	// re-enable service.namespace and made the default inconsistent between the
+	// two exporters.
+	for _, tc := range []struct {
+		name   string
+		groups AttrGroups
+	}{
+		{name: "otel", groups: 0},
+		{name: "prometheus", groups: GroupPrometheus},
+	} {
+		t.Run("off by default: "+tc.name, func(t *testing.T) {
+			definitions := getDefinitions(tc.groups, NewGroupAttributes(nil))
+			definition, ok := definitions[section]
+			require.True(t, ok)
 
-		// still selectable, just not part of the default set
-		assert.Contains(t, definition.All(), attr.ServiceName)
-		assert.Contains(t, definition.All(), attr.ServiceNamespace)
+			// still selectable, just not part of the default set
+			assert.Contains(t, definition.All(), attr.ServiceName)
+			assert.Contains(t, definition.All(), attr.ServiceNamespace)
 
-		assert.NotContains(t, definition.Default(), attr.ServiceName)
-		assert.NotContains(t, definition.Default(), attr.ServiceNamespace)
-	})
+			assert.NotContains(t, definition.Default(), attr.ServiceName)
+			assert.NotContains(t, definition.Default(), attr.ServiceNamespace)
+		})
+	}
 
 	t.Run("restored by the app extra-attribute group", func(t *testing.T) {
 		definitions := getDefinitions(0, NewGroupAttributes(map[string][]attr.Name{

--- a/pkg/export/attributes/attr_selector.go
+++ b/pkg/export/attributes/attr_selector.go
@@ -74,6 +74,8 @@ func NewGroupAttributes(groupAttrsCfg map[string][]attr.Name) GroupAttributes {
 
 func parseExtraAttrGroup(group string) (AttrGroups, error) {
 	switch group {
+	case "app":
+		return GroupApp, nil
 	case "k8s_app_meta":
 		return GroupAppKube, nil
 	default:

--- a/pkg/export/attributes/attr_selector_test.go
+++ b/pkg/export/attributes/attr_selector_test.go
@@ -205,8 +205,6 @@ func TestDefault_DBClientDuration(t *testing.T) {
 		attr.ErrorType,
 		attr.ServerAddr,
 		attr.ServerPort,
-		attr.ServiceName,
-		attr.ServiceNamespace,
 	}, p.For(DBClientDuration))
 }
 
@@ -282,9 +280,7 @@ func TestExtraGroupAttributes(t *testing.T) {
 		"k8s.statefulset.name",
 		"server.address",
 		"server.port",
-		"service.name",
 		"url.scheme",
-		"service.namespace",
 		"k8s.app.version",
 	}, p.For(HTTPServerRequestSize))
 }

--- a/pkg/export/prom/prom_jvm_test.go
+++ b/pkg/export/prom/prom_jvm_test.go
@@ -101,3 +101,49 @@ func TestRuntimeMetricsReporterDropsJVMServiceWithoutRuntimeFeature(t *testing.T
 		"jvm_memory_pool_name": "G1 Old Gen",
 	}))
 }
+
+// The service.name / service.namespace metric-attribute defaults are off, but
+// that only governs metric families whose labels come from AttrSelector. The
+// Prometheus runtime collectors build their label sets directly --
+// runtimeServiceLabels for JVM and Node.js, labelNamesTargetInfo for Go -- so
+// runtime series keep both labels regardless of the default and of
+// extra_group_attributes. This pins that exception until the runtime
+// collectors are routed through their attribute definitions.
+func TestRuntimeMetricsKeepServiceLabelsRegardlessOfDefaults(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	reporter, err := newReporter(
+		t.Context(),
+		&global.ContextInfo{Prometheus: &connector.PrometheusManager{}},
+		&PrometheusConfig{Registry: registry, TTL: time.Minute},
+		&perapp.GlobalMetricsConfig{Features: export.FeatureApplicationRuntime},
+		&attributes.SelectorConfig{},
+		request.UnresolvedNames{},
+		nil,
+		msg.NewQueue[exec.ProcessEvent](msg.ChannelBufferLen(1)),
+		nil,
+	)
+	require.NoError(t, err)
+
+	reporter.collectRuntimeMetrics([]runtimemetrics.RuntimeMetricSnapshot{{
+		Service: svc.Attrs{
+			UID:      svc.UID{Name: "orders", Namespace: "prod", Instance: "orders-1"},
+			Features: export.FeatureApplicationRuntime,
+		},
+		JVM: &runtimemetrics.JVMRuntimeMetricSnapshot{
+			Kind:       jvmruntime.JVMMetricMemoryUsed,
+			MemoryType: jvmruntime.JVMMemoryTypeHeap,
+			PoolName:   "G1 Old Gen",
+			GCPhase:    jvmruntime.JVMGCPhaseAfter,
+			ValueBytes: 42,
+		},
+	}})
+
+	metric := gatheredMetric(t, registry, "jvm_memory_used_bytes", map[string]string{
+		"service_name":         "orders",
+		"service_namespace":    "prod",
+		"service_instance_id":  "orders-1",
+		"jvm_memory_type":      "heap",
+		"jvm_memory_pool_name": "G1 Old Gen",
+	})
+	require.NotNil(t, metric, "runtime metrics must keep service_name and service_namespace")
+}

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -81,15 +81,15 @@ const (
 )
 
 // ExtraGroupAttributesMap defines additional attributes for attribute groups.
-// Currently only "k8s_app_meta" is supported as a key.
+// Supported keys are "app" and "k8s_app_meta".
 type ExtraGroupAttributesMap map[string][]attr.Name
 
 func (ExtraGroupAttributesMap) JSONSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
 		Type:        "object",
-		Description: "Map of attribute group names to arrays of attribute names. Only 'k8s_app_meta' is currently supported as a key.",
+		Description: "Map of attribute group names to arrays of attribute names. Supported keys are 'app' and 'k8s_app_meta'.",
 		PropertyNames: &jsonschema.Schema{
-			Enum: []any{"k8s_app_meta"},
+			Enum: []any{"app", "k8s_app_meta"},
 		},
 		AdditionalProperties: &jsonschema.Schema{
 			Type: "array",


### PR DESCRIPTION
## Summary

OBI reports `service.name` and `service.namespace` twice: as resource attributes, which the semantic conventions require, and again as metric-level attributes. This makes the metric-level copy opt-in instead of on by default, so what OBI emits matches the conventions.

The resource attributes are untouched.

## Restoring the old behaviour
For users who want/need this behavior:

`attributes.extra_group_attributes` gains an `app` group:

```yaml
attributes:
  extra_group_attributes:
    app: [service.name, service.namespace]
```

`attr_defs.go` already passed `extraGroupAttributes[GroupApp]` into the group, so only the parser case and the config schema enum were missing. Distributions that need the flattened form restore it with config rather than a patch.

## Scope

This affects both exporters, not just OTLP. `spanPromGetters` delegates to `spanOTELGetters`, so the two share one set of defaults, and there is no per-exporter attribute selection today.

**This is a breaking change for Prometheus users.** `service_name` and `service_namespace` are no longer emitted as labels on application metric series, so existing dashboards, alerts and recording rules that filter or group by them stop matching after an upgrade. Restore the previous behaviour with the `extra_group_attributes` config above, or migrate the queries to join through `target_info`.

Joining without the labels is possible today: the Prometheus exporter puts `job` and `instance` on `target_info`, and `job` is `namespace/name` (`svc.Attrs.Job()`), so service identity is recoverable.

### Families that keep the labels

Three code paths build their label sets directly instead of going through `AttrSelector`, so they are unaffected by this change and by `extra_group_attributes`:

| Family | Label source |
| --- | --- |
| `jvm_*`, `nodejs_*` runtime metrics | `runtimeServiceLabels()` |
| `go_*` runtime metrics | `labelNamesTargetInfo()` |
| `traces.span.metrics.*` data points | `spanMetricAttributes()` |

Work on them will be a follow up since it includes changes outside this scope

## Tests

- New coverage asserts the two attributes are absent from the default set, still present in the full set, and restored by the `app` group.
- Two existing expectations updated for the new default.
- `obi-config-perapp.yml` sets the restore key: that suite filters metric series by `service_name` and has no wildcard `select`, so it also keeps the opt-in path exercised in CI. The other suites that filter by `service_name` already use `select: {"*": {include: ["*"]}}`, which matches these attributes regardless of their default.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
