### PR TITLE
pids: keep blocked PIDs valid for a grace period so their final events drain

### DIFF
--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -33,9 +33,10 @@ var readNamespacePIDs = procs.FindNamespacedPids
 
 var pidsFilterMonoNow = timing.MonoTimeNow
 
-// removed entries are kept this long so spans captured before the removal can
-// still drain through the reader and batching stages; it only bounds memory,
-// admission is decided by comparing span timestamps against removedAt
+// Spans are filtered as soon as the ring buffer reader parses them, at most two
+// flush intervals after capture. Removed entries stay this long so those spans
+// still find their process; this only bounds memory, admission is decided by
+// comparing span timestamps against removedAt
 const pidRemovalRetention = 5 * time.Minute
 
 type PIDInfo struct {
@@ -45,6 +46,10 @@ type PIDInfo struct {
 	// zero while the process lives; the CLOCK_MONOTONIC instant it was
 	// blocked at otherwise, comparable against BPF span timestamps
 	removedAt time.Duration
+	// the process that held this pid before, kept while its spans may still arrive
+	previous *PIDInfo
+	// when that previous process was removed: older spans are not this process's
+	since time.Duration
 }
 
 type ServiceFilter interface {
@@ -98,18 +103,32 @@ func (pf *PIDsFilter) ValidPID(userPID app.PID, ns uint32, pidType PIDType) bool
 
 	if ns, nsExists := pf.current[ns]; nsExists {
 		if info, pidExists := ns[userPID]; pidExists {
-			return info.pidTypes&pidType != 0
+			// any generation still draining keeps its tracer type valid, so its
+			// last events are parsed; Filter then picks the generation by time
+			for g := &info; g != nil; g = g.previous {
+				if g.pidTypes&pidType != 0 {
+					return true
+				}
+			}
 		}
 	}
 
 	return false
 }
 
-// spans of a removed pid still pass if captured while it lived: they were
-// merely waiting in the reader and batching stages. Later timestamps mean the
-// pid was reused by a process we were not told to track
-func capturedWhileAllowed(info *PIDInfo, span *request.Span) bool {
-	return info.removedAt == 0 || span.End <= int64(info.removedAt)
+// The generation of the process that was alive when the span was captured, nil
+// when there is none: the span is newer than the last known process, or older
+// than the ones still kept
+func generationFor(info *PIDInfo, span *request.Span) *PIDInfo {
+	for g := info; g != nil; g = g.previous {
+		if g.removedAt != 0 && span.End > int64(g.removedAt) {
+			return nil
+		}
+		if g.since == 0 || span.End > int64(g.since) {
+			return g
+		}
+	}
+	return nil
 }
 
 func expired(info *PIDInfo, now time.Duration) bool {
@@ -163,15 +182,19 @@ func (pf *PIDsFilter) Filter(inputSpans []request.Span) []request.Span {
 		// If the namespace exist, we confirm that we are tracking the user PID that OBI
 		// saw. We don't check for the host pid, because we can't be sure of the number
 		// of container layers. The Host PID is always the outer most layer.
-		if info, pidExists := ns[span.Pid.UserPID]; pidExists && capturedWhileAllowed(&info, span) {
+		info, pidExists := ns[span.Pid.UserPID]
+		if !pidExists {
+			continue
+		}
+		if gen := generationFor(&info, span); gen != nil {
 			if pf.ignoreOtel {
-				pf.checkIfExportsOTel(info.fileInfo, span, pf.defaultOtlpGRPCPort)
+				pf.checkIfExportsOTel(gen.fileInfo, span, pf.defaultOtlpGRPCPort)
 			}
 			if pf.ignoreOtelSpan {
-				pf.checkIfExportsOTelSpanMetrics(info.fileInfo, span, pf.defaultOtlpGRPCPort)
+				pf.checkIfExportsOTelSpanMetrics(gen.fileInfo, span, pf.defaultOtlpGRPCPort)
 			}
 			// Must use the unsafe version to avoid massive memory pressure here.
-			inputSpans[i].Service = info.fileInfo.UnsafeServiceAttrs()
+			inputSpans[i].Service = gen.fileInfo.UnsafeServiceAttrs()
 			pf.normalizeTraceContext(&inputSpans[i])
 			outputSpans = append(outputSpans, inputSpans[i])
 		}
@@ -202,8 +225,10 @@ func (pf *PIDsFilter) addPID(pid app.PID, nsid uint32, fi *exec.FileInfo, t PIDT
 	for _, p := range allPids {
 		pidInfo := ns[p]
 		if pidInfo.removedAt != 0 {
-			// a reused pid must not inherit the previous process's tracer types
-			pidInfo = PIDInfo{}
+			// a reused pid starts a new generation; the old one is kept, not
+			// inherited, so its late spans still get its own attributes
+			previous := pidInfo
+			pidInfo = PIDInfo{previous: &previous, since: previous.removedAt}
 		}
 		pidInfo.fileInfo = fi
 		pidInfo.pidTypes |= t
@@ -243,7 +268,16 @@ func (pf *PIDsFilter) pruneExpired() {
 		for pid, info := range ns {
 			if expired(&info, now) {
 				delete(ns, pid)
+				continue
 			}
+			// older generations were removed earlier: cut the chain at the first expired one
+			for g := &info; g.previous != nil; g = g.previous {
+				if expired(g.previous, now) {
+					g.previous = nil
+					break
+				}
+			}
+			ns[pid] = info
 		}
 		if len(ns) == 0 {
 			delete(pf.current, nsid)

--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -6,6 +6,7 @@ package ebpfcommon // import "go.opentelemetry.io/obi/pkg/ebpf/common"
 import (
 	"log/slog"
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
@@ -29,10 +30,20 @@ const (
 // choose to filter traces using whether the User-space or Host-space PIDs
 var readNamespacePIDs = procs.FindNamespacedPids
 
+var pidsFilterNow = time.Now
+
+// blocked pids stay valid for this long: events of an exiting process can sit
+// in the kernel ring buffers up to the reader flush interval, and dropping the
+// pid immediately silently discards its final spans
+const pidRemovalGracePeriod = 5 * time.Second
+
 type PIDInfo struct {
 	fileInfo       *exec.FileInfo
 	pidTypes       PIDType
 	otherKnownPids []app.PID
+	// zero while the process lives; set when it is blocked, the entry then
+	// expires after pidRemovalGracePeriod
+	removedAt time.Time
 }
 
 type ServiceFilter interface {
@@ -86,11 +97,15 @@ func (pf *PIDsFilter) ValidPID(userPID app.PID, ns uint32, pidType PIDType) bool
 
 	if ns, nsExists := pf.current[ns]; nsExists {
 		if info, pidExists := ns[userPID]; pidExists {
-			return info.pidTypes&pidType != 0
+			return info.pidTypes&pidType != 0 && !expired(&info)
 		}
 	}
 
 	return false
+}
+
+func expired(info *PIDInfo) bool {
+	return !info.removedAt.IsZero() && pidsFilterNow().Sub(info.removedAt) > pidRemovalGracePeriod
 }
 
 func (pf *PIDsFilter) CurrentPIDs(t PIDType) map[uint32]map[app.PID]svc.Attrs {
@@ -101,7 +116,7 @@ func (pf *PIDsFilter) CurrentPIDs(t PIDType) map[uint32]map[app.PID]svc.Attrs {
 	for k, v := range pf.current {
 		cVal := map[app.PID]svc.Attrs{}
 		for kv, vv := range v {
-			if vv.pidTypes&t != 0 {
+			if vv.pidTypes&t != 0 && vv.removedAt.IsZero() {
 				cVal[kv] = vv.fileInfo.UnsafeServiceAttrs()
 			}
 		}
@@ -140,7 +155,7 @@ func (pf *PIDsFilter) Filter(inputSpans []request.Span) []request.Span {
 		// If the namespace exist, we confirm that we are tracking the user PID that OBI
 		// saw. We don't check for the host pid, because we can't be sure of the number
 		// of container layers. The Host PID is always the outer most layer.
-		if info, pidExists := ns[span.Pid.UserPID]; pidExists {
+		if info, pidExists := ns[span.Pid.UserPID]; pidExists && !expired(&info) {
 			if pf.ignoreOtel {
 				pf.checkIfExportsOTel(info.fileInfo, span, pf.defaultOtlpGRPCPort)
 			}
@@ -181,6 +196,7 @@ func (pf *PIDsFilter) addPID(pid app.PID, nsid uint32, fi *exec.FileInfo, t PIDT
 		pidInfo.fileInfo = fi
 		pidInfo.pidTypes |= t
 		pidInfo.otherKnownPids = allPids
+		pidInfo.removedAt = time.Time{}
 		ns[p] = pidInfo
 	}
 }
@@ -191,15 +207,35 @@ func (pf *PIDsFilter) removePID(pid app.PID, nsid uint32) {
 		return
 	}
 
-	if pidInfo, pidExists := ns[pid]; pidExists {
-		for _, otherPid := range pidInfo.otherKnownPids {
-			delete(ns, otherPid)
+	now := pidsFilterNow()
+	markAsRemoved := func(p app.PID) {
+		if info, ok := ns[p]; ok && info.removedAt.IsZero() {
+			info.removedAt = now
+			ns[p] = info
 		}
 	}
 
-	delete(ns, pid)
-	if len(ns) == 0 {
-		delete(pf.current, nsid)
+	if pidInfo, pidExists := ns[pid]; pidExists {
+		for _, otherPid := range pidInfo.otherKnownPids {
+			markAsRemoved(otherPid)
+		}
+	}
+	markAsRemoved(pid)
+
+	pf.pruneExpired()
+}
+
+// callers must hold the write lock
+func (pf *PIDsFilter) pruneExpired() {
+	for nsid, ns := range pf.current {
+		for pid, info := range ns {
+			if expired(&info) {
+				delete(ns, pid)
+			}
+		}
+		if len(ns) == 0 {
+			delete(pf.current, nsid)
+		}
 	}
 }
 

--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
+	"go.opentelemetry.io/obi/pkg/ebpf/timing"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/export/otel/idgen"
 	"go.opentelemetry.io/obi/pkg/internal/procs"
@@ -30,20 +31,20 @@ const (
 // choose to filter traces using whether the User-space or Host-space PIDs
 var readNamespacePIDs = procs.FindNamespacedPids
 
-var pidsFilterNow = time.Now
+var pidsFilterMonoNow = timing.MonoTimeNow
 
-// blocked pids stay valid for this long: events of an exiting process can sit
-// in the kernel ring buffers up to the reader flush interval, and dropping the
-// pid immediately silently discards its final spans
-const pidRemovalGracePeriod = 5 * time.Second
+// removed entries are kept this long so spans captured before the removal can
+// still drain through the reader and batching stages; it only bounds memory,
+// admission is decided by comparing span timestamps against removedAt
+const pidRemovalRetention = 5 * time.Minute
 
 type PIDInfo struct {
 	fileInfo       *exec.FileInfo
 	pidTypes       PIDType
 	otherKnownPids []app.PID
-	// zero while the process lives; set when it is blocked, the entry then
-	// expires after pidRemovalGracePeriod
-	removedAt time.Time
+	// zero while the process lives; the CLOCK_MONOTONIC instant it was
+	// blocked at otherwise, comparable against BPF span timestamps
+	removedAt time.Duration
 }
 
 type ServiceFilter interface {
@@ -97,15 +98,22 @@ func (pf *PIDsFilter) ValidPID(userPID app.PID, ns uint32, pidType PIDType) bool
 
 	if ns, nsExists := pf.current[ns]; nsExists {
 		if info, pidExists := ns[userPID]; pidExists {
-			return info.pidTypes&pidType != 0 && !expired(&info)
+			return info.pidTypes&pidType != 0
 		}
 	}
 
 	return false
 }
 
-func expired(info *PIDInfo) bool {
-	return !info.removedAt.IsZero() && pidsFilterNow().Sub(info.removedAt) > pidRemovalGracePeriod
+// spans of a removed pid still pass if captured while it lived: they were
+// merely waiting in the reader and batching stages. Later timestamps mean the
+// pid was reused by a process we were not told to track
+func capturedWhileAllowed(info *PIDInfo, span *request.Span) bool {
+	return info.removedAt == 0 || span.End <= int64(info.removedAt)
+}
+
+func expired(info *PIDInfo, now time.Duration) bool {
+	return info.removedAt != 0 && now-info.removedAt > pidRemovalRetention
 }
 
 func (pf *PIDsFilter) CurrentPIDs(t PIDType) map[uint32]map[app.PID]svc.Attrs {
@@ -116,7 +124,7 @@ func (pf *PIDsFilter) CurrentPIDs(t PIDType) map[uint32]map[app.PID]svc.Attrs {
 	for k, v := range pf.current {
 		cVal := map[app.PID]svc.Attrs{}
 		for kv, vv := range v {
-			if vv.pidTypes&t != 0 && vv.removedAt.IsZero() {
+			if vv.pidTypes&t != 0 && vv.removedAt == 0 {
 				cVal[kv] = vv.fileInfo.UnsafeServiceAttrs()
 			}
 		}
@@ -155,7 +163,7 @@ func (pf *PIDsFilter) Filter(inputSpans []request.Span) []request.Span {
 		// If the namespace exist, we confirm that we are tracking the user PID that OBI
 		// saw. We don't check for the host pid, because we can't be sure of the number
 		// of container layers. The Host PID is always the outer most layer.
-		if info, pidExists := ns[span.Pid.UserPID]; pidExists && !expired(&info) {
+		if info, pidExists := ns[span.Pid.UserPID]; pidExists && capturedWhileAllowed(&info, span) {
 			if pf.ignoreOtel {
 				pf.checkIfExportsOTel(info.fileInfo, span, pf.defaultOtlpGRPCPort)
 			}
@@ -193,10 +201,13 @@ func (pf *PIDsFilter) addPID(pid app.PID, nsid uint32, fi *exec.FileInfo, t PIDT
 
 	for _, p := range allPids {
 		pidInfo := ns[p]
+		if pidInfo.removedAt != 0 {
+			// a reused pid must not inherit the previous process's tracer types
+			pidInfo = PIDInfo{}
+		}
 		pidInfo.fileInfo = fi
 		pidInfo.pidTypes |= t
 		pidInfo.otherKnownPids = allPids
-		pidInfo.removedAt = time.Time{}
 		ns[p] = pidInfo
 	}
 }
@@ -207,9 +218,9 @@ func (pf *PIDsFilter) removePID(pid app.PID, nsid uint32) {
 		return
 	}
 
-	now := pidsFilterNow()
+	now := pidsFilterMonoNow()
 	markAsRemoved := func(p app.PID) {
-		if info, ok := ns[p]; ok && info.removedAt.IsZero() {
+		if info, ok := ns[p]; ok && info.removedAt == 0 {
 			info.removedAt = now
 			ns[p] = info
 		}
@@ -227,9 +238,10 @@ func (pf *PIDsFilter) removePID(pid app.PID, nsid uint32) {
 
 // callers must hold the write lock
 func (pf *PIDsFilter) pruneExpired() {
+	now := pidsFilterMonoNow()
 	for nsid, ns := range pf.current {
 		for pid, info := range ns {
-			if expired(&info) {
+			if expired(&info, now) {
 				delete(ns, pid)
 			}
 		}

--- a/pkg/ebpf/common/pids_test.go
+++ b/pkg/ebpf/common/pids_test.go
@@ -467,7 +467,17 @@ func TestBlockPIDDrainByCaptureTime(t *testing.T) {
 		"spans captured after the block must be dropped")
 }
 
-func TestBlockPIDReuseSameType(t *testing.T) {
+func serviceNamed(name string) *exec.FileInfo {
+	return exec.New(exec.Init{Service: svc.Attrs{UID: svc.UID{Name: name}}})
+}
+
+func spanOf(end int64) request.Span {
+	return request.Span{Pid: request.PidInfo{UserPID: 123, Namespace: 33}, End: end}
+}
+
+// a pid reused before the previous process's last spans arrived: every span
+// gets the attributes of the process that produced it
+func TestBlockPIDReuseKeepsPreviousGeneration(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
@@ -476,36 +486,71 @@ func TestBlockPIDReuseSameType(t *testing.T) {
 	t.Cleanup(func() { pidsFilterMonoNow = timing.MonoTimeNow })
 
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
-	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
+	pf.AllowPID(123, 33, serviceNamed("old"), PIDTypeKProbes)
+	preBlock := int64(now - time.Second)
 	pf.BlockPID(123, 33)
-	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
+	now += time.Second
+	pf.AllowPID(123, 33, serviceNamed("new"), PIDTypeKProbes)
+	postReuse := int64(now + time.Second)
 
-	now += pidRemovalRetention + time.Second
 	assert.True(t, pf.ValidPID(123, 33, PIDTypeKProbes), "re-allowed pid must not inherit the removal mark")
 
-	spans := pf.Filter([]request.Span{{Pid: request.PidInfo{UserPID: 123, Namespace: 33}, End: int64(now)}})
-	assert.Len(t, spans, 1, "spans of the new incarnation must pass")
+	spans := pf.Filter([]request.Span{spanOf(preBlock), spanOf(postReuse)})
+	require.Len(t, spans, 2)
+	assert.Equal(t, "old", spans[0].Service.UID.Name, "a span captured before the block belongs to the old process")
+	assert.Equal(t, "new", spans[1].Service.UID.Name, "a span captured after the reuse belongs to the new process")
+
+	// the old process keeps its attributes for as long as its spans may still arrive
+	now = time.Hour + pidRemovalRetention - time.Second
+	spans = pf.Filter([]request.Span{spanOf(preBlock)})
+	require.Len(t, spans, 1)
+	assert.Equal(t, "old", spans[0].Service.UID.Name, "a late span of the old process keeps its attributes")
+
+	// once the old generation expires only the new process is left
+	now += 2 * time.Second
+	pf.BlockPID(456, 33)
+	assert.Empty(t, pf.Filter([]request.Span{spanOf(preBlock)}), "expired generation no longer admits spans")
+	spans = pf.Filter([]request.Span{spanOf(postReuse)})
+	require.Len(t, spans, 1)
+	assert.Equal(t, "new", spans[0].Service.UID.Name)
 }
 
-// a pid reused by a process registered for a different tracer type must not
-// revive the previous process's types
+// a pid reused by a process registered for a different tracer type: the old
+// type stays valid only until the old spans have drained, and never re-enters
+// the BPF pid filter
 func TestBlockPIDReuseAcrossTypes(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
+	now := time.Hour
+	pidsFilterMonoNow = func() time.Duration { return now }
+	t.Cleanup(func() { pidsFilterMonoNow = timing.MonoTimeNow })
+
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
-	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
+	pf.AllowPID(123, 33, serviceNamed("old"), PIDTypeKProbes)
+	preBlock := int64(now - time.Second)
 	pf.BlockPID(123, 33)
-	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeGo)
+	now += time.Second
+	pf.AllowPID(123, 33, serviceNamed("new"), PIDTypeGo)
+	postReuse := int64(now + time.Second)
 
 	assert.True(t, pf.ValidPID(123, 33, PIDTypeGo))
-	assert.False(t, pf.ValidPID(123, 33, PIDTypeKProbes))
+	assert.True(t, pf.ValidPID(123, 33, PIDTypeKProbes), "the old process's type stays valid while its spans drain")
 
 	_, ok := pf.CurrentPIDs(PIDTypeKProbes)[33][123]
 	assert.False(t, ok, "the previous incarnation's tracer type must not re-enter the BPF filter")
-
 	_, ok = pf.CurrentPIDs(PIDTypeGo)[33][123]
 	assert.True(t, ok)
+
+	spans := pf.Filter([]request.Span{spanOf(preBlock), spanOf(postReuse)})
+	require.Len(t, spans, 2)
+	assert.Equal(t, "old", spans[0].Service.UID.Name)
+	assert.Equal(t, "new", spans[1].Service.UID.Name)
+
+	now = time.Hour + pidRemovalRetention + time.Second
+	pf.BlockPID(456, 33)
+	assert.False(t, pf.ValidPID(123, 33, PIDTypeKProbes), "the old type goes away with the old generation")
+	assert.True(t, pf.ValidPID(123, 33, PIDTypeGo))
 }
 
 func TestBlockPIDExcludedFromCurrentPIDs(t *testing.T) {

--- a/pkg/ebpf/common/pids_test.go
+++ b/pkg/ebpf/common/pids_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.opentelemetry.io/otel/trace"
 
@@ -74,24 +75,29 @@ func TestFilter_Block(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
+	now := time.Now()
+	pidsFilterNow = func() time.Time { return now }
+	t.Cleanup(func() { pidsFilterNow = time.Now })
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeGo)
 	pf.AllowPID(456, 33, exec.New(exec.Init{}), PIDTypeGo)
 	pf.BlockPID(123, 33)
+	now = now.Add(pidRemovalGracePeriod + time.Second)
 
 	// with the same namespace, it filters by user PID, as it is the PID
 	// that is seen by OBI's process discovery
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Equal(c, []request.Span{
-			{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
-		}, resetTraceContext(pf.Filter(spanSet)))
-	}, 10*time.Second, 10*time.Millisecond, "still haven't seen pid 123 as blocked")
+	assert.Equal(t, []request.Span{
+		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
+	}, resetTraceContext(pf.Filter(spanSet)))
 }
 
 func TestFilter_NewNSLater(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
+	now := time.Now()
+	pidsFilterNow = func() time.Time { return now }
+	t.Cleanup(func() { pidsFilterNow = time.Now })
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeGo)
 	pf.AllowPID(456, 33, exec.New(exec.Init{}), PIDTypeGo)
@@ -115,6 +121,7 @@ func TestFilter_NewNSLater(t *testing.T) {
 	}, resetTraceContext(pf.Filter(spanSet)))
 
 	pf.BlockPID(456, 33)
+	now = now.Add(pidRemovalGracePeriod + time.Second)
 
 	assert.Equal(t, []request.Span{
 		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
@@ -123,6 +130,7 @@ func TestFilter_NewNSLater(t *testing.T) {
 	}, resetTraceContext(pf.Filter(spanSet)))
 
 	pf.BlockPID(1000, 44)
+	now = now.Add(pidRemovalGracePeriod + time.Second)
 
 	assert.Equal(t, []request.Span{
 		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
@@ -303,6 +311,9 @@ func TestFilter_TriggersOTelSpanFiltering(t *testing.T) {
 }
 
 func TestFilter_Cleanup(t *testing.T) {
+	now := time.Now()
+	pidsFilterNow = func() time.Time { return now }
+	t.Cleanup(func() { pidsFilterNow = time.Now })
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		switch pid {
 		case 123:
@@ -349,6 +360,7 @@ func TestFilter_Cleanup(t *testing.T) {
 	pf.BlockPID(123, 33)
 	pf.BlockPID(456, 33)
 	pf.BlockPID(789, 33)
+	now = now.Add(pidRemovalGracePeriod + time.Second)
 
 	assert.False(t, pf.ValidPID(1, 33, PIDTypeGo))
 	assert.False(t, pf.ValidPID(2, 33, PIDTypeGo))
@@ -362,6 +374,9 @@ func TestFilter_PreservesMultiplePIDTypes(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid, pid + 1000}, nil
 	}
+	now := time.Now()
+	pidsFilterNow = func() time.Time { return now }
+	t.Cleanup(func() { pidsFilterNow = time.Now })
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 
 	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeGo)
@@ -387,6 +402,7 @@ func TestFilter_PreservesMultiplePIDTypes(t *testing.T) {
 	}
 
 	pf.BlockPID(123, 33)
+	now = now.Add(pidRemovalGracePeriod + time.Second)
 
 	assert.False(t, pf.ValidPID(123, 33, PIDTypeGo))
 	assert.False(t, pf.ValidPID(123, 33, PIDTypeKProbes))
@@ -411,4 +427,83 @@ func filterService(spans []request.Span) []svc.Attrs {
 	}
 
 	return result
+}
+
+// a blocked pid stays valid for the removal grace period so events still
+// buffered in the kernel ring buffers can drain, then turns invalid
+func TestBlockPIDGracePeriod(t *testing.T) {
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid}, nil
+	}
+	now := time.Now()
+	pidsFilterNow = func() time.Time { return now }
+	t.Cleanup(func() { pidsFilterNow = time.Now })
+
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
+	require.True(t, pf.ValidPID(123, 33, PIDTypeKProbes))
+
+	pf.BlockPID(123, 33)
+
+	assert.True(t, pf.ValidPID(123, 33, PIDTypeKProbes),
+		"events of an exited process must drain during the grace period")
+
+	spans := pf.Filter([]request.Span{{Pid: request.PidInfo{UserPID: 123, Namespace: 33}}})
+	assert.Len(t, spans, 1, "spans of an exited process must pass during the grace period")
+
+	now = now.Add(pidRemovalGracePeriod + time.Second)
+	assert.False(t, pf.ValidPID(123, 33, PIDTypeKProbes))
+	assert.Empty(t, pf.Filter([]request.Span{{Pid: request.PidInfo{UserPID: 123, Namespace: 33}}}))
+}
+
+func TestBlockPIDGraceRevival(t *testing.T) {
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid}, nil
+	}
+	now := time.Now()
+	pidsFilterNow = func() time.Time { return now }
+	t.Cleanup(func() { pidsFilterNow = time.Now })
+
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
+	pf.BlockPID(123, 33)
+	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
+
+	now = now.Add(pidRemovalGracePeriod + time.Second)
+	assert.True(t, pf.ValidPID(123, 33, PIDTypeKProbes), "re-allowed pid must not inherit the removal mark")
+}
+
+func TestBlockPIDGraceExcludedFromCurrentPIDs(t *testing.T) {
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid}, nil
+	}
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
+	pf.BlockPID(123, 33)
+
+	pids := pf.CurrentPIDs(PIDTypeKProbes)
+	_, ok := pids[33][123]
+	assert.False(t, ok, "pids marked as removed must not appear in the live view")
+}
+
+func TestBlockPIDPrunesExpiredTombstones(t *testing.T) {
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid}, nil
+	}
+	now := time.Now()
+	pidsFilterNow = func() time.Time { return now }
+	t.Cleanup(func() { pidsFilterNow = time.Now })
+
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
+	pf.AllowPID(456, 33, exec.New(exec.Init{}), PIDTypeKProbes)
+	pf.BlockPID(123, 33)
+
+	now = now.Add(pidRemovalGracePeriod + time.Second)
+	pf.BlockPID(456, 33)
+
+	pf.mux.RLock()
+	_, ok := pf.current[33][123]
+	pf.mux.RUnlock()
+	assert.False(t, ok, "entries past the grace period must be pruned")
 }

--- a/pkg/ebpf/common/pids_test.go
+++ b/pkg/ebpf/common/pids_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
+	"go.opentelemetry.io/obi/pkg/ebpf/timing"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 )
 
@@ -75,29 +76,31 @@ func TestFilter_Block(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
-	now := time.Now()
-	pidsFilterNow = func() time.Time { return now }
-	t.Cleanup(func() { pidsFilterNow = time.Now })
+	now := time.Hour
+	pidsFilterMonoNow = func() time.Duration { return now }
+	t.Cleanup(func() { pidsFilterMonoNow = timing.MonoTimeNow })
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeGo)
 	pf.AllowPID(456, 33, exec.New(exec.Init{}), PIDTypeGo)
 	pf.BlockPID(123, 33)
-	now = now.Add(pidRemovalGracePeriod + time.Second)
 
-	// with the same namespace, it filters by user PID, as it is the PID
-	// that is seen by OBI's process discovery
+	// spans captured after the block belong to a process we are not tracking
+	postBlock := int64(now + time.Second)
 	assert.Equal(t, []request.Span{
-		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}},
-	}, resetTraceContext(pf.Filter(spanSet)))
+		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}, End: postBlock},
+	}, resetTraceContext(pf.Filter([]request.Span{
+		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}, End: postBlock},
+		{Pid: request.PidInfo{UserPID: 456, HostPID: 666, Namespace: 33}, End: postBlock},
+	})))
 }
 
 func TestFilter_NewNSLater(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
-	now := time.Now()
-	pidsFilterNow = func() time.Time { return now }
-	t.Cleanup(func() { pidsFilterNow = time.Now })
+	now := time.Hour
+	pidsFilterMonoNow = func() time.Duration { return now }
+	t.Cleanup(func() { pidsFilterMonoNow = timing.MonoTimeNow })
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeGo)
 	pf.AllowPID(456, 33, exec.New(exec.Init{}), PIDTypeGo)
@@ -121,7 +124,8 @@ func TestFilter_NewNSLater(t *testing.T) {
 	}, resetTraceContext(pf.Filter(spanSet)))
 
 	pf.BlockPID(456, 33)
-	now = now.Add(pidRemovalGracePeriod + time.Second)
+	now += pidRemovalRetention + time.Second
+	pf.BlockPID(456, 33) // prunes the expired entry
 
 	assert.Equal(t, []request.Span{
 		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
@@ -130,7 +134,8 @@ func TestFilter_NewNSLater(t *testing.T) {
 	}, resetTraceContext(pf.Filter(spanSet)))
 
 	pf.BlockPID(1000, 44)
-	now = now.Add(pidRemovalGracePeriod + time.Second)
+	now += pidRemovalRetention + time.Second
+	pf.BlockPID(1000, 44) // prunes the expired entry
 
 	assert.Equal(t, []request.Span{
 		{Pid: request.PidInfo{UserPID: 123, HostPID: 333, Namespace: 33}},
@@ -311,9 +316,9 @@ func TestFilter_TriggersOTelSpanFiltering(t *testing.T) {
 }
 
 func TestFilter_Cleanup(t *testing.T) {
-	now := time.Now()
-	pidsFilterNow = func() time.Time { return now }
-	t.Cleanup(func() { pidsFilterNow = time.Now })
+	now := time.Hour
+	pidsFilterMonoNow = func() time.Duration { return now }
+	t.Cleanup(func() { pidsFilterMonoNow = timing.MonoTimeNow })
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		switch pid {
 		case 123:
@@ -360,7 +365,8 @@ func TestFilter_Cleanup(t *testing.T) {
 	pf.BlockPID(123, 33)
 	pf.BlockPID(456, 33)
 	pf.BlockPID(789, 33)
-	now = now.Add(pidRemovalGracePeriod + time.Second)
+	now += pidRemovalRetention + time.Second
+	pf.BlockPID(123, 33) // prunes the expired entries
 
 	assert.False(t, pf.ValidPID(1, 33, PIDTypeGo))
 	assert.False(t, pf.ValidPID(2, 33, PIDTypeGo))
@@ -374,9 +380,9 @@ func TestFilter_PreservesMultiplePIDTypes(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid, pid + 1000}, nil
 	}
-	now := time.Now()
-	pidsFilterNow = func() time.Time { return now }
-	t.Cleanup(func() { pidsFilterNow = time.Now })
+	now := time.Hour
+	pidsFilterMonoNow = func() time.Duration { return now }
+	t.Cleanup(func() { pidsFilterMonoNow = timing.MonoTimeNow })
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 
 	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeGo)
@@ -402,7 +408,8 @@ func TestFilter_PreservesMultiplePIDTypes(t *testing.T) {
 	}
 
 	pf.BlockPID(123, 33)
-	now = now.Add(pidRemovalGracePeriod + time.Second)
+	now += pidRemovalRetention + time.Second
+	pf.BlockPID(123, 33) // prunes the expired entries
 
 	assert.False(t, pf.ValidPID(123, 33, PIDTypeGo))
 	assert.False(t, pf.ValidPID(123, 33, PIDTypeKProbes))
@@ -429,51 +436,79 @@ func filterService(spans []request.Span) []svc.Attrs {
 	return result
 }
 
-// a blocked pid stays valid for the removal grace period so events still
-// buffered in the kernel ring buffers can drain, then turns invalid
-func TestBlockPIDGracePeriod(t *testing.T) {
+// spans captured before a pid was blocked must pass no matter how long the
+// reader and batching stages delay them; spans captured after the block
+// belong to a reused pid and must not
+func TestBlockPIDDrainByCaptureTime(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
-	now := time.Now()
-	pidsFilterNow = func() time.Time { return now }
-	t.Cleanup(func() { pidsFilterNow = time.Now })
+	now := time.Hour
+	pidsFilterMonoNow = func() time.Duration { return now }
+	t.Cleanup(func() { pidsFilterMonoNow = timing.MonoTimeNow })
 
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
 	require.True(t, pf.ValidPID(123, 33, PIDTypeKProbes))
 
+	preBlock := int64(now - time.Second)
 	pf.BlockPID(123, 33)
+	postBlock := int64(now + time.Second)
 
 	assert.True(t, pf.ValidPID(123, 33, PIDTypeKProbes),
-		"events of an exited process must drain during the grace period")
+		"events of an exited process must drain while its entry is retained")
 
-	spans := pf.Filter([]request.Span{{Pid: request.PidInfo{UserPID: 123, Namespace: 33}}})
-	assert.Len(t, spans, 1, "spans of an exited process must pass during the grace period")
+	now += pidRemovalRetention - time.Second
 
-	now = now.Add(pidRemovalGracePeriod + time.Second)
-	assert.False(t, pf.ValidPID(123, 33, PIDTypeKProbes))
-	assert.Empty(t, pf.Filter([]request.Span{{Pid: request.PidInfo{UserPID: 123, Namespace: 33}}}))
+	spans := pf.Filter([]request.Span{{Pid: request.PidInfo{UserPID: 123, Namespace: 33}, End: preBlock}})
+	assert.Len(t, spans, 1, "spans captured before the block must survive any delivery delay")
+
+	assert.Empty(t, pf.Filter([]request.Span{{Pid: request.PidInfo{UserPID: 123, Namespace: 33}, End: postBlock}}),
+		"spans captured after the block must be dropped")
 }
 
-func TestBlockPIDGraceRevival(t *testing.T) {
+func TestBlockPIDReuseSameType(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
-	now := time.Now()
-	pidsFilterNow = func() time.Time { return now }
-	t.Cleanup(func() { pidsFilterNow = time.Now })
+	now := time.Hour
+	pidsFilterMonoNow = func() time.Duration { return now }
+	t.Cleanup(func() { pidsFilterMonoNow = timing.MonoTimeNow })
 
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
 	pf.BlockPID(123, 33)
 	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
 
-	now = now.Add(pidRemovalGracePeriod + time.Second)
+	now += pidRemovalRetention + time.Second
 	assert.True(t, pf.ValidPID(123, 33, PIDTypeKProbes), "re-allowed pid must not inherit the removal mark")
+
+	spans := pf.Filter([]request.Span{{Pid: request.PidInfo{UserPID: 123, Namespace: 33}, End: int64(now)}})
+	assert.Len(t, spans, 1, "spans of the new incarnation must pass")
 }
 
-func TestBlockPIDGraceExcludedFromCurrentPIDs(t *testing.T) {
+// a pid reused by a process registered for a different tracer type must not
+// revive the previous process's types
+func TestBlockPIDReuseAcrossTypes(t *testing.T) {
+	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
+		return []app.PID{pid}, nil
+	}
+	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
+	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
+	pf.BlockPID(123, 33)
+	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeGo)
+
+	assert.True(t, pf.ValidPID(123, 33, PIDTypeGo))
+	assert.False(t, pf.ValidPID(123, 33, PIDTypeKProbes))
+
+	_, ok := pf.CurrentPIDs(PIDTypeKProbes)[33][123]
+	assert.False(t, ok, "the previous incarnation's tracer type must not re-enter the BPF filter")
+
+	_, ok = pf.CurrentPIDs(PIDTypeGo)[33][123]
+	assert.True(t, ok)
+}
+
+func TestBlockPIDExcludedFromCurrentPIDs(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
@@ -486,24 +521,28 @@ func TestBlockPIDGraceExcludedFromCurrentPIDs(t *testing.T) {
 	assert.False(t, ok, "pids marked as removed must not appear in the live view")
 }
 
-func TestBlockPIDPrunesExpiredTombstones(t *testing.T) {
+func TestBlockPIDPrunesExpiredEntries(t *testing.T) {
 	readNamespacePIDs = func(pid app.PID) ([]app.PID, error) {
 		return []app.PID{pid}, nil
 	}
-	now := time.Now()
-	pidsFilterNow = func() time.Time { return now }
-	t.Cleanup(func() { pidsFilterNow = time.Now })
+	now := time.Hour
+	pidsFilterMonoNow = func() time.Duration { return now }
+	t.Cleanup(func() { pidsFilterMonoNow = timing.MonoTimeNow })
 
 	pf := NewPIDsFilter(&services.DiscoveryConfig{}, slog.With("env", "testing"), &imetrics.NoopReporter{})
 	pf.AllowPID(123, 33, exec.New(exec.Init{}), PIDTypeKProbes)
 	pf.AllowPID(456, 33, exec.New(exec.Init{}), PIDTypeKProbes)
+	preBlock := int64(now - time.Second)
 	pf.BlockPID(123, 33)
 
-	now = now.Add(pidRemovalGracePeriod + time.Second)
+	now += pidRemovalRetention + time.Second
 	pf.BlockPID(456, 33)
 
 	pf.mux.RLock()
 	_, ok := pf.current[33][123]
 	pf.mux.RUnlock()
-	assert.False(t, ok, "entries past the grace period must be pruned")
+	assert.False(t, ok, "entries past the retention must be pruned")
+
+	assert.False(t, pf.ValidPID(123, 33, PIDTypeKProbes))
+	assert.Empty(t, pf.Filter([]request.Span{{Pid: request.PidInfo{UserPID: 123, Namespace: 33}, End: preBlock}}))
 }

--- a/pkg/ebpf/common/ringbuf.go
+++ b/pkg/ebpf/common/ringbuf.go
@@ -50,7 +50,7 @@ var readerFactory = func(rb *ebpf.Map) (ringBufReader, error) {
 // RecordParserFunc reads one ring buffer record and returns (item, ignore, err).
 type RecordParserFunc[T any] func(*ringbuf.Record) (T, bool, error)
 
-// BatchFilterFunc is an optional batch-level filter applied at flush time (nil = identity).
+// BatchFilterFunc is an optional filter applied to each parsed group before batching (nil = identity).
 type BatchFilterFunc[T any] func([]T) []T
 
 // ringBufForwarder[T] handles the common loop: read -> parse -> batch -> flush
@@ -69,9 +69,9 @@ type ringBufForwarder[T any] struct {
 	// Callers close over whatever context they need (parse ctx, filter, etc.)
 	parse RecordParserFunc[T]
 
-	// filter is optional batch-level filter applied at flush time (nil = identity)
-	// in appolly, filter the input spans, eliminating these from processes whose PID
-	// belong to a process that does not match the discovery policies
+	// filter is optional and runs on each parsed group before it enters the batch
+	// (nil = identity). In appolly it drops the spans of processes that do not match
+	// the discovery policies and decorates the rest while their process is still known
 	filter BatchFilterFunc[T]
 
 	// metrics is optional (nil = no-op)
@@ -95,7 +95,7 @@ func SharedRingbuf[T any](
 	cfg *config.EBPFTracer,
 	ringbuffer *ebpf.Map,
 	parse RecordParserFunc[T],
-	filter BatchFilterFunc[T], // nil = no batch filter
+	filter BatchFilterFunc[T], // nil = no filter
 	logger *slog.Logger,
 	metrics imetrics.Reporter,
 ) func(context.Context, []io.Closer, *msg.Queue[[]T]) {
@@ -123,7 +123,7 @@ func ForwardRingbuf[T any](
 	cfg *config.EBPFTracer,
 	ringbuffer *ebpf.Map,
 	parse RecordParserFunc[T],
-	filter BatchFilterFunc[T], // nil = no batch filter
+	filter BatchFilterFunc[T], // nil = no filter
 	logger *slog.Logger,
 	metrics imetrics.Reporter,
 	closers ...io.Closer,
@@ -337,13 +337,18 @@ func (rbf *ringBufForwarder[T]) parserLoop(
 			}
 		}
 
-		if len(parsed) == 0 {
+		// filter into a separate slice so parsed keeps its capacity across iterations
+		kept := parsed
+		if rbf.filter != nil {
+			kept = rbf.filter(parsed)
+		}
+		if len(kept) == 0 {
 			continue
 		}
 
 		// Lock once to enqueue the whole batch.
 		rbf.access.Lock()
-		for _, item := range parsed {
+		for _, item := range kept {
 			rbf.items[rbf.itemsLen] = item
 			rbf.itemsLen++
 			if rbf.itemsLen == rbf.cfg.BatchLength {
@@ -375,11 +380,7 @@ func (rbf *ringBufForwarder[T]) flushEvents(ctx context.Context, out *msg.Queue[
 	if rbf.metrics != nil {
 		rbf.metrics.TracerFlush(rbf.itemsLen)
 	}
-	batch := rbf.items[:rbf.itemsLen]
-	if rbf.filter != nil {
-		batch = rbf.filter(batch)
-	}
-	out.SendCtx(ctx, batch)
+	out.SendCtx(ctx, rbf.items[:rbf.itemsLen])
 	rbf.items = make([]T, rbf.cfg.BatchLength)
 	rbf.itemsLen = 0
 }

--- a/pkg/ebpf/common/ringbuf_test.go
+++ b/pkg/ebpf/common/ringbuf_test.go
@@ -137,6 +137,66 @@ func TestForwardRingbuf_Deadline(t *testing.T) {
 	assert.Equal(t, 7, metrics.flushedLen)
 }
 
+// spans are filtered and decorated when parsed, so a process going away before
+// its batch flushes does not strip the attributes of spans already waiting in it
+func TestForwardRingbuf_FiltersBeforeBatching(t *testing.T) {
+	ringBuf := replaceTestRingBuf()
+	forwardedMessagesQueue := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(100))
+	forwardedMessages := forwardedMessagesQueue.Subscribe()
+
+	var filtered atomic.Int32
+	var allowed atomic.Bool
+	allowed.Store(true)
+	filter := func(spans []request.Span) []request.Span {
+		defer filtered.Add(int32(len(spans)))
+		if !allowed.Load() {
+			return spans[:0]
+		}
+		for i := range spans {
+			spans[i].Service = svc.Attrs{UID: svc.UID{Name: "myService"}}
+		}
+		return spans
+	}
+	validPIDs := TestPidsFilter{services: map[app.PID]svc.Attrs{}}
+	cfg := &config.EBPFTracer{BatchLength: 10, BatchTimeout: 20 * time.Millisecond}
+	go ForwardRingbuf(
+		cfg,
+		nil,
+		func(r *ringbuf.Record) (request.Span, bool, error) {
+			return ReadBPFTraceAsSpan(nil, cfg, r, &validPIDs)
+		},
+		filter,
+		slog.With("test", "TestForwardRingbuf_FiltersBeforeBatching"),
+		&metricsReporter{},
+	)(t.Context(), forwardedMessagesQueue)
+
+	get := [7]byte{'G', 'E', 'T', 0, 0, 0, 0}
+	send := func(n int) {
+		for i := range n {
+			tr := HTTPRequestTrace{Type: 1, Method: get, ContentLength: int64(i)}
+			tr.Pid.HostPid = 1
+			ringBuf.events <- tr
+		}
+	}
+
+	// half a batch is parsed while the process is allowed
+	send(5)
+	require.Eventually(t, func() bool { return filtered.Load() == 5 }, testTimeout, time.Millisecond)
+
+	// the process goes away before the batch is full
+	allowed.Store(false)
+	send(5)
+
+	batch := testutil.ReadChannel(t, forwardedMessages, testTimeout)
+	for len(batch) < 5 {
+		batch = append(batch, testutil.ReadChannel(t, forwardedMessages, testTimeout)...)
+	}
+	require.Len(t, batch, 5, "only the spans parsed while the process was allowed are forwarded")
+	for i := range batch {
+		assert.Equal(t, "myService", batch[i].Service.UID.Name, "spans keep the attributes they got when parsed")
+	}
+}
+
 func TestForwardRingbuf_Close(t *testing.T) {
 	// GIVEN a ring buffer forwarder
 	ringBuf := replaceTestRingBuf()


### PR DESCRIPTION
## Summary

Events from an exiting process can sit in the ringbuffer for up to the reader flush interval (3s). Process exit triggers `BlockPID()`, which removes the PID immediately, so those buffered events were silently dropped by `ValidPID()`.

A short-lived client (one-shot mongosh, psql, a migration job) loses all of its spans; a long-running service loses the last ones before shutdown. Found while investigating the missing mongosh traces reported in #3146.

`BlockPID` now marks the entry instead of deleting it: events keep passing for a 5s grace period, then expire.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
