### PR TITLE
fix dns spans to conform to otel conventions + test coverage

### DIFF
--- a/internal/test/integration/components/dnsclient/dnsclient.py
+++ b/internal/test/integration/components/dnsclient/dnsclient.py
@@ -128,6 +128,11 @@ RESPONDER_DELAY_SECONDS = 0.5
 INTERLEAVED_SEND_NAME = "interleaved-send.test"
 INTERLEAVED_RECV_NAME = "interleaved-recv.test"
 
+# Answered by the delayed responder with more than one A record, so the reported
+# dns.answers has to carry each address separately.
+MULTI_ANSWER_NAME = "multi-answer.test"
+MULTI_ANSWER_ADDRESSES = ("10.1.2.3", "10.1.2.4", "10.1.2.5")
+
 # Discards whatever it is sent, so the send-side sequence gets an unrelated send
 # on the socket without also putting a datagram in its receive queue
 BLACKHOLE_PORT = 8126
@@ -145,13 +150,35 @@ def dns_query(name, txid):
     return header + encode_labels(name) + struct.pack("!HH", 1, 1)  # type A, class IN
 
 
-def dns_answer_for(query):
-    """A NOERROR response echoing the question, with one A record."""
-    header = query[:2] + struct.pack("!HHHHH", 0x8180, 1, 1, 0, 0)
-    question = query[12:]
+def a_record(address):
     # name as a pointer back to the question, then type A, class IN, ttl, rdlength
-    answer = b"\xc0\x0c" + struct.pack("!HHIH", 1, 1, 60, 4) + bytes([127, 0, 0, 1])
-    return header + question + answer
+    return (
+        b"\xc0\x0c"
+        + struct.pack("!HHIH", 1, 1, 60, 4)
+        + bytes(int(octet) for octet in address.split("."))
+    )
+
+
+def dns_answer_for(query):
+    """A NOERROR response echoing the question.
+
+    MULTI_ANSWER_NAME is answered with several A records; every other name gets
+    one. A lookup with more than one answer is the only case that distinguishes
+    dns.answers being reported as a list of addresses from a single joined
+    string, so the suite needs one to assert on.
+    """
+    name = query[12:-4]
+    addresses = (
+        MULTI_ANSWER_ADDRESSES
+        if name == encode_labels(MULTI_ANSWER_NAME)
+        else ("127.0.0.1",)
+    )
+
+    header = query[:2] + struct.pack("!HHHHH", 0x8180, 1, len(addresses), 0, 0)
+    question = query[12:]
+    answers = b"".join(a_record(address) for address in addresses)
+
+    return header + question + answers
 
 
 def run_responder():
@@ -197,12 +224,13 @@ def interleave_non_dns_receive(sock):
 
 
 def interleaved_lookup(name, txid, interleave, responder_ip):
-    """One lookup with an unrelated step between the query and its answer.
+    """One lookup, with an optional unrelated step between the query and its answer.
 
     The answer is taken with recv() rather than recvfrom(), so the kernel fills
     in no address and the answer carries no peer. Classifying it therefore rests
     entirely on the window the query opened, which the interleaved step must not
-    have closed.
+    have closed. Passing no interleave gives a plain lookup on the same kind of
+    socket.
     """
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.bind(("", 0))  # bound but never connected, so its tuple has no peer
@@ -210,13 +238,19 @@ def interleaved_lookup(name, txid, interleave, responder_ip):
 
     try:
         sock.sendto(dns_query(name, txid), (responder_ip, RESPONDER_PORT))
-        interleave(sock)
+        if interleave is not None:
+            interleave(sock)
         sock.recv(512)
-        print(f"interleaved lookup answered name={name}", flush=True)
+        print(f"lookup answered name={name}", flush=True)
     except OSError as err:
-        print(f"interleaved lookup failed name={name} error={err}", flush=True)
+        print(f"lookup failed name={name} error={err}", flush=True)
     finally:
         sock.close()
+
+
+def responder_lookup(name, txid, responder_ip):
+    """A plain lookup against the delayed responder, with nothing interleaved."""
+    interleaved_lookup(name, txid, None, responder_ip)
 
 
 def main():
@@ -258,6 +292,7 @@ def main():
         interleaved_lookup(
             INTERLEAVED_RECV_NAME, next_txid(), interleave_non_dns_receive, responder_ip
         )
+        responder_lookup(MULTI_ANSWER_NAME, next_txid(), responder_ip)
         time.sleep(INTERVAL_SECONDS)
 
 

--- a/internal/test/integration/configs/obi-config-dns.yml
+++ b/internal/test/integration/configs/obi-config-dns.yml
@@ -1,0 +1,10 @@
+otel_metrics_export:
+  endpoint: http://otelcol:4318
+otel_traces_export:
+  endpoint: http://otelcol:4318
+  instrumentations:
+    - dns
+attributes:
+  select:
+    "*":
+      include: ["*"]

--- a/internal/test/integration/docker-compose-dns-unconnected.yml
+++ b/internal/test/integration/docker-compose-dns-unconnected.yml
@@ -56,6 +56,9 @@ services:
       OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
       OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
       OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      # Pinned so the span assertions can name the service instead of relying on
+      # whatever the python executable is discovered as.
+      OTEL_EBPF_SERVICE_NAME: "dnsclient"
       OTEL_EBPF_METRICS_INTERVAL: "1s"
       OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
       OTEL_EBPF_LOG_LEVEL: "DEBUG"
@@ -78,7 +81,7 @@ services:
         limits:
           memory: 125M
     restart: unless-stopped
-    command: ["--config=/etc/otelcol-config/otelcol-config-weaver-no-jaeger.yml"]
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver.yml"]
     volumes:
       - ./configs/:/etc/otelcol-config
     ports:
@@ -89,8 +92,22 @@ services:
     depends_on:
       prometheus:
         condition: service_started
+      jaeger:
+        condition: service_started
       weaver:
         condition: service_healthy
+
+  # DNS spans are asserted directly, not just handed to weaver: weaver only
+  # judges the samples it receives, so a run that produced no DNS span at all
+  # would pass it silently.
+  jaeger:
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    command:
+      - "--set=service.telemetry.logs.level=debug"
 
   weaver:
     extends:

--- a/internal/test/integration/red_test_dns_unconnected.go
+++ b/internal/test/integration/red_test_dns_unconnected.go
@@ -4,12 +4,16 @@
 package integration // import "go.opentelemetry.io/obi/internal/test/integration"
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
 	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
 )
 
@@ -33,6 +37,17 @@ const (
 
 // The workload resolves the delayed responder's own name once, at startup
 const responderDNSName = "dnsresponder."
+
+// Answered by the delayed responder with several A records, so the span's
+// dns.answers has to carry each address separately rather than one joined
+// string. Kept in step with MULTI_ANSWER_NAME / MULTI_ANSWER_ADDRESSES in
+// components/dnsclient/dnsclient.py.
+const multiAnswerDNSName = "multi-answer.test."
+
+var multiAnswerDNSAddresses = []string{"10.1.2.3", "10.1.2.4", "10.1.2.5"}
+
+// Pinned via OTEL_EBPF_SERVICE_NAME in docker-compose-dns-unconnected.yml
+const dnsClientService = "dnsclient"
 
 // The Redis traffic that follows each lookup. Instrumenting it confirms the
 // workload is being watched, so a missing DNS metric means the lookup was not
@@ -159,6 +174,7 @@ func testDNSNoFalsePositiveFromNonDNSUDP(t *testing.T, namespace string) {
 		interleavedSendDNSName,
 		interleavedRecvDNSName,
 		responderDNSName,
+		multiAnswerDNSName,
 	}
 
 	for _, result := range results {
@@ -184,4 +200,46 @@ func testDNSInterleavedTraffic(t *testing.T) {
 
 func testDNSEveryLookupCounted(t *testing.T) {
 	testDNSMetricsCountEveryLookup(t, "integration-test")
+}
+
+func testDNSSpanAnswers(t *testing.T) {
+	testDNSSpanReportsEveryAnswer(t, dnsClientService)
+}
+
+// dns.answers is a span-only attribute, so the metric assertions above say
+// nothing about it. Weaver validates its type on whatever spans it receives,
+// but a run that emitted no DNS span at all would satisfy weaver silently —
+// hence a direct assertion that the span exists and carries every answer.
+func testDNSSpanReportsEveryAnswer(t *testing.T, service string) {
+	// The workload's multi-answer lookup, as OBI names a DNS span:
+	// "{question type} {question name}".
+	const operation = "A " + multiAnswerDNSName
+
+	var span jaeger.Span
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=" + service + "&operation=" + url.QueryEscape(operation))
+		require.NoError(ct, err)
+		defer resp.Body.Close()
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+
+		for i := range tq.Data {
+			if found := tq.Data[i].FindByOperationName(operation, ""); len(found) > 0 {
+				span = found[0]
+				return
+			}
+		}
+		assert.Fail(ct, "no DNS span yet", "operation %q on service %q", operation, service)
+	}, testTimeout, time.Second)
+
+	tag, ok := jaeger.FindIn(span.Tags, "dns.answers")
+	require.True(t, ok, "expected dns.answers on the DNS span")
+
+	// Reported as one joined string, this collapses to a single value that
+	// still contains the separator.
+	assert.ElementsMatch(t, multiAnswerDNSAddresses, jaeger.TagStringValues(tag),
+		"dns.answers must carry each resolved address as its own value")
 }

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -143,13 +143,14 @@ func TestSuite_DNSUnconnectedResolver(t *testing.T) {
 		compose.Env,
 		`OTEL_EBPF_EXECUTABLE_PATH=python`,
 		`OTEL_EBPF_OPEN_PORT=`,
-		`INSTRUMENTER_CONFIG_SUFFIX=-java`,
+		`INSTRUMENTER_CONFIG_SUFFIX=-dns`,
 	)
 	require.NoError(t, compose.Up())
 	t.Run("DNS RED metrics over an unconnected resolver socket", testDNSUnconnectedResolver)
 	t.Run("every DNS lookup is counted", testDNSEveryLookupCounted)
 	t.Run("non-DNS UDP is not reported as DNS", testDNSNoFalsePositive)
 	t.Run("unrelated traffic does not lose an outstanding lookup", testDNSInterleavedTraffic)
+	t.Run("DNS spans report every resolved address", testDNSSpanAnswers)
 	runWeaverValidation(t)
 	require.NoError(t, compose.Close())
 }

--- a/pkg/appolly/app/request/metric_attributes.go
+++ b/pkg/appolly/app/request/metric_attributes.go
@@ -351,8 +351,8 @@ func Instance(val string) attribute.KeyValue {
 	return attribute.Key(attr.Instance).String(val)
 }
 
-func DNSAnswers(val string) attribute.KeyValue {
-	return attribute.Key(attr.DNSAnswers).String(val)
+func DNSAnswers(vals []string) attribute.KeyValue {
+	return attribute.Key(attr.DNSAnswers).StringSlice(vals)
 }
 
 func DBResponseError(val string) attribute.KeyValue {

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -2232,6 +2232,16 @@ func (s *Span) IsDNSSpan() bool {
 	return s.Type == EventTypeDNS
 }
 
+// DNSAnswerList returns the addresses a DNS lookup resolved to, which the BPF
+// side accumulates into Statement as a comma-separated list.
+func (s *Span) DNSAnswerList() []string {
+	if s.Statement == "" {
+		return nil
+	}
+
+	return strings.Split(s.Statement, ",")
+}
+
 func (s *Span) isTracesExportURL() bool {
 	switch s.Type {
 	case EventTypeGRPCClient:

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -1592,7 +1592,9 @@ func traceAttributesSelectorInternal(span *request.Span, optionalAttrs map[attr.
 			request.ClientAddr(request.SpanHost(span)),
 			request.ServerAddr(request.PeerAsClient(span)),
 			request.ServerPort(span.HostPort),
-			request.DNSAnswers(span.Statement),
+		}
+		if answers := span.DNSAnswerList(); len(answers) > 0 {
+			attrs = append(attrs, request.DNSAnswers(answers))
 		}
 		// Include DNSQuestionName only when selected via attribute config.
 		if _, ok := optionalAttrs[attr.DNSQuestionName]; ok {

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -81,6 +81,34 @@ func TestTraceAttributesSelector_DNSQuestionName(t *testing.T) {
 	assert.Contains(t, optInAttrs, semconv.DNSQuestionName("example.com"))
 }
 
+func TestTraceAttributesSelector_DNSAnswers(t *testing.T) {
+	dnsSpan := func(statement string) *request.Span {
+		return &request.Span{
+			Type:      request.EventTypeDNS,
+			Method:    "A",
+			Path:      "example.com",
+			Statement: statement,
+		}
+	}
+
+	t.Run("emitted as a string array", func(t *testing.T) {
+		attrs := TraceAttributesSelector(dnsSpan("10.0.0.1,10.0.0.2"), map[attr.Name]struct{}{})
+		assert.Contains(t, attrs, attribute.StringSlice(string(attr.DNSAnswers), []string{"10.0.0.1", "10.0.0.2"}))
+	})
+
+	t.Run("single answer is still an array", func(t *testing.T) {
+		attrs := TraceAttributesSelector(dnsSpan("10.0.0.1"), map[attr.Name]struct{}{})
+		assert.Contains(t, attrs, attribute.StringSlice(string(attr.DNSAnswers), []string{"10.0.0.1"}))
+	})
+
+	t.Run("omitted when the lookup resolved nothing", func(t *testing.T) {
+		attrs := TraceAttributesSelector(dnsSpan(""), map[attr.Name]struct{}{})
+		for _, kv := range attrs {
+			assert.NotEqual(t, attr.DNSAnswers, attr.Name(kv.Key))
+		}
+	})
+}
+
 func TestTraceAttributesSelector_GraphQLDocumentSelection(t *testing.T) {
 	const document = `mutation ChangeEmail { updateUser(email: "secret@example.com") { id } }`
 

--- a/pkg/transform/name_resolver.go
+++ b/pkg/transform/name_resolver.go
@@ -325,13 +325,16 @@ func (nr *NameResolver) resolveIP(ip string) string {
 }
 
 func (nr *NameResolver) handleRDNS(span *request.Span) {
-	if span.Statement != "" {
-		nr.logger.Debug("storing reverse DNS record in cache", "ips", span.Statement, "name", span.Path)
-		ips := strings.Split(span.Statement, ",")
-		for _, ip := range ips {
-			if isValidRDNS(ip) {
-				nr.dnsCache.StorePair(ip, span.Path)
-			}
+	ips := span.DNSAnswerList()
+	if len(ips) == 0 {
+		return
+	}
+
+	nr.logger.Debug("storing reverse DNS record in cache", "ips", ips, "name", span.Path)
+
+	for _, ip := range ips {
+		if isValidRDNS(ip) {
+			nr.dnsCache.StorePair(ip, span.Path)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

`dns.answers` was emitted as one comma-joined string, but semconv declares it as `string[]` — weaver live-check reports it as a `type_mismatch` violation. It now emits as a string array, and is omitted entirely when a lookup resolved nothing (NXDOMAIN, SERVFAIL) instead of sending an empty array.

`Span.DNSAnswerList()` is now the only place the joined `Statement` field is read back; `name_resolver.go` had its own duplicate split.

## Why this wasn't caught

The DNS suite is weaver-wired, but DNS traces are off in the default instrumentation set and the suite's OBI config exported metrics only — so no DNS span ever reached weaver, and `dns.answers` is span-only.

## Coverage

Weaver alone isn't enough here: it only judges the samples it receives, so a run producing no DNS span would pass it silently. The suite now asserts the span directly.

- The suite exports DNS traces, so spans reach the weaver tap.
- The test responder answers `multi-answer.test` with three A records. A single-answer lookup can't distinguish an array from a joined string.
- `testDNSSpanAnswers` asserts through Jaeger that the span carries all three addresses as separate values. This fails on the old behaviour, where they collapse into one.
- Unit tests cover multi-answer, single-answer, and the omit-when-empty case.

`OTEL_EBPF_SERVICE_NAME` is pinned in the compose so the span query names the service rather than relying on how the python executable is discovered. The existing metric assertions filter on `service_namespace` only, so they're unaffected.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
