### PR TITLE
fix: reject inverted ranges in IntEnum port and PID config parsing

### DIFF
--- a/pkg/appolly/services/criteria.go
+++ b/pkg/appolly/services/criteria.go
@@ -270,6 +270,9 @@ func (p *IntEnum) UnmarshalText(text []byte) error {
 		e.Start, _ = strconv.Atoi(strings.TrimSpace(parts[0]))
 		if len(parts) > 1 {
 			e.End, _ = strconv.Atoi(strings.TrimSpace(parts[1]))
+			if e.End < e.Start {
+				return fmt.Errorf("invalid int enum %q: range end must not be less than start (%d-%d)", val, e.Start, e.End)
+			}
 		}
 		p.Ranges = append(p.Ranges, e)
 	}

--- a/pkg/appolly/services/criteria_test.go
+++ b/pkg/appolly/services/criteria_test.go
@@ -119,6 +119,7 @@ func TestYAMLParse_IntEnum_Errors(t *testing.T) {
 	assertError("unfinished range", "32,15-")
 	assertError("unstarted range", "12,-13")
 	assertError("wrong symbols", "1,2,*3,4")
+	assertError("inverted range", "9000-1000")
 }
 
 func TestYAMLParse_OtherAttrs(t *testing.T) {


### PR DESCRIPTION
## Summary

`open_port` / `target_pids` / `open_ports:` accept inverted ranges like `9000-1000`, no error. 
regex only checks shape, not order, so it just matches nothing, forever, silently

Repro:
```
OTEL_EBPF_OPEN_PORT=9000-1000 bin/obi
```
Parses fine, but `Matches()` needs `Start <= n <= End`, never true when `End < Start`. 
OBI starts up happy and just never finds the process

Fix: reject `end < start` in `UnmarshalText`, next to the existing syntax check. 
Added a test case for it

## Validation

- [x] I have read and followed the contributing guidelines
- [ ] not a core feature change, no docs update needed
