### PR TITLE
emit obi.queue.capacity.ratio and declare it

### DIFF
--- a/internal/test/integration/internal_metrics_otel_test.go
+++ b/internal/test/integration/internal_metrics_otel_test.go
@@ -32,6 +32,7 @@ var internalMetricsExpected = []string{
 	"obi_bpf_map_entries",                 // gauge, per eBPF map
 	"obi_bpf_map_max_entries",             // gauge, per eBPF map
 	"obi_bpf_probe_latency_seconds_count", // histogram, needs BPF run-stats + traffic
+	"obi_queue_capacity_ratio",            // gauge, per pipeline queue subscriber
 }
 
 // TestInternalOTelMetrics brings up OBI with internal_metrics.exporter=otel so

--- a/pkg/appolly/discover/finder.go
+++ b/pkg/appolly/discover/finder.go
@@ -85,7 +85,7 @@ func (pf *ProcessFinder) Start(ctx context.Context, opts ...ProcessFinderStartOp
 		opt(&startConfig)
 	}
 
-	tracerEvents := msgh.QueueFromConfig[Event[*ebpf.Instrumentable]](pf.cfg, "tracerEvents")
+	tracerEvents := msgh.QueueFromConfig[Event[*ebpf.Instrumentable]](pf.cfg, pf.ctxInfo.Metrics, "tracerEvents")
 
 	logDeprecationAndConflicts(pf.cfg)
 	configCriteria := FindingCriteria(pf.cfg)
@@ -95,7 +95,7 @@ func (pf *ProcessFinder) Start(ctx context.Context, opts ...ProcessFinderStartOp
 	}
 
 	swi := swarm.Instancer{}
-	processEvents := msgh.QueueFromConfig[[]Event[ProcessAttrs]](pf.cfg, "processEvents")
+	processEvents := msgh.QueueFromConfig[[]Event[ProcessAttrs]](pf.cfg, pf.ctxInfo.Metrics, "processEvents")
 
 	var addedPIDsCh <-chan []app.PID
 	if appDynamicSelector != nil {
@@ -104,13 +104,13 @@ func (pf *ProcessFinder) Start(ctx context.Context, opts ...ProcessFinderStartOp
 	swi.Add(swarm.DirectInstance(ProcessWatcherFunc(pf.cfg, pf.ebpfEventContext, processEvents, configCriteria, addedPIDsCh)),
 		swarm.WithID("ProcessWatcher"))
 
-	kubeEnrichedEvents := msgh.QueueFromConfig[[]Event[ProcessAttrs]](pf.cfg, "kubeEnrichedEvents")
+	kubeEnrichedEvents := msgh.QueueFromConfig[[]Event[ProcessAttrs]](pf.cfg, pf.ctxInfo.Metrics, "kubeEnrichedEvents")
 	swi.Add(WatcherKubeEnricherProvider(pf.ctxInfo.K8sInformer, processEvents, kubeEnrichedEvents),
 		swarm.WithID("WatcherKubeEnricher"))
 
 	enrichedProcessEvents := startConfig.enrichedProcessEvents
 	if enrichedProcessEvents == nil {
-		enrichedProcessEvents = msgh.QueueFromConfig[[]Event[ProcessAttrs]](pf.cfg, "enrichedProcessEvents")
+		enrichedProcessEvents = msgh.QueueFromConfig[[]Event[ProcessAttrs]](pf.cfg, pf.ctxInfo.Metrics, "enrichedProcessEvents")
 	}
 	swi.Add(DockerDiscoveryDecoratorProvider(
 		pf.ctxInfo.K8sInformer,
@@ -119,31 +119,31 @@ func (pf *ProcessFinder) Start(ctx context.Context, opts ...ProcessFinderStartOp
 		enrichedProcessEvents,
 	), swarm.WithID("DockerDiscoveryDecoratorProvider"))
 
-	langEnrichedEvents := msgh.QueueFromConfig[[]Event[ProcessAttrs]](pf.cfg, "languageEnrichedEvents")
+	langEnrichedEvents := msgh.QueueFromConfig[[]Event[ProcessAttrs]](pf.cfg, pf.ctxInfo.Metrics, "languageEnrichedEvents")
 	swi.Add(LanguageDecoratorProvider(
 		pf.cfg,
 		enrichedProcessEvents,
 		langEnrichedEvents,
 	), swarm.WithID("LanguageDecoratorProvider"))
 
-	criteriaFilteredEvents := msgh.QueueFromConfig[[]Event[ProcessMatch]](pf.cfg, "criteriaFilteredEvents")
+	criteriaFilteredEvents := msgh.QueueFromConfig[[]Event[ProcessMatch]](pf.cfg, pf.ctxInfo.Metrics, "criteriaFilteredEvents")
 	swi.Add(criteriaMatcherProvider(pf.cfg, langEnrichedEvents, criteriaFilteredEvents, configCriteria, startConfig.dynamicPIDSelector),
 		swarm.WithID("CriteriaMatcher"))
 	swi.Add(dynamicMatcherProvider(langEnrichedEvents, criteriaFilteredEvents, appDynamicSelector),
 		swarm.WithID("DynamicMatcher"))
 
-	executableTypes := msgh.QueueFromConfig[[]Event[ebpf.Instrumentable]](pf.cfg, "executableTypes")
+	executableTypes := msgh.QueueFromConfig[[]Event[ebpf.Instrumentable]](pf.cfg, pf.ctxInfo.Metrics, "executableTypes")
 	swi.Add(ExecTyperProvider(pf.cfg, pf.ctxInfo.Metrics, pf.ctxInfo.K8sInformer, criteriaFilteredEvents, executableTypes),
 		swarm.WithID("ExecTyper"))
 
-	processContextEnrichedTypes := msgh.QueueFromConfig[[]Event[ebpf.Instrumentable]](pf.cfg, "processContextEnrichedTypes")
+	processContextEnrichedTypes := msgh.QueueFromConfig[[]Event[ebpf.Instrumentable]](pf.cfg, pf.ctxInfo.Metrics, "processContextEnrichedTypes")
 	swi.Add(ProcessContextDecoratorProvider(pf.cfg.Discovery.ProcessContextPollInterval, executableTypes, processContextEnrichedTypes),
 		swarm.WithID("ProcessContextDecorator"))
 
 	// we could subscribe ContainerStoreUpdater directly to the executableTypes queue and not providing any output channel
 	// but forcing the output by the executableTypesReplica channel only after the Container DB has been updated
 	// prevents race conditions in later stages of the pipeline
-	storedExecutableTypes := msgh.QueueFromConfig[[]Event[ebpf.Instrumentable]](pf.cfg, "storedExecutableTypes")
+	storedExecutableTypes := msgh.QueueFromConfig[[]Event[ebpf.Instrumentable]](pf.cfg, pf.ctxInfo.Metrics, "storedExecutableTypes")
 	swi.Add(ContainerStoreUpdaterProvider(pf.ctxInfo.K8sInformer, processContextEnrichedTypes, storedExecutableTypes),
 		swarm.WithID("ContainerStoreUpdater"))
 

--- a/pkg/appolly/instrumenter.go
+++ b/pkg/appolly/instrumenter.go
@@ -74,14 +74,14 @@ func newGraphBuilder(
 	// Second, we register instancers for each pipe node, as well as communication queues between them
 	// TODO: consider moving the queues to a public structure so when OBI is used as library, other components can
 	// listen to the messages and expanding the Pipeline
-	tracesReaderToRouter := msg2.QueueFromConfig[[]request.Span](config, "tracesReaderToRouter")
+	tracesReaderToRouter := msg2.QueueFromConfig[[]request.Span](config, ctxInfo.Metrics, "tracesReaderToRouter")
 	swi.Add(traces.ReadFromChannel(&traces.ReadDecorator{
 		InstanceID:      config.Attributes.InstanceID,
 		TracesInput:     tracesCh,
 		DecoratedTraces: tracesReaderToRouter,
 	}), swarm.WithID("ReadFromChannel"))
 
-	routerToKubeDecorator := msg2.QueueFromConfig[[]request.Span](config, "routerToKubeDecorator",
+	routerToKubeDecorator := msg2.QueueFromConfig[[]request.Span](config, ctxInfo.Metrics, "routerToKubeDecorator",
 		// make sure that we are able to wait for the informer sync timeout before failing the pipeline
 		// if a message gets bocked while the Kube decorator starts
 		msg.SendTimeout(max(config.Attributes.Kubernetes.InformersSyncTimeout, config.ChannelSendTimeout)))
@@ -93,19 +93,19 @@ func newGraphBuilder(
 
 	// We connect the Kube and Docker metadata decorators in series, but only
 	// one of them will be active at the same time and bypass the other's queues
-	kubeToContainerDecorator := msg2.QueueFromConfig[[]request.Span](config, "kubeToContainerDecorator")
+	kubeToContainerDecorator := msg2.QueueFromConfig[[]request.Span](config, ctxInfo.Metrics, "kubeToContainerDecorator")
 	swi.Add(transform.KubeDecoratorProvider(
 		ctxInfo, &config.Attributes.Kubernetes,
 		routerToKubeDecorator, kubeToContainerDecorator,
 	), swarm.WithID("KubeDecorator"))
 
-	containerDecoratorToNameResolver := msg2.QueueFromConfig[[]request.Span](config, "containerDecoratorToNameResolver")
+	containerDecoratorToNameResolver := msg2.QueueFromConfig[[]request.Span](config, ctxInfo.Metrics, "containerDecoratorToNameResolver")
 	swi.Add(transform.DockerDecoratorProvider(
 		ctxInfo,
 		kubeToContainerDecorator, containerDecoratorToNameResolver,
 	), swarm.WithID("DockerDecorator"))
 
-	nameResolverToAttrFilter := msg2.QueueFromConfig[[]request.Span](config, "nameResolverToAttrFilter")
+	nameResolverToAttrFilter := msg2.QueueFromConfig[[]request.Span](config, ctxInfo.Metrics, "nameResolverToAttrFilter")
 	swi.Add(transform.NameResolutionProvider(ctxInfo, config.NameResolver,
 		containerDecoratorToNameResolver, nameResolverToAttrFilter),
 		swarm.WithID("NameResolution"))
@@ -114,9 +114,9 @@ func newGraphBuilder(
 	// own exporters, otherwise we create a new queue
 	exportableSpans := ctxInfo.OverrideAppExportQueue
 	if exportableSpans == nil {
-		exportableSpans = msg2.QueueFromConfig[[]request.Span](config, "exportableSpans")
+		exportableSpans = msg2.QueueFromConfig[[]request.Span](config, ctxInfo.Metrics, "exportableSpans")
 	}
-	attrFilteredSpans := msg2.QueueFromConfig[[]request.Span](config, "attrFilteredSpans")
+	attrFilteredSpans := msg2.QueueFromConfig[[]request.Span](config, ctxInfo.Metrics, "attrFilteredSpans")
 	swi.Add(filter.ByAttribute(config.Filters.Application,
 		nil,
 		selectorCfg.ExtraGroupAttributesCfg,
@@ -124,7 +124,7 @@ func newGraphBuilder(
 		nameResolverToAttrFilter,
 		attrFilteredSpans),
 		swarm.WithID("AttributesFilter"))
-	instrumentationFilteredSpans := msg2.QueueFromConfig[[]request.Span](config, "instrumentationFilteredSpans")
+	instrumentationFilteredSpans := msg2.QueueFromConfig[[]request.Span](config, ctxInfo.Metrics, "instrumentationFilteredSpans")
 	swi.Add(InstrumentationFilterSpanGate(
 		config.Filters.ApplicationByInstrumentation,
 		selectorCfg.ExtraGroupAttributesCfg,
@@ -132,7 +132,7 @@ func newGraphBuilder(
 		attrFilteredSpans,
 		instrumentationFilteredSpans,
 	), swarm.WithID("InstrumentationFilterSpanGate"))
-	gatedSpans := msg2.QueueFromConfig[[]request.Span](config, "gatedSpans")
+	gatedSpans := msg2.QueueFromConfig[[]request.Span](config, ctxInfo.Metrics, "gatedSpans")
 	swi.Add(DynamicSignalSpanGate(ctxInfo.DynamicPIDSelector, instrumentationFilteredSpans, gatedSpans),
 		swarm.WithID("DynamicSignalSpanGate"))
 	swi.Add(SettleConditionalParents(config.EBPF.MaxTransactionTime, gatedSpans, exportableSpans),
@@ -174,7 +174,7 @@ func setupMetricsSubPipeline(
 	jointMetricsConfig *perapp.GlobalMetricsConfig,
 	runtimeMetrics *msg.Queue[[]runtimemetrics.RuntimeMetricSnapshot],
 ) {
-	metricsProcessEvents := msg2.QueueFromConfig[exec.ProcessEvent](config, "metricsProcessEvents")
+	metricsProcessEvents := msg2.QueueFromConfig[exec.ProcessEvent](config, ctxInfo.Metrics, "metricsProcessEvents")
 	swi.Add(DynamicSignalProcessEventGate(ctxInfo.DynamicPIDSelector, processEventsCh, metricsProcessEvents),
 		swarm.WithID("DynamicSignalProcessEventGate"))
 
@@ -186,7 +186,7 @@ func setupMetricsSubPipeline(
 
 	var spanNameAggregatedMetrics *msg.Queue[[]request.Span]
 	if jointMetricsConfig.Features.AppOrSpan() || jointMetricsConfig.Features.ServiceGraph() {
-		spanNameAggregatedMetrics = msg2.QueueFromConfig[[]request.Span](config, "spanNameAggregatedMetrics")
+		spanNameAggregatedMetrics = msg2.QueueFromConfig[[]request.Span](config, ctxInfo.Metrics, "spanNameAggregatedMetrics")
 
 		swi.Add(transform.SpanNameLimiter(transform.SpanNameLimiterConfig{
 			Limit:      config.Attributes.MetricSpanNameAggregationLimit,
@@ -220,7 +220,7 @@ func setupMetricsSubPipeline(
 
 	runtimeMetricsInput := runtimeMetrics
 	if runtimeMetrics != nil {
-		gatedRuntimeMetrics := msg2.QueueFromConfig[[]runtimemetrics.RuntimeMetricSnapshot](config, "gatedRuntimeMetrics")
+		gatedRuntimeMetrics := msg2.QueueFromConfig[[]runtimemetrics.RuntimeMetricSnapshot](config, ctxInfo.Metrics, "gatedRuntimeMetrics")
 		swi.Add(DynamicSignalRuntimeMetricsGate(ctxInfo.DynamicPIDSelector, runtimeMetrics, gatedRuntimeMetrics),
 			swarm.WithID("DynamicSignalRuntimeMetricsGate"))
 		runtimeMetricsInput = gatedRuntimeMetrics

--- a/pkg/internal/appolly/appolly.go
+++ b/pkg/internal/appolly/appolly.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/traces"
 	"go.opentelemetry.io/obi/pkg/ebpf"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	msg2 "go.opentelemetry.io/obi/pkg/internal/helpers/msg"
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/pipe/global"
@@ -68,12 +69,12 @@ type finisher struct {
 func New(ctx context.Context, ctxInfo *global.ContextInfo, config *obi.Config) (*Instrumenter, error) {
 	setupFeatureContextInfo(ctx, ctxInfo, config)
 
-	tracesInput := msg2.QueueFromConfig[[]request.Span](config, "tracesInput")
+	tracesInput := msg2.QueueFromConfig[[]request.Span](config, ctxInfo.Metrics, "tracesInput")
 
 	swi := &swarm.Instancer{}
 
-	processEventsInput := msg2.QueueFromConfig[exec.ProcessEvent](config, "processEventsInput")
-	processEventsHostDecorated := msg2.QueueFromConfig[exec.ProcessEvent](config, "processEventsHostDecorated")
+	processEventsInput := msg2.QueueFromConfig[exec.ProcessEvent](config, ctxInfo.Metrics, "processEventsInput")
+	processEventsHostDecorated := msg2.QueueFromConfig[exec.ProcessEvent](config, ctxInfo.Metrics, "processEventsHostDecorated")
 
 	swi.Add(traces.HostProcessEventDecoratorProvider(
 		&config.Attributes.InstanceID,
@@ -81,7 +82,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *obi.Config) (
 		processEventsHostDecorated,
 	), swarm.WithID("HostProcessEventDecoratorProvider"))
 
-	processEventsKubeDecorated := msg2.QueueFromConfig[exec.ProcessEvent](config, "processEventsKubeDecorated")
+	processEventsKubeDecorated := msg2.QueueFromConfig[exec.ProcessEvent](config, ctxInfo.Metrics, "processEventsKubeDecorated")
 	swi.Add(transform.KubeProcessEventDecoratorProvider(
 		ctxInfo,
 		&config.Attributes.Kubernetes,
@@ -89,14 +90,14 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *obi.Config) (
 		processEventsKubeDecorated,
 	), swarm.WithID("KubeProcessEventDecoratorProvider"))
 
-	processEventsDockerDecorated := msg2.QueueFromConfig[exec.ProcessEvent](config, "processEventsDockerDecorated")
+	processEventsDockerDecorated := msg2.QueueFromConfig[exec.ProcessEvent](config, ctxInfo.Metrics, "processEventsDockerDecorated")
 	swi.Add(transform.DockerProcessEventDecoratorProvider(
 		ctxInfo,
 		processEventsKubeDecorated,
 		processEventsDockerDecorated,
 	), swarm.WithID("DockerProcessEventDecorator"))
 
-	runtimeMetrics := newRuntimeMetricsQueue(config)
+	runtimeMetrics := newRuntimeMetricsQueue(config, ctxInfo.Metrics)
 	ebpfEventContext := ebpfcommon.NewEBPFEventContext()
 
 	bp, err := appolly.Build(ctx, config, ctxInfo, tracesInput, processEventsDockerDecorated, runtimeMetrics)
@@ -126,7 +127,7 @@ func New(ctx context.Context, ctxInfo *global.ContextInfo, config *obi.Config) (
 	return instr, nil
 }
 
-func newRuntimeMetricsQueue(config *obi.Config) *msg.Queue[[]runtimemetrics.RuntimeMetricSnapshot] {
+func newRuntimeMetricsQueue(config *obi.Config, metrics imetrics.Reporter) *msg.Queue[[]runtimemetrics.RuntimeMetricSnapshot] {
 	jointMetricsConfig := appolly.JoinMetricsConfig(config)
 	runtimeMetricsEnabled := runtimemetrics.EnabledFeatures(jointMetricsConfig.Features)
 
@@ -136,7 +137,7 @@ func newRuntimeMetricsQueue(config *obi.Config) *msg.Queue[[]runtimemetrics.Runt
 		return nil
 	}
 
-	return msg2.QueueFromConfig[[]runtimemetrics.RuntimeMetricSnapshot](config, "runtimeMetrics")
+	return msg2.QueueFromConfig[[]runtimemetrics.RuntimeMetricSnapshot](config, metrics, "runtimeMetrics")
 }
 
 // FindAndInstrument searches in background for any new executable matching the

--- a/pkg/internal/helpers/msg/queue_from_cfg.go
+++ b/pkg/internal/helpers/msg/queue_from_cfg.go
@@ -4,16 +4,28 @@
 package msg // import "go.opentelemetry.io/obi/pkg/internal/helpers/msg"
 
 import (
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/obi"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 
-// QueueFromConfig creates a standard msg.Queue[T] from the given OBI config
-func QueueFromConfig[T any](config *obi.Config, name string, overrideQueueOpts ...msg.QueueOpts) *msg.Queue[T] {
+// QueueFromConfig creates a standard msg.Queue[T] from the given OBI config.
+// The reporter receives the queue buffer utilization of every subscriber.
+// It accepts a nil reporter because some callers build a global.ContextInfo
+// without a Metrics reporter; those queues keep the default no-op gauge.
+func QueueFromConfig[T any](
+	config *obi.Config,
+	metrics imetrics.Reporter,
+	name string,
+	overrideQueueOpts ...msg.QueueOpts,
+) *msg.Queue[T] {
 	queueOpts := []msg.QueueOpts{
 		msg.ChannelBufferLen(config.ChannelBufferLen),
 		msg.SendTimeout(config.ChannelSendTimeout),
 		msg.Name(name),
+	}
+	if metrics != nil {
+		queueOpts = append(queueOpts, msg.InternalMetrics(metrics))
 	}
 	if config.ChannelSendTimeoutPanic {
 		queueOpts = append(queueOpts, msg.PanicOnSendTimeout())

--- a/pkg/internal/helpers/msg/queue_from_cfg_test.go
+++ b/pkg/internal/helpers/msg/queue_from_cfg_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/testutil"
 	"go.opentelemetry.io/obi/pkg/obi"
 	msg2 "go.opentelemetry.io/obi/pkg/pipe/msg"
@@ -30,7 +31,7 @@ func TestBasicOptions(t *testing.T) {
 	queue := QueueFromConfig[int](&obi.Config{
 		ChannelBufferLen:   1,
 		ChannelSendTimeout: 5 * time.Millisecond,
-	}, "basicQueue")
+	}, imetrics.NoopReporter{}, "basicQueue")
 	out := queue.Subscribe(msg2.SubscriberName("test-out"))
 
 	ctx, c := context.WithTimeout(t.Context(), timeout)
@@ -71,7 +72,7 @@ func TestBasicOptions_PanicOnBlock(t *testing.T) {
 		ChannelBufferLen:        1,
 		ChannelSendTimeout:      5 * time.Millisecond,
 		ChannelSendTimeoutPanic: true,
-	}, "basicQueue")
+	}, imetrics.NoopReporter{}, "basicQueue")
 	out := queue.Subscribe(msg2.SubscriberName("test-out"))
 
 	ctx, c := context.WithTimeout(t.Context(), timeout)
@@ -92,6 +93,75 @@ func TestBasicOptions_PanicOnBlock(t *testing.T) {
 	assert.Equal(t, 123, testutil.ReadChannel(t, out, timeout))
 	// but the second message was never delivered
 	testutil.ChannelEmpty(t, out, 10*time.Millisecond)
+}
+
+// bufferUtilizationRecorder captures the queue buffer utilization samples the
+// factory is expected to wire into every queue it builds.
+type bufferUtilizationRecorder struct {
+	imetrics.NoopReporter
+
+	mt      sync.Mutex
+	samples map[string]float64
+}
+
+func (r *bufferUtilizationRecorder) QueueBufferUtilization(subscriber string, ratio float64) {
+	r.mt.Lock()
+	defer r.mt.Unlock()
+	if r.samples == nil {
+		r.samples = map[string]float64{}
+	}
+	r.samples[subscriber] = ratio
+}
+
+func (r *bufferUtilizationRecorder) sample(subscriber string) (float64, bool) {
+	r.mt.Lock()
+	defer r.mt.Unlock()
+	ratio, ok := r.samples[subscriber]
+	return ratio, ok
+}
+
+// The queue buffer utilization gauge defaults to a no-op, so it only reports
+// when the factory passes the reporter down to msg.InternalMetrics. Without
+// that wiring obi.queue.capacity.ratio is declared but never emitted.
+func TestQueueFromConfig_ReportsBufferUtilization(t *testing.T) {
+	recorder := &bufferUtilizationRecorder{}
+
+	queue := QueueFromConfig[int](&obi.Config{
+		ChannelBufferLen:   2,
+		ChannelSendTimeout: time.Second,
+	}, recorder, "utilizationQueue")
+	out := queue.Subscribe(msg2.SubscriberName("test-subscriber"))
+
+	ctx, c := context.WithTimeout(t.Context(), timeout)
+	defer c()
+	// the gauge is sampled before each send, so the second send observes the
+	// message left in the buffer by the first one: 1 unread message out of 2
+	queue.SendCtx(ctx, 123)
+	queue.SendCtx(ctx, 456)
+
+	ratio, ok := recorder.sample("test-subscriber")
+	require.True(t, ok, "no utilization reported for the subscriber")
+	assert.InDelta(t, 0.5, ratio, 0.0001)
+
+	assert.Equal(t, 123, testutil.ReadChannel(t, out, timeout))
+	assert.Equal(t, 456, testutil.ReadChannel(t, out, timeout))
+}
+
+// A nil reporter must leave the default no-op gauge in place instead of binding a
+// method on a nil interface: several in-repo callers build a global.ContextInfo
+// without a Metrics reporter, so sending must not panic.
+func TestQueueFromConfig_NilReporter(t *testing.T) {
+	queue := QueueFromConfig[int](&obi.Config{
+		ChannelBufferLen:   1,
+		ChannelSendTimeout: time.Second,
+	}, nil, "nilReporterQueue")
+	out := queue.Subscribe(msg2.SubscriberName("test-out"))
+
+	ctx, c := context.WithTimeout(t.Context(), timeout)
+	defer c()
+	queue.SendCtx(ctx, 123)
+
+	assert.Equal(t, 123, testutil.ReadChannel(t, out, timeout))
 }
 
 // avoids some race conditions between the queue and the eventually clauses

--- a/pkg/internal/netolly/flow/protocol_filter.go
+++ b/pkg/internal/netolly/flow/protocol_filter.go
@@ -46,14 +46,14 @@ func newFilter(allowed, excluded []string, input, output *msg.Queue[[]*ebpf.Reco
 		if err != nil {
 			return nil, err
 		}
-		return &protocolFilter{isAllowed: allow, input: input.Subscribe(), output: output}, nil
+		return &protocolFilter{isAllowed: allow, input: input.Subscribe(msg.SubscriberName("flow.ProtocolFilter")), output: output}, nil
 	}
 	// if the allowed list is empty, any interface is allowed except if it matches the exclusion list
 	exclude, err := excluder(excluded)
 	if err != nil {
 		return nil, err
 	}
-	return &protocolFilter{isAllowed: exclude, input: input.Subscribe(), output: output}, nil
+	return &protocolFilter{isAllowed: exclude, input: input.Subscribe(msg.SubscriberName("flow.ProtocolFilter")), output: output}, nil
 }
 
 func (pf *protocolFilter) nodeLoop(_ context.Context) {

--- a/pkg/netolly/agent/pipeline.go
+++ b/pkg/netolly/agent/pipeline.go
@@ -54,52 +54,52 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 	// Start nodes: those generating flow records (reading them from eBPF).
 	// ebpfFlows has two senders (MapTracer and RingBufTracer), so it must only be
 	// closed after both of them have marked it closeable, hence ClosingAttempts(2).
-	ebpfFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "ebpfFlows", msg.ClosingAttempts(2))
+	ebpfFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "ebpfFlows", msg.ClosingAttempts(2))
 	swi.Add(swarm.DirectInstance(newMapTracer(f, ebpfFlows)), swarm.WithID("MapTracer"))
 	swi.Add(swarm.DirectInstance(newRingBufTracer(f, ebpfFlows)), swarm.WithID("RingBufTracer"))
 
 	// Middle nodes: transforming flow records and passing them to the next stage in the pipeline.
 	// Many of the nodes here are not mandatory. It's decision of each InstanceFunc to decide
 	// whether the node needs to be instantiated or just bypass their input/output channels.
-	protocolFilteredEbpfFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "protocolFilteredEbpfFlows")
+	protocolFilteredEbpfFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "protocolFilteredEbpfFlows")
 	swi.Add(flow.ProtocolFilterProvider(f.cfg.NetworkFlows.Protocols, f.cfg.NetworkFlows.ExcludeProtocols,
 		ebpfFlows, protocolFilteredEbpfFlows), swarm.WithID("ProtocolFilter"))
 
-	dedupedEBPFFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "dedupedEBPFFlows")
+	dedupedEBPFFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "dedupedEBPFFlows")
 	swi.Add(flow.DeduperProvider(&flow.Deduper{
 		Type:               f.cfg.NetworkFlows.Deduper,
 		FCTTL:              f.cfg.NetworkFlows.DeduperFCTTL,
 		CacheActiveTimeout: f.cfg.NetworkFlows.CacheActiveTimeout,
 	}, protocolFilteredEbpfFlows, dedupedEBPFFlows), swarm.WithID("FlowDeduper"))
 
-	kubeDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "kubeDecoratedFlows")
+	kubeDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "kubeDecoratedFlows")
 	swi.Add(k8s.MetadataDecoratorProvider(ctx, &f.cfg.Attributes.Kubernetes, f.ctxInfo.K8sInformer,
 		recordAttrs,
 		dedupedEBPFFlows, kubeDecoratedFlows), swarm.WithID("K8sMetadataDecorator"))
 
-	dnsDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "dnsDecoratedFlows")
+	dnsDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "dnsDecoratedFlows")
 	swi.Add(rdns.ReverseDNSProvider(&f.cfg.NetworkFlows.ReverseDNS, recordAttrs, &f.cfg.EBPF,
 		kubeDecoratedFlows, dnsDecoratedFlows),
 		swarm.WithID("ReverseDNS"))
 
-	geoIPDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "geoIPDecoratedFlows")
+	geoIPDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "geoIPDecoratedFlows")
 	swi.Add(geoip.GeoIPProvider(&f.cfg.NetworkFlows.GeoIP,
 		recordAttrs,
 		dnsDecoratedFlows, geoIPDecoratedFlows), swarm.WithID("GeoIPDecorator"))
 
-	cidrDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "cidrDecoratedFlows")
+	cidrDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "cidrDecoratedFlows")
 	swi.Add(cidr.DecoratorProvider(f.cfg.NetworkFlows.CIDRs,
 		recordAttrs,
 		geoIPDecoratedFlows, cidrDecoratedFlows),
 		swarm.WithID("CIDRDecorator"))
 
-	commonDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "commonDecoratedFlows")
+	commonDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "commonDecoratedFlows")
 	swi.Add(decorate.Decorate(f.agentIP,
 		recordAttrs,
 		cidrDecoratedFlows, commonDecoratedFlows),
 		swarm.WithID("CommonFlowDecorator"))
 
-	decoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "decoratedFlows")
+	decoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "decoratedFlows")
 	swi.Add(func(_ context.Context) (swarm.RunFunc, error) {
 		// If deduper is enabled, we know that interfaces are unset.
 		// As an optimization, we just pass here an empty-string interface namer
@@ -112,12 +112,12 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 		return flow.Decorate(ifaceNamer, commonDecoratedFlows, decoratedFlows), nil
 	}, swarm.WithID("FlowDecorator"))
 
-	dynamicFilteredFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "dynamicFilteredFlows")
+	dynamicFilteredFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "dynamicFilteredFlows")
 	var dynamicSelector selection.PIDSelector
 	if f.ctxInfo.DynamicPIDSelector != nil {
 		dynamicSelector = f.ctxInfo.DynamicPIDSelector.NetworkMetrics()
 	}
-	dynamicDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "dynamicDecoratedFlows")
+	dynamicDecoratedFlows := msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "dynamicDecoratedFlows")
 	swi.Add(dynamicpid.MetadataDecoratorProvider(f.ctxInfo.DynamicPIDSelector, dynamicSelector,
 		f.ctxInfo.K8sInformer, recordAttrs, decoratedFlows, dynamicDecoratedFlows),
 		swarm.WithID("DynamicPIDMetadataDecorator"))
@@ -127,7 +127,7 @@ func (f *Flows) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 
 	filteredFlows := f.ctxInfo.OverrideNetExportQueue
 	if filteredFlows == nil {
-		filteredFlows = msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, "filteredFlows")
+		filteredFlows = msgh.QueueFromConfig[[]*ebpf.Record](f.cfg, f.ctxInfo.Metrics, "filteredFlows")
 	}
 	swi.Add(filter.ByAttribute(
 		f.cfg.Filters.Network,

--- a/pkg/pipe/msg/queue.go
+++ b/pkg/pipe/msg/queue.go
@@ -224,7 +224,7 @@ func (s *sink[T]) send(ctx context.Context, o T, route []string) {
 	var blocked []dst[T]
 	for _, d := range dsts {
 		// report channel len/capacity ratio metrics
-		d.gauge(d.name, float64(len(d.ch)+1)/float64(cap(d.ch)))
+		d.gauge(d.name, float64(len(d.ch))/float64(cap(d.ch)))
 		select {
 		case <-ctx.Done():
 			return
@@ -298,6 +298,9 @@ func (q *Queue[T]) Subscribe(options ...SubscribeOpt) <-chan T {
 	opts := subscribeOpts{subscriber: unnamed}
 	for _, opt := range options {
 		opt(&opts)
+	}
+	if opts.subscriber == unnamed {
+		opts.subscriber = q.cfg.name
 	}
 
 	// hold bypassMu so q.sink can't be re-pointed by a concurrent Bypass while we subscribe to it

--- a/pkg/pipe/msg/queue_test.go
+++ b/pkg/pipe/msg/queue_test.go
@@ -450,19 +450,20 @@ func TestMetrics_CapacityGauge(t *testing.T) {
 		// working channel reads values as long as they arrive
 		testutil.ReadChannel(t, working, timeout)
 	}
-	// working gauge will stay in 0.01 (metric is not cleaned up after last read)
-	assert.InDelta(t, 0.01, fp.GaugeFor("working"), 0.0001)
-	// blocked gauge reaches 0.5
-	assert.InDelta(t, 0.5, fp.GaugeFor("blocked"), 0.0001)
+	// working gauge stays at 0: its buffer is drained between sends
+	assert.True(t, fp.Reported("working"))
+	assert.InDelta(t, 0.0, fp.GaugeFor("working"), 0.0001)
+	// blocked gauge reaches 0.49: 49 unread messages out of 100 when the 50th is sent
+	assert.InDelta(t, 0.49, fp.GaugeFor("blocked"), 0.0001)
 
 	// send another batch
 	for i := 0; i < 50; i++ {
 		q.SendCtx(t.Context(), i)
 		testutil.ReadChannel(t, working, timeout)
 	}
-	assert.InDelta(t, 0.01, fp.GaugeFor("working"), 0.0001)
-	// blocked gauge reaches 1 (max)
-	assert.InDelta(t, 1.0, fp.GaugeFor("blocked"), 0.0001)
+	assert.InDelta(t, 0.0, fp.GaugeFor("working"), 0.0001)
+	// blocked gauge reaches 0.99: 99 unread messages out of 100 when the 100th is sent
+	assert.InDelta(t, 0.99, fp.GaugeFor("blocked"), 0.0001)
 
 	// unblock blocked subscriber --> metrics should go to lowest value
 	for i := 0; i < 100; i++ {
@@ -470,8 +471,8 @@ func TestMetrics_CapacityGauge(t *testing.T) {
 	}
 	// send a last message to force update of metrics
 	q.SendCtx(t.Context(), 0)
-	assert.InDelta(t, 0.01, fp.GaugeFor("blocked"), 0.0001)
-	assert.InDelta(t, 0.01, fp.GaugeFor("working"), 0.0001)
+	assert.InDelta(t, 0.0, fp.GaugeFor("blocked"), 0.0001)
+	assert.InDelta(t, 0.0, fp.GaugeFor("working"), 0.0001)
 }
 
 func TestMetrics_Labels(t *testing.T) {
@@ -483,6 +484,7 @@ func TestMetrics_Labels(t *testing.T) {
 			InternalMetrics(fp))
 		q.Subscribe(SubscriberName("subs"))
 		q.SendCtx(t.Context(), 1)
+		q.SendCtx(t.Context(), 2)
 		assert.InDelta(t, 0.2, fp.GaugeFor("subs"), 0.001)
 	})
 	t.Run("bypasses subscription", func(t *testing.T) {
@@ -507,12 +509,46 @@ func TestMetrics_Labels(t *testing.T) {
 
 		h1.SendCtx(t.Context(), 1)
 		h1.SendCtx(t.Context(), 2)
-		assert.InDelta(t, 0.4, fp.GaugeFor("subs1"), 0.001)
-		assert.InDelta(t, 0.4, fp.GaugeFor("subs2"), 0.001)
-		assert.InDelta(t, 0.4, fp.GaugeFor("subs3"), 0.001)
-		assert.InDelta(t, 0.4, fp.GaugeFor("subs4"), 0.001)
-		assert.InDelta(t, 0.4, fp.GaugeFor("subs5"), 0.001)
+		assert.InDelta(t, 0.2, fp.GaugeFor("subs1"), 0.001)
+		assert.InDelta(t, 0.2, fp.GaugeFor("subs2"), 0.001)
+		assert.InDelta(t, 0.2, fp.GaugeFor("subs3"), 0.001)
+		assert.InDelta(t, 0.2, fp.GaugeFor("subs4"), 0.001)
+		assert.InDelta(t, 0.2, fp.GaugeFor("subs5"), 0.001)
 	})
+}
+
+// A saturated queue must report exactly 1: the ratio is what tells operators the
+// consuming stage cannot keep up, so it may neither overshoot nor be clamped away.
+func TestMetrics_CapacityGauge_Saturation(t *testing.T) {
+	fp := &fakeProvisioner{gauges: map[string]float64{}}
+	q := NewQueue[int](
+		Name("head"),
+		ChannelBufferLen(5),
+		InternalMetrics(fp))
+	full := q.Subscribe(SubscriberName("full"))
+
+	// nobody reads: the 5th send observes 4 unread messages out of 5
+	for i := 0; i < 5; i++ {
+		q.SendCtx(t.Context(), i)
+	}
+	assert.InDelta(t, 0.8, fp.GaugeFor("full"), 0.0001)
+
+	// the buffer is now full, so this send samples a saturated queue and then blocks
+	sent := make(chan struct{})
+	go func() {
+		q.SendCtx(t.Context(), 5)
+		close(sent)
+	}()
+	assert.Eventually(t, func() bool {
+		return fp.GaugeFor("full") == 1.0
+	}, timeout, time.Millisecond, "a full queue must report a ratio of exactly 1")
+
+	// drain, unblocking the pending sender
+	for i := 0; i < 6; i++ {
+		testutil.ReadChannel(t, full, timeout)
+	}
+	testutil.ReadChannel(t, sent, timeout)
+	assert.LessOrEqual(t, fp.GaugeFor("full"), 1.0)
 }
 
 // implementation of fake gauge metrics for testing
@@ -526,6 +562,13 @@ func (fp *fakeProvisioner) GaugeFor(subscriber string) float64 {
 	fp.mt.RLock()
 	defer fp.mt.RUnlock()
 	return fp.gauges[subscriber]
+}
+
+func (fp *fakeProvisioner) Reported(subscriber string) bool {
+	fp.mt.RLock()
+	defer fp.mt.RUnlock()
+	_, ok := fp.gauges[subscriber]
+	return ok
 }
 
 func (fp *fakeProvisioner) QueueBufferUtilization(name string, val float64) {

--- a/pkg/statsolly/agent/pipeline.go
+++ b/pkg/statsolly/agent/pipeline.go
@@ -46,38 +46,38 @@ func (s *Stats) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 
 	swi := &swarm.Instancer{}
 	// Start nodes: those generating stats (reading them from eBPF)
-	ebpfStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "ebpfStats")
+	ebpfStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, s.ctxInfo.Metrics, "ebpfStats")
 	swi.Add(swarm.DirectInstance(newRingBufTracer(s, ebpfStats)), swarm.WithID("RingBufTracer"))
 
 	// Middle nodes: transforming stats and passing them to the next stage in the pipeline.
 	// Many of the nodes here are not mandatory. It's decision of each InstanceFunc to decide
 	// whether the node needs to be instantiated or just bypass their input/output channels.
-	kubeDecoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "kubeDecoratedStats")
+	kubeDecoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, s.ctxInfo.Metrics, "kubeDecoratedStats")
 	swi.Add(k8s.MetadataDecoratorProvider(ctx, &s.cfg.Attributes.Kubernetes, s.ctxInfo.K8sInformer,
 		statAttrs, ebpfStats, kubeDecoratedStats), swarm.WithID("K8sMetadataDecorator"))
 
-	dnsDecoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "dnsDecoratedStats")
+	dnsDecoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, s.ctxInfo.Metrics, "dnsDecoratedStats")
 	swi.Add(rdns.ReverseDNSProvider(&s.cfg.Stats.ReverseDNS, statAttrs, &s.cfg.EBPF, kubeDecoratedStats, dnsDecoratedStats),
 		swarm.WithID("ReverseDNS"))
 
-	geoIPDecoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "geoIPDecoratedStats")
+	geoIPDecoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, s.ctxInfo.Metrics, "geoIPDecoratedStats")
 	swi.Add(geoip.GeoIPProvider(&s.cfg.Stats.GeoIP, statAttrs,
 		dnsDecoratedStats, geoIPDecoratedStats), swarm.WithID("GeoIPDecorator"))
 
-	cidrDecoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "cidrDecoratedStats")
+	cidrDecoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, s.ctxInfo.Metrics, "cidrDecoratedStats")
 	swi.Add(cidr.DecoratorProvider(s.cfg.Stats.CIDRs, statAttrs, geoIPDecoratedStats, cidrDecoratedStats),
 		swarm.WithID("CIDRDecorator"))
 
-	decoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "decoratedStats")
+	decoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, s.ctxInfo.Metrics, "decoratedStats")
 	swi.Add(decorate.Decorate(s.agentIP, statAttrs, cidrDecoratedStats, decoratedStats),
 		swarm.WithID("StatsDecorator"))
 
-	dynamicFilteredStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "dynamicFilteredStats")
+	dynamicFilteredStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, s.ctxInfo.Metrics, "dynamicFilteredStats")
 	var dynamicSelector selection.PIDSelector
 	if s.ctxInfo.DynamicPIDSelector != nil {
 		dynamicSelector = s.ctxInfo.DynamicPIDSelector.StatsMetrics()
 	}
-	dynamicDecoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "dynamicDecoratedStats")
+	dynamicDecoratedStats := msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, s.ctxInfo.Metrics, "dynamicDecoratedStats")
 	swi.Add(dynamicpid.MetadataDecoratorProvider(s.ctxInfo.DynamicPIDSelector, dynamicSelector,
 		s.ctxInfo.K8sInformer, statAttrs, decoratedStats, dynamicDecoratedStats),
 		swarm.WithID("DynamicPIDMetadataDecorator"))
@@ -87,7 +87,7 @@ func (s *Stats) buildPipeline(ctx context.Context) (*swarm.Runner, error) {
 
 	filteredStats := s.ctxInfo.OverrideStatsExportQueue
 	if filteredStats == nil {
-		filteredStats = msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, "filteredStats")
+		filteredStats = msgh.QueueFromConfig[[]*ebpf.Stat](s.cfg, s.ctxInfo.Metrics, "filteredStats")
 	}
 	swi.Add(filter.ByAttribute(s.cfg.Filters.Stats, nil, selectorCfg.ExtraGroupAttributesCfg, ebpf.StatStringGetters, dynamicFilteredStats, filteredStats),
 		swarm.WithID("AttributeFilter"))

--- a/pkg/transform/transform_docker.go
+++ b/pkg/transform/transform_docker.go
@@ -87,7 +87,7 @@ func DockerProcessEventDecoratorProvider(
 			return swarm.Bypass(input, output)
 		}
 
-		in := input.Subscribe()
+		in := input.Subscribe(msg.SubscriberName("transform.DockerProcessEventDecorator"))
 		containers := ctxInfo.DockerMetadata
 		containerByPID := map[app.PID]docker.ContainerMeta{}
 

--- a/schemas/obi/groups/obi_internal.yaml
+++ b/schemas/obi/groups/obi_internal.yaml
@@ -188,6 +188,14 @@ groups:
         stability: development
         brief: Name of the eBPF map.
         examples: ["events", "ongoing_http"]
+      - id: subscriber
+        type: string
+        stability: development
+        brief: >
+          Name of the pipeline stage consuming the internal queue, as given to
+          msg.SubscriberName when the stage subscribed. Subscribers that do not
+          provide a name fall back to the name of the queue they subscribed to.
+        examples: ["discover.CriteriaMatcher", "traceAttacher"]
       - id: telemetry.type
         type: string
         stability: development
@@ -378,3 +386,16 @@ groups:
       How long, in seconds, it takes from a Kubernetes event happening until
       it is forwarded to the subscribers.
 
+  # --- Pipeline queues ----------------------------------------------------
+  - id: metric.obi.queue.capacity.ratio
+    type: metric
+    metric_name: obi.queue.capacity.ratio
+    instrument: gauge
+    unit: "1"
+    stability: development
+    brief: >
+      Ratio [0-1] between the unread messages of an internal Go channel and its
+      total capacity, sampled on every send to each subscriber. A sustained
+      value near 1 means the consuming stage cannot keep up with the producer.
+    attributes:
+      - ref: subscriber


### PR DESCRIPTION
## Summary

`obi.queue.capacity.ratio` has never been emitted. The instrument, the `imetrics.Reporter` method and both exporters all exist, and `Send` calls the gauge on every message — but `msg.NewQueue` defaults it to a no-op stub, and nothing in production ever passed `msg.InternalMetrics(...)` to replace it.

This wires the reporter through, corrects the ratio, names the remaining subscribers, and declares the metric.

## Changes

- `QueueFromConfig` takes an `imetrics.Reporter` and passes `msg.InternalMetrics` to every queue it builds. All 48 call sites already had `ctxInfo.Metrics` in scope. A nil reporter is tolerated, since some callers build a `global.ContextInfo` without one.
- The ratio is now `unread/capacity`, was `(unread+1)/capacity` — which never read 0 on an idle queue and reached 1.02 at the default buffer of 50, i.e. it was wrong exactly where the metric matters. Both the declared brief and the `Reporter` doc already specified `[0-1]`.
- Named the three subscribers that passed no `msg.SubscriberName`: `transform.DockerProcessEventDecorator` and `flow.ProtocolFilter` (both branches). They shared a single `(unnamed)` series, so Docker-without-Kubernetes running a netolly protocol filter had two unrelated queues writing to the same series. An unnamed `Subscribe` now falls back to the queue's name.
- Declared `obi.queue.capacity.ratio` and its `subscriber` attribute in the registry.

## Tests

`TestQueueFromConfig_ReportsBufferUtilization` fails against the old factory, which reported nothing. `TestMetrics_CapacityGauge_Saturation` fills a buffer and pins the gauge at exactly 1, failing against the old `+1` expression; existing gauge tests had `+1` baked into their expected values and were corrected. `obi_queue_capacity_ratio` is added to `internalMetricsExpected`, so the integration suite proves the series reaches Prometheus rather than only that the recorder was called.

## Behaviour change

Deployments with internal metrics enabled start receiving a new gauge, one series per subscriber name, sampled on every send. `NoopReporter` deployments are unaffected. No compatibility concern: the metric was never emitted, so no existing series changes meaning.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.