### PR TITLE
Fix confmap decoding of YAML sequences into text-unmarshalable types

### DIFF
--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -501,8 +501,11 @@ func (c *Config) Unmarshal(component *confmap.Conf) error {
 		WeaklyTypedInput: true,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			mapstructure.StringToTimeDurationHookFunc(),
-			mapstructure.TextUnmarshallerHookFunc(),
+			// ComposeDecodeHookFunc feeds each hook the previous hook's output, so the
+			// slice-joining hook must run before TextUnmarshallerHookFunc, which only
+			// fires on strings.
 			stringSliceToTextUnmarshalerHookFunc(),
+			mapstructure.TextUnmarshallerHookFunc(),
 			inlineMetadataHookFunc(),
 		),
 	})

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/collector/confmap"
+
 	"go.opentelemetry.io/obi/pkg/appolly/meta"
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/config"
@@ -1513,4 +1515,60 @@ func TestNormalizeConfig_Network(t *testing.T) {
 	obi.normalize()
 	assert.Equal(t, export.FeatureApplicationRED|export.FeatureNetwork,
 		obi.Metrics.Features)
+}
+
+// stringSliceToTextUnmarshalerHookFunc exists so that Features and ExportModes accept a
+// YAML sequence as well as the comma-separated text their UnmarshalText parses. Both shapes
+// have to decode through confmap, which is how the collector receiver loads the
+// configuration; plain YAML loading only ever reaches UnmarshalYAML.
+func TestUnmarshalConfmapSequences(t *testing.T) {
+	unmarshal := func(t *testing.T, raw map[string]any) *Config {
+		t.Helper()
+		cfg := DefaultConfig
+		require.NoError(t, cfg.Unmarshal(confmap.NewFromStringMap(raw)))
+		return &cfg
+	}
+
+	t.Run("metrics features", func(t *testing.T) {
+		expected := export.FeatureApplicationRED | export.FeatureSpanOTel
+
+		for _, tc := range []struct {
+			name  string
+			value any
+		}{
+			{name: "sequence", value: []any{"application", "application_span_otel"}},
+			{name: "comma separated", value: "application,application_span_otel"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := unmarshal(t, map[string]any{
+					"metrics": map[string]any{"features": tc.value},
+				})
+				assert.Equal(t, expected, cfg.Metrics.Features)
+			})
+		}
+	})
+
+	t.Run("discovery export modes", func(t *testing.T) {
+		for _, tc := range []struct {
+			name  string
+			value any
+		}{
+			{name: "sequence", value: []any{"metrics", "traces"}},
+			{name: "comma separated", value: "metrics,traces"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := unmarshal(t, map[string]any{
+					"discovery": map[string]any{"instrument": []any{
+						map[string]any{"k8s_namespace": "demo", "exports": tc.value},
+					}},
+				})
+				require.Len(t, cfg.Discovery.Instrument, 1)
+
+				modes := cfg.Discovery.Instrument[0].ExportModes
+				assert.True(t, modes.CanExportMetrics())
+				assert.True(t, modes.CanExportTraces())
+				assert.False(t, modes.CanExportLogs())
+			})
+		}
+	})
 }


### PR DESCRIPTION
Fixes #3188

## What

Swap the registration order of two decode hooks.

`stringSliceToTextUnmarshalerHookFunc` ran after `mapstructure.TextUnmarshallerHookFunc`.
`ComposeDecodeHookFunc` feeds each hook the previous one's output, so the comma-separated string the slice hook produces had no hook left to pass it to `UnmarshalText`.

## Why

Running OBI as a collector receiver, giving `metrics.features` as a list stops the collector from starting.

```yaml
receivers:
  obi:
    metrics:
      features:
        - application
        - application_span_otel
```

```
'metrics.features' cannot parse value as 'export.Features': strconv.ParseUint: invalid syntax
```

The list is the shape `Features.JSONSchema()` declares as `array` and `Features.UnmarshalYAML` accepts. It works in standalone mode; only the receiver path rejects it.

The slice hook was added to support this shape in the first place — its doc comment names `Features` and `ExportModes` — so this is an ordering slip rather than intended behaviour, unchanged since #1053.

Any type implementing `UnmarshalText` alongside a sequence-accepting `UnmarshalYAML` breaks the same way.

## Tests

`TestUnmarshalConfmapSequences` covers the sequence and the comma-separated form for both types the hook's doc comment names — `metrics.features` and `discovery.instrument[].exports`. Both sequence subtests fail without the reorder.


#### Generative AI disclosure

Per AI-POLICY.md §5: an AI assistant was used to investigate the decode-hook chaining, produce the reproduction, and draft the test. I reviewed the change and the test, confirmed the failure and the fix against `pkg/obi` and `collector`, and take responsibility for the contribution.