### PR TITLE
fix(export): surface the span's remote parent to the trace sampler

### DIFF
--- a/internal/test/integration/configs/obi-config-parentbased-sampler.yml
+++ b/internal/test/integration/configs/obi-config-parentbased-sampler.yml
@@ -1,0 +1,26 @@
+routes:
+  patterns:
+    - /basic/:rnd
+  unmatched: path
+ebpf:
+  track_request_headers: true
+otel_metrics_export:
+  endpoint: http://otelcol:4018
+otel_traces_export:
+  endpoint: http://jaeger:4318
+  sampler:
+    name: parentbased_always_off
+discovery:
+  disabled_route_harvesters: ["nodejs"]
+  services:
+    - namespace: multi-k
+      name: service-a
+      open_ports: 5000
+attributes:
+  kubernetes:
+    cluster_name: my-kube
+  select:
+    http_server_request_duration_seconds_count:
+      exclude: ["server_address"]
+    "*":
+      include: ["*"]

--- a/internal/test/integration/docker-compose-parentbased-sampler.yml
+++ b/internal/test/integration/docker-compose-parentbased-sampler.yml
@@ -1,0 +1,103 @@
+version: "3.8"
+
+services:
+  nodeserver:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/nodemultiproc/Dockerfile
+    image: nodemultiproc
+    ports:
+      - "5000:5000"
+      - "5001:5001"
+      - "5002:5002"
+      - "5003:5003"
+    environment:
+      LOG_LEVEL: DEBUG
+    depends_on:
+      otelcol:
+        condition: service_started
+      jaeger:
+        condition: service_started
+
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    command:
+      - --config=/configs/obi-config-parentbased-sampler.yml
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-multi:/var/run/obi
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    pid: "host"
+    environment:
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_METRICS_FEATURES: "application,application_span_otel"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PORT: 8999
+      OTEL_EBPF_INTERNAL_METRICS_PROMETHEUS_PATH: /metrics
+    ports:
+      - "8999:8999"
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.159.0@sha256:1f2c54a30e713fac6b3ae77a1ec84010c2007e29ced8ec666214fc2f6739c1cc
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-4017-weaver.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4017" # OTLP over gRPC receiver
+      - "4018:4018" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+      jaeger:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.14.0@sha256:5ce7540c3c00ef4ab0c9d2c995c6a5b9c421f44b4a115d97a2c7af3b1c21cbb0
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+      - --log.level=debug
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317:4317" # OTEL GRPC traces collector
+      - "4318:4318" # OTEL HTTP traces collector
+    command:
+      - "--set=service.telemetry.logs.level=debug"

--- a/internal/test/integration/parentbased_sampler_test.go
+++ b/internal/test/integration/parentbased_sampler_test.go
@@ -1,0 +1,118 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"encoding/json"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
+	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
+)
+
+// testParentBasedSamplerWireParent proves that parentbased_always_off follows
+// the sampling decision carried by an incoming traceparent (a wire-received
+// remote parent): requests joining a sampled trace are exported and keep the
+// parent link, while requests joining an unsampled trace and requests with no
+// traceparent at all export nothing.
+func testParentBasedSamplerWireParent(t *testing.T) {
+	waitForTestComponents(t, "http://localhost:5000")
+
+	// give enough time for the NodeJS injector to finish
+	// TODO: once we implement the instrumentation status query API, replace
+	// this with  a proper check to see if the target process has finished
+	// being instrumented
+	time.Sleep(60 * time.Second)
+
+	sampledTraceID := createTraceID()
+	sampledParentID := createParentID()
+	unsampledTraceID := createTraceID()
+
+	// Run several requests of each kind to make sure we flush out any
+	// transactions that might be stuck because of our tracking of full
+	// request times.
+	for i := 0; i < 10; i++ {
+		// flags 01: the upstream sampler decided to sample this trace
+		doHTTPGetWithTraceparent(t, "http://localhost:5000/a", 200, "00-"+sampledTraceID+"-"+sampledParentID+"-01")
+		// flags 00: the upstream sampler decided NOT to sample this trace
+		doHTTPGetWithTraceparent(t, "http://localhost:5000/a", 200, "00-"+unsampledTraceID+"-"+createParentID()+"-00")
+		// no traceparent: a trace root, dropped by always_off
+		ti.DoHTTPGet(t, "http://localhost:5000/a", 200)
+	}
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=service-a&operation=GET%20%2Fa")
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+
+		var sampled *jaeger.Trace
+		for i := range tq.Data {
+			if tq.Data[i].TraceID == sampledTraceID {
+				sampled = &tq.Data[i]
+			}
+			require.NotEqual(ct, unsampledTraceID, tq.Data[i].TraceID,
+				"a span joining an unsampled trace (traceparent flags 00) must not be exported")
+		}
+		require.NotNil(ct, sampled,
+			"spans joining a sampled trace (traceparent flags 01) must be exported with the incoming trace ID")
+
+		// the exported span must be linked to the wire parent, not re-rooted
+		foundParentRef := false
+		for _, span := range sampled.Spans {
+			for _, ref := range span.References {
+				if ref.SpanID == sampledParentID {
+					foundParentRef = true
+				}
+			}
+		}
+		require.True(ct, foundParentRef,
+			"the exported span must reference the traceparent's parent span ID")
+	}, testTimeout, 1500*time.Millisecond)
+
+	// The sampled trace has been exported by now, and all requests went
+	// through the same short-batched pipeline: if the unsampled or root
+	// spans had been exported at all, they would be visible by now.
+	resp, err := http.Get(jaegerQueryURL + "?service=service-a&operation=GET%20%2Fa")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var tq jaeger.TracesQuery
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tq))
+	for i := range tq.Data {
+		require.NotEqual(t, unsampledTraceID, tq.Data[i].TraceID)
+	}
+	// every exported trace for this service must be one that carried a
+	// sampled incoming traceparent: with parentbased_always_off, roots
+	// (requests without a traceparent) are never exported
+	for i := range tq.Data {
+		require.Equal(t, sampledTraceID, tq.Data[i].TraceID,
+			"only the trace with a sampled wire parent may be exported; roots must be dropped")
+	}
+}
+
+func TestParentBasedSamplerWireParent(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-parentbased-sampler.yml", path.Join(pathOutput, "test-suite-parentbased-sampler.log"))
+	require.NoError(t, err)
+
+	// we are going to setup discovery directly in the configuration file
+	compose.Env = append(compose.Env, `OTEL_EBPF_EXECUTABLE_PATH=`, `OTEL_EBPF_OPEN_PORT=`)
+	require.NoError(t, compose.Up())
+
+	t.Run("ParentBasedSamplerWireParent", testParentBasedSamplerWireParent)
+
+	require.NoError(t, compose.Close())
+}

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -77,6 +77,35 @@ func UserSelectedAttributes(selectorCfg *attributes.SelectorConfig) (map[attr.Na
 	return traceAttrs, err
 }
 
+// parentContext returns ctx carrying the span's remote parent, when it has
+// one received from the wire, so that parent-based samplers can honor the
+// sampling decision of the incoming trace context. Without it every span
+// looks like a trace root to the sampler and the parentbased_* samplers
+// collapse into their root halves (for example, parentbased_always_off
+// drops spans that belong to an already-sampled trace).
+//
+// Only server and consumer spans qualify: their parent comes from an
+// incoming trace context, where the sampled flag reflects a real upstream
+// sampling decision. Client and producer spans have a local parent whose
+// flags byte was written before any sampling decision existed (it is
+// unconditionally "sampled"), so presenting it would detach them from their
+// local root's fate. They keep root-half behavior until the sampling
+// decision is made in eBPF before the flags propagate.
+func parentContext(ctx context.Context, span *request.Span, kind trace2.SpanKind) context.Context {
+	if kind != trace2.SpanKindServer && kind != trace2.SpanKindConsumer {
+		return ctx
+	}
+	if !span.ParentSpanID.IsValid() || !span.TraceID.IsValid() {
+		return ctx
+	}
+	return trace2.ContextWithRemoteSpanContext(ctx, trace2.NewSpanContext(trace2.SpanContextConfig{
+		TraceID:    span.TraceID,
+		SpanID:     span.ParentSpanID,
+		TraceFlags: trace2.TraceFlags(span.TraceFlags),
+		Remote:     true,
+	}))
+}
+
 // GroupSpans must remain public for collectors embedding OBI.
 func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.Name]struct{}, sampler trace.Sampler, is instrumentations.InstrumentationSelection, redactKeys ...string) map[svc.UID][]TraceSpanAndAttributes {
 	spanGroups := map[svc.UID][]TraceSpanAndAttributes{}
@@ -102,11 +131,12 @@ func GroupSpans(ctx context.Context, spans []request.Span, traceAttrs map[attr.N
 			return sampler
 		}
 
+		kind := spanKind(span)
 		sr := spanSampler().ShouldSample(trace.SamplingParameters{
-			ParentContext: ctx,
+			ParentContext: parentContext(ctx, span, kind),
 			Name:          span.TraceName(),
 			TraceID:       span.TraceID,
-			Kind:          spanKind(span),
+			Kind:          kind,
 			Attributes:    samplerAttrs,
 		})
 

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -1396,3 +1396,135 @@ func TestTraceAttributesSelector_GenAITokenDetailAvailability(t *testing.T) {
 		})
 	}
 }
+
+// parentRecordingSampler captures the ParentContext handed to ShouldSample
+// and delegates the decision to an inner sampler.
+type parentRecordingSampler struct {
+	inner   sdktrace.Sampler
+	parents []trace2.SpanContext
+}
+
+func (s *parentRecordingSampler) ShouldSample(parameters sdktrace.SamplingParameters) sdktrace.SamplingResult {
+	s.parents = append(s.parents, trace2.SpanContextFromContext(parameters.ParentContext))
+	return s.inner.ShouldSample(parameters)
+}
+
+func (*parentRecordingSampler) Description() string {
+	return "parent recording sampler"
+}
+
+func samplingTestSpan(traceFlags uint8, parent trace2.SpanID) request.Span {
+	return request.Span{
+		Type:         request.EventTypeHTTP,
+		Method:       "GET",
+		Route:        "/products",
+		Status:       200,
+		TraceID:      trace2.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+		SpanID:       trace2.SpanID{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18},
+		ParentSpanID: parent,
+		TraceFlags:   traceFlags,
+	}
+}
+
+func samplingTestClientSpan(traceFlags uint8, parent trace2.SpanID) request.Span {
+	span := samplingTestSpan(traceFlags, parent)
+	span.Type = request.EventTypeHTTPClient
+	return span
+}
+
+func TestGroupSpansSamplerSeesRemoteParent(t *testing.T) {
+	remoteParent := trace2.SpanID{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28}
+	joined := samplingTestSpan(1, remoteParent)
+	root := samplingTestSpan(1, trace2.SpanID{})
+	client := samplingTestClientSpan(1, remoteParent)
+
+	sampler := &parentRecordingSampler{inner: sdktrace.AlwaysSample()}
+	GroupSpans(
+		t.Context(),
+		[]request.Span{joined, root, client},
+		map[attr.Name]struct{}{},
+		sampler,
+		instrumentations.NewInstrumentationSelection(
+			[]instrumentations.Instrumentation{instrumentations.InstrumentationALL},
+		),
+	)
+
+	require.Len(t, sampler.parents, 3)
+
+	joinedParent := sampler.parents[0]
+	require.True(t, joinedParent.IsValid(), "sampler must see the remote parent of a joined span")
+	assert.Equal(t, joined.TraceID, joinedParent.TraceID())
+	assert.Equal(t, remoteParent, joinedParent.SpanID())
+	assert.True(t, joinedParent.IsSampled())
+	assert.True(t, joinedParent.IsRemote())
+
+	assert.False(t, sampler.parents[1].IsValid(), "a root span must not present a parent to the sampler")
+	assert.False(t, sampler.parents[2].IsValid(), "a client span's local parent carries no sampling decision and must not be presented")
+}
+
+func TestGroupSpansParentBasedSampling(t *testing.T) {
+	remoteParent := trace2.SpanID{0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28}
+
+	tests := []struct {
+		name    string
+		span    request.Span
+		sampler sdktrace.Sampler
+		kept    bool
+	}{
+		{
+			name:    "parentbased_always_off keeps spans that join a sampled trace",
+			span:    samplingTestSpan(1, remoteParent),
+			sampler: sdktrace.ParentBased(sdktrace.NeverSample()),
+			kept:    true,
+		},
+		{
+			name:    "parentbased_always_off drops spans with an unsampled parent",
+			span:    samplingTestSpan(0, remoteParent),
+			sampler: sdktrace.ParentBased(sdktrace.NeverSample()),
+			kept:    false,
+		},
+		{
+			name:    "parentbased_always_off drops root spans",
+			span:    samplingTestSpan(1, trace2.SpanID{}),
+			sampler: sdktrace.ParentBased(sdktrace.NeverSample()),
+			kept:    false,
+		},
+		{
+			name:    "parentbased_always_on keeps root spans",
+			span:    samplingTestSpan(1, trace2.SpanID{}),
+			sampler: sdktrace.ParentBased(sdktrace.AlwaysSample()),
+			kept:    true,
+		},
+		{
+			name:    "parentbased_always_off drops client spans: their local parent carries no decision",
+			span:    samplingTestClientSpan(1, remoteParent),
+			sampler: sdktrace.ParentBased(sdktrace.NeverSample()),
+			kept:    false,
+		},
+		{
+			name:    "parentbased_always_on keeps client spans via the root half",
+			span:    samplingTestClientSpan(1, remoteParent),
+			sampler: sdktrace.ParentBased(sdktrace.AlwaysSample()),
+			kept:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groups := GroupSpans(
+				t.Context(),
+				[]request.Span{tt.span},
+				map[attr.Name]struct{}{},
+				tt.sampler,
+				instrumentations.NewInstrumentationSelection(
+					[]instrumentations.Instrumentation{instrumentations.InstrumentationALL},
+				),
+			)
+			if tt.kept {
+				require.Len(t, groups[tt.span.Service.UID], 1)
+			} else {
+				assert.Empty(t, groups[tt.span.Service.UID])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3190.

`GroupSpans` passed the exporter's lifecycle context as `ParentContext` to every `ShouldSample` call, so the sampler never saw the remote parent that the span itself carries. All `parentbased_*` samplers therefore took their **root** branch for every span:

- `parentbased_always_off` dropped 100% of spans — including spans joining an already-sampled trace (our production case: an Envoy gateway sampling at 100% and injecting `traceparent`, OBI configured to follow the edge decision → zero spans exported while OBI's own RED metrics counted the requests);
- `parentbased_always_on` was indistinguishable from `always_on`;
- `parentbased_traceidratio` ratio-sampled spans belonging to already-sampled traces, producing torn traces.

The fix builds the remote parent `SpanContext` from data the span already carries — `TraceID`, `ParentSpanID`, and `TraceFlags` (the incoming traceparent's flags byte, parsed by the BPF side) — and hands it to the sampler when a parent is present. Root spans still present no parent, so root-half behavior is unchanged, and `normalizeTraceContext` already guarantees roots get `TraceFlags=1` with no `ParentSpanID`.

One deliberate choice worth reviewer attention: the parent is marked `Remote: true` unconditionally. For spans whose parent is another eBPF-observed span of the same process there is no in-process OTel context either way, and the default `ParentBased` composition treats local and remote sampled parents identically, so the decision is unaffected; distinguishing them would require plumbing OBI doesn't have today.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed. *(No doc change needed — this makes the already-documented `parentbased_*` sampler names behave as documented.)*

New tests in `tracesgen_test.go`:

- `TestGroupSpansSamplerSeesRemoteParent` — the sampler receives a valid, remote, sampled parent for joined spans and no parent for roots;
- `TestGroupSpansParentBasedSampling` — `parentbased_always_off` keeps joined-sampled, drops joined-unsampled, drops roots; `parentbased_always_on` keeps roots.

Both fail on `main` without the fix and pass with it (`go test ./pkg/export/otel/tracesgen/`).

Real-world validation: with Beyla v3.28.0 (via Grafana Alloy v1.19.0), the same workload that exported zero spans under `parentbased_always_off` exports correctly-joined spans under `always_on` — the spans carry the right parent, only the sampling decision was blind to it. Full evidence in #3190.