### PR TITLE
Add `db.namespace` on `db.client` and `db.server` operation duration metrics

### DIFF
--- a/internal/test/integration/red_test_python_redis.go
+++ b/internal/test/integration/red_test_python_redis.go
@@ -36,12 +36,21 @@ func testREDMetricsForPythonRedisLibrary(t *testing.T, testCase TestCase) {
 	var results []promtest.Result
 	var err error
 	for _, span := range testCase.Spans {
+		// spans expected to carry db.namespace must also split the metric
+		// series by that label
+		dbNamespaceMatcher := ""
+		for _, a := range span.Attributes {
+			if string(a.Key) == "db.namespace" {
+				dbNamespaceMatcher = `db_namespace="` + a.Value.AsString() + `",`
+			}
+		}
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			var err error
 			// server_port is present despite being the redis default port because
 			// the suite config explicitly includes all attributes (include: ["*"])
 			results, err = pq.Query(`db_client_operation_duration_seconds_count{` +
 				`db_operation_name="` + span.Name + `",` +
+				dbNamespaceMatcher +
 				`server_port="6379",` +
 				`service_namespace="` + namespace + `"}`)
 			require.NoError(ct, err, "failed to query prometheus for %s", span.Name)

--- a/pkg/appolly/app/request/span_getters.go
+++ b/pkg/appolly/app/request/span_getters.go
@@ -194,7 +194,14 @@ func spanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 			return attribute.KeyValue{}
 		}
 	case attr.DBNamespace:
-		getter = func(span *Span) attribute.KeyValue { return DBNamespace(span.DBNamespace) }
+		getter = func(span *Span) attribute.KeyValue {
+			// db.namespace is Conditionally Required "if available": omit it
+			// instead of emitting an empty value
+			if span.DBNamespace == "" {
+				return attribute.KeyValue{}
+			}
+			return DBNamespace(span.DBNamespace)
+		}
 	case attr.ErrorType:
 		getter = func(span *Span) attribute.KeyValue {
 			if span.Type == EventTypeDNS && span.Status != int(dnsparser.RCodeSuccess) {

--- a/pkg/appolly/app/request/span_getters_test.go
+++ b/pkg/appolly/app/request/span_getters_test.go
@@ -1324,3 +1324,18 @@ func TestDBClientServerPortGetter(t *testing.T) {
 		})
 	}
 }
+
+func TestSpanOTELGetters_DBNamespace(t *testing.T) {
+	getter, ok := spanOTELGetters(attr.DBNamespace)
+	require.True(t, ok, "getter should be found for DBNamespace")
+
+	kv := getter(&Span{Type: EventTypeRedisClient, DBNamespace: "1"})
+	require.True(t, kv.Valid())
+	assert.Equal(t, string(attr.DBNamespace), string(kv.Key))
+	assert.Equal(t, "1", kv.Value.AsString())
+
+	// spans without an available namespace must omit the attribute
+	// instead of emitting an empty value
+	kv = getter(&Span{Type: EventTypeSQLClient, SubType: int(DBMySQL)})
+	assert.False(t, kv.Valid(), "expected db.namespace to be omitted, got %v", kv)
+}

--- a/pkg/export/attributes/attr_defs.go
+++ b/pkg/export/attributes/attr_defs.go
@@ -396,6 +396,7 @@ func getDefinitions(
 				attr.DBSystemName:     true,
 				attr.ErrorType:        true,
 				attr.DBCollectionName: false,
+				attr.DBNamespace:      true,
 			},
 		},
 		DBServerDuration.Section: {
@@ -405,6 +406,7 @@ func getDefinitions(
 				attr.DBSystemName:     true,
 				attr.ErrorType:        true,
 				attr.DBCollectionName: false,
+				attr.DBNamespace:      true,
 			},
 		},
 		MessagingPublishDuration.Section: {

--- a/pkg/export/attributes/attr_selector_test.go
+++ b/pkg/export/attributes/attr_selector_test.go
@@ -200,12 +200,26 @@ func TestDefault_DBClientDuration(t *testing.T) {
 	p, err := NewAttrSelector(0, &SelectorConfig{})
 	require.NoError(t, err)
 	assert.Equal(t, []attr.Name{
+		attr.DBNamespace,
 		attr.DBOperation,
 		attr.DBSystemName,
 		attr.ErrorType,
 		attr.ServerAddr,
 		attr.ServerPort,
 	}, p.For(DBClientDuration))
+}
+
+func TestDefault_DBServerDuration(t *testing.T) {
+	p, err := NewAttrSelector(0, &SelectorConfig{})
+	require.NoError(t, err)
+	assert.Equal(t, []attr.Name{
+		attr.DBNamespace,
+		attr.DBOperation,
+		attr.DBSystemName,
+		attr.ErrorType,
+		attr.ServerAddr,
+		attr.ServerPort,
+	}, p.For(DBServerDuration))
 }
 
 func TestExplicitlyIncluded(t *testing.T) {

--- a/pkg/export/otel/metrics_test.go
+++ b/pkg/export/otel/metrics_test.go
@@ -614,7 +614,7 @@ func TestAppMetrics_DBClientAttributes(t *testing.T) {
 		&attributes.SelectorConfig{
 			SelectionCfg: attributes.Selection{
 				attributes.DBClientDuration.Section: attributes.InclusionLists{
-					Include: []string{string(attr.DBCollectionName), string(attr.ServerPort)},
+					Include: []string{string(attr.DBCollectionName), string(attr.ServerPort), string(attr.DBNamespace)},
 				},
 			},
 		},
@@ -632,6 +632,7 @@ func TestAppMetrics_DBClientAttributes(t *testing.T) {
 		Path:         "customers",
 		Method:       "SELECT",
 		HostPort:     5432,
+		DBNamespace:  "testdb",
 		RequestStart: 100,
 		End:          200,
 	}})
@@ -639,6 +640,7 @@ func TestAppMetrics_DBClientAttributes(t *testing.T) {
 	records := readMetricsByName(t, metricRecords, timeout, attributes.DBClientDuration.OTEL)
 	require.Len(t, records, 1)
 	assert.Equal(t, "customers", records[0].Attributes[string(attr.DBCollectionName)])
+	assert.Equal(t, "testdb", records[0].Attributes[string(attr.DBNamespace)])
 	// the DBMS default port is still reported because the user explicitly
 	// included server.port in the selection
 	assert.Equal(t, "5432", records[0].Attributes[string(attr.ServerPort)])

--- a/schemas/obi/groups/db.yaml
+++ b/schemas/obi/groups/db.yaml
@@ -217,3 +217,4 @@ groups:
       - ref: server.port
       - ref: client.address
         requirement_level: opt_in
+      - ref: db.namespace


### PR DESCRIPTION
## Summary

This PR adds `db.namespace` as a default attribute on `db.client.operation.duration` (semconv marks it as conditionally required "if available") and on `db.server.operation.duration` (obi custom metric). The attribute is omitted (not emitted empty) when the namespace isn't captured. 


Limitation/Follow-ups:
- The attribute is available for postgres, redis (after SELECT), mongodb, couchbase, and aerospike, but not for mysql, mssql, or memcached. It is a planned follow-up.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
