### PR TITLE
Replace disabled Kafka Fetch v12/v15 tests with a session-fetch error case

### DIFF
--- a/pkg/ebpf/common/kafka_detect_transform_test.go
+++ b/pkg/ebpf/common/kafka_detect_transform_test.go
@@ -64,25 +64,24 @@ func TestProcessKafkaRequest(t *testing.T) {
 				},
 			},
 		},
-		// TODO these tests don't seem like valid kafka packets, check that
-		//{
-		//	name:  "Fetch request (v12)",
-		//	request: []byte{0, 0, 0, 52, 0, 1, 0, 12, 0, 0, 1, 3, 0, 12, 99, 111, 110, 115, 117, 109, 101, 114, 45, 49, 45, 49, 0, 255, 255, 255, 255, 0, 0, 1, 244, 0, 0, 0, 1, 3, 32, 0, 0, 0, 30, 37, 158, 231, 0, 0, 0, 156, 1, 1, 1, 0, 53, 99, 48, 57, 45, 52, 52, 48, 48, 45, 98, 54, 101, 101, 45, 56, 54, 102, 97, 102, 101, 102, 57, 52, 102, 101, 98, 0, 2, 9, 109, 121, 45, 116, 111, 112, 105, 99, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 1, 0, 0, 0, 101, 121, 12, 118, 97, 108, 117, 101, 51, 0, 30, 0, 0},
-		//	expected: &KafkaInfo{
-		//		ClientID:  "consumer-1-1",
-		//		Operation: Fetch,
-		//		Topic:     "my-topic",
-		//	},
-		// },
-		//{
-		//	name:  "Fetch request (v15)",
-		//	request: []byte{0, 0, 0, 68, 0, 1, 0, 15, 0, 0, 38, 94, 0, 32, 99, 111, 110, 115, 117, 109, 101, 114, 45, 102, 114, 97, 117, 100, 100, 101, 116, 101, 99, 116, 105, 111, 110, 115, 101, 114, 118, 105, 99, 101, 45, 49, 0, 0, 0, 1, 244, 0, 0, 0, 1, 3, 32, 0, 0, 0, 33, 62, 224, 94, 0, 0, 30, 44, 2, 1, 1, 0, 1, 70, 99, 111, 110, 115, 117, 109, 101, 114, 45, 102, 114, 97, 117, 100, 100, 101, 116, 101, 99, 116, 105, 111, 110, 115, 101, 114, 118, 105, 99, 101, 45, 49, 45, 50, 51, 48, 98, 51, 55, 101, 100, 45, 98, 101, 57, 102, 45, 52, 97, 53, 99, 45, 97, 52},
-		//	expected: &KafkaInfo{
-		//		ClientID:    "consumer-frauddetectionservice-1",
-		//		Operation:   Fetch,
-		//		Topic:       "*",
-		//	},
-		// },
+		{
+			// KIP-227 incremental fetch session: the topic list lives in the
+			// broker's session state, so a request with an empty topics array
+			// carries no topic information and cannot produce a KafkaInfo.
+			name: "Fetch request (v12, incremental session, no topics)",
+			request: []byte{
+				0, 0, 0, 52, 0, 1, 0, 12, 0, 0, 1, 3, 0, 12,
+				99, 111, 110, 115, 117, 109, 101, 114, 45, 49, 45, 49, // "consumer-1-1"
+				0, // header tagged fields
+				// replica_id .. session_epoch
+				255, 255, 255, 255, 0, 0, 1, 244, 0, 0, 0, 1, 3, 32, 0, 0, 0, 30, 37, 158, 231, 0, 0, 0, 156,
+				1, // topics: empty compact array
+				1, // forgotten_topics: empty compact array
+				1, // rack_id: empty compact string
+				0, // tagged fields
+			},
+			err: true,
+		},
 		{
 			name: "Fetch request (v17) without metadata",
 			request: []byte{


### PR DESCRIPTION
## Summary

This PR simply removes a `TODO` about `Fetch` test cases (v12, v15) that have been commented out since #512. 

Notes:
- v12 is a valid KIP-227 session fetch (empty topics; the expected topic came from garbage past the frame end) so it is re-added trimmed as an err case. 
- v15 is truncated mid-frame and it is deleted.

Limitations/follow-ups:
- The parser currently reads request bodies without clamping to `MessageSize` (`kafkaparser.NewBodyReader`), which is how the truncated v15 packet originally "parsed"; by reading garbage past the frame end. Added as follow-up PR.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
