### PR TITLE
ran 'go fix'  to modernize code to Go 1.26

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -108,6 +108,7 @@ linters:
     - unused
     - usestdlibvars
     - usetesting
+    - modernize
 
   # all available settings of specific linters
   settings:
@@ -196,6 +197,10 @@ linters:
       ignore-rules:
         - cancelled
         - RELA
+
+    modernize:
+      disable:
+        - importcomment
 
     nolintlint:
       require-specific: true
@@ -305,7 +310,7 @@ output:
 
 # options for analysis running
 run:
-  go: "1.25"
+  go: "1.26"
 
   # Allow multiple parallel golangci-lint instances running.
   # If false (default) - golangci-lint acquires file lock on start.

--- a/cmd/check-config-v2-parity/main.go
+++ b/cmd/check-config-v2-parity/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -451,13 +452,7 @@ func mustMapPayloadExtractionMembershipAt(
 	enabledValues := toStringSlice(enabledValue)
 
 	wantEnabled := fmt.Sprintf("%v", currentValue) == "true"
-	found := false
-	for _, item := range enabledValues {
-		if item == extractor {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(enabledValues, extractor)
 
 	if found != wantEnabled {
 		return fmt.Errorf("payload extraction mismatch for %s: current=%v example list=%v", extractor, wantEnabled, enabledValues)

--- a/cmd/obi-schema/main.go
+++ b/cmd/obi-schema/main.go
@@ -572,7 +572,7 @@ func callJSONSchemaMethod(t reflect.Type) *jsonschema.Schema {
 		zero := reflect.Zero(t)
 		results := method.Func.Call([]reflect.Value{zero})
 		if len(results) == 1 {
-			if schema, ok := results[0].Interface().(*jsonschema.Schema); ok {
+			if schema, ok := reflect.TypeAssert[*jsonschema.Schema](results[0]); ok {
 				return schema
 			}
 		}
@@ -584,7 +584,7 @@ func callJSONSchemaMethod(t reflect.Type) *jsonschema.Schema {
 		zero := reflect.New(t)
 		results := method.Func.Call([]reflect.Value{zero})
 		if len(results) == 1 {
-			if schema, ok := results[0].Interface().(*jsonschema.Schema); ok {
+			if schema, ok := reflect.TypeAssert[*jsonschema.Schema](results[0]); ok {
 				return schema
 			}
 		}

--- a/cmd/obi-schema/main_test.go
+++ b/cmd/obi-schema/main_test.go
@@ -273,7 +273,7 @@ func TestCustomMapper(t *testing.T) {
 	t.Run("maps time.Duration to string schema", func(t *testing.T) {
 		g := NewSchemaGenerator()
 		mapper := g.customMapper()
-		durationType := reflect.TypeOf(time.Duration(0))
+		durationType := reflect.TypeFor[time.Duration]()
 		schema := mapper(durationType)
 
 		require.NotNil(t, schema)
@@ -286,7 +286,7 @@ func TestCustomMapper(t *testing.T) {
 	t.Run("returns nil for regular types", func(t *testing.T) {
 		g := NewSchemaGenerator()
 		mapper := g.customMapper()
-		stringType := reflect.TypeOf("")
+		stringType := reflect.TypeFor[string]()
 		schema := mapper(stringType)
 		assert.Nil(t, schema)
 	})
@@ -308,7 +308,7 @@ func TestCustomMapper(t *testing.T) {
 
 		// Create a named type for testing
 		type TestEnum string
-		testType := reflect.TypeOf(TestEnum(""))
+		testType := reflect.TypeFor[TestEnum]()
 
 		schema := mapper(testType)
 
@@ -531,7 +531,7 @@ func TestSortSchemaProperties(t *testing.T) {
 
 func TestBuildInlineTypeSchemas(t *testing.T) {
 	t.Run("finds MetadataGlobMap and MetadataRegexMap from obi.Config", func(t *testing.T) {
-		result := NewSchemaGenerator().buildInlineTypeSchemas(reflect.TypeOf(obi.Config{}))
+		result := NewSchemaGenerator().buildInlineTypeSchemas(reflect.TypeFor[obi.Config]())
 
 		// Should find MetadataGlobMap
 		schemaFunc, found := result["MetadataGlobMap"]
@@ -556,12 +556,12 @@ func TestBuildInlineTypeSchemas(t *testing.T) {
 		type SimpleStruct struct {
 			Name string `yaml:"name"`
 		}
-		result := NewSchemaGenerator().buildInlineTypeSchemas(reflect.TypeOf(SimpleStruct{}))
+		result := NewSchemaGenerator().buildInlineTypeSchemas(reflect.TypeFor[SimpleStruct]())
 		assert.Empty(t, result)
 	})
 
 	t.Run("handles pointer types", func(t *testing.T) {
-		result := NewSchemaGenerator().buildInlineTypeSchemas(reflect.TypeOf(&obi.Config{}))
+		result := NewSchemaGenerator().buildInlineTypeSchemas(reflect.TypeFor[*obi.Config]())
 
 		// Should still find inline types
 		_, found := result["MetadataGlobMap"]
@@ -581,26 +581,26 @@ func (testJSONSchemaType) JSONSchema() *jsonschema.Schema {
 
 func TestHasJSONSchemaMethod(t *testing.T) {
 	t.Run("returns true for type implementing JSONSchema", func(t *testing.T) {
-		result := hasJSONSchemaMethod(reflect.TypeOf(testJSONSchemaType{}))
+		result := hasJSONSchemaMethod(reflect.TypeFor[testJSONSchemaType]())
 		assert.True(t, result)
 	})
 
 	t.Run("returns false for type not implementing JSONSchema", func(t *testing.T) {
 		type noSchema struct{}
-		result := hasJSONSchemaMethod(reflect.TypeOf(noSchema{}))
+		result := hasJSONSchemaMethod(reflect.TypeFor[noSchema]())
 		assert.False(t, result)
 	})
 
 	t.Run("returns true for string type", func(t *testing.T) {
 		// Plain string doesn't implement JSONSchema
-		result := hasJSONSchemaMethod(reflect.TypeOf(""))
+		result := hasJSONSchemaMethod(reflect.TypeFor[string]())
 		assert.False(t, result)
 	})
 }
 
 func TestCallJSONSchemaMethod(t *testing.T) {
 	t.Run("calls JSONSchema on type with value receiver", func(t *testing.T) {
-		schema := callJSONSchemaMethod(reflect.TypeOf(testJSONSchemaType{}))
+		schema := callJSONSchemaMethod(reflect.TypeFor[testJSONSchemaType]())
 		require.NotNil(t, schema)
 		assert.Equal(t, "string", schema.Type)
 		assert.Equal(t, "test schema", schema.Description)
@@ -608,7 +608,7 @@ func TestCallJSONSchemaMethod(t *testing.T) {
 
 	t.Run("returns nil for type without JSONSchema", func(t *testing.T) {
 		type noSchema struct{}
-		schema := callJSONSchemaMethod(reflect.TypeOf(noSchema{}))
+		schema := callJSONSchemaMethod(reflect.TypeFor[noSchema]())
 		assert.Nil(t, schema)
 	})
 }

--- a/cmd/obi/internal/configcmd/configcmd.go
+++ b/cmd/obi/internal/configcmd/configcmd.go
@@ -858,7 +858,7 @@ func unsupportedFeaturePathsFromYAML(data []byte) []string {
 
 func rawValueAtPath(root map[string]any, path string) (any, bool) {
 	var current any = root
-	for _, part := range strings.Split(path, ".") {
+	for part := range strings.SplitSeq(path, ".") {
 		mapping, ok := current.(map[string]any)
 		if !ok {
 			return nil, false
@@ -1072,7 +1072,7 @@ func hasAnyPath(root map[string]any, paths ...string) bool {
 	for _, path := range paths {
 		var current any = root
 		found := true
-		for _, part := range strings.Split(path, ".") {
+		for part := range strings.SplitSeq(path, ".") {
 			mapping, ok := current.(map[string]any)
 			if !ok {
 				found = false

--- a/internal/config/convert/export.go
+++ b/internal/config/convert/export.go
@@ -5,6 +5,7 @@ package convert // import "go.opentelemetry.io/obi/internal/config/convert"
 
 import (
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -233,12 +234,7 @@ func appendMetricInstrumentations(
 }
 
 func containsInstrumentation(list []instrumentations.Instrumentation, needle instrumentations.Instrumentation) bool {
-	for _, item := range list {
-		if item == needle {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, needle)
 }
 
 func protocolEnabled(

--- a/internal/config/convert/import_document.go
+++ b/internal/config/convert/import_document.go
@@ -684,7 +684,7 @@ func parseKeyValueList(raw string, dst map[string]string) error {
 	if strings.TrimSpace(raw) == "" {
 		return nil
 	}
-	for _, item := range strings.Split(raw, ",") {
+	for item := range strings.SplitSeq(raw, ",") {
 		key, value, found := strings.Cut(item, "=")
 		if !found || strings.TrimSpace(key) == "" || strings.TrimSpace(value) == "" {
 			return fmt.Errorf("invalid key-value pair %q", strings.TrimSpace(item))

--- a/internal/config/schema/decode.go
+++ b/internal/config/schema/decode.go
@@ -5,6 +5,7 @@ package schema // import "go.opentelemetry.io/obi/internal/config/schema"
 
 import (
 	"fmt"
+	"slices"
 
 	"go.yaml.in/yaml/v3"
 )
@@ -18,11 +19,9 @@ func unmarshalEnum[T ~string](value *yaml.Node, name string, dst *T, allowed ...
 		return fmt.Errorf("%s must be a scalar, got %v", name, value.Kind)
 	}
 	candidate := T(value.Value)
-	for _, option := range allowed {
-		if candidate == option {
-			*dst = candidate
-			return nil
-		}
+	if slices.Contains(allowed, candidate) {
+		*dst = candidate
+		return nil
 	}
 	return fmt.Errorf("invalid %s %q", name, value.Value)
 }

--- a/internal/test/integration/components/ai/bedrock/mock-server/main.go
+++ b/internal/test/integration/components/ai/bedrock/mock-server/main.go
@@ -52,16 +52,16 @@ func handleInvoke(w http.ResponseWriter, r *http.Request) {
 	// Extract model ID from path: /model/{modelId}/invoke
 	path := r.URL.Path
 	const prefix = "/model/"
-	idx := strings.Index(path, prefix)
-	if idx < 0 {
+	_, after, ok := strings.Cut(path, prefix)
+	if !ok {
 		http.Error(w, "invalid path", http.StatusBadRequest)
 		return
 	}
-	remainder := path[idx+len(prefix):]
-	slashIdx := strings.Index(remainder, "/")
+	remainder := after
+	before0, _, ok0 := strings.Cut(remainder, "/")
 	modelID := remainder
-	if slashIdx >= 0 {
-		modelID = remainder[:slashIdx]
+	if ok0 {
+		modelID = before0
 	}
 
 	h := w.Header()

--- a/internal/test/integration/components/testserver/gorillamid/middleware.go
+++ b/internal/test/integration/components/testserver/gorillamid/middleware.go
@@ -3,9 +3,10 @@
 
 package gorillamid // import "go.opentelemetry.io/obi/internal/test/integration/components/testserver/gorillamid"
 
-import "slices"
-
-import "net/http"
+import (
+	"net/http"
+	"slices"
+)
 
 // Interface is the shared contract for all middleware, and allows middlewares
 // to wrap handlers.

--- a/internal/test/integration/components/testserver/gorillamid/middleware.go
+++ b/internal/test/integration/components/testserver/gorillamid/middleware.go
@@ -3,6 +3,8 @@
 
 package gorillamid // import "go.opentelemetry.io/obi/internal/test/integration/components/testserver/gorillamid"
 
+import "slices"
+
 import "net/http"
 
 // Interface is the shared contract for all middleware, and allows middlewares
@@ -23,8 +25,8 @@ func (m Func) Wrap(next http.Handler) http.Handler {
 // ie Merge(f,g,h).Wrap(handler) == f.Wrap(g.Wrap(h.Wrap(handler)))
 func Merge(middlewares ...Interface) Interface {
 	return Func(func(next http.Handler) http.Handler {
-		for i := len(middlewares) - 1; i >= 0; i-- {
-			next = middlewares[i].Wrap(next)
+		for _, middleware := range slices.Backward(middlewares) {
+			next = middleware.Wrap(next)
 		}
 		return next
 	})

--- a/internal/test/integration/components/testserver/grpc/client/client.go
+++ b/internal/test/integration/components/testserver/grpc/client/client.go
@@ -38,7 +38,7 @@ import (
 
 var (
 	logs    = slog.With("component", "grpc.Client")
-	counter int64
+	counter atomic.Int64
 )
 
 type pingOpts struct {
@@ -140,7 +140,7 @@ func printFeatures(client pb.RouteGuideClient, rect *pb.Rectangle) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cnt := atomic.AddInt64(&counter, 1)
+	cnt := counter.Add(1)
 
 	var traceID [16]byte
 	var spanID [8]byte

--- a/internal/test/integration/discovery_test.go
+++ b/internal/test/integration/discovery_test.go
@@ -54,7 +54,7 @@ func testSelectiveExports(t *testing.T) {
 
 	// Run couple of requests to make sure we flush out any transactions that might be
 	// stuck because of our tracking of full request times
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ti.DoHTTPGet(t, "http://localhost:5000/a", 200)
 		ti.DoHTTPGet(t, "http://localhost:5001/b", 200)
 	}

--- a/internal/test/integration/go_kafka_traceparent_test.go
+++ b/internal/test/integration/go_kafka_traceparent_test.go
@@ -80,7 +80,7 @@ func testGoKafkaTraceparent(t *testing.T) {
 	// Contamination is timing-dependent, so drive a batch to give a buggy build
 	// many opportunities to leak the produce trace context into the worker line.
 	const batch = 60
-	for i := 0; i < batch; i++ {
+	for range batch {
 		fire()
 		time.Sleep(30 * time.Millisecond)
 	}

--- a/internal/test/integration/grpc_relay_test.go
+++ b/internal/test/integration/grpc_relay_test.go
@@ -607,7 +607,7 @@ func testGRPCPersistentDynTable(t *testing.T) {
 		lastFailed = lastFailed[:0]
 		traceIDs := make([]string, numRequests)
 		base := uint64(time.Now().UnixNano())
-		for i := 0; i < numRequests; i++ {
+		for i := range numRequests {
 			nowI := base + uint64(i)*1000
 			traceIDs[i] = fmt.Sprintf("%016x%016x", nowI, nowI+1)
 			req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/relay", nil)

--- a/internal/test/integration/http_enrichment_body_test.go
+++ b/internal/test/integration/http_enrichment_body_test.go
@@ -24,7 +24,7 @@ func bodyExtractionObfuscate(t *testing.T, postOperation string) {
 	// Send POST requests with a JSON body containing sensitive fields.
 	// The config obfuscates $.password and $.secret with "***", credit-card
 	// fields with "PCI", and social/insurance numbers with "PII" on POST requests.
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPPost(t, instrumentedServiceStdURL+"/rolldice/50", 200,
 			[]byte(`{"username":"alice","password":"secret123","secret":"my-api-key","email":"alice@test.com","credit-card":"4111-1111-1111-1111","creditcard":"5555555555554444","cc":"378282246310005","sin":"046454286","ssn":"123-45-6789"}`))
 	}
@@ -81,7 +81,7 @@ func bodyExtractionInclude(t *testing.T, postOperation string) {
 	// to the included body.
 
 	// Send a POST without the sensitive fields to test pure include behavior.
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPPost(t, instrumentedServiceStdURL+"/rolldice/51", 200,
 			[]byte(`{"action":"roll","sides":6}`))
 	}
@@ -125,7 +125,7 @@ func bodyExtractionInclude(t *testing.T, postOperation string) {
 // bodyExtractionExcludedByDefault verifies that GET requests (which don't match
 // any body rules) have no body content on the span.
 func bodyExtractionExcludedByDefault(t *testing.T, getOperation string) {
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPGetWithHeaders(t, instrumentedServiceStdURL+"/rolldice/52", 200, nil)
 	}
 
@@ -159,7 +159,7 @@ func bodyExtractionExcludedByDefault(t *testing.T, getOperation string) {
 // bodyExtractionContentTypeHeader verifies that the Content-Type header
 // is also included on the span (configured via a header include rule).
 func bodyExtractionContentTypeHeader(t *testing.T, postOperation string) {
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPPost(t, instrumentedServiceStdURL+"/rolldice/53", 200,
 			[]byte(`{"test":"header-check"}`))
 	}

--- a/internal/test/integration/http_enrichment_test.go
+++ b/internal/test/integration/http_enrichment_test.go
@@ -48,7 +48,7 @@ func doHTTPGetWithRawHeaders(t *testing.T, url string, status int, headers http.
 func testGenericHeaderExtraction(t *testing.T) {
 	// Send requests to /rolldice/42 with custom request headers.
 	// The test server sets response headers: Content-Type and X-Dice-Roll.
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPGetWithHeaders(t, instrumentedServiceStdURL+"/rolldice/42", 200, map[string]string{
 			"X-Custom-Foo":  "custom-value",
 			"Authorization": "Bearer secret-token",
@@ -115,7 +115,7 @@ func testGenericHeaderExtraction(t *testing.T) {
 // the obfuscate rule for Authorization fires before the include-all rule.
 func testGenericHeaderRuleOrder(t *testing.T) {
 	// Send a request with both Authorization and a custom header.
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPGetWithHeaders(t, instrumentedServiceStdURL+"/rolldice/99", 200, map[string]string{
 			"Authorization":   "Bearer another-secret",
 			"X-Custom-Header": "should-be-included",
@@ -169,7 +169,7 @@ func testGenericHeaderMultipleValues(t *testing.T) {
 	headers.Add("X-Custom-Triple", "beta")
 	headers.Add("X-Custom-Triple", "gamma")
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPGetWithRawHeaders(t, instrumentedServiceStdURL+"/rolldice/77", 200, headers.Clone())
 	}
 

--- a/internal/test/integration/http_go_otel_test.go
+++ b/internal/test/integration/http_go_otel_test.go
@@ -86,7 +86,7 @@ func setupGoOTelTestServer(t *testing.T, net dockertest.Network, env []string) {
 }
 
 func testForHTTPGoOTelLibrary(t *testing.T, route, svcNs string) {
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, "http://localhost:8080"+route, 200)
 	}
 
@@ -142,7 +142,7 @@ func testForHTTPGoOTelLibrary(t *testing.T, route, svcNs string) {
 }
 
 func testInstrumentationMissing(t *testing.T, route, svcNs string) {
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, "http://localhost:8080"+route, 200)
 	}
 

--- a/internal/test/integration/internal_metrics_test.go
+++ b/internal/test/integration/internal_metrics_test.go
@@ -69,7 +69,7 @@ func TestAvoidedServicesMetrics(t *testing.T) {
 		time.Sleep(15 * time.Second)
 
 		// Make additional requests to ensure OTLP endpoints are hit
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			ti.DoHTTPGet(t, "http://localhost:8080/rolldice", 200)
 			time.Sleep(1 * time.Second)
 		}

--- a/internal/test/integration/java_dist_test.go
+++ b/internal/test/integration/java_dist_test.go
@@ -59,7 +59,7 @@ func testJavaNestedTraces(t *testing.T, slug string) {
 func testJavaNestedTracesPlainHTTP(t *testing.T, slug string) {
 	t.Log("checking server to client nesting over plain HTTP for [/api/" + slug + "]")
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			ti.DoHTTPGet(ct, "http://localhost:8081/api/"+slug+"?url=http://downstream:8086/rolldice/1", 200)
 		}
 

--- a/internal/test/integration/java_vthreads_test.go
+++ b/internal/test/integration/java_vthreads_test.go
@@ -66,17 +66,15 @@ func TestJavaVirtualThreads(t *testing.T) {
 	var total, nested int
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		var wg sync.WaitGroup
-		for w := 0; w < 40; w++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for i := 0; i < 3; i++ {
+		for range 40 {
+			wg.Go(func() {
+				for range 3 {
 					resp, err := http.Get("http://localhost:8085/sync-client?url=http://downstream:8086/rolldice/1")
 					if err == nil {
 						_ = resp.Body.Close()
 					}
 				}
-			}()
+			})
 		}
 		wg.Wait()
 

--- a/internal/test/integration/log_enricher_test.go
+++ b/internal/test/integration/log_enricher_test.go
@@ -1051,7 +1051,6 @@ func testLogEnricherPlainText(t *testing.T, constants testServerConstants) {
 
 func findLogLine(logs []string, message string) string {
 	for _, line := range slices.Backward(logs) {
-
 		if strings.Contains(line, message) {
 			return line
 		}

--- a/internal/test/integration/log_enricher_test.go
+++ b/internal/test/integration/log_enricher_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -266,7 +267,7 @@ func testLogEnricherNodeJS(t *testing.T) {
 
 		// Log lines must appear in the same order requests were made.
 		// Using last-occurrence positions compares within the most recent batch.
-		for i := 0; i < len(logEnricherTestTraceparents)-1; i++ {
+		for i := range len(logEnricherTestTraceparents) - 1 {
 			a, b := logEnricherTestTraceparents[i], logEnricherTestTraceparents[i+1]
 			posA, okA := lastPos[a.traceID]
 			posB, okB := lastPos[b.traceID]
@@ -549,7 +550,7 @@ func testLogEnricherPythonAsyncEndpoint(t *testing.T, cl *client.Client, logEndp
 func testLogEnricherPythonAsyncOTelInstrumented(t *testing.T) {
 	waitForTestComponentsNoMetrics(t, logEnricherPythonAsyncConstants.url+logEnricherPythonAsyncConstants.smokeEndpoint)
 
-	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cl, err := client.New(client.FromEnv, client.WithAPIVersionNegotiation())
 	require.NoError(t, err)
 	defer cl.Close()
 
@@ -980,8 +981,8 @@ func testLogEnricher(t *testing.T, constants testServerConstants) {
 		logIdx := -1
 		// Loop from the end -- it might be possible that OBI wasn't ready to inject
 		// context when the test started, so get the latest request logs every time.
-		for i := len(logs) - 1; i >= 0; i-- {
-			if strings.Contains(logs[i], "span_id") {
+		for i, log := range slices.Backward(logs) {
+			if strings.Contains(log, "span_id") {
 				logIdx = i
 				break
 			}
@@ -1049,8 +1050,8 @@ func testLogEnricherPlainText(t *testing.T, constants testServerConstants) {
 }
 
 func findLogLine(logs []string, message string) string {
-	for i := len(logs) - 1; i >= 0; i-- {
-		line := logs[i]
+	for _, line := range slices.Backward(logs) {
+
 		if strings.Contains(line, message) {
 			return line
 		}
@@ -1062,7 +1063,7 @@ func findLogLine(logs []string, message string) string {
 func testLogEnricherWritevClamp(t *testing.T, constants testServerConstants) {
 	waitForTestComponentsNoMetrics(t, constants.url+constants.smokeEndpoint)
 
-	cl, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cl, err := client.New(client.FromEnv, client.WithAPIVersionNegotiation())
 	require.NoError(t, err)
 	defer cl.Close()
 

--- a/internal/test/integration/multiprocess_test.go
+++ b/internal/test/integration/multiprocess_test.go
@@ -172,7 +172,7 @@ func TestMultiProcessAppCPTCPOnly(t *testing.T) {
 // Prevents that two instances of the same process report traces or metrics by duplicate
 func checkReportedOnlyOnce(t *testing.T, baseURL, serviceName string) {
 	const path = "/check-only-once"
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		resp, err := http.Get(baseURL + path)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -223,7 +223,7 @@ func checkInstrumentedProcessesMetric(t *testing.T) {
 func testPartialLanguageHTTPProbes(t *testing.T) {
 	waitForTestComponentsSub(t, "http://localhost:8091", "/dist") // rust
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		ti.DoHTTPGet(t, "http://localhost:8091/dist", 200)
 	}
 

--- a/internal/test/integration/nodejs_multiproc_test.go
+++ b/internal/test/integration/nodejs_multiproc_test.go
@@ -49,7 +49,7 @@ func testNestedTraces(t *testing.T) {
 	// Add and check for specific trace ID
 	// Run couple of requests to make sure we flush out any transactions that might be
 	// stuck because of our tracking of full request times
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ti.DoHTTPGet(t, "http://localhost:5000/a", 200)
 	}
 

--- a/internal/test/integration/old_grpc_test.go
+++ b/internal/test/integration/old_grpc_test.go
@@ -25,7 +25,7 @@ func testREDMetricsTracesForOldGRPCLibrary(t *testing.T, svcNs string) {
 
 	path := "/factorial/2"
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPGetIgnoreStatus(t, url+path)
 	}
 

--- a/internal/test/integration/php_fm_test.go
+++ b/internal/test/integration/php_fm_test.go
@@ -40,7 +40,7 @@ func testREDMetricsForPHPHTTPLibrary(t *testing.T, url string, nginx, php string
 	// Call 4 times the instrumented service, forcing it to:
 	// - process multiple calls in a row with, one more than we might need
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, fmt.Sprintf("%s%s", url, path), 200)
 	}
 
@@ -128,7 +128,7 @@ func TestPHPFM(t *testing.T) {
 }
 
 func testHTTPTracesPHP(t *testing.T) {
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, "http://localhost:8080/", 200)
 	}
 

--- a/internal/test/integration/red_test.go
+++ b/internal/test/integration/red_test.go
@@ -266,7 +266,7 @@ func testREDMetricsForJSONRPCHTTP(t *testing.T, url, svcName, svcNs string) {
 	urlPath := "/jsonrpc"
 	expectedMethod := "Arith.Multiply"
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPPost(t, url+urlPath, 200, jsonBody)
 	}
 
@@ -305,7 +305,7 @@ func testREDMetricsForHTTPLibrary(t *testing.T, url, svcName, svcNs string) {
 	// Call 3 times the instrumented service, forcing it to:
 	// - take at least 30ms to respond
 	// - returning a 404 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, url+"/metrics", 200)
 		ti.DoHTTPGet(t, url+path+"?delay=30ms&status=404", 404)
 		if url == instrumentedServiceGorillaURL {
@@ -560,7 +560,7 @@ func testREDMetricsGRPCInternal(t *testing.T, opts []grpcclient.PingOption, serv
 	// Call 300 times the instrumented service, an overkill to make sure
 	// we get some of the metrics to be visible in Prometheus. This test is
 	// currently the last one that runs.
-	for i := 0; i < 300; i++ {
+	for range 300 {
 		err := grpcclient.Ping(opts...)
 		require.NoError(t, err)
 	}
@@ -597,7 +597,7 @@ func testREDMetricsForHTTPLibraryNoRoute(t *testing.T, url, svcName string) {
 	// Call 3 times the instrumented service, forcing it to:
 	// - take at least 30ms to respond
 	// - returning a 404 code
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		ti.DoHTTPGet(t, url+"/metrics", 200)
 		ti.DoHTTPGet(t, url+path+"?delay=30ms&status=404", 404)
 		ti.DoHTTPGet(t, url+"/echo", 203)
@@ -839,7 +839,7 @@ func testREDMetricsForHTTPLibraryNoRouteLowCardinality(t *testing.T, url, svcNam
 	// Call 3 times the instrumented service, forcing it to:
 	// - take at least 30ms to respond
 	// - returning a 404 code
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		for _, s := range validNames {
 			ti.DoHTTPGet(t, url+"/api/"+s+"?delay=30ms&status=404", 404)
 		}
@@ -947,7 +947,7 @@ func testREDMetricsRouteHarvesting(t *testing.T, url, svcName, svcNameSpace, rou
 	pq := promtest.Client{HostPort: prometheusHostPort}
 	path := "/rolldice/4"
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, url+path, 200)
 	}
 

--- a/internal/test/integration/red_test_aerospike.go
+++ b/internal/test/integration/red_test_aerospike.go
@@ -27,7 +27,7 @@ func testREDMetricsForAerospikeLibrary(t *testing.T, testCase TestCase) {
 	namespace := testCase.Namespace
 
 	// Drive the instrumented service a few times so each Aerospike operation runs.
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, baseURL+"/"+urlPath, 200)
 	}
 

--- a/internal/test/integration/red_test_dotnet.go
+++ b/internal/test/integration/red_test_dotnet.go
@@ -21,7 +21,7 @@ func testREDMetricsForNetHTTPLibrary(t *testing.T, url string, comm string) {
 	// Call 3 times the instrumented service, forcing it to:
 	// - take a large JSON file
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, url+urlPath, 200)
 	}
 
@@ -81,7 +81,7 @@ func testREDMetricsForNetHTTPSLibrary(t *testing.T, url string, comm string) {
 	// Call 3 times the instrumented service, forcing it to:
 	// - take at least 30ms to respond
 	// - returning a 204 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, url+path, 200)
 	}
 

--- a/internal/test/integration/red_test_elixir.go
+++ b/internal/test/integration/red_test_elixir.go
@@ -30,7 +30,7 @@ func testREDMetricsForElixirHTTPLibrary(t *testing.T, url string, comm string) {
 	// Call 4 times the instrumented service, forcing it to:
 	// - process multiple calls in a row with, one more than we might need
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		ti.DoHTTPGet(t, fmt.Sprintf("%s%s/%d", url, path, i), 200)
 	}
 

--- a/internal/test/integration/red_test_java.go
+++ b/internal/test/integration/red_test_java.go
@@ -26,7 +26,7 @@ func testREDMetricsForJavaHTTPLibrary(t *testing.T, urls []string, comm string) 
 	// Call 3 times the instrumented service, forcing it to:
 	// - take at least 30ms to respond
 	// - returning a 204 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		for _, url := range urls {
 			ti.DoHTTPGet(t, url+path+"?delay=30&response=204", 204)
 		}

--- a/internal/test/integration/red_test_memorybio.go
+++ b/internal/test/integration/red_test_memorybio.go
@@ -120,9 +120,7 @@ func driveMemoryBIOLoad(_ *testing.T) {
 	close(requests)
 
 	for range memoryBIOConcurrency {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			client := &http.Client{Timeout: 10 * time.Second}
 			for range requests {
 				resp, err := client.Get(memoryBIOAppURL)
@@ -132,7 +130,7 @@ func driveMemoryBIOLoad(_ *testing.T) {
 				_, _ = io.Copy(io.Discard, resp.Body)
 				resp.Body.Close()
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/internal/test/integration/red_test_nodejs.go
+++ b/internal/test/integration/red_test_nodejs.go
@@ -25,7 +25,7 @@ func testREDMetricsForNodeHTTPLibrary(t *testing.T, url, urlPath, comm, namespac
 	// Call 3 times the instrumented service, forcing it to:
 	// - take a large JSON file
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPPost(t, url+urlPath, 200, jsonBody)
 	}
 
@@ -56,7 +56,7 @@ func testREDMetricsForNodeHTTPLibraryRoutes(t *testing.T, url, comm, namespace s
 	slug := "/users/u"
 	// Call 3 times the instrumented service, forcing it to:
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		ti.DoHTTPGet(t, url+slug+strconv.Itoa(i), 200)
 	}
 

--- a/internal/test/integration/red_test_nodejs_bullmq.go
+++ b/internal/test/integration/red_test_nodejs_bullmq.go
@@ -30,7 +30,7 @@ func testREDMetricsNodeBullMQ(t *testing.T) {
 	const url = "http://localhost:8382"
 
 	// each job wakes the worker: bzpopmin reply + evalsha + get + set
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, url+"/job", 200)
 		time.Sleep(500 * time.Millisecond)
 	}

--- a/internal/test/integration/red_test_python.go
+++ b/internal/test/integration/red_test_python.go
@@ -20,7 +20,7 @@ func testREDMetricsForPythonHTTPLibrary(t *testing.T, url, comm, namespace strin
 	// Call 3 times the instrumented service, forcing it to:
 	// - take a large JSON file
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, url+urlPath, 200)
 	}
 
@@ -76,7 +76,7 @@ func testREDMetricsTimeoutForPythonHTTPLibrary(t *testing.T, url, comm, namespac
 }
 
 func testREDMetricsDNSForPython(t *testing.T, url, comm, namespace string) {
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, url+"/ok_dns", 200)
 		ti.DoHTTPGet(t, url+"/bad_dns", 200)
 	}

--- a/internal/test/integration/red_test_python_couchbase.go
+++ b/internal/test/integration/red_test_python_couchbase.go
@@ -28,7 +28,7 @@ func testREDMetricsForPythonCouchbaseLibrary(t *testing.T, testCase TestCase) {
 	namespace := testCase.Namespace
 
 	// Call 4 times the instrumented service
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, uri+"/"+urlPath, 200)
 	}
 
@@ -426,7 +426,7 @@ func testREDMetricsForCouchbaseSQLPP(t *testing.T, testCase TestCase) {
 	namespace := testCase.Namespace
 
 	// Call 4 times the instrumented service
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, uri+"/"+urlPath, 200)
 	}
 

--- a/internal/test/integration/red_test_python_mongo.go
+++ b/internal/test/integration/red_test_python_mongo.go
@@ -28,7 +28,7 @@ func testREDMetricsForPythonMongoLibrary(t *testing.T, testCase TestCase) {
 	// Call 3 times the instrumented service, forcing it to:
 	// - take a large JSON file
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, uri+"/"+urlPath, 200)
 	}
 

--- a/internal/test/integration/red_test_python_redis.go
+++ b/internal/test/integration/red_test_python_redis.go
@@ -27,7 +27,7 @@ func testREDMetricsForPythonRedisLibrary(t *testing.T, testCase TestCase) {
 	// Call 3 times the instrumented service, forcing it to:
 	// - take a large JSON file
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, url+"/"+urlPath, 200)
 	}
 

--- a/internal/test/integration/red_test_python_sql.go
+++ b/internal/test/integration/red_test_python_sql.go
@@ -403,7 +403,7 @@ func testREDMetricsForPythonSQLSSL(t *testing.T, url, comm, namespace string) {
 	// Call 3 times the instrumented service, forcing it to:
 	// - take a large JSON file
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, url+urlPath, 200)
 	}
 

--- a/internal/test/integration/red_test_redis_server.go
+++ b/internal/test/integration/red_test_redis_server.go
@@ -27,7 +27,7 @@ func testREDMetricsRedisServerSide(t *testing.T) {
 	urlPath := "redis"
 	namespace := "integration-test"
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, url+"/"+urlPath, 200)
 	}
 

--- a/internal/test/integration/red_test_ruby.go
+++ b/internal/test/integration/red_test_ruby.go
@@ -80,7 +80,7 @@ func testREDMetricsForRubyHTTPLibrary(t *testing.T, url string, comm string) {
 	// Call 4 times the instrumented service, forcing it to:
 	// - process multiple calls in a row with, one more than we might need
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		ti.DoHTTPGet(t, url+path+"/1", 200)
 	}
 
@@ -141,7 +141,7 @@ func assertRubyPumaSupportVersion(t *testing.T, compose *docker.Compose, expecte
 	require.NoError(t, err, "bundle exec ruby output:\n%s", output)
 
 	var versionLines []string
-	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "time=") {
 			continue

--- a/internal/test/integration/red_test_rust.go
+++ b/internal/test/integration/red_test_rust.go
@@ -28,7 +28,7 @@ func testREDMetricsForRustHTTPLibrary(t *testing.T, url, comm, namespace string,
 	// Call 4 times the instrumented service, forcing it to:
 	// - take a large JSON body
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPPost(t, url+urlPath, 200, jsonBody)
 	}
 
@@ -153,7 +153,7 @@ func validateLargeDownloadURLSeen(t *testing.T, comm, namespace, urlPath string)
 }
 
 func testREDMetricsForLargeRustDownloads(t *testing.T, tURL, comm, namespace string) {
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTPGetFullResponse(t, tURL+"/large", 200)
 		doHTTPGetFullResponse(t, tURL+"/download1", 200)
 		doHTTPGetFullResponse(t, tURL+"/download2", 200)
@@ -228,7 +228,7 @@ func testREDMetricsForRustHTTP2Library(t *testing.T, url, comm, namespace string
 	// Call 4 times the instrumented service, forcing it to:
 	// - take a large JSON body
 	// - returning a 200 code
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		doHTTP2Post(t, url+urlPath, 200, jsonBody)
 	}
 

--- a/internal/test/integration/sampler_test.go
+++ b/internal/test/integration/sampler_test.go
@@ -32,7 +32,7 @@ func testSampler(t *testing.T) {
 	// Add and check for specific trace ID
 	// Run couple of requests to make sure we flush out any transactions that might be
 	// stuck because of our tracking of full request times
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ti.DoHTTPGet(t, "http://localhost:5000/a", 200)
 	}
 

--- a/internal/test/integration/traces_node_manual_test.go
+++ b/internal/test/integration/traces_node_manual_test.go
@@ -25,7 +25,7 @@ import (
 // under OBI's "processing" sub-span, which carries the in-flight request
 // context that the bridge spans inherit).
 func testHTTPTracesNodeManualSpans(t *testing.T) {
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		ti.DoHTTPGet(t, "http://localhost:3031/manual", 200)
 	}
 
@@ -133,7 +133,7 @@ func testHTTPTracesNodeManualSpans(t *testing.T) {
 // background span ends, mis-parenting it into that trace. The request's own
 // manual span ("slow-op") must still re-anchor correctly afterwards.
 func testHTTPTracesNodeManualBackgroundSpan(t *testing.T) {
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		ti.DoHTTPGet(t, "http://localhost:3031/manual-slow", 200)
 	}
 

--- a/internal/test/integration/traces_test.go
+++ b/internal/test/integration/traces_test.go
@@ -414,7 +414,7 @@ func testHTTPTracesNestedCalls(t *testing.T) {
 	traceparent := createTraceparent(traceID, parentID)
 	doHTTPGetWithTraceparent(t, "http://localhost:8082/echo", 203, traceparent)
 	// Do some requests to make sure we see all events
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ti.DoHTTPGet(t, "http://localhost:8082/metrics", 200)
 	}
 
@@ -545,7 +545,7 @@ func testHTTP2GRPCTracesNestedCalls(t *testing.T, contextPropagation bool) {
 	traceparent := createTraceparent(traceID, parentID)
 	doHTTPGetWithTraceparent(t, "http://localhost:8080/echoCall", 204, traceparent)
 	// Do some requests to make sure we see all events
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ti.DoHTTPGet(t, "http://localhost:8080/metrics", 200)
 	}
 
@@ -696,7 +696,7 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 	// Add and check for specific trace ID
 	// Run couple of requests to make sure we flush out any transactions that might be
 	// stuck because of our tracking of full request times
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ti.DoHTTPGet(t, "http://localhost:8091/dist", 200)
 	}
 
@@ -866,7 +866,7 @@ func testNestedHTTPTracesKProbes(t *testing.T) {
 	}, 3*testTimeout, 100*time.Millisecond)
 
 	// test now with a different version of Java thread pool
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ti.DoHTTPGet(t, "http://localhost:8086/jtraceA", 200)
 	}
 
@@ -1314,7 +1314,7 @@ func testHTTPTracesNestedNodeJSDistCalls(t *testing.T) {
 	seenR := false
 	seenQ := false
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		child := children[i]
 
 		sd = child.Diff(
@@ -1360,7 +1360,7 @@ func testHTTPTracesNestedManualSpans(t *testing.T) {
 
 	ti.DoHTTPGet(t, "http://localhost:8080/manual", 200)
 	// Do some requests to make sure we see all events
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ti.DoHTTPGet(t, "http://localhost:8082/metrics", 200)
 	}
 
@@ -1689,7 +1689,7 @@ func testGoGenericHTTPTraces(t *testing.T) {
 	// 2. HTTP client call nested within Go Generic Server (Fiber)
 	// 3. HTTP non-Go library call nested within Go HTTP Server
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		ti.DoHTTPGet(t, "http://localhost:8080/produce", 200)
 		ti.DoHTTPGet(t, "http://localhost:8080/ping", 200)
 		ti.DoHTTPGet(t, "http://localhost:8081/ping1", 200)
@@ -1808,7 +1808,7 @@ func testGoGenericHTTPSTraces(t *testing.T) {
 	// 1. Go Generic client TLS (Kafka) call nested within Go Generic Server TLS (Fiber)
 	// 2. HTTPS non-Go library call nested within Go Generic Server TLS (Fiber)
 
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		ti.DoHTTPGet(t, "https://localhost:8443/produce/tls", 200)
 		ti.DoHTTPGet(t, "https://localhost:8443/api/pingssl", 200)
 	}
@@ -1895,7 +1895,7 @@ func testHTTPTracesNoNestedCalls(t *testing.T) {
 	traceparent := createTraceparent(traceID, parentID)
 	doHTTPGetWithTraceparent(t, "http://localhost:8080/delay", 203, traceparent)
 	// Do some requests to make sure we see all events
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ti.DoHTTPGet(t, "http://localhost:8080/metrics", 200)
 	}
 

--- a/internal/test/tools/dir.go
+++ b/internal/test/tools/dir.go
@@ -40,7 +40,7 @@ func ProjectDir() string {
 		return true
 	}
 
-	for i := 0; i < 50; i++ { // Limit directory traversal to prevent infinite loops
+	for range 50 { // Limit directory traversal to prevent infinite loops
 		if isProjectRoot(thisDir) {
 			break
 		}

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -315,9 +315,9 @@ type GenAI struct {
 }
 
 type OpenAIInputTokensDetails struct {
-	CachedTokens        TokenCount `json:"cached_tokens,omitempty"`
-	CacheCreationTokens TokenCount `json:"cache_creation_tokens,omitempty"`
-	AudioTokens         TokenCount `json:"audio_tokens,omitempty"`
+	CachedTokens        TokenCount `json:"cached_tokens"`
+	CacheCreationTokens TokenCount `json:"cache_creation_tokens"`
+	AudioTokens         TokenCount `json:"audio_tokens"`
 }
 
 type OpenAIUsage struct {
@@ -331,10 +331,10 @@ type OpenAIUsage struct {
 }
 
 type OpenAIOutputTokensDetails struct {
-	ReasoningTokens          TokenCount `json:"reasoning_tokens,omitempty"`
-	AudioTokens              TokenCount `json:"audio_tokens,omitempty"`
-	AcceptedPredictionTokens TokenCount `json:"accepted_prediction_tokens,omitempty"`
-	RejectedPredictionTokens TokenCount `json:"rejected_prediction_tokens,omitempty"`
+	ReasoningTokens          TokenCount `json:"reasoning_tokens"`
+	AudioTokens              TokenCount `json:"audio_tokens"`
+	AcceptedPredictionTokens TokenCount `json:"accepted_prediction_tokens"`
+	RejectedPredictionTokens TokenCount `json:"rejected_prediction_tokens"`
 }
 
 type OpenAIError struct {
@@ -617,17 +617,17 @@ type AnthropicResponse struct {
 type AnthropicUsage struct {
 	InputTokens              TokenCount              `json:"input_tokens"`
 	OutputTokens             TokenCount              `json:"output_tokens"`
-	CacheCreationInputTokens TokenCount              `json:"cache_creation_input_tokens,omitempty"`
-	CacheReadInputTokens     TokenCount              `json:"cache_read_input_tokens,omitempty"`
-	ReasoningOutputTokens    TokenCount              `json:"reasoning_output_tokens,omitempty"`
+	CacheCreationInputTokens TokenCount              `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     TokenCount              `json:"cache_read_input_tokens"`
+	ReasoningOutputTokens    TokenCount              `json:"reasoning_output_tokens"`
 	CacheCreation            *AnthropicCacheCreation `json:"cache_creation,omitempty"`
 	ServiceTier              string                  `json:"service_tier"`
 	InferenceGeo             string                  `json:"inference_geo"`
 }
 
 type AnthropicCacheCreation struct {
-	Ephemeral5mInputTokens TokenCount `json:"ephemeral_5m_input_tokens,omitempty"`
-	Ephemeral1hInputTokens TokenCount `json:"ephemeral_1h_input_tokens,omitempty"`
+	Ephemeral5mInputTokens TokenCount `json:"ephemeral_5m_input_tokens"`
+	Ephemeral1hInputTokens TokenCount `json:"ephemeral_1h_input_tokens"`
 }
 
 type AnthropicError struct {
@@ -693,9 +693,9 @@ type GeminiUsage struct {
 	PromptTokenCount           TokenCount                 `json:"promptTokenCount"`
 	CandidatesTokenCount       TokenCount                 `json:"candidatesTokenCount"`
 	TotalTokenCount            TokenCount                 `json:"totalTokenCount"`
-	ToolUsePromptTokenCount    TokenCount                 `json:"toolUsePromptTokenCount,omitempty"`
-	ThoughtsTokenCount         TokenCount                 `json:"thoughtsTokenCount,omitempty"`
-	CachedContentTokenCount    TokenCount                 `json:"cachedContentTokenCount,omitempty"`
+	ToolUsePromptTokenCount    TokenCount                 `json:"toolUsePromptTokenCount"`
+	ThoughtsTokenCount         TokenCount                 `json:"thoughtsTokenCount"`
+	CachedContentTokenCount    TokenCount                 `json:"cachedContentTokenCount"`
 	PromptTokensDetails        []GeminiModalityTokenCount `json:"promptTokensDetails,omitempty"`
 	CacheTokensDetails         []GeminiModalityTokenCount `json:"cacheTokensDetails,omitempty"`
 	CandidatesTokensDetails    []GeminiModalityTokenCount `json:"candidatesTokensDetails,omitempty"`
@@ -792,14 +792,14 @@ type BedrockResponse struct {
 	// Anthropic Claude format
 	Content    json.RawMessage `json:"content,omitempty"`
 	StopReason string          `json:"stop_reason,omitempty"`
-	Usage      BedrockUsage    `json:"usage,omitempty"`
+	Usage      BedrockUsage    `json:"usage"`
 	// Amazon Nova format
 	Output         *NovaOutput `json:"output,omitempty"`
 	StopReasonNova string      `json:"stopReason,omitempty"`
 	// Meta Llama format
 	Generation           string     `json:"generation,omitempty"`
-	PromptTokenCount     TokenCount `json:"prompt_token_count,omitempty"`
-	GenerationTokenCount TokenCount `json:"generation_token_count,omitempty"`
+	PromptTokenCount     TokenCount `json:"prompt_token_count"`
+	GenerationTokenCount TokenCount `json:"generation_token_count"`
 	// Amazon Titan format
 	Results []TitanResult `json:"results,omitempty"`
 	// Error fields appear at the top level of the Bedrock error response body
@@ -811,11 +811,11 @@ type BedrockResponse struct {
 }
 
 type BedrockUsage struct {
-	InputTokens           TokenCount              `json:"inputTokens,omitempty"`
-	OutputTokens          TokenCount              `json:"outputTokens,omitempty"`
-	TotalTokens           TokenCount              `json:"totalTokens,omitempty"`
-	CacheReadInputTokens  TokenCount              `json:"cacheReadInputTokens,omitempty"`
-	CacheWriteInputTokens TokenCount              `json:"cacheWriteInputTokens,omitempty"`
+	InputTokens           TokenCount              `json:"inputTokens"`
+	OutputTokens          TokenCount              `json:"outputTokens"`
+	TotalTokens           TokenCount              `json:"totalTokens"`
+	CacheReadInputTokens  TokenCount              `json:"cacheReadInputTokens"`
+	CacheWriteInputTokens TokenCount              `json:"cacheWriteInputTokens"`
 	CacheDetails          []BedrockCacheDetail    `json:"cacheDetails,omitempty"`
 	CacheCreation         *AnthropicCacheCreation `json:"cache_creation,omitempty"`
 }
@@ -1289,14 +1289,14 @@ func (r *RetrievalRequest) GetTopK() int {
 type RetrievalResponse struct {
 	ID    string         `json:"id,omitempty"`
 	Model string         `json:"model,omitempty"`
-	Usage RetrievalUsage `json:"usage,omitempty"`
+	Usage RetrievalUsage `json:"usage"`
 }
 
 // RetrievalUsage captures optional token usage information returned by
 // embedding-aware vector stores.
 type RetrievalUsage struct {
-	TotalTokens  TokenCount `json:"total_tokens,omitempty"`
-	PromptTokens TokenCount `json:"prompt_tokens,omitempty"`
+	TotalTokens  TokenCount `json:"total_tokens"`
+	PromptTokens TokenCount `json:"prompt_tokens"`
 }
 
 type SpanLink struct {

--- a/pkg/appolly/discover/java_injection_queue_test.go
+++ b/pkg/appolly/discover/java_injection_queue_test.go
@@ -55,8 +55,7 @@ func TestJavaInjectionQueue_InjectsOneAtATimeInOrder(t *testing.T) {
 		return nil
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	queue.start(ctx)
 
 	var want []app.PID
@@ -114,8 +113,7 @@ func TestJavaInjectionQueue_NoTwoJVMsShareProcessCredentials(t *testing.T) {
 		return nil
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	queue.start(ctx)
 
 	for pid := app.PID(1); pid <= targets; pid++ {
@@ -148,8 +146,7 @@ func TestJavaInjectionQueue_EnqueueDoesNotBlockOnStuckInjection(t *testing.T) {
 		return nil
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	queue.start(ctx)
 
 	queue.enqueue(javaTarget(1))

--- a/pkg/appolly/discover/matcher.go
+++ b/pkg/appolly/discover/matcher.go
@@ -267,12 +267,7 @@ func (m *Matcher) matchProcess(obj *ProcessAttrs, p *services.ProcessInfo, a ser
 }
 
 func pidInList(pid app.PID, list []app.PID) bool {
-	for _, p := range list {
-		if p == pid {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, pid)
 }
 
 func (m *Matcher) matchByPort(p *services.ProcessInfo, a services.Selector) bool {

--- a/pkg/appolly/discover/watcher_proc.go
+++ b/pkg/appolly/discover/watcher_proc.go
@@ -11,6 +11,7 @@ import (
 	"maps"
 	"math"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -210,11 +211,8 @@ func (pa *pollAccounter) forgetPIDs(pids []app.PID) {
 		delete(pa.pids, pid)
 	}
 	for pp := range pa.pidPorts {
-		for _, pid := range pids {
-			if pp.Pid == pid {
-				delete(pa.pidPorts, pp)
-				break
-			}
+		if slices.Contains(pids, pp.Pid) {
+			delete(pa.pidPorts, pp)
 		}
 	}
 }

--- a/pkg/appolly/discover/watcher_proc_linux_test.go
+++ b/pkg/appolly/discover/watcher_proc_linux_test.go
@@ -117,9 +117,7 @@ func TestProcessAgeFuncConcurrent(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 
 			for range iterations {
 				if age := processAge(pid); age <= 0 {
@@ -127,7 +125,7 @@ func TestProcessAgeFuncConcurrent(t *testing.T) {
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/pkg/appolly/discover/watcher_proc_linux_test.go
+++ b/pkg/appolly/discover/watcher_proc_linux_test.go
@@ -118,7 +118,6 @@ func TestProcessAgeFuncConcurrent(t *testing.T) {
 
 	for range goroutines {
 		wg.Go(func() {
-
 			for range iterations {
 				if age := processAge(pid); age <= 0 {
 					errCh <- fmt.Errorf("expected positive process age for pid %d", pid)

--- a/pkg/appolly/parent_settle_test.go
+++ b/pkg/appolly/parent_settle_test.go
@@ -183,7 +183,7 @@ func TestSettleFlushReleasesEverything(t *testing.T) {
 func TestSettleHeldOverflowSettlesOldest(t *testing.T) {
 	s, out := testSettler(t, time.Minute)
 
-	for i := 0; i < maxHeldSpans+10; i++ {
+	for i := range maxHeldSpans + 10 {
 		child := conditionalChild(int64(100 + i))
 		child.SpanID[7] = byte(i)
 		child.ParentSpanID[7] = byte(i % 251)

--- a/pkg/appolly/services/export.go
+++ b/pkg/appolly/services/export.go
@@ -142,7 +142,7 @@ func (modes *ExportModes) UnmarshalText(text []byte) error {
 	if len(text) == 0 {
 		return nil
 	}
-	for _, part := range strings.Split(string(text), ",") {
+	for part := range strings.SplitSeq(string(text), ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue

--- a/pkg/config/ebpf_tracer_test.go
+++ b/pkg/config/ebpf_tracer_test.go
@@ -255,7 +255,7 @@ func TestEBPFTracer_CudaInstrumentationEnabled(t *testing.T) {
 }
 
 func TestEBPFBufferSizesValidateTagsMatchMaxCapturedPayloadBytes(t *testing.T) {
-	typ := reflect.TypeOf(EBPFBufferSizes{})
+	typ := reflect.TypeFor[EBPFBufferSizes]()
 
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)

--- a/pkg/docker/docker_api_client.go
+++ b/pkg/docker/docker_api_client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -110,10 +111,7 @@ func (s *ContainerStore) initialize(ctx context.Context) {
 		return
 	}
 
-	docker, err := client.NewClientWithOpts(
-		client.WithAPIVersionNegotiation(),
-		client.FromEnv,
-	)
+	docker, err := client.New(client.WithAPIVersionNegotiation(), client.FromEnv)
 	if err != nil {
 		s.log.Debug("trying to instantiate docker client", "error", err)
 		return
@@ -160,13 +158,7 @@ func (s *ContainerStore) ContainerInfo(ctx context.Context, pid app.PID) (Contai
 			return ContainerMeta{}, false
 		}
 		meta := entry.meta
-		seen := false
-		for _, cachedPID := range entry.pids {
-			if cachedPID == pid {
-				seen = true
-				break
-			}
-		}
+		seen := slices.Contains(entry.pids, pid)
 		if !seen {
 			entry.pids = append(entry.pids, pid)
 			s.byContainerID[fullContainerID] = entry
@@ -216,13 +208,7 @@ func (s *ContainerStore) ContainerInfo(ctx context.Context, pid app.PID) (Contai
 	}
 	if entry, ok := s.byContainerID[meta.FullID]; ok {
 		meta = entry.meta
-		seen := false
-		for _, cachedPID := range entry.pids {
-			if cachedPID == pid {
-				seen = true
-				break
-			}
-		}
+		seen := slices.Contains(entry.pids, pid)
 		if !seen {
 			entry.pids = append(entry.pids, pid)
 		}

--- a/pkg/docker/docker_api_client_test.go
+++ b/pkg/docker/docker_api_client_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"slices"
 	"strconv"
 	"sync"
 	"testing"
@@ -76,13 +77,7 @@ func requireConsistency(t *testing.T, s *ContainerStore) {
 		entry, ok := s.byContainerID[meta.FullID]
 		require.Truef(t, ok,
 			"byPID[%d] references fullID %q but byContainerID has no entry for it", pid, meta.FullID)
-		found := false
-		for _, p := range entry.pids {
-			if p == pid {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(entry.pids, pid)
 		require.Truef(t, found,
 			"byPID[%d] references fullID %q but that pid is not listed in byContainerID[%q].pids", pid, meta.FullID, meta.FullID)
 	}
@@ -332,8 +327,7 @@ func TestContainerMetadata(t *testing.T) {
 
 func TestStart(t *testing.T) {
 	t.Run("starts_watcher_goroutine_and_processes_events", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		const fullID = "abc123def456789abc123def456789abc123def456789abc123def456789abcdef"
 		pid := app.PID(99)
@@ -375,8 +369,7 @@ func TestStart(t *testing.T) {
 // arrive during the 1-second backoff gap are not silently dropped.
 func TestStartSinceCheckpoint(t *testing.T) {
 	t.Run("initial_since_covers_gap_between_start_and_first_events_call", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		before := time.Now().Unix()
 

--- a/pkg/ebpf/common/aerospike_detect_transform.go
+++ b/pkg/ebpf/common/aerospike_detect_transform.go
@@ -149,7 +149,7 @@ func parseAerospikeRequest(buf *largebuf.LargeBuffer) *aerospikeInfo {
 // flags and the fields decoded before the cut.
 func parseAerospikeFields(r *largebuf.LargeBufferReader, nFields int, info *aerospikeInfo) (hasDigest, hasIndex, hasUDF bool) {
 fieldLoop:
-	for i := 0; i < nFields; i++ {
+	for range nFields {
 		fsz, err := r.ReadU32BE()
 		if err != nil || fsz < 1 {
 			break
@@ -259,7 +259,7 @@ func classifyAerospikeWrite(r *largebuf.LargeBufferReader, nOps int) string {
 	allWrite := true
 	allTouch := true
 	count := 0
-	for i := 0; i < nOps; i++ {
+	for range nOps {
 		opSz, err := r.ReadU32BE()
 		if err != nil || opSz < 1 {
 			break

--- a/pkg/ebpf/common/couchbase_detect_transform.go
+++ b/pkg/ebpf/common/couchbase_detect_transform.go
@@ -126,7 +126,7 @@ func appendValue(b *strings.Builder, pkt couchbasekv.Packet) {
 func stripLEB128Prefix(key []byte) []byte {
 	const maxLen = 5
 	limit := min(len(key), maxLen)
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		if key[i]&0x80 == 0 {
 			return key[i+1:]
 		}

--- a/pkg/ebpf/common/couchbase_detect_transform.go
+++ b/pkg/ebpf/common/couchbase_detect_transform.go
@@ -125,10 +125,7 @@ func appendValue(b *strings.Builder, pkt couchbasekv.Packet) {
 // within that window, the original slice is returned unchanged.
 func stripLEB128Prefix(key []byte) []byte {
 	const maxLen = 5
-	limit := len(key)
-	if limit > maxLen {
-		limit = maxLen
-	}
+	limit := min(len(key), maxLen)
 	for i := 0; i < limit; i++ {
 		if key[i]&0x80 == 0 {
 			return key[i+1:]

--- a/pkg/ebpf/common/fast_cgi_detect_transform.go
+++ b/pkg/ebpf/common/fast_cgi_detect_transform.go
@@ -143,8 +143,8 @@ func detectFastCGI(b, rb *largebuf.LargeBuffer) (string, string, int) {
 		return "", "", -1
 	}
 
-	methodPos := bytes.Index(raw, []byte(requestMethodKey))
-	if methodPos >= 0 {
+	found := bytes.Contains(raw, []byte(requestMethodKey))
+	if found {
 		kv := parseCGITable(raw)
 
 		method, ok := kv[requestMethodKey]

--- a/pkg/ebpf/common/http/anthropic.go
+++ b/pkg/ebpf/common/http/anthropic.go
@@ -216,8 +216,8 @@ func parseAnthropicStream(reader io.Reader) (*request.AnthropicResponse, []reque
 		}
 
 		// Parse event line
-		if strings.HasPrefix(line, "event:") {
-			currentEvent = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		if after, ok := strings.CutPrefix(line, "event:"); ok {
+			currentEvent = strings.TrimSpace(after)
 			continue
 		}
 

--- a/pkg/ebpf/common/http/aws_s3.go
+++ b/pkg/ebpf/common/http/aws_s3.go
@@ -66,7 +66,7 @@ func parseS3bucketKey(req *http.Request) (string, string) {
 	// Case 1: Virtual-hosted–style — bucket in the hostname.
 	// Example: my-bucket.s3.amazonaws.com /foo/bar.txt
 	if strings.Contains(req.Host, ".s3.") {
-		bucket := strings.SplitN(req.Host, ".s3.", 2)[0]
+		bucket, _, _ := strings.Cut(req.Host, ".s3.")
 		return bucket, path
 	}
 

--- a/pkg/ebpf/common/http/bedrock.go
+++ b/pkg/ebpf/common/http/bedrock.go
@@ -126,16 +126,16 @@ func extractBedrockModel(req *http.Request) string {
 	}
 	path := req.URL.Path
 	const prefix = "/model/"
-	idx := strings.Index(path, prefix)
-	if idx < 0 {
+	_, after, ok := strings.Cut(path, prefix)
+	if !ok {
 		return ""
 	}
-	remainder := path[idx+len(prefix):]
-	slashIdx := strings.Index(remainder, "/")
-	if slashIdx < 0 {
+	remainder := after
+	before, _, ok := strings.Cut(remainder, "/")
+	if !ok {
 		return remainder
 	}
-	return remainder[:slashIdx]
+	return before
 }
 
 // isBedrockStream detects streaming Bedrock calls by checking the URL path
@@ -157,10 +157,10 @@ func extractBedrockGuardrailID(req *http.Request, resp *http.Response) string {
 	if req != nil && req.URL != nil {
 		path := req.URL.Path
 		const prefix = "/guardrail/"
-		if idx := strings.Index(path, prefix); idx >= 0 {
-			remainder := path[idx+len(prefix):]
-			if slashIdx := strings.Index(remainder, "/"); slashIdx >= 0 {
-				return remainder[:slashIdx]
+		if _, after, ok := strings.Cut(path, prefix); ok {
+			remainder := after
+			if before, _, ok := strings.Cut(remainder, "/"); ok {
+				return before
 			}
 			return remainder
 		}

--- a/pkg/ebpf/common/http/gemini.go
+++ b/pkg/ebpf/common/http/gemini.go
@@ -209,11 +209,11 @@ func extractGeminiModel(req *http.Request) string {
 // extractGeminiModelFromPath returns the model name embedded in a Gemini URL
 // path, or "" when the path has no /models/ segment.
 func extractGeminiModelFromPath(path string) string {
-	idx := strings.Index(path, geminiModelPrefix)
-	if idx < 0 {
+	_, after, ok := strings.Cut(path, geminiModelPrefix)
+	if !ok {
 		return ""
 	}
-	model := path[idx+len(geminiModelPrefix):]
+	model := after
 	if colonIdx := strings.Index(model, ":"); colonIdx >= 0 {
 		model = model[:colonIdx]
 	}
@@ -228,11 +228,11 @@ func extractGeminiOperation(req *http.Request) string {
 		return request.DefaultGeminiOperation
 	}
 	path := req.URL.Path
-	idx := strings.Index(path, geminiModelPrefix)
-	if idx < 0 {
+	_, after0, ok := strings.Cut(path, geminiModelPrefix)
+	if !ok {
 		return request.DefaultGeminiOperation
 	}
-	after := path[idx+len(geminiModelPrefix):]
+	after := after0
 	colonIdx := strings.Index(after, ":")
 	if colonIdx < 0 || colonIdx+1 >= len(after) {
 		return request.DefaultGeminiOperation

--- a/pkg/ebpf/common/http/http_enrichment.go
+++ b/pkg/ebpf/common/http/http_enrichment.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/ohler55/ojg/oj"
@@ -349,10 +350,5 @@ func methodMatches(methods []config.HTTPMethod, method string) bool {
 		return true
 	}
 	upper := config.HTTPMethod(strings.ToUpper(method))
-	for _, m := range methods {
-		if m == upper {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(methods, upper)
 }

--- a/pkg/ebpf/common/http/http_enrichment_test.go
+++ b/pkg/ebpf/common/http/http_enrichment_test.go
@@ -1263,7 +1263,7 @@ func BenchmarkHTTPEnricher_BodyObfuscate_LargeJSON(b *testing.B) {
 
 	// Build a ~4KB JSON body with 50 users
 	var users []string
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		users = append(users, `{"name":"User`+strings.Repeat("x", 10)+`","email":"user@test.com","ssn":"123-45-6789","role":"admin"}`)
 	}
 	body := `{"users":[` + strings.Join(users, ",") + `]}`

--- a/pkg/ebpf/common/http/rerank.go
+++ b/pkg/ebpf/common/http/rerank.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
@@ -46,13 +47,7 @@ func isRerankPath(req *http.Request) bool {
 		return false
 	}
 
-	for _, segment := range strings.Split(path, "/") {
-		if segment == "rerank" {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(strings.Split(path, "/"), "rerank")
 }
 
 // rerankProviderFromHost returns the provider name based on the request

--- a/pkg/ebpf/common/http2grpc_transform_test.go
+++ b/pkg/ebpf/common/http2grpc_transform_test.go
@@ -406,7 +406,7 @@ func TestHPACKOpensResponseExhaustive(t *testing.T) {
 		varintMore  = 15
 	)
 
-	for b := 0; b < 256; b++ {
+	for b := range 256 {
 		idx, isField := hpackReference(byte(b))
 		fourBit := b&0x80 == 0 && b&0xc0 != 0x40 && b&0xe0 != 0x20
 
@@ -433,7 +433,7 @@ func TestHPACKOpenersAreDisjoint(t *testing.T) {
 		return idx >= 1 && idx <= 7
 	}
 
-	for b := 0; b < 256; b++ {
+	for b := range 256 {
 		if hpackOpensResponse([]byte{byte(b)}) {
 			assert.False(t, opensRequest(byte(b)), "byte 0x%02x opens both", b)
 		}

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -44,9 +44,9 @@ func sortConnectionInfo(info *BpfConnectionInfoT) {
 }
 
 func removeQuery(url string) string {
-	idx := strings.IndexByte(url, '?')
-	if idx >= 0 {
-		return url[:idx]
+	before, _, ok := strings.Cut(url, "?")
+	if ok {
+		return before
 	}
 	return url
 }

--- a/pkg/ebpf/common/memcached_detect_transform.go
+++ b/pkg/ebpf/common/memcached_detect_transform.go
@@ -540,8 +540,8 @@ func memcachedFirstLineFromReader(r *largebuf.LargeBufferReader) ([]byte, bool) 
 }
 
 func memcachedToken(line []byte) []byte {
-	if idx := bytes.IndexByte(line, ' '); idx >= 0 {
-		return line[:idx]
+	if before, _, ok := bytes.Cut(line, []byte{' '}); ok {
+		return before
 	}
 
 	return line

--- a/pkg/ebpf/common/memcached_detect_transform_test.go
+++ b/pkg/ebpf/common/memcached_detect_transform_test.go
@@ -75,14 +75,14 @@ func TestIsMemcachedFirstByte(t *testing.T) {
 
 	// Spot-check each allowed character explicitly so a failure points at the
 	// specific missing one.
-	for i := 0; i < len(allowed); i++ {
+	for i := range len(allowed) {
 		b := allowed[i]
 		assert.Truef(t, isMemcachedFirstByte(b), "expected %q (0x%02X) to be accepted", b, b)
 	}
 
 	// Exhaustive sweep across all 256 possible byte values to guarantee the
 	// bitmap doesn't accept anything outside the allowed set.
-	for b := 0; b < 256; b++ {
+	for b := range 256 {
 		got := isMemcachedFirstByte(byte(b))
 		want := inAllowed(byte(b))
 		assert.Equalf(t, want, got, "byte 0x%02X (%q): want %v", b, byte(b), want)
@@ -682,7 +682,7 @@ func memcachedBenchmarkSetPayload(size int, noreply bool) []byte {
 
 func memcachedBenchmarkCoalescedRequest(noreplyOps int) []byte {
 	buf := bytes.Buffer{}
-	for i := 0; i < noreplyOps; i++ {
+	for i := range noreplyOps {
 		payload := fmt.Sprintf("value-%02d", i)
 		fmt.Fprintf(&buf, "set session-key:%02d 0 300 %d noreply\r\n%s\r\n", i, len(payload), payload)
 	}

--- a/pkg/ebpf/common/mongo_detect_transform_fuzz_test.go
+++ b/pkg/ebpf/common/mongo_detect_transform_fuzz_test.go
@@ -125,10 +125,7 @@ func assertAcceptedMongoHeader(t *testing.T, payload []byte) {
 		t.Fatalf("accepted invalid MongoDB header: length=%d request=%d response=%d opcode=%d",
 			messageLength, requestID, responseTo, opcode)
 	}
-	parsedLength := len(payload)
-	if int(messageLength) < parsedLength {
-		parsedLength = int(messageLength)
-	}
+	parsedLength := min(int(messageLength), len(payload))
 	if responseTo != 0 && parsedLength == 16 {
 		return
 	}

--- a/pkg/ebpf/common/redis_detect_transform.go
+++ b/pkg/ebpf/common/redis_detect_transform.go
@@ -263,7 +263,7 @@ func parseRedisCommand(buf []byte, pos int) (*redisCommand, int, bool) {
 	var text strings.Builder
 	pos = next
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		lenLine, tokStart, ok := readRESPLine(buf, pos)
 		if !ok || len(lenLine) < 2 || lenLine[0] != '$' {
 			return salvageRedisCommand(op, &text), 0, false

--- a/pkg/ebpf/common/redis_detect_transform_test.go
+++ b/pkg/ebpf/common/redis_detect_transform_test.go
@@ -164,7 +164,7 @@ func redisBenchmarkCommand(args ...string) []byte {
 func redisBenchmarkMGet(keys int) []byte {
 	args := make([]string, 0, keys+1)
 	args = append(args, "MGET")
-	for i := 0; i < keys; i++ {
+	for i := range keys {
 		args = append(args, fmt.Sprintf("session-key:%02d", i))
 	}
 
@@ -173,7 +173,7 @@ func redisBenchmarkMGet(keys int) []byte {
 
 func redisBenchmarkPipeline(commands int, args ...string) []byte {
 	buf := bytes.Buffer{}
-	for i := 0; i < commands; i++ {
+	for range commands {
 		buf.Write(redisBenchmarkCommand(args...))
 	}
 

--- a/pkg/ebpf/instrumenter.go
+++ b/pkg/ebpf/instrumenter.go
@@ -47,8 +47,8 @@ func closeAll(closers []io.Closer) {
 }
 
 func closeAllReverse(closers []io.Closer) {
-	for i := len(closers) - 1; i >= 0; i-- {
-		closers[i].Close()
+	for _, closer := range slices.Backward(closers) {
+		closer.Close()
 	}
 }
 
@@ -78,8 +78,8 @@ type processScopedGoProbeRegistration struct {
 
 func (c *reverseCloser) Close() error {
 	c.once.Do(func() {
-		for i := len(c.closers) - 1; i >= 0; i-- {
-			c.err = errors.Join(c.err, c.closers[i].Close())
+		for _, v := range slices.Backward(c.closers) {
+			c.err = errors.Join(c.err, v.Close())
 		}
 	})
 
@@ -537,8 +537,8 @@ func versionFromPath(path string) (*version.Version, bool) {
 	components := strings.Split(path, string(filepath.Separator))
 	var dotted, plain []string
 
-	for i := len(components) - 1; i >= 0; i-- {
-		for _, m := range versionRe.FindAllString(components[i], -1) {
+	for _, component := range slices.Backward(components) {
+		for _, m := range versionRe.FindAllString(component, -1) {
 			if strings.Contains(m, ".") {
 				dotted = append(dotted, m)
 			} else {

--- a/pkg/ebpf/instrumenter_test.go
+++ b/pkg/ebpf/instrumenter_test.go
@@ -750,11 +750,9 @@ func TestUSDTLinkCloserCloseIsConcurrentSafe(t *testing.T) {
 	var wg sync.WaitGroup
 	errs := make(chan error, 16)
 	for range cap(errs) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			errs <- closer.Close()
-		}()
+		})
 	}
 	wg.Wait()
 	close(errs)

--- a/pkg/ebpf/usdt_test.go
+++ b/pkg/ebpf/usdt_test.go
@@ -145,7 +145,7 @@ func TestParseUSDTArgSpecHotSpotArm64MemoryPoolGC(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint16(8), spec.ArgCount)
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		assert.Equal(t, obiUSDTArgReg, spec.Args[i].ArgType)
 	}
 	assert.Equal(t, int16(22*8), spec.Args[0].RegOff)

--- a/pkg/export/connector/prommgr_test.go
+++ b/pkg/export/connector/prommgr_test.go
@@ -4,7 +4,6 @@
 package connector
 
 import (
-	"context"
 	"net"
 	"net/http"
 	"strconv"
@@ -51,8 +50,7 @@ func scrapes(t *testing.T, port int, path string) bool {
 // flows exporter registers and starts later when its pipeline is built. Both ports must
 // end up served, whichever order the two components happen to run in.
 func TestStartHTTP_ServesPortRegisteredAfterFirstStart(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	pm := &PrometheusManager{}
 
@@ -72,8 +70,7 @@ func TestStartHTTP_ServesPortRegisteredAfterFirstStart(t *testing.T) {
 // Same case one level down: the port is already listening, and a second component
 // registers a different path on it. That path has to reach the running mux.
 func TestStartHTTP_ServesPathRegisteredOnAlreadyServedPort(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	pm := &PrometheusManager{}
 	port := freePort(t)
@@ -90,8 +87,7 @@ func TestStartHTTP_ServesPathRegisteredOnAlreadyServedPort(t *testing.T) {
 }
 
 func TestStartHTTP_ServesAllPortsRegisteredBeforeStart(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	pm := &PrometheusManager{}
 
@@ -109,8 +105,7 @@ func TestStartHTTP_ServesAllPortsRegisteredBeforeStart(t *testing.T) {
 // Repeated calls with nothing newly registered must not open a second listener, and
 // must not re-register a path on the mux, which http.ServeMux panics on.
 func TestStartHTTP_IsIdempotentPerPortAndPath(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	pm := &PrometheusManager{}
 

--- a/pkg/export/otel/metric/pipeline.go
+++ b/pkg/export/otel/metric/pipeline.go
@@ -279,7 +279,7 @@ func (i *inserter[N]) addCallback(cback func(context.Context) error) {
 	i.pipeline.callbacks = append(i.pipeline.callbacks, cback)
 }
 
-var aggIDCount uint64
+var aggIDCount atomic.Uint64
 
 // aggVal is the cached value in an aggregators cache.
 type aggVal[N int64 | float64] struct {
@@ -371,7 +371,7 @@ func (i *inserter[N]) cachedAggregator(scope instrumentation.Scope, kind Instrum
 			unit:        stream.Unit,
 			compAgg:     out,
 		})
-		id := atomic.AddUint64(&aggIDCount, 1)
+		id := aggIDCount.Add(1)
 		return aggVal[N]{id, in, remove, err}
 	})
 	return cv.Measure, cv.Remove, cv.ID, cv.Err

--- a/pkg/export/otel/metrics_runtime_histograms_test.go
+++ b/pkg/export/otel/metrics_runtime_histograms_test.go
@@ -444,7 +444,7 @@ func TestGoRuntimeHistogramProducerSupportsConcurrentUpdateAndProduce(t *testing
 	waitGroup.Add(2)
 	go func() {
 		defer waitGroup.Done()
-		for i := 0; i < iterations; i++ {
+		for i := range iterations {
 			counts := testGoRuntimeHistogramCounts()
 			counts[i%len(counts)] = uint64(i)
 			producer.Update(testGoRuntimeHistogramSnapshot(
@@ -459,7 +459,7 @@ func TestGoRuntimeHistogramProducerSupportsConcurrentUpdateAndProduce(t *testing
 	}()
 	go func() {
 		defer waitGroup.Done()
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			if _, err := producer.Produce(t.Context()); err != nil {
 				errCh <- err
 			}

--- a/pkg/export/otel/otelcfg/common.go
+++ b/pkg/export/otel/otelcfg/common.go
@@ -67,7 +67,7 @@ func omitFieldsForYAML(input any, omitFields map[string]struct{}) map[string]any
 	result := make(map[string]any)
 
 	val := reflect.ValueOf(input)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 	typ := val.Type()

--- a/pkg/export/prom/prom_runtime_histograms_test.go
+++ b/pkg/export/prom/prom_runtime_histograms_test.go
@@ -532,7 +532,7 @@ func TestGoRuntimeHistogramCollectorSupportsConcurrentUpdateCollectAndDelete(_ *
 
 	go func() {
 		defer waitGroup.Done()
-		for i := 0; i < iterations; i++ {
+		for i := range iterations {
 			counts := testPromRuntimeHistogramCounts()
 			counts[i%len(counts)] = uint64(i)
 			collector.Update(101, []string{"orders"}, &runtimemetrics.GoRuntimeHistogramSnapshot{
@@ -553,7 +553,7 @@ func TestGoRuntimeHistogramCollectorSupportsConcurrentUpdateCollectAndDelete(_ *
 				_ = metric
 			}
 		}()
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			collector.Collect(metrics)
 		}
 		close(metrics)
@@ -561,7 +561,7 @@ func TestGoRuntimeHistogramCollectorSupportsConcurrentUpdateCollectAndDelete(_ *
 	}()
 	go func() {
 		defer waitGroup.Done()
-		for i := 0; i < iterations; i++ {
+		for range iterations {
 			collector.Delete([]string{"orders"})
 		}
 	}()

--- a/pkg/instrumenter/internal_metrics_resource_test.go
+++ b/pkg/instrumenter/internal_metrics_resource_test.go
@@ -4,7 +4,6 @@
 package instrumenter
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -18,8 +17,7 @@ import (
 )
 
 func TestInternalMetricsResourceHasHostMetadata(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	coll, err := collector.Start(ctx)
 	require.NoError(t, err)

--- a/pkg/internal/ebpf/amqpparser/parser_test.go
+++ b/pkg/internal/ebpf/amqpparser/parser_test.go
@@ -253,7 +253,7 @@ func TestParseShortBufferIsNotAMQP(t *testing.T) {
 func TestParseFrameIterationCap(t *testing.T) {
 	// Pack more than maxFramesParsed non-transfer frames and assert parsing stops.
 	payload := make([]byte, 0)
-	for i := 0; i < maxFramesParsed+4; i++ {
+	for range maxFramesParsed + 4 {
 		payload = append(payload, makeFrame(frameTypeAMQP, descriptorOpen)...)
 	}
 

--- a/pkg/internal/ebpf/bhpack/hpack_test.go
+++ b/pkg/internal/ebpf/bhpack/hpack_test.go
@@ -174,7 +174,7 @@ func TestDecoderRejectsMalformedInputDeterministically(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var previous string
-			for run := 0; run < 2; run++ {
+			for run := range 2 {
 				decoder := NewDecoder(64, nil)
 				fields, err := decoder.DecodeFull(tt.block)
 				require.Error(t, err)

--- a/pkg/internal/ebpf/couchbasekv/header.go
+++ b/pkg/internal/ebpf/couchbasekv/header.go
@@ -214,34 +214,22 @@ func (p Packet) ValueString() string {
 }
 
 func (p Packet) framingExtrasEnd() int {
-	end := HeaderLen + int(p.Header().FramingExtrasLen())
-	if end > len(p) {
-		end = len(p)
-	}
+	end := min(HeaderLen+int(p.Header().FramingExtrasLen()), len(p))
 	return end
 }
 
 func (p Packet) extrasEnd() int {
-	end := p.framingExtrasEnd() + int(p.Header().ExtrasLen())
-	if end > len(p) {
-		end = len(p)
-	}
+	end := min(p.framingExtrasEnd()+int(p.Header().ExtrasLen()), len(p))
 	return end
 }
 
 func (p Packet) keyEnd() int {
-	end := p.extrasEnd() + int(p.Header().KeyLen())
-	if end > len(p) {
-		end = len(p)
-	}
+	end := min(p.extrasEnd()+int(p.Header().KeyLen()), len(p))
 	return end
 }
 
 func (p Packet) valueEnd() int {
-	end := p.keyEnd() + p.Header().ValueLen()
-	if end > len(p) {
-		end = len(p)
-	}
+	end := min(p.keyEnd()+p.Header().ValueLen(), len(p))
 	return end
 }
 

--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -323,14 +324,7 @@ func New(
 ) *Tracer {
 	log := slog.With("component", "go.Tracer")
 
-	disabledRouteHarvesting := false
-
-	for _, lang := range cfg.Discovery.DisabledRouteHarvesters {
-		if lang == services.RouteHarvesterLanguageGo {
-			disabledRouteHarvesting = true
-			break
-		}
-	}
+	disabledRouteHarvesting := slices.Contains(cfg.Discovery.DisabledRouteHarvesters, services.RouteHarvesterLanguageGo)
 
 	return &Tracer{
 		log:                               log,
@@ -749,7 +743,7 @@ func resetGoAutoSDKActivationAttempts(
 	}
 
 	var cleanupErrors []error
-	for attempt := uint8(0); attempt < goAutoSDKActivationMaxAttempts; attempt++ {
+	for attempt := range uint8(goAutoSDKActivationMaxAttempts) {
 		key := BpfGoAutoActivationAttemptKeyT{
 			Generation: generation,
 			Pid:        uint32(pid),

--- a/pkg/internal/ebpf/tcmanager/lifecycle_test.go
+++ b/pkg/internal/ebpf/tcmanager/lifecycle_test.go
@@ -270,7 +270,7 @@ func TestConcurrentLifecycleOperationsAreSafe(t *testing.T) {
 			iface := &ifaces.Interface{Index: 42, Name: "test"}
 
 			operations := make([]func(), 0, 64)
-			for i := 0; i < 16; i++ {
+			for i := range 16 {
 				programName := fmt.Sprintf("program-%d", i)
 				operations = append(operations,
 					func() { manager.AddProgram(programName, nil, AttachmentType(255)) },

--- a/pkg/internal/ebpf/watcher/watcher_test.go
+++ b/pkg/internal/ebpf/watcher/watcher_test.go
@@ -19,7 +19,7 @@ func TestProcessWatchEventRejectsTruncatedRecords(t *testing.T) {
 	events := make(chan Event, 1)
 	w := New(&obi.Config{}, events)
 	sample := watchSample(1)
-	for length := 0; length < 8; length++ {
+	for length := range 8 {
 		_, _, err := w.processWatchEvent(t.Context(), &ringbuf.Record{RawSample: sample[:length]})
 		if err == nil {
 			t.Errorf("flags length %d: expected error", length)

--- a/pkg/internal/goexec/instructions.go
+++ b/pkg/internal/goexec/instructions.go
@@ -703,7 +703,7 @@ func decodeRelr(relr map[uint64]struct{}, data []byte, order binary.ByteOrder) {
 		} else {
 			// Bitmap entry: bits [1..63] select word slots after base.
 			bitmap := word >> 1
-			for b := 0; b < 63; b++ {
+			for b := range 63 {
 				if bitmap&(1<<uint(b)) != 0 {
 					relr[base+wordSize*uint64(b)] = struct{}{}
 				}

--- a/pkg/internal/jvmtools/jvm/cmd_hotspot.go
+++ b/pkg/internal/jvmtools/jvm/cmd_hotspot.go
@@ -86,7 +86,7 @@ func startAttachMechanism(ctx context.Context, pid, nspid, attachPid int, tmpPat
 	}
 
 	ts := 20 * time.Millisecond
-	for i := 0; i < 300; i++ {
+	for range 300 {
 		if err := sleepContext(ctx, ts); err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func writeHotspotCommand(ctx context.Context, conn net.Conn, args []string) erro
 	request = append(request, byte('1'))
 	request = append(request, byte(0))
 
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		if i < len(args) {
 			request = append(request, []byte(args[i])...)
 		}

--- a/pkg/internal/jvmtools/service_metadata.go
+++ b/pkg/internal/jvmtools/service_metadata.go
@@ -151,8 +151,8 @@ func springNameFromSystemProperties(args []string, env map[string]string) string
 	const prefix = "-D" + springApplicationName + "="
 	var value string
 	for _, arg := range args {
-		if strings.HasPrefix(arg, prefix) {
-			value = strings.TrimPrefix(arg, prefix)
+		if after, ok := strings.CutPrefix(arg, prefix); ok {
+			value = after
 		}
 	}
 	name, _ := resolvePlaceholders(value, env)

--- a/pkg/internal/largebuf/large_buffer_boundaries_test.go
+++ b/pkg/internal/largebuf/large_buffer_boundaries_test.go
@@ -140,7 +140,7 @@ func TestAbsoluteMethodsIntegerBoundaries(t *testing.T) {
 func TestChunkLayoutsMatchFlatOracle(t *testing.T) {
 	rng := rand.New(rand.NewPCG(20260803, 1))
 
-	for iteration := 0; iteration < 64; iteration++ {
+	for range 64 {
 		data := make([]byte, 1+rng.IntN(64))
 		layout := make([]byte, 1+rng.IntN(16))
 		for i := range data {
@@ -151,7 +151,7 @@ func TestChunkLayoutsMatchFlatOracle(t *testing.T) {
 		}
 		lb := chunkedLargeBuffer(data, layout)
 
-		for sample := 0; sample < 16; sample++ {
+		for range 16 {
 			offset := rng.IntN(len(data) + 1)
 			n := rng.IntN(len(data) - offset + 1)
 			want := data[offset : offset+n]
@@ -288,10 +288,7 @@ func chunkedLargeBuffer(data, layout []byte) *LargeBuffer {
 		if position == len(data) {
 			break
 		}
-		n := int(width)%8 + 1
-		if n > len(data)-position {
-			n = len(data) - position
-		}
+		n := min(int(width)%8+1, len(data)-position)
 		lb.AppendChunk(data[position : position+n])
 		position += n
 	}

--- a/pkg/internal/netns/netns_test.go
+++ b/pkg/internal/netns/netns_test.go
@@ -75,11 +75,9 @@ func TestWithNetNSConcurrentCallsAllComplete(t *testing.T) {
 	var wg sync.WaitGroup
 	errs := make([]error, callers)
 	for i := range callers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			errs[i] = WithNetNS(os.Getpid(), func() error { return nil })
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/pkg/internal/netolly/flow/tracer_ringbuf.go
+++ b/pkg/internal/netolly/flow/tracer_ringbuf.go
@@ -57,9 +57,9 @@ type ringBufReader interface {
 // stats supports atomic logging of ringBuffer metrics
 type stats struct {
 	loggingTimeout time.Duration
-	isForwarding   int32
-	forwardedFlows int32
-	mapFullErrs    int32
+	isForwarding   atomic.Int32
+	forwardedFlows atomic.Int32
+	mapFullErrs    atomic.Int32
 }
 
 type mapFlusher interface {
@@ -128,16 +128,16 @@ func (m *RingBufTracer) listenAndForwardRingBuffer(ctx context.Context, debuggin
 // logRingBufferFlows avoids flooding logs on long series of evicted flows by grouping how
 // many flows are forwarded
 func (m *stats) logRingBufferFlows(mapFullErr bool) {
-	atomic.AddInt32(&m.forwardedFlows, 1)
+	m.forwardedFlows.Add(1)
 	if mapFullErr {
-		atomic.AddInt32(&m.mapFullErrs, 1)
+		m.mapFullErrs.Add(1)
 	}
-	if atomic.CompareAndSwapInt32(&m.isForwarding, 0, 1) {
+	if m.isForwarding.CompareAndSwap(0, 1) {
 		go func() {
 			time.Sleep(m.loggingTimeout)
-			mfe := atomic.LoadInt32(&m.mapFullErrs)
+			mfe := m.mapFullErrs.Load()
 			l := rtlog().With(
-				"flows", atomic.LoadInt32(&m.forwardedFlows),
+				"flows", m.forwardedFlows.Load(),
 				"mapFullErrs", mfe,
 			)
 			if mfe == 0 {
@@ -145,9 +145,9 @@ func (m *stats) logRingBufferFlows(mapFullErr bool) {
 			} else {
 				l.Debug("received flows via ringbuffer due to Map Full. You might want to increase the OTEL_EBPF_NETWORK_CACHE_MAX_FLOWS value")
 			}
-			atomic.StoreInt32(&m.forwardedFlows, 0)
-			atomic.StoreInt32(&m.isForwarding, 0)
-			atomic.StoreInt32(&m.mapFullErrs, 0)
+			m.forwardedFlows.Store(0)
+			m.isForwarding.Store(0)
+			m.mapFullErrs.Store(0)
 		}()
 	}
 }

--- a/pkg/internal/nodejstools/service_metadata.go
+++ b/pkg/internal/nodejstools/service_metadata.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -272,12 +273,7 @@ func resolveRegularProcessFile(root, cwd, path string) (string, bool) {
 }
 
 func pathHasNodeModules(cwd, path string) bool {
-	for _, part := range strings.Split(absoluteProcessPath(cwd, path), string(filepath.Separator)) {
-		if part == "node_modules" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.Split(absoluteProcessPath(cwd, path), string(filepath.Separator)), "node_modules")
 }
 
 func absoluteProcessPath(cwd, path string) string {

--- a/pkg/internal/sqlprune/mssql.go
+++ b/pkg/internal/sqlprune/mssql.go
@@ -96,7 +96,7 @@ func parseMSSQLError(buf []uint8) *request.SQLError {
 		msgBytes := buf[offset : offset+msgLen*2]
 
 		u16s := make([]uint16, msgLen)
-		for i := 0; i < msgLen; i++ {
+		for i := range msgLen {
 			u16s[i] = binary.LittleEndian.Uint16(msgBytes[i*2:])
 		}
 		message := string(utf16.Decode(u16s))

--- a/pkg/internal/transform/route/clusterurl/trie_test.go
+++ b/pkg/internal/transform/route/clusterurl/trie_test.go
@@ -193,7 +193,7 @@ func BenchmarkPathTrie_Insert(b *testing.B) {
 	}
 
 	for b.Loop() {
-		for i := 0; i < len(paths); i++ {
+		for i := range paths {
 			trie.Insert(paths[i])
 		}
 	}

--- a/pkg/internal/transform/route/harvest/java/extractor.go
+++ b/pkg/internal/transform/route/harvest/java/extractor.go
@@ -143,7 +143,7 @@ func sortRoutes(routes []string) []string {
 }
 
 func routeHasWildcardSegment(route string) bool {
-	for _, segment := range strings.Split(route, "/") {
+	for segment := range strings.SplitSeq(route, "/") {
 		if segment == "" {
 			continue
 		}

--- a/pkg/internal/transform/route/harvest/js.go
+++ b/pkg/internal/transform/route/harvest/js.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -1610,9 +1611,7 @@ func FindNodeJSAppDir(pid app.PID) (string, error) {
 // JavaScript lives precisely in the directories the source scan skips.
 var compiledSkipDirs = func() map[string]string {
 	m := make(map[string]string, len(skipDirs))
-	for k, v := range skipDirs {
-		m[k] = v
-	}
+	maps.Copy(m, skipDirs)
 	delete(m, "dist")
 	delete(m, "build")
 	return m

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -558,7 +558,7 @@ func (c *Config) Log() {
 func stringSliceToTextUnmarshalerHookFunc() mapstructure.DecodeHookFunc {
 	return func(_ reflect.Type, to reflect.Type, data any) (any, error) {
 		// Check if target implements TextUnmarshaler
-		if to.Kind() == reflect.Ptr {
+		if to.Kind() == reflect.Pointer {
 			to = to.Elem()
 		}
 		toPtr := reflect.New(to)
@@ -602,7 +602,7 @@ func inlineMetadataHookFunc() mapstructure.DecodeHookFunc {
 
 		// Check if target type is GlobAttributes or RegexSelector
 		switch to {
-		case reflect.TypeOf(services.GlobAttributes{}), reflect.TypeOf(services.RegexSelector{}):
+		case reflect.TypeFor[services.GlobAttributes](), reflect.TypeFor[services.RegexSelector]():
 			// continue processing
 		default:
 			return data, nil

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -562,7 +562,7 @@ func stringSliceToTextUnmarshalerHookFunc() mapstructure.DecodeHookFunc {
 			to = to.Elem()
 		}
 		toPtr := reflect.New(to)
-		if _, ok := toPtr.Interface().(encoding.TextUnmarshaler); !ok {
+		if _, ok := reflect.TypeAssert[encoding.TextUnmarshaler](toPtr); !ok {
 			return data, nil
 		}
 

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -453,7 +453,7 @@ func TestConfig_NoLiteralEnvDefaultOnYamlFields(t *testing.T) {
 		seen[typ] = true
 		for i := 0; i < typ.NumField(); i++ {
 			f := typ.Field(i)
-			yamlTag := strings.Split(f.Tag.Get("yaml"), ",")[0]
+			yamlTag, _, _ := strings.Cut(f.Tag.Get("yaml"), ",")
 			envDefault := f.Tag.Get("envDefault")
 			if yamlTag != "" && yamlTag != "-" && envDefault != "" && !strings.HasPrefix(envDefault, "${") {
 				violations = append(violations, path+"."+f.Name)
@@ -461,7 +461,7 @@ func TestConfig_NoLiteralEnvDefaultOnYamlFields(t *testing.T) {
 			walk(f.Type, path+"."+f.Name)
 		}
 	}
-	walk(reflect.TypeOf(Config{}), "Config")
+	walk(reflect.TypeFor[Config](), "Config")
 	assert.Empty(t, violations, "literal envDefault on yaml-configurable fields; move the default to DefaultConfig")
 }
 
@@ -1442,9 +1442,7 @@ func loadConfig(t *testing.T, env envMap) *Config {
 		"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT":  "",
 		"OTEL_EBPF_PROMETHEUS_PORT":           "0",
 	}
-	for k, v := range env {
-		isolatedEnv[k] = v
-	}
+	maps.Copy(isolatedEnv, env)
 	for k, v := range isolatedEnv {
 		t.Setenv(k, v)
 	}

--- a/pkg/obi/os.go
+++ b/pkg/obi/os.go
@@ -31,7 +31,7 @@ var rhelIDs = []string{"rhel", "centos", "rocky", "alma"}
 
 func parseOSReleaseIsRHEL(data []byte) bool {
 	content := strings.ToLower(string(data))
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(content, "\n") {
 		var val string
 		switch {
 		case strings.HasPrefix(line, "id_like="):

--- a/pkg/pipe/msg/queue_test.go
+++ b/pkg/pipe/msg/queue_test.go
@@ -445,7 +445,7 @@ func TestMetrics_CapacityGauge(t *testing.T) {
 	working := q.Subscribe(SubscriberName("working"))
 	blocked := q.Subscribe(SubscriberName("blocked"))
 
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		q.SendCtx(t.Context(), i)
 		// working channel reads values as long as they arrive
 		testutil.ReadChannel(t, working, timeout)
@@ -457,7 +457,7 @@ func TestMetrics_CapacityGauge(t *testing.T) {
 	assert.InDelta(t, 0.49, fp.GaugeFor("blocked"), 0.0001)
 
 	// send another batch
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		q.SendCtx(t.Context(), i)
 		testutil.ReadChannel(t, working, timeout)
 	}
@@ -466,7 +466,7 @@ func TestMetrics_CapacityGauge(t *testing.T) {
 	assert.InDelta(t, 0.99, fp.GaugeFor("blocked"), 0.0001)
 
 	// unblock blocked subscriber --> metrics should go to lowest value
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		testutil.ReadChannel(t, blocked, timeout)
 	}
 	// send a last message to force update of metrics
@@ -528,7 +528,7 @@ func TestMetrics_CapacityGauge_Saturation(t *testing.T) {
 	full := q.Subscribe(SubscriberName("full"))
 
 	// nobody reads: the 5th send observes 4 unread messages out of 5
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		q.SendCtx(t.Context(), i)
 	}
 	assert.InDelta(t, 0.8, fp.GaugeFor("full"), 0.0001)
@@ -544,7 +544,7 @@ func TestMetrics_CapacityGauge_Saturation(t *testing.T) {
 	}, timeout, time.Millisecond, "a full queue must report a ratio of exactly 1")
 
 	// drain, unblocking the pending sender
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		testutil.ReadChannel(t, full, timeout)
 	}
 	testutil.ReadChannel(t, sent, timeout)

--- a/pkg/runtimemetrics/histogram.go
+++ b/pkg/runtimemetrics/histogram.go
@@ -47,12 +47,12 @@ func runtimeHistogramBoundariesSeconds() [timeHistogramTotalBuckets + 1]float64 
 	var boundaries [timeHistogramTotalBuckets + 1]float64
 	boundaries[0] = math.Inf(-1)
 
-	for subBucket := 0; subBucket < timeHistogramNumSubBuckets; subBucket++ {
+	for subBucket := range timeHistogramNumSubBuckets {
 		bucketNanos := uint64(subBucket) << (timeHistogramMinBucketBits - 1 - timeHistogramSubBucketBits)
 		boundaries[subBucket+1] = float64(bucketNanos) / 1e9
 	}
 	for bucketBit := timeHistogramMinBucketBits; bucketBit < timeHistogramMaxBucketBits; bucketBit++ {
-		for subBucket := 0; subBucket < timeHistogramNumSubBuckets; subBucket++ {
+		for subBucket := range timeHistogramNumSubBuckets {
 			bucketNanos := uint64(1) << (bucketBit - 1)
 			bucketNanos |= uint64(subBucket) << (bucketBit - 1 - timeHistogramSubBucketBits)
 			bucketIndex := (bucketBit-timeHistogramMinBucketBits+1)*timeHistogramNumSubBuckets + subBucket + 1

--- a/pkg/selection/dynamic_app_ips_test.go
+++ b/pkg/selection/dynamic_app_ips_test.go
@@ -5,6 +5,7 @@ package selection
 
 import (
 	"net"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,12 +31,7 @@ func (s *stubPIDSelector) GetPIDs() ([]app.PID, bool) {
 }
 
 func (s *stubPIDSelector) IncludesPID(pid app.PID) bool {
-	for _, p := range s.pids {
-		if p == pid {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s.pids, pid)
 }
 
 func (s *stubPIDSelector) AddedPIDsNotify() <-chan []app.PID { return s.addedCh }

--- a/pkg/test/integration/internals.go
+++ b/pkg/test/integration/internals.go
@@ -29,7 +29,7 @@ func InternalPrometheusExport(t *testing.T, config *TestConfig) {
 
 	// tests that internal metrics are properly exposed and updated
 	initialFlushedRecords := metricValue(t, flushesMetricName, nil)
-	for i := 0; i < 7; i++ {
+	for range 7 {
 		DoHTTPGet(t, instrumentedServiceStdURL+"/testing/some/flushes", http.StatusOK)
 	}
 	eventuallyIterations := 0

--- a/scripts/ci-analysis/ci_analysis_test.go
+++ b/scripts/ci-analysis/ci_analysis_test.go
@@ -135,7 +135,7 @@ func TestWriteReport(t *testing.T) {
 	require.Contains(t, report, "## Fingerprint Legend")
 
 	// TestPassed should not appear as a flaky test row
-	for _, line := range strings.Split(report, "\n") {
+	for line := range strings.SplitSeq(report, "\n") {
 		if strings.Contains(line, "| `TestPassed`") {
 			t.Errorf("TestPassed should not appear as a flaky test row")
 		}

--- a/scripts/ci-analysis/fingerprint.go
+++ b/scripts/ci-analysis/fingerprint.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -91,8 +92,8 @@ var labeledLineRE = regexp.MustCompile(`^\s+(Error Trace|Error|Test|Messages):\s
 // the test framework didn't emit testify-style output.
 func extractErrorBlock(output []string) (errorMsg, traceSite string) {
 	msgIdx := -1
-	for i := len(output) - 1; i >= 0; i-- {
-		if errorMsgRE.MatchString(output[i]) {
+	for i, o := range slices.Backward(output) {
+		if errorMsgRE.MatchString(o) {
 			msgIdx = i
 			break
 		}
@@ -122,8 +123,8 @@ func extractErrorBlock(output []string) (errorMsg, traceSite string) {
 		}
 	}
 
-	for i := len(output) - 1; i >= 0; i-- {
-		if m := errorTraceRE.FindStringSubmatch(output[i]); len(m) >= 2 {
+	for _, o := range slices.Backward(output) {
+		if m := errorTraceRE.FindStringSubmatch(o); len(m) >= 2 {
 			traceSite = m[1]
 			break
 		}
@@ -189,7 +190,7 @@ func fingerprintFromTestOutput(errorMsg, snippet, traceSite string) string {
 		h := sha256.Sum256([]byte(traceSite))
 		return fmt.Sprintf("unknown-%x", h[:4])
 	}
-	for _, line := range strings.Split(snippet, "\n") {
+	for line := range strings.SplitSeq(snippet, "\n") {
 		if t := strings.TrimSpace(line); t != "" {
 			h := sha256.Sum256([]byte(t))
 			return fmt.Sprintf("unknown-%x", h[:4])
@@ -302,10 +303,7 @@ func parseDockerLogForError(r io.Reader) (logError, bool) {
 		return logError{}, false
 	}
 
-	start := len(lines) - 200
-	if start < 0 {
-		start = 0
-	}
+	start := max(len(lines)-200, 0)
 	for i := len(lines) - 1; i >= start; i-- {
 		for _, ep := range errorPatterns {
 			if ep.regex.MatchString(lines[i]) {
@@ -333,8 +331,8 @@ func generateLogCandidates(testName string) []string {
 	name = strings.Trim(name, "-")
 
 	candidates := []string{"test-suite-" + name + ".log"}
-	if strings.HasPrefix(name, "suite-") {
-		candidates = append(candidates, "test-suite-"+strings.TrimPrefix(name, "suite-")+".log")
+	if after, ok := strings.CutPrefix(name, "suite-"); ok {
+		candidates = append(candidates, "test-suite-"+after+".log")
 	}
 	return candidates
 }

--- a/scripts/ci-analysis/report.go
+++ b/scripts/ci-analysis/report.go
@@ -108,10 +108,7 @@ func writeFlakyTestsTable(p func(string, ...any), tests []*testStats) {
 	p("| Workflow | Test | Runs | Failures | Retries | Failure rate | Primary error |")
 	p("|---------|------|------|----------|---------|-------------|--------------|")
 
-	limit := maxFlakyTestsShown
-	if len(flaky) < limit {
-		limit = len(flaky)
-	}
+	limit := min(len(flaky), maxFlakyTestsShown)
 	for _, ts := range flaky[:limit] {
 		failPct := 0.0
 		if ts.totalRuns > 0 {
@@ -200,10 +197,7 @@ func writeRecentFailuresTable(p func(string, ...any), results []TestResult, repo
 	p("| Run | Workflow | Test | Fingerprint | Error |")
 	p("|-----|---------|------|-------------|-------|")
 
-	limit := maxRecentFailuresShown
-	if len(failures) < limit {
-		limit = len(failures)
-	}
+	limit := min(len(failures), maxRecentFailuresShown)
 	for _, rf := range failures[:limit] {
 		snippet := rf.snippet
 		if len(snippet) > maxSnippetDisplay {
@@ -250,10 +244,7 @@ func formatTestList(ids []pkgTest) string {
 		rendered[i] = displayTestName(id.pkg, id.test)
 	}
 	sort.Strings(rendered)
-	limit := len(rendered)
-	if limit > maxTestsInList {
-		limit = maxTestsInList
-	}
+	limit := min(len(rendered), maxTestsInList)
 	backticked := make([]string, limit)
 	for i := range limit {
 		backticked[i] = "`" + rendered[i] + "`"

--- a/scripts/generate-integration-matrix_test.go
+++ b/scripts/generate-integration-matrix_test.go
@@ -29,7 +29,7 @@ func TestGenerateIntegrationMatrixIsCompleteUniqueAndDeterministic(t *testing.T)
 	mustWriteIntegrationTestFile(t, searchDir, "a_test.go", "TestCharlie", "TestBravo")
 	weightsFile := mustWriteWeightsFile(t, `{"_default": 1}`)
 	var first string
-	for run := 0; run < 5; run++ {
+	for run := range 5 {
 		stdout, stderr, err := runGenerateIntegrationMatrix(t, searchDir, "3", "", weightsFile, "")
 		if err != nil {
 			t.Fatalf("run %d failed: %v\nstderr:\n%s", run, err, stderr)
@@ -213,7 +213,7 @@ func matrixTestNames(t *testing.T, stdout string) []string {
 	seen := map[string]bool{}
 	var names []string
 	for _, shard := range matrix.Include {
-		for _, name := range strings.Split(shard.TestPattern, "|") {
+		for name := range strings.SplitSeq(shard.TestPattern, "|") {
 			if seen[name] {
 				t.Fatalf("test %s appears more than once", name)
 			}


### PR DESCRIPTION
## Summary

We recently updated the Go version from 1.25 to 1.26. Running `go fix ./...` to apply some automatic modernizations of the coding style and standard API usage.

Also added a linter option to make sure we keep modernized code style.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
