### PR TITLE
Derive `ProtocolType` constants from the generated BPF enum

### DIFF
--- a/bpf/common/common.c
+++ b/bpf/common/common.c
@@ -16,7 +16,8 @@
 
 #include <common/common.h>
 
-// Force emitting struct http_request_trace into the ELF for automatic creation of Golang struct
+// Force emitting these types into the ELF so bpf2go generates their Go
+// counterparts (structs, and constants for enums)
 const http_request_trace_t *unused_4 __attribute__((unused));
 const sql_request_trace_t *unused_3 __attribute__((unused));
 const tcp_req_t *unused_5 __attribute__((unused));
@@ -30,3 +31,4 @@ const dns_req_t *unused_12 __attribute__((unused));
 const channel_link_trace_t *unused_13 __attribute__((unused));
 const go_auto_span_t *unused_14 __attribute__((unused));
 const node_span_event_t *unused_15 __attribute__((unused));
+const enum protocol_type *unused_16 __attribute__((unused));

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -38,7 +38,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
 )
 
-//go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 -type http_request_trace_t -type sql_request_trace_t -type http_info_t -type connection_info_t -type http2_grpc_request_t -type tcp_req_t -type kafka_client_req_t -type kafka_go_req_t -type redis_client_req_t -type tcp_large_buffer_t -type otel_span_t -type channel_link_trace_t -type go_auto_span_t -type mongo_go_client_req_t -type dns_req_t -type node_span_event_t Bpf ../../../bpf/common/common.c -- -I../../../bpf
+//go:generate $BPF2GO -cc $BPF_CLANG -cflags $BPF_CFLAGS -target amd64,arm64 -type protocol_type -type http_request_trace_t -type sql_request_trace_t -type http_info_t -type connection_info_t -type http2_grpc_request_t -type tcp_req_t -type kafka_client_req_t -type kafka_go_req_t -type redis_client_req_t -type tcp_large_buffer_t -type otel_span_t -type channel_link_trace_t -type go_auto_span_t -type mongo_go_client_req_t -type dns_req_t -type node_span_event_t Bpf ../../../bpf/common/common.c -- -I../../../bpf
 
 // HTTPRequestTrace contains information from an HTTP request as directly received from the
 // eBPF layer. This contains low-level C structures for accurate binary read from ring buffer.
@@ -98,20 +98,21 @@ const (
 
 )
 
-// Kernel-side classification
-// Keep these values aligned with protocol_type in bpf/common/connection_info.h
+// Kernel-side classification. These alias the bpf2go-generated constants
+// derived from enum protocol_type in bpf/common/connection_info.h, so kernel
+// and userspace values cannot drift.
 const (
-	ProtocolTypeUnknown uint8 = iota
-	ProtocolTypeMySQL
-	ProtocolTypePostgres
-	ProtocolTypeHTTP // not used, written for consistency
-	ProtocolTypeKafka
-	ProtocolTypeMQTT // placeholder for future kernel-space detection
-	ProtocolTypeMSSQL
-	ProtocolTypeSunRPC
-	ProtocolTypeNATS // placeholder for future kernel-space detection
-	ProtocolTypeAMQP // placeholder for future kernel-space detection
-	ProtocolTypeAerospike
+	ProtocolTypeUnknown   = BpfProtocolTypeK_protocolTypeUnknown
+	ProtocolTypeMySQL     = BpfProtocolTypeK_protocolTypeMysql
+	ProtocolTypePostgres  = BpfProtocolTypeK_protocolTypePostgres
+	ProtocolTypeHTTP      = BpfProtocolTypeK_protocolTypeHttp // not used, written for consistency
+	ProtocolTypeKafka     = BpfProtocolTypeK_protocolTypeKafka
+	ProtocolTypeMQTT      = BpfProtocolTypeK_protocolTypeMqtt // placeholder for future kernel-space detection
+	ProtocolTypeMSSQL     = BpfProtocolTypeK_protocolTypeMssql
+	ProtocolTypeSunRPC    = BpfProtocolTypeK_protocolTypeSunrpc
+	ProtocolTypeNATS      = BpfProtocolTypeK_protocolTypeNats // placeholder for future kernel-space detection
+	ProtocolTypeAMQP      = BpfProtocolTypeK_protocolTypeAmqp // placeholder for future kernel-space detection
+	ProtocolTypeAerospike = BpfProtocolTypeK_protocolTypeAerospike
 )
 
 const (

--- a/pkg/ebpf/common/tcp_large_buffer.go
+++ b/pkg/ebpf/common/tcp_large_buffer.go
@@ -142,7 +142,7 @@ func containsTCPLargeBuffer(
 	traceID [16]uint8,
 	packetType, direction uint8,
 	connInfo BpfConnectionInfoT,
-	protocolType uint8,
+	protocolType BpfProtocolType,
 ) bool {
 	key := largeBufferKey{
 		traceID:    traceID,
@@ -154,7 +154,7 @@ func containsTCPLargeBuffer(
 	return parseCtx.largeBuffers.Contains(key)
 }
 
-func protocolToLargeBufferKind(protocolType uint8) largeBufferKind {
+func protocolToLargeBufferKind(protocolType BpfProtocolType) largeBufferKind {
 	switch protocolType {
 	case ProtocolTypeKafka, ProtocolTypeMySQL, ProtocolTypePostgres, ProtocolTypeMSSQL, ProtocolTypeHTTP, ProtocolTypeAerospike:
 		return KindLayerApp
@@ -168,7 +168,7 @@ func extractTCPLargeBuffer(
 	traceID [16]uint8,
 	packetType, direction uint8,
 	connInfo BpfConnectionInfoT,
-	protocolType uint8,
+	protocolType BpfProtocolType,
 ) (*largebuf.LargeBuffer, bool) {
 	return extractLargeBuffer(parseCtx, traceID, packetType, direction, connInfo, protocolToLargeBufferKind(protocolType))
 }

--- a/pkg/ebpf/common/tcp_large_buffer_test.go
+++ b/pkg/ebpf/common/tcp_large_buffer_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestProtocolToLargeBufferKind(t *testing.T) {
 	tests := []struct {
-		protocolType uint8
+		protocolType BpfProtocolType
 		expected     largeBufferKind
 	}{
 		{ProtocolTypeKafka, KindLayerApp},


### PR DESCRIPTION
## Summary

This PR replaces the hand-written `ProtocolType*` iota block with aliases of the bpf2go generated consts, so the Go values are derived from the compiled `protocol_type` C enum instead of being paired with it by hand. 

In this way we avoid of having an unmatched value that falls through the classified-protocol dispatch switch and events silently degrade to userspace heuristic detection, which produces identical spans with no error and no failing test.

Notes:
- Nothing outside `pkg/ebpf/common` uses these constants, so the change is contained to the package but external code importing `pkg/ebpf/common` and comparing these constants against raw `uint8` values gets a compile error. It is just a one-line fix per site.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
