### PR TITLE
Fix sys admin permission requirements

### DIFF
--- a/pkg/ebpf/instrumenter_test.go
+++ b/pkg/ebpf/instrumenter_test.go
@@ -12,6 +12,8 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -27,6 +29,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
+	ebpfconvenience "go.opentelemetry.io/obi/pkg/internal/ebpf/convenience"
 	"go.opentelemetry.io/obi/pkg/internal/goexec"
 	"go.opentelemetry.io/obi/pkg/internal/procs"
 	"go.opentelemetry.io/obi/pkg/obi"
@@ -1194,4 +1197,38 @@ func TestDedupModuleProbes(t *testing.T) {
 		require.Len(t, got, 1)
 		assert.Equal(t, []*ebpfcommon.ProbeDesc{descC}, got["uv_fs_access"])
 	})
+}
+
+func TestSetupOtelBPFFSPathFallsBackToInternalMaps(t *testing.T) {
+	bpffsPath := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(bpffsPath, nil, 0o600))
+
+	const maxEntries = 1 << 14
+	spec := &ebpf.CollectionSpec{Maps: map[string]*ebpf.MapSpec{
+		"traces_ctx_v1": {
+			Type:       ebpf.LRUHash,
+			MaxEntries: maxEntries,
+			Pinning:    ebpf.PinByName,
+		},
+	}}
+	pt := &ProcessTracer{bpffsPath: bpffsPath}
+
+	assert.Empty(t, pt.setupOtelBPFFSPath([]*ebpfcommon.SpecBundle{{Spec: spec}}))
+	assert.Equal(t, ebpfconvenience.PinInternal, spec.Maps["traces_ctx_v1"].Pinning)
+	assert.Equal(t, uint32(maxEntries), spec.Maps["traces_ctx_v1"].MaxEntries)
+}
+
+func TestMakeOtelBPFFSPathRejectsInaccessibleExistingDirectory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission checks")
+	}
+
+	bpffsPath := t.TempDir()
+	otelPath := filepath.Join(bpffsPath, "otel")
+	require.NoError(t, os.Mkdir(otelPath, 0o000))
+
+	pt := &ProcessTracer{bpffsPath: bpffsPath}
+	_, err := pt.makeOtelBPFFSPath()
+
+	require.ErrorContains(t, err, "accessing bpffs otel path")
 }

--- a/pkg/ebpf/tracer_linux.go
+++ b/pkg/ebpf/tracer_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
 	"github.com/cilium/ebpf/link"
+	"golang.org/x/sys/unix"
 
 	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
@@ -161,6 +162,14 @@ func (pt *ProcessTracer) makeOtelBPFFSPath() (string, error) {
 	if err := os.MkdirAll(otelPath, 0o1700); err != nil {
 		return "", fmt.Errorf("creating bpffs otel path: %w", err)
 	}
+	if err := unix.Faccessat(
+		unix.AT_FDCWD,
+		otelPath,
+		unix.R_OK|unix.W_OK|unix.X_OK,
+		unix.AT_EACCESS,
+	); err != nil {
+		return "", fmt.Errorf("accessing bpffs otel path: %w", err)
+	}
 
 	return otelPath, nil
 }
@@ -175,17 +184,16 @@ func (pt *ProcessTracer) setupOtelBPFFSPath(bundles []*common.SpecBundle) string
 
 	log := ptlog()
 
-	log.Warn("creating OTEL namespace in bpffs failed (is bpffs mounted?)",
+	log.Warn("creating or accessing OTEL namespace in bpffs failed (is bpffs mounted and accessible?)",
 		"bpffs_path", pt.bpffsPath, "err", err)
 
-	log.Warn("OBI will still work, but features depending on pinned maps (e.g., log enricher, profile correlation) will be disabled")
+	log.Warn("OBI will use process-internal maps; external features depending on pinned maps (e.g., profile correlation) will be disabled")
 
 	// disable pinning for ALL specs
 	for _, bundle := range bundles {
 		for _, v := range bundle.Spec.Maps {
 			if v.Pinning == ebpf.PinByName {
-				v.Pinning = ebpf.PinNone
-				v.MaxEntries = 1
+				v.Pinning = ebpfconvenience.PinInternal
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

When the BPF file system is mounted, it's possible to create a directory in there, but if OBI doesn't have CAP_SYS_ADMIN (or root), it will not be allowed to create the BPF map pinned by name. In this scenario we cannot load the tracer, instead of gracefully degrading to not sharing the data with the profiler.

I also made a small improvement to the fall back path, I changed the pinning to be PIN-INTERNAL, so that we can share the map between the tracers and the logenricher, even though we can't share it externally.

Closes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/3025

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
