### PR TITLE
Fix lint issue in http2go test

### DIFF
--- a/internal/test/integration/http2go_test.go
+++ b/internal/test/integration/http2go_test.go
@@ -209,12 +209,12 @@ func parseHTTP2OwnershipResults(logs string) []http2OwnershipResult {
 	const prefix = "HTTP2_OWNERSHIP_RESULT "
 	var results []http2OwnershipResult
 	for line := range strings.SplitSeq(logs, "\n") {
-		start := strings.Index(line, prefix)
-		if start < 0 {
+		_, payload, found := strings.Cut(line, prefix)
+		if !found {
 			continue
 		}
 		var result http2OwnershipResult
-		if json.Unmarshal([]byte(line[start+len(prefix):]), &result) == nil {
+		if json.Unmarshal([]byte(payload), &result) == nil {
 			results = append(results, result)
 		}
 	}


### PR DESCRIPTION
## Summary

This PR fixes the following lint issue:
```
internal/test/integration/http2go_test.go:212:12: stringscut: strings.Index can be simplified using strings.Cut (modernize)
		start := strings.Index(line, prefix)
		         ^
make: *** [Makefile:159: lint-run] Error 1
```

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
