### PR TITLE
Gate Go runtime metrics probes behind the `application_runtime` feature 

### DIFF
--- a/pkg/internal/ebpf/gotracer/gotracer.go
+++ b/pkg/internal/ebpf/gotracer/gotracer.go
@@ -308,6 +308,7 @@ type Tracer struct {
 	closers                           []io.Closer
 	disabledRouteHarvesting           bool
 	supportsBPFLoop                   bool
+	runtimeMetricsEnabled             bool
 	runtimeMetricTargetKeys           map[runtimeMetricTargetKey]BpfPidInfo
 	goChannelOffsetsByExecutable      map[executableIdentity]bool
 	goRuntimeMetricMaskByExecutable   map[executableIdentity]uint64
@@ -341,6 +342,7 @@ func New(
 		metrics:                           metrics,
 		disabledRouteHarvesting:           disabledRouteHarvesting,
 		supportsBPFLoop:                   ebpfcommon.SupportsEBPFLoops(log, cfg.EBPF.OverrideBPFLoopEnabled),
+		runtimeMetricsEnabled:             cfg.AppRuntimeMetricsEnabled(),
 		runtimeMetricTargetKeys:           map[runtimeMetricTargetKey]BpfPidInfo{},
 		goChannelOffsetsByExecutable:      map[executableIdentity]bool{},
 		goRuntimeMetricMaskByExecutable:   map[executableIdentity]uint64{},
@@ -1225,7 +1227,7 @@ func (p *Tracer) recordGoChannelOffsetAvailability(fileInfo *exec.FileInfo, offs
 }
 
 func (p *Tracer) recordGoRuntimeMetricAvailability(fileInfo *exec.FileInfo, offsets *goexec.Offsets) {
-	if p == nil || fileInfo == nil {
+	if p == nil || !p.runtimeMetricsEnabled || fileInfo == nil {
 		return
 	}
 
@@ -1387,7 +1389,7 @@ func hasBaseGoRuntimeMetrics(mask uint64) bool {
 // into BPF. Offsets stay inode-scoped in go_offsets_map, but these addresses
 // are process-scoped for PIE/ASLR and must follow the PID allow lifecycle.
 func (p *Tracer) registerRuntimeMetricTarget(pid app.PID, ns uint32, fileInfo *exec.FileInfo) {
-	if fileInfo == nil || p.bpfObjects.GoRuntimeMetricTargets == nil {
+	if !p.runtimeMetricsEnabled || fileInfo == nil || p.bpfObjects.GoRuntimeMetricTargets == nil {
 		return
 	}
 	identity := goOffsetsMapKey(fileInfo)
@@ -1950,24 +1952,26 @@ func (p *Tracer) GoProbes() map[string][]*ebpfcommon.ProbeDesc {
 		}},
 	}
 
-	if p.goRuntimeHeapSnapshotProbeEnabled() {
-		// Go 1.23+ heap statistics use a rotating ring. Collect at nextGen after GC
-		// accounting and before the world restarts so the ring cannot rotate mid-read.
-		m[goRuntimeMetricHeapSnapshotSymbol] = []*ebpfcommon.ProbeDesc{{
-			Start: p.bpfObjects.ObiUprobeGoRuntimeMetrics,
-		}}
-	} else {
-		// Older Go versions expose only the scalar metric set and may not contain
-		// nextGen. Keep the gcMarkDone return probe for backward compatibility.
-		m[goRuntimeMetricGCMarkDoneSymbol] = []*ebpfcommon.ProbeDesc{{
-			End: p.bpfObjects.ObiUprobeGoRuntimeMetrics,
-		}}
-	}
+	if p.runtimeMetricsEnabled {
+		if p.goRuntimeHeapSnapshotProbeEnabled() {
+			// Go 1.23+ heap statistics use a rotating ring. Collect at nextGen after GC
+			// accounting and before the world restarts so the ring cannot rotate mid-read.
+			m[goRuntimeMetricHeapSnapshotSymbol] = []*ebpfcommon.ProbeDesc{{
+				Start: p.bpfObjects.ObiUprobeGoRuntimeMetrics,
+			}}
+		} else {
+			// Older Go versions expose only the scalar metric set and may not contain
+			// nextGen. Keep the gcMarkDone return probe for backward compatibility.
+			m[goRuntimeMetricGCMarkDoneSymbol] = []*ebpfcommon.ProbeDesc{{
+				End: p.bpfObjects.ObiUprobeGoRuntimeMetrics,
+			}}
+		}
 
-	if p.goRuntimeGCGoalSourceEnabled() {
-		m[goRuntimeMetricGCGoalSymbol] = []*ebpfcommon.ProbeDesc{{
-			Start: p.bpfObjects.ObiUprobeGoRuntimeGcGoal,
-		}}
+		if p.goRuntimeGCGoalSourceEnabled() {
+			m[goRuntimeMetricGCGoalSymbol] = []*ebpfcommon.ProbeDesc{{
+				Start: p.bpfObjects.ObiUprobeGoRuntimeGcGoal,
+			}}
+		}
 	}
 
 	if p.goChannelLinkProbesEnabled() {

--- a/pkg/internal/ebpf/gotracer/gotracer_test.go
+++ b/pkg/internal/ebpf/gotracer/gotracer_test.go
@@ -317,7 +317,8 @@ func TestGoRuntimeGCGoalProbeAttachedOnlyForPaceScavengerSource(t *testing.T) {
 	disableContextPropagationForTest(t)
 	firstIdentity := executableIdentity{Ino: 1}
 	tracer := &Tracer{
-		currentBinary: firstIdentity,
+		runtimeMetricsEnabled: true,
+		currentBinary:         firstIdentity,
 		goRuntimeMetricMaskByExecutable: map[executableIdentity]uint64{
 			firstIdentity: goRuntimeMetricBaseMask | goRuntimeMetricMemoryGCGoalMask,
 		},
@@ -366,7 +367,8 @@ func TestGoRuntimeMetricsUseHeapSnapshotProbe(t *testing.T) {
 	disableContextPropagationForTest(t)
 
 	tracer := &Tracer{
-		currentBinary: executableIdentity{Ino: 1},
+		runtimeMetricsEnabled: true,
+		currentBinary:         executableIdentity{Ino: 1},
 		goRuntimeMetricMaskByExecutable: map[executableIdentity]uint64{
 			{Ino: 1}: goRuntimeMetricBaseMask,
 			{Ino: 2}: goRuntimeMetricBaseMask | goRuntimeMetricCPUTimeMask,
@@ -389,6 +391,26 @@ func TestGoRuntimeMetricsUseHeapSnapshotProbe(t *testing.T) {
 	assert.NotContains(t, probes, "runtime.gcMarkDone")
 }
 
+func TestGoRuntimeMetricProbesRequireRuntimeMetricsFeature(t *testing.T) {
+	disableContextPropagationForTest(t)
+
+	identity := executableIdentity{Ino: 1}
+	tracer := &Tracer{
+		currentBinary: identity,
+		goRuntimeMetricMaskByExecutable: map[executableIdentity]uint64{
+			identity: goRuntimeMetricBaseMask | goRuntimeMetricMemoryUsedMask,
+		},
+		goRuntimeGCGoalSourceByExecutable: map[executableIdentity]goRuntimeGCGoalSource{
+			identity: goRuntimeGCGoalSourcePaceScavengerArgument,
+		},
+	}
+
+	probes := tracer.GoProbes()
+	for _, symbol := range GoRuntimeMetricProbeSymbols() {
+		assert.NotContains(t, probes, symbol)
+	}
+}
+
 func TestGoRuntimeMetricsFallBackWhenHeapProbeIsMissing(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("Linux-only test")
@@ -396,7 +418,10 @@ func TestGoRuntimeMetricsFallBackWhenHeapProbeIsMissing(t *testing.T) {
 	disableContextPropagationForTest(t)
 
 	var logs bytes.Buffer
-	tracer := &Tracer{log: slog.New(slog.NewTextHandler(&logs, nil))}
+	tracer := &Tracer{
+		log:                   slog.New(slog.NewTextHandler(&logs, nil)),
+		runtimeMetricsEnabled: true,
+	}
 	fileInfo := exec.New(exec.Init{
 		ELF:        currentExecutableELF(t),
 		Ino:        1,
@@ -428,10 +453,13 @@ func TestGoRuntimeMetricsUseResolvedHeapProbe(t *testing.T) {
 	disableContextPropagationForTest(t)
 
 	var logs bytes.Buffer
-	tracer := &Tracer{log: slog.New(slog.NewTextHandler(
-		&logs,
-		&slog.HandlerOptions{Level: slog.LevelDebug},
-	))}
+	tracer := &Tracer{
+		log: slog.New(slog.NewTextHandler(
+			&logs,
+			&slog.HandlerOptions{Level: slog.LevelDebug},
+		)),
+		runtimeMetricsEnabled: true,
+	}
 	fileInfo := exec.New(exec.Init{ELF: currentExecutableELF(t), Ino: 1})
 	offsets := goRuntimeMetricOffsets()
 	offsets.Funcs[goRuntimeMetricProbeSymbols[1]] = []goexec.FuncOffsets{{}}


### PR DESCRIPTION
## Summary

Go runtime metrics uprobes were attached to every instrumented Go binary regardless of user configuration and the resulting events discarded in userspace when the `application_runtime` metric features was off.

This PR adds the check with `AppRuntimeMetricsEnabled()` (used also by the generictracer) and skips probe attachment, per-process target registration, and per-binary availability detection when the feature is disabled. In this way when the feature is off, instrumented Go apps no longer execute the related bpf runtime metrics program on every GC cycle or emit ring-buffer events that the userspace throws away. 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
