### PR TITLE
store-demo: add an Aerospike-backed recentlyviewed service

### DIFF
--- a/examples/store-demo/ARCHITECTURE.md
+++ b/examples/store-demo/ARCHITECTURE.md
@@ -19,6 +19,7 @@ This describes the service topology of the vendored Online Boutique app (`Google
 ```mermaid
 graph TD
     adservice["adservice<br/>:9555 gRPC"]
+    aerospike["aerospike<br/>:3000 Aerospike"]
     cartservice["cartservice<br/>:7070 gRPC"]
     checkoutservice["checkoutservice<br/>:5050 gRPC"]
     currencyservice["currencyservice<br/>:7000 gRPC"]
@@ -27,6 +28,7 @@ graph TD
     loadgenerator["loadgenerator"]
     paymentservice["paymentservice<br/>:50051 gRPC"]
     productcatalogservice["productcatalogservice<br/>:3550 gRPC"]
+    recentlyviewed["recentlyviewed<br/>:8080 HTTP"]
     recommendationservice["recommendationservice<br/>:8080 gRPC"]
     redis_cart["redis-cart<br/>:6379 Redis"]
     shippingservice["shippingservice<br/>:50051 gRPC"]
@@ -43,9 +45,11 @@ graph TD
     frontend -->|gRPC| checkoutservice
     frontend -->|gRPC| currencyservice
     frontend -->|gRPC| productcatalogservice
+    frontend -->|HTTP| recentlyviewed
     frontend -->|gRPC| recommendationservice
     frontend -->|gRPC| shippingservice
     loadgenerator -->|HTTP| frontend
+    recentlyviewed -->|Aerospike| aerospike
     recommendationservice -->|gRPC| productcatalogservice
 
     classDef go fill:darkturquoise,stroke:teal,color:black;
@@ -54,13 +58,15 @@ graph TD
     classDef dotnet fill:rebeccapurple,stroke:indigo,color:white;
     classDef java fill:darkorange,stroke:chocolate,color:black;
     classDef datastore fill:firebrick,stroke:darkred,color:white;
+    classDef datastore_aerospike fill:indianred,stroke:brown,color:white;
 
     class checkoutservice,frontend,productcatalogservice,shippingservice go;
     class emailservice,loadgenerator,recommendationservice python;
     class currencyservice,paymentservice nodejs;
     class cartservice dotnet;
-    class adservice java;
+    class adservice,recentlyviewed java;
     class redis_cart datastore;
+    class aerospike datastore_aerospike;
 ```
 <!-- /generated:graph -->
 
@@ -70,7 +76,8 @@ graph TD
 <span style="color:forestgreen">■</span> Node.js &nbsp;
 <span style="color:rebeccapurple">■</span> C# / .NET &nbsp;
 <span style="color:darkorange">■</span> Java &nbsp;
-<span style="color:firebrick">■</span> Redis (datastore)
+<span style="color:firebrick">■</span> Redis (datastore) &nbsp;
+<span style="color:indianred">■</span> Aerospike (datastore)
 <!-- /generated:legend -->
 
 ## Connections
@@ -93,9 +100,11 @@ environment variables in the manifests.
 | frontend | checkoutservice | `checkoutservice:5050` | gRPC |
 | frontend | currencyservice | `currencyservice:7000` | gRPC |
 | frontend | productcatalogservice | `productcatalogservice:3550` | gRPC |
+| frontend | recentlyviewed | `recentlyviewed:8080` | HTTP |
 | frontend | recommendationservice | `recommendationservice:8080` | gRPC |
 | frontend | shippingservice | `shippingservice:50051` | gRPC |
 | loadgenerator | frontend | `frontend:80` | HTTP |
+| recentlyviewed | aerospike | `aerospike:3000` | Aerospike |
 | recommendationservice | productcatalogservice | `productcatalogservice:3550` | gRPC |
 <!-- /generated:connections -->
 
@@ -110,6 +119,7 @@ detected from each service's source tree under [`app/src`](./app/src).
 | Service | Language | Source marker |
 | --- | --- | --- |
 | adservice | Java | `build.gradle` |
+| aerospike | Aerospike (datastore) | upstream `aerospike/aerospike-server` image |
 | cartservice | C# / .NET | `cartservice.csproj` |
 | checkoutservice | Go | `go.mod` |
 | currencyservice | Node.js | `package.json` |
@@ -118,6 +128,7 @@ detected from each service's source tree under [`app/src`](./app/src).
 | loadgenerator | Python | `requirements.txt` |
 | paymentservice | Node.js | `package.json` |
 | productcatalogservice | Go | `go.mod` |
+| recentlyviewed | Java | `pom.xml` |
 | recommendationservice | Python | `requirements.txt` |
 | redis-cart | Redis (datastore) | upstream `redis:alpine` image |
 | shippingservice | Go | `go.mod` |

--- a/examples/store-demo/README.md
+++ b/examples/store-demo/README.md
@@ -55,6 +55,7 @@ services=(
   "loadgenerator:examples/store-demo/app/src/loadgenerator"
   "paymentservice:examples/store-demo/app/src/paymentservice"
   "productcatalogservice:examples/store-demo/app/src/productcatalogservice"
+  "recentlyviewed:examples/store-demo/services/recentlyviewed"
   "recommendationservice:examples/store-demo/app/src/recommendationservice"
   "shippingservice:examples/store-demo/app/src/shippingservice"
 )

--- a/examples/store-demo/app/src/frontend/handlers.go
+++ b/examples/store-demo/app/src/frontend/handlers.go
@@ -154,6 +154,9 @@ func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request)
 		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve product"), http.StatusInternalServerError)
 		return
 	}
+
+	fe.recordProductView(r.Context(), log, id)
+
 	currencies, err := fe.getCurrencies(r.Context())
 	if err != nil {
 		renderHTTPError(log, r, w, errors.Wrap(err, "could not retrieve currencies"), http.StatusInternalServerError)
@@ -204,6 +207,36 @@ func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request)
 	})); err != nil {
 		log.Println(err)
 	}
+}
+
+// recordProductView tells the recentlyviewed service that this product was
+// looked at, which is what gives the demo its Aerospike traffic.
+//
+// Optional and best-effort, like getRecommendations below: the service may not
+// be deployed, and a failure here must never affect the product page.
+func (fe *frontendServer) recordProductView(ctx context.Context, log logrus.FieldLogger, id string) {
+	if fe.recentlyViewedSvcAddr == "" {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+
+	url := fmt.Sprintf("http://%s/viewed/%s", fe.recentlyViewedSvcAddr, id)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		log.WithField("error", err).Warn("failed to build recently-viewed request")
+		return
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.WithField("error", err).Warn("failed to record recently-viewed product")
+		return
+	}
+	defer resp.Body.Close()
+	// Drain so the connection can be reused.
+	_, _ = io.Copy(io.Discard, resp.Body)
 }
 
 func (fe *frontendServer) addToCartHandler(w http.ResponseWriter, r *http.Request) {

--- a/examples/store-demo/app/src/frontend/handlers.go
+++ b/examples/store-demo/app/src/frontend/handlers.go
@@ -155,7 +155,9 @@ func (fe *frontendServer) productHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	fe.recordProductView(r.Context(), log, id)
+	if r.Method == http.MethodGet {
+		fe.recordProductView(r.Context(), log, id)
+	}
 
 	currencies, err := fe.getCurrencies(r.Context())
 	if err != nil {

--- a/examples/store-demo/app/src/frontend/main.go
+++ b/examples/store-demo/app/src/frontend/main.go
@@ -112,7 +112,7 @@ func main() {
 	mustMapEnv(&svc.shippingSvcAddr, "SHIPPING_SERVICE_ADDR")
 	mustMapEnv(&svc.adSvcAddr, "AD_SERVICE_ADDR")
 	mapOptionalEnv(&svc.shoppingAssistantSvcAddr, "SHOPPING_ASSISTANT_SERVICE_ADDR")
-	mapOptionalEnv(&svc.recentlyViewedSvcAddr, "RECENTLYVIEWED_SERVICE_ADDR")
+	mapOptionalEnv(&svc.recentlyViewedSvcAddr, "RECENTLY_VIEWED_SERVICE_ADDR")
 
 	mustConnGRPC(ctx, &svc.currencySvcConn, svc.currencySvcAddr)
 	mustConnGRPC(ctx, &svc.productCatalogSvcConn, svc.productCatalogSvcAddr)

--- a/examples/store-demo/app/src/frontend/main.go
+++ b/examples/store-demo/app/src/frontend/main.go
@@ -76,6 +76,9 @@ type frontendServer struct {
 	adSvcConn *grpc.ClientConn
 
 	shoppingAssistantSvcAddr string
+
+	// Optional: when unset the product page simply does not record views.
+	recentlyViewedSvcAddr string
 }
 
 func main() {
@@ -109,6 +112,7 @@ func main() {
 	mustMapEnv(&svc.shippingSvcAddr, "SHIPPING_SERVICE_ADDR")
 	mustMapEnv(&svc.adSvcAddr, "AD_SERVICE_ADDR")
 	mapOptionalEnv(&svc.shoppingAssistantSvcAddr, "SHOPPING_ASSISTANT_SERVICE_ADDR")
+	mapOptionalEnv(&svc.recentlyViewedSvcAddr, "RECENTLYVIEWED_SERVICE_ADDR")
 
 	mustConnGRPC(ctx, &svc.currencySvcConn, svc.currencySvcAddr)
 	mustConnGRPC(ctx, &svc.productCatalogSvcConn, svc.productCatalogSvcAddr)

--- a/examples/store-demo/fix_architecture.py
+++ b/examples/store-demo/fix_architecture.py
@@ -28,6 +28,8 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 K8S = HERE / "k8s"
 APP_SRC = HERE / "app" / "src"
+# OBI-authored services live outside the vendored app/ tree; see PROVENANCE.md.
+SERVICES_SRC = HERE / "services"
 DOC = HERE / "ARCHITECTURE.md"
 
 # name: SOMETHING_ADDR  then  value: "callee:port" on the following line.
@@ -37,7 +39,12 @@ ADDR_RE = re.compile(
 )
 
 # Kubernetes `appProtocol` value -> the label shown in the doc.
-PROTOCOL_DISPLAY = {"grpc": "gRPC", "http": "HTTP", "redis": "Redis"}
+PROTOCOL_DISPLAY = {
+    "grpc": "gRPC",
+    "http": "HTTP",
+    "redis": "Redis",
+    "aerospike": "Aerospike",
+}
 
 # Language -> (mermaid classDef name, fill, stroke, text) in legend/classDef order.
 LANGUAGES = [
@@ -47,6 +54,7 @@ LANGUAGES = [
     ("C# / .NET", "dotnet", "rebeccapurple", "indigo", "white"),
     ("Java", "java", "darkorange", "chocolate", "black"),
     ("Redis (datastore)", "datastore", "firebrick", "darkred", "white"),
+    ("Aerospike (datastore)", "datastore_aerospike", "indianred", "brown", "white"),
 ]
 
 
@@ -126,25 +134,40 @@ def manifest_protocols() -> dict[str, str]:
     return protocols
 
 
-def detect_language(service: str) -> tuple[str, str]:
-    """(language, source-marker) for a service, detected from app/src/<service>/.
+# Services with no source tree of their own: they run an upstream image.
+DATASTORE_IMAGES = [
+    ("redis", "Redis (datastore)", "upstream `redis:alpine` image"),
+    ("aerospike", "Aerospike (datastore)", "upstream `aerospike/aerospike-server` image"),
+]
 
-    Heuristic: the source tree is searched for build/manifest markers in priority
+
+def detect_language(service: str) -> tuple[str, str]:
+    """(language, source-marker) for a service, from its source tree.
+
+    Two source roots are searched, in order: `app/src/<service>/` for the
+    vendored Online Boutique services, then `services/<service>/` for
+    OBI-authored ones (kept outside the vendored tree, see PROVENANCE.md).
+
+    Heuristic: the tree is searched for build/manifest markers in priority
     order and the FIRST match wins, so a service shipping more than one marker
     (e.g. a Go service that also has a `package.json` for assets) is classified
     by the highest-priority one. Priority:
 
         go.mod (Go) > *.csproj (C#/.NET) > build.gradle (Java) >
-        package.json (Node.js) > requirements.txt (Python) > *.py (Python)
+        pom.xml (Java) > package.json (Node.js) > requirements.txt (Python) >
+        *.py (Python)
 
-    A service with no `app/src/<service>/` directory falls back to the Redis
-    datastore label (redis-cart runs the upstream redis:alpine image, so it has
-    no vendored source).
+    A service with no source tree in either root is matched against
+    DATASTORE_IMAGES by name, since datastores run upstream images and have no
+    vendored source.
     """
     base = APP_SRC / service
     if not base.is_dir():
-        if "redis" in service:
-            return "Redis (datastore)", "upstream `redis:alpine` image"
+        base = SERVICES_SRC / service
+    if not base.is_dir():
+        for token, label, marker in DATASTORE_IMAGES:
+            if token in service:
+                return label, marker
         return "Unknown", ""
 
     def first(pattern: str):
@@ -157,6 +180,8 @@ def detect_language(service: str) -> tuple[str, str]:
         return "C# / .NET", f"`{csproj.name}`"
     if first("build.gradle"):
         return "Java", "`build.gradle`"
+    if first("pom.xml"):
+        return "Java", "`pom.xml`"
     if first("package.json"):
         return "Node.js", "`package.json`"
     if first("requirements.txt"):
@@ -228,7 +253,7 @@ def render_regions() -> dict[str, str]:
     if missing:
         sys.exit(
             f"ERROR: Service(s) missing 'appProtocol': {', '.join(missing)}. "
-            "Add 'appProtocol: <grpc|http|redis>' to the Service port in k8s/."
+            "Add 'appProtocol: <grpc|http|redis|aerospike>' to the Service port in k8s/."
         )
     proto_of = {svc: PROTOCOL_DISPLAY.get(p, p) for svc, p in raw_proto.items()}
 

--- a/examples/store-demo/k8s/03-obi-values.yaml
+++ b/examples/store-demo/k8s/03-obi-values.yaml
@@ -3,8 +3,6 @@ namespaceOverride: obi-store-demo
 image:
   registry: docker.io
   repository: otel/ebpf-instrument
-  # Aerospike instrumentation shipped in v0.11.0 (#2545); v0.9.0 predates it.
-  # Digest matches the one used by the other examples in this repo.
   tag: v0.12.2
   digest: sha256:750df53abff8d104f757b7f9a42ee88808db69d43cc338ab1819c00273b9422b
 

--- a/examples/store-demo/k8s/03-obi-values.yaml
+++ b/examples/store-demo/k8s/03-obi-values.yaml
@@ -3,8 +3,10 @@ namespaceOverride: obi-store-demo
 image:
   registry: docker.io
   repository: otel/ebpf-instrument
-  tag: v0.9.0
-  digest: sha256:26f82b148dfe8cb0530561ab72a3cb5490b3ae5df556a33c27984af2e28542cf
+  # Aerospike instrumentation shipped in v0.11.0 (#2545); v0.9.0 predates it.
+  # Digest matches the one used by the other examples in this repo.
+  tag: v0.12.2
+  digest: sha256:750df53abff8d104f757b7f9a42ee88808db69d43cc338ab1819c00273b9422b
 
 preset: application
 privileged: true
@@ -15,6 +17,13 @@ config:
     attributes:
       kubernetes:
         enable: true
+    ebpf:
+      buffer_sizes:
+        # Required for Aerospike spans. Once a connection is classified as
+        # Aerospike the generic tcp buffer no longer applies to it, and this
+        # setting defaults to 0 (disabled) - so without it nothing is captured
+        # and no spans are produced. See devdocs/protocols/tcp/aerospike.md.
+        aerospike: 1024
     routes:
       patterns:
         - /
@@ -24,6 +33,8 @@ config:
         - /setCurrency
         - /logout
         - /cart/checkout
+        - /viewed
+        - /viewed/:product_id
         - /_healthz
       unmatched: low-cardinality
     otel_metrics_export:
@@ -49,6 +60,8 @@ config:
           k8s_deployment_name: paymentservice
         - namespace: obi-store-demo
           k8s_deployment_name: productcatalogservice
+        - namespace: obi-store-demo
+          k8s_deployment_name: recentlyviewed
         - namespace: obi-store-demo
           k8s_deployment_name: recommendationservice
         - namespace: obi-store-demo

--- a/examples/store-demo/k8s/03-obi-values.yaml
+++ b/examples/store-demo/k8s/03-obi-values.yaml
@@ -3,8 +3,8 @@ namespaceOverride: obi-store-demo
 image:
   registry: docker.io
   repository: otel/ebpf-instrument
-  tag: v0.12.2
-  digest: sha256:750df53abff8d104f757b7f9a42ee88808db69d43cc338ab1819c00273b9422b
+  tag: v0.13.0
+  digest: sha256:5e89d7478b5feeb8ee73881c58bfe5bb0ccb6dcd4f8cd62e30457aa6e6426adb
 
 preset: application
 privileged: true

--- a/examples/store-demo/k8s/frontend.yaml
+++ b/examples/store-demo/k8s/frontend.yaml
@@ -80,7 +80,7 @@ spec:
             value: "checkoutservice:5050"
           - name: AD_SERVICE_ADDR
             value: "adservice:9555"
-          - name: RECENTLYVIEWED_SERVICE_ADDR
+          - name: RECENTLY_VIEWED_SERVICE_ADDR
             value: "recentlyviewed:8080"
           # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
           # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp

--- a/examples/store-demo/k8s/frontend.yaml
+++ b/examples/store-demo/k8s/frontend.yaml
@@ -80,6 +80,8 @@ spec:
             value: "checkoutservice:5050"
           - name: AD_SERVICE_ADDR
             value: "adservice:9555"
+          - name: RECENTLYVIEWED_SERVICE_ADDR
+            value: "recentlyviewed:8080"
           # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
           # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp
           # - name: ENV_PLATFORM

--- a/examples/store-demo/k8s/kustomization.yaml
+++ b/examples/store-demo/k8s/kustomization.yaml
@@ -27,5 +27,6 @@ resources:
 - loadgenerator.yaml
 - paymentservice.yaml
 - productcatalogservice.yaml
+- recentlyviewed.yaml
 - recommendationservice.yaml
 - shippingservice.yaml

--- a/examples/store-demo/k8s/recentlyviewed.yaml
+++ b/examples/store-demo/k8s/recentlyviewed.yaml
@@ -1,0 +1,146 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Records product page views in Aerospike. The frontend calls this on each
+# product view, which is what gives the demo Aerospike client spans.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recentlyviewed
+  labels:
+    app: recentlyviewed
+spec:
+  selector:
+    matchLabels:
+      app: recentlyviewed
+  template:
+    metadata:
+      labels:
+        app: recentlyviewed
+    spec:
+      serviceAccountName: recentlyviewed
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+      - name: server
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: obi-store-demo-recentlyviewed:local
+        ports:
+        - containerPort: 8080
+        env:
+        - name: AEROSPIKE_ADDR
+          value: "aerospike:3000"
+        readinessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          httpGet:
+            path: /_healthz
+            port: 8080
+        livenessProbe:
+          initialDelaySeconds: 20
+          periodSeconds: 10
+          httpGet:
+            path: /_healthz
+            port: 8080
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: recentlyviewed
+  labels:
+    app: recentlyviewed
+spec:
+  type: ClusterIP
+  selector:
+    app: recentlyviewed
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    appProtocol: http
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: recentlyviewed
+---
+# Single-node Aerospike backing recentlyviewed, bundled here the same way
+# redis-cart is bundled with cartservice. The image and version match the one
+# exercised by TestSuite_Aerospike in internal/test/integration, so the demo
+# and the integration tests observe the same server build.
+#
+# The default image configuration provides the `test` namespace the client
+# uses; no custom aerospike.conf is needed for a single node.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aerospike
+  labels:
+    app: aerospike
+spec:
+  selector:
+    matchLabels:
+      app: aerospike
+  template:
+    metadata:
+      labels:
+        app: aerospike
+    spec:
+      containers:
+      - name: aerospike
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+        image: aerospike/aerospike-server:8.1.2.3@sha256:73c78ec8c2010dbc83ffb4b1249abbdfad3a66173492f46fa54996d0608f122d
+        ports:
+        - containerPort: 3000
+          name: service
+        readinessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          tcpSocket:
+            port: 3000
+        livenessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          tcpSocket:
+            port: 3000
+        resources:
+          limits:
+            memory: 2Gi
+            cpu: 500m
+          requests:
+            memory: 1Gi
+            cpu: 200m
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aerospike
+  labels:
+    app: aerospike
+spec:
+  type: ClusterIP
+  selector:
+    app: aerospike
+  ports:
+  - name: tcp-aerospike
+    port: 3000
+    targetPort: 3000
+    appProtocol: aerospike

--- a/examples/store-demo/services/recentlyviewed/Dockerfile
+++ b/examples/store-demo/services/recentlyviewed/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Base images are pinned by digest per devdocs/dependency-integrity-policy.md.
+# They match the ones used by internal/test/integration/components/javaaerospike.
+FROM maven:3.9-eclipse-temurin-21@sha256:d7e7f57407437c014571f1ad5a9955f03fc3edcb1d964067ef351fa38e798665 AS builder
+
+WORKDIR /build
+
+COPY pom.xml pom.xml
+COPY src src/
+
+RUN mvn -q -e clean package
+
+FROM eclipse-temurin:21-jre@sha256:8ec353b20d3aab0758572236b81b967c7077c40c4d0819ce97f9a1329d684603
+
+EXPOSE 8080
+
+COPY --from=builder /build/target/recentlyviewed-1.0.0.jar /recentlyviewed.jar
+
+USER 1000:1000
+CMD ["java", "-jar", "/recentlyviewed.jar"]

--- a/examples/store-demo/services/recentlyviewed/pom.xml
+++ b/examples/store-demo/services/recentlyviewed/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>io.opentelemetry.obi</groupId>
+	<artifactId>recentlyviewed</artifactId>
+	<version>1.0.0</version>
+
+	<properties>
+		<java.version>21</java.version>
+		<maven.compiler.release>21</maven.compiler.release>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.aerospike</groupId>
+			<artifactId>aerospike-client-jdk21</artifactId>
+			<version>10.4.0</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<finalName>recentlyviewed-${project.version}</finalName>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<release>${maven.compiler.release}</release>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.6.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>RecentlyViewed</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/examples/store-demo/services/recentlyviewed/src/main/java/RecentlyViewed.java
+++ b/examples/store-demo/services/recentlyviewed/src/main/java/RecentlyViewed.java
@@ -1,0 +1,159 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.Bin;
+import com.aerospike.client.Host;
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.policy.ClientPolicy;
+import com.aerospike.client.policy.WritePolicy;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tracks the products a shopper has looked at, backed by Aerospike.
+ *
+ * The frontend calls this on each product page view. It exists so the store
+ * demo exercises OBI's Aerospike instrumentation the same way cartservice
+ * exercises the Redis path.
+ *
+ *   POST /viewed/{productId}   record a view          -> Aerospike PUT
+ *   GET  /viewed/{productId}   read one entry         -> Aerospike GET
+ *   GET  /viewed               list everything seen   -> Aerospike SCAN
+ *   GET  /_healthz             readiness probe        -> no Aerospike call
+ */
+public class RecentlyViewed {
+    private static final String NAMESPACE = "test";
+    private static final String SET = "viewed";
+    private static final int PORT = 8080;
+    private static final int CONNECT_ATTEMPTS = 30;
+
+    private static AerospikeClient client;
+    private static WritePolicy writePolicy;
+
+    public static void main(String[] args) throws Exception {
+        String host = envOrDefault("AEROSPIKE_ADDR", "aerospike:3000");
+        client = connect(host);
+        if (client == null) {
+            System.err.println("could not reach aerospike at " + host);
+            System.exit(1);
+        }
+
+        // sendKey puts the primary key on the wire, so OBI can report it as
+        // db.query.text rather than only the key digest.
+        writePolicy = new WritePolicy();
+        writePolicy.sendKey = true;
+
+        HttpServer server = HttpServer.create(new InetSocketAddress(PORT), 0);
+        server.createContext("/_healthz", exchange -> respond(exchange, 200, "ok"));
+        server.createContext("/viewed", RecentlyViewed::handleViewed);
+        server.setExecutor(null);
+        System.out.println("recentlyviewed listening on :" + PORT + ", aerospike at " + host);
+        server.start();
+    }
+
+    private static void handleViewed(HttpExchange exchange) throws IOException {
+        String productId = productIdFrom(exchange.getRequestURI().getPath());
+        String method = exchange.getRequestMethod();
+
+        try {
+            if ("POST".equals(method) && !productId.isEmpty()) {
+                recordView(productId);
+                respond(exchange, 200, "{\"recorded\":\"" + productId + "\"}");
+                return;
+            }
+            if ("GET".equals(method) && !productId.isEmpty()) {
+                String body = readView(productId);
+                respond(exchange, body == null ? 404 : 200, body == null ? "{}" : body);
+                return;
+            }
+            if ("GET".equals(method)) {
+                respond(exchange, 200, listViews());
+                return;
+            }
+            respond(exchange, 405, "{\"error\":\"method not allowed\"}");
+        } catch (Exception e) {
+            System.out.println("aerospike op failed: " + e.getMessage());
+            respond(exchange, 500, "{\"error\":\"upstream failure\"}");
+        }
+    }
+
+    private static void recordView(String productId) {
+        Key key = new Key(NAMESPACE, SET, productId);
+        client.put(writePolicy, key,
+                new Bin("product_id", productId),
+                new Bin("viewed_at", System.currentTimeMillis()));
+    }
+
+    private static String readView(String productId) {
+        Record record = client.get(null, new Key(NAMESPACE, SET, productId));
+        if (record == null) {
+            return null;
+        }
+        return "{\"product_id\":\"" + productId + "\",\"viewed_at\":"
+                + record.getLong("viewed_at") + "}";
+    }
+
+    private static String listViews() {
+        List<String> ids = new ArrayList<>();
+        client.scanAll(null, NAMESPACE, SET, (key, record) -> {
+            Object id = record.getValue("product_id");
+            if (id != null) {
+                synchronized (ids) {
+                    ids.add("\"" + id + "\"");
+                }
+            }
+        });
+        return "{\"viewed\":[" + String.join(",", ids) + "]}";
+    }
+
+    /** Everything after the last '/', empty when the path is just "/viewed". */
+    private static String productIdFrom(String path) {
+        String trimmed = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+        int slash = trimmed.lastIndexOf('/');
+        String tail = slash < 0 ? "" : trimmed.substring(slash + 1);
+        return "viewed".equals(tail) ? "" : tail;
+    }
+
+    private static AerospikeClient connect(String hostPort) throws InterruptedException {
+        String[] parts = hostPort.split(":", 2);
+        String host = parts[0];
+        int port = parts.length > 1 ? Integer.parseInt(parts[1]) : 3000;
+
+        ClientPolicy policy = new ClientPolicy();
+        policy.timeout = 10_000;
+
+        // The server is often still starting when this pod comes up.
+        for (int i = 0; i < CONNECT_ATTEMPTS; i++) {
+            try {
+                return new AerospikeClient(policy, new Host(host, port));
+            } catch (Exception e) {
+                System.out.println("waiting for aerospike: " + e.getMessage());
+                Thread.sleep(1000);
+            }
+        }
+        return null;
+    }
+
+    private static String envOrDefault(String name, String fallback) {
+        String value = System.getenv(name);
+        return value == null || value.isEmpty() ? fallback : value;
+    }
+
+    private static void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, payload.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(payload);
+        }
+    }
+}

--- a/examples/store-demo/test_fix_architecture.py
+++ b/examples/store-demo/test_fix_architecture.py
@@ -87,6 +87,51 @@ spec:
     appProtocol: redis
 """
 
+# An OBI-authored service under services/ with its datastore bundled in the
+# same manifest, mirroring the real recentlyviewed.yaml + aerospike layout.
+GAMMA = """\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gamma
+spec:
+  template:
+    spec:
+      containers:
+      - name: server
+        env:
+        - name: AEROSPIKE_ADDR
+          value: "aerospike:3000"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gamma
+spec:
+  ports:
+  - name: http
+    port: 4444
+    targetPort: 4444
+    appProtocol: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aerospike
+spec: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aerospike
+spec:
+  ports:
+  - name: tcp-aerospike
+    port: 3000
+    targetPort: 3000
+    appProtocol: aerospike
+"""
+
 # Numbered infra manifest that also declares a Deployment: must be filtered out.
 INFRA = """\
 apiVersion: apps/v1
@@ -105,6 +150,7 @@ class FixArchitectureTest(unittest.TestCase):
         (k8s / "alpha.yaml").write_text(ALPHA)
         (k8s / "beta.yaml").write_text(BETA)
         (k8s / "redis-cache.yaml").write_text(REDIS)
+        (k8s / "gamma.yaml").write_text(GAMMA)
         (k8s / "00-observability.yaml").write_text(INFRA)
         (k8s / "kustomization.yaml").write_text("resources:\n- alpha.yaml\n")
 
@@ -114,27 +160,46 @@ class FixArchitectureTest(unittest.TestCase):
         (src / "beta").mkdir(parents=True)
         (src / "beta" / "package.json").write_text("{}\n")
 
+        # OBI-authored services live outside the vendored app/src tree.
+        services_src = root / "services"
+        (services_src / "gamma").mkdir(parents=True)
+        (services_src / "gamma" / "pom.xml").write_text("<project/>\n")
+
         # Point the module at the fixture tree.
         fa.K8S = k8s
         fa.APP_SRC = src
+        fa.SERVICES_SRC = services_src
 
     def tearDown(self):
         self._tmp.cleanup()
 
     def test_services_exclude_numbered_infra(self):
         # lgtm lives in 00-observability.yaml and must be filtered out.
-        self.assertEqual(fa.manifest_services(), {"alpha", "beta", "redis-cache"})
+        self.assertEqual(
+            fa.manifest_services(),
+            {"alpha", "beta", "redis-cache", "gamma", "aerospike"},
+        )
 
     def test_edges(self):
         self.assertEqual(
             fa.manifest_edges(),
-            {("alpha", "beta", "2222"), ("alpha", "redis-cache", "6379")},
+            {
+                ("alpha", "beta", "2222"),
+                ("alpha", "redis-cache", "6379"),
+                ("gamma", "aerospike", "3000"),
+            },
         )
 
     def test_protocols_from_appprotocol(self):
         self.assertEqual(
             fa.manifest_protocols(),
-            {"alpha": "grpc", "beta": "http", "redis-cache": "redis"},
+            {
+                "alpha": "grpc",
+                "beta": "http",
+                "redis-cache": "redis",
+                "gamma": "http",
+                "aerospike": "aerospike",
+            },
         )
 
     def test_language_detection(self):
@@ -142,6 +207,11 @@ class FixArchitectureTest(unittest.TestCase):
         self.assertEqual(fa.detect_language("beta")[0], "Node.js")
         # No source dir + "redis" in the name -> datastore fallback.
         self.assertEqual(fa.detect_language("redis-cache")[0], "Redis (datastore)")
+        # Resolved from services/ rather than app/src/, and via pom.xml.
+        self.assertEqual(fa.detect_language("gamma"), ("Java", "`pom.xml`"))
+        self.assertEqual(
+            fa.detect_language("aerospike")[0], "Aerospike (datastore)"
+        )
 
     def test_render_regions_content(self):
         regions = fa.render_regions()
@@ -153,6 +223,15 @@ class FixArchitectureTest(unittest.TestCase):
         self.assertIn(
             "| alpha | redis-cache | `redis-cache:6379` | Redis |", regions["connections"]
         )
+        # appProtocol: aerospike must render through PROTOCOL_DISPLAY, not raw.
+        self.assertIn('aerospike["aerospike<br/>:3000 Aerospike"]', regions["graph"])
+        self.assertIn("gamma -->|Aerospike| aerospike", regions["graph"])
+        self.assertIn(
+            "| gamma | aerospike | `aerospike:3000` | Aerospike |",
+            regions["connections"],
+        )
+        self.assertIn("Aerospike (datastore)", regions["legend"])
+        self.assertIn("| gamma | Java | `pom.xml` |", regions["languages"])
 
     def test_missing_appprotocol_is_fatal(self):
         # Drop beta's appProtocol; beta is a callee, so generation must fail.


### PR DESCRIPTION
## Summary

Closes #2532.

The store demo had no Aerospike workload, so the instrumentation added in #2545 wasn't demonstrated anywhere. This adds `recentlyviewed`, a small Java service that records product views in Aerospike, called by `frontend` from the product page.

Browsing a product now produces a single trace across all three tiers — `frontend` (Go) → `recentlyviewed` (Java) → Aerospike — with no SDK in any of them:

<img width="2560" height="1353" alt="trace-tree" src="https://github.com/user-attachments/assets/bcdcde09-2795-48a4-9132-0a3b8eed0c02" />

The Aerospike span carries full DB semantic conventions, and OBI attributes it to its Kubernetes workload with no extra configuration:

<img width="2560" height="1351" alt="attributes" src="https://github.com/user-attachments/assets/e94ce410-9b7f-437a-b40a-adf8ca96d535" />

### Notes for reviewers

A few choices worth flagging, since several aren't obvious from the diff:

- **The OBI image bump is required, not incidental.** The demo pinned `v0.9.0`, which predates Aerospike support (first shipped in `v0.11.0`). Moved to `v0.12.2`, reusing the digest the other examples already use.

- **`ebpf.buffer_sizes.aerospike` is also required.** Once a connection is classified as Aerospike the generic tcp buffer no longer applies to it, and this setting defaults to `0` — so without it nothing is captured and no spans are produced. Same reason `docker-compose-aerospike.yml` sets it.

- **The service lives under `services/`, not `app/src/`**, to leave the vendored Online Boutique tree pinned at v0.10.5 unmodified. `fix_architecture.py` now searches both roots, and recognises `pom.xml` as a Java marker.

- **It speaks HTTP rather than gRPC.** gRPC would mean a proto file and generated stubs in the vendored frontend; the Aerospike traffic is the point of the service, and `frontend` already serves HTTP.

- **The `frontend` change is optional and best-effort** — `mapOptionalEnv`, a one second timeout, warn-and-continue on failure, matching the existing `getRecommendations` treatment. Verified by scaling `recentlyviewed` to zero replicas: the product page still returns 200.

`db.query.text` is intentionally not enabled. The client sets `sendKey`, but OBI emits the primary key only when the attribute is explicitly selected, and it is application data.

<details>
<summary>The demo storefront driving the traffic</summary>

<img width="2555" height="1328" alt="store" src="https://github.com/user-attachments/assets/1bac57ee-9df4-42de-aa5c-0736863cd99a" />

</details>

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] N/A — this adds a demo workload rather than changing a core feature, so `devdocs/features.md` and `SUPPORT_MATRIX.md` are unchanged.

Verified end to end on a `kind` cluster. `test_fix_architecture.py` and `fix_architecture.py --check` pass, and `make lint-markdown` is clean.

---

Generative AI (Claude) was used to explore the codebase, draft the service and manifests, and help diagnose why spans initially didn't appear. I ran and verified everything on my own cluster, and reviewed and revised the code before submitting.