### PR TITLE
fix memory pressure

### DIFF
--- a/pkg/appolly/discover/exec/file.go
+++ b/pkg/appolly/discover/exec/file.go
@@ -156,10 +156,7 @@ func (fi *FileInfo) ServiceAttrs() svc.Attrs {
 }
 
 // Do not use this function anywhere but when dealing with span events
-func (fi *FileInfo) ReadOnlyServiceAttrs() svc.Attrs {
-	fi.mu.RLock()
-	defer fi.mu.RUnlock()
-
+func (fi *FileInfo) UnsafeServiceAttrs() svc.Attrs {
 	return fi.service
 }
 

--- a/pkg/appolly/discover/exec/file.go
+++ b/pkg/appolly/discover/exec/file.go
@@ -155,6 +155,14 @@ func (fi *FileInfo) ServiceAttrs() svc.Attrs {
 	return out
 }
 
+// Do not use this function anywhere but when dealing with span events
+func (fi *FileInfo) ReadOnlyServiceAttrs() svc.Attrs {
+	fi.mu.RLock()
+	defer fi.mu.RUnlock()
+
+	return fi.service
+}
+
 func (fi *FileInfo) SDKLanguage() svc.InstrumentableType {
 	fi.mu.RLock()
 	defer fi.mu.RUnlock()

--- a/pkg/appolly/discover/exec/file.go
+++ b/pkg/appolly/discover/exec/file.go
@@ -155,7 +155,7 @@ func (fi *FileInfo) ServiceAttrs() svc.Attrs {
 	return out
 }
 
-// Do not use this function anywhere but when dealing with span events
+// UnsafeServiceAttrs should be used only when dealing with span events
 func (fi *FileInfo) UnsafeServiceAttrs() svc.Attrs {
 	return fi.service
 }

--- a/pkg/appolly/discover/exec/file.go
+++ b/pkg/appolly/discover/exec/file.go
@@ -157,6 +157,8 @@ func (fi *FileInfo) ServiceAttrs() svc.Attrs {
 
 // UnsafeServiceAttrs should be used only when dealing with span events
 func (fi *FileInfo) UnsafeServiceAttrs() svc.Attrs {
+	fi.mu.RLock()
+	defer fi.mu.RUnlock()
 	return fi.service
 }
 

--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -102,7 +102,7 @@ func (pf *PIDsFilter) CurrentPIDs(t PIDType) map[uint32]map[app.PID]svc.Attrs {
 		cVal := map[app.PID]svc.Attrs{}
 		for kv, vv := range v {
 			if vv.pidTypes&t != 0 {
-				cVal[kv] = vv.fileInfo.ServiceAttrs()
+				cVal[kv] = vv.fileInfo.UnsafeServiceAttrs()
 			}
 		}
 		cp[k] = cVal

--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -147,7 +147,8 @@ func (pf *PIDsFilter) Filter(inputSpans []request.Span) []request.Span {
 			if pf.ignoreOtelSpan {
 				pf.checkIfExportsOTelSpanMetrics(info.fileInfo, span, pf.defaultOtlpGRPCPort)
 			}
-			inputSpans[i].Service = info.fileInfo.ReadOnlyServiceAttrs()
+			// Must use the unsafe version to avoid massive memory pressure here.
+			inputSpans[i].Service = info.fileInfo.UnsafeServiceAttrs()
 			pf.normalizeTraceContext(&inputSpans[i])
 			outputSpans = append(outputSpans, inputSpans[i])
 		}

--- a/pkg/ebpf/common/pids.go
+++ b/pkg/ebpf/common/pids.go
@@ -147,7 +147,7 @@ func (pf *PIDsFilter) Filter(inputSpans []request.Span) []request.Span {
 			if pf.ignoreOtelSpan {
 				pf.checkIfExportsOTelSpanMetrics(info.fileInfo, span, pf.defaultOtlpGRPCPort)
 			}
-			inputSpans[i].Service = info.fileInfo.ServiceAttrs()
+			inputSpans[i].Service = info.fileInfo.ReadOnlyServiceAttrs()
 			pf.normalizeTraceContext(&inputSpans[i])
 			outputSpans = append(outputSpans, inputSpans[i])
 		}


### PR DESCRIPTION
## Summary

The recent change to make ServiceAttrs immutable and copy on read causes massive memory overhead while processing spans.

Closes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/3226

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
