### PR TITLE
Fix flaky Python runtime metrics integration test

### DIFF
--- a/internal/test/integration/components/python-runtime-metrics/controlled.py
+++ b/internal/test/integration/components/python-runtime-metrics/controlled.py
@@ -22,19 +22,9 @@ start_read_fd = int(sys.argv[1])
 stats_write_fd = int(sys.argv[2])
 os.read(start_read_fd, 1)
 os.close(start_read_fd)
-baseline = gc.get_stats()
-gc.set_threshold(10, 1, 1)
-gc.enable()
-for _ in range(1000):
+for generation in range(3):
     allocate_cycles()
-    stats = gc.get_stats()
-    if all(
-        stats[generation]["collections"] > baseline[generation]["collections"]
-        and stats[generation]["collected"] > baseline[generation]["collected"]
-        for generation in range(3)
-    ):
-        break
-gc.disable()
+    gc.collect(generation)
 os.write(stats_write_fd, json.dumps(gc.get_stats()).encode())
 os.close(stats_write_fd)
 signal.pause()


### PR DESCRIPTION
## Summary

Fix the flaky Python runtime metrics worker test by using explicit GC collections for each generation.

Fixes #3236.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
