### PR TITLE
Add IPv6 support to eBPF reverse DNS

### DIFF
--- a/bpf/rdns/rdns_xdp.c
+++ b/bpf/rdns/rdns_xdp.c
@@ -7,6 +7,7 @@
 #include <bpfcore/bpf_builtins.h>
 #include <bpfcore/bpf_endian.h>
 
+#include <common/protocol_defs.h>
 #include <logger/bpf_dbg.h>
 
 // Reverse DNS implementation by means of XDP packet inspection.
@@ -51,6 +52,17 @@ enum { RB_RECORD_LEN = 256 };                        // Maximum record length fo
 enum { DNS_PORT = 53 };                              // Standard DNS port
 enum { UDP_HDR_SIZE = sizeof(struct udphdr), DNS_HDR_SIZE = 12 }; // Header sizes
 
+// IPv6 next-header values used while walking the extension-header chain.
+enum ipv6_next_header {
+    IPV6_HOP_BY_HOP = 0,
+    IPV6_ROUTING = 43,
+    IPV6_FRAGMENT = 44,
+    IPV6_AUTHENTICATION = 51,
+    IPV6_DESTINATION_OPTIONS = 60,
+};
+
+enum { IPV4_FRAGMENT_MASK = 0x3fff };
+
 static __always_inline __u8 get_bit(__u8 word, __u8 offset) {
     return (word >> offset) & 0x1;
 }
@@ -76,40 +88,140 @@ static __always_inline void *ctx_xdp_data_end(struct xdp_md *ctx) {
     return data_end;
 }
 
-// Helper functions to parse network headers
-static __always_inline struct iphdr *ip_header(struct xdp_md *ctx) {
-    void *data = ctx_xdp_data(ctx);
+static __always_inline struct udphdr *validate_udp_header(unsigned char *cursor,
+                                                          const unsigned char *packet_end,
+                                                          const unsigned char *data_end) {
+    struct udphdr *udp = (void *)cursor;
 
-    data += sizeof(struct ethhdr);
-
-    return (data + sizeof(struct iphdr) > ctx_xdp_data_end(ctx)) ? NULL : data;
-}
-
-static __always_inline struct udphdr *udp_header(struct xdp_md *ctx) {
-    struct iphdr *iph = ip_header(ctx);
-
-    if (!iph) {
+    if ((void *)(udp + 1) > (void *)packet_end || (void *)(udp + 1) > (void *)data_end) {
         return NULL;
     }
 
-    if (iph->protocol != IPPROTO_UDP) {
+    const __u16 udp_len = bpf_ntohs(udp->len);
+    if (udp_len < sizeof(*udp) || cursor + udp_len > packet_end || cursor + udp_len > data_end) {
+        return NULL;
+    }
+
+    return udp;
+}
+
+static __always_inline struct udphdr *ipv4_udp_header(struct iphdr *iph,
+                                                      const unsigned char *data_end) {
+    if ((void *)(iph + 1) > (void *)data_end || iph->version != 4 || iph->ihl < 5 ||
+        iph->protocol != IPPROTO_UDP || (iph->frag_off & bpf_htons(IPV4_FRAGMENT_MASK)) != 0) {
         return NULL;
     }
 
     const __u32 advance = iph->ihl * 4;
+    const __u16 total_len = bpf_ntohs(iph->tot_len);
+    if (total_len < advance + sizeof(struct udphdr)) {
+        return NULL;
+    }
 
-    void *data = (void *)iph + advance;
+    unsigned char *ip_end = (void *)iph + total_len;
+    if (ip_end > data_end) {
+        return NULL;
+    }
 
-    return (data + sizeof(struct udphdr) > ctx_xdp_data_end(ctx)) ? NULL : data;
+    return validate_udp_header((void *)iph + advance, ip_end, data_end);
+}
+
+static __always_inline struct udphdr *ipv6_udp_header(struct ipv6hdr *iph,
+                                                      const unsigned char *data_end) {
+    if ((void *)(iph + 1) > (void *)data_end || iph->version != 6) {
+        return NULL;
+    }
+
+    const __u16 payload_len = bpf_ntohs(iph->payload_len);
+    // A zero payload length denotes an IPv6 jumbogram. UDP jumbograms use
+    // a zero UDP length and need separate option parsing, so skip them.
+    if (payload_len == 0) {
+        return NULL;
+    }
+
+    unsigned char *ip_end = (void *)(iph + 1) + payload_len;
+    if (ip_end > data_end) {
+        return NULL;
+    }
+
+    __u8 next_header = iph->nexthdr;
+    unsigned char *cursor = (void *)(iph + 1);
+
+    // IPv6 extension-header chains are finite in valid traffic. Keep the
+    // walk explicitly bounded so the BPF verifier can prove termination.
+#pragma unroll
+    for (__u8 i = 0; i < 6; ++i) {
+        if (next_header == IPPROTO_UDP) {
+            return validate_udp_header(cursor, ip_end, data_end);
+        }
+
+        // DNS messages spanning IPv6 fragments require reassembly, which
+        // is intentionally outside the scope of this packet-level tracer.
+        if (next_header == IPV6_FRAGMENT) {
+            return NULL;
+        }
+
+        if (next_header != IPV6_HOP_BY_HOP && next_header != IPV6_ROUTING &&
+            next_header != IPV6_DESTINATION_OPTIONS && next_header != IPV6_AUTHENTICATION) {
+            return NULL;
+        }
+
+        struct ipv6_opt_hdr *extension = (void *)cursor;
+        unsigned char *extension_end = (void *)(extension + 1);
+        if (extension_end > ip_end || extension_end > data_end) {
+            return NULL;
+        }
+
+        const __u8 extension_type = next_header;
+        next_header = extension->nexthdr;
+        __u32 extension_len;
+        if (extension_type == IPV6_AUTHENTICATION) {
+            // Authentication Header length is measured in 32-bit words,
+            // excluding the first two words.
+            if (extension->hdrlen < 1) {
+                return NULL;
+            }
+            extension_len = ((__u32)extension->hdrlen + 2) * 4;
+        } else {
+            extension_len = ((__u32)extension->hdrlen + 1) * 8;
+        }
+
+        if (cursor + extension_len > ip_end || cursor + extension_len > data_end) {
+            return NULL;
+        }
+        cursor += extension_len;
+    }
+
+    return NULL;
+}
+
+static __always_inline struct udphdr *udp_header(struct xdp_md *ctx) {
+    void *data = ctx_xdp_data(ctx);
+    void *data_end = ctx_xdp_data_end(ctx);
+    struct ethhdr *eth = data;
+
+    if ((void *)(eth + 1) > data_end) {
+        return NULL;
+    }
+
+    switch (bpf_ntohs(eth->h_proto)) {
+    case ETH_P_IP:
+        return ipv4_udp_header((void *)(eth + 1), data_end);
+    case ETH_P_IPV6:
+        return ipv6_udp_header((void *)(eth + 1), data_end);
+    default:
+        return NULL;
+    }
 };
 
 // Validates and calculates the size of a DNS question section
-static __always_inline __u32 validate_qsection(struct xdp_md *ctx, const unsigned char *data) {
+static __always_inline __u32 validate_qsection(const unsigned char *data,
+                                               const unsigned char *data_end) {
     __u32 size = 0;
 
     // try at most 16 sections
     for (__u8 i = 0; i < 16; ++i) {
-        if ((void *)data >= ctx_xdp_data_end(ctx)) {
+        if (data >= data_end) {
             return 0;
         }
 
@@ -119,9 +231,10 @@ static __always_inline __u32 validate_qsection(struct xdp_md *ctx, const unsigne
         ++data;
 
         if (len == 0) {
-            size += sizeof(__u16); // account for QTYPE and QCLASS
+            const __u32 question_fields_size = 2 * sizeof(__u16); // QTYPE and QCLASS
+            size += question_fields_size;
 
-            if ((void *)(data + sizeof(__u16)) < ctx_xdp_data_end(ctx)) {
+            if (data + question_fields_size <= data_end) {
                 return size;
             } else {
                 return 0;
@@ -138,9 +251,8 @@ static __always_inline __u32 validate_qsection(struct xdp_md *ctx, const unsigne
 // Submits a DNS packet to the ring buffer for user space processing.
 // Uses a bounded loop with per-iteration packet bounds checks so the BPF verifier
 // can track each access, avoiding bpf_xdp_load_bytes which requires kernel 5.18+.
-static __always_inline void submit_dns_packet(struct xdp_md *ctx, const unsigned char *const data) {
-    const unsigned char *end = ctx_xdp_data_end(ctx);
-
+static __always_inline void submit_dns_packet(const unsigned char *const data,
+                                              const unsigned char *const end) {
     const __u32 data_len = (end - data) & 0xffff;
 
     if (data_len == 0 || data_len > RB_RECORD_LEN) {
@@ -169,8 +281,8 @@ static __always_inline void submit_dns_packet(struct xdp_md *ctx, const unsigned
 }
 
 // Parses a DNS response packet and validates its structure
-static __always_inline void parse_dns_response(struct xdp_md *ctx,
-                                               const unsigned char *const data) {
+static __always_inline void parse_dns_response(const unsigned char *const data,
+                                               const unsigned char *const data_end) {
     // Extract DNS header fields
     const __u8 flags0 = *(data + 2);
     const __u8 flags1 = *(data + 3);
@@ -210,7 +322,7 @@ static __always_inline void parse_dns_response(struct xdp_md *ctx,
     const unsigned char *ptr = data + DNS_HEADER_SIZE;
 
     for (__u8 i = 0; i < 4 && i < qdcount; ++i) {
-        const __u32 qsection_size = validate_qsection(ctx, ptr);
+        const __u32 qsection_size = validate_qsection(ptr, data_end);
 
         if (qsection_size == 0) {
             bpf_d_printk("invalid qsection, bailing");
@@ -224,7 +336,7 @@ static __always_inline void parse_dns_response(struct xdp_md *ctx,
     bpf_d_printk("found qsection, dns_packet_size=%u", dns_packet_size);
 
     // Submit valid DNS packet to ring buffer
-    submit_dns_packet(ctx, data);
+    submit_dns_packet(data, data_end);
 }
 
 // Main XDP program entry point
@@ -253,12 +365,13 @@ int dns_response_tracker(struct xdp_md *ctx) {
         return XDP_PASS;
     }
 
-    if ((void *)udp + UDP_HDR_SIZE + DNS_HDR_SIZE >= ctx_xdp_data_end(ctx)) {
+    const unsigned char *udp_end = (void *)udp + udp_len;
+    if ((void *)udp + UDP_HDR_SIZE + DNS_HDR_SIZE >= (void *)udp_end) {
         return XDP_PASS;
     }
 
     // Parse and process DNS response
-    parse_dns_response(ctx, (unsigned char *)(udp) + UDP_HDR_SIZE);
+    parse_dns_response((unsigned char *)(udp) + UDP_HDR_SIZE, udp_end);
 
     return XDP_PASS;
 }

--- a/bpf/rdns/rdns_xdp.c
+++ b/bpf/rdns/rdns_xdp.c
@@ -60,8 +60,6 @@ enum ipv6_next_header {
     IPV6_DESTINATION_OPTIONS = 60,
 };
 
-enum { IPV4_FRAGMENT_MASK = 0x3fff };
-
 struct dns_record {
     __be16 len;
     unsigned char data[RB_RECORD_LEN];
@@ -94,108 +92,79 @@ static __always_inline void *ctx_xdp_data_end(struct xdp_md *ctx) {
     return data_end;
 }
 
-static __always_inline struct udphdr *validate_udp_header(unsigned char *cursor,
-                                                          const unsigned char *packet_end,
-                                                          const unsigned char *data_end) {
-    struct udphdr *udp = (void *)cursor;
+// Helper functions to parse network headers
+static __always_inline struct iphdr *ip4_header(struct xdp_md *ctx) {
+    void *data = ctx_xdp_data(ctx);
 
-    if ((void *)(udp + 1) > (void *)packet_end || (void *)(udp + 1) > (void *)data_end) {
-        return NULL;
-    }
+    data += sizeof(struct ethhdr);
 
-    const __u16 udp_len = bpf_ntohs(udp->len);
-    if (udp_len < sizeof(*udp) || cursor + udp_len > packet_end || cursor + udp_len > data_end) {
-        return NULL;
-    }
-
-    return udp;
+    return (data + sizeof(struct iphdr) > ctx_xdp_data_end(ctx)) ? NULL : data;
 }
 
-static __always_inline struct udphdr *ipv4_udp_header(struct iphdr *iph,
-                                                      const unsigned char *data_end) {
-    if ((void *)(iph + 1) > (void *)data_end || iph->version != 4 || iph->ihl < 5 ||
-        iph->protocol != IPPROTO_UDP || (iph->frag_off & bpf_htons(IPV4_FRAGMENT_MASK)) != 0) {
+static __always_inline struct udphdr *udp_header_ipv4(struct xdp_md *ctx) {
+    struct iphdr *iph = ip4_header(ctx);
+
+    if (!iph) {
+        return NULL;
+    }
+
+    if (iph->protocol != IPPROTO_UDP) {
         return NULL;
     }
 
     const __u32 advance = iph->ihl * 4;
-    const __u16 total_len = bpf_ntohs(iph->tot_len);
-    if (total_len < advance + sizeof(struct udphdr)) {
-        return NULL;
-    }
 
-    unsigned char *ip_end = (void *)iph + total_len;
-    if (ip_end > data_end) {
-        return NULL;
-    }
+    void *data = (void *)iph + advance;
 
-    return validate_udp_header((void *)iph + advance, ip_end, data_end);
+    return (data + sizeof(struct udphdr) > ctx_xdp_data_end(ctx)) ? NULL : data;
 }
 
-static __always_inline struct udphdr *ipv6_udp_header(struct ipv6hdr *iph,
-                                                      const unsigned char *data_end) {
-    if ((void *)(iph + 1) > (void *)data_end || iph->version != 6) {
-        return NULL;
-    }
+static __always_inline struct ipv6hdr *ip6_header(struct xdp_md *ctx) {
+    void *data = ctx_xdp_data(ctx);
 
-    const __u16 payload_len = bpf_ntohs(iph->payload_len);
-    // A zero payload length denotes an IPv6 jumbogram. UDP jumbograms use
-    // a zero UDP length and need separate option parsing, so skip them.
-    if (payload_len == 0) {
-        return NULL;
-    }
+    data += sizeof(struct ethhdr);
 
-    unsigned char *ip_end = (void *)(iph + 1) + payload_len;
-    if (ip_end > data_end) {
+    return (data + sizeof(struct ipv6hdr) > ctx_xdp_data_end(ctx)) ? NULL : data;
+}
+
+static __always_inline struct udphdr *udp_header_ipv6(struct xdp_md *ctx) {
+    struct ipv6hdr *iph = ip6_header(ctx);
+
+    if (!iph) {
         return NULL;
     }
 
     __u8 next_header = iph->nexthdr;
-    unsigned char *cursor = (void *)(iph + 1);
+    void *data = (void *)(iph + 1);
+    void *data_end = ctx_xdp_data_end(ctx);
 
-    // IPv6 extension-header chains are finite in valid traffic. Keep the
-    // walk explicitly bounded so the BPF verifier can prove termination.
 #pragma unroll
     for (__u8 i = 0; i < 6; ++i) {
         if (next_header == IPPROTO_UDP) {
-            return validate_udp_header(cursor, ip_end, data_end);
+            return (data + sizeof(struct udphdr) > data_end) ? NULL : data;
         }
 
-        // DNS messages spanning IPv6 fragments require reassembly, which
-        // is intentionally outside the scope of this packet-level tracer.
-        if (next_header == IPV6_FRAGMENT) {
+        if (next_header == IPV6_FRAGMENT ||
+            (next_header != IPV6_HOP_BY_HOP && next_header != IPV6_ROUTING &&
+             next_header != IPV6_DESTINATION_OPTIONS && next_header != IPV6_AUTHENTICATION)) {
             return NULL;
         }
 
-        if (next_header != IPV6_HOP_BY_HOP && next_header != IPV6_ROUTING &&
-            next_header != IPV6_DESTINATION_OPTIONS && next_header != IPV6_AUTHENTICATION) {
-            return NULL;
-        }
-
-        struct ipv6_opt_hdr *extension = (void *)cursor;
-        unsigned char *extension_end = (void *)(extension + 1);
-        if (extension_end > ip_end || extension_end > data_end) {
+        struct ipv6_opt_hdr *extension = data;
+        if ((void *)(extension + 1) > data_end) {
             return NULL;
         }
 
         const __u8 extension_type = next_header;
         next_header = extension->nexthdr;
-        __u32 extension_len;
-        if (extension_type == IPV6_AUTHENTICATION) {
-            // Authentication Header length is measured in 32-bit words,
-            // excluding the first two words.
-            if (extension->hdrlen < 1) {
-                return NULL;
-            }
-            extension_len = ((__u32)extension->hdrlen + 2) * 4;
-        } else {
-            extension_len = ((__u32)extension->hdrlen + 1) * 8;
-        }
+        const __u32 extension_len = extension_type == IPV6_AUTHENTICATION
+                                        ? ((__u32)extension->hdrlen + 2) * 4
+                                        : ((__u32)extension->hdrlen + 1) * 8;
 
-        if (cursor + extension_len > ip_end || cursor + extension_len > data_end) {
+        if (data + extension_len > data_end) {
             return NULL;
         }
-        cursor += extension_len;
+        data += extension_len;
     }
 
     return NULL;
@@ -212,9 +181,9 @@ static __always_inline struct udphdr *udp_header(struct xdp_md *ctx) {
 
     switch (bpf_ntohs(eth->h_proto)) {
     case ETH_P_IP:
-        return ipv4_udp_header((void *)(eth + 1), data_end);
+        return udp_header_ipv4(ctx);
     case ETH_P_IPV6:
-        return ipv6_udp_header((void *)(eth + 1), data_end);
+        return udp_header_ipv6(ctx);
     default:
         return NULL;
     }
@@ -374,7 +343,8 @@ int dns_response_tracker(struct xdp_md *ctx) {
     }
 
     const unsigned char *udp_end = (void *)udp + udp_len;
-    if ((void *)udp + UDP_HDR_SIZE + DNS_HDR_SIZE >= (void *)udp_end) {
+    if ((void *)udp_end > ctx_xdp_data_end(ctx) ||
+        (void *)udp + UDP_HDR_SIZE + DNS_HDR_SIZE >= (void *)udp_end) {
         return XDP_PASS;
     }
 

--- a/bpf/rdns/rdns_xdp.c
+++ b/bpf/rdns/rdns_xdp.c
@@ -52,7 +52,6 @@ enum { RB_RECORD_LEN = 256 };                        // Maximum record length fo
 enum { DNS_PORT = 53 };                              // Standard DNS port
 enum { UDP_HDR_SIZE = sizeof(struct udphdr), DNS_HDR_SIZE = 12 }; // Header sizes
 
-// IPv6 next-header values used while walking the extension-header chain.
 enum ipv6_next_header {
     IPV6_HOP_BY_HOP = 0,
     IPV6_ROUTING = 43,
@@ -62,6 +61,13 @@ enum ipv6_next_header {
 };
 
 enum { IPV4_FRAGMENT_MASK = 0x3fff };
+
+struct dns_record {
+    __be16 len;
+    unsigned char data[RB_RECORD_LEN];
+};
+
+enum { RB_RECORD_SIZE = sizeof(struct dns_record) };
 
 static __always_inline __u8 get_bit(__u8 word, __u8 offset) {
     return (word >> offset) & 0x1;
@@ -259,13 +265,15 @@ static __always_inline void submit_dns_packet(const unsigned char *const data,
         return;
     }
 
-    unsigned char *buf = bpf_ringbuf_reserve(&ring_buffer, RB_RECORD_LEN, 0);
+    struct dns_record *record = bpf_ringbuf_reserve(&ring_buffer, RB_RECORD_SIZE, 0);
 
-    if (!buf) {
-        bpf_d_printk("Failed to reserve %u bytes in the ring buffer", RB_RECORD_LEN);
+    if (!record) {
+        bpf_d_printk("Failed to reserve %u bytes in the ring buffer", RB_RECORD_SIZE);
 
         return;
     }
+
+    record->len = bpf_htons((__u16)data_len);
 
     for (__u32 i = 0; i < RB_RECORD_LEN; i++) {
         if (i >= data_len) {
@@ -274,10 +282,10 @@ static __always_inline void submit_dns_packet(const unsigned char *const data,
         if (data + i + 1 > end) {
             break;
         }
-        buf[i] = data[i];
+        record->data[i] = data[i];
     }
 
-    bpf_ringbuf_submit(buf, 0);
+    bpf_ringbuf_submit(record, 0);
 }
 
 // Parses a DNS response packet and validates its structure

--- a/pkg/internal/rdns/ebpf/xdp/parser_test.go
+++ b/pkg/internal/rdns/ebpf/xdp/parser_test.go
@@ -9,6 +9,8 @@ import (
 	"math"
 	"runtime"
 	"testing"
+
+	"go.opentelemetry.io/obi/pkg/ebpf/ringbuf"
 )
 
 const (
@@ -106,6 +108,57 @@ func TestParseDNSMessageCompressedResponses(t *testing.T) {
 			if answer.name != "example.com" || answer.typ != response.recordType || answer.class != 1 ||
 				answer.ttl != 60 || !bytes.Equal(answer.data, response.recordData) {
 				t.Fatalf("unexpected answer: %#v", answer)
+			}
+		})
+	}
+}
+
+func TestHandleDNSMessageIPAnswers(t *testing.T) {
+	tests := map[string]struct {
+		message []byte
+		wantIP  string
+	}{
+		"IPv4 A record": {
+			message: compressedResponse(typeA, typeA, []byte{192, 0, 2, 1}),
+			wantIP:  "192.0.2.1",
+		},
+		"IPv6 AAAA record": {
+			message: compressedResponse(typeAAAA, typeAAAA, []byte{
+				0x20, 1, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+			}),
+			wantIP: "2001:db8::1",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := handleDNSMessage(&ringbuf.Record{RawSample: test.message})
+			if got == nil {
+				t.Fatal("handleDNSMessage() = nil")
+			}
+			if got.HostName != "example.com" {
+				t.Fatalf("HostName = %q, want example.com", got.HostName)
+			}
+			if len(got.IPs) != 1 || got.IPs[0] != test.wantIP {
+				t.Fatalf("IPs = %v, want [%s]", got.IPs, test.wantIP)
+			}
+		})
+	}
+}
+
+func TestHandleDNSMessageRejectsNonIPAndMalformedAddresses(t *testing.T) {
+	tests := map[string][]byte{
+		"CNAME":          compressedResponse(typeA, typeCNAME, []byte{0}),
+		"short A":        compressedResponse(typeA, typeA, []byte{192, 0, 2}),
+		"oversized A":    compressedResponse(typeA, typeA, []byte{192, 0, 2, 1, 1}),
+		"short AAAA":     compressedResponse(typeAAAA, typeAAAA, make([]byte, 15)),
+		"oversized AAAA": compressedResponse(typeAAAA, typeAAAA, make([]byte, 17)),
+	}
+
+	for name, message := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := handleDNSMessage(&ringbuf.Record{RawSample: message}); got != nil {
+				t.Fatalf("handleDNSMessage() = %#v, want nil", got)
 			}
 		})
 	}

--- a/pkg/internal/rdns/ebpf/xdp/parser_test.go
+++ b/pkg/internal/rdns/ebpf/xdp/parser_test.go
@@ -59,6 +59,13 @@ func compressedRecord(offset uint16, recordData []byte) []byte {
 	return append(record, recordData...)
 }
 
+func ringBufferRecord(message []byte, trailing ...byte) *ringbuf.Record {
+	sample := binary.BigEndian.AppendUint16(nil, uint16(len(message)))
+	sample = append(sample, message...)
+	sample = append(sample, trailing...)
+	return &ringbuf.Record{RawSample: sample}
+}
+
 func validResponses() map[string]responseCase {
 	aData := []byte{192, 0, 2, 1}
 	aaaaData := []byte{0x20, 1, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
@@ -132,7 +139,7 @@ func TestHandleDNSMessageIPAnswers(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := handleDNSMessage(&ringbuf.Record{RawSample: test.message})
+			got := handleDNSMessage(ringBufferRecord(test.message))
 			if got == nil {
 				t.Fatal("handleDNSMessage() = nil")
 			}
@@ -157,10 +164,24 @@ func TestHandleDNSMessageRejectsNonIPAndMalformedAddresses(t *testing.T) {
 
 	for name, message := range tests {
 		t.Run(name, func(t *testing.T) {
-			if got := handleDNSMessage(&ringbuf.Record{RawSample: message}); got != nil {
+			if got := handleDNSMessage(ringBufferRecord(message)); got != nil {
 				t.Fatalf("handleDNSMessage() = %#v, want nil", got)
 			}
 		})
+	}
+}
+
+func TestHandleDNSMessageHonorsPayloadLength(t *testing.T) {
+	message := compressedResponse(typeA, typeA, []byte{192, 0, 2, 1})
+	payload := message[:len(message)-4]
+	staleTail := message[len(message)-4:]
+
+	if got := handleDNSMessage(ringBufferRecord(payload, staleTail...)); got != nil {
+		t.Fatalf("handleDNSMessage() = %#v, want nil", got)
+	}
+
+	if got := handleDNSMessage(&ringbuf.Record{RawSample: []byte{0, 4, 1, 2}}); got != nil {
+		t.Fatalf("handleDNSMessage() with invalid length = %#v, want nil", got)
 	}
 }
 

--- a/pkg/internal/rdns/ebpf/xdp/xdp.go
+++ b/pkg/internal/rdns/ebpf/xdp/xdp.go
@@ -95,7 +95,17 @@ func handleDNSMessage(rd *ringbuf.Record) *store.DNSEntry {
 	}
 
 	for _, answer := range dnsMessage.answers {
-		if answer.typ != uint16(dnsparser.TypeA) {
+		expectedLength := 0
+		switch answer.typ {
+		case uint16(dnsparser.TypeA):
+			expectedLength = net.IPv4len
+		case uint16(dnsparser.TypeAAAA):
+			expectedLength = net.IPv6len
+		default:
+			continue
+		}
+
+		if len(answer.data) != expectedLength {
 			continue
 		}
 

--- a/pkg/internal/rdns/ebpf/xdp/xdp.go
+++ b/pkg/internal/rdns/ebpf/xdp/xdp.go
@@ -5,6 +5,7 @@ package xdp // import "go.opentelemetry.io/obi/pkg/internal/rdns/ebpf/xdp"
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -83,7 +84,17 @@ func tracerLoop(ctx context.Context, storage storage, tracer *tracer) {
 }
 
 func handleDNSMessage(rd *ringbuf.Record) *store.DNSEntry {
-	dnsMessage := parseDNSMessage(rd.RawSample)
+	const recordHeaderLength = 2
+	if len(rd.RawSample) < recordHeaderLength {
+		return nil
+	}
+
+	payloadLength := int(binary.BigEndian.Uint16(rd.RawSample[:recordHeaderLength]))
+	if payloadLength == 0 || payloadLength > len(rd.RawSample)-recordHeaderLength {
+		return nil
+	}
+
+	dnsMessage := parseDNSMessage(rd.RawSample[recordHeaderLength : recordHeaderLength+payloadLength])
 
 	if dnsMessage == nil || len(dnsMessage.questions) == 0 {
 		return nil


### PR DESCRIPTION
## Summary

- inspect UDP DNS responses over IPv4 and IPv6, including bounded traversal of common IPv6 extension headers
- accept valid A and AAAA answers in the reverse-DNS cache while rejecting malformed address lengths
- constrain parsing and ring-buffer submission to the declared IP and UDP payload boundaries

Relates to grafana/beyla#1769. The reverse-DNS XDP implementation now lives in OBI and is consumed by Beyla through its pinned OBI dependency.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed. No documentation update is needed because this extends the existing reverse-DNS mode without changing configuration or telemetry schema.
- generated the rdns BPF objects for amd64 and arm64 with clang 18 and `-Wall -Werror`
- `go test ./pkg/internal/rdns/... ./pkg/internal/pipe/rdns/...`
- `go test -race ./pkg/internal/rdns/ebpf/xdp`
- `go vet ./pkg/internal/rdns/...`
- `clang-format-18 --dry-run --Werror bpf/rdns/rdns_xdp.c`
- `clang-tidy-18 bpf/rdns/rdns_xdp.c -- -target bpfel -D__TARGET_ARCH_arm64 -I bpf -std=gnu17 -O2`

## AI use disclosure

Codex assisted with codebase analysis, test drafting, and review. I reviewed the final patch and validation results in detail and take responsibility for the contribution.
