### PR TITLE
fix(rdns): fix rdns qsection validation check

### DIFF
--- a/bpf/rdns/rdns_xdp.c
+++ b/bpf/rdns/rdns_xdp.c
@@ -119,9 +119,9 @@ static __always_inline __u32 validate_qsection(struct xdp_md *ctx, const unsigne
         ++data;
 
         if (len == 0) {
-            size += sizeof(__u16); // account for QTYPE and QCLASS
+            size += sizeof(__u32); // account for QTYPE and QCLASS
 
-            if ((void *)(data + sizeof(__u16)) < ctx_xdp_data_end(ctx)) {
+            if ((void *)(data + sizeof(__u32)) < ctx_xdp_data_end(ctx)) {
                 return size;
             } else {
                 return 0;


### PR DESCRIPTION
QTYPE and QCLASS are both 16-bit long (and not 8-bit). This hardens the sanity check to do what it intended to - before this fix, it was effectively checking for QTYPE only, which was probably fine in practice.

## Summary

Describe the change briefly.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
