### PR TITLE
fix(cpython): resolve staticcheck and unused lint errors on non-amd64

### DIFF
--- a/pkg/internal/cpython/runtime/probe_linux.go
+++ b/pkg/internal/cpython/runtime/probe_linux.go
@@ -33,27 +33,3 @@ func findPythonGCDoneUSDT(file *elf.File) (*GCCompletionProbe, error) {
 		return nil, fmt.Errorf("%w: ambiguous python:gc__done USDT notes", errUnsupportedLayout)
 	}
 }
-
-// strictELFFileOffset maps one virtual address to exactly one file-backed load segment.
-func strictELFFileOffset(file *elf.File, address uint64, executable bool) (uint64, error) {
-	var offset uint64
-	matches := 0
-	for _, program := range file.Progs {
-		// Require a file-backed load segment. Probe locations must also belong to
-		// an executable segment, while semaphore locations can belong to data.
-		if program.Type != elf.PT_LOAD || executable && program.Flags&elf.PF_X == 0 ||
-			address < program.Vaddr || address-program.Vaddr >= program.Filesz {
-			continue
-		}
-		candidate := program.Off + address - program.Vaddr
-		if candidate < program.Off || candidate == 0 {
-			return 0, fmt.Errorf("%w: invalid CPython probe file offset", errUnsupportedLayout)
-		}
-		offset = candidate
-		matches++
-	}
-	if matches != 1 {
-		return 0, fmt.Errorf("%w: CPython probe address maps to %d file segments", errUnsupportedLayout, matches)
-	}
-	return offset, nil
-}

--- a/pkg/internal/cpython/runtime/probe_linux_amd64.go
+++ b/pkg/internal/cpython/runtime/probe_linux_amd64.go
@@ -73,3 +73,27 @@ func recognizedCollectorName(name string) bool {
 	}
 	return false
 }
+
+// strictELFFileOffset maps one virtual address to exactly one file-backed load segment.
+func strictELFFileOffset(file *elf.File, address uint64, executable bool) (uint64, error) {
+	var offset uint64
+	matches := 0
+	for _, program := range file.Progs {
+		// Require a file-backed load segment. Probe locations must also belong to
+		// an executable segment, while semaphore locations can belong to data.
+		if program.Type != elf.PT_LOAD || executable && program.Flags&elf.PF_X == 0 ||
+			address < program.Vaddr || address-program.Vaddr >= program.Filesz {
+			continue
+		}
+		candidate := program.Off + address - program.Vaddr
+		if candidate < program.Off || candidate == 0 {
+			return 0, fmt.Errorf("%w: invalid CPython probe file offset", errUnsupportedLayout)
+		}
+		offset = candidate
+		matches++
+	}
+	if matches != 1 {
+		return 0, fmt.Errorf("%w: CPython probe address maps to %d file segments", errUnsupportedLayout, matches)
+	}
+	return offset, nil
+}

--- a/pkg/internal/cpython/runtime/probe_linux_unsupported.go
+++ b/pkg/internal/cpython/runtime/probe_linux_unsupported.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 )
 
+var errPrivateCollectorProbeUnsupported = fmt.Errorf("%w: private CPython collector probes require amd64", errUnsupportedLayout)
+
 // findPrivateCollectorProbe fails closed because private collector probes support amd64 only.
 func findPrivateCollectorProbe(*elf.File) (GCCompletionProbe, error) {
-	return GCCompletionProbe{}, fmt.Errorf("%w: private CPython collector probes require amd64", errUnsupportedLayout)
+	return GCCompletionProbe{}, errPrivateCollectorProbeUnsupported
 }


### PR DESCRIPTION
## Summary

This PR fixes the following lint issue on Linux non-amd64
```
pkg/internal/cpython/runtime/resolver_linux.go:238:2: SA4023(related information): the lhs of the comparison is the 2nd return value of this function call (staticcheck)
	privateProbe, privateErr := findPrivateCollectorProbe(file)
	^
pkg/internal/cpython/runtime/resolver_linux.go:239:5: SA4023: this comparison is never true (staticcheck)
	if privateErr == nil {
	   ^
pkg/internal/cpython/runtime/probe_linux.go:38:6: func strictELFFileOffset is unused (unused)
func strictELFFileOffset(file *elf.File, address uint64, executable bool) (uint64, error) {
     ^
make: *** [Makefile:159: lint-run] Error 1

```

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
