### PR TITLE
tpinjector: skip HTTP injection on stale msg buffers

### DIFF
--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -1163,14 +1163,16 @@ int obi_packet_extender(struct sk_msg_md *msg) {
     }
 
     bpf_msg_pull_data(msg, 0, msg->size, 0);
-    fill_msg_buffers(msg, &t_ctx->p_conn, &e_key);
+    const bool msg_buffers_ready = fill_msg_buffers(msg, &t_ctx->p_conn, &e_key);
 
     if (is_h2_socket(msg)) {
         bpf_tail_call_static(msg, &extender_jump_table, k_tail_detect_h2);
         return SK_PASS;
     }
 
-    if (msg->size <= MIN_HTTP_SIZE) {
+    // on a bail (SSL, etc.) msg_buffer_mem is stale — the HTTP detector would
+    // match a prior request and inject into this connection
+    if (!msg_buffers_ready || msg->size <= MIN_HTTP_SIZE) {
         return SK_PASS;
     }
 

--- a/devdocs/context-propagation.md
+++ b/devdocs/context-propagation.md
@@ -52,6 +52,23 @@ Examples:
 - `tcp` - TCP options only
 - `headers` - HTTP headers only
 
+> **⚠️ TCP options and middleboxes.** TCP-option propagation writes an unknown
+> TCP option (kind 25) onto the connection's segments. On SSL/TLS connections
+> this is the *only* channel, since the payload is ciphertext (see Case 1). An
+> unknown TCP option on an established connection is not preserved end-to-end
+> across many network paths: L7 proxies and load balancers discard and replay
+> the original packets, and some middleboxes and managed endpoints drop or reset
+> the segment that carries it. The client then sees `connection reset by peer`,
+> typically on the first request after connect. The effect is path-dependent, so
+> it appears intermittently.
+>
+> If your instrumented services talk through such intermediaries, use
+> `headers` and do not enable `tcp`. HTTP-header propagation is unaffected;
+> only cross-service linking over paths that require the TCP-option channel
+> (chiefly non-Go SSL/TLS clients) is lost. TCP options are safe only when OBI
+> is on both ends and the path preserves them (typically a direct L2/L3 network
+> with no option-stripping middlebox).
+
 ## Egress (Sending) Flow
 
 ### Execution Order
@@ -112,6 +129,10 @@ The `written` flag implements mutual exclusion through the natural execution ord
    - Lookup fails (entry deleted), skips
 Result: TCP options only ✓
 ```
+
+TCP options are the only channel here, and they only reach the peer on paths
+that preserve the option (see the middlebox warning under
+[Configuration](#configuration)). Where they do not, prefer `headers`.
 
 **For Go HTTP (plaintext):**
 


### PR DESCRIPTION
## Summary

Gate the HTTP-detect/inject path on `fill_msg_buffers` success. Also document that TCP options
context propagation writes an unknown TCP option (kind 25) that L7 proxies and/or load balancers drop or reset, and recommend "headers" where instrumented traffic crosses such intermediaries.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
