### PR TITLE
Print `metrics.features` as feature names instead of a bitmask

### DIFF
--- a/pkg/export/feature.go
+++ b/pkg/export/feature.go
@@ -4,7 +4,9 @@
 package export // import "go.opentelemetry.io/obi/pkg/export"
 
 import (
+	"cmp"
 	"fmt"
+	"math/bits"
 	"slices"
 	"strings"
 
@@ -184,6 +186,56 @@ func validFeatureNames() []string {
 	}
 	slices.Sort(names)
 	return names
+}
+
+// marshalNames returns the enabled feature names: aggregate names (e.g. "all", "stats")
+// when all of their bits are enabled, then the remaining single-bit names in declaration order.
+func (f Features) marshalNames() []string {
+	singles := make([]string, 0, len(FeatureMapper))
+	aggregates := make([]string, 0, len(FeatureMapper))
+	for name, feature := range FeatureMapper {
+		// FeatureAll is emitted under its "all" alias
+		if name == "*" {
+			continue
+		}
+		if bits.OnesCount(uint(feature)) == 1 {
+			singles = append(singles, name)
+		} else {
+			aggregates = append(aggregates, name)
+		}
+	}
+	// widest aggregate first, so "all" wins over "stats" when both apply
+	slices.SortFunc(aggregates, func(a, b string) int {
+		return bits.OnesCount(uint(FeatureMapper[b])) - bits.OnesCount(uint(FeatureMapper[a]))
+	})
+	slices.SortFunc(singles, func(a, b string) int {
+		return cmp.Compare(FeatureMapper[a], FeatureMapper[b])
+	})
+
+	names := make([]string, 0, len(singles))
+	remaining := f
+	for _, name := range slices.Concat(aggregates, singles) {
+		feature := FeatureMapper[name]
+		if remaining.has(feature) {
+			names = append(names, name)
+			remaining = Features(maps.Bits(remaining) &^ maps.Bits(feature))
+		}
+	}
+	return names
+}
+
+// MarshalYAML renders the bitmask as the list of enabled feature names, so a logged
+// configuration shows the same values that can be written in the YAML.
+func (f Features) MarshalYAML() (any, error) {
+	if f.Undefined() {
+		return nil, nil
+	}
+	// an empty sequence, in opposition of "null" in the undefined case
+	node := yaml.Node{Kind: yaml.SequenceNode}
+	for _, name := range f.marshalNames() {
+		node.Content = append(node.Content, &yaml.Node{Kind: yaml.ScalarNode, Value: name})
+	}
+	return node, nil
 }
 
 func LoadFeatures(features []string) (Features, error) {

--- a/pkg/export/feature_test.go
+++ b/pkg/export/feature_test.go
@@ -261,3 +261,53 @@ func TestFeatureUndefined(t *testing.T) {
 		require.True(t, doc.Features.Undefined())
 	})
 }
+
+func TestFeatureMarshalYAML(t *testing.T) {
+	type doc struct {
+		Features Features `yaml:"features"`
+	}
+	for _, tc := range []struct {
+		name     string
+		features Features
+		expected string
+	}{
+		{name: "undefined", features: 0, expected: "features: null\n"},
+		{name: "explicitly empty", features: FeatureEmpty, expected: "features: []\n"},
+		{
+			name:     "single feature",
+			features: FeatureApplicationRuntime,
+			expected: "features:\n    - application_runtime\n",
+		},
+		{
+			name:     "combined features follow the declaration order",
+			features: FeatureApplicationRuntime | FeatureApplicationRED,
+			expected: "features:\n    - application\n    - application_runtime\n",
+		},
+		{
+			name:     "aggregate feature keeps its name",
+			features: FeatureStats,
+			expected: "features:\n    - stats\n",
+		},
+		{
+			name:     "aggregate name comes before the remaining single features",
+			features: FeatureStats | FeatureNetwork,
+			expected: "features:\n    - stats\n    - network\n",
+		},
+		{
+			name:     "partial aggregate expands to its bits",
+			features: FeatureStatsTCPRtt | FeatureStatsTCPRetransmits,
+			expected: "features:\n    - stats_tcp_rtt\n    - stats_tcp_retransmits\n",
+		},
+		{name: "all features", features: FeatureAll, expected: "features:\n    - all\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := yaml.Marshal(doc{Features: tc.features})
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, string(out))
+
+			var reparsed doc
+			require.NoError(t, yaml.Unmarshal(out, &reparsed))
+			require.Equal(t, tc.features, reparsed.Features)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

With `log_config: yaml|json`, the printed config showed features fields as raw bitmask integers, for example `features: 16834` when the requested feature is `application_runtime`.

This PR adds `Features.MarshalYAML`, so the logged config shows the same names a user can write.
Moreover, aggregate names are preferred when all of their bits are enabled (like `stats`, `all`...), falling back to individual names for partial masks.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
