### PR TITLE
tests: fix flaky unit test TestAppMetricsExpiration

### DIFF
--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -158,11 +158,12 @@ func TestAppMetricsExpiration(t *testing.T) {
 		assert.Regexp(ct, containsInstance, exported)
 	}, timeout, 100*time.Millisecond)
 
-	// AND WHEN it keeps receiving a subset of the initial metrics during the timeout
-	// advance the clock before sending so the consumer observes the final time (the cached
-	// clock only updates on span consumption); sending after advancing avoids a flaky race
-	now.Advance(4 * time.Minute)
-	// WHEN it receives metrics
+	// AND WHEN /foo keeps being received while /baz goes silent.
+	// Refresh /foo within its TTL so its entry is never expirable at the instant it is
+	// refreshed; the counter then accumulates to 246 deterministically. A single jump past
+	// the TTL would race the scrape-driven expiry, which could delete /foo and recreate it
+	// from zero (246 vs 123).
+	now.Advance(2 * time.Minute)
 	promInput.Send([]request.Span{
 		{
 			Type:    request.EventTypeHTTP,
@@ -172,12 +173,21 @@ func TestAppMetricsExpiration(t *testing.T) {
 		},
 	})
 
-	// THEN THE metrics that have been received during the timeout period are still visible
+	// THEN /foo shows the value accumulated from both observations
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		exported := getMetrics(ct, promURL)
 		assert.Contains(ct, exported, `http_server_request_duration_seconds_sum{k8s_app_version="v0.0.1",url_path="/foo"} 246`)
+		assert.Regexp(ct, containsTargetInfo, exported)
+	}, timeout, 100*time.Millisecond)
 
-		// BUT not the metrics that haven't been received during that time
+	// AND WHEN further time passes so /baz crosses its TTL while /foo, refreshed 2 minutes
+	// ago, stays within its own
+	now.Advance(2 * time.Minute)
+
+	// THEN /foo is still visible but /baz has expired
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		exported := getMetrics(ct, promURL)
+		assert.Contains(ct, exported, `http_server_request_duration_seconds_sum{k8s_app_version="v0.0.1",url_path="/foo"} 246`)
 		assert.NotContains(ct, exported, `http_server_request_duration_seconds_sum{k8s_app_version="",url_path="/baz"}`)
 		assert.Regexp(ct, containsTargetInfo, exported)
 	}, timeout, 100*time.Millisecond)

--- a/pkg/export/prom/prom_test.go
+++ b/pkg/export/prom/prom_test.go
@@ -173,10 +173,12 @@ func TestAppMetricsExpiration(t *testing.T) {
 		},
 	})
 
-	// THEN /foo shows the value accumulated from both observations
+	// THEN /foo shows the value accumulated from both observations, and /baz is still
+	// within its TTL
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		exported := getMetrics(ct, promURL)
 		assert.Contains(ct, exported, `http_server_request_duration_seconds_sum{k8s_app_version="v0.0.1",url_path="/foo"} 246`)
+		assert.Contains(ct, exported, `http_server_request_duration_seconds_sum{k8s_app_version="",url_path="/baz"} 456`)
 		assert.Regexp(ct, containsTargetInfo, exported)
 	}, timeout, 100*time.Millisecond)
 
@@ -202,7 +204,7 @@ func TestAppMetricsExpiration(t *testing.T) {
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		exported := getMetrics(ct, promURL)
 		assert.Contains(ct, exported, `http_server_request_duration_seconds_sum{k8s_app_version="",url_path="/baz"} 456`)
-		assert.NotContains(ct, exported, `http_server_request_duration_seconds_sum{k8s_app_version="",url_path="/foo"}`)
+		assert.NotContains(ct, exported, `http_server_request_duration_seconds_sum{k8s_app_version="v0.0.1",url_path="/foo"}`)
 		assert.Regexp(ct, containsTargetInfo, exported)
 	}, timeout, 100*time.Millisecond)
 


### PR DESCRIPTION
## Summary

fixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/33488584419/job/99797203754?pr=3265 

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
