### PR TITLE
Print unnamed cidrs as plain strings

### DIFF
--- a/pkg/internal/pipe/cidr/cidr.go
+++ b/pkg/internal/pipe/cidr/cidr.go
@@ -40,6 +40,19 @@ func (d Definition) Label() string {
 	return d.CIDR
 }
 
+// plainDefinition drops the Definition method set, so marshaling it does not
+// recurse back into MarshalYAML.
+type plainDefinition Definition
+
+// MarshalYAML emits back the shape the definition was written in: a plain CIDR
+// string when no name was given, a "cidr"/"name" mapping otherwise.
+func (d Definition) MarshalYAML() (any, error) {
+	if d.Name == "" {
+		return d.CIDR, nil
+	}
+	return plainDefinition(d), nil
+}
+
 // Definitions contains a list of CIDRs to be set as the "src.cidr" and "dst.cidr"
 // attribute as a function of the source and destination IP addresses.
 // It supports two YAML formats:

--- a/pkg/internal/pipe/cidr/cidr_test.go
+++ b/pkg/internal/pipe/cidr/cidr_test.go
@@ -308,3 +308,67 @@ func flow(srcIP, dstIP string) *testRecord {
 	copy(r.DstAddr[:], net.ParseIP(dstIP).To16())
 	return r
 }
+
+func TestMarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		defs     Definitions
+		expected string
+	}{
+		{
+			name: "Plain CIDRs marshal as scalars",
+			defs: defs("10.0.0.0/8", "192.168.0.0/16", "2001::/16"),
+			expected: `- 10.0.0.0/8
+- 192.168.0.0/16
+- 2001::/16
+`,
+		},
+		{
+			name: "Named CIDRs marshal as mappings",
+			defs: Definitions{
+				{CIDR: "10.0.0.0/8", Name: "cluster-internal"},
+				{CIDR: "192.168.0.0/16", Name: "private"},
+			},
+			expected: `- cidr: 10.0.0.0/8
+  name: cluster-internal
+- cidr: 192.168.0.0/16
+  name: private
+`,
+		},
+		{
+			name: "Mixed formats keep their own shape",
+			defs: Definitions{
+				{CIDR: "10.0.0.0/8"},
+				{CIDR: "192.168.0.0/16", Name: "private"},
+				{CIDR: "172.16.0.0/12"},
+			},
+			expected: `- 10.0.0.0/8
+- cidr: 192.168.0.0/16
+  name: private
+- 172.16.0.0/12
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := yaml.Marshal(tt.defs)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(out))
+
+			var roundTripped Definitions
+			require.NoError(t, yaml.Unmarshal(out, &roundTripped))
+			assert.Equal(t, tt.defs, roundTripped)
+		})
+	}
+}
+
+// yaml.v3 renders both a nil and an empty slice as an empty sequence, so an
+// unset "cidrs" key and an explicit "cidrs: []" print the same. MarshalYAML is
+// per-definition and must not change that.
+func TestMarshalYAML_NilAndEmpty(t *testing.T) {
+	for _, d := range []Definitions{nil, {}} {
+		out, err := yaml.Marshal(d)
+		require.NoError(t, err)
+		assert.Equal(t, "[]\n", string(out))
+	}
+}


### PR DESCRIPTION
## Summary

This PR prints `cidrs` how they are written in the configuration. In brief, `network.cidrs` and `stats.cidrs` accept either a plain CIDR string or a `{cidr, name}` map, but `log_config: yaml|json` always printed the map form, adding `name: ""` to every entry the user wrote as a plain string.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
