### PR TITLE
tpinjector: fix truncated msg buffer read that drops large client spans

### DIFF
--- a/bpf/common/msg_buffer.h
+++ b/bpf/common/msg_buffer.h
@@ -5,14 +5,12 @@
 
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_helpers.h>
+#include <bpfcore/utils.h>
 
 #include <common/http_buf_size.h>
 #include <common/pin_internal.h>
 
-enum {
-    k_msg_buffer_size_max = 8192,
-    k_msg_buffer_size_max_mask = k_msg_buffer_size_max - 1,
-};
+enum { k_msg_buffer_size_max = 8192 };
 
 struct {
     __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
@@ -35,3 +33,30 @@ typedef struct msg_buffer {
     // will then be used as a guard in different execution contexts.
     u32 cpu_id;
 } msg_buffer_t;
+
+// Copies as much of the message at src as msg_buffer_mem holds into dst, and
+// returns the number of bytes written — which is what the tcp_sendmsg kprobe
+// takes as the extent of this message. dst must have room for
+// k_msg_buffer_size_max bytes, and that many bytes at src must be readable.
+//
+// The length is bounded with bpf_clamp_umax() rather than min(). Both clamp the
+// value, but only the asm form bounds the register the length is passed in: min()
+// compiles to a compare and a select whose copy clang may hoist above the
+// compare, leaving the verifier to recover the range through scalar-ID linking
+// that older kernels do not have. bpf_clamp_umax() refines the register in place,
+// so any later move carries the bound with it.
+//
+// Returns 0 when nothing was written. bpf_probe_read_kernel() is all-or-nothing
+// and dst is a per-CPU buffer that nothing clears between messages, so reporting
+// a length the read did not produce would hand the protocol parsers whatever the
+// previous message on this CPU left behind.
+static __always_inline u16 msg_buffer_copy(unsigned char *dst, const void *src, u32 msg_size) {
+    u32 len = msg_size;
+    bpf_clamp_umax(len, k_msg_buffer_size_max);
+
+    if (len == 0 || bpf_probe_read_kernel(dst, len, src) != 0) {
+        return 0;
+    }
+
+    return (u16)len;
+}

--- a/bpf/tests/bpf_msg_buffer_copy.c
+++ b/bpf/tests/bpf_msg_buffer_copy.c
@@ -1,0 +1,187 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// fill_msg_buffers() copies the head of an outgoing message into msg_buffer_mem
+// and records how much it copied in msg_buffer_t.real_size. The kprobe on
+// tcp_sendmsg reads real_size back and hands that many bytes of msg_buffer_mem
+// to the protocol parsers, so real_size must never describe more than was
+// written. msg_buffer_mem is a BPF_MAP_TYPE_PERCPU_ARRAY that nothing clears
+// between messages, so every byte inside real_size this call did not write is
+// the previous message on this CPU.
+//
+// The length that has to hold is the one at the buffer's own size. A message of
+// exactly k_msg_buffer_size_max bytes is the largest one that fits, and it is
+// also the one a power-of-two mask maps onto zero.
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <bpfcore/bpf_helpers.h>
+
+static long test_probe_read_kernel(void *dst, unsigned int size, const void *src);
+
+#define bpf_probe_read_kernel test_probe_read_kernel
+
+#include <common/msg_buffer.h>
+
+#undef bpf_probe_read_kernel
+
+enum {
+    // Larger than the buffer, so a message can be longer than what is copied.
+    k_src_len = k_msg_buffer_size_max * 2,
+    // A byte no source position holds, left in the destination beforehand. Any
+    // occurrence below the reported length is a byte this call never wrote.
+    // build_src() cycles 0..250, so anything above that can never collide with
+    // the source pattern at any offset.
+    k_residue = 0xFF,
+};
+
+static unsigned char src[k_src_len];
+static unsigned char dst[k_msg_buffer_size_max];
+
+static int reads_fail;
+
+static long test_probe_read_kernel(void *d, unsigned int size, const void *s) {
+    if (reads_fail) {
+        // A faulting bpf_probe_read_kernel() copies nothing at all.
+        return -1;
+    }
+
+    memcpy(d, s, size);
+    return 0;
+}
+
+static void fail(const char *message, unsigned long expected, unsigned long actual) {
+    fprintf(stderr, "FAIL: %s\n  expected %lu, got %lu\n", message, expected, actual);
+    exit(1);
+}
+
+static void assert_eq(unsigned long expected, unsigned long actual, const char *message) {
+    if (expected != actual) {
+        fail(message, expected, actual);
+    }
+}
+
+// Fills src with a pattern that never contains k_residue, so the destination
+// can be checked byte for byte.
+static void build_src(void) {
+    for (int i = 0; i < k_src_len; i++) {
+        src[i] = (unsigned char)(i % 251);
+    }
+}
+
+static void fill_with_residue(void) {
+    memset(dst, k_residue, sizeof(dst));
+}
+
+// Reports how many leading bytes of dst hold the head of src.
+static unsigned long copied_prefix(void) {
+    unsigned long n = 0;
+
+    while (n < sizeof(dst) && dst[n] == src[n]) {
+        n++;
+    }
+
+    return n;
+}
+
+// Reports the first position at or after `from` that is not the residue.
+static unsigned long first_written_at_or_after(unsigned long from) {
+    unsigned long n = from;
+
+    while (n < sizeof(dst) && dst[n] == k_residue) {
+        n++;
+    }
+
+    return n;
+}
+
+static void check_copy(u32 msg_size, u16 want, const char *message) {
+    fill_with_residue();
+
+    const u16 copied = msg_buffer_copy(dst, src, msg_size);
+
+    assert_eq(want, copied, message);
+    assert_eq(want, copied_prefix(), "the bytes copied are exactly the reported length");
+    assert_eq(sizeof(dst),
+              first_written_at_or_after(want),
+              "nothing past the reported length was written");
+}
+
+// A message of exactly k_msg_buffer_size_max bytes is the largest one that
+// fits. Masking a length with k_msg_buffer_size_max - 1 turns it into a copy of
+// zero bytes while still reporting the full length.
+static void test_message_at_the_buffer_size_is_copied_whole(void) {
+    check_copy(k_msg_buffer_size_max,
+               k_msg_buffer_size_max,
+               "a message the size of the buffer copies the whole buffer");
+}
+
+static void test_message_larger_than_the_buffer_fills_it(void) {
+    check_copy(k_src_len, k_msg_buffer_size_max, "a message larger than the buffer fills it");
+
+    // Every length above the buffer's size lands on the same truncation, and a
+    // mask sends a whole class of them to zero rather than only the boundary.
+    check_copy(k_msg_buffer_size_max + 1, k_msg_buffer_size_max, "one byte over the buffer");
+    check_copy(k_msg_buffer_size_max * 2 - 1, k_msg_buffer_size_max, "just under twice over");
+}
+
+static void test_message_below_the_buffer_size_is_copied_whole(void) {
+    check_copy(k_msg_buffer_size_max - 1, k_msg_buffer_size_max - 1, "one byte under the buffer");
+    check_copy(4096, 4096, "a mid-sized message");
+    check_copy(1, 1, "a one byte message");
+}
+
+// The buffer is only ever read up to the reported length, so copying more than
+// the message holds reads past the extent the caller made readable.
+static void test_short_message_copies_only_its_own_bytes(void) {
+    check_copy(100, 100, "a message shorter than k_kprobes_http2_buf_size");
+    check_copy(k_kprobes_http2_buf_size - 1, k_kprobes_http2_buf_size - 1, "one byte under it");
+}
+
+static void test_empty_message_reports_nothing(void) {
+    fill_with_residue();
+
+    assert_eq(0, msg_buffer_copy(dst, src, 0), "an empty message reports no bytes");
+    assert_eq(sizeof(dst), first_written_at_or_after(0), "and writes nothing");
+}
+
+// bpf_probe_read_kernel() is all-or-nothing. A length that survived the failure
+// would name bytes belonging to the previous message on this CPU.
+static void test_failed_read_reports_nothing(void) {
+    reads_fail = 1;
+    fill_with_residue();
+
+    const u16 copied = msg_buffer_copy(dst, src, k_msg_buffer_size_max);
+
+    reads_fail = 0;
+
+    assert_eq(0, copied, "a faulting read reports no bytes");
+    assert_eq(sizeof(dst), first_written_at_or_after(0), "and leaves the residue in place");
+}
+
+// real_size is a u16, so the reported length has to fit in one.
+static void test_reported_length_fits_the_field(void) {
+    msg_buffer_t msg_buf = {0};
+
+    msg_buf.real_size = msg_buffer_copy(dst, src, k_src_len);
+
+    assert_eq(k_msg_buffer_size_max, msg_buf.real_size, "real_size holds the full buffer length");
+}
+
+int main(void) {
+    build_src();
+
+    test_message_at_the_buffer_size_is_copied_whole();
+    test_message_larger_than_the_buffer_fills_it();
+    test_message_below_the_buffer_size_is_copied_whole();
+    test_short_message_copies_only_its_own_bytes();
+    test_empty_message_reports_nothing();
+    test_failed_read_reports_nothing();
+    test_reported_length_fits_the_field();
+
+    printf("bpf_msg_buffer_copy: all tests passed\n");
+    return 0;
+}

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -675,16 +675,6 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
         return false;
     }
 
-    msg_buffer_t msg_buf = {
-        .pos = 0,
-        .real_size = min(msg->size, k_msg_buffer_size_max),
-        .cpu_id = bpf_get_smp_processor_id(),
-    };
-
-    bpf_probe_read_kernel(msg_buf.fallback_buf, k_kprobes_http2_buf_size, msg->data);
-
-    const u16 copy_bytes = max(msg_buf.real_size, k_kprobes_http2_buf_size);
-
     unsigned char **msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
 
     if (!msg_ptr) {
@@ -693,8 +683,25 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
     }
 
     msg_ptr[0] = 0;
-    bpf_probe_read_kernel(msg_ptr, copy_bytes & k_msg_buffer_size_max_mask, msg->data);
+
+    const u16 copied = msg_buffer_copy((unsigned char *)msg_ptr, msg->data, msg->size);
+
+    if (copied == 0) {
+        bpf_d_printk("failed to read msg data [%s]", __FUNCTION__);
+        return false;
+    }
+
     bpf_map_update_elem(&msg_buffer_mem, &(u32){0}, msg_ptr, BPF_ANY);
+
+    msg_buffer_t msg_buf = {
+        .pos = 0,
+        // Only ever the bytes msg_buffer_copy() wrote. The kprobe on
+        // tcp_sendmsg hands this length straight to the protocol parsers.
+        .real_size = copied,
+        .cpu_id = bpf_get_smp_processor_id(),
+    };
+
+    bpf_probe_read_kernel(msg_buf.fallback_buf, k_kprobes_http2_buf_size, msg->data);
 
     // We setup any call that looks like HTTP request to be extended.
     // This must match exactly to what the decision will be for

--- a/internal/test/integration/components/http_proxy_server/app.js
+++ b/internal/test/integration/components/http_proxy_server/app.js
@@ -54,7 +54,11 @@ app.post("/dial", jsonParser, async (req, res, next) => {
     console.log("sending nested call: ", req.body.rawRequest);
     const response = await send({ host: host, port: parseInt(port), rawRequest: req.body.rawRequest });
     const status = response.split("\r\n")[0];
-    res.send({ status: status });
+    // The body is returned so a caller can read what the far side actually
+    // received — the only way to observe a header this process never wrote,
+    // such as the traceparent an eBPF program injects on the way out.
+    const body = response.split("\r\n\r\n").slice(1).join("\r\n\r\n");
+    res.send({ status: status, body: body });
   } catch (err) {
     res.status(500).send({ error: err.message });
   }
@@ -62,6 +66,12 @@ app.post("/dial", jsonParser, async (req, res, next) => {
 
 app.get(/^\/arbitrary.{1}$/, (req, res) => {
   res.send(req.path);
+});
+
+// Reports the headers this server received, so a test can assert on a header
+// that was added to the request after the sender wrote it.
+app.get(/^\/echoheaders.{0,1}$/, (req, res) => {
+  res.json(req.headers);
 });
 
 app.listen(port, () => {

--- a/internal/test/integration/docker-compose-large-http-req.yml
+++ b/internal/test/integration/docker-compose-large-http-req.yml
@@ -14,6 +14,19 @@ services:
       otelcol:
         condition: service_started
 
+  # Uninstrumented peer. OBI shares httpproxyserver's network and pid
+  # namespaces only, so a request the proxy sends here is a real egress hop with
+  # nothing instrumenting the far side — which is what makes the sending side's
+  # client span the only span the hop can produce. A request the proxy sends to
+  # itself over loopback yields a server span and no client span at all.
+  httpechoserver:
+    build:
+      context: ../../..
+      dockerfile: internal/test/integration/components/http_proxy_server/Dockerfile
+    image: hatest-httpproxyserver
+    environment:
+      OTEL_SERVICE_NAME: "httpechoserver"
+
   obi:
     build:
       context: ../../..
@@ -50,6 +63,8 @@ services:
       OTEL_EBPF_BPF_CONTEXT_PROPAGATION: "all"
     depends_on:
       httpproxyserver:
+        condition: service_started
+      httpechoserver:
         condition: service_started
 
   # OpenTelemetry Collector

--- a/internal/test/integration/http_large_request_test.go
+++ b/internal/test/integration/http_large_request_test.go
@@ -160,7 +160,7 @@ func createRawHTTPRequest(t *testing.T, method, path, host string, headers ...st
 	return rawReq.String()
 }
 
-func getHTTPRequestSize(t *testing.T, host, method, path string, headers ...string) httpRequestSize { //nolint:unparam // the linter complains about "method" being always "GET"
+func getHTTPRequestSize(t *testing.T, host, method, path string, headers ...string) httpRequestSize {
 	t.Helper()
 
 	rawReq := createRawHTTPRequest(t, host, method, path, headers...)
@@ -230,4 +230,162 @@ func assertRequestTraceID(t *testing.T, method, path, traceID string) { //nolint
 	parent := res[0]
 	require.NotEmpty(t, parent.TraceID)
 	require.Equal(t, traceID, parent.TraceID)
+}
+
+// k_msg_buffer_size_max in bpf/common/msg_buffer.h — the size of msg_buffer_mem,
+// the per-CPU buffer the sk_msg program fills for the tcp_sendmsg kprobe.
+const msgBufferSizeMax = 8192
+
+// The uninstrumented peer the proxy sends to. OBI shares only
+// httpproxyserver's namespaces, so a request sent here is a genuine egress hop
+// whose only span is the sending side's client span. A request the proxy sends
+// to itself over loopback produces a server span and no client span at all, so
+// it cannot show this defect.
+const echoServerHost = "httpechoserver:3030"
+
+// An outgoing message at or above the size of msg_buffer_mem is where a length
+// bounded by a power-of-two mask rather than by a clamp collapses to zero:
+// 8192 & 8191 is 0, so the copy writes nothing while the recorded length still
+// says 8192. The tcp_sendmsg kprobe is then handed bytes this call never wrote,
+// protocol detection fails, and the request produces no client span at all. The
+// receiving side parses the request normally throughout, which is why this
+// needs an assertion on the sending side.
+//
+// The sizes are exact and they bracket the boundary. The two arbitrary-size
+// subtests above pad by rand.IntN(4096) on top of a 1 KB floor, so their
+// largest request is around 5 KB and neither has ever reached this boundary; a
+// randomized size that only sometimes crossed it would report a deterministic
+// defect as a flake. The small size is the control: it fails with the rest if
+// the fixture itself is broken, and passes alone if the boundary is.
+func testLargeHTTPRequestEgressAtMsgBufferBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		size int
+	}{
+		{name: "well below the msg buffer size", path: "/arbitrary3", size: 700},
+		{name: "one byte below the msg buffer size", path: "/arbitrary4", size: msgBufferSizeMax - 1},
+		{name: "exactly the msg buffer size", path: "/arbitrary5", size: msgBufferSizeMax},
+		{name: "above the msg buffer size", path: "/arbitrary6", size: msgBufferSizeMax + 512},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			headers := []string{
+				"Accept: */*",
+				"User-Agent: user_agent",
+				"Connection: close",
+				"Traceparent: " + createTraceparent(createTraceID(), createParentID()),
+			}
+			dialRawRequest(t, "GET", tc.path, headers, tc.size)
+
+			// The client span is what the boundary removes. The request carries
+			// a traceparent of its own so that the subtest exercises the
+			// existing-traceparent path through fill_msg_buffers(), which is
+			// the one a real caller with an upstream context takes.
+			awaitEgressClientSpan(t, "GET", tc.path)
+		})
+	}
+}
+
+// The same boundary for a request carrying no traceparent of its own, read off
+// the wire at the far end. fill_msg_buffers() feeds the decision to extend the
+// packet as well as the kprobe's buffer, so a fix that restored client spans by
+// suppressing injection would pass the test above and fail this one.
+func testLargeHTTPRequestEgressInjectionAtMsgBufferBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		size int
+	}{
+		{name: "well below the msg buffer size", path: "/echoheaders1", size: 700},
+		{name: "above the msg buffer size", path: "/echoheaders2", size: msgBufferSizeMax + 512},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			headers := []string{
+				"Accept: */*",
+				"User-Agent: user_agent",
+				"Connection: close",
+			}
+			received := dialRawRequest(t, "GET", tc.path, headers, tc.size)
+
+			var echoed map[string]string
+			require.NoError(t, json.Unmarshal([]byte(received), &echoed))
+
+			tp, ok := echoed["traceparent"]
+			require.True(t, ok, "no traceparent was injected into the outgoing request: %v", echoed)
+
+			client := awaitEgressClientSpan(t, "GET", tc.path)
+			require.Equal(t, "00-"+client.TraceID+"-"+client.SpanID+"-01", tp)
+		})
+	}
+}
+
+// Sends a raw request of exactly totalSize bytes from httpproxyserver to the
+// uninstrumented echo server, and returns the response body the echo server
+// sent back. totalSize is the length of the single write the proxy makes, and
+// therefore the sk_msg size the BPF program sees.
+func dialRawRequest(t *testing.T, method, path string, headers []string, totalSize int) string {
+	t.Helper()
+
+	const padHeader = "pad: "
+
+	reqSize := getHTTPRequestSize(t, echoServerHost, method, path, headers...)
+	padSize := totalSize - (reqSize.size + len(padHeader) + len("\r\n"))
+	require.Positive(t, padSize, "the request is already at least as large as the requested size")
+
+	headers = append(headers, padHeader+strings.Repeat("A", padSize))
+	rawReq := createRawHTTPRequest(t, method, path, echoServerHost, headers...)
+	require.Len(t, rawReq, totalSize, "the request must be exactly the size under test")
+
+	body, err := json.Marshal(map[string]string{"rawRequest": rawReq, "host": echoServerHost})
+	require.NoError(t, err)
+
+	resp := doHTTPPostReturnBody(t, "http://localhost:3035/dial", 200, body)
+
+	var dialResp struct {
+		Status string `json:"status"`
+		Body   string `json:"body"`
+	}
+	require.NoError(t, json.Unmarshal(resp, &dialResp))
+	require.Contains(t, dialResp.Status, "200")
+
+	return dialResp.Body
+}
+
+// Waits for the client span of the egress hop identified by path. Nothing
+// instruments the echo server, so this span is the only one the hop can
+// produce and its absence is exactly the defect under test. Each subtest uses a
+// path of its own, so the operation name identifies the hop on its own — a
+// client span carries the target as url.full rather than url.path, which is
+// asserted here rather than used to select the span.
+func awaitEgressClientSpan(t *testing.T, method, path string) jaeger.Span {
+	t.Helper()
+
+	operationName := fmt.Sprintf("%s %s", strings.ToUpper(method), path)
+
+	var span jaeger.Span
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=httpproxyserver&operation=" + url.QueryEscape(operationName))
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+
+		var spans []jaeger.Span
+		for i := range tq.Data {
+			spans = append(spans,
+				tq.Data[i].FindByOperationNameServiceAndKind(operationName, "httpproxyserver", "client")...)
+		}
+		require.Len(ct, spans, 1, "no client span was produced for the outgoing request")
+		span = spans[0]
+	}, testTimeout, 100*time.Millisecond)
+
+	full, ok := jaeger.FindIn(span.Tags, "url.full")
+	require.True(t, ok, "the client span carries no url.full")
+	require.Equal(t, "http://"+strings.Split(echoServerHost, ":")[0]+path, full.Value)
+
+	return span
 }

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -1350,6 +1350,14 @@ func TestSuite_LargeHTTPRequest(t *testing.T) {
 		testLargeHTTPRequestIngressArbitrarySize(t)
 	})
 
+	t.Run("Large HTTP Request egress flow at the msg buffer boundary (kprobe: tpinjector[sk_msg])", func(t *testing.T) {
+		testLargeHTTPRequestEgressAtMsgBufferBoundary(t)
+	})
+
+	t.Run("Large HTTP Request egress flow traceparent injection at the msg buffer boundary (kprobe: tpinjector[sk_msg])", func(t *testing.T) {
+		testLargeHTTPRequestEgressInjectionAtMsgBufferBoundary(t)
+	})
+
 	require.NoError(t, compose.Close())
 }
 

--- a/internal/test/integration/test_utils.go
+++ b/internal/test/integration/test_utils.go
@@ -72,13 +72,25 @@ func setHTTPClientDisableKeepAlives(disableKeepAlives bool) {
 }
 
 func doHTTPPost(t *testing.T, path string, status int, jsonBody []byte) {
+	doHTTPPostReturnBody(t, path, status, jsonBody)
+}
+
+// doHTTPPostReturnBody is doHTTPPost for a caller that needs to read what came
+// back rather than only the status.
+func doHTTPPostReturnBody(t *testing.T, path string, status int, jsonBody []byte) []byte {
 	req, err := http.NewRequest(http.MethodPost, path, bytes.NewReader(jsonBody))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
 	r, err := testHTTPClient.Do(req)
 	require.NoError(t, err)
+	defer r.Body.Close()
+
+	body, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
 	require.Equal(t, status, r.StatusCode)
+
+	return body
 }
 
 //nolint:errcheck


### PR DESCRIPTION

## The problem

`fill_msg_buffers()` copies the head of an outgoing message into a per-CPU buffer
so the `tcp_sendmsg` kprobe can parse it. It bounded that copy with
`copy_bytes & k_msg_buffer_size_max_mask`.

The mask is 8191, and the length caps at 8192. `8192 & 8191` is zero, so a
message of 8192 bytes or more copies nothing at all. The function still records
`real_size` as 8192.

The kprobe then finds the entry, trusts that length, and hands the protocol
parsers 8192 bytes this call never wrote. Nothing clears the buffer between
messages, so the parsers read whatever the previous message on that CPU left
behind.

## Symptoms and impact

Wherever context propagation is enabled, every plaintext outgoing HTTP request of
8 KB or more loses its client span. The request itself succeeds, and the
receiving service records it normally, so the loss looks like a missing
service-graph edge rather than an error. Stale bytes can also make a request
match a different protocol, so a span may be misattributed rather than merely
absent. Connections already known to carry TLS are exempt, because the function
returns early on `is_ssl_connection()`.

Two consequences are worth naming.

`exclude_otel_instrumented_services` never fires for a service that exports OTLP
over HTTP. An export batch always exceeds 8 KB, so the `POST /v1/traces` client
span the check looks for is one of the spans this bug destroys. The service is
then instrumented twice, by OBI and by its own SDK.

Memory-BIO TLS correlation cannot form for a record of 8 KB or more.
`tls_prefix_try_bind()` receives the same length and matches ciphertext against
residue, which may itself be a real TLS record from another connection.

## The fix

Bound the copy with `bpf_clamp_umax()`, and report only the bytes actually
written.

Use `bpf_clamp_umax()` rather than `min()`. The deleted mask bounded the register
on every kernel, because `BPF_AND` with an immediate always sets `umax_value`.
`min()` does not. It compiles to a compare and a select, and clang may hoist the
register copy above the compare, so the length reaches `bpf_probe_read_kernel()`
with its range unrefined unless the kernel links scalar IDs — 5.10 for ALU64, 6.4
for u32. Built at `-mcpu=v3`, `min()` fails to load on 5.10 for all 24
`tpinjector` constant combinations, with `R2 unbounded memory access, use
'var &= const' or 'if (var < const)'`. `bpf_clamp_umax()` refines the register in
place through inline asm, as its thirty existing call sites rely on, and holds
down to the 5.8 floor in `pkg/obi/os.go`.

`bpf_probe_read_kernel()` is all-or-nothing, so `real_size` now reports what it
wrote, and a zero-byte copy publishes no entry at all. Since #3257 gates the
sk_msg program's HTTP detection and injection on this function's return value, a
failed read now skips injection rather than deciding on bytes the call never
wrote.

### Testing

`bpf/tests/bpf_msg_buffer_copy.c` covers the arithmetic. It exercises the new
`msg_buffer_copy()` helper, so it cannot run against `main` unchanged.
Substituting the old expression into the helper makes it report `expected 8192,
got 0` for a maximal message.

`TestSuite_LargeHTTPRequest` gains egress subtests at 700, 8191, 8192 and 8704
bytes. The existing egress coverage pads to about 5 KB and never crosses the
boundary. One subtest sends without a `traceparent` of its own and reads the
header back off the wire at the far end, so a fix that restored client spans by
suppressing injection would fail it. Both need a peer the request genuinely
leaves the process for, since OBI emits no client span for a request an
instrumented process sends to itself.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

