### PR TITLE
tpinjector: gate the HTTP detector on the msg buffer fill in handle_existing_tp_pid

### DIFF
--- a/bpf/tests/bpf_tpinjector_msg_buffers.c
+++ b/bpf/tests/bpf_tpinjector_msg_buffers.c
@@ -1,0 +1,362 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// msg_buffer_mem is per CPU and nothing clears it between messages, so after
+// fill_msg_buffers bails it still holds whichever message that CPU filled it
+// from last. protocol_detector reads that buffer, so its answer describes this
+// message only when the fill that precedes it succeeded.
+//
+// The bail that matters is the SSL one: the message on the wire is a TLS
+// record, the resident message is a plaintext HTTP request from another
+// connection, and a caller that acts on the match splices a 'Traceparent:'
+// header into the middle of the record. test_stale_buffer_still_matches_http
+// establishes that the match happens; test_guarded_read_refuses_a_stale_buffer
+// is the regression - it fails if the reader stops being gated on the fill.
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <bpfcore/bpf_helpers.h>
+
+enum { BPF_ANY = 0, BPF_NOEXIST = 1 };
+
+// One entry holds the whole per-CPU msg_buffer_mem slab.
+enum { k_max_entries = 4, k_max_key = 64, k_max_val = 8192 };
+
+typedef struct mock_entry {
+    int used;
+    unsigned char key[k_max_key];
+    unsigned char val[k_max_val];
+} mock_entry_t;
+
+struct bpf_test_map {
+    const char *name;
+    unsigned int key_size;
+    unsigned int val_size;
+    mock_entry_t entries[k_max_entries];
+};
+
+static void *test_map_lookup(void *map, const void *key);
+static long test_map_update(void *map, const void *key, const void *val, unsigned long long flags);
+static long test_probe_read(void *dst, unsigned int size, const void *src);
+
+#define bpf_map_lookup_elem test_map_lookup
+#define bpf_map_update_elem test_map_update
+#define bpf_probe_read test_probe_read
+#define bpf_probe_read_kernel test_probe_read
+
+#include <tpinjector/msg_buffers.h>
+
+#undef bpf_map_lookup_elem
+#undef bpf_map_update_elem
+#undef bpf_probe_read
+#undef bpf_probe_read_kernel
+
+// The macros above are scoped to the code under test. Test code reaches the
+// mock maps directly, since the real helpers are no-op stubs on the host.
+#define map_get test_map_lookup
+#define map_put(m, k, v) test_map_update((m), (k), (v), 0)
+
+_Static_assert(k_max_val == k_msg_buffer_size_max, "one entry must hold the whole slab");
+
+struct bpf_test_map msg_buffer_mem = {
+    .name = "msg_buffer_mem", .key_size = sizeof(u32), .val_size = k_msg_buffer_size_max};
+struct bpf_test_map msg_buffers = {
+    .name = "msg_buffers", .key_size = sizeof(egress_key_t), .val_size = sizeof(msg_buffer_t)};
+struct bpf_test_map active_ssl_connections = {.name = "active_ssl_connections",
+                                              .key_size = sizeof(pid_connection_info_t),
+                                              .val_size = sizeof(u64)};
+struct bpf_test_map ongoing_http = {
+    .name = "ongoing_http", .key_size = sizeof(pid_connection_info_t), .val_size = sizeof(u64)};
+struct bpf_test_map ongoing_tcp_req = {
+    .name = "ongoing_tcp_req", .key_size = sizeof(pid_connection_info_t), .val_size = sizeof(u64)};
+struct bpf_test_map ongoing_http2_connections = {.name = "ongoing_http2_connections",
+                                                 .key_size = sizeof(pid_connection_info_t),
+                                                 .val_size = sizeof(u64)};
+
+static int failures;
+
+static void check(int ok, const char *message) {
+    if (!ok) {
+        fprintf(stderr, "FAIL: %s\n", message);
+        failures++;
+    }
+}
+
+static void *test_map_lookup(void *map, const void *key) {
+    struct bpf_test_map *m = map;
+
+    for (int i = 0; i < k_max_entries; i++) {
+        if (m->entries[i].used && memcmp(m->entries[i].key, key, m->key_size) == 0) {
+            return m->entries[i].val;
+        }
+    }
+
+    return NULL;
+}
+
+static long test_map_update(void *map, const void *key, const void *val, unsigned long long flags) {
+    struct bpf_test_map *m = map;
+    (void)flags;
+
+    int free_slot = -1;
+
+    for (int i = 0; i < k_max_entries; i++) {
+        if (!m->entries[i].used) {
+            if (free_slot < 0) {
+                free_slot = i;
+            }
+            continue;
+        }
+        if (memcmp(m->entries[i].key, key, m->key_size) == 0) {
+            // fill_msg_buffers writes the slab back over itself; a memcpy of a
+            // region onto itself is undefined, and the copy is a no-op anyway.
+            if (val != m->entries[i].val) {
+                memcpy(m->entries[i].val, val, m->val_size);
+            }
+            return 0;
+        }
+    }
+
+    if (free_slot < 0) {
+        return -1;
+    }
+
+    m->entries[free_slot].used = 1;
+    memcpy(m->entries[free_slot].key, key, m->key_size);
+    memcpy(m->entries[free_slot].val, val, m->val_size);
+
+    return 0;
+}
+
+static long test_probe_read(void *dst, unsigned int size, const void *src) {
+    if (!src) {
+        return -1;
+    }
+    memcpy(dst, src, size);
+    return 0;
+}
+
+// The kernel hands sk_msg programs a linear region; a message here is a fixed
+// slab so that fill_msg_buffers' 256-byte fallback read is always in bounds.
+typedef struct test_msg {
+    unsigned char bytes[k_msg_buffer_size_max];
+    struct sk_msg_md md;
+} test_msg_t;
+
+static const u64 k_id = 0x0000029a00000cafULL; // pid 666
+static const u32 k_cpu = 3;
+
+static void build_msg(test_msg_t *m, const void *payload, u32 len) {
+    memset(m->bytes, 0, sizeof(m->bytes));
+    memcpy(m->bytes, payload, len);
+    m->md.data = m->bytes;
+    m->md.data_end = m->bytes + sizeof(m->bytes);
+    m->md.size = len;
+}
+
+// A plaintext HTTP/1.1 client request, the shape protocol_detector matches.
+static void build_http_request(test_msg_t *m, const char *line) {
+    char buf[256];
+    const int n = snprintf(buf, sizeof(buf), "%s\r\nHost: upstream:8080\r\n\r\n", line);
+    build_msg(m, buf, (u32)n);
+}
+
+// A TLS 1.2+ application_data record. The 0x0a is what write_msg_traceparent
+// would find and split the record at.
+static void build_tls_record(test_msg_t *m) {
+    unsigned char rec[512];
+    memset(rec, 0xab, sizeof(rec));
+    rec[0] = 0x17; // application_data
+    rec[1] = 0x03;
+    rec[2] = 0x03;
+    rec[3] = 0x01;
+    rec[4] = 0xfb;
+    rec[64] = '\n';
+    build_msg(m, rec, sizeof(rec));
+}
+
+static pid_connection_info_t make_conn(u16 s_port, u16 d_port) {
+    pid_connection_info_t p_conn = {};
+
+    p_conn.conn.s_addr[15] = 10;
+    p_conn.conn.d_addr[15] = 20;
+    p_conn.conn.s_port = s_port;
+    p_conn.conn.d_port = d_port;
+    p_conn.pid = pid_from_pid_tgid(k_id);
+
+    sort_connection_info(&p_conn.conn);
+
+    return p_conn;
+}
+
+static egress_key_t make_key(u16 s_port, u16 d_port) {
+    egress_key_t e_key = {.s_port = s_port, .d_port = d_port, .stream_id = 0};
+
+    return e_key;
+}
+
+static void reset(void) {
+    memset(msg_buffer_mem.entries, 0, sizeof(msg_buffer_mem.entries));
+    memset(msg_buffers.entries, 0, sizeof(msg_buffers.entries));
+    memset(active_ssl_connections.entries, 0, sizeof(active_ssl_connections.entries));
+    memset(ongoing_http.entries, 0, sizeof(ongoing_http.entries));
+    memset(ongoing_tcp_req.entries, 0, sizeof(ongoing_tcp_req.entries));
+    memset(ongoing_http2_connections.entries, 0, sizeof(ongoing_http2_connections.entries));
+
+    bpf_smp_processor_id_value = k_cpu;
+
+    // the per-CPU array always has its single slot
+    unsigned char zero_slab[k_msg_buffer_size_max] = {0};
+    map_put(&msg_buffer_mem, &(u32){0}, zero_slab);
+}
+
+static const unsigned char *cpu_slab(void) {
+    return map_get(&msg_buffer_mem, &(u32){0});
+}
+
+// A plaintext send fills the slab from this message and reports it did.
+static void test_plaintext_fill_refreshes_the_buffer(void) {
+    reset();
+
+    test_msg_t plain;
+    build_http_request(&plain, "GET /catalog HTTP/1.1");
+    const pid_connection_info_t conn = make_conn(40000, 8080);
+    const egress_key_t key = make_key(40000, 8080);
+
+    check(fill_msg_buffers(&plain.md, &conn, &key), "a plaintext send fills the buffer");
+    check(memcmp(cpu_slab(), "GET /catalog HTTP/1.1", 21) == 0,
+          "the slab holds this message's request line");
+    check(protocol_detector(&plain.md, k_id, &conn.conn) == 1,
+          "the detector reports the request it was just filled from");
+
+    const msg_buffer_t *m_buf = map_get(&msg_buffers, &key);
+    check(m_buf != NULL, "the kprobe's msg_buffers entry is published");
+    check(m_buf && m_buf->cpu_id == k_cpu, "the entry records the CPU that filled the slab");
+}
+
+// An SSL connection bails without touching the slab, so the previous
+// connection's request is still resident and still matches.
+static void test_stale_buffer_still_matches_http(void) {
+    reset();
+
+    test_msg_t plain;
+    build_http_request(&plain, "POST /documents HTTP/1.1");
+    const pid_connection_info_t plain_conn = make_conn(40000, 8080);
+    const egress_key_t plain_key = make_key(40000, 8080);
+
+    check(fill_msg_buffers(&plain.md, &plain_conn, &plain_key), "the plaintext send fills first");
+
+    // the same CPU now handles a connection the SSL uprobes have bound
+    test_msg_t cipher;
+    build_tls_record(&cipher);
+    const pid_connection_info_t tls_conn = make_conn(40001, 8443);
+    const egress_key_t tls_key = make_key(40001, 8443);
+    map_put(&active_ssl_connections, &tls_conn, &(u64){0xdeadbeef});
+
+    check(!fill_msg_buffers(&cipher.md, &tls_conn, &tls_key),
+          "a known SSL connection reports the buffer was not filled");
+    check(map_get(&msg_buffers, &tls_key) == NULL,
+          "and publishes no msg_buffers entry for this connection");
+    check(memcmp(cpu_slab(), "POST /documents HTTP/1.1", 24) == 0,
+          "the slab still holds the previous connection's request");
+    check(protocol_detector(&cipher.md, k_id, &tls_conn.conn) == 1,
+          "so an ungated detector reports this TLS record as an HTTP request");
+}
+
+// The regression: the reader is gated on the fill, so the stale match above
+// never reaches the caller.
+static void test_guarded_read_refuses_a_stale_buffer(void) {
+    reset();
+
+    test_msg_t plain;
+    build_http_request(&plain, "POST /documents HTTP/1.1");
+    const pid_connection_info_t plain_conn = make_conn(40000, 8080);
+    const egress_key_t plain_key = make_key(40000, 8080);
+
+    check(fill_msg_buffers(&plain.md, &plain_conn, &plain_key), "the plaintext send fills first");
+
+    test_msg_t cipher;
+    build_tls_record(&cipher);
+    const pid_connection_info_t tls_conn = make_conn(40001, 8443);
+    const egress_key_t tls_key = make_key(40001, 8443);
+    map_put(&active_ssl_connections, &tls_conn, &(u64){0xdeadbeef});
+
+    check(!msg_buffer_holds_http_request(&cipher.md, k_id, &tls_conn, &tls_key),
+          "a bailed fill never reports an HTTP request");
+}
+
+// A zero-length send bails on the same path and must be gated the same way.
+static void test_guarded_read_refuses_an_empty_message(void) {
+    reset();
+
+    test_msg_t plain;
+    build_http_request(&plain, "GET /catalog HTTP/1.1");
+    const pid_connection_info_t plain_conn = make_conn(40000, 8080);
+    const egress_key_t plain_key = make_key(40000, 8080);
+
+    check(fill_msg_buffers(&plain.md, &plain_conn, &plain_key), "the plaintext send fills first");
+
+    test_msg_t empty;
+    build_msg(&empty, "", 0);
+    const pid_connection_info_t other_conn = make_conn(40002, 8080);
+    const egress_key_t other_key = make_key(40002, 8080);
+
+    check(!msg_buffer_holds_http_request(&empty.md, k_id, &other_conn, &other_key),
+          "an empty send never reports an HTTP request");
+}
+
+// The gate must not suppress a genuine match.
+static void test_guarded_read_accepts_a_fresh_request(void) {
+    reset();
+
+    test_msg_t plain;
+    build_http_request(&plain, "GET /catalog HTTP/1.1");
+    const pid_connection_info_t conn = make_conn(40000, 8080);
+    const egress_key_t key = make_key(40000, 8080);
+
+    check(msg_buffer_holds_http_request(&plain.md, k_id, &conn, &key),
+          "a filled buffer holding this message's request is reported");
+}
+
+// A plaintext send that is not a request must not be reported either, whichever
+// message the slab happened to hold before it.
+static void test_guarded_read_rejects_a_non_request(void) {
+    reset();
+
+    test_msg_t plain;
+    build_http_request(&plain, "GET /catalog HTTP/1.1");
+    const pid_connection_info_t first = make_conn(40000, 8080);
+    const egress_key_t first_key = make_key(40000, 8080);
+
+    check(fill_msg_buffers(&plain.md, &first, &first_key), "the plaintext request fills first");
+
+    test_msg_t response;
+    build_msg(&response, "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n", 37);
+    const pid_connection_info_t second = make_conn(40003, 8080);
+    const egress_key_t second_key = make_key(40003, 8080);
+
+    check(!msg_buffer_holds_http_request(&response.md, k_id, &second, &second_key),
+          "a response refreshes the slab and is not reported as a request");
+}
+
+int main(void) {
+    bpf_current_pid_tgid_value = k_id;
+
+    test_plaintext_fill_refreshes_the_buffer();
+    test_stale_buffer_still_matches_http();
+    test_guarded_read_refuses_a_stale_buffer();
+    test_guarded_read_refuses_an_empty_message();
+    test_guarded_read_accepts_a_fresh_request();
+    test_guarded_read_rejects_a_non_request();
+
+    if (failures) {
+        fprintf(stderr, "%d check(s) failed\n", failures);
+        return 1;
+    }
+
+    printf("bpf_tpinjector_msg_buffers: all checks passed\n");
+    return 0;
+}

--- a/bpf/tests/bpfcore/bpf_helpers.h
+++ b/bpf/tests/bpfcore/bpf_helpers.h
@@ -86,3 +86,8 @@ static inline long bpf_get_current_comm(void *buf, unsigned int sz) {
 static inline int bpf_printk(const char *fmt, ...) {
     return 0;
 }
+// Tests that exercise per-CPU state set this to choose which CPU they are on.
+static unsigned int bpf_smp_processor_id_value;
+static inline unsigned int bpf_get_smp_processor_id(void) {
+    return bpf_smp_processor_id_value;
+}

--- a/bpf/tests/bpfcore/vmlinux.h
+++ b/bpf/tests/bpfcore/vmlinux.h
@@ -162,6 +162,20 @@ struct __sk_buff {
     u32 len;
     u32 protocol;
 };
+// Only the fields the sk_msg programs read. data/data_end are void * in the
+// kernel UAPI; a host test points them at a plain buffer.
+struct sk_msg_md {
+    void *data;
+    void *data_end;
+    u32 family;
+    u32 remote_ip4;
+    u32 local_ip4;
+    u32 remote_ip6[4];
+    u32 local_ip6[4];
+    u32 remote_port;
+    u32 local_port;
+    u32 size;
+};
 // 16 bytes, as in bpfcore/vmlinux_*.h; obi_msg_name_port length-checks
 // msg_namelen against sizeof(struct sockaddr_in)
 struct sockaddr_in {

--- a/bpf/tests/common/msg_buffer.h
+++ b/bpf/tests/common/msg_buffer.h
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Host-test shadow of common/msg_buffer.h: keeps the sizes and the
+// msg_buffer_t layout the code under test depends on, and replaces the
+// per-CPU array with a mock map the test owns.
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/http_buf_size.h>
+
+enum {
+    k_msg_buffer_size_max = 8192,
+    k_msg_buffer_size_max_mask = k_msg_buffer_size_max - 1,
+};
+
+extern struct bpf_test_map msg_buffer_mem;
+
+typedef struct msg_buffer {
+    unsigned char fallback_buf[k_kprobes_http2_buf_size];
+    u16 pos;
+    u16 real_size;
+    u32 cpu_id;
+} msg_buffer_t;

--- a/bpf/tests/maps/msg_buffers.h
+++ b/bpf/tests/maps/msg_buffers.h
@@ -1,0 +1,11 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/egress_key.h>
+#include <common/msg_buffer.h>
+
+extern struct bpf_test_map msg_buffers;

--- a/bpf/tests/maps/ongoing_http.h
+++ b/bpf/tests/maps/ongoing_http.h
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/http_info.h>
+
+extern struct bpf_test_map ongoing_http;

--- a/bpf/tests/maps/ongoing_http2_connections.h
+++ b/bpf/tests/maps/ongoing_http2_connections.h
@@ -1,0 +1,12 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/connection_info.h>
+
+#include <generictracer/types/http2_conn_info_data.h>
+
+extern struct bpf_test_map ongoing_http2_connections;

--- a/bpf/tests/maps/ongoing_tcp_req.h
+++ b/bpf/tests/maps/ongoing_tcp_req.h
@@ -1,0 +1,11 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/common.h>
+#include <common/connection_info.h>
+
+extern struct bpf_test_map ongoing_tcp_req;

--- a/bpf/tpinjector/msg_buffers.h
+++ b/bpf/tpinjector/msg_buffers.h
@@ -1,0 +1,114 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_builtins.h>
+#include <bpfcore/bpf_helpers.h>
+
+#include <common/algorithm.h>
+#include <common/connection_info.h>
+#include <common/egress_key.h>
+#include <common/http_buf_size.h>
+#include <common/http_types.h>
+#include <common/msg_buffer.h>
+#include <common/protocol_http_helpers.h>
+#include <common/protocol_http2_helpers.h>
+#include <common/protocol_tcp_helpers.h>
+#include <common/ssl_connection.h>
+
+#include <pid/pid_helpers.h>
+
+#include <logger/bpf_dbg.h>
+
+#include <maps/msg_buffers.h>
+
+static __always_inline u8 already_tracked(const pid_connection_info_t *p_conn) {
+    return already_tracked_http(p_conn) || already_tracked_tcp(p_conn) ||
+           already_tracked_http2(p_conn);
+}
+
+// This code is copied from the kprobe on tcp_sendmsg and it's called from
+// the sock_msg program, which does the packet extension for injecting the
+// Traceparent. Since the sock_msg runs before the kprobe on tcp_sendmsg, we
+// need to extend the packet before we'll have the opportunity to setup the
+// outgoing_trace_map metadata. We can directly perhaps run the same code that
+// the kprobe on tcp_sendmsg does, but it's complicated, no tail calls from
+// sock_msg programs and inlining will eventually hit us with the instruction
+// limit when we eventually add HTTP2/gRPC support.
+// Populates msg_buffers / msg_buffer_mem for the kprobe on tcp_sendmsg,
+// which runs after sk_msg. Bails on size=0, SSL, or allocation failure.
+static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
+                                             const pid_connection_info_t *p_conn,
+                                             const egress_key_t *e_key) {
+    if (msg->size == 0 || is_ssl_connection(p_conn)) {
+        return false;
+    }
+
+    msg_buffer_t msg_buf = {
+        .pos = 0,
+        .real_size = min(msg->size, k_msg_buffer_size_max),
+        .cpu_id = bpf_get_smp_processor_id(),
+    };
+
+    bpf_probe_read_kernel(msg_buf.fallback_buf, k_kprobes_http2_buf_size, msg->data);
+
+    const u16 copy_bytes = max(msg_buf.real_size, k_kprobes_http2_buf_size);
+
+    unsigned char **msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
+
+    if (!msg_ptr) {
+        bpf_d_printk("failed to reserve msg_buffer space [%s]", __FUNCTION__);
+        return false;
+    }
+
+    msg_ptr[0] = 0;
+    bpf_probe_read_kernel(msg_ptr, copy_bytes & k_msg_buffer_size_max_mask, msg->data);
+    bpf_map_update_elem(&msg_buffer_mem, &(u32){0}, msg_ptr, BPF_ANY);
+
+    // We setup any call that looks like HTTP request to be extended.
+    // This must match exactly to what the decision will be for
+    // the kprobe program on tcp_sendmsg, which sets up the
+    // outgoing_trace_map data used by Traffic Control to write the
+    // actual 'Traceparent:...' string.
+
+    if (bpf_map_update_elem(&msg_buffers, e_key, &msg_buf, BPF_ANY)) {
+        // fail if we can't setup a msg buffer
+        return false;
+    }
+
+    return true;
+}
+
+static __always_inline u8 protocol_detector(struct sk_msg_md *msg,
+                                            u64 id,
+                                            const connection_info_t *conn) {
+    bpf_dbg_printk("id=%d, size=%d", id, msg->size);
+
+    pid_connection_info_t p_conn = {};
+    bpf_memcpy(&p_conn.conn, conn, sizeof(connection_info_t));
+
+    dbg_print_http_connection_info(&p_conn.conn);
+    sort_connection_info(&p_conn.conn);
+    p_conn.pid = pid_from_pid_tgid(id);
+
+    if (already_tracked(&p_conn)) {
+        bpf_dbg_printk("already extended before, ignoring this packet...");
+        return 0;
+    }
+
+    unsigned char **msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
+
+    if (!msg_ptr) {
+        return 0;
+    }
+
+    if (is_http_request_buf((const unsigned char *)msg_ptr)) {
+        bpf_dbg_printk("setting up request to be extended");
+
+        return 1;
+    }
+
+    return 0;
+}

--- a/bpf/tpinjector/msg_buffers.h
+++ b/bpf/tpinjector/msg_buffers.h
@@ -39,6 +39,11 @@ static __always_inline u8 already_tracked(const pid_connection_info_t *p_conn) {
 // limit when we eventually add HTTP2/gRPC support.
 // Populates msg_buffers / msg_buffer_mem for the kprobe on tcp_sendmsg,
 // which runs after sk_msg. Bails on size=0, SSL, or allocation failure.
+//
+// On a bail the per-CPU msg_buffer_mem is left untouched, so it still holds
+// whichever message this CPU last filled it from. Nothing clears it between
+// messages, so a caller that reads it after a bail is reading a different
+// connection's traffic — see msg_buffer_holds_http_request below.
 static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
                                              const pid_connection_info_t *p_conn,
                                              const egress_key_t *e_key) {
@@ -111,4 +116,24 @@ static __always_inline u8 protocol_detector(struct sk_msg_md *msg,
     }
 
     return 0;
+}
+
+// True only when msg_buffer_mem was refreshed from THIS message and that
+// message is an HTTP/1 request that may be extended.
+//
+// protocol_detector reads a per-CPU buffer that nothing clears between
+// messages, so its answer describes this message only when the fill that
+// precedes it succeeded. Reading it after a bail (SSL, size 0, allocation
+// failure) matches whatever plaintext request this CPU handled last and
+// injects a Traceparent into an unrelated connection - into the middle of a
+// TLS record, on the SSL bail. obi_packet_extender enforces the same rule
+// with an early return on fill_msg_buffers' result, because it needs that
+// result before its HTTP/2 branch.
+static __always_inline bool msg_buffer_holds_http_request(struct sk_msg_md *msg,
+                                                          u64 id,
+                                                          const pid_connection_info_t *p_conn,
+                                                          const egress_key_t *e_key) {
+    const bool msg_buffers_ready = fill_msg_buffers(msg, p_conn, e_key);
+
+    return msg_buffers_ready && protocol_detector(msg, id, &p_conn->conn);
 }

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -1008,9 +1008,11 @@ static __always_inline bool handle_existing_tp_pid(struct sk_msg_md *msg,
     }
 
     bpf_msg_pull_data(msg, 0, msg->size, 0);
-    fill_msg_buffers(msg, p_conn, e_key);
 
-    const bool is_http = protocol_detector(msg, id, &p_conn->conn);
+    // reads msg_buffer_mem only when the fill that precedes it refreshed the
+    // buffer from this message; on a bail it still holds whichever message this
+    // CPU filled last, and injecting on that match corrupts this connection
+    const bool is_http = msg_buffer_holds_http_request(msg, id, p_conn, e_key);
     if (is_http) {
         if (inject_flags & k_inject_http_headers) {
             write_http_traceparent(msg, tp_pid);

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -44,6 +44,7 @@
 
 #include <tpinjector/h2_parse.h>
 #include <tpinjector/inject_policy.h>
+#include <tpinjector/msg_buffers.h>
 #include <tpinjector/maps/sk_h2_flags.h>
 #include <tpinjector/maps/sk_h2_conn_flag.h>
 #include <tpinjector/maps/sk_tp_info_pid_map.h>
@@ -378,11 +379,6 @@ static __always_inline void clear_tp_info_pid(const egress_key_t *e_key) {
     bpf_map_delete_elem(&outgoing_trace_map, e_key);
 }
 
-static __always_inline u8 already_tracked(const pid_connection_info_t *p_conn) {
-    return already_tracked_http(p_conn) || already_tracked_tcp(p_conn) ||
-           already_tracked_http2(p_conn);
-}
-
 // Extracts what we need for connection_info_t from bpf_sock_ops if the
 // communication is IPv4
 static __always_inline connection_info_t sk_ops_extract_key_ip4(struct bpf_sock_ops *ops) {
@@ -656,90 +652,6 @@ int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
     }
 
     return 1;
-}
-
-// This code is copied from the kprobe on tcp_sendmsg and it's called from
-// the sock_msg program, which does the packet extension for injecting the
-// Traceparent. Since the sock_msg runs before the kprobe on tcp_sendmsg, we
-// need to extend the packet before we'll have the opportunity to setup the
-// outgoing_trace_map metadata. We can directly perhaps run the same code that
-// the kprobe on tcp_sendmsg does, but it's complicated, no tail calls from
-// sock_msg programs and inlining will eventually hit us with the instruction
-// limit when we eventually add HTTP2/gRPC support.
-// Populates msg_buffers / msg_buffer_mem for the kprobe on tcp_sendmsg,
-// which runs after sk_msg. Bails on size=0, SSL, or allocation failure.
-static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
-                                             const pid_connection_info_t *p_conn,
-                                             const egress_key_t *e_key) {
-    if (msg->size == 0 || is_ssl_connection(p_conn)) {
-        return false;
-    }
-
-    msg_buffer_t msg_buf = {
-        .pos = 0,
-        .real_size = min(msg->size, k_msg_buffer_size_max),
-        .cpu_id = bpf_get_smp_processor_id(),
-    };
-
-    bpf_probe_read_kernel(msg_buf.fallback_buf, k_kprobes_http2_buf_size, msg->data);
-
-    const u16 copy_bytes = max(msg_buf.real_size, k_kprobes_http2_buf_size);
-
-    unsigned char **msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
-
-    if (!msg_ptr) {
-        bpf_d_printk("failed to reserve msg_buffer space [%s]", __FUNCTION__);
-        return false;
-    }
-
-    msg_ptr[0] = 0;
-    bpf_probe_read_kernel(msg_ptr, copy_bytes & k_msg_buffer_size_max_mask, msg->data);
-    bpf_map_update_elem(&msg_buffer_mem, &(u32){0}, msg_ptr, BPF_ANY);
-
-    // We setup any call that looks like HTTP request to be extended.
-    // This must match exactly to what the decision will be for
-    // the kprobe program on tcp_sendmsg, which sets up the
-    // outgoing_trace_map data used by Traffic Control to write the
-    // actual 'Traceparent:...' string.
-
-    if (bpf_map_update_elem(&msg_buffers, e_key, &msg_buf, BPF_ANY)) {
-        // fail if we can't setup a msg buffer
-        return false;
-    }
-
-    return true;
-}
-
-static __always_inline u8 protocol_detector(struct sk_msg_md *msg,
-                                            u64 id,
-                                            const connection_info_t *conn) {
-    bpf_dbg_printk("id=%d, size=%d", id, msg->size);
-
-    pid_connection_info_t p_conn = {};
-    bpf_memcpy(&p_conn.conn, conn, sizeof(connection_info_t));
-
-    dbg_print_http_connection_info(&p_conn.conn);
-    sort_connection_info(&p_conn.conn);
-    p_conn.pid = pid_from_pid_tgid(id);
-
-    if (already_tracked(&p_conn)) {
-        bpf_dbg_printk("already extended before, ignoring this packet...");
-        return 0;
-    }
-
-    unsigned char **msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
-
-    if (!msg_ptr) {
-        return 0;
-    }
-
-    if (is_http_request_buf((const unsigned char *)msg_ptr)) {
-        bpf_dbg_printk("setting up request to be extended");
-
-        return 1;
-    }
-
-    return 0;
 }
 
 static __always_inline connection_info_t get_connection_info(struct sk_msg_md *msg) {


### PR DESCRIPTION

## The problem

`fill_msg_buffers()` returns early on `msg->size == 0` and on `is_ssl_connection()`,
before it invalidates the head of `msg_buffer_mem`. That buffer is a per-CPU array that
nothing clears between messages, so after an early return it still holds the previous
message on that CPU.

`handle_existing_tp_pid()` discards the return value and calls `protocol_detector()`
anyway. Nothing between those two points knows which message the buffer describes.

#3257 fixed this for `obi_packet_extender()`, which now gates on the same return value.
`handle_existing_tp_pid()` is the other caller and was not covered.

## The fix

`handle_existing_tp_pid()` now reads the buffer only through
`msg_buffer_holds_http_request()`, which returns `fill_msg_buffers(...) &&
protocol_detector(...)`. That is #3257's pattern applied to the second call site.

The change makes the program smaller: `obi_packet_extender` goes from 7,414 to 7,380
instructions.

Two commits. The first moves `fill_msg_buffers`, `protocol_detector` and `already_tracked`
verbatim into `bpf/tpinjector/msg_buffers.h`, alongside the existing `inject_policy.h`, so
a host test can reach them; the only line added to `tpinjector.c` is the include. I checked
that move is behaviour-neutral at the bytecode level rather than by eye — `llvm-objdump -d`
of the generated object before and after differs only in the file-name header line, 22,654
lines otherwise identical. The second commit adds the gate and the test.

### Testing

`bpf/tests/bpf_tpinjector_msg_buffers.c` drives `fill_msg_buffers()` and
`protocol_detector()` on the host with mock maps. It establishes the hazard before
asserting the fix: after a plaintext fill, an SSL connection's fill returns false,
publishes no `msg_buffers` entry, leaves the previous request byte-for-byte resident, and
`protocol_detector()` still returns 1. It then asserts that the guarded reader refuses that,
refuses a zero-length send, accepts a genuine request, and rejects a response.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

