### PR TITLE
Fix out-of-bounds read in fill_msg_buffers when msg pull fails

### DIFF
--- a/bpf/common/msg_buffer.h
+++ b/bpf/common/msg_buffer.h
@@ -11,7 +11,6 @@
 
 enum {
     k_msg_buffer_size_max = 8192,
-    k_msg_buffer_size_max_mask = k_msg_buffer_size_max - 1,
 };
 
 struct {

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -681,9 +681,15 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
         .cpu_id = bpf_get_smp_processor_id(),
     };
 
-    bpf_probe_read_kernel(msg_buf.fallback_buf, k_kprobes_http2_buf_size, msg->data);
-
     const u16 copy_bytes = max(msg_buf.real_size, k_kprobes_http2_buf_size);
+
+    // A failed bpf_msg_pull_data() leaves msg->data/data_end short of copy_bytes.
+    // Reading past data_end would copy whatever kernel memory follows the message.
+    if (!msg->data || msg->data + copy_bytes > msg->data_end) {
+        return false;
+    }
+
+    bpf_probe_read_kernel(msg_buf.fallback_buf, k_kprobes_http2_buf_size, msg->data);
 
     unsigned char **msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
 

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -675,21 +675,25 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
         return false;
     }
 
-    msg_buffer_t msg_buf = {
-        .pos = 0,
-        .real_size = min(msg->size, k_msg_buffer_size_max),
-        .cpu_id = bpf_get_smp_processor_id(),
-    };
-
-    const u16 copy_bytes = max(msg_buf.real_size, k_kprobes_http2_buf_size);
-
-    // A failed bpf_msg_pull_data() leaves msg->data/data_end short of copy_bytes.
-    // Reading past data_end would copy whatever kernel memory follows the message.
-    if (!msg->data || msg->data + copy_bytes > msg->data_end) {
+    if (!msg->data || msg->data >= msg->data_end) {
         return false;
     }
 
-    bpf_probe_read_kernel(msg_buf.fallback_buf, k_kprobes_http2_buf_size, msg->data);
+    // A failed bpf_msg_pull_data() can leave msg->data/data_end short of msg->size.
+    // Every read below is bounded by this mapped window instead of msg->size alone,
+    // so a short message never pulls in whatever kernel memory follows it.
+    const u32 mapped = (unsigned char *)msg->data_end - (unsigned char *)msg->data;
+    const u16 window = min(mapped, (u32)k_msg_buffer_size_max);
+
+    msg_buffer_t msg_buf = {
+        .pos = 0,
+        .real_size = min(min(msg->size, k_msg_buffer_size_max), (u32)window),
+        .cpu_id = bpf_get_smp_processor_id(),
+    };
+
+    const u16 copy_bytes = min(max(msg_buf.real_size, k_kprobes_http2_buf_size), window);
+
+    bpf_probe_read_kernel(msg_buf.fallback_buf, min(window, k_kprobes_http2_buf_size), msg->data);
 
     unsigned char **msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
 

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -5,6 +5,7 @@
 #include <bpfcore/bpf_builtins.h>
 #include <bpfcore/bpf_helpers.h>
 #include <bpfcore/bpf_endian.h>
+#include <bpfcore/utils.h>
 
 #include <common/algorithm.h>
 #include <common/connection_info.h>
@@ -679,21 +680,23 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
         return false;
     }
 
-    // A failed bpf_msg_pull_data() can leave msg->data/data_end short of msg->size.
-    // Every read below is bounded by this mapped window instead of msg->size alone,
-    // so a short message never pulls in whatever kernel memory follows it.
-    const u32 mapped = (unsigned char *)msg->data_end - (unsigned char *)msg->data;
-    const u16 window = min(mapped, (u32)k_msg_buffer_size_max);
+    // The mapped [data, data_end) window is always a sub-range of the message, so
+    // bounding every read by it is sufficient on its own — msg->size can't add
+    // information a failed bpf_msg_pull_data() has already invalidated.
+    u32 window = (unsigned char *)msg->data_end - (unsigned char *)msg->data;
+    bpf_clamp_umax(window, k_msg_buffer_size_max);
 
     msg_buffer_t msg_buf = {
         .pos = 0,
-        .real_size = min(min(msg->size, k_msg_buffer_size_max), (u32)window),
+        .real_size = window,
         .cpu_id = bpf_get_smp_processor_id(),
     };
 
-    const u16 copy_bytes = min(max(msg_buf.real_size, k_kprobes_http2_buf_size), window);
-
-    bpf_probe_read_kernel(msg_buf.fallback_buf, min(window, k_kprobes_http2_buf_size), msg->data);
+    // fallback_buf is a fixed k_kprobes_http2_buf_size array, smaller than window's
+    // ceiling, so it needs its own, tighter clamp.
+    u32 fallback_bytes = window;
+    bpf_clamp_umax(fallback_bytes, k_kprobes_http2_buf_size);
+    bpf_probe_read_kernel(msg_buf.fallback_buf, fallback_bytes, msg->data);
 
     unsigned char **msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
 
@@ -703,7 +706,7 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
     }
 
     msg_ptr[0] = 0;
-    bpf_probe_read_kernel(msg_ptr, copy_bytes & k_msg_buffer_size_max_mask, msg->data);
+    bpf_probe_read_kernel(msg_ptr, window, msg->data);
     bpf_map_update_elem(&msg_buffer_mem, &(u32){0}, msg_ptr, BPF_ANY);
 
     // We setup any call that looks like HTTP request to be extended.


### PR DESCRIPTION
Found this while going through the sk_msg path , `fill_msg_buffers()` just assumes the earlier `bpf_msg_pull_data()` pull actually worked, but nothing checks it. If it fails, `msg->data`/`data_end` stay narrow, and the function still blindly copies up to 8KB from `msg->data`, so it can pull in random adjacent kernel memory instead of the actual message. That memory can end up going out as span data.

Fixed it by bounding every read to the actual mapped `[data, data_end)` window instead of trusting `msg->size`. That window is always a sub-range of the message, so it's sufficient on its own ,no separate bounds check needed. Used `bpf_clamp_umax` (not `min()`) since a plain C compare loses its tracked bound across a register copy on older verifiers (kernel 5.8 rejected the first version of this fix). Along the way this also fixed a real pre-existing bug: a `& (k_msg_buffer_size_max - 1)` mask on the copy size masked exactly-8192-byte sends down to a 0-byte copy, so the kprobe would read stale bytes from a previous message.

Kept it inside `fill_msg_buffers()` itself since all three call sites go through it, so nothing else needed changing  and there's already a fallback path on the kprobe side for when this buffer isn't populated, so bailing here doesn't break anything.

Fixes #3278.
