### PR TITLE
Fix HTTP/2 and gRPC spans losing their peer by falling back to :authority

### DIFF
--- a/pkg/ebpf/common/http2grpc_transform.go
+++ b/pkg/ebpf/common/http2grpc_transform.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"net"
 	"regexp"
 	"strconv"
 	"strings"
@@ -88,6 +89,7 @@ type h2RequestMeta struct {
 	method   string
 	path     string
 	fullPath string
+	host     string
 	grpc     bool
 }
 
@@ -273,7 +275,7 @@ func hpackOpensResponse(frag []byte) bool {
 	return b&formMask != formMask
 }
 
-func readMetaFrame(parseContext *EBPFParseContext, connID uint64, fr *http2.Framer, hf *http2.HeadersFrame) (string, string, string, bool, bool) {
+func readMetaFrame(parseContext *EBPFParseContext, connID uint64, fr *http2.Framer, hf *http2.HeadersFrame) (string, string, string, string, bool, bool) {
 	h2c := getOrInitH2Conn(parseContext.h2c, connID)
 
 	ok := false
@@ -281,9 +283,10 @@ func readMetaFrame(parseContext *EBPFParseContext, connID uint64, fr *http2.Fram
 	method := ""
 	path := ""
 	contentType := ""
+	authority := ""
 
 	if h2c == nil {
-		return method, path, contentType, ok, isResponse
+		return method, path, contentType, authority, ok, isResponse
 	}
 
 	h2c.hdec.SetEmitFunc(func(hf bhpack.HeaderField) {
@@ -293,6 +296,9 @@ func readMetaFrame(parseContext *EBPFParseContext, connID uint64, fr *http2.Fram
 			ok = true
 		case ":path":
 			path = hf.Value
+			ok = true
+		case ":authority":
+			authority = hf.Value
 			ok = true
 		case ":status":
 			// only responses carry :status — this HEADERS was misread as a request start
@@ -314,12 +320,12 @@ func readMetaFrame(parseContext *EBPFParseContext, connID uint64, fr *http2.Fram
 	// HPACK state is per direction. Decoding a response block with the request decoder
 	// desyncs its dynamic table against the peer's, so every later index resolves wrong.
 	if hpackOpensResponse(frag) {
-		return method, path, contentType, ok, true
+		return method, path, contentType, authority, ok, true
 	}
 
 	for {
 		if _, err := h2c.hdec.Write(frag); err != nil {
-			return method, path, contentType, ok, isResponse
+			return method, path, contentType, authority, ok, isResponse
 		}
 		if hf.HeadersEnded() {
 			break
@@ -335,7 +341,7 @@ func readMetaFrame(parseContext *EBPFParseContext, connID uint64, fr *http2.Fram
 		frag = cf.HeaderBlockFragment()
 	}
 
-	return method, path, contentType, ok, isResponse
+	return method, path, contentType, authority, ok, isResponse
 }
 
 func http2grpcStatus(status int) int {
@@ -417,6 +423,16 @@ func readRetMetaFrame(parseContext *EBPFParseContext, connID uint64, fr *http2.F
 	}
 
 	return status, grpc, ok
+}
+
+// authorityHost strips the port from an :authority pseudo-header, mirroring how the
+// HTTP/1.x Host: header is handled. :authority usually omits the port, so this
+// recovers the address alone.
+func authorityHost(authority string) string {
+	if host, _, err := net.SplitHostPort(authority); err == nil {
+		return host
+	}
+	return authority
 }
 
 func http2InfoToSpan(info *BPFHTTP2Info, method, path, fullPath, peer, host string, status int, protocol Protocol) request.Span {
@@ -592,7 +608,7 @@ func http2EventToSpan(parseContext *EBPFParseContext, pending *pendingH2Event) (
 		}
 
 		if ff, ok := f.(*http2.HeadersFrame); ok {
-			method, path, contentType, ok, isResponse := readMetaFrame(parseContext, connID, framer, ff)
+			method, path, contentType, authority, ok, isResponse := readMetaFrame(parseContext, connID, framer, ff)
 			if isResponse {
 				return request.Span{}, true, nil // response HEADERS misread as a request start
 			}
@@ -621,6 +637,8 @@ func http2EventToSpan(parseContext *EBPFParseContext, pending *pendingH2Event) (
 				source, target := (*BPFConnInfo)(unsafe.Pointer(&event.ConnInfo)).reqHostInfo()
 				host = target
 				peer = source
+			} else {
+				host = authorityHost(authority)
 			}
 
 			return http2InfoToSpan(event, method, path, fullPath, peer, host, status, eventType), false, nil
@@ -705,6 +723,7 @@ func readHTTP2HeaderEvent(parseContext *EBPFParseContext, event *BPFHTTP2Info) e
 				method:   span.Method,
 				path:     span.Path,
 				fullPath: span.FullPath,
+				host:     span.Host,
 				grpc:     h2SpanIsGRPC(span),
 			}
 			stream.requestOK = true
@@ -785,6 +804,8 @@ func http2FromBuffers(parseContext *EBPFParseContext, event *BPFHTTP2Info) (requ
 		source, target := (*BPFConnInfo)(unsafe.Pointer(&event.ConnInfo)).reqHostInfo()
 		host = target
 		peer = source
+	} else {
+		host = cached.host
 	}
 	span := http2InfoToSpan(
 		event, cached.method, cached.path, cached.fullPath, peer, host, status, protocol,

--- a/pkg/ebpf/common/http2grpc_transform.go
+++ b/pkg/ebpf/common/http2grpc_transform.go
@@ -90,6 +90,7 @@ type h2RequestMeta struct {
 	path     string
 	fullPath string
 	host     string
+	hostPort int
 	grpc     bool
 }
 
@@ -425,17 +426,19 @@ func readRetMetaFrame(parseContext *EBPFParseContext, connID uint64, fr *http2.F
 	return status, grpc, ok
 }
 
-// authorityHost strips the port from an :authority pseudo-header, mirroring how the
-// HTTP/1.x Host: header is handled. :authority usually omits the port, so this
-// recovers the address alone.
-func authorityHost(authority string) string {
-	if host, _, err := net.SplitHostPort(authority); err == nil {
-		return host
+// splitAuthority parses host and, when present, port out of an :authority
+// pseudo-header, mirroring how the HTTP/1.x Host: header is handled. Unlike
+// Host:, gRPC clients (e.g. grpc-go) typically set :authority to host:port.
+func splitAuthority(authority string) (host string, port int) {
+	h, p, err := net.SplitHostPort(authority)
+	if err != nil {
+		return authority, 0
 	}
-	return authority
+	port, _ = strconv.Atoi(p)
+	return h, port
 }
 
-func http2InfoToSpan(info *BPFHTTP2Info, method, path, fullPath, peer, host string, status int, protocol Protocol) request.Span {
+func http2InfoToSpan(info *BPFHTTP2Info, method, path, fullPath, peer, host string, hostPort int, status int, protocol Protocol) request.Span {
 	return request.Span{
 		Type:              info.eventType(protocol),
 		ProtoVersion:      request.ProtoVersionHTTP2,
@@ -445,7 +448,7 @@ func http2InfoToSpan(info *BPFHTTP2Info, method, path, fullPath, peer, host stri
 		Peer:              peer,
 		PeerPort:          int(info.ConnInfo.S_port),
 		Host:              host,
-		HostPort:          int(info.ConnInfo.D_port),
+		HostPort:          hostPort,
 		ContentLength:     int64(info.Len),
 		RequestStart:      int64(info.StartMonotimeNs),
 		Start:             int64(info.StartMonotimeNs),
@@ -633,15 +636,16 @@ func http2EventToSpan(parseContext *EBPFParseContext, pending *pendingH2Event) (
 
 			peer := ""
 			host := ""
+			hostPort := int(event.ConnInfo.D_port)
 			if event.ConnInfo.S_port != 0 || event.ConnInfo.D_port != 0 {
 				source, target := (*BPFConnInfo)(unsafe.Pointer(&event.ConnInfo)).reqHostInfo()
 				host = target
 				peer = source
 			} else {
-				host = authorityHost(authority)
+				host, hostPort = splitAuthority(authority)
 			}
 
-			return http2InfoToSpan(event, method, path, fullPath, peer, host, status, eventType), false, nil
+			return http2InfoToSpan(event, method, path, fullPath, peer, host, hostPort, status, eventType), false, nil
 		}
 	}
 
@@ -724,6 +728,7 @@ func readHTTP2HeaderEvent(parseContext *EBPFParseContext, event *BPFHTTP2Info) e
 				path:     span.Path,
 				fullPath: span.FullPath,
 				host:     span.Host,
+				hostPort: span.HostPort,
 				grpc:     h2SpanIsGRPC(span),
 			}
 			stream.requestOK = true
@@ -800,15 +805,17 @@ func http2FromBuffers(parseContext *EBPFParseContext, event *BPFHTTP2Info) (requ
 
 	peer := ""
 	host := ""
+	hostPort := int(event.ConnInfo.D_port)
 	if event.ConnInfo.S_port != 0 || event.ConnInfo.D_port != 0 {
 		source, target := (*BPFConnInfo)(unsafe.Pointer(&event.ConnInfo)).reqHostInfo()
 		host = target
 		peer = source
 	} else {
 		host = cached.host
+		hostPort = cached.hostPort
 	}
 	span := http2InfoToSpan(
-		event, cached.method, cached.path, cached.fullPath, peer, host, status, protocol,
+		event, cached.method, cached.path, cached.fullPath, peer, host, hostPort, status, protocol,
 	)
 	return span, false, nil
 }

--- a/pkg/ebpf/common/http2grpc_transform_test.go
+++ b/pkg/ebpf/common/http2grpc_transform_test.go
@@ -26,7 +26,7 @@ import (
 func TestHTTP2InfoToSpanSetsFullPath(t *testing.T) {
 	var info BPFHTTP2Info
 	info.Type = uint8(request.EventTypeHTTP)
-	span := http2InfoToSpan(&info, "GET", "/users", "/users?x=1", "peer", "host", 200, HTTP2)
+	span := http2InfoToSpan(&info, "GET", "/users", "/users?x=1", "peer", "host", 8080, 200, HTTP2)
 	assert.Equal(t, "/users", span.Path)
 	assert.Equal(t, "/users?x=1", span.FullPath)
 }
@@ -1046,8 +1046,9 @@ func TestSequentialRequestsKeepResolvingMethods(t *testing.T) {
 }
 
 // When the connection tuple can't be resolved (both ports zero), the span should still
-// get a peer address by recovering it from the :authority pseudo-header, the HTTP/2
-// equivalent of the HTTP/1.x Host: header fallback.
+// get a peer address and port by recovering them from the :authority pseudo-header, the
+// HTTP/2 equivalent of the HTTP/1.x Host: header fallback. Unlike Host:, gRPC clients
+// (e.g. grpc-go) typically set :authority to host:port, so the port is recovered too.
 func TestUnresolvedConnFallsBackToAuthority(t *testing.T) {
 	parseContext := NewEBPFParseContext(nil, nil, nil)
 	enc := &h2ConnEncoder{}
@@ -1060,6 +1061,7 @@ func TestUnresolvedConnFallsBackToAuthority(t *testing.T) {
 	observeH2Headers(t, parseContext, event, EventTypeKHTTP2RequestHeaders)
 	span := completeH2(t, parseContext, event)
 	require.Equal(t, "ipservice.ipservice.svc.cluster.local", span.Host)
+	require.Equal(t, 9090, span.HostPort)
 }
 
 func TestCoalescedDataDoesNotPoisonHeaderState(t *testing.T) {

--- a/pkg/ebpf/common/http2grpc_transform_test.go
+++ b/pkg/ebpf/common/http2grpc_transform_test.go
@@ -201,7 +201,7 @@ func TestHTTP2Parsing(t *testing.T) {
 				}
 
 				if ff, ok := f.(*http2.HeadersFrame); ok {
-					method, path, contentType, _, _ := readMetaFrame(parseContext, 0, framer, ff)
+					method, path, contentType, _, _, _ := readMetaFrame(parseContext, 0, framer, ff)
 					assert.Equal(t, tt.method, method)
 					assert.Equal(t, tt.path, path)
 					assert.Equal(t, tt.contentType, contentType)
@@ -238,7 +238,7 @@ func TestHTTP2ResponseDetection(t *testing.T) {
 	parseContext := NewEBPFParseContext(nil, nil, nil)
 	framer := byteFramer(nil)
 
-	_, _, _, _, isResponse := readMetaFrame(parseContext, 1, framer, headersFrame(t, payload))
+	_, _, _, _, _, isResponse := readMetaFrame(parseContext, 1, framer, headersFrame(t, payload))
 	assert.True(t, isResponse, "HEADERS opening with :status must be flagged as a response")
 }
 
@@ -280,25 +280,25 @@ func TestHTTP2ResponseDoesNotPolluteRequestTable(t *testing.T) {
 
 			// peer inserts (:path, /p1)
 			first := append([]byte{0x82}, indexedNameField(pathStaticIdx, "/p1")...)
-			_, path, _, _, isResponse := readMetaFrame(parseContext, 1, framer, headersFrame(t, first))
+			_, path, _, _, _, isResponse := readMetaFrame(parseContext, 1, framer, headersFrame(t, first))
 			require.False(t, isResponse)
 			require.Equal(t, "/p1", path)
 
 			// a response lands on the same connection, inserting (:path, /bad) if it is decoded here
 			resp := append(append([]byte{}, tc.opener...), indexedNameField(pathStaticIdx, "/bad")...)
-			_, _, _, _, isResponse = readMetaFrame(parseContext, 1, framer, headersFrame(t, resp))
+			_, _, _, _, _, isResponse = readMetaFrame(parseContext, 1, framer, headersFrame(t, resp))
 			require.True(t, isResponse)
 
 			// peer inserts (:path, /p2), so its own table holds /p2 at 62 and /p1 at 63
 			second := append([]byte{0x82}, indexedNameField(pathStaticIdx, "/p2")...)
-			_, path, _, _, _ = readMetaFrame(parseContext, 1, framer, headersFrame(t, second))
+			_, path, _, _, _, _ = readMetaFrame(parseContext, 1, framer, headersFrame(t, second))
 			require.Equal(t, "/p2", path)
 
-			_, path, _, _, _ = readMetaFrame(parseContext, 1, framer,
+			_, path, _, _, _, _ = readMetaFrame(parseContext, 1, framer,
 				headersFrame(t, []byte{0x82, mostRecentIdx}))
 			assert.Equal(t, "/p2", path, "entry 62 must be the peer's most recent insertion")
 
-			_, path, _, _, _ = readMetaFrame(parseContext, 1, framer,
+			_, path, _, _, _, _ = readMetaFrame(parseContext, 1, framer,
 				headersFrame(t, []byte{0x82, secondIdx}))
 			assert.Equal(t, "/p1", path, "entry 63 must be the peer's previous insertion, not the response")
 		})
@@ -1043,6 +1043,23 @@ func TestSequentialRequestsKeepResolvingMethods(t *testing.T) {
 	observeH2Headers(t, parseContext, third, EventTypeKHTTP2RequestHeaders)
 	span = completeH2(t, parseContext, third)
 	require.Equal(t, pathB, span.Path)
+}
+
+// When the connection tuple can't be resolved (both ports zero), the span should still
+// get a peer address by recovering it from the :authority pseudo-header, the HTTP/2
+// equivalent of the HTTP/1.x Host: header fallback.
+func TestUnresolvedConnFallsBackToAuthority(t *testing.T) {
+	parseContext := NewEBPFParseContext(nil, nil, nil)
+	enc := &h2ConnEncoder{}
+	enc.enc = hpack.NewEncoder(&enc.buf)
+
+	event := h2Event(enc.frame(t, requestFields(pathA, "00-001f6ca4dd49f899e999ea3a7c0f1dab-9e5179d7828a4f85-01")), nil, 810, 1)
+	event.ConnInfo.S_port = 0
+	event.ConnInfo.D_port = 0
+
+	observeH2Headers(t, parseContext, event, EventTypeKHTTP2RequestHeaders)
+	span := completeH2(t, parseContext, event)
+	require.Equal(t, "ipservice.ipservice.svc.cluster.local", span.Host)
 }
 
 func TestCoalescedDataDoesNotPoisonHeaderState(t *testing.T) {


### PR DESCRIPTION
HTTP/1.x already falls back to the `Host:` header when the connection tuple can't be resolved, so client spans still get a peer. HTTP/2 has the same info sitting right there in the `:authority` pseudo-header, but nothing was reading it — so gRPC and HTTP/2 spans just went out with an empty peer whenever the connection was unresolved.

Added `:authority` extraction alongside the existing `:method`/`:path`/`content-type` parsing, and use it as the host fallback the same way `Host:` is used for HTTP/1.x (address only, since `:authority` usually omits the port anyway). Had to thread it through the per-stream cache too, since the header gets parsed once at capture time but the span only gets built later at stream completion.

Fixes #3283.
