### PR TITLE
ci: run k8s integration tests on arm

### DIFF
--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -64,20 +64,26 @@ jobs:
       - name: Build test matrix
         id: build-matrix
         run: |
-          echo -n "matrix=" >> $GITHUB_OUTPUT
-          make k8s-integration-test-matrix-json >> $GITHUB_OUTPUT
+          echo -n "matrix=" >> "$GITHUB_OUTPUT"
+          make k8s-integration-test-matrix-json >> "$GITHUB_OUTPUT"
 
   test:
-    name: ${{ matrix.basename }}
+    name: ${{ matrix.shard.basename }} (${{ matrix.platform.arch }})
     needs: [test-matrix, generate-bpf]
     permissions:
       checks: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+        shard: ${{ fromJson(needs.test-matrix.outputs.matrix).include }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -131,9 +137,9 @@ jobs:
 
       - name: Run integration tests
         env:
-          MATRIX_ID: ${{ matrix.id }}
+          MATRIX_ID: ${{ matrix.shard.id }}
           MATRIX_JSON: ${{ toJson(matrix) }}
-          MATRIX_TEST_PATTERN: ${{ matrix.test_pattern }}
+          MATRIX_TEST_PATTERN: ${{ matrix.shard.test_pattern }}
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           echo Partition
@@ -163,13 +169,13 @@ jobs:
         with:
           files: ./testoutput/itest-covdata.txt
           flags: k8s-integration-test
-          name: integration-k8s-coverage-${{ matrix.basename }}-${{ github.run_number }}
+          name: integration-k8s-coverage-${{ matrix.shard.basename }}-${{ matrix.platform.arch }}-${{ github.run_number }}
 
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: integration-k8s-reports-${{ matrix.basename }}-${{ github.run_number }}
+          name: integration-k8s-reports-${{ matrix.shard.basename }}-${{ matrix.platform.arch }}-${{ github.run_number }}
           path: /home/runner/reports/*.log
           retention-days: 5
 
@@ -177,7 +183,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: integration-k8s-logs-${{ matrix.basename }}-${{ github.run_number }}
+          name: integration-k8s-logs-${{ matrix.shard.basename }}-${{ matrix.platform.arch }}-${{ github.run_number }}
           path: |
             testoutput/*.log
             testoutput/kind

--- a/internal/test/integration/k8s/common/k8s_common.go
+++ b/internal/test/integration/k8s/common/k8s_common.go
@@ -10,12 +10,10 @@ import (
 )
 
 var (
-	DockerfileTestServer       = path.Join(testpath.Components, "testserver", "Dockerfile")
 	DockerfileOBI              = path.Join(testpath.Components, "obi", "Dockerfile")
 	DockerfileK8sCache         = path.Join(testpath.Components, "ebpf-instrument-k8s-cache", "Dockerfile")
 	DockerfilePinger           = path.Join(testpath.Components, "grpcpinger", "Dockerfile")
 	DockerfilePythonTestServer = path.Join(testpath.Components, "pythonserver", "Dockerfile_7773")
-	DockerfileHTTPPinger       = path.Join(testpath.Components, "httppinger", "Dockerfile")
 
 	PingerManifest               = path.Join(testpath.Manifests, "/06-instrumented-client.template.yml")
 	GrpcPingerManifest           = path.Join(testpath.Manifests, "/06-instrumented-grpc-client.template.yml")

--- a/internal/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
+++ b/internal/test/integration/k8s/daemonset/k8s_daemonset_main_test.go
@@ -35,7 +35,6 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "grpcpinger:dev", Dockerfile: k8s.DockerfilePinger},
 	); err != nil {
@@ -45,7 +44,6 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-daemonset",
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("grpcpinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),

--- a/internal/test/integration/k8s/daemonset_multi_node/k8s_daemonset_multi_node_main_test.go
+++ b/internal/test/integration/k8s/daemonset_multi_node/k8s_daemonset_multi_node_main_test.go
@@ -34,7 +34,6 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "pythontestserver:dev", Dockerfile: k8s.DockerfilePythonTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 	); err != nil {
@@ -44,7 +43,6 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-otel-multi",
 		kube.KindConfig(testpath.Manifests+"/00-kind-multi-node.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("pythontestserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),

--- a/internal/test/integration/k8s/disable_informers/k8s_disable_informers_test.go
+++ b/internal/test/integration/k8s/disable_informers/k8s_disable_informers_test.go
@@ -27,9 +27,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -37,9 +35,7 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-daemonset",
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
-		kube.LocalImage("httppinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),

--- a/internal/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
+++ b/internal/test/integration/k8s/informer_cache/k8s_informer_cache_main_test.go
@@ -37,8 +37,6 @@ func TestMain(m *testing.M) {
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
-		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 		docker.ImageBuild{Tag: "obi-k8s-cache:dev", Dockerfile: k8s.DockerfileK8sCache},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
@@ -48,8 +46,6 @@ func TestMain(m *testing.M) {
 	cluster = kube.NewKind("test-kind-cluster-external-cache",
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
 		kube.LocalImage("obi:dev"),
-		kube.LocalImage("testserver:dev"),
-		kube.LocalImage("httppinger:dev"),
 		kube.LocalImage("obi-k8s-cache:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),

--- a/internal/test/integration/k8s/manifests/05-hostpid-daemonset.yml
+++ b/internal/test/integration/k8s/manifests/05-hostpid-daemonset.yml
@@ -32,8 +32,8 @@ spec:
       hostPID: true
       containers:
         - name: hostpid-httpserver
-          image: testserver:dev
-          imagePullPolicy: Never # loaded into Kind from localhost
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8082
               hostPort: 8082

--- a/internal/test/integration/k8s/manifests/05-instrumented-service-otel.yml
+++ b/internal/test/integration/k8s/manifests/05-instrumented-service-otel.yml
@@ -52,8 +52,8 @@ spec:
             claimName: testoutput
       containers:
         - name: testserver
-          image: testserver:dev
-          imagePullPolicy: Never # loaded into Kind from localhost
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+          imagePullPolicy: IfNotPresent
           ports:
             # exposing hostports to enable operation from tests
             - containerPort: 8080

--- a/internal/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
+++ b/internal/test/integration/k8s/manifests/05-instrumented-service-prometheus.yml
@@ -65,8 +65,8 @@ spec:
             claimName: testoutput
       containers:
         - name: testserver
-          image: testserver:dev
-          imagePullPolicy: Never # loaded into Kind from localhost
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+          imagePullPolicy: IfNotPresent
           ports:
             # exposing hostports to enable operation from tests
             - containerPort: 8080

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-cronjob.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-cronjob.yml
@@ -33,8 +33,8 @@ spec:
           restartPolicy: Never
           containers:
             - name: cronjobservice
-              image: testserver:dev
-              imagePullPolicy: Never # loaded into Kind from localhost
+              image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+              imagePullPolicy: IfNotPresent
               ports:
                 - containerPort: 8083
                   hostPort: 8083

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-daemonset.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-daemonset.yml
@@ -31,8 +31,8 @@ spec:
     spec:
       containers:
         - name: dsservice
-          image: testserver:dev
-          imagePullPolicy: Never # loaded into Kind from localhost
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8081
               hostPort: 8081

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-few-services.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-few-services.yml
@@ -109,8 +109,8 @@ spec:
                   - go-progs
       containers:
         - name: testserver
-          image: testserver:dev
-          imagePullPolicy: Never # loaded into Kind from localhost
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
               hostPort: 8080
@@ -150,7 +150,7 @@ spec:
                   - other-progs
       containers:
         - name: utestserver
-          image: 'ghcr.io/open-telemetry/obi-testimg:rails-0.1.0'
+          image: ghcr.io/open-telemetry/obi-testimg:rails-0.1.2@sha256:ea4b000400f06ba09e7e0e5cbaa09c04da8417024ecc163ef942f657b5ef4266
           imagePullPolicy: IfNotPresent
           ports:          
           - containerPort: 3040

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-job.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-job.yml
@@ -29,8 +29,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: jobservice
-          image: testserver:dev
-          imagePullPolicy: Never # loaded into Kind from localhost
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8082
               hostPort: 8082

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-multizone-client-server.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-multizone-client-server.yml
@@ -27,7 +27,7 @@ spec:
                   - client-zone
   containers:
     - name: httppinger
-      image: httppinger:dev
+      image: ghcr.io/open-telemetry/obi-testimg:go-http-client-0.1.2@sha256:e2f600e5cb7fadfb7d7be7b17fe29eee89ebe8f63e15a05ccbf943edf5044a25
       env:
         - name: TARGET_URL
           value: "http://testserver:8080"
@@ -79,8 +79,8 @@ spec:
                       - server-zone
       containers:
         - name: testserver
-          image: testserver:dev
-          imagePullPolicy: Never # loaded into Kind from localhost
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+          imagePullPolicy: IfNotPresent
           ports:
             # exposing hostports to enable operation from tests
             - containerPort: 8080

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-server-client-different-nodes.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-server-client-different-nodes.yml
@@ -31,8 +31,8 @@ spec:
 
   containers:
     - name: httppinger
-      image: ghcr.io/open-telemetry/obi-testimg:httppinger-net
-      imagePullPolicy: IfNotPresent       
+      image: ghcr.io/open-telemetry/obi-testimg:go-http-client-0.1.2@sha256:e2f600e5cb7fadfb7d7be7b17fe29eee89ebe8f63e15a05ccbf943edf5044a25
+      imagePullPolicy: IfNotPresent
       env:
         - name: TARGET_URL
           value: "http://otherinstance:8080"
@@ -89,8 +89,8 @@ spec:
             claimName: testoutput
       containers:
         - name: otherinstance
-          image: ghcr.io/open-telemetry/obi-testimg:gotestserver-net
-          imagePullPolicy: IfNotPresent 
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+          imagePullPolicy: IfNotPresent
           ports:
             # exposing hostports to enable operation from tests
             - containerPort: 8080

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-service.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-service.yml
@@ -52,8 +52,8 @@ spec:
     spec:
       containers:
         - name: testserver
-          image: testserver:dev
-          imagePullPolicy: Never # loaded into Kind from localhost
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
               hostPort: 8080
@@ -88,8 +88,8 @@ spec:
     spec:
       containers:
         - name: otherinstance
-          image: testserver:dev
-          imagePullPolicy: Never # loaded into Kind from localhost
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8081
               hostPort: 8081

--- a/internal/test/integration/k8s/manifests/05-uninstrumented-statefulset.yml
+++ b/internal/test/integration/k8s/manifests/05-uninstrumented-statefulset.yml
@@ -32,8 +32,8 @@ spec:
     spec:
       containers:
         - name: statefulservice
-          image: testserver:dev
-          imagePullPolicy: Never # loaded into Kind from localhost
+          image: ghcr.io/open-telemetry/obi-testimg:go-0.1.2@sha256:b3e65ac053586943bcfbba0af32a0ec1cfb3fa64add67f92a742d8431835be39
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
               hostPort: 8080

--- a/internal/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
+++ b/internal/test/integration/k8s/manifests/06-instrumented-client-prom.template.yml
@@ -37,7 +37,7 @@ spec:
 
   containers:
     - name: pinger
-      image: httppinger:dev
+      image: ghcr.io/open-telemetry/obi-testimg:go-http-client-0.1.2@sha256:e2f600e5cb7fadfb7d7be7b17fe29eee89ebe8f63e15a05ccbf943edf5044a25
       env:
         - name: TARGET_URL
           value: "{{.TargetURL}}"

--- a/internal/test/integration/k8s/manifests/06-instrumented-client.template.yml
+++ b/internal/test/integration/k8s/manifests/06-instrumented-client.template.yml
@@ -37,7 +37,7 @@ spec:
 
   containers:
     - name: pinger
-      image: httppinger:dev
+      image: ghcr.io/open-telemetry/obi-testimg:go-http-client-0.1.2@sha256:e2f600e5cb7fadfb7d7be7b17fe29eee89ebe8f63e15a05ccbf943edf5044a25
       env:
         - name: TARGET_URL
           value: "{{.TargetURL}}"

--- a/internal/test/integration/k8s/manifests/06-uninstrumented-client.template.yml
+++ b/internal/test/integration/k8s/manifests/06-uninstrumented-client.template.yml
@@ -18,7 +18,7 @@ spec:
 
   containers:
     - name: pinger
-      image: httppinger:dev
+      image: ghcr.io/open-telemetry/obi-testimg:go-http-client-0.1.2@sha256:e2f600e5cb7fadfb7d7be7b17fe29eee89ebe8f63e15a05ccbf943edf5044a25
       env:
         - name: TARGET_URL
           value: "{{.TargetURL}}"

--- a/internal/test/integration/k8s/netolly/k8s_netolly_main_test.go
+++ b/internal/test/integration/k8s/netolly/k8s_netolly_main_test.go
@@ -27,9 +27,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -37,9 +35,7 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-netolly",
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
-		kube.LocalImage("httppinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),

--- a/internal/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
+++ b/internal/test/integration/k8s/netolly_dropexternal/k8s_netolly_dropexternal_test.go
@@ -40,9 +40,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -50,9 +48,7 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-netolly-dropexternal",
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
-		kube.LocalImage("httppinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),

--- a/internal/test/integration/k8s/netolly_multizone/k8s_netolly_multizone_main_test.go
+++ b/internal/test/integration/k8s/netolly_multizone/k8s_netolly_multizone_main_test.go
@@ -27,9 +27,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -37,9 +35,7 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-netolly-multizone",
 		kube.KindConfig(testpath.Manifests+"/00-kind-multi-zone.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
-		kube.LocalImage("httppinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape-multi-node.yml"),

--- a/internal/test/integration/k8s/netolly_multizone_prom/k8s_netolly_multizone_prom_main_test.go
+++ b/internal/test/integration/k8s/netolly_multizone_prom/k8s_netolly_multizone_prom_main_test.go
@@ -28,9 +28,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -38,9 +36,7 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-netolly-multizone-prom",
 		kube.KindConfig(testpath.Manifests+"/00-kind-multi-zone.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
-		kube.LocalImage("httppinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape-multizone.yml"),

--- a/internal/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
+++ b/internal/test/integration/k8s/netolly_promexport/k8s_netolly_prom_main_test.go
@@ -28,9 +28,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -38,9 +36,7 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-netolly-promexport",
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
-		kube.LocalImage("httppinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),

--- a/internal/test/integration/k8s/netolly_tc_promexport/k8s_netolly_prom_main_test.go
+++ b/internal/test/integration/k8s/netolly_tc_promexport/k8s_netolly_prom_main_test.go
@@ -28,9 +28,7 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
-		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -38,9 +36,7 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-netolly-sk-promexport",
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
-		kube.LocalImage("httppinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),

--- a/internal/test/integration/k8s/otel/k8s_main_test.go
+++ b/internal/test/integration/k8s/otel/k8s_main_test.go
@@ -36,10 +36,8 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "grpcpinger:dev", Dockerfile: k8s.DockerfilePinger},
-		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -47,10 +45,8 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-otel",
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("grpcpinger:dev"),
-		kube.LocalImage("httppinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),

--- a/internal/test/integration/k8s/owners/k8s_owners_main_test.go
+++ b/internal/test/integration/k8s/owners/k8s_owners_main_test.go
@@ -36,7 +36,6 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "grpcpinger:dev", Dockerfile: k8s.DockerfilePinger},
 	); err != nil {
@@ -46,7 +45,6 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-owners",
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("grpcpinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),

--- a/internal/test/integration/k8s/prom/k8s_prom_main_test.go
+++ b/internal/test/integration/k8s/prom/k8s_prom_main_test.go
@@ -29,10 +29,8 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 		docker.ImageBuild{Tag: "grpcpinger:dev", Dockerfile: k8s.DockerfilePinger},
-		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
 		os.Exit(-1)
@@ -40,10 +38,8 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-prom",
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.LocalImage("grpcpinger:dev"),
-		kube.LocalImage("httppinger:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
 		kube.Deploy(testpath.Manifests+"/02-prometheus-promscrape.yml"),

--- a/internal/test/integration/k8s/sharedpidns/k8s_sharedpidns_main_test.go
+++ b/internal/test/integration/k8s/sharedpidns/k8s_sharedpidns_main_test.go
@@ -37,7 +37,6 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := docker.Build(os.Stdout, tools.ProjectDir(),
-		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
 		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
 	); err != nil {
 		slog.Error("can't build docker images", "error", err)
@@ -46,7 +45,6 @@ func TestMain(m *testing.M) {
 
 	cluster = kube.NewKind("test-kind-cluster-sharedpidns",
 		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
-		kube.LocalImage("testserver:dev"),
 		kube.LocalImage("obi:dev"),
 		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
 		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),


### PR DESCRIPTION
## Summary

Part of:

- #2849

This PR adds arm runners to the k8s tests.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
