### PR TITLE
ci: run OATS tests on arm

### DIFF
--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -64,20 +64,26 @@ jobs:
       - name: Build test matrix
         id: build-matrix
         run: |
-          echo -n "matrix=" >> $GITHUB_OUTPUT
-          make oats-integration-test-matrix-json >> $GITHUB_OUTPUT
+          echo -n "matrix=" >> "$GITHUB_OUTPUT"
+          make oats-integration-test-matrix-json >> "$GITHUB_OUTPUT"
 
   test:
-    name: ${{ matrix.basename }}
+    name: ${{ matrix.shard.basename }} (${{ matrix.platform.arch }})
     needs: [test-matrix, generate-bpf]
     permissions:
       checks: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+        shard: ${{ fromJson(needs.test-matrix.outputs.matrix).include }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -131,7 +137,7 @@ jobs:
 
       - name: Run oats tests
         env:
-          MATRIX_BASENAME: ${{ matrix.basename }}
+          MATRIX_BASENAME: ${{ matrix.shard.basename }}
           TESTCASE_TIMEOUT: 5m
         run: make "oats-test-$MATRIX_BASENAME"
 
@@ -139,8 +145,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: oats-logs-${{ matrix.basename }}-${{ github.run_number }}
-          path: internal/test/oats/${{ matrix.basename }}/build/*
+          name: oats-logs-${{ matrix.shard.basename }}-${{ matrix.platform.arch }}-${{ github.run_number }}
+          path: internal/test/oats/${{ matrix.shard.basename }}/build/*
 
       - name: Process coverage data
         run: make itest-coverage-data
@@ -152,4 +158,4 @@ jobs:
         with:
           files: ./testoutput/itest-covdata.txt
           flags: oats-test
-          name: oats-coverage-${{ matrix.basename }}-${{ github.run_number }}
+          name: oats-coverage-${{ matrix.shard.basename }}-${{ matrix.platform.arch }}-${{ github.run_number }}

--- a/internal/test/oats/http/docker-compose-java-tls-jdk8.yml
+++ b/internal/test/oats/http/docker-compose-java-tls-jdk8.yml
@@ -7,7 +7,13 @@ services:
     ports:
       - "8080:8080"
   testserver:
-    image: ghcr.io/open-telemetry/obi-testimg:java-tls-0.0.1-jdk8@sha256:9381c0321f0e86f04bff1d921000a08c24837a880f7b2f80ad444046a667dd92
+    build:
+      context: ../../../..
+      dockerfile: ./internal/test/integration/components/java_tls/jdk8/Dockerfile
+    # TODO: use ghcr.io/open-telemetry/obi-testimg:java-tls-0.0.1-jdk8@sha256:9381c0321f0e86f04bff1d921000a08c24837a880f7b2f80ad444046a667dd92
+    # That image is only being built for amd64:
+    # docker inspect ghcr.io/open-telemetry/obi-testimg:java-tls-0.0.1-jdk8 --format '{{.Architecture}}' amd64
+    image: java-tls-jdk8
     ports:
       - "8443:8443"
   # eBPF auto instrumenter

--- a/internal/test/oats/http/docker-compose-java-tls-netty.yml
+++ b/internal/test/oats/http/docker-compose-java-tls-netty.yml
@@ -1,6 +1,12 @@
 services:
   testserver:
-    image: ghcr.io/open-telemetry/obi-testimg:netty-tls-0.0.1@sha256:04d122f1047e6c16aa5e117bebc5f986878b54d6dbab37e2b20913e221194cb1
+    build:
+      context: ../../../..
+      dockerfile: ./internal/test/integration/components/java_tls/netty_tls/Dockerfile
+    # TODO: use ghcr.io/open-telemetry/obi-testimg:netty-tls-0.0.1@sha256:04d122f1047e6c16aa5e117bebc5f986878b54d6dbab37e2b20913e221194cb1
+    # That image is only being built for amd64:
+    # docker inspect ghcr.io/open-telemetry/obi-testimg:netty-tls-0.0.1 --format '{{.Architecture}}' amd64
+    image: netty-tls
     ports:
       - "8080:8080"
   # eBPF auto instrumenter

--- a/internal/test/oats/http/docker-compose-java-tls-sync-async.yml
+++ b/internal/test/oats/http/docker-compose-java-tls-sync-async.yml
@@ -7,7 +7,13 @@ services:
     ports:
       - "8080:8080"
   testserver:
-    image: ghcr.io/open-telemetry/obi-testimg:java-tls-0.0.2@sha256:fc68b9f8ff775717bd6f936d92fce925033d3f64591ae0df0f267a40745eaef6
+    build:
+      context: ../../../..
+      dockerfile: ./internal/test/integration/components/java_tls/sync_async_tls/Dockerfile
+    # TODO: use ghcr.io/open-telemetry/obi-testimg:java-tls-0.0.2@sha256:fc68b9f8ff775717bd6f936d92fce925033d3f64591ae0df0f267a40745eaef6
+    # That image is only being built for amd64:
+    # docker inspect ghcr.io/open-telemetry/obi-testimg:java-tls-0.0.2 --format '{{.Architecture}}' amd64
+    image: java-tls
     ports:
       - "8443:8443"
   # eBPF auto instrumenter


### PR DESCRIPTION
## Summary

Part of:

- #2849
 
This PR adds arm64 runners to the OATS tests.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.