### PR TITLE
tpinjector: invalidate msg buffers when fill_msg_buffers bails

### DIFF
--- a/bpf/common/msg_buffer.h
+++ b/bpf/common/msg_buffer.h
@@ -21,6 +21,17 @@ struct {
     __uint(pinning, OBI_PIN_INTERNAL);
 } msg_buffer_mem SEC(".maps");
 
+// Read-only zero source: invalidates a full msg_buffer_mem slot with a single
+// bpf_map_update_elem instead of an unrolled 8K memset
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __type(key, u32);
+    __type(value, unsigned char[k_msg_buffer_size_max]);
+    __uint(max_entries, 1);
+    __uint(map_flags, BPF_F_RDONLY_PROG);
+    __uint(pinning, OBI_PIN_INTERNAL);
+} msg_buffer_zero SEC(".maps");
+
 // When sock_msg is installed it disables the kprobes attached to tcp_sendmsg.
 // We use this data structure to provide the buffer to the tcp_sendmsg logic,
 // because we can't read the bvec physical pages.

--- a/bpf/common/msg_buffer.h
+++ b/bpf/common/msg_buffer.h
@@ -21,17 +21,6 @@ struct {
     __uint(pinning, OBI_PIN_INTERNAL);
 } msg_buffer_mem SEC(".maps");
 
-// Read-only zero source: invalidates a full msg_buffer_mem slot with a single
-// bpf_map_update_elem instead of an unrolled 8K memset
-struct {
-    __uint(type, BPF_MAP_TYPE_ARRAY);
-    __type(key, u32);
-    __type(value, unsigned char[k_msg_buffer_size_max]);
-    __uint(max_entries, 1);
-    __uint(map_flags, BPF_F_RDONLY_PROG);
-    __uint(pinning, OBI_PIN_INTERNAL);
-} msg_buffer_zero SEC(".maps");
-
 // When sock_msg is installed it disables the kprobes attached to tcp_sendmsg.
 // We use this data structure to provide the buffer to the tcp_sendmsg logic,
 // because we can't read the bvec physical pages.

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -659,15 +659,12 @@ int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
     return 1;
 }
 
-// A bail must not leave the previous send's buffers behind: protocol_detector
-// and the tcp_sendmsg kprobe would consume them as if they were this send
+// A bail must not leave the previous send's buffers behind. Deleting the keyed
+// entry cuts off the tcp_sendmsg kprobe; msg_buffer_mem itself needs no
+// clearing because every reader is gated on fill_msg_buffers success or on the
+// msg_buffers entry deleted here — keep it that way
 static __always_inline void invalidate_msg_buffers(const egress_key_t *e_key) {
     bpf_map_delete_elem(&msg_buffers, e_key);
-
-    const unsigned char *zero = bpf_map_lookup_elem(&msg_buffer_zero, &(u32){0});
-    if (zero) {
-        bpf_map_update_elem(&msg_buffer_mem, &(u32){0}, zero, BPF_ANY);
-    }
 }
 
 // This code is copied from the kprobe on tcp_sendmsg and it's called from
@@ -689,6 +686,7 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
     }
 
     if (!msg->data || msg->data >= msg->data_end) {
+        invalidate_msg_buffers(e_key);
         return false;
     }
 

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -659,6 +659,17 @@ int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
     return 1;
 }
 
+// A bail must not leave the previous send's buffers behind: protocol_detector
+// and the tcp_sendmsg kprobe would consume them as if they were this send
+static __always_inline void invalidate_msg_buffers(const egress_key_t *e_key) {
+    bpf_map_delete_elem(&msg_buffers, e_key);
+
+    const unsigned char *zero = bpf_map_lookup_elem(&msg_buffer_zero, &(u32){0});
+    if (zero) {
+        bpf_map_update_elem(&msg_buffer_mem, &(u32){0}, zero, BPF_ANY);
+    }
+}
+
 // This code is copied from the kprobe on tcp_sendmsg and it's called from
 // the sock_msg program, which does the packet extension for injecting the
 // Traceparent. Since the sock_msg runs before the kprobe on tcp_sendmsg, we
@@ -673,6 +684,7 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
                                              const pid_connection_info_t *p_conn,
                                              const egress_key_t *e_key) {
     if (msg->size == 0 || is_ssl_connection(p_conn)) {
+        invalidate_msg_buffers(e_key);
         return false;
     }
 
@@ -702,6 +714,7 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
 
     if (!msg_ptr) {
         bpf_d_printk("failed to reserve msg_buffer space [%s]", __FUNCTION__);
+        invalidate_msg_buffers(e_key);
         return false;
     }
 
@@ -717,6 +730,7 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
 
     if (bpf_map_update_elem(&msg_buffers, e_key, &msg_buf, BPF_ANY)) {
         // fail if we can't setup a msg buffer
+        invalidate_msg_buffers(e_key);
         return false;
     }
 
@@ -1109,7 +1123,11 @@ static __always_inline bool handle_existing_tp_pid(struct sk_msg_md *msg,
     }
 
     bpf_msg_pull_data(msg, 0, msg->size, 0);
-    fill_msg_buffers(msg, p_conn, e_key);
+
+    if (!fill_msg_buffers(msg, p_conn, e_key)) {
+        clear_tp_info_pid(e_key);
+        return false;
+    }
 
     const bool is_http = protocol_detector(msg, id, &p_conn->conn);
     if (is_http) {


### PR DESCRIPTION
## Summary

Follow-up to #3257.

When `fill_msg_buffers()` bails, the buffers still hold data from the previous send. Anything that reads them afterwards treats old data as the current message. #3257 fixed this for one reader, but two readers were still exposed.

This PR clears the buffers on every bail instead of guarding each reader.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
