### PR TITLE
build: publish missing java and netty images

### DIFF
--- a/.github/actions/integration-test-image-build/action.yml
+++ b/.github/actions/integration-test-image-build/action.yml
@@ -1,17 +1,21 @@
 name: Build Integration Test Image
-description: 'Builds a Docker image for integration tests'
+description: 'Builds a single-platform Docker image for integration tests and pushes by digest'
 
 inputs:
   registry:
     description: 'Image registry (e.g. ghcr.io)'
     required: false
     default: ghcr.io
+  platform:
+    description: 'Target platform (e.g. linux/amd64)'
+    required: true
   tag-id:
     description: 'Image ID to be pretended to the tag (e.g. nodeserver)'
     required: true
   tag-version:
     description: 'Image version to be appended to the tag (e.g. 2.1.0)'
-    required: true
+    required: false
+    default: ''
   file:
     description: 'override name of the Dockerfile'
     required: false
@@ -19,6 +23,15 @@ inputs:
   labels:
     description: 'Image metadata labels'
     required: false
+  digest-dir:
+    description: 'Subdirectory under RUNNER_TEMP where per-image digest markers are stored'
+    required: false
+    default: obi-testimg-digests
+
+outputs:
+  digest:
+    description: 'Pushed image digest'
+    value: ${{ steps.push.outputs.digest }}
 
 runs:
   using: "composite"
@@ -29,8 +42,16 @@ runs:
       with:
         context: .
         file: ${{ inputs.file }}
-        push: true
-        platforms: linux/amd64,linux/arm64
+        platforms: ${{ inputs.platform }}
         labels: ${{ inputs.labels }}
-        tags: |
-          "${{ inputs.registry }}/open-telemetry/obi-testimg:${{ inputs.tag-id }}-${{ inputs.tag-version }}"
+        outputs: type=image,name=${{ inputs.registry }}/open-telemetry/obi-testimg,push-by-digest=true,name-canonical=true,push=true
+
+    - name: Record digest
+      shell: bash
+      env:
+        TAG_ID: ${{ inputs.tag-id }}
+        DIGEST: ${{ steps.push.outputs.digest }}
+        DIGEST_DIR: ${{ inputs.digest-dir }}
+      run: |
+        mkdir -p "${RUNNER_TEMP}/${DIGEST_DIR}/${TAG_ID}"
+        touch "${RUNNER_TEMP}/${DIGEST_DIR}/${TAG_ID}/${DIGEST#sha256:}"

--- a/.github/actions/integration-test-image-build/action.yml
+++ b/.github/actions/integration-test-image-build/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'Target platform (e.g. linux/amd64)'
     required: true
   tag-id:
-    description: 'Image ID to be pretended to the tag (e.g. nodeserver)'
+    description: 'Image ID to be prepended to the tag (e.g. nodeserver)'
     required: true
   tag-version:
     description: 'Image version to be appended to the tag (e.g. 2.1.0)'

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -346,6 +346,17 @@
       "schedule": ["before 6am on Tuesday"]
     },
     {
+      "description": "Re-enable digest/patch bumps for digest-pinned obi-testimg references in compose files so multi-arch republishes are picked up",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/open-telemetry/obi-testimg",
+        "open-telemetry/obi-testimg"
+      ],
+      "enabled": true,
+      "groupName": "obi-testimg pinned images",
+      "schedule": ["before 6am on Tuesday"]
+    },
+    {
       "description": "Disable Go 1.17 testserver updates",
       "matchFileNames": ["internal/test/integration/components/testserver_1.17"],
       "matchDatasources": ["docker"],

--- a/.github/workflows/ghcr_publish_testing_images.yml
+++ b/.github/workflows/ghcr_publish_testing_images.yml
@@ -56,11 +56,8 @@ jobs:
           if [[ "$OVERRIDE_IMG_TAG" == "" ]]; then
             echo "Fetching latest version from ${{ env.REGISTRY }}/${{ env.IMAGE }}..."
 
-            # Get authentication token for GHCR
-            TOKEN=$(echo ${{ secrets.GITHUB_TOKEN }} | base64)
-
             # Fetch tags from GHCR API
-            TAGS=$(curl -s -H "Authorization: Bearer $TOKEN" \
+            TAGS=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
               "https://${{ env.REGISTRY }}/v2/${{ env.IMAGE }}/tags/list")
             echo "Image tags: ${TAGS}"
 

--- a/.github/workflows/ghcr_publish_testing_images.yml
+++ b/.github/workflows/ghcr_publish_testing_images.yml
@@ -41,20 +41,35 @@ jobs:
             PACKAGE_NAME="${IMAGE#*/}"
             echo "Fetching latest version from ${REGISTRY}/${IMAGE}..."
 
-            # List package versions via GitHub Packages REST API
-            VERSIONS=$(curl -fsSL \
-              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/orgs/${PACKAGE_ORG}/packages/container/${PACKAGE_NAME}/versions?per_page=100")
-            echo "Package versions: $(echo "${VERSIONS}" | jq 'length') entries"
+            # List package versions via GitHub Packages REST API (paginate; each digest push is a version)
+            PAGE=1
+            VERSION_COUNT=0
+            TAGS_FILE="$(mktemp)"
+            while true; do
+              VERSIONS=$(curl -fsSL \
+                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/orgs/${PACKAGE_ORG}/packages/container/${PACKAGE_NAME}/versions?per_page=100&page=${PAGE}")
+              COUNT=$(echo "${VERSIONS}" | jq 'length')
+              VERSION_COUNT=$((VERSION_COUNT + COUNT))
+              if [[ "${COUNT}" -eq 0 ]]; then
+                break
+              fi
+              echo "${VERSIONS}" | jq -r '[.[].metadata.container.tags[]?] | unique[]' >> "${TAGS_FILE}"
+              if [[ "${COUNT}" -lt 100 ]]; then
+                break
+              fi
+              PAGE=$((PAGE + 1))
+            done
+            echo "Package versions: ${VERSION_COUNT} entries across ${PAGE} page(s)"
 
             # tags are in the form rust-0.1.0, so we use "tr" to split and later remove any prefix
-            LATEST_VERSION=$(echo "${VERSIONS}" | \
-              jq -r '[.[].metadata.container.tags[]?] | unique[]' | \
+            LATEST_VERSION=$(sort -u "${TAGS_FILE}" | \
               tr "-" "\n" | \
               grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | \
               sort -V | \
               tail -n 1)
+            rm -f "${TAGS_FILE}"
 
             if [[ -z "$LATEST_VERSION" ]]; then
               echo "No semantic version found, starting with 0.1.0"

--- a/.github/workflows/ghcr_publish_testing_images.yml
+++ b/.github/workflows/ghcr_publish_testing_images.yml
@@ -154,6 +154,30 @@ jobs:
           tag-id: java-native
           file: internal/test/integration/components/javatestserver/Dockerfile
 
+      - name: java-tls
+        uses: $/.github/actions/integration-test-image-build
+        with:
+          labels: ${{ steps.meta.outputs.labels }}
+          tag-version: ${{ steps.image_tag.outputs.imgtag }}
+          tag-id: java-tls
+          file: internal/test/integration/components/java_tls/sync_async_tls/Dockerfile
+
+      - name: java-tls-jdk8
+        uses: $/.github/actions/integration-test-image-build
+        with:
+          labels: ${{ steps.meta.outputs.labels }}
+          tag-version: ${{ steps.image_tag.outputs.imgtag }}
+          tag-id: java-tls-jdk8
+          file: internal/test/integration/components/java_tls/jdk8/Dockerfile
+
+      - name: netty-tls
+        uses: $/.github/actions/integration-test-image-build
+        with:
+          labels: ${{ steps.meta.outputs.labels }}
+          tag-version: ${{ steps.image_tag.outputs.imgtag }}
+          tag-id: netty-tls
+          file: internal/test/integration/components/java_tls/netty_tls/Dockerfile
+
       - name: node
         uses: $/.github/actions/integration-test-image-build
         with:

--- a/.github/workflows/ghcr_publish_testing_images.yml
+++ b/.github/workflows/ghcr_publish_testing_images.yml
@@ -1,5 +1,5 @@
 name: Publish integration testing images
-on:
+on: # zizmor: ignore[dangerous-triggers] workflow_dispatch only; override_image_tag validated as semver before use
   workflow_dispatch:
     inputs:
       override_image_tag:
@@ -10,55 +10,38 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ghcr-publish-testing-images
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE: open-telemetry/obi-testimg
 
 jobs:
-  build-and-push-image:
-    runs-on: oracle-16cpu-64gb-x86-64
-
+  prepare:
+    name: Prepare image tag
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-      attestations: write
-
+      packages: read # list existing obi-testimg tags from GHCR API
+    outputs:
+      imgtag: ${{ steps.image_tag.outputs.imgtag }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: 'false'
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4.3.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-        with:
-          platforms: linux/amd64,linux/arm64
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: "${{ env.REGISTRY }}/${{ env.IMAGE }}"
-
       - name: Set image tag
         id: image_tag
         env:
           OVERRIDE_IMG_TAG: ${{ github.event.inputs.override_image_tag }}
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE: ${{ env.IMAGE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "$OVERRIDE_IMG_TAG" == "" ]]; then
-            echo "Fetching latest version from ${{ env.REGISTRY }}/${{ env.IMAGE }}..."
+            echo "Fetching latest version from ${REGISTRY}/${IMAGE}..."
 
             # Fetch tags from GHCR API
             TAGS=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              "https://${{ env.REGISTRY }}/v2/${{ env.IMAGE }}/tags/list")
+              "https://${REGISTRY}/v2/${IMAGE}/tags/list")
             echo "Image tags: ${TAGS}"
 
             # tags are in the form rustserver-0.1.0, so we use "tr" to split and later remove any prefix
@@ -82,111 +65,120 @@ jobs:
             fi
 
             echo "New version: $NEW_VERSION"
-            echo "imgtag=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "imgtag=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           else
-            echo "imgtag=$OVERRIDE_IMG_TAG" >> $GITHUB_OUTPUT
+            if [[ ! "$OVERRIDE_IMG_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Error: override_image_tag must be semver (e.g. 0.1.2)" >&2
+              exit 1
+            fi
+            echo "imgtag=$OVERRIDE_IMG_TAG" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: go
-        uses: $/.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: go
-          file: internal/test/integration/components/testserver/Dockerfile
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - tag_id: go
+            file: internal/test/integration/components/testserver/Dockerfile
+          - tag_id: go-http-client
+            file: internal/test/integration/components/httppinger/Dockerfile
+          - tag_id: rust
+            file: internal/test/integration/components/rusttestserver/Dockerfile
+          - tag_id: rust-ssl
+            file: internal/test/integration/components/rustssltestserver/Dockerfile
+          - tag_id: rails
+            file: internal/test/integration/components/rubytestserver/testapi/Dockerfile
+          - tag_id: rails-ssl
+            file: internal/test/integration/components/rubytestserver/testapi/Dockerfile_tls
+          - tag_id: java-jar
+            file: internal/test/integration/components/javatestserver/Dockerfile_jar
+          - tag_id: java-native
+            file: internal/test/integration/components/javatestserver/Dockerfile
+          - tag_id: java-tls
+            file: internal/test/integration/components/java_tls/sync_async_tls/Dockerfile
+          - tag_id: java-tls-jdk8
+            file: internal/test/integration/components/java_tls/jdk8/Dockerfile
+          - tag_id: netty-tls
+            file: internal/test/integration/components/java_tls/netty_tls/Dockerfile
+          - tag_id: node
+            file: internal/test/integration/components/nodejsserver/Dockerfile
+          - tag_id: python
+            file: internal/test/integration/components/pythonserver/Dockerfile
+    uses: ./.github/workflows/integration_test_image_build.yml
+    with:
+      tag_id: ${{ matrix.image.tag_id }}
+      file: ${{ matrix.image.file }}
+    permissions:
+      contents: read
+      packages: write # push single-platform image layers by digest
+      attestations: write # SLSA provenance from docker/build-push-action
 
-      - name: go-http-client
-        uses: $/.github/actions/integration-test-image-build
+  merge:
+    name: Merge multi-arch manifests
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # publish versioned multi-arch manifest tags
+      attestations: write # attestations attached at digest push time
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: go-http-client
-          file: internal/test/integration/components/httppinger/Dockerfile
+          path: ${{ runner.temp }}/digests
+          pattern: obi-testimg-digest-*
 
-      - name: rust
-        uses: $/.github/actions/integration-test-image-build
+      - name: Log in to the Container registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: rust
-          file: internal/test/integration/components/rusttestserver/Dockerfile
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: rust-ssl
-        uses: $/.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: rust-ssl
-          file: internal/test/integration/components/rustssltestserver/Dockerfile
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      - name: rails
-        uses: $/.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: rails
-          file: internal/test/integration/components/rubytestserver/testapi/Dockerfile
+      - name: Create multi-arch manifests
+        env:
+          IMG_TAG: ${{ needs.prepare.outputs.imgtag }}
+          DIGESTS_DIR: ${{ runner.temp }}/digests
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+          TAG_IDS: >-
+            go
+            go-http-client
+            rust
+            rust-ssl
+            rails
+            rails-ssl
+            java-jar
+            java-native
+            java-tls
+            java-tls-jdk8
+            netty-tls
+            node
+            python
+        run: |
+          shopt -s nullglob
+          for tag_id in ${TAG_IDS}; do
+            amd64_files=("${DIGESTS_DIR}"/obi-testimg-digest-amd64-"${tag_id}"/*)
+            arm64_files=("${DIGESTS_DIR}"/obi-testimg-digest-arm64-"${tag_id}"/*)
 
-      - name: rails-ssl
-        uses: $/.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: rails-ssl
-          file: internal/test/integration/components/rubytestserver/testapi/Dockerfile_tls
+            if [ "${#amd64_files[@]}" -ne 1 ] || [ ! -f "${amd64_files[0]}" ]; then
+              echo "Error: expected one amd64 digest for ${tag_id}, found ${#amd64_files[@]}"
+              exit 1
+            fi
+            if [ "${#arm64_files[@]}" -ne 1 ] || [ ! -f "${arm64_files[0]}" ]; then
+              echo "Error: expected one arm64 digest for ${tag_id}, found ${#arm64_files[@]}"
+              exit 1
+            fi
 
-      - name: java-jar
-        uses: $/.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: java-jar
-          file: internal/test/integration/components/javatestserver/Dockerfile_jar
-
-      - name: java-native
-        uses: $/.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: java-native
-          file: internal/test/integration/components/javatestserver/Dockerfile
-
-      - name: java-tls
-        uses: $/.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: java-tls
-          file: internal/test/integration/components/java_tls/sync_async_tls/Dockerfile
-
-      - name: java-tls-jdk8
-        uses: $/.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: java-tls-jdk8
-          file: internal/test/integration/components/java_tls/jdk8/Dockerfile
-
-      - name: netty-tls
-        uses: $/.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: netty-tls
-          file: internal/test/integration/components/java_tls/netty_tls/Dockerfile
-
-      - name: node
-        uses: $/.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: node
-          file: internal/test/integration/components/nodejsserver/Dockerfile
-
-      - name: python
-        uses: $/.github/actions/integration-test-image-build
-        with:
-          labels: ${{ steps.meta.outputs.labels }}
-          tag-version: ${{ steps.image_tag.outputs.imgtag }}
-          tag-id: python
-          file: internal/test/integration/components/pythonserver/Dockerfile
+            amd64_digest=$(basename "${amd64_files[0]}")
+            arm64_digest=$(basename "${arm64_files[0]}")
+            echo "Publishing ${IMAGE}:${tag_id}-${IMG_TAG}"
+            docker buildx imagetools create \
+              -t "${IMAGE}:${tag_id}-${IMG_TAG}" \
+              "${IMAGE}@sha256:${amd64_digest}" \
+              "${IMAGE}@sha256:${arm64_digest}"
+          done

--- a/.github/workflows/ghcr_publish_testing_images.yml
+++ b/.github/workflows/ghcr_publish_testing_images.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read # list existing obi-testimg tags from GHCR API
+      packages: read # list existing obi-testimg tags via GitHub Packages REST API
     outputs:
       imgtag: ${{ steps.image_tag.outputs.imgtag }}
     steps:
@@ -37,16 +37,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [[ "$OVERRIDE_IMG_TAG" == "" ]]; then
+            PACKAGE_ORG="${IMAGE%%/*}"
+            PACKAGE_NAME="${IMAGE#*/}"
             echo "Fetching latest version from ${REGISTRY}/${IMAGE}..."
 
-            # Fetch tags from GHCR API
-            TAGS=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-              "https://${REGISTRY}/v2/${IMAGE}/tags/list")
-            echo "Image tags: ${TAGS}"
+            # List package versions via GitHub Packages REST API
+            VERSIONS=$(curl -fsSL \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/orgs/${PACKAGE_ORG}/packages/container/${PACKAGE_NAME}/versions?per_page=100")
+            echo "Package versions: $(echo "${VERSIONS}" | jq 'length') entries"
 
-            # tags are in the form rustserver-0.1.0, so we use "tr" to split and later remove any prefix
-            LATEST_VERSION=$(echo "${TAGS}" | \
-              jq -r '.tags[]' | \
+            # tags are in the form rust-0.1.0, so we use "tr" to split and later remove any prefix
+            LATEST_VERSION=$(echo "${VERSIONS}" | \
+              jq -r '[.[].metadata.container.tags[]?] | unique[]' | \
               tr "-" "\n" | \
               grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | \
               sort -V | \

--- a/.github/workflows/integration_test_image_build.yml
+++ b/.github/workflows/integration_test_image_build.yml
@@ -1,0 +1,75 @@
+name: Build integration test image
+on:
+  workflow_call:
+    inputs:
+      tag_id:
+        description: "obi-testimg tag prefix (e.g. go, java-tls)"
+        required: true
+        type: string
+      file:
+        description: "Dockerfile path relative to repository root"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: open-telemetry/obi-testimg
+
+jobs:
+  build:
+    name: ${{ inputs.tag_id }} (${{ matrix.platform.artifact_suffix }})
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            artifact_suffix: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            artifact_suffix: arm64
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write # push single-platform image layers by digest
+      attestations: write # SLSA provenance from docker/build-push-action
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: 'false'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: "${{ env.REGISTRY }}/${{ env.IMAGE }}"
+
+      - name: Build and push by digest
+        uses: ./.github/actions/integration-test-image-build
+        with:
+          labels: ${{ steps.meta.outputs.labels }}
+          platform: ${{ matrix.platform.platform }}
+          tag-id: ${{ inputs.tag_id }}
+          file: ${{ inputs.file }}
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: obi-testimg-digest-${{ matrix.platform.artifact_suffix }}-${{ inputs.tag_id }}
+          path: ${{ runner.temp }}/obi-testimg-digests/${{ inputs.tag_id }}
+          if-no-files-found: error
+          retention-days: 1

--- a/internal/test/integration/components/rusttestserver/src/main.rs
+++ b/internal/test/integration/components/rusttestserver/src/main.rs
@@ -4,7 +4,7 @@ use actix_web::http::header::ContentDisposition;
 use actix_web::http::header::DispositionType;
 use mime::Mime;
 use serde::{Deserialize, Serialize};
-use rand::Rng;
+use rand::RngExt;
 use std::time::Duration;
 use std::thread;
 use std::fs;
@@ -25,8 +25,7 @@ async fn greeting(item: web::Json<MyObj>) -> HttpResponse {
 }
 
 async fn smoke() -> HttpResponse {
-    let mut rng = rand::thread_rng();
-    let sleep_time = rng.gen_range(100..500);
+    let sleep_time = rand::rng().random_range(100..500);
     thread::sleep(Duration::from_millis(sleep_time));
     HttpResponse::Ok().into()
 }


### PR DESCRIPTION
## Summary

Part of:

- #2849 

Found while investigating:

- #3300 
- #3312

It looks like we already build some multi-arch testing images but the list was incomplete. This PR:

1. Adds the missing testing images (2x java, 1x netty) to the existing publish workflow
2. Modifies renovate config to pick up new testing images

- [x] I'll run a publish from this branch as a test and also as it's a prerequisite for #3312

Test runs (**note additional commits** pushed to resolve test failures):

- [run 1](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/33769111003) - auth failed, fix in 7c72b603a
- [run 2](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/33770265247) - auth success, cancelled due to slowness (expecting 1hr+) - fix in 1b4c1f027
- [run 3](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/33774854305) - parallelisation success, rust build failed. fix in ccfc1161e
- [run 4](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/33779898969) - publish success but failed to read existing tags, fixed in c4e201db4
- [run 5](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/33785751739) - successfully read tags, but missed some due to pagination on the results, fixed in c02a394e1
- [run 6](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/actions/runs/33794108902) - success, published all v0.1.2 multi-arch images

N.B. The workflow should be much faster on the wall clock (estimated <15m) but the above runs still took >1hr due to GitHub delays in allocating x86 runners. The majority of time spent is waiting for a runner, individual jobs only take a minute or so.

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
