### PR TITLE
policy: require short, plain-language PR and issue descriptions, enforce PR bodies in CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -17,7 +17,7 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      description: A clear description of the bug.
+      description: A few sentences, in plain language. Long AI-generated analyses will be sent back for a rewrite (see AI-POLICY.md).
     validations:
       required: true
   - type: textarea
@@ -30,6 +30,7 @@ body:
     id: repro
     attributes:
       label: Steps to reproduce
+      description: A minimal reproducer (small script or short list of steps) is worth more than pages of analysis.
     validations:
       required: true
   - type: textarea

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,17 @@
+<!--
+Keep the whole description short (aim for under ~20 lines) and in plain
+language: a reviewer must understand what changed and why in a single read.
+Long or AI-generated walls of text will be sent back for a rewrite before
+review (see AI-POLICY.md).
+-->
+
 ## Summary
 
-Describe the change briefly.
+<!-- What changed and why, in 2-4 sentences. Link the issue if there is one. -->
+
+## Testing
+
+<!-- How you verified it: tests run, environment, before/after behavior. -->
 
 ## Validation
 

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,0 +1,27 @@
+name: PR description
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+concurrency:
+  group: pr-description-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  check:
+    name: Length and readability
+    # bot PRs (Renovate, Dependabot) carry generated release notes; the policy
+    # is about human communication
+    if: github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check PR description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: python3 scripts/check-pr-description.py

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -17,9 +17,12 @@ permissions: {}
 jobs:
   check:
     name: Length and readability
-    # bot PRs (Renovate, Dependabot) carry generated release notes; the policy
-    # is about human communication
-    if: github.event.pull_request.user.type != 'Bot'
+    # bot PRs (Renovate, Dependabot) carry generated release notes and release
+    # PRs ("Release vX.Y.Z") carry changelogs; the policy is about human
+    # communication
+    if: >-
+      github.event.pull_request.user.type != 'Bot' &&
+      !startsWith(github.event.pull_request.title, 'Release v')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,7 +1,11 @@
 name: PR description
 
-on:
-  pull_request:
+# pull_request_target: the job needs to comment on fork PRs, where the
+# pull_request token is read-only. Only the base branch's workflow and script
+# run; nothing from the PR head is checked out or executed, and the PR body is
+# only ever passed through environment variables.
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 concurrency:
@@ -17,11 +21,59 @@ jobs:
     # is about human communication
     if: github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Run checker tests
+        run: python3 scripts/test_check_pr_description.py
       - name: Check PR description
+        id: check
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: python3 scripts/check-pr-description.py
+        run: |
+          set +e
+          out=$(python3 scripts/check-pr-description.py)
+          code=$?
+          echo "$out"
+          {
+            echo "findings<<FINDINGS_EOF"
+            echo "$out"
+            echo "FINDINGS_EOF"
+          } >> "$GITHUB_OUTPUT"
+          exit $code
+      - name: Comment the findings on the PR
+        if: failure() && steps.check.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FINDINGS: ${{ steps.check.outputs.findings }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          marker='<!-- pr-description-check -->'
+          body="${marker}
+          ${FINDINGS}
+
+          See [AI-POLICY.md](https://github.com/${REPO}/blob/main/AI-POLICY.md). Edit the description to rerun the check."
+          existing=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"${marker}\")) | .id] | first // empty" | head -n1)
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/${REPO}/issues/comments/${existing}" -f body="$body" > /dev/null
+          else
+            gh api "repos/${REPO}/issues/${PR}/comments" -f body="$body" > /dev/null
+          fi
+      - name: Remove a stale findings comment
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          marker='<!-- pr-description-check -->'
+          existing=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"${marker}\")) | .id] | first // empty" | head -n1)
+          if [ -n "$existing" ]; then
+            gh api --method DELETE "repos/${REPO}/issues/comments/${existing}" > /dev/null
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,11 @@ point, use short paragraphs or lists when helpful, and include only the context
 needed to understand or act on the message. Do not post generated wall-of-text
 reports, exhaustive restatements of the code, or a play-by-play of the work.
 
+Keep pull request descriptions short and in plain language: a reviewer must
+understand what changed and why in a single read. When reporting a bug, explain
+concisely what happened and what was expected, and include a reproducer
+whenever possible.
+
 ## Validation
 
 Before proposing changes, ensure the repository generates required artifacts, passes validation, and compiles successfully.

--- a/AI-POLICY.md
+++ b/AI-POLICY.md
@@ -65,6 +65,16 @@ or lightly edited Generative AI output, generated wall-of-text reports,
 exhaustive restatements of the code, or a play-by-play of the work. Include only
 the context needed for another contributor to understand or act on the message.
 
+Pull request descriptions must be short and written in plain language. A
+reviewer should understand what changed and why in a single read, without
+needing AI tooling to summarize or simplify the text. Maintainers may ask for a
+rewrite before reviewing a pull request whose description is very long or
+needlessly hard to read.
+
+Issues that report a bug must explain concisely what happened and what was
+expected. Include a reproducer whenever possible: a small script or a short
+list of steps is worth more than pages of analysis.
+
 ## 3. Unacceptable Use
 
 It is not acceptable to use Generative AI tools to:
@@ -81,6 +91,9 @@ It is not acceptable to use Generative AI tools to:
   sources without correct attribution or licensing.
 5. Submit contributions where you cannot explain, contextualize, or justify the
   submission as part of review.
+6. Submit pull request descriptions or issues that are so long, or written in
+  such complex language, that other contributors need Generative AI tooling to
+  read them.
 
 ## 4. Generative AI for Translation
 

--- a/scripts/check-pr-description.py
+++ b/scripts/check-pr-description.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# Checks that a PR description follows the AI policy (AI-POLICY.md, "GitHub
+# Communication"): short, plain-language prose a reviewer can take in with a
+# single read. Used by .github/workflows/pr-description.yml.
+#
+# A description fails when any of these hold:
+#   - more than 5 top-level (#, ##) section headings: it reads as a pasted
+#     document, not a description (### is free: issue forms generate it)
+#   - more than 2,000 characters of prose, not counting code blocks, comments,
+#     headings, checklists and URLs
+#   - sentences average more than 30 words
+#   - more than a quarter of the words are 14+ characters long
+#   - a boilerplate phrase nobody writes by hand ("it's important to note",
+#     "plays a crucial role", ...)
+#   - 3 or more abstract filler words ("seamless", "delve", "furthermore", ...)
+#     at a density above 1.5 per 100 words; single uses never fail
+#
+# The body is taken from the PR_BODY environment variable, or from stdin when
+# PR_BODY is unset:
+#
+#   gh pr view 1234 --json body -q .body | python3 scripts/check-pr-description.py
+
+import os
+import re
+import sys
+
+CHAR_LIMIT = 2000
+MAX_AVG_SENTENCE_WORDS = 30
+LONG_WORD_LEN = 14
+MAX_LONG_WORD_RATIO = 0.25
+MIN_WORDS_FOR_RATIO = 30
+MIN_SLOP_HITS = 3
+MAX_SLOP_PER_100_WORDS = 1.5
+MAX_HEADINGS = 5
+
+# Level 1-2 headings only: issue forms render their fields as ### headings,
+# which must not count against the author
+HEADING_RE = re.compile(r"^#{1,2} ", re.MULTILINE)
+
+# Abstract filler that reads as generated prose. Matched case-insensitively on
+# word boundaries; single uses never fail a PR, only density does.
+SLOP_WORDS = [
+    r"leverag(?:e|es|ed|ing)",
+    r"delv(?:e|es|ed|ing)",
+    r"seamless(?:ly)?",
+    r"holistic(?:ally)?",
+    r"streamlin(?:e|es|ed|ing)",
+    r"pivotal",
+    r"foster(?:s|ed|ing)?",
+    r"empower(?:s|ed|ing|ment)?",
+    r"synerg(?:y|ies|istic)",
+    r"paradigm",
+    r"meticulous(?:ly)?",
+    r"intricate(?:ly)?",
+    r"comprehensive(?:ly)?",
+    r"robust(?:ness|ly)?",
+    r"elegant(?:ly)?",
+    r"cutting.edge",
+    r"state.of.the.art",
+    r"game.chang(?:er|ing)",
+    r"furthermore",
+    r"moreover",
+    r"additionally",
+    r"crucial(?:ly)?",
+    r"vital(?:ly)?",
+    r"underscor(?:e|es|ed|ing)",
+    r"showcas(?:e|es|ed|ing)",
+    r"boast(?:s|ed|ing)?",
+    r"landscape",
+    r"journey",
+    r"unlock(?:s|ed|ing)?",
+    r"elevat(?:e|es|ed|ing)",
+    r"tapestry",
+    r"testament",
+    r"deep.dive",
+    r"commendable",
+    r"paramount",
+    r"unwavering",
+    r"transformative",
+    r"groundbreaking",
+    r"myriad",
+    r"embark(?:s|ed|ing)?",
+    r"endeavor(?:s|ed|ing)?",
+    r"realm(?:s)?",
+    r"resonat(?:e|es|ed|ing)",
+    r"compelling",
+    r"navigat(?:e|es|ed|ing)",
+    r"facilitat(?:e|es|ed|ing)",
+    r"encompass(?:es|ed|ing)?",
+    r"cultivat(?:e|es|ed|ing)",
+    r"exemplif(?:y|ies|ied|ying)",
+    r"multifaceted",
+    r"profound(?:ly)?",
+    r"vibrant",
+    r"renowned",
+    r"ever.evolving",
+    r"valuable insights?",
+    r"a? ?diverse array of",
+    r"in summary",
+    r"a wide range of",
+    r"it is worth noting",
+    r"dramatically",
+    r"drastically",
+    r"fundamentally",
+    r"inherently",
+    r"genuinely",
+    r"effortlessly",
+    r"disproportionately",
+    r"remarkably",
+    r"decompos(?:e|es|ed|ing|ition)",
+]
+SLOP_RE = re.compile(r"\b(?:" + "|".join(SLOP_WORDS) + r")\b", re.IGNORECASE)
+
+# Phrases that read as generated boilerplate on their own: one hit fails.
+SLOP_PHRASES = [
+    r"it'?s important to note",
+    r"it should be noted",
+    r"plays? a (?:vital|crucial|key|significant|important) role",
+    r"in conclusion",
+    r"in the realm of",
+    r"rich tapestry",
+]
+SLOP_PHRASES_RE = re.compile(
+    r"\b(?:" + "|".join(SLOP_PHRASES) + r")\b", re.IGNORECASE
+)
+
+
+def prose(body: str) -> str:
+    """Strip everything that is not the author's own prose: code blocks,
+    inline code, HTML comments (the template's guidance), markdown headings,
+    checklist lines (the template's validation section) and link URLs."""
+    body = re.sub(r"```.*?```", " ", body, flags=re.S)
+    body = re.sub(r"`[^`]*`", " ", body)
+    body = re.sub(r"<!--.*?-->", " ", body, flags=re.S)
+    body = re.sub(r"^#{1,6} .*$", " ", body, flags=re.M)
+    body = re.sub(r"^\s*- \[[ xX]\] .*$", " ", body, flags=re.M)
+    body = re.sub(r"\]\(\S+\)", "]", body)
+    body = re.sub(r"https?://\S+", " ", body)
+    return re.sub(r"\s+", " ", body).strip()
+
+
+def problems(text: str) -> list[str]:
+    found = []
+
+    if len(text) > CHAR_LIMIT:
+        found.append(
+            f"the description is {len(text)} characters of prose "
+            f"(limit {CHAR_LIMIT}). Trim it: a reviewer must understand "
+            "what changed and why in a single read."
+        )
+
+    words = text.split()
+    sentences = [s for s in re.split(r"[.!?:;]+(?:\s|$)", text) if s.split()]
+
+    if sentences and words:
+        avg = len(words) / len(sentences)
+        if avg > MAX_AVG_SENTENCE_WORDS:
+            found.append(
+                f"sentences average {avg:.0f} words "
+                f"(limit {MAX_AVG_SENTENCE_WORDS}). Use shorter sentences."
+            )
+
+    if len(words) >= MIN_WORDS_FOR_RATIO:
+        long_words = sum(
+            1 for w in words if len(re.sub(r"\W", "", w)) >= LONG_WORD_LEN
+        )
+        ratio = long_words / len(words)
+        if ratio > MAX_LONG_WORD_RATIO:
+            found.append(
+                f"{ratio:.0%} of the words have {LONG_WORD_LEN}+ characters "
+                f"(limit {MAX_LONG_WORD_RATIO:.0%}). Use plain language."
+            )
+
+    phrases = SLOP_PHRASES_RE.findall(text)
+    if phrases:
+        sample = "; ".join(sorted({p.lower() for p in phrases})[:4])
+        found.append(
+            f'generated boilerplate phrasing ("{sample}"). '
+            "Rewrite in your own words."
+        )
+
+    slop = SLOP_RE.findall(text)
+    if words and len(slop) >= MIN_SLOP_HITS:
+        per_100 = 100 * len(slop) / len(words)
+        if per_100 > MAX_SLOP_PER_100_WORDS:
+            sample = ", ".join(sorted({s.lower() for s in slop})[:8])
+            found.append(
+                f"{len(slop)} abstract filler words in {len(words)} words "
+                f"({sample}). Use concrete, plain language."
+            )
+
+    return found
+
+
+def structure_problems(body: str) -> list[str]:
+    headings = len(HEADING_RE.findall(body))
+    if headings > MAX_HEADINGS:
+        return [
+            f"{headings} section headings (limit {MAX_HEADINGS}). "
+            "A description is not a design document — keep it flat."
+        ]
+    return []
+
+
+def main() -> int:
+    body = os.environ.get("PR_BODY")
+    if body is None:
+        body = sys.stdin.read()
+
+    text = prose(body)
+    found = structure_problems(body) + problems(text)
+
+    if found:
+        print("The PR description does not follow the AI policy")
+        print("(AI-POLICY.md, 'GitHub Communication'):")
+        for p in found:
+            print(f"  - {p}")
+        return 1
+
+    print(f"PR description OK: {len(text)} characters of prose.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-pr-description.py
+++ b/scripts/check-pr-description.py
@@ -4,11 +4,17 @@
 # single read. Used by .github/workflows/pr-description.yml.
 #
 # A description fails when any of these hold:
+#   - the body is completely empty or unchanged from the PR template: any
+#     text of the author's own passes, a link to an issue included
 #   - more than 5 top-level (#, ##) section headings: it reads as a pasted
-#     document, not a description (### is free: issue forms generate it)
+#     document, not a description (### is free: issue forms generate it;
+#     headings inside code blocks and comments never count)
 #   - more than 2,000 characters of prose, not counting code blocks, comments,
 #     headings, checklists and URLs
-#   - sentences average more than 30 words
+#   - sentences average more than 30 words, judged only when there are at
+#     least 3 sentences so one long sentence in a short description does not
+#     fail on its own; above 60 it fails regardless (list items count as
+#     their own sentences, so bullet lists are never concatenated)
 #   - more than a quarter of the words are 14+ characters long
 #   - a boilerplate phrase nobody writes by hand ("it's important to note",
 #     "plays a crucial role", ...)
@@ -26,6 +32,8 @@ import sys
 
 CHAR_LIMIT = 2000
 MAX_AVG_SENTENCE_WORDS = 30
+MIN_SENTENCES_FOR_AVG = 3
+MAX_AVG_SENTENCE_WORDS_HARD = 60
 LONG_WORD_LEN = 14
 MAX_LONG_WORD_RATIO = 0.25
 MIN_WORDS_FOR_RATIO = 30
@@ -63,7 +71,6 @@ SLOP_WORDS = [
     r"additionally",
     r"crucial(?:ly)?",
     r"vital(?:ly)?",
-    r"underscor(?:e|es|ed|ing)",
     r"showcas(?:e|es|ed|ing)",
     r"boast(?:s|ed|ing)?",
     r"landscape",
@@ -124,19 +131,72 @@ SLOP_PHRASES_RE = re.compile(
     r"\b(?:" + "|".join(SLOP_PHRASES) + r")\b", re.IGNORECASE
 )
 
+# A markdown list item: bullet or numbered
+LIST_ITEM_RE = re.compile(r"^(?:[-*+]|\d+[.)])\s+(.*)$")
 
-def prose(body: str) -> str:
-    """Strip everything that is not the author's own prose: code blocks,
-    inline code, HTML comments (the template's guidance), markdown headings,
-    checklist lines (the template's validation section) and link URLs."""
+
+def strip_generated(body: str) -> str:
+    """Remove the regions that are not the author's own text and must not feed
+    any check: fenced code blocks (an unclosed fence runs to the end), inline
+    code and HTML comments (the template's guidance)."""
+    body = body.replace("\r\n", "\n")
     body = re.sub(r"```.*?```", " ", body, flags=re.S)
+    body = re.sub(r"```.*\Z", " ", body, flags=re.S)
     body = re.sub(r"`[^`]*`", " ", body)
     body = re.sub(r"<!--.*?-->", " ", body, flags=re.S)
-    body = re.sub(r"^#{1,6} .*$", " ", body, flags=re.M)
-    body = re.sub(r"^\s*- \[[ xX]\] .*$", " ", body, flags=re.M)
+    return body
+
+
+def author_text(body: str) -> str:
+    """The author's own text: the body without generated regions, markdown
+    headings and checklist lines (the template's validation section)."""
+    body = strip_generated(body)
+    body = re.sub(r"^#{1,6} .*$", "", body, flags=re.M)
+    body = re.sub(r"^\s*- \[[ xX]\] .*$", "", body, flags=re.M)
+    return body
+
+
+def empty_problems(body: str) -> list[str]:
+    """Fails only a body with no text of the author's own: completely empty,
+    or unchanged from the PR template (comments, headings and checklists)."""
+    if author_text(body).split():
+        return []
+    return [
+        "the description is empty or unchanged from the template. "
+        "Please say what changed and why."
+    ]
+
+
+def prose(body: str) -> str:
+    """Reduce the body to the author's own prose, one segment per line: each
+    list item is its own segment and paragraph lines are joined, so sentence
+    counting sees the same boundaries a reader does. Link URLs and list
+    markers are dropped."""
+    body = author_text(body)
     body = re.sub(r"\]\(\S+\)", "]", body)
     body = re.sub(r"https?://\S+", " ", body)
-    return re.sub(r"\s+", " ", body).strip()
+
+    segments = []
+    paragraph = []
+    for raw_line in body.split("\n"):
+        line = raw_line.strip()
+        item = LIST_ITEM_RE.match(line)
+        if item:
+            if paragraph:
+                segments.append(" ".join(paragraph))
+                paragraph = []
+            if item.group(1).strip():
+                segments.append(item.group(1).strip())
+        elif line:
+            paragraph.append(line)
+        else:
+            if paragraph:
+                segments.append(" ".join(paragraph))
+                paragraph = []
+    if paragraph:
+        segments.append(" ".join(paragraph))
+
+    return "\n".join(re.sub(r"\s+", " ", s) for s in segments)
 
 
 def problems(text: str) -> list[str]:
@@ -145,19 +205,21 @@ def problems(text: str) -> list[str]:
     if len(text) > CHAR_LIMIT:
         found.append(
             f"the description is {len(text)} characters of prose "
-            f"(limit {CHAR_LIMIT}). Trim it: a reviewer must understand "
-            "what changed and why in a single read."
+            f"(limit {CHAR_LIMIT}). Please make it shorter."
         )
 
     words = text.split()
-    sentences = [s for s in re.split(r"[.!?:;]+(?:\s|$)", text) if s.split()]
+    # a line break is a sentence boundary: list items stay separate sentences
+    sentences = [s for s in re.split(r"[.!?:;]+(?:\s|$)|\n", text) if s.split()]
 
     if sentences and words:
         avg = len(words) / len(sentences)
-        if avg > MAX_AVG_SENTENCE_WORDS:
+        over = (len(sentences) >= MIN_SENTENCES_FOR_AVG
+                and avg > MAX_AVG_SENTENCE_WORDS)
+        if over or avg > MAX_AVG_SENTENCE_WORDS_HARD:
             found.append(
                 f"sentences average {avg:.0f} words "
-                f"(limit {MAX_AVG_SENTENCE_WORDS}). Use shorter sentences."
+                f"(limit {MAX_AVG_SENTENCE_WORDS}). Please use shorter sentences."
             )
 
     if len(words) >= MIN_WORDS_FOR_RATIO:
@@ -168,15 +230,14 @@ def problems(text: str) -> list[str]:
         if ratio > MAX_LONG_WORD_RATIO:
             found.append(
                 f"{ratio:.0%} of the words have {LONG_WORD_LEN}+ characters "
-                f"(limit {MAX_LONG_WORD_RATIO:.0%}). Use plain language."
+                f"(limit {MAX_LONG_WORD_RATIO:.0%}). Please use simpler words."
             )
 
     phrases = SLOP_PHRASES_RE.findall(text)
     if phrases:
         sample = "; ".join(sorted({p.lower() for p in phrases})[:4])
         found.append(
-            f'generated boilerplate phrasing ("{sample}"). '
-            "Rewrite in your own words."
+            f'boilerplate phrasing ("{sample}"). Please reword it.'
         )
 
     slop = SLOP_RE.findall(text)
@@ -185,19 +246,19 @@ def problems(text: str) -> list[str]:
         if per_100 > MAX_SLOP_PER_100_WORDS:
             sample = ", ".join(sorted({s.lower() for s in slop})[:8])
             found.append(
-                f"{len(slop)} abstract filler words in {len(words)} words "
-                f"({sample}). Use concrete, plain language."
+                f"{len(slop)} filler words in {len(words)} words "
+                f"({sample}). Please use simpler words."
             )
 
     return found
 
 
 def structure_problems(body: str) -> list[str]:
-    headings = len(HEADING_RE.findall(body))
+    headings = len(HEADING_RE.findall(strip_generated(body)))
     if headings > MAX_HEADINGS:
         return [
             f"{headings} section headings (limit {MAX_HEADINGS}). "
-            "A description is not a design document — keep it flat."
+            "Please use fewer sections."
         ]
     return []
 
@@ -208,10 +269,10 @@ def main() -> int:
         body = sys.stdin.read()
 
     text = prose(body)
-    found = structure_problems(body) + problems(text)
+    found = empty_problems(body) + structure_problems(body) + problems(text)
 
     if found:
-        print("The PR description does not follow the AI policy")
+        print("Please adjust the PR description")
         print("(AI-POLICY.md, 'GitHub Communication'):")
         for p in found:
             print(f"  - {p}")

--- a/scripts/test_check_pr_description.py
+++ b/scripts/test_check_pr_description.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+# Tests for check-pr-description.py, with example bodies for every rule and
+# for the failure modes reported in review: bullet lists concatenated into one
+# sentence, headings counted inside code blocks and comments, domain terms
+# treated as filler, and empty or untouched-template bodies passing.
+#
+#   python3 scripts/test_check_pr_description.py
+
+import importlib.util
+import pathlib
+import unittest
+
+_SCRIPT = pathlib.Path(__file__).with_name("check-pr-description.py")
+_spec = importlib.util.spec_from_file_location("check_pr_description", _SCRIPT)
+check = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check)
+
+TEMPLATE = """<!--
+Keep the whole description short (aim for under ~20 lines) and in plain
+language: a reviewer must understand what changed and why in a single read.
+Long or AI-generated walls of text will be sent back for a rewrite before
+review (see AI-POLICY.md).
+-->
+
+## Summary
+
+<!-- What changed and why, in 2-4 sentences. Link the issue if there is one. -->
+
+## Testing
+
+<!-- How you verified it: tests run, environment, before/after behavior. -->
+
+## Validation
+
+- [ ] I have read and followed the [contributing guidelines](https://example.com/CONTRIBUTING.md)
+- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://example.com/features.md) and [support matrix](https://example.com/SUPPORT_MATRIX.md) as needed.
+"""
+
+
+def findings(body: str) -> list[str]:
+    text = check.prose(body)
+    return check.empty_problems(body) + check.structure_problems(body) + check.problems(text)
+
+
+class TestGoodDescriptions(unittest.TestCase):
+    def test_short_filled_template_passes(self):
+        body = TEMPLATE.replace(
+            "## Summary\n",
+            "## Summary\n\nFix a nil map access in the Kafka parser when the "
+            "header block is truncated. Fixes #1234.\n",
+        ).replace(
+            "## Testing\n",
+            "## Testing\n\nAdded a unit test with the truncated capture from "
+            "the issue; ran the Kafka integration suite.\n",
+        )
+        self.assertEqual(findings(body), [])
+
+    def test_bullet_list_without_punctuation_passes(self):
+        # regression: bullets used to be concatenated into one long sentence
+        body = """## Summary
+
+Rework the exporter startup:
+
+- move the queue setup out of the constructor
+- retry the endpoint resolution with backoff instead of failing once
+- drop the unused mutex around the batch counter
+- log the resolved endpoint at debug level so support can see it
+"""
+        self.assertEqual(findings(body), [])
+
+    def test_numbered_list_passes(self):
+        body = """Steps taken to validate the release artifacts before tagging:
+
+1) built the image from a clean checkout on both amd64 and arm64 hosts
+2) ran the verifier suite against every supported kernel in the matrix
+3) compared the emitted schema files against the previous release
+"""
+        self.assertEqual(findings(body), [])
+
+    def test_domain_term_underscore_passes(self):
+        # regression: "underscore" was on the filler list and a real
+        # metric-naming migration description used it five times
+        body = """## Summary
+
+Rename the Prometheus-style metric names to the OTel dot format. Every
+underscore in a metric name becomes a dot, except the unit suffix where the
+underscore is kept. Names with a leading underscore are rejected, names with
+a double underscore keep one underscore, and the target_info underscores are
+unchanged. Fixes #2634.
+"""
+        self.assertEqual(findings(body), [])
+
+    def test_headings_in_code_blocks_do_not_count(self):
+        # regression: shell comments in a fenced example counted as headings
+        body = """## Summary
+
+Teach the collector config loader to expand environment variables.
+
+## Testing
+
+Manual run with the config below plus the loader unit tests.
+
+```bash
+# start the collector
+# with the test config
+# and debug logging
+# on both ports
+OTEL_LOG=debug ./collector --config test.yaml
+```
+"""
+        self.assertEqual(findings(body), [])
+
+    def test_headings_in_html_comments_do_not_count(self):
+        body = "One-line fix for the flaky DNS test.\n<!--\n# a\n# b\n# c\n# d\n# e\n# f\n-->\n"
+        self.assertEqual(findings(body), [])
+
+    def test_crlf_body_passes(self):
+        body = "## Summary\r\n\r\nBump the base image to fix CVE-2026-1234.\r\n"
+        self.assertEqual(findings(body), [])
+
+    def test_one_long_sentence_in_a_short_description_passes(self):
+        # a single 35-word sentence is not a wall of text
+        body = (
+            "Fix a stuck collector shutdown caused by closing the ring "
+            "buffer reader too late in the pipeline teardown, and add a "
+            "deadline so a blocked reader cannot hold the shutdown forever."
+        )
+        self.assertEqual(findings(body), [])
+
+    def test_fixes_link_only_passes(self):
+        # "fixes <issue link>" leaves the explanation to the linked issue
+        body = TEMPLATE.replace(
+            "## Summary\n",
+            "## Summary\n\nfixes https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/3056\n",
+        )
+        self.assertEqual(findings(body), [])
+
+    def test_fixes_issue_number_only_passes(self):
+        self.assertEqual(findings("Fixes #123"), [])
+
+    def test_any_author_text_passes(self):
+        # only a completely empty or template-only body fails
+        self.assertEqual(findings("Fixes"), [])
+        self.assertEqual(findings(TEMPLATE + "\nrelease prep"), [])
+
+    def test_single_filler_word_passes(self):
+        body = (
+            "Make the retry loop robust against clock skew by comparing "
+            "monotonic timestamps instead of wall-clock times."
+        )
+        self.assertEqual(findings(body), [])
+
+
+class TestBadDescriptions(unittest.TestCase):
+    def assert_fails(self, body: str, needle: str):
+        found = findings(body)
+        self.assertTrue(
+            any(needle in f for f in found),
+            f"expected a finding containing {needle!r}, got {found!r}",
+        )
+
+    def test_empty_body_fails(self):
+        # regression: an empty body used to pass with 0 characters of prose
+        self.assert_fails("", "empty")
+
+    def test_untouched_template_fails(self):
+        # regression: the untouched template strips to nothing and passed
+        self.assert_fails(TEMPLATE, "empty")
+
+    def test_whitespace_only_body_fails(self):
+        self.assert_fails("   \n\n  \n", "empty")
+
+    def test_too_long_fails(self):
+        body = "The parser change touches every branch. " * 60
+        self.assert_fails(body, "limit 2000")
+
+    def test_too_many_headings_fails(self):
+        body = (
+            "# One\n## Two\n## Three\n## Four\n## Five\n## Six\n\n"
+            "Rewrite of the pipeline configuration docs.\n"
+        )
+        self.assert_fails(body, "section headings")
+
+    def test_long_sentences_fail(self):
+        sentence = (
+            "this change updates the exporter and the receiver and the "
+            "processor and the config loader and the docs and the tests and "
+            "the benchmarks and the examples and the readme and the changelog "
+            "and the release notes and the helm chart. "
+        )
+        self.assert_fails(sentence * 3, "sentences average")
+
+    def test_single_run_on_wall_fails(self):
+        body = "word " * 70
+        self.assert_fails(body, "sentences average")
+
+    def test_boilerplate_phrase_fails(self):
+        body = (
+            "It's important to note that this refactor keeps the wire format "
+            "unchanged while moving the encoder into its own package."
+        )
+        self.assert_fails(body, "boilerplate")
+
+    def test_filler_word_density_fails(self):
+        body = (
+            "This comprehensive change leverages the new API to seamlessly "
+            "streamline the pipeline."
+        )
+        self.assert_fails(body, "filler")
+
+    def test_long_word_ratio_fails(self):
+        word = "internationalization "
+        body = ("fix the parser.\n" + word * 3) * 5
+        self.assert_fails(body, "simpler words")
+
+
+class TestProse(unittest.TestCase):
+    def test_list_items_become_separate_lines(self):
+        text = check.prose("- first item\n- second item\n")
+        self.assertEqual(text, "first item\nsecond item")
+
+    def test_paragraph_lines_are_joined(self):
+        text = check.prose("a sentence wrapped\nover two lines\n")
+        self.assertEqual(text, "a sentence wrapped over two lines")
+
+    def test_unclosed_code_fence_is_stripped(self):
+        text = check.prose("Fix the flaky test.\n```\n# not a heading\nx = 1\n")
+        self.assertEqual(text, "Fix the flaky test.")
+        self.assertEqual(check.structure_problems("```\n# a\n# b\n"), [])
+
+    def test_template_strips_to_nothing(self):
+        self.assertEqual(check.prose(TEMPLATE), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Long, generated descriptions are hard to review without AI tooling. This makes the existing AI policy explicit about it and adds enforcement: PR descriptions must be short and in understandable english, and bug reports must say concisely what happened, with a reproducer when possible.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
