### PR TITLE
ci: run OATS tests on arm

### DIFF
--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -64,20 +64,26 @@ jobs:
       - name: Build test matrix
         id: build-matrix
         run: |
-          echo -n "matrix=" >> $GITHUB_OUTPUT
-          make oats-integration-test-matrix-json >> $GITHUB_OUTPUT
+          echo -n "matrix=" >> "$GITHUB_OUTPUT"
+          make oats-integration-test-matrix-json >> "$GITHUB_OUTPUT"
 
   test:
-    name: ${{ matrix.basename }}
+    name: ${{ matrix.shard.basename }} (${{ matrix.platform.arch }})
     needs: [test-matrix, generate-bpf]
     permissions:
       checks: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.test-matrix.outputs.matrix) }}
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+        shard: ${{ fromJson(needs.test-matrix.outputs.matrix).include }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -131,7 +137,7 @@ jobs:
 
       - name: Run oats tests
         env:
-          MATRIX_BASENAME: ${{ matrix.basename }}
+          MATRIX_BASENAME: ${{ matrix.shard.basename }}
           TESTCASE_TIMEOUT: 5m
         run: make "oats-test-$MATRIX_BASENAME"
 
@@ -139,8 +145,8 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
-          name: oats-logs-${{ matrix.basename }}-${{ github.run_number }}
-          path: internal/test/oats/${{ matrix.basename }}/build/*
+          name: oats-logs-${{ matrix.shard.basename }}-${{ matrix.platform.arch }}-${{ github.run_number }}
+          path: internal/test/oats/${{ matrix.shard.basename }}/build/*
 
       - name: Process coverage data
         run: make itest-coverage-data
@@ -152,4 +158,4 @@ jobs:
         with:
           files: ./testoutput/itest-covdata.txt
           flags: oats-test
-          name: oats-coverage-${{ matrix.basename }}-${{ github.run_number }}
+          name: oats-coverage-${{ matrix.shard.basename }}-${{ matrix.platform.arch }}-${{ github.run_number }}

--- a/internal/test/integration/components/javaamqp/Dockerfile
+++ b/internal/test/integration/components/javaamqp/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.10-eclipse-temurin-17@sha256:3f87b585f681619f5b27373461123425a095101ef0929d2cf15ad1888aeed7ff AS builder
+FROM maven:3.9.10-eclipse-temurin-17@sha256:cdd737b4dad70ec8543c8022c6e11338cfd7b7c83b1a1cf867d1629a185700d7 AS builder
 
 WORKDIR /build
 
@@ -7,7 +7,7 @@ COPY internal/test/integration/components/javaamqp/src /build/src
 
 RUN mvn -B --no-transfer-progress -DskipTests package
 
-FROM eclipse-temurin:17-jre@sha256:55f9905b45a83a43aba875de8ad1ffc7b635813ae6bc0830d076f7fd086da48e
+FROM eclipse-temurin:17-jre@sha256:13cc28a6cc72a38ce1f00c906be3580c1a3e604b8984d694f369a96742abc93b
 
 WORKDIR /app
 EXPOSE 8080

--- a/internal/test/oats/http/docker-compose-java-tls-jdk8.yml
+++ b/internal/test/oats/http/docker-compose-java-tls-jdk8.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8080:8080"
   testserver:
-    image: ghcr.io/open-telemetry/obi-testimg:java-tls-0.0.1-jdk8@sha256:9381c0321f0e86f04bff1d921000a08c24837a880f7b2f80ad444046a667dd92
+    image: ghcr.io/open-telemetry/obi-testimg:java-tls-jdk8-0.1.2@sha256:4f9a335549a9e4dd597ed4c42905bcfb66da814b2e9868dcf6032e1db76074b7
     ports:
       - "8443:8443"
   # eBPF auto instrumenter

--- a/internal/test/oats/http/docker-compose-java-tls-netty.yml
+++ b/internal/test/oats/http/docker-compose-java-tls-netty.yml
@@ -1,6 +1,6 @@
 services:
   testserver:
-    image: ghcr.io/open-telemetry/obi-testimg:netty-tls-0.0.1@sha256:04d122f1047e6c16aa5e117bebc5f986878b54d6dbab37e2b20913e221194cb1
+    image: ghcr.io/open-telemetry/obi-testimg:netty-tls-0.1.2@sha256:8f87a73de41fbdfef5cc74c8099ddfe95340e09da18643e0c4a20195e5a43451
     ports:
       - "8080:8080"
   # eBPF auto instrumenter

--- a/internal/test/oats/http/docker-compose-java-tls-sync-async.yml
+++ b/internal/test/oats/http/docker-compose-java-tls-sync-async.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8080:8080"
   testserver:
-    image: ghcr.io/open-telemetry/obi-testimg:java-tls-0.0.2@sha256:fc68b9f8ff775717bd6f936d92fce925033d3f64591ae0df0f267a40745eaef6
+    image: ghcr.io/open-telemetry/obi-testimg:java-tls-0.1.2@sha256:db9d65ca49b4962caeca26a9e7aab1adaf3c4bd2e6a22fc4e2957386d36f2eba
     ports:
       - "8443:8443"
   # eBPF auto instrumenter


### PR DESCRIPTION
## Summary

Part of:

- #2849

This PR:

1. adds arm runners to the OATS tests
2. pins multi-arch images instead of x86-only

## Validation

- [X] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.