### PR TITLE
send integration spans to weaver

### DIFF
--- a/cmd/obi/internal/configcmd/configcmd_test.go
+++ b/cmd/obi/internal/configcmd/configcmd_test.go
@@ -1520,7 +1520,7 @@ func TestMigrateIntegrationConfigurations(t *testing.T) {
 				require.True(t, cfg.Discovery.ExcludeInstrument[0].Metadata["k8s_deployment_name"].MatchString("testserver"))
 				require.Equal(t, "http://otelcol:4317", cfg.OTELMetrics.MetricsEndpoint)
 				require.Equal(t, otelcfg.ProtocolGRPC, cfg.OTELMetrics.MetricsProtocol)
-				require.Equal(t, "http://jaeger:4317", cfg.Traces.TracesEndpoint)
+				require.Equal(t, "http://otelcol:4317", cfg.Traces.TracesEndpoint)
 				require.Equal(t, otelcfg.ProtocolGRPC, cfg.Traces.TracesProtocol)
 				require.NotNil(t, cfg.Routes)
 				routes := cfg.Routes.DirectionalPolicies()

--- a/internal/test/integration/configs/obi-config-avoided-services.yml
+++ b/internal/test/integration/configs/obi-config-avoided-services.yml
@@ -9,7 +9,7 @@ routes:
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4318
 internal_metrics:
   exporter: otel
   # limit 2 so the rolldice server's 2nd avoided identity (traces) overflows,

--- a/internal/test/integration/configs/obi-config-container-meta.yml
+++ b/internal/test/integration/configs/obi-config-container-meta.yml
@@ -1,7 +1,7 @@
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4318
   otel_sdk_log_level: debug
 attributes:
   select:

--- a/internal/test/integration/configs/obi-config-discovery.yml
+++ b/internal/test/integration/configs/obi-config-discovery.yml
@@ -5,7 +5,7 @@ routes:
 otel_metrics_export:
   endpoint: http://otelcol:4018
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4018
 discovery:
   # these are repeated with different params to test the discovery section
   # ordering semantics

--- a/internal/test/integration/configs/obi-config-error-test.yml
+++ b/internal/test/integration/configs/obi-config-error-test.yml
@@ -5,7 +5,7 @@ routes:
 otel_metrics_export:
   endpoint: http://otelcol:4018
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4018
 discovery:
   services:
     # Target the real testserver process to attempt instrumentation

--- a/internal/test/integration/configs/obi-config-multiexec-host.yml
+++ b/internal/test/integration/configs/obi-config-multiexec-host.yml
@@ -5,7 +5,7 @@ routes:
 otel_metrics_export:
   endpoint: http://127.0.0.1:4018
 otel_traces_export:
-  endpoint: http://127.0.0.1:4318
+  endpoint: http://127.0.0.1:4018
 discovery:
   instrument:
     - namespace: just-will-be-ignored

--- a/internal/test/integration/configs/obi-config-node.yml
+++ b/internal/test/integration/configs/obi-config-node.yml
@@ -5,7 +5,7 @@ routes:
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4318
 attributes:
   select:
     "*":

--- a/internal/test/integration/configs/obi-config-nodemultiproc.yml
+++ b/internal/test/integration/configs/obi-config-nodemultiproc.yml
@@ -5,7 +5,7 @@ routes:
 otel_metrics_export:
   endpoint: http://otelcol:4018
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4018
 discovery:
   disabled_route_harvesters: ["nodejs"]
   services:

--- a/internal/test/integration/configs/obi-config-other-grpc.yml
+++ b/internal/test/integration/configs/obi-config-other-grpc.yml
@@ -16,7 +16,7 @@ routes:
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4318
 attributes:
   select:
     "*":

--- a/internal/test/integration/configs/obi-config-php.yml
+++ b/internal/test/integration/configs/obi-config-php.yml
@@ -1,7 +1,7 @@
 otel_metrics_export:
   endpoint: http://127.0.0.1:4018
 otel_traces_export:
-  endpoint: http://127.0.0.1:4318
+  endpoint: http://127.0.0.1:4018
 attributes:
   select:
     "*":

--- a/internal/test/integration/configs/obi-config-ruby.yml
+++ b/internal/test/integration/configs/obi-config-ruby.yml
@@ -3,7 +3,7 @@ routes:
 otel_metrics_export:
   endpoint: http://127.0.0.1:4318
 otel_traces_export:
-  endpoint: http://127.0.0.1:4418
+  endpoint: http://127.0.0.1:4318
 attributes:
   select:
     "*":

--- a/internal/test/integration/configs/obi-config-sampler.yml
+++ b/internal/test/integration/configs/obi-config-sampler.yml
@@ -5,7 +5,7 @@ routes:
 otel_metrics_export:
   endpoint: http://otelcol:4018
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4018
 discovery:
   disabled_route_harvesters: ["nodejs"]
   services:

--- a/internal/test/integration/configs/obi-config-tpclient.yml
+++ b/internal/test/integration/configs/obi-config-tpclient.yml
@@ -7,7 +7,7 @@ attributes:
 otel_metrics_export:
   endpoint: http://otelcol:4018
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4018
 discovery:
   services:
     - name: tpclient-a

--- a/internal/test/integration/configs/obi-config.yml
+++ b/internal/test/integration/configs/obi-config.yml
@@ -8,7 +8,7 @@ routes:
 otel_metrics_export:
   endpoint: http://otelcol:4318
 otel_traces_export:
-  endpoint: http://jaeger:4318
+  endpoint: http://otelcol:4318
   otel_sdk_log_level: debug
 attributes:
   kubernetes:

--- a/internal/test/integration/configs/otelcol-config.yml
+++ b/internal/test/integration/configs/otelcol-config.yml
@@ -16,11 +16,18 @@ exporters:
     resource_to_telemetry_conversion:
       enabled: true
     enable_open_metrics: true
+  otlphttp/jaeger:
+    endpoint: http://jaeger:4318
+    tls:
+      insecure: true
 service:
   pipelines:
     metrics:
       receivers: [otlp]
       exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/jaeger]
 #  telemetry:
 #    logs:
 #      level: debug

--- a/internal/test/integration/k8s/manifests/06-obi-daemonset-multi-node.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-daemonset-multi-node.yml
@@ -26,7 +26,7 @@ data:
     otel_metrics_export:
       endpoint: http://otelcol:4318
     otel_traces_export:
-      endpoint: http://jaeger:4318
+      endpoint: http://otelcol:4318
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/internal/test/integration/k8s/manifests/06-obi-daemonset-python.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-daemonset-python.yml
@@ -20,7 +20,7 @@ data:
     otel_metrics_export:
       endpoint: http://otelcol:4318
     otel_traces_export:
-      endpoint: http://jaeger:4318
+      endpoint: http://otelcol:4318
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/internal/test/integration/k8s/manifests/06-obi-daemonset.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-daemonset.yml
@@ -34,7 +34,7 @@ data:
       endpoint: http://otelcol:4317
       protocol: grpc
     otel_traces_export:
-      endpoint: http://jaeger:4317
+      endpoint: http://otelcol:4317
       protocol: grpc
     internal_metrics:
       exporter: otel

--- a/internal/test/integration/test_python_elasticsearchclient.go
+++ b/internal/test/integration/test_python_elasticsearchclient.go
@@ -76,7 +76,15 @@ func assertElasticsearchOperation(t *testing.T, dbSystemName, op, queryText, ind
 
 		var tq jaeger.TracesQuery
 		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
-		traces := tq.FindBySpan(jaeger.Tag{Key: "db.operation.name", Type: "string", Value: op})
+		// Both backends run against the same Jaeger under the same service and
+		// operation name, so the trace must be selected by the backend under
+		// test. Picking positionally would return whichever trace happens to
+		// land last, which is not the emission order once a collector batches
+		// the spans on their way to Jaeger.
+		traces := tq.FindBySpan(
+			jaeger.Tag{Key: "db.operation.name", Type: "string", Value: op},
+			jaeger.Tag{Key: "db.system.name", Type: "string", Value: dbSystemName},
+		)
 		require.GreaterOrEqual(ct, len(traces), 1, resp.Body)
 		lastTrace := traces[len(traces)-1]
 		require.GreaterOrEqual(ct, len(lastTrace.Spans), 1)


### PR DESCRIPTION
## Summary

Integration tests exported OBI traces straight to Jaeger, so the collector's weaver tap only ever received metrics. Suites that do assert spans (Elasticsearch, MCP, GraphQL, JSON-RPC, Kafka, Mongo, SQL, MQTT, Ruby, PHP) validated them through Jaeger while contributing nothing to weaver's view of emitted telemetry.

Each affected config now sends traces to the same collector endpoint it already uses for metrics. The collector forwards them to Jaeger exactly as before, so existing Jaeger assertions are unchanged. Three Kubernetes daemonsets had the same split and get the same fix; the k8s collector already had a Jaeger exporter added for this purpose.

`otelcol-config.yml` had no traces pipeline at all, so its two consumers would have lost spans entirely. It gains one matching the other collector configs.

Composes whose traces reach the weaver tap go from 13 to 56. The remaining weaver-enabled composes set no traces exporter and are metrics-only by design.

`obi-config-with-jaeger-host.yml` deliberately still points at Jaeger: it is shared with a compose that runs no collector.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
