### PR TITLE
derive SQS span kind from the messaging operation

### DIFF
--- a/internal/test/integration/red_test_python_aws.go
+++ b/internal/test/integration/red_test_python_aws.go
@@ -47,7 +47,7 @@ func waitAWSProxy(t *testing.T) {
 	}, testTimeout, 1*time.Second)
 }
 
-func fetchAWSSpanByOP(t require.TestingT, op string) jaeger.Span {
+func fetchAWSSpanByOP(t require.TestingT, op, spanKind string) jaeger.Span {
 	var tq jaeger.TracesQuery
 
 	params := neturl.Values{}
@@ -63,7 +63,7 @@ func fetchAWSSpanByOP(t require.TestingT, op string) jaeger.Span {
 	require.GreaterOrEqual(t, len(tq.Data), 1, op)
 
 	for _, tr := range tq.Data {
-		spans := tr.FindByOperationName(op, "client")
+		spans := tr.FindByOperationName(op, spanKind)
 		if len(spans) > 0 {
 			return spans[0]
 		}

--- a/internal/test/integration/red_test_python_aws_s3.go
+++ b/internal/test/integration/red_test_python_aws_s3.go
@@ -42,7 +42,7 @@ func testPythonAWSS3(t *testing.T) {
 func assertS3Operation(t require.TestingT, op, expectedKey string) {
 	opName := "s3." + op
 
-	span := fetchAWSSpanByOP(t, opName)
+	span := fetchAWSSpanByOP(t, opName, "client")
 	require.Equal(t, opName, span.OperationName)
 
 	tag, found := jaeger.FindIn(span.Tags, "rpc.method")

--- a/internal/test/integration/red_test_python_aws_sqs.go
+++ b/internal/test/integration/red_test_python_aws_sqs.go
@@ -12,7 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/otel/trace"
+
 	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
 
 type (
@@ -62,10 +65,19 @@ func sqsRequestWithData[T sqsQueueURL | sqsMessages](t *testing.T, url string) T
 	return data
 }
 
+func sqsSpanKind(operationType string) string {
+	kind, ok := request.MessagingSpanKind(operationType)
+	if !ok {
+		kind = trace.SpanKindClient
+	}
+
+	return kind.String()
+}
+
 func assertSQSOperation(t require.TestingT, op, expectedQueueURL, expectedMessageID, expectedOperationType string) {
 	opName := "sqs." + op
 
-	span := fetchAWSSpanByOP(t, opName)
+	span := fetchAWSSpanByOP(t, opName, sqsSpanKind(expectedOperationType))
 	require.Equal(t, opName, span.OperationName)
 
 	tag, found := jaeger.FindIn(span.Tags, "aws.request_id")

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -1940,6 +1940,11 @@ func (s *Span) ServiceGraphKind() string {
 	case EventTypeHTTP, EventTypeGRPC, EventTypeSunRPCServer, EventTypeRedisServer, EventTypeMemcachedServer, EventTypeSQLServer, EventTypeAerospikeServer:
 		return "SPAN_KIND_SERVER"
 	case EventTypeHTTPClient, EventTypeGRPCClient, EventTypeSQLClient, EventTypeRedisClient, EventTypeMongoClient, EventTypeFailedConnect, EventTypeCouchbaseClient, EventTypeMemcachedClient, EventTypeSunRPCClient, EventTypeAerospikeClient:
+		if s.SubType == HTTPSubtypeAWSSQS && s.AWS != nil {
+			if kind, ok := MessagingSpanKind(s.AWS.SQS.OperationType); ok {
+				return spanKindString(kind)
+			}
+		}
 		return "SPAN_KIND_CLIENT"
 	case EventTypeKafkaClient, EventTypeKafkaServer,
 		EventTypeMQTTClient, EventTypeMQTTServer,

--- a/pkg/appolly/app/request/span_test.go
+++ b/pkg/appolly/app/request/span_test.go
@@ -133,6 +133,28 @@ func TestMessagingSpanKind(t *testing.T) {
 	}
 }
 
+func TestSQSServiceGraphKind(t *testing.T) {
+	sqsSpan := func(operationType string) *Span {
+		return &Span{
+			Type:    EventTypeHTTPClient,
+			SubType: HTTPSubtypeAWSSQS,
+			AWS:     &AWS{SQS: AWSSQS{OperationType: operationType}},
+		}
+	}
+
+	// The service graph kind must match the span kind traces report, or the
+	// same SQS exchange is a producer in the trace and a client in the metric.
+	assert.Equal(t, "SPAN_KIND_PRODUCER", sqsSpan(MessagingSend).ServiceGraphKind())
+	assert.Equal(t, "SPAN_KIND_CLIENT", sqsSpan(MessagingReceive).ServiceGraphKind())
+	assert.Equal(t, "SPAN_KIND_CLIENT", sqsSpan(MessagingSettle).ServiceGraphKind())
+	assert.Equal(t, "SPAN_KIND_CLIENT", sqsSpan("").ServiceGraphKind())
+
+	assert.Equal(t, "SPAN_KIND_CLIENT", (&Span{
+		Type:    EventTypeHTTPClient,
+		SubType: HTTPSubtypeAWSS3,
+	}).ServiceGraphKind())
+}
+
 func TestServiceGraphConnectionType(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -1774,6 +1774,11 @@ func spanKind(span *request.Span) trace2.SpanKind {
 	case request.EventTypeHTTP, request.EventTypeGRPC, request.EventTypeRedisServer, request.EventTypeSunRPCServer, request.EventTypeMemcachedServer, request.EventTypeSQLServer, request.EventTypeAerospikeServer:
 		return trace2.SpanKindServer
 	case request.EventTypeHTTPClient, request.EventTypeGRPCClient, request.EventTypeSQLClient, request.EventTypeRedisClient, request.EventTypeMongoClient, request.EventTypeCouchbaseClient, request.EventTypeMemcachedClient, request.EventTypeSunRPCClient, request.EventTypeAerospikeClient, request.EventTypeFailedConnect:
+		if span.SubType == request.HTTPSubtypeAWSSQS && span.AWS != nil {
+			if kind, ok := request.MessagingSpanKind(span.AWS.SQS.OperationType); ok {
+				return kind
+			}
+		}
 		return trace2.SpanKindClient
 	// A messaging span is a producer, a consumer or a client, decided by the
 	// operation rather than by the side OBI observed it from. Semantic

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -1240,6 +1240,30 @@ func TestNoMessagingSpanIsReportedAsServerKind(t *testing.T) {
 	}
 }
 
+func TestSQSSpanKind(t *testing.T) {
+	sqsSpan := func(operationType string) *request.Span {
+		return &request.Span{
+			Type:    request.EventTypeHTTPClient,
+			SubType: request.HTTPSubtypeAWSSQS,
+			AWS:     &request.AWS{SQS: request.AWSSQS{OperationType: operationType}},
+		}
+	}
+
+	assert.Equal(t, trace2.SpanKindProducer, spanKind(sqsSpan(request.MessagingSend)))
+	assert.Equal(t, trace2.SpanKindClient, spanKind(sqsSpan(request.MessagingReceive)))
+	assert.Equal(t, trace2.SpanKindClient, spanKind(sqsSpan(request.MessagingSettle)))
+	assert.Equal(t, trace2.SpanKindClient, spanKind(sqsSpan("")))
+
+	assert.Equal(t, trace2.SpanKindClient, spanKind(&request.Span{
+		Type:    request.EventTypeHTTPClient,
+		SubType: request.HTTPSubtypeAWSSQS,
+	}))
+	assert.Equal(t, trace2.SpanKindClient, spanKind(&request.Span{
+		Type:    request.EventTypeHTTPClient,
+		SubType: request.HTTPSubtypeAWSS3,
+	}))
+}
+
 func manualOTelPayload(t *testing.T) []byte {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

SQS spans are HTTP client spans carrying messaging attributes, so they were emitted with span kind `client` regardless of the operation. Semantic conventions map the kind from the messaging operation type, and `SendMessage` is the one SQS operation whose kind was wrong.

`SendMessage` and `SendMessageBatch` now emit `producer`. Every other operation stays `client`, which is what conventions ask for: `receive` and `settle` are client operations, since OBI observes the exchange with the broker rather than what the application does with the message afterwards. `ReceiveMessage` and `DeleteMessage` therefore keep the kind they already had, and so do the queue administration calls that carry no messaging operation type at all, along with S3.

Both kind paths go through the `request.MessagingSpanKind` helper, so the trace span kind and the metric kind cannot drift apart.

## Metrics also change

`Span.ServiceGraphKind` feeds more than the service graph. An SQS send moves from `SPAN_KIND_CLIENT` to `SPAN_KIND_PRODUCER` in:

- the `span.kind` label on span metrics
- the `kind` label on `traces_service_graph_request_*`
- the `kind` field in the JSON span printer

`SPAN_KIND_PRODUCER` is already a declared member of the `span.kind` enum, so no schema transformation is owed, but a dashboard or alert pinned to `span_kind="SPAN_KIND_CLIENT"` for an `sqs.SendMessage` span will see that series move.

## Tests

`fetchAWSSpanByOP` hard-coded `client` when looking a span up in Jaeger, so it found nothing once the kind changed. It now takes the expected kind, which the SQS assertions derive from the operation type through the same shared helper.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

Unit tests cover both kind paths, including the negative cases: a nil AWS payload, an S3 subtype, and an unmapped operation type. Reverting either production change fails them.
