### PR TITLE
Prepare obi for version v0.13.0

### DIFF
--- a/internal/test/oats/ai/go.mod
+++ b/internal/test/oats/ai/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.2 // indirect
+	go.opentelemetry.io/obi v0.13.0 // indirect
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0 // indirect

--- a/internal/test/oats/amqp/go.mod
+++ b/internal/test/oats/amqp/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.2 // indirect
+	go.opentelemetry.io/obi v0.13.0 // indirect
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0 // indirect

--- a/internal/test/oats/harness/go.mod
+++ b/internal/test/oats/harness/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/grafana/oats v0.7.0
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.41.0
-	go.opentelemetry.io/obi v0.12.2
+	go.opentelemetry.io/obi v0.13.0
 )
 
 // The oats harness reuses the shared weaver-validation logic

--- a/internal/test/oats/http/go.mod
+++ b/internal/test/oats/http/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.2 // indirect
+	go.opentelemetry.io/obi v0.13.0 // indirect
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0 // indirect

--- a/internal/test/oats/kafka/go.mod
+++ b/internal/test/oats/kafka/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.2 // indirect
+	go.opentelemetry.io/obi v0.13.0 // indirect
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0 // indirect

--- a/internal/test/oats/memcached/go.mod
+++ b/internal/test/oats/memcached/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.2 // indirect
+	go.opentelemetry.io/obi v0.13.0 // indirect
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0 // indirect

--- a/internal/test/oats/mongo/go.mod
+++ b/internal/test/oats/mongo/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.2 // indirect
+	go.opentelemetry.io/obi v0.13.0 // indirect
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0 // indirect

--- a/internal/test/oats/nats/go.mod
+++ b/internal/test/oats/nats/go.mod
@@ -26,7 +26,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.2 // indirect
+	go.opentelemetry.io/obi v0.13.0 // indirect
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0 // indirect

--- a/internal/test/oats/redis/go.mod
+++ b/internal/test/oats/redis/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.2 // indirect
+	go.opentelemetry.io/obi v0.13.0 // indirect
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0 // indirect

--- a/internal/test/oats/sql/go.mod
+++ b/internal/test/oats/sql/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.64.0 // indirect
 	go.opentelemetry.io/collector/pdata v1.64.0 // indirect
-	go.opentelemetry.io/obi v0.12.2 // indirect
+	go.opentelemetry.io/obi v0.13.0 // indirect
 	go.opentelemetry.io/otel v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.46.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.46.0 // indirect

--- a/pkg/export/attributes/names/schema_version.go
+++ b/pkg/export/attributes/names/schema_version.go
@@ -5,4 +5,4 @@
 
 package attr
 
-var OBISchemaURL = "https://open-telemetry.github.io/opentelemetry-ebpf-instrumentation/schemas/obi/0.12.2"
+var OBISchemaURL = "https://open-telemetry.github.io/opentelemetry-ebpf-instrumentation/schemas/obi/0.13.0"

--- a/schemas/obi/manifest.yaml
+++ b/schemas/obi/manifest.yaml
@@ -1,4 +1,4 @@
-schema_url: https://open-telemetry.github.io/opentelemetry-ebpf-instrumentation/schemas/obi/0.12.2
+schema_url: https://open-telemetry.github.io/opentelemetry-ebpf-instrumentation/schemas/obi/0.13.0
 description: |
   Schema registry for the OpenTelemetry eBPF instrumentation (OBI).
 

--- a/site/schemas/obi/0.13.0
+++ b/site/schemas/obi/0.13.0
@@ -1,0 +1,5 @@
+file_format: 1.1.0
+schema_url: https://open-telemetry.github.io/opentelemetry-ebpf-instrumentation/schemas/obi/0.13.0
+versions:
+  0.13.0:
+  0.12.2:

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   obi:
-    version: v0.12.2
+    version: v0.13.0
     modules:
       - go.opentelemetry.io/obi
 excluded-modules:


### PR DESCRIPTION
v0.13.0 is a feature release. It also fixes a group of memory-safety bugs in the socket-layer context propagation that could corrupt TLS connections of instrumented workloads or copy unrelated kernel memory into telemetry.

### Context-propagation memory safety

- The HTTP header injector no longer acts on leftover buffer data from a previous request, which could write a traceparent into the middle of a TLS stream and reset the connection. ([#3257](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3257))
- Message-buffer reads are bounded by the mapped data window, so a failed pull can no longer copy adjacent kernel memory into span payloads. Also fixes a masking bug that copied nothing for sends of 8 KiB or more. ([#3298](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3298))
- The message buffers are invalidated whenever filling them fails, so no reader can mistake a previous message for the current one. ([#3304](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3304))

### Protocol and tracing fixes

- Application-supplied traceparents are preserved in Go HTTP/2, and header injection there fails safely. ([#3156](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3156), [#3159](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3159))
- TCP client and server roles are classified by the local port, fixing swapped roles for same-namespace clients. ([#3146](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3146))
- Established idle connections are no longer reported as failed connects. ([#3043](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3043))
- DNS spans follow OTel conventions, peer naming from DNS captures is fixed, and reverse DNS supports IPv6. ([#3174](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3174), [#2947](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/2947), [#3244](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3244))
- Exiting processes keep their PID valid for a grace period so their final events are not lost. ([#3170](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3170))

### New instrumentation and metrics

- Runtime metrics for Python, JVM, and Node.js; Go runtime probes are gated behind the `application_runtime` feature. ([#3028](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3028), [#3203](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3203), [#3131](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3131), [#3227](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3227))
- New attributes: `db.response.status_code`, `db.namespace`, and `server.port` on database duration metrics; `messaging.operation.name` on messaging spans. ([#3271](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3271), [#3193](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3193), [#3097](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3097), [#3136](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3136))
- Aerospike server spans, Go 1.27 support, and better service naming for Python, Deno, .NET, and Node.js apps. ([#3167](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3167), [#3221](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3221), [#3112](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3112), [#3132](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3132), [#3118](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3118), [#3099](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3099))
- OBI publishes its telemetry schema and a generated telemetry reference; `schema_url` now points at 0.13.0. ([#3044](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3044), [#3215](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3215))

### Behavior changes

- `service.name` and `service.namespace` are no longer default metric labels; select them explicitly if you depend on them. ([#3168](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3168))
- `error.type` values are unified across spans and metrics; the attribute name is unchanged. ([#3196](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3196))
- Go runtime metrics require enabling the `application_runtime` feature. ([#3227](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3227))
- `metrics.features` is printed as feature names instead of a bitmask. ([#3265](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3265))

**Full Changelog**: [v0.12.2...v0.13.0](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/compare/v0.12.2...v0.13.0)