### PR TITLE
tpinjector: fix wrong pointer type

### DIFF
--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -708,7 +708,7 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
     bpf_clamp_umax(fallback_bytes, k_kprobes_http2_buf_size);
     bpf_probe_read_kernel(msg_buf.fallback_buf, fallback_bytes, msg->data);
 
-    unsigned char **msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
+    unsigned char *msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
 
     if (!msg_ptr) {
         bpf_d_printk("failed to reserve msg_buffer space [%s]", __FUNCTION__);
@@ -752,7 +752,7 @@ static __always_inline u8 protocol_detector(struct sk_msg_md *msg,
         return 0;
     }
 
-    unsigned char **msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
+    unsigned char *msg_ptr = bpf_map_lookup_elem(&msg_buffer_mem, &(u32){0});
 
     if (!msg_ptr) {
         return 0;


### PR DESCRIPTION


## Summary

bpf_map_lookup_elem() returns a pointer to unsigned char[N] in this particular instance, which decays to unsigned char *. We are wrongly taking unsigned char ** (i.e. a pointer to a pointer, not a pointer to a unsigned char array). It's been mostly fine because it gets cast to (void*) later and passed around as such, but when we do:
```
  ptr[0] = '\0'
```
we are actually writing a 64-bit word, rather than  a single char (i.e. writing a pointer address) - which is fine for the purpose, but semantically wrong.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
