### PR TITLE
fix elasticsearch span select

### DIFF
--- a/internal/test/integration/test_python_elasticsearchclient.go
+++ b/internal/test/integration/test_python_elasticsearchclient.go
@@ -57,9 +57,10 @@ func assertElasticsearchOperation(t *testing.T, dbSystemName, op, queryText, ind
 	if index != "" {
 		operationName = op + " " + index
 		params.Add("operation", operationName)
+		params.Add("tags", fmt.Sprintf("{\"db.system.name\":\"%s\"}", dbSystemName))
 	} else {
 		operationName = op
-		params.Add("tags", fmt.Sprintf("{\"db.operation.name\":\"%s\"}", op))
+		params.Add("tags", fmt.Sprintf("{\"db.operation.name\":\"%s\",\"db.system.name\":\"%s\"}", op, dbSystemName))
 	}
 	fullJaegerURL := fmt.Sprintf("%s?%s", jaegerQueryURL, params.Encode())
 


### PR DESCRIPTION
## Summary

The Elasticsearch and OpenSearch subtests share one testserver and one Jaeger, and their spans carry the same operation name, so the query matched both and the assertion read whichever trace happened to arrive last. It now filters on `db.system.name`, making the selection deterministic.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
