### PR TITLE
Go manual SDK conformance

### DIFF
--- a/bpf/gotracer/go_sdk.c
+++ b/bpf/gotracer/go_sdk.c
@@ -40,7 +40,7 @@ enum { k_go_ptr_arr_size = 16 };
 enum { k_go_auto_activation_max_attempts = 3 };
 enum { k_efault = 14 };
 
-const char ERROR_KEY[] = "error message";
+const char ERROR_KEY[] = "exception.message";
 const u32 ERROR_KEY_SIZE = sizeof(ERROR_KEY) - 1;
 
 typedef struct span_info {
@@ -906,16 +906,18 @@ int GUARDED_PROG(obi_uprobe_RecordError, struct pt_regs *, ctx) {
             u8 valid_attrs = span->span_attrs.valid_attrs;
             bpf_dbg_printk("valid_attrs=%d, len=%d, str=%s", valid_attrs, go_str.len, go_str.str);
 
-            if ((go_str.len < OTEL_ATTRIBUTE_KEY_MAX_LEN) &&
-                (valid_attrs < OTEL_ATTRIBUTE_MAX_COUNT)) {
-                __builtin_memcpy(
-                    span->span_attrs.attrs[valid_attrs].key, ERROR_KEY, ERROR_KEY_SIZE);
-                bpf_probe_read_user(span->span_attrs.attrs[valid_attrs].value,
-                                    go_str.len & (OTEL_ATTRIBUTE_KEY_MAX_LEN - 1),
-                                    go_str.str);
-                span->span_attrs.attrs[valid_attrs].val_length = go_str.len;
-                span->span_attrs.attrs[valid_attrs].vtype = attr_type_string;
-                span->span_attrs.valid_attrs = valid_attrs + 1;
+            if ((go_str.len > 0) && (valid_attrs < OTEL_ATTRIBUTE_MAX_COUNT)) {
+                u32 val_len = (u32)go_str.len;
+                bpf_clamp_umax(val_len, OTEL_ATTRIBUTE_VALUE_MAX_LEN - 1);
+
+                if (bpf_probe_read_user(
+                        span->span_attrs.attrs[valid_attrs].value, val_len, go_str.str) == 0) {
+                    __builtin_memcpy(
+                        span->span_attrs.attrs[valid_attrs].key, ERROR_KEY, ERROR_KEY_SIZE);
+                    span->span_attrs.attrs[valid_attrs].val_length = val_len;
+                    span->span_attrs.attrs[valid_attrs].vtype = attr_type_string;
+                    span->span_attrs.valid_attrs = valid_attrs + 1;
+                }
             }
         }
     }

--- a/internal/test/integration/components/goautosdk/main.go
+++ b/internal/test/integration/components/goautosdk/main.go
@@ -105,20 +105,20 @@ func emitNestedSpans() {
 		spanName("root"),
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
-			attribute.String("activation.version", version),
-			attribute.Bool("activation.root", true),
+			attribute.String("obitest.activation.version", version),
+			attribute.Bool("obitest.activation.root", true),
 		),
 	)
 	root.AddEvent(
 		"root event",
-		trace.WithAttributes(attribute.String("event.detail", "preserved")),
+		trace.WithAttributes(attribute.String("obitest.event.detail", "preserved")),
 	)
 
 	_, child := tracer.Start(
 		ctx,
 		spanName("child-before-rename"),
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(attribute.Int("activation.answer", 42)),
+		trace.WithAttributes(attribute.Int("obitest.activation.answer", 42)),
 	)
 	child.SetName(spanName("child"))
 	child.SetStatus(codes.Error, "expected test status")

--- a/internal/test/integration/components/nodejsserver/app.js
+++ b/internal/test/integration/components/nodejsserver/app.js
@@ -20,20 +20,20 @@ app.get("/manual", (req, res, next) => {
   // Root manual span. OBI re-anchors it onto the in-flight request context,
   // i.e. it becomes a child of OBI's automatic "processing" sub-span.
   tracer.startActiveSpan("checkout", (checkout) => {
-    checkout.setAttribute("cart.items", 3);
+    checkout.setAttribute("obitest.cart.items", 3);
 
     // Plain (non-active) child of checkout.
     const validate = tracer.startSpan("validate-cart");
-    validate.setAttribute("valid", true);
+    validate.setAttribute("obitest.valid", true);
     validate.end(new Date()); // explicit end timestamp -> endWallNs path
 
     // Nested active span, so its own children nest under it.
     tracer.startActiveSpan("charge-card", { kind: SpanKind.CLIENT }, (charge) => {
-      charge.setAttribute("amount.cents", 4999);
+      charge.setAttribute("obitest.amount.cents", 4999);
       charge.setStatus({ code: SpanStatusCode.ERROR, message: "card declined" });
 
       const ledger = tracer.startSpan("ledger-write");
-      ledger.setAttribute("account", "acct-1");
+      ledger.setAttribute("obitest.account", "acct-1");
       ledger.updateName("ledger-commit");
       ledger.end();
 

--- a/internal/test/integration/components/testserver/std/std.go
+++ b/internal/test/integration/components/testserver/std/std.go
@@ -151,8 +151,8 @@ func inner(id int) {
 
 	opts := []trace.SpanStartOption{
 		trace.WithAttributes(
-			attribute.String("user", "user"+strconv.Itoa(id)),
-			attribute.Bool("admin", true),
+			attribute.String("obitest.user", "user"+strconv.Itoa(id)),
+			attribute.Bool("obitest.admin", true),
 		),
 		trace.WithTimestamp(y2k.Add(500 * time.Microsecond)),
 		trace.WithSpanKind(trace.SpanKindServer),
@@ -164,7 +164,7 @@ func inner(id int) {
 	if id == 2 {
 		span.SetName("changed name")
 		span.SetAttributes(
-			attribute.String("test", "append"),
+			attribute.String("obitest.test", "append"),
 		)
 	}
 }
@@ -193,7 +193,7 @@ func manual(rw http.ResponseWriter) {
 		errors.New("some unknown error"),
 		trace.WithTimestamp(y2k.Add(2*time.Second)),
 		trace.WithStackTrace(true),
-		trace.WithAttributes(attribute.Int("impact", 11)),
+		trace.WithAttributes(attribute.Int("obitest.impact", 11)),
 	)
 
 	rw.WriteHeader(http.StatusOK)

--- a/internal/test/integration/components/testserver_1.17/std/std.go
+++ b/internal/test/integration/components/testserver_1.17/std/std.go
@@ -78,8 +78,8 @@ func inner(id int) {
 
 	opts := []trace.SpanStartOption{
 		trace.WithAttributes(
-			attribute.String("user", "user"+strconv.Itoa(id)),
-			attribute.Bool("admin", true),
+			attribute.String("obitest.user", "user"+strconv.Itoa(id)),
+			attribute.Bool("obitest.admin", true),
 		),
 		trace.WithTimestamp(y2k.Add(500 * time.Microsecond)),
 		trace.WithSpanKind(trace.SpanKindServer),
@@ -90,7 +90,7 @@ func inner(id int) {
 	if id == 2 {
 		span.SetName("changed name")
 		span.SetAttributes(
-			attribute.String("test", "append"),
+			attribute.String("obitest.test", "append"),
 		)
 	}
 	defer span.End(trace.WithTimestamp(ts.Add(100 * time.Microsecond)))
@@ -112,7 +112,7 @@ func manual(rw http.ResponseWriter) {
 		errors.New("some unknown error"),
 		trace.WithTimestamp(y2k.Add(2*time.Second)),
 		trace.WithStackTrace(true),
-		trace.WithAttributes(attribute.Int("impact", 11)),
+		trace.WithAttributes(attribute.Int("obitest.impact", 11)),
 	)
 
 	rw.WriteHeader(http.StatusOK)

--- a/internal/test/integration/go_auto_sdk_test.go
+++ b/internal/test/integration/go_auto_sdk_test.go
@@ -199,15 +199,15 @@ func testGoAutoSDKRichSpans(t *testing.T, version, service string) {
 	require.NotEmpty(t, root.TraceID)
 	require.NotEmpty(t, root.SpanID)
 	assert.Empty(t, root.Diff(
-		jaeger.Tag{Key: "activation.version", Type: "string", Value: version},
-		jaeger.Tag{Key: "activation.root", Type: "bool", Value: true},
+		jaeger.Tag{Key: "obitest.activation.version", Type: "string", Value: version},
+		jaeger.Tag{Key: "obitest.activation.root", Type: "bool", Value: true},
 		jaeger.Tag{Key: "otel.scope.name", Type: "string", Value: "go-auto-sdk-activation-test"},
 		jaeger.Tag{Key: "otel.scope.version", Type: "string", Value: "v1.0.0"},
 	))
 	require.Len(t, root.Logs, 1)
 	assert.Empty(t, jaeger.Diff([]jaeger.Tag{
 		{Key: "event", Type: "string", Value: "root event"},
-		{Key: "event.detail", Type: "string", Value: "preserved"},
+		{Key: "obitest.event.detail", Type: "string", Value: "preserved"},
 	}, root.Logs[0].Fields))
 
 	childName := autoSDKSpanName("child", version)
@@ -220,7 +220,7 @@ func testGoAutoSDKRichSpans(t *testing.T, version, service string) {
 	require.True(t, ok)
 	assert.Equal(t, root.SpanID, parent.SpanID)
 	assert.Empty(t, child.Diff(
-		jaeger.Tag{Key: "activation.answer", Type: "int64", Value: float64(42)},
+		jaeger.Tag{Key: "obitest.activation.answer", Type: "int64", Value: float64(42)},
 		jaeger.Tag{Key: "otel.status_code", Type: "string", Value: "ERROR"},
 		jaeger.Tag{Key: "otel.status_description", Type: "string", Value: "expected test status"},
 	))

--- a/internal/test/integration/traces_node_manual_test.go
+++ b/internal/test/integration/traces_node_manual_test.go
@@ -78,7 +78,7 @@ func testHTTPTracesNodeManualSpans(t *testing.T) {
 	assert.Equal(t, processing.SpanID, p.SpanID,
 		"checkout must be re-anchored under OBI's automatic processing sub-span")
 	sd := checkout.Diff(
-		jaeger.Tag{Key: "cart.items", Type: "int64", Value: float64(3)},
+		jaeger.Tag{Key: "obitest.cart.items", Type: "int64", Value: float64(3)},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "internal"},
 	)
 	assert.Empty(t, sd, sd.String())
@@ -91,7 +91,7 @@ func testHTTPTracesNodeManualSpans(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, checkout.SpanID, p.SpanID, "validate-cart must be a child of checkout")
 	sd = validate.Diff(
-		jaeger.Tag{Key: "valid", Type: "bool", Value: bool(true)},
+		jaeger.Tag{Key: "obitest.valid", Type: "bool", Value: bool(true)},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "internal"},
 	)
 	assert.Empty(t, sd, sd.String())
@@ -105,7 +105,7 @@ func testHTTPTracesNodeManualSpans(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, checkout.SpanID, p.SpanID, "charge-card must be a child of checkout")
 	sd = charge.Diff(
-		jaeger.Tag{Key: "amount.cents", Type: "int64", Value: float64(4999)},
+		jaeger.Tag{Key: "obitest.amount.cents", Type: "int64", Value: float64(4999)},
 		jaeger.Tag{Key: "otel.status_code", Type: "string", Value: "ERROR"},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "client"},
 	)
@@ -119,7 +119,7 @@ func testHTTPTracesNodeManualSpans(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, charge.SpanID, p.SpanID, "ledger-commit must be a child of charge-card")
 	sd = ledger.Diff(
-		jaeger.Tag{Key: "account", Type: "string", Value: "acct-1"},
+		jaeger.Tag{Key: "obitest.account", Type: "string", Value: "acct-1"},
 		jaeger.Tag{Key: "span.kind", Type: "string", Value: "internal"},
 	)
 	assert.Empty(t, sd, sd.String())

--- a/internal/test/integration/traces_test.go
+++ b/internal/test/integration/traces_test.go
@@ -1472,9 +1472,9 @@ func testHTTPTracesNestedManualSpans(t *testing.T) {
 	assert.Equal(t, processing.SpanID, p.SpanID)
 	sd = sig.Diff(
 		jaeger.Tag{Key: "error", Type: "bool", Value: bool(true)},
-		jaeger.Tag{Key: "error message", Type: "string", Value: "some unknown error"},
+		jaeger.Tag{Key: "exception.message", Type: "string", Value: "some unknown error"},
 		jaeger.Tag{Key: "otel.status_code", Type: "string", Value: "ERROR"},
-		jaeger.Tag{Key: "impact", Type: "int64", Value: float64(11)},
+		jaeger.Tag{Key: "obitest.impact", Type: "int64", Value: float64(11)},
 	)
 	assert.Empty(t, sd, sd.String())
 
@@ -1487,8 +1487,8 @@ func testHTTPTracesNestedManualSpans(t *testing.T) {
 	assert.Equal(t, sig.TraceID, p.TraceID)
 	assert.Equal(t, sig.SpanID, p.SpanID)
 	sd = sigInner1.Diff(
-		jaeger.Tag{Key: "user", Type: "string", Value: "user1"},
-		jaeger.Tag{Key: "admin", Type: "bool", Value: bool(true)},
+		jaeger.Tag{Key: "obitest.user", Type: "string", Value: "user1"},
+		jaeger.Tag{Key: "obitest.admin", Type: "bool", Value: bool(true)},
 	)
 	assert.Empty(t, sd, sd.String())
 
@@ -1501,9 +1501,9 @@ func testHTTPTracesNestedManualSpans(t *testing.T) {
 	assert.Equal(t, sig.TraceID, p.TraceID)
 	assert.Equal(t, sig.SpanID, p.SpanID)
 	sd = sigInner2.Diff(
-		jaeger.Tag{Key: "test", Type: "string", Value: "append"},
-		jaeger.Tag{Key: "user", Type: "string", Value: "user2"},
-		jaeger.Tag{Key: "admin", Type: "bool", Value: bool(true)},
+		jaeger.Tag{Key: "obitest.test", Type: "string", Value: "append"},
+		jaeger.Tag{Key: "obitest.user", Type: "string", Value: "user2"},
+		jaeger.Tag{Key: "obitest.admin", Type: "bool", Value: bool(true)},
 	)
 	assert.Empty(t, sd, sd.String())
 }

--- a/schemas/obi/.weaver.toml
+++ b/schemas/obi/.weaver.toml
@@ -43,3 +43,12 @@ sample_names = [
   "traces_spanmetrics_size_total",
   "traces_spanmetrics_response_size_total",
 ]
+
+# OBI relays application-authored spans verbatim (its manual span feature), so the
+# attributes on them are chosen by the instrumented application and can never exist in
+# this registry. The integration test applications namespace theirs under `obitest.` so
+# a single scope covers all of them; an undeclared attribute outside that namespace,
+# including on any OBI-authored span, still surfaces.
+[[live-check.finding_filters]]
+exclude = ["missing_attribute"]
+sample_names = ["obitest.*"]

--- a/schemas/obi/groups/exception/registry.yaml
+++ b/schemas/obi/groups/exception/registry.yaml
@@ -1,0 +1,15 @@
+# Attributes OBI sets on the application-authored spans it relays through its
+# manual span feature. The spans themselves are named and shaped by the
+# instrumented application, so they match no span group in this registry;
+# these are declared here so they resolve as part of OBI's contract without
+# being falsely attributed to a span carrier OBI does not define.
+groups:
+  - id: registry.obi.exception
+    type: attribute_group
+    display_name: OBI Exception Attributes
+    brief: >
+      Exception attributes OBI's Go SDK tracer sets on relayed manual spans.
+    attributes:
+      # Set by the RecordError uprobe (bpf/gotracer/go_sdk.c) from the error
+      # passed to the Go SDK's span.RecordError.
+      - ref: exception.message


### PR DESCRIPTION
## Summary

Spans relayed from the Go manual SDK carry attributes chosen by the instrumented application, which can never exist in OBI's registry, so weaver reports each one as a violation once those spans reach it. The integration test applications now namespace their custom attributes under `obitest.`, and a single scoped filter accepts that namespace; an undeclared attribute anywhere else, including on an OBI-authored span, still surfaces.

The `RecordError` uprobe named its attribute `error message`, which is both absent from the registry and invalid as an attribute name. It now emits `exception.message`, the stable semantic convention for a recorded error. Unlike the application-authored attributes, this one OBI sets itself, so it is declared rather than filtered: an attribute group references it, which is what puts it in the resolved registry, since an upstream attribute no group references is not part of it.

That same code bounded the error text against the attribute *key* limit while writing into the *value* buffer, so any error message of 32 bytes or more was dropped instead of recorded. It now clamps the length to the value limit with `bpf_clamp_umax`, truncating a long message rather than losing it, rejects a non-positive length, and commits the attribute only when the read succeeds.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
