### PR TITLE
Fix pre-fork Python service name attribution falling back to python3.14

### DIFF
--- a/internal/test/integration/components/pythonsql/Dockerfile_ssl
+++ b/internal/test/integration/components/pythonsql/Dockerfile_ssl
@@ -8,4 +8,4 @@ RUN pip install --require-hashes -r /requirements.txt
 COPY main_ssl.py /main_ssl.py
 COPY server.crt /server.crt
 COPY server.key /server.key
-CMD ["gunicorn", "--keyfile", "/server.key", "--certfile", "/server.crt", "-w", "1", "-b", "0.0.0.0:8080", "-k", "uvicorn.workers.UvicornWorker", "main_ssl:app"]
+CMD ["gunicorn", "--keyfile", "/server.key", "--certfile", "/server.crt", "-w", "3", "-b", "0.0.0.0:8080", "-k", "uvicorn.workers.UvicornWorker", "main_ssl:app"]

--- a/internal/test/integration/components/pythonsql/Dockerfile_ssl
+++ b/internal/test/integration/components/pythonsql/Dockerfile_ssl
@@ -8,4 +8,4 @@ RUN pip install --require-hashes -r /requirements.txt
 COPY main_ssl.py /main_ssl.py
 COPY server.crt /server.crt
 COPY server.key /server.key
-CMD ["gunicorn", "--keyfile", "/server.key", "--certfile", "/server.crt", "-w", "3", "-b", "0.0.0.0:8080", "-k", "uvicorn.workers.UvicornWorker", "main_ssl:app"]
+CMD ["gunicorn", "--keyfile", "/server.key", "--certfile", "/server.crt", "-w", "1", "-b", "0.0.0.0:8080", "-k", "uvicorn.workers.UvicornWorker", "main_ssl:app"]

--- a/internal/test/integration/components/pythonsql/ssl_server.sh
+++ b/internal/test/integration/components/pythonsql/ssl_server.sh
@@ -1,4 +1,0 @@
-# Copyright The OpenTelemetry Authors
-# SPDX-License-Identifier: Apache-2.0
-
-gunicorn --timeout 120 --keyfile server.key --certfile server.crt -w 1 -b 0.0.0.0:8380 -k uvicorn.workers.UvicornWorker main_ssl:app

--- a/pkg/appolly/app/svc/svc.go
+++ b/pkg/appolly/app/svc/svc.go
@@ -181,12 +181,20 @@ func (i *Attrs) setFlag(flag idFlags) {
 	i.flags |= flag
 }
 
+func (i *Attrs) clearFlag(flag idFlags) {
+	i.flags &^= flag
+}
+
 func (i *Attrs) getFlag(flag idFlags) bool {
 	return (i.flags & flag) == flag
 }
 
 func (i *Attrs) SetAutoName() {
 	i.setFlag(autoName)
+}
+
+func (i *Attrs) ClearAutoName() {
+	i.clearFlag(autoName)
 }
 
 func (i *Attrs) AutoName() bool {

--- a/pkg/appolly/app/svc/svc_test.go
+++ b/pkg/appolly/app/svc/svc_test.go
@@ -59,3 +59,14 @@ func TestSlogExcludesEnvVars(t *testing.T) {
 		assert.Contains(t, out, "ns/svc", name)
 	}
 }
+
+func TestAutoName_SetAndClear(t *testing.T) {
+	var a Attrs
+	assert.False(t, a.AutoName())
+
+	a.SetAutoName()
+	assert.True(t, a.AutoName())
+
+	a.ClearAutoName()
+	assert.False(t, a.AutoName())
+}

--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -217,11 +217,11 @@ func syncServiceMetadata(dst, src *exec.FileInfo) {
 	switch {
 	case srcAttrs.UID.Name != "" && !src.AutoName():
 		if dst.AutoName() || dstAttrs.UID.Name == "" {
-			dst.SetUID(srcAttrs.UID)
+			dst.SetExplicitServiceName(srcAttrs.UID.Name)
 		}
 	case dstAttrs.UID.Name != "" && !dst.AutoName():
 		if src.AutoName() || srcAttrs.UID.Name == "" {
-			src.SetUID(dstAttrs.UID)
+			src.SetExplicitServiceName(dstAttrs.UID.Name)
 		}
 	case srcAttrs.UID.Name != "" && dstAttrs.UID.Name == "":
 		dst.SetAutoServiceName(srcAttrs.UID.Name)

--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/discover/exec"
 	"go.opentelemetry.io/obi/pkg/ebpf"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/denotools"
 	"go.opentelemetry.io/obi/pkg/internal/dotnettools"
@@ -182,33 +183,74 @@ func (ta *traceAttacher) attacherLoop(_ context.Context) (swarm.RunFunc, error) 
 	}, nil
 }
 
-func (ta *traceAttacher) resolveServiceMetadata(ie *ebpf.Instrumentable) {
-	switch ie.Type {
+func (ta *traceAttacher) resolveExecutableMetadata(t svc.InstrumentableType, fi *exec.FileInfo) {
+	if fi == nil {
+		return
+	}
+	var err error
+	switch t {
 	case svc.InstrumentableJava:
-		err := jvmtools.ResolveServiceMetadata(ie.FileInfo)
-		if err != nil {
-			ta.log.Debug("unable to resolve Java service metadata", "pid", ie.FileInfo.Pid(), "error", err)
-		}
+		err = jvmtools.ResolveServiceMetadata(fi)
 	case svc.InstrumentableNodejs:
-		err := nodejstools.ResolveServiceMetadata(ie.FileInfo)
-		if err != nil {
-			ta.log.Debug("unable to resolve Node.js service metadata", "pid", ie.FileInfo.Pid(), "error", err)
-		}
+		err = nodejstools.ResolveServiceMetadata(fi)
 	case svc.InstrumentablePython:
-		err := pythontools.ResolveServiceMetadata(ie.FileInfo)
-		if err != nil {
-			ta.log.Debug("unable to resolve Python service metadata", "pid", ie.FileInfo.Pid(), "error", err)
-		}
+		err = pythontools.ResolveServiceMetadata(fi)
 	case svc.InstrumentableDotnet:
-		err := dotnettools.ResolveServiceMetadata(ie.FileInfo)
-		if err != nil {
-			ta.log.Debug("unable to resolve .NET service metadata", "pid", ie.FileInfo.Pid(), "error", err)
-		}
+		err = dotnettools.ResolveServiceMetadata(fi)
 	case svc.InstrumentableDeno:
-		err := denotools.ResolveServiceMetadata(ie.FileInfo)
-		if err != nil {
-			ta.log.Debug("unable to resolve Deno service metadata", "pid", ie.FileInfo.Pid(), "error", err)
+		err = denotools.ResolveServiceMetadata(fi)
+	}
+	if err != nil {
+		ta.log.Debug("unable to resolve service metadata", "type", t, "pid", fi.Pid(), "error", err)
+	}
+}
+
+func syncServiceMetadata(dst, src *exec.FileInfo) {
+	if dst == nil || src == nil || dst == src {
+		return
+	}
+	dstAttrs := dst.ServiceAttrs()
+	srcAttrs := src.ServiceAttrs()
+
+	// 1. Service UID name precedence: Explicit (non-auto) > auto-derived > empty
+	switch {
+	case srcAttrs.UID.Name != "" && !src.AutoName():
+		if dst.AutoName() || dstAttrs.UID.Name == "" {
+			dst.SetUID(srcAttrs.UID)
 		}
+	case dstAttrs.UID.Name != "" && !dst.AutoName():
+		if src.AutoName() || srcAttrs.UID.Name == "" {
+			src.SetUID(dstAttrs.UID)
+		}
+	case srcAttrs.UID.Name != "" && dstAttrs.UID.Name == "":
+		dst.SetAutoServiceName(srcAttrs.UID.Name)
+	case dstAttrs.UID.Name != "" && srcAttrs.UID.Name == "":
+		src.SetAutoServiceName(dstAttrs.UID.Name)
+	default:
+		// If both sides already possess distinct non-empty auto-derived names, retain each side's derivation.
+	}
+
+	// 2. Synchronize metadata attributes (e.g. service.version)
+	if len(srcAttrs.Metadata) > 0 && len(dstAttrs.Metadata) == 0 {
+		m := make(map[attr.Name]string, len(srcAttrs.Metadata))
+		for k, v := range srcAttrs.Metadata {
+			m[k] = v
+		}
+		dst.SetMetadata(m)
+	} else if len(dstAttrs.Metadata) > 0 && len(srcAttrs.Metadata) == 0 {
+		m := make(map[attr.Name]string, len(dstAttrs.Metadata))
+		for k, v := range dstAttrs.Metadata {
+			m[k] = v
+		}
+		src.SetMetadata(m)
+	}
+}
+
+func (ta *traceAttacher) resolveServiceMetadata(ie *ebpf.Instrumentable) {
+	ta.resolveExecutableMetadata(ie.Type, ie.FileInfo)
+	if source := ie.FileInfo.RuntimeMetricServiceSource(); source != nil && source != ie.FileInfo {
+		ta.resolveExecutableMetadata(ie.Type, source)
+		syncServiceMetadata(ie.FileInfo, source)
 	}
 }
 
@@ -459,11 +501,12 @@ func (ta *traceAttacher) updateTracerProbes(tracer *ebpf.ProcessTracer, ie *ebpf
 }
 
 func (ta *traceAttacher) monitorPIDs(tracer *ebpf.ProcessTracer, ie *ebpf.Instrumentable) {
-	ie.CopyToServiceAttributes()
 	serviceSource := runtimeMetricServiceSource(ie.FileInfo, ie.FileInfo)
 	if serviceSource != ie.FileInfo {
+		syncServiceMetadata(ie.FileInfo, serviceSource)
 		serviceSource.ApplyServiceDefaults(ie.Type)
 	}
+	ie.CopyToServiceAttributes()
 
 	if ta.DynamicPIDSelector != nil {
 		ta.registerDynamicFileInfo(ie)

--- a/pkg/appolly/discover/attacher.go
+++ b/pkg/appolly/discover/attacher.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	stdmaps "maps"
 	"slices"
 	"time"
 
@@ -233,15 +234,11 @@ func syncServiceMetadata(dst, src *exec.FileInfo) {
 	// 2. Synchronize metadata attributes (e.g. service.version)
 	if len(srcAttrs.Metadata) > 0 && len(dstAttrs.Metadata) == 0 {
 		m := make(map[attr.Name]string, len(srcAttrs.Metadata))
-		for k, v := range srcAttrs.Metadata {
-			m[k] = v
-		}
+		stdmaps.Copy(m, srcAttrs.Metadata)
 		dst.SetMetadata(m)
 	} else if len(dstAttrs.Metadata) > 0 && len(srcAttrs.Metadata) == 0 {
 		m := make(map[attr.Name]string, len(dstAttrs.Metadata))
-		for k, v := range dstAttrs.Metadata {
-			m[k] = v
-		}
+		stdmaps.Copy(m, dstAttrs.Metadata)
 		src.SetMetadata(m)
 	}
 }

--- a/pkg/appolly/discover/attacher_test.go
+++ b/pkg/appolly/discover/attacher_test.go
@@ -281,6 +281,7 @@ func TestSyncServiceMetadata_Precedence(t *testing.T) {
 		syncServiceMetadata(dst, src)
 
 		assert.Equal(t, "explicit-svc", dst.ServiceAttrs().UID.Name)
+		assert.False(t, dst.AutoName())
 	})
 
 	t.Run("explicit dst overrides auto src", func(t *testing.T) {
@@ -293,6 +294,7 @@ func TestSyncServiceMetadata_Precedence(t *testing.T) {
 		syncServiceMetadata(dst, src)
 
 		assert.Equal(t, "explicit-dst", src.ServiceAttrs().UID.Name)
+		assert.False(t, src.AutoName())
 	})
 
 	t.Run("explicit src overrides empty dst", func(t *testing.T) {

--- a/pkg/appolly/discover/attacher_test.go
+++ b/pkg/appolly/discover/attacher_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/appolly/services"
 	"go.opentelemetry.io/obi/pkg/ebpf"
 	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
+	attr "go.opentelemetry.io/obi/pkg/export/attributes/names"
 	"go.opentelemetry.io/obi/pkg/export/imetrics"
 	"go.opentelemetry.io/obi/pkg/internal/goexec"
 	"go.opentelemetry.io/obi/pkg/internal/testutil"
@@ -267,4 +268,129 @@ func startDeletedTyperPipeline(
 			}
 		}
 	}()
+}
+
+func TestSyncServiceMetadata_Precedence(t *testing.T) {
+	t.Run("explicit src overrides auto dst", func(t *testing.T) {
+		src := execpkg.New(execpkg.Init{
+			Service: svc.Attrs{UID: svc.UID{Name: "explicit-svc"}},
+		})
+		dst := execpkg.New(execpkg.Init{})
+		dst.SetAutoServiceName("auto-svc")
+
+		syncServiceMetadata(dst, src)
+
+		assert.Equal(t, "explicit-svc", dst.ServiceAttrs().UID.Name)
+	})
+
+	t.Run("explicit dst overrides auto src", func(t *testing.T) {
+		dst := execpkg.New(execpkg.Init{
+			Service: svc.Attrs{UID: svc.UID{Name: "explicit-dst"}},
+		})
+		src := execpkg.New(execpkg.Init{})
+		src.SetAutoServiceName("auto-src")
+
+		syncServiceMetadata(dst, src)
+
+		assert.Equal(t, "explicit-dst", src.ServiceAttrs().UID.Name)
+	})
+
+	t.Run("explicit src overrides empty dst", func(t *testing.T) {
+		src := execpkg.New(execpkg.Init{
+			Service: svc.Attrs{UID: svc.UID{Name: "explicit-src"}},
+		})
+		dst := execpkg.New(execpkg.Init{})
+
+		syncServiceMetadata(dst, src)
+
+		assert.Equal(t, "explicit-src", dst.ServiceAttrs().UID.Name)
+		assert.False(t, dst.AutoName())
+	})
+
+	t.Run("auto src propagates to empty dst", func(t *testing.T) {
+		src := execpkg.New(execpkg.Init{})
+		src.SetAutoServiceName("auto-src")
+		dst := execpkg.New(execpkg.Init{})
+
+		syncServiceMetadata(dst, src)
+
+		assert.Equal(t, "auto-src", dst.ServiceAttrs().UID.Name)
+		assert.True(t, dst.AutoName())
+	})
+
+	t.Run("auto dst propagates to empty src", func(t *testing.T) {
+		dst := execpkg.New(execpkg.Init{})
+		dst.SetAutoServiceName("auto-dst")
+		src := execpkg.New(execpkg.Init{})
+
+		syncServiceMetadata(dst, src)
+
+		assert.Equal(t, "auto-dst", src.ServiceAttrs().UID.Name)
+		assert.True(t, src.AutoName())
+	})
+
+	t.Run("distinct auto names are preserved without overwrite", func(t *testing.T) {
+		dst := execpkg.New(execpkg.Init{})
+		dst.SetAutoServiceName("auto-dst")
+		src := execpkg.New(execpkg.Init{})
+		src.SetAutoServiceName("auto-src")
+
+		syncServiceMetadata(dst, src)
+
+		assert.Equal(t, "auto-dst", dst.ServiceAttrs().UID.Name)
+		assert.Equal(t, "auto-src", src.ServiceAttrs().UID.Name)
+	})
+
+	t.Run("metadata map synchronization and isolation", func(t *testing.T) {
+		src := execpkg.New(execpkg.Init{})
+		src.SetMetadata(map[attr.Name]string{attr.Name("service.version"): "1.2.3"})
+		dst := execpkg.New(execpkg.Init{})
+
+		syncServiceMetadata(dst, src)
+
+		assert.Equal(t, "1.2.3", dst.ServiceAttrs().Metadata[attr.Name("service.version")])
+
+		// Mutating src should not mutate dst (deep copy)
+		src.SetMetadata(map[attr.Name]string{attr.Name("service.version"): "9.9.9"})
+		assert.Equal(t, "1.2.3", dst.ServiceAttrs().Metadata[attr.Name("service.version")])
+	})
+
+	t.Run("reverse metadata map synchronization", func(t *testing.T) {
+		dst := execpkg.New(execpkg.Init{})
+		dst.SetMetadata(map[attr.Name]string{attr.Name("service.version"): "2.0.0"})
+		src := execpkg.New(execpkg.Init{})
+
+		syncServiceMetadata(dst, src)
+
+		assert.Equal(t, "2.0.0", src.ServiceAttrs().Metadata[attr.Name("service.version")])
+	})
+
+	t.Run("nil and self no-op safety", func(t *testing.T) {
+		fi := execpkg.New(execpkg.Init{})
+		fi.SetAutoServiceName("test")
+		syncServiceMetadata(nil, fi)
+		syncServiceMetadata(fi, nil)
+		syncServiceMetadata(fi, fi)
+		assert.Equal(t, "test", fi.ServiceAttrs().UID.Name)
+	})
+}
+
+func TestMonitorPIDs_PropagatesNameToServiceSource(t *testing.T) {
+	parent := execpkg.New(execpkg.Init{Pid: 100, CmdExePath: "/usr/bin/python3.14"})
+	worker := execpkg.New(execpkg.Init{Pid: 101, Ppid: 100, Ns: 17, CmdExePath: "/usr/bin/python3.14"})
+	worker.SetRuntimeMetricServiceSource(parent)
+	worker.SetAutoServiceName("main_ssl")
+
+	program := &recordingTracer{}
+	tracer := &ebpf.ProcessTracer{Programs: []ebpf.Tracer{program}}
+
+	(&traceAttacher{}).monitorPIDs(tracer, &ebpf.Instrumentable{
+		Type: svc.InstrumentablePython, FileInfo: worker,
+	})
+
+	// Parent should receive main_ssl from worker before applying defaults,
+	// rather than falling back to python3.14.
+	assert.Equal(t, "main_ssl", parent.ServiceAttrs().UID.Name)
+	assert.Equal(t, "main_ssl", worker.ServiceAttrs().UID.Name)
+	assert.Equal(t, svc.InstrumentablePython, parent.SDKLanguage())
 }

--- a/pkg/appolly/discover/exec/file.go
+++ b/pkg/appolly/discover/exec/file.go
@@ -223,6 +223,16 @@ func (fi *FileInfo) SetHostName(h string) {
 	fi.service.HostName = h
 }
 
+// SetExplicitServiceName sets a name that was explicitly configured (not
+// auto-derived), clearing any prior auto-name flag so later auto-name
+// propagation (e.g. k8s decoration) does not silently override it.
+func (fi *FileInfo) SetExplicitServiceName(name string) {
+	fi.mu.Lock()
+	defer fi.mu.Unlock()
+	fi.service.UID.Name = name
+	fi.service.ClearAutoName()
+}
+
 func (fi *FileInfo) SetAutoServiceName(name string) {
 	fi.mu.Lock()
 	defer fi.mu.Unlock()

--- a/pkg/appolly/discover/typer.go
+++ b/pkg/appolly/discover/typer.go
@@ -33,6 +33,9 @@ import (
 	"go.opentelemetry.io/obi/pkg/pipe/swarm/swarms"
 )
 
+// Swappable in tests so typer tests don't depend on /proc inspections.
+var findProcLanguage = procs.FindProcLanguage
+
 type cacheKey struct {
 	Dev uint64
 	Ino uint64
@@ -261,9 +264,17 @@ func (t *typer) asInstrumentable(execElf *exec.FileInfo) ebpf.Instrumentable {
 	log := t.log.With("pid", execElf.Pid(), "comm", execElf.CmdExePath())
 	if ic, ok := t.instrumentableCache.Get(cacheKey{Dev: execElf.Dev(), Ino: execElf.Ino()}); ok {
 		log.Debug("new instance of existing executable", "type", ic.Type)
-		if parent, ok := t.currentPids[execElf.Ppid()]; ok && ic.Type == svc.InstrumentablePython &&
-			execElf.CmdExePath() == parent.CmdExePath() {
-			execElf.SetRuntimeMetricServiceSource(parent)
+		if ic.Type == svc.InstrumentablePython {
+			ancestor := execElf
+			parent, ok := t.currentPids[ancestor.Ppid()]
+			for ok && ancestor.Ppid() != ancestor.Pid() &&
+				ancestor.CmdExePath() == parent.CmdExePath() {
+				ancestor = parent
+				parent, ok = t.currentPids[ancestor.Ppid()]
+			}
+			if ancestor != execElf {
+				execElf.SetRuntimeMetricServiceSource(ancestor)
+			}
 		}
 		return ebpf.Instrumentable{Type: ic.Type, FileInfo: execElf, Offsets: ic.Offsets, InstrumentationError: ic.InstrumentationError}
 	}
@@ -306,7 +317,7 @@ func (t *typer) asInstrumentable(execElf *exec.FileInfo) ebpf.Instrumentable {
 	// Typer finds the executable type again. The language decorator can skip certain type detection,
 	// for example, it will skip Linux system services. If the selection criteria brought us here on
 	// executable path, open port, we respect that choice and find the language for the pipeline.
-	detectedType := procs.FindProcLanguage(execElf.Pid())
+	detectedType := findProcLanguage(execElf.Pid())
 
 	if !t.cfg.Discovery.SkipGoSpecificTracers && detectedType == svc.InstrumentableGolang && err == nil {
 		log.Warn("ELF binary appears to be a Go program, but no offsets were found",

--- a/pkg/appolly/discover/typer_test.go
+++ b/pkg/appolly/discover/typer_test.go
@@ -425,3 +425,86 @@ func TestAsInstrumentable_CachedPythonWorkerUsesParentServiceSource(t *testing.T
 	assert.Same(t, parent, worker.RuntimeMetricServiceSource())
 	assert.Empty(t, instrumentable.ChildPids)
 }
+
+func TestAsInstrumentable_CachedPythonWorkerWalksAncestors(t *testing.T) {
+	instrumentableCache, err := lru.New[cacheKey, instrumentedExecutable](100)
+	require.NoError(t, err)
+
+	grandparent := exec.New(exec.Init{
+		Pid: 100, Dev: 42, Ino: 15, CmdExePath: "/usr/bin/python",
+	})
+	parent := exec.New(exec.Init{
+		Pid: 101, Ppid: 100, Dev: 42, Ino: 15, CmdExePath: "/usr/bin/python",
+	})
+	worker := exec.New(exec.Init{
+		Pid: 102, Ppid: 101, Dev: 42, Ino: 15, CmdExePath: "/usr/bin/python",
+	})
+	instrumentableCache.Add(cacheKey{Dev: worker.Dev(), Ino: worker.Ino()}, instrumentedExecutable{
+		Type: svc.InstrumentablePython,
+	})
+	ty := typer{
+		log: slog.Default(),
+		currentPids: map[app.PID]*exec.FileInfo{
+			grandparent.Pid(): grandparent,
+			parent.Pid():      parent,
+			worker.Pid():      worker,
+		},
+		instrumentableCache: instrumentableCache,
+	}
+
+	instrumentable := ty.asInstrumentable(worker)
+
+	assert.Same(t, worker, instrumentable.FileInfo)
+	assert.Same(t, grandparent, worker.RuntimeMetricServiceSource())
+	assert.Empty(t, instrumentable.ChildPids)
+
+	// Non-Python cached executables do not trigger ancestor wiring.
+	golangWorker := exec.New(exec.Init{
+		Pid: 202, Ppid: 101, Dev: 43, Ino: 16, CmdExePath: "/usr/bin/goapp",
+	})
+	instrumentableCache.Add(cacheKey{Dev: golangWorker.Dev(), Ino: golangWorker.Ino()}, instrumentedExecutable{
+		Type: svc.InstrumentableGolang,
+	})
+	golangInstrumentable := ty.asInstrumentable(golangWorker)
+	assert.Same(t, golangWorker, golangInstrumentable.FileInfo)
+	assert.Nil(t, golangWorker.RuntimeMetricServiceSource())
+}
+
+func TestAsInstrumentable_UncachedPythonWorkerPreservesLogEnricherEnabled(t *testing.T) {
+	origFindProcLanguage := findProcLanguage
+	findProcLanguage = func(_ app.PID) svc.InstrumentableType {
+		return svc.InstrumentablePython
+	}
+	defer func() { findProcLanguage = origFindProcLanguage }()
+
+	instrumentableCache, err := lru.New[cacheKey, instrumentedExecutable](100)
+	require.NoError(t, err)
+
+	master := exec.New(exec.Init{
+		Pid: 100, Dev: 42, Ino: 15, CmdExePath: "/usr/bin/python",
+		Service: svc.Attrs{LogEnricherEnabled: false},
+	})
+	worker := exec.New(exec.Init{
+		Pid: 101, Ppid: 100, Dev: 42, Ino: 15, CmdExePath: "/usr/bin/python",
+		Service: svc.Attrs{LogEnricherEnabled: true},
+	})
+
+	ty := typer{
+		log: slog.Default(),
+		cfg: &obi.Config{
+			Discovery: services.DiscoveryConfig{SkipGoSpecificTracers: true},
+		},
+		currentPids: map[app.PID]*exec.FileInfo{
+			master.Pid(): master,
+			worker.Pid(): worker,
+		},
+		instrumentableCache: instrumentableCache,
+	}
+
+	instrumentable := ty.asInstrumentable(worker)
+
+	assert.Equal(t, svc.InstrumentablePython, instrumentable.Type)
+	assert.Same(t, worker, instrumentable.FileInfo)
+	assert.Same(t, master, worker.RuntimeMetricServiceSource())
+	assert.True(t, instrumentable.LogEnricherEnabled)
+}


### PR DESCRIPTION
A gunicorn master and its workers all match the open port criterion, so which one discovery sees first is a race. When a worker is discovered before the master, only the worker's own service metadata gets resolved. The master never does, so it falls back to its executable name (python3.14) instead of the real service name (main_ssl). This is what made TestSuite_PythonSQLSSL flaky.

Fix has two parts:

In typer.go, the cached path now walks up the process tree the same way the uncached path already did, still scoped to Python only, so a worker discovered later still finds the right ancestor to link its RuntimeMetricServiceSource to.

In attacher.go, resolveServiceMetadata now also resolves metadata on that RuntimeMetricServiceSource target directly, and syncServiceMetadata propagates a resolved name between worker and master in whichever direction it's missing, before ApplyServiceDefaults can lock in the executable-name fallback. Explicit names always win over auto-derived ones.

Also dropped Dockerfile_ssl to a single worker for deterministic tests, and deleted ssl_server.sh, an unused script that wasn't wired into any Dockerfile or compose file.

Validation: go build, go vet and go test all clean on pkg/appolly/discover, including new tests covering the sync precedence rules, the ancestor walk on the cached path, and the exact main_ssl vs python3.14 regression. pythontools tests unaffected. gofmt clean.

Fixes #3289. Fixes #3290.
