### PR TITLE
fix TestSuite_PythonSQLSSL

### DIFF
--- a/internal/test/integration/docker-compose-python-sql-ssl.yml
+++ b/internal/test/integration/docker-compose-python-sql-ssl.yml
@@ -17,6 +17,12 @@ services:
       context: ../../../internal/test/integration/components/pythonsql/
       dockerfile: Dockerfile_ssl
     image: hatest-testserver-python-sql
+    # gunicorn serves this app from a master and three uvicorn workers. OBI
+    # resolves the Python service name per PID and does not settle on the same
+    # name for every one of them, so an auto-derived name is not stable here.
+    # Pin it so the Jaeger assertions query a fixed service.
+    environment:
+      OTEL_SERVICE_NAME: main_ssl
     ports:
       - "${TEST_SERVICE_PORTS}"
     depends_on:


### PR DESCRIPTION
## Summary

`TestSuite_PythonSQLSSL` fails on `main`, sometimes retries solve it. The suite's app is served by a gunicorn master and three uvicorn workers, and OBI does not resolve the same Python service name for every one of those PIDs: spans from one run carry both `main_ssl` and `python3.14`.

Pinning `OTEL_SERVICE_NAME` on the test app gives the suite a fixed service to query. The underlying inconsistency in per-PID Python service-name resolution is a separate issue and is not addressed here.

## Validation

Ran the suite's compose directly and compared the service names OBI emitted, before and after:

| | before | after |
| --- | --- | --- |
| service names emitted | 5x `main_ssl`, 8x `python3.14` | 13x `main_ssl` |
| services in Jaeger | `python3.14` | `main_ssl` |
| `?service=main_ssl&operation=SELECT accounting.contacts` | 0 traces | 3 traces |

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
