### PR TITLE
Remove mcp from genai metric + test MCP client

### DIFF
--- a/internal/test/integration/components/pythonmcp/main.py
+++ b/internal/test/integration/components/pythonmcp/main.py
@@ -5,6 +5,10 @@ Uses the official MCP Python SDK (https://github.com/modelcontextprotocol/python
 to exercise a real end-to-end MCP stack over Streamable HTTP.
 """
 
+import os
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
 from mcp.server.fastmcp import FastMCP
 
 mcp = FastMCP(
@@ -37,6 +41,33 @@ def read_report() -> str:
 def analyze_code() -> str:
     """Code analysis prompt."""
     return "Analyze this code"
+
+
+# Calling out to a second MCP server makes this process an MCP *client* as
+# well as a server, which is what produces a client-kind MCP span.
+REMOTE_MCP_URL = os.environ.get("REMOTE_MCP_URL", "http://mcpremote:8080/mcp")
+
+
+@mcp.tool(name="remote-weather", description="Get weather from a remote MCP server")
+async def remote_weather() -> str:
+    """Calls get-weather on the remote MCP server and returns its answer."""
+    async with streamablehttp_client(REMOTE_MCP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool("get-weather", {})
+            return result.content[0].text if result.content else ""
+
+
+@mcp.tool(name="remote-report", description="Read a report from a remote MCP server")
+async def remote_report() -> str:
+    """Reads a resource from the remote MCP server and returns its content."""
+    async with streamablehttp_client(REMOTE_MCP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.read_resource(
+                "file:///home/user/documents/report.pdf"
+            )
+            return result.contents[0].text if result.contents else ""
 
 
 if __name__ == "__main__":

--- a/internal/test/integration/docker-compose-python-mcp.yml
+++ b/internal/test/integration/docker-compose-python-mcp.yml
@@ -8,9 +8,21 @@ services:
     image: hatest-testserver-python-mcp
     ports:
       - "${TEST_SERVICE_PORTS}"
+    environment:
+      REMOTE_MCP_URL: "http://mcpremote:8080/mcp"
     depends_on:
       otelcol:
         condition: service_started
+      mcpremote:
+        condition: service_started
+
+  # A second MCP server the instrumented one calls out to, so the same process
+  # produces client-kind MCP spans as well as server-kind ones.
+  mcpremote:
+    build:
+      context: ../../../internal/test/integration/components/pythonmcp/
+      dockerfile: Dockerfile
+    image: hatest-testserver-python-mcp
 
   obi:
     build:

--- a/internal/test/integration/red_test_python_mcp.go
+++ b/internal/test/integration/red_test_python_mcp.go
@@ -246,3 +246,117 @@ func testPythonMCPInitialize(t *testing.T) {
 		assert.Empty(ct, sd, sd.String())
 	}, testTimeout, 100*time.Millisecond)
 }
+
+// testPythonMCPClient drives the instrumented server to call a second MCP
+// server, so OBI observes the outbound side of an MCP exchange. The tests above
+// only ever produce server-kind spans; this is what exercises the client-kind
+// MCP span and the peer attributes that come with it.
+func testPythonMCPClient(t *testing.T) {
+	const (
+		comm    = "python3.14"
+		address = "http://localhost:8381/mcp"
+	)
+
+	sessionID := mcpInitSession(t, address)
+
+	var tq jaeger.TracesQuery
+	params := neturl.Values{}
+	params.Add("service", comm)
+	// The outbound call the tool makes, named after the tool it invokes on the
+	// remote server. Scoping the query to it keeps the server-side traces the
+	// retry loop generates from filling the result page.
+	params.Add("operation", "execute_tool get-weather")
+	fullJaegerURL := fmt.Sprintf("%s?%s", jaegerQueryURL, params.Encode())
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := mcpCall(address, "tools/call", 10,
+			map[string]any{"name": "remote-weather", "arguments": map[string]any{}},
+			"Mcp-Session-Id", sessionID)
+		require.NoError(ct, err)
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		resp.Body.Close()
+
+		resp, err = http.Get(fullJaegerURL) //nolint:noctx
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+
+		// The remote-weather tool calls get-weather on the remote server, so the
+		// outbound tools/call is the client-kind span we are after.
+		var clientSpans []jaeger.Span
+		for _, trace := range tq.Data {
+			clientSpans = append(clientSpans,
+				trace.FindByOperationNameServiceAndKind("execute_tool get-weather", comm, "client")...)
+		}
+		require.NotEmpty(ct, clientSpans, "no client-kind MCP span found")
+
+		span := clientSpans[0]
+		sd := span.Diff(
+			jaeger.Tag{Key: "mcp.method.name", Type: "string", Value: "tools/call"},
+			jaeger.Tag{Key: "gen_ai.operation.name", Type: "string", Value: "execute_tool"},
+			jaeger.Tag{Key: "gen_ai.tool.name", Type: "string", Value: "get-weather"},
+			jaeger.Tag{Key: "span.kind", Type: "string", Value: "client"},
+		)
+		assert.Empty(ct, sd, sd.String())
+
+		// The peer is the remote MCP server, not this process.
+		peer, ok := jaeger.FindIn(span.Tags, "server.address")
+		assert.True(ct, ok, "client span must name the remote server")
+		assert.NotEmpty(ct, peer.Value)
+	}, testTimeout, 500*time.Millisecond)
+}
+
+// testPythonMCPClientResource covers the resource side of the client exchange:
+// reading a resource from the remote server is what carries mcp.resource.uri.
+func testPythonMCPClientResource(t *testing.T) {
+	const (
+		comm    = "python3.14"
+		address = "http://localhost:8381/mcp"
+	)
+
+	sessionID := mcpInitSession(t, address)
+
+	var tq jaeger.TracesQuery
+	params := neturl.Values{}
+	params.Add("service", comm)
+	params.Add("operation", "resources/read")
+	fullJaegerURL := fmt.Sprintf("%s?%s", jaegerQueryURL, params.Encode())
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := mcpCall(address, "tools/call", 20,
+			map[string]any{"name": "remote-report", "arguments": map[string]any{}},
+			"Mcp-Session-Id", sessionID)
+		require.NoError(ct, err)
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		resp.Body.Close()
+
+		resp, err = http.Get(fullJaegerURL) //nolint:noctx
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+
+		var clientSpans []jaeger.Span
+		for _, trace := range tq.Data {
+			clientSpans = append(clientSpans,
+				trace.FindByOperationNameServiceAndKind("resources/read", comm, "client")...)
+		}
+		require.NotEmpty(ct, clientSpans, "no client-kind resource read span found")
+
+		span := clientSpans[0]
+		sd := span.Diff(
+			jaeger.Tag{Key: "mcp.method.name", Type: "string", Value: "resources/read"},
+			jaeger.Tag{
+				Key: "mcp.resource.uri", Type: "string",
+				Value: "file:///home/user/documents/report.pdf",
+			},
+			jaeger.Tag{Key: "span.kind", Type: "string", Value: "client"},
+		)
+		assert.Empty(ct, sd, sd.String())
+	}, testTimeout, 500*time.Millisecond)
+}

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -972,6 +972,8 @@ func TestSuite_PythonMCP(t *testing.T) {
 	require.NoError(t, compose.Up())
 	t.Run("Python MCP server span", testPythonMCPServer)
 	t.Run("Python MCP initialize", testPythonMCPInitialize)
+	t.Run("Python MCP client span", testPythonMCPClient)
+	t.Run("Python MCP client resource span", testPythonMCPClientResource)
 	runWeaverValidation(t)
 	require.NoError(t, compose.Close())
 }

--- a/pkg/appolly/app/request/genai_subtype_test.go
+++ b/pkg/appolly/app/request/genai_subtype_test.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package request
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMCPIsNotRecordedOnTheGenAIMetrics(t *testing.T) {
+	assert.False(t, IsGenAISubtype(HTTPSubtypeMCP))
+}
+
+func TestGenAIProvidersAreRecordedOnTheGenAIMetrics(t *testing.T) {
+	for _, subtype := range []int{
+		HTTPSubtypeOpenAI,
+		HTTPSubtypeAnthropic,
+		HTTPSubtypeGemini,
+		HTTPSubtypeQwen,
+		HTTPSubtypeAWSBedrock,
+		HTTPSubtypeEmbedding,
+		HTTPSubtypeRerank,
+		HTTPSubtypeRetrieval,
+		HTTPSubtypeOpenAICompatible,
+		HTTPSubtypeOllama,
+	} {
+		assert.True(t, IsGenAISubtype(subtype), "subtype %d", subtype)
+	}
+}

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -118,13 +118,17 @@ const (
 	HTTPSubtypeOllama           = 17 // http + Ollama native API
 )
 
+// IsGenAISubtype reports whether a subtype is recorded on the GenAI client
+// metrics. MCP is deliberately absent: it is a tool and resource protocol
+// rather than a model provider, so it has no `gen_ai.provider.name` to report,
+// and semantic conventions give it its own `mcp.client.*` / `mcp.server.*`
+// metrics. Its spans still carry the GenAI attributes it does define.
 func IsGenAISubtype(subtype int) bool {
 	return subtype == HTTPSubtypeOpenAI ||
 		subtype == HTTPSubtypeAnthropic ||
 		subtype == HTTPSubtypeGemini ||
 		subtype == HTTPSubtypeQwen ||
 		subtype == HTTPSubtypeAWSBedrock ||
-		subtype == HTTPSubtypeMCP ||
 		subtype == HTTPSubtypeEmbedding ||
 		subtype == HTTPSubtypeRerank ||
 		subtype == HTTPSubtypeRetrieval ||

--- a/pkg/ebpf/common/http/mcp_test.go
+++ b/pkg/ebpf/common/http/mcp_test.go
@@ -449,7 +449,3 @@ func TestMCPCall_OperationName(t *testing.T) {
 		})
 	}
 }
-
-func TestIsGenAISubtype_MCP(t *testing.T) {
-	assert.True(t, request.IsGenAISubtype(request.HTTPSubtypeMCP))
-}


### PR DESCRIPTION
## Summary

MCP client spans were never tested and weaver never validated their shape. The MCP suite app now also acts as an MCP client against a second MCP server in the same compose.

An issue came up from this. MCP was recorded on the GenAI client metrics, but it reports no `gen_ai.provider.name`, which those metrics require, so every MCP client call emitted `gen_ai.client.operation.duration` with two required attributes missing. MCP is a tool and resource protocol rather than a model provider, and semantic conventions give it its own `mcp.client.*` metrics (which could be added in a seperate PR), so it is no longer recorded on the GenAI metrics. Its spans keep the GenAI attributes it does define, and it still records the HTTP client metrics. Only the metric routing changes: the predicate is used in the two GenAI metric emitters and nowhere on the span path.

Two subtests cover the outbound side: a `tools/call` that invokes a tool on the remote server, and a `resources/read` that reads a resource from it.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
