### PR TITLE
pkg/docker: avoid repeated container lookups for host processes

### DIFF
--- a/pkg/docker/docker_api_client.go
+++ b/pkg/docker/docker_api_client.go
@@ -27,6 +27,8 @@ import (
 
 const (
 	composeServiceLabelKey = "com.docker.compose.service"
+	// Bound repeated procfs scans for non-container PIDs without caching a negative result for the process lifetime.
+	containerNotFoundRetryInterval = time.Second
 	// abbreviationLength defines the length for the short ID form
 	abbreviationLength = 12
 )
@@ -77,9 +79,10 @@ type ContainerStore struct {
 	watcherStarted sync.Once
 	watcherRunning atomic.Bool
 
-	cacheMu       sync.RWMutex
-	byPID         map[app.PID]ContainerMeta
-	byContainerID map[ContainerID]containerEntry // metadata + PIDs keyed by full container ID
+	cacheMu                sync.RWMutex
+	byPID                  map[app.PID]ContainerMeta
+	byContainerID          map[ContainerID]containerEntry // metadata + PIDs keyed by full container ID
+	notContainerUntilByPID map[app.PID]time.Time
 
 	// lastEventAt is the Unix timestamp (seconds) of the last processed Docker event.
 	// It is seeded to the start time of watchContainerEvents and updated on each event,
@@ -90,9 +93,10 @@ type ContainerStore struct {
 
 func NewStore() *ContainerStore {
 	return &ContainerStore{
-		log:           cmlog(),
-		byPID:         make(map[app.PID]ContainerMeta),
-		byContainerID: make(map[ContainerID]containerEntry),
+		log:                    cmlog(),
+		byPID:                  make(map[app.PID]ContainerMeta),
+		byContainerID:          make(map[ContainerID]containerEntry),
+		notContainerUntilByPID: make(map[app.PID]time.Time),
 	}
 }
 
@@ -137,9 +141,36 @@ func (s *ContainerStore) ContainerInfo(ctx context.Context, pid app.PID) (Contai
 		s.cacheMu.RUnlock()
 		return ci, true
 	}
+	retryAt, notContainer := s.notContainerUntilByPID[pid]
 	s.cacheMu.RUnlock()
+	if notContainer {
+		if time.Now().Before(retryAt) {
+			return ContainerMeta{}, false
+		}
+		s.cacheMu.Lock()
+		if retryAt, ok := s.notContainerUntilByPID[pid]; ok {
+			if time.Now().Before(retryAt) {
+				s.cacheMu.Unlock()
+				return ContainerMeta{}, false
+			}
+			delete(s.notContainerUntilByPID, pid)
+		}
+		s.cacheMu.Unlock()
+	}
 
 	osCntInfo, err := osInfoForPID(pid)
+	if errors.Is(err, container.ErrContainerNotFound) {
+		s.cacheMu.Lock()
+		retryAt := s.notContainerUntilByPID[pid]
+		if _, ok := s.byPID[pid]; !ok && !time.Now().Before(retryAt) {
+			// InvalidatePID may have run while the first lookup was in flight.
+			_, currentErr := osInfoForPID(pid)
+			if errors.Is(currentErr, container.ErrContainerNotFound) {
+				s.notContainerUntilByPID[pid] = time.Now().Add(containerNotFoundRetryInterval)
+			}
+		}
+		s.cacheMu.Unlock()
+	}
 	if err != nil {
 		s.log.Debug("failed to get OS container info for pid", "pid", pid, "error", err)
 		return ContainerMeta{}, false
@@ -164,6 +195,7 @@ func (s *ContainerStore) ContainerInfo(ctx context.Context, pid app.PID) (Contai
 			s.byContainerID[fullContainerID] = entry
 		}
 		s.byPID[pid] = meta
+		delete(s.notContainerUntilByPID, pid)
 		s.cacheMu.Unlock()
 		return meta, true
 	}
@@ -214,11 +246,13 @@ func (s *ContainerStore) ContainerInfo(ctx context.Context, pid app.PID) (Contai
 		}
 		s.byPID[pid] = meta
 		s.byContainerID[meta.FullID] = entry
+		delete(s.notContainerUntilByPID, pid)
 		s.cacheMu.Unlock()
 		return meta, true
 	}
 	s.byPID[pid] = meta
 	s.byContainerID[meta.FullID] = containerEntry{meta: meta, pids: []app.PID{pid}}
+	delete(s.notContainerUntilByPID, pid)
 	s.cacheMu.Unlock()
 
 	return meta, true
@@ -357,6 +391,7 @@ func (s *ContainerStore) eventsLoop(ctx context.Context, fltrs client.Filters, s
 func (s *ContainerStore) InvalidatePID(pid app.PID) {
 	s.cacheMu.Lock()
 	defer s.cacheMu.Unlock()
+	delete(s.notContainerUntilByPID, pid)
 
 	meta, ok := s.byPID[pid]
 	if !ok {

--- a/pkg/docker/docker_api_client.go
+++ b/pkg/docker/docker_api_client.go
@@ -79,10 +79,10 @@ type ContainerStore struct {
 	watcherStarted sync.Once
 	watcherRunning atomic.Bool
 
-	cacheMu                sync.RWMutex
-	byPID                  map[app.PID]ContainerMeta
-	byContainerID          map[ContainerID]containerEntry // metadata + PIDs keyed by full container ID
-	notContainerUntilByPID map[app.PID]time.Time
+	cacheMu                       sync.RWMutex
+	byPID                         map[app.PID]ContainerMeta
+	byContainerID                 map[ContainerID]containerEntry // metadata + PIDs keyed by full container ID
+	containerNotFoundRetryAtByPID map[app.PID]time.Time
 
 	// lastEventAt is the Unix timestamp (seconds) of the last processed Docker event.
 	// It is seeded to the start time of watchContainerEvents and updated on each event,
@@ -93,10 +93,10 @@ type ContainerStore struct {
 
 func NewStore() *ContainerStore {
 	return &ContainerStore{
-		log:                    cmlog(),
-		byPID:                  make(map[app.PID]ContainerMeta),
-		byContainerID:          make(map[ContainerID]containerEntry),
-		notContainerUntilByPID: make(map[app.PID]time.Time),
+		log:                           cmlog(),
+		byPID:                         make(map[app.PID]ContainerMeta),
+		byContainerID:                 make(map[ContainerID]containerEntry),
+		containerNotFoundRetryAtByPID: make(map[app.PID]time.Time),
 	}
 }
 
@@ -141,19 +141,19 @@ func (s *ContainerStore) ContainerInfo(ctx context.Context, pid app.PID) (Contai
 		s.cacheMu.RUnlock()
 		return ci, true
 	}
-	retryAt, notContainer := s.notContainerUntilByPID[pid]
+	retryAt, notContainer := s.containerNotFoundRetryAtByPID[pid]
 	s.cacheMu.RUnlock()
 	if notContainer {
 		if time.Now().Before(retryAt) {
 			return ContainerMeta{}, false
 		}
 		s.cacheMu.Lock()
-		if retryAt, ok := s.notContainerUntilByPID[pid]; ok {
+		if retryAt, ok := s.containerNotFoundRetryAtByPID[pid]; ok {
 			if time.Now().Before(retryAt) {
 				s.cacheMu.Unlock()
 				return ContainerMeta{}, false
 			}
-			delete(s.notContainerUntilByPID, pid)
+			delete(s.containerNotFoundRetryAtByPID, pid)
 		}
 		s.cacheMu.Unlock()
 	}
@@ -161,12 +161,12 @@ func (s *ContainerStore) ContainerInfo(ctx context.Context, pid app.PID) (Contai
 	osCntInfo, err := osInfoForPID(pid)
 	if errors.Is(err, container.ErrContainerNotFound) {
 		s.cacheMu.Lock()
-		retryAt := s.notContainerUntilByPID[pid]
+		retryAt := s.containerNotFoundRetryAtByPID[pid]
 		if _, ok := s.byPID[pid]; !ok && !time.Now().Before(retryAt) {
 			// InvalidatePID may have run while the first lookup was in flight.
 			_, currentErr := osInfoForPID(pid)
 			if errors.Is(currentErr, container.ErrContainerNotFound) {
-				s.notContainerUntilByPID[pid] = time.Now().Add(containerNotFoundRetryInterval)
+				s.containerNotFoundRetryAtByPID[pid] = time.Now().Add(containerNotFoundRetryInterval)
 			}
 		}
 		s.cacheMu.Unlock()
@@ -195,7 +195,7 @@ func (s *ContainerStore) ContainerInfo(ctx context.Context, pid app.PID) (Contai
 			s.byContainerID[fullContainerID] = entry
 		}
 		s.byPID[pid] = meta
-		delete(s.notContainerUntilByPID, pid)
+		delete(s.containerNotFoundRetryAtByPID, pid)
 		s.cacheMu.Unlock()
 		return meta, true
 	}
@@ -246,13 +246,13 @@ func (s *ContainerStore) ContainerInfo(ctx context.Context, pid app.PID) (Contai
 		}
 		s.byPID[pid] = meta
 		s.byContainerID[meta.FullID] = entry
-		delete(s.notContainerUntilByPID, pid)
+		delete(s.containerNotFoundRetryAtByPID, pid)
 		s.cacheMu.Unlock()
 		return meta, true
 	}
 	s.byPID[pid] = meta
 	s.byContainerID[meta.FullID] = containerEntry{meta: meta, pids: []app.PID{pid}}
-	delete(s.notContainerUntilByPID, pid)
+	delete(s.containerNotFoundRetryAtByPID, pid)
 	s.cacheMu.Unlock()
 
 	return meta, true
@@ -391,7 +391,7 @@ func (s *ContainerStore) eventsLoop(ctx context.Context, fltrs client.Filters, s
 func (s *ContainerStore) InvalidatePID(pid app.PID) {
 	s.cacheMu.Lock()
 	defer s.cacheMu.Unlock()
-	delete(s.notContainerUntilByPID, pid)
+	delete(s.containerNotFoundRetryAtByPID, pid)
 
 	meta, ok := s.byPID[pid]
 	if !ok {

--- a/pkg/docker/docker_api_client_test.go
+++ b/pkg/docker/docker_api_client_test.go
@@ -10,7 +10,9 @@ import (
 	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	containerTypes "github.com/moby/moby/api/types/container"
@@ -135,14 +137,169 @@ func TestContainerInfo(t *testing.T) {
 		s := NewStore()
 		s.docker = eofMock()
 
+		calls := 0
 		orig := osInfoForPID
 		osInfoForPID = func(_ app.PID) (container.Info, error) {
+			calls++
 			return container.Info{}, errors.New("no cgroup")
 		}
 		defer func() { osInfoForPID = orig }()
 
-		_, ok := s.ContainerInfo(context.Background(), app.PID(1))
+		_, firstOK := s.ContainerInfo(context.Background(), app.PID(1))
+		_, secondOK := s.ContainerInfo(context.Background(), app.PID(1))
+		assert.False(t, firstOK)
+		assert.False(t, secondOK)
+		assert.Equal(t, 2, calls, "errors other than ErrContainerNotFound must not be cached")
+	})
+
+	t.Run("container_not_found_is_cached_until_retry_interval", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			s := NewStore()
+			s.docker = &mockDockerClient{
+				inspectResult: client.ContainerInspectResult{
+					Container: containerTypes.InspectResponse{ID: fullID, Name: "/my-container"},
+				},
+			}
+
+			calls := 0
+			found := false
+			orig := osInfoForPID
+			osInfoForPID = func(_ app.PID) (container.Info, error) {
+				calls++
+				if !found {
+					return container.Info{}, container.ErrContainerNotFound
+				}
+				return container.Info{ContainerID: fullID}, nil
+			}
+			defer func() { osInfoForPID = orig }()
+
+			pid := app.PID(1)
+			_, firstOK := s.ContainerInfo(context.Background(), pid)
+			_, cachedOK := s.ContainerInfo(context.Background(), pid)
+			assert.False(t, firstOK)
+			assert.False(t, cachedOK)
+			assert.Equal(t, 2, calls)
+
+			time.Sleep(containerNotFoundRetryInterval / 2)
+			_, laterCachedOK := s.ContainerInfo(context.Background(), pid)
+			assert.False(t, laterCachedOK)
+			assert.Equal(t, 2, calls)
+
+			found = true
+			time.Sleep(containerNotFoundRetryInterval / 2)
+
+			got, retriedOK := s.ContainerInfo(context.Background(), pid)
+			require.True(t, retriedOK)
+			assert.Equal(t, ContainerID(fullID), got.FullID)
+			assert.Equal(t, 4, calls)
+			s.cacheMu.RLock()
+			_, negativelyCached := s.notContainerUntilByPID[pid]
+			s.cacheMu.RUnlock()
+			assert.False(t, negativelyCached)
+		})
+	})
+
+	t.Run("expired_container_not_found_entry_is_removed_when_retry_fails", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			s := NewStore()
+			s.docker = eofMock()
+
+			lookupErr := container.ErrContainerNotFound
+			orig := osInfoForPID
+			osInfoForPID = func(_ app.PID) (container.Info, error) {
+				return container.Info{}, lookupErr
+			}
+			defer func() { osInfoForPID = orig }()
+
+			pid := app.PID(1)
+			_, ok := s.ContainerInfo(context.Background(), pid)
+			assert.False(t, ok)
+			s.cacheMu.RLock()
+			_, negativelyCached := s.notContainerUntilByPID[pid]
+			s.cacheMu.RUnlock()
+			require.True(t, negativelyCached)
+
+			time.Sleep(containerNotFoundRetryInterval)
+			lookupErr = errors.New("no cgroup")
+			_, ok = s.ContainerInfo(context.Background(), pid)
+			assert.False(t, ok)
+
+			s.cacheMu.RLock()
+			_, negativelyCached = s.notContainerUntilByPID[pid]
+			s.cacheMu.RUnlock()
+			assert.False(t, negativelyCached)
+		})
+	})
+
+	t.Run("invalidate_pid_clears_container_not_found_cache", func(t *testing.T) {
+		s := NewStore()
+		s.docker = &mockDockerClient{
+			inspectResult: client.ContainerInspectResult{
+				Container: containerTypes.InspectResponse{ID: fullID, Name: "/my-container"},
+			},
+		}
+
+		found := false
+		orig := osInfoForPID
+		osInfoForPID = func(_ app.PID) (container.Info, error) {
+			if !found {
+				return container.Info{}, container.ErrContainerNotFound
+			}
+			return container.Info{ContainerID: fullID}, nil
+		}
+		defer func() { osInfoForPID = orig }()
+
+		pid := app.PID(1)
+		_, ok := s.ContainerInfo(context.Background(), pid)
 		assert.False(t, ok)
+
+		found = true
+		s.InvalidatePID(pid)
+
+		got, ok := s.ContainerInfo(context.Background(), pid)
+		require.True(t, ok)
+		assert.Equal(t, ContainerID(fullID), got.FullID)
+	})
+
+	t.Run("invalidation_during_lookup_does_not_restore_container_not_found_cache", func(t *testing.T) {
+		s := NewStore()
+		s.docker = &mockDockerClient{
+			inspectResult: client.ContainerInspectResult{
+				Container: containerTypes.InspectResponse{ID: fullID, Name: "/my-container"},
+			},
+		}
+
+		pid := app.PID(1)
+		lookupStarted := make(chan struct{})
+		releaseLookup := make(chan struct{})
+		var calls atomic.Int32
+
+		orig := osInfoForPID
+		osInfoForPID = func(_ app.PID) (container.Info, error) {
+			if calls.Add(1) == 1 {
+				close(lookupStarted)
+				<-releaseLookup
+				return container.Info{}, container.ErrContainerNotFound
+			}
+
+			return container.Info{ContainerID: fullID}, nil
+		}
+		defer func() { osInfoForPID = orig }()
+
+		firstLookupResult := make(chan bool, 1)
+		go func() {
+			_, ok := s.ContainerInfo(context.Background(), pid)
+			firstLookupResult <- ok
+		}()
+
+		<-lookupStarted
+		s.InvalidatePID(pid)
+		close(releaseLookup)
+		assert.False(t, <-firstLookupResult)
+
+		got, ok := s.ContainerInfo(context.Background(), pid)
+		require.True(t, ok)
+		assert.Equal(t, ContainerID(fullID), got.FullID)
 	})
 
 	t.Run("inspect_error_returns_false", func(t *testing.T) {

--- a/pkg/docker/docker_api_client_test.go
+++ b/pkg/docker/docker_api_client_test.go
@@ -193,7 +193,7 @@ func TestContainerInfo(t *testing.T) {
 			assert.Equal(t, ContainerID(fullID), got.FullID)
 			assert.Equal(t, 4, calls)
 			s.cacheMu.RLock()
-			_, negativelyCached := s.notContainerUntilByPID[pid]
+			_, negativelyCached := s.containerNotFoundRetryAtByPID[pid]
 			s.cacheMu.RUnlock()
 			assert.False(t, negativelyCached)
 		})
@@ -215,7 +215,7 @@ func TestContainerInfo(t *testing.T) {
 			_, ok := s.ContainerInfo(context.Background(), pid)
 			assert.False(t, ok)
 			s.cacheMu.RLock()
-			_, negativelyCached := s.notContainerUntilByPID[pid]
+			_, negativelyCached := s.containerNotFoundRetryAtByPID[pid]
 			s.cacheMu.RUnlock()
 			require.True(t, negativelyCached)
 
@@ -225,7 +225,7 @@ func TestContainerInfo(t *testing.T) {
 			assert.False(t, ok)
 
 			s.cacheMu.RLock()
-			_, negativelyCached = s.notContainerUntilByPID[pid]
+			_, negativelyCached = s.containerNotFoundRetryAtByPID[pid]
 			s.cacheMu.RUnlock()
 			assert.False(t, negativelyCached)
 		})

--- a/pkg/internal/helpers/container/container.go
+++ b/pkg/internal/helpers/container/container.go
@@ -37,7 +37,7 @@ type Info struct {
 var cgroupFormats = []*regexp.Regexp{
 	// 0::/docker/<hex...>/kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-besteffort.slice/kubelet-kubepods-besteffort-pod<hex...>.slice/cri-containerd-<hex...>.scope
 	// where the last <hex...> chain is the container ID inside its Pod
-	regexp.MustCompile(`^\d+:.*:.*/.*-([\da-fA-F]+)\.scope`),
+	regexp.MustCompile(`^\d+:.*:.*/.*-([\da-fA-F]{64})\.scope`),
 
 	// formats for other Kubernetes distributions
 	// GKE: /kubepods/burstable/pod4a163a05-439d-484b-8e53-2968bc15824f/cde6dfaf5007ed65aad2d6aed72af91b0f3d95813492f773286e29ae145d20f4

--- a/pkg/internal/helpers/container/container_test.go
+++ b/pkg/internal/helpers/container/container_test.go
@@ -53,6 +53,7 @@ var fixturesWithContainer = map[app.PID]string{
 }
 
 var fixturesWithoutContainer = map[app.PID]string{
+	1012: `0::/user.slice/user-963461.slice/session-11909.scope`,
 	1011: `12:rdma:/
 11:perf_event:
 10:freezer:/docker/a2ffe0e97ac22657a2a023ad628e9df837c38a03b1ebc904d3f6d644eb1a1a81

--- a/pkg/transform/transform_docker.go
+++ b/pkg/transform/transform_docker.go
@@ -55,20 +55,12 @@ func (dd *dockerEnricher) decorate(ctx context.Context) {
 	swarms.ForEachInput(ctx, dd.in, dd.log.Debug, func(spans []request.Span) {
 		for i := range spans {
 			svc := &spans[i].Service
-			if ci, ok := dd.containerInfo(ctx, svc.ProcPID); ok {
+			if ci, ok := dd.docker.ContainerInfo(ctx, svc.ProcPID); ok {
 				ci.DecorateService(svc)
 			}
 		}
 		dd.out.SendCtx(ctx, spans)
 	})
-}
-
-func (dd *dockerEnricher) containerInfo(ctx context.Context, pid app.PID) (docker.ContainerMeta, bool) {
-	ci, ok := dd.docker.ContainerInfo(ctx, pid)
-	if !ok {
-		dd.log.Debug("can't find container metadata", "pid", pid)
-	}
-	return ci, ok
 }
 
 func dpelog() *slog.Logger {


### PR DESCRIPTION
## Problem

I found this while instrumenting an HTTP application running directly on the host while Docker was available.

`DockerEnricher` resolved container metadata for every span. Successful lookups were cached, but negative lookups were not, causing repeated procfs scans for host processes.

The cgroup parser also interpreted `session-11909.scope` as container ID `11909`, triggering repeated Docker inspection instead of identifying a non-container process.

At 10000 requests/s, Docker enrichment became a bottleneck: CPU and memory usage grew, while RED metrics fell behind the generated traffic.

## Fix

- Require a 64-character hexadecimal container ID in systemd scope paths.
- Cache `ErrContainerNotFound` per PID for one second; retry other errors immediately.
- Clear negative entries on success, PID invalidation, or expiry on access.
- Revalidate the PID under the cache lock before recording a miss to preserve invalidation safety.
- Remove the redundant per-span Docker enrichment lookup-failed debug log.

The cooldown bounds repeated procfs work without treating a negative lookup as permanent. This complements the positive metadata cache introduced in [#1990](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1990).

## Results

Compared unpatched Beyla 3.32.0 with the same source plus this PR's production changes. Both were built with Go 1.26 and tested on the same four-vCPU host, with identical configuration and Docker enrichment enabled; the application ran directly on the host, not in Docker.

Each run lasted five minutes at a target of 10,000 requests/s: concurrency 800, 1 KiB request payload, 5% error responses and 10% requests delayed by 250 ms.

| | Unpatched | Patched |
| --- | ---: | ---: |
| Completed requests accounted for in RED | 43.13% | 100% |
| Beyla CPU, % of the four-vCPU host | 14.15% | 6.86% |
| Beyla RSS | 877.80 MiB | 113.53 MiB |

CPU/RSS are averages excluding the first 30 seconds: about **52% less CPU and 87% less memory** with the fix. 

After export settled, unpatched RED accounted for 1,221,598 of 2,832,134 completed requests; patched RED accounted for all 2,996,362. Unpatched counters were stable for over two minutes and the collector export queue was empty, so the difference was not merely an unfinished export. Neither run had transport errors, OOM events or supervisor restarts during load.

## Validation

Passed on Linux:

- `make fmt`
- `make verify`
- `make compile`
- `go test -race ./pkg/docker -run TestContainerInfo -count=100`

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

## AI assistance

Codex assisted with investigation, implementation, and tests. I reviewed and verified the final changes before submission.
