### PR TITLE
test: fix jvm runtime OTLP test

### DIFF
--- a/internal/test/integration/configs/prometheus-config-promscrape-jvm.yml
+++ b/internal/test/integration/configs/prometheus-config-promscrape-jvm.yml
@@ -1,0 +1,8 @@
+global:
+  evaluation_interval: 250ms
+  scrape_interval: 250ms
+scrape_configs:
+  - job_name: otelcol-otlp
+    static_configs:
+      - targets:
+          - 'otelcol:9464'

--- a/internal/test/integration/docker-compose-jvm-runtime-metrics.yml
+++ b/internal/test/integration/docker-compose-jvm-runtime-metrics.yml
@@ -38,7 +38,7 @@ services:
       GOCOVERDIR: "/coverage"
       OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
       OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
-      OTEL_EBPF_METRICS_INTERVAL: "10ms"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
       OTEL_EBPF_LOG_LEVEL: "DEBUG"
       OTEL_EBPF_BPF_DEBUG: "TRUE"
       OTEL_EBPF_HOSTNAME: "obi"
@@ -57,7 +57,7 @@ services:
     image: quay.io/prometheus/prometheus:v3.14.0@sha256:5ce7540c3c00ef4ab0c9d2c995c6a5b9c421f44b4a115d97a2c7af3b1c21cbb0
     container_name: prometheus
     command:
-      - --config.file=/etc/prometheus/prometheus-config-promscrape.yml
+      - --config.file=/etc/prometheus/prometheus-config-promscrape-jvm.yml
       - --web.enable-lifecycle
       - --web.route-prefix=/
     volumes:


### PR DESCRIPTION
## Summary

The JVM suite reported no JVM runtime metrics to weaver, because its assertions read a faster path than weaver does.

The suite asserted against OBI's Prometheus exporter, which exposes a metric as soon as it is sampled, while weaver is fed from the OTLP path that only emits on the next export interval. The test was satisfied and stopped weaver before that export ran, and the weaver tap disables retries, so the batch was discarded.

Pointing the suite's Prometheus at the collector's OTLP-fed endpoint fixes it: both pipelines share one OTLP receiver, so the existing assertions cannot pass until weaver's feed has the data. No test code changes. The suite gets its own scrape config because the shared one is used by three other suites, and the export interval moves to 1s to match the other weaver-wired suites.

The weaver report goes from zero JVM metric families to all eleven, with no violations.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
