### PR TITLE
add k8s coverage for netolly and statsolly

### DIFF
--- a/internal/test/integration/k8s/manifests/06-obi-tcp-stats.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-tcp-stats.yml
@@ -6,36 +6,25 @@ data:
   obi-config.yml: |
     log_level: debug
     metrics:
-      features: ["network", "network_inter_zone", "network_flow_packets"]
+      features: ["stats"]
     otel_metrics_export:
       endpoint: http://otelcol.default:4317
-    network:
-      guess_ports: ordinal
-      protocols:
-        - TCP
-      cidrs:
-        # default subnets of Kind Pods and services
-        - 10.244.0.0/16
-        - fd00:10:244::/56
-        - 10.96.0.0/16
-        - fd00:10:96::/112
     attributes:
       kubernetes:
         enable: true
         cluster_name: my-kube
         resource_labels:
-          deployment.environment.name: ["${DEPLOYMENT_ENVIRONMENT:-error-not-replaced}"]
+          deployment.environment.name: ["${DEPLOYMENT_ENVIRONMENT:-deployment.environment.name}"]
       select:
-        obi.network.flow.bytes:
+        obi.stat.tcp.rtt:
           # assured cardinality explosion. Don't try in production!
           include: ["*"]
-          exclude: ["src_port"]
-        obi.network.inter.zone.bytes:
+        obi.stat.tcp.io:
           include: ["*"]
-          exclude: ["src_port"]
-        obi.network.flow.packets:
+        obi.stat.tcp.retransmits:
           include: ["*"]
-          exclude: ["src_port"]
+        obi.stat.tcp.failed.connections:
+          include: ["*"]
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -64,6 +53,13 @@ spec:
         - name: testoutput
           persistentVolumeClaim:
             claimName: testoutput
+        # the stats tracer attaches sock/inet_sock_set_state, which needs tracefs
+        - name: tracefs
+          hostPath:
+            path: /sys/kernel/tracing
+        - name: debugfs
+          hostPath:
+            path: /sys/kernel/debug
       containers:
         - name: obi
           image: obi:dev
@@ -76,25 +72,18 @@ spec:
               name: obi-config
             - mountPath: /testoutput
               name: testoutput
+            - mountPath: /sys/kernel/tracing
+              name: tracefs
+            - mountPath: /sys/kernel/debug
+              name: debugfs
           env:
             - name: GOCOVERDIR
               value: "/testoutput"
             - name: OTEL_EBPF_CONFIG_PATH
               value: /config/obi-config.yml
-            - name: OTEL_EBPF_NETWORK_METRICS
-              value: "true"
-            - name: OTEL_EBPF_NETWORK_CACHE_ACTIVE_TIMEOUT
-              value: "100ms"
-            - name: OTEL_EBPF_NETWORK_CACHE_MAX_FLOWS
-              value: "20"
             - name: OTEL_EBPF_METRICS_INTERVAL
               value: "1s"
-            - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
-              value: "10ms"
             - name: OTEL_METRIC_EXPORT_INTERVAL
               value: "5000"
-            # expecting to be replaced during the configuration YAML load
-            - name: DEPLOYMENT_ENVIRONMENT
-              value: "deployment.environment.name"
-            - name: OTEL_EBPF_NETWORK_MAX_FLOW_DURATION
-              value: "1s"
+            - name: OTEL_EBPF_BPF_BATCH_TIMEOUT
+              value: "10ms"

--- a/internal/test/integration/k8s/tcp_stats/k8s_tcp_stats_main_test.go
+++ b/internal/test/integration/k8s/tcp_stats/k8s_tcp_stats_main_test.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tcpstats
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/docker"
+	"go.opentelemetry.io/obi/internal/test/integration/components/kube"
+	k8s "go.opentelemetry.io/obi/internal/test/integration/k8s/common"
+	"go.opentelemetry.io/obi/internal/test/integration/k8s/common/testpath"
+	"go.opentelemetry.io/obi/internal/test/tools"
+)
+
+var cluster *kube.Kind
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Short() {
+		fmt.Println("skipping integration tests in short mode")
+		return
+	}
+
+	if err := docker.Build(os.Stdout, tools.ProjectDir(),
+		docker.ImageBuild{Tag: "testserver:dev", Dockerfile: k8s.DockerfileTestServer},
+		docker.ImageBuild{Tag: "obi:dev", Dockerfile: k8s.DockerfileOBI},
+		docker.ImageBuild{Tag: "httppinger:dev", Dockerfile: k8s.DockerfileHTTPPinger},
+	); err != nil {
+		slog.Error("can't build docker images", "error", err)
+		os.Exit(-1)
+	}
+
+	cluster = kube.NewKind("test-kind-cluster-tcp-stats",
+		kube.KindConfig(testpath.Manifests+"/00-kind.yml"),
+		kube.LocalImage("testserver:dev"),
+		kube.LocalImage("obi:dev"),
+		kube.LocalImage("httppinger:dev"),
+		kube.Deploy(testpath.Manifests+"/01-volumes.yml"),
+		kube.Deploy(testpath.Manifests+"/01-serviceaccount.yml"),
+		kube.Deploy(testpath.Manifests+"/02-prometheus-otelscrape.yml"),
+		// weaver-tapped otelcol + in-cluster weaver pod, validated at suite
+		// teardown (enforcing)
+		kube.WeaverValidation(),
+		kube.Deploy(testpath.Manifests+"/03-otelcol-weaver.yml"),
+		kube.Deploy(testpath.Manifests+"/05-uninstrumented-service.yml"),
+		kube.Deploy(testpath.Manifests+"/06-obi-tcp-stats.yml"),
+		kube.Deploy(testpath.Manifests+"/08-weaver.yml"),
+	)
+
+	cluster.Run(m)
+}
+
+func TestTCPStats(t *testing.T) {
+	cluster.TestEnv().Test(t, FeatureTCPStats())
+}

--- a/internal/test/integration/k8s/tcp_stats/k8s_tcp_stats_metrics.go
+++ b/internal/test/integration/k8s/tcp_stats/k8s_tcp_stats_metrics.go
@@ -1,0 +1,85 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tcpstats // import "go.opentelemetry.io/obi/internal/test/integration/k8s/tcp_stats"
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/kube"
+	"go.opentelemetry.io/obi/internal/test/integration/components/promtest"
+	k8s "go.opentelemetry.io/obi/internal/test/integration/k8s/common"
+)
+
+const (
+	testTimeout        = 5 * time.Minute
+	prometheusHostPort = "localhost:39090"
+	pingerPodName      = "internal-pinger-tcp-stats"
+
+	// A cardinality-exploded metric makes each Prometheus query cost hundreds of
+	// milliseconds, so a sub-second poll only piles up in-flight requests.
+	pollInterval = time.Second
+)
+
+func FeatureTCPStats() features.Feature {
+	pinger := kube.Template[k8s.Pinger]{
+		TemplateFile: k8s.UninstrumentedPingerManifest,
+		Data: k8s.Pinger{
+			PodName:   pingerPodName,
+			TargetURL: "http://testserver:8080/iping",
+		},
+	}
+	return features.New("tcp stats").
+		Setup(pinger.Deploy()).
+		Teardown(pinger.Delete()).
+		Assess("emits tcp stat metrics", testTCPStatsEmitted).
+		Assess("decorates tcp io metrics with kubernetes metadata", testTCPStatsIODecoration).
+		Feature()
+}
+
+func testTCPStatsEmitted(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		results, err := pq.Query("obi_stat_tcp_io_bytes_total")
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, results)
+	}, testTimeout, pollInterval)
+	return ctx
+}
+
+// testTCPStatsIODecoration pins the query to the flow the pinger generates.
+// obi.stat.tcp.io is selected with every attribute in this suite, including the
+// ports, so the metric carries a series per connection: asserting the label set
+// of an arbitrary member would sample unrelated flows — node-sourced ones that
+// legitimately have no namespace, or traffic to the CNI gateway that has no
+// destination workload.
+func testTCPStatsIODecoration(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		results, err := pq.Query(`obi_stat_tcp_io_bytes_total{` +
+			`k8s_cluster_name="my-kube",` +
+			`k8s_src_name="` + pingerPodName + `",` +
+			`k8s_dst_name=~"testserver.*"` +
+			`}`)
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, results)
+
+		for _, res := range results {
+			metric := res.Metric
+			assert.NotEmpty(ct, metric["k8s_src_namespace"])
+			assert.NotEmpty(ct, metric["k8s_src_owner_name"])
+			assert.NotEmpty(ct, metric["k8s_src_owner_type"])
+			assert.NotEmpty(ct, metric["k8s_src_node_name"])
+			assert.NotEmpty(ct, metric["k8s_dst_namespace"])
+			assert.Contains(ct, []string{"receive", "transmit"}, metric["network_io_direction"])
+		}
+	}, testTimeout, pollInterval)
+	return ctx
+}


### PR DESCRIPTION
## Summary

Several network and TCP metrics reach the telemetry coverage check with almost no attributes, because nothing exercises them on a Kubernetes cluster with full attribute selection.

`obi.network.flow.bytes` is selected with `include: ["*"]` in the multizone suite and comes out fully decorated. Its siblings on the same cluster fall back to the default attribute set: `obi.network.inter.zone.bytes` and `obi.network.flow.packets` report three attributes each, and neither carries the `k8s.src.*` / `k8s.dst.*` decoration that the sibling proves is available. This adds both to the same `select` block, and enables `network_flow_packets`, which no Kubernetes manifest turned on.

The `obi.stat.tcp.*` metrics had a different problem: the stats feature is enabled in no Kubernetes manifest at all, so they only ever emitted from Docker Compose suites where Kubernetes decoration cannot exist. This adds a `tcp_stats` suite: a weaver-tapped kind cluster with the stats feature on, a pinger generating TCP traffic, and assertions that the IO and round-trip-time metrics carry the source and destination Kubernetes metadata. The suite directory is picked up by the existing test matrix automatically.

Together these target the attribute gaps on six metrics. No production code changes: this is test configuration and a new suite.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
