### PR TITLE
test: add netolly k8s assertions

### DIFF
--- a/internal/test/integration/k8s/manifests/06-obi-netolly-promexport.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-netolly-promexport.yml
@@ -32,6 +32,10 @@ data:
           # assured cardinality explosion. Don't try in production!
           include: ["*"]
           exclude: ["src_port"]
+        obi.network.inter.zone.bytes:
+          # assured cardinality explosion. Don't try in production!
+          include: ["*"]
+          exclude: ["src_port"]
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/internal/test/integration/k8s/netolly_multizone/netolly_multizone_feature.go
+++ b/internal/test/integration/k8s/netolly_multizone/netolly_multizone_feature.go
@@ -37,12 +37,12 @@ func testFlowsDecoratedWithZone(ctx context.Context, t *testing.T, _ *envconf.Co
 			`k8s_src_name="httppinger",k8s_dst_name=~"testserver.*",` +
 			`k8s_src_type="Pod",k8s_dst_type="Pod"` +
 			`}`)
-		require.NoError(ct, err)
-		require.NotEmpty(ct, results)
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, results)
 
 		// check that the metrics are properly decorated
 		// should have 2 exact metrics, measured from OBI instances in both nodes
-		require.GreaterOrEqual(ct, len(results), 2)
+		assert.GreaterOrEqual(ct, len(results), 2)
 		for _, res := range results {
 			assert.Equal(ct, "client-zone", res.Metric["src_zone"])
 			assert.Equal(ct, "server-zone", res.Metric["dst_zone"])
@@ -54,12 +54,12 @@ func testFlowsDecoratedWithZone(ctx context.Context, t *testing.T, _ *envconf.Co
 			`k8s_dst_name="httppinger",k8s_src_name=~"testserver.*",` +
 			`k8s_src_type="Pod",k8s_dst_type="Pod"` +
 			`}`)
-		require.NoError(ct, err)
-		require.NotEmpty(ct, results)
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, results)
 
 		// check that the metrics are properly decorated
 		// should have 2 exact metrics, measured from OBI instances in both nodes
-		require.GreaterOrEqual(ct, len(results), 2)
+		assert.GreaterOrEqual(ct, len(results), 2)
 		for _, res := range results {
 			assert.Equal(ct, "server-zone", res.Metric["src_zone"])
 			assert.Equal(ct, "client-zone", res.Metric["dst_zone"])
@@ -72,48 +72,48 @@ func testFlowsDecoratedWithZone(ctx context.Context, t *testing.T, _ *envconf.Co
 			`src_zone="server-zone",dst_zone="control-plane-zone",` +
 			`k8s_src_type="Node",k8s_dst_type="Node"` +
 			`}`)
-		require.NoError(ct, err)
-		require.NotEmpty(ct, results)
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, results)
 
 		// check that the metrics are properly decorated
 		// should have 2 exact metrics, measured from OBI instances in both nodes
-		require.GreaterOrEqual(ct, len(results), 2)
+		assert.GreaterOrEqual(ct, len(results), 2)
 	}, testTimeout, 100*time.Millisecond)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		results, err := pq.Query(`obi_network_flow_bytes_total{` +
 			`dst_zone="server-zone",src_zone="control-plane-zone",` +
 			`k8s_src_type="Node",k8s_dst_type="Node"` +
 			`}`)
-		require.NoError(ct, err)
-		require.NotEmpty(ct, results)
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, results)
 
 		// check that the metrics are properly decorated
 		// should have 2 exact metrics, measured from OBI instances in both nodes
-		require.GreaterOrEqual(ct, len(results), 2)
+		assert.GreaterOrEqual(ct, len(results), 2)
 	}, testTimeout, 100*time.Millisecond)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		results, err := pq.Query(`obi_network_flow_bytes_total{` +
 			`src_zone="client-zone",dst_zone="control-plane-zone",` +
 			`k8s_src_type="Node",k8s_dst_type="Node"` +
 			`}`)
-		require.NoError(ct, err)
-		require.NotEmpty(ct, results)
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, results)
 
 		// check that the metrics are properly decorated
 		// should have 2 exact metrics, measured from OBI instances in both nodes
-		require.GreaterOrEqual(ct, len(results), 2)
+		assert.GreaterOrEqual(ct, len(results), 2)
 	}, testTimeout, 100*time.Millisecond)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		results, err := pq.Query(`obi_network_flow_bytes_total{` +
 			`dst_zone="client-zone",src_zone="control-plane-zone",` +
 			`k8s_src_type="Node",k8s_dst_type="Node"` +
 			`}`)
-		require.NoError(ct, err)
-		require.NotEmpty(ct, results)
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, results)
 
 		// check that the metrics are properly decorated
 		// should have 2 exact metrics, measured from OBI instances in both nodes
-		require.GreaterOrEqual(ct, len(results), 2)
+		assert.GreaterOrEqual(ct, len(results), 2)
 	}, testTimeout, 100*time.Millisecond)
 	return ctx
 }
@@ -125,17 +125,18 @@ func testInterZoneMetric(ctx context.Context, t *testing.T, _ *envconf.Config) c
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		results, err := pq.Query(`obi_network_inter_zone_bytes_total{` +
 			`src_zone="client-zone", dst_zone="server-zone"}`)
-		require.NoError(ct, err)
-		require.NotEmpty(ct, results)
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, results)
 	}, testTimeout, 100*time.Millisecond)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		results, err := pq.Query(`obi_network_inter_zone_bytes_total{` +
 			`dst_zone="client-zone", src_zone="server-zone"}`)
-		require.NoError(ct, err)
-		require.NotEmpty(ct, results)
-		// AND the reported attributes are different from the flow bytes attributes
-		require.NotContains(ct, results, "k8s_src_type")
-		require.NotContains(ct, results, "iface_direction")
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, results)
+		for _, res := range results {
+			assert.Contains(ct, res.Metric, "k8s_src_type")
+			assert.Contains(ct, res.Metric, "iface_direction")
+		}
 	}, testTimeout, 100*time.Millisecond)
 
 	// BUT same-zone bytes are not reported in this metric


### PR DESCRIPTION
## Summary

The two attribute assertions on the inter-zone metric never tested anything: `NotContains` was given the results slice rather than a series' label map, so it compared a struct against a string and could not fail.

Their premise is also no longer true. Selecting the inter-zone metric with every attribute means it does now carry `k8s_src_type` and `iface_direction`, so this asserts they are present, on every returned series, and drops the stale comment.

Also converts `require` to `assert` inside this file's `EventuallyWithT` callbacks. `require` on a `*assert.CollectT` calls `FailNow`, which is not what a polling condition wants.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
