### PR TITLE
test: add statsolly k8s metric assertions

### DIFF
--- a/internal/test/integration/components/httppinger/httppinger.go
+++ b/internal/test/integration/components/httppinger/httppinger.go
@@ -43,10 +43,18 @@ func main() {
 }
 
 func httpClient() *http.Client {
-	if os.Getenv("WRAP_TLS_CONN") != "true" {
-		return http.DefaultClient
+	if os.Getenv("WRAP_TLS_CONN") == "true" {
+		return tlsWrappingClient()
 	}
 
+	if os.Getenv("DISABLE_KEEPALIVES") == "true" {
+		return &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	}
+
+	return http.DefaultClient
+}
+
+func tlsWrappingClient() *http.Client {
 	dialer := tls.Dialer{
 		Config: &tls.Config{InsecureSkipVerify: true},
 	}

--- a/internal/test/integration/k8s/manifests/06-obi-tcp-stats.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-tcp-stats.yml
@@ -57,9 +57,6 @@ spec:
         - name: tracefs
           hostPath:
             path: /sys/kernel/tracing
-        - name: debugfs
-          hostPath:
-            path: /sys/kernel/debug
       containers:
         - name: obi
           image: obi:dev
@@ -74,8 +71,6 @@ spec:
               name: testoutput
             - mountPath: /sys/kernel/tracing
               name: tracefs
-            - mountPath: /sys/kernel/debug
-              name: debugfs
           env:
             - name: GOCOVERDIR
               value: "/testoutput"

--- a/internal/test/integration/k8s/manifests/06-uninstrumented-client.template.yml
+++ b/internal/test/integration/k8s/manifests/06-uninstrumented-client.template.yml
@@ -24,3 +24,7 @@ spec:
           value: "{{.TargetURL}}"
         - name: OTEL_RESOURCE_ATTRIBUTES
           value: "deployment.environment.name=test,service.version=3.2.1"
+        {{- range $key, $value := .Env }}
+        - name: {{$key}}
+          value: "{{$value}}"
+        {{- end }}

--- a/internal/test/integration/k8s/tcp_stats/k8s_tcp_stats_metrics.go
+++ b/internal/test/integration/k8s/tcp_stats/k8s_tcp_stats_metrics.go
@@ -22,6 +22,8 @@ const (
 	testTimeout        = 5 * time.Minute
 	prometheusHostPort = "localhost:39090"
 	pingerPodName      = "internal-pinger-tcp-stats"
+	failPingerPodName  = "internal-pinger-tcp-stats-fail"
+	closedPort         = "19999"
 
 	// A cardinality-exploded metric makes each Prometheus query cost hundreds of
 	// milliseconds, so a sub-second poll only piles up in-flight requests.
@@ -34,13 +36,33 @@ func FeatureTCPStats() features.Feature {
 		Data: k8s.Pinger{
 			PodName:   pingerPodName,
 			TargetURL: "http://testserver:8080/iping",
+			// obi.stat.tcp.rtt is reported from the tcp_close probe, so a
+			// keep-alive client would report nothing until pod teardown.
+			Env: map[string]string{"DISABLE_KEEPALIVES": "true"},
 		},
 	}
+	// Nothing listens on this pod's own closed port, so every request is refused
+	// by the kernel and feeds obi.stat.tcp.failed.connections.
+	failPinger := kube.Template[k8s.Pinger]{
+		TemplateFile: k8s.UninstrumentedPingerManifest,
+		Data: k8s.Pinger{
+			PodName:   failPingerPodName,
+			TargetURL: "http://127.0.0.1:" + closedPort + "/iping",
+		},
+	}
+	// obi.stat.tcp.retransmits is not asserted: retransmissions require packet
+	// loss, which the docker-compose stat suite injects with netem on the client
+	// container. This suite has no equivalent injection, so an assertion on that
+	// metric would only wait for the full timeout.
 	return features.New("tcp stats").
 		Setup(pinger.Deploy()).
+		Setup(failPinger.Deploy()).
 		Teardown(pinger.Delete()).
+		Teardown(failPinger.Delete()).
 		Assess("emits tcp stat metrics", testTCPStatsEmitted).
 		Assess("decorates tcp io metrics with kubernetes metadata", testTCPStatsIODecoration).
+		Assess("emits tcp rtt as a histogram", testTCPStatsRTT).
+		Assess("emits tcp failed connections", testTCPStatsFailedConnections).
 		Feature()
 }
 
@@ -54,20 +76,10 @@ func testTCPStatsEmitted(ctx context.Context, t *testing.T, _ *envconf.Config) c
 	return ctx
 }
 
-// testTCPStatsIODecoration pins the query to the flow the pinger generates.
-// obi.stat.tcp.io is selected with every attribute in this suite, including the
-// ports, so the metric carries a series per connection: asserting the label set
-// of an arbitrary member would sample unrelated flows — node-sourced ones that
-// legitimately have no namespace, or traffic to the CNI gateway that has no
-// destination workload.
 func testTCPStatsIODecoration(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
 	pq := promtest.Client{HostPort: prometheusHostPort}
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		results, err := pq.Query(`obi_stat_tcp_io_bytes_total{` +
-			`k8s_cluster_name="my-kube",` +
-			`k8s_src_name="` + pingerPodName + `",` +
-			`k8s_dst_name=~"testserver.*"` +
-			`}`)
+		results, err := pq.Query(pingerFlow("obi_stat_tcp_io_bytes_total"))
 		assert.NoError(ct, err)
 		assert.NotEmpty(ct, results)
 
@@ -78,8 +90,59 @@ func testTCPStatsIODecoration(ctx context.Context, t *testing.T, _ *envconf.Conf
 			assert.NotEmpty(ct, metric["k8s_src_owner_type"])
 			assert.NotEmpty(ct, metric["k8s_src_node_name"])
 			assert.NotEmpty(ct, metric["k8s_dst_namespace"])
+			assert.Equal(ct, "testserver", metric["k8s_dst_owner_name"])
+			assert.Equal(ct, "Service", metric["k8s_dst_owner_type"])
 			assert.Contains(ct, []string{"receive", "transmit"}, metric["network_io_direction"])
 		}
 	}, testTimeout, pollInterval)
 	return ctx
+}
+
+func testTCPStatsRTT(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		counts, err := pq.Query(pingerFlow("obi_stat_tcp_rtt_seconds_count") + " > 0")
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, counts)
+
+		sums, err := pq.Query(pingerFlow("obi_stat_tcp_rtt_seconds_sum") + " > 0")
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, sums)
+
+		buckets, err := pq.Query("count(" + pingerFlow("obi_stat_tcp_rtt_seconds_bucket") + ")")
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, buckets)
+	}, testTimeout, pollInterval)
+	return ctx
+}
+
+// testTCPStatsFailedConnections pins the query to the port the fail pinger
+// dials. That connection is refused over loopback, whose addresses carry no
+// kubernetes metadata, so port and handshake role are what identify the series.
+func testTCPStatsFailedConnections(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
+	pq := promtest.Client{HostPort: prometheusHostPort}
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		results, err := pq.Query(`obi_stat_tcp_failed_connections_total{` +
+			`dst_port="` + closedPort + `",` +
+			`network_tcp_handshake_role="client",` +
+			`reason="refused"` +
+			`} > 0`)
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, results)
+	}, testTimeout, pollInterval)
+	return ctx
+}
+
+// pingerFlow pins a query to the flow the pinger generates. The obi.stat.tcp.*
+// metrics are selected with every attribute in this suite, including the ports,
+// so each metric carries a series per connection: asserting the label set of an
+// arbitrary member would sample unrelated flows — node-sourced ones that
+// legitimately have no namespace, or traffic to the CNI gateway that has no
+// destination workload.
+func pingerFlow(metric string) string {
+	return metric + `{` +
+		`k8s_cluster_name="my-kube",` +
+		`k8s_src_name="` + pingerPodName + `",` +
+		`k8s_dst_name=~"testserver.*"` +
+		`}`
 }

--- a/internal/test/integration/k8s/tcp_stats/k8s_tcp_stats_metrics.go
+++ b/internal/test/integration/k8s/tcp_stats/k8s_tcp_stats_metrics.go
@@ -83,16 +83,9 @@ func testTCPStatsIODecoration(ctx context.Context, t *testing.T, _ *envconf.Conf
 		assert.NoError(ct, err)
 		assert.NotEmpty(ct, results)
 
+		assertPingerFlowDecoration(ct, results)
 		for _, res := range results {
-			metric := res.Metric
-			assert.NotEmpty(ct, metric["k8s_src_namespace"])
-			assert.NotEmpty(ct, metric["k8s_src_owner_name"])
-			assert.NotEmpty(ct, metric["k8s_src_owner_type"])
-			assert.NotEmpty(ct, metric["k8s_src_node_name"])
-			assert.NotEmpty(ct, metric["k8s_dst_namespace"])
-			assert.Equal(ct, "testserver", metric["k8s_dst_owner_name"])
-			assert.Equal(ct, "Service", metric["k8s_dst_owner_type"])
-			assert.Contains(ct, []string{"receive", "transmit"}, metric["network_io_direction"])
+			assert.Contains(ct, []string{"receive", "transmit"}, res.Metric["network_io_direction"])
 		}
 	}, testTimeout, pollInterval)
 	return ctx
@@ -104,6 +97,7 @@ func testTCPStatsRTT(ctx context.Context, t *testing.T, _ *envconf.Config) conte
 		counts, err := pq.Query(pingerFlow("obi_stat_tcp_rtt_seconds_count") + " > 0")
 		assert.NoError(ct, err)
 		assert.NotEmpty(ct, counts)
+		assertPingerFlowDecoration(ct, counts)
 
 		sums, err := pq.Query(pingerFlow("obi_stat_tcp_rtt_seconds_sum") + " > 0")
 		assert.NoError(ct, err)
@@ -131,6 +125,19 @@ func testTCPStatsFailedConnections(ctx context.Context, t *testing.T, _ *envconf
 		assert.NotEmpty(ct, results)
 	}, testTimeout, pollInterval)
 	return ctx
+}
+
+func assertPingerFlowDecoration(ct *assert.CollectT, results []promtest.Result) {
+	for _, res := range results {
+		metric := res.Metric
+		assert.NotEmpty(ct, metric["k8s_src_namespace"])
+		assert.NotEmpty(ct, metric["k8s_src_owner_name"])
+		assert.NotEmpty(ct, metric["k8s_src_owner_type"])
+		assert.NotEmpty(ct, metric["k8s_src_node_name"])
+		assert.NotEmpty(ct, metric["k8s_dst_namespace"])
+		assert.Equal(ct, "testserver", metric["k8s_dst_owner_name"])
+		assert.Equal(ct, "Service", metric["k8s_dst_owner_type"])
+	}
 }
 
 // pingerFlow pins a query to the flow the pinger generates. The obi.stat.tcp.*


### PR DESCRIPTION
## Summary

The suite asserted only TCP IO. This adds RTT and failed connections, and asserts the destination workload on the IO decoration.

RTT is emitted at `tcp_close`, and the pinger used a keep-alive client, so its connection only closed at pod teardown and the metric never appeared during the run. The pinger takes an opt-in `DISABLE_KEEPALIVES`, which this suite sets; the uninstrumented pinger template gains the `Env` block the instrumented ones already render.

Failed connections come from a second pinger dialing a closed port on its own loopback, so the refusal comes from the kernel rather than from kube-proxy or a SYN timeout. That series carries no Kubernetes labels, so it is pinned on port, role and reason instead.

Retransmits are not asserted. A kind cluster on veth drops nothing, and forcing loss needs netem inside the pinger's network namespace, which would reshape the pinger template every other suite shares. A note in the file records why one of the four is missing.

Also drops the `debugfs` mount, which is redundant: the stats tracer needs `tracefs`, which stays.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
