### PR TITLE
fix(mysql): recognize custom server error codes

### DIFF
--- a/pkg/internal/sqlprune/mysql.go
+++ b/pkg/internal/sqlprune/mysql.go
@@ -57,25 +57,24 @@ func parseMySQLError(buf []uint8) *request.SQLError {
 	sqlErr.Code = binary.LittleEndian.Uint16(buf[offset : offset+2])
 	offset += 2
 
-	// https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
-	if sqlErr.Code < 1002 || sqlErr.Code > 4167 {
-		return nil // Invalid error code
+	// MariaDB progress reports share the ERR marker but are not errors.
+	// Other codes may be user-defined or supplied by MySQL-compatible servers.
+	if sqlErr.Code == MySQLProgressReporting {
+		return nil
 	}
 
-	if sqlErr.Code != MySQLProgressReporting {
-		if buf[offset] == MySQLStateMarker {
-			if len(buf) < (MySQLErrMinLen + 6) {
-				return nil
-			}
-			// Skip the SQL state marker
-			offset++
-			// Read the SQL state
-			sqlErr.SQLState = string(MySQLStateMarker) + string(buf[offset:offset+5])
-			offset += 5
+	if buf[offset] == MySQLStateMarker {
+		if len(buf) < (MySQLErrMinLen + 6) {
+			return nil
 		}
-		// Read the error message
-		sqlErr.Message = unix.ByteSliceToString(buf[offset:])
+		// Skip the SQL state marker
+		offset++
+		// Read the SQL state
+		sqlErr.SQLState = string(MySQLStateMarker) + string(buf[offset:offset+5])
+		offset += 5
 	}
+	// Read the error message
+	sqlErr.Message = unix.ByteSliceToString(buf[offset:])
 
 	return &sqlErr
 }

--- a/pkg/internal/sqlprune/mysql.go
+++ b/pkg/internal/sqlprune/mysql.go
@@ -64,12 +64,13 @@ func parseMySQLError(buf []uint8) *request.SQLError {
 	}
 
 	if buf[offset] == MySQLStateMarker {
-		if len(buf) < (MySQLErrMinLen + 6) {
+		if length < offset+1+5 {
 			return nil
 		}
 		// Skip the SQL state marker
 		offset++
 		// Read the SQL state
+		// TODO: Normalize SQLState to five characters without changing error.type silently.
 		sqlErr.SQLState = string(MySQLStateMarker) + string(buf[offset:offset+5])
 		offset += 5
 	}

--- a/pkg/internal/sqlprune/mysql.go
+++ b/pkg/internal/sqlprune/mysql.go
@@ -57,6 +57,10 @@ func parseMySQLError(buf []uint8) *request.SQLError {
 	sqlErr.Code = binary.LittleEndian.Uint16(buf[offset : offset+2])
 	offset += 2
 
+	if sqlErr.Code == 0 {
+		return nil
+	}
+
 	// MariaDB progress reports share the ERR marker but are not errors.
 	// Other codes may be user-defined or supplied by MySQL-compatible servers.
 	if sqlErr.Code == MySQLProgressReporting {
@@ -70,7 +74,6 @@ func parseMySQLError(buf []uint8) *request.SQLError {
 		// Skip the SQL state marker
 		offset++
 		// Read the SQL state
-		// TODO: Normalize SQLState to five characters without changing error.type silently.
 		sqlErr.SQLState = string(MySQLStateMarker) + string(buf[offset:offset+5])
 		offset += 5
 	}

--- a/pkg/internal/sqlprune/mysql_test.go
+++ b/pkg/internal/sqlprune/mysql_test.go
@@ -6,6 +6,7 @@ package sqlprune
 import (
 	"encoding/binary"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,7 +22,7 @@ func TestMySQLErrorCodes(t *testing.T) {
 			err := SQLParseError(request.DBMySQL, packet)
 			require.NotNil(t, err)
 			assert.Equal(t, code, err.Code)
-			assert.Equal(t, "#HY000", err.SQLState)
+			assert.Equal(t, "HY000", strings.TrimPrefix(err.SQLState, "#"))
 			assert.Equal(t, "test error", err.Message)
 
 			err = SQLParseError(request.DBMySQL, mysqlErrorPacket(code, "legacy error"))
@@ -34,6 +35,16 @@ func TestMySQLErrorCodes(t *testing.T) {
 }
 
 func TestMySQLErrorPacketValidation(t *testing.T) {
+	t.Run("empty_message", func(t *testing.T) {
+		packet := mysqlErrorPacket(20301, "#HY000")
+		require.Len(t, packet, 13)
+		err := SQLParseError(request.DBMySQL, packet)
+		require.NotNil(t, err)
+		assert.Equal(t, uint16(20301), err.Code)
+		assert.Empty(t, err.Message)
+		assert.Equal(t, "HY000", strings.TrimPrefix(err.SQLState, "#"))
+	})
+
 	packet := mysqlErrorPacket(20301, "#HY000test error")
 	for length := 0; length < MySQLHdrSize+1+2+1+5; length++ {
 		t.Run("truncated/"+strconv.Itoa(length), func(t *testing.T) {

--- a/pkg/internal/sqlprune/mysql_test.go
+++ b/pkg/internal/sqlprune/mysql_test.go
@@ -35,6 +35,13 @@ func TestMySQLErrorCodes(t *testing.T) {
 }
 
 func TestMySQLErrorPacketValidation(t *testing.T) {
+	t.Run("zero_code_with_sqlstate", func(t *testing.T) {
+		assert.Nil(t, SQLParseError(request.DBMySQL, mysqlErrorPacket(0, "#HY000test error")))
+	})
+	t.Run("zero_code_without_sqlstate", func(t *testing.T) {
+		assert.Nil(t, SQLParseError(request.DBMySQL, mysqlErrorPacket(0, "legacy error")))
+	})
+
 	t.Run("empty_message", func(t *testing.T) {
 		packet := mysqlErrorPacket(20301, "#HY000")
 		require.Len(t, packet, 13)

--- a/pkg/internal/sqlprune/mysql_test.go
+++ b/pkg/internal/sqlprune/mysql_test.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sqlprune
+
+import (
+	"encoding/binary"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+)
+
+func TestMySQLErrorCodes(t *testing.T) {
+	for _, code := range []uint16{1, 1001, 1002, 1045, 4167, 4168, 20301, 39321, 50000, 65534} {
+		t.Run(strconv.Itoa(int(code)), func(t *testing.T) {
+			packet := mysqlErrorPacket(code, "#HY000test error")
+			err := SQLParseError(request.DBMySQL, packet)
+			require.NotNil(t, err)
+			assert.Equal(t, code, err.Code)
+			assert.Equal(t, "#HY000", err.SQLState)
+			assert.Equal(t, "test error", err.Message)
+
+			err = SQLParseError(request.DBMySQL, mysqlErrorPacket(code, "legacy error"))
+			require.NotNil(t, err)
+			assert.Equal(t, code, err.Code)
+			assert.Empty(t, err.SQLState)
+			assert.Equal(t, "legacy error", err.Message)
+		})
+	}
+}
+
+func TestMySQLErrorPacketValidation(t *testing.T) {
+	packet := mysqlErrorPacket(20301, "#HY000test error")
+	for length := 0; length < MySQLHdrSize+1+2+1+5; length++ {
+		t.Run("truncated/"+strconv.Itoa(length), func(t *testing.T) {
+			assert.Nil(t, SQLParseError(request.DBMySQL, packet[:length]))
+		})
+	}
+	for _, marker := range []byte{0x00, 0x01, 0xfe} {
+		packet[MySQLHdrSize] = marker
+		assert.Nil(t, SQLParseError(request.DBMySQL, packet))
+	}
+	assert.Nil(t, SQLParseError(request.DBMySQL, mysqlErrorPacket(MySQLProgressReporting, "progress")))
+}
+
+func mysqlErrorPacket(code uint16, message string) []byte {
+	payloadLength := 1 + 2 + len(message)
+	packet := make([]byte, MySQLHdrSize+payloadLength)
+	binary.LittleEndian.PutUint32(packet, uint32(payloadLength))
+	packet[MySQLHdrSize-1] = 1
+	packet[MySQLHdrSize] = MySQLErrPacketMarker
+	binary.LittleEndian.PutUint16(packet[MySQLHdrSize+1:], code)
+	copy(packet[MySQLHdrSize+1+2:], message)
+	return packet
+}

--- a/pkg/internal/sqlprune/mysql_test.go
+++ b/pkg/internal/sqlprune/mysql_test.go
@@ -46,7 +46,7 @@ func TestMySQLErrorPacketValidation(t *testing.T) {
 	})
 
 	packet := mysqlErrorPacket(20301, "#HY000test error")
-	for length := 0; length < MySQLHdrSize+1+2+1+5; length++ {
+	for length := range MySQLHdrSize + 1 + 2 + 1 + 5 {
 		t.Run("truncated/"+strconv.Itoa(length), func(t *testing.T) {
 			assert.Nil(t, SQLParseError(request.DBMySQL, packet[:length]))
 		})

--- a/pkg/internal/sqlprune/sqlparser_test.go
+++ b/pkg/internal/sqlprune/sqlparser_test.go
@@ -215,9 +215,9 @@ func TestSQLParseError(t *testing.T) {
 			},
 		},
 		{
-			name:     "Invalid MySQL error",
+			name:     "Not a MySQL error packet",
 			dbKind:   request.DBMySQL,
-			buf:      append([]uint8{0x00, 0x00, 0x00, 0x00}, []uint8{0xFF, 0x99, 0x99, 'I', 'n', 'v', 'a', 'l', 'i', 'd'}...),
+			buf:      append([]uint8{0x00, 0x00, 0x00, 0x00}, []uint8{0x00, 0x99, 0x99, 'I', 'n', 'v', 'a', 'l', 'i', 'd'}...),
 			expected: nil,
 		},
 		{

--- a/pkg/internal/sqlprune/sqlparser_test.go
+++ b/pkg/internal/sqlprune/sqlparser_test.go
@@ -215,12 +215,6 @@ func TestSQLParseError(t *testing.T) {
 			},
 		},
 		{
-			name:     "Not a MySQL error packet",
-			dbKind:   request.DBMySQL,
-			buf:      append([]uint8{0x00, 0x00, 0x00, 0x00}, []uint8{0x00, 0x99, 0x99, 'I', 'n', 'v', 'a', 'l', 'i', 'd'}...),
-			expected: nil,
-		},
-		{
 			name:     "Empty buffer",
 			dbKind:   request.DBMySQL,
 			buf:      []uint8{0x00, 0x00, 0x00, 0x00, 0x00},


### PR DESCRIPTION
## Summary

While using OBI to monitor MatrixOne's MySQL-protocol traffic, we found that some failed requests were not recognized as errors. MatrixOne can return custom error codes such as 20301, but OBI's MySQL error parser only accepts codes in the 1002–4167 range and discards these error responses.

This is not specific to MatrixOne: MySQL also supports user-defined MYSQL_ERRNO values through [SIGNAL](https://dev.mysql.com/doc/refman/8.4/en/signal.html). A fixed range of built-in error codes therefore excludes valid errors.

This change removes that range check while retaining packet marker/length checks and the exclusion of MariaDB progress reports. It also fixes the length check for a 13-byte ERR packet containing SQLSTATE and an empty message.

The existing SQLState prefix is deliberately unchanged. It feeds the emitted error.type attribute; normalizing it could affect existing queries, alerts, and aggregations and needs a separate compatibility review.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md).
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed. No updates needed: this fixes parsing within existing MySQL support, without adding a protocol or configuration option.

Regression tests cover custom codes, legacy and SQLSTATE-bearing packets, invalid markers, truncation, MariaDB progress reports, and empty messages. The affected cases fail with the old logic and pass with the fix.

Passed locally (Go 1.26.2, GOTOOLCHAIN=local):
- `go test -p 2 -mod=readonly ./pkg/internal/sqlprune -count=1`
- `go vet -p 2 -mod=readonly ./pkg/internal/sqlprune`
- `go tool -modfile=internal/tools/go.mod golangci-lint run ./pkg/internal/sqlprune --timeout=6m`

Validation was scoped to the affected package; no cluster end-to-end test was run for this patch.

## AI assistance

Codex assisted with the implementation and tests. I reviewed the code and regression tests and understand the error-code validation and empty-message boundary fixes. Codex also assisted with translating and preparing this description.
