### PR TITLE
fix(sql): disambiguate MySQL and PostgreSQL fallback detection

### DIFF
--- a/pkg/ebpf/common/sql_detect_postgres.go
+++ b/pkg/ebpf/common/sql_detect_postgres.go
@@ -95,14 +95,41 @@ func isValidPostgresPayload(b *largebuf.LargeBuffer) (byte, bool) {
 	return op, true
 }
 
-// validPostgresSQLBody disambiguates overlapping MySQL/PG headers using a complete
-// first PG message. Later pipelined messages are outside the reader's bounds.
-func validPostgresSQLBody(b *largebuf.LargeBuffer) bool {
+type postgresBodyStatus uint8
+
+const (
+	postgresBodyInvalid postgresBodyStatus = iota
+	postgresBodyIncomplete
+	postgresBodyValid
+)
+
+// postgresSQLBodyStatus bounds validation to the first declared message, not
+// the capture boundary or any later pipelined messages.
+func postgresSQLBodyStatus(b *largebuf.LargeBuffer) postgresBodyStatus {
+	if b.Len() < pgHeaderLen {
+		return postgresBodyIncomplete
+	}
+	op, ok := isValidPostgresPayload(b)
+	if !ok || (op != kPostgresQuery && op != kPostgresCommand && op != kPostgresBind) {
+		return postgresBodyInvalid
+	}
+	size, _ := b.I32BEAt(1)
+	if int(size)+1 > b.Len() {
+		return postgresBodyIncomplete
+	}
 	r, err := msgBodyReader(b)
 	if err != nil {
-		return false
+		return postgresBodyInvalid
 	}
-	op, _ := b.U8At(0)
+	if validPostgresSQLBody(op, &r) {
+		return postgresBodyValid
+	}
+	return postgresBodyInvalid
+}
+
+func validPostgresSQLBody(op byte, r *largebuf.LargeBufferReader) bool {
+	// C can be CommandComplete (a string) or frontend Close (S/P followed
+	// by a name). Both have exactly one trailing NUL and no embedded NULs.
 	if _, err := r.ReadCStr(); err != nil {
 		return false
 	}
@@ -112,7 +139,7 @@ func validPostgresSQLBody(b *largebuf.LargeBuffer) bool {
 	if _, err := r.ReadCStr(); err != nil {
 		return false
 	}
-	formats, ok := readPostgresFormats(&r)
+	formats, ok := readPostgresFormats(r)
 	if !ok {
 		return false
 	}
@@ -131,7 +158,7 @@ func validPostgresSQLBody(b *largebuf.LargeBuffer) bool {
 			}
 		}
 	}
-	_, ok = readPostgresFormats(&r)
+	_, ok = readPostgresFormats(r)
 	return ok && r.Remaining() == 0
 }
 
@@ -197,15 +224,8 @@ func parsePostgresBindCommand(b *largebuf.LargeBuffer) (string, string, []string
 		return "", "", nil, errPGTooShortPortal
 	}
 
-	// skip format codes: Int16 count + count*Int16 entries
-	formats, err := r.ReadI16BE()
-	if err != nil {
+	if _, ok := readPostgresFormats(&r); !ok {
 		return "", "", nil, errPGTooShortFormatCodes
-	}
-	if formats > 0 {
-		if err := r.Skip(2 * int(formats)); err != nil {
-			return "", "", nil, errPGTooShortFormatCodes
-		}
 	}
 
 	// parse parameter values: Int16 count + repeated (Int32 length + bytes)

--- a/pkg/ebpf/common/sql_detect_postgres.go
+++ b/pkg/ebpf/common/sql_detect_postgres.go
@@ -95,6 +95,60 @@ func isValidPostgresPayload(b *largebuf.LargeBuffer) (byte, bool) {
 	return op, true
 }
 
+// validPostgresSQLBody disambiguates overlapping MySQL/PG headers using a complete
+// first PG message. Later pipelined messages are outside the reader's bounds.
+func validPostgresSQLBody(b *largebuf.LargeBuffer) bool {
+	r, err := msgBodyReader(b)
+	if err != nil {
+		return false
+	}
+	op, _ := b.U8At(0)
+	if _, err := r.ReadCStr(); err != nil {
+		return false
+	}
+	if op != kPostgresBind {
+		return r.Remaining() == 0
+	}
+	if _, err := r.ReadCStr(); err != nil {
+		return false
+	}
+	formats, ok := readPostgresFormats(&r)
+	if !ok {
+		return false
+	}
+	params, err := r.ReadU16BE()
+	if err != nil || (formats > 1 && formats != params) {
+		return false
+	}
+	for range int(params) {
+		length, err := r.ReadI32BE()
+		if err != nil || length < -1 {
+			return false
+		}
+		if length >= 0 {
+			if err := r.Skip(int(length)); err != nil {
+				return false
+			}
+		}
+	}
+	_, ok = readPostgresFormats(&r)
+	return ok && r.Remaining() == 0
+}
+
+func readPostgresFormats(r *largebuf.LargeBufferReader) (uint16, bool) {
+	count, err := r.ReadU16BE()
+	if err != nil || int(count) > r.Remaining()/2 {
+		return 0, false
+	}
+	for range int(count) {
+		format, err := r.ReadU16BE()
+		if err != nil || format > 1 {
+			return 0, false
+		}
+	}
+	return count, true
+}
+
 // msgBody returns the raw bytes of the Postgres message body (after the 5-byte header),
 // bounded by the message size field. Returns an error if the buffer is too short.
 func msgBody(b *largebuf.LargeBuffer) ([]byte, error) {

--- a/pkg/ebpf/common/sql_detect_postgres.go
+++ b/pkg/ebpf/common/sql_detect_postgres.go
@@ -87,7 +87,8 @@ func isValidPostgresPayload(b *largebuf.LargeBuffer) (byte, bool) {
 	}
 
 	size, err := b.I32BEAt(1)
-	if err != nil || size < 0 || size > 3000 {
+	// The declared length includes the four-byte length field itself.
+	if err != nil || size < pgHeaderLen-1 || size > 3000 {
 		return 0, false
 	}
 

--- a/pkg/ebpf/common/sql_detect_transform.go
+++ b/pkg/ebpf/common/sql_detect_transform.go
@@ -13,14 +13,11 @@ import (
 func sqlKind(b *largebuf.LargeBuffer) request.SQLKind {
 	if isPostgres(b) {
 		if isMySQL(b) {
-			size, _ := b.I32BEAt(1)
-			if int(size)+1 > b.Len() {
-				// A truncated, ambiguous header cannot establish either protocol.
-				return request.DBGeneric
-			}
-			if !validPostgresSQLBody(b) {
+			if postgresSQLBodyStatus(b) == postgresBodyInvalid {
 				return request.DBMySQL
 			}
+			// Retain the existing PG fallback for incomplete captures. Generic
+			// would suppress SQL extraction when heuristic detection is disabled.
 		}
 		return request.DBPostgres
 	}

--- a/pkg/ebpf/common/sql_detect_transform.go
+++ b/pkg/ebpf/common/sql_detect_transform.go
@@ -12,6 +12,16 @@ import (
 
 func sqlKind(b *largebuf.LargeBuffer) request.SQLKind {
 	if isPostgres(b) {
+		if isMySQL(b) {
+			size, _ := b.I32BEAt(1)
+			if int(size)+1 > b.Len() {
+				// A truncated, ambiguous header cannot establish either protocol.
+				return request.DBGeneric
+			}
+			if !validPostgresSQLBody(b) {
+				return request.DBMySQL
+			}
+		}
 		return request.DBPostgres
 	}
 	if isMySQL(b) {

--- a/pkg/ebpf/common/sql_detect_transform.go
+++ b/pkg/ebpf/common/sql_detect_transform.go
@@ -12,13 +12,11 @@ import (
 
 func sqlKind(b *largebuf.LargeBuffer) request.SQLKind {
 	if isPostgres(b) {
-		if isMySQL(b) {
-			if postgresSQLBodyStatus(b) == postgresBodyInvalid {
-				return request.DBMySQL
-			}
-			// Retain the existing PG fallback for incomplete captures. Generic
-			// would suppress SQL extraction when heuristic detection is disabled.
+		if isMySQL(b) && postgresSQLBodyStatus(b) == postgresBodyInvalid {
+			return request.DBMySQL
 		}
+		// Retain the existing PG fallback for incomplete captures. Generic
+		// would suppress SQL extraction when heuristic detection is disabled.
 		return request.DBPostgres
 	}
 	if isMySQL(b) {

--- a/pkg/ebpf/common/sql_protocol_detection_test.go
+++ b/pkg/ebpf/common/sql_protocol_detection_test.go
@@ -94,3 +94,80 @@ func TestPostgresProtocolLengthField(t *testing.T) {
 		})
 	}
 }
+
+func TestMySQLPreparedProtocolLengthCollision(t *testing.T) {
+	for _, command := range []byte{kMySQLPrepare, kMySQLExecute} {
+		for _, payloadLength := range []int{65, 66, 67, 68, 80, 81, 82, 255, 256, 337} {
+			t.Run(fmt.Sprintf("%x/%d", command, payloadLength), func(t *testing.T) {
+				packet := make([]byte, 4+payloadLength)
+				binary.LittleEndian.PutUint32(packet, uint32(payloadLength))
+				packet[4] = command
+				if command == kMySQLPrepare {
+					copy(packet[5:], "SELECT ?"+strings.Repeat(" ", payloadLength))
+				} else {
+					// Statement 1, cursor flags 0, iteration count 1, one non-NULL
+					// string parameter with its type supplied on this execution.
+					binary.LittleEndian.PutUint32(packet[5:], 1)
+					binary.LittleEndian.PutUint32(packet[10:], 1)
+					packet[15] = 1
+					packet[16] = 0xfd // MYSQL_TYPE_VAR_STRING
+					value := strings.Repeat("x", len(packet)-21)
+					packet[18] = 0xfc // two-byte length-encoded string length
+					binary.LittleEndian.PutUint16(packet[19:], uint16(len(value)))
+					copy(packet[21:], value)
+				}
+				assert.Equal(t, request.DBMySQL, sqlKind(largebuf.NewLargeBufferFrom(packet)))
+			})
+		}
+	}
+}
+
+func postgresTestPacket(op byte, body []byte) []byte {
+	packet := make([]byte, pgHeaderLen+len(body))
+	packet[0] = op
+	binary.BigEndian.PutUint32(packet[1:], uint32(len(packet)-1))
+	copy(packet[pgHeaderLen:], body)
+	return packet
+}
+
+func TestPostgresReverseProtocolCollision(t *testing.T) {
+	for _, op := range []byte{kPostgresQuery, kPostgresCommand, kPostgresBind} {
+		for size := 12; size <= 3000; size++ {
+			if byte(size) != kMySQLQuery && byte(size) != kMySQLPrepare && byte(size) != kMySQLExecute {
+				continue
+			}
+			t.Run(fmt.Sprintf("%c/%d", op, size), func(t *testing.T) {
+				var body []byte
+				if op == kPostgresBind {
+					// Portal name, empty statement name, zero formats/parameters/results.
+					body = append([]byte(strings.Repeat("p", size-4-8)), make([]byte, 8)...)
+				} else {
+					body = append([]byte("SELECT 1"+strings.Repeat(" ", size-4-9)), 0)
+				}
+				packet := postgresTestPacket(op, body)
+				require.True(t, isMySQL(largebuf.NewLargeBufferFrom(packet)), "exercise overlapping headers")
+				assert.Equal(t, request.DBPostgres, sqlKind(largebuf.NewLargeBufferFrom(packet)))
+				// Coalesced messages must not be mistaken for a length mismatch.
+				pipeline := append(append([]byte(nil), packet...), postgresTestPacket('S', nil)...)
+				assert.Equal(t, request.DBPostgres, sqlKind(largebuf.NewLargeBufferFrom(pipeline)))
+				assert.Equal(t, request.DBGeneric, sqlKind(largebuf.NewLargeBufferFrom(packet[:6])))
+			})
+		}
+	}
+}
+
+func TestPostgresBindBodyValidation(t *testing.T) {
+	// Empty names, two parameter formats (text/binary), NULL and empty values,
+	// and one binary result format.
+	valid := []byte{0, 0, 0, 2, 0, 0, 0, 1, 0, 2, 255, 255, 255, 255, 0, 0, 0, 0, 0, 1, 0, 1}
+	assert.True(t, validPostgresSQLBody(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, valid))))
+	for n := 0; n < len(valid); n++ {
+		assert.False(t, validPostgresSQLBody(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, valid[:n]))), "prefix %d", n)
+	}
+	for _, pos := range []int{7, 9, 13, 17, 21} {
+		invalid := append([]byte(nil), valid...)
+		invalid[pos] = 3 // bad format, count, NULL length, value length or result format
+		assert.False(t, validPostgresSQLBody(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, invalid))), "offset %d", pos)
+	}
+	assert.False(t, validPostgresSQLBody(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, append(valid, 0)))))
+}

--- a/pkg/ebpf/common/sql_protocol_detection_test.go
+++ b/pkg/ebpf/common/sql_protocol_detection_test.go
@@ -6,6 +6,7 @@ package ebpfcommon
 import (
 	"encoding/binary"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -20,7 +21,7 @@ import (
 func TestMySQLQueryProtocolLengthCollision(t *testing.T) {
 	// Payload lengths 66, 67 and 81 start with PostgreSQL B, C and Q bytes.
 	for _, sqlLength := range []int{64, 65, 66, 67, 79, 80, 81, 82, 336} {
-		t.Run(fmt.Sprint(sqlLength), func(t *testing.T) {
+		t.Run(strconv.Itoa(sqlLength), func(t *testing.T) {
 			query := "SELECT 1" + strings.Repeat(" ", sqlLength-len("SELECT 1"))
 			packet := make([]byte, 4+1+len(query))
 			binary.LittleEndian.PutUint32(packet, uint32(1+len(query)))
@@ -88,7 +89,7 @@ func TestPostgresProtocolLengthField(t *testing.T) {
 			assert.True(t, isPostgres(largebuf.NewLargeBufferFrom(packet)))
 			// Capture truncation does not change a valid declared length.
 			assert.True(t, isPostgres(largebuf.NewLargeBufferFrom(packet[:pgHeaderLen])))
-			for size := 0; size < pgHeaderLen; size++ {
+			for size := range pgHeaderLen {
 				assert.False(t, isPostgres(largebuf.NewLargeBufferFrom(packet[:size])))
 			}
 		})
@@ -107,14 +108,14 @@ func TestMySQLPreparedProtocolLengthCollision(t *testing.T) {
 				} else {
 					// Statement 1, cursor flags 0, iteration count 1, one non-NULL
 					// string parameter with its type supplied on this execution.
-					binary.LittleEndian.PutUint32(packet[5:], 1)
-					binary.LittleEndian.PutUint32(packet[10:], 1)
-					packet[15] = 1
-					packet[16] = 0xfd // MYSQL_TYPE_VAR_STRING
+					binary.LittleEndian.PutUint32(packet[5:], 1)  // statement ID
+					binary.LittleEndian.PutUint32(packet[10:], 1) // iteration count; flags at 9 remain zero
+					packet[15] = 1                                // new_params_bound; NULL bitmap at 14 remains zero
+					packet[16] = 0xfd                             // MYSQL_TYPE_VAR_STRING
 					value := strings.Repeat("x", len(packet)-21)
-					packet[18] = 0xfc // two-byte length-encoded string length
-					binary.LittleEndian.PutUint16(packet[19:], uint16(len(value)))
-					copy(packet[21:], value)
+					packet[18] = 0xfc                                              // two-byte length-encoded string length
+					binary.LittleEndian.PutUint16(packet[19:], uint16(len(value))) // string length
+					copy(packet[21:], value)                                       // string bytes
 				}
 				assert.Equal(t, request.DBMySQL, sqlKind(largebuf.NewLargeBufferFrom(packet)))
 			})
@@ -150,7 +151,7 @@ func TestPostgresReverseProtocolCollision(t *testing.T) {
 				// Coalesced messages must not be mistaken for a length mismatch.
 				pipeline := append(append([]byte(nil), packet...), postgresTestPacket('S', nil)...)
 				assert.Equal(t, request.DBPostgres, sqlKind(largebuf.NewLargeBufferFrom(pipeline)))
-				assert.Equal(t, request.DBGeneric, sqlKind(largebuf.NewLargeBufferFrom(packet[:6])))
+				assert.Equal(t, request.DBPostgres, sqlKind(largebuf.NewLargeBufferFrom(packet[:6])))
 			})
 		}
 	}
@@ -160,14 +161,80 @@ func TestPostgresBindBodyValidation(t *testing.T) {
 	// Empty names, two parameter formats (text/binary), NULL and empty values,
 	// and one binary result format.
 	valid := []byte{0, 0, 0, 2, 0, 0, 0, 1, 0, 2, 255, 255, 255, 255, 0, 0, 0, 0, 0, 1, 0, 1}
-	assert.True(t, validPostgresSQLBody(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, valid))))
-	for n := 0; n < len(valid); n++ {
-		assert.False(t, validPostgresSQLBody(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, valid[:n]))), "prefix %d", n)
+	assert.Equal(t, postgresBodyValid, postgresSQLBodyStatus(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, valid))))
+	for n := range valid {
+		assert.Equal(t, postgresBodyInvalid, postgresSQLBodyStatus(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, valid[:n]))), "prefix %d", n)
 	}
 	for _, pos := range []int{7, 9, 13, 17, 21} {
 		invalid := append([]byte(nil), valid...)
 		invalid[pos] = 3 // bad format, count, NULL length, value length or result format
-		assert.False(t, validPostgresSQLBody(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, invalid))), "offset %d", pos)
+		assert.Equal(t, postgresBodyInvalid, postgresSQLBodyStatus(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, invalid))), "offset %d", pos)
 	}
-	assert.False(t, validPostgresSQLBody(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, append(valid, 0)))))
+	assert.Equal(t, postgresBodyInvalid, postgresSQLBodyStatus(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresBind, append(valid, 0)))))
+}
+
+func TestPostgresSQLBodyCompleteness(t *testing.T) {
+	for _, packet := range [][]byte{
+		postgresTestPacket(kPostgresQuery, []byte("SELECT 1\x00")),
+		postgresTestPacket(kPostgresBind, make([]byte, 8)),
+		postgresTestPacket(kPostgresCommand, []byte("SELECT 1\x00")),
+		postgresTestPacket(kPostgresCommand, []byte("Sstatement\x00")),
+		postgresTestPacket(kPostgresCommand, []byte("Pportal\x00")),
+	} {
+		assert.Equal(t, postgresBodyValid, postgresSQLBodyStatus(largebuf.NewLargeBufferFrom(packet)))
+		for n := range packet {
+			assert.Equal(t, postgresBodyIncomplete, postgresSQLBodyStatus(largebuf.NewLargeBufferFrom(packet[:n])), "op %c prefix %d", packet[0], n)
+		}
+	}
+	for _, body := range []string{"SELECT 1", "SELECT\x00extra\x00"} {
+		assert.Equal(t, postgresBodyInvalid, postgresSQLBodyStatus(largebuf.NewLargeBufferFrom(postgresTestPacket(kPostgresQuery, []byte(body)))))
+	}
+	assert.Equal(t, postgresBodyInvalid, postgresSQLBodyStatus(largebuf.NewLargeBufferFrom(postgresTestPacket('X', nil))))
+}
+
+func TestMatchSQLTruncatedPostgresCollision(t *testing.T) {
+	for _, declaredSize := range []int{22, 23, 259, 278, 279} {
+		t.Run(strconv.Itoa(declaredSize), func(t *testing.T) {
+			body := append([]byte("SELECT 1"+strings.Repeat(" ", declaredSize-4-9)), 0)
+			packet := postgresTestPacket(kPostgresQuery, body)
+			// Retain the complete SELECT expression, but not the full declared message.
+			captured := packet[:pgHeaderLen+len("SELECT 1")]
+			buf := largebuf.NewLargeBufferFrom(captured)
+			require.True(t, isMySQL(buf))
+			require.Equal(t, postgresBodyIncomplete, postgresSQLBodyStatus(buf))
+			cfg := config.EBPFTracer{
+				CouchbaseDBCacheSize:                1,
+				MySQLPreparedStatementsCacheSize:    1,
+				PostgresPreparedStatementsCacheSize: 1,
+				MSSQLPreparedStatementsCacheSize:    1,
+				KafkaTopicUUIDCacheSize:             1,
+				MongoRequestsCacheSize:              1,
+			}
+			require.False(t, cfg.HeuristicSQLDetect)
+			ctx := NewEBPFParseContext(&cfg, nil, nil)
+			span, ignore, matched, err := matchSQL(ctx, &cfg, &TCPRequestInfo{}, buf, largebuf.NewLargeBufferFrom(nil))
+			require.NoError(t, err)
+			require.True(t, matched, "default configuration must not drop the query")
+			assert.False(t, ignore)
+			assert.Equal(t, int(request.DBPostgres), span.SubType)
+			assert.Equal(t, "SELECT", span.Method)
+			assert.Contains(t, span.Statement, "SELECT 1")
+		})
+	}
+}
+
+func TestPostgresBindSharedFormats(t *testing.T) {
+	// Unnamed portal/statement, one text parameter format, one five-byte value.
+	body := []byte{0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 5, 'a', 'b', 'c', 'd', 'e', 0, 0}
+	packet := postgresTestPacket(kPostgresBind, body)
+	_, _, args, err := parsePostgresBindCommand(largebuf.NewLargeBufferFrom(packet))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"abcde"}, args)
+	_, _, args, err = parsePostgresBindCommand(largebuf.NewLargeBufferFrom(packet[:pgHeaderLen+14]))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"ab"}, args, "extraction must still tolerate a truncated value")
+	packet[pgHeaderLen+5] = 2 // Invalid format code, now rejected by both paths.
+	_, _, _, err = parsePostgresBindCommand(largebuf.NewLargeBufferFrom(packet))
+	require.Error(t, err)
+	assert.Equal(t, postgresBodyInvalid, postgresSQLBodyStatus(largebuf.NewLargeBufferFrom(packet)))
 }

--- a/pkg/ebpf/common/sql_protocol_detection_test.go
+++ b/pkg/ebpf/common/sql_protocol_detection_test.go
@@ -1,0 +1,96 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/internal/largebuf"
+)
+
+func TestMySQLQueryProtocolLengthCollision(t *testing.T) {
+	// Payload lengths 66, 67 and 81 start with PostgreSQL B, C and Q bytes.
+	for _, sqlLength := range []int{64, 65, 66, 67, 79, 80, 81, 82, 336} {
+		t.Run(fmt.Sprint(sqlLength), func(t *testing.T) {
+			query := "SELECT 1" + strings.Repeat(" ", sqlLength-len("SELECT 1"))
+			packet := make([]byte, 4+1+len(query))
+			binary.LittleEndian.PutUint32(packet, uint32(1+len(query)))
+			packet[4] = kMySQLQuery
+			copy(packet[5:], query)
+			buf := largebuf.NewLargeBufferFrom(packet)
+
+			assert.False(t, isPostgres(buf))
+			assert.Equal(t, request.DBMySQL, sqlKind(buf))
+
+			cfg := &config.EBPFTracer{
+				CouchbaseDBCacheSize:                1,
+				MySQLPreparedStatementsCacheSize:    1,
+				PostgresPreparedStatementsCacheSize: 1,
+				MSSQLPreparedStatementsCacheSize:    1,
+				KafkaTopicUUIDCacheSize:             1,
+				MongoRequestsCacheSize:              1,
+			}
+			ctx := NewEBPFParseContext(cfg, nil, nil)
+			span, ignore, matched, err := matchSQL(ctx, cfg, &TCPRequestInfo{}, buf, largebuf.NewLargeBufferFrom(nil))
+			require.NoError(t, err)
+			require.True(t, matched)
+			assert.False(t, ignore)
+			assert.Equal(t, int(request.DBMySQL), span.SubType)
+			assert.Equal(t, "SELECT", span.Method)
+		})
+	}
+}
+
+func TestPostgresProtocolLengthField(t *testing.T) {
+	t.Run("minimum_length", func(t *testing.T) {
+		// Sync has no body: its length is exactly the four-byte length field.
+		packet := []byte{'S', 0, 0, 0, 4}
+		op, valid := isValidPostgresPayload(largebuf.NewLargeBufferFrom(packet))
+		assert.True(t, valid)
+		assert.Equal(t, byte('S'), op)
+	})
+
+	for _, op := range []byte{kPostgresQuery, kPostgresCommand, kPostgresBind} {
+		for size := int32(-1); size < pgHeaderLen-1; size++ {
+			t.Run(fmt.Sprintf("%c/%d", op, size), func(t *testing.T) {
+				packet := make([]byte, pgHeaderLen)
+				packet[0] = op
+				binary.BigEndian.PutUint32(packet[1:], uint32(size))
+				_, valid := isValidPostgresPayload(largebuf.NewLargeBufferFrom(packet))
+				assert.False(t, valid)
+			})
+		}
+	}
+
+	for _, tt := range []struct {
+		name string
+		op   byte
+		body []byte
+	}{
+		{"query", kPostgresQuery, []byte("SELECT 1\x00")},
+		{"command_complete", kPostgresCommand, []byte("SELECT 1\x00")},
+		{"bind", kPostgresBind, make([]byte, 8)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			packet := make([]byte, pgHeaderLen+len(tt.body))
+			packet[0] = tt.op
+			binary.BigEndian.PutUint32(packet[1:], uint32(len(packet)-1))
+			copy(packet[pgHeaderLen:], tt.body)
+			assert.True(t, isPostgres(largebuf.NewLargeBufferFrom(packet)))
+			// Capture truncation does not change a valid declared length.
+			assert.True(t, isPostgres(largebuf.NewLargeBufferFrom(packet[:pgHeaderLen])))
+			for size := 0; size < pgHeaderLen; size++ {
+				assert.False(t, isPostgres(largebuf.NewLargeBufferFrom(packet[:size])))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

While using OBI to monitor MatrixOne's MySQL-protocol traffic, we found that some requests were misidentified as PostgreSQL. MySQL QUERY, PREPARE, and EXECUTE packets of certain lengths match both protocols' header heuristics, and the existing detection order prefers PostgreSQL.

This change corrects the minimum PostgreSQL message length and, when both headers match, validates the structure of the first complete PostgreSQL message rather than simply reversing detection order. Validation stays within that message's declared boundary, allowing subsequent pipelined messages in the same buffer. These changes address the same classification bug: the length check alone does not resolve PREPARE/EXECUTE collisions.

For truncated captures that cannot be disambiguated, the existing PostgreSQL classification is retained. Returning Generic would suppress SQL extraction with heuristic detection disabled by default. This preserves existing behavior but does not eliminate all protocol misclassification for truncated packets.

The change affects generic TCP fallback detection, not dispatch for protocols already classified by the kernel. Bind format-code reading is shared with the extraction path; invalid formats are rejected, while extraction still tolerates truncated parameter values. No new connection cache or configuration is introduced.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md).
- [x] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed. No updates needed: this corrects fallback classification within existing protocol support.

Regression tests cover:
- MySQL QUERY, PREPARE, and EXECUTE length collisions, including the six PREPARE/EXECUTE cases with payload lengths 66, 67, and 81.
- Reverse-direction PostgreSQL Q/C/B header collisions, pipelined and truncated captures, Bind structure, and frontend Close messages.
- Span generation for truncated queries with heuristic detection disabled. Restoring the Generic downgrade makes all five affected span-level cases fail.

Passed locally (Go 1.26.2, GOTOOLCHAIN=local):
- `go test -p 2 -mod=readonly ./pkg/ebpf/common -count=1 -timeout=120s`
- `go tool -modfile=internal/tools/go.mod golangci-lint run ./pkg/ebpf/common --timeout=6m`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -p 2 -mod=readonly ./pkg/ebpf/common`

Validation was scoped to the affected package; no cluster end-to-end test was run for this patch.

## AI assistance

Codex assisted with the implementation and tests. I reviewed the code and regression tests and understand the protocol disambiguation approach and the truncated-capture trade-off. Codex also assisted with translating and preparing this description.
