### PR TITLE
add resilience to semconv deps

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,6 +80,12 @@ jobs:
         with:
           name: bpf-generated-${{ github.run_id }}
 
+      - name: Upstream semconv registry cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] pinned upstream semconv tarball, keyed on the version in schemas/obi/manifest.yaml
+        with:
+          path: schemas/obi/.deps
+          key: semconv-deps-${{ hashFiles('schemas/obi/manifest.yaml') }}
+
       - name: Build test tools
         run: make prereqs
 

--- a/.github/workflows/pull_request_integration_tests.yml
+++ b/.github/workflows/pull_request_integration_tests.yml
@@ -221,6 +221,12 @@ jobs:
         with:
           name: bpf-generated-${{ github.run_id }}
 
+      - name: Upstream semconv registry cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] pinned upstream semconv tarball, keyed on the version in schemas/obi/manifest.yaml
+        with:
+          path: schemas/obi/.deps
+          key: semconv-deps-${{ hashFiles('schemas/obi/manifest.yaml') }}
+
       - name: Build test tools
         run: make prereqs
 

--- a/.github/workflows/pull_request_k8s_integration_tests.yml
+++ b/.github/workflows/pull_request_k8s_integration_tests.yml
@@ -123,6 +123,12 @@ jobs:
         with:
           name: bpf-generated-${{ github.run_id }}
 
+      - name: Upstream semconv registry cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] pinned upstream semconv tarball, keyed on the version in schemas/obi/manifest.yaml
+        with:
+          path: schemas/obi/.deps
+          key: semconv-deps-${{ hashFiles('schemas/obi/manifest.yaml') }}
+
       - name: Build test tools
         run: make prereqs
 

--- a/.github/workflows/pull_request_oats_test.yml
+++ b/.github/workflows/pull_request_oats_test.yml
@@ -123,6 +123,12 @@ jobs:
         with:
           name: bpf-generated-${{ github.run_id }}
 
+      - name: Upstream semconv registry cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] pinned upstream semconv tarball, keyed on the version in schemas/obi/manifest.yaml
+        with:
+          path: schemas/obi/.deps
+          key: semconv-deps-${{ hashFiles('schemas/obi/manifest.yaml') }}
+
       - name: Build test tools
         run: make prereqs
 

--- a/.github/workflows/pull_request_privileged.yml
+++ b/.github/workflows/pull_request_privileged.yml
@@ -64,6 +64,12 @@ jobs:
           restore-keys: |
             go-build-pr-race-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Upstream semconv registry cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] pinned upstream semconv tarball, keyed on the version in schemas/obi/manifest.yaml
+        with:
+          path: schemas/obi/.deps
+          key: semconv-deps-${{ hashFiles('schemas/obi/manifest.yaml') }}
+
       - name: Generate BPF + build test tools
         run: make prereqs docker-generate
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -110,6 +110,12 @@ jobs:
         with:
           name: bpf-generated-${{ github.run_id }}
 
+      - name: Upstream semconv registry cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] pinned upstream semconv tarball, keyed on the version in schemas/obi/manifest.yaml
+        with:
+          path: schemas/obi/.deps
+          key: semconv-deps-${{ hashFiles('schemas/obi/manifest.yaml') }}
+
       - name: Build test tools
         run: make prereqs
 

--- a/.github/workflows/workflow_integration_tests_vm.yml
+++ b/.github/workflows/workflow_integration_tests_vm.yml
@@ -156,6 +156,12 @@ jobs:
           restore-keys: |
             go-build-vm-integration-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Upstream semconv registry cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning] pinned upstream semconv tarball, keyed on the version in schemas/obi/manifest.yaml
+        with:
+          path: schemas/obi/.deps
+          key: semconv-deps-${{ hashFiles('schemas/obi/manifest.yaml') }}
+
       - name: Generate BPF + build test tools
         run: make prereqs docker-generate
 

--- a/scripts/fetch-upstream-semconv.sh
+++ b/scripts/fetch-upstream-semconv.sh
@@ -38,7 +38,16 @@ TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
 echo "fetch-upstream-semconv: fetching v$VERSION into $TARGET/model"
-curl -fsSL "https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/v${VERSION}.tar.gz" \
-  | tar -xz -C "$TMPDIR" --strip-components=1 "semantic-conventions-${VERSION}/model"
+TARBALL="$TMPDIR/semantic-conventions-v${VERSION}.tar.gz"
+curl -fsSL \
+  --connect-timeout 15 \
+  --retry 5 \
+  --retry-delay 2 \
+  --retry-all-errors \
+  --retry-max-time 180 \
+  -o "$TARBALL" \
+  "https://github.com/open-telemetry/semantic-conventions/archive/refs/tags/v${VERSION}.tar.gz"
+
+tar -xzf "$TARBALL" -C "$TMPDIR" --strip-components=1 "semantic-conventions-${VERSION}/model"
 
 mv "$TMPDIR/model" "$TARGET/model"


### PR DESCRIPTION
## Summary

`make prereqs` fetched the pinned upstream semconv registry with a single unretried `curl | tar`, so one transient GitHub error failed the whole job — most recently a 504 taking out a k8s integration matrix job, which needs the registry mounted into the kind node for the in-cluster weaver pod.

- Retry the fetch, downloading the tarball to a file before extracting. Piping straight into `tar` is not retry-safe: on a partial transfer `tar` has already consumed a truncated stream by the time curl retries.
- Cache `schemas/obi/.deps`, keyed on the version in `schemas/obi/manifest.yaml`. The script already no-ops when the registry is present, so a cache hit skips the network entirely.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
