### PR TITLE
Fix vacuous inter-zone attribute assertion in netolly multizone suite

### DIFF
--- a/internal/test/integration/k8s/manifests/06-obi-netolly-promexport.yml
+++ b/internal/test/integration/k8s/manifests/06-obi-netolly-promexport.yml
@@ -32,6 +32,9 @@ data:
           # assured cardinality explosion. Don't try in production!
           include: ["*"]
           exclude: ["src_port"]
+        obi.network.inter.zone.bytes:
+          include: ["*"]
+          exclude: ["src_port"]
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/internal/test/integration/k8s/netolly_multizone/netolly_multizone_feature.go
+++ b/internal/test/integration/k8s/netolly_multizone/netolly_multizone_feature.go
@@ -133,9 +133,12 @@ func testInterZoneMetric(ctx context.Context, t *testing.T, _ *envconf.Config) c
 			`dst_zone="client-zone", src_zone="server-zone"}`)
 		require.NoError(ct, err)
 		require.NotEmpty(ct, results)
-		// AND the reported attributes are different from the flow bytes attributes
-		require.NotContains(ct, results, "k8s_src_type")
-		require.NotContains(ct, results, "iface_direction")
+		// AND they carry the kubernetes decoration selected for this metric
+		for _, res := range results {
+			assert.Equal(ct, "my-kube", res.Metric["k8s_cluster_name"])
+			assert.NotEmpty(ct, res.Metric["k8s_src_type"])
+			assert.NotEmpty(ct, res.Metric["k8s_dst_type"])
+		}
 	}, testTimeout, 100*time.Millisecond)
 
 	// BUT same-zone bytes are not reported in this metric


### PR DESCRIPTION
## Summary

This PR fixes a broken assertion in `testInterZoneMetric` found in #3329.

Basically the test asserted that `k8s_src_type` and `iface_direction` were absent from `obi.network.inter.zone.bytes`. The check ran `NotContains` on a `[]Result` slice against a `string`, so it never inspected labels and always passed.

#3329 selected `include: ["*"]` for that metric, so both attributes are now present and the original intent no longer holds. The check is replaced with a positive one.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
