### PR TITLE
bind weaver grpc address to 0.0.0.0

### DIFF
--- a/internal/test/integration/components/weaver/service.yml
+++ b/internal/test/integration/components/weaver/service.yml
@@ -35,6 +35,8 @@ services:
       - --include-unreferenced
       - --inactivity-timeout
       - "300"
+      - --otlp-grpc-address
+      - "0.0.0.0"
       - --admin-port
       - "4320"
       - --format

--- a/internal/test/integration/k8s/manifests/08-weaver-multi-node.yml
+++ b/internal/test/integration/k8s/manifests/08-weaver-multi-node.yml
@@ -81,6 +81,8 @@ spec:
         - --include-unreferenced
         - --inactivity-timeout
         - "300"
+        - --otlp-grpc-address
+        - "0.0.0.0"
         - --admin-port
         - "4320"
         - --format

--- a/internal/test/integration/k8s/manifests/08-weaver.yml
+++ b/internal/test/integration/k8s/manifests/08-weaver.yml
@@ -80,6 +80,8 @@ spec:
         - --include-unreferenced
         - --inactivity-timeout
         - "300"
+        - --otlp-grpc-address
+        - "0.0.0.0"
         - --admin-port
         - "4320"
         - --format

--- a/internal/test/oats/weaver/docker-compose-weaver.yml
+++ b/internal/test/oats/weaver/docker-compose-weaver.yml
@@ -35,6 +35,8 @@ services:
       - --include-unreferenced
       - --inactivity-timeout
       - "300"
+      - --otlp-grpc-address
+      - "0.0.0.0"
       - --admin-port
       - "4320"
       - --format


### PR DESCRIPTION
## Summary

Blocks https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3348
Following [weaver breaking change](https://github.com/open-telemetry/weaver/releases/tag/v0.26.0)
livecheck listens on `127.0.0.1` instead of `0.0.0.0` by default
## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
