### PR TITLE
fix MCP span name and gen_ai.operation.name conformance

### DIFF
--- a/internal/test/integration/red_test_python_mcp.go
+++ b/internal/test/integration/red_test_python_mcp.go
@@ -137,7 +137,7 @@ func testPythonMCPServer(t *testing.T) {
 		lastTrace := traces[len(traces)-1]
 		// The trace may contain child spans ("in queue", "processing");
 		// locate the MCP server span by its expected operation name.
-		res := lastTrace.FindByOperationName("execute_tool get-weather", "server")
+		res := lastTrace.FindByOperationName("tools/call get-weather", "server")
 		require.GreaterOrEqual(ct, len(res), 1)
 		span := res[0]
 
@@ -186,7 +186,7 @@ func testPythonMCPServer(t *testing.T) {
 		require.GreaterOrEqual(ct, len(traces), 1)
 
 		lastTrace := traces[len(traces)-1]
-		res := lastTrace.FindByOperationName("execute_tool nonexistent", "server")
+		res := lastTrace.FindByOperationName("tools/call nonexistent", "server")
 		require.GreaterOrEqual(ct, len(res), 1)
 		span := res[0]
 
@@ -239,11 +239,13 @@ func testPythonMCPInitialize(t *testing.T) {
 
 		sd := span.Diff(
 			jaeger.Tag{Key: "mcp.method.name", Type: "string", Value: "initialize"},
-			jaeger.Tag{Key: "gen_ai.operation.name", Type: "string", Value: "initialize"},
 			jaeger.Tag{Key: "mcp.protocol.version", Type: "string", Value: "2025-03-26"},
 			jaeger.Tag{Key: "jsonrpc.request.id", Type: "string", Value: "10"},
 		)
 		assert.Empty(ct, sd, sd.String())
+
+		_, found := jaeger.FindIn(span.Tags, "gen_ai.operation.name")
+		assert.False(ct, found, "gen_ai.operation.name is set for tool calls only")
 	}, testTimeout, 100*time.Millisecond)
 }
 
@@ -265,7 +267,7 @@ func testPythonMCPClient(t *testing.T) {
 	// The outbound call the tool makes, named after the tool it invokes on the
 	// remote server. Scoping the query to it keeps the server-side traces the
 	// retry loop generates from filling the result page.
-	params.Add("operation", "execute_tool get-weather")
+	params.Add("operation", "tools/call get-weather")
 	fullJaegerURL := fmt.Sprintf("%s?%s", jaegerQueryURL, params.Encode())
 
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
@@ -289,7 +291,7 @@ func testPythonMCPClient(t *testing.T) {
 		var clientSpans []jaeger.Span
 		for _, trace := range tq.Data {
 			clientSpans = append(clientSpans,
-				trace.FindByOperationNameServiceAndKind("execute_tool get-weather", comm, "client")...)
+				trace.FindByOperationNameServiceAndKind("tools/call get-weather", comm, "client")...)
 		}
 		require.NotEmpty(ct, clientSpans, "no client-kind MCP span found")
 

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -970,13 +970,35 @@ type MCPCall struct {
 	ErrorMessage      string `json:"errorMessage,omitempty"`
 }
 
-// OperationName returns the GenAI operation name for the MCP method.
-// tools/call maps to execute_tool; other methods return the method name as-is.
-func (m *MCPCall) OperationName() string {
-	if m.Method == "tools/call" {
-		return "execute_tool"
+// MCPMethodToolsCall is the MCP method name for a tool call, the one method
+// that carries a GenAI operation name.
+const MCPMethodToolsCall = "tools/call"
+
+// GenAIOperationName returns the GenAI operation name for the MCP method.
+// Semantic conventions set it to execute_tool for a tool call and leave it
+// unset for every other method, so that consumers can treat MCP tool calls
+// like any other tool call.
+func (m *MCPCall) GenAIOperationName() string {
+	if m.Method == MCPMethodToolsCall {
+		return ExecuteToolOperationName
+	}
+	return ""
+}
+
+// SpanName is the MCP method name, followed by a target when a
+// low-cardinality one is available.
+func (m *MCPCall) SpanName() string {
+	if target := m.lowCardinalityTarget(); target != "" {
+		return m.Method + " " + target
 	}
 	return m.Method
+}
+
+func (m *MCPCall) lowCardinalityTarget() string {
+	if m.ToolName != "" {
+		return m.ToolName
+	}
+	return m.PromptName
 }
 
 type JSONRPC struct {
@@ -998,6 +1020,7 @@ const (
 	EmbeddingOperationName    = "embeddings"
 	ResponseOperationName     = "response"
 	ConversationOperationName = "conversation"
+	ExecuteToolOperationName  = "execute_tool"
 )
 
 // VendorEmbedding represents a generic embedding API provider such as
@@ -2094,11 +2117,7 @@ func (s *Span) TraceName() string {
 		}
 
 		if s.SubType == HTTPSubtypeMCP && s.GenAI != nil && s.GenAI.MCP != nil {
-			op := s.GenAI.MCP.OperationName()
-			if s.GenAI.MCP.ToolName != "" {
-				return op + " " + s.GenAI.MCP.ToolName
-			}
-			return op
+			return s.GenAI.MCP.SpanName()
 		}
 
 		if s.Type == EventTypeHTTPClient && s.SubType == HTTPSubtypeEmbedding && s.GenAI != nil && s.GenAI.Embedding != nil {

--- a/pkg/ebpf/common/http/mcp.go
+++ b/pkg/ebpf/common/http/mcp.go
@@ -16,7 +16,7 @@ import (
 var mcpMethods = map[string]struct{}{
 	"initialize":                         {},
 	"notifications/initialized":          {},
-	"tools/call":                         {},
+	request.MCPMethodToolsCall:           {},
 	"tools/list":                         {},
 	"resources/read":                     {},
 	"resources/list":                     {},
@@ -170,7 +170,7 @@ func parseMCPParams(rpcReq jsonRPCRequest, result *request.MCPCall) {
 	}
 
 	switch rpcReq.Method {
-	case "tools/call":
+	case request.MCPMethodToolsCall:
 		var p mcpToolCallParams
 		if json.Unmarshal(rpcReq.Params, &p) == nil {
 			result.ToolName = p.Name
@@ -239,7 +239,7 @@ func applyMCPResponse(resp jsonRPCResponse, result *request.MCPCall) {
 		}
 	}
 
-	if result.Method == "tools/call" && len(resp.Result) > 0 {
+	if result.Method == request.MCPMethodToolsCall && len(resp.Result) > 0 {
 		var toolResult mcpToolCallResult
 		if json.Unmarshal(resp.Result, &toolResult) == nil && len(toolResult.Content) > 0 {
 			result.ToolCallResult = string(toolResult.Content)

--- a/pkg/ebpf/common/http/mcp_test.go
+++ b/pkg/ebpf/common/http/mcp_test.go
@@ -161,7 +161,8 @@ func TestMCPSpan_ToolCall(t *testing.T) {
 	assert.Equal(t, "1", mcp.RequestID)
 	assert.Equal(t, 0, mcp.ErrorCode)
 	assert.Empty(t, mcp.ErrorMessage)
-	assert.Equal(t, "execute_tool", mcp.OperationName())
+	assert.Equal(t, "execute_tool", mcp.GenAIOperationName())
+	assert.Equal(t, "tools/call get-weather", mcp.SpanName())
 }
 
 func TestMCPSpan_ToolCallError(t *testing.T) {
@@ -201,7 +202,8 @@ func TestMCPSpan_ResourceRead(t *testing.T) {
 	assert.Equal(t, "file:///home/user/documents/report.pdf", mcp.ResourceURI)
 	assert.Equal(t, "sess-xyz-456", mcp.SessionID)
 	assert.Equal(t, "3", mcp.RequestID)
-	assert.Equal(t, "resources/read", mcp.OperationName())
+	assert.Empty(t, mcp.GenAIOperationName())
+	assert.Equal(t, "resources/read", mcp.SpanName())
 }
 
 func TestMCPSpan_PromptGet(t *testing.T) {
@@ -219,7 +221,8 @@ func TestMCPSpan_PromptGet(t *testing.T) {
 	assert.Equal(t, "prompts/get", mcp.Method)
 	assert.Equal(t, "analyze-code", mcp.PromptName)
 	assert.Equal(t, "4", mcp.RequestID)
-	assert.Equal(t, "prompts/get", mcp.OperationName())
+	assert.Empty(t, mcp.GenAIOperationName())
+	assert.Equal(t, "prompts/get analyze-code", mcp.SpanName())
 }
 
 func TestMCPSpan_Initialize(t *testing.T) {
@@ -236,7 +239,8 @@ func TestMCPSpan_Initialize(t *testing.T) {
 	assert.Equal(t, "initialize", mcp.Method)
 	assert.Equal(t, "2025-03-26", mcp.ProtocolVer)
 	assert.Equal(t, "5", mcp.RequestID)
-	assert.Equal(t, "initialize", mcp.OperationName())
+	assert.Empty(t, mcp.GenAIOperationName())
+	assert.Equal(t, "initialize", mcp.SpanName())
 }
 
 func TestMCPSpan_InitializeSessionIDFromResponseHeader(t *testing.T) {
@@ -429,23 +433,42 @@ func TestMCPSpan_NoResponseBody(t *testing.T) {
 	assert.Equal(t, 0, span.GenAI.MCP.ErrorCode)
 }
 
-func TestMCPCall_OperationName(t *testing.T) {
+func TestMCPCall_GenAIOperationName(t *testing.T) {
 	tests := []struct {
 		method string
 		want   string
 	}{
 		{method: "tools/call", want: "execute_tool"},
-		{method: "tools/list", want: "tools/list"},
-		{method: "resources/read", want: "resources/read"},
-		{method: "prompts/get", want: "prompts/get"},
-		{method: "initialize", want: "initialize"},
-		{method: "ping", want: "ping"},
+		{method: "tools/list", want: ""},
+		{method: "resources/read", want: ""},
+		{method: "prompts/get", want: ""},
+		{method: "initialize", want: ""},
+		{method: "ping", want: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.method, func(t *testing.T) {
 			mcp := &request.MCPCall{Method: tt.method}
-			assert.Equal(t, tt.want, mcp.OperationName())
+			assert.Equal(t, tt.want, mcp.GenAIOperationName())
+		})
+	}
+}
+
+func TestMCPCall_SpanName(t *testing.T) {
+	tests := []struct {
+		name string
+		call request.MCPCall
+		want string
+	}{
+		{"tool call names the tool", request.MCPCall{Method: "tools/call", ToolName: "get-weather"}, "tools/call get-weather"},
+		{"prompt names the prompt", request.MCPCall{Method: "prompts/get", PromptName: "analyze-code"}, "prompts/get analyze-code"},
+		{"no target is the method alone", request.MCPCall{Method: "tools/list"}, "tools/list"},
+		{"a resource uri is not a span name target", request.MCPCall{Method: "resources/read", ResourceURI: "file:///report.pdf"}, "resources/read"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.call.SpanName())
 		})
 	}
 }

--- a/pkg/export/otel/traces_test.go
+++ b/pkg/export/otel/traces_test.go
@@ -2233,7 +2233,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		attrs := topSpan.Attributes()
 		status := topSpan.Status()
 
-		assert.Equal(t, "execute_tool get-weather", topSpan.Name())
+		assert.Equal(t, "tools/call get-weather", topSpan.Name())
 		assert.Equal(t, ptrace.StatusCodeUnset, status.Code())
 		assert.Empty(t, status.Message())
 
@@ -2272,7 +2272,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		attrs := topSpan.Attributes()
 		status := topSpan.Status()
 
-		assert.Equal(t, "execute_tool nonexistent", topSpan.Name())
+		assert.Equal(t, "tools/call nonexistent", topSpan.Name())
 		assert.Equal(t, ptrace.StatusCodeError, status.Code())
 		assert.Equal(t, "Unknown tool: nonexistent", status.Message())
 
@@ -2309,7 +2309,7 @@ func TestGenerateTracesAttributes(t *testing.T) {
 		attrs := topSpan.Attributes()
 		status := topSpan.Status()
 
-		assert.Equal(t, "execute_tool get-weather", topSpan.Name())
+		assert.Equal(t, "tools/call get-weather", topSpan.Name())
 		assert.Equal(t, ptrace.StatusCodeError, status.Code())
 		assert.Equal(t, "Invalid Request", status.Message())
 

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -445,7 +445,9 @@ func mcpAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) []a
 	mcp := span.GenAI.MCP
 	attrs := []attribute.KeyValue{
 		attribute.String(string(attr.MCPMethodName), mcp.Method),
-		semconv.GenAIOperationNameKey.String(mcp.OperationName()),
+	}
+	if op := mcp.GenAIOperationName(); op != "" {
+		attrs = append(attrs, semconv.GenAIOperationNameKey.String(op))
 	}
 	if mcp.ToolName != "" {
 		attrs = append(attrs, attribute.String(string(attr.GenAIToolName), mcp.ToolName))

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -874,6 +874,42 @@ func (*recordingSampler) Description() string {
 	return "recording sampler"
 }
 
+func TestMCPGenAIOperationNameOnlyForToolCalls(t *testing.T) {
+	tests := []struct {
+		method string
+		want   string
+	}{
+		{method: "tools/call", want: "execute_tool"},
+		{method: "tools/list"},
+		{method: "initialize"},
+		{method: "resources/read"},
+		{method: "prompts/get"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			exported := generateSingleTraceSpan(t, &request.Span{
+				Type:    request.EventTypeHTTPClient,
+				SubType: request.HTTPSubtypeMCP,
+				Method:  "POST",
+				Status:  200,
+				GenAI:   &request.GenAI{MCP: &request.MCPCall{Method: tt.method}},
+			}, map[attr.Name]struct{}{})
+
+			if tt.want == "" {
+				// Semantic conventions require the attribute to be absent
+				// rather than empty for anything but a tool call.
+				assertSpanAttributeAbsent(t, exported, string(attr.GenAIOperationName))
+				return
+			}
+
+			value, ok := exported.Attributes().Get(string(attr.GenAIOperationName))
+			require.True(t, ok)
+			assert.Equal(t, tt.want, value.Str())
+		})
+	}
+}
+
 func generateSingleTraceSpan(
 	t *testing.T,
 	span *request.Span,

--- a/schemas/obi/README.md
+++ b/schemas/obi/README.md
@@ -49,7 +49,7 @@ Until weaver defines local-wins override semantics, every override in
   `unknown` are deliberately NOT declared and keep failing the suites.
 - **Open-ended value space, re-typed as string**: upstream declares an enum,
   but the real value space is unbounded by design — domain-specific error
-  codes (`error.type`) or provider/MCP operation vocabularies
+  codes (`error.type`) or provider operation vocabularies
   (`gen_ai.operation.name`). Enumerating these is impossible, so the override
   re-types the attribute as a plain `string` with examples. Weaver then
   validates presence/type but not membership. For these attributes the

--- a/schemas/obi/groups/gen_ai.yaml
+++ b/schemas/obi/groups/gen_ai.yaml
@@ -11,9 +11,10 @@ groups:
   # - `gen_ai.operation.name`: re-typed as a plain string. Upstream's note
   #   explicitly recommends system-specific operation names, and OBI emits the
   #   provider's own vocabulary ('invoke_model' for Bedrock, 'message' for
-  #   Anthropic, 'conversation'/'response' for the OpenAI APIs, 'rerank', ...)
-  #   plus MCP JSON-RPC method names verbatim — custom MCP servers make the
-  #   value space unbounded, so it cannot be enumerated.
+  #   Anthropic, 'conversation'/'response' for the OpenAI APIs, 'rerank', ...),
+  #   which upstream's enum has no members for. MCP is not part of this: it
+  #   emits only the upstream-defined 'execute_tool', and nothing at all for
+  #   methods that are not tool calls.
   #
   # See ../README.md for the override mechanics (x.obi.* group id, full
   # upstream member list, lint allowlist).
@@ -161,9 +162,9 @@ groups:
           applicable `aws.bedrock.*` attributes and are not expected to include
           `openai.*` attributes.
       # Re-typed as string (upstream: enum): OBI emits provider-specific
-      # operation vocabularies and MCP JSON-RPC method names verbatim, so the
-      # value space is open-ended. Emitters must omit the attribute when no
-      # operation name is available (never send an empty string); pinned by
+      # operation vocabularies, so the value space is open-ended. Emitters must
+      # omit the attribute when no operation name is available (never send an
+      # empty string); pinned by
       # pkg/appolly/app/request/span_getters_test.go.
       - id: gen_ai.operation.name
         stability: development
@@ -173,5 +174,6 @@ groups:
           OBI reports the provider's own operation vocabulary (e.g.
           'invoke_model' for Bedrock, 'message' for Anthropic, 'generation'
           for Qwen/DashScope, 'conversation'/'response' for the OpenAI APIs,
-          'rerank') and passes MCP JSON-RPC method names through verbatim.
-        examples: ['chat', 'embeddings', 'response', 'conversation', 'invoke_model', 'rerank', 'tools/call']
+          'rerank'). MCP reports 'execute_tool' for a tool call and omits the
+          attribute for every other method.
+        examples: ['chat', 'embeddings', 'response', 'conversation', 'invoke_model', 'rerank', 'execute_tool']

--- a/site/docs/attributes.md
+++ b/site/docs/attributes.md
@@ -167,7 +167,7 @@ OBI overrides of `gen_ai.provider.name` (upstream enum extended with the provide
 
 | Attribute | Type | Stability | Description | Examples |
 | --- | --- | --- | --- | --- |
-| `gen_ai.operation.name` | string | development | The name of the operation being performed. | chat; embeddings; response; conversation; invoke_model; rerank; tools/call |
+| `gen_ai.operation.name` | string | development | The name of the operation being performed. | chat; embeddings; response; conversation; invoke_model; rerank; execute_tool |
 | `gen_ai.provider.name` | enum | development | The Generative AI provider as identified by the client or server instrumentation. | openai; gcp.gen_ai; gcp.vertex_ai; gcp.gemini; anthropic; cohere; azure.ai.inference; azure.ai.openai; … |
 
 ## `x.obi.messaging`


### PR DESCRIPTION
## Summary

Two MCP span deviations from semantic conventions.

**Span name.** Conventions define it as `{mcp.method.name} {target}`, where target is the tool or prompt name. OBI used the GenAI operation name in place of the method, so a tool call was named `execute_tool get-weather` rather than `tools/call get-weather`. The resource URI is left out of the name: conventions say instrumentation MAY offer it as an opt-in but SHOULD NOT include it by default, since it is unbounded. Wiring that opt-in through `optionalAttrs` is a follow-up, not part of this change.

**`gen_ai.operation.name`.** Conventions set it to `execute_tool` for a tool call and say it SHOULD NOT be set otherwise. OBI set it on every MCP span, falling back to the raw JSON-RPC method name, so an `initialize` span carried `gen_ai.operation.name=initialize` and the value space was unbounded, since custom servers define their own methods.

`MCPCall.OperationName` encoded both behaviours and is replaced by two methods that each mean one thing: `SpanName` and `GenAIOperationName`.

`schemas/obi/groups/gen_ai.yaml` justified re-typing the upstream `gen_ai.operation.name` enum to an open string partly on MCP method names being unbounded. That is no longer true — MCP now emits only the upstream-defined `execute_tool` — so the rationale, the note and the examples are corrected there and in `schemas/obi/README.md`, and `site/docs/attributes.md` is regenerated to match. The override itself stays: the provider vocabularies OBI emits still have no upstream enum members.

`client.port` is recommended on `span.mcp.server` and is still not emitted. It is absent from every HTTP server span, not just MCP ones, so adding it belongs in a change scoped to HTTP. `client.address` is already emitted, since MCP server spans carry the HTTP server attribute set.

## Compatibility

MCP span names change: a tool call goes from `execute_tool <tool>` to `tools/call <tool>`, and a prompt fetch gains the prompt name as its target, where previously it had none. `gen_ai.operation.name` disappears from every MCP span that is not a tool call.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.