### PR TITLE
gotracer: clear parent_id when a client call has no parent request

### DIFF
--- a/bpf/gotracer/go_common.h
+++ b/bpf/gotracer/go_common.h
@@ -351,10 +351,11 @@ static __always_inline u8 client_trace_parent(void *goroutine_addr, tp_info_t *t
 
         if (!found_trace_id) {
             urand_bytes(tp_i->trace_id, TRACE_ID_SIZE_BYTES);
+            __builtin_memset(tp_i->parent_id, 0, sizeof(tp_i->parent_id));
         }
-
-        urand_bytes(tp_i->span_id, SPAN_ID_SIZE_BYTES);
     }
+
+    urand_bytes(tp_i->span_id, SPAN_ID_SIZE_BYTES);
 
     return found_trace_id;
 }

--- a/bpf/gotracer/go_common.h
+++ b/bpf/gotracer/go_common.h
@@ -17,6 +17,7 @@
 
 #include <bpfcore/utils.h>
 #include <bpfcore/bpf_helpers.h>
+#include <bpfcore/bpf_builtins.h>
 
 #include <common/go_addr_key.h>
 #include <common/map_sizing.h>
@@ -351,7 +352,7 @@ static __always_inline u8 client_trace_parent(void *goroutine_addr, tp_info_t *t
 
         if (!found_trace_id) {
             urand_bytes(tp_i->trace_id, TRACE_ID_SIZE_BYTES);
-            __builtin_memset(tp_i->parent_id, 0, sizeof(tp_i->parent_id));
+            bpf_memset(tp_i->parent_id, 0, sizeof(tp_i->parent_id));
         }
     }
 

--- a/bpf/gotracer/go_redis.c
+++ b/bpf/gotracer/go_redis.c
@@ -16,6 +16,7 @@
 //go:build obi_bpf_ignore
 
 #include <bpfcore/utils.h>
+#include <bpfcore/bpf_builtins.h>
 
 #include <common/preempt_guard.h>
 #include <common/ringbuf.h>
@@ -35,8 +36,9 @@ static __always_inline void setup_request(void *goroutine_addr) {
     redis_client_req_t *req = req_client_mem();
 
     if (req) {
+        bpf_memset(req, 0, sizeof(*req));
+
         req->type = k_event_type_go_redis;
-        req->buf_len = 0;
         req->start_monotime_ns = bpf_ktime_get_ns();
 
         go_addr_key_t g_key = {};

--- a/bpf/tests/bpf_dns_header.c
+++ b/bpf/tests/bpf_dns_header.c
@@ -19,9 +19,6 @@
 // included ahead of the override below, so the include chain does not redefine it
 #include <bpfcore/bpf_core_read.h>
 
-// Called by the dns.h include chain, omitted by the shared stub
-#define BPF_ANY 0
-
 static inline u32 bpf_get_prandom_u32(void) {
     return 0;
 }

--- a/bpf/tests/bpf_dns_unconnected.c
+++ b/bpf/tests/bpf_dns_unconnected.c
@@ -17,9 +17,6 @@
 // included ahead of the override below, so the include chain does not redefine it
 #include <bpfcore/bpf_core_read.h>
 
-// Called by the dns.h include chain, omitted by the shared stub
-#define BPF_ANY 0
-
 // The shared stub's clock, which this test drives so the answer-timeout
 // boundary can be pinned
 #define test_now_ns bpf_ktime_ns_value

--- a/bpf/tests/bpf_go_client_trace_parent.c
+++ b/bpf/tests/bpf_go_client_trace_parent.c
@@ -1,0 +1,123 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// client_trace_parent (gotracer/go_common.h) fills the trace context for an
+// outgoing Go client call. Callers pass it memory that still holds the previous
+// request's ids, so every field that is not copied from a real parent has to be
+// written explicitly. A client call with no parent request that leaves
+// parent_id alone emits a span whose parent belongs to an unrelated trace and
+// is never sent, which makes the trace rootless; a call adopted from a SQL
+// wrapper that leaves span_id alone emits a duplicate span id.
+//
+// Run from repo root:
+//   make -C bpf/tests bpf_go_client_trace_parent && bpf/tests/bpf_go_client_trace_parent
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <bpfcore/vmlinux.h>
+#include <bpfcore/bpf_helpers.h>
+
+// Called by the go_common.h include chain, omitted by the shared stub
+#define BPF_ANY 0
+
+static inline u32 bpf_get_prandom_u32(void) {
+    return 0x5a5a5a5a;
+}
+
+static inline long bpf_loop(u32 nr_loops, void *cb, void *ctx, u64 flags) {
+    return 0;
+}
+
+// Go uprobes read arguments out of pt_regs, and get_offsets_table walks the
+// running task to its executable inode. The tests need only enough of each for
+// the gotracer headers to compile.
+struct pt_regs {
+    u64 bx;
+};
+
+struct super_block {
+    u32 s_dev;
+};
+
+struct inode {
+    unsigned long i_ino;
+    struct super_block *i_sb;
+};
+
+struct file {
+    struct inode *f_inode;
+};
+
+struct mm_struct {
+    struct file *exe_file;
+};
+
+#define GO_PARAM2(x) ((void *)(x)->bx)
+
+#include <gotracer/go_common.h>
+
+static void expect(bool got, bool want, const char *message) {
+    if (got != want) {
+        fprintf(stderr, "FAIL: %s (want %d, got %d)\n", message, want, got);
+        exit(1);
+    }
+}
+
+static sql_func_invocation_t *sql_wrapper;
+
+static void *sql_wrapper_lookup(void *map, const void *key) {
+    return map == &ongoing_sql_queries ? sql_wrapper : NULL;
+}
+
+static void no_parent_request(void) {
+    tp_info_t tp;
+
+    memset(&tp, 0xAB, sizeof(tp));
+
+    const u8 found = client_trace_parent((void *)0x1234, &tp);
+
+    expect(found == 0, true, "no parent request is found when the maps are empty");
+    expect(valid_span(tp.parent_id),
+           false,
+           "a client call with no parent request must not inherit a parent id from the "
+           "previous occupant of the scratch buffer");
+    expect(valid_span(tp.span_id), true, "a client call always gets its own span id");
+}
+
+static void parent_is_a_sql_wrapper(void) {
+    sql_func_invocation_t invocation = {};
+    tp_info_t tp;
+    unsigned char stale[SPAN_ID_SIZE_BYTES];
+
+    memset(invocation.tp.trace_id, 0x11, sizeof(invocation.tp.trace_id));
+    memset(invocation.tp.span_id, 0x22, sizeof(invocation.tp.span_id));
+
+    memset(&tp, 0xAB, sizeof(tp));
+    memset(stale, 0xAB, sizeof(stale));
+
+    sql_wrapper = &invocation;
+    bpf_map_lookup_elem_hook = sql_wrapper_lookup;
+    const u8 found = client_trace_parent((void *)0x1234, &tp);
+    bpf_map_lookup_elem_hook = NULL;
+
+    expect(found == 1, true, "a cloud web database wrapping the call is adopted as the parent");
+    expect(memcmp(tp.parent_id, invocation.tp.span_id, sizeof(tp.parent_id)) == 0,
+           true,
+           "the adopted parent's span id becomes the client call's parent id");
+    expect(memcmp(tp.span_id, stale, sizeof(tp.span_id)) != 0,
+           true,
+           "a client call adopted from a SQL wrapper must not keep the span id left in the "
+           "scratch buffer");
+    expect(valid_span(tp.span_id), true, "the adopted client call still gets its own span id");
+}
+
+int main(void) {
+    no_parent_request();
+    parent_is_a_sql_wrapper();
+
+    printf("OK: %s\n", __FILE__);
+    return 0;
+}

--- a/bpf/tests/bpf_go_client_trace_parent.c
+++ b/bpf/tests/bpf_go_client_trace_parent.c
@@ -20,9 +20,6 @@
 #include <bpfcore/vmlinux.h>
 #include <bpfcore/bpf_helpers.h>
 
-// Called by the go_common.h include chain, omitted by the shared stub
-#define BPF_ANY 0
-
 static inline u32 bpf_get_prandom_u32(void) {
     return 0x5a5a5a5a;
 }

--- a/bpf/tests/bpf_go_h2_write_transaction.c
+++ b/bpf/tests/bpf_go_h2_write_transaction.c
@@ -13,8 +13,6 @@ static unsigned int write_calls;
 static unsigned int failed_writes;
 static unsigned int partial_writes;
 
-#define BPF_ANY 0
-
 static u32 bpf_get_prandom_u32(void) {
     return 0;
 }

--- a/bpf/tests/bpf_ssl_read_guard.c
+++ b/bpf/tests/bpf_ssl_read_guard.c
@@ -8,8 +8,6 @@
 
 #include <bpfcore/bpf_helpers.h>
 
-enum { BPF_ANY = 0, BPF_NOEXIST = 1 };
-
 struct bpf_test_map {
     int id;
 };

--- a/bpf/tests/bpf_tls_prefix_bind.c
+++ b/bpf/tests/bpf_tls_prefix_bind.c
@@ -18,8 +18,6 @@
 
 #include <bpfcore/bpf_helpers.h>
 
-enum { BPF_ANY = 0, BPF_NOEXIST = 1 };
-
 enum { k_max_entries = 32, k_max_key = 48, k_max_val = 128 };
 
 typedef struct mock_entry {

--- a/bpf/tests/bpfcore/bpf_helpers.h
+++ b/bpf/tests/bpfcore/bpf_helpers.h
@@ -28,6 +28,9 @@
 #define BPF_MAP_TYPE_LRU_PERCPU_HASH 13
 #define BPF_MAP_TYPE_RINGBUF 27
 
+#define BPF_ANY 0
+#define BPF_NOEXIST 1
+
 static void *(*bpf_map_lookup_elem_hook)(void *map, const void *key);
 static inline void *bpf_map_lookup_elem(void *map, const void *key) {
     return bpf_map_lookup_elem_hook ? bpf_map_lookup_elem_hook(map, key) : NULL;

--- a/bpf/tests/bpfcore/bpf_helpers.h
+++ b/bpf/tests/bpfcore/bpf_helpers.h
@@ -28,8 +28,9 @@
 #define BPF_MAP_TYPE_LRU_PERCPU_HASH 13
 #define BPF_MAP_TYPE_RINGBUF 27
 
+static void *(*bpf_map_lookup_elem_hook)(void *map, const void *key);
 static inline void *bpf_map_lookup_elem(void *map, const void *key) {
-    return NULL;
+    return bpf_map_lookup_elem_hook ? bpf_map_lookup_elem_hook(map, key) : NULL;
 }
 static inline long
 bpf_map_update_elem(void *map, const void *key, const void *val, unsigned long long flags) {

--- a/bpf/tests/bpfcore/vmlinux.h
+++ b/bpf/tests/bpfcore/vmlinux.h
@@ -62,6 +62,7 @@ struct task_struct {
     struct task_struct *real_parent;
     struct nsproxy *nsproxy;
     struct pid *thread_pid;
+    struct mm_struct *mm;
 };
 
 enum {


### PR DESCRIPTION
## Summary

The Go Redis client passes per-CPU scratch memory to `setup_request` and never zeroes it, so `err`, `conn` and `tp.parent_id` are inherited from whatever last used that CPU's slot. The whole struct is copied into the ring buffer, so a successful command can report a non-zero status, carry an unrelated peer address, or point at a parent from an unrelated trace that is never sent, leaving the trace rootless. `setup_request` now zeroes the struct.

`client_trace_parent` also left two fields unwritten. It never wrote `parent_id`, which the six callers that pass a zeroed stack struct did not notice; it is now cleared explicitly so the helper writes every field it does not copy from a real parent. It also skipped `span_id` when the parent came from the SQL wrapper path, emitting a duplicate span id there; `span_id` is now generated on every path.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
