### PR TITLE
docs: fix NATS delivered-message span kind wording

### DIFF
--- a/devdocs/protocols/tcp/nats.md
+++ b/devdocs/protocols/tcp/nats.md
@@ -21,7 +21,7 @@ Control traffic such as `INFO`, `CONNECT`, `SUB`, `UNSUB`, `PING`, `PONG`, `+OK`
 NATS traffic is detected in `ReadTCPRequestIntoSpan` in [pkg/ebpf/common/tcp_detect_transform.go](../../../pkg/ebpf/common/tcp_detect_transform.go).
 The parser itself lives in [pkg/ebpf/common/nats_detect_transform.go](../../../pkg/ebpf/common/nats_detect_transform.go).
 
-Unlike request/response protocols, NATS mixes control frames and message frames on the same connection. OBI scans the buffered traffic in both directions, skipping control-only traffic when possible. When one TCP event contains both a client publish and a server-delivered message, OBI emits the publish span as the main span and a second server span for the delivered message.
+Unlike request/response protocols, NATS mixes control frames and message frames on the same connection. OBI scans the buffered traffic in both directions, skipping control-only traffic when possible. When one TCP event contains both a client publish and a server-delivered message, OBI emits the publish span as the main span and a second `EventTypeNATSServer` span (consumer kind) for the delivered message.
 
 ### Header-Aware Frames
 


### PR DESCRIPTION
## Summary

Since #3306 messaging span kind is derived from the operation, so the extra span emitted for a delivered MSG/HMSG is a consumer span, not a server span.
This PR just updates the `nats.md` doc.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
