### PR TITLE
Keep SQS sends as client spans without context injection

### DIFF
--- a/internal/test/integration/red_test_python_aws.go
+++ b/internal/test/integration/red_test_python_aws.go
@@ -47,7 +47,7 @@ func waitAWSProxy(t *testing.T) {
 	}, testTimeout, 1*time.Second)
 }
 
-func fetchAWSSpanByOP(t require.TestingT, op, spanKind string) jaeger.Span {
+func fetchAWSSpanByOP(t require.TestingT, op string) jaeger.Span {
 	var tq jaeger.TracesQuery
 
 	params := neturl.Values{}
@@ -63,7 +63,7 @@ func fetchAWSSpanByOP(t require.TestingT, op, spanKind string) jaeger.Span {
 	require.GreaterOrEqual(t, len(tq.Data), 1, op)
 
 	for _, tr := range tq.Data {
-		spans := tr.FindByOperationName(op, spanKind)
+		spans := tr.FindByOperationName(op, "client")
 		if len(spans) > 0 {
 			return spans[0]
 		}

--- a/internal/test/integration/red_test_python_aws_s3.go
+++ b/internal/test/integration/red_test_python_aws_s3.go
@@ -42,7 +42,7 @@ func testPythonAWSS3(t *testing.T) {
 func assertS3Operation(t require.TestingT, op, expectedKey string) {
 	opName := "s3." + op
 
-	span := fetchAWSSpanByOP(t, opName, "client")
+	span := fetchAWSSpanByOP(t, opName)
 	require.Equal(t, opName, span.OperationName)
 
 	tag, found := jaeger.FindIn(span.Tags, "rpc.method")

--- a/internal/test/integration/red_test_python_aws_sqs.go
+++ b/internal/test/integration/red_test_python_aws_sqs.go
@@ -12,10 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/otel/trace"
-
 	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
-	"go.opentelemetry.io/obi/pkg/appolly/app/request"
 )
 
 type (
@@ -65,19 +62,10 @@ func sqsRequestWithData[T sqsQueueURL | sqsMessages](t *testing.T, url string) T
 	return data
 }
 
-func sqsSpanKind(operationType string) string {
-	kind, ok := request.MessagingSpanKind(operationType)
-	if !ok {
-		kind = trace.SpanKindClient
-	}
-
-	return kind.String()
-}
-
 func assertSQSOperation(t require.TestingT, op, expectedQueueURL, expectedMessageID, expectedOperationType string) {
 	opName := "sqs." + op
 
-	span := fetchAWSSpanByOP(t, opName, sqsSpanKind(expectedOperationType))
+	span := fetchAWSSpanByOP(t, opName)
 	require.Equal(t, opName, span.OperationName)
 
 	tag, found := jaeger.FindIn(span.Tags, "aws.request_id")

--- a/pkg/appolly/app/request/span.go
+++ b/pkg/appolly/app/request/span.go
@@ -1940,11 +1940,6 @@ func (s *Span) ServiceGraphKind() string {
 	case EventTypeHTTP, EventTypeGRPC, EventTypeSunRPCServer, EventTypeRedisServer, EventTypeMemcachedServer, EventTypeSQLServer, EventTypeAerospikeServer:
 		return "SPAN_KIND_SERVER"
 	case EventTypeHTTPClient, EventTypeGRPCClient, EventTypeSQLClient, EventTypeRedisClient, EventTypeMongoClient, EventTypeFailedConnect, EventTypeCouchbaseClient, EventTypeMemcachedClient, EventTypeSunRPCClient, EventTypeAerospikeClient:
-		if s.SubType == HTTPSubtypeAWSSQS && s.AWS != nil {
-			if kind, ok := MessagingSpanKind(s.AWS.SQS.OperationType); ok {
-				return spanKindString(kind)
-			}
-		}
 		return "SPAN_KIND_CLIENT"
 	case EventTypeKafkaClient, EventTypeKafkaServer,
 		EventTypeMQTTClient, EventTypeMQTTServer,

--- a/pkg/appolly/app/request/span_test.go
+++ b/pkg/appolly/app/request/span_test.go
@@ -133,7 +133,7 @@ func TestMessagingSpanKind(t *testing.T) {
 	}
 }
 
-func TestSQSServiceGraphKind(t *testing.T) {
+func TestSQSServiceGraphKindWithoutMessageContext(t *testing.T) {
 	sqsSpan := func(operationType string) *Span {
 		return &Span{
 			Type:    EventTypeHTTPClient,
@@ -142,9 +142,9 @@ func TestSQSServiceGraphKind(t *testing.T) {
 		}
 	}
 
-	// The service graph kind must match the span kind traces report, or the
-	// same SQS exchange is a producer in the trace and a client in the metric.
-	assert.Equal(t, "SPAN_KIND_PRODUCER", sqsSpan(MessagingSend).ServiceGraphKind())
+	// OBI does not inject the span context into SQS messages, so the observed
+	// exchanges remain client spans regardless of their messaging operation.
+	assert.Equal(t, "SPAN_KIND_CLIENT", sqsSpan(MessagingSend).ServiceGraphKind())
 	assert.Equal(t, "SPAN_KIND_CLIENT", sqsSpan(MessagingReceive).ServiceGraphKind())
 	assert.Equal(t, "SPAN_KIND_CLIENT", sqsSpan(MessagingSettle).ServiceGraphKind())
 	assert.Equal(t, "SPAN_KIND_CLIENT", sqsSpan("").ServiceGraphKind())

--- a/pkg/export/otel/tracesgen/tracesgen.go
+++ b/pkg/export/otel/tracesgen/tracesgen.go
@@ -1774,11 +1774,6 @@ func spanKind(span *request.Span) trace2.SpanKind {
 	case request.EventTypeHTTP, request.EventTypeGRPC, request.EventTypeRedisServer, request.EventTypeSunRPCServer, request.EventTypeMemcachedServer, request.EventTypeSQLServer, request.EventTypeAerospikeServer:
 		return trace2.SpanKindServer
 	case request.EventTypeHTTPClient, request.EventTypeGRPCClient, request.EventTypeSQLClient, request.EventTypeRedisClient, request.EventTypeMongoClient, request.EventTypeCouchbaseClient, request.EventTypeMemcachedClient, request.EventTypeSunRPCClient, request.EventTypeAerospikeClient, request.EventTypeFailedConnect:
-		if span.SubType == request.HTTPSubtypeAWSSQS && span.AWS != nil {
-			if kind, ok := request.MessagingSpanKind(span.AWS.SQS.OperationType); ok {
-				return kind
-			}
-		}
 		return trace2.SpanKindClient
 	// A messaging span is a producer, a consumer or a client, decided by the
 	// operation rather than by the side OBI observed it from. Semantic

--- a/pkg/export/otel/tracesgen/tracesgen_test.go
+++ b/pkg/export/otel/tracesgen/tracesgen_test.go
@@ -1240,7 +1240,7 @@ func TestNoMessagingSpanIsReportedAsServerKind(t *testing.T) {
 	}
 }
 
-func TestSQSSpanKind(t *testing.T) {
+func TestSQSSpanKindWithoutMessageContext(t *testing.T) {
 	sqsSpan := func(operationType string) *request.Span {
 		return &request.Span{
 			Type:    request.EventTypeHTTPClient,
@@ -1249,7 +1249,9 @@ func TestSQSSpanKind(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, trace2.SpanKindProducer, spanKind(sqsSpan(request.MessagingSend)))
+	// OBI does not inject the span context into SQS messages, so the observed
+	// exchanges remain client spans regardless of their messaging operation.
+	assert.Equal(t, trace2.SpanKindClient, spanKind(sqsSpan(request.MessagingSend)))
 	assert.Equal(t, trace2.SpanKindClient, spanKind(sqsSpan(request.MessagingReceive)))
 	assert.Equal(t, trace2.SpanKindClient, spanKind(sqsSpan(request.MessagingSettle)))
 	assert.Equal(t, trace2.SpanKindClient, spanKind(sqsSpan("")))


### PR DESCRIPTION
## Summary

#3314 classified `SendMessage` and `SendMessageBatch` spans as `PRODUCER` through the shared messaging-operation mapping. The messaging [semantic conventions require `CLIENT` when the send span's context is not used as the message creation context](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#span-kind).

OBI currently enriches the completed SQS HTTP exchange but does not inject the span context into SQS `MessageAttributes`. This restores `CLIENT` for all observed SQS operations in both trace export and metric-facing kind labels. If OBI adds SQS message-level propagation later, producer classification can be enabled from an explicit creation-context signal.

## Compatibility

The `span.kind` label on span metrics, the `kind` label on service-graph metrics, and the JSON span `kind` return to `SPAN_KIND_CLIENT` for SQS sends. Consumers that changed filters after #3314 should keep using the client series.

## Validation

- `make verify`
- `make compile`
- `go test ./pkg/appolly/app/request ./pkg/export/otel/tracesgen ./pkg/ebpf/common/http`
