### PR TITLE
Fix GraphQL test span selection and upgrade Jaeger to v2

### DIFF
--- a/internal/test/integration/docker-compose-python-graphql.yml
+++ b/internal/test/integration/docker-compose-python-graphql.yml
@@ -99,7 +99,7 @@ services:
       - "16686:16686" # Query frontend
       - "4317" # OTEL GRPC traces collector
       - "4318" # OTEL HTTP traces collector
-    environment:
-      - LOG_LEVEL=debug
+    command:
+      - "--set=service.telemetry.logs.level=debug"
 # curl http://localhost:16686/api/services
 # curl http://localhost:16686/api/traces?service=testserver

--- a/internal/test/integration/docker-compose-python-graphql.yml
+++ b/internal/test/integration/docker-compose-python-graphql.yml
@@ -94,7 +94,7 @@ services:
       - "9090:9090"
 
   jaeger:
-    image: jaegertracing/all-in-one:1.76.0@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
     ports:
       - "16686:16686" # Query frontend
       - "4317" # OTEL GRPC traces collector

--- a/internal/test/integration/red_test_python_graphql.go
+++ b/internal/test/integration/red_test_python_graphql.go
@@ -48,7 +48,8 @@ func testPythonGraphQL(t *testing.T) {
 		traces := tq.FindBySpan(jaeger.Tag{Key: "graphql.operation.type", Type: "string", Value: "query"})
 		require.GreaterOrEqual(ct, len(traces), 1)
 		lastTrace := traces[len(traces)-1]
-		spans := lastTrace.FindByOperationName(operationName, "")
+		// GraphQL spans are HTTP spans with a subtype, so their kind is server.
+		spans := lastTrace.FindByOperationName(operationName, "server")
 		require.Len(ct, spans, 1)
 		span := spans[0]
 

--- a/internal/test/integration/red_test_python_graphql.go
+++ b/internal/test/integration/red_test_python_graphql.go
@@ -48,9 +48,9 @@ func testPythonGraphQL(t *testing.T) {
 		traces := tq.FindBySpan(jaeger.Tag{Key: "graphql.operation.type", Type: "string", Value: "query"})
 		require.GreaterOrEqual(ct, len(traces), 1)
 		lastTrace := traces[len(traces)-1]
-		span := lastTrace.Spans[0]
-
-		assert.Equal(ct, operationName, span.OperationName)
+		spans := lastTrace.FindByOperationName(operationName, "")
+		require.Len(ct, spans, 1)
+		span := spans[0]
 
 		tag, found := jaeger.FindIn(span.Tags, "graphql.operation.name")
 		assert.True(ct, found)


### PR DESCRIPTION
## Summary

Closes #2891.

`red_test_python_graphql.go` read `lastTrace.Spans[0]` and asserted it was the GraphQL span. Jaeger makes no guarantee about span ordering within a trace, so that only worked while v1 happened to return it first. Under v2 the ordering differs and index 0 is OBI's synthetic `in queue` span:

```
expected: "GraphQL query"
actual  : "in queue"
```

Selects the span by operation name instead, using the existing `Trace.FindByOperationName` helper — the same approach `container_meta_suites_test.go` and `go_auto_sdk_test.go` already use. The `assert.Equal` on the operation name
drops out, since finding the span by that name is now the assertion.

Also bumps the compose file to `jaegertracing/jaeger:2.20.0` to match the other suites, and swaps `LOG_LEVEL`  which is a Jaeger v1 environment variable that v2 ignores for `--set=service.telemetry.logs.level=debug`. Verified directly against the image: the `--set` form emits debug output, the env var emits none.

Verified on a Linux host:

| Jaeger | Test | Result |
|---|---|---|
| v2 | before | fails — `expected "GraphQL query", actual "in queue"` |
| v2 | after | passes |
| v1 | after | passes |

Passing on both versions confirms the assertion no longer depends on span order.

Note: five other compose files still use `all-in-one:1.60`; out of scope here.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] N/A — test-only fix; no change to emitted telemetry, so `devdocs/features.md` and `SUPPORT_MATRIX.md` are unchanged.

---

Generative AI (Claude) was used to help diagnose the failure and draft the change. I reproduced the failure and verified the fix on my own Linux host before submitting.