### PR TITLE
nodejs: close the inspector when injection fails

### DIFF
--- a/pkg/internal/nodejs/injector.go
+++ b/pkg/internal/nodejs/injector.go
@@ -300,10 +300,6 @@ func sendMessageWithTimeout(wsConn *websocket.Conn, data []byte, timeout time.Du
 	return nil
 }
 
-// injectFileWS evaluates the agent, then always closes the WebSocket and, when
-// OBI opened the inspector, closes that too. A failed injection is left to the
-// caller: it cleans up over a fresh connection, which this stalled or broken
-// session cannot do.
 func (i *NodeInjector) injectFileWS(pid int, wsConn *websocket.Conn, payload []byte, openedByOBI bool) error {
 	defer wsConn.Close()
 
@@ -322,10 +318,6 @@ func (i *NodeInjector) injectFileWS(pid int, wsConn *websocket.Conn, payload []b
 	return nil
 }
 
-// injectViaConn drives the injection over an established inspector
-// connection. Every failure after the inspector is open would otherwise leave
-// the debugging interface listening, so a failed attempt closes it again when
-// OBI is the one that opened it.
 func (i *NodeInjector) injectViaConn(pid int, conn net.Conn, openedByOBI bool) (err error) {
 	defer func() {
 		if err != nil && openedByOBI {
@@ -347,8 +339,6 @@ func (i *NodeInjector) injectViaConn(pid int, conn net.Conn, openedByOBI bool) (
 	return i.injectFileWS(pid, wsConn, payload, openedByOBI)
 }
 
-// dialInspectorWS opens the debugger session that carries payload, taking
-// ownership of conn: it is closed on every failure.
 func (i *NodeInjector) dialInspectorWS(conn net.Conn, payload []byte) (*websocket.Conn, error) {
 	wsURL, err := i.requestDebuggerURL(conn)
 	if err != nil {
@@ -368,9 +358,6 @@ func (i *NodeInjector) dialInspectorWS(conn net.Conn, payload []byte) (*websocke
 	return wsConn, nil
 }
 
-// closeInspector makes a best-effort attempt to close an inspector that OBI
-// opened but could not inject into, over a connection of its own: the one the
-// injection used is already gone or unusable by this point.
 func (i *NodeInjector) closeInspector(pid int) {
 	conn, err := connectWait(inspectorHost, inspectorPort, inspectorCloseWait, inspectorCloseInterval)
 	if err != nil {

--- a/pkg/internal/nodejs/injector.go
+++ b/pkg/internal/nodejs/injector.go
@@ -41,6 +41,36 @@ type evalParams struct {
 
 const inspectorRequestTimeout = 5 * time.Second
 
+const inspectorHost = "127.0.0.1"
+
+// The inspector's fixed port. A variable so tests can dial a local stand-in,
+// following the cmdlineForPID pattern used elsewhere in this package.
+var inspectorPort = 9229
+
+// The inspector protocol is the only way to close the inspector again: SIGUSR1
+// opens it and no signal closes it.
+const debugEndExpression = "process._debugEnd();"
+
+const (
+	agentRequestID    = 1
+	debugEndRequestID = 2
+)
+
+const (
+	inspectorConnectInterval = 200 * time.Millisecond
+	inspectorCloseInterval   = 200 * time.Millisecond
+)
+
+// How long the injection waits for the inspector to come up after SIGUSR1,
+// and how long a cleanup attempt waits for one that opened later than that.
+// The cleanup budget is kept short: the injector runs synchronously from the
+// attacher loop, so it delays every other process being instrumented.
+// Variables for the same reason as inspectorPort.
+var (
+	inspectorConnectWait = 5 * time.Second
+	inspectorCloseWait   = 2 * time.Second
+)
+
 // IMPORTANT: the code in this file needs to run in the network namespace of the
 // target process in order to be able to connect to its inspector port - the
 // network namespace switching is done by the withNetNS function, which locks
@@ -277,41 +307,110 @@ func sendMessageWithTimeout(wsConn *websocket.Conn, data []byte, timeout time.Du
 	return nil
 }
 
-func (i *NodeInjector) injectFileWS(wsConn *websocket.Conn, payload []byte) error {
-	defer func() {
-		_ = sendEvaluate(wsConn, "process._debugEnd();", 2)
-	}()
-
+// injectFileWS evaluates the agent and, when OBI opened the inspector, closes
+// it again. A failed injection is left to the caller: it cleans up over a
+// fresh connection, which this stalled or broken session cannot do.
+func (i *NodeInjector) injectFileWS(pid int, wsConn *websocket.Conn, payload []byte, mayClose bool) error {
 	if err := sendMessageWithTimeout(wsConn, payload, inspectorRequestTimeout); err != nil {
 		return err
 	}
 
 	i.log.Info("Script successfully injected")
 
+	if mayClose {
+		if err := sendEvaluate(wsConn, debugEndExpression, debugEndRequestID); err != nil {
+			i.logInspectorStaysOpen(pid, err)
+		}
+	}
+
 	return nil
 }
 
-func (i *NodeInjector) injectViaConn(conn net.Conn) error {
+// injectViaConn drives the injection over an established inspector
+// connection. Every failure after the inspector is open would otherwise leave
+// the debugging interface listening, so a failed attempt closes it again when
+// OBI is the one that opened it.
+func (i *NodeInjector) injectViaConn(pid int, conn net.Conn, mayClose bool) (err error) {
+	defer func() {
+		if err != nil && mayClose {
+			i.closeInspector(pid)
+		}
+	}()
+
+	payload, err := evaluateRequest(i.agentCode(), agentRequestID)
+	if err != nil {
+		conn.Close()
+		return err
+	}
+
+	wsConn, err := i.dialInspectorWS(conn, payload)
+	if err != nil {
+		return err
+	}
+
+	return i.injectFileWS(pid, wsConn, payload, mayClose)
+}
+
+// dialInspectorWS opens the debugger session that carries payload, taking
+// ownership of conn: it is closed on every failure.
+func (i *NodeInjector) dialInspectorWS(conn net.Conn, payload []byte) (*websocket.Conn, error) {
 	wsURL, err := i.requestDebuggerURL(conn)
 	if err != nil {
 		conn.Close()
-		return err
+		return nil, err
 	}
 
 	i.log.Debug("found debugger url", "url", wsURL)
-
-	payload, err := evaluateRequest(i.agentCode(), 1)
-	if err != nil {
-		conn.Close()
-		return err
-	}
 
 	// buffer sized to the payload: the inspector rejects fragmented messages
 	wsConn, _, err := upgradeConn(conn, wsURL, len(payload))
 	if err != nil {
 		conn.Close()
-		return fmt.Errorf("failed to connect to inspector WebSocket: %w", err)
+		return nil, fmt.Errorf("failed to connect to inspector WebSocket: %w", err)
 	}
 
-	return i.injectFileWS(wsConn, payload)
+	return wsConn, nil
+}
+
+// closeInspector makes a best-effort attempt to close an inspector that OBI
+// opened but could not inject into, over a connection of its own: the one the
+// injection used is already gone or unusable by this point.
+func (i *NodeInjector) closeInspector(pid int) {
+	conn, err := connectWait(inspectorHost, inspectorPort, inspectorCloseWait, inspectorCloseInterval)
+	if err != nil {
+		i.log.Debug("no inspector to close", "pid", pid, "error", err)
+		return
+	}
+
+	if err := i.sendDebugEnd(conn); err != nil {
+		i.logInspectorStaysOpen(pid, err)
+		return
+	}
+
+	i.log.Info("closed the Node.js inspector after a failed injection", "pid", pid)
+}
+
+func (i *NodeInjector) sendDebugEnd(conn net.Conn) error {
+	payload, err := evaluateRequest(debugEndExpression, debugEndRequestID)
+	if err != nil {
+		conn.Close()
+		return err
+	}
+
+	wsConn, err := i.dialInspectorWS(conn, payload)
+	if err != nil {
+		return err
+	}
+	defer wsConn.Close()
+
+	return sendMessageWithTimeout(wsConn, payload, inspectorRequestTimeout)
+}
+
+// logInspectorStaysOpen reports the one outcome an operator has to act on: the
+// inspector is open, OBI could not close it, and it stays reachable inside the
+// process's network namespace until the process restarts.
+func (i *NodeInjector) logInspectorStaysOpen(pid int, err error) {
+	i.log.Warn("could not close the Node.js inspector: the debugging interface may stay "+
+		"open until the process restarts",
+		"pid", pid, "address", fmt.Sprintf("%s:%d", inspectorHost, inspectorPort), "error", err)
 }

--- a/pkg/internal/nodejs/injector.go
+++ b/pkg/internal/nodejs/injector.go
@@ -43,12 +43,8 @@ const inspectorRequestTimeout = 5 * time.Second
 
 const inspectorHost = "127.0.0.1"
 
-// The inspector's fixed port. A variable so tests can dial a local stand-in,
-// following the cmdlineForPID pattern used elsewhere in this package.
 var inspectorPort = 9229
 
-// The inspector protocol is the only way to close the inspector again: SIGUSR1
-// opens it and no signal closes it.
 const debugEndExpression = "process._debugEnd();"
 
 const (
@@ -61,11 +57,8 @@ const (
 	inspectorCloseInterval   = 200 * time.Millisecond
 )
 
-// How long the injection waits for the inspector to come up after SIGUSR1,
-// and how long a cleanup attempt waits for one that opened later than that.
 // The cleanup budget is kept short: the injector runs synchronously from the
 // attacher loop, so it delays every other process being instrumented.
-// Variables for the same reason as inspectorPort.
 var (
 	inspectorConnectWait = 5 * time.Second
 	inspectorCloseWait   = 2 * time.Second
@@ -307,17 +300,20 @@ func sendMessageWithTimeout(wsConn *websocket.Conn, data []byte, timeout time.Du
 	return nil
 }
 
-// injectFileWS evaluates the agent and, when OBI opened the inspector, closes
-// it again. A failed injection is left to the caller: it cleans up over a
-// fresh connection, which this stalled or broken session cannot do.
-func (i *NodeInjector) injectFileWS(pid int, wsConn *websocket.Conn, payload []byte, mayClose bool) error {
+// injectFileWS evaluates the agent, then always closes the WebSocket and, when
+// OBI opened the inspector, closes that too. A failed injection is left to the
+// caller: it cleans up over a fresh connection, which this stalled or broken
+// session cannot do.
+func (i *NodeInjector) injectFileWS(pid int, wsConn *websocket.Conn, payload []byte, openedByOBI bool) error {
+	defer wsConn.Close()
+
 	if err := sendMessageWithTimeout(wsConn, payload, inspectorRequestTimeout); err != nil {
 		return err
 	}
 
 	i.log.Info("Script successfully injected")
 
-	if mayClose {
+	if openedByOBI {
 		if err := sendEvaluate(wsConn, debugEndExpression, debugEndRequestID); err != nil {
 			i.logInspectorStaysOpen(pid, err)
 		}
@@ -330,9 +326,9 @@ func (i *NodeInjector) injectFileWS(pid int, wsConn *websocket.Conn, payload []b
 // connection. Every failure after the inspector is open would otherwise leave
 // the debugging interface listening, so a failed attempt closes it again when
 // OBI is the one that opened it.
-func (i *NodeInjector) injectViaConn(pid int, conn net.Conn, mayClose bool) (err error) {
+func (i *NodeInjector) injectViaConn(pid int, conn net.Conn, openedByOBI bool) (err error) {
 	defer func() {
-		if err != nil && mayClose {
+		if err != nil && openedByOBI {
 			i.closeInspector(pid)
 		}
 	}()
@@ -348,7 +344,7 @@ func (i *NodeInjector) injectViaConn(pid int, conn net.Conn, mayClose bool) (err
 		return err
 	}
 
-	return i.injectFileWS(pid, wsConn, payload, mayClose)
+	return i.injectFileWS(pid, wsConn, payload, openedByOBI)
 }
 
 // dialInspectorWS opens the debugger session that carries payload, taking

--- a/pkg/internal/nodejs/injector_test.go
+++ b/pkg/internal/nodejs/injector_test.go
@@ -486,16 +486,16 @@ type evalRequest struct {
 	Params evalParams `json:"params"`
 }
 
-// The inspector is a debugging interface, so OBI closes the one it opened
-// itself with SIGUSR1 and leaves an inspector the process asked for alone.
+// The inspector is a debugging interface, so OBI closes only the one it opened
+// itself with SIGUSR1 and leaves an already-listening one alone.
 func TestInjectionClosesOnlyAnInspectorOBIOpened(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
-		mayClose     bool
+		openedByOBI  bool
 		wantDebugEnd bool
 	}{
-		{name: "opened by OBI", mayClose: true, wantDebugEnd: true},
-		{name: "opened by the process", mayClose: false, wantDebugEnd: false},
+		{name: "opened by OBI", openedByOBI: true, wantDebugEnd: true},
+		{name: "already open when OBI arrived", openedByOBI: false, wantDebugEnd: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			expressions := make(chan string, 2)
@@ -526,12 +526,12 @@ func TestInjectionClosesOnlyAnInspectorOBIOpened(t *testing.T) {
 				t.Fatalf("marshaling evaluate request: %v", err)
 			}
 
-			if err := injector.injectFileWS(1, wsConn, payload, tc.mayClose); err != nil {
+			if err := injector.injectFileWS(1, wsConn, payload, tc.openedByOBI); err != nil {
 				t.Fatalf("injecting: %v", err)
 			}
 
-			// injectFileWS closes the inspector from a defer, so by the time it
-			// returns every message it sends has already been answered
+			// injectFileWS sends every message synchronously, so by the time it
+			// returns each one has already been answered
 			if got := <-expressions; got != "void 0;" {
 				t.Fatalf("expected the agent payload first, got %q", got)
 			}
@@ -756,8 +756,9 @@ func TestFailedInjectionClosesTheInspector(t *testing.T) {
 	}
 }
 
-// An inspector the process asked for stays open even when the injection fails.
-func TestFailedInjectionLeavesAProcessOwnedInspectorOpen(t *testing.T) {
+// An inspector that was already listening stays open even when the injection
+// fails: OBI did not open it and cannot know who did.
+func TestFailedInjectionLeavesAnAlreadyOpenInspectorAlone(t *testing.T) {
 	expressions := make(chan string, 1)
 	srv := newScriptedInspectorServer(t, inspectorScript{emptyLists: 1, expressions: expressions})
 	pointInjectorAtServer(t, srv)
@@ -778,18 +779,18 @@ func TestFailedInjectionLeavesAProcessOwnedInspectorOpen(t *testing.T) {
 	}
 }
 
-// injectFile reaches the inspector two ways - finding it already open, or
-// opening it with SIGUSR1 - and a failed injection has to close it in both.
-func TestInjectFileClosesTheInspectorAfterAFailedInjection(t *testing.T) {
+// injectFile reaches the inspector two ways, and only one of them is OBI's to
+// close: an inspector already listening was opened by someone else.
+func TestInjectFileClosesOnlyTheInspectorItOpened(t *testing.T) {
 	for _, tc := range []struct {
 		name           string
 		notAnInspector bool
+		wantDebugEnd   bool
 	}{
 		{name: "inspector already open"},
-		{name: "inspector opened by SIGUSR1", notAnInspector: true},
+		{name: "inspector opened by SIGUSR1", notAnInspector: true, wantDebugEnd: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			stubProcessWithoutInspectorFlag(t)
 			catchSIGUSR1(t)
 
 			expressions := make(chan string, 1)
@@ -805,6 +806,16 @@ func TestInjectFileClosesTheInspectorAfterAFailedInjection(t *testing.T) {
 				t.Fatal("expected the injection to fail")
 			}
 
+			if !tc.wantDebugEnd {
+				select {
+				case got := <-expressions:
+					t.Fatalf("expected no evaluation, got %q", got)
+				case <-time.After(testInspectorTimeout):
+				}
+
+				return
+			}
+
 			if got := awaitExpression(t, expressions); got != debugEndExpression {
 				t.Fatalf("expected %q, got %q", debugEndExpression, got)
 			}
@@ -815,7 +826,6 @@ func TestInjectFileClosesTheInspectorAfterAFailedInjection(t *testing.T) {
 // When the inspector never answers after SIGUSR1 there is nothing to close,
 // and the cleanup attempt must not turn that into a hang or a panic.
 func TestInjectFileReportsAnInspectorThatNeverOpens(t *testing.T) {
-	stubProcessWithoutInspectorFlag(t)
 	catchSIGUSR1(t)
 
 	// a port nothing listens on: closed by the time the injector dials it

--- a/pkg/internal/nodejs/injector_test.go
+++ b/pkg/internal/nodejs/injector_test.go
@@ -5,17 +5,24 @@ package nodejs
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/signal"
+	"strconv"
 	"strings"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -469,5 +476,451 @@ func TestInjectionPayloadIsNeverFragmented(t *testing.T) {
 	if unsized.fin {
 		t.Fatal("expected the default write buffer to fragment the payload; " +
 			"if gorilla no longer fragments, this test and the sizing rationale should be revisited")
+	}
+}
+
+// evalRequest reads back the expression a Runtime.evaluate request carries.
+type evalRequest struct {
+	ID     int        `json:"id"`
+	Method string     `json:"method"`
+	Params evalParams `json:"params"`
+}
+
+// The inspector is a debugging interface, so OBI closes the one it opened
+// itself with SIGUSR1 and leaves an inspector the process asked for alone.
+func TestInjectionClosesOnlyAnInspectorOBIOpened(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		mayClose     bool
+		wantDebugEnd bool
+	}{
+		{name: "opened by OBI", mayClose: true, wantDebugEnd: true},
+		{name: "opened by the process", mayClose: false, wantDebugEnd: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expressions := make(chan string, 2)
+			wsConn := newTestInspectorConn(t, func(conn *websocket.Conn) {
+				defer conn.Close()
+
+				for {
+					_, msg, err := conn.ReadMessage()
+					if err != nil {
+						return
+					}
+
+					var req evalRequest
+					if err := json.Unmarshal(msg, &req); err != nil {
+						return
+					}
+					expressions <- req.Params.Expression
+
+					if err := conn.WriteJSON(cdpResponse{ID: req.ID}); err != nil {
+						return
+					}
+				}
+			})
+
+			injector := newTestInjector()
+			payload, err := evaluateRequest("void 0;", agentRequestID)
+			if err != nil {
+				t.Fatalf("marshaling evaluate request: %v", err)
+			}
+
+			if err := injector.injectFileWS(1, wsConn, payload, tc.mayClose); err != nil {
+				t.Fatalf("injecting: %v", err)
+			}
+
+			// injectFileWS closes the inspector from a defer, so by the time it
+			// returns every message it sends has already been answered
+			if got := <-expressions; got != "void 0;" {
+				t.Fatalf("expected the agent payload first, got %q", got)
+			}
+
+			select {
+			case got := <-expressions:
+				if !tc.wantDebugEnd {
+					t.Fatalf("expected no further evaluation, got %q", got)
+				}
+				if got != debugEndExpression {
+					t.Fatalf("expected %q, got %q", debugEndExpression, got)
+				}
+			case <-time.After(testInspectorOperationTimeout):
+				if tc.wantDebugEnd {
+					t.Fatalf("timeout waiting for %q", debugEndExpression)
+				}
+			}
+		})
+	}
+}
+
+// A failed injection leaves the inspector listening, so the cleanup path has
+// to reach it over a connection of its own and evaluate process._debugEnd().
+func TestSendDebugEndEvaluatesDebugEnd(t *testing.T) {
+	expressions := make(chan string, 1)
+	srv := newScriptedInspectorServer(t, inspectorScript{expressions: expressions})
+
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial test inspector: %v", err)
+	}
+	defer conn.Close()
+
+	if err := newTestInjector().sendDebugEnd(conn); err != nil {
+		t.Fatalf("sending debug end: %v", err)
+	}
+
+	select {
+	case got := <-expressions:
+		if got != debugEndExpression {
+			t.Fatalf("expected %q, got %q", debugEndExpression, got)
+		}
+	case <-time.After(testInspectorOperationTimeout):
+		t.Fatal("timeout waiting for the evaluated expression")
+	}
+}
+
+// inspectorScript configures the stand-in inspector: how many initial
+// /json/list requests report no debugging targets, which is how an injection
+// attempt is made to fail after the inspector is already open.
+type inspectorScript struct {
+	emptyLists  int
+	expressions chan<- string
+	// notAnInspector answers /json/version with something the injector will
+	// not accept, so injectFile falls through to SIGUSR1 instead of injecting
+	// into an inspector it found already open
+	notAnInspector bool
+	// refuseUpgrade rejects the WebSocket upgrade, the way an inspector that
+	// has stopped serving its debugger session would
+	refuseUpgrade bool
+	// hangUpAfterFirstEvaluate answers one evaluation and then drops the
+	// session, so a following process._debugEnd() cannot be delivered
+	hangUpAfterFirstEvaluate bool
+}
+
+// newScriptedInspectorServer serves /json/version, /json/list and the debugger
+// WebSocket on one connection, the way the real inspector does, reporting
+// every expression it is asked to evaluate.
+func newScriptedInspectorServer(t *testing.T, script inspectorScript) *httptest.Server {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	remainingEmptyLists := &atomic.Int64{}
+	remainingEmptyLists.Store(int64(script.emptyLists))
+
+	var srv *httptest.Server
+
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/json/version":
+			if script.notAnInspector {
+				_, _ = w.Write([]byte("not an inspector"))
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"Browser":"node.js/v22.0.0"}`))
+
+			return
+		case "/json/list":
+			targets := []inspectorTarget{{
+				WebSocketDebuggerURL: "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws",
+			}}
+			if remainingEmptyLists.Add(-1) >= 0 {
+				targets = nil
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(targets)
+
+			return
+		}
+
+		if script.refuseUpgrade {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		for {
+			_, msg, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+
+			var req evalRequest
+			if err := json.Unmarshal(msg, &req); err != nil {
+				return
+			}
+			script.expressions <- req.Params.Expression
+
+			if err := conn.WriteJSON(cdpResponse{ID: req.ID}); err != nil {
+				return
+			}
+
+			if script.hangUpAfterFirstEvaluate {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// pointInjectorAtServer makes the injector dial srv instead of the real
+// inspector port, and keeps the connect budgets short enough that a failing
+// attempt does not stall the test.
+func pointInjectorAtServer(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+
+	_, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("splitting test inspector address: %v", err)
+	}
+
+	parsed, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatalf("parsing test inspector port: %v", err)
+	}
+
+	setInspectorDialTarget(t, parsed)
+}
+
+// setInspectorDialTarget points the injector at port and shortens the connect
+// budgets, restoring both when the test ends.
+func setInspectorDialTarget(t *testing.T, port int) {
+	t.Helper()
+
+	oldPort, oldConnect, oldClose := inspectorPort, inspectorConnectWait, inspectorCloseWait
+	inspectorPort = port
+	inspectorConnectWait = testInspectorTimeout
+	inspectorCloseWait = testInspectorTimeout
+
+	t.Cleanup(func() {
+		inspectorPort = oldPort
+		inspectorConnectWait = oldConnect
+		inspectorCloseWait = oldClose
+	})
+}
+
+func awaitExpression(t *testing.T, expressions <-chan string) string {
+	t.Helper()
+
+	select {
+	case got := <-expressions:
+		return got
+	case <-time.After(testInspectorOperationTimeout):
+		t.Fatal("timeout waiting for an evaluated expression")
+		return ""
+	}
+}
+
+// closeInspector reaches the inspector over a connection of its own, because
+// the one the failed injection used is gone by the time it runs.
+func TestCloseInspectorEvaluatesDebugEnd(t *testing.T) {
+	expressions := make(chan string, 1)
+	srv := newScriptedInspectorServer(t, inspectorScript{expressions: expressions})
+	pointInjectorAtServer(t, srv)
+
+	newTestInjector().closeInspector(1)
+
+	if got := awaitExpression(t, expressions); got != debugEndExpression {
+		t.Fatalf("expected %q, got %q", debugEndExpression, got)
+	}
+}
+
+// A failure after the inspector is open must not leave the debugging
+// interface listening.
+func TestFailedInjectionClosesTheInspector(t *testing.T) {
+	expressions := make(chan string, 1)
+	// the first /json/list reports no targets, failing the injection
+	srv := newScriptedInspectorServer(t, inspectorScript{emptyLists: 1, expressions: expressions})
+	pointInjectorAtServer(t, srv)
+
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial test inspector: %v", err)
+	}
+
+	if err := newTestInjector().injectViaConn(1, conn, true); err == nil {
+		t.Fatal("expected the injection to fail")
+	}
+
+	if got := awaitExpression(t, expressions); got != debugEndExpression {
+		t.Fatalf("expected %q, got %q", debugEndExpression, got)
+	}
+}
+
+// An inspector the process asked for stays open even when the injection fails.
+func TestFailedInjectionLeavesAProcessOwnedInspectorOpen(t *testing.T) {
+	expressions := make(chan string, 1)
+	srv := newScriptedInspectorServer(t, inspectorScript{emptyLists: 1, expressions: expressions})
+	pointInjectorAtServer(t, srv)
+
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial test inspector: %v", err)
+	}
+
+	if err := newTestInjector().injectViaConn(1, conn, false); err == nil {
+		t.Fatal("expected the injection to fail")
+	}
+
+	select {
+	case got := <-expressions:
+		t.Fatalf("expected no evaluation, got %q", got)
+	case <-time.After(testInspectorTimeout):
+	}
+}
+
+// injectFile reaches the inspector two ways - finding it already open, or
+// opening it with SIGUSR1 - and a failed injection has to close it in both.
+func TestInjectFileClosesTheInspectorAfterAFailedInjection(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		notAnInspector bool
+	}{
+		{name: "inspector already open"},
+		{name: "inspector opened by SIGUSR1", notAnInspector: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stubProcessWithoutInspectorFlag(t)
+			catchSIGUSR1(t)
+
+			expressions := make(chan string, 1)
+			// the first /json/list reports no targets, failing the injection
+			srv := newScriptedInspectorServer(t, inspectorScript{
+				emptyLists:     1,
+				expressions:    expressions,
+				notAnInspector: tc.notAnInspector,
+			})
+			pointInjectorAtServer(t, srv)
+
+			if err := newTestInjector().injectFile(os.Getpid(), nil); err == nil {
+				t.Fatal("expected the injection to fail")
+			}
+
+			if got := awaitExpression(t, expressions); got != debugEndExpression {
+				t.Fatalf("expected %q, got %q", debugEndExpression, got)
+			}
+		})
+	}
+}
+
+// When the inspector never answers after SIGUSR1 there is nothing to close,
+// and the cleanup attempt must not turn that into a hang or a panic.
+func TestInjectFileReportsAnInspectorThatNeverOpens(t *testing.T) {
+	stubProcessWithoutInspectorFlag(t)
+	catchSIGUSR1(t)
+
+	// a port nothing listens on: closed by the time the injector dials it
+	srv := newScriptedInspectorServer(t, inspectorScript{})
+	pointInjectorAtServer(t, srv)
+	srv.Close()
+
+	err := newTestInjector().injectFile(os.Getpid(), nil)
+	if err == nil {
+		t.Fatal("expected an error when the inspector never opens")
+	}
+
+	if !strings.Contains(err.Error(), "failed to connect to inspector after SIGUSR1") {
+		t.Fatalf("expected the SIGUSR1 connect failure, got %v", err)
+	}
+}
+
+// catchSIGUSR1 keeps the default disposition, which terminates the process,
+// from killing the test run when the injector signals it.
+func catchSIGUSR1(t *testing.T) {
+	t.Helper()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGUSR1)
+	t.Cleanup(func() {
+		signal.Stop(signals)
+	})
+}
+
+// captureInjectorLogs returns an injector that logs into the returned buffer,
+// so tests can assert on what an operator would see.
+func captureInjectorLogs(t *testing.T) (*NodeInjector, *bytes.Buffer) {
+	t.Helper()
+
+	logs := &bytes.Buffer{}
+	injector := newTestInjector()
+	injector.log = slog.New(slog.NewTextHandler(logs, nil))
+
+	return injector, logs
+}
+
+// A successful injection closes the inspector OBI opened, over the same
+// session it injected through.
+func TestInjectViaConnInjectsThenClosesTheInspector(t *testing.T) {
+	expressions := make(chan string, 2)
+	srv := newScriptedInspectorServer(t, inspectorScript{expressions: expressions})
+	pointInjectorAtServer(t, srv)
+
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial test inspector: %v", err)
+	}
+
+	if err := newTestInjector().injectViaConn(1, conn, true); err != nil {
+		t.Fatalf("injecting: %v", err)
+	}
+
+	if got := awaitExpression(t, expressions); got == debugEndExpression {
+		t.Fatal("expected the agent payload before the close")
+	}
+
+	if got := awaitExpression(t, expressions); got != debugEndExpression {
+		t.Fatalf("expected %q, got %q", debugEndExpression, got)
+	}
+}
+
+// The one outcome an operator has to act on: OBI could not close the
+// inspector, so it says so instead of failing silently.
+func TestCloseInspectorReportsAnInspectorItCannotClose(t *testing.T) {
+	expressions := make(chan string, 1)
+	srv := newScriptedInspectorServer(t, inspectorScript{
+		expressions:   expressions,
+		refuseUpgrade: true,
+	})
+	pointInjectorAtServer(t, srv)
+
+	injector, logs := captureInjectorLogs(t)
+	injector.closeInspector(1)
+
+	if !strings.Contains(logs.String(), "could not close the Node.js inspector") {
+		t.Fatalf("expected a warning about the inspector staying open, got: %s", logs.String())
+	}
+}
+
+// The same warning is due when the injection itself succeeded and only the
+// close failed: the agent is in, but the debugging interface is still open.
+func TestInjectionReportsACloseItCouldNotComplete(t *testing.T) {
+	expressions := make(chan string, 1)
+	srv := newScriptedInspectorServer(t, inspectorScript{
+		expressions:              expressions,
+		hangUpAfterFirstEvaluate: true,
+	})
+	pointInjectorAtServer(t, srv)
+
+	conn, err := net.Dial("tcp", srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial test inspector: %v", err)
+	}
+
+	injector, logs := captureInjectorLogs(t)
+	if err := injector.injectViaConn(1, conn, true); err != nil {
+		t.Fatalf("injecting: %v", err)
+	}
+
+	if !strings.Contains(logs.String(), "could not close the Node.js inspector") {
+		t.Fatalf("expected a warning about the inspector staying open, got: %s", logs.String())
 	}
 }

--- a/pkg/internal/nodejs/nodejs.go
+++ b/pkg/internal/nodejs/nodejs.go
@@ -9,22 +9,13 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"slices"
 	"strings"
 	"syscall"
 
-	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/ebpf"
-	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/internal/netns"
-	"go.opentelemetry.io/obi/pkg/internal/procs"
 	"go.opentelemetry.io/obi/pkg/obi"
-)
-
-var (
-	cmdlineForPID = ebpfcommon.CMDLineForPID
-	envVarsForPID = procs.EnvVars
 )
 
 type NodeInjector struct {
@@ -95,18 +86,16 @@ func (i *NodeInjector) attachAgent(pid int, elfFile *elf.File) error {
 // it checks for a custom SIGUSR1 handler and either sends SIGUSR1 to open the
 // inspector or bails out.
 func (i *NodeInjector) injectFile(pid int, elfFile *elf.File) error {
-	// An inspector the process asked for belongs to whoever started it, and
-	// closing it would break their debugging session. Anything else listening
-	// was opened by OBI, here or in an earlier attempt that failed to clean up.
-	mayClose := !processRequestedInspector(pid)
-
 	conn, err := connect(inspectorHost, inspectorPort)
 	if err == nil {
 		// Validate this is actually a Node.js inspector, not some other
 		// service that happens to listen on port 9229.
 		if i.isNodeInspector(conn) {
+			// Already listening before OBI got here, so it belongs to whoever
+			// opened it - the operator via --inspect, another tool, or a
+			// previous attach. Inject over it, but never close it.
 			i.log.Debug("Node.js inspector already open, injecting directly", "pid", pid)
-			return i.injectViaConn(pid, conn, mayClose)
+			return i.injectViaConn(pid, conn, false)
 		}
 		conn.Close()
 	}
@@ -134,44 +123,18 @@ func (i *NodeInjector) injectFile(pid int, elfFile *elf.File) error {
 		return fmt.Errorf("error enabling node inspector: %w", err)
 	}
 
+	// Past this point the inspector is ours: SIGUSR1 has been delivered and
+	// cannot be taken back.
 	conn, err = connectWait(inspectorHost, inspectorPort, inspectorConnectWait, inspectorConnectInterval)
 	if err != nil {
-		// SIGUSR1 has already been delivered and cannot be taken back: the
-		// inspector may still be coming up, in which case it would stay open
-		// with nobody left to close it.
-		if mayClose {
-			i.closeInspector(pid)
-		}
+		// It may still be coming up, in which case it would stay open with
+		// nobody left to close it.
+		i.closeInspector(pid)
 
 		return fmt.Errorf("failed to connect to inspector after SIGUSR1: %w", err)
 	}
 
-	return i.injectViaConn(pid, conn, mayClose)
-}
-
-// processRequestedInspector reports whether the process itself asked for the
-// inspector, either on its command line or through NODE_OPTIONS. When the
-// answer cannot be determined OBI assumes it did not, keeping the existing
-// behavior of closing the inspector after injecting.
-func processRequestedInspector(pid int) bool {
-	if _, args, err := cmdlineForPID(app.PID(pid)); err == nil {
-		if slices.ContainsFunc(args, isInspectorFlag) {
-			return true
-		}
-	}
-
-	env, err := envVarsForPID(app.PID(pid))
-	if err != nil {
-		return false
-	}
-
-	return isInspectorFlag(env["NODE_OPTIONS"])
-}
-
-// isInspectorFlag matches the whole --inspect family: --inspect,
-// --inspect-brk, --inspect-wait, --inspect-port and their =value forms.
-func isInspectorFlag(arg string) bool {
-	return strings.Contains(arg, "--inspect")
+	return i.injectViaConn(pid, conn, true)
 }
 
 // isNodeInspector validates that a connection to port 9229 is actually a

--- a/pkg/internal/nodejs/nodejs.go
+++ b/pkg/internal/nodejs/nodejs.go
@@ -9,14 +9,22 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"slices"
 	"strings"
 	"syscall"
-	"time"
 
+	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/ebpf"
+	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/internal/netns"
+	"go.opentelemetry.io/obi/pkg/internal/procs"
 	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+var (
+	cmdlineForPID = ebpfcommon.CMDLineForPID
+	envVarsForPID = procs.EnvVars
 )
 
 type NodeInjector struct {
@@ -87,13 +95,18 @@ func (i *NodeInjector) attachAgent(pid int, elfFile *elf.File) error {
 // it checks for a custom SIGUSR1 handler and either sends SIGUSR1 to open the
 // inspector or bails out.
 func (i *NodeInjector) injectFile(pid int, elfFile *elf.File) error {
-	conn, err := connect("127.0.0.1", 9229)
+	// An inspector the process asked for belongs to whoever started it, and
+	// closing it would break their debugging session. Anything else listening
+	// was opened by OBI, here or in an earlier attempt that failed to clean up.
+	mayClose := !processRequestedInspector(pid)
+
+	conn, err := connect(inspectorHost, inspectorPort)
 	if err == nil {
 		// Validate this is actually a Node.js inspector, not some other
 		// service that happens to listen on port 9229.
 		if i.isNodeInspector(conn) {
 			i.log.Debug("Node.js inspector already open, injecting directly", "pid", pid)
-			return i.injectViaConn(conn)
+			return i.injectViaConn(pid, conn, mayClose)
 		}
 		conn.Close()
 	}
@@ -121,12 +134,44 @@ func (i *NodeInjector) injectFile(pid int, elfFile *elf.File) error {
 		return fmt.Errorf("error enabling node inspector: %w", err)
 	}
 
-	conn, err = connectWait("127.0.0.1", 9229, 5*time.Second, 200*time.Millisecond)
+	conn, err = connectWait(inspectorHost, inspectorPort, inspectorConnectWait, inspectorConnectInterval)
 	if err != nil {
+		// SIGUSR1 has already been delivered and cannot be taken back: the
+		// inspector may still be coming up, in which case it would stay open
+		// with nobody left to close it.
+		if mayClose {
+			i.closeInspector(pid)
+		}
+
 		return fmt.Errorf("failed to connect to inspector after SIGUSR1: %w", err)
 	}
 
-	return i.injectViaConn(conn)
+	return i.injectViaConn(pid, conn, mayClose)
+}
+
+// processRequestedInspector reports whether the process itself asked for the
+// inspector, either on its command line or through NODE_OPTIONS. When the
+// answer cannot be determined OBI assumes it did not, keeping the existing
+// behavior of closing the inspector after injecting.
+func processRequestedInspector(pid int) bool {
+	if _, args, err := cmdlineForPID(app.PID(pid)); err == nil {
+		if slices.ContainsFunc(args, isInspectorFlag) {
+			return true
+		}
+	}
+
+	env, err := envVarsForPID(app.PID(pid))
+	if err != nil {
+		return false
+	}
+
+	return isInspectorFlag(env["NODE_OPTIONS"])
+}
+
+// isInspectorFlag matches the whole --inspect family: --inspect,
+// --inspect-brk, --inspect-wait, --inspect-port and their =value forms.
+func isInspectorFlag(arg string) bool {
+	return strings.Contains(arg, "--inspect")
 }
 
 // isNodeInspector validates that a connection to port 9229 is actually a

--- a/pkg/internal/nodejs/nodejs_test.go
+++ b/pkg/internal/nodejs/nodejs_test.go
@@ -4,14 +4,18 @@
 package nodejs
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/ebpf"
+	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/debug"
+	"go.opentelemetry.io/obi/pkg/internal/procs"
 	"go.opentelemetry.io/obi/pkg/obi"
 )
 
@@ -37,5 +41,66 @@ func TestNewExecutableSkipsDeno(t *testing.T) {
 	require.True(t, injector.Enabled())
 	require.NotPanics(t, func() {
 		injector.NewExecutable(&ebpf.Instrumentable{Type: svc.InstrumentableDeno})
+	})
+}
+
+func newTestInjector() *NodeInjector {
+	cfg := obi.DefaultConfig
+	return NewNodeInjector(&cfg)
+}
+
+// OBI may only close an inspector it opened itself, so it has to recognize the
+// ones the process asked for.
+func TestProcessRequestedInspector(t *testing.T) {
+	errUnreadable := errors.New("unreadable")
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		env        map[string]string
+		cmdlineErr error
+		envErr     error
+		want       bool
+	}{
+		{name: "no inspector requested", args: []string{"node", "app.js"}},
+		{name: "command line flag", args: []string{"node", "--inspect", "app.js"}, want: true},
+		{name: "command line flag with a value", args: []string{"node", "--inspect-brk=0.0.0.0:9229"}, want: true},
+		{name: "node options", args: []string{"node", "app.js"}, env: map[string]string{"NODE_OPTIONS": "--inspect-port=9230"}, want: true},
+		{name: "node options without the flag", args: []string{"node", "app.js"}, env: map[string]string{"NODE_OPTIONS": "--max-old-space-size=512"}},
+		{name: "command line unreadable, node options answer", cmdlineErr: errUnreadable, env: map[string]string{"NODE_OPTIONS": "--inspect"}, want: true},
+		{name: "nothing readable", cmdlineErr: errUnreadable, envErr: errUnreadable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmdlineForPID = func(app.PID) (string, []string, error) {
+				return "node", tc.args, tc.cmdlineErr
+			}
+			envVarsForPID = func(app.PID) (map[string]string, error) {
+				return tc.env, tc.envErr
+			}
+			t.Cleanup(func() {
+				cmdlineForPID = ebpfcommon.CMDLineForPID
+				envVarsForPID = procs.EnvVars
+			})
+
+			require.Equal(t, tc.want, processRequestedInspector(1))
+		})
+	}
+}
+
+// stubProcessWithoutInspectorFlag makes the ownership probe report a process
+// that did not ask for the inspector, so OBI owns whatever is listening.
+func stubProcessWithoutInspectorFlag(t *testing.T) {
+	t.Helper()
+
+	cmdlineForPID = func(app.PID) (string, []string, error) {
+		return "node", []string{"node", "app.js"}, nil
+	}
+	envVarsForPID = func(app.PID) (map[string]string, error) {
+		return nil, nil
+	}
+
+	t.Cleanup(func() {
+		cmdlineForPID = ebpfcommon.CMDLineForPID
+		envVarsForPID = procs.EnvVars
 	})
 }

--- a/pkg/internal/nodejs/nodejs_test.go
+++ b/pkg/internal/nodejs/nodejs_test.go
@@ -4,18 +4,14 @@
 package nodejs
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/obi/pkg/appolly/app"
 	"go.opentelemetry.io/obi/pkg/appolly/app/svc"
 	"go.opentelemetry.io/obi/pkg/ebpf"
-	ebpfcommon "go.opentelemetry.io/obi/pkg/ebpf/common"
 	"go.opentelemetry.io/obi/pkg/export"
 	"go.opentelemetry.io/obi/pkg/export/debug"
-	"go.opentelemetry.io/obi/pkg/internal/procs"
 	"go.opentelemetry.io/obi/pkg/obi"
 )
 
@@ -47,60 +43,4 @@ func TestNewExecutableSkipsDeno(t *testing.T) {
 func newTestInjector() *NodeInjector {
 	cfg := obi.DefaultConfig
 	return NewNodeInjector(&cfg)
-}
-
-// OBI may only close an inspector it opened itself, so it has to recognize the
-// ones the process asked for.
-func TestProcessRequestedInspector(t *testing.T) {
-	errUnreadable := errors.New("unreadable")
-
-	for _, tc := range []struct {
-		name       string
-		args       []string
-		env        map[string]string
-		cmdlineErr error
-		envErr     error
-		want       bool
-	}{
-		{name: "no inspector requested", args: []string{"node", "app.js"}},
-		{name: "command line flag", args: []string{"node", "--inspect", "app.js"}, want: true},
-		{name: "command line flag with a value", args: []string{"node", "--inspect-brk=0.0.0.0:9229"}, want: true},
-		{name: "node options", args: []string{"node", "app.js"}, env: map[string]string{"NODE_OPTIONS": "--inspect-port=9230"}, want: true},
-		{name: "node options without the flag", args: []string{"node", "app.js"}, env: map[string]string{"NODE_OPTIONS": "--max-old-space-size=512"}},
-		{name: "command line unreadable, node options answer", cmdlineErr: errUnreadable, env: map[string]string{"NODE_OPTIONS": "--inspect"}, want: true},
-		{name: "nothing readable", cmdlineErr: errUnreadable, envErr: errUnreadable},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			cmdlineForPID = func(app.PID) (string, []string, error) {
-				return "node", tc.args, tc.cmdlineErr
-			}
-			envVarsForPID = func(app.PID) (map[string]string, error) {
-				return tc.env, tc.envErr
-			}
-			t.Cleanup(func() {
-				cmdlineForPID = ebpfcommon.CMDLineForPID
-				envVarsForPID = procs.EnvVars
-			})
-
-			require.Equal(t, tc.want, processRequestedInspector(1))
-		})
-	}
-}
-
-// stubProcessWithoutInspectorFlag makes the ownership probe report a process
-// that did not ask for the inspector, so OBI owns whatever is listening.
-func stubProcessWithoutInspectorFlag(t *testing.T) {
-	t.Helper()
-
-	cmdlineForPID = func(app.PID) (string, []string, error) {
-		return "node", []string{"node", "app.js"}, nil
-	}
-	envVarsForPID = func(app.PID) (map[string]string, error) {
-		return nil, nil
-	}
-
-	t.Cleanup(func() {
-		cmdlineForPID = ebpfcommon.CMDLineForPID
-		envVarsForPID = procs.EnvVars
-	})
 }


### PR DESCRIPTION
## Summary

Fixes #3274.

`process._debugEnd()` was only sent from `injectFileWS`, which runs after the WebSocket upgrade succeeds. Every failure before that point returned with the inspector still listening on `127.0.0.1:9229` until the process restarted, and a failed close was discarded silently.

This closes it on each failure path, over a connection of its own since the one the injection used is unusable by then, and warns when the close attempt itself fails — that log is the only signal an operator gets today.

It also adds ownership tracking: OBI now closes only an inspector it opened itself, and leaves alone one the process asked for via `--inspect` or `NODE_OPTIONS`. The previous unconditional `defer` would close the operator's debugging session.

Follows the shape agreed in the issue discussion. The stalled-inspector case (5s deadlines firing repeatedly) remains not closable over the inspector protocol by definition; it now produces a warn log instead of failing silently.

- `closeInspector` / `sendDebugEnd`, composed from the existing connect/upgrade/evaluate helpers
- `processRequestedInspector` for ownership, checking cmdline and `NODE_OPTIONS`
- hardcoded `127.0.0.1`, `9229`, `5s`, `200ms` lifted to named constants
- 11 tests covering each failure path, ownership, and the close-fails case

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

Not a feature change, so the features docs and support matrix are untouched.
