### PR TITLE
generictracer: backfill listening ports for processes discovered late

### DIFF
--- a/pkg/internal/ebpf/generictracer/generictracer.go
+++ b/pkg/internal/ebpf/generictracer/generictracer.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"os"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -57,6 +58,8 @@ type Tracer struct {
 	eventCtx         *ebpfcommon.EBPFEventContext
 	jvmUSDTManager   ebpfcommon.USDTSpecManager
 	pythonRuntime    *pythonRuntimeController
+
+	itersDirty atomic.Bool
 }
 
 func tlog() *slog.Logger {
@@ -165,6 +168,8 @@ func (p *Tracer) AllowPID(pid app.PID, ns uint32, fi *exec.FileInfo) {
 	if p.pythonRuntime != nil {
 		p.pythonRuntime.allow(pid, ns, fi, serviceSource)
 	}
+
+	p.itersDirty.Store(true)
 
 	if err := p.rebuildValidPids(); err != nil {
 		p.log.Error("rebuilding the BPF PID filter", "error", err)
@@ -684,6 +689,24 @@ func (p *Tracer) runItersForPids() {
 	}
 }
 
+const itersBackfillInterval = 3 * time.Second
+
+func (p *Tracer) watchForNewPids(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if p.itersDirty.Swap(false) {
+				p.runItersForPids()
+			}
+		}
+	}
+}
+
 func (p *Tracer) Tracing() []*ebpfcommon.Tracing { return nil }
 
 func (p *Tracer) RecordInstrumentedLib(id uint64, closers []io.Closer) {
@@ -757,7 +780,9 @@ func (p *Tracer) Run(
 	go p.lookForTimeouts(ctx, parseContext, timeoutTicker, eventsChan)
 	defer timeoutTicker.Stop()
 
+	p.itersDirty.Store(false)
 	p.runItersForPids()
+	go p.watchForNewPids(ctx, itersBackfillInterval)
 
 	p.log.Info("Launching p.Tracer")
 

--- a/pkg/internal/ebpf/generictracer/generictracer_test.go
+++ b/pkg/internal/ebpf/generictracer/generictracer_test.go
@@ -8,6 +8,7 @@ package generictracer
 import (
 	"context"
 	"math"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unsafe"
@@ -465,4 +466,93 @@ func (f fakeServiceFilter) CurrentPIDs(ebpfcommon.PIDType) map[uint32]map[app.PI
 		(*f.currentPIDsCalls)++
 	}
 	return f.current
+}
+
+func TestAllowPIDSignalsBackfill(t *testing.T) {
+	currentPIDsCalls := 0
+	tracer := &Tracer{
+		log:        tlog(),
+		pidsFilter: fakeServiceFilter{currentPIDsCalls: &currentPIDsCalls},
+	}
+	file := exec.New(exec.Init{Pid: 101, Service: svc.Attrs{}})
+
+	tracer.AllowPID(101, 42, file)
+
+	require.True(t, tracer.itersDirty.Load())
+	assert.Zero(t, currentPIDsCalls)
+}
+
+func TestWatchForNewPidsRunsWhenDirty(t *testing.T) {
+	const interval = 10 * time.Millisecond
+	filter := &countingServiceFilter{}
+	tracer := &Tracer{log: tlog(), pidsFilter: filter}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go tracer.watchForNewPids(ctx, interval)
+
+	time.Sleep(interval * 2)
+	require.Zero(t, filter.calls.Load())
+
+	tracer.itersDirty.Store(true)
+	require.Eventually(t, func() bool { return filter.calls.Load() == 1 }, time.Second, interval)
+
+	time.Sleep(interval * 3)
+	assert.Equal(t, int64(1), filter.calls.Load())
+
+	tracer.itersDirty.Store(true)
+	require.Eventually(t, func() bool { return filter.calls.Load() == 2 }, time.Second, interval)
+}
+
+func TestWatchForNewPidsPreservesConcurrentSignalDuringWalk(t *testing.T) {
+	const interval = 10 * time.Millisecond
+	filter := &blockingServiceFilter{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	tracer := &Tracer{log: tlog(), pidsFilter: filter}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	tracer.itersDirty.Store(true)
+	go tracer.watchForNewPids(ctx, interval)
+
+	select {
+	case <-filter.entered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for watcher to enter walk")
+	}
+
+	tracer.itersDirty.Store(true)
+	filter.release <- struct{}{}
+
+	require.Eventually(t, func() bool { return filter.calls.Load() == 2 }, time.Second, interval)
+}
+
+type countingServiceFilter struct {
+	fakeServiceFilter
+	calls atomic.Int64
+}
+
+func (f *countingServiceFilter) CurrentPIDs(ebpfcommon.PIDType) map[uint32]map[app.PID]svc.Attrs {
+	f.calls.Add(1)
+	return nil
+}
+
+type blockingServiceFilter struct {
+	fakeServiceFilter
+	entered chan struct{}
+	release chan struct{}
+	calls   atomic.Int64
+}
+
+func (f *blockingServiceFilter) CurrentPIDs(ebpfcommon.PIDType) map[uint32]map[app.PID]svc.Attrs {
+	f.calls.Add(1)
+	select {
+	case f.entered <- struct{}{}:
+		<-f.release
+	default:
+	}
+	return nil
 }


### PR DESCRIPTION
### Description

Fixes #3297.

`generictracer` previously executed `runItersForPids()` only once during startup in `Run()`. Any process discovered after startup (e.g. secondary containers or late-starting services such as Kafka or Postgres) never had its listening sockets populated into the `listening_ports` BPF map. When early inbound traffic arrived on pre-existing connections for those processes, OBI misclassified the server traffic as unsolicited client responses and dropped the spans.

This PR re-runs the iterator backfill whenever new processes are discovered:

- `AllowPID()` marks an `itersDirty atomic.Bool` flag after adding the PID to `pidsFilter`.
- `Run()` performs the initial startup iterator pass, then launches a lightweight background goroutine that checks the flag every 3 seconds.
- When dirty, `watchForNewPids()` consumes the flag via `Swap(false)` and executes `runItersForPids()`. Using `Swap(false)` before iteration ensures any PID discovered while an iterator walk is active re-arms the flag for the subsequent tick.
- `runItersForPids()` remains unchanged, retaining its existing per-pass network namespace deduplication (`seen[inode]`).
