### PR TITLE
give batched spans their own trace when the batch has no parent

### DIFF
--- a/internal/test/integration/components/pythonredis/main.py
+++ b/internal/test/integration/components/pythonredis/main.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
 import os
+import threading
+import time
 import uvicorn
 import redis
 
@@ -110,6 +112,48 @@ def redis_error_test():
     db1_redis_cli.get('obi-db-1')
 
     return 'done', 200
+
+pipeline_cli = None
+
+@app.get("/redis-pipeline")
+def redis_pipeline():
+    global pipeline_cli
+    if pipeline_cli is None:
+        pipeline_cli = redis.Redis(
+            host='redis',
+            port=6379,
+            decode_responses=True
+            )
+
+    # One socket write carrying four commands, which OBI parses into four spans
+    pipe = pipeline_cli.pipeline(transaction=False)
+    pipe.set('obi-pipeline-1', 'rocks')
+    pipe.set('obi-pipeline-2', 'rocks')
+    pipe.get('obi-pipeline-1')
+    pipe.get('obi-pipeline-2')
+    pipe.execute()
+
+    return 'done', 200
+
+def background_pipeline_loop():
+    while True:
+        # A fresh connection each round so the commands are never parsed off a
+        # socket that was already open before OBI attached
+        bg_cli = redis.Redis(host='redis', port=6379, decode_responses=True)
+        pipe = bg_cli.pipeline(transaction=False)
+        pipe.sadd('obi-bg-set', 'a')
+        pipe.sadd('obi-bg-set', 'b')
+        pipe.smembers('obi-bg-set')
+        pipe.smembers('obi-bg-set')
+        pipe.execute()
+        bg_cli.close()
+        time.sleep(0.5)
+
+
+# A pipeline with no inbound request behind it, so its commands have no parent
+# span and each has to end up in a trace of its own. Started at import because
+# the container runs uvicorn directly, so __main__ never executes.
+threading.Thread(target=background_pipeline_loop, daemon=True).start()
 
 if __name__ == "__main__":
     print(f"Server running: port={8080} process_id={os.getpid()}")

--- a/internal/test/integration/docker-compose-python-redis-pipeline.yml
+++ b/internal/test/integration/docker-compose-python-redis-pipeline.yml
@@ -1,0 +1,110 @@
+version: "3.8"
+
+services:
+  redis:
+    build:
+      context: ../../../internal/test/integration/components/redis/
+      dockerfile: Dockerfile
+    image: redis
+
+  testserver:
+    build:
+      context: ../../../internal/test/integration/components/pythonredis/
+      dockerfile: Dockerfile
+    image: hatest-testserver-python-redis
+    ports:
+      - "${TEST_SERVICE_PORTS}"
+    depends_on:
+      otelcol:
+        condition: service_started
+      redis:
+        condition: service_started
+  obi:
+    build:
+      context: ../../..
+      dockerfile: ./internal/test/integration/components/obi/Dockerfile
+    volumes:
+      - ./configs/:/configs
+      - ./system/sys/kernel/security:/sys/kernel/security
+      - ../../../testoutput:/coverage
+      - ../../../testoutput/run-python:/var/run/obi
+    image: hatest-obi
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      OTEL_EBPF_CONFIG_PATH: "/configs/obi-config-redis.yml"
+      GOCOVERDIR: "/coverage"
+      OTEL_EBPF_TRACE_PRINTER: "text"
+      OTEL_EBPF_OPEN_PORT: "${OTEL_EBPF_OPEN_PORT}"
+      OTEL_EBPF_DISCOVERY_POLL_INTERVAL: 500ms
+      OTEL_EBPF_EXECUTABLE_PATH: "${OTEL_EBPF_EXECUTABLE_PATH}"
+      OTEL_EBPF_SERVICE_NAMESPACE: "integration-test"
+      OTEL_EBPF_METRICS_INTERVAL: "1s"
+      OTEL_EBPF_BPF_BATCH_TIMEOUT: "10ms"
+      OTEL_EBPF_LOG_LEVEL: "DEBUG"
+      OTEL_EBPF_BPF_DEBUG: "TRUE"
+      OTEL_EBPF_OTLP_TRACES_BATCH_TIMEOUT: "1ms"
+      OTEL_EBPF_HOSTNAME: "obi"
+      OTEL_EBPF_BPF_HTTP_REQUEST_TIMEOUT: "5s"
+      OTEL_EBPF_PROCESSES_INTERVAL: "100ms"
+      OTEL_EBPF_TRACES_INSTRUMENTATIONS: "http,redis"
+      OTEL_EBPF_METRICS_INSTRUMENTATIONS: "http,redis"
+      OTEL_EBPF_METRICS_FEATURES: "application"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  # OpenTelemetry Collector
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.160.0@sha256:799dc6cf12c96192af37b5bdba804da8c10b3bc563b43cb90c3f3c58d9572ad6
+    container_name: otel-col
+    deploy:
+      resources:
+        limits:
+          memory: 125M
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol-config/otelcol-config-weaver.yml"]
+    volumes:
+      - ./configs/:/etc/otelcol-config
+    ports:
+      - "4317" # OTLP over gRPC receiver
+      - "4318:4318" # OTLP over HTTP receiver
+      - "9464" # Prometheus exporter
+      - "8888" # metrics endpoint
+    depends_on:
+      prometheus:
+        condition: service_started
+      jaeger:
+        condition: service_started
+      weaver:
+        condition: service_healthy
+
+  weaver:
+    extends:
+      file: components/weaver/service.yml
+      service: weaver
+    volumes:
+      - ../../../schemas/obi:/obi-registry:ro
+
+  # Prometheus
+  prometheus:
+    image: quay.io/prometheus/prometheus:v3.14.0@sha256:5ce7540c3c00ef4ab0c9d2c995c6a5b9c421f44b4a115d97a2c7af3b1c21cbb0
+    container_name: prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus-config.yml
+      - --web.enable-lifecycle
+      - --web.route-prefix=/
+    volumes:
+      - ./configs/:/etc/prometheus
+    ports:
+      - "9090:9090"
+
+  jaeger:
+    image: jaegertracing/jaeger:2.20.0@sha256:46a886260e04002d8f45e213fc39063fa11a50446048fdaa64786fc0840cb9f8
+    ports:
+      - "16686:16686" # Query frontend
+      - "4317" # OTEL GRPC traces collector
+      - "4318" # OTEL HTTP traces collector
+    command:
+      - "--set=service.telemetry.logs.level=debug"

--- a/internal/test/integration/suites_test.go
+++ b/internal/test/integration/suites_test.go
@@ -807,6 +807,18 @@ func TestSuite_PythonRedis(t *testing.T) {
 	require.NoError(t, compose.Close())
 }
 
+func TestSuite_PythonRedisPipeline(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-python-redis-pipeline.yml", path.Join(pathOutput, "test-suite-python-redis-pipeline.log"))
+	require.NoError(t, err)
+
+	compose.Env = append(compose.Env, `OTEL_EBPF_OPEN_PORT=8080`, `OTEL_EBPF_EXECUTABLE_PATH=`, `TEST_SERVICE_PORTS=8381:8080`)
+	require.NoError(t, compose.Up())
+	t.Run("Redis pipeline traces", testTracesRedisPipeline)
+	t.Run("Redis pipeline traces without a parent", testTracesRedisPipelineNoParent)
+	runWeaverValidation(t)
+	require.NoError(t, compose.Close())
+}
+
 func TestSuite_PythonRedisServerSide(t *testing.T) {
 	compose, err := docker.ComposeSuite("docker-compose-python-redis-server.yml", path.Join(pathOutput, "test-suite-python-redis-server.log"))
 	require.NoError(t, err)

--- a/internal/test/integration/traces_test_redis_pipeline.go
+++ b/internal/test/integration/traces_test_redis_pipeline.go
@@ -1,0 +1,134 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package integration // import "go.opentelemetry.io/obi/internal/test/integration"
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/internal/test/integration/components/jaeger"
+	ti "go.opentelemetry.io/obi/pkg/test/integration"
+)
+
+// A redis pipeline puts several commands in one socket write, so OBI parses them
+// all out of a single event. Each command must still reach Jaeger as its own
+// span, and because the pipeline runs while a request is being served they all
+// belong to that request's trace, as siblings of each other.
+func testTracesRedisPipeline(t *testing.T) {
+	const pipelinedCommands = 4
+
+	waitForTestComponentsSub(t, "http://localhost:8381", "/redis-pipeline")
+
+	for range 3 {
+		ti.DoHTTPGet(t, "http://localhost:8381/redis-pipeline", 200)
+	}
+
+	var commands []jaeger.Span
+	var trace jaeger.Trace
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=python3.14&operation=GET%20%2Fredis-pipeline")
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+		traces := tq.FindBySpan(jaeger.Tag{Key: "url.path", Type: "string", Value: "/redis-pipeline"})
+		require.NotEmpty(ct, traces)
+
+		trace = traces[0]
+		commands = pipelinedRedisCommands(trace)
+		require.Len(ct, commands, pipelinedCommands)
+	}, testTimeout, 100*time.Millisecond)
+
+	server := trace.FindByOperationName("GET /redis-pipeline", "server")
+	require.Len(t, server, 1)
+
+	spanIDs := map[string]struct{}{}
+	parents := map[string]struct{}{}
+	for _, cmd := range commands {
+		assert.Equal(t, server[0].TraceID, cmd.TraceID,
+			"a pipelined command issued while serving a request belongs to that request's trace")
+
+		require.NotEmpty(t, cmd.SpanID)
+		require.NotContains(t, spanIDs, cmd.SpanID,
+			"every command parsed out of the batch needs its own span id")
+		spanIDs[cmd.SpanID] = struct{}{}
+
+		parent, ok := trace.ParentOf(&cmd)
+		require.True(t, ok, "a command issued while serving a request must have a parent")
+		parents[parent.SpanID] = struct{}{}
+	}
+	assert.Len(t, parents, 1, "the whole batch hangs off the request that issued it")
+}
+
+// The background loop pipelines its commands with no request behind them, so
+// none of them has a parent. Spans without a parent are roots, and a trace has
+// room for exactly one, so each command has to arrive in a trace of its own
+// rather than sharing the one trace id of the event they were parsed from.
+func testTracesRedisPipelineNoParent(t *testing.T) {
+	const wantTraces = 4
+
+	var traces []jaeger.Trace
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := http.Get(jaegerQueryURL + "?service=python3.14&operation=SADD")
+		require.NoError(ct, err)
+		if resp == nil {
+			return
+		}
+		require.Equal(ct, http.StatusOK, resp.StatusCode)
+		var tq jaeger.TracesQuery
+		require.NoError(ct, json.NewDecoder(resp.Body).Decode(&tq))
+		require.GreaterOrEqual(ct, len(tq.Data), wantTraces)
+		traces = tq.Data
+	}, testTimeout, 100*time.Millisecond)
+
+	for _, trace := range traces {
+		commands := backgroundRedisCommands(trace)
+		require.Len(t, commands, 1,
+			"a parentless command must not share a trace with the rest of its batch")
+
+		_, hasParent := trace.ParentOf(&commands[0])
+		assert.False(t, hasParent,
+			"a command with no request behind it is the root of its own trace")
+	}
+}
+
+// pipelinedRedisCommands returns the redis client spans for the commands the
+// /redis-pipeline endpoint batches, ignoring the CLIENT SETINFO handshake the
+// driver sends when it first connects.
+func pipelinedRedisCommands(trace jaeger.Trace) []jaeger.Span {
+	var commands []jaeger.Span
+	for _, span := range trace.Spans {
+		if span.OperationName != "SET" && span.OperationName != "GET" {
+			continue
+		}
+		if system, ok := jaeger.FindIn(span.Tags, "db.system.name"); !ok || system.Value != "redis" {
+			continue
+		}
+		commands = append(commands, span)
+	}
+
+	return commands
+}
+
+// backgroundRedisCommands returns the redis client spans for the commands the
+// background loop batches.
+func backgroundRedisCommands(trace jaeger.Trace) []jaeger.Span {
+	var commands []jaeger.Span
+	for _, span := range trace.Spans {
+		if span.OperationName != "SADD" && span.OperationName != "SMEMBERS" {
+			continue
+		}
+		commands = append(commands, span)
+	}
+
+	return commands
+}

--- a/pkg/ebpf/common/common.go
+++ b/pkg/ebpf/common/common.go
@@ -33,6 +33,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/ebpf/common/dnsparser"
 	ebpfhttp "go.opentelemetry.io/obi/pkg/ebpf/common/http"
 	"go.opentelemetry.io/obi/pkg/ebpf/ringbuf"
+	"go.opentelemetry.io/obi/pkg/export/otel/idgen"
 	"go.opentelemetry.io/obi/pkg/internal/ebpf/kafkaparser"
 	"go.opentelemetry.io/obi/pkg/internal/largebuf"
 	"go.opentelemetry.io/obi/pkg/pipe/msg"
@@ -516,6 +517,19 @@ func (ctx *EBPFParseContext) Close() {
 	ctx.discardPendingGoHTTPClients.Store(true)
 	if ctx.pendingGoHTTPClientRequests != nil {
 		ctx.pendingGoHTTPClientRequests.Purge()
+	}
+}
+
+// detachExtraSpans prepares sibling spans parsed out of a single batched event.
+// They all carry the ids of that one event, so each needs its own span id, and
+// when the batch has no parent request each also needs its own trace id: sharing
+// one would put several parentless spans in a trace that can have only one root.
+func detachExtraSpans(spans []request.Span) {
+	for i := range spans {
+		spans[i].SpanID = trace.SpanID{}
+		if !spans[i].ParentSpanID.IsValid() {
+			spans[i].TraceID = idgen.RandomTraceID()
+		}
 	}
 }
 

--- a/pkg/ebpf/common/detach_extra_spans_test.go
+++ b/pkg/ebpf/common/detach_extra_spans_test.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ebpfcommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"go.opentelemetry.io/obi/pkg/appolly/app/request"
+	"go.opentelemetry.io/obi/pkg/export/otel/idgen"
+)
+
+func batchedSpans(parent trace.SpanID) []request.Span {
+	traceID := idgen.RandomTraceID()
+	spanID := idgen.RandomSpanID()
+
+	spans := make([]request.Span, 3)
+	for i := range spans {
+		spans[i] = request.Span{TraceID: traceID, SpanID: spanID, ParentSpanID: parent}
+	}
+
+	return spans
+}
+
+func TestDetachExtraSpansUnparentedBatchGetsOneTraceEach(t *testing.T) {
+	spans := batchedSpans(trace.SpanID{})
+	batchTraceID := spans[0].TraceID
+
+	detachExtraSpans(spans)
+
+	seen := map[trace.TraceID]struct{}{batchTraceID: {}}
+	for i := range spans {
+		require.NotContains(t, seen, spans[i].TraceID,
+			"a parentless batched span must not share a trace with the rest of the batch")
+		seen[spans[i].TraceID] = struct{}{}
+
+		assert.True(t, spans[i].TraceID.IsValid())
+		assert.False(t, spans[i].SpanID.IsValid())
+		assert.False(t, spans[i].ParentSpanID.IsValid())
+	}
+}
+
+func TestDetachExtraSpansParentedBatchStaysInOneTrace(t *testing.T) {
+	parent := idgen.RandomSpanID()
+	spans := batchedSpans(parent)
+	batchTraceID := spans[0].TraceID
+
+	detachExtraSpans(spans)
+
+	for i := range spans {
+		assert.Equal(t, batchTraceID, spans[i].TraceID,
+			"a batch with a parent request stays in the parent's trace")
+		assert.Equal(t, parent, spans[i].ParentSpanID)
+		assert.False(t, spans[i].SpanID.IsValid())
+	}
+}

--- a/pkg/ebpf/common/memcached_detect_transform.go
+++ b/pkg/ebpf/common/memcached_detect_transform.go
@@ -270,6 +270,7 @@ func emitMemcachedNoreplySpans(parseCtx *EBPFParseContext, trace *TCPRequestInfo
 		spans = append(spans, memcachedNoreplySpan(trace, op.Op, op.Key))
 	}
 
+	detachExtraSpans(spans)
 	emitTCPExtraSpans(parseCtx, trace, spans...)
 }
 

--- a/pkg/ebpf/common/redis_detect_transform.go
+++ b/pkg/ebpf/common/redis_detect_transform.go
@@ -496,10 +496,7 @@ func ReadGoRedisRequestIntoSpan(parseCtx *EBPFParseContext, record *ringbuf.Reco
 		spans = append(spans, goRedisSpan(event, cmds[i].op, cmds[i].text))
 	}
 	if len(spans) > 1 {
-		// clear SpanID on extras so tracesgen assigns fresh IDs
-		for i := 1; i < len(spans); i++ {
-			spans[i].SpanID = trace2.SpanID{}
-		}
+		detachExtraSpans(spans[1:])
 		parseCtx.emitExtraSpans(spans[1:]...)
 	}
 	return spans[0], false, nil

--- a/pkg/ebpf/common/tcp_detect_transform.go
+++ b/pkg/ebpf/common/tcp_detect_transform.go
@@ -153,12 +153,9 @@ func kafkaSpanEmittingExtras(parseCtx *EBPFParseContext, event *TCPRequestInfo, 
 	if len(infos) > 1 {
 		extra := make([]request.Span, 0, len(infos)-1)
 		for _, info := range infos[1:] {
-			s := TCPToKafkaToSpan(event, info)
-			// Zero the SpanID so the pipeline assigns a unique one; otherwise every
-			// topic span from this request would share the event's SpanID.
-			s.SpanID = trace.SpanID{}
-			extra = append(extra, s)
+			extra = append(extra, TCPToKafkaToSpan(event, info))
 		}
+		detachExtraSpans(extra)
 		emitTCPExtraSpans(parseCtx, event, extra...)
 	}
 	return primary, true
@@ -475,10 +472,7 @@ func matchRedis(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer
 	}
 
 	if len(spans) > 1 {
-		// clear SpanID on extras so tracesgen assigns fresh IDs
-		for i := 1; i < len(spans); i++ {
-			spans[i].SpanID = trace.SpanID{}
-		}
+		detachExtraSpans(spans[1:])
 		emitTCPExtraSpans(parseCtx, event, spans[1:]...)
 	}
 
@@ -550,11 +544,7 @@ func matchAMQP(parseCtx *EBPFParseContext, event *TCPRequestInfo, requestBuffer,
 			return request.Span{}, true, true, nil
 		}
 		if len(spans) > 1 {
-			// Clear SpanID on extras so tracesgen assigns fresh IDs; otherwise
-			// every clone exports with the captured SpanID, violating OTel.
-			for i := 1; i < len(spans); i++ {
-				spans[i].SpanID = trace.SpanID{}
-			}
+			detachExtraSpans(spans[1:])
 			emitTCPExtraSpans(parseCtx, event, spans[1:]...)
 		}
 		return spans[0], false, true, nil


### PR DESCRIPTION
## Summary

Protocols that carry several operations in one payload are parsed into several spans built from a single event, so every span inherits that event's ids. The extras already had their span id cleared, but they kept the event's trace id.

When the batch has a parent request that is correct: the operations are siblings under it. When it has no parent it puts several parentless spans in one trace, and a trace should not have more then 1 root.

## Fix

`detachExtraSpans` clears the span id on each extra and, when the extra has no parent request, also gives it its own trace id. Applied to Redis (both the generic and the Go tracer path), Kafka multi-topic, AMQP and Memcached noreply. It replaces four copies of the existing span-id clearing loop, so the change is a net two lines.

Batches that do have a parent request are untouched and still export as siblings in the parent's trace.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
