### PR TITLE
declare dns.lookup.duration as a plain group instead of a v2 refinement

### DIFF
--- a/schemas/obi/README.md
+++ b/schemas/obi/README.md
@@ -9,7 +9,7 @@ upstream dependency it forms the complete contract of what OBI emits
 
 Weaver has **no precedence or merge semantics** between a local group and the
 groups a dependency contributes to the resolved registry
-(`groups/dns.yaml` imports all upstream groups). When the same attribute id is
+(`--include-unreferenced` pulls in all upstream groups). When the same attribute id is
 declared by more than one group, live-check silently resolves
 the duplicate in favor of the group whose id sorts **last lexicographically** —
 including the upstream `span.*` / `metric.*` groups that `ref` an attribute

--- a/schemas/obi/groups/dns.yaml
+++ b/schemas/obi/groups/dns.yaml
@@ -1,47 +1,41 @@
-file_format: definition/2
-
-imports:
-  entities: ["*"]
-  events: ["*"]
-  metrics: ["*"]
-  spans: ["*"]
-  attribute_groups: ["*"]
-
-metric_refinements:
-  # OBI override of the upstream metric.dns.lookup.duration definition.
-  #
-  # Upstream (semconv v1.41.0) marks dns.question.name as `required`, but OBI
-  # deliberately disables it by default to bound metric cardinality (raw DNS
-  # question names are unbounded / attacker-controlled — see
-  # attr.DNSQuestionName in pkg/export/attributes/attr_defs.go; users can opt
-  # in via `attributes.select`). This group re-declares the attribute as
-  # `opt_in` so weaver live-check accepts its absence while still validating
-  # its type/value whenever a user opts in. All other parent attributes
-  # (error.type, …) are inherited unchanged via `extends`.
-  #
-  # NOTE on the group id: Weaver has no precedence semantics between a local
-  # group and a dependency group sharing the same metric_name when the
-  # dependency's copy is imported into the resolved registry. The winner is
-  # the group whose id sorts LAST
-  # lexicographically (resolved registry is sorted by id; live-check's
-  # metric_name lookup is last-insert-wins). This id is deliberately chosen to
-  # sort after the upstream `metric.dns.lookup.duration` so the override wins.
-  # Do not rename it to something that sorts earlier, and do not reuse the
-  # upstream group id (a same-id redefinition loses the live-check tie to the
-  # dependency AND trips `DuplicateGroupId` in `registry check`). Tracked
-  # upstream in https://github.com/open-telemetry/weaver/issues/1578; once
-  # weaver defines local-wins precedence, this comment block can be dropped.
-  #
-  # `weaver registry check` flags this same-metric_name duplicate as a
-  # DuplicateMetricName error even though live-check resolves it; this
-  # specific expected duplicate is allowlisted in
-  # scripts/lint-schema-filter.jq with the same rationale.
-  - id: metric.dns.lookup.duration.obi
-    ref: dns.lookup.duration
-    stability: development
+# OBI's narrowed copy of the upstream dns.lookup.duration metric.
+#
+# Upstream (semconv v1.41.0) marks dns.question.name as `required`, but OBI
+# deliberately disables it by default to bound metric cardinality (raw DNS
+# question names are unbounded / attacker-controlled — see attr.DNSQuestionName
+# in pkg/export/attributes/attr_defs.go; users can opt in via
+# `attributes.select`). Declaring it `opt_in` here lets weaver live-check accept
+# its absence while still validating its type/value whenever a user opts in.
+#
+# This is a groups-format redeclaration rather than a definition/2
+# `metric_refinements` override. weaver 0.26 drops a refinement of a dependency
+# signal from the representation live-check reads, which silently restores
+# upstream's `required` and fails every test whose workload resolves DNS. A
+# groups-format declaration takes precedence over the dependency's definition in
+# both 0.25 and 0.26, so it does not rely on refinement resolution or on the
+# group-id sort order described in
+# https://github.com/open-telemetry/weaver/issues/1578.
+#
+# The blanket `imports` block this file used to carry is redundant: live-check
+# runs with `--include-unreferenced`, which already pulls every upstream group
+# into the resolved registry. Dropping it leaves the registry byte-identical
+# (849 attributes, unchanged findings for upstream metrics).
+#
+# The duplicate metric_name against the upstream definition is expected and
+# allowlisted in scripts/lint-schema-filter.jq.
+groups:
+  - id: metric.obi.dns.lookup.duration
+    type: metric
+    metric_name: dns.lookup.duration
     brief: >
       Measures the time taken to perform a DNS lookup. OBI variant of the
       upstream metric with dns.question.name opt-in instead of required.
+    instrument: histogram
+    unit: "s"
+    stability: development
     attributes:
       - ref: dns.question.name
         requirement_level: opt_in
+      - ref: error.type
+        requirement_level:
+          conditionally_required: if and only if an error has occurred.

--- a/scripts/lint-schema-filter.jq
+++ b/scripts/lint-schema-filter.jq
@@ -15,7 +15,14 @@
 #    id `x.obi.<ns>`) — either an enum extended with the values OBI
 #    intentionally emits, or an open-ended enum re-typed as string.
 #
-# 3. DeprecatedIncludeUnreferencedWarning: weaver 0.25 deprecated the
+# 3. DuplicateMetricName for dns.lookup.duration: OBI declares a narrowed copy
+#    in `schemas/obi/groups/dns.yaml` while `--include-unreferenced` keeps the
+#    upstream definition in the resolved registry, so weaver sees the name
+#    twice. live-check resolves it in OBI's favor. Scoped to exactly two
+#    provenances — OBI's dns file and the upstream dns model — so a third
+#    declaration, a different metric, or an unexpected file still fails.
+#
+# 4. DeprecatedIncludeUnreferencedWarning: weaver 0.25 deprecated the
 #    `--include-unreferenced` flag, which OBI still needs — its override and
 #    marker groups are standalone (not referenced by a signal), so without it
 #    they drop out of resolution. `--future` promotes the deprecation to an
@@ -45,6 +52,16 @@ map(select(
              | ($groups | length) == 2
                and ($groups[0] | startswith("registry."))
                and $groups[1] == ("x.obi." + ($groups[0] | ltrimstr("registry."))))
+    )
+    or
+    (
+      (.error.DuplicateMetricName? // null) as $dupmetric
+      | $dupmetric != null
+        and $dupmetric.metric_name == "dns.lookup.duration"
+        and (($dupmetric.provenances // []) | map(.path)) as $paths
+            | ($paths | length) == 2
+              and ($paths | any(. == "/obi-registry/groups/dns.yaml"))
+              and ($paths | any(startswith(".deps/") and endswith("/dns/metrics.yaml")))
     )
     or
     (

--- a/scripts/lint_schema_filter_test.go
+++ b/scripts/lint_schema_filter_test.go
@@ -114,6 +114,28 @@ func TestLintSchemaFilterAllowsExpectedEnumOverrideDuplicates(t *testing.T) {
 	}
 }
 
+// expectedDNSMetricDuplicate mirrors the DuplicateMetricName diagnostic weaver
+// emits because OBI declares a narrowed dns.lookup.duration while
+// --include-unreferenced keeps the upstream definition in the resolved
+// registry (see schemas/obi/groups/dns.yaml).
+const expectedDNSMetricDuplicate = `[{
+	"diagnostic": {"severity": "Error"},
+	"error": {"DuplicateMetricName": {
+		"metric_name": "dns.lookup.duration",
+		"provenances": [
+			{"path": "/obi-registry/groups/dns.yaml"},
+			{"path": ".deps/upstream-v1.41.0/model/dns/metrics.yaml"}
+		]
+	}}
+}]`
+
+func TestLintSchemaFilterAllowsExpectedDNSMetricDuplicate(t *testing.T) {
+	remaining := runLintSchemaFilter(t, expectedDNSMetricDuplicate)
+	if len(remaining) != 0 {
+		t.Fatalf("expected the documented dns.lookup.duration duplicate to be filtered, got %d diagnostics", len(remaining))
+	}
+}
+
 // expectedDeprecatedIncludeUnreferenced mirrors the diagnostic weaver 0.25
 // emits (promoted to Error by --future) for OBI's use of the deprecated
 // --include-unreferenced flag, which OBI still needs.
@@ -156,6 +178,15 @@ func TestLintSchemaFilterKeepsUnrelatedDiagnostics(t *testing.T) {
 					{"path": ".deps/upstream-v1.41.0/model/dns/metrics.yaml"},
 					{"path": "/obi-registry/groups/dns.yaml"},
 					{"path": "/obi-registry/groups/extra.yaml"}
+				]
+			}}
+		}]`,
+		"dns duplicate from an unexpected obi file": `[{
+			"error": {"DuplicateMetricName": {
+				"metric_name": "dns.lookup.duration",
+				"provenances": [
+					{"path": ".deps/upstream-v1.41.0/model/dns/metrics.yaml"},
+					{"path": "/obi-registry/groups/elsewhere.yaml"}
 				]
 			}}
 		}]`,


### PR DESCRIPTION
Blocks https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3348

## Summary

weaver 0.26 drops a v2 refinement from live-check reads.  so existing dns metric refinement breaks. `schemas/obi/groups/dns.yaml` now becomes a groups-format declaration of `metric.obi.dns.lookup.duration` instead of a `definition/2` file with a `metric_refinements` override. `dns.question.name` stays `opt_in`; emitted telemetry is unchanged.

## Verified

Same registry, same one-datapoint sample, only the weaver version differs:

| | 0.25.1 | 0.26.1 |
| --- | --- | --- |
| before | `opt_in_attribute_not_present` | `required_attribute_not_present` (violation) |
| after | `opt_in_attribute_not_present` | `opt_in_attribute_not_present` |

Dropping `imports` changes nothing else: same 849 resolved attributes, and an `http.server.request.duration` sample gives identical findings.

## Validation

- [ ] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
