### PR TITLE
fix(bpf): write packet-end bounds checks in the form old verifiers mark exactly

### DIFF
--- a/bpf/common/tc_common.h
+++ b/bpf/common/tc_common.h
@@ -19,7 +19,7 @@ const u32 INVALID_POS = 0xffffffff;
 static __always_inline unsigned char *
 memchar(unsigned char *haystack, char needle, const unsigned char *end, u32 size) {
     for (u32 i = 0; i < size; ++i) {
-        if (&haystack[i] >= end) {
+        if (&haystack[i] + 1 > end) {
             break;
         }
 
@@ -47,7 +47,7 @@ static __always_inline u32 memchar_pos(unsigned char *haystack,
     for (u32 i = 0; i < size; ++i) {
         unsigned char *ptr = haystack + i;
 
-        if (ptr + 1 >= end) {
+        if (ptr + 2 > end) { // `>` not `>=`: pre-5.16 verifiers mark `>=` one byte short
             break;
         } else if (ptr && *ptr == needle) {
             return i;

--- a/bpf/rdns/rdns_xdp.c
+++ b/bpf/rdns/rdns_xdp.c
@@ -220,7 +220,7 @@ static __always_inline __u32 validate_qsection(struct xdp_md *ctx, const unsigne
 
     // try at most 16 sections
     for (__u8 i = 0; i < 16; ++i) {
-        if ((void *)data >= ctx_xdp_data_end(ctx)) {
+        if ((void *)(data + 1) > ctx_xdp_data_end(ctx)) {
             return 0;
         }
 
@@ -232,7 +232,7 @@ static __always_inline __u32 validate_qsection(struct xdp_md *ctx, const unsigne
         if (len == 0) {
             size += sizeof(__u32); // account for QTYPE and QCLASS
 
-            if ((void *)(data + sizeof(__u32)) < ctx_xdp_data_end(ctx)) {
+            if ((void *)(data + sizeof(__u32) + 1) <= ctx_xdp_data_end(ctx)) {
                 return size;
             } else {
                 return 0;
@@ -386,7 +386,7 @@ int dns_response_tracker(struct xdp_md *ctx) {
         return XDP_PASS;
     }
 
-    if ((void *)udp + UDP_HDR_SIZE + DNS_HDR_SIZE >= ctx_xdp_data_end(ctx)) {
+    if ((void *)udp + UDP_HDR_SIZE + DNS_HDR_SIZE + 1 > ctx_xdp_data_end(ctx)) {
         return XDP_PASS;
     }
 

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -687,7 +687,7 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
         return false;
     }
 
-    if (!msg->data || msg->data >= msg->data_end) {
+    if (!msg->data || msg->data + 1 > msg->data_end) {
         invalidate_msg_buffers(e_key);
         return false;
     }
@@ -928,7 +928,7 @@ extend_and_write_tp(struct sk_msg_md *msg, u32 offset, const tp_info_t *tp) {
 
     unsigned char *ptr = msg->data + offset;
 
-    if ((void *)ptr + TP_SIZE >= msg->data_end) {
+    if ((void *)ptr + TP_SIZE + 1 > msg->data_end) {
         bpf_d_printk("not enough space [%s]", __FUNCTION__);
         return false;
     }
@@ -1299,7 +1299,7 @@ int obi_packet_extender_find_existing_tp(struct sk_msg_md *msg) {
     const unsigned char *e = msg->data_end;
     unsigned char *ptr = b + (niter * k_max_chunk_size);
 
-    if (ptr >= e) {
+    if (ptr + 1 > e) {
         return SK_PASS;
     }
 
@@ -1312,7 +1312,7 @@ int obi_packet_extender_find_existing_tp(struct sk_msg_md *msg) {
     }
 
     for (u32 i = 0; i < data_size; ++i) {
-        if ((ptr + TP_SIZE >= e) || is_eoh(ptr)) {
+        if ((ptr + TP_SIZE + 1 > e) || is_eoh(ptr)) {
             bpf_tail_call_static(msg, &extender_jump_table, k_tail_create_tp);
             break;
         }


### PR DESCRIPTION
## Summary

This PR fixes the `offset is outside of the packet` verifier error found on an unpatched 5.8 kernel (arm64). The failing programs are the rdns XDP inspector (`parse_dns_response`) and two tpinjector programs (`obi_packet_extender_write_msg_tp`, `obi_packet_extender_find_existing_tp`).

Verifier output for rdns:
```
; if ((void *)data >= ctx_xdp_data_end(ctx)) {
163: (3d) if r6 >= r1 goto pc+127
 R1_w=pkt_end(id=0,off=0,imm=0) R6=pkt(id=2,off=20,r=20,...)
; const __u8 len = data[0];
165: (71) r5 = *(u8 *)(r6 +0)
invalid access to packet, off=20 size=1, R6(id=2,off=20,r=20)
R6 offset is outside of the packet
```
and for tpinjector:
```
; if (*ptr++ != '\r' || *ptr != '\n') {
443: (71) r1 = *(u8 *)(r2 +69)
invalid access to packet, off=1092 size=1, R2(id=3,off=1092,r=1092)
R2 offset is outside of the packet
```

The issue is verifier bug, not our logic. The fix was added here [2fa7d94afc1a](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=2fa7d94afc1afbb4d702760c058dc2d7ed30f226) "bpf: Fix the off-by-two error in range markings" in 5.16 and backported to 5.10.y/5.15.y but never to 5.8/5.9.

Notes:
- Verified with the verifier suite on 5.8.0/arm64 before and after: the three rejections are gone, no new rejection in rdns, tpinjector or generictracer (which also compiles` tc_common.h`). 
-  CI kernels all carry the backport, so they cannot reproduce the failure.
- Six more guards of the same shape were rewritten too. They did not fail on 5.8 because no packet read depends on the byte they under-prove, but leaving them would leave two shapes in the same files and an allowlist for the follow-up lint check.

Follow-ups:
- `tpinjector` still fails to load on 5.8 for unrelated reasons. I'm working also on those fixes.
- I'm thinking to add a lint check for the open form (I'm open to suggestions)

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
