### PR TITLE
fix: reject invalid IntEnum ranges

### DIFF
--- a/pkg/appolly/services/criteria.go
+++ b/pkg/appolly/services/criteria.go
@@ -270,6 +270,9 @@ func (p *IntEnum) UnmarshalText(text []byte) error {
 		e.Start, _ = strconv.Atoi(strings.TrimSpace(parts[0]))
 		if len(parts) > 1 {
 			e.End, _ = strconv.Atoi(strings.TrimSpace(parts[1]))
+			if e.End < e.Start {
+				return fmt.Errorf("invalid int enum %q: range end must not be less than start (%d-%d)", val, e.Start, e.End)
+			}
 		}
 		p.Ranges = append(p.Ranges, e)
 	}

--- a/pkg/appolly/services/criteria.go
+++ b/pkg/appolly/services/criteria.go
@@ -267,9 +267,16 @@ func (p *IntEnum) UnmarshalText(text []byte) error {
 	for entry := range strings.SplitSeq(val, ",") {
 		e := IntRange{}
 		parts := strings.Split(entry, "-")
-		e.Start, _ = strconv.Atoi(strings.TrimSpace(parts[0]))
+		var err error
+		e.Start, err = strconv.Atoi(strings.TrimSpace(parts[0]))
+		if err != nil {
+			return fmt.Errorf("invalid int enum %q: %w", val, err)
+		}
 		if len(parts) > 1 {
-			e.End, _ = strconv.Atoi(strings.TrimSpace(parts[1]))
+			e.End, err = strconv.Atoi(strings.TrimSpace(parts[1]))
+			if err != nil {
+				return fmt.Errorf("invalid int enum %q: %w", val, err)
+			}
 			if e.End < e.Start {
 				return fmt.Errorf("invalid int enum %q: range end must not be less than start (%d-%d)", val, e.Start, e.End)
 			}

--- a/pkg/appolly/services/criteria_test.go
+++ b/pkg/appolly/services/criteria_test.go
@@ -119,6 +119,7 @@ func TestYAMLParse_IntEnum_Errors(t *testing.T) {
 	assertError("unfinished range", "32,15-")
 	assertError("unstarted range", "12,-13")
 	assertError("wrong symbols", "1,2,*3,4")
+	assertError("inverted range", "9000-1000")
 }
 
 func TestYAMLParse_OtherAttrs(t *testing.T) {

--- a/pkg/appolly/services/criteria_test.go
+++ b/pkg/appolly/services/criteria_test.go
@@ -120,6 +120,8 @@ func TestYAMLParse_IntEnum_Errors(t *testing.T) {
 	assertError("unstarted range", "12,-13")
 	assertError("wrong symbols", "1,2,*3,4")
 	assertError("inverted range", "9000-1000")
+	assertError("overflowing range start", "999999999999999999999-1")
+	assertError("overflowing range end", "1-999999999999999999999")
 }
 
 func TestYAMLParse_OtherAttrs(t *testing.T) {


### PR DESCRIPTION
## Summary

- reject inverted integer ranges used by port and PID discovery criteria
- reject range bounds that overflow the platform integer type before comparing them
- cover inverted ranges and overflow in either endpoint

Supersedes #3177, which was closed due to inactivity. This retains the original signed-off commit and adds the overflow validation requested in its review.

## Validation

- `go test ./pkg/appolly/services`
- `go test -run 'TestYAMLParse_IntEnum' -count=1 ./pkg/appolly/services`
