### PR TITLE
fix(bpf): clamp spilled sizes again at the point of use

### DIFF
--- a/bpf/common/iov_iter.h
+++ b/bpf/common/iov_iter.h
@@ -118,6 +118,9 @@ static __always_inline int read_iovec_ctx(iovec_iter_ctx *ctx, unsigned char *bu
             break;
         }
 
+        // clamp again at the use: verifiers before 5.10 drop the bound when the value
+        // is spilled to the stack between the clamp above and this read
+        bpf_clamp_umax(tot_len, k_iovec_max_len);
         bpf_probe_read(&buf[tot_len], iov_size, vec.iov_base);
 
         // bpf_dbg_printk("iov_size=%d, buf=[%s]", iov_size, buf);

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -719,6 +719,9 @@ static __always_inline bool fill_msg_buffers(struct sk_msg_md *msg,
     }
 
     msg_ptr[0] = 0;
+    // clamp again at the use: verifiers before 5.10 drop the bound when the value
+    // is spilled to the stack between the clamp above and this read
+    bpf_clamp_umax(window, k_msg_buffer_size_max);
     bpf_probe_read_kernel(msg_ptr, window, msg->data);
     bpf_map_update_elem(&msg_buffer_mem, &(u32){0}, msg_ptr, BPF_ANY);
 


### PR DESCRIPTION
## Summary

This PR fixes the `min value is negative` / `unbounded memory access` verifier errors found on an unpatched 5.8 kernel (arm64). The failing programs are tpinjector's `obi_packet_extender` and generictracer's `obi_kprobe_tcp_cleanup_rbuf` and `obi_kretprobe_tcp_recvmsg`.

Verifier output for tpinjector:
```
        	; bpf_probe_read_kernel(msg_ptr, window, msg->data);
        	745: (bf) r1 = r7
        	746: (79) r2 = *(u64 *)(r10 -480)
        	747: (85) call bpf_probe_read_kernel#113
        	R2 min value is negative, either use unsigned or 'var &= const'
```
and generictracer:
```
        	; bpf_probe_read(&buf[tot_len], iov_size, vec.iov_base);
        	2040: (79) r3 = *(u64 *)(r3 +0)
        	; bpf_probe_read(&buf[tot_len], iov_size, vec.iov_base);
        	2041: (85) call bpf_probe_read#4
        	 R0=inv0 R1_w=map_value(id=0,off=0,ks=4,vs=16384,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R2_w=invP(id=0,umax_value=8192,var_off=(0x0; 0x3fff)) R3_w=inv(id=0) R4_w=invP0 R6=inv240 R7=invP15 R8_w=invP(id=0,umax_value=16384,var_off=(0x0; 0x7fff)) R9=map_value(id=0,off=0,ks=8,vs=56,imm=0) R10=fp0 fp-40=mmmmmmmm fp-48=mmmmmmmm fp-72=????mmmm fp-120=mmmmmmmm fp-128=00000000 fp-136=00000000 fp-144=00000000 fp-152=00000000 fp-160=00000000 fp-184=mmmmmmmm fp-192=ctx fp-200=map_value fp-208_w=mmmmmmmm fp-216=inv8192 fp-224=map_value
        	R1 unbounded memory access, make sure to bounds check any such access
```

Both sizes are clamped where they are computed, but the compiler spills them to the stack before the read and verifiers is complaining. The fix was added here [5689d49b71ad](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5689d49b71ad) "bpf: Track spill/fill of bounded scalars" in 5.10 and never backported. 

We just need to clamp again immediately before the read. 
I left 2 identical comments before the `bpf_clamp_umax`, IMHO they are useful but I'm fine to delete them.


## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
