### PR TITLE
Make repository AI instructions verifiable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,12 +210,12 @@ MARKDOWNIMAGE = $(shell awk '$$4=="markdown" {print $$2}' $(DEPENDENCIES_DOCKERF
 .PHONY: lint-markdown
 lint-markdown:
 	@echo "### Linting markdown"
-	@docker run --rm -v "$(CURDIR):/workdir" $(MARKDOWNIMAGE) --config .markdownlint-cli2.yaml **/*.md
+	@docker run --rm -v "$(CURDIR):/workdir" $(MARKDOWNIMAGE) --config .markdownlint-cli2.yaml "**/*.md"
 
 .PHONY: lint-markdown-fix
 lint-markdown-fix:
 	@echo "### Formatting markdown"
-	@docker run --rm -v "$(CURDIR):/workdir" $(MARKDOWNIMAGE) --config .markdownlint-cli2.yaml --fix **/*.md
+	@docker run --rm -v "$(CURDIR):/workdir" $(MARKDOWNIMAGE) --config .markdownlint-cli2.yaml --fix "**/*.md"
 
 .PHONY: update-offsets
 update-offsets:

--- a/devdocs/ai-tooling.md
+++ b/devdocs/ai-tooling.md
@@ -33,3 +33,23 @@ Add DeepWiki as a user-scoped MCP server:
 ```sh
 claude mcp add --transport http --scope user deepwiki https://mcp.deepwiki.com/mcp
 ```
+
+## Verify repository instructions
+
+Agent tools may load or cache instruction files when a session starts. After
+changing one, start a new session or restart the current session when the tool
+does not automatically reload instructions.
+
+- **Codex:** In a new task rooted in this repository, ask Codex to list and
+  summarize the instruction files it loaded. `AGENTS.md` applies to Codex agent
+  workflows, not unrelated editor autocomplete.
+- **Claude Code:** Run `/context` and inspect the memory files. `CLAUDE.md` and
+  the files it imports should be listed. These instructions apply to Claude
+  Code sessions.
+- **GitHub Copilot:** In Copilot CLI, run `/instructions`. In other supported
+  Copilot chat or coding-agent surfaces, inspect the cited instruction files in
+  the response. Support varies by surface; inline completion does not
+  necessarily use these instructions.
+- **Cursor:** In an Agent or Chat session, inspect the active rules in the Agent
+  sidebar and confirm that `AGENTS.md` is included. These instructions do not
+  necessarily apply to tab completion.


### PR DESCRIPTION
## Summary

Repository AI instructions are useful only when they remain valid and contributors can confirm that their tools loaded them. This change makes both checks reliable:

- preserve the recursive Markdown glob for `markdownlint-cli2`, ensuring root, hidden, and deeply nested instruction files are validated
- document the tool-native ways to inspect loaded instructions in Codex, Claude Code, GitHub Copilot, and Cursor
- explain when instruction changes require a new or restarted session

## Why

The existing lint target allowed the host shell to expand `**/*.md`. In common shells this selected only one-directory-deep files, skipping root files such as `AGENTS.md` and `CLAUDE.md`, hidden GitHub instructions, and deeper documentation. Contributors also lacked a documented way to distinguish an instruction-loading problem from a model-adherence problem.

Together, these changes provide a reviewable validation path from instruction-file syntax to instruction discovery in supported agent workflows.

## Validation

- `make lint-markdown` — 83 files, no issues
- `git diff --check`