### PR TITLE
Preserve CIDR configuration shape in logs

### DIFF
--- a/internal/config/convert/import.go
+++ b/internal/config/convert/import.go
@@ -2519,14 +2519,16 @@ func cloneHTTPParsingRules(values []obiconfig.HTTPParsingRule) []obiconfig.HTTPP
 
 type runtimeCIDRDefinition interface {
 	~struct {
-		CIDR string `yaml:"cidr" json:"cidr"`
-		Name string `yaml:"name" json:"name"`
+		CIDR    string `yaml:"cidr" json:"cidr"`
+		Name    string `yaml:"name" json:"name"`
+		Mapping bool   `yaml:"-" json:"-"`
 	}
 }
 
 type runtimeCIDRDefinitionValue struct {
-	CIDR string `yaml:"cidr" json:"cidr"`
-	Name string `yaml:"name" json:"name"`
+	CIDR    string `yaml:"cidr" json:"cidr"`
+	Name    string `yaml:"name" json:"name"`
+	Mapping bool   `yaml:"-" json:"-"`
 }
 
 func cloneRuntimeCIDRDefinitions[T runtimeCIDRDefinition](_ []T, definitions schema.CIDRDefinitions) []T {

--- a/pkg/internal/pipe/cidr/cidr.go
+++ b/pkg/internal/pipe/cidr/cidr.go
@@ -30,6 +30,8 @@ func glog() *slog.Logger {
 type Definition struct {
 	CIDR string `yaml:"cidr" json:"cidr"`
 	Name string `yaml:"name" json:"name"`
+	// Mapping preserves mapping form for definitions without a name.
+	Mapping bool `yaml:"-" json:"-"`
 }
 
 // Label returns the name if set, otherwise the CIDR string.
@@ -44,11 +46,15 @@ func (d Definition) Label() string {
 // recurse back into MarshalYAML.
 type plainDefinition Definition
 
-// MarshalYAML emits back the shape the definition was written in: a plain CIDR
-// string when no name was given, a "cidr"/"name" mapping otherwise.
+// MarshalYAML emits each definition in the form it was configured in.
 func (d Definition) MarshalYAML() (any, error) {
 	if d.Name == "" {
-		return d.CIDR, nil
+		if !d.Mapping {
+			return d.CIDR, nil
+		}
+		return struct {
+			CIDR string `yaml:"cidr"`
+		}{CIDR: d.CIDR}, nil
 	}
 	return plainDefinition(d), nil
 }
@@ -83,6 +89,7 @@ func (c *Definitions) UnmarshalYAML(value *yaml.Node) error {
 			if d.CIDR == "" {
 				return fmt.Errorf("cidrs[%d]: missing required 'cidr' field", i)
 			}
+			d.Mapping = d.Name == ""
 			defs = append(defs, d)
 		default:
 			return fmt.Errorf("cidrs[%d]: unexpected YAML node kind %v", i, item.Kind)

--- a/pkg/internal/pipe/cidr/cidr_test.go
+++ b/pkg/internal/pipe/cidr/cidr_test.go
@@ -158,7 +158,7 @@ func TestUnmarshalYAML_NamedCIDRs(t *testing.T) {
 	require.Len(t, d, 3)
 	assert.Equal(t, Definition{CIDR: "10.0.0.0/8", Name: "cluster-internal"}, d[0])
 	assert.Equal(t, Definition{CIDR: "192.168.0.0/16", Name: "private"}, d[1])
-	assert.Equal(t, Definition{CIDR: "172.16.0.0/12"}, d[2])
+	assert.Equal(t, Definition{CIDR: "172.16.0.0/12", Mapping: true}, d[2])
 }
 
 func TestUnmarshalYAML_MixedFormats(t *testing.T) {
@@ -221,6 +221,21 @@ func TestValidate(t *testing.T) {
 func TestDefinition_Label(t *testing.T) {
 	assert.Equal(t, "my-network", Definition{CIDR: "10.0.0.0/8", Name: "my-network"}.Label())
 	assert.Equal(t, "10.0.0.0/8", Definition{CIDR: "10.0.0.0/8"}.Label())
+}
+
+func TestMarshalYAML_PreservesDefinitionShape(t *testing.T) {
+	input := `- 10.0.0.0/8
+- cidr: 192.168.0.0/16
+  name: private
+- cidr: 172.16.0.0/12
+`
+
+	var definitions Definitions
+	require.NoError(t, yaml.Unmarshal([]byte(input), &definitions))
+
+	output, err := yaml.Marshal(definitions)
+	require.NoError(t, err)
+	assert.Equal(t, input, string(output))
 }
 
 func TestEnvironmentVariableHandling(t *testing.T) {

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -37,6 +37,7 @@ import (
 	"go.opentelemetry.io/obi/pkg/filter"
 	"go.opentelemetry.io/obi/pkg/health"
 	"go.opentelemetry.io/obi/pkg/internal/avoidedsvc"
+	"go.opentelemetry.io/obi/pkg/internal/pipe/cidr"
 	"go.opentelemetry.io/obi/pkg/kube"
 	"go.opentelemetry.io/obi/pkg/kube/klogbridge"
 	"go.opentelemetry.io/obi/pkg/kube/kubeflags"
@@ -501,6 +502,7 @@ func (c *Config) Unmarshal(component *confmap.Conf) error {
 		Result:           c,
 		WeaklyTypedInput: true,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			cidrDefinitionsHookFunc(),
 			mapstructure.StringToTimeDurationHookFunc(),
 			// ComposeDecodeHookFunc feeds each hook the previous hook's output, so the
 			// slice-joining hook must run before TextUnmarshallerHookFunc, which only
@@ -515,6 +517,29 @@ func (c *Config) Unmarshal(component *confmap.Conf) error {
 	}
 
 	return dec.Decode(raw)
+}
+
+func cidrDefinitionsHookFunc() mapstructure.DecodeHookFunc {
+	return func(_ reflect.Type, to reflect.Type, data any) (any, error) {
+		if to != reflect.TypeFor[cidr.Definitions]() {
+			return data, nil
+		}
+		from := reflect.TypeOf(data)
+		if from == nil || (from.Kind() != reflect.Slice && from.Kind() != reflect.Array) {
+			return data, nil
+		}
+
+		encoded, err := yaml.Marshal(data)
+		if err != nil {
+			return nil, fmt.Errorf("encoding CIDR definitions: %w", err)
+		}
+
+		var definitions cidr.Definitions
+		if err := yaml.Unmarshal(encoded, &definitions); err != nil {
+			return nil, err
+		}
+		return definitions, nil
+	}
 }
 
 func (c *Config) Log() {

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -5,6 +5,7 @@ package obi
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -20,6 +21,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"go.opentelemetry.io/collector/confmap"
 
@@ -1573,6 +1575,91 @@ func TestUnmarshalConfmapSequences(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("comma-separated network CIDRs", func(t *testing.T) {
+		cfg := unmarshal(t, map[string]any{
+			"network": map[string]any{"cidrs": "10.0.0.0/8,192.168.0.0/16"},
+		})
+		assert.Equal(t, cidr.Definitions{
+			{CIDR: "10.0.0.0/8"},
+			{CIDR: "192.168.0.0/16"},
+		}, cfg.NetworkFlows.CIDRs)
+	})
+}
+
+func TestConfigCIDRShapePreserved(t *testing.T) {
+	expected := []any{
+		"10.0.0.0/8",
+		map[string]any{"cidr": "192.168.0.0/16", "name": "private"},
+		map[string]any{"cidr": "172.16.0.0/12"},
+	}
+
+	loaders := []struct {
+		name string
+		load func(t *testing.T) *Config
+	}{
+		{
+			name: "LoadConfig",
+			load: func(t *testing.T) *Config {
+				cfg, err := LoadConfig(strings.NewReader(`network:
+  cidrs:
+    - 10.0.0.0/8
+    - cidr: 192.168.0.0/16
+      name: private
+    - cidr: 172.16.0.0/12
+`))
+				require.NoError(t, err)
+				return cfg
+			},
+		},
+		{
+			name: "Config.Unmarshal",
+			load: func(t *testing.T) *Config {
+				cfg := DefaultConfig
+				err := cfg.Unmarshal(confmap.NewFromStringMap(map[string]any{
+					"network": map[string]any{
+						"cidrs": expected,
+					},
+				}))
+				require.NoError(t, err)
+				return &cfg
+			},
+		},
+	}
+
+	for _, loader := range loaders {
+		t.Run(loader.name, func(t *testing.T) {
+			cfg := loader.load(t)
+			configYAML, err := yaml.Marshal(cfg)
+			require.NoError(t, err)
+
+			t.Run("YAML", func(t *testing.T) {
+				assertConfigCIDRs(t, configYAML, expected, yaml.Unmarshal)
+			})
+
+			t.Run("JSON", func(t *testing.T) {
+				var configMap map[string]any
+				require.NoError(t, yaml.Unmarshal(configYAML, &configMap))
+				configJSON, err := json.Marshal(configMap)
+				require.NoError(t, err)
+				assertConfigCIDRs(t, configJSON, expected, json.Unmarshal)
+			})
+		})
+	}
+}
+
+func assertConfigCIDRs(
+	t *testing.T,
+	data []byte,
+	expected []any,
+	unmarshal func([]byte, any) error,
+) {
+	t.Helper()
+	var configMap map[string]any
+	require.NoError(t, unmarshal(data, &configMap))
+	network, ok := configMap["network"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, expected, network["cidrs"])
 }
 
 func TestConfigValidate_TracesCompression(t *testing.T) {


### PR DESCRIPTION
Follow-up to #3269.

A CIDR mapping without a `name` is valid, but configuration logging currently emits it as a scalar because both forms produce a definition with an empty name. This changes the logged configuration shape.

This change records when an unnamed CIDR was provided as a mapping and uses that information during YAML marshaling. The collector `confmap` path decodes CIDR sequences through the same shape-aware path, while retaining comma-separated string compatibility.

Regression coverage verifies YAML and JSON output after both `LoadConfig` and `Config.Unmarshal`.

## Testing

- `make verify`