### PR TITLE
Improve Python runtime probe logging to report attached probe and source

### DIFF
--- a/pkg/internal/cpython/runtime/probe_linux.go
+++ b/pkg/internal/cpython/runtime/probe_linux.go
@@ -26,6 +26,7 @@ func findPythonGCDoneUSDT(file *elf.File) (*GCCompletionProbe, error) {
 		target := targets[0]
 		return &GCCompletionProbe{
 			Kind:            GCCompletionProbeUSDT,
+			Source:          GCCompletionProbeSourceUSDT,
 			FileOffset:      target.FileOffset,
 			SemaphoreOffset: target.SemaphoreOffset,
 		}, nil

--- a/pkg/internal/cpython/runtime/probe_linux_amd64.go
+++ b/pkg/internal/cpython/runtime/probe_linux_amd64.go
@@ -114,7 +114,11 @@ func findPrivateCollectorProbe(file *elf.File, version pythonVersion) (GCComplet
 		if err != nil {
 			return GCCompletionProbe{}, err
 		}
-		return GCCompletionProbe{Kind: GCCompletionProbePrivateReturn, FileOffset: fileOffset}, nil
+		return GCCompletionProbe{
+			Kind:       GCCompletionProbePrivateReturn,
+			Source:     GCCompletionProbeSourceSymbol,
+			FileOffset: fileOffset,
+		}, nil
 	}
 
 	// A stripped libpython retains the exported anchor used to start the disassembly walk:
@@ -164,7 +168,11 @@ func derivePrivateCollectorProbe(
 	if err != nil {
 		return GCCompletionProbe{}, err
 	}
-	return GCCompletionProbe{Kind: GCCompletionProbePrivateReturn, FileOffset: fileOffset}, nil
+	return GCCompletionProbe{
+		Kind:       GCCompletionProbePrivateReturn,
+		Source:     GCCompletionProbeSourceDerived,
+		FileOffset: fileOffset,
+	}, nil
 }
 
 type tlsLookupStage uint8

--- a/pkg/internal/cpython/runtime/probe_linux_amd64_test.go
+++ b/pkg/internal/cpython/runtime/probe_linux_amd64_test.go
@@ -292,6 +292,7 @@ func TestDerivePrivateCollectorProbe(t *testing.T) {
 	probe, err := derivePrivateCollectorProbe(file, pythonVersion{major: 3, minor: 12}, root, uint64(len(body.data)))
 	require.NoError(t, err)
 	assert.Equal(t, GCCompletionProbePrivateReturn, probe.Kind)
+	assert.Equal(t, GCCompletionProbeSourceDerived, probe.Source)
 	assert.Equal(t, testCodeFileOffset+collector-testCodeBaseAddress, probe.FileOffset)
 
 	_, err = derivePrivateCollectorProbe(file, pythonVersion{major: 3, minor: 12}, root, 0)
@@ -331,6 +332,7 @@ func TestDerivePrivateCollectorProbeFromThreadStateCall(t *testing.T) {
 			)
 			require.NoError(t, err)
 			assert.Equal(t, GCCompletionProbePrivateReturn, probe.Kind)
+			assert.Equal(t, GCCompletionProbeSourceDerived, probe.Source)
 			assert.Equal(t, testCodeFileOffset+collector-testCodeBaseAddress, probe.FileOffset)
 		})
 	}

--- a/pkg/internal/cpython/runtime/resolver.go
+++ b/pkg/internal/cpython/runtime/resolver.go
@@ -31,9 +31,30 @@ const (
 	GCCompletionProbePrivateReturn
 )
 
+func (k GCCompletionProbeKind) String() string {
+	switch k {
+	case GCCompletionProbeUSDT:
+		return "usdt"
+	case GCCompletionProbePrivateReturn:
+		return "private-return"
+	default:
+		return fmt.Sprintf("unknown(%d)", uint8(k))
+	}
+}
+
+// GCCompletionProbeSource identifies how the probe location was resolved.
+type GCCompletionProbeSource string
+
+const (
+	GCCompletionProbeSourceUSDT    GCCompletionProbeSource = "usdt"
+	GCCompletionProbeSourceSymbol  GCCompletionProbeSource = "symbol"
+	GCCompletionProbeSourceDerived GCCompletionProbeSource = "derived"
+)
+
 // GCCompletionProbe identifies one probe location in the mapped CPython object.
 type GCCompletionProbe struct {
 	Kind            GCCompletionProbeKind
+	Source          GCCompletionProbeSource
 	FileOffset      uint64
 	SemaphoreOffset uint64
 }

--- a/pkg/internal/ebpf/generictracer/python_runtime.go
+++ b/pkg/internal/ebpf/generictracer/python_runtime.go
@@ -58,7 +58,7 @@ type pythonRuntimeController struct {
 	resolver    pythonRuntimeTargetResolver
 	targetMap   pythonRuntimeMap
 	snapshotMap pythonRuntimeMap
-	attach      func(*cpythonruntime.MetricTarget, *ebpf.Program, int) (io.Closer, error)
+	attach      func(*cpythonruntime.MetricTarget, *ebpf.Program, int) (io.Closer, cpythonruntime.GCCompletionProbe, error)
 	startTime   func(app.PID) (uint64, error)
 
 	mu      sync.Mutex
@@ -198,14 +198,14 @@ func (c *pythonRuntimeController) resolveAndAttach(ctx context.Context, target *
 		return
 	}
 
-	attached, err := c.attach(
+	attached, probe, err := c.attach(
 		metricTarget, c.tracer.bpfObjects.ObiUprobePythonGcDone, int(target.pid))
 	if err != nil {
 		_ = targets.Delete(key)
 		_ = snapshots.Delete(key)
 		delete(c.targets, target.pid)
 		c.tracer.log.Warn("Python runtime metrics probe attachment failed",
-			"pid", target.pid, "probe", metricTarget.PrimaryProbe.Kind, "error", err)
+			"pid", target.pid, "probe", metricTarget.PrimaryProbe.Kind.String(), "error", err)
 		return
 	}
 	currentStartTime, err := c.startTime(target.pid)
@@ -219,31 +219,32 @@ func (c *pythonRuntimeController) resolveAndAttach(ctx context.Context, target *
 	target.link = attached
 	c.tracer.log.Debug("Python runtime metrics attached",
 		"pid", target.pid,
-		"probe", metricTarget.PrimaryProbe.Kind,
-		"offset", fmt.Sprintf("%#x", metricTarget.PrimaryProbe.FileOffset))
+		"probe", probe.Kind.String(),
+		"source", probe.Source,
+		"offset", fmt.Sprintf("%#x", probe.FileOffset))
 }
 
 // attachPythonRuntimeTarget attaches to the stable mapped object and safe fallback.
-func attachPythonRuntimeTarget(target *cpythonruntime.MetricTarget, program *ebpf.Program, pid int) (io.Closer, error) {
+func attachPythonRuntimeTarget(target *cpythonruntime.MetricTarget, program *ebpf.Program, pid int) (io.Closer, cpythonruntime.GCCompletionProbe, error) {
 	if target == nil || program == nil || target.AttachmentPath() == "" {
-		return nil, errors.New("incomplete Python runtime metric target")
+		return nil, cpythonruntime.GCCompletionProbe{}, errors.New("incomplete Python runtime metric target")
 	}
 	executable, err := link.OpenExecutable(target.AttachmentPath())
 	if err != nil {
-		return nil, err
+		return nil, cpythonruntime.GCCompletionProbe{}, err
 	}
 	attached, err := attachPythonRuntimeProbe(executable, program, pid, target.PrimaryProbe)
 	if err == nil {
-		return attached, nil
+		return attached, target.PrimaryProbe, nil
 	}
 	if target.FallbackProbe == nil {
-		return nil, err
+		return nil, cpythonruntime.GCCompletionProbe{}, err
 	}
 	fallback, fallbackErr := attachPythonRuntimeProbe(executable, program, pid, *target.FallbackProbe)
 	if fallbackErr != nil {
-		return nil, errors.Join(err, fallbackErr)
+		return nil, cpythonruntime.GCCompletionProbe{}, errors.Join(err, fallbackErr)
 	}
-	return fallback, nil
+	return fallback, *target.FallbackProbe, nil
 }
 
 // attachPythonRuntimeProbe selects an entry or return probe at a raw offset.

--- a/pkg/internal/ebpf/generictracer/python_runtime_test.go
+++ b/pkg/internal/ebpf/generictracer/python_runtime_test.go
@@ -6,7 +6,9 @@
 package generictracer
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -100,8 +102,8 @@ func TestPythonRuntimeResolutionFailureDoesNotRetry(t *testing.T) {
 
 func TestPythonRuntimeAttachmentFailureRollsBackMapState(t *testing.T) {
 	controller, _, targets, snapshots := pythonRuntimeTestController()
-	controller.attach = func(*cpythonruntime.MetricTarget, *ebpf.Program, int) (io.Closer, error) {
-		return nil, errors.New("attach failed")
+	controller.attach = func(*cpythonruntime.MetricTarget, *ebpf.Program, int) (io.Closer, cpythonruntime.GCCompletionProbe, error) {
+		return nil, cpythonruntime.GCCompletionProbe{}, errors.New("attach failed")
 	}
 	lifecycle := pythonRuntimeTestFile(123, 100)
 
@@ -113,6 +115,59 @@ func TestPythonRuntimeAttachmentFailureRollsBackMapState(t *testing.T) {
 	}, time.Second, time.Millisecond)
 	assert.False(t, targets.hasEntries())
 	assert.False(t, snapshots.hasEntries())
+}
+
+func TestPythonRuntimeAttachmentLogUsesAttachedProbe(t *testing.T) {
+	for _, fallback := range []bool{false, true} {
+		name := "primary"
+		if fallback {
+			name = "fallback"
+		}
+		t.Run(name, func(t *testing.T) {
+			controller, resolver, _, _ := pythonRuntimeTestController()
+			defer controller.close()
+			primary := cpythonruntime.GCCompletionProbe{
+				Kind:       cpythonruntime.GCCompletionProbeUSDT,
+				Source:     cpythonruntime.GCCompletionProbeSourceUSDT,
+				FileOffset: 0x200,
+			}
+			secondary := cpythonruntime.GCCompletionProbe{
+				Kind:       cpythonruntime.GCCompletionProbePrivateReturn,
+				Source:     cpythonruntime.GCCompletionProbeSourceDerived,
+				FileOffset: 0x400,
+			}
+			resolver.target.PrimaryProbe = primary
+			resolver.target.FallbackProbe = &secondary
+			probe := primary
+			wantKind, wantSource, wantOffset := "usdt", "usdt", "0x200"
+			if fallback {
+				probe = secondary
+				wantKind, wantSource, wantOffset = "private-return", "derived", "0x400"
+			}
+			controller.attach = func(*cpythonruntime.MetricTarget, *ebpf.Program, int) (io.Closer, cpythonruntime.GCCompletionProbe, error) {
+				return &testCloser{}, probe, nil
+			}
+			var logs bytes.Buffer
+			controller.tracer.log = slog.New(slog.NewJSONHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			pid := app.PID(os.Getpid())
+			lifecycle := pythonRuntimeTestFile(pid, 100)
+			controller.allow(pid, 42, lifecycle, lifecycle)
+			require.Eventually(t, func() bool {
+				controller.mu.Lock()
+				defer controller.mu.Unlock()
+				target := controller.targets[pid]
+				return target != nil && target.link != nil
+			}, time.Second, time.Millisecond)
+			controller.close()
+
+			var record map[string]any
+			require.NoError(t, json.Unmarshal(logs.Bytes(), &record))
+			assert.Equal(t, "Python runtime metrics attached", record["msg"])
+			assert.Equal(t, wantKind, record["probe"])
+			assert.Equal(t, wantSource, record["source"])
+			assert.Equal(t, wantOffset, record["offset"])
+		})
+	}
 }
 
 func TestPythonRuntimeBlockRemovesExactLifecycle(t *testing.T) {
@@ -225,8 +280,8 @@ func pythonRuntimeTestController() (
 	controller := &pythonRuntimeController{
 		tracer: tracer, resolver: resolver,
 		targetMap: targets, snapshotMap: snapshots,
-		attach: func(*cpythonruntime.MetricTarget, *ebpf.Program, int) (io.Closer, error) {
-			return &testCloser{}, nil
+		attach: func(target *cpythonruntime.MetricTarget, _ *ebpf.Program, _ int) (io.Closer, cpythonruntime.GCCompletionProbe, error) {
+			return &testCloser{}, target.PrimaryProbe, nil
 		},
 		startTime: func(app.PID) (uint64, error) { return 100, nil },
 		targets:   map[app.PID]*pythonRuntimeLifecycle{},


### PR DESCRIPTION
## Summary

Log the Python runtime probe that actually attached, with a readable kind and its source: USDT, symbol lookup, or derivation.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
