### PR TITLE
fix(tpinjector): delete tracked socket cookies when the socket closes

### DIFF
--- a/bpf/maps/tracked_sock_cookies.h
+++ b/bpf/maps/tracked_sock_cookies.h
@@ -18,7 +18,9 @@
 #include <common/pin_internal.h>
 
 // Cookies of sockets inserted into sock_dir; the FIONREAD fixup uses them
-// to identify affected sockets. LRU so stale entries age out
+// to identify affected sockets. Entries are deleted when the socket reaches
+// TCP_CLOSE; LRU only as a safety net for iterator-backfilled sockets, which
+// cannot arm the state callback and leave their entry behind on close
 struct {
     __uint(type, BPF_MAP_TYPE_LRU_HASH);
     __uint(max_entries, 65535);

--- a/bpf/tpinjector/tpinjector.c
+++ b/bpf/tpinjector/tpinjector.c
@@ -517,8 +517,20 @@ static __always_inline void bpf_sock_ops_active_est_cb(struct bpf_sock_ops *skop
 
     if (bpf_sock_hash_update(skops, &sock_dir, (void *)&cookie, BPF_ANY) == 0) {
         bpf_map_update_elem(&tracked_sock_cookies, &cookie, &(u8){1}, BPF_ANY);
+        bpf_sock_ops_set_flags(skops, BPF_SOCK_OPS_STATE_CB_FLAG);
     }
     bpf_sock_ops_set_flags(skops, BPF_SOCK_OPS_WRITE_HDR_OPT_CB_FLAG);
+}
+
+// every full-socket death path goes through tcp_set_state(TCP_CLOSE), which is
+// also when the kernel unhashes the socket from sock_dir
+static __always_inline void bpf_sock_ops_state_cb(struct bpf_sock_ops *skops) {
+    if (skops->args[1] != BPF_TCP_CLOSE) {
+        return;
+    }
+
+    const u64 cookie = bpf_get_socket_cookie(skops);
+    bpf_map_delete_elem(&tracked_sock_cookies, &cookie);
 }
 
 static __always_inline void bpf_sock_ops_passive_est_cb(struct bpf_sock_ops *skops) {
@@ -653,6 +665,9 @@ int obi_sockmap_tracker(struct bpf_sock_ops *skops) {
         break;
     case BPF_SOCK_OPS_PARSE_HDR_OPT_CB:
         bpf_sock_ops_parse_hdr_cb(skops);
+        break;
+    case BPF_SOCK_OPS_STATE_CB:
+        bpf_sock_ops_state_cb(skops);
         break;
     default:
         break;

--- a/pkg/ebpf/map_sizes_test.go
+++ b/pkg/ebpf/map_sizes_test.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package ebpf
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/stretchr/testify/assert"
+
+	"go.opentelemetry.io/obi/pkg/config"
+	"go.opentelemetry.io/obi/pkg/obi"
+)
+
+// tracked_sock_cookies mirrors sock_dir membership one-to-one and sockhashes
+// are not resizable: scaling the shadow map below the sockhash guarantees
+// eviction of live sockets' cookies, silently disarming the FIONREAD fixup
+func TestScaleDownKeepsTrackedSockCookiesAtSockDirSize(t *testing.T) {
+	const sockDirSize = 65535
+
+	spec := &ebpf.CollectionSpec{
+		Maps: map[string]*ebpf.MapSpec{
+			"sock_dir": {
+				Type:       ebpf.SockHash,
+				KeySize:    8,
+				ValueSize:  4,
+				MaxEntries: sockDirSize,
+			},
+			"tracked_sock_cookies": {
+				Type:       ebpf.LRUHash,
+				KeySize:    8,
+				ValueSize:  1,
+				MaxEntries: sockDirSize,
+			},
+			"other_lru": {
+				Type:       ebpf.LRUHash,
+				KeySize:    8,
+				ValueSize:  8,
+				MaxEntries: 1024,
+			},
+		},
+	}
+
+	cfg := &obi.Config{}
+	cfg.EBPF.MapsConfig = config.MapsConfig{GlobalScaleFactor: -1}
+	setupBPFMapSizes(spec, cfg)
+
+	assert.Equal(t, uint32(sockDirSize), spec.Maps["sock_dir"].MaxEntries,
+		"sockhashes are not resizable")
+	assert.Equal(t, uint32(sockDirSize), spec.Maps["tracked_sock_cookies"].MaxEntries,
+		"the shadow map must never be smaller than the sockhash it mirrors")
+	assert.Equal(t, uint32(512), spec.Maps["other_lru"].MaxEntries,
+		"unrelated maps still scale")
+}
+
+// scaling up is harmless for the pairing: a larger shadow map is a superset
+func TestScaleUpStillScalesTrackedSockCookies(t *testing.T) {
+	spec := &ebpf.CollectionSpec{
+		Maps: map[string]*ebpf.MapSpec{
+			"tracked_sock_cookies": {
+				Type:       ebpf.LRUHash,
+				KeySize:    8,
+				ValueSize:  1,
+				MaxEntries: 65535,
+			},
+		},
+	}
+
+	cfg := &obi.Config{}
+	cfg.EBPF.MapsConfig = config.MapsConfig{GlobalScaleFactor: 1}
+	setupBPFMapSizes(spec, cfg)
+
+	assert.Equal(t, uint32(131070), spec.Maps["tracked_sock_cookies"].MaxEntries)
+}

--- a/pkg/ebpf/tracer_linux.go
+++ b/pkg/ebpf/tracer_linux.go
@@ -212,7 +212,27 @@ func (pt *ProcessTracer) setupOtelBPFFSPath(bundles []*common.SpecBundle) string
 }
 
 func setupBPFMapSizes(spec *ebpf.CollectionSpec, cfg *obi.Config) {
+	cookiesDeclared := trackedSockCookiesSize(spec)
+
 	ebpfconvenience.SetupMapSizes(spec, cfg.EBPF.MapsConfig.GlobalScaleFactor)
+
+	keepTrackedSockCookiesAtLeast(spec, cookiesDeclared)
+}
+
+// tracked_sock_cookies mirrors sock_dir membership and sockhashes are not
+// resizable: a shadow map smaller than the sockhash would evict cookies of
+// live sockets, silently disarming the FIONREAD compensation
+func trackedSockCookiesSize(spec *ebpf.CollectionSpec) uint32 {
+	if cookies := spec.Maps["tracked_sock_cookies"]; cookies != nil {
+		return cookies.MaxEntries
+	}
+	return 0
+}
+
+func keepTrackedSockCookiesAtLeast(spec *ebpf.CollectionSpec, declared uint32) {
+	if cookies := spec.Maps["tracked_sock_cookies"]; cookies != nil && cookies.MaxEntries < declared {
+		cookies.MaxEntries = declared
+	}
 }
 
 func (pt *ProcessTracer) loadAndAssign(eventContext *common.EBPFEventContext, p Tracer, cfg *obi.Config, cache *btf.Cache) error {

--- a/pkg/internal/ebpf/tpinjector/sock_cookies_privileged_test.go
+++ b/pkg/internal/ebpf/tpinjector/sock_cookies_privileged_test.go
@@ -1,0 +1,273 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux && privileged_tests
+
+package tpinjector // import "go.opentelemetry.io/obi/pkg/internal/ebpf/tpinjector"
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	ebpfconvenience "go.opentelemetry.io/obi/pkg/internal/ebpf/convenience"
+)
+
+const (
+	cookieWaitTimeout = 5 * time.Second
+	churnConnections  = 2000
+	churnWorkers      = 8
+	// transient entries for connections still finishing their close handshake
+	churnResidueBound = 64
+)
+
+// loads tpinjector and attaches its sockops program to a private cgroup that
+// contains only the test process, so every loopback connection made here goes
+// through bpf_sock_ops_active_est_cb exactly as in production
+func setupSockopsHarness(t *testing.T) *BpfObjects {
+	require.Equal(t, 0, os.Geteuid(), "privileged eBPF test must run as root")
+	require.NoError(t, rlimit.RemoveMemlock())
+
+	spec, err := LoadBpf()
+	require.NoError(t, err)
+
+	for _, m := range spec.Maps {
+		if m.Pinning == ebpfconvenience.PinInternal {
+			m.Pinning = ebpf.PinNone
+		}
+	}
+
+	objs := &BpfObjects{}
+	require.NoError(t, spec.LoadAndAssign(objs, nil))
+	t.Cleanup(func() { objs.Close() })
+
+	cgroupDir := enterTempCgroup(t)
+
+	lnk, err := link.AttachCgroup(link.CgroupOptions{
+		Path:    cgroupDir,
+		Attach:  ebpf.AttachCGroupSockOps,
+		Program: objs.ObiSockmapTracker,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { lnk.Close() })
+
+	return objs
+}
+
+// creates a child of the current cgroup, moves the test process into it, and
+// restores it on cleanup
+func enterTempCgroup(t *testing.T) string {
+	data, err := os.ReadFile("/proc/self/cgroup")
+	require.NoError(t, err)
+
+	var current string
+	for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
+		if rel, ok := strings.CutPrefix(line, "0::"); ok {
+			current = rel
+			break
+		}
+	}
+	require.NotEmpty(t, current, "cgroup v2 entry not found in /proc/self/cgroup")
+
+	base := filepath.Join("/sys/fs/cgroup", current)
+	dir := filepath.Join(base, fmt.Sprintf("obi-sock-cookies-test-%d", os.Getpid()))
+	require.NoError(t, os.Mkdir(dir, 0o755))
+
+	pid := []byte(strconv.Itoa(os.Getpid()))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "cgroup.procs"), pid, 0o644))
+
+	t.Cleanup(func() {
+		if err := os.WriteFile(filepath.Join(base, "cgroup.procs"), pid, 0o644); err != nil {
+			t.Logf("failed to restore cgroup: %v", err)
+		}
+		if err := os.Remove(dir); err != nil {
+			t.Logf("failed to remove test cgroup: %v", err)
+		}
+	})
+
+	return dir
+}
+
+func socketCookie(t *testing.T, conn *net.TCPConn) uint64 {
+	raw, err := conn.SyscallConn()
+	require.NoError(t, err)
+
+	var cookie uint64
+	var cookieErr error
+	require.NoError(t, raw.Control(func(fd uintptr) {
+		cookie, cookieErr = unix.GetsockoptUint64(int(fd), unix.SOL_SOCKET, unix.SO_COOKIE)
+	}))
+	require.NoError(t, cookieErr)
+	require.NotZero(t, cookie)
+
+	return cookie
+}
+
+func cookieTracked(objs *BpfObjects, cookie uint64) bool {
+	var val uint8
+	return objs.TrackedSockCookies.Lookup(&cookie, &val) == nil
+}
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	deadline := time.Now().Add(cookieWaitTimeout)
+	for !cond() {
+		require.False(t, time.Now().After(deadline), "timed out waiting for %s", what)
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func trackedCookieCount(t *testing.T, objs *BpfObjects) int {
+	var (
+		key   uint64
+		val   uint8
+		count int
+	)
+	it := objs.TrackedSockCookies.Iterate()
+	for it.Next(&key, &val) {
+		count++
+	}
+	require.NoError(t, it.Err())
+	return count
+}
+
+// an active connection's cookie must be registered on establishment and
+// removed when the socket dies, since a stale entry occupies the space that
+// decides whether a live socket gets the FIONREAD compensation
+func TestTrackedSockCookiesDeleteOnClose(t *testing.T) {
+	objs := setupSockopsHarness(t)
+
+	lsn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer lsn.Close()
+
+	client, err := net.Dial("tcp", lsn.Addr().String())
+	require.NoError(t, err)
+	server, err := lsn.Accept()
+	require.NoError(t, err)
+	defer server.Close()
+
+	cookie := socketCookie(t, client.(*net.TCPConn))
+	waitFor(t, "cookie registration", func() bool { return cookieTracked(objs, cookie) })
+
+	// server closes first so the client side, the tracked one, avoids TIME_WAIT
+	require.NoError(t, server.Close())
+	buf := make([]byte, 1)
+	_, readErr := client.Read(buf)
+	require.Error(t, readErr)
+	require.NoError(t, client.Close())
+
+	waitFor(t, "cookie deletion after close", func() bool { return !cookieTracked(objs, cookie) })
+}
+
+// connection churn must not evict the cookie of a live socket: that is the
+// exact sequence that silently disarmed the FIONREAD compensation in the field
+func TestTrackedSockCookiesSurviveChurn(t *testing.T) {
+	objs := setupSockopsHarness(t)
+
+	// the holder: a long-lived idle connection, the coldest possible entry
+	holderLsn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer holderLsn.Close()
+
+	holder, err := net.Dial("tcp", holderLsn.Addr().String())
+	require.NoError(t, err)
+	defer holder.Close()
+
+	holderSrv, err := holderLsn.Accept()
+	require.NoError(t, err)
+	defer holderSrv.Close()
+
+	holderCookie := socketCookie(t, holder.(*net.TCPConn))
+	waitFor(t, "holder cookie registration", func() bool { return cookieTracked(objs, holderCookie) })
+
+	// the churn sink closes every connection immediately, so churned client
+	// sockets die without TIME_WAIT
+	churnLsn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer churnLsn.Close()
+
+	go func() {
+		for {
+			conn, err := churnLsn.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+
+	var wg sync.WaitGroup
+	churnErrs := make(chan error, churnWorkers)
+	for range churnWorkers {
+		wg.Go(func() {
+			buf := make([]byte, 1)
+			for range churnConnections / churnWorkers {
+				conn, err := net.Dial("tcp", churnLsn.Addr().String())
+				if err != nil {
+					churnErrs <- err
+					return
+				}
+				// wait for the peer's close so our close ends the socket for good
+				conn.Read(buf) //nolint:errcheck
+				conn.Close()
+			}
+		})
+	}
+	wg.Wait()
+	close(churnErrs)
+	for err := range churnErrs {
+		require.NoError(t, err)
+	}
+
+	// churned entries must have been removed as their sockets died: an
+	// accumulating map is what evicts live cookies under LRU pressure
+	waitFor(t, "churn residue cleanup", func() bool {
+		return trackedCookieCount(t, objs) <= churnResidueBound
+	})
+
+	assert.True(t, cookieTracked(objs, holderCookie),
+		"the live holder's cookie was evicted by connection churn")
+}
+
+// ensures both tracepoint halves of the FIONREAD fixup still find the cookie
+// registered by the sockops program, guarding the interaction between
+// enrolment, deletion and the fixup's lookup
+func TestTrackedSockCookiesFixupLookupAfterReconnect(t *testing.T) {
+	objs := setupSockopsHarness(t)
+
+	lsn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer lsn.Close()
+
+	for range 3 {
+		client, err := net.Dial("tcp", lsn.Addr().String())
+		require.NoError(t, err)
+		server, err := lsn.Accept()
+		require.NoError(t, err)
+
+		cookie := socketCookie(t, client.(*net.TCPConn))
+		waitFor(t, "cookie registration", func() bool { return cookieTracked(objs, cookie) })
+
+		require.NoError(t, server.Close())
+		buf := make([]byte, 1)
+		if _, err := client.Read(buf); err == nil {
+			require.Fail(t, "expected EOF from closed peer")
+		}
+		require.NoError(t, client.Close())
+
+		waitFor(t, "cookie deletion", func() bool { return !cookieTracked(objs, cookie) })
+	}
+}

--- a/pkg/internal/ebpf/tpinjector/tpinjector_test.go
+++ b/pkg/internal/ebpf/tpinjector/tpinjector_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/ebpf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -92,7 +93,11 @@ func TestTracer_Constants(t *testing.T) {
 			err := cfg.EBPF.ContextPropagation.UnmarshalText([]byte(tt.contextPropagation))
 			require.NoError(t, err)
 
-			bundles, err := New(cfg).LoadSpecs()
+			tracer := New(cfg)
+			// the real probe would add the FIONREAD fixup bundle on affected kernels
+			tracer.fionreadProbe = func(*ebpf.Map) (bool, error) { return false, nil }
+
+			bundles, err := tracer.LoadSpecs()
 			require.NoError(t, err)
 			require.Len(t, bundles, expectedSpecCount, "tpinjector bundle count must match")
 


### PR DESCRIPTION
## Summary

`tracked_sock_cookies` had inserts but no delete, so ordinary connection churn filled the LRU and evicted the cookies of live long-lived sockets, silently disarming the FIONREAD compensation.

The fix subscribes to socket state changes when a socket is enrolled and removes its cookie from the map once the socket closes. Both maps now forget a socket at the same time.

The `GlobalScaleFactor` option could also shrink the cookie map below the size of `sock_dir`, which cannot be resized. A smaller cookie map is guaranteed to throw out entries for sockets that are still alive, so scaling down no longer shrinks it.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
