### PR TITLE
Recognize lowercase HTTP host headers

### DIFF
--- a/internal/test/oats/http/yaml/oats_java_tls_netty.yaml
+++ b/internal/test/oats/http/yaml/oats_java_tls_netty.yaml
@@ -8,7 +8,9 @@ input:
 interval: 500ms
 expected:
   traces:
-  - traceql: '{ .url.full = "/get" }'
+  # Netty sends a lowercase host header, so the client span carries the full URL.
+  - traceql: '{ .url.full = "https://httpbin.org/get" }'
     equals: GET /get
     attributes:
+      server.address: httpbin.org
       server.port: '443'

--- a/pkg/ebpf/common/http_transform.go
+++ b/pkg/ebpf/common/http_transform.go
@@ -658,6 +658,9 @@ func httpHostFromBuf(req []byte) (string, int) {
 
 	idx := bytes.Index(req, []byte("Host: "))
 	if idx < 0 {
+		idx = bytes.Index(req, []byte("host: "))
+	}
+	if idx < 0 {
 		return "", -1
 	}
 

--- a/pkg/ebpf/common/http_transform_test.go
+++ b/pkg/ebpf/common/http_transform_test.go
@@ -328,6 +328,21 @@ func TestToRequestTrace_BadHost(t *testing.T) {
 	assert.Equal(t, -1, p)
 }
 
+func TestHTTPInfoEventToSpan_HostHeaderCase(t *testing.T) {
+	for _, header := range []string{"Host", "host"} {
+		t.Run(header, func(t *testing.T) {
+			event := BPFHTTPInfo{Type: uint8(request.EventTypeHTTPClient)}
+			event.ConnInfo.D_port = 443
+			copy(event.Buf[:], "HEAD / HTTP/1.1\r\n"+header+": example.com\r\n\r\n")
+
+			span, ignored, err := HTTPInfoEventToSpan(nil, &event)
+			require.NoError(t, err)
+			assert.False(t, ignored)
+			assert.Equal(t, "http;example.com", span.Statement)
+		})
+	}
+}
+
 func TestHTTPInfoParsing(t *testing.T) {
 	t.Run("Test basic parsing", func(t *testing.T) {
 		tr := makeHTTPInfo("POST", "/users", "127.0.0.1", "127.0.0.2", 12345, 8080, 200, 5)


### PR DESCRIPTION
## Summary

I am setting up grafana's beyla to monitor network requests in some internal tooling, and I noticed that the host field was only returning IP addresses and not domains for most requests coming from Node processes.

It turns out that Node's `fetch` uses a lowercase `host` field, but the current code is only looking for  `Host` with a capital H.

This PR adds a fallback to look for `host: ` if `Host: ` isn't present.

The code was written by Codex Astra, validated by me, a human.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.

