### PR TITLE
Fix informers test race condition

### DIFF
--- a/pkg/kube/kubecache/envtest/integration_test.go
+++ b/pkg/kube/kubecache/envtest/integration_test.go
@@ -218,8 +218,8 @@ func TestBlockedClients(t *testing.T) {
 	ReadChannel(t, allSent, timeout)
 }
 
-// makes sure that a new cache server won't forward the sync data to the clients until
-// it effectively has synced everything
+// makes sure clients can connect before the cache starts and receive both the sync
+// signal and the initial data
 func TestAsynchronousStartup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -287,9 +287,13 @@ func TestAsynchronousStartup(t *testing.T) {
 		require.NotZero(ct, cl2.syncSignalOnMessage.Load())
 		require.NotZero(ct, cl3.syncSignalOnMessage.Load())
 	}, timeout, 100*time.Millisecond)
-	assert.LessOrEqual(t, int32(createdPods), cl1.syncSignalOnMessage.Load())
-	assert.LessOrEqual(t, int32(createdPods), cl2.syncSignalOnMessage.Load())
-	assert.LessOrEqual(t, int32(createdPods), cl3.syncSignalOnMessage.Load())
+
+	// Initial informer notifications can still be draining after the sync signal.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.GreaterOrEqual(ct, cl1.readMessages.Load(), int32(createdPods+1))
+		assert.GreaterOrEqual(ct, cl2.readMessages.Load(), int32(createdPods+1))
+		assert.GreaterOrEqual(ct, cl3.readMessages.Load(), int32(createdPods+1))
+	}, timeout, 100*time.Millisecond)
 }
 
 func TestResultsSortedByTimestamp(t *testing.T) {


### PR DESCRIPTION
## Summary

integration_test fails intermittently with the following report:

```
integration_test.go:290: 
    	Error Trace:	/home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/pkg/kube/kubecache/envtest/integration_test.go:290
    	Error:      	"20" is not less than or equal to "4"
    	Test:       	TestAsynchronousStartup
integration_test.go:291: 
    	Error Trace:	/home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/pkg/kube/kubecache/envtest/integration_test.go:291
    	Error:      	"20" is not less than or equal to "4"
    	Test:       	TestAsynchronousStartup
integration_test.go:292: 
    	Error Trace:	/home/runner/work/opentelemetry-ebpf-instrumentation/opentelemetry-ebpf-instrumentation/pkg/kube/kubecache/envtest/integration_test.go:292
    	Error:      	"20" is not less than or equal to "4"
    	Test:       	TestAsynchronousStartup
```

The reason is that it expected stronger semantics that the informers provide. The k8s informer doesn't sync while clients are connecting, it can send the welcome without all actual pods being there, they will just arrive later.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
