### PR TITLE
mysql errors followups

### DIFF
--- a/pkg/internal/sqlprune/mysql.go
+++ b/pkg/internal/sqlprune/mysql.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	MySQLHdrSize                  = 4
-	MySQLErrMinLen                = 8
+	MySQLErrMinLen                = 7
 	MySQLErrPacketMarker   byte   = 0xff
 	MySQLStateMarker       byte   = '#'
 	MySQLProgressReporting uint16 = 0xffff
@@ -49,6 +49,13 @@ func parseMySQLError(buf []uint8) *request.SQLError {
 		return nil // Not an error packet
 	}
 
+	// The capture may hold trailing packets or cut the message short
+	packetEnd := MySQLHdrSize + int(binary.LittleEndian.Uint32(buf)&0x00ffffff)
+	if packetEnd < MySQLErrMinLen {
+		return nil // Not an error packet
+	}
+	length = min(length, packetEnd)
+
 	if buf[offset] != MySQLErrPacketMarker {
 		return nil // Not an error packet
 	}
@@ -67,7 +74,8 @@ func parseMySQLError(buf []uint8) *request.SQLError {
 		return nil
 	}
 
-	if buf[offset] == MySQLStateMarker {
+	// A SQL state is only present when the declared packet has room for it
+	if offset < length && buf[offset] == MySQLStateMarker && packetEnd >= offset+1+5 {
 		if length < offset+1+5 {
 			return nil
 		}
@@ -78,7 +86,7 @@ func parseMySQLError(buf []uint8) *request.SQLError {
 		offset += 5
 	}
 	// Read the error message
-	sqlErr.Message = unix.ByteSliceToString(buf[offset:])
+	sqlErr.Message = unix.ByteSliceToString(buf[offset:length])
 
 	return &sqlErr
 }

--- a/pkg/internal/sqlprune/mysql_test.go
+++ b/pkg/internal/sqlprune/mysql_test.go
@@ -51,18 +51,86 @@ func TestMySQLErrorPacketValidation(t *testing.T) {
 		assert.Empty(t, err.Message)
 		assert.Equal(t, "HY000", strings.TrimPrefix(err.SQLState, "#"))
 	})
+	t.Run("legacy_empty_message", func(t *testing.T) {
+		packet := mysqlErrorPacket(1040, "")
+		require.Len(t, packet, MySQLErrMinLen)
+		err := SQLParseError(request.DBMySQL, packet)
+		require.NotNil(t, err)
+		assert.Equal(t, uint16(1040), err.Code)
+		assert.Empty(t, err.SQLState)
+		assert.Empty(t, err.Message)
+	})
+
+	for _, payloadLength := range []int{0, 1, 2} {
+		t.Run("header_payload_too_short/"+strconv.Itoa(payloadLength), func(t *testing.T) {
+			packet := mysqlErrorPacket(1040, "#HY000test error")
+			packet[0] = byte(payloadLength)
+			assert.Nil(t, SQLParseError(request.DBMySQL, packet))
+		})
+	}
 
 	packet := mysqlErrorPacket(20301, "#HY000test error")
 	for length := range MySQLHdrSize + 1 + 2 + 1 + 5 {
+		if length == MySQLErrMinLen {
+			continue // Cut right after the code, see truncated_after_code
+		}
 		t.Run("truncated/"+strconv.Itoa(length), func(t *testing.T) {
 			assert.Nil(t, SQLParseError(request.DBMySQL, packet[:length]))
 		})
 	}
+	t.Run("truncated_after_code", func(t *testing.T) {
+		err := SQLParseError(request.DBMySQL, packet[:MySQLErrMinLen])
+		require.NotNil(t, err)
+		assert.Equal(t, uint16(20301), err.Code)
+		assert.Empty(t, err.SQLState)
+		assert.Empty(t, err.Message)
+	})
 	for _, marker := range []byte{0x00, 0x01, 0xfe} {
 		packet[MySQLHdrSize] = marker
 		assert.Nil(t, SQLParseError(request.DBMySQL, packet))
 	}
 	assert.Nil(t, SQLParseError(request.DBMySQL, mysqlErrorPacket(MySQLProgressReporting, "progress")))
+}
+
+func TestMySQLErrorPacketBounds(t *testing.T) {
+	t.Run("trailing_bytes_after_message", func(t *testing.T) {
+		packet := append(mysqlErrorPacket(1040, "#HY000boom"), "trailing-next-packet"...)
+		err := SQLParseError(request.DBMySQL, packet)
+		require.NotNil(t, err)
+		assert.Equal(t, uint16(1040), err.Code)
+		assert.Equal(t, "HY000", strings.TrimPrefix(err.SQLState, "#"))
+		assert.Equal(t, "boom", err.Message)
+	})
+	t.Run("trailing_bytes_after_empty_message", func(t *testing.T) {
+		packet := append(mysqlErrorPacket(1040, "#HY000"), "trailing-next-packet"...)
+		err := SQLParseError(request.DBMySQL, packet)
+		require.NotNil(t, err)
+		assert.Equal(t, "HY000", strings.TrimPrefix(err.SQLState, "#"))
+		assert.Empty(t, err.Message)
+	})
+	t.Run("legacy_message_too_short_for_sqlstate", func(t *testing.T) {
+		packet := append(mysqlErrorPacket(1040, "#ab"), "trailing-next-packet"...)
+		err := SQLParseError(request.DBMySQL, packet)
+		require.NotNil(t, err)
+		assert.Equal(t, uint16(1040), err.Code)
+		assert.Empty(t, err.SQLState)
+		assert.Equal(t, "#ab", err.Message)
+	})
+	t.Run("trailing_sqlstate_after_legacy_packet", func(t *testing.T) {
+		packet := append(mysqlErrorPacket(1040, ""), "#HY000next"...)
+		err := SQLParseError(request.DBMySQL, packet)
+		require.NotNil(t, err)
+		assert.Equal(t, uint16(1040), err.Code)
+		assert.Empty(t, err.SQLState)
+		assert.Empty(t, err.Message)
+	})
+	t.Run("message_cut_by_capture", func(t *testing.T) {
+		packet := mysqlErrorPacket(1040, "#HY000Some error")
+		err := SQLParseError(request.DBMySQL, packet[:len(packet)-len(" error")])
+		require.NotNil(t, err)
+		assert.Equal(t, "HY000", strings.TrimPrefix(err.SQLState, "#"))
+		assert.Equal(t, "Some", err.Message)
+	})
 }
 
 func mysqlErrorPacket(code uint16, message string) []byte {

--- a/pkg/internal/sqlprune/sqlparser_test.go
+++ b/pkg/internal/sqlprune/sqlparser_test.go
@@ -191,7 +191,7 @@ func TestSQLParseError(t *testing.T) {
 		{
 			name:   "Valid MySQL error with SQL state",
 			dbKind: request.DBMySQL,
-			buf:    append([]uint8{0x00, 0x00, 0x00, 0x00}, []uint8{0xFF, 0x10, 0x04, '#', 'H', 'Y', '0', '0', '0', 'S', 'o', 'm', 'e', ' ', 'e', 'r', 'r', 'o', 'r'}...),
+			buf:    append([]uint8{0x13, 0x00, 0x00, 0x01}, []uint8{0xFF, 0x10, 0x04, '#', 'H', 'Y', '0', '0', '0', 'S', 'o', 'm', 'e', ' ', 'e', 'r', 'r', 'o', 'r'}...),
 			expected: &request.SQLError{
 				Code:     1040,
 				Message:  "Some error",
@@ -201,18 +201,24 @@ func TestSQLParseError(t *testing.T) {
 		{
 			name:     "Truncated buffer",
 			dbKind:   request.DBMySQL,
-			buf:      append([]uint8{0x00, 0x00, 0x00, 0x00}, []uint8{0xFF, 0x10, 0x04, '#', 'H'}...),
+			buf:      append([]uint8{0x13, 0x00, 0x00, 0x01}, []uint8{0xFF, 0x10, 0x04, '#', 'H'}...),
 			expected: nil,
 		},
 		{
 			name:   "Valid MySQL error",
 			dbKind: request.DBMySQL,
-			buf:    append([]uint8{0x00, 0x00, 0x00, 0x00}, []uint8{0xFF, 0x10, 0x04, 'S', 'o', 'm', 'e', ' ', 'e', 'r', 'r', 'o', 'r'}...),
+			buf:    append([]uint8{0x0d, 0x00, 0x00, 0x01}, []uint8{0xFF, 0x10, 0x04, 'S', 'o', 'm', 'e', ' ', 'e', 'r', 'r', 'o', 'r'}...),
 			expected: &request.SQLError{
 				Code:     1040,
 				Message:  "Some error",
 				SQLState: "",
 			},
+		},
+		{
+			name:     "MySQL error with empty declared payload",
+			dbKind:   request.DBMySQL,
+			buf:      append([]uint8{0x00, 0x00, 0x00, 0x01}, []uint8{0xFF, 0x99, 0x99, 'I', 'n', 'v', 'a', 'l', 'i', 'd'}...),
+			expected: nil,
 		},
 		{
 			name:     "Empty buffer",


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/3340

- Validate the MySQL packet header before treating a buffer as an ERR packet: a declared payload shorter than marker + error code is rejected. Restores the guard that the [1002, 4167] code-range check used to provide (e.g. a header declaring a 0-byte payload no longer yields a false error span).
- Bound the SQLSTATE and message to the packet length declared in the header instead of reading to the end of the captured buffer. Bytes from a following packet no longer leak into db.response.error; a message cut short by the capture is reported as far as it was captured.
- Only treat # as a SQLSTATE marker when the declared packet has room for a SQLSTATE; otherwise it is message text.
Accept the minimal legacy ERR packet (marker + code, no SQLSTATE, empty message, 7 bytes). MySQLErrMinLen was hardcoded to 8, so this packet was dropped and the failed query reported as successful.
- Tests: cover each case above; give the existing MySQL test vectors real header lengths; restore the "invalid header" case removed in #3340 as an explicit declared-empty-payload → nil assertion.

## Validation

- [x] I have read and followed the [contributing guidelines](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/CONTRIBUTING.md)
- [ ] If this enhances / fixes / changes a core feature, I have updated the [features documentation](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/devdocs/features.md) and [support matrix](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/blob/main/SUPPORT_MATRIX.md) as needed.
